### PR TITLE
fix: Description editing bug is using incorrect description filter

### DIFF
--- a/apps/web/integration/pages/space/[id]/[entityId].test.tsx
+++ b/apps/web/integration/pages/space/[id]/[entityId].test.tsx
@@ -20,20 +20,6 @@ const scalarDescriptionTriple: Triple = {
   },
 };
 
-const linkedDescriptionTriple: Triple = {
-  id: '1',
-  entityId: '1',
-  space: '1',
-  attributeId: 'Description',
-  attributeName: 'Description',
-  entityName: 'Banana',
-  value: {
-    id: '1',
-    type: 'entity',
-    name: 'Description of a Banana',
-  },
-};
-
 const genericAttribute: Triple = {
   id: '1',
   entityId: '1',

--- a/apps/web/modules/components/entity/editable-entity-page.tsx
+++ b/apps/web/modules/components/entity/editable-entity-page.tsx
@@ -1,7 +1,6 @@
 import styled from '@emotion/styled';
 import Head from 'next/head';
 import { useActionsStore } from '~/modules/action';
-import { SYSTEM_IDS } from '~/modules/constants';
 import { Button, SquareButton } from '~/modules/design-system/button';
 import { ChipButton } from '~/modules/design-system/chip';
 import { Relation } from '~/modules/design-system/icons/relation';
@@ -71,10 +70,8 @@ export function EditableEntityPage({ id, name: serverName, space, triples: serve
   // we can fallback to the server triples so we render real data and there's no layout shift.
   const triples = localTriples.length === 0 && actions.length === 0 ? serverTriples : localTriples;
 
-  const nameTriple = triples.find(t => t.attributeId === SYSTEM_IDS.NAME);
-  const descriptionTriple = triples.find(
-    t => t.attributeId === SYSTEM_IDS.DESCRIPTION || t.attributeName === SYSTEM_IDS.DESCRIPTION
-  );
+  const nameTriple = Entity.nameTriple(triples);
+  const descriptionTriple = Entity.descriptionTriple(triples);
   const description = Entity.description(triples);
   const name = Entity.name(triples) ?? serverName;
 

--- a/apps/web/modules/entity/entity.test.ts
+++ b/apps/web/modules/entity/entity.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { SYSTEM_IDS } from '../constants';
 import { Triple } from '../types';
-import { description, types } from './entity';
+import { description, descriptionTriple, name, nameTriple, types } from './entity';
 
 const triplesWithSystemDescriptionAttribute: Triple[] = [
   {
@@ -83,7 +83,7 @@ describe('Entity description helpers', () => {
     expect(description(triplesWithSystemDescriptionAttribute)).toBe('banana');
   });
 
-  it('Entity.description should parse description from triples where description is the expected system Description and value is a reference to another Entity', () => {
+  it('Entity.description should return null where description is the expected system Description and value is a reference to another Entity', () => {
     expect(description(triplesWithSystemDescriptionAttributeAndValueIsEntity)).toBe(null);
   });
 
@@ -91,8 +91,86 @@ describe('Entity description helpers', () => {
     expect(description(triplesWithNonSystemDescriptionAttribute)).toBe('banana');
   });
 
-  it('Entity.description should parse description from triples where description is not the expected system Description and value is a reference to another Entity', () => {
+  it('Entity.description should return null where description is not the expected system Description and value is a reference to another Entity', () => {
     expect(description(triplesWithNonSystemDescriptionAttributeAndValueIsEntity)).toBe(null);
+  });
+
+  it('Entity.descriptionTriple should return the Description triple', () => {
+    expect(descriptionTriple(triplesWithSystemDescriptionAttribute)).toBe(triplesWithSystemDescriptionAttribute[0]);
+  });
+
+  it('Entity.descriptionTriple should return undefined if there is no Description triple', () => {
+    expect(descriptionTriple([])).toBe(undefined);
+  });
+});
+
+const triplesWithSystemNameAttribute: Triple[] = [
+  {
+    id: '',
+    entityId: 'entityId',
+    attributeId: SYSTEM_IDS.NAME,
+    attributeName: 'Name',
+    entityName: 'banana',
+    space: 'spaceId',
+    value: {
+      id: 'valueId',
+      type: 'string',
+      value: 'banana',
+    },
+  },
+];
+
+const triplesWithSystemNameAttributeAndNameIsEntity: Triple[] = [
+  {
+    id: '',
+    entityId: 'entityId',
+    attributeId: SYSTEM_IDS.NAME,
+    attributeName: 'Name',
+    entityName: 'banana',
+    space: 'spaceId',
+    value: {
+      id: 'valueId',
+      type: 'entity',
+      name: 'banana',
+    },
+  },
+];
+
+const triplesWithNonSystemNameAttribute: Triple[] = [
+  {
+    id: '',
+    entityId: 'entityId',
+    attributeId: 'not-name',
+    attributeName: 'Name',
+    entityName: 'banana',
+    space: 'spaceId',
+    value: {
+      id: 'valueId',
+      type: 'string',
+      value: 'banana',
+    },
+  },
+];
+
+describe('Entity name helpers', () => {
+  it('Entity.name should parse name from triples where name attribute is the the expected system Name', () => {
+    expect(name(triplesWithSystemNameAttribute)).toBe('banana');
+  });
+
+  it('Entity.name should parse name from triples where name is the expected system Name and value is a reference to another Entity', () => {
+    expect(name(triplesWithSystemNameAttributeAndNameIsEntity)).toBe(null);
+  });
+
+  it('Entity.name should return null where name is not the expected system Name', () => {
+    expect(name(triplesWithNonSystemNameAttribute)).toBe(null);
+  });
+
+  it('Entity.nameTriple should return the Name triple', () => {
+    expect(nameTriple(triplesWithSystemNameAttribute)).toBe(triplesWithSystemNameAttribute[0]);
+  });
+
+  it('Entity.nameTriple should return undefined if there is no Name triple', () => {
+    expect(nameTriple([])).toBe(undefined);
   });
 });
 

--- a/apps/web/modules/entity/entity.ts
+++ b/apps/web/modules/entity/entity.ts
@@ -17,12 +17,15 @@ import { groupBy } from '../utils';
  * is an EntityValue we assume it's not valid and don't attempt to parse it to render in the UI.
  */
 export function description(triples: Triple[]): string | null {
-  const descriptionTriple = triples.find(
+  const triple = descriptionTriple(triples);
+  return triple?.value.type === 'string' ? triple.value.value : null;
+}
+
+export function descriptionTriple(triples: Triple[]): Triple | undefined {
+  return triples.find(
     triple =>
       triple.attributeId === SYSTEM_IDS.DESCRIPTION_SCALAR || triple.attributeName === SYSTEM_IDS.DESCRIPTION_SCALAR
   );
-
-  return descriptionTriple?.value?.type === 'string' ? descriptionTriple.value.value : null;
 }
 
 /**
@@ -63,6 +66,10 @@ export function types(triples: Triple[], currentSpace: string): string[] {
  * to find the name of the entity.
  */
 export function name(triples: Triple[]): string | null {
-  const nameValue = triples.find(triple => triple.attributeId === SYSTEM_IDS.NAME)?.value;
-  return nameValue?.type === 'string' ? nameValue.value : null;
+  const triple = nameTriple(triples);
+  return triple?.value.type === 'string' ? triple?.value.value : null;
+}
+
+export function nameTriple(triples: Triple[]): Triple | undefined {
+  return triples.find(triple => triple.attributeId === SYSTEM_IDS.NAME);
 }


### PR DESCRIPTION
There was a bug where we were using the incorrect description filter on entity triples. It's now updated to use a global `Entity.descriptionTriple` helper.