### PR TITLE
fix: merge local name change actions with triples

### DIFF
--- a/apps/web/modules/components/entity/edit-events.ts
+++ b/apps/web/modules/components/entity/edit-events.ts
@@ -122,7 +122,7 @@ const listener =
               space: context.spaceId,
               entityId: context.entityId,
               entityName: name,
-              attributeId: 'name',
+              attributeId: SYSTEM_IDS.NAME,
               attributeName: 'Name',
               value: { id: ID.createValueId(), type: 'string', value: name },
             })
@@ -132,6 +132,7 @@ const listener =
         return update(
           Triple.ensureStableId({
             ...triple,
+            entityName: name,
             value: { ...triple.value, type: 'string', value: name },
           }),
           triple
@@ -308,6 +309,18 @@ const listener =
 
       case 'UPDATE_VALUE': {
         const { value, triple } = event.payload;
+
+        if (triple.attributeId === SYSTEM_IDS.NAME) {
+          return update(
+            {
+              ...triple,
+              entityName: value,
+              value: { ...triple.value, type: 'string', value },
+            },
+            triple
+          );
+        }
+
         update(
           {
             ...triple,

--- a/apps/web/modules/entity/entity.ts
+++ b/apps/web/modules/entity/entity.ts
@@ -125,7 +125,8 @@ export function mergeActionsWithEntities(actions: Record<string, Action[]>, netw
 
       const networkEntity = networkEntities.find(e => A.isNotEmpty(entityIds) && e.id === A.head(entityIds));
       const triplesForNetworkEntity = networkEntity?.triples ?? [];
-      return Triple.fromActions(actions, triplesForNetworkEntity);
+      const updatedTriples = Triple.fromActions(actions, triplesForNetworkEntity);
+      return Triple.withLocalNames(actions, updatedTriples);
     },
     entitiesFromTriples
   );

--- a/apps/web/modules/triple/triple-store.tsx
+++ b/apps/web/modules/triple/triple-store.tsx
@@ -118,10 +118,11 @@ export class TripleStore implements ITripleStore {
 
     this.triples$ = computed(() => {
       const { triples: networkTriples } = networkData$.get();
-      const actions = ActionsStore.actions$.get()[space];
+      const actions = ActionsStore.actions$.get()[space] ?? [];
 
       // We want to merge any local actions with the network triples
-      return Triple.fromActions(actions, networkTriples);
+      const updatedTriples = Triple.fromActions(actions, networkTriples);
+      return Triple.withLocalNames(actions, updatedTriples);
     });
   }
 

--- a/apps/web/modules/triple/triple.test.ts
+++ b/apps/web/modules/triple/triple.test.ts
@@ -1,9 +1,10 @@
 import { describe, it } from 'vitest';
-import { Triple as TripleType } from '../types';
-import { empty, withId } from './triple';
+import { SYSTEM_IDS } from '~/../../packages/ids';
+import { Action as ActionType, Triple as TripleType } from '../types';
+import { empty, withId, withLocalNames } from './triple';
 
-describe('Triple', () => {
-  it('Returns the same triple with an ID', () => {
+describe('Triple helpers', () => {
+  it('Triple.withId returns the same triple with an updated ID', () => {
     const triple: TripleType = {
       id: '',
       entityId: 'entityId',
@@ -24,7 +25,107 @@ describe('Triple', () => {
     });
   });
 
-  it('Returns a unique, empty triple', () => {
+  it('Triple.empty returns a unique, empty triple', () => {
     expect(empty('space-id', 'banana-id')).not.toEqual(empty('space-id', 'banana-id'));
+  });
+
+  it('Triple.withLocalNames returns triples whose entity names have been changed locally', () => {
+    const tripleInEntity: TripleType = {
+      id: '',
+      entityId: 'entityId',
+      attributeId: 'attributeId',
+      attributeName: 'banana',
+      value: {
+        id: 'valueId',
+        type: 'string',
+        value: 'banana',
+      },
+      space: 'spaceId',
+      entityName: 'banana',
+    };
+
+    const editAction: ActionType = {
+      type: 'editTriple',
+      before: {
+        type: 'deleteTriple',
+        id: 'before',
+        entityId: 'entityId',
+        attributeId: SYSTEM_IDS.NAME,
+        attributeName: 'Name',
+        value: {
+          id: 'valueId',
+          type: 'string',
+          value: 'name-1',
+        },
+        space: 'spaceId',
+        entityName: 'entityName',
+      },
+      after: {
+        type: 'createTriple',
+        id: 'before',
+        entityId: 'entityId',
+        attributeId: SYSTEM_IDS.NAME,
+        attributeName: 'Name',
+        value: {
+          id: 'valueId',
+          type: 'string',
+          value: 'name-2',
+        },
+        space: 'spaceId',
+        entityName: 'name-2',
+      },
+    };
+
+    expect(withLocalNames([editAction], [tripleInEntity])).toStrictEqual([
+      {
+        ...tripleInEntity,
+        entityName: 'name-2',
+      },
+    ]);
+
+    const tripleWithEntityInAttribute: TripleType = {
+      id: '',
+      entityId: 'someOtherEntityId',
+      attributeId: 'entityId',
+      attributeName: 'entityName',
+      value: {
+        id: 'valueId',
+        type: 'string',
+        value: 'banana',
+      },
+      space: 'spaceId',
+      entityName: 'banana',
+    };
+
+    expect(withLocalNames([editAction], [tripleWithEntityInAttribute])).toStrictEqual([
+      {
+        ...tripleWithEntityInAttribute,
+        attributeName: 'name-2',
+      },
+    ]);
+
+    const tripleWithEntityInValue: TripleType = {
+      id: '',
+      entityId: 'someOtherEntityName',
+      attributeId: 'attirbuteId',
+      attributeName: 'attributeName',
+      value: {
+        id: 'entityId',
+        type: 'entity',
+        name: 'valueName',
+      },
+      space: 'spaceId',
+      entityName: 'entityName',
+    };
+
+    expect(withLocalNames([editAction], [tripleWithEntityInValue])).toStrictEqual([
+      {
+        ...tripleWithEntityInValue,
+        value: {
+          ...tripleWithEntityInValue.value,
+          name: 'name-2',
+        },
+      },
+    ]);
   });
 });

--- a/apps/web/modules/triple/triple.ts
+++ b/apps/web/modules/triple/triple.ts
@@ -1,6 +1,17 @@
 import { SYSTEM_IDS } from '@geogenesis/ids';
+import { A, pipe } from '@mobily/ts-belt';
+import { Action } from '../action';
 import { ID } from '../id';
-import { Action, EntityValue, NumberValue, OmitStrict, StringValue, Triple, TripleValueType, Value } from '../types';
+import {
+  Action as ActionType,
+  EntityValue,
+  NumberValue,
+  OmitStrict,
+  StringValue,
+  Triple,
+  TripleValueType,
+  Value,
+} from '../types';
 import { valueTypes } from '../value-types';
 
 export function withId(triple: OmitStrict<Triple, 'id'>): Triple {
@@ -70,7 +81,7 @@ export function ensureStableId(triple: Triple): Triple {
   return triple;
 }
 
-export function fromActions(actions: Action[] | undefined, triples: Triple[]) {
+export function fromActions(actions: ActionType[] | undefined, triples: Triple[]) {
   const newTriples: Triple[] = [...triples].reverse();
   const newActions = actions ?? [];
 
@@ -116,17 +127,22 @@ export function fromActions(actions: Action[] | undefined, triples: Triple[]) {
   return newTriples.reverse();
 }
 
-export function withLocalNames(actions: Action[], triples: Triple[]) {
-  // TODO: We need to make it work with create triple too?
-  const newEntityNames = actions
-    .flatMap(a => (a.type === 'editTriple' ? [a.after] : []))
-    .flatMap(e => (e ? [e] : []))
-    .reduce((acc, entity) => {
+/**
+ * This function applies locally changed entity names to all triples being rendered.
+ */
+export function withLocalNames(actions: ActionType[], triples: Triple[]) {
+  const newEntityNames = pipe(
+    actions,
+    Action.squashChanges,
+    A.flatMap(a => (a.type === 'editTriple' ? [a.after] : [])),
+    A.reduce({} as Record<string, string>, (acc, entity) => {
       if (entity.entityName) acc[entity.entityId] = entity.entityName;
       return acc;
-    }, {} as Record<string, string>);
+    })
+  );
 
-  return triples.map(triple => {
+  // TODO: We need to make it work with create triple too?
+  return A.map(triples, triple => {
     // The triple is part of the entity whose name changed
     if (triple.entityId in newEntityNames) {
       return {
@@ -145,6 +161,7 @@ export function withLocalNames(actions: Action[], triples: Triple[]) {
 
     // The triple has a an entity value whose name changed
     if (triple.value.id in newEntityNames) {
+      console.log(triple.value.id, 'is in newEntityNames');
       return {
         ...triple,
         value: {

--- a/apps/web/modules/triple/triple.ts
+++ b/apps/web/modules/triple/triple.ts
@@ -115,3 +115,49 @@ export function fromActions(actions: Action[] | undefined, triples: Triple[]) {
 
   return newTriples.reverse();
 }
+
+export function withLocalNames(actions: Action[], triples: Triple[]) {
+  const newEntityNames = actions
+    .flatMap(a => (a.type === 'editTriple' ? [a.after] : []))
+    .flatMap(e => (e ? [e] : []))
+    .reduce((acc, entity) => {
+      if (entity.entityName) acc[entity.entityId] = entity.entityName;
+      return acc;
+    }, {} as Record<string, string>);
+
+  if (Object.keys(newEntityNames).length > 0) console.log({ newEntityNames });
+
+  return triples.map(triple => {
+    // The triple is part of the entity whose name changed
+    if (triple.entityId in newEntityNames) {
+      return {
+        ...triple,
+        entityName: newEntityNames[triple.entityId],
+      };
+    }
+
+    // The triple has an attribute whose name changed
+    if (triple.attributeId in newEntityNames) {
+      return {
+        ...triple,
+        attributeName: newEntityNames[triple.attributeId],
+      };
+    }
+
+    if (triple.value.id === '2ca07701-4e0e-4ad3-a19b-4980e0994d6e') console.log('match');
+    if (triple.value.id in newEntityNames) console.log('match', triple.value.id, newEntityNames[triple.value.id]);
+
+    // The triple has a an entity value whose name changed
+    if (triple.value.id in newEntityNames) {
+      return {
+        ...triple,
+        value: {
+          ...triple.value,
+          name: newEntityNames[triple.value.id],
+        },
+      };
+    }
+
+    return triple;
+  });
+}

--- a/apps/web/modules/triple/triple.ts
+++ b/apps/web/modules/triple/triple.ts
@@ -117,6 +117,7 @@ export function fromActions(actions: Action[] | undefined, triples: Triple[]) {
 }
 
 export function withLocalNames(actions: Action[], triples: Triple[]) {
+  // TODO: We need to make it work with create triple too?
   const newEntityNames = actions
     .flatMap(a => (a.type === 'editTriple' ? [a.after] : []))
     .flatMap(e => (e ? [e] : []))
@@ -124,8 +125,6 @@ export function withLocalNames(actions: Action[], triples: Triple[]) {
       if (entity.entityName) acc[entity.entityId] = entity.entityName;
       return acc;
     }, {} as Record<string, string>);
-
-  if (Object.keys(newEntityNames).length > 0) console.log({ newEntityNames });
 
   return triples.map(triple => {
     // The triple is part of the entity whose name changed
@@ -143,9 +142,6 @@ export function withLocalNames(actions: Action[], triples: Triple[]) {
         attributeName: newEntityNames[triple.attributeId],
       };
     }
-
-    if (triple.value.id === '2ca07701-4e0e-4ad3-a19b-4980e0994d6e') console.log('match');
-    if (triple.value.id in newEntityNames) console.log('match', triple.value.id, newEntityNames[triple.value.id]);
 
     // The triple has a an entity value whose name changed
     if (triple.value.id in newEntityNames) {


### PR DESCRIPTION
We are now updating the `entityName`, `attributeName` and `value.name` of all triples if there associated entity's name has changed.

### TODO:
- [x] Combine `Triple.fromActions` and `Triple.withLocalNames` into a single function since they both need to run when actions update.
- [x] Render locally changed triples while in browse mode?