### PR TITLE
feat(experimental): edge render all routes

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -80,6 +80,8 @@ export const metadata: Metadata = {
   robots: 'follow, index',
 };
 
+export const runtime = 'edge';
+
 export default function RootLayout({
   // Layouts must accept a children prop.
   // This will be populated with nested layouts or pages

--- a/apps/web/app/not-found.tsx
+++ b/apps/web/app/not-found.tsx
@@ -6,6 +6,8 @@ import { Button } from '~/design-system/button';
 import { Spacer } from '~/design-system/spacer';
 import { Text } from '~/design-system/text';
 
+export const runtime = 'edge';
+
 export default function Custom404() {
   return (
     <div className="relative flex min-h-[75vh] flex-col items-center justify-center">

--- a/apps/web/app/space/(entities)/[id]/entities/page.tsx
+++ b/apps/web/app/space/(entities)/[id]/entities/page.tsx
@@ -15,6 +15,8 @@ import { EntityTable } from '~/core/utils/entity-table';
 
 import { Component } from './component';
 
+export const runtime = 'edge';
+
 interface Props {
   params: { id: string };
   searchParams: {

--- a/apps/web/app/space/(entity)/[id]/[entityId]/activity/layout.tsx
+++ b/apps/web/app/space/(entity)/[id]/[entityId]/activity/layout.tsx
@@ -5,6 +5,8 @@ import { ChevronDownSmall } from '~/design-system/icons/chevron-down-small';
 
 import { ActivitySpaceFilter } from '~/partials/profile/activity-space-filter';
 
+export const runtime = 'edge';
+
 interface Props {
   params: { id: string; entityId: string };
   children: React.ReactNode;

--- a/apps/web/app/space/(entity)/[id]/[entityId]/page.tsx
+++ b/apps/web/app/space/(entity)/[id]/[entityId]/page.tsx
@@ -7,6 +7,8 @@ import { fetchEntityType } from '~/core/io/fetch-entity-type';
 import DefaultEntityPage from './default-entity-page';
 import { ProfileEntityServerContainer } from './profile-entity-server-container';
 
+export const runtime = 'edge';
+
 interface Props {
   params: { id: string; entityId: string };
   searchParams: {

--- a/apps/web/app/space/(triples)/[id]/triples/page.tsx
+++ b/apps/web/app/space/(triples)/[id]/triples/page.tsx
@@ -9,6 +9,8 @@ import { DEFAULT_PAGE_SIZE } from '~/core/state/triple-store/triple-store';
 
 import { Component } from './component';
 
+export const runtime = 'edge';
+
 interface Props {
   params: { id: string };
   searchParams: {

--- a/apps/web/app/space/[id]/access-control/page.tsx
+++ b/apps/web/app/space/[id]/access-control/page.tsx
@@ -13,6 +13,8 @@ import { Publish } from '~/core/io';
 
 type RoleType = 'EDITOR_ROLE' | 'ADMIN_ROLE' | 'EDITOR_CONTROLLER_ROLE';
 
+export const runtime = 'edge';
+
 export default function AccessControl() {
   const store = useSpaces();
   const params = useParams();

--- a/apps/web/app/space/[id]/governance/page.tsx
+++ b/apps/web/app/space/[id]/governance/page.tsx
@@ -12,6 +12,8 @@ import { ChevronDownSmall } from '~/design-system/icons/chevron-down-small';
 
 import { GovernanceProposalsList } from '~/partials/governance/governance-proposals-list';
 
+export const runtime = 'edge';
+
 interface Props {
   params: { id: string };
 }

--- a/apps/web/app/space/[id]/layout.tsx
+++ b/apps/web/app/space/[id]/layout.tsx
@@ -25,6 +25,8 @@ import { SpacePageMetadataHeader } from '~/partials/space-page/space-metadata-he
 
 import { SpaceConfigProvider } from './space-config-provider';
 
+export const runtime = 'edge';
+
 interface Props {
   params: { id: string; entityId?: string };
   children: React.ReactNode;

--- a/apps/web/app/space/[id]/page.tsx
+++ b/apps/web/app/space/[id]/page.tsx
@@ -17,6 +17,8 @@ import {
 } from '~/partials/entity-page/entity-page-referenced-by-server-container';
 import { ToggleEntityPage } from '~/partials/entity-page/toggle-entity-page';
 
+export const runtime = 'edge';
+
 interface Props {
   params: { id: string };
 }

--- a/apps/web/app/spaces/page.tsx
+++ b/apps/web/app/spaces/page.tsx
@@ -44,6 +44,8 @@ export const metadata: Metadata = {
   robots: 'follow, index',
 };
 
+export const runtime = 'edge';
+
 const sortByCreatedAtBlock = (a: Space, b: Space) =>
   parseInt(a.createdAtBlock, 10) < parseInt(b.createdAtBlock, 10) ? -1 : 1;
 


### PR DESCRIPTION
We need to have a good balance between a good first render time, loading and streaming data, and loading frontend assets (we have large bundles). Rendering at the edge gets us a fast render time as long as the data we're loading before streaming is fast, as we will be further from our data sources (until we get on the decentralized network).

Partial pre-rendering in Next 14 might get us the rest of the way there, with fast content pre-rendered and delivered from a CDN. Then rendering and streaming can happen in regional edge functions that are closer to our data sources.