### PR TITLE
feat: permissionless navbar space metadata

### DIFF
--- a/apps/web/app/space/[id]/[entityId]/layout.tsx
+++ b/apps/web/app/space/[id]/[entityId]/layout.tsx
@@ -35,7 +35,7 @@ export default async function ProfileLayout({ children, params }: Props) {
   const env = cookies().get(Params.ENV_PARAM_NAME)?.value;
 
   // Layouts do not receive search params (hmm)
-  const config = Params.getConfigFromParams({}, env);
+  let config = Params.getConfigFromParams({}, env);
 
   params.entityId = decodeURIComponent(params.entityId);
 
@@ -48,7 +48,10 @@ export default async function ProfileLayout({ children, params }: Props) {
   }
 
   if (usePermissionlessSubgraph) {
-    config.subgraph = config.permissionlessSubgraph;
+    config = {
+      ...config,
+      subgraph: config.permissionlessSubgraph,
+    };
   }
 
   const types = await fetchEntityType({

--- a/apps/web/app/space/[id]/[entityId]/page.tsx
+++ b/apps/web/app/space/[id]/[entityId]/page.tsx
@@ -16,7 +16,7 @@ interface Props {
 
 export default async function EntityTemplateStrategy({ params, searchParams }: Props) {
   const env = cookies().get(Params.ENV_PARAM_NAME)?.value;
-  const config = Params.getConfigFromParams(searchParams, env);
+  let config = Params.getConfigFromParams(searchParams, env);
 
   let space = await Subgraph.fetchSpace({ endpoint: config.subgraph, id: params.id });
   let usePermissionlessSubgraph = false;
@@ -27,7 +27,10 @@ export default async function EntityTemplateStrategy({ params, searchParams }: P
   }
 
   if (usePermissionlessSubgraph) {
-    config.subgraph = config.permissionlessSubgraph;
+    config = {
+      ...config,
+      subgraph: config.permissionlessSubgraph,
+    };
   }
 
   const types = await fetchEntityType({

--- a/apps/web/app/space/[id]/[entityId]/profile-entity-server-container.tsx
+++ b/apps/web/app/space/[id]/[entityId]/profile-entity-server-container.tsx
@@ -17,7 +17,7 @@ interface Props {
 
 export async function ProfileEntityServerContainer({ params, searchParams }: Props) {
   const env = cookies().get(Params.ENV_PARAM_NAME)?.value;
-  const config = Params.getConfigFromParams(searchParams, env);
+  let config = Params.getConfigFromParams(searchParams, env);
 
   let space = await Subgraph.fetchSpace({ endpoint: config.subgraph, id: params.id });
   let usePermissionlessSubgraph = false;
@@ -28,7 +28,10 @@ export async function ProfileEntityServerContainer({ params, searchParams }: Pro
   }
 
   if (usePermissionlessSubgraph) {
-    config.subgraph = config.permissionlessSubgraph;
+    config = {
+      ...config,
+      subgraph: config.permissionlessSubgraph,
+    };
   }
 
   const person = await Subgraph.fetchEntity({ id: params.entityId, endpoint: config.subgraph });

--- a/apps/web/app/space/[id]/entities/page.tsx
+++ b/apps/web/app/space/[id]/entities/page.tsx
@@ -34,8 +34,6 @@ export default async function EntitiesPage({ params, searchParams }: Props) {
   let space = await Subgraph.fetchSpace({ endpoint: config.subgraph, id: spaceId });
   let usePermissionlessSubgraph = false;
 
-  console.log('space', space);
-
   if (!space) {
     space = await Subgraph.fetchSpace({ endpoint: config.permissionlessSubgraph, id: spaceId });
     if (space) usePermissionlessSubgraph = true;
@@ -47,8 +45,6 @@ export default async function EntitiesPage({ params, searchParams }: Props) {
       subgraph: config.permissionlessSubgraph,
     };
   }
-
-  console.log('config entities', config);
 
   const props = await getData({ space, config, initialParams });
 

--- a/apps/web/app/space/[id]/entities/page.tsx
+++ b/apps/web/app/space/[id]/entities/page.tsx
@@ -29,10 +29,12 @@ export default async function EntitiesPage({ params, searchParams }: Props) {
   const spaceId = params.id;
   const env = cookies().get(Params.ENV_PARAM_NAME)?.value;
   const initialParams = Params.parseEntityTableQueryFilterFromParams(searchParams);
-  const config = Params.getConfigFromParams(searchParams, env);
+  let config = Params.getConfigFromParams(searchParams, env);
 
   let space = await Subgraph.fetchSpace({ endpoint: config.subgraph, id: spaceId });
   let usePermissionlessSubgraph = false;
+
+  console.log('space', space);
 
   if (!space) {
     space = await Subgraph.fetchSpace({ endpoint: config.permissionlessSubgraph, id: spaceId });
@@ -40,8 +42,13 @@ export default async function EntitiesPage({ params, searchParams }: Props) {
   }
 
   if (usePermissionlessSubgraph) {
-    config.subgraph = config.permissionlessSubgraph;
+    config = {
+      ...config,
+      subgraph: config.permissionlessSubgraph,
+    };
   }
+
+  console.log('config entities', config);
 
   const props = await getData({ space, config, initialParams });
 

--- a/apps/web/app/space/[id]/governance/page.tsx
+++ b/apps/web/app/space/[id]/governance/page.tsx
@@ -21,7 +21,7 @@ interface Props {
 
 export default async function GovernancePage({ params, searchParams }: Props) {
   const env = cookies().get(Params.ENV_PARAM_NAME)?.value;
-  const config = Params.getConfigFromParams(searchParams, env);
+  let config = Params.getConfigFromParams(searchParams, env);
 
   let space = await Subgraph.fetchSpace({ endpoint: config.subgraph, id: params.id });
   let usePermissionlessSubgraph = false;
@@ -32,7 +32,10 @@ export default async function GovernancePage({ params, searchParams }: Props) {
   }
 
   if (usePermissionlessSubgraph) {
-    config.subgraph = config.permissionlessSubgraph;
+    config = {
+      ...config,
+      subgraph: config.permissionlessSubgraph,
+    };
   }
 
   const proposalsCount = await getProposalsCount({ params, searchParams });

--- a/apps/web/app/space/[id]/page.tsx
+++ b/apps/web/app/space/[id]/page.tsx
@@ -73,7 +73,7 @@ export async function generateMetadata({ params, searchParams }: Props): Promise
 export default async function SpacePage({ params, searchParams }: Props) {
   const env = cookies().get(Params.ENV_PARAM_NAME)?.value;
 
-  const config = Params.getConfigFromParams(searchParams, env);
+  let config = Params.getConfigFromParams(searchParams, env);
 
   let space = await Subgraph.fetchSpace({ endpoint: config.subgraph, id: params.id });
   let usePermissionlessSubgraph = false;
@@ -84,7 +84,10 @@ export default async function SpacePage({ params, searchParams }: Props) {
   }
 
   if (usePermissionlessSubgraph) {
-    config.subgraph = config.permissionlessSubgraph;
+    config = {
+      ...config,
+      subgraph: config.permissionlessSubgraph,
+    };
   }
 
   const props = await getData(params.id, config);

--- a/apps/web/app/space/[id]/space-layout.tsx
+++ b/apps/web/app/space/[id]/space-layout.tsx
@@ -36,10 +36,13 @@ interface Props {
 // so we use it like normal React component instead of a Next.js route layout.
 export async function SpaceLayout({ params, searchParams, children, usePermissionlessSpace }: Props) {
   const env = cookies().get(Params.ENV_PARAM_NAME)?.value;
-  const config = Params.getConfigFromParams(searchParams, env);
+  let config = Params.getConfigFromParams(searchParams, env);
 
   if (usePermissionlessSpace) {
-    config.subgraph = config.permissionlessSubgraph;
+    config = {
+      ...config,
+      subgraph: config.permissionlessSubgraph,
+    };
   }
 
   const props = await getData(params.id, config);

--- a/apps/web/core/services/services.tsx
+++ b/apps/web/core/services/services.tsx
@@ -37,11 +37,14 @@ export function ServicesProvider({ children }: Props) {
   const chainId = chain ? String(chain.id) : Environment.options.production.chainId;
 
   const services = useMemo((): Services => {
-    const config = Environment.getConfig(chainId);
+    let config = Environment.getConfig(chainId);
     const storageClient = new Storage.StorageClient(config.ipfs);
 
     if (secondarySubgraph) {
-      config.subgraph = config.permissionlessSubgraph;
+      config = {
+        ...config,
+        subgraph: config.permissionlessSubgraph,
+      };
     }
 
     return {

--- a/apps/web/partials/navbar/navbar-actions.tsx
+++ b/apps/web/partials/navbar/navbar-actions.tsx
@@ -5,6 +5,7 @@ import { cva } from 'class-variance-authority';
 import classnames from 'classnames';
 import { AnimatePresence, AnimationControls, motion, useAnimation } from 'framer-motion';
 import Link from 'next/link';
+import { useParams } from 'next/navigation';
 
 import * as React from 'react';
 
@@ -23,11 +24,10 @@ import { BulkEdit } from '~/design-system/icons/bulk-edit';
 import { EyeSmall } from '~/design-system/icons/eye-small';
 import { Menu } from '~/design-system/menu';
 
-interface Props {
-  spaceId?: string;
-}
+export function NavbarActions() {
+  const params = useParams();
+  const spaceId = params?.['id'] as string | undefined;
 
-export function NavbarActions({ spaceId }: Props) {
   const [open, onOpenChange] = React.useState(false);
 
   const { address } = useAccount();
@@ -127,7 +127,7 @@ const variants = {
 
 const MotionPopoverContent = motion(Popover.Content);
 
-function ModeToggle({ spaceId }: Props) {
+function ModeToggle({ spaceId }: { spaceId?: string }) {
   const { isEditor, isAdmin, isEditorController } = useAccessControl(spaceId);
   const { setEditable, editable } = useEditable();
   const controls = useAnimation();

--- a/apps/web/partials/navbar/navbar-space-metadata.tsx
+++ b/apps/web/partials/navbar/navbar-space-metadata.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { SYSTEM_IDS } from '@geogenesis/ids';
+import { useQuery } from '@tanstack/react-query';
+import { useParams } from 'next/navigation';
+
+import { Services } from '~/core/services';
+import { NavUtils } from '~/core/utils/utils';
+
+import { ChevronRight } from '~/design-system/icons/chevron-right';
+
+import { NavbarBreadcrumb } from './navbar-breadcrumb';
+import { NavbarLinkMenu } from './navbar-link-menu';
+
+export function NavbarSpaceMetadata() {
+  const { subgraph, config } = Services.useServices();
+  const params = useParams();
+  const spaceId: string | undefined = params?.['id'] as string | undefined;
+
+  const { data: space } = useQuery({
+    queryKey: ['space', spaceId, config.subgraph],
+    queryFn: async () => {
+      if (!spaceId) return null;
+      return await subgraph.fetchSpace({ id: spaceId, endpoint: config.subgraph });
+    },
+    suspense: true,
+  });
+
+  if (!space) {
+    return null;
+  }
+
+  const href = NavUtils.toSpace(space.id);
+  const img = space.attributes[SYSTEM_IDS.IMAGE_ATTRIBUTE];
+  const name = space.attributes[SYSTEM_IDS.NAME] ?? space.id;
+
+  return (
+    <div>
+      <div className="flex items-center gap-2">
+        <NavbarLinkMenu />
+
+        <ChevronRight color="grey-03" />
+
+        <NavbarBreadcrumb href={href} img={img ?? null}>
+          {name.slice(0, 48) + (name.length > 48 ? '...' : '')}
+        </NavbarBreadcrumb>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/partials/navbar/navbar.tsx
+++ b/apps/web/partials/navbar/navbar.tsx
@@ -1,61 +1,29 @@
-'use client';
-
-import { SYSTEM_IDS } from '@geogenesis/ids';
 import Link from 'next/link';
-import { useSelectedLayoutSegments } from 'next/navigation';
 
-import { useSpaces } from '~/core/hooks/use-spaces';
+import { Suspense } from 'react';
 
 import { ClientOnly } from '~/design-system/client-only';
 import { Icon } from '~/design-system/icon';
-import { ChevronRight } from '~/design-system/icons/chevron-right';
 import { GeoLogoLarge } from '~/design-system/icons/geo-logo-large';
-import { Spacer } from '~/design-system/spacer';
+import { Skeleton } from '~/design-system/skeleton';
 
 import { NavbarActions } from './navbar-actions';
-import { NavbarBreadcrumb } from './navbar-breadcrumb';
-import { NavbarLinkMenu } from './navbar-link-menu';
+import { NavbarSpaceMetadata } from './navbar-space-metadata';
 
 interface Props {
   onSearchClick: () => void;
 }
 
 export function Navbar({ onSearchClick }: Props) {
-  const { spaces } = useSpaces();
-  const urlComponents = useSelectedLayoutSegments();
-
-  const spaceNames = Object.fromEntries(spaces.map(space => [space.id, space.attributes.name]));
-  const spaceImages = Object.fromEntries(spaces.map(space => [space.id, space.attributes[SYSTEM_IDS.IMAGE_ATTRIBUTE]]));
-
-  const isHomePage = urlComponents.length === 1 && urlComponents[0] === 'spaces';
-
-  // We always want to return the Space as the active breadcrumb on the /[entityId]
-  // and /[id] pages.
-  const getActiveImage = () => {
-    return spaceImages[urlComponents[1]] ?? '';
-  };
-  const getActiveName = () => {
-    return spaceNames[urlComponents[1]] ?? '';
-  };
-  const getActiveLink = () => `/space/${urlComponents[1] ?? ''}`;
-
   return (
-    <nav className="flex h-11 w-full items-center justify-between gap-1 border-b border-divider py-1 px-4">
+    <nav className="flex h-11 w-full items-center justify-between gap-1 border-b border-divider px-4 py-1">
       <div className="flex items-center gap-8 md:gap-4">
         <Link href="/spaces">
           <GeoLogoLarge />
         </Link>
-        {!isHomePage && (
-          <div className="flex items-center gap-2">
-            <NavbarLinkMenu />
-
-            <ChevronRight color="grey-03" />
-
-            <NavbarBreadcrumb href={getActiveLink()} img={getActiveImage()}>
-              {getActiveName().slice(0, 48) + (getActiveName().length > 48 ? '...' : '')}
-            </NavbarBreadcrumb>
-          </div>
-        )}
+        <Suspense fallback={<SpaceSkeleton />}>
+          <NavbarSpaceMetadata />
+        </Suspense>
       </div>
 
       {/* Hide navbar actions until we are on the client. This is because our account state only exists
@@ -71,16 +39,21 @@ export function Navbar({ onSearchClick }: Props) {
       <ClientOnly>
         <div className="flex items-center gap-4">
           <button
-            className="text-grey-04 p-2 hover:bg-grey-01 active:bg-divider focus:bg-grey-01 rounded-full transition-colors duration-200"
+            className="rounded-full p-2 text-grey-04 transition-colors duration-200 hover:bg-grey-01 focus:bg-grey-01 active:bg-divider"
             onClick={onSearchClick}
           >
             <Icon icon="search" />
           </button>
           <div className="flex items-center sm:hidden">
-            <NavbarActions spaceId={urlComponents?.[1]} />
+            {/* <NavbarActions spaceId={urlComponents?.[1]} /> */}
+            <NavbarActions spaceId={''} />
           </div>
         </div>
       </ClientOnly>
     </nav>
   );
+}
+
+function SpaceSkeleton() {
+  return <Skeleton className="h-6 w-40" />;
 }

--- a/apps/web/partials/navbar/navbar.tsx
+++ b/apps/web/partials/navbar/navbar.tsx
@@ -45,8 +45,7 @@ export function Navbar({ onSearchClick }: Props) {
             <Icon icon="search" />
           </button>
           <div className="flex items-center sm:hidden">
-            {/* <NavbarActions spaceId={urlComponents?.[1]} /> */}
-            <NavbarActions spaceId={''} />
+            <NavbarActions />
           </div>
         </div>
       </ClientOnly>

--- a/apps/web/partials/space-page/get-editors-for-space.ts
+++ b/apps/web/partials/space-page/get-editors-for-space.ts
@@ -10,7 +10,7 @@ type EditorsForSpace = {
 };
 
 export async function getEditorsForSpace(spaceId: string, connectedAddress?: string): Promise<EditorsForSpace> {
-  const config = Params.getConfigFromParams({}, undefined);
+  let config = Params.getConfigFromParams({}, undefined);
   let space = await Subgraph.fetchSpace({ endpoint: config.subgraph, id: spaceId });
   let usePermissionlessSpace = false;
 
@@ -20,7 +20,10 @@ export async function getEditorsForSpace(spaceId: string, connectedAddress?: str
   }
 
   if (usePermissionlessSpace) {
-    config.subgraph = config.permissionlessSubgraph;
+    config = {
+      ...config,
+      subgraph: config.permissionlessSubgraph,
+    };
   }
 
   if (!space) {

--- a/packages/permissionless-subgraph/src/access-control.ts
+++ b/packages/permissionless-subgraph/src/access-control.ts
@@ -6,6 +6,7 @@ import {
   log,
 } from '@graphprotocol/graph-ts'
 import { Account, Space } from '../generated/schema'
+import { getChecksumAddress } from './get-checksum-address'
 
 class RoleAddedParams {
   account: Address
@@ -21,7 +22,7 @@ const EDITOR_CONTROLLER_ROLE = crypto.keccak256(
 const EDITOR_ROLE = crypto.keccak256(ByteArray.fromUTF8('EDITOR_ROLE'))
 
 export function addRole(params: RoleAddedParams): void {
-  const address = params.account.toHexString()
+  const address = getChecksumAddress(params.account)
   const role = params.role
   const spaceAddress = params.space.toHexString()
 
@@ -58,7 +59,7 @@ export function addRole(params: RoleAddedParams): void {
 }
 
 export function removeRole(params: RoleAddedParams): void {
-  const address = params.account.toHexString()
+  const address = getChecksumAddress(params.account)
   const role = params.role
   const spaceAddress = params.space.toHexString()
 


### PR DESCRIPTION
This PR adds functionality for fetching the navbar metadata from within the navbar itself and fixes some bugs with updating the config based on the current space.
- We now fetch space metadata in the navbar instead of reading from local spaces.
- We also now recreate the config object to create a new reference. Previously downstream dependencies weren't updating with the new config state as the reference to the object was the same.