### PR TITLE
fix: space dropdown hover state padding

### DIFF
--- a/apps/web/partials/entity-page/editable-space-header.tsx
+++ b/apps/web/partials/entity-page/editable-space-header.tsx
@@ -183,7 +183,11 @@ export function EditableSpaceHeading({
               open={isContextMenuOpen}
               onOpenChange={setIsContextMenuOpen}
               align="end"
-              trigger={isContextMenuOpen ? <Close color="grey-04" /> : <Context color="grey-04" />}
+              trigger={
+                <button type="button" className="rounded p-1 transition-colors duration-150 ease-in-out hover:bg-grey-01">
+                  {isContextMenuOpen ? <Close color="grey-04" /> : <Context color="grey-04" />}
+                </button>
+              }
               className={cx(!isCreatingNewVersion ? 'max-w-[160px]' : 'max-w-[320px]')}
             >
               {isCreatingNewVersion && (

--- a/apps/web/partials/entity-page/editable-space-header.tsx
+++ b/apps/web/partials/entity-page/editable-space-header.tsx
@@ -183,8 +183,9 @@ export function EditableSpaceHeading({
               open={isContextMenuOpen}
               onOpenChange={setIsContextMenuOpen}
               align="end"
+              asChild
               trigger={
-                <button type="button" className="rounded p-1 transition-colors duration-150 ease-in-out hover:bg-grey-01">
+                <button type="button" className="rounded p-1 transition-colors duration-75 hover:bg-grey-01">
                   {isContextMenuOpen ? <Close color="grey-04" /> : <Context color="grey-04" />}
                 </button>
               }


### PR DESCRIPTION
## Summary
- Added hover state padding to space dropdown button to match the new design system
- Fixed accessibility issue by adding asChild prop to prevent nested buttons
- Adjusted transition timing to match MenuItem component

## Changes
- Wrapped the Menu trigger (Context/Close icons) in a button with hover styles
- Added `asChild` prop to Menu component to properly merge the button with Radix Trigger
- Changed transition duration from 150ms to 75ms to align with MenuItem patterns

## Screenshots
- Before: https://uploads.linear.app/925704e7-2ef7-412c-a5df-8379d43e2c20/074b3ae0-7605-4daa-84ea-cfe5af5a4963/d403e9a3-34bd-4b2a-8add-145180b2979e
- Expected: https://uploads.linear.app/925704e7-2ef7-412c-a5df-8379d43e2c20/0b8f08dd-9ca3-4b9a-a77b-f2d4ab8d945f/096e9c93-6c7a-4486-87d9-c7e922bf8671

Fixes GEO-1780