### PR TITLE
feat: onboarding with backend

### DIFF
--- a/apps/web/app/api/deploy/make-deploy-effect.ts
+++ b/apps/web/app/api/deploy/make-deploy-effect.ts
@@ -5,7 +5,7 @@ import BeaconProxy from '@openzeppelin/upgrades-core/artifacts/@openzeppelin/con
 import { Effect } from 'effect';
 import { createPublicClient, createWalletClient, http } from 'viem';
 import { privateKeyToAccount } from 'viem/accounts';
-import { polygon, polygonMumbai } from 'viem/chains';
+import { polygon } from 'viem/chains';
 
 import { ADMIN_ROLE_BINARY, EDITOR_CONTROLLER_ROLE_BINARY, EDITOR_ROLE_BINARY } from '~/core/constants';
 import { Environment } from '~/core/environment';

--- a/apps/web/app/api/deploy/make-deploy-effect.ts
+++ b/apps/web/app/api/deploy/make-deploy-effect.ts
@@ -5,7 +5,7 @@ import BeaconProxy from '@openzeppelin/upgrades-core/artifacts/@openzeppelin/con
 import { Effect } from 'effect';
 import { createPublicClient, createWalletClient, http } from 'viem';
 import { privateKeyToAccount } from 'viem/accounts';
-import { polygon } from 'viem/chains';
+import { polygon, polygonMumbai } from 'viem/chains';
 
 import { ADMIN_ROLE_BINARY, EDITOR_CONTROLLER_ROLE_BINARY, EDITOR_ROLE_BINARY } from '~/core/constants';
 import { Environment } from '~/core/environment';
