### PR TITLE
chore: switch to noble md5

### DIFF
--- a/packages/substream/package.json
+++ b/packages/substream/package.json
@@ -26,6 +26,7 @@
     "@connectrpc/connect-node": "^1.3.0",
     "@effect/schema": "^0.63.0",
     "@graphprotocol/grc-20": "^0.9.4",
+    "@noble/hashes": "^1.8.0",
     "@sentry/node": "^7.112.2",
     "@std/csv": "npm:@jsr/std__csv@^1.0.5",
     "@substreams/core": "^0.16.0",

--- a/packages/substream/sink/utils/id.test.ts
+++ b/packages/substream/sink/utils/id.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+
+import { createVersionId } from './id';
+
+describe('createVersionId', () => {
+  it('should return a string', () => {
+    const result = createVersionId({ proposalId: 'proposal-1', entityId: 'entity-1' });
+    expect(result).toBe('JetExwSXsDajGBdkUv3bmN');
+  });
+
+  it('should return the same id for the same inputs', () => {
+    const result1 = createVersionId({ proposalId: 'proposal-2', entityId: 'entity-2' });
+    const result2 = createVersionId({ proposalId: 'proposal-2', entityId: 'entity-2' });
+    expect(result1).toBe(result2);
+  });
+
+  it('should return different ids for different inputs', () => {
+    const result1 = createVersionId({ proposalId: 'proposal-3', entityId: 'entity-3' });
+    const result2 = createVersionId({ proposalId: 'proposal-3', entityId: 'entity-4' });
+    const result3 = createVersionId({ proposalId: 'proposal-4', entityId: 'entity-3' });
+
+    expect(result1).not.toBe(result2);
+    expect(result1).not.toBe(result3);
+    expect(result2).not.toBe(result3);
+  });
+
+  it('should handle empty strings', () => {
+    const result1 = createVersionId({ proposalId: '', entityId: 'entity-5' });
+    const result2 = createVersionId({ proposalId: 'proposal-5', entityId: '' });
+    const result3 = createVersionId({ proposalId: '', entityId: '' });
+
+    expect(typeof result1).toBe('string');
+    expect(typeof result2).toBe('string');
+    expect(typeof result3).toBe('string');
+
+    expect(result1).not.toBe(result2);
+    expect(result1).not.toBe(result3);
+    expect(result2).not.toBe(result3);
+  });
+
+  it('should handle special characters in inputs', () => {
+    const result = createVersionId({
+      proposalId: 'proposal-!@#$%^&*()',
+      entityId: 'entity-{}[]|;:,.<>?/',
+    });
+
+    expect(typeof result).toBe('string');
+  });
+});

--- a/packages/substream/sink/utils/id.ts
+++ b/packages/substream/sink/utils/id.ts
@@ -1,5 +1,5 @@
 import { Base58, getChecksumAddress } from '@graphprotocol/grc-20';
