### PR TITLE
refactor(ui): improve select-entity popover positioning and styling

### DIFF
--- a/apps/web/design-system/select-entity.tsx
+++ b/apps/web/design-system/select-entity.tsx
@@ -4,7 +4,7 @@ import { SystemIds } from '@geoprotocol/geo-sdk/lite';
 import * as Popover from '@radix-ui/react-popover';
 
 import * as React from 'react';
-import { startTransition, useEffect, useRef, useState } from 'react';
+import { startTransition, useEffect, useLayoutEffect, useRef, useState } from 'react';
 
 import { cva } from 'class-variance-authority';
 import cx from 'classnames';
@@ -121,6 +121,10 @@ export const SelectEntity = ({
   const [spaceFilter, setSpaceFilter] = useState<SpaceFilter | null>(null);
   const [typeFilter, setTypeFilter] = useState<TypeFilter | null>(null);
   const [renderableType, setRenderableType] = useState<SwitchableRenderableType | undefined>('TEXT');
+
+  const [clipPath, setClipPath] = useState('inset(-0px -100px -100px -100px)');
+
+  const [popoverElement, setPopoverElement] = useState<HTMLDivElement | null>(null);
 
   const filterBySpace = spaceFilter?.spaceId ?? undefined;
 
@@ -248,6 +252,22 @@ export const SelectEntity = ({
   const inputRef = useRef<HTMLInputElement | null>(null);
   const hasFocusedRef = useRef(false);
 
+  useLayoutEffect(() => {
+    if (!popoverElement) return;
+
+    const updateClipPath = () => {
+      const side = popoverElement.getAttribute('data-side');
+      setClipPath(side === 'top' ? 'inset(-100px -100px -0px -100px)' : 'inset(-0px -100px -100px -100px)');
+    };
+
+    updateClipPath(); // initial check
+
+    const observer = new MutationObserver(updateClipPath);
+    observer.observe(popoverElement, { attributes: true, attributeFilter: ['data-side'] });
+
+    return () => observer.disconnect();
+  }, [popoverElement]);
+
   const inputCallbackRef = React.useCallback(
     (node: HTMLInputElement | null) => {
       inputRef.current = node;
@@ -313,7 +333,10 @@ export const SelectEntity = ({
         {query && (
           <Popover.Portal>
             <Popover.Content
-              ref={popoverRef}
+              ref={(node) => {
+                setPopoverElement(node);
+                popoverRef.current = node;
+              }}
               onOpenAutoFocus={event => {
                 event.preventDefault();
                 event.stopPropagation();
@@ -330,6 +353,7 @@ export const SelectEntity = ({
                     width === 'clamped' ? 'w-[400px]' : '-mr-px',
                     withSearchIcon && 'rounded-t-none'
                   )}
+                  style={{ clipPath }}
                 >
                   {advanced && (
                     <div className="w-full">
@@ -607,7 +631,7 @@ export const SelectEntity = ({
                     </ResizableContainer>
                   ) : (
                     <>
-                      <div className="flex items-center justify-between border-b border-divider bg-white">
+                      <div className="flex items-center justify-between border-b border-grey-02 bg-white">
                         <div className="w-1/3">
                           <button onClick={() => setResult(null)} className="p-2">
                             <ArrowLeft color="grey-04" />
@@ -730,7 +754,7 @@ const containerStyles = cva('relative', {
       full: 'w-full',
     },
     floating: {
-      true: 'rounded-md border border-divider bg-white shadow-lg',
+      true: 'rounded-md border border-grey-02 bg-white shadow-lg',
     },
     isQueried: {
       true: 'rounded-b-none',


### PR DESCRIPTION
Implement a dynamic clip-path using useLayoutEffect and MutationObserver to prevent popover clipping when positioned at the top of the viewport. Also updates border colors to use grey-02 for consistency.

Type
before:
<img width="410" height="174" alt="image" src="https://github.com/user-attachments/assets/0c6c172f-3bbc-4d40-9e06-29e610e70e2f" />

after:
<img width="432" height="780" alt="Screenshot 2026-04-20 at 10 39 12" src="https://github.com/user-attachments/assets/e1a1134a-5771-4aa3-9ccf-dedb0aff6aea" />

Property
before:
<img width="1888" height="482" alt="image" src="https://github.com/user-attachments/assets/85293c1c-c297-452e-a96b-44bc10fd4563" />

after:
<img width="424" height="723" alt="Screenshot 2026-04-20 at 10 41 03" src="https://github.com/user-attachments/assets/d9ab6af1-6170-4799-8b6e-7b0dc6898e4c" />


EE-Solutions/geo-project-issues#110