### PR TITLE
fix: table crash

### DIFF
--- a/apps/web/modules/components/editor/blocks/table/table.tsx
+++ b/apps/web/modules/components/editor/blocks/table/table.tsx
@@ -191,13 +191,12 @@ export const TableBlockTable = ({ rows, space, columns }: Props) => {
               <EmptyTableText>No results found</EmptyTableText>
             </tr>
           )}
-          {table.getRowModel().rows.map(row => {
+          {table.getRowModel().rows.map((row, index: number) => {
             const cells = row.getVisibleCells();
-
-            const entityId = cells[0].getValue<Cell>()?.entityId;
+            const entityId = cells?.[0]?.getValue<Cell>()?.entityId;
 
             return (
-              <tr key={entityId} className="hover:bg-bg">
+              <tr key={entityId ?? index} className="hover:bg-bg">
                 {cells.map(cell => {
                   const cellId = `${row.original.id}-${cell.column.id}`;
                   const firstTriple = cell.getValue<Cell>()?.triples[0];

--- a/apps/web/modules/components/entity-table/entity-table.tsx
+++ b/apps/web/modules/components/entity-table/entity-table.tsx
@@ -192,13 +192,12 @@ export const EntityTable = ({ rows, space, columns }: Props) => {
               <EmptyTableText>No results found</EmptyTableText>
             </tr>
           )}
-          {table.getRowModel().rows.map(row => {
+          {table.getRowModel().rows.map((row, index: number) => {
             const cells = row.getVisibleCells();
-
-            const entityId = cells[0].getValue<Cell>()?.entityId;
+            const entityId = cells?.[0]?.getValue<Cell>()?.entityId;
 
             return (
-              <tr key={entityId} className="hover:bg-bg">
+              <tr key={entityId ?? index} className="hover:bg-bg">
                 {cells.map(cell => {
                   const cellId = `${row.original.id}-${cell.column.id}`;
                   const firstTriple = cell.getValue<Cell>()?.triples[0];


### PR DESCRIPTION
This PR resolves an error caused by the creation of new entities that match the filter of a client-side rendered table block.