### PR TITLE
Track Genesis app actions

### DIFF
--- a/apps/web/core/analytics.test.ts
+++ b/apps/web/core/analytics.test.ts
@@ -36,6 +36,14 @@ describe('analytics', () => {
     expect(script?.src).toBe(analyticsScriptSrc);
   });
 
+  it('enables production collection for Genesis app routes on www.geobrowser.io', async () => {
+    const { analyticsEnvironment, isProductionGenesisHost, shouldUseAnalyticsCollector } = await import('./analytics');
+
+    expect(shouldUseAnalyticsCollector('www.geobrowser.io')).toBe(true);
+    expect(isProductionGenesisHost('www.geobrowser.io')).toBe(true);
+    expect(analyticsEnvironment('www.geobrowser.io')).toBe('production');
+  });
+
   it('tracks new Privy users as signups without raw Privy account data', async () => {
     const signedUp = vi.fn();
     window.lytics = {

--- a/apps/web/core/analytics.ts
+++ b/apps/web/core/analytics.ts
@@ -98,7 +98,7 @@ export function initAnalytics() {
   }
 
   const hostname = window.location.hostname.toLowerCase();
-  const shouldUseCollector = isGeoBrowserHost(hostname) && hostname !== 'www.geobrowser.io';
+  const shouldUseCollector = shouldUseAnalyticsCollector(hostname);
 
   window.lyticsConfig = {
     ...window.GeoAnalyticsConfig,
@@ -415,7 +415,7 @@ function formatDate(value: Date | string | null | undefined) {
   return value;
 }
 
-function analyticsEnvironment(hostname: string) {
+export function analyticsEnvironment(hostname: string) {
   if (isProductionGenesisHost(hostname)) {
     return 'production';
   }
@@ -431,9 +431,14 @@ function isGeoBrowserHost(hostname: string) {
   return hostname === 'geobrowser.io' || hostname.endsWith('.geobrowser.io');
 }
 
-function isProductionGenesisHost(hostname: string) {
+export function shouldUseAnalyticsCollector(hostname: string) {
+  return isGeoBrowserHost(hostname);
+}
+
+export function isProductionGenesisHost(hostname: string) {
   return (
     hostname === 'geobrowser.io' ||
+    hostname === 'www.geobrowser.io' ||
     hostname === 'app.geobrowser.io' ||
     hostname === 'genesis.geobrowser.io' ||
     hostname === 'geogenesis.geobrowser.io'


### PR DESCRIPTION
Genesis app routes served from `www.geobrowser.io` now send production event data, and key product actions are emitted as first-class events instead of relying on generic clicks. Explicit Privy login flows are classified as logins, restored sessions still identify the user, and Genesis now records successful entity votes, mode switches, and personal-space navigation.

## Coverage
- Enables production collection when the Genesis bundle runs on `www.geobrowser.io`.
- Treats the Sign in button as an explicit login flow, even if Privy reports an existing authenticated user.
- Records successful upvote, downvote, vote removal, edit mode, browse mode, and personal-space navigation actions.

## Checks
- `bun run test core/analytics.test.ts`
- `bunx tsc --noEmit --project tsconfig.json`
- `bun run lint` (existing warnings only)
- `git diff --check`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
