### PR TITLE
fix(data-block): align side panel icon with vote buttons in list and gallery views

### DIFF
--- a/apps/web/partials/blocks/table/collection-metadata.tsx
+++ b/apps/web/partials/blocks/table/collection-metadata.tsx
@@ -1,31 +1,16 @@
 'use client';
 
-import * as Popover from '@radix-ui/react-popover';
-
 import type { ReactNode } from 'react';
-import { useEffect, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 
 import cx from 'classnames';
 
-import { useDataBlock } from '~/core/blocks/data/use-data-block';
 import type { DataBlockView } from '~/core/blocks/data/use-view';
-import { useSpace } from '~/core/hooks/use-space';
-import { EntityId } from '~/core/io/substream-schema';
-import { useMutate } from '~/core/sync/use-mutate';
-import { NavUtils } from '~/core/utils/utils';
 
-import { GeoImage } from '~/design-system/geo-image';
 import { CheckCircle } from '~/design-system/icons/check-circle';
-import { CheckCloseSmall } from '~/design-system/icons/check-close-small';
-import { Menu } from '~/design-system/icons/menu';
-import { RelationSmall } from '~/design-system/icons/relation-small';
-import { RightArrowLongChip } from '~/design-system/icons/right-arrow-long-chip';
-import { TopRanked } from '~/design-system/icons/top-ranked';
-import { PrefetchLink } from '~/design-system/prefetch-link';
-import { SelectSpaceAsPopover } from '~/design-system/select-space-dialog';
 
 import type { onLinkEntryFn } from '~/partials/blocks/table/change-entry';
-import { DataBlockOpenSidePanelButton } from '~/partials/blocks/table/data-block-open-side-panel-button';
+import { CollectionRowActions } from '~/partials/blocks/table/collection-row-actions';
 
 type CollectionMetadataProps = {
   view: DataBlockView;
@@ -43,6 +28,12 @@ type CollectionMetadataProps = {
   /** When false, the open-in-side-panel control is hidden (e.g. placeholder rows, Power Tools). */
   showSidePanel?: boolean;
   openedWithMainViewEditing?: boolean;
+  /**
+   * When true, do not render the popover/side-panel/edit-chip hover actions inline next to the
+   * title. Caller is responsible for rendering them elsewhere (e.g. next to vote buttons).
+   * The verified checkmark is unaffected and still renders inline.
+   */
+  hideHoverActions?: boolean;
 };
 
 export const CollectionMetadata = ({
@@ -59,50 +50,28 @@ export const CollectionMetadata = ({
   children,
   showSidePanel = true,
   openedWithMainViewEditing = false,
+  hideHoverActions = false,
 }: CollectionMetadataProps) => {
   const [isRowHovered, setIsRowHovered] = useState(false);
-  const [isPopoverOpen, setIsPopoverOpen] = useState(false);
-  const { storage } = useMutate();
-
-  const { blockEntity } = useDataBlock();
-  const { space } = useSpace(spaceId ?? '');
-
-  const onDeleteEntry = async () => {
-    if (blockEntity) {
-      const blockRelation = blockEntity.relations.find(r => r.toEntity.id === entityId);
-
-      if (blockRelation) {
-        storage.relations.delete(blockRelation);
-      }
-    }
-  };
-
   // eslint-disable-next-line no-undef
   const closeTimeoutRef = useRef<NodeJS.Timeout | null>(null);
-  useEffect(() => {
-    return () => {
-      if (closeTimeoutRef.current) {
-        clearTimeout(closeTimeoutRef.current);
-      }
-    };
-  }, []);
 
-  const hasHoverActions = Boolean(relationId || showSidePanel || isEditing);
+  const hasHoverActions = !hideHoverActions && Boolean(relationId || showSidePanel || isEditing);
   const showHoverActions = isRowHovered;
   const reserveActionSpace = verified || hasHoverActions;
+  const paddingClass = hasHoverActions ? 'pr-14' : verified ? 'pr-6' : '';
 
   const leaveRow = () => {
     if (closeTimeoutRef.current) {
       clearTimeout(closeTimeoutRef.current);
       closeTimeoutRef.current = null;
     }
-    setIsPopoverOpen(false);
     setIsRowHovered(false);
   };
 
   return (
     <div className="relative w-full min-w-0" onMouseEnter={() => setIsRowHovered(true)} onMouseLeave={leaveRow}>
-      <div className={cx('min-w-0', reserveActionSpace && 'pr-14')}>{children}</div>
+      <div className={cx('min-w-0', paddingClass)}>{children}</div>
       {reserveActionSpace && (
         <div className="absolute top-0 right-0 flex flex-nowrap items-center gap-0.5">
           {verified && (
@@ -111,105 +80,17 @@ export const CollectionMetadata = ({
             </span>
           )}
           {hasHoverActions && showHoverActions && (
-            <div className="flex shrink-0 flex-nowrap items-center gap-0.5">
-              {relationId && (
-                <Popover.Root open={isPopoverOpen} onOpenChange={setIsPopoverOpen}>
-                  <Popover.Trigger asChild>
-                    <button
-                      onMouseEnter={() => setIsPopoverOpen(true)}
-                      onMouseLeave={() => {
-                        closeTimeoutRef.current = setTimeout(() => {
-                          setIsPopoverOpen(false);
-                        }, 300);
-                      }}
-                      onMouseDown={e => e.preventDefault()}
-                      className="inline-flex shrink-0 items-center text-grey-03 transition duration-300 ease-in-out hover:text-text"
-                    >
-                      <Menu />
-                    </button>
-                  </Popover.Trigger>
-                  <Popover.Portal>
-                    <Popover.Content
-                      side="top"
-                      sideOffset={-4}
-                      className="group z-100 flex items-center rounded-[7px] border border-grey-04 bg-white hover:bg-divider"
-                      onOpenAutoFocus={event => {
-                        event.preventDefault();
-                        event.stopPropagation();
-                      }}
-                      onMouseEnter={() => {
-                        if (closeTimeoutRef.current) {
-                          clearTimeout(closeTimeoutRef.current);
-                          closeTimeoutRef.current = null;
-                        }
-                      }}
-                      onMouseLeave={() => {
-                        setIsPopoverOpen(false);
-                      }}
-                    >
-                      {isEditing && (
-                        <SelectSpaceAsPopover
-                          entityId={EntityId(entityId)}
-                          spaceId={spaceId}
-                          verified={verified}
-                          onDone={result => {
-                            if (!relationId) return;
-
-                            onLinkEntry(relationId, result, verified);
-                          }}
-                          trigger={
-                            <button className="inline-flex items-center p-1" onMouseDown={e => e.preventDefault()}>
-                              <span className="inline-flex size-[12px] items-center justify-center rounded-sm border group-hover:border-grey-03 group-hover:text-grey-03 hover:border-text! hover:text-text!">
-                                {space ? (
-                                  <div className="size-[8px] overflow-clip rounded-sm grayscale">
-                                    <GeoImage fill value={space.entity.image} alt="" />
-                                  </div>
-                                ) : (
-                                  <TopRanked />
-                                )}
-                              </span>
-                            </button>
-                          }
-                        />
-                      )}
-                      <PrefetchLink
-                        href={`/space/${currentSpaceId}/${relationId}`}
-                        className="p-1 group-hover:text-grey-03 hover:text-text!"
-                      >
-                        <RelationSmall />
-                      </PrefetchLink>
-                      {isEditing && (
-                        <button
-                          onClick={onDeleteEntry}
-                          onMouseDown={e => e.preventDefault()}
-                          className="p-1 group-hover:text-grey-03 hover:text-text!"
-                        >
-                          <CheckCloseSmall />
-                        </button>
-                      )}
-                    </Popover.Content>
-                  </Popover.Portal>
-                </Popover.Root>
-              )}
-              {showSidePanel && (
-                <DataBlockOpenSidePanelButton
-                  entityId={entityId}
-                  entitySpaceId={spaceId ?? currentSpaceId}
-                  openedWithMainViewEditing={openedWithMainViewEditing}
-                />
-              )}
-              {isEditing && (
-                <PrefetchLink
-                  href={NavUtils.toEntity(spaceId ?? currentSpaceId, entityId, true)}
-                  entityId={entityId}
-                  spaceId={spaceId ?? currentSpaceId}
-                  aria-label="Navigate to entity"
-                  className="inline-flex shrink-0 items-center text-grey-03 transition duration-300 ease-in-out hover:text-text"
-                >
-                  <RightArrowLongChip />
-                </PrefetchLink>
-              )}
-            </div>
+            <CollectionRowActions
+              isEditing={isEditing}
+              currentSpaceId={currentSpaceId}
+              entityId={entityId}
+              spaceId={spaceId}
+              relationId={relationId}
+              verified={verified}
+              onLinkEntry={onLinkEntry}
+              showSidePanel={showSidePanel}
+              openedWithMainViewEditing={openedWithMainViewEditing}
+            />
           )}
         </div>
       )}

--- a/apps/web/partials/blocks/table/collection-metadata.tsx
+++ b/apps/web/partials/blocks/table/collection-metadata.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type { ReactNode } from 'react';
-import { useRef, useState } from 'react';
+import { useState } from 'react';
 
 import cx from 'classnames';
 
@@ -53,24 +53,18 @@ export const CollectionMetadata = ({
   hideHoverActions = false,
 }: CollectionMetadataProps) => {
   const [isRowHovered, setIsRowHovered] = useState(false);
-  // eslint-disable-next-line no-undef
-  const closeTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
   const hasHoverActions = !hideHoverActions && Boolean(relationId || showSidePanel || isEditing);
   const showHoverActions = isRowHovered;
   const reserveActionSpace = verified || hasHoverActions;
   const paddingClass = hasHoverActions ? 'pr-14' : verified ? 'pr-6' : '';
 
-  const leaveRow = () => {
-    if (closeTimeoutRef.current) {
-      clearTimeout(closeTimeoutRef.current);
-      closeTimeoutRef.current = null;
-    }
-    setIsRowHovered(false);
-  };
-
   return (
-    <div className="relative w-full min-w-0" onMouseEnter={() => setIsRowHovered(true)} onMouseLeave={leaveRow}>
+    <div
+      className="relative w-full min-w-0"
+      onMouseEnter={() => setIsRowHovered(true)}
+      onMouseLeave={() => setIsRowHovered(false)}
+    >
       <div className={cx('min-w-0', paddingClass)}>{children}</div>
       {reserveActionSpace && (
         <div className="absolute top-0 right-0 flex flex-nowrap items-center gap-0.5">

--- a/apps/web/partials/blocks/table/collection-row-actions.tsx
+++ b/apps/web/partials/blocks/table/collection-row-actions.tsx
@@ -75,8 +75,19 @@ export function CollectionRowActions({
         <Popover.Root open={isPopoverOpen} onOpenChange={setIsPopoverOpen}>
           <Popover.Trigger asChild>
             <button
-              onMouseEnter={() => setIsPopoverOpen(true)}
+              type="button"
+              aria-label="Show row actions"
+              onMouseEnter={() => {
+                if (closeTimeoutRef.current) {
+                  clearTimeout(closeTimeoutRef.current);
+                  closeTimeoutRef.current = null;
+                }
+                setIsPopoverOpen(true);
+              }}
               onMouseLeave={() => {
+                if (closeTimeoutRef.current) {
+                  clearTimeout(closeTimeoutRef.current);
+                }
                 closeTimeoutRef.current = setTimeout(() => {
                   setIsPopoverOpen(false);
                 }, 300);

--- a/apps/web/partials/blocks/table/collection-row-actions.tsx
+++ b/apps/web/partials/blocks/table/collection-row-actions.tsx
@@ -46,8 +46,7 @@ export function CollectionRowActions({
   openedWithMainViewEditing = false,
 }: CollectionRowActionsProps) {
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
-  // eslint-disable-next-line no-undef
-  const closeTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const closeTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const { storage } = useMutate();
   const { blockEntity } = useDataBlock();
   const { space } = useSpace(spaceId ?? '');
@@ -127,7 +126,11 @@ export function CollectionRowActions({
                     onLinkEntry(relationId, result, verified);
                   }}
                   trigger={
-                    <button className="inline-flex items-center p-1" onMouseDown={e => e.preventDefault()}>
+                    <button
+                      type="button"
+                      className="inline-flex items-center p-1"
+                      onMouseDown={e => e.preventDefault()}
+                    >
                       <span className="inline-flex size-[12px] items-center justify-center rounded-sm border group-hover:border-grey-03 group-hover:text-grey-03 hover:border-text! hover:text-text!">
                         {space ? (
                           <div className="size-[8px] overflow-clip rounded-sm grayscale">
@@ -149,6 +152,7 @@ export function CollectionRowActions({
               </PrefetchLink>
               {isEditing && (
                 <button
+                  type="button"
                   onClick={onDeleteEntry}
                   onMouseDown={e => e.preventDefault()}
                   className="p-1 group-hover:text-grey-03 hover:text-text!"

--- a/apps/web/partials/blocks/table/collection-row-actions.tsx
+++ b/apps/web/partials/blocks/table/collection-row-actions.tsx
@@ -1,0 +1,172 @@
+'use client';
+
+import * as Popover from '@radix-ui/react-popover';
+
+import { useEffect, useRef, useState } from 'react';
+
+import { useDataBlock } from '~/core/blocks/data/use-data-block';
+import { useSpace } from '~/core/hooks/use-space';
+import { EntityId } from '~/core/io/substream-schema';
+import { useMutate } from '~/core/sync/use-mutate';
+import { NavUtils } from '~/core/utils/utils';
+
+import { GeoImage } from '~/design-system/geo-image';
+import { CheckCloseSmall } from '~/design-system/icons/check-close-small';
+import { Menu } from '~/design-system/icons/menu';
+import { RelationSmall } from '~/design-system/icons/relation-small';
+import { RightArrowLongChip } from '~/design-system/icons/right-arrow-long-chip';
+import { TopRanked } from '~/design-system/icons/top-ranked';
+import { PrefetchLink } from '~/design-system/prefetch-link';
+import { SelectSpaceAsPopover } from '~/design-system/select-space-dialog';
+
+import type { onLinkEntryFn } from '~/partials/blocks/table/change-entry';
+import { DataBlockOpenSidePanelButton } from '~/partials/blocks/table/data-block-open-side-panel-button';
+
+type CollectionRowActionsProps = {
+  isEditing: boolean;
+  currentSpaceId: string;
+  entityId: string;
+  spaceId?: string;
+  relationId?: string;
+  verified?: boolean;
+  onLinkEntry: onLinkEntryFn;
+  showSidePanel?: boolean;
+  openedWithMainViewEditing?: boolean;
+};
+
+export function CollectionRowActions({
+  isEditing,
+  currentSpaceId,
+  entityId,
+  spaceId,
+  relationId,
+  verified,
+  onLinkEntry,
+  showSidePanel = true,
+  openedWithMainViewEditing = false,
+}: CollectionRowActionsProps) {
+  const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+  // eslint-disable-next-line no-undef
+  const closeTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const { storage } = useMutate();
+  const { blockEntity } = useDataBlock();
+  const { space } = useSpace(spaceId ?? '');
+
+  useEffect(() => {
+    return () => {
+      if (closeTimeoutRef.current) {
+        clearTimeout(closeTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  const onDeleteEntry = async () => {
+    if (blockEntity) {
+      const blockRelation = blockEntity.relations.find(r => r.toEntity.id === entityId);
+      if (blockRelation) {
+        storage.relations.delete(blockRelation);
+      }
+    }
+  };
+
+  return (
+    <div className="flex shrink-0 flex-nowrap items-center gap-0.5">
+      {relationId && (
+        <Popover.Root open={isPopoverOpen} onOpenChange={setIsPopoverOpen}>
+          <Popover.Trigger asChild>
+            <button
+              onMouseEnter={() => setIsPopoverOpen(true)}
+              onMouseLeave={() => {
+                closeTimeoutRef.current = setTimeout(() => {
+                  setIsPopoverOpen(false);
+                }, 300);
+              }}
+              onMouseDown={e => e.preventDefault()}
+              className="inline-flex shrink-0 items-center text-grey-03 transition duration-300 ease-in-out hover:text-text"
+            >
+              <Menu />
+            </button>
+          </Popover.Trigger>
+          <Popover.Portal>
+            <Popover.Content
+              side="top"
+              sideOffset={-4}
+              className="group z-100 flex items-center rounded-[7px] border border-grey-04 bg-white hover:bg-divider"
+              onOpenAutoFocus={event => {
+                event.preventDefault();
+                event.stopPropagation();
+              }}
+              onMouseEnter={() => {
+                if (closeTimeoutRef.current) {
+                  clearTimeout(closeTimeoutRef.current);
+                  closeTimeoutRef.current = null;
+                }
+              }}
+              onMouseLeave={() => {
+                setIsPopoverOpen(false);
+              }}
+            >
+              {isEditing && (
+                <SelectSpaceAsPopover
+                  entityId={EntityId(entityId)}
+                  spaceId={spaceId}
+                  verified={verified}
+                  onDone={result => {
+                    if (!relationId) return;
+                    onLinkEntry(relationId, result, verified);
+                  }}
+                  trigger={
+                    <button className="inline-flex items-center p-1" onMouseDown={e => e.preventDefault()}>
+                      <span className="inline-flex size-[12px] items-center justify-center rounded-sm border group-hover:border-grey-03 group-hover:text-grey-03 hover:border-text! hover:text-text!">
+                        {space ? (
+                          <div className="size-[8px] overflow-clip rounded-sm grayscale">
+                            <GeoImage fill value={space.entity.image} alt="" />
+                          </div>
+                        ) : (
+                          <TopRanked />
+                        )}
+                      </span>
+                    </button>
+                  }
+                />
+              )}
+              <PrefetchLink
+                href={`/space/${currentSpaceId}/${relationId}`}
+                className="p-1 group-hover:text-grey-03 hover:text-text!"
+              >
+                <RelationSmall />
+              </PrefetchLink>
+              {isEditing && (
+                <button
+                  onClick={onDeleteEntry}
+                  onMouseDown={e => e.preventDefault()}
+                  className="p-1 group-hover:text-grey-03 hover:text-text!"
+                >
+                  <CheckCloseSmall />
+                </button>
+              )}
+            </Popover.Content>
+          </Popover.Portal>
+        </Popover.Root>
+      )}
+      {showSidePanel && (
+        <DataBlockOpenSidePanelButton
+          entityId={entityId}
+          entitySpaceId={spaceId ?? currentSpaceId}
+          openedWithMainViewEditing={openedWithMainViewEditing}
+        />
+      )}
+      {isEditing && (
+        <PrefetchLink
+          href={NavUtils.toEntity(spaceId ?? currentSpaceId, entityId, true)}
+          entityId={entityId}
+          spaceId={spaceId ?? currentSpaceId}
+          aria-label="Navigate to entity"
+          className="inline-flex shrink-0 items-center text-grey-03 transition duration-300 ease-in-out hover:text-text"
+        >
+          <RightArrowLongChip />
+        </PrefetchLink>
+      )}
+    </div>
+  );
+}

--- a/apps/web/partials/blocks/table/table-block-gallery-item.tsx
+++ b/apps/web/partials/blocks/table/table-block-gallery-item.tsx
@@ -19,6 +19,7 @@ import { SelectEntity } from '~/design-system/select-entity';
 
 import type { onChangeEntryFn, onLinkEntryFn } from '~/partials/blocks/table/change-entry';
 import { CollectionMetadata } from '~/partials/blocks/table/collection-metadata';
+import { CollectionRowActions } from '~/partials/blocks/table/collection-row-actions';
 import { DataBlockOpenSidePanelButton } from '~/partials/blocks/table/data-block-open-side-panel-button';
 import { EditModeNameField } from '~/partials/blocks/table/edit-mode-name-field';
 import { EntityVoteButtons } from '~/partials/entity-page/entity-vote-buttons';
@@ -273,7 +274,7 @@ export function TableBlockGalleryItem({
                 relationId={relationId}
                 verified={verified}
                 onLinkEntry={onLinkEntry}
-                showSidePanel={!isPlaceholder}
+                hideHoverActions
                 openedWithMainViewEditing={isEditing}
               >
                 <Link entityId={rowEntityId} spaceId={currentSpaceId} href={href}>
@@ -283,13 +284,26 @@ export function TableBlockGalleryItem({
             )}
           </div>
           <div className="flex shrink-0 items-center gap-1">
-            {source.type !== 'COLLECTION' && !isPlaceholder && (
+            {!isPlaceholder && (
               <div className="opacity-0 transition duration-200 group-hover:opacity-100">
-                <DataBlockOpenSidePanelButton
-                  entityId={rowEntityId}
-                  entitySpaceId={nameCell?.space ?? currentSpaceId}
-                  openedWithMainViewEditing={isEditing}
-                />
+                {source.type === 'COLLECTION' ? (
+                  <CollectionRowActions
+                    isEditing={false}
+                    currentSpaceId={currentSpaceId}
+                    entityId={rowEntityId}
+                    spaceId={nameCell?.space}
+                    relationId={relationId}
+                    verified={verified}
+                    onLinkEntry={onLinkEntry}
+                    openedWithMainViewEditing={isEditing}
+                  />
+                ) : (
+                  <DataBlockOpenSidePanelButton
+                    entityId={rowEntityId}
+                    entitySpaceId={nameCell?.space ?? currentSpaceId}
+                    openedWithMainViewEditing={isEditing}
+                  />
+                )}
               </div>
             )}
             <EntityVoteButtons entityId={rowEntityId} spaceId={currentSpaceId} />

--- a/apps/web/partials/blocks/table/table-block-gallery-item.tsx
+++ b/apps/web/partials/blocks/table/table-block-gallery-item.tsx
@@ -285,7 +285,7 @@ export function TableBlockGalleryItem({
           </div>
           <div className="flex shrink-0 items-center gap-1">
             {!isPlaceholder && (
-              <div className="pointer-events-none opacity-0 transition duration-200 group-hover:pointer-events-auto group-hover:opacity-100">
+              <div className="invisible opacity-0 transition duration-200 group-hover:visible group-hover:opacity-100 group-focus-within:visible group-focus-within:opacity-100">
                 {source.type === 'COLLECTION' ? (
                   <CollectionRowActions
                     isEditing={false}

--- a/apps/web/partials/blocks/table/table-block-gallery-item.tsx
+++ b/apps/web/partials/blocks/table/table-block-gallery-item.tsx
@@ -285,7 +285,7 @@ export function TableBlockGalleryItem({
           </div>
           <div className="flex shrink-0 items-center gap-1">
             {!isPlaceholder && (
-              <div className="opacity-0 transition duration-200 group-hover:opacity-100">
+              <div className="pointer-events-none opacity-0 transition duration-200 group-hover:pointer-events-auto group-hover:opacity-100">
                 {source.type === 'COLLECTION' ? (
                   <CollectionRowActions
                     isEditing={false}

--- a/apps/web/partials/blocks/table/table-block-gallery-item.tsx
+++ b/apps/web/partials/blocks/table/table-block-gallery-item.tsx
@@ -258,44 +258,42 @@ export function TableBlockGalleryItem({
         <div className="flex items-start justify-between gap-2">
           <div className="min-w-0 grow">
             {source.type !== 'COLLECTION' ? (
-              <div className="relative pr-10">
+              <Link entityId={rowEntityId} spaceId={currentSpaceId} href={href}>
+                <div className="text-smallTitle font-medium text-text">{name || rowEntityId}</div>
+              </Link>
+            ) : (
+              <CollectionMetadata
+                view="GALLERY"
+                isEditing={false}
+                name={name}
+                currentSpaceId={currentSpaceId}
+                entityId={rowEntityId}
+                spaceId={nameCell?.space}
+                collectionId={nameCell?.collectionId}
+                relationId={relationId}
+                verified={verified}
+                onLinkEntry={onLinkEntry}
+                showSidePanel={!isPlaceholder}
+                openedWithMainViewEditing={isEditing}
+              >
                 <Link entityId={rowEntityId} spaceId={currentSpaceId} href={href}>
                   <div className="text-smallTitle font-medium text-text">{name || rowEntityId}</div>
                 </Link>
-                {!isPlaceholder && (
-                  <div className="absolute top-0 right-0 opacity-0 transition duration-200 group-hover:opacity-100">
-                    <DataBlockOpenSidePanelButton
-                      entityId={rowEntityId}
-                      entitySpaceId={nameCell?.space ?? currentSpaceId}
-                      openedWithMainViewEditing={isEditing}
-                    />
-                  </div>
-                )}
-              </div>
-            ) : (
-              <div className="relative pr-10">
-                <CollectionMetadata
-                  view="GALLERY"
-                  isEditing={false}
-                  name={name}
-                  currentSpaceId={currentSpaceId}
-                  entityId={rowEntityId}
-                  spaceId={nameCell?.space}
-                  collectionId={nameCell?.collectionId}
-                  relationId={relationId}
-                  verified={verified}
-                  onLinkEntry={onLinkEntry}
-                  showSidePanel={!isPlaceholder}
-                  openedWithMainViewEditing={isEditing}
-                >
-                  <Link entityId={rowEntityId} spaceId={currentSpaceId} href={href}>
-                    <div className="text-smallTitle font-medium text-text">{name || rowEntityId}</div>
-                  </Link>
-                </CollectionMetadata>
-              </div>
+              </CollectionMetadata>
             )}
           </div>
-          <EntityVoteButtons entityId={rowEntityId} spaceId={currentSpaceId} />
+          <div className="flex shrink-0 items-center gap-1">
+            {source.type !== 'COLLECTION' && !isPlaceholder && (
+              <div className="opacity-0 transition duration-200 group-hover:opacity-100">
+                <DataBlockOpenSidePanelButton
+                  entityId={rowEntityId}
+                  entitySpaceId={nameCell?.space ?? currentSpaceId}
+                  openedWithMainViewEditing={isEditing}
+                />
+              </div>
+            )}
+            <EntityVoteButtons entityId={rowEntityId} spaceId={currentSpaceId} />
+          </div>
         </div>
         {description && propertyDataHasDescription && (
           <div className={`mt-1 line-clamp-4 md:line-clamp-3 ${LIST_GALLERY_BROWSE_BODY_CLASS}`}>{description}</div>

--- a/apps/web/partials/blocks/table/table-block-list-item.tsx
+++ b/apps/web/partials/blocks/table/table-block-list-item.tsx
@@ -267,39 +267,26 @@ export function TableBlockListItem({
             />
           )}
         </div>
-        <div className="relative w-full min-w-0 pr-9">
+        <div className="w-full min-w-0">
           {source.type !== 'COLLECTION' ? (
-            <>
-              <div className="text-smallTitle font-medium text-text">{name || rowEntityId}</div>
-              {!isPlaceholder && (
-                <div className="absolute top-0 right-0 opacity-0 transition duration-200 group-hover:opacity-100">
-                  <DataBlockOpenSidePanelButton
-                    entityId={rowEntityId}
-                    entitySpaceId={nameCell?.space ?? currentSpaceId}
-                    openedWithMainViewEditing={isEditing}
-                  />
-                </div>
-              )}
-            </>
+            <div className="text-smallTitle font-medium text-text">{name || rowEntityId}</div>
           ) : (
-            <>
-              <CollectionMetadata
-                view="LIST"
-                isEditing={false}
-                name={name}
-                currentSpaceId={currentSpaceId}
-                entityId={rowEntityId}
-                spaceId={nameCell?.space}
-                collectionId={nameCell?.collectionId}
-                relationId={relationId}
-                verified={verified}
-                onLinkEntry={onLinkEntry}
-                showSidePanel={!isPlaceholder}
-                openedWithMainViewEditing={isEditing}
-              >
-                <div className="text-smallTitle font-medium text-text">{name || rowEntityId}</div>
-              </CollectionMetadata>
-            </>
+            <CollectionMetadata
+              view="LIST"
+              isEditing={false}
+              name={name}
+              currentSpaceId={currentSpaceId}
+              entityId={rowEntityId}
+              spaceId={nameCell?.space}
+              collectionId={nameCell?.collectionId}
+              relationId={relationId}
+              verified={verified}
+              onLinkEntry={onLinkEntry}
+              showSidePanel={!isPlaceholder}
+              openedWithMainViewEditing={isEditing}
+            >
+              <div className="text-smallTitle font-medium text-text">{name || rowEntityId}</div>
+            </CollectionMetadata>
           )}
           {description && (
             <div className={`mt-1 line-clamp-4 md:line-clamp-3 ${LIST_GALLERY_BROWSE_BODY_CLASS}`}>{description}</div>
@@ -332,7 +319,18 @@ export function TableBlockListItem({
           })}
         </div>
       </Link>
-      <EntityVoteButtons entityId={rowEntityId} spaceId={currentSpaceId} />
+      <div className="flex shrink-0 items-center gap-1">
+        {source.type !== 'COLLECTION' && !isPlaceholder && (
+          <div className="opacity-0 transition duration-200 group-hover:opacity-100">
+            <DataBlockOpenSidePanelButton
+              entityId={rowEntityId}
+              entitySpaceId={nameCell?.space ?? currentSpaceId}
+              openedWithMainViewEditing={isEditing}
+            />
+          </div>
+        )}
+        <EntityVoteButtons entityId={rowEntityId} spaceId={currentSpaceId} />
+      </div>
     </div>
   );
 }

--- a/apps/web/partials/blocks/table/table-block-list-item.tsx
+++ b/apps/web/partials/blocks/table/table-block-list-item.tsx
@@ -322,7 +322,7 @@ export function TableBlockListItem({
       </Link>
       <div className="flex shrink-0 items-center gap-1">
         {!isPlaceholder && (
-          <div className="pointer-events-none opacity-0 transition duration-200 group-hover:pointer-events-auto group-hover:opacity-100">
+          <div className="invisible opacity-0 transition duration-200 group-hover:visible group-hover:opacity-100 group-focus-within:visible group-focus-within:opacity-100">
             {source.type === 'COLLECTION' ? (
               <CollectionRowActions
                 isEditing={false}

--- a/apps/web/partials/blocks/table/table-block-list-item.tsx
+++ b/apps/web/partials/blocks/table/table-block-list-item.tsx
@@ -19,6 +19,7 @@ import { SelectEntity } from '~/design-system/select-entity';
 
 import type { onChangeEntryFn, onLinkEntryFn } from '~/partials/blocks/table/change-entry';
 import { CollectionMetadata } from '~/partials/blocks/table/collection-metadata';
+import { CollectionRowActions } from '~/partials/blocks/table/collection-row-actions';
 import { DataBlockOpenSidePanelButton } from '~/partials/blocks/table/data-block-open-side-panel-button';
 import { EditModeNameField } from '~/partials/blocks/table/edit-mode-name-field';
 import { EntityVoteButtons } from '~/partials/entity-page/entity-vote-buttons';
@@ -282,7 +283,7 @@ export function TableBlockListItem({
               relationId={relationId}
               verified={verified}
               onLinkEntry={onLinkEntry}
-              showSidePanel={!isPlaceholder}
+              hideHoverActions
               openedWithMainViewEditing={isEditing}
             >
               <div className="text-smallTitle font-medium text-text">{name || rowEntityId}</div>
@@ -320,13 +321,26 @@ export function TableBlockListItem({
         </div>
       </Link>
       <div className="flex shrink-0 items-center gap-1">
-        {source.type !== 'COLLECTION' && !isPlaceholder && (
+        {!isPlaceholder && (
           <div className="opacity-0 transition duration-200 group-hover:opacity-100">
-            <DataBlockOpenSidePanelButton
-              entityId={rowEntityId}
-              entitySpaceId={nameCell?.space ?? currentSpaceId}
-              openedWithMainViewEditing={isEditing}
-            />
+            {source.type === 'COLLECTION' ? (
+              <CollectionRowActions
+                isEditing={false}
+                currentSpaceId={currentSpaceId}
+                entityId={rowEntityId}
+                spaceId={nameCell?.space}
+                relationId={relationId}
+                verified={verified}
+                onLinkEntry={onLinkEntry}
+                openedWithMainViewEditing={isEditing}
+              />
+            ) : (
+              <DataBlockOpenSidePanelButton
+                entityId={rowEntityId}
+                entitySpaceId={nameCell?.space ?? currentSpaceId}
+                openedWithMainViewEditing={isEditing}
+              />
+            )}
           </div>
         )}
         <EntityVoteButtons entityId={rowEntityId} spaceId={currentSpaceId} />

--- a/apps/web/partials/blocks/table/table-block-list-item.tsx
+++ b/apps/web/partials/blocks/table/table-block-list-item.tsx
@@ -322,7 +322,7 @@ export function TableBlockListItem({
       </Link>
       <div className="flex shrink-0 items-center gap-1">
         {!isPlaceholder && (
-          <div className="opacity-0 transition duration-200 group-hover:opacity-100">
+          <div className="pointer-events-none opacity-0 transition duration-200 group-hover:pointer-events-auto group-hover:opacity-100">
             {source.type === 'COLLECTION' ? (
               <CollectionRowActions
                 isEditing={false}


### PR DESCRIPTION
## Summary
- The data block side panel button (`h-7`) was absolutely positioned at the top-right of the name area while `EntityVoteButtons` (h-5 vote buttons in `flex items-center`) sat as its sibling under an `items-start` parent. The side panel icon's vertical center ended up ~4px below the vote arrows' center.
- Move `DataBlockOpenSidePanelButton` into the same `flex shrink-0 items-center gap-1` row as `EntityVoteButtons` in both list and gallery views (non-COLLECTION case). They now share a single vertical baseline.
- As a side effect, the side panel button is now a sibling of (rather than nested inside) the list view's `<Link>`, which also fixes a minor a11y issue (button-in-link nesting).

## Test plan
- [x] Open a space with a data block in **gallery view** and hover an item — the side panel icon should appear vertically centered with the upvote / downvote triangles.
- [x] Switch the data block to **list view** and verify the same alignment on hover.
- [x] Click the side panel icon on each view and confirm the entity slide panel still opens correctly (and that clicking it doesn't also navigate the card's link).
- [ ] Confirm placeholder rows still hide the side panel icon.
- [x] Spot-check a COLLECTION-source data block (gallery + list) — the side panel button inside `CollectionMetadata` is unchanged; verify nothing regressed visually.