### PR TITLE
fix: don't retry DAO deployment granularly

### DIFF
--- a/apps/web/app/api/bootstrap/deploy/deploy.ts
+++ b/apps/web/app/api/bootstrap/deploy/deploy.ts
@@ -147,37 +147,27 @@ export function deploySpace(args: DeployArgs) {
     const deployStartTime = Date.now();
     yield* Effect.logInfo('Creating DAO');
 
-    const dao = yield* Effect.retry(
-      Effect.tryPromise({
-        try: async () => {
-          const steps = await createDao(createParams, deployParams);
-          let dao = '';
-          let pluginAddresses = [];
+    const dao = yield* Effect.tryPromise({
+      try: async () => {
+        const steps = await createDao(createParams, deployParams);
+        let dao = '';
+        let pluginAddresses = [];
 
-          for await (const step of steps) {
-            switch (step.key) {
-              case DaoCreationSteps.CREATING:
-                break;
-              case DaoCreationSteps.DONE: {
-                dao = step.address;
-                pluginAddresses = step.pluginAddresses ?? [];
-              }
+        for await (const step of steps) {
+          switch (step.key) {
+            case DaoCreationSteps.CREATING:
+              break;
+            case DaoCreationSteps.DONE: {
+              dao = step.address;
+              pluginAddresses = step.pluginAddresses ?? [];
             }
           }
+        }
 
-          return { dao, pluginAddresses };
-        },
-        catch: e => new DeployDaoError(`Failed creating DAO: ${e}`),
-      }),
-      {
-        schedule: Schedule.exponential(Duration.millis(100)).pipe(
-          Schedule.jittered,
-          Schedule.compose(Schedule.elapsed),
-          Schedule.tapInput(() => Effect.succeed(Telemetry.metric(Metrics.deploymentRetry))),
-          Schedule.whileOutput(Duration.lessThanOrEqualTo(Duration.minutes(1)))
-        ),
-      }
-    );
+        return { dao, pluginAddresses };
+      },
+      catch: e => new DeployDaoError(`Failed creating DAO: ${e}`),
+    });
 
     const deployEndTime = Date.now() - deployStartTime;
     Telemetry.metric(Metrics.timing('deploy_dao_duration', deployEndTime));

--- a/apps/web/core/io/subgraph/fetch-history-versions.ts
+++ b/apps/web/core/io/subgraph/fetch-history-versions.ts
@@ -20,7 +20,7 @@ const PAGE_SIZE = 5;
 
 const query = (entityId: string, page = 0) => {
   return `query {
-    versions(filter: { entityId: {equalTo: ${JSON.stringify(entityId)}}}) {
+    versions(filter: { entityId: {equalTo: ${JSON.stringify(entityId)}}} orderBy: CREATED_AT_DESC) {
       nodes {
         ${versionFragment}
         edit {


### PR DESCRIPTION
This might result in false positives that deploy the same space multiple times using the same ops. Instead we should retry the entire deploy flow, which we already do.