### PR TITLE
[codex] Show initial search results

### DIFF
--- a/apps/web/core/hooks/use-search.ts
+++ b/apps/web/core/hooks/use-search.ts
@@ -24,6 +24,7 @@ interface SearchOptions {
   initialQuery?: string;
   waitForFilterTypes?: boolean;
   restrictToFilterTypes?: boolean;
+  enabled?: boolean;
 }
 
 function normalizeTypeId(id: string): string {
@@ -56,6 +57,7 @@ export function useSearch({
   initialQuery,
   waitForFilterTypes,
   restrictToFilterTypes,
+  enabled,
 }: SearchOptions = {}) {
   const { store } = useSyncEngine();
   const cache = useQueryClient();
@@ -70,8 +72,10 @@ export function useSearch({
     (Boolean(waitForFilterTypes) && !filterByTypes?.length) ||
     (Boolean(restrictToFilterTypes) && !filterByTypes?.length);
 
+  const shouldSearch = (enabled ?? debouncedQuery !== '') && !searchBlocked;
+
   const { data: results, isLoading } = useQuery({
-    enabled: debouncedQuery !== '' && !searchBlocked,
+    enabled: shouldSearch,
     queryKey: [
       'search',
       debouncedQuery,
@@ -82,8 +86,6 @@ export function useSearch({
       additionalSpaceIds,
     ],
     queryFn: async () => {
-      if (query.length === 0) return [];
-
       const isValidEntityId = validateEntityId(maybeEntityId);
 
       if (isValidEntityId) {
@@ -193,11 +195,12 @@ export function useSearch({
   );
 
   const isQuerySyncing = query !== debouncedQuery;
-  const isWaitingForFilterTypes = searchBlocked && !isStringEmpty(query);
-  const shouldSuspend = isQuerySyncing || isLoading || isWaitingForFilterTypes;
+  const isWaitingForFilterTypes = shouldSearch === false && searchBlocked && (enabled ?? debouncedQuery !== '');
+  const shouldSuspend = isWaitingForFilterTypes || isQuerySyncing || isLoading;
 
   return {
-    isEmpty: isArrayEmpty(dedupedResults) && !isStringEmpty(query) && !shouldSuspend,
+    isEmpty:
+      isArrayEmpty(dedupedResults) && (Boolean(enabled) || !isStringEmpty(query)) && !shouldSuspend,
     isLoading: shouldSuspend,
     results: dedupedResults,
     query,

--- a/apps/web/core/hooks/use-spaces-query.ts
+++ b/apps/web/core/hooks/use-spaces-query.ts
@@ -74,7 +74,7 @@ export function useSpacesQuery(enabled = true, options?: UseSpacesQueryOptions) 
 
       return resultOrError.right;
     },
-    enabled: enabled && debouncedQuery.length > 0,
+    enabled,
   });
 
   const spaces = fuzzyMatchedSpaces.flatMap(entity => {

--- a/apps/web/core/hooks/use-spaces-query.ts
+++ b/apps/web/core/hooks/use-spaces-query.ts
@@ -16,10 +16,12 @@ const filterByTypes = ['362c1dbddc6444bba3c4652f38a642d7']; // Filter only space
 
 export type UseSpacesQueryOptions = {
   matchLimit?: number;
+  allowEmptyQuery?: boolean;
 };
 
 export function useSpacesQuery(enabled = true, options?: UseSpacesQueryOptions) {
   const matchLimit = options?.matchLimit ?? 10;
+  const allowEmptyQuery = options?.allowEmptyQuery ?? false;
   const [query, setQuery] = useState('');
   const debouncedQuery = useDebouncedValue(query, 200);
 
@@ -74,7 +76,7 @@ export function useSpacesQuery(enabled = true, options?: UseSpacesQueryOptions) 
 
       return resultOrError.right;
     },
-    enabled,
+    enabled: enabled && (allowEmptyQuery || debouncedQuery.trim().length > 0),
   });
 
   const spaces = fuzzyMatchedSpaces.flatMap(entity => {

--- a/apps/web/design-system/autocomplete/entity-search-autocomplete.tsx
+++ b/apps/web/design-system/autocomplete/entity-search-autocomplete.tsx
@@ -32,7 +32,11 @@ export function EntitySearchAutocomplete({
   dropdownClassName = '',
   filterByTypes,
 }: Props) {
-  const { query, onQueryChange, isLoading, results } = useSearch({ filterByTypes });
+  const [focused, setFocused] = React.useState(false);
+  const { query, onQueryChange, isLoading, results } = useSearch({
+    filterByTypes,
+    enabled: focused,
+  });
   const containerRef = useRef<HTMLDivElement>(null);
   const itemIdsSet = new Set(itemIds);
 
@@ -40,6 +44,7 @@ export function EntitySearchAutocomplete({
     const handleQueryChange = (e: MouseEvent) => {
       if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
         onQueryChange('');
+        setFocused(false);
       }
     };
 
@@ -47,20 +52,35 @@ export function EntitySearchAutocomplete({
     return () => document.removeEventListener('click', handleQueryChange);
   }, [onQueryChange]);
 
+  const close = React.useCallback(() => {
+    onQueryChange('');
+    setFocused(false);
+  }, [onQueryChange]);
+
   return (
-    <div className="relative w-full">
+    <div
+      ref={containerRef}
+      className="relative w-full"
+      onBlurCapture={event => {
+        if (event.relatedTarget instanceof Node && event.currentTarget.contains(event.relatedTarget)) return;
+        close();
+      }}
+    >
       <input
         value={query}
-        onChange={e => onQueryChange(e.target.value)}
+        onChange={e => {
+          onQueryChange(e.target.value);
+          setFocused(true);
+        }}
+        onFocus={() => setFocused(true)}
         placeholder={placeholder}
         className={cx(
           'inline-flex w-48 items-center justify-between rounded px-3 py-2 text-button whitespace-nowrap shadow-inner-grey-02 placeholder:text-text! focus:outline-hidden',
           className
         )}
       />
-      {query && (
+      {focused && (
         <div
-          ref={containerRef}
           className={cx(
             'absolute top-full left-0 z-10 mt-2 max-h-[400px] w-[384px] rounded border border-grey-02 bg-white shadow-lg',
             dropdownClassName
@@ -80,6 +100,7 @@ export function EntitySearchAutocomplete({
                     onClick={() => {
                       onDone(result);
                       onQueryChange('');
+                      setFocused(false);
                     }}
                     alreadySelected={itemIdsSet.has(result.id)}
                     result={result}

--- a/apps/web/design-system/find-entity.tsx
+++ b/apps/web/design-system/find-entity.tsx
@@ -51,7 +51,6 @@ export const FindEntity = ({
 
   const { query, onQueryChange, isLoading, isEmpty, results } = useSearch({
     filterByTypes: allowedTypes,
-    enabled: focused,
   });
 
   if (query === '' && result !== null) {
@@ -60,7 +59,8 @@ export const FindEntity = ({
     });
   }
 
-  const showPopover = focused && !hasDismissedPopover && (results.length > 0 || isLoading || isEmpty);
+  const showPopover =
+    focused && query.trim().length > 0 && !hasDismissedPopover && (results.length > 0 || isLoading || isEmpty);
 
   return (
     <div className="relative">

--- a/apps/web/design-system/find-entity.tsx
+++ b/apps/web/design-system/find-entity.tsx
@@ -36,6 +36,7 @@ export const FindEntity = ({
 }: FindEntityProps) => {
   const [portalContainer, setPortalContainer] = useState<HTMLDivElement | null>(null);
   const [hasDismissedPopover, setHasDismissedPopover] = useState<boolean>(false);
+  const [focused, setFocused] = useState<boolean>(false);
   const [result, setResult] = useState<SearchResult | null>(null);
 
   useEffect(() => {
@@ -50,6 +51,7 @@ export const FindEntity = ({
 
   const { query, onQueryChange, isLoading, isEmpty, results } = useSearch({
     filterByTypes: allowedTypes,
+    enabled: focused,
   });
 
   if (query === '' && result !== null) {
@@ -58,28 +60,21 @@ export const FindEntity = ({
     });
   }
 
-  const [hasStoppedTyping, setHasStoppedTyping] = useState<boolean>(false);
-
-  React.useEffect(() => {
-    setHasStoppedTyping(false);
-    const timeoutId = setTimeout(() => {
-      setHasStoppedTyping(true);
-    }, 500);
-
-    return () => clearTimeout(timeoutId);
-  }, [query]);
-
-  const showPopover = hasStoppedTyping && results.length > 0 && !hasDismissedPopover;
+  const showPopover = focused && !hasDismissedPopover && (results.length > 0 || isLoading || isEmpty);
 
   return (
     <div className="relative">
-      <Popover.Root open={!!query} onOpenChange={() => {}}>
+      <Popover.Root open={focused} onOpenChange={setFocused}>
         <Popover.Anchor asChild>
           <input
             value={query}
             onChange={event => {
               onQueryChange(event.target.value);
               onCreateEntity({ id: '', name: event.target.value });
+              setHasDismissedPopover(false);
+            }}
+            onFocus={() => {
+              setFocused(true);
               setHasDismissedPopover(false);
             }}
             placeholder={placeholder}
@@ -94,6 +89,7 @@ export const FindEntity = ({
                 event.preventDefault();
                 event.stopPropagation();
               }}
+              onInteractOutside={() => setFocused(false)}
               className="z-9999 w-(--radix-popper-anchor-width) pt-2"
               forceMount
             >
@@ -133,6 +129,7 @@ export const FindEntity = ({
                                     name: result.name,
                                   });
                                   onQueryChange('');
+                                  setFocused(false);
                                   setHasDismissedPopover(true);
                                 }}
                                 onKeyDown={event => {
@@ -143,6 +140,7 @@ export const FindEntity = ({
                                       name: result.name,
                                     });
                                     onQueryChange('');
+                                    setFocused(false);
                                     setHasDismissedPopover(true);
                                   }
                                 }}

--- a/apps/web/design-system/select-entity-compact.tsx
+++ b/apps/web/design-system/select-entity-compact.tsx
@@ -65,7 +65,7 @@ export function SelectEntityCompact({
   });
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [renderableType, setRenderableType] = useState<SwitchableRenderableType>(renderableTypeValue);
-  const hasResults = results.length > 0;
+  const hasResults = !isLoading && results.length > 0;
   const canCreate = Boolean(onCreateEntity) && query.trim().length > 0;
 
   React.useEffect(() => {

--- a/apps/web/design-system/select-entity-compact.tsx
+++ b/apps/web/design-system/select-entity-compact.tsx
@@ -123,11 +123,13 @@ export function SelectEntityCompact({
   });
 
   useKey('Escape', () => {
+    if (!focused) return;
     onQueryChange('');
     setFocused(false);
   });
 
   useKey('Enter', () => {
+    if (!focused) return;
     if (!hasResults && canCreate) {
       handleCreate();
       return;
@@ -138,12 +140,14 @@ export function SelectEntityCompact({
   });
 
   useKey('ArrowUp', e => {
+    if (!focused) return;
     if (!hasResults) return;
     e.preventDefault();
     setSelectedIndex(i => (i - 1 + results.length) % results.length);
   });
 
   useKey('ArrowDown', e => {
+    if (!focused) return;
     if (!hasResults) return;
     e.preventDefault();
     setSelectedIndex(i => (i + 1) % results.length);

--- a/apps/web/design-system/select-entity-compact.tsx
+++ b/apps/web/design-system/select-entity-compact.tsx
@@ -56,14 +56,16 @@ export function SelectEntityCompact({
   onRenderableTypeChange,
 }: SelectEntityCompactProps) {
   const anchorWrapperRef = React.useRef<HTMLDivElement | null>(null);
+  const [focused, setFocused] = React.useState(false);
   const { storage } = useMutate();
   const filterByTypes = relationValueTypes?.length ? relationValueTypes.map(r => r.id) : undefined;
   const { query, onQueryChange, results, isLoading, isEmpty } = useSearch({
     filterByTypes,
+    enabled: focused,
   });
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [renderableType, setRenderableType] = useState<SwitchableRenderableType>(renderableTypeValue);
-  const hasResults = query.trim() && results.length > 0;
+  const hasResults = results.length > 0;
   const canCreate = Boolean(onCreateEntity) && query.trim().length > 0;
 
   React.useEffect(() => {
@@ -81,6 +83,7 @@ export function SelectEntityCompact({
         primarySpaceName: space?.name,
       });
       onQueryChange('');
+      setFocused(false);
     },
     [onDone, onQueryChange]
   );
@@ -97,6 +100,7 @@ export function SelectEntityCompact({
     storage.entities.name.set(newEntityId, spaceId, query);
     onDone({ id: newEntityId, name: query });
     onQueryChange('');
+    setFocused(false);
   }, [onCreateEntity, onDone, onQueryChange, query, renderableType, spaceId, storage.entities.name]);
 
   const handleRenderableTypeChange = React.useCallback(
@@ -113,13 +117,14 @@ export function SelectEntityCompact({
   }, [query, results.length]);
 
   const { align: popoverAlign, side: popoverSide } = useAdaptiveDropdownPlacement(anchorWrapperRef, {
-    isOpen: query.trim().length > 0,
+    isOpen: focused,
     preferredHeight: 320,
     gap: 12,
   });
 
   useKey('Escape', () => {
     onQueryChange('');
+    setFocused(false);
   });
 
   useKey('Enter', () => {
@@ -144,8 +149,18 @@ export function SelectEntityCompact({
     setSelectedIndex(i => (i + 1) % results.length);
   });
 
+  const handleOpenChange = React.useCallback(
+    (open: boolean) => {
+      setFocused(open);
+      if (!open) {
+        onQueryChange('');
+      }
+    },
+    [onQueryChange]
+  );
+
   return (
-    <Popover.Root open={query.trim().length > 0}>
+    <Popover.Root open={focused} onOpenChange={handleOpenChange}>
       <Popover.Anchor asChild>
         <div ref={anchorWrapperRef} className="w-full space-y-2">
           <div className="relative w-full">
@@ -157,8 +172,10 @@ export function SelectEntityCompact({
               value={query}
               onChange={e => {
                 onQueryChange(e.target.value);
+                setFocused(true);
                 setSelectedIndex(0);
               }}
+              onFocus={() => setFocused(true)}
               aria-label="Search"
               placeholder={placeholder}
               className="w-full rounded-md border border-grey-02 bg-white py-2 pr-3 pl-9 text-body text-text shadow-inner shadow-grey-02 outline-hidden placeholder:text-grey-03 focus:shadow-inner-lg focus:shadow-text"
@@ -209,6 +226,7 @@ export function SelectEntityCompact({
           collisionPadding={16}
           avoidCollisions
           onOpenAutoFocus={e => e.preventDefault()}
+          onInteractOutside={() => setFocused(false)}
         >
           <div
             className="max-h-[min(50vh,300px)] overflow-y-auto overscroll-contain"

--- a/apps/web/design-system/select-entity.tsx
+++ b/apps/web/design-system/select-entity.tsx
@@ -132,6 +132,7 @@ export const SelectEntity = ({
   const [renderableType, setRenderableType] = useState<SwitchableRenderableType | undefined>('TEXT');
 
   const [clipPath, setClipPath] = useState('inset(-0px -100px -100px -100px)');
+  const [isSearchOpen, setIsSearchOpen] = useState(Boolean(autoFocus || initialQuery));
 
   const [popoverElement, setPopoverElement] = useState<HTMLDivElement | null>(null);
   // Mirror Radix's actual rendered `data-side` so the corner flip stays in lockstep
@@ -151,6 +152,7 @@ export const SelectEntity = ({
     filterByTypes,
     filterBySpace,
     initialQuery,
+    enabled: isSearchOpen,
     waitForFilterTypes,
     restrictToFilterTypes,
   });
@@ -211,13 +213,14 @@ export const SelectEntity = ({
     storage.entities.name.set(newEntityId, spaceId, query);
     onDone?.({ id: newEntityId, name: query, space: spaceId }, true);
     onQueryChange('');
+    setIsSearchOpen(false);
     setSelectedIndex(0);
     setToast(<EntityCreatedToast entityId={newEntityId} spaceId={spaceId} />);
   };
 
   const hasNoFilters = !typeFilter && !spaceFilter && allowedTypes.length === 0;
 
-  const hasResults = query && results.length > 0;
+  const hasResults = results.length > 0;
 
   useKey('Enter', () => {
     if (!hasResults) return;
@@ -232,6 +235,7 @@ export const SelectEntity = ({
         primarySpace: result.spaces?.[0]?.spaceId ? result.spaces[0].spaceId : undefined,
       });
       onQueryChange('');
+      setIsSearchOpen(false);
     }
   });
 
@@ -308,12 +312,12 @@ export const SelectEntity = ({
   }, [focusRequestKey]);
 
   const { align: popoverAlign, side: popoverSide } = useAdaptiveDropdownPlacement(inputRef, {
-    isOpen: Boolean(query),
+    isOpen: isSearchOpen,
     preferredHeight: advanced ? 520 : 300,
     gap: 12,
   });
 
-  const isQueried = query.length > 0;
+  const isQueried = isSearchOpen;
   // Use Radix's rendered `data-side` (mirrored into actualSide) so the corner flip
   // matches the visible position, even when Radix's collision middleware briefly
   // disagrees with our placement hook during scroll.
@@ -338,7 +342,7 @@ export const SelectEntity = ({
           <Search />
         </div>
       )}
-      <Popover.Root open={!!query}>
+      <Popover.Root open={isSearchOpen}>
         <Popover.Anchor asChild>
           <input
             ref={inputCallbackRef}
@@ -346,14 +350,16 @@ export const SelectEntity = ({
             value={query}
             onChange={({ currentTarget: { value } }) => {
               onQueryChange(value);
+              setIsSearchOpen(true);
               setSelectedIndex(0);
             }}
+            onFocus={() => setIsSearchOpen(true)}
             placeholder={placeholder}
             className={inputStyles({ [variant]: true, withSearchIcon, className: inputClassName })}
             spellCheck={false}
           />
         </Popover.Anchor>
-        {query && (
+        {isSearchOpen && (
           <Popover.Portal>
             <Popover.Content
               ref={node => {
@@ -378,6 +384,7 @@ export const SelectEntity = ({
                   return;
                 }
                 onQueryChange('');
+                setIsSearchOpen(false);
                 setSelectedIndex(0);
                 setResult(null);
               }}
@@ -571,6 +578,7 @@ export const SelectEntity = ({
                                           : undefined,
                                       });
                                       onQueryChange('');
+                                      setIsSearchOpen(false);
                                       setSelectedIndex(0);
                                     }}
                                     id={`select-entity-result-${index}`}
@@ -724,6 +732,7 @@ export const SelectEntity = ({
                                 space: space.spaceId,
                               });
                               onQueryChange('');
+                              setIsSearchOpen(false);
                               setSelectedIndex(0);
                             }}
                             className="flex w-full items-center gap-3 px-3 py-2 hover:bg-grey-01"
@@ -758,7 +767,7 @@ export const SelectEntity = ({
                         )}
                       </div>
                       <button
-                        disabled={isCreatingProperty && !renderableType}
+                        disabled={query.trim() === '' || (isCreatingProperty && !renderableType)}
                         onClick={onCreateNewEntity}
                         className="text-resultLink text-ctaHover disabled:text-grey-03"
                       >
@@ -849,10 +858,12 @@ type SpaceFilterInputProps = {
 };
 
 const SpaceFilterInput = ({ onSelect }: SpaceFilterInputProps) => {
-  const { query, setQuery, spaces: results } = useSpacesQuery();
+  const [focused, setFocused] = React.useState(false);
+  const { query, setQuery, spaces: results, isLoading } = useSpacesQuery(focused);
 
   const onSelectSpace = (space: (typeof results)[number]) => {
     setQuery('');
+    setFocused(false);
 
     onSelect({
       id: space.id,
@@ -860,19 +871,34 @@ const SpaceFilterInput = ({ onSelect }: SpaceFilterInputProps) => {
     });
   };
 
+  const close = React.useCallback(() => {
+    setQuery('');
+    setFocused(false);
+  }, [setQuery]);
+
   return (
     <div className="relative z-100 w-full">
-      <Popover.Root open={!!query} onOpenChange={() => setQuery('')}>
+      <Popover.Root
+        open={focused}
+        onOpenChange={open => {
+          if (open) {
+            setFocused(true);
+            return;
+          }
+          close();
+        }}
+      >
         <Popover.Anchor asChild>
-          <Input value={query} onChange={e => setQuery(e.target.value)} />
+          <Input value={query} onChange={e => setQuery(e.target.value)} onFocus={() => setFocused(true)} />
         </Popover.Anchor>
-        {query && (
+        {focused && (
           <Popover.Portal>
             <Popover.Content
               onOpenAutoFocus={event => {
                 event.preventDefault();
                 event.stopPropagation();
               }}
+              onInteractOutside={close}
               className="z-9999 w-(--radix-popper-anchor-width) leading-none"
               forceMount
             >
@@ -880,6 +906,11 @@ const SpaceFilterInput = ({ onSelect }: SpaceFilterInputProps) => {
                 <div className="flex max-h-[50vh] w-full flex-col overflow-hidden rounded border border-grey-02 bg-white">
                   <ResizableContainer>
                     <ResultsList>
+                      {!results.length && isLoading && (
+                        <div className="w-full border-b border-divider bg-white px-3 py-2">
+                          <div className="truncate text-button text-text">Loading...</div>
+                        </div>
+                      )}
                       {results.map(result => (
                         <ResultItem key={result.id} onClick={() => onSelectSpace(result)}>
                           <div className="flex w-full items-center justify-between leading-4">
@@ -917,23 +948,40 @@ type TypeFilterInputProps = {
 };
 
 const TypeFilterInput = ({ onSelect }: TypeFilterInputProps) => {
+  const [focused, setFocused] = React.useState(false);
   const { query, onQueryChange, isLoading, isEmpty, results } = useSearch({
     filterByTypes: [SystemIds.SCHEMA_TYPE],
+    enabled: focused,
   });
+
+  const close = React.useCallback(() => {
+    onQueryChange('');
+    setFocused(false);
+  }, [onQueryChange]);
 
   return (
     <div className="relative z-100 w-full">
-      <Popover.Root open={!!query} onOpenChange={() => onQueryChange('')}>
+      <Popover.Root
+        open={focused}
+        onOpenChange={open => {
+          if (open) {
+            setFocused(true);
+            return;
+          }
+          close();
+        }}
+      >
         <Popover.Anchor asChild>
-          <Input value={query} onChange={e => onQueryChange(e.target.value)} />
+          <Input value={query} onChange={e => onQueryChange(e.target.value)} onFocus={() => setFocused(true)} />
         </Popover.Anchor>
-        {query && (
+        {focused && (
           <Popover.Portal>
             <Popover.Content
               onOpenAutoFocus={event => {
                 event.preventDefault();
                 event.stopPropagation();
               }}
+              onInteractOutside={close}
               className="z-9999 w-(--radix-popper-anchor-width) leading-none"
               forceMount
             >
@@ -961,6 +1009,7 @@ const TypeFilterInput = ({ onSelect }: TypeFilterInputProps) => {
                                     name: result.name,
                                   });
                                   onQueryChange('');
+                                  setFocused(false);
                                 }}
                                 className="relative z-10 flex w-full flex-col transition-colors duration-150 hover:bg-grey-01 focus:bg-grey-01 focus:outline-hidden"
                               >

--- a/apps/web/partials/blocks/table/table-block-filter-creation-prompt.tsx
+++ b/apps/web/partials/blocks/table/table-block-filter-creation-prompt.tsx
@@ -1693,9 +1693,9 @@ function TableBlockSpaceFilterInput({
   memberSpaceId,
   onToggleSpace,
 }: TableBlockSpaceFilterInputProps) {
-  const { query, setQuery, spaces: results } = useSpacesQuery();
   const interactionRootRef = React.useRef<HTMLDivElement>(null);
   const { focused, setFocused, onFocus, onBlur, clearBlurTimeout } = useFilterValueInputFocus(interactionRootRef);
+  const { query, setQuery, spaces: results } = useSpacesQuery(focused);
 
   // Default suggestions shown on focus with empty query: the spaces the
   // current block's entity is a member of.

--- a/apps/web/partials/search/dialog.tsx
+++ b/apps/web/partials/search/dialog.tsx
@@ -41,7 +41,7 @@ export const SearchDialog = ({ open, onDone }: Props) => {
 
 const SearchDialogComponent = ({ open, onDone }: Props) => {
   const router = useRouter();
-  const autocomplete = useSearch();
+  const autocomplete = useSearch({ enabled: open });
   const { hydrate } = useSyncEngine();
 
   const [selectedIndex, setSelectedIndex] = useState<number>(0);
@@ -65,7 +65,7 @@ const SearchDialogComponent = ({ open, onDone }: Props) => {
     view = 'createEntity';
   }
 
-  const hasResults = autocomplete.query && autocomplete.results.length > 0;
+  const hasResults = autocomplete.results.length > 0;
 
   useKey('Enter', () => {
     if (!hasResults) return;


### PR DESCRIPTION
## Summary
- Allow search hooks to run with an empty query when explicitly enabled.
- Open/focused search windows now seed initial results before typing.
- Keep this PR single-page only; infinite scroll is split into the next PR.

## Validation
- eslint touched empty-query search files