### PR TITLE
fix: restore configVersion 1 in bun.lock

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 1,
   "workspaces": {
     "": {
       "name": "geogenesis",


### PR DESCRIPTION
PR #1775 dropped this field, switching Bun's install layout to hoisted. That surfaces @privy-io/react-auth's bundled viem@2.47.4 on the TS module resolution path, where it collides with the root viem and breaks @geogenesis/auth's tsc build (TS2883/TS2322 in wallet-config.ts).