### PR TITLE
fix: allow non-existent entities to be rendered

### DIFF
--- a/apps/web/pages/space/[id]/[entityId].tsx
+++ b/apps/web/pages/space/[id]/[entityId].tsx
@@ -85,11 +85,6 @@ export const getServerSideProps: GetServerSideProps<Props> = async context => {
     network.fetchProposedVersions(entityId, space),
   ]);
 
-  if (!entity)
-    return {
-      notFound: true,
-    };
-
   const spaces = await network.fetchSpaces();
 
   const referencedByEntities: ReferencedByEntity[] = related.map(e => {
@@ -112,10 +107,10 @@ export const getServerSideProps: GetServerSideProps<Props> = async context => {
 
   return {
     props: {
-      triples: entity.triples,
+      triples: entity?.triples ?? [],
       schemaTriples: [] /* @TODO: Fetch schema triples for entity if entity has a type */,
       id: entityId,
-      name: entity.name ?? entityId,
+      name: entity?.name ?? entityId,
       space,
       referencedByEntities,
       versions,


### PR DESCRIPTION
We may have a locally created entity page that won't fetch on the server. We still want to be able to show those pages.