### PR TITLE
feat: conditional user presence

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1,3 +1,5 @@
+### Getting started
+
 ```sh
 # Run dev
 pnpm dev
@@ -8,4 +10,13 @@ pnpm build
 # Run production version of web app
 pnpm build
 pnpm start
+```
+
+### Environment variables
+
+The frontend relies on [Liveblocks](https://liveblocks.io) for a frontend-specific feature that shows which users are currently editing a given entity. To use this feature you need to have a Liveblocks API key configured and in your `.env.local` file picked up by Next.js.
+
+```bash
+# .env.local
+NEXT_PUBLIC_LIVEBLOCKS_PUBLIC_KEY=
 ```

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -14,7 +14,7 @@ pnpm start
 
 ### Environment variables
 
-The frontend relies on [Liveblocks](https://liveblocks.io) for a frontend-specific feature that shows which users are currently editing a given entity. To use this feature you need to have a Liveblocks API key configured and in your `.env.local` file picked up by Next.js.
+The frontend relies on [Liveblocks](https://liveblocks.io) for a frontend-specific feature that shows which users are currently editing a given entity. To use this feature you need to have a Liveblocks API key configured and in your `.env.local` file.
 
 ```bash
 # .env.local

--- a/apps/web/modules/action/action.ts
+++ b/apps/web/modules/action/action.ts
@@ -1,5 +1,17 @@
 import { Action, Action as ActionType } from '~/modules/types';
 
+export function forEntityId(actions: ActionType[], entityId: string) {
+  return actions.filter(a => {
+    switch (a.type) {
+      case 'createTriple':
+      case 'deleteTriple':
+        return a.entityId === entityId;
+      case 'editTriple':
+        return a.before.entityId === entityId || a.after.entityId === entityId;
+    }
+  });
+}
+
 // For each id we find, we need to traverse the list to find the first and last actions associated with that id
 // Then we need to check the first and last actions and compare to see if they've changed.
 export function getChangeCount(actions: ActionType[]) {

--- a/apps/web/modules/components/entity-table/entity-table-container.tsx
+++ b/apps/web/modules/components/entity-table/entity-table-container.tsx
@@ -84,7 +84,7 @@ export function EntityTableContainer({ spaceId, initialColumns, initialRows }: P
         </PageNumberContainer>
       </PageContainer>
       {isEditor && editable && (
-        <EntityPresenceProvider entityId={entityTableStore.selectedType?.entityId ?? ''}>
+        <EntityPresenceProvider entityId={entityTableStore.selectedType?.entityId ?? ''} spaceId={spaceId}>
           <EntityOthersToast />
         </EntityPresenceProvider>
       )}

--- a/apps/web/modules/components/entity/editable-entity-page.tsx
+++ b/apps/web/modules/components/entity/editable-entity-page.tsx
@@ -199,7 +199,7 @@ export function EditableEntityPage({
           </Content>
         </EntityContainer>
       </PageContainer>
-      <EntityPresenceProvider entityId={id}>
+      <EntityPresenceProvider entityId={id} spaceId={space}>
         <EntityOthersToast />
       </EntityPresenceProvider>
     </>

--- a/apps/web/modules/components/entity/presence/entity-others-toast.tsx
+++ b/apps/web/modules/components/entity/presence/entity-others-toast.tsx
@@ -25,18 +25,27 @@ export function EntityOthersToast() {
   const editors = [
     ...others,
     {
+      // Set Other properties to me's address. We can use this later to
+      // differentiate between the active tab me and others in the editor list.
       id: me.address,
       connectionId: me.address,
       presence: {
         address: me.address,
+        hasChangesToEntity: me.hasChangesToEntity,
       },
     },
-  ];
+  ]
+    .filter(e => e.presence.hasChangesToEntity)
+    // Filter out myself if I am the only editor and I'm in the current tab being edited
+    .filter((e, _, filteredEditors) => {
+      if (filteredEditors.length === 1 && e.connectionId === account.address) return false;
+      return true;
+    });
 
   // We only show the first 3 avatars in the avatar group
   const editorsAvatars = editors.slice(0, 3);
-  const shouldShow = others.length > 0;
   const editorsCount = editors.length;
+  const shouldShow = editorsCount > 0;
 
   return (
     <AnimatePresence>

--- a/apps/web/modules/components/entity/presence/entity-others-toast.tsx
+++ b/apps/web/modules/components/entity/presence/entity-others-toast.tsx
@@ -9,22 +9,34 @@ import { Spacer } from '~/modules/design-system/spacer';
 import { ChevronDownSmall } from '~/modules/design-system/icons/chevron-down-small';
 import { AnimatePresence, motion } from 'framer-motion';
 import { ResizableContainer } from '~/modules/design-system/resizable-container';
+import { useAccount } from 'wagmi';
 
 function shortAddress(address: string) {
   return `${address.slice(0, 6)}...${address.slice(-6)}`;
 }
 
 export function EntityOthersToast() {
+  const account = useAccount();
   const [isExpanded, setIsExpanded] = useState(false);
   const others = EntityPresenceContext.useOthers();
   const [me] = EntityPresenceContext.useMyPresence();
 
-  // We only show the first 3 avatars in the avatar group
-  const editorsAvatars = others.slice(0, 3);
-  const shouldShow = others.length > 0;
+  // Include me in the list of editors
+  const editors = [
+    ...others,
+    {
+      id: me.address,
+      connectionId: me.address,
+      presence: {
+        address: me.address,
+      },
+    },
+  ];
 
-  // We include the active user in the count
-  const editorsCount = others.length + 1;
+  // We only show the first 3 avatars in the avatar group
+  const editorsAvatars = editors.slice(0, 3);
+  const shouldShow = others.length > 0;
+  const editorsCount = editors.length;
 
   return (
     <AnimatePresence>
@@ -38,9 +50,9 @@ export function EntityOthersToast() {
         >
           <div className="flex items-center gap-2">
             <ul className="flex items-center -space-x-1">
-              {editorsAvatars.map((other, i) => (
-                <li key={other.id} className={clsx({ 'rounded-full border border-white': i !== 0 })}>
-                  <BoringAvatar size={16} name={other.presence.address} variant="pixel" />
+              {editorsAvatars.map((editor, i) => (
+                <li key={editor.id} className={clsx({ 'rounded-full border border-white': i !== 0 })}>
+                  <BoringAvatar size={16} name={editor.presence.address} variant="pixel" />
                 </li>
               ))}
             </ul>
@@ -56,25 +68,21 @@ export function EntityOthersToast() {
             {isExpanded ? (
               <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}>
                 <ul key="presence-user-list" className="space-y-3 mb-2 overflow-hidden">
-                  {others.map(other => (
-                    <li key={other.connectionId} className="flex items-center gap-2">
-                      <BoringAvatar size={16} name={other.presence.address} variant="pixel" />
-                      <Text variant="metadata" color="grey-04">
-                        {shortAddress(other.presence.address ?? '')}
-                      </Text>
+                  {editors.map(editor => (
+                    <li key={editor.connectionId} className="flex items-center justify-between">
+                      <div className="flex items-center gap-2">
+                        <BoringAvatar size={16} name={me.address} variant="pixel" />
+                        <Text variant="metadata" color="grey-04">
+                          {shortAddress(editor.presence.address ?? '')}
+                        </Text>
+                      </div>
+                      {editor.presence.address === account?.address && (
+                        <Text className="rounded bg-grey-02 px-1" color="grey-04" variant="footnoteMedium">
+                          You
+                        </Text>
+                      )}
                     </li>
                   ))}
-                  <li className="flex items-center justify-between">
-                    <div className="flex items-center gap-2">
-                      <BoringAvatar size={16} name={me.address} variant="pixel" />
-                      <Text variant="metadata" color="grey-04">
-                        {shortAddress(me.address ?? '')}
-                      </Text>
-                    </div>
-                    <Text className="rounded bg-grey-02 px-1" color="grey-04" variant="footnoteMedium">
-                      You
-                    </Text>
-                  </li>
                 </ul>
                 <Spacer height={4} />
               </motion.div>


### PR DESCRIPTION
Previously we were showing all users who were in edit mode on an editable entity.

Now we only show users who have made changes to this entity and are currently viewing the entity. Also, if you are the only connected tab who had made changes to an entity we will not show the toast