### PR TITLE
fix(data-blocks): promote spaceIds/typeIds buried in empty-name and-wrap

### DIFF
--- a/apps/web/core/io/space-filter.test.ts
+++ b/apps/web/core/io/space-filter.test.ts
@@ -183,4 +183,35 @@ describe('removeSpaceIdsFromFilter', () => {
       and: [{ name: { isNull: false, isNot: '' } }, { id: { is: 'entity-123' } }],
     });
   });
+
+  it('strips only the first and-child spaceIds when multiple are present', () => {
+    // Mirrors extractor's first-wins semantics: only the clause that gets
+    // promoted is removed. Later spaceIds clauses represent independent
+    // constraints and must survive on the residual filter so the server
+    // still enforces them. A previous version stripped every match,
+    // silently broadening results.
+    const filter: EntityFilter = {
+      and: [
+        { spaceIds: { in: ['space-abc'] } },
+        { spaceIds: { in: ['space-def'] } },
+        { name: { isNull: false, isNot: '' } },
+      ],
+    };
+    expect(removeSpaceIdsFromFilter(filter)).toEqual({
+      and: [{ spaceIds: { in: ['space-def'] } }, { name: { isNull: false, isNot: '' } }],
+    });
+  });
+
+  it('leaves and-children intact when extraction took the top-level spaceIds', () => {
+    // Top-level wins during extraction, so the and-array is left untouched
+    // — any nested spaceIds is an independent constraint, not a duplicate
+    // of the promoted clause.
+    const filter: EntityFilter = {
+      spaceIds: { in: ['space-abc'] },
+      and: [{ spaceIds: { in: ['space-def'] } }, { name: { isNull: false, isNot: '' } }],
+    };
+    expect(removeSpaceIdsFromFilter(filter)).toEqual({
+      and: [{ spaceIds: { in: ['space-def'] } }, { name: { isNull: false, isNot: '' } }],
+    });
+  });
 });

--- a/apps/web/core/io/space-filter.test.ts
+++ b/apps/web/core/io/space-filter.test.ts
@@ -42,6 +42,20 @@ describe('extractSingleSpaceIdFromFilter', () => {
     const filter: EntityFilter = { spaceIds: { containedBy: ['space-abc'] } };
     expect(extractSingleSpaceIdFromFilter(filter)).toBeUndefined();
   });
+
+  it('finds spaceIds inside a top-level and array (empty-name wrap shape)', () => {
+    const filter: EntityFilter = {
+      and: [{ spaceIds: { in: ['space-abc'] } }, { name: { isNull: false, isNot: '' } }],
+    };
+    expect(extractSingleSpaceIdFromFilter(filter)).toBe('space-abc');
+  });
+
+  it('finds spaceIds with anyEqualTo inside a top-level and array', () => {
+    const filter: EntityFilter = {
+      and: [{ spaceIds: { anyEqualTo: 'space-abc' } }, { name: { isNull: false, isNot: '' } }],
+    };
+    expect(extractSingleSpaceIdFromFilter(filter)).toBe('space-abc');
+  });
 });
 
 describe('extractSpaceIdsFromFilter', () => {
@@ -87,6 +101,13 @@ describe('extractSpaceIdsFromFilter', () => {
     const filter: EntityFilter = { spaceIds: { in: [null, null] } };
     expect(extractSpaceIdsFromFilter(filter)).toBeUndefined();
   });
+
+  it('finds multi-element spaceIds inside a top-level and array', () => {
+    const filter: EntityFilter = {
+      and: [{ spaceIds: { in: ['space-abc', 'space-def'] } }, { name: { isNull: false, isNot: '' } }],
+    };
+    expect(extractSpaceIdsFromFilter(filter)).toEqual({ in: ['space-abc', 'space-def'] });
+  });
 });
 
 describe('removeSpaceIdsFromFilter', () => {
@@ -121,5 +142,32 @@ describe('removeSpaceIdsFromFilter', () => {
     const result = removeSpaceIdsFromFilter(filter);
     expect(result).toEqual({ name: { is: 'test' }, id: { is: 'entity-123' } });
     expect(result).not.toHaveProperty('spaceIds');
+  });
+
+  it('removes spaceIds buried in a top-level and (empty-name wrap) and hoists the remaining sibling', () => {
+    const filter: EntityFilter = {
+      and: [{ spaceIds: { in: ['space-abc'] } }, { name: { isNull: false, isNot: '' } }],
+    };
+    expect(removeSpaceIdsFromFilter(filter)).toEqual({ name: { isNull: false, isNot: '' } });
+  });
+
+  it('returns undefined when stripping spaceIds from an and leaves nothing', () => {
+    const filter: EntityFilter = {
+      and: [{ spaceIds: { in: ['space-abc'] } }],
+    };
+    expect(removeSpaceIdsFromFilter(filter)).toBeUndefined();
+  });
+
+  it('keeps the and-wrap when more than one sibling remains after stripping', () => {
+    const filter: EntityFilter = {
+      and: [
+        { spaceIds: { in: ['space-abc'] } },
+        { name: { isNull: false, isNot: '' } },
+        { id: { is: 'entity-123' } },
+      ],
+    };
+    expect(removeSpaceIdsFromFilter(filter)).toEqual({
+      and: [{ name: { isNull: false, isNot: '' } }, { id: { is: 'entity-123' } }],
+    });
   });
 });

