### PR TITLE
feat: search locally created entities

### DIFF
--- a/apps/web/modules/components/entity/edit-events.ts
+++ b/apps/web/modules/components/entity/edit-events.ts
@@ -232,6 +232,7 @@ const listener =
                 name: linkedEntity.name,
               },
               attributeName: triplesByAttributeId[attribute.id][0].attributeName,
+              entityName: entityName,
             }),
             triplesByAttributeId[attribute.id][0]
           );

--- a/apps/web/modules/entity/autocomplete.tsx
+++ b/apps/web/modules/entity/autocomplete.tsx
@@ -1,6 +1,6 @@
 import { computed, observable, ObservableComputed } from '@legendapp/state';
 import { useSelector } from '@legendapp/state/react';
-import { A, G, pipe, S } from '@mobily/ts-belt';
+import { A, G, pipe } from '@mobily/ts-belt';
 import { useEffect, useMemo } from 'react';
 import { Services } from '~/modules/services';
 import { INetwork } from '~/modules/services/network';
@@ -28,7 +28,9 @@ class EntityAutocomplete {
         this.abortController = new AbortController();
 
         try {
-          const networkEntities = await api.fetchEntities(this.query$.get(), spaceId, this.abortController);
+          const query = this.query$.get();
+
+          const networkEntities = await api.fetchEntities(query, spaceId, this.abortController);
           const localEntities = Entity.mergeActionsWithNetworkEntities(ActionsStore.actions$.get(), networkEntities);
 
           // We want to favor the local version of an entity if it exists on the network already.
@@ -37,7 +39,7 @@ class EntityAutocomplete {
 
           return pipe(
             mergedEntities,
-            A.filter(e => G.isString(e.name) && S.startsWith(S.toLowerCase(e.name), S.toLowerCase(this.query$.get())))
+            A.filter(e => G.isString(e.name) && e.name.toLowerCase().startsWith(query.toLowerCase()))
           );
         } catch (e) {
           return [];

--- a/apps/web/modules/entity/autocomplete.tsx
+++ b/apps/web/modules/entity/autocomplete.tsx
@@ -1,17 +1,27 @@
 import { computed, observable, ObservableComputed } from '@legendapp/state';
 import { useSelector } from '@legendapp/state/react';
+import { A, D, G, pipe, S } from '@mobily/ts-belt';
 import { useEffect, useMemo } from 'react';
 import { Services } from '~/modules/services';
 import { INetwork } from '~/modules/services/network';
 import { makeOptionalComputed } from '~/modules/utils';
-import { Entity } from '../types';
+import { Entity } from '.';
+import { Action, ActionsStore, useActionsStoreContext } from '../action';
+import { Triple } from '../triple';
+import { Entity as EntityType } from '../types';
+
+interface EntityAutocompleteOptions {
+  api: INetwork;
+  spaceId: string;
+  ActionsStore: ActionsStore;
+}
 
 class EntityAutocomplete {
   query$ = observable('');
-  results$: ObservableComputed<Entity[]>;
+  results$: ObservableComputed<EntityType[]>;
   abortController: AbortController = new AbortController();
 
-  constructor({ api, spaceId }: { api: INetwork; spaceId: string }) {
+  constructor({ api, spaceId, ActionsStore }: EntityAutocompleteOptions) {
     this.results$ = makeOptionalComputed(
       [],
       computed(async () => {
@@ -19,7 +29,19 @@ class EntityAutocomplete {
         this.abortController = new AbortController();
 
         try {
-          return await api.fetchEntities(this.query$.get(), spaceId, this.abortController);
+          const networkEntities = await api.fetchEntities(this.query$.get(), spaceId, this.abortController);
+
+          const localEntities = pipe(
+            ActionsStore.actions$.get(),
+            D.values,
+            A.flat,
+            actions => Triple.fromActions(spaceId, actions, []),
+            Entity.entitiesFromTriples,
+            A.filter(e => G.isString(e.name) && S.startsWith(S.toLowerCase(e.name), S.toLowerCase(this.query$.get())))
+          );
+
+          // TODO: Dedupe
+          return [...localEntities, ...networkEntities];
         } catch (e) {
           return [];
         }
@@ -34,10 +56,11 @@ class EntityAutocomplete {
 
 export function useAutocomplete(spaceId: string) {
   const { network } = Services.useServices();
+  const ActionsStore = useActionsStoreContext();
 
   const autocomplete = useMemo(() => {
-    return new EntityAutocomplete({ api: network, spaceId });
-  }, [network, spaceId]);
+    return new EntityAutocomplete({ api: network, spaceId, ActionsStore });
+  }, [network, spaceId, ActionsStore]);
 
   useEffect(() => {
     return () => {

--- a/apps/web/modules/entity/autocomplete.tsx
+++ b/apps/web/modules/entity/autocomplete.tsx
@@ -31,7 +31,7 @@ class EntityAutocomplete {
           const query = this.query$.get();
 
           const networkEntities = await api.fetchEntities(query, spaceId, this.abortController);
-          const localEntities = Entity.mergeActionsWithNetworkEntities(ActionsStore.actions$.get(), networkEntities);
+          const localEntities = Entity.mergeActionsWithEntities(ActionsStore.actions$.get(), networkEntities);
 
           // We want to favor the local version of an entity if it exists on the network already.
           const localEntityIds = new Set(localEntities.map(e => e.id));

--- a/apps/web/modules/entity/entity-store.tsx
+++ b/apps/web/modules/entity/entity-store.tsx
@@ -62,7 +62,7 @@ export class EntityStore implements IEntityStore {
         return isCreate || isDelete || isRemove;
       });
       // We want to merge any local actions with the network triples
-      return Triple.fromActions(spaceId, entitySpecificActions, initialDefaultTriples);
+      return Triple.fromActions(entitySpecificActions, initialDefaultTriples);
     });
   }
 

--- a/apps/web/modules/entity/entity.ts
+++ b/apps/web/modules/entity/entity.ts
@@ -74,6 +74,9 @@ export function nameTriple(triples: TripleType[]): TripleType | undefined {
   return triples.find(triple => triple.attributeId === SYSTEM_IDS.NAME);
 }
 
+/**
+ * This function takes an array of triples and maps them to an array of Entity types.
+ */
 export function entitiesFromTriples(triples: TripleType[]): Entity[] {
   return pipe(
     triples,
@@ -97,6 +100,11 @@ export function entitiesFromTriples(triples: TripleType[]): Entity[] {
   );
 }
 
+/**
+ * This function merges local triple actions with entities from the network. This is useful
+ * if you have a collection of Entities from the network and want to display any updates
+ * that were made to them during local editing.
+ */
 export function mergeActionsWithNetworkEntities(
   actions: Record<string, Action[]>,
   networkEntities: Entity[]

--- a/apps/web/modules/entity/entity.ts
+++ b/apps/web/modules/entity/entity.ts
@@ -84,7 +84,7 @@ export function entitiesFromTriples(triples: TripleType[]): Entity[] {
     D.toPairs,
     A.map(([entityId, triples]) => {
       // ts-belt returns readonly arrays from groupBy, so we need to coerce here.
-      // We can do array operations like .concat or .slice to close the triples
+      // We can do array operations like .concat or .slice to coerce the triples
       // array to a mutable version, but casting is cheaper performance-wise as
       // entitiesFromTriples may be used in performance-heavy situations.
       const mutableTriples = triples as unknown as TripleType[];

--- a/apps/web/modules/entity/entity.ts
+++ b/apps/web/modules/entity/entity.ts
@@ -105,10 +105,7 @@ export function entitiesFromTriples(triples: TripleType[]): Entity[] {
  * if you have a collection of Entities from the network and want to display any updates
  * that were made to them during local editing.
  */
-export function mergeActionsWithNetworkEntities(
-  actions: Record<string, Action[]>,
-  networkEntities: Entity[]
-): Entity[] {
+export function mergeActionsWithEntities(actions: Record<string, Action[]>, networkEntities: Entity[]): Entity[] {
   return pipe(
     actions,
     D.values,

--- a/apps/web/modules/entity/entity.ts
+++ b/apps/web/modules/entity/entity.ts
@@ -1,5 +1,6 @@
 import { SYSTEM_IDS } from '@geogenesis/ids';
-import { Triple } from '../types';
+import { A, D, pipe } from '@mobily/ts-belt';
+import { Entity, Triple } from '../types';
 import { groupBy } from '../utils';
 
 /**
@@ -37,7 +38,6 @@ export function descriptionTriple(triples: Triple[]): Triple | undefined {
  */
 export function types(triples: Triple[], currentSpace: string): string[] {
   const typeTriples = triples.filter(triple => triple.attributeId === SYSTEM_IDS.TYPES);
-
   const groupedTypeTriples = groupBy(typeTriples, t => t.attributeId);
 
   return Object.entries(groupedTypeTriples)
@@ -71,4 +71,18 @@ export function name(triples: Triple[]): string | null {
 
 export function nameTriple(triples: Triple[]): Triple | undefined {
   return triples.find(triple => triple.attributeId === SYSTEM_IDS.NAME);
+}
+
+export function entitiesFromTriples(triples: Triple[]): Entity[] {
+  return pipe(
+    triples,
+    A.groupBy(triple => triple.entityId),
+    D.toPairs,
+    A.map(([entityId, triples]) => ({
+      id: entityId,
+      name: name(triples),
+      description: description(triples),
+      types: types(triples, triples[0]?.space),
+    }))
+  );
 }

--- a/apps/web/modules/entity/entity.ts
+++ b/apps/web/modules/entity/entity.ts
@@ -78,11 +78,20 @@ export function entitiesFromTriples(triples: Triple[]): Entity[] {
     triples,
     A.groupBy(triple => triple.entityId),
     D.toPairs,
-    A.map(([entityId, triples]) => ({
-      id: entityId,
-      name: name(triples),
-      description: description(triples),
-      types: types(triples, triples[0]?.space),
-    }))
+    A.map(([entityId, triples]) => {
+      // ts-belt returns readonly arrays from groupBy, so we need to coerce here.
+      // We can do array operations like .concat or .slice to close the triples
+      // array to a mutable version, but casting is cheaper performance-wise as
+      // entitiesFromTriples may be used in performance-heavy situations.
+      const mutableTriples = triples as unknown as Triple[];
+
+      return {
+        id: entityId,
+        name: name(mutableTriples),
+        description: description(mutableTriples),
+        types: types(mutableTriples, triples[0]?.space),
+        triples: mutableTriples,
+      };
+    })
   );
 }

--- a/apps/web/modules/services/network.ts
+++ b/apps/web/modules/services/network.ts
@@ -246,6 +246,7 @@ export class Network implements INetwork {
         ...result,
         description: Entity.description(triples),
         types: Entity.types(triples, space),
+        triples,
       };
     });
 

--- a/apps/web/modules/services/network.ts
+++ b/apps/web/modules/services/network.ts
@@ -243,7 +243,8 @@ export class Network implements INetwork {
       const triples = fromNetworkTriples(result.entityOf);
 
       return {
-        ...result,
+        id: result.id,
+        name: result.name,
         description: Entity.description(triples),
         types: Entity.types(triples, space),
         triples,

--- a/apps/web/modules/triple/triple-store.tsx
+++ b/apps/web/modules/triple/triple-store.tsx
@@ -121,7 +121,7 @@ export class TripleStore implements ITripleStore {
       const actions = ActionsStore.actions$.get()[space];
 
       // We want to merge any local actions with the network triples
-      return Triple.fromActions(space, actions, networkTriples);
+      return Triple.fromActions(actions, networkTriples);
     });
   }
 

--- a/apps/web/modules/triple/triple.ts
+++ b/apps/web/modules/triple/triple.ts
@@ -70,7 +70,7 @@ export function ensureStableId(triple: Triple): Triple {
   return triple;
 }
 
-export function fromActions(spaceId: string, actions: Action[] | undefined, triples: Triple[]) {
+export function fromActions(actions: Action[] | undefined, triples: Triple[]) {
   const newTriples: Triple[] = [...triples].reverse();
   const newActions = actions ?? [];
 

--- a/apps/web/modules/triple/triple.ts
+++ b/apps/web/modules/triple/triple.ts
@@ -93,11 +93,20 @@ export function fromActions(spaceId: string, actions: Action[] | undefined, trip
       }
       case 'deleteTriple': {
         const index = newTriples.findIndex(t => t.id === action.id);
+        if (index === -1) {
+          return;
+        }
+
         newTriples.splice(index, 1);
         break;
       }
       case 'editTriple': {
         const index = newTriples.findIndex(t => t.id === action.before.id);
+        if (index === -1) {
+          newTriples.push(ensureStableId(action.after));
+          return;
+        }
+
         newTriples[index] = ensureStableId(action.after);
         break;
       }

--- a/apps/web/modules/types.ts
+++ b/apps/web/modules/types.ts
@@ -87,6 +87,7 @@ export type Entity = {
   name: string | null;
   description: string | null;
   types: string[];
+  triples: Triple[];
 };
 
 export interface Column {


### PR DESCRIPTION
As part of the editing flow users may create entities locally that they want to reference from other entities. Right now they need to publish these new entities before they are able to reference them.

This PR adds the ability to search locally created and edited entities with the search results from the network when searching for entities.