### PR TITLE
fix: change entities table to 50 items

### DIFF
--- a/apps/web/modules/components/entity-table/entity-table.tsx
+++ b/apps/web/modules/components/entity-table/entity-table.tsx
@@ -108,7 +108,7 @@ export const EntityTable = memo(function EntityTable({ rows, space, columns }: P
     state: {
       pagination: {
         pageIndex: 0,
-        pageSize: 100,
+        pageSize: 50,
       },
     },
     meta: {

--- a/apps/web/modules/entity/entity-store/entity-store.tsx
+++ b/apps/web/modules/entity/entity-store/entity-store.tsx
@@ -30,6 +30,8 @@ export const createInitialDefaultTriples = (spaceId: string, entityId: string): 
   ];
 };
 
+const DEFAULT_PAGE_SIZE = 100;
+
 interface IEntityStoreConfig {
   api: INetwork;
   spaceId: string;
@@ -114,7 +116,7 @@ export class EntityStore implements IEntityStore {
         typeTriples.map(triple => {
           return this.api.fetchTriples({
             query: '',
-            first: 100,
+            first: DEFAULT_PAGE_SIZE,
             abortController: this.abortController,
             skip: 0,
             filter: [
@@ -137,7 +139,7 @@ export class EntityStore implements IEntityStore {
         attributeTriples.map(attribute => {
           return this.api.fetchTriples({
             query: '',
-            first: 100,
+            first: DEFAULT_PAGE_SIZE,
             skip: 0,
             abortController: this.abortController,
             filter: [

--- a/apps/web/modules/entity/entity-table-store/entity-table-store.tsx
+++ b/apps/web/modules/entity/entity-table-store/entity-table-store.tsx
@@ -43,7 +43,7 @@ interface IEntityTableStoreConfig {
   initialColumns: Column[];
 }
 
-export const DEFAULT_PAGE_SIZE = 100;
+export const DEFAULT_PAGE_SIZE = 50;
 export const DEFAULT_INITIAL_PARAMS = {
   query: '',
   pageNumber: 0,

--- a/apps/web/modules/entity/index.ts
+++ b/apps/web/modules/entity/index.ts
@@ -3,6 +3,6 @@ export { EntityStoreProvider } from './entity-store/entity-store-provider';
 export { EntityStore } from './entity-store/entity-store';
 export { useEntityStore } from './entity-store/use-entity-store';
 export { EntityTableStoreProvider, useEntityTableStore } from './entity-table-store/entity-table-store-provider';
-export { EntityTableStore } from './entity-table-store/entity-table-store';
+export { EntityTableStore, DEFAULT_INITIAL_PARAMS, DEFAULT_PAGE_SIZE } from './entity-table-store/entity-table-store';
 export type { InitialEntityTableStoreParams } from './entity-table-store/entity-table-store-params';
 export { useEntityTable } from './entity-table-store/use-entity-tables';

--- a/apps/web/modules/services/network.ts
+++ b/apps/web/modules/services/network.ts
@@ -4,6 +4,7 @@ import { SYSTEM_IDS } from '@geogenesis/ids';
 import { ContractTransaction, Event, Signer, utils } from 'ethers';
 import { Entity, InitialEntityTableStoreParams } from '../entity';
 import { DEFAULT_PAGE_SIZE, Triple } from '../triple';
+import { DEFAULT_PAGE_SIZE as DEFAULT_PAGE_SIZE_ENTITY_TABLE } from '../entity';
 import {
   Account,
   Action,
@@ -452,7 +453,7 @@ export class Network implements INetwork {
     return {
       columns,
       rows,
-      hasNextPage: rowEntityIds.length > DEFAULT_PAGE_SIZE,
+      hasNextPage: rowEntityIds.length > DEFAULT_PAGE_SIZE_ENTITY_TABLE,
     };
   };
 }

--- a/apps/web/pages/space/[id].tsx
+++ b/apps/web/pages/space/[id].tsx
@@ -10,8 +10,7 @@ import { Params } from '~/modules/params';
 import { INetwork, Network } from '~/modules/services/network';
 import { StorageClient } from '~/modules/services/storage';
 import { Column, Row, Triple } from '~/modules/types';
-import { EntityTableStoreProvider } from '~/modules/entity';
-import { DEFAULT_PAGE_SIZE } from '~/modules/triple';
+import { DEFAULT_PAGE_SIZE, EntityTableStoreProvider } from '~/modules/entity';
 
 interface Props {
   spaceId: string;


### PR DESCRIPTION
We are updating the entire table every time there is an edit to an entity in the table. This is pretty slow on its own, but having 100 rows in the table exacerbates it. Additionally, creating 200+ styled-components on every table rerender is expensive. It may make sense for us to move to a static styling mechanism instead of a runtime one at some point. For now the 50 row limit should be good enough.