### PR TITLE
[codex] Fix ranking thumbnail crop

### DIFF
--- a/apps/web/design-system/geo-image.tsx
+++ b/apps/web/design-system/geo-image.tsx
@@ -58,6 +58,7 @@ type ThumbGeoImageProps = {
   loading?: ImgHTMLAttributes<HTMLImageElement>['loading'];
   fetchPriority?: ImgHTMLAttributes<HTMLImageElement>['fetchPriority'];
   className?: string;
+  style?: ImgHTMLAttributes<HTMLImageElement>['style'];
   onLoad?: ImgHTMLAttributes<HTMLImageElement>['onLoad'];
 };
 
@@ -71,13 +72,15 @@ export function ThumbGeoImage({
   loading = 'lazy',
   fetchPriority,
   className,
+  style,
   onLoad,
 }: ThumbGeoImageProps) {
   return (
     <NativeGeoImage
       value={value}
       alt={alt}
-      className={cn('absolute inset-0 h-full w-full object-cover', className)}
+      className={cn('absolute inset-0', className)}
+      style={{ display: 'block', width: '100%', height: '100%', objectFit: 'cover', ...style }}
       loading={loading}
       fetchPriority={fetchPriority}
       decoding="async"


### PR DESCRIPTION
## Summary

- Force native thumbnail images to fill their parent box with explicit inline sizing.
- Keep `object-fit: cover` on the thumbnail so ranking row images crop like proper square thumbnails instead of rendering as a thin intrinsic-height strip.

## Why

Ranking rows use `ThumbGeoImage` to bypass the Next image optimizer for small IPFS thumbnails. In the latest UI, those native images could render at their intrinsic aspect-ratio height inside the 64px tile, leaving most of the tile gray.

## Validation

- `git diff --check`
- App lint/tests were not run because this fresh worktree does not have `node_modules` installed.
