### PR TITLE
fix: ts error in api build

### DIFF
--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -42,7 +42,7 @@ const server = app.listen(PORT, () => {
   const address = server.address();
 
   if (typeof address !== 'string') {
-    const href = `http://localhost:${address?.port}${'/graphiql' || '/graphiql'}`;
+    const href = `http://localhost:${address?.port}/graphiql`;
     console.log(`PostGraphiQL available at ${href} 🚀`);
   } else {
     console.log(`PostGraphile listening on ${address} 🚀`);


### PR DESCRIPTION
This PR fixes a small typescript error in the API build process (TS2872: This kind of expression is always truthy).