### PR TITLE
feat: triple attributes should point to a version

### DIFF
--- a/apps/web/core/io/dto/triples.ts
+++ b/apps/web/core/io/dto/triples.ts
@@ -1,4 +1,4 @@
-import { Value } from '~/core/types';
+import { Triple, Value } from '~/core/types';
 
 import { SubstreamTriple } from '../schema';
 
@@ -17,16 +17,16 @@ export function extractValue(networkTriple: SubstreamTriple): Value {
   }
 }
 
-export function TripleDto(triple: SubstreamTriple) {
-  const entity = triple.entity;
-  const attribute = triple.attribute;
+export function TripleDto(triple: SubstreamTriple): Triple {
+  const entity = triple.version;
+  const attribute = triple.attributeVersion;
 
   return {
-    entityId: entity.id,
-    entityName: entity.currentVersion.version.name,
-    attributeId: attribute.id,
-    attributeName: attribute.currentVersion.version.name,
+    entityId: entity.entityId,
+    entityName: entity.name,
+    attributeId: attribute.entityId,
+    attributeName: attribute.name,
     value: extractValue(triple),
-    space: triple.space.id,
+    space: triple.spaceId,
   };
 }

--- a/apps/web/core/io/schema.ts
+++ b/apps/web/core/io/schema.ts
@@ -18,11 +18,6 @@ const SubstreamType = Schema.Struct({
 
 export type SubstreamType = Schema.Schema.Type<typeof SubstreamType>;
 
-const Nameable = Schema.Struct({
-  name: Schema.NullOr(Schema.String),
-});
-type Nameable = Schema.Schema.Type<typeof Nameable>;
-
 const Identifiable = Schema.Struct({
   id: Schema.String.pipe(Schema.fromBrand(EntityId)),
 });
@@ -147,19 +142,15 @@ type SubstreamSpaceWithoutMetadata = Schema.Schema.Type<typeof SubstreamSpaceWit
 export const SubstreamTriple = Schema.extend(
   SubstreamValue,
   Schema.Struct({
-    entity: Schema.Struct({
-      id: Schema.String.pipe(Schema.fromBrand(EntityId)),
-      currentVersion: Schema.Struct({
-        version: Schema.extend(Identifiable, Nameable),
-      }),
+    version: Schema.Struct({
+      entityId: Schema.String.pipe(Schema.fromBrand(EntityId)),
+      name: Schema.NullOr(Schema.String),
     }),
-    attribute: Schema.Struct({
-      id: Schema.String.pipe(Schema.fromBrand(EntityId)),
-      currentVersion: Schema.Struct({
-        version: Schema.extend(Identifiable, Nameable),
-      }),
+    attributeVersion: Schema.Struct({
+      entityId: Schema.String.pipe(Schema.fromBrand(EntityId)),
+      name: Schema.NullOr(Schema.String),
     }),
-    space: SubstreamSpaceWithoutMetadata.pick('id'),
+    spaceId: Schema.String.pipe(Schema.fromBrand(EntityId)),
   })
 );
 

--- a/apps/web/core/io/subgraph/fragments.ts
+++ b/apps/web/core/io/subgraph/fragments.ts
@@ -35,41 +35,19 @@ export const versionTypesFragment = `
 `;
 
 export const tripleFragment = `
-  attribute {
-    id
-    currentVersion {
-      version {
-        id
-        name
-      }
-    }
+  attributeVersion {
+    entityId
+    name
   }
-  entity {
-    id
-    currentVersion {
-      version {
-        id
-        name
-      }
-    }
-  }
-  entityValue {
-    id
-    currentVersion {
-      version {
-        id
-        name
-        ${versionTypesFragment}
-      }
-    }
+  version {
+    entityId
+    name
   }
   numberValue
   textValue
   booleanValue
   valueType
-  space {
-    id
-  }
+  spaceId
 `;
 
 /**

--- a/apps/web/core/utils/change/change.ts
+++ b/apps/web/core/utils/change/change.ts
@@ -9,6 +9,7 @@ import { Proposal } from '~/core/io/dto/proposals';
 import { Version } from '~/core/io/dto/versions';
 import { EntityId } from '~/core/io/schema';
 import { fetchEntity } from '~/core/io/subgraph';
+import { fetchVersion } from '~/core/io/subgraph/fetch-version';
 import { queryClient } from '~/core/query-client';
 import type { Relation, Triple } from '~/core/types';
 
@@ -94,7 +95,9 @@ export async function fromActiveProposal(proposal: Proposal): Promise<EntityChan
   const versionsByEditId = await fetchVersionsByEditId({ editId: proposal.editId });
 
   // Version entity ids are mapped to the version.id
-  const currentVersionsForEntityIds = await Promise.all(versionsByEditId.map(v => fetchEntity({ id: v.id })));
+  const currentVersionsForEntityIds = await Promise.all(
+    versionsByEditId.map(v => fetchVersion({ versionId: v.versionId }))
+  );
 
   return aggregateChanges({
     spaceId: proposal.space.id,

--- a/packages/substream/sink/events/get-triple-from-op.test.ts
+++ b/packages/substream/sink/events/get-triple-from-op.test.ts
@@ -17,7 +17,8 @@ describe('tripleFromOp', () => {
           },
         },
       },
-      '0x1234',
+      'entity-version-id',
+      'attribute-version-id',
       {
         blockNumber: 0,
         cursor: '',
@@ -27,6 +28,7 @@ describe('tripleFromOp', () => {
 
     expect(triple).toEqual({
       attribute_id: 'attribute-id',
+      attribute_version_id: '0x5678',
       created_at: 0,
       created_at_block: 0,
       entity_id: 'entity-id',
@@ -35,7 +37,7 @@ describe('tripleFromOp', () => {
       space_id: 'space-1',
       text_value: 'test value',
       value_type: 'TEXT',
-      version_id: '0x1234',
+      version_id: 'entity-version-id',
     });
   });
 
@@ -50,7 +52,8 @@ describe('tripleFromOp', () => {
           value: {},
         },
       },
-      '0x1234',
+      'entity-version-id',
+      'attribute-version-id',
       {
         blockNumber: 0,
         cursor: '',
@@ -60,6 +63,7 @@ describe('tripleFromOp', () => {
 
     expect(triple).toEqual({
       attribute_id: 'attribute-id',
+      attribute_version_id: 'attribute-version-id',
       created_at: 0,
       created_at_block: 0,
       entity_id: 'entity-id',
@@ -68,7 +72,7 @@ describe('tripleFromOp', () => {
       space_id: 'space-1',
       text_value: null,
       value_type: 'TEXT',
-      version_id: '0x1234',
+      version_id: 'entity-version-id',
     });
   });
 });

--- a/packages/substream/sink/events/get-triple-from-op.ts
+++ b/packages/substream/sink/events/get-triple-from-op.ts
@@ -10,6 +10,7 @@ import type { BlockEvent, DeleteTripleOp, SetTripleOp, ValueType } from '../type
 export function getTripleFromOp(
   op: SetTripleOp | DeleteTripleOp,
   versionId: string,
+  attributeVersionId: string,
   block: BlockEvent
 ): S.triples.Insertable {
   const { entity, attribute } = op.triple;
@@ -20,14 +21,15 @@ export function getTripleFromOp(
     const values = getValue(value_type, value);
 
     return {
+      ...values,
       version_id: versionId,
       space_id: op.space,
       entity_id: entity,
       attribute_id: attribute,
+      attribute_version_id: attributeVersionId,
       value_type,
       created_at: block.timestamp,
       created_at_block: block.blockNumber,
-      ...values,
     };
   }
 
@@ -36,6 +38,7 @@ export function getTripleFromOp(
     space_id: op.space,
     entity_id: entity,
     attribute_id: attribute,
+    attribute_version_id: attributeVersionId,
     value_type: 'TEXT', // this doesn't matter for deletes, but we populate it anyway for more ergonomic types
     created_at: block.timestamp,
     created_at_block: block.blockNumber,

--- a/packages/substream/sink/sql/init-indexes.sql
+++ b/packages/substream/sink/sql/init-indexes.sql
@@ -11,6 +11,12 @@ CREATE INDEX version_types_version_id ON public.version_types(version_id, type_i
 CREATE INDEX triple_entity_id
     on triples (entity_id);
 
+CREATE INDEX triple_attribute_id
+    on triples (attribute_id);
+
+CREATE INDEX triple_attribute_version_id
+    on triples (attribute_version_id);
+
 CREATE INDEX triple_version_id
     on triples (version_id);
 

--- a/packages/substream/sink/sql/init-public.sql
+++ b/packages/substream/sink/sql/init-public.sql
@@ -136,6 +136,7 @@ CREATE TABLE public.triples (
     space_id text NOT NULL REFERENCES public.spaces(id),
     entity_id text NOT NULL REFERENCES public.entities(id),
     attribute_id text NOT NULL REFERENCES public.entities(id),
+    attribute_version_id text NOT NULL REFERENCES public.versions(id),
     value_type triple_value_type NOT NULL,
     number_value text,
     text_value text,
@@ -248,7 +249,6 @@ ALTER TABLE
 ALTER TABLE
     public.versions DISABLE TRIGGER ALL;
 ALTER TABLE
-
     public.edits DISABLE TRIGGER ALL;
 
 ALTER TABLE

--- a/packages/substream/sink/write-edits/map-triples.ts
+++ b/packages/substream/sink/write-edits/map-triples.ts
@@ -11,7 +11,11 @@ export interface OpWithCreatedBy {
 
 export type SchemaTripleEdit = { ops: (SetTripleOp | DeleteTripleOp)[]; createdById: string; versonId: string };
 
-export function mapSchemaTriples(edit: SchemaTripleEdit, block: BlockEvent): OpWithCreatedBy[] {
+export function mapSchemaTriples(
+  edit: SchemaTripleEdit,
+  attributeVersionsByEntityId: Map<string, string>,
+  block: BlockEvent
+): OpWithCreatedBy[] {
   const squashedOps = squashOps(edit.ops, edit.versonId);
 
   // Validating after squashing is an intentional decision to throw away ops
@@ -20,10 +24,13 @@ export function mapSchemaTriples(edit: SchemaTripleEdit, block: BlockEvent): OpW
   // but it _was_ the final _valid_ op in an edit. For now we only take the
   // final op and validate to better represent the intended final state of
   // the set of edits.
-  const validOps = validateOps(squashedOps);
+  const validOps = validateOps(squashedOps, attributeVersionsByEntityId);
 
   return validOps.map((op): OpWithCreatedBy => {
-    const triple = getTripleFromOp(op, edit.versonId, block);
+    // We validate there's a matching version id in validateOps so it's safe-ish
+    // to cast here
+    const attributeVersionId = attributeVersionsByEntityId.get(op.triple.attribute)!;
+    const triple = getTripleFromOp(op, edit.versonId, attributeVersionId, block);
 
     return {
       createdById: edit.createdById,
@@ -44,9 +51,13 @@ function squashOps(ops: (SetTripleOp | DeleteTripleOp)[], versionId: string): (S
   return [...squashedOps.values()];
 }
 
-function validateOps(ops: (SetTripleOp | DeleteTripleOp)[]) {
+function validateOps(ops: (SetTripleOp | DeleteTripleOp)[], attributeVersionsByEntityId: Map<string, string>) {
   return ops.filter(o => {
     if (o.type === 'DELETE_TRIPLE') return true;
+
+    if (!attributeVersionsByEntityId.has(o.triple.attribute)) {
+      return false;
+    }
 
     const triple = o.triple;
 

--- a/packages/substream/sink/write-edits/merge-ops-with-previous-versions.ts
+++ b/packages/substream/sink/write-edits/merge-ops-with-previous-versions.ts
@@ -12,7 +12,7 @@ interface MergeOpsWithPreviousVersionArgs {
 
 export function mergeOpsWithPreviousVersions(args: MergeOpsWithPreviousVersionArgs) {
   const spaceIdByEditId = new Map<string, string>();
-  const { versions, tripleOpsByVersionId: opsByVersionId } = args;
+  const { versions, tripleOpsByVersionId } = args;
 
   for (const edit of args.edits) {
     spaceIdByEditId.set(edit.id.toString(), edit.space_id.toString());
@@ -60,7 +60,7 @@ export function mergeOpsWithPreviousVersions(args: MergeOpsWithPreviousVersionAr
     const triplesForLastVersion = Object.fromEntries(triplesForLastVersionTuples);
 
     for (const version of versions) {
-      const opsForVersion = opsByVersionId.get(version.id.toString()) ?? [];
+      const opsForVersion = tripleOpsByVersionId.get(version.id.toString()) ?? [];
       const lastVersionId = lastVersionForEntityId[version.entity_id.toString()];
 
       if (lastVersionId) {

--- a/packages/substream/sink/write-edits/write-edits.ts
+++ b/packages/substream/sink/write-edits/write-edits.ts
@@ -83,8 +83,6 @@ export function writeEdits(args: PopulateContentArgs) {
       })
     );
 
-    console.log('attribute versions by edit id', attributeVersionsByEdit);
-
     // We might get multiple proposals at once in the same block that change the same set of entities.
     // We need to make sure that we process the proposals in order to avoid conflicts when writing to
     // the DB as well as to make sure we preserve the proposal ordering as they're received from the chain.

--- a/packages/substream/sink/zapatos/schema.d.ts
+++ b/packages/substream/sink/zapatos/schema.d.ts
@@ -3235,6 +3235,12 @@ declare module 'zapatos/schema' {
       */
       attribute_id: string;
       /**
+      * **triples.attribute_version_id**
+      * - `text` in database
+      * - `NOT NULL`, no default
+      */
+      attribute_version_id: string;
+      /**
       * **triples.value_type**
       * - `triple_value_type` in database
       * - `NOT NULL`, no default
@@ -3302,6 +3308,12 @@ declare module 'zapatos/schema' {
       * - `NOT NULL`, no default
       */
       attribute_id: string;
+      /**
+      * **triples.attribute_version_id**
+      * - `text` in database
+      * - `NOT NULL`, no default
+      */
+      attribute_version_id: string;
       /**
       * **triples.value_type**
       * - `triple_value_type` in database
@@ -3371,6 +3383,12 @@ declare module 'zapatos/schema' {
       */
       attribute_id?: string | db.Parameter<string> | db.SQLFragment | db.ParentColumn | db.SQLFragment<any, string | db.Parameter<string> | db.SQLFragment | db.ParentColumn>;
       /**
+      * **triples.attribute_version_id**
+      * - `text` in database
+      * - `NOT NULL`, no default
+      */
+      attribute_version_id?: string | db.Parameter<string> | db.SQLFragment | db.ParentColumn | db.SQLFragment<any, string | db.Parameter<string> | db.SQLFragment | db.ParentColumn>;
+      /**
       * **triples.value_type**
       * - `triple_value_type` in database
       * - `NOT NULL`, no default
@@ -3439,6 +3457,12 @@ declare module 'zapatos/schema' {
       */
       attribute_id: string | db.Parameter<string> | db.SQLFragment;
       /**
+      * **triples.attribute_version_id**
+      * - `text` in database
+      * - `NOT NULL`, no default
+      */
+      attribute_version_id: string | db.Parameter<string> | db.SQLFragment;
+      /**
       * **triples.value_type**
       * - `triple_value_type` in database
       * - `NOT NULL`, no default
@@ -3506,6 +3530,12 @@ declare module 'zapatos/schema' {
       * - `NOT NULL`, no default
       */
       attribute_id?: string | db.Parameter<string> | db.SQLFragment | db.SQLFragment<any, string | db.Parameter<string> | db.SQLFragment>;
+      /**
+      * **triples.attribute_version_id**
+      * - `text` in database
+      * - `NOT NULL`, no default
+      */
+      attribute_version_id?: string | db.Parameter<string> | db.SQLFragment | db.SQLFragment<any, string | db.Parameter<string> | db.SQLFragment>;
       /**
       * **triples.value_type**
       * - `triple_value_type` in database


### PR DESCRIPTION
### Summary
The reference data service has a versioning mechanism which enables querying any entity at any version at any point in time with a unified data model. This allows us to do time-traveling as well as compare (diff) entities over time.

In order for this to work, any data models in the data service that reference an entity must also (or instead) reference a specific version of that entity. By default the data service picks the latest version, but the model supports users being able to select versions themselves.

This PR updates the data model for triples to also reference a version for the `attribute`. Previously we were only referencing the entity for that attribute, so we could not correctly time-travel for any triples where the attribute did not previously exist.

This also updates our queries in the web application to point to this new `attributeVersion` data model as well as updates our queries to point to the `version` for a triple instead of the `entity`.