### PR TITLE
fix: keep editor selection by preventing blur on mousedown

### DIFF
--- a/apps/web/partials/editor/command-list.tsx
+++ b/apps/web/partials/editor/command-list.tsx
@@ -64,7 +64,12 @@ export const CommandList = forwardRef<CommandListRef, CommandListProps>(({ comma
               key={index}
               data-index={index}
               onMouseOver={() => setSelectedIndex(index)}
-              onClick={() => command(items[selectedIndex])}
+              onClick={() => {
+                command(items[selectedIndex]);
+              }}
+              onMouseDown={e => {
+                e.preventDefault();
+              }}
             >
               <div
                 className={cx(


### PR DESCRIPTION
To fix headings and lists in text editor