### PR TITLE
fix(entity-page): prevent property-type pill from wrapping

### DIFF
--- a/apps/web/partials/entity-page/data-type-pill.tsx
+++ b/apps/web/partials/entity-page/data-type-pill.tsx
@@ -62,7 +62,7 @@ export function DataTypePill({ dataType, renderableType, spaceId, iconOnly = fal
   if (!isClickable) {
     // Non-clickable pill (data type only)
     return (
-      <span className="inline-flex items-center gap-1 rounded border border-grey-02 bg-white px-1.5 py-px text-metadata tabular-nums">
+      <span className="inline-flex shrink-0 items-center gap-1 whitespace-nowrap rounded border border-grey-02 bg-white px-1.5 py-px text-metadata tabular-nums">
         {IconComponent && <IconComponent color="grey-04" />}
         <span>{formattedType}</span>
       </span>
@@ -73,7 +73,7 @@ export function DataTypePill({ dataType, renderableType, spaceId, iconOnly = fal
   return (
     <Link
       href={NavUtils.toEntity(spaceId, targetId!)}
-      className="group inline-flex items-center gap-1 rounded border border-grey-02 bg-white py-px pl-1.5 text-metadata tabular-nums hover:cursor-pointer hover:border-text hover:text-text focus:cursor-pointer focus:border-text focus:bg-ctaTertiary focus:text-text focus:shadow-inner-lg"
+      className="group inline-flex shrink-0 items-center gap-1 whitespace-nowrap rounded border border-grey-02 bg-white py-px pl-1.5 text-metadata tabular-nums hover:cursor-pointer hover:border-text hover:text-text focus:cursor-pointer focus:border-text focus:bg-ctaTertiary focus:text-text focus:shadow-inner-lg"
     >
       {IconComponent && <IconComponent color="grey-04" />}
       <span className="pr-1.5">{formattedType}</span>

--- a/apps/web/partials/entity-page/renderable-type-dropdown.tsx
+++ b/apps/web/partials/entity-page/renderable-type-dropdown.tsx
@@ -72,7 +72,7 @@ export const RenderableTypeDropdown = ({ value, onChange, baseDataType }: Props)
       <DropdownPrimitive.Trigger className="text-text" asChild>
         <button
           ref={triggerRef}
-          className={`flex items-center gap-[6px] rounded-[6px] border px-1.5 py-[3px] text-[1rem] leading-4 ${open ? 'border-text' : 'border-grey-02'}`}
+          className={`flex shrink-0 items-center gap-[6px] whitespace-nowrap rounded-[6px] border px-1.5 py-[3px] text-[1rem] leading-4 ${open ? 'border-text' : 'border-grey-02'}`}
         >
           <Icon color={open ? 'text' : 'grey-04'} className="h-3 w-3" />
           {label}


### PR DESCRIPTION
## Summary
- Property-type pill (e.g. `Date & Time`) wrapped onto two lines when the metadata header got tight.
- Added `whitespace-nowrap` + `shrink-0` to the editable `RenderableTypeDropdown` trigger and both read-only `DataTypePill` variants so the pill grows to fit its label instead of being squeezed by flex siblings.

## Test plan
- [ ] Open a Property entity with a multi-word type (e.g. `Date & Time`) and confirm the pill renders on a single line in both editable and read-only modes.
- [ ] Narrow the viewport — pill should stay single-line and not be squeezed by sibling pills.