### PR TITLE
feat: do not return deleted triples by default, but allow escape hatch

### DIFF
--- a/apps/web/core/database/triples.tsx
+++ b/apps/web/core/database/triples.tsx
@@ -12,13 +12,14 @@ import { localOpsAtom } from './write';
 interface UseTriplesArgs {
   mergeWith?: ITriple[];
   selector?: (t: StoredTriple) => boolean;
+  includeDeleted?: boolean;
 }
 
-const makeLocalActionsAtomWithSelector = ({ selector, mergeWith = [] }: UseTriplesArgs) => {
+const makeLocalActionsAtomWithSelector = ({ selector, includeDeleted = false, mergeWith = [] }: UseTriplesArgs) => {
   return atom(get => {
     const mergedTriples = Triples.merge(get(localOpsAtom), mergeWith);
     return mergedTriples.filter(t => {
-      return isNotDeletedSelector(t) && (selector ? selector(t) : true);
+      return (selector ? selector(t) : true) && (includeDeleted ? true : isNotDeletedSelector(t));
     });
   });
 };

--- a/apps/web/partials/review/flow-bar.tsx
+++ b/apps/web/partials/review/flow-bar.tsx
@@ -25,7 +25,7 @@ export const FlowBar = () => {
   const { editable } = useEditable();
   const { isReviewOpen, setIsReviewOpen } = useDiff();
 
-  const triples = useTriples(React.useMemo(() => ({ selector: t => t.hasBeenPublished === false }), []));
+  const triples = useTriples(React.useMemo(() => ({ selector: t => t.hasBeenPublished === false, includeDeleted: true }), []));
 
   const opsCount = triples.length;
 


### PR DESCRIPTION
This is mostly used by things like diffs or the flowbar