### PR TITLE
fix: list item bugs

### DIFF
--- a/apps/web/core/state/editor/parser.ts
+++ b/apps/web/core/state/editor/parser.ts
@@ -21,9 +21,22 @@ export function htmlToMarkdown(html: string): string {
   // Convert links
   md = md.replace(/<a href="(.*?)">(.*?)<\/a>/gi, '[$2]($1)');
 
-  // Convert unordered lists
-  md = md.replace(/<ul>(.*?)<\/ul>/gis, match => {
-    return match.replace(/<li>(.*?)<\/li>/gi, '- $1\n');
+  const ulRegex = /<ul[^>]*>([\s\S]*?)<\/ul>/g;
+  const liRegex = /<li[^>]*>([\s\S]*?)<\/li>/g;
+
+  md = md.replace(ulRegex, match => {
+    const listItems = [];
+    let liMatch;
+
+    // Extract text content from <li> tags
+    while ((liMatch = liRegex.exec(match)) !== null) {
+      const cleanedText = liMatch[1]
+        .replace(/<[^>]*>/g, '') // Remove any nested HTML tags
+        .trim();
+      listItems.push(`- ${cleanedText}`);
+    }
+
+    return listItems.join('\n');
   });
 
   // Convert ordered lists

--- a/apps/web/core/state/editor/text-entity.ts
+++ b/apps/web/core/state/editor/text-entity.ts
@@ -22,11 +22,7 @@ export function getTextEntityOps(node: JSONContent): [UpsertNameOp, UpsertMarkdo
   const blockEntityId = getNodeId(node);
   const nodeHTML = getTextNodeHtml(node);
   const entityName = getNodeName(node);
-  let markdown = Parser.htmlToMarkdown(nodeHTML);
-
-  if (node.type === 'bulletList') {
-    markdown = markdown.startsWith('- ') ? markdown : `- ${markdown}`;
-  }
+  const markdown = Parser.htmlToMarkdown(nodeHTML);
 
   return [
     {

--- a/apps/web/partials/editor/extensions.tsx
+++ b/apps/web/partials/editor/extensions.tsx
@@ -44,27 +44,27 @@ export const tiptapExtensions = [
   ParagraphNode,
   HeadingNode,
   ConfiguredCommandExtension,
-  HardBreak.extend({
-    addKeyboardShortcuts() {
-      // Make hard breaks behave like normal paragraphs
-      const handleEnter = () =>
-        this.editor.commands.first(({ commands }) => [
-          () => commands.newlineInCode(),
-          () => commands.createParagraphNear(),
-          () => commands.liftEmptyBlock(),
-          () => commands.splitBlock(),
-        ]);
+  // HardBreak.extend({
+  //   addKeyboardShortcuts() {
+  //     // Make hard breaks behave like normal paragraphs
+  //     const handleEnter = () =>
+  //       this.editor.commands.first(({ commands }) => [
+  //         () => commands.newlineInCode(),
+  //         () => commands.createParagraphNear(),
+  //         () => commands.liftEmptyBlock(),
+  //         () => commands.splitBlock(),
+  //       ]);
 
-      return {
-        // This was intercepting the 'Enter' behavior in `command-list.tsx`
-        // Disabling doesn't seem to make a difference so maybe it was unnecessary?
-        // Enter: handleEnter,
+  //     return {
+  //       // This was intercepting the 'Enter' behavior in `command-list.tsx`
+  //       // Disabling doesn't seem to make a difference so maybe it was unnecessary?
+  //       // Enter: handleEnter,
 
-        'Mod-Enter': handleEnter,
-        'Shift-Enter': handleEnter,
-      };
-    },
-  }),
+  //       'Mod-Enter': handleEnter,
+  //       'Shift-Enter': handleEnter,
+  //     };
+  //   },
+  // }),
   Gapcursor,
   TrailingNode,
   BulletList,

--- a/apps/web/partials/editor/id-extension.tsx
+++ b/apps/web/partials/editor/id-extension.tsx
@@ -2,7 +2,7 @@ import { Extension, findChildren } from '@tiptap/core';
 
 import { ID } from '~/core/id';
 
-const nodeTypes = ['heading', 'list', 'paragraph', 'tableNode', 'image'];
+const nodeTypes = ['heading', 'list', 'paragraph', 'tableNode', 'image', 'bulletList'];
 
 export const createIdExtension = (spaceId: string) => {
   return Extension.create({


### PR DESCRIPTION
This PR fixes a few list item bugs
- we weren't parsing the tiptap representation of list items into markdown list items correctly
- we weren't grouping list items together when they're siblings, but tiptap is. This is due to how hardbreaks interact with the editor. For now I'm disabling hard breaks.
- Tiptap was generating for some reason generates new blocks (entities) for list items