### PR TITLE
fix(tabs): polish inline tab UI

### DIFF
--- a/apps/web/partials/entity-page/editable-tab-group.tsx
+++ b/apps/web/partials/entity-page/editable-tab-group.tsx
@@ -188,32 +188,36 @@ export function EditableTabGroup({
   const handleDeleteTab = (tab: EditableTab) => {
     const tabEntityId = tab.entityId;
 
-    // 1. Gather every value and relation attached to the tab entity (both directions).
-    const tabValues = getValues({ selector: v => v.entity.id === tabEntityId });
-    const tabRelations = getRelations({
-      selector: r => r.fromEntity.id === tabEntityId || r.toEntity.id === tabEntityId,
+    // Mirrors the deleteEntityFromSource pattern in entity-to-space-dialog.tsx — all selectors
+    // scoped to the current spaceId so we don't reach into copies of the tab entity in other spaces.
+    const tabValues = getValues({
+      selector: v => v.entity.id === tabEntityId && v.spaceId === spaceId,
+    });
+    const outgoingRelations = getRelations({
+      selector: r => r.fromEntity.id === tabEntityId && r.spaceId === spaceId,
     });
 
-    // 2. Find block entities the tab owns via BLOCKS relations.
+    // Find block entities the tab owns via BLOCKS relations in this space.
     const blockIds = [
-      ...new Set(
-        tabRelations.filter(r => r.fromEntity.id === tabEntityId && r.type.id === SystemIds.BLOCKS).map(r => r.toEntity.id)
-      ),
+      ...new Set(outgoingRelations.filter(r => r.type.id === SystemIds.BLOCKS).map(r => r.toEntity.id)),
     ];
 
-    // A block is orphaned once the tab's BLOCKS relations are removed and nothing else points to it.
+    // A block is orphaned once the tab's BLOCKS relation (in this space) is removed and nothing else points to it.
     const orphanedBlockIds = blockIds.filter(blockId => {
       const remainingRefs = getRelations({
         selector: r =>
-          r.toEntity.id === blockId && !(r.fromEntity.id === tabEntityId && r.type.id === SystemIds.BLOCKS),
+          r.toEntity.id === blockId &&
+          !(r.fromEntity.id === tabEntityId && r.type.id === SystemIds.BLOCKS && r.spaceId === spaceId),
       });
       return remainingRefs.length === 0;
     });
 
-    // 3. Collect relation/value objects for orphan blocks so they get cleaned up too.
     const relationIds = new Set<string>();
-    const allRelationsToDelete: typeof tabRelations = [];
-    for (const r of [...tabRelations, tab.relation]) {
+    const allRelationsToDelete: typeof outgoingRelations = [];
+    for (const r of [
+      ...outgoingRelations,
+      ...getRelations({ selector: r => r.toEntity.id === tabEntityId && r.spaceId === spaceId }),
+    ]) {
       if (!relationIds.has(r.id)) {
         relationIds.add(r.id);
         allRelationsToDelete.push(r);
@@ -233,7 +237,7 @@ export function EditableTabGroup({
       }
     }
 
-    // 4. Batch the deletes so the UI only flashes once.
+    // Batch the deletes so the UI only flashes once.
     storage.values.deleteMany(allValuesToDelete);
     storage.relations.deleteMany(allRelationsToDelete);
 
@@ -385,14 +389,26 @@ function SortableTab({
     }
   };
 
-  const openPopover = () => {
-    cancelClose();
+  // Align 'start' when the trigger is in the left half of the viewport, 'end' otherwise.
+  const updateAlign = () => {
     const rect = triggerRef.current?.getBoundingClientRect();
     if (rect) {
       const triggerCenter = rect.left + rect.width / 2;
       setAlign(triggerCenter < window.innerWidth / 2 ? 'start' : 'end');
     }
+  };
+
+  const openPopover = () => {
+    cancelClose();
+    updateAlign();
     setIsPopoverOpen(true);
+  };
+
+  // Also recompute alignment for non-hover opens (click, keyboard) that go through Radix's
+  // onOpenChange instead of our hover handler.
+  const handleOpenChange = (open: boolean) => {
+    if (open) updateAlign();
+    setIsPopoverOpen(open);
   };
 
   const scheduleClose = () => {
@@ -453,7 +469,7 @@ function SortableTab({
             isPopoverOpen ? 'opacity-100' : 'opacity-0 group-hover/tab:opacity-100'
           )}
         >
-          <Popover.Root open={isPopoverOpen} onOpenChange={setIsPopoverOpen}>
+          <Popover.Root open={isPopoverOpen} onOpenChange={handleOpenChange}>
             <Popover.Trigger asChild>
               <button
                 ref={triggerRef}

--- a/apps/web/partials/entity-page/editable-tab-group.tsx
+++ b/apps/web/partials/entity-page/editable-tab-group.tsx
@@ -188,8 +188,9 @@ export function EditableTabGroup({
   const handleDeleteTab = (tab: EditableTab) => {
     const tabEntityId = tab.entityId;
 
-    // Mirrors the deleteEntityFromSource pattern in entity-to-space-dialog.tsx — all selectors
-    // scoped to the current spaceId so we don't reach into copies of the tab entity in other spaces.
+    // Mirrors the deleteEntityFromSource pattern in entity-to-space-dialog.tsx: the tab entity's
+    // own values/relations are scoped to the current spaceId, while orphan checks and deletion for
+    // block entities intentionally use global selectors so we only remove blocks that are truly unused.
     const tabValues = getValues({
       selector: v => v.entity.id === tabEntityId && v.spaceId === spaceId,
     });
@@ -409,7 +410,11 @@ function SortableTab({
   // Also recompute alignment for non-hover opens (click, keyboard) that go through Radix's
   // onOpenChange instead of our hover handler.
   const handleOpenChange = (open: boolean) => {
-    if (open) updateAlign();
+    if (open) {
+      // Cancel any pending close so a stale mouseleave timeout can't snap the menu shut after open.
+      cancelClose();
+      updateAlign();
+    }
     setIsPopoverOpen(open);
   };
 

--- a/apps/web/partials/entity-page/editable-tab-group.tsx
+++ b/apps/web/partials/entity-page/editable-tab-group.tsx
@@ -26,7 +26,11 @@ import { ID } from '~/core/id';
 import { useTabId } from '~/core/state/editor/use-editor';
 import { useName } from '~/core/state/entity-page-store/entity-store';
 import { useMutate } from '~/core/sync/use-mutate';
+import { getRelations, getValues } from '~/core/sync/use-store';
 import type { Relation } from '~/core/types';
+
+// Page entity type — new tabs are created as entities of this type.
+const PAGE_TYPE_ID = '480e3fc267f3499385fbacdf4ddeaa6b';
 
 import { EditSmall } from '~/design-system/icons/edit-small';
 import { ExpandSmall } from '~/design-system/icons/expand-small';
@@ -121,8 +125,10 @@ export function EditableTabGroup({
 
   const handleAddTab = () => {
     const tabEntityId = ID.createEntityId();
-    const relationId = ID.createEntityId();
-    const relationEntityId = ID.createEntityId();
+    const tabsRelationId = ID.createEntityId();
+    const tabsRelationEntityId = ID.createEntityId();
+    const typesRelationId = ID.createEntityId();
+    const typesRelationEntityId = ID.createEntityId();
 
     // Set name for the new tab entity
     storage.entities.name.set(tabEntityId, spaceId, '');
@@ -133,8 +139,8 @@ export function EditableTabGroup({
 
     // Create the TABS_PROPERTY relation
     storage.relations.set({
-      id: relationId,
-      entityId: relationEntityId,
+      id: tabsRelationId,
+      entityId: tabsRelationEntityId,
       spaceId,
       renderableType: 'RELATION',
       verified: false,
@@ -154,6 +160,29 @@ export function EditableTabGroup({
       },
     });
 
+    // Type the new tab entity as a Page so it renders with the correct schema.
+    storage.relations.set({
+      id: typesRelationId,
+      entityId: typesRelationEntityId,
+      spaceId,
+      renderableType: 'RELATION',
+      verified: false,
+      position: Position.generate(),
+      type: {
+        id: SystemIds.TYPES_PROPERTY,
+        name: 'Types',
+      },
+      fromEntity: {
+        id: tabEntityId,
+        name: null,
+      },
+      toEntity: {
+        id: PAGE_TYPE_ID,
+        name: 'Page',
+        value: PAGE_TYPE_ID,
+      },
+    });
+
     // Navigate to the new tab so it becomes the active tab, and enter rename mode.
     // `scroll: false` keeps the user's current scroll position.
     router.replace(`${overviewHref}?tabId=${tabEntityId}`, { scroll: false });
@@ -161,11 +190,60 @@ export function EditableTabGroup({
   };
 
   const handleDeleteTab = (tab: EditableTab) => {
-    storage.relations.delete(tab.relation);
+    const tabEntityId = tab.entityId;
+
+    // 1. Gather every value and relation attached to the tab entity (both directions).
+    const tabValues = getValues({ selector: v => v.entity.id === tabEntityId });
+    const tabRelations = getRelations({
+      selector: r => r.fromEntity.id === tabEntityId || r.toEntity.id === tabEntityId,
+    });
+
+    // 2. Find block entities the tab owns via BLOCKS relations.
+    const blockIds = [
+      ...new Set(
+        tabRelations.filter(r => r.fromEntity.id === tabEntityId && r.type.id === SystemIds.BLOCKS).map(r => r.toEntity.id)
+      ),
+    ];
+
+    // A block is orphaned once the tab's BLOCKS relations are removed and nothing else points to it.
+    const orphanedBlockIds = blockIds.filter(blockId => {
+      const remainingRefs = getRelations({
+        selector: r =>
+          r.toEntity.id === blockId && !(r.fromEntity.id === tabEntityId && r.type.id === SystemIds.BLOCKS),
+      });
+      return remainingRefs.length === 0;
+    });
+
+    // 3. Collect relation/value objects for orphan blocks so they get cleaned up too.
+    const relationIds = new Set<string>();
+    const allRelationsToDelete: typeof tabRelations = [];
+    for (const r of [...tabRelations, tab.relation]) {
+      if (!relationIds.has(r.id)) {
+        relationIds.add(r.id);
+        allRelationsToDelete.push(r);
+      }
+    }
+    const allValuesToDelete = [...tabValues];
+
+    for (const blockId of orphanedBlockIds) {
+      allValuesToDelete.push(...getValues({ selector: v => v.entity.id === blockId }));
+      for (const r of getRelations({
+        selector: r => r.fromEntity.id === blockId || r.toEntity.id === blockId,
+      })) {
+        if (!relationIds.has(r.id)) {
+          relationIds.add(r.id);
+          allRelationsToDelete.push(r);
+        }
+      }
+    }
+
+    // 4. Batch the deletes so the UI only flashes once.
+    storage.values.deleteMany(allValuesToDelete);
+    storage.relations.deleteMany(allRelationsToDelete);
 
     // If the deleted tab is currently active, navigate to overview
     if (tabId === tab.entityId) {
-      router.replace(overviewHref);
+      router.replace(overviewHref, { scroll: false });
     }
   };
 
@@ -175,9 +253,15 @@ export function EditableTabGroup({
   };
 
   const activeTab = activeId ? editableTabs.find(t => t.relation.id === activeId) : null;
+  const isAnyDragging = activeId !== null;
 
   // Stable array identity for SortableContext so drag doesn't re-register items on every render.
-  const sortableIds = React.useMemo(() => editableTabs.map(t => t.relation.id), [editableTabs]);
+  // Key the memo on a joined string so we only allocate a new array when the id set actually changes.
+  const sortableIdsKey = editableTabs.map(t => t.relation.id).join(',');
+  const sortableIds = React.useMemo(
+    () => (sortableIdsKey === '' ? [] : sortableIdsKey.split(',')),
+    [sortableIdsKey]
+  );
 
   return (
     <div className="relative">
@@ -205,6 +289,7 @@ export function EditableTabGroup({
                   key={tab.relation.id}
                   tab={tab}
                   active={tab.href === fullPath}
+                  isAnyDragging={isAnyDragging}
                   isEditing={editingTabId === tab.entityId}
                   onStartEditing={() => setEditingTabId(tab.entityId)}
                   onRename={newName => handleRenameTab(tab, newName)}
@@ -265,6 +350,7 @@ function StaticTab({ href, label, active }: { href: string; label: string; activ
 type SortableTabProps = {
   tab: EditableTab;
   active: boolean;
+  isAnyDragging: boolean;
   isEditing: boolean;
   onStartEditing: () => void;
   onRename: (name: string) => void;
@@ -276,6 +362,7 @@ type SortableTabProps = {
 function SortableTab({
   tab,
   active,
+  isAnyDragging,
   isEditing,
   onStartEditing,
   onRename,
@@ -291,6 +378,7 @@ function SortableTab({
     transform: CSS.Translate.toString(transform),
     transition,
     opacity: isDragging ? 0 : 1,
+    willChange: 'transform',
   };
 
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
@@ -336,15 +424,18 @@ function SortableTab({
           {...listeners}
         >
           {displayName || 'Untitled'}
-          {active && (
-            <motion.div
-              layoutId="tab-group-active-border"
-              layout
-              initial={false}
-              transition={{ duration: 0.2 }}
-              className="absolute right-0 bottom-[-8px] left-0 z-100 h-px bg-text"
-            />
-          )}
+          {active &&
+            (isAnyDragging ? (
+              <div className="absolute right-0 bottom-[-8px] left-0 z-100 h-px bg-text" />
+            ) : (
+              <motion.div
+                layoutId="tab-group-active-border"
+                layout
+                initial={false}
+                transition={{ duration: 0.2 }}
+                className="absolute right-0 bottom-[-8px] left-0 z-100 h-px bg-text"
+              />
+            ))}
         </Link>
       )}
 

--- a/apps/web/partials/entity-page/editable-tab-group.tsx
+++ b/apps/web/partials/entity-page/editable-tab-group.tsx
@@ -23,7 +23,6 @@ import { usePathname, useRouter } from 'next/navigation';
 
 import { ID } from '~/core/id';
 import { useTabId } from '~/core/state/editor/use-editor';
-import { useName } from '~/core/state/entity-page-store/entity-store';
 import { useMutate } from '~/core/sync/use-mutate';
 import { getRelations, getValues } from '~/core/sync/use-store';
 import type { Relation } from '~/core/types';
@@ -95,7 +94,8 @@ export function EditableTabGroup({
 
   const sensors = useSensors(
     useSensor(PointerSensor, {
-      activationConstraint: { distance: 4 },
+      // 8px matches table-block-dnd-items.tsx and avoids click-becomes-drag jitter on trackpads.
+      activationConstraint: { distance: 8 },
     })
   );
 
@@ -400,11 +400,11 @@ function SortableTab({
 
   const scheduleClose = () => {
     cancelClose();
-    closeTimeoutRef.current = setTimeout(() => setIsPopoverOpen(false), 120);
+    closeTimeoutRef.current = setTimeout(() => setIsPopoverOpen(false), 200);
   };
 
-  const liveName = useName(tab.entityId, tab.relation.spaceId);
-  const displayName = liveName ?? tab.name;
+  // tab.name already includes the live name via EntityTabs' liveNameMap, so no per-tab subscription needed here.
+  const displayName = tab.name;
 
   return (
     <div ref={setNodeRef} style={style} className="group/tab relative flex items-center">

--- a/apps/web/partials/entity-page/editable-tab-group.tsx
+++ b/apps/web/partials/entity-page/editable-tab-group.tsx
@@ -424,8 +424,16 @@ function SortableTab({
   };
 
   // Clear any pending close timeout if the tab unmounts (e.g., after a route change)
-  // so it doesn't try to setState on an unmounted component.
-  useEffect(() => () => cancelClose(), []);
+  // so it doesn't try to setState on an unmounted component. Inlined rather than calling
+  // cancelClose to keep the effect's dep array honest with react-hooks/exhaustive-deps.
+  useEffect(() => {
+    return () => {
+      if (closeTimeoutRef.current) {
+        clearTimeout(closeTimeoutRef.current);
+        closeTimeoutRef.current = null;
+      }
+    };
+  }, []);
 
   // Suppress the click that fires on pointer-up after a drag, so reordering a tab
   // doesn't navigate. Mirrors the justDragged pattern in table-block-dnd-items.tsx.

--- a/apps/web/partials/entity-page/editable-tab-group.tsx
+++ b/apps/web/partials/entity-page/editable-tab-group.tsx
@@ -19,7 +19,6 @@ import React, { useRef, useState } from 'react';
 
 import { cva } from 'class-variance-authority';
 import cx from 'classnames';
-import { motion } from 'framer-motion';
 import { usePathname, useRouter } from 'next/navigation';
 
 import { ID } from '~/core/id';
@@ -253,7 +252,6 @@ export function EditableTabGroup({
   };
 
   const activeTab = activeId ? editableTabs.find(t => t.relation.id === activeId) : null;
-  const isAnyDragging = activeId !== null;
 
   // Stable array identity for SortableContext so drag doesn't re-register items on every render.
   // Key the memo on a joined string so we only allocate a new array when the id set actually changes.
@@ -268,6 +266,7 @@ export function EditableTabGroup({
       <DndContext
         sensors={sensors}
         collisionDetection={closestCenter}
+        autoScroll={false}
         onDragStart={handleDragStart}
         onDragEnd={handleDragEnd}
       >
@@ -289,7 +288,6 @@ export function EditableTabGroup({
                   key={tab.relation.id}
                   tab={tab}
                   active={tab.href === fullPath}
-                  isAnyDragging={isAnyDragging}
                   isEditing={editingTabId === tab.entityId}
                   onStartEditing={() => setEditingTabId(tab.entityId)}
                   onRename={newName => handleRenameTab(tab, newName)}
@@ -334,15 +332,7 @@ function StaticTab({ href, label, active }: { href: string; label: string; activ
   return (
     <Link className={tabStyles({ active })} href={href} prefetch>
       {label}
-      {active && (
-        <motion.div
-          layoutId="tab-group-active-border"
-          layout
-          initial={false}
-          transition={{ duration: 0.2 }}
-          className="absolute right-0 bottom-[-8px] left-0 z-100 h-px bg-text"
-        />
-      )}
+      {active && <div className="absolute right-0 bottom-[-8px] left-0 z-100 h-px bg-text" />}
     </Link>
   );
 }
@@ -350,7 +340,6 @@ function StaticTab({ href, label, active }: { href: string; label: string; activ
 type SortableTabProps = {
   tab: EditableTab;
   active: boolean;
-  isAnyDragging: boolean;
   isEditing: boolean;
   onStartEditing: () => void;
   onRename: (name: string) => void;
@@ -362,7 +351,6 @@ type SortableTabProps = {
 function SortableTab({
   tab,
   active,
-  isAnyDragging,
   isEditing,
   onStartEditing,
   onRename,
@@ -424,18 +412,7 @@ function SortableTab({
           {...listeners}
         >
           {displayName || 'Untitled'}
-          {active &&
-            (isAnyDragging ? (
-              <div className="absolute right-0 bottom-[-8px] left-0 z-100 h-px bg-text" />
-            ) : (
-              <motion.div
-                layoutId="tab-group-active-border"
-                layout
-                initial={false}
-                transition={{ duration: 0.2 }}
-                className="absolute right-0 bottom-[-8px] left-0 z-100 h-px bg-text"
-              />
-            ))}
+          {active && <div className="absolute right-0 bottom-[-8px] left-0 z-100 h-px bg-text" />}
         </Link>
       )}
 

--- a/apps/web/partials/entity-page/editable-tab-group.tsx
+++ b/apps/web/partials/entity-page/editable-tab-group.tsx
@@ -306,6 +306,7 @@ export function EditableTabGroup({
             ))}
 
             <button
+              type="button"
               onClick={handleAddTab}
               className="relative z-10 flex shrink-0 items-center gap-1 text-grey-04 transition-colors duration-100 hover:text-text"
               title="Add tab"
@@ -473,6 +474,9 @@ function SortableTab({
             <Popover.Trigger asChild>
               <button
                 ref={triggerRef}
+                type="button"
+                aria-label="Tab actions"
+                title="Tab actions"
                 onMouseEnter={openPopover}
                 onMouseLeave={scheduleClose}
                 onMouseDown={e => e.preventDefault()}
@@ -541,6 +545,7 @@ function MenuItem({
 }) {
   return (
     <button
+      type="button"
       onClick={onClick}
       className={cx(
         'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-smallButton transition-colors hover:bg-grey-01',

--- a/apps/web/partials/entity-page/editable-tab-group.tsx
+++ b/apps/web/partials/entity-page/editable-tab-group.tsx
@@ -5,6 +5,7 @@ import {
   DragEndEvent,
   DragOverlay,
   DragStartEvent,
+  MeasuringStrategy,
   PointerSensor,
   closestCenter,
   useSensor,
@@ -92,7 +93,7 @@ export function EditableTabGroup({
 
   const sensors = useSensors(
     useSensor(PointerSensor, {
-      activationConstraint: { distance: 8 },
+      activationConstraint: { distance: 4 },
     })
   );
 
@@ -180,6 +181,7 @@ export function EditableTabGroup({
       <DndContext
         sensors={sensors}
         collisionDetection={closestCenter}
+        measuring={{ droppable: { strategy: MeasuringStrategy.Always } }}
         onDragStart={handleDragStart}
         onDragEnd={handleDragEnd}
       >
@@ -346,7 +348,12 @@ function SortableTab({
 
       {/* Action menu — absolute so it doesn't push neighboring tabs apart */}
       {!isEditing && !isDragging && (
-        <div className="absolute top-1/2 left-full z-20 ml-3 -translate-x-1/2 -translate-y-1/2 opacity-0 transition-opacity duration-150 group-hover/tab:opacity-100">
+        <div
+          className={cx(
+            'absolute top-1/2 left-full z-20 ml-3 -translate-x-1/2 -translate-y-1/2 transition-opacity duration-150',
+            isPopoverOpen ? 'opacity-100' : 'opacity-0 group-hover/tab:opacity-100'
+          )}
+        >
           <Popover.Root open={isPopoverOpen} onOpenChange={setIsPopoverOpen}>
             <Popover.Trigger asChild>
               <button
@@ -439,7 +446,7 @@ type TabNameInputProps = {
 
 function TabNameInput({ initialValue, onSubmit, onCancel }: TabNameInputProps) {
   const [value, setValue] = useState(initialValue);
-  const placeholder = 'Add value...';
+  const placeholder = 'Tab name';
   // The hidden sizer renders the same text the input shows, so the input's width
   // tracks the rendered glyph width rather than ch units (which over-estimate narrow text).
   const sizerText = value.length > 0 ? value : placeholder;
@@ -463,7 +470,7 @@ function TabNameInput({ initialValue, onSubmit, onCancel }: TabNameInputProps) {
           }
         }}
         onFocus={e => e.currentTarget.select()}
-        className="absolute inset-0 bg-transparent text-text outline-none"
+        className="absolute inset-0 bg-transparent text-text outline-none placeholder:text-grey-03"
         placeholder={placeholder}
       />
     </span>

--- a/apps/web/partials/entity-page/editable-tab-group.tsx
+++ b/apps/web/partials/entity-page/editable-tab-group.tsx
@@ -31,7 +31,6 @@ import type { Relation } from '~/core/types';
 import { EditSmall } from '~/design-system/icons/edit-small';
 import { ExpandSmall } from '~/design-system/icons/expand-small';
 import { Menu } from '~/design-system/icons/menu';
-import { OrderDots } from '~/design-system/icons/order-dots';
 import { Trash } from '~/design-system/icons/trash';
 import { PrefetchLink as Link } from '~/design-system/prefetch-link';
 import { NavUtils } from '~/core/utils/utils';
@@ -128,6 +127,10 @@ export function EditableTabGroup({
     // Set name for the new tab entity
     storage.entities.name.set(tabEntityId, spaceId, '');
 
+    // Always append after the last existing tab — callers may have reordered,
+    // so Position.generate() alone would not guarantee end-of-list placement.
+    const lastPosition = editableTabs.length > 0 ? editableTabs[editableTabs.length - 1].relation.position : null;
+
     // Create the TABS_PROPERTY relation
     storage.relations.set({
       id: relationId,
@@ -135,7 +138,7 @@ export function EditableTabGroup({
       spaceId,
       renderableType: 'RELATION',
       verified: false,
-      position: Position.generate(),
+      position: Position.generateBetween(lastPosition ?? null, null),
       type: {
         id: SystemIds.TABS_PROPERTY,
         name: 'Tabs',
@@ -151,7 +154,8 @@ export function EditableTabGroup({
       },
     });
 
-    // Auto-enter rename mode for the new tab
+    // Navigate to the new tab so it becomes the active tab, and enter rename mode.
+    router.replace(`${overviewHref}?tabId=${tabEntityId}`);
     setEditingTabId(tabEntityId);
   };
 
@@ -213,7 +217,7 @@ export function EditableTabGroup({
 
             <button
               onClick={handleAddTab}
-              className="relative z-10 flex shrink-0 items-center gap-1 text-grey-04 transition-colors duration-100 hover:text-text"
+              className="relative z-10 ml-2 flex shrink-0 items-center gap-1 text-grey-04 transition-colors duration-100 hover:text-text"
               title="Add tab"
             >
               <svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -292,19 +296,16 @@ function SortableTab({
 
   return (
     <div ref={setNodeRef} style={style} className="group/tab relative flex items-center">
-      {/* Drag handle — absolute so it doesn't push neighboring tabs apart */}
-      <div
-        className="hover:text-grey-05 absolute top-1/2 right-full z-20 mr-0.5 flex -translate-y-1/2 cursor-grab touch-none items-center rounded p-0.5 text-grey-04 opacity-0 transition-opacity duration-150 group-hover/tab:opacity-100 hover:bg-grey-02 active:cursor-grabbing"
-        {...attributes}
-        {...listeners}
-      >
-        <OrderDots color="currentColor" />
-      </div>
-
       {isEditing ? (
         <TabNameInput initialValue={displayName} onSubmit={onRename} onCancel={onCancelEditing} />
       ) : (
-        <Link className={tabStyles({ active })} href={tab.href} prefetch>
+        <Link
+          className={cx(tabStyles({ active }), 'cursor-grab touch-none select-none active:cursor-grabbing')}
+          href={tab.href}
+          prefetch
+          {...attributes}
+          {...listeners}
+        >
           {displayName || 'Untitled'}
           {active && (
             <motion.div
@@ -353,22 +354,22 @@ function SortableTab({
                 <button
                   onClick={() => {
                     setIsPopoverOpen(false);
-                    onOpen();
-                  }}
-                  className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-smallButton text-text transition-colors hover:bg-grey-01"
-                >
-                  <ExpandSmall />
-                  Open tab entity
-                </button>
-                <button
-                  onClick={() => {
-                    setIsPopoverOpen(false);
                     onDelete();
                   }}
                   className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-smallButton text-red-01 transition-colors hover:bg-grey-01"
                 >
                   <Trash color="red-01" />
                   Delete tab
+                </button>
+                <button
+                  onClick={() => {
+                    setIsPopoverOpen(false);
+                    onOpen();
+                  }}
+                  className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-smallButton text-text transition-colors hover:bg-grey-01"
+                >
+                  <ExpandSmall />
+                  Open tab entity
                 </button>
               </Popover.Content>
             </Popover.Portal>

--- a/apps/web/partials/entity-page/editable-tab-group.tsx
+++ b/apps/web/partials/entity-page/editable-tab-group.tsx
@@ -29,10 +29,12 @@ import { useMutate } from '~/core/sync/use-mutate';
 import type { Relation } from '~/core/types';
 
 import { EditSmall } from '~/design-system/icons/edit-small';
+import { ExpandSmall } from '~/design-system/icons/expand-small';
 import { Menu } from '~/design-system/icons/menu';
 import { OrderDots } from '~/design-system/icons/order-dots';
 import { Trash } from '~/design-system/icons/trash';
 import { PrefetchLink as Link } from '~/design-system/prefetch-link';
+import { NavUtils } from '~/core/utils/utils';
 
 export type SystemTab = {
   label: string;
@@ -200,6 +202,7 @@ export function EditableTabGroup({
                   onRename={newName => handleRenameTab(tab, newName)}
                   onCancelEditing={() => setEditingTabId(null)}
                   onDelete={() => handleDeleteTab(tab)}
+                  onOpen={() => router.push(NavUtils.toEntity(tab.relation.spaceId, tab.entityId))}
                 />
               ))}
             </SortableContext>
@@ -259,6 +262,7 @@ type SortableTabProps = {
   onRename: (name: string) => void;
   onCancelEditing: () => void;
   onDelete: () => void;
+  onOpen: () => void;
 };
 
 function SortableTab({
@@ -269,6 +273,7 @@ function SortableTab({
   onRename,
   onCancelEditing,
   onDelete,
+  onOpen,
 }: SortableTabProps) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: tab.relation.id,
@@ -315,7 +320,7 @@ function SortableTab({
 
       {/* Action menu — absolute so it doesn't push neighboring tabs apart */}
       {!isEditing && !isDragging && (
-        <div className="absolute top-1/2 left-full z-20 ml-0.5 -translate-y-1/2 opacity-0 transition-opacity duration-150 group-hover/tab:opacity-100">
+        <div className="absolute top-1/2 left-full z-20 ml-2 -translate-y-1/2 opacity-0 transition-opacity duration-150 group-hover/tab:opacity-100">
           <Popover.Root open={isPopoverOpen} onOpenChange={setIsPopoverOpen}>
             <Popover.Trigger asChild>
               <button
@@ -344,6 +349,16 @@ function SortableTab({
                 >
                   <EditSmall />
                   Edit name
+                </button>
+                <button
+                  onClick={() => {
+                    setIsPopoverOpen(false);
+                    onOpen();
+                  }}
+                  className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-smallButton text-text transition-colors hover:bg-grey-01"
+                >
+                  <ExpandSmall />
+                  Open tab entity
                 </button>
                 <button
                   onClick={() => {
@@ -388,9 +403,9 @@ function TabNameInput({ initialValue, onSubmit, onCancel }: TabNameInputProps) {
         }
       }}
       onFocus={e => e.currentTarget.select()}
-      className="relative z-10 min-w-[40px] border-b border-text bg-transparent text-quoteMedium text-text outline-none"
-      placeholder="Tab name..."
-      style={{ width: `${Math.max(value.length, 6)}ch` }}
+      className="relative z-10 bg-transparent text-quoteMedium text-text outline-none"
+      placeholder="Tab name"
+      style={{ width: `${Math.max(value.length, 'Tab name'.length)}ch` }}
     />
   );
 }

--- a/apps/web/partials/entity-page/editable-tab-group.tsx
+++ b/apps/web/partials/entity-page/editable-tab-group.tsx
@@ -15,7 +15,7 @@ import { CSS } from '@dnd-kit/utilities';
 import { Position, SystemIds } from '@geoprotocol/geo-sdk/lite';
 import * as Popover from '@radix-ui/react-popover';
 
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 
 import { cva } from 'class-variance-authority';
 import cx from 'classnames';
@@ -290,6 +290,31 @@ function SortableTab({
   };
 
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+  const [align, setAlign] = useState<'start' | 'end'>('start');
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const closeTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const cancelClose = () => {
+    if (closeTimeoutRef.current) {
+      clearTimeout(closeTimeoutRef.current);
+      closeTimeoutRef.current = null;
+    }
+  };
+
+  const openPopover = () => {
+    cancelClose();
+    const rect = triggerRef.current?.getBoundingClientRect();
+    if (rect) {
+      const triggerCenter = rect.left + rect.width / 2;
+      setAlign(triggerCenter < window.innerWidth / 2 ? 'start' : 'end');
+    }
+    setIsPopoverOpen(true);
+  };
+
+  const scheduleClose = () => {
+    cancelClose();
+    closeTimeoutRef.current = setTimeout(() => setIsPopoverOpen(false), 120);
+  };
 
   const liveName = useName(tab.entityId, tab.relation.spaceId);
   const displayName = liveName ?? tab.name;
@@ -325,6 +350,9 @@ function SortableTab({
           <Popover.Root open={isPopoverOpen} onOpenChange={setIsPopoverOpen}>
             <Popover.Trigger asChild>
               <button
+                ref={triggerRef}
+                onMouseEnter={openPopover}
+                onMouseLeave={scheduleClose}
                 onMouseDown={e => e.preventDefault()}
                 className="text-grey-03 transition duration-200 hover:text-text"
               >
@@ -334,49 +362,72 @@ function SortableTab({
             <Popover.Portal>
               <Popover.Content
                 side="bottom"
+                align={align}
                 sideOffset={8}
+                onMouseEnter={cancelClose}
+                onMouseLeave={scheduleClose}
                 className="z-100 min-w-[140px] rounded-lg border border-grey-02 bg-white p-1 shadow-lg"
                 onOpenAutoFocus={e => {
                   e.preventDefault();
                   e.stopPropagation();
                 }}
               >
-                <button
+                <MenuItem
                   onClick={() => {
                     setIsPopoverOpen(false);
                     onStartEditing();
                   }}
-                  className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-smallButton text-text transition-colors hover:bg-grey-01"
-                >
-                  <EditSmall />
-                  Edit name
-                </button>
-                <button
+                  icon={<EditSmall />}
+                  label="Edit name"
+                />
+                <MenuItem
                   onClick={() => {
                     setIsPopoverOpen(false);
                     onDelete();
                   }}
-                  className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-smallButton text-red-01 transition-colors hover:bg-grey-01"
-                >
-                  <Trash color="red-01" />
-                  Delete tab
-                </button>
-                <button
+                  icon={<Trash color="red-01" />}
+                  label="Delete tab"
+                  tone="danger"
+                />
+                <MenuItem
                   onClick={() => {
                     setIsPopoverOpen(false);
                     onOpen();
                   }}
-                  className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-smallButton text-text transition-colors hover:bg-grey-01"
-                >
-                  <ExpandSmall />
-                  Open tab entity
-                </button>
+                  icon={<ExpandSmall />}
+                  label="Open tab"
+                />
               </Popover.Content>
             </Popover.Portal>
           </Popover.Root>
         </div>
       )}
     </div>
+  );
+}
+
+function MenuItem({
+  onClick,
+  icon,
+  label,
+  tone = 'default',
+}: {
+  onClick: () => void;
+  icon: React.ReactNode;
+  label: string;
+  tone?: 'default' | 'danger';
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className={cx(
+        'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-smallButton transition-colors hover:bg-grey-01',
+        tone === 'danger' ? 'text-red-01' : 'text-text'
+      )}
+    >
+      <span className="flex w-4 shrink-0 items-center justify-center">{icon}</span>
+      <span className="flex-1">{label}</span>
+    </button>
   );
 }
 
@@ -388,25 +439,33 @@ type TabNameInputProps = {
 
 function TabNameInput({ initialValue, onSubmit, onCancel }: TabNameInputProps) {
   const [value, setValue] = useState(initialValue);
+  const placeholder = 'Add value...';
+  // The hidden sizer renders the same text the input shows, so the input's width
+  // tracks the rendered glyph width rather than ch units (which over-estimate narrow text).
+  const sizerText = value.length > 0 ? value : placeholder;
 
   return (
-    <input
-      autoFocus
-      value={value}
-      onChange={e => setValue(e.target.value)}
-      onBlur={() => onSubmit(value.trim())}
-      onKeyDown={e => {
-        if (e.key === 'Enter') {
-          e.preventDefault();
-          onSubmit(value.trim());
-        } else if (e.key === 'Escape') {
-          onCancel();
-        }
-      }}
-      onFocus={e => e.currentTarget.select()}
-      className="relative z-10 bg-transparent text-quoteMedium text-text outline-none"
-      placeholder="Tab name"
-      style={{ width: `${Math.max(value.length, 'Tab name'.length)}ch` }}
-    />
+    <span className="relative z-10 inline-block text-quoteMedium">
+      <span aria-hidden="true" className="invisible whitespace-pre">
+        {sizerText}
+      </span>
+      <input
+        autoFocus
+        value={value}
+        onChange={e => setValue(e.target.value)}
+        onBlur={() => onSubmit(value.trim())}
+        onKeyDown={e => {
+          if (e.key === 'Enter') {
+            e.preventDefault();
+            onSubmit(value.trim());
+          } else if (e.key === 'Escape') {
+            onCancel();
+          }
+        }}
+        onFocus={e => e.currentTarget.select()}
+        className="absolute inset-0 bg-transparent text-text outline-none"
+        placeholder={placeholder}
+      />
+    </span>
   );
 }

--- a/apps/web/partials/entity-page/editable-tab-group.tsx
+++ b/apps/web/partials/entity-page/editable-tab-group.tsx
@@ -271,6 +271,7 @@ export function EditableTabGroup({
         autoScroll={false}
         onDragStart={handleDragStart}
         onDragEnd={handleDragEnd}
+        onDragCancel={() => setActiveId(null)}
       >
         <div
           className={cx(

--- a/apps/web/partials/entity-page/editable-tab-group.tsx
+++ b/apps/web/partials/entity-page/editable-tab-group.tsx
@@ -5,7 +5,6 @@ import {
   DragEndEvent,
   DragOverlay,
   DragStartEvent,
-  MeasuringStrategy,
   PointerSensor,
   closestCenter,
   useSensor,
@@ -156,7 +155,8 @@ export function EditableTabGroup({
     });
 
     // Navigate to the new tab so it becomes the active tab, and enter rename mode.
-    router.replace(`${overviewHref}?tabId=${tabEntityId}`);
+    // `scroll: false` keeps the user's current scroll position.
+    router.replace(`${overviewHref}?tabId=${tabEntityId}`, { scroll: false });
     setEditingTabId(tabEntityId);
   };
 
@@ -176,12 +176,14 @@ export function EditableTabGroup({
 
   const activeTab = activeId ? editableTabs.find(t => t.relation.id === activeId) : null;
 
+  // Stable array identity for SortableContext so drag doesn't re-register items on every render.
+  const sortableIds = React.useMemo(() => editableTabs.map(t => t.relation.id), [editableTabs]);
+
   return (
     <div className="relative">
       <DndContext
         sensors={sensors}
         collisionDetection={closestCenter}
-        measuring={{ droppable: { strategy: MeasuringStrategy.Always } }}
         onDragStart={handleDragStart}
         onDragEnd={handleDragEnd}
       >
@@ -197,7 +199,7 @@ export function EditableTabGroup({
               <StaticTab key={tab.href} href={tab.href} label={tab.label} active={tab.href === fullPath} />
             ))}
 
-            <SortableContext items={editableTabs.map(t => t.relation.id)} strategy={horizontalListSortingStrategy}>
+            <SortableContext items={sortableIds} strategy={horizontalListSortingStrategy}>
               {editableTabs.map(tab => (
                 <SortableTab
                   key={tab.relation.id}

--- a/apps/web/partials/entity-page/editable-tab-group.tsx
+++ b/apps/web/partials/entity-page/editable-tab-group.tsx
@@ -15,7 +15,7 @@ import { CSS } from '@dnd-kit/utilities';
 import { Position, SystemIds } from '@geoprotocol/geo-sdk/lite';
 import * as Popover from '@radix-ui/react-popover';
 
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 import { cva } from 'class-variance-authority';
 import cx from 'classnames';
@@ -26,16 +26,13 @@ import { useTabId } from '~/core/state/editor/use-editor';
 import { useMutate } from '~/core/sync/use-mutate';
 import { getRelations, getValues } from '~/core/sync/use-store';
 import type { Relation } from '~/core/types';
-
-// Page entity type — new tabs are created as entities of this type.
-const PAGE_TYPE_ID = '480e3fc267f3499385fbacdf4ddeaa6b';
+import { NavUtils } from '~/core/utils/utils';
 
 import { EditSmall } from '~/design-system/icons/edit-small';
 import { ExpandSmall } from '~/design-system/icons/expand-small';
 import { Menu } from '~/design-system/icons/menu';
 import { Trash } from '~/design-system/icons/trash';
 import { PrefetchLink as Link } from '~/design-system/prefetch-link';
-import { NavUtils } from '~/core/utils/utils';
 
 export type SystemTab = {
   label: string;
@@ -176,9 +173,9 @@ export function EditableTabGroup({
         name: null,
       },
       toEntity: {
-        id: PAGE_TYPE_ID,
+        id: SystemIds.PAGE_TYPE,
         name: 'Page',
-        value: PAGE_TYPE_ID,
+        value: SystemIds.PAGE_TYPE,
       },
     });
 
@@ -403,6 +400,29 @@ function SortableTab({
     closeTimeoutRef.current = setTimeout(() => setIsPopoverOpen(false), 200);
   };
 
+  // Clear any pending close timeout if the tab unmounts (e.g., after a route change)
+  // so it doesn't try to setState on an unmounted component.
+  useEffect(() => () => cancelClose(), []);
+
+  // Suppress the click that fires on pointer-up after a drag, so reordering a tab
+  // doesn't navigate. Mirrors the justDragged pattern in table-block-dnd-items.tsx.
+  const [justDragged, setJustDragged] = useState(false);
+  useEffect(() => {
+    if (isDragging) {
+      setJustDragged(true);
+    } else if (justDragged) {
+      const t = setTimeout(() => setJustDragged(false), 200);
+      return () => clearTimeout(t);
+    }
+  }, [isDragging, justDragged]);
+
+  const handleLinkClick = (e: React.MouseEvent) => {
+    if (justDragged) {
+      e.preventDefault();
+      e.stopPropagation();
+    }
+  };
+
   // tab.name already includes the live name via EntityTabs' liveNameMap, so no per-tab subscription needed here.
   const displayName = tab.name;
 
@@ -415,6 +435,7 @@ function SortableTab({
           className={cx(tabStyles({ active }), 'cursor-grab touch-none select-none active:cursor-grabbing')}
           href={tab.href}
           prefetch
+          onClick={handleLinkClick}
           {...attributes}
           {...listeners}
         >

--- a/apps/web/partials/entity-page/editable-tab-group.tsx
+++ b/apps/web/partials/entity-page/editable-tab-group.tsx
@@ -252,6 +252,7 @@ export function EditableTabGroup({
   };
 
   const activeTab = activeId ? editableTabs.find(t => t.relation.id === activeId) : null;
+  const isAnyDragging = activeId !== null;
 
   // Stable array identity for SortableContext so drag doesn't re-register items on every render.
   // Key the memo on a joined string so we only allocate a new array when the id set actually changes.
@@ -288,6 +289,7 @@ export function EditableTabGroup({
                   key={tab.relation.id}
                   tab={tab}
                   active={tab.href === fullPath}
+                  isAnyDragging={isAnyDragging}
                   isEditing={editingTabId === tab.entityId}
                   onStartEditing={() => setEditingTabId(tab.entityId)}
                   onRename={newName => handleRenameTab(tab, newName)}
@@ -340,6 +342,7 @@ function StaticTab({ href, label, active }: { href: string; label: string; activ
 type SortableTabProps = {
   tab: EditableTab;
   active: boolean;
+  isAnyDragging: boolean;
   isEditing: boolean;
   onStartEditing: () => void;
   onRename: (name: string) => void;
@@ -351,6 +354,7 @@ type SortableTabProps = {
 function SortableTab({
   tab,
   active,
+  isAnyDragging,
   isEditing,
   onStartEditing,
   onRename,
@@ -416,8 +420,9 @@ function SortableTab({
         </Link>
       )}
 
-      {/* Action menu — absolute so it doesn't push neighboring tabs apart */}
-      {!isEditing && !isDragging && (
+      {/* Action menu — absolute so it doesn't push neighboring tabs apart.
+          Skip rendering entirely during any drag so the Popover tree doesn't re-reconcile on every drag tick. */}
+      {!isEditing && !isDragging && !isAnyDragging && (
         <div
           className={cx(
             'absolute top-1/2 left-full z-20 ml-3 -translate-x-1/2 -translate-y-1/2 transition-opacity duration-150',

--- a/apps/web/partials/entity-page/editable-tab-group.tsx
+++ b/apps/web/partials/entity-page/editable-tab-group.tsx
@@ -277,7 +277,7 @@ export function EditableTabGroup({
             className
           )}
         >
-          <div className="relative flex w-max items-center gap-6 pb-2">
+          <div className="relative z-10 flex w-max items-center gap-6 pb-2">
             {systemTabsBefore.map(tab => (
               <StaticTab key={tab.href} href={tab.href} label={tab.label} active={tab.href === fullPath} />
             ))}

--- a/apps/web/partials/entity-page/editable-tab-group.tsx
+++ b/apps/web/partials/entity-page/editable-tab-group.tsx
@@ -217,7 +217,7 @@ export function EditableTabGroup({
 
             <button
               onClick={handleAddTab}
-              className="relative z-10 ml-2 flex shrink-0 items-center gap-1 text-grey-04 transition-colors duration-100 hover:text-text"
+              className="relative z-10 flex shrink-0 items-center gap-1 text-grey-04 transition-colors duration-100 hover:text-text"
               title="Add tab"
             >
               <svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -321,7 +321,7 @@ function SortableTab({
 
       {/* Action menu — absolute so it doesn't push neighboring tabs apart */}
       {!isEditing && !isDragging && (
-        <div className="absolute top-1/2 left-full z-20 ml-2 -translate-y-1/2 opacity-0 transition-opacity duration-150 group-hover/tab:opacity-100">
+        <div className="absolute top-1/2 left-full z-20 ml-3 -translate-x-1/2 -translate-y-1/2 opacity-0 transition-opacity duration-150 group-hover/tab:opacity-100">
           <Popover.Root open={isPopoverOpen} onOpenChange={setIsPopoverOpen}>
             <Popover.Trigger asChild>
               <button

--- a/apps/web/partials/entity-page/editable-tab-group.tsx
+++ b/apps/web/partials/entity-page/editable-tab-group.tsx
@@ -364,6 +364,9 @@ function SortableTab({
 }: SortableTabProps) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: tab.relation.id,
+    // Snappier easing than dnd-kit's default 250ms cubic — neighbors settle into their new slot
+    // much closer to the pointer so the reorder feels tighter.
+    transition: { duration: 150, easing: 'cubic-bezier(0.2, 0, 0, 1)' },
   });
 
   const style = {

--- a/apps/web/partials/entity-page/readable-entity-page.tsx
+++ b/apps/web/partials/entity-page/readable-entity-page.tsx
@@ -39,6 +39,7 @@ const SKIPPED_PROPERTIES: string[] = [
   SystemIds.TYPES_PROPERTY,
   SystemIds.NAME_PROPERTY,
   SystemIds.COVER_PROPERTY,
+  SystemIds.TABS_PROPERTY,
   ContentIds.AVATAR_PROPERTY,
   DATA_TYPE_PROPERTY,
   RENDERABLE_TYPE_PROPERTY,
@@ -183,6 +184,7 @@ export function RelationsGroup({
     propertyId === SystemIds.COVER_PROPERTY ||
     propertyId === ContentIds.AVATAR_PROPERTY ||
     (propertyId === SystemIds.TYPES_PROPERTY && !isMetadataHeader) ||
+    propertyId === SystemIds.TABS_PROPERTY ||
     propertyId === DATA_TYPE_PROPERTY ||
     propertyId === RENDERABLE_TYPE_PROPERTY
   ) {


### PR DESCRIPTION
## Summary
Polishes the inline tab editing UI from #1674 and tightens up tab create/delete semantics.

### UI / UX
- **Hide `Tabs` from the properties container** in browse mode — tabs render inline above the content, so the relation list is redundant (mirrors the existing exclusions for `Cover`, `Avatar`, and `Types`).
- **Inline rename input** — removed the `border-b` underline; widened the field via a hidden text-sizer so the `Tab name` placeholder isn't clipped; added `placeholder:text-grey-03` to match the rest of the property fields.
- **Drag the whole tab label** to reorder, not just a separate handle. Activation distance stays at 8px (matches `table-block-dnd-items.tsx`); `justDragged` click-suppression prevents a pointer-up click from navigating after a drag.
- **`…` action menu** centered in the gap (`ml-3 + -translate-x-1/2`) so it doesn't overlap the next tab or the `+` button. Opens on hover with a 200ms close grace and auto-aligns `start`/`end` based on viewport half. Stays visible while open. Hidden entirely while any tab is being dragged.
- **Menu items** (in order): `Edit name`, `Delete tab`, `Open tab` (with `ExpandSmall` icon). Each row uses a fixed-width icon column so labels left-align cleanly.
- **Active underline** sits in its own stacking layer (`z-10` on the tab row) so it paints on top of the grey divider.
- **Browse-mode tab bar** is hidden when an entity has no tab relations (already in place at `entity-tabs.tsx`).

### Behavior
- **New tabs append to the end** via `Position.generateBetween(lastPosition, null)` (was `Position.generate()`, which wouldn't keep new tabs at the end after reordering).
- **New tabs auto-activate** — `router.replace(?tabId=…, { scroll: false })` so creating a tab opens it without jumping the scroll position.
- **New tabs are typed as `Page`** via a `TYPES_PROPERTY` relation to `SystemIds.PAGE_TYPE`, so the resulting entity renders with the correct schema.
- **Deleting a tab cascades** — removes the tab entity's values, all relations touching it (incoming and outgoing), and any tab-owned blocks that become orphaned. Mirrors the pattern in [`entity-page-context-menu.tsx`](apps/web/partials/entity-page/entity-page-context-menu.tsx). One batched `deleteMany` so the UI only flashes once.

### Drag perf
- `autoScroll: false` on `DndContext` (the row is short, no auto-scroll needed; removes per-frame scroll-detection cost).
- `useSortable` transition shortened to `150ms cubic-bezier(0.2, 0, 0, 1)` from dnd-kit's default ~250ms cubic.
- `Popover.Root` subtree is skipped while any tab is dragging (the heaviest part of the per-tab reconciliation).
- `willChange: 'transform'` hint on the sortable item.
- Stable `SortableContext` `items` identity via a joined-id `useMemo` key.
- Dropped the duplicate per-tab `useName` subscription — `EntityTabs` already merges live names into `tab.name`.

## Test plan
- [ ] In edit mode: add a tab — `Tab name` placeholder visible, no underline, scroll position preserved, new tab is active and entered rename mode.
- [ ] Reorder tabs by dragging the tab label. Drop should land in the new slot; click on the just-dragged tab should not navigate.
- [ ] Hover a tab: `…` button sits centered between the tab and its right neighbor; in the right half of the viewport the dropdown aligns to `end`, in the left half to `start`.
- [ ] Open the menu via hover; verify it stays open while moving the cursor across the gap into it.
- [ ] `Edit name`, `Delete tab`, `Open tab` are all functional. `Open tab` navigates to the tab entity page.
- [ ] Delete a tab that has block content — the tab entity, its values, its relations (both directions), and orphaned blocks are all removed in one batch.
- [ ] Browse mode: confirm `Tabs` is no longer listed in the properties container; confirm the tab bar is hidden when an entity has no tab relations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)