### PR TITLE
feat: remove adding to root space when deploying spaces

### DIFF
--- a/apps/web/app/api/company/deploy/make-company-effect.ts
+++ b/apps/web/app/api/company/deploy/make-company-effect.ts
@@ -178,7 +178,7 @@ export async function makeCompanyEffect(
 
       slog({
         requestId,
-        message: `Adding profile to space ${spaceAddress}`,
+        message: `Adding company entity to space ${spaceAddress}`,
         account: userAccount,
       });
 

--- a/apps/web/app/api/contracts/deploy/make-deploy-effect.ts
+++ b/apps/web/app/api/contracts/deploy/make-deploy-effect.ts
@@ -1,20 +1,13 @@
 import { SpaceArtifact } from '@geogenesis/contracts';
 import { SYSTEM_IDS } from '@geogenesis/ids';
 import BeaconProxy from '@openzeppelin/upgrades-core/artifacts/@openzeppelin/contracts/proxy/beacon/BeaconProxy.sol/BeaconProxy.json';
-// import UpgradeableBeacon from '@openzeppelin/upgrades-core/artifacts/@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol/UpgradeableBeacon.json';
 import * as Effect from 'effect/Effect';
 import * as Schedule from 'effect/Schedule';
 import { createPublicClient, createWalletClient, http } from 'viem';
 import { privateKeyToAccount } from 'viem/accounts';
 import { polygon } from 'viem/chains';
 
-import { Environment } from '~/core/environment';
-import { ID } from '~/core/id';
-import { StorageClient } from '~/core/io/storage/storage';
-import { OmitStrict, Triple } from '~/core/types';
 import { slog } from '~/core/utils/utils';
-
-import { makeProposalServer } from '../../make-proposal-server';
 
 class ProxyBeaconInitializeFailedError extends Error {
   readonly _tag = 'ProxyBeaconInitializeFailedError';
@@ -142,88 +135,6 @@ export function makeDeployEffect(requestId: string, { account: userAccount }: Us
       },
     });
 
-  // Logic for registering the proxy contract address in the permissionless registry.
-  // We add the contract address to the space registry as a Geo Entity with a specific "Indexed Space"
-  // type. This triggers the permissionless subgraph to create a dynamic data source for this address
-  // and begin indexing events from this address.
-  //
-  // @TODO: With substreams we won't need to add the contract address to the registry since substreams
-  // map over every block.
-  const createRegisterSpaceEffect = (contractAddress: `0x${string}`) =>
-    Effect.tryPromise({
-      try: async () => {
-        const spaceAddressTripleWithoutId: OmitStrict<Triple, 'id'> = {
-          entityId: ID.createEntityId(),
-          entityName: `${userAccount}'s Space`,
-          attributeId: SYSTEM_IDS.SPACE,
-          attributeName: 'Space',
-          space: SYSTEM_IDS.PERMISSIONLESS_SPACE_REGISTRY_ADDRESS,
-          value: {
-            type: 'string',
-            value: contractAddress as string,
-            id: ID.createValueId(),
-          },
-        };
-
-        const spaceNameTripleWithoutId: OmitStrict<Triple, 'id'> = {
-          entityId: ID.createEntityId(),
-          entityName: `${userAccount}'s Space`,
-          attributeId: SYSTEM_IDS.NAME,
-          attributeName: 'Name',
-          space: SYSTEM_IDS.PERMISSIONLESS_SPACE_REGISTRY_ADDRESS,
-          value: {
-            type: 'string',
-            value: `${userAccount}'s Space`,
-            id: ID.createValueId(),
-          },
-        };
-
-        slog({
-          requestId,
-          message: `Adding space ${contractAddress} for ${userAccount} to space registry at ${SYSTEM_IDS.PERMISSIONLESS_SPACE_REGISTRY_ADDRESS}`,
-          account: userAccount,
-        });
-
-        const proposalEffect = await makeProposalServer({
-          actions: [
-            {
-              type: 'createTriple',
-              id: ID.createTripleId(spaceAddressTripleWithoutId),
-              ...spaceAddressTripleWithoutId,
-            },
-            {
-              type: 'createTriple',
-              id: ID.createTripleId(spaceNameTripleWithoutId),
-              ...spaceNameTripleWithoutId,
-            },
-          ],
-          name: `Adding space ${contractAddress} for ${userAccount} to space registry`,
-          space: SYSTEM_IDS.PERMISSIONLESS_SPACE_REGISTRY_ADDRESS,
-          storageClient: new StorageClient(Environment.getConfig(process.env.NEXT_PUBLIC_APP_ENV).ipfs),
-          account,
-          wallet: client,
-          publicClient,
-        });
-
-        await Effect.runPromise(proposalEffect);
-
-        slog({
-          requestId,
-          message: `Successfully added space ${contractAddress} to space registry`,
-          account: userAccount,
-        });
-      },
-      catch: error => {
-        slog({
-          level: 'error',
-          requestId,
-          message: `Adding space ${contractAddress} to space registry failed: ${(error as Error).message}`,
-          account: userAccount,
-        });
-        return new AddToSpaceRegistryError();
-      },
-    });
-
   // Logic for configuring roles in the proxy contract. We need to configure the roles after adding
   // to the registry. This is because the indexer will not pick up events that happen before the indexer starts
   // indexing a dynamic data source. `configureRoles` emits events for configuring the initial roles for the space
