### PR TITLE
[codex] Improve ranking image quality

### DIFF
--- a/apps/web/partials/blocks/table/ranking-entry-row.tsx
+++ b/apps/web/partials/blocks/table/ranking-entry-row.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import cx from 'classnames';
-import NextImage from 'next/image';
 
 import { RANKING_POINTS_UI_ENABLED } from '~/core/blocks/ranking/ranking-points';
 import type { RankingEntryDisplay } from '~/core/blocks/ranking/use-ranking-entry-entities';
@@ -9,10 +8,8 @@ import { PLACEHOLDER_SPACE_IMAGE } from '~/core/constants';
 import { useEntityMedia, useImageUrlFromEntity } from '~/core/utils/use-entity-media';
 import { NavUtils } from '~/core/utils/utils';
 
-import { GeoImage } from '~/design-system/geo-image';
+import { ThumbGeoImage } from '~/design-system/geo-image';
 import { PrefetchLink as Link } from '~/design-system/prefetch-link';
-
-const ROW_AVATAR_SIZE_PX = 64;
 
 const ROW_NAME_CLASS = 'block truncate tracking-[-0.17px] text-text text-[19px] font-medium leading-[1.3]';
 const ROW_DESCRIPTION_CLASS = 'break-words text-[16px] leading-[24px] text-grey-04';
@@ -61,24 +58,7 @@ export function RankingEntryRow({
           {rank}
         </span>
       ) : null}
-      {imageUrl ? (
-        <GeoImage
-          key={avatarImageValue}
-          value={imageUrl}
-          alt=""
-          fill
-          sizes={`${ROW_AVATAR_SIZE_PX}px`}
-          className="object-cover"
-        />
-      ) : (
-        <NextImage
-          src={PLACEHOLDER_SPACE_IMAGE}
-          alt=""
-          fill
-          sizes={`${ROW_AVATAR_SIZE_PX}px`}
-          className="object-cover"
-        />
-      )}
+      <ThumbGeoImage key={avatarImageValue} value={avatarImageValue} className="object-cover" />
     </div>
   );
 


### PR DESCRIPTION
## Summary

- Render ranking row thumbnails with `ThumbGeoImage` instead of `GeoImage` / `next/image`.
- Keep the existing 64px ranking row layout and image selection behavior unchanged.

## Why

The Next image optimizer was producing visibly soft/downscaled thumbnails in the ranking list. `ThumbGeoImage` uses the existing native image path that the design system already documents for tiny IPFS thumbnails where optimizer output can look soft.

## Tradeoff

This intentionally bypasses Next image optimization for these small ranking thumbnails. That can change browser caching and downloaded bytes for large source images, but it preserves the sharper source image in the 64px slot.

## Validation

- Verified visually in the Vercel preview: ranking thumbnails no longer appear blurry.
- Not run locally: this fresh worktree does not have dependencies linked/installed, so `eslint` is unavailable.
