### PR TITLE
feat: use new profiles

### DIFF
--- a/apps/web/app/dashboard/component.tsx
+++ b/apps/web/app/dashboard/component.tsx
@@ -140,14 +140,14 @@ const MembershipRequest = ({ request }: MembershipRequestProps) => {
   }
 
   return (
-    <ClientOnly>
+    <div>
       <div className="space-y-4 rounded-lg border border-grey-02 p-4">
-        <div className="flex items-center justify-between">
+        <Link href={profile.homeSpaceLink} className="flex items-center justify-between">
           <div className="text-smallTitle">{profile?.name ?? profile.id}</div>
           <div className="relative h-5 w-5 overflow-hidden rounded-full">
             <Avatar value={profile.id} avatarUrl={profile?.avatarUrl} size={20} />
           </div>
-        </div>
+        </Link>
         <div className="flex items-center gap-1.5 text-breadcrumb text-grey-04">
           <span className="relative h-3 w-3 overflow-hidden rounded-sm">
             <img
@@ -170,7 +170,7 @@ const MembershipRequest = ({ request }: MembershipRequestProps) => {
           </div>
         </div>
       </div>
-    </ClientOnly>
+    </div>
   );
 };
 

--- a/apps/web/app/dashboard/component.tsx
+++ b/apps/web/app/dashboard/component.tsx
@@ -124,7 +124,7 @@ const MembershipRequest = ({ request }: MembershipRequestProps) => {
   const handleAccept = async () => {
     if (wallet && request.space && profile.id) {
       const roleToChange = await Publish.getRole(request.space, 'EDITOR_ROLE');
-      await Publish.grantRole({ spaceId: request.space, role: roleToChange, wallet, userAddress: profile.id });
+      await Publish.grantRole({ spaceId: request.space, role: roleToChange, wallet, userAddress: profile.address });
     }
   };
 

--- a/apps/web/app/dashboard/component.tsx
+++ b/apps/web/app/dashboard/component.tsx
@@ -140,9 +140,9 @@ const MembershipRequest = ({ request }: MembershipRequestProps) => {
   }
 
   return (
-    <div>
+    <ClientOnly>
       <div className="space-y-4 rounded-lg border border-grey-02 p-4">
-        <Link href={profile.homeSpaceLink} className="flex items-center justify-between">
+        <Link href={profile?.profileLink ?? ''} className="flex items-center justify-between">
           <div className="text-smallTitle">{profile?.name ?? profile.id}</div>
           <div className="relative h-5 w-5 overflow-hidden rounded-full">
             <Avatar value={profile.id} avatarUrl={profile?.avatarUrl} size={20} />
@@ -170,7 +170,7 @@ const MembershipRequest = ({ request }: MembershipRequestProps) => {
           </div>
         </div>
       </div>
-    </div>
+    </ClientOnly>
   );
 };
 

--- a/apps/web/app/dashboard/page.tsx
+++ b/apps/web/app/dashboard/page.tsx
@@ -2,10 +2,8 @@ import { cookies } from 'next/headers';
 
 import { Cookie } from '~/core/cookie';
 import { options } from '~/core/environment/environment';
-import {
-  type MembershipRequest,
-  fetchInterimMembershipRequests,
-} from '~/core/io/subgraph/fetch-interim-membership-requests';
+import { fetchInterimMembershipRequests } from '~/core/io/subgraph/fetch-interim-membership-requests';
+import { Space } from '~/core/types';
 
 import { Component } from './component';
 
@@ -18,9 +16,7 @@ export default async function PersonalHomePage() {
     spaces.map(spaceId => fetchInterimMembershipRequests({ endpoint: options.production.membershipSubgraph, spaceId }))
   );
 
-  const membershipRequests: MembershipRequest[] = membershipRequestsBySpace
-    .flat()
-    .sort((a, b) => (a.createdAt > b.createdAt ? -1 : 1));
+  const membershipRequests = membershipRequestsBySpace.flat().sort((a, b) => (a.createdAt > b.createdAt ? -1 : 1));
 
   return <Component membershipRequests={membershipRequests} />;
 }
