### PR TITLE
feat: limit single block read time to 5 minutes

### DIFF
--- a/packages/substream/sink/run-stream.ts
+++ b/packages/substream/sink/run-stream.ts
@@ -186,7 +186,7 @@ export function runStream({ startBlockNumber, shouldUseCursor }: StreamConfig) {
             const error = result.left;
 
             if (error._tag === 'TimeoutException') {
-              yield* _(Effect.logError('[BLOCK] Timed out after 3 seconds'));
+              yield* _(Effect.logError('[BLOCK] Timed out after 5 minutes'));
               return;
             }
 

--- a/packages/substream/sink/run-stream.ts
+++ b/packages/substream/sink/run-stream.ts
@@ -169,6 +169,7 @@ export function runStream({ startBlockNumber, shouldUseCursor }: StreamConfig) {
               withRequestId(requestId),
               Logger.withMinimumLogLevel(logLevel),
               Effect.provide(LoggerLive),
+              // Limit the maximum time a block takes to index to 5 minutes
               Effect.timeout(Duration.minutes(5))
             ),
             Effect.either


### PR DESCRIPTION
This PR adds a time-limit to a single block index operation to 5 minutes.