### PR TITLE
fix(entity-page): resolve property description across spaces

### DIFF
--- a/apps/web/partials/entity-page/property-name-link.tsx
+++ b/apps/web/partials/entity-page/property-name-link.tsx
@@ -1,7 +1,10 @@
 'use client';
 
-import { useDescription } from '~/core/state/entity-page-store/entity-store';
+import { SystemIds } from '@geoprotocol/geo-sdk/lite';
+
+import { useValues } from '~/core/sync/use-store';
 import { Property } from '~/core/types';
+import { getSpaceRank } from '~/core/utils/space/space-ranking';
 import { NavUtils } from '~/core/utils/utils';
 
 import { PrefetchLink as Link } from '~/design-system/prefetch-link';
@@ -14,7 +17,17 @@ type PropertyNameLinkProps = {
 };
 
 export function PropertyNameLink({ property, spaceId }: PropertyNameLinkProps) {
-  const description = useDescription(property.id, spaceId)?.trim();
+  const descriptionValues = useValues({
+    selector: v => v.property.id === SystemIds.DESCRIPTION_PROPERTY && v.entity.id === property.id && Boolean(v.value),
+  });
+
+  // Prefer the current (to-)space's description if present, otherwise pick
+  // the value from the highest-ranked space the property is published in.
+  const description = (
+    descriptionValues.find(v => v.spaceId === spaceId)?.value ??
+    [...descriptionValues].sort((a, b) => getSpaceRank(a.spaceId) - getSpaceRank(b.spaceId))[0]?.value ??
+    ''
+  ).trim();
   const propertyName = property.name?.trim() || property.id;
 
   const link = (

--- a/apps/web/partials/entity-page/property-name-link.tsx
+++ b/apps/web/partials/entity-page/property-name-link.tsx
@@ -18,16 +18,24 @@ type PropertyNameLinkProps = {
 
 export function PropertyNameLink({ property, spaceId }: PropertyNameLinkProps) {
   const descriptionValues = useValues({
-    selector: v => v.property.id === SystemIds.DESCRIPTION_PROPERTY && v.entity.id === property.id && Boolean(v.value),
+    selector: v =>
+      v.property.id === SystemIds.DESCRIPTION_PROPERTY &&
+      v.entity.id === property.id &&
+      typeof v.value === 'string' &&
+      v.value.trim().length > 0,
   });
 
   // Prefer the current (to-)space's description if present, otherwise pick
   // the value from the highest-ranked space the property is published in.
-  const description = (
-    descriptionValues.find(v => v.spaceId === spaceId)?.value ??
-    [...descriptionValues].sort((a, b) => getSpaceRank(a.spaceId) - getSpaceRank(b.spaceId))[0]?.value ??
-    ''
-  ).trim();
+  const description =
+    descriptionValues.find(v => v.spaceId === spaceId)?.value.trim() ??
+    descriptionValues
+      .reduce<(typeof descriptionValues)[number] | null>(
+        (best, v) => (best === null || getSpaceRank(v.spaceId) < getSpaceRank(best.spaceId) ? v : best),
+        null
+      )
+      ?.value.trim() ??
+    '';
   const propertyName = property.name?.trim() || property.id;
 
   const link = (


### PR DESCRIPTION
## Summary
- Follow-up to #1729. The property name popover only rendered the description when the user happened to be viewing the entity in the same space where the property's description value was published.
- Now look up the description across all spaces and pick the best one: prefer the current page's `spaceId` (the "to-space"), then fall back to the highest-ranked space (using `getSpaceRank`, the same ordering used elsewhere when choosing an entity's canonical space).

## Test plan
- [ ] Open an entity in a space that does NOT publish the property's description and confirm the property name popover now shows the description on hover.
- [ ] Open an entity in a space that DOES publish the property's description and confirm that space's description still wins.
- [ ] Hover a property whose description is empty everywhere and confirm no popover renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)