### PR TITLE
refactor(entity-menu): simplify copy and drop convert action

### DIFF
--- a/apps/web/design-system/icons/switch.tsx
+++ b/apps/web/design-system/icons/switch.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react';
+
+import { ColorName, colors } from '~/design-system/theme/colors';
+
+interface Props {
+  color?: ColorName;
+}
+
+export function Switch({ color }: Props) {
+  const themeColor = color ? colors.light[color] : 'currentColor';
+
+  return (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path d="M3.5 0.5L3.5 14.5" stroke={themeColor} strokeLinecap="round" />
+      <path d="M0.5 12.25L3.5 15.25L6.5 12.25" stroke={themeColor} strokeLinecap="round" />
+      <path d="M12.5 1.5L12.5 15.5" stroke={themeColor} strokeLinecap="round" />
+      <path d="M9.5 4.5L12.5 1.5L15.5 4.5" stroke={themeColor} strokeLinecap="round" />
+    </svg>
+  );
+}

--- a/apps/web/design-system/icons/switch.tsx
+++ b/apps/web/design-system/icons/switch.tsx
@@ -11,10 +11,10 @@ export function Switch({ color }: Props) {
 
   return (
     <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <path d="M3.5 0.5L3.5 14.5" stroke={themeColor} strokeLinecap="round" />
-      <path d="M0.5 12.25L3.5 15.25L6.5 12.25" stroke={themeColor} strokeLinecap="round" />
-      <path d="M12.5 1.5L12.5 15.5" stroke={themeColor} strokeLinecap="round" />
-      <path d="M9.5 4.5L12.5 1.5L15.5 4.5" stroke={themeColor} strokeLinecap="round" />
+      <path d="M1.5 3.5L15.5 3.5" stroke={themeColor} strokeLinecap="round" />
+      <path d="M12.5 0.5L15.5 3.5L12.5 6.5" stroke={themeColor} strokeLinecap="round" />
+      <path d="M0.5 12.5L14.5 12.5" stroke={themeColor} strokeLinecap="round" />
+      <path d="M3.5 9.5L0.5 12.5L3.5 15.5" stroke={themeColor} strokeLinecap="round" />
     </svg>
   );
 }

--- a/apps/web/partials/entity-page/entity-page-context-menu.tsx
+++ b/apps/web/partials/entity-page/entity-page-context-menu.tsx
@@ -198,7 +198,7 @@ export function EntityPageContextMenu({ entityId, entityName, spaceId }: Props) 
                     <div className="shrink-0">
                       <AddTo color="grey-04" />
                     </div>
-                    Turn into new space
+                    Turn into space
                   </button>
                 }
               />

--- a/apps/web/partials/entity-page/entity-page-context-menu.tsx
+++ b/apps/web/partials/entity-page/entity-page-context-menu.tsx
@@ -17,6 +17,7 @@ import { AddTo } from '~/design-system/icons/add-to';
 import { Context } from '~/design-system/icons/context';
 import { Copy } from '~/design-system/icons/copy';
 import { MoveSpace } from '~/design-system/icons/move-space';
+import { Switch } from '~/design-system/icons/switch';
 import { Trash } from '~/design-system/icons/trash';
 import { Menu } from '~/design-system/menu';
 import { Tooltip } from '~/design-system/tooltip';
@@ -196,7 +197,7 @@ export function EntityPageContextMenu({ entityId, entityName, spaceId }: Props) 
                     className="flex h-full w-full items-center gap-2 px-2 py-2"
                   >
                     <div className="shrink-0">
-                      <AddTo color="grey-04" />
+                      <Switch color="grey-04" />
                     </div>
                     Turn into space
                   </button>

--- a/apps/web/partials/entity-page/entity-page-context-menu.tsx
+++ b/apps/web/partials/entity-page/entity-page-context-menu.tsx
@@ -12,7 +12,6 @@ import { EntityId } from '~/core/io/substream-schema';
 import { useEditable } from '~/core/state/editable-store';
 import { useMutate } from '~/core/sync/use-mutate';
 import { getRelations, getValues, useRelations, useValues } from '~/core/sync/use-store';
-import { useSyncEngine } from '~/core/sync/use-sync-engine';
 
 import { AddTo } from '~/design-system/icons/add-to';
 import { Context } from '~/design-system/icons/context';
@@ -20,6 +19,7 @@ import { Copy } from '~/design-system/icons/copy';
 import { MoveSpace } from '~/design-system/icons/move-space';
 import { Trash } from '~/design-system/icons/trash';
 import { Menu } from '~/design-system/menu';
