### PR TITLE
fix: merging ops from previous version was overriding space ids

### DIFF
--- a/packages/substream/sink/bootstrap-root.ts
+++ b/packages/substream/sink/bootstrap-root.ts
@@ -143,6 +143,7 @@ const types: Record<string, string[]> = {
 const nameOps: Op[] = Object.entries(names).map(([entityId, name]) => {
   return {
     type: 'SET_TRIPLE',
+    space: SPACE_ID,
     triple: {
       attribute: SYSTEM_IDS.NAME,
       entity: entityId!,
@@ -159,7 +160,10 @@ const attributeOps: Op[] = Object.keys(attributes).flatMap(attributeId => {
     fromId: attributeId,
     toId: SYSTEM_IDS.ATTRIBUTE,
     relationTypeId: SYSTEM_IDS.TYPES,
-  });
+  }).map(op => ({
+    ...op,
+    space: SPACE_ID,
+  }));
 });
 
 const attributeValueTypeOps: Op[] = Object.entries(attributes).flatMap(([attributeId, valueType]) => {
@@ -167,7 +171,10 @@ const attributeValueTypeOps: Op[] = Object.entries(attributes).flatMap(([attribu
     fromId: attributeId,
     toId: valueType,
     relationTypeId: SYSTEM_IDS.VALUE_TYPE,
-  });
+  }).map(op => ({
+    ...op,
+    space: SPACE_ID,
+  }));
 });
 
 const typeOps: Op[] = Object.keys(types).flatMap(typeId => {
@@ -175,7 +182,10 @@ const typeOps: Op[] = Object.keys(types).flatMap(typeId => {
     fromId: typeId,
     toId: SYSTEM_IDS.SCHEMA_TYPE,
     relationTypeId: SYSTEM_IDS.TYPES,
-  });
+  }).map(op => ({
+    ...op,
+    space: SPACE_ID,
+  }));
 });
 
 const typeSchemaOps: Op[] = Object.entries(types).flatMap(([typeId, attributeIds]) => {
@@ -184,7 +194,10 @@ const typeSchemaOps: Op[] = Object.entries(types).flatMap(([typeId, attributeIds
       fromId: typeId,
       toId: attributeId,
       relationTypeId: SYSTEM_IDS.ATTRIBUTES,
-    });
+    }).map(op => ({
+      ...op,
+      space: SPACE_ID,
+    }));
   });
 });
 

