### PR TITLE
fix: ordering of table rows being re-sorted incorrectly client side

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - uses: pnpm/action-setup@v2
         with:

--- a/.github/workflows/test-subgraph.yml
+++ b/.github/workflows/test-subgraph.yml
@@ -1,7 +1,9 @@
 name: Subgraph Integration Test
 
-on: push
-
+on:
+  pull_request:
+    branches:
+      - master
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,12 @@
 name: Unit Tests
 
-on: push
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   build:

--- a/apps/web/modules/io/data-source/network.ts
+++ b/apps/web/modules/io/data-source/network.ts
@@ -769,9 +769,7 @@ export class Network implements INetwork {
         };
       } = await response.json();
 
-      const sortedResults = sortSearchResultsByRelevance(json.data.geoEntities, []);
-
-      return sortedResults.map(result => {
+      return json.data.geoEntities.map(result => {
         const triples = fromNetworkTriples(result.entityOf);
         const nameTriple = Entity.nameTriple(triples);
 


### PR DESCRIPTION
Previously we were applying client-side sorting similarly to how we do when we fetch startsWith and contains for fetchEntities. This wasn't applicable to table rows and was incorrectly re-ordering content during pagination.