### PR TITLE
fix(classify-url): route Wikipedia and OpenAI /index URLs to Post

### DIFF
--- a/apps/web/app/api/chat/classify-url/route.ts
+++ b/apps/web/app/api/chat/classify-url/route.ts
@@ -192,18 +192,12 @@ const HOSTNAME_RULES: Array<{ match: (host: string, pathname: string) => boolean
       (host === 'anthropic.com' || host === 'www.anthropic.com') && /^\/(engineering|research)(\/|$)/.test(path),
     type: 'post',
   },
-  // OpenAI publishes its articles under /index, and the newsroom landing
-  // (openai.com/news) surfaces those same /index posts as its cards — so
-  // /index IS OpenAI's newsroom → News Story.
-  {
-    match: (host, path) => (host === 'openai.com' || host === 'www.openai.com') && /^\/index(\/|$)/.test(path),
-    type: 'news-story-single',
-  },
-  // OpenAI's other editorial sections → Post (blog/research). Whether these
-  // should also be News is still TBD.
+  // OpenAI editorial sections (/index, /blog, /research) → Post. The newsroom
+  // landing at openai.com/news still routes to News Story via the general
+  // /news rule below.
   {
     match: (host, path) =>
-      (host === 'openai.com' || host === 'www.openai.com') && /^\/(blog|research)(\/|$)/.test(path),
+      (host === 'openai.com' || host === 'www.openai.com') && /^\/(index|blog|research)(\/|$)/.test(path),
     type: 'post',
   },
   // Any company's own /news section → News Story. A /news path is a newsroom /

--- a/apps/web/app/api/chat/classify-url/route.ts
+++ b/apps/web/app/api/chat/classify-url/route.ts
@@ -211,7 +211,9 @@ const HOSTNAME_RULES: Array<{ match: (host: string, pathname: string) => boolean
   // news outlet (covers anthropic.com/news, openai.com/news, and any company).
   // Runs AFTER the blog-platform rule above, so Substack/Medium/etc. stay Post.
   { match: (_host, path) => /^\/news(\/|$)/.test(path), type: 'news-story-single' },
-  { match: host => host.endsWith('.wikipedia.org') || host === 'wikipedia.org', type: 'news-story-single' },
+  // Wikipedia → Post: the article IS the content (an encyclopedic entry), not a
+  // news event to seed sibling-source discovery from.
+  { match: host => host.endsWith('.wikipedia.org') || host === 'wikipedia.org', type: 'post' },
   { match: host => host === 'linkedin.com' || host === 'www.linkedin.com', type: 'news-story-single' },
   { match: host => matchesNewsHost(host), type: 'news-story-single' },
 ];
@@ -231,8 +233,8 @@ Return route="chat" ONLY when the URL clearly points to:
 - Encyclopedic definitions of static concepts with no time-sensitive component.
 
 When route="inject", also pick the most appropriate type:
-- "news-story-single" — a journalistic news article or current-events story from a news publication, OR a Wikipedia article, OR a LinkedIn / personal profile.
-- "post" — a blog post, company/engineering blog, personal essay, or newsletter/Substack/Medium/Mirror post: editorial web content that is NOT from a journalistic news outlet. (Reddit URLs are also "post".)
+- "news-story-single" — a journalistic news article or current-events story from a news publication, OR a LinkedIn / personal profile.
+- "post" — a blog post, company/engineering blog, personal essay, newsletter/Substack/Medium/Mirror post, OR a Wikipedia article: editorial or encyclopedic web content that is NOT from a journalistic news outlet. (Reddit URLs are also "post".)
 - "tweet" — X / Twitter URL.
 
 Decide "news-story-single" vs "post" by the SOURCE, not the topic: a news organization reporting an event → "news-story-single"; an individual's or a company's OWN blog/essay/newsletter → "post".


### PR DESCRIPTION
## Summary

Two corrections to the URL classifier's deterministic `HOSTNAME_RULES` so encyclopedic and editorial content stops being treated as news.

### 1. Wikipedia → Post
A Wikipedia article is encyclopedic content that stands on its own — it shouldn't seed sibling-source discovery as a news event. `*.wikipedia.org` now routes to `post` (web Post) instead of `news-story-single`. Classifier prompt updated to match.

### 2. OpenAI `/index` → Post
Per Armando: `openai.com/index/*` posts (e.g. *Strengthening societal resilience with Rosalind Biodefense*) are editorial blog content, not newsroom articles. Merged `/index` into the existing `/blog`|`/research` rule so all three OpenAI editorial sections route to `post`. The actual newsroom at `openai.com/news` still routes to `news-story-single` via the general `/news` rule below.

## Affected URLs (smoke-tested, 20/20 ✓)

| URL | Before | After |
|---|---|---|
| `https://openai.com/index/strengthening-societal-resilience-with-rosalind-biodefense/` | news-story-single | **post** |
| `https://openai.com/blog/*`, `/research/*` | post | post (unchanged) |
| `https://openai.com/news/*` | news-story-single | news-story-single (unchanged) |
| `https://en.wikipedia.org/wiki/*` | news-story-single | **post** |
| `https://wikipedia.org/wiki/*` | news-story-single | **post** |
| `https://www.anthropic.com/research/*`, `/engineering/*` | post | post (unchanged) |
| `https://www.anthropic.com/news/*` | news-story-single | news-story-single (unchanged) |
| `nytimes.com`, `theverge.com`, `linkedin.com`, etc. | news-story-single | news-story-single (unchanged) |
| `reddit.com`, `medium.com`, `substack.com`, `x.com` | post/tweet | post/tweet (unchanged) |