### PR TITLE
feat(ranking-share): prefill tweet body with ranking name

### DIFF
--- a/apps/web/partials/blocks/table/use-ranking-block-state.ts
+++ b/apps/web/partials/blocks/table/use-ranking-block-state.ts
@@ -592,15 +592,16 @@ export function useRankingBlockState({
   const sharePersonalRanking = React.useCallback(() => {
     if (!personalSharePath || isPreparingPersonalShare) return;
     const shareUrl = buildAbsoluteRankingShareUrl(personalSharePath);
+    const shareText = `I just published my "${displayName}" ranking. Check it out and add your vote 🔮`;
 
     setIsPreparingPersonalShare(true);
     void ensurePersonalRankingOg()
       .catch(() => {})
       .finally(() => {
         setIsPreparingPersonalShare(false);
-        shareRankingOnX(shareUrl);
+        shareRankingOnX(shareUrl, shareText);
       });
-  }, [ensurePersonalRankingOg, isPreparingPersonalShare, personalSharePath]);
+  }, [displayName, ensurePersonalRankingOg, isPreparingPersonalShare, personalSharePath]);
 
   // Generate the personal OG image
   React.useEffect(() => {


### PR DESCRIPTION
## Summary
- Share X button on a user's personal ranking now opens X's tweet intent prefilled with:
  `I just published my "{ranking name}" ranking. Check it out and add your vote 🔮`
- The share URL is still appended by X via the `url` intent param.

## Test plan
- [x] Publish a personal ranking, click **Share X**, confirm the tweet composer shows the prefilled text above the share URL.
- [x] Confirm the ranking name in the tweet matches the block's display name (incl. special chars).
- [x] Confirm shared-view (read-only) and global-ranking copy-link flows are unchanged.