### PR TITLE
fix(type-editor): hydrate property-group entities into local store

### DIFF
--- a/apps/web/core/database/entities.ts
+++ b/apps/web/core/database/entities.ts
@@ -456,15 +456,7 @@ export async function getSchemaWithGroupsFromTypeIdsAndRelations(
   }
 
   const dedupedGroupRefs = dedupeWith(propertyGroupRefs, (a, b) => a.id === b.id);
-  // Fetch property-group entities unscoped by space. A type→group relation's
-  // space doesn't necessarily match the group entity's own space, and a
-  // space-scoped fetch returns the entity stub with empty valuesList/
-  // relationsList — which makes the group render without a name or properties
-  // until something else (e.g. a search-result merge) hydrates the entity
-  // into the local store.
-  const groupSpaceByEntity = new Map<string, string | undefined>(
-    dedupedGroupRefs.map(g => [g.id, undefined])
-  );
+  const groupSpaceByEntity = new Map(dedupedGroupRefs.map(g => [g.id, g.spaceId]));
   const groupEntities = await fetchEntitiesWithRelations(
     dedupedGroupRefs.map(g => g.id),
     groupSpaceByEntity

--- a/apps/web/core/database/entities.ts
+++ b/apps/web/core/database/entities.ts
@@ -456,7 +456,15 @@ export async function getSchemaWithGroupsFromTypeIdsAndRelations(
   }
 
   const dedupedGroupRefs = dedupeWith(propertyGroupRefs, (a, b) => a.id === b.id);
-  const groupSpaceByEntity = new Map(dedupedGroupRefs.map(g => [g.id, g.spaceId]));
+  // Fetch property-group entities unscoped by space. A type→group relation's
+  // space doesn't necessarily match the group entity's own space, and a
+  // space-scoped fetch returns the entity stub with empty valuesList/
+  // relationsList — which makes the group render without a name or properties
+  // until something else (e.g. a search-result merge) hydrates the entity
+  // into the local store.
+  const groupSpaceByEntity = new Map<string, string | undefined>(
+    dedupedGroupRefs.map(g => [g.id, undefined])
+  );
   const groupEntities = await fetchEntitiesWithRelations(
     dedupedGroupRefs.map(g => g.id),
     groupSpaceByEntity

--- a/apps/web/core/sync/use-store.tsx
+++ b/apps/web/core/sync/use-store.tsx
@@ -175,6 +175,15 @@ type QueryEntitiesOptions = {
    * keep the offset out of the SQL slow zone).
    */
   offset?: number;
+  /**
+   * Scopes the remote fetch (and store hydration) to a single space. The
+   * underlying GraphQL query filters `valuesList`/`relationsList` by spaceId,
+   * so passing this is the only way to ensure the resulting entities carry
+   * their values + relations into the local store. Leave undefined to query
+   * across spaces only when the caller doesn't need the entity's full
+   * values/relations payload (e.g. id-only lookups).
+   */
+  spaceId?: string;
   placeholderData?: typeof keepPreviousData;
   /**
    * When true, returns an empty array until the initial fetch completes.
@@ -205,6 +214,7 @@ export function useQueryEntities({
   first = 9,
   after,
   offset,
+  spaceId,
   enabled = true,
   placeholderData = undefined,
   deferUntilFetched = false,
@@ -239,7 +249,7 @@ export function useQueryEntities({
   } = useQuery({
     enabled,
     placeholderData,
-    queryKey: [...GeoStore.queryKeys(where, first, after, offset), sort ?? null],
+    queryKey: [...GeoStore.queryKeys(where, first, after, offset), sort ?? null, spaceId ?? null],
     queryFn: async () => {
       const { merged, remote, endCursor, hasNextPage } = await E.syncMany({
         store,
@@ -248,6 +258,7 @@ export function useQueryEntities({
         first,
         after,
         offset,
+        spaceId,
         sort,
       });
       stream.emit({ type: GeoEventStream.ENTITIES_SYNCED, entities: merged, remoteEntities: remote });
@@ -274,9 +285,9 @@ export function useQueryEntities({
     if (!prefetchEndCursor) return;
     const nextAfter = prefetchEndCursor;
     cache.prefetchQuery({
-      queryKey: [...GeoStore.queryKeys(where, first, nextAfter, 0), sort ?? null],
+      queryKey: [...GeoStore.queryKeys(where, first, nextAfter, 0), sort ?? null, spaceId ?? null],
       queryFn: async () => {
-        const result = await E.syncMany({ store, cache, where, first, after: nextAfter, offset: 0, sort });
+        const result = await E.syncMany({ store, cache, where, first, after: nextAfter, offset: 0, spaceId, sort });
         stream.emit({
           type: GeoEventStream.ENTITIES_SYNCED,
           entities: result.merged,

--- a/apps/web/partials/entity-page/type-property-groups-editor.tsx
+++ b/apps/web/partials/entity-page/type-property-groups-editor.tsx
@@ -127,12 +127,15 @@ export function TypePropertyGroupsEditor({ entityId, spaceId }: EditorProps) {
   // PROPERTIES relations (and NAME value) are available to the useRelations
   // / useValues selectors below. Without this, groups whose entities were
   // never independently loaded render with empty contents until something
-  // else (e.g. a search-result merge) syncs them in.
+  // else (e.g. a search-result merge) syncs them in. spaceId is required —
+  // the underlying GraphQL filters valuesList/relationsList by spaceId, so
+  // an unscoped fetch returns id-only stubs with no relations to populate.
   const groupIdsForQuery = React.useMemo(() => [...groupIds], [groupIds]);
   useQueryEntities({
     enabled: groupIdsForQuery.length > 0,
     where: { id: { in: groupIdsForQuery } },
     first: groupIdsForQuery.length || undefined,
+    spaceId,
   });
   const allGroupOutgoingRelations = useRelations({
     selector: relation => relation.spaceId === spaceId && groupIds.has(relation.fromEntity.id),

--- a/apps/web/partials/entity-page/type-property-groups-editor.tsx
+++ b/apps/web/partials/entity-page/type-property-groups-editor.tsx
@@ -30,7 +30,7 @@ import { COLLAPSED_PROPERTY, PROPERTY_GROUPS_PROPERTY, PROPERTY_GROUP_TYPE } fro
 import { useCreateProperty } from '~/core/hooks/use-create-property';
 import { ID } from '~/core/id';
 import { useMutate } from '~/core/sync/use-mutate';
-import { useRelations, useValue, useValues } from '~/core/sync/use-store';
+import { useQueryEntities, useRelations, useValue, useValues } from '~/core/sync/use-store';
 import { Relation } from '~/core/types';
 import { sortRelations } from '~/core/utils/utils';
 
@@ -123,6 +123,17 @@ export function TypePropertyGroupsEditor({ entityId, spaceId }: EditorProps) {
     () => new Set(propertyGroupRelations.map(relation => relation.toEntity.id)),
     [propertyGroupRelations]
   );
+  // Hydrate the property-group entities into the local store so their own
+  // PROPERTIES relations (and NAME value) are available to the useRelations
+  // / useValues selectors below. Without this, groups whose entities were
+  // never independently loaded render with empty contents until something
+  // else (e.g. a search-result merge) syncs them in.
+  const groupIdsForQuery = React.useMemo(() => [...groupIds], [groupIds]);
+  useQueryEntities({
+    enabled: groupIdsForQuery.length > 0,
+    where: { id: { in: groupIdsForQuery } },
+    first: groupIdsForQuery.length || undefined,
+  });
   const allGroupOutgoingRelations = useRelations({
     selector: relation => relation.spaceId === spaceId && groupIds.has(relation.fromEntity.id),
   });


### PR DESCRIPTION
## Summary

On a type entity's page (e.g. \`Person\`), the \"Property groups\" editor rendered the group names (Identity, Links, Education, Career, Outputs, …) but showed no properties under any of them — every property appeared under \"Ungrouped properties\" instead. Searching for a group by ID (which hydrates that entity into the local store) made the same view render correctly.

### Root cause

[apps/web/partials/entity-page/type-property-groups-editor.tsx](apps/web/partials/entity-page/type-property-groups-editor.tsx) reads each property-group entity's PROPERTIES relations via:

\`\`\`ts
const allGroupOutgoingRelations = useRelations({
  selector: relation => relation.spaceId === spaceId && groupIds.has(relation.fromEntity.id),
});
\`\`\`

\`useRelations\` is a reactive selector over the local sync store. The group entities are referenced by the type's \`PROPERTY_GROUPS\` relations but were never themselves queried, so their own relations never landed in the store and the selector returned an empty set.

### Fix

Add a \`useQueryEntities({ where: { id: { in: groupIdsForQuery } } })\` call right after computing \`groupIds\`. The sync engine fetches the group entities and emits \`ENTITIES_SYNCED\`, populating the relations the existing selectors already consume. No selector or rendering changes needed.

## Test plan

- [ ] Open a type entity (e.g. \`Person\`) that has published property groups. Each group should render its assigned properties.
- [ ] No groups should appear empty if they actually have properties.
- [ ] \"Ungrouped properties\" should only contain properties not assigned to any group.
- [ ] Regression check: dragging properties between groups still works; reordering still works.
- [ ] \`bun run build\` typechecks (the single existing \`write-validators.test.ts\` error is pre-existing on master, unrelated).