### PR TITLE
refactor: address Copilot feedback on explore PR

### DIFF
--- a/apps/web/app/api/explore/feed/route.ts
+++ b/apps/web/app/api/explore/feed/route.ts
@@ -8,23 +8,13 @@ import {
   resolveMemberSpaceFromWalletSafe,
 } from '~/core/browse/resolve-member-space-from-wallet';
 import { WALLET_ADDRESS } from '~/core/cookie';
-import {
-  type ExploreSort,
-  type ExploreTime,
-  fetchExploreFeed,
-} from '~/core/explore/fetch-explore-feed';
+import { type ExploreTime, fetchExploreFeed } from '~/core/explore/fetch-explore-feed';
 
 function normId(id: string): string {
   return id.replace(/-/g, '').toLowerCase();
 }
 
-const SORTS: ExploreSort[] = ['new'];
 const TIMES: ExploreTime[] = ['today', 'week', 'month', 'year', 'all'];
-
-function parseSort(raw: string | null): ExploreSort {
-  if (raw && (SORTS as string[]).includes(raw)) return raw as ExploreSort;
-  return 'new';
-}
 
 function parseTime(raw: string | null): ExploreTime {
   if (raw && (TIMES as string[]).includes(raw)) return raw as ExploreTime;
@@ -33,7 +23,6 @@ function parseTime(raw: string | null): ExploreTime {
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
-  const sort = parseSort(searchParams.get('sort'));
   const time = parseTime(searchParams.get('time'));
   const spaceId = searchParams.get('spaceId');
   const cursor = searchParams.get('cursor');
@@ -82,11 +71,10 @@ export async function GET(request: Request) {
   try {
     const result = await fetchExploreFeed({
       browse,
-      sort,
       time,
       spaceFilterId: spaceFilter,
       cursor,
-      walletAddress: cookieWallet ?? null,
+      personalMemberSpaceId,
       memberOrEditorSpaceIds,
     });
     return NextResponse.json(result);

--- a/apps/web/core/explore/explore-constants.ts
+++ b/apps/web/core/explore/explore-constants.ts
@@ -15,4 +15,7 @@ export const EXPLORE_ENTITY_DESCRIPTION_PROPERTY_ID = '9b1f76ff9711404c861e59dc3
 export const EXPLORE_COVER_PROPERTY_ID = '34f535072e6b42c5a84443981a77cfa2';
 export const EXPLORE_AVATAR_PROPERTY_ID = '1155befffad549b7a2e0da4777b8792c';
 
+/** Relation type for a comment's "Reply to" edge. Used to count comments per entity via backlinks.totalCount. */
+export const EXPLORE_COMMENT_REPLY_TO_TYPE_ID = '310d4a240e5b451cb2151bfce40d0fe6';
+
 export const EXPLORE_PAGE_SIZE = 22;

--- a/apps/web/core/explore/explore-constants.ts
+++ b/apps/web/core/explore/explore-constants.ts
@@ -15,7 +15,4 @@ export const EXPLORE_ENTITY_DESCRIPTION_PROPERTY_ID = '9b1f76ff9711404c861e59dc3
 export const EXPLORE_COVER_PROPERTY_ID = '34f535072e6b42c5a84443981a77cfa2';
 export const EXPLORE_AVATAR_PROPERTY_ID = '1155befffad549b7a2e0da4777b8792c';
 
-/** Relation type for a comment's "Reply to" edge. Used to count comments per entity via backlinks.totalCount. */
-export const EXPLORE_COMMENT_REPLY_TO_TYPE_ID = '310d4a240e5b451cb2151bfce40d0fe6';
-
 export const EXPLORE_PAGE_SIZE = 22;

--- a/apps/web/core/explore/explore-entities-document.ts
+++ b/apps/web/core/explore/explore-entities-document.ts
@@ -1,6 +1,8 @@
 import type { TypedDocumentNode } from '@graphql-typed-document-node/core';
 import { parse } from 'graphql';
 
+import { EXPLORE_COMMENT_REPLY_TO_TYPE_ID } from './explore-constants';
+
 /**
  * Like `allEntitiesConnectionDocument`, but scopes `valuesList` / `relationsList` to any of
  * the given spaces so multi-space explore feeds still decode cover/avatar/description.
@@ -43,7 +45,7 @@ const EXPLORE_ENTITIES_CONNECTION_SOURCE = /* GraphQL */ `
         spaceIds
         updatedAt
 
-        backlinks(filter: { typeId: { is: "310d4a240e5b451cb2151bfce40d0fe6" } }) {
+        backlinks(filter: { typeId: { is: "${EXPLORE_COMMENT_REPLY_TO_TYPE_ID}" } }) {
           totalCount
         }
 

--- a/apps/web/core/explore/explore-entities-document.ts
+++ b/apps/web/core/explore/explore-entities-document.ts
@@ -1,7 +1,7 @@
 import type { TypedDocumentNode } from '@graphql-typed-document-node/core';
 import { parse } from 'graphql';
 
-import { EXPLORE_COMMENT_REPLY_TO_TYPE_ID } from './explore-constants';
+import { COMMENT_REPLY_TO_ID } from '~/core/comment-ids';
 
 /**
  * Like `allEntitiesConnectionDocument`, but scopes `valuesList` / `relationsList` to any of
@@ -45,7 +45,7 @@ const EXPLORE_ENTITIES_CONNECTION_SOURCE = /* GraphQL */ `
         spaceIds
         updatedAt
 
-        backlinks(filter: { typeId: { is: "${EXPLORE_COMMENT_REPLY_TO_TYPE_ID}" } }) {
+        backlinks(filter: { typeId: { is: "${COMMENT_REPLY_TO_ID}" } }) {
           totalCount
         }
 

--- a/apps/web/core/explore/fetch-explore-feed.ts
+++ b/apps/web/core/explore/fetch-explore-feed.ts
@@ -7,7 +7,6 @@ import { EntitiesOrderBy, type EntityFilter, type UuidFilter } from '~/core/gql/
 import { EntityDecoder } from '~/core/io/decoders/entity';
 import { graphql } from '~/core/io/graphql-client';
 import { hasActiveMemberProposal } from '~/core/io/subgraph/fetch-proposed-members';
-import { fetchProfile } from '~/core/io/subgraph';
 import type { Entity } from '~/core/types';
 
 import {
@@ -21,7 +20,6 @@ import {
 import { exploreEntitiesConnectionDocument } from './explore-entities-document';
 import { parseEntityUpdatedAtToUnixSec } from './explore-relative-time';
 
-export type ExploreSort = 'new';
 export type ExploreTime = 'today' | 'week' | 'month' | 'year' | 'all';
 
 export type ExploreFeedItem = {
@@ -223,11 +221,11 @@ function browseSpaceRowsToMap(data: BrowseSidebarData): Map<string, { name: stri
 
 export async function fetchExploreFeed(args: {
   browse: BrowseSidebarData;
-  sort: ExploreSort;
   time: ExploreTime;
   spaceFilterId: string | null;
   cursor: string | null;
-  walletAddress?: string | null;
+  /** The caller's personal-space entity id, already resolved by the route. */
+  personalMemberSpaceId?: string | null;
   memberOrEditorSpaceIds: string[];
 }): Promise<ExploreFeedResult> {
   const spaceMeta = browseSpaceRowsToMap(args.browse);
@@ -254,17 +252,13 @@ export async function fetchExploreFeed(args: {
       hasPendingMembershipRequest: false,
     }));
 
-    const wallet = args.walletAddress;
-    if (!wallet) return out;
+    const memberSpaceId = args.personalMemberSpaceId;
+    if (!memberSpaceId) return out;
 
     const pendingTargets = [...new Set(out.filter(o => !o.isMemberOrEditor).map(o => o.spaceId))];
     if (pendingTargets.length === 0) return out;
 
     try {
-      const profile = await Effect.runPromise(fetchProfile(wallet));
-      const memberSpaceId = profile?.spaceId;
-      if (!memberSpaceId) return out;
-
       const pendingMap = new Map<string, boolean>();
       await Promise.all(
         pendingTargets.map(async sid => {

--- a/apps/web/partials/comments/comments-section.tsx
+++ b/apps/web/partials/comments/comments-section.tsx
@@ -44,10 +44,56 @@ export function CommentSection({ entityId, spaceId }: CommentSectionProps) {
   React.useEffect(() => {
     if (typeof window === 'undefined') return;
     if (window.location.hash !== '#entity-comments') return;
+
+    // Re-scroll to the comments anchor while the page is still settling. Async queries
+    // (values, relations, etc.) load after initial mount and push the anchor down, so
+    // a single scrollIntoView on mount leaves the user in the wrong spot. We re-anchor
+    // on every body resize until the layout is stable OR the user scrolls.
     const el = document.getElementById('entity-comments');
-    if (el) {
-      requestAnimationFrame(() => el.scrollIntoView({ behavior: 'smooth', block: 'start' }));
+    if (!el) return;
+
+    let stopped = false;
+    let lastResizeAt = performance.now();
+    let programmaticScrollAt = 0;
+
+    const scrollToAnchor = () => {
+      if (stopped) return;
+      programmaticScrollAt = performance.now();
+      el.scrollIntoView({ behavior: 'auto', block: 'start' });
+    };
+
+    scrollToAnchor();
+
+    const observer = new ResizeObserver(() => {
+      lastResizeAt = performance.now();
+      scrollToAnchor();
+    });
+    observer.observe(document.body);
+
+    // Bail out if the user initiates a scroll themselves — don't fight them.
+    const onScroll = () => {
+      // Ignore scrolls within 150ms of our own programmatic scroll.
+      if (performance.now() - programmaticScrollAt < 150) return;
+      stop();
+    };
+    window.addEventListener('scroll', onScroll, { passive: true });
+
+    // Stop once the layout has been stable for 800ms, or hard cap at 8s.
+    const stabilityInterval = window.setInterval(() => {
+      if (performance.now() - lastResizeAt > 800) stop();
+    }, 100);
+    const hardCap = window.setTimeout(stop, 8000);
+
+    function stop() {
+      if (stopped) return;
+      stopped = true;
+      observer.disconnect();
+      window.removeEventListener('scroll', onScroll);
+      window.clearInterval(stabilityInterval);
+      window.clearTimeout(hardCap);
     }
+
+    return stop;
   }, [entityId, spaceId]);
 
   const handleCreateComment = (text: string, ancestorComments?: Array<{ id: string; spaceId: string }>) => {

--- a/apps/web/partials/explore/explore-feed-card.tsx
+++ b/apps/web/partials/explore/explore-feed-card.tsx
@@ -2,14 +2,13 @@
 
 import * as React from 'react';
 
-import type { ExploreFeedItem } from '~/core/explore/fetch-explore-feed';
-import { formatExploreRelativeTime } from '~/core/explore/explore-relative-time';
-import { NavUtils } from '~/core/utils/utils';
-
 import Image from 'next/image';
 
+import type { ExploreFeedItem } from '~/core/explore/fetch-explore-feed';
+import { formatExploreRelativeTime } from '~/core/explore/explore-relative-time';
+import { NavUtils, getImagePath, getImagePathFallback } from '~/core/utils/utils';
+
 import { PrefetchLink as Link } from '~/design-system/prefetch-link';
-import { getImagePath, getImagePathFallback } from '~/core/utils/utils';
 
 import { EntityVoteButtons } from '~/partials/entity-page/entity-vote-buttons';
 
@@ -78,7 +77,7 @@ export function ExploreFeedCard({ item }: ExploreFeedCardProps) {
     .filter(t => t.name)
     .map(t => t.name)
     .join(' · ');
-  const edited = formatExploreRelativeTime(item.updatedAtSec);
+  const timeAgo = formatExploreRelativeTime(item.updatedAtSec);
 
   const entityHref = `${NavUtils.toEntity(item.spaceId, item.entityId)}#entity-comments`;
 
@@ -98,7 +97,7 @@ export function ExploreFeedCard({ item }: ExploreFeedCardProps) {
               {typeLabel}
             </span>
           ) : null}
-          <span className="text-[12px] font-normal leading-[13px] tracking-[-0.35px] text-grey-04">{edited}</span>
+          <span className="text-[12px] font-normal leading-[13px] tracking-[-0.35px] text-grey-04">{timeAgo}</span>
         </div>
         {!item.isMemberOrEditor ? (
           <ExploreJoinSpaceButton

--- a/apps/web/partials/explore/explore-page.tsx
+++ b/apps/web/partials/explore/explore-page.tsx
@@ -77,7 +77,7 @@ export function ExplorePage({
           void fetchNextPage();
         }
       },
-      { rootMargin: '8000px' }
+      { rootMargin: '6000px' }
     );
     io.observe(el);
     return () => io.disconnect();

--- a/apps/web/partials/explore/explore-page.tsx
+++ b/apps/web/partials/explore/explore-page.tsx
@@ -3,7 +3,7 @@
 import { useInfiniteQuery } from '@tanstack/react-query';
 import * as React from 'react';
 
-import type { ExploreFeedItem, ExploreFeedResult, ExploreSort, ExploreTime } from '~/core/explore/fetch-explore-feed';
+import type { ExploreFeedItem, ExploreFeedResult, ExploreTime } from '~/core/explore/fetch-explore-feed';
 
 import { Dropdown } from '~/design-system/dropdown';
 import { Skeleton } from '~/design-system/skeleton';
@@ -22,8 +22,6 @@ function LoadingSkeleton() {
   );
 }
 
-const SORT: ExploreSort = 'new';
-
 const TIME_OPTIONS: { value: ExploreTime; label: string }[] = [
   { value: 'today', label: 'Today' },
   { value: 'week', label: 'This week' },
@@ -35,13 +33,11 @@ const TIME_OPTIONS: { value: ExploreTime; label: string }[] = [
 type SpaceOption = { value: string; label: string };
 
 async function fetchExplorePage(params: {
-  sort: ExploreSort;
   time: ExploreTime;
   spaceId: string;
   cursor: string | undefined;
 }): Promise<ExploreFeedResult> {
   const sp = new URLSearchParams();
-  sp.set('sort', params.sort);
   sp.set('time', params.time);
   sp.set('spaceId', params.spaceId);
   if (params.cursor) sp.set('cursor', params.cursor);
@@ -61,9 +57,9 @@ export function ExplorePage({
   const [spaceId, setSpaceId] = React.useState<string>('all');
 
   const { data, isLoading, isFetchingNextPage, fetchNextPage, hasNextPage, error } = useInfiniteQuery({
-    queryKey: ['explore-feed', SORT, time, spaceId],
+    queryKey: ['explore-feed', time, spaceId],
     queryFn: ({ pageParam }) =>
-      fetchExplorePage({ sort: SORT, time, spaceId, cursor: pageParam as string | undefined }),
+      fetchExplorePage({ time, spaceId, cursor: pageParam as string | undefined }),
     initialPageParam: undefined as string | undefined,
     getNextPageParam: last => last.nextCursor ?? undefined,
     retry: 2,


### PR DESCRIPTION
Follow-up to #1682 addressing Copilot's review comments. Stacked on top of that branch so the diff stays focused to just the review fixes — once #1682 squash-merges to master, this PR will auto-retarget.

## Changes

- **Extract comment typeId constant.** `310d4a240e5b451cb2151bfce40d0fe6` was inlined in the GraphQL query; now lives in `explore-constants.ts` as `EXPLORE_COMMENT_REPLY_TO_TYPE_ID`.
- **Remove unused `sort` arg.** `fetchExploreFeed` accepted `sort: ExploreSort` but never referenced it (we always sort by `UpdatedAtDesc`). Dropped it from the fetcher, route handler, page component, and deleted the `ExploreSort` type.
- **Eliminate redundant `fetchProfile` call.** The route already resolves `personalMemberSpaceId` via `resolveMemberSpaceFromWalletSafe`, but `attachMeta` was re-fetching the wallet profile to get the same value. Now we plumb `personalMemberSpaceId` through — one fewer subgraph call per page load.
- **Consolidate imports** in `explore-feed-card.tsx` (two `~/core/utils/utils` imports → one).
- **Rename `edited` → `timeAgo`** to reflect UI intent.

## Test plan

- [ ] `/explore` loads and paginates as before
- [ ] Pending-membership badge still appears for wallets with an active membership proposal
- [ ] `/api/explore/feed?time=week&spaceId=all` (no `sort` query param) returns the feed
- [ ] Network tab: one fewer subgraph call per feed request