### PR TITLE
feat: more granular error handling for publish flow

### DIFF
--- a/apps/web/core/io/publish/publish.ts
+++ b/apps/web/core/io/publish/publish.ts
@@ -87,13 +87,11 @@ export async function publish({
   const writeTxEffect = Effect.gen(function* (awaited) {
     const contractConfig = yield* awaited(prepareTxEffect);
 
+    onChangePublishState('signing-wallet');
+
     return yield* awaited(
       Effect.tryPromise({
-        try: async () => {
-          onChangePublishState('signing-wallet');
-
-          return await writeContract(contractConfig);
-        },
+        try: () => writeContract(contractConfig),
         catch: error => new TransactionWriteFailedError(`Publish failed: ${error}`),
       })
     );

--- a/apps/web/core/io/publish/publish.ts
+++ b/apps/web/core/io/publish/publish.ts
@@ -97,7 +97,7 @@ export async function publish({
     );
   });
 
-  const effect = Effect.gen(function* (awaited) {
+  const publishProgram = Effect.gen(function* (awaited) {
     const writeTxResult = yield* awaited(writeTxEffect);
 
     console.log('Transaction hash: ', writeTxResult.hash);
@@ -135,7 +135,7 @@ export async function publish({
     `);
   });
 
-  await Effect.runPromise(effect);
+  await Effect.runPromise(publishProgram);
 }
 
 export async function uploadFile(storageClient: Storage.IStorageClient, file: File): Promise<string> {


### PR DESCRIPTION
Right now our publish flow can be flaky if using a mobile wallet. Our current publish flow only handled high-level errors which did not make it obvious on which step of the publish flow an error is occurring. This PR adds more granular error handling using `Effect` at every step of the publish flow that requires external IO.

We now return explicit errors for each step of the publish flow so it's obvious where an error has occurred in the process.