### PR TITLE
fix: create new versions for entities that become stale after relation changes

### DIFF
--- a/apps/web/core/database/entities.ts
+++ b/apps/web/core/database/entities.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { SYSTEM_IDS } from '@geogenesis/sdk';
 import { useQuery } from '@tanstack/react-query';
 import { Duration } from 'effect';

--- a/apps/web/partials/editor/server-content.tsx
+++ b/apps/web/partials/editor/server-content.tsx
@@ -25,6 +25,7 @@ type BlockProps = {
 };
 
 const Block = ({ block }: BlockProps) => {
+  if (!block.content) return null;
   switch (block.type) {
     case 'paragraph': {
       return (

--- a/packages/substream/sink/db/transaction.ts
+++ b/packages/substream/sink/db/transaction.ts
@@ -1,0 +1,9 @@
+import * as db from 'zapatos/db';
+
+import { pool } from '../utils/pool';
+
+export class Transaction {
+  static async run(fn: (client: db.TxnClient<db.IsolationLevel.Serializable>) => Promise<boolean>) {
+    return await db.transaction(pool, db.IsolationLevel.Serializable, fn);
+  }
+}

--- a/packages/substream/sink/db/versions.ts
+++ b/packages/substream/sink/db/versions.ts
@@ -5,18 +5,23 @@ import { pool } from '../utils/pool';
 import { CHUNK_SIZE } from './constants';
 
 export class Versions {
-  static async upsert(versions: S.versions.Insertable[], options: { chunked?: boolean } = {}) {
+  static async upsert(
+    versions: S.versions.Insertable[],
+    options: { chunked?: boolean; client?: db.TxnClient<db.IsolationLevel.Serializable> } = {}
+  ) {
+    const client = options.client ?? pool;
+
     if (options.chunked) {
       for (let i = 0; i < versions.length; i += CHUNK_SIZE) {
         const chunk = versions.slice(i, i + CHUNK_SIZE);
 
-        await db.upsert('versions', chunk, ['id'], { updateColumns: db.doNothing }).run(pool);
+        await db.upsert('versions', chunk, ['id'], { updateColumns: db.doNothing }).run(client);
       }
 
       return;
     }
 
-    return await db.upsert('versions', versions, ['id'], { updateColumns: db.doNothing }).run(pool);
+    return await db.upsert('versions', versions, ['id'], { updateColumns: db.doNothing }).run(client);
   }
 
   static async insert(versions: S.versions.Insertable[], options: { chunked?: boolean } = {}) {
@@ -39,5 +44,13 @@ export class Versions {
 
   static select(where: S.versions.Whereable) {
     return db.select('versions', where).run(pool);
+  }
+
+  static selectOne(where: S.versions.Whereable) {
+    return db
+      .selectOne('versions', where, {
+        columns: ['id', 'entity_id'],
+      })
+      .run(pool);
   }
 }

--- a/packages/substream/sink/events/initial-proposal-created/handler.ts
+++ b/packages/substream/sink/events/initial-proposal-created/handler.ts
@@ -4,11 +4,13 @@ import { mapIpfsProposalToSchemaProposalByType } from '../proposals-created/map-
 import type { EditProposal } from '../proposals-created/parser';
 import { Accounts, Proposals, Versions } from '~/sink/db';
 import { Edits } from '~/sink/db/edits';
+import { Transaction } from '~/sink/db/transaction';
 import { CouldNotWriteAccountsError } from '~/sink/errors';
 import { Telemetry } from '~/sink/telemetry';
 import type { BlockEvent } from '~/sink/types';
 import { retryEffect } from '~/sink/utils/retry-effect';
 import { slog } from '~/sink/utils/slog';
+import { aggregateNewVersions } from '~/sink/write-edits/aggregate-versions';
 import { mergeOpsWithPreviousVersions } from '~/sink/write-edits/merge-ops-with-previous-versions';
 import { writeEdits } from '~/sink/write-edits/write-edits';
 
@@ -67,84 +69,80 @@ export function handleInitialProposalsCreated(proposalsFromIpfs: EditProposal[],
     // @TODO: We need a special function to map a proposal endtime to be now
     const { schemaEditProposals } = mapIpfsProposalToSchemaProposalByType(proposalsFromIpfs, block);
 
-    slog({
-      requestId: block.requestId,
-      message: `Writing ${schemaEditProposals.edits.length} edits for edits without proposals`,
-    });
-
-    const editProposalsResult = yield* _(
-      Effect.tryPromise({
-        try: () => Edits.upsert(schemaEditProposals.edits, { chunked: true }),
-        catch: error => {
-          return new CouldNotWriteInitialSpaceProposalsError(String(error));
-        },
-      }),
-      Effect.either,
-      retryEffect
-    );
-
-    if (Either.isLeft(editProposalsResult)) {
-      const error = editProposalsResult.left;
-      console.log('error', error);
-      return;
-    }
-
-    slog({
-      requestId: block.requestId,
-      message: `Writing ${schemaEditProposals.proposals.length} proposals for edits without proposals`,
-    });
-
-    yield* _(
-      Effect.tryPromise({
-        try: () => Proposals.upsert(schemaEditProposals.proposals, { chunked: true }),
-        catch: error => {
-          return new CouldNotWriteInitialSpaceProposalsError(String(error));
-        },
-      }),
-      retryEffect
-    );
-
-    slog({
-      requestId: block.requestId,
-      message: `Writing ${schemaEditProposals.versions.length} versions for edits without proposals`,
-    });
-
-    yield* _(
-      Effect.tryPromise({
-        try: () => Versions.upsert(schemaEditProposals.versions, { chunked: true }),
-        catch: error => {
-          return new CouldNotWriteInitialSpaceProposalsError(String(error));
-        },
-      }),
-      retryEffect
-    );
-
-    // @TODO: All of this write flow is going to be redone to be oriented around
-    // edits + transactions as well as simplifying our data aggregation + write
-    // pipeline to be easier to reason about and test.
-
-    const opsByVersionId = yield* _(
-      mergeOpsWithPreviousVersions({
+    const versionsWithStaleEntities = yield* _(
+      aggregateNewVersions({
+        block,
         edits: schemaEditProposals.edits,
-        opsByVersionId: schemaEditProposals.opsByVersionId,
-        versions: schemaEditProposals.versions,
+        ipfsVersions: schemaEditProposals.versions,
+        opsByEditId: schemaEditProposals.opsByEditId,
+        opsByEntityId: schemaEditProposals.opsByEntityId,
       })
     );
+
+    // @TODO relationsByVersionId
+
+    slog({
+      requestId: block.requestId,
+      message: `Writing edits, proposals, and versions for edits without proposals`,
+    });
+
+    // 1. Orient the write flow based on processing edits in order.
+    //    If we do this right we can do all of the writing at once
+    //    as transactions while preserving the order with Effect.all.
+    for (const edit of schemaEditProposals.edits) {
+      // @TODO this is nested af
+      const write = Effect.tryPromise({
+        try: async () => {
+          return await Transaction.run(async client => {
+            // @TODO this can probably go into an effect somewhere that's defined after
+            // we aggregate all the appropriate data to write.
+            await Promise.all([
+              Edits.upsert([edit], { client }),
+              Proposals.upsert(
+                schemaEditProposals.proposals.filter(p => p.edit_id?.toString() === edit.id),
+                { client }
+              ),
+              Versions.upsert(
+                versionsWithStaleEntities.filter(v => v.edit_id.toString() === edit.id),
+                { chunked: true, client }
+              ),
+            ]);
+
+            return true;
+          });
+        },
+        catch: error => new CouldNotWriteInitialSpaceProposalsError(String(error)),
+      });
+
+      // @TODO retry
+      yield* _(write);
+    }
 
     slog({
       requestId: block.requestId,
       message: `Writing content for edits without proposals`,
     });
 
+    const opsByNewVersions = yield* _(
+      mergeOpsWithPreviousVersions({
+        edits: schemaEditProposals.edits,
+        opsByVersionId: schemaEditProposals.opsByVersionId,
+        versions: versionsWithStaleEntities,
+      })
+    );
+
     const populateResult = yield* _(
       Effect.either(
         writeEdits({
-          versions: schemaEditProposals.versions,
-          opsByVersionId,
+          versions: versionsWithStaleEntities,
+          opsByVersionId: opsByNewVersions,
           block,
 
           // We treat all edits that occur at the same time the space is created
           // as imported edits.
+          //
+          // @TODO Should we be setting IMPORT for all edits in this handler?
+          // I don't think so...
           editType: 'IMPORT',
           edits: schemaEditProposals.edits,
         })

--- a/packages/substream/sink/events/initial-proposal-created/handler.ts
+++ b/packages/substream/sink/events/initial-proposal-created/handler.ts
@@ -76,6 +76,8 @@ export function handleInitialProposalsCreated(proposalsFromIpfs: EditProposal[],
         ipfsVersions: schemaEditProposals.versions,
         opsByEditId: schemaEditProposals.opsByEditId,
         opsByEntityId: schemaEditProposals.opsByEntityId,
+        // @TODO this isn't correct, we'll need two separate flows
+        editType: 'IMPORT',
       })
     );
 

--- a/packages/substream/sink/events/proposals-created/handler.ts
+++ b/packages/substream/sink/events/proposals-created/handler.ts
@@ -16,6 +16,7 @@ import { Telemetry } from '~/sink/telemetry';
 import type { BlockEvent } from '~/sink/types';
 import { retryEffect } from '~/sink/utils/retry-effect';
 import { slog } from '~/sink/utils/slog';
+import { aggregateNewVersions } from '~/sink/write-edits/aggregate-versions';
 import { mergeOpsWithPreviousVersions } from '~/sink/write-edits/merge-ops-with-previous-versions';
 import { writeEdits } from '~/sink/write-edits/write-edits';
 
@@ -97,6 +98,16 @@ export function handleProposalsCreated(proposalsCreated: ProposalCreated[], bloc
       return;
     }
 
+    const versionsWithStaleEntities = yield* _(
+      aggregateNewVersions({
+        block,
+        edits: schemaEditProposals.edits,
+        ipfsVersions: schemaEditProposals.versions,
+        opsByEditId: schemaEditProposals.opsByEditId,
+        opsByEntityId: schemaEditProposals.opsByEntityId,
+      })
+    );
+
     // @TODO: Put this in a transaction since all these writes are related
     const writtenProposals = yield* _(
       Effect.tryPromise({
@@ -105,7 +116,7 @@ export function handleProposalsCreated(proposalsCreated: ProposalCreated[], bloc
             // Content proposals
             Edits.upsert(schemaEditProposals.edits),
             Proposals.upsert(schemaEditProposals.proposals),
-            Versions.upsert(schemaEditProposals.versions),
+            Versions.upsert(versionsWithStaleEntities),
 
             // Subspace proposals
             Proposals.upsert(schemaSubspaceProposals.proposals),
@@ -149,14 +160,14 @@ export function handleProposalsCreated(proposalsCreated: ProposalCreated[], bloc
       mergeOpsWithPreviousVersions({
         edits: schemaEditProposals.edits,
         opsByVersionId: schemaEditProposals.opsByVersionId,
-        versions: schemaEditProposals.versions,
+        versions: versionsWithStaleEntities,
       })
     );
 
     const populateResult = yield* _(
       Effect.either(
         writeEdits({
-          versions: schemaEditProposals.versions,
+          versions: versionsWithStaleEntities,
           opsByVersionId,
           block,
           editType: 'DEFAULT',

--- a/packages/substream/sink/events/proposals-created/handler.ts
+++ b/packages/substream/sink/events/proposals-created/handler.ts
@@ -105,6 +105,7 @@ export function handleProposalsCreated(proposalsCreated: ProposalCreated[], bloc
         ipfsVersions: schemaEditProposals.versions,
         opsByEditId: schemaEditProposals.opsByEditId,
         opsByEntityId: schemaEditProposals.opsByEntityId,
+        editType: 'DEFAULT',
       })
     );
 

--- a/packages/substream/sink/events/proposals-created/map-proposals.ts
+++ b/packages/substream/sink/events/proposals-created/map-proposals.ts
@@ -191,11 +191,15 @@ function mapEditProposalToSchema(
   versions: S.versions.Insertable[];
   edits: S.edits.Insertable[];
   opsByVersionId: Map<string, Op[]>;
+  opsByEntityId: Map<string, Op[]>;
+  opsByEditId: Map<string, Op[]>;
 } {
   const proposalsToWrite: S.proposals.Insertable[] = [];
   const versionsToWrite: S.versions.Insertable[] = [];
   const editsToWrite: S.edits.Insertable[] = [];
   const opsByVersionId = new Map<string, Op[]>();
+  const opsByEntityId = new Map<string, Op[]>();
+  const opsByEditId = new Map<string, Op[]>();
 
   for (const p of proposals) {
     const spaceId = p.space;
@@ -245,12 +249,11 @@ function mapEditProposalToSchema(
 
       const opsForEntityId = p.ops.filter(o => o.triple.entity === entityId);
 
-      if (opsForEntityId.length === 0) {
-        console.log('invalid edit ops', { id });
-      }
-
       opsByVersionId.set(id, opsForEntityId);
+      opsByEntityId.set(entityId, opsForEntityId);
     }
+
+    opsByEditId.set(p.proposalId, p.ops);
   }
 
   return {
@@ -258,6 +261,8 @@ function mapEditProposalToSchema(
     versions: versionsToWrite,
     edits: editsToWrite,
     opsByVersionId,
+    opsByEntityId,
+    opsByEditId,
   };
 }
 

--- a/packages/substream/sink/events/proposals-created/parser.ts
+++ b/packages/substream/sink/events/proposals-created/parser.ts
@@ -237,7 +237,6 @@ const ZodImportEditSetTriplePayload = z.object({
 const ZodImportEditDeleteTriplePayload = z.object({
   entity: z.string(),
   attribute: z.string(),
-  value: z.object({}),
 });
 
 const ZodImportEditSetTripleOp = z.object({

--- a/packages/substream/sink/events/proposals-created/parser.ts
+++ b/packages/substream/sink/events/proposals-created/parser.ts
@@ -237,6 +237,7 @@ const ZodImportEditSetTriplePayload = z.object({
 const ZodImportEditDeleteTriplePayload = z.object({
   entity: z.string(),
   attribute: z.string(),
+  value: z.object({}),
 });
 
 const ZodImportEditSetTripleOp = z.object({

--- a/packages/substream/sink/proto/decoder.ts
+++ b/packages/substream/sink/proto/decoder.ts
@@ -127,11 +127,11 @@ function decodeImportEdit(data: Buffer): Effect.Effect<ParsedImportEdit | null> 
 
       if (parseResult.success) {
         // @TODO(migration): For now we have some invalid ops while we still work on the data migration
-        const validOps = parseResult.data.ops.filter(
-          o => o.type === 'SET_TRIPLE' && (o.triple as unknown as any)?.value?.type !== 'FILTER_ME_OUT'
-        );
+        // const validOps = parseResult.data.ops.filter(
+        //   o => o.type === 'SET_TRIPLE' && (o.triple as unknown as any)?.value?.type !== 'FILTER_ME_OUT'
+        // );
 
-        parseResult.data.ops = validOps;
+        // parseResult.data.ops = validOps;
 
         return parseResult.data;
       }

--- a/packages/substream/sink/proto/decoder.ts
+++ b/packages/substream/sink/proto/decoder.ts
@@ -126,13 +126,6 @@ function decodeImportEdit(data: Buffer): Effect.Effect<ParsedImportEdit | null> 
       const parseResult = ZodImportEdit.safeParse(edit);
 
       if (parseResult.success) {
-        // @TODO(migration): For now we have some invalid ops while we still work on the data migration
-        // const validOps = parseResult.data.ops.filter(
-        //   o => o.type === 'SET_TRIPLE' && (o.triple as unknown as any)?.value?.type !== 'FILTER_ME_OUT'
-        // );
-
-        // parseResult.data.ops = validOps;
-
         return parseResult.data;
       }
 

--- a/packages/substream/sink/write-edits/aggregate-relations-v2.ts
+++ b/packages/substream/sink/write-edits/aggregate-relations-v2.ts
@@ -1,0 +1,104 @@
+import { SYSTEM_IDS } from '@geogenesis/sdk';
+import { Effect } from 'effect';
+
+import { Versions } from '../db';
+import { Relations } from '../db/relations';
+import type { Op } from '../types';
+
+type RelationWithEntities = {
+  to: string;
+  from: string;
+  typeOf: string;
+  entityId: string;
+  index?: string;
+};
+
+export function maybeEntityOpsToRelation(ops: Op[], entityId: string): RelationWithEntities | null {
+  // Grab other triples in this edit that match the relation's entity id. We
+  // want to add all of the relation properties to the item in the
+  // collection_items table.
+  const setTriples = ops.filter(t => t.type === 'SET_TRIPLE');
+
+  const isRelation = setTriples.find(
+    t =>
+      t.triple.attribute === SYSTEM_IDS.TYPES &&
+      t.triple.value.type === 'ENTITY' &&
+      t.triple.value.value === SYSTEM_IDS.RELATION_TYPE
+  );
+  const to = setTriples.find(
+    t => t.triple.attribute === SYSTEM_IDS.RELATION_TO_ATTRIBUTE && t.triple.value.type === 'ENTITY'
+  );
+  const from = setTriples.find(
+    t => t.triple.attribute === SYSTEM_IDS.RELATION_FROM_ATTRIBUTE && t.triple.value.type === 'ENTITY'
+  );
+  const type = setTriples.find(
+    t => t.triple.attribute === SYSTEM_IDS.RELATION_TYPE_ATTRIBUTE && t.triple.value.type === 'ENTITY'
+  );
+  const index = setTriples.find(
+    t => t.triple.attribute === SYSTEM_IDS.RELATION_INDEX && t.triple.value.type === 'TEXT'
+  );
+
+  if (!isRelation) {
+    return null;
+  }
+
+  if (!to || !from || !type) {
+    return null;
+  }
+
+  return {
+    to: to.triple.value.value,
+    from: from.triple.value.value,
+    entityId: entityId,
+    typeOf: type.triple.value.value,
+    index: index?.triple.value.value,
+  };
+}
+
+export function getStaleEntitiesInEdit(args: {
+  createdRelations: RelationWithEntities[];
+  deletedRelations: string[];
+  entityIds: Set<string>;
+}) {
+  const { createdRelations, deletedRelations, entityIds } = args;
+  const createdRelationFromIds = createdRelations.map(r => r.from);
+  return [...createdRelationFromIds, ...deletedRelations].filter(fromId => !entityIds.has(fromId));
+}
+
+export function getDeletedRelations(ops: Op[]) {
+  return Effect.gen(function* (_) {
+    // DELETE_TRIPLE ops don't store the value of the deleted op, so we have no way
+    // of knowing if the op being deleted here is actually a relation unless we query
+    // the Relations table with the entity id.
+    const entityIdsForDeletedTypeOps = ops
+      .filter(o => o.type === 'DELETE_TRIPLE' && o.triple.attribute === SYSTEM_IDS.TYPES)
+      .map(o => o.triple.entity);
+
+    const getRelations = Effect.all(
+      entityIdsForDeletedTypeOps.map(entityId =>
+        Effect.promise(() => {
+          return Relations.selectOne({
+            entity_id: entityId,
+          });
+        })
+      )
+    );
+
+    // The relations we get here are unfortunately versions so we have to then query
+    // the versions to get the entity ids. We could do a JOIN here with a special SQL
+    // query but I've found it's super slow.
+    const relations = (yield* _(getRelations)).filter(r => r !== undefined);
+
+    const getEntityIdOfFromRelations = Effect.all(
+      relations.map(relation =>
+        Effect.promise(() => {
+          return Versions.selectOne({
+            id: relation.entity_id,
+          });
+        })
+      )
+    );
+
+    return (yield* _(getEntityIdOfFromRelations)).filter(e => e !== undefined).map(r => r.entity_id);
+  });
+}

--- a/packages/substream/sink/write-edits/aggregate-versions.ts
+++ b/packages/substream/sink/write-edits/aggregate-versions.ts
@@ -1,0 +1,82 @@
+import { Effect } from 'effect';
+import type * as Schema from 'zapatos/schema';
+
+import type { BlockEvent, Op } from '../types';
+import { getDeletedRelations, getStaleEntitiesInEdit, maybeEntityOpsToRelation } from './aggregate-relations-v2';
+import { makeVersionForStaleEntity } from './make-version-for-stale-entity';
+
+interface AggregateNewVersionsArgs {
+  edits: Schema.edits.Insertable[];
+  ipfsVersions: Schema.versions.Insertable[];
+  opsByEditId: Map<string, Op[]>;
+  opsByEntityId: Map<string, Op[]>;
+  block: BlockEvent;
+}
+
+/**
+ *  When aggregating relations there's two steps
+ *  1. Gathering relations from previous version of an entity
+ *  2. Filtering any relations deleted in the same edit
+ *  3. Adding any new relations in the same edit
+ *
+ * #3 is also used to see if we need to manually create any versions for
+ * entities with new relations that don't have created versions.
+ */
+// Can we parallelize in order? Effect.all
+export function aggregateNewVersions(args: AggregateNewVersionsArgs) {
+  const { edits, opsByEditId, opsByEntityId, ipfsVersions, block } = args;
+  const newVersions = ipfsVersions;
+
+  return Effect.gen(function* (_) {
+    // @TODO This needs to be import-aware...
+    for (const edit of edits) {
+      const versionsInEdit = ipfsVersions.filter(v => v.edit_id.toString() === edit.id);
+      const entitiesInEdit = new Set(versionsInEdit.map(v => v.entity_id.toString()));
+      const opsInEdit = opsByEditId.get(edit.id.toString()) ?? [];
+
+      const createdRelations = [...opsByEntityId.entries()]
+        .filter(([entityId]) => entitiesInEdit.has(entityId))
+        .map(([entityId, ops]) => maybeEntityOpsToRelation(ops, entityId))
+        .filter(r => r !== null);
+
+      const deletedRelations = yield* _(getDeletedRelations(opsInEdit));
+
+      // Stale entities are entities which are referenced by the "from" field in
+      // created or deleted relations where the entity does not have a new version
+      // in the edit.
+      //
+      // e.g., you make a new relation from Entity A, but do not change Entity A
+      // itself, therefore a new version for Entity A is not created in this edit.
+      const staleEntities = [
+        ...new Set(getStaleEntitiesInEdit({ createdRelations, deletedRelations, entityIds: entitiesInEdit })),
+      ];
+      const versionsForStaleEntities = staleEntities.map(entityId =>
+        makeVersionForStaleEntity({
+          block,
+          createdAt: edit.created_at.toString(),
+          creator: edit.created_by_id.toString(),
+          editId: edit.id.toString(),
+          entityId,
+        })
+      );
+
+      // Append new versions for stale entities to versions in edit
+      newVersions.push(...versionsForStaleEntities);
+
+      console.log('relations', {
+        staleEntities,
+        deletedRelations,
+        versionsForStaleEntities,
+        newVersions,
+      });
+
+      // Theoretically as soon as we append the new versions we can just let the existing
+      //     write flow continue as-is. But it wouldn't be ideal since we're doing a lot
+      //     of duplicated work and those db writes aren't contained to a tx'.
+      // Map aggregated relations to be version-aware
+      // Map aggregated relations to Map<VersionId, Relations[]>
+    }
+
+    return newVersions;
+  });
+}

--- a/packages/substream/sink/write-edits/make-version-for-stale-entity.ts
+++ b/packages/substream/sink/write-edits/make-version-for-stale-entity.ts
@@ -1,0 +1,28 @@
+import type * as Schema from 'zapatos/schema';
+
+import type { BlockEvent } from '../types';
+import { createVersionId } from '../utils/id';
+
+export function makeVersionForStaleEntity(args: {
+  entityId: string;
+  editId: string;
+  block: BlockEvent;
+  creator: string;
+  createdAt: string;
+}): Schema.versions.Insertable {
+  const { block, createdAt, creator, editId, entityId } = args;
+
+  const id = createVersionId({
+    entityId,
+    proposalId: editId,
+  });
+
+  return {
+    id,
+    entity_id: entityId,
+    created_at_block: block.blockNumber,
+    created_at: Number(createdAt),
+    created_by_id: creator,
+    edit_id: editId,
+  };
+}

--- a/packages/substream/sink/write-edits/map-triples.ts
+++ b/packages/substream/sink/write-edits/map-triples.ts
@@ -45,10 +45,6 @@ function squashOps(ops: Op[], spaceId: string, versionId: string): Op[] {
 }
 
 function validateOps(ops: Op[]) {
-  if (ops === undefined) {
-    return [];
-  }
-
   return ops.filter(o => {
     if (o.type === 'DELETE_TRIPLE') return true;
 


### PR DESCRIPTION
This PR adds functionality for creating a new version for an entity if relations from the entity are changed and there's not already a new version for that entity in the edit.
- You make a new relation from Entity A, but do not change any triples on Entity A. This does not make a new version of Entity A, so the new relation won't be associated with the latest version of Entity A in the DB
- You delete a relation from Entity A, but do not change any triples on Entity A. Same issue as 1.

This PR also fixes a bug when merging imported ops where the imported entity did not merge any pre-existing data for that entity from other spaces (or bootstrap).
