### PR TITLE
feat: horizontal scrollable tables

### DIFF
--- a/apps/web/modules/components/entity-table/entity-input.tsx
+++ b/apps/web/modules/components/entity-table/entity-input.tsx
@@ -12,22 +12,31 @@ import { TypeDialog } from '../filter/type-dialog';
 const SearchInputContainer = styled.div(props => ({
   position: 'relative',
   width: '100%',
-  marginLeft: props.theme.space * 4,
+
+  '@media (max-width: 640px)': {
+    marginLeft: 0,
+  },
 }));
 
 const SearchIconContainer = styled.div(props => ({
   position: 'absolute',
   left: props.theme.space * 3,
   top: props.theme.space * 2.5,
-  zIndex: 100,
+  zIndex: 10,
 }));
 
-const InputContainer = styled.div({
+const InputContainer = styled.div(props => ({
   overflow: 'hidden',
   display: 'flex',
   width: '100%',
   position: 'relative',
-});
+  gap: props.theme.space * 4,
+
+  '@media (max-width: 640px)': {
+    flexDirection: 'column',
+    gap: props.theme.space,
+  },
+}));
 
 const TriplesInputField = styled(Input)(props => ({
   width: '100%',

--- a/apps/web/modules/components/entity-table/entity-table-container.tsx
+++ b/apps/web/modules/components/entity-table/entity-table-container.tsx
@@ -1,3 +1,4 @@
+import styled from '@emotion/styled';
 import { Spacer } from '~/modules/design-system/spacer';
 import { Text } from '~/modules/design-system/text';
 import { useEntityTable } from '~/modules/triple';
@@ -16,6 +17,16 @@ interface Props {
   initialColumns: Column[];
 }
 
+// Using a container to wrap the table to make styling borders around
+// the table easier. Otherwise we need to do some pseudoselector shenanigans
+// or use box-shadow instead of border.
+const Container = styled.div(props => ({
+  padding: 0,
+  border: `1px solid ${props.theme.colors['grey-02']}`,
+  borderRadius: props.theme.radius,
+  overflow: 'hidden',
+}));
+
 export function EntityTableContainer({ spaceId, initialColumns, initialRows }: Props) {
   const entityTableStore = useEntityTable();
 
@@ -26,11 +37,13 @@ export function EntityTableContainer({ spaceId, initialColumns, initialRows }: P
       <EntityInput />
       <Spacer height={12} />
 
-      <EntityTable
-        space={spaceId}
-        columns={entityTableStore.hydrated ? entityTableStore.columns : initialColumns}
-        rows={entityTableStore.hydrated ? entityTableStore.rows : initialRows}
-      />
+      <Container>
+        <EntityTable
+          space={spaceId}
+          columns={entityTableStore.hydrated ? entityTableStore.columns : initialColumns}
+          rows={entityTableStore.hydrated ? entityTableStore.rows : initialRows}
+        />
+      </Container>
 
       <Spacer height={12} />
 

--- a/apps/web/modules/components/entity-table/entity-table.tsx
+++ b/apps/web/modules/components/entity-table/entity-table.tsx
@@ -58,7 +58,7 @@ const TableRow = styled.tr(props => ({
 const Container = styled.div({
   overflowX: 'hidden',
 
-  '@media(max-width: 900px)': {
+  '@media(max-width: 1200px)': {
     overflowX: 'scroll',
   },
 });

--- a/apps/web/modules/components/filter/type-dialog.tsx
+++ b/apps/web/modules/components/filter/type-dialog.tsx
@@ -54,7 +54,7 @@ const StyledContent = styled(PopoverPrimitive.Content)<ContentProps>(props => ({
   width: `calc(${props.width}px / 2)`,
   backgroundColor: props.theme.colors.white,
   boxShadow: props.theme.shadows.dropdown,
-  zIndex: 1,
+  zIndex: 100,
 
   border: `1px solid ${props.theme.colors['grey-02']}`,
 

--- a/apps/web/modules/components/table/styles.tsx
+++ b/apps/web/modules/components/table/styles.tsx
@@ -8,7 +8,6 @@ export const EmptyTableText = styled.td(props => ({
 export const PageContainer = styled.div({
   display: 'flex',
   flexDirection: 'column',
-  alignItems: 'center',
 });
 
 export const PageNumberContainer = styled.div({

--- a/apps/web/modules/components/table/styles.tsx
+++ b/apps/web/modules/components/table/styles.tsx
@@ -28,7 +28,7 @@ export const TableHeader = styled.th<{ width: number }>(props => ({
   border: `1px solid ${props.theme.colors['grey-02']}`,
   padding: props.theme.space * 2.5,
   textAlign: 'left',
-  width: props.width,
+  minWidth: props.width,
 }));
 
 export const TableRow = styled.tr(props => ({

--- a/apps/web/modules/components/triple-table.tsx
+++ b/apps/web/modules/components/triple-table.tsx
@@ -116,6 +116,8 @@ export const TripleTable = memo(function TripleTable({ triples, space }: Props) 
     meta: {
       expandedCells,
       space,
+      isEditor: false,
+      editable: false,
     },
   });
 

--- a/apps/web/modules/components/triple-table.tsx
+++ b/apps/web/modules/components/triple-table.tsx
@@ -22,6 +22,10 @@ const Container = styled.div(props => ({
   border: `1px solid ${props.theme.colors['grey-02']}`,
   borderRadius: props.theme.radius,
   overflow: 'hidden',
+
+  '@media(max-width: 1200px)': {
+    overflowX: 'scroll',
+  },
 }));
 
 const columnHelper = createColumnHelper<Triple>();

--- a/apps/web/pages/_app.tsx
+++ b/apps/web/pages/_app.tsx
@@ -16,6 +16,7 @@ import '../styles/styles.css';
 const globalStyles = css`
   html {
     overflow-y: overlay;
+    overflow-x: hidden;
   }
 
   body {

--- a/apps/web/react-table.d.ts
+++ b/apps/web/react-table.d.ts
@@ -7,5 +7,7 @@ declare module '@tanstack/react-table' {
   export interface TableMeta<TData extends RowData> {
     space: string;
     expandedCells: Record<string, boolean>;
+    editable: boolean;
+    isEditor: boolean;
   }
 }


### PR DESCRIPTION
Right now if a table if wider than 1200px it will squish the columns to be as small as possible to accomodate the fixed width. We're now setting a minimum width for columns so they are more readable, and now the table will be horizontally scrollable if it expands beyond 1200px.