### PR TITLE
fix: change data source

### DIFF
--- a/apps/web/core/hooks/use-spaces-query.ts
+++ b/apps/web/core/hooks/use-spaces-query.ts
@@ -23,7 +23,7 @@ type NetworkResult = {
 const spacesQuery = (name: string) => `
   {
     spaces(
-      filter: { spacesMetadata: { some: { entity: { name: { includesInsensitive: "${name}" } } } } }
+      filter: { spacesMetadata: { some: { entity: { currentVersion: { version: { name: { includesInsensitive: "${name}" } } } } } } } 
       first: 10
     ) {
       nodes {
@@ -33,8 +33,8 @@ const spacesQuery = (name: string) => `
             entity {
               id
               currentVersion {
-              version {
-                ${spaceMetadataFragment}
+                version {
+                  ${spaceMetadataFragment}
                 }
               }
             }

--- a/apps/web/core/state/editor/sources.ts
+++ b/apps/web/core/state/editor/sources.ts
@@ -189,8 +189,8 @@ function makeRelationsForSourceEntities(source: Source, blockId: EntityId, space
   }
 
   if (source.type === 'SPACES') {
-    return source.value.map(spaceId => {
-      return makeRelationForSource(EntityId(spaceId), blockId, spaceId);
+    return source.value.map(sourceSpaceId => {
+      return makeRelationForSource(EntityId(sourceSpaceId), blockId, spaceId);
     });
   }
 

--- a/apps/web/partials/blocks/table/data-block-source-menu.tsx
+++ b/apps/web/partials/blocks/table/data-block-source-menu.tsx
@@ -1,13 +1,8 @@
-'use client';
-
-import { SYSTEM_IDS } from '@geogenesis/sdk';
-
 import { useState } from 'react';
 
 import { PLACEHOLDER_SPACE_IMAGE } from '~/core/constants';
 import { useSpaces } from '~/core/hooks/use-spaces';
 import { useSpacesQuery } from '~/core/hooks/use-spaces-query';
-import { ID } from '~/core/id';
 import { SpaceConfigEntity } from '~/core/io/dto/spaces';
 import { SpaceId } from '~/core/io/schema';
 import { useTableBlock } from '~/core/state/table-block-store';


### PR DESCRIPTION
This PR fixes two bugs which were blocking changing the data block source types
- Space search was not updated to latest versioning model
- We were shadowing the source space id when creating source spaces with another space id