### PR TITLE
fix: hidden search results

### DIFF
--- a/apps/web/core/hooks/use-autocomplete.ts
+++ b/apps/web/core/hooks/use-autocomplete.ts
@@ -35,7 +35,7 @@ export function useAutocomplete({ allowedTypes, filter }: AutocompleteOptions = 
               signal,
               filter: filter ?? [],
               typeIds: allowedTypes,
-              first: 10,
+              first: 100,
             }),
           catch: () => new Subgraph.Errors.AbortError(),
         })

--- a/apps/web/core/hooks/use-global-search.ts
+++ b/apps/web/core/hooks/use-global-search.ts
@@ -26,7 +26,7 @@ export function useGlobalSearch() {
             merged.fetchEntities({
               query,
               signal,
-              first: 10,
+              first: 100,
               filter: [],
             }),
           catch: () => new Subgraph.Errors.AbortError(),


### PR DESCRIPTION
Right now we do some client-side filtering of entity search results, particularly for block entities. We ran into an issue where some entities aren't showing up in search because the first X results are block entities.

This PR increases the number of search results for now to workaround this issue. I've made a ticket to implement a more robust fix to do server-side filtering of table blocks instead.