### PR TITLE
feat: migrate value types

### DIFF
--- a/apps/web/core/io/mocks/mock-network.ts
+++ b/apps/web/core/io/mocks/mock-network.ts
@@ -1,7 +1,7 @@
 import { SYSTEM_IDS } from '@geogenesis/ids';
 import { observable } from '@legendapp/state';
 
-import { Space, Triple, Value } from '~/core/types';
+import { Space, Triple, TripleWithDateValue, TripleWithStringValue, TripleWithUrlValue, Value } from '~/core/types';
 import { Entity } from '~/core/utils/entity';
 
 import { Subgraph } from '..';
@@ -85,6 +85,54 @@ export const makeStubRelationAttribute = (name: string): Triple => {
       id: SYSTEM_IDS.RELATION,
     },
     space: 's',
+  };
+};
+
+export const makeStubTripleWithStringValue = (value: string): TripleWithStringValue => {
+  return {
+    id: `id~${value}`,
+    entityId: `entityId~${value}`,
+    entityName: `entityName~${value}`,
+    attributeId: `attributeId~${value}`,
+    attributeName: `attributeName~${value}`,
+    value: {
+      type: 'string',
+      value,
+      id: `s~${value}`,
+    },
+    space: `space~${value}`,
+  };
+};
+
+export const makeStubTripleWithDateValue = (value: string): TripleWithDateValue => {
+  return {
+    id: `id~${value}`,
+    entityId: `entityId~${value}`,
+    entityName: `entityName~${value}`,
+    attributeId: `attributeId~${value}`,
+    attributeName: `attributeName~${value}`,
+    value: {
+      type: 'date',
+      value,
+      id: `d~${value}`,
+    },
+    space: `space~${value}`,
+  };
+};
+
+export const makeStubTripleWithUrlValue = (value: string): TripleWithUrlValue => {
+  return {
+    id: `id~${value}`,
+    entityId: `entityId~${value}`,
+    entityName: `entityName~${value}`,
+    attributeId: `attributeId~${value}`,
+    attributeName: `attributeName~${value}`,
+    value: {
+      type: 'url',
+      value,
+      id: `u~${value}`,
+    },
+    space: `space~${value}`,
   };
 };
 

