### PR TITLE
Resolve filtering for 'asdfasdf' bug showing initial state for entity and triples table

### DIFF
--- a/apps/web/modules/components/entity-table/entity-table-container.tsx
+++ b/apps/web/modules/components/entity-table/entity-table-container.tsx
@@ -28,8 +28,8 @@ export function EntityTableContainer({ spaceId, initialColumns, initialRows }: P
 
       <EntityTable
         space={spaceId}
-        columns={entityTableStore.columns.length === 0 ? initialColumns : entityTableStore.columns}
-        rows={entityTableStore.rows.length === 0 ? initialRows : entityTableStore.rows}
+        columns={entityTableStore.hydrated ? entityTableStore.columns : initialColumns}
+        rows={entityTableStore.hydrated ? entityTableStore.rows : initialRows}
       />
 
       <Spacer height={12} />

--- a/apps/web/modules/components/triples.tsx
+++ b/apps/web/modules/components/triples.tsx
@@ -67,10 +67,7 @@ export function Triples({ spaceId, initialTriples, spaceName = ZERO_WIDTH_SPACE 
 
         <Spacer height={12} />
 
-        <TripleTable
-          space={spaceId}
-          triples={tripleStore.triples.length === 0 ? initialTriples : tripleStore.triples}
-        />
+        <TripleTable space={spaceId} triples={tripleStore.hydrated ? tripleStore.triples : initialTriples} />
 
         <Spacer height={12} />
 

--- a/apps/web/modules/triple/entity-table-store-provider.tsx
+++ b/apps/web/modules/triple/entity-table-store-provider.tsx
@@ -1,7 +1,6 @@
 import { useSelector } from '@legendapp/state/react';
 import { useRouter } from 'next/router';
 import { createContext, useContext, useEffect, useMemo, useRef } from 'react';
-import { AppConfig } from '../config';
 import { Params } from '../params';
 import { Services } from '../services';
 import { Column, FilterState, Row, Triple } from '../types';
@@ -16,12 +15,10 @@ interface Props {
   initialSelectedType: Triple | null;
   initialColumns: Column[];
   initialTypes: Triple[];
-  config: AppConfig;
 }
 
 export function EntityTableStoreProvider({
   space,
-  config,
   children,
   initialRows,
   initialSelectedType,
@@ -45,9 +42,8 @@ export function EntityTableStoreProvider({
       initialSelectedType,
       initialColumns,
       initialTypes,
-      config,
     });
-  }, [network, space, initialRows, initialSelectedType, initialColumns, initialTypes, config]);
+  }, [network, space, initialRows, initialSelectedType, initialColumns, initialTypes]);
 
   const query = useSelector(store.query$);
   const pageNumber = useSelector(store.pageNumber$);

--- a/apps/web/modules/triple/triple-store.tsx
+++ b/apps/web/modules/triple/triple-store.tsx
@@ -9,6 +9,7 @@ import { makeOptionalComputed } from '../utils';
 interface ITripleStore {
   triples$: ObservableComputed<TripleType[]>;
   pageNumber$: Observable<number>;
+  hydrated$: Observable<boolean>;
   query$: ObservableComputed<string>;
   hasPreviousPage$: ObservableComputed<boolean>;
   hasNextPage$: ObservableComputed<boolean>;
@@ -54,6 +55,7 @@ export class TripleStore implements ITripleStore {
   query$: ObservableComputed<string>;
   filterState$: Observable<FilterState>;
   hasPreviousPage$: ObservableComputed<boolean>;
+  hydrated$: Observable<boolean> = observable(false);
   hasNextPage$: ObservableComputed<boolean>;
   space: string;
   ActionsStore: ActionsStore;
@@ -96,6 +98,7 @@ export class TripleStore implements ITripleStore {
             abortController: this.abortController,
           });
 
+          this.hydrated$.set(true);
           return { triples: triples.slice(0, pageSize), hasNextPage: triples.length > pageSize };
         } catch (e) {
           if (e instanceof Error && e.name === 'AbortError') {

--- a/apps/web/modules/triple/use-entity-tables.tsx
+++ b/apps/web/modules/triple/use-entity-tables.tsx
@@ -18,6 +18,7 @@ export const useEntityTable = () => {
     hasPreviousPage$,
     hasNextPage$,
     filterState$,
+    hydrated$,
     selectedType$,
     columns$,
     types$,
@@ -27,6 +28,7 @@ export const useEntityTable = () => {
   const actions = useSelector(actions$);
   const columns = useSelector(columns$);
   const types = useSelector(types$);
+  const hydrated = useSelector(hydrated$);
   const selectedType = useSelector(selectedType$);
   const pageNumber = useSelector(pageNumber$);
   const hasPreviousPage = useSelector(hasPreviousPage$);
@@ -42,6 +44,7 @@ export const useEntityTable = () => {
     create,
     publish,
     query,
+    hydrated,
     selectedType,
     setQuery,
     setPageNumber,

--- a/apps/web/modules/triple/use-triples.tsx
+++ b/apps/web/modules/triple/use-triples.tsx
@@ -14,6 +14,7 @@ export const useTriples = () => {
     hasPreviousPage$,
     hasNextPage$,
     filterState$,
+    hydrated$,
     setFilterState,
   } = useTripleStoreContext();
   const triples = useSelector(triples$);
@@ -21,6 +22,7 @@ export const useTriples = () => {
   const hasPreviousPage = useSelector(hasPreviousPage$);
   const hasNextPage = useSelector(hasNextPage$);
   const query = useSelector(query$);
+  const hydrated = useSelector(hydrated$);
   const filterState = useSelector<FilterState>(filterState$);
 
   return {
@@ -30,6 +32,7 @@ export const useTriples = () => {
     setPageNumber,
     setNextPage,
     setPreviousPage,
+    hydrated,
     pageNumber,
     hasPreviousPage,
     hasNextPage,

--- a/apps/web/pages/space/[id]/entities.tsx
+++ b/apps/web/pages/space/[id]/entities.tsx
@@ -31,7 +31,6 @@ export default function EntitiesPage({
   initialSelectedType,
   initialRows,
   initialTypes,
-  config,
 }: Props) {
   return (
     <div>
@@ -46,7 +45,6 @@ export default function EntitiesPage({
 
       <EntityTableStoreProvider
         space={spaceId}
-        config={config}
         initialRows={initialRows}
         initialSelectedType={initialSelectedType}
         initialColumns={initialColumns}
@@ -90,7 +88,6 @@ export const getServerSideProps: GetServerSideProps<Props> = async context => {
   const { columns, rows } = await network.fetchEntityTableData({
     spaceId,
     params,
-    config,
   });
 
   return {


### PR DESCRIPTION
When filtering for 'asdfasdf' or other gibberish, both entity table and triples table would display initial rows fetched during SSR.

Rather than using filter state to determine whether or not to show SSR rows, I instead used a hydrated$ flag to mark when client side should be responsible for displaying data. 

This feels closer to the intent of our table filtering logic and less prone to bugs, especially as we begin to add table editing functionality.

Also used this PR as an opportunity to pass in the new abortController to fetchEntityTableData to prevent race conditions.