### PR TITLE
fix: Filter triples from subgraph on client that have an empty attribute or empty entity value

### DIFF
--- a/apps/web/modules/services/network.ts
+++ b/apps/web/modules/services/network.ts
@@ -46,6 +46,9 @@ export function extractValue(networkTriple: NetworkTriple): Value {
     case 'ENTITY': {
       return {
         type: 'entity',
+        // TODO(baiirun): fix types
+        // These fallback cases should never happen because we are filtering network triples with
+        // empty entity values before it gets to this point.
         id: networkTriple?.entityValue?.id ?? '',
         name: networkTriple?.entityValue?.name ?? null,
       };


### PR DESCRIPTION
I'll add tests and improve the network types as part of [this PR](https://github.com/geobrowser/geogenesis/pull/163) since I'm touching a bit of the network file already. Just wanna get this fix out ASAP.