### PR TITLE
[codex] Fix synthetic property group rendering

### DIFF
--- a/apps/web/core/database/entities.test.ts
+++ b/apps/web/core/database/entities.test.ts
@@ -112,7 +112,7 @@ describe('getSchemaWithGroupsFromTypeIdsAndRelations', () => {
     expect(result.hasPropertyGroups).toBe(false);
   });
 
-  it('renders isType properties as a named group even without explicit property groups', async () => {
+  it('keeps isType properties flat when there are no explicit property groups', async () => {
     mocks.propertiesById.set(
       'is-type-property',
       property('is-type-property', 'Is type property', { dataType: 'RELATION', isType: true })
@@ -144,17 +144,10 @@ describe('getSchemaWithGroupsFromTypeIdsAndRelations', () => {
       ]
     );
 
-    expect(result.propertyGroups).toEqual([
-      {
-        id: 'is-type-entity-is-type-relation',
-        name: 'Target type',
-        collapsed: false,
-        propertyIds: ['target-property'],
-        source: 'isType',
-      },
-    ]);
-    expect(result.ungroupedPropertyIds).toEqual(['is-type-property']);
-    expect(result.hasPropertyGroups).toBe(true);
+    expect(result.propertyGroups).toEqual([]);
+    expect(result.ungroupedPropertyIds).toEqual(['is-type-property', 'target-property']);
+    expect(result.hasPropertyGroups).toBe(false);
+    expect(result.schema.map(item => item.id)).toContain('target-property');
   });
 
   it('does not render an isType group when the target entity has no properties', async () => {
@@ -326,15 +319,9 @@ describe('getSchemaWithGroupsFromTypeIdsAndRelations', () => {
       ]
     );
 
-    expect(result.propertyGroups).toEqual([
-      {
-        id: 'is-type-entity-role-relation',
-        name: 'Product lead',
-        collapsed: false,
-        propertyIds: ['related-projects'],
-        source: 'isType',
-      },
-    ]);
+    expect(result.propertyGroups).toEqual([]);
+    expect(result.ungroupedPropertyIds).toEqual(['roles-property', 'related-projects']);
+    expect(result.hasPropertyGroups).toBe(false);
     expect(result.schema.map(item => item.id)).toContain('related-projects');
   });
 });

--- a/apps/web/core/database/entities.ts
+++ b/apps/web/core/database/entities.ts
@@ -595,7 +595,28 @@ export async function getSchemaWithGroupsFromTypeIdsAndRelations(
     }
   }
 
-  const groupedPropertyIds = propertyGroups.flatMap(group => group.propertyIds);
+  // Synthetic isType groups are only meaningful as a layout hint when at
+  // least one real type-defined group exists. Otherwise, keep the inherited
+  // properties in the normal flat section so entity pages do not get a
+  // type-named collapsible wrapper around their standard properties.
+  const hasRealGroups = propertyGroups.some(group => group.source === 'type');
+  let effectivePropertyGroups = propertyGroups;
+  if (!hasRealGroups) {
+    const syntheticPropertyIds = propertyGroups
+      .filter(group => group.source === 'isType')
+      .flatMap(group => group.propertyIds);
+
+    const ungroupedSeen = new Set(ungroupedPropertyIds);
+    for (const propertyId of syntheticPropertyIds) {
+      if (ungroupedSeen.has(propertyId)) continue;
+      ungroupedSeen.add(propertyId);
+      ungroupedPropertyIds.push(propertyId);
+    }
+
+    effectivePropertyGroups = [];
+  }
+
+  const groupedPropertyIds = effectivePropertyGroups.flatMap(group => group.propertyIds);
   const groupedPropertyIdSet = new Set(groupedPropertyIds);
   const ungroupedSet = new Set(ungroupedPropertyIds);
 
@@ -632,8 +653,8 @@ export async function getSchemaWithGroupsFromTypeIdsAndRelations(
 
   return {
     schema: orderedSchema,
-    propertyGroups,
+    propertyGroups: effectivePropertyGroups,
     ungroupedPropertyIds,
-    hasPropertyGroups: propertyGroups.length > 0,
+    hasPropertyGroups: effectivePropertyGroups.length > 0,
   };
 }


### PR DESCRIPTION
## Summary

- Keep synthetic `isType` schema groups flat unless the entity type defines at least one real property group.
- Preserve inherited properties in the normal ungrouped properties section so Post-like entities do not get a type-named collapsible wrapper around the standard properties panel.
- Update schema grouping tests to lock the flat fallback while preserving explicit grouped behavior.

## Root Cause

The property grouping assembly surfaced synthetic `isType` groups even when a type had no explicit property groups. That caused inherited type properties to become a custom collapsible section, such as a Post-named information wrapper, instead of rendering inside the normal properties container.

## Validation

- `bun run test core/database/entities.test.ts` from `apps/web`: 5 tests passed.
- `bun run lint -- core/database/entities.ts core/database/entities.test.ts`: 0 errors; existing repo warnings remain.