### PR TITLE
fix(editor): switch formula delimiters from \(...\) to $$ notation

### DIFF
--- a/apps/web/core/state/editor/markdown-adapter.test.ts
+++ b/apps/web/core/state/editor/markdown-adapter.test.ts
@@ -13,6 +13,7 @@ import Text from '@tiptap/extension-text';
 
 import { describe, expect, it } from 'vitest';
 
+import { MATH_DELIMITERS } from '~/partials/editor/math-node';
 import { Web2URLMark } from '~/partials/editor/web2-url-extension';
 
 import { editorNodeToMarkdown, markdownToEditorJson, markdownToRenderedHtml } from './markdown-adapter';
@@ -34,7 +35,7 @@ const testExtensions = [
   HardBreak,
   BulletList,
   ListItem,
-  MathExtension.configure({ evaluation: false, delimiters: { inlineStart: '$$', inlineEnd: '$$', inlineRegex: '\\$\\$(?!\\s)(.*?(?<!\\\\))\\$\\$' }, katexOptions: { throwOnError: false } }),
+  MathExtension.configure({ evaluation: false, delimiters: MATH_DELIMITERS, katexOptions: { throwOnError: false } }),
   Web2URLMark,
 ];
 
@@ -107,6 +108,12 @@ describe('markdown-adapter', () => {
   // Safety tests
   // ---------------------------------------------------------------------------
   describe('safety', () => {
+    it('whitespace-only $$ $$ is not parsed as math', () => {
+      const json = markdownToEditorJson('Value is $$ $$ here', testExtensions);
+      const hasInlineMath = JSON.stringify(json).includes('"type":"inlineMath"');
+      expect(hasInlineMath).toBe(false);
+    });
+
     it('dollar amounts are not parsed as math', () => {
       const json = markdownToEditorJson('Price is $5 and $10 today', testExtensions);
       // Should produce a single paragraph with plain text (no inlineMath nodes)

--- a/apps/web/core/state/editor/markdown-adapter.test.ts
+++ b/apps/web/core/state/editor/markdown-adapter.test.ts
@@ -34,7 +34,7 @@ const testExtensions = [
   HardBreak,
   BulletList,
   ListItem,
-  MathExtension.configure({ evaluation: false, delimiters: 'bracket', katexOptions: { throwOnError: false } }),
+  MathExtension.configure({ evaluation: false, delimiters: { inlineStart: '$$', inlineEnd: '$$', inlineRegex: '\\$\\$(?!\\s)(.*?(?<!\\\\))\\$\\$' }, katexOptions: { throwOnError: false } }),
   Web2URLMark,
 ];
 
@@ -83,8 +83,8 @@ describe('markdown-adapter', () => {
       expect(roundTrip(md)).toBe(md);
     });
 
-    it('inline math with bracket delimiters round-trips', () => {
-      expect(roundTrip('The formula \\(x^2\\) is quadratic')).toBe('The formula \\(x^2\\) is quadratic');
+    it('inline math with $$ delimiters round-trips', () => {
+      expect(roundTrip('The formula $$x^2$$ is quadratic')).toBe('The formula $$x^2$$ is quadratic');
     });
 
     it('code block round-trips', () => {
@@ -98,7 +98,7 @@ describe('markdown-adapter', () => {
     });
 
     it('mixed paragraph with bold + italic + code + formula', () => {
-      const md = 'Text **bold** *italic* `code` \\(E=mc^2\\)';
+      const md = 'Text **bold** *italic* `code` $$E=mc^2$$';
       expect(roundTrip(md)).toBe(md);
     });
   });
@@ -124,12 +124,32 @@ describe('markdown-adapter', () => {
       expect(flat).toContain('"type":"inlineMath"');
     });
 
-    it('legacy $...$ saves as bracket delimiters', () => {
+    it('legacy $...$ saves as $$ delimiters', () => {
       const json = markdownToEditorJson('Formula $x^2$ here', testExtensions);
       const parts = (json.content ?? []).map(node => editorNodeToMarkdown(node));
       const result = parts.join('\n').trimEnd();
-      expect(result).toContain('\\(x^2\\)');
-      expect(result).not.toContain('$x^2$');
+      expect(result).toBe('Formula $$x^2$$ here');
+    });
+
+    it('legacy \\(...\\) saves as $$ delimiters', () => {
+      const json = markdownToEditorJson('Formula \\(x^2\\) here', testExtensions);
+      const parts = (json.content ?? []).map(node => editorNodeToMarkdown(node));
+      const result = parts.join('\n').trimEnd();
+      expect(result).toContain('$$x^2$$');
+    });
+
+    it('escaped dollar in LaTeX round-trips correctly', () => {
+      // LaTeX containing \$ gets space-padded to avoid delimiter ambiguity: $$ cost \$ $$
+      const input = 'Price $$ cost \\$ $$ rest';
+      const json = markdownToEditorJson(input, testExtensions);
+      const flat = JSON.stringify(json);
+      expect(flat).toContain('"type":"inlineMath"');
+      // The parser trims padding, so latex attr is "cost \$"
+      expect(flat).toContain('cost \\\\$');
+      const parts = (json.content ?? []).map(node => editorNodeToMarkdown(node));
+      const result = parts.join('\n').trimEnd();
+      // Re-serializes with padding since content ends with $
+      expect(result).toBe('Price $$ cost \\$ $$ rest');
     });
   });
 
@@ -163,7 +183,7 @@ describe('markdown-adapter', () => {
     });
 
     it('math renders as KaTeX HTML', () => {
-      const html = markdownToRenderedHtml('Formula \\(x^2\\)');
+      const html = markdownToRenderedHtml('Formula $$x^2$$');
       expect(html).toContain('katex');
     });
 
@@ -233,7 +253,7 @@ describe('markdown-adapter', () => {
       expect(editorNodeToMarkdown(node)).toBe('**bold**');
     });
 
-    it('serializes inline math as bracket delimiters', () => {
+    it('serializes inline math as $$ delimiters', () => {
       const node = {
         type: 'paragraph',
         content: [
@@ -241,7 +261,7 @@ describe('markdown-adapter', () => {
           { type: 'inlineMath', attrs: { latex: 'x^2' } },
         ],
       };
-      expect(editorNodeToMarkdown(node)).toBe('f(x) = \\(x^2\\)');
+      expect(editorNodeToMarkdown(node)).toBe('f(x) = $$x^2$$');
     });
 
     it('serializes code block with dynamic fence length', () => {

--- a/apps/web/core/state/editor/markdown-adapter.test.ts
+++ b/apps/web/core/state/editor/markdown-adapter.test.ts
@@ -13,7 +13,7 @@ import Text from '@tiptap/extension-text';
 
 import { describe, expect, it } from 'vitest';
 
-import { MATH_DELIMITERS } from '~/partials/editor/math-node';
+import { MATH_DELIMITERS } from '~/core/state/editor/math-delimiters';
 import { Web2URLMark } from '~/partials/editor/web2-url-extension';
 
 import { editorNodeToMarkdown, markdownToEditorJson, markdownToRenderedHtml } from './markdown-adapter';
@@ -157,6 +157,14 @@ describe('markdown-adapter', () => {
       const result = parts.join('\n').trimEnd();
       // Re-serializes with padding since content ends with $
       expect(result).toBe('Price $$ cost \\$ $$ rest');
+    });
+
+    it('escaped dollar without space padding parses via overlapping close', () => {
+      // $$cost\$$$ — the closing $$ overlaps with the escaped \$
+      const input = 'A $$cost\\$$$ B';
+      const json = markdownToEditorJson(input, testExtensions);
+      const flat = JSON.stringify(json);
+      expect(flat).toContain('"type":"inlineMath"');
     });
   });
 

--- a/apps/web/core/state/editor/markdown-adapter.ts
+++ b/apps/web/core/state/editor/markdown-adapter.ts
@@ -249,8 +249,9 @@ function serializeInlineNode(node: JSONContent): string {
 
   if (node.type === 'inlineMath') {
     const latex = node.attrs?.latex ?? '';
-    // Space-pad when content starts or ends with $ to avoid ambiguity with the delimiters
-    const needsPad = latex.startsWith('$') || latex.endsWith('$');
+    // Space-pad when content contains $ to avoid ambiguity with the delimiters
+    // (covers start/end $ merging into $$, and internal $$ causing early close)
+    const needsPad = latex.includes('$');
     return needsPad ? `$$ ${latex} $$` : `$$${latex}$$`;
   }
 

--- a/apps/web/core/state/editor/markdown-adapter.ts
+++ b/apps/web/core/state/editor/markdown-adapter.ts
@@ -249,7 +249,9 @@ function serializeInlineNode(node: JSONContent): string {
 
   if (node.type === 'inlineMath') {
     const latex = node.attrs?.latex ?? '';
-    return `\\(${latex}\\)`;
+    // Space-pad when content starts/ends with $ to avoid ambiguity with the delimiters
+    const needsPad = latex.startsWith('$') || latex.endsWith('$');
+    return needsPad ? `$$ ${latex} $$` : `$$${latex}$$`;
   }
 
   if (node.type === 'hardBreak') {

--- a/apps/web/core/state/editor/markdown-adapter.ts
+++ b/apps/web/core/state/editor/markdown-adapter.ts
@@ -249,7 +249,7 @@ function serializeInlineNode(node: JSONContent): string {
 
   if (node.type === 'inlineMath') {
     const latex = node.attrs?.latex ?? '';
-    // Space-pad when content starts/ends with $ to avoid ambiguity with the delimiters
+    // Space-pad when content starts or ends with $ to avoid ambiguity with the delimiters
     const needsPad = latex.startsWith('$') || latex.endsWith('$');
     return needsPad ? `$$ ${latex} $$` : `$$${latex}$$`;
   }

--- a/apps/web/core/state/editor/markdown-core.ts
+++ b/apps/web/core/state/editor/markdown-core.ts
@@ -3,6 +3,8 @@ import type StateInline from 'markdown-it/lib/rules_inline/state_inline.mjs';
 
 import { parseGraphLinkHref } from '~/core/utils/graph-link';
 
+import { isEscaped } from './math-delimiters';
+
 export function mathPlugin(md: MarkdownIt) {
   // Primary inline rule: $$...$$ (Notion-style)
   md.inline.ruler.before('escape', 'double_dollar_math', (state: StateInline, silent: boolean) => {
@@ -15,16 +17,10 @@ export function mathPlugin(md: MarkdownIt) {
     let end = start;
     while (end < state.posMax - 1) {
       if (state.src.charCodeAt(end) === 0x24 /* $ */ && state.src.charCodeAt(end + 1) === 0x24 /* $ */) {
-        // Check if the first $ of the closing pair is escaped by an odd number of backslashes
-        let backslashes = 0;
-        let k = end - 1;
-        while (k >= start && state.src.charCodeAt(k) === 0x5c /* \ */) {
-          backslashes++;
-          k--;
-        }
-        if (backslashes % 2 === 0) break; // even (or zero) backslashes — real close
-        // Odd backslashes means the $ is escaped — skip past both dollars and keep scanning
-        end += 2;
+        if (!isEscaped(state.src, end, start)) break; // real close
+        // Escaped $ — advance by 1 so the next iteration can find
+        // an overlapping closing $$ (e.g. $$cost\$$$)
+        end += 1;
         continue;
       }
       end++;

--- a/apps/web/core/state/editor/markdown-core.ts
+++ b/apps/web/core/state/editor/markdown-core.ts
@@ -3,9 +3,47 @@ import type StateInline from 'markdown-it/lib/rules_inline/state_inline.mjs';
 
 import { parseGraphLinkHref } from '~/core/utils/graph-link';
 
-export function bracketMathPlugin(md: MarkdownIt) {
-  // Inline rule for \(...\) bracket math — must run BEFORE 'escape' so \( isn't consumed as escaped paren
-  md.inline.ruler.before('escape', 'bracket_math', (state: StateInline, silent: boolean) => {
+export function mathPlugin(md: MarkdownIt) {
+  // Primary inline rule: $$...$$ (Notion-style)
+  md.inline.ruler.before('escape', 'double_dollar_math', (state: StateInline, silent: boolean) => {
+    if (state.src.charCodeAt(state.pos) !== 0x24 /* $ */) return false;
+    if (state.src.charCodeAt(state.pos + 1) !== 0x24 /* $ */) return false;
+
+    const start = state.pos + 2;
+    if (start >= state.posMax) return false;
+
+    let end = start;
+    while (end < state.posMax - 1) {
+      if (state.src.charCodeAt(end) === 0x24 /* $ */ && state.src.charCodeAt(end + 1) === 0x24 /* $ */) {
+        // Check if the first $ of the closing pair is escaped by an odd number of backslashes
+        let backslashes = 0;
+        let k = end - 1;
+        while (k >= start && state.src.charCodeAt(k) === 0x5c /* \ */) {
+          backslashes++;
+          k--;
+        }
+        if (backslashes % 2 === 0) break; // even (or zero) backslashes — real close
+        // Odd backslashes means the $ is escaped — skip past both dollars and keep scanning
+        end += 2;
+        continue;
+      }
+      end++;
+    }
+    if (end >= state.posMax - 1) return false;
+    if (end === start) return false; // reject empty $$$$
+
+    if (!silent) {
+      const token = state.push('inline_math', 'math', 0);
+      // Trim padding spaces added by the serializer to avoid delimiter ambiguity
+      token.content = state.src.slice(start, end).trim();
+    }
+
+    state.pos = end + 2;
+    return true;
+  });
+
+  // Legacy read support: \(...\) bracket math
+  md.inline.ruler.after('double_dollar_math', 'bracket_math', (state: StateInline, silent: boolean) => {
     if (state.src.charCodeAt(state.pos) !== 0x5c /* \ */) return false;
     if (state.src.charCodeAt(state.pos + 1) !== 0x28 /* ( */) return false;
 
@@ -70,7 +108,7 @@ export function bracketMathPlugin(md: MarkdownIt) {
 
 export function createMarkdownIt(): MarkdownIt {
   const md = new MarkdownIt({ html: false });
-  md.use(bracketMathPlugin);
+  md.use(mathPlugin);
   return md;
 }
 

--- a/apps/web/core/state/editor/markdown-core.ts
+++ b/apps/web/core/state/editor/markdown-core.ts
@@ -32,10 +32,13 @@ export function mathPlugin(md: MarkdownIt) {
     if (end >= state.posMax - 1) return false;
     if (end === start) return false; // reject empty $$$$
 
+    // Trim padding spaces added by the serializer to avoid delimiter ambiguity
+    const content = state.src.slice(start, end).trim();
+    if (content.length === 0) return false; // reject whitespace-only like $$ $$
+
     if (!silent) {
       const token = state.push('inline_math', 'math', 0);
-      // Trim padding spaces added by the serializer to avoid delimiter ambiguity
-      token.content = state.src.slice(start, end).trim();
+      token.content = content;
     }
 
     state.pos = end + 2;

--- a/apps/web/core/state/editor/markdown-render.test.tsx
+++ b/apps/web/core/state/editor/markdown-render.test.tsx
@@ -8,7 +8,11 @@ const VALID_SPACE_ID = '22222222222222222222222222222222';
 
 describe('markdown-render', () => {
   describe('hasMarkdownSyntax', () => {
-    it('detects inline math with normal parentheses', () => {
+    it('detects inline math with $$ delimiters', () => {
+      expect(hasMarkdownSyntax('Use $$f(x)$$ here')).toBe(true);
+    });
+
+    it('detects inline math with legacy bracket delimiters', () => {
       expect(hasMarkdownSyntax('Use \\(f(x)\\) here')).toBe(true);
     });
 
@@ -18,7 +22,12 @@ describe('markdown-render', () => {
   });
 
   describe('renderMarkdownInline', () => {
-    it('renders bracket math with inner parentheses', () => {
+    it('renders $$ math', () => {
+      const html = renderToStaticMarkup(<>{renderMarkdownInline('Use $$f(x)$$ here')}</>);
+      expect(html).toContain('katex');
+    });
+
+    it('renders legacy bracket math with inner parentheses', () => {
       const html = renderToStaticMarkup(<>{renderMarkdownInline('Use \\(f(x)\\) here')}</>);
       expect(html).toContain('katex');
     });

--- a/apps/web/core/state/editor/math-delimiters.ts
+++ b/apps/web/core/state/editor/math-delimiters.ts
@@ -1,0 +1,32 @@
+/** Regex (as string) for tiptap input/paste rules — handles \$ escaping.
+ *
+ * Structure:
+ *   \$\$              — opening delimiter
+ *   (?!\s*\$\$)       — reject empty / whitespace-only content
+ *   (capture group)   — LaTeX content, alternation:
+ *     [^$\\]          — any character that isn't $ or \
+ *     \\.             — backslash + any character (handles \$, \\, etc.)
+ *     \$(?!\$)        — a lone $ not followed by another $
+ *   \$\$              — closing delimiter
+ */
+export const INLINE_MATH_REGEX = '\\$\\$(?!\\s*\\$\\$)((?:[^$\\\\]|\\\\.|\\$(?!\\$))*)\\$\\$';
+
+export const MATH_DELIMITERS = {
+  inlineStart: '$$',
+  inlineEnd: '$$',
+  inlineRegex: INLINE_MATH_REGEX,
+};
+
+/**
+ * Check whether the character at `pos` in `src` is escaped by an odd
+ * number of preceding backslashes (searching back no further than `minPos`).
+ */
+export function isEscaped(src: string, pos: number, minPos: number): boolean {
+  let backslashes = 0;
+  let k = pos - 1;
+  while (k >= minPos && src.charCodeAt(k) === 0x5c /* \ */) {
+    backslashes++;
+    k--;
+  }
+  return backslashes % 2 === 1;
+}

--- a/apps/web/partials/editor/math-node.ts
+++ b/apps/web/partials/editor/math-node.ts
@@ -2,6 +2,10 @@ import { MathExtension } from '@aarkue/tiptap-math-extension';
 
 export const MathNode = MathExtension.configure({
   evaluation: false,
-  delimiters: 'bracket',
+  delimiters: {
+    inlineStart: '$$',
+    inlineEnd: '$$',
+    inlineRegex: '\\$\\$(?!\\s)(.*?(?<!\\\\))\\$\\$',
+  },
   katexOptions: { throwOnError: false },
 });

--- a/apps/web/partials/editor/math-node.ts
+++ b/apps/web/partials/editor/math-node.ts
@@ -1,10 +1,6 @@
 import { MathExtension } from '@aarkue/tiptap-math-extension';
 
-export const MATH_DELIMITERS = {
-  inlineStart: '$$',
-  inlineEnd: '$$',
-  inlineRegex: '\\$\\$(.*?)\\$\\$',
-};
+import { MATH_DELIMITERS } from '~/core/state/editor/math-delimiters';
 
 export const MathNode = MathExtension.configure({
   evaluation: false,

--- a/apps/web/partials/editor/math-node.ts
+++ b/apps/web/partials/editor/math-node.ts
@@ -1,11 +1,13 @@
 import { MathExtension } from '@aarkue/tiptap-math-extension';
 
+export const MATH_DELIMITERS = {
+  inlineStart: '$$',
+  inlineEnd: '$$',
+  inlineRegex: '\\$\\$(.*?)\\$\\$',
+};
+
 export const MathNode = MathExtension.configure({
   evaluation: false,
-  delimiters: {
-    inlineStart: '$$',
-    inlineEnd: '$$',
-    inlineRegex: '\\$\\$(?!\\s)(.*?(?<!\\\\))\\$\\$',
-  },
+  delimiters: MATH_DELIMITERS,
   katexOptions: { throwOnError: false },
 });


### PR DESCRIPTION
Migrate to Notion-style $$ delimiters for inline math formulas. The parser handles escaped dollars inside LaTeX content and the serializer space-pads when content contains $ to prevent ambiguity. Legacy \(...\) and $...$ formats are still read for backward compat.