@@ -51,7 +47,7 @@ const getSpacesWhereAdmin = async (address?: string): Promise<string[]> => {
 
     const { data } = (await response.json()) as any;
 
-    const spaces = data.spaces.map((space: any) => space.id);
+    const spaces = data.spaces.map((space: Space) => space.id);
 
     return spaces;
   } catch (error) {

--- a/apps/web/core/io/fetch-proposals-by-user.ts
+++ b/apps/web/core/io/fetch-proposals-by-user.ts
@@ -138,11 +138,19 @@ export async function fetchProposalsByUser({
       name: p.name,
       description: p.description,
       // If the Wallet -> Profile doesn't mapping doesn't exist we use the Wallet address.
-      createdBy: profile?.[1] ?? p.createdBy,
+      createdBy: profile?.[1] ?? {
+        ...p.createdBy,
+        address: p.createdBy.id as `0x${string}`,
+        profileLink: null,
+      },
       proposedVersions: p.proposedVersions.map(v => {
         return {
           ...v,
-          createdBy: profile?.[1] ?? p.createdBy,
+          createdBy: profile?.[1] ?? {
+            ...p.createdBy,
+            address: p.createdBy.id as `0x${string}`,
+            profileLink: null,
+          },
           actions: fromNetworkActions(v.actions, userId),
         };
       }),

--- a/apps/web/core/io/subgraph/fetch-interim-membership-requests.ts
+++ b/apps/web/core/io/subgraph/fetch-interim-membership-requests.ts
@@ -110,6 +110,7 @@ export async function fetchInterimMembershipRequests({
         avatarUrl: '',
         coverUrl: '',
         name: '',
+        profileLink: '/',
       },
     })
   );

--- a/apps/web/core/io/subgraph/fetch-profile-permissionless.ts
+++ b/apps/web/core/io/subgraph/fetch-profile-permissionless.ts
@@ -37,5 +37,6 @@ export async function fetchProfilePermissionless(options: FetchProfilePermission
     avatarUrl: Entity.avatar(profile.triples),
     coverUrl: Entity.cover(profile.triples),
     homeSpaceLink: NavUtils.toEntity(onchainProfile.homeSpace, onchainProfile.id),
+    address: onchainProfile.account as `0x${string}`,
   };
 }

--- a/apps/web/core/io/subgraph/fetch-profile-permissionless.ts
+++ b/apps/web/core/io/subgraph/fetch-profile-permissionless.ts
@@ -57,8 +57,6 @@ export async function fetchProfilePermissionless(options: FetchProfilePermission
     endpoint: Environment.options.production.profileSubgraph,
   });
 
-  console.log('onchain profile', onchainProfile);
-
   if (!onchainProfile) {
     return null;
   }
@@ -67,8 +65,6 @@ export async function fetchProfilePermissionless(options: FetchProfilePermission
     endpoint: Environment.options.production.permissionlessSubgraph,
     id: onchainProfile.id,
   });
