### PR TITLE
fix: set non-existent block content to empty

### DIFF
--- a/apps/web/partials/editor/server-content.tsx
+++ b/apps/web/partials/editor/server-content.tsx
@@ -30,9 +30,15 @@ type BlockProps = {
 };
 
 const Block = ({ block }: BlockProps) => {
-  // if (!block.content) {
-  //   return null;
-  // }
+  /**
+   * If a paragraph block is empty the editor might not store the content
+   * array on the block. This can cause errors in here since we expect the
+   * content array to exist. If the content does not exist we set it here
+   * to an empty array.
+   */
+  if (!block.content) {
+    block.content = [];
+  }
 
   switch (block.type) {
     case 'paragraph': {


### PR DESCRIPTION
If a paragraph block is empty the editor might not store the content array on the block. This can cause errors in our server content renderer. If the content does not exist we set it on the server to an empty array.