### PR TITLE
feat: abstract status bar into global flowbar

### DIFF
--- a/apps/web/core/providers.tsx
+++ b/apps/web/core/providers.tsx
@@ -5,13 +5,12 @@ import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 
 import * as React from 'react';
 
-import { StatusBarContextProvider } from '~/partials/review/flow-bar';
-
 import { Services } from './services';
 import { ActionsStoreProvider } from './state/actions-store';
 import { DiffProvider } from './state/diff-store/diff-store';
 import { LocalStoreProvider } from './state/local-store';
 import { SpaceStoreProvider } from './state/spaces-store';
+import { StatusBarContextProvider } from './state/status-bar-store';
 import { WalletProvider } from './wallet';
 
 const queryClient = new QueryClient();

--- a/apps/web/core/providers.tsx
+++ b/apps/web/core/providers.tsx
@@ -5,6 +5,8 @@ import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 
 import * as React from 'react';
 
+import { StatusBarContextProvider } from '~/partials/review/flow-bar';
+
 import { Services } from './services';
 import { ActionsStoreProvider } from './state/actions-store';
 import { DiffProvider } from './state/diff-store/diff-store';
@@ -22,7 +24,9 @@ export function Providers({ children }: { children: React.ReactNode }) {
           <ActionsStoreProvider>
             <SpaceStoreProvider>
               <LocalStoreProvider>
-                <DiffProvider>{children}</DiffProvider>
+                <StatusBarContextProvider>
+                  <DiffProvider>{children}</DiffProvider>
+                </StatusBarContextProvider>
               </LocalStoreProvider>
             </SpaceStoreProvider>
           </ActionsStoreProvider>

--- a/apps/web/core/state/status-bar-store/index.ts
+++ b/apps/web/core/state/status-bar-store/index.ts
@@ -1,0 +1,1 @@
+export { StatusBarContextProvider, useStatusBar } from './status-bar-store';

--- a/apps/web/core/state/status-bar-store/status-bar-store.tsx
+++ b/apps/web/core/state/status-bar-store/status-bar-store.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react';
+
+import { ReviewState } from '~/core/types';
+
+interface StatusBarState {
+  reviewState: ReviewState;
+  error: string | null;
+}
+
+type StatusBarActions =
+  | {
+      type: 'SET_REVIEW_STATE';
+      payload: ReviewState;
+    }
+  | { type: 'ERROR'; payload: string | null };
+
+const statusBarReducer = (state: StatusBarState, action: StatusBarActions): StatusBarState => {
+  switch (action.type) {
+    case 'SET_REVIEW_STATE':
+      return { reviewState: action.payload, error: null };
+    case 'ERROR':
+      return { reviewState: 'publish-error', error: action.payload };
+  }
+};
+
+const StatusBarContext = React.createContext<{
+  state: StatusBarState;
+  dispatch: React.Dispatch<StatusBarActions>;
+} | null>(null);
+
+export const StatusBarContextProvider = ({ children }: { children: React.ReactNode }) => {
+  const [state, dispatch] = React.useReducer(statusBarReducer, {
+    reviewState: 'idle',
+    error: null,
+  });
+
+  return <StatusBarContext.Provider value={{ state, dispatch }}>{children}</StatusBarContext.Provider>;
+};
+
+export function useStatusBar() {
+  const context = React.useContext(StatusBarContext);
+
+  if (!context) {
+    throw new Error('useStatusBar must be used within a StatusBarContextProvider');
+  }
+
+  return context;
+}

--- a/apps/web/core/state/status-bar-store/status-bar-store.tsx
+++ b/apps/web/core/state/status-bar-store/status-bar-store.tsx
@@ -2,19 +2,19 @@ import * as React from 'react';
 
 import { ReviewState } from '~/core/types';
 
-interface StatusBarState {
+export interface StatusBarState {
   reviewState: ReviewState;
   error: string | null;
 }
 
-type StatusBarActions =
+export type StatusBarActions =
   | {
       type: 'SET_REVIEW_STATE';
       payload: ReviewState;
     }
   | { type: 'ERROR'; payload: string | null };
 
-const statusBarReducer = (state: StatusBarState, action: StatusBarActions): StatusBarState => {
+export const statusBarReducer = (state: StatusBarState, action: StatusBarActions): StatusBarState => {
   switch (action.type) {
     case 'SET_REVIEW_STATE':
       return { reviewState: action.payload, error: null };
@@ -23,7 +23,7 @@ const statusBarReducer = (state: StatusBarState, action: StatusBarActions): Stat
   }
 };
 
-const StatusBarContext = React.createContext<{
+export const StatusBarContext = React.createContext<{
   state: StatusBarState;
   dispatch: React.Dispatch<StatusBarActions>;
 } | null>(null);

--- a/apps/web/partials/review/flow-bar.test.tsx
+++ b/apps/web/partials/review/flow-bar.test.tsx
@@ -296,7 +296,7 @@ describe('Status bar', () => {
     expect(screen.queryByText('Adding your changes to The Graph')).toBeInTheDocument();
   });
 
-  it.only('should render publish success state', () => {
+  it('should render publish success state', () => {
     const store = new ActionsStore({
       storageClient: new Storage.StorageClient(options.production.ipfs),
     });
@@ -323,6 +323,6 @@ describe('Status bar', () => {
       store.create(MockNetworkData.makeStubTriple('Alice'));
     });
 
-    expect(screen.queryByText('Adding your changes to The Graph')).toBeInTheDocument();
+    expect(screen.queryByText('Changes published!')).toBeInTheDocument();
   });
 });

--- a/apps/web/partials/review/flow-bar.test.tsx
+++ b/apps/web/partials/review/flow-bar.test.tsx
@@ -1,11 +1,20 @@
 import { act, render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 
+import React from 'react';
+
 import { options } from '~/core/environment/environment';
 import { MockNetworkData, Storage } from '~/core/io';
 import { Providers } from '~/core/providers';
 import { ActionsStore, ActionsStoreContext } from '~/core/state/actions-store';
 import { editable$ } from '~/core/state/editable-store';
+import {
+  StatusBarActions,
+  StatusBarContext,
+  StatusBarState,
+  statusBarReducer,
+} from '~/core/state/status-bar-store/status-bar-store';
+import { ReviewState } from '~/core/types';
 
 import { FlowBar } from './flow-bar';
 
@@ -43,6 +52,38 @@ describe('Flow Bar', () => {
     );
 
     act(() => store.create(MockNetworkData.makeStubTriple('Alice')));
+
+    expect(screen.queryByText('Review')).not.toBeInTheDocument();
+  });
+
+  it('Should not render the flowbar when the status bar is open', () => {
+    const store = new ActionsStore({
+      storageClient: new Storage.StorageClient(options.production.ipfs),
+    });
+
+    const initialState: StatusBarState = {
+      reviewState: 'publish-complete',
+      error: null,
+    };
+
+    const initialDispatch = () => {
+      //
+    };
+
+    render(
+      <ActionsStoreContext.Provider value={store}>
+        <StatusBarContext.Provider value={{ state: initialState, dispatch: initialDispatch }}>
+          <FlowBar />
+        </StatusBarContext.Provider>
+      </ActionsStoreContext.Provider>
+    );
+
+    screen.debug();
+
+    act(() => {
+      editable$.set(true);
+      store.create(MockNetworkData.makeStubTriple('Alice'));
+    });
 
     expect(screen.queryByText('Review')).not.toBeInTheDocument();
   });

--- a/apps/web/partials/review/flow-bar.test.tsx
+++ b/apps/web/partials/review/flow-bar.test.tsx
@@ -72,8 +72,6 @@ describe('Flow Bar', () => {
       </ActionsStoreContext.Provider>
     );
 
-    screen.debug();
-
     act(() => {
       editable$.set(true);
       store.create(MockNetworkData.makeStubTriple('Alice'));
@@ -206,7 +204,7 @@ describe('Status bar', () => {
     expect(screen.queryByText('Review edit')).toBeInTheDocument();
   });
 
-  it.only('should render ipfs uploading state', () => {
+  it('should render ipfs uploading state', () => {
     const store = new ActionsStore({
       storageClient: new Storage.StorageClient(options.production.ipfs),
     });
@@ -324,5 +322,35 @@ describe('Status bar', () => {
     });
 
     expect(screen.queryByText('Changes published!')).toBeInTheDocument();
+  });
+
+  it('should render publish error state', async () => {
+    const store = new ActionsStore({
+      storageClient: new Storage.StorageClient(options.production.ipfs),
+    });
+
+    const initialState: StatusBarState = {
+      reviewState: 'publish-error',
+      error: 'Banana is brown.',
+    };
+
+    const initialDispatch = () => {
+      //
+    };
+
+    render(
+      <ActionsStoreContext.Provider value={store}>
+        <StatusBarContext.Provider value={{ state: initialState, dispatch: initialDispatch }}>
+          <FlowBar />
+        </StatusBarContext.Provider>
+      </ActionsStoreContext.Provider>
+    );
+
+    act(() => {
+      editable$.set(true);
+      store.create(MockNetworkData.makeStubTriple('Alice'));
+    });
+
+    expect(screen.queryByText('An error has occurred')).toBeInTheDocument();
   });
 });

--- a/apps/web/partials/review/flow-bar.test.tsx
+++ b/apps/web/partials/review/flow-bar.test.tsx
@@ -8,13 +8,7 @@ import { MockNetworkData, Storage } from '~/core/io';
 import { Providers } from '~/core/providers';
 import { ActionsStore, ActionsStoreContext } from '~/core/state/actions-store';
 import { editable$ } from '~/core/state/editable-store';
-import {
-  StatusBarActions,
-  StatusBarContext,
-  StatusBarState,
-  statusBarReducer,
-} from '~/core/state/status-bar-store/status-bar-store';
-import { ReviewState } from '~/core/types';
+import { StatusBarContext, StatusBarState } from '~/core/state/status-bar-store/status-bar-store';
 
 import { FlowBar } from './flow-bar';
 
@@ -35,7 +29,7 @@ describe('Flow Bar', () => {
       </Providers>
     );
 
-    expect(screen.queryByText('Review')).not.toBeInTheDocument();
+    expect(screen.queryByText('Review edit')).not.toBeInTheDocument();
   });
 
   it('Should not render the flow bar when there are changes but not in edit mode', () => {
@@ -53,7 +47,7 @@ describe('Flow Bar', () => {
 
     act(() => store.create(MockNetworkData.makeStubTriple('Alice')));
 
-    expect(screen.queryByText('Review')).not.toBeInTheDocument();
+    expect(screen.queryByText('Review edit')).not.toBeInTheDocument();
   });
 
   it('Should not render the flowbar when the status bar is open', () => {
@@ -85,7 +79,7 @@ describe('Flow Bar', () => {
       store.create(MockNetworkData.makeStubTriple('Alice'));
     });
 
-    expect(screen.queryByText('Review')).not.toBeInTheDocument();
+    expect(screen.queryByText('Review edit')).not.toBeInTheDocument();
   });
 
   it('Should render the flow bar when there are changes and in edit mode', () => {
@@ -148,7 +142,7 @@ describe('Flow Bar', () => {
       store.remove(MockNetworkData.makeStubTriple('Alice'));
     });
 
-    expect(screen.queryByText('Review')).not.toBeInTheDocument();
+    expect(screen.queryByText('Review edit')).not.toBeInTheDocument();
 
     // create -> edit should only be one change
     act(() => {
@@ -178,5 +172,157 @@ describe('Flow Bar', () => {
 
     expect(screen.queryByText('3 edits')).toBeInTheDocument();
     expect(screen.queryByText('2 entities in 1 space')).toBeInTheDocument();
+  });
+});
+
+describe('Status bar', () => {
+  it('should not render the status bar when status is idle or reviewing and we are in edit mode with actions', () => {
+    const store = new ActionsStore({
+      storageClient: new Storage.StorageClient(options.production.ipfs),
+    });
+
+    const initialState: StatusBarState = {
+      reviewState: 'idle',
+      error: null,
+    };
+
+    const initialDispatch = () => {
+      //
+    };
+
+    render(
+      <ActionsStoreContext.Provider value={store}>
+        <StatusBarContext.Provider value={{ state: initialState, dispatch: initialDispatch }}>
+          <FlowBar />
+        </StatusBarContext.Provider>
+      </ActionsStoreContext.Provider>
+    );
+
+    act(() => {
+      editable$.set(true);
+      store.create(MockNetworkData.makeStubTriple('Alice'));
+    });
+
+    expect(screen.queryByText('Review edit')).toBeInTheDocument();
+  });
+
+  it.only('should render ipfs uploading state', () => {
+    const store = new ActionsStore({
+      storageClient: new Storage.StorageClient(options.production.ipfs),
+    });
+
+    const initialState: StatusBarState = {
+      reviewState: 'publishing-ipfs',
+      error: null,
+    };
+
+    const initialDispatch = () => {
+      //
+    };
+
+    render(
+      <ActionsStoreContext.Provider value={store}>
+        <StatusBarContext.Provider value={{ state: initialState, dispatch: initialDispatch }}>
+          <FlowBar />
+        </StatusBarContext.Provider>
+      </ActionsStoreContext.Provider>
+    );
+
+    act(() => {
+      editable$.set(true);
+      store.create(MockNetworkData.makeStubTriple('Alice'));
+    });
+
+    expect(screen.queryByText('Uploading changes to IPFS')).toBeInTheDocument();
+  });
+
+  it('should render wallet signing state', () => {
+    const store = new ActionsStore({
+      storageClient: new Storage.StorageClient(options.production.ipfs),
+    });
+
+    const initialState: StatusBarState = {
+      reviewState: 'signing-wallet',
+      error: null,
+    };
+
+    const initialDispatch = () => {
+      //
+    };
+
+    render(
+      <ActionsStoreContext.Provider value={store}>
+        <StatusBarContext.Provider value={{ state: initialState, dispatch: initialDispatch }}>
+          <FlowBar />
+        </StatusBarContext.Provider>
+      </ActionsStoreContext.Provider>
+    );
+
+    act(() => {
+      editable$.set(true);
+      store.create(MockNetworkData.makeStubTriple('Alice'));
+    });
+
+    expect(screen.queryByText('Sign your transaction')).toBeInTheDocument();
+  });
+
+  it('should render publishing contract state', () => {
+    const store = new ActionsStore({
+      storageClient: new Storage.StorageClient(options.production.ipfs),
+    });
+
+    const initialState: StatusBarState = {
+      reviewState: 'publishing-contract',
+      error: null,
+    };
+
+    const initialDispatch = () => {
+      //
+    };
+
+    render(
+      <ActionsStoreContext.Provider value={store}>
+        <StatusBarContext.Provider value={{ state: initialState, dispatch: initialDispatch }}>
+          <FlowBar />
+        </StatusBarContext.Provider>
+      </ActionsStoreContext.Provider>
+    );
+
+    act(() => {
+      editable$.set(true);
+      store.create(MockNetworkData.makeStubTriple('Alice'));
+    });
+
+    expect(screen.queryByText('Adding your changes to The Graph')).toBeInTheDocument();
+  });
+
+  it.only('should render publish success state', () => {
+    const store = new ActionsStore({
+      storageClient: new Storage.StorageClient(options.production.ipfs),
+    });
+
+    const initialState: StatusBarState = {
+      reviewState: 'publish-complete',
+      error: null,
+    };
+
+    const initialDispatch = () => {
+      //
+    };
+
+    render(
+      <ActionsStoreContext.Provider value={store}>
+        <StatusBarContext.Provider value={{ state: initialState, dispatch: initialDispatch }}>
+          <FlowBar />
+        </StatusBarContext.Provider>
+      </ActionsStoreContext.Provider>
+    );
+
+    act(() => {
+      editable$.set(true);
+      store.create(MockNetworkData.makeStubTriple('Alice'));
+    });
+
+    expect(screen.queryByText('Adding your changes to The Graph')).toBeInTheDocument();
   });
 });

--- a/apps/web/partials/review/flow-bar.tsx
+++ b/apps/web/partials/review/flow-bar.tsx
@@ -10,6 +10,7 @@ import { useActionsStore } from '~/core/hooks/use-actions-store';
 import { useToast } from '~/core/hooks/use-toast';
 import { useDiff } from '~/core/state/diff-store/diff-store';
 import { useEditable } from '~/core/state/editable-store/editable-store';
+import { useStatusBar } from '~/core/state/status-bar-store';
 import { ReviewState } from '~/core/types';
 import { Action } from '~/core/utils/action';
 
@@ -87,51 +88,6 @@ export const FlowBar = () => {
     </AnimatePresence>
   );
 };
-
-interface StatusBarState {
-  reviewState: ReviewState;
-  error: string | null;
-}
-
-type StatusBarActions =
-  | {
-      type: 'SET_REVIEW_STATE';
-      payload: ReviewState;
-    }
-  | { type: 'ERROR'; payload: string | null };
-
-const statusBarReducer = (state: StatusBarState, action: StatusBarActions): StatusBarState => {
-  switch (action.type) {
-    case 'SET_REVIEW_STATE':
-      return { reviewState: action.payload, error: null };
-    case 'ERROR':
-      return { reviewState: 'publish-error', error: action.payload };
-  }
-};
-
-const StatusBarContext = React.createContext<{
-  state: StatusBarState;
-  dispatch: React.Dispatch<StatusBarActions>;
-} | null>(null);
-
-export const StatusBarContextProvider = ({ children }: { children: React.ReactNode }) => {
-  const [state, dispatch] = React.useReducer(statusBarReducer, {
-    reviewState: 'idle',
-    error: null,
-  });
-
-  return <StatusBarContext.Provider value={{ state, dispatch }}>{children}</StatusBarContext.Provider>;
-};
-
-export function useStatusBar() {
-  const context = React.useContext(StatusBarContext);
-
-  if (!context) {
-    throw new Error('useStatusBar must be used within a StatusBarContextProvider');
-  }
-
-  return context;
-}
 
 const StatusBar = () => {
   const { state, dispatch } = useStatusBar();

--- a/apps/web/partials/review/flow-bar.tsx
+++ b/apps/web/partials/review/flow-bar.tsx
@@ -136,8 +136,6 @@ export function useStatusBar() {
 const StatusBar = () => {
   const { state, dispatch } = useStatusBar();
 
-  console.log('rendering status bar');
-
   const [isCopied, setIsCopied] = React.useState(false);
 
   const onCopyError = async () => {

--- a/apps/web/partials/review/review.tsx
+++ b/apps/web/partials/review/review.tsx
@@ -22,6 +22,7 @@ import { Subgraph } from '~/core/io';
 import { fetchColumns } from '~/core/io/fetch-columns';
 import { Services } from '~/core/services';
 import { useDiff } from '~/core/state/diff-store/diff-store';
+import { useStatusBar } from '~/core/state/status-bar-store';
 import { TableBlockFilter } from '~/core/state/table-block-store';
 import type { Action as ActionType, Entity as EntityType, Space } from '~/core/types';
 import { Action } from '~/core/utils/action';
@@ -38,8 +39,6 @@ import { Spacer } from '~/design-system/spacer';
 import { colors } from '~/design-system/theme/colors';
 
 import { TableBlockPlaceholder } from '~/partials/blocks/table/table-block';
-
-import { useStatusBar } from './flow-bar';
 
 export const Review = () => {
   const { isReviewOpen, setIsReviewOpen } = useDiff();

--- a/apps/web/partials/review/review.tsx
+++ b/apps/web/partials/review/review.tsx
@@ -7,7 +7,6 @@ import { cva } from 'class-variance-authority';
 import cx from 'classnames';
 import { diffWords } from 'diff';
 import type { Change as Difference } from 'diff';
-import { AnimatePresence, motion } from 'framer-motion';
 import pluralize from 'pluralize';
 
 import * as React from 'react';
@@ -24,7 +23,7 @@ import { fetchColumns } from '~/core/io/fetch-columns';
 import { Services } from '~/core/services';
 import { useDiff } from '~/core/state/diff-store/diff-store';
 import { TableBlockFilter } from '~/core/state/table-block-store';
-import type { Action as ActionType, Entity as EntityType, ReviewState, Space } from '~/core/types';
+import type { Action as ActionType, Entity as EntityType, Space } from '~/core/types';
 import { Action } from '~/core/utils/action';
 import { Change } from '~/core/utils/change';
 import type { AttributeChange, AttributeId, BlockChange, BlockId, Changeset } from '~/core/utils/change/change';
@@ -33,16 +32,14 @@ import { GeoDate, getImagePath } from '~/core/utils/utils';
 
 import { Button, SmallButton, SquareButton } from '~/design-system/button';
 import { Dropdown } from '~/design-system/dropdown';
-import { Close } from '~/design-system/icons/close';
 import { Minus } from '~/design-system/icons/minus';
-import { TickSmall } from '~/design-system/icons/tick-small';
-import { Warning } from '~/design-system/icons/warning';
 import { SlideUp } from '~/design-system/slide-up';
 import { Spacer } from '~/design-system/spacer';
-import { Spinner } from '~/design-system/spinner';
 import { colors } from '~/design-system/theme/colors';
 
 import { TableBlockPlaceholder } from '~/partials/blocks/table/table-block';
+
+import { useStatusBar } from './flow-bar';
 
 export const Review = () => {
   const { isReviewOpen, setIsReviewOpen } = useDiff();
@@ -98,8 +95,7 @@ const ReviewChanges = () => {
   }));
 
   // Proposal state
-  const [error, setError] = useState<string | null>(null);
-  const [reviewState, setReviewState] = useState<ReviewState>('idle');
+  const { dispatch } = useStatusBar();
   const [proposals, setProposals] = useState<Proposals>({});
   const proposalName = proposals[activeSpace]?.name?.trim() ?? '';
   const isReadyToPublish = proposalName?.length > 3;
@@ -119,21 +115,26 @@ const ReviewChanges = () => {
     };
 
     try {
-      await publish(activeSpace, wallet, setReviewState, unstagedChanges, proposalName);
-      setError(null);
+      await publish(
+        activeSpace,
+        wallet,
+        reviewState => dispatch({ type: 'SET_REVIEW_STATE', payload: reviewState }),
+        unstagedChanges,
+        proposalName
+      );
+      dispatch({ type: 'ERROR', payload: null });
       clearProposalName();
     } catch (e: unknown) {
       if (e instanceof Error) {
         if (e.message.startsWith('Publish failed: TransactionExecutionError: User rejected the request.')) {
-          setReviewState('idle');
+          dispatch({ type: 'SET_REVIEW_STATE', payload: 'idle' });
           return;
         }
 
-        setReviewState('publish-error');
-        setError((e as Error).message);
+        dispatch({ type: 'ERROR', payload: e.message });
       }
     }
-  }, [activeSpace, proposalName, proposals, publish, wallet, unstagedChanges]);
+  }, [activeSpace, proposalName, proposals, publish, wallet, unstagedChanges, dispatch]);
 
   if (isLoading || !data) {
     return null;
@@ -243,7 +244,6 @@ const ReviewChanges = () => {
           </div>
         </div>
       </div>
-      <StatusBar reviewState={reviewState} error={error} onClose={() => setReviewState('idle')} />
     </>
   );
 };
@@ -879,94 +879,6 @@ const labelClassNames = `text-footnote text-grey-04`;
 
 const timeClassNames = `w-[21px] tabular-nums bg-transparent p-0 m-0 text-body`;
 
-type StatusBarProps = {
-  reviewState: ReviewState;
-  onClose: () => void;
-  error: string | null;
-};
-
-const StatusBar = ({ reviewState, error, onClose }: StatusBarProps) => {
-  const [isCopied, setIsCopied] = useState(false);
-
-  const onCopyError = async () => {
-    if (navigator.clipboard) {
-      await navigator.clipboard.writeText(error || '');
-      setIsCopied(true);
-      setTimeout(() => setIsCopied(false), 2000);
-    }
-  };
-
-  let content = (
-    <>
-      {reviewState === 'publish-complete' && (
-        <motion.span initial={{ scale: 0.95 }} animate={{ scale: 1 }} transition={{ type: 'spring', duration: 0.15 }}>
-          🎉
-        </motion.span>
-      )}
-      {/* Only show spinner if not the complete state */}
-      {reviewState !== 'publish-complete' && publishingStates.includes(reviewState) && <Spinner />}
-      <span>{message[reviewState]}</span>
-    </>
-  );
-
-  if (reviewState === 'publish-error' && error) {
-    content = (
-      <>
-        <Warning color="orange" />
-        <span>{message[reviewState]}</span>
-        <button
-          className="flex w-[70px] items-center justify-center rounded border border-white bg-transparent p-1 text-smallButton"
-          onClick={onCopyError}
-        >
-          <AnimatePresence mode="popLayout">
-            {isCopied ? (
-              <motion.div
-                key="status-bar-error"
-                initial={{ scale: 0.95, opacity: 0 }}
-                animate={{ scale: 1, opacity: 1 }}
-                exit={{ scale: 0.95, opacity: 0 }}
-              >
-                <TickSmall />
-              </motion.div>
-            ) : (
-              <motion.div
-                key="status-bar-error"
-                initial={{ scale: 0.95, opacity: 0 }}
-                animate={{ scale: 1, opacity: 1 }}
-                exit={{ scale: 0.95, opacity: 0 }}
-              >
-                Copy error
-              </motion.div>
-            )}
-          </AnimatePresence>
-        </button>
-        <button onClick={onClose}>
-          <Close />
-        </button>
-      </>
-    );
-  }
-
-  return (
-    <AnimatePresence>
-      {reviewState !== 'idle' && (
-        <div className="fixed bottom-0 right-0 left-0 flex w-full justify-center">
-          <motion.div
-            variants={statusVariants}
-            initial="hidden"
-            animate="visible"
-            exit="hidden"
-            transition={transition}
-            className="m-8 inline-flex items-center gap-2 rounded bg-text px-3 py-2.5 text-metadataMedium text-white"
-          >
-            {content}
-          </motion.div>
-        </div>
-      )}
-    </AnimatePresence>
-  );
-};
-
 const useChanges = (actions: Array<ActionType> = [], spaceId: string) => {
   const { subgraph, config } = Services.useServices();
   const { data, isLoading } = useQuery({
@@ -976,23 +888,6 @@ const useChanges = (actions: Array<ActionType> = [], spaceId: string) => {
 
   return [data, isLoading] as const;
 };
-
-const message: Record<ReviewState, string> = {
-  idle: '',
-  reviewing: '',
-  'publishing-ipfs': 'Uploading changes to IPFS',
-  'signing-wallet': 'Sign your transaction',
-  'publishing-contract': 'Adding your changes to The Graph',
-  'publish-complete': 'Changes published!',
-  'publish-error': 'An error has occurred',
-};
-
-const publishingStates: Array<ReviewState> = [
-  'publishing-ipfs',
-  'signing-wallet',
-  'publishing-contract',
-  'publish-complete',
-];
 
 type ChipProps = {
   status?: 'added' | 'removed' | 'unchanged';
@@ -1052,13 +947,6 @@ function getSpaceImage(spaces: Space[], spaceId: string): string {
       'https://via.placeholder.com/600x600/FF00FF/FFFFFF'
   );
 }
-
-const statusVariants = {
-  hidden: { opacity: 0, y: '4px' },
-  visible: { opacity: 1, y: '0px' },
-};
-
-const transition = { type: 'spring', duration: 0.5, bounce: 0 };
 
 type TableFiltersProps = {
   rawFilter: string;

--- a/apps/web/partials/review/review.tsx
+++ b/apps/web/partials/review/review.tsx
@@ -122,7 +122,6 @@ const ReviewChanges = () => {
         unstagedChanges,
         proposalName
       );
-      dispatch({ type: 'ERROR', payload: null });
       clearProposalName();
     } catch (e: unknown) {
       if (e instanceof Error) {


### PR DESCRIPTION
Previously the `StatusBar` only rendered in the context of the Review UI. This made sense previously as the Review feature was the only place where users could publish content.

Soon users will be able to publish content from multiple contexts, including merging entities and moving entities to other spaces. This means that we want to render the status bar in a global context so other features can take advantage of the `StatusBar` UI when handling their own publish states.

Additionally, future features like Bulk Actions will augment the flow bar in a global way. Having a single, unified way of sending messages that will augment the FlowBar will be required there as well.

This PR is the first step in abstracting in a global status bar/flow bar. Future PRs will improve the UX of changing UI context between the flow bars and status bars.