### PR TITLE
feat: show access control on space page

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
       - master
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/apps/web/modules/components/entity/editable-entity-header.tsx
+++ b/apps/web/modules/components/entity/editable-entity-header.tsx
@@ -31,7 +31,7 @@ export function EditableHeading({
 }) {
   const { triples: localTriples, update, create, remove } = useEntityStore();
   const { editable } = useEditable();
-  const { isEditor } = useAccessControl(spaceId);
+  const { isEditor, isAdmin, isEditorController } = useAccessControl(spaceId);
   const { actionsFromSpace } = useActionsStore(spaceId);
 
   const triples = localTriples.length === 0 && actionsFromSpace.length === 0 ? serverTriples : localTriples;
@@ -80,11 +80,29 @@ export function EditableHeading({
         </div>
       ) : (
         <div>
-          <Truncate maxLines={3} shouldTruncate>
-            <Text as="h1" variant="mainPage">
-              {name}
-            </Text>
-          </Truncate>
+          <div className="flex items-center">
+            <Truncate maxLines={3} shouldTruncate>
+              <Text as="h1" variant="mainPage">
+                {name}
+              </Text>
+            </Truncate>
+            {isEditing && (
+              <div className="absolute top-0 right-0 flex items-center gap-2">
+                {(isAdmin || isEditorController) && (
+                  <Link href={NavUtils.toAdmin(spaceId)} passHref>
+                    <a>
+                      <Button variant="secondary">Access control</Button>
+                    </a>
+                  </Link>
+                )}
+                <Link href={NavUtils.toCreateEntity(spaceId)} passHref>
+                  <a>
+                    <Button icon="create">New entity</Button>
+                  </a>
+                </Link>
+              </div>
+            )}
+          </div>
           <Spacer height={12} />
         </div>
       )}
@@ -95,15 +113,6 @@ export function EditableHeading({
       )}
       <Spacer height={40} />
       <Editor editable={isEditing} />
-      {space && isEditing && (
-        <div className="absolute top-0 right-0">
-          <Link href={NavUtils.toCreateEntity(spaceId)} passHref>
-            <a>
-              <Button icon="create">New entity</Button>
-            </a>
-          </Link>
-        </div>
-      )}
     </div>
   );
 }

