### PR TITLE
feat(data-blocks): per-property AND/OR mode + in-operator collapse

### DIFF
--- a/apps/web/app/api/chat/tools/write/data-block.test.ts
+++ b/apps/web/app/api/chat/tools/write/data-block.test.ts
@@ -176,7 +176,7 @@ describe('setDataBlockFilters', () => {
         kind: 'setDataBlockFilters',
         blockId: BLOCK,
         spaceId: SPACE,
-        mode: 'AND',
+        modesByColumn: {},
         filters: [
           expect.objectContaining({
             columnId: SystemIds.TYPES_PROPERTY,

--- a/apps/web/app/api/chat/tools/write/data-block.ts
+++ b/apps/web/app/api/chat/tools/write/data-block.ts
@@ -51,7 +51,15 @@ type SetDataBlockFiltersInput = {
   parentEntityId: string;
   spaceId: string;
   filters: FilterInput[];
-  mode?: FilterMode;
+  /**
+   * Per-property mode keyed by columnId. Default for any missing column is
+   * `'OR'` — multiple values for the same property collapse into one
+   * `in`/`inInsensitive` clause. Pass `'AND'` for a column when the user
+   * wants intersection semantics (e.g. "tagged with both Sports and
+   * Politics"). Only relation-typed properties really need AND; values OR
+   * by default.
+   */
+  modesByColumn?: Record<string, FilterMode>;
 };
 
 export function buildSetDataBlockFiltersTool(context: WriteContext) {
@@ -63,14 +71,17 @@ Each filter is \`{ columnId, valueType, value }\`. Special columnIds:
 - Types filter: columnId = "${SystemIds.TYPES_PROPERTY}", valueType = "RELATION", value = a type entity id.
 Otherwise columnId is a property id.
 
-For RELATION-typed values, pass the target entity id (dashless hex or dashed UUID — the tool normalizes). \`mode\` is AND (default) or OR.`,
+For RELATION-typed values, pass the target entity id (dashless hex or dashed UUID — the tool normalizes). \`modesByColumn\` is an optional map of \`columnId\` → \`'AND' | 'OR'\` (default per column is \`'OR'\`).`,
     inputSchema: jsonSchema<SetDataBlockFiltersInput>({
       type: 'object',
       properties: {
         blockId: { type: 'string', pattern: ENTITY_ID_PATTERN },
         parentEntityId: { type: 'string', pattern: ENTITY_ID_PATTERN },
         spaceId: { type: 'string', pattern: ENTITY_ID_PATTERN },
-        mode: { type: 'string', enum: ['AND', 'OR'] },
+        modesByColumn: {
+          type: 'object',
+          additionalProperties: { type: 'string', enum: ['AND', 'OR'] },
+        },
         filters: {
           type: 'array',
           items: {
@@ -143,7 +154,7 @@ For RELATION-typed values, pass the target entity id (dashless hex or dashed UUI
           blockId,
           spaceId,
           filters,
-          mode: input.mode ?? 'AND',
+          modesByColumn: input.modesByColumn ?? {},
         },
       };
     },

--- a/apps/web/core/blocks/data/filters.test.ts
+++ b/apps/web/core/blocks/data/filters.test.ts
@@ -76,9 +76,9 @@ describe('filters', () => {
       },
     };
 
-    const { filters: stringFilter, mode } = await fromGeoFilterString(JSON.stringify(filter));
+    const { filters: stringFilter, modesByColumn } = await fromGeoFilterString(JSON.stringify(filter));
 
-    expect(mode).toBe('AND');
+    expect(modesByColumn).toEqual({});
     expect(stringFilter).toEqual([
       {
         columnId: SystemIds.SPACE_FILTER,
@@ -167,7 +167,7 @@ describe('filters', () => {
     });
   });
 
-  it('round-trips OR mode through filter string', async () => {
+  it('round-trips per-property AND mode through filter string', async () => {
     const filters = [
       {
         columnId: SystemIds.TYPES_PROPERTY,
@@ -177,30 +177,49 @@ describe('filters', () => {
       },
     ];
 
-    const stringFilter = toGeoFilterState(filters, 'OR');
-    const parsedFilter = JSON.parse(stringFilter);
-    expect(parsedFilter.mode).toBe('OR');
-
-    const { mode } = await fromGeoFilterString(stringFilter);
-    expect(mode).toBe('OR');
-  });
-
-  it('omits mode from AND filter string for backward compatibility', () => {
-    const filters = [
-      {
-        columnId: SystemIds.TYPES_PROPERTY,
-        columnName: 'Types',
-        valueType: 'RELATION' as const,
-        value: SystemIds.SCHEMA_TYPE,
-      },
-    ];
-
-    const stringFilter = toGeoFilterState(filters, 'AND');
+    const stringFilter = toGeoFilterState(filters, { [SystemIds.TYPES_PROPERTY]: 'AND' });
     const parsedFilter = JSON.parse(stringFilter);
     expect(parsedFilter.mode).toBeUndefined();
+    expect(parsedFilter.modes).toEqual({ [SystemIds.TYPES_PROPERTY]: 'AND' });
+
+    const { modesByColumn } = await fromGeoFilterString(stringFilter);
+    expect(modesByColumn).toEqual({ [SystemIds.TYPES_PROPERTY]: 'AND' });
   });
 
-  it('defaults to AND mode when mode is absent in stored filter string', async () => {
+  it('omits modes when every group uses the OR default', () => {
+    const filters = [
+      {
+        columnId: SystemIds.TYPES_PROPERTY,
+        columnName: 'Types',
+        valueType: 'RELATION' as const,
+        value: SystemIds.SCHEMA_TYPE,
+      },
+    ];
+
+    // OR is the default — no need to persist it.
+    const stringFilter = toGeoFilterState(filters, { [SystemIds.TYPES_PROPERTY]: 'OR' });
+    const parsedFilter = JSON.parse(stringFilter);
+    expect(parsedFilter.mode).toBeUndefined();
+    expect(parsedFilter.modes).toBeUndefined();
+  });
+
+  it('legacy mode: OR fans out to every present property group on read', async () => {
+    const filter: FilterString = {
+      mode: 'OR',
+      filter: {
+        [SystemIds.TYPES_PROPERTY]: { is: SystemIds.SCHEMA_TYPE },
+        [SystemIds.NAME_PROPERTY]: { is: 'foo' },
+      },
+    };
+
+    const { modesByColumn } = await fromGeoFilterString(JSON.stringify(filter));
+    expect(modesByColumn).toEqual({
+      [SystemIds.TYPES_PROPERTY]: 'OR',
+      [SystemIds.NAME_PROPERTY]: 'OR',
+    });
+  });
+
+  it('legacy mode: AND or absent => empty modesByColumn (default OR per group)', async () => {
     const filter: FilterString = {
       filter: {
         [SystemIds.TYPES_PROPERTY]: {
@@ -209,30 +228,30 @@ describe('filters', () => {
       },
     };
 
-    const { mode } = await fromGeoFilterString(JSON.stringify(filter));
-    expect(mode).toBe('AND');
+    const { modesByColumn } = await fromGeoFilterString(JSON.stringify(filter));
+    expect(modesByColumn).toEqual({});
   });
 });
 
 describe('parseFiltersSync', () => {
   it('returns empty filters for null input', () => {
     const result = parseFiltersSync(null);
-    expect(result).toEqual({ filters: [], mode: 'AND' });
+    expect(result).toEqual({ filters: [], modesByColumn: {} });
   });
 
   it('returns empty filters for empty string', () => {
     const result = parseFiltersSync('');
-    expect(result).toEqual({ filters: [], mode: 'AND' });
+    expect(result).toEqual({ filters: [], modesByColumn: {} });
   });
 
   it('returns empty filters for invalid JSON', () => {
     const result = parseFiltersSync('not-json');
-    expect(result).toEqual({ filters: [], mode: 'AND' });
+    expect(result).toEqual({ filters: [], modesByColumn: {} });
   });
 
   it('returns empty filters for invalid schema', () => {
     const result = parseFiltersSync(JSON.stringify({ filter: 'bad' }));
-    expect(result).toEqual({ filters: [], mode: 'AND' });
+    expect(result).toEqual({ filters: [], modesByColumn: {} });
   });
 
   it('parses a simple property filter', () => {
@@ -242,8 +261,8 @@ describe('parseFiltersSync', () => {
       },
     };
 
-    const { filters, mode } = parseFiltersSync(JSON.stringify(input));
-    expect(mode).toBe('AND');
+    const { filters, modesByColumn } = parseFiltersSync(JSON.stringify(input));
+    expect(modesByColumn).toEqual({});
     expect(filters).toEqual([
       {
         columnId: SystemIds.TYPES_PROPERTY,
@@ -336,7 +355,7 @@ describe('parseFiltersSync', () => {
     expect(filters.every(f => f.columnId === SystemIds.TYPES_PROPERTY)).toBe(true);
   });
 
-  it('parses OR mode', () => {
+  it('legacy mode: OR fans out to every present property group', () => {
     const input: FilterString = {
       mode: 'OR',
       filter: {
@@ -344,19 +363,32 @@ describe('parseFiltersSync', () => {
       },
     };
 
-    const { mode } = parseFiltersSync(JSON.stringify(input));
-    expect(mode).toBe('OR');
+    const { modesByColumn } = parseFiltersSync(JSON.stringify(input));
+    expect(modesByColumn).toEqual({ [SystemIds.TYPES_PROPERTY]: 'OR' });
   });
 
-  it('defaults to AND mode when mode is absent', () => {
+  it('returns empty modesByColumn when no mode info is present', () => {
     const input: FilterString = {
       filter: {
         [SystemIds.TYPES_PROPERTY]: { is: SystemIds.SCHEMA_TYPE },
       },
     };
 
-    const { mode } = parseFiltersSync(JSON.stringify(input));
-    expect(mode).toBe('AND');
+    const { modesByColumn } = parseFiltersSync(JSON.stringify(input));
+    expect(modesByColumn).toEqual({});
+  });
+
+  it('reads new modes map verbatim, ignoring legacy mode field', () => {
+    const input: FilterString = {
+      mode: 'OR', // legacy — ignored when `modes` is present
+      modes: { [SystemIds.TYPES_PROPERTY]: 'AND' },
+      filter: {
+        [SystemIds.TYPES_PROPERTY]: { in: ['type-a', 'type-b'] },
+      },
+    };
+
+    const { modesByColumn } = parseFiltersSync(JSON.stringify(input));
+    expect(modesByColumn).toEqual({ [SystemIds.TYPES_PROPERTY]: 'AND' });
   });
 });
 

--- a/apps/web/core/blocks/data/filters.ts
+++ b/apps/web/core/blocks/data/filters.ts
@@ -44,8 +44,23 @@ const PropertyFilter = Schema.Struct({
 
 type PropertyFilter = Schema.Schema.Type<typeof PropertyFilter>;
 
+/**
+ * Persisted filter wire format.
+ *
+ * `mode` was a global AND/OR setting that applied across every property
+ * group. It's been replaced by per-property `modes` keyed by columnId, and
+ * the writer no longer emits `mode`. We keep `mode` in the schema purely so
+ * legacy filter strings still parse; on the next save the new shape (with
+ * `modes`) is written and the legacy key disappears.
+ */
 const FilterString = Schema.Struct({
   mode: Schema.optional(Schema.Literal('AND', 'OR')),
+  modes: Schema.optional(
+    Schema.Record({
+      key: Schema.String,
+      value: Schema.Literal('AND', 'OR'),
+    })
+  ),
   spaceId: Schema.optional(
     Schema.Struct({
       in: Schema.Array(Schema.String),
@@ -114,7 +129,16 @@ const FilterMap = Schema.mutable(
 
 type FilterMap = Schema.Schema.Type<typeof FilterMap>;
 
-export function toGeoFilterState(filters: OmitStrict<Filter, 'valueName'>[], mode: FilterMode = 'AND'): string {
+/**
+ * Per-property mode map keyed by `columnId` (or `_relation` for backlinks).
+ * Missing entries default to `'OR'` at the WHERE-builder layer.
+ */
+export type ModesByColumn = Record<string, FilterMode>;
+
+export function toGeoFilterState(
+  filters: OmitStrict<Filter, 'valueName'>[],
+  modesByColumn: ModesByColumn = {}
+): string {
   const spaces = filters.filter(f => ID.equals(f.columnId, SystemIds.SPACE_FILTER)).map(f => f.value);
 
   const filterMap: FilterMap = {};
@@ -141,10 +165,20 @@ export function toGeoFilterState(filters: OmitStrict<Filter, 'valueName'>[], mod
       }
     });
 
+  // Only persist mode entries for groups that actually exist in the filter map
+  // and that diverge from the default ('OR'). Cuts wire noise.
+  const presentKeys = new Set(Object.keys(filterMap));
+  const persistableModes: ModesByColumn = {};
+  for (const [columnId, mode] of Object.entries(modesByColumn)) {
+    if (presentKeys.has(columnId) && mode === 'AND') {
+      persistableModes[columnId] = mode;
+    }
+  }
+
   const filter: FilterString = {
-    ...(mode === 'OR' && { mode: 'OR' as const }),
     ...(spaces.length > 0 && { spaceId: { in: spaces } }),
     ...(Object.keys(filterMap).length > 0 && { filter: filterMap }),
+    ...(Object.keys(persistableModes).length > 0 && { modes: persistableModes }),
   };
 
   const maybeEncoded = Schema.encodeUnknownEither(FilterString)(filter);
@@ -162,8 +196,35 @@ export function toGeoFilterState(filters: OmitStrict<Filter, 'valueName'>[], mod
 
 export type FilterStateResult = {
   filters: Filter[];
-  mode: FilterMode;
+  modesByColumn: ModesByColumn;
 };
+
+/**
+ * Resolve the per-property modes map from a parsed filter payload, applying
+ * legacy migration:
+ *
+ * - If `modes` is present, use it verbatim (new format).
+ * - Else if legacy `mode: 'OR'` is set, fan it out to every property group
+ *   present in `filter` so existing OR filters keep behaving as OR within
+ *   each property column. Cross-property OR is silently dropped — the new
+ *   model is always AND between columns. The next save rewrites the filter
+ *   in the new shape and the legacy `mode` field disappears.
+ * - Else (legacy `mode: 'AND'` or unset) → empty map; per-group default
+ *   is `'OR'` at the WHERE-builder layer (collapses to `in`).
+ */
+function resolveModesByColumn(value: FilterString): ModesByColumn {
+  if (value.modes && Object.keys(value.modes).length > 0) {
+    return { ...value.modes };
+  }
+  if (value.mode === 'OR' && value.filter) {
+    const fanOut: ModesByColumn = {};
+    for (const key of Object.keys(value.filter)) {
+      fanOut[key] = 'OR';
+    }
+    return fanOut;
+  }
+  return {};
+}
 
 /**
  * Synchronously parse filter string into filters with IDs only (no display names).
@@ -171,14 +232,14 @@ export type FilterStateResult = {
  */
 export function parseFiltersSync(filterString: string | null): FilterStateResult {
   if (!filterString) {
-    return { filters: [], mode: 'AND' };
+    return { filters: [], modesByColumn: {} };
   }
 
   let where: unknown;
   try {
     where = JSON.parse(filterString);
   } catch {
-    return { filters: [], mode: 'AND' };
+    return { filters: [], modesByColumn: {} };
   }
 
   const decoded = Schema.decodeUnknownEither(FilterString)(where);
@@ -246,17 +307,17 @@ export function parseFiltersSync(filterString: string | null): FilterStateResult
 
       return {
         filters,
-        mode: (value.mode ?? 'AND') as FilterMode,
+        modesByColumn: resolveModesByColumn(value),
       };
     },
   });
 
-  return result ?? { filters: [], mode: 'AND' };
+  return result ?? { filters: [], modesByColumn: {} };
 }
 
 export async function fromGeoFilterString(filterString: string | null): Promise<FilterStateResult> {
   if (!filterString) {
-    return { filters: [], mode: 'AND' };
+    return { filters: [], modesByColumn: {} };
   }
 
   const where = JSON.parse(filterString);
@@ -304,7 +365,7 @@ export async function fromGeoFilterString(filterString: string | null): Promise<
       }
 
       return {
-        mode: value.mode,
+        modesByColumn: resolveModesByColumn(value),
         spaces: value.spaceId?.in ?? [],
         filters,
         entity: entity as { fromEntity: string; typeOf: string } | undefined,
@@ -313,10 +374,10 @@ export async function fromGeoFilterString(filterString: string | null): Promise<
   });
 
   if (!filtersFromString) {
-    return { filters: [], mode: 'AND' };
+    return { filters: [], modesByColumn: {} };
   }
 
-  const mode: FilterMode = filtersFromString.mode ?? 'AND';
+  const modesByColumn = filtersFromString.modesByColumn;
 
   const filters: Filter[] = [];
 
@@ -360,7 +421,7 @@ export async function fromGeoFilterString(filterString: string | null): Promise<
     filters.push(entityFilter);
   }
 
-  return { filters, mode };
+  return { filters, modesByColumn };
 }
 
 async function getSpaceName(spaceId: string) {

--- a/apps/web/core/blocks/data/use-data-block.tsx
+++ b/apps/web/core/blocks/data/use-data-block.tsx
@@ -14,7 +14,9 @@ import { sortRows } from '~/core/utils/utils';
 
 import { useProperties } from '../../hooks/use-properties';
 import { mapSelectorLexiconToSourceEntity, parseSelectorIntoLexicon } from './data-selectors';
-import { Filter, FilterMode } from './filters';
+import { Filter, FilterMode, ModesByColumn } from './filters';
+import { FilterableValueType } from '~/core/value-types';
+import { ValueDataType } from '~/core/sync/experimental_query-layer';
 import { Source } from './source';
 import { useCollection } from './use-collection';
 import { useFilters } from './use-filters';
@@ -42,7 +44,7 @@ const queryKeys = {
 
 interface UseDataBlockOptions {
   filterState?: Filter[];
-  filterMode?: FilterMode;
+  modesByColumn?: ModesByColumn;
   canEdit?: boolean;
 }
 
@@ -71,23 +73,23 @@ export function useDataBlock(options?: UseDataBlockOptions) {
     filterState: dbFilterState,
     resolvedFilterState: dbResolvedFilterState,
     isFilterResolving,
-    filterMode: dbFilterMode,
+    modesByColumn: dbModesByColumn,
     filterableProperties,
     setFilterState,
-    setFilterMode,
+    setGroupMode,
     temporaryFilters,
-    temporaryFilterMode,
+    temporaryModesByColumn,
     setTemporaryFilters,
-    setTemporaryFilterMode,
+    setTemporaryGroupMode,
   } = useFilters(options?.canEdit);
 
   const { source, setSource } = useSource({ filterState: dbFilterState, setFilterState });
   const { relationBlockSourceRelations } = useRelationsBlock({ source, filterState: dbFilterState });
 
   const activeFilterState = options?.canEdit ? dbResolvedFilterState : temporaryFilters;
-  const activeFilterMode = options?.canEdit ? dbFilterMode : temporaryFilterMode;
+  const activeModesByColumn = options?.canEdit ? dbModesByColumn : temporaryModesByColumn;
   const effectiveFilterState = options?.filterState ?? activeFilterState;
-  const effectiveFilterMode = options?.filterMode ?? activeFilterMode;
+  const effectiveModesByColumn = options?.modesByColumn ?? activeModesByColumn;
   const {
     shownColumnIds,
     mapping,
@@ -104,9 +106,10 @@ export function useDataBlock(options?: UseDataBlockOptions) {
   const { sortState, setSortState } = useSort(options?.canEdit);
 
   const filterStateKey = React.useMemo(() => stableStringify(effectiveFilterState), [effectiveFilterState]);
+  const modesByColumnKey = React.useMemo(() => stableStringify(effectiveModesByColumn), [effectiveModesByColumn]);
   const where = React.useMemo(
-    () => filterStateToWhere(effectiveFilterState, effectiveFilterMode),
-    [filterStateKey, effectiveFilterMode]
+    () => filterStateToWhere(effectiveFilterState, effectiveModesByColumn),
+    [filterStateKey, modesByColumnKey, effectiveFilterState, effectiveModesByColumn]
   );
 
   // Use the mapping to get the potential renderable properties.
@@ -450,17 +453,17 @@ export function useDataBlock(options?: UseDataBlockOptions) {
     // From useFilters
     filterState: effectiveFilterState,
     resolvedFilterState: dbResolvedFilterState,
-    filterMode: effectiveFilterMode,
+    modesByColumn: effectiveModesByColumn,
     dbFilterState,
-    dbFilterMode,
+    dbModesByColumn,
     setFilterState,
-    setFilterMode,
+    setGroupMode,
     filterableProperties,
 
     temporaryFilters,
-    temporaryFilterMode,
+    temporaryModesByColumn,
     setTemporaryFilters,
-    setTemporaryFilterMode,
+    setTemporaryGroupMode,
 
     // From useSort
     sortState,
@@ -536,28 +539,41 @@ export function useDataBlockInstance() {
   return context;
 }
 
-export function filterStateToWhere(filterState: Filter[], mode: FilterMode = 'AND'): WhereCondition {
+/** Per-group default mode. Multi-value RELATION/TEXT collapses cleanly to `in`. */
+const DEFAULT_GROUP_MODE: FilterMode = 'OR';
+
+/**
+ * Group key shared by all filter chips that combine into a single GraphQL
+ * clause. Backlinks bucket under `_relation` so multiple backlink chips on
+ * the same relation type collapse to a single `backlinks: [...]` clause
+ * (matching the persisted format).
+ */
+function groupKeyFor(f: Filter): string {
+  const isBacklink = f.isBacklink || f.columnName === 'Backlink';
+  return isBacklink ? `_relation:${f.columnId}` : f.columnId;
+}
+
+export function filterStateToWhere(filterState: Filter[], modesByColumn: ModesByColumn = {}): WhereCondition {
   if (filterState.length === 0) return {};
   if (filterState.length === 1) return buildSingleFilterWhere(filterState[0]);
 
-  // Group filters by columnId so we can AND between groups and apply
-  // the user-chosen mode (AND/OR) only within each group.
+  // Bucket filters by column, then build one WhereCondition per group using
+  // that group's mode. Between groups is always AND (the global mode is gone).
   const groups = new Map<string, Filter[]>();
   for (const f of filterState) {
-    const key = f.columnId;
+    const key = groupKeyFor(f);
     if (!groups.has(key)) groups.set(key, []);
     groups.get(key)!.push(f);
   }
 
   const groupConditions: WhereCondition[] = [];
-  for (const [, filters] of groups) {
-    if (filters.length === 1) {
-      groupConditions.push(buildSingleFilterWhere(filters[0]));
-    } else if (mode === 'OR') {
-      groupConditions.push(buildOrWhere(filters));
-    } else {
-      groupConditions.push(buildAndWhere(filters));
-    }
+  for (const [groupKey, filters] of groups) {
+    // The persisted modes map keys backlinks under their columnId, not the
+    // synthetic group key with the `_relation:` prefix. Strip the prefix when
+    // looking up the mode so a group of backlinks finds its mode.
+    const lookupKey = groupKey.startsWith('_relation:') ? groupKey.slice('_relation:'.length) : groupKey;
+    const groupMode = modesByColumn[lookupKey] ?? DEFAULT_GROUP_MODE;
+    groupConditions.push(buildGroupWhere(filters, groupMode));
   }
 
   if (groupConditions.length === 1) return groupConditions[0];
@@ -603,13 +619,29 @@ function mergeWhereConditions(conditions: WhereCondition[]): WhereCondition {
   return { AND: [merged, ...unmerged] };
 }
 
+function valueDataTypeFor(valueType: FilterableValueType): ValueDataType | undefined {
+  switch (valueType) {
+    case 'TEXT':
+    case 'INTEGER':
+    case 'FLOAT':
+    case 'DECIMAL':
+    case 'DATETIME':
+    case 'DATE':
+    case 'TIME':
+    case 'BOOLEAN':
+      return valueType;
+    default:
+      return undefined;
+  }
+}
+
 function buildSingleFilterWhere(f: Filter): WhereCondition {
   if (f.valueType === 'TEXT') {
     if (ID.equals(f.columnId, SystemIds.NAME_PROPERTY)) {
       return { name: { contains: f.value } };
     }
     return {
-      values: [{ propertyId: { equals: f.columnId }, value: { contains: f.value } }],
+      values: [{ propertyId: { equals: f.columnId }, value: { contains: f.value }, dataType: 'TEXT' }],
     };
   }
 
@@ -633,26 +665,72 @@ function buildSingleFilterWhere(f: Filter): WhereCondition {
   return {};
 }
 
-function buildOrWhere(filterState: Filter[]): WhereCondition {
-  if (filterState.length === 0) return {};
-  if (filterState.length === 1) return buildSingleFilterWhere(filterState[0]);
+/**
+ * Build a single WhereCondition for one property group (all filter chips
+ * sharing the same columnId, or all backlink chips of the same relation
+ * type). The returned shape depends on `groupMode`:
+ *
+ * - `'OR'` (default) collapses multi-value RELATION/TEXT groups to one
+ *   clause using the schema's `in` / `inInsensitive` operators — far less
+ *   verbose than `OR: [{...}, {...}, ...]` on the wire.
+ * - `'AND'` wraps each chip as a separate AND clause so "tagged with both
+ *   X and Y" stays expressible. Same shape as the prior `buildAndWhere`.
+ */
+function buildGroupWhere(filters: Filter[], groupMode: FilterMode): WhereCondition {
+  if (filters.length === 0) return {};
+  if (filters.length === 1) return buildSingleFilterWhere(filters[0]);
 
-  return {
-    OR: filterState.map(f => buildSingleFilterWhere(f)),
-  };
-}
+  if (groupMode === 'AND') {
+    // AND-of-singles. Each chip evaluated independently (matches the local
+    // query engine's matchesCondition expectations and lets the converter
+    // emit a real GraphQL `and: [...]`).
+    return { AND: filters.map(f => buildSingleFilterWhere(f)) };
+  }
 
-function buildAndWhere(filterState: Filter[]): WhereCondition {
-  if (filterState.length === 0) return {};
-  if (filterState.length === 1) return buildSingleFilterWhere(filterState[0]);
+  // OR mode → in-collapse where the schema supports it.
+  const head = filters[0];
+  const isBacklink = head.isBacklink || head.columnName === 'Backlink';
+  const values = filters.map(f => f.value);
 
-  // Wrap each filter in AND so ALL conditions must match.
-  // We use individual sub-conditions (via buildSingleFilterWhere) rather than
-  // merging into one flat object, because the local query engine's matchesCondition
-  // returns early when it sees AND/OR — mixing AND with other fields on the same
-  // object would skip those fields. Using AND: [...] also correctly handles types
-  // and spaces which need per-condition evaluation for true AND semantics.
-  return { AND: filterState.map(f => buildSingleFilterWhere(f)) };
+  if (head.valueType === 'RELATION') {
+    if (ID.equals(head.columnId, SystemIds.SPACE_FILTER)) {
+      // Top-level `spaces` already promotes to the fast `spaceIds` query param.
+      // Multiple values stay as multiple StringConditions; the converter
+      // collects them into a single UuidListFilter.
+      return { spaces: values.map(v => ({ equals: v })) };
+    }
+    if (ID.equals(head.columnId, SystemIds.TYPES_PROPERTY)) {
+      // Same story for `types` → `typeIds`.
+      return { types: values.map(v => ({ id: { equals: v } })) };
+    }
+    if (isBacklink) {
+      return {
+        backlinks: [{ typeOf: { id: { equals: head.columnId } }, fromEntity: { id: { in: values } } }],
+      };
+    }
+    return {
+      relations: [{ typeOf: { id: { equals: head.columnId } }, toEntity: { id: { in: values } } }],
+    };
+  }
+
+  if (head.valueType === 'TEXT') {
+    if (ID.equals(head.columnId, SystemIds.NAME_PROPERTY)) {
+      // Name multi-value is exact-match `in` (vs `contains` for single).
+      // Different semantics, but `inInsensitive` on a fuzzy multi-search
+      // would be surprising — users selecting from a list want exact matches.
+      return { name: { in: values } };
+    }
+    return {
+      values: [{ propertyId: { equals: head.columnId }, value: { in: values }, dataType: 'TEXT' }],
+    };
+  }
+
+  // Other scalar dataTypes (INTEGER/FLOAT/DECIMAL/DATETIME/DATE/TIME/BOOLEAN)
+  // aren't currently UI-surfaced as multi-chip filters. If we ever do, fall
+  // back to OR-of-singles — the converter routes each by dataType.
+  const _dataType = valueDataTypeFor(head.valueType);
+  void _dataType; // referenced for future UI; suppress unused warning today
+  return { OR: filters.map(f => buildSingleFilterWhere(f)) };
 }
 
 function stableStringify(value: unknown): string {

--- a/apps/web/core/blocks/data/use-filters.ts
+++ b/apps/web/core/blocks/data/use-filters.ts
@@ -15,7 +15,14 @@ import { useValues } from '~/core/sync/use-store';
 import { store } from '~/core/sync/use-sync-engine';
 import { mergeRelationValueTypesFromStore } from '~/core/utils/property/properties';
 
-import { Filter, FilterMode, parseFiltersSync, resolveFilterDisplayNames, toGeoFilterState } from './filters';
+import {
+  Filter,
+  FilterMode,
+  ModesByColumn,
+  parseFiltersSync,
+  resolveFilterDisplayNames,
+  toGeoFilterState,
+} from './filters';
 import { useDataBlockInstance } from './use-data-block';
 
 export function useFilters(canEdit?: boolean) {
@@ -48,7 +55,7 @@ export function useFilters(canEdit?: boolean) {
     return null;
   }, [filterTriple]);
 
-  const { filters: filterState, mode: filterMode } = React.useMemo(
+  const { filters: filterState, modesByColumn } = React.useMemo(
     () => parseFiltersSync(geoFilterString),
     [geoFilterString]
   );
@@ -88,30 +95,30 @@ export function useFilters(canEdit?: boolean) {
   const effectiveResolvedState = filterState.length === 0 ? [] : (freshResolvedState ?? filterState);
 
   const [temporaryFilterOverride, setTemporaryFilterOverride] = React.useState<Filter[] | null>(null);
-  const [temporaryModeOverride, setTemporaryModeOverride] = React.useState<FilterMode | null>(null);
+  const [temporaryModesOverride, setTemporaryModesOverride] = React.useState<ModesByColumn | null>(null);
 
   const temporaryFilters = temporaryFilterOverride ?? effectiveResolvedState;
-  const temporaryFilterMode: FilterMode = temporaryModeOverride ?? filterMode;
+  const temporaryModesByColumn: ModesByColumn = temporaryModesOverride ?? modesByColumn;
 
   const setTemporaryFilters = React.useCallback((filters: Filter[]) => {
     setTemporaryFilterOverride(filters);
   }, []);
 
-  const setTemporaryFilterMode = React.useCallback((mode: FilterMode) => {
-    setTemporaryModeOverride(mode);
+  const setTemporaryGroupMode = React.useCallback((columnId: string, mode: FilterMode) => {
+    setTemporaryModesOverride(prev => ({ ...(prev ?? {}), [columnId]: mode }));
   }, []);
 
   React.useEffect(() => {
     if (canEdit === true) {
       setTemporaryFilterOverride(null);
-      setTemporaryModeOverride(null);
+      setTemporaryModesOverride(null);
     }
   }, [canEdit]);
 
-  const filterModeRef = React.useRef(filterMode);
+  const modesByColumnRef = React.useRef(modesByColumn);
   React.useEffect(() => {
-    filterModeRef.current = filterMode;
-  }, [filterMode]);
+    modesByColumnRef.current = modesByColumn;
+  }, [modesByColumn]);
 
   const filterStateRef = React.useRef(filterState);
   React.useEffect(() => {
@@ -119,8 +126,9 @@ export function useFilters(canEdit?: boolean) {
   }, [filterState]);
 
   const writeFilterTriple = React.useCallback(
-    (filters: Filter[], mode: FilterMode) => {
-      const newFiltersString = filters.length === 0 && mode === 'AND' ? '' : toGeoFilterState(filters, mode);
+    (filters: Filter[], modes: ModesByColumn) => {
+      const newFiltersString =
+        filters.length === 0 && Object.keys(modes).length === 0 ? '' : toGeoFilterState(filters, modes);
       const entityName = initialBlockEntity?.name ?? '';
 
       storage.values.set({
@@ -147,15 +155,26 @@ export function useFilters(canEdit?: boolean) {
 
   const setFilterState = React.useCallback(
     (filters: Filter[]) => {
-      writeFilterTriple(filters, filterModeRef.current);
+      // Drop any per-group mode entries for columns that no longer have filters,
+      // so removing a filter chip cleans up its mode entry too.
+      const presentColumns = new Set(filters.map(f => (f.isBacklink ? '_relation' : f.columnId)));
+      const trimmedModes: ModesByColumn = {};
+      for (const [columnId, mode] of Object.entries(modesByColumnRef.current)) {
+        if (presentColumns.has(columnId)) {
+          trimmedModes[columnId] = mode;
+        }
+      }
+      modesByColumnRef.current = trimmedModes;
+      writeFilterTriple(filters, trimmedModes);
     },
     [writeFilterTriple]
   );
 
-  const setFilterMode = React.useCallback(
-    (mode: FilterMode) => {
-      filterModeRef.current = mode;
-      writeFilterTriple(filterStateRef.current, mode);
+  const setGroupMode = React.useCallback(
+    (columnId: string, mode: FilterMode) => {
+      const next = { ...modesByColumnRef.current, [columnId]: mode };
+      modesByColumnRef.current = next;
+      writeFilterTriple(filterStateRef.current, next);
     },
     [writeFilterTriple]
   );
@@ -164,13 +183,13 @@ export function useFilters(canEdit?: boolean) {
     filterState,
     resolvedFilterState: effectiveResolvedState,
     isFilterResolving,
-    filterMode,
+    modesByColumn,
     temporaryFilters,
-    temporaryFilterMode,
+    temporaryModesByColumn,
     filterableProperties: filterableProperties ?? [],
     setFilterState,
-    setFilterMode,
+    setGroupMode,
     setTemporaryFilters,
-    setTemporaryFilterMode,
+    setTemporaryGroupMode,
   };
 }

--- a/apps/web/core/chat/edit-dispatcher.test.ts
+++ b/apps/web/core/chat/edit-dispatcher.test.ts
@@ -316,7 +316,7 @@ describe('setDataBlockFilters', () => {
   it('aborts when the block entity cannot be resolved (guards against stray FILTER writes)', async () => {
     findOne.mockImplementation(async () => null);
     await applyIntent(
-      { kind: 'setDataBlockFilters', blockId: 'block1', spaceId: 'space1', filters: [], mode: 'AND' },
+      { kind: 'setDataBlockFilters', blockId: 'block1', spaceId: 'space1', filters: [], modesByColumn: {} },
       ctx
     );
     expect(storage.values.set).not.toHaveBeenCalled();
@@ -325,7 +325,7 @@ describe('setDataBlockFilters', () => {
   it('writes the filter value when the block exists', async () => {
     findOne.mockResolvedValue(makeEntity({ id: 'block1' }));
     await applyIntent(
-      { kind: 'setDataBlockFilters', blockId: 'block1', spaceId: 'space1', filters: [], mode: 'AND' },
+      { kind: 'setDataBlockFilters', blockId: 'block1', spaceId: 'space1', filters: [], modesByColumn: {} },
       ctx
     );
     expect(storage.values.set).toHaveBeenCalledWith(

--- a/apps/web/core/chat/edit-dispatcher.ts
+++ b/apps/web/core/chat/edit-dispatcher.ts
@@ -422,7 +422,7 @@ async function applySetDataBlockFilters(intent: Extract<EditIntent, { kind: 'set
     return;
   }
 
-  const encoded = intent.filters.length === 0 ? '' : toGeoFilterState(intent.filters, intent.mode);
+  const encoded = intent.filters.length === 0 ? '' : toGeoFilterState(intent.filters, intent.modesByColumn);
 
   storage.values.set({
     spaceId: intent.spaceId,

--- a/apps/web/core/chat/edit-types.ts
+++ b/apps/web/core/chat/edit-types.ts
@@ -1,5 +1,5 @@
 // Types only — safe to import across client/server boundary.
-import type { Filter, FilterMode } from '~/core/blocks/data/filters';
+import type { Filter, ModesByColumn } from '~/core/blocks/data/filters';
 import type { DataType } from '~/core/types';
 
 export type BlockKind = 'text' | 'code' | 'image' | 'video' | 'data';
@@ -92,7 +92,7 @@ export type EditIntent =
       blockId: string;
       spaceId: string;
       filters: Filter[];
-      mode: FilterMode;
+      modesByColumn: ModesByColumn;
     }
   | {
       kind: 'setDataBlockView';

--- a/apps/web/core/io/converters.test.ts
+++ b/apps/web/core/io/converters.test.ts
@@ -107,3 +107,97 @@ describe('convertWhereConditionToEntityFilter empty-name exclusion', () => {
     });
   });
 });
+
+describe('convertWhereConditionToEntityFilter scalar value routing', () => {
+  it('routes a multi-value text filter to text.inInsensitive', () => {
+    const result = convertWhereConditionToEntityFilter(
+      {
+        values: [
+          { propertyId: { equals: 'prop-1' }, value: { in: ['Foo', 'Bar'] }, dataType: 'TEXT' },
+        ],
+      },
+      { includeEmptyNames: true }
+    );
+
+    expect(result).toEqual({
+      values: { some: { propertyId: { is: 'prop-1' }, text: { inInsensitive: ['Foo', 'Bar'] } } },
+    });
+  });
+
+  it('routes an integer filter to integer.in (BigInt strings)', () => {
+    const result = convertWhereConditionToEntityFilter(
+      {
+        values: [
+          { propertyId: { equals: 'prop-int' }, value: { in: [1, 2, 3] }, dataType: 'INTEGER' },
+        ],
+      },
+      { includeEmptyNames: true }
+    );
+
+    expect(result).toEqual({
+      values: { some: { propertyId: { is: 'prop-int' }, integer: { in: ['1', '2', '3'] } } },
+    });
+  });
+
+  it('routes a float filter to float.in (numbers)', () => {
+    const result = convertWhereConditionToEntityFilter(
+      {
+        values: [
+          { propertyId: { equals: 'prop-f' }, value: { in: [1.5, 2.5] }, dataType: 'FLOAT' },
+        ],
+      },
+      { includeEmptyNames: true }
+    );
+
+    expect(result).toEqual({
+      values: { some: { propertyId: { is: 'prop-f' }, float: { in: [1.5, 2.5] } } },
+    });
+  });
+
+  it('routes a datetime filter to datetime field with inInsensitive (StringFilter)', () => {
+    const result = convertWhereConditionToEntityFilter(
+      {
+        values: [
+          {
+            propertyId: { equals: 'prop-dt' },
+            value: { in: ['2026-01-01', '2026-02-01'] },
+            dataType: 'DATETIME',
+          },
+        ],
+      },
+      { includeEmptyNames: true }
+    );
+
+    expect(result).toEqual({
+      values: {
+        some: {
+          propertyId: { is: 'prop-dt' },
+          datetime: { inInsensitive: ['2026-01-01', '2026-02-01'] },
+        },
+      },
+    });
+  });
+
+  it('routes a relation filter with multi-value to.id.in', () => {
+    const result = convertWhereConditionToEntityFilter(
+      {
+        relations: [
+          {
+            typeOf: { id: { equals: 'rel-type' } },
+            toEntity: { id: { in: ['a', 'b', 'c'] } },
+          },
+        ],
+      },
+      { includeEmptyNames: true }
+    );
+
+    expect(result).toEqual({
+      relations: {
+        some: {
+          typeId: { is: 'rel-type' },
+          toEntityId: { in: ['a', 'b', 'c'] },
+        },
+      },
+    });
+  });
+});

--- a/apps/web/core/io/converters.ts
+++ b/apps/web/core/io/converters.ts
@@ -1,7 +1,11 @@
 import {
+  BigFloatFilter,
+  BigIntFilter,
+  BooleanFilter,
   EntityFilter,
   EntityToManyRelationFilter,
   EntityToManyValueFilter,
+  FloatFilter,
   RelationFilter,
   StringFilter,
   UuidFilter,
@@ -10,6 +14,7 @@ import {
 } from '~/core/gql/graphql';
 import {
   BacklinkCondition,
+  BooleanCondition,
   NumberCondition,
   RelationCondition,
   StringCondition,
@@ -88,7 +93,90 @@ function convertStringConditionToUuidFilter(condition: StringCondition | undefin
 }
 
 /**
- * Converts a ValueCondition to a ValueFilter for GraphQL
+ * Maps a StringCondition (text values) to a case-insensitive StringFilter
+ * suitable for the `text` / `date` / `datetime` / `time` fields on
+ * ValueFilter. Differs from `convertStringConditionToStringFilter` in two
+ * ways: it prefers `inInsensitive` for arrays so multi-value text filters
+ * collapse into one clause, and it routes equality through `isInsensitive`
+ * rather than `startsWithInsensitive`.
+ */
+function convertStringConditionToInsensitiveStringFilter(
+  condition: StringCondition | undefined
+): StringFilter | undefined {
+  if (!condition) return undefined;
+
+  if (typeof condition === 'string') {
+    return { isInsensitive: condition };
+  }
+
+  const filter: StringFilter = {};
+
+  if (condition.equals !== undefined) {
+    filter.isInsensitive = condition.equals;
+  }
+  if (condition.fuzzy !== undefined || condition.contains !== undefined) {
+    filter.includesInsensitive = condition.fuzzy ?? condition.contains;
+  }
+  if (condition.startsWith !== undefined) {
+    filter.startsWithInsensitive = condition.startsWith;
+  }
+  if (condition.endsWith !== undefined) {
+    filter.endsWithInsensitive = condition.endsWith;
+  }
+  if (condition.in !== undefined && condition.in.length > 0) {
+    filter.inInsensitive = condition.in;
+  }
+
+  return Object.keys(filter).length > 0 ? filter : undefined;
+}
+
+function buildBigIntFilter(condition: NumberCondition): BigIntFilter | undefined {
+  const filter: BigIntFilter = {};
+  if (condition.equals !== undefined) filter.is = String(condition.equals);
+  if (condition.gt !== undefined) filter.greaterThan = String(condition.gt);
+  if (condition.gte !== undefined) filter.greaterThanOrEqualTo = String(condition.gte);
+  if (condition.lt !== undefined) filter.lessThan = String(condition.lt);
+  if (condition.lte !== undefined) filter.lessThanOrEqualTo = String(condition.lte);
+  if (condition.in !== undefined && condition.in.length > 0) filter.in = condition.in.map(String);
+  return Object.keys(filter).length > 0 ? filter : undefined;
+}
+
+function buildFloatFilter(condition: NumberCondition): FloatFilter | undefined {
+  const filter: FloatFilter = {};
+  if (condition.equals !== undefined) filter.is = condition.equals;
+  if (condition.gt !== undefined) filter.greaterThan = condition.gt;
+  if (condition.gte !== undefined) filter.greaterThanOrEqualTo = condition.gte;
+  if (condition.lt !== undefined) filter.lessThan = condition.lt;
+  if (condition.lte !== undefined) filter.lessThanOrEqualTo = condition.lte;
+  if (condition.in !== undefined && condition.in.length > 0) filter.in = condition.in;
+  return Object.keys(filter).length > 0 ? filter : undefined;
+}
+
+function buildBigFloatFilter(condition: NumberCondition): BigFloatFilter | undefined {
+  const filter: BigFloatFilter = {};
+  if (condition.equals !== undefined) filter.is = String(condition.equals);
+  if (condition.gt !== undefined) filter.greaterThan = String(condition.gt);
+  if (condition.gte !== undefined) filter.greaterThanOrEqualTo = String(condition.gte);
+  if (condition.lt !== undefined) filter.lessThan = String(condition.lt);
+  if (condition.lte !== undefined) filter.lessThanOrEqualTo = String(condition.lte);
+  if (condition.in !== undefined && condition.in.length > 0) filter.in = condition.in.map(String);
+  return Object.keys(filter).length > 0 ? filter : undefined;
+}
+
+function buildBooleanFilter(condition: BooleanCondition): BooleanFilter {
+  return { is: condition.equals };
+}
+
+/**
+ * Converts a ValueCondition to a ValueFilter for GraphQL.
+ *
+ * Routes the value to the matching scalar field on `ValueFilter` (`text`,
+ * `integer`, `float`, `decimal`, `datetime`, `date`, `time`, `boolean`)
+ * based on `condition.dataType`. Without a `dataType` hint we fall back
+ * to populating `text`, which is the legacy behavior — fine for old
+ * persisted filters but every new filter the data block UI builds carries
+ * the correct dataType so multi-value selections end up in `text.inInsensitive`,
+ * `integer.in`, etc., as a single clause instead of a nested OR fan-out.
  */
 function convertValueConditionToValueFilter(condition: ValueCondition): ValueFilter {
   const filter: ValueFilter = {};
@@ -101,36 +189,80 @@ function convertValueConditionToValueFilter(condition: ValueCondition): ValueFil
     filter.spaceId = convertStringConditionToUuidFilter(condition.space);
   }
 
-  // Handle value based on type
-  if (condition.value) {
-    if (
-      typeof condition.value === 'object' &&
-      'equals' in condition.value &&
-      typeof condition.value.equals === 'boolean'
-    ) {
-      // Boolean condition - convert to string filter
-      filter.text = { is: String(condition.value.equals) };
-    } else if (
-      typeof condition.value === 'object' &&
-      ('gt' in condition.value ||
-        'gte' in condition.value ||
-        'lt' in condition.value ||
-        'lte' in condition.value ||
-        'between' in condition.value)
-    ) {
-      // Number condition - convert to string filter (GraphQL treats as string)
-      const numCondition = condition.value as NumberCondition;
-      if (numCondition.equals !== undefined) {
-        filter.text = { is: String(numCondition.equals) };
+  if (!condition.value) {
+    return filter;
+  }
+
+  // Boolean values are scalar; arrays are meaningless (only two possible values).
+  if (typeof condition.value === 'object' && 'equals' in condition.value && typeof condition.value.equals === 'boolean') {
+    filter.boolean = buildBooleanFilter(condition.value as BooleanCondition);
+    return filter;
+  }
+
+  // Numeric values: route by dataType. We can't tell INTEGER vs FLOAT vs DECIMAL
+  // from the JS value alone (5 could be any of the three), so the data block
+  // layer must supply `dataType` whenever it builds a numeric filter.
+  const isNumberCondition =
+    typeof condition.value === 'object' &&
+    ('gt' in condition.value ||
+      'gte' in condition.value ||
+      'lt' in condition.value ||
+      'lte' in condition.value ||
+      'between' in condition.value ||
+      ('in' in condition.value && Array.isArray(condition.value.in) && typeof condition.value.in[0] === 'number') ||
+      (typeof condition.value === 'object' &&
+        'equals' in condition.value &&
+        typeof condition.value.equals === 'number'));
+
+  if (isNumberCondition) {
+    const numCondition = condition.value as NumberCondition;
+    switch (condition.dataType) {
+      case 'INTEGER': {
+        const built = buildBigIntFilter(numCondition);
+        if (built) filter.integer = built;
+        return filter;
       }
-      // Note: GraphQL StringFilter doesn't support numeric comparisons directly
-      // You may need to handle this differently based on your GraphQL schema
-    } else {
-      // String condition
-      filter.text = convertStringConditionToStringFilter(condition.value as StringCondition);
+      case 'FLOAT': {
+        const built = buildFloatFilter(numCondition);
+        if (built) filter.float = built;
+        return filter;
+      }
+      case 'DECIMAL': {
+        const built = buildBigFloatFilter(numCondition);
+        if (built) filter.decimal = built;
+        return filter;
+      }
+      default: {
+        // No dataType hint — preserve legacy behavior of stringifying into `text`.
+        if (numCondition.equals !== undefined) {
+          filter.text = { is: String(numCondition.equals) };
+        }
+        return filter;
+      }
     }
   }
 
+  // String/string-like values. ValueFilter exposes `text`, `date`, `datetime`,
+  // `time`, `point` as StringFilters; pick by dataType (default to `text`).
+  const stringCondition = condition.value as StringCondition;
+  const stringFilter = convertStringConditionToInsensitiveStringFilter(stringCondition);
+  if (!stringFilter) return filter;
+
+  switch (condition.dataType) {
+    case 'DATETIME':
+      filter.datetime = stringFilter;
+      break;
+    case 'DATE':
+      filter.date = stringFilter;
+      break;
+    case 'TIME':
+      filter.time = stringFilter;
+      break;
+    case 'TEXT':
+    default:
+      filter.text = stringFilter;
+      break;
+  }
   return filter;
 }
 

--- a/apps/web/core/sync/experimental_query-layer.ts
+++ b/apps/web/core/sync/experimental_query-layer.ts
@@ -41,14 +41,24 @@ export type NumberCondition = {
   lt?: number;
   lte?: number;
   between?: [number, number];
+  in?: number[];
 };
 
 export type BooleanCondition = { equals: boolean };
+
+/**
+ * Scalar dataType hint used by the GraphQL converter to route a value-typed
+ * filter to the correct underlying field on `ValueFilter` (e.g. `text` vs
+ * `integer` vs `datetime`). Mirrors `Property.dataType` for the value-typed
+ * subset (relations are routed via `RelationCondition`, not here).
+ */
+export type ValueDataType = 'TEXT' | 'INTEGER' | 'FLOAT' | 'DECIMAL' | 'DATETIME' | 'DATE' | 'TIME' | 'BOOLEAN';
 
 export type ValueCondition = {
   propertyId?: StringCondition;
   value?: StringCondition | NumberCondition | BooleanCondition;
   space?: StringCondition;
+  dataType?: ValueDataType;
 };
 
 export type RelationCondition = {

--- a/apps/web/partials/blocks/table/table-block-filter-pill.tsx
+++ b/apps/web/partials/blocks/table/table-block-filter-pill.tsx
@@ -24,6 +24,14 @@ function PublishedFilterIconFilled() {
 export type FilterGroup = {
   columnId: string;
   columnName: string | null;
+  /**
+   * True when every chip in the group resolves a relation (entity-id) value
+   * — including special properties like `Types`, `Space`, and backlinks. Only
+   * relation groups can meaningfully toggle between AND and OR within a
+   * single property; value-typed groups (text/number/date) always OR-collapse
+   * via `in`/`inInsensitive` so the pill hides its mode toggle for them.
+   */
+  isRelationGroup: boolean;
   filters: { filter: Filter; originalIndex: number }[];
 };
 
@@ -38,6 +46,7 @@ export function groupFilters(filters: Filter[]): FilterGroup[] {
       groups.set(f.columnId, {
         columnId: f.columnId,
         columnName: f.columnName,
+        isRelationGroup: f.valueType === 'RELATION',
         filters: [{ filter: f, originalIndex: index }],
       });
     }
@@ -71,6 +80,11 @@ export function TableBlockFilterGroupPill({
 }: TableBlockFilterGroupPillProps) {
   const hasMultipleValues = group.filters.length > 1;
 
+  // The mode toggle is only meaningful for RELATION groups — value-typed
+  // groups (text/number/date) always OR-collapse via the GraphQL `in`
+  // operators, so AND would have no representation on the wire.
+  const showModeToggle = hasMultipleValues && group.isRelationGroup;
+
   // The mode toggle is only interactive when the user can actually modify
   // at least one value in the group (i.e. is editing, or has local filters).
   const hasAnyLocalFilter = group.filters.some(({ filter }) => !serverFilterKeys.has(filterKey(filter)));
@@ -89,7 +103,7 @@ export function TableBlockFilterGroupPill({
           ) : (
             <>{group.columnName} is</>
           )}
-          {hasMultipleValues && (
+          {showModeToggle && (
             <>
               {' '}
               {canToggleMode ? (

--- a/apps/web/partials/blocks/table/table-block.tsx
+++ b/apps/web/partials/blocks/table/table-block.tsx
@@ -284,23 +284,23 @@ export const TableBlock = ({ spaceId, blockId }: Props) => {
     shownColumnIds,
     source,
     filterState: activeFilters,
-    filterMode: activeFilterMode,
+    modesByColumn: activeModesByColumn,
     dbFilterState,
     setFilterState,
-    setFilterMode,
+    setGroupMode,
     setTemporaryFilters,
-    setTemporaryFilterMode,
+    setTemporaryGroupMode,
     sortState,
     setSortState,
     filterableProperties,
   } = useDataBlock({ canEdit });
 
-  const setActiveFilterMode = React.useCallback(
-    (mode: FilterMode) => {
-      if (canEdit) setFilterMode(mode);
-      else setTemporaryFilterMode(mode);
+  const setActiveGroupMode = React.useCallback(
+    (columnId: string, mode: FilterMode) => {
+      if (canEdit) setGroupMode(columnId, mode);
+      else setTemporaryGroupMode(columnId, mode);
     },
-    [canEdit, setFilterMode, setTemporaryFilterMode]
+    [canEdit, setGroupMode, setTemporaryGroupMode]
   );
 
   const filterSpaceIds = React.useMemo(
@@ -540,24 +540,27 @@ export const TableBlock = ({ spaceId, blockId }: Props) => {
                 filterSuggestionSpaceId={spaceId}
               />
 
-              {filterGroups.map(group => (
-                <React.Fragment key={group.columnId}>
-                  <TableBlockFilterGroupPill
-                    group={group}
-                    mode={activeFilterMode}
-                    onToggleMode={() => setActiveFilterMode(activeFilterMode === 'AND' ? 'OR' : 'AND')}
-                    onDeleteValue={originalIndex => {
-                      const newFilterState = produce(activeFilters, draft => {
-                        draft.splice(originalIndex, 1);
-                      });
-                      setActiveFilters(newFilterState);
-                    }}
-                    onAddSimilar={() => filterPromptRef.current?.openWithColumn(group.columnId)}
-                    isEditing={isEditing}
-                    serverFilterKeys={serverFilterKeys}
-                  />
-                </React.Fragment>
-              ))}
+              {filterGroups.map(group => {
+                const groupMode: FilterMode = activeModesByColumn[group.columnId] ?? 'OR';
+                return (
+                  <React.Fragment key={group.columnId}>
+                    <TableBlockFilterGroupPill
+                      group={group}
+                      mode={groupMode}
+                      onToggleMode={() => setActiveGroupMode(group.columnId, groupMode === 'AND' ? 'OR' : 'AND')}
+                      onDeleteValue={originalIndex => {
+                        const newFilterState = produce(activeFilters, draft => {
+                          draft.splice(originalIndex, 1);
+                        });
+                        setActiveFilters(newFilterState);
+                      }}
+                      onAddSimilar={() => filterPromptRef.current?.openWithColumn(group.columnId)}
+                      isEditing={isEditing}
+                      serverFilterKeys={serverFilterKeys}
+                    />
+                  </React.Fragment>
+                );
+              })}
             </motion.div>
           </motion.div>
         </AnimatePresence>

--- a/apps/web/partials/power-tools/hooks/use-power-tools-data.ts
+++ b/apps/web/partials/power-tools/hooks/use-power-tools-data.ts
@@ -5,7 +5,7 @@ import { keepPreviousData, useQuery } from '@tanstack/react-query';
 
 import * as React from 'react';
 
-import { Filter, FilterMode } from '~/core/blocks/data/filters';
+import { Filter, ModesByColumn } from '~/core/blocks/data/filters';
 import { useCollection } from '~/core/blocks/data/use-collection';
 import { filterStateToWhere, useDataBlock, useDataBlockInstance } from '~/core/blocks/data/use-data-block';
 import { useFilters } from '~/core/blocks/data/use-filters';
@@ -52,7 +52,7 @@ function buildRowMeta(
 export function usePowerToolsData(options?: {
   pageSize?: number;
   filterStateOverride?: Filter[];
-  filterModeOverride?: FilterMode;
+  modesByColumnOverride?: ModesByColumn;
   /** Extra column (property) IDs to always show, e.g. newly created properties. */
   extraColumnIds?: string[];
   /** Column (property) IDs to hide from the table, e.g. after "Remove Property". */
@@ -69,16 +69,16 @@ export function usePowerToolsData(options?: {
     [options?.excludedColumnIds]
   );
   const { spaceId } = useDataBlockInstance();
-  const { resolvedFilterState, isFilterResolving, filterMode, filterState, setFilterState } = useFilters();
+  const { resolvedFilterState, isFilterResolving, modesByColumn, filterState, setFilterState } = useFilters();
   const { source } = useSource({ filterState, setFilterState });
   const { blockEntity } = useDataBlock();
   const { shownColumnRelations } = useView();
 
   const effectiveFilterState = options?.filterStateOverride ?? resolvedFilterState;
-  const effectiveFilterMode = options?.filterModeOverride ?? filterMode;
+  const effectiveModesByColumn = options?.modesByColumnOverride ?? modesByColumn;
   const where = React.useMemo(
-    () => filterStateToWhere(effectiveFilterState, effectiveFilterMode),
-    [effectiveFilterState, effectiveFilterMode]
+    () => filterStateToWhere(effectiveFilterState, effectiveModesByColumn),
+    [effectiveFilterState, effectiveModesByColumn]
   );
 
   const queryEntitiesAsync = useQueryEntitiesAsync();

--- a/apps/web/partials/power-tools/power-tools-screen.tsx
+++ b/apps/web/partials/power-tools/power-tools-screen.tsx
@@ -164,10 +164,10 @@ export function PowerToolsScreen() {
     temporaryFilters,
     setFilterState,
     setTemporaryFilters,
-    filterMode,
-    setFilterMode,
-    temporaryFilterMode,
-    setTemporaryFilterMode,
+    modesByColumn,
+    setGroupMode,
+    temporaryModesByColumn,
+    setTemporaryGroupMode,
   } = useFilters(canEdit);
   const { source } = useSource({ filterState, setFilterState });
 
@@ -175,13 +175,13 @@ export function PowerToolsScreen() {
   // This matches TableBlock's behavior and is independent of the edit mode toggle.
   const effectiveFilterState = canEdit ? resolvedFilterState : temporaryFilters;
   const effectiveSetFilterState = canEdit ? setFilterState : setTemporaryFilters;
-  const activeFilterMode = canEdit ? filterMode : temporaryFilterMode;
-  const setActiveFilterMode = React.useCallback(
-    (mode: FilterMode) => {
-      if (canEdit) setFilterMode(mode);
-      else setTemporaryFilterMode(mode);
+  const activeModesByColumn = canEdit ? modesByColumn : temporaryModesByColumn;
+  const setActiveGroupMode = React.useCallback(
+    (columnId: string, mode: FilterMode) => {
+      if (canEdit) setGroupMode(columnId, mode);
+      else setTemporaryGroupMode(columnId, mode);
     },
-    [canEdit, setFilterMode, setTemporaryFilterMode]
+    [canEdit, setGroupMode, setTemporaryGroupMode]
   );
 
   const [extraColumnIds, setExtraColumnIds] = React.useState<string[]>([]);
@@ -195,7 +195,7 @@ export function PowerToolsScreen() {
 
   const data = usePowerToolsData({
     filterStateOverride: canEdit ? undefined : temporaryFilters,
-    filterModeOverride: canEdit ? undefined : temporaryFilterMode,
+    modesByColumnOverride: canEdit ? undefined : temporaryModesByColumn,
     extraColumnIds,
     excludedColumnIds,
     sort: serverSort,
@@ -959,18 +959,21 @@ export function PowerToolsScreen() {
       {hasActiveFilters && (
         <div className="flex items-center gap-2 border-b border-grey-02 px-4 py-2">
           <div className="flex flex-wrap items-center gap-1.5">
-            {filterGroups.map(group => (
-              <React.Fragment key={group.columnId}>
-                <TableBlockFilterGroupPill
-                  group={group}
-                  mode={activeFilterMode}
-                  onToggleMode={() => setActiveFilterMode(activeFilterMode === 'AND' ? 'OR' : 'AND')}
-                  onDeleteValue={originalIndex => handleDeleteFilter(originalIndex)}
-                  isEditing={isEditing}
-                  serverFilterKeys={serverFilterKeys}
-                />
-              </React.Fragment>
-            ))}
+            {filterGroups.map(group => {
+              const groupMode: FilterMode = activeModesByColumn[group.columnId] ?? 'OR';
+              return (
+                <React.Fragment key={group.columnId}>
+                  <TableBlockFilterGroupPill
+                    group={group}
+                    mode={groupMode}
+                    onToggleMode={() => setActiveGroupMode(group.columnId, groupMode === 'AND' ? 'OR' : 'AND')}
+                    onDeleteValue={originalIndex => handleDeleteFilter(originalIndex)}
+                    isEditing={isEditing}
+                    serverFilterKeys={serverFilterKeys}
+                  />
+                </React.Fragment>
+              );
+            })}
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary
- Replaces the global filter `mode` with per-property modes (one AND/OR per column).
- Collapses multi-value selections into single GraphQL `in` clauses: RELATION → `toEntity.id.in`, TEXT → `text.inInsensitive`, numeric/date filters route to the right scalar via a new `dataType` discriminator on `ValueCondition`.
- Adds `dataType`-aware scalar routing in the converter so future numeric / date / datetime UI lands without converter changes.
- Migrates old persisted filters in-memory on read (legacy `mode: 'OR'` fans out to every property group); next save writes the new shape only — no compat shim long-term.

## Why
- The global `'AND' | 'OR'` toggle was the wrong granularity. Users want "type is Person OR Author, AND status is Active" — per-property OR with implicit AND between columns. The global mode couldn't express that.
- N values for the same property used to expand to N nested `OR` clauses on the wire (each its own `relations.some {...}` / `values.some {...}`). The schema has `in` everywhere relevant, so a multi-value selection collapses to one clause — smaller payload, simpler filter, less work on the API.

## Architecture notes
- New `buildGroupWhere(filters, groupMode)` in `use-data-block.tsx` replaces the prior `buildSingleFilterWhere` / `buildOrWhere` / `buildAndWhere` trio.
- `WhereCondition` (DSL) gains `ValueCondition.dataType` and `NumberCondition.in`. The local `EntityQuery` engine doesn't need updates for the dataType hint — the converter is the only consumer that uses it.
- Persisted format adds `modes: Record<columnId, 'AND' | 'OR'>` and stops emitting the legacy top-level `mode`. Schema keeps `mode` optional for read-time compat.
- The per-group default mode is `'OR'` (collapses cleanly to `in`); the persisted `modes` map only stores entries that diverge from default — keeps wire noise down.

## Out of scope (separate PRs)
- **Backlinks in the filter creation UI.** The engine handles them already (`isBacklink` round-trips through persistence + WHERE-builder + converter), but the picker has no path to add one. Tracked as PR B.
- **Multi-value chips for numeric / date / boolean.** Converter routes by dataType when given multi-value, but the UI doesn't surface those pickers today. Future PR adds the pickers; the engine is ready.
- **Per-group `AND` for spaces.** Kept OR-only (matches the top-level `spaceIds.in` API shape).

## Test plan
- [ ] **Single relation column, multi-value, OR mode (default).** Network tab: filter payload uses `relations.some.toEntity.id.in: [...]` (one clause), not nested OR.
- [ ] **Same column, click toggle to AND.** Payload becomes `and: [{...}, {...}]` (one per chip). Results narrow to entities matching all values.
- [ ] **Two different columns, both multi-value.** Each column collapses to its own `in` clause; the two clauses are AND'd between groups regardless of per-group toggle.
- [ ] **TEXT column, multi-value.** No mode toggle visible. Payload uses `text.inInsensitive: [...]`.
- [ ] **Open a data block in legacy format** (persisted with `mode: 'OR'`, multiple property groups). Renders correctly. Edit any chip → save. Reopen the entity values raw and confirm the persisted filter string now uses `modes` and the legacy `mode` key is gone.
- [ ] **Add → remove a relation chip in a group, then add again.** No stale `modes[columnId]` entries persist when the group goes empty.
- [ ] **Power tools panel + non-edit (temporary) filters.** Per-group toggle still works in the temporary state.
- [ ] **Chat tool flow:** issue a `setDataBlockFilters` write with `modesByColumn: { typeId: 'AND' }` → verify the persisted filter has the right `modes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)