### PR TITLE
feat: seo title for relations

### DIFF
--- a/apps/web/app/space/(entity)/[id]/[entityId]/layout.tsx
+++ b/apps/web/app/space/(entity)/[id]/[entityId]/layout.tsx
@@ -60,7 +60,7 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
       ]);
 
       if (maybeFromEntity && maybeToEntity) {
-        name = `${maybeFromEntity.name} → ${maybeToEntity.name}`;
+        name = `${maybeFromEntity.name ?? maybeFromEntity.id} → ${maybeToEntity.name ?? maybeToEntity.id}`;
       }
     }
   }

--- a/apps/web/app/space/(entity)/[id]/[entityId]/layout.tsx
+++ b/apps/web/app/space/(entity)/[id]/[entityId]/layout.tsx
@@ -65,13 +65,13 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
 
   const entity = await cachedFetchEntity(entityId);
   const { entityName, description, openGraphImageUrl } = getOpenGraphMetadataForEntity(entity);
-  const name = (await getTitleForRelation(entity)) ?? entityName;
+  const title = (await getTitleForRelation(entity)) ?? entityName ?? 'New entity';
 
   return {
-    title: name ?? 'New entity',
+    title,
     description,
     openGraph: {
-      title: name ?? 'New entity',
+      title,
       description: description ?? undefined,
       url: `https://geobrowser.io${NavUtils.toEntity(spaceId, entityId)}`,
       images: openGraphImageUrl

--- a/apps/web/app/space/(entity)/[id]/[entityId]/layout.tsx
+++ b/apps/web/app/space/(entity)/[id]/[entityId]/layout.tsx
@@ -31,17 +31,7 @@ interface Props {
   children: React.ReactNode;
 }
 
-export async function generateMetadata(props: Props): Promise<Metadata> {
-  const params = await props.params;
-  const spaceId = params.id;
-  const entityId = params.entityId;
-
-  const entity = await cachedFetchEntity(entityId);
-
-  const { entityName, description, openGraphImageUrl } = getOpenGraphMetadataForEntity(entity);
-
-  let name = entityName;
-
+async function getTitleForRelation(entity: Entity | null): Promise<string | null> {
   const maybeRelation = entity?.triples.find(t => t.attributeId === SYSTEM_IDS.TYPES_ATTRIBUTE);
   const maybeType = maybeRelation?.value.value;
 
@@ -60,10 +50,22 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
       ]);
 
       if (maybeFromEntity && maybeToEntity) {
-        name = `${maybeFromEntity.name ?? maybeFromEntity.id} → ${maybeToEntity.name ?? maybeToEntity.id}`;
+        return `${maybeFromEntity.name ?? maybeFromEntity.id} → ${maybeToEntity.name ?? maybeToEntity.id}`;
       }
     }
   }
+
+  return null;
+}
+
+export async function generateMetadata(props: Props): Promise<Metadata> {
+  const params = await props.params;
+  const spaceId = params.id;
+  const entityId = params.entityId;
+
+  const entity = await cachedFetchEntity(entityId);
+  const { entityName, description, openGraphImageUrl } = getOpenGraphMetadataForEntity(entity);
+  const name = (await getTitleForRelation(entity)) ?? entityName;
 
   return {
     title: name ?? 'New entity',


### PR DESCRIPTION
Changes the title for relation entities to `[From entity name] -> [To entity name]`. Falls back to the entity id if it does not have a name.