### PR TITLE
[codex] Fix add ranking CTA on shared ranking links

### DIFF
--- a/apps/web/atoms/ranking-compose-return.ts
+++ b/apps/web/atoms/ranking-compose-return.ts
@@ -1,0 +1,9 @@
+import { atomWithStorage, createJSONStorage } from 'jotai/utils';
+
+const sessionStorageJSON = createJSONStorage<string | null>(() => sessionStorage);
+
+export const rankingComposeReturnHrefAtom = atomWithStorage<string | null>(
+  'rankingComposeReturnHref',
+  null,
+  sessionStorageJSON
+);

--- a/apps/web/core/hooks/use-ranking-compose-access.ts
+++ b/apps/web/core/hooks/use-ranking-compose-access.ts
@@ -2,10 +2,11 @@
 
 import { useGeoLogin } from '@geogenesis/auth';
 
-import { useCallback } from 'react';
+import { useCallback, useRef } from 'react';
 
 import { Either } from 'effect';
 import { useSetAtom } from 'jotai';
+import { useRouter } from 'next/navigation';
 
 import { getSpaceAccessById, normalizeSpaceId } from '~/core/access/space-access';
 import { trackPrivyAuth } from '~/core/analytics';
@@ -31,6 +32,7 @@ export type RankingComposeAccessStatus =
 const autoRequestedMemberships = new Set<string>();
 
 export function useRankingComposeAccess(spaceId: string) {
+  const router = useRouter();
   const { smartAccount, isLoading: isLoadingSmartAccount } = useSmartAccount();
   const { personalSpaceId, isRegistered, isLoading: isLoadingPersonalSpace, isFetched } = usePersonalSpaceId();
   const { space, isLoading: isLoadingSpace } = useSpace(spaceId);
@@ -41,9 +43,18 @@ export function useRankingComposeAccess(spaceId: string) {
   const setAvatar = useSetAtom(avatarAtom);
   const setSpaceId = useSetAtom(spaceIdAtom);
   const setStep = useSetAtom(stepAtom);
+  const postLoginRedirectRef = useRef<string | null>(null);
 
   const { login } = useGeoLogin({
-    onComplete: args => trackPrivyAuth(args, { auth_flow: 'manual_login' }),
+    onComplete: args => {
+      trackPrivyAuth(args, { auth_flow: 'manual_login' });
+
+      const postLoginRedirect = postLoginRedirectRef.current;
+      postLoginRedirectRef.current = null;
+      if (postLoginRedirect) {
+        router.push(postLoginRedirect);
+      }
+    },
   });
 
   const isLoading = isLoadingPersonalSpace || isLoadingSpace || isLoadingAccess;
@@ -58,7 +69,8 @@ export function useRankingComposeAccess(spaceId: string) {
     return 'ready';
   })();
 
-  const promptLogin = useCallback(() => {
+  const promptLogin = useCallback((postLoginRedirect?: string) => {
+    postLoginRedirectRef.current = postLoginRedirect ?? null;
     setName('');
     setTopicId('');
     setAvatar('');

--- a/apps/web/core/hooks/use-ranking-compose-access.ts
+++ b/apps/web/core/hooks/use-ranking-compose-access.ts
@@ -52,6 +52,8 @@ export function useRankingComposeAccess(spaceId: string) {
       const postLoginRedirect = postLoginRedirectRef.current;
       postLoginRedirectRef.current = null;
       if (postLoginRedirect) {
+        // Logged-out compose entry goes straight to compose after auth. If the
+        // account is new, the compose screen records this URL for onboarding.
         router.push(postLoginRedirect);
       }
     },

--- a/apps/web/partials/blocks/table/ranking-block-body.tsx
+++ b/apps/web/partials/blocks/table/ranking-block-body.tsx
@@ -172,6 +172,8 @@ export function RankingBlockBody({ state, presentation = 'embedded' }: Props) {
   // On mobile fullscreen the action buttons move below the My ranking tab.
   const isFullscreenMobile = presentation === 'fullscreen' && isMobile;
   const movesEditBelowTabs = isFullscreenMobile && showMyRankingSection && !isSharedRankingView;
+  const movesSharedAddBelowTabs = isFullscreenMobile && isSharedRankingView && showAddMyRankingInGlobalHeader;
+  const movesActionBelowTabs = movesEditBelowTabs || movesSharedAddBelowTabs;
   const showMyTabActionsBelowTabs =
     presentation === 'fullscreen' && activeTab === 'my' && showMyRankingSection && Boolean(myRankingTabActions);
 
@@ -377,7 +379,7 @@ export function RankingBlockBody({ state, presentation = 'embedded' }: Props) {
                       ) : null}
                     </div>
 
-                    {!movesEditBelowTabs && !showMyTabActionsBelowTabs ? (
+                    {!movesActionBelowTabs && !showMyTabActionsBelowTabs ? (
                       <div className="mb-2 flex shrink-0 items-center">{myRankingActionButton}</div>
                     ) : null}
                   </div>
@@ -387,6 +389,8 @@ export function RankingBlockBody({ state, presentation = 'embedded' }: Props) {
 
                 {showMyTabActionsBelowTabs ? (
                   <div className="mb-4 flex w-full shrink-0">{myRankingTabActions}</div>
+                ) : movesSharedAddBelowTabs ? (
+                  <div className="mb-4 flex shrink-0 justify-start">{myRankingActionButton}</div>
                 ) : movesEditBelowTabs && activeTab === 'my' ? (
                   <div className="mb-4 flex shrink-0 justify-end">{buildMobileFullscreenEditButton(state)}</div>
                 ) : null}

--- a/apps/web/partials/blocks/table/ranking-block-body.tsx
+++ b/apps/web/partials/blocks/table/ranking-block-body.tsx
@@ -49,8 +49,7 @@ function buildMobileFullscreenEditButton(state: RankingBlockState) {
 }
 
 function buildMyRankingActionButton(state: RankingBlockState) {
-  const { showEditRankingButton, isSaving, isSharedRankingView, openRankingCompose } = state;
-  if (isSharedRankingView) return null;
+  const { showEditRankingButton, isSaving, openRankingCompose } = state;
 
   return showEditRankingButton ? (
     <Button
@@ -172,7 +171,7 @@ export function RankingBlockBody({ state, presentation = 'embedded' }: Props) {
 
   // On mobile fullscreen the action buttons move below the My ranking tab.
   const isFullscreenMobile = presentation === 'fullscreen' && isMobile;
-  const movesEditBelowTabs = isFullscreenMobile && showMyRankingSection;
+  const movesEditBelowTabs = isFullscreenMobile && showMyRankingSection && !isSharedRankingView;
   const showMyTabActionsBelowTabs =
     presentation === 'fullscreen' && activeTab === 'my' && showMyRankingSection && Boolean(myRankingTabActions);
 

--- a/apps/web/partials/blocks/table/ranking-compose-screen.tsx
+++ b/apps/web/partials/blocks/table/ranking-compose-screen.tsx
@@ -4,7 +4,7 @@ import { SystemIds } from '@geoprotocol/geo-sdk/lite';
 
 import * as React from 'react';
 
-import { useSetAtom } from 'jotai';
+import { useAtom, useSetAtom } from 'jotai';
 import { useRouter, useSearchParams } from 'next/navigation';
 
 import { useDataBlock } from '~/core/blocks/data/use-data-block';
@@ -47,6 +47,7 @@ import { RankingComposeMyRanking } from './ranking-compose-my-ranking';
 import Custom404 from '~/app/not-found';
 import { postOnboardingRedirectAtom } from '~/atoms/post-onboarding-redirect';
 import { rankingComposeCreateEntityAtom } from '~/atoms/ranking-compose-create-entity';
+import { rankingComposeReturnHrefAtom } from '~/atoms/ranking-compose-return';
 
 type Props = {
   spaceId: string;
@@ -60,14 +61,25 @@ export function RankingComposeScreen({ spaceId, rankingStartDate = '', rankingEn
   const searchParams = useSearchParams();
   const parentEntityId = searchParams?.get('parentEntityId') ?? '';
   const relationId = searchParams?.get('relationId') ?? '';
-  const { name, entityId, rows: _rows, filterState } = useDataBlock();
+  const { name, entityId, filterState } = useDataBlock();
   const displayName = name?.trim() || 'Untitled ranking';
   const { showOnboarding } = useOnboarding();
   const { status: accessStatus, ensureAccess } = useRankingComposeAccess(spaceId);
   const { onClick: createEntityWithFilters } = useCreateEntityWithFilters(spaceId);
   const setCreateEntityFlow = useSetAtom(rankingComposeCreateEntityAtom);
   const setPostOnboardingRedirect = useSetAtom(postOnboardingRedirectAtom);
+  const [rankingComposeReturnHref, setRankingComposeReturnHref] = useAtom(rankingComposeReturnHrefAtom);
   const setStep = useSetAtom(stepAtom);
+
+  const handleBack = React.useCallback(() => {
+    if (rankingComposeReturnHref) {
+      setRankingComposeReturnHref(null);
+      router.replace(rankingComposeReturnHref);
+      return;
+    }
+
+    router.back();
+  }, [rankingComposeReturnHref, router, setRankingComposeReturnHref]);
 
   React.useEffect(() => {
     if (accessStatus === 'ready' || accessStatus === 'not-found') return;
@@ -347,6 +359,7 @@ export function RankingComposeScreen({ spaceId, rankingStartDate = '', rankingEn
     });
 
     // After publishing, land on the fullscreen ranking view instead of the parent space page.
+    setRankingComposeReturnHref(null);
     router.replace(
       rankingComposeHref({
         spaceId,
@@ -454,7 +467,7 @@ export function RankingComposeScreen({ spaceId, rankingStartDate = '', rankingEn
             <div className="shrink-0 bg-white px-4 py-2">
               <RankingComposePinnedToolbar
                 isMobile={isMobile}
-                onBack={() => router.back()}
+                onBack={handleBack}
                 showPublishButton
                 canPublish={canPublish}
                 isSaving={isSaving}
@@ -477,7 +490,7 @@ export function RankingComposeScreen({ spaceId, rankingStartDate = '', rankingEn
             <div className="shrink-0 py-2">
               <RankingComposePinnedToolbar
                 isMobile={isMobile}
-                onBack={() => router.back()}
+                onBack={handleBack}
                 showPublishButton={false}
                 canPublish={canPublish}
                 isSaving={isSaving}

--- a/apps/web/partials/blocks/table/use-ranking-block-state.ts
+++ b/apps/web/partials/blocks/table/use-ranking-block-state.ts
@@ -293,7 +293,6 @@ export function useRankingBlockState({
     [embeddedMyTotalPages]
   );
 
-  const hasDisplayedSubmission = Boolean(sharedSubmission || hasMySubmission);
   const hasOwnMyRankingData =
     hasMySubmission || (!hasSharedRankingUrl && !sharedSubmission && myDisplayEntityIds.length > 0);
   const hasMyRankingData =
@@ -635,7 +634,7 @@ export function useRankingBlockState({
     });
   }, [effectiveGlobalOgVersion, entityId, rankingEndDate, rankingStartDate, spaceId]);
 
-  const showEditRankingButton = !isSharedRankingView && (hasMySubmission || myDisplayEntityIds.length > 0);
+  const showEditRankingButton = hasMySubmission || (!isSharedRankingView && myDisplayEntityIds.length > 0);
 
   const showFirstRankingPrompt =
     !isLoadingGlobalEntries &&

--- a/apps/web/partials/blocks/table/use-ranking-block-state.ts
+++ b/apps/web/partials/blocks/table/use-ranking-block-state.ts
@@ -5,7 +5,7 @@ import { SystemIds } from '@geoprotocol/geo-sdk/lite';
 import * as React from 'react';
 
 import { useSetAtom } from 'jotai';
-import { useRouter, useSearchParams } from 'next/navigation';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 
 import { PAGE_SIZE, useDataBlock } from '~/core/blocks/data/use-data-block';
 import { useFilters } from '~/core/blocks/data/use-filters';
@@ -49,6 +49,7 @@ import { useEditorStoreLite } from '~/core/state/editor/use-editor';
 import { stepAtom } from '~/partials/onboarding/dialog';
 
 import { postOnboardingRedirectAtom } from '~/atoms/post-onboarding-redirect';
+import { rankingComposeReturnHrefAtom } from '~/atoms/ranking-compose-return';
 
 export type RankingTab = 'global' | 'my';
 
@@ -75,11 +76,13 @@ export function useRankingBlockState({
 }: UseRankingBlockStateParams) {
   const isMobile = useIsMobileLayout();
   const router = useRouter();
+  const pathname = usePathname();
   const searchParams = useSearchParams();
   const preferMyTab = searchParams?.get('tab') === RANKING_COMPOSE_TAB_MY;
   const { showOnboarding } = useOnboarding();
   const { promptLogin, ensureAccess, status: composeAccessStatus } = useRankingComposeAccess(spaceId);
   const setPostOnboardingRedirect = useSetAtom(postOnboardingRedirectAtom);
+  const setRankingComposeReturnHref = useSetAtom(rankingComposeReturnHrefAtom);
   const setStep = useSetAtom(stepAtom);
 
   const { name, entityId, relationId, rows } = useDataBlock();
@@ -481,6 +484,8 @@ export function useRankingBlockState({
       }
 
       if (mode !== 'view') {
+        setRankingComposeReturnHref(`${pathname}${searchParams?.toString() ? `?${searchParams.toString()}` : ''}`);
+
         if (!smartAccount || composeAccessStatus === 'needs-login' || composeAccessStatus === 'needs-onboarding') {
           setPostOnboardingRedirect(href);
         }
@@ -509,12 +514,15 @@ export function useRankingBlockState({
       showOnboarding,
       entityId,
       parentEntityId,
+      pathname,
       rankingEndDate,
       rankingStartDate,
       resolveBlockRelationId,
       router,
       setPostOnboardingRedirect,
+      setRankingComposeReturnHref,
       setStep,
+      searchParams,
       smartAccount,
       spaceId,
     ]

--- a/apps/web/partials/blocks/table/use-ranking-block-state.ts
+++ b/apps/web/partials/blocks/table/use-ranking-block-state.ts
@@ -484,15 +484,16 @@ export function useRankingBlockState({
       }
 
       if (mode !== 'view') {
-        setRankingComposeReturnHref(`${pathname}${searchParams?.toString() ? `?${searchParams.toString()}` : ''}`);
-
-        if (!smartAccount || composeAccessStatus === 'needs-login' || composeAccessStatus === 'needs-onboarding') {
-          setPostOnboardingRedirect(href);
-        }
+        const queryString = searchParams?.toString() ?? '';
+        setRankingComposeReturnHref(`${pathname}${queryString ? `?${queryString}` : ''}`);
 
         if (!smartAccount) {
           promptLogin(href);
           return;
+        }
+
+        if (composeAccessStatus === 'needs-login' || composeAccessStatus === 'needs-onboarding') {
+          setPostOnboardingRedirect(href);
         }
 
         if (composeAccessStatus === 'needs-onboarding') {

--- a/apps/web/partials/blocks/table/use-ranking-block-state.ts
+++ b/apps/web/partials/blocks/table/use-ranking-block-state.ts
@@ -486,7 +486,7 @@ export function useRankingBlockState({
         }
 
         if (!smartAccount) {
-          promptLogin();
+          promptLogin(href);
           return;
         }
 


### PR DESCRIPTION
## Summary

Fixes the shared ranking view so visitors still see the normal `Add my ranking` entry point when opening someone else's social share link.

## Root Cause

The shared ranking state was being treated as ranking data for the current viewer in the CTA rendering path. On mobile fullscreen, that also moved the action area below the shared author's ranking tab, where shared-ranking actions are intentionally hidden.

## Changes

- Allow the global header action button to render in shared-ranking views.
- Keep edit/share actions hidden for someone else's ranking while preserving the viewer's `Add my ranking` flow.
- Only move fullscreen mobile edit actions below tabs for non-shared views.
- Remove an adjacent unused ranking state variable.

## Validation

- `./node_modules/.bin/eslint apps/web/partials/blocks/table/ranking-block-body.tsx apps/web/partials/blocks/table/use-ranking-block-state.ts`