### PR TITLE
feat: don't set default opengraph description or image

### DIFF
--- a/apps/web/app/space/(entity)/[id]/[entityId]/layout.tsx
+++ b/apps/web/app/space/(entity)/[id]/[entityId]/layout.tsx
@@ -57,7 +57,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     description,
     openGraph: {
       title: entityName ?? 'New entity',
-      description,
+      description: description ?? undefined,
       url: `https://geobrowser.io${NavUtils.toEntity(spaceId, entityId)}`,
       images: [
         {
@@ -67,7 +67,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     },
     twitter: {
       card: 'summary_large_image',
-      description,
+      description: description ?? undefined,
       images: [
         {
           url: openGraphImageUrl,

--- a/apps/web/app/space/(entity)/[id]/[entityId]/layout.tsx
+++ b/apps/web/app/space/(entity)/[id]/[entityId]/layout.tsx
@@ -59,20 +59,24 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       title: entityName ?? 'New entity',
       description: description ?? undefined,
       url: `https://geobrowser.io${NavUtils.toEntity(spaceId, entityId)}`,
-      images: [
-        {
-          url: openGraphImageUrl,
-        },
-      ],
+      images: openGraphImageUrl
+        ? [
+            {
+              url: openGraphImageUrl,
+            },
+          ]
+        : undefined,
     },
     twitter: {
       card: 'summary_large_image',
       description: description ?? undefined,
-      images: [
-        {
-          url: openGraphImageUrl,
-        },
-      ],
+      images: openGraphImageUrl
+        ? [
+            {
+              url: openGraphImageUrl,
+            },
+          ]
+        : undefined,
     },
   };
 }

--- a/apps/web/app/space/[id]/page.tsx
+++ b/apps/web/app/space/[id]/page.tsx
@@ -52,22 +52,26 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     description,
     openGraph: {
       title: entityName ?? spaceId,
-      description,
+      description: description ?? undefined,
       url: `https://geobrowser.io${NavUtils.toEntity(spaceId, entityId)}`,
-      images: [
-        {
-          url: openGraphImageUrl,
-        },
-      ],
+      images: openGraphImageUrl
+        ? [
+            {
+              url: openGraphImageUrl,
+            },
+          ]
+        : undefined,
     },
     twitter: {
       card: 'summary_large_image',
-      description,
-      images: [
-        {
-          url: openGraphImageUrl,
-        },
-      ],
+      description: description ?? undefined,
+      images: openGraphImageUrl
+        ? [
+            {
+              url: openGraphImageUrl,
+            },
+          ]
+        : undefined,
     },
   };
 }

--- a/apps/web/core/utils/utils.test.ts
+++ b/apps/web/core/utils/utils.test.ts
@@ -106,7 +106,7 @@ describe('getOpenGraphImageUrl', () => {
   });
 
   it('an empty string returns the default OG image', () => {
-    expect(getOpenGraphImageUrl('')).toBe('https://www.geobrowser.io/static/geo-social-image-v2.png');
+    expect(getOpenGraphImageUrl('')).toBe(null);
   });
 });
 

--- a/apps/web/core/utils/utils.ts
+++ b/apps/web/core/utils/utils.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_OPENGRAPH_DESCRIPTION, DEFAULT_OPENGRAPH_IMAGE, IPFS_GATEWAY_PATH } from '~/core/constants';
+import { IPFS_GATEWAY_PATH } from '~/core/constants';
 import { Entity as IEntity } from '~/core/types';
 
 import { Entity } from './entity';
@@ -146,7 +146,7 @@ export const getOpenGraphImageUrl = (value: string) => {
     return `https://www.geobrowser.io/preview/${value}.png`;
   }
 
-  return DEFAULT_OPENGRAPH_IMAGE;
+  return null;
 };
 
 export const getOpenGraphMetadataForEntity = (entity: IEntity | null) => {

--- a/apps/web/core/utils/utils.ts
+++ b/apps/web/core/utils/utils.ts
@@ -155,7 +155,7 @@ export const getOpenGraphMetadataForEntity = (entity: IEntity | null) => {
   const serverCoverUrl = Entity.cover(entity?.triples);
   const imageUrl = serverAvatarUrl || serverCoverUrl || '';
   const openGraphImageUrl = getOpenGraphImageUrl(imageUrl);
-  const description = Entity.description(entity?.triples ?? []) || DEFAULT_OPENGRAPH_DESCRIPTION;
+  const description = Entity.description(entity?.triples ?? []);
 
   return {
     entityName,


### PR DESCRIPTION
If an entity does not have a description or cover image set we no longer fallback to the generic geobrowser metadata.