### PR TITLE
fix: filter local table rows by table filter

### DIFF
--- a/apps/web/core/merged/merged.ts
+++ b/apps/web/core/merged/merged.ts
@@ -241,6 +241,9 @@ export class Merged implements IMergedDataSource {
     const entitiesWithAppliedGraphqlFilters = entitiesWithSelectedType.filter(entity => {
       for (const filter of filterState) {
         return entity.triples.some(triple => {
+          // @HACK: We special-case `space` since it's not an attribute:value in an entity but is a property
+          // attached to a triple in the subgraph. Once we represents entities across multiple spaces
+          // this filter likely won't make sense anymore.
           if (filter.columnId === 'space') {
             return entity.nameTripleSpace === filter.value;
           }

--- a/apps/web/core/merged/merged.ts
+++ b/apps/web/core/merged/merged.ts
@@ -161,6 +161,11 @@ export class Merged implements IMergedDataSource {
   rows = async (options: Parameters<typeof fetchRows>[0], columns: Column[], selectedTypeEntityId?: string) => {
     const serverRows = await fetchRows(options);
 
+    const filterState = await TableBlockSdk.createFiltersFromGraphQLString(
+      options.params.filter ?? '',
+      async id => await this.fetchEntity({ id, endpoint: options.params.endpoint })
+    );
+
     /**
      * Aggregate data for the rows from local and server entities.
      *
@@ -198,64 +203,92 @@ export class Merged implements IMergedDataSource {
       changedEntitiesIdsFromAnotherType.map(id => this.subgraph.fetchEntity({ id, endpoint: options.params.endpoint }))
     );
 
-    const serverEntitiesChangedLocally = maybeServerEntitiesChangedLocally.flatMap(e => (e ? [e] : []));
+    const serverEntitiesChangedLocally = maybeServerEntitiesChangedLocally
+      .flatMap(e => (e ? [e] : []))
+      .filter(entity => {
+        for (const filter of filterState) {
+          return entity.triples.some(triple => {
+            // @HACK: We special-case `space` since it's not an attribute:value in an entity but is a property
+            // attached to a triple in the subgraph. Once we represents entities across multiple spaces
+            // this filter likely won't make sense anymore.
+            if (filter.columnId === 'space') {
+              return entity.nameTripleSpace === filter.value;
+            }
+
+            return triple.attributeId === filter.columnId && filterValue(triple.value, filter.value);
+          });
+        }
+
+        return true;
+      });
 
     const serverEntityTriples = serverRows.flatMap(t => t.triples);
 
     const entitiesCreatedOrChangedLocally = pipe(
       this.store.actions$.get(),
       actions => Entity.mergeActionsWithEntities(actions, Entity.entitiesFromTriples(serverEntityTriples)),
-      A.filter(e => e.types.some(t => t.id === selectedTypeEntityId))
+      A.filter(e => e.types.some(t => t.id === selectedTypeEntityId)),
+      A.filter(entity => {
+        for (const filter of filterState) {
+          return entity.triples.some(triple => {
+            // @HACK: We special-case `space` since it's not an attribute:value in an entity but is a property
+            // attached to a triple in the subgraph. Once we represents entities across multiple spaces
+            // this filter likely won't make sense anymore.
+            if (filter.columnId === 'space') {
+              return entity.nameTripleSpace === filter.value;
+            }
+
+            return triple.attributeId === filter.columnId && filterValue(triple.value, filter.value);
+          });
+        }
+
+        return true;
+      })
     );
 
     const localEntitiesIds = new Set(entitiesCreatedOrChangedLocally.map(e => e.id));
     const serverEntitiesChangedLocallyIds = new Set(serverEntitiesChangedLocally.map(e => e.id));
 
     // Filter out any server rows that have been changed locally
-    const filteredServerRows = serverEntityTriples.filter(
-      sr => !localEntitiesIds.has(sr.entityId) && !serverEntitiesChangedLocallyIds.has(sr.entityId)
+    const filteredServerRows = serverRows.filter(
+      sr => !localEntitiesIds.has(sr.id) && !serverEntitiesChangedLocallyIds.has(sr.id)
     );
 
-    const entities = Entity.entitiesFromTriples([
+    const entities = [
       // These are entities that were created locally and have the selected type
-      ...entitiesCreatedOrChangedLocally.flatMap(e => e.triples),
+      ...entitiesCreatedOrChangedLocally,
 
       // These are entities that have a new type locally and may exist on the server.
       // We need to fetch all triples associated with this entity in order to correctly
       // populate the table.
-      ...serverEntitiesChangedLocally.flatMap(e => e.triples),
+      ...serverEntitiesChangedLocally,
 
       // These are entities that have been fetched from the server and have the selected type.
       // They are deduped from the local changes above.
       ...filteredServerRows,
-    ]);
+    ];
 
     // Make sure we only generate rows for entities that have the selected type
     const entitiesWithSelectedType = entities.filter(e => e.types.some(t => t.id === selectedTypeEntityId));
 
-    const filterState = await TableBlockSdk.createFiltersFromGraphQLString(
-      options.params.filter ?? '',
-      async id => await this.fetchEntity({ id, endpoint: options.params.endpoint })
-    );
+    // const entitiesWithAppliedGraphqlFilters = entitiesWithSelectedType.filter(entity => {
+    //   for (const filter of filterState) {
+    //     return entity.triples.some(triple => {
+    //       // @HACK: We special-case `space` since it's not an attribute:value in an entity but is a property
+    //       // attached to a triple in the subgraph. Once we represents entities across multiple spaces
+    //       // this filter likely won't make sense anymore.
+    //       if (filter.columnId === 'space') {
+    //         return entity.nameTripleSpace === filter.value;
+    //       }
 
-    const entitiesWithAppliedGraphqlFilters = entitiesWithSelectedType.filter(entity => {
-      for (const filter of filterState) {
-        return entity.triples.some(triple => {
-          // @HACK: We special-case `space` since it's not an attribute:value in an entity but is a property
-          // attached to a triple in the subgraph. Once we represents entities across multiple spaces
-          // this filter likely won't make sense anymore.
-          if (filter.columnId === 'space') {
-            return entity.nameTripleSpace === filter.value;
-          }
+    //       return triple.attributeId === filter.columnId && filterValue(triple.value, filter.value);
+    //     });
+    //   }
 
-          return triple.attributeId === filter.columnId && filterValue(triple.value, filter.value);
-        });
-      }
+    //   return true;
+    // });
 
-      return true;
-    });
-
-    return EntityTable.fromColumnsAndRows(entitiesWithAppliedGraphqlFilters, columns);
+    return EntityTable.fromColumnsAndRows(entitiesWithSelectedType, columns);
   };
 }
 


### PR DESCRIPTION
Right now we aren't applying many server filters to locally merged-in data. This PR adds filtering on local rows in a Table based on the filters applied to the table.

This might be slow if there are many filters (10+), but we can improve this over time. Ideally we come up with a system for querying remote and local data with a simplified API/query language so we don't have to re-implement filtering on the client using plain JavaScript. This idea was part of the initial thinking on the graph-client.