### PR TITLE
feat: create additional relations via + button

### DIFF
--- a/apps/web/design-system/autocomplete/results-list.tsx
+++ b/apps/web/design-system/autocomplete/results-list.tsx
@@ -2,9 +2,7 @@ import cx from 'classnames';
 
 import * as React from 'react';
 
-import { Entity } from '~/core/io/dto/entities';
 import { SearchResult } from '~/core/io/dto/search';
-import { Space } from '~/core/io/dto/spaces';
 
 import { Breadcrumb } from '~/design-system/breadcrumb';
 import { CheckCircleSmall } from '~/design-system/icons/check-circle-small';

--- a/apps/web/design-system/select-entity-dialog.tsx
+++ b/apps/web/design-system/select-entity-dialog.tsx
@@ -19,13 +19,13 @@ export function SelectEntityAsPopover({ trigger, onDone, spaceId, allowedTypes }
       <Popover.Trigger asChild>{trigger}</Popover.Trigger>
 
       <Popover.Portal>
-        <Popover.Content sideOffset={4} align="start" className="rounded-md border border-divider bg-white">
+        <Popover.Content sideOffset={4} align="start">
           <SelectEntity
             withSearchIcon={true}
             spaceId={spaceId}
             allowedTypes={allowedTypes}
             onDone={onDone}
-            inputVariant="floating"
+            variant="floating"
           />
         </Popover.Content>
       </Popover.Portal>

--- a/apps/web/design-system/select-entity-dialog.tsx
+++ b/apps/web/design-system/select-entity-dialog.tsx
@@ -1,46 +1,34 @@
-import * as PopoverPrimitive from '@radix-ui/react-popover';
+import * as Popover from '@radix-ui/react-popover';
 
-import { useState } from 'react';
+import * as React from 'react';
 
-import type { RelationValueType } from '~/core/types';
-
-import { SquareButton } from '~/design-system/button';
-import { CreateSmall } from '~/design-system/icons/create-small';
+import { RelationValueType } from '~/core/types';
 
 import { SelectEntity } from './select-entity';
 
-type SelectEntityDialogProps = {
-  onDone: (result: { id: string; name: string | null; space?: string }) => void;
+interface Props {
+  trigger: React.ReactNode;
   spaceId: string;
+  onDone: (result: { id: string; name: string | null; space?: string }) => void;
   allowedTypes?: RelationValueType[];
-  placeholder?: string;
-  className?: string;
-};
+}
 
-export const SelectEntityDialog = ({ onDone, spaceId, allowedTypes }: SelectEntityDialogProps) => {
-  const [open, setOpen] = useState(false);
-
+export function SelectEntityAsPopover({ trigger, onDone, spaceId, allowedTypes }: Props) {
   return (
-    <PopoverPrimitive.Root open={open} onOpenChange={setOpen}>
-      <PopoverPrimitive.Trigger asChild>
-        <SquareButton icon={<CreateSmall />} />
-      </PopoverPrimitive.Trigger>
-      <div className="elevated-popover">
-        <PopoverPrimitive.Content className="mt-1 flex flex-col overflow-hidden" align="start" avoidCollisions={false}>
+    <Popover.Root>
+      <Popover.Trigger asChild>{trigger}</Popover.Trigger>
+
+      <Popover.Portal>
+        <Popover.Content sideOffset={4} align="start" className="rounded-md border border-divider bg-white">
           <SelectEntity
-            onDone={result => {
-              onDone(result);
-              setOpen(false);
-            }}
+            withSearchIcon={true}
             spaceId={spaceId}
             allowedTypes={allowedTypes}
-            wrapperClassName="relative w-[400px] rounded-md border border-divider bg-white"
-            inputClassName="m-0 block w-full resize-none bg-transparent p-2 text-body placeholder:text-grey-02 focus:outline-none"
-            resultsClassName="-mx-px -mb-px"
-            withSearchIcon
+            onDone={onDone}
+            inputVariant="floating"
           />
-        </PopoverPrimitive.Content>
-      </div>
-    </PopoverPrimitive.Root>
+        </Popover.Content>
+      </Popover.Portal>
+    </Popover.Root>
   );
-};
+}

--- a/apps/web/design-system/select-entity.tsx
+++ b/apps/web/design-system/select-entity.tsx
@@ -1,5 +1,5 @@
 import { SYSTEM_IDS } from '@geogenesis/sdk';
-import * as Popover from '@radix-ui/react-popover';
+import { cva } from 'class-variance-authority';
 import cx from 'classnames';
 import { useAtom } from 'jotai';
 import pluralize from 'pluralize';
@@ -21,7 +21,7 @@ import { Tag } from '~/design-system/tag';
 import { Toggle } from '~/design-system/toggle';
 
 import { ArrowLeft } from './icons/arrow-left';
-import { Input } from './input';
+import { Search } from './icons/search';
 import { showingIdsAtom } from '~/atoms';
 
 type SelectEntityProps = {
@@ -32,6 +32,25 @@ type SelectEntityProps = {
   inputVariant?: 'floating' | 'fixed';
   withSearchIcon?: boolean;
 };
+
+const inputStyles = cva('', {
+  variants: {
+    fixed: {
+      true: 'm-0 -mb-[1px] block w-full resize-none bg-white p-0 text-body placeholder:text-grey-02 focus:outline-none',
+    },
+    floating: {
+      true: 'm-0 block w-full resize-none bg-transparent p-2 text-body placeholder:text-grey-02 focus:outline-none',
+    },
+    withSearchIcon: {
+      true: 'pl-9',
+    },
+  },
+  defaultVariants: {
+    fixed: true,
+    floating: false,
+    withSearchIcon: false,
+  },
+});
 
 export const SelectEntity = ({
   onDone,
@@ -105,30 +124,24 @@ export const SelectEntity = ({
 
   return (
     <div ref={ref} className="relative w-[400px]">
-      {inputVariant === 'fixed' ? (
-        <input
-          type="text"
-          value={query}
-          onChange={({ currentTarget: { value } }) => onQueryChange(value)}
-          placeholder={placeholder}
-          className="m-0 -mb-[1px] block w-full resize-none bg-white p-0 text-body placeholder:text-grey-02 focus:outline-none"
-        />
-      ) : (
-        <Input
-          placeholder={placeholder}
-          value={query}
-          withExternalSearchIcon={withSearchIcon}
-          onChange={e => onQueryChange(e.currentTarget.value)}
-        />
+      {withSearchIcon && (
+        <div className="absolute left-3 top-3.5 z-10">
+          <Search />
+        </div>
       )}
+
+      <input
+        type="text"
+        value={query}
+        onChange={({ currentTarget: { value } }) => onQueryChange(value)}
+        placeholder={placeholder}
+        className={inputStyles({ [inputVariant]: true, withSearchIcon })}
+      />
 
       {query && (
         <div className="absolute z-[1000]">
           <div
-            className={cx(
-              'w-[400px] overflow-hidden rounded-md border border-divider bg-white',
-              withSearchIcon && 'rounded-t-none'
-            )}
+            className={cx('w-[400px] rounded-md border border-divider bg-white', withSearchIcon && 'rounded-t-none')}
           >
             {!result ? (
               <div className="flex max-h-[180px] flex-col overflow-y-auto bg-white">
@@ -260,14 +273,3 @@ export const SelectEntity = ({
     </div>
   );
 };
-
-export function SelectEntityAsPopover({ children, trigger }: { children: React.ReactNode; trigger: React.ReactNode }) {
-  return (
-    <Popover.Root>
-      <Popover.Trigger asChild>{trigger}</Popover.Trigger>
-      <Popover.Portal>
-        <Popover.Content>{children}</Popover.Content>
-      </Popover.Portal>
-    </Popover.Root>
-  );
-}

--- a/apps/web/design-system/select-entity.tsx
+++ b/apps/web/design-system/select-entity.tsx
@@ -15,11 +15,11 @@ import type { RelationValueType } from '~/core/types';
 import { getImagePath } from '~/core/utils/utils';
 
 import { EntityCreatedToast } from '~/design-system/autocomplete/entity-created-toast';
-import { Search } from '~/design-system/icons/search';
 import { Tag } from '~/design-system/tag';
 import { Toggle } from '~/design-system/toggle';
 
 import { ArrowLeft } from './icons/arrow-left';
+import { Input } from './input';
 import { showingIdsAtom } from '~/atoms';
 
 type SelectEntityProps = {
@@ -27,9 +27,7 @@ type SelectEntityProps = {
   spaceId: string;
   allowedTypes?: RelationValueType[];
   placeholder?: string;
-  wrapperClassName?: string;
-  inputClassName?: string;
-  resultsClassName?: string;
+  inputVariant?: 'floating' | 'fixed';
   withSearchIcon?: boolean;
 };
 
@@ -38,9 +36,7 @@ export const SelectEntity = ({
   spaceId,
   allowedTypes,
   placeholder = 'Find or create...',
-  wrapperClassName = '',
-  inputClassName = '',
-  resultsClassName = '',
+  inputVariant = 'fixed',
   withSearchIcon = false,
 }: SelectEntityProps) => {
   const [isShowingIds, setIsShowingIds] = useAtom(showingIdsAtom);
@@ -106,21 +102,26 @@ export const SelectEntity = ({
   }, ref);
 
   return (
-    <div ref={ref} className={wrapperClassName}>
-      <input
-        type="text"
-        value={query}
-        onChange={({ currentTarget: { value } }) => onQueryChange(value)}
-        placeholder={placeholder}
-        className={cx(withSearchIcon && 'pl-9', inputClassName)}
-      />
-      {withSearchIcon && (
-        <div className="absolute left-3 top-3.5 z-10">
-          <Search />
-        </div>
+    <div ref={ref} className="w-[400px]">
+      {inputVariant === 'fixed' ? (
+        <input
+          type="text"
+          value={query}
+          onChange={({ currentTarget: { value } }) => onQueryChange(value)}
+          placeholder={placeholder}
+          className="m-0 -mb-[1px] block w-full resize-none bg-white p-0 text-body placeholder:text-grey-02 focus:outline-none"
+        />
+      ) : (
+        <Input
+          placeholder={placeholder}
+          value={query}
+          withExternalSearchIcon={withSearchIcon}
+          onChange={e => onQueryChange(e.currentTarget.value)}
+        />
       )}
+
       {query && (
-        <div className={resultsClassName}>
+        <div>
           <div
             className={cx(
               'w-[400px] overflow-hidden rounded-md border border-divider bg-white',
@@ -128,23 +129,23 @@ export const SelectEntity = ({
             )}
           >
             {!result ? (
-              <div className="flex max-h-[180px] flex-col overflow-y-auto">
+              <div className="flex max-h-[180px] flex-col overflow-y-auto bg-white">
                 {!results?.length && isLoading && (
-                  <div className="block w-full border-b border-divider px-3 py-2">
+                  <div className="w-full border-b border-divider bg-white px-3 py-2">
                     <div className="truncate text-button text-text">Loading...</div>
                   </div>
                 )}
                 {isEmpty ? (
-                  <div className="block w-full border-b border-divider px-3 py-2">
+                  <div className="w-full border-b border-divider bg-white px-3 py-2">
                     <div className="truncate text-button text-text">No results.</div>
                   </div>
                 ) : (
-                  <>
+                  <div className="divider-y-divider bg-white">
                     {results.map((result, index) => (
                       <button
                         key={index}
                         onClick={() => setResult(result)}
-                        className="block w-full border-b border-divider px-3 py-2 hover:bg-grey-01"
+                        className="w-full px-3 py-2 hover:bg-grey-01"
                       >
                         <div className="truncate text-button text-text">{result.name}</div>
                         {isShowingIds && <div className="mb-2 mt-1 text-footnoteMedium text-grey-04">{result.id}</div>}
@@ -155,11 +156,7 @@ export const SelectEntity = ({
                                 key={space.spaceId}
                                 className="-ml-[4px] h-[14px] w-[14px] overflow-clip rounded-sm border border-white first:ml-0"
                               >
-                                <img
-                                  src={getImagePath(space.image)}
-                                  alt=""
-                                  className="block h-full w-full object-cover"
-                                />
+                                <img src={getImagePath(space.image)} alt="" className="h-full w-full object-cover" />
                               </div>
                             ))}
                           </div>
@@ -169,12 +166,12 @@ export const SelectEntity = ({
                         </div>
                       </button>
                     ))}
-                  </>
+                  </div>
                 )}
               </div>
             ) : (
               <>
-                <div className="flex items-center justify-evenly border-b border-divider">
+                <div className="flex items-center justify-evenly border-b border-divider bg-white">
                   <div className="flex-1">
                     <button onClick={() => setResult(null)} className="p-2">
                       <ArrowLeft color="grey-04" />
@@ -183,14 +180,16 @@ export const SelectEntity = ({
                   <div className="flex flex-1 justify-center">
                     <span className="p-2 text-center text-smallButton text-grey-04">Select space version</span>
                   </div>
-                  <div className="flex flex-1 justify-end">
-                    {/* @TODO add settings */}
-                    {/* <button className="p-2 text-smallButton text-grey-04">Settings</button> */}
-                  </div>
+                  {/* <div className="flex flex-1 justify-end">
+                     @TODO add settings 
+                    <button className="p-2 text-smallButton text-grey-04">Settings</button> 
+                  </div> */}
                 </div>
-                <div className="flex max-h-[180px] flex-col overflow-y-auto">
+                <div className="flex max-h-[180px] flex-col overflow-y-auto bg-white">
                   <button
                     onClick={() => {
+                      // @TODO: Set space
+                      setResult(null);
                       onDone({
                         id: result.id,
                         name: result.name,
@@ -210,7 +209,7 @@ export const SelectEntity = ({
                           key={space.spaceId}
                           className="-ml-[4px] h-[14px] w-[14px] overflow-clip rounded-sm border border-white first:ml-0"
                         >
-                          <img src={getImagePath(space.image)} alt="" className="block h-full w-full object-cover" />
+                          <img src={getImagePath(space.image)} alt="" className="h-full w-full object-cover" />
                         </div>
                       ))}
                     </div>
@@ -219,6 +218,7 @@ export const SelectEntity = ({
                     <button
                       key={index}
                       onClick={() => {
+                        setResult(null);
                         onDone({
                           id: result.id,
                           name: result.name,
@@ -235,7 +235,7 @@ export const SelectEntity = ({
                       </div>
                       <div>
                         <div className="h-[32px] w-[32px] overflow-clip rounded-md">
-                          <img src={getImagePath(space.image)} alt="" className="block h-full w-full object-cover" />
+                          <img src={getImagePath(space.image)} alt="" className="h-full w-full object-cover" />
                         </div>
                       </div>
                     </button>

--- a/apps/web/design-system/select-entity.tsx
+++ b/apps/web/design-system/select-entity.tsx
@@ -1,8 +1,10 @@
 import { SYSTEM_IDS } from '@geogenesis/sdk';
+import * as Popover from '@radix-ui/react-popover';
 import cx from 'classnames';
 import { useAtom } from 'jotai';
 import pluralize from 'pluralize';
 
+import * as React from 'react';
 import { useRef, useState } from 'react';
 
 import { useWriteOps } from '~/core/database/write';
@@ -260,3 +262,14 @@ export const SelectEntity = ({
     </div>
   );
 };
+
+export function SelectEntityAsPopover({ children, trigger }: { children: React.ReactNode; trigger: React.ReactNode }) {
+  return (
+    <Popover.Root>
+      <Popover.Trigger asChild>{trigger}</Popover.Trigger>
+      <Popover.Portal>
+        <Popover.Content>{children}</Popover.Content>
+      </Popover.Portal>
+    </Popover.Root>
+  );
+}

--- a/apps/web/design-system/select-entity.tsx
+++ b/apps/web/design-system/select-entity.tsx
@@ -104,7 +104,7 @@ export const SelectEntity = ({
   }, ref);
 
   return (
-    <div ref={ref} className="w-[400px]">
+    <div ref={ref} className="relative w-[400px]">
       {inputVariant === 'fixed' ? (
         <input
           type="text"
@@ -123,7 +123,7 @@ export const SelectEntity = ({
       )}
 
       {query && (
-        <div>
+        <div className="absolute z-[1000]">
           <div
             className={cx(
               'w-[400px] overflow-hidden rounded-md border border-divider bg-white',
@@ -173,15 +173,13 @@ export const SelectEntity = ({
               </div>
             ) : (
               <>
-                <div className="flex items-center justify-evenly border-b border-divider bg-white">
+                <div className="flex items-center justify-between border-b border-divider bg-white">
                   <div className="flex-1">
                     <button onClick={() => setResult(null)} className="p-2">
                       <ArrowLeft color="grey-04" />
                     </button>
                   </div>
-                  <div className="flex flex-1 justify-center">
-                    <span className="p-2 text-center text-smallButton text-grey-04">Select space version</span>
-                  </div>
+                  <p className="p-2 text-smallButton text-grey-04">Select space version</p>
                   {/* <div className="flex flex-1 justify-end">
                      @TODO add settings 
                     <button className="p-2 text-smallButton text-grey-04">Settings</button> 

--- a/apps/web/design-system/select-entity.tsx
+++ b/apps/web/design-system/select-entity.tsx
@@ -29,14 +29,14 @@ type SelectEntityProps = {
   spaceId: string;
   allowedTypes?: RelationValueType[];
   placeholder?: string;
-  inputVariant?: 'floating' | 'fixed';
+  variant?: 'floating' | 'fixed';
   withSearchIcon?: boolean;
 };
 
 const inputStyles = cva('', {
   variants: {
     fixed: {
-      true: 'm-0 -mb-[1px] block w-full resize-none bg-white p-0 text-body placeholder:text-grey-02 focus:outline-none',
+      true: 'm-0 block w-full resize-none bg-transparent p-0 text-body placeholder:text-grey-02 focus:outline-none',
     },
     floating: {
       true: 'm-0 block w-full resize-none bg-transparent p-2 text-body placeholder:text-grey-02 focus:outline-none',
@@ -52,12 +52,27 @@ const inputStyles = cva('', {
   },
 });
 
+const containerStyles = cva('relative w-[400px]', {
+  variants: {
+    floating: {
+      true: 'rounded-md border border-divider bg-white',
+    },
+    isQueried: {
+      true: 'rounded-b-none',
+    },
+  },
+  defaultVariants: {
+    floating: false,
+    isQueried: false,
+  },
+});
+
 export const SelectEntity = ({
   onDone,
   spaceId,
   allowedTypes,
   placeholder = 'Find or create...',
-  inputVariant = 'fixed',
+  variant = 'fixed',
   withSearchIcon = false,
 }: SelectEntityProps) => {
   const [isShowingIds, setIsShowingIds] = useAtom(showingIdsAtom);
@@ -123,7 +138,7 @@ export const SelectEntity = ({
   }, ref);
 
   return (
-    <div ref={ref} className="relative w-[400px]">
+    <div ref={ref} className={containerStyles({ floating: variant === 'floating', isQueried: query.length > 0 })}>
       {withSearchIcon && (
         <div className="absolute left-3 top-3.5 z-10">
           <Search />
@@ -135,13 +150,16 @@ export const SelectEntity = ({
         value={query}
         onChange={({ currentTarget: { value } }) => onQueryChange(value)}
         placeholder={placeholder}
-        className={inputStyles({ [inputVariant]: true, withSearchIcon })}
+        className={inputStyles({ [variant]: true, withSearchIcon })}
       />
 
       {query && (
         <div className="absolute z-[1000]">
           <div
-            className={cx('w-[400px] rounded-md border border-divider bg-white', withSearchIcon && 'rounded-t-none')}
+            className={cx(
+              '-ml-px w-[400px] overflow-hidden rounded-md border border-divider bg-white',
+              withSearchIcon && 'rounded-t-none'
+            )}
           >
             {!result ? (
               <div className="flex max-h-[180px] flex-col overflow-y-auto bg-white">

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -59,7 +59,7 @@
     "@vercel/analytics": "^0.1.6",
     "@vercel/og": "^0.5.4",
     "boring-avatars": "^1.10.1",
-    "class-variance-authority": "^0.4.0",
+    "class-variance-authority": "^0.7.0",
     "classnames": "^2.3.2",
     "cmdk": "^0.1.21",
     "crypto-js": "^4.2.0",

--- a/apps/web/partials/entity-page/editable-entity-page.tsx
+++ b/apps/web/partials/entity-page/editable-entity-page.tsx
@@ -21,7 +21,8 @@ import { WebUrlField } from '~/design-system/editable-fields/web-url-field';
 import { Create } from '~/design-system/icons/create';
 import { Trash } from '~/design-system/icons/trash';
 import { PrefetchLink as Link } from '~/design-system/prefetch-link';
-import { SelectEntity, SelectEntityAsPopover } from '~/design-system/select-entity';
+import { SelectEntity } from '~/design-system/select-entity';
+import { SelectEntityAsPopover } from '~/design-system/select-entity-dialog';
 import { Text } from '~/design-system/text';
 
 import { getRenderableTypeSelectorOptions } from './get-renderable-type-options';
@@ -244,25 +245,22 @@ function RelationsGroup({ relations }: { relations: RelationRenderableProperty[]
       })}
       {!hasPlaceholders && (
         <div className="mt-1">
-          <SelectEntityAsPopover trigger={<SquareButton icon={<Create />} />}>
-            <SelectEntity
-              withSearchIcon={true}
-              spaceId={spaceId}
-              onDone={result => {
-                send({
-                  type: 'UPSERT_RELATION',
-                  payload: {
-                    fromEntityId: id,
-                    toEntityId: result.id,
-                    toEntityName: result.name,
-                    typeOfId: typeOfId,
-                    typeOfName: typeOfName,
-                  },
-                });
-              }}
-              inputVariant="floating"
-            />
-          </SelectEntityAsPopover>
+          <SelectEntityAsPopover
+            trigger={<SquareButton icon={<Create />} />}
+            onDone={result => {
+              send({
+                type: 'UPSERT_RELATION',
+                payload: {
+                  fromEntityId: id,
+                  toEntityId: result.id,
+                  toEntityName: result.name,
+                  typeOfId: typeOfId,
+                  typeOfName: typeOfName,
+                },
+              });
+            }}
+            spaceId={spaceId}
+          />
         </div>
       )}
     </div>

--- a/apps/web/partials/entity-page/editable-entity-page.tsx
+++ b/apps/web/partials/entity-page/editable-entity-page.tsx
@@ -218,7 +218,7 @@ function RelationsGroup({ relations }: { relations: RelationRenderableProperty[]
                     },
                   });
                 }}
-                inputVariant="fixed"
+                variant="fixed"
               />
             </div>
           );
@@ -327,7 +327,7 @@ function TriplesGroup({ triples }: { triples: TripleRenderableProperty[] }) {
                         },
                       });
                     }}
-                    inputVariant="fixed"
+                    variant="fixed"
                   />
                 </div>
               );

--- a/apps/web/partials/entity-page/editable-entity-page.tsx
+++ b/apps/web/partials/entity-page/editable-entity-page.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { SYSTEM_IDS } from '@geogenesis/sdk';
-import * as Popover from '@radix-ui/react-popover';
 
 import * as React from 'react';
 
@@ -22,7 +21,7 @@ import { WebUrlField } from '~/design-system/editable-fields/web-url-field';
 import { Create } from '~/design-system/icons/create';
 import { Trash } from '~/design-system/icons/trash';
 import { PrefetchLink as Link } from '~/design-system/prefetch-link';
-import { SelectEntity } from '~/design-system/select-entity';
+import { SelectEntity, SelectEntityAsPopover } from '~/design-system/select-entity';
 import { Text } from '~/design-system/text';
 
 import { getRenderableTypeSelectorOptions } from './get-renderable-type-options';
@@ -245,32 +244,25 @@ function RelationsGroup({ relations }: { relations: RelationRenderableProperty[]
       })}
       {!hasPlaceholders && (
         <div className="mt-1">
-          <Popover.Root>
-            <Popover.Trigger asChild>
-              <SquareButton icon={<Create />} />
-            </Popover.Trigger>
-            <Popover.Portal>
-              <Popover.Content>
-                <SelectEntity
-                  withSearchIcon={true}
-                  spaceId={spaceId}
-                  onDone={result => {
-                    send({
-                      type: 'UPSERT_RELATION',
-                      payload: {
-                        fromEntityId: id,
-                        toEntityId: result.id,
-                        toEntityName: result.name,
-                        typeOfId: typeOfId,
-                        typeOfName: typeOfName,
-                      },
-                    });
-                  }}
-                  inputVariant="floating"
-                />
-              </Popover.Content>
-            </Popover.Portal>
-          </Popover.Root>
+          <SelectEntityAsPopover trigger={<SquareButton icon={<Create />} />}>
+            <SelectEntity
+              withSearchIcon={true}
+              spaceId={spaceId}
+              onDone={result => {
+                send({
+                  type: 'UPSERT_RELATION',
+                  payload: {
+                    fromEntityId: id,
+                    toEntityId: result.id,
+                    toEntityName: result.name,
+                    typeOfId: typeOfId,
+                    typeOfName: typeOfName,
+                  },
+                });
+              }}
+              inputVariant="floating"
+            />
+          </SelectEntityAsPopover>
         </div>
       )}
     </div>

--- a/apps/web/partials/entity-page/editable-entity-page.tsx
+++ b/apps/web/partials/entity-page/editable-entity-page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { SYSTEM_IDS } from '@geogenesis/sdk';
+import * as Popover from '@radix-ui/react-popover';
 
 import * as React from 'react';
 
@@ -183,6 +184,8 @@ function RelationsGroup({ relations }: { relations: RelationRenderableProperty[]
   });
 
   const hasPlaceholders = relations.some(r => r.placeholder === true);
+  const typeOfId = relations[0].attributeId;
+  const typeOfName = relations[0].attributeName;
 
   return (
     <div className="flex flex-wrap items-center gap-2">
@@ -215,9 +218,7 @@ function RelationsGroup({ relations }: { relations: RelationRenderableProperty[]
                     },
                   });
                 }}
-                wrapperClassName="contents"
-                inputClassName="m-0 -mb-[1px] block w-full resize-none bg-transparent p-0 text-body placeholder:text-grey-02 focus:outline-none"
-                resultsClassName="absolute z-[1000]"
+                inputVariant="fixed"
               />
             </div>
           );
@@ -244,12 +245,32 @@ function RelationsGroup({ relations }: { relations: RelationRenderableProperty[]
       })}
       {!hasPlaceholders && (
         <div className="mt-1">
-          <SquareButton
-            onClick={() => {
-              //
-            }}
-            icon={<Create />}
-          />
+          <Popover.Root>
+            <Popover.Trigger asChild>
+              <SquareButton icon={<Create />} />
+            </Popover.Trigger>
+            <Popover.Portal>
+              <Popover.Content>
+                <SelectEntity
+                  withSearchIcon={true}
+                  spaceId={spaceId}
+                  onDone={result => {
+                    send({
+                      type: 'UPSERT_RELATION',
+                      payload: {
+                        fromEntityId: id,
+                        toEntityId: result.id,
+                        toEntityName: result.name,
+                        typeOfId: typeOfId,
+                        typeOfName: typeOfName,
+                      },
+                    });
+                  }}
+                  inputVariant="floating"
+                />
+              </Popover.Content>
+            </Popover.Portal>
+          </Popover.Root>
         </div>
       )}
     </div>
@@ -316,9 +337,7 @@ function TriplesGroup({ triples }: { triples: TripleRenderableProperty[] }) {
                         },
                       });
                     }}
-                    wrapperClassName="contents"
-                    inputClassName="m-0 -mb-[1px] block w-full resize-none bg-transparent p-0 text-body placeholder:text-grey-02 focus:outline-none"
-                    resultsClassName="absolute z-[1000]"
+                    inputVariant="fixed"
                   />
                 </div>
               );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,7 +92,7 @@ importers:
       '@vitest/ui': ^0.25.6
       autoprefixer: ^10.4.13
       boring-avatars: ^1.10.1
-      class-variance-authority: ^0.4.0
+      class-variance-authority: ^0.7.0
       classnames: ^2.3.2
       cmdk: ^0.1.21
       crypto-js: ^4.2.0
@@ -189,7 +189,7 @@ importers:
       '@vercel/analytics': 0.1.6_react@18.2.0
       '@vercel/og': 0.5.4
       boring-avatars: 1.10.1
-      class-variance-authority: 0.4.0_typescript@5.5.3
+      class-variance-authority: 0.7.0
       classnames: 2.3.2
       cmdk: 0.1.21_ew3x2u2ugx4vldoypxrzsnu5mm
       crypto-js: 4.2.0
@@ -1233,7 +1233,7 @@ packages:
       eth-json-rpc-filters: 6.0.1
       eventemitter3: 5.0.1
       keccak: 3.0.4
-      preact: 10.23.1
+      preact: 10.23.2
       sha.js: 2.4.11
     transitivePeerDependencies:
       - supports-color
@@ -7701,15 +7701,10 @@ packages:
       consola: 3.2.3
     dev: false
 
-  /class-variance-authority/0.4.0_typescript@5.5.3:
-    resolution: {integrity: sha512-74enNN8O9ZNieycac/y8FxqgyzZhZbxmCitAtAeUrLPlxjSd5zA7LfpprmxEcOmQBnaGs5hYhiSGnJ0mqrtBLQ==}
-    peerDependencies:
-      typescript: '>= 4.5.5 < 5'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
+  /class-variance-authority/0.7.0:
+    resolution: {integrity: sha512-jFI8IQw4hczaL4ALINxqLEXQbWcNjoSkloa4IaufXCJr6QawJyw7tuRysRsrE8w2p/4gGaxKIt/hX3qz/IbD1A==}
     dependencies:
-      typescript: 5.5.3
+      clsx: 2.0.0
     dev: false
 
   /classnames/2.3.2:
@@ -7748,6 +7743,11 @@ packages:
 
   /clsx/1.2.1:
     resolution: {integrity: sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==}
+    engines: {node: '>=6'}
+    dev: false
+
+  /clsx/2.0.0:
+    resolution: {integrity: sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q==}
     engines: {node: '>=6'}
     dev: false
 
@@ -9821,7 +9821,7 @@ packages:
     resolution: {integrity: sha512-an2S5quJMiy5bnZKEf6AkfH/7r8CzHvhchU40gxN+OM6HPhe7Z9T1FUychcf2M9PpPOO0Hf7BAEfJkw2TDIBDw==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      readable-stream: 4.4.2
+      readable-stream: 3.6.2
       webextension-polyfill: 0.10.0
     dev: false
 
@@ -12599,8 +12599,8 @@ packages:
     resolution: {integrity: sha512-jRYbDDgMpIb5LHq3hkI0bbl+l/TQ9UnkdQ0ww+lp+4MMOdqaUYdFc5qeyP+IV8FAd/2Em7drVPeKdQxsiWCf/A==}
     dev: false
 
-  /preact/10.23.1:
-    resolution: {integrity: sha512-O5UdRsNh4vdZaTieWe3XOgSpdMAmkIYBCT3VhQDlKrzyCm8lUYsk0fmVEvoQQifoOjFRTaHZO69ylrzTW2BH+A==}
+  /preact/10.23.2:
+    resolution: {integrity: sha512-kKYfePf9rzKnxOAKDpsWhg/ysrHPqT+yQ7UW4JjdnqjFIeNUnNcEJvhuA8fDenxAGWzUqtd51DfVg7xp/8T9NA==}
     dev: false
 
   /prebuild-install/7.1.1:


### PR DESCRIPTION
This PR updates the select-entity component to be consumed via multiple contexts: 1) an empty relation field 2) a non-empty relation field with a + button to trigger the select-entity experience