### PR TITLE
fix(entity-routing): harden hidden property routing fallback

### DIFF
--- a/apps/web/core/io/dto/entities.test.ts
+++ b/apps/web/core/io/dto/entities.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { SCORE_SYSTEM_PROPERTY } from '~/core/constants';
+
+import { RemoteEntity } from '../schema';
+import { EntityDtoLive } from './entities';
+
+vi.mock('~/core/utils/property/properties', () => ({
+  getDataTypeFromEntityId: () => 'TEXT',
+}));
+
+const entityId = '11111111111111111111111111111111';
+const hiddenSpaceId = '22222222222222222222222222222222';
+const nullPropertySpaceId = '33333333333333333333333333333333';
+const nullPropertyIdSpaceId = '44444444444444444444444444444444';
+
+function entity(overrides: Partial<RemoteEntity> = {}): RemoteEntity {
+  return {
+    id: entityId,
+    name: null,
+    description: null,
+    types: [],
+    spaceIds: [hiddenSpaceId, nullPropertySpaceId, nullPropertyIdSpaceId],
+    valuesList: [],
+    relationsList: [],
+    ...overrides,
+  };
+}
+
+describe('EntityDtoLive', () => {
+  it('treats unresolved routing value property metadata as real content', () => {
+    const remoteEntity = entity({
+      allValuesList: [
+        {
+          spaceId: hiddenSpaceId,
+          property: {
+            id: SCORE_SYSTEM_PROPERTY,
+          },
+        },
+        {
+          spaceId: nullPropertySpaceId,
+          property: null,
+        },
+        {
+          spaceId: nullPropertyIdSpaceId,
+          property: {
+            id: null,
+          },
+        },
+      ],
+      allRelationsList: [],
+    });
+
+    expect(EntityDtoLive(remoteEntity).spaces).toEqual([nullPropertySpaceId, nullPropertyIdSpaceId]);
+  });
+});

--- a/apps/web/core/io/dto/entities.ts
+++ b/apps/web/core/io/dto/entities.ts
@@ -22,7 +22,7 @@ export function EntityDtoLive(remoteEntity: RemoteEntity): Entity {
   if (remoteEntity.allValuesList && remoteEntity.allRelationsList) {
     const spacesWithRealContent = new Set<string>();
     for (const v of remoteEntity.allValuesList) {
-      if (v.property?.id && !HIDDEN_PROPERTIES.has(v.property.id)) spacesWithRealContent.add(v.spaceId);
+      if (!v.property?.id || !HIDDEN_PROPERTIES.has(v.property.id)) spacesWithRealContent.add(v.spaceId);
     }
     for (const r of remoteEntity.allRelationsList) {
       spacesWithRealContent.add(r.spaceId);

--- a/apps/web/core/utils/entity/entities.test.ts
+++ b/apps/web/core/utils/entity/entities.test.ts
@@ -2,7 +2,7 @@ import { SystemIds } from '@geoprotocol/geo-sdk';
 
 import { describe, expect, it } from 'vitest';
 
-import { HIDDEN_PROPERTIES } from '~/core/constants';
+import { SCORE_SYSTEM_PROPERTY } from '~/core/constants';
 import { Relation, Value } from '~/core/types';
 
 import { description, descriptionTriple, name, nameValue, spaces } from './entities';
@@ -81,8 +81,6 @@ describe('Entity name helpers', () => {
 });
 
 describe('Entity space helpers', () => {
-  const hiddenPropertyId = [...HIDDEN_PROPERTIES][0];
-
   const value = (propertyId: string, spaceId: string): Value =>
     ({
       id: `${propertyId}-${spaceId}`,
@@ -100,17 +98,17 @@ describe('Entity space helpers', () => {
     }) as Value;
 
   it('ignores spaces that only contribute hidden properties when real content exists elsewhere', () => {
-    expect(spaces([value(hiddenPropertyId, 'hidden-space'), value(SystemIds.NAME_PROPERTY, 'real-space')])).toEqual([
-      'real-space',
-    ]);
+    expect(
+      spaces([value(SCORE_SYSTEM_PROPERTY, 'hidden-space'), value(SystemIds.NAME_PROPERTY, 'real-space')])
+    ).toEqual(['real-space']);
   });
 
   it('keeps hidden-only spaces when there is no real content anywhere', () => {
     expect(
       spaces([
-        value(hiddenPropertyId, 'hidden-space-b'),
-        value(hiddenPropertyId, 'hidden-space-a'),
-        value(hiddenPropertyId, 'hidden-space-b'),
+        value(SCORE_SYSTEM_PROPERTY, 'hidden-space-b'),
+        value(SCORE_SYSTEM_PROPERTY, 'hidden-space-a'),
+        value(SCORE_SYSTEM_PROPERTY, 'hidden-space-b'),
       ])
     ).toEqual(['hidden-space-b', 'hidden-space-a']);
   });
@@ -120,6 +118,6 @@ describe('Entity space helpers', () => {
       spaceId: 'relation-space',
     } as Relation;
 
-    expect(spaces([value(hiddenPropertyId, 'hidden-space')], [relation])).toEqual(['relation-space']);
+    expect(spaces([value(SCORE_SYSTEM_PROPERTY, 'hidden-space')], [relation])).toEqual(['relation-space']);
   });
 });

--- a/apps/web/core/utils/entity/entities.test.ts
+++ b/apps/web/core/utils/entity/entities.test.ts
@@ -2,7 +2,7 @@ import { SystemIds } from '@geoprotocol/geo-sdk';
 
 import { describe, expect, it } from 'vitest';
 
-import { SCORE_SYSTEM_PROPERTY } from '~/core/constants';
+import { HIDDEN_PROPERTIES, SCORE_SYSTEM_PROPERTY } from '~/core/constants';
 import { Relation, Value } from '~/core/types';
 
 import { description, descriptionTriple, name, nameValue, spaces } from './entities';
@@ -81,6 +81,10 @@ describe('Entity name helpers', () => {
 });
 
 describe('Entity space helpers', () => {
+  it('treats score as a hidden property', () => {
+    expect(HIDDEN_PROPERTIES.has(SCORE_SYSTEM_PROPERTY)).toBe(true);
+  });
+
   const value = (propertyId: string, spaceId: string): Value =>
     ({
       id: `${propertyId}-${spaceId}`,


### PR DESCRIPTION
## Summary
- Treat unresolved routing projection property metadata as real content so we do not drop a space unless we can prove the value is hidden-only.
- Make the entity space helper tests refer to SCORE_SYSTEM_PROPERTY explicitly instead of relying on hidden-property Set iteration order.

## Notes
- I did not add allValuesList/allRelationsList back to list-style entity queries. That would address score-only routing in more surfaces, but it also reintroduces the unbounded payload/cost concern Copilot flagged. A better follow-up for that is a backend/API field that returns distinct routing/contributing space IDs.

## Testing
- git diff --check
- Attempted: bun test apps/web/core/utils/entity/entities.test.ts, but the fresh /private/tmp worktree has no linked node_modules and could not resolve @geoprotocol/geo-sdk.