### PR TITLE
feat(chat-classify-url): expand post type to blogs and editorial content

### DIFF
--- a/apps/web/app/api/chat/classify-url/route.ts
+++ b/apps/web/app/api/chat/classify-url/route.ts
@@ -163,11 +163,44 @@ function matchesNewsHost(host: string): boolean {
   return false;
 }
 
+const BLOG_HOSTS = new Set([
+  'substack.com',
+  'medium.com',
+  'mirror.xyz',
+  'paragraph.xyz',
+  'ghost.io',
+]);
+
+function matchesBlogHost(host: string): boolean {
+  for (const domain of BLOG_HOSTS) {
+    if (host === domain || host.endsWith(`.${domain}`)) return true;
+  }
+  return false;
+}
+
 const HOSTNAME_RULES: Array<{ match: (host: string, pathname: string) => boolean; type: InjectType }> = [
   { match: host => host === 'x.com' || host === 'twitter.com' || host === 'mobile.twitter.com', type: 'tweet' },
   {
     match: host =>
       host === 'reddit.com' || host === 'www.reddit.com' || host === 'old.reddit.com' || host === 'redd.it',
+    type: 'post',
+  },
+  // Blog platforms → Post (editorial, not news). Placed before the news-host
+  // check so a blog never gets mistaken for a news article.
+  { match: host => matchesBlogHost(host), type: 'post' },
+  // Specific company blogs (host + blog path → Post). Path-scoped on purpose
+  // so docs.* subdomains and product/landing pages are NOT routed to post —
+  // only the editorial blog/news/research sections are.
+  {
+    match: (host, path) =>
+      (host === 'anthropic.com' || host === 'www.anthropic.com') &&
+      /^\/(news|engineering|research)(\/|$)/.test(path),
+    type: 'post',
+  },
+  {
+    match: (host, path) =>
+      (host === 'openai.com' || host === 'www.openai.com') &&
+      /^\/(index|blog|research)(\/|$)/.test(path),
     type: 'post',
   },
   { match: host => host.endsWith('.wikipedia.org') || host === 'wikipedia.org', type: 'news-story-single' },
@@ -179,6 +212,7 @@ const CLASSIFIER_SYSTEM_PROMPT = `You are routing a URL to one of two pipelines 
 
 Return route="inject" when the URL points to:
 - A news article, current event, breaking story, exposé, or evolving topic from any publication.
+- A blog post, company or engineering blog, personal essay, or newsletter post (e.g. Substack, Medium, Mirror, Ghost, or a company's /blog).
 - A Wikipedia article (any kind — topic, person, organization, event).
 - A LinkedIn profile or personal/portfolio site.
 - A social post (X / Twitter / Reddit) you would expect to discuss a current happening.
@@ -189,11 +223,13 @@ Return route="chat" ONLY when the URL clearly points to:
 - Encyclopedic definitions of static concepts with no time-sensitive component.
 
 When route="inject", also pick the most appropriate type:
-- "news-story-single" — any news article, current event, Wikipedia article, LinkedIn profile, or personal/portfolio site.
+- "news-story-single" — a journalistic news article or current-events story from a news publication, OR a Wikipedia article, OR a LinkedIn / personal profile.
+- "post" — a blog post, company/engineering blog, personal essay, or newsletter/Substack/Medium/Mirror post: editorial web content that is NOT from a journalistic news outlet. (Reddit URLs are also "post".)
 - "tweet" — X / Twitter URL.
-- "post" — Reddit URL.
 
-Bias toward route="inject": if the URL plausibly looks like a news article, current event, biography, or social post, choose inject. Only choose chat when the page is clearly static/reference/marketing content. When genuinely unsure, prefer route="inject" with type="news-story-single". Never invent a URL or visit it; decide from the URL itself.`;
+Decide "news-story-single" vs "post" by the SOURCE, not the topic: a news organization reporting an event → "news-story-single"; an individual's or a company's OWN blog/essay/newsletter → "post".
+
+Bias toward route="inject": if the URL plausibly looks like a news article, blog post, current event, biography, or social post, choose inject. Only choose chat when the page is clearly static/reference/marketing content. When genuinely unsure between the two inject types, prefer "news-story-single". Never invent a URL or visit it; decide from the URL itself.`;
 
 function isSameOrigin(req: Request): boolean {
   const origin = req.headers.get('origin');


### PR DESCRIPTION
## Summary
Aligns the URL classifier with news-worker's commit [`ab99eec5`](https://github.com/geo-explorers/news-worker/commit/ab99eec5) (`feat(inject): web Posts (any non-X URL)`), which generalized the inject pipeline's `post` type from "Reddit only" to "any non-X editorial URL". On the classifier side this means a paste of a Substack/Medium/Mirror/Ghost/paragraph.xyz article — or an editorial page on a company blog like `anthropic.com/news` or `openai.com/blog` — should route to `type=post` instead of defaulting to `news-story-single` (journalism only) or falling through to `chat`.

## Changes (in `apps/web/app/api/chat/classify-url/route.ts`)

**1. `BLOG_HOSTS` + `matchesBlogHost` (new).** Suffix-matched set of `{substack.com, medium.com, mirror.xyz, paragraph.xyz, ghost.io}` so `alice.substack.com` etc. are caught.

**2. `HOSTNAME_RULES` (extended).** Three new `post`-typed entries between the existing Reddit and Wikipedia/LinkedIn rules:
- Generic `matchesBlogHost` — placed *before* the news-host check so a blog never gets mistaken for a news article.
- **Path-scoped** `anthropic.com/{news,engineering,research}` — `docs.anthropic.com`, `anthropic.com/api`, `anthropic.com/pricing` etc. are NOT routed to post.
- **Path-scoped** `openai.com/{index,blog,research}` — `openai.com/api`, `openai.com/pricing` etc. are NOT routed to post.

The Reddit hostname rule is intentionally **unchanged** at the original 4-host enum.

**3. `CLASSIFIER_SYSTEM_PROMPT` (rewritten).** Adds a blog-post bullet to the inject criteria, rewrites the type definitions so `news-story-single` is journalism-only and `post` is the editorial bucket (with Reddit kept inside), and introduces the SOURCE-not-topic decision rule so a NYT-published essay isn't classified as a blog post (it's still journalism). The unsure-default is reworded to clarify it's a tiebreaker between the two inject types, not a global fallback.

## Test plan

- [ ] Paste `https://nathanbarry.substack.com/p/something` → `{route: 'inject', type: 'post'}` *(new — deterministic via BLOG_HOSTS)*
- [ ] Paste `https://www.anthropic.com/news/claude-3-5-sonnet` → `{route: 'inject', type: 'post'}` *(new — deterministic via path-scope)*
- [ ] Paste `https://openai.com/index/gpt-4o/` → `{route: 'inject', type: 'post'}` *(new — deterministic via path-scope)*
- [ ] Paste `https://docs.anthropic.com/en/docs/...` → falls through deterministic rules → LLM should return `{route: 'chat'}` *(unchanged — docs/API references are not editorial)*
- [ ] Paste `https://openai.com/pricing` → falls through → LLM returns `{route: 'chat'}` *(unchanged — product/marketing page)*
- [ ] Paste `https://reddit.com/r/.../comments/.../...` → `{route: 'inject', type: 'post'}` *(unchanged — same 4-host Reddit rule)*
- [ ] Paste `https://nytimes.com/...` → `{route: 'inject', type: 'news-story-single'}` *(unchanged — journalistic outlet)*
- [ ] Paste `https://x.com/.../status/...` → `{route: 'inject', type: 'tweet'}` *(unchanged)*
- [ ] Paste a Substack article published by a journalist → `{route: 'inject', type: 'post'}` (deterministic, regardless of the topic). Confirms the SOURCE-not-topic rule via host-based deterministic short-circuit.
- [ ] Paste an unknown editorial site (e.g. `https://stratechery.com/2024/some-essay/`) → LLM should choose `{route: 'inject', type: 'post'}` *(new — via prompt rewrite)*

## Coordination

Pairs with news-worker's [`ab99eec5`](https://github.com/geo-explorers/news-worker/commit/ab99eec5) which is already on the `feat/inject-urls-async-pipeline` branch. Without that change, classifying a Substack URL as `post` here would still fail at fetch time on news-worker (old `schedule.ts` gate rejected non-Reddit URLs). With it, the inject pipeline accepts the URL and produces a Post entity using the standard article fetcher.

## Context: replaces #1831

PR #1831 was based on a misread of the original ask — it widened Reddit hostname matching and dropped the "current happening" prompt qualifier. Closed. This PR has the correct scope, aligned with news-worker [`ab99eec5`](https://github.com/geo-explorers/news-worker/commit/ab99eec5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
