### PR TITLE
feat(substream): new entity versioning model

### DIFF
--- a/packages/substream/package.json
+++ b/packages/substream/package.json
@@ -10,7 +10,7 @@
   ],
   "license": "MIT OR Apache-2.0",
   "scripts": {
-    "build": "esbuild index.ts --bundle --outfile=dist/index.js --bundle --platform=node",
+    "build": "tsc --noEmit && esbuild index.ts --bundle --outfile=dist/index.js --bundle --platform=node",
     "prepublishOnly": "npm run build",
     "nuke-public": "tsx ./src/utils/executeSql.ts ./src/sql/nukePublic.sql",
     "zapatos": "pnpm dotenv -e .env -- npx zapatos",

--- a/packages/substream/src/populate-entries.ts
+++ b/packages/substream/src/populate-entries.ts
@@ -68,6 +68,13 @@ export async function populateWithFullEntries({
       cursor,
     });
 
+    // Fetch all existing triples into the new triple_versions join table. A new version of an entity
+    // should include all of the triples that were included in the previous entity, minus any triples
+    // that were deleted as part of a proposal.
+    //
+    // This fetches all of the triples that were included in the previous version of an entity. Later
+    // on we process all triples that were added and removed as part of this proposal and remove
+    // deleted triples from the new version.
     const triplesForVersionsEffect = Effect.gen(function* (awaited) {
       const triplesForVersions = yield* awaited(
         Effect.all(
@@ -107,7 +114,7 @@ export async function populateWithFullEntries({
             });
           }),
           {
-            concurrency: 10,
+            concurrency: 75,
           }
         )
       );

--- a/packages/substream/src/populate-roles.ts
+++ b/packages/substream/src/populate-roles.ts
@@ -19,8 +19,6 @@ export async function handleRoleGranted({
     const isMemberRole = role === 'MEMBER';
     const isModeratorRole = role === 'MODERATOR';
 
-    console.log('Handling role granted:', roleGranted);
-
     if (isAdminRole) {
       await db
         .upsert(
@@ -75,8 +73,6 @@ export async function handleRoleRevoked({ roleRevoked }: { roleRevoked: RoleChan
     const isAdminRole = role === 'ADMIN';
     const isMemberRole = role === 'MEMBER';
     const isModeratorRole = role === 'MODERATOR';
-
-    console.log('Handling role revoked:', roleRevoked);
 
     if (isAdminRole) {
       await db

--- a/packages/substream/src/run-stream.ts
+++ b/packages/substream/src/run-stream.ts
@@ -99,6 +99,11 @@ export function getStreamEffect(startBlockNum?: number) {
           const blockNumber = Number(message.clock?.number.toString());
           const timestamp = Number(message.clock?.timestamp?.seconds.toString());
 
+          // Skipping a massive block for now
+          if (message.clock?.number.toString() === '36472865') {
+            return;
+          }
+
           if (blockNumber % 1000 === 0) {
             console.log(`@ Block ${blockNumber}`);
           }

--- a/packages/substream/src/sql/initPublic.sql
+++ b/packages/substream/src/sql/initPublic.sql
@@ -22,11 +22,13 @@ CREATE TABLE public.geo_entities (
     id text PRIMARY KEY,
     name character varying,
     description character varying,
+    -- latest_version_id text REFERENCES public.versions(id),
     created_by_id text NOT NULL REFERENCES public.accounts(id),
     created_at integer NOT NULL,
     created_at_block integer NOT NULL,
     updated_at integer,
-    updated_at_block integer -- is_attribute boolean DEFAULT false,
+    updated_at_block integer 
+    -- is_attribute boolean DEFAULT false,
     -- attribute_value_type_id text
 );
 
@@ -162,6 +164,12 @@ CREATE TABLE public.actions (
     cursor text NOT NULL
 );
 
+CREATE TABLE public.triple_versions (
+    PRIMARY KEY (triple_id, version_id),
+    triple_id text NOT NULL REFERENCES public.triples(id),
+    version_id text NOT NULL REFERENCES public.versions(id)
+);
+
 -- 
 -- Disable Foreign Key Constraints to allow for bulk loading + unordered inserts
 -- 
@@ -206,3 +214,6 @@ ALTER TABLE
 
 ALTER TABLE
     public.space_editor_controllers DISABLE TRIGGER ALL;
+
+ALTER TABLE
+    public.triple_versions DISABLE TRIGGER ALL;

--- a/packages/substream/src/zapatos/schema.d.ts
+++ b/packages/substream/src/zapatos/schema.d.ts
@@ -2572,6 +2572,89 @@ declare module 'zapatos/schema' {
   }
 
   /**
+   * **triple_versions**
+   * - Table in database
+   */
+  export namespace triple_versions {
+    export type Table = 'triple_versions';
+    export interface Selectable {
+      /**
+      * **triple_versions.triple_id**
+      * - `text` in database
+      * - `NOT NULL`, no default
+      */
+      triple_id: string;
+      /**
+      * **triple_versions.version_id**
+      * - `text` in database
+      * - `NOT NULL`, no default
+      */
+      version_id: string;
+    }
+    export interface JSONSelectable {
+      /**
+      * **triple_versions.triple_id**
+      * - `text` in database
+      * - `NOT NULL`, no default
+      */
+      triple_id: string;
+      /**
+      * **triple_versions.version_id**
+      * - `text` in database
+      * - `NOT NULL`, no default
+      */
+      version_id: string;
+    }
+    export interface Whereable {
+      /**
+      * **triple_versions.triple_id**
+      * - `text` in database
+      * - `NOT NULL`, no default
+      */
+      triple_id?: string | db.Parameter<string> | db.SQLFragment | db.ParentColumn | db.SQLFragment<any, string | db.Parameter<string> | db.SQLFragment | db.ParentColumn>;
+      /**
+      * **triple_versions.version_id**
+      * - `text` in database
+      * - `NOT NULL`, no default
+      */
+      version_id?: string | db.Parameter<string> | db.SQLFragment | db.ParentColumn | db.SQLFragment<any, string | db.Parameter<string> | db.SQLFragment | db.ParentColumn>;
+    }
+    export interface Insertable {
+      /**
+      * **triple_versions.triple_id**
+      * - `text` in database
+      * - `NOT NULL`, no default
+      */
+      triple_id: string | db.Parameter<string> | db.SQLFragment;
+      /**
+      * **triple_versions.version_id**
+      * - `text` in database
+      * - `NOT NULL`, no default
+      */
+      version_id: string | db.Parameter<string> | db.SQLFragment;
+    }
+    export interface Updatable {
+      /**
+      * **triple_versions.triple_id**
+      * - `text` in database
+      * - `NOT NULL`, no default
+      */
+      triple_id?: string | db.Parameter<string> | db.SQLFragment | db.SQLFragment<any, string | db.Parameter<string> | db.SQLFragment>;
+      /**
+      * **triple_versions.version_id**
+      * - `text` in database
+      * - `NOT NULL`, no default
+      */
+      version_id?: string | db.Parameter<string> | db.SQLFragment | db.SQLFragment<any, string | db.Parameter<string> | db.SQLFragment>;
+    }
+    export type UniqueIndex = 'triple_versions_pkey';
+    export type Column = keyof Selectable;
+    export type OnlyCols<T extends readonly Column[]> = Pick<Selectable, T[number]>;
+    export type SQLExpression = Table | db.ColumnNames<Updatable | (keyof Updatable)[]> | db.ColumnValues<Updatable> | Whereable | Column | db.ParentColumn | db.GenericSQLExpression;
+    export type SQL = SQLExpression | SQLExpression[];
+  }
+
+  /**
    * **triples**
    * - Table in database
    */
@@ -3280,20 +3363,20 @@ declare module 'zapatos/schema' {
   /* --- aggregate types --- */
 
   export namespace public {  
-    export type Table = accounts.Table | actions.Table | cursors.Table | geo_entities.Table | geo_entity_types.Table | log_entries.Table | proposals.Table | proposed_versions.Table | space_admins.Table | space_editor_controllers.Table | space_editors.Table | spaces.Table | subspaces.Table | triples.Table | versions.Table;
-    export type Selectable = accounts.Selectable | actions.Selectable | cursors.Selectable | geo_entities.Selectable | geo_entity_types.Selectable | log_entries.Selectable | proposals.Selectable | proposed_versions.Selectable | space_admins.Selectable | space_editor_controllers.Selectable | space_editors.Selectable | spaces.Selectable | subspaces.Selectable | triples.Selectable | versions.Selectable;
-    export type JSONSelectable = accounts.JSONSelectable | actions.JSONSelectable | cursors.JSONSelectable | geo_entities.JSONSelectable | geo_entity_types.JSONSelectable | log_entries.JSONSelectable | proposals.JSONSelectable | proposed_versions.JSONSelectable | space_admins.JSONSelectable | space_editor_controllers.JSONSelectable | space_editors.JSONSelectable | spaces.JSONSelectable | subspaces.JSONSelectable | triples.JSONSelectable | versions.JSONSelectable;
-    export type Whereable = accounts.Whereable | actions.Whereable | cursors.Whereable | geo_entities.Whereable | geo_entity_types.Whereable | log_entries.Whereable | proposals.Whereable | proposed_versions.Whereable | space_admins.Whereable | space_editor_controllers.Whereable | space_editors.Whereable | spaces.Whereable | subspaces.Whereable | triples.Whereable | versions.Whereable;
-    export type Insertable = accounts.Insertable | actions.Insertable | cursors.Insertable | geo_entities.Insertable | geo_entity_types.Insertable | log_entries.Insertable | proposals.Insertable | proposed_versions.Insertable | space_admins.Insertable | space_editor_controllers.Insertable | space_editors.Insertable | spaces.Insertable | subspaces.Insertable | triples.Insertable | versions.Insertable;
-    export type Updatable = accounts.Updatable | actions.Updatable | cursors.Updatable | geo_entities.Updatable | geo_entity_types.Updatable | log_entries.Updatable | proposals.Updatable | proposed_versions.Updatable | space_admins.Updatable | space_editor_controllers.Updatable | space_editors.Updatable | spaces.Updatable | subspaces.Updatable | triples.Updatable | versions.Updatable;
-    export type UniqueIndex = accounts.UniqueIndex | actions.UniqueIndex | cursors.UniqueIndex | geo_entities.UniqueIndex | geo_entity_types.UniqueIndex | log_entries.UniqueIndex | proposals.UniqueIndex | proposed_versions.UniqueIndex | space_admins.UniqueIndex | space_editor_controllers.UniqueIndex | space_editors.UniqueIndex | spaces.UniqueIndex | subspaces.UniqueIndex | triples.UniqueIndex | versions.UniqueIndex;
-    export type Column = accounts.Column | actions.Column | cursors.Column | geo_entities.Column | geo_entity_types.Column | log_entries.Column | proposals.Column | proposed_versions.Column | space_admins.Column | space_editor_controllers.Column | space_editors.Column | spaces.Column | subspaces.Column | triples.Column | versions.Column;
+    export type Table = accounts.Table | actions.Table | cursors.Table | geo_entities.Table | geo_entity_types.Table | log_entries.Table | proposals.Table | proposed_versions.Table | space_admins.Table | space_editor_controllers.Table | space_editors.Table | spaces.Table | subspaces.Table | triple_versions.Table | triples.Table | versions.Table;
+    export type Selectable = accounts.Selectable | actions.Selectable | cursors.Selectable | geo_entities.Selectable | geo_entity_types.Selectable | log_entries.Selectable | proposals.Selectable | proposed_versions.Selectable | space_admins.Selectable | space_editor_controllers.Selectable | space_editors.Selectable | spaces.Selectable | subspaces.Selectable | triple_versions.Selectable | triples.Selectable | versions.Selectable;
+    export type JSONSelectable = accounts.JSONSelectable | actions.JSONSelectable | cursors.JSONSelectable | geo_entities.JSONSelectable | geo_entity_types.JSONSelectable | log_entries.JSONSelectable | proposals.JSONSelectable | proposed_versions.JSONSelectable | space_admins.JSONSelectable | space_editor_controllers.JSONSelectable | space_editors.JSONSelectable | spaces.JSONSelectable | subspaces.JSONSelectable | triple_versions.JSONSelectable | triples.JSONSelectable | versions.JSONSelectable;
+    export type Whereable = accounts.Whereable | actions.Whereable | cursors.Whereable | geo_entities.Whereable | geo_entity_types.Whereable | log_entries.Whereable | proposals.Whereable | proposed_versions.Whereable | space_admins.Whereable | space_editor_controllers.Whereable | space_editors.Whereable | spaces.Whereable | subspaces.Whereable | triple_versions.Whereable | triples.Whereable | versions.Whereable;
+    export type Insertable = accounts.Insertable | actions.Insertable | cursors.Insertable | geo_entities.Insertable | geo_entity_types.Insertable | log_entries.Insertable | proposals.Insertable | proposed_versions.Insertable | space_admins.Insertable | space_editor_controllers.Insertable | space_editors.Insertable | spaces.Insertable | subspaces.Insertable | triple_versions.Insertable | triples.Insertable | versions.Insertable;
+    export type Updatable = accounts.Updatable | actions.Updatable | cursors.Updatable | geo_entities.Updatable | geo_entity_types.Updatable | log_entries.Updatable | proposals.Updatable | proposed_versions.Updatable | space_admins.Updatable | space_editor_controllers.Updatable | space_editors.Updatable | spaces.Updatable | subspaces.Updatable | triple_versions.Updatable | triples.Updatable | versions.Updatable;
+    export type UniqueIndex = accounts.UniqueIndex | actions.UniqueIndex | cursors.UniqueIndex | geo_entities.UniqueIndex | geo_entity_types.UniqueIndex | log_entries.UniqueIndex | proposals.UniqueIndex | proposed_versions.UniqueIndex | space_admins.UniqueIndex | space_editor_controllers.UniqueIndex | space_editors.UniqueIndex | spaces.UniqueIndex | subspaces.UniqueIndex | triple_versions.UniqueIndex | triples.UniqueIndex | versions.UniqueIndex;
+    export type Column = accounts.Column | actions.Column | cursors.Column | geo_entities.Column | geo_entity_types.Column | log_entries.Column | proposals.Column | proposed_versions.Column | space_admins.Column | space_editor_controllers.Column | space_editors.Column | spaces.Column | subspaces.Column | triple_versions.Column | triples.Column | versions.Column;
   
-    export type AllBaseTables = [accounts.Table, actions.Table, cursors.Table, geo_entities.Table, geo_entity_types.Table, log_entries.Table, proposals.Table, proposed_versions.Table, space_admins.Table, space_editor_controllers.Table, space_editors.Table, spaces.Table, subspaces.Table, triples.Table, versions.Table];
+    export type AllBaseTables = [accounts.Table, actions.Table, cursors.Table, geo_entities.Table, geo_entity_types.Table, log_entries.Table, proposals.Table, proposed_versions.Table, space_admins.Table, space_editor_controllers.Table, space_editors.Table, spaces.Table, subspaces.Table, triple_versions.Table, triples.Table, versions.Table];
     export type AllForeignTables = [];
     export type AllViews = [];
     export type AllMaterializedViews = [];
-    export type AllTablesAndViews = [accounts.Table, actions.Table, cursors.Table, geo_entities.Table, geo_entity_types.Table, log_entries.Table, proposals.Table, proposed_versions.Table, space_admins.Table, space_editor_controllers.Table, space_editors.Table, spaces.Table, subspaces.Table, triples.Table, versions.Table];
+    export type AllTablesAndViews = [accounts.Table, actions.Table, cursors.Table, geo_entities.Table, geo_entity_types.Table, log_entries.Table, proposals.Table, proposed_versions.Table, space_admins.Table, space_editor_controllers.Table, space_editors.Table, spaces.Table, subspaces.Table, triple_versions.Table, triples.Table, versions.Table];
   }
 
 
@@ -3828,6 +3911,7 @@ declare module 'zapatos/schema' {
     "space_editors": space_editors.Selectable;
     "spaces": spaces.Selectable;
     "subspaces": subspaces.Selectable;
+    "triple_versions": triple_versions.Selectable;
     "triples": triples.Selectable;
     "versions": versions.Selectable;
     "cache.entries": cache.entries.Selectable;
@@ -3848,6 +3932,7 @@ declare module 'zapatos/schema' {
     "space_editors": space_editors.JSONSelectable;
     "spaces": spaces.JSONSelectable;
     "subspaces": subspaces.JSONSelectable;
+    "triple_versions": triple_versions.JSONSelectable;
     "triples": triples.JSONSelectable;
     "versions": versions.JSONSelectable;
     "cache.entries": cache.entries.JSONSelectable;
@@ -3868,6 +3953,7 @@ declare module 'zapatos/schema' {
     "space_editors": space_editors.Whereable;
     "spaces": spaces.Whereable;
     "subspaces": subspaces.Whereable;
+    "triple_versions": triple_versions.Whereable;
     "triples": triples.Whereable;
     "versions": versions.Whereable;
     "cache.entries": cache.entries.Whereable;
@@ -3888,6 +3974,7 @@ declare module 'zapatos/schema' {
     "space_editors": space_editors.Insertable;
     "spaces": spaces.Insertable;
     "subspaces": subspaces.Insertable;
+    "triple_versions": triple_versions.Insertable;
     "triples": triples.Insertable;
     "versions": versions.Insertable;
     "cache.entries": cache.entries.Insertable;
@@ -3908,6 +3995,7 @@ declare module 'zapatos/schema' {
     "space_editors": space_editors.Updatable;
     "spaces": spaces.Updatable;
     "subspaces": subspaces.Updatable;
+    "triple_versions": triple_versions.Updatable;
     "triples": triples.Updatable;
     "versions": versions.Updatable;
     "cache.entries": cache.entries.Updatable;
@@ -3928,6 +4016,7 @@ declare module 'zapatos/schema' {
     "space_editors": space_editors.UniqueIndex;
     "spaces": spaces.UniqueIndex;
     "subspaces": subspaces.UniqueIndex;
+    "triple_versions": triple_versions.UniqueIndex;
     "triples": triples.UniqueIndex;
     "versions": versions.UniqueIndex;
     "cache.entries": cache.entries.UniqueIndex;
@@ -3948,6 +4037,7 @@ declare module 'zapatos/schema' {
     "space_editors": space_editors.Column;
     "spaces": spaces.Column;
     "subspaces": subspaces.Column;
+    "triple_versions": triple_versions.Column;
     "triples": triples.Column;
     "versions": versions.Column;
     "cache.entries": cache.entries.Column;
@@ -3968,6 +4058,7 @@ declare module 'zapatos/schema' {
     "space_editors": space_editors.SQL;
     "spaces": spaces.SQL;
     "subspaces": subspaces.SQL;
+    "triple_versions": triple_versions.SQL;
     "triples": triples.SQL;
     "versions": versions.SQL;
     "cache.entries": cache.entries.SQL;


### PR DESCRIPTION
This PR refactors the versioning model to store the full state of an entity as part of each Entity's Versions. 

### The previous implementation was compute and storage in-efficient
Previously we stored all Actions that resulted in a specific state in each Version. To calculate the state for an Entity at a specific Version you would query the Version and re-run the Actions to build the state of the Entity. This created a few problems:
- Getting the state of a Version would mean calculating the entire state from genesis for that Entity using all of the Actions ever applied to that Entity. It wasn't ergonomic to rely on clients (or even the server) to compute the state of an Entity dynamically every time we wanted to query a historical representation of an Entity, especially if an Entity changed frequently.
- Storing all of the Actions to re-create each Version was very storage in-efficient, especially as Geo grew. Doubly-so because we were duplicating Actions across Versions.

To avoid this compute step, we relied on time-travel queries in `graph-node` to be able to query the state of an Entity at the time a Version was created. Since we are no longer using `graph-node` we don't have these temporal queries anymore, so we need a new mechanism that was less compute-intensive, ergonomic, and more space-efficient.

### New approach
We now store the state of an Entity as a series of Version(s) over time. Each Version references the set of Triples that represent the Entity at the time that the Version was created. Triples might belong to multiple versions if they aren't changed, so we represent which Triples belong to each Version(s) in a join table pointing to the Triple id and Version id.