### PR TITLE
fix: version spaces were not deriving from relations

### DIFF
--- a/packages/substream/sink/write-edits/write-edits.ts
+++ b/packages/substream/sink/write-edits/write-edits.ts
@@ -122,6 +122,18 @@ export function writeEdits(args: PopulateContentArgs) {
       })
     );
 
+    for (const relation of relations) {
+      versionSpaces.push({
+        version_id: relation.from_version_id,
+        space_id: relation.space_id,
+      });
+    }
+
+    const versionSpacesUnique = dedupeWith(
+      versionSpaces,
+      (a, z) => a.space_id.toString() !== z.space_id.toString() && a.version_id.toString() !== z.version_id.toString()
+    );
+
     /**
      * 1. Write versions with primitive metadata (e.g., name, description)
      * 2. Write any new entities
@@ -141,7 +153,7 @@ export function writeEdits(args: PopulateContentArgs) {
           catch: error => new Error(`Failed to insert entities. ${(error as Error).message}`),
         }),
         Effect.tryPromise({
-          try: () => VersionSpaces.upsert(versionSpaces),
+          try: () => VersionSpaces.upsert(versionSpacesUnique),
           catch: error => new Error(`Failed to insert version spaces. ${(error as Error).message}`),
         }),
         writeTriples({

--- a/packages/substream/sink/write-edits/write-edits.ts
+++ b/packages/substream/sink/write-edits/write-edits.ts
@@ -92,19 +92,11 @@ export function writeEdits(args: PopulateContentArgs) {
         description,
       } satisfies Schema.versions.Insertable);
 
-      const spaces = triplesForVersion.reduce(
-        (acc, t) => {
-          acc.set(version.id.toString(), t.triple.space_id.toString());
-          return acc;
-        },
-        // version id -> space id
-        new Map<string, string>()
-      );
-
-      for (const [versionId, spaceId] of spaces.entries()) {
+      // Later we dedupe after applying space versions derived from relations
+      for (const triple of triplesForVersion) {
         versionSpaces.push({
-          version_id: versionId,
-          space_id: spaceId,
+          version_id: triple.triple.version_id.toString(),
+          space_id: triple.triple.space_id.toString(),
         });
       }
     }

--- a/packages/substream/sink/write-edits/write-edits.ts
+++ b/packages/substream/sink/write-edits/write-edits.ts
@@ -95,8 +95,8 @@ export function writeEdits(args: PopulateContentArgs) {
       // Later we dedupe after applying space versions derived from relations
       for (const triple of triplesForVersion) {
         versionSpaces.push({
-          version_id: triple.triple.version_id.toString(),
-          space_id: triple.triple.space_id.toString(),
+          version_id: triple.triple.version_id,
+          space_id: triple.triple.space_id,
         });
       }
     }


### PR DESCRIPTION
Previously version spaces were only deriving from triples on a version, but not relations.