--- a/packages/substream/sink/events/edits-published/aggregate-mergable-versions.test.ts
+++ b/packages/substream/sink/events/edits-published/aggregate-mergable-versions.test.ts
@@ -55,6 +55,7 @@ const opsByVersionId = new Map<string, Op[]>([
     [
       {
         type: 'SET_TRIPLE',
+        space: 'space-1',
         triple: {
           attribute: 'attribute-id-1',
           entity: 'same',
@@ -68,6 +69,7 @@ const opsByVersionId = new Map<string, Op[]>([
     [
       {
         type: 'SET_TRIPLE',
+        space: 'space-1',
         triple: {
           attribute: 'attribute-id-2',
           entity: 'same',

--- a/packages/substream/sink/events/edits-published/get-edits-proposal-from-processed-proposal.ts
+++ b/packages/substream/sink/events/edits-published/get-edits-proposal-from-processed-proposal.ts
@@ -157,7 +157,28 @@ function fetchEditProposalFromIpfs(
             proposalId: e.id,
             onchainProposalId: '-1',
             pluginAddress: getChecksumAddress(processedProposal.pluginAddress),
-            ops: e.ops as Op[],
+            ops: e.ops.map((op): Op => {
+              if (op.type === 'SET_TRIPLE') {
+                return {
+                  type: 'SET_TRIPLE',
+                  space: maybeSpaceIdForSpacePlugin.id,
+                  triple: op.triple,
+                  // Have to do some weird transforms with import edits for some reason
+                  // and Zod doesn't recognize the transform as a literal. Means we can't
+                  // correctly discriminate between SET_TRIPLE and DELETE_TRIPLE structures.
+                } as Op;
+              }
+
+              return {
+                type: 'DELETE_TRIPLE',
+                space: maybeSpaceIdForSpacePlugin.id,
+                triple: {
+                  attribute: op.triple.attribute,
+                  entity: op.triple.entity,
+                  value: {},
+                },
+              };
+            }),
             creator: getChecksumAddress(e.createdBy),
             space: maybeSpaceIdForSpacePlugin.id,
             endTime: block.timestamp.toString(),

--- a/packages/substream/sink/events/get-triple-from-op.test.ts
+++ b/packages/substream/sink/events/get-triple-from-op.test.ts
@@ -7,6 +7,7 @@ describe('tripleFromOp', () => {
     const triple = getTripleFromOp(
       {
         type: 'SET_TRIPLE',
+        space: 'space-1',
         triple: {
           attribute: 'attribute-id',
           entity: 'entity-id',
@@ -17,7 +18,6 @@ describe('tripleFromOp', () => {
         },
       },
       '0x1234',
-      '0',
       {
         blockNumber: 0,
         cursor: '',
@@ -42,6 +42,7 @@ describe('tripleFromOp', () => {
     const triple = getTripleFromOp(
       {
         type: 'DELETE_TRIPLE',
+        space: 'space-1',
         triple: {
           attribute: 'attribute-id',
           entity: 'entity-id',
@@ -49,7 +50,6 @@ describe('tripleFromOp', () => {
         },
       },
       '0x1234',
-      '0',
       {
         blockNumber: 0,
         cursor: '',

--- a/packages/substream/sink/events/get-triple-from-op.ts
+++ b/packages/substream/sink/events/get-triple-from-op.ts
@@ -2,9 +2,13 @@ import type * as S from 'zapatos/schema';
 
 import type { BlockEvent, Op, ValueType } from '../types';
 
-export function getTripleFromOp(op: Op, spaceId: string, versionId: string, block: BlockEvent): S.triples.Insertable {
+/**
+ * @NOTE that we currently merge ops from previous versions of entities into new versions. If
+ * an entity has triples from multiple spaces we need to keep the space_id of the original
+ * triple instead of changing it to the space id of the edit being processed.
+ */
+export function getTripleFromOp(op: Op, versionId: string, block: BlockEvent): S.triples.Insertable {
   const { entity, attribute } = op.triple;
-  const space_id = spaceId;
 
   if (op.type === 'SET_TRIPLE') {
     const value = op.triple.value;
@@ -13,7 +17,7 @@ export function getTripleFromOp(op: Op, spaceId: string, versionId: string, bloc
 
     return {
       version_id: versionId,
-      space_id,
+      space_id: op.space,
       entity_id: entity,
       attribute_id: attribute,
       value_type,
@@ -25,7 +29,7 @@ export function getTripleFromOp(op: Op, spaceId: string, versionId: string, bloc
 
   return {
     version_id: versionId,
-    space_id,
+    space_id: op.space,
     entity_id: entity,
     attribute_id: attribute,
     value_type: 'TEXT', // this doesn't matter for deletes, but we populate it anyway for more ergonomic types

--- a/packages/substream/sink/events/proposals-created/get-proposal-from-ipfs.ts
+++ b/packages/substream/sink/events/proposals-created/get-proposal-from-ipfs.ts
@@ -124,8 +124,25 @@ export function getProposalFromIpfs(
           proposalId: parsedContent.id,
           onchainProposalId: proposal.proposalId,
           pluginAddress: getChecksumAddress(proposal.pluginAddress),
-          // @TODO: Figure out these types
-          ops: parsedContent.ops as unknown as Op[],
+          ops: parsedContent.ops.map((op): Op => {
+            if (op.type === 'SET_TRIPLE') {
+              return {
+                type: 'SET_TRIPLE',
+                space: maybeSpaceIdForVotingPlugin,
+                triple: op.triple,
+              };
+            }
+
+            return {
+              type: 'DELETE_TRIPLE',
+              space: maybeSpaceIdForVotingPlugin,
+              triple: {
+                attribute: op.triple.attribute,
+                entity: op.triple.entity,
+                value: {},
+              },
+            };
+          }),
           creator: getChecksumAddress(proposal.creator),
           space: maybeSpaceIdForVotingPlugin,
         };

--- a/packages/substream/sink/events/proposals-created/parser.ts
+++ b/packages/substream/sink/events/proposals-created/parser.ts
@@ -228,7 +228,7 @@ const ZodImportEditSetTriplePayload = z.object({
         case 7:
           return 'GEO_LOCATION';
         default:
-          return 'FILTER_ME_OUT';
+          return 'TEXT';
       }
     }),
   }),

--- a/packages/substream/sink/run-stream.ts
+++ b/packages/substream/sink/run-stream.ts
@@ -5,7 +5,7 @@ import { NETWORK_IDS } from '@geogenesis/sdk/src/system-ids';
 import { authIssue, createAuthInterceptor, createRegistry } from '@substreams/core';
 import type { BlockScopedData } from '@substreams/core/proto';
 import { readPackageFromFile } from '@substreams/manifest';
-import { Data, Duration, Effect, LogLevel, Logger, Secret, Stream } from 'effect';
+import { Data, Duration, Effect, Logger, Secret, Stream } from 'effect';
 
 import { MANIFEST } from './constants/constants';
 import { readCursor, writeCursor } from './cursor';

--- a/packages/substream/sink/types.ts
+++ b/packages/substream/sink/types.ts
@@ -15,16 +15,22 @@ export interface GeoBlock extends BlockEvent {
 
 export type ValueType = 'TEXT' | 'NUMBER' | 'ENTITY' | 'COLLECTION' | 'CHECKBOX' | 'URI' | 'TIME' | 'GEO_LOCATION';
 
-// We hardcode our Op type instead of deriving it from the Zod types.
-// This is due to zod having issues generating disciminate types from
-// discriminate unions. See `ZodEditDeleteTriplePayload` and `ZodEditDeleteTriplePayload`
-// above.
-//
-// For now we cast the value depending on the op type during decoding and
-// trust that it is constructed into the correct ormat once it's decoded.
+/**
+ * We hardcode our Op type instead of deriving it from the Zod types. This is due to zod having
+ * issues generating disciminate types from discriminate unions. See `ZodEditDeleteTriplePayload`
+ * and `ZodEditDeleteTriplePayload` above.
+ *
+ * For now we cast the value depending on the op type during decoding and trust that it is
+ * constructed into the correct ormat once it's decoded.
+ *
+ * @NOTE that we currently merge ops from previous versions of entities into new versions. If
+ * an entity has triples from multiple spaces we need to keep the space_id of the original
+ * triple instead of changing it to the space id of the edit being processed.
+ */
 export type Op =
   | {
       type: 'SET_TRIPLE';
+      space: string;
       triple: {
         entity: string;
         attribute: string;
@@ -36,6 +42,7 @@ export type Op =
     }
   | {
       type: 'DELETE_TRIPLE';
+      space: string;
       triple: {
         entity: string;
         attribute: string;

--- a/packages/substream/sink/write-edits/map-triples.ts
+++ b/packages/substream/sink/write-edits/map-triples.ts
@@ -9,10 +9,10 @@ export interface OpWithCreatedBy {
   triple: S.triples.Insertable;
 }
 
-export type SchemaTripleEdit = { ops: Op[]; spaceId: string; createdById: string; versonId: string };
+export type SchemaTripleEdit = { ops: Op[]; createdById: string; versonId: string };
 
 export function mapSchemaTriples(edit: SchemaTripleEdit, block: BlockEvent): OpWithCreatedBy[] {
-  const squashedOps = squashOps(edit.ops, edit.spaceId, edit.versonId);
+  const squashedOps = squashOps(edit.ops, edit.versonId);
 
   // Validating after squashing is an intentional decision to throw away ops
   // with the _final_ state of the ops in an edit. If we validate before we
@@ -23,7 +23,7 @@ export function mapSchemaTriples(edit: SchemaTripleEdit, block: BlockEvent): OpW
   const validOps = validateOps(squashedOps);
 
   return validOps.map((op): OpWithCreatedBy => {
-    const triple = getTripleFromOp(op, edit.spaceId, edit.versonId, block);
+    const triple = getTripleFromOp(op, edit.versonId, block);
 
     return {
       createdById: edit.createdById,
@@ -33,10 +33,10 @@ export function mapSchemaTriples(edit: SchemaTripleEdit, block: BlockEvent): OpW
   });
 }
 
-function squashOps(ops: Op[], spaceId: string, versionId: string): Op[] {
+function squashOps(ops: Op[], versionId: string): Op[] {
   // We take the last op for each (S,E,A,V) tuple
   const squashedOps = ops.reduce((acc, op) => {
-    const idForOp = `${spaceId}:${op.triple.entity}:${op.triple.attribute}:${versionId}`;
+    const idForOp = `${op.space}:${op.triple.entity}:${op.triple.attribute}:${versionId}`;
     acc.set(idForOp, op);
     return acc;
   }, new Map<string, Op>());

--- a/packages/substream/sink/write-edits/relations/aggregate-relations.ts
+++ b/packages/substream/sink/write-edits/relations/aggregate-relations.ts
@@ -101,6 +101,12 @@ export function aggregateRelations({ triples, versions, edits, editType }: Aggre
       .filter(v => Boolean(v))
       .flat();
 
+    // @TODO we should only check the per-edit triples. we can also do this above the loop
+    // and map the deleted relation ids to edits.
+    //
+    // We also need to scope the deleted ids to the current edit.
+    const deletedRelationEntityIds = yield* _(collectDeletedRelationsEntityIds(triples));
+
     // We process relations by edit id so that we can use either the latest or any version
     // in the specific edit when referencing to, from, and type within a relation. Otherwise
     // we can have relations referencing versions in different edits which doesn't make sense.
@@ -133,8 +139,6 @@ export function aggregateRelations({ triples, versions, edits, editType }: Aggre
       for (const version of allVersionsReferencedByRelations) {
         latestVersionForChangedEntities[version.entity_id.toString()] = version.id.toString();
       }
-
-      const deletedRelationEntityIds = yield* _(collectDeletedRelationsEntityIds(triples));
 
       const nonDeletedDbRelations = latestRelationsFromDbForVersions.filter(
         r => !deletedRelationEntityIds.has(r.entity_id)

--- a/packages/substream/sink/write-edits/write-edits.ts
+++ b/packages/substream/sink/write-edits/write-edits.ts
@@ -72,8 +72,6 @@ export function writeEdits(args: PopulateContentArgs) {
       const editWithCreatedById: SchemaTripleEdit = {
         versonId: version.id.toString(),
         createdById: version.created_by_id.toString(),
-        spaceId: spaceIdByEditId.get(version.edit_id.toString())!,
-        // @TODO: These can just be passed into the function as OpsWithCreatedBy instead of Ops
         ops: opsByVersionId.get(version.id.toString()) ?? [],
       };
 


### PR DESCRIPTION
This PR fixes a bug where we were overriding pre-existing triples' spaces when merging them into new versions.

We now track the space as part of ops directly during IPFS parsing. This means we can write the space for each op more granularly instead of applying the space id of the edit to merged ops.