### PR TITLE
fix: ordering of table rows being re-sorted incorrectly client side

### DIFF
--- a/apps/web/modules/io/data-source/network.ts
+++ b/apps/web/modules/io/data-source/network.ts
@@ -769,9 +769,7 @@ export class Network implements INetwork {
         };
       } = await response.json();
 
-      const sortedResults = sortSearchResultsByRelevance(json.data.geoEntities, []);
-
-      return sortedResults.map(result => {
+      return json.data.geoEntities.map(result => {
         const triples = fromNetworkTriples(result.entityOf);
         const nameTriple = Entity.nameTriple(triples);
 


### PR DESCRIPTION
Previously we were applying client-side sorting similarly to how we do when we fetch startsWith and contains for fetchEntities. This wasn't applicable to table rows and was incorrectly re-ordering content during pagination.