### PR TITLE
fix: flow bar should use actions store instead of local store

### DIFF
--- a/apps/web/modules/action/actions-store-provider.tsx
+++ b/apps/web/modules/action/actions-store-provider.tsx
@@ -4,7 +4,7 @@ import { createContext, useContext, useMemo } from 'react';
 import { Services } from '../services';
 import { ActionsStore } from './actions-store';
 
-const ActionsStoreContext = createContext<ActionsStore | undefined>(undefined);
+export const ActionsStoreContext = createContext<ActionsStore | undefined>(undefined);
 
 interface Props {
   children: React.ReactNode;

--- a/apps/web/modules/components/entity-table/entity-table.tsx
+++ b/apps/web/modules/components/entity-table/entity-table.tsx
@@ -67,7 +67,10 @@ const defaultColumn: Partial<ColumnDef<Row>> = {
     const editable = table.options.meta?.editable;
     const isEditor = table.options.meta?.isEditor;
 
+    // eslint-disable-next-line react-hooks/rules-of-hooks
     const { create, update, remove, actions$ } = useActionsStoreContext();
+
+    // eslint-disable-next-line react-hooks/rules-of-hooks
     const { columnValueType } = useEntityTable();
 
     const cellData = getValue<Cell | undefined>();

--- a/apps/web/modules/components/flow-bar.test.tsx
+++ b/apps/web/modules/components/flow-bar.test.tsx
@@ -1,0 +1,121 @@
+import { act, render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { Providers } from '../providers';
+import { FlowBar } from './flow-bar';
+import { ActionsStoreContext } from '../action/actions-store-provider';
+import { ActionsStore } from '../action';
+import { MockNetworkData, NetworkData } from '../io';
+import { StorageClient } from '../services/storage';
+import { options } from '../config/config';
+import { editable$ } from '../stores/use-editable';
+
+// Most of these tests are covered by the action.test.ts file, but there are some
+// other cases we want to handle, particularly for rendering the flow bar in different
+// states.
+describe('Flow Bar', () => {
+  it('Should not render the flow bar when there are not changes', () => {
+    const store = new ActionsStore({
+      api: new NetworkData.Network(new StorageClient(options.production.ipfs), options.production.subgraph),
+    });
+
+    render(
+      <Providers>
+        <ActionsStoreContext.Provider value={store}>
+          <FlowBar />
+        </ActionsStoreContext.Provider>
+      </Providers>
+    );
+
+    expect(screen.queryByText('Review')).not.toBeInTheDocument();
+  });
+
+  it('Should not render the flow bar when there are changes but not in edit mode', () => {
+    const store = new ActionsStore({
+      api: new NetworkData.Network(new StorageClient(options.production.ipfs), options.production.subgraph),
+    });
+
+    render(
+      <Providers>
+        <ActionsStoreContext.Provider value={store}>
+          <FlowBar />
+        </ActionsStoreContext.Provider>
+      </Providers>
+    );
+
+    act(() => store.create(MockNetworkData.makeStubTriple('Alice')));
+
+    expect(screen.queryByText('Review')).not.toBeInTheDocument();
+  });
+
+  it('Should render the flow bar when there are changes and in edit mode', () => {
+    const store = new ActionsStore({
+      api: new NetworkData.Network(new StorageClient(options.production.ipfs), options.production.subgraph),
+    });
+
+    render(
+      <Providers>
+        <ActionsStoreContext.Provider value={store}>
+          <FlowBar />
+        </ActionsStoreContext.Provider>
+      </Providers>
+    );
+
+    act(() => {
+      store.create(MockNetworkData.makeStubTriple('Alice'));
+      editable$.set(true);
+    });
+
+    expect(screen.queryByRole('button')).toBeInTheDocument();
+  });
+
+  /**
+   * 1. createTriple, createTriple -- This should only be considered one change
+   * 2. createTriple, editTriple -- This should only be considered one change
+   * 3. createTriple, deleteTriple -- This should be considered no change
+   * 4. editTriple, editTriple -- This should be considered one change only if the value has changed
+   * 5. editTriple, deleteTriple -- This should be considered one change
+   */
+  it('Should show correct counts', () => {
+    const store = new ActionsStore({
+      api: new NetworkData.Network(new StorageClient(options.production.ipfs), options.production.subgraph),
+    });
+
+    render(
+      <Providers>
+        <ActionsStoreContext.Provider value={store}>
+          <FlowBar />
+        </ActionsStoreContext.Provider>
+      </Providers>
+    );
+
+    act(() => {
+      store.create(MockNetworkData.makeStubTriple('Alice'));
+      editable$.set(true);
+    });
+
+    expect(screen.queryByText('1 edit')).toBeInTheDocument();
+
+    // create -> create should only be one change
+    act(() => {
+      store.create(MockNetworkData.makeStubTriple('Alice'));
+    });
+
+    expect(screen.queryByText('1 edit')).toBeInTheDocument();
+
+    // create -> delete should be 0 changes
+    act(() => {
+      store.remove(MockNetworkData.makeStubTriple('Alice'));
+    });
+
+    expect(screen.queryByText('Review')).not.toBeInTheDocument();
+
+    // create -> edit should only be one change
+    act(() => {
+      const newTriple = MockNetworkData.makeStubTriple('Alice');
+      store.create(newTriple);
+      store.update({ ...newTriple, value: { ...newTriple.value, id: 'Bob' } }, newTriple);
+    });
+
+    expect(screen.queryByText('1 edit')).toBeInTheDocument();
+  });
+});

--- a/apps/web/modules/components/flow-bar.test.tsx
+++ b/apps/web/modules/components/flow-bar.test.tsx
@@ -80,7 +80,7 @@ describe('Flow Bar', () => {
       api: new NetworkData.Network(new StorageClient(options.production.ipfs), options.production.subgraph),
     });
 
-    render(
+    const { debug } = render(
       <Providers>
         <ActionsStoreContext.Provider value={store}>
           <FlowBar />
@@ -117,5 +117,25 @@ describe('Flow Bar', () => {
     });
 
     expect(screen.queryByText('1 edit')).toBeInTheDocument();
+
+    // Multiple changes to the same entity should show the correct count
+    act(() => {
+      // Passing the previous entityId as a parameter to add this triple to the same entity
+      const newTriple = MockNetworkData.makeStubTriple('Bob', 'Alice');
+      store.create(newTriple);
+    });
+
+    expect(screen.queryByText('2 edits')).toBeInTheDocument();
+    expect(screen.queryByText('1 entity in 1 space')).toBeInTheDocument();
+
+    // Changes to multiple entities should show the correct count
+    act(() => {
+      // Passing the previous entityId as a parameter to add this triple to the same entity
+      const newTriple = MockNetworkData.makeStubTriple('Charlie');
+      store.create(newTriple);
+    });
+
+    expect(screen.queryByText('3 edits')).toBeInTheDocument();
+    expect(screen.queryByText('2 entities in 1 space')).toBeInTheDocument();
   });
 });

--- a/apps/web/modules/components/flow-bar.tsx
+++ b/apps/web/modules/components/flow-bar.tsx
@@ -26,9 +26,6 @@ export const FlowBar = () => {
     A.length
   );
 
-  console.log('allActions', allActions);
-  console.log('editable', editable);
-
   const spacesCount = allSpacesWithActions.length;
 
   if (actionsCount === 0 || !editable) return null;

--- a/apps/web/modules/components/flow-bar.tsx
+++ b/apps/web/modules/components/flow-bar.tsx
@@ -5,18 +5,33 @@ import pluralize from 'pluralize';
 import { Button } from '~/modules/design-system/button';
 import { useEditable } from '~/modules/stores/use-editable';
 import { useReview } from '~/modules/review';
-import { LocalData } from '~/modules/io';
+import { Action, useActionsStore } from '../action';
+import { A, D, pipe } from '@mobily/ts-belt';
 
 export const FlowBar = () => {
   const { editable } = useEditable();
   const { isReviewOpen, setIsReviewOpen } = useReview();
-  const { unpublishedEntities, unpublishedTriples, unpublishedSpaces } = LocalData.useLocalStore();
+  const { allActions, allSpacesWithActions } = useActionsStore();
 
-  const entitiesCount = unpublishedEntities.length;
-  const changesCount = unpublishedTriples.length;
-  const spacesCount = unpublishedSpaces.length;
+  const allUnpublishedSquashedActions = Action.prepareActionsForPublishing(allActions);
+  const actionsCount = allUnpublishedSquashedActions.length;
 
-  if (!editable || changesCount === 0) return null;
+  const entitiesCount = pipe(
+    allUnpublishedSquashedActions,
+    A.groupBy(action => {
+      if (action.type === 'deleteTriple' || action.type === 'createTriple') return action.entityId;
+      return action.after.entityId;
+    }),
+    D.keys,
+    A.length
+  );
+
+  console.log('allActions', allActions);
+  console.log('editable', editable);
+
+  const spacesCount = allSpacesWithActions.length;
+
+  if (actionsCount === 0 || !editable) return null;
 
   return (
     <AnimatePresence>
@@ -31,14 +46,14 @@ export const FlowBar = () => {
           className="pointer-events-auto inline-flex items-center gap-4 rounded bg-white p-2 pl-3 shadow-card"
         >
           <div className="inline-flex items-center font-medium">
-            <span>{pluralize('edit', changesCount, true)}</span>
+            <span>{pluralize('edit', actionsCount, true)}</span>
             <hr className="mx-2 inline-block h-4 w-px border-none bg-grey-03" />
             <span>
               {pluralize('entity', entitiesCount, true)} in {pluralize('space', spacesCount, true)}
             </span>
           </div>
           <Button onClick={() => setIsReviewOpen(true)} variant="primary">
-            Review {pluralize('edit', changesCount, false)}
+            Review {pluralize('edit', actionsCount, false)}
           </Button>
         </motion.div>
       </div>

--- a/apps/web/modules/io/data-source/local.tsx
+++ b/apps/web/modules/io/data-source/local.tsx
@@ -92,7 +92,7 @@ export function useLocalStoreContext() {
   const value = useContext(LocalStoreContext);
 
   if (!value) {
-    throw new Error(`Missing ActionsStoreProvider`);
+    throw new Error(`Missing LocalStoreProvider`);
   }
 
   return value;

--- a/apps/web/modules/io/mocks/mock-network.ts
+++ b/apps/web/modules/io/mocks/mock-network.ts
@@ -5,10 +5,10 @@ import { Entity } from '../../entity';
 import { Triple } from '../../types';
 import { FetchTriplesOptions, INetwork } from '../data-source/network';
 
-export const makeStubTriple = (name: string): Triple => {
+export const makeStubTriple = (name: string, entityId?: string): Triple => {
   return {
     id: name,
-    entityId: name,
+    entityId: entityId ?? name,
     entityName: name,
     attributeId: 'name',
     attributeName: 'Name',

--- a/apps/web/modules/stores/use-editable.ts
+++ b/apps/web/modules/stores/use-editable.ts
@@ -1,7 +1,7 @@
 import { observable } from '@legendapp/state';
 import { useSelector } from '@legendapp/state/react';
 
-const editable$ = observable(false);
+export const editable$ = observable(false);
 
 export const useEditable = () => {
   const editable = useSelector(editable$);


### PR DESCRIPTION
The local store doesn't account for deletions as changes since it only tracks the current state of triples. If a triple was deleted this won't be tracked.