### PR TITLE
Fix: Create multiple triples simultaneously

### DIFF
--- a/apps/web/modules/triple/triple.test.ts
+++ b/apps/web/modules/triple/triple.test.ts
@@ -24,19 +24,7 @@ describe('Triple', () => {
     });
   });
 
-  it('Returns an empty triple', () => {
-    expect(empty('space-id', 'banana-id')).toEqual({
-      id: 'space-id:banana-id::',
-      entityId: 'banana-id',
-      attributeId: '',
-      attributeName: '',
-      value: {
-        id: '',
-        type: 'string',
-        value: '',
-      },
-      space: 'space-id',
-      entityName: '',
-    });
+  it('Returns a unique, empty triple', () => {
+    expect(empty('space-id', 'banana-id')).not.toEqual(empty('space-id', 'banana-id'));
   });
 });

--- a/apps/web/modules/triple/triple.ts
+++ b/apps/web/modules/triple/triple.ts
@@ -14,7 +14,7 @@ export function empty(spaceId: string, entityId: string): Triple {
     attributeId: '',
     attributeName: '',
     value: {
-      id: '',
+      id: ID.createValueId(),
       type: 'string',
       value: '',
     },

--- a/apps/web/modules/triple/triple.ts
+++ b/apps/web/modules/triple/triple.ts
@@ -8,6 +8,8 @@ export function withId(triple: OmitStrict<Triple, 'id'>): Triple {
   };
 }
 
+// New, empty triples should generate unique triple IDs so they are distinguishable from
+// other newly created triples locally.
 export function empty(spaceId: string, entityId: string): Triple {
   const emptyTriple: OmitStrict<Triple, 'id'> = {
     entityId: entityId,


### PR DESCRIPTION
We are keeping local IDs static when creating and editing new local triples in order to handle diffing and change count more gracefully. This caused a bug where each newly created triple had the same triple ID.

We now create a unique value ID on triple creation so the triple ID is unique across local triples.