### PR TITLE
[codex] Restore relation data blocks

### DIFF
--- a/apps/web/core/blocks/data/data-selectors.ts
+++ b/apps/web/core/blocks/data/data-selectors.ts
@@ -3,7 +3,7 @@ import { GraphUrl, SystemIds } from '@geoprotocol/geo-sdk/lite';
 import { queryClient } from '~/core/query-client';
 import { E } from '~/core/sync/orm';
 import { store } from '~/core/sync/use-sync-engine';
-import { Entity } from '~/core/types';
+import { Entity, Relation } from '~/core/types';
 
 type TripleSegment = {
   type: 'TRIPLE';
@@ -137,6 +137,75 @@ export async function mapSelectorLexiconToSourceEntity(
   }
 
   return [];
+}
+
+export async function mapSelectorLexiconToRelationEntities(
+  lexicon: PathSegment[],
+  relation: Relation
+): Promise<Entity[]> {
+  let input = await getRelationSelectorRoot(lexicon, relation);
+  const startIndex = getRelationSelectorStartIndex(lexicon);
+
+  for (const segment of lexicon.slice(startIndex)) {
+    if (segment.type === 'TRIPLE') {
+      continue;
+    }
+
+    const relations = input?.relations.filter(r => r.type.id === segment.property) ?? [];
+
+    if (relations.length === 0) {
+      return [];
+    }
+
+    return await E.findMany({
+      store,
+      cache: queryClient,
+      where: { id: { in: relations.map(r => r.toEntity.id) } },
+      first: 100,
+    });
+  }
+
+  return input ? [input] : [];
+}
+
+async function getRelationSelectorRoot(lexicon: PathSegment[], relation: Relation): Promise<Entity | null> {
+  const firstSegment = lexicon[0];
+
+  if (!firstSegment) {
+    return await findEntityForRelationSelector(relation.toEntity.id);
+  }
+
+  if (firstSegment.type !== 'RELATION') {
+    return await findEntityForRelationSelector(relation.entityId);
+  }
+
+  if (firstSegment.property === SystemIds.RELATION_TO_PROPERTY) {
+    return await findEntityForRelationSelector(relation.toEntity.id);
+  }
+
+  if (firstSegment.property === SystemIds.RELATION_FROM_PROPERTY) {
+    return await findEntityForRelationSelector(relation.fromEntity.id);
+  }
+
+  return await findEntityForRelationSelector(relation.entityId);
+}
+
+function getRelationSelectorStartIndex(lexicon: PathSegment[]): number {
+  const firstSegment = lexicon[0];
+
+  if (
+    firstSegment?.type === 'RELATION' &&
+    (firstSegment.property === SystemIds.RELATION_TO_PROPERTY ||
+      firstSegment.property === SystemIds.RELATION_FROM_PROPERTY)
+  ) {
+    return 1;
+  }
+
+  return 0;
+}
+
+async function findEntityForRelationSelector(id: string): Promise<Entity | null> {
+  return await E.findOne({ id, cache: queryClient, store });
 }
 
 const valueRenderableTypes: string[] = ['TEXT', 'NUMBER', 'TIME', 'CHECKBOX'];

--- a/apps/web/core/blocks/data/use-data-block.tsx
+++ b/apps/web/core/blocks/data/use-data-block.tsx
@@ -13,7 +13,7 @@ import { Cell, Property, Row } from '~/core/types';
 import { sortRows } from '~/core/utils/utils';
 
 import { useProperties } from '../../hooks/use-properties';
-import { mapSelectorLexiconToSourceEntity, parseSelectorIntoLexicon } from './data-selectors';
+import { mapSelectorLexiconToRelationEntities, parseSelectorIntoLexicon } from './data-selectors';
 import { Filter, FilterMode } from './filters';
 import { Source } from './source';
 import { useCollection } from './use-collection';
