### PR TITLE
perf(navbar): compress top-right avatar via Next image optimizer

### DIFF
--- a/apps/web/design-system/fallback-image.tsx
+++ b/apps/web/design-system/fallback-image.tsx
@@ -10,6 +10,7 @@ type FallbackImageProps = {
   value: string;
   sizes: string;
   className?: string;
+  priority?: boolean;
 };
 
 /**
@@ -22,7 +23,7 @@ type FallbackImageProps = {
  *      `dangerouslyAllowSVG`, and timeouts where browser can still reach Pinata fine)
  *   3. Lighthouse unoptimized (legacy CIDs not on Pinata)
  */
-export function FallbackImage({ value, sizes, className }: FallbackImageProps) {
+export function FallbackImage({ value, sizes, className, priority = false }: FallbackImageProps) {
   const [stage, setStage] = React.useState<'primary' | 'primary-unoptimized' | 'lighthouse-unoptimized'>('primary');
 
   const src = stage === 'lighthouse-unoptimized' ? getImagePathFallback(value) : getImagePath(value);
@@ -36,6 +37,7 @@ export function FallbackImage({ value, sizes, className }: FallbackImageProps) {
       sizes={sizes}
       className={className}
       unoptimized={unoptimized}
+      priority={priority}
       onError={() => {
         setStage(prev => {
           if (prev === 'primary') return 'primary-unoptimized';

--- a/apps/web/partials/navbar/navbar-actions.tsx
+++ b/apps/web/partials/navbar/navbar-actions.tsx
@@ -21,6 +21,7 @@ import { NavUtils } from '~/core/utils/utils';
 import { GeoConnectButton } from '~/core/wallet';
 
 import { Avatar } from '~/design-system/avatar';
+import { FallbackImage } from '~/design-system/fallback-image';
 import { BulkEdit } from '~/design-system/icons/bulk-edit';
 import { DisconnectWallet } from '~/design-system/icons/disconnect-wallet';
 import { EyeSmall } from '~/design-system/icons/eye-small';
@@ -91,7 +92,11 @@ export function NavbarActions() {
       <Menu
         trigger={
           <div className="relative h-7 w-7 overflow-hidden rounded-full">
-            <Avatar value={address} avatarUrl={profile?.avatarUrl} size={28} />
+            {profile?.avatarUrl ? (
+              <FallbackImage value={profile.avatarUrl} sizes="28px" className="object-cover" />
+            ) : (
+              <Avatar value={address} size={28} />
+            )}
           </div>
         }
         open={open}

--- a/apps/web/partials/space-page/space-editors-chip.tsx
+++ b/apps/web/partials/space-page/space-editors-chip.tsx
@@ -2,6 +2,7 @@ import pluralize from 'pluralize';
 
 import { Avatar } from '~/design-system/avatar';
 import { AvatarGroup } from '~/design-system/avatar-group';
+import { FallbackImage } from '~/design-system/fallback-image';
 
 import { getFirstThreeEditorsForSpace } from './get-first-three-editors-for-space';
 
@@ -18,7 +19,11 @@ export async function SpaceEditorsChip({ spaceId }: Props) {
       <AvatarGroup>
         {firstThreeEditors.map(editor => (
           <AvatarGroup.Item key={editor.id}>
-            <Avatar priority size={12} avatarUrl={editor.avatarUrl} value={editor.address} />
+            {editor.avatarUrl ? (
+              <FallbackImage value={editor.avatarUrl} sizes="12px" className="object-cover" />
+            ) : (
+              <Avatar size={12} value={editor.address} />
+            )}
           </AvatarGroup.Item>
         ))}
       </AvatarGroup>

--- a/apps/web/partials/space-page/space-editors-chip.tsx
+++ b/apps/web/partials/space-page/space-editors-chip.tsx
@@ -20,7 +20,7 @@ export async function SpaceEditorsChip({ spaceId }: Props) {
         {firstThreeEditors.map(editor => (
           <AvatarGroup.Item key={editor.id}>
             {editor.avatarUrl ? (
-              <FallbackImage value={editor.avatarUrl} sizes="12px" className="object-cover" />
+              <FallbackImage value={editor.avatarUrl} sizes="12px" className="object-cover" priority />
             ) : (
               <Avatar size={12} value={editor.address} />
             )}

--- a/apps/web/partials/space-page/space-members-chip.tsx
+++ b/apps/web/partials/space-page/space-members-chip.tsx
@@ -2,6 +2,7 @@ import pluralize from 'pluralize';
 
 import { Avatar } from '~/design-system/avatar';
 import { AvatarGroup } from '~/design-system/avatar-group';
+import { FallbackImage } from '~/design-system/fallback-image';
 
 import { getFirstThreeMembersForSpace } from './get-first-three-members-for-space';
 
@@ -18,7 +19,11 @@ export async function SpaceMembersChip({ spaceId }: Props) {
       <AvatarGroup>
         {firstThreeMembers.map(editor => (
           <AvatarGroup.Item key={editor.id}>
-            <Avatar priority size={12} avatarUrl={editor.avatarUrl} value={editor.address} />
+            {editor.avatarUrl ? (
+              <FallbackImage value={editor.avatarUrl} sizes="12px" className="object-cover" />
+            ) : (
+              <Avatar size={12} value={editor.address} />
+            )}
           </AvatarGroup.Item>
         ))}
       </AvatarGroup>

--- a/apps/web/partials/space-page/space-members-chip.tsx
+++ b/apps/web/partials/space-page/space-members-chip.tsx
@@ -20,7 +20,7 @@ export async function SpaceMembersChip({ spaceId }: Props) {
         {firstThreeMembers.map(editor => (
           <AvatarGroup.Item key={editor.id}>
             {editor.avatarUrl ? (
-              <FallbackImage value={editor.avatarUrl} sizes="12px" className="object-cover" />
+              <FallbackImage value={editor.avatarUrl} sizes="12px" className="object-cover" priority />
             ) : (
               <Avatar size={12} value={editor.address} />
             )}


### PR DESCRIPTION
## Summary
- The top-right navbar avatar and the space-page member/editor chip avatars rendered via `NativeGeoImage` (raw `<img>`), so they skipped the Next.js image optimizer and downloaded the full-size IPFS asset.
- Swap those call sites to `FallbackImage` (the same component the browse sidebar already uses) so each tiny slot gets a small optimized webp from the Pinata→Lighthouse fallback chain.
- Extend `FallbackImage` to accept an optional `priority` prop and pass it from the chips to preserve the eager-load behavior they had previously via `<Avatar priority />`.
- The shared `Avatar` component is unchanged so other consumers keep their current behavior.

## Test plan
- [ ] Sign in and confirm the top-right navbar avatar loads quickly at the correct size.
- [ ] Open a space page and confirm the member/editor chip avatars render at 12px and load eagerly.
- [ ] Confirm the BoringAvatar fallback still renders for accounts without an `avatarUrl` in all three locations.
- [ ] Sanity check: the avatar menu (Personal space / Sign out) still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)