-
-  console.log('profile', profile);
 
   if (!profile) {
     return null;

--- a/apps/web/core/io/subgraph/fetch-profile-permissionless.ts
+++ b/apps/web/core/io/subgraph/fetch-profile-permissionless.ts
@@ -1,49 +1,10 @@
-import * as Effect from 'effect/Effect';
-import * as Either from 'effect/Either';
-import { v4 as uuid } from 'uuid';
-
 import { Environment } from '~/core/environment';
 import { Profile } from '~/core/types';
 import { Entity } from '~/core/utils/entity';
+import { NavUtils } from '~/core/utils/utils';
 
-import { Subgraph } from '..';
 import { fetchEntity } from './fetch-entity';
 import { fetchOnchainProfile } from './fetch-on-chain-profile';
-import { graphql } from './graphql';
-import { NetworkEntity } from './network-local-mapping';
-
-// We fetch for geoEntities -> name because the id of the wallet entity might not be the
-// same as the actual wallet address.
-function getFetchProfileQuery(profileId: string) {
-  return `query {
-    geoEntity(id: "${profileId}") {
-      id
-      name
-      entityOf {
-        id
-        stringValue
-        valueId
-        valueType
-        numberValue
-        space {
-          id
-        }
-        entityValue {
-          id
-          name
-        }
-        attribute {
-          id
-          name
-        }
-        entity {
-          id
-          name
-        }
-      }
-    }
-  }`;
-}
 
 export interface FetchProfilePermissionlessOptions {
   endpoint: string;
@@ -75,5 +36,6 @@ export async function fetchProfilePermissionless(options: FetchProfilePermission
     name: profile.name,
     avatarUrl: Entity.avatar(profile.triples),
     coverUrl: Entity.cover(profile.triples),
+    homeSpaceLink: NavUtils.toEntity(onchainProfile.homeSpace, onchainProfile.id),
   };
 }

--- a/apps/web/core/io/subgraph/fetch-profile-permissionless.ts
+++ b/apps/web/core/io/subgraph/fetch-profile-permissionless.ts
@@ -36,7 +36,7 @@ export async function fetchProfilePermissionless(options: FetchProfilePermission
     name: profile.name,
     avatarUrl: Entity.avatar(profile.triples),
     coverUrl: Entity.cover(profile.triples),
-    homeSpaceLink: NavUtils.toEntity(onchainProfile.homeSpace, onchainProfile.id),
+    profileLink: NavUtils.toEntity(onchainProfile.homeSpace, onchainProfile.id),
     address: onchainProfile.account as `0x${string}`,
   };
 }

--- a/apps/web/core/io/subgraph/fetch-profile-permissionless.ts
+++ b/apps/web/core/io/subgraph/fetch-profile-permissionless.ts
@@ -1,0 +1,83 @@
+import * as Effect from 'effect/Effect';
+import * as Either from 'effect/Either';
+import { v4 as uuid } from 'uuid';
+
+import { Environment } from '~/core/environment';
+import { Profile } from '~/core/types';
+import { Entity } from '~/core/utils/entity';
+
+import { Subgraph } from '..';
+import { fetchEntity } from './fetch-entity';
+import { fetchOnchainProfile } from './fetch-on-chain-profile';
+import { graphql } from './graphql';
+import { NetworkEntity } from './network-local-mapping';
+
+// We fetch for geoEntities -> name because the id of the wallet entity might not be the
+// same as the actual wallet address.
+function getFetchProfileQuery(profileId: string) {
+  return `query {
+    geoEntity(id: "${profileId}") {
+      id
+      name
+      entityOf {
+        id
+        stringValue
+        valueId
+        valueType
+        numberValue
+        space {
+          id
+        }
+        entityValue {
+          id
+          name
+        }
+        attribute {
+          id
+          name
+        }
+        entity {
+          id
+          name
+        }
+      }
+    }
+  }`;
+}
+
+export interface FetchProfilePermissionlessOptions {
+  endpoint: string;
+  address: string;
+  signal?: AbortController['signal'];
+}
+
+export async function fetchProfilePermissionless(options: FetchProfilePermissionlessOptions): Promise<Profile | null> {
+  const onchainProfile = await fetchOnchainProfile({
+    address: options.address,
+    endpoint: Environment.options.production.profileSubgraph,
+  });
+
+  console.log('onchain profile', onchainProfile);
+
+  if (!onchainProfile) {
+    return null;
+  }
+
+  const profile = await fetchEntity({
+    endpoint: Environment.options.production.permissionlessSubgraph,
+    id: onchainProfile.id,
+  });
+
+  console.log('profile', profile);
+
+  if (!profile) {
+    return null;
+  }
+
+  return {
+    id: profile.id,
+    name: profile.name,
+    avatarUrl: Entity.avatar(profile.triples),
+    coverUrl: Entity.cover(profile.triples),
+  };
+}

