### PR TITLE
feat(substream: read from cache

### DIFF
--- a/packages/substream/index.ts
+++ b/packages/substream/index.ts
@@ -4,7 +4,7 @@ import { Effect, Either, pipe } from 'effect';
 
 import { bootstrapRoot } from './src/bootstrap-root.js';
 import { START_BLOCK } from './src/constants/constants.js';
-import { populateFromCache } from './src/populate-cache.js';
+import { populateFromCache } from './src/populate-from-cache.js';
 import { getStreamEffect } from './src/run-stream.js';
 import { resetPublicTablesToGenesis } from './src/utils/reset-public-tables-to-genesis.js';
 

--- a/packages/substream/src/populate-roles.ts
+++ b/packages/substream/src/populate-roles.ts
@@ -1,6 +1,6 @@
 import * as db from 'zapatos/db';
 
-import { upsertCachedRoles } from './populate-cache';
+import { upsertCachedRoles } from './populate-from-cache';
 import { pool } from './utils/pool';
 import { type RoleChange } from './zod';
 
@@ -8,12 +8,10 @@ export async function handleRoleGranted({
   roleGranted,
   blockNumber,
   timestamp,
-  cursor,
 }: {
   roleGranted: RoleChange;
   blockNumber: number;
   timestamp: number;
-  cursor: string;
 }) {
   try {
     const role = roleGranted.role;
@@ -22,14 +20,6 @@ export async function handleRoleGranted({
     const isModeratorRole = role === 'MODERATOR';
 
     console.log('Handling role granted:', roleGranted);
-
-    upsertCachedRoles({
-      roleChange: roleGranted,
-      blockNumber,
-      cursor,
-      type: 'GRANTED',
-      timestamp,
-    });
 
     if (isAdminRole) {
       await db
@@ -79,17 +69,7 @@ export async function handleRoleGranted({
   }
 }
 
-export async function handleRoleRevoked({
-  roleRevoked,
-  blockNumber,
-  timestamp,
-  cursor,
-}: {
-  roleRevoked: RoleChange;
-  blockNumber: number;
-  timestamp: number;
-  cursor: string;
-}) {
+export async function handleRoleRevoked({ roleRevoked }: { roleRevoked: RoleChange }) {
   try {
     const role = roleRevoked.role;
     const isAdminRole = role === 'ADMIN';
@@ -97,14 +77,6 @@ export async function handleRoleRevoked({
     const isModeratorRole = role === 'MODERATOR';
 
     console.log('Handling role revoked:', roleRevoked);
-
-    upsertCachedRoles({
-      roleChange: roleRevoked,
-      blockNumber,
-      timestamp,
-      cursor,
-      type: 'REVOKED',
-    });
 
     if (isAdminRole) {
       await db

--- a/packages/substream/src/sql/initAll.sh
+++ b/packages/substream/src/sql/initAll.sh
@@ -4,6 +4,7 @@ source .env
 
 echo "Running SQL scripts..."
 psql $DATABASE_URL < src/sql/initPublic.sql
+psql $DATABASE_URL < src/sql/initIndexes.sql
 psql $DATABASE_URL < src/sql/initCache.sql
 psql $DATABASE_URL < src/sql/initFunctions.sql
 echo "SQL scripts executed successfully."

--- a/packages/substream/src/sql/initIndexes.sql
+++ b/packages/substream/src/sql/initIndexes.sql
@@ -1,0 +1,19 @@
+-- 
+-- Create Indexes for Speedy Querying
+-- 
+
+
+
+CREATE INDEX idx_entity_attribute ON public.triples(entity_id, attribute_id);
+
+CREATE INDEX idx_entity_attribute_value_id ON public.triples(entity_id, attribute_id, value_id);
+
+CREATE INDEX idx_entity_value_id ON public.triples(entity_value_id);
+
+CREATE INDEX idx_triple_space ON public.triples(space_id);
+
+CREATE INDEX idx_accounts_space_id ON public.space_admins(account_id, space_id);
+
+CREATE INDEX idx_space_editors ON public.space_editors(account_id, space_id);
+
+CREATE INDEX idx_space_editor_controllers ON public.space_editor_controllers(account_id, space_id);

--- a/packages/substream/src/sql/initPublic.sql
+++ b/packages/substream/src/sql/initPublic.sql
@@ -206,10 +206,3 @@ ALTER TABLE
 
 ALTER TABLE
     public.space_editor_controllers DISABLE TRIGGER ALL;
-
--- 
--- Create Indexes for Speedy Querying
--- 
-CREATE INDEX idx_entity_attribute ON public.triples(entity_id, attribute_id);
-
-CREATE INDEX idx_entity_attribute_value_id ON public.triples(entity_id, attribute_id, value_id);

--- a/packages/substream/src/types.ts
+++ b/packages/substream/src/types.ts
@@ -1,5 +1,9 @@
 import type * as s from 'zapatos/schema';
 
+// The names of the roles don't match 1:1 with the existing model
+// as the substream package uses the below naming convention instead.
+export type Roles = 'MEMBER' | 'MODERATOR' | 'ADMIN';
+
 export enum TripleAction {
   Create = 'createTriple',
   Delete = 'deleteTriple',


### PR DESCRIPTION
This PR adds the capability to read from the postgres cache tables when re-indexing from genesis. This require a cold, full-index from genesis to populate the cache tables the first time. There might be a good way to share cache to other indexers in the future.

In testing on my local machine full indexing takes anywhere from 3-10 hours depending on firehose performance. Using the cache takes ~15 minutes.