### PR TITLE
fix: migrate proposed editors/members to REST API and skip RELATION values in publish

### DIFF
--- a/apps/web/core/io/subgraph/fetch-proposed-editors.ts
+++ b/apps/web/core/io/subgraph/fetch-proposed-editors.ts
@@ -1,91 +1,60 @@
-import * as Effect from 'effect/Effect';
-import * as Either from 'effect/Either';
-import { v4 as uuid } from 'uuid';
+import { Effect, Either, Schema } from 'effect';
 
 import { Environment } from '~/core/environment';
 
-import { graphql } from './graphql';
-
-const getFetchProposedEditorsQuery = (spaceId: string) => `query {
-  proposalsConnection(
-    filter: {
-      spaceId: { is: "${spaceId}" }
-      executedAt: { isNull: true }
-      proposalActionsConnection: {
-        some: { actionType: { in: [ADD_EDITOR] } }
-      }
-    }
-  ) {
-    nodes {
-      proposalActions {
-        targetId
-      }
-    }
-  }
-}`;
+import { ApiProposalListResponseSchema, encodePathSegment, restFetch, validateActionTypes } from '../rest';
+import { AbortError } from './errors';
 
 export interface FetchProposedEditorsOptions {
   id: string;
 }
 
-type NetworkResult = {
-  proposalsConnection: {
-    nodes: Array<{
-      proposalActions: Array<{ targetId: string | null }>;
-    }>;
-  };
-};
-
+/**
+ * Fetch the space IDs of editors with active (non-rejected, non-expired) ADD_EDITOR proposals.
+ *
+ * Uses the REST API which correctly computes proposal status, handling both
+ * time-based expiry and fast-path rejections (where a proposal can be rejected
+ * before the voting period ends).
+ */
 export async function fetchProposedEditors(options: FetchProposedEditorsOptions): Promise<string[]> {
-  const queryId = uuid();
-  const endpoint = Environment.getConfig().api;
+  const config = Environment.getConfig();
 
-  const graphqlFetchEffect = graphql<NetworkResult>({
-    endpoint,
-    query: getFetchProposedEditorsQuery(options.id),
-  });
+  const params = new URLSearchParams();
+  params.set('limit', '100');
+  params.set('status', 'PROPOSED,EXECUTABLE');
+  params.set('actionTypes', validateActionTypes(['AddEditor']).join(','));
 
-  const graphqlFetchWithErrorFallbacks = Effect.gen(function* (awaited) {
-    const resultOrError = yield* awaited(Effect.either(graphqlFetchEffect));
+  const path = `/proposals/space/${encodePathSegment(options.id)}/status?${params.toString()}`;
 
-    if (Either.isLeft(resultOrError)) {
-      const error = resultOrError.left;
+  const result = await Effect.runPromise(
+    Effect.either(
+      restFetch<unknown>({
+        endpoint: config.api,
+        path,
+      })
+    )
+  );
 
-      switch (error._tag) {
-        case 'AbortError':
-          // Right now we re-throw AbortErrors and let the callers handle it. Eventually we want
-          // the caller to consume the error channel as an effect. We throw here the typical JS
-          // way so we don't infect more of the codebase with the effect runtime.
-          throw error;
-        case 'GraphqlRuntimeError':
-          console.error(
-            `Encountered runtime graphql error in fetchProposedEditors. queryId: ${queryId} spaceId: ${
-              options.id
-            } endpoint: ${endpoint}
+  if (Either.isLeft(result)) {
+    const error = result.left;
 
-            queryString: ${getFetchProposedEditorsQuery(options.id)}
-            `,
-            error.message
-          );
-
-          return { proposalsConnection: { nodes: [] } };
-
-        default:
-          console.error(
-            `${error._tag}: Unable to fetch proposed editors, queryId: ${queryId} spaceId: ${options.id} endpoint: ${endpoint}`
-          );
-
-          return { proposalsConnection: { nodes: [] } };
-      }
+    if (error instanceof AbortError) {
+      throw error;
     }
 
-    return resultOrError.right;
-  });
+    console.error(`Failed to fetch proposed editors for space ${options.id}:`, error);
+    return [];
+  }
 
-  const result = await Effect.runPromise(graphqlFetchWithErrorFallbacks);
+  const decoded = Schema.decodeUnknownEither(ApiProposalListResponseSchema)(result.right);
 
-  const targetIds = result.proposalsConnection.nodes.flatMap(node =>
-    node.proposalActions.map(action => action.targetId).filter((id): id is string => id != null)
+  if (Either.isLeft(decoded)) {
+    console.error(`Failed to decode proposed editors for space ${options.id}:`, decoded.left);
+    return [];
+  }
+
+  const targetIds = decoded.right.proposals.flatMap(proposal =>
+    proposal.actions.filter(a => a.actionType === 'ADD_EDITOR').map(a => a.targetId).filter((id): id is string => id != null)
   );
 
   return targetIds;

--- a/apps/web/core/utils/publish/publish.test.ts
+++ b/apps/web/core/utils/publish/publish.test.ts
@@ -372,6 +372,44 @@ describe('prepareLocalDataForPublishing', () => {
       expect(result[0].type).toBe('createRelation');
       expect(result[1].type).toBe('updateEntity');
     });
+
+    it('should skip values with RELATION data type instead of throwing', () => {
+      const entityId = IdUtils.generate();
+      const values = [
+        createMockValue({
+          entity: { id: entityId, name: 'Entity' },
+          property: { id: IdUtils.generate(), name: 'Some Relation', dataType: 'RELATION' },
+          value: '',
+        }),
+        createMockValue({
+          entity: { id: entityId, name: 'Entity' },
+          property: { id: IdUtils.generate(), name: 'Name', dataType: 'TEXT' },
+          value: 'hello',
+        }),
+      ];
+      const relations: Relation[] = [];
+
+      const result = prepareLocalDataForPublishing(values, relations, 'test-space');
+
+      expect(result).toHaveLength(1);
+      const updateOp = result[0] as UpdateEntityOp;
+      expect(updateOp.type).toBe('updateEntity');
+      expect(updateOp.set).toHaveLength(1);
+    });
+
+    it('should skip deleted values with RELATION data type instead of unsetting them', () => {
+      const values = [
+        createMockValue({
+          property: { id: IdUtils.generate(), name: 'Some Relation', dataType: 'RELATION' },
+          isDeleted: true,
+        }),
+      ];
+      const relations: Relation[] = [];
+
+      const result = prepareLocalDataForPublishing(values, relations, 'test-space');
+
+      expect(result).toHaveLength(0);
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

- **Migrate `fetchProposedEditors` and `fetchProposedMembers` from GraphQL to the REST API.** The GraphQL queries used `executedAt: isNull` to find active proposals, which missed fast-path rejections (rejected before voting period ends) and expired-but-unexecuted proposals. The REST API correctly computes proposal status, handling both time-based expiry and fast-path rejections. Responses are validated with Effect Schema.

- **Skip RELATION data type values in the publish flow instead of throwing.** Values with `RELATION` data type can end up in the local store's values array, but they should be handled via `Graph.createRelation`/`deleteRelation`. The publish logic now gracefully filters them out for both set and deleted values, preventing crashes.