### PR TITLE
feat: unify image/video block types and add image placeholder upload

### DIFF
--- a/apps/web/core/constants.ts
+++ b/apps/web/core/constants.ts
@@ -10,11 +10,7 @@ export const PINATA_GATEWAY_READ_PATH = 'https://magenta-naval-crow-536.mypinata
 
 export const RENDERABLE_TYPE_PROPERTY = '2316bbe1c76f463583f23e03b4f1fe46';
 
-// Video type IDs
-export const VIDEO_URL_PROPERTY = '33da2ef5bd554e91af973e082e431a13';
 export const VIDEO_RENDERABLE_TYPE = '0fb6bbf022044db49f70fa82c41570a4';
-export const VIDEO_TYPE = 'd7a4817c9795405b93e212df759c43f8';
-export const VIDEO_BLOCK_TYPE = '809bc406d0f34f3ca8a1aa265733c6ce';
 
 // Video file types and upload constraints
 export const VALID_VIDEO_TYPES = [
@@ -27,6 +23,11 @@ export const VALID_VIDEO_TYPES = [
 ];
 export const VIDEO_ACCEPT = VALID_VIDEO_TYPES.join(',');
 export const MAX_VIDEO_SIZE_BYTES = 100 * 1024 * 1024; // 100MB
+
+// Image file types and upload constraints
+export const VALID_IMAGE_TYPES = ['image/png', 'image/jpeg', 'image/webp', 'image/gif'];
+export const IMAGE_ACCEPT = VALID_IMAGE_TYPES.join(',');
+export const MAX_IMAGE_SIZE_BYTES = 20 * 1024 * 1024; // 20MB
 
 export const DATA_TYPE_PROPERTY = '6d29d57849bb4959baf72cc696b1671a';
 

--- a/apps/web/core/io/dto/relations.ts
+++ b/apps/web/core/io/dto/relations.ts
@@ -1,15 +1,12 @@
 import { SystemIds } from '@geoprotocol/geo-sdk';
 
-import { VIDEO_BLOCK_TYPE, VIDEO_TYPE, VIDEO_URL_PROPERTY } from '~/core/constants';
 import { RemoteEntityType, RemoteRelation } from '~/core/io/schema';
 import { Relation, RenderableEntityType } from '~/core/types';
 
 export function RelationDtoLive(relation: RemoteRelation): Relation {
-  const imageUrlPropertyHex = SystemIds.IMAGE_URL_PROPERTY.replace(/-/g, '');
+  const ipfsUrlPropertyHex = SystemIds.IMAGE_URL_PROPERTY.replace(/-/g, '');
   const mediaEntityUrlValue =
-    relation.toEntity.valuesList.find(v => v.propertyId === imageUrlPropertyHex)?.text ??
-    relation.toEntity.valuesList.find(v => v.propertyId === VIDEO_URL_PROPERTY)?.text ??
-    null;
+    relation.toEntity.valuesList.find(v => v.propertyId === ipfsUrlPropertyHex)?.text ?? null;
   const renderableType = v2_getRenderableEntityType(relation.toEntity.types);
 
   const toEntityId = relation.toEntity.id;
@@ -48,6 +45,8 @@ function v2_getRenderableEntityType(types: readonly RemoteEntityType[]): Rendera
   const typeIds = types.map(type => type.id);
 
   const imageTypeHex = SystemIds.IMAGE_TYPE.replace(/-/g, '');
+  const videoTypeHex = SystemIds.VIDEO_TYPE.replace(/-/g, '');
+  const videoBlockHex = SystemIds.VIDEO_BLOCK.replace(/-/g, '');
   const dataBlockHex = SystemIds.DATA_BLOCK.replace(/-/g, '');
   const textBlockHex = SystemIds.TEXT_BLOCK.replace(/-/g, '');
 
@@ -55,7 +54,8 @@ function v2_getRenderableEntityType(types: readonly RemoteEntityType[]): Rendera
     return 'IMAGE';
   }
 
-  if (typeIds.includes(VIDEO_TYPE) || typeIds.includes(VIDEO_BLOCK_TYPE)) {
+  // Match both VIDEO_TYPE (new) and VIDEO_BLOCK (legacy) for backwards compatibility
+  if (typeIds.includes(videoTypeHex) || typeIds.includes(videoBlockHex)) {
     return 'VIDEO';
   }
 

--- a/apps/web/core/io/queries.ts
+++ b/apps/web/core/io/queries.ts
@@ -1,6 +1,5 @@
 import { SystemIds } from '@geoprotocol/geo-sdk';
 
-import { VIDEO_BLOCK_TYPE } from '~/core/constants';
 import { EntitiesOrderBy, type EntityFilter, type UuidFilter } from '~/core/gql/graphql';
 import { Entity, SearchResult } from '~/core/types';
 
@@ -256,7 +255,8 @@ const EXCLUDED_BLOCK_TYPES = [
   SystemIds.IMAGE_BLOCK,
   SystemIds.DATA_BLOCK,
   SystemIds.IMAGE_TYPE,
-  VIDEO_BLOCK_TYPE,
+  SystemIds.VIDEO_TYPE,
+  SystemIds.VIDEO_BLOCK,
 ];
 
 const BLOCK_TYPE_EXCLUSION_FILTERS = EXCLUDED_BLOCK_TYPES.map(typeId => ({

--- a/apps/web/core/state/editor/block-types.ts
+++ b/apps/web/core/state/editor/block-types.ts
@@ -1,6 +1,5 @@
 import { IdUtils, Position, SystemIds } from '@geoprotocol/geo-sdk';
 
-import { VIDEO_BLOCK_TYPE } from '~/core/constants';
 import { EntityId } from '~/core/io/substream-schema';
 import { Relation } from '~/core/types';
 
@@ -8,7 +7,14 @@ type BlockTypeId =
   | typeof SystemIds.TEXT_BLOCK
   | typeof SystemIds.IMAGE_TYPE
   | typeof SystemIds.DATA_BLOCK
-  | typeof VIDEO_BLOCK_TYPE;
+  | typeof SystemIds.VIDEO_TYPE;
+
+const BLOCK_TYPE_NAMES: Record<BlockTypeId, string> = {
+  [SystemIds.TEXT_BLOCK]: 'Text Block',
+  [SystemIds.IMAGE_TYPE]: 'Image',
+  [SystemIds.DATA_BLOCK]: 'Data Block',
+  [SystemIds.VIDEO_TYPE]: 'Video',
+};
 
 export function getRelationForBlockType(
   fromBlockEntityId: string,
@@ -27,7 +33,7 @@ export function getRelationForBlockType(
     },
     toEntity: {
       id: EntityId(blockTypeId),
-      name: null,
+      name: BLOCK_TYPE_NAMES[blockTypeId],
       value: blockTypeId,
     },
     fromEntity: {

--- a/apps/web/core/state/editor/use-editor.tsx
+++ b/apps/web/core/state/editor/use-editor.tsx
@@ -8,11 +8,10 @@ import { useSearchParams } from 'next/navigation';
 
 import * as React from 'react';
 
-import { VIDEO_BLOCK_TYPE, VIDEO_URL_PROPERTY } from '~/core/constants';
 import { storage } from '~/core/sync/use-mutate';
 import { getValues, useValues } from '~/core/sync/use-store';
 import { Relation, RenderableEntityType } from '~/core/types';
-import { getImageHash, getImagePath, getVideoPath, validateEntityId } from '~/core/utils/utils';
+import { getImagePath, getVideoPath, validateEntityId } from '~/core/utils/utils';
 
 import { tiptapExtensions } from '~/partials/editor/extensions';
 
@@ -263,24 +262,37 @@ export function useEditorStore() {
         const toEntity = relationForBlockId?.block;
 
         if (toEntity?.type === 'IMAGE') {
+          // Read image URL from Values using IMAGE_URL_PROPERTY (unified IPFS URL property)
+          const imageUrlValues = getValues({
+            mergeWith: initialBlockValues,
+            selector: value => value.entity.id === block.block.id && value.property.id === SystemIds.IMAGE_URL_PROPERTY,
+          });
+          const imageUrlValue = imageUrlValues?.[0]?.value || toEntity.value;
+
+          // Read image title from Values using NAME_PROPERTY
+          const titleValues = getValues({
+            mergeWith: initialBlockValues,
+            selector: value => value.entity.id === block.block.id && value.property.id === SystemIds.NAME_PROPERTY,
+          });
+          const titleValue = titleValues?.[0]?.value || '';
+
           return {
             type: 'image',
             attrs: {
               id: block.block.id,
-              src: getImagePath(toEntity.value),
+              src: getImagePath(imageUrlValue),
+              title: titleValue,
               relationId: block.relationId,
               spaceId,
-              alt: '',
-              title: '',
             },
           };
         }
 
         if (toEntity?.type === 'VIDEO') {
-          // Read video URL from Values using VIDEO_URL_PROPERTY
+          // Read video URL from Values using IMAGE_URL_PROPERTY (unified IPFS URL property)
           const videoUrlValues = getValues({
             mergeWith: initialBlockValues,
-            selector: value => value.entity.id === block.block.id && value.property.id === VIDEO_URL_PROPERTY,
+            selector: value => value.entity.id === block.block.id && value.property.id === SystemIds.IMAGE_URL_PROPERTY,
           });
           const videoUrlValue = videoUrlValues?.[0]?.value || toEntity.value;
 
@@ -405,7 +417,7 @@ export function useEditorStore() {
             case 'image':
               return SystemIds.IMAGE_TYPE;
             case 'video':
-              return VIDEO_BLOCK_TYPE;
+              return SystemIds.VIDEO_TYPE;
             default:
               return SystemIds.TEXT_BLOCK;
           }
@@ -420,35 +432,15 @@ export function useEditorStore() {
             break;
           }
           case SystemIds.IMAGE_TYPE: {
-            const imageHash = getImageHash(node.attrs?.src);
-            const imageUrl = `ipfs://${imageHash}`;
-
-            // const { ops } = Image.make({ cid: imageUrl });
-            // const [, setTripleOp] = ops;
-
-            // DB.upsertRelation({ relation: getRelationForBlockType(node.id, SystemIds.IMAGE_TYPE, spaceId), spaceId });
-
-            // if (setTripleOp.type === 'SET_TRIPLE') {
-            //   DB.upsert(
-            //     {
-            //       value: {
-            //         type: 'URL',
-            //         value: setTripleOp.triple.value.value,
-            //       },
-            //       entityId: node.id,
-            //       attributeId: setTripleOp.triple.attribute,
-            //       entityName: null,
-            //       attributeName: 'Image URL',
-            //     },
-            //     spaceId
-            //   );
-            // }
-
+            // Create a Types relation to mark this entity as an Image type
+            // URL storage is handled by image-node.tsx component
+            const imageTypeRelation = getRelationForBlockType(node.id, SystemIds.IMAGE_TYPE, spaceId);
+            storage.relations.set(imageTypeRelation);
             break;
           }
-          case VIDEO_BLOCK_TYPE: {
-            // Create a Types relation to mark this entity as a Video Block type
-            const relation = getRelationForBlockType(node.id, VIDEO_BLOCK_TYPE, spaceId);
+          case SystemIds.VIDEO_TYPE: {
+            // Create a Types relation to mark this entity as a Video type
+            const relation = getRelationForBlockType(node.id, SystemIds.VIDEO_TYPE, spaceId);
             storage.relations.set(relation);
             break;
           }
@@ -470,29 +462,9 @@ export function useEditorStore() {
 
       makeBlocksRelations({
         nextBlocks: newBlocks,
-        addedBlocks: addedBlocks.map(block => {
-          // For image blocks, store the ipfs URL in toEntity.value
-          // For video blocks, just use the block ID (URL is stored as a Value with VIDEO_URL_PROPERTY)
-          if (block.type === 'image') {
-            const imageHash = getImageHash(block.attrs?.src ?? '');
-            const imageUrl = `ipfs://${imageHash}`;
-            return { id: block.id, value: imageHash === '' ? block.id : imageUrl };
-          }
-          // Video blocks and other blocks use block ID as the value
-          return { id: block.id, value: block.id };
-        }),
+        addedBlocks: addedBlocks.map(block => ({ id: block.id, value: block.id })),
         removedBlockIds: removed,
-        movedBlocks: movedBlocks.map(block => {
-          // For image blocks, store the ipfs URL in toEntity.value
-          // For video blocks, just use the block ID (URL is stored as a Value with VIDEO_URL_PROPERTY)
-          if (block.type === 'image') {
-            const imageHash = getImageHash(block.attrs?.src ?? '');
-            const imageUrl = `ipfs://${imageHash}`;
-            return { id: block.id, value: imageHash === '' ? block.id : imageUrl };
-          }
-          // Video blocks and other blocks use block ID as the value
-          return { id: block.id, value: block.id };
-        }),
+        movedBlocks: movedBlocks.map(block => ({ id: block.id, value: block.id })),
         spaceId,
         blockRelations: blockRelations,
         entityPageId: activeEntityId,
@@ -515,26 +487,10 @@ export function useEditorStore() {
 
             break;
           }
-          case 'image': {
-            // Update the relation if the image src has changed
-            const existingRelation = blockRelations.find(r => r.block.id === node.attrs?.id);
-            if (existingRelation && node.attrs?.src) {
-              const imageHash = getImageHash(node.attrs.src);
-              const imageUrl = `ipfs://${imageHash}`;
-              // Only update if the value has changed
-              if (existingRelation.toEntity.value !== imageUrl && imageHash !== '') {
-                const updatedRelation: Relation = {
-                  ...existingRelation,
-                  toEntity: {
-                    ...existingRelation.toEntity,
-                    value: imageUrl,
-                  },
-                };
-                storage.relations.set(updatedRelation);
-              }
-            }
+          case 'image':
+            // Image block persistence is handled directly in image-node.tsx component
+            // using storage.values.set() for URL and storage.entities.name.set() for title
             break;
-          }
           case 'video':
             // Video block persistence is handled directly in video-node.tsx component
             // using storage.entities.name.set() for title

--- a/apps/web/core/sync/use-mutate.tsx
+++ b/apps/web/core/sync/use-mutate.tsx
@@ -1,7 +1,7 @@
 import { Graph, Position, SystemIds } from '@geoprotocol/geo-sdk';
 import { Draft, produce } from 'immer';
 
-import { DATA_TYPE_ENTITY_IDS, DATA_TYPE_PROPERTY, RENDERABLE_TYPE_PROPERTY, VIDEO_TYPE, VIDEO_URL_PROPERTY } from '../constants';
+import { DATA_TYPE_ENTITY_IDS, DATA_TYPE_PROPERTY, RENDERABLE_TYPE_PROPERTY } from '../constants';
 import { ID } from '../id';
 import { OmitStrict } from '../types';
 import { DataType, Relation, Value } from '../types';
@@ -433,13 +433,13 @@ function createMutator(store: GeoStore): Mutator {
           }
         }
 
-        // Create a video entity with VIDEO_URL_PROPERTY instead of IMAGE_URL_PROPERTY
+        // Create a video entity with the unified IPFS URL property
         const videoIdStr = toHexId(videoId);
         if (ipfsUrl) {
           store.setValue({
             id: ID.createValueId({
               entityId: videoIdStr,
-              propertyId: VIDEO_URL_PROPERTY,
+              propertyId: SystemIds.IMAGE_URL_PROPERTY,
               spaceId,
             }),
             entity: {
@@ -447,8 +447,8 @@ function createMutator(store: GeoStore): Mutator {
               name: null,
             },
             property: {
-              id: VIDEO_URL_PROPERTY,
-              name: 'Video URL',
+              id: SystemIds.IMAGE_URL_PROPERTY,
+              name: 'IPFS URL',
               dataType: 'TEXT',
               renderableType: 'URL',
             },
@@ -470,9 +470,9 @@ function createMutator(store: GeoStore): Mutator {
             name: 'Types',
           },
           toEntity: {
-            id: VIDEO_TYPE,
+            id: SystemIds.VIDEO_TYPE,
             name: 'Video',
-            value: VIDEO_TYPE,
+            value: SystemIds.VIDEO_TYPE,
           },
           spaceId,
           position: Position.generate(),

--- a/apps/web/partials/editor/command-items.tsx
+++ b/apps/web/partials/editor/command-items.tsx
@@ -1,9 +1,6 @@
-import { Graph } from '@geoprotocol/geo-sdk';
 import { Editor, Range } from '@tiptap/core';
 
 import * as React from 'react';
-
-import { getImagePath } from '~/core/utils/utils';
 
 import { EditorH1 } from '~/design-system/icons/editor-h1';
 import { EditorH2 } from '~/design-system/icons/editor-h2';
@@ -96,44 +93,18 @@ export const commandItems: CommandSuggestionItem[] = [
   {
     icon: <EditorImage />,
     title: 'Image',
-    command: async ({ editor, range }) => {
-      const input = document.createElement('input');
-      input.type = 'file';
-      input.accept = 'image/png, image/jpeg';
-      input.className = 'hidden';
-      input.onchange = async (e: any) => {
-        if (!e?.target?.files?.[0]) return;
-        const file = e.target.files[0];
-        // Use TESTNET network to upload to Pinata via alternative gateway
-        const { id, ops } = await Graph.createImage({
-          blob: file,
-          network: 'TESTNET',
-        });
-
-        // Extract the image URL from the ops - look for createEntity with ipfs:// value
-        let ipfsUrl: string | undefined;
-        for (const op of ops) {
-          if (op.type === 'createEntity') {
-            // Type assertion for new SDK format
-            const values = (op as unknown as { values: Array<{ value: { type: string; value?: string } }> }).values;
-            const ipfsValue = values?.find(pv => {
-              const val = pv.value?.value;
-              return typeof val === 'string' && val.startsWith('ipfs://');
-            });
-            if (ipfsValue) {
-              ipfsUrl = ipfsValue.value?.value;
-              break;
-            }
-          }
-        }
-
-        const src = ipfsUrl ? getImagePath(ipfsUrl) : '';
-
-        if (src) {
-          editor.chain().focus().deleteRange(range).setImage({ src }).run();
-        }
-      };
-      input.click();
+    command: ({ editor, range }) => {
+      editor
+        .chain()
+        .focus()
+        .deleteRange({ from: range.from, to: range.to })
+        .insertContent({
+          type: 'image',
+        })
+        .createParagraphNear()
+        .blur()
+        .focus()
+        .run();
     },
   },
   {

--- a/apps/web/partials/editor/extensions.tsx
+++ b/apps/web/partials/editor/extensions.tsx
@@ -4,7 +4,6 @@ import Document from '@tiptap/extension-document';
 import Gapcursor from '@tiptap/extension-gapcursor';
 import HardBreak from '@tiptap/extension-hard-break';
 import History from '@tiptap/extension-history';
-import Image from '@tiptap/extension-image';
 import Italic from '@tiptap/extension-italic';
 import Link from '@tiptap/extension-link';
 import ListItem from '@tiptap/extension-list-item';
@@ -14,6 +13,7 @@ import Text from '@tiptap/extension-text';
 import { ConfiguredCommandExtension } from './command-extension';
 import { DataNode } from './data-node';
 import { HeadingNode } from './heading-node';
+import { ImageNode } from './image-node';
 import { ParagraphNode } from './paragraph-node';
 import { TrailingNode } from './trailing-node';
 import { VideoNode } from './video-node';
@@ -52,7 +52,7 @@ export const tiptapExtensions = [
   BulletList,
   ListItem,
   DataNode,
-  Image,
+  ImageNode,
   VideoNode,
   Placeholder.configure({
     placeholder: ({ node }) => {


### PR DESCRIPTION
Image blocks now use the same placeholder-then-upload pattern as video blocks instead of opening a file picker inline. Block type names are included in local relations so the diff viewer shows types before publish. Image block entities are no longer incorrectly filtered from local diffs.