### PR TITLE
Caller should pass in abort controller

### DIFF
--- a/apps/web/modules/services/network.ts
+++ b/apps/web/modules/services/network.ts
@@ -51,6 +51,7 @@ export type FetchTriplesOptions = {
   skip: number;
   first: number;
   filter: FilterState;
+  abortController?: AbortController;
 };
 
 export type PublishOptions = {
@@ -65,16 +66,13 @@ type FetchTriplesResult = { triples: Triple[] };
 export interface INetwork {
   fetchTriples: (options: FetchTriplesOptions) => Promise<FetchTriplesResult>;
   fetchSpaces: () => Promise<Space[]>;
-  fetchEntities: (name: string) => Promise<{ id: string; name: string | null }[]>;
+  fetchEntities: (name: string, abortController?: AbortController) => Promise<{ id: string; name: string | null }[]>;
   publish: (options: PublishOptions) => Promise<void>;
 }
 
 const UPLOAD_CHUNK_SIZE = 2000;
 
 export class Network implements INetwork {
-  triplesAbortController = new AbortController();
-  entitiesAbortController = new AbortController();
-
   constructor(public storageClient: IStorageClient, public subgraphUrl: string) {}
 
   publish = async ({ actions, signer, onChangePublishState, space }: PublishOptions): Promise<void> => {
@@ -102,10 +100,7 @@ export class Network implements INetwork {
     await addEntries(contract, cids);
   };
 
-  fetchTriples = async ({ space, query, skip, first, filter }: FetchTriplesOptions) => {
-    this.triplesAbortController.abort();
-    this.triplesAbortController = new AbortController();
-
+  fetchTriples = async ({ space, query, skip, first, filter, abortController }: FetchTriplesOptions) => {
     const fieldFilters = Object.fromEntries(filter.map(clause => [clause.field, clause.value])) as Record<
       FilterField,
       string
@@ -131,7 +126,7 @@ export class Network implements INetwork {
       headers: {
         'Content-Type': 'application/json',
       },
-      signal: this.triplesAbortController.signal,
+      signal: abortController?.signal,
       body: JSON.stringify({
         query: `query {
           triples(where: {${where}}, skip: ${skip}, first: ${first}) {
@@ -181,10 +176,7 @@ export class Network implements INetwork {
     return { triples };
   };
 
-  fetchEntities = async (name: string) => {
-    this.entitiesAbortController.abort();
-    this.entitiesAbortController = new AbortController();
-
+  fetchEntities = async (name: string, abortController?: AbortController) => {
     // Until full-text search is supported, fetchEntities will return a list of entities that start with the search term,
     // followed by a list of entities that contain the search term.
     // Tracking issue:  https://github.com/graphprotocol/graph-node/issues/2330#issuecomment-1353512794
@@ -193,7 +185,7 @@ export class Network implements INetwork {
       headers: {
         'Content-Type': 'application/json',
       },
-      signal: this.entitiesAbortController.signal,
+      signal: abortController?.signal,
       body: JSON.stringify({
         query: `query {
           startEntities: geoEntities(where: {name_starts_with_nocase: ${JSON.stringify(name)}}) {

--- a/apps/web/modules/state/triple-store.tsx
+++ b/apps/web/modules/state/triple-store.tsx
@@ -59,6 +59,7 @@ export class TripleStore implements ITripleStore {
   hasPreviousPage$: ObservableComputed<boolean>;
   hasNextPage$: ObservableComputed<boolean>;
   space: string;
+  abortController: AbortController = new AbortController();
 
   constructor({
     api,
@@ -83,12 +84,16 @@ export class TripleStore implements ITripleStore {
       { triples: [], hasNextPage: false },
       computed(async () => {
         try {
+          this.abortController.abort();
+          this.abortController = new AbortController();
+
           const { triples } = await this.api.fetchTriples({
             query: this.query$.get(),
             space: this.space,
             skip: this.pageNumber$.get() * pageSize,
             first: pageSize + 1,
             filter: this.filterState$.get(),
+            abortController: this.abortController,
           });
 
           return { triples: triples.slice(0, pageSize), hasNextPage: triples.length > pageSize };

--- a/apps/web/pages/space/[id]/[entityId].tsx
+++ b/apps/web/pages/space/[id]/[entityId].tsx
@@ -50,8 +50,10 @@ export const getServerSideProps: GetServerSideProps<Props> = async context => {
   const config = Params.getConfigFromUrl(context.resolvedUrl, context.req.cookies[Params.ENV_PARAM_NAME]);
   const storage = new StorageClient(config.ipfs);
 
+  const network = new Network(storage, config.subgraph);
+
   const [entity, related] = await Promise.all([
-    new Network(storage, config.subgraph).fetchTriples({
+    network.fetchTriples({
       space,
       query: '',
       skip: 0,
@@ -59,7 +61,7 @@ export const getServerSideProps: GetServerSideProps<Props> = async context => {
       filter: [{ field: 'entity-id', value: entityId }],
     }),
 
-    new Network(storage, config.subgraph).fetchTriples({
+    network.fetchTriples({
       space,
       query: '',
       skip: 0,
@@ -70,7 +72,7 @@ export const getServerSideProps: GetServerSideProps<Props> = async context => {
 
   const relatedEntities = await Promise.all(
     related.triples.map(triple =>
-      new Network(storage, config.subgraph).fetchTriples({
+      network.fetchTriples({
         space,
         query: '',
         skip: 0,


### PR DESCRIPTION
This lets us reuse Network instances since not every usage of Network methods requires cancellation capability.