### PR TITLE
feat: cache as view for entity sync store

### DIFF
--- a/apps/web/core/database/write.ts
+++ b/apps/web/core/database/write.ts
@@ -10,50 +10,9 @@ import { E } from '../sync/orm';
 import { store as geoStore } from '../sync/use-sync-engine';
 import { OmitStrict } from '../types';
 import { Relation, Value } from '../v2.types';
-import { db } from './indexeddb';
 
-const opsWithPersistence = () => {
-  const baseAtom = atom<Value[]>([]);
-
-  baseAtom.onMount = setValue => {
-    (async () => {
-      const stored = await db.values.toArray();
-
-      // @TODO: Move this to hydration layer based on change stream
-      for (const value of stored) {
-        if (value.isDeleted) geoStore.deleteValue(value);
-        else geoStore.setValue(value);
-      }
-
-      setValue(stored);
-    })();
-  };
-
-  return baseAtom;
-};
-
-const relationsWithPersistence = () => {
-  const baseAtom = atom<Relation[]>([]);
-
-  baseAtom.onMount = setValue => {
-    (async () => {
-      const stored = await db.relations.toArray();
-
-      // @TODO: Move this to hydration layer based on change stream
-      for (const relation of stored) {
-        if (relation.isDeleted) geoStore.deleteRelation(relation);
-        else geoStore.setRelation(relation);
-      }
-
-      setValue(stored);
-    })();
-  };
-
-  return baseAtom;
-};
-
-export const localValuesAtom = opsWithPersistence();
-export const localRelationsAtom = relationsWithPersistence();
+export const localValuesAtom = atom<Value[]>([]);
+export const localRelationsAtom = atom<Relation[]>([]);
 
 type UpsertRelationArgs = {
   type: 'SET_RELATION';

--- a/apps/web/core/state/editor/use-blocks.ts
+++ b/apps/web/core/state/editor/use-blocks.ts
@@ -1,7 +1,6 @@
 import { SystemIds } from '@graphprotocol/grc-20';
 
-import { useRelations } from '~/core/database/relations';
-import '~/core/io/schema';
+import { useEntity } from '~/core/database/entities';
 import { Relation, RenderableEntityType } from '~/core/v2.types';
 
 export type RelationWithBlock = Relation & {
@@ -25,14 +24,15 @@ export type RelationWithBlock = Relation & {
  *
  */
 export function useBlocks(fromEntityId: string, initialBlockRelations?: Relation[]) {
-  // @TODO: For some reason using useEntity or useQueryEntity here causes an infinite
-  // render loop. Continuing to use jotai-based hook for now.
-  const blocks = useRelations({
-    mergeWith: initialBlockRelations,
-    selector: r => r.fromEntity.id === fromEntityId && r.type.id === SystemIds.BLOCKS,
+  const entity = useEntity({
+    id: fromEntityId,
+    initialData: { relations: initialBlockRelations ?? [], spaces: [], values: [] },
   });
 
-  return blocks.map(relationToRelationWithBlock).sort(sortByIndex);
+  return (entity?.relations ?? [])
+    .filter(r => r.type.id === SystemIds.BLOCKS)
+    .map(relationToRelationWithBlock)
+    .sort(sortByIndex);
 }
 
 function relationToRelationWithBlock(r: Relation): RelationWithBlock {

--- a/apps/web/core/state/editor/use-blocks.ts
+++ b/apps/web/core/state/editor/use-blocks.ts
@@ -14,15 +14,6 @@ export type RelationWithBlock = Relation & {
   };
 };
 
-/**
- * Blocks are defined via relations with relation type of {@link SystemIds.BLOCKS}.
- * These relations point to entities which are renderable by the content editor. The
- * currently renderable block types are:
- * 1) Text
- * 2) Data
- * 3) Image
- *
- */
 export function useBlocks(fromEntityId: string, initialBlockRelations?: Relation[]) {
   const entity = useEntity({
     id: fromEntityId,
@@ -39,7 +30,7 @@ function relationToRelationWithBlock(r: Relation): RelationWithBlock {
   return {
     ...r,
     typeOfId: r.type.id,
-    // @TODO(migration): default position
+    // @TODO(migration): default position.
     index: r.position ?? 'a0',
     block: {
       id: r.toEntity.id,

--- a/apps/web/core/state/persistence.tsx
+++ b/apps/web/core/state/persistence.tsx
@@ -8,36 +8,32 @@ import { store } from './jotai-store';
 
 export const Persistence = () => {
   React.useEffect(() => {
-    const unsubValues = store.sub(localValuesAtom, async () => {
-      const newValues = store.get(localValuesAtom);
-
-      // Dexie docs recommend putting all batched operations in a transaction scope
-      // https://dexie.org/docs/Tutorial/Best-Practices#5-use-transaction-scopes-whenever-you-plan-to-make-more-than-one-operation
-      db.transaction('rw', db.values, () => {
-        db.values.clear();
-        // Dexie docs recommend returning the last promise used in a transaction.
-        // We don't need to await the promises in a transaction, either.
-        return db.values.bulkPut(newValues.filter(t => !t.hasBeenPublished));
-      });
-    });
-
-    const unsubRelations = store.sub(localRelationsAtom, async () => {
-      const newRelations = store.get(localRelationsAtom);
-
-      // Dexie docs recommend putting all batched operations in a transaction scope
-      // https://dexie.org/docs/Tutorial/Best-Practices#5-use-transaction-scopes-whenever-you-plan-to-make-more-than-one-operation
-      db.transaction('rw', db.relations, () => {
-        db.relations.clear();
-        // Dexie docs recommend returning the last promise used in a transaction.
-        // We don't need to await the promises in a transaction, either.
-        return db.relations.bulkPut(newRelations.filter(r => !r.hasBeenPublished));
-      });
-    });
-
-    return () => {
-      unsubValues();
-      unsubRelations();
-    };
+    // const unsubValues = store.sub(localValuesAtom, async () => {
+    //   const newValues = store.get(localValuesAtom);
+    //   // Dexie docs recommend putting all batched operations in a transaction scope
+    //   // https://dexie.org/docs/Tutorial/Best-Practices#5-use-transaction-scopes-whenever-you-plan-to-make-more-than-one-operation
+    //   db.transaction('rw', db.values, () => {
+    //     db.values.clear();
+    //     // Dexie docs recommend returning the last promise used in a transaction.
+    //     // We don't need to await the promises in a transaction, either.
+    //     return db.values.bulkPut(newValues.filter(t => !t.hasBeenPublished));
+    //   });
+    // });
+    // const unsubRelations = store.sub(localRelationsAtom, async () => {
+    //   const newRelations = store.get(localRelationsAtom);
+    //   // Dexie docs recommend putting all batched operations in a transaction scope
+    //   // https://dexie.org/docs/Tutorial/Best-Practices#5-use-transaction-scopes-whenever-you-plan-to-make-more-than-one-operation
+    //   db.transaction('rw', db.relations, () => {
+    //     db.relations.clear();
+    //     // Dexie docs recommend returning the last promise used in a transaction.
+    //     // We don't need to await the promises in a transaction, either.
+    //     return db.relations.bulkPut(newRelations.filter(r => !r.hasBeenPublished));
+    //   });
+    // });
+    // return () => {
+    //   unsubValues();
+    //   unsubRelations();
+    // };
   }, []);
 
   return null;

--- a/apps/web/core/sync/engine.ts
+++ b/apps/web/core/sync/engine.ts
@@ -144,6 +144,10 @@ export class SyncEngine {
     // Don't resync an entity if it already has been synced
     const uniqueEntityIds = [...new Set(entityIds.filter(e => !this.syncedEntities.has(e)))];
 
+    if (uniqueEntityIds.length === 0) {
+      return;
+    }
+
     const entities = await this.cache.fetchQuery({
       queryKey: ['entities-batch-sync', uniqueEntityIds],
       queryFn: async () => {

--- a/apps/web/core/sync/engine.ts
+++ b/apps/web/core/sync/engine.ts
@@ -11,6 +11,16 @@ export class SyncEngine {
   private cache: QueryClient;
   private store: GeoStore;
 
+  /**
+   * We track already-synced entities so we don't sync them
+   * again unnecessarily. This gets reset with new user sessions.
+   *
+   * We could handle this through our caching layer, but since we
+   * batch fetch entities for syncing it's not straight forward to
+   * manage the cache for an array of entities to sync. It's simpler
+   * to just manage them outside of the cache and avoid fetching
+   * them at all.
+   */
   private syncedEntities: Set<string> = new Set();
 
   private subs: (() => void)[] = [];
@@ -79,10 +89,6 @@ export class SyncEngine {
       onRelationsDeleted,
       onEntitiesRevalidated,
     ];
-  }
-
-  public start() {
-    // this.processSyncQueue();
   }
 
   public stop() {

--- a/apps/web/core/sync/store.ts
+++ b/apps/web/core/sync/store.ts
@@ -5,7 +5,7 @@ import { readTypes } from '../database/entities';
 import { ID } from '../id';
 import { EntityId } from '../io/schema';
 import { Entities } from '../utils/entity';
-import { DataType, Entity, ExtraRenderableType, Property, Relation, RenderableType, Value } from '../v2.types';
+import { DataType, Entity, ExtraRenderableType, Property, Relation, Value } from '../v2.types';
 import { WhereCondition } from './experimental_query-layer';
 import { GeoEventStream } from './stream';
 

--- a/apps/web/core/sync/store.ts
+++ b/apps/web/core/sync/store.ts
@@ -99,8 +99,8 @@ Entity ids: ${entities.map(e => e.id).join(', ')}`);
     return ['store', 'entity', id];
   }
 
-  static queryKeys(where: WhereCondition) {
-    return ['store', 'entities', JSON.stringify(where)];
+  static queryKeys(where: WhereCondition, first?: number, skip?: number) {
+    return ['store', 'entities', JSON.stringify(where), first, skip];
   }
 
   clear() {

--- a/apps/web/core/sync/use-store.tsx
+++ b/apps/web/core/sync/use-store.tsx
@@ -209,6 +209,14 @@ export function useQueryEntities({
     queryKey: [...GeoStore.queryKeys(where), first, skip],
     queryFn: async () => {
       const entities = await E.findMany({ store, cache, where, first, skip });
+
+      /**
+       * @TODO
+       * Do we need to actually sync the results since we're returning it?
+       * One benefit of syncing is that all of the entities end up in the
+       * store, so any components subscribed to the store can hook into
+       * the new synced data as needed.
+       */
       stream.emit({ type: GeoEventStream.ENTITIES_SYNCED, entities });
       return entities;
     },

--- a/apps/web/core/sync/use-store.tsx
+++ b/apps/web/core/sync/use-store.tsx
@@ -1,7 +1,7 @@
 import { keepPreviousData, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Effect } from 'effect';
 
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 
 import { getProperties, getProperty } from '../io/v2/queries';
 import { Property } from '../v2.types';
@@ -172,16 +172,27 @@ export function useQueryEntities({
   const cache = useQueryClient();
   const { store, stream } = useSyncEngine();
 
-  const prevWhere = useRef(where);
-
-  useEffect(() => {
-    // We need to compare by hash since there's no guarantee that the
-    // where clause is actually stable.
-    // @TODO: We could hash this instead, but stringify works for now
-    if (JSON.stringify(prevWhere.current) !== JSON.stringify(where)) {
-      prevWhere.current = where;
-    }
-  }, [where]);
+  /**
+   * What would a reactive approach to queried entities look like?
+   * Currently we listen to the event stream and execute some heuristics
+   * to see if we should update the existing state.
+   *
+   * There's a few approaches we could take
+   * 1. Keep the heuristics, but instead of setting state, just update
+   *    the cache by invalidating it. (how we used to do it)
+   * 2. Keep the heuristics, but instead of settubg state, just set
+   *    the cache state directly. (how we currently do it)
+   * 3. Introduce some other reactive system that automatically updates
+   *    when its dependencies are updated. This would require that its
+   *    dependencies are themselves reactive. The filter could also be
+   *    reactive, so when the filter changes it causes the reactive result
+   *    to also update.
+   *
+   * Benefits of moving to the cache-based system is that we get "view sharing."
+   * Different callers get the same data back as long as the parameters are
+   * the same. Q: But what happens if one of them mutates? We might end up
+   * with multiple cache updates simultaneously.
+   */
 
   /**
    * This query runs behind the scenes to sync any remote entities that match

--- a/apps/web/core/sync/use-store.tsx
+++ b/apps/web/core/sync/use-store.tsx
@@ -224,7 +224,7 @@ export function useQueryEntities({
   } = useQuery({
     enabled,
     placeholderData,
-    queryKey: [...GeoStore.queryKeys(where), first, skip],
+    queryKey: GeoStore.queryKeys(where, first, skip),
     queryFn: async () => {
       const entities = await E.findMany({ store, cache, where, first, skip });
 
@@ -263,7 +263,7 @@ export function useQueryEntities({
        * end up with an empty query result.
        */
       if (syncedEntitiesIds.length === 0 && latestQueriedEntitiesIds.length === 0) {
-        cache.setQueryData([...GeoStore.queryKeys(where), first, skip], []);
+        cache.setQueryData(GeoStore.queryKeys(where, first, skip), []);
         return;
       }
 
@@ -310,7 +310,7 @@ export function useQueryEntities({
       }
 
       if (shouldUpdate) {
-        cache.setQueryData([...GeoStore.queryKeys(where), first, skip], latestQueriedEntities);
+        cache.setQueryData(GeoStore.queryKeys(where, first, skip), latestQueriedEntities);
       }
     });
 
@@ -324,7 +324,7 @@ export function useQueryEntities({
       const ids: string[] = entities.map(e => e.id);
 
       if (ids.includes(event.relation.fromEntity.id)) {
-        cache.setQueryData([...GeoStore.queryKeys(where), first, skip], entities);
+        cache.setQueryData(GeoStore.queryKeys(where, first, skip), entities);
       }
     });
 
@@ -341,7 +341,7 @@ export function useQueryEntities({
 
       // This means the queried list has changed as a result of the deleted relation
       if (previousListHasFromEntity && newListDoesNotHaveFromEntity) {
-        cache.setQueryData([...GeoStore.queryKeys(where), first, skip], entities);
+        cache.setQueryData(GeoStore.queryKeys(where, first, skip), entities);
       }
     });
 
@@ -380,7 +380,7 @@ export function useQueryEntities({
       }
 
       if (shouldUpdate) {
-        cache.setQueryData([...GeoStore.queryKeys(where), first, skip], entities);
+        cache.setQueryData(GeoStore.queryKeys(where, first, skip), entities);
       }
     });
 
@@ -432,7 +432,7 @@ export function useQueryEntities({
       }
 
       if (shouldUpdate) {
-        cache.setQueryData([...GeoStore.queryKeys(where), first, skip], entities);
+        cache.setQueryData(GeoStore.queryKeys(where, first, skip), entities);
       }
     });
 

--- a/apps/web/partials/entity-page/editable-entity-header.tsx
+++ b/apps/web/partials/entity-page/editable-entity-header.tsx
@@ -28,6 +28,8 @@ export function EditableHeading({ spaceId, entityId }: { spaceId: string; entity
   const isEditing = useUserIsEditing(spaceId);
   const { storage } = useMutate();
 
+  console.log('name', name);
+
   const [isHistoryOpen, setIsHistoryOpen] = React.useState(false);
 
   const {
@@ -54,24 +56,7 @@ export function EditableHeading({ spaceId, entityId }: { spaceId: string; entity
   const showMore = !isOnePage && !isLastPage;
 
   const onNameChange = (value: string) => {
-    storage.values.set({
-      id: ID.createValueId({
-        entityId,
-        propertyId: SystemIds.NAME_PROPERTY,
-        spaceId,
-      }),
-      spaceId,
-      entity: {
-        id: entityId,
-        name: value,
-      },
-      property: {
-        id: SystemIds.NAME_PROPERTY,
-        name: 'Name',
-        dataType: 'TEXT',
-      },
-      value,
-    });
+    storage.entities.name.set(entityId, spaceId, value);
   };
 
   return (


### PR DESCRIPTION
This PR updates the entity sync store to use the query cache as the source of truth for view state. Previously we set tracked entities in local state. Instead we can just update the react query cache. In the future I may explore just making the entire sync store reactive rather than relying on the change events and manual tracking based on heuristics.