+import { Tooltip } from '~/design-system/tooltip';
 
 import { CreateNewVersionInSpace } from '~/partials/versions/create-new-version-in-space';
 import { MoveEntityToSpace } from '~/partials/versions/move-entity-to-space';
@@ -35,7 +35,6 @@ type Props = {
 export function EntityPageContextMenu({ entityId, entityName, spaceId }: Props) {
   const [isMenuOpen, setIsMenuOpen] = React.useState(false);
   const { storage } = useMutate();
-  const { store } = useSyncEngine();
   const { isMember, isEditor } = useAccessControl(spaceId);
 
   const { editable, setEditable } = useEditable();
@@ -90,7 +89,7 @@ export function EntityPageContextMenu({ entityId, entityName, spaceId }: Props) 
 
     storage.values.deleteMany(allValuesToDelete);
     storage.relations.deleteMany(allRelationsToDelete);
-  }, [entityId, outgoingRelations, store, storage.relations, storage.values, values]);
+  }, [entityId, outgoingRelations, storage.relations, storage.values, values]);
 
   const onCopyEntityId = async () => {
     try {
@@ -113,12 +112,7 @@ export function EntityPageContextMenu({ entityId, entityName, spaceId }: Props) 
 
   const [isCreatingNewVersion, setIsCreatingNewVersion] = useState<boolean>(false);
   const [isMovingEntity, setIsMovingEntity] = useState<boolean>(false);
-  const [convertToSpaceOpen, setConvertToSpaceOpen] = useState(false);
   const [duplicateToSpaceOpen, setDuplicateToSpaceOpen] = useState(false);
-
-  // Check if entity exists in multiple spaces
-  const entity = store.getEntity(entityId);
-  const isMultiSpaceEntity = (entity?.spaces?.length ?? 0) > 1;
 
   const isSubMenu = isCreatingNewVersion || isMovingEntity;
 
@@ -172,7 +166,7 @@ export function EntityPageContextMenu({ entityId, entityName, spaceId }: Props) 
                 <div className="shrink-0">
                   <AddTo color="grey-04" />
                 </div>
-                Create in existing space
+                Copy to...
               </button>
             </EntityPageContextMenuItem>
             {(isMember || isEditor) && editable && (
@@ -184,40 +178,31 @@ export function EntityPageContextMenu({ entityId, entityName, spaceId }: Props) 
                   <div className="shrink-0">
                     <MoveSpace color="red-01" />
                   </div>
-                  Move to existing space
+                  Move to...
                 </button>
               </EntityPageContextMenuItem>
             )}
             <EntityPageContextMenuItem>
-              <button
-                onClick={() => {
-                  setIsMenuOpen(false);
-                  setDuplicateToSpaceOpen(true);
-                }}
-                className="flex h-full w-full items-center gap-2 px-2 py-2"
-              >
-                <div className="shrink-0">
-                  <AddTo color="grey-04" />
-                </div>
-                Clone to new space
-              </button>
+              <Tooltip
+                position="left"
+                variant="light"
+                label="Use current entity as new space home page"
+                trigger={
+                  <button
+                    onClick={() => {
+                      setIsMenuOpen(false);
+                      setDuplicateToSpaceOpen(true);
+                    }}
+                    className="flex h-full w-full items-center gap-2 px-2 py-2"
+                  >
+                    <div className="shrink-0">
+                      <AddTo color="grey-04" />
+                    </div>
+                    Turn into new space
+                  </button>
+                }
+              />
             </EntityPageContextMenuItem>
-            {(isMember || isEditor) && editable && !isMultiSpaceEntity && (
-              <EntityPageContextMenuItem>
-                <button
-                  onClick={() => {
-                    setIsMenuOpen(false);
-                    setConvertToSpaceOpen(true);
-                  }}
-                  className="flex h-full w-full items-center gap-2 px-2 py-2 text-red-01"
-                >
-                  <div className="shrink-0">
-                    <MoveSpace color="red-01" />
-                  </div>
-                  Convert to new space
-                </button>
-              </EntityPageContextMenuItem>
-            )}
             {(isMember || isEditor) && editable && (
               <EntityPageContextMenuItem>
                 <button className="flex h-full w-full items-center gap-2 px-2 py-2 text-red-01" onClick={onDelete}>
@@ -233,15 +218,6 @@ export function EntityPageContextMenu({ entityId, entityName, spaceId }: Props) 
         entityId={entityId}
         entityName={entityName}
         sourceSpaceId={spaceId}
-        mode="convert"
-        open={convertToSpaceOpen}
-        onOpenChange={setConvertToSpaceOpen}
-      />
-      <EntityToSpaceDialog
-        entityId={entityId}
-        entityName={entityName}
-        sourceSpaceId={spaceId}
-        mode="duplicate"
         open={duplicateToSpaceOpen}
         onOpenChange={setDuplicateToSpaceOpen}
       />

--- a/apps/web/partials/entity-page/entity-page-context-menu.tsx
+++ b/apps/web/partials/entity-page/entity-page-context-menu.tsx
@@ -160,27 +160,41 @@ export function EntityPageContextMenu({ entityId, entityName, spaceId }: Props) 
               </button>
             </EntityPageContextMenuItem>
             <EntityPageContextMenuItem>
-              <button
-                onClick={() => setIsCreatingNewVersion(true)}
-                className="flex h-full w-full items-center gap-2 px-2 py-2"
-              >
-                <div className="shrink-0">
-                  <AddTo color="grey-04" />
-                </div>
-                Copy to...
-              </button>
+              <Tooltip
+                position="left"
+                variant="light"
+                label="Copy entity to an existing space as a multi space entity"
+                trigger={
+                  <button
+                    onClick={() => setIsCreatingNewVersion(true)}
+                    className="flex h-full w-full items-center gap-2 px-2 py-2"
+                  >
+                    <div className="shrink-0">
+                      <AddTo color="grey-04" />
+                    </div>
+                    Copy to...
+                  </button>
+                }
+              />
             </EntityPageContextMenuItem>
             {(isMember || isEditor) && editable && (
               <EntityPageContextMenuItem>
-                <button
-                  onClick={() => setIsMovingEntity(true)}
-                  className="flex h-full w-full items-center gap-2 px-2 py-2 text-red-01"
-                >
-                  <div className="shrink-0">
-                    <MoveSpace color="red-01" />
-                  </div>
-                  Move to...
-                </button>
+                <Tooltip
+                  position="left"
+                  variant="light"
+                  label="Move entity to an existing space and delete entity in current space"
+                  trigger={
+                    <button
+                      onClick={() => setIsMovingEntity(true)}
+                      className="flex h-full w-full items-center gap-2 px-2 py-2 text-red-01"
+                    >
+                      <div className="shrink-0">
+                        <MoveSpace color="red-01" />
+                      </div>
+                      Move to...
+                    </button>
+                  }
+                />
               </EntityPageContextMenuItem>
             )}
             <EntityPageContextMenuItem>

--- a/apps/web/partials/entity-page/entity-page-context-menu.tsx
+++ b/apps/web/partials/entity-page/entity-page-context-menu.tsx
@@ -187,7 +187,7 @@ export function EntityPageContextMenu({ entityId, entityName, spaceId }: Props) 
               <Tooltip
                 position="left"
                 variant="light"
-                label="Use current entity as new space home page"
+                label="Use current entity as the home page for a newly created space"
                 trigger={
                   <button
                     onClick={() => {

--- a/apps/web/partials/entity-page/entity-page-context-menu.tsx
+++ b/apps/web/partials/entity-page/entity-page-context-menu.tsx
@@ -220,8 +220,8 @@ export function EntityPageContextMenu({ entityId, entityName, spaceId }: Props) 
             </EntityPageContextMenuItem>
             {(isMember || isEditor) && editable && (
               <EntityPageContextMenuItem>
-                <button className="flex h-full w-full items-center gap-2 px-2 py-2 text-red-01" onClick={onDelete}>
-                  <Trash />
+                <button className="flex h-full w-full items-center gap-2 px-2 py-2" onClick={onDelete}>
+                  <Trash color="grey-04" />
                   Delete entity
                 </button>
               </EntityPageContextMenuItem>

--- a/apps/web/partials/entity-page/entity-page-context-menu.tsx
+++ b/apps/web/partials/entity-page/entity-page-context-menu.tsx
@@ -186,10 +186,10 @@ export function EntityPageContextMenu({ entityId, entityName, spaceId }: Props) 
                   trigger={
                     <button
                       onClick={() => setIsMovingEntity(true)}
-                      className="flex h-full w-full items-center gap-2 px-2 py-2 text-red-01"
+                      className="flex h-full w-full items-center gap-2 px-2 py-2"
                     >
                       <div className="shrink-0">
-                        <MoveSpace color="red-01" />
+                        <MoveSpace color="grey-04" />
                       </div>
                       Move to...
                     </button>

--- a/apps/web/partials/entity-page/entity-to-space-dialog.tsx
+++ b/apps/web/partials/entity-page/entity-to-space-dialog.tsx
@@ -73,7 +73,7 @@ export function EntityToSpaceDialog({
 
   const address = smartAccount?.account.address;
 
-  const title = 'Copy to new space';
+  const title = 'Turn into space';
 
   const resetState = () => {
     setStep('select-type');
@@ -149,7 +149,7 @@ export function EntityToSpaceDialog({
           }}
         >
           <Dialog.Title className="sr-only">{title}</Dialog.Title>
-          <Dialog.Description className="sr-only">Copy this entity into a new space</Dialog.Description>
+          <Dialog.Description className="sr-only">Turn this entity into a new space</Dialog.Description>
           <div className="pointer-events-none fixed inset-0 z-100 flex h-full w-full items-start justify-center bg-grey-04/50">
             <AnimatePresence mode="wait">
               <motion.div
@@ -227,7 +227,7 @@ export function EntityToSpaceDialog({
                             {hasCompleted ? 'Finalizing details...' : 'Creating space...'}
                           </Text>
                           <Text as="p" variant="body" className="mx-auto mt-2 px-4 text-center text-base!">
-                            Duplicating entity into a new space.
+                            Turning entity into a new space.
                           </Text>
                           {!hasCompleted && <Spacer height={32} />}
                         </div>

--- a/apps/web/partials/entity-page/entity-to-space-dialog.tsx
+++ b/apps/web/partials/entity-page/entity-to-space-dialog.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { SystemIds } from '@geoprotocol/geo-sdk/lite';
 import * as Dialog from '@radix-ui/react-dialog';
 
 import * as React from 'react';
@@ -15,7 +14,6 @@ import { useSmartAccount } from '~/core/hooks/use-smart-account';
 import { EntityId } from '~/core/io/substream-schema';
 import { useReportError } from '~/core/state/status-bar-store';
 import { useMutate } from '~/core/sync/use-mutate';
-import { getRelations, getValues } from '~/core/sync/use-store';
 import { SpaceGovernanceType, SpaceType } from '~/core/types';
 import { describeError } from '~/core/utils/error-diagnostics';
 import { NavUtils } from '~/core/utils/utils';
@@ -29,15 +27,12 @@ import { Text } from '~/design-system/text';
 import { Animation } from '~/partials/onboarding/dialog';
 import { cloneEntityIntoSpace } from '~/partials/versions/clone-entity-into-space';
 
-type Mode = 'convert' | 'duplicate';
-
 type Step = 'select-type' | 'creating' | 'completed';
 
 type EntityToSpaceDialogProps = {
   entityId: string;
   entityName: string;
   sourceSpaceId: string;
-  mode: Mode;
   open: boolean;
   onOpenChange: (open: boolean) => void;
 };
@@ -64,7 +59,6 @@ export function EntityToSpaceDialog({
   entityId,
   entityName,
   sourceSpaceId,
-  mode,
   open,
   onOpenChange,
 }: EntityToSpaceDialogProps) {
@@ -79,62 +73,11 @@ export function EntityToSpaceDialog({
 
   const address = smartAccount?.account.address;
 
-  const title = mode === 'convert' ? 'Move to new space' : 'Copy to new space';
+  const title = 'Copy to new space';
 
   const resetState = () => {
     setStep('select-type');
     setNewSpaceId('');
-  };
-
-  const deleteEntityFromSource = () => {
-    const sourceValues = getValues({
-      selector: value => value.entity.id === entityId && value.spaceId === sourceSpaceId,
-    });
-
-    const sourceRelations = getRelations({
-      selector: relation => relation.fromEntity.id === entityId && relation.spaceId === sourceSpaceId,
-    });
-
-    const blocksRelations = sourceRelations.filter(r => r.type.id === SystemIds.BLOCKS);
-    const blockIds = [...new Set(blocksRelations.map(r => r.toEntity.id))];
-
-    const orphanedBlockIds = blockIds.filter(blockId => {
-      const remainingRefs = getRelations({
-        selector: r =>
-          r.toEntity.id === blockId &&
-          !(r.fromEntity.id === entityId && r.type.id === SystemIds.BLOCKS && r.spaceId === sourceSpaceId),
-      });
-      return remainingRefs.length === 0;
-    });
-
-    const allValuesToDelete = [...sourceValues];
-    const relationIds = new Set<string>();
-    const allRelationsToDelete: typeof sourceRelations = [];
-
-    for (const r of [
-      ...sourceRelations,
-      ...getRelations({ selector: r => r.toEntity.id === entityId && r.spaceId === sourceSpaceId }),
-    ]) {
-      if (!relationIds.has(r.id)) {
-        relationIds.add(r.id);
-        allRelationsToDelete.push(r);
-      }
-    }
-
-    for (const blockId of orphanedBlockIds) {
-      allValuesToDelete.push(...getValues({ selector: v => v.entity.id === blockId }));
-      for (const r of getRelations({
-        selector: r => r.fromEntity.id === blockId || r.toEntity.id === blockId,
-      })) {
-        if (!relationIds.has(r.id)) {
-          relationIds.add(r.id);
-          allRelationsToDelete.push(r);
-        }
-      }
-    }
-
-    storage.values.deleteMany(allValuesToDelete);
-    storage.relations.deleteMany(allRelationsToDelete);
   };
 
   const createSpace = async (spaceType: SpaceType) => {
@@ -152,13 +95,7 @@ export function EntityToSpaceDialog({
         throw new Error('Creating space failed');
       }
 
-      // Clone entity content from source space into the new space
       cloneEntityIntoSpace(entityId as EntityId, sourceSpaceId, spaceId, storage);
-
-      // Delete entity from source space if converting
-      if (mode === 'convert') {
-        deleteEntityFromSource();
-      }
 
       setNewSpaceId(spaceId);
       setStep('completed');
@@ -212,9 +149,7 @@ export function EntityToSpaceDialog({
           }}
         >
           <Dialog.Title className="sr-only">{title}</Dialog.Title>
-          <Dialog.Description className="sr-only">
-            {mode === 'convert' ? 'Move this entity into a new space' : 'Copy this entity into a new space'}
-          </Dialog.Description>
+          <Dialog.Description className="sr-only">Copy this entity into a new space</Dialog.Description>
           <div className="pointer-events-none fixed inset-0 z-100 flex h-full w-full items-start justify-center bg-grey-04/50">
             <AnimatePresence mode="wait">
               <motion.div
@@ -292,9 +227,7 @@ export function EntityToSpaceDialog({
                             {hasCompleted ? 'Finalizing details...' : 'Creating space...'}
                           </Text>
                           <Text as="p" variant="body" className="mx-auto mt-2 px-4 text-center text-base!">
-                            {mode === 'convert'
-                              ? 'Converting entity into a new space.'
-                              : 'Duplicating entity into a new space.'}
+                            Duplicating entity into a new space.
                           </Text>
                           {!hasCompleted && <Spacer height={32} />}
                         </div>

--- a/apps/web/partials/versions/create-new-version-in-space.tsx
+++ b/apps/web/partials/versions/create-new-version-in-space.tsx
@@ -70,7 +70,7 @@ export const CreateNewVersionInSpace = ({
             <ArrowLeft />
           </button>
         </div>
-        <div className="flex-4 p-2 text-center text-button text-text">Select space to create in</div>
+        <div className="flex-4 p-2 text-center text-button text-text">Select space to copy to</div>
         <div className="flex-1"></div>
       </div>
       <div className="p-1">

--- a/apps/web/partials/versions/create-new-version-in-space.tsx
+++ b/apps/web/partials/versions/create-new-version-in-space.tsx
@@ -70,7 +70,7 @@ export const CreateNewVersionInSpace = ({
             <ArrowLeft />
           </button>
         </div>
-        <div className="flex-4 p-2 text-center text-button text-text">Select space to copy to</div>
+        <div className="flex-4 whitespace-nowrap p-2 text-center text-button text-text">Select space to copy to</div>
         <div className="flex-1"></div>
       </div>
       <div className="p-1">

--- a/apps/web/partials/versions/create-new-version-in-space.tsx
+++ b/apps/web/partials/versions/create-new-version-in-space.tsx
@@ -10,6 +10,7 @@ import { useSpace } from '~/core/hooks/use-space';
 import { useSpacesWhereMember } from '~/core/hooks/use-spaces-where-member';
 import { EntityId } from '~/core/io/substream-schema';
 import { useMutate } from '~/core/sync/use-mutate';
+import { sortSpaceListByRankNameId } from '~/core/utils/space/browse-space-list-sort';
 import { NavUtils, hasName } from '~/core/utils/utils';
 
 import { GeoImage } from '~/design-system/geo-image';
@@ -43,11 +44,15 @@ export const CreateNewVersionInSpace = ({
   const [query, setQuery] = useState<string>('');
 
   const allSpaces = React.useMemo(() => {
-    const spaces = [...memberSpaces];
-    if (personalSpace && !spaces.some(s => s.id === personalSpace.id)) {
-      spaces.unshift(personalSpace);
-    }
-    return spaces;
+    const others = memberSpaces.filter(s => s.id !== personalSpace?.id);
+    const sortKeyed = others.map(s => ({
+      id: s.id,
+      name: s?.entity?.name ?? '',
+      unnamed: !hasName(s?.entity?.name),
+      space: s,
+    }));
+    const sorted = sortSpaceListByRankNameId(sortKeyed).map(entry => entry.space);
+    return personalSpace ? [personalSpace, ...sorted] : sorted;
   }, [personalSpace, memberSpaces]);
 
   const namedSpaces = allSpaces.filter(space => hasName(space?.entity?.name));

--- a/apps/web/partials/versions/move-entity-to-space.tsx
+++ b/apps/web/partials/versions/move-entity-to-space.tsx
@@ -13,6 +13,7 @@ import { useSpacesWhereMember } from '~/core/hooks/use-spaces-where-member';
 import { EntityId } from '~/core/io/substream-schema';
 import { useMutate } from '~/core/sync/use-mutate';
 import { getRelations, getValues } from '~/core/sync/use-store';
+import { sortSpaceListByRankNameId } from '~/core/utils/space/browse-space-list-sort';
 import { NavUtils, hasName } from '~/core/utils/utils';
 
 import { GeoImage } from '~/design-system/geo-image';
@@ -46,12 +47,15 @@ export const MoveEntityToSpace = ({
   const [query, setQuery] = useState<string>('');
 
   const allSpaces = React.useMemo(() => {
-    const spaces = [...memberSpaces];
-    if (personalSpace && !spaces.some(s => s.id === personalSpace.id)) {
-      spaces.unshift(personalSpace);
-    }
-    // Filter out the source space since we're moving away from it
-    return spaces.filter(s => s.id !== sourceSpaceId);
+    const others = memberSpaces.filter(s => s.id !== personalSpace?.id && s.id !== sourceSpaceId);
+    const sortKeyed = others.map(s => ({
+      id: s.id,
+      name: s?.entity?.name ?? '',
+      unnamed: !hasName(s?.entity?.name),
+      space: s,
+    }));
+    const sorted = sortSpaceListByRankNameId(sortKeyed).map(entry => entry.space);
+    return personalSpace && personalSpace.id !== sourceSpaceId ? [personalSpace, ...sorted] : sorted;
   }, [personalSpace, memberSpaces, sourceSpaceId]);
 
   const namedSpaces = allSpaces.filter(space => hasName(space?.entity?.name));

--- a/apps/web/partials/versions/move-entity-to-space.tsx
+++ b/apps/web/partials/versions/move-entity-to-space.tsx
@@ -126,7 +126,7 @@ export const MoveEntityToSpace = ({
             <ArrowLeft />
           </button>
         </div>
-        <div className="flex-4 p-2 text-center text-button text-text">Select space to move to</div>
+        <div className="flex-4 whitespace-nowrap p-2 text-center text-button text-text">Select space to move to</div>
         <div className="flex-1"></div>
       </div>
       <div className="p-1">


### PR DESCRIPTION
## Summary
- Relabel entity context menu: "Create in existing space" → "Copy to...", "Move to existing space" → "Move to...", "Clone to new space" → "Turn into new space"
- Add tooltip to "Turn into new space": "Use current entity as new space home page"
- Remove the "Convert to new space" action and its dead code paths in `EntityToSpaceDialog` (`mode` prop, `deleteEntityFromSource` helper)
- "Select space to create in" sub-menu header → "Select space to copy to"

## Test plan
- [ ] Open any entity, click the "..." menu — five items in order: Copy ID, Copy to..., Move to..., Turn into new space, Delete entity
- [ ] As an editor on a single-space entity, confirm "Convert to new space" is gone
- [ ] Hover "Turn into new space" → tooltip "Use current entity as new space home page" appears
- [ ] "Copy to..." sub-menu shows header "Select space to copy to"; copying into another space still works
- [ ] "Turn into new space" still opens the new-space dialog and the duplicate-into-new-space flow completes