### PR TITLE
feat(search): always include root, current, and personal spaces in REST /search

### DIFF
--- a/apps/web/core/hooks/use-global-search-space-ids.ts
+++ b/apps/web/core/hooks/use-global-search-space-ids.ts
@@ -1,0 +1,26 @@
+'use client';
+
+import * as React from 'react';
+
+import { ROOT_SPACE } from '~/core/constants';
+
+import { usePersonalSpaceId } from './use-personal-space-id';
+import { useSpaceId } from './use-space-id';
+
+/**
+ * Space ids that are always passed as `additional_space_ids` to the REST
+ * /search endpoint: root, the user's current space (if any), and the user's
+ * personal space (if any). Use this anywhere the REST search api is called
+ * from a client component / hook so results from these spaces surface
+ * regardless of the active scope.
+ */
+export function useGlobalSearchSpaceIds(): string[] {
+  const currentSpaceId = useSpaceId();
+  const { personalSpaceId } = usePersonalSpaceId();
+
+  return React.useMemo(
+    () =>
+      Array.from(new Set([ROOT_SPACE, currentSpaceId, personalSpaceId].filter((id): id is string => Boolean(id)))),
+    [currentSpaceId, personalSpaceId]
+  );
+}

--- a/apps/web/core/hooks/use-search.ts
+++ b/apps/web/core/hooks/use-search.ts
@@ -15,6 +15,7 @@ import { mergeSearchResult } from '../database/result';
 import { E } from '../sync/orm';
 import { useSyncEngine } from '../sync/use-sync-engine';
 import { useDebouncedValue } from './use-debounced-value';
