### PR TITLE
fix(editor): allow external URL links in block content

### DIFF
--- a/apps/web/core/state/editor/markdown-adapter.test.ts
+++ b/apps/web/core/state/editor/markdown-adapter.test.ts
@@ -164,19 +164,22 @@ describe('markdown-adapter', () => {
       expect(html).toContain('katex');
     });
 
-    it('renders safe https links as anchor tags', () => {
+    it('renders safe https links as anchor tags that open in a new tab', () => {
       const html = markdownToRenderedHtml('[safe](https://example.com)');
       expect(html).toContain('<a ');
       expect(html).toContain('class="entity-link-valid"');
       expect(html).toContain('href="https://example.com"');
+      expect(html).toContain('target="_blank"');
+      expect(html).toContain('rel="noopener noreferrer"');
       expect(html).toContain('</a>');
     });
 
-    it('renders safe graph links as anchor tags', () => {
+    it('renders safe graph links as in-app anchor tags without target=_blank', () => {
       const html = markdownToRenderedHtml('[entity](graph://foo)');
       expect(html).toContain('<a ');
       expect(html).toContain('class="entity-link-valid"');
       expect(html).toContain('href="graph://foo"');
+      expect(html).not.toContain('target="_blank"');
       expect(html).toContain('</a>');
     });
 

--- a/apps/web/core/state/editor/markdown-adapter.ts
+++ b/apps/web/core/state/editor/markdown-adapter.ts
@@ -290,6 +290,11 @@ function renderLinkTagOpen(token: Token): string {
     attrs.set('class', appendClassName(attrs.get('class') ?? null, className));
     attrs.set('href', safeHref);
 
+    if (!safeHref.startsWith('graph://')) {
+      attrs.set('target', '_blank');
+      attrs.set('rel', 'noopener noreferrer');
+    }
+
     const serializedAttributes = Array.from(attrs.entries())
       .map(([name, value]) => `${name}="${escapeHtml(value)}"`)
       .join(' ');

--- a/apps/web/core/state/editor/markdown-render.test.tsx
+++ b/apps/web/core/state/editor/markdown-render.test.tsx
@@ -22,18 +22,21 @@ describe('markdown-render', () => {
   });
 
   describe('renderMarkdownDocument', () => {
-    it('renders safe links as anchor tags', () => {
+    it('renders safe external links as anchor tags that open in a new tab', () => {
       const html = renderToStaticMarkup(<>{renderMarkdownDocument('[safe](https://example.com)')}</>);
       expect(html).toContain('<a');
       expect(html).toContain('class="entity-link-valid"');
       expect(html).toContain('href="https://example.com"');
+      expect(html).toContain('target="_blank"');
+      expect(html).toContain('rel="noopener noreferrer"');
     });
 
-    it('renders graph links as anchor tags', () => {
+    it('renders graph links as in-app anchor tags without target=_blank', () => {
       const html = renderToStaticMarkup(<>{renderMarkdownDocument('[entity](graph://foo)')}</>);
       expect(html).toContain('<a');
       expect(html).toContain('class="entity-link-valid"');
       expect(html).toContain('href="graph://foo"');
+      expect(html).not.toContain('target="_blank"');
     });
 
     it('marks unsafe links as invalid instead of keeping href', () => {

--- a/apps/web/core/state/editor/markdown-render.tsx
+++ b/apps/web/core/state/editor/markdown-render.tsx
@@ -246,10 +246,16 @@ function renderInlineTokenRange(
       case 'link_open': {
         const { className, isValid, safeHref } = getRenderedLinkState(token.attrGet('href'));
         const rendered = renderInlineTokenRange(tokens, index + 1, 'link_close', options);
+        const isGraph = !!safeHref && safeHref.startsWith('graph://');
 
         if (isValid && safeHref) {
           nodes.push(
-            <a key={`link-${index}`} href={safeHref} className={cx(className, options?.markClassName)}>
+            <a
+              key={`link-${index}`}
+              href={safeHref}
+              className={cx(className, options?.markClassName)}
+              {...(isGraph ? {} : { target: '_blank', rel: 'noopener noreferrer' })}
+            >
               {rendered.nodes}
             </a>
           );

--- a/apps/web/partials/editor/web2-url-extension.tsx
+++ b/apps/web/partials/editor/web2-url-extension.tsx
@@ -143,17 +143,17 @@ export const Web2URLMark = Mark.create({
         0,
       ];
     } else {
-      // VIEW MODE: Normal text
+      // VIEW MODE: clickable external link, opens in new tab
       return [
-        'span',
+        'a',
         {
           ...cleanHTMLAttributes,
-          // Keep data attributes for persistence and re-parsing
+          href: mark.attrs.url,
+          target: '_blank',
+          rel: 'noopener noreferrer',
           'data-web2-url': 'true',
           'data-url': mark.attrs.url,
-          // Explicitly clear class and style to ensure normal text appearance
-          class: '',
-          style: 'color: inherit; text-decoration: none; background-color: transparent; cursor: inherit;',
+          class: 'entity-link-valid',
         },
         0,
       ];
@@ -165,7 +165,6 @@ export const Web2URLMark = Mark.create({
 // Web2 URL Extension
 // ============================================================================
 
-// Links aren't clickable in browse mode but still appear in text; add external links in the properties panel.
 export const Web2URLExtension = Extension.create({
   name: 'web2URLHighlight',
 


### PR DESCRIPTION
## Summary

- Reverts the specific portion of #1355 that disallowed clickable external URLs in text-block content. External (http/https) links now render as real anchors that open in a **new tab** (`target=\"_blank\" rel=\"noopener noreferrer\"`).
- Internal `graph://` links keep their existing same-page in-app navigation (intercepted by the document-level click handler in `editor.tsx`).
- Affects both the client TipTap browse-mode renderer (`Web2URLMark`) and the server-rendered markdown path (`renderMarkdownDocument` / `markdownToRenderedHtml`) so SSR and CSR behave the same.

Edit-mode rendering is unchanged — markdown text editing UX from #1355 (mention/link insertion, hover tooltips, parsing) is preserved.

## Test plan

- [x] Unit: `markdown-render` and `markdown-adapter` render tests assert `target=\"_blank\"` on https anchors and absence on `graph://` anchors
- [ ] Manual: external `[example](https://example.com)` in a text block is clickable in browse mode and opens in a new tab
- [ ] Manual: same content in edit mode still renders the markdown source string with the existing edit-mode styling
- [ ] Manual: `graph://` link still navigates in-app, same tab
- [ ] Manual: SSR — first paint of an entity page with an external link produces an anchor with `target=\"_blank\"`