### PR TITLE
fix(suggested-card): debounce task sync to stop check/plus flicker

### DIFF
--- a/apps/web/partials/entity-page/personal-profile-suggested-task-sync.tsx
+++ b/apps/web/partials/entity-page/personal-profile-suggested-task-sync.tsx
@@ -167,18 +167,30 @@ export function PersonalProfileSuggestedTaskSync({ entityId, spaceId }: { entity
     };
   }, [skillsIntent, entityId, spaceId, canEdit, setSkillsIntent]);
 
+  const skillsDone = React.useMemo(() => {
+    for (const prop of Object.values(rendered)) {
+      if (propertyIsSkillsProperty(prop.id)) return true;
+    }
+    return false;
+  }, [rendered]);
+
+  const bioDone = React.useMemo(
+    () => stripProfileOverviewMarkdownNoise(overviewTextMarkdownJoined).length > 0,
+    [overviewTextMarkdownJoined]
+  );
+
+  // Debounced sync: the underlying reactive store can briefly emit transient states
+  // while local edits resettle (e.g. after deleting a freshly-added overview block).
+  // Writing eagerly causes the persisted atom to flip back and forth, which renders
+  // as a check/plus flicker on the Get Started pills. Coalesce into one write after
+  // the computed values have been stable for a short window.
+  const tasksRef = React.useRef(tasks);
+  tasksRef.current = tasks;
+  const setTasksRef = React.useRef(setTasks);
+  setTasksRef.current = setTasks;
+
   React.useEffect(() => {
     if (dismissForever) return;
-
-    const bioDone = stripProfileOverviewMarkdownNoise(overviewTextMarkdownJoined).length > 0;
-
-    let skillsDone = false;
-    for (const prop of Object.values(rendered)) {
-      if (propertyIsSkillsProperty(prop.id)) {
-        skillsDone = true;
-        break;
-      }
-    }
 
     const next = {
       bio: bioDone,
@@ -188,29 +200,23 @@ export function PersonalProfileSuggestedTaskSync({ entityId, spaceId }: { entity
       post: hasPostAuthoredByProfile,
     };
 
+    const current = tasksRef.current;
     if (
-      next.bio !== tasks.bio ||
-      next.skills !== tasks.skills ||
-      next.post !== tasks.post ||
-      next.work !== tasks.work ||
-      next.education !== tasks.education
+      next.bio === current.bio &&
+      next.skills === current.skills &&
+      next.post === current.post &&
+      next.work === current.work &&
+      next.education === current.education
     ) {
-      setTasks(next);
+      return;
     }
-  }, [
-    dismissForever,
-    entityId,
-    hasPostAuthoredByProfile,
-    rendered,
-    overviewTextMarkdownJoined,
-    setTasks,
-    spaceId,
-    tasks.bio,
-    tasks.education,
-    tasks.post,
-    tasks.skills,
-    tasks.work,
-  ]);
+
+    const timeoutId = window.setTimeout(() => {
+      setTasksRef.current(next);
+    }, 250);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [dismissForever, bioDone, skillsDone, hasPostAuthoredByProfile]);
 
 
   return null;


### PR DESCRIPTION
## Summary

- The Get Started pills on the personal space home page flicker between the check and plus icons when a user adds local edits (e.g. bio content) and then deletes them before publishing.
- Root cause: the persisted `personalProfileSuggestedTasksAtom` disagrees with what the live sync engine computes, and the engine briefly emits transient values while local edits resettle. The old effect ran every render (because `rendered` is a fresh object each render) and wrote eagerly on every flip — producing visible oscillation.
- Fix in `personal-profile-suggested-task-sync.tsx`:
  - Memoize `bioDone` / `skillsDone` so the effect depends on stable primitives.
  - Read `tasks` / `setTasks` via refs so the effect no longer self-retriggers on every write.
  - Debounce the `setTasks` write by 250ms so transient oscillation collapses into one settled write.

## Repro

1. On your own personal space home, add bio content locally (don't publish).
2. Delete those edits.
3. Observe the three Get Started pills rapidly flicking between check and plus.

After the fix the pills settle within ~250ms.

## Test plan

- [ ] Open personal space home in the browser that previously showed the flicker — pills no longer flicker.
- [ ] Add bio locally → pill flips to check (debounced) → publish → still check.
- [ ] Add bio locally → delete edit → pill returns to plus once, no flicker.
- [ ] Create post via the pill → optimistic check stays, no flicker on sync catch-up.
- [ ] Fresh browser (no local state, no localStorage) → no regression in steady state.