### PR TITLE
feat: default states for new relation blocks

### DIFF
--- a/apps/web/core/blocks/data/use-relations-block.tsx
+++ b/apps/web/core/blocks/data/use-relations-block.tsx
@@ -1,0 +1,32 @@
+import { SYSTEM_IDS } from '@geogenesis/sdk';
+
+import { useEntity } from '~/core/database/entities';
+import { EntityId } from '~/core/io/schema';
+import { Relation } from '~/core/types';
+
+import { Filter } from './filters';
+import { useFilters } from './use-filters';
+import { useSource } from './use-source';
+
+export function useRelationsBlock() {
+  const { source } = useSource();
+  const { filterState } = useFilters();
+
+  const relationBlockSourceEntity = useEntity({
+    id: source.type === 'RELATIONS' ? EntityId(source.value) : EntityId(''),
+  });
+
+  const relationBlockSourceRelations = getRelevantRelationsForRelationBlock(
+    relationBlockSourceEntity.relationsOut,
+    filterState
+  );
+
+  return { relationBlockSourceRelations };
+}
+
+function getRelevantRelationsForRelationBlock(relations: Relation[], filterState: Filter[]) {
+  const maybeFilter = filterState.find(f => f.columnId === SYSTEM_IDS.RELATION_TYPE_ATTRIBUTE);
+  const relationType = maybeFilter?.value;
+
+  return relations.filter(r => r.typeOf.id === relationType);
+}

--- a/apps/web/core/blocks/data/use-source.ts
+++ b/apps/web/core/blocks/data/use-source.ts
@@ -1,7 +1,5 @@
 import { SYSTEM_IDS } from '@geogenesis/sdk';
 
-import * as React from 'react';
-
 import { useEntity } from '~/core/database/entities';
 import { upsert } from '~/core/database/write';
 import { EntityId, SpaceId } from '~/core/io/schema';

