### PR TITLE
feat: explore page polish — type pills + createdAt

### DIFF
--- a/apps/web/core/explore/explore-entities-document.ts
+++ b/apps/web/core/explore/explore-entities-document.ts
@@ -9,7 +9,7 @@ import {
   EXPLORE_ENTITY_NAME_PROPERTY_ID,
 } from './explore-constants';
 
-// Only the four property IDs and the two relation-type IDs we actually read per entity.
+// Only the four property IDs and the three relation-type IDs we actually read per entity.
 // Narrowing these on the server slashes payload size — most entities have dozens of
 // unrelated values/relations we'd otherwise serialize, ship, and decode for nothing.
 const CARD_VALUE_PROPERTY_IDS = [

--- a/apps/web/core/explore/explore-entities-document.ts
+++ b/apps/web/core/explore/explore-entities-document.ts
@@ -41,7 +41,7 @@ const EXPLORE_ENTITIES_CONNECTION_SOURCE = /* GraphQL */ `
         name
         description
         spaceIds
-        updatedAt
+        createdAt
 
         backlinks(filter: { typeId: { is: "310d4a240e5b451cb2151bfce40d0fe6" } }) {
           totalCount

--- a/apps/web/core/explore/explore-entities-document.ts
+++ b/apps/web/core/explore/explore-entities-document.ts
@@ -1,9 +1,37 @@
 import type { TypedDocumentNode } from '@graphql-typed-document-node/core';
+import { ContentIds, SystemIds } from '@geoprotocol/geo-sdk/lite';
 import { parse } from 'graphql';
+
+import {
+  EXPLORE_AVATAR_PROPERTY_ID,
+  EXPLORE_COVER_PROPERTY_ID,
+  EXPLORE_ENTITY_DESCRIPTION_PROPERTY_ID,
+  EXPLORE_ENTITY_NAME_PROPERTY_ID,
+} from './explore-constants';
+
+// Only the four property IDs and the two relation-type IDs we actually read per entity.
+// Narrowing these on the server slashes payload size — most entities have dozens of
+// unrelated values/relations we'd otherwise serialize, ship, and decode for nothing.
+const CARD_VALUE_PROPERTY_IDS = [
+  EXPLORE_ENTITY_NAME_PROPERTY_ID,
+  EXPLORE_ENTITY_DESCRIPTION_PROPERTY_ID,
+  EXPLORE_COVER_PROPERTY_ID,
+  EXPLORE_AVATAR_PROPERTY_ID,
+];
+const CARD_RELATION_TYPE_IDS = [
+  SystemIds.COVER_PROPERTY,
+  ContentIds.AVATAR_PROPERTY,
+  // `types` relation — used to derive space-scoped type tags.
+  SystemIds.TYPES_PROPERTY,
+];
+
+const valuePropertyIdList = CARD_VALUE_PROPERTY_IDS.map(id => `"${id}"`).join(', ');
+const relationTypeIdList = CARD_RELATION_TYPE_IDS.map(id => `"${id}"`).join(', ');
 
 /**
  * Like `allEntitiesConnectionDocument`, but scopes `valuesList` / `relationsList` to any of
- * the given spaces so multi-space explore feeds still decode cover/avatar/description.
+ * the given spaces AND to just the property/relation types the card reads — so multi-space
+ * explore feeds still decode cover/avatar/description without pulling every unrelated value.
  */
 const EXPLORE_ENTITIES_CONNECTION_SOURCE = /* GraphQL */ `
   fragment ExplorePropertyFragment on PropertyInfo {
@@ -52,7 +80,10 @@ const EXPLORE_ENTITIES_CONNECTION_SOURCE = /* GraphQL */ `
           name
         }
 
-        valuesList(filter: { spaceId: { in: $spaceIdsForLists } }) {
+        valuesList(filter: {
+          spaceId: { in: $spaceIdsForLists }
+          propertyId: { in: [${valuePropertyIdList}] }
+        }) {
           spaceId
           property {
             ...ExplorePropertyFragment
@@ -72,7 +103,10 @@ const EXPLORE_ENTITIES_CONNECTION_SOURCE = /* GraphQL */ `
           schedule
         }
 
-        relationsList(filter: { spaceId: { in: $spaceIdsForLists } }) {
+        relationsList(filter: {
+          spaceId: { in: $spaceIdsForLists }
+          typeId: { in: [${relationTypeIdList}] }
+        }) {
           id
           spaceId
           position

--- a/apps/web/core/explore/explore-relative-time.ts
+++ b/apps/web/core/explore/explore-relative-time.ts
@@ -19,10 +19,10 @@ export function parseEntityUpdatedAtToUnixSec(raw: string | undefined): number {
 /**
  * Compact relative labels for the feed metadata row (e.g. `3m ago`, `2d ago`).
  */
-export function formatExploreRelativeTime(updatedAtSec: number): string {
-  if (updatedAtSec <= 0) return '—';
-  const date = new Date(updatedAtSec * 1000);
-  const diffSec = Math.max(0, (Date.now() - updatedAtSec * 1000) / 1000);
+export function formatExploreRelativeTime(timestampSec: number): string {
+  if (timestampSec <= 0) return '—';
+  const date = new Date(timestampSec * 1000);
+  const diffSec = Math.max(0, (Date.now() - timestampSec * 1000) / 1000);
   if (diffSec < 45) return 'just now';
   if (diffSec < 3600) return `${Math.floor(diffSec / 60)}m ago`;
   if (diffSec < 86400) return `${Math.floor(diffSec / 3600)}h ago`;

--- a/apps/web/core/explore/fetch-explore-feed.ts
+++ b/apps/web/core/explore/fetch-explore-feed.ts
@@ -160,6 +160,7 @@ async function fetchExploreEntitiesPage(args: {
   const t = timeThresholdSec(args.time);
   const filter: EntityFilter = {
     typeIds: { overlaps: [...EXPLORE_ENTITY_TYPE_IDS] },
+    name: { isNull: false, isNot: '' },
     ...(t != null ? { createdAt: { greaterThanOrEqualTo: String(t) } } : {}),
   };
 

--- a/apps/web/core/explore/fetch-explore-feed.ts
+++ b/apps/web/core/explore/fetch-explore-feed.ts
@@ -117,7 +117,7 @@ function entityMatchesExploreTypes(entity: Entity): boolean {
   return entity.types.some(t => TYPE_SET.has(normId(t.id)));
 }
 
-type ExploreEntity = Entity & { commentCount: number };
+type ExploreEntity = Entity & { commentCount: number; createdAt?: string };
 
 type ExploreEntitiesPageResponse = {
   entities: ExploreEntity[];
@@ -133,13 +133,14 @@ function decodeExploreEntities(data: {
 }): ExploreEntitiesPageResponse {
   const entities: ExploreEntity[] = [];
   for (const n of (data.entitiesConnection?.nodes ?? []) as Array<
-    Record<string, unknown> & { backlinks?: { totalCount?: number } | null }
+    Record<string, unknown> & { backlinks?: { totalCount?: number } | null; createdAt?: string }
   >) {
     const decoded = EntityDecoder.decode(n);
     if (!decoded) continue;
     entities.push({
       ...decoded,
       commentCount: n.backlinks?.totalCount ?? 0,
+      createdAt: n.createdAt,
     });
   }
   return {
@@ -159,7 +160,7 @@ async function fetchExploreEntitiesPage(args: {
   const t = timeThresholdSec(args.time);
   const filter: EntityFilter = {
     typeIds: { overlaps: [...EXPLORE_ENTITY_TYPE_IDS] },
-    ...(t != null ? { updatedAt: { greaterThanOrEqualTo: String(t) } } : {}),
+    ...(t != null ? { createdAt: { greaterThanOrEqualTo: String(t) } } : {}),
   };
 
   return Effect.runPromise(
@@ -197,8 +198,8 @@ function buildItems(
     items.push({
       entityId: e.id,
       spaceId,
-      types: e.types.filter(t => TYPE_SET.has(normId(t.id))).map(t => ({ id: t.id, name: t.name })),
-      updatedAtSec: parseEntityUpdatedAtToUnixSec(e.updatedAt),
+      types: e.types.map(t => ({ id: t.id, name: t.name })),
+      updatedAtSec: parseEntityUpdatedAtToUnixSec(e.createdAt),
       title,
       description,
       imageUrl: imageFromEntity(e, spaceId),
@@ -293,7 +294,7 @@ export async function fetchExploreFeed(args: {
     time: args.time,
     limit: scanChunk,
     after: args.cursor,
-    orderBy: [EntitiesOrderBy.UpdatedAtDesc],
+    orderBy: [EntitiesOrderBy.CreatedAtDesc],
   });
 
   const enriched = buildItems(page.entities, allowed, memberOrEditorSet);

--- a/apps/web/core/explore/fetch-explore-feed.ts
+++ b/apps/web/core/explore/fetch-explore-feed.ts
@@ -30,7 +30,7 @@ export type ExploreFeedItem = {
   spaceName: string;
   spaceImage: string | null;
   types: { id: string; name: string | null }[];
-  updatedAtSec: number;
+  createdAtSec: number;
   title: string;
   description: string | null;
   imageUrl: string | null;
@@ -193,10 +193,14 @@ function buildItems(
     const spaceId = pickDisplaySpaceId(e, allowedSpaceIds);
     if (!spaceId || !entityMatchesExploreTypes(e)) continue;
 
-    // Space-scoped title/description/types only — no cross-space fallbacks. A card
-    // rendered for space A shouldn't leak a name from space C.
-    const title = textValueForProperty(e, EXPLORE_ENTITY_NAME_PROPERTY_ID, spaceId) ?? 'Untitled';
-    const description = textValueForProperty(e, EXPLORE_ENTITY_DESCRIPTION_PROPERTY_ID, spaceId) ?? null;
+    // Prefer space-scoped values so a card rendered for space A doesn't leak values
+    // from space C. Fall back to the top-level aggregated name/description when the
+    // entity has no value in the display space — avoids "Untitled" cards purely
+    // because of the space boundary.
+    const title =
+      textValueForProperty(e, EXPLORE_ENTITY_NAME_PROPERTY_ID, spaceId) ?? e.name?.trim() ?? 'Untitled';
+    const description =
+      textValueForProperty(e, EXPLORE_ENTITY_DESCRIPTION_PROPERTY_ID, spaceId) ?? e.description ?? null;
 
     const displaySpaceIdNorm = normId(spaceId);
     const types = e.relations
@@ -207,7 +211,7 @@ function buildItems(
       entityId: e.id,
       spaceId,
       types,
-      updatedAtSec: parseEntityUpdatedAtToUnixSec(e.createdAt),
+      createdAtSec: parseEntityUpdatedAtToUnixSec(e.createdAt),
       title,
       description,
       imageUrl: imageFromEntity(e, spaceId),

--- a/apps/web/core/explore/fetch-explore-feed.ts
+++ b/apps/web/core/explore/fetch-explore-feed.ts
@@ -187,19 +187,26 @@ function buildItems(
 ): Omit<ExploreFeedItem, 'spaceName' | 'spaceImage' | 'hasPendingMembershipRequest'>[] {
   const items: Omit<ExploreFeedItem, 'spaceName' | 'spaceImage' | 'hasPendingMembershipRequest'>[] = [];
 
+  const typesRelationIdNorm = normId(SystemIds.TYPES_PROPERTY);
+
   for (const e of entities) {
     const spaceId = pickDisplaySpaceId(e, allowedSpaceIds);
     if (!spaceId || !entityMatchesExploreTypes(e)) continue;
 
-    const title =
-      textValueForProperty(e, EXPLORE_ENTITY_NAME_PROPERTY_ID, spaceId) ?? e.name?.trim() ?? 'Untitled';
-    const description =
-      textValueForProperty(e, EXPLORE_ENTITY_DESCRIPTION_PROPERTY_ID, spaceId) ?? e.description ?? null;
+    // Space-scoped title/description/types only — no cross-space fallbacks. A card
+    // rendered for space A shouldn't leak a name from space C.
+    const title = textValueForProperty(e, EXPLORE_ENTITY_NAME_PROPERTY_ID, spaceId) ?? 'Untitled';
+    const description = textValueForProperty(e, EXPLORE_ENTITY_DESCRIPTION_PROPERTY_ID, spaceId) ?? null;
+
+    const displaySpaceIdNorm = normId(spaceId);
+    const types = e.relations
+      .filter(r => normId(r.type.id) === typesRelationIdNorm && normId(r.spaceId) === displaySpaceIdNorm)
+      .map(r => ({ id: r.toEntity.id, name: r.toEntity.name }));
 
     items.push({
       entityId: e.id,
       spaceId,
-      types: e.types.map(t => ({ id: t.id, name: t.name })),
+      types,
       updatedAtSec: parseEntityUpdatedAtToUnixSec(e.createdAt),
       title,
       description,

--- a/apps/web/partials/explore/explore-feed-card.tsx
+++ b/apps/web/partials/explore/explore-feed-card.tsx
@@ -101,14 +101,18 @@ export function ExploreFeedCard({ item }: ExploreFeedCardProps) {
             <SpaceThumb image={item.spaceImage} name={item.spaceName} />
             <span className="min-w-0 truncate">{item.spaceName}</span>
           </Link>
-          {uniqueTypes.map(t => (
-            <span
-              key={t.id}
-              className="rounded-[4px] bg-grey-01 px-1.5 py-0.5 text-[12px] font-normal leading-[13px] tracking-[-0.35px] text-grey-04"
-            >
-              {t.name}
-            </span>
-          ))}
+          {uniqueTypes.length > 0 ? (
+            <div className="flex flex-wrap items-center gap-x-1 gap-y-1">
+              {uniqueTypes.map(t => (
+                <span
+                  key={t.id}
+                  className="rounded-[4px] bg-grey-01 px-1.5 py-0.5 text-[12px] font-normal leading-[13px] tracking-[-0.35px] text-grey-04"
+                >
+                  {t.name}
+                </span>
+              ))}
+            </div>
+          ) : null}
           <span className="text-[12px] font-normal leading-[13px] tracking-[-0.35px] text-grey-04">{edited}</span>
         </div>
         {!item.isMemberOrEditor ? (

--- a/apps/web/partials/explore/explore-feed-card.tsx
+++ b/apps/web/partials/explore/explore-feed-card.tsx
@@ -86,7 +86,7 @@ export function ExploreFeedCard({ item }: ExploreFeedCardProps) {
     }
     return out;
   }, [item.types]);
-  const edited = formatExploreRelativeTime(item.updatedAtSec);
+  const timeAgo = formatExploreRelativeTime(item.createdAtSec);
 
   const entityHref = `${NavUtils.toEntity(item.spaceId, item.entityId)}#entity-comments`;
 
@@ -113,7 +113,7 @@ export function ExploreFeedCard({ item }: ExploreFeedCardProps) {
               ))}
             </div>
           ) : null}
-          <span className="text-[12px] font-normal leading-[13px] tracking-[-0.35px] text-grey-04">{edited}</span>
+          <span className="text-[12px] font-normal leading-[13px] tracking-[-0.35px] text-grey-04">{timeAgo}</span>
         </div>
         {!item.isMemberOrEditor ? (
           <ExploreJoinSpaceButton

--- a/apps/web/partials/explore/explore-feed-card.tsx
+++ b/apps/web/partials/explore/explore-feed-card.tsx
@@ -74,10 +74,18 @@ function SpaceThumb({ image, name }: { image: string | null; name: string }) {
 }
 
 export function ExploreFeedCard({ item }: ExploreFeedCardProps) {
-  const typeLabel = item.types
-    .filter(t => t.name)
-    .map(t => t.name)
-    .join(' · ');
+  const uniqueTypes = React.useMemo(() => {
+    const seen = new Set<string>();
+    const out: { id: string; name: string }[] = [];
+    for (const t of item.types) {
+      if (!t.name) continue;
+      const key = t.id.replace(/-/g, '').toLowerCase();
+      if (seen.has(key)) continue;
+      seen.add(key);
+      out.push({ id: t.id, name: t.name });
+    }
+    return out;
+  }, [item.types]);
   const edited = formatExploreRelativeTime(item.updatedAtSec);
 
   const entityHref = `${NavUtils.toEntity(item.spaceId, item.entityId)}#entity-comments`;
@@ -93,11 +101,14 @@ export function ExploreFeedCard({ item }: ExploreFeedCardProps) {
             <SpaceThumb image={item.spaceImage} name={item.spaceName} />
             <span className="min-w-0 truncate">{item.spaceName}</span>
           </Link>
-          {typeLabel ? (
-            <span className="rounded-[4px] bg-grey-01 px-1.5 py-0.5 text-[12px] font-normal leading-[13px] tracking-[-0.35px] text-grey-04">
-              {typeLabel}
+          {uniqueTypes.map(t => (
+            <span
+              key={t.id}
+              className="rounded-[4px] bg-grey-01 px-1.5 py-0.5 text-[12px] font-normal leading-[13px] tracking-[-0.35px] text-grey-04"
+            >
+              {t.name}
             </span>
-          ) : null}
+          ))}
           <span className="text-[12px] font-normal leading-[13px] tracking-[-0.35px] text-grey-04">{edited}</span>
         </div>
         {!item.isMemberOrEditor ? (

--- a/apps/web/partials/explore/explore-join-space-button.tsx
+++ b/apps/web/partials/explore/explore-join-space-button.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { atom, useAtom } from 'jotai';
 import * as React from 'react';
 
 import { useOnboardGuard } from '~/core/hooks/use-onboard-guard';
@@ -12,20 +13,40 @@ type ExploreJoinSpaceButtonProps = {
   hasRequestedSpaceMembership: boolean;
 };
 
+function normId(id: string): string {
+  return id.replace(/-/g, '').toLowerCase();
+}
+
+/**
+ * Space IDs the user has requested membership for in this session. Shared across all
+ * explore cards so every card for the same space flips to "Membership pending" after
+ * one click — no need to refetch the feed.
+ */
+const locallyRequestedSpaceIdsAtom = atom<Set<string>>(new Set<string>());
+
 export function ExploreJoinSpaceButton({ spaceId, hasRequestedSpaceMembership }: ExploreJoinSpaceButtonProps) {
   const { requestToBeMember, status } = useRequestToBeMember({ spaceId });
   const { shouldShowElement } = useOnboardGuard();
-  const [localSuccess, setLocalSuccess] = React.useState(false);
+  const [locallyRequested, setLocallyRequested] = useAtom(locallyRequestedSpaceIdsAtom);
+
+  const normalizedId = normId(spaceId);
+  const locallyRequestedThisSpace = locallyRequested.has(normalizedId);
 
   React.useEffect(() => {
-    if (status === 'success') setLocalSuccess(true);
-  }, [status]);
+    if (status === 'success' && !locallyRequestedThisSpace) {
+      setLocallyRequested(prev => {
+        const next = new Set(prev);
+        next.add(normalizedId);
+        return next;
+      });
+    }
+  }, [status, normalizedId, locallyRequestedThisSpace, setLocallyRequested]);
 
   if (!shouldShowElement) {
     return null;
   }
 
-  const showPendingLabel = hasRequestedSpaceMembership || localSuccess;
+  const showPendingLabel = hasRequestedSpaceMembership || locallyRequestedThisSpace;
 
   return (
     <Pending isPending={status === 'pending'} position="end">

--- a/apps/web/partials/explore/explore-page.tsx
+++ b/apps/web/partials/explore/explore-page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { usePrivy } from '@geogenesis/auth';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import * as React from 'react';
 
@@ -60,8 +61,13 @@ export function ExplorePage({
   const [time, setTime] = React.useState<ExploreTime>('week');
   const [spaceId, setSpaceId] = React.useState<string>('all');
 
+  // Include the Privy user id in the queryKey so the feed refetches when the user signs
+  // in/out. Otherwise `isMemberOrEditor` / pending-membership state is stale until refresh.
+  const { user } = usePrivy();
+  const userId = user?.id ?? null;
+
   const { data, isLoading, isFetchingNextPage, fetchNextPage, hasNextPage, error } = useInfiniteQuery({
-    queryKey: ['explore-feed', SORT, time, spaceId],
+    queryKey: ['explore-feed', SORT, time, spaceId, userId],
     queryFn: ({ pageParam }) =>
       fetchExplorePage({ sort: SORT, time, spaceId, cursor: pageParam as string | undefined }),
     initialPageParam: undefined as string | undefined,

--- a/apps/web/partials/explore/explore-page.tsx
+++ b/apps/web/partials/explore/explore-page.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import { usePrivy } from '@geogenesis/auth';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import * as React from 'react';
 
 import type { ExploreFeedItem, ExploreFeedResult, ExploreSort, ExploreTime } from '~/core/explore/fetch-explore-feed';
+import { useSmartAccount } from '~/core/hooks/use-smart-account';
 
 import { Dropdown } from '~/design-system/dropdown';
 import { Skeleton } from '~/design-system/skeleton';
@@ -61,13 +61,15 @@ export function ExplorePage({
   const [time, setTime] = React.useState<ExploreTime>('week');
   const [spaceId, setSpaceId] = React.useState<string>('all');
 
-  // Include the Privy user id in the queryKey so the feed refetches when the user signs
-  // in/out. Otherwise `isMemberOrEditor` / pending-membership state is stale until refresh.
-  const { user } = usePrivy();
-  const userId = user?.id ?? null;
+  // Key the query on the smart-account address because that hook is what writes the
+  // WALLET_ADDRESS cookie the server route reads. `usePrivy().user.id` updates earlier
+  // (before the cookie is set), which caused refetches to return anonymous data on
+  // sign-in and leave "Join space" buttons stuck for a few seconds.
+  const { smartAccount } = useSmartAccount();
+  const smartAccountAddress = smartAccount?.account.address ?? null;
 
   const { data, isLoading, isFetchingNextPage, fetchNextPage, hasNextPage, error } = useInfiniteQuery({
-    queryKey: ['explore-feed', SORT, time, spaceId, userId],
+    queryKey: ['explore-feed', SORT, time, spaceId, smartAccountAddress],
     queryFn: ({ pageParam }) =>
       fetchExplorePage({ sort: SORT, time, spaceId, cursor: pageParam as string | undefined }),
     initialPageParam: undefined as string | undefined,


### PR DESCRIPTION
## Summary

Two small quality polish items on the `/explore` feed.

### Type pills

- Each entity type renders as its own pill — `[Type A] [Type B]` — instead of being joined into a single pill with `·` separators.
- Types are deduplicated by normalized id so duplicates on an entity only render once.
- Card-side display now shows **all** of the entity's types, not just the ones in the 8-type whitelist. The feed is still filtered to whitelisted types at the query level (\`typeIds.overlaps\`) — only the display filter is relaxed.

### `createdAt` for sort / filter / display

- Explore sort, time filter, and the "time ago" indicator now use \`createdAt\` instead of \`updatedAt\`.
- API team indexed the field, so the previous ~10× latency cost of ordering by \`createdAt\` is gone.
- The indicator now reflects actual entity creation, not bumps from unrelated backlink edits.

## Test plan

- [ ] Reload \`/explore\`:
  - Each card shows entity types as separate pills.
  - An entity with duplicate type ids only renders each once.
  - Types outside the 8-type whitelist appear on cards; the feed still only contains whitelisted entity types.
- [ ] "Time ago" on a card matches entity creation time (spot-check a known entity).
- [ ] Page load latency is in the same ballpark as before on \`updatedAt\`; if noticeably slower, escalate to API team before merging (index may not be in place).