--- a/apps/web/core/io/subgraph/fetch-profile.ts
+++ b/apps/web/core/io/subgraph/fetch-profile.ts
@@ -166,6 +166,7 @@ export async function fetchProfile(options: FetchProfileOptions): Promise<[strin
       avatarUrl,
       coverUrl,
       homeSpaceLink: NavUtils.toEntity(SYSTEM_IDS.PEOPLE_SPACE, maybePerson.id),
+      address: options.address as `0x${string}`,
     },
   ];
 }

--- a/apps/web/core/io/subgraph/fetch-profile.ts
+++ b/apps/web/core/io/subgraph/fetch-profile.ts
@@ -165,7 +165,7 @@ export async function fetchProfile(options: FetchProfileOptions): Promise<[strin
       name: maybePerson.name,
       avatarUrl,
       coverUrl,
-      homeSpaceLink: NavUtils.toEntity(SYSTEM_IDS.PEOPLE_SPACE, maybePerson.id),
+      profileLink: NavUtils.toEntity(SYSTEM_IDS.PEOPLE_SPACE, maybePerson.id),
       address: options.address as `0x${string}`,
     },
   ];

--- a/apps/web/core/io/subgraph/fetch-profile.ts
+++ b/apps/web/core/io/subgraph/fetch-profile.ts
@@ -4,6 +4,7 @@ import { v4 as uuid } from 'uuid';
 
 import { Environment } from '~/core/environment';
 import { Profile } from '~/core/types';
+import { NavUtils } from '~/core/utils/utils';
 
 import { fetchEntity } from './fetch-entity';
 import { fetchProfilePermissionless } from './fetch-profile-permissionless';
@@ -153,13 +154,18 @@ export async function fetchProfile(options: FetchProfileOptions): Promise<[strin
   const avatarTriple = maybePerson?.triples.find(t => t.attributeId === SYSTEM_IDS.AVATAR_ATTRIBUTE);
   const avatarUrl = avatarTriple?.value.type === 'image' ? avatarTriple.value.value : null;
 
+  if (!maybePerson) {
+    return null;
+  }
+
   return [
     options.address,
     {
-      id: maybePerson?.id ?? '',
-      name: maybePerson?.name ?? null,
+      id: maybePerson.id,
+      name: maybePerson.name,
       avatarUrl,
       coverUrl,
+      homeSpaceLink: NavUtils.toEntity(SYSTEM_IDS.PEOPLE_SPACE, maybePerson.id),
     },
   ];
 }

