### PR TITLE
fix: normalize IDs when comparing against SystemIds

### DIFF
--- a/apps/web/core/blocks/data/filters.ts
+++ b/apps/web/core/blocks/data/filters.ts
@@ -2,6 +2,7 @@ import { SystemIds } from '@geoprotocol/geo-sdk';
 import { Schema } from 'effect';
 import { Effect, Either } from 'effect';
 
+import { ID } from '~/core/id';
 import { getProperty, getSpace } from '~/core/io/v2/queries';
 import { queryClient } from '~/core/query-client';
 import { E } from '~/core/sync/orm';
@@ -104,12 +105,12 @@ const FilterMap = Schema.mutable(
 type FilterMap = Schema.Schema.Type<typeof FilterMap>;
 
 export function toGeoFilterState(filters: OmitStrict<Filter, 'valueName'>[]): string {
-  const spaces = filters.filter(f => f.columnId === SystemIds.SPACE_FILTER).map(f => f.value);
+  const spaces = filters.filter(f => ID.equals(f.columnId, SystemIds.SPACE_FILTER)).map(f => f.value);
 
   const filterMap: FilterMap = {};
 
   filters
-    .filter(f => f.columnId !== SystemIds.SPACE_FILTER)
+    .filter(f => !ID.equals(f.columnId, SystemIds.SPACE_FILTER))
     .forEach(f => {
       if (f.columnName === 'Backlink') {
         filterMap['_relation'] = {

--- a/apps/web/core/blocks/data/use-data-block.tsx
+++ b/apps/web/core/blocks/data/use-data-block.tsx
@@ -4,6 +4,7 @@ import { Effect } from 'effect';
 
 import * as React from 'react';
 
+import { ID } from '~/core/id';
 import { WhereCondition } from '~/core/sync/experimental_query-layer';
 import { useMutate } from '~/core/sync/use-mutate';
 import { useQueryEntities, useQueryEntity } from '~/core/sync/use-store';
@@ -299,7 +300,7 @@ export function filterStateToWhere(filterState: Filter[]): WhereCondition {
   for (const filter of filterState) {
     if (filter.valueType === 'TEXT') {
       // For NAME_PROPERTY, filter on the entity name field directly
-      if (filter.columnId === SystemIds.NAME_PROPERTY) {
+      if (ID.equals(filter.columnId, SystemIds.NAME_PROPERTY)) {
         where['name'] = {
           contains: filter.value,
         };
@@ -320,12 +321,12 @@ export function filterStateToWhere(filterState: Filter[]): WhereCondition {
     }
 
     if (filter.valueType === 'RELATION') {
-      if (filter.columnId === SystemIds.SPACE_FILTER) {
+      if (ID.equals(filter.columnId, SystemIds.SPACE_FILTER)) {
         where['spaces'] = [{ equals: filter.value }];
         continue;
       }
 
-      if (filter.columnId === SystemIds.TYPES_PROPERTY) {
+      if (ID.equals(filter.columnId, SystemIds.TYPES_PROPERTY)) {
         if (!where.types) {
           where.types = [];
         }

--- a/apps/web/core/id/index.ts
+++ b/apps/web/core/id/index.ts
@@ -1,1 +1,7 @@
-export * as ID from './create-id';
+import * as createId from './create-id';
+import * as normalize from './normalize';
+
+export const ID = {
+  ...createId,
+  ...normalize,
+};

--- a/apps/web/core/id/normalize.test.ts
+++ b/apps/web/core/id/normalize.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+
+import { equals, uuidToHex } from './normalize';
+
+describe('uuidToHex', () => {
+  it('removes dashes and lowercases', () => {
+    expect(uuidToHex('4C81561D-1F95-4131-9CDD-DD20AB831BA2')).toBe('4c81561d1f9541319cdddd20ab831ba2');
+  });
+
+  it('lowercases already undashed IDs', () => {
+    expect(uuidToHex('4C81561D1F9541319CDDDD20AB831BA2')).toBe('4c81561d1f9541319cdddd20ab831ba2');
+  });
+
+  it('handles already normalized IDs', () => {
+    expect(uuidToHex('4c81561d1f9541319cdddd20ab831ba2')).toBe('4c81561d1f9541319cdddd20ab831ba2');
+  });
+
+  it('handles empty string', () => {
+    expect(uuidToHex('')).toBe('');
+  });
+});
+
+describe('equals', () => {
+  it('matches dashed UUID to undashed hex', () => {
+    expect(equals('4c81561d-1f95-4131-9cdd-dd20ab831ba2', '4c81561d1f9541319cdddd20ab831ba2')).toBe(true);
+  });
+
+  it('matches regardless of case', () => {
+    expect(equals('4C81561D-1F95-4131-9CDD-DD20AB831BA2', '4c81561d1f9541319cdddd20ab831ba2')).toBe(true);
+  });
+
+  it('matches two dashed UUIDs', () => {
+    expect(equals('4c81561d-1f95-4131-9cdd-dd20ab831ba2', '4c81561d-1f95-4131-9cdd-dd20ab831ba2')).toBe(true);
+  });
+
+  it('matches two undashed hex IDs', () => {
+    expect(equals('4c81561d1f9541319cdddd20ab831ba2', '4c81561d1f9541319cdddd20ab831ba2')).toBe(true);
+  });
+
+  it('returns false for different IDs', () => {
+    expect(equals('4c81561d-1f95-4131-9cdd-dd20ab831ba2', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee')).toBe(false);
+  });
+
+  it('handles empty strings', () => {
+    expect(equals('', '')).toBe(true);
+    expect(equals('', 'abc')).toBe(false);
+  });
+});

--- a/apps/web/core/id/normalize.ts
+++ b/apps/web/core/id/normalize.ts
@@ -1,0 +1,15 @@
+/**
+ * Converts a UUID with hyphens to a 32-character lowercase hex string.
+ * "4c81561d-1f95-4131-9cdd-dd20ab831ba2" -> "4c81561d1f9541319cdddd20ab831ba2"
+ */
+export function uuidToHex(uuid: string): string {
+  return uuid.replace(/-/g, '').toLowerCase();
+}
+
+/**
+ * Compares two IDs for equality, ignoring dashes and case.
+ * Use this when comparing user-provided IDs (may have dashes) against SystemIds (no dashes).
+ */
+export function equals(a: string, b: string): boolean {
+  return uuidToHex(a) === uuidToHex(b);
+}

--- a/apps/web/core/sync/experimental_query-layer.ts
+++ b/apps/web/core/sync/experimental_query-layer.ts
@@ -1,11 +1,13 @@
+import { ID } from '~/core/id';
+
 import { Entity, Relation, Value } from '../v2.types';
 
 const compareOperators = {
   string: {
-    equals: (a: string, b: string) => a === b,
-    contains: (a: string, b: string) => a.toLowerCase().includes(b.toLowerCase()),
-    startsWith: (a: string, b: string) => a.toLowerCase().startsWith(b.toLowerCase()),
-    endsWith: (a: string, b: string) => a.toLowerCase().endsWith(b.toLowerCase()),
+    equals: (a: string, b: string) => ID.uuidToHex(a) === ID.uuidToHex(b),
+    contains: (a: string, b: string) => ID.uuidToHex(a).includes(ID.uuidToHex(b)),
+    startsWith: (a: string, b: string) => ID.uuidToHex(a).startsWith(ID.uuidToHex(b)),
+    endsWith: (a: string, b: string) => ID.uuidToHex(a).endsWith(ID.uuidToHex(b)),
   },
   number: {
     equals: (a: number, b: number) => a === b,


### PR DESCRIPTION
## Summary

Data block filters weren't working on page load because dashed UUIDs from filter state (e.g., `4c81561d-1f95-4131-9cdd-dd20ab831ba2`) weren't matching undashed SystemIds (e.g., `4c81561d1f9541319cdddd20ab831ba2`).

## Changes

- Added `ID.equals()` and `ID.uuidToHex()` utilities in `core/id/normalize.ts` to normalize UUIDs before comparison
- Updated SystemIds comparisons in `filters.ts` and `use-data-block.tsx` to use `ID.equals()`
- Updated string comparison operators in `experimental_query-layer.ts` to normalize IDs