### PR TITLE
fix(home): remove personal profile suggested card from governance home

### DIFF
--- a/apps/web/app/home/component.tsx
+++ b/apps/web/app/home/component.tsx
@@ -24,7 +24,6 @@ type Props = {
   proposalType?: 'membership' | 'content';
   connectedAddress?: string;
   connectedSpaceId?: string;
-  personalOnboarding?: { spaceId: string; entityId: string } | null;
   governanceTab: 'review' | 'my';
   governanceFilters: GovernanceFilters;
   editorSpaceOptions: { id: string; name: string; image: string | null }[];
@@ -38,7 +37,6 @@ export async function Component({
   proposalType,
   connectedAddress,
   connectedSpaceId,
-  personalOnboarding,
   governanceTab,
   governanceFilters,
   editorSpaceOptions,
@@ -54,7 +52,6 @@ export async function Component({
           governanceFilters={governanceFilters}
           editorSpaceOptions={editorSpaceOptions}
           myProposalSpaceOptions={myProposalSpaceOptions}
-          personalOnboarding={personalOnboarding}
           proposalsList={
             governanceTab === 'my' && !connectedSpaceId ? (
               <p className="text-body text-grey-04">Sign in to see your proposals.</p>

--- a/apps/web/app/home/page.tsx
+++ b/apps/web/app/home/page.tsx
@@ -85,9 +85,6 @@ export default async function PersonalHomePage(props: Props) {
     myProposalSpaceOptions = mapAndSortGovernanceSpaceOptions(mySpaces);
   }
 
-  const personalOnboarding =
-    person?.spaceId && person?.id ? { spaceId: person.spaceId, entityId: person.id } : null;
-
   return (
     <Component
       header={<GovernanceHomeHeader />}
@@ -95,7 +92,6 @@ export default async function PersonalHomePage(props: Props) {
       sidebarCounts={sidebarCounts}
       connectedAddress={connectedAddress}
       connectedSpaceId={person?.spaceId}
-      personalOnboarding={personalOnboarding}
       governanceTab={tab}
       governanceFilters={{
         spaceId: governanceSpaceId,

--- a/apps/web/app/home/personal-home-dashboard.tsx
+++ b/apps/web/app/home/personal-home-dashboard.tsx
@@ -23,7 +23,6 @@ import { Menu } from '~/design-system/menu';
 import { PrefetchLink as Link } from '~/design-system/prefetch-link';
 import { tabGroupTabLinkStyles } from '~/design-system/tab-group';
 import { Text } from '~/design-system/text';
-import { PersonalProfileSuggestedCard } from '~/partials/entity-page/personal-profile-suggested-card';
 
 import {
   type GovernanceHomeReviewCategory,
@@ -71,7 +70,6 @@ type PersonalHomeDashboardProps = {
   governanceFilters: GovernanceFilters;
   editorSpaceOptions: { id: string; name: string; image: string | null }[];
   myProposalSpaceOptions: { id: string; name: string; image: string | null }[];
-  personalOnboarding?: { spaceId: string; entityId: string } | null;
 };
 
 function GovernanceTabsRow({
@@ -143,7 +141,6 @@ export function PersonalHomeDashboard({
   governanceFilters,
   editorSpaceOptions,
   myProposalSpaceOptions,
-  personalOnboarding,
 }: PersonalHomeDashboardProps) {
   const spaceOptions = governanceTab === 'review' ? editorSpaceOptions : myProposalSpaceOptions;
 
@@ -163,11 +160,6 @@ export function PersonalHomeDashboard({
 
   return (
     <>
-      {personalOnboarding ? (
-        <div className="mt-8">
-          <PersonalProfileSuggestedCard spaceId={personalOnboarding.spaceId} entityId={personalOnboarding.entityId} />
-        </div>
-      ) : null}
       <React.Suspense fallback={<div className="mt-8 h-8" />}>
         <GovernanceTabsRow governanceTab={governanceTab} filterState={filterState} />
       </React.Suspense>


### PR DESCRIPTION
## Summary
- Removes the "Get started" personal profile onboarding card (`PersonalProfileSuggestedCard`) from `/home`. It still renders on personal space home pages, where it belongs.
- Cleans up the now-unused `personalOnboarding` prop plumbing through `page.tsx` → `component.tsx` → `personal-home-dashboard.tsx`.
- Leaves the "Welcome to your governance home" notice intact.

## Test plan
- [ ] Visit `/home` — confirm no "Get started / Add bio / Add skills / Create post" card renders.
- [ ] Visit a personal space home — confirm the suggested card still renders.