### PR TITLE
feat: index space ids as a uuid instead of contract address

### DIFF
--- a/apps/web/app/dao/page.tsx
+++ b/apps/web/app/dao/page.tsx
@@ -58,7 +58,7 @@ export default async function Page() {
 
       <div className="flex flex-row gap-4">
         <ClientOnly>
-          <CreateDao type="personal" />
+          <CreateDao type="governance" />
           <AddMember />
         </ClientOnly>
       </div>

--- a/apps/web/core/constants.ts
+++ b/apps/web/core/constants.ts
@@ -20,7 +20,6 @@ export const DEFAULT_OPENGRAPH_DESCRIPTION =
 
 export const IPFS_GATEWAY_PATH = 'https://node.lighthouse.storage';
 export const IPFS_GATEWAY_READ_PATH = `${IPFS_GATEWAY_PATH}/ipfs/`;
-// export const IPFS_GATEWAY_READ_PATH = 'https://api.thegraph.com/ipfs/api/v0/cat?arg=';
 
 export const ADMIN_ROLE_BINARY = '0xa49807205ce4d355092ef5a8a18f56e8913cf4a201fbe287825b095693c21775';
 export const EDITOR_CONTROLLER_ROLE_BINARY = '0xbc2c04b16435c5f4eaa37fec9ad808fec563d665b1febf40775380f3f1b592b4';

--- a/apps/web/core/io/storage/storage.ts
+++ b/apps/web/core/io/storage/storage.ts
@@ -17,17 +17,19 @@ export class StorageClient implements IStorageClient {
     const formData = new FormData();
     formData.append('file', blob);
 
-    const url = `${this.ipfsUrl}/api/v0/add`;
+    // const url = `${this.ipfsUrl}/api/v0/add`;
 
-    console.log(`Posting to url`, url);
+    console.log(`Posting to url`, 'https://node.lighthouse.storage/api/v0/add');
 
-    const response = await fetch(url, {
+    const response = await fetch('https://node.lighthouse.storage/api/v0/add', {
       method: 'POST',
       body: formData,
       headers: {
         Authorization: `Bearer ${process.env.NEXT_PUBLIC_IPFS_KEY}`,
       },
     });
+
+    // const output = await lighthouse.upload(formData, process.env.NEXT_PUBLIC_IPFS_KEY!, false, null, progressCallback);
 
     if (response.status >= 300) {
       const text = await response.text();

--- a/packages/sdk/src/proto/create-edit-proposal.ts
+++ b/packages/sdk/src/proto/create-edit-proposal.ts
@@ -13,15 +13,15 @@ export function createEditProposal(
 ): Uint8Array {
   return new Edit({
     type: ActionType.ADD_EDIT,
-    authors: [author],
-    version: '0.0.1',
+    version: '1.0.0',
+    id: createGeoId(),
+    name,
     ops: ops.map(o => {
       return new OpBinary({
         opType: o.type === 'SET_TRIPLE' ? OpType.SET_TRIPLE : OpType.DELETE_TRIPLE,
         payload: Payload.fromJson(o.payload) // janky but works
       })
     }),
-    id: createGeoId(),
-    name,
+    authors: [author],
   }).toBinary()
 }

--- a/packages/substream/sink/bootstrap-root.ts
+++ b/packages/substream/sink/bootstrap-root.ts
@@ -1,4 +1,5 @@
 import { SYSTEM_IDS, createCollectionItem, createGeoId } from '@geogenesis/sdk';
+import { NETWORK_IDS } from '@geogenesis/sdk/src/system-ids';
 import { Effect } from 'effect';
 import type * as s from 'zapatos/schema';
 
@@ -11,6 +12,7 @@ import {
 import { Accounts, Collections, Entities, Proposals, Spaces, Triples } from './db';
 import { CollectionItems } from './db/collection-items';
 import { getTripleFromOp } from './events/get-triple-from-op';
+import { createSpaceId } from './utils/id';
 
 const entities: string[] = [
   SYSTEM_IDS.TYPES,
@@ -308,7 +310,7 @@ const getTypeTriples = () => {
 };
 
 const space: s.spaces.Insertable = {
-  id: SYSTEM_IDS.ROOT_SPACE_ADDRESS,
+  id: createSpaceId({ address: SYSTEM_IDS.ROOT_SPACE_ADDRESS, network: NETWORK_IDS.POLYGON }),
   dao_address: SYSTEM_IDS.ROOT_SPACE_ADDRESS,
   is_root_space: true,
   type: 'public',

--- a/packages/substream/sink/bootstrap-root.ts
+++ b/packages/substream/sink/bootstrap-root.ts
@@ -309,6 +309,7 @@ const getTypeTriples = () => {
 
 const space: s.spaces.Insertable = {
   id: SYSTEM_IDS.ROOT_SPACE_ADDRESS,
+  dao_address: SYSTEM_IDS.ROOT_SPACE_ADDRESS,
   is_root_space: true,
   type: 'public',
   created_at_block: ROOT_SPACE_CREATED_AT_BLOCK,

--- a/packages/substream/sink/db/spaces.ts
+++ b/packages/substream/sink/db/spaces.ts
@@ -9,12 +9,20 @@ export class Spaces {
     return await db.upsert('spaces', spaces, ['id']).run(pool);
   }
 
+  static async findForDaoAddress(daoAddress: string) {
+    const result = await db
+      .selectOne('spaces', { dao_address: getChecksumAddress(daoAddress) }, { columns: ['id'] })
+      .run(pool);
+
+    return result ? result.id : null;
+  }
+
   static async findForVotingPlugin(votingPluginAddress: string) {
     const result = await db
       .selectOne('spaces', { main_voting_plugin_address: getChecksumAddress(votingPluginAddress) }, { columns: ['id'] })
       .run(pool);
 
-    return result ? getChecksumAddress(result.id) : null;
+    return result ? result.id : null;
   }
 
   static async findForPersonalPlugin(personalPluginAddress: string) {
@@ -28,7 +36,7 @@ export class Spaces {
 
     return result
       ? {
-          id: getChecksumAddress(result.id),
+          id: result.id,
           personal_space_admin_plugin_address: result.personal_space_admin_plugin_address,
         }
       : null;
@@ -43,7 +51,7 @@ export class Spaces {
       )
       .run(pool);
 
-    return result ? getChecksumAddress(result.id) : null;
+    return result ? result.id : null;
   }
 
   static async findForSpacePlugin(spacePluginAddress: string) {
@@ -57,7 +65,7 @@ export class Spaces {
 
     return result
       ? {
-          id: getChecksumAddress(result.id),
+          id: result.id,
           space_plugin_address: result.space_plugin_address,
         }
       : null;

--- a/packages/substream/sink/events/editor-added/map-editors.ts
+++ b/packages/substream/sink/events/editor-added/map-editors.ts
@@ -45,7 +45,7 @@ export function mapEditors(editorAdded: EditorAdded[], block: BlockEvent) {
       if (maybeSpaceIdForPersonalPlugin) {
         const newMember: S.space_editors.Insertable = {
           account_id: getChecksumAddress(editor.editorAddress),
-          space_id: getChecksumAddress(maybeSpaceIdForPersonalPlugin.id),
+          space_id: maybeSpaceIdForPersonalPlugin.id,
           created_at: block.timestamp,
           created_at_block: block.blockNumber,
         };

--- a/packages/substream/sink/events/get-derived-space-id-from-imported-space.ts
+++ b/packages/substream/sink/events/get-derived-space-id-from-imported-space.ts
@@ -1,1 +1,0 @@
-export function getDerivedSpaceIdFromImportedSpace() {}

--- a/packages/substream/sink/events/get-derived-space-id-from-imported-space.ts
+++ b/packages/substream/sink/events/get-derived-space-id-from-imported-space.ts
@@ -1,0 +1,1 @@
+export function getDerivedSpaceIdFromImportedSpace() {}

--- a/packages/substream/sink/events/get-derived-space-ids-from-imported-spaces.ts
+++ b/packages/substream/sink/events/get-derived-space-ids-from-imported-spaces.ts
@@ -1,0 +1,97 @@
+import { ActionType, Import, IpfsMetadata } from '@geogenesis/sdk/proto';
+import { Effect, Either } from 'effect';
+
+import { getFetchIpfsContentEffect } from '../ipfs';
+import type { BlockEvent } from '../types';
+import { createSpaceId } from '../utils/id';
+import { slog } from '../utils/slog';
+import { Decoder, decode } from '~/sink/proto';
+
+function fetchSpaceImportFromIpfs(ipfsUri: string, block: BlockEvent) {
+  return Effect.gen(function* (_) {
+    slog({
+      message: `Fetching IPFS content for space import
+        ipfsUri:       ${ipfsUri}`,
+      requestId: block.requestId,
+    });
+
+    const fetchIpfsContentEffect = getFetchIpfsContentEffect(ipfsUri);
+    const maybeIpfsContent = yield* _(Effect.either(fetchIpfsContentEffect));
+
+    if (Either.isLeft(maybeIpfsContent)) {
+      const error = maybeIpfsContent.left;
+
+      switch (error._tag) {
+        case 'UnableToParseBase64Error':
+          console.error(`Unable to parse base64 string ${ipfsUri}`, error);
+          break;
+        case 'FailedFetchingIpfsContentError':
+          console.error(`Failed fetching IPFS content from uri ${ipfsUri}`, error);
+          break;
+        case 'UnableToParseJsonError':
+          console.error(`Unable to parse JSON when reading content from uri ${ipfsUri}`, error);
+          break;
+        case 'TimeoutException':
+          console.error(`Timed out when fetching IPFS content for uri ${ipfsUri}`, error);
+          break;
+        default:
+          console.error(`Unknown error when fetching IPFS content for uri ${ipfsUri}`, error);
+          break;
+      }
+
+      return null;
+    }
+
+    const ipfsContent = maybeIpfsContent.right;
+
+    if (!ipfsContent) {
+      return null;
+    }
+
+    const validIpfsMetadata = yield* _(decode(() => IpfsMetadata.fromBinary(ipfsContent)));
+
+    if (!validIpfsMetadata) {
+      // @TODO: Effectify error handling
+      console.error('Failed to parse IPFS metadata', validIpfsMetadata);
+      return null;
+    }
+
+    switch (validIpfsMetadata.type) {
+      // The initial content set might not be an Edit and instead be an import. If it's an import
+      // we need to turn every Edit in the import into an individual EditProposal.
+      case ActionType.IMPORT_SPACE:
+        // @TODO: Map every edit in the import into many EditProposals. We then need to flatten
+        // these later
+        const importResult = yield* _(decode(() => Import.fromBinary(ipfsContent)));
+
+        if (!importResult) {
+          return null;
+        }
+
+        return createSpaceId({ network: importResult.previousNetwork, address: importResult.previousContractAddress });
+    }
+
+    return null;
+  });
+}
+
+export function getDerivedSpaceIdsFromImportedSpaces(ipfsUris: string[], block: BlockEvent) {
+  return Effect.gen(function* (_) {
+    slog({
+      requestId: block.requestId,
+      message: `Gathering IPFS import content for ${ipfsUris.length} initial space proposals`,
+    });
+
+    const maybeImportsFromIpfs = yield* _(
+      Effect.all(
+        ipfsUris.map(uri => fetchSpaceImportFromIpfs(uri, block)),
+        {
+          concurrency: 20,
+        }
+      )
+    );
+
+    const proposalsFromIpfs = maybeImportsFromIpfs.flatMap(e => (e ? [e] : [])).flat();
+    return proposalsFromIpfs;
+  });
+}

--- a/packages/substream/sink/events/initial-editors-added/handler.ts
+++ b/packages/substream/sink/events/initial-editors-added/handler.ts
@@ -69,7 +69,7 @@ export function handleInitialGovernanceSpaceEditorsAdded(editorsAdded: InitialEd
           const checksumPluginAddress = getChecksumAddress(s.main_voting_plugin_address!);
 
           if (!acc.has(checksumPluginAddress)) {
-            acc.set(checksumPluginAddress, getChecksumAddress(s.id));
+            acc.set(checksumPluginAddress, s.id);
           }
 
           return acc;
@@ -258,7 +258,7 @@ export function handleInitialPersonalSpaceEditorsAdded(editorsAdded: InitialEdit
           const checksumPluginAddress = getChecksumAddress(s.personal_space_admin_plugin_address!);
 
           if (!acc.has(checksumPluginAddress)) {
-            acc.set(checksumPluginAddress, getChecksumAddress(s.id));
+            acc.set(checksumPluginAddress, s.id);
           }
 
           return acc;

--- a/packages/substream/sink/events/initial-proposal-created/get-initial-proposals.test.ts
+++ b/packages/substream/sink/events/initial-proposal-created/get-initial-proposals.test.ts
@@ -7,12 +7,7 @@ import { getInitialProposalsForSpaces } from './get-initial-proposals';
 
 describe('get-initial-proposals', () => {
   it('proposal is in set of new spaces', () => {
-    const spacesCreated: SpacePluginCreated[] = [
-      {
-        daoAddress: '0x7eC3D9a27F89f52FAEa2C9cCC8dFBBA1A0c6a239',
-        spaceAddress: '',
-      },
-    ];
+    const spacesCreated: string[] = ['0x7eC3D9a27F89f52FAEa2C9cCC8dFBBA1A0c6a239'];
 
     const processedProposal: EditProposal = {
       proposalId: createGeoId(),
@@ -35,12 +30,7 @@ describe('get-initial-proposals', () => {
   it('proposal is not set of new spaces', () => {
     // const proposals = getInitialProposalsForSpaces();
 
-    const spacesCreated: SpacePluginCreated[] = [
-      {
-        daoAddress: '0xF4781fA765A5D73DFa457F5d0d495344a787b57F',
-        spaceAddress: '',
-      },
-    ];
+    const spacesCreated: string[] = ['0xF4781fA765A5D73DFa457F5d0d495344a787b57F'];
 
     const processedProposal: EditProposal = {
       proposalId: createGeoId(),

--- a/packages/substream/sink/events/initial-proposal-created/get-initial-proposals.ts
+++ b/packages/substream/sink/events/initial-proposal-created/get-initial-proposals.ts
@@ -1,6 +1,5 @@
 import type { EditProposal } from '../proposals-created/parser';
 import type { SpacePluginCreated } from '../spaces-created/parser';
-import { getChecksumAddress } from '~/sink/utils/get-checksum-address';
 
 /**
  * If we have a set of "SpacePluginCreated" events in the same block as a set of "ProposalProcessed" events
@@ -10,7 +9,7 @@ import { getChecksumAddress } from '~/sink/utils/get-checksum-address';
  * If there are processed proposals as a result of an initial content uri, we need to create the appropriate
  * proposals, proposed versions, actions, etc. before we actually set the proposal as "ACCEPTED"
  */
-export function getInitialProposalsForSpaces(spacesCreated: SpacePluginCreated[], proposals: EditProposal[]) {
-  const spaceAddresses = new Set(spacesCreated.map(s => getChecksumAddress(s.daoAddress)));
-  return proposals.filter(p => spaceAddresses.has(getChecksumAddress(p.space)));
+export function getInitialProposalsForSpaces(spacesCreated: string[], proposals: EditProposal[]) {
+  const spaceAddresses = new Set(spacesCreated);
+  return proposals.filter(p => spaceAddresses.has(p.space));
 }

--- a/packages/substream/sink/events/member-added/map-members.ts
+++ b/packages/substream/sink/events/member-added/map-members.ts
@@ -45,7 +45,7 @@ export function mapMembers(membersApproved: MemberAdded[], block: BlockEvent) {
       if (maybeSpaceIdForPersonalPlugin) {
         const newMember: S.space_members.Insertable = {
           account_id: getChecksumAddress(member.memberAddress),
-          space_id: getChecksumAddress(maybeSpaceIdForPersonalPlugin.id),
+          space_id: maybeSpaceIdForPersonalPlugin.id,
           created_at: block.timestamp,
           created_at_block: block.blockNumber,
         };

--- a/packages/substream/sink/events/onchain-profiles-registered/handler.ts
+++ b/packages/substream/sink/events/onchain-profiles-registered/handler.ts
@@ -30,6 +30,7 @@ export function handleOnchainProfilesRegistered(profiles: OnchainProfileRegister
     const spaces = profiles.map(p => {
       const newSpace: S.spaces.Insertable = {
         id: getChecksumAddress(p.space),
+        dao_address: getChecksumAddress(p.space),
         type: 'personal',
         created_at_block: block.blockNumber,
         is_root_space: false,

--- a/packages/substream/sink/events/proposal-processed/get-edits-proposal-from-processed-proposal.ts
+++ b/packages/substream/sink/events/proposal-processed/get-edits-proposal-from-processed-proposal.ts
@@ -100,7 +100,7 @@ function fetchEditProposalFromIpfs(
           // @TODO: We can use the createdBy on the ImportEdit type instead of
           // hard-coding Geo as the creator.
           creator: getChecksumAddress('0x66703c058795B9Cb215fbcc7c6b07aee7D216F24'),
-          space: getChecksumAddress(maybeSpaceIdForVotingPlugin.id),
+          space: maybeSpaceIdForVotingPlugin.id,
           endTime: block.timestamp.toString(),
           startTime: block.timestamp.toString(),
           metadataUri: processedProposal.ipfsUri,
@@ -111,8 +111,6 @@ function fetchEditProposalFromIpfs(
       // The initial content set might not be an Edit and instead be an import. If it's an import
       // we need to turn every Edit in the import into an individual EditProposal.
       case ActionType.IMPORT_SPACE:
-        // @TODO: Map every edit in the import into many EditProposals. We then need to flatten
-        // these later
         const importResult = yield* _(decode(() => Import.fromBinary(ipfsContent)));
 
         if (!importResult) {
@@ -149,7 +147,7 @@ function fetchEditProposalFromIpfs(
             pluginAddress: getChecksumAddress(processedProposal.pluginAddress),
             ops: e.ops as Op[],
             creator: getChecksumAddress(e.createdBy),
-            space: getChecksumAddress(maybeSpaceIdForVotingPlugin.id),
+            space: maybeSpaceIdForVotingPlugin.id,
             endTime: block.timestamp.toString(),
             startTime: block.timestamp.toString(),
             metadataUri: processedProposal.ipfsUri,
@@ -197,7 +195,6 @@ export function getProposalFromInitialSpaceProposalIpfsUri(proposalsProcessed: P
       )
     );
 
-    // @TODO: Ensure ordering of proposals is correct
     const proposalsFromIpfs = maybeProposalsFromIpfs.flatMap(e => (e ? [e] : [])).flat();
     return proposalsFromIpfs;
   });

--- a/packages/substream/sink/events/spaces-created/get-spaces-with-initial-proposals-processed.ts
+++ b/packages/substream/sink/events/spaces-created/get-spaces-with-initial-proposals-processed.ts
@@ -1,0 +1,19 @@
+import type { EditProposal, ProposalProcessed } from '../proposals-created/parser';
+import type { SpacePluginCreated } from './parser';
+import { getChecksumAddress } from '~/sink/utils/get-checksum-address';
+
+/**
+ * If we have a set of "SpacePluginCreated" events in the same block as a set of "ProposalProcessed" events
+ * we need to check if any of the processed proposals are because an initial content IPFS URI was passed
+ * during space creation.
+ *
+ * If there are processed proposals as a result of an initial content uri, we need to create the appropriate
+ * proposals, proposed versions, actions, etc. before we actually set the proposal as "ACCEPTED"
+ */
+export function getSpacesWithInitialProposalsProcessed(
+  spacesCreated: SpacePluginCreated[],
+  proposalsProcessed: ProposalProcessed[]
+) {
+  const proposalPluginAddresses = new Set(proposalsProcessed.map(s => getChecksumAddress(s.pluginAddress)));
+  return spacesCreated.filter(p => proposalPluginAddresses.has(getChecksumAddress(p.spaceAddress)));
+}

--- a/packages/substream/sink/events/spaces-created/map-spaces.ts
+++ b/packages/substream/sink/events/spaces-created/map-spaces.ts
@@ -42,9 +42,19 @@ export function mapGovernanceToSpaces(
   }));
 }
 
-export function mapPersonalToSpaces(spaces: PersonalPluginsCreated[], createdAtBlock: number): S.spaces.Insertable[] {
+type PersonalPluginsCreatedWithSpaceId = PersonalPluginsCreated & {
+  // The id here is required as we can't derive it from the dao address + the network.
+  // We don't know which network this space was originally created on, so we need to
+  // know the id ahead of time before updating the space with the governance data.
+  id: string;
+};
+
+export function mapPersonalToSpaces(
+  spaces: PersonalPluginsCreatedWithSpaceId[],
+  createdAtBlock: number
+): S.spaces.Insertable[] {
   return spaces.map(s => ({
-    id: s.daoAddress,
+    id: s.id,
     type: 'personal',
     is_root_space: false,
     created_at_block: createdAtBlock,

--- a/packages/substream/sink/events/spaces-created/map-spaces.ts
+++ b/packages/substream/sink/events/spaces-created/map-spaces.ts
@@ -6,6 +6,7 @@ import { getChecksumAddress } from '~/sink/utils/get-checksum-address';
 export function mapSpaces(spaces: SpacePluginCreated[], createdAtBlock: number): S.spaces.Insertable[] {
   return spaces.map(s => ({
     id: getChecksumAddress(s.daoAddress),
+    dao_address: getChecksumAddress(s.daoAddress),
     space_plugin_address: getChecksumAddress(s.spaceAddress),
     is_root_space: false,
     type: 'public',
@@ -22,6 +23,7 @@ export function mapGovernanceToSpaces(
     is_root_space: false,
     created_at_block: createdAtBlock,
     type: 'public',
+    dao_address: getChecksumAddress(s.daoAddress),
     main_voting_plugin_address: getChecksumAddress(s.mainVotingAddress),
     member_access_plugin_address: getChecksumAddress(s.memberAccessAddress),
   }));
@@ -33,6 +35,7 @@ export function mapPersonalToSpaces(spaces: PersonalPluginsCreated[], createdAtB
     is_root_space: false,
     created_at_block: createdAtBlock,
     type: 'personal',
+    dao_address: getChecksumAddress(s.daoAddress),
     personal_space_admin_plugin_address: getChecksumAddress(s.personalAdminAddress),
   }));
 }

--- a/packages/substream/sink/events/spaces-created/map-spaces.ts
+++ b/packages/substream/sink/events/spaces-created/map-spaces.ts
@@ -1,28 +1,41 @@
+import { NETWORK_IDS } from '@geogenesis/sdk/src/system-ids';
 import type * as S from 'zapatos/schema';
 
-import type { GovernancePluginsCreated, PersonalPluginsCreated, SpacePluginCreated } from './parser';
+import type { GovernancePluginsCreated, PersonalPluginsCreated, SpacePluginCreatedWithSpaceId } from './parser';
 import { getChecksumAddress } from '~/sink/utils/get-checksum-address';
+import { createSpaceId } from '~/sink/utils/id';
 
-export function mapSpaces(spaces: SpacePluginCreated[], createdAtBlock: number): S.spaces.Insertable[] {
-  return spaces.map(s => ({
-    id: getChecksumAddress(s.daoAddress),
-    dao_address: getChecksumAddress(s.daoAddress),
-    space_plugin_address: getChecksumAddress(s.spaceAddress),
-    is_root_space: false,
-    type: 'public',
-    created_at_block: createdAtBlock,
-  }));
+export function mapSpaces(spaces: SpacePluginCreatedWithSpaceId[], createdAtBlock: number): S.spaces.Insertable[] {
+  return spaces.map(s => {
+    const daoAddress = getChecksumAddress(s.daoAddress);
+
+    return {
+      id: s.id ?? createSpaceId({ network: NETWORK_IDS.GEO, address: daoAddress }),
+      dao_address: daoAddress,
+      space_plugin_address: getChecksumAddress(s.spaceAddress),
+      is_root_space: false,
+      type: 'public',
+      created_at_block: createdAtBlock,
+    };
+  });
 }
 
+type GovernancePluginsCreatedWithSpaceId = GovernancePluginsCreated & {
+  // The id here is required as we can't derive it from the dao address + the network.
+  // We don't know which network this space was originally created on, so we need to
+  // know the id ahead of time before updating the space with the governance data.
+  id: string;
+};
+
 export function mapGovernanceToSpaces(
-  spaces: GovernancePluginsCreated[],
+  spaces: GovernancePluginsCreatedWithSpaceId[],
   createdAtBlock: number
 ): S.spaces.Insertable[] {
   return spaces.map(s => ({
-    id: getChecksumAddress(s.daoAddress),
+    id: s.id,
+    type: 'public',
     is_root_space: false,
     created_at_block: createdAtBlock,
-    type: 'public',
     dao_address: getChecksumAddress(s.daoAddress),
     main_voting_plugin_address: getChecksumAddress(s.mainVotingAddress),
     member_access_plugin_address: getChecksumAddress(s.memberAccessAddress),
@@ -31,10 +44,10 @@ export function mapGovernanceToSpaces(
 
 export function mapPersonalToSpaces(spaces: PersonalPluginsCreated[], createdAtBlock: number): S.spaces.Insertable[] {
   return spaces.map(s => ({
-    id: getChecksumAddress(s.daoAddress),
+    id: s.daoAddress,
+    type: 'personal',
     is_root_space: false,
     created_at_block: createdAtBlock,
-    type: 'personal',
     dao_address: getChecksumAddress(s.daoAddress),
     personal_space_admin_plugin_address: getChecksumAddress(s.personalAdminAddress),
   }));

--- a/packages/substream/sink/events/spaces-created/parser.ts
+++ b/packages/substream/sink/events/spaces-created/parser.ts
@@ -7,6 +7,9 @@ export const ZodSpacePluginCreated = z.object({
 });
 
 export type SpacePluginCreated = z.infer<typeof ZodSpacePluginCreated>;
+export type SpacePluginCreatedWithSpaceId = SpacePluginCreated & {
+  id?: string | null;
+};
 
 export const ZodSpacePluginCreatedStreamResponse = z.object({
   spacesCreated: z.array(ZodSpacePluginCreated).min(1),

--- a/packages/substream/sink/events/subspaces-added/map-subspaces.ts
+++ b/packages/substream/sink/events/subspaces-added/map-subspaces.ts
@@ -46,7 +46,7 @@ export function mapSubspaces({
           const checksumPluginAddress = getChecksumAddress(s.space_plugin_address!);
 
           if (!acc.has(checksumPluginAddress)) {
-            acc.set(checksumPluginAddress, getChecksumAddress(s.id));
+            acc.set(checksumPluginAddress, s.id);
           }
 
           return acc;

--- a/packages/substream/sink/events/subspaces-removed/map-subspaces-to-remove.ts
+++ b/packages/substream/sink/events/subspaces-removed/map-subspaces-to-remove.ts
@@ -39,7 +39,7 @@ export function mapSubspacesToRemove(
           const checksumPluginAddress = getChecksumAddress(s.space_plugin_address!);
 
           if (!acc.has(checksumPluginAddress)) {
-            acc.set(checksumPluginAddress, getChecksumAddress(s.id));
+            acc.set(checksumPluginAddress, s.id);
           }
 
           return acc;

--- a/packages/substream/sink/sql/init-public.sql
+++ b/packages/substream/sink/sql/init-public.sql
@@ -32,6 +32,7 @@ CREATE TABLE public.spaces (
     created_at_block integer NOT NULL,
     is_root_space boolean NOT NULL,
     type space_type NOT NULL,   
+    dao_address text NOT NULL,
     space_plugin_address text,
     main_voting_plugin_address text,
     member_access_plugin_address text,

--- a/packages/substream/sink/utils/id.ts
+++ b/packages/substream/sink/utils/id.ts
@@ -1,4 +1,6 @@
 import { createGeoId } from '@geogenesis/sdk';
+import { createHash } from 'crypto';
+import { v4 } from 'uuid';
 
 export function createActionId(): string {
   return createGeoId();
@@ -6,4 +8,28 @@ export function createActionId(): string {
 
 export function createVersionId({ proposalId, entityId }: { proposalId: string; entityId: string }): string {
   return `${proposalId}:${entityId}`;
+}
+
+export function createSpaceId({ network, address }: { network: string; address: string }) {
+  return createIdFromUniqueString(`${network}:${address}`);
+}
+
+function createIdFromUniqueString(text: string) {
+  const hashed = createHash('md5').update(text).digest('hex');
+  const bytes = hexToBytesArray(hashed);
+  const uuid = v4({ random: bytes });
+  const id = stripDashes(uuid);
+
+  return id;
+}
+
+function hexToBytesArray(hex: string) {
+  let bytes = [];
+  for (let c = 0; c < hex.length; c += 2) bytes.push(parseInt(hex.substr(c, 2), 16));
+  return bytes;
+}
+
+// Helper function for createIdFromUniqueString
+function stripDashes(uuid: string) {
+  return uuid.split('-').join('');
 }

--- a/packages/substream/sink/utils/id.ts
+++ b/packages/substream/sink/utils/id.ts
@@ -10,6 +10,11 @@ export function createVersionId({ proposalId, entityId }: { proposalId: string; 
   return `${proposalId}:${entityId}`;
 }
 
+/**
+ * A space's id is derived from the contract address of the DAO and the network the DAO is deployed to.
+ * Users can import or fork a space from any network and import the contents of the original space into
+ * the new one that they're creating.
+ */
 export function createSpaceId({ network, address }: { network: string; address: string }) {
   return createIdFromUniqueString(`${network}:${address}`);
 }
@@ -18,14 +23,16 @@ function createIdFromUniqueString(text: string) {
   const hashed = createHash('md5').update(text).digest('hex');
   const bytes = hexToBytesArray(hashed);
   const uuid = v4({ random: bytes });
-  const id = stripDashes(uuid);
-
-  return id;
+  return stripDashes(uuid);
 }
 
 function hexToBytesArray(hex: string) {
-  let bytes = [];
-  for (let c = 0; c < hex.length; c += 2) bytes.push(parseInt(hex.substr(c, 2), 16));
+  let bytes: number[] = [];
+
+  for (let character = 0; character < hex.length; character += 2) {
+    bytes.push(parseInt(hex.slice(character, character + 2), 16));
+  }
+
   return bytes;
 }
 

--- a/packages/substream/sink/zapatos/schema.d.ts
+++ b/packages/substream/sink/zapatos/schema.d.ts
@@ -4037,6 +4037,12 @@ declare module 'zapatos/schema' {
       */
       type: space_type;
       /**
+      * **spaces.dao_address**
+      * - `text` in database
+      * - `NOT NULL`, no default
+      */
+      dao_address: string;
+      /**
       * **spaces.space_plugin_address**
       * - `text` in database
       * - Nullable, no default
@@ -4092,6 +4098,12 @@ declare module 'zapatos/schema' {
       * - `NOT NULL`, no default
       */
       type: space_type;
+      /**
+      * **spaces.dao_address**
+      * - `text` in database
+      * - `NOT NULL`, no default
+      */
+      dao_address: string;
       /**
       * **spaces.space_plugin_address**
       * - `text` in database
@@ -4149,6 +4161,12 @@ declare module 'zapatos/schema' {
       */
       type?: space_type | db.Parameter<space_type> | db.SQLFragment | db.ParentColumn | db.SQLFragment<any, space_type | db.Parameter<space_type> | db.SQLFragment | db.ParentColumn>;
       /**
+      * **spaces.dao_address**
+      * - `text` in database
+      * - `NOT NULL`, no default
+      */
+      dao_address?: string | db.Parameter<string> | db.SQLFragment | db.ParentColumn | db.SQLFragment<any, string | db.Parameter<string> | db.SQLFragment | db.ParentColumn>;
+      /**
       * **spaces.space_plugin_address**
       * - `text` in database
       * - Nullable, no default
@@ -4205,6 +4223,12 @@ declare module 'zapatos/schema' {
       */
       type: space_type | db.Parameter<space_type> | db.SQLFragment;
       /**
+      * **spaces.dao_address**
+      * - `text` in database
+      * - `NOT NULL`, no default
+      */
+      dao_address: string | db.Parameter<string> | db.SQLFragment;
+      /**
       * **spaces.space_plugin_address**
       * - `text` in database
       * - Nullable, no default
@@ -4260,6 +4284,12 @@ declare module 'zapatos/schema' {
       * - `NOT NULL`, no default
       */
       type?: space_type | db.Parameter<space_type> | db.SQLFragment | db.SQLFragment<any, space_type | db.Parameter<space_type> | db.SQLFragment>;
+      /**
+      * **spaces.dao_address**
+      * - `text` in database
+      * - `NOT NULL`, no default
+      */
+      dao_address?: string | db.Parameter<string> | db.SQLFragment | db.SQLFragment<any, string | db.Parameter<string> | db.SQLFragment>;
       /**
       * **spaces.space_plugin_address**
       * - `text` in database


### PR DESCRIPTION
This PR moves space ids from being contract addresses to a chain-independent uuid. For spaces that might be imported from another chain, we derive the original space id from the network and the original contract address. For new spaces we derive the id from the current network for the indexer and the contract address.