### PR TITLE
perf(explore): scope name requirement to display space via values.some

### DIFF
--- a/apps/web/core/explore/fetch-explore-feed.ts
+++ b/apps/web/core/explore/fetch-explore-feed.ts
@@ -179,7 +179,17 @@ async function fetchExploreEntitiesPage(args: {
   const filter: EntityFilter = {
     ...FEED_EXCLUDED_RELATIONS_FILTER,
     ...(args.typeIds?.length ? { typeIds: { overlaps: [...args.typeIds] } } : {}),
-    ...(args.requireName !== false ? { name: { isNull: false, isNot: '' } } : {}),
+    ...(args.requireName !== false
+      ? {
+          values: {
+            some: {
+              spaceId: { in: args.spaceIds },
+              propertyId: { is: EXPLORE_ENTITY_NAME_PROPERTY_ID },
+              text: { isNull: false, isNot: '' },
+            },
+          },
+        }
+      : {}),
     ...(t != null ? { createdAt: { greaterThanOrEqualTo: String(t) } } : {}),
   };
 


### PR DESCRIPTION
## Summary
- Replaces the aggregated `name: { isNot: "" }` filter on `entitiesConnection` with a space-scoped `values: { some: { spaceId, propertyId: NAME, text: { isNot: "" } } }`.
- Goal: speed up the activity feed for the root space, which currently scans the full space and sorts by the unindexed `createdAt`. The aggregated-name predicate amplifies that cost; the values-index predicate should let the planner narrow earlier.
- Side benefit: stricter activity-feed semantics — drops entities that have a name in another space but not the displayed one, removing "Untitled" fallback cards.

## Affected paths
- Activity feed: `/api/activity/feed` → `fetchExploreFeed` → `fetchExploreEntitiesPage`
- Explore feed shares the same code path; behavior is consistent because we scope to `args.spaceIds` (the in-scope space set), so multi-space explore continues to require a name in any of the visible spaces.

## Test plan
- [ ] Open the root space activity tab and confirm wall-clock load time vs. master.
- [ ] Spot-check that explore feed still renders entities with names.
- [ ] Confirm no entities appear with "Untitled" fallback titles in the activity feed.
- [ ] Pagination still works (cursor + Load more).