### PR TITLE
fix(entity-page): show inline description on Person entity pages

### DIFF
--- a/apps/web/app/space/(entity)/[id]/[entityId]/layout.tsx
+++ b/apps/web/app/space/(entity)/[id]/[entityId]/layout.tsx
@@ -20,6 +20,7 @@ import { Spacer } from '~/design-system/spacer';
 import { EditableHeading } from '~/partials/entity-page/editable-entity-header';
 import { EntityPageContentContainer } from '~/partials/entity-page/entity-page-content-container';
 import { EntityPageCover } from '~/partials/entity-page/entity-page-cover';
+import { EntityPageInlineDescription } from '~/partials/entity-page/entity-page-inline-description';
 import { EntityPageMetadataHeader } from '~/partials/entity-page/entity-page-metadata-header';
 import { EntityTabs } from '~/partials/entity-page/entity-tabs';
 
@@ -84,6 +85,7 @@ export default async function ProfileLayout(props: Props) {
         <EntityPageContentContainer>
           <div className="space-y-2">
             <EditableHeading spaceId={spaceId} entityId={entityId} />
+            <EntityPageInlineDescription entityId={entityId} spaceId={spaceId} />
             <EntityPageMetadataHeader id={profile.id} spaceId={spaceId} />
           </div>
 


### PR DESCRIPTION
## Summary
- Follow-up to #1736 — Person-typed entities weren't getting the inline description in the header.

## Root cause
`apps/web/app/space/(entity)/[id]/[entityId]/layout.tsx` has a dedicated branch for Person entities (when `typeIds.includes(SystemIds.PERSON_TYPE)`) that renders `EditableHeading` + `EntityPageMetadataHeader` directly inside its own provider stack, instead of going through `EntityPageHeader`. The inline description was wired into `EntityPageHeader` and the space layout, so the Person flow was never picked up.

## Fix
Slot `EntityPageInlineDescription` between `EditableHeading` and `EntityPageMetadataHeader` in the Person layout branch — same position and props as on regular entity pages and the space homepage.

## Test plan
- [ ] Open a Person entity that has a description; confirm it renders inline under the name in browse mode.
- [ ] Toggle into edit mode; confirm the textarea with the "Add a description..." placeholder appears under the name.
- [ ] Confirm description still does not double-render in the properties panel below.
- [ ] Open a non-Person entity and the space homepage; confirm no regression.