### PR TITLE
[codex] Remove space homepage image fallback

### DIFF
--- a/apps/web/core/io/decoders/space.test.ts
+++ b/apps/web/core/io/decoders/space.test.ts
@@ -1,18 +1,59 @@
+import { ContentIds, SystemIds } from '@geoprotocol/geo-sdk/lite';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { PLACEHOLDER_SPACE_IMAGE } from '~/core/constants';
 
 import { SpaceDecoder } from './space';
 
 const SPACE_ID = '00000000000000000000000000000001';
 const TOPIC_ID = '00000000000000000000000000000002';
+const IMAGE_ENTITY_ID = '00000000000000000000000000000004';
+
+function toHex(id: string) {
+  return id.replace(/-/g, '');
+}
+
+function makeImageRelation(typeId: string, imageUrl: string) {
+  return {
+    id: '00000000000000000000000000000005',
+    spaceId: SPACE_ID,
+    position: null,
+    verified: null,
+    fromEntity: {
+      id: TOPIC_ID,
+      name: 'From entity',
+    },
+    toEntity: {
+      id: IMAGE_ENTITY_ID,
+      name: 'Image',
+      types: [{ id: toHex(SystemIds.IMAGE_TYPE), name: 'Image' }],
+      valuesList: [
+        {
+          spaceId: SPACE_ID,
+          propertyId: toHex(SystemIds.IMAGE_URL_PROPERTY),
+          text: imageUrl,
+        },
+      ],
+    },
+    toSpaceId: null,
+    type: {
+      id: toHex(typeId),
+      name: null,
+    },
+    entityId: '00000000000000000000000000000006',
+  };
+}
 
 function makeRemoteEntity({
   id,
   name,
   description = null,
+  relationsList = [],
 }: {
   id: string;
   name: string | null;
   description?: string | null;
+  relationsList?: ReturnType<typeof makeImageRelation>[];
 }) {
   return {
     id,
@@ -21,7 +62,7 @@ function makeRemoteEntity({
     types: [],
     spaceIds: [SPACE_ID],
     valuesList: [],
-    relationsList: [],
+    relationsList,
     updatedAt: '1712345678',
   };
 }
@@ -83,5 +124,36 @@ describe('SpaceDecoder', () => {
 
     expect(space?.entity.name).toBe('Page name');
     expect(space?.topicId).toBeNull();
+  });
+
+  it('does not use page media as the space image for page-only payloads', () => {
+    const space = SpaceDecoder.decode(
+      makeRemoteSpace({
+        topicId: null,
+        page: makeRemoteEntity({
+          id: '00000000000000000000000000000003',
+          name: 'Page name',
+          relationsList: [makeImageRelation(ContentIds.AVATAR_PROPERTY, 'ipfs://page-avatar')],
+        }),
+      })
+    );
+
+    expect(space?.entity.name).toBe('Page name');
+    expect(space?.entity.image).toBe(PLACEHOLDER_SPACE_IMAGE);
+  });
+
+  it('uses topic media as the space image when topic data is available', () => {
+    const space = SpaceDecoder.decode(
+      makeRemoteSpace({
+        topic: makeRemoteEntity({
+          id: TOPIC_ID,
+          name: 'Topic name',
+          relationsList: [makeImageRelation(ContentIds.AVATAR_PROPERTY, 'ipfs://topic-avatar')],
+        }),
+      })
+    );
+
+    expect(space?.entity.name).toBe('Topic name');
+    expect(space?.entity.image).toBe('ipfs://topic-avatar');
   });
 });

--- a/apps/web/core/io/dto/spaces.ts
+++ b/apps/web/core/io/dto/spaces.ts
@@ -1,9 +1,10 @@
-import { PLACEHOLDER_SPACE_IMAGE, ROOT_SPACE, ROOT_SPACE_IMAGE } from '~/core/constants';
+import { ROOT_SPACE, ROOT_SPACE_IMAGE } from '~/core/constants';
 import { SpaceGovernanceType } from '~/core/types';
 import { SpaceEntity } from '~/core/types';
 import { Entities } from '~/core/utils/entity';
 
 import { type Address, RemoteEntity, RemoteSpace } from '../schema';
