### PR TITLE
fix: lint warnings (WIP)

### DIFF
--- a/apps/web/core/cookie/cookie.test.ts
+++ b/apps/web/core/cookie/cookie.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import { getEnv } from './cookie';
 

--- a/apps/web/core/hooks/use-autocomplete.ts
+++ b/apps/web/core/hooks/use-autocomplete.ts
@@ -104,8 +104,10 @@ export function useAutocomplete({ allowedTypes, filter }: AutocompleteOptions = 
   const LocalStore = useLocalStoreInstance();
 
   // @TODO(baiirun): fix this
-  const memoizedAllowedTypes = useMemo(() => allowedTypes, [JSON.stringify(allowedTypes)]);
-  const memoizedFilter = useMemo(() => filter, [JSON.stringify(filter)]);
+  const stringifiedAllowedTypes = JSON.stringify(allowedTypes);
+  const stringifiedFilter = JSON.stringify(filter);
+  const memoizedAllowedTypes = useMemo(() => allowedTypes, [stringifiedAllowedTypes]);
+  const memoizedFilter = useMemo(() => filter, [stringifiedFilter]);
 
   const autocomplete = useMemo(() => {
     return new EntityAutocomplete({

--- a/apps/web/core/state/diff-store/diff-store.tsx
+++ b/apps/web/core/state/diff-store/diff-store.tsx
@@ -28,30 +28,7 @@ type DiffState = {
 
 type CompareMode = 'versions' | 'proposals';
 
-const initialDiffState = {
-  isReviewOpen: false,
-  setIsReviewOpen: (value: boolean) => null,
-  activeSpace: '',
-  setActiveSpace: (value: string) => null,
-  isReadyToPublish: false,
-  setIsReadyToPublish: (value: boolean) => null,
-  isCompareOpen: false,
-  setIsCompareOpen: (value: boolean) => null,
-  compareMode: 'versions' as CompareMode,
-  setCompareMode: (value: CompareMode) => null,
-  activeEntity: '',
-  setActiveEntity: (value: string) => null,
-  selectedVersion: '',
-  setSelectedVersion: (value: string) => null,
-  previousVersion: '',
-  setPreviousVersion: (value: string) => null,
-  selectedProposal: '',
-  setSelectedProposal: (value: string) => null,
-  previousProposal: '',
-  setPreviousProposal: (value: string) => null,
-};
-
-const DiffContext = createContext<DiffState>(initialDiffState);
+const DiffContext = createContext<DiffState | null>(null);
 
 type DiffProviderProps = {
   children: React.ReactNode;
@@ -103,7 +80,7 @@ export const useDiff = () => {
   const value = useContext(DiffContext);
 
   if (!value) {
-    throw new Error(`Missing DiffProvider`);
+    throw new Error(`useDiff must be used within a  DiffProvider`);
   }
 
   return value;

--- a/apps/web/core/state/move-entity-store/move-entity-store.tsx
+++ b/apps/web/core/state/move-entity-store/move-entity-store.tsx
@@ -14,18 +14,7 @@ type MoveEntityState = {
   setEntityId: (value: string) => void;
 };
 
-const initialMoveEntityState = {
-  isMoveReviewOpen: false,
-  setIsMoveReviewOpen: (value: boolean) => null,
-  spaceIdFrom: '',
-  setSpaceIdFrom: (value: string) => null,
-  spaceIdTo: '',
-  setSpaceIdTo: (value: string) => null,
-  entityId: '',
-  setEntityId: (value: string) => null,
-};
-
-const MoveEntityContext = createContext<MoveEntityState>(initialMoveEntityState);
+const MoveEntityContext = createContext<MoveEntityState | null>(null);
 
 type MoveEntityProviderProps = {
   children: React.ReactNode;

--- a/apps/web/design-system/avatar-group.tsx
+++ b/apps/web/design-system/avatar-group.tsx
@@ -1,3 +1,5 @@
+import * as React from 'react';
+
 interface Props {
   children: React.ReactNode;
 }

--- a/apps/web/partials/move-entity/move-entity-review.tsx
+++ b/apps/web/partials/move-entity/move-entity-review.tsx
@@ -1,5 +1,4 @@
 import { SYSTEM_IDS } from '@geogenesis/ids';
-import { batch } from '@legendapp/state';
 import Image from 'next/legacy/image';
 import { useRouter } from 'next/navigation';
 
@@ -7,7 +6,6 @@ import * as React from 'react';
 
 import { useWalletClient } from 'wagmi';
 
-import { useActionsStore } from '~/core/hooks/use-actions-store';
 import { useEntityPageStore } from '~/core/hooks/use-entity-page-store';
 import { useMoveTriplesState } from '~/core/hooks/use-move-triples-state';
 import { usePublish } from '~/core/hooks/use-publish';
@@ -49,7 +47,6 @@ function MoveEntityReviewChanges() {
   const { state: deleteState, dispatch: deleteDispatch } = useMoveTriplesState();
   const [firstPublishComplete, setFirstPublishComplete] = React.useState(false); // to allow the user to reenter only the second publish
   const router = useRouter();
-  const { create, remove } = useActionsStore();
 
   const { data: wallet } = useWalletClient(); // user wallet session
 

--- a/apps/web/partials/navbar/navbar.tsx
+++ b/apps/web/partials/navbar/navbar.tsx
@@ -10,7 +10,6 @@ import { ClientOnly } from '~/design-system/client-only';
 import { Icon } from '~/design-system/icon';
 import { ChevronRight } from '~/design-system/icons/chevron-right';
 import { GeoLogoLarge } from '~/design-system/icons/geo-logo-large';
-import { Spacer } from '~/design-system/spacer';
 
 import { NavbarActions } from './navbar-actions';
 import { NavbarBreadcrumb } from './navbar-breadcrumb';

--- a/apps/web/partials/profile/activity-space-filter.tsx
+++ b/apps/web/partials/profile/activity-space-filter.tsx
@@ -3,7 +3,7 @@
 import { SYSTEM_IDS } from '@geogenesis/ids';
 import Image from 'next/legacy/image';
 import Link from 'next/link';
-import { useRouter, useSearchParams } from 'next/navigation';
+import { useSearchParams } from 'next/navigation';
 
 import * as React from 'react';
 
@@ -27,7 +27,6 @@ export function ActivitySpaceFilter({ entityId, spaceId }: Props) {
   const initialSpace = spaces.find(space => space.id === selectedSpaceId);
   const initialName = initialSpace?.attributes[SYSTEM_IDS.NAME];
 
-  const router = useRouter();
   const [open, onOpenChange] = React.useState(false);
   const [name, setName] = React.useState('All');
 

--- a/apps/web/partials/review/review.tsx
+++ b/apps/web/partials/review/review.tsx
@@ -690,14 +690,16 @@ const ChangedAttribute = ({
             <div className="flex flex-wrap gap-2">
               {entity?.triples
                 .filter(
-                  (triple: any) =>
+                  (triple: Triple) =>
                     triple.attributeId === attributeId &&
+                    'name' in triple.value &&
+                    triple.value.name !== null &&
                     !before?.includes(triple.value.name) &&
                     !after?.includes(triple.value.name)
                 )
-                .map((triple: any) => (
+                .map((triple: Triple) => (
                   <Chip key={triple.id} status="unchanged">
-                    {triple.value.name}
+                    {'name' in triple.value && triple.value.name}
                   </Chip>
                 ))}
               {Array.isArray(after) && (

--- a/apps/web/partials/review/review.tsx
+++ b/apps/web/partials/review/review.tsx
@@ -25,7 +25,7 @@ import { Services } from '~/core/services';
 import { useDiff } from '~/core/state/diff-store/diff-store';
 import { useStatusBar } from '~/core/state/status-bar-store';
 import { TableBlockFilter } from '~/core/state/table-block-store';
-import type { Action as ActionType, Entity as EntityType, Space } from '~/core/types';
+import type { Action as ActionType, Entity as EntityType, Space, Triple } from '~/core/types';
 import { Action } from '~/core/utils/action';
 import { Change } from '~/core/utils/change';
 import type { AttributeChange, AttributeId, BlockChange, BlockId, Changeset } from '~/core/utils/change/change';
@@ -658,10 +658,16 @@ const ChangedAttribute = ({
             <div className="text-bodySemibold capitalize">{name}</div>
             <div className="flex flex-wrap gap-2">
               {entity?.triples
-                .filter((triple: any) => triple.attributeId === attributeId && !before?.includes(triple.value.name))
-                .map((triple: any) => (
+                .filter(
+                  (triple: Triple) =>
+                    triple.attributeId === attributeId &&
+                    'name' in triple.value &&
+                    triple.value.name !== null &&
+                    !before?.includes(triple.value.name)
+                )
+                .map((triple: Triple) => (
                   <Chip key={triple.id} status="unchanged">
-                    {triple.value.name}
+                    {'name' in triple.value && triple.value.name}
                   </Chip>
                 ))}
               {Array.isArray(before) && (


### PR DESCRIPTION
When running `pnpm --filter web lint` I noticed we had some warnings, mostly related to unused vars and unexpected anys. 

This is a WIP to reduce these.

Prior to this PR there were `✖ 58 problems (0 errors, 58 warnings)` and it's now down to 10 (`✖ 10 problems (0 errors, 10 warnings)`)

I'm not as familiar with the command components yet but this makes some progress toward reducing the warnings.

Realized my branch name is `feat` and not `fix` -- noticed this after opening the PR. Can close this and rename my branch to stay consistent! 