### PR TITLE
fix: entity created toast should use app router

### DIFF
--- a/apps/web/modules/components/entity/autocomplete/entity-created-toast.tsx
+++ b/apps/web/modules/components/entity/autocomplete/entity-created-toast.tsx
@@ -1,4 +1,6 @@
-import { useRouter } from 'next/router';
+'use client';
+
+import { useRouter } from 'next/navigation';
 import { SmallButton } from '~/modules/design-system/button';
 import { Icon } from '~/modules/design-system/icon';
 import { useToast } from '~/modules/hooks/use-toast';


### PR DESCRIPTION
Previously it was using the page router and wasn't migrated when we introduced next 13.