@@ -85,7 +85,21 @@ export function useDataBlock(options?: UseDataBlockOptions) {
   // round-trip preserves columnName/valueName on the OTHER filters while the
   // new filter list is being re-resolved.
   const { source, setSource } = useSource({ filterState: dbResolvedFilterState, setFilterState });
-  const { relationBlockSourceRelations } = useRelationsBlock({ source, filterState: dbFilterState });
+  const {
+    relationBlockSourceRelations,
+    isLoading: isRelationsBlockLoading,
+    isFetched: isRelationsBlockFetched,
+    isPlaceholderData: isRelationsBlockPlaceholder,
+    endCursor: relationsEndCursor,
+    hasNextPage: relationsHasNextPage,
+  } = useRelationsBlock({
+    source,
+    filterState: dbFilterState,
+    first: PAGE_SIZE,
+    after: currentAfter,
+    offset: currentOffset !== undefined ? currentOffset * PAGE_SIZE : undefined,
+    spaceId,
+  });
 
   const activeFilterState = options?.canEdit ? dbResolvedFilterState : temporaryFilters;
   const activeFilterMode = options?.canEdit ? dbFilterMode : temporaryFilterMode;
@@ -221,6 +235,20 @@ export function useDataBlock(options?: UseDataBlockOptions) {
     recordEndCursor,
   ]);
 
