### PR TITLE
fix: opengraph images

### DIFF
--- a/apps/web/pages/space/[id]/[entityId].tsx
+++ b/apps/web/pages/space/[id]/[entityId].tsx
@@ -56,10 +56,8 @@ export default function EntityPage(props: Props) {
         <title>{props.name ?? props.id}</title>
         <meta property="og:title" content={props.name} />
         <meta property="og:url" content={`https://geobrowser.io${NavUtils.toEntity(props.spaceId, props.id)}`} />
-        {props.serverCoverUrl && <meta property="og:image" content={props.serverCoverUrl} />}
-        {props.serverCoverUrl && (
-          <meta name="twitter:image" content="https://www.geobrowser.io/static/geo-social-image.png" />
-        )}
+        {props.serverCoverUrl && <meta property="og:image" content={props.serverAvatarUrl ?? props.serverCoverUrl} />}
+        {props.serverCoverUrl && <meta name="twitter:image" content={props.serverAvatarUrl ?? props.serverCoverUrl} />}
         {props.description && <meta property="description" content={props.description} />}
         {props.description && <meta property="og:description" content={props.description} />}
         {props.description && <meta name="twitter:description" content={props.description} />}


### PR DESCRIPTION
This PR adjusts the social media card preview images to use the avatar (if available) for entity pages.