### PR TITLE
[codex] Prefer ranking avatars over covers

### DIFF
--- a/apps/web/core/blocks/ranking/use-ranking-entry-entities.ts
+++ b/apps/web/core/blocks/ranking/use-ranking-entry-entities.ts
@@ -37,7 +37,7 @@ export function useRankingEntryEntities(spaceId: string, entityIds: string[]) {
             entityId: id,
             name: entity.name?.trim() || 'Untitled',
             description: entity.description?.trim() || null,
-            image: Entities.cover(entity.relations) ?? Entities.avatar(entity.relations) ?? null,
+            image: Entities.avatar(entity.relations) ?? Entities.cover(entity.relations) ?? null,
           };
         })
         .filter((e): e is RankingEntryDisplay => e != null),

--- a/apps/web/partials/blocks/table/ranking-entry-row.tsx
+++ b/apps/web/partials/blocks/table/ranking-entry-row.tsx
@@ -45,7 +45,7 @@ export function RankingEntryRow({
   const directIpfs =
     imageHint && typeof imageHint === 'string' && imageHint.startsWith('ipfs://') ? imageHint : undefined;
   const lookedUpFromHint = useImageUrlFromEntity(imageHint && !directIpfs ? imageHint : undefined, spaceId);
-  const imageUrl = imageUrlOverride ?? directIpfs ?? lookedUpFromHint ?? coverUrl ?? avatarUrl;
+  const imageUrl = imageUrlOverride ?? directIpfs ?? lookedUpFromHint ?? avatarUrl ?? coverUrl;
   const avatarImageValue = imageUrl ?? PLACEHOLDER_SPACE_IMAGE;
   const href = NavUtils.toEntity(spaceId, entry.entityId);
   const showRank = rank != null && rank > 0;


### PR DESCRIPTION
## Summary

- Prefer avatar images over cover images when building hydrated ranking entry display data.
- Prefer avatar media before cover media in the ranking row fallback chain.

## Why

Ranking rows are avatar-sized list items, so avatar imagery is a better default than wide cover imagery when both are available.

## Validation

- Attempted `bun run lint` in `apps/web`, but the fresh worktree does not have dependencies linked/installed, so it failed with `eslint: command not found`.