+  React.useEffect(() => {
+    if (source.type !== 'RELATIONS') return;
+    if (!isRelationsBlockFetched) return;
+    if (isRelationsBlockPlaceholder) return;
+    recordEndCursor(pageNumber, relationsEndCursor);
+  }, [
+    source.type,
+    isRelationsBlockFetched,
+    isRelationsBlockPlaceholder,
+    relationsEndCursor,
+    pageNumber,
+    recordEndCursor,
+  ]);
+
   const mappingKey = React.useMemo(() => stableStringify(mapping), [mapping]);
   const sourceKey = React.useMemo(() => {
     if (source.type === 'SPACES') {
@@ -274,7 +302,7 @@ export function useDataBlock(options?: UseDataBlockOptions) {
 
                 for (const [propertyId, selector] of Object.entries(mapping)) {
                   const lexicon = parseSelectorIntoLexicon(selector);
-                  const entities = await mapSelectorLexiconToSourceEntity(lexicon, relation.id);
+                  const entities = await mapSelectorLexiconToRelationEntities(lexicon, relation);
                   cells.push(mappingToCell(entities, propertyId, lexicon));
                 }
 
@@ -384,7 +412,12 @@ export function useDataBlock(options?: UseDataBlockOptions) {
   }
 
   if (source.type === 'RELATIONS') {
-    isLoading = !isRelationDataFetched || isRelationDataLoading || isSharedDataLoading;
+    isLoading =
+      !isRelationsBlockFetched ||
+      isRelationsBlockLoading ||
+      !isRelationDataFetched ||
+      isRelationDataLoading ||
+      isSharedDataLoading;
   }
 
   if (source.type === 'GEO' || source.type === 'SPACES') {
@@ -395,7 +428,7 @@ export function useDataBlock(options?: UseDataBlockOptions) {
   if (source.type === 'COLLECTION') {
     isFetched = isCollectionFetched && !isSharedDataLoading;
   } else if (source.type === 'RELATIONS') {
-    isFetched = isRelationDataFetched && !isSharedDataLoading;
+    isFetched = isRelationsBlockFetched && isRelationDataFetched && !isSharedDataLoading;
   } else if (source.type === 'GEO' || source.type === 'SPACES') {
     isFetched = isQueryEntitiesFetched && !isSharedDataLoading;
   }
@@ -413,7 +446,9 @@ export function useDataBlock(options?: UseDataBlockOptions) {
         : (pageNumber + 1) * PAGE_SIZE < collectionData.totalCount
       : source.type === 'GEO' || source.type === 'SPACES'
         ? queriedHasNextPage
-        : false;
+        : source.type === 'RELATIONS'
+          ? relationsHasNextPage
+          : false;
 
   const result = {
     entityId,

--- a/apps/web/core/blocks/data/use-mapping.ts
+++ b/apps/web/core/blocks/data/use-mapping.ts
@@ -1,5 +1,7 @@
-import { GraphUri, GraphUrl, SystemIds } from '@geoprotocol/geo-sdk/lite';
+import { SystemIds } from '@geoprotocol/geo-sdk/lite';
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
+
+import * as React from 'react';
 
 import { useQueryEntitiesAsync } from '~/core/sync/use-store';
 import { Cell, Entity, Relation, Row } from '~/core/types';
@@ -44,13 +46,21 @@ const initialData = {
 
 export function useMapping(
   blockRelationId: string,
-  shownPropertyRelationEntityIds: string[]
+  shownPropertyRelations: Relation[]
 ): {
   mapping: Mapping;
   isLoading: boolean;
   isFetched: boolean;
 } {
   const findMany = useQueryEntitiesAsync();
+  const shownPropertyRelationEntityIds = React.useMemo(
+    () => shownPropertyRelations.map(relation => relation.entityId),
+    [shownPropertyRelations]
+  );
+  const shownPropertyRelationIds = React.useMemo(
+    () => shownPropertyRelations.map(relation => relation.id),
+    [shownPropertyRelations]
+  );
 
   const {
     data: mapping,
@@ -58,25 +68,24 @@ export function useMapping(
     isFetched,
   } = useQuery({
     placeholderData: keepPreviousData,
-    enabled: shownPropertyRelationEntityIds.length > 0,
+    enabled: shownPropertyRelations.length > 0,
     initialData,
-    queryKey: ['mapping-shown-properties', blockRelationId, shownPropertyRelationEntityIds],
+    queryKey: ['mapping-shown-properties', blockRelationId, shownPropertyRelationIds, shownPropertyRelationEntityIds],
     queryFn: async () => {
       const entities = await findMany({ where: { id: { in: shownPropertyRelationEntityIds } } });
+      const selectorEntityById = new Map(entities.map(entity => [entity.id, entity]));
 
-      const mapping = entities.reduce<Mapping>((acc, entity) => {
-        // @TODO(migration): This is broken in the new relations model. We no
-        // longer use GraphUri to represent relations
-        const key = entity.values.find(t => t.property.id === SystemIds.RELATION_TO_PROPERTY)?.value;
-        const selector = entity.values.find(t => t.property.id === SystemIds.SELECTOR_PROPERTY)?.value;
-        const decodedKey = key ? GraphUrl.toEntityId(key as GraphUri) : null;
+      const mapping = shownPropertyRelations.reduce<Mapping>((acc, relation) => {
+        const entity = selectorEntityById.get(relation.entityId);
+        const selector = entity?.values.find(t => t.property.id === SystemIds.SELECTOR_PROPERTY)?.value;
+        const key = relation.toEntity.id;
 
-        if (decodedKey && selector) {
-          acc[decodedKey] = selector;
+        if (selector) {
+          acc[key] = selector;
         }
 
-        if (decodedKey && !selector) {
-          acc[decodedKey] = null;
+        if (!selector) {
+          acc[key] = null;
         }
 
         return acc;
@@ -94,7 +103,7 @@ export function useMapping(
 
   return {
     isLoading,
-    isFetched: shownPropertyRelationEntityIds.length === 0 || isFetched,
+    isFetched: shownPropertyRelations.length === 0 || isFetched,
     mapping,
   };
 }

--- a/apps/web/core/blocks/data/use-relations-block.tsx
+++ b/apps/web/core/blocks/data/use-relations-block.tsx
@@ -1,7 +1,10 @@
 import { SystemIds } from '@geoprotocol/geo-sdk/lite';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 
-import { useQueryEntity } from '~/core/sync/use-store';
-import { Relation } from '~/core/types';
+import { Effect } from 'effect';
+
+import { RelationFilter, RelationsOrderBy } from '~/core/gql/graphql';
+import { getRelationsConnection } from '~/core/io/queries';
 
 import { Filter } from './filters';
 import { Source } from './source';
@@ -9,25 +12,64 @@ import { Source } from './source';
 type UseRelationsBlockOptions = {
   source: Source;
   filterState: Filter[];
+  first: number;
+  after?: string;
+  offset?: number;
+  spaceId: string;
 };
 
-export function useRelationsBlock({ source, filterState }: UseRelationsBlockOptions) {
-  const { entity: relationBlockSourceEntity } = useQueryEntity({
-    id: source.type === 'RELATIONS' ? source.value : undefined,
-    enabled: source.type === 'RELATIONS',
+export function useRelationsBlock({ source, filterState, first, after, offset, spaceId }: UseRelationsBlockOptions) {
+  const relationFilter = getRelationsConnectionFilter(source, filterState, spaceId);
+
+  const { data, isLoading, isFetched, isPlaceholderData } = useQuery({
+    enabled: source.type === 'RELATIONS' && relationFilter !== null,
+    placeholderData: keepPreviousData,
+    queryKey: ['blocks', 'data', 'relations-connection', source, relationFilter, first, after, offset],
+    queryFn: async ({ signal }) => {
+      if (!relationFilter) {
+        return { relations: [], endCursor: null, hasNextPage: false };
+      }
+
+      return await Effect.runPromise(
+        getRelationsConnection(
+          {
+            filter: relationFilter,
+            first,
+            after,
+            offset,
+            orderBy: [RelationsOrderBy.PositionAsc, RelationsOrderBy.IdAsc],
+          },
+          signal
+        )
+      );
+    },
   });
 
-  const relationBlockSourceRelations = getRelevantRelationsForRelationBlock(
-    relationBlockSourceEntity?.relations ?? [],
-    filterState
-  );
-
-  return { relationBlockSourceRelations };
+  return {
+    relationBlockSourceRelations: data?.relations ?? [],
+    endCursor: data?.endCursor ?? null,
+    hasNextPage: data?.hasNextPage ?? false,
+    isLoading,
+    isFetched: source.type !== 'RELATIONS' || relationFilter === null || isFetched,
+    isPlaceholderData,
+  };
 }
 
-function getRelevantRelationsForRelationBlock(relations: Relation[], filterState: Filter[]) {
+function getRelationsConnectionFilter(source: Source, filterState: Filter[], spaceId: string): RelationFilter | null {
+  if (source.type !== 'RELATIONS') {
+    return null;
+  }
+
   const maybeFilter = filterState.find(f => f.columnId === SystemIds.RELATION_TYPE_PROPERTY);
   const relationType = maybeFilter?.value;
 
-  return relations.filter(r => r.type.id === relationType);
+  if (!source.value || !relationType) {
+    return null;
+  }
+
+  return {
+    fromEntityId: { is: source.value },
+    typeId: { is: relationType },
+    spaceId: { is: spaceId },
+  };
 }

--- a/apps/web/core/blocks/data/use-view.ts
+++ b/apps/web/core/blocks/data/use-view.ts
@@ -57,10 +57,7 @@ export function useView() {
     [shownColumnRelations]
   );
 
-  const { mapping, isLoading, isFetched } = useMapping(
-    entityId,
-    orderedShownColumnRelations.map(r => r.id)
-  );
+  const { mapping, isLoading, isFetched } = useMapping(entityId, orderedShownColumnRelations);
 
   const shownColumnIds = [SystemIds.NAME_PROPERTY, ...orderedShownColumnRelations.map(r => r.toEntity.id)];
 

--- a/apps/web/core/io/queries.ts
+++ b/apps/web/core/io/queries.ts
@@ -14,10 +14,12 @@ import {
   EntityExistsDocument,
   type EntityExistsQuery,
   type EntityFilter,
+  type RelationFilter,
+  type RelationsOrderBy,
   SortOrder,
   type UuidFilter,
 } from '~/core/gql/graphql';
-import { Entity, SearchResult } from '~/core/types';
+import { Entity, Relation, SearchResult } from '~/core/types';
 import { spacesFromRoutingProjections } from '~/core/utils/entity/entities';
 
 import { allEntitiesConnectionDocument } from './all-entities-connection-document';
@@ -29,6 +31,7 @@ import { ResultDecoder } from './decoders/result';
 import { SpaceDecoder } from './decoders/space';
 import { Space } from './dto/spaces';
 import { graphql } from './graphql-client';
+import { relationsConnectionDocument } from './relations-connection-document';
 import {
   entitiesBatchQuery,
   entitySpacesBatchQuery,
@@ -137,6 +140,12 @@ export type EntitiesPage = {
   hasNextPage: boolean;
 };
 
+export type RelationsPage = {
+  relations: Relation[];
+  endCursor: string | null;
+  hasNextPage: boolean;
+};
+
 type EntitiesConnectionShape = {
   nodes?: unknown[] | null;
   pageInfo?: { endCursor?: string | null; hasNextPage?: boolean | null } | null;
@@ -152,6 +161,45 @@ function decodeEntitiesConnectionPage(connection: EntitiesConnectionShape): Enti
     endCursor: connection?.pageInfo?.endCursor ?? null,
     hasNextPage: connection?.pageInfo?.hasNextPage ?? false,
   };
+}
+
+type RelationsConnectionShape = {
+  nodes?: unknown[] | null;
+  pageInfo?: { endCursor?: string | null; hasNextPage?: boolean | null } | null;
+} | null;
+
+function decodeRelationsConnectionPage(connection: RelationsConnectionShape): RelationsPage {
+  const relations =
+    connection?.nodes
+      ?.map((n: unknown) => RelationDecoder.decode(n))
+      .filter((relation: Relation | null): relation is Relation => relation !== null) ?? [];
+
+  return {
+    relations,
+    endCursor: connection?.pageInfo?.endCursor ?? null,
+    hasNextPage: connection?.pageInfo?.hasNextPage ?? false,
+  };
+}
+
+type GetRelationsConnectionOptions = {
+  filter?: RelationFilter;
+  first?: number;
+  after?: string;
+  offset?: number;
+  orderBy?: RelationsOrderBy[];
+};
+
+export function getRelationsConnection(
+  { filter, first, after, offset, orderBy }: GetRelationsConnectionOptions,
+  signal?: AbortController['signal']
+) {
+  return graphql({
+    query: relationsConnectionDocument,
+    decoder: (data: { relationsConnection?: RelationsConnectionShape }) =>
+      decodeRelationsConnectionPage(data.relationsConnection ?? null),
+    variables: { filter, first, after, offset, orderBy },
+    signal,
+  });
 }
 
 export function getAllEntities(

--- a/apps/web/core/io/relations-connection-document.ts
+++ b/apps/web/core/io/relations-connection-document.ts
@@ -1,0 +1,66 @@
+import type { TypedDocumentNode } from '@graphql-typed-document-node/core';
+
+import { parse } from 'graphql';
+
+/**
+ * Cursor-paginated relation query used by relation data blocks. Kept as a
+ * parsed document so relation-block work can move without requiring GraphQL
+ * codegen every time the projection changes.
+ */
+const RELATIONS_CONNECTION_SOURCE = /* GraphQL */ `
+  query RelationsConnection(
+    $filter: RelationFilter
+    $first: Int
+    $after: Cursor
+    $offset: Int
+    $orderBy: [RelationsOrderBy!]
+  ) {
+    relationsConnection(first: $first, after: $after, offset: $offset, filter: $filter, orderBy: $orderBy) {
+      pageInfo {
+        endCursor
+        hasNextPage
+      }
+      nodes {
+        id
+        spaceId
+        position
+        verified
+        entityId
+        fromEntity {
+          id
+          name
+        }
+        toEntity {
+          id
+          name
+          types {
+            id
+            name
+          }
+          valuesList {
+            spaceId
+            propertyId
+            text
+            integer
+            float
+            point
+            boolean
+            time
+            datetime
+            date
+            decimal
+            bytes
+            schedule
+          }
+        }
+        toSpaceId
+        type {
+          id
+          name
+        }
+      }
+    }
+  }
+`;
+
+export const relationsConnectionDocument = parse(RELATIONS_CONNECTION_SOURCE) as TypedDocumentNode<any, any>;

--- a/apps/web/partials/blocks/table/table-block-edit-properties-panel.tsx
+++ b/apps/web/partials/blocks/table/table-block-edit-properties-panel.tsx
@@ -17,7 +17,7 @@ import { ID } from '~/core/id';
 import { useFilters } from '~/core/blocks/data/use-filters';
 import { useSource } from '~/core/blocks/data/use-source';
 import { useView } from '~/core/blocks/data/use-view';
-import { PLACEHOLDER_SPACE_IMAGE } from '~/core/constants';
+import { PLACEHOLDER_SPACE_IMAGE, RELATION_ENTITY_RELATIONSHIP_TYPE } from '~/core/constants';
 import { getSchemaFromTypeIds } from '~/core/database/entities';
 import { getProperties } from '~/core/io/queries';
 import { useQueryEntityAsync } from '~/core/sync/use-store';
@@ -73,14 +73,32 @@ function RelationsPropertySelector() {
     },
   });
 
+  const filteredPropertyId = filterState.find(r => r.columnId === SystemIds.RELATION_TYPE_PROPERTY)?.value;
+
+  const { data: relationPropertyEntity } = useQuery({
+    enabled: source.type === 'RELATIONS' && Boolean(filteredPropertyId),
+    queryKey: ['relation-property-entity-for-data-block-properties', filteredPropertyId],
+    queryFn: async () => {
+      if (!filteredPropertyId) {
+        return null;
+      }
+
+      return await findOne(filteredPropertyId);
+    },
+  });
+
   if (sourceEntity === null || sourceEntity === undefined || source.type !== 'RELATIONS') {
     return null;
   }
 
-  // @TODO: This should be stored as a data structure somewhere
-  const filteredPropertyId = filterState.find(r => r.columnId === SystemIds.RELATION_TYPE_PROPERTY)?.value;
-  const relationIds = sourceEntity.relations.filter(r => r.type.id === filteredPropertyId).map(r => r.id);
-  const toIds = sourceEntity.relations.filter(r => r.type.id === filteredPropertyId).map(r => r.toEntity.id);
+  const relationEntityTypeIds =
+    relationPropertyEntity?.relations
+      .filter(r => r.type.id === RELATION_ENTITY_RELATIONSHIP_TYPE)
+      .map(r => r.toEntity.id) ?? [];
+  const toTypeIds =
+    relationPropertyEntity?.relations
+      .filter(r => r.type.id === SystemIds.RELATION_VALUE_RELATIONSHIP_TYPE)
+      .map(r => r.toEntity.id) ?? [];
 
   const maybeSourceEntityImage = sourceEntity.relations.find(r => r.type.id === ContentIds.AVATAR_PROPERTY)?.toEntity
     .value;
@@ -121,7 +139,7 @@ function RelationsPropertySelector() {
             </div>
           </MenuItem>
 
-          <MenuItem onClick={() => setSelectedEntities({ type: 'SOURCE', entityIds: relationIds })}>
+          <MenuItem onClick={() => setSelectedEntities({ type: 'SOURCE', entityIds: relationEntityTypeIds })}>
             <div className="flex items-center gap-2">
               <div className="flex items-center gap-1">
                 <div className="flex h-4 w-4 items-center justify-center rounded bg-grey-04">
@@ -132,7 +150,7 @@ function RelationsPropertySelector() {
               <p className="text-button">Relation entity</p>
             </div>
           </MenuItem>
-          <MenuItem onClick={() => setSelectedEntities({ type: 'TO', entityIds: toIds })}>
+          <MenuItem onClick={() => setSelectedEntities({ type: 'TO', entityIds: toTypeIds })}>
             <div className="flex items-center gap-2">
               <div className="flex items-center gap-1">
                 <div className="flex h-4 w-4 items-center justify-center rounded bg-grey-04">

--- a/apps/web/partials/blocks/table/table-block-editable-filters.tsx
+++ b/apps/web/partials/blocks/table/table-block-editable-filters.tsx
@@ -79,7 +79,7 @@ export const TableBlockEditableFilters = React.forwardRef<TableBlockFilterPrompt
             },
             {
               columnId: SystemIds.RELATION_TYPE_PROPERTY,
-              columnName: 'Relation type',
+              columnName: 'Relation property',
               valueType: 'RELATION',
               value: '',
               valueName: null,

--- a/apps/web/partials/blocks/table/table-block-filter-creation-prompt.tsx
+++ b/apps/web/partials/blocks/table/table-block-filter-creation-prompt.tsx
@@ -1311,8 +1311,8 @@ function StaticRelationsFilters({ from, relationType, setFrom, setRelationType }
 
   const onSetRelationType = (entity: { id: string; name: string | null }) => {
     setRelationType({
-      columnId: SystemIds.RELATION_FROM_PROPERTY,
-      columnName: 'From',
+      columnId: SystemIds.RELATION_TYPE_PROPERTY,
+      columnName: 'Relation property',
       value: entity.id,
       valueName: entity.name,
       valueType: 'RELATION',
@@ -1324,7 +1324,7 @@ function StaticRelationsFilters({ from, relationType, setFrom, setRelationType }
       ...withoutRelationType,
       {
         columnId: SystemIds.RELATION_TYPE_PROPERTY,
-        columnName: null,
+        columnName: 'Relation property',
         value: entity.id,
         valueName: entity.name,
         valueType: 'RELATION',

--- a/apps/web/partials/blocks/table/table-block.tsx
+++ b/apps/web/partials/blocks/table/table-block.tsx
@@ -36,10 +36,12 @@ import { FilterTable } from '~/design-system/icons/filter-table';
 import { FilterTableWithFilters } from '~/design-system/icons/filter-table-with-filters';
 import { Fullscreen } from '~/design-system/icons/full-screen';
 import { PrefetchLink as Link } from '~/design-system/prefetch-link';
+import { SelectEntity } from '~/design-system/select-entity';
 import { Spacer } from '~/design-system/spacer';
 import { PageNumberContainer } from '~/design-system/table/styles';
 import { NextButton, PageNumber, PreviousButton } from '~/design-system/table/table-pagination';
 import { Text } from '~/design-system/text';
+import { Toggle } from '~/design-system/toggle';
 
 import { onChangeEntryFn, writeValue } from './change-entry';
 import { DataBlockScopeDropdown } from './data-block-scope-dropdown';
@@ -303,12 +305,47 @@ function TableBlockQuerySetup({ spaceId, onCompleteQuerySetup }: Props) {
   const canEdit = useCanUserEdit(spaceId);
   const { filterState, setFilterState } = useFilters(canEdit);
   const { source, setSource } = useSource({ filterState, setFilterState });
+  const relationSource = source.type === 'RELATIONS' ? source : null;
+  const isRelationsMode = relationSource !== null;
+  const relationTypeFilter = filterState.find(f => f.columnId === SystemIds.RELATION_TYPE_PROPERTY);
+  const canConfirmQuerySetup =
+    canEdit && (!relationSource || Boolean(relationSource.value && relationTypeFilter?.value));
 
   const handleConfirmQuerySetup = React.useCallback(() => {
+    if (!canConfirmQuerySetup) return;
     setSource(source);
     setEditable(true);
     onCompleteQuerySetup?.();
-  }, [onCompleteQuerySetup, setEditable, setSource, source]);
+  }, [canConfirmQuerySetup, onCompleteQuerySetup, setEditable, setSource, source]);
+
+  const setRelationType = React.useCallback(
+    (entity: { id: string; name: string | null }) => {
+      const withoutRelationType = filterState.filter(f => f.columnId !== SystemIds.RELATION_TYPE_PROPERTY);
+      setFilterState([
+        ...withoutRelationType,
+        {
+          columnId: SystemIds.RELATION_TYPE_PROPERTY,
+          columnName: 'Relation property',
+          valueType: 'RELATION',
+          value: entity.id,
+          valueName: entity.name,
+        },
+      ]);
+    },
+    [filterState, setFilterState]
+  );
+
+  const setRelationsMode = React.useCallback(
+    (checked: boolean) => {
+      if (checked) {
+        setSource({ type: 'RELATIONS', value: source.type === 'RELATIONS' ? source.value : '', name: null });
+        return;
+      }
+
+      setSource({ type: 'GEO' });
+    },
+    [setSource, source]
+  );
 
   return (
     <motion.div layout="position" transition={{ duration: 0.15 }}>
@@ -328,14 +365,53 @@ function TableBlockQuerySetup({ spaceId, onCompleteQuerySetup }: Props) {
         </div>
       </div>
 
-      <div className="flex min-h-[92px] flex-col items-center justify-center gap-2 rounded-lg bg-grey-01 px-4 py-5">
+      <div className="flex min-h-[92px] flex-col items-center justify-center gap-3 rounded-lg bg-grey-01 px-4 py-5">
         <p className="max-w-md text-center text-metadata text-text">Where do you want to query data from?</p>
-        <div className="flex w-[132px] max-w-full items-center justify-start gap-2 overflow-visible">
-          <DataBlockScopeDropdown source={source} setSource={setSource} disabled={!canEdit} variant="setup" />
+        <div className="flex items-center gap-2 text-footnote text-grey-04">
+          <span>Entities</span>
+          <button
+            type="button"
+            disabled={!canEdit}
+            aria-label="Toggle relation query mode"
+            onClick={() => setRelationsMode(!isRelationsMode)}
+            className="disabled:pointer-events-none disabled:opacity-50"
+          >
+            <Toggle checked={isRelationsMode} />
+          </button>
+          <span>Relations</span>
+        </div>
+        <div className="flex max-w-full flex-wrap items-center justify-center gap-2 overflow-visible">
+          {isRelationsMode ? (
+            <>
+              <div className="w-[220px]">
+                <SelectEntity
+                  spaceId={spaceId}
+                  placeholder="From entity"
+                  variant="fixed"
+                  width="full"
+                  selectedEntityId={relationSource?.value}
+                  onDone={entity => setSource({ type: 'RELATIONS', value: entity.id, name: entity.name })}
+                />
+              </div>
+              <div className="w-[220px]">
+                <SelectEntity
+                  spaceId={spaceId}
+                  placeholder="Relation property"
+                  variant="fixed"
+                  width="full"
+                  relationValueTypes={[{ id: SystemIds.PROPERTY, name: 'Property' }]}
+                  selectedEntityId={relationTypeFilter?.value}
+                  onDone={entity => setRelationType(entity)}
+                />
+              </div>
+            </>
+          ) : (
+            <DataBlockScopeDropdown source={source} setSource={setSource} disabled={!canEdit} variant="setup" />
+          )}
           <button
             type="button"
             onClick={handleConfirmQuerySetup}
-            disabled={!canEdit}
+            disabled={!canConfirmQuerySetup}
             className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded border border-grey-02 bg-white shadow-button transition hover:border-text focus:outline-hidden focus-visible:ring-2 focus-visible:ring-grey-04 disabled:pointer-events-none disabled:opacity-50"
             aria-label="Confirm query scope"
           >


### PR DESCRIPTION
## Summary

Restores the first usable slice of relation data blocks on the current relation architecture.

- Adds a `relationsConnection` query helper and uses it as the source of truth for relation block rows.
- Replaces the old source-entity local relation filtering path.
- Adds relation-aware selector mapping for From entity, To entity, and relation entity scopes.
- Fixes relation shown-column mapping so it reads current relation records instead of old GraphUri relation-to values.
- Adds the Figma-aligned relation setup state with Entities/Relations mode, From entity picker, Relation property picker, and guarded confirm.
- Fixes Relation property filter persistence to write `RELATION_TYPE_PROPERTY`.
- Updates relation properties panel options to use relation type metadata for Relation entity and To groups.

## Validation

- `git diff --check origin/master...HEAD`
- `data-selectors.test.ts` with required test env vars: 11 passing.

## Notes

This intentionally leaves versioned Hypergraph-style filters, nested relation filters, and deeper arbitrary selector traversal for separate follow-up chunks.