### PR TITLE
Keep local actions after publish

### DIFF
--- a/apps/web/modules/action/action.test.ts
+++ b/apps/web/modules/action/action.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect } from 'vitest';
 import { makeStubTriple } from '~/modules/services/mock-network';
 import { Action as ActionType, EditTripleAction } from '~/modules/types';
-import { getChangeCount, squashChanges } from './action';
+import { getChangeCount, squashChanges, unpublishedChanges } from './action';
 
 // Count should be 3
 const basicActions: ActionType[] = [
@@ -207,5 +207,31 @@ describe('Action squashing', () => {
 
     const squashed = squashChanges(actions);
     expect(squashed).toEqual([actions[2]]);
+  });
+});
+
+const publishedAndUnpublishedActions: ActionType[] = [
+  {
+    type: 'createTriple',
+    ...makeStubTriple('Alice'),
+  },
+  {
+    type: 'editTriple',
+    before: {
+      type: 'deleteTriple',
+      ...makeStubTriple('Alice'),
+    },
+    after: {
+      type: 'createTriple',
+      ...makeStubTriple('Alice'),
+      value: { type: 'string', id: 'string:2', value: 'Alice-2' },
+    },
+    hasBeenPublished: true,
+  },
+];
+
+describe('Published actions', () => {
+  it('Returns actions that have not been published', () => {
+    expect(unpublishedChanges(publishedAndUnpublishedActions)).toEqual([publishedAndUnpublishedActions[0]]);
   });
 });

--- a/apps/web/modules/action/action.ts
+++ b/apps/web/modules/action/action.ts
@@ -107,3 +107,7 @@ export function squashChanges(actions: Action[]) {
     })
     .flatMap(changeTuple => (changeTuple ? changeTuple : []));
 }
+
+export function unpublishedChanges(actions: Action[]) {
+  return actions.filter(a => !a.hasBeenPublished);
+}