+import { defaultSpaceImage } from '../subgraph/space-image';
 import { EntityDtoLive } from './entities';
 
 export type Space = {
@@ -22,7 +23,9 @@ export type Space = {
 
 export function SpaceDto(space: RemoteSpace): Space {
   const spaceId = space.id;
-  const spaceEntity = SpaceEntityDto(spaceId, space.topic ?? space.page);
+  const spaceEntity = SpaceEntityDto(spaceId, space.topic ?? space.page, {
+    useEntityImage: Boolean(space.topic),
+  });
 
   return {
     id: spaceId,
@@ -37,7 +40,11 @@ export function SpaceDto(space: RemoteSpace): Space {
   };
 }
 
-export function SpaceEntityDto(spaceId: string, remoteEntity: RemoteEntity | null): SpaceEntity {
+export function SpaceEntityDto(
+  spaceId: string,
+  remoteEntity: RemoteEntity | null,
+  options: { useEntityImage?: boolean } = {}
+): SpaceEntity {
   const maybeEntity = remoteEntity ? EntityDtoLive(remoteEntity) : null;
 
   let entity = null;
@@ -51,12 +58,13 @@ export function SpaceEntityDto(spaceId: string, remoteEntity: RemoteEntity | nul
     };
   }
 
+  const useEntityImage = options.useEntityImage ?? true;
   const resolvedImage =
     spaceId === ROOT_SPACE
       ? ROOT_SPACE_IMAGE
-      : entity
-        ? (Entities.avatar(entity.relations) ?? Entities.cover(entity.relations) ?? PLACEHOLDER_SPACE_IMAGE)
-        : PLACEHOLDER_SPACE_IMAGE;
+      : entity && useEntityImage
+        ? (Entities.avatar(entity.relations) ?? Entities.cover(entity.relations) ?? defaultSpaceImage(spaceId))
+        : defaultSpaceImage(spaceId);
 
   const spaceConfigWithImage: SpaceEntity = entity
     ? {

--- a/apps/web/core/io/queries.test.ts
+++ b/apps/web/core/io/queries.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
+import { PLACEHOLDER_SPACE_IMAGE } from '~/core/constants';
+
 import { buildSearchPath, groupRestResults, hasDefaultSearchExcludedType } from './queries';
 
 describe('buildSearchPath', () => {
@@ -101,7 +103,7 @@ describe('groupRestResults', () => {
             id: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
             name: 'Alpha',
             description: null,
-            image: 'ipfs://alpha',
+            image: PLACEHOLDER_SPACE_IMAGE,
             relations: [],
             spaceId: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
             spaces: ['aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'],
@@ -112,7 +114,7 @@ describe('groupRestResults', () => {
             id: 'cccccccccccccccccccccccccccccccc',
             name: null,
             description: null,
-            image: '',
+            image: PLACEHOLDER_SPACE_IMAGE,
             relations: [],
             spaceId: 'cccccccccccccccccccccccccccccccc',
             spaces: ['cccccccccccccccccccccccccccccccc'],

--- a/apps/web/core/io/queries.ts
+++ b/apps/web/core/io/queries.ts
@@ -28,6 +28,7 @@ import { PropertyDecoder } from './decoders/property';
 import { RelationDecoder } from './decoders/relation';
 import { ResultDecoder } from './decoders/result';
 import { SpaceDecoder } from './decoders/space';
+import { defaultSpaceImage } from './subgraph/space-image';
 import { Space } from './dto/spaces';
 import { entitiesOrderedByPropertyConnectionDocument } from './entities-ordered-by-property-connection-document';
 import { graphql } from './graphql-client';
@@ -747,7 +748,7 @@ export function groupRestResults(results: RestSearchResult[]): SearchResult[] {
           id: spaceId,
           name: r.space.name ?? null,
           description: null,
-          image: r.space.avatar ?? '',
+          image: defaultSpaceImage(spaceId),
           relations: [],
           spaceId,
           spaces: [spaceId],
@@ -789,7 +790,7 @@ export function groupRestResults(results: RestSearchResult[]): SearchResult[] {
             id: spaceId,
             name: r.space.name ?? null,
             description: null,
-            image: r.space.avatar ?? '',
+            image: defaultSpaceImage(spaceId),
             relations: [],
             spaceId,
             spaces: [spaceId],

--- a/apps/web/core/io/subgraph/fetch-active-subspaces.ts
+++ b/apps/web/core/io/subgraph/fetch-active-subspaces.ts
@@ -8,8 +8,8 @@ import {
   AVATAR_PROPERTY_ID,
   COVER_PROPERTY_ID,
   IMAGE_URL_PROPERTY_ID,
+  defaultSpaceImage,
   type SpaceImageRelationNode,
-  resolveSpaceImage,
 } from './space-image';
 
 interface SubspaceNode {
@@ -158,7 +158,7 @@ export async function fetchActiveSubspaces(spaceId: string): Promise<ActiveSubsp
         id: subspace.childSpaceId,
         name: page?.name ?? 'Untitled',
         description: page?.description ?? null,
-        image: resolveSpaceImage(page?.relationsList ?? [], subspace.childSpaceId),
+        image: defaultSpaceImage(subspace.childSpaceId),
         relationType,
       };
     })

--- a/apps/web/core/io/subgraph/fetch-recently-claimed-spaces.ts
+++ b/apps/web/core/io/subgraph/fetch-recently-claimed-spaces.ts
@@ -10,8 +10,8 @@ import {
   AVATAR_PROPERTY_ID,
   COVER_PROPERTY_ID,
   IMAGE_URL_PROPERTY_ID,
+  defaultSpaceImage,
   type SpaceImageRelationNode,
-  resolveSpaceImage,
 } from './space-image';
 import { PLACEHOLDER_TOPIC_NAME } from './topic-space-usage';
 
@@ -153,7 +153,7 @@ export async function fetchRecentlyClaimedSpaces(): Promise<RecentlyClaimedSpace
     for (const space of entity.spacesByTopicIdConnection.nodes ?? []) {
       if (rowsBySpaceId.has(space.id)) continue;
       const spaceName = space.page?.name?.trim() ? space.page.name : name;
-      const spaceImage = resolveSpaceImage(space.page?.relationsList ?? [], space.id);
+      const spaceImage = defaultSpaceImage(space.id);
       rowsBySpaceId.set(space.id, {
         space: {
           spaceId: space.id,

--- a/apps/web/core/io/subgraph/space-image.ts
+++ b/apps/web/core/io/subgraph/space-image.ts
@@ -20,6 +20,10 @@ export const AVATAR_PROPERTY_ID = toHex(ContentIds.AVATAR_PROPERTY);
 export const COVER_PROPERTY_ID = toHex(SystemIds.COVER_PROPERTY);
 export const IMAGE_URL_PROPERTY_ID = toHex(SystemIds.IMAGE_URL_PROPERTY);
 
+export function defaultSpaceImage(spaceId?: string): string {
+  return spaceId === ROOT_SPACE ? ROOT_SPACE_IMAGE : PLACEHOLDER_SPACE_IMAGE;
+}
+
 export function resolveSpaceImage(relations: SpaceImageRelationNode[], spaceId?: string): string {
   if (spaceId === ROOT_SPACE) return ROOT_SPACE_IMAGE;
 
@@ -33,5 +37,5 @@ export function resolveSpaceImage(relations: SpaceImageRelationNode[], spaceId?:
 
   if (coverUrl) return coverUrl;
 
-  return PLACEHOLDER_SPACE_IMAGE;
+  return defaultSpaceImage(spaceId);
 }

--- a/apps/web/core/io/subgraph/topic-space-usage.ts
+++ b/apps/web/core/io/subgraph/topic-space-usage.ts
@@ -1,6 +1,6 @@
 import { PLACEHOLDER_SPACE_IMAGE } from '~/core/constants';
 
-import { type SpaceImageRelationNode, resolveSpaceImage } from './space-image';
+import { defaultSpaceImage, type SpaceImageRelationNode } from './space-image';
 
 export const MAX_TOPIC_USAGE_AVATARS = 3;
 export const PLACEHOLDER_TOPIC_NAME = 'Untitled';
@@ -37,7 +37,7 @@ function toUsageSpace(space: TopicUsageSpaceNode): TopicUsage['spaces'][number] 
   return {
     id: space.id,
     name: space.page?.name ?? PLACEHOLDER_TOPIC_NAME,
-    image: resolveSpaceImage(space.page?.relationsList ?? [], space.id),
+    image: defaultSpaceImage(space.id),
   };
 }
 

--- a/apps/web/partials/active-proposal/subspace-proposal.tsx
+++ b/apps/web/partials/active-proposal/subspace-proposal.tsx
@@ -12,6 +12,7 @@ import {
   AVATAR_PROPERTY_ID,
   COVER_PROPERTY_ID,
   IMAGE_URL_PROPERTY_ID,
+  defaultSpaceImage,
   type SpaceImageRelationNode,
   resolveSpaceImage,
 } from '~/core/io/subgraph/space-image';
@@ -216,7 +217,7 @@ async function fetchTopicProposalMetadata(topicId: string): Promise<TopicProposa
     associatedSpaces: result.entity.spacesByTopicId.map(space => ({
       id: space.id,
       name: space.page?.name ?? space.id,
-      image: resolveSpaceImage(space.page?.relationsList ?? [], space.id),
+      image: defaultSpaceImage(space.id),
       editorsCount: space.editorsList.length,
       membersCount: space.membersList.length,
     })),


### PR DESCRIPTION
## Summary

- Stop using a space page/home entity's avatar or cover as the generic space image fallback.
- Keep topic media as a valid space image when topic data is available.
- Use the default placeholder/root image for page-derived space image slots.
- Add tests covering page-only versus topic-backed space image behavior.

## Why

Some cards were showing a space homepage image instead of the empty placeholder image because page/home media was being promoted into `space.entity.image`. This makes placeholder behavior more predictable when a space does not have an intentional topic image.

## Validation

- `git diff --check`
- Attempted `bun test core/io/decoders/space.test.ts`, but this fresh worktree does not have workspace dependencies linked, so it failed with `Cannot find module '@geoprotocol/geo-sdk/lite'`.
