### PR TITLE
fix: multi-space entities + edit execution order

### DIFF
--- a/apps/web/app/api/space/deploy/deploy.ts
+++ b/apps/web/app/api/space/deploy/deploy.ts
@@ -66,7 +66,6 @@ interface DeployArgs {
   spaceAvatarUri: string | null;
   spaceCoverUri: string | null;
   initialEditorAddress: string;
-  baseUrl: string;
 }
 
 export function deploySpace(args: DeployArgs) {

--- a/apps/web/app/api/space/deploy/route.ts
+++ b/apps/web/app/api/space/deploy/route.ts
@@ -54,7 +54,6 @@ export async function GET(request: Request) {
       spaceName,
       spaceAvatarUri,
       spaceCoverUri,
-      baseUrl: `${protocol}//${baseUrl}`,
       type,
       governanceType: governanceType ?? undefined,
     }),

--- a/packages/substream/sink/db/current-versions.ts
+++ b/packages/substream/sink/db/current-versions.ts
@@ -9,7 +9,7 @@ export class CurrentVersions {
   }
 
   static async selectOne(where: S.current_versions.Whereable) {
-    return db.selectOne('current_versions', where).run(pool);
+    return db.selectOne('current_versions', where, { columns: ['entity_id', 'version_id'] }).run(pool);
   }
 
   static async select(where: S.current_versions.Whereable) {

--- a/packages/substream/sink/db/versions.ts
+++ b/packages/substream/sink/db/versions.ts
@@ -49,7 +49,7 @@ export class Versions {
   static selectOne(where: S.versions.Whereable) {
     return db
       .selectOne('versions', where, {
-        columns: ['id', 'entity_id'],
+        columns: ['id', 'entity_id', 'created_at_block'],
       })
       .run(pool);
   }

--- a/packages/substream/sink/events/edits-published/get-edits-proposal-from-processed-proposal.ts
+++ b/packages/substream/sink/events/edits-published/get-edits-proposal-from-processed-proposal.ts
@@ -1,4 +1,4 @@
-import { SYSTEM_IDS, getChecksumAddress } from '@geogenesis/sdk';
+import { getChecksumAddress } from '@geogenesis/sdk';
 import { Effect, Either } from 'effect';
 
 import { Spaces } from '../../db';

--- a/packages/substream/sink/events/edits-published/handler.ts
+++ b/packages/substream/sink/events/edits-published/handler.ts
@@ -110,7 +110,6 @@ export function handleEditsPublished(ipfsProposals: SinkEditProposal[], createdS
      * are created with the entire state of the entity _at the time the version is
      * created_.
      */
-
     const handleStaleCurrentVersions = Effect.forEach(
       nonstaleVersions,
       version =>
@@ -123,10 +122,6 @@ export function handleEditsPublished(ipfsProposals: SinkEditProposal[], createdS
 
           // Can do a JOIN on current version instead of querying again
           const currentVersion = await Versions.selectOne({ id: maybeCurrentVersion.version_id });
-
-          if (currentVersion?.entity_id === '5FkVvS4mTz6Ge7wHkAUMRk') {
-            console.log('current version', currentVersion, version);
-          }
 
           if (!currentVersion) {
             return null;

--- a/packages/substream/sink/events/edits-published/handler.ts
+++ b/packages/substream/sink/events/edits-published/handler.ts
@@ -2,12 +2,14 @@ import { Data, Effect } from 'effect';
 import { dedupeWith } from 'effect/ReadonlyArray';
 
 import { mapIpfsProposalToSchemaProposalByType } from '../proposals-created/map-proposals';
-import { CurrentVersions, Proposals, SpaceMetadata } from '~/sink/db';
-import type { BlockEvent, SinkEditProposal } from '~/sink/types';
+import { CurrentVersions, Proposals, SpaceMetadata, Versions } from '~/sink/db';
+import type { BlockEvent, DeleteTripleOp, SetTripleOp, SinkEditProposal } from '~/sink/types';
+import { createVersionId } from '~/sink/utils/id';
 import { retryEffect } from '~/sink/utils/retry-effect';
 import { aggregateNewVersions } from '~/sink/write-edits/aggregate-versions';
+import { mergeOpsWithPreviousVersions } from '~/sink/write-edits/merge-ops-with-previous-versions';
 import { aggregateRelations } from '~/sink/write-edits/relations/aggregate-relations';
-import { aggregateSpacesFromRelations } from '~/sink/write-edits/write-edits';
+import { aggregateSpacesFromRelations, writeEdits } from '~/sink/write-edits/write-edits';
 
 export class ProposalDoesNotExistError extends Error {
   readonly _tag = 'ProposalDoesNotExistError';
@@ -31,7 +33,7 @@ export function handleEditsPublished(ipfsProposals: SinkEditProposal[], createdS
     yield* _(Effect.logInfo('Handling approved edits'));
 
     const {
-      schemaEditProposals: { versions, relationOpsByEditId, edits },
+      schemaEditProposals: { versions, relationOpsByEditId, tripleOpsByVersionId, edits },
     } = mapIpfsProposalToSchemaProposalByType(ipfsProposals, block);
 
     const nonstaleVersions = yield* _(
@@ -78,6 +80,126 @@ export function handleEditsPublished(ipfsProposals: SinkEditProposal[], createdS
         }
       )
     );
+    /**
+     * If multiple proposals are created at different times, there's no guarantee that
+     * they will be executed in the same order they were created except in cases of
+     * early execution being triggered by the contract.
+     *
+     * This can result in states where a proposal that was created before another is
+     * executed last. This would result in the first proposal's versions being the
+     * current versions even though they aren't the most recently created, accepted
+     * version.
+     */
+
+    // Currently we don't solve for above ordering issue.
+
+    /**
+     * Before writing new current versions we should check to see if the active current
+     * version should be applied to the new version. This can happen if the new version
+     * was created before the current version was created, but not executed until after
+     * the current version was executed. When this happens neither of the versions
+     * have data from each other.
+     *
+     * If we encounter versions where the current version is not the new version and
+     * the current version block > new version block then we should run writeEdits
+     * again on the new version and set the result as the current version.
+     *
+     * We should only replace the versions where the above condition applies. We
+     * can just set the current version as normal for versions where it doesn't apply.
+     * This behavior is necessary due to the way the versioning model works. Versions
+     * are created with the entire state of the entity _at the time the version is
+     * created_.
+     */
+
+    const handleStaleCurrentVersions = Effect.forEach(
+      nonstaleVersions,
+      version =>
+        Effect.promise(async () => {
+          const maybeCurrentVersion = await CurrentVersions.selectOne({ entity_id: version.entity_id });
+
+          if (!maybeCurrentVersion) {
+            return null;
+          }
+
+          // Can do a JOIN on current version instead of querying again
+          const currentVersion = await Versions.selectOne({ id: maybeCurrentVersion.version_id });
+
+          if (currentVersion?.entity_id === '5FkVvS4mTz6Ge7wHkAUMRk') {
+            console.log('current version', currentVersion, version);
+          }
+
+          if (!currentVersion) {
+            return null;
+          }
+
+          // Query the DB representation since the mapped version doesn't have the
+          // real created at block
+          const editVersion = await Versions.selectOne({ id: version.id });
+
+          if (!editVersion) {
+            return null;
+          }
+
+          if (currentVersion.created_at_block > editVersion.created_at_block) {
+            const newVersionId = createVersionId({
+              entityId: version.id.toString(),
+              proposalId: version.edit_id.toString(),
+            });
+            const newVersion = {
+              // We create a new version derived from the old version. This new version
+              // will go through the writeEdits processing to create a new version with
+              // data from the current version and the new version.
+              newVersion: {
+                ...version,
+                created_at_block: editVersion.created_at_block,
+                id: newVersionId,
+              },
+              versionIdFromEdit: version.id.toString(),
+              editId: version.edit_id.toString(),
+            };
+
+            return newVersion;
+          }
+
+          return null;
+        }),
+      {
+        concurrency: 25,
+      }
+    );
+
+    const newIdsForStaleCurrentVersions = (yield* _(handleStaleCurrentVersions)).filter(v => v !== null);
+
+    const tripleOpsForNewVersions = newIdsForStaleCurrentVersions.reduce((acc, nv) => {
+      const ops = tripleOpsByVersionId.get(nv.versionIdFromEdit);
+
+      if (ops) {
+        acc.set(nv.newVersion.id, ops);
+      }
+
+      return acc;
+    }, new Map<string, (SetTripleOp | DeleteTripleOp)[]>());
+
+    const newVersions = newIdsForStaleCurrentVersions.map(v => v.newVersion);
+
+    const opsByNewVersions = yield* _(
+      mergeOpsWithPreviousVersions({
+        edits: edits,
+        tripleOpsByVersionId: tripleOpsForNewVersions,
+        versions: newVersions,
+      })
+    );
+
+    yield* _(
+      writeEdits({
+        versions: newVersions,
+        block,
+        editType: 'DEFAULT',
+        edits,
+        tripleOpsByVersionId: opsByNewVersions,
+        relationOpsByEditId,
+      })
+    );
 
     yield* _(
       Effect.tryPromise({
@@ -100,6 +222,29 @@ export function handleEditsPublished(ipfsProposals: SinkEditProposal[], createdS
       retryEffect
     );
 
+    // Update the current version using any new versions created in this handler
+    yield* _(
+      Effect.tryPromise({
+        try: () =>
+          CurrentVersions.upsert(
+            newIdsForStaleCurrentVersions.map(v => {
+              return {
+                entity_id: v.newVersion.entity_id,
+                version_id: v.newVersion.id,
+              };
+            })
+          ),
+        catch: error => {
+          console.error(`Failed to insert current versions. ${(error as Error).message}`);
+          return new CouldNotWriteCurrentVersionsError(
+            `Failed to insert current versions. ${(error as Error).message}`
+          );
+        },
+      }),
+      retryEffect
+    );
+
+    // @TODO: Should this use the potentially merged version?
     const relations = yield* _(
       aggregateRelations({
         relationOpsByEditId,

--- a/packages/substream/sink/events/edits-published/handler.ts
+++ b/packages/substream/sink/events/edits-published/handler.ts
@@ -68,6 +68,7 @@ export function handleEditsPublished(ipfsProposals: SinkEditProposal[], createdS
             Effect.tryPromise({
               try: () => Proposals.setAcceptedById(proposal.proposalId),
               catch: error => {
+                console.error('Could not set proposal to accepted for proposal id', proposal.proposalId);
                 return new ProposalDoesNotExistError(String(error));
               },
             })
@@ -89,8 +90,12 @@ export function handleEditsPublished(ipfsProposals: SinkEditProposal[], createdS
               };
             })
           ),
-        catch: error =>
-          new CouldNotWriteCurrentVersionsError(`Failed to insert current versions. ${(error as Error).message}`),
+        catch: error => {
+          console.error(`Failed to insert current versions. ${(error as Error).message}`);
+          return new CouldNotWriteCurrentVersionsError(
+            `Failed to insert current versions. ${(error as Error).message}`
+          );
+        },
       }),
       retryEffect
     );

--- a/packages/substream/sink/events/proposals-created/map-proposals.ts
+++ b/packages/substream/sink/events/proposals-created/map-proposals.ts
@@ -56,6 +56,8 @@ function mapEditorshipProposalsToSchema(
       id: p.proposalId,
       onchain_proposal_id: p.onchainProposalId,
       plugin_address: p.pluginAddress,
+      name: p.name,
+      created_at: Number(p.startTime),
       type: p.type,
       created_by_id: p.creator,
       start_time: Number(p.startTime),
@@ -110,6 +112,8 @@ function mapMembershipProposalsToSchema(
     const proposalToWrite: S.proposals.Insertable = {
       id: p.proposalId,
       onchain_proposal_id: p.onchainProposalId,
+      created_at: Number(p.startTime),
+      name: p.name,
       plugin_address: p.pluginAddress,
       type: p.type,
       created_by_id: p.creator,
@@ -163,6 +167,8 @@ function mapSubspaceProposalsToSchema(
     const proposalToWrite: S.proposals.Insertable = {
       id: p.proposalId,
       onchain_proposal_id: p.onchainProposalId,
+      created_at: Number(p.startTime),
+      name: p.name,
       plugin_address: p.pluginAddress,
       type: p.type,
       created_by_id: p.creator,
@@ -226,6 +232,8 @@ function mapEditProposalToSchema(
     proposalsToWrite.push({
       id: p.proposalId,
       onchain_proposal_id: p.onchainProposalId,
+      created_at: Number(p.startTime),
+      name: p.name,
       plugin_address: p.pluginAddress,
       type: 'ADD_EDIT',
       created_by_id: p.creator,

--- a/packages/substream/sink/sql/init-public.sql
+++ b/packages/substream/sink/sql/init-public.sql
@@ -54,6 +54,8 @@ CREATE TABLE public.edits (
 
 CREATE TABLE public.proposals (
     id text PRIMARY KEY,
+    name text NOT NULL,
+    created_at integer NOT NULL,
     onchain_proposal_id text NOT NULL,
     plugin_address text NOT NULL,
     space_id text NOT NULL REFERENCES public.spaces(id),

--- a/packages/substream/sink/types.ts
+++ b/packages/substream/sink/types.ts
@@ -3,7 +3,6 @@ import type {
   ChainAddMemberProposal,
   ChainAddSubspaceProposal,
   ChainEditProposal,
-  ChainProposal,
   ChainRemoveEditorProposal,
   ChainRemoveMemberProposal,
   ChainRemoveSubspaceProposal,

--- a/packages/substream/sink/write-edits/write-edits.ts
+++ b/packages/substream/sink/write-edits/write-edits.ts
@@ -155,7 +155,7 @@ export function writeEdits(args: PopulateContentArgs) {
 
     const versionSpacesUnique = dedupeWith(
       versionSpaces,
-      (a, z) => a.space_id.toString() !== z.space_id.toString() && a.version_id.toString() !== z.version_id.toString()
+      (a, z) => a.space_id.toString() === z.space_id.toString() && a.version_id.toString() === z.version_id.toString()
     );
 
     yield* _(

--- a/packages/substream/sink/zapatos/schema.d.ts
+++ b/packages/substream/sink/zapatos/schema.d.ts
@@ -1163,6 +1163,18 @@ declare module 'zapatos/schema' {
       */
       id: string;
       /**
+      * **proposals.name**
+      * - `text` in database
+      * - `NOT NULL`, no default
+      */
+      name: string;
+      /**
+      * **proposals.created_at**
+      * - `int4` in database
+      * - `NOT NULL`, no default
+      */
+      created_at: number;
+      /**
       * **proposals.onchain_proposal_id**
       * - `text` in database
       * - `NOT NULL`, no default
@@ -1224,6 +1236,18 @@ declare module 'zapatos/schema' {
       * - `NOT NULL`, no default
       */
       id: string;
+      /**
+      * **proposals.name**
+      * - `text` in database
+      * - `NOT NULL`, no default
+      */
+      name: string;
+      /**
+      * **proposals.created_at**
+      * - `int4` in database
+      * - `NOT NULL`, no default
+      */
+      created_at: number;
       /**
       * **proposals.onchain_proposal_id**
       * - `text` in database
@@ -1287,6 +1311,18 @@ declare module 'zapatos/schema' {
       */
       id?: string | db.Parameter<string> | db.SQLFragment | db.ParentColumn | db.SQLFragment<any, string | db.Parameter<string> | db.SQLFragment | db.ParentColumn>;
       /**
+      * **proposals.name**
+      * - `text` in database
+      * - `NOT NULL`, no default
+      */
+      name?: string | db.Parameter<string> | db.SQLFragment | db.ParentColumn | db.SQLFragment<any, string | db.Parameter<string> | db.SQLFragment | db.ParentColumn>;
+      /**
+      * **proposals.created_at**
+      * - `int4` in database
+      * - `NOT NULL`, no default
+      */
+      created_at?: number | db.Parameter<number> | db.SQLFragment | db.ParentColumn | db.SQLFragment<any, number | db.Parameter<number> | db.SQLFragment | db.ParentColumn>;
+      /**
       * **proposals.onchain_proposal_id**
       * - `text` in database
       * - `NOT NULL`, no default
@@ -1349,6 +1385,18 @@ declare module 'zapatos/schema' {
       */
       id: string | db.Parameter<string> | db.SQLFragment;
       /**
+      * **proposals.name**
+      * - `text` in database
+      * - `NOT NULL`, no default
+      */
+      name: string | db.Parameter<string> | db.SQLFragment;
+      /**
+      * **proposals.created_at**
+      * - `int4` in database
+      * - `NOT NULL`, no default
+      */
+      created_at: number | db.Parameter<number> | db.SQLFragment;
+      /**
       * **proposals.onchain_proposal_id**
       * - `text` in database
       * - `NOT NULL`, no default
@@ -1410,6 +1458,18 @@ declare module 'zapatos/schema' {
       * - `NOT NULL`, no default
       */
       id?: string | db.Parameter<string> | db.SQLFragment | db.SQLFragment<any, string | db.Parameter<string> | db.SQLFragment>;
+      /**
+      * **proposals.name**
+      * - `text` in database
+      * - `NOT NULL`, no default
+      */
+      name?: string | db.Parameter<string> | db.SQLFragment | db.SQLFragment<any, string | db.Parameter<string> | db.SQLFragment>;
+      /**
+      * **proposals.created_at**
+      * - `int4` in database
+      * - `NOT NULL`, no default
+      */
+      created_at?: number | db.Parameter<number> | db.SQLFragment | db.SQLFragment<any, number | db.Parameter<number> | db.SQLFragment>;
       /**
       * **proposals.onchain_proposal_id**
       * - `text` in database


### PR DESCRIPTION
## Summary

This PR fixes a handful of indexing bugs related to multi-space entities and edit execution order.
- Writing version spaces incorrectly filtered which spaces a version exists in
- Any other edits executed while an edit is waiting to be executed would result in the pending edit not having all of the data from the executed edits