### PR TITLE
fix(property-panel): tighten property name line-height when wrapping

### DIFF
--- a/apps/web/partials/entity-page/property-name-link.tsx
+++ b/apps/web/partials/entity-page/property-name-link.tsx
@@ -47,7 +47,7 @@ export function PropertyNameLink({ property, spaceId }: PropertyNameLinkProps) {
       <Text
         as="span"
         variant="bodySemibold"
-        className="min-w-0 break-words underline-offset-2 group-hover:underline group-focus-visible:underline"
+        className="min-w-0 leading-tight break-words underline-offset-2 group-hover:underline group-focus-visible:underline"
       >
         {propertyName}
       </Text>

--- a/apps/web/partials/entity-page/readable-entity-page.tsx
+++ b/apps/web/partials/entity-page/readable-entity-page.tsx
@@ -251,8 +251,10 @@ function ReadablePropertyRow({
 
   return (
     <div className="grid grid-cols-[170px_minmax(0,1fr)] items-start gap-4">
-      <div className="inline-flex min-w-0 items-center gap-2 text-text">
-        <InlinePropertyTypeIcon dataType={property.dataType} renderableType={property.renderableTypeStrict ?? property.renderableType} />
+      <div className="inline-flex min-w-0 items-start gap-2 text-text">
+        <span className="flex h-[1.5rem] shrink-0 items-center">
+          <InlinePropertyTypeIcon dataType={property.dataType} renderableType={property.renderableTypeStrict ?? property.renderableType} />
+        </span>
         <PropertyNameLink property={property} spaceId={spaceId} />
       </div>
       {isRelation ? (


### PR DESCRIPTION
## Summary
- Long property names (e.g. "Employment status") wrap to two lines in the property panel after #1760, and the default `bodySemibold` line-height (29px on a 19px font, ~1.53 ratio) leaves a visibly large gap between the wrapped lines.
- Apply `leading-tight` (1.25) to `PropertyNameLink` so wrapped names read as a single label.

Single-line property names are unaffected since line-height only manifests visually on wrap. The other `PropertyNameLink` caller (data-block table column header) typically truncates, so this is effectively a no-op there.

## Test plan
- [ ] Open an entity with a long property name (e.g. "Employment status") in browse mode and confirm the wrapped lines sit tightly together
- [ ] Verify single-line property names look unchanged
- [ ] Sanity-check data-block table column headers