### PR TITLE
fix(browse-sidebar): extend collapsed rail to viewport top; trim navbar

### DIFF
--- a/apps/web/partials/browse-sidebar/browse-sidebar.tsx
+++ b/apps/web/partials/browse-sidebar/browse-sidebar.tsx
@@ -323,7 +323,7 @@ export function BrowseSidebar() {
         aria-label="Browse menu (collapsed)"
       >
         {/* Vertical rail aligned to the centre of the navbar logo (navbar px-4 = 16px + 8px half-logo ≈ 24px). */}
-        <div className="pointer-events-none absolute bottom-0 left-6 top-11 w-px bg-divider" />
+        <div className="pointer-events-none absolute bottom-0 left-6 top-0 w-px bg-divider" />
         <SidebarToggle
           open={false}
           onToggle={() => setOpen(true)}

--- a/apps/web/partials/navbar/navbar-space-metadata.tsx
+++ b/apps/web/partials/navbar/navbar-space-metadata.tsx
@@ -4,10 +4,7 @@ import { useParams } from 'next/navigation';
 
 import { useSpace } from '~/core/hooks/use-space';
 
-import { ChevronRight } from '~/design-system/icons/chevron-right';
-
 import { NavbarBreadcrumb } from './navbar-breadcrumb';
-import { NavbarLinkMenu } from './navbar-link-menu';
 
 export function NavbarSpaceMetadata() {
   const params = useParams();
@@ -19,13 +16,7 @@ export function NavbarSpaceMetadata() {
 
   return (
     <div className="flex items-center gap-2">
-      <NavbarLinkMenu />
-      {spaceId && (
-        <>
-          <ChevronRight color="grey-03" />
-          <NavbarBreadcrumb spaceId={spaceId} entityId={entityId ?? space?.entity?.id ?? ''} />
-        </>
-      )}
+      {spaceId && <NavbarBreadcrumb spaceId={spaceId} entityId={entityId ?? space?.entity?.id ?? ''} />}
     </div>
   );
 }

--- a/apps/web/partials/navbar/navbar.tsx
+++ b/apps/web/partials/navbar/navbar.tsx
@@ -18,8 +18,8 @@ export function Navbar({ onSearchClick, hideLogo = false }: Props) {
   return (
     <nav
       className={cx(
-        'flex h-11 w-full items-center justify-between gap-1 border-b border-divider px-4 py-1',
-        process.env.NODE_ENV === 'development' && 'sticky top-0 z-100 bg-white'
+        'relative z-[60] flex h-11 w-full items-center justify-between gap-1 border-b border-divider bg-white px-4 py-1',
+        process.env.NODE_ENV === 'development' && 'sticky top-0 z-100'
       )}
     >
       <div className="flex items-center gap-8 md:gap-4">


### PR DESCRIPTION
## Summary
- **Collapsed sidebar rail** no longer floats below a scrolled-away navbar. The rail now extends to `top-0`; the navbar is given `relative z-[60] bg-white` so it paints over the rail while it's in view and reveals the full rail as it scrolls away. Collapse/expand toggle position is unchanged.
- **Navbar trim**: removed the `...` (`NavbarLinkMenu`) and the `>` (`ChevronRight`) separator from `NavbarSpaceMetadata`.

## Test plan
- [ ] Collapsed sidebar: scroll the page down. Vertical rail is continuous from viewport top to bottom once the navbar scrolls out of view.
- [ ] While the navbar is still in view, no rail is visible behind the logo area.
- [ ] Toggle button stays at its existing offset (~52px from viewport top).
- [ ] Expanded sidebar behaves as before (own right border, no regressions).
- [ ] Navbar on root and inside a space: no `...` trigger, no `>` chevron. Breadcrumb pill still renders inside a space.
- [ ] Dev-mode sticky navbar still sticks (`NODE_ENV=development`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)