### PR TITLE
fix: only render flowbar for actions that are unpublished

### DIFF
--- a/apps/web/modules/components/flow-bar.tsx
+++ b/apps/web/modules/components/flow-bar.tsx
@@ -11,10 +11,11 @@ export const FlowBar = () => {
   const { allActions, allSpacesWithActions } = useActionsStore();
   const { isReviewOpen, setIsReviewOpen } = useReview();
 
-  const actionsCount = Action.getChangeCount(allActions);
+  const allUnpublishedActions = allActions.filter(a => !a.hasBeenPublished);
+  const actionsCount = Action.getChangeCount(allUnpublishedActions);
 
   const entitiesCount = pipe(
-    allActions,
+    allUnpublishedActions,
     actions => Action.squashChanges(actions),
     A.groupBy(action => {
       if (action.type === 'deleteTriple' || action.type === 'createTriple') return action.entityId;


### PR DESCRIPTION
Previously we were rendering the flowbar for _all_ actions instead of just the unpublished ones.