### PR TITLE
chore(web): rename sign in button to "Log in"

### DIFF
--- a/apps/web/core/wallet/wallet.tsx
+++ b/apps/web/core/wallet/wallet.tsx
@@ -65,5 +65,5 @@ export function GeoConnectButton() {
     login();
   };
 
-  return <Button onClick={onLogin}>Sign in</Button>;
+  return <Button onClick={onLogin}>Log in</Button>;
 }


### PR DESCRIPTION
## Summary
- Renames the top-right header auth button label from "Sign in" to "Log in" on `GeoConnectButton`.

## Test plan
- [x] Load the app while signed out and confirm the top-right button reads "Log in".
- [x] Clicking it still opens the existing login flow.