### PR TITLE
fix(sidebar): rename Documentation to Docs

### DIFF
--- a/apps/web/partials/browse-sidebar/browse-sidebar.tsx
+++ b/apps/web/partials/browse-sidebar/browse-sidebar.tsx
@@ -162,7 +162,7 @@ function BrowseNavPrimaryLinks({ personalSpaceId }: { personalSpaceId: string | 
       </Link>
       <Link href={docHref} className={isDoc ? navLinkActive : navLinkIdle}>
         <BrowseNavIconSwap idleSrc={BROWSE_NAV_ICON.docs} activeSrc={BROWSE_NAV_ICON.docsFilled} isActive={isDoc} />
-        <span>Documentation</span>
+        <span>Docs</span>
       </Link>
     </>
   );


### PR DESCRIPTION
Renames the sidebar nav link label from 'Documentation' to 'Docs'.