### PR TITLE
fix(chat-inject): enable extract_claims for post and tweet

### DIFF
--- a/apps/web/app/api/chat/inject/route.ts
+++ b/apps/web/app/api/chat/inject/route.ts
@@ -9,6 +9,11 @@ import { ipCeilingLimit, loggedInLimit } from '../rate-limit';
 
 const INJECT_SPACE = 'world-affairs' as const;
 const VALID_TYPES: ReadonlySet<InjectType> = new Set(['news-story-single', 'post', 'tweet']);
+// Inject types whose pipeline gates claim extraction on the request body
+// (`InjectPostsOptions.extractClaims` defaults to false in news-worker).
+// `news-story-single` extracts claims unconditionally so we omit the flag
+// for it to keep the wire payload identical to today's behavior.
+const EXTRACT_CLAIMS_TYPES: ReadonlySet<InjectType> = new Set(['post', 'tweet']);
 const INJECT_FETCH_TIMEOUT_MS = 15_000;
 
 function isSameOrigin(req: Request): boolean {
@@ -133,7 +138,12 @@ export async function POST(req: Request) {
     return jsonError(503, 'Inject service not configured.');
   }
 
-  const payload = { space: INJECT_SPACE, url, type };
+  const payload = {
+    space: INJECT_SPACE,
+    url,
+    type,
+    ...(EXTRACT_CLAIMS_TYPES.has(type) ? { extract_claims: true } : {}),
+  };
 
   let res: Response;
   try {


### PR DESCRIPTION
## Summary
- The inject pipeline on `news-worker` gates claim extraction for posts and tweets on `InjectPostsOptions.extractClaims`, which defaults to `false`. Our proxy at `apps/web/app/api/chat/inject/route.ts` never sent that flag, so the enrich (Stage 2) step was being skipped for Reddit and X/Twitter URLs — no claims DATA block op was ever emitted, and the claims section on the injected post entity stayed empty.
- Adds `extract_claims: true` to the payload sent to the external inject service, but only for `post` and `tweet`.
- `news-story-single` is intentionally omitted: that pipeline extracts claims unconditionally via `lib/extraction-api-fresh.ts`, so omitting the field keeps the wire payload identical to today's behavior for news.
- No client-side change needed — `apps/web/core/chat/apply-inject-ops.ts` already maps `SystemIds.DATA_BLOCK` to the `'DATA'` renderable type (and pre-passes the op batch so the type resolves regardless of op order).

## Test plan
- [ ] Inject a Reddit URL: news-worker logs show `Stage 2/4: enrich (claim extraction)` (was `enrich skipped (extract_claims=false)`); after polling completes, the staged post entity shows a populated Claims data block in the review panel.
- [ ] Inject an X/Twitter URL: same expectations as Reddit.
- [ ] Inject a news article URL (`news-story-single`): unchanged from today — claims still render, no regression in the news flow.
- [ ] Server-side network sanity check: the outbound POST to `\${INJECT_BASE}/inject` includes `extract_claims: true` only for `post`/`tweet`, and omits the field entirely for `news-story-single`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)