### PR TITLE
feat: show property descriptions on hover

### DIFF
--- a/apps/web/design-system/prefetch-link.tsx
+++ b/apps/web/design-system/prefetch-link.tsx
@@ -10,11 +10,14 @@ import { NavUtils } from '~/core/utils/utils';
 
 type Props = React.ComponentPropsWithoutRef<typeof Link> & { entityId?: string; spaceId?: string };
 
-export function PrefetchLink({ children, entityId, spaceId, prefetch: prefetchProp = false, ...rest }: Props) {
+export const PrefetchLink = React.forwardRef<HTMLAnchorElement, Props>(function PrefetchLink(
+  { children, entityId, spaceId, prefetch: prefetchProp = false, onMouseEnter, ...rest },
+  ref
+) {
   const { hydrate } = useSyncEngine();
   const router = useRouter();
 
-  const prefetchOnHover = () => {
+  const prefetchOnHover = (event: React.MouseEvent<HTMLAnchorElement>) => {
     if (entityId && spaceId) {
       router.prefetch(NavUtils.toEntity(spaceId, entityId));
     }
@@ -22,11 +25,13 @@ export function PrefetchLink({ children, entityId, spaceId, prefetch: prefetchPr
     if (entityId) {
       hydrate([entityId]);
     }
+
+    onMouseEnter?.(event);
   };
 
   return (
-    <Link {...rest} prefetch={prefetchProp} onMouseEnter={prefetchOnHover}>
+    <Link {...rest} ref={ref} prefetch={prefetchProp} onMouseEnter={prefetchOnHover}>
       {children}
     </Link>
   );
-}
+});

--- a/apps/web/design-system/tooltip.tsx
+++ b/apps/web/design-system/tooltip.tsx
@@ -12,14 +12,23 @@ type TooltipProps = {
   trigger: ReactNode;
   label: ReactNode;
   position?: Position;
+  align?: Align;
   variant?: Variant;
 };
 
 type Position = 'top' | 'bottom' | 'left' | 'right';
 
+type Align = 'start' | 'center' | 'end';
+
 type Variant = 'light' | 'dark' | 'propertyDescription';
 
-export const Tooltip = ({ trigger, label = '', position = 'bottom', variant = 'dark' }: TooltipProps) => {
+export const Tooltip = ({
+  trigger,
+  label = '',
+  position = 'bottom',
+  align = 'center',
+  variant = 'dark',
+}: TooltipProps) => {
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const [x, y] = originCoordinates[position];
 
@@ -30,7 +39,7 @@ export const Tooltip = ({ trigger, label = '', position = 'bottom', variant = 'd
         <AnimatePresence mode="popLayout">
           {isOpen && (
             // a combined <MotionContent> component made with motion(Content) breaks the tooltip behavior
-            <Content side={position} align="center" alignOffset={0} sideOffset={4} forceMount>
+            <Content side={position} align={align} alignOffset={0} sideOffset={4} forceMount>
               <motion.div
                 className={cx(
                   'relative w-full focus:outline-hidden',

--- a/apps/web/design-system/tooltip.tsx
+++ b/apps/web/design-system/tooltip.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Arrow, Content, Provider, Root, Trigger } from '@radix-ui/react-tooltip';
+import { Arrow, Content, Portal, Provider, Root, Trigger } from '@radix-ui/react-tooltip';
 
 import { useState } from 'react';
 import type { ReactNode } from 'react';
@@ -36,31 +36,40 @@ export const Tooltip = ({
     <Provider delayDuration={300} skipDelayDuration={300}>
       <Root open={isOpen} onOpenChange={setIsOpen}>
         <Trigger asChild>{trigger}</Trigger>
-        <AnimatePresence mode="popLayout">
-          {isOpen && (
-            // a combined <MotionContent> component made with motion(Content) breaks the tooltip behavior
-            <Content side={position} align={align} alignOffset={0} sideOffset={4} forceMount>
-              <motion.div
-                className={cx(
-                  'relative w-full focus:outline-hidden',
-                  positionClassName[position],
-                  variantClassName[variant]
-                )}
-                initial={{ opacity: 0, scale: 0.95, x, y }}
-                animate={{ opacity: 1, scale: 1, x: 0, y: 0 }}
-                exit={{ opacity: 0, scale: 0.95, x, y }}
-                transition={{
-                  type: 'spring',
-                  duration: 0.15,
-                  bounce: 0,
-                }}
+        <Portal>
+          <AnimatePresence mode="popLayout">
+            {isOpen && (
+              // a combined <MotionContent> component made with motion(Content) breaks the tooltip behavior
+              <Content
+                side={position}
+                align={align}
+                alignOffset={0}
+                sideOffset={4}
+                forceMount
+                className="z-1001"
               >
-                {variant === 'dark' && <Arrow />}
-                <div className={labelClassName[variant]}>{label}</div>
-              </motion.div>
-            </Content>
-          )}
-        </AnimatePresence>
+                <motion.div
+                  className={cx(
+                    'relative w-full focus:outline-hidden',
+                    positionClassName[position],
+                    variantClassName[variant]
+                  )}
+                  initial={{ opacity: 0, scale: 0.95, x, y }}
+                  animate={{ opacity: 1, scale: 1, x: 0, y: 0 }}
+                  exit={{ opacity: 0, scale: 0.95, x, y }}
+                  transition={{
+                    type: 'spring',
+                    duration: 0.15,
+                    bounce: 0,
+                  }}
+                >
+                  {variant === 'dark' && <Arrow />}
+                  <div className={labelClassName[variant]}>{label}</div>
+                </motion.div>
+              </Content>
+            )}
+          </AnimatePresence>
+        </Portal>
       </Root>
     </Provider>
   );

--- a/apps/web/design-system/tooltip.tsx
+++ b/apps/web/design-system/tooltip.tsx
@@ -56,7 +56,7 @@ export const Tooltip = ({
                 }}
               >
                 {variant === 'dark' && <Arrow />}
-                <div>{label}</div>
+                <div className={labelClassName[variant]}>{label}</div>
               </motion.div>
             </Content>
           )}
@@ -85,4 +85,10 @@ const variantClassName: Record<Variant, string> = {
   dark: 'bg-text text-white max-w-[192px] rounded p-2 shadow-button text-center text-breadcrumb',
   propertyDescription:
     'w-[350px] max-w-[calc(100vw-32px)] rounded-lg border border-grey-02 bg-white p-3 text-metadata text-text shadow-[0px_8px_25px_0px_rgba(0,0,0,0.09)]',
+};
+
+const labelClassName: Record<Variant, string> = {
+  light: '',
+  dark: '',
+  propertyDescription: 'h-[60px] line-clamp-3',
 };

--- a/apps/web/design-system/tooltip.tsx
+++ b/apps/web/design-system/tooltip.tsx
@@ -17,7 +17,7 @@ type TooltipProps = {
 
 type Position = 'top' | 'bottom' | 'left' | 'right';
 
-type Variant = 'light' | 'dark';
+type Variant = 'light' | 'dark' | 'propertyDescription';
 
 export const Tooltip = ({ trigger, label = '', position = 'bottom', variant = 'dark' }: TooltipProps) => {
   const [isOpen, setIsOpen] = useState<boolean>(false);
@@ -74,4 +74,6 @@ const positionClassName: Record<Position, string> = {
 const variantClassName: Record<Variant, string> = {
   light: 'bg-white text-text max-w-[250px] rounded p-3 shadow-lg text-metadata',
   dark: 'bg-text text-white max-w-[192px] rounded p-2 shadow-button text-center text-breadcrumb',
+  propertyDescription:
+    'w-[350px] max-w-[calc(100vw-32px)] rounded-lg border border-grey-02 bg-white p-3 text-metadata text-text shadow-[0px_8px_25px_0px_rgba(0,0,0,0.09)]',
 };

--- a/apps/web/design-system/tooltip.tsx
+++ b/apps/web/design-system/tooltip.tsx
@@ -84,11 +84,11 @@ const variantClassName: Record<Variant, string> = {
   light: 'bg-white text-text max-w-[250px] rounded p-3 shadow-lg text-metadata',
   dark: 'bg-text text-white max-w-[192px] rounded p-2 shadow-button text-center text-breadcrumb',
   propertyDescription:
-    'w-[350px] max-w-[calc(100vw-32px)] rounded-lg border border-grey-02 bg-white p-3 text-metadata text-text shadow-[0px_8px_25px_0px_rgba(0,0,0,0.09)]',
+    'w-[350px] max-w-[min(700px,calc(100vw-32px))] overflow-hidden rounded-lg border border-grey-02 bg-white p-3 text-metadata text-text shadow-[0px_8px_25px_0px_rgba(0,0,0,0.09)]',
 };
 
 const labelClassName: Record<Variant, string> = {
   light: '',
   dark: '',
-  propertyDescription: 'line-clamp-3',
+  propertyDescription: 'line-clamp-3 break-words',
 };

--- a/apps/web/design-system/tooltip.tsx
+++ b/apps/web/design-system/tooltip.tsx
@@ -90,5 +90,5 @@ const variantClassName: Record<Variant, string> = {
 const labelClassName: Record<Variant, string> = {
   light: '',
   dark: '',
-  propertyDescription: 'h-[60px] line-clamp-3',
+  propertyDescription: 'line-clamp-3',
 };

--- a/apps/web/partials/entity-page/editable-entity-page.tsx
+++ b/apps/web/partials/entity-page/editable-entity-page.tsx
@@ -29,7 +29,6 @@ import { Property, Relation, ValueOptions } from '~/core/types';
 import { mapPropertyType } from '~/core/utils/property/properties';
 import { isUrlTemplate, resolveUrlTemplate } from '~/core/utils/url-template';
 import { useImageUrlFromEntity, useVideoUrlFromEntity } from '~/core/utils/use-entity-media';
-import { NavUtils } from '~/core/utils/utils';
 
 import { AddTypeButton, SquareButton } from '~/design-system/button';
 import { Checkbox, getChecked } from '~/design-system/checkbox';
@@ -48,7 +47,6 @@ import { ScheduleField } from '~/design-system/editable-fields/schedule-field';
 import { Create } from '~/design-system/icons/create';
 import { Trash } from '~/design-system/icons/trash';
 import { InputPlace } from '~/design-system/input-address';
-import { PrefetchLink as Link } from '~/design-system/prefetch-link';
 import ReorderableRelationChipsDnd from '~/design-system/reorderable-relation-chips-dnd';
 import { SelectEntity } from '~/design-system/select-entity';
 import { SelectEntityAsPopover } from '~/design-system/select-entity-dialog';
@@ -57,6 +55,7 @@ import { Text } from '~/design-system/text';
 
 import { createRelationEntityTypeRelation } from '~/partials/blocks/table/change-entry';
 import { DataTypePill } from '~/partials/entity-page/data-type-pill';
+import { PropertyNameLink } from '~/partials/entity-page/property-name-link';
 import { getEntityTemplate } from '~/partials/entity-page/utils/get-entity-template';
 
 type EditableEntityPageProps = {
@@ -179,13 +178,7 @@ export function EditableEntityPage({ id, spaceId }: EditableEntityPageProps) {
 }
 
 function RenderedProperty({ property, spaceId }: { property: Property; spaceId: string }) {
-  return (
-    <Link href={NavUtils.toEntity(spaceId, property.id)}>
-      <Text as="p" variant="bodySemibold">
-        {property.name ?? property.id}
-      </Text>
-    </Link>
-  );
+  return <PropertyNameLink property={property} spaceId={spaceId} />;
 }
 
 type RelationPropertyWithDeleteProps = {

--- a/apps/web/partials/entity-page/property-name-link.tsx
+++ b/apps/web/partials/entity-page/property-name-link.tsx
@@ -15,7 +15,7 @@ type PropertyNameLinkProps = {
 
 export function PropertyNameLink({ property, spaceId }: PropertyNameLinkProps) {
   const description = useDescription(property.id, spaceId)?.trim();
-  const propertyName = property.name ?? property.id;
+  const propertyName = property.name?.trim() || property.id;
 
   const link = (
     <Link

--- a/apps/web/partials/entity-page/property-name-link.tsx
+++ b/apps/web/partials/entity-page/property-name-link.tsx
@@ -38,5 +38,7 @@ export function PropertyNameLink({ property, spaceId }: PropertyNameLinkProps) {
     return link;
   }
 
-  return <Tooltip trigger={link} label={description} position="top" variant="propertyDescription" />;
+  return (
+    <Tooltip trigger={link} label={description} position="top" align="start" variant="propertyDescription" />
+  );
 }

--- a/apps/web/partials/entity-page/property-name-link.tsx
+++ b/apps/web/partials/entity-page/property-name-link.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { useDescription } from '~/core/state/entity-page-store/entity-store';
+import { Property } from '~/core/types';
+import { NavUtils } from '~/core/utils/utils';
+
+import { PrefetchLink as Link } from '~/design-system/prefetch-link';
+import { Text } from '~/design-system/text';
+import { Tooltip } from '~/design-system/tooltip';
+
+type PropertyNameLinkProps = {
+  property: Property;
+  spaceId: string;
+};
+
+export function PropertyNameLink({ property, spaceId }: PropertyNameLinkProps) {
+  const description = useDescription(property.id, spaceId)?.trim();
+  const propertyName = property.name ?? property.id;
+
+  const link = (
+    <Link
+      href={NavUtils.toEntity(spaceId, property.id)}
+      entityId={property.id}
+      spaceId={spaceId}
+      className="group inline-flex max-w-full"
+    >
+      <Text
+        as="span"
+        variant="bodySemibold"
+        className="min-w-0 break-words underline-offset-2 group-hover:underline group-focus-visible:underline"
+      >
+        {propertyName}
+      </Text>
+    </Link>
+  );
+
+  if (!description) {
+    return link;
+  }
+
+  return <Tooltip trigger={link} label={description} position="top" variant="propertyDescription" />;
+}

--- a/apps/web/partials/entity-page/readable-entity-page.tsx
+++ b/apps/web/partials/entity-page/readable-entity-page.tsx
@@ -17,7 +17,7 @@ import {
 import { DataType, RenderableType } from '~/core/types';
 import { isUrlTemplate } from '~/core/utils/url-template';
 import { useImageUrlFromEntity, useVideoUrlFromEntity } from '~/core/utils/use-entity-media';
-import { GeoNumber, GeoPoint, NavUtils, sortRelations } from '~/core/utils/utils';
+import { GeoNumber, GeoPoint, sortRelations } from '~/core/utils/utils';
 
 import { Checkbox, getChecked } from '~/design-system/checkbox';
 import { LinkableRelationChip } from '~/design-system/chip';
@@ -27,8 +27,9 @@ import { GeoLocationWrapper } from '~/design-system/editable-fields/geo-location
 import { ScheduleField } from '~/design-system/editable-fields/schedule-field';
 import { WebUrlField } from '~/design-system/editable-fields/web-url-field';
 import { Map } from '~/design-system/map';
-import { PrefetchLink as Link } from '~/design-system/prefetch-link';
 import { Text } from '~/design-system/text';
+
+import { PropertyNameLink } from '~/partials/entity-page/property-name-link';
 
 interface Props {
   id: string;
@@ -124,11 +125,7 @@ function ValuesGroup({ entityId, spaceId, propertyId }: { entityId: string; spac
         }
         return (
           <div key={`${entityId}-${propertyId}-${index}`} className="min-w-0 max-w-full break-words">
-            <Link href={NavUtils.toEntity(spaceId, propertyId)}>
-              <Text as="p" variant="bodySemibold">
-                {property.name || propertyId}
-              </Text>
-            </Link>
+            <PropertyNameLink property={property} spaceId={spaceId} />
             <div className="flex min-w-0 w-full max-w-full flex-wrap gap-2">
               <RenderedValue
                 propertyId={propertyId}
@@ -197,11 +194,7 @@ export function RelationsGroup({
     <>
       <div key={`${propertyId}-${property.name}`} className="min-w-0 max-w-full break-words">
         {propertyId !== SystemIds.TYPES_PROPERTY && (
-          <Link href={NavUtils.toEntity(spaceId, propertyId)}>
-            <Text as="p" variant="bodySemibold">
-              {property.name ?? propertyId}
-            </Text>
-          </Link>
+          <PropertyNameLink property={property} spaceId={spaceId} />
         )}
 
         <div className="flex min-w-0 w-full max-w-full flex-wrap gap-2">


### PR DESCRIPTION
## Summary
- Add a reusable property name link that underlines on hover/focus and shows the property entity's Description text in a popover when available.
- Add a tooltip variant matching the Figma popover styling.
- Forward refs and compose mouse-enter handlers in PrefetchLink so Radix tooltip triggers work while preserving hover prefetching.

## Verification
- Not run: dependencies are unavailable in the new worktree. `bun run lint` failed because `eslint` was missing, and `bun install` failed in the sandbox with package symlink/link ENOENT errors.