--- a/apps/web/core/migrate/migrate.tsx
+++ b/apps/web/core/migrate/migrate.tsx
@@ -167,8 +167,6 @@ async function migrate(action: MigrateAction, config: MigrateHubConfig) {
        * If we are migrating between types that can't be migrated we delete all
        * existing triples with the old type.
        */
-      // @TODO: Batch update
-
       batch(() => {
         for (const triple of triplesWithAttribute) {
           // config.actionsApi.remove(triple);

--- a/apps/web/core/migrate/migrate.tsx
+++ b/apps/web/core/migrate/migrate.tsx
@@ -154,41 +154,43 @@ async function migrate(action: MigrateAction, config: MigrateHubConfig) {
        * existing triples with the old type.
        */
       // @TODO: Batch update
-      for (const triple of triplesWithAttribute) {
-        const value = triple.value;
+      triplesWithAttribute.forEach(triple => {
+        config.actionsApi.remove(triple);
 
-        if (value.type !== oldValueType) {
-          // delete
-          continue;
-        }
+        // const value = triple.value;
 
-        switch (value.type) {
-          case 'string': {
-            // can migrate to date
-            // can migrate to url
-            // delete otherwise
-            break;
-          }
+        // @TODO: For now we just delete the old triple
+        // if (value.type !== oldValueType) {
+        //   // delete
+        //   continue;
+        // }
 
-          case 'date': {
-            // can migrate to string
-            // delete otherwise
-            break;
-          }
+        // switch (value.type) {
+        //   case 'string': {
 
-          case 'url': {
-            // can migrate to string
-            // delete otherwise
-            break;
-          }
+        //     // can migrate to date
+        //     // can migrate to url
+        //     // delete otherwise
+        //     break;
+        //   }
 
-          default:
-            // delete
-            break;
-        }
-      }
+        //   case 'date': {
+        //     // can migrate to string
+        //     // delete otherwise
+        //     break;
+        //   }
 
-      break;
+        //   case 'url': {
+        //     // can migrate to string
+        //     // delete otherwise
+        //     break;
+        //   }
+
+        //   default:
+        //     // delete
+        //     break;
+        // }
+      });
     }
   }
 }

--- a/apps/web/core/migrate/migrate.tsx
+++ b/apps/web/core/migrate/migrate.tsx
@@ -173,9 +173,9 @@ async function migrate(action: MigrateAction, config: MigrateHubConfig) {
 
           const value = triple.value;
 
-          // @TODO: For now we just delete the old triple
+          // We just delete the old triple if its value type does not match the value
+          // type of the attribute.
           if (value.type !== oldValueType) {
-            // delete
             config.actionsApi.remove(triple);
             continue;
           }

--- a/apps/web/core/migrate/migrate.tsx
+++ b/apps/web/core/migrate/migrate.tsx
@@ -1,4 +1,5 @@
 import { batch } from '@legendapp/state';
+import { A } from '@mobily/ts-belt';
 import { QueryClient } from '@tanstack/query-core';
 import { useQueryClient } from '@tanstack/react-query';
 
@@ -78,12 +79,18 @@ async function migrate(action: MigrateAction, config: MigrateHubConfig) {
               ],
             });
 
-            page = page + 1;
-            triplesReferencingEntity.push(...triplesChunk);
+            // graph-node allows you to page past the last entry. Doing so will return an empty array.
+            // We can use this to determine if we have reached the end of the triples. This will result
+            // in an extra network call, but that's not a big deal right now. Newer Geo APIs will allow
+            // us to know the number of entries ahead of time to avoid this.
+            const newHead: ITriple | undefined = triplesChunk[0];
 
-            if (triplesChunk.length < FIRST) {
+            if (!newHead) {
               isRemainingTriples = true;
             }
+
+            page = page + 1;
+            triplesReferencingEntity.push(...triplesChunk);
           }
 
           return triplesReferencingEntity;
@@ -126,12 +133,18 @@ async function migrate(action: MigrateAction, config: MigrateHubConfig) {
               ],
             });
 
-            page = page + 1;
-            triplesReferencingEntity.push(...triplesChunk);
+            // graph-node allows you to page past the last entry. Doing so will return an empty array.
+            // We can use this to determine if we have reached the end of the triples. This will result
+            // in an extra network call, but that's not a big deal right now. Newer Geo APIs will allow
+            // us to know the number of entries ahead of time to avoid this.
+            const newHead: ITriple | undefined = triplesChunk[0];
 
-            if (triplesChunk.length < FIRST) {
+            if (!newHead) {
               isRemainingTriples = true;
             }
+
+            page = page + 1;
+            triplesReferencingEntity.push(...triplesChunk);
           }
 
           return triplesReferencingEntity;

--- a/apps/web/core/migrate/utils.test.ts
+++ b/apps/web/core/migrate/utils.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+
+import { makeStubTripleWithStringValue } from '../io/mocks/mock-network';
+import { migrateStringTripleToDateTriple } from './utils';
+
+describe('migration utils', () => {
+  it('migrates from string to date for valid date', () => {
+    const triple = makeStubTripleWithStringValue('01/01/2020');
+    const migratedTriple = migrateStringTripleToDateTriple(triple);
+    expect(migratedTriple?.value).toMatchObject({
+      type: 'string',
+      value: '2020-01-01T00:00:00.000Z',
+      id: 's~01/01/2020',
+    });
+  });
+
+  it('migrates from string to date for invalid date', () => {
+    const triple = makeStubTripleWithStringValue('banana sandwich');
+    const migratedTriple = migrateStringTripleToDateTriple(triple);
+    expect(migratedTriple).toBe(null);
+  });
+
+  // it('migrates from string to url for valid url', () => {});
+  // it('migrates from string to url for invalid url', () => {});
+
+  // it('migrates from date to string', () => {});
+
+  // it('migrates from url to string', () => {});
+});

