### PR TITLE
exploration: removing server data store hydration in entity page

### DIFF
--- a/apps/web/integration/pages/space/[id].test.tsx
+++ b/apps/web/integration/pages/space/[id].test.tsx
@@ -8,15 +8,7 @@ describe('Space page', () => {
   it('Should render header as non-editor', () => {
     render(
       <Providers>
-        <SpacePage
-          spaceId="1"
-          spaceName="Banana"
-          spaceImage={null}
-          initialTypes={[]}
-          initialColumns={[]}
-          initialRows={[]}
-          initialSelectedType={null}
-        />
+        <SpacePage spaceId="1" spaceName="Banana" spaceImage={null} />
       </Providers>
     );
 
@@ -27,15 +19,7 @@ describe('Space page', () => {
   it('Should render empty table', () => {
     render(
       <Providers>
-        <SpacePage
-          spaceId="1"
-          spaceName="Banana"
-          spaceImage={null}
-          initialTypes={[]}
-          initialColumns={[]}
-          initialRows={[]}
-          initialSelectedType={null}
-        />
+        <SpacePage spaceId="1" spaceName="Banana" spaceImage={null} />
       </Providers>
     );
 
@@ -45,23 +29,7 @@ describe('Space page', () => {
   it('Should render non-empty table', () => {
     render(
       <Providers>
-        <SpacePage
-          spaceId="1"
-          spaceName="Banana"
-          spaceImage={null}
-          initialTypes={[]}
-          initialColumns={[{ id: '1', name: 'Alice' }]}
-          initialRows={[
-            {
-              '1': {
-                columnId: '1',
-                entityId: '1',
-                triples: [],
-              },
-            },
-          ]}
-          initialSelectedType={null}
-        />
+        <SpacePage spaceId="1" spaceName="Banana" spaceImage={null} />
       </Providers>
     );
 
@@ -74,15 +42,7 @@ describe('Space page', () => {
 
     render(
       <Providers>
-        <SpacePage
-          spaceId="1"
-          spaceName="Banana"
-          spaceImage={null}
-          initialTypes={[]}
-          initialColumns={[]}
-          initialRows={[]}
-          initialSelectedType={null}
-        />
+        <SpacePage spaceId="1" spaceName="Banana" spaceImage={null} />
       </Providers>
     );
 

--- a/apps/web/integration/pages/space/[id]/triples.test.tsx
+++ b/apps/web/integration/pages/space/[id]/triples.test.tsx
@@ -9,7 +9,7 @@ describe('Space page', () => {
   it('Should render header as non-editor', () => {
     render(
       <Providers>
-        <TriplesPage spaceId="1" spaceName="Banana" spaceImage={null} initialTriples={[]} />
+        <TriplesPage spaceId="1" spaceName="Banana" spaceImage={null} />
       </Providers>
     );
 
@@ -20,22 +20,11 @@ describe('Space page', () => {
   it('Should render empty table', () => {
     render(
       <Providers>
-        <TriplesPage spaceId="1" spaceName="Banana" spaceImage={null} initialTriples={[]} />
+        <TriplesPage spaceId="1" spaceName="Banana" spaceImage={null} />
       </Providers>
     );
 
     expect(screen.queryByText('No results found')).toBeInTheDocument();
-  });
-
-  it('Should render non-empty table', () => {
-    render(
-      <Providers>
-        <TriplesPage spaceId="1" spaceName="Banana" spaceImage={null} initialTriples={[makeStubTriple('Alice')]} />
-      </Providers>
-    );
-
-    expect(screen.queryByText('No results found')).not.toBeInTheDocument();
-    expect(screen.getAllByText('Alice')).toBeTruthy();
   });
 
   it('Should toggle advanced filters queries', async () => {
@@ -43,7 +32,7 @@ describe('Space page', () => {
 
     render(
       <Providers>
-        <TriplesPage spaceId="1" spaceName="Banana" spaceImage={null} initialTriples={[]} />
+        <TriplesPage spaceId="1" spaceName="Banana" spaceImage={null} />
       </Providers>
     );
 

--- a/apps/web/modules/components/entity-table/entity-table-container.tsx
+++ b/apps/web/modules/components/entity-table/entity-table-container.tsx
@@ -2,7 +2,6 @@ import styled from '@emotion/styled';
 import { Spacer } from '~/modules/design-system/spacer';
 import { Text } from '~/modules/design-system/text';
 import { useEntityTable } from '~/modules/entity';
-import { Column, Row } from '../../types';
 import { PageContainer, PageNumberContainer } from '../table/styles';
 import { NextButton, PageNumber, PreviousButton } from '../table/table-pagination';
 import { EntityInput } from './entity-input';
@@ -11,8 +10,6 @@ import { EntityTable } from './entity-table';
 interface Props {
   spaceId: string;
   spaceName?: string;
-  initialRows: Row[];
-  initialColumns: Column[];
 }
 
 // Using a container to wrap the table to make styling borders around
@@ -25,7 +22,7 @@ const Container = styled.div(props => ({
   overflow: 'hidden',
 }));
 
-export function EntityTableContainer({ spaceId, initialColumns, initialRows }: Props) {
+export function EntityTableContainer({ spaceId }: Props) {
   const entityTableStore = useEntityTable();
 
   return (
@@ -36,11 +33,7 @@ export function EntityTableContainer({ spaceId, initialColumns, initialRows }: P
       <Spacer height={12} />
 
       <Container>
-        <EntityTable
-          space={spaceId}
-          columns={entityTableStore.hydrated ? entityTableStore.columns : initialColumns}
-          rows={entityTableStore.hydrated ? entityTableStore.rows : initialRows}
-        />
+        <EntityTable space={spaceId} columns={entityTableStore.columns} rows={entityTableStore.rows} />
       </Container>
 
       <Spacer height={12} />

--- a/apps/web/modules/components/entity-table/entity-table.tsx
+++ b/apps/web/modules/components/entity-table/entity-table.tsx
@@ -155,13 +155,7 @@ export const EntityTable = memo(function EntityTable({ rows, space, columns }: P
             const entityId = cells[0].getValue<Cell>()?.entityId;
 
             return (
-              <EntityStoreProvider
-                key={row.id}
-                id={entityId}
-                spaceId={space}
-                initialSchemaTriples={[]}
-                initialTriples={initialTriples}
-              >
+              <EntityStoreProvider key={row.id} id={entityId} spaceId={space}>
                 <TableRow>
                   {cells.map(cell => {
                     const cellId = `${row.original.id}-${cell.column.id}`;

--- a/apps/web/modules/components/entity/editable-entity-page.test.tsx
+++ b/apps/web/modules/components/entity/editable-entity-page.test.tsx
@@ -12,16 +12,8 @@ describe('Editable Entity Page', () => {
 
     render(
       <Providers>
-        <EntityStoreProvider id={'1'} spaceId={'1'} initialTriples={[]} initialSchemaTriples={[]}>
-          <EditableEntityPage
-            id="1"
-            name="Banana"
-            space="1"
-            triples={[]}
-            schemaTriples={[
-              { ...makeStubTriple('Schema'), attributeName: 'Schema', attributeId: 'Schema', placeholder: true },
-            ]}
-          />
+        <EntityStoreProvider id={'1'} spaceId={'1'}>
+          <EditableEntityPage id="1" space="1" />
         </EntityStoreProvider>
       </Providers>
     );
@@ -35,26 +27,8 @@ describe('Editable Entity Page', () => {
 
     render(
       <Providers>
-        <EntityStoreProvider id={'1'} spaceId={'1'} initialTriples={[]} initialSchemaTriples={[]}>
-          <EditableEntityPage
-            id="1"
-            name="Banana"
-            space="1"
-            triples={[]}
-            schemaTriples={[
-              {
-                ...makeStubTriple('Schema'),
-                attributeName: 'Schema',
-                attributeId: 'Schema',
-                value: {
-                  type: 'entity',
-                  name: '',
-                  id: '',
-                },
-                placeholder: true,
-              },
-            ]}
-          />
+        <EntityStoreProvider id={'1'} spaceId={'1'}>
+          <EditableEntityPage id="1" space="1" />
         </EntityStoreProvider>
       </Providers>
     );

--- a/apps/web/modules/components/entity/editable-entity-page.tsx
+++ b/apps/web/modules/components/entity/editable-entity-page.tsx
@@ -1,6 +1,5 @@
 import styled from '@emotion/styled';
 import Head from 'next/head';
-import { useActionsStore } from '~/modules/action';
 import { Button, SquareButton } from '~/modules/design-system/button';
 import { DeletableChipButton } from '~/modules/design-system/chip';
 import { Relation } from '~/modules/design-system/icons/relation';
@@ -57,34 +56,19 @@ const AddTripleContainer = styled.div(({ theme }) => ({
 }));
 
 interface Props {
-  triples: TripleType[];
-  schemaTriples: TripleType[];
   id: string;
-  name: string;
   space: string;
 }
 
-export function EditableEntityPage({ id, name: serverName, space, schemaTriples: serverSchemaTriples }: Props) {
-  const {
-    triples,
-    schemaTriples: localSchemaTriples,
-    update,
-    create,
-    remove,
-    hideSchema,
-    hiddenSchemaIds,
-  } = useEntityStore();
-
-  const { actions } = useActionsStore(space);
+export function EditableEntityPage({ id, space }: Props) {
+  const { triples, schemaTriples, update, create, remove, hideSchema, hiddenSchemaIds, name } = useEntityStore();
 
   // We hydrate the local editable store with the triples from the server. While it's hydrating
   // we can fallback to the server triples so we render real data and there's no layout shift.
-  const schemaTriples = localSchemaTriples.length === 0 ? serverSchemaTriples : localSchemaTriples;
 
   const nameTriple = Entity.nameTriple(triples);
   const descriptionTriple = Entity.descriptionTriple(triples);
   const description = Entity.description(triples);
-  const name = Entity.name(triples) ?? serverName;
 
   const send = useEditEvents({
     context: {

--- a/apps/web/modules/components/entity/editable-entity-page.tsx
+++ b/apps/web/modules/components/entity/editable-entity-page.tsx
@@ -64,15 +64,9 @@ interface Props {
   space: string;
 }
 
-export function EditableEntityPage({
-  id,
-  name: serverName,
-  space,
-  schemaTriples: serverSchemaTriples,
-  triples: serverTriples,
-}: Props) {
+export function EditableEntityPage({ id, name: serverName, space, schemaTriples: serverSchemaTriples }: Props) {
   const {
-    triples: localTriples,
+    triples,
     schemaTriples: localSchemaTriples,
     update,
     create,
@@ -85,7 +79,6 @@ export function EditableEntityPage({
 
   // We hydrate the local editable store with the triples from the server. While it's hydrating
   // we can fallback to the server triples so we render real data and there's no layout shift.
-  const triples = localTriples.length === 0 && actions.length === 0 ? serverTriples : localTriples;
   const schemaTriples = localSchemaTriples.length === 0 ? serverSchemaTriples : localSchemaTriples;
 
   const nameTriple = Entity.nameTriple(triples);

--- a/apps/web/modules/components/entity/readable-entity-page.tsx
+++ b/apps/web/modules/components/entity/readable-entity-page.tsx
@@ -12,7 +12,7 @@ import { ResizableContainer } from '~/modules/design-system/resizable-container'
 import { Spacer } from '~/modules/design-system/spacer';
 import { Text } from '~/modules/design-system/text';
 import { Truncate } from '~/modules/design-system/truncate';
-import { Entity } from '~/modules/entity';
+import { Entity, useEntityStore } from '~/modules/entity';
 import { Triple } from '~/modules/types';
 import { groupBy, NavUtils, partition } from '~/modules/utils';
 import { CopyIdButton } from './copy-id';
@@ -50,14 +50,14 @@ const EntityActionGroup = styled.div({
 });
 
 interface Props {
-  triples: Triple[];
   id: string;
   name: string;
   space: string;
   linkedEntities: Record<string, LinkedEntityGroup>;
 }
 
-export function ReadableEntityPage({ triples, id, name, space, linkedEntities }: Props) {
+export function ReadableEntityPage({ id, name, space, linkedEntities }: Props) {
+  const { triples } = useEntityStore();
   const description = Entity.description(triples);
 
   return (
@@ -152,7 +152,7 @@ function EntityAttributes({
   space,
 }: {
   entityId: string;
-  triples: Props['triples'];
+  triples: Triple[];
   space: Props['space'];
 }) {
   const groupedTriples = groupBy(triples, t => t.attributeId);

--- a/apps/web/modules/components/entity/readable-entity-page.tsx
+++ b/apps/web/modules/components/entity/readable-entity-page.tsx
@@ -3,7 +3,7 @@ import { LayoutGroup } from 'framer-motion';
 import Head from 'next/head';
 import Link from 'next/link';
 import pluralize from 'pluralize';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { SmallButton } from '~/modules/design-system/button';
 import { Chip } from '~/modules/design-system/chip';
 import { ChevronDownSmall } from '~/modules/design-system/icons/chevron-down-small';
@@ -13,6 +13,7 @@ import { Spacer } from '~/modules/design-system/spacer';
 import { Text } from '~/modules/design-system/text';
 import { Truncate } from '~/modules/design-system/truncate';
 import { Entity, useEntityStore } from '~/modules/entity';
+import { usePageName } from '~/modules/stores/use-page-name';
 import { Triple } from '~/modules/types';
 import { groupBy, NavUtils, partition } from '~/modules/utils';
 import { CopyIdButton } from './copy-id';
@@ -51,14 +52,20 @@ const EntityActionGroup = styled.div({
 
 interface Props {
   id: string;
-  name: string;
   space: string;
-  linkedEntities: Record<string, LinkedEntityGroup>;
 }
 
-export function ReadableEntityPage({ id, name, space, linkedEntities }: Props) {
-  const { triples } = useEntityStore();
+export function ReadableEntityPage({ id, space }: Props) {
+  const { setPageName } = usePageName();
+  const { triples, linkedEntities, name } = useEntityStore();
   const description = Entity.description(triples);
+
+  // This is a janky way to set the name in the navbar until we have nested layouts
+  // and the navbar can query the name itself in a nice way.
+  useEffect(() => {
+    setPageName(name);
+    return () => setPageName('');
+  }, [name]);
 
   return (
     <div>

--- a/apps/web/modules/components/space/space-header.tsx
+++ b/apps/web/modules/components/space/space-header.tsx
@@ -1,9 +1,7 @@
 import styled from '@emotion/styled';
 import Image from 'next/image';
 import { Text } from '~/modules/design-system/text';
-// import { importCSVFile } from '~/modules/services/import';
 import { ZERO_WIDTH_SPACE } from '../../constants';
-// import { getFilesFromFileList } from '../utils';
 
 const SpaceImageContainer = styled.div(props => ({
   // this is required for next/image
@@ -27,14 +25,6 @@ const SpaceHeaderContainer = styled.div({
   justifyContent: 'space-between',
   width: '100%',
 });
-
-// const FileImport = styled.input({
-//   margin: '0',
-//   padding: '0',
-//   opacity: '0',
-//   position: 'absolute',
-//   inset: '0',
-// });
 
 interface Props {
   spaceId: string;

--- a/apps/web/modules/components/triples.tsx
+++ b/apps/web/modules/components/triples.tsx
@@ -11,10 +11,9 @@ import { TripleTable } from './triple-table';
 
 interface Props {
   spaceId: string;
-  initialTriples: Triple[];
 }
 
-export function Triples({ spaceId, initialTriples }: Props) {
+export function Triples({ spaceId }: Props) {
   const [showPredefinedQueries, setShowPredefinedQueries] = useState(true);
   const tripleStore = useTriples();
 
@@ -27,7 +26,7 @@ export function Triples({ spaceId, initialTriples }: Props) {
 
         <Spacer height={12} />
 
-        <TripleTable space={spaceId} triples={tripleStore.hydrated ? tripleStore.triples : initialTriples} />
+        <TripleTable space={spaceId} triples={tripleStore.triples} />
 
         <Spacer height={12} />
 

--- a/apps/web/modules/entity/entity-store.test.ts
+++ b/apps/web/modules/entity/entity-store.test.ts
@@ -11,8 +11,6 @@ describe('EntityStore', () => {
       id: 'e',
       api: network,
       spaceId: 's',
-      initialTriples: [],
-      initialSchemaTriples: [],
       ActionsStore: new ActionsStore({ api: network }),
     });
     const defaultTriples = createInitialDefaultTriples('s', 'e');
@@ -36,8 +34,6 @@ describe('EntityStore', () => {
       id: 'e',
       api: network,
       spaceId: 's',
-      initialTriples: initialEntityStoreTriples,
-      initialSchemaTriples: [],
       ActionsStore: new ActionsStore({ api: network }),
     });
 
@@ -58,8 +54,6 @@ describe('EntityStore', () => {
       id: 'e',
       api: network,
       spaceId: 's',
-      initialTriples: initialEntityStoreTriples,
-      initialSchemaTriples: [],
       ActionsStore: new ActionsStore({ api: network }),
     });
 

--- a/apps/web/modules/entity/entity-store/entity-store-provider.tsx
+++ b/apps/web/modules/entity/entity-store/entity-store-provider.tsx
@@ -1,7 +1,6 @@
 import { createContext, useContext, useMemo } from 'react';
 import { useActionsStoreContext } from '../../action';
 import { Services } from '../../services';
-import { Triple } from '../../types';
 import { EntityStore } from './entity-store';
 
 const EntityStoreContext = createContext<EntityStore | undefined>(undefined);
@@ -10,17 +9,15 @@ interface Props {
   id: string;
   spaceId: string;
   children: React.ReactNode;
-  initialTriples: Triple[];
-  initialSchemaTriples: Triple[];
 }
 
-export function EntityStoreProvider({ id, spaceId, children, initialTriples, initialSchemaTriples }: Props) {
+export function EntityStoreProvider({ id, spaceId, children }: Props) {
   const { network } = Services.useServices();
   const ActionsStore = useActionsStoreContext();
 
   const store = useMemo(() => {
-    return new EntityStore({ api: network, spaceId, initialTriples, initialSchemaTriples, id, ActionsStore });
-  }, [network, spaceId, initialTriples, initialSchemaTriples, id, ActionsStore]);
+    return new EntityStore({ api: network, spaceId, id, ActionsStore });
+  }, [network, spaceId, id, ActionsStore]);
 
   return <EntityStoreContext.Provider value={store}>{children}</EntityStoreContext.Provider>;
 }

--- a/apps/web/modules/entity/entity-store/use-entity-store.tsx
+++ b/apps/web/modules/entity/entity-store/use-entity-store.tsx
@@ -3,13 +3,18 @@ import { Triple } from '~/modules/types';
 import { useEntityStoreContext } from './entity-store-provider';
 
 export function useEntityStore() {
-  const { create, triples$, schemaTriples$, update, remove, hideSchema, hiddenSchemaIds$ } = useEntityStoreContext();
+  const { create, triples$, schemaTriples$, update, remove, hideSchema, hiddenSchemaIds$, linkedEntities$, name$ } =
+    useEntityStoreContext();
   const triples = useSelector(triples$);
   const schemaTriples = useSelector<Triple[]>(schemaTriples$);
   const hiddenSchemaIds = useSelector<string[]>(hiddenSchemaIds$);
+  const linkedEntities = useSelector(linkedEntities$);
+  const name = useSelector(name$);
 
   return {
+    name,
     triples,
+    linkedEntities,
     schemaTriples,
     create,
     update,

--- a/apps/web/modules/entity/entity-table-store/entity-table-store-provider.tsx
+++ b/apps/web/modules/entity/entity-table-store/entity-table-store-provider.tsx
@@ -11,20 +11,9 @@ const EntityTableStoreContext = createContext<EntityTableStore | undefined>(unde
 interface Props {
   space: string;
   children: React.ReactNode;
-  initialRows: Row[];
-  initialSelectedType: Triple | null;
-  initialColumns: Column[];
-  initialTypes: Triple[];
 }
 
-export function EntityTableStoreProvider({
-  space,
-  children,
-  initialRows,
-  initialSelectedType,
-  initialColumns,
-  initialTypes,
-}: Props) {
+export function EntityTableStoreProvider({ space, children }: Props) {
   const { network } = Services.useServices();
   const router = useRouter();
   const replace = useRef(router.replace);
@@ -38,12 +27,8 @@ export function EntityTableStoreProvider({
       api: network,
       space,
       initialParams,
-      initialRows,
-      initialSelectedType,
-      initialColumns,
-      initialTypes,
     });
-  }, [network, space, initialRows, initialSelectedType, initialColumns, initialTypes]);
+  }, [network, space]);
 
   const query = useSelector(store.query$);
   const pageNumber = useSelector(store.pageNumber$);

--- a/apps/web/modules/entity/entity-table-store/use-entity-tables.tsx
+++ b/apps/web/modules/entity/entity-table-store/use-entity-tables.tsx
@@ -18,7 +18,6 @@ export const useEntityTable = () => {
     hasPreviousPage$,
     hasNextPage$,
     filterState$,
-    hydrated$,
     selectedType$,
     columns$,
     types$,
@@ -28,7 +27,6 @@ export const useEntityTable = () => {
   const actions = useSelector(actions$);
   const columns = useSelector(columns$);
   const types = useSelector(types$);
-  const hydrated = useSelector(hydrated$);
   const selectedType = useSelector(selectedType$);
   const pageNumber = useSelector(pageNumber$);
   const hasPreviousPage = useSelector(hasPreviousPage$);
@@ -44,7 +42,6 @@ export const useEntityTable = () => {
     create,
     publish,
     query,
-    hydrated,
     selectedType,
     setQuery,
     setPageNumber,

--- a/apps/web/modules/triple/triple-store-provider.tsx
+++ b/apps/web/modules/triple/triple-store-provider.tsx
@@ -12,10 +12,9 @@ const TripleStoreContext = createContext<TripleStore | undefined>(undefined);
 interface Props {
   space: string;
   children: React.ReactNode;
-  initialTriples: Triple[];
 }
 
-export function TripleStoreProvider({ space, children, initialTriples }: Props) {
+export function TripleStoreProvider({ space, children }: Props) {
   const { network } = Services.useServices();
   const ActionsStore = useActionsStoreContext();
   const router = useRouter();
@@ -26,8 +25,8 @@ export function TripleStoreProvider({ space, children, initialTriples }: Props) 
 
   const store = useMemo(() => {
     const initialParams = Params.parseTripleQueryParameters(urlRef.current);
-    return new TripleStore({ api: network, space, initialParams, initialTriples, ActionsStore });
-  }, [network, space, initialTriples, ActionsStore]);
+    return new TripleStore({ api: network, space, initialParams, ActionsStore });
+  }, [network, space, ActionsStore]);
 
   const query = useSelector(store.query$);
   const pageNumber = useSelector(store.pageNumber$);

--- a/apps/web/modules/triple/triple-store.tsx
+++ b/apps/web/modules/triple/triple-store.tsx
@@ -9,7 +9,6 @@ import { makeOptionalComputed } from '../utils';
 interface ITripleStore {
   triples$: ObservableComputed<TripleType[]>;
   pageNumber$: Observable<number>;
-  hydrated$: Observable<boolean>;
   query$: ObservableComputed<string>;
   hasPreviousPage$: ObservableComputed<boolean>;
   hasNextPage$: ObservableComputed<boolean>;
@@ -29,7 +28,6 @@ interface ITripleStoreConfig {
   ActionsStore: ActionsStore;
   initialParams?: InitialTripleStoreParams;
   pageSize?: number;
-  initialTriples: TripleType[];
 }
 
 export const DEFAULT_PAGE_SIZE = 100;
@@ -55,7 +53,6 @@ export class TripleStore implements ITripleStore {
   query$: ObservableComputed<string>;
   filterState$: Observable<FilterState>;
   hasPreviousPage$: ObservableComputed<boolean>;
-  hydrated$: Observable<boolean> = observable(false);
   hasNextPage$: ObservableComputed<boolean>;
   space: string;
   ActionsStore: ActionsStore;
@@ -64,14 +61,12 @@ export class TripleStore implements ITripleStore {
   constructor({
     api,
     space,
-    initialTriples,
     ActionsStore,
     initialParams = DEFAULT_INITIAL_PARAMS,
     pageSize = DEFAULT_PAGE_SIZE,
   }: ITripleStoreConfig) {
     this.api = api;
     this.ActionsStore = ActionsStore;
-    this.triples$ = observable(initialTriples);
     this.pageNumber$ = observable(initialParams.pageNumber);
     this.filterState$ = observable<FilterState>(
       initialParams.filterState.length === 0 ? initialFilterState() : initialParams.filterState
@@ -98,7 +93,6 @@ export class TripleStore implements ITripleStore {
             abortController: this.abortController,
           });
 
-          this.hydrated$.set(true);
           return { triples: triples.slice(0, pageSize), hasNextPage: triples.length > pageSize };
         } catch (e) {
           if (e instanceof Error && e.name === 'AbortError') {

--- a/apps/web/modules/triple/use-triples.tsx
+++ b/apps/web/modules/triple/use-triples.tsx
@@ -14,7 +14,6 @@ export const useTriples = () => {
     hasPreviousPage$,
     hasNextPage$,
     filterState$,
-    hydrated$,
     setFilterState,
   } = useTripleStoreContext();
   const triples = useSelector(triples$);
@@ -22,7 +21,6 @@ export const useTriples = () => {
   const hasPreviousPage = useSelector(hasPreviousPage$);
   const hasNextPage = useSelector(hasNextPage$);
   const query = useSelector(query$);
-  const hydrated = useSelector(hydrated$);
   const filterState = useSelector<FilterState>(filterState$);
 
   return {
@@ -32,7 +30,6 @@ export const useTriples = () => {
     setPageNumber,
     setNextPage,
     setPreviousPage,
-    hydrated,
     pageNumber,
     hasPreviousPage,
     hasNextPage,

--- a/apps/web/pages/space/[id]/[entityId].tsx
+++ b/apps/web/pages/space/[id]/[entityId].tsx
@@ -1,40 +1,23 @@
 import { GetServerSideProps } from 'next';
+import Head from 'next/head';
 import { useEffect } from 'react';
 import { useLogRocket } from '~/modules/analytics/use-logrocket';
 import { useAccessControl } from '~/modules/auth/use-access-control';
 import { EditableEntityPage } from '~/modules/components/entity/editable-entity-page';
 import { ReadableEntityPage } from '~/modules/components/entity/readable-entity-page';
-import { LinkedEntityGroup } from '~/modules/components/entity/types';
-import { Entity, EntityStoreProvider } from '~/modules/entity';
-import { Params } from '~/modules/params';
-import { Network } from '~/modules/services/network';
-import { StorageClient } from '~/modules/services/storage';
+import { EntityStoreProvider } from '~/modules/entity';
 import { useEditable } from '~/modules/stores/use-editable';
 import { usePageName } from '~/modules/stores/use-page-name';
-import { DEFAULT_PAGE_SIZE } from '~/modules/triple';
-import { Triple } from '~/modules/types';
 
 interface Props {
-  triples: Triple[];
-  schemaTriples: Triple[];
   id: string;
-  name: string;
   space: string;
-  linkedEntities: Record<string, LinkedEntityGroup>;
 }
 
 export default function EntityPage(props: Props) {
-  const { setPageName } = usePageName();
   const { isEditor } = useAccessControl(props.space);
   const { editable } = useEditable();
   useLogRocket(props.space);
-
-  // This is a janky way to set the name in the navbar until we have nested layouts
-  // and the navbar can query the name itself in a nice way.
-  useEffect(() => {
-    if (props.name !== props.id) setPageName(props.name);
-    return () => setPageName('');
-  }, [props.name, props.id, setPageName]);
 
   const renderEditablePage = isEditor && editable;
   // const renderEditablePage = true;
@@ -50,59 +33,11 @@ export default function EntityPage(props: Props) {
 export const getServerSideProps: GetServerSideProps<Props> = async context => {
   const space = context.query.id as string;
   const entityId = context.query.entityId as string;
-  const config = Params.getConfigFromUrl(context.resolvedUrl, context.req.cookies[Params.ENV_PARAM_NAME]);
-  const storage = new StorageClient(config.ipfs);
-
-  const network = new Network(storage, config.subgraph);
-
-  const [entity, related] = await Promise.all([
-    network.fetchTriples({
-      space,
-      query: '',
-      skip: 0,
-      first: DEFAULT_PAGE_SIZE,
-      filter: [{ field: 'entity-id', value: entityId }],
-    }),
-
-    network.fetchTriples({
-      space,
-      query: '',
-      skip: 0,
-      first: DEFAULT_PAGE_SIZE,
-      filter: [{ field: 'linked-to', value: entityId }],
-    }),
-  ]);
-
-  const relatedEntities = await Promise.all(
-    related.triples.map(triple =>
-      network.fetchTriples({
-        space,
-        query: '',
-        skip: 0,
-        first: DEFAULT_PAGE_SIZE,
-        filter: [{ field: 'entity-id', value: triple.entityId }],
-      })
-    )
-  );
-
-  const linkedEntities: Record<string, LinkedEntityGroup> = relatedEntities
-    .flatMap(entity => entity.triples)
-    .reduce((acc, triple) => {
-      if (!acc[triple.entityId]) acc[triple.entityId] = { triples: [], name: null, id: triple.entityId };
-      acc[triple.entityId].id = triple.entityId;
-      acc[triple.entityId].name = triple.entityName;
-      acc[triple.entityId].triples = [...acc[triple.entityId].triples, triple]; // Duplicates?
-      return acc;
-    }, {} as Record<string, LinkedEntityGroup>);
 
   return {
     props: {
-      triples: entity.triples,
-      schemaTriples: [] /* Todo: Fetch schema triples for entity if entity has a type */,
       id: entityId,
-      name: Entity.name(entity.triples) ?? entityId,
       space,
-      linkedEntities,
       key: entityId,
     },
   };

--- a/apps/web/pages/space/[id]/[entityId].tsx
+++ b/apps/web/pages/space/[id]/[entityId].tsx
@@ -17,7 +17,6 @@ export default function EntityPage(props: Props) {
   useLogRocket(props.space);
 
   const renderEditablePage = isEditor && editable;
-  // const renderEditablePage = true;
   const Page = renderEditablePage ? EditableEntityPage : ReadableEntityPage;
 
   return (
@@ -35,7 +34,6 @@ export const getServerSideProps: GetServerSideProps<Props> = async context => {
     props: {
       id: entityId,
       space,
-      key: entityId,
     },
   };
 };

--- a/apps/web/pages/space/[id]/[entityId].tsx
+++ b/apps/web/pages/space/[id]/[entityId].tsx
@@ -1,13 +1,10 @@
 import { GetServerSideProps } from 'next';
-import Head from 'next/head';
-import { useEffect } from 'react';
 import { useLogRocket } from '~/modules/analytics/use-logrocket';
 import { useAccessControl } from '~/modules/auth/use-access-control';
 import { EditableEntityPage } from '~/modules/components/entity/editable-entity-page';
 import { ReadableEntityPage } from '~/modules/components/entity/readable-entity-page';
 import { EntityStoreProvider } from '~/modules/entity';
 import { useEditable } from '~/modules/stores/use-editable';
-import { usePageName } from '~/modules/stores/use-page-name';
 
 interface Props {
   id: string;

--- a/apps/web/pages/space/[id]/[entityId].tsx
+++ b/apps/web/pages/space/[id]/[entityId].tsx
@@ -41,12 +41,7 @@ export default function EntityPage(props: Props) {
   const Page = renderEditablePage ? EditableEntityPage : ReadableEntityPage;
 
   return (
-    <EntityStoreProvider
-      id={props.id}
-      spaceId={props.space}
-      initialTriples={props.triples}
-      initialSchemaTriples={props.schemaTriples}
-    >
+    <EntityStoreProvider id={props.id} spaceId={props.space}>
       <Page {...props} />
     </EntityStoreProvider>
   );

--- a/apps/web/pages/space/[id]/create-entity.tsx
+++ b/apps/web/pages/space/[id]/create-entity.tsx
@@ -12,8 +12,8 @@ export default function CreateEntity({ spaceId }: Props) {
   const newId = useMemo(() => ID.createEntityId(), []);
 
   return (
-    <EntityStoreProvider id={newId} spaceId={spaceId} initialTriples={[]} initialSchemaTriples={[]}>
-      <EditableEntityPage id={newId} name="" space={spaceId} triples={[]} schemaTriples={[]} />
+    <EntityStoreProvider id={newId} spaceId={spaceId}>
+      <EditableEntityPage id={newId} space={spaceId} />
     </EntityStoreProvider>
   );
 }

--- a/apps/web/pages/space/[id]/triples.tsx
+++ b/apps/web/pages/space/[id]/triples.tsx
@@ -16,10 +16,9 @@ interface Props {
   spaceId: string;
   spaceName?: string;
   spaceImage: string | null;
-  initialTriples: Triple[];
 }
 
-export default function TriplesPage({ spaceId, spaceName, spaceImage, initialTriples }: Props) {
+export default function TriplesPage({ spaceId, spaceName, spaceImage }: Props) {
   useLogRocket(spaceId);
   return (
     <div>
@@ -33,8 +32,8 @@ export default function TriplesPage({ spaceId, spaceName, spaceImage, initialTri
       <Spacer height={34} />
       <SpaceNavbar spaceId={spaceId} />
 
-      <TripleStoreProvider space={spaceId} initialTriples={initialTriples}>
-        <Triples spaceId={spaceId} initialTriples={initialTriples} />
+      <TripleStoreProvider space={spaceId}>
+        <Triples spaceId={spaceId} />
       </TripleStoreProvider>
     </div>
   );
@@ -52,20 +51,12 @@ export const getServerSideProps: GetServerSideProps<Props> = async context => {
   const spaceImage = space?.attributes[SYSTEM_IDS.IMAGE_ATTRIBUTE] ?? null;
   const spaceNames = Object.fromEntries(spaces.map(space => [space.id, space.attributes.name]));
   const spaceName = spaceNames[spaceId];
-  const triples = await network.fetchTriples({
-    query: initialParams.query,
-    space: spaceId,
-    first: DEFAULT_PAGE_SIZE,
-    skip: initialParams.pageNumber * DEFAULT_PAGE_SIZE,
-    filter: initialParams.filterState,
-  });
 
   return {
     props: {
       spaceId,
       spaceName,
       spaceImage,
-      initialTriples: triples.triples,
     },
   };
 };


### PR DESCRIPTION
This is an exploration on making the codebase simpler by removing store hydration from server data. This means we're doing all app data loading on the client side except for anything we need for SEO.