### PR TITLE
feat: remove reading images from root spaces

### DIFF
--- a/apps/web/app/space/[id]/space-layout.tsx
+++ b/apps/web/app/space/[id]/space-layout.tsx
@@ -43,8 +43,8 @@ export async function SpaceLayout({ params, children, usePermissionlessSpace }: 
 
   const props = await getData(params.id, config);
 
-  const avatarUrl = Entity.avatar(props.triples) ?? props.serverAvatarUrl;
-  const coverUrl = Entity.cover(props.triples) ?? props.serverCoverUrl;
+  const avatarUrl = Entity.avatar(props.triples);
+  const coverUrl = Entity.cover(props.triples);
 
   return (
     <TypesStoreServerContainer spaceId={params.id}>
@@ -136,8 +136,6 @@ const getData = async (spaceId: string, config: AppConfig) => {
   }
 
   const spaceName = space?.attributes[SYSTEM_IDS.NAME] ?? null;
-  const serverAvatarUrl = space?.attributes[SYSTEM_IDS.IMAGE_ATTRIBUTE] ?? null;
-  const serverCoverUrl = Entity.cover(entity?.triples);
 
   const blockIdsTriple = entity?.triples.find(t => t.attributeId === SYSTEM_IDS.BLOCKS) || null;
   const blockIds: string[] = blockIdsTriple ? JSON.parse(Value.stringValue(blockIdsTriple) || '[]') : [];
@@ -162,8 +160,6 @@ const getData = async (spaceId: string, config: AppConfig) => {
     name: entity?.name ?? spaceName ?? '',
     description: Entity.description(entity?.triples ?? []),
     spaceId,
-    serverAvatarUrl,
-    serverCoverUrl,
 
     // For entity page editor
     blockIdsTriple,

--- a/apps/web/app/space/[id]/space-layout.tsx
+++ b/apps/web/app/space/[id]/space-layout.tsx
@@ -43,7 +43,6 @@ export async function SpaceLayout({ params, children, usePermissionlessSpace }: 
 
   const props = await getData(params.id, config);
 
-  const avatarUrl = Entity.avatar(props.triples);
   const coverUrl = Entity.cover(props.triples);
 
   return (
@@ -56,7 +55,7 @@ export async function SpaceLayout({ params, children, usePermissionlessSpace }: 
         initialBlockIdsTriple={props.blockIdsTriple}
         initialBlockTriples={props.blockTriples}
       >
-        <EntityPageCover avatarUrl={avatarUrl} coverUrl={coverUrl} />
+        <EntityPageCover avatarUrl={null} coverUrl={coverUrl} />
 
         <EntityPageContentContainer>
           <EditableHeading


### PR DESCRIPTION
This PR removes reading from space entities in the root space and instead now reads from the space configuration entity in the space itself for everything except the `useSpaces` hook.