### PR TITLE
 fix(governance): show a toast instead of the error modal when voting on stale proposals

### DIFF
--- a/apps/web/app/home/accept-or-reject-editor.tsx
+++ b/apps/web/app/home/accept-or-reject-editor.tsx
@@ -6,7 +6,14 @@ import { useRouter } from 'next/navigation';
 
 import { useSmartAccount } from '~/core/hooks/use-smart-account';
 import { useToast } from '~/core/hooks/use-toast';
-import { STALE_PROPOSAL_VOTE_ERROR_MESSAGE, isStaleProposalVoteError, useVote } from '~/core/hooks/use-vote';
+import {
+  MEMBERSHIP_ALREADY_APPLIED_MESSAGE,
+  VOTE_NOT_ACCEPTED_MESSAGE,
+  isMembershipProposalType,
+  isProposalActionRevertedError,
+  isVoteNotAcceptedError,
+  useVote,
+} from '~/core/hooks/use-vote';
 import { Proposal } from '~/core/io/dto/proposals';
 import { SubstreamVote } from '~/core/io/substream-schema';
 import { useReportError } from '~/core/state/status-bar-store';
@@ -23,12 +30,21 @@ interface Props {
   isProposalEnded: boolean;
   canExecute: boolean;
   status: Proposal['status'];
+  proposalType: Proposal['type'];
 
   userVote: SubstreamVote | undefined;
   proposalId: string;
 }
 
