### PR TITLE
fix: only persist unpublished actions

### DIFF
--- a/apps/web/modules/persistence.tsx
+++ b/apps/web/modules/persistence.tsx
@@ -8,12 +8,6 @@ import type { SpaceActions } from './action/actions-store';
 export const Persistence = () => {
   const [isInitialRender, setIsInitialRender] = useState<boolean>(true);
   const { actions, restore } = useActionsStore();
-
-  const unpublishedActions: SpaceActions = {};
-  Object.keys(actions).forEach(key => {
-    unpublishedActions[key] = actions[key].filter(a => !a.hasBeenPublished);
-  });
-
   const [storedActions, setStoredActions] = useLocalStorage('storedActions', {});
 
   // Restore actions on first render, save actions each render thereafter
@@ -23,10 +17,14 @@ export const Persistence = () => {
       restore(storedActions);
     } else {
       console.info('💾 saving actions');
+      const unpublishedActions: SpaceActions = {};
+      Object.keys(actions).forEach(key => {
+        unpublishedActions[key] = actions[key].filter(a => !a.hasBeenPublished);
+      });
       setStoredActions(unpublishedActions);
     }
     // note: finely tuned dependency because `storedActions` is only used on initial render
-    // no need to save stored actions a second time when storedactions are updated
+    // no need to save stored actions a second time when `storedAactions` are updated
   }, [isInitialRender, actions]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {

--- a/apps/web/modules/persistence.tsx
+++ b/apps/web/modules/persistence.tsx
@@ -3,10 +3,17 @@ import { useState, useEffect } from 'react';
 
 import { useActionsStore } from './action';
 import { useLocalStorage } from './hooks/use-local-storage';
+import type { SpaceActions } from './action/actions-store';
 
 export const Persistence = () => {
   const [isInitialRender, setIsInitialRender] = useState<boolean>(true);
   const { actions, restore } = useActionsStore();
+
+  const unpublishedActions: SpaceActions = {};
+  Object.keys(actions).forEach(key => {
+    unpublishedActions[key] = actions[key].filter(a => !a.hasBeenPublished);
+  });
+
   const [storedActions, setStoredActions] = useLocalStorage('storedActions', {});
 
   // Restore actions on first render, save actions each render thereafter
@@ -16,7 +23,7 @@ export const Persistence = () => {
       restore(storedActions);
     } else {
       console.info('💾 saving actions');
-      setStoredActions(actions);
+      setStoredActions(unpublishedActions);
     }
     // note: finely tuned dependency because `storedActions` is only used on initial render
     // no need to save stored actions a second time when storedactions are updated

--- a/apps/web/modules/persistence.tsx
+++ b/apps/web/modules/persistence.tsx
@@ -24,7 +24,7 @@ export const Persistence = () => {
       setStoredActions(unpublishedActions);
     }
     // note: finely tuned dependency because `storedActions` is only used on initial render
-    // no need to save stored actions a second time when `storedAactions` are updated
+    // no need to save stored actions a second time when `storedActions` are updated
   }, [isInitialRender, actions]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {


### PR DESCRIPTION
This PR filters out published actions before being saved to localStorage.