### PR TITLE
feat: space-aware relations

### DIFF
--- a/packages/substream/sink/db/relations.ts
+++ b/packages/substream/sink/db/relations.ts
@@ -12,7 +12,7 @@ export class Relations {
 
         await db
           .upsert('relations', chunk, ['id'], {
-            updateColumns: ['entity_id', 'id', 'from_version_id', 'to_version_id', 'type_of_id', 'index'],
+            updateColumns: ['entity_id', 'id', 'from_version_id', 'to_version_id', 'type_of_id', 'index', 'space_id'],
           })
           .run(pool);
       }
@@ -22,7 +22,7 @@ export class Relations {
 
     return await db
       .upsert('relations', relations, ['id'], {
-        updateColumns: ['entity_id', 'id', 'from_version_id', 'to_version_id', 'type_of_id', 'index'],
+        updateColumns: ['entity_id', 'id', 'from_version_id', 'to_version_id', 'type_of_id', 'index', 'space_id'],
       })
       .run(pool);
   }
@@ -42,7 +42,7 @@ export class Relations {
   static async selectOne(relation: S.relations.Whereable) {
     return await db
       .selectOne('relations', relation, {
-        columns: ['id', 'entity_id', 'from_version_id', 'to_version_id', 'type_of_id'],
+        columns: ['id', 'entity_id', 'from_version_id', 'to_version_id', 'type_of_id', 'space_id'],
       })
       .run(pool);
   }
@@ -50,7 +50,7 @@ export class Relations {
   static async select(relation: S.relations.Whereable) {
     return await db
       .select('relations', relation, {
-        columns: ['id', 'entity_id', 'from_version_id', 'to_version_id', 'type_of_id', 'index'],
+        columns: ['id', 'entity_id', 'from_version_id', 'to_version_id', 'type_of_id', 'index', 'space_id'],
         lateral: {
           to_entity: db.selectOne('versions', { id: db.parent('to_version_id') }, { columns: ['entity_id'] }),
           type_of: db.selectOne('versions', { id: db.parent('type_of_id') }, { columns: ['entity_id'] }),

--- a/packages/substream/sink/sql/init-public.sql
+++ b/packages/substream/sink/sql/init-public.sql
@@ -115,6 +115,7 @@ CREATE TABLE public.current_versions (
 
 CREATE TABLE public.relations (
     id text PRIMARY KEY NOT NULL,
+    space_id text REFERENCES public.spaces(id) NOT NULL,
     type_of_id text REFERENCES public.versions(id) NOT NULL, -- type of the relation, e.g., "Type", "Attribute", "Friend"
     to_version_id text REFERENCES public.versions(id) NOT NULL, -- the entity the relation is pointing to
     index text, -- the fractional index of the relation relative to other relations of the same type

--- a/packages/substream/sink/zapatos/schema.d.ts
+++ b/packages/substream/sink/zapatos/schema.d.ts
@@ -2185,6 +2185,12 @@ declare module 'zapatos/schema' {
       */
       id: string;
       /**
+      * **relations.space_id**
+      * - `text` in database
+      * - `NOT NULL`, no default
+      */
+      space_id: string;
+      /**
       * **relations.type_of_id**
       * - `text` in database
       * - `NOT NULL`, no default
@@ -2222,6 +2228,12 @@ declare module 'zapatos/schema' {
       * - `NOT NULL`, no default
       */
       id: string;
+      /**
+      * **relations.space_id**
+      * - `text` in database
+      * - `NOT NULL`, no default
+      */
+      space_id: string;
       /**
       * **relations.type_of_id**
       * - `text` in database
@@ -2261,6 +2273,12 @@ declare module 'zapatos/schema' {
       */
       id?: string | db.Parameter<string> | db.SQLFragment | db.ParentColumn | db.SQLFragment<any, string | db.Parameter<string> | db.SQLFragment | db.ParentColumn>;
       /**
+      * **relations.space_id**
+      * - `text` in database
+      * - `NOT NULL`, no default
+      */
+      space_id?: string | db.Parameter<string> | db.SQLFragment | db.ParentColumn | db.SQLFragment<any, string | db.Parameter<string> | db.SQLFragment | db.ParentColumn>;
+      /**
       * **relations.type_of_id**
       * - `text` in database
       * - `NOT NULL`, no default
@@ -2299,6 +2317,12 @@ declare module 'zapatos/schema' {
       */
       id: string | db.Parameter<string> | db.SQLFragment;
       /**
+      * **relations.space_id**
+      * - `text` in database
+      * - `NOT NULL`, no default
+      */
+      space_id: string | db.Parameter<string> | db.SQLFragment;
+      /**
       * **relations.type_of_id**
       * - `text` in database
       * - `NOT NULL`, no default
@@ -2336,6 +2360,12 @@ declare module 'zapatos/schema' {
       * - `NOT NULL`, no default
       */
       id?: string | db.Parameter<string> | db.SQLFragment | db.SQLFragment<any, string | db.Parameter<string> | db.SQLFragment>;
+      /**
+      * **relations.space_id**
+      * - `text` in database
+      * - `NOT NULL`, no default
+      */
+      space_id?: string | db.Parameter<string> | db.SQLFragment | db.SQLFragment<any, string | db.Parameter<string> | db.SQLFragment>;
       /**
       * **relations.type_of_id**
       * - `text` in database


### PR DESCRIPTION
We now track the space id from which relations are created. This allows us to query for entity data scoped by space for both triples and relations.