--- a/apps/web/modules/components/entity/editable-entity-header.tsx
+++ b/apps/web/modules/components/entity/editable-entity-header.tsx
@@ -80,18 +80,20 @@ export function EditableHeading({
         </div>
       ) : (
         <div>
-          <div className="flex items-center">
+          <div className="flex items-center justify-between">
             <Truncate maxLines={3} shouldTruncate>
               <Text as="h1" variant="mainPage">
                 {name}
               </Text>
             </Truncate>
             {isEditing && (
-              <div className="absolute top-0 right-0 flex items-center gap-2">
+              <div className="flex shrink-0 items-center gap-2">
                 {(isAdmin || isEditorController) && (
                   <Link href={NavUtils.toAdmin(spaceId)} passHref>
                     <a>
-                      <Button variant="secondary">Access control</Button>
+                      <Button className="shrink" variant="secondary">
+                        Access control
+                      </Button>
                     </a>
                   </Link>
                 )}

--- a/apps/web/modules/components/space/space-navbar.tsx
+++ b/apps/web/modules/components/space/space-navbar.tsx
@@ -22,8 +22,10 @@ const SpaceActions = ({ spaceId }: Props) => {
       {(isEditor || isAdmin || isEditorController) && editable && (
         <div className="flex w-full items-center justify-between">
           {(isEditorController || isAdmin) && (
-            <Link href={`/space/${spaceId}/access-control`}>
-              <Button variant="secondary">Devvy Admin</Button>
+            <Link href={NavUtils.toAdmin(spaceId)}>
+              <a>
+                <Button variant="secondary">Access control</Button>
+              </a>
             </Link>
           )}
           {isAdmin && isEditor && <Spacer width={8} />}

--- a/apps/web/modules/design-system/button.tsx
+++ b/apps/web/modules/design-system/button.tsx
@@ -28,7 +28,7 @@ const buttonClassNames = (className = '') =>
           tertiary: 'text-white bg-text border-white shadow-none',
           done: 'text-text bg-green border-green',
           // using a variant for disabled to overwrite the background/text styles
-          disabled: ' text-grey-03 bg-divider hover:bg-divider border-transparent',
+          disabled: 'text-grey-03 bg-divider hover:bg-divider border-transparent',
         },
         small: {
           false: 'px-3 py-2 gap-2 text-[1.0625rem] leading-[1.125rem] text-button',

--- a/apps/web/modules/design-system/button.tsx
+++ b/apps/web/modules/design-system/button.tsx
@@ -14,18 +14,10 @@ type ButtonProps = React.ComponentPropsWithoutRef<'button'> & {
   small?: boolean;
 };
 
-export const Button = forwardRef(function Button(
-  { variant = 'primary', icon, small = false, className = '', disabled = false, children, ...rest }: ButtonProps,
-  ref: React.ForwardedRef<HTMLButtonElement>
-) {
-  const buttonClassNames = cva(
-    [
-      'relative inline-flex justify-center items-center border rounded-sm focus:outline-none transition ease-in-out duration-200 tracking-[-0.17px] font-medium shadow-light',
-      !small
-        ? 'px-3 py-2 gap-2 text-[1.0625rem] leading-[1.125rem] text-button'
-        : 'px-1.5 py-1 gap-1.5 text-xs leading-none text-smallButton',
-      !disabled ? 'cursor-pointer' : 'cursor-not-allowed',
-    ],
+const buttonClassNames = (className = '') =>
+  cva(
+    `relative inline-flex justify-center items-center border rounded-sm focus:outline-none transition ease-in-out duration-200 tracking-[-0.17px] font-medium shadow-light ${className}`,
+
     {
       variants: {
         variant: {
@@ -35,18 +27,37 @@ export const Button = forwardRef(function Button(
             '!text-grey-04 hover:!text-text bg-white hover:bg-bg border-grey-02 hover:border-text focus:border-text focus:shadow-inner-text shadow-button',
           tertiary: 'text-white bg-text border-white shadow-none',
           done: 'text-text bg-green border-green',
-          disabled: 'text-grey-03 bg-divider hover:bg-divider border-transparent',
+          // using a variant for disabled to overwrite the background/text styles
+          disabled: ' text-grey-03 bg-divider hover:bg-divider border-transparent',
         },
+        small: {
+          false: 'px-3 py-2 gap-2 text-[1.0625rem] leading-[1.125rem] text-button',
+          true: 'px-1.5 py-1 gap-1.5 text-xs leading-none text-smallButton',
+        },
+        disabled: {
+          true: 'cursor-not-allowed',
+          false: 'cursor-pointer',
+        },
+      },
+
+      defaultVariants: {
+        variant: 'primary',
+        small: false,
+        disabled: false,
       },
     }
   );
 
+export const Button = forwardRef(function Button(
+  { variant = 'primary', icon, small = false, className = '', disabled = false, children, ...rest }: ButtonProps,
+  ref: React.ForwardedRef<HTMLButtonElement>
+) {
   const iconColor = !small && variant === 'secondary' ? 'ctaPrimary' : undefined;
 
   return (
     <button
       ref={ref}
-      className={buttonClassNames({ className, variant: !disabled ? variant : 'disabled' })}
+      className={buttonClassNames(className)({ variant: !disabled ? variant : 'disabled', disabled, small })}
       disabled={disabled}
       {...rest}
     >

--- a/apps/web/modules/utils.ts
+++ b/apps/web/modules/utils.ts
@@ -28,6 +28,7 @@ export function titleCase(string: string): string {
 }
 
 export const NavUtils = {
+  toAdmin: (spaceId: string) => `/space/${spaceId}/access-control`,
   toSpace: (spaceId: string) => `/space/${spaceId}`,
   toEntity: (spaceId: string, entityId: string) => `/space/${spaceId}/${entityId}`,
   toCreateEntity: (spaceId: string, typeId?: string | null, filterId?: string | null, filterValue?: string | null) => {


### PR DESCRIPTION
The access control button should be visible on the space page if there is a space configuration set. Previously it was only visible on the entities/triples routes.
<img width="1284" alt="CleanShot 2023-06-27 at 16 44 59@2x" src="https://github.com/geobrowser/geogenesis/assets/26263630/7c5501da-cb22-45fd-bdc3-b5af7e919530">
