### PR TITLE
feat: filter blocks from entity search

### DIFF
--- a/apps/web/modules/services/io/queries.ts
+++ b/apps/web/modules/services/io/queries.ts
@@ -1,3 +1,60 @@
+export const entitiesQuery = (query: string | undefined, entityOfWhere: string) => `query {
+  startEntities: geoEntities(where: {name_starts_with_nocase: ${JSON.stringify(
+    query
+  )}, entityOf_: {${entityOfWhere}}}) {
+    id,
+    name
+    entityOf {
+      id
+      stringValue
+      valueId
+      valueType
+      numberValue
+      space {
+        id
+      }
+      entityValue {
+        id
+        name
+      }
+      attribute {
+        id
+        name
+      }
+      entity {
+        id
+        name
+      }
+    }
+  }
+  containEntities: geoEntities(where: {name_contains_nocase: ${JSON.stringify(query)}, entityOf_: {${entityOfWhere}}}) {
+    id,
+    name,
+    entityOf {
+      id
+      stringValue
+      valueId
+      valueType
+      numberValue
+      space {
+        id
+      }
+      entityValue {
+        id
+        name
+      }
+      attribute {
+        id
+        name
+      }
+      entity {
+        id
+        name
+      }
+    }
+  }
+}`;
+
 export const proposedVersionsQuery = (entityId: string) => `query {
   proposedVersions(where: {entity: ${JSON.stringify(entityId)}}, orderBy: createdAt, orderDirection: desc) {
     id


### PR DESCRIPTION
For now we don't want to clutter entity search with all the block entities within Geo. Eventually, once we have transclusion and other block-based reference features we may want to index entities or handle network filtering a different way. For now this works.