### PR TITLE
fix(import): orange unmapped warnings, hoist Next button into Entities header

### DIFF
--- a/apps/web/partials/import/generate.tsx
+++ b/apps/web/partials/import/generate.tsx
@@ -343,7 +343,7 @@ export const Generate = ({ spaceId }: GenerateProps) => {
           <>
             <div className="flex flex-wrap items-center gap-2">
               <span className="flex shrink-0 items-center" aria-hidden>
-                <Warning color="red-01" />
+                <Warning color="orange" />
               </span>
               <span className="text-[1rem] leading-5 tracking-[-0.35px] text-text">
                 {unmappedCount} {unmappedCount === 1 ? 'property needs' : 'properties need'} linking
@@ -355,7 +355,7 @@ export const Generate = ({ spaceId }: GenerateProps) => {
               className="shrink-0 rounded-md"
               onClick={handleNavigateToReview}
             >
-              Review
+              Next
             </SmallButton>
           </>
         ) : (

--- a/apps/web/partials/import/import-preview-table.tsx
+++ b/apps/web/partials/import/import-preview-table.tsx
@@ -22,6 +22,7 @@ import { DateField } from '~/design-system/editable-fields/date-field';
 import { WebUrlField } from '~/design-system/editable-fields/web-url-field';
 import { GeoImage, NativeGeoImage } from '~/design-system/geo-image';
 import { CloseSmall } from '~/design-system/icons/close-small';
+import { Warning } from '~/design-system/icons/warning';
 import { SelectEntityAsPopover } from '~/design-system/select-entity-dialog';
 import { Text } from '~/design-system/text';
 
@@ -528,8 +529,8 @@ export const ImportPreviewTable = React.forwardRef<ImportPreviewTableHandle, Pro
                     initialQuery={col.headerLabel}
                     trigger={
                       <span className="flex items-center gap-1.5">
-                        <span className="inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-full bg-red-01 text-[10px] font-semibold text-white">
-                          !
+                        <span className="flex shrink-0 items-center" aria-hidden>
+                          <Warning color="orange" />
                         </span>
                         <Text variant="metadata" className="text-text">
                           Needs mapping
@@ -539,8 +540,8 @@ export const ImportPreviewTable = React.forwardRef<ImportPreviewTableHandle, Pro
                   />
                 ) : (
                   <span className="mt-0.5 flex items-center gap-1.5">
-                    <span className="inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-full bg-red-01 text-[10px] font-semibold text-white">
-                      !
+                    <span className="flex shrink-0 items-center" aria-hidden>
+                      <Warning color="orange" />
                     </span>
                     <Text variant="metadata" className="text-text">
                       Needs mapping

--- a/apps/web/partials/import/import-review.tsx
+++ b/apps/web/partials/import/import-review.tsx
@@ -256,37 +256,13 @@ export const ImportReview = ({ spaceId }: ImportReviewProps) => {
         Map properties to relevant properties in the space, and map any data to entities you want the data to link to.
       </p>
 
-      <div className="mb-4 flex flex-wrap items-center gap-2">
+      <div className="mb-4 flex items-center gap-2">
         <Text variant="quoteMedium" as="span" className="tracking-[-0.5px] text-text">
           {selectedType?.name ?? 'Entities'}
         </Text>
         <span className="flex h-6 min-w-6 items-center justify-center rounded-full bg-grey-02 px-2 text-[1rem] leading-5 tracking-[-0.35px] text-text">
           {entityCount}
         </span>
-        {hasData && unmappedCount > 0 && (
-          <button
-            type="button"
-            onClick={() => tableHandleRef.current?.jumpToNextUnmappedProperty()}
-            className="flex items-center gap-1.5 rounded hover:bg-grey-02/60"
-          >
-            <span className="flex shrink-0 items-center" aria-hidden>
-              <Warning color="orange" />
-            </span>
-            <Text as="span" variant="metadata" className="tracking-[-0.35px] text-text">
-              {unmappedCount} {unmappedCount === 1 ? 'property needs' : 'properties need'} linking
-            </Text>
-          </button>
-        )}
-        {hasData && hasUnmappedColumns && unmappedCount > 0 && (
-          <SmallButton
-            type="button"
-            variant="primary"
-            className="ml-auto shrink-0 rounded-md"
-            onClick={handleSkipAndDeleteUnmapped}
-          >
-            Next
-          </SmallButton>
-        )}
       </div>
 
       {hasNoRecords ? (
@@ -319,23 +295,49 @@ export const ImportReview = ({ spaceId }: ImportReviewProps) => {
         </div>
       ) : (
         <>
-          {!hasUnmappedColumns && unresolvedDataCount > 0 ? (
+          {unmappedCount > 0 || (!hasUnmappedColumns && unresolvedDataCount > 0) ? (
             <div className="mb-4 flex flex-wrap items-center gap-3 rounded-lg border border-grey-02 bg-grey-01 px-4 py-3">
-              <button
-                type="button"
-                onClick={() => tableHandleRef.current?.jumpToNextUnresolvedCell()}
-                className="flex items-center gap-1.5 rounded hover:bg-grey-02/60"
-              >
-                <span className="flex shrink-0 items-center" aria-hidden>
-                  <Warning color="orange" />
-                </span>
-                <Text as="span" variant="metadata" className="tracking-[-0.35px] text-text">
-                  {unresolvedDataCount.toLocaleString('en-US')}{' '}
-                  {unresolvedDataCount === 1 ? 'data point needs' : 'data points need'} linking
-                </Text>
-              </button>
+              {unmappedCount > 0 && (
+                <button
+                  type="button"
+                  onClick={() => tableHandleRef.current?.jumpToNextUnmappedProperty()}
+                  className="flex items-center gap-1.5 rounded hover:bg-grey-02/60"
+                >
+                  <span className="flex shrink-0 items-center" aria-hidden>
+                    <Warning color="orange" />
+                  </span>
+                  <Text as="span" variant="metadata" className="tracking-[-0.35px] text-text">
+                    {unmappedCount} {unmappedCount === 1 ? 'property needs' : 'properties need'} linking
+                  </Text>
+                </button>
+              )}
+              {!hasUnmappedColumns && unresolvedDataCount > 0 && (
+                <button
+                  type="button"
+                  onClick={() => tableHandleRef.current?.jumpToNextUnresolvedCell()}
+                  className="flex items-center gap-1.5 rounded hover:bg-grey-02/60"
+                >
+                  <span className="flex shrink-0 items-center" aria-hidden>
+                    <Warning color="orange" />
+                  </span>
+                  <Text as="span" variant="metadata" className="tracking-[-0.35px] text-text">
+                    {unresolvedDataCount.toLocaleString('en-US')}{' '}
+                    {unresolvedDataCount === 1 ? 'data point needs' : 'data points need'} linking
+                  </Text>
+                </button>
+              )}
+              {hasUnmappedColumns && unmappedCount > 0 && (
+                <SmallButton
+                  type="button"
+                  variant="primary"
+                  className="ml-auto shrink-0 rounded-md"
+                  onClick={handleSkipAndDeleteUnmapped}
+                >
+                  Next
+                </SmallButton>
+              )}
             </div>
-          ) : unmappedCount === 0 && values.length > 0 ? (
+          ) : values.length > 0 ? (
             <div className="mb-4 flex items-center gap-1.5 rounded-lg border border-grey-02 bg-grey-01 px-4 py-3">
               <span className="flex shrink-0 items-center" aria-hidden>
                 <Check color="green" />

--- a/apps/web/partials/import/import-review.tsx
+++ b/apps/web/partials/import/import-review.tsx
@@ -263,6 +263,16 @@ export const ImportReview = ({ spaceId }: ImportReviewProps) => {
         <span className="flex h-6 min-w-6 items-center justify-center rounded-full bg-grey-02 px-2 text-[1rem] leading-5 tracking-[-0.35px] text-text">
           {entityCount}
         </span>
+        {hasData && hasUnmappedColumns && unmappedCount > 0 && (
+          <SmallButton
+            type="button"
+            variant="primary"
+            className="ml-auto shrink-0 rounded-md"
+            onClick={handleSkipAndDeleteUnmapped}
+          >
+            Next
+          </SmallButton>
+        )}
       </div>
 
       {hasNoRecords ? (
@@ -325,16 +335,6 @@ export const ImportReview = ({ spaceId }: ImportReviewProps) => {
                     {unresolvedDataCount === 1 ? 'data point needs' : 'data points need'} linking
                   </Text>
                 </button>
-              )}
-              {hasUnmappedColumns && unmappedCount > 0 && (
-                <SmallButton
-                  type="button"
-                  variant="primary"
-                  className="ml-auto shrink-0 rounded-md"
-                  onClick={handleSkipAndDeleteUnmapped}
-                >
-                  Next
-                </SmallButton>
               )}
             </div>
           ) : values.length > 0 ? (

--- a/apps/web/partials/import/import-review.tsx
+++ b/apps/web/partials/import/import-review.tsx
@@ -256,13 +256,37 @@ export const ImportReview = ({ spaceId }: ImportReviewProps) => {
         Map properties to relevant properties in the space, and map any data to entities you want the data to link to.
       </p>
 
-      <div className="mb-4 flex items-center gap-2">
+      <div className="mb-4 flex flex-wrap items-center gap-2">
         <Text variant="quoteMedium" as="span" className="tracking-[-0.5px] text-text">
           {selectedType?.name ?? 'Entities'}
         </Text>
         <span className="flex h-6 min-w-6 items-center justify-center rounded-full bg-grey-02 px-2 text-[1rem] leading-5 tracking-[-0.35px] text-text">
           {entityCount}
         </span>
+        {hasData && unmappedCount > 0 && (
+          <button
+            type="button"
+            onClick={() => tableHandleRef.current?.jumpToNextUnmappedProperty()}
+            className="flex items-center gap-1.5 rounded hover:bg-grey-02/60"
+          >
+            <span className="flex shrink-0 items-center" aria-hidden>
+              <Warning color="orange" />
+            </span>
+            <Text as="span" variant="metadata" className="tracking-[-0.35px] text-text">
+              {unmappedCount} {unmappedCount === 1 ? 'property needs' : 'properties need'} linking
+            </Text>
+          </button>
+        )}
+        {hasData && hasUnmappedColumns && unmappedCount > 0 && (
+          <SmallButton
+            type="button"
+            variant="primary"
+            className="ml-auto shrink-0 rounded-md"
+            onClick={handleSkipAndDeleteUnmapped}
+          >
+            Next
+          </SmallButton>
+        )}
       </div>
 
       {hasNoRecords ? (
@@ -295,49 +319,23 @@ export const ImportReview = ({ spaceId }: ImportReviewProps) => {
         </div>
       ) : (
         <>
-          {unmappedCount > 0 || (!hasUnmappedColumns && unresolvedDataCount > 0) ? (
+          {!hasUnmappedColumns && unresolvedDataCount > 0 ? (
             <div className="mb-4 flex flex-wrap items-center gap-3 rounded-lg border border-grey-02 bg-grey-01 px-4 py-3">
-              {unmappedCount > 0 && (
-                <button
-                  type="button"
-                  onClick={() => tableHandleRef.current?.jumpToNextUnmappedProperty()}
-                  className="flex items-center gap-1.5 rounded hover:bg-grey-02/60"
-                >
-                  <span className="flex shrink-0 items-center" aria-hidden>
-                    <Warning color="red-01" />
-                  </span>
-                  <Text as="span" variant="metadata" className="tracking-[-0.35px] text-text">
-                    {unmappedCount} {unmappedCount === 1 ? 'property needs' : 'properties need'} linking
-                  </Text>
-                </button>
-              )}
-              {!hasUnmappedColumns && unresolvedDataCount > 0 && (
-                <button
-                  type="button"
-                  onClick={() => tableHandleRef.current?.jumpToNextUnresolvedCell()}
-                  className="flex items-center gap-1.5 rounded hover:bg-grey-02/60"
-                >
-                  <span className="flex shrink-0 items-center" aria-hidden>
-                    <Warning color="red-01" />
-                  </span>
-                  <Text as="span" variant="metadata" className="tracking-[-0.35px] text-text">
-                    {unresolvedDataCount.toLocaleString('en-US')}{' '}
-                    {unresolvedDataCount === 1 ? 'data point needs' : 'data points need'} linking
-                  </Text>
-                </button>
-              )}
-              {hasUnmappedColumns && unmappedCount > 0 && (
-                <SmallButton
-                  type="button"
-                  variant="primary"
-                  className="ml-auto shrink-0 rounded-md"
-                  onClick={handleSkipAndDeleteUnmapped}
-                >
-                  Skip
-                </SmallButton>
-              )}
+              <button
+                type="button"
+                onClick={() => tableHandleRef.current?.jumpToNextUnresolvedCell()}
+                className="flex items-center gap-1.5 rounded hover:bg-grey-02/60"
+              >
+                <span className="flex shrink-0 items-center" aria-hidden>
+                  <Warning color="orange" />
+                </span>
+                <Text as="span" variant="metadata" className="tracking-[-0.35px] text-text">
+                  {unresolvedDataCount.toLocaleString('en-US')}{' '}
+                  {unresolvedDataCount === 1 ? 'data point needs' : 'data points need'} linking
+                </Text>
+              </button>
             </div>
-          ) : values.length > 0 ? (
+          ) : unmappedCount === 0 && values.length > 0 ? (
             <div className="mb-4 flex items-center gap-1.5 rounded-lg border border-grey-02 bg-grey-01 px-4 py-3">
               <span className="flex shrink-0 items-center" aria-hidden>
                 <Check color="green" />

--- a/apps/web/partials/import/import-review.tsx
+++ b/apps/web/partials/import/import-review.tsx
@@ -263,7 +263,7 @@ export const ImportReview = ({ spaceId }: ImportReviewProps) => {
         <span className="flex h-6 min-w-6 items-center justify-center rounded-full bg-grey-02 px-2 text-[1rem] leading-5 tracking-[-0.35px] text-text">
           {entityCount}
         </span>
-        {hasData && hasUnmappedColumns && unmappedCount > 0 && (
+        {hasData && !isLoading && hasUnmappedColumns && unmappedCount > 0 && (
           <SmallButton
             type="button"
             variant="primary"


### PR DESCRIPTION
## Summary

UX polish for the Import CSV flow:

- **Step 3 (generate page):** unmapped-state `!` icon switches from red to orange; CTA renamed Review → Next (only in the unmapped state — all-mapped state still says "Review").
- **Review/map page:** the Skip button is renamed Next and lives in the Entities header row (right-aligned), gated on `!isLoading`. The "# properties need linking" message stays inside its grey alert container with an orange `!`.
- **Preview table:** the two "Needs mapping" `!` icons in column headers now use the same orange `Warning` SVG as the other alerts. Other unresolved-data indicators (red `WarningIcon` / status dots in cells) intentionally remain red — only the "Needs mapping" icons were in scope.

## Test plan

- [ ] Upload a CSV with unmapped properties; confirm step 3 shows orange `!` and "Next" button.
- [ ] Click Next → review page; confirm Entities row shows `{type}` + count + right-aligned "Next" button (hidden while loading).
- [ ] Confirm "# properties need linking" still renders inside the grey alert container with an orange `!`.
- [ ] Confirm the column-header "Needs mapping" `!` icons match the other orange warning icons.
- [ ] Clicking the linking text jumps to the next unmapped property; clicking "Next" still skips/deletes unmapped (unchanged handler).
- [ ] Resolve all properties → if data points need linking, alert renders with orange `!`; once all resolved, "All properties and data points are linked" banner shows.