### PR TITLE
fix: incorrect initial table loading state

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,4 +19,6 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      - run: pnpm build
+
       - run: pnpm test

--- a/apps/web/modules/components/editor/blocks/table/table-block-store.tsx
+++ b/apps/web/modules/components/editor/blocks/table/table-block-store.tsx
@@ -147,10 +147,93 @@ export class TableBlockStore {
             abortController: this.abortController,
           });
 
+          /**
+           * Aggregate columns from local and server columns.
+           */
+          const columns = EntityTable.columnsFromActions(
+            this.ActionsStore.actions$.get()[spaceId],
+            serverColumns,
+            selectedType?.entityId
+          );
+
+          /**
+           * Aggregate data for the rows from local and server entities.
+           *
+           * There are several edge-cases we need to handle in order to correctly merge local changes
+           * with server data in the entity table:
+           * 1. An entity is created locally and is given the selected type
+           * 2. An entity is edited locally and is given the selected type
+           * 3. A type is created locally and an entity is given the new type
+           *
+           * Since the table aggregation code expects triples, we may end up in a situation where
+           * the type for an entity has changed, but the name hasn't. In this case there is no local
+           * version of the name triple, so we need to fetch it along with any other triples the table
+           * needs to render the columnSchema.
+           */
+          const changedEntitiesIdsFromAnotherType = pipe(
+            this.ActionsStore.actions$.get()[spaceId],
+            actions => Triple.fromActions(actions, []),
+            triples => Entity.entitiesFromTriples(triples),
+            A.filter(e => e.types.some(t => t.id === selectedType?.entityId)),
+            A.map(t => t.id)
+          );
+
+          // Fetch any entities that exist already remotely that have been changed locally
+          // and have the selected type to make sure we have all of the triples necessary
+          // to represent the entity in the table.
+          //
+          // e.g., We add Type A to Entity A. When we render the Type A table, we need
+          // _all_ of the triples for Entity A, not just the ones that have changed locally.
+          //
+          // This will return null if the entity we're fetching does not exist remotely.
+          // i.e., the entity was created locally and has not been published to the server.
+          const maybeServerEntitiesChangedLocally = await Promise.all(
+            changedEntitiesIdsFromAnotherType.map(id => this.api.fetchEntity(id))
+          );
+
+          const serverEntitiesChangedLocally = maybeServerEntitiesChangedLocally.flatMap(e => (e ? [e] : []));
+
+          const serverEntityTriples = serverRows.flatMap(t => t.triples);
+
+          const entitiesCreatedOrChangedLocally = pipe(
+            this.ActionsStore.actions$.get(),
+            actions => Entity.mergeActionsWithEntities(actions, Entity.entitiesFromTriples(serverEntityTriples)),
+            A.filter(e => e.types.some(t => t.id === selectedType?.entityId))
+          );
+
+          const localEntitiesIds = new Set(entitiesCreatedOrChangedLocally.map(e => e.id));
+          const serverEntitiesChangedLocallyIds = new Set(serverEntitiesChangedLocally.map(e => e.id));
+
+          // Filter out any server rows that have been changed locally
+          const filteredServerRows = serverEntityTriples.filter(
+            sr => !localEntitiesIds.has(sr.entityId) && !serverEntitiesChangedLocallyIds.has(sr.entityId)
+          );
+
+          const entities = Entity.entitiesFromTriples([
+            // These are entities that were created locally and have the selected type
+            ...entitiesCreatedOrChangedLocally.flatMap(e => e.triples),
+
+            // These are entities that have a new type locally and may exist on the server.
+            // We need to fetch all triples associated with this entity in order to correctly
+            // populate the table.
+            ...serverEntitiesChangedLocally.flatMap(e => e.triples),
+
+            // These are entities that have been fetched from the server and have the selected type.
+            // They are deduped from the local changes above.
+            ...filteredServerRows,
+          ]);
+
+          // Make sure we only generate rows for entities that have the selected type
+          const entitiesWithSelectedType = entities.filter(e => e.types.some(t => t.id === selectedType?.entityId));
+
+          const { rows } = EntityTable.fromColumnsAndRows(spaceId, entitiesWithSelectedType, columns);
+
+          this.isLoading$.set(false);
+
           return {
-            columns: serverColumns,
-            rows: serverRows.slice(0, PAGE_SIZE),
-            hasNextPage: serverRows.length > PAGE_SIZE,
+            columns,
+            rows: rows.slice(0, PAGE_SIZE),
+            hasNextPage: rows.length > PAGE_SIZE,
           };
         } catch (e) {
           if (e instanceof Error && e.name === 'AbortError') {
@@ -164,92 +247,15 @@ export class TableBlockStore {
       })
     );
 
