### PR TITLE
fix: duplicate triples in fromActions

### DIFF
--- a/apps/web/core/state/entity-page-store/entity-store.ts
+++ b/apps/web/core/state/entity-page-store/entity-store.ts
@@ -145,11 +145,7 @@ export class EntityStore implements IEntityStore {
           Triple.withLocalNames(
             Object.values(ActionsStore.actions$.get()).flatMap(a => a),
             triples
-          ),
-        // This is a hack to render a single triple even if there are multiple in the store the
-        // issue happens in triple.fromActions() not deduplicating when deleting and recreating a
-        // triple of the same id
-        A.uniqBy(t => t.id)
+          )
       );
     });
 

--- a/apps/web/core/utils/triple/triple.ts
+++ b/apps/web/core/utils/triple/triple.ts
@@ -100,7 +100,7 @@ export function ensureStableId(triple: Triple): Triple {
   return triple;
 }
 
-export function fromActions(actions: ActionType[] | undefined, triples: Triple[]) {
+export function fromActions(actions: ActionType[] | undefined, triples: Triple[]): Triple[] {
   if (!actions) return triples;
 
   const newTriples: Triple[] = [...triples].reverse();
@@ -144,13 +144,20 @@ export function fromActions(actions: ActionType[] | undefined, triples: Triple[]
     }
   });
 
-  return newTriples.reverse();
+  // We might be merging actions into a set of triples that have already been merged. In this
+  // case we need to replace the existing triple instead of adding a new one. Failing to do
+  // this will result in duplicate triples in the store since we have added the `createTriple`
+  // action multiple times.
+  //
+  // One option to solve this is to handle this edge-case in the `createTriple` part of the above
+  // switch. For now, though, the simplest way is to remove duplicate triples here.
+  return A.uniqBy(newTriples, t => t.id).reverse();
 }
 
 /**
  * This function applies locally changed entity names to all triples being rendered.
  */
-export function withLocalNames(actions: ActionType[], triples: Triple[]) {
+export function withLocalNames(actions: ActionType[], triples: Triple[]): Triple[] {
   const newEntityNames = pipe(
     actions,
     A.map(a => {

--- a/apps/web/partials/blocks/table/table-block-table.tsx
+++ b/apps/web/partials/blocks/table/table-block-table.tsx
@@ -100,8 +100,7 @@ const defaultColumn: Partial<ColumnDef<Row>> = {
         const isCurrentValueType = triple.value.type === valueTypes[valueType];
 
         return isRowCell && isColCell && isCurrentValueType;
-      }),
-      A.uniqBy(triple => triple.id)
+      })
     );
 
     if (isEditMode) {

--- a/apps/web/partials/entities-page/entity-table.tsx
+++ b/apps/web/partials/entities-page/entity-table.tsx
@@ -101,8 +101,7 @@ const defaultColumn: Partial<ColumnDef<Row>> = {
         const isCurrentValueType = triple.value.type === valueTypes[valueType];
 
         return isRowCell && isColCell && isCurrentValueType;
-      }),
-      A.uniqBy(triple => triple.id)
+      })
     );
 
     if (isEditMode) {

--- a/apps/web/partials/entity-page/editable-entity-table-column-header.tsx
+++ b/apps/web/partials/entity-page/editable-entity-table-column-header.tsx
@@ -43,8 +43,7 @@ export const EditableEntityTableColumnHeader = memo(function EditableEntityTable
 
   const localTriples = pipe(
     Triple.fromActions(actionsFromSpace, column.triples),
-    A.filter(t => t.entityId === column.id),
-    A.uniqBy(t => t.id)
+    A.filter(t => t.entityId === column.id)
   );
 
   const localCellTriples = pipe(


### PR DESCRIPTION
This can happen if we are running `fromActions` on an array of triples that has already had `fromActions` run on it.

In this case we need to replace the existing triple instead of adding a new one. Otherwise we will get duplicate triples since we've added the `createTriple` action as a triple multiple times.

For now we dedupe the entire triples array at the end of `fromActions`. If this becomes a performance problem we can instead dedupe at the `createTriple` section of the switch statement in `fromActions` instead.