### PR TITLE
fix: reactive changes to editable title

### DIFF
--- a/apps/web/core/database/relations.ts
+++ b/apps/web/core/database/relations.ts
@@ -7,7 +7,6 @@ import { atomFamily, selectAtom } from 'jotai/utils';
 import * as React from 'react';
 
 import { store } from '../state/jotai-store';
-import { useQueryEntity } from '../sync/use-store';
 import { Relation } from '../types';
 import { createRelationsAtom } from './atoms';
 

--- a/apps/web/core/events/edit-events.ts
+++ b/apps/web/core/events/edit-events.ts
@@ -9,7 +9,6 @@ import {
   BaseRelationRenderableProperty,
   ImageRelationRenderableProperty,
   OmitStrict,
-  Relation,
   RenderableEntityType,
   RenderableProperty,
   TripleRenderableProperty,

--- a/apps/web/core/hooks/use-debounced-value.ts
+++ b/apps/web/core/hooks/use-debounced-value.ts
@@ -26,7 +26,16 @@ const debounce = <T extends (...args: any[]) => any>(fn: T, delay: number) => {
   };
 };
 
-export function useDebouncedValueWithSideEffect<T>({
+/**
+ * Keeps a local version of the initial value. This local version
+ * is updated optimistically. Accepts a callback that executes
+ * with a debounced delay.
+ *
+ * One common usecase is to keep local state for an input. After
+ * a debounced delay this local state is synced with an external
+ * store like the Geo KG.
+ */
+export function useOptimisticValueWithSideEffect<T>({
   callback,
   delay,
   initialValue,

--- a/apps/web/core/hooks/use-debounced-value.ts
+++ b/apps/web/core/hooks/use-debounced-value.ts
@@ -3,7 +3,7 @@
 import * as React from 'react';
 
 export function useDebouncedValue<T>(value: T, delay = 200): T {
-  const [debouncedValue, setDebouncedValue] = React.useState<T>(value);
+  const [debouncedValue, setDebouncedValue] = React.useState(value);
 
   React.useEffect(() => {
     const timer = setTimeout(() => setDebouncedValue(value), delay);
@@ -14,4 +14,41 @@ export function useDebouncedValue<T>(value: T, delay = 200): T {
   }, [value, delay]);
 
   return debouncedValue;
+}
+
+const debounce = <T extends (...args: any[]) => any>(fn: T, delay: number) => {
+  let timer: number | null = null;
+
+  return (...args: Parameters<T>) => {
+    if (timer) clearTimeout(timer);
+    // @ts-expect-error incorrect type
+    timer = setTimeout(() => fn(...args), delay);
+  };
+};
+
+export function useDebouncedValueWithSideEffect<T>({
+  callback,
+  delay,
+  initialValue,
+}: {
+  callback: (value: T) => void;
+  delay: number;
+  initialValue: T;
+}) {
+  const [value, setValue] = React.useState(initialValue);
+
+  const debouncedCallback = debounce((value: T) => {
+    callback(value);
+  }, delay);
+
+  const onChange = (newValue: T) => {
+    setValue(newValue);
+    debouncedCallback(newValue);
+  };
+
+  React.useEffect(() => {
+    setValue(initialValue);
+  }, [initialValue]);
+
+  return { value, onChange };
 }

--- a/apps/web/core/io/subgraph/fetch-history-versions.ts
+++ b/apps/web/core/io/subgraph/fetch-history-versions.ts
@@ -16,9 +16,7 @@ interface FetchVersionsArgs {
   signal?: AbortSignal;
 }
 
-const PAGE_SIZE = 5;
-
-const query = (entityId: string, page = 0) => {
+const query = (entityId: string) => {
   return `query {
     versions(filter: { entityId: {equalTo: ${JSON.stringify(entityId)}}} orderBy: CREATED_AT_DESC) {
       nodes {

--- a/apps/web/design-system/editable-fields/editable-fields.tsx
+++ b/apps/web/design-system/editable-fields/editable-fields.tsx
@@ -3,8 +3,9 @@ import Zoom from 'react-medium-image-zoom';
 import Textarea from 'react-textarea-autosize';
 
 import * as React from 'react';
-import { ChangeEvent, useEffect, useRef } from 'react';
+import { ChangeEvent, useRef } from 'react';
 
+import { useOptimisticValueWithSideEffect } from '~/core/hooks/use-debounced-value';
 import { useEffectOnce } from '~/core/hooks/use-effect-once';
 import { Services } from '~/core/services';
 import { getImagePath } from '~/core/utils/utils';
@@ -35,16 +36,6 @@ const textareaStyles = cva(
   }
 );
 
-export const debounce = <T extends (...args: any[]) => any>(fn: T, delay: number) => {
-  let timer: number | null = null;
-
-  return (...args: Parameters<T>) => {
-    if (timer) clearTimeout(timer);
-    // @ts-expect-error incorrect type
-    timer = setTimeout(() => fn(...args), delay);
-  };
-};
-
 interface TableStringFieldProps {
   onChange: (value: string) => void;
   placeholder?: string;
@@ -52,29 +43,16 @@ interface TableStringFieldProps {
 }
 
 export function TableStringField({ ...props }: TableStringFieldProps) {
-  const [localValue, setLocalValue] = React.useState(props.value || '');
-  const { onChange } = props;
-
-  // Apply debounce effect
-  const debouncedCallback = debounce((value: string) => {
-    onChange(value);
-  }, 1000);
-
-  // Handle input changes
-  const handleChange = (value: string) => {
-    setLocalValue(value);
-    debouncedCallback(value);
-  };
-
-  useEffect(() => {
-    // Update local value if value prop changes from outside the component
-    setLocalValue(props.value || '');
-  }, [props.value]);
+  const { value: localValue, onChange: setLocalValue } = useOptimisticValueWithSideEffect({
+    callback: props.onChange,
+    delay: 1000,
+    initialValue: props.value || '',
+  });
 
   return (
     <Textarea
       {...props}
-      onChange={e => handleChange(e.currentTarget.value)}
+      onChange={e => setLocalValue(e.currentTarget.value)}
       value={localValue}
       className={textareaStyles({ variant: 'tableCell' })}
     />
@@ -89,38 +67,28 @@ type PageStringFieldProps = {
 };
 
 export function PageStringField({ ...props }: PageStringFieldProps) {
-  const [localValue, setLocalValue] = React.useState(() => props.value || '');
-  const { onChange } = props;
-
-  useEffect(() => {
-    // Update local value if value prop changes from outside the component
-    setLocalValue(props.value || '');
-  }, [props.value]);
-
-  // Apply debounce effect
-  const debouncedCallback = debounce((value: string) => {
-    onChange(value);
-  }, 1000);
-
-  // Handle input changes
-  const handleChange = (value: string) => {
-    setLocalValue(value);
-    debouncedCallback(value);
-  };
+  const { value: localValue, onChange: setLocalValue } = useOptimisticValueWithSideEffect({
+    callback: props.onChange,
+    delay: 1000,
+    initialValue: props.value || '',
+  });
 
   return (
     <Textarea
       {...props}
       value={localValue}
-      onChange={e => handleChange(e.currentTarget.value)}
+      onChange={e => setLocalValue(e.currentTarget.value)}
       className={textareaStyles({ variant: props.variant })}
     />
   );
 }
 
 export function FocusedStringField({ ...props }: PageStringFieldProps) {
-  const [localValue, setLocalValue] = React.useState(() => props.value || '');
-  const { onChange } = props;
+  const { value: localValue, onChange: setLocalValue } = useOptimisticValueWithSideEffect({
+    callback: props.onChange,
+    delay: 1000,
+    initialValue: props.value || '',
+  });
 
   const ref = useRef<HTMLTextAreaElement>(null!);
 
@@ -132,28 +100,12 @@ export function FocusedStringField({ ...props }: PageStringFieldProps) {
     }, 200);
   });
 
-  useEffect(() => {
-    // Update local value if value prop changes from outside the component
-    setLocalValue(props.value || '');
-  }, [props.value]);
-
-  // Apply debounce effect
-  const debouncedCallback = debounce((value: string) => {
-    onChange(value);
-  }, 1000);
-
-  // Handle input changes
-  const handleChange = (value: string) => {
-    setLocalValue(value);
-    debouncedCallback(value);
-  };
-
   return (
     <Textarea
       {...props}
       ref={ref}
       value={localValue}
-      onChange={e => handleChange(e.currentTarget.value)}
+      onChange={e => setLocalValue(e.currentTarget.value)}
       className={textareaStyles({ variant: props.variant })}
     />
   );

--- a/apps/web/design-system/editable-fields/editable-fields.tsx
+++ b/apps/web/design-system/editable-fields/editable-fields.tsx
@@ -35,7 +35,7 @@ const textareaStyles = cva(
   }
 );
 
-const debounce = <T extends (...args: any[]) => any>(fn: T, delay: number) => {
+export const debounce = <T extends (...args: any[]) => any>(fn: T, delay: number) => {
   let timer: number | null = null;
 
   return (...args: Parameters<T>) => {

--- a/apps/web/partials/blocks/table/editable-title.tsx
+++ b/apps/web/partials/blocks/table/editable-title.tsx
@@ -8,7 +8,7 @@ import { useRef, useState } from 'react';
 import { useDataBlock } from '~/core/blocks/data/use-data-block';
 import type { DataBlockView } from '~/core/blocks/data/use-view';
 import { removeRelation, useWriteOps } from '~/core/database/write';
-import { useDebouncedValueWithSideEffect } from '~/core/hooks/use-debounced-value';
+import { useOptimisticValueWithSideEffect } from '~/core/hooks/use-debounced-value';
 import { useOnClickOutside } from '~/core/hooks/use-on-click-outside';
 import { useSpace } from '~/core/hooks/use-space';
 import { EntityId } from '~/core/io/schema';
@@ -56,7 +56,7 @@ export const EditableTitle = ({
   onChangeEntry,
   onLinkEntry,
 }: EditableTitleProps) => {
-  const { value: newName, onChange: setNewName } = useDebouncedValueWithSideEffect({
+  const { value: newName, onChange: setNewName } = useOptimisticValueWithSideEffect({
     callback: value => {
       onChangeEntry(
         {

--- a/apps/web/partials/blocks/table/editable-title.tsx
+++ b/apps/web/partials/blocks/table/editable-title.tsx
@@ -88,7 +88,6 @@ export const EditableTitle = ({
     initialValue: name ?? '',
   });
 
-  // const [newName, setNewName] = useState<string>(() => name ?? '');
   const [isEditingTitle, setIsEditingTitle] = useState<boolean>(false);
   const [isHovered, setIsHovered] = useState<boolean>(false);
   const [isPopoverOpen, setIsPopoverOpen] = useState<boolean>(false);

--- a/apps/web/partials/blocks/table/editable-title.tsx
+++ b/apps/web/partials/blocks/table/editable-title.tsx
@@ -146,7 +146,7 @@ export const EditableTitle = ({
                 href={href}
                 className={cx(
                   'truncate',
-                  view === 'TABLE' && 'text-tableCell text-ctaHover',
+                  view === 'TABLE' && 'text-tableCell text-ctaHover hover:underline',
                   view === 'LIST' && 'text-smallTitle font-medium text-text',
                   view === 'GALLERY' && 'text-smallTitle font-medium text-text'
                 )}


### PR DESCRIPTION
We weren't updating the editable title state whenever any changes to the entity were triggered from outside of the editable title.

Since the knowledge graph is highly reactive it's common for an entity to be rendered multiple times on the same page. If this entity is changed anywhere it should be reflected reactively everywhere.