### PR TITLE
fix: bounties panel viewport-bound; transforming Publish button

### DIFF
--- a/apps/web/partials/active-proposal/proposal-bounty-links.tsx
+++ b/apps/web/partials/active-proposal/proposal-bounty-links.tsx
@@ -616,31 +616,42 @@ export function ProposalBountyHeadButton() {
   // Non-authors only see the pill when there are linked bounties to view.
   if (!isAuthor && n === 0) return null;
 
+  const showPublish = isAuthor && hasUnsaved;
+
   return (
     <>
-      <button
-        type="button"
-        onClick={togglePanel}
-        className={cx(
-          'inline-flex h-6 shrink-0 items-center gap-1.5 rounded border px-1.5 text-metadata leading-none text-text transition-colors',
-          'border-grey-02 bg-white hover:border-text'
+      <div className="inline-flex items-center">
+        <button
+          type="button"
+          onClick={togglePanel}
+          className={cx(
+            'inline-flex h-6 shrink-0 items-center gap-1.5 rounded border px-1.5 text-metadata leading-none text-text transition-colors',
+            'border-grey-02 bg-white hover:border-text',
+            showPublish && 'rounded-r-none border-r-0'
+          )}
+          title="Bounties"
+          aria-expanded={isPanelOpen}
+        >
+          <Gem color="purple" />
+          <span>{isAuthor && n === 0 ? 'Link to bounty' : String(n)}</span>
+        </button>
+        {showPublish && (
+          <Button
+            variant="primary"
+            small
+            onClick={onSave}
+            disabled={isSaving || !smartAccountReady}
+            className="rounded-l-none"
+          >
+            <Pending isPending={isSaving}>
+              <span className="inline-flex items-center gap-1.5">
+                <Gem color="white" strokeColor="#3963FE" />
+                Publish
+              </span>
+            </Pending>
+          </Button>
         )}
-        title="Bounties"
-        aria-expanded={isPanelOpen}
-      >
-        <Gem color="purple" />
-        <span>{isAuthor && n === 0 ? 'Link to bounty' : String(n)}</span>
-      </button>
-      {isAuthor && hasUnsaved && (
-        <Button variant="primary" small onClick={onSave} disabled={isSaving || !smartAccountReady}>
-          <Pending isPending={isSaving}>
-            <span className="inline-flex items-center gap-1.5">
-              <Gem color="white" strokeColor="#3963FE" />
-              Publish
-            </span>
-          </Pending>
-        </Button>
-      )}
+      </div>
       <span aria-hidden className="h-4 w-px shrink-0 self-center bg-grey-02 last:hidden" />
     </>
   );

--- a/apps/web/partials/active-proposal/proposal-bounty-links.tsx
+++ b/apps/web/partials/active-proposal/proposal-bounty-links.tsx
@@ -616,18 +616,24 @@ export function ProposalBountyHeadButton() {
   // Non-authors only see the pill when there are linked bounties to view.
   if (!isAuthor && n === 0) return null;
 
-  const showPublish = isAuthor && hasUnsaved;
-
   return (
     <>
-      <div className="inline-flex items-center">
+      {isAuthor && hasUnsaved ? (
+        <Button variant="primary" small onClick={onSave} disabled={isSaving || !smartAccountReady}>
+          <Pending isPending={isSaving}>
+            <span className="inline-flex items-center gap-1.5">
+              <Gem color="white" strokeColor="#3963FE" />
+              Publish
+            </span>
+          </Pending>
+        </Button>
+      ) : (
         <button
           type="button"
           onClick={togglePanel}
           className={cx(
             'inline-flex h-6 shrink-0 items-center gap-1.5 rounded border px-1.5 text-metadata leading-none text-text transition-colors',
-            'border-grey-02 bg-white hover:border-text',
-            showPublish && 'rounded-r-none border-r-0'
+            'border-grey-02 bg-white hover:border-text'
           )}
           title="Bounties"
           aria-expanded={isPanelOpen}
@@ -635,23 +641,7 @@ export function ProposalBountyHeadButton() {
           <Gem color="purple" />
           <span>{isAuthor && n === 0 ? 'Link to bounty' : String(n)}</span>
         </button>
-        {showPublish && (
-          <Button
-            variant="primary"
-            small
-            onClick={onSave}
-            disabled={isSaving || !smartAccountReady}
-            className="rounded-l-none"
-          >
-            <Pending isPending={isSaving}>
-              <span className="inline-flex items-center gap-1.5">
-                <Gem color="white" strokeColor="#3963FE" />
-                Publish
-              </span>
-            </Pending>
-          </Button>
-        )}
-      </div>
+      )}
       <span aria-hidden className="h-4 w-px shrink-0 self-center bg-grey-02 last:hidden" />
     </>
   );
@@ -682,10 +672,10 @@ export function ProposalBountyPanel() {
 
   return (
     <aside
-      className="flex w-full max-w-[400px] shrink-0 flex-col self-stretch"
+      className="sticky top-[44px] flex max-h-[calc(100vh-44px)] w-full max-w-[400px] shrink-0 flex-col self-start"
       aria-label="Bounties"
     >
-      <div className="flex-1 overflow-hidden rounded-lg border border-grey-02 bg-white">
+      <div className="flex min-h-0 flex-1 flex-col overflow-y-auto rounded-lg border border-grey-02 bg-white">
         {!isAuthor && (
           <>
             <div className="px-5 py-4">

--- a/apps/web/partials/active-proposal/proposal-bounty-links.tsx
+++ b/apps/web/partials/active-proposal/proposal-bounty-links.tsx
@@ -672,7 +672,7 @@ export function ProposalBountyPanel() {
 
   return (
     <aside
-      className="sticky top-[44px] flex max-h-[calc(100vh-44px)] w-full max-w-[400px] shrink-0 flex-col self-start"
+      className="sticky top-[52px] flex h-[calc(100vh-60px)] w-full max-w-[400px] shrink-0 flex-col self-start"
       aria-label="Bounties"
     >
       <div className="flex min-h-0 flex-1 flex-col overflow-y-auto rounded-lg border border-grey-02 bg-white">


### PR DESCRIPTION
## Summary
- **Bounties panel** is now sticky to the top of the proposal nav and capped at `100vh - 44px`, so it stops stretching to match the diff column. The inner card scrolls vertically when its content exceeds that height.
- **Head button** transforms instead of pairing: the Bounties pill toggle becomes the Publish button when there are unsaved drafts. They are never visible at the same time.

Follow-up to #1712 — both behaviors regressed there.

## Test plan
- [ ] Open a long proposal with a tall diff. Verify the bounties panel stays anchored under the nav and only extends to the bottom of the viewport.
- [ ] With overflowing panel content, scrolling happens inside the panel, not the page.
- [ ] As the author, tick a bounty: the toggle pill is replaced by Publish (no two buttons side by side).
- [ ] Untick the draft: Publish disappears; the pill returns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)