### PR TITLE
feat: force caching and prefetching in prod

### DIFF
--- a/apps/web/app/space/[id]/[entityId]/page.tsx
+++ b/apps/web/app/space/[id]/[entityId]/page.tsx
@@ -9,6 +9,7 @@ import type { Metadata } from 'next';
 import { AppConfig } from '~/core/environment';
 import { Subgraph } from '~/core/io';
 import { Params } from '~/core/params';
+import { serverRuntime } from '~/core/runtime';
 import { DEFAULT_PAGE_SIZE } from '~/core/state/triple-store';
 import { TypesStoreServerContainer } from '~/core/state/types-store/types-store-server-container';
 import { ServerSideEnvParams } from '~/core/types';
@@ -22,6 +23,9 @@ import {
 } from '~/partials/entity-page/entity-page-referenced-by-server-container';
 
 import { Component } from './component';
+
+export const runtime = serverRuntime.runtime;
+export const fetchCache = serverRuntime.fetchCache;
 
 interface Props {
   params: { id: string; entityId: string };

--- a/apps/web/app/space/[id]/page.tsx
+++ b/apps/web/app/space/[id]/page.tsx
@@ -9,6 +9,7 @@ import type { Metadata } from 'next';
 import { AppConfig } from '~/core/environment';
 import { Subgraph } from '~/core/io';
 import { Params } from '~/core/params';
+import { serverRuntime } from '~/core/runtime';
 import { DEFAULT_PAGE_SIZE } from '~/core/state/triple-store';
 import { TypesStoreServerContainer } from '~/core/state/types-store/types-store-server-container';
 import { ServerSideEnvParams } from '~/core/types';
@@ -23,7 +24,8 @@ import {
 
 import { Component } from './component';
 
-export const runtime = 'edge';
+export const runtime = serverRuntime.runtime;
+export const fetchCache = serverRuntime.fetchCache;
 
 interface Props {
   params: { id: string };

--- a/apps/web/app/spaces/page.tsx
+++ b/apps/web/app/spaces/page.tsx
@@ -6,6 +6,7 @@ import { Metadata } from 'next';
 import { DEFAULT_OPENGRAPH_IMAGE } from '~/core/constants';
 import { Subgraph } from '~/core/io';
 import { Params } from '~/core/params';
+import { serverRuntime } from '~/core/runtime';
 import { ServerSideEnvParams, Space } from '~/core/types';
 
 import { Card } from '~/design-system/card';
@@ -13,6 +14,9 @@ import { Spacer } from '~/design-system/spacer';
 
 import { OboardingCarousel } from '~/partials/spaces-page/carousel';
 import { Email } from '~/partials/spaces-page/email';
+
+export const runtime = serverRuntime.runtime;
+export const fetchCache = serverRuntime.fetchCache;
 
 export const metadata: Metadata = {
   title: 'Geo Genesis',

--- a/apps/web/core/runtime.ts
+++ b/apps/web/core/runtime.ts
@@ -1,0 +1,10 @@
+// Set different page configurations based on whether we are in dev or prod.
+//
+// Next will not cache or prefetch at the fetch level when using functions that
+// opt-out of dynamic page caching, such as `cookies()` and `headers()`. We only
+// use cookies in pages in dev mode, so in prod we can force cache and prefetch
+// at the fetch level.
+export const serverRuntime = {
+  runtime: 'edge' as const,
+  fetchCache: process.env.NODE_ENV === 'development' ? ('auto' as const) : ('force-cache' as const),
+};


### PR DESCRIPTION
Set different page configurations based on whether we are in dev or prod.

Next will not cache or prefetch at the fetch level when using functions that opt-out of dynamic page caching, such as `cookies()` and `headers()`. We only  use cookies in pages in dev mode, so in prod we can force cache and prefetch  at the fetch level.