### PR TITLE
fix: tighten Sentry first-party allowlist matching

### DIFF
--- a/apps/web/instrumentation-client.ts
+++ b/apps/web/instrumentation-client.ts
@@ -33,6 +33,14 @@ if (isTelemetryEnabled) {
       return event;
     },
 
+    // Keep only errors with stack frames from first-party origins.
+    allowUrls: [
+      /^https:\/\/([\w-]+\.)*geobrowser\.io(?:\/|$)/i,
+      /^https:\/\/.*\.vercel\.app(?:\/|$)/i,
+      /^https?:\/\/localhost(?::\d+)?(?:\/|$)/i,
+      /^https?:\/\/127\.0\.0\.1(?::\d+)?(?:\/|$)/i,
+    ],
+
     // Block errors from proxied third-party origins
     denyUrls: [/geo\.framer\.website/, /geo-blog\.vercel\.app/, /geobrowser-v2\.vercel\.app/],
 


### PR DESCRIPTION
## Summary
- tighten Sentry `allowUrls` host matching in `apps/web/instrumentation-client.ts` by anchoring patterns to explicit URL boundaries
- keep existing first-party targets (`*.geobrowser.io`, Vercel previews, localhost, 127.0.0.1) while preventing loose substring-style matches
- improve signal quality for extension-noise filtering by making the allowlist deterministic and easier to reason about