### PR TITLE
fix: add space type to created profile

### DIFF
--- a/apps/web/core/io/publish/publish.ts
+++ b/apps/web/core/io/publish/publish.ts
@@ -117,7 +117,7 @@ export async function makeProposal({
     if (waitForTransactionEffect.status !== 'success') {
       return yield* awaited(
         Effect.fail(
-          new TransactionRevertedError(`Transaction reverted: 
+          new TransactionRevertedError(`Transaction reverted:
       hash: ${waitForTransactionEffect.transactionHash}
       status: ${waitForTransactionEffect.status}
       blockNumber: ${waitForTransactionEffect.blockNumber}
@@ -128,7 +128,7 @@ export async function makeProposal({
       );
     }
 
-    console.log(`Transaction successful. Receipt: 
+    console.log(`Transaction successful. Receipt:
     hash: ${waitForTransactionEffect.transactionHash}
     status: ${waitForTransactionEffect.status}
     blockNumber: ${waitForTransactionEffect.blockNumber}

--- a/apps/web/partials/onboarding/create-profile-dialog.tsx
+++ b/apps/web/partials/onboarding/create-profile-dialog.tsx
@@ -139,7 +139,7 @@ export const CreateProfileDialog = () => {
         });
       }
 
-      const typeTriple: OmitStrict<Triple, 'id'> = {
+      const personTypeTriple: OmitStrict<Triple, 'id'> = {
         attributeId: SYSTEM_IDS.TYPES,
         attributeName: 'Types',
         entityId: onchainProfile.id,
@@ -152,20 +152,11 @@ export const CreateProfileDialog = () => {
         },
       };
 
-      actions.push({
-        type: 'createTriple',
-        id: ID.createTripleId(typeTriple),
-        ...typeTriple,
-      });
-
-      // Add triples for creating a space configuration entity
-      const spaceConfigurationId = ID.createEntityId();
-
-      const spaceTriple: OmitStrict<Triple, 'id'> = {
+      const spaceTypeTriple: OmitStrict<Triple, 'id'> = {
         attributeId: SYSTEM_IDS.TYPES,
         attributeName: 'Types',
-        entityId: spaceConfigurationId,
-        entityName: `${name ?? address}'s Space`,
+        entityId: onchainProfile.id,
+        entityName: name ?? '',
         space: onchainProfile.homeSpace,
         value: {
           type: 'entity',
@@ -176,27 +167,14 @@ export const CreateProfileDialog = () => {
 
       actions.push({
         type: 'createTriple',
-        id: ID.createTripleId(spaceTriple),
-        ...spaceTriple,
+        id: ID.createTripleId(personTypeTriple),
+        ...personTypeTriple,
       });
-
-      const spaceNameTriple: OmitStrict<Triple, 'id'> = {
-        attributeId: SYSTEM_IDS.NAME,
-        attributeName: 'Name',
-        entityId: spaceConfigurationId,
-        entityName: `${name ?? address}'s Space`,
-        space: onchainProfile.homeSpace,
-        value: {
-          type: 'string',
-          value: `${name ?? address}'s Space`,
-          id: ID.createValueId(),
-        },
-      };
 
       actions.push({
         type: 'createTriple',
-        id: ID.createTripleId(spaceNameTriple),
-        ...spaceNameTriple,
+        id: ID.createTripleId(spaceTypeTriple),
+        ...spaceTypeTriple,
       });
 
       try {


### PR DESCRIPTION
We have a separate flow for creating a profile if a wallet has an on-chain profile but not a Geo entity profile. We did not update this flow when updating to adding the space type to the entity itself instead of creating a separate space configuration entity