+import { useGlobalSearchSpaceIds } from './use-global-search-space-ids';
 
 interface SearchOptions {
   filterByTypes?: string[];
@@ -63,6 +64,8 @@ export function useSearch({
   const [query, setQuery] = React.useState<string>(initialQuery ?? '');
   const debouncedQuery = useDebouncedValue(query);
 
+  const additionalSpaceIds = useGlobalSearchSpaceIds();
+
   const maybeEntityId = debouncedQuery.trim();
 
   const searchBlocked =
@@ -78,6 +81,7 @@ export function useSearch({
       filterBySpace,
       Boolean(waitForFilterTypes),
       Boolean(restrictToFilterTypes),
+      additionalSpaceIds?.join('-'),
     ],
     queryFn: async () => {
       if (query.length === 0) return [];
@@ -147,6 +151,7 @@ export function useSearch({
               },
               first: 10,
               skip: 0,
+              additionalSpaceIds,
             }),
           catch: error => {
             console.error('error', error);

--- a/apps/web/core/hooks/use-search.ts
+++ b/apps/web/core/hooks/use-search.ts
@@ -81,7 +81,7 @@ export function useSearch({
       filterBySpace,
       Boolean(waitForFilterTypes),
       Boolean(restrictToFilterTypes),
-      additionalSpaceIds?.join('-'),
+      additionalSpaceIds,
     ],
     queryFn: async () => {
       if (query.length === 0) return [];

--- a/apps/web/core/io/queries.test.ts
+++ b/apps/web/core/io/queries.test.ts
@@ -1,6 +1,62 @@
 import { describe, expect, it } from 'vitest';
 
-import { groupRestResults } from './queries';
+import { buildSearchPath, groupRestResults } from './queries';
+
+describe('buildSearchPath', () => {
+  const ROOT = 'a19c345ab9866679b001d7d2138d88a1';
+  const CURRENT = 'c9f267dcb0d270718c2a3c45a64afd32';
+  const PERSONAL = 'f3dab79cb5a3d9d1759656dd5361d1c6';
+
+  it('builds a minimal global path with default limit/offset', () => {
+    expect(buildSearchPath({ query: 'football' })).toBe('/search?query=football&limit=10&offset=0');
+  });
+
+  it('omits additional_space_ids when the array is empty or undefined', () => {
+    expect(buildSearchPath({ query: 'football', additionalSpaceIds: [] })).toBe(
+      '/search?query=football&limit=10&offset=0'
+    );
+    expect(buildSearchPath({ query: 'football', additionalSpaceIds: undefined })).toBe(
+      '/search?query=football&limit=10&offset=0'
+    );
+  });
+
+  it('serializes additional_space_ids as a comma-joined list of hyphenated UUIDs', () => {
+    const path = buildSearchPath({
+      query: 'baseball',
+      additionalSpaceIds: [ROOT, CURRENT, PERSONAL],
+    });
+
+    // URLSearchParams encodes commas as %2C.
+    expect(path).toBe(
+      '/search?query=baseball&limit=10&offset=0&additional_space_ids=' +
+        'a19c345a-b986-6679-b001-d7d2138d88a1%2Cc9f267dc-b0d2-7071-8c2a-3c45a64afd32%2Cf3dab79c-b5a3-d9d1-7596-56dd5361d1c6'
+    );
+  });
+
+  it('passes through ids that already contain hyphens', () => {
+    const alreadyHyphenated = 'a19c345a-b986-6679-b001-d7d2138d88a1';
+    const path = buildSearchPath({ query: 'q', additionalSpaceIds: [alreadyHyphenated] });
+    expect(path).toContain('additional_space_ids=a19c345a-b986-6679-b001-d7d2138d88a1');
+  });
+
+  it('combines additional_space_ids with single-space scope and type_ids', () => {
+    const path = buildSearchPath({
+      query: 'q',
+      spaceId: ROOT,
+      typeIds: [CURRENT],
+      additionalSpaceIds: [PERSONAL],
+      limit: 25,
+      offset: 50,
+    });
+
+    expect(path).toBe(
+      '/search?query=q&limit=25&offset=50' +
+        '&scope=SPACE_SINGLE&space_id=a19c345a-b986-6679-b001-d7d2138d88a1' +
+        '&type_ids=c9f267dc-b0d2-7071-8c2a-3c45a64afd32' +
+        '&additional_space_ids=f3dab79c-b5a3-d9d1-7596-56dd5361d1c6'
+    );
+  });
+});
 
 describe('groupRestResults', () => {
   it('groups nested REST search rows into search results', () => {

--- a/apps/web/core/io/queries.ts
+++ b/apps/web/core/io/queries.ts
@@ -632,7 +632,7 @@ export type SearchResultsPage = {
   rawCount: number;
 };
 
-export function getResultsPage(args: ResultsArgs, signal?: AbortController['signal']) {
+export function buildSearchPath(args: ResultsArgs): string {
   const params = new URLSearchParams();
   params.set('query', args.query);
   params.set('limit', String(args.limit ?? 10));
@@ -653,10 +653,14 @@ export function getResultsPage(args: ResultsArgs, signal?: AbortController['sign
     params.set('additional_space_ids', args.additionalSpaceIds.map(toUuid).join(','));
   }
 
+  return `/search?${params.toString()}`;
+}
+
+export function getResultsPage(args: ResultsArgs, signal?: AbortController['signal']) {
   return Effect.map(
     restFetch<RestSearchResponse>({
       endpoint: getConfig().api,
-      path: `/search?${params.toString()}`,
+      path: buildSearchPath(args),
       signal,
     }),
     (response): SearchResultsPage => {

--- a/apps/web/core/io/queries.ts
+++ b/apps/web/core/io/queries.ts
@@ -484,6 +484,7 @@ interface ResultsArgs {
   typeIds?: string[];
   limit?: number;
   offset?: number;
+  additionalSpaceIds?: string[];
 }
 
 /**
@@ -646,6 +647,10 @@ export function getResultsPage(args: ResultsArgs, signal?: AbortController['sign
   if (args.typeIds?.length) {
     // REST endpoint expects UUIDs with hyphens
     params.set('type_ids', args.typeIds.map(toUuid).join(','));
+  }
+
+  if (args.additionalSpaceIds?.length) {
+    params.set('additional_space_ids', args.additionalSpaceIds.map(toUuid).join(','));
   }
 
   return Effect.map(

--- a/apps/web/core/sync/orm.ts
+++ b/apps/web/core/sync/orm.ts
@@ -324,6 +324,7 @@ export class E {
     where: WhereCondition;
     first: number;
     skip: number;
+    additionalSpaceIds?: string[];
   }): Promise<SearchResult[]> {
     const page = await this.findFuzzyPage(args);
     return page.results;
@@ -343,6 +344,7 @@ export class E {
     first,
     skip,
     signal,
+    additionalSpaceIds,
   }: {
     store: GeoStore;
     cache: QueryClient;
@@ -350,6 +352,7 @@ export class E {
     first: number;
     skip: number;
     signal?: AbortController['signal'];
+    additionalSpaceIds?: string[];
   }): Promise<{ results: SearchResult[]; rawCount: number; total: number }> {
     // Empty string is intentional here: the REST /search endpoint accepts
     // an empty query and returns top-N globally ranked entities (optionally
@@ -361,7 +364,7 @@ export class E {
     const typeIdsFilter = where.types?.map(t => t.id?.equals).filter(t => t !== undefined) ?? [];
 
     const page = await cache.fetchQuery({
-      queryKey: ['network', 'entities', 'fuzzy', 'page', where, first, skip],
+      queryKey: ['network', 'entities', 'fuzzy', 'page', where, first, skip, additionalSpaceIds],
       queryFn: ({ signal: innerSignal }) =>
         Effect.runPromise(
           getResultsPage(
@@ -371,6 +374,7 @@ export class E {
               query: nameFilter,
               spaceId: spaceIdsFilter ? spaceIdsFilter : undefined,
               typeIds: typeIdsFilter,
+              additionalSpaceIds,
             },
             // Prefer the caller-supplied signal so React Query cancellation
             // on the hook side (query change, unmount) aborts the in-flight

--- a/apps/web/partials/blocks/table/table-block-filter-creation-prompt.tsx
+++ b/apps/web/partials/blocks/table/table-block-filter-creation-prompt.tsx
@@ -1197,7 +1197,7 @@ function TableBlockEntityFilterInput({
       'table-block-filter-search',
       query,
       filterByTypes?.slice().sort().join(',') ?? '',
-      additionalSpaceIds.join(','),
+      additionalSpaceIds,
     ],
     enabled: focused && !searchBlocked,
     initialPageParam: 0,

--- a/apps/web/partials/blocks/table/table-block-filter-creation-prompt.tsx
+++ b/apps/web/partials/blocks/table/table-block-filter-creation-prompt.tsx
@@ -17,6 +17,7 @@ import { Source } from '~/core/blocks/data/source';
 import { useFilters } from '~/core/blocks/data/use-filters';
 import { useSource } from '~/core/blocks/data/use-source';
 import { useDebouncedValue } from '~/core/hooks/use-debounced-value';
+import { useGlobalSearchSpaceIds } from '~/core/hooks/use-global-search-space-ids';
 import { searchResultMatchesAllowedTypes } from '~/core/hooks/use-search';
 import { useSpacesQuery } from '~/core/hooks/use-spaces-query';
 import { getSpacesWhereMember } from '~/core/io/queries';
@@ -1175,6 +1176,7 @@ function TableBlockEntityFilterInput({
 
   const [rawQuery, setRawQuery] = React.useState('');
   const query = useDebouncedValue(rawQuery);
+  const additionalSpaceIds = useGlobalSearchSpaceIds();
 
   const searchBlocked =
     (waitForFilterTypes || restrictSearchToTypes) && !filterByTypes?.length;
@@ -1195,6 +1197,7 @@ function TableBlockEntityFilterInput({
       'table-block-filter-search',
       query,
       filterByTypes?.slice().sort().join(',') ?? '',
+      additionalSpaceIds.join(','),
     ],
     enabled: focused && !searchBlocked,
     initialPageParam: 0,
@@ -1218,6 +1221,7 @@ function TableBlockEntityFilterInput({
         first: FILTER_DROPDOWN_PAGE_SIZE,
         skip: pageParam,
         signal,
+        additionalSpaceIds,
       });
       return { rows: results, offset: pageParam, rawCount, total };
     },

--- a/apps/web/partials/import/use-auto-map-columns.ts
+++ b/apps/web/partials/import/use-auto-map-columns.ts
@@ -7,6 +7,7 @@ import { useCallback, useState } from 'react';
 import { Effect } from 'effect';
 import { useAtom, useAtomValue } from 'jotai';
 
+import { useGlobalSearchSpaceIds } from '~/core/hooks/use-global-search-space-ids';
 import { getProperty, getResults } from '~/core/io/queries';
 import { useSyncEngine } from '~/core/sync/use-sync-engine';
 import { Property } from '~/core/types';
@@ -29,6 +30,7 @@ export function useAutoMapColumns(spaceId: string) {
   const [columnMapping, setColumnMapping] = useAtom(columnMappingAtom);
   const [, setExtraProperties] = useAtom(extraPropertiesAtom);
   const { store } = useSyncEngine();
+  const additionalSpaceIds = useGlobalSearchSpaceIds();
   const [isAutoMapping, setIsAutoMapping] = useState(false);
 
   const runWithConcurrency = useCallback(async <T>(tasks: Array<() => Promise<T>>, concurrency: number) => {
@@ -82,6 +84,7 @@ export function useAutoMapColumns(spaceId: string) {
               getResults({
                 query: headerName,
                 typeIds: [SystemIds.PROPERTY],
+                additionalSpaceIds,
               })
             );
 
@@ -142,7 +145,16 @@ export function useAutoMapColumns(spaceId: string) {
     } finally {
       setIsAutoMapping(false);
     }
-  }, [headers, typesColumnIndex, columnMapping, store, setColumnMapping, setExtraProperties, runWithConcurrency]);
+  }, [
+    headers,
+    typesColumnIndex,
+    columnMapping,
+    store,
+    additionalSpaceIds,
+    setColumnMapping,
+    setExtraProperties,
+    runWithConcurrency,
+  ]);
 
   return { autoMap, isAutoMapping };
 }


### PR DESCRIPTION
## Summary
- Adds an `additional_space_ids` query parameter to the REST `/search` endpoint when called from the **global search dialog and the autocompletes/pickers that share the `useSearch` hook** (entity pickers, space pickers, find-entity, number-options dropdown, etc.), plus the **table-block entity filter dropdown** and the **CSV-import auto-mapper**.
- The set of ids is the root space, the user's current space (if any), and the user's personal space (if any), deduped. Computed once in the new [`useGlobalSearchSpaceIds`](apps/web/core/hooks/use-global-search-space-ids.ts) hook.
- UUID searches are unaffected — they continue to bypass `/search` and resolve directly through `mergeSearchResult` against the local store.

## Not in scope
A few client-side `E.findFuzzy` call sites still bypass `useSearch` and were intentionally left as-is: [`use-place-search`](apps/web/core/hooks/use-place-search.ts), [`use-spaces-query`](apps/web/core/hooks/use-spaces-query.ts), [`onboarding/dialog`](apps/web/partials/onboarding/dialog.tsx). They can be updated in a follow-up if we want them to share the same surfacing behavior. Server-side API routes under `app/api/chat/tools/...` also call `/search` directly but have no user/session context, so they're out of scope.

## Test plan
- [ ] Open the global search dialog inside a non-root space → request includes `additional_space_ids=<root>,<current>,<personal>` (deduped, hyphenated UUIDs).
- [ ] Sign out and search → request still includes root + current.
- [ ] Use an entity-page relation autocomplete (e.g. `select-entity` / `find-entity`) → request now includes the same three space ids.
- [ ] Open a table block filter dropdown and type → request includes `additional_space_ids` and pagination still works.
- [ ] Run the CSV import auto-map step → property-name lookup carries the new param.
- [ ] Type a UUID into global search → no `/search` call fires (direct entity lookup path).
- [x] `bun x vitest run core/io/queries.test.ts` passes — covers `additional_space_ids` serialization and `toUuid` hyphenation.