### PR TITLE
fix: move entity

### DIFF
--- a/apps/web/partials/move-entity/move-entity-review.tsx
+++ b/apps/web/partials/move-entity/move-entity-review.tsx
@@ -1,5 +1,4 @@
 import { SYSTEM_IDS } from '@geogenesis/ids';
-import { batch } from '@legendapp/state';
 import Image from 'next/legacy/image';
 import { useRouter } from 'next/navigation';
 
@@ -7,7 +6,6 @@ import * as React from 'react';
 
 import { useWalletClient } from 'wagmi';
 
-import { useActionsStore } from '~/core/hooks/use-actions-store';
 import { useEntityPageStore } from '~/core/hooks/use-entity-page-store';
 import { useMoveTriplesState } from '~/core/hooks/use-move-triples-state';
 import { usePublish } from '~/core/hooks/use-publish';
@@ -49,7 +47,6 @@ function MoveEntityReviewChanges() {
   const { state: deleteState, dispatch: deleteDispatch } = useMoveTriplesState();
   const [firstPublishComplete, setFirstPublishComplete] = React.useState(false); // to allow the user to reenter only the second publish
   const router = useRouter();
-  const { create, remove } = useActionsStore();
 
   const { data: wallet } = useWalletClient(); // user wallet session
 
@@ -68,18 +65,17 @@ function MoveEntityReviewChanges() {
     const onCreateNewTriples = (): CreateTripleAction[] => {
       return triples.map(t => ({
         ...t,
-
         type: 'createTriple',
         space: spaceIdTo,
       }));
     };
 
-    const createProposalName = `Create ${triples[0]?.entityName ?? entityId} in ${
-      spaceTo?.attributes[SYSTEM_IDS.NAME]
-    }`;
-    const deleteProposalName = `Delete ${triples[0]?.entityName ?? entityId} from ${
-      spaceFrom?.attributes[SYSTEM_IDS.NAME]
-    }`;
+    const createProposalName = `Create ${triples[0]?.entityName ?? entityId} in ${spaceTo?.attributes[
+      SYSTEM_IDS.NAME
+    ]}`;
+    const deleteProposalName = `Delete ${triples[0]?.entityName ?? entityId} from ${spaceFrom?.attributes[
+      SYSTEM_IDS.NAME
+    ]}`;
 
     let createActions: CreateTripleAction[] = [];
     let deleteActions: DeleteTripleAction[] = [];
@@ -90,9 +86,9 @@ function MoveEntityReviewChanges() {
 
         await makeProposal({
           actions: createActions,
-          spaceId: spaceIdTo,
           name: createProposalName,
           onChangePublishState: reviewState => createDispatch({ type: 'SET_REVIEW_STATE', payload: reviewState }),
+          spaceId: spaceIdTo,
         });
         createDispatch({ type: 'SET_REVIEW_STATE', payload: 'publish-complete' });
         setFirstPublishComplete(true); // so the user can re-enter the second publish only if this succeeds
@@ -114,9 +110,9 @@ function MoveEntityReviewChanges() {
 
       await makeProposal({
         actions: deleteActions,
-        spaceId: spaceIdFrom,
         name: deleteProposalName,
         onChangePublishState: reviewState => deleteDispatch({ type: 'SET_REVIEW_STATE', payload: reviewState }),
+        spaceId: spaceIdFrom,
       });
       deleteDispatch({ type: 'SET_REVIEW_STATE', payload: 'publish-complete' });
     } catch (e: unknown) {
@@ -133,7 +129,7 @@ function MoveEntityReviewChanges() {
     // close the review UI after displaying the state messages for 2 seconds
     await sleepWithCallback(() => {
       setIsMoveReviewOpen(false);
-      router.push(`/space/${spaceIdTo}/${entityId}`);
+      router.push(`/space/${spaceIdTo}`);
     }, 2000);
   }, [
     wallet,
@@ -179,7 +175,7 @@ function MoveEntityReviewChanges() {
 
   return (
     <>
-      <div className="flex w-full items-center justify-between gap-1 bg-white py-1 px-4 shadow-big md:py-3 md:px-4">
+      <div className="flex w-full items-center justify-between gap-1 bg-white px-4 py-1 shadow-big md:px-4 md:py-3">
         <div className="inline-flex items-center gap-4">
           <SquareButton onClick={() => setIsMoveReviewOpen(false)} icon="close" />
           <Text variant="metadataMedium">Move entities</Text>
@@ -188,9 +184,9 @@ function MoveEntityReviewChanges() {
           <Button onClick={handlePublish}>Publish and move</Button>
         </div>
       </div>
-      <div className="mt-3 rounded-t-[16px] bg-bg shadow-big h-full ">
-        <div className="mx-auto max-w-[1200px] pt-10 pb-20 xl:pt-[40px] xl:pr-[2ch] xl:pb-[4ch] xl:pl-[2ch] ">
-          <div className="flex flex-row sm:flex-col items-center justify-between gap-4 w-full">
+      <div className="mt-3 h-full rounded-t-[16px] bg-bg shadow-big ">
+        <div className="mx-auto max-w-[1200px] pb-20 pt-10 xl:pb-[4ch] xl:pl-[2ch] xl:pr-[2ch] xl:pt-[40px] ">
+          <div className="flex w-full flex-row items-center justify-between gap-4 sm:flex-col">
             <SpaceMoveCard
               spaceName={spaceTo?.attributes[SYSTEM_IDS.NAME]}
               spaceImage={spaceTo?.attributes[SYSTEM_IDS.IMAGE_ATTRIBUTE]}
@@ -236,14 +232,14 @@ function SpaceMoveCard({
   getBgClassByState: (index: number, state: ReviewState) => string;
 }) {
   return (
-    <div className="flex flex-col border border-grey-02 rounded px-4 py-5 basis-3/5 w-full gap-3">
+    <div className="flex w-full basis-3/5 flex-col gap-3 rounded border border-grey-02 px-4 py-5">
       <div className="flex flex-row items-center justify-between gap-2">
         <Text variant="metadata">
           Step {actionType === 'create' ? 1 : 2} &middot; {actionType === 'create' ? 'Create' : 'Delete'} triples
         </Text>
         <div className="flex flex-row items-center gap-2">
           {spaceImage !== undefined && (
-            <div className="relative w-[16px] h-[16px] rounded-xs overflow-hidden">
+            <div className="relative h-[16px] w-[16px] overflow-hidden rounded-xs">
               <Image src={getImagePath(spaceImage)} layout="fill" objectFit="cover" />
             </div>
           )}
@@ -251,7 +247,7 @@ function SpaceMoveCard({
         </div>
       </div>
       <Divider type="horizontal" />
-      <div className="flex flex-row items-center gap-2 justify-between">
+      <div className="flex flex-row items-center justify-between gap-2">
         <StatusMessage txState={txState} handlePublish={handlePublish} />
         <div className="flex flex-row items-center gap-1.5">
           <ProgressBar txState={txState} getBgClassByState={getBgClassByState} />
@@ -306,7 +302,7 @@ function ProgressBar({
   return (
     <div className="flex flex-row items-center gap-1.5">
       {[0, 1, 2, 3].map(index => (
-        <div key={index} className={`w-[30px] h-[6px] rounded-[30px] ${getBgClassByState(index, txState)}`} />
+        <div key={index} className={`h-[6px] w-[30px] rounded-[30px] ${getBgClassByState(index, txState)}`} />
       ))}
     </div>
   );


### PR DESCRIPTION
## Overview

Fixes the issues reported with inconsistencies in the Move Entity flow. The redirect after a successful Move was causing issues due to the new entity not being indexed, so the user was being redirected back to the original space and entity. 

Upon a successful Move the user is now redirected to the destination space.

We can revisit the redirect destination once we have substreams in place.

Here's a screencap of the updated flow:

![move-entity-fixed-redirect](https://github.com/geobrowser/geogenesis/assets/9438776/5c5fb57f-612f-4f8f-b66b-667986aa07ae)

Here's the steps in the screencap:

- Select an entity in Personal Development
- Move it to Philosophy
- Copy the entity Id
- Upon the redirect to Philosophy (destination space) I add the `/entityId` to the route to check that the entity is in the new space

I also tested moving the same entity back and forth, to check that there aren't any inconsistencies with that flow.

Builds and passes lint locally 👍 