--- a/apps/web/core/io/subgraph/fetch-proposal.ts
+++ b/apps/web/core/io/subgraph/fetch-proposal.ts
@@ -119,11 +119,25 @@ export async function fetchProposal(options: FetchProposalOptions): Promise<Prop
 
   return {
     ...proposal,
-    createdBy: maybeProfile !== null ? maybeProfile[1] : proposal.createdBy,
+    createdBy:
+      maybeProfile !== null
+        ? maybeProfile[1]
+        : {
+            ...proposal.createdBy,
+            address: proposal.createdBy.id as `0x${string}`,
+            profileLink: null,
+          },
     proposedVersions: proposal.proposedVersions.map(v => {
       return {
         ...v,
-        createdBy: maybeProfile !== null ? maybeProfile[1] : proposal.createdBy,
+        createdBy:
+          maybeProfile !== null
+            ? maybeProfile[1]
+            : {
+                ...proposal.createdBy,
+                address: proposal.createdBy.id as `0x${string}`,
+                profileLink: null,
+              },
         actions: fromNetworkActions(v.actions, proposal.space),
       };
     }),

--- a/apps/web/core/io/subgraph/fetch-proposals.ts
+++ b/apps/web/core/io/subgraph/fetch-proposals.ts
@@ -134,11 +134,19 @@ export async function fetchProposals({
       name: p.name,
       description: p.description,
       // If the Wallet -> Profile doesn't mapping doesn't exist we use the Wallet address.
-      createdBy: profiles[p.createdBy.id] ?? p.createdBy,
+      createdBy: profiles[p.createdBy.id] ?? {
+        ...p.createdBy,
+        address: p.createdBy.id as `0x${string}`,
+        profileLink: null,
+      },
       proposedVersions: p.proposedVersions.map(v => {
         return {
           ...v,
-          createdBy: profiles[v.createdBy.id] ?? v.createdBy,
+          createdBy: profiles[v.createdBy.id] ?? {
+            ...p.createdBy,
+            address: p.createdBy.id as `0x${string}`,
+            profileLink: null,
+          },
           actions: fromNetworkActions(v.actions, spaceId),
         };
       }),

--- a/apps/web/core/types.ts
+++ b/apps/web/core/types.ts
@@ -187,6 +187,7 @@ export type Profile = {
   name: string | null;
   avatarUrl: string | null;
   coverUrl: string | null;
+  homeSpaceLink: string;
 };
 
 export type AppEnv = 'development' | 'staging' | 'testnet' | 'production';

--- a/apps/web/core/types.ts
+++ b/apps/web/core/types.ts
@@ -188,6 +188,7 @@ export type Profile = {
   avatarUrl: string | null;
   coverUrl: string | null;
   homeSpaceLink: string;
+  address: `0x${string}`;
 };
 
 export type AppEnv = 'development' | 'staging' | 'testnet' | 'production';

--- a/apps/web/core/types.ts
+++ b/apps/web/core/types.ts
@@ -187,7 +187,7 @@ export type Profile = {
   name: string | null;
   avatarUrl: string | null;
   coverUrl: string | null;
-  homeSpaceLink: string;
+  profileLink: string | null;
   address: `0x${string}`;
 };
 

--- a/apps/web/partials/governance/governance-proposals-list.tsx
+++ b/apps/web/partials/governance/governance-proposals-list.tsx
@@ -1,10 +1,10 @@
 import { cookies } from 'next/headers';
+import Link from 'next/link';
 import pluralize from 'pluralize';
 
 import { Cookie } from '~/core/cookie';
 import { options } from '~/core/environment/environment';
 import { Subgraph } from '~/core/io';
-import { fetchInterimMembershipRequests } from '~/core/io/subgraph/fetch-interim-membership-requests';
 import { Action as IAction } from '~/core/types';
 import { Action } from '~/core/utils/action';
 
@@ -36,7 +36,6 @@ export async function GovernanceProposalsList({ spaceId }: Props) {
   const [proposals, editorsForSpace] = await Promise.all([
     Subgraph.fetchProposals({ spaceId, first: 5, endpoint: options.production.subgraph }),
     getEditorsForSpace(spaceId, connectedAddress),
-    fetchInterimMembershipRequests({ endpoint: options.production.membershipSubgraph, spaceId }),
   ]);
 
   return (
@@ -52,12 +51,15 @@ export async function GovernanceProposalsList({ spaceId }: Props) {
               <div className="flex flex-col gap-2">
                 <h3 className="text-smallTitle">{p.name}</h3>
                 <div className="flex items-center gap-5 text-breadcrumb text-grey-04">
-                  <div className="flex items-center gap-1.5">
+                  <Link
+                    href={p.createdBy?.profileLink ?? ''}
+                    className="flex items-center gap-1.5 transition-colors duration-75 hover:text-text"
+                  >
                     <div className="relative h-3 w-3 overflow-hidden rounded-full">
                       <Avatar avatarUrl={p.createdBy.avatarUrl} value={p.createdBy.id} />
                     </div>
                     <p>{p.createdBy.name ?? p.createdBy.id}</p>
-                  </div>
+                  </Link>
                   <div className="flex items-center gap-1.5">
                     <p>
                       {changeCount} {pluralize('edit', changeCount)}

--- a/apps/web/partials/onboarding/dialog.tsx
+++ b/apps/web/partials/onboarding/dialog.tsx
@@ -338,7 +338,7 @@ function StepComplete({ workflowStep: stage, spaceAddress }: StepCompleteProps) 
         <div className="flex justify-center gap-2 whitespace-nowrap">
           <Link href={NavUtils.toDashboard()}>
             <Button className="!flex-1 !flex-shrink-0" disabled={stage !== 'done'}>
-              View Feed
+              View Personal Home
             </Button>
           </Link>
           <Link href={spaceAddress === null ? '/' : NavUtils.toSpace(spaceAddress)}>

--- a/apps/web/partials/space-page/get-editors-for-space.ts
+++ b/apps/web/partials/space-page/get-editors-for-space.ts
@@ -43,7 +43,7 @@ export async function getEditorsForSpace(spaceId: string, connectedAddress?: str
     avatarUrl: profile[1].avatarUrl,
     name: profile[1].name,
     address: profile[1].address,
-    homeSpaceLink: profile[1].homeSpaceLink,
+    profileLink: profile[1].profileLink,
   }));
 
   const firstThreeEditors = allEditors.slice(0, 3);

--- a/apps/web/partials/space-page/get-editors-for-space.ts
+++ b/apps/web/partials/space-page/get-editors-for-space.ts
@@ -42,6 +42,8 @@ export async function getEditorsForSpace(spaceId: string, connectedAddress?: str
     id: profile[1].id,
     avatarUrl: profile[1].avatarUrl,
     name: profile[1].name,
+    address: profile[1].address,
+    homeSpaceLink: profile[1].homeSpaceLink,
   }));
 
   const firstThreeEditors = allEditors.slice(0, 3);

--- a/apps/web/partials/space-page/space-member-row.tsx
+++ b/apps/web/partials/space-page/space-member-row.tsx
@@ -1,3 +1,5 @@
+import Link from 'next/link';
+
 import { OmitStrict, Profile } from '~/core/types';
 
 import { Avatar } from '~/design-system/avatar';
@@ -8,11 +10,14 @@ interface EditorRowProps {
 
 export function MemberRow({ editor }: EditorRowProps) {
   return (
-    <div className="flex items-center gap-2 p-2">
+    <Link
+      href={editor.profileLink ?? ''}
+      className="flex items-center gap-2 p-2 transition-colors duration-150 hover:bg-divider"
+    >
       <div className="relative h-8 w-8 overflow-hidden rounded-full">
         <Avatar size={32} avatarUrl={editor.avatarUrl} value={editor.name ?? ''} />
       </div>
       <p className="text-metadataMedium">{editor.name}</p>
-    </div>
+    </Link>
   );
 }

--- a/packages/ids/system-ids.ts
+++ b/packages/ids/system-ids.ts
@@ -91,6 +91,8 @@ export const FILTER = 'b0f2d71a-79ca-4dc4-9218-e3e40dfed103'
 
 export const WALLETS_ATTRIBUTE = '31f6922e-0d4e-4f14-a1ee-8c7689457715'
 
+export const PEOPLE_SPACE = '0xb4476A42A66eC1356A58D300555169E17db6756c'
+
 /**
  * Addresses for important contracts on Polygon mainnet.
  *

--- a/packages/profile-subgraph/src/mapping.ts
+++ b/packages/profile-subgraph/src/mapping.ts
@@ -7,7 +7,7 @@ import { GeoProfile } from '../generated/schema'
 import { getChecksumAddress } from './get-checksum-address'
 
 function getProfileId(account: string, onChainId: string): string {
-  return account + '-' + onChainId
+  return account + '–' + onChainId
 }
 
 export function handleGeoProfileRegistered(event: GeoProfileRegistered): void {

--- a/packages/profile-subgraph/subgraph.yaml
+++ b/packages/profile-subgraph/subgraph.yaml
@@ -9,11 +9,11 @@ schema:
 dataSources:
   - kind: ethereum/contract
     name: GeoProfileRegistry
-    network: matic
+    network: mumbai
     source:
       abi: GeoProfileRegistry
-      address: "0xc066E89bF7669b905f869Cb936818b0fd0bc456d"
-      startBlock: 48833716
+      address: "0x62b5b813B74C4166DA4f3f88Af6E8E4e657a9458"
+      startBlock: 41134741
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.6


### PR DESCRIPTION
This PR adds functionality to replace the existing profile mechanism with permissionlessly created profiles. If a permissionless profile for a wallet account doesn't exist it will fall back to the People space profile.