### PR TITLE
refactor(bounty-linking): extract hooks for proposal-view reuse

### DIFF
--- a/apps/web/partials/active-proposal/active-proposal.tsx
+++ b/apps/web/partials/active-proposal/active-proposal.tsx
@@ -25,6 +25,7 @@ import { ShowVoters } from './active-proposal-show-voters';
 import { ActiveProposalSlideUp } from './active-proposal-slide-up';
 import { CloseProposalButton } from './close-proposal-button';
 import { ContentProposal } from './content-proposal';
+import { ProposalBountyLinksLauncher, ProposalLinkedBountiesList } from './proposal-bounty-links';
 import { SpaceTopicProposal } from './space-topic-proposal';
 import { SubspaceProposal } from './subspace-proposal';
 
@@ -69,6 +70,10 @@ async function ReviewProposal({ proposalId, spaceId, connectedAddress }: Props) 
   const proposalTitle =
     proposal.name ?? getProposalName({ name: proposal.id, type: proposal.type, space: proposal.space });
 
+  const isAuthor = Boolean(
+    connectedAddress && proposal.createdBy.address.toLowerCase() === connectedAddress.toLowerCase()
+  );
+
   return (
     <>
       <div className="sticky top-0 z-50 flex w-full items-center justify-between gap-1 border-b border-divider bg-white px-4 py-1 text-button text-text md:px-4 md:py-3">
@@ -77,15 +82,23 @@ async function ReviewProposal({ proposalId, spaceId, connectedAddress }: Props) 
           <p>Review proposal</p>
         </div>
 
-        <AcceptOrReject
-          spaceId={spaceId}
-          proposalId={proposal.id}
-          isProposalEnded={isProposalEnded}
-          status={proposal.status}
-          canExecute={proposal.canExecute}
-          proposalType={proposal.type}
-          userVote={userVote}
-        />
+        <div className="inline-flex items-center gap-2">
+          <ProposalBountyLinksLauncher
+            proposalId={proposal.id}
+            proposalName={proposalTitle}
+            spaceId={spaceId}
+            isAuthor={isAuthor}
+          />
+          <AcceptOrReject
+            spaceId={spaceId}
+            proposalId={proposal.id}
+            isProposalEnded={isProposalEnded}
+            status={proposal.status}
+            canExecute={proposal.canExecute}
+            proposalType={proposal.type}
+            userVote={userVote}
+          />
+        </div>
       </div>
       <div className="relative overflow-x-clip">
         <MetadataMotionContainer>
@@ -174,6 +187,7 @@ async function ReviewProposal({ proposalId, spaceId, connectedAddress }: Props) 
         </MetadataMotionContainer>
         <div className="h-full overflow-x-clip border-t border-divider">
           <div className="mx-auto max-w-[1200px] pt-10 pb-20 xl:pt-[40px] xl:pr-[2ch] xl:pb-[4ch] xl:pl-[2ch]">
+            <ProposalLinkedBountiesList proposalId={proposal.id} />
             {proposal.type === 'ADD_EDIT' && <ContentProposal proposal={proposal} spaceId={spaceId} />}
             {isSubspaceProposal && <SubspaceProposal proposal={proposal} />}
             {isSpaceTopicProposal && <SpaceTopicProposal proposal={proposal} />}

--- a/apps/web/partials/active-proposal/active-proposal.tsx
+++ b/apps/web/partials/active-proposal/active-proposal.tsx
@@ -25,7 +25,7 @@ import { ShowVoters } from './active-proposal-show-voters';
 import { ActiveProposalSlideUp } from './active-proposal-slide-up';
 import { CloseProposalButton } from './close-proposal-button';
 import { ContentProposal } from './content-proposal';
-import { ProposalBountyLinksLauncher, ProposalLinkedBountiesList } from './proposal-bounty-links';
+import { ProposalBountyLinksButton, ProposalBountyLinksProvider } from './proposal-bounty-links';
 import { SpaceTopicProposal } from './space-topic-proposal';
 import { SubspaceProposal } from './subspace-proposal';
 
@@ -70,12 +70,13 @@ async function ReviewProposal({ proposalId, spaceId, connectedAddress }: Props) 
   const proposalTitle =
     proposal.name ?? getProposalName({ name: proposal.id, type: proposal.type, space: proposal.space });
 
-  const isAuthor = Boolean(
-    connectedAddress && proposal.createdBy.address.toLowerCase() === connectedAddress.toLowerCase()
-  );
-
   return (
-    <>
+    <ProposalBountyLinksProvider
+      proposalId={proposal.id}
+      proposalName={proposalTitle}
+      spaceId={spaceId}
+      authorAddress={proposal.createdBy.address}
+    >
       <div className="sticky top-0 z-50 flex w-full items-center justify-between gap-1 border-b border-divider bg-white px-4 py-1 text-button text-text md:px-4 md:py-3">
         <div className="inline-flex items-center gap-4">
           <CloseProposalButton spaceId={spaceId} />
@@ -83,12 +84,7 @@ async function ReviewProposal({ proposalId, spaceId, connectedAddress }: Props) 
         </div>
 
         <div className="inline-flex items-center gap-2">
-          <ProposalBountyLinksLauncher
-            proposalId={proposal.id}
-            proposalName={proposalTitle}
-            spaceId={spaceId}
-            isAuthor={isAuthor}
-          />
+          <ProposalBountyLinksButton />
           <AcceptOrReject
             spaceId={spaceId}
             proposalId={proposal.id}
@@ -187,13 +183,12 @@ async function ReviewProposal({ proposalId, spaceId, connectedAddress }: Props) 
         </MetadataMotionContainer>
         <div className="h-full overflow-x-clip border-t border-divider">
           <div className="mx-auto max-w-[1200px] pt-10 pb-20 xl:pt-[40px] xl:pr-[2ch] xl:pb-[4ch] xl:pl-[2ch]">
-            <ProposalLinkedBountiesList proposalId={proposal.id} />
             {proposal.type === 'ADD_EDIT' && <ContentProposal proposal={proposal} spaceId={spaceId} />}
             {isSubspaceProposal && <SubspaceProposal proposal={proposal} />}
             {isSpaceTopicProposal && <SpaceTopicProposal proposal={proposal} />}
           </div>
         </div>
       </div>
-    </>
+    </ProposalBountyLinksProvider>
   );
 }

