### PR TITLE
fix(data-block): keep space image behind sticky navbar on scroll

### DIFF
--- a/apps/web/partials/blocks/table/table-block-editable-title.tsx
+++ b/apps/web/partials/blocks/table/table-block-editable-title.tsx
@@ -44,7 +44,7 @@ export function TableBlockEditableTitle({ spaceId }: { spaceId: string }) {
         />
       )}
       {source.type === 'SPACES' && (
-        <div className="group relative z-100 flex h-full">
+        <div className="group relative z-10 flex h-full">
           {renderedSpaces.map(spaceId => {
             const selectedSpace = spacesById.get(spaceId);
 


### PR DESCRIPTION
## Summary
- When a data block scrolled off the top of the viewport, the source-space image rendered over the navbar instead of going under it.
- The SPACES title wrapper in `table-block-editable-title.tsx` used `z-100`, which created a stacking context above the navbar's `z-60`.
- Lowered the wrapper to `z-10`. It still creates a stacking context (so the inner hover popover at `z-100` continues to stack above sibling rows in the data block), but now sits well below the navbar.

## Test plan
- [ ] Open a page with a data block whose source is one or more spaces (so the space avatar(s) appear next to the title).
- [ ] Scroll the data block off the top — confirm the space image scrolls under the navbar instead of over it.
- [ ] Hover the space avatar stack — confirm the popover listing the spaces still appears above the rest of the data block.
- [ ] Verify the overflow "+N" badge still renders correctly when there are more than 3 spaces.