### PR TITLE
fix: only include new triples in version spaces

### DIFF
--- a/packages/substream/sink/write-edits/write-edits.ts
+++ b/packages/substream/sink/write-edits/write-edits.ts
@@ -127,7 +127,7 @@ export function writeEdits(args: PopulateContentArgs) {
       } satisfies Schema.versions.Insertable);
 
       // Later we dedupe after applying space versions derived from relations
-      for (const triple of triplesForVersion) {
+      for (const triple of setTriples) {
         versionSpaces.push({
           version_id: triple.triple.version_id,
           space_id: triple.triple.space_id,


### PR DESCRIPTION
This PR fixes a bug where we were including deleted triples as a data source for version spaces.