### PR TITLE
chore: remove console.log statements from proposal hooks

### DIFF
--- a/apps/web/core/hooks/use-propose-add-editor.ts
+++ b/apps/web/core/hooks/use-propose-add-editor.ts
@@ -90,13 +90,6 @@ export function useProposeAddEditor({ spaceId }: UseProposeAddEditorArgs) {
 
       const spaceAddress = space.address as Hex;
 
-      console.log('Proposing to add editor', {
-        fromSpaceId: personalSpaceId,
-        toSpaceId: spaceId,
-        targetEditorSpaceId,
-        spaceAddress,
-      });
-
       const writeTxEffect = Effect.gen(function* () {
         const proposalId = `0x${IdUtils.generate()}` as const;
         const fromSpaceId = `0x${personalSpaceId}` as const;
@@ -128,7 +121,6 @@ export function useProposeAddEditor({ spaceId }: UseProposeAddEditorArgs) {
         });
 
         const hash = yield* tx(callData);
-        console.log('Transaction hash: ', hash);
         return hash;
       });
 
@@ -145,7 +137,7 @@ export function useProposeAddEditor({ spaceId }: UseProposeAddEditorArgs) {
           // Necessary to propagate error status to useMutation
           throw error;
         },
-        onRight: () => console.log('Successfully proposed to add editor'),
+        onRight: () => {},
       });
     },
     [dispatch, smartAccount, personalSpaceId, isRegistered, spaceId, space, tx]

--- a/apps/web/core/hooks/use-propose-add-member.ts
+++ b/apps/web/core/hooks/use-propose-add-member.ts
@@ -87,14 +87,6 @@ export function useProposeAddMember({ spaceId }: UseProposeAddMemberArgs) {
       const spaceAddress = space.address as Hex;
       const votingModeValue = votingMode === 'fast' ? VOTING_MODE.FAST : VOTING_MODE.SLOW;
 
-      console.log('Proposing to add member', {
-        fromSpaceId: personalSpaceId,
-        toSpaceId: spaceId,
-        targetMemberSpaceId,
-        votingMode,
-        spaceAddress,
-      });
-
       const writeTxEffect = Effect.gen(function* () {
         const proposalId = `0x${IdUtils.generate()}` as const;
         const fromSpaceId = `0x${personalSpaceId}` as const;
@@ -125,7 +117,6 @@ export function useProposeAddMember({ spaceId }: UseProposeAddMemberArgs) {
         });
 
         const hash = yield* tx(callData);
-        console.log('Transaction hash: ', hash);
         return hash;
       });
 
@@ -142,7 +133,7 @@ export function useProposeAddMember({ spaceId }: UseProposeAddMemberArgs) {
           // Necessary to propagate error status to useMutation
           throw error;
         },
-        onRight: () => console.log('Successfully proposed to add member'),
+        onRight: () => {},
       });
     },
     [dispatch, smartAccount, personalSpaceId, isRegistered, spaceId, space, tx]

--- a/apps/web/core/hooks/use-propose-remove-editor.ts
+++ b/apps/web/core/hooks/use-propose-remove-editor.ts
@@ -90,13 +90,6 @@ export function useProposeRemoveEditor({ spaceId }: UseProposeRemoveEditorArgs) 
 
       const spaceAddress = space.address as Hex;
 
-      console.log('Proposing to remove editor', {
-        fromSpaceId: personalSpaceId,
-        toSpaceId: spaceId,
-        targetEditorSpaceId,
-        spaceAddress,
-      });
-
       const writeTxEffect = Effect.gen(function* () {
         const proposalId = `0x${IdUtils.generate()}` as const;
         const fromSpaceId = `0x${personalSpaceId}` as const;
@@ -128,7 +121,6 @@ export function useProposeRemoveEditor({ spaceId }: UseProposeRemoveEditorArgs) 
         });
 
         const hash = yield* tx(callData);
-        console.log('Transaction hash: ', hash);
         return hash;
       });
 
@@ -145,7 +137,7 @@ export function useProposeRemoveEditor({ spaceId }: UseProposeRemoveEditorArgs) 
           // Necessary to propagate error status to useMutation
           throw error;
         },
-        onRight: () => console.log('Successfully proposed to remove editor'),
+        onRight: () => {},
       });
     },
     [dispatch, smartAccount, personalSpaceId, isRegistered, spaceId, space, tx]

--- a/apps/web/core/hooks/use-propose-remove-member.ts
+++ b/apps/web/core/hooks/use-propose-remove-member.ts
@@ -87,14 +87,6 @@ export function useProposeRemoveMember({ spaceId }: UseProposeRemoveMemberArgs) 
       const spaceAddress = space.address as Hex;
       const votingModeValue = votingMode === 'fast' ? VOTING_MODE.FAST : VOTING_MODE.SLOW;
 
-      console.log('Proposing to remove member', {
-        fromSpaceId: personalSpaceId,
-        toSpaceId: spaceId,
-        targetMemberSpaceId,
-        votingMode,
-        spaceAddress,
-      });
-
       const writeTxEffect = Effect.gen(function* () {
         const proposalId = `0x${IdUtils.generate()}` as const;
         const fromSpaceId = `0x${personalSpaceId}` as const;
@@ -125,7 +117,6 @@ export function useProposeRemoveMember({ spaceId }: UseProposeRemoveMemberArgs) 
         });
 
         const hash = yield* tx(callData);
-        console.log('Transaction hash: ', hash);
         return hash;
       });
 
@@ -142,7 +133,7 @@ export function useProposeRemoveMember({ spaceId }: UseProposeRemoveMemberArgs) 
           // Necessary to propagate error status to useMutation
           throw error;
         },
-        onRight: () => console.log('Successfully proposed to remove member'),
+        onRight: () => {},
       });
     },
     [dispatch, smartAccount, personalSpaceId, isRegistered, spaceId, space, tx]


### PR DESCRIPTION
## Summary

Remove debugging console.log statements from proposal hooks to prevent leaking internal details in production.

## Changes

- Removed console.log statements from `use-propose-add-member.ts`
- Removed console.log statements from `use-propose-remove-member.ts`
- Removed console.log statements from `use-propose-add-editor.ts`
- Removed console.log statements from `use-propose-remove-editor.ts`
- Preserved console.error statements for error handling

## Files Modified

- `apps/web/core/hooks/use-propose-add-editor.ts` (10 lines removed)
- `apps/web/core/hooks/use-propose-add-member.ts` (11 lines removed)
- `apps/web/core/hooks/use-propose-remove-editor.ts` (10 lines removed)
- `apps/web/core/hooks/use-propose-remove-member.ts` (11 lines removed)

Total: 42 lines removed

## Verification

Verified no console.log statements remain in these files:
```bash
grep -rn "console\.log" apps/web/core/hooks/use-propose-*.ts | grep -v "console.error"
```

Result: No matches found