### PR TITLE
[codex] Scope explore feed with top-level filters

### DIFF
--- a/apps/web/core/explore/explore-entities-document.ts
+++ b/apps/web/core/explore/explore-entities-document.ts
@@ -51,6 +51,8 @@ const EXPLORE_ENTITIES_CONNECTION_SOURCE = /* GraphQL */ `
     $after: Cursor
     $filter: EntityFilter
     $orderBy: [EntitiesOrderBy!]
+    $spaceIds: UUIDFilter!
+    $typeIds: UUIDFilter
     $spaceIdsForLists: [UUID!]!
   ) {
     entitiesConnection(
@@ -58,6 +60,8 @@ const EXPLORE_ENTITIES_CONNECTION_SOURCE = /* GraphQL */ `
       after: $after
       filter: $filter
       orderBy: $orderBy
+      spaceIds: $spaceIds
+      typeIds: $typeIds
     ) {
       pageInfo {
         endCursor

--- a/apps/web/core/explore/fetch-explore-feed.ts
+++ b/apps/web/core/explore/fetch-explore-feed.ts
@@ -229,7 +229,7 @@ async function fetchExploreEntitiesPage(args: {
         filter: buildFeedFilter(args),
         orderBy: args.orderBy,
         spaceIds: { in: args.spaceIds },
-        typeIds: args.typeIds?.length ? { in: [...args.typeIds] } : null,
+        typeIds: args.typeIds?.length ? { in: [...args.typeIds] } : undefined,
         spaceIdsForLists: args.spaceIds,
       },
     })

--- a/apps/web/core/explore/fetch-explore-feed.ts
+++ b/apps/web/core/explore/fetch-explore-feed.ts
@@ -184,12 +184,17 @@ function buildFeedFilter(args: {
   time: ExploreTime;
   typeIds?: readonly string[];
   requireName?: boolean;
+  includeEntityScopeInFilter?: boolean;
 }): EntityFilter {
   const t = timeThresholdSec(args.time);
   return {
     ...FEED_EXCLUDED_RELATIONS_FILTER,
-    spaceIds: { overlaps: [...args.spaceIds] },
-    ...(args.typeIds?.length ? { typeIds: { overlaps: [...args.typeIds] } } : {}),
+    ...(args.includeEntityScopeInFilter
+      ? {
+          spaceIds: { overlaps: [...args.spaceIds] },
+          ...(args.typeIds?.length ? { typeIds: { overlaps: [...args.typeIds] } } : {}),
+        }
+      : {}),
     ...(args.requireName !== false
       ? {
           values: {
@@ -223,6 +228,8 @@ async function fetchExploreEntitiesPage(args: {
         after: args.after,
         filter: buildFeedFilter(args),
         orderBy: args.orderBy,
+        spaceIds: { in: args.spaceIds },
+        typeIds: args.typeIds?.length ? { in: [...args.typeIds] } : null,
         spaceIdsForLists: args.spaceIds,
       },
     })
@@ -230,7 +237,7 @@ async function fetchExploreEntitiesPage(args: {
 }
 
 // "Top" sort: rank by the integer score property via `entitiesOrderedByPropertyConnection`.
-// The endpoint takes `spaceIds` only inside `filter` (no top-level arg, unlike `entitiesConnection`).
+// This endpoint does not expose top-level `spaceIds` / `typeIds` args, unlike `entitiesConnection`.
 async function fetchTopEntitiesPage(args: {
   spaceIds: string[];
   time: ExploreTime;
@@ -246,7 +253,7 @@ async function fetchTopEntitiesPage(args: {
       variables: {
         first: args.limit,
         after: args.after,
-        filter: buildFeedFilter(args),
+        filter: buildFeedFilter({ ...args, includeEntityScopeInFilter: true }),
         propertyId: SCORE_SYSTEM_PROPERTY,
         dataType: 'integer',
         sortDirection: 'DESC',


### PR DESCRIPTION
## Summary

- Moves entitiesConnection Explore feed space/type scoping from filter.spaceIds and filter.typeIds to top-level spaceIds and typeIds arguments.
- Keeps the name/time/excluded-relation predicates in the filter, and continues using the same display-list space filtering for values and relations.
- Preserves the entitiesOrderedByPropertyConnection top-sort path with filter-based scoping because that query does not expose top-level spaceIds or typeIds in the generated schema.

## Impact

Default Explore, Explore time/space filters, and Activity feed calls all route through the updated shared entitiesConnection fetch path. The Top sort remains behaviorally unchanged due to API shape.

## Validation

- bun run lint passes with existing warnings.
- GraphQL document import/parse smoke checks pass for both Explore query documents.
- bunx tsc --noEmit --project apps/web/tsconfig.json currently fails on an existing unrelated error in core/chat/write-validators.test.ts.
- bun run build was attempted but the local Next build stopped after hanging in production compile for several minutes.