### PR TITLE
feat: show entity description inline

### DIFF
--- a/apps/web/app/space/(entity)/[id]/[entityId]/entity-page-header.tsx
+++ b/apps/web/app/space/(entity)/[id]/[entityId]/entity-page-header.tsx
@@ -4,6 +4,7 @@ import { useRelationEntityRelations } from '~/core/state/entity-page-store/entit
 import type { Relation } from '~/core/types';
 
 import { EditableHeading } from '~/partials/entity-page/editable-entity-header';
+import { EntityPageDescription } from '~/partials/entity-page/entity-page-description';
 import { EntityPageMetadataHeader } from '~/partials/entity-page/entity-page-metadata-header';
 import { EntityPageRelations } from '~/partials/entity-page/entity-page-relations';
 
@@ -29,6 +30,7 @@ export function EntityPageHeader({
     <div className="space-y-2">
       <EntityPageRelations entityId={entityId} spaceId={spaceId} serverRelations={serverRelations} />
       {showHeading && <EditableHeading spaceId={spaceId} entityId={entityId} />}
+      {showHeading && !isRelationPage && <EntityPageDescription entityId={entityId} spaceId={spaceId} />}
       {showHeader && !isRelationPage && <EntityPageMetadataHeader id={entityId} spaceId={spaceId} isVoteable />}
     </div>
   );

--- a/apps/web/partials/entity-page/editable-entity-page.tsx
+++ b/apps/web/partials/entity-page/editable-entity-page.tsx
@@ -1048,6 +1048,7 @@ async function applyTemplate(templateOptions: {
 // System properties that are editable elsewhere
 const SYSTEM_PROPERTIES = [
   SystemIds.NAME_PROPERTY,
+  SystemIds.DESCRIPTION_PROPERTY,
   SystemIds.TYPES_PROPERTY,
   SystemIds.COVER_PROPERTY,
   SystemIds.BLOCKS,

--- a/apps/web/partials/entity-page/entity-page-description.tsx
+++ b/apps/web/partials/entity-page/entity-page-description.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import { SystemIds } from '@geoprotocol/geo-sdk/lite';
+
+import { ID } from '~/core/id';
+import { useUserIsEditing } from '~/core/hooks/use-user-is-editing';
+import { useMutate } from '~/core/sync/use-mutate';
+import { useValue } from '~/core/sync/use-store';
+
+import { PageStringField } from '~/design-system/editable-fields/editable-fields';
+import { Text } from '~/design-system/text';
+
+type EntityPageDescriptionProps = {
+  entityId: string;
+  spaceId: string;
+};
+
+export function EntityPageDescription({ entityId, spaceId }: EntityPageDescriptionProps) {
+  const isEditing = useUserIsEditing(spaceId);
+  const { storage } = useMutate();
+
+  const descriptionValue = useValue({
+    selector: v =>
+      v.entity.id === entityId &&
+      v.spaceId === spaceId &&
+      v.property.id === SystemIds.DESCRIPTION_PROPERTY &&
+      !v.isDeleted,
+  });
+
+  const description = descriptionValue?.value ?? '';
+
+  const onDescriptionChange = (value: string) => {
+    if (value.length === 0) {
+      if (descriptionValue) {
+        storage.values.delete(descriptionValue);
+      }
+      return;
+    }
+
+    if (!descriptionValue) {
+      storage.values.set({
+        id: ID.createValueId({
+          entityId,
+          propertyId: SystemIds.DESCRIPTION_PROPERTY,
+          spaceId,
+        }),
+        spaceId,
+        entity: {
+          id: entityId,
+          name: null,
+        },
+        property: {
+          id: SystemIds.DESCRIPTION_PROPERTY,
+          name: 'Description',
+          dataType: 'TEXT',
+        },
+        value,
+      });
+      return;
+    }
+
+    storage.values.update(descriptionValue, draft => {
+      draft.value = value;
+      draft.property.dataType = 'TEXT';
+    });
+  };
+
+  if (isEditing) {
+    return (
+      <div className="min-w-0 text-text">
+        <PageStringField
+          variant="body"
+          placeholder="Add a description..."
+          value={description}
+          onChange={onDescriptionChange}
+        />
+      </div>
+    );
+  }
+
+  if (description.trim().length === 0) {
+    return null;
+  }
+
+  return (
+    <Text as="p" variant="body" className="min-w-0 max-w-full break-words">
+      {description}
+    </Text>
+  );
+}

--- a/apps/web/partials/entity-page/readable-entity-page.tsx
+++ b/apps/web/partials/entity-page/readable-entity-page.tsx
@@ -38,6 +38,7 @@ interface Props {
 const SKIPPED_PROPERTIES: string[] = [
   SystemIds.TYPES_PROPERTY,
   SystemIds.NAME_PROPERTY,
+  SystemIds.DESCRIPTION_PROPERTY,
   SystemIds.COVER_PROPERTY,
   ContentIds.AVATAR_PROPERTY,
   DATA_TYPE_PROPERTY,


### PR DESCRIPTION
## Summary
- show the Description system property inline beneath entity names
- make the inline description editable in edit mode and hidden when empty in browse mode
- remove Description from the lower readable/editable property panels

## Verification
- mise exec -- bun run lint (passes with existing warnings)
- mise exec -- bun test (Bun native runner fails on existing environment/runner issues: missing NEXT_PUBLIC_PRIVY_APP_ID, DOM globals, and unrelated existing tests)
- mise exec -- bun run test (Vitest: 45 files / 585 tests pass; one existing workspace package resolution failure for @geogenesis/auth/account in leaf-node-serialization.test.ts)
- mise exec -- bun run build (not required per request; failed during page data collection because NEXT_PUBLIC_PRIVY_APP_ID is not set)