### PR TITLE
fix: triples array on cell may be empty, resulting in runtime error

### DIFF
--- a/apps/web/modules/components/entity-table/entity-table-cell.tsx
+++ b/apps/web/modules/components/entity-table/entity-table-cell.tsx
@@ -16,14 +16,14 @@ export const EntityTableCell = ({ cell, triples, space, isExpanded }: Props) => 
   const isNameCell = cell.columnId === SYSTEM_IDS.NAME;
 
   if (isNameCell) {
-    const entityId = cell.triples[0].entityId;
+    const entityId = cell.entityId;
     const value = Entity.name(cell.triples) ?? entityId;
 
     return (
       <CellContent
         key={value}
         isEntity
-        href={NavUtils.toEntity(space, entityId)}
+        href={NavUtils.toEntity(space, cell.entityId)}
         isExpanded={isExpanded}
         value={value}
       />

--- a/apps/web/modules/components/entity-table/entity-table-cell.tsx
+++ b/apps/web/modules/components/entity-table/entity-table-cell.tsx
@@ -23,7 +23,7 @@ export const EntityTableCell = ({ cell, triples, space, isExpanded }: Props) => 
       <CellContent
         key={value}
         isEntity
-        href={NavUtils.toEntity(space, cell.entityId)}
+        href={NavUtils.toEntity(space, entityId)}
         isExpanded={isExpanded}
         value={value}
       />


### PR DESCRIPTION
We should be fixing this at compile-time with the `noUncheckedIndexedAccess` flag in TypeScript, but right now the DX for that flag is terrible since it does not correctly narrow the type after you check it.