### PR TITLE
fix: secondary space drill-down

### DIFF
--- a/apps/web/design-system/autocomplete/results-list.tsx
+++ b/apps/web/design-system/autocomplete/results-list.tsx
@@ -120,7 +120,10 @@ export const ResultContent = ({
       </button>
       {hasOtherSpaces && !!onChooseSpace && (
         <button
-          onClick={onChooseSpace}
+          onClick={e => {
+            e.stopPropagation();
+            onChooseSpace();
+          }}
           className="-mt-2 flex w-full items-center justify-between p-2 transition-colors duration-150 hover:bg-grey-01"
         >
           <div className="flex items-center">


### PR DESCRIPTION
stop propagation on onClick event in ResultContent