### PR TITLE
fix: keep `+ type` and property `+` inline with chips

### DIFF
--- a/apps/web/design-system/reorderable-relation-chips-dnd.tsx
+++ b/apps/web/design-system/reorderable-relation-chips-dnd.tsx
@@ -117,11 +117,9 @@ export default function ReorderableRelationChipsDnd({
       onDragEnd={handleDragEnd}
     >
       <SortableContext items={sortedRelations.map(r => r.id)} strategy={horizontalListSortingStrategy}>
-        <div className="flex min-w-0 w-full max-w-full flex-wrap gap-1">
-          {sortedRelations.map(relation => (
-            <SortableRelationChip key={relation?.id} relation={relation} spaceId={spaceId} />
-          ))}
-        </div>
+        {sortedRelations.map(relation => (
+          <SortableRelationChip key={relation?.id} relation={relation} spaceId={spaceId} />
+        ))}
       </SortableContext>
 
       <DragOverlay>


### PR DESCRIPTION
## Summary
- The multi-relation branch of `ReorderableRelationChipsDnd` wrapped chips in a `flex w-full flex-wrap` div, which always claimed a full row inside `RelationsGroup`'s outer flex-wrap container and forced the trailing `+` / `+ type` button to wrap to a new line — even when there was plenty of horizontal space next to the last pill.
- Removed the inner wrapper so chips render as flat siblings of the `+` button (matching the single-relation branch). `SortableContext` is Context-API based, so the wrapper isn't needed for DnD.
- Fixes both reported instances: `+ type` on the entity / space header, and the per-property `+` add-relation button (Goals, Principles, Values, etc.).

## Test plan
- [ ] In edit mode on the Geo space, the `Root` `Space` types row keeps `+ type` inline next to `Space` instead of wrapping below.
- [ ] In the About tab, multi-value rows (Goals, Principles, Values) keep `+` inline next to the last pill until the row genuinely runs out of horizontal space.
- [ ] When the row is actually full, `+` wraps cleanly with the chips.
- [ ] Single-chip rows still render normally.
- [ ] Drag-to-reorder a chip in a multi-chip row — reorder still works and persists.