### PR TITLE
feat(substream): saturate i/o by allowing unblocked async work to execute

### DIFF
--- a/apps/web/core/constants.ts
+++ b/apps/web/core/constants.ts
@@ -1,3 +1,5 @@
+import { SYSTEM_IDS } from '@geogenesis/sdk';
+
 export const ZERO_WIDTH_SPACE = '\u200b';
 
 export const PLACEHOLDER_IMAGES = {
@@ -23,7 +25,7 @@ export const IPFS_GATEWAY_READ_PATH = `https://gateway.lighthouse.storage/ipfs/`
 
 export const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
 export const PUBLIC_SPACES = [
-  'ab7d4b9e02f840dab9746d352acb0ac6', // root
+  SYSTEM_IDS.ROOT_SPACE_ID, // root
   // '0xc46618C200f02EF1EEA28923FC3828301e63C4Bd', // San Francisco
   // '0xe3d08763498e3247EC00A481F199B018f2148723', // Health
   // '0xB4B3d95e9c82cb26A5bd4BC73ffBa46F1e979f16', // Philosophy

--- a/apps/web/core/io/schema.ts
+++ b/apps/web/core/io/schema.ts
@@ -178,7 +178,7 @@ const SubstreamRelation = Schema.Struct({
     name: Schema.NullOr(Schema.String),
     versionTypes: SubstreamVersionTypes,
 
-    // Currently our relation query only returns triples where the value type is URI
+    // Currently our relation query only returns triples where the value type is URL
     triples: Schema.Struct({
       nodes: Schema.Array(SubstreamTriple),
     }),

--- a/apps/web/core/utils/change/change.ts
+++ b/apps/web/core/utils/change/change.ts
@@ -37,18 +37,26 @@ export async function fromLocal(spaceId?: string) {
   const entityIdsToFetch = [...entityIds.values()];
 
   const collectEntities = Effect.gen(function* () {
-    const maybeRemoteEntitiesEffect = Effect.all(
-      entityIdsToFetch.map(id => Effect.promise(() => getEntityAsync(EntityId(id))))
+    const maybeRemoteEntitiesEffect = Effect.forEach(
+      entityIdsToFetch,
+      id => Effect.promise(() => getEntityAsync(EntityId(id))),
+      {
+        concurrency: 50,
+      }
     );
 
-    const maybeLocalEntitiesEffect = Effect.all(
-      entityIdsToFetch.map(id => Effect.promise(() => mergeEntityAsync(EntityId(id))))
+    const maybeLocalEntitiesEffect = Effect.forEach(
+      entityIdsToFetch,
+      id => Effect.promise(() => mergeEntityAsync(EntityId(id))),
+      {
+        concurrency: 50,
+      }
     );
 
-    const [maybeRemoteEntities, maybeLocalEntities] = yield* Effect.all([
-      maybeRemoteEntitiesEffect,
-      maybeLocalEntitiesEffect,
-    ]);
+    const [maybeRemoteEntities, maybeLocalEntities] = yield* Effect.all(
+      [maybeRemoteEntitiesEffect, maybeLocalEntitiesEffect],
+      { concurrency: 2 }
+    );
 
     const remoteEntities = maybeRemoteEntities.filter(e => e !== null);
     const localEntities = maybeLocalEntities.filter(e => e !== null);

--- a/packages/substream/sink/events/editor-added/map-editors.ts
+++ b/packages/substream/sink/events/editor-added/map-editors.ts
@@ -14,25 +14,24 @@ export function mapEditors(editorAdded: EditorAdded[], block: BlockEvent) {
     yield* _(Effect.logDebug('Mapping editors'));
 
     for (const editor of editorAdded) {
-      // @TODO: effect.all
-      const maybeSpaceIdForVotingPlugin = yield* _(
-        Effect.tryPromise({
-          try: () => Spaces.findForVotingPlugin(editor.mainVotingPluginAddress),
-          catch: () =>
-            new InvalidPluginAddressForDaoError(
-              `Could not find space for main voting plugin address ${editor.mainVotingPluginAddress}`
-            ),
-        })
-      );
+      const maybeSpaceIdForVotingPluginEffect = Effect.tryPromise({
+        try: () => Spaces.findForVotingPlugin(editor.mainVotingPluginAddress),
+        catch: () =>
+          new InvalidPluginAddressForDaoError(
+            `Could not find space for main voting plugin address ${editor.mainVotingPluginAddress}`
+          ),
+      });
 
-      const maybeSpaceIdForPersonalPlugin = yield* _(
-        Effect.tryPromise({
-          try: () => Spaces.findForPersonalPlugin(editor.mainVotingPluginAddress),
-          catch: () =>
-            new InvalidPluginAddressForDaoError(
-              `Could not find space for main voting plugin address ${editor.mainVotingPluginAddress}`
-            ),
-        })
+      const maybeSpaceIdForPersonalPluginEffect = Effect.tryPromise({
+        try: () => Spaces.findForPersonalPlugin(editor.mainVotingPluginAddress),
+        catch: () =>
+          new InvalidPluginAddressForDaoError(
+            `Could not find space for main voting plugin address ${editor.mainVotingPluginAddress}`
+          ),
+      });
+
+      const [maybeSpaceIdForVotingPlugin, maybeSpaceIdForPersonalPlugin] = yield* _(
+        Effect.all([maybeSpaceIdForVotingPluginEffect, maybeSpaceIdForPersonalPluginEffect], { concurrency: 2 })
       );
 
       if (!maybeSpaceIdForVotingPlugin && !maybeSpaceIdForPersonalPlugin) {

--- a/packages/substream/sink/events/editor-removed/handler.ts
+++ b/packages/substream/sink/events/editor-removed/handler.ts
@@ -15,15 +15,19 @@ export function handleEditorRemoved(editorsRemoved: EditorRemoved[]) {
     yield* _(Effect.logInfo('Handling editor removed'));
 
     yield* _(
-      Effect.all(
-        schemaEditors.map(m => {
+      Effect.forEach(
+        schemaEditors,
+        m => {
           return Effect.tryPromise({
             try: () => SpaceEditors.remove(m),
             catch: error => {
               return new CouldNotWriteRemovedEditorsError(String(error));
             },
           });
-        })
+        },
+        {
+          concurrency: 20,
+        }
       )
     );
 

--- a/packages/substream/sink/events/edits-published/get-edits-proposal-from-processed-proposal.ts
+++ b/packages/substream/sink/events/edits-published/get-edits-proposal-from-processed-proposal.ts
@@ -162,7 +162,7 @@ function fetchEditProposalFromIpfs(
         };
 
         const maybeDecodedEdits = yield* _(
-          Effect.all(importResult.edits.map(decodeImportEditEffect), {
+          Effect.forEach(importResult.edits, decodeImportEditEffect, {
             concurrency: 50,
             // @TODO: Batching, filtering errors? retrying errors?
           })
@@ -223,16 +223,16 @@ export function getEditsProposalsFromIpfsUri(proposalsProcessed: ProposalProcess
     yield* _(Effect.logInfo('Gathering IPFS content for accepted proposals'));
 
     const maybeProposalsFromIpfs = yield* _(
-      Effect.all(
-        proposalsProcessed.map(proposal =>
+      Effect.forEach(
+        proposalsProcessed,
+        proposal =>
           fetchEditProposalFromIpfs(
             {
               ipfsUri: proposal.contentUri,
               pluginAddress: proposal.pluginAddress,
             },
             block
-          )
-        ),
+          ),
         {
           concurrency: 20,
         }

--- a/packages/substream/sink/events/get-derived-space-ids-from-imported-spaces.ts
+++ b/packages/substream/sink/events/get-derived-space-ids-from-imported-spaces.ts
@@ -62,8 +62,9 @@ export function getDerivedSpaceIdsFromImportedSpaces(processedProposals: Proposa
     yield* _(Effect.logDebug(`Gathering IPFS import content for ${processedProposals.length} initial space proposals`));
 
     const maybeImportsFromIpfs = yield* _(
-      Effect.all(
-        processedProposals.map(p => {
+      Effect.forEach(
+        processedProposals,
+        p => {
           return Effect.gen(function* (_) {
             const maybeSpaceId = yield* _(fetchSpaceImportFromIpfs(p.contentUri));
 
@@ -73,7 +74,7 @@ export function getDerivedSpaceIdsFromImportedSpaces(processedProposals: Proposa
               spaceId: maybeSpaceId,
             };
           });
-        }),
+        },
         {
           concurrency: 50,
         }

--- a/packages/substream/sink/events/initial-editors-added/handler.ts
+++ b/packages/substream/sink/events/initial-editors-added/handler.ts
@@ -37,8 +37,9 @@ export function handleInitialGovernanceSpaceEditorsAdded(editorsAdded: InitialEd
     yield* _(Effect.logDebug('Collecting spaces for public plugins'));
 
     const maybeSpacesForPlugins = yield* _(
-      Effect.all(
-        pluginAddresses.map(p =>
+      Effect.forEach(
+        pluginAddresses,
+        p =>
           Effect.tryPromise({
             try: () =>
               db
@@ -49,8 +50,7 @@ export function handleInitialGovernanceSpaceEditorsAdded(editorsAdded: InitialEd
                 )
                 .run(pool),
             catch: error => new SpaceWithPluginAddressNotFoundError(String(error)),
-          })
-        ),
+          }),
         {
           concurrency: 20,
         }
@@ -158,13 +158,13 @@ export function handleInitialPersonalSpaceEditorsAdded(editorsAdded: InitialEdit
     yield* _(Effect.logDebug('Collecting spaces for personal plugins'));
 
     const maybeSpacesForPlugins = yield* _(
-      Effect.all(
-        pluginAddresses.map(p =>
+      Effect.forEach(
+        pluginAddresses,
+        p =>
           Effect.tryPromise({
             try: () => Spaces.findForPersonalPlugin(p),
             catch: error => new SpaceWithPluginAddressNotFoundError(String(error)),
-          })
-        ),
+          }),
         {
           concurrency: 20,
         }

--- a/packages/substream/sink/events/member-added/map-members.ts
+++ b/packages/substream/sink/events/member-added/map-members.ts
@@ -14,16 +14,19 @@ export function mapMembers(membersApproved: MemberAdded[], block: BlockEvent) {
 
     for (const member of membersApproved) {
       const [maybeSpaceIdForVotingPlugin, maybeSpaceIdForPersonalPlugin] = yield* _(
-        Effect.all([
-          Effect.tryPromise({
-            try: () => Spaces.findForVotingPlugin(member.mainVotingPluginAddress),
-            catch: () => new Error(),
-          }),
-          Effect.tryPromise({
-            try: () => Spaces.findForPersonalPlugin(member.mainVotingPluginAddress),
-            catch: () => new Error(),
-          }),
-        ])
+        Effect.all(
+          [
+            Effect.tryPromise({
+              try: () => Spaces.findForVotingPlugin(member.mainVotingPluginAddress),
+              catch: () => new Error(),
+            }),
+            Effect.tryPromise({
+              try: () => Spaces.findForPersonalPlugin(member.mainVotingPluginAddress),
+              catch: () => new Error(),
+            }),
+          ],
+          { concurrency: 2 }
+        )
       );
 
       if (!maybeSpaceIdForVotingPlugin && !maybeSpaceIdForPersonalPlugin) {

--- a/packages/substream/sink/events/member-removed/handler.ts
+++ b/packages/substream/sink/events/member-removed/handler.ts
@@ -27,6 +27,7 @@ export function handleMemberRemoved(membersRemoved: MemberRemoved[]) {
           });
         }),
         {
+          concurrency: 20,
           mode: 'either',
         }
       )

--- a/packages/substream/sink/events/proposals-created/handler.ts
+++ b/packages/substream/sink/events/proposals-created/handler.ts
@@ -29,12 +29,9 @@ export function handleProposalsCreated(proposalsCreated: ProposalCreated[], bloc
     yield* _(Effect.logDebug(`Gathering IPFS content for ${proposalsCreated.length} proposals`));
 
     const maybeProposals = yield* _(
-      Effect.all(
-        proposalsCreated.map(proposal => getProposalFromIpfs(proposal)),
-        {
-          concurrency: 20,
-        }
-      )
+      Effect.forEach(proposalsCreated, proposal => getProposalFromIpfs(proposal), {
+        concurrency: 20,
+      })
     );
 
     const proposals = maybeProposals.filter(

--- a/packages/substream/sink/events/proposals-executed/handler.ts
+++ b/packages/substream/sink/events/proposals-executed/handler.ts
@@ -15,8 +15,9 @@ export function handleProposalsExecuted(proposalsExecuted: ProposalExecuted[]) {
 
     // @TODO: Batch update proposals in one insert instead of iteratively
     yield* _(
-      Effect.all(
-        proposalsExecuted.map(proposal => {
+      Effect.forEach(
+        proposalsExecuted,
+        proposal => {
           return Effect.tryPromise({
             try: async () => {
               // There might be executed proposals coming from both the member access plugin
@@ -86,7 +87,10 @@ export function handleProposalsExecuted(proposalsExecuted: ProposalExecuted[]) {
               return new CouldNotWriteExecutedProposalError(String(error));
             },
           });
-        })
+        },
+        {
+          concurrency: 50,
+        }
       )
     );
   });

--- a/packages/substream/sink/events/spaces-created/handler.ts
+++ b/packages/substream/sink/events/spaces-created/handler.ts
@@ -44,8 +44,9 @@ export function handlePersonalSpacesCreated(personalPluginsCreated: PersonalPlug
     yield* _(Effect.logDebug('Collecting spaces for personal plugins'));
 
     const personalPluginsWithSpaceId = (yield* _(
-      Effect.all(
-        personalPluginsCreated.map(p => {
+      Effect.forEach(
+        personalPluginsCreated,
+        p => {
           return Effect.gen(function* (_) {
             const maybeSpace = yield* _(Effect.promise(() => Spaces.findForDaoAddress(p.daoAddress)));
 
@@ -63,7 +64,7 @@ export function handlePersonalSpacesCreated(personalPluginsCreated: PersonalPlug
               id: maybeSpace.id,
             };
           });
-        }),
+        },
         {
           concurrency: 25,
         }
@@ -96,8 +97,9 @@ export function handleGovernancePluginCreated(governancePluginsCreated: Governan
     yield* _(Effect.logDebug('Collecting spaces for public plugins'));
 
     const governancePluginsWithSpaceId = (yield* _(
-      Effect.all(
-        governancePluginsCreated.map(g => {
+      Effect.forEach(
+        governancePluginsCreated,
+        g => {
           return Effect.gen(function* (_) {
             const maybeSpace = yield* _(Effect.promise(() => Spaces.findForDaoAddress(g.daoAddress)));
 
@@ -115,7 +117,7 @@ export function handleGovernancePluginCreated(governancePluginsCreated: Governan
               id: maybeSpace.id,
             };
           });
-        }),
+        },
         {
           concurrency: 25,
         }

--- a/packages/substream/sink/events/subspaces-added/map-subspaces.ts
+++ b/packages/substream/sink/events/subspaces-added/map-subspaces.ts
@@ -19,13 +19,13 @@ export function mapSubspaces({
     // Need to get the DAO/space address for the space plugin that emits the
     // SubspaceAdded event.
     const maybeSpacesForPlugins = yield* _(
-      Effect.all(
-        subspacesAdded.map(p =>
+      Effect.forEach(
+        subspacesAdded,
+        p =>
           Effect.tryPromise({
             try: () => Spaces.findForSpacePlugin(p.pluginAddress),
             catch: error => new SpaceWithPluginAddressNotFoundError(String(error)),
-          })
-        ),
+          }),
         {
           concurrency: 20,
         }
@@ -55,13 +55,13 @@ export function mapSubspaces({
       );
 
     const maybeSpaceIdsForSubspaceDaoAddress = yield* _(
-      Effect.all(
-        subspacesAdded.map(p =>
+      Effect.forEach(
+        subspacesAdded,
+        p =>
           Effect.tryPromise({
             try: () => Spaces.findForDaoAddress(p.subspace),
             catch: error => new SpaceWithPluginAddressNotFoundError(String(error)),
-          })
-        ),
+          }),
         {
           concurrency: 20,
         }

--- a/packages/substream/sink/events/subspaces-removed/map-subspaces-to-remove.ts
+++ b/packages/substream/sink/events/subspaces-removed/map-subspaces-to-remove.ts
@@ -13,13 +13,13 @@ export function mapSubspacesToRemove(
     // Need to get the DAO/space address for the space plugin that emits the
     // SubspaceAdded event.
     const maybeSpacesForPlugins = yield* _(
-      Effect.all(
-        subspacesRemoved.map(p =>
+      Effect.forEach(
+        subspacesRemoved,
+        p =>
           Effect.tryPromise({
             try: () => Spaces.findForSpacePlugin(p.pluginAddress),
             catch: error => new SpaceWithPluginAddressNotFoundError(String(error)),
-          })
-        ),
+          }),
         {
           concurrency: 20,
         }
@@ -49,13 +49,13 @@ export function mapSubspacesToRemove(
       );
 
     const maybeSpaceIdsForSubspaceDaoAddress = yield* _(
-      Effect.all(
-        subspacesRemoved.map(p =>
+      Effect.forEach(
+        subspacesRemoved,
+        p =>
           Effect.tryPromise({
             try: () => Spaces.findForDaoAddress(p.subspace),
             catch: error => new SpaceWithPluginAddressNotFoundError(String(error)),
-          })
-        ),
+          }),
         {
           concurrency: 20,
         }

--- a/packages/substream/sink/events/votes-cast/map-votes.ts
+++ b/packages/substream/sink/events/votes-cast/map-votes.ts
@@ -59,10 +59,13 @@ export function mapVotes(
       // If maybeSpaceIdForVotingPlugin returns data we know that the vote corresponds to a voting action.
       // Same for maybeSpaceIdForMemberPlugin.
       const [maybeSpaceIdForVotingPlugin, maybeSpaceIdForMemberPlugin] = yield* _(
-        Effect.all([
-          Effect.promise(() => Spaces.findForVotingPlugin(vote.pluginAddress)),
-          Effect.promise(() => Spaces.findForMembershipPlugin(vote.pluginAddress)),
-        ])
+        Effect.all(
+          [
+            Effect.promise(() => Spaces.findForVotingPlugin(vote.pluginAddress)),
+            Effect.promise(() => Spaces.findForMembershipPlugin(vote.pluginAddress)),
+          ],
+          { concurrency: 2 }
+        )
       );
 
       if (!maybeSpaceIdForVotingPlugin && !maybeSpaceIdForMemberPlugin) {

--- a/packages/substream/sink/run-stream.ts
+++ b/packages/substream/sink/run-stream.ts
@@ -270,13 +270,15 @@ function handleMessage(message: BlockScopedData, registry: IMessageTypeRegistry)
       yield* _(Effect.logInfo(`Handling new events in block ${blockNumber}`));
 
       yield* _(
-        handleNewGeoBlock({
-          blockNumber,
-          cursor,
-          timestamp,
-          hash: message.clock?.id ?? '',
-          network: NETWORK_IDS.GEO,
-        })
+        Effect.fork(
+          handleNewGeoBlock({
+            blockNumber,
+            cursor,
+            timestamp,
+            hash: message.clock?.id ?? '',
+            network: NETWORK_IDS.GEO,
+          })
+        )
       );
     }
 
@@ -382,11 +384,13 @@ function handleMessage(message: BlockScopedData, registry: IMessageTypeRegistry)
       });
 
       yield* _(
-        handleInitialPersonalSpaceEditorsAdded(initialEditors, {
-          blockNumber,
-          cursor,
-          timestamp,
-        })
+        Effect.fork(
+          handleInitialPersonalSpaceEditorsAdded(initialEditors, {
+            blockNumber,
+            cursor,
+            timestamp,
+          })
+        )
       );
     }
 
@@ -406,26 +410,14 @@ function handleMessage(message: BlockScopedData, registry: IMessageTypeRegistry)
      */
     if (initialEditorsAddedResponse.success) {
       yield* _(
-        handleInitialGovernanceSpaceEditorsAdded(initialEditorsAddedResponse.data.initialEditorsAdded, {
-          blockNumber,
-          cursor,
-          timestamp,
-        })
+        Effect.fork(
+          handleInitialGovernanceSpaceEditorsAdded(initialEditorsAddedResponse.data.initialEditorsAdded, {
+            blockNumber,
+            cursor,
+            timestamp,
+          })
+        )
       );
-    }
-
-    if (subspacesAdded.success) {
-      yield* _(
-        handleSubspacesAdded(subspacesAdded.data.subspacesAdded, {
-          blockNumber,
-          cursor,
-          timestamp,
-        })
-      );
-    }
-
-    if (subspacesRemoved.success) {
-      yield* _(handleSubspacesRemoved(subspacesRemoved.data.subspacesRemoved));
     }
 
     if (proposalCreatedResponse.success) {
@@ -436,6 +428,66 @@ function handleMessage(message: BlockScopedData, registry: IMessageTypeRegistry)
           timestamp,
         })
       );
+    }
+
+    if (membersAdded.success) {
+      yield* _(
+        Effect.fork(
+          handleMemberAdded(membersAdded.data.membersAdded, {
+            blockNumber,
+            cursor,
+            timestamp,
+          })
+        )
+      );
+    }
+
+    if (membersRemoved.success) {
+      yield* _(Effect.fork(handleMemberRemoved(membersRemoved.data.membersRemoved)));
+    }
+
+    if (editorsAdded.success) {
+      yield* _(
+        Effect.fork(
+          handleEditorsAdded(editorsAdded.data.editorsAdded, {
+            blockNumber,
+            cursor,
+            timestamp,
+          })
+        )
+      );
+    }
+
+    if (editorsRemoved.success) {
+      yield* _(Effect.fork(handleEditorRemoved(editorsRemoved.data.editorsRemoved)));
+    }
+
+    if (votesCast.success) {
+      yield* _(
+        Effect.fork(
+          handleVotesCast(votesCast.data.votesCast, {
+            blockNumber,
+            cursor,
+            timestamp,
+          })
+        )
+      );
+    }
+
+    if (subspacesAdded.success) {
+      yield* _(
+        Effect.fork(
+          handleSubspacesAdded(subspacesAdded.data.subspacesAdded, {
+            blockNumber,
+            cursor,
+            timestamp,
+          })
+        )
+      );
+    }
+
+    if (subspacesRemoved.success) {
+      yield* _(Effect.fork(handleSubspacesRemoved(subspacesRemoved.data.subspacesRemoved)));
     }
 
     /**
@@ -549,46 +601,8 @@ function handleMessage(message: BlockScopedData, registry: IMessageTypeRegistry)
       );
     }
 
-    if (membersAdded.success) {
-      yield* _(
-        handleMemberAdded(membersAdded.data.membersAdded, {
-          blockNumber,
-          cursor,
-          timestamp,
-        })
-      );
-    }
-
-    if (membersRemoved.success) {
-      yield* _(handleMemberRemoved(membersRemoved.data.membersRemoved));
-    }
-
-    if (editorsAdded.success) {
-      yield* _(
-        handleEditorsAdded(editorsAdded.data.editorsAdded, {
-          blockNumber,
-          cursor,
-          timestamp,
-        })
-      );
-    }
-
-    if (editorsRemoved.success) {
-      yield* _(handleEditorRemoved(editorsRemoved.data.editorsRemoved));
-    }
-
-    if (votesCast.success) {
-      yield* _(
-        handleVotesCast(votesCast.data.votesCast, {
-          blockNumber,
-          cursor,
-          timestamp,
-        })
-      );
-    }
-
     if (executedProposals.success) {
-      yield* _(handleProposalsExecuted(executedProposals.data.executedProposals));
+      yield* _(Effect.fork(handleProposalsExecuted(executedProposals.data.executedProposals)));
     }
 
     return hasValidEvent;

--- a/packages/substream/sink/write-edits/merge-ops-with-previous-versions.ts
+++ b/packages/substream/sink/write-edits/merge-ops-with-previous-versions.ts
@@ -22,8 +22,9 @@ export function mergeOpsWithPreviousVersions(args: MergeOpsWithPreviousVersionAr
     const newOpsByVersionId = new Map<string, Op[]>();
 
     const maybeLatestVersionForEntityIds = yield* _(
-      Effect.all(
-        versions.map(v =>
+      Effect.forEach(
+        versions,
+        v =>
           Effect.retry(
             Effect.promise(async () => {
               const latestVersion = await CurrentVersions.selectOne({ entity_id: v.entity_id.toString() });
@@ -32,23 +33,27 @@ export function mergeOpsWithPreviousVersions(args: MergeOpsWithPreviousVersionAr
             }),
             {
               times: 5,
-              concurrency: 100,
             }
-          )
-        )
+          ),
+        {
+          concurrency: 50,
+        }
       )
     );
 
     // entity id -> version id
     const lastVersionForEntityId = Object.fromEntries(maybeLatestVersionForEntityIds.filter(v => v !== null));
     const triplesForLastVersionTuples = yield* _(
-      Effect.all(
-        Object.values(lastVersionForEntityId).map(versionId =>
+      Effect.forEach(
+        Object.values(lastVersionForEntityId),
+        versionId =>
           Effect.promise(async () => {
             const lastVersionTriples = await Triples.select({ version_id: versionId });
             return [versionId, lastVersionTriples] as const;
-          })
-        )
+          }),
+        {
+          concurrency: 50,
+        }
       )
     );
 

--- a/packages/substream/sink/write-edits/relations/get-deleted-relations-from-ops.ts
+++ b/packages/substream/sink/write-edits/relations/get-deleted-relations-from-ops.ts
@@ -19,14 +19,17 @@ export function getDeletedRelationsFromOps(ops: PartialOp[]) {
       .filter(o => o.opType === 'DELETE_TRIPLE' && o.attribute === SYSTEM_IDS.TYPES)
       .map(o => o.entity);
 
-    const getRelations = Effect.all(
-      entityIdsForDeletedTypeOps.map(entityId =>
+    const getRelations = Effect.forEach(
+      entityIdsForDeletedTypeOps,
+      entityId =>
         Effect.promise(() => {
           return Relations.selectOne({
             entity_id: entityId,
           });
-        })
-      )
+        }),
+      {
+        concurrency: 50,
+      }
     );
 
     return (yield* _(getRelations)).filter(r => r !== undefined);

--- a/packages/substream/sink/write-edits/relations/get-stale-entities-from-relations.ts
+++ b/packages/substream/sink/write-edits/relations/get-stale-entities-from-relations.ts
@@ -92,14 +92,17 @@ export function getStaleEntitiesFromDeletedRelations(ops: Op[]) {
       )
     );
 
-    const getEntityIdOfFromRelations = Effect.all(
-      relations.map(relation =>
+    const getEntityIdOfFromRelations = Effect.forEach(
+      relations,
+      relation =>
         Effect.promise(() => {
           return Versions.selectOne({
             id: relation.from_version_id,
           });
-        })
-      )
+        }),
+      {
+        concurrency: 50,
+      }
     );
 
     const maybeEntityIds = yield* _(getEntityIdOfFromRelations);


### PR DESCRIPTION
This PR adds several performance improvements to the indexer.
- We now add concurrency to all the `Effect.all` and `Effect.forEach` calls. Previously some of them didn't specify concurrency, so Effect would execute them sequentially by default.
- We now fork some of the event handler into new fibers in `runStream`. Not all event handlers are dependent on other events in the indexer. The non-dependent events now just execute when they are able. This should help saturate CPU/IO time in the indexer.