### PR TITLE
feat: add error messaging for unsupported action types

### DIFF
--- a/apps/web/modules/components/review.test.ts
+++ b/apps/web/modules/components/review.test.ts
@@ -113,14 +113,14 @@ const ENTITY_CHANGES: Changes = {
 
 describe('Actions to changes transformer (string values)', () => {
   it('Generates changes from actions', () => {
-    const changes = getChanges(STRING_ACTIONS);
+    const [changes] = getChanges(STRING_ACTIONS);
     expect(changes).toEqual(STRING_CHANGES);
   });
 });
 
 describe('Actions to changes transformer (entity values)', () => {
   it('Generates changes from actions', () => {
-    const changes = getChanges(ENTITY_ACTIONS);
+    const [changes] = getChanges(ENTITY_ACTIONS);
     expect(changes).toEqual(ENTITY_CHANGES);
   });
 });


### PR DESCRIPTION
This PR adds error messages for unsupported action types until the review changes UI is refactored to support block diffs and other recent additions.

![image](https://user-images.githubusercontent.com/20441876/230658214-392cbec3-fa93-4e54-beee-19522248b47b.png)
