### PR TITLE
fix(chat-inject): use Sec-Fetch-Site so GET poll passes same-origin check

### DIFF
--- a/apps/web/app/api/chat/inject/[jobId]/route.ts
+++ b/apps/web/app/api/chat/inject/[jobId]/route.ts
@@ -21,6 +21,17 @@ import { ipCeilingLimit, loggedInLimit } from '../../rate-limit';
 const INJECT_FETCH_TIMEOUT_MS = 15_000;
 
 function isSameOrigin(req: Request): boolean {
+  // Prefer Sec-Fetch-Site when the browser provides it (Fetch Metadata).
+  // Browsers omit `Origin` on same-origin GET/HEAD requests per the Fetch
+  // spec, which previously caused poll GETs to be rejected here even though
+  // they come from the same React app as the POST that just succeeded.
+  // Sec-Fetch-Site is sent on every fetch regardless of method.
+  const site = req.headers.get('sec-fetch-site');
+  if (site !== null) {
+    return site === 'same-origin' || site === 'none';
+  }
+  // Legacy fallback for non-browser clients / older browsers that don't
+  // emit Sec-Fetch-Site. Same check as before.
   const origin = req.headers.get('origin');
   const host = req.headers.get('host');
   if (!origin) return process.env.NODE_ENV !== 'production';

--- a/apps/web/app/api/chat/inject/route.ts
+++ b/apps/web/app/api/chat/inject/route.ts
@@ -12,6 +12,17 @@ const VALID_TYPES: ReadonlySet<InjectType> = new Set(['news-story-single', 'post
 const INJECT_FETCH_TIMEOUT_MS = 15_000;
 
 function isSameOrigin(req: Request): boolean {
+  // Prefer Sec-Fetch-Site when the browser provides it (Fetch Metadata).
+  // Browsers omit `Origin` on same-origin GET/HEAD requests per the Fetch
+  // spec, which previously caused poll GETs to be rejected here even though
+  // they come from the same React app as the POST that just succeeded.
+  // Sec-Fetch-Site is sent on every fetch regardless of method.
+  const site = req.headers.get('sec-fetch-site');
+  if (site !== null) {
+    return site === 'same-origin' || site === 'none';
+  }
+  // Legacy fallback for non-browser clients / older browsers that don't
+  // emit Sec-Fetch-Site. Same check as before.
   const origin = req.headers.get('origin');
   const host = req.headers.get('host');
   if (!origin) return process.env.NODE_ENV !== 'production';


### PR DESCRIPTION
## Summary

Fixes `403 Forbidden` on every `GET /api/chat/inject/[jobId]` poll in production. The chat-widget inject flow:

1. User pastes a URL → `POST /api/chat/inject` → returns `jobId` (works ✅)
2. `useInjectJob` polls `GET /api/chat/inject/[jobId]` → **403** (broken ❌)
3. UI surfaces `News pipeline didn't return results (Poll failed (403)) — falling back to the standard import.`

## Root cause

`isSameOrigin()` in both BFF route files rejects requests without an `Origin` header in production:

```ts
if (!origin) return process.env.NODE_ENV !== 'production';
```

Per the [Fetch spec §4.5 — Append a request `Origin` header](https://fetch.spec.whatwg.org/#origin-header), browsers **do not attach `Origin` to same-origin `GET`/`HEAD` requests**. `Origin` is only appended when (a) response tainting is `cors`, (b) the request mode is `websocket`, or (c) the method is neither `GET` nor `HEAD`. So a same-origin `fetch('/api/chat/inject/123', { method: 'GET' })` lands at the BFF with no `Origin` header → `isSameOrigin` falls into the no-Origin branch → 403.

The `POST` worked the whole time because state-changing methods always carry `Origin`.

## Fix

Prefer `Sec-Fetch-Site` (a [Fetch Metadata Request Header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-Fetch-Site)) when the browser provides it. Browsers send `Sec-Fetch-Site` on every request regardless of method, with values `same-origin`, `same-site`, `cross-site`, or `none` (direct navigation). Keep the existing `Origin`/`Host` check as a legacy fallback for non-browser callers.

```ts
function isSameOrigin(req: Request): boolean {
  const site = req.headers.get('sec-fetch-site');
  if (site !== null) {
    return site === 'same-origin' || site === 'none';
  }
  // legacy fallback unchanged
  ...
}
```

Same patch applied to both `apps/web/app/api/chat/inject/route.ts` and `apps/web/app/api/chat/inject/[jobId]/route.ts`.

## Evidence

**1. Production Vercel logs (deployment `geogenesis-c3oat05ld`, last 24h, filtered to `/api/chat/inject*`):**

```
14:37:31.77  GET  /api/chat/inject/262   403
14:37:31.22  POST /api/chat/inject       202
14:19:03.20  GET  /api/chat/inject/245   403
14:19:02.56  POST /api/chat/inject       202
... 12 more identical pairs ...
```

14 inject sessions, 100% follow the pattern `POST 202 → GET 403 within 0.5s`. The only `403`s on this deployment in the last 24h come from `/api/chat/inject/[jobId]`.

**2. Browser DevTools header comparison (Firefox 150, same React app, same browser session, milliseconds apart):**

| Header | `GET /api/chat/inject/275` → 403 | `POST /api/chat/inject` → 202 |
|---|---|---|
| `Sec-Fetch-Site` | `same-origin` | `same-origin` |
| **`Origin`** | **(absent)** | `https://www.geobrowser.io` |
| `Host` | `www.geobrowser.io` | `www.geobrowser.io` |
| `Cookie`, `Referer`, `Sec-Fetch-Mode`, `Sec-Fetch-Dest`, `User-Agent` | identical | identical |

The single distinguishing header between passing and failing requests is `Origin`. `Sec-Fetch-Site` is identical on both, which is exactly why the fix works.

**3. News-worker side is clean.** Confirmed via Railway logs on the staging worker the BFF proxies to: every `POST /inject` that the BFF forwards (when it does forward, which is just the submit) succeeds end-to-end with the full 7-stage pipeline. The bug is purely in the BFF.

## How to verify

In a deployment of this branch:

1. Sign in on a space page.
2. Paste a fresh news URL (e.g., from Reuters/NYT/NPR) into the **Add data** panel and submit.
3. The submit (`POST /api/chat/inject` → 202) and the polls (`GET /api/chat/inject/[jobId]` → 200) should both succeed.
4. ~2–4 min later (inject pipeline duration), the chat assistant should display `Imported <headline> — Review and publish when ready.` rather than the fallback message.

For a quick sanity check without the full pipeline:

```bash
# Should still 403 — no Sec-Fetch-Site, no Origin, production NODE_ENV
curl -i https://www.geobrowser.io/api/chat/inject/123 \
  -H "Cookie: walletAddress=0x<your-wallet>"

# Should pass the gate (will then 404 since the job doesn't exist, but
# crucially not 403)
curl -i https://www.geobrowser.io/api/chat/inject/123 \
  -H "Cookie: walletAddress=0x<your-wallet>" \
  -H "Sec-Fetch-Site: same-origin"
```

## Security analysis

The patch is strictly equivalent-or-stronger than the original:

- **Same-origin browser requests (legit)** — now pass for both GET and POST. ✅
- **Cross-site browser requests** — rejected by `Sec-Fetch-Site: cross-site`. ✅
- **Same-site requests from a different subdomain** — rejected by `Sec-Fetch-Site: same-site`. ✅
- **Spoofed `Origin` header from a malicious page** — `Sec-Fetch-*` headers are forbidden headers per the Fetch spec; the browser sets them and refuses to let JS override them. So they're more resistant to spoofing than `Origin` itself.
- **Non-browser callers** (curl, server-to-server, very old browsers) — fall through to the legacy `Origin`/`Host` path. Behavior identical to today.

## Out of scope

- The two BFF files have an identical copy-pasted `isSameOrigin` function plus several other shared helpers (`parseWalletCookie`, `getClientIp`, `jsonError`, `rateLimitResponse`, `injectBase`). Tempting to DRY them into a shared module, but kept this PR minimal to make the fix easy to review and back out if needed. Happy to follow up with a refactor PR if useful.