### PR TITLE
[codex] Fix property group deletion and isType grouping

### DIFF
--- a/apps/web/core/database/entities.test.ts
+++ b/apps/web/core/database/entities.test.ts
@@ -1,0 +1,309 @@
+import { SystemIds } from '@geoprotocol/geo-sdk';
+
+import { Effect } from 'effect';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { PROPERTY_GROUPS_PROPERTY } from '../constants';
+import { Entity, Property, Relation } from '../types';
+import { getSchemaWithGroupsFromTypeIdsAndRelations } from './entities';
+
+const mocks = vi.hoisted(() => ({
+  entitiesById: new Map<string, Entity>(),
+  propertiesById: new Map<string, Property>(),
+  findMany: vi.fn(),
+  getProperties: vi.fn(),
+}));
+
+vi.mock('../sync/orm', () => ({
+  E: {
+    findMany: mocks.findMany,
+  },
+}));
+
+vi.mock('../io/queries', () => ({
+  getProperties: mocks.getProperties,
+}));
+
+vi.mock('../sync/use-sync-engine', () => ({
+  store: {},
+}));
+
+vi.mock('../query-client', () => ({
+  queryClient: {},
+}));
+
+const spaceId = 'space-1';
+
+function property(id: string, name: string, options: Partial<Property> = {}): Property {
+  return {
+    id,
+    name,
+    dataType: 'TEXT',
+    ...options,
+  };
+}
+
+function entity(id: string, name: string, relations: Relation[] = [], spaces: string[] = [spaceId]): Entity {
+  return {
+    id,
+    name,
+    description: null,
+    spaces,
+    types: [],
+    values: [],
+    relations,
+  };
+}
+
+function relation(params: {
+  id: string;
+  from: string;
+  type: string;
+  to: string;
+  toName?: string | null;
+  position?: string | null;
+  spaceId?: string;
+}): Relation {
+  return {
+    id: params.id,
+    entityId: `${params.id}-entity`,
+    type: { id: params.type, name: params.type },
+    fromEntity: { id: params.from, name: params.from },
+    toEntity: { id: params.to, name: params.toName ?? params.to, value: params.to },
+    renderableType: 'RELATION',
+    position: params.position ?? '1',
+    verified: false,
+    spaceId: params.spaceId ?? spaceId,
+  };
+}
+
+describe('getSchemaWithGroupsFromTypeIdsAndRelations', () => {
+  beforeEach(() => {
+    mocks.entitiesById.clear();
+    mocks.propertiesById.clear();
+    mocks.findMany.mockReset();
+    mocks.getProperties.mockReset();
+
+    mocks.findMany.mockImplementation(async ({ where }: { where: { id?: { in?: string[] } } }) => {
+      const ids = where.id?.in ?? [];
+      return ids.map(id => mocks.entitiesById.get(id)).filter((item): item is Entity => item != null);
+    });
+
+    mocks.getProperties.mockImplementation((ids: string[]) =>
+      Effect.succeed(ids.map(id => mocks.propertiesById.get(id)).filter((item): item is Property => item != null))
+    );
+  });
+
+  it('keeps type properties ungrouped when only group relations are removed', async () => {
+    mocks.propertiesById.set('property-a', property('property-a', 'Property A'));
+    mocks.propertiesById.set('property-b', property('property-b', 'Property B'));
+    mocks.entitiesById.set(
+      'type',
+      entity('type', 'Type', [
+        relation({ id: 'type-property-a', from: 'type', type: SystemIds.PROPERTIES, to: 'property-a', position: '1' }),
+        relation({ id: 'type-property-b', from: 'type', type: SystemIds.PROPERTIES, to: 'property-b', position: '2' }),
+      ])
+    );
+
+    const result = await getSchemaWithGroupsFromTypeIdsAndRelations([{ id: 'type', spaceId }], []);
+
+    expect(result.propertyGroups).toEqual([]);
+    expect(result.ungroupedPropertyIds).toEqual(['property-a', 'property-b']);
+    expect(result.hasPropertyGroups).toBe(false);
+  });
+
+  it('renders isType properties as a named group even without explicit property groups', async () => {
+    mocks.propertiesById.set(
+      'is-type-property',
+      property('is-type-property', 'Is type property', { dataType: 'RELATION', isType: true })
+    );
+    mocks.propertiesById.set('target-property', property('target-property', 'Target property'));
+    mocks.entitiesById.set(
+      'type',
+      entity('type', 'Type', [
+        relation({ id: 'type-is-type-property', from: 'type', type: SystemIds.PROPERTIES, to: 'is-type-property' }),
+      ])
+    );
+    mocks.entitiesById.set(
+      'target',
+      entity('target', 'Target type', [
+        relation({ id: 'target-property-relation', from: 'target', type: SystemIds.PROPERTIES, to: 'target-property' }),
+      ])
+    );
+
+    const result = await getSchemaWithGroupsFromTypeIdsAndRelations(
+      [{ id: 'type', spaceId }],
+      [
+        relation({
+          id: 'entity-is-type-relation',
+          from: 'entity',
+          type: 'is-type-property',
+          to: 'target',
+          toName: 'Target type',
+        }),
+      ]
+    );
+
+    expect(result.propertyGroups).toEqual([
+      {
+        id: 'is-type-entity-is-type-relation',
+        name: 'Target type',
+        collapsed: false,
+        propertyIds: ['target-property'],
+        source: 'isType',
+      },
+    ]);
+    expect(result.ungroupedPropertyIds).toEqual(['is-type-property']);
+    expect(result.hasPropertyGroups).toBe(true);
+  });
+
+  it('places isType groups directly after the explicit group containing the triggering property', async () => {
+    mocks.propertiesById.set(
+      'is-type-property',
+      property('is-type-property', 'Is type property', { dataType: 'RELATION', isType: true })
+    );
+    mocks.propertiesById.set('other-property', property('other-property', 'Other property'));
+    mocks.propertiesById.set('target-property', property('target-property', 'Target property'));
+    mocks.entitiesById.set(
+      'type',
+      entity('type', 'Type', [
+        relation({
+          id: 'type-is-type-property',
+          from: 'type',
+          type: SystemIds.PROPERTIES,
+          to: 'is-type-property',
+          position: '1',
+        }),
+        relation({
+          id: 'type-other-property',
+          from: 'type',
+          type: SystemIds.PROPERTIES,
+          to: 'other-property',
+          position: '2',
+        }),
+        relation({ id: 'type-group', from: 'type', type: PROPERTY_GROUPS_PROPERTY, to: 'group', toName: 'Main group' }),
+      ])
+    );
+    mocks.entitiesById.set(
+      'group',
+      entity('group', 'Main group', [
+        relation({ id: 'group-is-type-property', from: 'group', type: SystemIds.PROPERTIES, to: 'is-type-property' }),
+      ])
+    );
+    mocks.entitiesById.set(
+      'target',
+      entity('target', 'Target type', [
+        relation({ id: 'target-property-relation', from: 'target', type: SystemIds.PROPERTIES, to: 'target-property' }),
+      ])
+    );
+
+    const result = await getSchemaWithGroupsFromTypeIdsAndRelations(
+      [{ id: 'type', spaceId }],
+      [
+        relation({
+          id: 'entity-is-type-relation',
+          from: 'entity',
+          type: 'is-type-property',
+          to: 'target',
+          toName: 'Target type',
+        }),
+      ]
+    );
+
+    expect(result.propertyGroups.map(group => group.id)).toEqual(['group', 'is-type-entity-is-type-relation']);
+    expect(result.propertyGroups[0]).toMatchObject({
+      id: 'group',
+      name: 'Main group',
+      propertyIds: ['is-type-property'],
+      source: 'type',
+    });
+    expect(result.propertyGroups[1]).toMatchObject({
+      id: 'is-type-entity-is-type-relation',
+      name: 'Target type',
+      propertyIds: ['target-property'],
+      source: 'isType',
+    });
+    expect(result.ungroupedPropertyIds).toEqual(['other-property']);
+  });
+
+  it('resolves isType targets through their top-ranked space when no toSpace is defined', async () => {
+    const roleSpaceId = 'role-space';
+    const entitiesByIdAndSpace = new Map<string, Entity>();
+    mocks.findMany.mockImplementation(
+      async ({ where, spaceId: fetchedSpaceId }: { where: { id?: { in?: string[] } }; spaceId?: string }) => {
+        const ids = where.id?.in ?? [];
+        return ids
+          .map(id => entitiesByIdAndSpace.get(`${id}:${fetchedSpaceId ?? ''}`) ?? entitiesByIdAndSpace.get(`${id}:`))
+          .filter((item): item is Entity => item != null);
+      }
+    );
+
+    mocks.propertiesById.set(
+      'roles-property',
+      property('roles-property', 'Roles', { dataType: 'RELATION', isType: true })
+    );
+    mocks.propertiesById.set('related-projects', property('related-projects', 'Related projects'));
+    mocks.entitiesById.set(
+      'type',
+      entity('type', 'Type', [
+        relation({ id: 'type-roles-property', from: 'type', type: SystemIds.PROPERTIES, to: 'roles-property' }),
+      ])
+    );
+    entitiesByIdAndSpace.set(
+      'type:space-1',
+      entity('type', 'Type', [
+        relation({ id: 'type-roles-property', from: 'type', type: SystemIds.PROPERTIES, to: 'roles-property' }),
+      ])
+    );
+    entitiesByIdAndSpace.set(
+      'product-lead:space-1',
+      entity(
+        'product-lead',
+        'Product lead',
+        [relation({ id: 'role-kind', from: 'product-lead', type: SystemIds.TYPES_PROPERTY, to: 'role', spaceId })],
+        [roleSpaceId, spaceId]
+      )
+    );
+    entitiesByIdAndSpace.set(
+      'product-lead:',
+      entity(
+        'product-lead',
+        'Product lead',
+        [
+          relation({
+            id: 'related-projects-relation',
+            from: 'product-lead',
+            type: SystemIds.PROPERTIES,
+            to: 'related-projects',
+            spaceId: roleSpaceId,
+          }),
+        ],
+        [roleSpaceId, spaceId]
+      )
+    );
+
+    const result = await getSchemaWithGroupsFromTypeIdsAndRelations(
+      [{ id: 'type', spaceId }],
+      [
+        relation({
+          id: 'entity-role-relation',
+          from: 'entity',
+          type: 'roles-property',
+          to: 'product-lead',
+          toName: 'Product lead',
+        }),
+      ]
+    );
+
+    expect(result.propertyGroups).toEqual([
+      {
+        id: 'is-type-entity-role-relation',
+        name: 'Product lead',
+        collapsed: false,
+        propertyIds: ['related-projects'],
+        source: 'isType',
+      },
+    ]);
+    expect(result.schema.map(item => item.id)).toContain('related-projects');
+  });
+});

