### PR TITLE
feat(navbar): hide create dropdown when signed out

### DIFF
--- a/apps/web/partials/create-entity/create-entity-dropdown.tsx
+++ b/apps/web/partials/create-entity/create-entity-dropdown.tsx
@@ -5,6 +5,7 @@ import { useState } from 'react';
 import { usePathname, useRouter } from 'next/navigation';
 
 import { useAccessControl } from '~/core/hooks/use-access-control';
+import { useSmartAccount } from '~/core/hooks/use-smart-account';
 import { ID } from '~/core/id';
 import { NavUtils } from '~/core/utils/utils';
 
@@ -20,6 +21,11 @@ export function CreateEntityDropdown() {
 
   const spaceId = pathname?.startsWith('/space/') ? pathname.split('/space/')[1].split('/')[0] : null;
   const { isEditor, isMember } = useAccessControl(spaceId ?? '');
+  const { smartAccount } = useSmartAccount();
+
+  if (!smartAccount?.account.address) {
+    return null;
+  }
 
   return (
     <Menu


### PR DESCRIPTION
## Summary
- The '+' create button in the navbar was always rendered. Gate `CreateEntityDropdown` on the smart account address so it only appears once the user is signed in.
- Uses the same auth signal (`useSmartAccount().smartAccount?.account.address`) that `NavbarActions` already uses to swap between the connect button and the user menu.

## Test plan
- [ ] Signed out: '+' button is not visible in navbar
- [ ] After sign-in: '+' button appears and dropdown works (New entity / New property / Import data in a space context)
- [ ] After sign-out: '+' button disappears