### PR TITLE
feat: dynamic renderable type

### DIFF
--- a/apps/web/core/environment/environment.ts
+++ b/apps/web/core/environment/environment.ts
@@ -57,7 +57,7 @@ export const options: Record<AppEnv, AppConfig> = {
     chainId: '80451',
     rpc: variables.rpcEndpoint,
     ipfs: IPFS_GATEWAY_PATH,
-    api: 'http://localhost:3000/graphql',
+    api: 'https://api-testnet.geobrowser.io/graphql',
     bundler: `https://api.pimlico.io/v2/80451/rpc?apikey=${variables.accountAbstractionApiKey}`,
   },
   testnet: {

--- a/apps/web/core/environment/environment.ts
+++ b/apps/web/core/environment/environment.ts
@@ -57,7 +57,7 @@ export const options: Record<AppEnv, AppConfig> = {
     chainId: '80451',
     rpc: variables.rpcEndpoint,
     ipfs: IPFS_GATEWAY_PATH,
-    api: 'https://api-testnet.geobrowser.io/graphql',
+    api: 'http://localhost:3000/graphql',
     bundler: `https://api.pimlico.io/v2/80451/rpc?apikey=${variables.accountAbstractionApiKey}`,
   },
   testnet: {

--- a/apps/web/core/io/v2/v2.schema.ts
+++ b/apps/web/core/io/v2/v2.schema.ts
@@ -1,3 +1,4 @@
+import { SystemIds } from '@graphprotocol/grc-20';
 import { Brand, Schema } from 'effect';
 
 export const DataType = Schema.Union(
@@ -76,7 +77,28 @@ export const Relation = Schema.Struct({
     entity: Schema.Struct({
       name: Schema.NullOr(Schema.String),
     }),
-    renderableType: Schema.NullOr(Schema.Union(Schema.Literal('IMAGE'), Schema.Literal('URL'))),
+    renderableType: Schema.NullOr(
+      Schema.transform(
+        Schema.Union(Schema.Literal(SystemIds.IMAGE), Schema.Literal(SystemIds.URL)),
+        Schema.Union(Schema.Literal('IMAGE'), Schema.Literal('URL')),
+        {
+          strict: true,
+          decode: id => {
+            switch (id) {
+              case SystemIds.IMAGE:
+                return 'IMAGE' as const;
+              case SystemIds.URL:
+                return 'URL' as const;
+              default:
+                throw new Error();
+            }
+          },
+          encode: () => {
+            throw new Error();
+          },
+        }
+      )
+    ),
   }),
   entityId: Schema.UUID,
 });


### PR DESCRIPTION
We now return renderables from the API as ids and parse them on the client into specific types. Clients can now write arbitrary renderable types and as long as they can parse it in their clients, render them.