### PR TITLE
fix: governance vote display and publish relation filtering

### DIFF
--- a/apps/web/core/utils/publish/publish.ts
+++ b/apps/web/core/utils/publish/publish.ts
@@ -11,9 +11,13 @@ export function prepareLocalDataForPublishing(values: Value[], relations: Relati
       v.spaceId === spaceId && !v.hasBeenPublished && v.property.id !== '' && v.entity.id !== '' && v.isLocal === true
   );
 
+  const validRelations = relations.filter(
+    r => r.spaceId === spaceId && !r.hasBeenPublished && r.isLocal === true
+  );
+
   const ops: Op[] = [];
 
-  for (const r of relations) {
+  for (const r of validRelations) {
     if (r.isDeleted) {
       const { ops: deleteOps } = Graph.deleteRelation({ id: r.id });
       ops.push(...deleteOps);
@@ -23,6 +27,7 @@ export function prepareLocalDataForPublishing(values: Value[], relations: Relati
         toEntity: r.toEntity.id,
         type: r.type.id,
         id: r.id,
+        entityId: r.entityId,
         position: r.position ?? undefined,
         ...(r.toSpaceId && { toSpace: r.toSpaceId }),
       });

--- a/apps/web/partials/governance/governance-proposal-vote-state.tsx
+++ b/apps/web/partials/governance/governance-proposal-vote-state.tsx
@@ -1,27 +1,19 @@
-import { SubstreamVote } from '~/core/io/substream-schema';
-import { getNoVotePercentage, getYesVotePercentage } from '~/core/utils/utils';
-
 import { Avatar } from '~/design-system/avatar';
 import { CloseSmall } from '~/design-system/icons/close-small';
 import { TickSmall } from '~/design-system/icons/tick-small';
 
 interface Props {
-  votes: {
-    totalCount: number;
-    votes: SubstreamVote[];
-  };
+  yesPercentage: number;
+  noPercentage: number;
 
-  userVote?: SubstreamVote['vote'];
+  userVote?: 'ACCEPT' | 'REJECT' | 'ABSTAIN';
   user?: {
     address?: string;
     avatarUrl: string | null;
   };
 }
 
-export function GovernanceProposalVoteState({ votes, user, userVote }: Props) {
-  const yesVotesPercentage = getYesVotePercentage(votes.votes, votes.totalCount);
-  const noVotesPercentage = getNoVotePercentage(votes.votes, votes.totalCount);
-
+export function GovernanceProposalVoteState({ yesPercentage, noPercentage, user, userVote }: Props) {
   return (
     <>
       <div className="flex items-center gap-2 text-metadataMedium">
@@ -35,9 +27,9 @@ export function GovernanceProposalVoteState({ votes, user, userVote }: Props) {
           </div>
         )}
         <div className="relative h-1 w-[180px] overflow-clip rounded-full bg-grey-02">
-          <div className="absolute bottom-0 left-0 top-0 bg-green" style={{ width: `${yesVotesPercentage}%` }} />
+          <div className="absolute bottom-0 left-0 top-0 bg-green" style={{ width: `${yesPercentage}%` }} />
         </div>
-        <div>{yesVotesPercentage}%</div>
+        <div>{yesPercentage}%</div>
       </div>
       <div className="flex items-center gap-2 text-metadataMedium">
         {userVote === 'REJECT' ? (
@@ -50,9 +42,9 @@ export function GovernanceProposalVoteState({ votes, user, userVote }: Props) {
           </div>
         )}
         <div className="relative h-1 w-[180px] overflow-clip rounded-full bg-grey-02">
-          <div className="absolute bottom-0 left-0 top-0 bg-red-01" style={{ width: `${noVotesPercentage}%` }} />
+          <div className="absolute bottom-0 left-0 top-0 bg-red-01" style={{ width: `${noPercentage}%` }} />
         </div>
-        <div>{noVotesPercentage}%</div>
+        <div>{noPercentage}%</div>
       </div>
     </>
   );

--- a/apps/web/partials/governance/governance-status-chip.tsx
+++ b/apps/web/partials/governance/governance-status-chip.tsx
@@ -49,6 +49,17 @@ export function GovernanceStatusChip({ status, endTime, yesPercentage }: Props) 
 
       return <div className="flex items-center gap-2 rounded-sm px-2 py-1.5 text-metadataMedium">{statusText}</div>;
     }
+    case 'REJECTED': {
+      return (
+        <div className="flex items-center gap-2 rounded-sm px-2 py-1.5 text-metadataMedium text-red-01">
+          {/* Optically align the icon */}
+          <div className="mt-[0.75px]">
+            <CheckCloseSmall />
+          </div>
+          Rejected
+        </div>
+      );
+    }
     default:
       throw new Error(`${status} proposal status not implemented yet`);
   }

--- a/apps/web/partials/review/review-changes.tsx
+++ b/apps/web/partials/review/review-changes.tsx
@@ -104,7 +104,8 @@ export const ReviewChanges = () => {
     }
   }, [spacesKey, statusBarState.reviewState, setIsReviewOpen]);
 
-  const proposalName = proposals[activeSpace]?.name?.trim() ?? '';
+  const rawProposalName = proposals[activeSpace]?.name ?? '';
+  const proposalName = rawProposalName.trim();
 
   const valuesFromSpace = useValues({
     selector: t => t.spaceId === activeSpace && t.isLocal === true,
@@ -224,7 +225,7 @@ export const ReviewChanges = () => {
               <div className="text-body">Proposal name</div>
               <input
                 type="text"
-                value={proposalName}
+                value={rawProposalName}
                 onChange={e => handleProposalNameChange(e.target.value)}
                 placeholder="Name your proposal..."
                 className="w-full bg-transparent text-[40px] font-semibold text-text placeholder:text-grey-02 focus:outline-none"


### PR DESCRIPTION
## Summary

- **Governance vote percentages showed 0%**: The list API omits individual voter records for performance but returns aggregate counts. The frontend was computing percentages from the empty voters array instead of using the available `votes.yes` / `votes.no` / `votes.total` counts.
- **User vote avatar never appeared**: `userVote` was always null because the list query didn't fetch individual vote records. This is fixed on the API side in geobrowser/gaia#371 with a LATERAL join; the frontend now reads the simplified `userVote` field directly.
- **Relations published without filtering**: `prepareLocalDataForPublishing` filtered values by `spaceId`, `hasBeenPublished`, and `isLocal`, but sent all relations as ops regardless. Now applies the same filters. Also passes `entityId` to `createRelation` ops (was missing).
- **REJECTED proposals threw**: `GovernanceStatusChip` had no `case 'REJECTED'` — added.

## Changes

### Governance (`apps/web/partials/governance/`)
- `governance-proposals-list.tsx` — count-based percentage helper, simplified `GovernanceProposal` type (flattened `userVotes` array → optional `userVote` string, removed dead `votes` field), removed `connectedAddress` param from DTO mapper
- `governance-proposal-vote-state.tsx` — pure presentational component, accepts `yesPercentage`/`noPercentage` props instead of computing from voters array
- `governance-status-chip.tsx` — added `REJECTED` case

### Publish (`apps/web/core/utils/publish/`)
- `publish.ts` — filter relations by `spaceId`, `hasBeenPublished`, `isLocal` before building ops; pass `entityId` to `createRelation`
- `publish.test.ts` — added tests for relation filtering, updated existing test expectations

### Companion PR
- **gaia**: geobrowser/gaia#371 — adds `voterId` LATERAL join to the list endpoint so `userVote` is returned