### PR TITLE
fix: editor hydration

### DIFF
--- a/apps/web/core/blocks/data/use-data-block.tsx
+++ b/apps/web/core/blocks/data/use-data-block.tsx
@@ -46,12 +46,16 @@ export function useDataBlock() {
     id: EntityId(entityId),
   });
 
-  const { filterState, isLoading: isLoadingFilterState } = useFilters();
+  const { filterState, isLoading: isLoadingFilterState, isFetched: isFilterStateFetched } = useFilters();
   const { source } = useSource();
   const { collectionItems } = useCollection();
-  const { shownColumnIds, mapping, isLoading: isViewLoading } = useView();
+  const { shownColumnIds, mapping, isLoading: isViewLoading, isFetched: isViewFetched } = useView();
 
-  const { data: rows, isLoading: isLoadingRenderables } = useQuery({
+  const {
+    data: rows,
+    isLoading: isLoadingRenderables,
+    isFetched: isRenderablesFetched,
+  } = useQuery({
     enabled: filterState !== undefined,
     placeholderData: keepPreviousData,
     // @TODO: Should re-run when the relations for the entity source changes
@@ -195,7 +199,13 @@ export function useDataBlock() {
     // state then back into a loading state. By adding the isFetched state we
     // will stay in a placeholder state until we've fetched our queries at least
     // one time.
-    isLoading: isLoadingRenderables || isLoadingFilterState || isViewLoading,
+    isLoading:
+      isLoadingRenderables ||
+      isLoadingFilterState ||
+      isViewLoading ||
+      !isFilterStateFetched ||
+      !isViewFetched ||
+      !isRenderablesFetched,
     name: blockEntity.name,
     setName,
   };

--- a/apps/web/core/blocks/data/use-data-block.tsx
+++ b/apps/web/core/blocks/data/use-data-block.tsx
@@ -199,6 +199,12 @@ export function useDataBlock() {
     // state then back into a loading state. By adding the isFetched state we
     // will stay in a placeholder state until we've fetched our queries at least
     // one time.
+    //
+    // @NOTE there's an edge-case issue where collection queries respond to the
+    // loading states differently than the other types of queries. If we include
+    // the renderable fetched state collection blocks will jitter between loading
+    // and fetched states. Will fix this in the future, for now just discard the
+    // renderable fetched state for collection blocks.
     isLoading:
       source.type === 'COLLECTION'
         ? isLoadingRenderables || isLoadingFilterState || isViewLoading || !isFilterStateFetched || !isViewFetched

--- a/apps/web/core/blocks/data/use-data-block.tsx
+++ b/apps/web/core/blocks/data/use-data-block.tsx
@@ -46,16 +46,12 @@ export function useDataBlock() {
     id: EntityId(entityId),
   });
 
-  const { filterState, isLoading: isLoadingFilterState, isFetched: isFilterStateFetched } = useFilters();
+  const { filterState, isLoading: isLoadingFilterState } = useFilters();
   const { source } = useSource();
   const { collectionItems } = useCollection();
-  const { shownColumnIds, mapping, isLoading: isViewLoading, isFetched: isViewFetched } = useView();
+  const { shownColumnIds, mapping, isLoading: isViewLoading } = useView();
 
-  const {
-    data: rows,
-    isLoading: isLoadingRenderables,
-    isFetched: isRenderablesFetched,
-  } = useQuery({
+  const { data: rows, isLoading: isLoadingRenderables } = useQuery({
     enabled: filterState !== undefined,
     placeholderData: keepPreviousData,
     // @TODO: Should re-run when the relations for the entity source changes
@@ -199,14 +195,7 @@ export function useDataBlock() {
     // state then back into a loading state. By adding the isFetched state we
     // will stay in a placeholder state until we've fetched our queries at least
     // one time.
-    isLoading:
-      isLoadingRenderables ||
-      isLoadingFilterState ||
-      isViewLoading ||
-      !isFilterStateFetched ||
-      !isRenderablesFetched ||
-      !isViewFetched,
-
+    isLoading: isLoadingRenderables || isLoadingFilterState || isViewLoading,
     name: blockEntity.name,
     setName,
   };

--- a/apps/web/core/blocks/data/use-data-block.tsx
+++ b/apps/web/core/blocks/data/use-data-block.tsx
@@ -200,12 +200,14 @@ export function useDataBlock() {
     // will stay in a placeholder state until we've fetched our queries at least
     // one time.
     isLoading:
-      isLoadingRenderables ||
-      isLoadingFilterState ||
-      isViewLoading ||
-      !isFilterStateFetched ||
-      !isViewFetched ||
-      !isRenderablesFetched,
+      source.type === 'COLLECTION'
+        ? isLoadingRenderables || isLoadingFilterState || isViewLoading || !isFilterStateFetched || !isViewFetched
+        : isLoadingRenderables ||
+          isLoadingFilterState ||
+          isViewLoading ||
+          !isFilterStateFetched ||
+          !isRenderablesFetched ||
+          !isViewFetched,
     name: blockEntity.name,
     setName,
   };

--- a/apps/web/core/state/editor/use-editor.tsx
+++ b/apps/web/core/state/editor/use-editor.tsx
@@ -225,6 +225,7 @@ export function useEditorStore() {
         return {
           ...nodeData,
           attrs: {
+            ...nodeData.attrs,
             id: block.block.id,
             relationId: block.relationId,
             spaceId,

--- a/apps/web/partials/editor/editor.tsx
+++ b/apps/web/partials/editor/editor.tsx
@@ -2,7 +2,6 @@
 
 import { GraphUrl } from '@geogenesis/sdk';
 import { EditorContent, Editor as TiptapEditor, useEditor } from '@tiptap/react';
-import { Hash } from 'effect';
 import { LayoutGroup } from 'framer-motion';
 import { useRouter } from 'next/navigation';
 

--- a/apps/web/partials/editor/editor.tsx
+++ b/apps/web/partials/editor/editor.tsx
@@ -2,6 +2,7 @@
 
 import { GraphUrl } from '@geogenesis/sdk';
 import { EditorContent, Editor as TiptapEditor, useEditor } from '@tiptap/react';
+import { Hash } from 'effect';
 import { LayoutGroup } from 'framer-motion';
 import { useRouter } from 'next/navigation';
 
@@ -37,38 +38,26 @@ export const Editor = React.memo(function Editor({
 
   const extensions = React.useMemo(() => [...tiptapExtensions, createIdExtension(spaceId)], [spaceId]);
 
-  const editor = useEditor({
-    extensions,
-    editable: true,
-    content: editorJson,
-    editorProps: {
-      transformPastedHTML: html => removeIdAttributes(html),
-    },
-    immediatelyRender: false,
-  });
-
   useInterceptEditorLinks(spaceId);
 
-  const onBlur = React.useCallback(
-    (params: { editor: TiptapEditor }) => {
-      // Responsible for converting all editor blocks to triples
-      // Fires after the IdExtension's onBlur event which sets the "id" attribute on all nodes
-      upsertEditorState(params.editor.getJSON());
+  const onBlur = (params: { editor: TiptapEditor }) => {
+    // Responsible for converting all editor blocks to Geo knowledge graph state
+    upsertEditorState(params.editor.getJSON());
+  };
+
+  const editor = useEditor(
+    {
+      extensions,
+      editable: true,
+      content: editorJson,
+      editorProps: {
+        transformPastedHTML: html => removeIdAttributes(html),
+      },
+      immediatelyRender: false,
+      onBlur: onBlur,
     },
-    [upsertEditorState]
+    [editorJson]
   );
-
-  // Running onBlur directly through the hook executes it twice for some reason.
-  // Doing it imperatively here correctly only executes once.
-  React.useEffect(() => {
-    // Tiptap doesn't export the needed type APIs for us to be able to make this typesafe
-    editor?.on('blur', onBlur as unknown as any);
-
-    return () => {
-      // Tiptap doesn't export the needed type APIs for us to be able to make this typesafe
-      editor?.off('blur', onBlur as unknown as any);
-    };
-  }, [onBlur, editor]);
 
   // We are in browse mode and there is no content.
   if (!editable && blockIds.length === 0) {
@@ -94,7 +83,7 @@ export const Editor = React.memo(function Editor({
   return (
     <LayoutGroup id="editor">
       <div className={editable ? 'editable' : 'not-editable'}>
-        {!editor ? <ServerContent content={editorJson.content} /> : <EditorContent editor={editor} />}
+        {editor ? <EditorContent editor={editor} /> : <ServerContent content={editorJson.content} />}
 
         {shouldHandleOwnSpacing && <Spacer height={60} />}
       </div>

--- a/apps/web/partials/editor/server-content.tsx
+++ b/apps/web/partials/editor/server-content.tsx
@@ -1,6 +1,7 @@
 import { Content } from '~/core/state/editor/types';
 
 import { Skeleton } from '~/design-system/skeleton';
+import { Spacer } from '~/design-system/spacer';
 
 import { TableBlockLoadingPlaceholder } from '../blocks/table/table-block';
 
@@ -29,9 +30,9 @@ type BlockProps = {
 };
 
 const Block = ({ block }: BlockProps) => {
-  if (!block.content) {
-    return null;
-  }
+  // if (!block.content) {
+  //   return null;
+  // }
 
   switch (block.type) {
     case 'paragraph': {
@@ -111,6 +112,7 @@ const Block = ({ block }: BlockProps) => {
     case 'tableNode': {
       return (
         <>
+          <Spacer height={24} />
           <div className="space-y-3">
             <div className="flex items-center gap-2">
               <Skeleton className="h-4 w-4" />

--- a/apps/web/partials/navbar/navbar-actions.tsx
+++ b/apps/web/partials/navbar/navbar-actions.tsx
@@ -281,7 +281,7 @@ function AnimatedTogglePill({ controls }: { controls: AnimationControls }) {
       animate={controls}
       variants={variants}
       transition={{
-        duration: 0.15,
+        duration: 0.5,
         type: 'spring',
         bounce: 0,
       }}


### PR DESCRIPTION
This PR fixes a few bugs related to editor hydration. These issues mostly stem from synchronizing Geo state and Tiptap editor state. 

Previously we would store all editor block state as Geo state and let Tiptap handle it's internal state separately. There was a syncing layer between the two, but we would only sync _to_ tiptap on editor load state. This was because in older versions of Tiptap, syncing back to Tiptap for every change in Geo state would cause our custom React Tiptap nodes to re-mount, resulting in loading states for our data blocks. This seems to be resolved now in newer versions of Tiptap.

- We now sync Geo state back to Tiptap for the active editor
- We now correctly spread any Tiptap block attributes for text blocks. This manifested in bugs for our server content state for headings
- Headings now persist with the right level