### PR TITLE
fix: redirect personal profile entities to the personal space

### DIFF
--- a/apps/web/app/space/(entity)/[id]/[entityId]/default-entity-page.tsx
+++ b/apps/web/app/space/(entity)/[id]/[entityId]/default-entity-page.tsx
@@ -9,6 +9,7 @@ import { EditorProvider } from '~/core/state/editor-store';
 import { EntityStoreProvider } from '~/core/state/entity-page-store/entity-store-provider';
 import { MoveEntityProvider } from '~/core/state/move-entity-store';
 import { DEFAULT_PAGE_SIZE } from '~/core/state/triple-store/constants';
+import { Entity as EntityType } from '~/core/types';
 import { Entity } from '~/core/utils/entity';
 import { Value } from '~/core/utils/value';
 
@@ -86,7 +87,22 @@ const getData = async (spaceId: string, entityId: string, config: AppConfig) => 
     };
   }
 
-  const entity = await Subgraph.fetchEntity({ endpoint: config.subgraph, id: entityId });
+  const entityTriples = await Subgraph.fetchTriples({
+    endpoint: config.subgraph,
+    filter: [{ field: 'entity-id', value: entityId }],
+    space: spaceId,
+    query: '',
+    skip: 0,
+    first: 100,
+  });
+
+  const entity: EntityType = {
+    id: entityId,
+    name: Entity.name(entityTriples),
+    description: Entity.description(entityTriples),
+    types: Entity.types(entityTriples),
+    triples: entityTriples,
+  };
 
   // Redirect from space configuration page to space page
   if (entity?.types.some(type => type.id === SYSTEM_IDS.SPACE_CONFIGURATION) && entity?.nameTripleSpace) {

--- a/apps/web/app/space/(entity)/[id]/[entityId]/default-entity-page.tsx
+++ b/apps/web/app/space/(entity)/[id]/[entityId]/default-entity-page.tsx
@@ -9,7 +9,6 @@ import { EditorProvider } from '~/core/state/editor-store';
 import { EntityStoreProvider } from '~/core/state/entity-page-store/entity-store-provider';
 import { MoveEntityProvider } from '~/core/state/move-entity-store';
 import { DEFAULT_PAGE_SIZE } from '~/core/state/triple-store/constants';
-import { Entity as EntityType } from '~/core/types';
 import { Entity } from '~/core/utils/entity';
 import { Value } from '~/core/utils/value';
 
@@ -87,22 +86,7 @@ const getData = async (spaceId: string, entityId: string, config: AppConfig) => 
     };
   }
 
