### PR TITLE
feat: handle multi-space entity navigation

### DIFF
--- a/apps/web/app/space/(entity)/[id]/[entityId]/cached-entity-type.ts
+++ b/apps/web/app/space/(entity)/[id]/[entityId]/cached-entity-type.ts
@@ -1,0 +1,7 @@
+import { cache } from 'react';
+
+import { fetchEntityType } from '~/core/io/fetch-entity-type';
+
+export const cachedFetchEntityType = cache(async (entityId: string) => {
+  return fetchEntityType({ id: entityId });
+});

--- a/apps/web/app/space/(entity)/[id]/[entityId]/cached-fetch-entity.ts
+++ b/apps/web/app/space/(entity)/[id]/[entityId]/cached-fetch-entity.ts
@@ -1,0 +1,7 @@
+import { cache } from 'react';
+
+import { fetchEntity } from '~/core/io/subgraph';
+
+export const cachedFetchEntity = cache(async (entityId: string) => {
+  return fetchEntity({ id: entityId });
+});

--- a/apps/web/app/space/(entity)/[id]/[entityId]/default-entity-page.tsx
+++ b/apps/web/app/space/(entity)/[id]/[entityId]/default-entity-page.tsx
@@ -8,6 +8,7 @@ import { EditorProvider } from '~/core/state/editor-store';
 import { EntityStoreProvider } from '~/core/state/entity-page-store/entity-store-provider';
 import { MoveEntityProvider } from '~/core/state/move-entity-store';
 import { Entity } from '~/core/utils/entity';
+import { NavUtils } from '~/core/utils/utils';
 import { Value } from '~/core/utils/value';
 
 import { Spacer } from '~/design-system/spacer';