@@ -329,8 +329,8 @@ export function makeDeployEffect(requestId: string, { account: userAccount, user
           }
 
           const typeTriple: OmitStrict<Triple, 'id'> = {
-            attributeId: SYSTEM_IDS.SCHEMA_TYPE,
-            attributeName: 'Type',
+            attributeId: SYSTEM_IDS.TYPES,
+            attributeName: 'Types',
             entityId,
             entityName: username ?? '',
             space: deployProxyEffect.contractAddress as string,

--- a/apps/web/app/api/deploy/route.ts
+++ b/apps/web/app/api/deploy/route.ts
@@ -15,7 +15,9 @@ export async function GET(request: Request) {
   const userAccount = searchParams.get('userAddress') as `0x${string}` | null;
 
   if (userAccount === null) {
-    return new Response('Missing user address', { status: 400 });
+    return new Response(JSON.stringify({ error: 'Missing user address', reason: 'Missing user address' }), {
+      status: 400,
+    });
   }
 
   const username = searchParams.get('username');
@@ -35,7 +37,7 @@ export async function GET(request: Request) {
 
     switch (error._tag) {
       case 'ProxyBeaconDeploymentFailedError':
-        return new Response('Could not deploy space contract. Please try again.', {
+        return new Response(JSON.stringify({ error: 'Deployment error', reason: 'Proxy Beacon failed to deploy' }), {
           status: 500,
           statusText: error.message,
         });
@@ -46,40 +48,76 @@ export async function GET(request: Request) {
           message: `Space proxy deployment failed for unknown reason`,
           account: userAccount,
         });
-        return new Response('Could not deploy space contract. Please try again.', {
+        return new Response(JSON.stringify({ error: 'Deployment error', reason: 'Deployed space has null address' }), {
           status: 500,
           statusText: 'Unknown error',
         });
       case 'ProxyBeaconInitializeFailedError':
-        return new Response(`Could not initialize space contract for user: ${userAccount}`, {
-          status: 500,
-          statusText: error.message,
-        });
+        return new Response(
+          JSON.stringify({
+            error: 'Contract could not be initialized',
+            reason: `Could not initialize space contract for user: ${userAccount}`,
+          }),
+          {
+            status: 500,
+            statusText: error.message,
+          }
+        );
       case 'ProxyBeaconConfigureRolesFailedError':
-        return new Response(`Could not configure contract roles for user: ${userAccount}`, {
-          status: 500,
-          statusText: error.message,
-        });
+        return new Response(
+          JSON.stringify({
+            error: 'Contract could not be configured',
+            reason: `Could not configure contract roles for user: ${userAccount}`,
+          }),
+          {
+            status: 500,
+            statusText: error.message,
+          }
+        );
       case 'CreateProfileGeoEntityFailedError':
-        return new Response(`Could not create profile Geo Entity for user: ${userAccount}`, {
-          status: 500,
-          statusText: error.message,
-        });
+        return new Response(
+          JSON.stringify({
+            error: 'Could not create profile entity',
+            reason: `Could not create profile Geo Entity for user: ${userAccount}`,
+          }),
+          {
+            status: 500,
+            statusText: error.message,
+          }
+        );
       case 'AddToSpaceRegistryError':
-        return new Response(`Could not add user to space registry for user: ${userAccount}`, {
-          status: 500,
-          statusText: error.message,
-        });
+        return new Response(
+          JSON.stringify({
+            error: 'Could not add contract to space registry',
+            reason: `Could not add space to space registry for user: ${userAccount}`,
+          }),
+          {
+            status: 500,
+            statusText: error.message,
+          }
+        );
       case 'GrantAdminRole':
-        return new Response(`Could not grant admin role for user: ${userAccount}`, {
-          status: 500,
-          statusText: error.message,
-        });
+        return new Response(
+          JSON.stringify({
+            error: 'Could not grant roles to user',
+            reason: `Could not grant admin role for user: ${userAccount}`,
+          }),
+          {
+            status: 500,
+            statusText: error.message,
+          }
+        );
       default:
-        return new Response('Could not deploy space contract. Please try again.', {
-          status: 500,
-          statusText: 'Unknown error',
-        });
+        return new Response(
+          JSON.stringify({
+            error: 'Unable to deploy contract for unknown reasons',
+            reason: 'Could not deploy space contract. Please try again.',
+          }),
+          {
+            status: 500,
+            statusText: 'Unknown error',
+          }
+        );
     }
   }
 
@@ -91,6 +129,5 @@ export async function GET(request: Request) {
     account: userAccount,
   });
 
-  // @TODO: Anything else we should return here?
-  return new Response(proxyDeployTxReceipt.contractAddress, { status: 200 });
+  return new Response(JSON.stringify({ spaceAddress: proxyDeployTxReceipt.contractAddress }), { status: 200 });
 }

--- a/apps/web/app/space/[id]/[entityId]/education/page.tsx
+++ b/apps/web/app/space/[id]/[entityId]/education/page.tsx
@@ -1,5 +1,0 @@
-export const runtime = 'edge';
-
-export default async function EducationPage() {
-  return <p className="text-grey-04 text-body">There is no information here yet.</p>;
-}

--- a/apps/web/app/space/[id]/[entityId]/layout.tsx
+++ b/apps/web/app/space/[id]/[entityId]/layout.tsx
@@ -37,6 +37,18 @@ export default async function ProfileLayout({ children, params }: Props) {
   // Layouts do not receive search params (hmm)
   const config = Params.getConfigFromParams({}, env);
 
+  let space = await Subgraph.fetchSpace({ endpoint: config.subgraph, id: params.id });
+  let usePermissionlessSubgraph = false;
+
+  if (!space) {
+    space = await Subgraph.fetchSpace({ endpoint: config.permissionlessSubgraph, id: params.id });
+    if (space) usePermissionlessSubgraph = true;
+  }
+
+  if (usePermissionlessSubgraph) {
+    config.subgraph = config.permissionlessSubgraph;
+  }
+
   const types = await fetchEntityType({
     endpoint: config.subgraph,
     id: params.entityId,

--- a/apps/web/app/space/[id]/[entityId]/page.tsx
+++ b/apps/web/app/space/[id]/[entityId]/page.tsx
@@ -22,6 +22,8 @@ export default async function EntityTemplateStrategy({ params, searchParams }: P
     id: params.entityId,
   });
 
+  console.log('types', types);
+
   if (types.includes(SYSTEM_IDS.PERSON_TYPE)) {
     // @ts-expect-error async JSX function
     return <ProfileEntityServerContainer params={params} searchParams={searchParams} />;

--- a/apps/web/app/space/[id]/[entityId]/page.tsx
+++ b/apps/web/app/space/[id]/[entityId]/page.tsx
@@ -22,8 +22,6 @@ export default async function EntityTemplateStrategy({ params, searchParams }: P
     id: params.entityId,
   });
 
-  console.log('types', types);
-
   if (types.includes(SYSTEM_IDS.PERSON_TYPE)) {
     // @ts-expect-error async JSX function
     return <ProfileEntityServerContainer params={params} searchParams={searchParams} />;

--- a/apps/web/app/space/[id]/[entityId]/profile-entity-server-container.tsx
+++ b/apps/web/app/space/[id]/[entityId]/profile-entity-server-container.tsx
@@ -19,6 +19,18 @@ export async function ProfileEntityServerContainer({ params, searchParams }: Pro
   const env = cookies().get(Params.ENV_PARAM_NAME)?.value;
   const config = Params.getConfigFromParams(searchParams, env);
 
+  let space = await Subgraph.fetchSpace({ endpoint: config.subgraph, id: params.id });
+  let usePermissionlessSubgraph = false;
+
+  if (!space) {
+    space = await Subgraph.fetchSpace({ endpoint: config.permissionlessSubgraph, id: params.id });
+    if (space) usePermissionlessSubgraph = true;
+  }
+
+  if (usePermissionlessSubgraph) {
+    config.subgraph = config.permissionlessSubgraph;
+  }
+
   const person = await Subgraph.fetchEntity({ id: params.entityId, endpoint: config.subgraph });
 
   // @TODO: Real error handling

--- a/apps/web/app/space/[id]/[entityId]/work/page.tsx
+++ b/apps/web/app/space/[id]/[entityId]/work/page.tsx
@@ -1,5 +1,0 @@
-export const runtime = 'edge';
-
-export default async function WorkPage() {
-  return <p className="text-grey-04 text-body">There is no information here yet.</p>;
-}

--- a/apps/web/app/space/[id]/governance/page.tsx
+++ b/apps/web/app/space/[id]/governance/page.tsx
@@ -3,6 +3,7 @@ import { cookies } from 'next/headers';
 
 import * as React from 'react';
 
+import { Subgraph } from '~/core/io';
 import { graphql } from '~/core/io/subgraph/graphql';
 import { Params } from '~/core/params';
 import { ServerSideEnvParams } from '~/core/types';
@@ -19,6 +20,21 @@ interface Props {
 }
 
 export default async function GovernancePage({ params, searchParams }: Props) {
+  const env = cookies().get(Params.ENV_PARAM_NAME)?.value;
+  const config = Params.getConfigFromParams(searchParams, env);
+
+  let space = await Subgraph.fetchSpace({ endpoint: config.subgraph, id: params.id });
+  let usePermissionlessSubgraph = false;
+
+  if (!space) {
+    space = await Subgraph.fetchSpace({ endpoint: config.permissionlessSubgraph, id: params.id });
+    if (space) usePermissionlessSubgraph = true;
+  }
+
+  if (usePermissionlessSubgraph) {
+    config.subgraph = config.permissionlessSubgraph;
+  }
+
   const proposalsCount = await getProposalsCount({ params, searchParams });
 
   return (

--- a/apps/web/app/space/[id]/layout.tsx
+++ b/apps/web/app/space/[id]/layout.tsx
@@ -1,0 +1,30 @@
+import { cookies } from 'next/headers';
+
+import * as React from 'react';
+
+import { Subgraph } from '~/core/io';
+import { Params } from '~/core/params';
+
+import { SpaceConfigProvider } from './space-config-provider';
+
+interface Props {
+  params: { id: string };
+  children: React.ReactNode;
+}
+
+export default async function Layout({ children, params }: Props) {
+  const env = cookies().get(Params.ENV_PARAM_NAME)?.value;
+
+  // Layouts don't get search params (hmm)
+  const config = Params.getConfigFromParams({}, env);
+
+  let space = await Subgraph.fetchSpace({ endpoint: config.subgraph, id: params.id });
+  let usePermissionlessSubgraph = false;
+
+  if (!space) {
+    space = await Subgraph.fetchSpace({ endpoint: config.permissionlessSubgraph, id: params.id });
+    if (space) usePermissionlessSubgraph = true;
+  }
+
+  return <SpaceConfigProvider usePermissionlessSubgraph={usePermissionlessSubgraph}>{children}</SpaceConfigProvider>;
+}

--- a/apps/web/app/space/[id]/page.tsx
+++ b/apps/web/app/space/[id]/page.tsx
@@ -72,12 +72,26 @@ export async function generateMetadata({ params, searchParams }: Props): Promise
 
 export default async function SpacePage({ params, searchParams }: Props) {
   const env = cookies().get(Params.ENV_PARAM_NAME)?.value;
+
   const config = Params.getConfigFromParams(searchParams, env);
+
+  let space = await Subgraph.fetchSpace({ endpoint: config.subgraph, id: params.id });
+  let usePermissionlessSubgraph = false;
+
+  if (!space) {
+    space = await Subgraph.fetchSpace({ endpoint: config.permissionlessSubgraph, id: params.id });
+    if (space) usePermissionlessSubgraph = true;
+  }
+
+  if (usePermissionlessSubgraph) {
+    config.subgraph = config.permissionlessSubgraph;
+  }
+
   const props = await getData(params.id, config);
 
   return (
     // @ts-expect-error async JSX function
-    <SpaceLayout params={params} searchParams={searchParams}>
+    <SpaceLayout params={params} searchParams={searchParams} usePermissionlessSpace={usePermissionlessSubgraph}>
       <Editor shouldHandleOwnSpacing />
       <ToggleEntityPage {...props} />
       <Spacer height={40} />

--- a/apps/web/app/space/[id]/page.tsx
+++ b/apps/web/app/space/[id]/page.tsx
@@ -90,8 +90,13 @@ export default async function SpacePage({ params, searchParams }: Props) {
 }
 
 const getData = async (spaceId: string, config: AppConfig) => {
-  const spaces = await Subgraph.fetchSpaces({ endpoint: config.subgraph });
-  const space = spaces.find(s => s.id === spaceId) ?? null;
+  // Attempt to fetch the space from the public subgraph first. If the space doesn't exist there, try the permissionless subgraph.
+  let space = await Subgraph.fetchSpace({ endpoint: config.subgraph, id: spaceId });
+
+  if (!space) {
+    space = await Subgraph.fetchSpace({ endpoint: config.permissionlessSubgraph, id: spaceId });
+  }
+
   const entityId = space?.spaceConfigEntityId;
 
   if (!entityId) {

--- a/apps/web/app/space/[id]/space-config-provider.tsx
+++ b/apps/web/app/space/[id]/space-config-provider.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import * as React from 'react';
+
+import { setSecondarySubgraphAsMain } from '~/core/services/services';
+
+interface Props {
+  children: React.ReactNode;
+  usePermissionlessSubgraph: boolean;
+}
+
+export function SpaceConfigProvider({ children, usePermissionlessSubgraph }: Props) {
+  React.useEffect(() => {
+    setSecondarySubgraphAsMain(usePermissionlessSubgraph);
+  }, [usePermissionlessSubgraph]);
+
+  return <>{children}</>;
+}

--- a/apps/web/app/space/[id]/space-layout.tsx
+++ b/apps/web/app/space/[id]/space-layout.tsx
@@ -29,13 +29,18 @@ interface Props {
   params: { id: string };
   searchParams: ServerSideEnvParams;
   children: React.ReactNode;
+  usePermissionlessSpace?: boolean;
 }
 
 // We don't want this layout to nest within the space/ route component tree,
 // so we use it like normal React component instead of a Next.js route layout.
-export async function SpaceLayout({ params, searchParams, children }: Props) {
+export async function SpaceLayout({ params, searchParams, children, usePermissionlessSpace }: Props) {
   const env = cookies().get(Params.ENV_PARAM_NAME)?.value;
   const config = Params.getConfigFromParams(searchParams, env);
+
+  if (usePermissionlessSpace) {
+    config.subgraph = config.permissionlessSubgraph;
+  }
 
   const props = await getData(params.id, config);
 
@@ -98,8 +103,8 @@ export async function SpaceLayout({ params, searchParams, children }: Props) {
 }
 
 const getData = async (spaceId: string, config: AppConfig) => {
-  const spaces = await Subgraph.fetchSpaces({ endpoint: config.subgraph });
-  const space = spaces.find(s => s.id === spaceId) ?? null;
+  const space = await Subgraph.fetchSpace({ endpoint: config.subgraph, id: spaceId });
+
   const entityId = space?.spaceConfigEntityId;
 
   if (!entityId) {

--- a/apps/web/core/io/mocks/mock-network.ts
+++ b/apps/web/core/io/mocks/mock-network.ts
@@ -202,6 +202,10 @@ export class MockNetwork implements ISubgraph {
     return null;
   };
 
+  fetchOnchainProfile = async () => {
+    return null;
+  };
+
   fetchProposedVersion = async () => {
     return null;
   };

--- a/apps/web/core/io/publish/contracts.ts
+++ b/apps/web/core/io/publish/contracts.ts
@@ -6,7 +6,7 @@ export async function deploySpaceContract({
   account: string;
   username: string | null;
   avatarUri: string | null;
-}): Promise<{ spaceAddress: string }> {
+}): Promise<{ spaceAddress: `0x${string}` }> {
   const url = new URL(`/api/deploy?userAddress=${account}`, window.location.href);
 
   if (username) {

--- a/apps/web/core/io/publish/contracts.ts
+++ b/apps/web/core/io/publish/contracts.ts
@@ -1,7 +1,25 @@
-import { WalletClient } from 'wagmi';
+export async function deploySpaceContract({
+  account,
+  username,
+  avatarUri,
+}: {
+  account: string;
+  username: string | null;
+  avatarUri: string | null;
+}): Promise<{ spaceAddress: string }> {
+  const url = new URL(`/api/deploy?userAddress=${account}`, window.location.href);
 
-export async function deploySpaceContract(client: WalletClient) {
+  if (username) {
+    url.searchParams.set('username', username);
+  }
+
+  if (avatarUri) {
+    url.searchParams.set('avatarUri', avatarUri);
+  }
+
+  console.log('url', url);
+
   // @TODO: Error and success handling with Effect
-  await fetch(`/api/deploy?userAddress=${client.account.address}&username=bananabob`);
-  return; //
+  const idk = await fetch(url);
+  return await idk.json();
 }

--- a/apps/web/core/io/publish/contracts.ts
+++ b/apps/web/core/io/publish/contracts.ts
@@ -17,9 +17,7 @@ export async function deploySpaceContract({
     url.searchParams.set('avatarUri', avatarUri);
   }
 
-  console.log('url', url);
-
   // @TODO: Error and success handling with Effect
-  const idk = await fetch(url);
-  return await idk.json();
+  const spaceContractDeploymentResponse = await fetch(url);
+  return await spaceContractDeploymentResponse.json();
 }

--- a/apps/web/core/io/publish/publish-interface.ts
+++ b/apps/web/core/io/publish/publish-interface.ts
@@ -9,4 +9,5 @@ export interface IPublish {
   getRole(spaceId: string, role: 'EDITOR_ROLE' | 'ADMIN_ROLE' | 'EDITOR_CONTROLLER_ROLE'): Promise<string>;
   grantRole(options: { spaceId: string; wallet: WalletClient; role: string; userAddress: string }): Promise<string>;
   revokeRole(options: { spaceId: string; wallet: WalletClient; role: string; userAddress: string }): Promise<string>;
+  registerGeoProfile: (wallet: WalletClient, spaceId: `0x${string}`) => Promise<void>;
 }

--- a/apps/web/core/io/publish/publish-interface.ts
+++ b/apps/web/core/io/publish/publish-interface.ts
@@ -9,5 +9,5 @@ export interface IPublish {
   getRole(spaceId: string, role: 'EDITOR_ROLE' | 'ADMIN_ROLE' | 'EDITOR_CONTROLLER_ROLE'): Promise<string>;
   grantRole(options: { spaceId: string; wallet: WalletClient; role: string; userAddress: string }): Promise<string>;
   revokeRole(options: { spaceId: string; wallet: WalletClient; role: string; userAddress: string }): Promise<string>;
-  registerGeoProfile: (wallet: WalletClient, spaceId: `0x${string}`) => Promise<void>;
+  registerGeoProfile: (wallet: WalletClient, spaceId: `0x${string}`) => Promise<string>;
 }

--- a/apps/web/core/io/publish/publish.ts
+++ b/apps/web/core/io/publish/publish.ts
@@ -1,5 +1,6 @@
 import { Root } from '@geogenesis/action-schema';
-import { SpaceAbi } from '@geogenesis/contracts';
+import { GeoProfileRegistryAbi, SpaceAbi } from '@geogenesis/contracts';
+import { SYSTEM_IDS } from '@geogenesis/ids';
 import { Effect } from 'effect';
 
 import { WalletClient } from 'wagmi';
@@ -198,5 +199,19 @@ export async function revokeRole({
 
   const tx = await writeContract(contractConfig);
   console.log(`Role revoked from ${userAddress}. Transaction hash: ${tx.hash}`);
+  return tx.hash;
+}
+
+export async function registerGeoProfile(wallet: WalletClient, spaceId: `0x${string}`) {
+  const contractConfig = await prepareWriteContract({
+    abi: GeoProfileRegistryAbi,
+    address: SYSTEM_IDS.PROFILE_REGISTRY_ADDRESS,
+    functionName: 'registerGeoProfile',
+    walletClient: wallet,
+    args: [spaceId],
+  });
+
+  const tx = await writeContract(contractConfig);
+  console.log(`Geo profile created. Transaction hash: ${tx.hash}`);
   return tx.hash;
 }

--- a/apps/web/core/io/publish/publish.ts
+++ b/apps/web/core/io/publish/publish.ts
@@ -1,7 +1,7 @@
 import { Root } from '@geogenesis/action-schema';
 import { GeoProfileRegistryAbi, SpaceAbi } from '@geogenesis/contracts';
 import { SYSTEM_IDS } from '@geogenesis/ids';
-import { Effect } from 'effect';
+import * as Effect from 'effect/Effect';
 
 import { WalletClient } from 'wagmi';
 import { prepareWriteContract, readContract, waitForTransaction, writeContract } from 'wagmi/actions';

--- a/apps/web/core/io/subgraph/fetch-on-chain-profile.ts
+++ b/apps/web/core/io/subgraph/fetch-on-chain-profile.ts
@@ -1,0 +1,91 @@
+import { Effect, Either } from 'effect';
+import { v4 as uuid } from 'uuid';
+
+import { graphql } from './graphql';
+
+export interface FetchOnchainProfileOptions {
+  endpoint: string;
+  address: string;
+  signal?: AbortController['signal'];
+}
+
+interface OnchainGeoProfile {
+  id: string;
+  homeSpace: string;
+  account: string;
+}
+
+interface NetworkResult {
+  geoProfiles: OnchainGeoProfile[];
+}
+
+// We fetch for geoEntities -> name because the id of the wallet entity might not be the
+// same as the actual wallet address.
+function getFetchProfileQuery(address: string) {
+  // Have to fetch the profiles as an array as we can't query an individual profile by it's account.
+  return `query {
+    geoProfiles(where: {account: "${address}"} first: 1) {
+      id
+      homeSpace
+      account
+    }
+  }`;
+}
+
+export async function fetchOnchainProfile(options: FetchOnchainProfileOptions): Promise<OnchainGeoProfile | null> {
+  const queryId = uuid();
+
+  const fetchWalletsGraphqlEffect = graphql<NetworkResult>({
+    endpoint: options.endpoint,
+    query: getFetchProfileQuery(options.address),
+    signal: options?.signal,
+  });
+
+  const graphqlFetchWithErrorFallbacks = Effect.gen(function* (awaited) {
+    const resultOrError = yield* awaited(Effect.either(fetchWalletsGraphqlEffect));
+
+    if (Either.isLeft(resultOrError)) {
+      const error = resultOrError.left;
+
+      switch (error._tag) {
+        case 'AbortError':
+          // Right now we re-throw AbortErrors and let the callers handle it. Eventually we want
+          // the caller to consume the error channel as an effect. We throw here the typical JS
+          // way so we don't infect more of the codebase with the effect runtime.
+          throw error;
+        case 'GraphqlRuntimeError':
+          console.error(
+            `Encountered runtime graphql error in fetchProfile. queryId: ${queryId} endpoint: ${
+              options.endpoint
+            } address: ${options.address}
+            
+            queryString: ${getFetchProfileQuery(options.address)}
+            `,
+            error.message
+          );
+
+          return {
+            geoProfiles: [],
+          };
+        default:
+          console.error(
+            `${error._tag}: Unable to fetch wallets to derive profile, queryId: ${queryId} endpoint: ${options.endpoint} address: ${options.address}`
+          );
+
+          return {
+            geoProfiles: [],
+          };
+      }
+    }
+
+    return resultOrError.right;
+  });
+
+  const result = await Effect.runPromise(graphqlFetchWithErrorFallbacks);
+
+  if (result.geoProfiles.length === 0) {
+    return null;
+  }
+
+  return result.geoProfiles[0];
+}

--- a/apps/web/core/io/subgraph/index.ts
+++ b/apps/web/core/io/subgraph/index.ts
@@ -29,4 +29,7 @@ export type { FetchProposedVersionOptions } from './fetch-proposed-version';
 export { fetchTableRowEntities } from './fetch-table-row-entities';
 export type { FetchTableRowEntitiesOptions } from './fetch-table-row-entities';
 
+export { fetchOnchainProfile } from './fetch-on-chain-profile';
+export type { FetchOnchainProfileOptions } from './fetch-on-chain-profile';
+
 export * as Errors from './errors';

--- a/apps/web/core/io/subgraph/subgraph-interface.ts
+++ b/apps/web/core/io/subgraph/subgraph-interface.ts
@@ -2,6 +2,7 @@ import { Entity, Profile, Proposal, ProposedVersion, Space, Triple } from '~/cor
 
 import { FetchEntitiesOptions } from './fetch-entities';
 import { FetchEntityOptions } from './fetch-entity';
+import { FetchOnchainProfileOptions } from './fetch-on-chain-profile';
 import { FetchProfileOptions } from './fetch-profile';
 import { FetchProposalOptions } from './fetch-proposal';
 import { FetchProposalsOptions } from './fetch-proposals';
@@ -19,6 +20,9 @@ export interface ISubgraph {
   fetchSpace: (options: FetchSpaceOptions) => Promise<Space | null>;
   fetchEntity: (options: FetchEntityOptions) => Promise<Entity | null>;
   fetchProfile: (options: FetchProfileOptions) => Promise<[string, Profile] | null>;
+  fetchOnchainProfile: (
+    options: FetchOnchainProfileOptions
+  ) => Promise<{ id: string; homeSpace: string; account: string } | null>;
   fetchProposals: (options: FetchProposalsOptions) => Promise<Proposal[]>;
   fetchProposal: (options: FetchProposalOptions) => Promise<Proposal | null>;
   fetchProposedVersions: (options: FetchProposedVersionsOptions) => Promise<ProposedVersion[]>;

--- a/apps/web/core/merged/merged.ts
+++ b/apps/web/core/merged/merged.ts
@@ -30,6 +30,7 @@ interface IMergedDataSource
     | 'fetchSpace'
     | 'fetchSpaces'
     | 'fetchProfile'
+    | 'fetchOnchainProfile'
   > {
   // Rows and columns aren't part of the subgraph API and instead are higher-order functions that
   // call the subgraph APIs themselves. This is because rows and columns are not entities in the

--- a/apps/web/partials/entity-page/editable-entity-page.test.tsx
+++ b/apps/web/partials/entity-page/editable-entity-page.test.tsx
@@ -13,7 +13,11 @@ describe('Editable Entity Page', () => {
     userEvent.setup();
 
     render(
-      <Providers>
+      <Providers
+        onConnectionChange={async () => {
+          //
+        }}
+      >
         <EntityStoreProvider
           id="1"
           spaceId="1"
@@ -29,22 +33,7 @@ describe('Editable Entity Page', () => {
             },
           ]}
         >
-          <EditableEntityPage
-            id="1"
-            name="Banana"
-            spaceId="1"
-            triples={[]}
-            serverAvatarUrl={null}
-            serverCoverUrl={null}
-            schemaTriples={[
-              {
-                ...MockNetworkData.makeStubTriple('Schema'),
-                attributeName: 'Schema',
-                attributeId: 'Schema',
-                placeholder: true,
-              },
-            ]}
-          />
+          <EditableEntityPage id="1" spaceId="1" triples={[]} />
         </EntityStoreProvider>
       </Providers>
     );
@@ -57,7 +46,11 @@ describe('Editable Entity Page', () => {
     userEvent.setup();
 
     render(
-      <Providers>
+      <Providers
+        onConnectionChange={async () => {
+          //
+        }}
+      >
         <EntityStoreProvider
           id="1"
           spaceId="1"
@@ -78,27 +71,7 @@ describe('Editable Entity Page', () => {
             },
           ]}
         >
-          <EditableEntityPage
-            id="1"
-            name="Banana"
-            spaceId="1"
-            triples={[]}
-            serverAvatarUrl={null}
-            serverCoverUrl={null}
-            schemaTriples={[
-              {
-                ...MockNetworkData.makeStubTriple('Schema'),
-                attributeName: 'Schema',
-                attributeId: 'Schema',
-                value: {
-                  type: 'entity',
-                  name: '',
-                  id: '',
-                },
-                placeholder: true,
-              },
-            ]}
-          />
+          <EditableEntityPage id="1" spaceId="1" triples={[]} />
         </EntityStoreProvider>
       </Providers>
     );

--- a/apps/web/partials/entity-page/entity-page-cover.tsx
+++ b/apps/web/partials/entity-page/entity-page-cover.tsx
@@ -5,6 +5,8 @@ import Image from 'next/legacy/image';
 
 import * as React from 'react';
 
+import { useEntityPageStore } from '~/core/hooks/use-entity-page-store';
+import { Entity } from '~/core/utils/entity';
 import { getImagePath } from '~/core/utils/utils';
 
 type EntityPageCoverProps = {
@@ -13,7 +15,16 @@ type EntityPageCoverProps = {
   space?: boolean;
 };
 
-export const EntityPageCover = ({ avatarUrl, coverUrl, space = false }: EntityPageCoverProps) => {
+export const EntityPageCover = ({
+  avatarUrl: serverAvatarUrl,
+  coverUrl: serverCoverUrl,
+  space = false,
+}: EntityPageCoverProps) => {
+  const { triples } = useEntityPageStore();
+
+  const avatarUrl = Entity.avatar(triples) ?? serverAvatarUrl;
+  const coverUrl = Entity.cover(triples) ?? serverCoverUrl;
+
   if (!coverUrl && !avatarUrl) return null;
 
   if (coverUrl) {

--- a/apps/web/partials/governance/governance-proposals-list.tsx
+++ b/apps/web/partials/governance/governance-proposals-list.tsx
@@ -21,6 +21,18 @@ interface Props {
 export async function GovernanceProposalsList({ spaceId }: Props) {
   const connectedAddress = cookies().get(Cookie.WALLET_ADDRESS)?.value;
 
+  let space = await Subgraph.fetchSpace({ endpoint: options.production.subgraph, id: spaceId });
+  let usePermissionlessSubgraph = false;
+
+  if (!space) {
+    space = await Subgraph.fetchSpace({ endpoint: options.production.permissionlessSubgraph, id: spaceId });
+    if (space) usePermissionlessSubgraph = true;
+  }
+
+  if (usePermissionlessSubgraph) {
+    options.production.subgraph = options.production.permissionlessSubgraph;
+  }
+
   const [proposals, editorsForSpace] = await Promise.all([
     Subgraph.fetchProposals({ spaceId, first: 5, endpoint: options.production.subgraph }),
     getEditorsForSpace(spaceId, connectedAddress),

--- a/apps/web/partials/onboarding/dialog.tsx
+++ b/apps/web/partials/onboarding/dialog.tsx
@@ -7,7 +7,7 @@ import { Command } from 'cmdk';
 import { AnimatePresence, motion } from 'framer-motion';
 
 import * as React from 'react';
-import { ChangeEvent, useCallback, useEffect, useRef, useState } from 'react';
+import { ChangeEvent, useCallback, useRef, useState } from 'react';
 
 import { useAccount } from 'wagmi';
 
@@ -47,6 +47,8 @@ export const OnboardingDialog = observer(() => {
       setWorkflowStep('creating-profile');
 
       await sleepWithCallback(() => setWorkflowStep('done'), 5000);
+
+      setStep('completed');
     }
   }
 
@@ -81,7 +83,7 @@ export const OnboardingDialog = observer(() => {
               {(step === 'completing' || step === 'completed') && (
                 <>
                   <StepHeader step={step} />
-                  <StepComplete onNext={() => setStep('completed')} workflowStep={workflowStep} />
+                  <StepComplete workflowStep={workflowStep} />
                 </>
               )}
             </ModalCard>
@@ -274,30 +276,17 @@ function StepOnboarding({ onNext, address, name, setName, avatar, setAvatar }: S
 }
 
 type StepCompleteProps = {
-  onNext: () => void;
   workflowStep: 'idle' | 'creating-spaces' | 'creating-profile' | 'done';
 };
 
-function StepComplete({ onNext, workflowStep: stage }: StepCompleteProps) {
-  // useEffect(() => {
-  //   if (stage >= 5) {
-  //     onNext();
-  //     return;
-  //   }
+const stageAsNumber = {
+  idle: 0,
+  'creating-spaces': 1,
+  'creating-profile': 2,
+  done: 3,
+};
 
-  //   setTimeout(() => {
-  //     const nextStage = stage + 1;
-  //     setStage(nextStage);
-  //   }, 10_000);
-  // }, [stage, onNext]);
-
-  const stageAsNumber = {
-    idle: 0,
-    'creating-spaces': 1,
-    'creating-profile': 2,
-    done: 3,
-  };
-
+function StepComplete({ workflowStep: stage }: StepCompleteProps) {
   return (
     <>
       <StepContents key="start">

--- a/apps/web/partials/onboarding/dialog.tsx
+++ b/apps/web/partials/onboarding/dialog.tsx
@@ -333,11 +333,9 @@ function StepComplete({ onNext, workflowStep: stage }: StepCompleteProps) {
 }
 
 const complete: Record<number, string> = {
-  1: `Step 1. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do.`,
-  2: `Step 2. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do.`,
-  3: `Step 3. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do.`,
-  4: `Final Step. Lorem ipsum dolor sit amet, consectetur adipiscing elit sed.`,
-  5: `Start browsing content, voting on what matters, joining spaces and contributing to GEO as an editor.`,
+  1: `Step 1. Creating your personal space.`,
+  2: `Step 2. Sign the transaction to create your profile.`,
+  3: `Start browsing content, voting on what matters, joining spaces and contributing to GEO as an editor.`,
 };
 
 type ProgressProps = {

--- a/apps/web/partials/onboarding/dialog.tsx
+++ b/apps/web/partials/onboarding/dialog.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { observer } from '@legendapp/state/react';
 import BoringAvatar from 'boring-avatars';
 import cx from 'classnames';
 import { Command } from 'cmdk';
@@ -22,7 +21,7 @@ import { Text } from '~/design-system/text';
 
 type Step = 'start' | 'onboarding' | 'completing' | 'completed';
 
-export const OnboardingDialog = observer(() => {
+export const OnboardingDialog = () => {
   const { address } = useAccount();
   const [name, setName] = useState('');
   const [avatar, setAvatar] = useState('');
@@ -92,7 +91,7 @@ export const OnboardingDialog = observer(() => {
       </div>
     </Command.Dialog>
   );
-});
+};
 
 type ModalCardProps = {
   key: string;

--- a/apps/web/partials/space-page/get-editors-for-space.ts
+++ b/apps/web/partials/space-page/get-editors-for-space.ts
@@ -11,7 +11,17 @@ type EditorsForSpace = {
 
 export async function getEditorsForSpace(spaceId: string, connectedAddress?: string): Promise<EditorsForSpace> {
   const config = Params.getConfigFromParams({}, undefined);
-  const space = await Subgraph.fetchSpace({ endpoint: config.subgraph, id: spaceId });
+  let space = await Subgraph.fetchSpace({ endpoint: config.subgraph, id: spaceId });
+  let usePermissionlessSpace = false;
+
+  if (!space) {
+    space = await Subgraph.fetchSpace({ endpoint: config.permissionlessSubgraph, id: spaceId });
+    if (space) usePermissionlessSpace = true;
+  }
+
+  if (usePermissionlessSpace) {
+    config.subgraph = config.permissionlessSubgraph;
+  }
 
   if (!space) {
     throw new Error("Space doesn't exist");

--- a/packages/contracts/.openzeppelin/polygon.json
+++ b/packages/contracts/.openzeppelin/polygon.json
@@ -45,6 +45,11 @@
       "address": "0x717a842318951c8D2eCc94C448483fea0f6da957",
       "txHash": "0x1a76bc30fc68a7e2b18ce3375e1b04ca824899cab2f6959b617f2f879f2290ad",
       "kind": "beacon"
+    },
+    {
+      "address": "0x68930a23A91A8FA97C6053cD5057431BaD3eEB52",
+      "txHash": "0xf4a2666decd37a0f402869684e133bfdc08f8c6b763345e6239e8638800b1cc8",
+      "kind": "beacon"
     }
   ],
   "impls": {

--- a/packages/ids/system-ids.ts
+++ b/packages/ids/system-ids.ts
@@ -99,7 +99,7 @@ export const WALLETS_ATTRIBUTE = '31f6922e-0d4e-4f14-a1ee-8c7689457715'
  */
 
 export const PROFILE_REGISTRY_ADDRESS =
-  '0xa55917aF3055cbB2ABAbAB8552b3358B0A27d87b'
+  '0xc42Cd03dFfE4Ff10959d65428A7adA2C752B5822'
 // '0x62b5b813B74C4166DA4f3f88Af6E8E4e657a9458' // mumbai
 
 // This represents the beacon for the first set of deployed permissioned spaces.
@@ -123,7 +123,7 @@ export const PERMISSIONLESS_SPACE_BEACON_ADDRESS =
 // This represents the PermissionlessSpace contract acting as the registry for all
 // permissionless spaces.
 export const PERMISSIONLESS_SPACE_REGISTRY_ADDRESS =
-  '0x717a842318951c8D2eCc94C448483fea0f6da957'
+  '0x68930a23A91A8FA97C6053cD5057431BaD3eEB52'
 // '0x42096035524630382E73cfFAE1CA319CFa72F4dC' // mumbai
 
 export const MEMBERSHIP_CONTRACT_ADDRESS =

--- a/packages/permissionless-subgraph/networks.json
+++ b/packages/permissionless-subgraph/networks.json
@@ -1,8 +1,8 @@
 {
   "matic": {
     "PermissionlessSpaceRegistry": {
-      "address": "0x717a842318951c8D2eCc94C448483fea0f6da957",
-      "startBlock": 48797127
+      "address": "0x68930a23A91A8FA97C6053cD5057431BaD3eEB52",
+      "startBlock": 48810411
     }
   },
   "mumbai": {

--- a/packages/permissionless-subgraph/src/bootstrap.ts
+++ b/packages/permissionless-subgraph/src/bootstrap.ts
@@ -82,20 +82,20 @@ const names: Tuple<string, StringValue>[] = [
   { _0: TYPES, _1: new StringValue(TYPES, 'Types') },
   { _0: NAME, _1: new StringValue(NAME, 'Name') },
   { _0: ATTRIBUTE, _1: new StringValue(ATTRIBUTE, 'Attribute') },
-  { _0: SPACE, _1: new StringValue(SPACE, 'Space') },
+  { _0: SPACE, _1: new StringValue(SPACE, 'Indexed Space') },
   { _0: ATTRIBUTES, _1: new StringValue(ATTRIBUTES, 'Attributes') },
   { _0: SCHEMA_TYPE, _1: new StringValue(SCHEMA_TYPE, 'Type') },
   { _0: VALUE_TYPE, _1: new StringValue(VALUE_TYPE, 'Value type') },
   { _0: RELATION, _1: new StringValue(RELATION, 'Relation') },
   { _0: TEXT, _1: new StringValue(TEXT, 'Text') },
-  { _0: IMAGE, _1: new StringValue(TEXT, 'Image') },
+  { _0: IMAGE, _1: new StringValue(IMAGE, 'Image') },
   { _0: DATE, _1: new StringValue(DATE, 'Date') },
   { _0: WEB_URL, _1: new StringValue(WEB_URL, 'Web URL') },
   { _0: IMAGE_ATTRIBUTE, _1: new StringValue(IMAGE_ATTRIBUTE, 'Image') },
   { _0: DESCRIPTION, _1: new StringValue(DESCRIPTION, 'Description') },
   {
     _0: SPACE_CONFIGURATION,
-    _1: new StringValue(SPACE_CONFIGURATION, 'Space Configuration'),
+    _1: new StringValue(SPACE_CONFIGURATION, 'Space'),
   },
   { _0: FOREIGN_TYPES, _1: new StringValue(FOREIGN_TYPES, 'Foreign Types') },
   { _0: TABLE_BLOCK, _1: new StringValue(TABLE_BLOCK, 'Table Block') },
@@ -138,6 +138,8 @@ const attributes: Tuple<string, string>[] = [
   { _0: PARENT_ENTITY, _1: RELATION },
   { _0: FILTER, _1: TEXT },
   { _0: RELATION_VALUE_RELATIONSHIP_TYPE, _1: RELATION },
+  { _0: AVATAR_ATTRIBUTE, _1: IMAGE },
+  { _0: COVER_ATTRIBUTE, _1: IMAGE },
 ]
 
 /* Multi-dimensional array of [TypeId, [Attributes]] */

--- a/packages/permissionless-subgraph/src/bootstrap.ts
+++ b/packages/permissionless-subgraph/src/bootstrap.ts
@@ -153,6 +153,7 @@ const types: Tuple<string, string[]>[] = [
   { _0: IMAGE_BLOCK, _1: [IMAGE_ATTRIBUTE, PARENT_ENTITY] },
   { _0: TABLE_BLOCK, _1: [ROW_TYPE, PARENT_ENTITY] },
   { _0: TEXT_BLOCK, _1: [MARKDOWN_CONTENT, PARENT_ENTITY] },
+  { _0: PERSON_TYPE, _1: [AVATAR_ATTRIBUTE, COVER_ATTRIBUTE] },
 ]
 
 export function bootstrapRootSpaceCoreTypes(

--- a/packages/permissionless-subgraph/src/bootstrap.ts
+++ b/packages/permissionless-subgraph/src/bootstrap.ts
@@ -19,6 +19,7 @@ import {
   MARKDOWN_CONTENT,
   NAME,
   PARENT_ENTITY,
+  PERSON_TYPE,
   RELATION,
   ROW_TYPE,
   SCHEMA_TYPE,
@@ -69,6 +70,7 @@ const entities: string[] = [
   RELATION_VALUE_RELATIONSHIP_TYPE,
   DATE,
   WEB_URL,
+  PERSON_TYPE,
 ]
 
 class Tuple<T, U> {
@@ -102,6 +104,7 @@ const names: Tuple<string, StringValue>[] = [
   { _0: IMAGE_BLOCK, _1: new StringValue(IMAGE_BLOCK, 'Image Block') },
   { _0: BLOCKS, _1: new StringValue(BLOCKS, 'Blocks') },
   { _0: PARENT_ENTITY, _1: new StringValue(PARENT_ENTITY, 'Parent Entity') },
+  { _0: PERSON_TYPE, _1: new StringValue(PERSON_TYPE, 'Person') },
   {
     _0: MARKDOWN_CONTENT,
     _1: new StringValue(MARKDOWN_CONTENT, 'Markdown Content'),

--- a/packages/permissionless-subgraph/src/mapping.ts
+++ b/packages/permissionless-subgraph/src/mapping.ts
@@ -6,10 +6,9 @@ import {
 } from '../generated/templates/Space/Space'
 import { addEntry } from './add-entry'
 import { addRole, removeRole } from './access-control'
-import { getChecksumAddress } from './get-checksum-address'
 
 export function handleEntryAdded(event: EntryAdded): void {
-  const address = getChecksumAddress(event.address)
+  const address = event.address.toHexString()
 
   const rootSpace = Space.load(address)
 

--- a/packages/permissionless-subgraph/src/root-mapping.ts
+++ b/packages/permissionless-subgraph/src/root-mapping.ts
@@ -4,22 +4,21 @@ import { EntryAdded as RegistryEntryAdded } from '../generated/PermissionlessSpa
 import { handleSpaceAdded } from './actions'
 import { addEntry } from './add-entry'
 import { bootstrapRootSpaceCoreTypes } from './bootstrap'
-import { getChecksumAddress } from './get-checksum-address'
 
 export function handleRootEntryAdded(event: RegistryEntryAdded): void {
-  const address = getChecksumAddress(event.address)
+  const address = event.address
   const createdAtBlock = event.block.number
   const createdAtTimestamp = event.block.timestamp
 
   bootstrapRootSpace(
-    address,
+    address.toHexString(),
     createdAtBlock,
     createdAtTimestamp,
     event.transaction.from
   )
 
   addEntry({
-    space: address,
+    space: address.toHexString(),
     index: event.params.index,
     uri: event.params.uri,
     createdBy: event.params.author,

--- a/packages/permissionless-subgraph/subgraph.yaml
+++ b/packages/permissionless-subgraph/subgraph.yaml
@@ -9,11 +9,11 @@ schema:
 dataSources:
   - kind: ethereum/contract
     name: PermissionlessSpaceRegistry
-    network: matic
+    network: mumbai
     source:
       abi: PermissionlessSpaceRegistry
-      address: "0x717a842318951c8D2eCc94C448483fea0f6da957"
-      startBlock: 48797127
+      address: "0x42096035524630382E73cfFAE1CA319CFa72F4dC"
+      startBlock: 41274221
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.6
@@ -30,7 +30,7 @@ dataSources:
 templates:
   - kind: ethereum/contract
     name: Space
-    network: matic
+    network: mumbai
     source:
       abi: Space
     mapping:

--- a/packages/permissionless-subgraph/subgraph.yaml
+++ b/packages/permissionless-subgraph/subgraph.yaml
@@ -9,11 +9,11 @@ schema:
 dataSources:
   - kind: ethereum/contract
     name: PermissionlessSpaceRegistry
-    network: mumbai
+    network: matic
     source:
       abi: PermissionlessSpaceRegistry
-      address: "0x42096035524630382E73cfFAE1CA319CFa72F4dC"
-      startBlock: 41274221
+      address: "0x717a842318951c8D2eCc94C448483fea0f6da957"
+      startBlock: 48797127
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.6
@@ -30,7 +30,7 @@ dataSources:
 templates:
   - kind: ethereum/contract
     name: Space
-    network: mumbai
+    network: matic
     source:
       abi: Space
     mapping:

--- a/packages/permissionless-subgraph/subgraph.yaml
+++ b/packages/permissionless-subgraph/subgraph.yaml
@@ -12,8 +12,8 @@ dataSources:
     network: matic
     source:
       abi: PermissionlessSpaceRegistry
-      address: "0x717a842318951c8D2eCc94C448483fea0f6da957"
-      startBlock: 48797127
+      address: "0x68930a23A91A8FA97C6053cD5057431BaD3eEB52"
+      startBlock: 48810411
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.6

--- a/packages/profile-subgraph/networks.json
+++ b/packages/profile-subgraph/networks.json
@@ -7,8 +7,8 @@
   },
   "matic": {
     "GeoProfileRegistry": {
-      "address": "0xa55917aF3055cbB2ABAbAB8552b3358B0A27d87b",
-      "startBlock": 48640368
+      "address": "0xc42Cd03dFfE4Ff10959d65428A7adA2C752B5822",
+      "startBlock": 48810387
     }
   }
 }

--- a/packages/profile-subgraph/src/mapping.ts
+++ b/packages/profile-subgraph/src/mapping.ts
@@ -12,13 +12,13 @@ function getProfileId(account: string, onChainId: string): string {
 
 export function handleGeoProfileRegistered(event: GeoProfileRegistered): void {
   const userAccount = getChecksumAddress(event.params.account)
-  const space = getChecksumAddress(event.params.homeSpace)
+  const space = event.params.homeSpace
   const onChainId = event.params.id.toString()
   const id = getProfileId(userAccount, onChainId)
 
   const newProfile = new GeoProfile(id)
   newProfile.account = userAccount
-  newProfile.homeSpace = space
+  newProfile.homeSpace = space.toHexString()
   newProfile.createdAt = event.block.timestamp
   newProfile.save()
 
@@ -29,7 +29,7 @@ export function handleGeoProfileHomeSpaceUpdated(
   event: GeoProfileHomeSpaceUpdated
 ): void {
   const userAccount = getChecksumAddress(event.params.account)
-  const space = getChecksumAddress(event.params.homeSpace)
+  const space = event.params.homeSpace
   const onChainId = event.params.id.toString()
   const id = getProfileId(userAccount, onChainId)
 
@@ -46,11 +46,11 @@ export function handleGeoProfileHomeSpaceUpdated(
     return
   }
 
-  profile.homeSpace = space
+  profile.homeSpace = space.toHexString()
   profile.save()
 
   log.info('Profile home space updated. Profile id – {}. New space – {}', [
     id,
-    space,
+    space.toHexString(),
   ])
 }

--- a/packages/profile-subgraph/subgraph.yaml
+++ b/packages/profile-subgraph/subgraph.yaml
@@ -12,8 +12,8 @@ dataSources:
     network: matic
     source:
       abi: GeoProfileRegistry
-      address: "0xa55917aF3055cbB2ABAbAB8552b3358B0A27d87b"
-      startBlock: 48640368
+      address: "0xc42Cd03dFfE4Ff10959d65428A7adA2C752B5822"
+      startBlock: 48810387
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.6

--- a/packages/subgraph/src/actions.ts
+++ b/packages/subgraph/src/actions.ts
@@ -217,9 +217,6 @@ export function handleCreateTripleAction(
   const dateValue = fact.value.asDateValue()
   if (dateValue) {
     log.debug('Creating date value', [])
-    if (attribute.id == TYPES) {
-      addEntityTypeId(entity, dateValue.value)
-    }
     triple.valueType = 'DATE'
     triple.valueId = dateValue.id
     triple.stringValue = dateValue.value
@@ -228,9 +225,6 @@ export function handleCreateTripleAction(
 
   const stringValue = fact.value.asStringValue()
   if (stringValue) {
-    if (attribute.id == TYPES) {
-      addEntityTypeId(entity, stringValue.id)
-    }
     triple.valueType = 'STRING'
     triple.valueId = stringValue.id
     triple.stringValue = stringValue.value
@@ -253,9 +247,7 @@ export function handleCreateTripleAction(
   const urlValue = fact.value.asUrlValue()
   if (urlValue) {
     log.debug('Creating url value', [])
-    if (attribute.id == TYPES) {
-      addEntityTypeId(entity, urlValue.value)
-    }
+
     triple.valueType = 'URL'
     triple.valueId = urlValue.id
     triple.stringValue = urlValue.value
@@ -276,9 +268,6 @@ export function handleCreateTripleAction(
 
   const numberValue = fact.value.asNumberValue()
   if (numberValue) {
-    if (attribute.id == TYPES) {
-      addEntityTypeId(entity, numberValue.id)
-    }
     triple.valueType = 'NUMBER'
     triple.valueId = numberValue.id
     triple.numberValue = BigDecimal.fromString(numberValue.value)


### PR DESCRIPTION
This PR integrates (jankily) the e2e workflow for onboarding a new Geo user on Polygon mainnet.
- Deploys personal space
- Configures space with correct roles for the connected user
- Creates profile entity in the new space
- Registers the user in the on-chain `GeoProfileRegistry`
- Integrates network calls in app to attempt querying both the permissionless and permissioned spaces and sets up context to query the correct space on the client depending on the current space.
- Fixes some bugs during the onboarding API workflow