### PR TITLE
Only allow expanding a table cell in the values column if the value is a string

### DIFF
--- a/apps/web/modules/components/triple-table.tsx
+++ b/apps/web/modules/components/triple-table.tsx
@@ -14,7 +14,6 @@ import { Chip } from '../design-system/chip';
 import { Text } from '../design-system/text';
 import { createTripleWithId } from '../services/create-id';
 import { useEditable } from '../state/use-editable';
-import { useTriples } from '../state/use-triples';
 import { EntityNames, Triple, Value } from '../types';
 import { navUtils } from '../utils';
 import { TableCell } from './table/cell';
@@ -288,7 +287,7 @@ const TripleTable = memo(function TripleTable({ update, triples, entityNames, sp
                 return (
                   <TableCell
                     isEditable={editable}
-                    isExpandable={cell.column.id === 'value'}
+                    isExpandable={cell.column.id === 'value' && (cell.getValue() as Value).type === 'string'}
                     isExpanded={expandedCells[cellId]}
                     width={cell.column.getSize()}
                     key={cell.id}


### PR DESCRIPTION
Note that chips can be longer than 3 lines, though our current truncation doesn't affect chips.

![Screenshot 2022-12-02 at 11 58 36 AM](https://user-images.githubusercontent.com/1198882/205375967-aca8203b-d408-4bdb-bdf0-838ab72600f3.png)

But maybe users should have to click through to the entity page anyway
