### PR TITLE
feat(sink): process exit on timeout error + performance improvements

### DIFF
--- a/apps/web/app/home/fetch-active-proposals-in-editor-spaces.ts
+++ b/apps/web/app/home/fetch-active-proposals-in-editor-spaces.ts
@@ -135,8 +135,6 @@ export async function getActiveProposalsForSpacesWhereEditor(
     query: substreamQuery,
   });
 
-  console.log('substream query', substreamQuery);
-
   const proposalsInSpacesWhereEditor = await Effect.runPromise(Effect.either(permissionlessSpacesEffect));
 
   if (Either.isLeft(proposalsInSpacesWhereEditor)) {
@@ -144,11 +142,11 @@ export async function getActiveProposalsForSpacesWhereEditor(
 
     switch (error._tag) {
       case 'GraphqlRuntimeError':
-        console.error(`Encountered runtime graphql error in getSpacesWhereEditor.`, error.message);
+        console.error(`Encountered runtime graphql error in getActiveProposalsForSpacesWhereEditor.`, error.message);
         break;
 
       default:
-        console.error(`${error._tag}: Unable to fetch spaces where editor controller`);
+        console.error(`${error._tag}: Unable to fetch proposals where editor`);
         break;
     }
 

--- a/apps/web/core/environment/environment.ts
+++ b/apps/web/core/environment/environment.ts
@@ -49,8 +49,7 @@ export const options: Record<AppEnv, AppConfig> = {
     chainId: '19411',
     rpc: variables.rpcEndpoint,
     ipfs: IPFS_GATEWAY_PATH,
-    // api: 'https://geo-conduit.up.railway.app/graphql',
-    api: 'http://localhost:5001/graphql',
+    api: 'https://geo-conduit.up.railway.app/graphql',
     bundler: `https://api.pimlico.io/v2/geo-testnet/rpc?apikey=${variables.accountAbstractionApiKey}`,
   },
   testnet: {

--- a/packages/substream/index.ts
+++ b/packages/substream/index.ts
@@ -2,7 +2,7 @@ import { Command } from 'commander';
 import { Effect, Either, pipe } from 'effect';
 
 import { bootstrapRoot } from './sink/bootstrap-root';
-import { Environment } from './sink/environment';
+import { Environment, EnvironmentLive } from './sink/environment';
 import { getStreamConfiguration } from './sink/get-stream-configuration';
 import { runStream } from './sink/run-stream';
 import { Telemetry, TelemetryLive } from './sink/telemetry';

--- a/packages/substream/sink/cursor.ts
+++ b/packages/substream/sink/cursor.ts
@@ -7,6 +7,11 @@ export async function readCursor() {
   return cursor?.cursor;
 }
 
+export async function readStartBlock() {
+  const cursor = await db.selectOne('cursors', { id: 0 }).run(pool);
+  return cursor?.block_number ?? null;
+}
+
 export async function writeCursor(cursor: string, block_number: number) {
   try {
     await db.upsert('cursors', { id: 0, cursor, block_number }, 'id').run(pool);

--- a/packages/substream/sink/db/constants.ts
+++ b/packages/substream/sink/db/constants.ts
@@ -1,1 +1,1 @@
-export const CHUNK_SIZE = 4000;
+export const CHUNK_SIZE = 2000;

--- a/packages/substream/sink/db/current-versions.ts
+++ b/packages/substream/sink/db/current-versions.ts
@@ -11,4 +11,8 @@ export class CurrentVersions {
   static async selectOne(where: S.current_versions.Whereable) {
     return db.selectOne('current_versions', where).run(pool);
   }
+
+  static async select(where: S.current_versions.Whereable) {
+    return db.select('current_versions', where).run(pool);
+  }
 }

--- a/packages/substream/sink/db/edits.ts
+++ b/packages/substream/sink/db/edits.ts
@@ -2,13 +2,40 @@ import * as db from 'zapatos/db';
 import type * as S from 'zapatos/schema';
 
 import { pool } from '../utils/pool';
+import { CHUNK_SIZE } from './constants';
 
 export class Edits {
-  static async upsert(edits: S.edits.Insertable[]) {
+  static async upsert(edits: S.edits.Insertable[], options: { chunked?: boolean } = {}) {
+    if (options.chunked) {
+      for (let i = 0; i < edits.length; i += CHUNK_SIZE) {
+        const chunk = edits.slice(i, i + CHUNK_SIZE);
+        await db
+          .upsert('edits', chunk, ['id'], {
+            updateColumns: db.doNothing,
+          })
+          .run(pool);
+      }
+
+      return;
+    }
+
     return await db
       .upsert('edits', edits, ['id'], {
         updateColumns: db.doNothing,
       })
       .run(pool);
+  }
+
+  static async insert(edits: S.edits.Insertable[], options: { chunked?: boolean } = {}) {
+    if (options.chunked) {
+      for (let i = 0; i < edits.length; i += CHUNK_SIZE) {
+        const chunk = edits.slice(i, i + CHUNK_SIZE);
+        await db.insert('edits', chunk).run(pool);
+      }
+
+      return;
+    }
+
+    return await db.insert('edits', edits).run(pool);
   }
 }

--- a/packages/substream/sink/db/space-metadata.ts
+++ b/packages/substream/sink/db/space-metadata.ts
@@ -2,9 +2,23 @@ import * as db from 'zapatos/db';
 import type * as S from 'zapatos/schema';
 
 import { pool } from '../utils/pool';
+import { CHUNK_SIZE } from './constants';
 
 export class SpaceMetadata {
-  static async upsert(metadata: S.spaces_metadata.Insertable[]) {
+  static async upsert(metadata: S.spaces_metadata.Insertable[], options: { chunked?: boolean } = {}) {
+    if (options.chunked) {
+      for (let i = 0; i < metadata.length; i += CHUNK_SIZE) {
+        const chunk = metadata.slice(i, i + CHUNK_SIZE);
+        await db
+          .upsert('spaces_metadata', chunk, db.constraint('space_metadata_unique_entity_space_pair'), {
+            updateColumns: db.doNothing,
+          })
+          .run(pool);
+      }
+
+      return;
+    }
+
     return await db
       .upsert('spaces_metadata', metadata, db.constraint('space_metadata_unique_entity_space_pair'), {
         updateColumns: db.doNothing,

--- a/packages/substream/sink/db/versions.ts
+++ b/packages/substream/sink/db/versions.ts
@@ -1,61 +1,45 @@
+import { Effect } from 'effect';
 import * as db from 'zapatos/db';
 import type * as S from 'zapatos/schema';
 
 import { pool } from '../utils/pool';
+import { CHUNK_SIZE } from './constants';
 import { CurrentVersions } from './current-versions';
 
 export class Versions {
-  static async upsert(versions: S.versions.Insertable[]) {
+  static async upsert(versions: S.versions.Insertable[], options: { chunked?: boolean } = {}) {
+    if (options.chunked) {
+      for (let i = 0; i < versions.length; i += CHUNK_SIZE) {
+        const chunk = versions.slice(i, i + CHUNK_SIZE);
+
+        await db.upsert('versions', chunk, ['id'], { updateColumns: db.doNothing }).run(pool);
+      }
+
+      return;
+    }
+
     return await db.upsert('versions', versions, ['id'], { updateColumns: db.doNothing }).run(pool);
+  }
+
+  static async insert(versions: S.versions.Insertable[], options: { chunked?: boolean } = {}) {
+    if (options.chunked) {
+      for (let i = 0; i < versions.length; i += CHUNK_SIZE) {
+        const chunk = versions.slice(i, i + CHUNK_SIZE);
+
+        await db.insert('versions', chunk).run(pool);
+      }
+
+      return;
+    }
+
+    return await db.insert('versions', versions).run(pool);
   }
 
   static async upsertMetadata(versions: S.versions.Insertable[]) {
     return await db.upsert('versions', versions, ['id'], { updateColumns: ['name', 'description'] }).run(pool);
   }
 
-  static findOne(where: S.versions.Whereable) {
-    return db.selectOne('versions', where).run(pool);
-  }
-
   static select(where: S.versions.Whereable) {
     return db.select('versions', where).run(pool);
-  }
-
-  static findMany(where: S.versions.Whereable) {
-    return db.select('versions', where).run(pool);
-  }
-
-  static async findLatestValid(entityId: string) {
-    const currentVersion = await CurrentVersions.selectOne({ entity_id: entityId });
-
-    if (!currentVersion) {
-      return null;
-    }
-
-    const res = await db
-      .selectOne(
-        'versions',
-        { id: currentVersion.version_id },
-        {
-          columns: ['id', 'entity_id', 'edit_id'],
-          order: {
-            by: 'created_at',
-            direction: 'DESC',
-          },
-          // @TODO(performance): Can't figure out how to conditionally select
-          // the version where it's proposal is accepted, so we just query
-          // all versions and filter out the ones that aren't accepted in JS.
-          lateral: {
-            proposal: db.selectOne(
-              'proposals',
-              { status: 'accepted', edit_id: db.parent('edit_id') },
-              { columns: ['id'] }
-            ),
-          },
-        }
-      )
-      .run(pool);
-
-    return res;
   }
 }

--- a/packages/substream/sink/get-stream-configuration.ts
+++ b/packages/substream/sink/get-stream-configuration.ts
@@ -13,9 +13,10 @@ export const getStreamConfiguration: GetStreamConfigurationFn = (options, blockN
     };
   }
 
+  console.info(`Configured to start stream from cache using block ${blockNumberFromCache}.`);
+
   return {
-    // Default to using the value in .env. If there's no value in .env default to the Geo genesis block.
-    startBlockNumber: 620,
+    startBlockNumber: blockNumberFromCache,
 
     // We should always use cursor unless we specify a block number or have used the cache.
     shouldUseCursor: true,

--- a/packages/substream/sink/sql/init-indexes.sql
+++ b/packages/substream/sink/sql/init-indexes.sql
@@ -23,6 +23,9 @@ CREATE INDEX edits_created_by_id
 CREATE INDEX proposal_edit_id
     on proposals (edit_id);
 
+CREATE INDEX versions_id
+    on versions (id);
+
 CREATE INDEX versions_edit_id
     on versions (edit_id);
 


### PR DESCRIPTION
We now exit the process on timeout errors so our data service can restart the container. This is needed due to flaky timeout issues from the substream API. Restarting the container forces the connection to re-establish.