### PR TITLE
fix: don't need space filter in filter menu

### DIFF
--- a/apps/web/core/database/entities.ts
+++ b/apps/web/core/database/entities.ts
@@ -256,10 +256,7 @@ export async function getSchemaFromTypeIds(typesIds: string[]): Promise<Schema[]
       {
         id: EntityId(SYSTEM_IDS.TYPES),
         name: 'Types',
-        // @TODO: Should specify that this attribute is a relation. We probably want
-        // a want to distinguish  between the schema value type so we can render it
-        // in the UI differently.
-        valueType: SYSTEM_IDS.TEXT,
+        valueType: SYSTEM_IDS.RELATION,
       },
       ...schema,
     ],

--- a/apps/web/partials/blocks/table/table-block-editable-filters.tsx
+++ b/apps/web/partials/blocks/table/table-block-editable-filters.tsx
@@ -26,20 +26,6 @@ export function TableBlockEditableFilters() {
     //   value: '',
     //   valueName: null,
     // },
-    {
-      columnId: SYSTEM_IDS.SPACE_FILTER,
-      columnName: 'Space',
-      valueType: valueTypes[SYSTEM_IDS.TEXT],
-      value: '',
-      valueName: null,
-    },
-    {
-      columnId: SYSTEM_IDS.TYPES,
-      columnName: 'Types',
-      valueType: valueTypes[SYSTEM_IDS.RELATION],
-      value: '',
-      valueName: null,
-    },
     ...columns
       .map(c => {
         return {


### PR DESCRIPTION
This is now changed via the source space selector