### PR TITLE
fix(suggested-card): bump vertical spacing to 40px

### DIFF
--- a/apps/web/partials/entity-page/personal-profile-suggested-card.tsx
+++ b/apps/web/partials/entity-page/personal-profile-suggested-card.tsx
@@ -264,7 +264,7 @@ export function PersonalProfileSuggestedCard({ spaceId, entityId }: Props) {
 
   return (
     <div
-      className="relative mt-6 mb-6 min-h-[173px] overflow-hidden rounded-lg bg-[#dbe9c6] bg-cover bg-right bg-no-repeat"
+      className="relative mb-10 min-h-[173px] overflow-hidden rounded-lg bg-[#dbe9c6] bg-cover bg-right bg-no-repeat"
       style={{ backgroundImage: `url('/personal-profile/suggested-card-leaves.png')` }}
     >
       <div className="absolute right-6 top-6 z-20">


### PR DESCRIPTION
## Summary

In the Figma frame the type pills end at y=122 and the onboarding card starts at y=162 — a 40px gap. Matching gap to the Overview section below. The current `mt-6 mb-6` (24px each) sits the card too close to its neighbors.

Figma: https://www.figma.com/design/iWKsYButqqKWd1bqeBrUUj/Geo---Web?node-id=67140-52560

## Test plan

- [ ] On your personal space home, the gap above and below the "Get started" card matches Figma (40px)