### PR TITLE
fix: build DAO publish proposals locally

### DIFF
--- a/apps/web/core/hooks/use-publish.ts
+++ b/apps/web/core/hooks/use-publish.ts
@@ -1,14 +1,15 @@
 'use client';
 
-import { daoSpace, personalSpace } from '@geoprotocol/geo-sdk';
+import { Ipfs, personalSpace } from '@geoprotocol/geo-sdk';
 import { Op } from '@geoprotocol/geo-sdk/lite';
 
 import * as React from 'react';
 
 import { Duration, Effect, Either, Schedule } from 'effect';
 
-import { getSpaceAccess } from '~/core/access/space-access';
+import { getSpaceAccess, normalizeSpaceId } from '~/core/access/space-access';
 import { Relation, Value } from '~/core/types';
+import { buildDaoPublishEditProposalCalldata } from '~/core/utils/contracts/publish-proposal';
 
 import { TransactionWriteFailedError } from '../errors';
 import { getSpace } from '../io/queries';
@@ -67,27 +68,35 @@ export function usePublish() {
       }
       if (valuesToPublish.length === 0 && relations.length === 0) return;
 
-      const space = await Effect.runPromise(getSpace(spaceId));
+      const normalizedSpaceId = normalizeSpaceId(spaceId);
+      const normalizedPersonalSpaceId = normalizeSpaceId(personalSpaceId);
+      const space = await Effect.runPromise(getSpace(normalizedSpaceId));
 
       if (!space) return;
 
       const publish = Effect.gen(function* () {
-        const ops = yield* Publish.prepareLocalDataForPublishing(valuesToPublish, relations, spaceId);
+        const ops = yield* Publish.prepareLocalDataForPublishing(valuesToPublish, relations, normalizedSpaceId);
 
         if (ops.length === 0) {
           console.error('resulting ops are empty, cancelling publish', {
             values: valuesToPublish,
             relations,
-            spaceId,
+            spaceId: normalizedSpaceId,
           });
           return;
         }
 
-        const spaceAccess = yield* getSpaceAccess(space, personalSpaceId);
+        const spaceAccess = yield* getSpaceAccess(space, normalizedPersonalSpaceId);
+
+        if (!spaceAccess.canEdit) {
+          return yield* Effect.fail(
+            new TransactionWriteFailedError('Unable to publish: you are not a member or editor of this space.')
+          );
+        }
 
         yield* makeProposal({
           name,
-          author: personalSpaceId,
+          author: normalizedPersonalSpaceId,
           proposalId,
           onChangePublishState: (newState: ReviewState) =>
             dispatch({
@@ -97,7 +106,7 @@ export function usePublish() {
           ops,
           smartAccount,
           space: {
-            id: space.id,
+            id: normalizedSpaceId,
             type: space.type,
             address: space.address,
             isEditor: spaceAccess.isEditor,
@@ -166,17 +175,25 @@ export function useBulkPublish() {
       // @TODO(governance): Pass this to either the makeProposal call or to usePublish.
       // All of our contract calls rely on knowing plugin metadata so this is probably
       // something we need for all of them.
-      const space = await Effect.runPromise(getSpace(spaceId));
+      const normalizedSpaceId = normalizeSpaceId(spaceId);
+      const normalizedPersonalSpaceId = normalizeSpaceId(personalSpaceId);
+      const space = await Effect.runPromise(getSpace(normalizedSpaceId));
 
       if (!space) return;
 
       const publish = Effect.gen(function* () {
-        const ops = yield* Publish.prepareLocalDataForPublishing(triples, relations, spaceId);
-        const spaceAccess = yield* getSpaceAccess(space, personalSpaceId);
+        const ops = yield* Publish.prepareLocalDataForPublishing(triples, relations, normalizedSpaceId);
+        const spaceAccess = yield* getSpaceAccess(space, normalizedPersonalSpaceId);
+
+        if (!spaceAccess.canEdit) {
+          return yield* Effect.fail(
+            new TransactionWriteFailedError('Unable to publish: you are not a member or editor of this space.')
+          );
+        }
 
         yield* makeProposal({
           name,
-          author: personalSpaceId,
+          author: normalizedPersonalSpaceId,
           onChangePublishState: (newState: ReviewState) =>
             dispatch({
               type: 'SET_REVIEW_STATE',
@@ -185,7 +202,7 @@ export function useBulkPublish() {
           ops,
           smartAccount,
           space: {
-            id: space.id,
+            id: normalizedSpaceId,
             type: space.type,
             address: space.address,
             isEditor: spaceAccess.isEditor,
@@ -294,22 +311,17 @@ function makeProposal(args: MakeProposalArgs) {
       // Members must use the slow path which requires a voting period.
       const votingMode = space.isEditor ? 'FAST' : 'SLOW';
 
-      const result = yield* Effect.retry(
+      const edit = yield* Effect.retry(
         Effect.tryPromise({
           try: () =>
-            daoSpace.proposeEdit({
+            Ipfs.publishEdit({
               name,
               ops,
               author,
-              daoSpaceAddress: space.address as `0x${string}`,
-              callerSpaceId: `0x${author}`,
-              daoSpaceId: `0x${space.id}`,
-              votingMode,
-              ...(proposalId ? { proposalId: `0x${proposalId}` as `0x${string}` } : {}),
               network: 'TESTNET',
             }),
           catch: error => {
-            console.error('[PUBLISH] daoSpace.proposeEdit failed:', error);
+            console.error('[PUBLISH] Ipfs.publishEdit failed:', error);
             return new TransactionWriteFailedError('IPFS upload failed', { cause: error });
           },
         }).pipe(
@@ -321,11 +333,20 @@ function makeProposal(args: MakeProposalArgs) {
             'governance.action': 'proposal_created',
           })
         ),
-        retrySchedule('proposeEdit', Duration.minutes(1))
+        retrySchedule('publishEdit', Duration.minutes(1))
       );
 
-      to = result.to as `0x${string}`;
-      calldata = result.calldata as `0x${string}`;
+      const proposal = buildDaoPublishEditProposalCalldata({
+        authorSpaceId: author,
+        daoSpaceId: space.id,
+        daoSpaceAddress: space.address as `0x${string}`,
+        proposalId: proposalId ?? edit.editId,
+        cid: edit.cid,
+        votingMode,
+      });
+
+      to = proposal.to;
+      calldata = proposal.calldata;
     } else {
       // Personal spaces: use personalSpace.publishEdit()
       const result = yield* Effect.retry(
@@ -362,11 +383,9 @@ function makeProposal(args: MakeProposalArgs) {
     const result = yield* Effect.retry(
       Effect.tryPromise({
         try: () =>
-          smartAccount.sendUserOperation({
-            calls: [{ to, value: 0n, data: calldata }],
-          }),
+          smartAccount.sendTransaction({ to, value: 0n, data: calldata }),
         catch: error => {
-          console.error('[PUBLISH] sendUserOperation failed:', error);
+          console.error('[PUBLISH] sendTransaction failed:', error);
           return new TransactionWriteFailedError('Publish failed', { cause: error });
         },
       }).pipe(

--- a/apps/web/core/utils/contracts/publish-proposal.test.ts
+++ b/apps/web/core/utils/contracts/publish-proposal.test.ts
@@ -1,0 +1,107 @@
+import { decodeAbiParameters, decodeFunctionData } from 'viem';
+import { describe, expect, it } from 'vitest';
+
+import { buildDaoPublishEditProposalCalldata } from './publish-proposal';
+import {
+  DAOSpaceAbi,
+  EMPTY_SIGNATURE,
+  EMPTY_TOPIC_HEX,
+  GOVERNANCE_ACTIONS,
+  SPACE_REGISTRY_ADDRESS,
+  SpaceRegistryAbi,
+  VOTING_MODE,
+} from './space-registry';
+
+describe('buildDaoPublishEditProposalCalldata', () => {
+  it('builds a slow publish proposal with normalized ids and the app governance encoding', () => {
+    const result = buildDaoPublishEditProposalCalldata({
+      authorSpaceId: '68e800d1-d89e-8f0c-3293-82f4c3106d78',
+      daoSpaceId: 'C9F267DC-B0D2-7071-8C2A-3C45A64AFD32',
+      daoSpaceAddress: '0x40230BBf745b3708688347aDe02d04e52eD82f45',
+      proposalId: '11111111-1111-1111-1111-111111111111',
+      cid: 'ipfs://example-edit-cid',
+      votingMode: 'SLOW',
+    });
+
+    expect(result.to).toBe(SPACE_REGISTRY_ADDRESS);
+
+    const decodedEnter = decodeFunctionData({
+      abi: SpaceRegistryAbi,
+      data: result.calldata,
+    });
+
+    expect(decodedEnter.functionName).toBe('enter');
+    expect(decodedEnter.args).toEqual([
+      '0x68e800d1d89e8f0c329382f4c3106d78',
+      '0xc9f267dcb0d270718c2a3c45a64afd32',
+      GOVERNANCE_ACTIONS.PROPOSAL_CREATED,
+      EMPTY_TOPIC_HEX,
+      expect.any(String),
+      EMPTY_SIGNATURE,
+    ]);
+
+    const [proposalId, votingMode, actions] = decodeAbiParameters(
+      [
+        { name: 'proposalId', type: 'bytes16' },
+        { name: 'votingMode', type: 'uint8' },
+        {
+          name: 'actions',
+          type: 'tuple[]',
+          components: [
+            { name: 'to', type: 'address' },
+            { name: 'value', type: 'uint256' },
+            { name: 'data', type: 'bytes' },
+          ],
+        },
+      ],
+      decodedEnter.args[4]
+    );
+
+    expect(proposalId).toBe('0x11111111111111111111111111111111');
+    expect(votingMode).toBe(VOTING_MODE.SLOW);
+    expect(actions).toHaveLength(1);
+    expect(actions[0].to).toBe('0x40230BBf745b3708688347aDe02d04e52eD82f45');
+
+    const decodedPublish = decodeFunctionData({
+      abi: DAOSpaceAbi,
+      data: actions[0].data,
+    });
+
+    expect(decodedPublish.functionName).toBe('publish');
+    expect(decodedPublish.args[0]).toBe(EMPTY_TOPIC_HEX);
+  });
+
+  it('encodes fast voting mode for editors', () => {
+    const result = buildDaoPublishEditProposalCalldata({
+      authorSpaceId: '68e800d1d89e8f0c329382f4c3106d78',
+      daoSpaceId: 'c9f267dcb0d270718c2a3c45a64afd32',
+      daoSpaceAddress: '0x40230BBf745b3708688347aDe02d04e52eD82f45',
+      proposalId: '11111111111111111111111111111111',
+      cid: 'ipfs://example-edit-cid',
+      votingMode: 'FAST',
+    });
+
+    const decodedEnter = decodeFunctionData({
+      abi: SpaceRegistryAbi,
+      data: result.calldata,
+    });
+    const [, votingMode] = decodeAbiParameters(
+      [
+        { name: 'proposalId', type: 'bytes16' },
+        { name: 'votingMode', type: 'uint8' },
+        {
+          name: 'actions',
+          type: 'tuple[]',
+          components: [
+            { name: 'to', type: 'address' },
+            { name: 'value', type: 'uint256' },
+            { name: 'data', type: 'bytes' },
+          ],
+        },
+      ],
+      decodedEnter.args[4]
+    );
+
+    expect(votingMode).toBe(VOTING_MODE.FAST);
+  });
+});

--- a/apps/web/core/utils/contracts/publish-proposal.ts
+++ b/apps/web/core/utils/contracts/publish-proposal.ts
@@ -1,0 +1,75 @@
+import { type Hex, encodeAbiParameters, encodeFunctionData } from 'viem';
+
+import { normalizeSpaceId } from '~/core/access/space-access';
+
+import { encodeProposalCreatedData } from './governance';
+import {
+  DAOSpaceAbi,
+  EMPTY_SIGNATURE,
+  EMPTY_TOPIC_HEX,
+  GOVERNANCE_ACTIONS,
+  SPACE_REGISTRY_ADDRESS,
+  SpaceRegistryAbi,
+  VOTING_MODE,
+} from './space-registry';
+
+export type DaoPublishVotingMode = 'FAST' | 'SLOW';
+
+export type DaoPublishEditProposalCalldataArgs = {
+  authorSpaceId: string;
+  daoSpaceId: string;
+  daoSpaceAddress: Hex;
+  proposalId: string;
+  cid: string;
+  votingMode: DaoPublishVotingMode;
+};
+
+export function buildDaoPublishEditProposalCalldata({
+  authorSpaceId,
+  daoSpaceId,
+  daoSpaceAddress,
+  proposalId,
+  cid,
+  votingMode,
+}: DaoPublishEditProposalCalldataArgs): { to: Hex; calldata: Hex } {
+  const normalizedAuthorSpaceId = normalizeSpaceId(authorSpaceId);
+  const normalizedDaoSpaceId = normalizeSpaceId(daoSpaceId);
+  const normalizedProposalId = normalizeSpaceId(proposalId);
+
+  const editsContentUri = encodeAbiParameters([{ type: 'string' }], [cid]);
+  const publishCalldata = encodeFunctionData({
+    functionName: 'publish',
+    abi: DAOSpaceAbi,
+    args: [EMPTY_TOPIC_HEX, editsContentUri, '0x'],
+  });
+
+  const data = encodeProposalCreatedData(
+    `0x${normalizedProposalId}`,
+    votingMode === 'FAST' ? VOTING_MODE.FAST : VOTING_MODE.SLOW,
+    [
+      {
+        to: daoSpaceAddress,
+        value: 0n,
+        data: publishCalldata,
+      },
+    ]
+  );
+
+  const calldata = encodeFunctionData({
+    functionName: 'enter',
+    abi: SpaceRegistryAbi,
+    args: [
+      `0x${normalizedAuthorSpaceId}`,
+      `0x${normalizedDaoSpaceId}`,
+      GOVERNANCE_ACTIONS.PROPOSAL_CREATED,
+      EMPTY_TOPIC_HEX,
+      data,
+      EMPTY_SIGNATURE,
+    ],
+  });
+
+  return {
+    to: SPACE_REGISTRY_ADDRESS,
+    calldata,
+  };
+}

--- a/apps/web/core/utils/contracts/space-registry.ts
+++ b/apps/web/core/utils/contracts/space-registry.ts
@@ -76,6 +76,17 @@ export const VOTING_MODE = {
  */
 export const DAOSpaceAbi = [
   {
+    inputs: [
+      { internalType: 'bytes32', name: '_topic', type: 'bytes32' },
+      { internalType: 'bytes', name: '_editsContentUri', type: 'bytes' },
+      { internalType: 'bytes', name: '_editsMetadata', type: 'bytes' },
+    ],
+    name: 'publish',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
     inputs: [{ internalType: 'bytes16', name: '_newMemberSpaceId', type: 'bytes16' }],
     name: 'addMember',
     outputs: [],


### PR DESCRIPTION
## Summary
- replace the DAO publish path's SDK all-in-one proposal builder with local governance calldata encoding
- keep SDK IPFS edit upload, then submit the proposal through the app's SpaceRegistry proposal shape
- normalize publish IDs and explicitly require centralized member/editor access before proposing
- add coverage for slow member proposals and fast editor proposals

## Investigation notes
- confirmed the affected personal space is a member, not an editor, of Crypto
- simulated a slow PROPOSAL_CREATED call from that personal space into Crypto on testnet; membership itself is accepted on-chain
- this PR focuses on the client publish construction/submission path, which matches the screen-recording symptom after access succeeded

## Verification
- env TMPDIR=/private/tmp mise exec -- bun run test core/utils/contracts/publish-proposal.test.ts core/utils/contracts/space-topic.test.ts core/hooks/use-access-control.test.tsx
- env TMPDIR=/private/tmp mise exec -- bunx eslint core/hooks/use-publish.ts core/utils/contracts/publish-proposal.ts core/utils/contracts/publish-proposal.test.ts core/utils/contracts/space-registry.ts
- env TMPDIR=/private/tmp NEXT_PUBLIC_APP_ENV=production NEXT_PUBLIC_PRIVY_APP_ID=clpsvsqpt005fl70fe775owo5 NEXT_PUBLIC_GEOGENESIS_RPC=https://test.example.com NEXT_PUBLIC_GEOGENESIS_RPC_TESTNET=https://test.example.com NEXT_PUBLIC_API_ENDPOINT=https://test.example.com NEXT_PUBLIC_API_ENDPOINT_TESTNET=https://test.example.com NEXT_PUBLIC_BUNDLER_RPC=https://test.example.com NEXT_PUBLIC_BUNDLER_RPC_TESTNET=https://test.example.com NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID=a NEXT_PUBLIC_PIMLICO_API_KEY=a mise exec -- bun run build