### PR TITLE
feat: add additional toast step for signing tx during publish

### DIFF
--- a/apps/web/modules/components/flow-bar.tsx
+++ b/apps/web/modules/components/flow-bar.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import { useSigner } from 'wagmi';
 import { Signer } from 'ethers';
 import pluralize from 'pluralize';
-import { Button } from '../design-system/button';
+import { Button, SmallButton } from '../design-system/button';
 import { Trash } from '../design-system/icons/trash';
 import { Spacer } from '../design-system/spacer';
 import { Text } from '../design-system/text';
@@ -13,6 +13,7 @@ import { Action as ActionType, ReviewState } from '../types';
 import { Spinner } from '../design-system/spinner';
 import { groupBy } from '../utils';
 import { Action } from '../action';
+import { RetrySmall } from '../design-system/icons/retry-small';
 
 const Container = styled.div(props => ({
   display: 'flex',
@@ -46,7 +47,10 @@ export function FlowBar({ actions, onPublish, onClear, spaceId }: Props) {
   // deletes since that would double the change count.
   const showFlowBar = reviewState === 'idle';
   const showToast =
-    reviewState === 'publishing-ipfs' || reviewState === 'publishing-contract' || reviewState === 'publish-complete';
+    reviewState === 'publishing-ipfs' ||
+    reviewState === 'signing-wallet' ||
+    reviewState === 'publishing-contract' ||
+    reviewState === 'publish-complete';
 
   const actionsCount = Action.getChangeCount(actions);
 
@@ -89,7 +93,21 @@ export function FlowBar({ actions, onPublish, onClear, spaceId }: Props) {
                 </motion.span>
               )}
               <Spacer width={12} />
-              {reviewState === 'publishing-ipfs' && 'Uploading changes to IPFS'}
+              {reviewState === 'publishing-ipfs' && ' Uploading changes to IPFS'}
+              {reviewState === 'signing-wallet' && (
+                <div className="flex items-center justify-between gap-[6px]">
+                  Sign your transaction
+                  <button
+                    className="flex items-center bg-transparent border gap-[6px] border-white rounded p-1"
+                    onClick={publish}
+                  >
+                    <RetrySmall />
+                    <Text variant="smallButton" color="white">
+                      Re-prompt
+                    </Text>
+                  </button>
+                </div>
+              )}
               {reviewState === 'publishing-contract' && 'Adding your changes to the blockchain'}
               {reviewState === 'publish-complete' && 'Changes published!'}
             </Toast>

--- a/apps/web/modules/components/flow-bar.tsx
+++ b/apps/web/modules/components/flow-bar.tsx
@@ -128,10 +128,10 @@ export function FlowBar({ actions, onPublish, onClear, spaceId }: Props) {
 function ToastText({ children }: { children: React.ReactNode }) {
   return (
     <motion.span
-      initial={{ y: 15, opacity: 0 }}
+      initial={{ y: 20, opacity: 0 }}
       animate={{ y: 0, opacity: 1 }}
-      exit={{ y: -15, opacity: 0 }}
-      transition={{ duration: 0.2, ease: 'easeInOut' }}
+      exit={{ y: -20, opacity: 0 }}
+      transition={{ duration: 0.2, ease: 'easeInOut', opacity: { duration: 0.25 } }}
     >
       {children}
     </motion.span>

--- a/apps/web/modules/components/flow-bar.tsx
+++ b/apps/web/modules/components/flow-bar.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import { useSigner } from 'wagmi';
 import { Signer } from 'ethers';
 import pluralize from 'pluralize';
-import { Button, SmallButton } from '../design-system/button';
+import { Button } from '../design-system/button';
 import { Trash } from '../design-system/icons/trash';
 import { Spacer } from '../design-system/spacer';
 import { Text } from '../design-system/text';
@@ -66,7 +66,7 @@ export function FlowBar({ actions, onPublish, onClear, spaceId }: Props) {
   };
 
   return (
-    <AnimatePresence>
+    <AnimatePresence mode="wait">
       {/* We let the toast persist during the publish-complete state before it switches to idle state */}
       {actionsCount > 0 || reviewState === 'publish-complete' ? (
         <>
@@ -93,9 +93,14 @@ export function FlowBar({ actions, onPublish, onClear, spaceId }: Props) {
                 </motion.span>
               )}
               <Spacer width={12} />
-              {reviewState === 'publishing-ipfs' && ' Uploading changes to IPFS'}
+              {reviewState === 'publishing-ipfs' && <ToastText>Uploading changes to IPFS</ToastText>}
               {reviewState === 'signing-wallet' && (
-                <div className="flex items-center justify-between gap-[6px]">
+                <motion.div
+                  initial={{ y: 15, opacity: 0 }}
+                  animate={{ y: 0, opacity: 1 }}
+                  exit={{ y: -15, opacity: 0 }}
+                  className="flex items-center justify-between gap-[6px]"
+                >
                   Sign your transaction
                   <button
                     className="flex items-center bg-transparent border gap-[6px] border-white rounded p-1"
@@ -106,15 +111,23 @@ export function FlowBar({ actions, onPublish, onClear, spaceId }: Props) {
                       Re-prompt
                     </Text>
                   </button>
-                </div>
+                </motion.div>
               )}
-              {reviewState === 'publishing-contract' && 'Adding your changes to the blockchain'}
-              {reviewState === 'publish-complete' && 'Changes published!'}
+              {reviewState === 'publishing-contract' && <ToastText>Adding your changes to the blockchain</ToastText>}
+              {reviewState === 'publish-complete' && <ToastText>Changes published!</ToastText>}
             </Toast>
           )}
         </>
       ) : null}
     </AnimatePresence>
+  );
+}
+
+function ToastText({ children }: { children: React.ReactNode }) {
+  return (
+    <motion.span initial={{ y: 15, opacity: 0 }} animate={{ y: 0, opacity: 1 }} exit={{ y: -15, opacity: 0 }}>
+      {children}
+    </motion.span>
   );
 }
 

--- a/apps/web/modules/components/flow-bar.tsx
+++ b/apps/web/modules/components/flow-bar.tsx
@@ -127,7 +127,12 @@ export function FlowBar({ actions, onPublish, onClear, spaceId }: Props) {
 
 function ToastText({ children }: { children: React.ReactNode }) {
   return (
-    <motion.span initial={{ y: 15, opacity: 0 }} animate={{ y: 0, opacity: 1 }} exit={{ y: -15, opacity: 0 }}>
+    <motion.span
+      initial={{ y: 15, opacity: 0 }}
+      animate={{ y: 0, opacity: 1 }}
+      exit={{ y: -15, opacity: 0 }}
+      transition={{ duration: 0.2, ease: 'easeInOut' }}
+    >
       {children}
     </motion.span>
   );

--- a/apps/web/modules/components/flow-bar.tsx
+++ b/apps/web/modules/components/flow-bar.tsx
@@ -102,7 +102,9 @@ export function FlowBar({ actions, onPublish, onClear, spaceId }: Props) {
                   className="flex items-center justify-between gap-[6px]"
                 >
                   Sign your transaction
-                  <button
+                  <motion.button
+                    whileHover={{ scale: 1.02 }}
+                    whileTap={{ scale: 0.98 }}
                     className="flex items-center bg-transparent border gap-[6px] border-white rounded p-1"
                     onClick={publish}
                   >
@@ -110,7 +112,7 @@ export function FlowBar({ actions, onPublish, onClear, spaceId }: Props) {
                     <Text variant="smallButton" color="white">
                       Re-prompt
                     </Text>
-                  </button>
+                  </motion.button>
                 </motion.div>
               )}
               {reviewState === 'publishing-contract' && <ToastText>Adding your changes to the blockchain</ToastText>}

--- a/apps/web/modules/design-system/icons/retry-small.tsx
+++ b/apps/web/modules/design-system/icons/retry-small.tsx
@@ -1,0 +1,21 @@
+import { useTheme } from '@emotion/react';
+import { ColorName } from '../theme/colors';
+
+interface Props {
+  color?: ColorName;
+}
+
+export function RetrySmall({ color }: Props) {
+  const theme = useTheme();
+  const themeColor = color ? theme.colors[color] : 'currentColor';
+
+  return (
+    <svg width="13" height="12" viewBox="0 0 13 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M10.8242 6.1875C10.8242 3.59867 8.72555 1.5 6.13672 1.5C3.54788 1.5 1.44922 3.59867 1.44922 6.1875C1.44922 8.77633 3.54788 10.875 6.13672 10.875C7.21136 10.875 8.20154 10.5134 8.9922 9.90517"
+        stroke={themeColor}
+      />
+      <path d="M12.3242 5.1001L10.8242 6.6001L9.32422 5.1001" stroke={themeColor} />
+    </svg>
+  );
+}

--- a/apps/web/modules/types.ts
+++ b/apps/web/modules/types.ts
@@ -53,7 +53,13 @@ export type Account = {
   id: string;
 };
 
-export type ReviewState = 'idle' | 'reviewing' | 'publishing-ipfs' | 'publishing-contract' | 'publish-complete';
+export type ReviewState =
+  | 'idle'
+  | 'reviewing'
+  | 'publishing-ipfs'
+  | 'signing-wallet'
+  | 'publishing-contract'
+  | 'publish-complete';
 
 export type FilterField = 'entity-id' | 'entity-name' | 'attribute-id' | 'attribute-name' | 'value' | 'linked-to';
 


### PR DESCRIPTION
Previously there was no step in the publish toast telling the user to sign the outgoing publish transaction in their wallet. Additionally, sometimes the notification for signing the notification would never appear in the wallet, leaving users in a purgatory state where they couldn't sign the transaction and couldn't retry without refreshing the page and losing their work.

This feature handles now enables users to retry the transaction prompt. In the future we will investigate the root cause for missing tx notification and also store user changes in persistent storage.