@@ -77,21 +78,22 @@ export default async function DefaultEntityPage({ params, searchParams }: Props)
 
 const getData = async (spaceId: string, entityId: string) => {
   const entity = await Subgraph.fetchEntity({ id: entityId });
+  const nameTripleSpace = entity?.nameTripleSpaces?.[0];
 
   // Redirect from space configuration page to space page
-  if (entity?.types.some(type => type.id === SYSTEM_IDS.SPACE_CONFIGURATION) && entity?.nameTripleSpace) {
-    console.log(`Redirecting from space configuration entity ${entity.id} to space page ${entity?.nameTripleSpace}`);
-    return redirect(`/space/${entity?.nameTripleSpace}`);
+  if (entity?.types.some(type => type.id === SYSTEM_IDS.SPACE_CONFIGURATION) && nameTripleSpace) {
+    console.log(`Redirecting from space configuration entity ${entity.id} to space page ${nameTripleSpace}`);
+    return redirect(NavUtils.toSpace(nameTripleSpace));
   }
 
   // @HACK: Entities we are rendering might be in a different space. Right now we aren't fetching
   // the space for the entity we are rendering, so we need to redirect to the correct space.
-  if (entity?.nameTripleSpace) {
-    if (spaceId !== entity?.nameTripleSpace) {
+  if (nameTripleSpace) {
+    if (spaceId !== nameTripleSpace) {
       console.log(
-        `Redirecting from incorrect space ${spaceId} to correct space ${entity?.nameTripleSpace} for entity ${entityId}`
+        `Redirecting from incorrect space ${spaceId} to correct space ${nameTripleSpace} for entity ${entityId}`
       );
-      return redirect(`/space/${entity?.nameTripleSpace}/${entityId}`);
+      return redirect(NavUtils.toEntity(nameTripleSpace, entityId));
     }
   }
 

--- a/apps/web/app/space/(entity)/[id]/[entityId]/layout.tsx
+++ b/apps/web/app/space/(entity)/[id]/[entityId]/layout.tsx
@@ -4,9 +4,6 @@ import * as React from 'react';
 
 import { Metadata } from 'next';
 
-import { PLACEHOLDER_SPACE_IMAGE } from '~/core/constants';
-import { Subgraph } from '~/core/io';
-import { fetchEntityType } from '~/core/io/fetch-entity-type';
 import { EditorProvider } from '~/core/state/editor-store';
 import { EntityStoreProvider } from '~/core/state/entity-page-store/entity-store-provider';
 import { TypesStoreServerContainer } from '~/core/state/types-store/types-store-server-container';
@@ -22,7 +19,9 @@ import { EditableHeading } from '~/partials/entity-page/editable-entity-header';
 import { EntityPageContentContainer } from '~/partials/entity-page/entity-page-content-container';
 import { EntityPageCover } from '~/partials/entity-page/entity-page-cover';
 import { EntityPageMetadataHeader } from '~/partials/entity-page/entity-page-metadata-header';
-import { ReferencedByEntity } from '~/partials/entity-page/types';
+
+import { cachedFetchEntityType } from './cached-entity-type';
+import { cachedFetchEntity } from './cached-fetch-entity';
 
 const TABS = ['Overview', 'Activity'] as const;
 
@@ -35,7 +34,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const spaceId = params.id;
   const entityId = decodeURIComponent(params.entityId);
 
-  const entity = await Subgraph.fetchEntity({ id: entityId });
+  const entity = await cachedFetchEntity(entityId);
   const { entityName, description, openGraphImageUrl } = getOpenGraphMetadataForEntity(entity);
 
   return {
@@ -70,9 +69,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 export default async function ProfileLayout({ children, params }: Props) {
   const decodedId = decodeURIComponent(params.entityId);
 
-  const types = await fetchEntityType({
-    id: decodedId,
-  });
+  const types = await cachedFetchEntityType(decodedId);
 
   if (!types.includes(SYSTEM_IDS.PERSON_TYPE)) {
     return <TypesStoreServerContainer spaceId={params.id}>{children}</TypesStoreServerContainer>;
@@ -132,14 +129,7 @@ async function getProfilePage(entityId: string): Promise<
     blockIdsTriple: Triple | null;
   }
 > {
-  const [person, referencesPerson, spaces] = await Promise.all([
-    Subgraph.fetchEntity({ id: entityId }),
-    Subgraph.fetchEntities({
-      query: '',
-      filter: [{ field: 'linked-to', value: entityId }],
-    }),
-    Subgraph.fetchSpaces(),
-  ]);
+  const person = await cachedFetchEntity(entityId);
 
   // @TODO: Real error handling
   if (!person) {
@@ -151,30 +141,10 @@ async function getProfilePage(entityId: string): Promise<
       triples: [],
       types: [],
       description: null,
-      referencedByEntities: [],
       blockTriples: [],
       blockIdsTriple: null,
     };
   }
-
-  const referencedByEntities: ReferencedByEntity[] = referencesPerson.map(e => {
-    const spaceId = Entity.nameTriple(e.triples)?.space ?? '';
-    const space = spaces.find(s => s.id === spaceId);
-    const configEntity = space?.spaceConfig;
-    const spaceName = space?.spaceConfig?.name ? space.spaceConfig?.name : space?.id ?? '';
-    const spaceImage = configEntity ? Entity.cover(configEntity.triples) : PLACEHOLDER_SPACE_IMAGE;
-
-    return {
-      id: e.id,
-      name: e.name,
-      types: e.types,
-      space: {
-        id: spaceId,
-        name: spaceName,
-        image: spaceImage,
-      },
-    };
-  });
 
   const blockIdsTriple = person?.triples.find(t => t.attributeId === SYSTEM_IDS.BLOCKS) || null;
   const blockIds: string[] = blockIdsTriple ? JSON.parse(Value.stringValue(blockIdsTriple) || '[]') : [];
@@ -182,7 +152,7 @@ async function getProfilePage(entityId: string): Promise<
   const blockTriples = (
     await Promise.all(
       blockIds.map(blockId => {
-        return Subgraph.fetchEntity({ id: blockId });
+        return cachedFetchEntity(blockId);
       })
     )
   ).flatMap(entity => entity?.triples ?? []);
@@ -191,7 +161,6 @@ async function getProfilePage(entityId: string): Promise<
     ...person,
     avatarUrl: Entity.avatar(person.triples),
     coverUrl: Entity.cover(person.triples),
-    referencedByEntities,
     blockTriples,
     blockIdsTriple,
   };

--- a/apps/web/app/space/(entity)/[id]/[entityId]/layout.tsx
+++ b/apps/web/app/space/(entity)/[id]/[entityId]/layout.tsx
@@ -124,7 +124,6 @@ async function getProfilePage(entityId: string): Promise<
   IEntity & {
     avatarUrl: string | null;
     coverUrl: string | null;
-    referencedByEntities: ReferencedByEntity[];
     blockTriples: Triple[];
     blockIdsTriple: Triple | null;
   }

--- a/apps/web/app/space/(entity)/[id]/[entityId]/page.tsx
+++ b/apps/web/app/space/(entity)/[id]/[entityId]/page.tsx
@@ -1,7 +1,6 @@
 import { SYSTEM_IDS } from '@geogenesis/ids';
 
-import { fetchEntityType } from '~/core/io/fetch-entity-type';
-
+import { cachedFetchEntityType } from './cached-entity-type';
 import DefaultEntityPage from './default-entity-page';
 import { ProfileEntityServerContainer } from './profile-entity-server-container';
 
@@ -14,11 +13,9 @@ interface Props {
 }
 
 export default async function EntityTemplateStrategy({ params, searchParams }: Props) {
-  const decodedId = decodeURIComponent(params.entityId);
+  const decodedId = decodeURI(params.entityId);
 
-  const types = await fetchEntityType({
-    id: decodedId,
-  });
+  const types = await cachedFetchEntityType(decodedId);
 
   if (types.includes(SYSTEM_IDS.PERSON_TYPE)) {
     return <ProfileEntityServerContainer params={params} />;

--- a/apps/web/app/space/(entity)/[id]/[entityId]/profile-entity-server-container.tsx
+++ b/apps/web/app/space/(entity)/[id]/[entityId]/profile-entity-server-container.tsx
@@ -4,6 +4,8 @@ import { redirect } from 'next/navigation';
 import * as React from 'react';
 
 import { Subgraph } from '~/core/io';
+import { fetchOnchainProfileByEntityId } from '~/core/io/fetch-onchain-profile-by-entity-id';
+import { NavUtils } from '~/core/utils/utils';
 
 import {
   EntityReferencedByLoading,
@@ -17,30 +19,40 @@ interface Props {
 }
 
 export async function ProfileEntityServerContainer({ params }: Props) {
-  const person = await Subgraph.fetchEntity({ id: decodeURIComponent(params.entityId) });
+  const entityId = decodeURIComponent(params.entityId);
+
+  const [person, profile] = await Promise.all([
+    Subgraph.fetchEntity({ id: entityId }),
+    fetchOnchainProfileByEntityId(entityId),
+  ]);
 
   // @TODO: Real error handling
   if (!person) {
     return <ProfilePageComponent id={params.entityId} triples={[]} spaceId={params.id} referencedByComponent={null} />;
   }
 
+  // Redirect from space configuration page to space page. An entity might be a Person _and_ a Space.
+  // In that case we want to render on the space front page.
+  if (person?.types.some(type => type.id === SYSTEM_IDS.SPACE_CONFIGURATION) && profile?.homeSpace) {
+    console.log(`Redirecting from space configuration entity ${person.id} to space page ${profile?.homeSpace}`);
+
+    // We need to stay in the space that we're currently in
+    return redirect(NavUtils.toSpace(profile.homeSpace));
+  }
+
   // @HACK: Entities we are rendering might be in a different space. Right now we aren't fetching
   // the space for the entity we are rendering, so we need to redirect to the correct space.
   // Once we have cross-space entity data we won't redirect and will instead only show the data
   // from the current space for the selected entity.
-  if (person?.nameTripleSpace) {
-    if (params.id !== person?.nameTripleSpace) {
-      console.log(
-        `Redirecting from incorrect space ${params.id} to correct space ${person?.nameTripleSpace} for entity ${params.entityId}`
-      );
-      return redirect(`/space/${person?.nameTripleSpace}/${encodeURIComponent(params.entityId)}`);
-    }
-  }
+  if (profile?.homeSpace) {
+    if (params.id !== profile.homeSpace) {
+      console.log('redirect url', NavUtils.toEntity(profile.homeSpace, entityId));
 
-  // Redirect from space configuration page to space page
-  if (person?.types.some(type => type.id === SYSTEM_IDS.SPACE_CONFIGURATION) && person?.nameTripleSpace) {
-    console.log(`Redirecting from space configuration entity ${person.id} to space page ${person?.nameTripleSpace}`);
-    return redirect(`/space/${person?.nameTripleSpace}`);
+      console.log(
+        `Redirecting from incorrect space ${params.id} to correct space ${profile.homeSpace} for profile ${entityId}`
+      );
+      return redirect(NavUtils.toEntity(profile.homeSpace, entityId));
+    }
   }
 
   return (

--- a/apps/web/app/space/(triples)/[id]/triples/page.tsx
+++ b/apps/web/app/space/(triples)/[id]/triples/page.tsx
@@ -3,7 +3,6 @@ import * as React from 'react';
 import { PLACEHOLDER_SPACE_IMAGE } from '~/core/constants';
 import { Subgraph } from '~/core/io';
 import { Params } from '~/core/params';
-import { Entity } from '~/core/utils/entity';
 
 import { Component } from './component';
 
@@ -27,8 +26,8 @@ const getData = async ({ params, searchParams }: Props) => {
   const initialParams = Params.parseTripleQueryFilterFromParams(searchParams);
   const configEntity = space?.spaceConfig;
 
-  const spaceName = space?.spaceConfig?.name ? space.spaceConfig?.name : space?.id ?? '';
-  const spaceImage = configEntity ? Entity.cover(configEntity.triples) : PLACEHOLDER_SPACE_IMAGE;
+  const spaceName = space?.spaceConfig?.name ?? space?.id ?? '';
+  const spaceImage = configEntity ? configEntity.image : PLACEHOLDER_SPACE_IMAGE;
 
   return {
     spaceId,

--- a/apps/web/app/space/[id]/cached-fetch-space.ts
+++ b/apps/web/app/space/[id]/cached-fetch-space.ts
@@ -1,0 +1,7 @@
+import { cache } from 'react';
+
+import { fetchSpace } from '~/core/io/subgraph';
+
+export const cachedFetchSpace = cache(async (spaceId: string) => {
+  return fetchSpace({ id: spaceId });
+});

--- a/apps/web/app/space/[id]/layout.tsx
+++ b/apps/web/app/space/[id]/layout.tsx
@@ -191,15 +191,6 @@ const getData = async (spaceId: string) => {
     redirect(`/space/${spaceId}/entities`);
   }
 
-  // @HACK: Entities we are rendering might be in a different space. Right now there's a bug where we aren't
-  // fetching the space for the entity we are rendering, so we need to redirect to the correct space.
-  if (entity?.nameTripleSpace) {
-    if (spaceId !== entity?.nameTripleSpace) {
-      console.log('Redirecting to space from space configuration entity', entity?.nameTripleSpace);
-      redirect(`/space/${entity?.nameTripleSpace}/${entity.id}`);
-    }
-  }
-
   const spaceName = space?.spaceConfig?.name ? space.spaceConfig?.name : space?.id ?? '';
 
   const blockIdsTriple = entity?.triples.find(t => t.attributeId === SYSTEM_IDS.BLOCKS) || null;

--- a/apps/web/app/space/[id]/layout.tsx
+++ b/apps/web/app/space/[id]/layout.tsx
@@ -23,6 +23,8 @@ import { SpaceEditors } from '~/partials/space-page/space-editors';
 import { SpaceMembers } from '~/partials/space-page/space-members';
 import { SpacePageMetadataHeader } from '~/partials/space-page/space-metadata-header';
 
+import { cachedFetchSpace } from './cached-fetch-space';
+
 interface Props {
   params: { id: string };
   children: React.ReactNode;
@@ -180,7 +182,8 @@ function MembersSkeleton() {
 }
 
 const getData = async (spaceId: string) => {
-  const space = await Subgraph.fetchSpace({ id: spaceId });
+  // @TODO: If there's no space we should 404
+  const space = await cachedFetchSpace(spaceId);
   const entity = space?.spaceConfig;
 
   if (!entity) {

--- a/apps/web/app/space/[id]/page.tsx
+++ b/apps/web/app/space/[id]/page.tsx
@@ -129,15 +129,6 @@ const getData = async (spaceId: string) => {
     redirect(`/space/${spaceId}/entities`);
   }
 
-  // @HACK: Entities we are rendering might be in a different space. Right now there's a bug where we aren't
-  // fetching the space for the entity we are rendering, so we need to redirect to the correct space.
-  if (entity?.nameTripleSpace) {
-    if (spaceId !== entity?.nameTripleSpace) {
-      console.log('Redirecting to space from space configuration entity', entity?.nameTripleSpace);
-      redirect(`/space/${entity?.nameTripleSpace}/${entity.id}`);
-    }
-  }
-
   return {
     name: entity?.name ?? null,
     triples: entity?.triples ?? [],

--- a/apps/web/app/space/[id]/team/page.tsx
+++ b/apps/web/app/space/[id]/team/page.tsx
@@ -1,93 +1,13 @@
 import { AVATAR_ATTRIBUTE, NAME, ROLE_ATTRIBUTE } from '@geogenesis/ids/system-ids';
-import { Effect, Either } from 'effect';
 
-import { Environment } from '~/core/environment';
 import { Subgraph } from '~/core/io';
-import { graphql } from '~/core/io/subgraph/graphql';
+import { fetchOnchainProfileByEntityId } from '~/core/io/fetch-onchain-profile-by-entity-id';
 import type { Triple as TripleType } from '~/core/types';
 import { Entity } from '~/core/utils/entity';
 import { Triple } from '~/core/utils/triple';
 import { Value } from '~/core/utils/value';
 
 import { TeamMembers } from '~/partials/team/team-members';
-
-// We fetch for geoEntities -> name because the id of the wallet entity might not be the
-// same as the actual wallet address.
-function getFetchProfileQuery(entityId: string) {
-  // Have to fetch the profiles as an array as we can't query an individual profile by it's account.
-  // account_starts_with_nocase is also a hack since our subgraph does not store the account the same
-  // way as the profiles. Profiles are a string but `createdBy` in our subgraph is stored as Bytes.
-  return `query {
-    geoProfile(id: "${entityId}") {
-      id
-      homeSpace
-      account
-    }
-  }`;
-}
-
-interface OnchainGeoProfile {
-  id: string;
-  homeSpace: string;
-  account: string;
-}
-
-interface NetworkResult {
-  geoProfile: OnchainGeoProfile | null;
-}
-
-async function fetchOnchainProfileByEntityId(entityId: string): Promise<OnchainGeoProfile | null> {
-  const config = Environment.getConfig(process.env.NEXT_PUBLIC_APP_ENV);
-
-  const fetchWalletsGraphqlEffect = graphql<NetworkResult>({
-    endpoint: config.profileSubgraph,
-    query: getFetchProfileQuery(entityId),
-  });
-
-  const graphqlFetchWithErrorFallbacks = Effect.gen(function* (awaited) {
-    const resultOrError = yield* awaited(Effect.either(fetchWalletsGraphqlEffect));
-
-    if (Either.isLeft(resultOrError)) {
-      const error = resultOrError.left;
-
-      switch (error._tag) {
-        case 'AbortError':
-          // Right now we re-throw AbortErrors and let the callers handle it. Eventually we want
-          // the caller to consume the error channel as an effect. We throw here the typical JS
-          // way so we don't infect more of the codebase with the effect runtime.
-          throw error;
-        case 'GraphqlRuntimeError':
-          console.error(
-            `Encountered runtime graphql error in fetchProfile. endpoint: ${
-              config.profileSubgraph
-            } entityId: ${entityId}
-
-              queryString: ${getFetchProfileQuery(entityId)}
-              `,
-            error.message
-          );
-
-          return {
-            geoProfile: null,
-          };
-        default:
-          console.error(
-            `${error._tag}: Unable to fetch wallets to derive profile, endpoint: ${config.profileSubgraph} entityId: ${entityId}`
-          );
-
-          return {
-            geoProfile: null,
-          };
-      }
-    }
-
-    return resultOrError.right;
-  });
-
-  const result = await Effect.runPromise(graphqlFetchWithErrorFallbacks);
-
-  return result.geoProfile;
-}
 
 type TeamPageProps = {
   params: { id: string; entityId: string };

--- a/apps/web/core/io/fetch-onchain-profile-by-entity-id.ts
+++ b/apps/web/core/io/fetch-onchain-profile-by-entity-id.ts
@@ -1,0 +1,80 @@
+import { Effect, Either } from 'effect';
+
+import { Environment } from '../environment';
+import { graphql } from './subgraph/graphql';
+
+function getFetchProfileQuery(entityId: string) {
+  // Have to fetch the profiles as an array as we can't query an individual profile by it's account.
+  // account_starts_with_nocase is also a hack since our subgraph does not store the account the same
+  // way as the profiles. Profiles are a string but `createdBy` in our subgraph is stored as Bytes.
+  return `query {
+    geoProfile(id: "${entityId}") {
+      id
+      homeSpace
+      account
+    }
+  }`;
+}
+
+interface OnchainGeoProfile {
+  id: string;
+  homeSpace: string;
+  account: string;
+}
+
+interface NetworkResult {
+  geoProfile: OnchainGeoProfile | null;
+}
+
+export async function fetchOnchainProfileByEntityId(entityId: string): Promise<OnchainGeoProfile | null> {
+  const config = Environment.getConfig(process.env.NEXT_PUBLIC_APP_ENV);
+
+  const fetchWalletsGraphqlEffect = graphql<NetworkResult>({
+    endpoint: config.profileSubgraph,
+    query: getFetchProfileQuery(entityId),
+  });
+
+  const graphqlFetchWithErrorFallbacks = Effect.gen(function* (awaited) {
+    const resultOrError = yield* awaited(Effect.either(fetchWalletsGraphqlEffect));
+
+    if (Either.isLeft(resultOrError)) {
+      const error = resultOrError.left;
+
+      switch (error._tag) {
+        case 'AbortError':
+          // Right now we re-throw AbortErrors and let the callers handle it. Eventually we want
+          // the caller to consume the error channel as an effect. We throw here the typical JS
+          // way so we don't infect more of the codebase with the effect runtime.
+          throw error;
+        case 'GraphqlRuntimeError':
+          console.error(
+            `Encountered runtime graphql error in fetchProfile. endpoint: ${
+              config.profileSubgraph
+            } entityId: ${entityId}
+
+              queryString: ${getFetchProfileQuery(entityId)}
+              `,
+            error.message
+          );
+
+          return {
+            geoProfile: null,
+          };
+        default:
+          console.error(
+            `${error._tag}: Unable to fetch wallets to derive profile, endpoint: ${config.profileSubgraph} entityId: ${entityId}`
+          );
+
+          return {
+            geoProfile: null,
+          };
+      }
+    }
+
+    return resultOrError.right;
+  });
+
+  const result = await Effect.runPromise(graphqlFetchWithErrorFallbacks);
+
+  return result.geoProfile;
+}

--- a/apps/web/core/io/subgraph/fetch-entities.ts
+++ b/apps/web/core/io/subgraph/fetch-entities.ts
@@ -175,7 +175,7 @@ export async function fetchEntities(options: FetchEntitiesOptions) {
         id: result.id,
         name: result.name,
         description: null,
-        nameTripleSpace: undefined,
+        nameTripleSpaces: [],
         types: [],
         triples: [],
       };

--- a/apps/web/core/io/subgraph/fetch-entities.ts
+++ b/apps/web/core/io/subgraph/fetch-entities.ts
@@ -182,14 +182,14 @@ export async function fetchEntities(options: FetchEntitiesOptions) {
     }
 
     const triples = fromNetworkTriples(networkTriples);
-    const nameTriple = Entity.nameTriple(triples);
+    const nameTriples = Entity.nameTriples(triples);
 
     return {
       id: result.id,
       name: result.name,
       description: Entity.description(triples),
-      nameTripleSpace: nameTriple?.space,
-      types: Entity.types(triples, nameTriple?.space),
+      nameTripleSpaces: nameTriples.map(t => t.space),
+      types: Entity.types(triples),
       triples,
     };
   });

--- a/apps/web/core/io/subgraph/fetch-entity.ts
+++ b/apps/web/core/io/subgraph/fetch-entity.ts
@@ -110,14 +110,14 @@ export async function fetchEntity(options: FetchEntityOptions): Promise<IEntity 
 
   const networkTriples = entity.triplesByEntityId.nodes;
   const triples = fromNetworkTriples(networkTriples);
-  const nameTriple = Entity.nameTriple(triples);
+  const nameTriples = Entity.nameTriples(triples);
 
   return {
     id: entity.id,
     name: entity.name,
     description: Entity.description(triples),
-    nameTripleSpace: nameTriple?.space,
-    types: Entity.types(triples, entity?.nameTripleSpace),
+    nameTripleSpaces: nameTriples.map(t => t.space),
+    types: Entity.types(triples),
     triples,
   };
 }

--- a/apps/web/core/io/subgraph/fetch-space.ts
+++ b/apps/web/core/io/subgraph/fetch-space.ts
@@ -108,9 +108,7 @@ export async function fetchSpace(options: FetchSpaceOptions): Promise<Space | nu
 
   const spaceConfigs = await fetchEntities({
     query: '',
-    first: 1,
     spaceId: options.id,
-    skip: 0,
     typeIds: [SYSTEM_IDS.SPACE_CONFIGURATION],
     filter: [],
   });

--- a/apps/web/core/io/subgraph/fetch-table-row-entities.ts
+++ b/apps/web/core/io/subgraph/fetch-table-row-entities.ts
@@ -124,20 +124,19 @@ export async function fetchTableRowEntities(options: FetchTableRowEntitiesOption
         id: result.id,
         name: result.name,
         description: null,
-        nameTripleSpace: undefined,
         types: [],
         triples: [],
       };
     }
 
     const triples = fromNetworkTriples(networkTriples);
-    const nameTriple = Entity.nameTriple(triples);
+    const nameTriples = Entity.nameTriples(triples);
 
     return {
       id: result.id,
       name: result.name,
       description: Entity.description(triples),
-      nameTripleSpace: nameTriple?.space,
+      nameTripleSpaces: nameTriples.map(t => t.space),
       types: Entity.types(triples),
       triples,
     };

--- a/apps/web/core/io/subgraph/fetch-table-row-entities.ts
+++ b/apps/web/core/io/subgraph/fetch-table-row-entities.ts
@@ -138,7 +138,7 @@ export async function fetchTableRowEntities(options: FetchTableRowEntitiesOption
       name: result.name,
       description: Entity.description(triples),
       nameTripleSpace: nameTriple?.space,
-      types: Entity.types(triples, nameTriple?.space),
+      types: Entity.types(triples),
       triples,
     };
   });

--- a/apps/web/core/merged/merged.ts
+++ b/apps/web/core/merged/merged.ts
@@ -233,7 +233,7 @@ export class Merged implements IMergedDataSource {
             // attached to a triple in the data model. Once we represents entities across multiple spaces
             // this filter likely won't make sense anymore.
             if (filter.columnId === 'space') {
-              return entity.nameTripleSpace === filter.value;
+              return entity.nameTripleSpaces?.includes(filter.value);
             }
 
             return triple.attributeId === filter.columnId && filterValue(triple.value, filter.value);
@@ -258,7 +258,7 @@ export class Merged implements IMergedDataSource {
             // attached to a triple in the data model. Once we represents entities across multiple spaces
             // this filter likely won't make sense anymore.
             if (filter.columnId === 'space') {
-              return entity.nameTripleSpace === filter.value;
+              return entity.nameTripleSpaces?.includes(filter.value);
             }
 
             return triple.attributeId === filter.columnId && filterValue(triple.value, filter.value);

--- a/apps/web/core/state/types-store/types-store-server-container.tsx
+++ b/apps/web/core/state/types-store/types-store-server-container.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 
-import { Subgraph } from '~/core/io';
 import { fetchForeignTypeTriples, fetchSpaceTypeTriples } from '~/core/io/fetch-types';
 
 import { TypesStoreProvider } from './types-store';
+import { cachedFetchSpace } from '~/app/space/[id]/cached-fetch-space';
 
 interface Props {
   spaceId: string;
@@ -11,7 +11,7 @@ interface Props {
 }
 
 export async function TypesStoreServerContainer({ spaceId, children }: Props) {
-  const space = await Subgraph.fetchSpace({ id: spaceId });
+  const space = await cachedFetchSpace(spaceId);
 
   const [types, foreignTypes] = await Promise.all([
     fetchSpaceTypeTriples(spaceId),

--- a/apps/web/core/types.ts
+++ b/apps/web/core/types.ts
@@ -131,7 +131,7 @@ export type Entity = {
   description: string | null;
   types: EntityType[];
   triples: Triple[];
-  nameTripleSpace?: string;
+  nameTripleSpaces?: string[];
 };
 
 export type GeoType = {

--- a/apps/web/core/utils/entity/entity.test.ts
+++ b/apps/web/core/utils/entity/entity.test.ts
@@ -320,7 +320,7 @@ it('Entity.entitiesFromTriples should map Triples to Entity', () => {
       name: 'entity-1',
       description: 'banana description',
       types: [],
-      nameTripleSpace: 'spaceId',
+      nameTripleSpaces: ['spaceId'],
       triples: [triplesFromMultipleEntities[0], triplesFromMultipleEntities[1]],
     },
     {
@@ -328,7 +328,7 @@ it('Entity.entitiesFromTriples should map Triples to Entity', () => {
       name: 'entity-2',
       description: 'apple description',
       types: [],
-      nameTripleSpace: 'spaceId',
+      nameTripleSpaces: ['spaceId'],
       triples: [triplesFromMultipleEntities[2], triplesFromMultipleEntities[3]],
     },
   ];
@@ -339,6 +339,7 @@ it('Entity.entitiesFromTriples should map Triples to Entity', () => {
 const localActions: Record<string, Action[]> = {
   spaceId: [
     {
+      id: '5',
       type: 'editTriple',
       before: {
         type: 'deleteTriple',
@@ -374,7 +375,7 @@ it('Entity.mergeActionsWithNetworkEntities should merge local actions with entit
       name: 'entity-1-changed',
       description: 'banana description',
       types: [],
-      nameTripleSpace: 'spaceId',
+      nameTripleSpaces: ['spaceId'],
       triples: [
         {
           type: 'createTriple',

--- a/apps/web/core/utils/entity/entity.ts
+++ b/apps/web/core/utils/entity/entity.ts
@@ -86,6 +86,10 @@ export function nameTriple(triples: ITriple[]): ITriple | undefined {
   return triples.find(triple => triple.attributeId === SYSTEM_IDS.NAME);
 }
 
+export function nameTriples(triples: ITriple[]): ITriple[] {
+  return triples.filter(triple => triple.attributeId === SYSTEM_IDS.NAME);
+}
+
 export function valueTypeTriple(triples: ITriple[]): ITriple | undefined {
   return triples.find(triple => triple.attributeId === SYSTEM_IDS.VALUE_TYPE);
 }
@@ -114,7 +118,7 @@ export function entitiesFromTriples(triples: ITriple[]): IEntity[] {
         id: entityId,
         name: name(triples),
         description: description(triples),
-        nameTripleSpace: nameTriple(triples)?.space,
+        nameTripleSpaces: nameTriples(triples).map(triple => triple.space),
         types: types(triples, tripleForName?.space),
         triples,
       };
@@ -166,7 +170,7 @@ export function mergeActionsWithEntity(allActionsInStore: Action[], networkEntit
     id: networkEntity.id,
     name: name(triplesForEntity),
     description: description(triplesForEntity),
-    nameTripleSpace: nameTriple(triplesForEntity)?.space,
+    nameTripleSpaces: nameTriples(triplesForEntity).map(triple => triple.space),
     types: types(triplesForEntity, triplesForEntity[0]?.space),
     triples: triplesForEntity,
   };
@@ -181,7 +185,7 @@ export function fromActions(allActionsInStore: Action[], entityId: string): IEnt
     id: entityId,
     name: name(triplesForEntityWithLocalNames),
     description: description(triplesForEntityWithLocalNames),
-    nameTripleSpace: nameTriple(triplesForEntityWithLocalNames)?.space,
+    nameTripleSpaces: nameTriples(triplesForEntityWithLocalNames).map(triple => triple.space),
     types: types(triplesForEntityWithLocalNames, triplesForEntityWithLocalNames[0]?.space),
     triples: triplesForEntityWithLocalNames,
   };

--- a/apps/web/design-system/autocomplete/results-list.test.tsx
+++ b/apps/web/design-system/autocomplete/results-list.test.tsx
@@ -18,7 +18,6 @@ const space: Space = {
     image: null,
     name: 'Space-1',
     triples: [],
-    nameTripleSpace: 'space-1',
     description: 'Description-1',
     types: [
       {
@@ -45,7 +44,6 @@ describe('Entity autocomplete results list', () => {
             description: 'Description-1',
             types: [{ id: 'type-id-1', name: 'Type-1' }],
             triples: [],
-            nameTripleSpace: 'space-1',
           }}
           alreadySelected={false}
         />

--- a/apps/web/design-system/autocomplete/results-list.test.tsx
+++ b/apps/web/design-system/autocomplete/results-list.test.tsx
@@ -43,6 +43,7 @@ describe('Entity autocomplete results list', () => {
             name: 'Name-1',
             description: 'Description-1',
             types: [{ id: 'type-id-1', name: 'Type-1' }],
+            nameTripleSpaces: ['space-1'],
             triples: [],
           }}
           alreadySelected={false}

--- a/apps/web/design-system/autocomplete/results-list.tsx
+++ b/apps/web/design-system/autocomplete/results-list.tsx
@@ -37,17 +37,17 @@ export const ResultItem = ({ existsOnEntity = false, className = '', ...rest }: 
 
 interface Props {
   onClick: () => void;
-  result: Entity & { space: string };
+  result: Entity;
   alreadySelected?: boolean;
   spaces: Space[];
   withDescription?: boolean;
 }
 
 export function ResultContent({ onClick, result, alreadySelected, spaces, withDescription = true }: Props) {
-  const duplicates = spaces.filter(space => space.id === result.space);
+  const duplicates = spaces.filter(space => space.id === result.name);
   console.log('duplicates', duplicates);
 
-  const space = spaces.find(space => space.id === result.space);
+  const space = spaces.find(space => space.id === result.nameTripleSpaces?.[0] ?? '');
 
   const spaceName = space?.spaceConfig?.name ?? space?.id ?? '';
   const spaceImg = space?.spaceConfig?.image ?? null;

--- a/apps/web/design-system/autocomplete/results-list.tsx
+++ b/apps/web/design-system/autocomplete/results-list.tsx
@@ -37,14 +37,17 @@ export const ResultItem = ({ existsOnEntity = false, className = '', ...rest }: 
 
 interface Props {
   onClick: () => void;
-  result: Entity;
+  result: Entity & { space: string };
   alreadySelected?: boolean;
   spaces: Space[];
   withDescription?: boolean;
 }
 
 export function ResultContent({ onClick, result, alreadySelected, spaces, withDescription = true }: Props) {
-  const space = spaces.find(space => space.id === result.nameTripleSpace);
+  const duplicates = spaces.filter(space => space.id === result.space);
+  console.log('duplicates', duplicates);
+
+  const space = spaces.find(space => space.id === result.space);
 
   const spaceName = space?.spaceConfig?.name ?? space?.id ?? '';
   const spaceImg = space?.spaceConfig?.image ?? null;

--- a/apps/web/partials/blocks/table/table-block-context-menu.tsx
+++ b/apps/web/partials/blocks/table/table-block-context-menu.tsx
@@ -125,6 +125,8 @@ function useOptimisticAttributes({
 
   const onChangeAttributeValueType = (newValueTypeId: ValueTypeId, attribute: IEntity) => {
     const attributeValueTypeTriple = attribute.triples.find(t => t.attributeId === SYSTEM_IDS.VALUE_TYPE);
+    // This _should_ only be one space, but there may be a situation now where it's multiple spaces. Need to monitor this.
+    const attributeSpace = attribute.nameTripleSpaces?.[0];
 
     if (attributeValueTypeTriple) {
       remove(attributeValueTypeTriple);
@@ -148,13 +150,13 @@ function useOptimisticAttributes({
       }
     }
 
-    if (attribute.nameTripleSpace) {
+    if (attributeSpace) {
       const newTriple = Triple.withId({
         entityId: attribute.id,
         entityName: attribute.name,
         attributeId: SYSTEM_IDS.VALUE_TYPE,
         attributeName: 'Value type',
-        space: attribute.nameTripleSpace,
+        space: attributeSpace,
         value: {
           type: 'entity',
           id: newValueTypeId,
@@ -439,8 +441,11 @@ function SchemaAttributes() {
     spaceId: type.space,
   });
 
-  const onChangeAttributeName = (newName: string, entity: IEntity, oldNameTriple?: ITriple) => {
-    if (!entity.nameTripleSpace) {
+  const onChangeAttributeName = (newName: string, attribute: IEntity, oldNameTriple?: ITriple) => {
+    // This _should_ only be in one space, but it could be in multiple now. Need to monitor this.
+    const attributeSpace = attribute.nameTripleSpaces?.[0];
+
+    if (!attributeSpace) {
       console.error("The entity doesn't have a name triple space");
       return;
     }
@@ -450,9 +455,9 @@ function SchemaAttributes() {
         Triple.withId({
           attributeId: SYSTEM_IDS.NAME,
           attributeName: 'Name',
-          entityId: entity.id,
-          entityName: entity.name,
-          space: entity.nameTripleSpace,
+          entityId: attribute.id,
+          entityName: attribute.name,
+          space: attributeSpace,
           value: {
             type: 'string',
             id: ID.createValueId(),

--- a/apps/web/partials/search/dialog.tsx
+++ b/apps/web/partials/search/dialog.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link';
 
 import { useGlobalSearch } from '~/core/hooks/use-global-search';
 import { useSpaces } from '~/core/hooks/use-spaces';
+import { Entity, OmitStrict } from '~/core/types';
 import { NavUtils } from '~/core/utils/utils';
 
 import { ResultContent, ResultsList } from '~/design-system/autocomplete/results-list';
@@ -25,6 +26,22 @@ export function Dialog({ onDone, open, onOpenChange }: Props) {
   const { spaces } = useSpaces();
 
   if (!open) return null;
+
+  const separatedResults = autocomplete.results.reduce(
+    (acc, result) => {
+      for (const spaceId of result.nameTripleSpaces ?? []) {
+        acc.push({
+          ...result,
+          space: spaceId,
+        });
+      }
+
+      return acc;
+    },
+    [] as (OmitStrict<Entity, 'nameTripleSpaces'> & { space: string })[]
+  );
+
+  console.log('separated results', separatedResults);
 
   return (
     <Command.Dialog open={open} onOpenChange={onOpenChange} label="Entity search">
@@ -69,7 +86,7 @@ export function Dialog({ onDone, open, onOpenChange }: Props) {
               {autocomplete.isEmpty && (
                 <Command.Empty className="px-2 pb-2">No results found for {autocomplete.query}</Command.Empty>
               )}
-              {autocomplete.results.map((result, i) => (
+              {separatedResults.map((result, i) => (
                 <motion.div
                   initial={{ opacity: 0, y: -5 }}
                   animate={{ opacity: 1, y: 0 }}
@@ -77,7 +94,7 @@ export function Dialog({ onDone, open, onOpenChange }: Props) {
                   key={result.id}
                 >
                   {/* It's safe to cast nameTripleSpace since we only render entities that have a name triple */}
-                  <Link href={NavUtils.toEntity(result.nameTripleSpace!, result.id)} onClick={() => onDone()}>
+                  <Link href={NavUtils.toEntity(result.space, result.id)} onClick={() => onDone()}>
                     <Command.Item className="transition-colors duration-75 aria-selected:bg-grey-01">
                       <ResultContent
                         onClick={() => {

--- a/apps/web/partials/search/dialog.tsx
+++ b/apps/web/partials/search/dialog.tsx
@@ -27,21 +27,16 @@ export function Dialog({ onDone, open, onOpenChange }: Props) {
 
   if (!open) return null;
 
-  const separatedResults = autocomplete.results.reduce(
-    (acc, result) => {
-      for (const spaceId of result.nameTripleSpaces ?? []) {
-        acc.push({
-          ...result,
-          space: spaceId,
-        });
-      }
+  const separatedResults = autocomplete.results.reduce((acc, result) => {
+    for (const spaceId of result.nameTripleSpaces ?? []) {
+      acc.push({
+        ...result,
+        nameTripleSpaces: [spaceId],
+      });
+    }
 
-      return acc;
-    },
-    [] as (OmitStrict<Entity, 'nameTripleSpaces'> & { space: string })[]
-  );
-
-  console.log('separated results', separatedResults);
+    return acc;
+  }, [] as Entity[]);
 
   return (
     <Command.Dialog open={open} onOpenChange={onOpenChange} label="Entity search">
@@ -94,7 +89,7 @@ export function Dialog({ onDone, open, onOpenChange }: Props) {
                   key={result.id}
                 >
                   {/* It's safe to cast nameTripleSpace since we only render entities that have a name triple */}
-                  <Link href={NavUtils.toEntity(result.space, result.id)} onClick={() => onDone()}>
+                  <Link href={NavUtils.toEntity(result.nameTripleSpaces![0], result.id)} onClick={() => onDone()}>
                     <Command.Item className="transition-colors duration-75 aria-selected:bg-grey-01">
                       <ResultContent
                         onClick={() => {

--- a/apps/web/partials/space-page/get-editors-for-space.ts
+++ b/apps/web/partials/space-page/get-editors-for-space.ts
@@ -1,3 +1,5 @@
+import { cache } from 'react';
+
 import { Subgraph } from '~/core/io';
 import { OmitStrict, Profile } from '~/core/types';
 
@@ -6,7 +8,7 @@ type EditorsForSpace = {
   totalEditors: number;
 };
 
-export async function getEditorsForSpace(spaceId: string): Promise<EditorsForSpace> {
+export const getEditorsForSpace = cache(async (spaceId: string): Promise<EditorsForSpace> => {
   const space = await Subgraph.fetchSpace({ id: spaceId });
 
   if (!space) {
@@ -39,4 +41,4 @@ export async function getEditorsForSpace(spaceId: string): Promise<EditorsForSpa
     allEditors: allEditorsWithProfiles,
     totalEditors: space.editors.length,
   };
-}
+});

--- a/apps/web/partials/space-page/get-first-three-editors-for-space.ts
+++ b/apps/web/partials/space-page/get-first-three-editors-for-space.ts
@@ -1,4 +1,5 @@
-import '~/core/environment';
+import { cache } from 'react';
+
 import { Subgraph } from '~/core/io';
 import { OmitStrict, Profile } from '~/core/types';
 
@@ -7,7 +8,7 @@ type EditorsForSpace = {
   totalEditors: number;
 };
 
-export async function getFirstThreeEditorsForSpace(spaceId: string): Promise<EditorsForSpace> {
+export const getFirstThreeEditorsForSpace = cache(async (spaceId: string): Promise<EditorsForSpace> => {
   const space = await Subgraph.fetchSpace({ id: spaceId });
 
   if (!space) {
@@ -44,4 +45,4 @@ export async function getFirstThreeEditorsForSpace(spaceId: string): Promise<Edi
     firstThreeEditors,
     totalEditors: space.editors.length,
   };
-}
+});

--- a/apps/web/partials/space-page/get-is-editor-for-space.ts
+++ b/apps/web/partials/space-page/get-is-editor-for-space.ts
@@ -1,6 +1,8 @@
+import { cache } from 'react';
+
 import { Subgraph } from '~/core/io';
 
-export async function getIsEditorForSpace(spaceId: string, connectedAddress?: string): Promise<boolean> {
+export const getIsEditorForSpace = cache(async (spaceId: string, connectedAddress?: string): Promise<boolean> => {
   const space = await Subgraph.fetchSpace({ id: spaceId });
 
   if (!space) {
@@ -9,4 +11,4 @@ export async function getIsEditorForSpace(spaceId: string, connectedAddress?: st
 
   // @HACK to get around incorrect checksum addresses in substream
   return connectedAddress ? space.editors.map(e => e.toLowerCase()).includes(connectedAddress?.toLowerCase()) : false;
-}
+});

--- a/apps/web/partials/team/find-team-member.tsx
+++ b/apps/web/partials/team/find-team-member.tsx
@@ -44,6 +44,7 @@ import {
 import { NoAvatar } from './no-avatar';
 import { TeamMemberCreatedToast } from './toast';
 import type { Role } from './types';
+import { cachedFetchEntityType } from '~/app/space/(entity)/[id]/[entityId]/cached-entity-type';
 
 type FindTeamMemberProps = {
   spaceId: string;
@@ -162,12 +163,8 @@ export const FindTeamMember = ({ spaceId }: FindTeamMemberProps) => {
         Subgraph.fetchEntity({
           id: entityId,
         }),
-        fetchEntityType({
-          id: entityId,
-        }),
+        cachedFetchEntityType(entityId),
       ]);
-
-      console.log('person', person)
 
       if (person) {
         if (types.includes(SYSTEM_IDS.PERSON_TYPE)) {


### PR DESCRIPTION
Entities can now exist in multiple spaces at once. This PR updates our navigation model to be able to handle multi-space entities. Eventually we will need a mechanism for users to be able to define which space they want an entity link to go to.