### PR TITLE
fix(navbar): make navbar persistent on scroll

### DIFF
--- a/apps/web/partials/navbar/navbar.tsx
+++ b/apps/web/partials/navbar/navbar.tsx
@@ -1,5 +1,3 @@
-import cx from 'classnames';
-
 import { NavUtils } from '~/core/utils/utils';
 
 import { ClientOnly } from '~/design-system/client-only';
@@ -16,12 +14,7 @@ interface Props {
 
 export function Navbar({ onSearchClick, hideLogo = false }: Props) {
   return (
-    <nav
-      className={cx(
-        'relative z-[60] flex h-11 w-full items-center justify-between gap-1 border-b border-divider bg-white px-4 py-1',
-        process.env.NODE_ENV === 'development' && 'sticky top-0 z-100'
-      )}
-    >
+    <nav className="sticky top-0 z-100 flex h-11 w-full items-center justify-between gap-1 border-b border-divider bg-white px-4 py-1">
       <div className="flex items-center gap-8 md:gap-4">
         {hideLogo ? null : (
           <Link href={NavUtils.toRoot()}>

--- a/apps/web/partials/navbar/navbar.tsx
+++ b/apps/web/partials/navbar/navbar.tsx
@@ -14,7 +14,7 @@ interface Props {
 
 export function Navbar({ onSearchClick, hideLogo = false }: Props) {
   return (
-    <nav className="sticky top-0 z-100 flex h-11 w-full items-center justify-between gap-1 border-b border-divider bg-white px-4 py-1">
+    <nav className="sticky top-0 z-60 flex h-11 w-full items-center justify-between gap-1 border-b border-divider bg-white px-4 py-1">
       <div className="flex items-center gap-8 md:gap-4">
         {hideLogo ? null : (
           <Link href={NavUtils.toRoot()}>


### PR DESCRIPTION
## Summary
- The navbar was only `sticky top-0` when `NODE_ENV === 'development'`, so in production it scrolled away with the page.
- Apply sticky positioning unconditionally so the navbar stays visible at the top while scrolling in all environments.

## Test plan
- [x] Run `bun dev` and scroll long pages — navbar stays pinned to the top.
- [x] Run `bun run build && bun start` and verify the same behavior in production mode.
- [x] Confirm no z-index regressions against dialogs/dropdowns/menus that overlap the nav.