### PR TITLE
fix: table block name sync on blur

### DIFF
--- a/apps/web/modules/components/editor/command-items.tsx
+++ b/apps/web/modules/components/editor/command-items.tsx
@@ -34,6 +34,8 @@ export const tableCommandItem: CommandSuggestionItem = {
         },
       })
       .createParagraphNear()
+      .blur()
+      .focus()
       .run();
   },
 };


### PR DESCRIPTION
This PR automatically populates the initial table block name.