### PR TITLE
fix: no caching and additional server requests in For You

### DIFF
--- a/apps/web/app/home/component.tsx
+++ b/apps/web/app/home/component.tsx
@@ -2,6 +2,8 @@
 
 import Link from 'next/link';
 
+import * as React from 'react';
+
 import { useAccount, useWalletClient } from 'wagmi';
 
 import { useGeoProfile } from '~/core/hooks/use-geo-profile';
@@ -27,40 +29,19 @@ const TABS = ['For You', 'Unpublished', 'Published', 'Following', 'Activity'] as
 type Props = {
   activeProposals: any[];
   membershipRequests: MembershipRequestWithProfile[];
+  header: React.ReactNode;
 };
 
-export const Component = ({ activeProposals, membershipRequests }: Props) => {
+export const Component = ({ activeProposals, membershipRequests, header }: Props) => {
   return (
     <>
       <div className="mx-auto max-w-[784px]">
-        <PersonalHomeHeader />
+        {header}
         <PersonalHomeNavigation />
         <PersonalHomeDashboard activeProposals={activeProposals} membershipRequests={membershipRequests} />
       </div>
       <ActiveProposal />
     </>
-  );
-};
-
-const PersonalHomeHeader = () => {
-  const { address } = useAccount();
-  const { person } = usePerson(address);
-  const { profile: onchainProfile } = useGeoProfile(address);
-
-  return (
-    <div className="flex w-full items-center justify-between">
-      <div className="flex items-center gap-4">
-        <div className="relative h-14 w-14 overflow-hidden rounded-lg bg-grey-01">
-          <Avatar value={address} avatarUrl={person?.avatarUrl} size={56} square={true} />
-        </div>
-        <h2 className="text-largeTitle">{person?.name ?? 'Anonymous'}</h2>
-      </div>
-      {onchainProfile?.homeSpace && (
-        <Link prefetch={false} href={NavUtils.toSpace(onchainProfile.homeSpace)}>
-          <SmallButton className="!bg-transparent !text-text">View personal space</SmallButton>
-        </Link>
-      )}
-    </div>
   );
 };
 

--- a/apps/web/app/home/page.tsx
+++ b/apps/web/app/home/page.tsx
@@ -1,9 +1,15 @@
 import { cookies } from 'next/headers';
+import Link from 'next/link';
 
 import { Cookie } from '~/core/cookie';
 import { Environment } from '~/core/environment';
+import { fetchOnchainProfile, fetchProfile } from '~/core/io/subgraph';
 import { fetchInterimMembershipRequests } from '~/core/io/subgraph/fetch-interim-membership-requests';
-import { Space } from '~/core/types';
+import { OnchainProfile, Profile, Space } from '~/core/types';
+import { NavUtils } from '~/core/utils/utils';
+
+import { Avatar } from '~/design-system/avatar';
+import { SmallButton } from '~/design-system/button';
 
 import { Component } from './component';
 
@@ -13,7 +19,11 @@ export default async function PersonalHomePage() {
   const connectedAddress = cookies().get(Cookie.WALLET_ADDRESS)?.value;
   const config = Environment.getConfig(process.env.NEXT_PUBLIC_APP_ENV);
 
-  const spaces = await getSpacesWhereAdmin(connectedAddress);
+  const [spaces, person, profile] = await Promise.all([
+    getSpacesWhereAdmin(connectedAddress),
+    connectedAddress ? fetchProfile({ address: connectedAddress, endpoint: config.subgraph }) : null,
+    connectedAddress ? fetchOnchainProfile({ address: connectedAddress }) : null,
+  ]);
 
   const membershipRequestsBySpace = await Promise.all(
     spaces.map(spaceId => fetchInterimMembershipRequests({ endpoint: config.membershipSubgraph, spaceId }))
@@ -21,11 +31,47 @@ export default async function PersonalHomePage() {
 
   const membershipRequests = membershipRequestsBySpace.flat().sort((a, b) => (a.createdAt > b.createdAt ? -1 : 1));
 
-  return <Component activeProposals={[]} membershipRequests={membershipRequests} />;
+  return (
+    <Component
+      header={
+        <PersonalHomeHeader
+          person={person ? person[1] : null}
+          address={connectedAddress ?? null}
+          onchainProfile={profile}
+        />
+      }
+      activeProposals={[]}
+      membershipRequests={membershipRequests}
+    />
+  );
 }
 
 export const metadata = {
   title: `For you`,
+};
+
+interface HeaderProps {
+  person: Profile | null;
+  onchainProfile: OnchainProfile | null;
+  address: string | null;
+}
+
+const PersonalHomeHeader = ({ onchainProfile, person, address }: HeaderProps) => {
+  return (
+    <div className="flex w-full items-center justify-between">
+      <div className="flex items-center gap-4">
+        <div className="relative h-14 w-14 overflow-hidden rounded-lg bg-grey-01">
+          <Avatar value={address ?? undefined} avatarUrl={person?.avatarUrl} size={56} square={true} />
+        </div>
+        <h2 className="text-largeTitle">{person?.name ?? 'Anonymous'}</h2>
+      </div>
+      {onchainProfile?.homeSpace && (
+        <Link prefetch={false} href={NavUtils.toSpace(onchainProfile.homeSpace)}>
+          <SmallButton className="!bg-transparent !text-text">View personal space</SmallButton>
+        </Link>
+      )}
+    </div>
+  );
 };
 
 const getSpacesWhereAdmin = async (address?: string): Promise<string[]> => {

--- a/apps/web/app/home/page.tsx
+++ b/apps/web/app/home/page.tsx
@@ -7,6 +7,8 @@ import { Space } from '~/core/types';
 
 import { Component } from './component';
 
+export const dynamic = 'force-dynamic';
+
 export default async function PersonalHomePage() {
   const connectedAddress = cookies().get(Cookie.WALLET_ADDRESS)?.value;
   const config = Environment.getConfig(process.env.NEXT_PUBLIC_APP_ENV);

--- a/apps/web/core/hooks/use-geo-profile.ts
+++ b/apps/web/core/hooks/use-geo-profile.ts
@@ -1,6 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
 
-import { Environment } from '../environment';
 import { Services } from '../services';
 import { OnchainProfile } from '../types';
 
@@ -22,7 +21,6 @@ export function useGeoProfile(account?: `0x${string}`): {
 
       return await subgraph.fetchOnchainProfile({
         address: account,
-        endpoint: Environment.getConfig(process.env.NEXT_PUBLIC_APP_ENV).profileSubgraph,
       });
     },
     // Only fetch the profile when the page is loaded. If a user has gone through onboarding,

--- a/apps/web/core/hooks/use-geo-profile.ts
+++ b/apps/web/core/hooks/use-geo-profile.ts
@@ -2,8 +2,13 @@ import { useQuery } from '@tanstack/react-query';
 
 import { Environment } from '../environment';
 import { Services } from '../services';
+import { OnchainProfile } from '../types';
 
-export function useGeoProfile(account?: `0x${string}`) {
+export function useGeoProfile(account?: `0x${string}`): {
+  profile: OnchainProfile | null;
+  isLoading: boolean;
+  isFetched: boolean;
+} {
   const { subgraph } = Services.useServices();
 
   const {

--- a/apps/web/core/io/subgraph/fetch-on-chain-profile.ts
+++ b/apps/web/core/io/subgraph/fetch-on-chain-profile.ts
@@ -2,10 +2,11 @@ import * as Effect from 'effect/Effect';
 import * as Either from 'effect/Either';
 import { v4 as uuid } from 'uuid';
 
+import { Environment } from '~/core/environment';
+
 import { graphql } from './graphql';
 
 export interface FetchOnchainProfileOptions {
-  endpoint: string;
   address: string;
   signal?: AbortController['signal'];
 }
@@ -37,9 +38,10 @@ function getFetchProfileQuery(address: string) {
 
 export async function fetchOnchainProfile(options: FetchOnchainProfileOptions): Promise<OnchainGeoProfile | null> {
   const queryId = uuid();
+  const config = Environment.getConfig(process.env.NEXT_PUBLIC_APP_ENV);
 
   const fetchWalletsGraphqlEffect = graphql<NetworkResult>({
-    endpoint: options.endpoint,
+    endpoint: config.profileSubgraph,
     query: getFetchProfileQuery(options.address),
     signal: options?.signal,
   });
@@ -59,7 +61,7 @@ export async function fetchOnchainProfile(options: FetchOnchainProfileOptions): 
         case 'GraphqlRuntimeError':
           console.error(
             `Encountered runtime graphql error in fetchProfile. queryId: ${queryId} endpoint: ${
-              options.endpoint
+              config.profileSubgraph
             } address: ${options.address}
             
             queryString: ${getFetchProfileQuery(options.address)}
@@ -72,7 +74,7 @@ export async function fetchOnchainProfile(options: FetchOnchainProfileOptions): 
           };
         default:
           console.error(
-            `${error._tag}: Unable to fetch wallets to derive profile, queryId: ${queryId} endpoint: ${options.endpoint} address: ${options.address}`
+            `${error._tag}: Unable to fetch wallets to derive profile, queryId: ${queryId} endpoint: ${config.profileSubgraph} address: ${options.address}`
           );
 
           return {

--- a/apps/web/core/io/subgraph/fetch-profile-permissionless.ts
+++ b/apps/web/core/io/subgraph/fetch-profile-permissionless.ts
@@ -15,7 +15,6 @@ export async function fetchProfilePermissionless(options: FetchProfilePermission
 
   const onchainProfile = await fetchOnchainProfile({
     address: options.address,
-    endpoint: config.profileSubgraph,
   });
 
   if (!onchainProfile) {

--- a/apps/web/core/types.ts
+++ b/apps/web/core/types.ts
@@ -191,6 +191,12 @@ export type Profile = {
   address: `0x${string}`;
 };
 
+export type OnchainProfile = {
+  id: string;
+  homeSpace: string;
+  account: string;
+};
+
 export type AppEnv = 'development' | 'testnet' | 'production';
 
 export type RelationValueType = {


### PR DESCRIPTION
This PR removes stale revalidation from the For You page. This is to ensure that users always get up-to-date data. We also now do fetching of user-specific account information on the server instead of the client.