### PR TITLE
fix: history dropdown

### DIFF
--- a/apps/web/modules/components/history/history-item.tsx
+++ b/apps/web/modules/components/history/history-item.tsx
@@ -35,14 +35,11 @@ export function HistoryItem({ changeCount, createdAt, createdBy, name }: Props) 
   // an address – date format.
   const versionName = name ?? `${formatShortAddress(createdBy.id)} – ${formattedLastEditedDate}`;
 
-  // Names might be very long, so we truncate to make it work with the menu UI
-  const truncatedVersionName = versionName.length > 36 ? `${versionName.slice(0, 36)}...` : versionName;
-
   return (
     <div className="bg-white px-2 py-3 text-grey-04 hover:bg-bg hover:text-text">
       <div className="flex items-center justify-between">
-        <Text as="h1" variant="metadataMedium" className="mb-2">
-          {truncatedVersionName}
+        <Text as="h1" variant="metadataMedium" className="mb-2 !text-sm">
+          {versionName}
         </Text>
       </div>
       <div className="flex items-center justify-between ">


### PR DESCRIPTION
This PR revises the history dropdown menu to replace truncation of long names with a smaller font and text wrapping.