-export function AcceptOrRejectEditor({ spaceId, isProposalEnded, canExecute, status, userVote, proposalId }: Props) {
+export function AcceptOrRejectEditor({
+  spaceId,
+  isProposalEnded,
+  canExecute,
+  status,
+  proposalType,
+  userVote,
+  proposalId,
+}: Props) {
   const router = useRouter();
 
   const { vote, status: voteStatus } = useVote({
@@ -65,9 +81,16 @@ export function AcceptOrRejectEditor({ spaceId, isProposalEnded, canExecute, sta
   const onVoteError = (choice: 'ACCEPT' | 'REJECT') => (error: unknown) => {
     removeOptimisticVote(proposalId);
     // A stale proposal can't be voted through — retrying would revert again,
-    // so toast + refresh instead of raising the error modal.
-    if (isStaleProposalVoteError(error)) {
-      setToast(<span>{STALE_PROPOSAL_VOTE_ERROR_MESSAGE}</span>);
+    // so toast + refresh instead of raising the error modal. ActionReverted is
+    // only treated as stale for membership proposals; for content proposals it
+    // can be a genuine execution failure that should surface as an error.
+    if (isVoteNotAcceptedError(error)) {
+      setToast(<span>{VOTE_NOT_ACCEPTED_MESSAGE}</span>);
+      router.refresh();
+      return;
+    }
+    if (isMembershipProposalType(proposalType) && isProposalActionRevertedError(error)) {
+      setToast(<span>{MEMBERSHIP_ALREADY_APPLIED_MESSAGE}</span>);
       router.refresh();
       return;
     }

--- a/apps/web/app/home/accept-or-reject-editor.tsx
+++ b/apps/web/app/home/accept-or-reject-editor.tsx
@@ -5,7 +5,8 @@ import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 
 import { useSmartAccount } from '~/core/hooks/use-smart-account';
-import { useVote } from '~/core/hooks/use-vote';
+import { useToast } from '~/core/hooks/use-toast';
+import { STALE_PROPOSAL_VOTE_ERROR_MESSAGE, isStaleProposalVoteError, useVote } from '~/core/hooks/use-vote';
 import { Proposal } from '~/core/io/dto/proposals';
 import { SubstreamVote } from '~/core/io/substream-schema';
 import { useReportError } from '~/core/state/status-bar-store';
@@ -46,6 +47,7 @@ export function AcceptOrRejectEditor({ spaceId, isProposalEnded, canExecute, sta
   const addOptimisticVote = useAddOptimisticVote();
   const removeOptimisticVote = useRemoveOptimisticVote();
   const reportError = useReportError();
+  const [, setToast] = useToast();
 
   // Drop the optimistic entry once router.refresh has caught up and userVote
   // is reflected on the prop — server render now naturally places the card
@@ -62,6 +64,13 @@ export function AcceptOrRejectEditor({ spaceId, isProposalEnded, canExecute, sta
 
   const onVoteError = (choice: 'ACCEPT' | 'REJECT') => (error: unknown) => {
     removeOptimisticVote(proposalId);
+    // A stale proposal can't be voted through — retrying would revert again,
+    // so toast + refresh instead of raising the error modal.
+    if (isStaleProposalVoteError(error)) {
+      setToast(<span>{STALE_PROPOSAL_VOTE_ERROR_MESSAGE}</span>);
+      router.refresh();
+      return;
+    }
     const message = describeError(error);
     reportError(`Vote failed: ${message}`, () => {
       addOptimisticVote(proposalId);

--- a/apps/web/app/home/accept-or-reject-editor.tsx
+++ b/apps/web/app/home/accept-or-reject-editor.tsx
@@ -6,14 +6,7 @@ import { useRouter } from 'next/navigation';
 
 import { useSmartAccount } from '~/core/hooks/use-smart-account';
 import { useToast } from '~/core/hooks/use-toast';
-import {
-  MEMBERSHIP_ALREADY_APPLIED_MESSAGE,
-  VOTE_NOT_ACCEPTED_MESSAGE,
-  isMembershipProposalType,
-  isProposalActionRevertedError,
-  isVoteNotAcceptedError,
-  useVote,
-} from '~/core/hooks/use-vote';
+import { getStaleProposalVoteToastMessage, useVote } from '~/core/hooks/use-vote';
 import { Proposal } from '~/core/io/dto/proposals';
 import { SubstreamVote } from '~/core/io/substream-schema';
 import { useReportError } from '~/core/state/status-bar-store';
@@ -81,16 +74,10 @@ export function AcceptOrRejectEditor({
   const onVoteError = (choice: 'ACCEPT' | 'REJECT') => (error: unknown) => {
     removeOptimisticVote(proposalId);
     // A stale proposal can't be voted through — retrying would revert again,
-    // so toast + refresh instead of raising the error modal. ActionReverted is
-    // only treated as stale for membership proposals; for content proposals it
-    // can be a genuine execution failure that should surface as an error.
-    if (isVoteNotAcceptedError(error)) {
-      setToast(<span>{VOTE_NOT_ACCEPTED_MESSAGE}</span>);
-      router.refresh();
-      return;
-    }
-    if (isMembershipProposalType(proposalType) && isProposalActionRevertedError(error)) {
-      setToast(<span>{MEMBERSHIP_ALREADY_APPLIED_MESSAGE}</span>);
+    // so toast + refresh instead of raising the error modal.
+    const staleMessage = getStaleProposalVoteToastMessage(error, proposalType);
+    if (staleMessage) {
+      setToast(<span>{staleMessage}</span>);
       router.refresh();
       return;
     }

--- a/apps/web/app/home/accept-or-reject-member.tsx
+++ b/apps/web/app/home/accept-or-reject-member.tsx
@@ -7,13 +7,7 @@ import { useRouter } from 'next/navigation';
 
 import { useSmartAccount } from '~/core/hooks/use-smart-account';
 import { useToast } from '~/core/hooks/use-toast';
-import {
-  MEMBERSHIP_ALREADY_APPLIED_MESSAGE,
-  VOTE_NOT_ACCEPTED_MESSAGE,
-  isProposalActionRevertedError,
-  isVoteNotAcceptedError,
-  useVote,
-} from '~/core/hooks/use-vote';
+import { getStaleProposalVoteToastMessage, useVote } from '~/core/hooks/use-vote';
 import { Proposal } from '~/core/io/dto/proposals';
 import type { SubstreamVote } from '~/core/io/substream-schema';
 import { useReportError } from '~/core/state/status-bar-store';
@@ -38,6 +32,7 @@ interface Props {
   spaceId: string;
   proposalId: string;
   proposalName: string;
+  proposalType: Proposal['type'];
   governanceHomeReturnSearch?: string;
   endTime: number;
   isProposalEnded: boolean;
@@ -64,6 +59,7 @@ export function AcceptOrRejectMember({
   spaceId,
   proposalId,
   proposalName,
+  proposalType,
   governanceHomeReturnSearch,
   endTime,
   isProposalEnded,
@@ -113,16 +109,10 @@ export function AcceptOrRejectMember({
       onError: (error: unknown) => {
         removeOptimisticVote(proposalId);
         // A stale proposal can't be voted through — retrying would revert
-        // again, so toast + refresh instead of raising the error modal. This
-        // card is always a membership proposal, so ActionReverted means the
-        // change was already applied.
-        if (isVoteNotAcceptedError(error)) {
-          setToast(<span>{VOTE_NOT_ACCEPTED_MESSAGE}</span>);
-          router.refresh();
-          return;
-        }
-        if (isProposalActionRevertedError(error)) {
-          setToast(<span>{MEMBERSHIP_ALREADY_APPLIED_MESSAGE}</span>);
+        // again, so toast + refresh instead of raising the error modal.
+        const staleMessage = getStaleProposalVoteToastMessage(error, proposalType);
+        if (staleMessage) {
+          setToast(<span>{staleMessage}</span>);
           router.refresh();
           return;
         }

--- a/apps/web/app/home/accept-or-reject-member.tsx
+++ b/apps/web/app/home/accept-or-reject-member.tsx
@@ -7,7 +7,13 @@ import { useRouter } from 'next/navigation';
 
 import { useSmartAccount } from '~/core/hooks/use-smart-account';
 import { useToast } from '~/core/hooks/use-toast';
-import { STALE_PROPOSAL_VOTE_ERROR_MESSAGE, isStaleProposalVoteError, useVote } from '~/core/hooks/use-vote';
+import {
+  MEMBERSHIP_ALREADY_APPLIED_MESSAGE,
+  VOTE_NOT_ACCEPTED_MESSAGE,
+  isProposalActionRevertedError,
+  isVoteNotAcceptedError,
+  useVote,
+} from '~/core/hooks/use-vote';
 import { Proposal } from '~/core/io/dto/proposals';
 import type { SubstreamVote } from '~/core/io/substream-schema';
 import { useReportError } from '~/core/state/status-bar-store';
@@ -107,9 +113,16 @@ export function AcceptOrRejectMember({
       onError: (error: unknown) => {
         removeOptimisticVote(proposalId);
         // A stale proposal can't be voted through — retrying would revert
-        // again, so toast + refresh instead of raising the error modal.
-        if (isStaleProposalVoteError(error)) {
-          setToast(<span>{STALE_PROPOSAL_VOTE_ERROR_MESSAGE}</span>);
+        // again, so toast + refresh instead of raising the error modal. This
+        // card is always a membership proposal, so ActionReverted means the
+        // change was already applied.
+        if (isVoteNotAcceptedError(error)) {
+          setToast(<span>{VOTE_NOT_ACCEPTED_MESSAGE}</span>);
+          router.refresh();
+          return;
+        }
+        if (isProposalActionRevertedError(error)) {
+          setToast(<span>{MEMBERSHIP_ALREADY_APPLIED_MESSAGE}</span>);
           router.refresh();
           return;
         }

--- a/apps/web/app/home/accept-or-reject-member.tsx
+++ b/apps/web/app/home/accept-or-reject-member.tsx
@@ -6,7 +6,8 @@ import cx from 'classnames';
 import { useRouter } from 'next/navigation';
 
 import { useSmartAccount } from '~/core/hooks/use-smart-account';
-import { useVote } from '~/core/hooks/use-vote';
+import { useToast } from '~/core/hooks/use-toast';
+import { STALE_PROPOSAL_VOTE_ERROR_MESSAGE, isStaleProposalVoteError, useVote } from '~/core/hooks/use-vote';
 import { Proposal } from '~/core/io/dto/proposals';
 import type { SubstreamVote } from '~/core/io/substream-schema';
 import { useReportError } from '~/core/state/status-bar-store';
@@ -83,6 +84,7 @@ export function AcceptOrRejectMember({
   const addOptimisticVote = useAddOptimisticVote();
   const removeOptimisticVote = useRemoveOptimisticVote();
   const reportError = useReportError();
+  const [, setToast] = useToast();
 
   // Drop the optimistic entry once router.refresh has caught up and userVote
   // is reflected on the prop — server render now naturally places the card
@@ -104,6 +106,13 @@ export function AcceptOrRejectMember({
       onSuccess: onVoteSuccess,
       onError: (error: unknown) => {
         removeOptimisticVote(proposalId);
+        // A stale proposal can't be voted through — retrying would revert
+        // again, so toast + refresh instead of raising the error modal.
+        if (isStaleProposalVoteError(error)) {
+          setToast(<span>{STALE_PROPOSAL_VOTE_ERROR_MESSAGE}</span>);
+          router.refresh();
+          return;
+        }
         const message = describeError(error);
         reportError(`Vote failed: ${message}`, () => castVote(choice));
       },

--- a/apps/web/app/home/my-governance-proposal-card.tsx
+++ b/apps/web/app/home/my-governance-proposal-card.tsx
@@ -152,6 +152,7 @@ export function MyGovernanceProposalCard({
             isProposalEnded={votingEnded}
             canExecute={canExecute}
             status={status}
+            proposalType={proposalType}
             userVote={userVoteSubstream}
           />
         ) : votingEnded || status !== 'PROPOSED' ? (

--- a/apps/web/app/home/pending-proposals-page.tsx
+++ b/apps/web/app/home/pending-proposals-page.tsx
@@ -331,6 +331,7 @@ async function PendingContentProposal({
           isProposalEnded={isProposalEnded}
           canExecute={proposal.canExecute}
           status={proposal.status}
+          proposalType={proposal.type}
           userVote={userVote}
         />
       </div>

--- a/apps/web/app/home/pending-proposals-page.tsx
+++ b/apps/web/app/home/pending-proposals-page.tsx
@@ -158,6 +158,7 @@ async function PendingMembershipProposal({
       spaceId={proposal.space.id}
       proposalId={proposal.id}
       proposalName={proposalName}
+      proposalType={proposal.type}
       governanceHomeReturnSearch={governanceHomeReturnSearch}
       endTime={proposal.endTime}
       isProposalEnded={isProposalEnded}

--- a/apps/web/core/hooks/use-toast.tsx
+++ b/apps/web/core/hooks/use-toast.tsx
@@ -2,8 +2,11 @@
 
 import * as React from 'react';
 
+import cx from 'classnames';
 import { AnimatePresence, motion } from 'framer-motion';
 import { atom, useAtom } from 'jotai';
+
+import { Z_LAYER_CLASS } from '~/core/z-layers';
 
 const toastAtom = atom<React.ReactElement<any> | null>(null);
 
@@ -26,7 +29,12 @@ export function Toast() {
   return (
     <AnimatePresence>
       {toast && (
-        <div className="pointer-events-none fixed right-0 bottom-0 left-0 flex w-full justify-center p-4">
+        <div
+          className={cx(
+            'pointer-events-none fixed right-0 bottom-0 left-0 flex w-full justify-center p-4',
+            Z_LAYER_CLASS.toast
+          )}
+        >
           <motion.div
             variants={flowVariants}
             initial="hidden"

--- a/apps/web/core/hooks/use-toast.tsx
+++ b/apps/web/core/hooks/use-toast.tsx
@@ -27,14 +27,19 @@ export function Toast() {
   const [toast] = useToast();
 
   return (
-    <AnimatePresence>
-      {toast && (
-        <div
-          className={cx(
-            'pointer-events-none fixed right-0 bottom-0 left-0 flex w-full justify-center p-4',
-            Z_LAYER_CLASS.toast
-          )}
-        >
+    // The live region stays mounted so screen readers reliably announce
+    // toasts; only the toast content itself animates in and out.
+    <div
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+      className={cx(
+        'pointer-events-none fixed right-0 bottom-0 left-0 flex w-full justify-center p-4',
+        Z_LAYER_CLASS.toast
+      )}
+    >
+      <AnimatePresence>
+        {toast && (
           <motion.div
             variants={flowVariants}
             initial="hidden"
@@ -46,9 +51,9 @@ export function Toast() {
           >
             {toast}
           </motion.div>
-        </div>
-      )}
-    </AnimatePresence>
+        )}
+      </AnimatePresence>
+    </div>
   );
 }
 

--- a/apps/web/core/hooks/use-vote.ts
+++ b/apps/web/core/hooks/use-vote.ts
@@ -32,8 +32,8 @@ const CAN_NOT_VOTE = { selector: '0x543ffef7', name: 'CanNotVote' };
 // ActionReverted(): a deciding YES executes the proposal's actions inline and
 // one of them reverted. For membership proposals this almost always means the
 // change was already applied via a duplicate request. For other proposal types
-// it can be a genuine execution failure, so callers should only treat it as
-// stale when `isMembershipProposalType` — otherwise let it surface as an error.
+// it can be a genuine execution failure, so it's only treated as stale for
+// membership proposals — otherwise it surfaces as an error.
 const ACTION_REVERTED = { selector: '0x24c05f9a', name: 'ActionReverted' };
 
 function matchesRevert(error: unknown, revert: { selector: string; name: string }): boolean {
@@ -41,23 +41,32 @@ function matchesRevert(error: unknown, revert: { selector: string; name: string 
   return description.includes(revert.selector) || description.includes(revert.name);
 }
 
-export function isVoteNotAcceptedError(error: unknown): boolean {
-  return matchesRevert(error, CAN_NOT_VOTE);
-}
-
-export function isProposalActionRevertedError(error: unknown): boolean {
-  return matchesRevert(error, ACTION_REVERTED);
-}
-
-export function isMembershipProposalType(type: ProposalType): boolean {
+function isMembershipProposalType(type: ProposalType): boolean {
   return type === 'ADD_MEMBER' || type === 'REMOVE_MEMBER' || type === 'ADD_EDITOR' || type === 'REMOVE_EDITOR';
 }
 
-export const VOTE_NOT_ACCEPTED_MESSAGE =
+const VOTE_NOT_ACCEPTED_MESSAGE =
   'Your vote could not be cast — voting may have ended, or your vote may already be counted. Refreshing to show the latest state.';
 
-export const MEMBERSHIP_ALREADY_APPLIED_MESSAGE =
+const MEMBERSHIP_ALREADY_APPLIED_MESSAGE =
   'This membership change could not be applied — it has likely already been made. Refreshing to show the latest state.';
+
+/**
+ * Returns the toast message for a vote error caused by a stale proposal, or
+ * null when the error should surface through the regular error path. Keeps the
+ * detection + messaging policy in one place so every vote surface behaves the
+ * same: callers toast the returned message and refresh instead of raising the
+ * error modal (retrying a stale vote would only revert again).
+ */
+export function getStaleProposalVoteToastMessage(error: unknown, proposalType: ProposalType): string | null {
+  if (matchesRevert(error, CAN_NOT_VOTE)) {
+    return VOTE_NOT_ACCEPTED_MESSAGE;
+  }
+  if (isMembershipProposalType(proposalType) && matchesRevert(error, ACTION_REVERTED)) {
+    return MEMBERSHIP_ALREADY_APPLIED_MESSAGE;
+  }
+  return null;
+}
 
 interface UseVoteArgs {
   /** The DAO space ID (bytes16 hex without 0x prefix) where the proposal exists */

--- a/apps/web/core/hooks/use-vote.ts
+++ b/apps/web/core/hooks/use-vote.ts
@@ -12,7 +12,33 @@ import { SubstreamVote } from '~/core/io/substream-schema';
 import { geo } from '~/core/sdk/geo-client';
 import { runEffectEither } from '~/core/telemetry/effect-runtime';
 import { SPACE_REGISTRY_ADDRESS } from '~/core/utils/contracts/space-registry';
+import { describeError } from '~/core/utils/error-diagnostics';
 import { validateSpaceId } from '~/core/utils/utils';
+
+/**
+ * DAOSpace reverts that mean the vote arrived too late — the UI showed a stale
+ * proposal the chain has already moved past. The render-time stale-request
+ * filter can't catch these when the indexer lags the chain, so we detect them
+ * at vote time and refresh instead of surfacing raw hex (retrying would only
+ * revert again).
+ */
+const STALE_PROPOSAL_REVERTS = [
+  // ActionReverted(): a deciding YES executes the proposal's actions in the
+  // same transaction; for membership proposals this almost always means the
+  // target was already added through a duplicate request.
+  { selector: '0x24c05f9a', name: 'ActionReverted' },
+  // CanNotVote(): the proposal already executed/closed, or this account
+  // already voted — e.g. a second Accept on a card that didn't re-render.
+  { selector: '0x543ffef7', name: 'CanNotVote' },
+];
+
+export function isStaleProposalVoteError(error: unknown): boolean {
+  const description = describeError(error);
+  return STALE_PROPOSAL_REVERTS.some(r => description.includes(r.selector) || description.includes(r.name));
+}
+
+export const STALE_PROPOSAL_VOTE_ERROR_MESSAGE =
+  'This proposal was already completed, so your vote was no longer needed. Refreshing the list.';
 
 interface UseVoteArgs {
   /** The DAO space ID (bytes16 hex without 0x prefix) where the proposal exists */

--- a/apps/web/core/hooks/use-vote.ts
+++ b/apps/web/core/hooks/use-vote.ts
@@ -8,7 +8,7 @@ import { Effect, Either } from 'effect';
 
 import { usePersonalSpaceId } from '~/core/hooks/use-personal-space-id';
 import { useSmartAccountTransaction } from '~/core/hooks/use-smart-account-transaction';
-import { SubstreamVote } from '~/core/io/substream-schema';
+import { ProposalType, SubstreamVote } from '~/core/io/substream-schema';
 import { geo } from '~/core/sdk/geo-client';
 import { runEffectEither } from '~/core/telemetry/effect-runtime';
 import { SPACE_REGISTRY_ADDRESS } from '~/core/utils/contracts/space-registry';
@@ -16,29 +16,48 @@ import { describeError } from '~/core/utils/error-diagnostics';
 import { validateSpaceId } from '~/core/utils/utils';
 
 /**
- * DAOSpace reverts that mean the vote arrived too late — the UI showed a stale
- * proposal the chain has already moved past. The render-time stale-request
- * filter can't catch these when the indexer lags the chain, so we detect them
- * at vote time and refresh instead of surfacing raw hex (retrying would only
- * revert again).
+ * DAOSpace reverts that usually mean the UI showed a stale proposal the chain
+ * has already moved past. The render-time stale-request filter can't catch
+ * these when the indexer lags the chain, so we detect them at vote time and
+ * toast + refresh instead of surfacing raw hex (retrying would only revert
+ * again). Both errors are parameterless, so we can't tell sub-cases apart —
+ * the user-facing messages below must hold for every possible cause.
  */
-const STALE_PROPOSAL_REVERTS = [
-  // ActionReverted(): a deciding YES executes the proposal's actions in the
-  // same transaction; for membership proposals this almost always means the
-  // target was already added through a duplicate request.
-  { selector: '0x24c05f9a', name: 'ActionReverted' },
-  // CanNotVote(): the proposal already executed/closed, or this account
-  // already voted — e.g. a second Accept on a card that didn't re-render.
-  { selector: '0x543ffef7', name: 'CanNotVote' },
-];
 
-export function isStaleProposalVoteError(error: unknown): boolean {
+// CanNotVote(): the DAOSpace rejected the vote upfront — the proposal already
+// executed or closed, this account already voted, or it is no longer eligible
+// to vote. No action runs, so treating this as stale never masks a failure.
+const CAN_NOT_VOTE = { selector: '0x543ffef7', name: 'CanNotVote' };
+
+// ActionReverted(): a deciding YES executes the proposal's actions inline and
+// one of them reverted. For membership proposals this almost always means the
+// change was already applied via a duplicate request. For other proposal types
+// it can be a genuine execution failure, so callers should only treat it as
+// stale when `isMembershipProposalType` — otherwise let it surface as an error.
+const ACTION_REVERTED = { selector: '0x24c05f9a', name: 'ActionReverted' };
+
+function matchesRevert(error: unknown, revert: { selector: string; name: string }): boolean {
   const description = describeError(error);
-  return STALE_PROPOSAL_REVERTS.some(r => description.includes(r.selector) || description.includes(r.name));
+  return description.includes(revert.selector) || description.includes(revert.name);
 }
 
-export const STALE_PROPOSAL_VOTE_ERROR_MESSAGE =
-  'This proposal was already completed, so your vote was no longer needed. Refreshing the list.';
+export function isVoteNotAcceptedError(error: unknown): boolean {
+  return matchesRevert(error, CAN_NOT_VOTE);
+}
+
+export function isProposalActionRevertedError(error: unknown): boolean {
+  return matchesRevert(error, ACTION_REVERTED);
+}
+
+export function isMembershipProposalType(type: ProposalType): boolean {
+  return type === 'ADD_MEMBER' || type === 'REMOVE_MEMBER' || type === 'ADD_EDITOR' || type === 'REMOVE_EDITOR';
+}
+
+export const VOTE_NOT_ACCEPTED_MESSAGE =
+  'Your vote could not be cast — voting may have ended, or your vote may already be counted. Refreshing to show the latest state.';
+
+export const MEMBERSHIP_ALREADY_APPLIED_MESSAGE =
+  'This membership change could not be applied — it has likely already been made. Refreshing to show the latest state.';
 
 interface UseVoteArgs {
   /** The DAO space ID (bytes16 hex without 0x prefix) where the proposal exists */

--- a/apps/web/core/hooks/use-vote.ts
+++ b/apps/web/core/hooks/use-vote.ts
@@ -49,7 +49,7 @@ const VOTE_NOT_ACCEPTED_MESSAGE =
   'Your vote could not be cast — voting may have ended, or your vote may already be counted. Refreshing to show the latest state.';
 
 const MEMBERSHIP_ALREADY_APPLIED_MESSAGE =
-  'This membership change could not be applied — it has likely already been made. Refreshing to show the latest state.';
+  'This change could not be applied — it has likely already been made. Refreshing to show the latest state.';
 
 /**
  * Returns the toast message for a vote error caused by a stale proposal, or

--- a/apps/web/core/z-layers.ts
+++ b/apps/web/core/z-layers.ts
@@ -11,10 +11,12 @@ export const Z_LAYERS = {
   reviewOnboardingTip: 10000,
 
   statusBar: 10001,
+  toast: 10001,
 } as const;
 
 export const Z_LAYER_CLASS = {
   flowBar: 'z-1000',
   slideUp: 'z-slide-up',
   statusBar: 'z-10001',
+  toast: 'z-10001',
 } as const;

--- a/apps/web/core/z-layers.ts
+++ b/apps/web/core/z-layers.ts
@@ -11,12 +11,14 @@ export const Z_LAYERS = {
   reviewOnboardingTip: 10000,
 
   statusBar: 10001,
-  toast: 10001,
+  // Strictly above statusBar: <StatusBar /> renders after <Toast /> in
+  // entry.tsx, so an equal z-index would stack the status bar over toasts.
+  toast: 10002,
 } as const;
 
 export const Z_LAYER_CLASS = {
   flowBar: 'z-1000',
   slideUp: 'z-slide-up',
   statusBar: 'z-10001',
-  toast: 'z-10001',
+  toast: 'z-10002',
 } as const;

--- a/apps/web/core/z-layers.ts
+++ b/apps/web/core/z-layers.ts
@@ -20,5 +20,5 @@ export const Z_LAYER_CLASS = {
   flowBar: 'z-1000',
   slideUp: 'z-slide-up',
   statusBar: 'z-10001',
-  toast: 'z-10002',
+  toast: 'z-toast',
 } as const;

--- a/apps/web/partials/active-proposal/accept-or-reject.tsx
+++ b/apps/web/partials/active-proposal/accept-or-reject.tsx
@@ -8,14 +8,7 @@ import { useRouter } from 'next/navigation';
 import { useAccessControl } from '~/core/hooks/use-access-control';
 import { useSmartAccount } from '~/core/hooks/use-smart-account';
 import { useToast } from '~/core/hooks/use-toast';
-import {
-  MEMBERSHIP_ALREADY_APPLIED_MESSAGE,
-  VOTE_NOT_ACCEPTED_MESSAGE,
-  isMembershipProposalType,
-  isProposalActionRevertedError,
-  isVoteNotAcceptedError,
-  useVote,
-} from '~/core/hooks/use-vote';
+import { getStaleProposalVoteToastMessage, useVote } from '~/core/hooks/use-vote';
 import { Proposal } from '~/core/io/dto/proposals';
 import { SubstreamVote } from '~/core/io/substream-schema';
 import { useReportError } from '~/core/state/status-bar-store';
@@ -88,17 +81,9 @@ export function AcceptOrReject({
     removeOptimisticVote(proposalId);
     // A stale proposal can't be voted through — retrying would revert again,
     // so close the review window and toast instead of raising the error modal.
-    // ActionReverted is only treated as stale for membership proposals; for
-    // content proposals it can be a genuine execution failure that should
-    // surface as an error.
-    if (isVoteNotAcceptedError(error)) {
-      setToast(<span>{VOTE_NOT_ACCEPTED_MESSAGE}</span>);
-      closeProposal();
-      router.refresh();
-      return;
-    }
-    if (isMembershipProposalType(proposalType) && isProposalActionRevertedError(error)) {
-      setToast(<span>{MEMBERSHIP_ALREADY_APPLIED_MESSAGE}</span>);
+    const staleMessage = getStaleProposalVoteToastMessage(error, proposalType);
+    if (staleMessage) {
+      setToast(<span>{staleMessage}</span>);
       closeProposal();
       router.refresh();
       return;

--- a/apps/web/partials/active-proposal/accept-or-reject.tsx
+++ b/apps/web/partials/active-proposal/accept-or-reject.tsx
@@ -8,7 +8,14 @@ import { useRouter } from 'next/navigation';
 import { useAccessControl } from '~/core/hooks/use-access-control';
 import { useSmartAccount } from '~/core/hooks/use-smart-account';
 import { useToast } from '~/core/hooks/use-toast';
-import { STALE_PROPOSAL_VOTE_ERROR_MESSAGE, isStaleProposalVoteError, useVote } from '~/core/hooks/use-vote';
+import {
+  MEMBERSHIP_ALREADY_APPLIED_MESSAGE,
+  VOTE_NOT_ACCEPTED_MESSAGE,
+  isMembershipProposalType,
+  isProposalActionRevertedError,
+  isVoteNotAcceptedError,
+  useVote,
+} from '~/core/hooks/use-vote';
 import { Proposal } from '~/core/io/dto/proposals';
 import { SubstreamVote } from '~/core/io/substream-schema';
 import { useReportError } from '~/core/state/status-bar-store';
@@ -81,8 +88,17 @@ export function AcceptOrReject({
     removeOptimisticVote(proposalId);
     // A stale proposal can't be voted through — retrying would revert again,
     // so close the review window and toast instead of raising the error modal.
-    if (isStaleProposalVoteError(error)) {
-      setToast(<span>{STALE_PROPOSAL_VOTE_ERROR_MESSAGE}</span>);
+    // ActionReverted is only treated as stale for membership proposals; for
+    // content proposals it can be a genuine execution failure that should
+    // surface as an error.
+    if (isVoteNotAcceptedError(error)) {
+      setToast(<span>{VOTE_NOT_ACCEPTED_MESSAGE}</span>);
+      closeProposal();
+      router.refresh();
+      return;
+    }
+    if (isMembershipProposalType(proposalType) && isProposalActionRevertedError(error)) {
+      setToast(<span>{MEMBERSHIP_ALREADY_APPLIED_MESSAGE}</span>);
       closeProposal();
       router.refresh();
       return;

--- a/apps/web/partials/active-proposal/accept-or-reject.tsx
+++ b/apps/web/partials/active-proposal/accept-or-reject.tsx
@@ -7,7 +7,8 @@ import { useRouter } from 'next/navigation';
 
 import { useAccessControl } from '~/core/hooks/use-access-control';
 import { useSmartAccount } from '~/core/hooks/use-smart-account';
-import { useVote } from '~/core/hooks/use-vote';
+import { useToast } from '~/core/hooks/use-toast';
+import { STALE_PROPOSAL_VOTE_ERROR_MESSAGE, isStaleProposalVoteError, useVote } from '~/core/hooks/use-vote';
 import { Proposal } from '~/core/io/dto/proposals';
 import { SubstreamVote } from '~/core/io/substream-schema';
 import { useReportError } from '~/core/state/status-bar-store';
@@ -20,6 +21,7 @@ import { GovernanceReopenEditButton } from '~/partials/governance/governance-reo
 import { useAddOptimisticVote, useRemoveOptimisticVote } from '~/partials/governance/optimistic-voted-atom';
 
 import { Execute } from './execute';
+import { useCloseProposal } from './use-close-proposal';
 
 interface Props {
   spaceId: string;
@@ -59,6 +61,8 @@ export function AcceptOrReject({
   const addOptimisticVote = useAddOptimisticVote();
   const removeOptimisticVote = useRemoveOptimisticVote();
   const reportError = useReportError();
+  const [, setToast] = useToast();
+  const closeProposal = useCloseProposal(spaceId);
 
   // Once the server-rendered userVote catches up after router.refresh, the
   // optimistic entry has done its job — drop it so the atom doesn't grow
@@ -75,6 +79,14 @@ export function AcceptOrReject({
 
   const onVoteError = (choice: 'ACCEPT' | 'REJECT') => (error: unknown) => {
     removeOptimisticVote(proposalId);
+    // A stale proposal can't be voted through — retrying would revert again,
+    // so close the review window and toast instead of raising the error modal.
+    if (isStaleProposalVoteError(error)) {
+      setToast(<span>{STALE_PROPOSAL_VOTE_ERROR_MESSAGE}</span>);
+      closeProposal();
+      router.refresh();
+      return;
+    }
     const message = describeError(error);
     reportError(`Vote failed: ${message}`, () => {
       addOptimisticVote(proposalId);

--- a/apps/web/styles/styles.css
+++ b/apps/web/styles/styles.css
@@ -69,6 +69,7 @@
   --z-index-flow-bar: 1000;
   --z-index-slide-up: 10000;
   --z-index-status-bar: 10001;
+  --z-index-toast: 10002;
 
   /* Breakpoints (max-width variants defined below) */
   --breakpoint-*: initial;


### PR DESCRIPTION

Voting on a proposal the chain has already moved past reverts in the DAOSpace contract as ActionReverted (0x24c05f9a, deciding YES executes inline and the target is already a member) or CanNotVote (0x543ffef7, proposal already executed or vote already cast). The render-time stale-request filter can't catch these when the indexer lags the chain, so editors doing rapid acceptances hit raw hex in the error modal.

Detect both selectors at vote time in useVote, surface a friendly toast (raised above the slide-up via a new toast z-layer), refresh the list, and close the proposal review window instead of offering a retry that would only revert again.