### PR TITLE
feat: new default proposal time for new spaces

### DIFF
--- a/apps/web/app/api/space/deploy/deploy.ts
+++ b/apps/web/app/api/space/deploy/deploy.ts
@@ -111,7 +111,7 @@ export function deploySpace(args: DeployArgs) {
         votingSettings: {
           votingMode: VotingMode.EarlyExecution,
           supportThreshold: pctToRatio(50),
-          duration: BigInt(60 * 60 * 4), // 4 hours
+          duration: BigInt(60 * 60 * 24), // 4 hours
         },
         memberAccessProposalDuration: BigInt(60 * 60 * 4), // 4 hours
         initialEditors: [getChecksumAddress(initialEditorAddress)],

--- a/apps/web/app/space/[id]/governance/page.tsx
+++ b/apps/web/app/space/[id]/governance/page.tsx
@@ -17,7 +17,20 @@ interface Props {
   searchParams: { proposalId?: string };
 }
 
-const votingPeriod = '4h';
+const INITIAL_PUBLIC_SPACES = [
+  '25omwWh6HYgeRQKCaSpVpa', // Geo root
+  'DqiHGrgbniQ9RXRbcQArQ2', // Industries
+  'SgjATMbm41LX6naizMqBVd', // Crypto
+  'BDuZwkjCg3nPWMDshoYtpS', // Crypto News
+  '9WjyZnACdQorhyZWXvjsYB', // software
+];
+
+const getVotingPeriod = (spaceId: string) => {
+  // We don't currently track voting settings in the indexer, so we
+  // hardcode which initial spaces had the 4h voting duration.
+  if (INITIAL_PUBLIC_SPACES.includes(spaceId)) return '4h';
+  return '24h';
+};
 const passThreshold = '50%';
 
 export const dynamic = 'force-dynamic';
@@ -32,7 +45,7 @@ export default async function GovernancePage({ params, searchParams }: Props) {
         <div className="flex items-center gap-5">
           <GovernanceMetadataBox>
             <h2 className="text-metadata text-grey-04">Voting period</h2>
-            <p className="text-mediumTitle">{votingPeriod}</p>
+            <p className="text-mediumTitle">{getVotingPeriod(params.id)}</p>
           </GovernanceMetadataBox>
           <GovernanceMetadataBox>
             <h2 className="text-metadata text-grey-04">Pass threshold</h2>


### PR DESCRIPTION
This updates new space deployments for governed spaces to have 24 hour voting windows. Previously deployed governed spaces aren't being updated to 24 hours. Currently the indexer does not track voting settings for spaces, so we need to hardcode the existing space ids in order to render the correct voting window on the governance screen. In the future we'll update the indexer to track voting settings for each space.