### PR TITLE
[codex] Use top search space name

### DIFF
--- a/apps/web/core/io/queries.test.ts
+++ b/apps/web/core/io/queries.test.ts
@@ -93,6 +93,10 @@ describe('groupRestResults', () => {
           aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa: [{ id: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb', name: null }],
           cccccccccccccccccccccccccccccccc: [{ id: 'dddddddddddddddddddddddddddddddd', name: 'Person' }],
         },
+        namesBySpace: {
+          aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa: 'Valid result',
+          cccccccccccccccccccccccccccccccc: null,
+        },
         spaces: [
           {
             id: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',

--- a/apps/web/core/io/queries.ts
+++ b/apps/web/core/io/queries.ts
@@ -723,9 +723,10 @@ export function groupRestResults(results: RestSearchResult[]): SearchResult[] {
       if (existing.typesBySpace) {
         existing.typesBySpace[spaceId] = spaceTypes;
       }
-      if (existing.namesBySpace) {
-        existing.namesBySpace[spaceId] = r.name ?? null;
-      }
+      existing.namesBySpace = {
+        ...(existing.namesBySpace ?? {}),
+        [spaceId]: r.name ?? null,
+      };
     } else {
       byEntity.set(entityId, {
         id: entityId,

--- a/apps/web/core/io/queries.ts
+++ b/apps/web/core/io/queries.ts
@@ -723,12 +723,16 @@ export function groupRestResults(results: RestSearchResult[]): SearchResult[] {
       if (existing.typesBySpace) {
         existing.typesBySpace[spaceId] = spaceTypes;
       }
+      if (existing.namesBySpace) {
+        existing.namesBySpace[spaceId] = r.name ?? null;
+      }
     } else {
       byEntity.set(entityId, {
         id: entityId,
         name: r.name ?? null,
         description: r.description ?? null,
         types: (r.types ?? []).map(type => ({ id: stripHyphens(type.id), name: type.name ?? null })),
+        namesBySpace: { [spaceId]: r.name ?? null },
         typesBySpace: { [spaceId]: spaceTypes },
         spaces: [
           {

--- a/apps/web/core/sync/orm.search.test.ts
+++ b/apps/web/core/sync/orm.search.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import type { Entity, SearchResult, SpaceEntity } from '../types';
-import { applyKnownEntitySpaces, mergeResolvableSpaces, resolveSearchSpaces } from './orm';
+import { applyKnownEntitySpaces, getSearchResultNameForTopSpace, mergeResolvableSpaces, resolveSearchSpaces } from './orm';
 
 function makeSpaceEntity(spaceId: string, overrides: Partial<SpaceEntity> = {}): SpaceEntity {
   return {
@@ -91,5 +91,36 @@ describe('mergeResolvableSpaces', () => {
       'space-2',
       'space-3',
     ]);
+  });
+});
+
+describe('getSearchResultNameForTopSpace', () => {
+  it('uses the name from the top displayed space', () => {
+    expect(
+      getSearchResultNameForTopSpace(
+        {
+          name: '',
+          namesBySpace: {
+            'stale-space': '',
+            'top-space': 'Top Space Name',
+          },
+        },
+        [makeSpaceEntity('top-space')]
+      )
+    ).toBe('Top Space Name');
+  });
+
+  it('falls back to the grouped result name when the top space name is blank', () => {
+    expect(
+      getSearchResultNameForTopSpace(
+        {
+          name: 'Grouped Name',
+          namesBySpace: {
+            'top-space': '',
+          },
+        },
+        [makeSpaceEntity('top-space')]
+      )
+    ).toBe('Grouped Name');
   });
 });

--- a/apps/web/core/sync/orm.search.test.ts
+++ b/apps/web/core/sync/orm.search.test.ts
@@ -123,4 +123,18 @@ describe('getSearchResultNameForTopSpace', () => {
       )
     ).toBe('Grouped Name');
   });
+
+  it('returns null when neither the top space nor grouped result has a real name', () => {
+    expect(
+      getSearchResultNameForTopSpace(
+        {
+          name: '   ',
+          namesBySpace: {
+            'top-space': '',
+          },
+        },
+        [makeSpaceEntity('top-space')]
+      )
+    ).toBeNull();
+  });
 });

--- a/apps/web/core/sync/orm.ts
+++ b/apps/web/core/sync/orm.ts
@@ -47,6 +47,14 @@ export function resolveSearchSpaces(
 
 type SearchResultWithResolvableSpaces = OmitStrict<SearchResult, 'spaces'> & { spaces: Array<string | SpaceEntity> };
 
+export function getSearchResultNameForTopSpace(
+  result: Pick<SearchResult, 'name' | 'namesBySpace'>,
+  spaces: SpaceEntity[]
+): string | null {
+  const topSpaceName = result.namesBySpace?.[spaces[0]?.spaceId ?? ''];
+  return hasName(topSpaceName) ? (topSpaceName ?? null) : result.name;
+}
+
 export function applyKnownEntitySpaces(
   result: SearchResult,
   knownEntity: Pick<Entity, 'spaces'> | null | undefined
@@ -492,6 +500,7 @@ export class E {
 
         return {
           ...e,
+          name: getSearchResultNameForTopSpace(e, resolvedSpaces),
           types: e.types.map(t => ({
             id: t.id,
             name: t.name ?? typeNamesById.get(t.id) ?? null,
@@ -550,6 +559,7 @@ function mergeSearchResult({
     name,
     description,
     types,
+    namesBySpace: remoteEntity.namesBySpace,
     typesBySpace: remoteEntity.typesBySpace,
     spaces: mergeResolvableSpaces(remoteEntity.spaces, getLocalSearchResultSpaces(values, relations)),
   };

--- a/apps/web/core/sync/orm.ts
+++ b/apps/web/core/sync/orm.ts
@@ -1,4 +1,5 @@
 import { QueryClient } from '@tanstack/react-query';
+import { SystemIds } from '@geoprotocol/geo-sdk/lite';
 
 import { Effect } from 'effect';
 import { dedupeWith } from 'effect/Array';
@@ -86,6 +87,14 @@ export function mergeResolvableSpaces(
   }
 
   return merged;
+}
+
+function getLocalNamesBySpace(values: Entity['values']): Record<string, string | null> {
+  return Object.fromEntries(
+    values
+      .filter(value => value.property.id === SystemIds.NAME_PROPERTY)
+      .map(value => [value.spaceId, hasName(value.value) ? value.value : null])
+  );
 }
 
 export function mergeRelations(localRelations: Relation[], remoteRelations: Relation[]) {
@@ -553,13 +562,17 @@ function mergeSearchResult({
   const name = Entities.name(values) ?? remoteEntity.name;
   const description = Entities.description(values) ?? remoteEntity.description;
   const types = dedupeWith([...readTypes(relations), ...remoteEntity.types], (a, z) => a.id === z.id);
+  const namesBySpace = {
+    ...remoteEntity.namesBySpace,
+    ...getLocalNamesBySpace(values),
+  };
 
   return {
     id: id,
     name,
     description,
     types,
-    namesBySpace: remoteEntity.namesBySpace,
+    namesBySpace,
     typesBySpace: remoteEntity.typesBySpace,
     spaces: mergeResolvableSpaces(remoteEntity.spaces, getLocalSearchResultSpaces(values, relations)),
   };

--- a/apps/web/core/sync/orm.ts
+++ b/apps/web/core/sync/orm.ts
@@ -53,7 +53,8 @@ export function getSearchResultNameForTopSpace(
   spaces: SpaceEntity[]
 ): string | null {
   const topSpaceName = result.namesBySpace?.[spaces[0]?.spaceId ?? ''];
-  return hasName(topSpaceName) ? (topSpaceName ?? null) : result.name;
+  if (hasName(topSpaceName)) return topSpaceName ?? null;
+  return hasName(result.name) ? result.name : null;
 }
 
 export function applyKnownEntitySpaces(

--- a/apps/web/core/types.ts
+++ b/apps/web/core/types.ts
@@ -296,6 +296,8 @@ export type SearchResult = {
   description: string | null;
   spaces: SpaceEntity[];
   types: { id: string; name: string | null }[];
+  /** Entity names keyed by spaceId, so search can show the name for the displayed top-ranked space. */
+  namesBySpace?: Record<string, string | null>;
   /** Types keyed by spaceId, so the UI can show only the types relevant to the displayed space */
   typesBySpace?: Record<string, { id: string; name: string | null }[]>;
 };


### PR DESCRIPTION
## Summary
- Preserve search result names by space while grouping REST rows.
- After resolving and ranking spaces, display the name from the top displayed space.
- Fall back to the grouped search name when the top-space name is blank.

## Validation
- bun run test core/io/queries.test.ts core/sync/orm.search.test.ts
- eslint touched search name files