### PR TITLE
feat(chat-classify-url): route company /news sections to News Story

### DIFF
--- a/apps/web/app/api/chat/classify-url/route.ts
+++ b/apps/web/app/api/chat/classify-url/route.ts
@@ -190,19 +190,37 @@ const HOSTNAME_RULES: Array<{ match: (host: string, pathname: string) => boolean
   { match: host => matchesBlogHost(host), type: 'post' },
   // Specific company blogs (host + blog path → Post). Path-scoped on purpose
   // so docs.* subdomains and product/landing pages are NOT routed to post —
-  // only the editorial blog/news/research sections are.
+  // only the editorial blog/research sections are. NOTE: /news is deliberately
+  // excluded here — a company's /news section is a newsroom, routed to News
+  // Story by the general /news rule below.
   {
     match: (host, path) =>
       (host === 'anthropic.com' || host === 'www.anthropic.com') &&
-      /^\/(news|engineering|research)(\/|$)/.test(path),
+      /^\/(engineering|research)(\/|$)/.test(path),
     type: 'post',
   },
+  // OpenAI publishes its articles under /index, and the newsroom landing
+  // (openai.com/news) surfaces those same /index posts as its cards — so
+  // /index IS OpenAI's newsroom → News Story.
   {
     match: (host, path) =>
       (host === 'openai.com' || host === 'www.openai.com') &&
-      /^\/(index|blog|research)(\/|$)/.test(path),
+      /^\/index(\/|$)/.test(path),
+    type: 'news-story-single',
+  },
+  // OpenAI's other editorial sections → Post (blog/research). Whether these
+  // should also be News is still TBD.
+  {
+    match: (host, path) =>
+      (host === 'openai.com' || host === 'www.openai.com') &&
+      /^\/(blog|research)(\/|$)/.test(path),
     type: 'post',
   },
+  // Any company's own /news section → News Story. A /news path is a newsroom /
+  // press section, so it's a news source even when the domain isn't a dedicated
+  // news outlet (covers anthropic.com/news, openai.com/news, and any company).
+  // Runs AFTER the blog-platform rule above, so Substack/Medium/etc. stay Post.
+  { match: (_host, path) => /^\/news(\/|$)/.test(path), type: 'news-story-single' },
   { match: host => host.endsWith('.wikipedia.org') || host === 'wikipedia.org', type: 'news-story-single' },
   { match: host => host === 'linkedin.com' || host === 'www.linkedin.com', type: 'news-story-single' },
   { match: host => matchesNewsHost(host), type: 'news-story-single' },


### PR DESCRIPTION
## What

A company's own `/news` section is a newsroom, so a URL there should ingest as a **News Story**, not a **Post**. This adjusts the deterministic `HOSTNAME_RULES` in `classify-url` to reflect that.

## Changes

- **Anthropic** — strip `news` from the Post rule. `anthropic.com/news/*` is their newsroom → **News Story**. `/engineering` and `/research` stay **Post** (genuine technical blog).
- **OpenAI** — `openai.com/index/*` → **News Story**. The newsroom landing (`openai.com/news`) surfaces `/index` articles as its cards, so `/index` *is* OpenAI's newsroom. `/blog` and `/research` stay **Post** (revisit later).
- **General rule** — any host whose path is `/news` or `/news/*` → **News Story**. Placed *after* the blog-platform rule, so Substack / Medium / Mirror / Ghost still resolve to **Post**.

## Behavior

| URL | Routes to |
|---|---|
| `anthropic.com/news/claude-design-anthropic-labs` | News Story |
| `anthropic.com/research/…`, `/engineering/…` | Post |
| `openai.com/index/model-disproves-…` | News Story |
| `openai.com/news/` | News Story |
| `openai.com/blog/…`, `/research/…` | Post |
| `somecompany.com/news/quarterly-results` | News Story |
| `x.com/…` / Wikipedia / foxnews.com | tweet / News Story (unchanged) |

## Testing

Verified against the real `POST` handler with 15 deterministic cases (the table above plus blog-platform precedence and the some edge cases). ESLint clean.