--- a/apps/web/core/migrate/utils.test.ts
+++ b/apps/web/core/migrate/utils.test.ts
@@ -1,29 +1,67 @@
 import { describe, expect, it } from 'vitest';
 
-import { makeStubTripleWithStringValue } from '../io/mocks/mock-network';
-import { migrateStringTripleToDateTriple } from './utils';
+import {
+  makeStubTripleWithDateValue,
+  makeStubTripleWithStringValue,
+  makeStubTripleWithUrlValue,
+} from '../io/mocks/mock-network';
+import {
+  migrateDateTripleToStringTriple,
+  migrateStringTripleToDateTriple,
+  migrateStringTripleToUrlTriple,
+  migrateUrlTripleToStringTriple,
+} from './utils';
 
 describe('migration utils', () => {
   it('migrates from string to date for valid date', () => {
     const triple = makeStubTripleWithStringValue('01/01/2020');
     const migratedTriple = migrateStringTripleToDateTriple(triple);
     expect(migratedTriple?.value).toMatchObject({
-      type: 'string',
+      type: 'date',
       value: '2020-01-01T00:00:00.000Z',
       id: 's~01/01/2020',
     });
   });
 
   it('migrates from string to date for invalid date', () => {
-    const triple = makeStubTripleWithStringValue('banana sandwich');
+    const triple = makeStubTripleWithStringValue('banana');
     const migratedTriple = migrateStringTripleToDateTriple(triple);
     expect(migratedTriple).toBe(null);
   });
 
-  // it('migrates from string to url for valid url', () => {});
-  // it('migrates from string to url for invalid url', () => {});
+  it('migrates from string to url for valid url', () => {
+    const triple = makeStubTripleWithStringValue('https://www.google.com');
+    const migratedTriple = migrateStringTripleToUrlTriple(triple);
+    expect(migratedTriple?.value).toMatchObject({
+      type: 'url',
+      value: 'https://www.google.com',
+      id: 's~https://www.google.com',
+    });
+  });
 
-  // it('migrates from date to string', () => {});
+  it('migrates from string to url for invalid url', () => {
+    const triple = makeStubTripleWithStringValue('banana');
+    const migratedTriple = migrateStringTripleToUrlTriple(triple);
+    expect(migratedTriple).toBe(null);
+  });
 
-  // it('migrates from url to string', () => {});
+  it('migrates from date to string', () => {
+    const triple = makeStubTripleWithDateValue('2020-01-01T00:00:00.000Z');
+    const migratedTriple = migrateDateTripleToStringTriple(triple);
+    expect(migratedTriple?.value).toMatchObject({
+      type: 'string',
+      value: '1/1/2020',
+      id: 'd~2020-01-01T00:00:00.000Z',
+    });
+  });
+
+  it('migrates from url to string', () => {
+    const triple = makeStubTripleWithUrlValue('https://www.google.com');
+    const migratedTriple = migrateUrlTripleToStringTriple(triple);
+    expect(migratedTriple?.value).toMatchObject({
+      type: 'string',
+      value: 'https://www.google.com',
+      id: 'u~https://www.google.com',
+    });
+  });
 });

--- a/apps/web/core/migrate/utils.ts
+++ b/apps/web/core/migrate/utils.ts
@@ -1,13 +1,13 @@
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
 
-import { Triple as ITriple, TripleWithDateValue, TripleWithStringValue, TripleWithUrlValue } from '../types';
+import { TripleWithDateValue, TripleWithStringValue, TripleWithUrlValue } from '../types';
 import { Triple } from '../utils/triple';
 import { GeoDate } from '../utils/utils';
 
 dayjs.extend(utc);
 
