### PR TITLE
fix: apply isStale filter to table filter queries

### DIFF
--- a/apps/web/core/blocks-sdk/__snapshots__/table.test.ts.snap
+++ b/apps/web/core/blocks-sdk/__snapshots__/table.test.ts.snap
@@ -1,0 +1,35 @@
+// Vitest Snapshot v1
+
+exports[`TableBlock SDK > Builds a graphql query from table block filters for the postgraphile-based substreams API 1`] = `"{ geoEntityTypesByEntityId: { some: { typeId: { equalTo: \\"type-id\\" } } }, triplesByEntityId: { some: { attributeId: { equalTo: \\"type\\" }, stringValue: { equalToInsensitive: \\"Value 1\\"}, isStale: { equalTo: false } } }}"`;
+
+exports[`TableBlock SDK > Builds a graphql query from table block filters for the postgraphile-based substreams API 2`] = `"{ geoEntityTypesByEntityId: { some: { typeId: { equalTo: \\"type-id\\" } } }, triplesByEntityId: { some: { attributeId: { equalTo: \\"type\\" }, entityValueId: { equalTo: \\"id 1\\"}, isStale: { equalTo: false } } }}"`;
+
+exports[`TableBlock SDK > Builds a graphql query from table block filters for the postgraphile-based substreams API 3`] = `"{ geoEntityTypesByEntityId: { some: { typeId: { equalTo: \\"type-id\\" } } }, name: { startsWithInsensitive: \\"id 1\\" }}"`;
+
+exports[`TableBlock SDK > Builds a graphql query from table block filters for the postgraphile-based substreams API 4`] = `"{ and: [{ geoEntityTypesByEntityId: { some: { typeId: { equalTo: \\"type-id\\" } } } } { triplesByEntityId: { some: { attributeId: { equalTo: \\"type\\" }, stringValue: { equalToInsensitive: \\"Value 1\\"}, isStale: { equalTo: false } } } }, { triplesByEntityId: { some: { attributeId: { equalTo: \\"type\\" }, entityValueId: { equalTo: \\"id 1\\"}, isStale: { equalTo: false } } } }, { name: { startsWithInsensitive: \\"id 1\\" } }] }"`;
+
+exports[`TableBlock SDK > Builds a graphql query from table block filters for the postgraphile-based substreams API 5`] = `
+"{ geoEntityTypesByEntityId: { some: { typeId: { equalTo: \\"type-id\\" } } }, triplesByEntityId: {
+          some: {
+            spaceId: { equalTo: \\"0x0000000000000000000000000000000000000000\\" },
+            isStale: { equalTo: false }
+          }
+        }}"
+`;
+
+exports[`TableBlock SDK > Substream: Builds a graphql query from table block filters 1`] = `"{ geoEntityTypesByEntityId: { some: { typeId: { equalTo: \\"type-id\\" } } }, triplesByEntityId: { some: { attributeId: { equalTo: \\"type\\" }, stringValue: { equalToInsensitive: \\"Value 1\\"}, isStale: { equalTo: false } } }}"`;
+
+exports[`TableBlock SDK > Substream: Builds a graphql query from table block filters 2`] = `"{ geoEntityTypesByEntityId: { some: { typeId: { equalTo: \\"type-id\\" } } }, triplesByEntityId: { some: { attributeId: { equalTo: \\"type\\" }, entityValueId: { equalTo: \\"id 1\\"}, isStale: { equalTo: false } } }}"`;
+
+exports[`TableBlock SDK > Substream: Builds a graphql query from table block filters 3`] = `"{ geoEntityTypesByEntityId: { some: { typeId: { equalTo: \\"type-id\\" } } }, name: { startsWithInsensitive: \\"id 1\\" }}"`;
+
+exports[`TableBlock SDK > Substream: Builds a graphql query from table block filters 4`] = `"{ and: [{ geoEntityTypesByEntityId: { some: { typeId: { equalTo: \\"type-id\\" } } } } { triplesByEntityId: { some: { attributeId: { equalTo: \\"type\\" }, stringValue: { equalToInsensitive: \\"Value 1\\"}, isStale: { equalTo: false } } } }, { triplesByEntityId: { some: { attributeId: { equalTo: \\"type\\" }, entityValueId: { equalTo: \\"id 1\\"}, isStale: { equalTo: false } } } }, { name: { startsWithInsensitive: \\"id 1\\" } }] }"`;
+
+exports[`TableBlock SDK > Substream: Builds a graphql query from table block filters 5`] = `
+"{ geoEntityTypesByEntityId: { some: { typeId: { equalTo: \\"type-id\\" } } }, triplesByEntityId: {
+          some: {
+            spaceId: { equalTo: \\"0x0000000000000000000000000000000000000000\\" },
+            isStale: { equalTo: false }
+          }
+        }}"
+`;