--- a/apps/web/core/database/entities.ts
+++ b/apps/web/core/database/entities.ts
@@ -86,6 +86,24 @@ function readBooleanEntityValue(entity: Entity, propertyId: string, preferredSpa
   return normalized === '1' || normalized === 'true' || normalized === 'yes';
 }
 
+function selectRelationsByType(
+  entity: Entity,
+  relationTypeId: string,
+  preferredSpaceId?: string
+): Relation[] {
+  const relationsOfType = entity.relations.filter(r => r.type.id === relationTypeId);
+  if (!preferredSpaceId) return relationsOfType;
+
+  const preferredSpaceRelations = relationsOfType.filter(r => r.spaceId === preferredSpaceId);
+  if (preferredSpaceRelations.length > 0) return preferredSpaceRelations;
+
+  const topSpaceId = entity.spaces[0];
+  if (!topSpaceId || topSpaceId === preferredSpaceId) return relationsOfType;
+
+  const topSpaceRelations = relationsOfType.filter(r => r.spaceId === topSpaceId);
+  return topSpaceRelations.length > 0 ? topSpaceRelations : relationsOfType;
+}
+
 export function useEntity(options: UseEntityOptions): EntityWithSchema & { isLoading: boolean } {
   const { spaceId, id } = options;
 
@@ -185,7 +203,8 @@ export const DEFAULT_ENTITY_SCHEMA: Property[] = [
  */
 async function fetchEntitiesWithRelations(
   ids: string[],
-  spaceByEntity: Map<string, string | undefined>
+  spaceByEntity: Map<string, string | undefined>,
+  options: { requiredRelationTypeId?: string } = {}
 ): Promise<Entity[]> {
   if (ids.length === 0) return [];
 
@@ -211,10 +230,13 @@ async function fetchEntitiesWithRelations(
     )
   ).flat();
 
-  // Re-fetch entities that have no relations and whose top-ranked space
-  // differs from the space we fetched with (cross-space type resolution).
+  // Re-fetch entities whose requested space did not include the relations we
+  // need and whose top-ranked space differs from the space we fetched with.
   const missingEntities = entities.filter(entity => {
-    if (entity.relations.length > 0) return false;
+    const hasRequiredRelations = options.requiredRelationTypeId
+      ? entity.relations.some(r => r.type.id === options.requiredRelationTypeId)
+      : entity.relations.length > 0;
+    if (hasRequiredRelations) return false;
     const fetchedSpace = spaceByEntity.get(entity.id);
     return entity.spaces.length > 0 && entity.spaces[0] !== fetchedSpace;
   });
@@ -378,20 +400,21 @@ export async function getSchemaFromTypeIdsAndRelations(
 
   if (isTypePropertyIds.size === 0) return baseSchema;
 
-  // Collect target entity IDs from matching IS_TYPE relations,
-  // preserving the relation's spaceId for per-target filtering
+  // Collect target entity IDs from matching IS_TYPE relations. A toSpaceId is
+  // an explicit target-space override; otherwise resolve via the target's own
+  // top-ranked space.
   const isTypeRelations = relations.filter(r => isTypePropertyIds.has(r.type.id));
   const targetIds = [...new Set(isTypeRelations.map(r => r.toEntity.id))];
-  const spaceByTarget = new Map(isTypeRelations.map(r => [r.toEntity.id, r.toSpaceId ?? r.spaceId]));
+  const spaceByTarget = new Map(isTypeRelations.map(r => [r.toEntity.id, r.toSpaceId]));
 
-  const targetEntities = await fetchEntitiesWithRelations(targetIds, spaceByTarget);
+  const targetEntities = await fetchEntitiesWithRelations(targetIds, spaceByTarget, {
+    requiredRelationTypeId: SystemIds.PROPERTIES,
+  });
   const targetEntitiesOrdered = orderEntitiesByIdList(targetIds, targetEntities);
 
   const additionalPropertyIds = targetEntitiesOrdered.flatMap(entity => {
     const targetSpaceId = spaceByTarget.get(entity.id) ?? entity.spaces[0];
-    const props = entity.relations.filter(
-      r => r.type.id === SystemIds.PROPERTIES && (targetSpaceId ? r.spaceId === targetSpaceId : true)
-    );
+    const props = selectRelationsByType(entity, SystemIds.PROPERTIES, targetSpaceId);
     return sortRelations(props).map(r => r.toEntity.id);
   });
 
@@ -440,7 +463,8 @@ export async function getSchemaWithGroupsFromTypeIdsAndRelations(
   );
   const groupEntitiesById = new Map(groupEntities.map(entity => [entity.id, entity]));
 
-  const propertyGroups: SchemaPropertyGroup[] = [];
+  let propertyGroups: SchemaPropertyGroup[] = [];
+  const groupIdByPropertyId = new Map<string, string>();
   const globalSeenPropertyIds = new Set<string>();
   const ungroupedPropertyIds: string[] = [];
 
@@ -492,6 +516,12 @@ export async function getSchemaWithGroupsFromTypeIdsAndRelations(
         propertyIds: uniqueGroupPropertyIds,
         source: 'type',
       });
+
+      for (const propertyId of uniqueGroupPropertyIds) {
+        if (!groupIdByPropertyId.has(propertyId)) {
+          groupIdByPropertyId.set(propertyId, groupId);
+        }
+      }
     }
 
     for (const propertyId of typePropertyIds) {
@@ -509,28 +539,28 @@ export async function getSchemaWithGroupsFromTypeIdsAndRelations(
     const uniqueIsTypeRefs = dedupeWith(
       orderedIsTypeRelations.map(r => ({
         relationId: r.id,
+        triggerPropertyId: r.type.id,
         targetId: r.toEntity.id,
         targetName: r.toEntity.name,
-        spaceId: r.toSpaceId ?? r.spaceId,
+        spaceId: r.toSpaceId,
       })),
       (a, b) => a.targetId === b.targetId && a.spaceId === b.spaceId
     );
 
     const isTypeSpaceByTarget = new Map(uniqueIsTypeRefs.map(r => [r.targetId, r.spaceId]));
-    const isTypeEntities = await fetchEntitiesWithRelations(
-      uniqueIsTypeRefs.map(r => r.targetId),
-      isTypeSpaceByTarget
-    );
+    const isTypeEntities = await fetchEntitiesWithRelations(uniqueIsTypeRefs.map(r => r.targetId), isTypeSpaceByTarget, {
+      requiredRelationTypeId: SystemIds.PROPERTIES,
+    });
     const isTypeEntitiesById = new Map(isTypeEntities.map(entity => [entity.id, entity]));
+    const isTypeGroupsByParentGroupId = new Map<string, SchemaPropertyGroup[]>();
+    const ungroupedIsTypeGroups: SchemaPropertyGroup[] = [];
 
     for (const relation of uniqueIsTypeRefs) {
       const targetEntity = isTypeEntitiesById.get(relation.targetId);
       if (!targetEntity) continue;
 
       const targetSpaceId = relation.spaceId ?? targetEntity.spaces[0];
-      const targetPropertyRelations = targetEntity.relations.filter(
-        r => r.type.id === SystemIds.PROPERTIES && (targetSpaceId ? r.spaceId === targetSpaceId : true)
-      );
+      const targetPropertyRelations = selectRelationsByType(targetEntity, SystemIds.PROPERTIES, targetSpaceId);
       const targetPropertyIds = sortRelations(targetPropertyRelations).map(r => r.toEntity.id);
       const uniqueTargetPropertyIds = targetPropertyIds.filter(propertyId => {
         if (globalSeenPropertyIds.has(propertyId)) return false;
@@ -538,35 +568,33 @@ export async function getSchemaWithGroupsFromTypeIdsAndRelations(
         return true;
       });
 
-      propertyGroups.push({
+      const isTypeGroup: SchemaPropertyGroup = {
         id: `is-type-${relation.relationId}`,
         name: relation.targetName ?? readEntityValue(targetEntity, SystemIds.NAME_PROPERTY, targetSpaceId),
         collapsed: false,
         propertyIds: uniqueTargetPropertyIds,
         source: 'isType',
-      });
+      };
+
+      const parentGroupId = groupIdByPropertyId.get(relation.triggerPropertyId);
+      if (parentGroupId) {
+        const groups = isTypeGroupsByParentGroupId.get(parentGroupId) ?? [];
+        groups.push(isTypeGroup);
+        isTypeGroupsByParentGroupId.set(parentGroupId, groups);
+      } else {
+        ungroupedIsTypeGroups.push(isTypeGroup);
+      }
+    }
+
+    if (isTypeGroupsByParentGroupId.size > 0 || ungroupedIsTypeGroups.length > 0) {
+      propertyGroups = [
+        ...propertyGroups.flatMap(group => [group, ...(isTypeGroupsByParentGroupId.get(group.id) ?? [])]),
+        ...ungroupedIsTypeGroups,
+      ];
     }
   }
 
-  // Synthetic isType groups are only meaningful as a layout hint when at least one
-  // real (user-defined) group exists. Otherwise, fold their properties into the
-  // ungrouped list so the entity panel renders flat.
-  const hasRealGroups = propertyGroups.some(group => group.source === 'type');
-  let effectivePropertyGroups = propertyGroups;
-  if (!hasRealGroups) {
-    const syntheticPropertyIds = propertyGroups
-      .filter(group => group.source === 'isType')
-      .flatMap(group => group.propertyIds);
-    const ungroupedSeen = new Set(ungroupedPropertyIds);
-    for (const propertyId of syntheticPropertyIds) {
-      if (ungroupedSeen.has(propertyId)) continue;
-      ungroupedSeen.add(propertyId);
-      ungroupedPropertyIds.push(propertyId);
-    }
-    effectivePropertyGroups = [];
-  }
-
-  const groupedPropertyIds = effectivePropertyGroups.flatMap(group => group.propertyIds);
+  const groupedPropertyIds = propertyGroups.flatMap(group => group.propertyIds);
   const groupedPropertyIdSet = new Set(groupedPropertyIds);
   const ungroupedSet = new Set(ungroupedPropertyIds);
 
@@ -603,8 +631,8 @@ export async function getSchemaWithGroupsFromTypeIdsAndRelations(
 
   return {
     schema: orderedSchema,
-    propertyGroups: effectivePropertyGroups,
+    propertyGroups,
     ungroupedPropertyIds,
-    hasPropertyGroups: effectivePropertyGroups.length > 0,
+    hasPropertyGroups: propertyGroups.length > 0,
   };
 }

--- a/apps/web/core/sync/store.test.ts
+++ b/apps/web/core/sync/store.test.ts
@@ -798,6 +798,70 @@ describe('GeoStore', () => {
         spaceId: 'space-1',
       });
     });
+
+    it('should immediately restore a locally deleted remote relation from the synced baseline', () => {
+      const remoteRelation: Relation = {
+        ...mockRelation1,
+        type: { id: SystemIds.PROPERTIES, name: 'Properties' },
+        isLocal: false,
+        hasBeenPublished: true,
+        isDeleted: false,
+      };
+      const localDeletedRelation: Relation = {
+        ...remoteRelation,
+        isLocal: true,
+        hasBeenPublished: false,
+        isDeleted: true,
+      };
+
+      syncedEntities.set('entity-1', {
+        ...mockEntity1,
+        relations: [remoteRelation],
+      });
+      reactiveRelations.set([localDeletedRelation]);
+
+      store.clearLocalChangesByIds({
+        spaceId: 'space-1',
+        valueIds: [],
+        relationIds: [remoteRelation.id],
+      });
+
+      expect(reactiveRelations.get()).toEqual([remoteRelation]);
+    });
+  });
+
+  describe('clearLocalChangesForSpace', () => {
+    it('should immediately restore locally deleted remote type properties from the synced baseline', () => {
+      const remotePropertyRelation: Relation = {
+        ...mockRelation1,
+        id: 'type-property-relation',
+        type: { id: SystemIds.PROPERTIES, name: 'Properties' },
+        toEntity: { id: 'property-1', name: 'Property 1', value: 'property-1' },
+        isLocal: false,
+        hasBeenPublished: true,
+        isDeleted: false,
+      };
+      const localDeletedPropertyRelation: Relation = {
+        ...remotePropertyRelation,
+        isLocal: true,
+        hasBeenPublished: false,
+        isDeleted: true,
+      };
+
+      syncedEntities.set('entity-1', {
+        ...mockEntity1,
+        relations: [remotePropertyRelation],
+      });
+      reactiveRelations.set([localDeletedPropertyRelation]);
+
+      store.clearLocalChangesForSpace('space-1');
+
+      expect(reactiveRelations.get()).toEqual([remotePropertyRelation]);
+      expect(mockStream.emit).toHaveBeenCalledWith({
+        type: GeoEventStream.HYDRATE,
+        entities: ['entity-1'],
+      });
+    });
   });
 
   describe('findReferencingEntities', () => {

--- a/apps/web/core/sync/store.ts
+++ b/apps/web/core/sync/store.ts
@@ -262,7 +262,9 @@ export class GeoStore {
     // Remove local relations for this space
     reactiveRelations.set(prev => prev.filter(r => !localRelationIds.has(r.id)));
 
-    // Re-hydrate affected entities to restore their server state
+    this.restoreSyncedBaselines(affectedEntityIds);
+
+    // Re-hydrate affected entities to refresh their server state
     if (affectedEntityIds.size > 0) {
       this.stream.emit({ type: GeoEventStream.HYDRATE, entities: [...affectedEntityIds] });
     }
@@ -300,6 +302,8 @@ export class GeoStore {
     reactiveValues.set(prev => prev.filter(v => !(valueIdsSet.has(v.id) && v.isLocal === true)));
     reactiveRelations.set(prev => prev.filter(r => !(relationIdsSet.has(r.id) && r.isLocal === true)));
 
+    this.restoreSyncedBaselines(affectedEntityIds);
+
     if (affectedEntityIds.size > 0) {
       this.stream.emit({ type: GeoEventStream.HYDRATE, entities: [...affectedEntityIds] });
     }
@@ -317,6 +321,15 @@ export class GeoStore {
     }
 
     this.hydrateReactiveState(entities);
+  }
+
+  private restoreSyncedBaselines(entityIds: Set<string>) {
+    if (entityIds.size === 0) return;
+
+    const baselines = [...entityIds]
+      .map(id => syncedEntities.get(id))
+      .filter((entity): entity is Entity => entity != null);
+    this.hydrateReactiveState(baselines);
   }
 
   private hydrateReactiveState(entities: Entity[]) {

--- a/apps/web/partials/entity-page/readable-entity-page.tsx
+++ b/apps/web/partials/entity-page/readable-entity-page.tsx
@@ -13,7 +13,7 @@ import {
   VENUE_PROPERTY,
 } from '~/core/constants';
 import { useRenderedPropertiesWithContent } from '~/core/hooks/use-renderables';
-import { useEntitySchemaWithGroups } from '~/core/state/entity-page-store/entity-store';
+import { useEntitySchemaWithGroups, useEntityTypes } from '~/core/state/entity-page-store/entity-store';
 import {
   useHydrateEntity,
   useQueryEntity,
@@ -47,8 +47,6 @@ interface Props {
 }
 
 const SKIPPED_PROPERTIES: string[] = [
-  SystemIds.PROPERTIES,
-  PROPERTY_GROUPS_PROPERTY,
   SystemIds.TYPES_PROPERTY,
   SystemIds.NAME_PROPERTY,
   SystemIds.DESCRIPTION_PROPERTY,
@@ -60,10 +58,24 @@ const SKIPPED_PROPERTIES: string[] = [
   SCORE_SYSTEM_PROPERTY,
 ];
 
-function countRenderableProperty(renderedProperties: string[]): number {
+function useReadableSkippedPropertyIds(entityId: string, spaceId: string): Set<string> {
+  const entityTypes = useEntityTypes(entityId, spaceId);
+  const isTypeEntity = entityTypes.some(type => type.id === SystemIds.SCHEMA_TYPE);
+
+  return React.useMemo(() => {
+    const skipped = new Set(SKIPPED_PROPERTIES);
+    if (isTypeEntity) {
+      skipped.add(SystemIds.PROPERTIES);
+      skipped.add(PROPERTY_GROUPS_PROPERTY);
+    }
+    return skipped;
+  }, [isTypeEntity]);
+}
+
+function countRenderableProperty(renderedProperties: string[], skippedPropertyIds: Set<string>): number {
   let count = 0;
   renderedProperties.forEach(propertyId => {
-    if (!SKIPPED_PROPERTIES.includes(propertyId)) {
+    if (!skippedPropertyIds.has(propertyId)) {
       count++;
     }
   });
@@ -72,7 +84,8 @@ function countRenderableProperty(renderedProperties: string[]): number {
 
 export function useReadableEntityHasContent(entityId: string, spaceId: string): boolean {
   const renderedProperties = useRenderedPropertiesWithContent(entityId, spaceId);
-  return countRenderableProperty(Object.keys(renderedProperties)) > 0;
+  const skippedPropertyIds = useReadableSkippedPropertyIds(entityId, spaceId);
+  return countRenderableProperty(Object.keys(renderedProperties), skippedPropertyIds) > 0;
 }
 
 export function ReadableEntityPage({ id, spaceId }: Props) {
@@ -88,6 +101,7 @@ export function ReadableEntityPage({ id, spaceId }: Props) {
 export function ReadableEntityProperties({ id: entityId, spaceId }: Props) {
   const renderedProperties = useRenderedPropertiesWithContent(entityId, spaceId);
   const schemaWithGroups = useEntitySchemaWithGroups(entityId, spaceId);
+  const skippedPropertyIds = useReadableSkippedPropertyIds(entityId, spaceId);
   const [collapsedGroups, setCollapsedGroups] = React.useState<Record<string, boolean>>({});
 
   React.useEffect(() => {
@@ -110,7 +124,7 @@ export function ReadableEntityProperties({ id: entityId, spaceId }: Props) {
 
   const groupedSections = React.useMemo(() => {
     const visiblePropertyIds = new Set(
-      Object.keys(renderedProperties).filter(propertyId => !SKIPPED_PROPERTIES.includes(propertyId))
+      Object.keys(renderedProperties).filter(propertyId => !skippedPropertyIds.has(propertyId))
     );
 
     if (!schemaWithGroups.hasPropertyGroups) {
@@ -155,9 +169,9 @@ export function ReadableEntityProperties({ id: entityId, spaceId }: Props) {
       groups,
       ungrouped: orderedUngrouped,
     };
-  }, [renderedProperties, schemaWithGroups]);
+  }, [renderedProperties, schemaWithGroups, skippedPropertyIds]);
 
-  if (countRenderableProperty(Object.keys(renderedProperties)) <= 0) {
+  if (countRenderableProperty(Object.keys(renderedProperties), skippedPropertyIds) <= 0) {
     return null;
   }
 

--- a/apps/web/partials/entity-page/type-property-groups-editor.tsx
+++ b/apps/web/partials/entity-page/type-property-groups-editor.tsx
@@ -2,19 +2,25 @@
 
 import {
   type CollisionDetection,
-  closestCenter,
   DndContext,
   DragEndEvent,
-  DragOverlay,
   DragOverEvent,
+  DragOverlay,
   DragStartEvent,
   PointerSensor,
+  closestCenter,
   pointerWithin,
   useDroppable,
   useSensor,
   useSensors,
 } from '@dnd-kit/core';
-import { SortableContext, arrayMove, rectSortingStrategy, useSortable, verticalListSortingStrategy } from '@dnd-kit/sortable';
+import {
+  SortableContext,
+  arrayMove,
+  rectSortingStrategy,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { Position, SystemIds } from '@geoprotocol/geo-sdk/lite';
 
@@ -24,18 +30,18 @@ import { COLLAPSED_PROPERTY, PROPERTY_GROUPS_PROPERTY, PROPERTY_GROUP_TYPE } fro
 import { useCreateProperty } from '~/core/hooks/use-create-property';
 import { ID } from '~/core/id';
 import { useMutate } from '~/core/sync/use-mutate';
-import { useRelations, useValue } from '~/core/sync/use-store';
+import { useRelations, useValue, useValues } from '~/core/sync/use-store';
 import { Relation } from '~/core/types';
 import { sortRelations } from '~/core/utils/utils';
 
 import { Checkbox, getChecked } from '~/design-system/checkbox';
-import { Create } from '~/design-system/icons/create';
+import { LinkableRelationChip } from '~/design-system/chip';
 import { ChevronDownSmall } from '~/design-system/icons/chevron-down-small';
+import { Create } from '~/design-system/icons/create';
 import { OrderDots } from '~/design-system/icons/order-dots';
 import { Trash } from '~/design-system/icons/trash';
 import { SelectEntityAsPopover } from '~/design-system/select-entity-dialog';
 import { Text } from '~/design-system/text';
-import { LinkableRelationChip } from '~/design-system/chip';
 
 import { InlinePropertyTypeIcon } from '~/partials/entity-page/inline-property-type-icon';
 
@@ -92,12 +98,15 @@ export function TypePropertyGroupsEditor({ entityId, spaceId }: EditorProps) {
   const [activePropertyDragId, setActivePropertyDragId] = React.useState<string | null>(null);
   const [activeGroupDragId, setActiveGroupDragId] = React.useState<string | null>(null);
   const [groupOverlayWidths, setGroupOverlayWidths] = React.useState<Record<string, number>>({});
+  const [focusGroupNameId, setFocusGroupNameId] = React.useState<string | null>(null);
   const lastOverIdRef = React.useRef<string | null>(null);
 
   const typePropertyRelations = sortRelations(
     useRelations({
       selector: relation =>
-        relation.fromEntity.id === entityId && relation.spaceId === spaceId && relation.type.id === SystemIds.PROPERTIES,
+        relation.fromEntity.id === entityId &&
+        relation.spaceId === spaceId &&
+        relation.type.id === SystemIds.PROPERTIES,
     })
   );
 
@@ -110,12 +119,19 @@ export function TypePropertyGroupsEditor({ entityId, spaceId }: EditorProps) {
     })
   );
 
-  const groupIds = React.useMemo(() => new Set(propertyGroupRelations.map(relation => relation.toEntity.id)), [propertyGroupRelations]);
-  const allGroupPropertyRelations = useRelations({
-    selector: relation =>
-      relation.spaceId === spaceId &&
-      relation.type.id === SystemIds.PROPERTIES &&
-      groupIds.has(relation.fromEntity.id),
+  const groupIds = React.useMemo(
+    () => new Set(propertyGroupRelations.map(relation => relation.toEntity.id)),
+    [propertyGroupRelations]
+  );
+  const allGroupOutgoingRelations = useRelations({
+    selector: relation => relation.spaceId === spaceId && groupIds.has(relation.fromEntity.id),
+  });
+  const allGroupPropertyRelations = React.useMemo(
+    () => allGroupOutgoingRelations.filter(relation => relation.type.id === SystemIds.PROPERTIES),
+    [allGroupOutgoingRelations]
+  );
+  const allGroupValues = useValues({
+    selector: value => value.spaceId === spaceId && groupIds.has(value.entity.id),
   });
 
   const groupContainers: GroupContainer[] = React.useMemo(
@@ -163,9 +179,13 @@ export function TypePropertyGroupsEditor({ entityId, spaceId }: EditorProps) {
     }
 
     // Keep any remaining current relations at the end in their current order.
-    const targetIds = [...desiredExistingIds, ...currentIds.filter(propertyId => !desiredExistingIds.includes(propertyId))];
+    const targetIds = [
+      ...desiredExistingIds,
+      ...currentIds.filter(propertyId => !desiredExistingIds.includes(propertyId)),
+    ];
     const sameOrder =
-      currentIds.length === targetIds.length && currentIds.every((propertyId, index) => propertyId === targetIds[index]);
+      currentIds.length === targetIds.length &&
+      currentIds.every((propertyId, index) => propertyId === targetIds[index]);
     if (sameOrder) return;
 
     targetIds.forEach((propertyId, index) => {
@@ -211,9 +231,7 @@ export function TypePropertyGroupsEditor({ entityId, spaceId }: EditorProps) {
     // When dragging whole groups, only collide against other group rows.
     // Ignoring nested property droppables prevents jitter/glitchy snapping.
     if (draggedGroupRelationId) {
-      const groupOnlyContainers = args.droppableContainers.filter(container =>
-        parseGroupDragId(String(container.id))
-      );
+      const groupOnlyContainers = args.droppableContainers.filter(container => parseGroupDragId(String(container.id)));
       return closestCenter({
         ...args,
         droppableContainers: groupOnlyContainers,
@@ -301,14 +319,16 @@ export function TypePropertyGroupsEditor({ entityId, spaceId }: EditorProps) {
       fromEntity: { id: entityId, name: null },
       toEntity: { id: groupEntityId, name: null, value: groupEntityId },
     });
+    setFocusGroupNameId(groupEntityId);
   };
 
   const onDeleteGroup = (groupRelation: Relation) => {
     const groupId = groupRelation.toEntity.id;
-    const groupPropertyRelations = allGroupPropertyRelations.filter(relation => relation.fromEntity.id === groupId);
-    const groupedPropertyIds = new Set(groupPropertyRelations.map(relation => relation.toEntity.id));
-    const typeRelationsToDelete = typePropertyRelations.filter(relation => groupedPropertyIds.has(relation.toEntity.id));
-    storage.relations.deleteMany([...groupPropertyRelations, ...typeRelationsToDelete, groupRelation]);
+    const groupRelations = allGroupOutgoingRelations.filter(relation => relation.fromEntity.id === groupId);
+    const groupValues = allGroupValues.filter(value => value.entity.id === groupId);
+
+    storage.relations.deleteMany([...groupRelations, groupRelation]);
+    storage.values.deleteMany(groupValues);
   };
 
   const onAddPropertyToGroup = (groupId: string, property: { id: string; name: string | null }) => {
@@ -320,7 +340,9 @@ export function TypePropertyGroupsEditor({ entityId, spaceId }: EditorProps) {
     );
     if (existing) return;
 
-    const groupRelations = sortRelations(allGroupPropertyRelations.filter(relation => relation.fromEntity.id === groupId));
+    const groupRelations = sortRelations(
+      allGroupPropertyRelations.filter(relation => relation.fromEntity.id === groupId)
+    );
     const lastPosition = groupRelations.at(-1)?.position ?? null;
     storage.relations.set({
       id: ID.createEntityId(),
@@ -409,10 +431,15 @@ export function TypePropertyGroupsEditor({ entityId, spaceId }: EditorProps) {
       : [];
     const destinationInsertIndex =
       overPropertyId && destinationGroupId
-        ? Math.max(0, destinationGroupRelations.findIndex(relation => relation.toEntity.id === overPropertyId))
+        ? Math.max(
+            0,
+            destinationGroupRelations.findIndex(relation => relation.toEntity.id === overPropertyId)
+          )
         : destinationGroupRelations.length;
     const destinationPrevPosition =
-      destinationGroupId && destinationInsertIndex > 0 ? destinationGroupRelations[destinationInsertIndex - 1]?.position : null;
+      destinationGroupId && destinationInsertIndex > 0
+        ? destinationGroupRelations[destinationInsertIndex - 1]?.position
+        : null;
     const destinationNextPosition =
       destinationGroupId && destinationInsertIndex < destinationGroupRelations.length
         ? destinationGroupRelations[destinationInsertIndex]?.position
@@ -510,9 +537,12 @@ export function TypePropertyGroupsEditor({ entityId, spaceId }: EditorProps) {
                     spaceId={spaceId}
                     groupRelation={container.groupRelation}
                     propertyRelations={container.propertyRelations}
+                    typePropertyRelations={typePropertyRelations}
                     onDeleteGroup={() => onDeleteGroup(container.groupRelation)}
                     onAddProperty={property => onAddPropertyToGroup(container.groupEntityId, property)}
                     createProperty={createProperty}
+                    autoFocusName={focusGroupNameId === container.groupEntityId}
+                    onNameAutoFocused={() => setFocusGroupNameId(current => (current === container.groupEntityId ? null : current))}
                     onMeasureWidth={width =>
                       setGroupOverlayWidths(previous => {
                         if (previous[container.groupRelation.id] === width) return previous;
@@ -540,7 +570,9 @@ export function TypePropertyGroupsEditor({ entityId, spaceId }: EditorProps) {
               ) : activeGroupDragId ? (
                 <GroupDragOverlayPreview
                   groupRelation={propertyGroupRelations.find(relation => relation.id === activeGroupDragId) ?? null}
-                  groupContainer={groupContainers.find(container => container.groupRelation.id === activeGroupDragId) ?? null}
+                  groupContainer={
+                    groupContainers.find(container => container.groupRelation.id === activeGroupDragId) ?? null
+                  }
                   spaceId={spaceId}
                   width={activeGroupDragId ? groupOverlayWidths[activeGroupDragId] : undefined}
                 />
@@ -566,10 +598,12 @@ function GroupDragOverlayPreview({
 }) {
   const groupId = groupRelation?.toEntity.id ?? '';
   const nameValue = useValue({
-    selector: value => value.entity.id === groupId && value.spaceId === spaceId && value.property.id === SystemIds.NAME_PROPERTY,
+    selector: value =>
+      value.entity.id === groupId && value.spaceId === spaceId && value.property.id === SystemIds.NAME_PROPERTY,
   });
   const collapsedValue = useValue({
-    selector: value => value.entity.id === groupId && value.spaceId === spaceId && value.property.id === COLLAPSED_PROPERTY,
+    selector: value =>
+      value.entity.id === groupId && value.spaceId === spaceId && value.property.id === COLLAPSED_PROPERTY,
   });
 
   if (!groupRelation || !groupContainer) return null;
@@ -624,17 +658,23 @@ function TypePropertyGroupCard({
   spaceId,
   groupRelation,
   propertyRelations,
+  typePropertyRelations,
   onDeleteGroup,
   onAddProperty,
   createProperty,
+  autoFocusName,
+  onNameAutoFocused,
   onMeasureWidth,
 }: {
   spaceId: string;
   groupRelation: Relation;
   propertyRelations: Relation[];
+  typePropertyRelations: Relation[];
   onDeleteGroup: () => void;
   onAddProperty: (property: { id: string; name: string | null }) => void;
   createProperty: CreatePropertyFn;
+  autoFocusName: boolean;
+  onNameAutoFocused: () => void;
   onMeasureWidth: (width: number) => void;
 }) {
   const { storage } = useMutate();
@@ -647,10 +687,12 @@ function TypePropertyGroupCard({
 
   const groupId = groupRelation.toEntity.id;
   const nameValue = useValue({
-    selector: value => value.entity.id === groupId && value.spaceId === spaceId && value.property.id === SystemIds.NAME_PROPERTY,
+    selector: value =>
+      value.entity.id === groupId && value.spaceId === spaceId && value.property.id === SystemIds.NAME_PROPERTY,
   });
   const collapsedValue = useValue({
-    selector: value => value.entity.id === groupId && value.spaceId === spaceId && value.property.id === COLLAPSED_PROPERTY,
+    selector: value =>
+      value.entity.id === groupId && value.spaceId === spaceId && value.property.id === COLLAPSED_PROPERTY,
   });
 
   const drop = useDroppable({ id: containerIdForGroup(groupId) });
@@ -665,7 +707,11 @@ function TypePropertyGroupCard({
   );
 
   return (
-    <div ref={setMeasuredNodeRef} style={style} className="group relative border-b border-grey-02 py-3 pr-4 pl-4 last:border-b-0">
+    <div
+      ref={setMeasuredNodeRef}
+      style={style}
+      className="group relative border-b border-grey-02 py-3 pr-4 pl-4 last:border-b-0"
+    >
       <button
         type="button"
         className="absolute top-4 -left-6 z-10 cursor-grab text-grey-04 opacity-0 transition-opacity group-hover:opacity-100 active:cursor-grabbing"
@@ -679,7 +725,9 @@ function TypePropertyGroupCard({
       <GroupHeader
         nameValue={nameValue?.value ?? ''}
         collapsedValue={collapsedValue?.value ?? '0'}
+        autoFocusName={autoFocusName}
         onChangeName={nextName => storage.entities.name.set(groupId, spaceId, nextName)}
+        onNameAutoFocused={onNameAutoFocused}
         onToggleCollapsed={() => {
           const currentlyCollapsed = getChecked(collapsedValue?.value ?? '0') === true;
           storage.values.set({
@@ -692,8 +740,11 @@ function TypePropertyGroupCard({
         onDeleteGroup={onDeleteGroup}
       />
 
-      <div ref={drop.setNodeRef} className={`${drop.isOver ? 'bg-grey-01' : ''} rounded-md pr-2 py-2`}>
-        <SortableContext items={propertyRelations.map(relation => propertyDragId(relation.toEntity.id))} strategy={rectSortingStrategy}>
+      <div ref={drop.setNodeRef} className={`${drop.isOver ? 'bg-grey-01' : ''} rounded-md py-2 pr-2`}>
+        <SortableContext
+          items={propertyRelations.map(relation => propertyDragId(relation.toEntity.id))}
+          strategy={rectSortingStrategy}
+        >
           <div className="grid grid-cols-[170px_minmax(0,1fr)] items-start gap-2">
             <div className="inline-flex items-center gap-2 pt-[3px]">
               <InlinePropertyTypeIcon dataType="RELATION" />
@@ -701,7 +752,32 @@ function TypePropertyGroupCard({
             </div>
             <div className="flex flex-wrap items-center gap-2">
               {propertyRelations.map(relation => (
-                <SortablePropertyRow key={relation.id} relation={relation} spaceId={spaceId} />
+                <SortablePropertyRow
+                  key={relation.id}
+                  relation={relation}
+                  spaceId={spaceId}
+                  onDelete={() => {
+                    const typeRelation = typePropertyRelations.find(
+                      typePropertyRelation => typePropertyRelation.toEntity.id === relation.toEntity.id
+                    );
+                    storage.relations.deleteMany(typeRelation ? [relation, typeRelation] : [relation]);
+                  }}
+                  onDone={result => {
+                    const typeRelation = typePropertyRelations.find(
+                      typePropertyRelation => typePropertyRelation.toEntity.id === relation.toEntity.id
+                    );
+                    storage.relations.update(relation, draft => {
+                      draft.toSpaceId = result.space;
+                      draft.verified = result.verified;
+                    });
+                    if (typeRelation) {
+                      storage.relations.update(typeRelation, draft => {
+                        draft.toSpaceId = result.space;
+                        draft.verified = result.verified;
+                      });
+                    }
+                  }}
+                />
               ))}
               <SelectEntityAsPopover
                 trigger={
@@ -739,16 +815,28 @@ function TypePropertyGroupCard({
 function GroupHeader({
   nameValue,
   collapsedValue,
+  autoFocusName,
   onChangeName,
+  onNameAutoFocused,
   onToggleCollapsed,
   onDeleteGroup,
 }: {
   nameValue: string;
   collapsedValue: string;
+  autoFocusName: boolean;
   onChangeName: (nextName: string) => void;
+  onNameAutoFocused: () => void;
   onToggleCollapsed: () => void;
   onDeleteGroup: () => void;
 }) {
+  const inputRef = React.useRef<HTMLInputElement | null>(null);
+
+  React.useEffect(() => {
+    if (!autoFocusName) return;
+    inputRef.current?.focus();
+    onNameAutoFocused();
+  }, [autoFocusName, onNameAutoFocused]);
+
   return (
     <div className="mb-2 grid grid-cols-[170px_minmax(0,1fr)] items-center gap-2">
       <div className="inline-flex items-center gap-2 text-tableCell font-medium text-text">
@@ -757,6 +845,7 @@ function GroupHeader({
       </div>
       <div className="flex min-w-0 items-center gap-2">
         <input
+          ref={inputRef}
           value={nameValue}
           onChange={event => onChangeName(event.target.value)}
           placeholder="Add name..."
@@ -823,15 +912,18 @@ function UngroupedDropContainer({
   return (
     <div className={`${hasGroupsAbove ? 'border-t border-grey-02' : ''} px-4 py-3`}>
       {hasGroupsAbove && (
-        <Text as="p" variant="metadata" className="text-grey-04 leading-[13px] tracking-[-0.35px]">
+        <Text as="p" variant="metadata" className="leading-[13px] tracking-[-0.35px] text-grey-04">
           Ungrouped properties
         </Text>
       )}
       <div
         ref={drop.setNodeRef}
-        className={`${hasGroupsAbove ? 'mt-2' : ''} rounded-md pr-2 py-2 ${drop.isOver ? 'bg-grey-01' : ''}`}
+        className={`${hasGroupsAbove ? 'mt-2' : ''} rounded-md py-2 pr-2 ${drop.isOver ? 'bg-grey-01' : ''}`}
       >
-        <SortableContext items={relations.map(relation => propertyDragId(relation.toEntity.id))} strategy={rectSortingStrategy}>
+        <SortableContext
+          items={relations.map(relation => propertyDragId(relation.toEntity.id))}
+          strategy={rectSortingStrategy}
+        >
           <div className="grid grid-cols-[170px_minmax(0,1fr)] items-start gap-2">
             <div className="inline-flex items-center gap-2 pt-[3px]">
               <InlinePropertyTypeIcon dataType="RELATION" />
@@ -839,7 +931,18 @@ function UngroupedDropContainer({
             </div>
             <div className="flex flex-wrap items-center gap-2">
               {relations.map(relation => (
-                <SortablePropertyRow key={relation.id} relation={relation} spaceId={spaceId} />
+                <SortablePropertyRow
+                  key={relation.id}
+                  relation={relation}
+                  spaceId={spaceId}
+                  onDelete={() => storage.relations.delete(relation)}
+                  onDone={result => {
+                    storage.relations.update(relation, draft => {
+                      draft.toSpaceId = result.space;
+                      draft.verified = result.verified;
+                    });
+                  }}
+                />
               ))}
               <SelectEntityAsPopover
                 trigger={
@@ -876,7 +979,17 @@ function UngroupedDropContainer({
   );
 }
 
-function SortablePropertyRow({ relation, spaceId }: { relation: Relation; spaceId: string }) {
+function SortablePropertyRow({
+  relation,
+  spaceId,
+  onDelete,
+  onDone,
+}: {
+  relation: Relation;
+  spaceId: string;
+  onDelete: () => void;
+  onDone: (result: { id: string; name: string | null; space?: string; verified?: boolean }) => void;
+}) {
   const sortable = useSortable({ id: propertyDragId(relation.toEntity.id) });
   const style = {
     transform: CSS.Translate.toString(sortable.transform),
@@ -891,18 +1004,24 @@ function SortablePropertyRow({ relation, spaceId }: { relation: Relation; spaceI
       className="relative inline-block max-w-full min-w-0"
       aria-label="Drag property"
     >
-      <span className="inline-flex max-w-full min-w-0 items-center cursor-grab active:cursor-grabbing" {...sortable.attributes} {...sortable.listeners}>
+      <span
+        className="inline-flex max-w-full min-w-0 cursor-grab items-center active:cursor-grabbing"
+        {...sortable.attributes}
+        {...sortable.listeners}
+      >
         <LinkableRelationChip
-          isEditing={false}
+          isEditing
           small
           truncateLabel
-          className="max-w-[220px] cursor-grab! tracking-[-0.25px] hover:cursor-grab! focus:cursor-grab! active:cursor-grabbing! **:cursor-grab! [&>button]:cursor-pointer! [&>button_*]:cursor-pointer!"
+          className="max-w-[220px] cursor-grab! tracking-[-0.25px] **:cursor-grab! hover:cursor-grab! focus:cursor-grab! active:cursor-grabbing! [&>button]:cursor-pointer! [&>button_*]:cursor-pointer!"
           currentSpaceId={spaceId}
           entityId={relation.toEntity.id}
           relationId={relation.id}
           relationEntityId={relation.entityId}
           spaceId={relation.toSpaceId}
           verified={relation.verified}
+          onDelete={onDelete}
+          onDone={onDone}
         >
           {relation.toEntity.name ?? relation.toEntity.id}
         </LinkableRelationChip>


### PR DESCRIPTION
## Summary
- Preserve parent type property relations when deleting a property group so grouped properties drop back into ungrouped properties.
- Restore synced baselines immediately when clearing local review edits so deleted local tombstones do not temporarily hide remote properties.
- Render `isType`-derived schema properties as named groups, placed after their triggering explicit group or as their own group when ungrouped.

## Validation
- `bun run test core/database/entities.test.ts core/sync/store.test.ts`

## Notes
- Implemented in a new worktree based on current `origin/master` (`13b76cb9`).
