### PR TITLE
[codex] Adjust ranking share image layout

### DIFF
--- a/apps/web/core/blocks/ranking/ranking-og-image.tsx
+++ b/apps/web/core/blocks/ranking/ranking-og-image.tsx
@@ -659,6 +659,9 @@ function Card({ data, variant }: { data: RankingOgCardData; variant: RankingOgVa
   const size = RANKING_OG_VARIANT_SIZES[variant];
   const scale = scaleForVariant(variant);
   const entries = data.entries.slice(0, 5);
+  const brandTop = isStory ? 154 : 26;
+  const titleTop = isStory ? 242 : 114;
+  const listTop = isStory ? 560 : 114;
 
   return (
     <div
@@ -679,7 +682,17 @@ function Card({ data, variant }: { data: RankingOgCardData; variant: RankingOgVa
         style={{
           position: 'absolute',
           left: scaled(isStory ? 78 : 52, scale),
-          top: scaled(isStory ? 154 : 64, scale),
+          top: scaled(brandTop, scale),
+          display: 'flex',
+        }}
+      >
+        <BrandMark variant={variant} scale={scale} />
+      </div>
+      <div
+        style={{
+          position: 'absolute',
+          left: scaled(isStory ? 78 : 52, scale),
+          top: scaled(titleTop, scale),
           width: scaled(isStory ? 680 : 318, scale),
           display: 'flex',
           flexDirection: 'column',
@@ -700,7 +713,7 @@ function Card({ data, variant }: { data: RankingOgCardData; variant: RankingOgVa
         style={{
           position: 'absolute',
           left: scaled(isStory ? 110 : 384, scale),
-          top: scaled(isStory ? 560 : 114, scale),
+          top: scaled(listTop, scale),
           width: scaled(isStory ? 890 : 790, scale),
           display: 'flex',
           flexDirection: 'column',
@@ -720,16 +733,6 @@ function Card({ data, variant }: { data: RankingOgCardData; variant: RankingOgVa
             <EmptyRows variant={variant} scale={scale} />
           )}
         </div>
-      </div>
-      <div
-        style={{
-          position: 'absolute',
-          left: scaled(isStory ? 78 : 52, scale),
-          bottom: scaled(isStory ? 132 : 116, scale),
-          display: 'flex',
-        }}
-      >
-        <BrandMark variant={variant} scale={scale} />
       </div>
     </div>
   );

--- a/apps/web/core/blocks/ranking/ranking-og-version.ts
+++ b/apps/web/core/blocks/ranking/ranking-og-version.ts
@@ -1,5 +1,5 @@
-export const RANKING_OG_LAYOUT_VERSION = 'ranking-og-v3';
-export const RANKING_GLOBAL_OG_LAYOUT_VERSION = 'ranking-global-og-v3';
+export const RANKING_OG_LAYOUT_VERSION = 'ranking-og-v4';
+export const RANKING_GLOBAL_OG_LAYOUT_VERSION = 'ranking-global-og-v4';
 
 export type RankingOgVersionInput = {
   rankEntityId: string;


### PR DESCRIPTION
## What changed

- Moved the Geo brand mark above the ranking title in ranking social share images.
- Moved the landscape ranking title down so it top-aligns with the #1 row.
- Bumped the ranking OG layout versions to v4 so cached/generated share images refresh.

## Why

The existing share image composition placed the Geo logo near the bottom and the ranking title higher than the ranked list. This aligns the brand, title, and first ranking row with the requested visual hierarchy.

## Validation

- bun test apps/web/core/blocks/ranking/ranking-og-version.test.ts apps/web/core/blocks/ranking/ranking-og-image.test.ts