### PR TITLE
[codex] Wait for relation target search types

### DIFF
--- a/apps/web/core/hooks/use-relation-target-type-ids.ts
+++ b/apps/web/core/hooks/use-relation-target-type-ids.ts
@@ -5,8 +5,6 @@ import { useSelector } from '@xstate/store/react';
 
 import * as React from 'react';
 
-import equal from 'fast-deep-equal';
-
 import { reactiveRelations } from '~/core/sync/store';
 import { useSyncEngine } from '~/core/sync/use-sync-engine';
 import type { Property } from '~/core/types';
@@ -31,7 +29,7 @@ export function useRelationTargetTypeIds({
   waitForFilterTypes: boolean;
 } {
   const { store } = useSyncEngine();
-  const relationsSnapshot = useSelector(reactiveRelations, r => r, equal);
+  const relationsSnapshot = useSelector(reactiveRelations, r => r);
 
   const fromStore = React.useMemo(() => {
     void relationsSnapshot;

--- a/apps/web/core/hooks/use-relation-target-type-ids.ts
+++ b/apps/web/core/hooks/use-relation-target-type-ids.ts
@@ -46,7 +46,7 @@ export function useRelationTargetTypeIds({
     isFetching: isFetchingNetworkTypes,
     isPending: isPendingNetworkTypes,
   } = useQuery({
-    enabled: Boolean(propertyId) && !fromStore?.length,
+    enabled: Boolean(propertyId) && !fromStore?.length && !relationValueTypes?.length,
     queryKey: ['relation-target-type-ids', propertyId, spaceId],
     queryFn: () => fetchRelationTargetTypeIdsForProperty(propertyId!, spaceId),
     staleTime: 60_000,

--- a/apps/web/core/hooks/use-relation-target-type-ids.ts
+++ b/apps/web/core/hooks/use-relation-target-type-ids.ts
@@ -1,0 +1,71 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { useSelector } from '@xstate/store/react';
+
+import * as React from 'react';
+
+import equal from 'fast-deep-equal';
+
+import { reactiveRelations } from '~/core/sync/store';
+import { useSyncEngine } from '~/core/sync/use-sync-engine';
+import type { Property } from '~/core/types';
+import {
+  fetchRelationTargetTypeIdsForProperty,
+  mergeRelationValueTypesFromStore,
+} from '~/core/utils/property/properties';
+
+type RelationValueType = NonNullable<Property['relationValueTypes']>[number];
+
+export function useRelationTargetTypeIds({
+  propertyId,
+  spaceId,
+  relationValueTypes,
+}: {
+  propertyId: string | undefined;
+  spaceId: string | undefined;
+  relationValueTypes: Property['relationValueTypes'] | undefined;
+}): {
+  relationValueTypes: RelationValueType[] | undefined;
+  typeIds: string[] | undefined;
+  waitForFilterTypes: boolean;
+} {
+  const { store } = useSyncEngine();
+  const relationsSnapshot = useSelector(reactiveRelations, r => r, equal);
+
+  const fromStore = React.useMemo(() => {
+    void relationsSnapshot;
+    if (!propertyId) return undefined;
+
+    const merged = mergeRelationValueTypesFromStore({ id: propertyId, name: null, dataType: 'RELATION' }, store);
+    return merged.relationValueTypes?.length ? merged.relationValueTypes : undefined;
+  }, [propertyId, relationsSnapshot, store]);
+
+  const {
+    data: fromNetwork,
+    isFetching: isFetchingNetworkTypes,
+    isPending: isPendingNetworkTypes,
+  } = useQuery({
+    enabled: Boolean(propertyId) && !fromStore?.length,
+    queryKey: ['relation-target-type-ids', propertyId, spaceId],
+    queryFn: () => fetchRelationTargetTypeIdsForProperty(propertyId!, spaceId),
+    staleTime: 60_000,
+  });
+
+  const resolvedRelationValueTypes = React.useMemo(() => {
+    if (fromStore?.length) return fromStore;
+    if (fromNetwork?.length) return fromNetwork.map(id => ({ id, name: null }));
+    return relationValueTypes?.length ? relationValueTypes : undefined;
+  }, [fromStore, fromNetwork, relationValueTypes]);
+
+  const typeIds = React.useMemo(
+    () => resolvedRelationValueTypes?.map(type => type.id),
+    [resolvedRelationValueTypes]
+  );
+
+  return {
+    relationValueTypes: resolvedRelationValueTypes,
+    typeIds,
+    waitForFilterTypes: Boolean(propertyId) && !typeIds?.length && (isFetchingNetworkTypes || isPendingNetworkTypes),
+  };
+}

--- a/apps/web/core/hooks/use-search.ts
+++ b/apps/web/core/hooks/use-search.ts
@@ -193,10 +193,11 @@ export function useSearch({
   );
 
   const isQuerySyncing = query !== debouncedQuery;
-  const shouldSuspend = isQuerySyncing || isLoading;
+  const isWaitingForFilterTypes = searchBlocked && !isStringEmpty(query);
+  const shouldSuspend = isQuerySyncing || isLoading || isWaitingForFilterTypes;
 
   return {
-    isEmpty: isArrayEmpty(dedupedResults) && !isStringEmpty(query) && !shouldSuspend,
+    isEmpty: isArrayEmpty(dedupedResults) && !isStringEmpty(query) && !shouldSuspend && !isWaitingForFilterTypes,
     isLoading: shouldSuspend,
     results: dedupedResults,
     query,

--- a/apps/web/core/hooks/use-search.ts
+++ b/apps/web/core/hooks/use-search.ts
@@ -197,7 +197,7 @@ export function useSearch({
   const shouldSuspend = isQuerySyncing || isLoading || isWaitingForFilterTypes;
 
   return {
-    isEmpty: isArrayEmpty(dedupedResults) && !isStringEmpty(query) && !shouldSuspend && !isWaitingForFilterTypes,
+    isEmpty: isArrayEmpty(dedupedResults) && !isStringEmpty(query) && !shouldSuspend,
     isLoading: shouldSuspend,
     results: dedupedResults,
     query,

--- a/apps/web/design-system/select-entity-dialog.tsx
+++ b/apps/web/design-system/select-entity-dialog.tsx
@@ -29,6 +29,8 @@ type SelectEntityAsPopoverProps = {
   advanced?: boolean;
   showIDs?: boolean;
   initialQuery?: string;
+  waitForFilterTypes?: boolean;
+  restrictToFilterTypes?: boolean;
   selectedEntityId?: string;
 };
 
@@ -42,6 +44,8 @@ export function SelectEntityAsPopover({
   advanced = true,
   showIDs = true,
   initialQuery,
+  waitForFilterTypes,
+  restrictToFilterTypes,
   selectedEntityId,
 }: SelectEntityAsPopoverProps) {
   const [open, setOpen] = useState<boolean>(false);
@@ -70,6 +74,8 @@ export function SelectEntityAsPopover({
             advanced={advanced}
             showIDs={showIDs}
             initialQuery={initialQuery}
+            waitForFilterTypes={waitForFilterTypes}
+            restrictToFilterTypes={restrictToFilterTypes}
             selectedEntityId={selectedEntityId}
           />
         </Popover.Content>

--- a/apps/web/design-system/select-entity.tsx
+++ b/apps/web/design-system/select-entity.tsx
@@ -76,6 +76,8 @@ type SelectEntityProps = {
   autoFocus?: boolean;
   showIDs?: boolean;
   initialQuery?: string;
+  waitForFilterTypes?: boolean;
+  restrictToFilterTypes?: boolean;
   /** When set, the result with this ID gets a "Currently selected" indicator */
   selectedEntityId?: string;
   /** Increment (e.g. on "add row") to move focus into this input even when already mounted. */
@@ -102,6 +104,8 @@ export const SelectEntity = ({
   advanced = true,
   showIDs = true,
   initialQuery,
+  waitForFilterTypes,
+  restrictToFilterTypes,
   selectedEntityId,
   focusRequestKey,
 }: SelectEntityProps) => {
@@ -147,6 +151,8 @@ export const SelectEntity = ({
     filterByTypes,
     filterBySpace,
     initialQuery,
+    waitForFilterTypes,
+    restrictToFilterTypes,
   });
 
   // Auto focus input when component mounts

--- a/apps/web/partials/blocks/table/table-block-filter-creation-prompt.tsx
+++ b/apps/web/partials/blocks/table/table-block-filter-creation-prompt.tsx
@@ -3,7 +3,6 @@
 import { SystemIds } from '@geoprotocol/geo-sdk/lite';
 import { Anchor, Content, Portal, Root, Trigger } from '@radix-ui/react-popover';
 import { useInfiniteQuery, useQuery, useQueryClient } from '@tanstack/react-query';
-import { useSelector } from '@xstate/store/react';
 
 import * as React from 'react';
 
@@ -20,18 +19,14 @@ import { useSource } from '~/core/blocks/data/use-source';
 import { PLACEHOLDER_SPACE_IMAGE } from '~/core/constants';
 import { useDebouncedValue } from '~/core/hooks/use-debounced-value';
 import { useGlobalSearchSpaceIds } from '~/core/hooks/use-global-search-space-ids';
+import { useRelationTargetTypeIds } from '~/core/hooks/use-relation-target-type-ids';
 import { searchResultMatchesAllowedTypes } from '~/core/hooks/use-search';
 import { useSpacesQuery } from '~/core/hooks/use-spaces-query';
 import { getSpacesWhereMember } from '~/core/io/queries';
 import { useName } from '~/core/state/entity-page-store/entity-store';
 import { useEntityStoreInstance } from '~/core/state/entity-page-store/entity-store-provider';
 import { E } from '~/core/sync/orm';
-import { reactiveRelations } from '~/core/sync/store';
 import { useSyncEngine } from '~/core/sync/use-sync-engine';
-import {
-  fetchRelationTargetTypeIdsForProperty,
-  mergeRelationValueTypesFromStore,
-} from '~/core/utils/property/properties';
 import { FilterableValueType } from '~/core/value-types';
 
 import { ResultContent, ResultsList } from '~/design-system/autocomplete/results-list';
@@ -216,39 +211,11 @@ function useRelationColumnTargetTypeIds(
   blockSpaceId: string | undefined,
   relationValueTypesFromOptions: { id: string; name: string | null }[] | undefined
 ): { typeIds: string[] | undefined; waitForFilterTypes: boolean } {
-  const { store } = useSyncEngine();
-  const relationsSnapshot = useSelector(reactiveRelations, r => r, equal);
-
-  const fromStore = React.useMemo(() => {
-    void relationsSnapshot;
-    if (!propertyId) return undefined;
-    const merged = mergeRelationValueTypesFromStore({ id: propertyId, name: null, dataType: 'RELATION' }, store);
-    return merged.relationValueTypes?.length ? merged.relationValueTypes.map(t => t.id) : undefined;
-  }, [propertyId, relationsSnapshot, store]);
-
-  const {
-    data: fromNetwork,
-    isFetching: isFetchingNetworkTypes,
-    isPending: isPendingNetworkTypes,
-  } = useQuery({
-    enabled: Boolean(propertyId) && !fromStore?.length,
-    queryKey: ['table-block-filter-relation-target-type-ids', propertyId, blockSpaceId],
-    queryFn: () => fetchRelationTargetTypeIdsForProperty(propertyId!, blockSpaceId),
-    staleTime: 60_000,
+  const { typeIds, waitForFilterTypes } = useRelationTargetTypeIds({
+    propertyId,
+    spaceId: blockSpaceId,
+    relationValueTypes: relationValueTypesFromOptions,
   });
-
-  const typeIds = React.useMemo(() => {
-    const fromOptions = relationValueTypesFromOptions?.length
-      ? relationValueTypesFromOptions.map(t => t.id)
-      : undefined;
-    if (fromStore?.length) return fromStore;
-    if (fromNetwork?.length) return fromNetwork;
-    return fromOptions;
-  }, [fromStore, fromNetwork, relationValueTypesFromOptions]);
-
-  /** Until we have target type ids, do not show unfiltered relation suggestions or run unscoped search. */
-  const waitForFilterTypes =
-    Boolean(propertyId) && !typeIds?.length && (isFetchingNetworkTypes || isPendingNetworkTypes);
 
   return { typeIds, waitForFilterTypes };
 }

--- a/apps/web/partials/blocks/table/table-block-property-field.tsx
+++ b/apps/web/partials/blocks/table/table-block-property-field.tsx
@@ -5,6 +5,7 @@ import { useState } from 'react';
 import cx from 'classnames';
 
 import { Source } from '~/core/blocks/data/source';
+import { useRelationTargetTypeIds } from '~/core/hooks/use-relation-target-type-ids';
 import { useUserIsEditing } from '~/core/hooks/use-user-is-editing';
 import { useMutate } from '~/core/sync/use-mutate';
 import { useRelations, useSpaceAwareValue } from '~/core/sync/use-store';
@@ -182,8 +183,13 @@ function EditableRelationsGroup({
   const { storage } = useMutate();
 
   const typeOfId = property.id;
-  const filterSearchByTypes = property?.relationValueTypes ? property?.relationValueTypes : [];
-  const firstRelationValueType = property?.relationValueTypes?.[0];
+  const { relationValueTypes, waitForFilterTypes } = useRelationTargetTypeIds({
+    propertyId: property.id,
+    spaceId,
+    relationValueTypes: property.relationValueTypes,
+  });
+  const filterSearchByTypes = relationValueTypes ?? [];
+  const firstRelationValueType = relationValueTypes?.[0];
 
   // We don't filter by space id as we want to render data from all spaces.
   const relations = useRelations({
@@ -215,6 +221,8 @@ function EditableRelationsGroup({
         <SelectEntity
           spaceId={spaceId}
           relationValueTypes={filterSearchByTypes}
+          waitForFilterTypes={waitForFilterTypes}
+          restrictToFilterTypes={Boolean(filterSearchByTypes.length)}
           onCreateEntity={result => {
             if (firstRelationValueType) {
               createTypeRelationForNewEntity(storage, spaceId, result, firstRelationValueType);
@@ -268,6 +276,8 @@ function EditableRelationsGroup({
           <SelectEntityAsPopover
             trigger={<SquareButton icon={<Create />} />}
             relationValueTypes={filterSearchByTypes}
+            waitForFilterTypes={waitForFilterTypes}
+            restrictToFilterTypes={Boolean(filterSearchByTypes.length)}
             onCreateEntity={result => {
               if (firstRelationValueType) {
                 createTypeRelationForNewEntity(storage, spaceId, result, firstRelationValueType);


### PR DESCRIPTION
## Summary
- Resolve relation target type ids for property searches from local store or network.
- Pass wait/restrict type-filter flags through entity selectors.
- Ensure relation property search does not run unfiltered while target types are loading.

## Validation
- eslint touched relation search files