### PR TITLE
feat(governance): instant vote reorder, snappier dropdowns, cleaner focus outline

### DIFF
--- a/apps/web/app/home/accept-or-reject-editor.tsx
+++ b/apps/web/app/home/accept-or-reject-editor.tsx
@@ -104,10 +104,10 @@ export function AcceptOrRejectEditor({
     return (
       <div className="relative">
         <div className="flex items-center gap-2">
-          <SmallButton variant="secondary" onClick={onReject} disabled={voteStatus !== 'idle'}>
+          <SmallButton variant="secondary" onClick={onReject} disabled={voteStatus === 'pending'}>
             <Pending isPending={isPendingRejection}>Reject</Pending>
           </SmallButton>
-          <SmallButton variant="secondary" onClick={onApprove} disabled={voteStatus !== 'idle'}>
+          <SmallButton variant="secondary" onClick={onApprove} disabled={voteStatus === 'pending'}>
             <Pending isPending={isPendingApproval}>Approve</Pending>
           </SmallButton>
         </div>

--- a/apps/web/app/home/accept-or-reject-editor.tsx
+++ b/apps/web/app/home/accept-or-reject-editor.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { useRouter } from 'next/navigation';
 
 import { useSmartAccount } from '~/core/hooks/use-smart-account';
 import { useVote } from '~/core/hooks/use-vote';
@@ -11,6 +12,7 @@ import { SmallButton } from '~/design-system/button';
 import { Pending } from '~/design-system/pending';
 
 import { Execute } from '~/partials/active-proposal/execute';
+import { useAddOptimisticVote, useRemoveOptimisticVote } from '~/partials/governance/optimistic-voted-atom';
 
 interface Props {
   spaceId: string;
@@ -30,6 +32,8 @@ export function AcceptOrRejectEditor({
   userVote,
   proposalId,
 }: Props) {
+  const router = useRouter();
+
   const { vote, status: voteStatus } = useVote({
     spaceId,
     proposalId,
@@ -43,15 +47,27 @@ export function AcceptOrRejectEditor({
   const isPendingRejection = hasRejected && voteStatus === 'pending';
 
   const { smartAccount } = useSmartAccount();
+  const addOptimisticVote = useAddOptimisticVote();
+  const removeOptimisticVote = useRemoveOptimisticVote();
+
+  const onVoteSuccess = () => {
+    router.refresh();
+  };
+
+  const onVoteError = () => {
+    removeOptimisticVote(proposalId);
+  };
 
   const onApprove = () => {
     setHasApproved(true);
-    vote('ACCEPT');
+    addOptimisticVote(proposalId);
+    vote('ACCEPT', { onSuccess: onVoteSuccess, onError: onVoteError });
   };
 
   const onReject = () => {
     setHasRejected(true);
-    vote('REJECT');
+    addOptimisticVote(proposalId);
+    vote('REJECT', { onSuccess: onVoteSuccess, onError: onVoteError });
   };
 
   // Terminal / post-vote states on the proposal must win over "You accepted" so we match space

--- a/apps/web/app/home/accept-or-reject-editor.tsx
+++ b/apps/web/app/home/accept-or-reject-editor.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 
 import { useSmartAccount } from '~/core/hooks/use-smart-account';
@@ -49,6 +49,15 @@ export function AcceptOrRejectEditor({
   const { smartAccount } = useSmartAccount();
   const addOptimisticVote = useAddOptimisticVote();
   const removeOptimisticVote = useRemoveOptimisticVote();
+
+  // Drop the optimistic entry once router.refresh has caught up and userVote
+  // is reflected on the prop — server render now naturally places the card
+  // at the bottom of its bucket without our artificial order bump.
+  useEffect(() => {
+    if (userVote) {
+      removeOptimisticVote(proposalId);
+    }
+  }, [userVote, proposalId, removeOptimisticVote]);
 
   const onVoteSuccess = () => {
     router.refresh();

--- a/apps/web/app/home/accept-or-reject-member.tsx
+++ b/apps/web/app/home/accept-or-reject-member.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, type ReactNode } from 'react';
+import { useRouter } from 'next/navigation';
 
 import cx from 'classnames';
 
@@ -23,6 +24,7 @@ import { Pending } from '~/design-system/pending';
 import { PrefetchLink as Link } from '~/design-system/prefetch-link';
 
 import { Execute } from '~/partials/active-proposal/execute';
+import { useAddOptimisticVote, useRemoveOptimisticVote } from '~/partials/governance/optimistic-voted-atom';
 
 interface Props {
   spaceId: string;
@@ -65,6 +67,8 @@ export function AcceptOrRejectMember({
 }: Props) {
   const [selectedVote, setSelectedVote] = useState<'ACCEPT' | 'REJECT' | null>(null);
 
+  const router = useRouter();
+
   const { vote, status: voteStatus } = useVote({
     spaceId,
     proposalId,
@@ -76,15 +80,27 @@ export function AcceptOrRejectMember({
   const isPendingRejection = selectedVote === 'REJECT' && voteStatus === 'pending';
 
   const { smartAccount } = useSmartAccount();
+  const addOptimisticVote = useAddOptimisticVote();
+  const removeOptimisticVote = useRemoveOptimisticVote();
+
+  const onVoteSuccess = () => {
+    router.refresh();
+  };
+
+  const onVoteError = () => {
+    removeOptimisticVote(proposalId);
+  };
 
   const onApprove = () => {
     setSelectedVote('ACCEPT');
-    vote('ACCEPT');
+    addOptimisticVote(proposalId);
+    vote('ACCEPT', { onSuccess: onVoteSuccess, onError: onVoteError });
   };
 
   const onReject = () => {
     setSelectedVote('REJECT');
-    vote('REJECT');
+    addOptimisticVote(proposalId);
+    vote('REJECT', { onSuccess: onVoteSuccess, onError: onVoteError });
   };
 
   const { hours, minutes } = getProposalTimeRemaining(endTime);

--- a/apps/web/app/home/accept-or-reject-member.tsx
+++ b/apps/web/app/home/accept-or-reject-member.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, type ReactNode } from 'react';
+import { useEffect, useState, type ReactNode } from 'react';
 import { useRouter } from 'next/navigation';
 
 import cx from 'classnames';
@@ -82,6 +82,15 @@ export function AcceptOrRejectMember({
   const { smartAccount } = useSmartAccount();
   const addOptimisticVote = useAddOptimisticVote();
   const removeOptimisticVote = useRemoveOptimisticVote();
+
+  // Drop the optimistic entry once router.refresh has caught up and userVote
+  // is reflected on the prop — server render now naturally places the card
+  // at the bottom of its bucket without our artificial order bump.
+  useEffect(() => {
+    if (userVote) {
+      removeOptimisticVote(proposalId);
+    }
+  }, [userVote, proposalId, removeOptimisticVote]);
 
   const onVoteSuccess = () => {
     router.refresh();

--- a/apps/web/app/home/accept-or-reject-member.tsx
+++ b/apps/web/app/home/accept-or-reject-member.tsx
@@ -91,17 +91,14 @@ export function AcceptOrRejectMember({
     removeOptimisticVote(proposalId);
   };
 
-  const onApprove = () => {
-    setSelectedVote('ACCEPT');
+  const castVote = (choice: 'ACCEPT' | 'REJECT') => {
+    setSelectedVote(choice);
     addOptimisticVote(proposalId);
-    vote('ACCEPT', { onSuccess: onVoteSuccess, onError: onVoteError });
+    vote(choice, { onSuccess: onVoteSuccess, onError: onVoteError });
   };
 
-  const onReject = () => {
-    setSelectedVote('REJECT');
-    addOptimisticVote(proposalId);
-    vote('REJECT', { onSuccess: onVoteSuccess, onError: onVoteError });
-  };
+  const onApprove = () => castVote('ACCEPT');
+  const onReject = () => castVote('REJECT');
 
   const { hours, minutes } = getProposalTimeRemaining(endTime);
 
@@ -162,7 +159,7 @@ export function AcceptOrRejectMember({
         <SmallButton
           variant="secondary"
           onClick={() => {
-            if (selectedVote) vote(selectedVote);
+            if (selectedVote) castVote(selectedVote);
           }}
         >
           Retry

--- a/apps/web/app/home/component.tsx
+++ b/apps/web/app/home/component.tsx
@@ -2,12 +2,11 @@ import * as React from 'react';
 
 import { SidebarCounts } from '~/core/io/fetch-sidebar-counts';
 
-import { Skeleton } from '~/design-system/skeleton';
-
 import {
   type GovernanceHomeReviewCategory,
   type GovernanceHomeStatusFilter,
 } from './fetch-active-proposals-in-editor-spaces';
+import { LoadingSkeleton } from './loading-skeleton';
 import { HomeProposalsInfiniteScroll } from './home-proposals-infinite-scroll';
 import { MyGovernanceProposalsList } from './my-governance-proposals-list';
 import { PendingProposalsPage } from './pending-proposals-page';
@@ -99,18 +98,6 @@ export async function Component({
         />
       </div>
     </>
-  );
-}
-
-export function LoadingSkeleton() {
-  return (
-    <div className="space-y-4 rounded-lg border border-grey-02 p-4">
-      <div className="space-y-2">
-        <Skeleton className="h-5 w-36" />
-        <Skeleton className="h-4 w-20" />
-      </div>
-      <Skeleton className="h-5 w-48" />
-    </div>
   );
 }
 

--- a/apps/web/app/home/component.tsx
+++ b/apps/web/app/home/component.tsx
@@ -44,8 +44,6 @@ export async function Component({
   myProposalSpaceOptions,
   myProposalSpaceIds,
 }: Props) {
-  const listKey = `${governanceTab}-${governanceFilters.spaceId}-${governanceFilters.category}-${governanceFilters.status}-${proposalType}-${connectedAddress}`;
-
   return (
     <>
       <div className="mx-auto w-full max-w-[880px]">
@@ -60,7 +58,6 @@ export async function Component({
               <p className="text-body text-grey-04">Sign in to see your proposals.</p>
             ) : governanceTab === 'my' && connectedSpaceId ? (
               <React.Suspense
-                key={listKey}
                 fallback={
                   <div className="space-y-2">
                     <LoadingSkeleton />
@@ -81,7 +78,6 @@ export async function Component({
               </React.Suspense>
             ) : (
               <React.Suspense
-                key={listKey}
                 fallback={
                   <div className="space-y-2">
                     <LoadingSkeleton />

--- a/apps/web/app/home/home-proposals-infinite-scroll.tsx
+++ b/apps/web/app/home/home-proposals-infinite-scroll.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 
 import { SmallButton } from '~/design-system/button';
 
+import { LoadingSkeleton } from './component';
 import {
   type GovernanceHomeReviewCategory,
   type GovernanceHomeStatusFilter,
@@ -31,7 +32,7 @@ export function HomeProposalsInfiniteScroll({
   initialHasMore = true,
   governanceFilters,
 }: Props) {
-  const buttonRef = React.useRef<HTMLButtonElement>(null);
+  const sentinelRef = React.useRef<HTMLDivElement>(null);
   const [loadMoreNodes, setLoadMoreNodes] = React.useState<React.ReactNode[]>([]);
   const [isLoading, setIsLoading] = React.useState(false);
   const [hasMore, setHasMore] = React.useState(initialHasMore);
@@ -72,7 +73,7 @@ export function HomeProposalsInfiniteScroll({
 
   React.useEffect(() => {
     const signal = new AbortController();
-    const element = buttonRef.current;
+    const element = sentinelRef.current;
 
     const observer = new IntersectionObserver(([entry]) => {
       if (entry.isIntersecting && !isLoadingRef.current && hasMoreRef.current) {
@@ -93,13 +94,21 @@ export function HomeProposalsInfiniteScroll({
   }, [loadMore]);
 
   return (
-    <div>
-      {loadMoreNodes}
+    <div className="space-y-2">
+      {loadMoreNodes.map((node, i) => (
+        <React.Fragment key={i}>{node}</React.Fragment>
+      ))}
 
       {hasMore && (
-        <SmallButton variant="secondary" ref={buttonRef} onClick={() => loadMore()} disabled={isLoading}>
-          {isLoading ? 'Loading...' : 'Load more'}
-        </SmallButton>
+        <div ref={sentinelRef}>
+          {isLoading ? (
+            <LoadingSkeleton />
+          ) : (
+            <SmallButton variant="secondary" onClick={() => loadMore()}>
+              Load more
+            </SmallButton>
+          )}
+        </div>
       )}
     </div>
   );

--- a/apps/web/app/home/home-proposals-infinite-scroll.tsx
+++ b/apps/web/app/home/home-proposals-infinite-scroll.tsx
@@ -48,12 +48,34 @@ export function HomeProposalsInfiniteScroll({
       isLoadingRef.current = true;
       setIsLoading(true);
 
-      // Calling a Next.js server action triggers a server-component re-render
-      // for the current route. Even though our action only reads, the re-render
-      // can re-reconcile the proposal cards above the sentinel and break the
-      // browser's scroll anchor, snapping the viewport up. Capture the scroll
-      // position and restore it once React commits the appended page.
+      // Calling a Next.js server action triggers an RSC refetch for the current
+      // route, which reconciles the proposal cards above the sentinel and breaks
+      // the browser's scroll anchor — snapping the viewport up to the top of
+      // the list. Capture the scroll position and pin it across the load:
+      // a single rAF isn't enough because the RSC payload commits asynchronously
+      // and images on the new cards can settle 100s of ms later.
       const scrollY = typeof window !== 'undefined' ? window.scrollY : 0;
+      const pinScroll = () => {
+        if (typeof window === 'undefined') return () => {};
+        let stopped = false;
+        const restore = () => {
+          if (stopped) return;
+          if (Math.abs(window.scrollY - scrollY) > 1) {
+            window.scrollTo(0, scrollY);
+          }
+        };
+        const interval = setInterval(restore, 16);
+        const timeout = setTimeout(() => {
+          stopped = true;
+          clearInterval(interval);
+        }, 800);
+        return () => {
+          stopped = true;
+          clearInterval(interval);
+          clearTimeout(timeout);
+        };
+      };
+      const stopPinning = pinScroll();
 
       try {
         const [node, next, more] = await loadMoreHomeProposalsAction(
@@ -63,7 +85,10 @@ export function HomeProposalsInfiniteScroll({
           currentPageRef.current,
           governanceFilters
         );
-        if (abortController?.signal.aborted) return;
+        if (abortController?.signal.aborted) {
+          stopPinning();
+          return;
+        }
         setLoadMoreNodes(prev => [...prev, node]);
         currentPageRef.current = next;
         hasMoreRef.current = more;
@@ -73,17 +98,6 @@ export function HomeProposalsInfiniteScroll({
           isLoadingRef.current = false;
           setIsLoading(false);
         }
-      }
-
-      if (typeof window !== 'undefined') {
-        // Two rAFs: first commits the React update, second catches any
-        // late layout shift (image-driven reflow on the freshly mounted cards).
-        requestAnimationFrame(() => {
-          window.scrollTo({ top: scrollY, behavior: 'instant' });
-          requestAnimationFrame(() => {
-            window.scrollTo({ top: scrollY, behavior: 'instant' });
-          });
-        });
       }
     },
     [connectedSpaceId, connectedAddress, proposalType, governanceFilters]
@@ -112,7 +126,7 @@ export function HomeProposalsInfiniteScroll({
   }, [loadMore]);
 
   return (
-    <div className="space-y-2">
+    <div className="mt-2 space-y-2">
       {loadMoreNodes.map((node, i) => (
         <React.Fragment key={i}>{node}</React.Fragment>
       ))}

--- a/apps/web/app/home/home-proposals-infinite-scroll.tsx
+++ b/apps/web/app/home/home-proposals-infinite-scroll.tsx
@@ -4,12 +4,12 @@ import * as React from 'react';
 
 import { SmallButton } from '~/design-system/button';
 
-import { LoadingSkeleton } from './component';
 import {
   type GovernanceHomeReviewCategory,
   type GovernanceHomeStatusFilter,
 } from './fetch-active-proposals-in-editor-spaces';
 import { loadMoreHomeProposalsAction } from './load-more-home-proposals-action';
+import { LoadingSkeleton } from './loading-skeleton';
 
 interface Props {
   page: number;

--- a/apps/web/app/home/home-proposals-infinite-scroll.tsx
+++ b/apps/web/app/home/home-proposals-infinite-scroll.tsx
@@ -48,35 +48,6 @@ export function HomeProposalsInfiniteScroll({
       isLoadingRef.current = true;
       setIsLoading(true);
 
-      // Calling a Next.js server action triggers an RSC refetch for the current
-      // route, which reconciles the proposal cards above the sentinel and breaks
-      // the browser's scroll anchor — snapping the viewport up to the top of
-      // the list. Capture the scroll position and pin it across the load:
-      // a single rAF isn't enough because the RSC payload commits asynchronously
-      // and images on the new cards can settle 100s of ms later.
-      const scrollY = typeof window !== 'undefined' ? window.scrollY : 0;
-      const pinScroll = () => {
-        if (typeof window === 'undefined') return () => {};
-        let stopped = false;
-        const restore = () => {
-          if (stopped) return;
-          if (Math.abs(window.scrollY - scrollY) > 1) {
-            window.scrollTo(0, scrollY);
-          }
-        };
-        const interval = setInterval(restore, 16);
-        const timeout = setTimeout(() => {
-          stopped = true;
-          clearInterval(interval);
-        }, 800);
-        return () => {
-          stopped = true;
-          clearInterval(interval);
-          clearTimeout(timeout);
-        };
-      };
-      const stopPinning = pinScroll();
-
       try {
         const [node, next, more] = await loadMoreHomeProposalsAction(
           connectedSpaceId,
@@ -85,10 +56,7 @@ export function HomeProposalsInfiniteScroll({
           currentPageRef.current,
           governanceFilters
         );
-        if (abortController?.signal.aborted) {
-          stopPinning();
-          return;
-        }
+        if (abortController?.signal.aborted) return;
         setLoadMoreNodes(prev => [...prev, node]);
         currentPageRef.current = next;
         hasMoreRef.current = more;

--- a/apps/web/app/home/home-proposals-infinite-scroll.tsx
+++ b/apps/web/app/home/home-proposals-infinite-scroll.tsx
@@ -48,6 +48,13 @@ export function HomeProposalsInfiniteScroll({
       isLoadingRef.current = true;
       setIsLoading(true);
 
+      // Calling a Next.js server action triggers a server-component re-render
+      // for the current route. Even though our action only reads, the re-render
+      // can re-reconcile the proposal cards above the sentinel and break the
+      // browser's scroll anchor, snapping the viewport up. Capture the scroll
+      // position and restore it once React commits the appended page.
+      const scrollY = typeof window !== 'undefined' ? window.scrollY : 0;
+
       try {
         const [node, next, more] = await loadMoreHomeProposalsAction(
           connectedSpaceId,
@@ -66,6 +73,17 @@ export function HomeProposalsInfiniteScroll({
           isLoadingRef.current = false;
           setIsLoading(false);
         }
+      }
+
+      if (typeof window !== 'undefined') {
+        // Two rAFs: first commits the React update, second catches any
+        // late layout shift (image-driven reflow on the freshly mounted cards).
+        requestAnimationFrame(() => {
+          window.scrollTo({ top: scrollY, behavior: 'instant' });
+          requestAnimationFrame(() => {
+            window.scrollTo({ top: scrollY, behavior: 'instant' });
+          });
+        });
       }
     },
     [connectedSpaceId, connectedAddress, proposalType, governanceFilters]
@@ -100,9 +118,12 @@ export function HomeProposalsInfiniteScroll({
       ))}
 
       {hasMore && (
-        <div ref={sentinelRef}>
+        <div ref={sentinelRef} className="space-y-2">
           {isLoading ? (
-            <LoadingSkeleton />
+            <>
+              <LoadingSkeleton />
+              <LoadingSkeleton />
+            </>
           ) : (
             <SmallButton variant="secondary" onClick={() => loadMore()}>
               Load more

--- a/apps/web/app/home/loading-skeleton.tsx
+++ b/apps/web/app/home/loading-skeleton.tsx
@@ -1,0 +1,13 @@
+import { Skeleton } from '~/design-system/skeleton';
+
+export function LoadingSkeleton() {
+  return (
+    <div className="space-y-4 rounded-lg border border-grey-02 p-4">
+      <div className="space-y-2">
+        <Skeleton className="h-5 w-36" />
+        <Skeleton className="h-4 w-20" />
+      </div>
+      <Skeleton className="h-5 w-48" />
+    </div>
+  );
+}

--- a/apps/web/app/home/personal-home-dashboard.tsx
+++ b/apps/web/app/home/personal-home-dashboard.tsx
@@ -227,12 +227,24 @@ function GovernanceFilterMenu({
   maxHeightClass?: string;
 }) {
   const [open, setOpen] = React.useState(false);
+  const [pendingLabel, setPendingLabel] = React.useState<string | null>(null);
+  const prevLabelRef = React.useRef(label);
+
+  React.useEffect(() => {
+    if (prevLabelRef.current !== label) {
+      prevLabelRef.current = label;
+      setPendingLabel(null);
+    }
+  }, [label]);
+
+  const displayLabel = pendingLabel ?? label;
+
   return (
     <Menu
       open={open}
       onOpenChange={setOpen}
       asChild
-      trigger={<SmallButton icon={<ChevronDownSmall />}>{label}</SmallButton>}
+      trigger={<SmallButton icon={<ChevronDownSmall />}>{displayLabel}</SmallButton>}
       align="start"
     >
       <div className={maxHeightClass}>
@@ -240,7 +252,10 @@ function GovernanceFilterMenu({
           <Link
             key={item.href}
             href={item.href}
-            onClick={() => setOpen(false)}
+            onClick={() => {
+              if (item.label !== label) setPendingLabel(item.label);
+              setOpen(false);
+            }}
             className="flex w-full cursor-pointer items-center gap-2 bg-white px-3 py-2.5 hover:bg-bg"
           >
             {showImages && item.showImage !== false ? (

--- a/apps/web/app/home/personal-home-dashboard.tsx
+++ b/apps/web/app/home/personal-home-dashboard.tsx
@@ -253,7 +253,7 @@ function GovernanceFilterMenu({
             key={item.href}
             href={item.href}
             onClick={() => {
-              if (item.label !== label) setPendingLabel(item.label);
+              if (item.label !== displayLabel) setPendingLabel(item.label);
               setOpen(false);
             }}
             className="flex w-full cursor-pointer items-center gap-2 bg-white px-3 py-2.5 hover:bg-bg"

--- a/apps/web/design-system/button.tsx
+++ b/apps/web/design-system/button.tsx
@@ -30,14 +30,14 @@ const buttonClassNames = (className = '') =>
       variants: {
         variant: {
           primary:
-            'border-transparent bg-ctaPrimary text-white hover:bg-ctaHover focus:border-ctaHover focus:shadow-inner-ctaHover',
+            'border-transparent bg-ctaPrimary text-white hover:bg-ctaHover focus-visible:border-ctaHover focus-visible:shadow-inner-ctaHover',
           secondary:
-            'border-grey-02 bg-white text-text shadow-button hover:border-text hover:bg-bg hover:text-text! focus:border-text focus:shadow-inner-text',
+            'border-grey-02 bg-white text-text shadow-button hover:border-text hover:bg-bg hover:text-text! focus-visible:border-text focus-visible:shadow-inner-text',
           tertiary: 'border-white bg-text text-white shadow-none',
           ghost:
-            'border-transparent bg-white text-grey-04! shadow-none hover:border-text hover:bg-bg hover:text-text! hover:shadow-button focus:border-text focus:shadow-inner-text',
+            'border-transparent bg-white text-grey-04! shadow-none hover:border-text hover:bg-bg hover:text-text! hover:shadow-button focus-visible:border-text focus-visible:shadow-inner-text',
           transparent:
-            'border-text bg-transparent text-text! shadow-none hover:border-text hover:text-text! focus:border-text focus:shadow-inner-text',
+            'border-text bg-transparent text-text! shadow-none hover:border-text hover:text-text! focus-visible:border-text focus-visible:shadow-inner-text',
           success: 'border-white bg-green text-white shadow-none transition-colors duration-150 hover:bg-green/80',
           error: 'border-white bg-red-01 text-white shadow-none transition-colors duration-150 hover:bg-red-01/80',
           done: 'border-green bg-green text-text transition-colors duration-150 hover:bg-green/80',

--- a/apps/web/partials/active-proposal/accept-or-reject.tsx
+++ b/apps/web/partials/active-proposal/accept-or-reject.tsx
@@ -55,6 +55,15 @@ export function AcceptOrReject({
   const addOptimisticVote = useAddOptimisticVote();
   const removeOptimisticVote = useRemoveOptimisticVote();
 
+  // Once the server-rendered userVote catches up after router.refresh, the
+  // optimistic entry has done its job — drop it so the atom doesn't grow
+  // across a session and the artificial CSS order bump stops applying.
+  React.useEffect(() => {
+    if (userVote) {
+      removeOptimisticVote(proposalId);
+    }
+  }, [userVote, proposalId, removeOptimisticVote]);
+
   const onVoteSuccess = () => {
     router.refresh();
   };

--- a/apps/web/partials/active-proposal/accept-or-reject.tsx
+++ b/apps/web/partials/active-proposal/accept-or-reject.tsx
@@ -2,6 +2,7 @@
 
 import * as React from 'react';
 import { useState } from 'react';
+import { useRouter } from 'next/navigation';
 
 import { useAccessControl } from '~/core/hooks/use-access-control';
 import { useSmartAccount } from '~/core/hooks/use-smart-account';
@@ -11,6 +12,7 @@ import { SubstreamVote } from '~/core/io/substream-schema';
 
 import { Button } from '~/design-system/button';
 import { Pending } from '~/design-system/pending';
+import { useAddOptimisticVote, useRemoveOptimisticVote } from '~/partials/governance/optimistic-voted-atom';
 import { GovernanceReopenEditButton } from '~/partials/governance/governance-reopen-edit-button';
 
 import { Execute } from './execute';
@@ -35,6 +37,7 @@ export function AcceptOrReject({
   userVote,
   proposalId,
 }: Props) {
+  const router = useRouter();
   const { isEditor } = useAccessControl(spaceId);
   const { vote, status: voteStatus } = useVote({
     spaceId,
@@ -49,14 +52,27 @@ export function AcceptOrReject({
   const isPendingRejection = hasRejected && voteStatus === 'pending';
 
   const { smartAccount } = useSmartAccount();
+  const addOptimisticVote = useAddOptimisticVote();
+  const removeOptimisticVote = useRemoveOptimisticVote();
+
+  const onVoteSuccess = () => {
+    router.refresh();
+  };
+
+  const onVoteError = () => {
+    removeOptimisticVote(proposalId);
+  };
+
   const onApprove = () => {
     setHasApproved(true);
-    vote('ACCEPT');
+    addOptimisticVote(proposalId);
+    vote('ACCEPT', { onSuccess: onVoteSuccess, onError: onVoteError });
   };
 
   const onReject = () => {
     setHasRejected(true);
-    vote('REJECT');
+    addOptimisticVote(proposalId);
+    vote('REJECT', { onSuccess: onVoteSuccess, onError: onVoteError });
   };
 
   if (isProposalEnded) {

--- a/apps/web/partials/active-proposal/accept-or-reject.tsx
+++ b/apps/web/partials/active-proposal/accept-or-reject.tsx
@@ -118,11 +118,11 @@ export function AcceptOrReject({
     return (
       <div className="relative">
         <div className="inline-flex items-center gap-4">
-          <Button onClick={onReject} variant="error" disabled={voteStatus !== 'idle'}>
+          <Button onClick={onReject} variant="error" disabled={voteStatus === 'pending'}>
             <Pending isPending={isPendingRejection}>Reject</Pending>
           </Button>
           <span>or</span>
-          <Button onClick={onApprove} variant="success" disabled={voteStatus !== 'idle'}>
+          <Button onClick={onApprove} variant="success" disabled={voteStatus === 'pending'}>
             <Pending isPending={isPendingApproval}>Accept</Pending>
           </Button>
         </div>

--- a/apps/web/partials/governance/governance-proposals-list.tsx
+++ b/apps/web/partials/governance/governance-proposals-list.tsx
@@ -122,7 +122,7 @@ export async function GovernanceProposalsList({
 
   return {
     node: (
-      <div className="flex flex-col divide-y divide-grey-01">
+      <div className="flex flex-col">
         {proposals.map(p => {
           const displayProfile = p.targetProfile ?? p.createdBy;
           const proposalTitle = p.targetProfile

--- a/apps/web/partials/governance/governance-proposals-list.tsx
+++ b/apps/web/partials/governance/governance-proposals-list.tsx
@@ -53,6 +53,13 @@ const PAGE_SIZE = 100;
 
 const MEMBERSHIP_ACTION_TYPES = new Set(['ADD_MEMBER', 'REMOVE_MEMBER', 'ADD_EDITOR', 'REMOVE_EDITOR']);
 
+/** Finds the membership action in a proposal's action list. The REST schema does
+ *  not guarantee action order, so a lookup by index 0 can miss multi-action
+ *  proposals where the membership action is not first. */
+function findMembershipAction(actions: ApiProposalListItem['actions']): ApiProposalListItem['actions'][number] | undefined {
+  return actions.find(a => MEMBERSHIP_ACTION_TYPES.has(a.actionType));
+}
+
 /** Unvoted proposals first; voted ones sink to the bottom (same as governance home review). */
 function sortOpenProposalsUnvotedFirstByEndTimeAsc(items: readonly ApiProposalListItem[]): ApiProposalListItem[] {
   return [...items].sort((a, b) => {
@@ -406,9 +413,9 @@ async function fetchGovernanceProposals({
 
   // Filter by proposal type
   if (effectiveType === 'proposals') {
-    combinedProposals = combinedProposals.filter(p => !MEMBERSHIP_ACTION_TYPES.has(p.actions[0]?.actionType ?? ''));
+    combinedProposals = combinedProposals.filter(p => findMembershipAction(p.actions) === undefined);
   } else if (effectiveType === 'requests') {
-    combinedProposals = combinedProposals.filter(p => MEMBERSHIP_ACTION_TYPES.has(p.actions[0]?.actionType ?? ''));
+    combinedProposals = combinedProposals.filter(p => findMembershipAction(p.actions) !== undefined);
   }
 
   // Apply pagination
@@ -425,8 +432,7 @@ async function fetchGovernanceProposals({
 
   // Fetch target profiles for membership proposals (extract targetId from actions)
   const targetIds = paginatedProposals
-    .filter(p => MEMBERSHIP_ACTION_TYPES.has(p.actions[0]?.actionType ?? ''))
-    .map(p => p.actions[0]?.targetId)
+    .map(p => findMembershipAction(p.actions)?.targetId)
     .filter((id): id is string => !!id);
   const uniqueTargetIds = [...new Set(targetIds)];
 
@@ -441,7 +447,7 @@ async function fetchGovernanceProposals({
 
   const proposals = paginatedProposals.map(p => {
     const maybeProfile = profilesBySpaceId.get(p.proposedBy);
-    const targetId = p.actions[0]?.targetId;
+    const targetId = findMembershipAction(p.actions)?.targetId;
     const maybeTargetProfile = targetId ? targetProfilesBySpaceId.get(targetId) : undefined;
     return apiProposalToGovernanceDto(p, getProposalBucket(p.status), maybeProfile, maybeTargetProfile);
   });

--- a/apps/web/partials/governance/governance-proposals-list.tsx
+++ b/apps/web/partials/governance/governance-proposals-list.tsx
@@ -18,7 +18,7 @@ import {
   convertVoteOption,
   encodePathSegment,
   isValidUUID,
-  mapActionTypeToProposalType,
+  mapApiActionsToProposalType,
   mapProposalStatus,
   restFetch,
 } from '~/core/io/rest';
@@ -253,8 +253,10 @@ function apiProposalToGovernanceDto(
 ): GovernanceProposal {
   const profile = maybeProfile ?? defaultProfile(proposal.proposedBy, proposal.proposedBy);
 
-  const firstAction = proposal.actions[0];
-  const proposalType = mapActionTypeToProposalType(firstAction?.actionType ?? 'UNKNOWN');
+  // Walks all actions rather than reading actions[0] — REST action order isn't
+  // guaranteed, so a multi-action proposal that contains a PUBLISH would be
+  // misclassified if PUBLISH happens to be at a later index.
+  const proposalType = mapApiActionsToProposalType(proposal.actions);
 
   return {
     id: proposal.proposalId,
@@ -278,10 +280,16 @@ function apiProposalToGovernanceDto(
   };
 }
 
-function getProposalBucket(apiStatus: string): ProposalBucket {
-  if (apiStatus === 'EXECUTABLE') return 'executable';
-  if (apiStatus === 'PROPOSED') return 'active';
-  return 'completed';
+function getProposalBucket(apiStatus: ApiProposalListItem['status']): ProposalBucket {
+  switch (apiStatus) {
+    case 'EXECUTABLE':
+      return 'executable';
+    case 'PROPOSED':
+      return 'active';
+    case 'ACCEPTED':
+    case 'REJECTED':
+      return 'completed';
+  }
 }
 
 /**

--- a/apps/web/partials/governance/governance-proposals-list.tsx
+++ b/apps/web/partials/governance/governance-proposals-list.tsx
@@ -39,11 +39,29 @@ import type { GovernanceProposalType } from './governance-proposal-type-filter';
 import { GovernanceProposalVoteState } from './governance-proposal-vote-state';
 import { GovernanceRejectedProposalMenu } from './governance-rejected-proposal-menu';
 import { GovernanceStatusChip } from './governance-status-chip';
+import { ProposalListItem } from './proposal-list-item';
 import { cachedFetchSpace } from '~/app/space/[id]/cached-fetch-space';
+
+type ProposalBucket = 'executable' | 'active' | 'completed';
+const BUCKET_BASE_ORDER: Record<ProposalBucket, number> = {
+  executable: 0,
+  active: 10000,
+  completed: 20000,
+};
 
 const PAGE_SIZE = 100;
 
 const MEMBERSHIP_ACTION_TYPES = new Set(['ADD_MEMBER', 'REMOVE_MEMBER', 'ADD_EDITOR', 'REMOVE_EDITOR']);
+
+/** Unvoted proposals first; voted ones sink to the bottom (same as governance home review). */
+function sortOpenProposalsUnvotedFirstByEndTimeAsc(items: readonly ApiProposalListItem[]): ApiProposalListItem[] {
+  return [...items].sort((a, b) => {
+    const aVoted = a.userVote != null;
+    const bVoted = b.userVote != null;
+    if (aVoted !== bVoted) return aVoted ? 1 : -1;
+    return a.timing.endTime - b.timing.endTime;
+  });
+}
 
 function percentageFromCounts(count: number, total: number): number {
   if (total === 0) return 0;
@@ -100,6 +118,8 @@ export async function GovernanceProposalsList({
 
   const spaceName = space?.entity?.name ?? '';
 
+  const bucketPositions: Record<ProposalBucket, number> = { executable: 0, active: 0, completed: 0 };
+
   return {
     node: (
       <div className="flex flex-col divide-y divide-grey-01">
@@ -120,9 +140,16 @@ export async function GovernanceProposalsList({
           const showReopenMenu =
             p.status === 'REJECTED' && p.type === 'ADD_EDIT' && getIsProposalEnded(p.status, p.endTime);
 
+          const baseOrder = BUCKET_BASE_ORDER[p.bucket] + bucketPositions[p.bucket]++;
+
           return (
-            <Link
+            <ProposalListItem
               key={p.id}
+              proposalId={p.id}
+              baseOrder={baseOrder}
+              canSink={p.bucket !== 'completed'}
+            >
+            <Link
               href={`/space/${spaceId}/governance?proposalId=${p.id}`}
               className="flex w-full flex-col gap-3 py-4"
             >
@@ -178,6 +205,7 @@ export async function GovernanceProposalsList({
                 <GovernanceStatusChip endTime={p.endTime} status={p.status} canExecute={p.canExecute} />
               </div>
             </Link>
+            </ProposalListItem>
           );
         })}
       </div>
@@ -208,6 +236,7 @@ type GovernanceProposal = {
   endTime: number;
   status: ProposalStatus;
   canExecute: boolean;
+  bucket: ProposalBucket;
   proposalVotes: {
     totalCount: number;
     yesCount: number;
@@ -218,6 +247,7 @@ type GovernanceProposal = {
 
 function apiProposalToGovernanceDto(
   proposal: ApiProposalListItem,
+  bucket: ProposalBucket,
   maybeProfile?: Profile,
   maybeTargetProfile?: Profile
 ): GovernanceProposal {
@@ -236,6 +266,7 @@ function apiProposalToGovernanceDto(
     endTime: proposal.timing.endTime,
     status: mapProposalStatus(proposal.status),
     canExecute: proposal.canExecute,
+    bucket,
     createdBy: profile,
     targetProfile: maybeTargetProfile,
     userVote: proposal.userVote ? convertVoteOption(proposal.userVote) : undefined,
@@ -245,6 +276,12 @@ function apiProposalToGovernanceDto(
       noCount: proposal.votes.no,
     },
   };
+}
+
+function getProposalBucket(apiStatus: string): ProposalBucket {
+  if (apiStatus === 'EXECUTABLE') return 'executable';
+  if (apiStatus === 'PROPOSED') return 'active';
+  return 'completed';
 }
 
 /**
@@ -352,8 +389,12 @@ async function fetchGovernanceProposals({
     }),
   ]);
 
-  // Combine in priority order: executable > active > completed
-  let combinedProposals = [...executableProposals, ...activeProposals, ...completedProposals];
+  // Combine in priority order: executable > active > completed; within open phases, unvoted first.
+  let combinedProposals = [
+    ...sortOpenProposalsUnvotedFirstByEndTimeAsc(executableProposals),
+    ...sortOpenProposalsUnvotedFirstByEndTimeAsc(activeProposals),
+    ...completedProposals,
+  ];
 
   // Filter by proposal type
   if (effectiveType === 'proposals') {
@@ -394,7 +435,7 @@ async function fetchGovernanceProposals({
     const maybeProfile = profilesBySpaceId.get(p.proposedBy);
     const targetId = p.actions[0]?.targetId;
     const maybeTargetProfile = targetId ? targetProfilesBySpaceId.get(targetId) : undefined;
-    return apiProposalToGovernanceDto(p, maybeProfile, maybeTargetProfile);
+    return apiProposalToGovernanceDto(p, getProposalBucket(p.status), maybeProfile, maybeTargetProfile);
   });
 
   return { proposals, hasMore };

--- a/apps/web/partials/governance/optimistic-voted-atom.ts
+++ b/apps/web/partials/governance/optimistic-voted-atom.ts
@@ -1,0 +1,37 @@
+'use client';
+
+import { atom, useAtomValue, useSetAtom } from 'jotai';
+
+/** Proposal ids whose card should appear as "voted" (sunk to the bottom of the list) as soon as
+ *  the user clicks Accept/Reject, without waiting for the tx round-trip or a server refetch.
+ *  Removed by useRemoveOptimisticVote if the vote mutation errors. */
+const optimisticVotedIdsAtom = atom<Set<string>>(new Set<string>());
+
+export function useAddOptimisticVote() {
+  const setter = useSetAtom(optimisticVotedIdsAtom);
+  return (proposalId: string) => {
+    setter(prev => {
+      if (prev.has(proposalId)) return prev;
+      const next = new Set(prev);
+      next.add(proposalId);
+      return next;
+    });
+  };
+}
+
+export function useRemoveOptimisticVote() {
+  const setter = useSetAtom(optimisticVotedIdsAtom);
+  return (proposalId: string) => {
+    setter(prev => {
+      if (!prev.has(proposalId)) return prev;
+      const next = new Set(prev);
+      next.delete(proposalId);
+      return next;
+    });
+  };
+}
+
+export function useIsOptimisticallyVoted(proposalId: string): boolean {
+  const set = useAtomValue(optimisticVotedIdsAtom);
+  return set.has(proposalId);
+}

--- a/apps/web/partials/governance/proposal-list-item.tsx
+++ b/apps/web/partials/governance/proposal-list-item.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import * as React from 'react';
+
+import { useIsOptimisticallyVoted } from './optimistic-voted-atom';
+
+interface Props {
+  proposalId: string;
+  baseOrder: number;
+  canSink: boolean;
+  children: React.ReactNode;
+}
+
+const OPTIMISTIC_VOTE_ORDER_BUMP = 5000;
+
+export function ProposalListItem({ proposalId, baseOrder, canSink, children }: Props) {
+  const isOptimistic = useIsOptimisticallyVoted(proposalId);
+  const order = isOptimistic && canSink ? baseOrder + OPTIMISTIC_VOTE_ORDER_BUMP : baseOrder;
+  return <div style={{ order }}>{children}</div>;
+}

--- a/apps/web/partials/governance/proposal-list-item.tsx
+++ b/apps/web/partials/governance/proposal-list-item.tsx
@@ -16,5 +16,13 @@ const OPTIMISTIC_VOTE_ORDER_BUMP = 5000;
 export function ProposalListItem({ proposalId, baseOrder, canSink, children }: Props) {
   const isOptimistic = useIsOptimisticallyVoted(proposalId);
   const order = isOptimistic && canSink ? baseOrder + OPTIMISTIC_VOTE_ORDER_BUMP : baseOrder;
-  return <div style={{ order }}>{children}</div>;
+  // Per-item border-bottom (rather than a parent `divide-y`) so dividers track
+  // the visual position assigned by CSS `order`. With `divide-y`, the borderless
+  // first DOM item would stay borderless even after being sunk to the visual
+  // bottom, producing missing/spurious dividers when an item is voted on.
+  return (
+    <div style={{ order }} className="border-b border-grey-01">
+      {children}
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary

Three governance UX improvements split out from #1692 so they can ship now; the red-dot + notification-service integration stays on the original PR pending webhook registration with the gaia team.

- **Optimistic vote card reorder.** Clicking Accept/Reject on a proposal sinks its card to the bottom of its bucket (executable / active) immediately, via a jotai-driven CSS `order` bump. Rolled back if the tx errors. Fixes the multi-second gap between _You accepted_ appearing and the list finally reordering.
- **Governance home dropdowns.** Selecting a space / category / status now updates the trigger label instantly via local `pendingLabel` state, cleared once the server-derived label catches up. Removed the Suspense `key` that forced a skeleton flash on every filter change — the remaining Suspense fallback now fires only when the component actually suspends (cached / prefetched responses swap without any skeleton).
- **Button focus outline.** Switched `Button` primitive's `focus:` styles to `focus-visible:` so mouse clicks no longer leave a lingering bold inset border. Keyboard focus still shows it.
- **Infinite-scroll loading state.** On `/home`, the "Load more…" text-only button during pagination is replaced by two card-shaped skeletons (matching the proposal card spacing) so the loading state reads the same as the rest of the page. Also wrapped appended pages in keyed `React.Fragment`s so appends don't thrash the whole subtree.
- **Extracted `LoadingSkeleton`** into its own module so the client infinite-scroll component can consume it without dragging server-only transitive imports (`@opentelemetry/context-async-hooks` → `node:async_hooks`) into the client bundle.

## Known pre-existing issue NOT fixed here

On `/home`, clicking "Load more" (or scrolling to trigger the IntersectionObserver) still scrolls the viewport back to the top of the proposal list. **This behavior is on `master` as well** and was not introduced by this PR. Root cause is architectural: `loadMoreHomeProposalsAction` is a Next.js server action, and every server-action call ships a fresh RSC tree for the current route. Committing that tree re-reconciles every proposal card above the viewport and breaks the browser's scroll anchor.

Patching around it from inside the client component (rAF restore, scroll pinning) fights the RSC commit visibly. The proper fix is to refactor the pagination server action into a route handler that returns serializable proposal data and render the cards client-side — deferring that to its own ticket since it touches the membership / content proposal card server components, profile / space resolution, and `cachedFetchSpace` usage.

## What's **not** in this PR

- Sidebar red-dot behavior (`hasPendingVotes` → `pendingVoteProposalIds`, parallelized scan, confirm-vote wiring).
- Webhook receiver + Redis-backed pending-votes cache.
- Sidebar auto-refresh / polling changes.

Those remain on [#1692](https://github.com/geobrowser/geogenesis/pull/1692), which is blocked on gaia registering the webhook endpoint. Once this PR merges, that branch will rebase cleanly to contain only the red-dot / notification-service work.

## Test plan

- [ ] On a governance space page, open a pending proposal and click Accept or Reject. The card should visibly sink to the bottom of its section before the tx round-trip resolves.
- [ ] If the tx errors, the card should bounce back to its original position.
- [ ] On `/home`, change the space / category / status dropdown. The trigger button should show the new label immediately on click.
- [ ] On cached / prefetched dropdown navigation, no skeleton should flash.
- [ ] Mouse-click any `variant="secondary"` button (e.g. a dropdown trigger). No persistent thick dark outline should remain after the click.
- [ ] Keyboard-focus (Tab) the same button. The focus outline should still appear.
- [ ] On `/home` with enough proposals to paginate, scroll to the bottom; two card-shaped skeletons appear during the fetch (no "Loading…" text); the freshly appended page is spaced the same as the earlier cards.