--- a/apps/web/core/blocks/data/use-source.ts
+++ b/apps/web/core/blocks/data/use-source.ts
@@ -42,8 +42,11 @@ export function useSource() {
     upsertSourceType({ source: newSource, blockId: EntityId(entityId), spaceId: SpaceId(spaceId) });
 
     if (newSource.type === 'RELATIONS') {
+      const maybeExistingRelationType = filterState.filter(f => f.columnId === SYSTEM_IDS.RELATION_TYPE_ATTRIBUTE);
+
       setFilterState(
         [
+          ...maybeExistingRelationType,
           {
             columnId: SYSTEM_IDS.RELATION_FROM_ATTRIBUTE,
             valueType: 'RELATION',

--- a/apps/web/core/blocks/data/use-source.ts
+++ b/apps/web/core/blocks/data/use-source.ts
@@ -3,7 +3,9 @@ import { SYSTEM_IDS } from '@geogenesis/sdk';
 import * as React from 'react';
 
 import { useEntity } from '~/core/database/entities';
+import { upsert } from '~/core/database/write';
 import { EntityId, SpaceId } from '~/core/io/schema';
+import { useEntityPageStore } from '~/core/state/entity-page-store/entity-store';
 
 import { Source, getSource, removeSourceType, upsertSourceType } from './source';
 import { useDataBlockInstance } from './use-data-block';
@@ -11,72 +13,81 @@ import { useFilters } from './use-filters';
 
 export function useSource() {
   const { entityId, spaceId } = useDataBlockInstance();
+  const { name: fromEntityName } = useEntityPageStore();
 
   const blockEntity = useEntity({
-    spaceId: React.useMemo(() => SpaceId(spaceId), [spaceId]),
-    id: React.useMemo(() => EntityId(entityId), [entityId]),
+    spaceId: SpaceId(spaceId),
+    id: EntityId(entityId),
   });
 
   const { filterState, setFilterState } = useFilters();
 
-  const source: Source = React.useMemo(() => {
-    return getSource({
-      blockId: blockEntity.id,
-      dataEntityRelations: blockEntity.relationsOut,
-      currentSpaceId: SpaceId(spaceId),
-      filterState,
+  const source: Source = getSource({
+    blockId: blockEntity.id,
+    dataEntityRelations: blockEntity.relationsOut,
+    currentSpaceId: SpaceId(spaceId),
+    filterState,
+  });
+
+  const setSource = (newSource: Source) => {
+    // We have three source types
+    // 1. Collection
+    // 2. Query
+    // For each source type we need to change the source type
+    // For `spaces` we need to update the filter string by setting the new
+    // filter state
+    removeSourceType({
+      relations: blockEntity.relationsOut,
+      spaceId: SpaceId(spaceId),
+      entityId: EntityId(entityId),
     });
-  }, [blockEntity.id, blockEntity.relationsOut, spaceId, filterState]);
+    upsertSourceType({ source: newSource, blockId: EntityId(entityId), spaceId: SpaceId(spaceId) });
 
-  const setSource = React.useCallback(
-    (newSource: Source) => {
-      // We have three source types
-      // 1. Collection
-      // 2. Query
-      // For each source type we need to change the source type
-      // For `spaces` we need to update the filter string by setting the new
-      // filter state
-      removeSourceType({
-        relations: blockEntity.relationsOut,
-        spaceId: SpaceId(spaceId),
-        entityId: EntityId(entityId),
-      });
-      upsertSourceType({ source: newSource, blockId: EntityId(entityId), spaceId: SpaceId(spaceId) });
+    if (newSource.type === 'RELATIONS') {
+      setFilterState(
+        [
+          {
+            columnId: SYSTEM_IDS.RELATION_FROM_ATTRIBUTE,
+            valueType: 'RELATION',
+            value: newSource.value,
+            valueName: newSource.name,
+          },
+        ],
+        newSource
+      );
 
-      if (newSource.type === 'RELATIONS') {
-        setFilterState(
-          [
-            {
-              columnId: SYSTEM_IDS.RELATION_FROM_ATTRIBUTE,
-              valueType: 'RELATION',
-              value: newSource.value,
-              valueName: newSource.name,
-            },
-          ],
-          newSource
+      if (fromEntityName) {
+        upsert(
+          {
+            attributeId: SYSTEM_IDS.NAME_ATTRIBUTE,
+            entityId: entityId,
+            entityName: fromEntityName,
+            attributeName: 'Name',
+            value: { type: 'TEXT', value: fromEntityName },
+          },
+          spaceId
         );
       }
+    }
 
-      if (newSource.type === 'SPACES') {
-        // We only allow one space filter at a time currently, so remove any existing space filters before
-        // adding the new one.
-        const filtersWithoutSpaces = filterState?.filter(f => f.columnId !== SYSTEM_IDS.SPACE_FILTER) ?? [];
+    if (newSource.type === 'SPACES') {
+      // We only allow one space filter at a time currently, so remove any existing space filters before
+      // adding the new one.
+      const filtersWithoutSpaces = filterState?.filter(f => f.columnId !== SYSTEM_IDS.SPACE_FILTER) ?? [];
 
-        setFilterState(
-          [
-            ...filtersWithoutSpaces,
-            { columnId: SYSTEM_IDS.SPACE_FILTER, valueType: 'RELATION', value: newSource.value[0], valueName: null },
-          ],
-          newSource
-        );
-      }
+      setFilterState(
+        [
+          ...filtersWithoutSpaces,
+          { columnId: SYSTEM_IDS.SPACE_FILTER, valueType: 'RELATION', value: newSource.value[0], valueName: null },
+        ],
+        newSource
+      );
+    }
 
-      if (newSource.type === 'GEO') {
-        setFilterState([], newSource);
-      }
-    },
-    [entityId, blockEntity.relationsOut, spaceId, setFilterState, filterState]
-  );
+    if (newSource.type === 'GEO') {
+      setFilterState([], newSource);
+    }
+  };
 
   return {
     source,

--- a/apps/web/partials/blocks/table/table-block-filter-creation-prompt.tsx
+++ b/apps/web/partials/blocks/table/table-block-filter-creation-prompt.tsx
@@ -12,6 +12,7 @@ import { useDebouncedValue } from '~/core/hooks/use-debounced-value';
 import { useSearch } from '~/core/hooks/use-search';
 import { useSpaces } from '~/core/hooks/use-spaces';
 import { Space } from '~/core/io/dto/spaces';
+import { useEntityPageStore } from '~/core/state/entity-page-store/entity-store';
 import { FilterableValueType } from '~/core/value-types';
 
 import { ResultContent, ResultsList } from '~/design-system/autocomplete/results-list';
@@ -180,7 +181,7 @@ function getInitialState(source: Source): PromptState {
       selectedColumn: SYSTEM_IDS.RELATION_TYPE_ATTRIBUTE,
       value: {
         type: 'entity',
-        entityId: '',
+        entityId: source.value,
         entityName: null,
       },
       open: false,
@@ -236,6 +237,7 @@ function ToggleQueryMode({ queryMode, setQueryMode, localSource }: ToggleQueryMo
 }
 
 export function TableBlockFilterPrompt({ trigger, onCreate, options }: TableBlockFilterPromptProps) {
+  const { id: fromId, name: fromName } = useEntityPageStore();
   const { source } = useSource();
   const { filterState } = useFilters();
   const [state, dispatch] = React.useReducer(reducer, getInitialState(source));
@@ -243,7 +245,11 @@ export function TableBlockFilterPrompt({ trigger, onCreate, options }: TableBloc
     source.type === 'RELATIONS' ? 'RELATIONS' : 'ENTITIES'
   );
 
-  const [from, setFrom] = React.useState<Source | null>(source);
+  const [from, setFrom] = React.useState<Source | null>({
+    type: 'RELATIONS',
+    name: fromName,
+    value: fromId,
+  });
   const [relationType, setRelationType] = React.useState<Filter | null>(
     filterState.find(f => f.columnId === SYSTEM_IDS.RELATION_TYPE_ATTRIBUTE) ?? null
   );
@@ -445,7 +451,7 @@ function StaticRelationsFilters({ from, relationType, setFrom, setRelationType }
           <p className="flex h-9 min-w-28 items-center justify-start rounded bg-divider px-3 text-button">From</p>
           <TableBlockEntityFilterInput
             onSelect={onSetSource}
-            selectedValue={from?.type === 'RELATIONS' ? from?.name ?? '' : ''}
+            selectedValue={from?.type === 'RELATIONS' ? (from?.name ?? '') : ''}
           />
         </div>
       </div>


### PR DESCRIPTION
This PR adds some default states for new relation blocks
- Set the block name to the `from` entity
- Set the `from` entity in the relation to the current page entity
- Fixes local state to re-render when there's a new relation