### PR TITLE
fix: fetch versions by entity id decoding

### DIFF
--- a/apps/web/core/io/dto/relations.ts
+++ b/apps/web/core/io/dto/relations.ts
@@ -101,12 +101,14 @@ function getRenderableEntityType(types: SubstreamType[]): RenderableEntityType {
 }
 
 function getIndexFromRelationEntity(relation: SubstreamRelationLive | SubstreamRelationHistorical): string {
-  const maybeIndexTriple = relation.entity.currentVersion.version.triples.nodes.find(
+  // @TODO: We don't have a good way to get the version that a given relation belongs to. This might be fixed
+  // when we migrate to the newer relation data model and new versioning model
+  const maybeIndexTriple = relation.entity.currentVersion?.version.triples.nodes.find(
     t => t.attributeVersion.entityId === EntityId(SystemIds.RELATION_INDEX) && t.valueType === 'TEXT'
   );
 
   if (!maybeIndexTriple) {
-    return '';
+    return relation.index;
   }
 
   return TripleDto(maybeIndexTriple).value.value;

--- a/apps/web/core/io/schema.ts
+++ b/apps/web/core/io/schema.ts
@@ -164,13 +164,15 @@ const SubstreamRelationHistorical = Schema.Struct({
   spaceId: Schema.String,
   entityId: Schema.String.pipe(Schema.fromBrand(EntityId)),
   entity: Schema.Struct({
-    currentVersion: Schema.Struct({
-      version: Schema.Struct({
-        triples: Schema.Struct({
-          nodes: Schema.Array(SubstreamTriple),
+    currentVersion: Schema.NullOr(
+      Schema.Struct({
+        version: Schema.Struct({
+          triples: Schema.Struct({
+            nodes: Schema.Array(SubstreamTriple),
+          }),
         }),
-      }),
-    }),
+      })
+    ),
   }),
   index: Schema.String,
   typeOfVersion: Schema.Struct({

--- a/apps/web/partials/diff/changed-entity.tsx
+++ b/apps/web/partials/diff/changed-entity.tsx
@@ -84,12 +84,8 @@ export const ChangedEntity = ({ change, deleteAllComponent, renderAttributeStagi
         </div>
       )}
       {changes.length > 0 && (
-        <div className="mt-2">
-          <ChangedAttribute
-            renderAttributeStagingComponent={renderAttributeStagingComponent}
-            key={`${change.id}-${change.id}`}
-            changes={changes}
-          />
+        <div className="mt-2" key={change.id}>
+          <ChangedAttribute renderAttributeStagingComponent={renderAttributeStagingComponent} changes={changes} />
         </div>
       )}
     </div>
@@ -430,7 +426,13 @@ const ChangedAttribute = ({ changes, renderAttributeStagingComponent }: ChangedA
                   <div className="text-bodySemibold capitalize">{name}</div>
                   <div className="flex flex-wrap gap-2">
                     {changes.map(c => {
-                      return c.before && <Chip status={c.before.type}>{c.before.valueName ?? c.before.value}</Chip>;
+                      if (c.before === null) return null;
+
+                      return (
+                        <Chip key={`${c.attribute.id}-${c.before.value}`} status={c.before.type}>
+                          {c.before.valueName ?? c.before.value}
+                        </Chip>
+                      );
                     })}
                   </div>
                 </div>
@@ -442,7 +444,7 @@ const ChangedAttribute = ({ changes, renderAttributeStagingComponent }: ChangedA
                       if (c.after === null) return null;
 
                       return (
-                        <Chip key={c.after.value} status={c.after.type}>
+                        <Chip key={`${c.attribute.id}-${c.after.value}`} status={c.after.type}>
                           {c.after.valueName ?? c.after.value}
                         </Chip>
                       );

--- a/apps/web/partials/diff/changed-entity.tsx
+++ b/apps/web/partials/diff/changed-entity.tsx
@@ -542,7 +542,7 @@ const ChangedAttribute = ({ changes, renderAttributeStagingComponent }: ChangedA
               <div key={index} className="-mt-px flex gap-16">
                 <div className="flex-1 border border-grey-02 p-4">
                   <div className="text-bodySemibold capitalize">{name}</div>
-                  <div className="truncate text-ctaPrimary no-underline">
+                  <div className="truncate text-wrap text-ctaPrimary no-underline">
                     {changes.map(c => {
                       const checkedBefore = c.before ? c.before.value : '';
                       const checkedAfter = c.after ? c.after.value : '';
@@ -564,7 +564,7 @@ const ChangedAttribute = ({ changes, renderAttributeStagingComponent }: ChangedA
                 <div className="group relative flex-1 border border-grey-02 p-4">
                   {renderAttributeStagingComponent?.(attributeId)}
                   <div className="text-bodySemibold capitalize">{name}</div>
-                  <div className="truncate text-ctaPrimary no-underline">
+                  <div className="truncate text-wrap text-ctaPrimary no-underline">
                     {changes.map(c => {
                       const checkedBefore = c.before ? c.before.value : '';
                       const checkedAfter = c.after ? c.after.value : '';


### PR DESCRIPTION
If the relation is new then there won't be a current version for the relation entity