### PR TITLE
feat: add 60s revalidate to cacheable routes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ replay.log
 .output
 .nitro
 tmp
+.worktrees/

--- a/apps/web/app/root/layout.tsx
+++ b/apps/web/app/root/layout.tsx
@@ -8,6 +8,8 @@ import { DEFAULT_OPENGRAPH_IMAGE, ROOT_SPACE } from '~/core/constants';
 
 import Layout from '../space/[id]/layout';
 
+export const revalidate = 60;
+
 export const metadata: Metadata = {
   title: 'Geo Genesis',
   description: "Browse and organize the world's public knowledge and information in a decentralized way.",

--- a/apps/web/app/space/(entity)/[id]/[entityId]/activity/page.tsx
+++ b/apps/web/app/space/(entity)/[id]/[entityId]/activity/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from 'next/navigation';
 
 import { ActivityPage } from '~/partials/activity/activity-page';
 
+export const revalidate = 60;
 interface Props {
   params: Promise<{ id: string; entityId: string }>;
   searchParams: Promise<{

--- a/apps/web/app/space/(entity)/[id]/[entityId]/default-entity-page.tsx
+++ b/apps/web/app/space/(entity)/[id]/[entityId]/default-entity-page.tsx
@@ -25,6 +25,7 @@ import { ToggleEntityPage } from '~/partials/entity-page/toggle-entity-page';
 import { cachedFetchEntitiesBatch, cachedFetchEntityPage } from './cached-fetch-entity';
 import { EntityPageHeader } from './entity-page-header';
 
+export const revalidate = 60;
 interface Props {
   params: { id: string; entityId: string };
   searchParams?: { [key: string]: string | string[] | undefined };

--- a/apps/web/app/space/(entity)/[id]/[entityId]/layout.tsx
+++ b/apps/web/app/space/(entity)/[id]/[entityId]/layout.tsx
@@ -22,6 +22,7 @@ import { EntityTabs } from '~/partials/entity-page/entity-tabs';
 
 import { cachedFetchEntitiesBatch, cachedFetchEntity, cachedFetchEntityPage } from './cached-fetch-entity';
 
+export const revalidate = 60;
 interface Props {
   params: Promise<{ id: string; entityId: string }>;
   children: React.ReactNode;

--- a/apps/web/app/space/[id]/activity/page.tsx
+++ b/apps/web/app/space/[id]/activity/page.tsx
@@ -6,6 +6,7 @@ import { Skeleton } from '~/design-system/skeleton';
 
 import { ActivityServerContainer } from '~/partials/activity/activity-server-container';
 
+export const revalidate = 60;
 interface Props {
   params: Promise<{ id: string }>;
 }

--- a/apps/web/app/space/[id]/layout.tsx
+++ b/apps/web/app/space/[id]/layout.tsx
@@ -26,6 +26,7 @@ import { SpaceTabs } from '~/partials/space-page/space-tabs';
 import { cachedFetchEntitiesBatch } from '../(entity)/[id]/[entityId]/cached-fetch-entity';
 import { cachedFetchSpace } from './cached-fetch-space';
 
+export const revalidate = 60;
 type LayoutProps = {
   params: Promise<{ id: string }>;
   children: React.ReactNode;

--- a/apps/web/app/space/[id]/page.tsx
+++ b/apps/web/app/space/[id]/page.tsx
@@ -21,6 +21,7 @@ import { Subspaces } from '~/partials/space-page/subspaces';
 
 import { cachedFetchSpace } from './cached-fetch-space';
 
+export const revalidate = 60;
 interface Props {
   params: Promise<{ id: string }>;
 }


### PR DESCRIPTION
Summary:
- Add 60s revalidate to public app routes/layouts to enable edge caching
- Ignore local .worktrees directory