### PR TITLE
[codex] Fix ranked by count badge centering

### DIFF
--- a/apps/web/partials/blocks/table/ranking-period-metadata.tsx
+++ b/apps/web/partials/blocks/table/ranking-period-metadata.tsx
@@ -65,9 +65,9 @@ function RankingRankedByAvatarGroup({
       {extraCount > 0 ? (
         <li
           key="extra-count"
-          className="relative box-content flex h-5 shrink-0 list-none items-center justify-center rounded-full border-2 border-white bg-grey-02 px-1.5 text-[11px] leading-none text-grey-04 tabular-nums"
+          className="relative box-content flex h-5 shrink-0 list-none items-center justify-center rounded-full border-2 border-white bg-grey-02 px-1.5 text-[11px] text-grey-04 tabular-nums"
         >
-          +{extraCount}
+          <span className="block h-5 leading-[20px]">+{extraCount}</span>
         </li>
       ) : null}
     </AvatarGroup>


### PR DESCRIPTION
## Summary

- Center the ranked-by `+N` count text inside its avatar-group badge.
- Keep the existing badge dimensions and spacing intact.

## Why

In the embedded ranking block, the count text could appear vertically off-center inside the grey `+N` pill because it inherited the surrounding metadata row's typography.

## Validation

- `git diff --check`
- App lint/tests were not run because this fresh worktree does not have `node_modules` installed.
