### PR TITLE
fix: infinite loop in type dropdown

### DIFF
--- a/apps/web/modules/search/autocomplete.ts
+++ b/apps/web/modules/search/autocomplete.ts
@@ -79,7 +79,7 @@ export function useAutocomplete({ allowedTypes, filter }: AutocompleteOptions = 
 
   // @TODO(baiirun): fix this
   const memoizedAllowedTypes = useMemo(() => allowedTypes, [JSON.stringify(allowedTypes)]);
-  const memoizedFilter = useMemo(() => filter, [filter]);
+  const memoizedFilter = useMemo(() => filter, [JSON.stringify(filter)]);
 
   const autocomplete = useMemo(() => {
     return new EntityAutocomplete({


### PR DESCRIPTION
Ideally we solve this by passing stable references into useAutocomplete, but it's okay memoizing dependencies internally if the dependencies are small. Libraries like react-query do this.