### PR TITLE
fix: remove staging IPFS endpoints

### DIFF
--- a/apps/web/core/environment/environment.ts
+++ b/apps/web/core/environment/environment.ts
@@ -15,13 +15,13 @@ export const options: Record<AppEnv, AppConfig> = {
   development: {
     chainId: '31337',
     rpc: 'http://localhost:8545',
-    ipfs: 'https://api.staging.thegraph.com/ipfs',
+    ipfs: 'https://api.thegraph.com/ipfs',
     subgraph: 'http://localhost:8000/subgraphs/name/example',
   },
   staging: {
     chainId: '1337',
     rpc: 'https://devnet-dabbott.cloud.okteto.net',
-    ipfs: 'https://api.staging.thegraph.com/ipfs',
+    ipfs: 'https://api.thegraph.com/ipfs',
     subgraph: 'https://graph-node-8000-dabbott.cloud.okteto.net/subgraphs/name/example',
   },
   testnet: {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ services:
       postgres_user: graph-node
       postgres_pass: let-me-in
       postgres_db: graph-node
-      ipfs: 'https://api.staging.thegraph.com/ipfs/'
+      ipfs: 'https://api.thegraph.com/ipfs/'
       ethereum: 'mainnet:http://devnet:8545'
       GRAPH_LOG: debug
       GRAPH_IPFS_TIMEOUT: 10
@@ -82,7 +82,7 @@ services:
       dockerfile: ./docker/Build.dockerfile
     environment:
       GRAPH_NODE_URL: http://graph-node:8020
-      IPFS_URL: https://api.staging.thegraph.com/ipfs/
+      IPFS_URL: https://api.thegraph.com/ipfs/
     command: >
       sh -c "pnpm --filter subgraph run update-contract-address:local &&
       pnpm --filter subgraph run cat &&

--- a/packages/subgraph/package.json
+++ b/packages/subgraph/package.json
@@ -13,7 +13,7 @@
     "deploy:production": "graph deploy --product hosted-service --network matic baiirun/geo",
     "deploy:staging": "graph deploy --product hosted-service --network matic baiirun/geo-staging",
     "cat": "cat subgraph.yaml",
-    "local": "GRAPH_NODE_URL=http://127.0.0.1:8020 IPFS_URL=https://api.staging.thegraph.com/ipfs npm run",
+    "local": "GRAPH_NODE_URL=http://127.0.0.1:8020 IPFS_URL=https://api.thegraph.com/ipfs npm run",
     "local:create": "npm run local create",
     "local:deploy": "npm run local deploy",
     "update-contract-address:local": "yq -i \".mainnet.SpaceRegistry.address = $(jq .SpaceRegistry.address ../contracts/addresses/localhost.json)\" networks.json",


### PR DESCRIPTION
It appears that the staging IPFS endpoints are down (under maintenance) which is affecting our local dev environment. For now we can point to the non-staging IPFS endpoints in dev.