### PR TITLE
fix(chat-classify-url): accept any reddit.com subdomain + sync with news-worker

### DIFF
--- a/apps/web/app/api/chat/classify-url/route.ts
+++ b/apps/web/app/api/chat/classify-url/route.ts
@@ -166,8 +166,12 @@ function matchesNewsHost(host: string): boolean {
 const HOSTNAME_RULES: Array<{ match: (host: string, pathname: string) => boolean; type: InjectType }> = [
   { match: host => host === 'x.com' || host === 'twitter.com' || host === 'mobile.twitter.com', type: 'tweet' },
   {
-    match: host =>
-      host === 'reddit.com' || host === 'www.reddit.com' || host === 'old.reddit.com' || host === 'redd.it',
+    // Apex + any reddit.com subdomain (mobile, old, np, sh, new, future…), plus
+    // the redd.it short-link host. Media CDNs i.redd.it / v.redd.it sit on a
+    // sibling domain and don't match endsWith('.reddit.com'), so they
+    // correctly fall through to the LLM/chat path — they aren't post
+    // permalinks. Mirrors `isRedditUrl` in news-worker's lib/reddit-fetch.ts.
+    match: host => host === 'reddit.com' || host.endsWith('.reddit.com') || host === 'redd.it',
     type: 'post',
   },
   { match: host => host.endsWith('.wikipedia.org') || host === 'wikipedia.org', type: 'news-story-single' },
@@ -181,7 +185,7 @@ Return route="inject" when the URL points to:
 - A news article, current event, breaking story, exposé, or evolving topic from any publication.
 - A Wikipedia article (any kind — topic, person, organization, event).
 - A LinkedIn profile or personal/portfolio site.
-- A social post (X / Twitter / Reddit) you would expect to discuss a current happening.
+- A social post on X / Twitter / Reddit.
 
 Return route="chat" ONLY when the URL clearly points to:
 - Static documentation, manuals, or developer/API references.


### PR DESCRIPTION
## Summary
- News-worker's inject pipeline has been updated to support any kind of Reddit URL (mobile, np, sh, redd.it short-links). The classifier in geogenesis was still gating URLs at two layers, dropping non-canonical Reddit pastes onto the chat path instead of the inject path.
- **Deterministic match (`HOSTNAME_RULES`):** broadens the Reddit clause from a 4-hostname enum to apex + any `.reddit.com` subdomain + `redd.it`, future-proofing against subdomains Reddit ships (already shipped `sh.reddit.com` for the modern mobile share-link UI).
- **System prompt:** drops the "you would expect to discuss a current happening" qualifier from the social-post bullet. That qualifier filtered Reddit URLs that fell through the deterministic rule based on newsworthiness — meaningful before news-worker opened its curate gates, now actively blocking the intended new behavior.
- **Media CDNs (`i.redd.it`, `v.redd.it`) intentionally not matched** — they're on a sibling domain so `endsWith('.reddit.com')` correctly excludes them. They carry binary media URLs, not post permalinks, and should keep falling through to chat as today.
- Mirrors the canonical `isRedditUrl` being implemented in news-worker `lib/reddit-fetch.ts` (parallel PR), where `redd.it` short-links are resolved via 302 follow before parsing.

## Test plan
- [ ] Paste `https://m.reddit.com/r/<sub>/comments/<id>/<slug>/` → DevTools Network shows `POST /api/chat/classify-url` returns `{route: 'inject', type: 'post'}` and a follow-up `POST /api/chat/inject` returns a `jobId`.
- [ ] Paste `https://sh.reddit.com/r/<sub>/comments/<id>/<slug>/?context=3` → same as above.
- [ ] Paste `https://np.reddit.com/r/<sub>/comments/<id>/<slug>/` → same as above.
- [ ] Paste `https://redd.it/<id>` (a short-link) → classified as `post` here; news-worker resolves the 302 to fetch the canonical post.
- [ ] Paste a non-newsy Reddit post (e.g. `https://www.reddit.com/r/programming/comments/.../linker-tips/`) → classified as `post` (was previously at risk of LLM-rerouting to `chat` due to the "current happening" qualifier; now deterministic).
- [ ] Paste `https://i.redd.it/foo.jpg` → not classified as `post` (correctly falls through to LLM/chat — it's a media URL, not a permalink).
- [ ] Paste `https://nytimes.com/...` → unchanged: `{route: 'inject', type: 'news-story-single'}`.
- [ ] Paste `https://example.com/static-marketing-page` → unchanged: `{route: 'chat'}`.

## Coordination
Pairs with a news-worker PR landing the same canonical `isRedditUrl` rule plus `redd.it` short-link redirect resolution. Both sides need to agree on the host set for the inject flow to be coherent; ordering between the two PRs is safe in either direction but the feature is fully usable only once both have shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)