### PR TITLE
fix(browse-sidebar): remove arrow icons from Geo Apps links

### DIFF
--- a/apps/web/core/browse/geo-apps-sidebar-src.ts
+++ b/apps/web/core/browse/geo-apps-sidebar-src.ts
@@ -1,5 +1,3 @@
-export const GEO_APPS_SIDEBAR_EXTERNAL_ICON = '/browse-nav/geo-apps-external.svg' as const;
-
 export const GEO_APPS_SIDEBAR_LINKS = [
   {
     label: 'Geo Curators',

--- a/apps/web/partials/browse-sidebar/browse-sidebar.tsx
+++ b/apps/web/partials/browse-sidebar/browse-sidebar.tsx
@@ -14,7 +14,7 @@ import { useSpaceId } from '~/core/hooks/use-space-id';
 import { NavUtils, getImagePath } from '~/core/utils/utils';
 
 import { BROWSE_NAV_ICON } from '~/core/browse/browse-nav-icon-src';
-import { GEO_APPS_SIDEBAR_EXTERNAL_ICON, GEO_APPS_SIDEBAR_LINKS } from '~/core/browse/geo-apps-sidebar-src';
+import { GEO_APPS_SIDEBAR_LINKS } from '~/core/browse/geo-apps-sidebar-src';
 import type { BrowseSidebarData, BrowseSpaceRow } from '~/core/browse/fetch-browse-sidebar-data';
 
 import { Avatar } from '~/design-system/avatar';
@@ -110,16 +110,6 @@ function GeoAppsSidebarLinks() {
           <BrowseNavIcon src={item.icon} />
           <span className="min-w-0 flex-1 overflow-hidden">
             <p className="-my-0.5 truncate leading-5">{item.label}</p>
-          </span>
-          <span className="inline-flex h-4 w-4 shrink-0 items-center justify-center text-grey-04">
-            <img
-              src={GEO_APPS_SIDEBAR_EXTERNAL_ICON}
-              alt=""
-              width={16}
-              height={16}
-              className="h-4 w-4 max-h-none max-w-none object-contain"
-              draggable={false}
-            />
           </span>
         </a>
       ))}


### PR DESCRIPTION
## Summary
- Remove the external-link arrow icon rendered next to each link in the Geo Apps section of the browse sidebar
- Drop the now-unused `GEO_APPS_SIDEBAR_EXTERNAL_ICON` constant

## Test plan
- [ ] Open the browse sidebar and verify Geo Apps links no longer display a trailing arrow icon
- [ ] Confirm links still open in a new tab