### PR TITLE
fix: janky attribute value type mutations

### DIFF
--- a/apps/web/core/hooks/use-entity-page-store.ts
+++ b/apps/web/core/hooks/use-entity-page-store.ts
@@ -5,7 +5,7 @@ import { useSelector } from '@legendapp/state/react';
 import { useQuery } from '@tanstack/react-query';
 import { pipe } from 'effect';
 
-import { Action, Triple as ITriple } from '~/core/types';
+import { Action, Triple as ITriple, RelationValueTypesByAttributeId } from '~/core/types';
 
 import { Merged } from '../merged';
 import { Services } from '../services';
@@ -15,14 +15,6 @@ import { useLocalStoreInstance } from '../state/local-store';
 import { Triple } from '../utils/triple';
 import { Value } from '../utils/value';
 import { useActionsStore } from './use-actions-store';
-
-export type RelationValueType = {
-  typeId: string;
-  typeName: string | null;
-  spaceIdOfAttribute: string;
-};
-
-type RelationValueTypesByAttributeId = Record<string, Array<RelationValueType>>;
 
 /**
  * This function takes triples from the server for the relation value types and merges them with any locally
@@ -67,7 +59,7 @@ function useConfiguredAttributeRelationTypes({
 }: {
   triples: Array<ITriple>;
   schemaTriples: Array<ITriple>;
-}): Record<string, Array<RelationValueType>> {
+}): RelationValueTypesByAttributeId {
   // Here triples includes both local and remote triples
   const attributesWithRelationValues = [
     ...new Set([...triples, ...schemaTriples].filter(t => t.value.type === 'entity').map(t => t.attributeId)),

--- a/apps/web/core/hooks/use-entity-page-store.ts
+++ b/apps/web/core/hooks/use-entity-page-store.ts
@@ -122,14 +122,11 @@ function useConfiguredAttributeRelationTypes({
 
   // We need to merge any local actions for the attribute relation types with the server attribute relation types.
   // Additionally we map to the data structure the UI expects to consume.
-  const thing = mergeTriplesToRelationValueTypes(
+  return mergeTriplesToRelationValueTypes(
     allActions,
     // Flatten all the triples for each entity into a single array (there shouldn't be duplicates)
     serverAttributeRelationTypes.flatMap(t => t)
   );
-
-  console.log('thing', thing);
-  return thing;
 }
 
 export function useEntityPageStore() {

--- a/apps/web/core/hooks/use-entity-page-store.ts
+++ b/apps/web/core/hooks/use-entity-page-store.ts
@@ -1,10 +1,69 @@
 'use client';
 
+import { SYSTEM_IDS } from '@geogenesis/ids';
 import { useSelector } from '@legendapp/state/react';
+import { useQuery } from '@tanstack/react-query';
 
-import { Triple } from '~/core/types';
+import { EntityValue, Triple as ITriple } from '~/core/types';
 
-import { useEntityStoreInstance } from '../state/entity-page-store/entity-store-provider';
+import { Services } from '../services';
+import { useEntityStoreInstance } from '../state/entity-page-store';
+import { Triple } from '../utils/triple';
+import { useActionsStore } from './use-actions-store';
+
+export function useConfiguredAttributeRelationTypes({
+  triples,
+  schemaTriples,
+}: {
+  triples: Array<ITriple>;
+  schemaTriples: Array<ITriple>;
+}) {
+  const attributesWithRelationValues = [
+    ...new Set([...triples, ...schemaTriples].filter(t => t.value.type === 'entity').map(t => t.attributeId)),
+  ];
+
+  const { subgraph, config } = Services.useServices();
+  const { allActions } = useActionsStore();
+
+  const {
+    data: serverAttributeRelationTypes,
+    isLoading,
+    error,
+  } = useQuery({
+    queryKey: ['serverAttributeRelationTypes', attributesWithRelationValues],
+    queryFn: async () => {
+      const result = await Promise.all(
+        attributesWithRelationValues.map(attributeId =>
+          subgraph.fetchEntity({ id: attributeId, endpoint: config.subgraph })
+        )
+      );
+
+      return result.flatMap(r => (r ? [r] : []));
+    },
+  });
+
+  if (!serverAttributeRelationTypes || isLoading || error) {
+    return {};
+  }
+
+  // We need to merge any local actions for the attribute relation types with the server attribute relation types.
+  // Additionally we map to the data structure the UI expects to consume.
+  return Triple.fromActions(
+    allActions,
+    serverAttributeRelationTypes.flatMap(e => e.triples)
+  )
+    .filter(t => t.attributeId === SYSTEM_IDS.RELATION_VALUE_RELATIONSHIP_TYPE && t.value.type === 'entity')
+    .reduce<Record<string, { typeId: string; typeName: string | null; spaceId: string }[]>>((acc, relationType) => {
+      if (!acc[relationType.entityId]) acc[relationType.entityId] = [];
+      acc[relationType.entityId].push({
+        typeId: relationType.value.id,
+        // We can safely cast here because we filter for entity type values above.
+        typeName: (relationType.value as EntityValue).name,
+        spaceId: relationType.space,
+      });
+      return acc;
+    }, {});
+}
 
 export function useEntityPageStore() {
   const {
@@ -20,14 +79,13 @@ export function useEntityPageStore() {
     id,
     updateEditorBlocks,
     editorJson$,
-    attributeRelationTypes$,
   } = useEntityStoreInstance();
   const triples = useSelector(triples$);
-  const schemaTriples = useSelector<Triple[]>(schemaTriples$);
+  const schemaTriples = useSelector<ITriple[]>(schemaTriples$);
   const hiddenSchemaIds = useSelector<string[]>(hiddenSchemaIds$);
   const blockIds = useSelector<string[]>(blockIds$);
   const editorJson = useSelector(editorJson$);
-  const attributeRelationTypes = useSelector(attributeRelationTypes$);
+  const attributeRelationTypes = useConfiguredAttributeRelationTypes({ triples, schemaTriples });
 
   return {
     triples,

--- a/apps/web/core/hooks/use-entity-page-store.ts
+++ b/apps/web/core/hooks/use-entity-page-store.ts
@@ -1,23 +1,72 @@
 'use client';
 
-import { SYSTEM_IDS } from '@geogenesis/ids';
 import { useSelector } from '@legendapp/state/react';
 import { useQuery } from '@tanstack/react-query';
+import { pipe } from 'effect';
 
-import { EntityValue, Triple as ITriple } from '~/core/types';
+import { Action, EntityValue, Triple as ITriple } from '~/core/types';
 
 import { Services } from '../services';
 import { useEntityStoreInstance } from '../state/entity-page-store';
 import { Triple } from '../utils/triple';
+import { Value } from '../utils/value';
 import { useActionsStore } from './use-actions-store';
 
-export function useConfiguredAttributeRelationTypes({
+type RelationValueType = {
+  typeId: string;
+  typeName: string | null;
+  spaceId: string;
+};
+
+type EntityValueTriple = ITriple & { value: EntityValue };
+
+type MergeRelationValueTypesFn = (
+  actions: Array<Action>,
+  relationTypeTriples: Array<ITriple>
+) => Array<EntityValueTriple>;
+
+/**
+ * This function takes triples from the server for the relation value types and merges them with any locally
+ * created/deleted relation value types.
+ *
+ * It returns an object that maps entity ids to an array of relation value types.
+ */
+export const mergeLocalAndRemoteRelationValueTypes: MergeRelationValueTypesFn = (actions, relationTypeTriples) => {
+  const mergedTriples = Triple.fromActions(actions, relationTypeTriples);
+
+  return pipe(mergedTriples, triples => triples.filter(Value.isRelationValueType));
+};
+
+export function triplesToRelationValueTypes(triples: ReturnType<typeof mergeLocalAndRemoteRelationValueTypes>) {
+  return triples.reduce<Record<string, { typeId: string; typeName: string | null; spaceId: string }[]>>(
+    (acc, relationType) => {
+      if (!acc[relationType.entityId]) acc[relationType.entityId] = [];
+      acc[relationType.entityId].push({
+        typeId: relationType.value.id,
+        typeName: relationType.value.name,
+        spaceId: relationType.space,
+      });
+      return acc;
+    },
+    {}
+  );
+}
+
+/**
+ * This function is responsible for fetching the attribute relation value types for the triples
+ * and schema triples that make up an entity on the entity page. It merges any remote relation
+ * value types and merges them with any local actions that have acted on the relation value types
+ * for this entity.
+ *
+ * It returns an object that maps attribute ids to an array of relation value types.
+ */
+function useConfiguredAttributeRelationTypes({
   triples,
   schemaTriples,
 }: {
   triples: Array<ITriple>;
   schemaTriples: Array<ITriple>;
-}) {
+}): Record<string, Array<RelationValueType>> {
   const attributesWithRelationValues = [
     ...new Set([...triples, ...schemaTriples].filter(t => t.value.type === 'entity').map(t => t.attributeId)),
   ];
@@ -31,15 +80,12 @@ export function useConfiguredAttributeRelationTypes({
     error,
   } = useQuery({
     queryKey: ['serverAttributeRelationTypes', attributesWithRelationValues],
-    queryFn: async () => {
-      const result = await Promise.all(
+    queryFn: async () =>
+      Promise.all(
         attributesWithRelationValues.map(attributeId =>
           subgraph.fetchEntity({ id: attributeId, endpoint: config.subgraph })
         )
-      );
-
-      return result.flatMap(r => (r ? [r] : []));
-    },
+      ),
   });
 
   if (!serverAttributeRelationTypes || isLoading || error) {
@@ -48,21 +94,16 @@ export function useConfiguredAttributeRelationTypes({
 
   // We need to merge any local actions for the attribute relation types with the server attribute relation types.
   // Additionally we map to the data structure the UI expects to consume.
-  return Triple.fromActions(
-    allActions,
-    serverAttributeRelationTypes.flatMap(e => e.triples)
-  )
-    .filter(t => t.attributeId === SYSTEM_IDS.RELATION_VALUE_RELATIONSHIP_TYPE && t.value.type === 'entity')
-    .reduce<Record<string, { typeId: string; typeName: string | null; spaceId: string }[]>>((acc, relationType) => {
-      if (!acc[relationType.entityId]) acc[relationType.entityId] = [];
-      acc[relationType.entityId].push({
-        typeId: relationType.value.id,
-        // We can safely cast here because we filter for entity type values above.
-        typeName: (relationType.value as EntityValue).name,
-        spaceId: relationType.space,
-      });
-      return acc;
-    }, {});
+  return pipe(
+    mergeLocalAndRemoteRelationValueTypes(
+      allActions,
+      // Filter out any non-existent entities
+      serverAttributeRelationTypes
+        .flatMap(e => (e ? [e] : []))
+        .flatMap(e => e.triples.filter(Value.isRelationValueType))
+    ),
+    triplesToRelationValueTypes
+  );
 }
 
 export function useEntityPageStore() {

--- a/apps/web/core/merged/merged.test.ts
+++ b/apps/web/core/merged/merged.test.ts
@@ -51,7 +51,7 @@ describe('MergeDataSource merges local triples with network triples', () => {
     expect(triples).toEqual([changedLocalTripleAsAction]);
   });
 
-  it.only('merges local triples with filters', async () => {
+  it('merges local triples with filters', async () => {
     const stubTriple = makeStubTriple('Alice', 'alice-id');
 
     const store = new ActionsStore({ storageClient });

--- a/apps/web/core/merged/merged.ts
+++ b/apps/web/core/merged/merged.ts
@@ -73,7 +73,40 @@ export class Merged implements IMergedDataSource {
     const updatedTriples = Triple.fromActions(actions, networkTriples);
     const mergedTriplesWithName = Triple.withLocalNames(actions, updatedTriples);
 
-    return mergedTriplesWithName;
+    // We need to apply any server filters to locally created data.
+    const locallyFilteredTriples = [];
+
+    for (const filter of options.filter ?? []) {
+      locallyFilteredTriples.push(
+        ...mergedTriplesWithName.filter(t => {
+          if (filter.field === 'attribute-id') {
+            return t.attributeId === filter.value;
+          }
+
+          if (filter.field === 'entity-id') {
+            return t.entityId === filter.value;
+          }
+
+          if (filter.field === 'attribute-name') {
+            return t.attributeName === filter.value;
+          }
+
+          if (filter.field === 'entity-name') {
+            return t.entityName === filter.value;
+          }
+
+          if (filter.field === 'linked-to') {
+            return t.value.type === 'entity' && t.value.id === filter.value;
+          }
+
+          if (filter.field === 'value') {
+            return t.value.type === 'entity' && t.value.name === filter.value;
+          }
+        })
+      );
+    }
+
+    return locallyFilteredTriples;
   };
 
   fetchEntities = async (options: Parameters<Subgraph.ISubgraph['fetchEntities']>[0]) => {

--- a/apps/web/core/merged/merged.ts
+++ b/apps/web/core/merged/merged.ts
@@ -62,9 +62,7 @@ export class Merged implements IMergedDataSource {
   fetchTriples = async (options: Parameters<Subgraph.ISubgraph['fetchTriples']>[0]) => {
     const networkTriples = await this.subgraph.fetchTriples(options);
 
-    if (!options.space) return networkTriples;
-
-    const actions = this.store.actions$.get()[options.space] ?? [];
+    const actions = options.space ? this.store.actions$.get()[options.space] : this.store.allActions$.get() ?? [];
 
     // Merge any local actions with the network triples
     const updatedTriples = Triple.fromActions(actions, networkTriples);

--- a/apps/web/core/merged/merged.ts
+++ b/apps/web/core/merged/merged.ts
@@ -66,44 +66,39 @@ export class Merged implements IMergedDataSource {
 
     const actions = this.store.actions$.get()[options.space] ?? [];
 
-    // We want to merge any local actions with the network triples
-    // @TODO: Do local actions need to have filters applied to them? Right now we aren't doing
-    // this in our app code for local triples. This might mean that we render local triples that
-    // don't map to the selected filter.
+    // Merge any local actions with the network triples
     const updatedTriples = Triple.fromActions(actions, networkTriples);
     const mergedTriplesWithName = Triple.withLocalNames(actions, updatedTriples);
 
-    // We need to apply any server filters to locally created data.
-    const locallyFilteredTriples = [];
+    // Apply any server filters to locally created data.
+    let locallyFilteredTriples = mergedTriplesWithName;
 
     for (const filter of options.filter ?? []) {
-      locallyFilteredTriples.push(
-        ...mergedTriplesWithName.filter(t => {
-          if (filter.field === 'attribute-id') {
-            return t.attributeId === filter.value;
-          }
+      locallyFilteredTriples = locallyFilteredTriples.filter(t => {
+        if (filter.field === 'attribute-id') {
+          return t.attributeId === filter.value;
+        }
 
-          if (filter.field === 'entity-id') {
-            return t.entityId === filter.value;
-          }
+        if (filter.field === 'entity-id') {
+          return t.entityId === filter.value;
+        }
 
-          if (filter.field === 'attribute-name') {
-            return t.attributeName === filter.value;
-          }
+        if (filter.field === 'attribute-name') {
+          return t.attributeName === filter.value;
+        }
 
-          if (filter.field === 'entity-name') {
-            return t.entityName === filter.value;
-          }
+        if (filter.field === 'entity-name') {
+          return t.entityName === filter.value;
+        }
 
-          if (filter.field === 'linked-to') {
-            return t.value.type === 'entity' && t.value.id === filter.value;
-          }
+        if (filter.field === 'linked-to') {
+          return t.value.type === 'entity' && t.value.id === filter.value;
+        }
 
-          if (filter.field === 'value') {
-            return t.value.type === 'entity' && t.value.name === filter.value;
-          }
-        })
-      );
+        if (filter.field === 'value') {
+          return t.value.type === 'entity' && t.value.name === filter.value;
+        }
+      });
     }
 
     return locallyFilteredTriples;

--- a/apps/web/core/state/entity-page-store/entity-store.ts
+++ b/apps/web/core/state/entity-page-store/entity-store.ts
@@ -9,12 +9,11 @@ import { TableBlockSdk } from '~/core/blocks-sdk';
 import { Environment } from '~/core/environment';
 import { ID } from '~/core/id';
 import { Subgraph } from '~/core/io';
-import { Merged } from '~/core/merged';
 import { EntityValue, Triple as ITriple } from '~/core/types';
 import { Action } from '~/core/utils/action';
 import { Entity } from '~/core/utils/entity';
 import { Triple } from '~/core/utils/triple';
-import { getImagePath, makeOptionalComputed } from '~/core/utils/utils';
+import { getImagePath } from '~/core/utils/utils';
 import { Value } from '~/core/utils/value';
 
 import { tiptapExtensions } from '~/partials/editor/editor';
@@ -109,9 +108,6 @@ export class EntityStore implements IEntityStore {
   ActionsStore: ActionsStore;
   abortController: AbortController = new AbortController();
   name$: ObservableComputed<string>;
-  attributeRelationTypes$: ObservableComputed<
-    Record<string, { typeId: string; typeName: string | null; spaceId: string }[]>
-  >;
 
   constructor({
     initialTriples,
@@ -279,65 +275,6 @@ export class EntityStore implements IEntityStore {
     this.typeTriples$ = computed(() => {
       return this.triples$.get().filter(triple => triple.attributeId === SYSTEM_IDS.TYPES && triple.value.id !== '');
     });
-
-    this.attributeRelationTypes$ = makeOptionalComputed(
-      {},
-      computed(async () => {
-        const triples = this.triples$.get();
-        const schemaTriples = this.schemaTriples$.get();
-
-        // 1. Fetch all attributes that are entity values
-        // 2. Filter attributes that have the relation type attribute
-        // 3. Return the type id and name of the relation type
-
-        // Filter out any duplicate attributes across triples + schemaTriples.
-        // Also ensure they are entity values.
-        const attributesWithRelationValues = [
-          ...new Set([...triples, ...schemaTriples].filter(t => t.value.type === 'entity').map(t => t.attributeId)),
-        ];
-
-        // Make sure we merge any unpublished entities
-        const mergedStore = new Merged({
-          store: this.ActionsStore,
-          localStore: this.LocalStore,
-          subgraph,
-        });
-        const maybeRelationAttributeTypes = await Promise.all(
-          attributesWithRelationValues.map(attributeId =>
-            mergedStore.fetchEntity({ id: attributeId, endpoint: config.subgraph })
-          )
-        );
-
-        const relationTypeEntities = maybeRelationAttributeTypes.flatMap(a => (a ? a.triples : []));
-
-        // Merge all local and server triples
-        const mergedTriples = A.uniqBy(
-          Triple.fromActions(this.ActionsStore.allActions$.get(), relationTypeEntities),
-          t => t.id
-        );
-
-        const relationTypes = mergedTriples.filter(
-          t => t.attributeId === SYSTEM_IDS.RELATION_VALUE_RELATIONSHIP_TYPE && t.value.type === 'entity'
-        );
-
-        return relationTypes.reduce<Record<string, { typeId: string; typeName: string | null; spaceId: string }[]>>(
-          (acc, relationType) => {
-            if (!acc[relationType.entityId]) acc[relationType.entityId] = [];
-
-            acc[relationType.entityId].push({
-              typeId: relationType.value.id,
-
-              // We can safely cast here because we filter for entity type values above.
-              typeName: (relationType.value as EntityValue).name,
-              spaceId: relationType.space,
-            });
-
-            return acc;
-          },
-          {}
-        );
-      })
-    );
 
     /*
     Computed values in @legendapp/state will rerun for every change recursively up the tree.

--- a/apps/web/core/types.ts
+++ b/apps/web/core/types.ts
@@ -188,3 +188,11 @@ export type AppEnv = 'development' | 'staging' | 'testnet' | 'production';
 export type ServerSideEnvParams = {
   env?: AppEnv;
 };
+
+export type RelationValueType = {
+  typeId: string;
+  typeName: string | null;
+  spaceIdOfAttribute: string;
+};
+
+export type RelationValueTypesByAttributeId = Record<string, Array<RelationValueType>>;

--- a/apps/web/core/utils/action/action.ts
+++ b/apps/web/core/utils/action/action.ts
@@ -118,6 +118,16 @@ export function squashChanges(actions: Action[]) {
         return null;
       }
 
+      // Delete->Create where the previous triple is the same as the new triple
+      if (changeTuple[0].type === 'deleteTriple' && changeTuple[1].type === 'createTriple') {
+        if (
+          changeTuple[0].value.type === changeTuple[1].value.type &&
+          getValue(changeTuple[0]) === getValue(changeTuple[1])
+        ) {
+          return null;
+        }
+      }
+
       // Edit -> Edit where the value types are the same and the before/after values are the same.
       // We don't need to send this to the subgraph.
       if (changeTuple[0].type === 'editTriple' && changeTuple[1].type === 'editTriple') {

--- a/apps/web/core/utils/value/value.ts
+++ b/apps/web/core/utils/value/value.ts
@@ -1,4 +1,6 @@
-import type { Triple } from '~/core/types';
+import { SYSTEM_IDS } from '@geogenesis/ids';
+
+import type { EntityValue, Triple } from '~/core/types';
 
 import { getImageHash } from '../utils';
 
@@ -40,4 +42,8 @@ export function toImageValue(rawValue: string) {
   } else {
     return '';
   }
+}
+
+export function isRelationValueType(t: Triple): t is Triple & { value: EntityValue } {
+  return t.value.type === 'entity' && t.attributeId === SYSTEM_IDS.RELATION_VALUE_RELATIONSHIP_TYPE;
 }

--- a/apps/web/partials/entity-page/attribute-configuration-menu.tsx
+++ b/apps/web/partials/entity-page/attribute-configuration-menu.tsx
@@ -8,13 +8,13 @@ import * as React from 'react';
 
 import { useActionsStore } from '~/core/hooks/use-actions-store';
 import { useAutocomplete } from '~/core/hooks/use-autocomplete';
-import { RelationValueType, useEntityPageStore } from '~/core/hooks/use-entity-page-store';
+import { useEntityPageStore } from '~/core/hooks/use-entity-page-store';
 import { useSpaces } from '~/core/hooks/use-spaces';
 import { Merged } from '~/core/merged';
 import { Services } from '~/core/services';
 import { useActionsStoreInstance } from '~/core/state/actions-store';
 import { useLocalStoreInstance } from '~/core/state/local-store';
-import { Entity } from '~/core/types';
+import { Entity, RelationValueType } from '~/core/types';
 import { Triple } from '~/core/utils/triple';
 import { NavUtils } from '~/core/utils/utils';
 

--- a/apps/web/partials/entity-page/attribute-configuration-menu.tsx
+++ b/apps/web/partials/entity-page/attribute-configuration-menu.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { SYSTEM_IDS } from '@geogenesis/ids';
+import { useQuery } from '@tanstack/react-query';
 import { Command } from 'cmdk';
 
 import * as React from 'react';
@@ -9,6 +10,10 @@ import { useActionsStore } from '~/core/hooks/use-actions-store';
 import { useAutocomplete } from '~/core/hooks/use-autocomplete';
 import { RelationValueType, useEntityPageStore } from '~/core/hooks/use-entity-page-store';
 import { useSpaces } from '~/core/hooks/use-spaces';
+import { Merged } from '~/core/merged';
+import { Services } from '~/core/services';
+import { useActionsStoreInstance } from '~/core/state/actions-store';
+import { useLocalStoreInstance } from '~/core/state/local-store';
 import { Entity } from '~/core/types';
 import { Triple } from '~/core/utils/triple';
 import { NavUtils } from '~/core/utils/utils';
@@ -27,20 +32,61 @@ interface Props {
 
 export function AttributeConfigurationMenu({ attributeId, attributeName }: Props) {
   const [open, setOpen] = React.useState(false);
+  const localStore = useLocalStoreInstance();
+  const store = useActionsStoreInstance();
+
+  const { subgraph, config } = Services.useServices();
+
+  const merged = React.useMemo(
+    () =>
+      new Merged({
+        store,
+        localStore,
+        subgraph,
+      }),
+    [store, localStore, subgraph]
+  );
+
+  // To add the relation value type triple to the correct space we need to fetch
+  // the attribute and read the space off one of the triples.
+  //
+  // The attribute being fetched might only exist locally so we need to use the merged
+  // API to fetch both local and remote data.
+  const { data: tripleForAttributeId } = useQuery({
+    queryKey: ['attribute-search', attributeId],
+    queryFn: () =>
+      merged.fetchTriples({
+        query: '',
+        first: 1,
+        skip: 0,
+        endpoint: config.subgraph,
+        filter: [
+          {
+            field: 'entity-id',
+            value: attributeId,
+          },
+        ],
+      }),
+  });
+
+  const spaceIdForAttribute = tripleForAttributeId?.[0].space ?? '';
 
   return (
     <Menu open={open} onOpenChange={setOpen} trigger={<SquareButton icon="cog" />}>
       <div className="flex flex-col gap-2 bg-white">
         <h1 className="px-2 pt-2 text-metadataMedium">Add relation types (optional)</h1>
-        <AttributeSearch attributeId={attributeId} attributeName={attributeName} />
+        <AttributeSearch
+          attributeId={attributeId}
+          attributeName={attributeName}
+          attributeSpaceId={spaceIdForAttribute}
+        />
       </div>
     </Menu>
   );
 }
 
-function AttributeSearch({ attributeId, attributeName }: Props) {
+function AttributeSearch({ attributeId, attributeName, attributeSpaceId }: Props & { attributeSpaceId: string }) {
   const { attributeRelationTypes } = useEntityPageStore();
-
   const { create, remove } = useActionsStore();
 
   const autocomplete = useAutocomplete({
@@ -53,16 +99,18 @@ function AttributeSearch({ attributeId, attributeName }: Props) {
 
   const alreadySelectedTypes = relationValueTypesForAttribute.map(st => st.typeId);
 
-  const onSelect = (result: Entity) => {
-    autocomplete.onQueryChange('');
-
+  const onSelect = async (result: Entity) => {
     create(
       Triple.withId({
         entityId: attributeId,
         attributeId: SYSTEM_IDS.RELATION_VALUE_RELATIONSHIP_TYPE,
         attributeName: 'Relation Value Types',
         entityName: attributeName,
-        space: result.nameTripleSpace ?? '',
+
+        // Ensure that we create the triple for the relation value type in the same space
+        // as the attribute itself. Eventually we might want space-scoped triples for data
+        // in which case we would want to set triple in the current space instead.
+        space: attributeSpaceId,
         value: {
           type: 'entity',
           id: result.id,
@@ -79,7 +127,7 @@ function AttributeSearch({ attributeId, attributeName }: Props) {
         attributeId: SYSTEM_IDS.RELATION_VALUE_RELATIONSHIP_TYPE,
         attributeName: 'Relation Value Types',
         entityName: attributeName,
-        space: spaceIdOfAttribute, // @TODO: This should the spaceId of the attribute, not the type.
+        space: spaceIdOfAttribute,
         value: {
           type: 'entity',
           id: typeId,

--- a/apps/web/partials/entity-page/attribute-configuration-menu.tsx
+++ b/apps/web/partials/entity-page/attribute-configuration-menu.tsx
@@ -7,6 +7,7 @@ import * as React from 'react';
 
 import { useActionsStore } from '~/core/hooks/use-actions-store';
 import { useAutocomplete } from '~/core/hooks/use-autocomplete';
+import { useEntityPageStore } from '~/core/hooks/use-entity-page-store';
 import { useSpaces } from '~/core/hooks/use-spaces';
 import { Entity } from '~/core/types';
 import { Triple } from '~/core/utils/triple';
@@ -22,23 +23,24 @@ interface Props {
   // This is the entityId of the attribute being configured with a relation type.
   attributeId: string;
   attributeName: string | null;
-  configuredTypes: { typeId: string; typeName: string | null; spaceId: string }[];
 }
 
-export function AttributeConfigurationMenu({ attributeId, attributeName, configuredTypes }: Props) {
+export function AttributeConfigurationMenu({ attributeId, attributeName }: Props) {
   const [open, setOpen] = React.useState(false);
 
   return (
     <Menu open={open} onOpenChange={setOpen} trigger={<SquareButton icon="cog" />}>
       <div className="flex flex-col gap-2 bg-white">
         <h1 className="px-2 pt-2 text-metadataMedium">Add relation types (optional)</h1>
-        <AttributeSearch attributeId={attributeId} attributeName={attributeName} configuredTypes={configuredTypes} />
+        <AttributeSearch attributeId={attributeId} attributeName={attributeName} />
       </div>
     </Menu>
   );
 }
 
-function AttributeSearch({ attributeId, attributeName, configuredTypes }: Props) {
+function AttributeSearch({ attributeId, attributeName }: Props) {
+  const { attributeRelationTypes } = useEntityPageStore();
+
   const { create, remove } = useActionsStore();
 
   const autocomplete = useAutocomplete({
@@ -47,7 +49,11 @@ function AttributeSearch({ attributeId, attributeName, configuredTypes }: Props)
 
   const { spaces } = useSpaces();
 
-  const alreadySelectedTypes = configuredTypes.map(st => st.typeId);
+  const relationValueTypesForAttribute = attributeRelationTypes[attributeId] ?? [];
+
+  console.log('mergedTypes', relationValueTypesForAttribute);
+
+  const alreadySelectedTypes = relationValueTypesForAttribute.map(st => st.typeId);
 
   const onSelect = (result: Entity) => {
     autocomplete.onQueryChange('');
@@ -91,7 +97,7 @@ function AttributeSearch({ attributeId, attributeName, configuredTypes }: Props)
         <Input onChange={e => autocomplete.onQueryChange(e.currentTarget.value)} />
       </div>
       <div className="mb-2 flex flex-wrap items-center gap-2 px-2">
-        {configuredTypes.map(st => (
+        {relationValueTypesForAttribute.map(st => (
           <DeletableChipButton
             href={NavUtils.toEntity(st.spaceId, st.typeId)}
             onClick={() => onRemove(st)}

--- a/apps/web/partials/entity-page/attribute-configuration-menu.tsx
+++ b/apps/web/partials/entity-page/attribute-configuration-menu.tsx
@@ -7,7 +7,7 @@ import * as React from 'react';
 
 import { useActionsStore } from '~/core/hooks/use-actions-store';
 import { useAutocomplete } from '~/core/hooks/use-autocomplete';
-import { useEntityPageStore } from '~/core/hooks/use-entity-page-store';
+import { RelationValueType, useEntityPageStore } from '~/core/hooks/use-entity-page-store';
 import { useSpaces } from '~/core/hooks/use-spaces';
 import { Entity } from '~/core/types';
 import { Triple } from '~/core/utils/triple';
@@ -51,8 +51,6 @@ function AttributeSearch({ attributeId, attributeName }: Props) {
 
   const relationValueTypesForAttribute = attributeRelationTypes[attributeId] ?? [];
 
-  console.log('mergedTypes', relationValueTypesForAttribute);
-
   const alreadySelectedTypes = relationValueTypesForAttribute.map(st => st.typeId);
 
   const onSelect = (result: Entity) => {
@@ -74,14 +72,14 @@ function AttributeSearch({ attributeId, attributeName }: Props) {
     );
   };
 
-  const onRemove = ({ typeId, spaceId, typeName }: { typeId: string; spaceId: string; typeName: string | null }) => {
+  const onRemove = ({ typeId, spaceIdOfAttribute, typeName }: RelationValueType) => {
     remove(
       Triple.withId({
         entityId: attributeId,
         attributeId: SYSTEM_IDS.RELATION_VALUE_RELATIONSHIP_TYPE,
         attributeName: 'Relation Value Types',
         entityName: attributeName,
-        space: spaceId,
+        space: spaceIdOfAttribute, // @TODO: This should the spaceId of the attribute, not the type.
         value: {
           type: 'entity',
           id: typeId,
@@ -99,7 +97,7 @@ function AttributeSearch({ attributeId, attributeName }: Props) {
       <div className="mb-2 flex flex-wrap items-center gap-2 px-2">
         {relationValueTypesForAttribute.map(st => (
           <DeletableChipButton
-            href={NavUtils.toEntity(st.spaceId, st.typeId)}
+            href={NavUtils.toEntity(st.spaceIdOfAttribute, st.typeId)}
             onClick={() => onRemove(st)}
             key={st.typeId}
           >

--- a/apps/web/partials/entity-page/editable-entity-page.tsx
+++ b/apps/web/partials/entity-page/editable-entity-page.tsx
@@ -10,7 +10,7 @@ import { useEntityPageStore } from '~/core/hooks/use-entity-page-store';
 import { EntityOthersToast } from '~/core/presence/entity-others-toast';
 import { EntityPresenceProvider } from '~/core/presence/presence-provider';
 import { Services } from '~/core/services';
-import { Triple as ITriple, TripleValueType } from '~/core/types';
+import { Triple as ITriple, RelationValueTypesByAttributeId, TripleValueType } from '~/core/types';
 import { Entity } from '~/core/utils/entity';
 import { NavUtils, groupBy } from '~/core/utils/utils';
 
@@ -186,7 +186,7 @@ function EntityAttributes({
   name: string;
   hideSchema: (id: string) => void;
   hiddenSchemaIds: string[];
-  allowedTypes: Record<string, { typeId: string; typeName: string | null; spaceId: string }[]>;
+  allowedTypes: RelationValueTypesByAttributeId;
   spaceId: string;
 }) {
   const tripleAttributeIds = triples.map(triple => triple.attributeId);

--- a/apps/web/partials/entity-page/editable-entity-page.tsx
+++ b/apps/web/partials/entity-page/editable-entity-page.tsx
@@ -566,11 +566,7 @@ function EntityAttributes({
               )}
               <div className="absolute top-6 right-0 flex items-center gap-1">
                 {isEntityGroup ? (
-                  <AttributeConfigurationMenu
-                    attributeId={attributeId}
-                    attributeName={attributeName}
-                    configuredTypes={relationTypes}
-                  />
+                  <AttributeConfigurationMenu attributeId={attributeId} attributeName={attributeName} />
                 ) : null}
                 {!isPlaceholder && (
                   <>


### PR DESCRIPTION
This PR updates the code for reading and manipulating attribute value types in the attribute configuration menu. Previously the code to re-run and read the attribute value types for a given attribute did not execute deterministically, sometimes returning updated values and sometimes not. This is likely due to some internal memoization in the Legendstate observable code.

I've removed the observable-based logic on the store to instead run procedurally in an idiomatic, react-y way. This is now more deterministic and executes as expected. Deterministic executions has been an issue using legendstate the way we do, so this PR also serves as a PoC for moving to new patterns that don't use legendstate observables directly in application state models, eventually phasing out Legendstate entirely for some other approach.

Additionally, this PR fixes a bug where adding a relation value type triple will add the triple to the active space instead of the space in which the attribute lives. In the future this might be desirable behavior as it would allow each space to consume an attribute's configuration differently. For now all spaces expect to read the configuration the same way.