### PR TITLE
fix: next/image component width/height usage

### DIFF
--- a/apps/web/modules/components/space/space-header.tsx
+++ b/apps/web/modules/components/space/space-header.tsx
@@ -44,8 +44,6 @@ interface Props {
 }
 
 export function SpaceHeader({ spaceImage, spaceName = ZERO_WIDTH_SPACE }: Props) {
-  const theme = useTheme();
-
   return (
     <SpaceHeaderContainer>
       <SpaceInfo>
@@ -53,8 +51,6 @@ export function SpaceHeader({ spaceImage, spaceName = ZERO_WIDTH_SPACE }: Props)
           <Image
             objectFit="cover"
             layout="fill"
-            width={theme.space * 14}
-            height={theme.space * 14}
             src={spaceImage ?? 'https://via.placeholder.com/600x600/FF00FF/FFFFFF'}
             alt={`Cover image for ${spaceName}`}
           />

--- a/apps/web/modules/components/space/space-header.tsx
+++ b/apps/web/modules/components/space/space-header.tsx
@@ -1,4 +1,3 @@
-import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
 import Image from 'next/image';
 import { Text } from '~/modules/design-system/text';


### PR DESCRIPTION
`next/image` doesn't use `width` or `height` when `layout="fill"`