### PR TITLE
fix: add editor heading back to create-entity

### DIFF
--- a/apps/web/modules/components/entity/editable-entity-header.tsx
+++ b/apps/web/modules/components/entity/editable-entity-header.tsx
@@ -1,0 +1,90 @@
+import { useActionsStore } from '~/modules/action';
+import { useAccessControl } from '~/modules/auth/use-access-control';
+import { Entity, useEntityStore } from '~/modules/entity';
+import { useEditable } from '~/modules/stores/use-editable';
+import { Triple } from '~/modules/types';
+import { useEditEvents } from './edit-events';
+import React from 'react';
+import { PageStringField } from './editable-fields';
+import { Spacer } from '~/modules/design-system/spacer';
+import { Truncate } from '~/modules/design-system/truncate';
+import { Text } from '~/modules/design-system/text';
+import { EntityPageMetadataHeader } from '../entity-page/entity-page-metadata-header';
+import { Editor } from '../editor/editor';
+
+export function EditableHeading({
+  spaceId,
+  entityId,
+  name: serverName,
+  triples: serverTriples,
+}: {
+  spaceId: string;
+  entityId: string;
+  name: string;
+  triples: Triple[];
+}) {
+  const { triples: localTriples, update, create, remove } = useEntityStore();
+  const { editable } = useEditable();
+  const { isEditor } = useAccessControl(spaceId);
+  const { actionsFromSpace } = useActionsStore(spaceId);
+
+  const triples = localTriples.length === 0 && actionsFromSpace.length === 0 ? serverTriples : localTriples;
+
+  const nameTriple = Entity.nameTriple(triples);
+  const name = Entity.name(triples) ?? serverName;
+  const types = Entity.types(triples) ?? [];
+
+  const isEditing = editable && isEditor;
+
+  const send = useEditEvents({
+    context: {
+      entityId,
+      spaceId,
+      entityName: name,
+    },
+    api: {
+      create,
+      update,
+      remove,
+    },
+  });
+
+  const onNameChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    send({
+      type: 'EDIT_ENTITY_NAME',
+      payload: {
+        name: e.target.value,
+        triple: nameTriple,
+      },
+    });
+  };
+
+  return (
+    <div>
+      {isEditing ? (
+        <div>
+          <PageStringField variant="mainPage" placeholder="Entity name..." value={name} onChange={onNameChange} />
+          {/* 
+            This height differs from the readable page height due to how we're using an expandable textarea for editing
+            the entity name. We can't perfectly match the height of the normal <Text /> field with the textarea, so we
+            have to manually adjust the spacing here to remove the layout shift.
+          */}
+          <Spacer height={5.5} />
+        </div>
+      ) : (
+        <div>
+          <Truncate maxLines={3} shouldTruncate>
+            <Text as="h1" variant="mainPage">
+              {name}
+            </Text>
+          </Truncate>
+          <Spacer height={12} />
+        </div>
+      )}
+
+      <EntityPageMetadataHeader id={entityId} spaceId={spaceId} types={types} />
+      <Spacer height={40} />
+      <Editor editable={isEditing} />
+    </div>
+  );
+}

--- a/apps/web/modules/spaces/fetch-types.ts
+++ b/apps/web/modules/spaces/fetch-types.ts
@@ -1,0 +1,59 @@
+import { SYSTEM_IDS } from '@geogenesis/ids';
+import { NetworkData } from '../io';
+import { Space } from '../types';
+
+export const fetchSpaceTypeTriples = async (network: NetworkData.INetwork, spaceId: string, pageSize = 0) => {
+  /* Fetch all entities with a type of type (e.g. Person / Place / Claim) */
+
+  const { triples } = await network.fetchTriples({
+    query: '',
+    space: spaceId,
+    skip: 0,
+    first: pageSize,
+    filter: [
+      { field: 'attribute-id', value: SYSTEM_IDS.TYPES },
+      {
+        field: 'linked-to',
+        value: SYSTEM_IDS.SCHEMA_TYPE,
+      },
+    ],
+  });
+
+  return triples;
+};
+
+export const fetchForeignTypeTriples = async (network: NetworkData.INetwork, space: Space, pageSize = 0) => {
+  if (!space.spaceConfigEntityId) {
+    return [];
+  }
+
+  const foreignTypesFromSpaceConfig = await network.fetchTriples({
+    query: '',
+    space: space.id,
+    skip: 0,
+    first: pageSize,
+    filter: [
+      { field: 'entity-id', value: space.spaceConfigEntityId },
+      { field: 'attribute-id', value: SYSTEM_IDS.FOREIGN_TYPES },
+    ],
+  });
+
+  const foreignTypesIds = foreignTypesFromSpaceConfig.triples.map(triple => triple.value.id);
+
+  const foreignTypes = await Promise.all(
+    foreignTypesIds.map(entityId =>
+      network.fetchTriples({
+        query: '',
+        skip: 0,
+        first: pageSize,
+        filter: [
+          { field: 'entity-id', value: entityId },
+          { field: 'attribute-id', value: SYSTEM_IDS.TYPES },
+          { field: 'linked-to', value: SYSTEM_IDS.SCHEMA_TYPE },
+        ],
+      })
+    )
+  );
+
+  return foreignTypes.flatMap(foreignType => foreignType.triples);
+};