--- a/apps/web/core/io/space-filter.test.ts
+++ b/apps/web/core/io/space-filter.test.ts
@@ -158,6 +158,19 @@ describe('removeSpaceIdsFromFilter', () => {
     expect(removeSpaceIdsFromFilter(filter)).toBeUndefined();
   });
 
+  it('keeps the and-wrap when the lone remaining sibling collides with a top-level key', () => {
+    // Both top-level and the post-strip singleton carry `name` — hoisting would
+    // silently drop one. The wrap must be preserved so both clauses survive.
+    const filter: EntityFilter = {
+      name: { is: 'top' },
+      and: [{ spaceIds: { in: ['space-abc'] }, name: { is: 'inner' } }],
+    };
+    expect(removeSpaceIdsFromFilter(filter)).toEqual({
+      name: { is: 'top' },
+      and: [{ name: { is: 'inner' } }],
+    });
+  });
+
   it('keeps the and-wrap when more than one sibling remains after stripping', () => {
     const filter: EntityFilter = {
       and: [

--- a/apps/web/core/io/space-filter.ts
+++ b/apps/web/core/io/space-filter.ts
@@ -1,16 +1,40 @@
 import type { EntityFilter, UuidFilter, UuidListFilter } from '~/core/gql/graphql';
 
 /**
+ * Find a child of a top-level `and` array that carries a `spaceIds` clause.
+ *
+ * Why: `convertWhereConditionToEntityFilter` AND-wraps the produced filter
+ * with the empty-name exclusion (`{ name: { isNull: false, isNot: '' } }`),
+ * which buries any `spaceIds` clause one level deep. Without this lookup
+ * the helpers below silently fail to promote `spaceIds` to the top-level
+ * GraphQL query arg, the per-row `valuesList`/`relationsList` filters lose
+ * their `$spaceId` constraint, and the connection scan stops using the
+ * indexed top-level path. We only peek into `and` (never `or` — semantics
+ * differ) and only one level deep — that covers the wrap shape produced
+ * by the converter.
+ */
+function findSpaceIdsClause(filter: EntityFilter): UuidListFilter | undefined {
+  if (filter.spaceIds) return filter.spaceIds;
+  if (!filter.and) return undefined;
+  for (const child of filter.and) {
+    if (child?.spaceIds) return child.spaceIds;
+  }
+  return undefined;
+}
+
+/**
  * Extract a single space ID from the filter's spaceIds field.
  *
  * Handles `anyEqualTo` (scalar match) and single-element `in` arrays.
  * Returns undefined for multi-space or unrecognized operators — those
  * fall through to `extractSpaceIdsFromFilter` or remain in the filter.
+ *
+ * Also looks one level deep into a top-level `and` (see {@link findSpaceIdsClause}).
  */
 export function extractSingleSpaceIdFromFilter(filter?: EntityFilter): string | undefined {
-  if (!filter?.spaceIds) return undefined;
-
-  const spaceIds: UuidListFilter = filter.spaceIds;
+  if (!filter) return undefined;
+  const spaceIds = findSpaceIdsClause(filter);
+  if (!spaceIds) return undefined;
 
   if (spaceIds.anyEqualTo) {
     return spaceIds.anyEqualTo;
@@ -32,11 +56,13 @@ export function extractSingleSpaceIdFromFilter(filter?: EntityFilter): string | 
  * Note: `UuidListFilter` (array column) and `UuidFilter` (scalar) have
  * different semantics. This conversion relies on the server's top-level
  * `spaceIds` arg using array-membership semantics internally.
+ *
+ * Also looks one level deep into a top-level `and` (see {@link findSpaceIdsClause}).
  */
 export function extractSpaceIdsFromFilter(filter?: EntityFilter): UuidFilter | undefined {
-  if (!filter?.spaceIds) return undefined;
-
-  const spaceIds: UuidListFilter = filter.spaceIds;
+  if (!filter) return undefined;
+  const spaceIds = findSpaceIdsClause(filter);
+  if (!spaceIds) return undefined;
 
   if (spaceIds.in && spaceIds.in.length > 1) {
     const validIds = spaceIds.in.filter((v): v is string => typeof v === 'string');
@@ -54,11 +80,42 @@ export function extractSpaceIdsFromFilter(filter?: EntityFilter): UuidFilter | u
 
 /**
  * Remove the `spaceIds` key from a filter after its constraints have been
- * promoted to top-level query args. Returns undefined when stripping
- * spaceIds leaves no remaining filter keys.
+ * promoted to top-level query args. Strips both top-level `spaceIds` and
+ * any `spaceIds` carried inside a top-level `and` array, then collapses
+ * trivially-empty shells (`and: []`, `and: [singleton]`) so the resulting
+ * filter is the smallest equivalent expression. Returns undefined when
+ * stripping leaves no remaining filter keys.
  */
 export function removeSpaceIdsFromFilter(filter?: EntityFilter): EntityFilter | undefined {
-  if (!filter?.spaceIds) return filter;
-  const { spaceIds: _spaceIds, ...rest } = filter;
-  return Object.keys(rest).length > 0 ? (rest as EntityFilter) : undefined;
+  if (!filter) return filter;
+  if (!filter.spaceIds && !filter.and) return filter;
+
+  const { spaceIds: _spaceIds, and, ...rest } = filter;
+  let next: EntityFilter = { ...rest };
+
+  if (and) {
+    const cleaned = and
+      .map(child => {
+        if (!child?.spaceIds) return child;
+        const { spaceIds: _s, ...childRest } = child;
+        return Object.keys(childRest).length > 0 ? (childRest as EntityFilter) : null;
+      })
+      .filter((child): child is EntityFilter => child !== null);
+
+    if (cleaned.length === 1) {
+      // Hoist the only remaining sibling out of the and-wrap. If a key
+      // collides with what's already on `next`, keep the and-wrap intact
+      // to preserve semantics.
+      const collides = Object.keys(cleaned[0]).some(k => k in next);
+      if (!collides) {
+        next = { ...next, ...cleaned[0] };
+      } else {
+        next = { ...next, and: cleaned };
+      }
+    } else if (cleaned.length > 1) {
+      next = { ...next, and: cleaned };
+    }
+  }
+
+  return Object.keys(next).length > 0 ? next : undefined;
 }

--- a/apps/web/core/io/space-filter.ts
+++ b/apps/web/core/io/space-filter.ts
@@ -79,41 +79,64 @@ export function extractSpaceIdsFromFilter(filter?: EntityFilter): UuidFilter | u
 }
 
 /**
- * Remove the `spaceIds` key from a filter after its constraints have been
- * promoted to top-level query args. Strips both top-level `spaceIds` and
- * any `spaceIds` carried inside a top-level `and` array, then collapses
- * trivially-empty shells (`and: []`, `and: [singleton]`) so the resulting
- * filter is the smallest equivalent expression. Returns undefined when
- * stripping leaves no remaining filter keys.
+ * Remove the `spaceIds` clause that {@link findSpaceIdsClause} would have
+ * promoted to a top-level query arg, and only that clause. Mirrors the
+ * extractor's first-wins semantics:
+ *
+ * - top-level `spaceIds` present → strip top-level only; any `and`-child
+ *   `spaceIds` clauses represent independent constraints and are left on
+ *   the residual filter so the server still enforces them.
+ * - top-level absent, `and` present → strip the first `and`-child that
+ *   carries `spaceIds`; later children with their own `spaceIds` survive.
+ *
+ * The previous implementation stripped every matching `and`-child, which
+ * silently broadened results when callers passed shapes like
+ * `{ and: [{ spaceIds: A }, { spaceIds: B }, ... ] }` — only A was promoted
+ * but both A and B were removed. Producers in this codebase don't construct
+ * those shapes today, but the helper shouldn't trust callers.
+ *
+ * After stripping, trivially-empty shells (`and: []`, `and: [singleton]`)
+ * are collapsed so the residual filter is the smallest equivalent
+ * expression. Returns undefined when stripping leaves no remaining keys.
  */
 export function removeSpaceIdsFromFilter(filter?: EntityFilter): EntityFilter | undefined {
   if (!filter) return filter;
   if (!filter.spaceIds && !filter.and) return filter;
 
-  const { spaceIds: _spaceIds, and, ...rest } = filter;
+  const { spaceIds: topLevel, and, ...rest } = filter;
   let next: EntityFilter = { ...rest };
 
   if (and) {
-    const cleaned = and
-      .map(child => {
-        if (!child?.spaceIds) return child;
-        const { spaceIds: _s, ...childRest } = child;
-        return Object.keys(childRest).length > 0 ? (childRest as EntityFilter) : null;
-      })
-      .filter((child): child is EntityFilter => child !== null);
+    if (topLevel !== undefined) {
+      // Top-level took priority during extraction; leave the and-array
+      // intact so any nested spaceIds clauses (independent constraints,
+      // not duplicates of the promoted one) survive untouched.
+      next = { ...next, and };
+    } else {
+      // Strip only the first and-child carrying spaceIds.
+      let stripped = false;
+      const cleaned = and
+        .map(child => {
+          if (stripped || !child?.spaceIds) return child;
+          stripped = true;
+          const { spaceIds: _s, ...childRest } = child;
+          return Object.keys(childRest).length > 0 ? (childRest as EntityFilter) : null;
+        })
+        .filter((child): child is EntityFilter => child !== null);
 
-    if (cleaned.length === 1) {
-      // Hoist the only remaining sibling out of the and-wrap. If a key
-      // collides with what's already on `next`, keep the and-wrap intact
-      // to preserve semantics.
-      const collides = Object.keys(cleaned[0]).some(k => k in next);
-      if (!collides) {
-        next = { ...next, ...cleaned[0] };
-      } else {
+      if (cleaned.length === 1) {
+        // Hoist the only remaining sibling out of the and-wrap. If a key
+        // collides with what's already on `next`, keep the and-wrap intact
+        // to preserve semantics.
+        const collides = Object.keys(cleaned[0]).some(k => k in next);
+        if (!collides) {
+          next = { ...next, ...cleaned[0] };
+        } else {
+          next = { ...next, and: cleaned };
+        }
+      } else if (cleaned.length > 1) {
         next = { ...next, and: cleaned };
       }
-    } else if (cleaned.length > 1) {
-      next = { ...next, and: cleaned };
     }
   }
 

--- a/apps/web/core/io/type-filter.test.ts
+++ b/apps/web/core/io/type-filter.test.ts
@@ -42,6 +42,13 @@ describe('extractSingleTypeIdFromFilter', () => {
     const filter: EntityFilter = { typeIds: { containedBy: ['type-abc'] } };
     expect(extractSingleTypeIdFromFilter(filter)).toBeUndefined();
   });
+
+  it('finds typeIds inside a top-level and array (empty-name wrap shape)', () => {
+    const filter: EntityFilter = {
+      and: [{ typeIds: { in: ['type-abc'] } }, { name: { isNull: false, isNot: '' } }],
+    };
+    expect(extractSingleTypeIdFromFilter(filter)).toBe('type-abc');
+  });
 });
 
 describe('extractTypeIdsFromFilter', () => {
@@ -87,6 +94,13 @@ describe('extractTypeIdsFromFilter', () => {
     const filter: EntityFilter = { typeIds: { in: [null, null] } };
     expect(extractTypeIdsFromFilter(filter)).toBeUndefined();
   });
+
+  it('finds multi-element typeIds inside a top-level and array', () => {
+    const filter: EntityFilter = {
+      and: [{ typeIds: { in: ['type-abc', 'type-def'] } }, { name: { isNull: false, isNot: '' } }],
+    };
+    expect(extractTypeIdsFromFilter(filter)).toEqual({ in: ['type-abc', 'type-def'] });
+  });
 });
 
 describe('removeTypeIdsFromFilter', () => {
@@ -121,5 +135,30 @@ describe('removeTypeIdsFromFilter', () => {
     const result = removeTypeIdsFromFilter(filter);
     expect(result).toEqual({ name: { is: 'test' }, id: { is: 'entity-123' } });
     expect(result).not.toHaveProperty('typeIds');
+  });
+
+  it('removes typeIds buried in a top-level and (empty-name wrap) and hoists the remaining sibling', () => {
+    const filter: EntityFilter = {
+      and: [{ typeIds: { in: ['type-abc'] } }, { name: { isNull: false, isNot: '' } }],
+    };
+    expect(removeTypeIdsFromFilter(filter)).toEqual({ name: { isNull: false, isNot: '' } });
+  });
+
+  it('returns undefined when stripping typeIds from an and leaves nothing', () => {
+    const filter: EntityFilter = { and: [{ typeIds: { in: ['type-abc'] } }] };
+    expect(removeTypeIdsFromFilter(filter)).toBeUndefined();
+  });
+
+  it('keeps the and-wrap when more than one sibling remains after stripping', () => {
+    const filter: EntityFilter = {
+      and: [
+        { typeIds: { in: ['type-abc'] } },
+        { name: { isNull: false, isNot: '' } },
+        { id: { is: 'entity-123' } },
+      ],
+    };
+    expect(removeTypeIdsFromFilter(filter)).toEqual({
+      and: [{ name: { isNull: false, isNot: '' } }, { id: { is: 'entity-123' } }],
+    });
   });
 });

--- a/apps/web/core/io/type-filter.test.ts
+++ b/apps/web/core/io/type-filter.test.ts
@@ -149,6 +149,19 @@ describe('removeTypeIdsFromFilter', () => {
     expect(removeTypeIdsFromFilter(filter)).toBeUndefined();
   });
 
+  it('keeps the and-wrap when the lone remaining sibling collides with a top-level key', () => {
+    // Both top-level and the post-strip singleton carry `name` — hoisting would
+    // silently drop one. The wrap must be preserved so both clauses survive.
+    const filter: EntityFilter = {
+      name: { is: 'top' },
+      and: [{ typeIds: { in: ['type-abc'] }, name: { is: 'inner' } }],
+    };
+    expect(removeTypeIdsFromFilter(filter)).toEqual({
+      name: { is: 'top' },
+      and: [{ name: { is: 'inner' } }],
+    });
+  });
+
   it('keeps the and-wrap when more than one sibling remains after stripping', () => {
     const filter: EntityFilter = {
       and: [

--- a/apps/web/core/io/type-filter.test.ts
+++ b/apps/web/core/io/type-filter.test.ts
@@ -174,4 +174,27 @@ describe('removeTypeIdsFromFilter', () => {
       and: [{ name: { isNull: false, isNot: '' } }, { id: { is: 'entity-123' } }],
     });
   });
+
+  it('strips only the first and-child typeIds when multiple are present', () => {
+    const filter: EntityFilter = {
+      and: [
+        { typeIds: { in: ['type-abc'] } },
+        { typeIds: { in: ['type-def'] } },
+        { name: { isNull: false, isNot: '' } },
+      ],
+    };
+    expect(removeTypeIdsFromFilter(filter)).toEqual({
+      and: [{ typeIds: { in: ['type-def'] } }, { name: { isNull: false, isNot: '' } }],
+    });
+  });
+
+  it('leaves and-children intact when extraction took the top-level typeIds', () => {
+    const filter: EntityFilter = {
+      typeIds: { in: ['type-abc'] },
+      and: [{ typeIds: { in: ['type-def'] } }, { name: { isNull: false, isNot: '' } }],
+    };
+    expect(removeTypeIdsFromFilter(filter)).toEqual({
+      and: [{ typeIds: { in: ['type-def'] } }, { name: { isNull: false, isNot: '' } }],
+    });
+  });
 });

--- a/apps/web/core/io/type-filter.ts
+++ b/apps/web/core/io/type-filter.ts
@@ -51,31 +51,42 @@ export function extractTypeIdsFromFilter(filter?: EntityFilter): UuidFilter | un
   return undefined;
 }
 
+/**
+ * Remove only the `typeIds` clause that {@link findTypeIdsClause} would
+ * have promoted. See `space-filter.ts`'s `removeSpaceIdsFromFilter` for
+ * the full rationale — this mirrors that behavior for `typeIds`.
+ */
 export function removeTypeIdsFromFilter(filter?: EntityFilter): EntityFilter | undefined {
   if (!filter) return filter;
   if (!filter.typeIds && !filter.and) return filter;
 
-  const { typeIds: _typeIds, and, ...rest } = filter;
+  const { typeIds: topLevel, and, ...rest } = filter;
   let next: EntityFilter = { ...rest };
 
   if (and) {
-    const cleaned = and
-      .map(child => {
-        if (!child?.typeIds) return child;
-        const { typeIds: _t, ...childRest } = child;
-        return Object.keys(childRest).length > 0 ? (childRest as EntityFilter) : null;
-      })
-      .filter((child): child is EntityFilter => child !== null);
+    if (topLevel !== undefined) {
+      next = { ...next, and };
+    } else {
+      let stripped = false;
+      const cleaned = and
+        .map(child => {
+          if (stripped || !child?.typeIds) return child;
+          stripped = true;
+          const { typeIds: _t, ...childRest } = child;
+          return Object.keys(childRest).length > 0 ? (childRest as EntityFilter) : null;
+        })
+        .filter((child): child is EntityFilter => child !== null);
 
-    if (cleaned.length === 1) {
-      const collides = Object.keys(cleaned[0]).some(k => k in next);
-      if (!collides) {
-        next = { ...next, ...cleaned[0] };
-      } else {
+      if (cleaned.length === 1) {
+        const collides = Object.keys(cleaned[0]).some(k => k in next);
+        if (!collides) {
+          next = { ...next, ...cleaned[0] };
+        } else {
+          next = { ...next, and: cleaned };
+        }
+      } else if (cleaned.length > 1) {
         next = { ...next, and: cleaned };
       }
-    } else if (cleaned.length > 1) {
-      next = { ...next, and: cleaned };
     }
   }
 

--- a/apps/web/core/io/type-filter.ts
+++ b/apps/web/core/io/type-filter.ts
@@ -1,9 +1,25 @@
 import type { EntityFilter, UuidFilter, UuidListFilter } from '~/core/gql/graphql';
 
-export function extractSingleTypeIdFromFilter(filter?: EntityFilter): string | undefined {
-  if (!filter?.typeIds) return undefined;
+/**
+ * Find a child of a top-level `and` array that carries a `typeIds` clause.
+ * Mirrors {@link findSpaceIdsClause} in `space-filter.ts` — see that file
+ * for the full rationale. Briefly: the converter AND-wraps with the
+ * empty-name exclusion, burying `typeIds` one level deep and breaking
+ * the top-level promotion that uses the indexed query path.
+ */
+function findTypeIdsClause(filter: EntityFilter): UuidListFilter | undefined {
+  if (filter.typeIds) return filter.typeIds;
+  if (!filter.and) return undefined;
+  for (const child of filter.and) {
+    if (child?.typeIds) return child.typeIds;
+  }
+  return undefined;
+}
 
-  const typeIds: UuidListFilter = filter.typeIds;
+export function extractSingleTypeIdFromFilter(filter?: EntityFilter): string | undefined {
+  if (!filter) return undefined;
+  const typeIds = findTypeIdsClause(filter);
+  if (!typeIds) return undefined;
 
   if (typeIds.anyEqualTo) {
     return typeIds.anyEqualTo;
@@ -17,9 +33,9 @@ export function extractSingleTypeIdFromFilter(filter?: EntityFilter): string | u
 }
 
 export function extractTypeIdsFromFilter(filter?: EntityFilter): UuidFilter | undefined {
-  if (!filter?.typeIds) return undefined;
-
-  const typeIds: UuidListFilter = filter.typeIds;
+  if (!filter) return undefined;
+  const typeIds = findTypeIdsClause(filter);
+  if (!typeIds) return undefined;
 
   if (typeIds.in && typeIds.in.length > 1) {
     const validIds = typeIds.in.filter((v): v is string => typeof v === 'string');
@@ -36,7 +52,32 @@ export function extractTypeIdsFromFilter(filter?: EntityFilter): UuidFilter | un
 }
 
 export function removeTypeIdsFromFilter(filter?: EntityFilter): EntityFilter | undefined {
-  if (!filter?.typeIds) return filter;
-  const { typeIds: _typeIds, ...rest } = filter;
-  return Object.keys(rest).length > 0 ? (rest as EntityFilter) : undefined;
+  if (!filter) return filter;
+  if (!filter.typeIds && !filter.and) return filter;
+
+  const { typeIds: _typeIds, and, ...rest } = filter;
+  let next: EntityFilter = { ...rest };
+
+  if (and) {
+    const cleaned = and
+      .map(child => {
+        if (!child?.typeIds) return child;
+        const { typeIds: _t, ...childRest } = child;
+        return Object.keys(childRest).length > 0 ? (childRest as EntityFilter) : null;
+      })
+      .filter((child): child is EntityFilter => child !== null);
+
+    if (cleaned.length === 1) {
+      const collides = Object.keys(cleaned[0]).some(k => k in next);
+      if (!collides) {
+        next = { ...next, ...cleaned[0] };
+      } else {
+        next = { ...next, and: cleaned };
+      }
+    } else if (cleaned.length > 1) {
+      next = { ...next, and: cleaned };
+    }
+  }
+
+  return Object.keys(next).length > 0 ? next : undefined;
 }


### PR DESCRIPTION
## Summary

A data block scoped to one space (no other filters, no type) was taking forever to load. Two compounding causes:

1. `convertWhereConditionToEntityFilter` AND-wraps the produced filter with the empty-name exclusion (`{ name: { isNull: false, isNot: '' } }`), burying any `spaceIds` clause one level deep.
2. The extract helpers in `getAllEntities` (`extractSingleSpaceIdFromFilter`, `extractSpaceIdsFromFilter`, and the `typeIds` equivalents) only inspected the top of the `EntityFilter`. So `spaceIds` was never lifted to the top-level `entitiesConnection` arg, which:
   - dropped the indexed top-level scan path on `entitiesConnection`
   - left `$spaceId` null in the variables, so the per-row `valuesList(filter: { spaceId: { is: $spaceId } })` and `relationsList(...)` filters were unconstrained — pulling values/relations from every space each row participated in

That second effect amplified the recent `valuesList`/`relationsList` `first: 1000` bump (#1758) into the "FOREVER to load" symptom on space-only data blocks.

### Fix

Teach the space-filter and type-filter extract/remove helpers to peek one level into a top-level `and` array (only `and` — `or` semantics differ), and to collapse trivially-empty shells (`and: []`, `and: [singleton]`) when stripping. Covers the wrap shape produced by the converter and `filterStateToWhere`'s `mergeWhereConditions` output.

### Before vs after (variables for a one-space data block)

Before:
```json
{
  "spaceId": null,
  "filter": {
    "and": [
      { "spaceIds": { "in": ["bf7a..."] } },
      { "name": { "isNull": false, "isNot": "" } }
    ]
  }
}
```

After:
```json
{
  "spaceId": "bf7a...",
  "filter": { "name": { "isNull": false, "isNot": "" } }
}
```

## Test plan

- [ ] CI: new unit tests in `apps/web/core/io/space-filter.test.ts` and `apps/web/core/io/type-filter.test.ts` cover the and-wrap extraction + collapsing-on-removal cases.
- [ ] Smoke: open a data block scoped to a single space with no other filters; confirm load time matches pre-#1758 expectations.
- [ ] Smoke: data block with space + type filter still scopes correctly (both lifted to top level).
- [ ] Smoke: multi-space data block (multi-element `in`) still works.
- [ ] Regression check: data block that filters by `name` (where the and-wrap might have a name collision) still resolves correctly without losing the user filter — covered by the collision branch in `removeSpaceIdsFromFilter` that keeps the and-wrap when keys would clash.

## Followups (not in this PR)

The `valuesList`/`relationsList` `first: 1000` per-row over-fetch is still wasteful for data blocks that only render a small set of `shownColumnIds`. Worth a separate PR: either parameterize the page sizes per consumer, introduce a slim data-block-only document, or drop the nested `toEntity.valuesList` from the data-block path.