### PR TITLE
feat: more minimal global search icon

### DIFF
--- a/apps/web/partials/navbar/navbar.tsx
+++ b/apps/web/partials/navbar/navbar.tsx
@@ -69,13 +69,14 @@ export function Navbar({ onSearchClick }: Props) {
           we don't get any layout shift when the navbar actions appear.
       */}
       <ClientOnly>
-        <div className="flex items-center">
-          <button className="flex items-center gap-2 text-grey-04 hover:text-text" onClick={onSearchClick}>
+        <div className="flex items-center gap-4">
+          <button
+            className="text-grey-04 p-2 hover:bg-grey-01 active:bg-divider focus:bg-grey-01 rounded-full transition-colors duration-200"
+            onClick={onSearchClick}
+          >
             <Icon icon="search" />
-            <p className="text-input">Search</p>
           </button>
           <div className="flex items-center sm:hidden">
-            <Spacer width={16} />
             <NavbarActions spaceId={urlComponents?.[1]} />
           </div>
         </div>


### PR DESCRIPTION
The new seach icon has no text with hover and active styling.


https://github.com/geobrowser/geogenesis/assets/26263630/f948765c-775b-460b-a2f8-41f7bd68adcd