--- a/apps/web/modules/spaces/fetch-types.ts
+++ b/apps/web/modules/spaces/fetch-types.ts
@@ -2,7 +2,7 @@ import { SYSTEM_IDS } from '@geogenesis/ids';
 import { NetworkData } from '../io';
 import { Space } from '../types';
 
-export const fetchSpaceTypeTriples = async (network: NetworkData.INetwork, spaceId: string, pageSize = 0) => {
+export const fetchSpaceTypeTriples = async (network: NetworkData.INetwork, spaceId: string, pageSize = 50) => {
   /* Fetch all entities with a type of type (e.g. Person / Place / Claim) */
 
   const { triples } = await network.fetchTriples({
@@ -22,7 +22,7 @@ export const fetchSpaceTypeTriples = async (network: NetworkData.INetwork, space
   return triples;
 };
 
-export const fetchForeignTypeTriples = async (network: NetworkData.INetwork, space: Space, pageSize = 0) => {
+export const fetchForeignTypeTriples = async (network: NetworkData.INetwork, space: Space, pageSize = 50) => {
   if (!space.spaceConfigEntityId) {
     return [];
   }

--- a/apps/web/pages/space/[id]/[entityId].tsx
+++ b/apps/web/pages/space/[id]/[entityId].tsx
@@ -7,7 +7,7 @@ import { useAccessControl } from '~/modules/auth/use-access-control';
 import { EditableEntityPage } from '~/modules/components/entity/editable-entity-page';
 import { ReadableEntityPage } from '~/modules/components/entity/readable-entity-page';
 import { ReferencedByEntity } from '~/modules/components/entity/types';
-import { Entity, EntityStoreProvider, useEntityStore } from '~/modules/entity';
+import { Entity, EntityStoreProvider } from '~/modules/entity';
 import { Params } from '~/modules/params';
 import { NetworkData } from '~/modules/io';
 import { StorageClient } from '~/modules/services/storage';
@@ -17,16 +17,10 @@ import { NavUtils } from '~/modules/utils';
 import { DEFAULT_PAGE_SIZE } from '~/modules/triple';
 import { Value } from '~/modules/value';
 import { TypesStoreProvider } from '~/modules/type/types-store';
-import { Truncate } from '~/modules/design-system/truncate';
-import { Text } from '~/modules/design-system/text';
-import { Spacer } from '~/modules/design-system/spacer';
-import { EntityPageMetadataHeader } from '~/modules/components/entity-page/entity-page-metadata-header';
-import { Editor } from '~/modules/components/editor/editor';
 import { EntityPageCover } from '~/modules/components/entity/entity-page-cover';
 import { EntityPageContentContainer } from '~/modules/components/entity/entity-page-content-container';
-import { PageStringField } from '~/modules/components/entity/editable-fields';
-import { useActionsStore } from '~/modules/action';
-import { useEditEvents } from '~/modules/components/entity/edit-events';
+import { EditableHeading } from '~/modules/components/entity/editable-entity-header';
+import { fetchForeignTypeTriples, fetchSpaceTypeTriples } from '~/modules/spaces/fetch-types';
 
 interface Props {
   triples: Triple[];
@@ -89,83 +83,6 @@ export default function EntityPage(props: Props) {
         </EntityStoreProvider>
       </TypesStoreProvider>
     </>
-  );
-}
-
-function EditableHeading({
-  spaceId,
-  entityId,
-  name: serverName,
-  triples: serverTriples,
-}: {
-  spaceId: string;
-  entityId: string;
-  name: string;
-  triples: Triple[];
-}) {
-  const { triples: localTriples, update, create, remove } = useEntityStore();
-  const { editable } = useEditable();
-  const { isEditor } = useAccessControl(spaceId);
-  const { actionsFromSpace } = useActionsStore(spaceId);
-
-  const triples = localTriples.length === 0 && actionsFromSpace.length === 0 ? serverTriples : localTriples;
-
-  const nameTriple = Entity.nameTriple(triples);
-  const name = Entity.name(triples) ?? serverName;
-  const types = Entity.types(triples) ?? [];
-
-  const isEditing = editable && isEditor;
-
-  const send = useEditEvents({
-    context: {
-      entityId,
-      spaceId,
-      entityName: name,
-    },
-    api: {
-      create,
-      update,
-      remove,
-    },
-  });
-
-  const onNameChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    send({
-      type: 'EDIT_ENTITY_NAME',
-      payload: {
-        name: e.target.value,
-        triple: nameTriple,
-      },
-    });
-  };
-
-  return (
-    <div>
-      {isEditing ? (
-        <div>
-          <PageStringField variant="mainPage" placeholder="Entity name..." value={name} onChange={onNameChange} />
-          {/* 
-            This height differs from the readable page height due to how we're using an expandable textarea for editing
-            the entity name. We can't perfectly match the height of the normal <Text /> field with the textarea, so we
-            have to manually adjust the spacing here to remove the layout shift.
-          */}
-          <Spacer height={5.5} />
-        </div>
-      ) : (
-        <div>
-          <Truncate maxLines={3} shouldTruncate>
-            <Text as="h1" variant="mainPage">
-              {name}
-            </Text>
-          </Truncate>
-          <Spacer height={12} />
-        </div>
-      )}
-
-      <EntityPageMetadataHeader id={entityId} spaceId={spaceId} types={types} />
-      <Spacer height={40} />
-      <Editor editable={isEditing} />
-    </div>
   );
 }
 
@@ -254,60 +171,4 @@ export const getServerSideProps: GetServerSideProps<Props> = async context => {
       spaceTypes: [...spaceTypes, ...foreignSpaceTypes],
     },
   };
-};
-
-export const fetchSpaceTypeTriples = async (network: NetworkData.INetwork, spaceId: string) => {
-  /* Fetch all entities with a type of type (e.g. Person / Place / Claim) */
-
-  const { triples } = await network.fetchTriples({
-    query: '',
-    space: spaceId,
-    skip: 0,
-    first: DEFAULT_PAGE_SIZE,
-    filter: [
-      { field: 'attribute-id', value: SYSTEM_IDS.TYPES },
-      {
-        field: 'linked-to',
-        value: SYSTEM_IDS.SCHEMA_TYPE,
-      },
-    ],
-  });
-
-  return triples;
-};
-
-export const fetchForeignTypeTriples = async (network: NetworkData.INetwork, space: Space) => {
-  if (!space.spaceConfigEntityId) {
-    return [];
-  }
-
-  const foreignTypesFromSpaceConfig = await network.fetchTriples({
-    query: '',
-    space: space.id,
-    skip: 0,
-    first: DEFAULT_PAGE_SIZE,
-    filter: [
-      { field: 'entity-id', value: space.spaceConfigEntityId },
-      { field: 'attribute-id', value: SYSTEM_IDS.FOREIGN_TYPES },
-    ],
-  });
-
-  const foreignTypesIds = foreignTypesFromSpaceConfig.triples.map(triple => triple.value.id);
-
-  const foreignTypes = await Promise.all(
-    foreignTypesIds.map(entityId =>
-      network.fetchTriples({
-        query: '',
-        skip: 0,
-        first: DEFAULT_PAGE_SIZE,
-        filter: [
-          { field: 'entity-id', value: entityId },
-          { field: 'attribute-id', value: SYSTEM_IDS.TYPES },
-          { field: 'linked-to', value: SYSTEM_IDS.SCHEMA_TYPE },
-        ],
-      })
-    )
-  );
-
-  return foreignTypes.flatMap(foreignType => foreignType.triples);
 };

--- a/apps/web/pages/space/[id]/create-entity.tsx
+++ b/apps/web/pages/space/[id]/create-entity.tsx
@@ -49,7 +49,7 @@ export function CreateEntityContent({ spaceId, newId }: { spaceId: string; newId
       <EntityPageCover avatarUrl={avatarUrl} coverUrl={coverUrl} />
       <EntityPageContentContainer>
         <EditableHeading spaceId={spaceId} entityId={newId} name="" triples={triples} />
-        <EditableEntityPage id={newId} name="" spaceId={spaceId} triples={[]} />
+        <EditableEntityPage id={newId} name="" spaceId={spaceId} triples={triples} />
       </EntityPageContentContainer>
     </>
   );

--- a/apps/web/pages/space/[id]/create-entity.tsx
+++ b/apps/web/pages/space/[id]/create-entity.tsx
@@ -1,38 +1,80 @@
 import type { GetServerSideProps } from 'next';
 import { useMemo } from 'react';
+import { EditableHeading } from '~/modules/components/entity/editable-entity-header';
 
 import { EditableEntityPage } from '~/modules/components/entity/editable-entity-page';
-import { EntityStoreProvider } from '~/modules/entity';
+import { EntityPageContentContainer } from '~/modules/components/entity/entity-page-content-container';
+import { EntityPageCover } from '~/modules/components/entity/entity-page-cover';
+import { Entity, EntityStoreProvider, useEntityStore } from '~/modules/entity';
 import { ID } from '~/modules/id';
+import { NetworkData } from '~/modules/io';
+import { Params } from '~/modules/params';
+import { StorageClient } from '~/modules/services/storage';
+import { fetchForeignTypeTriples, fetchSpaceTypeTriples } from '~/modules/spaces/fetch-types';
+import { TypesStoreProvider } from '~/modules/type/types-store';
+import { Space, Triple } from '~/modules/types';
 
 interface Props {
   spaceId: string;
+  space: Space | null;
+  spaceTypes: Triple[];
 }
 
-export default function CreateEntity({ spaceId }: Props) {
+export default function CreateEntity({ spaceId, spaceTypes, space }: Props) {
   const newId = useMemo(() => ID.createEntityId(), []);
 
   return (
-    <EntityStoreProvider
-      id={newId}
-      spaceId={spaceId}
-      initialTriples={[]}
-      initialSchemaTriples={[]}
-      initialBlockTriples={[]}
-      initialBlockIdsTriple={null}
-    >
-      <EditableEntityPage id={newId} name="" spaceId={spaceId} triples={[]} />
-    </EntityStoreProvider>
+    <TypesStoreProvider initialTypes={spaceTypes} space={space}>
+      <EntityStoreProvider
+        id={newId}
+        spaceId={spaceId}
+        initialTriples={[]}
+        initialSchemaTriples={[]}
+        initialBlockTriples={[]}
+        initialBlockIdsTriple={null}
+      >
+        <CreateEntityContent newId={newId} spaceId={spaceId} />
+      </EntityStoreProvider>
+    </TypesStoreProvider>
+  );
+}
+
+export function CreateEntityContent({ spaceId, newId }: { spaceId: string; newId: string }) {
+  const { triples } = useEntityStore();
+  const avatarUrl = Entity.avatar(triples) ?? null;
+  const coverUrl = Entity.cover(triples) ?? null;
+
+  return (
+    <>
+      <EntityPageCover avatarUrl={avatarUrl} coverUrl={coverUrl} />
+      <EntityPageContentContainer>
+        <EditableHeading spaceId={spaceId} entityId={newId} name="" triples={triples} />
+        <EditableEntityPage id={newId} name="" spaceId={spaceId} triples={[]} />
+      </EntityPageContentContainer>
+    </>
   );
 }
 
 export const getServerSideProps: GetServerSideProps<Props> = async context => {
   const spaceId = context.query.id as string;
+  const config = Params.getConfigFromUrl(context.resolvedUrl, context.req.cookies[Params.ENV_PARAM_NAME]);
+
+  const storage = new StorageClient(config.ipfs);
+  const network = new NetworkData.Network(storage, config.subgraph);
+
+  const spaces = await network.fetchSpaces();
+  const space = spaces.find(s => s.id === spaceId) ?? null;
+
+  const [spaceTypes, foreignSpaceTypes] = await Promise.all([
+    fetchSpaceTypeTriples(network, spaceId),
+    space ? fetchForeignTypeTriples(network, space) : [],
+  ]);
 
   return {
     props: {
       spaceId,
-      key: spaceId,
+      space,
+      spaceTypes: [...spaceTypes, ...foreignSpaceTypes],
     },
   };
 };


### PR DESCRIPTION
We previously refactored the heading editor to be lifted above the editable/readabable pages. We forgot to do the same thing for the `create-entity` page. This made it so you couldn't add text editor content when creating a new entity.

This PR also abstracts type fetching to the `spaces` module so `space/create-entity`, `/space/[id]` and `/space/[id]/[entityId]` can all consume the same functionality.