### PR TITLE
fix(entity-page): ellipsis before More toggle, bump description→types gap to 20px

### DIFF
--- a/apps/web/partials/entity-page/entity-page-inline-description.tsx
+++ b/apps/web/partials/entity-page/entity-page-inline-description.tsx
@@ -122,12 +122,18 @@ function TruncatedDescription({ text }: { text: string }) {
   const buttonFocus =
     'focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-text';
 
+  // Reserve room at the right of the last line so the auto line-clamp
+  // ellipsis ("…") lands inline with the text and the More button sits in
+  // the reserved padding to the right of it.
+  const togglePadding = 'pr-12';
+  const buttonStyle = `cursor-pointer text-grey-04 hover:underline ${buttonFocus}`;
+
   return (
     <div className="relative">
       <p
         className={[
           'text-body wrap-break-word text-text',
-          clamp ? CLAMP_CLASS : '',
+          clamp ? `${CLAMP_CLASS} ${togglePadding}` : '',
         ]
           .filter(Boolean)
           .join(' ')}
@@ -140,32 +146,27 @@ function TruncatedDescription({ text }: { text: string }) {
               type="button"
               onClick={() => setExpanded(false)}
               aria-expanded={true}
-              className={`cursor-pointer underline ${buttonFocus}`}
+              className={buttonStyle}
             >
               Less
             </button>
           </>
         )}
-        {showToggle && !expanded && (
-          <button
-            type="button"
-            onClick={() => setExpanded(true)}
-            aria-expanded={false}
-            className={`absolute bottom-0 right-0 cursor-pointer bg-white pl-6 ${buttonFocus}`}
-            style={{
-              backgroundImage:
-                'linear-gradient(to right, rgba(255,255,255,0), #fff 1.25rem)',
-            }}
-          >
-            <span aria-hidden="true">…&nbsp;</span>
-            <span className="underline">More</span>
-          </button>
-        )}
       </p>
+      {showToggle && !expanded && (
+        <button
+          type="button"
+          onClick={() => setExpanded(true)}
+          aria-expanded={false}
+          className={`absolute bottom-0 right-0 ${buttonStyle}`}
+        >
+          More
+        </button>
+      )}
       <p
         ref={measureRef}
         aria-hidden="true"
-        className="pointer-events-none invisible absolute inset-x-0 top-0 text-body wrap-break-word"
+        className="pointer-events-none invisible absolute inset-x-0 top-0 pr-12 text-body wrap-break-word"
       >
         {text}
       </p>

--- a/apps/web/partials/entity-page/entity-page-inline-description.tsx
+++ b/apps/web/partials/entity-page/entity-page-inline-description.tsx
@@ -125,7 +125,7 @@ function TruncatedDescription({ text }: { text: string }) {
   // Reserve room at the right of the last line so the auto line-clamp
   // ellipsis ("…") lands inline with the text and the More button sits in
   // the reserved padding to the right of it.
-  const togglePadding = 'pr-12';
+  const togglePadding = 'pr-11';
   // text-body so the More button matches the inline Less button's size —
   // buttons don't inherit font styles from their ancestors by default.
   const buttonStyle = `cursor-pointer text-body text-grey-04 hover:underline ${buttonFocus}`;
@@ -168,7 +168,7 @@ function TruncatedDescription({ text }: { text: string }) {
       <p
         ref={measureRef}
         aria-hidden="true"
-        className="pointer-events-none invisible absolute inset-x-0 top-0 pr-12 text-body wrap-break-word"
+        className="pointer-events-none invisible absolute inset-x-0 top-0 pr-11 text-body wrap-break-word"
       >
         {text}
       </p>

--- a/apps/web/partials/entity-page/entity-page-inline-description.tsx
+++ b/apps/web/partials/entity-page/entity-page-inline-description.tsx
@@ -126,7 +126,9 @@ function TruncatedDescription({ text }: { text: string }) {
   // ellipsis ("…") lands inline with the text and the More button sits in
   // the reserved padding to the right of it.
   const togglePadding = 'pr-12';
-  const buttonStyle = `cursor-pointer text-grey-04 hover:underline ${buttonFocus}`;
+  // text-body so the More button matches the inline Less button's size —
+  // buttons don't inherit font styles from their ancestors by default.
+  const buttonStyle = `cursor-pointer text-body text-grey-04 hover:underline ${buttonFocus}`;
 
   return (
     <div className="relative">

--- a/apps/web/partials/entity-page/entity-page-inline-description.tsx
+++ b/apps/web/partials/entity-page/entity-page-inline-description.tsx
@@ -130,12 +130,18 @@ function TruncatedDescription({ text }: { text: string }) {
   // buttons don't inherit font styles from their ancestors by default.
   const buttonStyle = `cursor-pointer text-body text-grey-04 hover:underline ${buttonFocus}`;
 
+  // Only reserve the toggle gutter once we know the text actually
+  // overflows — otherwise short descriptions get unnecessarily narrowed,
+  // which can flip the overflow check itself.
+  const reserveToggle = showToggle && clamp;
+
   return (
     <div className="relative">
       <p
         className={[
           'text-body wrap-break-word text-text',
-          clamp ? `${CLAMP_CLASS} ${togglePadding}` : '',
+          clamp ? CLAMP_CLASS : '',
+          reserveToggle ? togglePadding : '',
         ]
           .filter(Boolean)
           .join(' ')}
@@ -168,7 +174,7 @@ function TruncatedDescription({ text }: { text: string }) {
       <p
         ref={measureRef}
         aria-hidden="true"
-        className="pointer-events-none invisible absolute inset-x-0 top-0 pr-11 text-body wrap-break-word"
+        className="pointer-events-none invisible absolute inset-x-0 top-0 text-body wrap-break-word"
       >
         {text}
       </p>

--- a/apps/web/partials/entity-page/entity-page-inline-description.tsx
+++ b/apps/web/partials/entity-page/entity-page-inline-description.tsx
@@ -65,7 +65,7 @@ export function EntityPageInlineDescription({ entityId, spaceId }: { entityId: s
     };
 
     return (
-      <div className="-mt-3 mb-3 text-text">
+      <div className="-mt-3 mb-5 text-text">
         <PageStringField
           variant="body"
           placeholder="Add a description..."
@@ -82,7 +82,7 @@ export function EntityPageInlineDescription({ entityId, spaceId }: { entityId: s
   }
 
   return (
-    <div className="-mt-3 mb-3">
+    <div className="-mt-3 mb-5">
       <TruncatedDescription text={description} />
     </div>
   );
@@ -151,13 +151,14 @@ function TruncatedDescription({ text }: { text: string }) {
             type="button"
             onClick={() => setExpanded(true)}
             aria-expanded={false}
-            className={`absolute bottom-0 right-0 cursor-pointer bg-white pl-6 underline ${buttonFocus}`}
+            className={`absolute bottom-0 right-0 cursor-pointer bg-white pl-6 ${buttonFocus}`}
             style={{
               backgroundImage:
                 'linear-gradient(to right, rgba(255,255,255,0), #fff 1.25rem)',
             }}
           >
-            More
+            <span aria-hidden="true">…&nbsp;</span>
+            <span className="underline">More</span>
           </button>
         )}
       </p>


### PR DESCRIPTION
## Summary
Follow-up to #1736. Visual fixes for the inline entity description:

- **Truncation cue.** The auto line-clamp `…` was being painted under the absolutely positioned toggle, so it was never visible. Now reserve a small right gutter (`pr-11`) on the clamped paragraph so the browser's native ellipsis lands inline with the text, and place the `More` button in the reserved gutter to its right. Padding is only applied when overflow is actually detected, so short descriptions still use the full width.
- **Toggle styling.** `text-grey-04` (#606060, matches Figma) at body size, underline only on hover.
- **Description → types spacing.** Was 12px (`mb-3`), Figma calls for 20px → bumped to `mb-5`.

## Test plan
- [ ] Open an entity with a long description in browse mode — third line ends with the native `…` directly followed by the `More` button (~one space gap).
- [ ] Click `More` → expands; inline `Less` at end of last line collapses back. Both toggles render at the same body-text size.
- [ ] Open an entity with a *short* description — no toggle, paragraph uses the full width (no extra right padding).
- [ ] Edit mode: description editor still has 20px breathing room above the types row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)