-export function migrateStringTripleToDateTriple(triple: TripleWithStringValue): ITriple | null {
+export function migrateStringTripleToDateTriple(triple: TripleWithStringValue): TripleWithDateValue | null {
   // We only attempt to convert dates that are in the format MM/DD/YYYY. There is
   // an infinite number of potential date formats (and formatting errors) with a
   // raw string. The simplest is to choose a single format and delete any triples
@@ -18,23 +18,25 @@ export function migrateStringTripleToDateTriple(triple: TripleWithStringValue): 
     return null;
   }
 
+  const dateValue = GeoDate.toISOStringUTC({
+    day: date.date().toString(),
+    month: (date.month() + 1).toString(),
+    year: date.year().toString(),
+    hour: '0',
+    minute: '0',
+  });
+
   return Triple.ensureStableId({
     ...triple,
     value: {
       ...triple.value,
-      type: 'string',
-      value: GeoDate.toISOStringUTC({
-        day: date.date().toString(),
-        month: (date.month() + 1).toString(),
-        year: date.year().toString(),
-        hour: '0',
-        minute: '0',
-      }),
+      type: 'date',
+      value: dateValue,
     },
   });
 }
 
-export function migrateDateTripleToStringTriple(triple: TripleWithDateValue): ITriple {
+export function migrateDateTripleToStringTriple(triple: TripleWithDateValue): TripleWithStringValue {
   const { day, month, year } = GeoDate.fromISOStringUTC(triple.value.value);
 
   return Triple.ensureStableId({
@@ -47,7 +49,7 @@ export function migrateDateTripleToStringTriple(triple: TripleWithDateValue): IT
   });
 }
 
-export function migrateStringTripleToUrlTriple(triple: TripleWithStringValue): ITriple | null {
+export function migrateStringTripleToUrlTriple(triple: TripleWithStringValue): TripleWithUrlValue | null {
   const isUrl = triple.value.value.startsWith('http://') || triple.value.value.startsWith('https://');
 
   if (!isUrl) {
@@ -58,12 +60,13 @@ export function migrateStringTripleToUrlTriple(triple: TripleWithStringValue): I
     ...triple,
     value: {
       ...triple.value,
-      type: 'string',
+      type: 'url',
+      value: triple.value.value,
     },
   });
 }
 
-export function migrateUrlTripleToStringTriple(triple: TripleWithUrlValue): ITriple {
+export function migrateUrlTripleToStringTriple(triple: TripleWithUrlValue): TripleWithStringValue {
   return Triple.ensureStableId({
     ...triple,
     value: {

--- a/apps/web/core/migrate/utils.ts
+++ b/apps/web/core/migrate/utils.ts
@@ -1,0 +1,75 @@
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+
+import { Triple as ITriple, TripleWithDateValue, TripleWithStringValue, TripleWithUrlValue } from '../types';
+import { Triple } from '../utils/triple';
+import { GeoDate } from '../utils/utils';
+
+dayjs.extend(utc);
+
+export function migrateStringTripleToDateTriple(triple: TripleWithStringValue): ITriple | null {
+  // We only attempt to convert dates that are in the format MM/DD/YYYY. There is
+  // an infinite number of potential date formats (and formatting errors) with a
+  // raw string. The simplest is to choose a single format and delete any triples
+  // that don't match the correct format.
+  const date = dayjs.utc(triple.value.value, 'MM/DD/YYYY');
+
+  if (!date.isValid()) {
+    return null;
+  }
+
+  return Triple.ensureStableId({
+    ...triple,
+    value: {
+      ...triple.value,
+      type: 'string',
+      value: GeoDate.toISOStringUTC({
+        day: date.date().toString(),
+        month: (date.month() + 1).toString(),
+        year: date.year().toString(),
+        hour: '0',
+        minute: '0',
+      }),
+    },
+  });
+}
+
+export function migrateDateTripleToStringTriple(triple: TripleWithDateValue): ITriple {
+  const { day, month, year } = GeoDate.fromISOStringUTC(triple.value.value);
+
+  return Triple.ensureStableId({
+    ...triple,
+    value: {
+      ...triple.value,
+      type: 'string',
+      value: `${month}/${day}/${year}`,
+    },
+  });
+}
+
+export function migrateStringTripleToUrlTriple(triple: TripleWithStringValue): ITriple | null {
+  const isUrl = triple.value.value.startsWith('http://') || triple.value.value.startsWith('https://');
+
+  if (!isUrl) {
+    return null;
+  }
+
+  return Triple.ensureStableId({
+    ...triple,
+    value: {
+      ...triple.value,
+      type: 'string',
+    },
+  });
+}
+
+export function migrateUrlTripleToStringTriple(triple: TripleWithUrlValue): ITriple {
+  return Triple.ensureStableId({
+    ...triple,
+    value: {
+      ...triple.value,
+      type: 'string',
+      value: triple.value.value,
+    },
+  });
+}

--- a/apps/web/core/types.ts
+++ b/apps/web/core/types.ts
@@ -196,3 +196,9 @@ export type RelationValueType = {
 };
 
 export type RelationValueTypesByAttributeId = Record<string, Array<RelationValueType>>;
+
+export type TripleWithStringValue = OmitStrict<Triple, 'value'> & { value: StringValue };
+export type TripleWithEntityValue = OmitStrict<Triple, 'value'> & { value: EntityValue };
+export type TripleWithImageValue = OmitStrict<Triple, 'value'> & { value: ImageValue };
+export type TripleWithDateValue = OmitStrict<Triple, 'value'> & { value: DateValue };
+export type TripleWithUrlValue = OmitStrict<Triple, 'value'> & { value: UrlValue };

--- a/apps/web/core/utils/triple/triple.ts
+++ b/apps/web/core/utils/triple/triple.ts
@@ -100,7 +100,7 @@ export function empty(spaceId: string, entityId: string, type: TripleValueType =
  *
  * Whenever the triple gets published to the network, the subgraph will generate a new ID for the triple.
  */
-export function ensureStableId(triple: Triple): Triple {
+export function ensureStableId<T extends Triple>(triple: T): T {
   return triple;
 }
 

--- a/apps/web/core/utils/triple/triple.ts
+++ b/apps/web/core/utils/triple/triple.ts
@@ -98,7 +98,8 @@ export function empty(spaceId: string, entityId: string, type: TripleValueType =
  * track how triples have changed locally over time for use in change counts, diffing, and
  * squashing local actions before publishing them.
  *
- * Whenever the triple gets published to the network, the subgraph will generate a new ID for the triple.
+ * Whenever the triple gets published to the network, the subgraph will correctly handle updating
+ * the old triple with the new triple.
  */
 export function ensureStableId<T extends Triple>(triple: T): T {
   return triple;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -53,6 +53,7 @@
     "classnames": "^2.3.2",
     "cmdk": "^0.1.21",
     "connectkit": "1.5.1",
+    "dayjs": "^1.11.9",
     "diff": "^5.1.0",
     "effect": "2.0.0-next.21",
     "framer-motion": "^10.15.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,7 @@ importers:
       classnames: ^2.3.2
       cmdk: ^0.1.21
       connectkit: 1.5.1
+      dayjs: ^1.11.9
       diff: ^5.1.0
       effect: 2.0.0-next.21
       eslint: ^8.21.0
@@ -158,6 +159,7 @@ importers:
       classnames: 2.3.2
       cmdk: 0.1.21_rj7ozvcq3uehdlnj3cbwzbi5ce
       connectkit: 1.5.1_cmm52l5usp4p32k7ozxntkoy5q
+      dayjs: 1.11.9
       diff: 5.1.0
       effect: 2.0.0-next.21
       framer-motion: 10.15.2_biqbaboplfbrettd7655fr4n2y
@@ -8229,6 +8231,10 @@ packages:
 
   /dateformat/4.6.3:
     resolution: {integrity: sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==}
+    dev: false
+
+  /dayjs/1.11.9:
+    resolution: {integrity: sha512-QvzAURSbQ0pKdIye2txOzNaHmxtUBXerpY0FJsFXUMKbIZeFm5ht1LS/jFsrncjnmtv8HsG0W2g6c0zUjZWmpA==}
     dev: false
 
   /death/1.1.0:


### PR DESCRIPTION
Previously we would not migrate triples whose Attribute's value type changed. This PR adds functionality to allow changing Attributes. The migration service will attempt to migrate value types that are migrateable. If a value type change, or an individual triple change, is not able to be migrated it will delete the current triples.