### PR TITLE
fix: jittered backoff in onboarding

### DIFF
--- a/apps/web/app/api/company/deploy/make-company-effect.ts
+++ b/apps/web/app/api/company/deploy/make-company-effect.ts
@@ -297,20 +297,20 @@ export async function makeCompanyEffect(
 
   const onboardEffect = Effect.gen(function* (unwrap) {
     // Add geo profile entity to new space
-    yield* unwrap(Effect.retry(profileEffect, Schedule.exponential('1 seconds')));
+    yield* unwrap(Effect.retry(profileEffect, Schedule.exponential('100 millis').pipe(Schedule.jittered)));
 
     // @TODO: Batch?
     // Configure roles in proxy contract
     for (const role of ROLES) {
       const grantRoleEffect = createGrantRoleEffect(role);
-      yield* unwrap(Effect.retry(grantRoleEffect, Schedule.exponential('1 seconds')));
+      yield* unwrap(Effect.retry(grantRoleEffect, Schedule.exponential('100 millis').pipe(Schedule.jittered)));
     }
 
     // @TODO Batch?
     // Renounce deployer roles in proxy contract
     for (const role of ROLES) {
       const renounceRoleEffect = createRenounceRoleEffect(role);
-      yield* unwrap(Effect.retry(renounceRoleEffect, Schedule.exponential('1 seconds')));
+      yield* unwrap(Effect.retry(renounceRoleEffect, Schedule.exponential('100 millis').pipe(Schedule.jittered)));
     }
   });
 

--- a/apps/web/app/api/nonprofit/deploy/make-nonprofit-effect.ts
+++ b/apps/web/app/api/nonprofit/deploy/make-nonprofit-effect.ts
@@ -316,20 +316,20 @@ export async function makeNonprofitEffect(
 
   const onboardEffect = Effect.gen(function* (unwrap) {
     // Add geo profile entity to new space
-    yield* unwrap(Effect.retry(profileEffect, Schedule.exponential('1 seconds')));
+    yield* unwrap(Effect.retry(profileEffect, Schedule.exponential('100 millis').pipe(Schedule.jittered)));
 
     // @TODO: Batch?
     // Configure roles in proxy contract
     for (const role of ROLES) {
       const grantRoleEffect = createGrantRoleEffect(role);
-      yield* unwrap(Effect.retry(grantRoleEffect, Schedule.exponential('1 seconds')));
+      yield* unwrap(Effect.retry(grantRoleEffect, Schedule.exponential('100 millis').pipe(Schedule.jittered)));
     }
 
     // @TODO Batch?
     // Renounce deployer roles in proxy contract
     for (const role of ROLES) {
       const renounceRoleEffect = createRenounceRoleEffect(role);
-      yield* unwrap(Effect.retry(renounceRoleEffect, Schedule.exponential('1 seconds')));
+      yield* unwrap(Effect.retry(renounceRoleEffect, Schedule.exponential('100 millis').pipe(Schedule.jittered)));
     }
   });
 

--- a/apps/web/app/api/person/deploy/make-person-effect.ts
+++ b/apps/web/app/api/person/deploy/make-person-effect.ts
@@ -297,20 +297,20 @@ export async function makePersonEffect(
 
   const onboardEffect = Effect.gen(function* (unwrap) {
     // Add geo profile entity to new space
-    yield* unwrap(Effect.retry(profileEffect, Schedule.exponential('1 seconds')));
+    yield* unwrap(Effect.retry(profileEffect, Schedule.exponential('100 millis').pipe(Schedule.jittered)));
 
     // @TODO: Batch?
     // Configure roles in proxy contract
     for (const role of ROLES) {
       const grantRoleEffect = createGrantRoleEffect(role);
-      yield* unwrap(Effect.retry(grantRoleEffect, Schedule.exponential('1 seconds')));
+      yield* unwrap(Effect.retry(grantRoleEffect, Schedule.exponential('100 millis').pipe(Schedule.jittered)));
     }
 
     // @TODO Batch?
     // Renounce deployer roles in proxy contract
     for (const role of ROLES) {
       const renounceRoleEffect = createRenounceRoleEffect(role);
-      yield* unwrap(Effect.retry(renounceRoleEffect, Schedule.exponential('1 seconds')));
+      yield* unwrap(Effect.retry(renounceRoleEffect, Schedule.exponential('100 millis').pipe(Schedule.jittered)));
     }
   });
 

--- a/apps/web/core/io/publish/contracts.ts
+++ b/apps/web/core/io/publish/contracts.ts
@@ -39,6 +39,11 @@ export async function createProfileEntity({
   }
 
   const createProfileResponse = await fetch(url);
+
+  if (!createProfileResponse.ok || createProfileResponse.status >= 400) {
+    console.error('Unable to create profile', createProfileResponse.status, createProfileResponse.statusText);
+  }
+
   return await createProfileResponse.json();
 }
 

--- a/apps/web/core/io/publish/contracts.ts
+++ b/apps/web/core/io/publish/contracts.ts
@@ -5,6 +5,18 @@ export async function deploySpaceContract({ account }: { account: string }): Pro
 
   // @TODO: Error and success handling with Effect
   const spaceContractDeploymentResponse = await fetch(url);
+
+  const createAndConfigureSpaceResponse = await fetch(url);
+
+  if (!createAndConfigureSpaceResponse.ok || createAndConfigureSpaceResponse.status >= 400) {
+    console.error(
+      'Unable to create and configure space',
+      createAndConfigureSpaceResponse.status,
+      createAndConfigureSpaceResponse.statusText
+    );
+    throw new Error(`Unable to create and configure space: ${createAndConfigureSpaceResponse.statusText}`);
+  }
+
   return await spaceContractDeploymentResponse.json();
 }
 
@@ -42,6 +54,7 @@ export async function createProfileEntity({
 
   if (!createProfileResponse.ok || createProfileResponse.status >= 400) {
     console.error('Unable to create profile', createProfileResponse.status, createProfileResponse.statusText);
+    throw new Error(`Unable to create profile: ${createProfileResponse.statusText}`);
   }
 
   return await createProfileResponse.json();
@@ -68,6 +81,16 @@ export async function createSpaceWithEntities({
     url.searchParams.set('spaceAvatarUri', spaceAvatarUri);
   }
 
-  const createProfileResponse = await fetch(url);
-  return await createProfileResponse.json();
+  const createSpaceEntitiesResponse = await fetch(url);
+
+  if (!createSpaceEntitiesResponse.ok || createSpaceEntitiesResponse.status >= 400) {
+    console.error(
+      'Unable to create entities in space',
+      createSpaceEntitiesResponse.status,
+      createSpaceEntitiesResponse.statusText
+    );
+    throw new Error(`Unable to create entities in space: ${createSpaceEntitiesResponse.statusText}`);
+  }
+
+  return await createSpaceEntitiesResponse.json();
 }


### PR DESCRIPTION
We might be running into RPC rate limits in our node providers. We currently only have exponential backoff when making contract calls. This PR adds jittering to the calls and lowers the base value for the backoff.

This PR also adds some very basic client-side logging to debug any errors we get back from the server during onboarding to make sure errors in both environments align.