### PR TITLE
[codex] Add search dropdown infinite scroll

### DIFF
--- a/apps/web/core/hooks/use-fetch-next-page-on-scroll.ts
+++ b/apps/web/core/hooks/use-fetch-next-page-on-scroll.ts
@@ -1,0 +1,35 @@
+'use client';
+
+import * as React from 'react';
+
+const DEFAULT_FETCH_MORE_DISTANCE_PX = 275;
+
+type UseFetchNextPageOnScrollOptions = {
+  hasNextPage?: boolean;
+  isFetchingNextPage?: boolean;
+  fetchNextPage: () => unknown;
+  distanceFromBottom?: number;
+};
+
+export function useFetchNextPageOnScroll<T extends HTMLElement>({
+  hasNextPage,
+  isFetchingNextPage,
+  fetchNextPage,
+  distanceFromBottom = DEFAULT_FETCH_MORE_DISTANCE_PX,
+}: UseFetchNextPageOnScrollOptions): React.UIEventHandler<T> {
+  return React.useCallback(
+    event => {
+      const element = event.currentTarget;
+      if (!isNearScrollBottom(element, distanceFromBottom)) return;
+      if (hasNextPage && !isFetchingNextPage) {
+        void fetchNextPage();
+      }
+    },
+    [distanceFromBottom, fetchNextPage, hasNextPage, isFetchingNextPage]
+  );
+}
+
+export function isNearScrollBottom(element: HTMLElement, distanceFromBottom = DEFAULT_FETCH_MORE_DISTANCE_PX): boolean {
+  const remainingScroll = element.scrollHeight - element.scrollTop - element.clientHeight;
+  return remainingScroll <= distanceFromBottom;
+}

