### PR TITLE
fix: clean up attribute relation value type implementation

### DIFF
--- a/apps/web/partials/entity-page/attribute-configuration-menu.tsx
+++ b/apps/web/partials/entity-page/attribute-configuration-menu.tsx
@@ -69,23 +69,19 @@ export function AttributeConfigurationMenu({ attributeId, attributeName }: Props
       }),
   });
 
-  const spaceIdForAttribute = tripleForAttributeId?.[0].space ?? '';
+  const attributeSpaceId = tripleForAttributeId?.[0].space;
 
   return (
     <Menu open={open} onOpenChange={setOpen} trigger={<SquareButton icon="cog" />}>
       <div className="flex flex-col gap-2 bg-white">
         <h1 className="px-2 pt-2 text-metadataMedium">Add relation types (optional)</h1>
-        <AttributeSearch
-          attributeId={attributeId}
-          attributeName={attributeName}
-          attributeSpaceId={spaceIdForAttribute}
-        />
+        <AttributeSearch attributeId={attributeId} attributeName={attributeName} attributeSpaceId={attributeSpaceId} />
       </div>
     </Menu>
   );
 }
 
-function AttributeSearch({ attributeId, attributeName, attributeSpaceId }: Props & { attributeSpaceId: string }) {
+function AttributeSearch({ attributeId, attributeName, attributeSpaceId }: Props & { attributeSpaceId?: string }) {
   const { attributeRelationTypes } = useEntityPageStore();
   const { create, remove } = useActionsStore();
 
@@ -100,6 +96,8 @@ function AttributeSearch({ attributeId, attributeName, attributeSpaceId }: Props
   const alreadySelectedTypes = relationValueTypesForAttribute.map(st => st.typeId);
 
   const onSelect = async (result: Entity) => {
+    if (!attributeSpaceId) return;
+
     create(
       Triple.withId({
         entityId: attributeId,

--- a/apps/web/partials/review/review.tsx
+++ b/apps/web/partials/review/review.tsx
@@ -886,8 +886,8 @@ const timeClassNames = `w-[21px] tabular-nums bg-transparent p-0 m-0 text-body`;
 const useChanges = (actions: Array<ActionType> = [], spaceId: string) => {
   const { subgraph, config } = Services.useServices();
   const { data, isLoading } = useQuery({
-    queryKey: [`${spaceId}-changes-${actions.length}`],
-    queryFn: async () => Change.fromActions(actions, subgraph, config),
+    queryKey: ['changes', spaceId, actions],
+    queryFn: async () => Change.fromActions(Action.prepareActionsForPublishing(actions), subgraph, config),
   });
 
   return [data, isLoading] as const;


### PR DESCRIPTION
This PR adds back reverted logic for squashing actions before review time. Additionally, it adds code to handle cases where we are still fetching the space for the attribute id. Lastly it works around an edge-case in `fromActions` where merging an already merged set of triples will result in duplicates.