--- a/apps/web/core/blocks-sdk/table.test.ts
+++ b/apps/web/core/blocks-sdk/table.test.ts
@@ -3,7 +3,11 @@ import { describe, expect, it } from 'vitest';
 
 import { MockNetworkData } from '~/core/io';
 
-import { createFiltersFromGraphQLString, createGraphQLStringFromFilters } from './table';
+import {
+  createFiltersFromGraphQLString,
+  createGraphQLStringFromFilters,
+  createGraphQLStringFromFiltersV2,
+} from './table';
 
 describe('TableBlock SDK', () => {
   /**
@@ -228,5 +232,86 @@ describe('TableBlock SDK', () => {
         valueName: null,
       },
     ]);
+  });
+
+  it('Builds a graphql query from table block filters for the postgraphile-based substreams API', () => {
+    const stringFilter = createGraphQLStringFromFiltersV2(
+      [
+        {
+          columnId: 'type',
+          value: 'Value 1',
+          valueType: 'string',
+        },
+      ],
+      'type-id'
+    );
+
+    expect(stringFilter).toMatchSnapshot();
+
+    const entityFilter = createGraphQLStringFromFiltersV2(
+      [
+        {
+          columnId: 'type',
+          value: 'id 1',
+          valueType: 'entity',
+        },
+      ],
+      'type-id'
+    );
+
+    expect(entityFilter).toMatchSnapshot();
+
+    const nameFilter = createGraphQLStringFromFiltersV2(
+      [
+        {
+          columnId: SYSTEM_IDS.NAME,
+          value: 'id 1',
+          valueType: 'string',
+        },
+      ],
+      'type-id'
+    );
+
+    expect(nameFilter).toMatchSnapshot();
+
+    const andFilter = createGraphQLStringFromFiltersV2(
+      [
+        {
+          columnId: 'type',
+          value: 'Value 1',
+          valueType: 'string',
+        },
+        {
+          columnId: 'type',
+          value: 'id 1',
+          valueType: 'entity',
+        },
+        {
+          columnId: SYSTEM_IDS.NAME,
+          value: 'id 1',
+          valueType: 'string',
+        },
+      ],
+      'type-id'
+    );
+
+    expect(andFilter).toMatchSnapshot();
+
+    const spaceFilter = createGraphQLStringFromFiltersV2(
+      [
+        {
+          columnId: SYSTEM_IDS.SPACE,
+          valueType: 'string',
+          value: '0x0000000000000000000000000000000000000000',
+        },
+      ],
+      'type-id'
+    );
+
+    expect(spaceFilter).toMatchSnapshot();
+
+    const nullTypeIdFilter = createGraphQLStringFromFiltersV2([], null);
+
+    expect(nullTypeIdFilter).toEqual('');
   });
 });

--- a/apps/web/core/blocks-sdk/table.ts
+++ b/apps/web/core/blocks-sdk/table.ts
@@ -302,19 +302,20 @@ export function createGraphQLStringFromFiltersV2(
         // against newer versions of the protocol.
         return `triplesByEntityId: {
           some: {
-            spaceId: { equalTo: "${getAddress(filter.value)}" }
+            spaceId: { equalTo: "${getAddress(filter.value)}" },
+            isStale: { equalTo: false }
           }
         }`;
       }
 
       if (filter.valueType === 'entity') {
         // value is the ID of the relation
-        return `triplesByEntityId: { some: { attributeId: { equalTo: "${filter.columnId}" }, entityValueId: { equalTo: "${filter.value}"} } }`;
+        return `triplesByEntityId: { some: { attributeId: { equalTo: "${filter.columnId}" }, entityValueId: { equalTo: "${filter.value}"}, isStale: { equalTo: false } } }`;
       }
 
       if (filter.valueType === 'string') {
         // value is just the stringValue of the triple
-        return `triplesByEntityId: { some: { attributeId: { equalTo: "${filter.columnId}" }, stringValue: { equalToInsensitive: "${filter.value}"} } }`;
+        return `triplesByEntityId: { some: { attributeId: { equalTo: "${filter.columnId}" }, stringValue: { equalToInsensitive: "${filter.value}"}, isStale: { equalTo: false } } }`;
       }
 
       // We don't support other value types yet

--- a/apps/web/core/io/subgraph/fetch-table-row-entities.ts
+++ b/apps/web/core/io/subgraph/fetch-table-row-entities.ts
@@ -7,7 +7,7 @@ import { Entity as IEntity } from '~/core/types';
 import { Entity } from '~/core/utils/entity';
 
 import { graphql } from './graphql';
-import { NetworkEntity, SubstreamNetworkEntity, fromNetworkTriples } from './network-local-mapping';
+import { SubstreamNetworkEntity, fromNetworkTriples } from './network-local-mapping';
 
 // this differs from the fetchEntities method in that we pass in a custom graphql string that represents
 // the set of custom Table filters set on the table. These filters have small differences from the other


### PR DESCRIPTION
Entities now store _all_ triples that have ever been applied to any entity, so we need to make sure we're only filtering on active triples