### PR TITLE
fix: manually configure wagmi

### DIFF
--- a/apps/web/core/wallet/wallet.tsx
+++ b/apps/web/core/wallet/wallet.tsx
@@ -103,7 +103,7 @@ const createRealWalletConfig = () => {
             name: 'Geo Genesis',
             description: "Browse and organize the world's public knowledge and information in a decentralized way.",
             url: 'https://geobrowser.io',
-            icons: ['/static/favicon.png'],
+            icons: ['https://geobrowser.io/static/favicon-32x32.png'],
           },
         },
       }),

--- a/apps/web/core/wallet/wallet.tsx
+++ b/apps/web/core/wallet/wallet.tsx
@@ -76,6 +76,9 @@ const createRealWalletConfig = () => {
     publicClient,
     webSocketPublicClient,
     autoConnect: true,
+    // These connectors are based on how `connectkit` configures them internally when using
+    // their default configuration.
+    // https://github.com/family/connectkit/blob/47984040867a15ff8cbfdcdea534ad662c2d405e/packages/connectkit/src/defaultConfig.ts#L173
     connectors: [
       new MetaMaskConnector({
         chains,

--- a/apps/web/core/wallet/wallet.tsx
+++ b/apps/web/core/wallet/wallet.tsx
@@ -116,20 +116,6 @@ const createRealWalletConfig = () => {
   });
 };
 
-// getDefaultConfig({
-//   appName: 'Geo Genesis',
-//   appIcon: '/static/favicon.png',
-//   appDescription: "Browse and organize the world's public knowledge and information in a decentralized way.",
-//   appUrl: 'https://geobrowser.io',
-//   chains,
-//   webSocketPublicClient,
-//   publicClient,
-//   autoConnect: true,
-//   walletConnectProjectId: process.env.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID!,
-//   enableWebSocketPublicClient: true,
-//   alchemyId: process.env.NEXT_PUBLIC_ALCHEMY_API_KEY!,
-// })
-
 const mockConnector = new MockConnector({
   chains,
   options: { chainId: polygon.id, walletClient: getMockWalletClient() },
@@ -154,6 +140,7 @@ const wagmiConfig = isTestEnv ? createMockWalletConfig() : createRealWalletConfi
 
 export function WalletProvider({ children }: { children: React.ReactNode }) {
   return (
+    // @ts-expect-error not sure why wagmi isn't happy. It works at runtime as expected.
     <WagmiConfig config={wagmiConfig}>
       <ConnectKitProvider>{children}</ConnectKitProvider>
     </WagmiConfig>


### PR DESCRIPTION
We have been having intermittent RPC errors on mobile wallets. This is likely because `connectkit` manually adds public and JsonRPC providers when using their default config. This PR removes the default config and manually creates configuration for wagmi. This configuration is based on `connectkit` internals, but without the additional providers.

https://github.com/family/connectkit/blob/47984040867a15ff8cbfdcdea534ad662c2d405e/packages/connectkit/src/defaultConfig.ts#L173