### PR TITLE
fix: keep table async data from previous state while computing new state

### DIFF
--- a/apps/web/core/state/table-block-store.tsx
+++ b/apps/web/core/state/table-block-store.tsx
@@ -89,7 +89,8 @@ export function useTableBlock() {
 
   const collectionItemIds = collectionItems?.map(c => c.id) ?? [];
 
-  const { data: collectionItemEntities, isLoading: isLoadingCollectionItemEntities } = useQuery({
+  const { data: collectionItemEntities } = useQuery({
+    placeholderData: keepPreviousData,
     enabled: collectionItems.length > 0,
     queryKey: queryKeys.collectionItemEntities(collectionItemIds),
     queryFn: async () => {
@@ -119,6 +120,7 @@ export function useTableBlock() {
    * only includes _data_ filters, but not _where_ to query from.
    */
   const { data: filterState, isLoading: isLoadingFilterState } = useQuery({
+    placeholderData: keepPreviousData,
     queryKey: queryKeys.filterState(filterString, source),
     queryFn: async () => {
       const filterState = await createFiltersFromGraphQLStringAndSource(filterString, source);
@@ -130,6 +132,7 @@ export function useTableBlock() {
   // We need the entities before we can fetch the columns since we need to know the
   // types of the entities when rendering a collection source.
   const { data: columns, isLoading: isLoadingColumns } = useQuery({
+    placeholderData: keepPreviousData,
     queryKey: queryKeys.columns(filterState ?? null),
     queryFn: async () => {
       const typesInFilter = filterState?.filter(f => f.columnId === SYSTEM_IDS.TYPES).map(f => f.value) ?? [];
@@ -177,6 +180,7 @@ export function useTableBlock() {
   }, [tableEntities, columns, collectionItemEntities]);
 
   const { data: columnRelationTypes } = useQuery({
+    placeholderData: keepPreviousData,
     enabled: columns !== undefined,
     queryKey: queryKeys.relationTypes(columns),
     queryFn: async () => {
@@ -277,7 +281,7 @@ export function useTableBlock() {
     entityId,
     spaceId,
 
-    isLoading: isLoadingColumns || isLoadingEntities || isLoadingFilterState || isLoadingCollectionItemEntities,
+    isLoading: isLoadingColumns || isLoadingEntities || isLoadingFilterState,
 
     name: blockEntity.name,
     setName,


### PR DESCRIPTION
Previously changing any state that required async requests would send the table into a loading state when making the changes. This was janky. Now we keep previous state while computing the new state. This still isn't perfect as there might be a delay while we wait for your local state to show up in the UI, but it's better than what we had previously.