### PR TITLE
fix: update to correct beacon address

### DIFF
--- a/packages/contracts/.openzeppelin/polygon.json
+++ b/packages/contracts/.openzeppelin/polygon.json
@@ -15,6 +15,11 @@
       "address": "0x9952B5C325981fa48Df48BfCCdb019161E9e56D3",
       "txHash": "0xfafedd87721f08c559dd0c7fc80c73b4a61756650a3dee504c89160a11045e69",
       "kind": "beacon"
+    },
+    {
+      "address": "0x42f7efb71E7126bff66eEF89D52769B710B46803",
+      "txHash": "0x223b8662661e67d703399f3055749e3c379f6c9ff4b17188242293cc5528bdb1",
+      "kind": "beacon"
     }
   ],
   "impls": {

--- a/packages/contracts/scripts/deploy-permissioned-space-registry.ts
+++ b/packages/contracts/scripts/deploy-permissioned-space-registry.ts
@@ -22,7 +22,7 @@ async function deployPermissionedSpaceRegistry() {
   console.log('Deploying on network', networkId, networkConfig)
 
   const spaceBeacon = ethers.ContractFactory.getContract(
-    '0x8991A5056A0ebC8740A9F74Fd9122dAdE2F29ED0',
+    '0xe44be15e413169ad49fb24cbf8db192be5a9a8bf',
     Space__factory.abi
   ) as Space
 

--- a/packages/ids/system-ids.ts
+++ b/packages/ids/system-ids.ts
@@ -37,7 +37,7 @@ export const DEFAULT_TYPE = 'aeebbd5e-4d79-4d24-ae99-239e9142d9ed'
 // This represents the beacon proxy for the first set of deployed permissioned spaces.
 // We should use this beacon proxy for all new permissioned spaces.
 export const PERMISSIONED_SPACE_BEACON_ADDRESS =
-  '0x8991A5056A0ebC8740A9F74Fd9122dAdE2F29ED0'
+  '0xe44Be15e413169Ad49fB24CBF8db192BE5A9A8bF'
 
 // This represents the Space contract acting as the registry for all permissioned spaces.
 // This is the address for the Root Space.


### PR DESCRIPTION
We store the address of the beacon contract used to proxy implementations to our contracts. The value was using the incorrect contract address previously.