-  const entityTriples = await Subgraph.fetchTriples({
-    endpoint: config.subgraph,
-    filter: [{ field: 'entity-id', value: entityId }],
-    space: spaceId,
-    query: '',
-    skip: 0,
-    first: 100,
-  });
-
-  const entity: EntityType = {
-    id: entityId,
-    name: Entity.name(entityTriples),
-    description: Entity.description(entityTriples),
-    types: Entity.types(entityTriples),
-    triples: entityTriples,
-  };
+  const entity = await Subgraph.fetchEntity({ endpoint: config.subgraph, id: entityId });
 
   // Redirect from space configuration page to space page
   if (entity?.types.some(type => type.id === SYSTEM_IDS.SPACE_CONFIGURATION) && entity?.nameTripleSpace) {

--- a/apps/web/app/space/(entity)/[id]/[entityId]/page.tsx
+++ b/apps/web/app/space/(entity)/[id]/[entityId]/page.tsx
@@ -36,7 +36,6 @@ export default async function EntityTemplateStrategy({ params, searchParams }: P
   params.entityId = decodeURIComponent(params.entityId);
 
   if (types.includes(SYSTEM_IDS.PERSON_TYPE)) {
-    // @ts-expect-error async JSX function
     return <ProfileEntityServerContainer params={params} />;
   }
 

--- a/apps/web/app/space/(entity)/[id]/[entityId]/profile-entity-server-container.tsx
+++ b/apps/web/app/space/(entity)/[id]/[entityId]/profile-entity-server-container.tsx
@@ -27,40 +27,35 @@ export async function ProfileEntityServerContainer({ params }: Props) {
     };
   }
 
-  const personTriples = await Subgraph.fetchTriples({
-    query: '',
-    space: params.id,
-    filter: [{ field: 'entity-id', value: params.entityId }],
-    endpoint: config.subgraph,
-    skip: 0,
-    first: 100,
-  });
+  const person = await Subgraph.fetchEntity({ id: params.entityId, endpoint: config.subgraph });
 
-  if (personTriples.length === 0) {
-    <ProfilePageComponent
-      id={params.entityId}
-      triples={personTriples}
-      spaceId={params.id}
-      referencedByComponent={
-        <React.Suspense fallback={<EntityReferencedByLoading />}>
-          <EntityReferencedByServerContainer entityId={params.entityId} name={null} spaceId={params.id} />
-        </React.Suspense>
-      }
-    />;
+  // @TODO: Real error handling
+  if (!person) {
+    return {
+      id: params.entityId,
+      name: null,
+      avatarUrl: null,
+      coverUrl: null,
+      triples: [],
+      types: [],
+      description: null,
+    };
   }
+
+  const profile = {
+    ...person,
+    avatarUrl: Entity.avatar(person.triples),
+    coverUrl: Entity.cover(person.triples),
+  };
 
   return (
     <ProfilePageComponent
       id={params.entityId}
-      triples={personTriples}
+      triples={profile.triples}
       spaceId={params.id}
       referencedByComponent={
         <React.Suspense fallback={<EntityReferencedByLoading />}>
-          <EntityReferencedByServerContainer
-            entityId={params.entityId}
-            name={Entity.name(personTriples)}
-            spaceId={params.id}
-          />
+          <EntityReferencedByServerContainer entityId={person.id} name={person.name} spaceId={params.id} />
         </React.Suspense>
       }
     />

--- a/apps/web/app/space/(entity)/[id]/[entityId]/profile-entity-server-container.tsx
+++ b/apps/web/app/space/(entity)/[id]/[entityId]/profile-entity-server-container.tsx
@@ -4,7 +4,6 @@ import * as React from 'react';
 
 import { Environment } from '~/core/environment';
 import { API, Subgraph } from '~/core/io';
-import { Entity } from '~/core/utils/entity';
 
 import {
   EntityReferencedByLoading,
@@ -49,12 +48,14 @@ export async function ProfileEntityServerContainer({ params }: Props) {
 
   // @HACK: Entities we are rendering might be in a different space. Right now we aren't fetching
   // the space for the entity we are rendering, so we need to redirect to the correct space.
+  // Once we have cross-space entity data we won't redirect and will instead only show the data
+  // from the current space for the selected entity.
   if (person?.nameTripleSpace) {
     if (params.id !== person?.nameTripleSpace) {
       console.log(
         `Redirecting from incorrect space ${params.id} to correct space ${person?.nameTripleSpace} for entity ${params.entityId}`
       );
-      return redirect(`/space/${person?.nameTripleSpace}/${params.entityId}`);
+      return redirect(`/space/${person?.nameTripleSpace}/${encodeURIComponent(params.entityId)}`);
     }
   }
 

--- a/apps/web/app/space/(entity)/[id]/[entityId]/profile-entity-server-container.tsx
+++ b/apps/web/app/space/(entity)/[id]/[entityId]/profile-entity-server-container.tsx
@@ -27,35 +27,40 @@ export async function ProfileEntityServerContainer({ params }: Props) {
     };
   }
 
-  const person = await Subgraph.fetchEntity({ id: params.entityId, endpoint: config.subgraph });
+  const personTriples = await Subgraph.fetchTriples({
+    query: '',
+    space: params.id,
+    filter: [{ field: 'entity-id', value: params.entityId }],
+    endpoint: config.subgraph,
+    skip: 0,
+    first: 100,
+  });
 
-  // @TODO: Real error handling
-  if (!person) {
-    return {
-      id: params.entityId,
-      name: null,
-      avatarUrl: null,
-      coverUrl: null,
-      triples: [],
-      types: [],
-      description: null,
-    };
+  if (personTriples.length === 0) {
+    <ProfilePageComponent
+      id={params.entityId}
+      triples={personTriples}
+      spaceId={params.id}
+      referencedByComponent={
+        <React.Suspense fallback={<EntityReferencedByLoading />}>
+          <EntityReferencedByServerContainer entityId={params.entityId} name={null} spaceId={params.id} />
+        </React.Suspense>
+      }
+    />;
   }
-
-  const profile = {
-    ...person,
-    avatarUrl: Entity.avatar(person.triples),
-    coverUrl: Entity.cover(person.triples),
-  };
 
   return (
     <ProfilePageComponent
       id={params.entityId}
-      triples={profile.triples}
+      triples={personTriples}
       spaceId={params.id}
       referencedByComponent={
         <React.Suspense fallback={<EntityReferencedByLoading />}>
-          <EntityReferencedByServerContainer entityId={person.id} name={person.name} spaceId={params.id} />
+          <EntityReferencedByServerContainer
+            entityId={params.entityId}
+            name={Entity.name(personTriples)}
+            spaceId={params.id}
+          />
         </React.Suspense>
       }
     />


### PR DESCRIPTION
This should correctly redirect to the personal profile space if you attempt to load a profile in your own space. This is a temporary application-level fix until we decide to move over to per-space entity data loading.