### PR TITLE
fix: ux issues

### DIFF
--- a/apps/web/modules/components/editor/blocks/table/table-block-store.tsx
+++ b/apps/web/modules/components/editor/blocks/table/table-block-store.tsx
@@ -84,10 +84,14 @@ export class TableBlockStore {
     this.blockEntity$ = makeOptionalComputed(
       null,
       computed(() => {
+        // @TODO restore an alternate hack or implement the updated MergedData methods
+
         // HACK: This is a hack to rerun this computed when actions change.
         // In the future we should pass in the actions as a dependency to
         // the MergedData method calls to trigger any re-runs of computeds.
-        this.ActionsStore.allActions$.get();
+
+        // ↓ hack temporarily disabled due to UX issues
+        // this.ActionsStore.allActions$.get();
 
         return this.MergedData.fetchEntity(entityId);
       })

--- a/apps/web/modules/components/editor/blocks/table/table-block.tsx
+++ b/apps/web/modules/components/editor/blocks/table/table-block.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react';
 import Link from 'next/link';
+import { SYSTEM_IDS } from '@geogenesis/ids';
 import { Trigger, Root, Content, Portal } from '@radix-ui/react-popover';
 import { motion, AnimatePresence } from 'framer-motion';
+import produce from 'immer';
 import BoringAvatar from 'boring-avatars';
 
 import { TableBlockFilter, useTableBlock } from './table-block-store';
@@ -18,12 +20,10 @@ import { Spacer } from '~/modules/design-system/spacer';
 import { Text } from '~/modules/design-system/text';
 import { IconButton, SmallButton } from '~/modules/design-system/button';
 import { valueTypes } from '~/modules/value-types';
-import { SYSTEM_IDS } from '@geogenesis/ids';
 import { Entity as IEntity, TripleValueType } from '~/modules/types';
 import { Input } from '~/modules/design-system/input';
 import { Select } from '~/modules/design-system/select';
 import { TextButton } from '~/modules/design-system/text-button';
-import produce from 'immer';
 import { ResultContent, ResultsList } from '~/modules/components/entity/autocomplete/results-list';
 import { useAutocomplete } from '~/modules/search';
 import { useSpaces } from '~/modules/spaces/use-spaces';
@@ -240,6 +240,9 @@ function EditableTitle({ spaceId }: { spaceId: string }) {
   const { isEditor } = useAccessControl(spaceId);
   const { blockEntity } = useTableBlock();
 
+  // @TODO remove console.info
+  console.info('blockEntity:', blockEntity);
+
   const onNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     TableBlockSdk.upsertName({ name: e.currentTarget.value, blockEntity, api: { update, create } });
   };
@@ -248,6 +251,7 @@ function EditableTitle({ spaceId }: { spaceId: string }) {
     <input
       onBlur={onNameChange}
       defaultValue={blockEntity?.name ?? undefined}
+      value={blockEntity?.name ?? ''}
       placeholder="Enter a name for this table..."
       className="w-full appearance-none text-smallTitle text-text outline-none placeholder:text-grey-03"
     />

--- a/apps/web/modules/components/entity/entity-page-cover.tsx
+++ b/apps/web/modules/components/entity/entity-page-cover.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import cx from 'classnames';
 import Image from 'next/image';
 
 type EntityPageCoverProps = {
@@ -12,7 +13,7 @@ export const EntityPageCover = ({ avatarUrl, coverUrl, space = false }: EntityPa
 
   if (coverUrl) {
     return (
-      <div className="relative mx-auto mb-20 h-[320px] w-full max-w-[1192px]">
+      <div className={cx('relative mx-auto h-[320px] w-full max-w-[1192px]', !space && avatarUrl ? 'mb-20' : 'mb-8')}>
         <div className="relative h-full w-full overflow-hidden rounded bg-grey-01">
           <Image src={coverUrl} layout="fill" objectFit="cover" priority className="h-full w-full" alt="" />
         </div>

--- a/apps/web/modules/design-system/chip.tsx
+++ b/apps/web/modules/design-system/chip.tsx
@@ -11,7 +11,7 @@ interface LinkableChipProps {
 }
 
 const linkableChipStyles = cva(
-  'text-metadataMedium rounded-sm shadow-inner shadow-text min-h-[1.5rem] px-2 py-1 inline-flex items-center bg-white text-left hover:cursor-pointer leading-none hover:text-ctaPrimary hover:bg-ctaTertiary hover:shadow-ctaPrimary focus:cursor-pointer focus:text-ctaPrimary focus:shadow-inner-lg focus:bg-ctaTertiary focus:shadow-ctaPrimary'
+  'text-metadataMedium rounded-sm shadow-inner shadow-text min-h-[1.5rem] px-2 py-1 inline-flex items-center bg-white text-left hover:cursor-pointer leading-none hover:text-ctaPrimary hover:bg-ctaTertiary hover:shadow-ctaPrimary focus:cursor-pointer focus:text-ctaPrimary focus:shadow-inner-lg focus:bg-ctaTertiary focus:shadow-ctaPrimary break-all'
 );
 
 export function LinkableChip({ href, children }: LinkableChipProps) {
@@ -31,7 +31,7 @@ interface ChipButtonProps {
 }
 
 const deletableChipStyles = cva(
-  'items-center gap-1 text-metadataMedium leading-none text-left rounded-sm min-h-[1.5rem] py-1 inline-flex items-center px-2 text-text bg-white shadow-inner shadow-text hover:bg-ctaTertiary hover:text-ctaPrimary hover:shadow-ctaPrimary focus:bg-ctaTertiary focus:text-ctaPrimary focus:shadow-inner-lg focus:shadow-ctaPrimary hover:cursor-pointer group',
+  'items-center gap-1 text-metadataMedium leading-none text-left rounded-sm min-h-[1.5rem] py-1 inline-flex items-center px-2 text-text bg-white shadow-inner shadow-text hover:bg-ctaTertiary hover:text-ctaPrimary hover:shadow-ctaPrimary focus:bg-ctaTertiary focus:text-ctaPrimary focus:shadow-inner-lg focus:shadow-ctaPrimary hover:cursor-pointer group break-all',
   {
     variants: {
       isWarning: {


### PR DESCRIPTION
This PR implements the following fixes:

- table names no longer revert on blur
- pages have reduced space below covers when no avatar is present
- chips with long content now wrap to multiple lines