### PR TITLE
fix(substream): fetch from multiple gateway urls

### DIFF
--- a/packages/substream/sink/utils/ipfs.ts
+++ b/packages/substream/sink/utils/ipfs.ts
@@ -73,18 +73,62 @@ function getFetchIpfsContentEffect(
         },
       });
 
-      const response = yield* unwrap(
-        // Attempt to fetch with jittered exponential backoff for 60 seconds before failing
-        Effect.retry(
-          ipfsFetchEffect.pipe(Effect.timeout(Duration.seconds(60))),
-          Schedule.exponential(100).pipe(
-            Schedule.jittered,
-            Schedule.compose(Schedule.elapsed),
-            // Retry for 1 minute.
-            Schedule.whileOutput(Duration.lessThanOrEqualTo(Duration.seconds(60)))
+      const mainGatewayResponse = yield* unwrap(
+        Effect.either(
+          // Attempt to fetch with jittered exponential backoff for 30 seconds before failing
+          Effect.retry(
+            ipfsFetchEffect.pipe(Effect.timeout(Duration.seconds(30))),
+            Schedule.exponential(100).pipe(
+              Schedule.jittered,
+              Schedule.compose(Schedule.elapsed),
+              // Retry for 1 minute.
+              Schedule.whileOutput(Duration.lessThanOrEqualTo(Duration.seconds(30)))
+            )
           )
         )
       );
+
+      // @HACK: May 09, 2024: We're currently using Edge & Node's IPFS cluster. They are
+      // in the process of a migration where some data in not available on every node. Try
+      // two nodes until we are on our own IPFS infra.
+      if (Either.isLeft(mainGatewayResponse)) {
+        const secondaryIpfsFetchEffect = Effect.tryPromise({
+          try: async () => {
+            const parsedCid = uri.replace('ipfs://', '');
+            const url = `https://api.thegraph.com/ipfs/api/v0/cat?arg=${parsedCid}`;
+
+            return await fetch(url);
+          },
+          catch: error => {
+            return new FailedFetchingIpfsContentError(`Failed fetching IPFS content from uri ${uri}. ${String(error)}`);
+          },
+        });
+
+        const secondaryGatewayResponse = yield* unwrap(
+          // Attempt to fetch with jittered exponential backoff for 30 seconds before failing
+          Effect.retry(
+            secondaryIpfsFetchEffect.pipe(Effect.timeout(Duration.seconds(30))),
+            Schedule.exponential(100).pipe(
+              Schedule.jittered,
+              Schedule.compose(Schedule.elapsed),
+              // Retry for 1 minute.
+              Schedule.whileOutput(Duration.lessThanOrEqualTo(Duration.seconds(30)))
+            )
+          )
+        );
+
+        return yield* unwrap(
+          Effect.tryPromise({
+            try: async () => {
+              return (await secondaryGatewayResponse.json()) as UriData;
+            },
+            catch: error =>
+              new UnableToParseJsonError(`Unable to parse JSON when reading content from uri ${uri}. ${String(error)}`),
+          })
+        );
+      }
+
+      const response = mainGatewayResponse.right;
 
       return yield* unwrap(
         Effect.tryPromise({


### PR DESCRIPTION
E&N is doing an IPFS node migration so there are instances where our IPFS data might not exist on certain nodes, but does exist on others. For now we'll fetch from multiple nodes to attempt to get the data.