### PR TITLE
fix: use v1 graphql filters when mapping to entity and local state

### DIFF
--- a/apps/web/core/state/editor-store.tsx
+++ b/apps/web/core/state/editor-store.tsx
@@ -333,7 +333,7 @@ export function useEditorStore() {
               value: {
                 id: ID.createValueId(),
                 type: 'string',
-                value: TableBlockSdk.createGraphQLStringFromFiltersV2(
+                value: TableBlockSdk.createGraphQLStringFromFilters(
                   [
                     {
                       columnId: SYSTEM_IDS.SPACE,

--- a/apps/web/core/state/table-block-store.tsx
+++ b/apps/web/core/state/table-block-store.tsx
@@ -248,7 +248,7 @@ export function useTableBlock() {
 
       // We can just set the string as empty if the new state is empty. Alternatively we just delete the triple.
       const newFiltersString =
-        newState.length === 0 ? '' : TableBlockSdk.createGraphQLStringFromFiltersV2(newState, selectedType.entityId);
+        newState.length === 0 ? '' : TableBlockSdk.createGraphQLStringFromFilters(newState, selectedType.entityId);
 
       const entityName = Entity.name(nameTriple ? [nameTriple] : []) ?? '';
 


### PR DESCRIPTION
We then map to the v2 filters when making queries