### PR TITLE
feat: deleting a block from the editor should delete the block entity

### DIFF
--- a/apps/web/modules/action/action.ts
+++ b/apps/web/modules/action/action.ts
@@ -1,3 +1,4 @@
+import { pipe } from '@mobily/ts-belt';
 import { Action, Action as ActionType } from '~/modules/types';
 
 export function forEntityId(actions: ActionType[], entityId: string) {
@@ -122,4 +123,8 @@ export function squashChanges(actions: Action[]) {
 
 export function unpublishedChanges(actions: Action[]) {
   return actions.filter(a => !a.hasBeenPublished);
+}
+
+export function prepareActionsForPublishing(actions: Action[]) {
+  return pipe(actions, unpublishedChanges, squashChanges);
 }

--- a/apps/web/modules/action/actions-store.ts
+++ b/apps/web/modules/action/actions-store.ts
@@ -142,7 +142,7 @@ export class ActionsStore implements IActionsStore {
 
     try {
       await this.api.publish({
-        actions: Action.unpublishedChanges(Action.squashChanges(actionsToPublish)),
+        actions: Action.prepareActionsForPublishing(actionsToPublish),
         signer,
         onChangePublishState,
         space: spaceId,

--- a/apps/web/modules/components/flow-bar.tsx
+++ b/apps/web/modules/components/flow-bar.tsx
@@ -11,7 +11,7 @@ export const FlowBar = () => {
   const { allActions, allSpacesWithActions } = useActionsStore();
   const { isReviewOpen, setIsReviewOpen } = useReview();
 
-  const allUnpublishedActions = allActions.filter(a => !a.hasBeenPublished);
+  const allUnpublishedActions = Action.unpublishedChanges(allActions);
   const actionsCount = Action.getChangeCount(allUnpublishedActions);
 
   const entitiesCount = pipe(

--- a/apps/web/modules/entity/entity-store/entity-store.ts
+++ b/apps/web/modules/entity/entity-store/entity-store.ts
@@ -522,9 +522,9 @@ export class EntityStore implements IEntityStore {
   Helper function to create or update the block IDs on an entity
   Since we don't currently support array value types, we store all ordered blocks as a single stringified array 
   */
-  upsertBlocksTriple = (blockIds: string[]) => {
+  upsertBlocksTriple = async (newBlockIds: string[]) => {
     const existingBlockTriple = this.blockIdsTriple$.get();
-    const isUpdated = existingBlockTriple && Value.stringValue(existingBlockTriple) !== JSON.stringify(blockIds);
+    const isUpdated = existingBlockTriple && Value.stringValue(existingBlockTriple) !== JSON.stringify(newBlockIds);
 
     if (!existingBlockTriple) {
       const triple = Triple.withId({
@@ -536,20 +536,63 @@ export class EntityStore implements IEntityStore {
         value: {
           id: ID.createValueId(),
           type: 'string',
-          value: JSON.stringify(blockIds),
+          value: JSON.stringify(newBlockIds),
         },
       });
-      this.create(triple);
+
+      return this.create(triple);
     } else if (isUpdated) {
+      // If a block is deleted we want to make sure that we delete the block entity as well.
+      // The block entity might exist remotely, so we need to fetch all the triple associated
+      // with that block entity in order to delete them all.
+      //
+      // Additionally,there may be local triples associated with the block entity that we need
+      // to delete.
+      const prevBlockIds = this.blockIds$.get();
+      const removedBlockIds = A.difference(prevBlockIds, newBlockIds);
+
+      // Fetch all the subgraph data for all the deleted block entities.
+      const maybeRemoteBlocks = await Promise.all(removedBlockIds.map(async blockId => this.api.fetchEntity(blockId)));
+      const remoteBlocks = maybeRemoteBlocks.flatMap(block => (block ? [block] : []));
+
+      // To delete an entity we delete all of its triples
+      remoteBlocks.forEach(block => {
+        block.triples.forEach(t => this.remove(t));
+      });
+
+      // TODO: There may still be local triples to delete
+      const localTriplesForAllDeletedBlocks = pipe(
+        this.ActionsStore.allActions$.get(),
+        actions => Triple.fromActions(actions, []),
+        t => {
+          console.log('t');
+          return t;
+        },
+        triples => triples.filter(t => removedBlockIds.includes(t.entityId))
+      );
+
+      localTriplesForAllDeletedBlocks.forEach(t => this.remove(t));
+
+      console.log('localTriplesForAllDeletedBlocks', localTriplesForAllDeletedBlocks);
+      console.log('prevBlockIds', prevBlockIds);
+      console.log('removedBlockIds', removedBlockIds);
+      console.log('remoteBlocks', remoteBlocks);
+
+      // We delete the existingBlockTriple if the page content is completely empty
+      if (newBlockIds.length === 0) {
+        return this.remove(existingBlockTriple);
+      }
+
       const updatedTriple = Triple.ensureStableId({
         ...existingBlockTriple,
         value: {
           ...existingBlockTriple.value,
           type: 'string',
-          value: JSON.stringify(blockIds),
+          value: JSON.stringify(newBlockIds),
         },
       });
-      this.update(updatedTriple, existingBlockTriple);
+
+      return this.update(updatedTriple, existingBlockTriple);
     }
   };
 

--- a/apps/web/modules/entity/entity-store/entity-store.ts
+++ b/apps/web/modules/entity/entity-store/entity-store.ts
@@ -560,23 +560,14 @@ export class EntityStore implements IEntityStore {
         block.triples.forEach(t => this.remove(t));
       });
 
-      // TODO: There may still be local triples to delete
+      // Delete any local triples associated with the deleted block entities
       const localTriplesForAllDeletedBlocks = pipe(
         this.ActionsStore.allActions$.get(),
         actions => Triple.fromActions(actions, []),
-        t => {
-          console.log('t');
-          return t;
-        },
         triples => triples.filter(t => removedBlockIds.includes(t.entityId))
       );
 
       localTriplesForAllDeletedBlocks.forEach(t => this.remove(t));
-
-      console.log('localTriplesForAllDeletedBlocks', localTriplesForAllDeletedBlocks);
-      console.log('prevBlockIds', prevBlockIds);
-      console.log('removedBlockIds', removedBlockIds);
-      console.log('remoteBlocks', remoteBlocks);
 
       // We delete the existingBlockTriple if the page content is completely empty
       if (newBlockIds.length === 0) {

--- a/docs/pages.md
+++ b/docs/pages.md
@@ -107,7 +107,7 @@ Since blocks are entities, any other entity (such as entity pages) can reference
 
 Blocks are "owned" by a parent entity, so only the parent entity can completely delete a block. We should also cascade update all pages that reference the block that was deleted.
 
-_Note: Right now this is all only enforced by Geo Genesis' UI. There is no mechanism for enforcing this behavior in the protocol itself._
+_Note: Right now this is all only enforced by Geo Genesis' UI. There is no mechanism for enforcing this behavior in the protocol itself._ **Additionally, right now Geo Genesis does not have a way to tranclude blocks into other pages from the UI, so handling cascading block deletions isn't a large concern.**
 
 <br/>
 


### PR DESCRIPTION
This PR handles some edge-cases when deleting content from the text editor on an Entity Page
- If we delete a block from the editor, it should also delete the block entity for that block. Right now we don't have transclusion, so we can safely delete the entity without any dangerous side-effects for other pages.
- If we delete the _last_ block in the text editor, we delete the `block ids` triple, too.