### PR TITLE
feat: merge profile with versions on the server when fetching proposed versions

### DIFF
--- a/apps/web/modules/avatar.tsx
+++ b/apps/web/modules/avatar.tsx
@@ -1,9 +1,16 @@
 import BoringAvatar from 'boring-avatars';
+import Image from 'next/image';
 
-export const Avatar = ({ value, size = '100%' }: { value: string; size?: number | string }) => {
-  return (
-    <div className="inline-block rounded border-4">
-      <BoringAvatar size={size} square={true} name={value} variant="pixel" />
-    </div>
+interface Props {
+  avatarUrl?: string | null;
+  value?: string;
+  alt?: string;
+}
+
+export const Avatar = ({ value, avatarUrl, alt }: Props) => {
+  return avatarUrl ? (
+    <Image objectFit="cover" layout="fill" src={avatarUrl} alt={alt} />
+  ) : (
+    <BoringAvatar size={12} square={true} variant="pixel" name={value} />
   );
 };

--- a/apps/web/modules/components/entity-page/entity-page-metadata-header.tsx
+++ b/apps/web/modules/components/entity-page/entity-page-metadata-header.tsx
@@ -34,7 +34,9 @@ export function EntityPageMetadataHeader({ versions }: Props) {
     month: 'short',
   });
 
-  // We restrict how many versions we render in the history panel
+  // We restrict how many versions we render in the history panel. We don't
+  // restrict on the subgraph since it would result in an inaccurate contributor
+  // count since we would only have queried the most recent 10 versions.
   const mostRecentVersions = A.take(versions, 10);
 
   return (

--- a/apps/web/modules/components/entity-page/entity-page-metadata-header.tsx
+++ b/apps/web/modules/components/entity-page/entity-page-metadata-header.tsx
@@ -1,12 +1,10 @@
-import BoringAvatar from 'boring-avatars';
-import clsx from 'classnames';
 import { Version } from '~/modules/types';
 import { HistoryItem, HistoryPanel } from '../history';
 import { AvatarGroup } from '~/modules/design-system/avatar-group';
 import { A, pipe } from '@mobily/ts-belt';
 import pluralize from 'pluralize';
 import { GeoDate } from '~/modules/utils';
-import Image from 'next/image';
+import { Avatar } from '~/modules/avatar';
 
 interface Props {
   versions: Array<Version>;
@@ -47,16 +45,11 @@ export function EntityPageMetadataHeader({ versions }: Props) {
             <AvatarGroup>
               {lastThreeContributors.map((contributor, i) => (
                 <AvatarGroup.Item>
-                  {contributor.avatarUrl ? (
-                    <Image
-                      objectFit="cover"
-                      layout="fill"
-                      src={contributor.avatarUrl}
-                      alt={`Avatar for ${contributor.name ?? contributor.id}`}
-                    />
-                  ) : (
-                    <BoringAvatar size={12} square={true} variant="pixel" name={contributor.name ?? contributor.id} />
-                  )}
+                  <Avatar
+                    alt={`Avatar for ${contributor.name ?? contributor.id}`}
+                    avatarUrl={contributor.avatarUrl}
+                    value={contributor.name ?? contributor.id}
+                  />
                 </AvatarGroup.Item>
               ))}
             </AvatarGroup>

--- a/apps/web/modules/components/entity-page/entity-page-metadata-header.tsx
+++ b/apps/web/modules/components/entity-page/entity-page-metadata-header.tsx
@@ -21,8 +21,9 @@ export function EntityPageMetadataHeader({ versions }: Props) {
     A.flatMap(version => version.createdBy)
   );
 
-  // We only render the first three avatars in the avatar group
-  const firstThreeContributors = A.take(contributors, 3);
+  // We only render the most recent three avatars in the avatar group and
+  // render them in reverse order
+  const lastThreeContributors = A.take(contributors, 3).reverse();
   const latestVersion = A.head(versions);
 
   // This will default to the beginning of UNIX time if there are no versions
@@ -39,8 +40,8 @@ export function EntityPageMetadataHeader({ versions }: Props) {
         <div className="flex items-center justify-between text-text">
           <div className="flex items-center justify-between gap-2 text-breadcrumb text-text">
             <AvatarGroup>
-              {firstThreeContributors.map((contributor, i) => (
-                <AvatarGroup.Item first={i === 0} key={i}>
+              {lastThreeContributors.map((contributor, i) => (
+                <AvatarGroup.Item>
                   {contributor.avatarUrl ? (
                     <Image
                       objectFit="cover"

--- a/apps/web/modules/components/entity-page/entity-page-metadata-header.tsx
+++ b/apps/web/modules/components/entity-page/entity-page-metadata-header.tsx
@@ -1,10 +1,12 @@
+import BoringAvatar from 'boring-avatars';
+import clsx from 'classnames';
 import { Version } from '~/modules/types';
 import { HistoryItem, HistoryPanel } from '../history';
 import { AvatarGroup } from '~/modules/design-system/avatar-group';
 import { A, pipe } from '@mobily/ts-belt';
 import pluralize from 'pluralize';
-import { EntityPageTypeChip } from './entity-page-type-chip';
 import { GeoDate } from '~/modules/utils';
+import Image from 'next/image';
 
 interface Props {
   versions: Array<Version>;
@@ -16,7 +18,7 @@ export function EntityPageMetadataHeader({ versions }: Props) {
   const contributors = pipe(
     versions,
     A.uniqBy(v => v.createdBy.id),
-    A.flatMap(version => version.createdBy.name ?? version.createdBy.id)
+    A.flatMap(version => version.createdBy)
   );
 
   // We only render the first three avatars in the avatar group
@@ -36,7 +38,22 @@ export function EntityPageMetadataHeader({ versions }: Props) {
       {contributors.length > 0 && (
         <div className="flex items-center justify-between text-text">
           <div className="flex items-center justify-between gap-2 text-breadcrumb text-text">
-            <AvatarGroup usernames={firstThreeContributors} />
+            <AvatarGroup>
+              {firstThreeContributors.map((contributor, i) => (
+                <AvatarGroup.Item first={i === 0} key={i}>
+                  {contributor.avatarUrl ? (
+                    <Image
+                      objectFit="cover"
+                      layout="fill"
+                      src={contributor.avatarUrl}
+                      alt={`Avatar for ${contributor.name ?? contributor.id}`}
+                    />
+                  ) : (
+                    <BoringAvatar size={12} square={true} variant="pixel" name={contributor.name ?? contributor.id} />
+                  )}
+                </AvatarGroup.Item>
+              ))}
+            </AvatarGroup>
             <p className="text-text">
               {contributors.length} {pluralize('Editor', contributors.length)}
             </p>

--- a/apps/web/modules/components/entity-page/entity-page-metadata-header.tsx
+++ b/apps/web/modules/components/entity-page/entity-page-metadata-header.tsx
@@ -34,6 +34,9 @@ export function EntityPageMetadataHeader({ versions }: Props) {
     month: 'short',
   });
 
+  // We restrict how many versions we render in the history panel
+  const mostRecentVersions = A.take(versions, 10);
+
   return (
     <div>
       {contributors.length > 0 && (
@@ -62,7 +65,7 @@ export function EntityPageMetadataHeader({ versions }: Props) {
           </div>
 
           <HistoryPanel>
-            {versions.map(version => (
+            {mostRecentVersions.map(version => (
               <HistoryItem key={version.id} version={version} />
             ))}
           </HistoryPanel>

--- a/apps/web/modules/components/entity/presence/entity-others-toast.tsx
+++ b/apps/web/modules/components/entity/presence/entity-others-toast.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { useState } from 'react';
-import clsx from 'classnames';
 import BoringAvatar from 'boring-avatars';
 import pluralize from 'pluralize';
 import { useAccount } from 'wagmi';
@@ -14,6 +13,7 @@ import { ChevronDownSmall } from '~/modules/design-system/icons/chevron-down-sma
 import { ResizableContainer } from '~/modules/design-system/resizable-container';
 import { AvatarGroup } from '~/modules/design-system/avatar-group';
 
+// Formatting for this truncated address differs from the one in utils
 function shortAddress(address: string) {
   return `${address.slice(0, 6)}...${address.slice(-6)}`;
 }
@@ -24,6 +24,7 @@ export function EntityOthersToast() {
   const others = EntityPresenceContext.useOthers();
   const [me] = EntityPresenceContext.useMyPresence();
 
+  // @TODO: Fetch all user profiles on the client
   // Include me in the list of editors
   const editors = [
     ...others,
@@ -61,7 +62,13 @@ export function EntityOthersToast() {
           className="fixed right-8 bottom-8 w-60 rounded border border-grey-02 bg-white p-3 shadow-lg"
         >
           <div className="flex items-center gap-2">
-            <AvatarGroup usernames={editorsAvatars.map(e => e.presence.address ?? '')} />
+            <AvatarGroup>
+              {editorsAvatars.map((e, i) => (
+                <AvatarGroup.Item key={e.id} first={i === 0}>
+                  <BoringAvatar size={12} variant="pixel" name={e.presence.address ?? ''} />
+                </AvatarGroup.Item>
+              ))}
+            </AvatarGroup>
             <Text variant="metadataMedium">
               {editorsCount >= 3 ? '3+' : editorsCount} {pluralize('user', editorsCount)}{' '}
               {editorsCount > 1 ? 'are' : 'is'} editing now

--- a/apps/web/modules/components/entity/presence/entity-others-toast.tsx
+++ b/apps/web/modules/components/entity/presence/entity-others-toast.tsx
@@ -64,7 +64,7 @@ export function EntityOthersToast() {
           <div className="flex items-center gap-2">
             <AvatarGroup>
               {editorsAvatars.map((e, i) => (
-                <AvatarGroup.Item key={e.id} first={i === 0}>
+                <AvatarGroup.Item key={e.id}>
                   <BoringAvatar size={12} variant="pixel" name={e.presence.address ?? ''} />
                 </AvatarGroup.Item>
               ))}

--- a/apps/web/modules/components/history/history-item.tsx
+++ b/apps/web/modules/components/history/history-item.tsx
@@ -1,3 +1,4 @@
+import Image from 'next/image';
 import Avatar from 'boring-avatars';
 import pluralize from 'pluralize';
 import { Action } from '~/modules/action';
@@ -46,8 +47,17 @@ export function HistoryItem({ version }: Props) {
       </div>
       <div className="flex items-center justify-between ">
         <div className="flex items-center justify-between gap-1">
-          <div className="overflow-hidden rounded-xs">
-            <Avatar size={12} square={true} variant="pixel" name={version.createdBy.id} />
+          <div className="relative h-3 w-3 overflow-hidden rounded-full">
+            {version.createdBy.avatarUrl ? (
+              <Image
+                objectFit="cover"
+                layout="fill"
+                src={version.createdBy.avatarUrl}
+                alt={`Avatar for ${version.createdBy.name ?? version.createdBy.id}`}
+              />
+            ) : (
+              <Avatar size={12} square={true} variant="pixel" name={version.createdBy.id} />
+            )}
           </div>
           <p className="text-smallButton">{version.createdBy.name ?? formatShortAddress(version.createdBy.id)}</p>
         </div>

--- a/apps/web/modules/components/history/history-item.tsx
+++ b/apps/web/modules/components/history/history-item.tsx
@@ -1,5 +1,5 @@
 import Image from 'next/image';
-import Avatar from 'boring-avatars';
+import BoringAvatar from 'boring-avatars';
 import pluralize from 'pluralize';
 import { Action } from '~/modules/action';
 import { Text } from '~/modules/design-system/text';
@@ -56,7 +56,7 @@ export function HistoryItem({ version }: Props) {
                 alt={`Avatar for ${version.createdBy.name ?? version.createdBy.id}`}
               />
             ) : (
-              <Avatar size={12} square={true} variant="pixel" name={version.createdBy.id} />
+              <BoringAvatar size={12} square={true} variant="pixel" name={version.createdBy.id} />
             )}
           </div>
           <p className="text-smallButton">{version.createdBy.name ?? formatShortAddress(version.createdBy.id)}</p>

--- a/apps/web/modules/components/history/history-item.tsx
+++ b/apps/web/modules/components/history/history-item.tsx
@@ -1,10 +1,9 @@
-import Image from 'next/image';
-import BoringAvatar from 'boring-avatars';
 import pluralize from 'pluralize';
 import { Action } from '~/modules/action';
 import { Text } from '~/modules/design-system/text';
 import { Version } from '~/modules/types';
 import { formatShortAddress, GeoDate } from '~/modules/utils';
+import { Avatar } from '~/modules/avatar';
 
 interface Props {
   version: Version;
@@ -48,16 +47,11 @@ export function HistoryItem({ version }: Props) {
       <div className="flex items-center justify-between ">
         <div className="flex items-center justify-between gap-1">
           <div className="relative h-3 w-3 overflow-hidden rounded-full">
-            {version.createdBy.avatarUrl ? (
-              <Image
-                objectFit="cover"
-                layout="fill"
-                src={version.createdBy.avatarUrl}
-                alt={`Avatar for ${version.createdBy.name ?? version.createdBy.id}`}
-              />
-            ) : (
-              <BoringAvatar size={12} square={true} variant="pixel" name={version.createdBy.id} />
-            )}
+            <Avatar
+              alt={`Avatar for ${version.createdBy.name ?? version.createdBy.id}`}
+              avatarUrl={version.createdBy.avatarUrl}
+              value={version.createdBy.name ?? version.createdBy.id}
+            />
           </div>
           <p className="text-smallButton">{version.createdBy.name ?? formatShortAddress(version.createdBy.id)}</p>
         </div>

--- a/apps/web/modules/design-system/avatar-group.tsx
+++ b/apps/web/modules/design-system/avatar-group.tsx
@@ -1,18 +1,21 @@
-import BoringAvatar from 'boring-avatars';
 import clsx from 'classnames';
 
 interface Props {
-  usernames: string[];
+  children: React.ReactNode;
 }
 
-export function AvatarGroup({ usernames }: Props) {
+export function AvatarGroup({ children }: Props) {
+  return <ul className="flex items-center -space-x-2">{children}</ul>;
+}
+
+function AvatarGroupItem({ children, first }: Props & { first?: boolean }) {
   return (
-    <ul className="flex items-center -space-x-2">
-      {usernames.map((username, i) => (
-        <li key={username} className={clsx({ 'rounded-full border border-white': i !== 0 })}>
-          <BoringAvatar size={16} name={username} variant="pixel" />
-        </li>
-      ))}
-    </ul>
+    <li
+      className={clsx('relative box-content h-3 w-3 overflow-hidden rounded-full', { 'border border-white': !first })}
+    >
+      {children}
+    </li>
   );
 }
+
+AvatarGroup.Item = AvatarGroupItem;

--- a/apps/web/modules/design-system/avatar-group.tsx
+++ b/apps/web/modules/design-system/avatar-group.tsx
@@ -8,11 +8,9 @@ export function AvatarGroup({ children }: Props) {
   return <ul className="flex items-center -space-x-2">{children}</ul>;
 }
 
-function AvatarGroupItem({ children, first }: Props & { first?: boolean }) {
+function AvatarGroupItem({ children, first }: Props) {
   return (
-    <li
-      className={clsx('relative box-content h-3 w-3 overflow-hidden rounded-full', { 'border border-white': !first })}
-    >
+    <li className={clsx('relative box-content h-3 w-3 overflow-hidden rounded-full border border-white')}>
       {children}
     </li>
   );

--- a/apps/web/modules/design-system/avatar-group.tsx
+++ b/apps/web/modules/design-system/avatar-group.tsx
@@ -1,5 +1,3 @@
-import clsx from 'classnames';
-
 interface Props {
   children: React.ReactNode;
 }
@@ -8,12 +6,8 @@ export function AvatarGroup({ children }: Props) {
   return <ul className="flex items-center -space-x-2">{children}</ul>;
 }
 
-function AvatarGroupItem({ children, first }: Props) {
-  return (
-    <li className={clsx('relative box-content h-3 w-3 overflow-hidden rounded-full border border-white')}>
-      {children}
-    </li>
-  );
+function AvatarGroupItem({ children }: Props) {
+  return <li className="relative box-content h-3 w-3 overflow-hidden rounded-full border border-white">{children}</li>;
 }
 
 AvatarGroup.Item = AvatarGroupItem;

--- a/apps/web/modules/entity/entity.ts
+++ b/apps/web/modules/entity/entity.ts
@@ -42,8 +42,6 @@ export function types(triples: TripleType[], currentSpace?: string): { id: strin
   const typeTriples = triples.filter(triple => triple.attributeId === SYSTEM_IDS.TYPES);
   const groupedTypeTriples = groupBy(typeTriples, t => t.attributeId);
 
-  console.log('groupedTypeTriples', groupedTypeTriples);
-
   return Object.entries(groupedTypeTriples)
     .flatMap(([, triples]) => {
       if (triples.length === 1) {

--- a/apps/web/modules/onboarding/dialog.tsx
+++ b/apps/web/modules/onboarding/dialog.tsx
@@ -1,5 +1,6 @@
 import { observer } from '@legendapp/state/react';
 import { Command } from 'cmdk';
+import BoringAvatar from 'boring-avatars';
 import { AnimatePresence, motion } from 'framer-motion';
 import Confetti from 'js-confetti';
 import * as React from 'react';
@@ -7,7 +8,6 @@ import { ChangeEvent, useEffect, useRef, useState } from 'react';
 import { useAccount } from 'wagmi';
 
 import { GeoLogoLarge } from '~/modules/design-system/icons/geo-logo-large';
-import { Avatar } from '../avatar';
 import { Button, SquareButton } from '../design-system/button';
 import { Text } from '../design-system/text';
 import { Services } from '../services';
@@ -224,7 +224,7 @@ function StepAvatar({ onNext, name, avatar, setAvatar, address }: StepAvatarProp
               }}
             />
           ) : (
-            <Avatar size={154} value={address} />
+            <BoringAvatar size={154} name={address} variant="pixel" />
           )}
         </div>
         <div className="flex justify-center">

--- a/apps/web/modules/services/io/queries.ts
+++ b/apps/web/modules/services/io/queries.ts
@@ -1,5 +1,5 @@
 export const proposedVersionsQuery = (entityId: string) => `query {
-  proposedVersions(where: {entity: ${JSON.stringify(entityId)}}, first: 10, orderBy: createdAt, orderDirection: desc) {
+  proposedVersions(where: {entity: ${JSON.stringify(entityId)}}, orderBy: createdAt, orderDirection: desc) {
     id
     name
     createdAt

--- a/apps/web/modules/services/io/queries.ts
+++ b/apps/web/modules/services/io/queries.ts
@@ -28,3 +28,32 @@ export const proposedVersionsQuery = (entityId: string) => `query {
     }
   }
 }`;
+
+export const profileQuery = (address: string) => `query {
+  geoEntities(where: {name_starts_with_nocase: ${JSON.stringify(address)}}) {
+    id
+    name
+    entityOf {
+      id
+      stringValue
+      valueId
+      valueType
+      numberValue
+      space {
+        id
+      }
+      entityValue {
+        id
+        name
+      }
+      attribute {
+        id
+        name
+      }
+      entity {
+        id
+        name
+      }
+    }
+  }
+}`;

--- a/apps/web/modules/services/network-local-mapping.ts
+++ b/apps/web/modules/services/network-local-mapping.ts
@@ -137,8 +137,10 @@ export function fromNetworkActions(networkActions: NetworkAction[], spaceId: str
           id: networkAction.id,
           entityId: networkAction.entity.id,
           entityName: networkAction.entity.name,
-          attributeId: networkAction.attribute.id,
-          attributeName: networkAction.attribute.name,
+          // @TODO why can these be null? Let's investigate when
+          // we tackle review UI for comparing versions
+          attributeId: networkAction.attribute?.id ?? '',
+          attributeName: networkAction.attribute?.name ?? '',
           value,
           space: spaceId,
         };
@@ -150,8 +152,10 @@ export function fromNetworkActions(networkActions: NetworkAction[], spaceId: str
           id: networkAction.id,
           entityId: networkAction.entity.id,
           entityName: networkAction.entity.name,
-          attributeId: networkAction.attribute.id,
-          attributeName: networkAction.attribute.name,
+          // @TODO why can these be null? Let's investigate when
+          // we tackle review UI for comparing versions
+          attributeId: networkAction.attribute?.id ?? '',
+          attributeName: networkAction.attribute?.name ?? '',
           value,
           space: spaceId,
         };

--- a/apps/web/modules/services/network-local-mapping.ts
+++ b/apps/web/modules/services/network-local-mapping.ts
@@ -11,9 +11,6 @@ type NetworkEntityValue = { valueType: 'ENTITY'; entityValue: { id: string; name
 
 type NetworkValue = NetworkNumberValue | NetworkStringValue | NetworkEntityValue | NetworkImageValue;
 
-/**
- * Triple type returned by GraphQL
- */
 export type NetworkTriple = NetworkValue & {
   id: string;
   entity: { id: string; name: string | null };
@@ -32,8 +29,14 @@ export type NetworkEntity = Entity & {
   entityOf: ({ space: Space } & NetworkTriple)[];
 };
 
-export type NetworkVersion = Version & {
+export type NetworkVersion = OmitStrict<Version, 'createdBy'> & {
   actions: NetworkAction[];
+
+  // The NetworkVersion does not have a name or avatar associated
+  // with the createdBy field
+  createdBy: {
+    id: string;
+  };
 };
 
 export function extractValue(networkTriple: NetworkTriple | NetworkAction): Value {

--- a/apps/web/modules/types.ts
+++ b/apps/web/modules/types.ts
@@ -132,11 +132,13 @@ export type Version = {
   id: string;
   name: string;
   description?: string;
-  createdBy: {
-    id: string;
-    name?: string;
-    avatarUrl?: string;
-  };
+  createdBy: Profile;
   createdAt: number;
   actions: Action[];
+};
+
+export type Profile = {
+  id: string;
+  name: string | null;
+  avatarUrl: string | null;
 };

--- a/packages/ids/system-ids.ts
+++ b/packages/ids/system-ids.ts
@@ -30,6 +30,10 @@ export const TEXT = '9edb6fcc-e454-4aa5-8611-39d7f024c010'
 /* Note that this is a temporary workaround for production MVP release. As such, this system ID isn't included in the bootstrap process.*/
 export const DEFAULT_TYPE = 'aeebbd5e-4d79-4d24-ae99-239e9142d9ed'
 
+export const AVATAR_ATTRIBUTE = '85ae56a3-aa6f-4dd3-a1d0-3027d3c64810'
+
+export const PERSON_ATTRIBUTE = '626e4ad5-61c3-49ae-af5e-3c80e53cf890'
+
 /**
  * Addresses for important contracts on Polygon mainnet.
  *

--- a/packages/subgraph/src/actions.ts
+++ b/packages/subgraph/src/actions.ts
@@ -4,7 +4,7 @@ import {
   CreateTripleAction,
   DeleteTripleAction,
 } from '@geogenesis/action-schema/assembly'
-import { TYPES } from '@geogenesis/ids/system-ids'
+import { NAME, SPACE, TYPES } from '@geogenesis/ids/system-ids'
 import {
   Address,
   BigDecimal,
@@ -215,7 +215,7 @@ export function handleCreateTripleAction(
     triple.valueId = stringValue.id
     triple.stringValue = stringValue.value
 
-    if (attribute.id == 'name') {
+    if (attribute.id == NAME) {
       entity.name = stringValue.value
       entity.save()
     }
@@ -225,7 +225,7 @@ export function handleCreateTripleAction(
       []
     )
 
-    if (attribute.id == 'space') {
+    if (attribute.id == SPACE) {
       handleSpaceAdded(stringValue.value, false, createdAtBlock, fact.entityId)
     }
   }


### PR DESCRIPTION
Right now there is no wallet -> profile mapping in the subgraph until we added permissionless spaces and profiles. We can create an ad-hoc profile system using GeoEntities and associated them with a Wallet entity.

This PR sets up infrastructure for querying a Profile GeoEntity based on the wallet address in a version's createdBy field. We then add the profile information to the version to populate the name and avatar.

---
**Demo here**
https://share.cleanshot.com/pn6v2wXS