### PR TITLE
fix: fix editable entity name truncating and entity page responsiveness

### DIFF
--- a/apps/web/modules/components/entity/editable-entity-page.tsx
+++ b/apps/web/modules/components/entity/editable-entity-page.tsx
@@ -92,7 +92,12 @@ export function EditableEntityPage({
   return (
     <>
       <PageStringField variant="mainPage" placeholder="Entity name..." value={name} onChange={onNameChange} />
-      <Spacer height={16} />
+      {/* 
+        This height differs from the readable page height due to how we're using an expandable textarea for editing
+        the entity name. We can't perfectly match the height of the normal <Text /> field with the textarea, so we
+        have to manually adjust the spacing here to remove the layout shift.
+      */}
+      <Spacer height={9.5} />
       <EntityPageMetadataHeader versions={versions} />
       <Spacer height={24} />
       <EntityTypeChipGroup types={types} />

--- a/apps/web/modules/components/entity/editable-fields.tsx
+++ b/apps/web/modules/components/entity/editable-fields.tsx
@@ -68,7 +68,9 @@ export function PageStringField({ ...props }: PageStringFieldProps) {
       if (props.variant === 'body') {
         // This aligns the bottom of the text area with the sum of line heights * number of lines
         // for body text.
-        ref.current.style.height = ref.current.scrollHeight - 4 + 'px';
+        ref.current.style.height = `${ref.current.scrollHeight - 4}px`;
+      } else {
+        ref.current.style.height = `${ref.current.scrollHeight - 3}px`;
       }
     }
   });

--- a/apps/web/modules/components/entity/entity-page-content-container.tsx
+++ b/apps/web/modules/components/entity/entity-page-content-container.tsx
@@ -1,10 +1,12 @@
+import * as React from 'react';
+
 interface Props {
   children: React.ReactNode;
 }
 
 export function EntityPageContentContainer({ children }: Props) {
   return (
-    <div className="m-auto flex min-h-full w-[784px] flex-col items-center">
+    <div className="m-auto flex min-h-full max-w-[784px] flex-col items-center">
       <div className="w-full">{children}</div>
     </div>
   );


### PR DESCRIPTION
We were not correctly setting the dynamic height of the expandable text area previously. We also were setting a fixed width for the entity page content container which did not scale responsively for smaller widths.