### PR TITLE
fix: only write edits in publish handler if there are fresh versions

### DIFF
--- a/apps/web/core/utils/change/change.ts
+++ b/apps/web/core/utils/change/change.ts
@@ -10,8 +10,6 @@ import { Version } from '~/core/io/dto/versions';
 import { EntityId } from '~/core/io/schema';
 import { fetchEntity } from '~/core/io/subgraph';
 import { fetchEntitiesBatch } from '~/core/io/subgraph/fetch-entities-batch';
-import { fetchVersion } from '~/core/io/subgraph/fetch-version';
-import { fetchVersionsBatch } from '~/core/io/subgraph/fetch-versions-batch';
 import { queryClient } from '~/core/query-client';
 import type { Relation, Triple } from '~/core/types';
 


### PR DESCRIPTION
This can have unintended side-effects of writing data that's already been written or affect versions that have already been frozen.