### PR TITLE
fix: use deleted relations from current edit when setting relations on new version

### DIFF
--- a/packages/substream/sink/events/edits-published/handler.ts
+++ b/packages/substream/sink/events/edits-published/handler.ts
@@ -110,6 +110,7 @@ export function handleEditsPublished(ipfsProposals: EditProposal[], createdSpace
         }),
         writeEdits({
           versions: defaultMergedVersions,
+          opsByEditId,
           opsByVersionId: defaultMergedOpsByVersionId,
           edits: defaultEdits,
           block,
@@ -133,6 +134,7 @@ export function handleEditsPublished(ipfsProposals: EditProposal[], createdSpace
      */
     yield* _(
       writeEdits({
+        opsByEditId,
         versions: importedMergedVersions,
         opsByVersionId: importedMergedOpsByVersionId,
         block,

--- a/packages/substream/sink/events/initial-proposal-created/handler.ts
+++ b/packages/substream/sink/events/initial-proposal-created/handler.ts
@@ -4,7 +4,6 @@ import { mapIpfsProposalToSchemaProposalByType } from '../proposals-created/map-
 import type { EditProposal } from '../proposals-created/parser';
 import { Accounts, Proposals, Versions } from '~/sink/db';
 import { Edits } from '~/sink/db/edits';
-import { Transaction } from '~/sink/db/transaction';
 import { CouldNotWriteAccountsError } from '~/sink/errors';
 import { Telemetry } from '~/sink/telemetry';
 import type { BlockEvent } from '~/sink/types';
@@ -87,7 +86,6 @@ export function createInitialContentForSpaces(args: InitialContentArgs) {
 
     // @TODO transactions are pretty slow for actual content writing for now, so
     // we are skipping writing the actual content in a transaction for now.
-    // @TODO this is nested af
     const write = Effect.tryPromise({
       try: async () => {
         // @TODO this can probably go into an effect somewhere that's defined after
@@ -120,6 +118,7 @@ export function createInitialContentForSpaces(args: InitialContentArgs) {
         writeEdits({
           versions: versionsWithStaleEntities,
           opsByVersionId: opsByNewVersions,
+          opsByEditId: schemaEditProposals.opsByEditId,
           block,
           editType,
           edits: schemaEditProposals.edits,

--- a/packages/substream/sink/events/proposals-created/handler.ts
+++ b/packages/substream/sink/events/proposals-created/handler.ts
@@ -151,6 +151,7 @@ export function handleProposalsCreated(proposalsCreated: ProposalCreated[], bloc
       Effect.either(
         writeEdits({
           versions: versionsWithStaleEntities,
+          opsByEditId: schemaEditProposals.opsByEditId,
           opsByVersionId,
           block,
           editType: 'DEFAULT',

--- a/packages/substream/sink/types.ts
+++ b/packages/substream/sink/types.ts
@@ -15,6 +15,29 @@ export interface GeoBlock extends BlockEvent {
 
 export type ValueType = 'TEXT' | 'NUMBER' | 'ENTITY' | 'COLLECTION' | 'CHECKBOX' | 'URI' | 'TIME' | 'GEO_LOCATION';
 
+export type SetTripleOp = {
+  type: 'SET_TRIPLE';
+  space: string;
+  triple: {
+    entity: string;
+    attribute: string;
+    value: {
+      type: ValueType;
+      value: string;
+    };
+  };
+};
+
+type DeleteTripleOp = {
+  type: 'DELETE_TRIPLE';
+  space: string;
+  triple: {
+    entity: string;
+    attribute: string;
+    value: Record<string, never>;
+  };
+};
+
 /**
  * We hardcode our Op type instead of deriving it from the Zod types. This is due to zod having
  * issues generating disciminate types from discriminate unions. See `ZodEditDeleteTriplePayload`
@@ -27,28 +50,7 @@ export type ValueType = 'TEXT' | 'NUMBER' | 'ENTITY' | 'COLLECTION' | 'CHECKBOX'
  * an entity has triples from multiple spaces we need to keep the space_id of the original
  * triple instead of changing it to the space id of the edit being processed.
  */
-export type Op =
-  | {
-      type: 'SET_TRIPLE';
-      space: string;
-      triple: {
-        entity: string;
-        attribute: string;
-        value: {
-          type: ValueType;
-          value: string;
-        };
-      };
-    }
-  | {
-      type: 'DELETE_TRIPLE';
-      space: string;
-      triple: {
-        entity: string;
-        attribute: string;
-        value: Record<string, never>;
-      };
-    };
+export type Op = SetTripleOp | DeleteTripleOp;
 
 export type Edit = {
   name: string;

--- a/packages/substream/sink/write-edits/write-edits.ts
+++ b/packages/substream/sink/write-edits/write-edits.ts
@@ -14,6 +14,7 @@ interface PopulateContentArgs {
   block: BlockEvent;
   versions: Schema.versions.Insertable[];
   opsByVersionId: Map<string, Op[]>;
+  opsByEditId: Map<string, Op[]>;
   /**
    * We pass in any imported edits to write to the db since we need to
    * write the imported edits as if they are a single atomic unit rather
@@ -41,7 +42,7 @@ interface PopulateContentArgs {
  * versions as a single unit.
  */
 export function writeEdits(args: PopulateContentArgs) {
-  const { versions, opsByVersionId, edits, block, editType } = args;
+  const { versions, opsByVersionId, opsByEditId, edits, block, editType } = args;
   const spaceIdByEditId = new Map<string, string>();
 
   for (const edit of edits) {
@@ -105,10 +106,11 @@ export function writeEdits(args: PopulateContentArgs) {
 
     const relations = yield* _(
       aggregateRelations({
-        triples: triplesWithCreatedBy,
+        opsByEditId,
         versions,
         edits,
         editType,
+        spaceIdByEditId,
       })
     );
 


### PR DESCRIPTION
Previously we were using deleted relations from all the edits in a block.

Right now there's some duplication between the logic we're using to calculate stale entity versions and the logic for aggregating new relations. We can merge this into the same code in a future PR.