### PR TITLE
refactor(web): migrate proposal hooks to geo-sdk

### DIFF
--- a/apps/web/core/hooks/use-propose-add-editor.ts
+++ b/apps/web/core/hooks/use-propose-add-editor.ts
@@ -1,29 +1,18 @@
 'use client';
 
-import { IdUtils } from '@geoprotocol/geo-sdk/lite';
+import { daoSpace } from '@geoprotocol/geo-sdk';
 import { useMutation } from '@tanstack/react-query';
 
 import { useCallback } from 'react';
 
 import { Effect, Either } from 'effect';
-import { type Hex, encodeFunctionData } from 'viem';
 
 import { usePersonalSpaceId } from '~/core/hooks/use-personal-space-id';
 import { useSmartAccount } from '~/core/hooks/use-smart-account';
 import { useSmartAccountTransaction } from '~/core/hooks/use-smart-account-transaction';
-import { useSpace } from '~/core/hooks/use-space';
 import { useStatusBar } from '~/core/state/status-bar-store';
 import { runEffectEither } from '~/core/telemetry/effect-runtime';
-import { encodeProposalCreatedData } from '~/core/utils/contracts/governance';
-import {
-  DAOSpaceAbi,
-  EMPTY_SIGNATURE,
-  EMPTY_TOPIC_HEX,
-  GOVERNANCE_ACTIONS,
-  SPACE_REGISTRY_ADDRESS,
-  SpaceRegistryAbi,
-  VOTING_MODE,
-} from '~/core/utils/contracts/space-registry';
+import { SPACE_REGISTRY_ADDRESS } from '~/core/utils/contracts/space-registry';
 import { validateSpaceId } from '~/core/utils/utils';
 
 interface UseProposeAddEditorArgs {
@@ -40,14 +29,13 @@ interface ProposeAddEditorParams {
  * Hook to propose adding an editor to a DAO space.
  *
  * Note: Editor actions are NOT valid for fast path per the DAOSpace contract.
- * This hook always uses slow path (VOTING_MODE.SLOW).
+ * This hook always uses slow path.
  */
 export function useProposeAddEditor({ spaceId }: UseProposeAddEditorArgs) {
   const { dispatch } = useStatusBar();
 
   const { smartAccount } = useSmartAccount();
   const { personalSpaceId, isRegistered } = usePersonalSpaceId();
-  const { space } = useSpace(spaceId ?? undefined);
 
   const tx = useSmartAccountTransaction({
     address: SPACE_REGISTRY_ADDRESS,
@@ -76,13 +64,6 @@ export function useProposeAddEditor({ spaceId }: UseProposeAddEditorArgs) {
         throw new Error(message);
       }
 
-      if (!space?.address) {
-        const message = 'Space information is still loading. Please try again.';
-        console.error('No space address found');
-        dispatch({ type: 'ERROR', payload: message });
-        throw new Error(message);
-      }
-
       if (!validateSpaceId(targetEditorSpaceId)) {
         const message = 'Invalid editor ID format. Please try again.';
         console.error('Invalid target editor space ID:', targetEditorSpaceId);
@@ -90,58 +71,29 @@ export function useProposeAddEditor({ spaceId }: UseProposeAddEditorArgs) {
         throw new Error(message);
       }
 
-      const spaceAddress = space.address as Hex;
-
       console.log('Proposing to add editor', {
-        fromSpaceId: personalSpaceId,
-        toSpaceId: spaceId,
+        authorSpaceId: personalSpaceId,
+        spaceId,
         targetEditorSpaceId,
-        spaceAddress,
       });
 
-      const writeTxEffect = Effect.gen(function* () {
-        const proposalId = `0x${IdUtils.generate()}` as const;
-        const fromSpaceId = `0x${personalSpaceId}` as const;
-        const toSpaceId = `0x${spaceId}` as const;
-        const editorSpaceId = `0x${targetEditorSpaceId}` as const;
-
-        // Encode the addEditor call that will execute if the proposal passes
-        const addEditorCallData = encodeFunctionData({
-          functionName: 'addEditor',
-          abi: DAOSpaceAbi,
-          args: [editorSpaceId],
-        });
-
-        const proposalActions = [
-          {
-            to: spaceAddress,
-            value: 0n,
-            data: addEditorCallData,
-          },
-        ];
-
-        // Editor actions must use slow path - not valid for fast path per contract
-        const data = encodeProposalCreatedData(proposalId, VOTING_MODE.SLOW, proposalActions);
-
-        const callData = encodeFunctionData({
-          functionName: 'enter',
-          abi: SpaceRegistryAbi,
-          args: [fromSpaceId, toSpaceId, GOVERNANCE_ACTIONS.PROPOSAL_CREATED, EMPTY_TOPIC_HEX, data, EMPTY_SIGNATURE],
-        });
-
-        const hash = yield* tx(callData).pipe(
-          Effect.withSpan('web.write.createProposal.addEditor'),
-          Effect.annotateSpans({
-            'io.operation': 'create_proposal',
-            'space.type': 'DAO',
-            'governance.action': 'proposal_created',
-            'governance.proposal_action': 'add_editor',
-            'governance.voting_mode': 'SLOW',
-          })
-        );
-        console.log('Transaction hash: ', hash);
-        return hash;
+      const { calldata: callData } = daoSpace.proposeAddEditor({
+        authorSpaceId: personalSpaceId,
+        spaceId,
+        newEditorSpaceId: targetEditorSpaceId,
+        votingMode: 'SLOW',
       });
+
+      const writeTxEffect = tx(callData).pipe(
+        Effect.withSpan('web.write.createProposal.addEditor'),
+        Effect.annotateSpans({
+          'io.operation': 'create_proposal',
+          'space.type': 'DAO',
+          'governance.action': 'proposal_created',
+          'governance.proposal_action': 'add_editor',
+          'governance.voting_mode': 'SLOW',
+        })
+      );
 
       const result = await runEffectEither(writeTxEffect);
 
@@ -156,10 +108,10 @@ export function useProposeAddEditor({ spaceId }: UseProposeAddEditorArgs) {
           // Necessary to propagate error status to useMutation
           throw error;
         },
-        onRight: () => console.log('Successfully proposed to add editor'),
+        onRight: hash => console.log('Successfully proposed to add editor. Transaction hash:', hash),
       });
     },
-    [dispatch, smartAccount, personalSpaceId, isRegistered, spaceId, space, tx]
+    [dispatch, smartAccount, personalSpaceId, isRegistered, spaceId, tx]
   );
 
   const { mutate, status } = useMutation({

--- a/apps/web/core/hooks/use-propose-add-member.ts
+++ b/apps/web/core/hooks/use-propose-add-member.ts
@@ -1,29 +1,18 @@
 'use client';
 
-import { IdUtils } from '@geoprotocol/geo-sdk/lite';
+import { daoSpace } from '@geoprotocol/geo-sdk';
 import { useMutation } from '@tanstack/react-query';
 
 import { useCallback } from 'react';
 
 import { Effect, Either } from 'effect';
-import { type Hex, encodeFunctionData } from 'viem';
 
 import { usePersonalSpaceId } from '~/core/hooks/use-personal-space-id';
 import { useSmartAccount } from '~/core/hooks/use-smart-account';
 import { useSmartAccountTransaction } from '~/core/hooks/use-smart-account-transaction';
-import { useSpace } from '~/core/hooks/use-space';
 import { useStatusBar } from '~/core/state/status-bar-store';
 import { runEffectEither } from '~/core/telemetry/effect-runtime';
-import { encodeProposalCreatedData } from '~/core/utils/contracts/governance';
-import {
-  DAOSpaceAbi,
-  EMPTY_SIGNATURE,
-  EMPTY_TOPIC_HEX,
-  GOVERNANCE_ACTIONS,
-  SPACE_REGISTRY_ADDRESS,
-  SpaceRegistryAbi,
-  VOTING_MODE,
-} from '~/core/utils/contracts/space-registry';
+import { SPACE_REGISTRY_ADDRESS } from '~/core/utils/contracts/space-registry';
 import { validateSpaceId } from '~/core/utils/utils';
 
 interface UseProposeAddMemberArgs {
@@ -43,7 +32,6 @@ export function useProposeAddMember({ spaceId }: UseProposeAddMemberArgs) {
 
   const { smartAccount } = useSmartAccount();
   const { personalSpaceId, isRegistered } = usePersonalSpaceId();
-  const { space } = useSpace(spaceId ?? undefined);
 
   const tx = useSmartAccountTransaction({
     address: SPACE_REGISTRY_ADDRESS,
@@ -72,13 +60,6 @@ export function useProposeAddMember({ spaceId }: UseProposeAddMemberArgs) {
         throw new Error(message);
       }
 
-      if (!space?.address) {
-        const message = 'Space information is still loading. Please try again.';
-        console.error('No space address found');
-        dispatch({ type: 'ERROR', payload: message });
-        throw new Error(message);
-      }
-
       if (!validateSpaceId(targetMemberSpaceId)) {
         const message = 'Invalid member ID format. Please try again.';
         console.error('Invalid target member space ID:', targetMemberSpaceId);
@@ -86,60 +67,32 @@ export function useProposeAddMember({ spaceId }: UseProposeAddMemberArgs) {
         throw new Error(message);
       }
 
-      const spaceAddress = space.address as Hex;
       const normalizedVotingMode = votingMode === 'slow' ? 'SLOW' : 'FAST';
-      const votingModeValue = normalizedVotingMode === 'FAST' ? VOTING_MODE.FAST : VOTING_MODE.SLOW;
 
       console.log('Proposing to add member', {
-        fromSpaceId: personalSpaceId,
-        toSpaceId: spaceId,
+        authorSpaceId: personalSpaceId,
+        spaceId,
         targetMemberSpaceId,
-        votingMode,
-        spaceAddress,
+        votingMode: normalizedVotingMode,
       });
 
-      const writeTxEffect = Effect.gen(function* () {
-        const proposalId = `0x${IdUtils.generate()}` as const;
-        const fromSpaceId = `0x${personalSpaceId}` as const;
-        const toSpaceId = `0x${spaceId}` as const;
-        const memberSpaceId = `0x${targetMemberSpaceId}` as const;
-
-        // Encode the addMember call that will execute if the proposal passes
-        const addMemberCallData = encodeFunctionData({
-          functionName: 'addMember',
-          abi: DAOSpaceAbi,
-          args: [memberSpaceId],
-        });
-
-        const proposalActions = [
-          {
-            to: spaceAddress,
-            value: 0n,
-            data: addMemberCallData,
-          },
-        ];
-
-        const data = encodeProposalCreatedData(proposalId, votingModeValue, proposalActions);
-
-        const callData = encodeFunctionData({
-          functionName: 'enter',
-          abi: SpaceRegistryAbi,
-          args: [fromSpaceId, toSpaceId, GOVERNANCE_ACTIONS.PROPOSAL_CREATED, EMPTY_TOPIC_HEX, data, EMPTY_SIGNATURE],
-        });
-
-        const hash = yield* tx(callData).pipe(
-          Effect.withSpan('web.write.createProposal.addMember'),
-          Effect.annotateSpans({
-            'io.operation': 'create_proposal',
-            'space.type': 'DAO',
-            'governance.action': 'proposal_created',
-            'governance.proposal_action': 'add_member',
-            'governance.voting_mode': normalizedVotingMode,
-          })
-        );
-        console.log('Transaction hash: ', hash);
-        return hash;
+      const { calldata: callData } = daoSpace.proposeAddMember({
+        authorSpaceId: personalSpaceId,
+        spaceId,
+        newMemberSpaceId: targetMemberSpaceId,
+        votingMode: normalizedVotingMode,
       });
+
+      const writeTxEffect = tx(callData).pipe(
+        Effect.withSpan('web.write.createProposal.addMember'),
+        Effect.annotateSpans({
+          'io.operation': 'create_proposal',
+          'space.type': 'DAO',
+          'governance.action': 'proposal_created',
+          'governance.proposal_action': 'add_member',
+          'governance.voting_mode': normalizedVotingMode,
+        })
+      );
 
       const result = await runEffectEither(writeTxEffect);
 
@@ -158,10 +111,10 @@ export function useProposeAddMember({ spaceId }: UseProposeAddMemberArgs) {
           // Necessary to propagate error status to useMutation
           throw error;
         },
-        onRight: () => console.log('Successfully proposed to add member'),
+        onRight: hash => console.log('Successfully proposed to add member. Transaction hash:', hash),
       });
     },
-    [dispatch, smartAccount, personalSpaceId, isRegistered, spaceId, space, tx]
+    [dispatch, smartAccount, personalSpaceId, isRegistered, spaceId, tx]
   );
 
   const { mutate, status } = useMutation({

--- a/apps/web/core/hooks/use-propose-remove-editor.ts
+++ b/apps/web/core/hooks/use-propose-remove-editor.ts
@@ -1,29 +1,18 @@
 'use client';
 
-import { IdUtils } from '@geoprotocol/geo-sdk/lite';
+import { daoSpace } from '@geoprotocol/geo-sdk';
 import { useMutation } from '@tanstack/react-query';
 
 import { useCallback } from 'react';
 
 import { Effect, Either } from 'effect';
-import { type Hex, encodeFunctionData } from 'viem';
 
 import { usePersonalSpaceId } from '~/core/hooks/use-personal-space-id';
 import { useSmartAccount } from '~/core/hooks/use-smart-account';
 import { useSmartAccountTransaction } from '~/core/hooks/use-smart-account-transaction';
-import { useSpace } from '~/core/hooks/use-space';
 import { useStatusBar } from '~/core/state/status-bar-store';
 import { runEffectEither } from '~/core/telemetry/effect-runtime';
-import { encodeProposalCreatedData } from '~/core/utils/contracts/governance';
-import {
-  DAOSpaceAbi,
-  EMPTY_SIGNATURE,
-  EMPTY_TOPIC_HEX,
-  GOVERNANCE_ACTIONS,
-  SPACE_REGISTRY_ADDRESS,
-  SpaceRegistryAbi,
-  VOTING_MODE,
-} from '~/core/utils/contracts/space-registry';
+import { SPACE_REGISTRY_ADDRESS } from '~/core/utils/contracts/space-registry';
 import { validateSpaceId } from '~/core/utils/utils';
 
 interface UseProposeRemoveEditorArgs {
@@ -40,14 +29,13 @@ interface ProposeRemoveEditorParams {
  * Hook to propose removing an editor from a DAO space.
  *
  * Note: Editor actions are NOT valid for fast path per the DAOSpace contract.
- * This hook always uses slow path (VOTING_MODE.SLOW).
+ * This hook always uses slow path.
  */
 export function useProposeRemoveEditor({ spaceId }: UseProposeRemoveEditorArgs) {
   const { dispatch } = useStatusBar();
 
   const { smartAccount } = useSmartAccount();
   const { personalSpaceId, isRegistered } = usePersonalSpaceId();
-  const { space } = useSpace(spaceId ?? undefined);
 
   const tx = useSmartAccountTransaction({
     address: SPACE_REGISTRY_ADDRESS,
@@ -76,13 +64,6 @@ export function useProposeRemoveEditor({ spaceId }: UseProposeRemoveEditorArgs) 
         throw new Error(message);
       }
 
-      if (!space?.address) {
-        const message = 'Space information is still loading. Please try again.';
-        console.error('No space address found');
-        dispatch({ type: 'ERROR', payload: message });
-        throw new Error(message);
-      }
-
       if (!validateSpaceId(targetEditorSpaceId)) {
         const message = 'Invalid editor ID format. Please try again.';
         console.error('Invalid target editor space ID:', targetEditorSpaceId);
@@ -90,58 +71,29 @@ export function useProposeRemoveEditor({ spaceId }: UseProposeRemoveEditorArgs) 
         throw new Error(message);
       }
 
-      const spaceAddress = space.address as Hex;
-
       console.log('Proposing to remove editor', {
-        fromSpaceId: personalSpaceId,
-        toSpaceId: spaceId,
+        authorSpaceId: personalSpaceId,
+        spaceId,
         targetEditorSpaceId,
-        spaceAddress,
       });
 
-      const writeTxEffect = Effect.gen(function* () {
-        const proposalId = `0x${IdUtils.generate()}` as const;
-        const fromSpaceId = `0x${personalSpaceId}` as const;
-        const toSpaceId = `0x${spaceId}` as const;
-        const editorSpaceId = `0x${targetEditorSpaceId}` as const;
-
-        // Encode the removeEditor call that will execute if the proposal passes
-        const removeEditorCallData = encodeFunctionData({
-          functionName: 'removeEditor',
-          abi: DAOSpaceAbi,
-          args: [editorSpaceId],
-        });
-
-        const proposalActions = [
-          {
-            to: spaceAddress,
-            value: 0n,
-            data: removeEditorCallData,
-          },
-        ];
-
-        // Editor actions must use slow path - not valid for fast path per contract
-        const data = encodeProposalCreatedData(proposalId, VOTING_MODE.SLOW, proposalActions);
-
-        const callData = encodeFunctionData({
-          functionName: 'enter',
-          abi: SpaceRegistryAbi,
-          args: [fromSpaceId, toSpaceId, GOVERNANCE_ACTIONS.PROPOSAL_CREATED, EMPTY_TOPIC_HEX, data, EMPTY_SIGNATURE],
-        });
-
-        const hash = yield* tx(callData).pipe(
-          Effect.withSpan('web.write.createProposal.removeEditor'),
-          Effect.annotateSpans({
-            'io.operation': 'create_proposal',
-            'space.type': 'DAO',
-            'governance.action': 'proposal_created',
-            'governance.proposal_action': 'remove_editor',
-            'governance.voting_mode': 'SLOW',
-          })
-        );
-        console.log('Transaction hash: ', hash);
-        return hash;
+      const { calldata: callData } = daoSpace.proposeRemoveEditor({
+        authorSpaceId: personalSpaceId,
+        spaceId,
+        editorToRemoveSpaceId: targetEditorSpaceId,
+        votingMode: 'SLOW',
       });
+
+      const writeTxEffect = tx(callData).pipe(
+        Effect.withSpan('web.write.createProposal.removeEditor'),
+        Effect.annotateSpans({
+          'io.operation': 'create_proposal',
+          'space.type': 'DAO',
+          'governance.action': 'proposal_created',
+          'governance.proposal_action': 'remove_editor',
+          'governance.voting_mode': 'SLOW',
+        })
+      );
 
       const result = await runEffectEither(writeTxEffect);
 
@@ -156,10 +108,10 @@ export function useProposeRemoveEditor({ spaceId }: UseProposeRemoveEditorArgs) 
           // Necessary to propagate error status to useMutation
           throw error;
         },
-        onRight: () => console.log('Successfully proposed to remove editor'),
+        onRight: hash => console.log('Successfully proposed to remove editor. Transaction hash:', hash),
       });
     },
-    [dispatch, smartAccount, personalSpaceId, isRegistered, spaceId, space, tx]
+    [dispatch, smartAccount, personalSpaceId, isRegistered, spaceId, tx]
   );
 
   const { mutate, status } = useMutation({

--- a/apps/web/core/hooks/use-propose-remove-member.ts
+++ b/apps/web/core/hooks/use-propose-remove-member.ts
@@ -1,29 +1,18 @@
 'use client';
 
-import { IdUtils } from '@geoprotocol/geo-sdk/lite';
+import { daoSpace } from '@geoprotocol/geo-sdk';
 import { useMutation } from '@tanstack/react-query';
 
 import { useCallback } from 'react';
 
 import { Effect, Either } from 'effect';
-import { type Hex, encodeFunctionData } from 'viem';
 
 import { usePersonalSpaceId } from '~/core/hooks/use-personal-space-id';
 import { useSmartAccount } from '~/core/hooks/use-smart-account';
 import { useSmartAccountTransaction } from '~/core/hooks/use-smart-account-transaction';
-import { useSpace } from '~/core/hooks/use-space';
 import { useStatusBar } from '~/core/state/status-bar-store';
 import { runEffectEither } from '~/core/telemetry/effect-runtime';
-import { encodeProposalCreatedData } from '~/core/utils/contracts/governance';
-import {
-  DAOSpaceAbi,
-  EMPTY_SIGNATURE,
-  EMPTY_TOPIC_HEX,
-  GOVERNANCE_ACTIONS,
-  SPACE_REGISTRY_ADDRESS,
-  SpaceRegistryAbi,
-  VOTING_MODE,
-} from '~/core/utils/contracts/space-registry';
+import { SPACE_REGISTRY_ADDRESS } from '~/core/utils/contracts/space-registry';
 import { validateSpaceId } from '~/core/utils/utils';
 
 interface UseProposeRemoveMemberArgs {
@@ -43,7 +32,6 @@ export function useProposeRemoveMember({ spaceId }: UseProposeRemoveMemberArgs) 
 
   const { smartAccount } = useSmartAccount();
   const { personalSpaceId, isRegistered } = usePersonalSpaceId();
-  const { space } = useSpace(spaceId ?? undefined);
 
   const tx = useSmartAccountTransaction({
     address: SPACE_REGISTRY_ADDRESS,
@@ -72,13 +60,6 @@ export function useProposeRemoveMember({ spaceId }: UseProposeRemoveMemberArgs) 
         throw new Error(message);
       }
 
-      if (!space?.address) {
-        const message = 'Space information is still loading. Please try again.';
-        console.error('No space address found');
-        dispatch({ type: 'ERROR', payload: message });
-        throw new Error(message);
-      }
-
       if (!validateSpaceId(targetMemberSpaceId)) {
         const message = 'Invalid member ID format. Please try again.';
         console.error('Invalid target member space ID:', targetMemberSpaceId);
@@ -86,60 +67,32 @@ export function useProposeRemoveMember({ spaceId }: UseProposeRemoveMemberArgs) 
         throw new Error(message);
       }
 
-      const spaceAddress = space.address as Hex;
       const normalizedVotingMode = votingMode === 'slow' ? 'SLOW' : 'FAST';
-      const votingModeValue = normalizedVotingMode === 'FAST' ? VOTING_MODE.FAST : VOTING_MODE.SLOW;
 
       console.log('Proposing to remove member', {
-        fromSpaceId: personalSpaceId,
-        toSpaceId: spaceId,
+        authorSpaceId: personalSpaceId,
+        spaceId,
         targetMemberSpaceId,
-        votingMode,
-        spaceAddress,
+        votingMode: normalizedVotingMode,
       });
 
-      const writeTxEffect = Effect.gen(function* () {
-        const proposalId = `0x${IdUtils.generate()}` as const;
-        const fromSpaceId = `0x${personalSpaceId}` as const;
-        const toSpaceId = `0x${spaceId}` as const;
-        const memberSpaceId = `0x${targetMemberSpaceId}` as const;
-
-        // Encode the removeMember call that will execute if the proposal passes
-        const removeMemberCallData = encodeFunctionData({
-          functionName: 'removeMember',
-          abi: DAOSpaceAbi,
-          args: [memberSpaceId],
-        });
-
-        const proposalActions = [
-          {
-            to: spaceAddress,
-            value: 0n,
-            data: removeMemberCallData,
-          },
-        ];
-
-        const data = encodeProposalCreatedData(proposalId, votingModeValue, proposalActions);
-
-        const callData = encodeFunctionData({
-          functionName: 'enter',
-          abi: SpaceRegistryAbi,
-          args: [fromSpaceId, toSpaceId, GOVERNANCE_ACTIONS.PROPOSAL_CREATED, EMPTY_TOPIC_HEX, data, EMPTY_SIGNATURE],
-        });
-
-        const hash = yield* tx(callData).pipe(
-          Effect.withSpan('web.write.createProposal.removeMember'),
-          Effect.annotateSpans({
-            'io.operation': 'create_proposal',
-            'space.type': 'DAO',
-            'governance.action': 'proposal_created',
-            'governance.proposal_action': 'remove_member',
-            'governance.voting_mode': normalizedVotingMode,
-          })
-        );
-        console.log('Transaction hash: ', hash);
-        return hash;
+      const { calldata: callData } = daoSpace.proposeRemoveMember({
+        authorSpaceId: personalSpaceId,
+        spaceId,
+        memberToRemoveSpaceId: targetMemberSpaceId,
+        votingMode: normalizedVotingMode,
       });
+
+      const writeTxEffect = tx(callData).pipe(
+        Effect.withSpan('web.write.createProposal.removeMember'),
+        Effect.annotateSpans({
+          'io.operation': 'create_proposal',
+          'space.type': 'DAO',
+          'governance.action': 'proposal_created',
+          'governance.proposal_action': 'remove_member',
+          'governance.voting_mode': normalizedVotingMode,
+        })
+      );
 
       const result = await runEffectEither(writeTxEffect);
 
@@ -158,10 +111,10 @@ export function useProposeRemoveMember({ spaceId }: UseProposeRemoveMemberArgs) 
           // Necessary to propagate error status to useMutation
           throw error;
         },
-        onRight: () => console.log('Successfully proposed to remove member'),
+        onRight: hash => console.log('Successfully proposed to remove member. Transaction hash:', hash),
       });
     },
-    [dispatch, smartAccount, personalSpaceId, isRegistered, spaceId, space, tx]
+    [dispatch, smartAccount, personalSpaceId, isRegistered, spaceId, tx]
   );
 
   const { mutate, status } = useMutation({

--- a/apps/web/core/hooks/use-request-to-be-editor.ts
+++ b/apps/web/core/hooks/use-request-to-be-editor.ts
@@ -1,29 +1,19 @@
 'use client';
 
-import { IdUtils } from '@geoprotocol/geo-sdk/lite';
+import { daoSpace } from '@geoprotocol/geo-sdk';
 import { useMutation } from '@tanstack/react-query';
 
 import { useCallback } from 'react';
 
 import { Effect, Either } from 'effect';
-import { type Hex, encodeFunctionData } from 'viem';
 
 import { usePersonalSpaceId } from '~/core/hooks/use-personal-space-id';
 import { useSmartAccount } from '~/core/hooks/use-smart-account';
 import { useSmartAccountTransaction } from '~/core/hooks/use-smart-account-transaction';
-import { useSpace } from '~/core/hooks/use-space';
 import { useStatusBar } from '~/core/state/status-bar-store';
 import { runEffectEither } from '~/core/telemetry/effect-runtime';
-import { encodeProposalCreatedData } from '~/core/utils/contracts/governance';
-import {
-  DAOSpaceAbi,
-  EMPTY_SIGNATURE,
-  EMPTY_TOPIC_HEX,
-  GOVERNANCE_ACTIONS,
-  SPACE_REGISTRY_ADDRESS,
-  SpaceRegistryAbi,
-  VOTING_MODE,
-} from '~/core/utils/contracts/space-registry';
+import { SPACE_REGISTRY_ADDRESS } from '~/core/utils/contracts/space-registry';
+import { validateSpaceId } from '~/core/utils/utils';
 
 interface UseRequestToBeEditorArgs {
   /** The space ID (bytes16 hex without 0x, e.g., UUID format) of the space to become an editor of */
@@ -35,7 +25,6 @@ export function useRequestToBeEditor({ spaceId }: UseRequestToBeEditorArgs) {
 
   const { smartAccount } = useSmartAccount();
   const { personalSpaceId, isRegistered } = usePersonalSpaceId();
-  const { space } = useSpace(spaceId ?? undefined);
 
   const tx = useSmartAccountTransaction({
     address: SPACE_REGISTRY_ADDRESS,
@@ -54,63 +43,33 @@ export function useRequestToBeEditor({ spaceId }: UseRequestToBeEditorArgs) {
       throw new Error('User does not have a registered personal space ID');
     }
 
-    if (!spaceId) {
-      throw new Error('No target space ID provided');
+    if (!validateSpaceId(spaceId)) {
+      throw new Error('Invalid target space ID');
     }
-
-    if (!space?.address) {
-      throw new Error('No space address found');
-    }
-
-    const spaceAddress = space.address as Hex;
 
     console.log('Requesting to be editor', {
-      fromSpaceId: personalSpaceId,
-      toSpaceId: spaceId,
-      spaceAddress,
+      authorSpaceId: personalSpaceId,
+      spaceId,
     });
 
-    const writeTxEffect = Effect.gen(function* () {
-      const proposalId = `0x${IdUtils.generate()}` as const;
-      const fromSpaceId = `0x${personalSpaceId}` as const;
-      const toSpaceId = `0x${spaceId}` as const;
-
-      // Encode the addEditor call that will execute if the proposal passes
-      const addEditorCallData = encodeFunctionData({
-        functionName: 'addEditor',
-        abi: DAOSpaceAbi,
-        args: [fromSpaceId],
-      });
-
-      const proposalActions = [
-        {
-          to: spaceAddress,
-          value: 0n,
-          data: addEditorCallData,
-        },
-      ];
-
-      const data = encodeProposalCreatedData(proposalId, VOTING_MODE.SLOW, proposalActions);
-
-      const callData = encodeFunctionData({
-        functionName: 'enter',
-        abi: SpaceRegistryAbi,
-        args: [fromSpaceId, toSpaceId, GOVERNANCE_ACTIONS.PROPOSAL_CREATED, EMPTY_TOPIC_HEX, data, EMPTY_SIGNATURE],
-      });
-
-      const hash = yield* tx(callData).pipe(
-        Effect.withSpan('web.write.createProposal.requestEditorship'),
-        Effect.annotateSpans({
-          'io.operation': 'create_proposal',
-          'space.type': 'DAO',
-          'governance.action': 'proposal_created',
-          'governance.proposal_action': 'add_editor',
-          'governance.voting_mode': 'SLOW',
-        })
-      );
-      console.log('Transaction hash: ', hash);
-      return hash;
+    // Caller proposes themselves as a new editor. Editor proposals are slow-path only.
+    const { calldata: callData } = daoSpace.proposeAddEditor({
+      authorSpaceId: personalSpaceId,
+      spaceId,
+      newEditorSpaceId: personalSpaceId,
+      votingMode: 'SLOW',
     });
+
+    const writeTxEffect = tx(callData).pipe(
+      Effect.withSpan('web.write.createProposal.requestEditorship'),
+      Effect.annotateSpans({
+        'io.operation': 'create_proposal',
+        'space.type': 'DAO',
+        'governance.action': 'proposal_created',
+        'governance.proposal_action': 'add_editor',
+        'governance.voting_mode': 'SLOW',
+      })
+    );
 
     const result = await runEffectEither(writeTxEffect);
 
@@ -121,9 +80,9 @@ export function useRequestToBeEditor({ spaceId }: UseRequestToBeEditorArgs) {
         // Necessary to propagate error status to useMutation
         throw error;
       },
-      onRight: () => console.log('Successfully requested to be editor'),
+      onRight: hash => console.log('Successfully requested to be editor. Transaction hash:', hash),
     });
-  }, [dispatch, smartAccount, personalSpaceId, isRegistered, spaceId, space, tx]);
+  }, [dispatch, smartAccount, personalSpaceId, isRegistered, spaceId, tx]);
 
   const { mutate, status } = useMutation({
     mutationFn: handleRequestToBeEditor,

--- a/apps/web/core/hooks/use-request-to-be-member.ts
+++ b/apps/web/core/hooks/use-request-to-be-member.ts
@@ -1,26 +1,19 @@
 'use client';
 
-import { IdUtils } from '@geoprotocol/geo-sdk/lite';
+import { daoSpace } from '@geoprotocol/geo-sdk';
 import { useMutation } from '@tanstack/react-query';
 
 import { useCallback } from 'react';
 
 import { Effect, Either } from 'effect';
-import { encodeFunctionData } from 'viem';
 
 import { usePersonalSpaceId } from '~/core/hooks/use-personal-space-id';
 import { useSmartAccount } from '~/core/hooks/use-smart-account';
 import { useSmartAccountTransaction } from '~/core/hooks/use-smart-account-transaction';
 import { useStatusBar } from '~/core/state/status-bar-store';
 import { runEffectEither } from '~/core/telemetry/effect-runtime';
-import { encodeMembershipRequestData } from '~/core/utils/contracts/governance';
-import {
-  EMPTY_SIGNATURE,
-  EMPTY_TOPIC_HEX,
-  GOVERNANCE_ACTIONS,
-  SPACE_REGISTRY_ADDRESS,
-  SpaceRegistryAbi,
-} from '~/core/utils/contracts/space-registry';
+import { SPACE_REGISTRY_ADDRESS } from '~/core/utils/contracts/space-registry';
+import { validateSpaceId } from '~/core/utils/utils';
 
 interface UseRequestToBeMemberArgs {
   /** The space ID (bytes16 hex without 0x, e.g., UUID format) of the space to join */
@@ -50,40 +43,28 @@ export function useRequestToBeMember({ spaceId }: UseRequestToBeMemberArgs) {
       throw new Error('User does not have a registered personal space ID');
     }
 
-    if (!spaceId) {
-      throw new Error('No target space ID provided');
+    if (!validateSpaceId(spaceId)) {
+      throw new Error('Invalid target space ID');
     }
 
     console.log('Requesting to be member', {
-      fromSpaceId: personalSpaceId,
-      toSpaceId: spaceId,
+      authorSpaceId: personalSpaceId,
+      spaceId,
     });
 
-    const writeTxEffect = Effect.gen(function* () {
-      const proposalId = `0x${IdUtils.generate()}` as const;
-      const fromSpaceId = `0x${personalSpaceId}` as const;
-      const toSpaceId = `0x${spaceId}` as const;
-
-      // Encode the data payload: (proposalId, newMemberSpaceId)
-      const data = encodeMembershipRequestData(proposalId, fromSpaceId);
-
-      const callData = encodeFunctionData({
-        functionName: 'enter',
-        abi: SpaceRegistryAbi,
-        args: [fromSpaceId, toSpaceId, GOVERNANCE_ACTIONS.MEMBERSHIP_REQUESTED, EMPTY_TOPIC_HEX, data, EMPTY_SIGNATURE],
-      });
-
-      const hash = yield* tx(callData).pipe(
-        Effect.withSpan('web.write.requestMembership'),
-        Effect.annotateSpans({
-          'io.operation': 'request_membership',
-          'space.type': 'DAO',
-          'governance.action': 'membership_requested',
-        })
-      );
-      console.log('Transaction hash: ', hash);
-      return hash;
+    const { calldata: callData } = daoSpace.proposeRequestMembership({
+      authorSpaceId: personalSpaceId,
+      spaceId,
     });
+
+    const writeTxEffect = tx(callData).pipe(
+      Effect.withSpan('web.write.requestMembership'),
+      Effect.annotateSpans({
+        'io.operation': 'request_membership',
+        'space.type': 'DAO',
+        'governance.action': 'membership_requested',
+      })
+    );
 
     const result = await runEffectEither(writeTxEffect);
 
@@ -94,7 +75,7 @@ export function useRequestToBeMember({ spaceId }: UseRequestToBeMemberArgs) {
         // Necessary to propagate error status to useMutation
         throw error;
       },
-      onRight: () => console.log('Successfully requested to be member'),
+      onRight: hash => console.log('Successfully requested to be member. Transaction hash:', hash),
     });
   }, [dispatch, smartAccount, personalSpaceId, isRegistered, spaceId, tx]);
 

--- a/apps/web/core/utils/contracts/governance.ts
+++ b/apps/web/core/utils/contracts/governance.ts
@@ -1,23 +1,6 @@
 import { type Hex, encodeAbiParameters } from 'viem';
 
 /**
- * Encodes the data payload for a MEMBERSHIP_REQUESTED action.
- *
- * @param proposalId - bytes16 proposal ID
- * @param newMemberSpaceId - bytes16 space ID of the user requesting membership
- * @returns Encoded bytes for use in SpaceRegistry.enter()
- */
-export function encodeMembershipRequestData(proposalId: Hex, newMemberSpaceId: Hex): Hex {
-  return encodeAbiParameters(
-    [
-      { name: 'proposalId', type: 'bytes16' },
-      { name: 'newMemberSpaceId', type: 'bytes16' },
-    ],
-    [proposalId, newMemberSpaceId]
-  );
-}
-
-/**
  * Represents a single action to be executed as part of a proposal.
  */
 export interface ProposalAction {

--- a/apps/web/core/utils/contracts/space-registry.ts
+++ b/apps/web/core/utils/contracts/space-registry.ts
@@ -1,17 +1,13 @@
 import { type Hex } from 'viem';
 
-export const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000' as const;
-
 /**
  * SpaceRegistry address (Geo Testnet)
  */
 export const SPACE_REGISTRY_ADDRESS = '0xB01683b2f0d38d43fcD4D9aAB980166988924132' as const;
 
-export const ZERO_ADDRESS_HEX = ZERO_ADDRESS as Hex;
 export const SPACE_REGISTRY_ADDRESS_HEX = SPACE_REGISTRY_ADDRESS as Hex;
 
-export const EMPTY_TOPIC = '0x0000000000000000000000000000000000000000000000000000000000000000' as const;
-export const EMPTY_TOPIC_HEX = EMPTY_TOPIC as Hex;
+export const EMPTY_TOPIC_HEX = '0x0000000000000000000000000000000000000000000000000000000000000000' as Hex;
 
 export const EMPTY_SIGNATURE = '0x' as Hex;
 
@@ -115,8 +111,6 @@ export const DAOSpaceAbi = [
     type: 'function',
   },
 ] as const;
-
-export const ZERO_SPACE_ID = '0x00000000000000000000000000000000' as Hex;
 
 /**
  * Minimal SpaceRegistry ABI - only includes functions used by this app.

--- a/apps/web/design-system/slide-up.tsx
+++ b/apps/web/design-system/slide-up.tsx
@@ -6,9 +6,9 @@ import { AnimatePresence, type AnimationDefinition, motion } from 'framer-motion
 import { useAtomValue } from 'jotai';
 import { RemoveScroll } from 'react-remove-scroll';
 
-import { entitySidePanelHostElementAtom } from '~/atoms';
-
 import { Z_LAYER_CLASS } from '~/core/z-layers';
+
+import { entitySidePanelHostElementAtom } from '~/atoms';
 
 type SlideUpProps = {
   isOpen: boolean;

--- a/apps/web/partials/space-page/space-members-dialog-server-container.tsx
+++ b/apps/web/partials/space-page/space-members-dialog-server-container.tsx
@@ -1,12 +1,12 @@
 import { SpaceMembersManageDialog } from './space-members-manage-dialog';
 import { SpaceMembersManageDialogContent } from './space-members-manage-dialog-content';
 
-export function SpaceMembersDialogServerContainer({ spaceId }: { spaceId: string }) {
+export function SpaceMembersDialogServerContainer({ spaceId, isEditor }: { spaceId: string; isEditor: boolean }) {
   return (
     <SpaceMembersManageDialog
       header={<h1 className="text-smallTitle">Manage members</h1>}
       trigger={<p>Manage members</p>}
-      content={<SpaceMembersManageDialogContent spaceId={spaceId} />}
+      content={<SpaceMembersManageDialogContent spaceId={spaceId} isEditor={isEditor} />}
     />
   );
 }

--- a/apps/web/partials/space-page/space-members-manage-dialog-content.tsx
+++ b/apps/web/partials/space-page/space-members-manage-dialog-content.tsx
@@ -17,9 +17,10 @@ import { MemberRow } from './space-member-row';
 
 interface Props {
   spaceId: string;
+  isEditor: boolean;
 }
 
-export function SpaceMembersManageDialogContent({ spaceId }: Props) {
+export function SpaceMembersManageDialogContent({ spaceId, isEditor }: Props) {
   const { participants, totalCount, isLoading, isFetchingNextPage, hasNextPage, fetchNextPage } =
     useSpaceParticipantsInfinite({ spaceId, kind: 'members' });
 
@@ -49,7 +50,7 @@ export function SpaceMembersManageDialogContent({ spaceId }: Props) {
         ) : (
           <div className="divide-y divide-grey-02">
             {queriedMembers.map(m => (
-              <CurrentMember key={m.id} member={m} spaceId={spaceId} />
+              <CurrentMember key={m.id} member={m} spaceId={spaceId} isEditor={isEditor} />
             ))}
             {hasNextPage ? <div ref={sentinelRef} className="h-px" /> : null}
             {isFetchingNextPage ? <ManageDialogSkeletons count={3} /> : null}
@@ -63,9 +64,10 @@ export function SpaceMembersManageDialogContent({ spaceId }: Props) {
 interface CurrentMemberProps {
   member: SpaceParticipantProfile;
   spaceId: string;
+  isEditor: boolean;
 }
 
-function CurrentMember({ member, spaceId }: CurrentMemberProps) {
+function CurrentMember({ member, spaceId, isEditor }: CurrentMemberProps) {
   const { proposeRemoveMember, status } = useProposeRemoveMember({ spaceId });
 
   const buttonText = (() => {
@@ -81,6 +83,10 @@ function CurrentMember({ member, spaceId }: CurrentMemberProps) {
     }
   })();
 
+  // Fast-path proposals are editor-only on-chain; routing non-editor callers
+  // to slow-path avoids an InvalidFromSpace() revert from the DAOSpace contract.
+  const votingMode = isEditor ? 'fast' : 'slow';
+
   return (
     <div key={member.id} className="flex items-center justify-between transition-colors duration-150 hover:bg-divider">
       <MemberRow user={member} />
@@ -88,7 +94,7 @@ function CurrentMember({ member, spaceId }: CurrentMemberProps) {
         disabled={status === 'pending' || status === 'success'}
         onClick={event => {
           event.preventDefault();
-          proposeRemoveMember({ targetMemberSpaceId: member.spaceId });
+          proposeRemoveMember({ targetMemberSpaceId: member.spaceId, votingMode });
         }}
       >
         {buttonText}

--- a/apps/web/partials/space-page/space-members.tsx
+++ b/apps/web/partials/space-page/space-members.tsx
@@ -8,6 +8,7 @@ import { ChevronDownSmall } from '~/design-system/icons/chevron-down-small';
 
 import { getHasRequestedSpaceMembership } from '~/partials/space-page/get-has-requested-space-membership';
 
+import { getIsEditorForSpace } from './get-is-editor-for-space';
 import { getIsMemberForSpace } from './get-is-member-for-space';
 import { SpaceMembersChip } from './space-members-chip';
 import { SpaceMembersDialogServerContainer } from './space-members-dialog-server-container';
@@ -23,8 +24,9 @@ interface Props {
 
 export async function SpaceMembers({ spaceId }: Props) {
   const connectedAddress = (await cookies()).get(WALLET_ADDRESS)?.value;
-  const [isMember, space, hasRequestedSpaceMembership] = await Promise.all([
+  const [isMember, isEditor, space, hasRequestedSpaceMembership] = await Promise.all([
     getIsMemberForSpace(spaceId, connectedAddress),
+    getIsEditorForSpace(spaceId, connectedAddress),
     cachedFetchSpace(spaceId),
     getHasRequestedSpaceMembership(spaceId, connectedAddress),
   ]);
@@ -55,7 +57,7 @@ export async function SpaceMembers({ spaceId }: Props) {
         <SpaceMembersPopover trigger={<SpaceMembersChip spaceId={spaceId} />} content={popoverContent} />
         <div className="h-4 w-px bg-divider" />
         <SpaceMembersMenu
-          manageMembersComponent={<SpaceMembersDialogServerContainer spaceId={spaceId} />}
+          manageMembersComponent={<SpaceMembersDialogServerContainer spaceId={spaceId} isEditor={isEditor} />}
           trigger={<ChevronDownSmall color="grey-04" />}
         />
       </div>


### PR DESCRIPTION
Continues #1828 by moving the remaining hand-rolled proposal hooks to @geoprotocol/geo-sdk@0.19.2:

- use-propose-add-member / use-propose-remove-member -> daoSpace.proposeAddMember / proposeRemoveMember
- use-propose-add-editor / use-propose-remove-editor -> daoSpace.proposeAddEditor / proposeRemoveEditor
- use-request-to-be-editor -> daoSpace.proposeAddEditor (self as target; the ticket's mapping to proposeRequestMembership did not match the addEditor action the hook actually encoded)
- use-request-to-be-member -> daoSpace.proposeRequestMembership (beyond ticket scope; same hand-rolled pattern, retired here so the membership encoder can go too)

Side cleanup: drop encodeMembershipRequestData from governance.ts (no remaining callers) and ZERO_ADDRESS / ZERO_ADDRESS_HEX / ZERO_SPACE_ID / EMPTY_TOPIC from space-registry.ts (no callers).

encodeProposalCreatedData stays in governance.ts; use-subspace.ts and space-topic.ts still need it. Retiring it depends on SDK helpers for subspace and topic proposals (follow-up).