@@ -289,13 +200,6 @@ export function makeDeployEffect(requestId: string, { account: userAccount }: Us
       Schedule.exponential('100 millis').pipe(Schedule.jittered)
     );
     yield* unwrap(initializeEffect);
-
-    // Add the new space to the permissionless space registry
-    const registerSpaceEffect = Effect.retry(
-      createRegisterSpaceEffect(deployProxyResult.contractAddress),
-      Schedule.exponential('100 millis').pipe(Schedule.jittered)
-    );
-    yield* unwrap(registerSpaceEffect);
 
     // Configure roles in proxy contract. We need to configure the roles after adding to the registry.
     const configureRolesEffect = Effect.retry(

--- a/apps/web/app/api/contracts/deploy/make-deploy-effect.ts
+++ b/apps/web/app/api/contracts/deploy/make-deploy-effect.ts
@@ -25,10 +25,6 @@ class SpaceProxyContractAddressNullError extends Error {
   readonly _tag = 'SpaceProxyContractAddressNullError';
 }
 
-class AddToSpaceRegistryError extends Error {
-  readonly _tag = 'AddToSpaceRegistryError';
-}
-
 interface UserConfig {
   account: `0x${string}`;
 }

--- a/apps/web/app/api/contracts/deploy/route.ts
+++ b/apps/web/app/api/contracts/deploy/route.ts
@@ -78,17 +78,6 @@ export async function GET(request: Request) {
             statusText: error.message,
           }
         );
