### PR TITLE
fix: use max width for avatar dropdown

### DIFF
--- a/apps/web/partials/navbar/navbar-actions.tsx
+++ b/apps/web/partials/navbar/navbar-actions.tsx
@@ -62,7 +62,7 @@ export function NavbarActions({ spaceId }: Props) {
         }
         open={open}
         onOpenChange={onOpenChange}
-        className="w-[10rem]"
+        className="max-w-[165px]"
       >
         <AvatarMenuItem disabled>
           <div className="flex items-center gap-2 grayscale">


### PR DESCRIPTION
`width` CSS property does not have ordering precedence with conflicting `width` definitions. `max-width` overwrites `width`.