### PR TITLE
fix(entity-page): show inline description on relation-entity pages

### DIFF
--- a/apps/web/app/space/(entity)/[id]/[entityId]/entity-page-header.tsx
+++ b/apps/web/app/space/(entity)/[id]/[entityId]/entity-page-header.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { useRelationEntityRelations } from '~/core/state/entity-page-store/entity-store';
 import type { Relation } from '~/core/types';
 
 import { EditableHeading } from '~/partials/entity-page/editable-entity-header';
@@ -23,15 +22,12 @@ export function EntityPageHeader({
   spaceId,
   serverRelations,
 }: EntityPageHeaderProps) {
-  const relations = useRelationEntityRelations(entityId, spaceId);
-  const isRelationPage = relations.length > 0;
-
   return (
     <div className="space-y-2">
       <EntityPageRelations entityId={entityId} spaceId={spaceId} serverRelations={serverRelations} />
       {showHeading && <EditableHeading spaceId={spaceId} entityId={entityId} />}
       {showHeading && <EntityPageInlineDescription entityId={entityId} spaceId={spaceId} />}
-      {showHeader && !isRelationPage && <EntityPageMetadataHeader id={entityId} spaceId={spaceId} isVoteable />}
+      {showHeader && <EntityPageMetadataHeader id={entityId} spaceId={spaceId} isVoteable />}
     </div>
   );
 }

--- a/apps/web/app/space/(entity)/[id]/[entityId]/entity-page-header.tsx
+++ b/apps/web/app/space/(entity)/[id]/[entityId]/entity-page-header.tsx
@@ -30,9 +30,7 @@ export function EntityPageHeader({
     <div className="space-y-2">
       <EntityPageRelations entityId={entityId} spaceId={spaceId} serverRelations={serverRelations} />
       {showHeading && <EditableHeading spaceId={spaceId} entityId={entityId} />}
-      {showHeading && !isRelationPage && (
-        <EntityPageInlineDescription entityId={entityId} spaceId={spaceId} />
-      )}
+      {showHeading && <EntityPageInlineDescription entityId={entityId} spaceId={spaceId} />}
       {showHeader && !isRelationPage && <EntityPageMetadataHeader id={entityId} spaceId={spaceId} isVoteable />}
     </div>
   );

--- a/apps/web/partials/entity-page/editable-entity-header.tsx
+++ b/apps/web/partials/entity-page/editable-entity-header.tsx
@@ -10,7 +10,6 @@ import Link from 'next/link';
 import { ZERO_WIDTH_SPACE } from '~/core/constants';
 import { useUserIsEditing } from '~/core/hooks/use-user-is-editing';
 import { ID } from '~/core/id';
-import { useRelationEntityRelations } from '~/core/state/entity-page-store/entity-store';
 import { useMutate } from '~/core/sync/use-mutate';
 import { useSyncEngine } from '~/core/sync/use-sync-engine';
 import { NavUtils } from '~/core/utils/utils';
@@ -29,7 +28,6 @@ import { EntityVersionItem } from '../history/history-item';
 import { HistoryPanel } from '../history/history-panel';
 import { useEntityHistory } from '../history/use-entity-history';
 import { EntityPageContextMenu } from './entity-page-context-menu';
-import { EntityPageMetadataHeader } from './entity-page-metadata-header';
 
 export function EditableHeading({ spaceId, entityId }: { spaceId: string; entityId: string }) {
   const { values } = useSyncEngine();
@@ -61,40 +59,31 @@ export function EditableHeading({ spaceId, entityId }: { spaceId: string; entity
     storage.entities.name.set(entityId, spaceId, value);
   };
 
-  const relations = useRelationEntityRelations(entityId, spaceId);
-  const isRelationPage = relations.length > 0;
-
   return (
     <>
       <div className="relative flex items-center justify-between gap-4">
-        {!isRelationPage ? (
-          <>
-            {isEditing ? (
-              <div className="min-w-0 flex-1 text-text">
-                <PageStringField
-                  variant="mainPage"
-                  placeholder="Entity name..."
-                  value={name ?? ''}
-                  onChange={onNameChange}
-                />
-                {/* Manual spacing to match the <Text /> height and avoid layout shift */}
-                <Spacer height={3.5} />
-              </div>
-            ) : (
-              <div className="min-w-0 flex-1">
-                <div className="flex min-w-0 items-center justify-between">
-                  <Truncate maxLines={3} shouldTruncate>
-                    <Text as="h1" variant="mainPage">
-                      {name ?? ZERO_WIDTH_SPACE}
-                    </Text>
-                  </Truncate>
-                </div>
-                <Spacer height={12} />
-              </div>
-            )}
-          </>
+        {isEditing ? (
+          <div className="min-w-0 flex-1 text-text">
+            <PageStringField
+              variant="mainPage"
+              placeholder="Entity name..."
+              value={name ?? ''}
+              onChange={onNameChange}
+            />
+            {/* Manual spacing to match the <Text /> height and avoid layout shift */}
+            <Spacer height={3.5} />
+          </div>
         ) : (
-          <EntityPageMetadataHeader id={entityId} spaceId={spaceId} />
+          <div className="min-w-0 flex-1">
+            <div className="flex min-w-0 items-center justify-between">
+              <Truncate maxLines={3} shouldTruncate>
+                <Text as="h1" variant="mainPage">
+                  {name ?? ZERO_WIDTH_SPACE}
+                </Text>
+              </Truncate>
+            </div>
+            <Spacer height={12} />
+          </div>
         )}
 
         <div className="flex shrink-0 items-center gap-5">


### PR DESCRIPTION
## Summary
- The inline description was hidden whenever the entity was also a relation entity (rows in the relations table where `r.entityId === entityId`).
- Drop the `!isRelationPage` gate on `EntityPageInlineDescription` so the description renders on those pages too.
- `EntityPageMetadataHeader` keeps its existing gate — only the description was reported as wrongly hidden.

## Test plan
- [x] Open an entity that is the relation entity of some relation and confirm its description renders inline under the name
- [x] Confirm regular entities still render the description as before
- [x] Edit mode: description textarea is editable on relation-entity pages