-import { createHash } from 'crypto';
+import { md5 } from '@noble/hashes/legacy';
 import { v4 } from 'uuid';
 
 export function createMergedVersionId(mergedVersionIds: string[]) {
@@ -19,21 +19,11 @@ export function deriveSpaceId({ network, address }: { network: string; address: 
   return createIdFromUniqueString(`${network}:${getChecksumAddress(address)}`);
 }
 
-export function createIdFromUniqueString(text: string) {
-  const hashed = createHash('md5').update(text).digest('hex');
-  const bytes = hexToBytesArray(hashed);
-  const uuid = v4({ random: bytes });
+function createIdFromUniqueString(text: string) {
+  const encoded = new TextEncoder().encode(text);
+  const hashed = md5(encoded);
+  const uuid = v4({ random: hashed });
   return Base58.encodeBase58(uuid.split('-').join(''));
-}
-
-function hexToBytesArray(hex: string) {
-  const bytes: number[] = [];
-
-  for (let character = 0; character < hex.length; character += 2) {
-    bytes.push(parseInt(hex.slice(character, character + 2), 16));
-  }
-
-  return bytes;
 }
 
 type DeriveProposalIdArgs = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -541,10 +541,10 @@ importers:
         version: 1.21.4(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1)
       vite:
         specifier: ^5.2.11
-        version: 5.4.14(@types/node@22.14.1)
+        version: 5.4.14(@types/node@22.15.2)
       vitest:
         specifier: ^1.6.0
-        version: 1.6.0(@types/node@22.14.1)(jsdom@20.0.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+        version: 1.6.0(@types/node@22.15.2)(jsdom@20.0.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
     devDependencies:
       '@bufbuild/buf':
         specifier: ^1.31.0
@@ -585,6 +585,9 @@ importers:
       '@graphprotocol/grc-20':
         specifier: ^0.9.4
         version: 0.9.4(bufferutil@4.0.9)(ox@0.6.7(typescript@5.7.3)(zod@3.24.1))(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1)
+      '@noble/hashes':
+        specifier: ^1.8.0
+        version: 1.8.0
       '@sentry/node':
         specifier: ^7.112.2
         version: 7.120.3
@@ -657,7 +660,7 @@ importers:
         version: 4.3.0(prettier@3.4.2)
       '@types/node':
         specifier: latest
-        version: 22.14.1
+        version: 22.15.2
       '@types/pg':
         specifier: ^8.10.9
         version: 8.11.11
@@ -699,10 +702,10 @@ importers:
         version: 5.7.3
       vite:
         specifier: ^5.2.10
-        version: 5.4.14(@types/node@22.14.1)
+        version: 5.4.14(@types/node@22.15.2)
       vitest:
         specifier: ^1.5.2
-        version: 1.6.0(@types/node@22.14.1)(jsdom@20.0.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+        version: 1.6.0(@types/node@22.15.2)(jsdom@20.0.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
 
 packages:
 
@@ -2279,6 +2282,10 @@ packages:
     resolution: {integrity: sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==}
     engines: {node: ^14.21.3 || >=16}
 
+  '@noble/hashes@1.8.0':
+    resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
+    engines: {node: ^14.21.3 || >=16}
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -3653,8 +3660,8 @@ packages:
   '@types/node@20.17.16':
     resolution: {integrity: sha512-vOTpLduLkZXePLxHiHsBLp98mHGnl8RptV4YAO3HfKO5UHjDvySGbxKtpYfy8Sx5+WKcgc45qNreJJRVM3L6mw==}
 
-  '@types/node@22.14.1':
-    resolution: {integrity: sha512-u0HuPQwe/dHrItgHHpmw3N2fYCR6x4ivMNbPHRkBVP4CvN+kiRrKHWk3i8tXiO/joPwXLMYvF9TTF0eqgHIuOw==}
+  '@types/node@22.15.2':
+    resolution: {integrity: sha512-uKXqKN9beGoMdBfcaTY1ecwz6ctxuJAcUlwE55938g0ZJ8lRxwAZqRz2AJ4pzpt5dHdTPMB863UZ0ESiFUcP7A==}
 
   '@types/pg@8.11.11':
     resolution: {integrity: sha512-kGT1qKM8wJQ5qlawUrEkXgvMSXoV213KfMGXcwfDwUIfUHXqXYXOfS1nE1LINRJVVVx5wCm70XnFlMHaIcQAfw==}
@@ -10698,6 +10705,8 @@ snapshots:
 
   '@noble/hashes@1.7.1': {}
 
+  '@noble/hashes@1.8.0': {}
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -12180,13 +12189,13 @@ snapshots:
     dependencies:
       undici-types: 6.19.8
 
-  '@types/node@22.14.1':
+  '@types/node@22.15.2':
     dependencies:
       undici-types: 6.21.0
 
   '@types/pg@8.11.11':
     dependencies:
-      '@types/node': 20.17.16
+      '@types/node': 22.15.2
       pg-protocol: 1.7.0
       pg-types: 4.0.2
 
@@ -12256,7 +12265,7 @@ snapshots:
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 22.14.1
+      '@types/node': 20.17.16
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -17991,13 +18000,13 @@ snapshots:
       - utf-8-validate
       - zod
 
-  vite-node@1.6.0(@types/node@22.14.1):
+  vite-node@1.6.0(@types/node@22.15.2):
     dependencies:
       cac: 6.7.14
       debug: 4.4.0
       pathe: 1.1.2
       picocolors: 1.1.1
-      vite: 5.4.14(@types/node@22.14.1)
+      vite: 5.4.14(@types/node@22.15.2)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -18040,13 +18049,13 @@ snapshots:
       '@types/node': 17.0.45
       fsevents: 2.3.3
 
-  vite@5.4.14(@types/node@22.14.1):
+  vite@5.4.14(@types/node@22.15.2):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.5.1
       rollup: 4.32.1
     optionalDependencies:
-      '@types/node': 22.14.1
+      '@types/node': 22.15.2
       fsevents: 2.3.3
 
   vite@6.2.5(@types/node@17.0.45)(jiti@1.21.7)(tsx@4.19.2)(yaml@2.7.0):
@@ -18061,7 +18070,7 @@ snapshots:
       tsx: 4.19.2
       yaml: 2.7.0
 
-  vitest@1.6.0(@types/node@22.14.1)(jsdom@20.0.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)):
+  vitest@1.6.0(@types/node@22.15.2)(jsdom@20.0.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)):
     dependencies:
       '@vitest/expect': 1.6.0
       '@vitest/runner': 1.6.0
@@ -18080,11 +18089,11 @@ snapshots:
       strip-literal: 2.1.1
       tinybench: 2.9.0
       tinypool: 0.8.4
-      vite: 5.4.14(@types/node@22.14.1)
-      vite-node: 1.6.0(@types/node@22.14.1)
+      vite: 5.4.14(@types/node@22.15.2)
+      vite-node: 1.6.0(@types/node@22.15.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 22.14.1
+      '@types/node': 22.15.2
       jsdom: 20.0.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - less


### PR DESCRIPTION
Just realized this is only run in Node. Initially I thought the crypto package is polyfilled. So we could also discard the PR. An alternative would be to move the functionality to the GRC-20 TS lib since I need it in Hypergraph as well.

When I run `pnpm test` in substream the tests fail and the new id.test.ts does not run. No idea why. If I run `pnpm vitest ./sink/utils/id.test.ts` they run fine.