### PR TITLE
fix(space-members): seed popover/dialog count from SSR to avoid 0-flash

### DIFF
--- a/apps/web/core/space-members/use-space-participants-infinite.ts
+++ b/apps/web/core/space-members/use-space-participants-infinite.ts
@@ -45,6 +45,12 @@ type UseSpaceParticipantsInfiniteArgs = {
   kind: ParticipantKind;
   enabled?: boolean;
   pageSize?: number;
+  /**
+   * Server-known total to display before the first page resolves. Avoids the
+   * "0 members → 231 members" flash on popover open. The chip already has
+   * this number from the SSR `space.totalMembers` / `space.totalEditors`.
+   */
+  initialTotalCount?: number;
 };
 
 export function useSpaceParticipantsInfinite({
@@ -52,6 +58,7 @@ export function useSpaceParticipantsInfinite({
   kind,
   enabled = true,
   pageSize = SPACE_PARTICIPANTS_PAGE_SIZE,
+  initialTotalCount,
 }: UseSpaceParticipantsInfiniteArgs) {
   const query = useInfiniteQuery({
     enabled,
@@ -70,9 +77,9 @@ export function useSpaceParticipantsInfinite({
     return flat;
   }, [query.data?.pages]);
 
-  // The chip and the popover/dialog footers all read this. It's authoritative
-  // because it comes from the GraphQL `totalCount`, not the loaded page length.
-  const totalCount = query.data?.pages[0]?.totalCount ?? 0;
+  // Prefer the live count from the API once available; fall back to the
+  // server-seeded count so the footer/header doesn't flash 0 on open.
+  const totalCount = query.data?.pages[0]?.totalCount ?? initialTotalCount ?? 0;
 
   return {
     participants,

--- a/apps/web/partials/space-page/space-editors-dialog-server-container.tsx
+++ b/apps/web/partials/space-page/space-editors-dialog-server-container.tsx
@@ -1,12 +1,18 @@
 import { SpaceEditorsManageDialogContent } from './space-editors-manage-dialog-content';
 import { SpaceMembersManageDialog } from './space-members-manage-dialog';
 
-export function SpaceEditorsDialogServerContainer({ spaceId }: { spaceId: string }) {
+export function SpaceEditorsDialogServerContainer({
+  spaceId,
+  initialTotalEditors,
+}: {
+  spaceId: string;
+  initialTotalEditors: number;
+}) {
   return (
     <SpaceMembersManageDialog
       header={<h1 className="text-smallTitle">Manage editors</h1>}
       trigger={<p>Manage editors</p>}
-      content={<SpaceEditorsManageDialogContent spaceId={spaceId} />}
+      content={<SpaceEditorsManageDialogContent spaceId={spaceId} initialTotalEditors={initialTotalEditors} />}
     />
   );
 }

--- a/apps/web/partials/space-page/space-editors-manage-dialog-content.tsx
+++ b/apps/web/partials/space-page/space-editors-manage-dialog-content.tsx
@@ -17,11 +17,12 @@ import { MemberRow } from './space-member-row';
 
 interface Props {
   spaceId: string;
+  initialTotalEditors: number;
 }
 
-export function SpaceEditorsManageDialogContent({ spaceId }: Props) {
+export function SpaceEditorsManageDialogContent({ spaceId, initialTotalEditors }: Props) {
   const { participants, totalCount, isLoading, isFetchingNextPage, hasNextPage, fetchNextPage } =
-    useSpaceParticipantsInfinite({ spaceId, kind: 'editors' });
+    useSpaceParticipantsInfinite({ spaceId, kind: 'editors', initialTotalCount: initialTotalEditors });
 
   const sentinelRef = useInfiniteScrollSentinel({ hasNextPage, isFetchingNextPage, fetchNextPage });
 

--- a/apps/web/partials/space-page/space-editors-popover-content.tsx
+++ b/apps/web/partials/space-page/space-editors-popover-content.tsx
@@ -20,6 +20,7 @@ interface Props {
   isMember: boolean;
   hasRequestedSpaceEditorship: boolean;
   connectedAddress: string | null;
+  initialTotalEditors: number;
 }
 
 export function SpaceEditorsContent({
@@ -28,9 +29,10 @@ export function SpaceEditorsContent({
   isMember,
   hasRequestedSpaceEditorship,
   connectedAddress,
+  initialTotalEditors,
 }: Props) {
   const { participants, totalCount, isLoading, isFetchingNextPage, hasNextPage, fetchNextPage } =
-    useSpaceParticipantsInfinite({ spaceId, kind: 'editors' });
+    useSpaceParticipantsInfinite({ spaceId, kind: 'editors', initialTotalCount: initialTotalEditors });
 
   const sentinelRef = useInfiniteScrollSentinel({ hasNextPage, isFetchingNextPage, fetchNextPage });
 

--- a/apps/web/partials/space-page/space-editors.tsx
+++ b/apps/web/partials/space-page/space-editors.tsx
@@ -42,6 +42,7 @@ export async function SpaceEditors({ spaceId }: Props) {
       isMember={isMember}
       hasRequestedSpaceEditorship={hasRequestedSpaceEditorship}
       connectedAddress={connectedAddress ?? null}
+      initialTotalEditors={space.totalEditors}
     />
   );
 
@@ -53,7 +54,9 @@ export async function SpaceEditors({ spaceId }: Props) {
 
         <SpaceMembersMenu
           trigger={<ChevronDownSmall color="grey-04" />}
-          manageMembersComponent={<SpaceEditorsDialogServerContainer spaceId={spaceId} />}
+          manageMembersComponent={
+            <SpaceEditorsDialogServerContainer spaceId={spaceId} initialTotalEditors={space.totalEditors} />
+          }
         />
       </div>
     );

--- a/apps/web/partials/space-page/space-members-dialog-server-container.tsx
+++ b/apps/web/partials/space-page/space-members-dialog-server-container.tsx
@@ -1,12 +1,18 @@
 import { SpaceMembersManageDialog } from './space-members-manage-dialog';
 import { SpaceMembersManageDialogContent } from './space-members-manage-dialog-content';
 
-export function SpaceMembersDialogServerContainer({ spaceId }: { spaceId: string }) {
+export function SpaceMembersDialogServerContainer({
+  spaceId,
+  initialTotalMembers,
+}: {
+  spaceId: string;
+  initialTotalMembers: number;
+}) {
   return (
     <SpaceMembersManageDialog
       header={<h1 className="text-smallTitle">Manage members</h1>}
       trigger={<p>Manage members</p>}
-      content={<SpaceMembersManageDialogContent spaceId={spaceId} />}
+      content={<SpaceMembersManageDialogContent spaceId={spaceId} initialTotalMembers={initialTotalMembers} />}
     />
   );
 }

--- a/apps/web/partials/space-page/space-members-manage-dialog-content.tsx
+++ b/apps/web/partials/space-page/space-members-manage-dialog-content.tsx
@@ -17,11 +17,12 @@ import { MemberRow } from './space-member-row';
 
 interface Props {
   spaceId: string;
+  initialTotalMembers: number;
 }
 
-export function SpaceMembersManageDialogContent({ spaceId }: Props) {
+export function SpaceMembersManageDialogContent({ spaceId, initialTotalMembers }: Props) {
   const { participants, totalCount, isLoading, isFetchingNextPage, hasNextPage, fetchNextPage } =
-    useSpaceParticipantsInfinite({ spaceId, kind: 'members' });
+    useSpaceParticipantsInfinite({ spaceId, kind: 'members', initialTotalCount: initialTotalMembers });
 
   const sentinelRef = useInfiniteScrollSentinel({ hasNextPage, isFetchingNextPage, fetchNextPage });
 

--- a/apps/web/partials/space-page/space-members-popover-content.tsx
+++ b/apps/web/partials/space-page/space-members-popover-content.tsx
@@ -20,6 +20,7 @@ interface Props {
   isMember: boolean;
   hasRequestedSpaceMembership: boolean;
   connectedAddress: string | null;
+  initialTotalMembers: number;
 }
 
 export function SpaceMembersContent({
@@ -28,9 +29,10 @@ export function SpaceMembersContent({
   isMember,
   hasRequestedSpaceMembership,
   connectedAddress,
+  initialTotalMembers,
 }: Props) {
   const { participants, totalCount, isLoading, isFetchingNextPage, hasNextPage, fetchNextPage } =
-    useSpaceParticipantsInfinite({ spaceId, kind: 'members' });
+    useSpaceParticipantsInfinite({ spaceId, kind: 'members', initialTotalCount: initialTotalMembers });
 
   const sentinelRef = useInfiniteScrollSentinel({ hasNextPage, isFetchingNextPage, fetchNextPage });
 

--- a/apps/web/partials/space-page/space-members.tsx
+++ b/apps/web/partials/space-page/space-members.tsx
@@ -46,6 +46,7 @@ export async function SpaceMembers({ spaceId }: Props) {
       isMember={isMember}
       hasRequestedSpaceMembership={hasRequestedSpaceMembership}
       connectedAddress={connectedAddress ?? null}
+      initialTotalMembers={space.totalMembers}
     />
   );
 
@@ -55,7 +56,9 @@ export async function SpaceMembers({ spaceId }: Props) {
         <SpaceMembersPopover trigger={<SpaceMembersChip spaceId={spaceId} />} content={popoverContent} />
         <div className="h-4 w-px bg-divider" />
         <SpaceMembersMenu
-          manageMembersComponent={<SpaceMembersDialogServerContainer spaceId={spaceId} />}
+          manageMembersComponent={
+            <SpaceMembersDialogServerContainer spaceId={spaceId} initialTotalMembers={space.totalMembers} />
+          }
           trigger={<ChevronDownSmall color="grey-04" />}
         />
       </div>


### PR DESCRIPTION
## Summary

Follow-up to #1749. The members/editors popovers (and the Manage… dialogs) briefly rendered \"0 members\" / \"0 editors\" on open before the first paginated API page resolved, even though the chip already had the correct number from SSR.

The chip reads `space.totalMembers` / `space.totalEditors` server-side (added in #1733). This change threads those same numbers into the popover/dialog as `initialTotalMembers` / `initialTotalEditors`, and the shared `useSpaceParticipantsInfinite` hook uses them as the fallback until the live API count arrives.

```ts
const totalCount = query.data?.pages[0]?.totalCount ?? initialTotalCount ?? 0;
```

So the count is correct on first paint and only ever \"refreshes\" if the SSR value and the live API value disagree (which they shouldn't — both come from the same GraphQL `totalCount`).

## Test plan

- [ ] Open the AI space members popover: footer reads `231 members` immediately, no flash to 0.
- [ ] Open \"Manage members\" on the AI space: heading reads `231 members` immediately.
- [ ] Same for editors popover and \"Manage editors\".
- [ ] Smaller space (≤100 members): no regressions.