### PR TITLE
fix: schema build ordering

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: pnpm/action-setup@v2
         with:
-          version: 7
+          version: 7.30.5
 
       - uses: actions/setup-node@v3
         with:

--- a/packages/action-schema/package.json
+++ b/packages/action-schema/package.json
@@ -12,7 +12,7 @@
     "test:wasm": "yarn build:wasm && ts-node test/index.ts",
     "test:ts": "vitest run",
     "clean": "rimraf build dist assembly/generated",
-    "build": "pnpm run build:ts && pnpm run build:wasm",
+    "build": "pnpm run build:wasm && pnpm run build:ts",
     "build:wasm": "asc assembly/index.ts -o build/test.wasm -t build/test.wat --debug --runtime stub --exportRuntime --bindings raw --disableWarning 235",
     "build:ts": "npx tsc"
   },

--- a/packages/contracts/src/deploy.ts
+++ b/packages/contracts/src/deploy.ts
@@ -3,7 +3,7 @@ import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
 import { Contract } from 'ethers'
 import { ethers, upgrades } from 'hardhat'
 
-import { Space, FakeSpaceV2, PermissionlessSpace } from '../build/types'
+import { Space, PermissionlessSpace } from '../build/types'
 
 type DeployOptions = {
   debug?: true

--- a/packages/contracts/tsconfig.json
+++ b/packages/contracts/tsconfig.json
@@ -8,6 +8,6 @@
     "declaration": true,
     "resolveJsonModule": true
   },
-  "include": ["./test", "./src", "./build/types"],
+  "include": ["./build/types"],
   "files": ["./hardhat.config.ts"]
 }

--- a/packages/contracts/tsconfig.json
+++ b/packages/contracts/tsconfig.json
@@ -8,6 +8,6 @@
     "declaration": true,
     "resolveJsonModule": true
   },
-  "include": ["./scripts", "./test", "./src", "./build/types"],
+  "include": ["./test", "./src", "./build/types"],
   "files": ["./hardhat.config.ts"]
 }


### PR DESCRIPTION
We sometimes get build errors when running tests as the ordering of the build step for the action-schema isn't deterministic.