-      case 'AddToSpaceRegistryError':
-        return new Response(
-          JSON.stringify({
-            error: 'Could not add contract to space registry',
-            reason: `Could not add space to space registry for user: ${userAccount}`,
-          }),
-          {
-            status: 500,
-            statusText: error.message,
-          }
-        );
       default:
         return new Response(
           JSON.stringify({

--- a/apps/web/app/api/errors.ts
+++ b/apps/web/app/api/errors.ts
@@ -29,7 +29,3 @@ export class ProxyBeaconDeploymentFailedError extends Error {
 export class SpaceProxyContractAddressNullError extends Error {
   readonly _tag = 'SpaceProxyContractAddressNullError';
 }
-
-export class AddToSpaceRegistryError extends Error {
-  readonly _tag = 'AddToSpaceRegistryError';
-}

--- a/apps/web/app/api/make-proposal-server.ts
+++ b/apps/web/app/api/make-proposal-server.ts
@@ -1,5 +1,6 @@
 import { Root } from '@geogenesis/action-schema';
 import { SpaceAbi } from '@geogenesis/contracts';
+import { Schedule } from 'effect';
 import * as Effect from 'effect/Effect';
 import { PrivateKeyAccount, PublicClient, WalletClient } from 'viem';
 
@@ -31,6 +32,10 @@ export class TransactionPrepareFailedError extends Error {
 
 export class TransactionWriteFailedError extends Error {
   _tag = 'TransactionWriteFailedError';
+}
+
+export class IpfsUploadFailedError extends Error {
+  _tag = 'IpfsUploadFailedError';
 }
 
 export type MakeProposalServerOptions = {
@@ -66,7 +71,15 @@ export async function makeProposalServer({
       name,
     };
 
-    const cidString = await storageClient.uploadObject(root);
+    const uploadEffect = Effect.retry(
+      Effect.tryPromise({
+        try: () => storageClient.uploadObject(root),
+        catch: error => new IpfsUploadFailedError(`IPFS upload failed: ${error}`),
+      }),
+      Schedule.exponential('100 millis').pipe(Schedule.jittered)
+    );
+
+    const cidString = await Effect.runPromise(uploadEffect);
     cids.push(`ipfs://${cidString}`);
   }
 
@@ -83,18 +96,25 @@ export async function makeProposalServer({
   });
 
   const writeTxEffect = Effect.gen(function* (awaited) {
-    const contractConfig = yield* awaited(prepareTxEffect);
+    const contractConfig = yield* awaited(
+      Effect.retry(prepareTxEffect, Schedule.exponential('100 millis').pipe(Schedule.jittered))
+    );
 
     return yield* awaited(
-      Effect.tryPromise({
-        try: () => wallet.writeContract(contractConfig.request),
-        catch: error => new TransactionWriteFailedError(`Publish failed: ${error}`),
-      })
+      Effect.retry(
+        Effect.tryPromise({
+          try: () => wallet.writeContract(contractConfig.request),
+          catch: error => new TransactionWriteFailedError(`Publish failed: ${error}`),
+        }),
+        Schedule.exponential('100 millis').pipe(Schedule.jittered)
+      )
     );
   });
 
   const publishProgram = Effect.gen(function* (awaited) {
-    const writeTxHash = yield* awaited(writeTxEffect);
+    const writeTxHash = yield* awaited(
+      Effect.retry(writeTxEffect, Schedule.exponential('100 millis').pipe(Schedule.jittered))
+    );
 
     const waitForTransactionEffect = yield* awaited(
       Effect.tryPromise({

--- a/apps/web/app/api/nonprofit/deploy/make-nonprofit-effect.ts
+++ b/apps/web/app/api/nonprofit/deploy/make-nonprofit-effect.ts
@@ -202,7 +202,7 @@ export async function makeNonprofitEffect(
 
       slog({
         requestId,
-        message: `Adding profile to space ${spaceAddress}`,
+        message: `Adding nonprofit entity to space ${spaceAddress}`,
         account: userAccount,
       });
 

--- a/apps/web/app/api/space/deploy/make-create-entities-effect.ts
+++ b/apps/web/app/api/space/deploy/make-create-entities-effect.ts
@@ -177,7 +177,7 @@ export function makeCreateEntitiesEffect(
 
       slog({
         requestId,
-        message: `Adding profile to space ${spaceAddress}`,
+        message: `Adding entities for ${type} space type to space ${spaceAddress}`,
       });
 
       const proposalEffect = await makeProposalServer({

--- a/apps/web/app/api/space/deploy/make-deploy-space-effect.ts
+++ b/apps/web/app/api/space/deploy/make-deploy-space-effect.ts
@@ -1,27 +1,20 @@
 import { SpaceArtifact } from '@geogenesis/contracts';
 import { SYSTEM_IDS } from '@geogenesis/ids';
 import BeaconProxy from '@openzeppelin/upgrades-core/artifacts/@openzeppelin/contracts/proxy/beacon/BeaconProxy.sol/BeaconProxy.json';
-// import UpgradeableBeacon from '@openzeppelin/upgrades-core/artifacts/@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol/UpgradeableBeacon.json';
 import * as Effect from 'effect/Effect';
 import * as Schedule from 'effect/Schedule';
 import { createPublicClient, createWalletClient, http } from 'viem';
 import { privateKeyToAccount } from 'viem/accounts';
 import { polygon } from 'viem/chains';
 
-import { Environment } from '~/core/environment';
-import { ID } from '~/core/id';
-import { StorageClient } from '~/core/io/storage/storage';
-import { OmitStrict, Triple } from '~/core/types';
 import { slog } from '~/core/utils/utils';
 
 import {
-  AddToSpaceRegistryError,
   ProxyBeaconConfigureRolesFailedError,
   ProxyBeaconDeploymentFailedError,
   ProxyBeaconInitializeFailedError,
   SpaceProxyContractAddressNullError,
 } from '../../errors';
-import { makeProposalServer } from '../../make-proposal-server';
 
 interface UserConfig {
   account: `0x${string}`;
@@ -129,88 +122,6 @@ export function makeDeploySpaceEffect(requestId: string, { account: userAccount 
       },
     });
 
-  // Logic for registering the proxy contract address in the permissionless registry.
-  // We add the contract address to the space registry as a Geo Entity with a specific "Indexed Space"
-  // type. This triggers the permissionless subgraph to create a dynamic data source for this address
-  // and begin indexing events from this address.
-  //
-  // @TODO: With substreams we won't need to add the contract address to the registry since substreams
-  // map over every block.
-  const createRegisterSpaceEffect = (contractAddress: `0x${string}`) =>
-    Effect.tryPromise({
-      try: async () => {
-        const spaceAddressTripleWithoutId: OmitStrict<Triple, 'id'> = {
-          entityId: ID.createEntityId(),
-          entityName: `${userAccount}'s Space`,
-          attributeId: SYSTEM_IDS.SPACE,
-          attributeName: 'Space',
-          space: SYSTEM_IDS.PERMISSIONLESS_SPACE_REGISTRY_ADDRESS,
-          value: {
-            type: 'string',
-            value: contractAddress as string,
-            id: ID.createValueId(),
-          },
-        };
-
-        const spaceNameTripleWithoutId: OmitStrict<Triple, 'id'> = {
-          entityId: ID.createEntityId(),
-          entityName: `${userAccount}'s Space`,
-          attributeId: SYSTEM_IDS.NAME,
-          attributeName: 'Name',
-          space: SYSTEM_IDS.PERMISSIONLESS_SPACE_REGISTRY_ADDRESS,
-          value: {
-            type: 'string',
-            value: `${userAccount}'s Space`,
-            id: ID.createValueId(),
-          },
-        };
-
-        slog({
-          requestId,
-          message: `Adding space ${contractAddress} for ${userAccount} to space registry at ${SYSTEM_IDS.PERMISSIONLESS_SPACE_REGISTRY_ADDRESS}`,
-          account: userAccount,
-        });
-
-        const proposalEffect = await makeProposalServer({
-          actions: [
-            {
-              type: 'createTriple',
-              id: ID.createTripleId(spaceAddressTripleWithoutId),
-              ...spaceAddressTripleWithoutId,
-            },
-            {
-              type: 'createTriple',
-              id: ID.createTripleId(spaceNameTripleWithoutId),
-              ...spaceNameTripleWithoutId,
-            },
-          ],
-          name: `Adding space ${contractAddress} for ${userAccount} to space registry`,
-          space: SYSTEM_IDS.PERMISSIONLESS_SPACE_REGISTRY_ADDRESS,
-          storageClient: new StorageClient(Environment.getConfig(process.env.NEXT_PUBLIC_APP_ENV).ipfs),
-          account,
-          wallet: client,
-          publicClient,
-        });
-
-        await Effect.runPromise(proposalEffect);
-
-        slog({
-          requestId,
-          message: `Successfully added space ${contractAddress} to space registry`,
-          account: userAccount,
-        });
-      },
-      catch: error => {
-        slog({
-          level: 'error',
-          requestId,
-          message: `Adding space ${contractAddress} to space registry failed: ${(error as Error).message}`,
-          account: userAccount,
-        });
-        return new AddToSpaceRegistryError();
-      },
-    });
-
   // Logic for configuring roles in the proxy contract. We need to configure the roles after adding
   // to the registry. This is because the indexer will not pick up events that happen before the indexer starts
   // indexing a dynamic data source. `configureRoles` emits events for configuring the initial roles for the space
@@ -276,13 +187,6 @@ export function makeDeploySpaceEffect(requestId: string, { account: userAccount 
       Schedule.exponential('1 seconds')
     );
     yield* unwrap(initializeEffect);
-
-    // Add the new space to the permissionless space registry
-    const registerSpaceEffect = Effect.retry(
-      createRegisterSpaceEffect(deployProxyResult.contractAddress),
-      Schedule.exponential('1 seconds')
-    );
-    yield* unwrap(registerSpaceEffect);
 
     // Configure roles in proxy contract. We need to configure the roles after adding to the registry.
     // This is because the indexer will not pick up events that happen before the indexer starts indexing

--- a/apps/web/app/api/space/deploy/route.ts
+++ b/apps/web/app/api/space/deploy/route.ts
@@ -133,17 +133,6 @@ export async function GET(request: Request) {
             statusText: error.message,
           }
         );
-      case 'AddToSpaceRegistryError':
-        return new Response(
-          JSON.stringify({
-            error: 'Could not add contract to space registry',
-            reason: `Could not add space to space registry for user: ${userAccount}`,
-          }),
-          {
-            status: 500,
-            statusText: error.message,
-          }
-        );
       case 'CreateSpaceEntitiesFailedError':
         return new Response(
           JSON.stringify({


### PR DESCRIPTION
With substreams we don't rely on spaces being added to the space registry anymore since we track all space creation being done onchain.