### PR TITLE
feat: prompt non-logged-in users to create a personal space

### DIFF
--- a/apps/web/app/entry.tsx
+++ b/apps/web/app/entry.tsx
@@ -30,6 +30,11 @@ const OnboardingDialog = dynamic(
   { ssr: false }
 );
 
+const SignInPrompt = dynamic(
+  () => import('~/partials/sign-in-prompt/sign-in-prompt').then(m => ({ default: m.SignInPrompt })),
+  { ssr: false }
+);
+
 const ReviewChanges = dynamic(
   () => import('~/partials/review/review-changes').then(m => ({ default: m.ReviewChanges })),
   { ssr: false }
@@ -80,6 +85,7 @@ export function App({ children }: { children: React.ReactNode }) {
       <ClientOnly>
         <OnboardingDialog />
         <CreateSpaceDialog />
+        <SignInPrompt />
         <Toast />
         <GovernanceReopenEditLoadingBar />
         <FlowBar />

--- a/apps/web/core/state/sign-in-prompt-store.ts
+++ b/apps/web/core/state/sign-in-prompt-store.ts
@@ -1,0 +1,15 @@
+import { atom, useAtom } from 'jotai';
+
+export type SignInPromptAction = 'vote' | 'join' | 'comment';
+
+export const signInPromptActionAtom = atom<SignInPromptAction | null>(null);
+
+export function useSignInPrompt() {
+  const [action, setAction] = useAtom(signInPromptActionAtom);
+
+  return {
+    action,
+    open: (next: SignInPromptAction) => setAction(next),
+    close: () => setAction(null),
+  };
+}

--- a/apps/web/partials/comments/comments-section.tsx
+++ b/apps/web/partials/comments/comments-section.tsx
@@ -6,8 +6,10 @@ import { useState } from 'react';
 import { useComments } from '~/core/hooks/use-comments';
 import { useCreateComment } from '~/core/hooks/use-create-comment';
 import { usePersonalSpaceId } from '~/core/hooks/use-personal-space-id';
+import { useSmartAccount } from '~/core/hooks/use-smart-account';
 import { useSpaceEditorIds } from '~/core/hooks/use-space-editor-ids';
 import { renderMarkdownDocument } from '~/core/state/editor/markdown-render';
+import { useSignInPrompt } from '~/core/state/sign-in-prompt-store';
 import { NavUtils } from '~/core/utils/utils';
 import { normalizeSpaceId } from '~/core/access/space-access';
 
@@ -141,6 +143,10 @@ export function CommentSection({ entityId, spaceId }: CommentSectionProps) {
   const { comments, totalCount, isLoading } = useComments({ entityId, spaceId });
   const { createComment, editComment } = useCreateComment(entityId);
   const { personalSpaceId } = usePersonalSpaceId();
+  const { smartAccount } = useSmartAccount();
+  const { open: openSignInPrompt } = useSignInPrompt();
+  const isLoggedIn = !!smartAccount;
+  const requireSignInToComment = React.useCallback(() => openSignInPrompt('comment'), [openSignInPrompt]);
   const commentAuthorSpaceIds = React.useMemo(() => collectCommentAuthorSpaceIds(comments), [comments]);
   const { editorSpaceIds } = useSpaceEditorIds(spaceId, commentAuthorSpaceIds);
 
@@ -246,7 +252,11 @@ export function CommentSection({ entityId, spaceId }: CommentSectionProps) {
       <div id="entity-comments" className="flex w-full flex-col pt-10">
         <div className="text-mediumTitle">Comments ({totalCount})</div>
         <Spacer height={16} />
-        <TopLevelCommentInput onSubmit={handleCreateComment} />
+        <TopLevelCommentInput
+          onSubmit={handleCreateComment}
+          isLoggedIn={isLoggedIn}
+          onSignInRequired={requireSignInToComment}
+        />
         {totalCount > 0 && (
           <>
             <Spacer height={16} />
@@ -279,6 +289,8 @@ export function CommentSection({ entityId, spaceId }: CommentSectionProps) {
                 isThreadCollapsed={isThreadCollapsed}
                 toggleThreadCollapsed={toggleThreadCollapsed}
                 sortReplies={sortWithSessionPinned}
+                isLoggedIn={isLoggedIn}
+                onSignInRequired={requireSignInToComment}
               />
             </>
           )
@@ -354,13 +366,27 @@ function CommentFilters({
 }
 
 /** Top-level pill-style input matching the design ("Start the discussion...") */
-function TopLevelCommentInput({ onSubmit }: { onSubmit: (text: string) => void }) {
+function TopLevelCommentInput({
+  onSubmit,
+  isLoggedIn,
+  onSignInRequired,
+}: {
+  onSubmit: (text: string) => void;
+  isLoggedIn: boolean;
+  onSignInRequired: () => void;
+}) {
   const [isExpanded, setIsExpanded] = useState(false);
 
   if (!isExpanded) {
     return (
       <button
-        onClick={() => setIsExpanded(true)}
+        onClick={() => {
+          if (!isLoggedIn) {
+            onSignInRequired();
+            return;
+          }
+          setIsExpanded(true);
+        }}
         className="w-full rounded-lg border border-grey-02 px-4 py-3 text-left text-body text-grey-04 hover:border-text"
       >
         Start the discussion...
@@ -482,6 +508,8 @@ function CommentList({
   isThreadCollapsed,
   toggleThreadCollapsed,
   sortReplies,
+  isLoggedIn,
+  onSignInRequired,
   depth = 0,
   ancestors = [],
   parentCommentId,
@@ -496,6 +524,8 @@ function CommentList({
   isThreadCollapsed: (commentId: string) => boolean;
   toggleThreadCollapsed: (commentId: string) => void;
   sortReplies: (items: CommentWithReplies[]) => CommentWithReplies[];
+  isLoggedIn: boolean;
+  onSignInRequired: () => void;
   depth?: number;
   ancestors?: Array<{ id: string; spaceId: string }>;
   parentCommentId?: string;
@@ -518,6 +548,8 @@ function CommentList({
             isThreadCollapsed={isThreadCollapsed}
             toggleThreadCollapsed={toggleThreadCollapsed}
             sortReplies={sortReplies}
+            isLoggedIn={isLoggedIn}
+            onSignInRequired={onSignInRequired}
             isLast={index === comments.length - 1}
             depth={depth}
             ancestors={ancestors}
@@ -688,6 +720,8 @@ function CommentList({
               isThreadCollapsed={isThreadCollapsed}
               toggleThreadCollapsed={toggleThreadCollapsed}
               sortReplies={sortReplies}
+              isLoggedIn={isLoggedIn}
+              onSignInRequired={onSignInRequired}
               isLast={index === comments.length - 1}
               depth={depth}
               ancestors={ancestors}
@@ -710,6 +744,8 @@ function CommentItem({
   isThreadCollapsed,
   toggleThreadCollapsed,
   sortReplies,
+  isLoggedIn,
+  onSignInRequired,
   isLast,
   depth,
   ancestors,
@@ -724,6 +760,8 @@ function CommentItem({
   isThreadCollapsed: (commentId: string) => boolean;
   toggleThreadCollapsed: (commentId: string) => void;
   sortReplies: (items: CommentWithReplies[]) => CommentWithReplies[];
+  isLoggedIn: boolean;
+  onSignInRequired: () => void;
   isLast: boolean;
   depth: number;
   ancestors: Array<{ id: string; spaceId: string }>;
@@ -899,7 +937,16 @@ function CommentItem({
             </button>
           )}
           <EntityVoteButtons entityId={comment.id} spaceId={comment.spaceId} />
-          <button onClick={() => setIsReplying(!isReplying)} className="text-smallButton text-grey-04 hover:text-text">
+          <button
+            onClick={() => {
+              if (!isLoggedIn) {
+                onSignInRequired();
+                return;
+              }
+              setIsReplying(!isReplying);
+            }}
+            className="text-smallButton text-grey-04 hover:text-text"
+          >
             Reply
           </button>
           {isOwnComment && (
@@ -940,6 +987,8 @@ function CommentItem({
             isThreadCollapsed={isThreadCollapsed}
             toggleThreadCollapsed={toggleThreadCollapsed}
             sortReplies={sortReplies}
+            isLoggedIn={isLoggedIn}
+            onSignInRequired={onSignInRequired}
             depth={depth + 1}
             ancestors={[{ id: comment.id, spaceId: comment.spaceId }, ...ancestors]}
             parentCommentId={comment.id}

--- a/apps/web/partials/entity-page/entity-vote-buttons.tsx
+++ b/apps/web/partials/entity-page/entity-vote-buttons.tsx
@@ -10,8 +10,10 @@ import { Effect } from 'effect';
 
 import { downvoted, upvoted, voteCast } from '~/core/analytics';
 import { type VoteObjectType, useEntityVote } from '~/core/hooks/use-entity-vote';
+import { useSmartAccount } from '~/core/hooks/use-smart-account';
 import { type EntityVoter, getEntityVoteCount, getEntityVoters, getUserEntityVote } from '~/core/io/queries';
 import { fetchProfilesBySpaceIds } from '~/core/io/subgraph/fetch-profile';
+import { useSignInPrompt } from '~/core/state/sign-in-prompt-store';
 import { Profile } from '~/core/types';
 
 import { Avatar } from '~/design-system/avatar';
@@ -32,6 +34,8 @@ export function EntityVoteButtons({ entityId, spaceId, objectType = 0 }: EntityV
     spaceId,
     objectType,
   });
+  const { smartAccount } = useSmartAccount();
+  const { open: openSignInPrompt } = useSignInPrompt();
 
   const [optimisticVote, setOptimisticVote] = React.useState<OptimisticVote>(null);
   const [optimisticScore, setOptimisticScore] = React.useState<bigint | null>(null);
@@ -77,6 +81,10 @@ export function EntityVoteButtons({ entityId, spaceId, objectType = 0 }: EntityV
   const displayScore = optimisticScore !== null ? optimisticScore : netScore;
 
   function handleUpvote() {
+    if (!smartAccount) {
+      openSignInPrompt('vote');
+      return;
+    }
     if (!isConnected) return;
     const base = optimisticScore !== null ? optimisticScore : netScore;
     if (activeVote === 0) {
@@ -109,6 +117,10 @@ export function EntityVoteButtons({ entityId, spaceId, objectType = 0 }: EntityV
   }
 
   function handleDownvote() {
+    if (!smartAccount) {
+      openSignInPrompt('vote');
+      return;
+    }
     if (!isConnected) return;
     const base = optimisticScore !== null ? optimisticScore : netScore;
     if (activeVote === 1) {
@@ -161,11 +173,19 @@ export function EntityVoteButtons({ entityId, spaceId, objectType = 0 }: EntityV
     <div className="flex items-center gap-1 text-metadataMedium text-text">
       <button
         onClick={handleUpvote}
-        disabled={!isConnected}
-        title={isConnected ? (upvoteActive ? 'Remove upvote' : 'Upvote') : 'Connect wallet to vote'}
+        disabled={!!smartAccount && !isConnected}
+        title={
+          !smartAccount
+            ? 'Sign in to vote'
+            : isConnected
+              ? upvoteActive
+                ? 'Remove upvote'
+                : 'Upvote'
+              : 'Connect wallet to vote'
+        }
         className={cx(
           'group/vote flex h-5 w-5 items-center justify-center rounded transition-colors',
-          !isConnected && 'cursor-default opacity-50'
+          !!smartAccount && !isConnected && 'cursor-default opacity-50'
         )}
       >
         <VoteArrow direction="up" filled={upvoteActive} color="grey-03" />
@@ -193,11 +213,19 @@ export function EntityVoteButtons({ entityId, spaceId, objectType = 0 }: EntityV
       </Popover.Root>
       <button
         onClick={handleDownvote}
-        disabled={!isConnected}
-        title={isConnected ? (downvoteActive ? 'Remove downvote' : 'Downvote') : 'Connect wallet to vote'}
+        disabled={!!smartAccount && !isConnected}
+        title={
+          !smartAccount
+            ? 'Sign in to vote'
+            : isConnected
+              ? downvoteActive
+                ? 'Remove downvote'
+                : 'Downvote'
+              : 'Connect wallet to vote'
+        }
         className={cx(
           'group/vote flex h-5 w-5 items-center justify-center rounded transition-colors',
-          !isConnected && 'cursor-default opacity-50'
+          !!smartAccount && !isConnected && 'cursor-default opacity-50'
         )}
       >
         <VoteArrow direction="down" filled={downvoteActive} color="grey-03" />

--- a/apps/web/partials/explore/explore-join-space-button.tsx
+++ b/apps/web/partials/explore/explore-join-space-button.tsx
@@ -5,6 +5,8 @@ import * as React from 'react';
 import { atom, useAtom } from 'jotai';
 
 import { useRequestToBeMember } from '~/core/hooks/use-request-to-be-member';
+import { useSmartAccount } from '~/core/hooks/use-smart-account';
+import { useSignInPrompt } from '~/core/state/sign-in-prompt-store';
 
 import { Pending } from '~/design-system/pending';
 
@@ -27,6 +29,8 @@ const locallyRequestedSpaceIdsAtom = atom<Set<string>>(new Set<string>());
 export function ExploreJoinSpaceButton({ spaceId, hasRequestedSpaceMembership }: ExploreJoinSpaceButtonProps) {
   const { requestToBeMember, status } = useRequestToBeMember({ spaceId });
   const [locallyRequested, setLocallyRequested] = useAtom(locallyRequestedSpaceIdsAtom);
+  const { smartAccount } = useSmartAccount();
+  const { open: openSignInPrompt } = useSignInPrompt();
 
   const normalizedId = normId(spaceId);
   const locallyRequestedThisSpace = locallyRequested.has(normalizedId);
@@ -52,7 +56,13 @@ export function ExploreJoinSpaceButton({ spaceId, hasRequestedSpaceMembership }:
           type="button"
           className="text-smallButton text-grey-04 transition-colors duration-75 hover:text-text"
           disabled={status !== 'idle'}
-          onClick={() => requestToBeMember()}
+          onClick={() => {
+            if (!smartAccount) {
+              openSignInPrompt('join');
+              return;
+            }
+            requestToBeMember();
+          }}
         >
           Join space
         </button>

--- a/apps/web/partials/sign-in-prompt/sign-in-prompt.tsx
+++ b/apps/web/partials/sign-in-prompt/sign-in-prompt.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import { useGeoLogin } from '@geogenesis/auth';
+import { Content, Description, Overlay, Portal, Root, Title } from '@radix-ui/react-dialog';
+
+import * as React from 'react';
+
+import { useSetAtom } from 'jotai';
+
+import { trackPrivyAuth } from '~/core/analytics';
+import { useSmartAccount } from '~/core/hooks/use-smart-account';
+import { type SignInPromptAction, useSignInPrompt } from '~/core/state/sign-in-prompt-store';
+
+import { Button, SquareButton } from '~/design-system/button';
+import { Close } from '~/design-system/icons/close';
+import { Text } from '~/design-system/text';
+
+import { avatarAtom, nameAtom, spaceIdAtom, stepAtom, topicIdAtom } from '~/partials/onboarding/dialog';
+
+const COPY: Record<SignInPromptAction, { title: string }> = {
+  vote: { title: 'Create your personal space to vote on entities' },
+  join: { title: 'Create your personal space to join spaces' },
+  comment: { title: 'Create your personal space to comment' },
+};
+
+const BODY = 'A personal space lets you vote, comment, join spaces, and more.';
+
+export function SignInPrompt() {
+  const { action, close } = useSignInPrompt();
+  const { smartAccount } = useSmartAccount();
+
+  const setName = useSetAtom(nameAtom);
+  const setTopicId = useSetAtom(topicIdAtom);
+  const setAvatar = useSetAtom(avatarAtom);
+  const setSpaceId = useSetAtom(spaceIdAtom);
+  const setStep = useSetAtom(stepAtom);
+
+  const { login } = useGeoLogin({
+    onComplete: args => trackPrivyAuth(args, { auth_flow: 'manual_login' }),
+  });
+
+  // Close once the wallet is connected — useOnboarding takes over and shows the
+  // onboarding dialog if the user has no personal space yet.
+  React.useEffect(() => {
+    if (smartAccount && action !== null) {
+      close();
+    }
+  }, [smartAccount, action, close]);
+
+  if (action === null) return null;
+
+  const { title } = COPY[action];
+
+  const handleSignIn = () => {
+    // Same reset the navbar's GeoConnectButton runs — clears any in-progress
+    // onboarding state before launching Privy.
+    setName('');
+    setTopicId('');
+    setAvatar('');
+    setSpaceId('');
+    setStep('start');
+    login();
+  };
+
+  return (
+    <Root open onOpenChange={open => !open && close()}>
+      <Portal>
+        <Overlay className="fixed inset-0 z-100 bg-text/20" />
+        <Content className="fixed inset-0 z-1000 flex h-full w-full items-start justify-center focus:outline-hidden">
+          <div className="pointer-events-auto relative mt-40 flex w-full max-w-[360px] flex-col gap-4 rounded-lg border border-grey-02 bg-white p-4 shadow-dropdown">
+            <div className="absolute top-3 right-3">
+              <SquareButton onClick={close} icon={<Close />} />
+            </div>
+            <div className="space-y-2 px-2 pt-6">
+              <Title asChild>
+                <Text as="h3" variant="bodySemibold" className="text-center text-2xl!">
+                  {title}
+                </Text>
+              </Title>
+              <Description asChild>
+                <Text as="p" variant="body" className="text-center text-base!">
+                  {BODY}
+                </Text>
+              </Description>
+            </div>
+            <Button onClick={handleSignIn} className="w-full">
+              Sign in
+            </Button>
+          </div>
+        </Content>
+      </Portal>
+    </Root>
+  );
+}

--- a/apps/web/partials/sign-in-prompt/sign-in-prompt.tsx
+++ b/apps/web/partials/sign-in-prompt/sign-in-prompt.tsx
@@ -84,7 +84,7 @@ export function SignInPrompt() {
               </Description>
             </div>
             <Button onClick={handleSignIn} className="w-full">
-              Sign in
+              Sign up
             </Button>
           </div>
         </Content>

--- a/apps/web/partials/space-page/space-members-join-button.tsx
+++ b/apps/web/partials/space-page/space-members-join-button.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import { useRequestToBeMember } from '~/core/hooks/use-request-to-be-member';
+import { useSmartAccount } from '~/core/hooks/use-smart-account';
+import { useSignInPrompt } from '~/core/state/sign-in-prompt-store';
 
 import { Pending } from '~/design-system/pending';
 
@@ -11,6 +13,8 @@ type SpaceMembersJoinButtonProps = {
 
 export function SpaceMembersJoinButton({ spaceId, hasRequestedSpaceMembership }: SpaceMembersJoinButtonProps) {
   const { requestToBeMember, status } = useRequestToBeMember({ spaceId });
+  const { smartAccount } = useSmartAccount();
+  const { open: openSignInPrompt } = useSignInPrompt();
 
   return (
     <>
@@ -22,7 +26,16 @@ export function SpaceMembersJoinButton({ spaceId, hasRequestedSpaceMembership }:
         className="text-grey-04 transition-colors duration-75 hover:cursor-pointer hover:text-text"
       >
         {!hasRequestedSpaceMembership ? (
-          <button onClick={() => requestToBeMember()} disabled={status !== 'idle'}>
+          <button
+            onClick={() => {
+              if (!smartAccount) {
+                openSignInPrompt('join');
+                return;
+              }
+              requestToBeMember();
+            }}
+            disabled={status !== 'idle'}
+          >
             <RequestButtonText status={status} />
           </button>
         ) : (

--- a/apps/web/partials/space-page/space-members-popover-members-request-button.tsx
+++ b/apps/web/partials/space-page/space-members-popover-members-request-button.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import { useRequestToBeMember } from '~/core/hooks/use-request-to-be-member';
+import { useSmartAccount } from '~/core/hooks/use-smart-account';
+import { useSignInPrompt } from '~/core/state/sign-in-prompt-store';
 
 import { Pending } from '~/design-system/pending';
 
@@ -14,6 +16,8 @@ export function SpaceMembersPopoverMemberRequestButton({
   hasRequestedSpaceMembership,
 }: SpaceMembersPopoverMemberRequestButtonProps) {
   const { requestToBeMember, status } = useRequestToBeMember({ spaceId });
+  const { smartAccount } = useSmartAccount();
+  const { open: openSignInPrompt } = useSignInPrompt();
 
   return (
     <Pending isPending={status === 'pending'} position="end">
@@ -21,7 +25,13 @@ export function SpaceMembersPopoverMemberRequestButton({
         <button
           className="text-smallButton text-grey-04 transition-colors duration-75 hover:text-text"
           disabled={status !== 'idle'}
-          onClick={() => requestToBeMember()}
+          onClick={() => {
+            if (!smartAccount) {
+              openSignInPrompt('join');
+              return;
+            }
+            requestToBeMember();
+          }}
         >
           <RequestButtonText status={status} />
         </button>


### PR DESCRIPTION
Add a reusable SignInPrompt modal that opens when a guest clicks vote, join space, comment, or reply. CTA invokes useGeoLogin so the existing onboarding flow takes over after Privy login.