### PR TITLE
feat: search by entity id

### DIFF
--- a/apps/web/core/hooks/use-search.ts
+++ b/apps/web/core/hooks/use-search.ts
@@ -24,7 +24,6 @@ export function useSearch({ filterByTypes }: SearchOptions = {}) {
   const debouncedQuery = useDebouncedValue(query);
 
   const maybeEntityId = debouncedQuery.trim();
-  const isValidEntityId = validateEntityId(maybeEntityId);
 
   const { data: results, isLoading } = useQuery({
     enabled: debouncedQuery !== '',
@@ -32,8 +31,10 @@ export function useSearch({ filterByTypes }: SearchOptions = {}) {
     queryFn: async ({ signal }) => {
       if (query.length === 0) return [];
 
+      const isValidEntityId = validateEntityId(maybeEntityId);
+
       if (isValidEntityId) {
-        const id = maybeEntityId as EntityId;
+        const id = EntityId(maybeEntityId);
         const result = await fetchResult({ id });
         if (result) return [result];
         return [];

--- a/apps/web/core/io/subgraph/fetch-result.ts
+++ b/apps/web/core/io/subgraph/fetch-result.ts
@@ -1,0 +1,106 @@
+import { Schema } from '@effect/schema';
+import * as Effect from 'effect/Effect';
+import * as Either from 'effect/Either';
+import { v4 as uuid } from 'uuid';
+
+import { Environment } from '~/core/environment';
+
+import { SearchResult, SearchResultDto } from '../dto/search';
+import { SubstreamSearchResult } from '../schema';
+import { resultEntityFragment } from './fragments';
+import { graphql } from './graphql';
+
+function getFetchResultQuery(id: string) {
+  return `query {
+    entity(id: ${JSON.stringify(id)}) {
+      id
+      currentVersion {
+        version {
+          ${resultEntityFragment}
+        }
+      }
+    }
+  }`;
+}
+
+export interface FetchResultOptions {
+  id: string;
+  signal?: AbortController['signal'];
+}
+
+interface NetworkResult {
+  entity: SubstreamSearchResult | null;
+}
+
+export async function fetchResult(options: FetchResultOptions): Promise<SearchResult | null> {
+  const queryId = uuid();
+  const endpoint = Environment.getConfig().api;
+
+  const graphqlFetchEffect = graphql<NetworkResult>({
+    endpoint,
+    query: getFetchResultQuery(options.id),
+    signal: options.signal,
+  });
+
+  const graphqlFetchWithErrorFallbacks = Effect.gen(function* () {
+    const resultOrError = yield* Effect.either(graphqlFetchEffect);
+
+    if (Either.isLeft(resultOrError)) {
+      const error = resultOrError.left;
+
+      switch (error._tag) {
+        case 'AbortError':
+          // Right now we re-throw AbortErrors and let the callers handle it. Eventually we want
+          // the caller to consume the error channel as an effect. We throw here the typical JS
+          // way so we don't infect more of the codebase with the effect runtime.
+          throw error;
+        case 'GraphqlRuntimeError':
+          console.error(
+            `Encountered runtime graphql error in fetchResult. id: ${options.id}
+
+            queryString: ${getFetchResultQuery(options.id)}
+            `,
+            error.message
+          );
+
+          return {
+            entity: null,
+          };
+        default:
+          console.error(
+            `${error._tag}: Unable to fetch result, queryId: ${queryId} endpoint: ${endpoint} id: ${options.id}`
+          );
+          return {
+            entity: null,
+          };
+      }
+    }
+
+    return resultOrError.right;
+  });
+
+  const result = await Effect.runPromise(graphqlFetchWithErrorFallbacks);
+  const entity = result.entity;
+
+  if (!entity) {
+    return null;
+  }
+
+  const entityOrError = Schema.decodeEither(SubstreamSearchResult)(entity);
+
+  const decodedResult = Either.match(entityOrError, {
+    onLeft: error => {
+      console.error(`Unable to decode search result: ${String(error)}`);
+      return null;
+    },
+    onRight: result => {
+      return SearchResultDto(result);
+    },
+  });
+
+  if (decodedResult === null) {
+    return null;
+  }
+
+  return decodedResult;
+}

--- a/apps/web/core/io/subgraph/index.ts
+++ b/apps/web/core/io/subgraph/index.ts
@@ -5,6 +5,8 @@ export type { FetchTriplesOptions } from './fetch-triples';
 
 export { fetchEntities } from './fetch-entities';
 export type { FetchEntitiesOptions } from './fetch-entities';
+export { fetchResult } from './fetch-result';
+export type { FetchResultOptions } from './fetch-result';
 export { fetchResults } from './fetch-results';
 export type { FetchResultsOptions } from './fetch-results';
 export { fetchEntity } from './fetch-entity';

--- a/apps/web/core/utils/utils.ts
+++ b/apps/web/core/utils/utils.ts
@@ -1,7 +1,9 @@
+import { BASE58_ALLOWED_CHARS } from '@geogenesis/sdk';
 import { validate as uuidValidate, version as uuidVersion } from 'uuid';
 import { getAddress } from 'viem';
 
 import { IPFS_GATEWAY_READ_PATH } from '~/core/constants';
+import type { EntityId } from '~/core/io/schema';
 
 import { Entity } from '../io/dto/entities';
 import { Proposal } from '../io/dto/proposals';
@@ -313,4 +315,19 @@ export const uuidValidateV4 = (uuid: string) => {
   if (!uuid) return false;
 
   return uuidValidate(uuid) && uuidVersion(uuid) === 4;
+};
+
+export const validateEntityId = (maybeEntityId: EntityId | string | null | undefined) => {
+  if (typeof maybeEntityId !== 'string') return false;
+
+  if (maybeEntityId.length !== 22) return false;
+
+  for (const char of maybeEntityId) {
+    const index = BASE58_ALLOWED_CHARS.indexOf(char);
+    if (index === -1) {
+      return false;
+    }
+  }
+
+  return true;
 };

--- a/apps/web/core/utils/utils.ts
+++ b/apps/web/core/utils/utils.ts
@@ -320,7 +320,7 @@ export const uuidValidateV4 = (uuid: string) => {
 export const validateEntityId = (maybeEntityId: EntityId | string | null | undefined) => {
   if (typeof maybeEntityId !== 'string') return false;
 
-  if (maybeEntityId.length !== 22) return false;
+  if (!VALID_ENTITY_ID_LENGTHS.includes(maybeEntityId.length)) return false;
 
   for (const char of maybeEntityId) {
     const index = BASE58_ALLOWED_CHARS.indexOf(char);
@@ -331,3 +331,5 @@ export const validateEntityId = (maybeEntityId: EntityId | string | null | undef
 
   return true;
 };
+
+const VALID_ENTITY_ID_LENGTHS = [21, 22];

--- a/apps/web/design-system/select-entity.tsx
+++ b/apps/web/design-system/select-entity.tsx
@@ -6,7 +6,7 @@ import { useAtom } from 'jotai';
 import pluralize from 'pluralize';
 
 import * as React from 'react';
-import { useState } from 'react';
+import { startTransition, useState } from 'react';
 
 import { useWriteOps } from '~/core/database/write';
 import { useSearch } from '~/core/hooks/use-search';
@@ -98,6 +98,12 @@ export const SelectEntity = ({
   const { query, onQueryChange, isLoading, isEmpty, results } = useSearch({
     filterByTypes: allowedTypes?.map(type => type.typeId),
   });
+
+  if (query === '' && result !== null) {
+    startTransition(() => {
+      setResult(null);
+    });
+  }
 
   const handleShowIds = () => {
     setIsShowingIds(!isShowingIds);

--- a/packages/sdk/index.ts
+++ b/packages/sdk/index.ts
@@ -1,7 +1,7 @@
 export * from './src/types.js';
 
 export { createGeoId } from './src/id.js';
-export { decodeBase58ToUUID, encodeBase58 } from './src/core/base58.js';
+export { BASE58_ALLOWED_CHARS, decodeBase58ToUUID, encodeBase58 } from './src/core/base58.js';
 export {
   getProcessGeoProposalArguments,
   getAcceptSubspaceArguments,

--- a/packages/sdk/src/core/base58.ts
+++ b/packages/sdk/src/core/base58.ts
@@ -1,4 +1,4 @@
-const BASE58_ALLOWED_CHARS = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+export const BASE58_ALLOWED_CHARS = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
 
 export type Base58 = string;
 


### PR DESCRIPTION
This PR extends the `useSearch` hook to allow searching by manually entered entity ID.