### PR TITLE
feat: substream should handle many names for an entity

### DIFF
--- a/apps/web/core/environment/environment.ts
+++ b/apps/web/core/environment/environment.ts
@@ -48,7 +48,7 @@ export const options: Record<AppEnv, AppConfig> = {
     ipfs: 'https://api.thegraph.com/ipfs',
     membershipSubgraph: 'https://api.thegraph.com/subgraphs/name/baiirun/geo-membership-logs',
     profileSubgraph: 'https://api.thegraph.com/subgraphs/name/baiirun/geo-profile-registry',
-    api: 'https://geobrowser.up.railway.app/graphql',
+    api: 'https://geo-protocol.up.railway.app/graphql',
 
     subgraph: 'https://api.thegraph.com/subgraphs/name/baiirun/geo',
     permissionlessSubgraph: 'https://api.thegraph.com/subgraphs/name/baiirun/geo-permissionless',


### PR DESCRIPTION
Currently if an entity has multiple names and we delete one, we delete the name association on the entity itself. If the entity has any _additional_ names to the one that was deleted, we should instead update the entity's name to one of them.

There are probably better ways of doing this with some derived/computed columns in Postgres, but this is the simplest approach for now.