### PR TITLE
fix: rename bullet list command

### DIFF
--- a/apps/web/partials/editor/command-items.tsx
+++ b/apps/web/partials/editor/command-items.tsx
@@ -194,7 +194,7 @@ export const getCommandItems = (spaceId: string): CommandSuggestionItem[] => [
   textCommandItem,
   {
     icon: <EditorList />,
-    title: 'Bullet points',
+    title: 'Bullet list',
     command: ({ editor, range }) => {
       editor.chain().focus().deleteRange(range).toggleBulletList().run();
     },


### PR DESCRIPTION
## Summary
- Rename the slash-command block picker option from "Bullet points" to "Bullet list".

## Testing
- Confirmed the updated label appears in apps/web/partials/editor/command-items.tsx.