### PR TITLE
fix: bury property groups in property "+" menu

### DIFF
--- a/apps/web/atoms/index.ts
+++ b/apps/web/atoms/index.ts
@@ -5,6 +5,11 @@ export const showingIdsAtom = atomWithStorage<boolean>('showingIds', false);
 
 export const editingPropertiesAtom = atom<boolean>(false);
 
+// Holds the entity id of a newly-created property group whose name input should
+// auto-focus. Set when a group is created (from the "+" menu) and consumed by the
+// property groups editor, which can live in a separate page section from the trigger.
+export const focusPropertyGroupNameAtom = atom<string | null>(null);
+
 export type EntitySidePanelTarget = {
   entityId: string;
   spaceId: string;

--- a/apps/web/core/hooks/use-create-property-group.ts
+++ b/apps/web/core/hooks/use-create-property-group.ts
@@ -1,0 +1,75 @@
+'use client';
+
+import { Position, SystemIds } from '@geoprotocol/geo-sdk/lite';
+
+import * as React from 'react';
+
+import { useSetAtom } from 'jotai';
+
+import { focusPropertyGroupNameAtom } from '~/atoms';
+import { COLLAPSED_PROPERTY, PROPERTY_GROUPS_PROPERTY, PROPERTY_GROUP_TYPE } from '~/core/constants';
+import { ID } from '~/core/id';
+import { useMutate } from '~/core/sync/use-mutate';
+import { useRelations } from '~/core/sync/use-store';
+import { sortRelations } from '~/core/utils/utils';
+
+/**
+ * Creates a new property group on a type entity. Property groups are an advanced
+ * feature, so creation is buried in the "+" menu rather than shown as its own
+ * labeled section. Returns the new group's entity id and flags its name input to
+ * auto-focus via {@link focusPropertyGroupNameAtom}, since the groups editor can
+ * render in a different page section than the trigger.
+ */
+export function useCreatePropertyGroup(entityId: string, spaceId: string) {
+  const { storage } = useMutate();
+  const setFocusGroupNameId = useSetAtom(focusPropertyGroupNameAtom);
+
+  const propertyGroupRelations = sortRelations(
+    useRelations({
+      selector: relation =>
+        relation.fromEntity.id === entityId &&
+        relation.spaceId === spaceId &&
+        relation.type.id === PROPERTY_GROUPS_PROPERTY,
+    })
+  );
+
+  return React.useCallback(() => {
+    const groupEntityId = ID.createEntityId();
+    const lastGroupPosition = propertyGroupRelations.at(-1)?.position ?? null;
+
+    storage.entities.name.set(groupEntityId, spaceId, '');
+    storage.values.set({
+      spaceId,
+      entity: { id: groupEntityId, name: null },
+      property: { id: COLLAPSED_PROPERTY, name: 'Collapsed', dataType: 'BOOLEAN' },
+      value: '0',
+    });
+
+    storage.relations.set({
+      id: ID.createEntityId(),
+      entityId: ID.createEntityId(),
+      spaceId,
+      renderableType: 'RELATION',
+      verified: false,
+      position: Position.generate(),
+      type: { id: SystemIds.TYPES_PROPERTY, name: 'Types' },
+      fromEntity: { id: groupEntityId, name: null },
+      toEntity: { id: PROPERTY_GROUP_TYPE, name: 'Property group', value: PROPERTY_GROUP_TYPE },
+    });
+
+    storage.relations.set({
+      id: ID.createEntityId(),
+      entityId: ID.createEntityId(),
+      spaceId,
+      renderableType: 'RELATION',
+      verified: false,
+      position: Position.generateBetween(lastGroupPosition, null),
+      type: { id: PROPERTY_GROUPS_PROPERTY, name: 'Property groups' },
+      fromEntity: { id: entityId, name: null },
+      toEntity: { id: groupEntityId, name: null, value: groupEntityId },
+    });
+
+    setFocusGroupNameId(groupEntityId);
+    return groupEntityId;
+  }, [entityId, propertyGroupRelations, setFocusGroupNameId, spaceId, storage]);
+}

--- a/apps/web/partials/entity-page/editable-entity-page.tsx
+++ b/apps/web/partials/entity-page/editable-entity-page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { ContentIds, IdUtils, Position, SystemIds } from '@geoprotocol/geo-sdk/lite';
+import * as Popover from '@radix-ui/react-popover';
 
 import * as React from 'react';
 
@@ -23,6 +24,8 @@ import {
   isBlockConfigRelationType,
 } from '~/core/blocks/data/shown-column-relations';
 import { useCreateProperty } from '~/core/hooks/use-create-property';
+import { useCreatePropertyGroup } from '~/core/hooks/use-create-property-group';
+import { useKey } from '~/core/hooks/use-key';
 import { useEditableProperties } from '~/core/hooks/use-renderables';
 import { ID } from '~/core/id';
 import {
@@ -34,7 +37,7 @@ import {
 } from '~/core/state/entity-page-store/entity-store';
 import { Mutator, useMutate } from '~/core/sync/use-mutate';
 import { useQueryProperty, useRelations, useValue } from '~/core/sync/use-store';
-import { Property, Relation, ValueOptions } from '~/core/types';
+import { Property, Relation, SwitchableRenderableType, ValueOptions } from '~/core/types';
 import { mapPropertyType } from '~/core/utils/property/properties';
 import { isUrlTemplate, resolveUrlTemplate } from '~/core/utils/url-template';
 import { useImageUrlFromEntity, useVideoUrlFromEntity } from '~/core/utils/use-entity-media';
@@ -58,9 +61,11 @@ import { ChevronDownSmall } from '~/design-system/icons/chevron-down-small';
 import { Create } from '~/design-system/icons/create';
 import { Trash } from '~/design-system/icons/trash';
 import { InputPlace } from '~/design-system/input-address';
+import { MenuItem } from '~/design-system/menu';
 import ReorderableRelationChipsDnd from '~/design-system/reorderable-relation-chips-dnd';
 import { SelectEntity } from '~/design-system/select-entity';
 import { SelectEntityAsPopover } from '~/design-system/select-entity-dialog';
+import { useElevatedPopoverPortal } from '~/design-system/use-elevated-popover-portal';
 import SuggestedFormats from '~/design-system/suggested-formats-window';
 import { Text } from '~/design-system/text';
 
@@ -119,6 +124,55 @@ export function EditableEntityPage({ id, spaceId }: EditableEntityPageProps) {
     },
     [id, name, spaceId, storage.relations, typePropertyRelations]
   );
+  const createPropertyGroup = useCreatePropertyGroup(id, spaceId);
+
+  // Shared by the "+" control whether it adds the property to a type's schema or to a
+  // regular entity. `onCreateProperty` runs when a brand-new property is created;
+  // `onSelectProperty` runs when an existing one is picked.
+  const onCreateProperty = (result: {
+    name: string | null;
+    space?: string;
+    verified?: boolean;
+    renderableType?: SwitchableRenderableType;
+  }) => {
+    const renderableType = result.renderableType || 'TEXT';
+
+    const createdPropertyId = createProperty({
+      name: result.name || '',
+      propertyType: renderableType,
+      verified: result.verified,
+      space: result.space,
+    });
+
+    if (isTypeEntity) {
+      addPropertyToType({ id: createdPropertyId, name: result.name || '' });
+    } else {
+      addPropertyToEntity({
+        entityId: id,
+        propertyId: createdPropertyId,
+        propertyName: result.name || '',
+        entityName: name || undefined,
+      });
+    }
+
+    return createdPropertyId;
+  };
+
+  const onSelectProperty = (result: { id: string; name: string | null }) => {
+    if (!result) return;
+
+    if (isTypeEntity) {
+      addPropertyToType({ id: result.id, name: result.name });
+    } else {
+      addPropertyToEntity({
+        entityId: id,
+        propertyId: result.id,
+        propertyName: result.name || '',
+        entityName: name || undefined,
+      });
+    }
+  };
+
   const visiblePropertySections = useVisiblePropertySections(id, spaceId);
   const visibleFlatPropertiesEntries = useVisiblePropertiesEntries(id, spaceId, {
     hideTypeGroupingFields: isTypeEntity,
@@ -250,52 +304,27 @@ export function EditableEntityPage({ id, spaceId }: EditableEntityPageProps) {
               })}
             </div>
             <div className={effectiveTotalProperties === 0 ? 'absolute bottom-0 left-0 p-4' : 'p-4'}>
-              <SelectEntityAsPopover
-                trigger={<SquareButton icon={<Create />} />}
-                spaceId={spaceId}
-                relationValueTypes={[{ id: SystemIds.PROPERTY, name: 'Property' }]}
-                onCreateEntity={result => {
-                  const renderableType = result.renderableType || 'TEXT';
-
-                  const createdPropertyId = createProperty({
-                    name: result.name || '',
-                    propertyType: renderableType,
-                    verified: result.verified,
-                    space: result.space,
-                  });
-
-                  if (isTypeEntity) {
-                    addPropertyToType({ id: createdPropertyId, name: result.name || '' });
-                  } else {
-                    // Immediately add the property to the entity
-                    addPropertyToEntity({
-                      entityId: id,
-                      propertyId: createdPropertyId,
-                      propertyName: result.name || '',
-                      entityName: name || undefined,
-                    });
-                  }
-
-                  return createdPropertyId;
-                }}
-                onDone={result => {
-                  if (result) {
-                    if (isTypeEntity) {
-                      addPropertyToType({ id: result.id, name: result.name });
-                    } else {
-                      addPropertyToEntity({
-                        entityId: id,
-                        propertyId: result.id,
-                        propertyName: result.name || '',
-                        entityName: name || undefined,
-                      });
-                    }
-                  }
-                }}
-                placeholder="Find or create property..."
-                advanced={false}
-                showIDs={false}
-              />
+              {isTypeEntity ? (
+                // Type entities can also have property groups, but that's an advanced
+                // feature so it's buried in this menu rather than shown as its own section.
+                <AddPropertyMenu
+                  spaceId={spaceId}
+                  onCreateProperty={onCreateProperty}
+                  onSelectProperty={onSelectProperty}
+                  onAddGroup={createPropertyGroup}
+                />
+              ) : (
+                <SelectEntityAsPopover
+                  trigger={<SquareButton icon={<Create />} />}
+                  spaceId={spaceId}
+                  relationValueTypes={[{ id: SystemIds.PROPERTY, name: 'Property' }]}
+                  onCreateEntity={onCreateProperty}
+                  onDone={onSelectProperty}
+                  placeholder="Find or create property..."
+                  advanced={false}
+                  showIDs={false}
+                />
+              )}
             </div>
           </motion.div>
         </div>
@@ -305,6 +334,90 @@ export function EditableEntityPage({ id, spaceId }: EditableEntityPageProps) {
 }
 
 export const EditableEntityProperties = EditableEntityPage;
+
+/**
+ * The "+" control for type entities. Opens a small menu so property-group creation —
+ * an advanced feature — can live alongside "New property" without crowding the
+ * common case. Picking "New property" swaps the same popover over to the entity search.
+ */
+function AddPropertyMenu({
+  spaceId,
+  onCreateProperty,
+  onSelectProperty,
+  onAddGroup,
+}: {
+  spaceId: string;
+  onCreateProperty: (result: {
+    name: string | null;
+    space?: string;
+    verified?: boolean;
+    renderableType?: SwitchableRenderableType;
+  }) => string;
+  onSelectProperty: (result: { id: string; name: string | null }) => void;
+  onAddGroup: () => void;
+}) {
+  const [open, setOpen] = React.useState(false);
+  const [mode, setMode] = React.useState<'menu' | 'search'>('menu');
+  const elevatedPopoverPortal = useElevatedPopoverPortal();
+
+  useKey('Escape', () => {
+    if (open) setOpen(false);
+  });
+
+  // Always (re)open on the menu, never lingering on a previous search.
+  React.useEffect(() => {
+    if (!open) setMode('menu');
+  }, [open]);
+
+  return (
+    <Popover.Root open={open} onOpenChange={setOpen} modal={false}>
+      <Popover.Trigger asChild>
+        <SquareButton icon={<Create />} />
+      </Popover.Trigger>
+
+      {open && elevatedPopoverPortal ? (
+        <Popover.Portal container={elevatedPopoverPortal}>
+          <Popover.Content
+            sideOffset={4}
+            align="start"
+            className="pointer-events-auto z-[var(--elevated-popover-z,1001)]"
+            collisionPadding={10}
+            avoidCollisions={true}
+          >
+            {mode === 'menu' ? (
+              <div className="flex w-[240px] flex-col overflow-hidden rounded-lg border border-grey-02 bg-white py-1 shadow-lg">
+                <MenuItem onClick={() => setMode('search')}>
+                  <span>New property</span>
+                </MenuItem>
+                <MenuItem
+                  onClick={() => {
+                    onAddGroup();
+                    setOpen(false);
+                  }}
+                >
+                  <span>New property group</span>
+                </MenuItem>
+              </div>
+            ) : (
+              <SelectEntity
+                withSearchIcon={true}
+                spaceId={spaceId}
+                relationValueTypes={[{ id: SystemIds.PROPERTY, name: 'Property' }]}
+                placeholder="Find or create property..."
+                onDone={onSelectProperty}
+                onCreateEntity={onCreateProperty}
+                variant="floating"
+                advanced={false}
+                showIDs={false}
+              />
+            )}
+          </Popover.Content>
+        </Popover.Portal>
+      ) : null}
+    </Popover.Root>
+  );
+}
+
 function InlinePropertyRow({
   entityId,
   propertyId,

--- a/apps/web/partials/entity-page/type-property-groups-editor.tsx
+++ b/apps/web/partials/entity-page/type-property-groups-editor.tsx
@@ -27,8 +27,10 @@ import { Position, SystemIds } from '@geoprotocol/geo-sdk/lite';
 import * as React from 'react';
 
 import cx from 'classnames';
+import { useAtom } from 'jotai';
 
-import { COLLAPSED_PROPERTY, PROPERTY_GROUPS_PROPERTY, PROPERTY_GROUP_TYPE } from '~/core/constants';
+import { focusPropertyGroupNameAtom } from '~/atoms';
+import { COLLAPSED_PROPERTY, PROPERTY_GROUPS_PROPERTY } from '~/core/constants';
 import { useCreateProperty } from '~/core/hooks/use-create-property';
 import { ID } from '~/core/id';
 import { useMutate } from '~/core/sync/use-mutate';
@@ -38,7 +40,6 @@ import { sortRelations } from '~/core/utils/utils';
 
 import { Checkbox, getChecked } from '~/design-system/checkbox';
 import { LinkableRelationChip } from '~/design-system/chip';
-import { ChevronDownSmall } from '~/design-system/icons/chevron-down-small';
 import { Create } from '~/design-system/icons/create';
 import { OrderDots } from '~/design-system/icons/order-dots';
 import { Trash } from '~/design-system/icons/trash';
@@ -96,11 +97,12 @@ type CreatePropertyFn = ReturnType<typeof useCreateProperty>['createProperty'];
 export function TypePropertyGroupsEditor({ entityId, spaceId }: EditorProps) {
   const { storage } = useMutate();
   const { createProperty } = useCreateProperty(spaceId);
-  const [sectionCollapsed, setSectionCollapsed] = React.useState(false);
   const [activePropertyDragId, setActivePropertyDragId] = React.useState<string | null>(null);
   const [activeGroupDragId, setActiveGroupDragId] = React.useState<string | null>(null);
   const [groupOverlayWidths, setGroupOverlayWidths] = React.useState<Record<string, number>>({});
-  const [focusGroupNameId, setFocusGroupNameId] = React.useState<string | null>(null);
+  // Newly-created groups (added from the "+" menu, possibly in another page section)
+  // flag their name input to auto-focus via this shared atom.
+  const [focusGroupNameId, setFocusGroupNameId] = useAtom(focusPropertyGroupNameAtom);
   const lastOverIdRef = React.useRef<string | null>(null);
 
   const typePropertyRelations = sortRelations(
@@ -286,44 +288,6 @@ export function TypePropertyGroupsEditor({ entityId, spaceId }: EditorProps) {
     });
   };
 
-  const onAddGroup = () => {
-    const groupEntityId = ID.createEntityId();
-    const lastGroupPosition = propertyGroupRelations.at(-1)?.position ?? null;
-
-    storage.entities.name.set(groupEntityId, spaceId, '');
-    storage.values.set({
-      spaceId,
-      entity: { id: groupEntityId, name: null },
-      property: { id: COLLAPSED_PROPERTY, name: 'Collapsed', dataType: 'BOOLEAN' },
-      value: '0',
-    });
-
-    storage.relations.set({
-      id: ID.createEntityId(),
-      entityId: ID.createEntityId(),
-      spaceId,
-      renderableType: 'RELATION',
-      verified: false,
-      position: Position.generate(),
-      type: { id: SystemIds.TYPES_PROPERTY, name: 'Types' },
-      fromEntity: { id: groupEntityId, name: null },
-      toEntity: { id: PROPERTY_GROUP_TYPE, name: 'Property group', value: PROPERTY_GROUP_TYPE },
-    });
-
-    storage.relations.set({
-      id: ID.createEntityId(),
-      entityId: ID.createEntityId(),
-      spaceId,
-      renderableType: 'RELATION',
-      verified: false,
-      position: Position.generateBetween(lastGroupPosition, null),
-      type: { id: PROPERTY_GROUPS_PROPERTY, name: 'Property groups' },
-      fromEntity: { id: entityId, name: null },
-      toEntity: { id: groupEntityId, name: null, value: groupEntityId },
-    });
-    setFocusGroupNameId(groupEntityId);
-  };
-
   const onDeleteGroup = (groupRelation: Relation) => {
     const groupId = groupRelation.toEntity.id;
     const groupRelations = allGroupOutgoingRelations.filter(relation => relation.fromEntity.id === groupId);
@@ -492,99 +456,80 @@ export function TypePropertyGroupsEditor({ entityId, spaceId }: EditorProps) {
     ensurePropertyOnType(draggedPropertyId, draggedName);
   };
 
+  // Property groups are an advanced feature, so the editor stays out of the way until
+  // a group actually exists. Creation lives in the "+" menu (useCreatePropertyGroup).
+  if (propertyGroupRelations.length === 0) {
+    return null;
+  }
+
   return (
-    <div className="flex flex-col gap-2">
-      <div className="flex items-center justify-between">
-        <button
-          type="button"
-          className="inline-flex items-center gap-1 text-tableCell text-grey-04"
-          onClick={() => setSectionCollapsed(previous => !previous)}
+    <div className="rounded-lg border border-grey-02 shadow-button">
+      <DndContext
+        sensors={sensors}
+        collisionDetection={collisionDetection}
+        onDragStart={onDragStart}
+        onDragOver={onDragOver}
+        onDragEnd={onDragEnd}
+        onDragCancel={() => {
+          setActivePropertyDragId(null);
+          setActiveGroupDragId(null);
+        }}
+      >
+        <SortableContext
+          items={propertyGroupRelations.map(groupRelation => groupDragId(groupRelation.id))}
+          strategy={verticalListSortingStrategy}
         >
-          <span>Property groups</span>
-          <div className={cx(sectionCollapsed && '-rotate-90', 'scale-110 transition-transform')}>
-            <ChevronDownSmall color="grey-04" />
+          <div>
+            {groupContainers.map(container => (
+              <TypePropertyGroupCard
+                key={container.groupRelation.id}
+                spaceId={spaceId}
+                groupRelation={container.groupRelation}
+                propertyRelations={container.propertyRelations}
+                typePropertyRelations={typePropertyRelations}
+                onDeleteGroup={() => onDeleteGroup(container.groupRelation)}
+                onAddProperty={property => onAddPropertyToGroup(container.groupEntityId, property)}
+                createProperty={createProperty}
+                autoFocusName={focusGroupNameId === container.groupEntityId}
+                onNameAutoFocused={() =>
+                  setFocusGroupNameId(current => (current === container.groupEntityId ? null : current))
+                }
+                onMeasureWidth={width =>
+                  setGroupOverlayWidths(previous => {
+                    if (previous[container.groupRelation.id] === width) return previous;
+                    return { ...previous, [container.groupRelation.id]: width };
+                  })
+                }
+              />
+            ))}
           </div>
-        </button>
-        <button
-          type="button"
-          onClick={onAddGroup}
-          className="inline-flex h-6 w-6 items-center justify-center text-grey-04 transition-colors hover:text-text"
-          aria-label="Add property group"
-        >
-          <Create />
-        </button>
-      </div>
+        </SortableContext>
 
-      {!sectionCollapsed && (
-        <div className="rounded-lg border border-grey-02 shadow-button">
-          <DndContext
-            sensors={sensors}
-            collisionDetection={collisionDetection}
-            onDragStart={onDragStart}
-            onDragOver={onDragOver}
-            onDragEnd={onDragEnd}
-            onDragCancel={() => {
-              setActivePropertyDragId(null);
-              setActiveGroupDragId(null);
-            }}
-          >
-            <SortableContext
-              items={propertyGroupRelations.map(groupRelation => groupDragId(groupRelation.id))}
-              strategy={verticalListSortingStrategy}
-            >
-              <div>
-                {groupContainers.map(container => (
-                  <TypePropertyGroupCard
-                    key={container.groupRelation.id}
-                    spaceId={spaceId}
-                    groupRelation={container.groupRelation}
-                    propertyRelations={container.propertyRelations}
-                    typePropertyRelations={typePropertyRelations}
-                    onDeleteGroup={() => onDeleteGroup(container.groupRelation)}
-                    onAddProperty={property => onAddPropertyToGroup(container.groupEntityId, property)}
-                    createProperty={createProperty}
-                    autoFocusName={focusGroupNameId === container.groupEntityId}
-                    onNameAutoFocused={() =>
-                      setFocusGroupNameId(current => (current === container.groupEntityId ? null : current))
-                    }
-                    onMeasureWidth={width =>
-                      setGroupOverlayWidths(previous => {
-                        if (previous[container.groupRelation.id] === width) return previous;
-                        return { ...previous, [container.groupRelation.id]: width };
-                      })
-                    }
-                  />
-                ))}
-              </div>
-            </SortableContext>
-
-            <UngroupedDropContainer
-              entityId={entityId}
+        <UngroupedDropContainer
+          entityId={entityId}
+          spaceId={spaceId}
+          relations={ungroupedRelations}
+          allTypePropertyIds={typePropertyRelations.map(relation => relation.toEntity.id)}
+          hasGroupsAbove={groupContainers.length > 0}
+          createProperty={createProperty}
+        />
+        <DragOverlay>
+          {activePropertyDragId ? (
+            <div className="inline-flex max-w-[220px] items-center rounded border border-text bg-white px-1.5 py-px text-metadata font-normal tracking-[-0.25px] text-text shadow-lg">
+              <span className="truncate">{propertyNameById.get(activePropertyDragId) ?? activePropertyDragId}</span>
+            </div>
+          ) : activeGroupDragId ? (
+            <GroupDragOverlayPreview
+              groupRelation={propertyGroupRelations.find(relation => relation.id === activeGroupDragId) ?? null}
+              groupContainer={
+                groupContainers.find(container => container.groupRelation.id === activeGroupDragId) ?? null
+              }
               spaceId={spaceId}
-              relations={ungroupedRelations}
-              allTypePropertyIds={typePropertyRelations.map(relation => relation.toEntity.id)}
-              hasGroupsAbove={groupContainers.length > 0}
-              createProperty={createProperty}
+              width={activeGroupDragId ? groupOverlayWidths[activeGroupDragId] : undefined}
             />
-            <DragOverlay>
-              {activePropertyDragId ? (
-                <div className="inline-flex max-w-[220px] items-center rounded border border-text bg-white px-1.5 py-px text-metadata font-normal tracking-[-0.25px] text-text shadow-lg">
-                  <span className="truncate">{propertyNameById.get(activePropertyDragId) ?? activePropertyDragId}</span>
-                </div>
-              ) : activeGroupDragId ? (
-                <GroupDragOverlayPreview
-                  groupRelation={propertyGroupRelations.find(relation => relation.id === activeGroupDragId) ?? null}
-                  groupContainer={
-                    groupContainers.find(container => container.groupRelation.id === activeGroupDragId) ?? null
-                  }
-                  spaceId={spaceId}
-                  width={activeGroupDragId ? groupOverlayWidths[activeGroupDragId] : undefined}
-                />
-              ) : null}
-            </DragOverlay>
-          </DndContext>
-        </div>
-      )}
+          ) : null}
+        </DragOverlay>
+      </DndContext>
     </div>
   );
 }


### PR DESCRIPTION
Property groups are an advanced feature, so showing a prominent "Property groups" section while setting up a new type entity added noise to the common case. Remove the standalone header and only render the groups editor once a group exists. Group creation now lives in the property "+" menu (New property / New property group) via a shared useCreatePropertyGroup hook, with a focus atom coordinating auto-focus across page sections.