### PR TITLE
chore: document RELATION value leak in local store

### DIFF
--- a/apps/web/partials/entity-page/entity-page-metadata-header.tsx
+++ b/apps/web/partials/entity-page/entity-page-metadata-header.tsx
@@ -107,6 +107,15 @@ export function EntityPageMetadataHeader({ id, spaceId, isRelationPage = false }
     return Properties.getCurrentRenderableType(propertyDataType);
   }, [propertyDataType]);
 
+  // @TODO: When a property's dataType changes (e.g. TEXT → RELATION or vice versa),
+  // this function only updates the property entity's own metadata (Data Type and
+  // Renderable Type relations). It does not clean up existing value or relation entries
+  // on consumer entities that use this property. For example, switching TEXT → RELATION
+  // leaves orphaned value entries (with value: '') on those entities, and switching
+  // RELATION → TEXT would leave orphaned relation entries. These orphans persist in
+  // IndexedDB and can surface at publish time. The publish flow has a defensive filter
+  // for RELATION values (see publish.ts), but the proper fix would be to clean up
+  // stale entries here — needs careful testing to avoid cascading issues.
   const handlePropertyTypeChange = React.useCallback(
     (newType: SwitchableRenderableType) => {
       if (!entityId || !spaceId) return;


### PR DESCRIPTION
## Summary

Documents the root cause of the RELATION values that were crashing the publish flow (fixed in #1471).

**Two `@TODO` comments added:**

1. **`addPropertyToEntity` in `use-create-property.ts`** — When a user adds a RELATION-type property to an entity, this function unconditionally calls `storage.values.set()`, creating a phantom `{ dataType: 'RELATION', value: '' }` entry in the values store. RELATION properties should only exist in the relations store. The fix is to gate on `if (dataType === 'RELATION') return;` but needs testing to ensure it doesn't break property visibility or schema placeholder resolution.

2. **`handlePropertyTypeChange` in `entity-page-metadata-header.tsx`** — When a property's dataType changes (e.g. TEXT → RELATION), this only updates the property entity's own metadata. It does not clean up existing value or relation entries on consumer entities. Switching TEXT → RELATION leaves orphaned value entries; RELATION → TEXT would leave orphaned relation entries. These persist in IndexedDB and surface at publish time.