### PR TITLE
fix: unnecessary version duplication causes duplicated relations for default edits

### DIFF
--- a/apps/web/core/hooks/use-renderables.ts
+++ b/apps/web/core/hooks/use-renderables.ts
@@ -28,9 +28,6 @@ export function useRenderables(serverTriples: Triple[], spaceId: string) {
   const { placeholderRenderables, addPlaceholderRenderable, removeEmptyPlaceholderRenderable } =
     usePlaceholderRenderables();
 
-  // @TODO(relations): We may want to pass these in instead of reading from context so that
-  // we can use the useRenderables hook for other contexts like tables. Alternatively we can
-  // enforce that all consumers of useRenderables has the same context shape and wraps the hook.
   const { triples: localTriples, relations, schema, name, id } = useEntityPageStore();
 
   const triplesFromSpace = useTriples(

--- a/apps/web/core/hooks/use-request-to-be-editor.ts
+++ b/apps/web/core/hooks/use-request-to-be-editor.ts
@@ -3,7 +3,7 @@
 import { MainVotingAbi } from '@geogenesis/sdk/abis';
 import { createMembershipProposal } from '@geogenesis/sdk/proto';
 import { useMutation } from '@tanstack/react-query';
-import { Effect } from 'effect';
+import { Effect, Either } from 'effect';
 import { encodeFunctionData, stringToHex } from 'viem';
 
 import { useSmartAccount } from '~/core/hooks/use-smart-account';
@@ -22,6 +22,8 @@ export function useRequestToBeEditor(votingPluginAddress: string | null) {
       if (!smartAccount) {
         return;
       }
+
+      console.log('requesting to be editor', smartAccount);
 
       const proposal = createMembershipProposal({
         name: 'Editor request',
@@ -47,7 +49,12 @@ export function useRequestToBeEditor(votingPluginAddress: string | null) {
         return writeTxHash;
       });
 
-      await Effect.runPromise(publishProgram);
+      const result = await Effect.runPromise(Effect.either(publishProgram));
+
+      Either.match(result, {
+        onLeft: error => console.error(error),
+        onRight: () => console.log('Successfully requested to be editor'),
+      });
     },
   });
 

--- a/apps/web/core/hooks/use-request-to-be-member.ts
+++ b/apps/web/core/hooks/use-request-to-be-member.ts
@@ -3,7 +3,7 @@
 import { MainVotingAbi } from '@geogenesis/sdk/abis';
 import { createMembershipProposal } from '@geogenesis/sdk/proto';
 import { useMutation } from '@tanstack/react-query';
-import { Effect } from 'effect';
+import { Effect, Either } from 'effect';
 import { encodeFunctionData, getAddress, stringToHex } from 'viem';
 
 import { useSmartAccount } from '~/core/hooks/use-smart-account';
@@ -49,7 +49,12 @@ export function useRequestToBeMember(votingPluginAddress: string | null) {
         return writeTxHash;
       });
 
-      await Effect.runPromise(publishProgram);
+      const result = await Effect.runPromise(Effect.either(publishProgram));
+
+      Either.match(result, {
+        onLeft: error => console.error(error),
+        onRight: () => console.log('Successfully requested to be member'),
+      });
     },
   });
 