--- a/apps/web/core/hooks/use-fetch-next-page-on-scroll.ts
+++ b/apps/web/core/hooks/use-fetch-next-page-on-scroll.ts
@@ -9,6 +9,7 @@ type UseFetchNextPageOnScrollOptions = {
   isFetchingNextPage?: boolean;
   fetchNextPage: () => unknown;
   distanceFromBottom?: number;
+  scrollRef?: React.RefObject<HTMLElement | null>;
 };
 
 export function useFetchNextPageOnScroll<T extends HTMLElement>({
@@ -16,16 +17,30 @@ export function useFetchNextPageOnScroll<T extends HTMLElement>({
   isFetchingNextPage,
   fetchNextPage,
   distanceFromBottom = DEFAULT_FETCH_MORE_DISTANCE_PX,
+  scrollRef,
 }: UseFetchNextPageOnScrollOptions): React.UIEventHandler<T> {
-  return React.useCallback(
-    event => {
-      const element = event.currentTarget;
-      if (!isNearScrollBottom(element, distanceFromBottom)) return;
+  const fetchIfNeeded = React.useCallback(
+    (element: HTMLElement, includeNoOverflow = false) => {
+      const noOverflow = element.scrollHeight <= element.clientHeight + 2;
+      if (!isNearScrollBottom(element, distanceFromBottom) && !(includeNoOverflow && noOverflow)) return;
       if (hasNextPage && !isFetchingNextPage) {
         void fetchNextPage();
       }
     },
     [distanceFromBottom, fetchNextPage, hasNextPage, isFetchingNextPage]
+  );
+
+  React.useLayoutEffect(() => {
+    const element = scrollRef?.current;
+    if (!element) return;
+    fetchIfNeeded(element, true);
+  }, [fetchIfNeeded, scrollRef]);
+
+  return React.useCallback(
+    event => {
+      fetchIfNeeded(event.currentTarget);
+    },
+    [fetchIfNeeded]
   );
 }
 

--- a/apps/web/core/hooks/use-search.ts
+++ b/apps/web/core/hooks/use-search.ts
@@ -82,6 +82,7 @@ export function useSearch({
   const additionalSpaceIds = useGlobalSearchSpaceIds();
 
   const maybeEntityId = debouncedQuery.trim();
+  const filterTypeKey = React.useMemo(() => (filterByTypes ? [...filterByTypes].sort() : undefined), [filterByTypes]);
 
   const searchBlocked =
     (Boolean(waitForFilterTypes) && !filterByTypes?.length) ||
@@ -101,7 +102,7 @@ export function useSearch({
     queryKey: [
       'search',
       debouncedQuery,
-      filterByTypes?.join('-'),
+      filterTypeKey,
       filterBySpace,
       Boolean(waitForFilterTypes),
       Boolean(restrictToFilterTypes),

--- a/apps/web/core/hooks/use-search.ts
+++ b/apps/web/core/hooks/use-search.ts
@@ -30,6 +30,7 @@ interface SearchOptions {
 }
 
 const DEFAULT_SEARCH_PAGE_SIZE = 10;
+const EMPTY_PAGE_PUMP_LIMIT = 3;
 
 type SearchPage = {
   rows: SearchResult[];
@@ -210,10 +211,7 @@ export function useSearch({
     },
     getNextPageParam: lastPage => {
       const nextOffset = lastPage.offset + pageSize;
-      if (typeof lastPage.total === 'number') {
-        return nextOffset >= lastPage.total ? undefined : nextOffset;
-      }
-      return lastPage.rawCount < pageSize ? undefined : nextOffset;
+      return nextOffset >= lastPage.total ? undefined : nextOffset;
     },
     /**
      * We don't want to return stale search results. Instead we just
@@ -224,6 +222,28 @@ export function useSearch({
      */
     gcTime: Duration.toMillis(Duration.seconds(15)),
   });
+
+  const emptyPagePumpCountRef = React.useRef(0);
+
+  React.useEffect(() => {
+    const lastPage = resultPages?.pages.at(-1);
+    if (!lastPage) {
+      emptyPagePumpCountRef.current = 0;
+      return;
+    }
+
+    if (lastPage.rows.length > 0 || !hasNextPage) {
+      emptyPagePumpCountRef.current = 0;
+      return;
+    }
+
+    if (lastPage.rawCount < pageSize || isFetchingNextPage || emptyPagePumpCountRef.current >= EMPTY_PAGE_PUMP_LIMIT) {
+      return;
+    }
+
+    emptyPagePumpCountRef.current += 1;
+    void fetchNextPage();
+  }, [fetchNextPage, hasNextPage, isFetchingNextPage, pageSize, resultPages]);
 
   const results = React.useMemo(() => {
     const seen = new Set<string>();

--- a/apps/web/core/hooks/use-search.ts
+++ b/apps/web/core/hooks/use-search.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useInfiniteQuery, useQueryClient } from '@tanstack/react-query';
 
 import * as React from 'react';
 
@@ -15,6 +15,7 @@ import { validateEntityId } from '~/core/utils/utils';
 import { mergeSearchResult } from '../database/result';
 import { E } from '../sync/orm';
 import { useSyncEngine } from '../sync/use-sync-engine';
+import type { SearchResult } from '../types';
 import { useDebouncedValue } from './use-debounced-value';
 import { useGlobalSearchSpaceIds } from './use-global-search-space-ids';
 
@@ -25,7 +26,19 @@ interface SearchOptions {
   waitForFilterTypes?: boolean;
   restrictToFilterTypes?: boolean;
   enabled?: boolean;
+  pageSize?: number;
 }
+
+const DEFAULT_SEARCH_PAGE_SIZE = 10;
+
+type SearchPage = {
+  rows: SearchResult[];
+  offset: number;
+  rawCount: number;
+  total: number;
+};
+
+const emptySearchPage = (offset: number): SearchPage => ({ rows: [], offset, rawCount: 0, total: 0 });
 
 function normalizeTypeId(id: string): string {
   return id.replace(/-/g, '');
@@ -58,6 +71,7 @@ export function useSearch({
   waitForFilterTypes,
   restrictToFilterTypes,
   enabled,
+  pageSize = DEFAULT_SEARCH_PAGE_SIZE,
 }: SearchOptions = {}) {
   const { store } = useSyncEngine();
   const cache = useQueryClient();
@@ -74,7 +88,14 @@ export function useSearch({
 
   const shouldSearch = (enabled ?? debouncedQuery !== '') && !searchBlocked;
 
-  const { data: results, isLoading } = useQuery({
+  const {
+    data: resultPages,
+    isLoading,
+    isFetching,
+    isFetchingNextPage,
+    hasNextPage,
+    fetchNextPage,
+  } = useInfiniteQuery({
     enabled: shouldSearch,
     queryKey: [
       'search',
@@ -84,11 +105,15 @@ export function useSearch({
       Boolean(waitForFilterTypes),
       Boolean(restrictToFilterTypes),
       additionalSpaceIds,
+      pageSize,
     ],
-    queryFn: async () => {
+    initialPageParam: 0,
+    queryFn: async ({ pageParam, signal }): Promise<SearchPage> => {
       const isValidEntityId = validateEntityId(maybeEntityId);
 
       if (isValidEntityId) {
+        if (pageParam > 0) return emptySearchPage(pageParam);
+
         const id = maybeEntityId;
 
         const fetchResultEffect = Effect.either(
@@ -113,7 +138,7 @@ export function useSearch({
           switch (error._tag) {
             case 'AbortError':
               console.log(`abort error`);
-              return [];
+              return emptySearchPage(pageParam);
             default:
               console.error('useSearch error:', String(error));
               throw error;
@@ -121,17 +146,17 @@ export function useSearch({
         }
 
         const merged = resultOrError.right;
-        if (!merged) return [];
+        if (!merged) return emptySearchPage(pageParam);
         if (filterByTypes?.length && !resultMatchesFilterTypes(merged, filterByTypes)) {
-          return [];
+          return emptySearchPage(pageParam);
         }
-        return [merged];
+        return { rows: [merged], offset: pageParam, rawCount: 1, total: 1 };
       }
 
       const fetchResultsEffect = Effect.either(
         Effect.tryPromise({
           try: async () =>
-            await E.findFuzzy({
+            await E.findFuzzyPage({
               store,
               cache,
               where: {
@@ -149,8 +174,9 @@ export function useSearch({
                   : {}),
                 ...(filterBySpace ? { space: { id: { equals: filterBySpace } } } : {}),
               },
-              first: 10,
-              skip: 0,
+              first: pageSize,
+              skip: pageParam,
+              signal,
               additionalSpaceIds,
             }),
           catch: error => {
@@ -168,16 +194,26 @@ export function useSearch({
         switch (error._tag) {
           case 'AbortError':
             console.log(`abort error`);
-            return [];
+            return emptySearchPage(pageParam);
           default:
             console.error('useSearch error:', String(error));
             throw error;
         }
       }
 
-      const rows = resultOrError.right;
-      if (!filterByTypes?.length) return rows;
-      return rows.filter(r => resultMatchesFilterTypes(r, filterByTypes));
+      const page = resultOrError.right;
+      const rows = !filterByTypes?.length
+        ? page.results
+        : page.results.filter(r => resultMatchesFilterTypes(r, filterByTypes));
+
+      return { rows, offset: pageParam, rawCount: page.rawCount, total: page.total };
+    },
+    getNextPageParam: lastPage => {
+      const nextOffset = lastPage.offset + pageSize;
+      if (typeof lastPage.total === 'number') {
+        return nextOffset >= lastPage.total ? undefined : nextOffset;
+      }
+      return lastPage.rawCount < pageSize ? undefined : nextOffset;
     },
     /**
      * We don't want to return stale search results. Instead we just
@@ -189,10 +225,16 @@ export function useSearch({
     gcTime: Duration.toMillis(Duration.seconds(15)),
   });
 
-  const dedupedResults = React.useMemo(
-    () => (results ?? []).map(result => dedupeSearchResultTypeTags(result)),
-    [results]
-  );
+  const results = React.useMemo(() => {
+    const seen = new Set<string>();
+    const rows: NonNullable<typeof resultPages>['pages'][number]['rows'] = [];
+    for (const row of resultPages?.pages.flatMap(page => page.rows) ?? []) {
+      if (seen.has(row.id)) continue;
+      seen.add(row.id);
+      rows.push(dedupeSearchResultTypeTags(row));
+    }
+    return rows;
+  }, [resultPages]);
 
   const isQuerySyncing = query !== debouncedQuery;
   const isWaitingForFilterTypes = shouldSearch === false && searchBlocked && (enabled ?? debouncedQuery !== '');
@@ -200,9 +242,13 @@ export function useSearch({
 
   return {
     isEmpty:
-      isArrayEmpty(dedupedResults) && (Boolean(enabled) || !isStringEmpty(query)) && !shouldSuspend,
+      isArrayEmpty(results) && (Boolean(enabled) || !isStringEmpty(query)) && !shouldSuspend,
     isLoading: shouldSuspend,
-    results: dedupedResults,
+    isFetching,
+    isFetchingNextPage,
+    hasNextPage,
+    fetchNextPage,
+    results,
     query,
     onQueryChange: setQuery,
   };

--- a/apps/web/core/hooks/use-spaces-query.ts
+++ b/apps/web/core/hooks/use-spaces-query.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useInfiniteQuery, useQueryClient } from '@tanstack/react-query';
 
 import { useState } from 'react';
 
@@ -28,13 +28,20 @@ export function useSpacesQuery(enabled = true, options?: UseSpacesQueryOptions) 
   const { store } = useSyncEngine();
   const cache = useQueryClient();
 
-  const { data: fuzzyMatchedSpaces = [], isLoading } = useQuery({
+  const {
+    data: fuzzyMatchedSpacePages,
+    isLoading,
+    isFetchingNextPage,
+    hasNextPage,
+    fetchNextPage,
+  } = useInfiniteQuery({
     queryKey: ['spaces-by-name', debouncedQuery, matchLimit],
-    queryFn: async () => {
+    initialPageParam: 0,
+    queryFn: async ({ pageParam, signal }) => {
       const fetchResultsEffect = Effect.either(
         Effect.tryPromise({
           try: async () =>
-            await E.findFuzzy({
+            await E.findFuzzyPage({
               store,
               cache,
               where: {
@@ -50,7 +57,8 @@ export function useSpacesQuery(enabled = true, options?: UseSpacesQueryOptions) 
                 }),
               },
               first: matchLimit,
-              skip: 0,
+              skip: pageParam,
+              signal,
             }),
           catch: error => {
             console.error('error', error);
@@ -67,17 +75,31 @@ export function useSpacesQuery(enabled = true, options?: UseSpacesQueryOptions) 
         switch (error._tag) {
           case 'AbortError':
             console.log(`abort error`);
-            return [];
+            return { rows: [], offset: pageParam, rawCount: 0, total: 0 };
           default:
             console.error('useSearch error:', String(error));
             throw error;
         }
       }
 
-      return resultOrError.right;
+      return {
+        rows: resultOrError.right.results,
+        offset: pageParam,
+        rawCount: resultOrError.right.rawCount,
+        total: resultOrError.right.total,
+      };
+    },
+    getNextPageParam: lastPage => {
+      const nextOffset = lastPage.offset + matchLimit;
+      if (typeof lastPage.total === 'number') {
+        return nextOffset >= lastPage.total ? undefined : nextOffset;
+      }
+      return lastPage.rawCount < matchLimit ? undefined : nextOffset;
     },
     enabled: enabled && (allowEmptyQuery || debouncedQuery.trim().length > 0),
   });
+
+  const fuzzyMatchedSpaces = fuzzyMatchedSpacePages?.pages.flatMap(page => page.rows) ?? [];
 
   const spaces = fuzzyMatchedSpaces.flatMap(entity => {
     return entity.spaces.map(space => ({
@@ -114,19 +136,13 @@ export function useSpacesQuery(enabled = true, options?: UseSpacesQueryOptions) 
     return [...byId.values()];
   };
 
-  if (!fuzzyMatchedSpaces) {
-    return {
-      query,
-      setQuery,
-      spaces: [],
-      isLoading,
-    };
-  }
-
   return {
     query,
     setQuery,
     spaces: uniqueSpacesById(spaces),
     isLoading,
+    isFetchingNextPage,
+    hasNextPage,
+    fetchNextPage,
   };
 }

--- a/apps/web/core/hooks/use-spaces-query.ts
+++ b/apps/web/core/hooks/use-spaces-query.ts
@@ -91,10 +91,7 @@ export function useSpacesQuery(enabled = true, options?: UseSpacesQueryOptions) 
     },
     getNextPageParam: lastPage => {
       const nextOffset = lastPage.offset + matchLimit;
-      if (typeof lastPage.total === 'number') {
-        return nextOffset >= lastPage.total ? undefined : nextOffset;
-      }
-      return lastPage.rawCount < matchLimit ? undefined : nextOffset;
+      return nextOffset >= lastPage.total ? undefined : nextOffset;
     },
     enabled: enabled && (allowEmptyQuery || debouncedQuery.trim().length > 0),
   });

--- a/apps/web/design-system/autocomplete/entity-search-autocomplete.tsx
+++ b/apps/web/design-system/autocomplete/entity-search-autocomplete.tsx
@@ -6,6 +6,7 @@ import { useEffect, useRef } from 'react';
 import cx from 'classnames';
 import { AnimatePresence, motion } from 'framer-motion';
 
+import { useFetchNextPageOnScroll } from '~/core/hooks/use-fetch-next-page-on-scroll';
 import { useSearch } from '~/core/hooks/use-search';
 
 import { Dots } from '~/design-system/dots';
@@ -52,17 +53,11 @@ export function EntitySearchAutocomplete({
     return () => document.removeEventListener('click', handleQueryChange);
   }, [onQueryChange]);
 
-  const handleResultsScroll = React.useCallback(
-    (e: React.UIEvent<HTMLUListElement>) => {
-      const el = e.currentTarget;
-      const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
-      if (distanceFromBottom > 275) return;
-      if (hasNextPage && !isFetchingNextPage) {
-        void fetchNextPage();
-      }
-    },
-    [fetchNextPage, hasNextPage, isFetchingNextPage]
-  );
+  const handleResultsScroll = useFetchNextPageOnScroll<HTMLUListElement>({
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
+  });
 
   const close = React.useCallback(() => {
     onQueryChange('');

--- a/apps/web/design-system/autocomplete/entity-search-autocomplete.tsx
+++ b/apps/web/design-system/autocomplete/entity-search-autocomplete.tsx
@@ -33,7 +33,7 @@ export function EntitySearchAutocomplete({
   filterByTypes,
 }: Props) {
   const [focused, setFocused] = React.useState(false);
-  const { query, onQueryChange, isLoading, results } = useSearch({
+  const { query, onQueryChange, isLoading, results, hasNextPage, fetchNextPage, isFetchingNextPage } = useSearch({
     filterByTypes,
     enabled: focused,
   });
@@ -51,6 +51,18 @@ export function EntitySearchAutocomplete({
     document.addEventListener('click', handleQueryChange);
     return () => document.removeEventListener('click', handleQueryChange);
   }, [onQueryChange]);
+
+  const handleResultsScroll = React.useCallback(
+    (e: React.UIEvent<HTMLUListElement>) => {
+      const el = e.currentTarget;
+      const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
+      if (distanceFromBottom > 275) return;
+      if (hasNextPage && !isFetchingNextPage) {
+        void fetchNextPage();
+      }
+    },
+    [fetchNextPage, hasNextPage, isFetchingNextPage]
+  );
 
   const close = React.useCallback(() => {
     onQueryChange('');
@@ -87,7 +99,7 @@ export function EntitySearchAutocomplete({
           )}
         >
           <ResizableContainer duration={0.125}>
-            <ResultsList>
+            <ResultsList onScroll={handleResultsScroll}>
               {results.map((result, i) => (
                 <motion.div
                   initial={{ opacity: 0, y: -5 }}
@@ -110,7 +122,7 @@ export function EntitySearchAutocomplete({
             </ResultsList>
             <div className="flex items-center justify-center py-2 text-smallButton">
               <AnimatePresence mode="wait">
-                {isLoading ? (
+                {isLoading || isFetchingNextPage ? (
                   <motion.span
                     key="dots"
                     initial={{ opacity: 0, scale: 0.95 }}

--- a/apps/web/design-system/autocomplete/entity-search-autocomplete.tsx
+++ b/apps/web/design-system/autocomplete/entity-search-autocomplete.tsx
@@ -53,10 +53,12 @@ export function EntitySearchAutocomplete({
     return () => document.removeEventListener('click', handleQueryChange);
   }, [onQueryChange]);
 
+  const resultsScrollRef = React.useRef<HTMLUListElement | null>(null);
   const handleResultsScroll = useFetchNextPageOnScroll<HTMLUListElement>({
     hasNextPage,
     isFetchingNextPage,
     fetchNextPage,
+    scrollRef: resultsScrollRef,
   });
 
   const close = React.useCallback(() => {
@@ -94,7 +96,7 @@ export function EntitySearchAutocomplete({
           )}
         >
           <ResizableContainer duration={0.125}>
-            <ResultsList onScroll={handleResultsScroll}>
+            <ResultsList ref={resultsScrollRef} onScroll={handleResultsScroll}>
               {results.map((result, i) => (
                 <motion.div
                   initial={{ opacity: 0, y: -5 }}

--- a/apps/web/design-system/find-entity.tsx
+++ b/apps/web/design-system/find-entity.tsx
@@ -49,7 +49,16 @@ export const FindEntity = ({
     };
   }, []);
 
-  const { query, onQueryChange, isLoading, isEmpty, results } = useSearch({
+  const {
+    query,
+    onQueryChange,
+    isLoading,
+    isEmpty,
+    results,
+    hasNextPage,
+    fetchNextPage,
+    isFetchingNextPage,
+  } = useSearch({
     filterByTypes: allowedTypes,
   });
 
@@ -61,6 +70,18 @@ export const FindEntity = ({
 
   const showPopover =
     focused && query.trim().length > 0 && !hasDismissedPopover && (results.length > 0 || isLoading || isEmpty);
+
+  const handleResultsScroll = React.useCallback(
+    (e: React.UIEvent<HTMLDivElement>) => {
+      const el = e.currentTarget;
+      const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
+      if (distanceFromBottom > 275) return;
+      if (hasNextPage && !isFetchingNextPage) {
+        void fetchNextPage();
+      }
+    },
+    [fetchNextPage, hasNextPage, isFetchingNextPage]
+  );
 
   return (
     <div className="relative">
@@ -104,6 +125,7 @@ export const FindEntity = ({
                 <ResizableContainer>
                   <div
                     className="flex max-h-[210px] flex-col overflow-x-clip overflow-y-auto overscroll-contain border-t border-grey-02 bg-white"
+                    onScroll={handleResultsScroll}
                     onWheel={e => trapWheelToElement(e.currentTarget, e)}
                   >
                     {!results?.length && isLoading && (

--- a/apps/web/design-system/find-entity.tsx
+++ b/apps/web/design-system/find-entity.tsx
@@ -72,10 +72,12 @@ export const FindEntity = ({
   const showPopover =
     focused && query.trim().length > 0 && !hasDismissedPopover && (results.length > 0 || isLoading || isEmpty);
 
+  const resultsScrollRef = React.useRef<HTMLDivElement | null>(null);
   const handleResultsScroll = useFetchNextPageOnScroll<HTMLDivElement>({
     hasNextPage,
     isFetchingNextPage,
     fetchNextPage,
+    scrollRef: resultsScrollRef,
   });
 
   return (
@@ -119,6 +121,7 @@ export const FindEntity = ({
                 </div>
                 <ResizableContainer>
                   <div
+                    ref={resultsScrollRef}
                     className="flex max-h-[210px] flex-col overflow-x-clip overflow-y-auto overscroll-contain border-t border-grey-02 bg-white"
                     onScroll={handleResultsScroll}
                     onWheel={e => trapWheelToElement(e.currentTarget, e)}

--- a/apps/web/design-system/find-entity.tsx
+++ b/apps/web/design-system/find-entity.tsx
@@ -8,6 +8,7 @@ import { startTransition, useEffect, useState } from 'react';
 import pluralize from 'pluralize';
 
 import { ROOT_SPACE } from '~/core/constants';
+import { useFetchNextPageOnScroll } from '~/core/hooks/use-fetch-next-page-on-scroll';
 import { useSearch } from '~/core/hooks/use-search';
 import { SearchResult } from '~/core/types';
 import { NavUtils } from '~/core/utils/utils';
@@ -71,17 +72,11 @@ export const FindEntity = ({
   const showPopover =
     focused && query.trim().length > 0 && !hasDismissedPopover && (results.length > 0 || isLoading || isEmpty);
 
-  const handleResultsScroll = React.useCallback(
-    (e: React.UIEvent<HTMLDivElement>) => {
-      const el = e.currentTarget;
-      const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
-      if (distanceFromBottom > 275) return;
-      if (hasNextPage && !isFetchingNextPage) {
-        void fetchNextPage();
-      }
-    },
-    [fetchNextPage, hasNextPage, isFetchingNextPage]
-  );
+  const handleResultsScroll = useFetchNextPageOnScroll<HTMLDivElement>({
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
+  });
 
   return (
     <div className="relative">
@@ -225,6 +220,11 @@ export const FindEntity = ({
                             </div>
                           </div>
                         ))}
+                        {isFetchingNextPage ? (
+                          <div className="w-full border-t border-divider bg-white px-3 py-2">
+                            <div className="truncate text-button text-text">Loading more...</div>
+                          </div>
+                        ) : null}
                       </div>
                     )}
                   </div>

--- a/apps/web/design-system/select-entity-compact.tsx
+++ b/apps/web/design-system/select-entity-compact.tsx
@@ -59,7 +59,16 @@ export function SelectEntityCompact({
   const [focused, setFocused] = React.useState(false);
   const { storage } = useMutate();
   const filterByTypes = relationValueTypes?.length ? relationValueTypes.map(r => r.id) : undefined;
-  const { query, onQueryChange, results, isLoading, isEmpty } = useSearch({
+  const {
+    query,
+    onQueryChange,
+    results,
+    isLoading,
+    isEmpty,
+    hasNextPage,
+    fetchNextPage,
+    isFetchingNextPage,
+  } = useSearch({
     filterByTypes,
     enabled: focused,
   });
@@ -153,6 +162,18 @@ export function SelectEntityCompact({
     setSelectedIndex(i => (i + 1) % results.length);
   });
 
+  const handleResultsScroll = React.useCallback(
+    (e: React.UIEvent<HTMLDivElement>) => {
+      const el = e.currentTarget;
+      const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
+      if (distanceFromBottom > 275) return;
+      if (hasNextPage && !isFetchingNextPage) {
+        void fetchNextPage();
+      }
+    },
+    [fetchNextPage, hasNextPage, isFetchingNextPage]
+  );
+
   const handleOpenChange = React.useCallback(
     (open: boolean) => {
       setFocused(open);
@@ -234,6 +255,7 @@ export function SelectEntityCompact({
         >
           <div
             className="max-h-[min(50vh,300px)] overflow-y-auto overscroll-contain"
+            onScroll={handleResultsScroll}
             onWheel={e => trapWheelToElement(e.currentTarget, e)}
           >
             {isLoading && <div className="px-3 py-2 text-resultTitle text-text">Loading...</div>}
@@ -291,6 +313,9 @@ export function SelectEntityCompact({
                     </div>
                   </button>
                 ))}
+                {isFetchingNextPage ? (
+                  <div className="px-3 py-2 text-resultTitle text-text">Loading more...</div>
+                ) : null}
               </div>
             )}
           </div>

--- a/apps/web/design-system/select-entity-compact.tsx
+++ b/apps/web/design-system/select-entity-compact.tsx
@@ -163,10 +163,12 @@ export function SelectEntityCompact({
     setSelectedIndex(i => (i + 1) % results.length);
   });
 
+  const resultsScrollRef = React.useRef<HTMLDivElement | null>(null);
   const handleResultsScroll = useFetchNextPageOnScroll<HTMLDivElement>({
     hasNextPage,
     isFetchingNextPage,
     fetchNextPage,
+    scrollRef: resultsScrollRef,
   });
 
   const handleOpenChange = React.useCallback(
@@ -249,6 +251,7 @@ export function SelectEntityCompact({
           onInteractOutside={() => setFocused(false)}
         >
           <div
+            ref={resultsScrollRef}
             className="max-h-[min(50vh,300px)] overflow-y-auto overscroll-contain"
             onScroll={handleResultsScroll}
             onWheel={e => trapWheelToElement(e.currentTarget, e)}

--- a/apps/web/design-system/select-entity-compact.tsx
+++ b/apps/web/design-system/select-entity-compact.tsx
@@ -5,6 +5,7 @@ import * as Popover from '@radix-ui/react-popover';
 import * as React from 'react';
 import { useState } from 'react';
 
+import { useFetchNextPageOnScroll } from '~/core/hooks/use-fetch-next-page-on-scroll';
 import { useKey } from '~/core/hooks/use-key';
 import { useSearch } from '~/core/hooks/use-search';
 import { ID } from '~/core/id';
@@ -162,17 +163,11 @@ export function SelectEntityCompact({
     setSelectedIndex(i => (i + 1) % results.length);
   });
 
-  const handleResultsScroll = React.useCallback(
-    (e: React.UIEvent<HTMLDivElement>) => {
-      const el = e.currentTarget;
-      const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
-      if (distanceFromBottom > 275) return;
-      if (hasNextPage && !isFetchingNextPage) {
-        void fetchNextPage();
-      }
-    },
-    [fetchNextPage, hasNextPage, isFetchingNextPage]
-  );
+  const handleResultsScroll = useFetchNextPageOnScroll<HTMLDivElement>({
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
+  });
 
   const handleOpenChange = React.useCallback(
     (open: boolean) => {

--- a/apps/web/design-system/select-entity.tsx
+++ b/apps/web/design-system/select-entity.tsx
@@ -148,7 +148,16 @@ export const SelectEntity = ({
       ? allowedTypes.map(r => r.id)
       : undefined;
 
-  const { query, onQueryChange, isLoading, isEmpty, results } = useSearch({
+  const {
+    query,
+    onQueryChange,
+    isLoading,
+    isEmpty,
+    results,
+    hasNextPage,
+    fetchNextPage,
+    isFetchingNextPage,
+  } = useSearch({
     filterByTypes,
     filterBySpace,
     initialQuery,
@@ -322,6 +331,18 @@ export const SelectEntity = ({
   // matches the visible position, even when Radix's collision middleware briefly
   // disagrees with our placement hook during scroll.
   const popoverAbove = actualSide === 'top';
+
+  const handleResultsScroll = React.useCallback(
+    (e: React.UIEvent<HTMLDivElement>) => {
+      const el = e.currentTarget;
+      const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
+      if (distanceFromBottom > 275) return;
+      if (hasNextPage && !isFetchingNextPage) {
+        void fetchNextPage();
+      }
+    },
+    [fetchNextPage, hasNextPage, isFetchingNextPage]
+  );
 
   return (
     <div
@@ -551,6 +572,7 @@ export const SelectEntity = ({
                           // the dropdown above the input.
                           minHeight: results.length > 0 ? '100px' : '2.5rem',
                         }}
+                        onScroll={handleResultsScroll}
                         onWheel={e => trapWheelToElement(e.currentTarget, e)}
                       >
                         {!results?.length && isLoading && (
@@ -684,6 +706,11 @@ export const SelectEntity = ({
                                 )}
                               </div>
                             ))}
+                            {isFetchingNextPage ? (
+                              <div className="w-full bg-white px-3 py-2">
+                                <div className="truncate text-resultTitle text-text">Loading more...</div>
+                              </div>
+                            ) : null}
                           </div>
                         )}
                       </div>
@@ -859,7 +886,27 @@ type SpaceFilterInputProps = {
 
 const SpaceFilterInput = ({ onSelect }: SpaceFilterInputProps) => {
   const [focused, setFocused] = React.useState(false);
-  const { query, setQuery, spaces: results, isLoading } = useSpacesQuery(focused);
+  const {
+    query,
+    setQuery,
+    spaces: results,
+    isLoading,
+    hasNextPage,
+    fetchNextPage,
+    isFetchingNextPage,
+  } = useSpacesQuery(focused);
+
+  const handleResultsScroll = React.useCallback(
+    (e: React.UIEvent<HTMLUListElement>) => {
+      const el = e.currentTarget;
+      const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
+      if (distanceFromBottom > 275) return;
+      if (hasNextPage && !isFetchingNextPage) {
+        void fetchNextPage();
+      }
+    },
+    [fetchNextPage, hasNextPage, isFetchingNextPage]
+  );
 
   const onSelectSpace = (space: (typeof results)[number]) => {
     setQuery('');
@@ -905,7 +952,7 @@ const SpaceFilterInput = ({ onSelect }: SpaceFilterInputProps) => {
               <div className="pt-1">
                 <div className="flex max-h-[50vh] w-full flex-col overflow-hidden rounded border border-grey-02 bg-white">
                   <ResizableContainer>
-                    <ResultsList>
+                    <ResultsList onScroll={handleResultsScroll}>
                       {!results.length && isLoading && (
                         <div className="w-full border-b border-divider bg-white px-3 py-2">
                           <div className="truncate text-button text-text">Loading...</div>
@@ -931,6 +978,11 @@ const SpaceFilterInput = ({ onSelect }: SpaceFilterInputProps) => {
                           </div>
                         </ResultItem>
                       ))}
+                      {isFetchingNextPage ? (
+                        <div className="w-full border-b border-divider bg-white px-3 py-2">
+                          <div className="truncate text-button text-text">Loading more...</div>
+                        </div>
+                      ) : null}
                     </ResultsList>
                   </ResizableContainer>
                 </div>
@@ -949,10 +1001,31 @@ type TypeFilterInputProps = {
 
 const TypeFilterInput = ({ onSelect }: TypeFilterInputProps) => {
   const [focused, setFocused] = React.useState(false);
-  const { query, onQueryChange, isLoading, isEmpty, results } = useSearch({
+  const {
+    query,
+    onQueryChange,
+    isLoading,
+    isEmpty,
+    results,
+    hasNextPage,
+    fetchNextPage,
+    isFetchingNextPage,
+  } = useSearch({
     filterByTypes: [SystemIds.SCHEMA_TYPE],
     enabled: focused,
   });
+
+  const handleResultsScroll = React.useCallback(
+    (e: React.UIEvent<HTMLUListElement>) => {
+      const el = e.currentTarget;
+      const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
+      if (distanceFromBottom > 275) return;
+      if (hasNextPage && !isFetchingNextPage) {
+        void fetchNextPage();
+      }
+    },
+    [fetchNextPage, hasNextPage, isFetchingNextPage]
+  );
 
   const close = React.useCallback(() => {
     onQueryChange('');
@@ -988,7 +1061,7 @@ const TypeFilterInput = ({ onSelect }: TypeFilterInputProps) => {
               <div className="pt-1">
                 <div className="flex max-h-[50vh] w-full flex-col overflow-hidden rounded border border-grey-02 bg-white">
                   <ResizableContainer>
-                    <ResultsList>
+                    <ResultsList onScroll={handleResultsScroll}>
                       {!results?.length && isLoading && (
                         <div className="w-full border-b border-divider bg-white px-3 py-2">
                           <div className="truncate text-button text-text">Loading...</div>
@@ -1057,6 +1130,11 @@ const TypeFilterInput = ({ onSelect }: TypeFilterInputProps) => {
                               </button>
                             </ResultItem>
                           ))}
+                          {isFetchingNextPage ? (
+                            <div className="w-full border-b border-divider bg-white px-3 py-2">
+                              <div className="truncate text-button text-text">Loading more...</div>
+                            </div>
+                          ) : null}
                         </>
                       )}
                     </ResultsList>

--- a/apps/web/design-system/select-entity.tsx
+++ b/apps/web/design-system/select-entity.tsx
@@ -11,6 +11,7 @@ import cx from 'classnames';
 import { useAtom } from 'jotai';
 import pluralize from 'pluralize';
 
+import { useFetchNextPageOnScroll } from '~/core/hooks/use-fetch-next-page-on-scroll';
 import { useKey } from '~/core/hooks/use-key';
 import { useSearch } from '~/core/hooks/use-search';
 import { useSpacesQuery } from '~/core/hooks/use-spaces-query';
@@ -332,17 +333,11 @@ export const SelectEntity = ({
   // disagrees with our placement hook during scroll.
   const popoverAbove = actualSide === 'top';
 
-  const handleResultsScroll = React.useCallback(
-    (e: React.UIEvent<HTMLDivElement>) => {
-      const el = e.currentTarget;
-      const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
-      if (distanceFromBottom > 275) return;
-      if (hasNextPage && !isFetchingNextPage) {
-        void fetchNextPage();
-      }
-    },
-    [fetchNextPage, hasNextPage, isFetchingNextPage]
-  );
+  const handleResultsScroll = useFetchNextPageOnScroll<HTMLDivElement>({
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
+  });
 
   return (
     <div
@@ -896,17 +891,11 @@ const SpaceFilterInput = ({ onSelect }: SpaceFilterInputProps) => {
     isFetchingNextPage,
   } = useSpacesQuery(focused);
 
-  const handleResultsScroll = React.useCallback(
-    (e: React.UIEvent<HTMLUListElement>) => {
-      const el = e.currentTarget;
-      const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
-      if (distanceFromBottom > 275) return;
-      if (hasNextPage && !isFetchingNextPage) {
-        void fetchNextPage();
-      }
-    },
-    [fetchNextPage, hasNextPage, isFetchingNextPage]
-  );
+  const handleResultsScroll = useFetchNextPageOnScroll<HTMLUListElement>({
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
+  });
 
   const onSelectSpace = (space: (typeof results)[number]) => {
     setQuery('');
@@ -1015,17 +1004,11 @@ const TypeFilterInput = ({ onSelect }: TypeFilterInputProps) => {
     enabled: focused,
   });
 
-  const handleResultsScroll = React.useCallback(
-    (e: React.UIEvent<HTMLUListElement>) => {
-      const el = e.currentTarget;
-      const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
-      if (distanceFromBottom > 275) return;
-      if (hasNextPage && !isFetchingNextPage) {
-        void fetchNextPage();
-      }
-    },
-    [fetchNextPage, hasNextPage, isFetchingNextPage]
-  );
+  const handleResultsScroll = useFetchNextPageOnScroll<HTMLUListElement>({
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
+  });
 
   const close = React.useCallback(() => {
     onQueryChange('');

--- a/apps/web/design-system/select-entity.tsx
+++ b/apps/web/design-system/select-entity.tsx
@@ -333,10 +333,12 @@ export const SelectEntity = ({
   // disagrees with our placement hook during scroll.
   const popoverAbove = actualSide === 'top';
 
+  const resultsScrollRef = React.useRef<HTMLDivElement | null>(null);
   const handleResultsScroll = useFetchNextPageOnScroll<HTMLDivElement>({
     hasNextPage,
     isFetchingNextPage,
     fetchNextPage,
+    scrollRef: resultsScrollRef,
   });
 
   return (
@@ -557,6 +559,7 @@ export const SelectEntity = ({
                   {!result ? (
                     <ResizableContainer>
                       <div
+                        ref={resultsScrollRef}
                         className="no-scrollbar flex flex-col overflow-x-clip overflow-y-auto overscroll-contain bg-white"
                         style={{
                           // 80px accounts for Advanced toolbar (~32px) + Create new footer (~36px) + borders/padding
@@ -891,10 +894,12 @@ const SpaceFilterInput = ({ onSelect }: SpaceFilterInputProps) => {
     isFetchingNextPage,
   } = useSpacesQuery(focused);
 
+  const resultsScrollRef = React.useRef<HTMLUListElement | null>(null);
   const handleResultsScroll = useFetchNextPageOnScroll<HTMLUListElement>({
     hasNextPage,
     isFetchingNextPage,
     fetchNextPage,
+    scrollRef: resultsScrollRef,
   });
 
   const onSelectSpace = (space: (typeof results)[number]) => {
@@ -941,7 +946,7 @@ const SpaceFilterInput = ({ onSelect }: SpaceFilterInputProps) => {
               <div className="pt-1">
                 <div className="flex max-h-[50vh] w-full flex-col overflow-hidden rounded border border-grey-02 bg-white">
                   <ResizableContainer>
-                    <ResultsList onScroll={handleResultsScroll}>
+                    <ResultsList ref={resultsScrollRef} onScroll={handleResultsScroll}>
                       {!results.length && isLoading && (
                         <div className="w-full border-b border-divider bg-white px-3 py-2">
                           <div className="truncate text-button text-text">Loading...</div>
@@ -1004,10 +1009,12 @@ const TypeFilterInput = ({ onSelect }: TypeFilterInputProps) => {
     enabled: focused,
   });
 
+  const resultsScrollRef = React.useRef<HTMLUListElement | null>(null);
   const handleResultsScroll = useFetchNextPageOnScroll<HTMLUListElement>({
     hasNextPage,
     isFetchingNextPage,
     fetchNextPage,
+    scrollRef: resultsScrollRef,
   });
 
   const close = React.useCallback(() => {
@@ -1044,7 +1051,7 @@ const TypeFilterInput = ({ onSelect }: TypeFilterInputProps) => {
               <div className="pt-1">
                 <div className="flex max-h-[50vh] w-full flex-col overflow-hidden rounded border border-grey-02 bg-white">
                   <ResizableContainer>
-                    <ResultsList onScroll={handleResultsScroll}>
+                    <ResultsList ref={resultsScrollRef} onScroll={handleResultsScroll}>
                       {!results?.length && isLoading && (
                         <div className="w-full border-b border-divider bg-white px-3 py-2">
                           <div className="truncate text-button text-text">Loading...</div>

--- a/apps/web/partials/blocks/table/table-block-filter-creation-prompt.tsx
+++ b/apps/web/partials/blocks/table/table-block-filter-creation-prompt.tsx
@@ -18,6 +18,7 @@ import { useFilters } from '~/core/blocks/data/use-filters';
 import { useSource } from '~/core/blocks/data/use-source';
 import { PLACEHOLDER_SPACE_IMAGE } from '~/core/constants';
 import { useDebouncedValue } from '~/core/hooks/use-debounced-value';
+import { isNearScrollBottom } from '~/core/hooks/use-fetch-next-page-on-scroll';
 import { useGlobalSearchSpaceIds } from '~/core/hooks/use-global-search-space-ids';
 import { useRelationTargetTypeIds } from '~/core/hooks/use-relation-target-type-ids';
 import { searchResultMatchesAllowedTypes } from '~/core/hooks/use-search';
@@ -1492,11 +1493,8 @@ function TableBlockEntityFilterInput({
   const handleEntityResultsScroll = React.useCallback(
     (e: React.UIEvent<HTMLUListElement>) => {
       const el = e.currentTarget;
-      // ~2 result-row heights of early prefetch on top of the baseline.
-      const threshold = 275;
-      const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
       const noOverflow = el.scrollHeight <= el.clientHeight + 2;
-      const nearBottom = distanceFromBottom <= threshold;
+      const nearBottom = isNearScrollBottom(el);
       if (!nearBottom && !noOverflow) return;
       if (entityVisibleCount < rowsToRender.length) {
         setEntityVisibleCount(c => Math.min(c + FILTER_DROPDOWN_PAGE_SIZE, rowsToRender.length));
@@ -1743,11 +1741,8 @@ function TableBlockSpaceFilterInput({
 
   const applySpaceListPagination = React.useCallback(
     (el: HTMLUListElement) => {
-      // ~2 result-row heights of early prefetch on top of the baseline.
-      const threshold = 275;
-      const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
       const noOverflow = el.scrollHeight <= el.clientHeight + 2;
-      const nearBottom = distanceFromBottom <= threshold;
+      const nearBottom = isNearScrollBottom(el);
       if (!nearBottom && !noOverflow) return;
       if (spaceVisibleCount < spaceFullRowCount) {
         setSpaceVisibleCount(c => Math.min(c + FILTER_DROPDOWN_PAGE_SIZE, spaceFullRowCount));

--- a/apps/web/partials/search/dialog.tsx
+++ b/apps/web/partials/search/dialog.tsx
@@ -42,6 +42,7 @@ export const SearchDialog = ({ open, onDone }: Props) => {
 const SearchDialogComponent = ({ open, onDone }: Props) => {
   const router = useRouter();
   const autocomplete = useSearch({ enabled: open });
+  const { fetchNextPage, hasNextPage, isFetchingNextPage } = autocomplete;
   const { hydrate } = useSyncEngine();
 
   const [selectedIndex, setSelectedIndex] = useState<number>(0);
@@ -66,6 +67,17 @@ const SearchDialogComponent = ({ open, onDone }: Props) => {
   }
 
   const hasResults = autocomplete.results.length > 0;
+  const handleResultsScroll = React.useCallback(
+    (e: React.UIEvent<HTMLUListElement>) => {
+      const el = e.currentTarget;
+      const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
+      if (distanceFromBottom > 275) return;
+      if (hasNextPage && !isFetchingNextPage) {
+        void fetchNextPage();
+      }
+    },
+    [fetchNextPage, hasNextPage, isFetchingNextPage]
+  );
 
   useKey('Enter', () => {
     if (!hasResults) return;
@@ -161,7 +173,7 @@ const SearchDialogComponent = ({ open, onDone }: Props) => {
                   />
                 </div>
                 <ResizableContainer duration={0.15}>
-                  <ResultsList>
+                  <ResultsList onScroll={handleResultsScroll}>
                     {autocomplete.isEmpty ? (
                       isValidEntityId ? (
                         <div className="px-2 pb-1">
@@ -204,6 +216,11 @@ const SearchDialogComponent = ({ open, onDone }: Props) => {
                         </div>
                       </motion.div>
                     ))}
+                    {autocomplete.isFetchingNextPage ? (
+                      <div className="flex items-center justify-center py-2 text-smallButton">
+                        <Dots />
+                      </div>
+                    ) : null}
                   </ResultsList>
                 </ResizableContainer>
               </>

--- a/apps/web/partials/search/dialog.tsx
+++ b/apps/web/partials/search/dialog.tsx
@@ -8,6 +8,7 @@ import { Command } from 'cmdk';
 import { AnimatePresence, motion } from 'framer-motion';
 import { useRouter } from 'next/navigation';
 
+import { useFetchNextPageOnScroll } from '~/core/hooks/use-fetch-next-page-on-scroll';
 import { useKey } from '~/core/hooks/use-key';
 import { usePersonalSpaceId } from '~/core/hooks/use-personal-space-id';
 import { useSearch } from '~/core/hooks/use-search';
@@ -67,17 +68,11 @@ const SearchDialogComponent = ({ open, onDone }: Props) => {
   }
 
   const hasResults = autocomplete.results.length > 0;
-  const handleResultsScroll = React.useCallback(
-    (e: React.UIEvent<HTMLUListElement>) => {
-      const el = e.currentTarget;
-      const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
-      if (distanceFromBottom > 275) return;
-      if (hasNextPage && !isFetchingNextPage) {
-        void fetchNextPage();
-      }
-    },
-    [fetchNextPage, hasNextPage, isFetchingNextPage]
-  );
+  const handleResultsScroll = useFetchNextPageOnScroll<HTMLUListElement>({
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
+  });
 
   useKey('Enter', () => {
     if (!hasResults) return;

--- a/apps/web/partials/search/dialog.tsx
+++ b/apps/web/partials/search/dialog.tsx
@@ -68,10 +68,12 @@ const SearchDialogComponent = ({ open, onDone }: Props) => {
   }
 
   const hasResults = autocomplete.results.length > 0;
+  const resultsScrollRef = React.useRef<HTMLUListElement | null>(null);
   const handleResultsScroll = useFetchNextPageOnScroll<HTMLUListElement>({
     hasNextPage,
     isFetchingNextPage,
     fetchNextPage,
+    scrollRef: resultsScrollRef,
   });
 
   useKey('Enter', () => {
@@ -168,7 +170,7 @@ const SearchDialogComponent = ({ open, onDone }: Props) => {
                   />
                 </div>
                 <ResizableContainer duration={0.15}>
-                  <ResultsList onScroll={handleResultsScroll}>
+                  <ResultsList ref={resultsScrollRef} onScroll={handleResultsScroll}>
                     {autocomplete.isEmpty ? (
                       isValidEntityId ? (
                         <div className="px-2 pb-1">


### PR DESCRIPTION
## Summary
- Convert search and space search hooks to paginated infinite queries.
- Expose next-page state and fetch functions to dropdown surfaces.
- Add scroll-near-bottom loading behavior across search dropdowns.

## Validation
- eslint touched infinite-scroll search files