--- a/apps/web/modules/action/actions-store.tsx
+++ b/apps/web/modules/action/actions-store.tsx
@@ -88,7 +88,7 @@ export class ActionsStore implements IActionsStore {
 
     try {
       await this.api.publish({
-        actions: Action.squashChanges(spaceActions),
+        actions: Action.squashChanges(Action.unpublishedChanges(spaceActions)),
         signer,
         onChangePublishState,
         space: spaceId,
@@ -99,9 +99,14 @@ export class ActionsStore implements IActionsStore {
       return;
     }
 
+    const publishedActions = spaceActions.map(a => ({
+      ...a,
+      hasBeenPublished: true,
+    }));
+
     this.actions$.set({
       ...this.actions$.get(),
-      [spaceId]: [],
+      [spaceId]: publishedActions,
     });
 
     onChangePublishState('publish-complete');

--- a/apps/web/modules/action/actions-store.tsx
+++ b/apps/web/modules/action/actions-store.tsx
@@ -82,6 +82,13 @@ export class ActionsStore implements IActionsStore {
     this.addActions(spaceId, [action]);
   };
 
+  clear = (spaceId: string) => {
+    this.actions$.set({
+      ...this.actions$.get(),
+      [spaceId]: [],
+    });
+  };
+
   publish = async (spaceId: string, signer: Signer, onChangePublishState: (newState: ReviewState) => void) => {
     const spaceActions: ActionType[] = this.actions$.get()[spaceId];
     if (!spaceActions) return;

--- a/apps/web/modules/action/use-actions-store.tsx
+++ b/apps/web/modules/action/use-actions-store.tsx
@@ -8,18 +8,20 @@ import { useActionsStoreContext } from './actions-store-provider';
  * on a dev route or the root /spaces page.
  */
 export function useActionsStore(spaceId?: string) {
-  const { actions$, publish } = useActionsStoreContext();
+  const { actions$, publish, clear } = useActionsStoreContext();
   const actions = useSelector(actions$);
 
   if (!spaceId) {
     return {
       actions: [],
       publish,
+      clear,
     };
   }
 
   return {
     actions: actions[spaceId] ?? [],
     publish,
+    clear,
   };
 }

--- a/apps/web/modules/components/entity-table/editable-entity-table-cell.tsx
+++ b/apps/web/modules/components/entity-table/editable-entity-table-cell.tsx
@@ -29,6 +29,7 @@ export const EditableEntityTableCell = ({ cell, space, entityId }: Props) => {
     context: {
       entityId,
       spaceId: space,
+      entityName: Entity.name(localTriples) ?? '',
     },
     api: {
       create,

--- a/apps/web/modules/components/entity/edit-events.ts
+++ b/apps/web/modules/components/entity/edit-events.ts
@@ -89,6 +89,7 @@ interface ListenerConfig {
   context: {
     spaceId: string;
     entityId: string;
+    entityName: string;
   };
 }
 
@@ -149,7 +150,7 @@ const listener =
         );
       }
       case 'CREATE_NEW_TRIPLE':
-        return create(Triple.empty(context.spaceId, context.entityId));
+        return create({ ...Triple.empty(context.spaceId, context.entityId), entityName: context.entityName });
       case 'REMOVE_TRIPLE':
         return remove(event.payload.triple);
       case 'CHANGE_TRIPLE_TYPE': {

--- a/apps/web/modules/components/entity/editable-entity-page.tsx
+++ b/apps/web/modules/components/entity/editable-entity-page.tsx
@@ -66,17 +66,6 @@ interface Props {
 export function EditableEntityPage({ id, name: serverName, space, triples: serverTriples }: Props) {
   const { triples: localTriples, update, create, remove } = useEntityStore();
   const { actions } = useActionsStore(space);
-  const send = useEditEvents({
-    context: {
-      entityId: id,
-      spaceId: space,
-    },
-    api: {
-      create,
-      update,
-      remove,
-    },
-  });
 
   // We hydrate the local editable store with the triples from the server. While it's hydrating
   // we can fallback to the server triples so we render real data and there's no layout shift.
@@ -88,6 +77,19 @@ export function EditableEntityPage({ id, name: serverName, space, triples: serve
   );
   const description = Entity.description(triples);
   const name = Entity.name(triples) ?? serverName;
+
+  const send = useEditEvents({
+    context: {
+      entityId: id,
+      spaceId: space,
+      entityName: name,
+    },
+    api: {
+      create,
+      update,
+      remove,
+    },
+  });
 
   const onNameChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     send({

--- a/apps/web/modules/components/flow-bar.tsx
+++ b/apps/web/modules/components/flow-bar.tsx
@@ -56,6 +56,11 @@ export function FlowBar({ actions, onPublish, onClear, spaceId }: Props) {
     await onPublish(spaceId, signer, setReviewState);
   };
 
+  const clear = () => {
+    if (!spaceId) return;
+    onClear(spaceId);
+  };
+
   return (
     <AnimatePresence>
       {/* We let the toast persist during the publish-complete state before it switches to idle state */}
@@ -70,12 +75,7 @@ export function FlowBar({ actions, onPublish, onClear, spaceId }: Props) {
               key="action-bar"
             >
               {reviewState === 'idle' && (
-                <Review
-                  actions={actions}
-                  onBack={() => setReviewState('idle')}
-                  onNext={publish}
-                  onClear={() => onClear(spaceId)}
-                />
+                <Review actions={actions} onBack={() => setReviewState('idle')} onNext={publish} onClear={clear} />
               )}
             </MotionContainer>
           )}

--- a/apps/web/modules/components/flow-bar.tsx
+++ b/apps/web/modules/components/flow-bar.tsx
@@ -35,9 +35,10 @@ interface Props {
   actions: ActionType[];
   spaceId?: string;
   onPublish: (spaceId: string, signer: Signer, setReviewState: (newState: ReviewState) => void) => void;
+  onClear: (spaceId: string) => void;
 }
 
-export function FlowBar({ actions, onPublish, spaceId }: Props) {
+export function FlowBar({ actions, onPublish, onClear, spaceId }: Props) {
   const { data: signer } = useSigner();
   const [reviewState, setReviewState] = useState<ReviewState>('idle');
 
@@ -69,7 +70,12 @@ export function FlowBar({ actions, onPublish, spaceId }: Props) {
               key="action-bar"
             >
               {reviewState === 'idle' && (
-                <Review actions={actions} onBack={() => setReviewState('idle')} onNext={publish} />
+                <Review
+                  actions={actions}
+                  onBack={() => setReviewState('idle')}
+                  onNext={publish}
+                  onClear={() => onClear(spaceId)}
+                />
               )}
             </MotionContainer>
           )}
@@ -98,9 +104,15 @@ interface ReviewProps {
   onBack: () => void;
   actions: ActionType[];
   onNext: () => void;
+  onClear: () => void;
 }
 
-function Review({ actions, onNext }: ReviewProps) {
+const TrashButton = styled.button({
+  all: 'unset',
+  cursor: 'pointer',
+});
+
+function Review({ actions, onNext, onClear }: ReviewProps) {
   const actionsCount = Action.getChangeCount(actions);
   const entitiesCount = Object.keys(
     groupBy(Action.squashChanges(actions), action => {
@@ -111,7 +123,9 @@ function Review({ actions, onNext }: ReviewProps) {
 
   return (
     <>
-      <Trash color="grey-04" />
+      <TrashButton onClick={onClear}>
+        <Trash color="grey-04" />
+      </TrashButton>
       <Spacer width={8} />
       <Text color="grey-04" variant="button">
         {actionsCount} {pluralize('change', actionsCount)} across {entitiesCount} {pluralize('entity', entitiesCount)}

--- a/apps/web/modules/types.ts
+++ b/apps/web/modules/types.ts
@@ -60,17 +60,21 @@ export type FilterClause = {
 
 export type FilterState = FilterClause[];
 
-export type CreateTripleAction = CreateTripleActionSchema & Identifiable & Triple;
-export type DeleteTripleAction = DeleteTripleActionSchema & Identifiable & Triple;
+export type CreateTripleAction = CreateTripleActionSchema & Identifiable & Triple & Publishable;
+export type DeleteTripleAction = DeleteTripleActionSchema & Identifiable & Triple & Publishable;
 
 export type EditTripleAction = {
   type: 'editTriple';
   before: DeleteTripleAction;
   after: CreateTripleAction;
-};
+} & Publishable;
 
 type Identifiable = {
   id: string;
+};
+
+type Publishable = {
+  hasBeenPublished?: boolean;
 };
 
 export type Action = CreateTripleAction | DeleteTripleAction | EditTripleAction;

--- a/apps/web/pages/_app.tsx
+++ b/apps/web/pages/_app.tsx
@@ -64,11 +64,11 @@ const FlowbarContainer = styled.div({
 function GlobalFlowBar() {
   const router = useRouter();
   const { id: spaceId } = router.query as { id: string | undefined };
-  const { actions, publish } = useActionsStore(spaceId);
+  const { actions, publish, clear } = useActionsStore(spaceId);
 
   return (
     <FlowbarContainer>
-      <FlowBar actions={Action.unpublishedChanges(actions)} onPublish={publish} spaceId={spaceId} />
+      <FlowBar actions={Action.unpublishedChanges(actions)} onClear={clear} onPublish={publish} spaceId={spaceId} />
     </FlowbarContainer>
   );
 }

--- a/apps/web/pages/_app.tsx
+++ b/apps/web/pages/_app.tsx
@@ -6,7 +6,7 @@ import { Navbar } from '~/modules/components/navbar/navbar';
 import { colors } from '~/modules/design-system/theme/colors';
 import { Providers } from '~/modules/providers';
 import { FlowBar } from '~/modules/components/flow-bar';
-import { useActionsStore } from '~/modules/action';
+import { Action, useActionsStore } from '~/modules/action';
 import { useRouter } from 'next/router';
 import { Analytics } from '@vercel/analytics/react';
 
@@ -68,7 +68,7 @@ function GlobalFlowBar() {
 
   return (
     <FlowbarContainer>
-      <FlowBar actions={actions} onPublish={publish} spaceId={spaceId} />
+      <FlowBar actions={Action.unpublishedChanges(actions)} onPublish={publish} spaceId={spaceId} />
     </FlowbarContainer>
   );
 }


### PR DESCRIPTION
Instead of blowing away local actions we can persist them to keep a more optimistic experience, especially since dealing with blockchain transaction and subgraph indexing time can be slow.

We added a `hasBeenPublished` flag to local actions to know whether there are new actions since last publish and to show the FlowBar. 