--- a/apps/web/core/hooks/use-vote.ts
+++ b/apps/web/core/hooks/use-vote.ts
@@ -19,7 +19,7 @@ export function useVote({ address, onchainProposalId }: Args) {
 
   const { mutate, status } = useMutation({
     mutationFn: async (option: SubstreamVote['vote']) => {
-      const txEffect = await tx(
+      const txEffect = tx(
         encodeFunctionData({
           abi: MainVotingAbi,
           functionName: 'vote',

--- a/apps/web/core/wallet/privy.tsx
+++ b/apps/web/core/wallet/privy.tsx
@@ -9,10 +9,6 @@ import { CONDUIT_TESTNET } from './conduit-chain';
 const config: PrivyClientConfig = {
   defaultChain: CONDUIT_TESTNET,
   supportedChains: [CONDUIT_TESTNET],
-  // embeddedWallets: {
-  // noPromptOnSignature: false,
-  // createOnLogin: 'users-without-wallets',
-  // },
   appearance: {
     showWalletLoginFirst: false,
     logo: '/static/favicon-320x180.png',

--- a/apps/web/partials/blocks/table/table-block.tsx
+++ b/apps/web/partials/blocks/table/table-block.tsx
@@ -182,7 +182,7 @@ export const TableBlock = React.memo(({ spaceId }: Props) => {
 
       <motion.div layout="position" transition={{ duration: 0.15 }}>
         {isLoading ? (
-          <TableBlockPlaceholder />
+          <TableBlockLoadingPlaceholder />
         ) : (
           <TableBlockTable
             space={spaceId}
@@ -230,7 +230,7 @@ type TableBlockPlaceholderProps = {
   rows?: number;
 };
 
-export function TableBlockPlaceholder({ className = '', columns = 3, rows = 10 }: TableBlockPlaceholderProps) {
+export function TableBlockLoadingPlaceholder({ className = '', columns = 3, rows = 10 }: TableBlockPlaceholderProps) {
   const PLACEHOLDER_COLUMNS = new Array(columns).fill(0);
   const PLACEHOLDER_ROWS = new Array(rows).fill(0);
 

--- a/apps/web/partials/editor/server-content.tsx
+++ b/apps/web/partials/editor/server-content.tsx
@@ -3,7 +3,7 @@ import { Content } from '~/core/state/editor/types';
 import { Skeleton } from '~/design-system/skeleton';
 import { Spacer } from '~/design-system/spacer';
 
-import { TableBlockPlaceholder } from '../blocks/table/table-block';
+import { TableBlockLoadingPlaceholder } from '../blocks/table/table-block';
 
 type ServerContentProps = {
   content: Content[];
@@ -110,7 +110,7 @@ const Block = ({ block }: BlockProps) => {
               <Skeleton className="h-4 w-4" />
               <Skeleton className="h-5 w-16" />
             </div>
-            <TableBlockPlaceholder />
+            <TableBlockLoadingPlaceholder />
           </div>
         </>
       );

--- a/apps/web/partials/entities-page/entity-table-container.tsx
+++ b/apps/web/partials/entities-page/entity-table-container.tsx
@@ -11,7 +11,7 @@ import { PageContainer, PageNumberContainer } from '~/design-system/table/styles
 import { NextButton, PageNumber, PreviousButton } from '~/design-system/table/table-pagination';
 import { Text } from '~/design-system/text';
 
-import { TableBlockPlaceholder } from '../blocks/table/table-block';
+import { TableBlockLoadingPlaceholder } from '../blocks/table/table-block';
 import { EntityInput } from './entity-input';
 import { EntityTable } from './entity-table';
 
@@ -51,7 +51,7 @@ export const EntityTableContainer = memo(function EntityTableContainer({ spaceId
           {entityTableStore.hydrated ? (
             <EntityTable space={spaceId} columns={entityTableStore.columns} rows={entityTableStore.rows} />
           ) : (
-            <TableBlockPlaceholder />
+            <TableBlockLoadingPlaceholder />
           )}
         </div>
         <Spacer height={12} />

--- a/apps/web/partials/space-page/space-editors-join-button.tsx
+++ b/apps/web/partials/space-page/space-editors-join-button.tsx
@@ -16,7 +16,7 @@ export function SpaceEditorsJoinButton({ votingPluginAddress }: Props) {
 
   return (
     <button
-      onClick={requestToBeEditor}
+      onClick={() => requestToBeEditor()}
       disabled={status !== 'idle'}
       className="text-grey-04 transition-colors duration-75 hover:cursor-pointer hover:text-text"
     >

--- a/apps/web/partials/space-page/space-editors-join-button.tsx
+++ b/apps/web/partials/space-page/space-editors-join-button.tsx
@@ -12,15 +12,11 @@ interface Props {
 export function SpaceEditorsJoinButton({ votingPluginAddress }: Props) {
   const { requestToBeEditor, status } = useRequestToBeEditor(votingPluginAddress);
 
-  const onClick = async () => {
-    await requestToBeEditor();
-  };
-
   const text = status === 'idle' ? 'Join' : status === 'pending' ? 'Pending...' : 'Requested';
 
   return (
     <button
-      onClick={onClick}
+      onClick={requestToBeEditor}
       disabled={status !== 'idle'}
       className="text-grey-04 transition-colors duration-75 hover:cursor-pointer hover:text-text"
     >

--- a/apps/web/partials/triples-page/triples.tsx
+++ b/apps/web/partials/triples-page/triples.tsx
@@ -7,7 +7,7 @@ import { PageContainer, PageNumberContainer } from '~/design-system/table/styles
 import { NextButton, PageNumber, PreviousButton } from '~/design-system/table/table-pagination';
 import { Text } from '~/design-system/text';
 
-import { TableBlockPlaceholder } from '../blocks/table/table-block';
+import { TableBlockLoadingPlaceholder } from '../blocks/table/table-block';
 import { TripleInput } from './triple-input';
 import { TripleTable } from './triple-table';
 
@@ -35,7 +35,7 @@ export function Triples({ spaceId }: Props) {
         {tripleStore.hydrated ? (
           <TripleTable space={spaceId} triples={tripleStore.triples} />
         ) : (
-          <TableBlockPlaceholder />
+          <TableBlockLoadingPlaceholder />
         )}
       </div>
 

--- a/packages/substream/sink/events/edits-published/aggregate-mergable-versions.test.ts
+++ b/packages/substream/sink/events/edits-published/aggregate-mergable-versions.test.ts
@@ -72,6 +72,7 @@ describe('aggregateMergableOps', () => {
         requestId: '',
         timestamp: 0,
       },
+      editType: 'DEFAULT',
     });
 
     const expectedVersionOps = [...mergedOpsByVersionId.values()];
@@ -92,6 +93,7 @@ describe('aggregateMergableOps', () => {
         requestId: '',
         timestamp: 0,
       },
+      editType: 'DEFAULT',
     });
 
     expect(mergedVersions[0]?.id).to.not.equal(versions[0]?.id);

--- a/packages/substream/sink/events/edits-published/aggregate-mergable-versions.ts
+++ b/packages/substream/sink/events/edits-published/aggregate-mergable-versions.ts
@@ -13,8 +13,10 @@ export function aggregateMergableOps(args: AggregateMergableVersionsArgs) {
   const { manyVersionsByEntityId, opsByVersionId, block } = args;
   const newOpsByVersionId = new Map<string, Op[]>();
 
-  const newVersions = [...manyVersionsByEntityId.values()].map((versionsByEntityId): S.versions.Insertable => {
+  const newVersions = [...manyVersionsByEntityId.values()].map((versionsByEntityId): S.versions.Insertable | null => {
     const newVersionId = createMergedVersionId(versionsByEntityId.map(v => v.id.toString()));
+
+    if (versionsByEntityId.length === 1) return null;
 
     for (const version of versionsByEntityId) {
       const opsForVersion = opsByVersionId.get(version.id.toString());
@@ -56,7 +58,7 @@ export function aggregateMergableOps(args: AggregateMergableVersionsArgs) {
   });
 
   return {
-    mergedVersions: newVersions,
+    mergedVersions: newVersions.filter(v => v !== null),
     mergedOpsByVersionId: newOpsByVersionId,
   };
 }

--- a/packages/substream/sink/events/edits-published/aggregate-mergable-versions.ts
+++ b/packages/substream/sink/events/edits-published/aggregate-mergable-versions.ts
@@ -15,7 +15,11 @@ export function aggregateMergableOps(args: AggregateMergableVersionsArgs) {
   const newOpsByVersionId = new Map<string, Op[]>();
 
   const newVersions = [...manyVersionsByEntityId.values()].map((versionsByEntityId): S.versions.Insertable | null => {
-    // @TODO: EXPLAIN WHY
+    // We handle mergable versions differently for imported edits vs default edits. For
+    // default edits we only want to create a mergable version if there is more than
+    // version for the same entity id in the block. For imports there might be only
+    // one version in the block, or there might be many and we don't know ahead of
+    // time, so we always create a mergable version.
     if (args.editType === 'DEFAULT' && versionsByEntityId.length === 1) return null;
     const newVersionId = createMergedVersionId(versionsByEntityId.map(v => v.id.toString()));
 

--- a/packages/substream/sink/events/edits-published/handler.ts
+++ b/packages/substream/sink/events/edits-published/handler.ts
@@ -46,8 +46,6 @@ export function handleEditsPublished(ipfsProposals: EditProposal[], createdSpace
           try: () => Versions.upsert(mergedVersions),
           catch: error => new Error(`Failed to insert merged versions. ${(error as Error).message}`),
         }),
-        Effect.tryPromise({
-          try: () => CurrentVersions.upsert(currentVersions),
         writeEdits({
           versions: defaultVersions,
           opsByVersionId: mergedOpsByVersionId,

--- a/packages/substream/sink/events/edits-published/handler.ts
+++ b/packages/substream/sink/events/edits-published/handler.ts
@@ -1,11 +1,12 @@
 import { Effect } from 'effect';
 import type * as S from 'zapatos/schema';
+import { OK } from 'zod';
 
 import { mapIpfsProposalToSchemaProposalByType } from '../proposals-created/map-proposals';
 import type { EditProposal } from '../proposals-created/parser';
 import { aggregateMergableOps, aggregateMergableVersions } from './aggregate-mergable-versions';
 import { CurrentVersions, Proposals, Versions } from '~/sink/db';
-import type { BlockEvent } from '~/sink/types';
+import type { BlockEvent, Op } from '~/sink/types';
 import { partition } from '~/sink/utils';
 import { slog } from '~/sink/utils/slog';
 import { writeEdits } from '~/sink/write-edits/write-edits';
@@ -26,29 +27,48 @@ export function handleEditsPublished(ipfsProposals: EditProposal[], createdSpace
       message: `Updating processed proposals to accepted`,
     });
 
-    // See comment above function definition for more details as to why we do this.
-    const { mergedOpsByVersionId, mergedVersions, edits, versions } = aggregateMergedVersions(ipfsProposals, block);
+    const {
+      schemaEditProposals: { opsByVersionId, versions, edits },
+    } = mapIpfsProposalToSchemaProposalByType(ipfsProposals, block);
 
     /**
      * We treat imported edits and non-imported edits as separate units of work since
      * imports have separate requirements for how they handle merging data for versions.
      * See comment in {@link writeEdits} for more details.
      */
-    const currentVersions = aggregateCurrentVersions(versions, mergedVersions);
     const [importedEdits, defaultEdits] = partition(edits, e => createdSpaceIds.includes(e.space_id.toString()));
-    const [importedVersions, defaultVersions] = partition(mergedVersions, v =>
+    const [importedVersions, defaultVersions] = partition(versions, v =>
       importedEdits.some(e => e.id.toString() === v.edit_id.toString())
     );
+
+    const { mergedOpsByVersionId: defaultMergedOpsByVersionId, mergedVersions: defaultMergedVersions } =
+      aggregateMergedVersions({
+        block,
+        editType: 'DEFAULT',
+        opsByVersionId,
+        versions: defaultVersions,
+      });
+
+    const { mergedOpsByVersionId: importedMergedOpsByVersionId, mergedVersions: importedMergedVersions } =
+      aggregateMergedVersions({
+        block,
+        editType: 'IMPORT',
+        opsByVersionId,
+        versions: importedVersions,
+      });
+
+    const allMergedVersions = [...defaultMergedVersions, ...importedMergedVersions];
+    const currentVersions = aggregateCurrentVersions(versions, allMergedVersions);
 
     yield* _(
       Effect.all([
         Effect.tryPromise({
-          try: () => Versions.upsert(mergedVersions),
+          try: () => Versions.upsert(allMergedVersions),
           catch: error => new Error(`Failed to insert merged versions. ${(error as Error).message}`),
         }),
         writeEdits({
-          versions: defaultVersions,
-          opsByVersionId: mergedOpsByVersionId,
+          versions: defaultMergedVersions,
+          opsByVersionId: defaultMergedOpsByVersionId,
           edits: defaultEdits,
           block,
           editType: 'DEFAULT',
@@ -71,8 +91,8 @@ export function handleEditsPublished(ipfsProposals: EditProposal[], createdSpace
      */
     yield* _(
       writeEdits({
-        versions: importedVersions,
-        opsByVersionId: mergedOpsByVersionId,
+        versions: importedMergedVersions,
+        opsByVersionId: importedMergedOpsByVersionId,
         block,
         edits: importedEdits,
         editType: 'IMPORT',
@@ -116,6 +136,13 @@ function aggregateCurrentVersions(
   });
 }
 
+interface AggregateMergedVersionsArgs {
+  versions: S.versions.Insertable[];
+  opsByVersionId: Map<string, Op[]>;
+  block: BlockEvent;
+  editType: 'IMPORT' | 'DEFAULT';
+}
+
 /**
  * Merges versions from the same entity into a new version. If many versions change
  * the same entity in the same block we need to make sure that there exists a version
@@ -141,7 +168,7 @@ function aggregateCurrentVersions(
  * This function implements #2. The implementation might change in the future as we get more
  * feedback on our versioning mechanisms.
  */
-function aggregateMergedVersions(proposals: EditProposal[], block: BlockEvent) {
+function aggregateMergedVersions(args: AggregateMergedVersionsArgs) {
   // @NOTE:
   // We still use the re-fetched data from IPFS since we need to re-apply all of the ops
   // from each of the merged versions into the new version.
@@ -152,11 +179,9 @@ function aggregateMergedVersions(proposals: EditProposal[], block: BlockEvent) {
   // deleted in one of the merged versions still existing on the merged version. Alternatively
   // we could store the ops in the db as well, but for now we'll just re-fetch from IPFS since
   // we already have that workflow in place.
-  const {
-    schemaEditProposals: { opsByVersionId, versions, edits },
-  } = mapIpfsProposalToSchemaProposalByType(proposals, block);
-
+  //
   // Get the versions that have more than one version for the same entity id
+  const { versions, opsByVersionId, block, editType } = args;
   const manyVersionsByEntityId = aggregateMergableVersions(versions);
 
   // Merge the versions in this block with the same entity id into a new aggregated version
@@ -165,12 +190,11 @@ function aggregateMergedVersions(proposals: EditProposal[], block: BlockEvent) {
     manyVersionsByEntityId,
     opsByVersionId,
     block,
+    editType,
   });
 
   return {
     mergedVersions,
     mergedOpsByVersionId,
-    edits,
-    versions,
   };
 }

--- a/packages/substream/sink/utils/id.ts
+++ b/packages/substream/sink/utils/id.ts
@@ -18,7 +18,7 @@ export function createSpaceId({ network, address }: { network: string; address: 
   return createIdFromUniqueString(`${network}:${address}`);
 }
 
-function createIdFromUniqueString(text: string) {
+export function createIdFromUniqueString(text: string) {
   const hashed = createHash('md5').update(text).digest('hex');
   const bytes = hexToBytesArray(hashed);
   const uuid = v4({ random: bytes });

--- a/packages/substream/sink/write-edits/aggregate-relations.ts
+++ b/packages/substream/sink/write-edits/aggregate-relations.ts
@@ -2,7 +2,7 @@ import { SYSTEM_IDS, createGeoId } from '@geogenesis/sdk';
 import { Effect } from 'effect';
 import type * as Schema from 'zapatos/schema';
 
-import { CurrentVersions, Versions } from '../db';
+import { CurrentVersions } from '../db';
 import { Relations } from '../db/relations';
 import type { OpWithCreatedBy } from './map-triples';
 

--- a/packages/substream/sink/write-edits/aggregate-relations.ts
+++ b/packages/substream/sink/write-edits/aggregate-relations.ts
@@ -103,11 +103,6 @@ export function aggregateRelations({ triples, versions, edits, editType }: Aggre
     // We process relations by edit id so that we can use either the latest or any version
     // in the specific edit when referencing to, from, and type within a relation. Otherwise
     // we can have relations referencing versions in different edits which doesn't make sense.
-    //
-    // @TODO we can run into a situation during space imports where we have entities referencing
-    // an entity that was created in a previous edit. Since imports are all processed in the same
-    // block, these entities aren't approved yet, so any logic that looks for previous versions
-    // of an entity (like relations) will fail.
     for (const edit of edits) {
       const latestVersionForChangedEntities: Record<string, string> = {};
       const blockVersionsForEdit = versions.filter(v => v.edit_id.toString() === edit.id.toString());
@@ -298,10 +293,8 @@ function getRelationFromTriples(
     return null;
   }
 
-  const relationId = createGeoId(); // Not deterministic
-
   return {
-    id: relationId,
+    id: createGeoId(),
     to_version_id: toVersion,
     from_version_id: fromVersion,
     entity_id: entityId,


### PR DESCRIPTION
Before this change we were creating merged versions in blocks that didn't contain multiple versions for the same entity. This resulted in writing duplicated relations that point to the same version of the entity both when initially writing the edits content and when handling the merge step.

Now we only create merged versions for default edits if there is at least more than one version in the same block for the entity. For imported edits we allow single versions since imports need to be aware of the full state of the import in order to process correctly.