### PR TITLE
fix(onboarding): clearer button copy on "Is this you?" step

### DIFF
--- a/apps/web/partials/onboarding/dialog.tsx
+++ b/apps/web/partials/onboarding/dialog.tsx
@@ -522,7 +522,7 @@ function StepExistingEntityMatch({ candidates, onSkip, onSelect }: StepExistingE
       </div>
       <div className="shrink-0 pt-4">
         <Button type="button" onClick={handlePrimary} className="w-full">
-          {selectedResult ? 'Continue' : 'None of these are me'}
+          {selectedResult ? 'Use existing profile' : 'Create a profile'}
         </Button>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- "None of these are me" → **"Create a profile"** so the button describes what it does instead of opting out.
- When a candidate is selected, the button now reads **"Use existing profile"** instead of generic "Continue", so the user knows the click will claim that entity.

## Test plan
- [ ] Open onboarding, type a name with existing matches, hit Continue
- [ ] No selection: button reads "Create a profile" — clicking still creates a fresh space
- [ ] Click a candidate: button switches to "Use existing profile" — clicking creates the personal space against that entity's `topicId`
- [ ] Deselect: button reverts to "Create a profile"

🤖 Generated with [Claude Code](https://claude.com/claude-code)