### PR TITLE
fix: align default avatar to use address instead of id

### DIFF
--- a/apps/web/app/home/component.tsx
+++ b/apps/web/app/home/component.tsx
@@ -327,7 +327,7 @@ const MembershipRequest = ({ request, onRequestProcessed }: MembershipRequestPro
         <Link href={profile?.profileLink ?? ''} className="flex items-center justify-between">
           <div className="text-smallTitle">{profile?.name ?? profile.id}</div>
           <div className="relative h-5 w-5 overflow-hidden rounded-full">
-            <Avatar value={profile.id} avatarUrl={profile?.avatarUrl} size={20} />
+            <Avatar value={profile.address} avatarUrl={profile?.avatarUrl} size={20} />
           </div>
         </Link>
         <Link

--- a/apps/web/partials/governance/governance-proposals-list.tsx
+++ b/apps/web/partials/governance/governance-proposals-list.tsx
@@ -43,7 +43,7 @@ export async function GovernanceProposalsList({ spaceId }: Props) {
                     className="flex items-center gap-1.5 transition-colors duration-75 hover:text-text"
                   >
                     <div className="relative h-3 w-3 overflow-hidden rounded-full">
-                      <Avatar avatarUrl={p.createdBy.avatarUrl} value={p.createdBy.id} />
+                      <Avatar avatarUrl={p.createdBy.avatarUrl} value={p.createdBy.address} />
                     </div>
                     <p>{p.createdBy.name ?? p.createdBy.id}</p>
                   </Link>

--- a/apps/web/partials/space-page/space-editors-chip.tsx
+++ b/apps/web/partials/space-page/space-editors-chip.tsx
@@ -18,7 +18,7 @@ export async function SpaceEditorsChip({ spaceId }: Props) {
       <AvatarGroup>
         {firstThreeEditors.map(editor => (
           <AvatarGroup.Item key={editor.id}>
-            <Avatar priority size={12} avatarUrl={editor.avatarUrl} value={editor.id} />
+            <Avatar priority size={12} avatarUrl={editor.avatarUrl} value={editor.address} />
           </AvatarGroup.Item>
         ))}
       </AvatarGroup>

--- a/apps/web/partials/space-page/space-member-row.tsx
+++ b/apps/web/partials/space-page/space-member-row.tsx
@@ -15,7 +15,7 @@ export function MemberRow({ editor }: EditorRowProps) {
       className="flex flex-1 items-center gap-2 p-2 transition-colors duration-150 hover:bg-divider"
     >
       <div className="relative h-8 w-8 overflow-hidden rounded-full">
-        <Avatar size={32} avatarUrl={editor.avatarUrl} value={editor.address ?? ''} />
+        <Avatar size={32} avatarUrl={editor.avatarUrl} value={editor.address} />
       </div>
       <p className="text-metadataMedium">{editor.name}</p>
     </Link>

--- a/apps/web/partials/space-page/space-members-chip.tsx
+++ b/apps/web/partials/space-page/space-members-chip.tsx
@@ -19,7 +19,7 @@ export async function SpaceMembersChip({ spaceId }: Props) {
       <AvatarGroup>
         {firstThreeMembers.map(editor => (
           <AvatarGroup.Item key={editor.id}>
-            <Avatar priority size={12} avatarUrl={editor.avatarUrl} value={editor.id} />
+            <Avatar priority size={12} avatarUrl={editor.avatarUrl} value={editor.address} />
           </AvatarGroup.Item>
         ))}
       </AvatarGroup>


### PR DESCRIPTION
Currently in some places we use an editor/profile's id as the seed for the avatar's default image and some places we use the address. This PR aligns all the usage to use the address as there may be instances where a user does not have a Geo profile.