### PR TITLE
fix: generate metadata at the entity layout

### DIFF
--- a/apps/web/app/space/[id]/[entityId]/default-entity-page.tsx
+++ b/apps/web/app/space/[id]/[entityId]/default-entity-page.tsx
@@ -3,8 +3,6 @@ import { redirect } from 'next/navigation';
 
 import { Suspense } from 'react';
 
-import type { Metadata } from 'next';
-
 import { AppConfig, Environment } from '~/core/environment';
 import { API, Subgraph } from '~/core/io';
 import { EntityStoreProvider } from '~/core/state/entity-page-store/entity-store-provider';
@@ -12,7 +10,6 @@ import { MoveEntityProvider } from '~/core/state/move-entity-store';
 import { DEFAULT_PAGE_SIZE } from '~/core/state/triple-store/triple-store';
 import { TypesStoreServerContainer } from '~/core/state/types-store/types-store-server-container';
 import { Entity } from '~/core/utils/entity';
-import { NavUtils, getOpenGraphMetadataForEntity } from '~/core/utils/utils';
 import { Value } from '~/core/utils/value';
 
 import { Spacer } from '~/design-system/spacer';

--- a/apps/web/app/space/[id]/[entityId]/default-entity-page.tsx
+++ b/apps/web/app/space/[id]/[entityId]/default-entity-page.tsx
@@ -38,39 +38,6 @@ interface Props {
   };
 }
 
-export async function generateMetadata({ params }: Props): Promise<Metadata> {
-  const spaceId = params.id;
-  const entityId = params.entityId;
-  const config = Environment.getConfig(process.env.NEXT_PUBLIC_APP_ENV);
-
-  const entity = await Subgraph.fetchEntity({ endpoint: config.subgraph, id: entityId });
-  const { entityName, description, openGraphImageUrl } = getOpenGraphMetadataForEntity(entity);
-
-  return {
-    title: entityName ?? 'New entity',
-    description,
-    openGraph: {
-      title: entityName ?? 'New entity',
-      description,
-      url: `https://geobrowser.io${NavUtils.toEntity(spaceId, entityId)}`,
-      images: [
-        {
-          url: openGraphImageUrl,
-        },
-      ],
-    },
-    twitter: {
-      card: 'summary_large_image',
-      description,
-      images: [
-        {
-          url: openGraphImageUrl,
-        },
-      ],
-    },
-  };
-}
-
 export default async function DefaultEntityPage({ params, searchParams }: Props) {
   const config = Environment.getConfig(process.env.NEXT_PUBLIC_APP_ENV);
 

--- a/apps/web/app/space/[id]/[entityId]/layout.tsx
+++ b/apps/web/app/space/[id]/[entityId]/layout.tsx
@@ -34,8 +34,18 @@ export const runtime = 'edge';
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const spaceId = params.id;
-  const entityId = params.entityId;
-  const config = Environment.getConfig(process.env.NEXT_PUBLIC_APP_ENV);
+  const entityId = decodeURIComponent(params.entityId);
+
+  let config = Environment.getConfig(process.env.NEXT_PUBLIC_APP_ENV);
+
+  const { isPermissionlessSpace } = await API.space(params.id);
+
+  if (isPermissionlessSpace) {
+    config = {
+      ...config,
+      subgraph: config.permissionlessSubgraph,
+    };
+  }
 
   const entity = await Subgraph.fetchEntity({ endpoint: config.subgraph, id: entityId });
   const { entityName, description, openGraphImageUrl } = getOpenGraphMetadataForEntity(entity);


### PR DESCRIPTION
Previously this was working, but as part of the `stream/social` work the metadata generation got moved to a separate file. Moving it back to the entity page layout fixes this.