### PR TITLE
[codex] Use placeholder for ranking share fallback images

### DIFF
--- a/apps/web/core/blocks/ranking/ranking-og-image.test.ts
+++ b/apps/web/core/blocks/ranking/ranking-og-image.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+
+import { PINATA_GATEWAY_READ_PATH } from '~/core/constants';
+
+import type { RankingOgEntryData } from './ranking-og-data';
+import { resolveRankingOgEntryImageSrc } from './ranking-og-image';
+
+function entry(partial: Partial<RankingOgEntryData> = {}): RankingOgEntryData {
+  return {
+    entityId: 'entry-1',
+    name: 'Entry One',
+    description: null,
+    image: null,
+    ...partial,
+  };
+}
+
+describe('resolveRankingOgEntryImageSrc', () => {
+  it('uses the placeholder image when an entry has no image', () => {
+    expect(resolveRankingOgEntryImageSrc(entry())).toMatch(/^data:image\/png;base64,/);
+  });
+
+  it('uses the placeholder image when an entry image cannot be rendered by Satori', () => {
+    expect(resolveRankingOgEntryImageSrc(entry({ image: 'https://example.com/image.jpg' }))).toMatch(
+      /^data:image\/png;base64,/
+    );
+  });
+
+  it('keeps renderable IPFS gateway images', () => {
+    expect(resolveRankingOgEntryImageSrc(entry({ image: 'ipfs://bafy-image-cid' }))).toBe(
+      `${PINATA_GATEWAY_READ_PATH}bafy-image-cid`
+    );
+  });
+});

--- a/apps/web/core/blocks/ranking/ranking-og-image.tsx
+++ b/apps/web/core/blocks/ranking/ranking-og-image.tsx
@@ -4,7 +4,7 @@ import { ImageResponse } from 'next/og';
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
-import { LIGHTHOUSE_GATEWAY_READ_PATH, PINATA_GATEWAY_READ_PATH } from '~/core/constants';
+import { LIGHTHOUSE_GATEWAY_READ_PATH, PINATA_GATEWAY_READ_PATH, PLACEHOLDER_SPACE_IMAGE } from '~/core/constants';
 import { getImagePath } from '~/core/utils/utils';
 
 import type { RankingOgCardData, RankingOgEntryData } from './ranking-og-data';
@@ -31,10 +31,11 @@ function scaledBorder(width: number, scale: number, color: string): string {
   return `${Math.max(1, scaled(width, scale))}px solid ${color}`;
 }
 
-function readStaticImageSrc(fileName: string, contentType: string): string | null {
+function readPublicImageSrc(fileName: string, contentType: string): string | null {
+  const normalizedFileName = fileName.replace(/^\/+/, '');
   const candidates = [
-    join(process.cwd(), `public/static/${fileName}`),
-    join(process.cwd(), `apps/web/public/static/${fileName}`),
+    join(process.cwd(), `public/${normalizedFileName}`),
+    join(process.cwd(), `apps/web/public/${normalizedFileName}`),
   ];
   const filePath = candidates.find(candidate => existsSync(candidate));
   if (!filePath) return null;
@@ -53,9 +54,7 @@ function readStaticFontData(fileName: string): ArrayBuffer {
   return data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength) as ArrayBuffer;
 }
 
-const cityThumbnailSrcs = [1, 2, 3, 4, 5]
-  .map(index => readStaticImageSrc(`ranking-og-city-${index}.jpg`, 'image/jpeg'))
-  .filter((src): src is string => Boolean(src));
+const placeholderThumbnailSrc = readPublicImageSrc(PLACEHOLDER_SPACE_IMAGE, 'image/png');
 
 const geistFonts = [
   {
@@ -318,9 +317,8 @@ function BrandMark({ variant, scale }: { variant: RankingOgVariant; scale: numbe
   );
 }
 
-function fallbackThumbnailSrc(entry: RankingOgEntryData): string | null {
-  if (cityThumbnailSrcs.length === 0) return null;
-  return cityThumbnailSrcs[seedHue(entry.entityId || entry.name) % cityThumbnailSrcs.length] ?? cityThumbnailSrcs[0];
+export function resolveRankingOgEntryImageSrc(entry: RankingOgEntryData): string | null {
+  return toRenderableImageSrc(entry.image) ?? placeholderThumbnailSrc;
 }
 
 function OwnerBadge({ data, variant, scale }: { data: RankingOgCardData; variant: RankingOgVariant; scale: number }) {
@@ -484,7 +482,7 @@ function EntryImage({
   variant: RankingOgVariant;
   scale: number;
 }) {
-  const src = toRenderableImageSrc(entry.image) ?? fallbackThumbnailSrc(entry);
+  const src = resolveRankingOgEntryImageSrc(entry);
   const { width, height } = imageDimensions(index, variant, scale);
 
   if (src) {


### PR DESCRIPTION
## Summary

This fixes ranking social share images so ranked entities without a renderable image use the standard Geo placeholder instead of one of the bundled sample city thumbnails.

## Root Cause

The ranking OG renderer treated missing entry images as a seeded fallback into `ranking-og-city-*.jpg`. That made unrelated ranked entities reuse example city imagery, such as the Paris image seen in the attached share preview.

## Changes

- Resolve missing or non-renderable ranking entry images to the embedded `/placeholder.png` asset.
- Keep valid IPFS gateway images unchanged.
- Add focused tests for missing images, blocked external images, and renderable IPFS images.

## Validation

- `env NEXT_PUBLIC_IS_TEST_ENV=true NEXT_PUBLIC_PRIVY_APP_ID=test NEXT_PUBLIC_GEOGENESIS_RPC=http://localhost:8545 NEXT_PUBLIC_GEOGENESIS_RPC_TESTNET=http://localhost:8546 NEXT_PUBLIC_API_ENDPOINT=http://localhost:3000/graphql NEXT_PUBLIC_API_ENDPOINT_TESTNET=http://localhost:3001/graphql NEXT_PUBLIC_BUNDLER_RPC=http://localhost:4337 NEXT_PUBLIC_BUNDLER_RPC_TESTNET=http://localhost:4338 NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID=test NEXT_PUBLIC_PIMLICO_API_KEY=test bun test apps/web/core/blocks/ranking/ranking-og-image.test.ts apps/web/core/blocks/ranking/ranking-og-data.test.ts`
- `bunx eslint apps/web/core/blocks/ranking/ranking-og-image.tsx apps/web/core/blocks/ranking/ranking-og-image.test.ts`