### PR TITLE
feat: delete entity

### DIFF
--- a/apps/web/integration/pages/space/[id]/[entityId].test.tsx
+++ b/apps/web/integration/pages/space/[id]/[entityId].test.tsx
@@ -26,12 +26,15 @@ describe('Entity page', () => {
           id="1"
           name="Banana"
           spaceId="1"
-          versions={[]}
           triples={[]}
-          schemaTriples={[]}
           referencedByEntities={[]}
           blockTriples={[]}
           blockIdsTriple={null}
+          description={null}
+          serverAvatarUrl={null}
+          serverCoverUrl={null}
+          space={null}
+          spaceTypes={[]}
         />
       </Providers>
     );
@@ -46,12 +49,15 @@ describe('Entity page', () => {
           id="1"
           name="Banana"
           spaceId="1"
-          versions={[]}
           triples={[genericAttribute]}
-          schemaTriples={[]}
           referencedByEntities={[]}
           blockTriples={[]}
           blockIdsTriple={null}
+          description={null}
+          serverAvatarUrl={null}
+          serverCoverUrl={null}
+          space={null}
+          spaceTypes={[]}
         />
       </Providers>
     );
@@ -66,12 +72,15 @@ describe('Entity page', () => {
           id="1"
           name="Banana"
           spaceId="1"
-          versions={[]}
           triples={[{ ...genericAttribute, attributeName: null }]}
-          schemaTriples={[]}
           referencedByEntities={[]}
           blockTriples={[]}
           blockIdsTriple={null}
+          description={null}
+          serverAvatarUrl={null}
+          serverCoverUrl={null}
+          space={null}
+          spaceTypes={[]}
         />
       </Providers>
     );
@@ -86,12 +95,15 @@ describe('Entity page', () => {
           id="1"
           name="Banana"
           spaceId="1"
-          versions={[]}
           triples={[]}
-          schemaTriples={[]}
           referencedByEntities={[]}
           blockTriples={[]}
           blockIdsTriple={null}
+          description={null}
+          serverAvatarUrl={null}
+          serverCoverUrl={null}
+          space={null}
+          spaceTypes={[]}
         />
       </Providers>
     );
@@ -106,9 +118,7 @@ describe('Entity page', () => {
           id="1"
           name="Banana"
           spaceId="1"
-          versions={[]}
           triples={[]}
-          schemaTriples={[]}
           referencedByEntities={[
             {
               id: '1',
@@ -132,6 +142,11 @@ describe('Entity page', () => {
           ]}
           blockTriples={[]}
           blockIdsTriple={null}
+          description={null}
+          serverAvatarUrl={null}
+          serverCoverUrl={null}
+          space={null}
+          spaceTypes={[]}
         />
       </Providers>
     );

--- a/apps/web/modules/components/entity-page/entity-page-context-menu.tsx
+++ b/apps/web/modules/components/entity-page/entity-page-context-menu.tsx
@@ -1,39 +1,83 @@
 import * as React from 'react';
 import { Icon } from '~/modules/design-system/icon';
 import { Menu } from '~/modules/design-system/menu';
+import { EntityPageDeleteEntityModal } from './entity-page-delete-entity-modal';
+import { useEntityStore } from '~/modules/entity';
+import { batch } from '@legendapp/state';
+import { useUserIsEditing } from '~/modules/hooks/use-user-is-editing';
 
 interface Props {
-  children: React.ReactNode;
+  entityId: string;
+  spaceId: string;
 }
 
-export function EntityPageContextMenu({ children }: Props) {
-  const [open, onOpenChange] = React.useState(false);
+export function EntityPageContextMenu({ entityId, spaceId }: Props) {
+  const [isMenuOpen, onMenuOpenChange] = React.useState(false);
+  const [isModalOpen, setIsModalOpen] = React.useState(false);
+  const isEditing = useUserIsEditing(spaceId);
+  const { triples, schemaTriples, remove } = useEntityStore();
+
+  const onCopyId = async () => {
+    try {
+      await navigator.clipboard.writeText(entityId);
+      onMenuOpenChange(false);
+    } catch (err) {
+      console.error('Failed to copy entity ID in: ', entityId);
+    }
+  };
+
+  const onDelete = () => {
+    batch(() => {
+      triples.forEach(t => remove(t));
+      schemaTriples.forEach(t => remove(t));
+    });
+
+    setIsModalOpen(false);
+    onMenuOpenChange(false);
+  };
+
+  const onModalOpenChange = (isOpen: boolean) => {
+    // if (isOpen) onMenuOpenChange(false);
+    setIsModalOpen(isOpen);
+  };
 
   return (
     <Menu
       className="w-[160px]"
-      open={open}
-      onOpenChange={onOpenChange}
+      open={isMenuOpen}
+      onOpenChange={onMenuOpenChange}
       trigger={<Icon icon="context" color="grey-04" />}
       side="bottom"
     >
-      {children}
+      <EntityPageContextMenuItem isMenuOpen={isMenuOpen} isModalOpen={isModalOpen}>
+        <button className="h-full w-full px-2 py-2" onClick={onCopyId}>
+          Copy ID
+        </button>
+      </EntityPageContextMenuItem>
+      {isEditing && (
+        <EntityPageContextMenuItem isMenuOpen={isMenuOpen} isModalOpen={isModalOpen}>
+          <EntityPageDeleteEntityModal
+            open={isModalOpen}
+            onOpenChange={onModalOpenChange}
+            onDelete={onDelete}
+            trigger={<button className="h-full w-full px-2 py-2 text-red-01">Delete entity</button>}
+          />
+        </EntityPageContextMenuItem>
+      )}
     </Menu>
   );
 }
 
 interface EntityPageContextMenuItemProps {
   children: React.ReactNode;
-  onClick: () => void;
+  isMenuOpen: boolean;
+  isModalOpen: boolean;
 }
 
-export function EntityPageContextMenuItem({ children, onClick }: EntityPageContextMenuItemProps) {
+function EntityPageContextMenuItem({ children, isMenuOpen, isModalOpen }: EntityPageContextMenuItemProps) {
   return (
-    <button
-      onClick={onClick}
-      className="w-full divide-y divide-divider bg-white px-2 py-2 text-button text-grey-04 hover:bg-bg hover:text-text"
-    >
+    <div className={`w-full divide-y divide-divider bg-white text-button text-grey-04 hover:bg-bg hover:text-text`}>
       {children}
-    </button>
+    </div>
   );
 }

--- a/apps/web/modules/components/entity-page/entity-page-context-menu.tsx
+++ b/apps/web/modules/components/entity-page/entity-page-context-menu.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import { Icon } from '~/modules/design-system/icon';
+import { Menu } from '~/modules/design-system/menu';
+
+interface Props {
+  children: React.ReactNode;
+}
+
+export function EntityPageContextMenu({ children }: Props) {
+  const [open, onOpenChange] = React.useState(false);
+
+  return (
+    <Menu
+      className="w-[160px]"
+      open={open}
+      onOpenChange={onOpenChange}
+      trigger={<Icon icon="context" color="grey-04" />}
+      side="bottom"
+    >
+      {children}
+    </Menu>
+  );
+}
+
+interface EntityPageContextMenuItemProps {
+  children: React.ReactNode;
+  onClick: () => void;
+}
+
+export function EntityPageContextMenuItem({ children, onClick }: EntityPageContextMenuItemProps) {
+  return (
+    <button
+      onClick={onClick}
+      className="w-full divide-y divide-divider bg-white px-2 py-2 text-button text-grey-04 hover:bg-bg hover:text-text"
+    >
+      {children}
+    </button>
+  );
+}

--- a/apps/web/modules/components/entity-page/entity-page-context-menu.tsx
+++ b/apps/web/modules/components/entity-page/entity-page-context-menu.tsx
@@ -50,7 +50,8 @@ export function EntityPageContextMenu({ entityId, spaceId }: Props) {
       side="bottom"
     >
       <EntityPageContextMenuItem isMenuOpen={isMenuOpen} isModalOpen={isModalOpen}>
-        <button className="h-full w-full px-2 py-2" onClick={onCopyId}>
+        <button className="flex h-full w-full items-center gap-2 px-2 py-2" onClick={onCopyId}>
+          <Icon icon="copy" />
           Copy ID
         </button>
       </EntityPageContextMenuItem>
@@ -60,7 +61,12 @@ export function EntityPageContextMenu({ entityId, spaceId }: Props) {
             open={isModalOpen}
             onOpenChange={onModalOpenChange}
             onDelete={onDelete}
-            trigger={<button className="h-full w-full px-2 py-2 text-red-01">Delete entity</button>}
+            trigger={
+              <button className="flex h-full w-full items-center gap-2 px-2 py-2 text-red-01">
+                <Icon icon="trash" />
+                Delete entity
+              </button>
+            }
           />
         </EntityPageContextMenuItem>
       )}

--- a/apps/web/modules/components/entity-page/entity-page-context-menu.tsx
+++ b/apps/web/modules/components/entity-page/entity-page-context-menu.tsx
@@ -37,7 +37,6 @@ export function EntityPageContextMenu({ entityId, spaceId }: Props) {
   };
 
   const onModalOpenChange = (isOpen: boolean) => {
-    // if (isOpen) onMenuOpenChange(false);
     setIsModalOpen(isOpen);
   };
 
@@ -49,14 +48,14 @@ export function EntityPageContextMenu({ entityId, spaceId }: Props) {
       trigger={<Icon icon="context" color="grey-04" />}
       side="bottom"
     >
-      <EntityPageContextMenuItem isMenuOpen={isMenuOpen} isModalOpen={isModalOpen}>
+      <EntityPageContextMenuItem>
         <button className="flex h-full w-full items-center gap-2 px-2 py-2" onClick={onCopyId}>
           <Icon icon="copy" />
           Copy ID
         </button>
       </EntityPageContextMenuItem>
       {isEditing && (
-        <EntityPageContextMenuItem isMenuOpen={isMenuOpen} isModalOpen={isModalOpen}>
+        <EntityPageContextMenuItem>
           <EntityPageDeleteEntityModal
             open={isModalOpen}
             onOpenChange={onModalOpenChange}
@@ -76,11 +75,9 @@ export function EntityPageContextMenu({ entityId, spaceId }: Props) {
 
 interface EntityPageContextMenuItemProps {
   children: React.ReactNode;
-  isMenuOpen: boolean;
-  isModalOpen: boolean;
 }
 
-function EntityPageContextMenuItem({ children, isMenuOpen, isModalOpen }: EntityPageContextMenuItemProps) {
+function EntityPageContextMenuItem({ children }: EntityPageContextMenuItemProps) {
   return (
     <div className={`w-full divide-y divide-divider bg-white text-button text-grey-04 hover:bg-bg hover:text-text`}>
       {children}

--- a/apps/web/modules/components/entity-page/entity-page-delete-entity-modal.tsx
+++ b/apps/web/modules/components/entity-page/entity-page-delete-entity-modal.tsx
@@ -10,24 +10,24 @@ interface Props {
 }
 
 export function EntityPageDeleteEntityModal({ trigger }: Props) {
+  const onCancel = () => {};
+
   return (
     <Root>
       <Trigger asChild>{trigger}</Trigger>
       <Portal>
-        <Overlay className="data-[state=open]:animate-overlayShow fixed inset-0 bg-text opacity-20" />
-        <Content className="fixed top-[25%] left-[50%] max-h-[85vh] w-[90vw] max-w-[455px] translate-x-[-50%] translate-y-[-25%] rounded bg-white p-4 focus:outline-none">
+        <Overlay className="fixed inset-0 bg-text opacity-20" />
+        <Content className="fixed top-[25%] left-[50%] max-h-[85vh] w-[90vw] max-w-[455px] translate-x-[-50%] translate-y-[-25%] rounded bg-white p-4 shadow-card focus:outline-none">
           <h1 className="text-center text-metadataMedium">Delete entity</h1>
           <Spacer height={16} />
           <p>
-            This will delete all attributes and values assigned to this entity. Deleting this entity may have unexpected
-            side-effects as any entities referencing this entity will be broken.
+            This will delete all triples in this entity. Deleting this entity may have unexpected side-effects as any
+            entities referencing this entity will be broken.
           </p>
           <Spacer height={32} />
           <div className="flex items-center justify-between">
             <button className="text-button text-grey-04 transition-colors duration-75 hover:text-text">Cancel</button>
-            <Button variant="secondary" icon="trash">
-              Delete
-            </Button>
+            <Button variant="tertiary">Delete</Button>
           </div>
         </Content>
       </Portal>

--- a/apps/web/modules/components/entity-page/entity-page-delete-entity-modal.tsx
+++ b/apps/web/modules/components/entity-page/entity-page-delete-entity-modal.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { motion } from 'framer-motion';
 import { Content, Overlay, Portal, Root, Trigger } from '@radix-ui/react-dialog';
 import { Spacer } from '~/modules/design-system/spacer';
 import { Button } from '~/modules/design-system/button';
@@ -17,27 +18,52 @@ export function EntityPageDeleteEntityModal({ trigger, open, onOpenChange, onDel
     <Root open={open} onOpenChange={onOpenChange}>
       <Trigger asChild>{trigger}</Trigger>
       <Portal>
-        <Overlay className="fixed inset-0 z-10 bg-text opacity-20" />
-        <Content className="fixed top-[25%] left-[50%] z-100 max-h-[85vh] w-[90vw] max-w-[455px] translate-x-[-50%] translate-y-[-25%] rounded bg-white p-4 shadow-card focus:outline-none">
-          <h1 className="text-center text-metadataMedium">Delete entity</h1>
-          <Spacer height={16} />
-          <p>
-            This will delete all triples in this entity. Deleting this entity may have unexpected side-effects as any
-            entities referencing this entity will be broken.
-          </p>
-          <Spacer height={32} />
-          <div className="flex items-center justify-between">
-            <button
-              className="text-button text-grey-04 transition-colors duration-75 hover:text-text"
-              onClick={onCancel}
+        {open && (
+          <>
+            <motion.div
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{
+                duration: 0.1,
+                ease: 'easeInOut',
+              }}
             >
-              Cancel
-            </button>
-            <Button variant="tertiary" onClick={onDelete}>
-              Delete
-            </Button>
-          </div>
-        </Content>
+              <Overlay className="fixed inset-0 z-10 bg-text opacity-20" />
+            </motion.div>
+            <motion.div
+              initial={{ opacity: 0, scale: 0.95, y: 10 }}
+              animate={{ opacity: 1, scale: 1, y: 0 }}
+              exit={{ opacity: 0, scale: 0.95, y: 0 }}
+              transition={{
+                duration: 0.125,
+                ease: 'easeInOut',
+              }}
+              className="fixed left-[50%] top-[25%] z-100"
+            >
+              <Content className="fixed max-h-[85vh] w-[455px] translate-x-[-50%] rounded bg-white p-4 shadow-card focus:outline-none">
+                <h1 className="text-center text-metadataMedium">Delete entity</h1>
+                <Spacer height={16} />
+                <p>
+                  This will delete all triples in this entity. Deleting this entity may have unexpected side-effects as
+                  any entities referencing this entity will be broken.
+                </p>
+                <Spacer height={32} />
+                <div className="flex items-center justify-between">
+                  <button
+                    className="text-button text-grey-04 transition-colors duration-75 hover:text-text"
+                    onClick={onCancel}
+                  >
+                    Cancel
+                  </button>
+                  <Button variant="tertiary" onClick={onDelete}>
+                    Delete
+                  </Button>
+                </div>
+              </Content>
+            </motion.div>
+          </>
+        )}
       </Portal>
     </Root>
   );

--- a/apps/web/modules/components/entity-page/entity-page-delete-entity-modal.tsx
+++ b/apps/web/modules/components/entity-page/entity-page-delete-entity-modal.tsx
@@ -4,20 +4,21 @@ import { Spacer } from '~/modules/design-system/spacer';
 import { Button } from '~/modules/design-system/button';
 
 interface Props {
-  // open: boolean;
-  // onOpenChange: (open: boolean) => void;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
   trigger: React.ReactNode;
+  onDelete: () => void;
 }
 
-export function EntityPageDeleteEntityModal({ trigger }: Props) {
-  const onCancel = () => {};
+export function EntityPageDeleteEntityModal({ trigger, open, onOpenChange, onDelete }: Props) {
+  const onCancel = () => onOpenChange(false);
 
   return (
-    <Root>
+    <Root open={open} onOpenChange={onOpenChange}>
       <Trigger asChild>{trigger}</Trigger>
       <Portal>
-        <Overlay className="fixed inset-0 bg-text opacity-20" />
-        <Content className="fixed top-[25%] left-[50%] max-h-[85vh] w-[90vw] max-w-[455px] translate-x-[-50%] translate-y-[-25%] rounded bg-white p-4 shadow-card focus:outline-none">
+        <Overlay className="fixed inset-0 z-10 bg-text opacity-20" />
+        <Content className="fixed top-[25%] left-[50%] z-100 max-h-[85vh] w-[90vw] max-w-[455px] translate-x-[-50%] translate-y-[-25%] rounded bg-white p-4 shadow-card focus:outline-none">
           <h1 className="text-center text-metadataMedium">Delete entity</h1>
           <Spacer height={16} />
           <p>
@@ -26,8 +27,15 @@ export function EntityPageDeleteEntityModal({ trigger }: Props) {
           </p>
           <Spacer height={32} />
           <div className="flex items-center justify-between">
-            <button className="text-button text-grey-04 transition-colors duration-75 hover:text-text">Cancel</button>
-            <Button variant="tertiary">Delete</Button>
+            <button
+              className="text-button text-grey-04 transition-colors duration-75 hover:text-text"
+              onClick={onCancel}
+            >
+              Cancel
+            </button>
+            <Button variant="tertiary" onClick={onDelete}>
+              Delete
+            </Button>
           </div>
         </Content>
       </Portal>

--- a/apps/web/modules/components/entity-page/entity-page-delete-entity-modal.tsx
+++ b/apps/web/modules/components/entity-page/entity-page-delete-entity-modal.tsx
@@ -46,7 +46,7 @@ export function EntityPageDeleteEntityModal({ trigger, open, onOpenChange, onDel
                 <Spacer height={16} />
                 <p>
                   This will delete all triples in this entity. Deleting this entity may have unexpected side-effects as
-                  any entities referencing this entity will be broken.
+                  any other entities referencing this entity will be broken.
                 </p>
                 <Spacer height={32} />
                 <div className="flex items-center justify-between">

--- a/apps/web/modules/components/entity-page/entity-page-delete-entity-modal.tsx
+++ b/apps/web/modules/components/entity-page/entity-page-delete-entity-modal.tsx
@@ -1,0 +1,36 @@
+import * as React from 'react';
+import { Content, Overlay, Portal, Root, Trigger } from '@radix-ui/react-dialog';
+import { Spacer } from '~/modules/design-system/spacer';
+import { Button } from '~/modules/design-system/button';
+
+interface Props {
+  // open: boolean;
+  // onOpenChange: (open: boolean) => void;
+  trigger: React.ReactNode;
+}
+
+export function EntityPageDeleteEntityModal({ trigger }: Props) {
+  return (
+    <Root>
+      <Trigger asChild>{trigger}</Trigger>
+      <Portal>
+        <Overlay className="data-[state=open]:animate-overlayShow fixed inset-0 bg-text opacity-20" />
+        <Content className="fixed top-[25%] left-[50%] max-h-[85vh] w-[90vw] max-w-[455px] translate-x-[-50%] translate-y-[-25%] rounded bg-white p-4 focus:outline-none">
+          <h1 className="text-center text-metadataMedium">Delete entity</h1>
+          <Spacer height={16} />
+          <p>
+            This will delete all attributes and values assigned to this entity. Deleting this entity may have unexpected
+            side-effects as any entities referencing this entity will be broken.
+          </p>
+          <Spacer height={32} />
+          <div className="flex items-center justify-between">
+            <button className="text-button text-grey-04 transition-colors duration-75 hover:text-text">Cancel</button>
+            <Button variant="secondary" icon="trash">
+              Delete
+            </Button>
+          </div>
+        </Content>
+      </Portal>
+    </Root>
+  );
+}

--- a/apps/web/modules/components/entity-page/entity-page-metadata-header.tsx
+++ b/apps/web/modules/components/entity-page/entity-page-metadata-header.tsx
@@ -13,8 +13,7 @@ import { Context } from '~/modules/design-system/icons/context';
 import { Close } from '~/modules/design-system/icons/close';
 import { Text } from '~/modules/design-system/text';
 import { Action as IAction } from '~/modules/types';
-import { EntityPageContextMenu, EntityPageContextMenuItem } from './entity-page-context-menu';
-import { EntityPageDeleteEntityModal } from './entity-page-delete-entity-modal';
+import { EntityPageContextMenu } from './entity-page-context-menu';
 
 interface EntityPageMetadataHeaderProps {
   id: string;
@@ -30,14 +29,6 @@ export function EntityPageMetadataHeader({ id, spaceId, types }: EntityPageMetad
   });
 
   const isLoadingVersions = !versions || isLoading;
-
-  const onCopyId = async () => {
-    try {
-      await navigator.clipboard.writeText(id);
-    } catch (err) {
-      console.error('Failed to copy: ', err);
-    }
-  };
 
   return (
     <div className="flex items-center justify-between text-text">
@@ -60,16 +51,7 @@ export function EntityPageMetadataHeader({ id, spaceId, types }: EntityPageMetad
             />
           ))}
         </HistoryPanel>
-        <EntityPageContextMenu>
-          <EntityPageContextMenuItem onClick={onCopyId}>Copy ID</EntityPageContextMenuItem>
-          <EntityPageContextMenuItem
-            onClick={() => {
-              //
-            }}
-          >
-            <EntityPageDeleteEntityModal trigger={<button className="text-red-01">Delete entity</button>} />
-          </EntityPageContextMenuItem>
-        </EntityPageContextMenu>
+        <EntityPageContextMenu entityId={id} spaceId={spaceId} />
       </div>
     </div>
   );

--- a/apps/web/modules/components/entity-page/entity-page-metadata-header.tsx
+++ b/apps/web/modules/components/entity-page/entity-page-metadata-header.tsx
@@ -3,17 +3,18 @@ import Link from 'next/link';
 import { useRouter } from 'next/router';
 
 import { EntityType } from '~/modules/types';
-import { HistoryItem, HistoryLoading, HistoryPanel } from '../history';
+import { HistoryItem, HistoryPanel } from '../history';
 import { EntityPageTypeChip } from './entity-page-type-chip';
 import { Action } from '~/modules/action';
 import { useQuery } from '@tanstack/react-query';
 import { Services } from '~/modules/services';
-import { HistoryEmpty } from '../history/history-empty';
 import { Menu } from '~/modules/design-system/menu';
 import { Context } from '~/modules/design-system/icons/context';
 import { Close } from '~/modules/design-system/icons/close';
 import { Text } from '~/modules/design-system/text';
 import { Action as IAction } from '~/modules/types';
+import { EntityPageContextMenu, EntityPageContextMenuItem } from './entity-page-context-menu';
+import { EntityPageDeleteEntityModal } from './entity-page-delete-entity-modal';
 
 interface EntityPageMetadataHeaderProps {
   id: string;
@@ -30,6 +31,14 @@ export function EntityPageMetadataHeader({ id, spaceId, types }: EntityPageMetad
 
   const isLoadingVersions = !versions || isLoading;
 
+  const onCopyId = async () => {
+    try {
+      await navigator.clipboard.writeText(id);
+    } catch (err) {
+      console.error('Failed to copy: ', err);
+    }
+  };
+
   return (
     <div className="flex items-center justify-between text-text">
       <ul className="flex items-center gap-1">
@@ -39,17 +48,29 @@ export function EntityPageMetadataHeader({ id, spaceId, types }: EntityPageMetad
           </li>
         ))}
       </ul>
-      <HistoryPanel isLoading={isLoadingVersions} isEmpty={versions?.length === 0}>
-        {versions?.map(v => (
-          <HistoryItem
-            key={v.id}
-            changeCount={Action.getChangeCount(v.actions)}
-            createdAt={v.createdAt}
-            createdBy={v.createdBy}
-            name={v.name}
-          />
-        ))}
-      </HistoryPanel>
+      <div className="flex items-center gap-3">
+        <HistoryPanel isLoading={isLoadingVersions} isEmpty={versions?.length === 0}>
+          {versions?.map(v => (
+            <HistoryItem
+              key={v.id}
+              changeCount={Action.getChangeCount(v.actions)}
+              createdAt={v.createdAt}
+              createdBy={v.createdBy}
+              name={v.name}
+            />
+          ))}
+        </HistoryPanel>
+        <EntityPageContextMenu>
+          <EntityPageContextMenuItem onClick={onCopyId}>Copy ID</EntityPageContextMenuItem>
+          <EntityPageContextMenuItem
+            onClick={() => {
+              //
+            }}
+          >
+            <EntityPageDeleteEntityModal trigger={<button className="text-red-01">Delete entity</button>} />
+          </EntityPageContextMenuItem>
+        </EntityPageContextMenu>
+      </div>
     </div>
   );
 }

--- a/apps/web/modules/components/entity/editable-entity-header.tsx
+++ b/apps/web/modules/components/entity/editable-entity-header.tsx
@@ -36,11 +36,13 @@ export function EditableHeading({
 
   const triples = localTriples.length === 0 && actionsFromSpace.length === 0 ? serverTriples : localTriples;
 
-  const nameTriple = Entity.nameTriple(triples);
-  const name = Entity.name(triples) ?? serverName;
-  const types = Entity.types(triples) ?? [];
-
   const isEditing = editable && isEditor;
+  const nameTriple = Entity.nameTriple(triples);
+  // Default to the server name if there is no local name only when in browse mode.
+  // Otherwise leave it empty when in edit mode.
+  const name = isEditing ? Entity.name(triples) ?? '' : serverName;
+  console.log('name', name);
+  const types = Entity.types(triples) ?? [];
 
   const send = useEditEvents({
     context: {

--- a/apps/web/modules/components/entity/editable-entity-page.tsx
+++ b/apps/web/modules/components/entity/editable-entity-page.tsx
@@ -26,22 +26,13 @@ import { Services } from '~/modules/services';
 interface Props {
   triples: TripleType[];
   id: string;
-  name: string;
   spaceId: string;
   typeId?: string | null;
   filterId?: string | null;
   filterValue?: string | null;
 }
 
-export function EditableEntityPage({
-  id,
-  name: serverName,
-  spaceId,
-  triples: serverTriples,
-  typeId,
-  filterId,
-  filterValue,
-}: Props) {
+export function EditableEntityPage({ id, spaceId, triples: serverTriples, typeId, filterId, filterValue }: Props) {
   const {
     triples: localTriples,
     schemaTriples,
@@ -58,8 +49,7 @@ export function EditableEntityPage({
   // We hydrate the local editable store with the triples from the server. While it's hydrating
   // we can fallback to the server triples so we render real data and there's no layout shift.
   const triples = localTriples.length === 0 && actionsFromSpace.length === 0 ? serverTriples : localTriples;
-
-  const name = Entity.name(triples) ?? serverName;
+  const name = Entity.name(triples) ?? '';
 
   const send = useEditEvents({
     context: {

--- a/apps/web/modules/design-system/chip.tsx
+++ b/apps/web/modules/design-system/chip.tsx
@@ -31,7 +31,7 @@ interface ChipButtonProps {
 }
 
 const deletableChipStyles = cva(
-  'items-center gap-1 text-metadataMedium leading-none text-left rounded-sm min-h-[1.5rem] py-1 inline-flex items-center px-2 text-text bg-white shadow-inner shadow-text hover:bg-ctaTertiary hover:text-ctaPrimary hover:shadow-ctaPrimary focus:bg-ctaTertiary focus:text-ctaPrimary focus:shadow-inner-lg focus:shadow-ctaPrimary hover:cursor-pointer group break-words',
+  'items-center gap-1 text-metadataMedium leading-none text-left rounded-sm min-h-[1.5rem] py-1 inline-flex px-2 text-text bg-white shadow-inner shadow-text hover:bg-ctaTertiary hover:text-ctaPrimary hover:shadow-ctaPrimary focus:bg-ctaTertiary focus:text-ctaPrimary focus:shadow-inner-lg focus:shadow-ctaPrimary hover:cursor-pointer group break-words',
   {
     variants: {
       isWarning: {

--- a/apps/web/modules/entity/entity-store/entity-store.ts
+++ b/apps/web/modules/entity/entity-store/entity-store.ts
@@ -5,7 +5,7 @@ import { Editor, generateHTML, generateJSON, JSONContent } from '@tiptap/core';
 import showdown from 'showdown';
 import pluralize from 'pluralize';
 
-import { ActionsStore } from '~/modules/action';
+import { Action, ActionsStore } from '~/modules/action';
 import { tiptapExtensions } from '~/modules/components/editor/editor';
 import { htmlToPlainText } from '~/modules/components/editor/editor-utils';
 import { ID } from '~/modules/id';
@@ -119,6 +119,16 @@ export class EntityStore implements IEntityStore {
       const localBlockIdsForEntity = Triple.fromActions(ActionsStore.actions$.get()[spaceId], [])
         .filter(t => t.entityId === id)
         .find(t => t.attributeId === SYSTEM_IDS.BLOCKS);
+
+      // If there previously was a published blockIdsTriple, but it was deleted locally, we want to
+      // favor the local version of the blockIdsTriple.
+      const isLocalBlockTripleDeleted = Action.squashChanges(ActionsStore.allActions$.get()).find(
+        a => a.type === 'deleteTriple' && a.entityId === id && a.attributeId === SYSTEM_IDS.BLOCKS
+      );
+
+      if (isLocalBlockTripleDeleted) {
+        return null;
+      }
 
       // Favor the local version of the blockIdsTriple if it exists
       return localBlockIdsForEntity ?? initialBlockIdsTriple;

--- a/apps/web/modules/onboarding/dialog.tsx
+++ b/apps/web/modules/onboarding/dialog.tsx
@@ -17,7 +17,6 @@ import { useOnboarding } from './use-onboarding';
 type Steps = 'wallet' | 'name' | 'avatar' | 'success';
 
 export const OnboardingDialog = observer(() => {
-  const { isOnboardingVisible } = useOnboarding();
   const { address } = useAccount();
 
   const [name, setName] = useState('');

--- a/apps/web/pages/space/[id]/create-entity.tsx
+++ b/apps/web/pages/space/[id]/create-entity.tsx
@@ -74,7 +74,6 @@ export function CreateEntityContent({ spaceId, newId, typeId, filterId, filterVa
         <EditableHeading spaceId={spaceId} entityId={newId} name="" triples={triples} />
         <EditableEntityPage
           id={newId}
-          name=""
           spaceId={spaceId}
           typeId={typeId}
           filterId={filterId}


### PR DESCRIPTION
This PR adds a context menu for entity-wide actions on the entity page. The first two are
- Copy Id: Copies the ID of the entity
- Delete Entity: Deletes all of the entities' triples