### PR TITLE
feat/add-icons-design-system

### DIFF
--- a/apps/web/design-system/icon.tsx
+++ b/apps/web/design-system/icon.tsx
@@ -21,6 +21,7 @@ import { Trash } from '~/design-system/icons/trash';
 import { Upload } from '~/design-system/icons/upload';
 import type { ColorName } from '~/design-system/theme/colors';
 
+import { BulkEdit } from './icons/bulk-edit';
 import { CheckCloseSmall } from './icons/check-close-small';
 import { ChevronDownSmall } from './icons/chevron-down-small';
 import { Cog } from './icons/cog';
@@ -40,6 +41,7 @@ import { FilterTable } from './icons/filter-table';
 import { FilterTableWithFilters } from './icons/filter-table-with-filters';
 import { History } from './icons/history';
 import { Image } from './icons/image';
+import { Member } from './icons/member';
 import { Minus } from './icons/minus';
 import { NewTab } from './icons/new-tab';
 import { Plus } from './icons/plus';
@@ -92,7 +94,9 @@ export type IconName =
   | 'minus'
   | 'url'
   | 'wallet'
-  | 'disconnectWallet';
+  | 'disconnectWallet'
+  | 'bulkEdit'
+  | 'member';
 
 type IconProps = React.ComponentPropsWithoutRef<'svg'> & {
   icon: IconName;
@@ -109,6 +113,7 @@ const Blank = () => <svg width="16" height="16" viewBox="0 0 16 16" fill="none" 
 
 const icons: Record<IconName, React.ElementType> = {
   blank: Blank,
+  bulkEdit: BulkEdit,
   create: Create,
   createSmall: CreateSmall,
   close: Close,
@@ -154,4 +159,5 @@ const icons: Record<IconName, React.ElementType> = {
   url: Url,
   wallet: Wallet,
   disconnectWallet: DisconnectWallet,
+  member: Member,
 };

--- a/apps/web/design-system/icons/member.tsx
+++ b/apps/web/design-system/icons/member.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+
+import { ColorName, colors } from '~/design-system/theme/colors';
+
+interface Props {
+  color?: ColorName;
+}
+
+export function Member({ color }: Props) {
+  const themeColor = color ? colors.light[color] : 'currentColor';
+
+  return (
+    <svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <circle cx="6" cy="2.625" r="2.125" stroke={themeColor} />
+      <path
+        d="M0.5 11.4237C0.5 8.70443 2.70443 6.5 5.42373 6.5H6.57627C9.29557 6.5 11.5 8.70443 11.5 11.4237C11.5 11.4659 11.4659 11.5 11.4237 11.5H0.576271C0.534148 11.5 0.5 11.4659 0.5 11.4237Z"
+        stroke={themeColor}
+      />
+    </svg>
+  );
+}


### PR DESCRIPTION
This PR adds the following in preparation for the For You UI:
- Adds the Member icon (`member.tsx`) to the `icons` folder in the design system (SVG from Figma)
- Adds `Member` and `BulkEdit` to the `IconNames` type and `icons` in `icon.tsx` in the design system

The build and lint succeed locally
