### PR TITLE
[codex] Filter final search results

### DIFF
--- a/apps/web/core/io/queries.test.ts
+++ b/apps/web/core/io/queries.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { buildSearchPath, groupRestResults } from './queries';
+import { buildSearchPath, groupRestResults, hasDefaultSearchExcludedType } from './queries';
 
 describe('buildSearchPath', () => {
   const ROOT = 'a19c345ab9866679b001d7d2138d88a1';
@@ -123,5 +123,16 @@ describe('groupRestResults', () => {
         ],
       },
     ]);
+  });
+});
+
+describe('hasDefaultSearchExcludedType', () => {
+  it('matches excluded type ids in hyphenated and non-hyphenated forms', () => {
+    expect(hasDefaultSearchExcludedType([{ id: 'b8803a86-65de-412b-bb35-7e0c84adf473' }])).toBe(true);
+    expect(hasDefaultSearchExcludedType([{ id: 'B8803A8665DE412BBB357E0C84ADF473' }])).toBe(true);
+  });
+
+  it('does not match non-excluded type ids', () => {
+    expect(hasDefaultSearchExcludedType([{ id: '11111111-1111-1111-1111-111111111111' }])).toBe(false);
   });
 });

--- a/apps/web/core/io/queries.ts
+++ b/apps/web/core/io/queries.ts
@@ -963,6 +963,10 @@ const BLOCK_TYPE_EXCLUSION_FILTER: EntityFilter = {
 
 const EXCLUDED_BLOCK_TYPE_IDS = new Set(EXCLUDED_BLOCK_TYPES.map(typeId => typeId.replace(/-/g, '')));
 
+export function hasDefaultSearchExcludedType(types: Array<{ id: string }>): boolean {
+  return types.some(type => EXCLUDED_BLOCK_TYPE_IDS.has(stripHyphens(type.id)));
+}
+
 function shouldIncludeRestSearchResult(result: RestSearchResult): boolean {
-  return !(result.types ?? []).some(type => EXCLUDED_BLOCK_TYPE_IDS.has(stripHyphens(type.id)));
+  return !hasDefaultSearchExcludedType(result.types ?? []);
 }

--- a/apps/web/core/io/queries.ts
+++ b/apps/web/core/io/queries.ts
@@ -662,7 +662,7 @@ interface RestSearchResponse {
 }
 
 function stripHyphens(uuid: string): string {
-  return uuid.replace(/-/g, '');
+  return uuid.replace(/-/g, '').toLowerCase();
 }
 
 /**

--- a/apps/web/core/sync/orm.search.test.ts
+++ b/apps/web/core/sync/orm.search.test.ts
@@ -1,7 +1,14 @@
 import { describe, expect, it } from 'vitest';
 
 import type { Entity, SearchResult, SpaceEntity } from '../types';
-import { applyKnownEntitySpaces, getSearchResultNameForTopSpace, mergeResolvableSpaces, resolveSearchSpaces } from './orm';
+import {
+  applyKnownEntitySpaces,
+  getSearchResultNameForTopSpace,
+  isDisplayableSearchResult,
+  isIncludedSearchResult,
+  mergeResolvableSpaces,
+  resolveSearchSpaces,
+} from './orm';
 
 function makeSpaceEntity(spaceId: string, overrides: Partial<SpaceEntity> = {}): SpaceEntity {
   return {
@@ -136,5 +143,38 @@ describe('getSearchResultNameForTopSpace', () => {
         [makeSpaceEntity('top-space')]
       )
     ).toBeNull();
+  });
+});
+
+describe('isDisplayableSearchResult', () => {
+  it('requires a non-blank name and at least one resolved space', () => {
+    const space = makeSpaceEntity('space-1', { name: 'Space' });
+
+    expect(isDisplayableSearchResult({ name: 'Named Entity', spaces: [space] })).toBe(true);
+    expect(isDisplayableSearchResult({ name: '   ', spaces: [space] })).toBe(false);
+    expect(isDisplayableSearchResult({ name: null, spaces: [space] })).toBe(false);
+    expect(isDisplayableSearchResult({ name: 'Named Entity', spaces: [] })).toBe(false);
+  });
+});
+
+describe('isIncludedSearchResult', () => {
+  it('filters out results with default excluded block/media types', () => {
+    const space = makeSpaceEntity('space-1', { name: 'Space' });
+
+    expect(
+      isIncludedSearchResult({
+        name: 'Latest',
+        spaces: [space],
+        types: [{ id: 'b8803a8665de412bbb357e0c84adf473', name: 'Data Block' }],
+      })
+    ).toBe(false);
+
+    expect(
+      isIncludedSearchResult({
+        name: 'Latest',
+        spaces: [space],
+        types: [{ id: '11111111111111111111111111111111', name: 'Article' }],
+      })
+    ).toBe(true);
   });
 });

--- a/apps/web/core/sync/orm.ts
+++ b/apps/web/core/sync/orm.ts
@@ -479,7 +479,9 @@ export class E {
       return mergeSearchResult({ id: entityId, store, mergeWith: remoteById.get(entityId) });
     });
 
-    const entities = maybeEntities.filter(e => e !== null);
+    const entities = maybeEntities
+      .filter(e => e !== null)
+      .filter(entity => !hasDefaultSearchExcludedType(entity.types));
 
     const spaceIds = [
       ...new Set(entities.flatMap(e => e.spaces.map(space => (typeof space === 'string' ? space : space.spaceId)))),

--- a/apps/web/core/sync/orm.ts
+++ b/apps/web/core/sync/orm.ts
@@ -18,6 +18,7 @@ import {
   getRelation,
   getResultsPage,
   getSpaces,
+  hasDefaultSearchExcludedType,
 } from '../io/queries';
 import { OmitStrict } from '../types';
 import { Entity, Relation, SearchResult, SpaceEntity } from '../types';
@@ -67,6 +68,14 @@ export function applyKnownEntitySpaces(
     ...result,
     spaces: knownEntity.spaces,
   };
+}
+
+export function isDisplayableSearchResult(result: Pick<SearchResult, 'name' | 'spaces'>): boolean {
+  return result.spaces.length > 0 && hasName(result.name);
+}
+
+export function isIncludedSearchResult(result: Pick<SearchResult, 'name' | 'spaces' | 'types'>): boolean {
+  return isDisplayableSearchResult(result) && !hasDefaultSearchExcludedType(result.types);
 }
 
 function getLocalSearchResultSpaces(values: Entity['values'], relations: Entity['relations']): string[] {
@@ -519,7 +528,7 @@ export class E {
           spaces: resolvedSpaces,
         };
       })
-      .filter(e => e.spaces.length > 0);
+      .filter(isIncludedSearchResult);
 
     return { results, rawCount: page.rawCount, total: page.total };
   }


### PR DESCRIPTION
## Summary
- Filter final merged search results to require a non-blank name and resolved space.
- Exclude block/media types after remote/local merge so local sync-store results cannot leak through.
- Keep REST search URLs free of exclude_type_ids.

## Validation
- bun run test core/io/queries.test.ts core/sync/orm.search.test.ts
- eslint touched final search hygiene files