### PR TITLE
fix(tabs): always delete the parent TABS_PROPERTY edge when deleting a tab

### DIFF
--- a/apps/web/partials/entity-page/editable-tab-group.tsx
+++ b/apps/web/partials/entity-page/editable-tab-group.tsx
@@ -215,7 +215,11 @@ export function EditableTabGroup({
 
     const relationIds = new Set<string>();
     const allRelationsToDelete: typeof outgoingRelations = [];
+    // Always include tab.relation (the parent's TABS_PROPERTY edge). getRelations only sees the local
+    // reactive store, so a server-only relation would otherwise be missed and the tab would resurrect
+    // as "Untitled" after publish — its own values get cleared by the orphan cascade but the edge stays.
     for (const r of [
+      tab.relation,
       ...outgoingRelations,
       ...getRelations({ selector: r => r.toEntity.id === tabEntityId && r.spaceId === spaceId }),
     ]) {


### PR DESCRIPTION
## Summary

Follow-up to #1717. Deleting a tab sometimes resurrected it as "Untitled" after publish.

### Root cause

[`handleDeleteTab`](apps/web/partials/entity-page/editable-tab-group.tsx) discovered the parent's `TABS_PROPERTY` edge via:

```ts
getRelations({ selector: r => r.toEntity.id === tabEntityId && r.spaceId === spaceId })
```

But [`getRelations`](apps/web/core/sync/use-store.tsx#L650) without `mergeWith` only inspects the local reactive store (`reactiveRelations.get()`). On a fresh page load the `TABS_PROPERTY` edge is server-only — it's hydrated into the view by `useRelations`' `mergeWith` in [`entity-tabs.tsx`](apps/web/partials/entity-page/entity-tabs.tsx), but it never lands in the local store unless something writes to it.

So the lookup returned an empty array, the edge was never marked deleted, and no delete op was emitted at publish. Meanwhile the tab entity's own name values *were* cleared by `buildOrphanChildDeleteOps` (which fetches from the server), so the surviving edge re-rendered the tab with no name → "Untitled".

### Fix

Prepend `tab.relation` to the deletion list. We already hold a direct reference to the exact relation we want to remove, so there's no need to rediscover it via the local store — works whether the edge is local or server-only.

## Test plan
- [ ] Open an entity that already has published tabs (so the `TABS_PROPERTY` edges are server-only on load). Delete a tab, publish, refresh — the tab stays gone.
- [ ] Create a new tab, publish, then delete it without refreshing — still works (edge is local in this path).
- [ ] Delete a tab that has block content — blocks still cascade-delete via the orphan path.