### PR TITLE
fix: hydration errors in editor + SEO fix

### DIFF
--- a/apps/web/app/space/(entity)/[id]/[entityId]/default-entity-page.tsx
+++ b/apps/web/app/space/(entity)/[id]/[entityId]/default-entity-page.tsx
@@ -75,9 +75,9 @@ export default async function DefaultEntityPage({
             <Editor shouldHandleOwnSpacing />
             <ToggleEntityPage {...props} typeId={typeId} filters={filters} />
             <Spacer height={40} />
-            {/* <Suspense fallback={null}>
+            <Suspense fallback={<div />}>
               <EntityReferencedByServerContainer entityId={props.id} name={props.name} spaceId={params.id} />
-            </Suspense> */}
+            </Suspense>
           </EntityPageContentContainer>
           <MoveEntityReview />
         </MoveEntityProvider>

--- a/apps/web/app/space/(entity)/[id]/[entityId]/default-entity-page.tsx
+++ b/apps/web/app/space/(entity)/[id]/[entityId]/default-entity-page.tsx
@@ -75,9 +75,9 @@ export default async function DefaultEntityPage({
             <Editor shouldHandleOwnSpacing />
             <ToggleEntityPage {...props} typeId={typeId} filters={filters} />
             <Spacer height={40} />
-            <Suspense fallback={null}>
+            {/* <Suspense fallback={null}>
               <EntityReferencedByServerContainer entityId={props.id} name={props.name} spaceId={params.id} />
-            </Suspense>
+            </Suspense> */}
           </EntityPageContentContainer>
           <MoveEntityReview />
         </MoveEntityProvider>

--- a/apps/web/app/space/(entity)/[id]/[entityId]/default-entity-page.tsx
+++ b/apps/web/app/space/(entity)/[id]/[entityId]/default-entity-page.tsx
@@ -1,8 +1,7 @@
 import { SYSTEM_IDS } from '@geogenesis/ids';
 import { redirect } from 'next/navigation';
 
-import { Suspense } from 'react';
-
+// import { Suspense } from 'react';
 import { Subgraph } from '~/core/io';
 import { EditorProvider } from '~/core/state/editor-store';
 import { EntityStoreProvider } from '~/core/state/entity-page-store/entity-store-provider';
@@ -18,7 +17,7 @@ import { EditableHeading } from '~/partials/entity-page/editable-entity-header';
 import { EntityPageContentContainer } from '~/partials/entity-page/entity-page-content-container';
 import { EntityPageCover } from '~/partials/entity-page/entity-page-cover';
 import { EntityPageMetadataHeader } from '~/partials/entity-page/entity-page-metadata-header';
-import { EntityReferencedByServerContainer } from '~/partials/entity-page/entity-page-referenced-by-server-container';
+// import { EntityReferencedByServerContainer } from '~/partials/entity-page/entity-page-referenced-by-server-container';
 import { ToggleEntityPage } from '~/partials/entity-page/toggle-entity-page';
 import { MoveEntityReview } from '~/partials/move-entity/move-entity-review';
 
@@ -75,9 +74,9 @@ export default async function DefaultEntityPage({
             <Editor shouldHandleOwnSpacing />
             <ToggleEntityPage {...props} typeId={typeId} filters={filters} />
             <Spacer height={40} />
-            <Suspense fallback={<div />}>
+            {/* <Suspense fallback={<div />}>
               <EntityReferencedByServerContainer entityId={props.id} name={props.name} spaceId={params.id} />
-            </Suspense>
+            </Suspense> */}
           </EntityPageContentContainer>
           <MoveEntityReview />
         </MoveEntityProvider>

--- a/apps/web/app/space/(entity)/[id]/[entityId]/profile-entity-server-container.tsx
+++ b/apps/web/app/space/(entity)/[id]/[entityId]/profile-entity-server-container.tsx
@@ -7,8 +7,7 @@ import { Subgraph } from '~/core/io';
 import { fetchOnchainProfileByEntityId } from '~/core/io/fetch-onchain-profile-by-entity-id';
 import { NavUtils } from '~/core/utils/utils';
 
-import { EntityReferencedByServerContainer } from '~/partials/entity-page/entity-page-referenced-by-server-container';
-
+// import { EntityReferencedByServerContainer } from '~/partials/entity-page/entity-page-referenced-by-server-container';
 import { ProfilePageComponent } from './profile-entity-page';
 
 interface Props {
@@ -58,9 +57,10 @@ export async function ProfileEntityServerContainer({ params }: Props) {
       triples={person.triples}
       spaceId={params.id}
       referencedByComponent={
-        <React.Suspense fallback={null}>
-          <EntityReferencedByServerContainer entityId={person.id} name={person.name} spaceId={params.id} />
-        </React.Suspense>
+        <></>
+        // <React.Suspense fallback={null}>
+        //   <EntityReferencedByServerContainer entityId={person.id} name={person.name} spaceId={params.id} />
+        // </React.Suspense>
       }
     />
   );

--- a/apps/web/app/space/[id]/page.tsx
+++ b/apps/web/app/space/[id]/page.tsx
@@ -14,7 +14,7 @@ import { Skeleton } from '~/design-system/skeleton';
 import { Spacer } from '~/design-system/spacer';
 
 import { Editor } from '~/partials/editor/editor';
-import { EntityReferencedByServerContainer } from '~/partials/entity-page/entity-page-referenced-by-server-container';
+// import { EntityReferencedByServerContainer } from '~/partials/entity-page/entity-page-referenced-by-server-container';
 import { ToggleEntityPage } from '~/partials/entity-page/toggle-entity-page';
 import { SpaceNotices } from '~/partials/space-page/space-notices';
 import { Subspaces } from '~/partials/space-page/subspaces';
@@ -81,9 +81,9 @@ export default async function SpacePage({ params }: Props) {
       <Editor shouldHandleOwnSpacing spacePage />
       <ToggleEntityPage {...props} />
       <Spacer height={40} />
-      <React.Suspense fallback={null}>
+      {/* <React.Suspense fallback={null}>
         <EntityReferencedByServerContainer entityId={props.id} name={props.name} spaceId={spaceId} />
-      </React.Suspense>
+      </React.Suspense> */}
     </>
   );
 }

--- a/apps/web/partials/editor/editor.tsx
+++ b/apps/web/partials/editor/editor.tsx
@@ -171,8 +171,7 @@ export const Editor = React.memo(function Editor({
 
   return (
     <div className={cx(editable ? 'editable' : 'not-editable')}>
-      <EditorContent editor={editor} />
-      {/* {!hasUpdatedEditorJson ? <ServerContent content={content} /> : <EditorContent editor={editor} />} */}
+      {!editor ? <ServerContent content={content} /> : <EditorContent editor={editor} />}
       {/* <FloatingMenu editor={editor}>
         <div className="absolute -left-12 -top-3">
           <SquareButton onClick={openCommandMenu} icon={<Plus />} />

--- a/apps/web/partials/editor/editor.tsx
+++ b/apps/web/partials/editor/editor.tsx
@@ -171,7 +171,8 @@ export const Editor = React.memo(function Editor({
 
   return (
     <div className={cx(editable ? 'editable' : 'not-editable')}>
-      {!editor ? <ServerContent content={content} /> : <EditorContent editor={editor} />}
+      <EditorContent editor={editor} />
+      {/* {!hasUpdatedEditorJson ? <ServerContent content={content} /> : <EditorContent editor={editor} />} */}
       {/* <FloatingMenu editor={editor}>
         <div className="absolute -left-12 -top-3">
           <SquareButton onClick={openCommandMenu} icon={<Plus />} />

--- a/apps/web/partials/editor/server-content.tsx
+++ b/apps/web/partials/editor/server-content.tsx
@@ -156,9 +156,7 @@ const TrailingBreak = () => {
     <div className="react-renderer node-paragraph">
       <div className="whitespace-normal">
         <p className="whitespace-pre">
-          <div>
-            <br className="ProseMirror-trailingBreak" />
-          </div>
+          <br className="ProseMirror-trailingBreak" />
         </p>
       </div>
     </div>


### PR DESCRIPTION
Rendering a page during SSR with streaming RSC can block meta tag parsing on discord and twitter if there is no fallback for the streaming RSC.