### PR TITLE
fix: more fetch logs + fix space decoding errors

### DIFF
--- a/apps/web/core/hooks/use-spaces-query.ts
+++ b/apps/web/core/hooks/use-spaces-query.ts
@@ -106,7 +106,7 @@ export function useSpacesQuery() {
           return null;
         },
         onRight: space => {
-          return SpaceMetadataDto(space.id, space.spacesMetadatum.version);
+          return SpaceMetadataDto(space.id, space.spacesMetadatum?.version);
         },
       });
     })

--- a/apps/web/core/io/dto/search.ts
+++ b/apps/web/core/io/dto/search.ts
@@ -11,7 +11,7 @@ export type SearchResult = {
 
 export function SearchResultDto(result: SubstreamSearchResult): SearchResult {
   const spaces = result.currentVersion.version.versionSpaces.nodes.flatMap(result =>
-    SpaceMetadataDto(result.space.id, result.space.spacesMetadatum.version)
+    SpaceMetadataDto(result.space.id, result.space.spacesMetadatum?.version)
   );
 
   return {

--- a/apps/web/core/io/dto/spaces.ts
+++ b/apps/web/core/io/dto/spaces.ts
@@ -26,7 +26,7 @@ export type SpaceConfigEntity = Entity & {
 };
 
 export function SpaceDto(space: SubstreamSpace): Space {
-  const spaceConfigEntity = SpaceMetadataDto(space.id, space.spacesMetadatum.version);
+  const spaceConfigEntity = SpaceMetadataDto(space.id, space.spacesMetadatum?.version);
 
   return {
     id: space.id,

--- a/apps/web/core/io/dto/subspaces.ts
+++ b/apps/web/core/io/dto/subspaces.ts
@@ -10,7 +10,7 @@ export type Subspace = {
 };
 
 export function SubspaceDto(subspace: SubstreamSubspace) {
-  const spaceConfigWithImage = SpaceMetadataDto(subspace.id, subspace.spacesMetadatum.version);
+  const spaceConfigWithImage = SpaceMetadataDto(subspace.id, subspace.spacesMetadatum?.version);
 
   return {
     id: subspace.id,

--- a/apps/web/core/io/schema.ts
+++ b/apps/web/core/io/schema.ts
@@ -384,9 +384,11 @@ export type SubstreamEntityHistorical = Schema.Schema.Type<typeof SubstreamEntit
 export const SubstreamSpace = Schema.extend(
   SubstreamSpaceWithoutMetadata,
   Schema.Struct({
-    spacesMetadatum: Schema.Struct({
-      version: SubstreamVersion,
-    }),
+    spacesMetadatum: Schema.NullOr(
+      Schema.Struct({
+        version: SubstreamVersion,
+      })
+    ),
   })
 );
 
@@ -406,9 +408,11 @@ export const SubstreamSubspace = Schema.extend(
     spaceMembers: Schema.Struct({
       totalCount: Schema.Number,
     }),
-    spacesMetadatum: Schema.Struct({
-      version: SubstreamVersion,
-    }),
+    spacesMetadatum: Schema.NullOr(
+      Schema.Struct({
+        version: SubstreamVersion,
+      })
+    ),
   })
 );
 
@@ -461,9 +465,11 @@ export type SubstreamVote = Schema.Schema.Type<typeof SubstreamVote>;
 
 export const SubstreamSpaceEntityConfig = Schema.Struct({
   id: Schema.String.pipe(Schema.fromBrand(SpaceId)),
-  spacesMetadatum: Schema.Struct({
-    version: SubstreamVersion,
-  }),
+  spacesMetadatum: Schema.NullOr(
+    Schema.Struct({
+      version: SubstreamVersion,
+    })
+  ),
 });
 
 export type SubstreamSpaceConfigEntityConfig = Schema.Schema.Type<typeof SubstreamSpaceEntityConfig>;

--- a/apps/web/core/io/subgraph/fetch-history-version.ts
+++ b/apps/web/core/io/subgraph/fetch-history-version.ts
@@ -92,7 +92,7 @@ export async function fetchHistoryVersion(args: FetchVersionsArgs) {
   return Either.match(decoded, {
     onLeft: error => {
       console.error(
-        `Could not decode version with id ${networkVersion.id} and entityId ${networkVersion.entityId}. ${String(
+        `FetchHistoryVersion: Could not decode version with id ${networkVersion.id} and entityId ${networkVersion.entityId}. ${String(
           error
         )}`
       );

--- a/apps/web/core/io/subgraph/fetch-spaces-where-editor.ts
+++ b/apps/web/core/io/subgraph/fetch-spaces-where-editor.ts
@@ -23,7 +23,7 @@ interface NetworkResult {
   spaces: {
     nodes: {
       id: string;
-      spacesMetadatum: SubstreamVersion;
+      spacesMetadatum: { version: SubstreamVersion };
     }[];
   };
 }
@@ -103,7 +103,7 @@ export async function fetchSpacesWhereEditor(address: string): Promise<SpaceWher
 
 const SpaceWhereEditorSchema = Schema.Struct({
   id: Schema.String.pipe(Schema.length(22), Schema.fromBrand(SpaceId)),
-  spacesMetadatum: SubstreamVersion,
+  spacesMetadatum: Schema.NullOr(Schema.Struct({ version: SubstreamVersion })),
 });
 
 type SpaceWhereEditorSchema = Schema.Schema.Type<typeof SpaceWhereEditorSchema>;
@@ -114,7 +114,7 @@ type SpaceWhereEditor = {
 };
 
 function SpaceWhereEditorDto(space: SpaceWhereEditorSchema) {
-  const spaceConfigWithImage = SpaceMetadataDto(space.id, space.spacesMetadatum);
+  const spaceConfigWithImage = SpaceMetadataDto(space.id, space.spacesMetadatum?.version);
 
   return {
     id: space.id,

--- a/apps/web/core/io/subgraph/fetch-spaces-where-member.ts
+++ b/apps/web/core/io/subgraph/fetch-spaces-where-member.ts
@@ -109,7 +109,7 @@ export async function fetchSpacesWhereMember(address?: string): Promise<SpaceWhe
 
 const SpaceWhereMemberSchema = Schema.Struct({
   id: Schema.String,
-  spacesMetadatum: Schema.Struct({ version: SubstreamVersion }),
+  spacesMetadatum: Schema.NullOr(Schema.Struct({ version: SubstreamVersion })),
 });
 
 type SpaceWhereMemberSchema = Schema.Schema.Type<typeof SpaceWhereMemberSchema>;
@@ -120,7 +120,7 @@ type SpaceWhereMember = {
 };
 
 function SpaceWhereMemberDto(space: SpaceWhereMemberSchema) {
-  const spaceConfigWithImage = SpaceMetadataDto(space.id, space.spacesMetadatum.version);
+  const spaceConfigWithImage = SpaceMetadataDto(space.id, space.spacesMetadatum?.version);
 
   return {
     id: space.id,

--- a/apps/web/core/io/subgraph/fetch-spaces.ts
+++ b/apps/web/core/io/subgraph/fetch-spaces.ts
@@ -22,7 +22,7 @@ const getFetchSpacesQuery = (spaceIds?: string[]) => {
   }
 
   return `query {
-    spaces {
+    spaces(filter: { spacePluginAddress: { isNull: false } }) {
       nodes {
         ${spaceFragment}
       }
@@ -98,7 +98,7 @@ export async function fetchSpaces(args?: FetchSpacesArgs): Promise<Space[]> {
 
       return Either.match(decodedSpace, {
         onLeft: error => {
-          console.error(`Unable to decode space: ${String(error)}`);
+          console.error(`Unable to decode space. spaceId: ${space.id} ${String(error)}`);
           return null;
         },
         onRight: space => {

--- a/apps/web/core/io/subgraph/fetch-versions-batch.ts
+++ b/apps/web/core/io/subgraph/fetch-versions-batch.ts
@@ -92,7 +92,7 @@ export async function fetchHistoricalVersionsBatch(args: FetchVersionsArgs) {
       return Either.match(decoded, {
         onLeft: error => {
           console.error(
-            `Could not decode version with id ${networkVersion.id} and entityId ${networkVersion.entityId}. ${String(
+            `FetchVersionsBatch: Could not decode version with id ${networkVersion.id} and entityId ${networkVersion.entityId}. ${String(
               error
             )}`
           );

--- a/apps/web/core/utils/change/fetch-previous-version-by-created-at.ts
+++ b/apps/web/core/utils/change/fetch-previous-version-by-created-at.ts
@@ -99,7 +99,7 @@ export async function fetchPreviousVersionByCreatedAt(args: FetchVersionsArgs) {
   return Either.match(decoded, {
     onLeft: error => {
       console.error(
-        `Could not decode version with id ${latestVersion.id} and entityId ${latestVersion.entityId} less than ${
+        `FetchPreviousVersionByCreatedAt: Could not decode version with id ${latestVersion.id} and entityId ${latestVersion.entityId} less than ${
           args.createdAt
         }. ${String(error)}`
       );

--- a/apps/web/core/utils/change/fetch-versions-by-edit-id.ts
+++ b/apps/web/core/utils/change/fetch-versions-by-edit-id.ts
@@ -88,7 +88,9 @@ export async function fetchVersionsByEditId(args: FetchVersionsArgs) {
 
       return Either.match(decoded, {
         onLeft: error => {
-          console.error(`Could not decode version with id ${v.id} and entityId ${v.entityId}. ${String(error)}`);
+          console.error(
+            `FetchVersionsByEditId: Could not decode version with id ${v.id} and entityId ${v.entityId}. ${String(error)}`
+          );
           return null;
         },
         onRight: result => {


### PR DESCRIPTION
Previously we assumed that every space had a space metadata. This isn't always true. We now also filter out invalid spaces.