### PR TITLE
fix: add relation value type

### DIFF
--- a/apps/web/design-system/autocomplete/entity-text-autocomplete.tsx
+++ b/apps/web/design-system/autocomplete/entity-text-autocomplete.tsx
@@ -10,6 +10,7 @@ import { useRef } from 'react';
 
 import { useActionsStore } from '~/core/hooks/use-actions-store';
 import { useAutocomplete } from '~/core/hooks/use-autocomplete';
+import { useConfiguredAttributeRelationTypes } from '~/core/hooks/use-configured-attribute-relation-types';
 import { useSpaces } from '~/core/hooks/use-spaces';
 import { useToast } from '~/core/hooks/use-toast';
 import { ID } from '~/core/id';
@@ -29,10 +30,19 @@ interface Props {
   itemIds: string[];
   allowedTypes?: { typeId: string; typeName: string | null }[];
   spaceId: string;
+  attributeId?: string;
   className?: string;
 }
 
-export function EntityTextAutocomplete({ placeholder, itemIds, onDone, allowedTypes, spaceId, className = '' }: Props) {
+export function EntityTextAutocomplete({
+  placeholder,
+  itemIds,
+  onDone,
+  allowedTypes,
+  spaceId,
+  attributeId,
+  className = '',
+}: Props) {
   const [, setToast] = useToast();
   const { create } = useActionsStore();
   const { query, onQueryChange, isLoading, isEmpty, results } = useAutocomplete({
@@ -41,6 +51,9 @@ export function EntityTextAutocomplete({ placeholder, itemIds, onDone, allowedTy
   const containerRef = useRef<HTMLDivElement>(null);
   const itemIdsSet = new Set(itemIds);
   const { spaces } = useSpaces();
+
+  const attributeRelationTypes = useConfiguredAttributeRelationTypes({ entityId: attributeId ?? '' });
+  const relationValueTypesForAttribute = attributeId ? attributeRelationTypes[attributeId] ?? [] : [];
 
   const onCreateNewEntity = () => {
     const newEntityId = ID.createEntityId();
@@ -63,6 +76,25 @@ export function EntityTextAutocomplete({ placeholder, itemIds, onDone, allowedTy
 
     if (allowedTypes) {
       allowedTypes.forEach(type => {
+        create(
+          Triple.withId({
+            entityId: newEntityId,
+            attributeId: SYSTEM_IDS.TYPES,
+            entityName: query,
+            attributeName: 'Types',
+            space: spaceId,
+            value: {
+              type: 'entity',
+              id: type.typeId,
+              name: type.typeName,
+            },
+          })
+        );
+      });
+    }
+
+    if (relationValueTypesForAttribute) {
+      relationValueTypesForAttribute.forEach(type => {
         create(
           Triple.withId({
             entityId: newEntityId,

--- a/apps/web/partials/entity-page/editable-entity-page.tsx
+++ b/apps/web/partials/entity-page/editable-entity-page.tsx
@@ -496,6 +496,7 @@ function EntityAttributes({
                 itemIds={entityValueTriples
                   .filter(triple => triple.attributeId === attributeId)
                   .map(triple => triple.value.id)}
+                attributeId={attributeId}
               />
             </div>
           );
@@ -569,6 +570,7 @@ function EntityAttributes({
                 onDone={result => linkAttribute(attributeId, result)}
                 itemIds={attributeIds}
                 allowedTypes={relationTypes}
+                attributeId={attributeId}
               />
             ) : (
               <Text as="p" variant="bodySemibold">

--- a/apps/web/partials/entity-page/editable-entity-table-cell.tsx
+++ b/apps/web/partials/entity-page/editable-entity-table-cell.tsx
@@ -222,6 +222,7 @@ export const EditableEntityTableCell = memo(function EditableEntityTableCell({
               .map(triple => triple.value.id)}
             allowedTypes={typesToFilter}
             spaceId={space}
+            attributeId={attributeId}
           />
         </>
       )}
@@ -233,6 +234,7 @@ export const EditableEntityTableCell = memo(function EditableEntityTableCell({
           onDone={result => createEntityTripleWithValue(attributeId, result)}
           itemIds={entityValueTriples.filter(t => t.attributeId === attributeId).map(t => t.value.id)}
           allowedTypes={typesToFilter}
+          attributeId={attributeId}
         />
       )}
 


### PR DESCRIPTION
This PR extends the create new entity logic of `<EntityAutocompleteDialog>` (added in #596) to apply to the `<EntityTextAutocomplete>` component as well.