### PR TITLE
[codex] Skip empty isType property groups

### DIFF
--- a/apps/web/core/database/entities.test.ts
+++ b/apps/web/core/database/entities.test.ts
@@ -157,6 +157,37 @@ describe('getSchemaWithGroupsFromTypeIdsAndRelations', () => {
     expect(result.hasPropertyGroups).toBe(true);
   });
 
+  it('does not render an isType group when the target entity has no properties', async () => {
+    mocks.propertiesById.set(
+      'is-type-property',
+      property('is-type-property', 'Is type property', { dataType: 'RELATION', isType: true })
+    );
+    mocks.entitiesById.set(
+      'type',
+      entity('type', 'Type', [
+        relation({ id: 'type-is-type-property', from: 'type', type: SystemIds.PROPERTIES, to: 'is-type-property' }),
+      ])
+    );
+    mocks.entitiesById.set('target', entity('target', 'Target type'));
+
+    const result = await getSchemaWithGroupsFromTypeIdsAndRelations(
+      [{ id: 'type', spaceId }],
+      [
+        relation({
+          id: 'entity-is-type-relation',
+          from: 'entity',
+          type: 'is-type-property',
+          to: 'target',
+          toName: 'Target type',
+        }),
+      ]
+    );
+
+    expect(result.propertyGroups).toEqual([]);
+    expect(result.ungroupedPropertyIds).toEqual(['is-type-property']);
+    expect(result.hasPropertyGroups).toBe(false);
+  });
+
   it('places isType groups directly after the explicit group containing the triggering property', async () => {
     mocks.propertiesById.set(
       'is-type-property',

--- a/apps/web/core/database/entities.ts
+++ b/apps/web/core/database/entities.ts
@@ -567,6 +567,7 @@ export async function getSchemaWithGroupsFromTypeIdsAndRelations(
         globalSeenPropertyIds.add(propertyId);
         return true;
       });
+      if (uniqueTargetPropertyIds.length === 0) continue;
 
       const isTypeGroup: SchemaPropertyGroup = {
         id: `is-type-${relation.relationId}`,


### PR DESCRIPTION
## Summary
- Skip synthetic isType property groups when the target entity has no Properties relations to contribute.
- Add a regression test covering an isType relation whose target entity has no properties.

## Root cause
The grouped schema builder created an isType group as soon as an isType relation target existed, even when that target contributed an empty property list.

## Validation
- bun run test core/database/entities.test.ts
- bun run lint core/database/entities.ts core/database/entities.test.ts