### PR TITLE
feat: only filter entity values in search by attribute id

### DIFF
--- a/apps/web/modules/components/entity-table/editable-entity-table-cell.tsx
+++ b/apps/web/modules/components/entity-table/editable-entity-table-cell.tsx
@@ -168,7 +168,9 @@ export const EditableEntityTableCell = memo(function EditableEntityTableCell({
 
           <EntityAutocompleteDialog
             onDone={entity => createEntityTripleWithValue(attributeId, entity)}
-            entityValueIds={entityValueTriples.map(t => t.value.id)}
+            entityValueIds={entityValueTriples
+              .filter(triple => triple.attributeId === attributeId)
+              .map(triple => triple.value.id)}
             allowedTypes={typesToFilter}
           />
         </>

--- a/apps/web/modules/components/entity/autocomplete/entity-autocomplete.tsx
+++ b/apps/web/modules/components/entity/autocomplete/entity-autocomplete.tsx
@@ -44,6 +44,8 @@ export function EntityAutocompleteDialog({ onDone, entityValueIds, allowedTypes 
   const entityItemIdsSet = new Set(entityValueIds);
   const { spaces } = useSpaces();
 
+  // Space entity id: 1d5d0c2a-db23-466c-a0b0-9abe879df457
+
   // Using a controlled state to enable exit animations with framer-motion
   const [open, setOpen] = useState(false);
 

--- a/apps/web/modules/components/entity/editable-entity-page.tsx
+++ b/apps/web/modules/components/entity/editable-entity-page.tsx
@@ -462,7 +462,9 @@ function EntityAttributes({
               {isEntityGroup && !isEmptyEntity && (
                 <EntityAutocompleteDialog
                   onDone={entity => addEntityValue(attributeId, entity)}
-                  entityValueIds={entityValueTriples.map(triple => triple.value.id)}
+                  entityValueIds={entityValueTriples
+                    .filter(triple => triple.attributeId === attributeId)
+                    .map(triple => triple.value.id)}
                   allowedTypes={relationTypesIds}
                 />
               )}


### PR DESCRIPTION
We were not filtering by attribute id, so all entity values were being passed to the autocomplete dialog. This resulted in incorrectly including relational values that weren't part of the Foreign Types attribute.