### PR TITLE
fix: cannot navigate to local entity from global search

### DIFF
--- a/apps/web/modules/entity/entity.test.ts
+++ b/apps/web/modules/entity/entity.test.ts
@@ -318,6 +318,7 @@ it('Entity.entitiesFromTriples should map Triples to Entity', () => {
       name: 'entity-1',
       description: 'banana description',
       types: [],
+      nameTripleSpace: 'spaceId',
       triples: [triplesFromMultipleEntities[0], triplesFromMultipleEntities[1]],
     },
     {
@@ -325,6 +326,7 @@ it('Entity.entitiesFromTriples should map Triples to Entity', () => {
       name: 'entity-2',
       description: 'apple description',
       types: [],
+      nameTripleSpace: 'spaceId',
       triples: [triplesFromMultipleEntities[2], triplesFromMultipleEntities[3]],
     },
   ];
@@ -370,6 +372,7 @@ it('Entity.mergeActionsWithNetworkEntities should merge local actions with entit
       name: 'entity-1-changed',
       description: 'banana description',
       types: [],
+      nameTripleSpace: 'spaceId',
       triples: [
         {
           type: 'createTriple',

--- a/apps/web/modules/entity/entity.ts
+++ b/apps/web/modules/entity/entity.ts
@@ -95,6 +95,7 @@ export function entitiesFromTriples(triples: TripleType[]): Entity[] {
         id: entityId,
         name: name(mutableTriples),
         description: description(mutableTriples),
+        nameTripleSpace: nameTriple(mutableTriples)?.space,
         types: types(mutableTriples, triples[0]?.space),
         triples: mutableTriples,
       };


### PR DESCRIPTION
This was due to us not adding the `nameTripleSpace` to local entities when mapping triples to entities.