### PR TITLE
fix: autocomplete does not use spaceId

### DIFF
--- a/apps/web/modules/components/entity/autocomplete/entity-autocomplete.tsx
+++ b/apps/web/modules/components/entity/autocomplete/entity-autocomplete.tsx
@@ -36,11 +36,10 @@ const MotionContent = motion(StyledContent);
 interface Props {
   entityValueIds: string[];
   onDone: (result: Entity) => void;
-  spaceId: string;
 }
 
-export function EntityAutocompleteDialog({ onDone, entityValueIds, spaceId }: Props) {
-  const autocomplete = useAutocomplete({ spaceId });
+export function EntityAutocompleteDialog({ onDone, entityValueIds }: Props) {
+  const autocomplete = useAutocomplete();
   const entityItemIdsSet = new Set(entityValueIds);
   const { spaces } = useSpaces();
 

--- a/apps/web/modules/components/entity/autocomplete/entity-text-autocomplete.tsx
+++ b/apps/web/modules/components/entity/autocomplete/entity-text-autocomplete.tsx
@@ -12,11 +12,10 @@ interface Props {
   placeholder?: string;
   onDone: (result: Entity) => void;
   itemIds: string[];
-  spaceId: string;
 }
 
-export function EntityTextAutocomplete({ placeholder, itemIds, onDone, spaceId }: Props) {
-  const { query, results, onQueryChange } = useAutocomplete({ spaceId });
+export function EntityTextAutocomplete({ placeholder, itemIds, onDone }: Props) {
+  const { query, results, onQueryChange } = useAutocomplete();
   const containerRef = useRef<HTMLDivElement>(null);
   const itemIdsSet = new Set(itemIds);
   const { spaces } = useSpaces();

--- a/apps/web/modules/search/autocomplete.ts
+++ b/apps/web/modules/search/autocomplete.ts
@@ -23,7 +23,7 @@ class EntityAutocomplete {
   results$: ObservableComputed<EntityType[]>;
   abortController: AbortController = new AbortController();
 
-  constructor({ api, spaceId, ActionsStore, filter = [] }: EntityAutocompleteOptions) {
+  constructor({ api, ActionsStore, filter = [] }: EntityAutocompleteOptions) {
     this.results$ = makeOptionalComputed(
       [],
       computed(async () => {
@@ -76,20 +76,19 @@ class EntityAutocomplete {
   };
 }
 
-interface AutocompleteProps {
-  spaceId?: string;
+interface AutocompleteOptions {
   filter?: FilterState;
 }
 
-export function useAutocomplete({ spaceId, filter }: AutocompleteProps) {
+export function useAutocomplete({ filter = [] }: AutocompleteOptions = {}) {
   const { network } = Services.useServices();
   const ActionsStore = useActionsStoreContext();
 
   const autocomplete = useMemo(() => {
-    return new EntityAutocomplete({ api: network, spaceId, ActionsStore, filter });
+    return new EntityAutocomplete({ api: network, ActionsStore, filter });
     // Typically we wouldn't want to stringify a dependency array value, but since
     // we know that the FilterState object is small we know it won't create a performance issue.
-  }, [network, spaceId, ActionsStore, JSON.stringify(filter)]);
+  }, [network, ActionsStore, JSON.stringify(filter)]);
 
   const results = useSelector(autocomplete.results$);
   const query = useSelector(autocomplete.query$);

--- a/apps/web/modules/search/dialog.tsx
+++ b/apps/web/modules/search/dialog.tsx
@@ -12,13 +12,12 @@ import { ResizableContainer } from '../design-system/resizable-container';
 
 interface Props {
   onDone: (result: Entity) => void;
-  spaceId: string;
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }
 
-export function Dialog({ onDone, spaceId, open, onOpenChange }: Props) {
-  const autocomplete = useAutocomplete({ spaceId });
+export function Dialog({ onDone, open, onOpenChange }: Props) {
+  const autocomplete = useAutocomplete();
   const { spaces } = useSpaces();
 
   if (!open) return null;

--- a/apps/web/pages/_app.tsx
+++ b/apps/web/pages/_app.tsx
@@ -85,7 +85,6 @@ function App({ Component, pageProps }: AppProps) {
           router.push(NavUtils.toEntity(result.nameTripleSpace, result.id));
           setOpen(false);
         }}
-        spaceId=""
       />
       <Main>
         <Component {...pageProps} />


### PR DESCRIPTION
We can clean up some of the callsites for useAutocomplete since it does not use the spaceId anymore.