### PR TITLE
feat: render image relations

### DIFF
--- a/apps/web/app/space/(entities)/[id]/entities/component.tsx
+++ b/apps/web/app/space/(entities)/[id]/entities/component.tsx
@@ -2,7 +2,7 @@ import { Space } from '~/core/io/dto/spaces';
 import { InitialEntityTableStoreParams } from '~/core/state/entity-table-store/entity-table-store-params';
 import { EntityTableStoreProvider } from '~/core/state/entity-table-store/entity-table-store-provider';
 import { TypesStoreProvider } from '~/core/state/types-store/types-store';
-import { Column, Row, Triple } from '~/core/types';
+import { Row, Schema, Triple } from '~/core/types';
 
 import { Spacer } from '~/design-system/spacer';
 
@@ -16,7 +16,7 @@ interface Props {
   spaceImage: string | null;
   initialSelectedType: Triple | null;
   initialTypes: Triple[];
-  initialColumns: Column[];
+  initialColumns: Schema[];
   initialRows: Row[];
   initialParams: InitialEntityTableStoreParams;
 }

--- a/apps/web/app/space/(entity)/[id]/[entityId]/default-entity-page.tsx
+++ b/apps/web/app/space/(entity)/[id]/[entityId]/default-entity-page.tsx
@@ -40,8 +40,8 @@ export default async function DefaultEntityPage({
 
   const props = await getData(params.id, params.entityId);
 
-  const avatarUrl = Entities.avatar(props.triples) ?? props.serverAvatarUrl;
-  const coverUrl = Entities.cover(props.triples) ?? props.serverCoverUrl;
+  const avatarUrl = Entities.avatar(props.relationsOut) ?? props.serverAvatarUrl;
+  const coverUrl = Entities.cover(props.relationsOut) ?? props.serverCoverUrl;
   const types = props.types;
 
   return (
@@ -105,8 +105,8 @@ const getData = async (spaceId: string, entityId: string) => {
     }
   }
 
-  const serverAvatarUrl = Entities.avatar(entity?.triples);
-  const serverCoverUrl = Entities.cover(entity?.triples);
+  const serverAvatarUrl = Entities.avatar(entity?.relationsOut);
+  const serverCoverUrl = Entities.cover(entity?.relationsOut);
 
   const blockIds = entity?.relationsOut
     .filter(r => r.typeOf.id === EntityId(SYSTEM_IDS.BLOCKS))

--- a/apps/web/app/space/(entity)/[id]/[entityId]/layout.tsx
+++ b/apps/web/app/space/(entity)/[id]/[entityId]/layout.tsx
@@ -156,8 +156,8 @@ async function getProfilePage(entityId: string): Promise<
 
   return {
     ...person,
-    avatarUrl: Entities.avatar(person.triples),
-    coverUrl: Entities.cover(person.triples),
+    avatarUrl: Entities.avatar(person.relationsOut),
+    coverUrl: Entities.cover(person.relationsOut),
 
     relationsOut: [],
     blockRelations: person.relationsOut,

--- a/apps/web/app/space/[id]/layout.tsx
+++ b/apps/web/app/space/[id]/layout.tsx
@@ -244,7 +244,7 @@ export default async function Layout({ children, params }: Props) {
     fetchSubspacesBySpaceId(params.id),
     fetchInFlightSubspaceProposalsForSpaceId(params.id),
   ]);
-  const coverUrl = Entities.cover(props.triples);
+  const coverUrl = Entities.cover(props.relationsOut);
 
   const typeNames = props.space.spaceConfig?.types?.flatMap(t => (t.name ? [t.name] : [])) ?? [];
   const tabs = await buildTabsForSpacePage(props.space.spaceConfig?.types ?? [], params);

--- a/apps/web/app/space/[id]/team/page.tsx
+++ b/apps/web/app/space/[id]/team/page.tsx
@@ -130,7 +130,7 @@ const getTeamMembers = async (spaceId: string) => {
         //   teamMembers[teamMemberIndex].avatar = avatar;
         // }
       } else {
-        const avatar = Entities.avatar(entity.triples);
+        const avatar = Entities.avatar(entity.relationsOut);
 
         if (avatar) {
           teamMembers[teamMemberIndex].avatar = avatar;
@@ -143,7 +143,7 @@ const getTeamMembers = async (spaceId: string) => {
         teamMembers[teamMemberIndex].name = name;
       }
 
-      const avatar = Entities.avatar(entity.triples);
+      const avatar = Entities.avatar(entity.relationsOut);
 
       if (avatar) {
         teamMembers[teamMemberIndex].avatar = avatar;

--- a/apps/web/core/database/atoms.ts
+++ b/apps/web/core/database/atoms.ts
@@ -3,69 +3,18 @@ import { atom } from 'jotai';
 import { localRelationsAtom } from '~/core/database/write';
 import { Relation } from '~/core/io/dto/entities';
 
+import { StoredRelation } from './types';
+
 // @TODO: This should read from local relations atom instead of local ops atom
 export const createRelationsAtom = (initialRelations: Relation[]) => {
-  return atom(get => {
+  return atom((get): StoredRelation[] => {
     const localRelations = get(localRelationsAtom);
-
-    /***********************************************************************************************/
-    // A relation might exist remotely but is deleted locally. We need to remove those from the
-    // list of relations that we return.
-    //
-    // We can consider a relation as being deleted when its Types -> Relation triple is deleted. This set
-    // of ids might include relations from entities besides the entityPageId that were deleted locally.
-    //
-    // Later we filter these to only be the relations that are from the entityPageId.
     const locallyDeletedRelations = localRelations.filter(r => r.isDeleted).map(r => r.id);
 
-    const deletedRelationIds = new Set(...locallyDeletedRelations);
+    const deletedRelationIds = new Set(locallyDeletedRelations);
     const remoteRelationsThatWerentDeleted = initialRelations
-      // Only return relations coming from the entity page id which haven't been deleted locally
+      // Only return initialRelations that haven't been deleted locally
       .filter(r => !deletedRelationIds.has(r.id));
-
-    // const localRelationById = groupBy(localRelations, r => r.id);
-
-    // const activeRemoteRelations = remoteRelationsThatWerentDeleted.map((r): Relation => {
-    //   const localRelation = localRelationById[r.id];
-
-    //   return {
-    //     id: r.id,
-    //     typeOf: {
-    //       id: maybeLocalTypeOfTriple ? EntityId(maybeLocalTypeOfTriple.value.value) : EntityId(r.typeOf.id),
-    //       name: maybeLocalTypeOfTriple
-    //         ? maybeLocalTypeOfTriple.value.type === 'ENTITY'
-    //           ? maybeLocalTypeOfTriple.value.name
-    //           : r.typeOf.name
-    //         : r.typeOf.name,
-    //     },
-    //     index: maybeLocalIndexTriple ? maybeLocalIndexTriple.value.value : r.index,
-    //     fromEntity: {
-    //       id: maybeLocalFromTriple ? EntityId(maybeLocalFromTriple.value.value) : r.fromEntity.id,
-    //       name: maybeLocalFromTriple
-    //         ? maybeLocalFromTriple.value.type === 'ENTITY'
-    //           ? maybeLocalFromTriple.value.name
-    //           : r.fromEntity.name
-    //         : r.fromEntity.name,
-    //     },
-    //     toEntity: {
-    //       id: maybeLocalToTriple ? EntityId(maybeLocalToTriple.value.value) : r.toEntity.id,
-    //       renderableType: 'DEFAULT',
-    //       value: maybeLocalToTriple
-    //         ? maybeLocalToTriple.value.type === 'ENTITY'
-    //           ? maybeLocalToTriple.value.value
-    //           : r.toEntity.value
-    //         : r.toEntity.value,
-    //       name: maybeLocalToTriple
-    //         ? maybeLocalToTriple.value.type === 'ENTITY'
-    //           ? maybeLocalToTriple.value.name
-    //           : r.toEntity.name
-    //         : r.toEntity.name,
-
-    //       // @TODO(database): Not sure if this is correct
-    //       triples: localTriples.filter(t => t.entityId === r.toEntity.id),
-    //     },
-    //   };
-    // });
 
     // @TODO: Merge local triples for updated (not created) relations. This is for things like
     // the index.

--- a/apps/web/core/database/atoms.ts
+++ b/apps/web/core/database/atoms.ts
@@ -1,63 +1,12 @@
-import { SYSTEM_IDS } from '@geogenesis/sdk';
 import { atom } from 'jotai';
 
-import { localOpsAtom } from '~/core/database/write';
+import { localRelationsAtom } from '~/core/database/write';
 import { Relation } from '~/core/io/dto/entities';
-import { EntityId } from '~/core/io/schema';
 
+// @TODO: This should read from local relations atom instead of local ops atom
 export const createRelationsAtom = (initialRelations: Relation[]) => {
   return atom(get => {
-    const localTriples = get(localOpsAtom);
-
-    /***********************************************************************************************
-     * Map all triples for locally created relations to Relation
-     **********************************************************************************************/
-    // We assume if there is a created triple with Types -> Relation that it's creating an entire
-    // relation. Users shouldn't normally have a reason to change this type to something else locally,
-    // so using this triple should be a good heuristic to get all locally created relations while
-    // still reading from triples.
-    const typeTriplesForAllLocallyCreatedRelations = localTriples.filter(
-      t => t.attributeId === SYSTEM_IDS.TYPES && t.value.value === SYSTEM_IDS.RELATION_TYPE && t.isDeleted === false
-    );
-
-    // Map all the triples for locally created relations to a Relation
-    const locallyCreatedRelationTriplesByRelationId = typeTriplesForAllLocallyCreatedRelations.map(t => t.entityId);
-
-    const locallyCreatedRelations = locallyCreatedRelationTriplesByRelationId
-      .map((relationId): Relation | null => {
-        const triplesForRelation = localTriples.filter(t => t.entityId === relationId);
-        const typeOfTriple = triplesForRelation.find(t => t.attributeId === SYSTEM_IDS.RELATION_TYPE_ATTRIBUTE);
-        const indexTriple = triplesForRelation.find(t => t.attributeId === SYSTEM_IDS.RELATION_INDEX);
-        const fromEntityTriple = triplesForRelation.find(t => t.attributeId === SYSTEM_IDS.RELATION_FROM_ATTRIBUTE);
-        const toEntityTriple = triplesForRelation.find(t => t.attributeId === SYSTEM_IDS.RELATION_TO_ATTRIBUTE);
-
-        if (!typeOfTriple || !indexTriple || !fromEntityTriple || !toEntityTriple) {
-          return null;
-        }
-
-        return {
-          typeOf: {
-            id: EntityId(typeOfTriple.value.value),
-            name: typeOfTriple.value.type === 'ENTITY' ? typeOfTriple.value.name : null,
-          },
-          index: indexTriple.value.value,
-          id: EntityId(relationId),
-          fromEntity: {
-            id: EntityId(fromEntityTriple.value.value),
-            name: fromEntityTriple.value.type === 'ENTITY' ? fromEntityTriple.value.name : null,
-          },
-          toEntity: {
-            id: EntityId(toEntityTriple.value.value),
-            name: toEntityTriple.value.type === 'ENTITY' ? toEntityTriple.value.name : null,
-            // @TODO(relations): To know if a relation is an image we need to read the relations on the
-            // toEntity to see read its types.
-            renderableType: 'DEFAULT',
-            value: toEntityTriple.value.type === 'ENTITY' ? toEntityTriple.value.value : '',
-            triples: localTriples.filter(t => t.entityId === toEntityTriple.value.value),
-          },
-        };
-      })
-      .filter(r => r !== null);
+    const localRelations = get(localRelationsAtom);
 
     /***********************************************************************************************/
     // A relation might exist remotely but is deleted locally. We need to remove those from the
@@ -67,79 +16,59 @@ export const createRelationsAtom = (initialRelations: Relation[]) => {
     // of ids might include relations from entities besides the entityPageId that were deleted locally.
     //
     // Later we filter these to only be the relations that are from the entityPageId.
-    const locallyDeletedRelations = localTriples
-      .filter(
-        t => t.attributeId === SYSTEM_IDS.TYPES && t.value.value === SYSTEM_IDS.RELATION_TYPE && t.isDeleted === true
-      )
-      .map(t => t.entityId);
+    const locallyDeletedRelations = localRelations.filter(r => r.isDeleted).map(r => r.id);
 
     const deletedRelationIds = new Set(...locallyDeletedRelations);
     const remoteRelationsThatWerentDeleted = initialRelations
       // Only return relations coming from the entity page id which haven't been deleted locally
       .filter(r => !deletedRelationIds.has(r.id));
 
-    const remoteRelationsThatWerentDeletedIds = new Set(remoteRelationsThatWerentDeleted.map(r => r.id));
+    // const localRelationById = groupBy(localRelations, r => r.id);
 
-    const localTriplesForActiveRemoteRelations = localTriples.filter(t =>
-      remoteRelationsThatWerentDeletedIds.has(EntityId(t.entityId))
-    );
+    // const activeRemoteRelations = remoteRelationsThatWerentDeleted.map((r): Relation => {
+    //   const localRelation = localRelationById[r.id];
 
-    const activeRemoteRelations = remoteRelationsThatWerentDeleted.map((r): Relation => {
-      const maybeLocalTypeOfTriple = localTriplesForActiveRemoteRelations.find(
-        t => t.attributeId === SYSTEM_IDS.RELATION_TYPE_ATTRIBUTE && t.entityId === r.id
-      );
+    //   return {
+    //     id: r.id,
+    //     typeOf: {
+    //       id: maybeLocalTypeOfTriple ? EntityId(maybeLocalTypeOfTriple.value.value) : EntityId(r.typeOf.id),
+    //       name: maybeLocalTypeOfTriple
+    //         ? maybeLocalTypeOfTriple.value.type === 'ENTITY'
+    //           ? maybeLocalTypeOfTriple.value.name
+    //           : r.typeOf.name
+    //         : r.typeOf.name,
+    //     },
+    //     index: maybeLocalIndexTriple ? maybeLocalIndexTriple.value.value : r.index,
+    //     fromEntity: {
+    //       id: maybeLocalFromTriple ? EntityId(maybeLocalFromTriple.value.value) : r.fromEntity.id,
+    //       name: maybeLocalFromTriple
+    //         ? maybeLocalFromTriple.value.type === 'ENTITY'
+    //           ? maybeLocalFromTriple.value.name
+    //           : r.fromEntity.name
+    //         : r.fromEntity.name,
+    //     },
+    //     toEntity: {
+    //       id: maybeLocalToTriple ? EntityId(maybeLocalToTriple.value.value) : r.toEntity.id,
+    //       renderableType: 'DEFAULT',
+    //       value: maybeLocalToTriple
+    //         ? maybeLocalToTriple.value.type === 'ENTITY'
+    //           ? maybeLocalToTriple.value.value
+    //           : r.toEntity.value
+    //         : r.toEntity.value,
+    //       name: maybeLocalToTriple
+    //         ? maybeLocalToTriple.value.type === 'ENTITY'
+    //           ? maybeLocalToTriple.value.name
+    //           : r.toEntity.name
+    //         : r.toEntity.name,
 
-      const maybeLocalIndexTriple = localTriplesForActiveRemoteRelations.find(
-        t => t.attributeId === SYSTEM_IDS.RELATION_INDEX && t.entityId === r.id
-      );
+    //       // @TODO(database): Not sure if this is correct
+    //       triples: localTriples.filter(t => t.entityId === r.toEntity.id),
+    //     },
+    //   };
+    // });
 
-      const maybeLocalFromTriple = localTriplesForActiveRemoteRelations.find(
-        t => t.attributeId === SYSTEM_IDS.RELATION_FROM_ATTRIBUTE && t.entityId === r.id
-      );
-
-      const maybeLocalToTriple = localTriplesForActiveRemoteRelations.find(
-        t => t.attributeId === SYSTEM_IDS.RELATION_TO_ATTRIBUTE && t.entityId === r.id
-      );
-
-      return {
-        id: r.id,
-        typeOf: {
-          id: maybeLocalTypeOfTriple ? EntityId(maybeLocalTypeOfTriple.value.value) : EntityId(r.typeOf.id),
-          name: maybeLocalTypeOfTriple
-            ? maybeLocalTypeOfTriple.value.type === 'ENTITY'
-              ? maybeLocalTypeOfTriple.value.name
-              : r.typeOf.name
-            : r.typeOf.name,
-        },
-        index: maybeLocalIndexTriple ? maybeLocalIndexTriple.value.value : r.index,
-        fromEntity: {
-          id: maybeLocalFromTriple ? EntityId(maybeLocalFromTriple.value.value) : r.fromEntity.id,
-          name: maybeLocalFromTriple
-            ? maybeLocalFromTriple.value.type === 'ENTITY'
-              ? maybeLocalFromTriple.value.name
-              : r.fromEntity.name
-            : r.fromEntity.name,
-        },
-        toEntity: {
-          id: maybeLocalToTriple ? EntityId(maybeLocalToTriple.value.value) : r.toEntity.id,
-          renderableType: 'DEFAULT',
-          value: maybeLocalToTriple
-            ? maybeLocalToTriple.value.type === 'ENTITY'
-              ? maybeLocalToTriple.value.value
-              : r.toEntity.value
-            : r.toEntity.value,
-          name: maybeLocalToTriple
-            ? maybeLocalToTriple.value.type === 'ENTITY'
-              ? maybeLocalToTriple.value.name
-              : r.toEntity.name
-            : r.toEntity.name,
-
-          // @TODO(database): Not sure if this is correct
-          triples: localTriples.filter(t => t.entityId === r.toEntity.id),
-        },
-      };
-    });
-
-    return [...locallyCreatedRelations, ...activeRemoteRelations];
+    // @TODO: Merge local triples for updated (not created) relations. This is for things like
+    // the index.
+    return [...localRelations, ...remoteRelationsThatWerentDeleted];
   });
 };

--- a/apps/web/core/database/relations.ts
+++ b/apps/web/core/database/relations.ts
@@ -14,7 +14,7 @@ interface UseRelationsArgs {
 const makeLocalActionsAtomWithSelector = ({ selector, mergeWith = [] }: UseRelationsArgs) => {
   return atom(get => {
     return get(createRelationsAtom(mergeWith)).filter(r => {
-      return selector ? selector(r) : true;
+      return !r.isDeleted && (selector ? selector(r) : true);
     });
   });
 };

--- a/apps/web/core/database/search.ts
+++ b/apps/web/core/database/search.ts
@@ -48,7 +48,9 @@ export async function mergeResultsAsync(options: FetchResultsOptions): Promise<S
           ...mergedEntity,
           spaceId: space.id,
           image:
-            Entities.avatar(mergedEntity.triples) ?? Entities.cover(mergedEntity.triples) ?? PLACEHOLDER_SPACE_IMAGE,
+            Entities.avatar(mergedEntity.relationsOut) ??
+            Entities.cover(mergedEntity.relationsOut) ??
+            PLACEHOLDER_SPACE_IMAGE,
         };
       }),
     spaces => groupBy(spaces, s => s.spaceId)

--- a/apps/web/core/database/table.ts
+++ b/apps/web/core/database/table.ts
@@ -6,7 +6,7 @@ import { fetchColumns } from '../io/fetch-columns';
 import { EntityId } from '../io/schema';
 import { fetchTableRowEntities } from '../io/subgraph';
 import { queryClient } from '../query-client';
-import { Value } from '../types';
+import { Schema, Value } from '../types';
 import { EntityWithSchema, mergeEntity, mergeEntityAsync } from './entities';
 import { getRelations } from './relations';
 
@@ -97,7 +97,7 @@ export async function mergeTableEntities({ options, selectedTypeId }: MergeTable
   });
 }
 
-export async function mergeColumns(typeId: EntityId) {
+export async function mergeColumns(typeId: EntityId): Promise<Schema[]> {
   const cachedColumns = await queryClient.fetchQuery({
     queryKey: ['table-columns-for-merging', typeId],
     queryFn: () => fetchColumns({ typeIds: [typeId] }),
@@ -105,11 +105,12 @@ export async function mergeColumns(typeId: EntityId) {
 
   const localAttributesForSelectedType = getRelations({
     selector: r => r.typeOf.id === SYSTEM_IDS.ATTRIBUTES && r.fromEntity.id === typeId,
-  }).map(r => {
+  }).map((r): Schema => {
     return {
       id: r.toEntity.id,
       name: r.toEntity.name,
-      triples: r.toEntity.triples,
+      // @TODO: use the real value type
+      valueType: SYSTEM_IDS.TEXT,
     };
   });
 

--- a/apps/web/core/database/types.ts
+++ b/apps/web/core/database/types.ts
@@ -1,5 +1,9 @@
 import { Triple } from '~/core/types';
 
+import { Relation } from '../io/dto/entities';
+
 export interface StoredTriple extends Triple {
   id: string;
 }
+
+export type StoredRelation = Relation & { isDeleted?: boolean };

--- a/apps/web/core/database/write.ts
+++ b/apps/web/core/database/write.ts
@@ -94,7 +94,6 @@ const writeRelation = (args: UpsertRelationArgs | DeleteRelationArgs) => {
         id: EntityId(args.relationId),
         name: null,
         renderableType: 'DEFAULT',
-        triples: [],
         value: '',
       },
     },

--- a/apps/web/core/database/write.ts
+++ b/apps/web/core/database/write.ts
@@ -8,7 +8,6 @@ import { store } from '../state/jotai-store';
 import { DeleteTripleAppOp, OmitStrict, SetTripleAppOp } from '../types';
 import { Relations } from '../utils/relations';
 import { Triples } from '../utils/triples';
-import { partition } from '../utils/utils';
 import { mergeEntityAsync } from './entities';
 import { StoredRelation, StoredTriple } from './types';
 

--- a/apps/web/core/database/write.ts
+++ b/apps/web/core/database/write.ts
@@ -73,7 +73,6 @@ const writeRelation = (args: UpsertRelationArgs | DeleteRelationArgs) => {
   }
 
   const nonDeletedRelations = store.get(localRelationsAtom).filter(r => r.id !== args.relationId);
-  console.log('deletedRelations', { nonDeletedRelations, id: args.relationId });
 
   store.set(localRelationsAtom, [
     ...nonDeletedRelations,
@@ -93,7 +92,7 @@ const writeRelation = (args: UpsertRelationArgs | DeleteRelationArgs) => {
       toEntity: {
         id: EntityId(args.relationId),
         name: null,
-        renderableType: 'DEFAULT',
+        renderableType: 'RELATION',
         value: '',
       },
     },

--- a/apps/web/core/events/edit-events.ts
+++ b/apps/web/core/events/edit-events.ts
@@ -252,7 +252,7 @@ const listener =
           toEntity: {
             id: EntityId(toEntityId),
             name: toEntityName,
-            renderableType: renderableType ?? 'DEFAULT',
+            renderableType: renderableType ?? 'RELATION',
             value: toEntityId, // @TODO(relations): Add support for images
           },
         };

--- a/apps/web/core/events/edit-events.ts
+++ b/apps/web/core/events/edit-events.ts
@@ -20,7 +20,7 @@ import { groupBy } from '~/core/utils/utils';
 import { Values } from '~/core/utils/value';
 import { valueTypeNames, valueTypes } from '~/core/value-types';
 
-import { StoreRelation, deleteRelation, upsertRelation, useWriteOps } from '../database/write';
+import { StoreRelation, removeRelation, upsertRelation, useWriteOps } from '../database/write';
 import { EntityId } from '../io/schema';
 
 export type EditEvent =
@@ -327,7 +327,7 @@ const listener =
         const { renderable } = event.payload;
 
         if (renderable.type === 'RELATION' || renderable.type === 'IMAGE') {
-          return deleteRelation(renderable.relationId, context.spaceId);
+          return removeRelation({ relationId: EntityId(renderable.relationId), spaceId: context.spaceId });
         }
 
         return remove(

--- a/apps/web/core/events/edit-events.ts
+++ b/apps/web/core/events/edit-events.ts
@@ -253,7 +253,6 @@ const listener =
             id: EntityId(toEntityId),
             name: toEntityName,
             renderableType: renderableType ?? 'DEFAULT',
-            triples: [],
             value: toEntityId, // @TODO(relations): Add support for images
           },
         };

--- a/apps/web/core/io/dto.ts
+++ b/apps/web/core/io/dto.ts
@@ -35,13 +35,13 @@ export function TripleDto(triple: SubstreamTriple) {
 }
 
 export function SpaceMetadataDto(spaceId: string, metadata: SubstreamEntity | undefined | null): SpaceConfigEntity {
-  const spaceConfigTriples = (metadata?.triples.nodes ?? []).map(TripleDto);
+  const entity = metadata ? EntityDto(metadata) : null;
 
-  const spaceConfigWithImage: SpaceConfigEntity = metadata
+  const spaceConfigWithImage: SpaceConfigEntity = entity
     ? {
+        ...entity,
         spaceId: spaceId,
-        image: Entities.avatar(spaceConfigTriples) ?? Entities.cover(spaceConfigTriples) ?? PLACEHOLDER_SPACE_IMAGE,
-        ...EntityDto(metadata),
+        image: Entities.avatar(entity.relationsOut) ?? Entities.cover(entity.relationsOut) ?? PLACEHOLDER_SPACE_IMAGE,
       }
     : {
         id: EntityId(''),

--- a/apps/web/core/io/dto/entities.ts
+++ b/apps/web/core/io/dto/entities.ts
@@ -30,7 +30,6 @@ export type Relation = {
   toEntity: {
     id: EntityId;
     name: string | null;
-    triples: Triple[];
 
     // The "Renderable Type" for an entity provides a hint to the consumer
     // of the entity to _what_ the entity is so they know how they should
@@ -74,7 +73,6 @@ export function EntityDto(entity: SubstreamEntity): Entity {
         toEntity: {
           id: t.toEntity.id,
           name: t.toEntity.name,
-          triples: toEntityTriples,
 
           // The "Renderable Type" for an entity provides a hint to the consumer
           // of the entity to _what_ the entity is so they know how they should

--- a/apps/web/core/io/dto/entities.ts
+++ b/apps/web/core/io/dto/entities.ts
@@ -68,6 +68,11 @@ export function EntityDto(entity: SubstreamEntity): Entity {
 
       const renderableType = getRenderableEntityType(toEntityTypes);
 
+      // @TODO(relations): Until we fix the migrations we'll manually check for cover and avatar
+      // relations and set the renderable typ to image.
+      const isCoverOrAvatar =
+        t.typeOf.id === EntityId(SYSTEM_IDS.COVER_ATTRIBUTE) || t.typeOf.id === EntityId(SYSTEM_IDS.AVATAR_ATTRIBUTE);
+
       return {
         ...t,
         toEntity: {
@@ -77,9 +82,9 @@ export function EntityDto(entity: SubstreamEntity): Entity {
           // The "Renderable Type" for an entity provides a hint to the consumer
           // of the entity to _what_ the entity is so they know how they should
           // render it depending on their use case.
-          renderableType: renderableType,
+          renderableType: isCoverOrAvatar ? 'IMAGE' : renderableType,
           // Right now we only support images and entity ids as the value of the To entity.
-          value: renderableType === 'IMAGE' ? imageEntityUrlValue ?? '' : t.toEntity.id,
+          value: isCoverOrAvatar || renderableType === 'IMAGE' ? imageEntityUrlValue ?? '' : t.toEntity.id,
         },
       };
     }),
@@ -92,5 +97,5 @@ function getRenderableEntityType(types: SubstreamType[]): RenderableEntityType {
     return 'IMAGE';
   }
 
-  return 'DEFAULT';
+  return 'RELATION';
 }

--- a/apps/web/core/io/dto/proposals.ts
+++ b/apps/web/core/io/dto/proposals.ts
@@ -2,8 +2,8 @@ import { PLACEHOLDER_SPACE_IMAGE } from '~/core/constants';
 import { AppOp, OmitStrict, Profile, Triple } from '~/core/types';
 import { Entities } from '~/core/utils/entity';
 
-import { TripleDto } from '../dto';
 import { ProposalStatus, ProposalType, SubstreamEntity, SubstreamProposal, SubstreamVote } from '../schema';
+import { EntityDto } from './entities';
 
 export type VoteWithProfile = SubstreamVote & { voter: Profile };
 
@@ -47,12 +47,12 @@ export function ProposalDto(
   };
 
   const spaceConfig = proposal.space.spacesMetadata.nodes[0].entity as SubstreamEntity | undefined;
-  const spaceConfigTriples = (spaceConfig?.triples.nodes ?? []).map(TripleDto);
+  const entity = spaceConfig ? EntityDto(spaceConfig) : null;
 
   const spaceWithMetadata: SpaceWithImage = {
     id: proposal.space.id,
     name: spaceConfig?.name ?? null,
-    image: Entities.avatar(spaceConfigTriples) ?? Entities.cover(spaceConfigTriples) ?? PLACEHOLDER_SPACE_IMAGE,
+    image: Entities.avatar(entity?.relationsOut) ?? Entities.cover(entity?.relationsOut) ?? PLACEHOLDER_SPACE_IMAGE,
   };
 
   return {
@@ -109,12 +109,12 @@ export function ProposalWithoutVotersDto(
   };
 
   const spaceConfig = proposal.space.spacesMetadata.nodes[0].entity as SubstreamEntity | undefined;
-  const spaceConfigTriples = (spaceConfig?.triples.nodes ?? []).map(TripleDto);
+  const entity = spaceConfig ? EntityDto(spaceConfig) : null;
 
   const spaceWithMetadata: SpaceWithImage = {
     id: proposal.space.id,
     name: spaceConfig?.name ?? null,
-    image: Entities.avatar(spaceConfigTriples) ?? Entities.cover(spaceConfigTriples) ?? PLACEHOLDER_SPACE_IMAGE,
+    image: Entities.avatar(entity?.relationsOut) ?? Entities.cover(entity?.relationsOut) ?? PLACEHOLDER_SPACE_IMAGE,
   };
 
   return {

--- a/apps/web/core/io/subgraph/fetch-profile-via-wallets-triple.ts
+++ b/apps/web/core/io/subgraph/fetch-profile-via-wallets-triple.ts
@@ -37,8 +37,8 @@ export async function fetchProfileViaWalletsTripleAddress(address: string): Prom
   return {
     id: profile.id,
     name: profile.name,
-    avatarUrl: Entities.avatar(profile.triples),
-    coverUrl: Entities.cover(profile.triples),
+    avatarUrl: Entities.avatar(profile.relationsOut),
+    coverUrl: Entities.cover(profile.relationsOut),
     profileLink: space ? NavUtils.toEntity(space, profile.id) : null,
     address: address as `0x${string}`,
   };

--- a/apps/web/core/state/entity-table-store/entity-table-store-provider.tsx
+++ b/apps/web/core/state/entity-table-store/entity-table-store-provider.tsx
@@ -5,7 +5,7 @@ import { createContext, useContext, useMemo } from 'react';
 
 import { useSpaces } from '~/core/hooks/use-spaces';
 import { Space } from '~/core/io/dto/spaces';
-import { Column, GeoType, OmitStrict, Row } from '~/core/types';
+import { GeoType, OmitStrict, Row, Schema } from '~/core/types';
 
 import { InitialEntityTableStoreParams } from './entity-table-store-params';
 
@@ -18,7 +18,7 @@ interface Props {
   children: React.ReactNode;
   initialSelectedType: GeoType | null;
   initialParams: InitialEntityTableStoreParams;
-  initialColumns: Column[];
+  initialColumns: Schema[];
   initialRows: Row[];
 }
 

--- a/apps/web/core/types.ts
+++ b/apps/web/core/types.ts
@@ -1,5 +1,7 @@
 import { SYSTEM_IDS } from '@geogenesis/sdk';
 
+import { EntityId } from './io/schema';
+
 export type Dictionary<K extends string, T> = Partial<Record<K, T>>;
 export type OmitStrict<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 
@@ -160,9 +162,10 @@ export type GeoType = {
 
 // A column in the table _is_ an Entity. It's a reference to a specific Attribute entity.
 // In this use case we don't really care about description, types, etc.
-export interface Column {
-  id: string;
-  triples: Triple[];
+export interface Schema {
+  id: EntityId;
+  name: string | null;
+  valueType: ValueTypeId;
 }
 
 export interface Cell {
@@ -201,7 +204,6 @@ export type TripleWithUrlValue = OmitStrict<Triple, 'value'> & { value: Value };
 export type SpaceId = string;
 export type SpaceTriples = Record<SpaceId, Triple[]>;
 
-export type EntityId = string;
 export type AttributeId = string;
 export type EntityActions = Record<EntityId, Record<AttributeId, Triple>>;
 

--- a/apps/web/core/types.ts
+++ b/apps/web/core/types.ts
@@ -67,7 +67,7 @@ export type Triple = {
   isDeleted?: boolean;
 };
 
-export type RenderableEntityType = 'IMAGE' | 'DEFAULT' | 'BLOCK'; // specific block types?
+export type RenderableEntityType = 'IMAGE' | 'RELATION';
 
 // Renderable fields are a special data model to represent us rendering both
 // triples and relations in the same way. This is used across tables and entity

--- a/apps/web/core/utils/entity-table/entity-table.ts
+++ b/apps/web/core/utils/entity-table/entity-table.ts
@@ -16,7 +16,7 @@ export type EntityCell = {
 
 export function fromColumnsAndRows(entities: Entity[], columns: Schema[]) {
   /* Finally, we can build our initialRows */
-  const aggregatedRows = entities.map(({ name, triples, id }) => {
+  const aggregatedRows = entities.map(({ name, triples, id, relationsOut, description }) => {
     return columns.reduce((acc, column) => {
       // @TODO: Might be relations for attribute id as well
       const triplesForAttribute = triples.filter(triple => triple.attributeId === column.id);
@@ -30,8 +30,8 @@ export function fromColumnsAndRows(entities: Entity[], columns: Schema[]) {
       };
 
       if (column.id === SYSTEM_IDS.NAME) {
-        cell.description = Entities.description(triples) || null;
-        cell.image = Entities.cover(triples) || Entities.avatar(triples) || null;
+        cell.description = description;
+        cell.image = Entities.cover(relationsOut) || Entities.avatar(relationsOut) || null;
       }
 
       return {

--- a/apps/web/core/utils/entity-table/entity-table.ts
+++ b/apps/web/core/utils/entity-table/entity-table.ts
@@ -1,7 +1,7 @@
 import { SYSTEM_IDS } from '@geogenesis/sdk';
 
 import { Entity } from '~/core/io/dto/entities';
-import { Column, Triple as ITriple, Row } from '~/core/types';
+import { Triple as ITriple, Row, Schema } from '~/core/types';
 
 import { Entities } from '../entity';
 
@@ -14,16 +14,16 @@ export type EntityCell = {
   image?: string | null;
 };
 
-export function fromColumnsAndRows(entities: Entity[], columns: Column[]) {
+export function fromColumnsAndRows(entities: Entity[], columns: Schema[]) {
   /* Finally, we can build our initialRows */
-  const aggregatedRows = entities.map(({ triples, id }) => {
+  const aggregatedRows = entities.map(({ name, triples, id }) => {
     return columns.reduce((acc, column) => {
+      // @TODO: Might be relations for attribute id as well
       const triplesForAttribute = triples.filter(triple => triple.attributeId === column.id);
-
       const cellTriples = triplesForAttribute.length ? triplesForAttribute : [];
 
       const cell: EntityCell = {
-        name: Entities.name(triples),
+        name,
         columnId: column.id,
         entityId: id,
         triples: cellTriples,

--- a/apps/web/core/utils/entity/entities.ts
+++ b/apps/web/core/utils/entity/entities.ts
@@ -1,6 +1,7 @@
 import { SYSTEM_IDS } from '@geogenesis/sdk';
 
-import { Entity } from '~/core/io/dto/entities';
+import { Entity, Relation } from '~/core/io/dto/entities';
+import { EntityId } from '~/core/io/schema';
 import { Triple as ITriple, ValueTypeId } from '~/core/types';
 
 /**
@@ -54,21 +55,19 @@ export function valueTypeId(triples: ITriple[]): ValueTypeId | null {
 }
 
 /**
- * This function traverses through all the triples associated with an entity and attempts to find the avatar URL of the entity.
+ * This function traverses through all the relations associated with an entity and attempts to find the avatar URL of the entity.
  */
-export function avatar(triples: ITriple[] | undefined): string | null {
-  if (!triples) return null;
-  // @TODO(relations): This should be a relation pointing to the image entity
-  return null;
+export function avatar(relations?: Relation[]): string | null {
+  if (!relations) return null;
+  return relations.find(r => r.typeOf.id === EntityId(SYSTEM_IDS.AVATAR_ATTRIBUTE))?.toEntity.value ?? null;
 }
 
 /**
- * This function traverses through all the triples associated with an entity and attempts to find the cover URL of the entity.
+ * This function traverses through all the relations associated with an entity and attempts to find the cover URL of the entity.
  */
-export function cover(triples: ITriple[] | undefined): string | null {
-  if (!triples) return null;
-  // @TODO(relations): This should be a relation pointing to the image entity
-  return null;
+export function cover(relations?: Relation[]): string | null {
+  if (!relations) return null;
+  return relations.find(r => r.typeOf.id === EntityId(SYSTEM_IDS.COVER_ATTRIBUTE))?.toEntity.value ?? null;
 }
 
 /**

--- a/apps/web/core/utils/to-renderables.ts
+++ b/apps/web/core/utils/to-renderables.ts
@@ -1,6 +1,5 @@
 import { Relation } from '../io/dto/entities';
-import { EntityId } from '../io/schema';
-import { RelationRenderableProperty, RenderableProperty, Triple, TripleRenderableProperty } from '../types';
+import { RelationRenderableProperty, RenderableProperty, Schema, Triple, TripleRenderableProperty } from '../types';
 
 interface ToRenderablesArgs {
   entityId: string;
@@ -8,7 +7,7 @@ interface ToRenderablesArgs {
   triples: Triple[];
   relations: Relation[];
   spaceId: string;
-  schema?: { id: EntityId; name: string | null }[];
+  schema?: Schema[];
   placeholderRenderables?: RenderableProperty[];
 }
 

--- a/apps/web/core/utils/to-renderables.ts
+++ b/apps/web/core/utils/to-renderables.ts
@@ -70,7 +70,7 @@ export function toRenderables({
 
   const relationsToRenderable = relations.map((r): RelationRenderableProperty => {
     return {
-      type: 'RELATION',
+      type: r.toEntity.renderableType,
       entityId: r.id,
       entityName: null,
       attributeId: r.typeOf.id,

--- a/apps/web/core/utils/utils.ts
+++ b/apps/web/core/utils/utils.ts
@@ -196,8 +196,8 @@ export const getOpenGraphImageUrl = (value: string) => {
 
 export const getOpenGraphMetadataForEntity = (entity: Entity | null) => {
   const entityName = entity?.name ?? null;
-  const serverAvatarUrl = Entities.avatar(entity?.triples) ?? null;
-  const serverCoverUrl = Entities.cover(entity?.triples);
+  const serverAvatarUrl = Entities.avatar(entity?.relationsOut) ?? null;
+  const serverCoverUrl = Entities.cover(entity?.relationsOut);
   const imageUrl = serverAvatarUrl || serverCoverUrl || '';
   const openGraphImageUrl = getOpenGraphImageUrl(imageUrl);
   const description = Entities.description(entity?.triples ?? []);

--- a/apps/web/partials/active-proposal/content-proposal.tsx
+++ b/apps/web/partials/active-proposal/content-proposal.tsx
@@ -10,11 +10,11 @@ import * as React from 'react';
 import { createFiltersFromGraphQLString } from '~/core/blocks-sdk/table';
 import { Proposal } from '~/core/io/dto/proposals';
 import { fetchColumns } from '~/core/io/fetch-columns';
+import { EntityId } from '~/core/io/schema';
 import { fetchEntity } from '~/core/io/subgraph';
 import { TableBlockFilter } from '~/core/state/table-block-store';
-import { AttributeId, EntityId, SpaceId } from '~/core/types';
+import { AttributeId, SpaceId } from '~/core/types';
 import { AttributeChange, BlockChange, BlockId, Changeset } from '~/core/utils/change/change';
-import { Entities } from '~/core/utils/entity';
 import { getImagePath } from '~/core/utils/utils';
 
 import { colors } from '~/design-system/theme/colors';
@@ -584,7 +584,7 @@ const getFilters = async (rawFilter: string) => {
     }
     return {
       ...f,
-      columnName: Entities.name(serverColumns.find(c => c.id === f.columnId)?.triples ?? []) ?? '',
+      columnName: serverColumns.find(c => c.id === f.columnId)?.name ?? '',
     };
   });
 

--- a/apps/web/partials/active-proposal/get-active-proposal-diff.ts
+++ b/apps/web/partials/active-proposal/get-active-proposal-diff.ts
@@ -2,8 +2,8 @@ import { SYSTEM_IDS } from '@geogenesis/sdk';
 
 import { Subgraph } from '~/core/io';
 import { Proposal } from '~/core/io/dto/proposals';
+import { EntityId } from '~/core/io/schema';
 import { fetchProposal } from '~/core/io/subgraph';
-import { EntityId } from '~/core/types';
 import { Triple as TripleType } from '~/core/types';
 import { BlockValueType, Changeset } from '~/core/utils/change/change';
 import { Triples } from '~/core/utils/triples';

--- a/apps/web/partials/active-proposal/get-ended-proposal-diff.ts
+++ b/apps/web/partials/active-proposal/get-ended-proposal-diff.ts
@@ -2,8 +2,8 @@ import { SYSTEM_IDS } from '@geogenesis/sdk';
 
 import { Subgraph } from '~/core/io';
 import { Proposal } from '~/core/io/dto/proposals';
+import { EntityId } from '~/core/io/schema';
 import { fetchProposal } from '~/core/io/subgraph';
-import { EntityId } from '~/core/types';
 import { Triple as TripleType } from '~/core/types';
 import { BlockValueType, Changeset } from '~/core/utils/change/change';
 import { Triples } from '~/core/utils/triples';

--- a/apps/web/partials/blocks/table/table-block-editable-filters.tsx
+++ b/apps/web/partials/blocks/table/table-block-editable-filters.tsx
@@ -2,7 +2,6 @@ import { SYSTEM_IDS } from '@geogenesis/sdk';
 
 import { TableBlockFilter, useTableBlock } from '~/core/state/table-block-store';
 import { ValueType as TripleValueType } from '~/core/types';
-import { Entities } from '~/core/utils/entity';
 import { valueTypes } from '~/core/value-types';
 
 import { SmallButton } from '~/design-system/button';
@@ -33,12 +32,10 @@ export function TableBlockEditableFilters() {
     },
     ...columns
       .map(c => {
-        const maybeValueType = Entities.valueTypeId(c.triples);
-
         return {
           columnId: c.id,
-          columnName: Entities.name(c.triples) ?? '',
-          valueType: maybeValueType ? valueTypes[maybeValueType] : 'TEXT',
+          columnName: c.name ?? '',
+          valueType: valueTypes[c.valueType],
           value: '',
           valueName: null,
         };

--- a/apps/web/partials/blocks/table/table-block-table.tsx
+++ b/apps/web/partials/blocks/table/table-block-table.tsx
@@ -22,7 +22,7 @@ import { useAccessControl } from '~/core/hooks/use-access-control';
 import { ID } from '~/core/id';
 import { useEditable } from '~/core/state/editable-store';
 import { DataBlockView, useTableBlock } from '~/core/state/table-block-store';
-import { Cell, Column, Row } from '~/core/types';
+import { Cell, Row, Schema } from '~/core/types';
 import { Entities } from '~/core/utils/entity';
 import { EntityCell } from '~/core/utils/entity-table/entity-table';
 import { NavUtils, getImagePath } from '~/core/utils/utils';
@@ -42,7 +42,7 @@ import { editingColumnsAtom } from '~/atoms';
 
 const columnHelper = createColumnHelper<Row>();
 
-const formatColumns = (columns: Column[] = [], isEditMode: boolean, unpublishedColumns: Column[]) => {
+const formatColumns = (columns: Schema[] = [], isEditMode: boolean, unpublishedColumns: Schema[]) => {
   const columnSize = 784 / columns.length;
 
   return columns.map((column, i) =>
@@ -60,11 +60,12 @@ const formatColumns = (columns: Column[] = [], isEditMode: boolean, unpublishedC
               unpublishedColumns={unpublishedColumns}
               column={column}
               entityId={column.id}
-              spaceId={Entities.nameTriple(column.triples)?.space}
+              // @TODO(relations): Fix when we work on tables
+              spaceId={''}
             />
           </div>
         ) : (
-          <Text variant="smallTitle">{isNameColumn ? 'Name' : Entities.name(column.triples)}</Text>
+          <Text variant="smallTitle">{isNameColumn ? 'Name' : column.name ?? column.id}</Text>
         );
       },
       size: columnSize ? (columnSize < 150 ? 150 : columnSize) : 150,
@@ -136,7 +137,7 @@ const defaultColumn: Partial<ColumnDef<Row>> = {
 interface Props {
   space: string;
   typeId: string;
-  columns: Column[];
+  columns: Schema[];
   rows: Row[];
   shownColumnIds: string[];
   view: DataBlockView;

--- a/apps/web/partials/blocks/table/table-block.tsx
+++ b/apps/web/partials/blocks/table/table-block.tsx
@@ -11,7 +11,6 @@ import { useSpaces } from '~/core/hooks/use-spaces';
 import { useUserIsEditing } from '~/core/hooks/use-user-is-editing';
 import { ID } from '~/core/id';
 import { useTableBlock } from '~/core/state/table-block-store';
-import { Entities } from '~/core/utils/entity';
 import { NavUtils } from '~/core/utils/utils';
 
 import { IconButton } from '~/design-system/button';
@@ -59,7 +58,7 @@ export const TableBlock = React.memo(({ spaceId }: Props) => {
 
   const allColumns = columns.map(column => ({
     id: column.id,
-    name: Entities.name(column.triples),
+    name: column.name,
   }));
 
   const shownColumnRelations = [
@@ -100,7 +99,7 @@ export const TableBlock = React.memo(({ spaceId }: Props) => {
 
     return {
       ...f,
-      columnName: Entities.name(columns.find(c => c.id === f.columnId)?.triples ?? []) ?? '',
+      columnName: columns.find(c => c.id === f.columnId)?.name ?? '',
     };
   });
 

--- a/apps/web/partials/blocks/table/utils.ts
+++ b/apps/web/partials/blocks/table/utils.ts
@@ -1,24 +1,23 @@
 import { SYSTEM_IDS } from '@geogenesis/sdk';
 
-import { Column, ValueTypeId } from '~/core/types';
-import { Entities } from '~/core/utils/entity';
+import { Schema, ValueTypeId } from '~/core/types';
 
-export function columnName(columnId: string, columns: Column[]): string {
+export function columnName(columnId: string, columns: Schema[]): string {
   const column = columns.find(c => c.id === columnId);
 
   if (!column) {
     return '';
   }
 
-  return Entities.name(column.triples) || '';
+  return column.name ?? '';
 }
 
-export function columnValueType(columnId: string, columns: Column[]): ValueTypeId {
+export function columnValueType(columnId: string, columns: Schema[]): ValueTypeId {
   const column = columns.find(c => c.id === columnId);
 
   if (!column) {
     return SYSTEM_IDS.TEXT;
   }
 
-  return Entities.valueTypeId(column.triples) ?? SYSTEM_IDS.TEXT;
+  return column.valueType ?? SYSTEM_IDS.TEXT;
 }

--- a/apps/web/partials/entities-page/entity-table.tsx
+++ b/apps/web/partials/entities-page/entity-table.tsx
@@ -19,7 +19,7 @@ import { useAccessControl } from '~/core/hooks/use-access-control';
 import { useEditable } from '~/core/state/editable-store';
 import { DEFAULT_PAGE_SIZE } from '~/core/state/entity-table-store/entity-table-store';
 import { useEntityTable } from '~/core/state/entity-table-store/entity-table-store';
-import { Cell, Column, Row } from '~/core/types';
+import { Cell, Row, Schema } from '~/core/types';
 import { Entities } from '~/core/utils/entity';
 import { NavUtils } from '~/core/utils/utils';
 import { valueTypes } from '~/core/value-types';
@@ -36,7 +36,7 @@ import { EntityTableCell } from './entity-table-cell';
 
 const columnHelper = createColumnHelper<Row>();
 
-const formatColumns = (columns: Column[] = [], isEditMode: boolean, unpublishedColumns: Column[]) => {
+const formatColumns = (columns: Schema[] = [], isEditMode: boolean, unpublishedColumns: Schema[]) => {
   const columnSize = 1200 / columns.length;
 
   return columns.map((column, i) =>
@@ -54,11 +54,12 @@ const formatColumns = (columns: Column[] = [], isEditMode: boolean, unpublishedC
               unpublishedColumns={unpublishedColumns}
               column={column}
               entityId={column.id}
-              spaceId={Entities.nameTriple(column.triples)?.space}
+              // @TODO: fix later
+              spaceId={''}
             />
           </div>
         ) : (
-          <Text variant="smallTitle">{isNameColumn ? 'Name' : Entities.name(column.triples)}</Text>
+          <Text variant="smallTitle">{isNameColumn ? 'Name' : column.name ?? column.id}</Text>
         );
       },
       size: columnSize ? (columnSize < 300 ? 300 : columnSize) : 300,
@@ -133,7 +134,7 @@ const defaultColumn: Partial<ColumnDef<Row>> = {
 
 interface Props {
   space: string;
-  columns: Column[];
+  columns: Schema[];
   rows: Row[];
 }
 

--- a/apps/web/partials/entity-page/editable-entity-page.tsx
+++ b/apps/web/partials/entity-page/editable-entity-page.tsx
@@ -83,7 +83,7 @@ export function EditableEntityPage({ id, spaceId, triples: serverTriples }: Prop
                     }
                   }}
                 />
-                {renderableType === 'RELATION' ? (
+                {renderableType === 'RELATION' || renderableType === 'IMAGE' ? (
                   <RelationsGroup key={attributeId} relations={renderables as RelationRenderableProperty[]} />
                 ) : (
                   <TriplesGroup key={attributeId} triples={renderables as TripleRenderableProperty[]} />

--- a/apps/web/partials/entity-page/editable-entity-table-column-header.tsx
+++ b/apps/web/partials/entity-page/editable-entity-table-column-header.tsx
@@ -1,28 +1,24 @@
 'use client';
 
-import { SYSTEM_IDS } from '@geogenesis/sdk';
-
 import * as React from 'react';
 import { memo, useState } from 'react';
 
-import { useTriples } from '~/core/database/triples';
 import { useEditEvents } from '~/core/events/edit-events';
-import { Column } from '~/core/types';
-import { Entities } from '~/core/utils/entity';
+import { Schema } from '~/core/types';
 import { toRenderables } from '~/core/utils/to-renderables';
 
 import { getRenderableTypeFromValueType, getRenderableTypeSelectorOptions } from './get-renderable-type-options';
 import { RenderableTypeDropdown } from './renderable-type-dropdown';
 
 interface Props {
-  column: Column;
+  column: Schema;
   // This spaceId is the spaceId of the attribute, not the current space.
   // We need the attribute spaceId to get the actions for the attribute
   // (since actions are grouped by spaceId) to be able to keep the updated
   // name in sync.
   spaceId?: string;
   entityId: string;
-  unpublishedColumns: Column[];
+  unpublishedColumns: Schema[];
 }
 
 export const EditableEntityTableColumnHeader = memo(function EditableEntityTableColumn({
@@ -31,14 +27,13 @@ export const EditableEntityTableColumnHeader = memo(function EditableEntityTable
   entityId,
   unpublishedColumns,
 }: Props) {
-  const localTriples = useTriples(
-    React.useMemo(() => {
-      return {
-        mergeWith: column.triples,
-        selector: t => t.entityId === column.id,
-      };
-    }, [column.triples, column.id])
-  );
+  // const localTriples = useTriples(
+  //   React.useMemo(() => {
+  //     return {
+  //       selector: t => t.entityId === column.id,
+  //     };
+  //   }, [column.id])
+  // );
 
   // const localCellTriples = useTriples(
   //   React.useMemo(() => {
@@ -50,24 +45,23 @@ export const EditableEntityTableColumnHeader = memo(function EditableEntityTable
 
   // There's some issue where this component is losing focus after changing the value of the input. For now we can work
   // around this issue by using local state.
-  const [localName, setLocalName] = useState(Entities.name(localTriples) ?? '');
+  const [localName, setLocalName] = useState(column.name ?? '');
 
   const send = useEditEvents({
     context: {
       entityId,
       spaceId: spaceId ?? '',
-      entityName: Entities.name(localTriples) ?? '',
+      entityName: column.name ?? '',
     },
   });
 
   // We hydrate the local editable store with the triples from the server. While it's hydrating
   // we can fallback to the server triples so we render real data and there's no layout shift.
-  const triples = localTriples.length === 0 ? column.triples : localTriples;
-  const valueType = Entities.valueTypeId(triples) ?? SYSTEM_IDS.TEXT;
+  const valueType = column.valueType;
   const isUnpublished = unpublishedColumns.some(unpublishedColumn => unpublishedColumn.id === column.id);
   const selectorOptions = getRenderableTypeSelectorOptions(
     toRenderables({
-      triples: triples,
+      triples: [],
       relations: [],
       spaceId: spaceId ?? '',
       entityId,

--- a/apps/web/partials/entity-page/entity-page-cover.tsx
+++ b/apps/web/partials/entity-page/entity-page-cover.tsx
@@ -15,10 +15,10 @@ type EntityPageCoverProps = {
 };
 
 export const EntityPageCover = ({ avatarUrl: serverAvatarUrl, coverUrl: serverCoverUrl }: EntityPageCoverProps) => {
-  const { triples } = useEntityPageStore();
+  const { relations } = useEntityPageStore();
 
-  const avatarUrl = Entities.avatar(triples) ?? serverAvatarUrl;
-  const coverUrl = Entities.cover(triples) ?? serverCoverUrl;
+  const avatarUrl = Entities.avatar(relations) ?? serverAvatarUrl;
+  const coverUrl = Entities.cover(relations) ?? serverCoverUrl;
 
   if (!coverUrl && !avatarUrl) return null;
 

--- a/apps/web/partials/entity-page/readable-entity-page.tsx
+++ b/apps/web/partials/entity-page/readable-entity-page.tsx
@@ -25,7 +25,7 @@ export function ReadableEntityPage({ triples: serverTriples, id }: Props) {
   return (
     <div className="flex flex-col gap-6 rounded-lg border border-grey-02 p-5 shadow-button">
       {Object.entries(renderables).map(([attributeId, renderable]) => {
-        const isRelation = renderable[0].type === 'RELATION';
+        const isRelation = renderable[0].type === 'RELATION' || renderable[0].type === 'IMAGE';
 
         if (isRelation) {
           return <RelationsGroup key={attributeId} relations={renderable as RelationRenderableProperty[]} />;
@@ -99,9 +99,8 @@ function RelationsGroup({ relations }: { relations: RelationRenderableProperty[]
             const relationValue = r.value;
 
             if (renderableType === 'IMAGE') {
-              return (
-                <ImageZoom key={`image-${relationId}-${relationValue}`} imageSrc={getImagePath(relationValue ?? '')} />
-              );
+              const imagePath = getImagePath(relationValue ?? '');
+              return <ImageZoom key={`image-${relationId}-${relationValue}`} imageSrc={imagePath} />;
             }
 
             return (
@@ -110,7 +109,7 @@ function RelationsGroup({ relations }: { relations: RelationRenderableProperty[]
                   entityHref={NavUtils.toEntity(spaceId, relationValue ?? '')}
                   relationHref={NavUtils.toEntity(spaceId, relationId)}
                 >
-                  {relationName ?? relationId}
+                  {relationName ?? relationValue}
                 </LinkableRelationChip>
               </div>
             );

--- a/apps/web/partials/entity-page/readable-entity-page.tsx
+++ b/apps/web/partials/entity-page/readable-entity-page.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 
 import { useRenderables } from '~/core/hooks/use-renderables';
 import { Relation } from '~/core/io/dto/entities';
+import { Services } from '~/core/services';
 import { RelationRenderableProperty, Triple, TripleRenderableProperty } from '~/core/types';
 import { NavUtils, getImagePath } from '~/core/utils/utils';
 

--- a/apps/web/partials/entity-page/renderable-type-dropdown.tsx
+++ b/apps/web/partials/entity-page/renderable-type-dropdown.tsx
@@ -35,12 +35,11 @@ interface Props {
 export const RenderableTypeDropdown = ({ value, options }: Props) => {
   // Using a controlled state to enable exit animations with framer-motion
   const [open, setOpen] = useState(false);
-
   const Icon = icons[value];
 
   return (
     <DropdownPrimitive.Root open={open} onOpenChange={setOpen}>
-      <DropdownPrimitive.Trigger className="inline-flex flex-1 items-center justify-between">
+      <DropdownPrimitive.Trigger asChild>
         <SquareButton icon={<Icon />} isActive={open} />
       </DropdownPrimitive.Trigger>
       <AnimatePresence>

--- a/apps/web/partials/history/compare.tsx
+++ b/apps/web/partials/history/compare.tsx
@@ -17,7 +17,6 @@ import { Services } from '~/core/services';
 import { useDiff } from '~/core/state/diff-store';
 import { TableBlockFilter } from '~/core/state/table-block-store';
 import type { AttributeChange, AttributeId, BlockChange, BlockId, Changeset } from '~/core/utils/change/change';
-import { Entities } from '~/core/utils/entity';
 import { getImagePath } from '~/core/utils/utils';
 
 import { Button } from '~/design-system/button';
@@ -917,7 +916,7 @@ const getFilters = async (rawFilter: string, subgraph: Subgraph.ISubgraph) => {
     }
     return {
       ...f,
-      columnName: Entities.name(serverColumns.find(c => c.id === f.columnId)?.triples ?? []) ?? '',
+      columnName: serverColumns.find(c => c.id === f.columnId)?.name ?? '',
     };
   });
 

--- a/apps/web/partials/import/publish.tsx
+++ b/apps/web/partials/import/publish.tsx
@@ -47,7 +47,7 @@ const PublishImport = ({ spaceId, space }: PublishImportProps) => {
   const setIsPublishOpen = useSetAtom(publishAtom);
 
   const spaceName = Entities.name(space?.spaceConfig?.triples ?? []);
-  const spaceAvatar = Entities.avatar(space?.spaceConfig?.triples ?? []);
+  const spaceAvatar = Entities.avatar(space?.spaceConfig?.relationsOut);
 
   const [proposalName, setProposalName] = useState('');
   const isReadyToPublish = proposalName.length > 3;

--- a/apps/web/partials/navbar/navbar-space-metadata.tsx
+++ b/apps/web/partials/navbar/navbar-space-metadata.tsx
@@ -42,7 +42,7 @@ export function NavbarSpaceMetadata() {
         // the images explicitly from the triples, and render null if it doesn't exist.
         //
         // spaceConfig.image will have a placeholder if the images don't exist.
-        img: Entities.avatar(spaceConfig.triples) ?? Entities.cover(spaceConfig.triples),
+        img: Entities.avatar(spaceConfig.relationsOut) ?? Entities.cover(spaceConfig.relationsOut),
         href: NavUtils.toSpace(space.id),
       };
     },

--- a/apps/web/partials/review/review.tsx
+++ b/apps/web/partials/review/review.tsx
@@ -27,7 +27,6 @@ import { TableBlockFilter } from '~/core/state/table-block-store';
 import type { Triple } from '~/core/types';
 import { Change } from '~/core/utils/change';
 import type { AttributeChange, AttributeId, BlockChange, BlockId, Changeset } from '~/core/utils/change/change';
-import { Entities } from '~/core/utils/entity';
 import { GeoDate, getImagePath } from '~/core/utils/utils';
 
 import { Button, SmallButton, SquareButton } from '~/design-system/button';
@@ -1075,7 +1074,7 @@ const getFilters = async (rawFilter: string, subgraph: Subgraph.ISubgraph) => {
     }
     return {
       ...f,
-      columnName: Entities.name(serverColumns.find(c => c.id === f.columnId)?.triples ?? []) ?? '',
+      columnName: serverColumns.find(c => c.id === f.columnId)?.name ?? '',
     };
   });
 

--- a/apps/web/partials/team/find-team-member.tsx
+++ b/apps/web/partials/team/find-team-member.tsx
@@ -172,7 +172,7 @@ export const FindTeamMember = ({ spaceId }: FindTeamMemberProps) => {
 
       if (person) {
         if (types.includes(TypeId(SYSTEM_IDS.PERSON_TYPE))) {
-          const avatar = Entities.avatar(person?.triples);
+          const avatar = Entities.avatar(person?.relationsOut);
           setAvatar(avatar);
           setName(Entities.name(person?.triples ?? []));
           setPerson(person);


### PR DESCRIPTION
This PR adds support for rendering relations as images. In the future we'll have many non-native value types that we want to render as a renderable property. This adds patterns for mapping arbitrary renderable relations to the RenderableProperty data format