### PR TITLE
fix: image uploads during space creation

### DIFF
--- a/apps/web/core/hooks/use-deploy-space.ts
+++ b/apps/web/core/hooks/use-deploy-space.ts
@@ -12,7 +12,7 @@ type DeployArgs =
   | {
       type: 'personal' | 'company';
       spaceName: string;
-      spaceAvatarUri?: string;
+      spaceImage?: string;
       governanceType?: SpaceGovernanceType;
     }
   | {
@@ -27,7 +27,7 @@ type DeployArgs =
         | 'government-org'
         | 'interest-group';
       spaceName: string;
-      spaceCoverUri?: string;
+      spaceImage?: string;
       governanceType?: SpaceGovernanceType;
     };
 
@@ -54,8 +54,8 @@ export function useDeploySpace() {
       );
 
       if (args.type === 'personal' || args.type === 'company') {
-        if (args.spaceAvatarUri && args.spaceAvatarUri !== '') {
-          url.searchParams.set('spaceAvatarUri', args.spaceAvatarUri);
+        if (args.spaceImage && args.spaceImage !== '') {
+          url.searchParams.set('spaceAvatarUri', args.spaceImage);
         }
       } else if (
         args.type === 'default' ||
@@ -68,8 +68,8 @@ export function useDeploySpace() {
         args.type === 'government-org' ||
         args.type === 'interest-group'
       ) {
-        if (args.spaceCoverUri && args.spaceCoverUri !== '') {
-          url.searchParams.set('spaceCoverUri', args.spaceCoverUri);
+        if (args.spaceImage && args.spaceImage !== '') {
+          url.searchParams.set('spaceCoverUri', args.spaceImage);
         }
       }
 

--- a/apps/web/core/hooks/use-deploy-space.ts
+++ b/apps/web/core/hooks/use-deploy-space.ts
@@ -8,28 +8,23 @@ import { SpaceGovernanceType } from '../types';
 
 // Governance type is only manually set if the space is a "Blank"/default space.
 // Otherwise we manually set the governance type depending on the space type.
-type DeployArgs =
-  | {
-      type: 'personal' | 'company';
-      spaceName: string;
-      spaceImage?: string;
-      governanceType?: SpaceGovernanceType;
-    }
-  | {
-      type:
-        | 'default'
-        | 'nonprofit'
-        | 'academic-field'
-        | 'region'
-        | 'industry'
-        | 'protocol'
-        | 'dao'
-        | 'government-org'
-        | 'interest-group';
-      spaceName: string;
-      spaceImage?: string;
-      governanceType?: SpaceGovernanceType;
-    };
+type DeployArgs = {
+  type:
+    | 'personal'
+    | 'company'
+    | 'default'
+    | 'nonprofit'
+    | 'academic-field'
+    | 'region'
+    | 'industry'
+    | 'protocol'
+    | 'dao'
+    | 'government-org'
+    | 'interest-group';
+  spaceName: string;
+  spaceImage?: string;
+  governanceType?: SpaceGovernanceType;
+};
 
 export function useDeploySpace() {
   const smartAccount = useSmartAccount();

--- a/apps/web/core/io/dto/entities.ts
+++ b/apps/web/core/io/dto/entities.ts
@@ -46,12 +46,6 @@ export function EntityDto(substreamEntity: SubstreamEntity): Entity {
 
       const renderableType = getRenderableEntityType(toEntityTypes);
 
-      // @TODO(relations): Until we fix the migrations we'll manually check for cover and avatar
-      // relations and set the renderable typ to image.
-      const isCoverOrAvatar =
-        t.typeOf.entityId === EntityId(SYSTEM_IDS.COVER_ATTRIBUTE) ||
-        t.typeOf.entityId === EntityId(SYSTEM_IDS.AVATAR_ATTRIBUTE);
-
       return {
         id: t.entityId,
         index: t.index,
@@ -70,9 +64,9 @@ export function EntityDto(substreamEntity: SubstreamEntity): Entity {
           // The "Renderable Type" for an entity provides a hint to the consumer
           // of the entity to _what_ the entity is so they know how they should
           // render it depending on their use case.
-          renderableType: isCoverOrAvatar ? 'IMAGE' : renderableType,
+          renderableType,
           // Right now we only support images and entity ids as the value of the To entity.
-          value: isCoverOrAvatar || renderableType === 'IMAGE' ? imageEntityUrlValue ?? '' : t.toVersion.entityId,
+          value: renderableType === 'IMAGE' ? imageEntityUrlValue ?? '' : t.toVersion.entityId,
         },
       };
     }),

--- a/apps/web/core/utils/contracts/generate-ops-for-space-type.ts
+++ b/apps/web/core/utils/contracts/generate-ops-for-space-type.ts
@@ -67,29 +67,30 @@ export const generateOpsForSpaceType = async ({ type, spaceName, spaceAvatarUri,
 
     // Creates the image entity
     ops.push(...imageOps);
+    const imageEntityId = imageOps.find(o => o.triple.attribute === SYSTEM_IDS.IMAGE_URL_ATTRIBUTE)!.triple.entity;
 
     // Creates the relation pointing to the image entity
     ops.push(
       ...Relation.make({
         fromId: newEntityId,
-        toId: imageOps[0].triple.entity, // Set the avatar relation to point to the entity id of the new entity
+        toId: imageEntityId, // Set the avatar relation to point to the entity id of the new entity
         relationTypeId: SYSTEM_IDS.AVATAR_ATTRIBUTE,
       })
     );
   }
 
   if (spaceCoverUri) {
-    const [typeOp, srcOp] = Image.make(spaceCoverUri);
+    const imageOps = Image.make(spaceCoverUri);
 
     // Creates the image entity
-    ops.push(typeOp);
-    ops.push(srcOp);
+    ops.push(...imageOps);
+    const imageEntityId = imageOps.find(o => o.triple.attribute === SYSTEM_IDS.IMAGE_URL_ATTRIBUTE)!.triple.entity;
 
     // Creates the relation pointing to the image entity
     ops.push(
       ...Relation.make({
         fromId: newEntityId,
-        toId: typeOp.triple.entity, // Set the avatar relation to point to the entity id of the new entity
+        toId: imageEntityId, // Set the avatar relation to point to the entity id of the new entity
         relationTypeId: SYSTEM_IDS.COVER_ATTRIBUTE,
       })
     );

--- a/apps/web/core/utils/contracts/generate-ops-for-space-type.ts
+++ b/apps/web/core/utils/contracts/generate-ops-for-space-type.ts
@@ -63,34 +63,32 @@ export const generateOpsForSpaceType = async ({ type, spaceName, spaceAvatarUri,
   }
 
   if (spaceAvatarUri) {
-    const imageOps = Image.make(spaceAvatarUri);
+    const { imageId, ops } = Image.make(spaceAvatarUri);
 
     // Creates the image entity
-    ops.push(...imageOps);
-    const imageEntityId = imageOps.find(o => o.triple.attribute === SYSTEM_IDS.IMAGE_URL_ATTRIBUTE)!.triple.entity;
+    ops.push(...ops);
 
     // Creates the relation pointing to the image entity
     ops.push(
       ...Relation.make({
         fromId: newEntityId,
-        toId: imageEntityId, // Set the avatar relation to point to the entity id of the new entity
+        toId: imageId, // Set the avatar relation to point to the entity id of the new entity
         relationTypeId: SYSTEM_IDS.AVATAR_ATTRIBUTE,
       })
     );
   }
 
   if (spaceCoverUri) {
-    const imageOps = Image.make(spaceCoverUri);
+    const { imageId, ops } = Image.make(spaceCoverUri);
 
     // Creates the image entity
-    ops.push(...imageOps);
-    const imageEntityId = imageOps.find(o => o.triple.attribute === SYSTEM_IDS.IMAGE_URL_ATTRIBUTE)!.triple.entity;
+    ops.push(...ops);
 
     // Creates the relation pointing to the image entity
     ops.push(
       ...Relation.make({
         fromId: newEntityId,
-        toId: imageEntityId, // Set the avatar relation to point to the entity id of the new entity
+        toId: imageId, // Set the avatar relation to point to the entity id of the new entity
         relationTypeId: SYSTEM_IDS.COVER_ATTRIBUTE,
       })
     );

--- a/apps/web/core/utils/contracts/generate-ops-for-space-type.ts
+++ b/apps/web/core/utils/contracts/generate-ops-for-space-type.ts
@@ -35,16 +35,6 @@ export const generateOpsForSpaceType = async ({ type, spaceName, spaceAvatarUri,
 
   // Add space type-specific ops
   switch (type) {
-    case 'default': {
-      ops.push(
-        ...Relation.make({
-          fromId: newEntityId,
-          toId: SYSTEM_IDS.SPACE_CONFIGURATION,
-          relationTypeId: SYSTEM_IDS.TYPES,
-        })
-      );
-      break;
-    }
     case 'personal': {
       const personOps = await generateOpsForPerson(newEntityId, spaceName);
       ops.push(...personOps);
@@ -60,13 +50,23 @@ export const generateOpsForSpaceType = async ({ type, spaceName, spaceAvatarUri,
       ops.push(...nonprofitOps);
       break;
     }
+    default: {
+      ops.push(
+        ...Relation.make({
+          fromId: newEntityId,
+          toId: SYSTEM_IDS.SPACE_CONFIGURATION,
+          relationTypeId: SYSTEM_IDS.TYPES,
+        })
+      );
+      break;
+    }
   }
 
   if (spaceAvatarUri) {
-    const { imageId, ops } = Image.make(spaceAvatarUri);
+    const { imageId, ops: imageOps } = Image.make(spaceAvatarUri);
 
     // Creates the image entity
-    ops.push(...ops);
+    ops.push(...imageOps);
 
     // Creates the relation pointing to the image entity
     ops.push(
@@ -79,10 +79,10 @@ export const generateOpsForSpaceType = async ({ type, spaceName, spaceAvatarUri,
   }
 
   if (spaceCoverUri) {
-    const { imageId, ops } = Image.make(spaceCoverUri);
+    const { imageId, ops: imageOps } = Image.make(spaceCoverUri);
 
     // Creates the image entity
-    ops.push(...ops);
+    ops.push(...imageOps);
 
     // Creates the relation pointing to the image entity
     ops.push(

--- a/apps/web/partials/create-space/create-space-dialog.tsx
+++ b/apps/web/partials/create-space/create-space-dialog.tsx
@@ -32,8 +32,7 @@ import { Animation } from '~/partials/onboarding/dialog';
 const spaceTypeAtom = atom<SpaceType | null>(null);
 const governanceTypeAtom = atom<SpaceGovernanceType | null>(null);
 const nameAtom = atom<string>('');
-const avatarAtom = atom<string>('');
-const coverAtom = atom<string>('');
+const imageAtom = atom<string>('');
 const spaceIdAtom = atom<string>('');
 
 type Step = 'select-type' | 'select-governance' | 'enter-profile' | 'create-space' | 'completed';
@@ -50,7 +49,7 @@ export function CreateSpaceDialog() {
 
   const spaceType = useAtomValue(spaceTypeAtom);
   const [name, setName] = useAtom(nameAtom);
-  const [cover, setCover] = useAtom(coverAtom);
+  const [image, setImage] = useAtom(imageAtom);
   const setSpaceId = useSetAtom(spaceIdAtom);
   const [governanceType, setGovernanceType] = useAtom(governanceTypeAtom);
   const [step, setStep] = useAtom(stepAtom);
@@ -67,8 +66,7 @@ export function CreateSpaceDialog() {
       const spaceId = await deploy({
         type: spaceType,
         spaceName: name,
-        spaceAvatarUri: '',
-        spaceCoverUri: cover,
+        spaceImage: image,
         governanceType: governanceType ?? undefined,
       });
 
@@ -106,7 +104,7 @@ export function CreateSpaceDialog() {
       <Dialog.Trigger
         onClick={() => {
           setName('');
-          setCover('');
+          setImage('');
           setGovernanceType(null);
           setStep('select-type');
         }}
@@ -379,8 +377,7 @@ function StepEnterProfile({ onNext }: StepEnterProfileProps) {
   const [name, setName] = useAtom(nameAtom);
   const spaceType = useAtomValue(spaceTypeAtom);
   const isCompany = spaceType === 'company';
-  const [avatar, setAvatar] = useAtom(avatarAtom);
-  const [cover, setCover] = useAtom(coverAtom);
+  const [image, setImage] = useAtom(imageAtom);
 
   const validName = name.length > 0;
 
@@ -397,11 +394,7 @@ function StepEnterProfile({ onNext }: StepEnterProfileProps) {
       const file = e.target.files[0];
       const ipfsUri = await ipfs.uploadFile(file);
       const imageValue = Values.toImageValue(ipfsUri);
-      if (isCompany) {
-        setAvatar(imageValue);
-      } else {
-        setCover(imageValue);
-      }
+      setImage(imageValue);
     }
   };
 
@@ -417,11 +410,11 @@ function StepEnterProfile({ onNext }: StepEnterProfileProps) {
             <div className="group relative overflow-hidden rounded-lg shadow-lg">
               {isCompany ? (
                 <>
-                  {avatar ? (
+                  {image ? (
                     <>
                       <div
                         style={{
-                          backgroundImage: `url(${getImagePath(avatar)})`,
+                          backgroundImage: `url(${getImagePath(image)})`,
                           height: 152,
                           width: 152,
                           backgroundSize: 'cover',
@@ -429,7 +422,7 @@ function StepEnterProfile({ onNext }: StepEnterProfileProps) {
                         }}
                       />
                       <div className="absolute right-0 top-0 p-1.5 opacity-0 transition-opacity duration-200 ease-in-out group-hover:opacity-100">
-                        <SquareButton disabled={avatar === ''} onClick={() => setAvatar('')} icon={<Trash />} />
+                        <SquareButton disabled={image === ''} onClick={() => setImage('')} icon={<Trash />} />
                       </div>
                     </>
                   ) : (
@@ -438,11 +431,11 @@ function StepEnterProfile({ onNext }: StepEnterProfileProps) {
                 </>
               ) : (
                 <>
-                  {cover ? (
+                  {image ? (
                     <>
                       <div
                         style={{
-                          backgroundImage: `url(${getImagePath(cover)})`,
+                          backgroundImage: `url(${getImagePath(image)})`,
                           height: 100,
                           width: 250,
                           backgroundSize: 'cover',
@@ -450,7 +443,7 @@ function StepEnterProfile({ onNext }: StepEnterProfileProps) {
                         }}
                       />
                       <div className="absolute right-0 top-0 p-1.5 opacity-0 transition-opacity duration-200 ease-in-out group-hover:opacity-100">
-                        <SquareButton disabled={cover === ''} onClick={() => setCover('')} icon={<Trash />} />
+                        <SquareButton disabled={image === ''} onClick={() => setImage('')} icon={<Trash />} />
                       </div>
                     </>
                   ) : (

--- a/apps/web/partials/onboarding/dialog.tsx
+++ b/apps/web/partials/onboarding/dialog.tsx
@@ -65,7 +65,7 @@ export const OnboardingDialog = () => {
 
     try {
       const spaceId = await deploy({
-        spaceAvatarUri: avatar,
+        spaceImage: avatar,
         spaceName: name,
         type: 'personal',
       });

--- a/packages/sdk/src/core/image.ts
+++ b/packages/sdk/src/core/image.ts
@@ -1,32 +1,40 @@
 import { createGeoId } from '../id';
 import { Relation } from '../relation';
 import { SYSTEM_IDS } from '../system-ids';
-import type { Op } from '../types';
+import type { SetTripleOp } from '../types';
+
+type MakeImageReturnType = {
+  imageId: string;
+  ops: SetTripleOp[];
+};
 
 /**
  * Creates an entity representing an Image.
  *
  * @returns ops: The SET_TRIPLE ops for an Image entity
  */
-export function make(src: string): Op[] {
+export function make(src: string): MakeImageReturnType {
   const entityId = createGeoId();
 
-  return [
-    ...Relation.make({
-      fromId: entityId,
-      toId: SYSTEM_IDS.IMAGE,
-      relationTypeId: SYSTEM_IDS.TYPES,
-    }),
-    {
-      type: 'SET_TRIPLE',
-      triple: {
-        entity: entityId,
-        attribute: SYSTEM_IDS.IMAGE_URL_ATTRIBUTE,
-        value: {
-          type: 'URL',
-          value: src,
+  return {
+    imageId: entityId,
+    ops: [
+      ...Relation.make({
+        fromId: entityId,
+        toId: SYSTEM_IDS.IMAGE,
+        relationTypeId: SYSTEM_IDS.TYPES,
+      }),
+      {
+        type: 'SET_TRIPLE',
+        triple: {
+          entity: entityId,
+          attribute: SYSTEM_IDS.IMAGE_URL_ATTRIBUTE,
+          value: {
+            type: 'URL',
+            value: src,
+          },
         },
       },
-    },
-  ];
+    ],
+  };
 }


### PR DESCRIPTION
We were previously using the incorrect entity id when setting the relation for an avatar or cover when creating spaces. We now return the image id from `Image.make` so consumers have easy access to the underlying image entity that was created.

Additionally, we weren't correctly handling the setting the image string for ad-hoc creation of spaces, specifically for company spaces. We now have a unified `image` state instead of an `avatar` and `cover` state.

Lastly, this fixes a bug where we weren't setting the space configuration on spaces that weren't `company`, `personal`, or `nonprofit` spaces.