### PR TITLE
feat: use normal filters for relation blocks

### DIFF
--- a/apps/web/core/blocks/data/source.ts
+++ b/apps/web/core/blocks/data/source.ts
@@ -187,6 +187,7 @@ export function makeRelationForSourceType(
     Match.when('COLLECTION', () => SYSTEM_IDS.COLLECTION_DATA_SOURCE),
     Match.when('SPACES', () => SYSTEM_IDS.QUERY_DATA_SOURCE),
     Match.when('GEO', () => SYSTEM_IDS.ALL_OF_GEO_DATA_SOURCE),
+    Match.when('RELATIONS', () => SYSTEM_IDS.ALL_OF_GEO_DATA_SOURCE),
     Match.orElse(() => SYSTEM_IDS.COLLECTION_DATA_SOURCE)
   );
 

--- a/apps/web/core/blocks/data/use-filters.ts
+++ b/apps/web/core/blocks/data/use-filters.ts
@@ -16,8 +16,8 @@ export function useFilters() {
   const { entityId, spaceId } = useDataBlockInstance();
 
   const blockEntity = useEntity({
-    spaceId: React.useMemo(() => SpaceId(spaceId), [spaceId]),
-    id: React.useMemo(() => EntityId(entityId), [entityId]),
+    spaceId: SpaceId(spaceId),
+    id: EntityId(entityId),
   });
 
   const filterTriple = React.useMemo(() => {

--- a/apps/web/partials/blocks/table/table-block-filter-creation-prompt.tsx
+++ b/apps/web/partials/blocks/table/table-block-filter-creation-prompt.tsx
@@ -408,7 +408,7 @@ function StaticRelationsFilters({ from, relationType, setFrom, setRelationType }
       valueType: 'RELATION',
     });
 
-    const withoutRelationType = filterState.filter(f => f.columnId === SYSTEM_IDS.RELATION_TYPE_ATTRIBUTE);
+    const withoutRelationType = filterState.filter(f => f.columnId !== SYSTEM_IDS.RELATION_TYPE_ATTRIBUTE);
 
     setFilterState(
       [

--- a/apps/web/partials/blocks/table/table-block-table.tsx
+++ b/apps/web/partials/blocks/table/table-block-table.tsx
@@ -417,8 +417,6 @@ export const TableBlockTable = React.memo(
                   c.slotId !== SYSTEM_IDS.DESCRIPTION_ATTRIBUTE
               );
 
-              console.log('otherPropertyData', otherPropertyData);
-
               return (
                 <div key={index}>
                   <Link href={href} className="group flex w-full max-w-full items-start justify-start gap-6 pr-6">


### PR DESCRIPTION
Previously we stored the `From` relation in a special `entity` property on the block filter. We now store it as a normal `AND` filter. If we encounter a `From` filter in the app we treat it as a relations block instead of a query block.

This enables us to treat the filter storage the same for regular queries as we do relation queries. Also enables us to use `To` as a potential filter in the future and build special views for it.