### PR TITLE
feat: lift error handling to handleMessage caller

### DIFF
--- a/packages/substream/sink/errors.ts
+++ b/packages/substream/sink/errors.ts
@@ -1,23 +1,25 @@
+import { Data } from 'effect';
+
 import { getChecksumAddress } from './utils/get-checksum-address';
 
+export class CouldNotWriteSpacesError extends Data.TaggedError('CouldNotWriteSpacesError')<{
+  message: string;
+}> {}
+
 export class SpaceWithPluginAddressNotFoundError extends Error {
-  _tag: 'SpaceWithPluginAddressNotFoundError' = 'SpaceWithPluginAddressNotFoundError';
+  readonly _tag: 'SpaceWithPluginAddressNotFoundError' = 'SpaceWithPluginAddressNotFoundError';
 }
 
 export class ProposalWithOnchainProposalIdAndSpaceIdNotFoundError extends Error {
-  _tag: 'ProposalWithOnchainProposalIdAndSpaceIdNotFoundError' = 'ProposalWithOnchainProposalIdAndSpaceIdNotFoundError';
-}
-
-export class CouldNotWriteSpacesError extends Error {
-  _tag: 'CouldNotWriteSpacesError' = 'CouldNotWriteSpacesError';
+  _tag = 'ProposalWithOnchainProposalIdAndSpaceIdNotFoundError';
 }
 
 export class CouldNotWriteAccountsError extends Error {
-  _tag: 'CouldNotWriteAccountsError' = 'CouldNotWriteAccountsError';
+  _tag = 'CouldNotWriteAccountsError';
 }
 
 export class InvalidPluginAddressForDaoError extends Error {
-  _tag: 'InvalidPluginAddressForDaoError' = 'InvalidPluginAddressForDaoError';
+  _tag = 'InvalidPluginAddressForDaoError';
 }
 
 export function isInvalidPluginForDao(

--- a/packages/substream/sink/events/editor-added/map-editors.ts
+++ b/packages/substream/sink/events/editor-added/map-editors.ts
@@ -3,6 +3,7 @@ import type * as S from 'zapatos/schema';
 
 import type { EditorAdded } from './parser';
 import { Spaces } from '~/sink/db';
+import { InvalidPluginAddressForDaoError } from '~/sink/errors';
 import type { BlockEvent } from '~/sink/types';
 import { getChecksumAddress } from '~/sink/utils/get-checksum-address';
 
@@ -17,14 +18,20 @@ export function mapEditors(editorAdded: EditorAdded[], block: BlockEvent) {
       const maybeSpaceIdForVotingPlugin = yield* _(
         Effect.tryPromise({
           try: () => Spaces.findForVotingPlugin(editor.mainVotingPluginAddress),
-          catch: () => new Error(),
+          catch: () =>
+            new InvalidPluginAddressForDaoError(
+              `Could not find space for main voting plugin address ${editor.mainVotingPluginAddress}`
+            ),
         })
       );
 
       const maybeSpaceIdForPersonalPlugin = yield* _(
         Effect.tryPromise({
           try: () => Spaces.findForPersonalPlugin(editor.mainVotingPluginAddress),
-          catch: () => new Error(),
+          catch: () =>
+            new InvalidPluginAddressForDaoError(
+              `Could not find space for main voting plugin address ${editor.mainVotingPluginAddress}`
+            ),
         })
       );
 

--- a/packages/substream/sink/events/editor-removed/handler.ts
+++ b/packages/substream/sink/events/editor-removed/handler.ts
@@ -1,9 +1,8 @@
-import { Effect, Either } from 'effect';
+import { Effect } from 'effect';
 
 import { mapRemovedEditors } from './map-removed-editors';
 import type { EditorRemoved } from './parser';
 import { SpaceEditors } from '~/sink/db';
-import { Telemetry } from '~/sink/telemetry';
 
 export class CouldNotWriteRemovedEditorsError extends Error {
   _tag: 'CouldNotWriteRemovedEditorsError' = 'CouldNotWriteRemovedEditorsError';
@@ -11,12 +10,11 @@ export class CouldNotWriteRemovedEditorsError extends Error {
 
 export function handleEditorRemoved(editorsRemoved: EditorRemoved[]) {
   return Effect.gen(function* (_) {
-    const telemetry = yield* _(Telemetry);
     const schemaEditors = yield* _(mapRemovedEditors(editorsRemoved));
 
     yield* _(Effect.logInfo('Handling editor removed'));
 
-    const writtenRemovedEditors = yield* _(
+    yield* _(
       Effect.all(
         schemaEditors.map(m => {
           return Effect.tryPromise({
@@ -25,37 +23,10 @@ export function handleEditorRemoved(editorsRemoved: EditorRemoved[]) {
               return new CouldNotWriteRemovedEditorsError(String(error));
             },
           });
-        }),
-        {
-          mode: 'either',
-        }
+        })
       )
     );
 
-    let failedDeletions = 0;
-
-    for (const removedEditor of writtenRemovedEditors) {
-      if (Either.isLeft(removedEditor)) {
-        const error = removedEditor.left;
-        telemetry.captureException(error);
-
-        yield* _(
-          Effect.logError(`Could not remove editor
-        Cause: ${error.cause}
-        Message: ${error.message}
-      `)
-        );
-
-        failedDeletions++;
-
-        continue;
-      }
-    }
-
-    yield* _(
-      Effect.logInfo(
-        `${writtenRemovedEditors.length - failedDeletions} out of ${writtenRemovedEditors.length} editors removed`
-      )
-    );
+    yield* _(Effect.logInfo(`Editors removed`));
   });
 }

--- a/packages/substream/sink/events/editor-removed/map-removed-editors.ts
+++ b/packages/substream/sink/events/editor-removed/map-removed-editors.ts
@@ -16,7 +16,11 @@ export function mapRemovedEditors(editorsRemoved: EditorRemoved[]) {
       // @TODO(performance): We can query for this outside of the loop. Alternatively we
       // can use effect's structured concurrency to run every block of the loop concurrently.
       const maybeSpace = yield* _(
-        Effect.tryPromise({ try: () => Spaces.findForDaoAddress(editor.daoAddress), catch: () => new Error() })
+        Effect.tryPromise({
+          try: () => Spaces.findForDaoAddress(editor.daoAddress),
+          catch: () =>
+            new InvalidPluginAddressForDaoError(`Could not find find space with dao address of ${editor.daoAddress}`),
+        })
       );
 
       if (!maybeSpace) {

--- a/packages/substream/sink/events/edits-published/handler.ts
+++ b/packages/substream/sink/events/edits-published/handler.ts
@@ -15,6 +15,14 @@ export class ProposalDoesNotExistError extends Error {
   readonly _tag = 'ProposalDoesNotExistError';
 }
 
+export class CouldNotWriteMergedVersionsError extends Error {
+  readonly _tag = 'CouldNotWriteMergedVersionsError';
+}
+
+export class CouldNotWriteCurrentVersionsError extends Error {
+  readonly _tag = 'CouldNotWriteCurrentVersionsError';
+}
+
 /**
  * Handles when the EditsPublished event is emitted by a space contract. When this
  * event is emitted depends on the governance mechanism that a space has configured
@@ -106,7 +114,8 @@ export function handleEditsPublished(ipfsProposals: EditProposal[], createdSpace
       Effect.all([
         Effect.tryPromise({
           try: () => Versions.upsert(allMergedVersions),
-          catch: error => new Error(`Failed to insert merged versions. ${(error as Error).message}`),
+          catch: error =>
+            new CouldNotWriteMergedVersionsError(`Failed to insert merged versions. ${(error as Error).message}`),
         }),
         writeEdits({
           versions: defaultMergedVersions,
@@ -149,7 +158,8 @@ export function handleEditsPublished(ipfsProposals: EditProposal[], createdSpace
     yield* _(
       Effect.tryPromise({
         try: () => CurrentVersions.upsert(currentVersions),
-        catch: error => new Error(`Failed to insert current versions. ${(error as Error).message}`),
+        catch: error =>
+          new CouldNotWriteCurrentVersionsError(`Failed to insert current versions. ${(error as Error).message}`),
       })
     );
 

--- a/packages/substream/sink/events/member-added/handler.ts
+++ b/packages/substream/sink/events/member-added/handler.ts
@@ -1,10 +1,9 @@
-import { Effect, Either } from 'effect';
+import { Effect } from 'effect';
 
+import { writeAccounts } from '../write-accounts';
 import { mapMembers } from './map-members';
 import type { MemberAdded } from './parser';
-import { Accounts, SpaceMembers } from '~/sink/db';
-import { CouldNotWriteAccountsError } from '~/sink/errors';
-import { Telemetry } from '~/sink/telemetry';
+import { SpaceMembers } from '~/sink/db';
 import type { BlockEvent } from '~/sink/types';
 import { getChecksumAddress } from '~/sink/utils/get-checksum-address';
 import { retryEffect } from '~/sink/utils/retry-effect';
@@ -15,73 +14,34 @@ export class CouldNotWriteAddedMembersError extends Error {
 
 export function handleMemberAdded(membersAdded: MemberAdded[], block: BlockEvent) {
   return Effect.gen(function* (_) {
-    const telemetry = yield* _(Telemetry);
-
     yield* _(Effect.logInfo('Handling member added'));
-
     const schemaMembers = yield* _(mapMembers(membersAdded, block));
-
-    yield* _(Effect.logDebug('Writing accounts'));
 
     /**
      * Ensure that we create any relations for the role change before we create the
      * role change itself.
      */
-    const writtenAccounts = yield* _(
-      Effect.tryPromise({
-        try: async () => {
-          const accounts = schemaMembers.map(m => {
-            return {
-              id: getChecksumAddress(m.account_id as string),
-            };
-          });
-          await Accounts.upsert(accounts);
-        },
-        catch: error => new CouldNotWriteAccountsError(String(error)),
-      }),
-      Effect.either
+    yield* _(
+      writeAccounts(
+        schemaMembers.map(m => {
+          return {
+            id: getChecksumAddress(m.account_id as string),
+          };
+        })
+      )
     );
-
-    if (Either.isLeft(writtenAccounts)) {
-      const error = writtenAccounts.left;
-      telemetry.captureException(error);
-
-      yield* _(
-        Effect.logError(`Could not write accounts when writing added members
-        Cause: ${error.cause}
-        Message: ${error.message}
-      `)
-      );
-
-      return;
-    }
 
     yield* _(Effect.logDebug('Writing members'));
 
-    const writtenAddedMembers = yield* _(
+    yield* _(
       Effect.tryPromise({
         try: () => SpaceMembers.upsert(schemaMembers),
         catch: error => {
           return new CouldNotWriteAddedMembersError(String(error));
         },
       }),
-      retryEffect,
-      Effect.either
+      retryEffect
     );
-
-    if (Either.isLeft(writtenAddedMembers)) {
-      const error = writtenAddedMembers.left;
-      telemetry.captureException(error);
-
-      yield* _(
-        Effect.logError(`Could not write approved members
-        Cause: ${error.cause}
-        Message: ${error.message}
-      `)
-      );
-
-      return;
-    }
 
     yield* _(Effect.logInfo('Members added'));
   });

--- a/packages/substream/sink/events/spaces-created/handler.ts
+++ b/packages/substream/sink/events/spaces-created/handler.ts
@@ -1,10 +1,9 @@
-import { Effect, Either } from 'effect';
+import { Effect } from 'effect';
 
 import { mapGovernanceToSpaces, mapPersonalToSpaces, mapSpaces } from './map-spaces';
 import type { GovernancePluginsCreated, PersonalPluginsCreated, SpacePluginCreatedWithSpaceId } from './parser';
 import { Spaces } from '~/sink/db';
 import { CouldNotWriteSpacesError } from '~/sink/errors';
-import { Telemetry } from '~/sink/telemetry';
 import type { BlockEvent } from '~/sink/types';
 import { retryEffect } from '~/sink/utils/retry-effect';
 
@@ -16,11 +15,12 @@ export class CouldNotWritePersonalPlugins extends Error {
   _tag: 'CouldNotWritePersonalPlugins' = 'CouldNotWritePersonalPlugins';
 }
 
-export function handleSpacesCreated(spacesCreated: SpacePluginCreatedWithSpaceId[], block: BlockEvent) {
+export function handleSpacesCreated(
+  spacesCreated: SpacePluginCreatedWithSpaceId[],
+  block: BlockEvent
+): Effect.Effect<string[], CouldNotWriteSpacesError> {
   return Effect.gen(function* (_) {
-    const telemetry = yield* _(Telemetry);
     const spaces = mapSpaces(spacesCreated, block.blockNumber);
-
     yield* _(Effect.logInfo('Handling spaces created'));
 
     const writtenSpaces = yield* _(
@@ -28,36 +28,18 @@ export function handleSpacesCreated(spacesCreated: SpacePluginCreatedWithSpaceId
         try: async () => {
           return await Spaces.upsert(spaces);
         },
-        catch: error => {
-          return new CouldNotWriteSpacesError(String(error));
-        },
+        catch: error => new CouldNotWriteSpacesError({ message: String(error) }),
       }),
-      retryEffect,
-      Effect.either
+      retryEffect
     );
 
-    if (Either.isLeft(writtenSpaces)) {
-      const error = writtenSpaces.left;
-      telemetry.captureException(error);
-      yield* _(
-        Effect.logError(`Could not write spaces
-        Cause: ${error.cause}
-        Message: ${error.message}
-      `)
-      );
-
-      return null;
-    }
-
     yield* _(Effect.logInfo('Spaces created'));
-    return writtenSpaces.right.map(s => s.id);
+    return writtenSpaces.map(s => s.id);
   });
 }
 
 export function handlePersonalSpacesCreated(personalPluginsCreated: PersonalPluginsCreated[], block: BlockEvent) {
   return Effect.gen(function* (_) {
-    const telemetry = yield* _(Telemetry);
-
     yield* _(Effect.logInfo('Handling personal space plugins created'));
     yield* _(Effect.logDebug('Collecting spaces for personal plugins'));
 
@@ -68,7 +50,11 @@ export function handlePersonalSpacesCreated(personalPluginsCreated: PersonalPlug
             const maybeSpace = yield* _(Effect.promise(() => Spaces.findForDaoAddress(p.daoAddress)));
 
             if (maybeSpace === null) {
-              yield* _(Effect.fail(new Error()));
+              yield* _(
+                Effect.fail(
+                  new CouldNotWritePersonalPlugins(`Could not find space for personal plugin ${p.personalAdminAddress}`)
+                )
+              );
               return null;
             }
 
@@ -90,38 +76,22 @@ export function handlePersonalSpacesCreated(personalPluginsCreated: PersonalPlug
     const writtenGovernancePlugins = yield* _(
       Effect.tryPromise({
         try: async () => {
-          await Spaces.upsert(spaces);
+          return await Spaces.upsert(spaces);
         },
         catch: error => {
           return new CouldNotWritePersonalPlugins(String(error));
         },
       }),
-      retryEffect,
-      Effect.either
+      retryEffect
     );
 
-    if (Either.isLeft(writtenGovernancePlugins)) {
-      const error = writtenGovernancePlugins.left;
-      telemetry.captureException(error);
-
-      yield* _(
-        Effect.logError(`Could not write personal plugins for spaces
-        Cause: ${error.cause}
-        Message: ${error.message}
-      `)
-      );
-
-      return;
-    }
-
     yield* _(Effect.logInfo('Personal space plugins created'));
+    return writtenGovernancePlugins.map(p => p.id);
   });
 }
 
 export function handleGovernancePluginCreated(governancePluginsCreated: GovernancePluginsCreated[], block: BlockEvent) {
   return Effect.gen(function* (_) {
-    const telemetry = yield* _(Telemetry);
-
     yield* _(Effect.logInfo('Handling public space plugins created'));
     yield* _(Effect.logDebug('Collecting spaces for public plugins'));
 
@@ -132,7 +102,11 @@ export function handleGovernancePluginCreated(governancePluginsCreated: Governan
             const maybeSpace = yield* _(Effect.promise(() => Spaces.findForDaoAddress(g.daoAddress)));
 
             if (maybeSpace === null) {
-              yield* _(Effect.fail(new Error()));
+              yield* _(
+                Effect.fail(
+                  new CouldNotWriteGovernancePlugins(`Could not find find space for daoAddress ${g.daoAddress}`)
+                )
+              );
               return null;
             }
 
@@ -154,7 +128,7 @@ export function handleGovernancePluginCreated(governancePluginsCreated: Governan
     // @TODO:
     // - Should error each plugin independently
     // - We need to know the actual space address
-    const writtenGovernancePlugins = yield* _(
+    yield* _(
       Effect.tryPromise({
         try: async () => {
           await Spaces.upsert(spaces);
@@ -163,23 +137,8 @@ export function handleGovernancePluginCreated(governancePluginsCreated: Governan
           return new CouldNotWriteGovernancePlugins(String(error));
         },
       }),
-      retryEffect,
-      Effect.either
+      retryEffect
     );
-
-    if (Either.isLeft(writtenGovernancePlugins)) {
-      const error = writtenGovernancePlugins.left;
-      telemetry.captureException(error);
-
-      yield* _(
-        Effect.logError(`Could not write governance plugins for spaces
-          Cause: ${error.cause}
-          Message: ${error.message}
-        `)
-      );
-
-      return;
-    }
 
     yield* _(Effect.logInfo('Public space plugins created'));
   });

--- a/packages/substream/sink/events/subspaces-added/map-subspaces.ts
+++ b/packages/substream/sink/events/subspaces-added/map-subspaces.ts
@@ -5,7 +5,6 @@ import type { SubspaceAdded } from './parser';
 import { Spaces } from '~/sink/db';
 import { SpaceWithPluginAddressNotFoundError } from '~/sink/errors';
 import { getChecksumAddress } from '~/sink/utils/get-checksum-address';
-import { pool } from '~/sink/utils/pool';
 
 export function mapSubspaces({
   subspacesAdded,

--- a/packages/substream/sink/events/votes-cast/handler.ts
+++ b/packages/substream/sink/events/votes-cast/handler.ts
@@ -1,9 +1,8 @@
-import { Effect, Either } from 'effect';
+import { Effect } from 'effect';
 
 import { mapVotes } from './map-votes';
 import type { VoteCast } from './parser';
 import { ProposalVotes } from '~/sink/db/proposal-votes';
-import { Telemetry } from '~/sink/telemetry';
 import type { BlockEvent } from '~/sink/types';
 import { retryEffect } from '~/sink/utils/retry-effect';
 
@@ -13,14 +12,13 @@ class CouldNotWriteVotesError extends Error {
 
 export function handleVotesCast(votesCast: VoteCast[], block: BlockEvent) {
   return Effect.gen(function* (_) {
-    const telemetry = yield* _(Telemetry);
     yield* _(Effect.logInfo('Handling votes cast'));
 
     const schemaVotes = yield* _(mapVotes(votesCast, block));
 
     yield* _(Effect.logDebug('Writing votes'));
 
-    const writtenVotes = yield* _(
+    yield* _(
       Effect.tryPromise({
         try: async () => {
           await ProposalVotes.insert(schemaVotes);
@@ -29,22 +27,8 @@ export function handleVotesCast(votesCast: VoteCast[], block: BlockEvent) {
           return new CouldNotWriteVotesError(String(error));
         },
       }),
-      retryEffect,
-      Effect.either
+      retryEffect
     );
-
-    if (Either.isLeft(writtenVotes)) {
-      const error = writtenVotes.left;
-      telemetry.captureException(error);
-      yield* _(
-        Effect.logError(`Could not write votes
-        Cause: ${error.cause}
-        Message: ${error.message}
-      `)
-      );
-
-      return;
-    }
 
     yield* _(Effect.logInfo('Votes cast'));
   });

--- a/packages/substream/sink/events/write-accounts.ts
+++ b/packages/substream/sink/events/write-accounts.ts
@@ -1,0 +1,24 @@
+import { Effect } from 'effect';
+import type * as S from 'zapatos/schema';
+
+import { Accounts } from '../db';
+import { CouldNotWriteAccountsError } from '../errors';
+import { retryEffect } from '../utils/retry-effect';
+
+export const writeAccounts = (accounts: S.accounts.Insertable[]) =>
+  Effect.gen(function* (_) {
+    yield* _(Effect.logDebug('Writing accounts'));
+
+    const result = yield* _(
+      Effect.tryPromise({
+        try: async () => {
+          return await Accounts.upsert(accounts);
+        },
+        catch: error => new CouldNotWriteAccountsError(String(error)),
+      }),
+      retryEffect
+    );
+
+    yield* _(Effect.logDebug(`Succesfully wrote accounts ${accounts.map(a => a.id).join(', ')}`));
+    return result;
+  });

--- a/packages/substream/sink/run-stream.ts
+++ b/packages/substream/sink/run-stream.ts
@@ -146,7 +146,9 @@ export function runStream({ startBlockNumber, shouldUseCursor }: StreamConfig) {
         return Effect.gen(function* (_) {
           const requestId = createGeoId();
           const logLevel = yield* _(getConfiguredLogLevel);
-          yield* _(handleEvent(message, registry).pipe(withRequestId(requestId), Logger.withMinimumLogLevel(logLevel)));
+          yield* _(
+            handleMessage(message, registry).pipe(withRequestId(requestId), Logger.withMinimumLogLevel(logLevel))
+          );
         });
       },
 
@@ -179,7 +181,7 @@ export function runStream({ startBlockNumber, shouldUseCursor }: StreamConfig) {
   });
 }
 
-function handleEvent(message: BlockScopedData, registry: IMessageTypeRegistry) {
+function handleMessage(message: BlockScopedData, registry: IMessageTypeRegistry) {
   return Effect.gen(function* (_) {
     const telemetry = yield* _(Telemetry);
 

--- a/packages/substream/sink/run-stream.ts
+++ b/packages/substream/sink/run-stream.ts
@@ -5,7 +5,7 @@ import { NETWORK_IDS } from '@geogenesis/sdk/src/system-ids';
 import { authIssue, createAuthInterceptor, createRegistry } from '@substreams/core';
 import type { BlockScopedData } from '@substreams/core/proto';
 import { readPackageFromFile } from '@substreams/manifest';
-import { Data, Duration, Effect, Logger, Secret, Stream } from 'effect';
+import { Data, Duration, Effect, Either, Logger, Secret, Stream } from 'effect';
 
 import { MANIFEST } from './constants/constants';
 import { readCursor, writeCursor } from './cursor';
@@ -55,7 +55,7 @@ import { ZodSubspacesRemovedStreamResponse } from './events/subspaces-removed/pa
 import { handleVotesCast } from './events/votes-cast/handler';
 import { ZodVotesCastStreamResponse } from './events/votes-cast/parser';
 import { getConfiguredLogLevel, withRequestId } from './logs';
-import { Telemetry } from './telemetry';
+import { Telemetry, TelemetryLive } from './telemetry';
 import { createSink, createStream } from './vendor/sink/src';
 
 export class InvalidPackageError extends Error {
@@ -144,12 +144,33 @@ export function runStream({ startBlockNumber, shouldUseCursor }: StreamConfig) {
     const sink = createSink({
       handleBlockScopedData: message => {
         return Effect.gen(function* (_) {
+          const blockNumber = Number(message.clock?.number.toString());
+
           const requestId = createGeoId();
+          const telemetry = yield* _(Telemetry);
           const logLevel = yield* _(getConfiguredLogLevel);
-          yield* _(
-            handleMessage(message, registry).pipe(withRequestId(requestId), Logger.withMinimumLogLevel(logLevel))
+
+          // If we get an unrecoverable error (how do we define those)
+          // then we don't want to exit the entire handler though, and
+          // continue if possible.
+          const result = yield* _(
+            handleMessage(message, registry).pipe(withRequestId(requestId), Logger.withMinimumLogLevel(logLevel)),
+            Effect.either
           );
-        });
+
+          if (Either.isLeft(result)) {
+            const error = result.left;
+            telemetry.captureMessage(error.message);
+            yield* _(Effect.logError(error.message));
+            return;
+          }
+
+          const hasValidEvent = result.right;
+
+          if (hasValidEvent) {
+            yield* _(Effect.logInfo(`Finished processing block ${blockNumber}`));
+          }
+        }).pipe(Effect.provideService(Telemetry, TelemetryLive));
       },
 
       handleBlockUndoSignal: message => {
@@ -379,6 +400,20 @@ function handleMessage(message: BlockScopedData, registry: IMessageTypeRegistry)
       );
     }
 
+    /**
+     * Public plugins get their own event when adding initial edits whereas the personal spaces
+     * emit the initial editors as part of the space creation event.
+     */
+    if (initialEditorsAddedResponse.success) {
+      yield* _(
+        handleInitialGovernanceSpaceEditorsAdded(initialEditorsAddedResponse.data.initialEditorsAdded, {
+          blockNumber,
+          cursor,
+          timestamp,
+        })
+      );
+    }
+
     if (subspacesAdded.success) {
       yield* _(
         handleSubspacesAdded(subspacesAdded.data.subspacesAdded, {
@@ -390,23 +425,7 @@ function handleMessage(message: BlockScopedData, registry: IMessageTypeRegistry)
     }
 
     if (subspacesRemoved.success) {
-      yield* _(
-        handleSubspacesRemoved(subspacesRemoved.data.subspacesRemoved, {
-          blockNumber,
-          cursor,
-          timestamp,
-        })
-      );
-    }
-
-    if (initialEditorsAddedResponse.success) {
-      yield* _(
-        handleInitialGovernanceSpaceEditorsAdded(initialEditorsAddedResponse.data.initialEditorsAdded, {
-          blockNumber,
-          cursor,
-          timestamp,
-        })
-      );
+      yield* _(handleSubspacesRemoved(subspacesRemoved.data.subspacesRemoved));
     }
 
     if (proposalCreatedResponse.success) {
@@ -571,5 +590,7 @@ function handleMessage(message: BlockScopedData, registry: IMessageTypeRegistry)
     if (executedProposals.success) {
       yield* _(handleProposalsExecuted(executedProposals.data.executedProposals));
     }
+
+    return hasValidEvent;
   });
 }

--- a/packages/substream/sink/utils/retry-effect.ts
+++ b/packages/substream/sink/utils/retry-effect.ts
@@ -1,6 +1,6 @@
 import { Duration, Effect, Schedule } from 'effect';
 
-export function retryEffect<T>(effect: Effect.Effect<T, Error>) {
+export function retryEffect<V, E>(effect: Effect.Effect<V, E>) {
   return Effect.retry(
     effect,
     Schedule.exponential(100).pipe(

--- a/packages/substream/sink/write-edits/write-triples.ts
+++ b/packages/substream/sink/write-edits/write-triples.ts
@@ -3,6 +3,10 @@ import { Effect } from 'effect';
 import { type OpWithCreatedBy } from './map-triples';
 import { Triples } from '~/sink/db';
 
+class CouldNotWriteTriplesError extends Error {
+  readonly _tag = 'CouldNotWriteTriplesError';
+}
+
 interface PopulateTriplesArgs {
   schemaTriples: OpWithCreatedBy[];
 }
@@ -20,7 +24,7 @@ export function writeTriples({ schemaTriples }: PopulateTriplesArgs) {
             schemaTriples.filter(t => t.op === 'SET_TRIPLE').map(op => op.triple),
             { chunked: true }
           ),
-        catch: error => new Error(`Failed to insert bulk triples. ${(error as Error).message}`),
+        catch: error => new CouldNotWriteTriplesError(`Failed to insert bulk triples. ${(error as Error).message}`),
       })
     );
   });


### PR DESCRIPTION
Most of the errors in the substream fall into a couple categories and can mostly be handled the same way
1. A space doesn't exist for a given plugin/dao address
2. Inserting into the db fails for some reason

We now bubble these errors to the caller so we can handle the same category of errors in a single place instead of ad-hoc throughout the codebase.

Next we'll need to handle gracefully failing in places where that's okay.