### PR TITLE
Default type for entities

### DIFF
--- a/apps/web/modules/services/network.ts
+++ b/apps/web/modules/services/network.ts
@@ -284,6 +284,7 @@ export class Network implements INetwork {
               id
             }
             entity {
+              id
               entityOf {
                 id
                 stringValue
@@ -306,6 +307,7 @@ export class Network implements INetwork {
           editors: Account[];
           editorControllers: Account[];
           entity?: {
+            id: string;
             entityOf: { id: string; stringValue: string; attribute: { id: string } }[];
           };
         }[];
@@ -327,6 +329,7 @@ export class Network implements INetwork {
         admins: space.admins.map(account => account.id),
         editorControllers: space.editorControllers.map(account => account.id),
         editors: space.editors.map(account => account.id),
+        entityId: space.entity?.id || '',
         attributes,
       };
     });

--- a/apps/web/modules/types.ts
+++ b/apps/web/modules/types.ts
@@ -46,6 +46,7 @@ export type Space = {
   editorControllers: string[];
   admins: string[];
   attributes: Dictionary<string, string>;
+  entityId: string;
 };
 
 export type Account = {

--- a/apps/web/pages/space/[id].tsx
+++ b/apps/web/pages/space/[id].tsx
@@ -1,16 +1,16 @@
+import { SYSTEM_IDS } from '@geogenesis/ids';
 import { GetServerSideProps } from 'next';
 import Head from 'next/head';
 import { useLogRocket } from '~/modules/analytics/use-logrocket';
 import { EntityTableContainer } from '~/modules/components/entity-table/entity-table-container';
 import { SpaceHeader } from '~/modules/components/space/space-header';
 import { SpaceNavbar } from '~/modules/components/space/space-navbar';
-import { SYSTEM_IDS } from '@geogenesis/ids';
 import { Spacer } from '~/modules/design-system/spacer';
+import { DEFAULT_PAGE_SIZE, EntityTableStoreProvider } from '~/modules/entity';
 import { Params } from '~/modules/params';
 import { INetwork, Network } from '~/modules/services/network';
 import { StorageClient } from '~/modules/services/storage';
 import { Column, Row, Triple } from '~/modules/types';
-import { DEFAULT_PAGE_SIZE, EntityTableStoreProvider } from '~/modules/entity';
 
 interface Props {
   spaceId: string;
@@ -75,9 +75,26 @@ export const getServerSideProps: GetServerSideProps<Props> = async context => {
   const spaceNames = Object.fromEntries(spaces.map(space => [space.id, space.attributes.name]));
   const spaceName = spaceNames[spaceId];
 
-  const initialTypes = (await fetchSpaceTypeTriples(network, spaceId)) || [];
+  const [initialTypes, defaultTypeTriples] = await Promise.all([
+    fetchSpaceTypeTriples(network, spaceId),
+    network.fetchTriples({
+      query: '',
+      skip: 0,
+      first: DEFAULT_PAGE_SIZE,
+      filter: [
+        { field: 'entity-id', value: space?.entityId ?? '' },
+        {
+          field: 'attribute-id',
+          value: SYSTEM_IDS.DEFAULT_TYPE,
+        },
+      ],
+    }),
+  ]);
 
-  const initialSelectedType = initialTypes.find(t => t.entityId === initialParams.typeId) || initialTypes[0] || null;
+  const defaultTypeId = defaultTypeTriples.triples[0]?.value.id;
+
+  const initialSelectedType =
+    initialTypes.find(t => t.entityId === (initialParams.typeId || defaultTypeId)) || initialTypes[0] || null;
 
   const typeId = initialSelectedType?.entityId;
 

--- a/packages/ids/system-ids.ts
+++ b/packages/ids/system-ids.ts
@@ -23,3 +23,6 @@ export const RELATION = '14611456-b466-4cab-920d-2245f59ce828'
 
 /* Example Usage: Address -> VALUE_TYPE -> TEXT */
 export const TEXT = '9edb6fcc-e454-4aa5-8611-39d7f024c010'
+
+/* Note that this is a temporary workaround for production MVP release. As such, this system ID isn't included in the bootstrap process.*/
+export const DEFAULT_TYPE = 'aeebbd5e-4d79-4d24-ae99-239e9142d9ed'


### PR DESCRIPTION
<img width="597" alt="Screen Shot 2023-01-18 at 7 01 03 PM" src="https://user-images.githubusercontent.com/2068463/213346537-8ea970dc-ede7-4496-9470-5e3eeb3623f0.png">

Works on reload too and other type selections. Not included in bootstrap file since this is a temp thing. Only works in prod. 