### PR TITLE
fix: restore properties container layout

### DIFF
--- a/apps/web/partials/entity-page/data-type-pill.tsx
+++ b/apps/web/partials/entity-page/data-type-pill.tsx
@@ -53,7 +53,11 @@ export function DataTypePill({ dataType, renderableType, spaceId, iconOnly = fal
 
   if (iconOnly) {
     return (
-      <span className="inline-flex items-center rounded border border-grey-02 bg-white p-1 text-metadata tabular-nums">
+      <span
+        role="img"
+        aria-label={`${formattedType} property type`}
+        className="inline-flex items-center rounded border border-grey-02 bg-white p-1 text-metadata tabular-nums"
+      >
         {IconComponent && <IconComponent color="grey-04" />}
       </span>
     );

--- a/apps/web/partials/entity-page/editable-entity-page.tsx
+++ b/apps/web/partials/entity-page/editable-entity-page.tsx
@@ -311,7 +311,7 @@ function InlinePropertyRow({
 }) {
   return (
     <div className="w-full max-w-full min-w-0 break-words">
-      <PropertyNameLink property={property} spaceId={spaceId} />
+      <PropertyNameLink property={property} spaceId={spaceId} showDescriptionTooltip={false} />
 
       {isRelation || isVideo ? (
         <RelationPropertyWithDelete

--- a/apps/web/partials/entity-page/editable-entity-page.tsx
+++ b/apps/web/partials/entity-page/editable-entity-page.tsx
@@ -60,7 +60,8 @@ import { Text } from '~/design-system/text';
 import { ChevronDownSmall } from '~/design-system/icons/chevron-down-small';
 
 import { createRelationEntityTypeRelation } from '~/partials/blocks/table/change-entry';
-import { InlinePropertyTypeIcon } from '~/partials/entity-page/inline-property-type-icon';
+import { DataTypePill } from '~/partials/entity-page/data-type-pill';
+import { PropertyNameLink } from '~/partials/entity-page/property-name-link';
 import { getEntityTemplate } from '~/partials/entity-page/utils/get-entity-template';
 
 type EditableEntityPageProps = {
@@ -309,31 +310,27 @@ function InlinePropertyRow({
   hideActions?: boolean;
 }) {
   return (
-    <div className="grid grid-cols-[170px_minmax(0,1fr)] items-start gap-4 sm:grid-cols-1 sm:gap-1">
-      <div className="inline-flex min-w-0 items-center gap-2 pt-[3px] text-text">
-        <InlinePropertyTypeIcon dataType={property.dataType} renderableType={property.renderableTypeStrict ?? property.renderableType} />
-        <span className="truncate text-tableCell font-medium">{property.name}</span>
-      </div>
-      <div className="min-w-0">
-        {isRelation || isVideo ? (
-          <RelationPropertyWithDelete
-            propertyId={propertyId}
-            entityId={entityId}
-            spaceId={spaceId}
-            property={property}
-            isSchemaProperty={isSchemaProperty}
-            hideActions={hideActions}
-          />
-        ) : (
-          <RenderedValue
-            propertyId={propertyId}
-            entityId={entityId}
-            spaceId={spaceId}
-            property={property}
-            hideActions={hideActions}
-          />
-        )}
-      </div>
+    <div className="w-full max-w-full min-w-0 break-words">
+      <PropertyNameLink property={property} spaceId={spaceId} />
+
+      {isRelation || isVideo ? (
+        <RelationPropertyWithDelete
+          propertyId={propertyId}
+          entityId={entityId}
+          spaceId={spaceId}
+          property={property}
+          isSchemaProperty={isSchemaProperty}
+          hideActions={hideActions}
+        />
+      ) : (
+        <RenderedValue
+          propertyId={propertyId}
+          entityId={entityId}
+          spaceId={spaceId}
+          property={property}
+          hideActions={hideActions}
+        />
+      )}
     </div>
   );
 }
@@ -412,8 +409,18 @@ function RelationPropertyWithDelete({
       <div className="min-w-0 flex-1">
         <RelationsGroup key={propertyId} propertyId={propertyId} id={entityId} spaceId={spaceId} />
       </div>
-      {!hideActions && (!isSchemaProperty || propertyRelations.length > 0) && (
-        <div className="flex shrink-0 items-center">
+      <div className="flex shrink-0 items-center gap-1">
+        <DataTypePill
+          dataType={property.dataType}
+          renderableType={
+            property.renderableTypeStrict
+              ? { id: property.renderableType ?? null, name: property.renderableTypeStrict }
+              : null
+          }
+          spaceId={spaceId}
+          iconOnly={true}
+        />
+        {!hideActions && (!isSchemaProperty || propertyRelations.length > 0) && (
           <SquareButton
             icon={<Trash />}
             onClick={() => {
@@ -425,8 +432,8 @@ function RelationPropertyWithDelete({
               }
             }}
           />
-        </div>
-      )}
+        )}
+      </div>
     </div>
   );
 }
@@ -1183,11 +1190,19 @@ function RenderedValue({
   return (
     <div className="flex w-full items-start justify-between gap-2">
       <div className="min-w-0 flex-1">{renderField()}</div>
-      {!hideActions && rawValue && (
-        <div className="flex shrink-0 items-center">
-          <SquareButton icon={<Trash />} onClick={onDelete} />
-        </div>
-      )}
+      <div className="flex shrink-0 items-center gap-1">
+        <DataTypePill
+          dataType={property.dataType}
+          renderableType={
+            property.renderableTypeStrict
+              ? { id: property.renderableType ?? null, name: property.renderableTypeStrict }
+              : null
+          }
+          spaceId={spaceId}
+          iconOnly={true}
+        />
+        {!hideActions && rawValue && <SquareButton icon={<Trash />} onClick={onDelete} />}
+      </div>
     </div>
   );
 }

--- a/apps/web/partials/entity-page/property-name-link.tsx
+++ b/apps/web/partials/entity-page/property-name-link.tsx
@@ -13,9 +13,31 @@ import { Tooltip } from '~/design-system/tooltip';
 type PropertyNameLinkProps = {
   property: { id: string; name: string | null };
   spaceId: string;
+  showDescriptionTooltip?: boolean;
 };
 
-export function PropertyNameLink({ property, spaceId }: PropertyNameLinkProps) {
+function PropertyNameLinkBase({ property, spaceId }: Pick<PropertyNameLinkProps, 'property' | 'spaceId'>) {
+  const propertyName = property.name?.trim() || property.id;
+
+  return (
+    <Link
+      href={NavUtils.toEntity(spaceId, property.id)}
+      entityId={property.id}
+      spaceId={spaceId}
+      className="group inline-flex max-w-full"
+    >
+      <Text
+        as="span"
+        variant="bodySemibold"
+        className="min-w-0 leading-tight break-words underline-offset-2 group-hover:underline group-focus-visible:underline"
+      >
+        {propertyName}
+      </Text>
+    </Link>
+  );
+}
+
+function PropertyNameLinkWithTooltip({ property, spaceId }: Pick<PropertyNameLinkProps, 'property' | 'spaceId'>) {
   const descriptionValues = useValues({
     selector: v =>
       v.property.id === SystemIds.DESCRIPTION_PROPERTY &&
@@ -35,28 +57,19 @@ export function PropertyNameLink({ property, spaceId }: PropertyNameLinkProps) {
       )
       ?.value.trim() ??
     '';
-  const propertyName = property.name?.trim() || property.id;
-
-  const link = (
-    <Link
-      href={NavUtils.toEntity(spaceId, property.id)}
-      entityId={property.id}
-      spaceId={spaceId}
-      className="group inline-flex max-w-full"
-    >
-      <Text
-        as="span"
-        variant="bodySemibold"
-        className="min-w-0 leading-tight break-words underline-offset-2 group-hover:underline group-focus-visible:underline"
-      >
-        {propertyName}
-      </Text>
-    </Link>
-  );
+  const link = <PropertyNameLinkBase property={property} spaceId={spaceId} />;
 
   if (!description) {
     return link;
   }
 
   return <Tooltip trigger={link} label={description} position="top" align="start" variant="propertyDescription" />;
+}
+
+export function PropertyNameLink({ property, spaceId, showDescriptionTooltip = true }: PropertyNameLinkProps) {
+  if (!showDescriptionTooltip) {
+    return <PropertyNameLinkBase property={property} spaceId={spaceId} />;
+  }
+
+  return <PropertyNameLinkWithTooltip property={property} spaceId={spaceId} />;
 }

--- a/apps/web/partials/entity-page/readable-entity-page.tsx
+++ b/apps/web/partials/entity-page/readable-entity-page.tsx
@@ -38,7 +38,6 @@ import { Map as GeoMap } from '~/design-system/map';
 import { Text } from '~/design-system/text';
 import { ChevronDownSmall } from '~/design-system/icons/chevron-down-small';
 
-import { InlinePropertyTypeIcon } from '~/partials/entity-page/inline-property-type-icon';
 import { PropertyNameLink } from '~/partials/entity-page/property-name-link';
 
 interface Props {
@@ -162,7 +161,7 @@ export function ReadableEntityProperties({ id: entityId, spaceId }: Props) {
   }
 
   return (
-    <div className="flex flex-col gap-4 rounded-lg border border-grey-02 p-4 shadow-button">
+    <div className="flex flex-col gap-6 rounded-lg border border-grey-02 p-5 shadow-button">
       {groupedSections.hasGroups &&
         groupedSections.groups.map(group => {
           const isCollapsed = collapsedGroups[group.id] ?? false;
@@ -187,20 +186,17 @@ export function ReadableEntityProperties({ id: entityId, spaceId }: Props) {
               </button>
 
               {!isCollapsed && (
-                <div className="flex flex-col gap-2 sm:gap-5">
+                <div className="flex flex-col gap-6">
                   {group.propertyIds.map(propertyId => {
                     const property = renderedProperties[propertyId];
                     if (!property) return null;
+                    const isRelation = property.dataType === 'RELATION';
 
-                    return (
-                      <ReadablePropertyRow
-                        key={propertyId}
-                        entityId={entityId}
-                        spaceId={spaceId}
-                        propertyId={propertyId}
-                        property={property}
-                      />
-                    );
+                    if (isRelation) {
+                      return <RelationsGroup key={propertyId} entityId={entityId} spaceId={spaceId} propertyId={propertyId} />;
+                    }
+
+                    return <ValuesGroup key={propertyId} entityId={entityId} propertyId={propertyId} spaceId={spaceId} />;
                   })}
                 </div>
               )}
@@ -215,52 +211,20 @@ export function ReadableEntityProperties({ id: entityId, spaceId }: Props) {
               Ungrouped properties
             </Text>
           )}
-          <div className="flex flex-col gap-2 sm:gap-5">
+          <div className="flex flex-col gap-6">
             {groupedSections.ungrouped.map(propertyId => {
               const property = renderedProperties[propertyId];
               if (!property) return null;
-              return (
-                <ReadablePropertyRow
-                  key={propertyId}
-                  entityId={entityId}
-                  spaceId={spaceId}
-                  propertyId={propertyId}
-                  property={property}
-                />
-              );
+              const isRelation = property.dataType === 'RELATION';
+
+              if (isRelation) {
+                return <RelationsGroup key={propertyId} entityId={entityId} spaceId={spaceId} propertyId={propertyId} />;
+              }
+
+              return <ValuesGroup key={propertyId} entityId={entityId} propertyId={propertyId} spaceId={spaceId} />;
             })}
           </div>
         </div>
-      )}
-    </div>
-  );
-}
-
-function ReadablePropertyRow({
-  entityId,
-  spaceId,
-  propertyId,
-  property,
-}: {
-  entityId: string;
-  spaceId: string;
-  propertyId: string;
-  property: { id: string; name: string | null; dataType: DataType; renderableTypeStrict?: string | null; renderableType?: string | null };
-}) {
-  const isRelation = property.dataType === 'RELATION';
-
-  return (
-    <div className="grid grid-cols-[170px_minmax(0,1fr)] items-start gap-4 sm:grid-cols-1 sm:gap-1">
-      <div className="inline-flex min-w-0 items-start gap-2 text-text">
-        <span className="flex h-[1.5rem] shrink-0 items-center">
-          <InlinePropertyTypeIcon dataType={property.dataType} renderableType={property.renderableTypeStrict ?? property.renderableType} />
-        </span>
-        <PropertyNameLink property={property} spaceId={spaceId} />
-      </div>
-      {isRelation ? (
-        <RelationsGroup entityId={entityId} spaceId={spaceId} propertyId={propertyId} hidePropertyName />
-      ) : (
-        <ValuesGroup entityId={entityId} propertyId={propertyId} spaceId={spaceId} hidePropertyName />
       )}
     </div>
   );
@@ -289,12 +253,10 @@ function ValuesGroup({
   entityId,
   spaceId,
   propertyId,
-  hidePropertyName,
 }: {
   entityId: string;
   spaceId: string;
   propertyId: string;
-  hidePropertyName?: boolean;
 }) {
   // @TODO: This should be prefetched with _all_ the properties
   const { property } = useQueryProperty({ id: propertyId });
@@ -324,7 +286,7 @@ function ValuesGroup({
         }
         return (
           <div key={`${entityId}-${propertyId}-${index}`} className="max-w-full min-w-0 break-words">
-            {!hidePropertyName && <PropertyNameLink property={property} spaceId={spaceId} />}
+            <PropertyNameLink property={property} spaceId={spaceId} />
             <div className="flex w-full max-w-full min-w-0 flex-wrap gap-2">
               <RenderedValue
                 propertyId={propertyId}
@@ -346,13 +308,11 @@ export function RelationsGroup({
   spaceId,
   propertyId,
   isMetadataHeader,
-  hidePropertyName,
 }: {
   entityId: string;
   propertyId: string;
   spaceId: string;
   isMetadataHeader?: boolean;
-  hidePropertyName?: boolean;
 }) {
   const { property } = useQueryProperty({ id: propertyId });
 
@@ -395,7 +355,7 @@ export function RelationsGroup({
   return (
     <>
       <div key={`${propertyId}-${property.name}`} className="max-w-full min-w-0 break-words">
-        {!hidePropertyName && propertyId !== SystemIds.TYPES_PROPERTY && <PropertyNameLink property={property} spaceId={spaceId} />}
+        {propertyId !== SystemIds.TYPES_PROPERTY && <PropertyNameLink property={property} spaceId={spaceId} />}
 
         <div className="flex w-full max-w-full min-w-0 flex-wrap gap-2">
           {relations.map(r => {


### PR DESCRIPTION
## Summary
- keep property group dropdown/collapse behavior from the property groups work
- restore the properties container to the previous stacked property-name/value layout
- move relation pills back under property names and restore the editable data-type icon pill beside row actions

## Why
PR #1760 introduced property groups, but also changed the properties container row layout. We want to keep groups while reverting the unrelated visual changes.

## Validation
- `git diff --check`
- `bun run lint` passed with existing warnings
- `apps/web bun run build` passed with dummy required local env vars after the root build exposed missing local env configuration
