### PR TITLE
feat(chat-inject): send extract_claims: false for posts and tweets

### DIFF
--- a/apps/web/app/api/chat/inject/route.ts
+++ b/apps/web/app/api/chat/inject/route.ts
@@ -9,11 +9,13 @@ import { ipCeilingLimit, loggedInLimit } from '../rate-limit';
 
 const INJECT_SPACE = 'world-affairs' as const;
 const VALID_TYPES: ReadonlySet<InjectType> = new Set(['news-story-single', 'post', 'tweet']);
-// Inject types whose pipeline gates claim extraction on the request body
-// (`InjectPostsOptions.extractClaims` defaults to false in news-worker).
-// `news-story-single` extracts claims unconditionally so we omit the flag
-// for it to keep the wire payload identical to today's behavior.
-const EXTRACT_CLAIMS_TYPES: ReadonlySet<InjectType> = new Set(['post', 'tweet']);
+// Inject types that explicitly turn OFF claim extraction. Posts (Reddit + web)
+// and tweets publish a Text block of the full body + Description summary as
+// their primary content; Notable claims are noise on top of that. The pipeline
+// still runs Pass 3a/3b (topics + entities + Description) regardless — Notable
+// claims is the only thing the flag gates today. news-story-single isn't in
+// this set because news-worker runs full enrich on it unconditionally.
+const CLAIMS_OFF_TYPES: ReadonlySet<InjectType> = new Set(['post', 'tweet']);
 const INJECT_FETCH_TIMEOUT_MS = 15_000;
 
 function isSameOrigin(req: Request): boolean {
@@ -142,7 +144,7 @@ export async function POST(req: Request) {
     space: INJECT_SPACE,
     url,
     type,
-    ...(EXTRACT_CLAIMS_TYPES.has(type) ? { extract_claims: true } : {}),
+    ...(CLAIMS_OFF_TYPES.has(type) ? { extract_claims: false } : {}),
   };
 
   let res: Response;


### PR DESCRIPTION
## Summary

Send `extract_claims: false` explicitly in the chat-inject payload for `post` and `tweet` types so news-worker skips the Notable claims pipeline for them. Posts (Reddit + web) and tweets publish a Text block of the full body plus a Description summary as their primary content; Notable claims add noise without adding signal on these surfaces.

The flag is now opt-OUT for posts/tweets rather than opt-IN.

## What changes on the wire

| Type | Before | After |
|---|---|---|
| `post` (Reddit + web) | `extract_claims: true` | **`extract_claims: false`** |
| `tweet` | `extract_claims: true` | **`extract_claims: false`** |
| `news-story-single` | omitted | omitted (unchanged) |

## What news-worker does with it

Pairs with the news-worker change on `feat/inject-urls-async-pipeline` (commit `52f07fd`) that refactors `runEnrichPost` so `extract_claims=false` skips only Pass 1+2 (overview topics + claims/quotes) — Pass 3a (topics + entities) and Pass 3b (narrativeSummary → Description) still run unconditionally.

**Net effect** for posts/tweets:
- ✗ No Notable claims relation
- ✗ No Claim entities
- ✗ No Quotes
- ✓ Description (Pass 3b)
- ✓ Topics relation (Pass 3a)
- ✓ Related entities (Pass 3a)
- ✓ Author (resolve stage — unrelated to claims)
- ✓ Platform (resolve stage — unrelated to claims)

`news-story-single` is unaffected — news-worker runs the news pipeline (`runInject` → `runEnrich`) for that type, which has no `extractClaims` flag and always extracts claims.