--- a/apps/web/partials/active-proposal/proposal-bounty-links.tsx
+++ b/apps/web/partials/active-proposal/proposal-bounty-links.tsx
@@ -1,0 +1,199 @@
+'use client';
+
+import { useQueryClient } from '@tanstack/react-query';
+
+import * as React from 'react';
+
+import cx from 'classnames';
+
+import { usePersonalSpaceId } from '~/core/hooks/use-personal-space-id';
+
+import { Button } from '~/design-system/button';
+import { Gem } from '~/design-system/icons/gem';
+import { Pending } from '~/design-system/pending';
+import { Skeleton } from '~/design-system/skeleton';
+
+import { BountyCard } from '~/partials/review/bounty-linking/bounty-card';
+import {
+  BountyLinkingPanel,
+  useLinkableBounties,
+  useLinkedBountiesForProposal,
+  usePublishBountyLinks,
+} from '~/partials/review/bounty-linking';
+
+type LauncherProps = {
+  proposalId: string;
+  proposalName: string;
+  spaceId: string;
+  isAuthor: boolean;
+  /** The personal page entity id for the connected user (optional — only needed to filter the
+   *  linkable list to bounties allocated to this user). */
+  personalPageEntityId?: string | null;
+};
+
+/**
+ * Author-only "Link to bounty" control for the proposal voting screen. Renders a header button
+ * (hidden for non-authors) and a fixed right-side drawer that reuses `BountyLinkingPanel` for
+ * selection + `usePublishBountyLinks` for persistence. Initial selection is seeded from the
+ * current set of linked bounties so the author can add new links; removing existing links is
+ * not supported yet.
+ */
+export function ProposalBountyLinksLauncher({
+  proposalId,
+  proposalName,
+  spaceId,
+  isAuthor,
+  personalPageEntityId = null,
+}: LauncherProps) {
+  const queryClient = useQueryClient();
+  const { personalSpaceId } = usePersonalSpaceId();
+
+  const [isOpen, setIsOpen] = React.useState(false);
+  const [selectedBountyIds, setSelectedBountyIds] = React.useState<Set<string>>(new Set());
+  const [initialSelectionLoaded, setInitialSelectionLoaded] = React.useState(false);
+
+  const { linkedBounties } = useLinkedBountiesForProposal({
+    proposalId,
+    enabled: isAuthor,
+  });
+
+  // Seed selection from the currently-linked bounties the first time they arrive. After that
+  // the user owns the selection; we don't overwrite their in-progress edits if the query
+  // refetches.
+  React.useEffect(() => {
+    if (!isAuthor || initialSelectionLoaded) return;
+    if (linkedBounties.length === 0) return;
+    setSelectedBountyIds(new Set(linkedBounties.map(b => b.id)));
+    setInitialSelectionLoaded(true);
+  }, [isAuthor, initialSelectionLoaded, linkedBounties]);
+
+  const { bounties, bountiesById } = useLinkableBounties({
+    activeSpace: spaceId,
+    personalSpaceId: personalSpaceId ?? null,
+    personalPageEntityId,
+    enabled: isAuthor && isOpen,
+  });
+
+  // Ensure already-linked bounties show up in the picker even if they don't come back from
+  // `useLinkableBounties` (e.g. status has moved to In Progress and the card would otherwise
+  // be filtered out by allocation checks).
+  const mergedBountiesById = React.useMemo(() => {
+    const merged = new Map(bountiesById);
+    for (const b of linkedBounties) {
+      if (!merged.has(b.id)) merged.set(b.id, b);
+    }
+    return merged;
+  }, [bountiesById, linkedBounties]);
+
+  const mergedBounties = React.useMemo(() => Array.from(mergedBountiesById.values()), [mergedBountiesById]);
+
+  const { publish, isPublishing } = usePublishBountyLinks({ personalSpaceId: personalSpaceId ?? null });
+
+  const alreadyLinkedIds = React.useMemo(() => new Set(linkedBounties.map(b => b.id)), [linkedBounties]);
+  const newlySelectedIds = React.useMemo(() => {
+    const next = new Set<string>();
+    for (const id of selectedBountyIds) if (!alreadyLinkedIds.has(id)) next.add(id);
+    return next;
+  }, [selectedBountyIds, alreadyLinkedIds]);
+
+  const canSave = newlySelectedIds.size > 0 && Boolean(personalSpaceId);
+
+  const handleSave = async () => {
+    if (!canSave) return;
+    await publish({
+      proposalId,
+      proposalName,
+      toSpaceId: personalSpaceId && spaceId !== personalSpaceId ? spaceId : undefined,
+      bountyIds: newlySelectedIds,
+      bountiesById: mergedBountiesById,
+      onSuccess: () => {
+        queryClient.invalidateQueries({ queryKey: ['proposal-entity-for-bounty-links', proposalId] });
+        queryClient.invalidateQueries({ queryKey: ['linked-bounty-entities'] });
+        setIsOpen(false);
+      },
+    });
+  };
+
+  if (!isAuthor) return null;
+
+  return (
+    <>
+      <button
+        onClick={() => setIsOpen(prev => !prev)}
+        className={cx(
+          'group inline-flex items-center gap-1.5 rounded border px-2 py-2 text-button font-normal transition-colors',
+          'border-grey-02 bg-white text-text hover:border-text'
+        )}
+      >
+        <Gem color="purple" />
+        {selectedBountyIds.size > 0 ? <span>{selectedBountyIds.size}</span> : <span>Link to bounty</span>}
+      </button>
+
+      {isOpen && (
+        <div className="fixed inset-y-0 right-0 z-[10001] flex w-[416px] max-w-full flex-col bg-white shadow-xl">
+          <div className="flex-1 min-h-0 overflow-hidden">
+            <BountyLinkingPanel
+              isOpen={isOpen}
+              setIsOpen={setIsOpen}
+              selectedBountyIds={selectedBountyIds}
+              setSelectedBountyIds={setSelectedBountyIds}
+              bounties={mergedBounties}
+            />
+          </div>
+          <div className="flex shrink-0 items-center justify-end gap-2 border-t border-grey-02 bg-white p-3">
+            <Button variant="secondary" onClick={() => setIsOpen(false)}>
+              Cancel
+            </Button>
+            <Button variant="primary" onClick={handleSave} disabled={!canSave || isPublishing}>
+              <Pending isPending={isPublishing}>Save links</Pending>
+            </Button>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}
+
+type ListProps = {
+  proposalId: string;
+};
+
+/**
+ * Read-only display of the bounties already linked to this proposal. Visible to all viewers
+ * (not just the author). Returns null when there are none, so it occupies no space for
+ * proposals without any links.
+ */
+export function ProposalLinkedBountiesList({ proposalId }: ListProps) {
+  const { linkedBounties, isLoading } = useLinkedBountiesForProposal({ proposalId });
+
+  if (isLoading && linkedBounties.length === 0) {
+    return (
+      <div className="mx-auto max-w-[1200px] px-[2ch] pb-6">
+        <Skeleton className="h-5 w-32" />
+        <div className="mt-3 flex flex-col divide-y divide-grey-02 rounded-lg border border-grey-02 bg-white px-4">
+          <Skeleton className="my-4 h-24 w-full" />
+        </div>
+      </div>
+    );
+  }
+
+  if (linkedBounties.length === 0) return null;
+
+  return (
+    <div className="mx-auto max-w-[1200px] px-[2ch] pb-6">
+      <div className="mb-3 flex items-center gap-2">
+        <span className="text-purple">
+          <Gem color="purple" />
+        </span>
+        <span className="text-body text-text">
+          {linkedBounties.length} {linkedBounties.length === 1 ? 'linked bounty' : 'linked bounties'}
+        </span>
+      </div>
+      <div className="flex flex-col divide-y divide-grey-02 rounded-lg border border-grey-02 bg-white px-4">
+        {linkedBounties.map(bounty => (
+          <BountyCard key={bounty.id} bounty={bounty} isSelected={false} onToggle={() => {}} readOnly />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/partials/active-proposal/proposal-bounty-links.tsx
+++ b/apps/web/partials/active-proposal/proposal-bounty-links.tsx
@@ -6,16 +6,16 @@ import * as React from 'react';
 
 import cx from 'classnames';
 
+import { useGeoProfile } from '~/core/hooks/use-geo-profile';
 import { usePersonalSpaceId } from '~/core/hooks/use-personal-space-id';
 import { useSmartAccount } from '~/core/hooks/use-smart-account';
 
-import { Button, SquareButton } from '~/design-system/button';
-import { Close } from '~/design-system/icons/close';
+import { Button } from '~/design-system/button';
 import { Gem } from '~/design-system/icons/gem';
 import { Pending } from '~/design-system/pending';
 
-import { BountyCard } from '~/partials/review/bounty-linking/bounty-card';
 import {
+  BountyLinkingPanel,
   useLinkableBounties,
   useLinkedBountiesForProposal,
   usePublishBountyLinks,
@@ -135,6 +135,9 @@ function ProposalBountyLinksPanelInternal({ proposalId, proposalName, spaceId, i
   const { isOpen, close } = useBountyLinksContext();
   const queryClient = useQueryClient();
   const { personalSpaceId } = usePersonalSpaceId();
+  const { smartAccount } = useSmartAccount();
+  const { profile } = useGeoProfile(smartAccount?.account.address);
+  const personalPageEntityId = profile?.id ?? null;
 
   const { linkedBounties, relationsByBountyId } = useLinkedBountiesForProposal({
     proposalId,
@@ -156,12 +159,13 @@ function ProposalBountyLinksPanelInternal({ proposalId, proposalName, spaceId, i
     }
   }, [isOpen, linkedBounties]);
 
-  // For authors, also offer bounties that aren't yet linked so they can add more in the same
-  // panel. For viewers the picker is collapsed to just the currently-linked set.
+  // Same query shape as the review-your-edits screen: allocation must match the user's
+  // personal page entity OR their personal space, otherwise bounties allocated to the page
+  // entity (the common case) disappear after an unlink and can't be re-linked.
   const { bounties: linkableBounties, bountiesById: linkableBountiesById } = useLinkableBounties({
     activeSpace: spaceId,
     personalSpaceId: personalSpaceId ?? null,
-    personalPageEntityId: null,
+    personalPageEntityId,
     enabled: isOpen && isAuthor,
   });
 
@@ -240,57 +244,24 @@ function ProposalBountyLinksPanelInternal({ proposalId, proposalName, spaceId, i
     });
   };
 
-  const toggleBounty = (bountyId: string) => {
-    setSelectedBountyIds(prev => {
-      const next = new Set(prev);
-      if (next.has(bountyId)) next.delete(bountyId);
-      else next.add(bountyId);
-      return next;
-    });
-  };
-
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-y-0 right-0 z-[10001] flex w-[416px] max-w-full flex-col bg-white shadow-xl">
-      <div className="flex items-center justify-between border-b border-grey-02 px-4 py-3">
-        <div className="flex items-center gap-2">
-          <span className="text-purple">
-            <Gem color="purple" />
-          </span>
-          <span className="text-body text-text">
-            {linkedBounties.length} linked {linkedBounties.length === 1 ? 'bounty' : 'bounties'}
-          </span>
-        </div>
-        <SquareButton onClick={close} icon={<Close />} />
-      </div>
-
-      <div className="flex-1 overflow-y-auto p-4">
-        {displayBounties.length === 0 ? (
-          <div className="flex flex-col items-center justify-center py-12 text-center">
-            <p className="text-body text-grey-04">
-              {isAuthor
-                ? 'No allocated bounties available to link in this space.'
-                : 'No bounties are linked to this proposal.'}
-            </p>
-          </div>
-        ) : (
-          <div className="flex flex-col divide-y divide-grey-02">
-            {displayBounties.map(bounty => (
-              <BountyCard
-                key={bounty.id}
-                bounty={bounty}
-                isSelected={selectedBountyIds.has(bounty.id)}
-                onToggle={toggleBounty}
-                readOnly={!isAuthor}
-              />
-            ))}
-          </div>
-        )}
-      </div>
-
-      {isAuthor && (
-        <div className="flex shrink-0 items-center justify-end gap-2 border-t border-grey-02 bg-white p-3">
+    <div className="fixed inset-y-0 right-0 z-[10001] flex flex-col items-stretch">
+      {/* Reuse the exact review-your-edits panel so the card chrome, header label, and
+          selection UX stay in lockstep with the review screen. */}
+      <BountyLinkingPanel
+        isOpen={isOpen}
+        setIsOpen={value => {
+          if (!value) close();
+        }}
+        selectedBountyIds={selectedBountyIds}
+        setSelectedBountyIds={isAuthor ? setSelectedBountyIds : () => {}}
+        bounties={displayBounties}
+        readOnly={!isAuthor}
+      />
+      {isAuthor && hasPendingChanges && (
+        <div className="mr-2 -mt-2 mb-2 flex w-[400px] shrink-0 items-center justify-end gap-2 rounded-lg bg-white px-4 py-3">
           <Button variant="secondary" onClick={close}>
             Cancel
           </Button>

--- a/apps/web/partials/active-proposal/proposal-bounty-links.tsx
+++ b/apps/web/partials/active-proposal/proposal-bounty-links.tsx
@@ -7,96 +7,222 @@ import * as React from 'react';
 import cx from 'classnames';
 
 import { usePersonalSpaceId } from '~/core/hooks/use-personal-space-id';
+import { useSmartAccount } from '~/core/hooks/use-smart-account';
 
-import { Button } from '~/design-system/button';
+import { Button, SquareButton } from '~/design-system/button';
+import { Close } from '~/design-system/icons/close';
 import { Gem } from '~/design-system/icons/gem';
 import { Pending } from '~/design-system/pending';
-import { Skeleton } from '~/design-system/skeleton';
 
 import { BountyCard } from '~/partials/review/bounty-linking/bounty-card';
 import {
-  BountyLinkingPanel,
   useLinkableBounties,
   useLinkedBountiesForProposal,
   usePublishBountyLinks,
 } from '~/partials/review/bounty-linking';
 
-type LauncherProps = {
+type ProviderProps = {
+  proposalId: string;
+  proposalName: string;
+  /** The DAO space this proposal targets. */
+  spaceId: string;
+  /** Wallet address of the proposal author; compared (case-insensitively) against the
+   *  connected wallet to decide whether edit affordances are shown. */
+  authorAddress: string;
+  children: React.ReactNode;
+};
+
+type ContextValue = {
+  isOpen: boolean;
+  open: () => void;
+  close: () => void;
+  toggle: () => void;
+  isAuthor: boolean;
+  linkedCount: number;
+};
+
+const BountyLinksContext = React.createContext<ContextValue | null>(null);
+
+function useBountyLinksContext(): ContextValue {
+  const ctx = React.useContext(BountyLinksContext);
+  if (!ctx) {
+    throw new Error('ProposalBountyLinks components must be rendered inside <ProposalBountyLinksProvider>');
+  }
+  return ctx;
+}
+
+/**
+ * Wraps the proposal voting view with shared bounty-linking state so that the header button
+ * and the side panel can coordinate open/close without a parent-child relationship. Author
+ * detection is done client-side via the connected wallet (not the server-side cookie) so
+ * editing affordances appear as soon as the wallet hydrates, not when the cookie was set.
+ */
+export function ProposalBountyLinksProvider({
+  proposalId,
+  proposalName,
+  spaceId,
+  authorAddress,
+  children,
+}: ProviderProps) {
+  const { smartAccount } = useSmartAccount();
+  const connectedAddress = smartAccount?.account.address ?? null;
+  const isAuthor = Boolean(
+    connectedAddress && authorAddress && connectedAddress.toLowerCase() === authorAddress.toLowerCase()
+  );
+
+  const { linkedBounties } = useLinkedBountiesForProposal({ proposalId });
+  const [isOpen, setIsOpen] = React.useState(false);
+
+  const value = React.useMemo<ContextValue>(
+    () => ({
+      isOpen,
+      open: () => setIsOpen(true),
+      close: () => setIsOpen(false),
+      toggle: () => setIsOpen(v => !v),
+      isAuthor,
+      linkedCount: linkedBounties.length,
+    }),
+    [isOpen, isAuthor, linkedBounties.length]
+  );
+
+  return (
+    <BountyLinksContext.Provider value={value}>
+      {children}
+      <ProposalBountyLinksPanelInternal
+        proposalId={proposalId}
+        proposalName={proposalName}
+        spaceId={spaceId}
+        isAuthor={isAuthor}
+      />
+    </BountyLinksContext.Provider>
+  );
+}
+
+/**
+ * Header affordance. Shown to everyone when at least one bounty is linked (so viewers can
+ * pop open the side panel and see them); shown to the author unconditionally so they can add
+ * the first link.
+ */
+export function ProposalBountyLinksButton() {
+  const { isAuthor, linkedCount, toggle } = useBountyLinksContext();
+
+  if (!isAuthor && linkedCount === 0) return null;
+
+  const label = linkedCount > 0 ? String(linkedCount) : 'Link to bounty';
+
+  return (
+    <button
+      onClick={toggle}
+      className={cx(
+        'group inline-flex items-center gap-1.5 rounded border px-2 py-2 text-button font-normal transition-colors',
+        'border-grey-02 bg-white text-text hover:border-text'
+      )}
+    >
+      <Gem color="purple" />
+      <span>{label}</span>
+    </button>
+  );
+}
+
+type PanelProps = {
   proposalId: string;
   proposalName: string;
   spaceId: string;
   isAuthor: boolean;
-  /** The personal page entity id for the connected user (optional — only needed to filter the
-   *  linkable list to bounties allocated to this user). */
-  personalPageEntityId?: string | null;
 };
 
-/**
- * Author-only "Link to bounty" control for the proposal voting screen. Renders a header button
- * (hidden for non-authors) and a fixed right-side drawer that reuses `BountyLinkingPanel` for
- * selection + `usePublishBountyLinks` for persistence. Initial selection is seeded from the
- * current set of linked bounties so the author can add new links; removing existing links is
- * not supported yet.
- */
-export function ProposalBountyLinksLauncher({
-  proposalId,
-  proposalName,
-  spaceId,
-  isAuthor,
-  personalPageEntityId = null,
-}: LauncherProps) {
+function ProposalBountyLinksPanelInternal({ proposalId, proposalName, spaceId, isAuthor }: PanelProps) {
+  const { isOpen, close } = useBountyLinksContext();
   const queryClient = useQueryClient();
   const { personalSpaceId } = usePersonalSpaceId();
 
-  const [isOpen, setIsOpen] = React.useState(false);
-  const [selectedBountyIds, setSelectedBountyIds] = React.useState<Set<string>>(new Set());
-  const [initialSelectionLoaded, setInitialSelectionLoaded] = React.useState(false);
-
-  const { linkedBounties } = useLinkedBountiesForProposal({
+  const { linkedBounties, relationsByBountyId } = useLinkedBountiesForProposal({
     proposalId,
-    enabled: isAuthor,
+    enabled: isOpen,
   });
 
-  // Seed selection from the currently-linked bounties the first time they arrive. After that
-  // the user owns the selection; we don't overwrite their in-progress edits if the query
-  // refetches.
+  // Seed selection from the currently-linked set whenever the panel opens. While open, the
+  // selection is owned by the user so upstream refetches don't stomp in-progress edits.
+  const [selectedBountyIds, setSelectedBountyIds] = React.useState<Set<string>>(new Set());
+  const wasOpenRef = React.useRef(false);
   React.useEffect(() => {
-    if (!isAuthor || initialSelectionLoaded) return;
-    if (linkedBounties.length === 0) return;
-    setSelectedBountyIds(new Set(linkedBounties.map(b => b.id)));
-    setInitialSelectionLoaded(true);
-  }, [isAuthor, initialSelectionLoaded, linkedBounties]);
+    if (!isOpen) {
+      wasOpenRef.current = false;
+      return;
+    }
+    if (!wasOpenRef.current) {
+      wasOpenRef.current = true;
+      setSelectedBountyIds(new Set(linkedBounties.map(b => b.id)));
+    }
+  }, [isOpen, linkedBounties]);
 
-  const { bounties, bountiesById } = useLinkableBounties({
+  // For authors, also offer bounties that aren't yet linked so they can add more in the same
+  // panel. For viewers the picker is collapsed to just the currently-linked set.
+  const { bounties: linkableBounties, bountiesById: linkableBountiesById } = useLinkableBounties({
     activeSpace: spaceId,
     personalSpaceId: personalSpaceId ?? null,
-    personalPageEntityId,
-    enabled: isAuthor && isOpen,
+    personalPageEntityId: null,
+    enabled: isOpen && isAuthor,
   });
 
-  // Ensure already-linked bounties show up in the picker even if they don't come back from
-  // `useLinkableBounties` (e.g. status has moved to In Progress and the card would otherwise
-  // be filtered out by allocation checks).
   const mergedBountiesById = React.useMemo(() => {
-    const merged = new Map(bountiesById);
+    const merged = new Map(linkableBountiesById);
     for (const b of linkedBounties) {
       if (!merged.has(b.id)) merged.set(b.id, b);
     }
     return merged;
-  }, [bountiesById, linkedBounties]);
+  }, [linkableBountiesById, linkedBounties]);
 
-  const mergedBounties = React.useMemo(() => Array.from(mergedBountiesById.values()), [mergedBountiesById]);
-
-  const { publish, isPublishing } = usePublishBountyLinks({ personalSpaceId: personalSpaceId ?? null });
+  const displayBounties = React.useMemo(() => {
+    if (!isAuthor) return linkedBounties;
+    // Show linked bounties first, then any other eligible bounties, so the author can see
+    // what's already attached and optionally extend or trim.
+    const seen = new Set<string>();
+    const ordered: typeof linkedBounties = [];
+    for (const b of linkedBounties) {
+      if (!seen.has(b.id)) {
+        seen.add(b.id);
+        ordered.push(b);
+      }
+    }
+    for (const b of linkableBounties) {
+      if (!seen.has(b.id)) {
+        seen.add(b.id);
+        ordered.push(b);
+      }
+    }
+    return ordered;
+  }, [isAuthor, linkedBounties, linkableBounties]);
 
   const alreadyLinkedIds = React.useMemo(() => new Set(linkedBounties.map(b => b.id)), [linkedBounties]);
-  const newlySelectedIds = React.useMemo(() => {
+
+  const bountyIdsToAdd = React.useMemo(() => {
+    if (!isAuthor) return new Set<string>();
     const next = new Set<string>();
     for (const id of selectedBountyIds) if (!alreadyLinkedIds.has(id)) next.add(id);
     return next;
-  }, [selectedBountyIds, alreadyLinkedIds]);
+  }, [isAuthor, selectedBountyIds, alreadyLinkedIds]);
 
-  const canSave = newlySelectedIds.size > 0 && Boolean(personalSpaceId);
+  const relationsToRemove = React.useMemo(() => {
+    if (!isAuthor) return [];
+    const out = [];
+    for (const bountyId of alreadyLinkedIds) {
+      if (selectedBountyIds.has(bountyId)) continue;
+      const relation = relationsByBountyId.get(bountyId);
+      if (relation) out.push(relation);
+    }
+    return out;
+  }, [isAuthor, alreadyLinkedIds, selectedBountyIds, relationsByBountyId]);
+
+  const hasPendingChanges = bountyIdsToAdd.size > 0 || relationsToRemove.length > 0;
+  const canSave = hasPendingChanges && Boolean(personalSpaceId);
+
+  const { publish, isPublishing } = usePublishBountyLinks({ personalSpaceId: personalSpaceId ?? null });
+
+  const invalidate = () => {
+    queryClient.invalidateQueries({ queryKey: ['proposal-entity-for-bounty-links', proposalId] });
+    queryClient.invalidateQueries({ queryKey: ['linked-bounty-entities'] });
+  };
 
   const handleSave = async () => {
     if (!canSave) return;
@@ -104,96 +230,75 @@ export function ProposalBountyLinksLauncher({
       proposalId,
       proposalName,
       toSpaceId: personalSpaceId && spaceId !== personalSpaceId ? spaceId : undefined,
-      bountyIds: newlySelectedIds,
+      bountyIds: bountyIdsToAdd,
       bountiesById: mergedBountiesById,
+      relationsToRemove,
       onSuccess: () => {
-        queryClient.invalidateQueries({ queryKey: ['proposal-entity-for-bounty-links', proposalId] });
-        queryClient.invalidateQueries({ queryKey: ['linked-bounty-entities'] });
-        setIsOpen(false);
+        invalidate();
+        close();
       },
     });
   };
 
-  if (!isAuthor) return null;
+  const toggleBounty = (bountyId: string) => {
+    setSelectedBountyIds(prev => {
+      const next = new Set(prev);
+      if (next.has(bountyId)) next.delete(bountyId);
+      else next.add(bountyId);
+      return next;
+    });
+  };
+
+  if (!isOpen) return null;
 
   return (
-    <>
-      <button
-        onClick={() => setIsOpen(prev => !prev)}
-        className={cx(
-          'group inline-flex items-center gap-1.5 rounded border px-2 py-2 text-button font-normal transition-colors',
-          'border-grey-02 bg-white text-text hover:border-text'
-        )}
-      >
-        <Gem color="purple" />
-        {selectedBountyIds.size > 0 ? <span>{selectedBountyIds.size}</span> : <span>Link to bounty</span>}
-      </button>
+    <div className="fixed inset-y-0 right-0 z-[10001] flex w-[416px] max-w-full flex-col bg-white shadow-xl">
+      <div className="flex items-center justify-between border-b border-grey-02 px-4 py-3">
+        <div className="flex items-center gap-2">
+          <span className="text-purple">
+            <Gem color="purple" />
+          </span>
+          <span className="text-body text-text">
+            {linkedBounties.length} linked {linkedBounties.length === 1 ? 'bounty' : 'bounties'}
+          </span>
+        </div>
+        <SquareButton onClick={close} icon={<Close />} />
+      </div>
 
-      {isOpen && (
-        <div className="fixed inset-y-0 right-0 z-[10001] flex w-[416px] max-w-full flex-col bg-white shadow-xl">
-          <div className="flex-1 min-h-0 overflow-hidden">
-            <BountyLinkingPanel
-              isOpen={isOpen}
-              setIsOpen={setIsOpen}
-              selectedBountyIds={selectedBountyIds}
-              setSelectedBountyIds={setSelectedBountyIds}
-              bounties={mergedBounties}
-            />
+      <div className="flex-1 overflow-y-auto p-4">
+        {displayBounties.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-12 text-center">
+            <p className="text-body text-grey-04">
+              {isAuthor
+                ? 'No allocated bounties available to link in this space.'
+                : 'No bounties are linked to this proposal.'}
+            </p>
           </div>
-          <div className="flex shrink-0 items-center justify-end gap-2 border-t border-grey-02 bg-white p-3">
-            <Button variant="secondary" onClick={() => setIsOpen(false)}>
-              Cancel
-            </Button>
-            <Button variant="primary" onClick={handleSave} disabled={!canSave || isPublishing}>
-              <Pending isPending={isPublishing}>Save links</Pending>
-            </Button>
+        ) : (
+          <div className="flex flex-col divide-y divide-grey-02">
+            {displayBounties.map(bounty => (
+              <BountyCard
+                key={bounty.id}
+                bounty={bounty}
+                isSelected={selectedBountyIds.has(bounty.id)}
+                onToggle={toggleBounty}
+                readOnly={!isAuthor}
+              />
+            ))}
           </div>
+        )}
+      </div>
+
+      {isAuthor && (
+        <div className="flex shrink-0 items-center justify-end gap-2 border-t border-grey-02 bg-white p-3">
+          <Button variant="secondary" onClick={close}>
+            Cancel
+          </Button>
+          <Button variant="primary" onClick={handleSave} disabled={!canSave || isPublishing}>
+            <Pending isPending={isPublishing}>Save links</Pending>
+          </Button>
         </div>
       )}
-    </>
-  );
-}
-
-type ListProps = {
-  proposalId: string;
-};
-
-/**
- * Read-only display of the bounties already linked to this proposal. Visible to all viewers
- * (not just the author). Returns null when there are none, so it occupies no space for
- * proposals without any links.
- */
-export function ProposalLinkedBountiesList({ proposalId }: ListProps) {
-  const { linkedBounties, isLoading } = useLinkedBountiesForProposal({ proposalId });
-
-  if (isLoading && linkedBounties.length === 0) {
-    return (
-      <div className="mx-auto max-w-[1200px] px-[2ch] pb-6">
-        <Skeleton className="h-5 w-32" />
-        <div className="mt-3 flex flex-col divide-y divide-grey-02 rounded-lg border border-grey-02 bg-white px-4">
-          <Skeleton className="my-4 h-24 w-full" />
-        </div>
-      </div>
-    );
-  }
-
-  if (linkedBounties.length === 0) return null;
-
-  return (
-    <div className="mx-auto max-w-[1200px] px-[2ch] pb-6">
-      <div className="mb-3 flex items-center gap-2">
-        <span className="text-purple">
-          <Gem color="purple" />
-        </span>
-        <span className="text-body text-text">
-          {linkedBounties.length} {linkedBounties.length === 1 ? 'linked bounty' : 'linked bounties'}
-        </span>
-      </div>
-      <div className="flex flex-col divide-y divide-grey-02 rounded-lg border border-grey-02 bg-white px-4">
-        {linkedBounties.map(bounty => (
-          <BountyCard key={bounty.id} bounty={bounty} isSelected={false} onToggle={() => {}} readOnly />
-        ))}
-      </div>
     </div>
   );
 }

--- a/apps/web/partials/review/bounty-linking/bounty-card.tsx
+++ b/apps/web/partials/review/bounty-linking/bounty-card.tsx
@@ -16,9 +16,21 @@ interface BountyCardProps {
   bounty: Bounty;
   isSelected: boolean;
   onToggle: (id: string) => void;
+  /** Hides the selection checkbox/Linked label and disables toggling — used when rendering the
+   *  read-only list of bounties already linked to a proposal. */
+  readOnly?: boolean;
 }
 
-export function BountyCard({ bounty, isSelected, onToggle }: BountyCardProps) {
+/**
+ * Which payout label + value the card should show. Self-assigned bounties are paid out per
+ * submission, so we label their budget as "Est. payout"; bounties with a fixed allocation
+ * (Allocated / In progress / Completed / etc.) are labeled "Max payout".
+ */
+function getPayoutLabel(status: BountyStatus | null): 'Max payout' | 'Est. payout' {
+  return status === 'SELF_ASSIGNED' ? 'Est. payout' : 'Max payout';
+}
+
+export function BountyCard({ bounty, isSelected, onToggle, readOnly = false }: BountyCardProps) {
   const formattedDeadline =
     bounty.deadline &&
     new Date(bounty.deadline).toLocaleDateString('en-US', {
@@ -29,12 +41,10 @@ export function BountyCard({ bounty, isSelected, onToggle }: BountyCardProps) {
 
   const hasDetails =
     bounty.budget != null ||
-    bounty.maxContributors != null ||
-    bounty.submissionsPerPerson != null ||
-    bounty.submissionsCount != null ||
-    bounty.userSubmissionsCount != null ||
     bounty.difficulty ||
     bounty.status ||
+    bounty.userSubmissionsCount != null ||
+    bounty.submissionsPerPerson != null ||
     formattedDeadline;
 
   const handleOpenBounty = () => {
@@ -45,23 +55,24 @@ export function BountyCard({ bounty, isSelected, onToggle }: BountyCardProps) {
 
   return (
     <div className="py-4">
-      {/* Checkbox row */}
-      <label className="flex cursor-pointer items-center gap-2">
-        <input type="checkbox" checked={isSelected} onChange={() => onToggle(bounty.id)} className="sr-only" />
-        <div
-          className={cx(
-            'flex h-4 w-4 items-center justify-center rounded border transition-all',
-            isSelected ? 'border-text bg-text' : 'border-grey-03 bg-white'
-          )}
-        >
-          {isSelected && (
-            <svg width="10" height="10" viewBox="0 0 10 10" fill="none" xmlns="http://www.w3.org/2000/svg">
-              <path d="M2 5L4 7L8 3" stroke="white" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
-            </svg>
-          )}
-        </div>
-        {isSelected && <span className="text-metadata font-medium text-text">Linked</span>}
-      </label>
+      {!readOnly && (
+        <label className="flex cursor-pointer items-center gap-2">
+          <input type="checkbox" checked={isSelected} onChange={() => onToggle(bounty.id)} className="sr-only" />
+          <div
+            className={cx(
+              'flex h-4 w-4 items-center justify-center rounded border transition-all',
+              isSelected ? 'border-text bg-text' : 'border-grey-03 bg-white'
+            )}
+          >
+            {isSelected && (
+              <svg width="10" height="10" viewBox="0 0 10 10" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path d="M2 5L4 7L8 3" stroke="white" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+              </svg>
+            )}
+          </div>
+          {isSelected && <span className="text-metadata font-medium text-text">Linked</span>}
+        </label>
+      )}
 
       {(bounty.spaceLabel ?? bounty.spaceId) && (
         <div className="mt-2 flex min-w-0 items-center gap-1.5">
@@ -96,29 +107,12 @@ export function BountyCard({ bounty, isSelected, onToggle }: BountyCardProps) {
       {hasDetails && (
         <div className="mt-3 flex flex-col gap-0">
           {bounty.budget != null && (
-            <DetailRow label="Bounty budget">
+            <DetailRow label={getPayoutLabel(bounty.status)}>
               <span className="inline-flex items-center gap-1">
                 <span className="text-purple">
                   <Gem color="purple" />
                 </span>
                 <span className="text-[14px] text-text">{bounty.budget.toLocaleString('en-US')}</span>
-              </span>
-            </DetailRow>
-          )}
-          {bounty.maxContributors != null && (
-            <DetailRow label="Submissions">
-              <span className="text-[14px] text-text">
-                {(bounty.submissionsCount ?? 0).toLocaleString('en-US')} /{' '}
-                {bounty.maxContributors.toLocaleString('en-US')}
-              </span>
-            </DetailRow>
-          )}
-
-          {bounty.submissionsPerPerson != null && (
-            <DetailRow label="Your submissions">
-              <span className="text-[14px] text-text">
-                {(bounty.userSubmissionsCount ?? 0).toLocaleString('en-US')} /{' '}
-                {bounty.submissionsPerPerson.toLocaleString('en-US')}
               </span>
             </DetailRow>
           )}
@@ -132,6 +126,17 @@ export function BountyCard({ bounty, isSelected, onToggle }: BountyCardProps) {
           {bounty.status && (
             <DetailRow label="Status">
               <span className="text-[14px] text-text">{formatStatus(bounty.status)}</span>
+            </DetailRow>
+          )}
+
+          {(bounty.userSubmissionsCount != null || bounty.submissionsPerPerson != null) && (
+            <DetailRow label="Your submissions">
+              <span className="text-[14px] text-text">
+                {(bounty.userSubmissionsCount ?? 0).toLocaleString('en-US')} /{' '}
+                {bounty.submissionsPerPerson != null && bounty.submissionsPerPerson > 0
+                  ? bounty.submissionsPerPerson.toLocaleString('en-US')
+                  : 'Unlimited'}
+              </span>
             </DetailRow>
           )}
 

--- a/apps/web/partials/review/bounty-linking/bounty-linking-panel.tsx
+++ b/apps/web/partials/review/bounty-linking/bounty-linking-panel.tsx
@@ -15,6 +15,9 @@ interface BountyLinkingPanelProps {
   selectedBountyIds: Set<string>;
   setSelectedBountyIds: React.Dispatch<React.SetStateAction<Set<string>>>;
   bounties: Bounty[];
+  /** Hides the per-card checkbox and disables toggling. Used on the proposal voting screen
+   *  when a non-author is viewing the linked bounties. */
+  readOnly?: boolean;
 }
 
 export function BountyLinkingPanel({
@@ -23,6 +26,7 @@ export function BountyLinkingPanel({
   selectedBountyIds,
   setSelectedBountyIds,
   bounties,
+  readOnly = false,
 }: BountyLinkingPanelProps) {
   const handleToggleBounty = (bountyId: string) => {
     setSelectedBountyIds(prev => {
@@ -64,6 +68,7 @@ export function BountyLinkingPanel({
               bounty={bounty}
               isSelected={selectedBountyIds.has(bounty.id)}
               onToggle={handleToggleBounty}
+              readOnly={readOnly}
             />
           ))}
         </div>

--- a/apps/web/partials/review/bounty-linking/index.ts
+++ b/apps/web/partials/review/bounty-linking/index.ts
@@ -8,4 +8,5 @@ export {
   isAllocatedToUser,
 } from './build-bounties';
 export { useLinkableBounties } from './use-linkable-bounties';
+export { useLinkedBountiesForProposal } from './use-linked-bounties-for-proposal';
 export { usePublishBountyLinks } from './use-publish-bounty-links';

--- a/apps/web/partials/review/bounty-linking/index.ts
+++ b/apps/web/partials/review/bounty-linking/index.ts
@@ -7,3 +7,5 @@ export {
   isBountyTypeRelation,
   isAllocatedToUser,
 } from './build-bounties';
+export { useLinkableBounties } from './use-linkable-bounties';
+export { usePublishBountyLinks } from './use-publish-bounty-links';

--- a/apps/web/partials/review/bounty-linking/use-linkable-bounties.ts
+++ b/apps/web/partials/review/bounty-linking/use-linkable-bounties.ts
@@ -112,7 +112,7 @@ export function useLinkableBounties({
     return [...new Set([...bountyEntityIds, ...remoteIds])].sort();
   }, [bountyEntityIds, remoteBountyEntities]);
 
-  const { data: bountySubmissionRelations = [] } = useQuery({
+  const { data: bountySubmissionRelations = [], isLoading: isLoadingSubmissions } = useQuery({
     queryKey: ['bounty-submission-relations', allBountyIds],
     enabled: allBountyIds.length > 0 && enabled,
     staleTime: 60_000,
@@ -121,7 +121,7 @@ export function useLinkableBounties({
     },
   });
 
-  const { data: bountyPersonalSubmissionRelations = [] } = useQuery({
+  const { data: bountyPersonalSubmissionRelations = [], isLoading: isLoadingPersonalSubmissions } = useQuery({
     queryKey: ['bounty-submission-relations-personal', allBountyIds, personalSpaceId],
     enabled: allBountyIds.length > 0 && enabled && Boolean(personalSpaceId),
     staleTime: 60_000,
@@ -208,7 +208,7 @@ export function useLinkableBounties({
     [bounties]
   );
 
-  const { data: bountyLabelSpaces = [] } = useQuery({
+  const { data: bountyLabelSpaces = [], isLoading: isLoadingLabels } = useQuery({
     queryKey: ['bounty-space-labels', bountySpaceIdsForLabels.join(',')],
     enabled: bountySpaceIdsForLabels.length > 0 && enabled,
     staleTime: 60_000,
@@ -219,9 +219,10 @@ export function useLinkableBounties({
   });
 
   const bountiesWithSpaceLabels = React.useMemo((): Bounty[] => {
+    const spacesById = new Map(bountyLabelSpaces.map(s => [s.id, s]));
     const row = new Map<string, { label: string; image: string }>();
     for (const id of bountySpaceIdsForLabels) {
-      const space = bountyLabelSpaces.find(s => s.id === id);
+      const space = spacesById.get(id);
       const name = space?.entity?.name?.trim();
       const label = name && name.length > 0 ? name : bountySpaceFallbackLabel(id);
       const image =
@@ -248,6 +249,11 @@ export function useLinkableBounties({
   return {
     bounties: bountiesWithSpaceLabels,
     bountiesById: bountiesByIdWithLabels,
-    isLoading: isLoadingAncestors || isLoadingRemote,
+    isLoading:
+      isLoadingAncestors ||
+      isLoadingRemote ||
+      isLoadingSubmissions ||
+      isLoadingPersonalSubmissions ||
+      isLoadingLabels,
   };
 }

--- a/apps/web/partials/review/bounty-linking/use-linkable-bounties.ts
+++ b/apps/web/partials/review/bounty-linking/use-linkable-bounties.ts
@@ -1,0 +1,253 @@
+'use client';
+
+import { SystemIds } from '@geoprotocol/geo-sdk/lite';
+import { useQuery } from '@tanstack/react-query';
+
+import * as React from 'react';
+
+import { Effect } from 'effect';
+
+import { BOUNTIES_RELATION_TYPE, BOUNTY_TYPE_ID, PLACEHOLDER_SPACE_IMAGE } from '~/core/constants';
+import { getAllEntities, getRelationsByToEntityIds, getSpaces } from '~/core/io/queries';
+import { fetchSpacesWithAncestors } from '~/core/io/subgraph/fetch-spaces-with-ancestors';
+import { useRelations, useValues } from '~/core/sync/use-store';
+
+import {
+  buildBounties,
+  buildBounty,
+  buildBountyAllocationTargets,
+  hasBountyTaskStatusDoneRelation,
+  isAllocatedToUser,
+  isBountyTypeRelation,
+} from './build-bounties';
+import type { Bounty } from './types';
+
+type UseLinkableBountiesArgs = {
+  /** The space whose bounties (plus ancestors) should be offered for linking. */
+  activeSpace: string;
+  /** The logged-in user's personal space id. Null when signed-out; the hook returns empty. */
+  personalSpaceId: string | null;
+  /** The logged-in user's personal page entity id. */
+  personalPageEntityId: string | null;
+  /** Gate the queries — pass `false` to skip fetching (e.g. when the panel is closed). */
+  enabled?: boolean;
+};
+
+function bountySpaceFallbackLabel(spaceId: string): string {
+  const compact = spaceId.replace(/-/g, '');
+  return compact.length > 14 ? `${compact.slice(0, 6)}…${compact.slice(-4)}` : spaceId;
+}
+
+/**
+ * Fetches the list of bounties the current user can link from `activeSpace` (and its ancestor spaces).
+ * Merges remote bounty entities with locally-edited bounty entities in the sync store, counts
+ * submissions, and attaches space labels/images for the card footer. Behavior matches the prior
+ * inline logic in `review-changes.tsx`.
+ */
+export function useLinkableBounties({
+  activeSpace,
+  personalSpaceId,
+  personalPageEntityId,
+  enabled = true,
+}: UseLinkableBountiesArgs): { bounties: Bounty[]; bountiesById: Map<string, Bounty>; isLoading: boolean } {
+  const bountyTypeRelations = useRelations({
+    selector: r => r.spaceId === activeSpace && r.type.id === SystemIds.TYPES_PROPERTY && r.isDeleted !== true,
+  });
+
+  const bountyEntityIds = React.useMemo(() => {
+    const ids = bountyTypeRelations.filter(isBountyTypeRelation).map(relation => relation.fromEntity.id);
+    return [...new Set(ids)];
+  }, [bountyTypeRelations]);
+
+  const bountyEntityIdSet = React.useMemo(() => new Set(bountyEntityIds), [bountyEntityIds]);
+
+  const bountyValues = useValues({
+    selector: value =>
+      value.spaceId === activeSpace && bountyEntityIdSet.has(value.entity.id) && value.isDeleted !== true,
+  });
+
+  const bountyRelations = useRelations({
+    selector: relation =>
+      relation.spaceId === activeSpace && bountyEntityIdSet.has(relation.fromEntity.id) && relation.isDeleted !== true,
+  });
+
+  const { data: bountySearchSpaceIds = [], isLoading: isLoadingAncestors } = useQuery({
+    queryKey: ['bounty-link-spaces-with-ancestors', activeSpace],
+    enabled: Boolean(activeSpace && enabled),
+    staleTime: 60_000,
+    queryFn: async () => {
+      if (!activeSpace) return [];
+      return await fetchSpacesWithAncestors(activeSpace);
+    },
+  });
+
+  const { data: remoteBountyEntities = [], isLoading: isLoadingRemote } = useQuery({
+    queryKey: ['bounties-by-type', bountySearchSpaceIds.join(','), BOUNTY_TYPE_ID],
+    enabled: bountySearchSpaceIds.length > 0 && enabled,
+    staleTime: 60_000,
+    queryFn: async () => {
+      if (bountySearchSpaceIds.length === 0) return [];
+      const pages = await Promise.all(
+        bountySearchSpaceIds.map(spaceId =>
+          Effect.runPromise(
+            getAllEntities({
+              spaceId,
+              typeIds: { is: BOUNTY_TYPE_ID },
+            })
+          )
+        )
+      );
+      const merged = new Map<string, (typeof pages)[0][0]>();
+      for (const entities of pages) {
+        for (const entity of entities) {
+          merged.set(entity.id, entity);
+        }
+      }
+      return [...merged.values()];
+    },
+  });
+
+  const allBountyIds = React.useMemo(() => {
+    const remoteIds = remoteBountyEntities.map(entity => entity.id);
+    return [...new Set([...bountyEntityIds, ...remoteIds])].sort();
+  }, [bountyEntityIds, remoteBountyEntities]);
+
+  const { data: bountySubmissionRelations = [] } = useQuery({
+    queryKey: ['bounty-submission-relations', allBountyIds],
+    enabled: allBountyIds.length > 0 && enabled,
+    staleTime: 60_000,
+    queryFn: async () => {
+      return await Effect.runPromise(getRelationsByToEntityIds(allBountyIds, BOUNTIES_RELATION_TYPE));
+    },
+  });
+
+  const { data: bountyPersonalSubmissionRelations = [] } = useQuery({
+    queryKey: ['bounty-submission-relations-personal', allBountyIds, personalSpaceId],
+    enabled: allBountyIds.length > 0 && enabled && Boolean(personalSpaceId),
+    staleTime: 60_000,
+    queryFn: async () => {
+      if (!personalSpaceId) return [];
+      return await Effect.runPromise(getRelationsByToEntityIds(allBountyIds, BOUNTIES_RELATION_TYPE, personalSpaceId));
+    },
+  });
+
+  const bountySubmissionCounts = React.useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const relation of bountySubmissionRelations) {
+      const id = relation.toEntityId;
+      if (!id) continue;
+      counts.set(id, (counts.get(id) ?? 0) + 1);
+    }
+    return counts;
+  }, [bountySubmissionRelations]);
+
+  const bountyPersonalSubmissionCounts = React.useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const relation of bountyPersonalSubmissionRelations) {
+      const id = relation.toEntityId;
+      if (!id) continue;
+      counts.set(id, (counts.get(id) ?? 0) + 1);
+    }
+    return counts;
+  }, [bountyPersonalSubmissionRelations]);
+
+  const { bounties, bountiesById } = React.useMemo(() => {
+    if (!personalSpaceId) {
+      return { bounties: [] as Bounty[], bountiesById: new Map<string, Bounty>() };
+    }
+
+    const allocationTargets = buildBountyAllocationTargets(personalSpaceId, personalPageEntityId);
+    const localResult = buildBounties(
+      bountyEntityIds,
+      bountyValues,
+      bountyRelations,
+      bountySubmissionCounts,
+      bountyPersonalSubmissionCounts,
+      allocationTargets,
+      activeSpace,
+      personalSpaceId
+    );
+    const remoteBounties = remoteBountyEntities
+      .filter(
+        entity =>
+          isAllocatedToUser(entity.relations ?? [], allocationTargets) &&
+          !hasBountyTaskStatusDoneRelation(entity.relations ?? [])
+      )
+      .map(entity => {
+        const bountySpaceId = entity.spaces?.[0] ?? activeSpace;
+        return buildBounty(
+          entity.id,
+          entity.values ?? [],
+          entity.relations ?? [],
+          bountySubmissionCounts,
+          bountyPersonalSubmissionCounts,
+          bountySpaceId,
+          personalSpaceId
+        );
+      });
+
+    const merged = new Map<string, Bounty>();
+    for (const bounty of remoteBounties) merged.set(bounty.id, bounty);
+    for (const bounty of localResult.bounties) merged.set(bounty.id, bounty);
+
+    return { bounties: Array.from(merged.values()), bountiesById: merged };
+  }, [
+    bountyEntityIds,
+    bountyValues,
+    bountyRelations,
+    remoteBountyEntities,
+    bountySubmissionCounts,
+    bountyPersonalSubmissionCounts,
+    activeSpace,
+    personalSpaceId,
+    personalPageEntityId,
+  ]);
+
+  const bountySpaceIdsForLabels = React.useMemo(
+    () => [...new Set(bounties.map(b => b.spaceId).filter((id): id is string => Boolean(id)))].sort(),
+    [bounties]
+  );
+
+  const { data: bountyLabelSpaces = [] } = useQuery({
+    queryKey: ['bounty-space-labels', bountySpaceIdsForLabels.join(',')],
+    enabled: bountySpaceIdsForLabels.length > 0 && enabled,
+    staleTime: 60_000,
+    queryFn: async () => {
+      if (bountySpaceIdsForLabels.length === 0) return [];
+      return await Effect.runPromise(getSpaces({ spaceIds: bountySpaceIdsForLabels }));
+    },
+  });
+
+  const bountiesWithSpaceLabels = React.useMemo((): Bounty[] => {
+    const row = new Map<string, { label: string; image: string }>();
+    for (const id of bountySpaceIdsForLabels) {
+      const space = bountyLabelSpaces.find(s => s.id === id);
+      const name = space?.entity?.name?.trim();
+      const label = name && name.length > 0 ? name : bountySpaceFallbackLabel(id);
+      const image =
+        space?.entity?.image && space.entity.image.length > 0 ? space.entity.image : PLACEHOLDER_SPACE_IMAGE;
+      row.set(id, { label, image });
+    }
+
+    return bounties.map(b => {
+      const r = b.spaceId ? row.get(b.spaceId) : undefined;
+      return {
+        ...b,
+        spaceLabel: b.spaceId ? (r?.label ?? bountySpaceFallbackLabel(b.spaceId)) : null,
+        spaceImage: b.spaceId ? (r?.image ?? PLACEHOLDER_SPACE_IMAGE) : null,
+      };
+    });
+  }, [bounties, bountySpaceIdsForLabels, bountyLabelSpaces]);
+
+  const bountiesByIdWithLabels = React.useMemo(() => {
+    const m = new Map<string, Bounty>();
+    for (const b of bountiesWithSpaceLabels) m.set(b.id, b);
+    return m;
+  }, [bountiesWithSpaceLabels]);
+
+  return {
+    bounties: bountiesWithSpaceLabels,
+    bountiesById: bountiesByIdWithLabels,
+    isLoading: isLoadingAncestors || isLoadingRemote,
+  };
+}

--- a/apps/web/partials/review/bounty-linking/use-linked-bounties-for-proposal.ts
+++ b/apps/web/partials/review/bounty-linking/use-linked-bounties-for-proposal.ts
@@ -1,0 +1,148 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+
+import * as React from 'react';
+
+import { Effect } from 'effect';
+
+import { BOUNTIES_RELATION_TYPE, PLACEHOLDER_SPACE_IMAGE } from '~/core/constants';
+import { getBatchEntities, getRelationsByToEntityIds, getSpaces } from '~/core/io/queries';
+
+import { buildBounty } from './build-bounties';
+import type { Bounty } from './types';
+
+type UseLinkedBountiesForProposalArgs = {
+  /** The on-chain proposal id — also the Proposal entity id when the link was created via the
+   *  standard flow (review-changes.tsx passes the same id to both `makeProposal` and the
+   *  relation's `fromEntity.id`). Pass null/undefined to skip fetching. */
+  proposalId: string | null | undefined;
+  /** Gate the queries — pass `false` to skip fetching (e.g. when the proposal slide-up is
+   *  closed). Defaults to `true`. */
+  enabled?: boolean;
+};
+
+function bountySpaceFallbackLabel(spaceId: string): string {
+  const compact = spaceId.replace(/-/g, '');
+  return compact.length > 14 ? `${compact.slice(0, 6)}…${compact.slice(-4)}` : spaceId;
+}
+
+/**
+ * Returns the set of bounties currently linked to `proposalId` by walking the Proposal
+ * entity's outgoing `BOUNTIES_RELATION_TYPE` relations and hydrating the bounty entities.
+ */
+export function useLinkedBountiesForProposal({
+  proposalId,
+  enabled = true,
+}: UseLinkedBountiesForProposalArgs): { linkedBounties: Bounty[]; isLoading: boolean } {
+  const gated = Boolean(enabled && proposalId);
+
+  const { data: proposalEntities = [], isLoading: isLoadingProposal } = useQuery({
+    queryKey: ['proposal-entity-for-bounty-links', proposalId],
+    enabled: gated,
+    staleTime: 30_000,
+    queryFn: async () => {
+      if (!proposalId) return [];
+      return await Effect.runPromise(getBatchEntities([proposalId]));
+    },
+  });
+
+  const linkedBountyIds = React.useMemo(() => {
+    const proposalEntity = proposalEntities[0];
+    if (!proposalEntity) return [] as string[];
+    const ids = (proposalEntity.relations ?? [])
+      .filter(r => r.type.id === BOUNTIES_RELATION_TYPE && r.isDeleted !== true)
+      .map(r => r.toEntity?.id)
+      .filter((id): id is string => typeof id === 'string' && id.length > 0);
+    return [...new Set(ids)].sort();
+  }, [proposalEntities]);
+
+  const { data: bountyEntities = [], isLoading: isLoadingBounties } = useQuery({
+    queryKey: ['linked-bounty-entities', linkedBountyIds],
+    enabled: gated && linkedBountyIds.length > 0,
+    staleTime: 30_000,
+    queryFn: async () => {
+      if (linkedBountyIds.length === 0) return [];
+      return await Effect.runPromise(getBatchEntities(linkedBountyIds));
+    },
+  });
+
+  const { data: submissionRelations = [] } = useQuery({
+    queryKey: ['linked-bounty-submissions', linkedBountyIds],
+    enabled: gated && linkedBountyIds.length > 0,
+    staleTime: 30_000,
+    queryFn: async () => {
+      if (linkedBountyIds.length === 0) return [];
+      return await Effect.runPromise(getRelationsByToEntityIds(linkedBountyIds, BOUNTIES_RELATION_TYPE));
+    },
+  });
+
+  const submissionCounts = React.useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const relation of submissionRelations) {
+      const id = relation.toEntityId;
+      if (!id) continue;
+      counts.set(id, (counts.get(id) ?? 0) + 1);
+    }
+    return counts;
+  }, [submissionRelations]);
+
+  const bountySpaceIds = React.useMemo(
+    () =>
+      [
+        ...new Set(
+          bountyEntities.flatMap(e => (e.spaces ?? []).filter((s): s is string => typeof s === 'string' && s.length > 0))
+        ),
+      ].sort(),
+    [bountyEntities]
+  );
+
+  const { data: spaceRows = [] } = useQuery({
+    queryKey: ['linked-bounty-space-labels', bountySpaceIds.join(',')],
+    enabled: gated && bountySpaceIds.length > 0,
+    staleTime: 60_000,
+    queryFn: async () => {
+      if (bountySpaceIds.length === 0) return [];
+      return await Effect.runPromise(getSpaces({ spaceIds: bountySpaceIds }));
+    },
+  });
+
+  const linkedBounties = React.useMemo((): Bounty[] => {
+    if (bountyEntities.length === 0) return [];
+
+    const spaceRow = new Map<string, { label: string; image: string }>();
+    for (const id of bountySpaceIds) {
+      const space = spaceRows.find(s => s.id === id);
+      const name = space?.entity?.name?.trim();
+      const label = name && name.length > 0 ? name : bountySpaceFallbackLabel(id);
+      const image =
+        space?.entity?.image && space.entity.image.length > 0 ? space.entity.image : PLACEHOLDER_SPACE_IMAGE;
+      spaceRow.set(id, { label, image });
+    }
+
+    // Empty map for the "your submissions" slot. The proposal view shows a read-only
+    // summary of which bounties are linked; per-user submission count is not relevant
+    // here and would add a round-trip.
+    const emptyPersonalCounts = new Map<string, number>();
+
+    return bountyEntities.map(entity => {
+      const bountySpaceId = entity.spaces?.[0] ?? undefined;
+      const bounty = buildBounty(
+        entity.id,
+        entity.values ?? [],
+        entity.relations ?? [],
+        submissionCounts,
+        emptyPersonalCounts,
+        bountySpaceId
+      );
+      const row = bountySpaceId ? spaceRow.get(bountySpaceId) : undefined;
+      return {
+        ...bounty,
+        spaceLabel: bountySpaceId ? (row?.label ?? bountySpaceFallbackLabel(bountySpaceId)) : null,
+        spaceImage: bountySpaceId ? (row?.image ?? PLACEHOLDER_SPACE_IMAGE) : null,
+      };
+    });
+  }, [bountyEntities, bountySpaceIds, spaceRows, submissionCounts]);
+
+  return { linkedBounties, isLoading: isLoadingProposal || isLoadingBounties };
+}

--- a/apps/web/partials/review/bounty-linking/use-linked-bounties-for-proposal.ts
+++ b/apps/web/partials/review/bounty-linking/use-linked-bounties-for-proposal.ts
@@ -8,6 +8,7 @@ import { Effect } from 'effect';
 
 import { BOUNTIES_RELATION_TYPE, PLACEHOLDER_SPACE_IMAGE } from '~/core/constants';
 import { getBatchEntities, getRelationsByToEntityIds, getSpaces } from '~/core/io/queries';
+import type { Relation } from '~/core/types';
 
 import { buildBounty } from './build-bounties';
 import type { Bounty } from './types';
@@ -34,7 +35,13 @@ function bountySpaceFallbackLabel(spaceId: string): string {
 export function useLinkedBountiesForProposal({
   proposalId,
   enabled = true,
-}: UseLinkedBountiesForProposalArgs): { linkedBounties: Bounty[]; isLoading: boolean } {
+}: UseLinkedBountiesForProposalArgs): {
+  linkedBounties: Bounty[];
+  /** For each linked bounty id, the Relation object that created the link. Needed to issue a
+   *  deletion op when an author unlinks a previously-linked bounty. */
+  relationsByBountyId: Map<string, Relation>;
+  isLoading: boolean;
+} {
   const gated = Boolean(enabled && proposalId);
 
   const { data: proposalEntities = [], isLoading: isLoadingProposal } = useQuery({
@@ -47,14 +54,20 @@ export function useLinkedBountiesForProposal({
     },
   });
 
-  const linkedBountyIds = React.useMemo(() => {
+  const { linkedBountyIds, relationsByBountyId } = React.useMemo(() => {
     const proposalEntity = proposalEntities[0];
-    if (!proposalEntity) return [] as string[];
-    const ids = (proposalEntity.relations ?? [])
-      .filter(r => r.type.id === BOUNTIES_RELATION_TYPE && r.isDeleted !== true)
-      .map(r => r.toEntity?.id)
-      .filter((id): id is string => typeof id === 'string' && id.length > 0);
-    return [...new Set(ids)].sort();
+    const map = new Map<string, Relation>();
+    if (!proposalEntity) return { linkedBountyIds: [] as string[], relationsByBountyId: map };
+    for (const r of proposalEntity.relations ?? []) {
+      if (r.type.id !== BOUNTIES_RELATION_TYPE) continue;
+      if (r.isDeleted) continue;
+      const toId = r.toEntity?.id;
+      if (typeof toId !== 'string' || toId.length === 0) continue;
+      // If the same bounty somehow has two link relations, keep the first — either works for
+      // the subsequent delete op.
+      if (!map.has(toId)) map.set(toId, r);
+    }
+    return { linkedBountyIds: [...map.keys()].sort(), relationsByBountyId: map };
   }, [proposalEntities]);
 
   const { data: bountyEntities = [], isLoading: isLoadingBounties } = useQuery({
@@ -144,5 +157,5 @@ export function useLinkedBountiesForProposal({
     });
   }, [bountyEntities, bountySpaceIds, spaceRows, submissionCounts]);
 
-  return { linkedBounties, isLoading: isLoadingProposal || isLoadingBounties };
+  return { linkedBounties, relationsByBountyId, isLoading: isLoadingProposal || isLoadingBounties };
 }

--- a/apps/web/partials/review/bounty-linking/use-publish-bounty-links.ts
+++ b/apps/web/partials/review/bounty-linking/use-publish-bounty-links.ts
@@ -57,6 +57,14 @@ export function usePublishBountyLinks({ personalSpaceId }: UsePublishBountyLinks
       }
 
       setIsPublishing(true);
+      let settled = false;
+      const settle = (success: boolean) => {
+        if (settled) return;
+        settled = true;
+        if (success) onSuccess?.();
+        else onError?.();
+      };
+
       try {
         const bountyLinkValues: StoreValue[] = [
           {
@@ -137,14 +145,24 @@ export function usePublishBountyLinks({ personalSpaceId }: UsePublishBountyLinks
           }),
         ];
 
-        await makeProposal({
-          values: bountyLinkValues,
-          relations: bountyLinkRelations,
-          spaceId: personalSpaceId,
-          name: `Bounty links for: ${proposalName}`,
-          onSuccess,
-          onError,
-        });
+        // `makeProposal` has several early-return paths (no smart account, no space, empty
+        // ops) where it resolves without invoking either callback. Capture the promise
+        // resolution and, if neither callback has fired by then, surface a failure through
+        // `onError` so consumers can react deterministically.
+        try {
+          await makeProposal({
+            values: bountyLinkValues,
+            relations: bountyLinkRelations,
+            spaceId: personalSpaceId,
+            name: `Bounty links for: ${proposalName}`,
+            onSuccess: () => settle(true),
+            onError: () => settle(false),
+          });
+        } catch {
+          settle(false);
+          return;
+        }
+        settle(false);
       } finally {
         setIsPublishing(false);
       }

--- a/apps/web/partials/review/bounty-linking/use-publish-bounty-links.ts
+++ b/apps/web/partials/review/bounty-linking/use-publish-bounty-links.ts
@@ -1,0 +1,156 @@
+'use client';
+
+import { Position, SystemIds } from '@geoprotocol/geo-sdk/lite';
+
+import * as React from 'react';
+
+import { BOUNTIES_RELATION_TYPE, PROPOSAL_TYPE_ID } from '~/core/constants';
+import { usePublish } from '~/core/hooks/use-publish';
+import { ID } from '~/core/id';
+import type { Relation as StoreRelation, Value as StoreValue } from '~/core/types';
+
+import type { Bounty } from './types';
+
+type PublishBountyLinksArgs = {
+  /** The Proposal entity id. For new proposals this is the same value passed as `proposalId` to
+   *  `makeProposal`; for post-hoc linking from the proposal view it is `proposal.id`. */
+  proposalId: string;
+  /** Display name for the proposal entity and for the "Bounty links for: …" proposal name. */
+  proposalName: string;
+  /** The DAO space the bounties live in when it differs from the author's personal space. Left
+   *  undefined when the two are the same. */
+  toSpaceId?: string;
+  /** Bounty ids to create relations for. */
+  bountyIds: Set<string>;
+  /** Lookup to resolve each id → its display name for the relation payload. */
+  bountiesById: Map<string, Bounty>;
+  onSuccess?: () => void;
+  onError?: () => void;
+};
+
+type UsePublishBountyLinksArgs = {
+  personalSpaceId: string | null;
+};
+
+/**
+ * Publishes a "Bounty links for: {proposalName}" proposal into the author's personal space,
+ * creating a Proposal entity (identified by `proposalId`) and one `Bounties` relation per
+ * selected bounty. Extracted from the inline logic in `review-changes.tsx` so the same
+ * machinery can be invoked post-hoc from the proposal voting screen.
+ */
+export function usePublishBountyLinks({ personalSpaceId }: UsePublishBountyLinksArgs): {
+  publish: (args: PublishBountyLinksArgs) => Promise<void>;
+  isPublishing: boolean;
+} {
+  const { makeProposal } = usePublish();
+  const [isPublishing, setIsPublishing] = React.useState(false);
+
+  const publish = React.useCallback(
+    async ({ proposalId, proposalName, toSpaceId, bountyIds, bountiesById, onSuccess, onError }: PublishBountyLinksArgs) => {
+      if (!personalSpaceId) {
+        onError?.();
+        return;
+      }
+      if (bountyIds.size === 0) {
+        onSuccess?.();
+        return;
+      }
+
+      setIsPublishing(true);
+      try {
+        const bountyLinkValues: StoreValue[] = [
+          {
+            id: ID.createValueId({
+              entityId: proposalId,
+              propertyId: SystemIds.NAME_PROPERTY,
+              spaceId: personalSpaceId,
+            }),
+            entity: {
+              id: proposalId,
+              name: proposalName,
+            },
+            property: {
+              id: SystemIds.NAME_PROPERTY,
+              name: 'Name',
+              dataType: 'TEXT',
+            },
+            spaceId: personalSpaceId,
+            value: proposalName,
+            isLocal: true,
+            isDeleted: false,
+            hasBeenPublished: false,
+            timestamp: new Date().toISOString(),
+          },
+        ];
+
+        const proposalTypeRelation: StoreRelation = {
+          id: ID.createEntityId(),
+          entityId: ID.createEntityId(),
+          spaceId: personalSpaceId,
+          renderableType: 'RELATION',
+          verified: false,
+          position: Position.generate(),
+          type: {
+            id: SystemIds.TYPES_PROPERTY,
+            name: 'Types',
+          },
+          fromEntity: {
+            id: proposalId,
+            name: proposalName,
+          },
+          toEntity: {
+            id: PROPOSAL_TYPE_ID,
+            name: 'Proposal',
+            value: PROPOSAL_TYPE_ID,
+          },
+        };
+
+        const bountyLinkRelations: StoreRelation[] = [
+          proposalTypeRelation,
+          ...Array.from(bountyIds).flatMap<StoreRelation>(bountyId => {
+            const bounty = bountiesById.get(bountyId);
+            if (!bounty) return [];
+            return [
+              {
+                id: ID.createEntityId(),
+                entityId: ID.createEntityId(),
+                spaceId: personalSpaceId,
+                toSpaceId,
+                renderableType: 'RELATION',
+                verified: false,
+                position: Position.generate(),
+                type: {
+                  id: BOUNTIES_RELATION_TYPE,
+                  name: 'Bounties',
+                },
+                fromEntity: {
+                  id: proposalId,
+                  name: proposalName,
+                },
+                toEntity: {
+                  id: bounty.id,
+                  name: bounty.name,
+                  value: bounty.id,
+                },
+              },
+            ];
+          }),
+        ];
+
+        await makeProposal({
+          values: bountyLinkValues,
+          relations: bountyLinkRelations,
+          spaceId: personalSpaceId,
+          name: `Bounty links for: ${proposalName}`,
+          onSuccess,
+          onError,
+        });
+      } finally {
+        setIsPublishing(false);
+      }
+    },
+    [makeProposal, personalSpaceId]
+  );
+
+  return { publish, isPublishing };
+}

--- a/apps/web/partials/review/bounty-linking/use-publish-bounty-links.ts
+++ b/apps/web/partials/review/bounty-linking/use-publish-bounty-links.ts
@@ -20,10 +20,14 @@ type PublishBountyLinksArgs = {
   /** The DAO space the bounties live in when it differs from the author's personal space. Left
    *  undefined when the two are the same. */
   toSpaceId?: string;
-  /** Bounty ids to create relations for. */
+  /** Bounty ids to create new relations for. */
   bountyIds: Set<string>;
   /** Lookup to resolve each id → its display name for the relation payload. */
   bountiesById: Map<string, Bounty>;
+  /** Existing Bounties relations to remove. Each Relation's `id` identifies the on-chain
+   *  relation to tombstone; the rest of the fields are copied through to satisfy the
+   *  `StoreRelation` shape the publish pipeline expects. */
+  relationsToRemove?: StoreRelation[];
   onSuccess?: () => void;
   onError?: () => void;
 };
@@ -46,12 +50,21 @@ export function usePublishBountyLinks({ personalSpaceId }: UsePublishBountyLinks
   const [isPublishing, setIsPublishing] = React.useState(false);
 
   const publish = React.useCallback(
-    async ({ proposalId, proposalName, toSpaceId, bountyIds, bountiesById, onSuccess, onError }: PublishBountyLinksArgs) => {
+    async ({
+      proposalId,
+      proposalName,
+      toSpaceId,
+      bountyIds,
+      bountiesById,
+      relationsToRemove = [],
+      onSuccess,
+      onError,
+    }: PublishBountyLinksArgs) => {
       if (!personalSpaceId) {
         onError?.();
         return;
       }
-      if (bountyIds.size === 0) {
+      if (bountyIds.size === 0 && relationsToRemove.length === 0) {
         onSuccess?.();
         return;
       }
@@ -66,30 +79,35 @@ export function usePublishBountyLinks({ personalSpaceId }: UsePublishBountyLinks
       };
 
       try {
-        const bountyLinkValues: StoreValue[] = [
-          {
-            id: ID.createValueId({
-              entityId: proposalId,
-              propertyId: SystemIds.NAME_PROPERTY,
-              spaceId: personalSpaceId,
-            }),
-            entity: {
-              id: proposalId,
-              name: proposalName,
-            },
-            property: {
-              id: SystemIds.NAME_PROPERTY,
-              name: 'Name',
-              dataType: 'TEXT',
-            },
-            spaceId: personalSpaceId,
-            value: proposalName,
-            isLocal: true,
-            isDeleted: false,
-            hasBeenPublished: false,
-            timestamp: new Date().toISOString(),
-          },
-        ];
+        // Only write the name value when there's at least one new link. Delete-only updates
+        // don't need to re-assert it — the entity already exists in the personal space graph.
+        const bountyLinkValues: StoreValue[] =
+          bountyIds.size > 0
+            ? [
+                {
+                  id: ID.createValueId({
+                    entityId: proposalId,
+                    propertyId: SystemIds.NAME_PROPERTY,
+                    spaceId: personalSpaceId,
+                  }),
+                  entity: {
+                    id: proposalId,
+                    name: proposalName,
+                  },
+                  property: {
+                    id: SystemIds.NAME_PROPERTY,
+                    name: 'Name',
+                    dataType: 'TEXT',
+                  },
+                  spaceId: personalSpaceId,
+                  value: proposalName,
+                  isLocal: true,
+                  isDeleted: false,
+                  hasBeenPublished: false,
+                  timestamp: new Date().toISOString(),
+                },
+              ]
+            : [];
 
         const proposalTypeRelation: StoreRelation = {
           id: ID.createEntityId(),
@@ -113,36 +131,50 @@ export function usePublishBountyLinks({ personalSpaceId }: UsePublishBountyLinks
           },
         };
 
-        const bountyLinkRelations: StoreRelation[] = [
-          proposalTypeRelation,
-          ...Array.from(bountyIds).flatMap<StoreRelation>(bountyId => {
-            const bounty = bountiesById.get(bountyId);
-            if (!bounty) return [];
-            return [
-              {
-                id: ID.createEntityId(),
-                entityId: ID.createEntityId(),
-                spaceId: personalSpaceId,
-                toSpaceId,
-                renderableType: 'RELATION',
-                verified: false,
-                position: Position.generate(),
-                type: {
-                  id: BOUNTIES_RELATION_TYPE,
-                  name: 'Bounties',
-                },
-                fromEntity: {
-                  id: proposalId,
-                  name: proposalName,
-                },
-                toEntity: {
-                  id: bounty.id,
-                  name: bounty.name,
-                  value: bounty.id,
-                },
+        const addedRelations = Array.from(bountyIds).flatMap<StoreRelation>(bountyId => {
+          const bounty = bountiesById.get(bountyId);
+          if (!bounty) return [];
+          return [
+            {
+              id: ID.createEntityId(),
+              entityId: ID.createEntityId(),
+              spaceId: personalSpaceId,
+              toSpaceId,
+              renderableType: 'RELATION',
+              verified: false,
+              position: Position.generate(),
+              type: {
+                id: BOUNTIES_RELATION_TYPE,
+                name: 'Bounties',
               },
-            ];
-          }),
+              fromEntity: {
+                id: proposalId,
+                name: proposalName,
+              },
+              toEntity: {
+                id: bounty.id,
+                name: bounty.name,
+                value: bounty.id,
+              },
+            },
+          ];
+        });
+
+        // Tombstone existing relations. Only `id` is consulted by Graph.deleteRelation, so we
+        // mirror the original relation payload and flip `isDeleted` to true.
+        const deletedRelations = relationsToRemove.map<StoreRelation>(relation => ({
+          ...relation,
+          isDeleted: true,
+          isLocal: true,
+          hasBeenPublished: false,
+        }));
+
+        const bountyLinkRelations: StoreRelation[] = [
+          // Only re-assert the Proposal entity's type when there are adds — for delete-only
+          // updates the entity already exists in the personal space graph.
+          ...(addedRelations.length > 0 ? [proposalTypeRelation] : []),
+          ...addedRelations,
+          ...deletedRelations,
         ];
 
         // `makeProposal` has several early-return paths (no smart account, no space, empty

--- a/apps/web/partials/review/review-changes.tsx
+++ b/apps/web/partials/review/review-changes.tsx
@@ -1,7 +1,5 @@
 'use client';
 
-import { Position, SystemIds } from '@geoprotocol/geo-sdk/lite';
-import { useQuery } from '@tanstack/react-query';
 import { useVirtualizer } from '@tanstack/react-virtual';
 
 import * as React from 'react';
@@ -10,12 +8,6 @@ import cx from 'classnames';
 import { Effect } from 'effect';
 import { useSetAtom } from 'jotai';
 
-import {
-  BOUNTIES_RELATION_TYPE,
-  BOUNTY_TYPE_ID,
-  PLACEHOLDER_SPACE_IMAGE,
-  PROPOSAL_TYPE_ID,
-} from '~/core/constants';
 import { useAutofocus } from '~/core/hooks/use-autofocus';
 import { useGeoProfile } from '~/core/hooks/use-geo-profile';
 import { useKeyboardShortcuts } from '~/core/hooks/use-keyboard-shortcuts';
@@ -25,13 +17,11 @@ import { usePublish } from '~/core/hooks/use-publish';
 import { useSmartAccount } from '~/core/hooks/use-smart-account';
 import { ID } from '~/core/id';
 import type { Space } from '~/core/io/dto/spaces';
-import { getAllEntities, getRelationsByToEntityIds, getSpaces } from '~/core/io/queries';
-import { fetchSpacesWithAncestors } from '~/core/io/subgraph/fetch-spaces-with-ancestors';
+import { getSpaces } from '~/core/io/queries';
 import { useDiff } from '~/core/state/diff-store';
 import { useStatusBar } from '~/core/state/status-bar-store';
 import { useRelations, useValues } from '~/core/sync/use-store';
 import { useSyncEngine } from '~/core/sync/use-sync-engine';
-import type { Relation as StoreRelation, Value as StoreValue } from '~/core/types';
 
 import { Button, SmallButton, SquareButton } from '~/design-system/button';
 import { Dropdown } from '~/design-system/dropdown';
@@ -45,24 +35,10 @@ import { Text } from '~/design-system/text';
 
 import { ChangedEntity, hasVisibleChanges } from '~/partials/diffs/changed-entity';
 
-import {
-  BountyLinkingPanel,
-  buildBounties,
-  buildBounty,
-  buildBountyAllocationTargets,
-  hasBountyTaskStatusDoneRelation,
-  isAllocatedToUser,
-  isBountyTypeRelation,
-} from './bounty-linking';
-import type { Bounty } from './bounty-linking/types';
+import { BountyLinkingPanel, useLinkableBounties, usePublishBountyLinks } from './bounty-linking';
 import { editorContentVersionAtom } from '~/atoms';
 
 type Proposals = Record<string, { name: string; description: string }>;
-
-function bountySpaceFallbackLabel(spaceId: string): string {
-  const compact = spaceId.replace(/-/g, '');
-  return compact.length > 14 ? `${compact.slice(0, 6)}…${compact.slice(-4)}` : spaceId;
-}
 
 export const ReviewChanges = () => {
   const {
@@ -193,201 +169,18 @@ export const ReviewChanges = () => {
     includeDeleted: true,
   });
 
-  const bountyTypeRelations = useRelations({
-    selector: r => r.spaceId === activeSpace && r.type.id === SystemIds.TYPES_PROPERTY && r.isDeleted !== true,
-  });
-
-  const bountyEntityIds = React.useMemo(() => {
-    const ids = bountyTypeRelations.filter(isBountyTypeRelation).map(relation => relation.fromEntity.id);
-    return [...new Set(ids)];
-  }, [bountyTypeRelations]);
-
-  const bountyEntityIdSet = React.useMemo(() => new Set(bountyEntityIds), [bountyEntityIds]);
-
-  const bountyValues = useValues({
-    selector: value =>
-      value.spaceId === activeSpace && bountyEntityIdSet.has(value.entity.id) && value.isDeleted !== true,
-  });
-
-  const bountyRelations = useRelations({
-    selector: relation =>
-      relation.spaceId === activeSpace && bountyEntityIdSet.has(relation.fromEntity.id) && relation.isDeleted !== true,
-  });
-
-  const { data: bountySearchSpaceIds = [] } = useQuery({
-    queryKey: ['bounty-link-spaces-with-ancestors', activeSpace],
-    enabled: Boolean(activeSpace && isReviewOpen),
-    staleTime: 60_000,
-    queryFn: async () => {
-      if (!activeSpace) return [];
-      return await fetchSpacesWithAncestors(activeSpace);
-    },
-  });
-
-  const { data: remoteBountyEntities = [] } = useQuery({
-    queryKey: ['bounties-by-type', bountySearchSpaceIds.join(','), BOUNTY_TYPE_ID],
-    enabled: bountySearchSpaceIds.length > 0 && isReviewOpen,
-    staleTime: 60_000,
-    queryFn: async () => {
-      if (bountySearchSpaceIds.length === 0) return [];
-      const pages = await Promise.all(
-        bountySearchSpaceIds.map(spaceId =>
-          Effect.runPromise(
-            getAllEntities({
-              spaceId,
-              typeIds: { is: BOUNTY_TYPE_ID },
-            })
-          )
-        )
-      );
-      const merged = new Map<string, (typeof pages)[0][0]>();
-      for (const entities of pages) {
-        for (const entity of entities) {
-          merged.set(entity.id, entity);
-        }
-      }
-      return [...merged.values()];
-    },
-  });
-
-  const allBountyIds = React.useMemo(() => {
-    const remoteIds = remoteBountyEntities.map(entity => entity.id);
-    return [...new Set([...bountyEntityIds, ...remoteIds])].sort();
-  }, [bountyEntityIds, remoteBountyEntities]);
-
-  const { data: bountySubmissionRelations = [] } = useQuery({
-    queryKey: ['bounty-submission-relations', allBountyIds],
-    enabled: allBountyIds.length > 0 && isReviewOpen,
-    staleTime: 60_000,
-    queryFn: async () => {
-      return await Effect.runPromise(getRelationsByToEntityIds(allBountyIds, BOUNTIES_RELATION_TYPE));
-    },
-  });
-
-  const { data: bountyPersonalSubmissionRelations = [] } = useQuery({
-    queryKey: ['bounty-submission-relations-personal', allBountyIds, personalSpaceId],
-    enabled: allBountyIds.length > 0 && isReviewOpen && Boolean(personalSpaceId),
-    staleTime: 60_000,
-    queryFn: async () => {
-      if (!personalSpaceId) return [];
-      return await Effect.runPromise(getRelationsByToEntityIds(allBountyIds, BOUNTIES_RELATION_TYPE, personalSpaceId));
-    },
-  });
-
-  const bountySubmissionCounts = React.useMemo(() => {
-    const counts = new Map<string, number>();
-    for (const relation of bountySubmissionRelations) {
-      const id = relation.toEntityId;
-      if (!id) continue;
-      counts.set(id, (counts.get(id) ?? 0) + 1);
-    }
-    return counts;
-  }, [bountySubmissionRelations]);
-
-  const bountyPersonalSubmissionCounts = React.useMemo(() => {
-    const counts = new Map<string, number>();
-    for (const relation of bountyPersonalSubmissionRelations) {
-      const id = relation.toEntityId;
-      if (!id) continue;
-      counts.set(id, (counts.get(id) ?? 0) + 1);
-    }
-    return counts;
-  }, [bountyPersonalSubmissionRelations]);
-
-  const { bounties, bountiesById } = React.useMemo(() => {
-    if (!personalSpaceId) {
-      return { bounties: [], bountiesById: new Map<string, Bounty>() };
-    }
-
-    const allocationTargets = buildBountyAllocationTargets(personalSpaceId, personalPageEntityId);
-    const localResult = buildBounties(
-      bountyEntityIds,
-      bountyValues,
-      bountyRelations,
-      bountySubmissionCounts,
-      bountyPersonalSubmissionCounts,
-      allocationTargets,
-      activeSpace,
-      personalSpaceId
-    );
-    const remoteBounties = remoteBountyEntities
-      .filter(
-        entity =>
-          isAllocatedToUser(entity.relations ?? [], allocationTargets) &&
-          !hasBountyTaskStatusDoneRelation(entity.relations ?? [])
-      )
-      .map(entity => {
-        const bountySpaceId = entity.spaces?.[0] ?? activeSpace;
-        return buildBounty(
-          entity.id,
-          entity.values ?? [],
-          entity.relations ?? [],
-          bountySubmissionCounts,
-          bountyPersonalSubmissionCounts,
-          bountySpaceId,
-          personalSpaceId
-        );
-      });
-
-    const merged = new Map<string, Bounty>();
-    for (const bounty of remoteBounties) merged.set(bounty.id, bounty);
-    for (const bounty of localResult.bounties) merged.set(bounty.id, bounty);
-
-    return { bounties: Array.from(merged.values()), bountiesById: merged };
-  }, [
-    bountyEntityIds,
-    bountyValues,
-    bountyRelations,
-    remoteBountyEntities,
-    bountySubmissionCounts,
-    bountyPersonalSubmissionCounts,
+  const { bounties, bountiesById } = useLinkableBounties({
     activeSpace,
-    personalSpaceId,
+    personalSpaceId: personalSpaceId ?? null,
     personalPageEntityId,
-  ]);
-
-  const bountySpaceIdsForLabels = React.useMemo(
-    () => [...new Set(bounties.map(b => b.spaceId).filter((id): id is string => Boolean(id)))].sort(),
-    [bounties]
-  );
-
-  const { data: bountyLabelSpaces = [] } = useQuery({
-    queryKey: ['bounty-space-labels', bountySpaceIdsForLabels.join(',')],
-    enabled: bountySpaceIdsForLabels.length > 0 && isReviewOpen,
-    staleTime: 60_000,
-    queryFn: async () => {
-      if (bountySpaceIdsForLabels.length === 0) return [];
-      return await Effect.runPromise(getSpaces({ spaceIds: bountySpaceIdsForLabels }));
-    },
+    enabled: isReviewOpen,
   });
-
-  const bountySpaceRowById = React.useMemo(() => {
-    const m = new Map<string, { label: string; image: string }>();
-    for (const id of bountySpaceIdsForLabels) {
-      const space = bountyLabelSpaces.find(s => s.id === id);
-      const name = space?.entity?.name?.trim();
-      const label = name && name.length > 0 ? name : bountySpaceFallbackLabel(id);
-      const image =
-        space?.entity?.image && space.entity.image.length > 0 ? space.entity.image : PLACEHOLDER_SPACE_IMAGE;
-      m.set(id, { label, image });
-    }
-    return m;
-  }, [bountyLabelSpaces, bountySpaceIdsForLabels]);
-
-  const bountiesWithSpaceLabels = React.useMemo(
-    (): Bounty[] =>
-      bounties.map(b => {
-        const row = b.spaceId ? bountySpaceRowById.get(b.spaceId) : undefined;
-        return {
-          ...b,
-          spaceLabel: b.spaceId ? (row?.label ?? bountySpaceFallbackLabel(b.spaceId)) : null,
-          spaceImage: b.spaceId ? (row?.image ?? PLACEHOLDER_SPACE_IMAGE) : null,
-        };
-      }),
-    [bounties, bountySpaceRowById]
-  );
 
   const bountyIdSet = React.useMemo(() => new Set(bounties.map(bounty => bounty.id)), [bounties]);
+
+  const { publish: publishBountyLinks } = usePublishBountyLinks({
+    personalSpaceId: personalSpaceId ?? null,
+  });
 
   const isReadyToPublish = proposalName.length > 0;
 
@@ -457,92 +250,12 @@ export const ReviewChanges = () => {
     });
 
     if (publishSucceeded && selectedBountyIds.size > 0 && personalSpaceId) {
-      const bountyLinkValues: StoreValue[] = [
-        {
-          id: ID.createValueId({
-            entityId: proposalEntityId,
-            propertyId: SystemIds.NAME_PROPERTY,
-            spaceId: personalSpaceId,
-          }),
-          entity: {
-            id: proposalEntityId,
-            name: proposalName,
-          },
-          property: {
-            id: SystemIds.NAME_PROPERTY,
-            name: 'Name',
-            dataType: 'TEXT',
-          },
-          spaceId: personalSpaceId,
-          value: proposalName,
-          isLocal: true,
-          isDeleted: false,
-          hasBeenPublished: false,
-          timestamp: new Date().toISOString(),
-        },
-      ];
-
-      const bountyTargetSpaceId = activeSpace !== personalSpaceId ? activeSpace : undefined;
-
-      const proposalTypeRelation: StoreRelation = {
-        id: ID.createEntityId(),
-        entityId: ID.createEntityId(),
-        spaceId: personalSpaceId,
-        renderableType: 'RELATION',
-        verified: false,
-        position: Position.generate(),
-        type: {
-          id: SystemIds.TYPES_PROPERTY,
-          name: 'Types',
-        },
-        fromEntity: {
-          id: proposalEntityId,
-          name: proposalName,
-        },
-        toEntity: {
-          id: PROPOSAL_TYPE_ID,
-          name: 'Proposal',
-          value: PROPOSAL_TYPE_ID,
-        },
-      };
-
-      const bountyLinkRelations: StoreRelation[] = [
-        proposalTypeRelation,
-        ...Array.from(selectedBountyIds).flatMap<StoreRelation>(bountyId => {
-          const bounty = bountiesById.get(bountyId);
-          if (!bounty) return [];
-          return [
-            {
-              id: ID.createEntityId(),
-              entityId: ID.createEntityId(),
-              spaceId: personalSpaceId,
-              toSpaceId: bountyTargetSpaceId,
-              renderableType: 'RELATION',
-              verified: false,
-              position: Position.generate(),
-              type: {
-                id: BOUNTIES_RELATION_TYPE,
-                name: 'Bounties',
-              },
-              fromEntity: {
-                id: proposalEntityId,
-                name: proposalName,
-              },
-              toEntity: {
-                id: bounty.id,
-                name: bounty.name,
-                value: bounty.id,
-              },
-            },
-          ];
-        }),
-      ];
-
-      await makeProposal({
-        values: bountyLinkValues,
-        relations: bountyLinkRelations,
-        spaceId: personalSpaceId,
-        name: `Bounty links for: ${proposalName}`,
+      await publishBountyLinks({
+        proposalId: proposalEntityId,
+        proposalName,
+        toSpaceId: activeSpace !== personalSpaceId ? activeSpace : undefined,
+        bountyIds: selectedBountyIds,
+        bountiesById,
         onSuccess: () => {
           setSelectedBountyIds(new Set());
         },
@@ -564,6 +277,7 @@ export const ReviewChanges = () => {
     selectedBountyIds,
     personalSpaceId,
     bountiesById,
+    publishBountyLinks,
   ]);
 
   useKeyboardShortcuts(
@@ -774,7 +488,7 @@ export const ReviewChanges = () => {
             setIsOpen={setIsBountyLinkingOpen}
             selectedBountyIds={selectedBountyIds}
             setSelectedBountyIds={setSelectedBountyIds}
-            bounties={bountiesWithSpaceLabels}
+            bounties={bounties}
           />
         </div>
       </div>


### PR DESCRIPTION
## Summary
Behavior-preserving refactor that pulls the bounty fetch/merge and "Bounty links for: …" publish logic out of `review-changes.tsx` into two reusable hooks:
- `useLinkableBounties` — fetch eligible bounties (ancestor-space search, submission counts, space labels) and merge with locally-edited bounties from the sync store.
- `usePublishBountyLinks` — publish a Proposal entity + `Bounties` relations into the author's personal space.

This is prep work for [plan item: link bounties from the proposal voting screen]. On the review screen, behavior is unchanged.

## Follow-ups on this branch
- `useLinkedBountiesForProposal` (read currently-linked bounties)
- Design refresh on `BountyCard` + `BountyLinkingPanel` per Figma
- Wire author-gated linking UI into `active-proposal.tsx`

## Test plan
- [x] Review screen still lists the same eligible bounties as before
- [x] Linking a bounty at publish time still creates the "Bounty links for: …" proposal in the personal space
- [x] `bun run build` passes