-    this.columns$ = computed(() => {
-      const { columns } = networkData$.get();
-      return EntityTable.columnsFromActions(this.ActionsStore.actions$.get()[spaceId], columns, selectedType?.entityId);
+    this.rows$ = computed(() => {
+      const { rows } = networkData$.get();
+      return rows;
     });
 
-    this.rows$ = makeOptionalComputed(
-      [],
-      computed(async () => {
-        const columns = this.columns$.get();
-        const { rows: serverRows } = networkData$.get();
-
-        /**
-         * There are several edge-cases we need to handle in order to correctly merge local changes
-         * with server data in the entity table:
-         * 1. An entity is created locally and is given the selected type
-         * 2. An entity is edited locally and is given the selected type
-         * 3. A type is created locally and an entity is given the new type
-         *
-         * Since the table aggregation code expects triples, we may end up in a situation where
-         * the type for an entity has changed, but the name hasn't. In this case there is no local
-         * version of the name triple, so we need to fetch it along with any other triples the table
-         * needs to render the columnSchema.
-         */
-        const changedEntitiesIdsFromAnotherType = pipe(
-          this.ActionsStore.actions$.get()[spaceId],
-          actions => Triple.fromActions(actions, []),
-          triples => Entity.entitiesFromTriples(triples),
-          A.filter(e => e.types.some(t => t.id === selectedType?.entityId)),
-          A.map(t => t.id)
-        );
-
-        // Fetch any entities that exist already remotely that have been changed locally
-        // and have the selected type to make sure we have all of the triples necessary
-        // to represent the entity in the table.
-        //
-        // e.g., We add Type A to Entity A. When we render the Type A table, we need
-        // _all_ of the triples for Entity A, not just the ones that have changed locally.
-        //
-        // This will return null if the entity we're fetching does not exist remotely.
-        // i.e., the entity was created locally and has not been published to the server.
-        const maybeServerEntitiesChangedLocally = await Promise.all(
-          changedEntitiesIdsFromAnotherType.map(id => this.api.fetchEntity(id))
-        );
-
-        const serverEntitiesChangedLocally = maybeServerEntitiesChangedLocally.flatMap(e => (e ? [e] : []));
-
-        const serverEntityTriples = serverRows.flatMap(t => t.triples);
-
-        const entitiesCreatedOrChangedLocally = pipe(
-          this.ActionsStore.actions$.get(),
-          actions => Entity.mergeActionsWithEntities(actions, Entity.entitiesFromTriples(serverEntityTriples)),
-          A.filter(e => e.types.some(t => t.id === selectedType?.entityId))
-        );
-
-        const localEntitiesIds = new Set(entitiesCreatedOrChangedLocally.map(e => e.id));
-        const serverEntitiesChangedLocallyIds = new Set(serverEntitiesChangedLocally.map(e => e.id));
-
-        // Filter out any server rows that have been changed locally
-        const filteredServerRows = serverEntityTriples.filter(
-          sr => !localEntitiesIds.has(sr.entityId) && !serverEntitiesChangedLocallyIds.has(sr.entityId)
-        );
-
-        const entities = Entity.entitiesFromTriples([
-          // These are entities that were created locally and have the selected type
-          ...entitiesCreatedOrChangedLocally.flatMap(e => e.triples),
-
-          // These are entities that have a new type locally and may exist on the server.
-          // We need to fetch all triples associated with this entity in order to correctly
-          // populate the table.
-          ...serverEntitiesChangedLocally.flatMap(e => e.triples),
-
-          // These are entities that have been fetched from the server and have the selected type.
-          // They are deduped from the local changes above.
-          ...filteredServerRows,
-        ]);
-
-        // Make sure we only generate rows for entities that have the selected type
-        const entitiesWithSelectedType = entities.filter(e => e.types.some(t => t.id === selectedType?.entityId));
-
-        const { rows } = EntityTable.fromColumnsAndRows(spaceId, entitiesWithSelectedType, columns);
-
-        this.isLoading$.set(false);
-
-        return rows;
-      })
-    );
+    this.columns$ = computed(() => {
+      const { columns } = networkData$.get();
+      return columns;
+    });
 
     this.unpublishedColumns$ = computed(() => {
       return EntityTable.columnsFromActions(this.ActionsStore.actions$.get()[spaceId], [], selectedType?.entityId);

--- a/apps/web/modules/components/editor/blocks/table/table-block.tsx
+++ b/apps/web/modules/components/editor/blocks/table/table-block.tsx
@@ -45,6 +45,8 @@ export function TableBlock({ spaceId }: Props) {
     type,
   } = useTableBlock();
 
+  console.log('isLoading in TableBlock', isLoading);
+
   const [isMenuOpen, setIsMenuOpen] = React.useState(false);
   const [isFilterOpen, setIsFilterOpen] = React.useState(false);
   const isEditing = useUserIsEditing(spaceId);


### PR DESCRIPTION
Since legendstate computed evaluates asynchronously, we were initially setting the result of the table construction as `false` when the `rows` computed executed. We _then_ started evaluating the result of network data, triggering the loading state back to `true`.

We now do all row and column evaluation within the networkData computed callback so table construction for rows and columns happens synchronously, resulting in the correct loading state.