### PR TITLE
feat: short ranking share links 

### DIFF
--- a/apps/web/app/r/[rankEntityId]/page.tsx
+++ b/apps/web/app/r/[rankEntityId]/page.tsx
@@ -1,0 +1,42 @@
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+
+import { buildPersonalRankingMetadata } from '~/core/blocks/ranking/ranking-og-metadata';
+import { buildShortPersonalRankingSharePath } from '~/core/blocks/ranking/ranking-share';
+import { resolvePersonalRankingShare } from '~/core/blocks/ranking/resolve-ranking-share';
+
+import { RankingComposeClientPage } from '~/app/space/(entity)/[id]/[entityId]/ranking-compose/ranking-compose-client-page';
+
+type Props = {
+  params: Promise<{ rankEntityId: string }>;
+};
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { rankEntityId } = await params;
+  const resolved = await resolvePersonalRankingShare(rankEntityId);
+  if (!resolved) return {};
+
+  const siteUrl = new URL(process.env.ENV_URL ?? 'https://geobrowser.io');
+  return buildPersonalRankingMetadata(resolved, siteUrl, buildShortPersonalRankingSharePath(rankEntityId));
+}
+
+export default async function ShortPersonalRankingPage({ params }: Props) {
+  const { rankEntityId } = await params;
+  const resolved = await resolvePersonalRankingShare(rankEntityId);
+  if (!resolved) notFound();
+
+  return (
+    <RankingComposeClientPage
+      spaceId={resolved.blockEntitySpaceId}
+      dataBlockEntityId={resolved.blockEntityId}
+      relationId={resolved.relationId}
+      parentEntityIdParam={resolved.parentEntityId}
+      rankingStartDate={resolved.rankingStartDate}
+      rankingEndDate={resolved.rankingEndDate}
+      mode="view"
+      rankEntityId={resolved.rankEntityId}
+      authorSpaceId={resolved.authorSpaceId}
+      ogVersion={resolved.ogVersion}
+    />
+  );
+}

--- a/apps/web/app/r/g/[blockEntityId]/page.tsx
+++ b/apps/web/app/r/g/[blockEntityId]/page.tsx
@@ -1,0 +1,39 @@
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+
+import { buildGlobalRankingMetadata } from '~/core/blocks/ranking/ranking-og-metadata';
+import { buildShortGlobalRankingSharePath } from '~/core/blocks/ranking/ranking-share';
+import { resolveGlobalRankingShare } from '~/core/blocks/ranking/resolve-ranking-share';
+
+import { RankingComposeClientPage } from '~/app/space/(entity)/[id]/[entityId]/ranking-compose/ranking-compose-client-page';
+
+type Props = {
+  params: Promise<{ blockEntityId: string }>;
+};
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { blockEntityId } = await params;
+  const resolved = await resolveGlobalRankingShare(blockEntityId);
+  if (!resolved) return {};
+
+  const siteUrl = new URL(process.env.ENV_URL ?? 'https://geobrowser.io');
+  return buildGlobalRankingMetadata(resolved, siteUrl, buildShortGlobalRankingSharePath(blockEntityId));
+}
+
+export default async function ShortGlobalRankingPage({ params }: Props) {
+  const { blockEntityId } = await params;
+  const resolved = await resolveGlobalRankingShare(blockEntityId);
+  if (!resolved) notFound();
+
+  return (
+    <RankingComposeClientPage
+      spaceId={resolved.blockEntitySpaceId}
+      dataBlockEntityId={resolved.blockEntityId}
+      relationId={resolved.relationId}
+      parentEntityIdParam={resolved.parentEntityId}
+      rankingStartDate={resolved.rankingStartDate}
+      rankingEndDate={resolved.rankingEndDate}
+      mode="view"
+    />
+  );
+}

--- a/apps/web/app/space/(entity)/[id]/[entityId]/ranking-compose/page.tsx
+++ b/apps/web/app/space/(entity)/[id]/[entityId]/ranking-compose/page.tsx
@@ -7,15 +7,17 @@ import type { Metadata } from 'next';
 import { Effect } from 'effect';
 
 import { type RankingComposeMode, rankingComposeHref } from '~/core/blocks/ranking/ranking-compose-url';
+import {
+  buildGlobalRankingMetadataFromParts,
+  buildPersonalRankingMetadataFromParts,
+} from '~/core/blocks/ranking/ranking-og-metadata';
 import { buildRankingOgPreviewUrl } from '~/core/blocks/ranking/ranking-og-preview-url';
 import {
-  RANKING_OG_VARIANT_SIZES,
   buildGlobalRankingOgObjectKey,
   buildRankingOgObjectKey,
   buildRankingOgPublicUrl,
   getRankingOgPublicBaseUrl,
 } from '~/core/blocks/ranking/ranking-og-storage';
-import { formatSharedRankingOwnerLabel } from '~/core/blocks/ranking/ranking-owner-label';
 import { fetchProfileBySpaceId } from '~/core/io/subgraph/fetch-profile';
 
 import { cachedFetchEntity } from '../cached-fetch-entity';
@@ -94,11 +96,6 @@ export async function generateMetadata({ params, searchParams }: Props): Promise
   if (hasValidPersonalRankingOgParams({ rankEntityId, authorSpaceId, ogVersion })) {
     const authorProfile = await cachedFetchProfileBySpaceId(authorSpaceId);
     const authorName = authorProfile?.name?.trim() || '';
-    const pageTitle = rankingName;
-    const shareTitle = authorName ? formatSharedRankingOwnerLabel(authorName) : `My ${rankingName}`;
-    const description = authorName
-      ? `${shareTitle} for ${rankingName}.`
-      : `A personal Geo ranking for ${rankingName}.`;
     const publicBaseUrl = getRankingOgPublicBaseUrl();
     const imageUrl = publicBaseUrl
       ? buildRankingOgPublicUrl(
@@ -128,32 +125,15 @@ export async function generateMetadata({ params, searchParams }: Props): Promise
       ogVersion,
     });
 
-    return {
-      title: pageTitle,
-      description,
-      openGraph: {
-        title: shareTitle,
-        description,
-        url: new URL(url, siteUrl).toString(),
-        images: [
-          {
-            url: imageUrl,
-            ...RANKING_OG_VARIANT_SIZES.landscape,
-            alt: shareTitle,
-          },
-        ],
-      },
-      twitter: {
-        card: 'summary_large_image',
-        title: shareTitle,
-        description,
-        images: [imageUrl],
-      },
-    };
+    return buildPersonalRankingMetadataFromParts({
+      rankingName,
+      authorName,
+      imageUrl,
+      url: new URL(url, siteUrl).toString(),
+    });
   }
 
   if (hasValidGlobalRankingOgParams({ blockEntityId: entityId, globalOgVersion })) {
-    const title = rankingName;
     const publicBaseUrl = getRankingOgPublicBaseUrl();
     const imageUrl = publicBaseUrl
       ? buildRankingOgPublicUrl(
@@ -179,28 +159,11 @@ export async function generateMetadata({ params, searchParams }: Props): Promise
       globalOgVersion,
     });
 
-    return {
-      title,
-      description: `Vote on the global Geo ranking for ${rankingName}.`,
-      openGraph: {
-        title,
-        description: `Vote on the global Geo ranking for ${rankingName}.`,
-        url: new URL(url, siteUrl).toString(),
-        images: [
-          {
-            url: imageUrl,
-            ...RANKING_OG_VARIANT_SIZES.landscape,
-            alt: title,
-          },
-        ],
-      },
-      twitter: {
-        card: 'summary_large_image',
-        title,
-        description: `Vote on the global Geo ranking for ${rankingName}.`,
-        images: [imageUrl],
-      },
-    };
+    return buildGlobalRankingMetadataFromParts({
+      rankingName,
+      imageUrl,
+      url: new URL(url, siteUrl).toString(),
+    });
   }
 
   return {};

--- a/apps/web/core/blocks/ranking/my-ranking-entity.ts
+++ b/apps/web/core/blocks/ranking/my-ranking-entity.ts
@@ -1,7 +1,7 @@
 import type { EntityFilter } from '~/core/gql/graphql';
 import { ID } from '~/core/id';
 import { RANK_TYPE_ID, RANK_VOTES_RELATION_TYPE_ID, SUBMITTED_TO_PROPERTY_ID } from '~/core/ranking-block-ids';
-import type { Entity } from '~/core/types';
+import type { Entity, Relation } from '~/core/types';
 
 import { getOrderedRelationTargetIds } from './ranking-block-relations';
 
@@ -25,6 +25,19 @@ export function isRankSubmittedToBlock(rankEntity: Entity, authorSpaceId: string
       ID.equals(relation.type.id, SUBMITTED_TO_PROPERTY_ID) &&
       ID.equals(relation.toEntity.id, blockEntityId)
   );
+}
+
+/**
+ * Resolve the data/ranking block a rank entity was submitted to from its
+ * relations. A RANK entity carries a single SUBMITTED_TO relation (scoped to the
+ * author's personal space) pointing at the block it ranks. Shared with the short
+ * share-link resolver so the block-detection logic lives in one place.
+ */
+export function getSubmittedBlockIdFromRank(relations: Relation[], authorSpaceId: string): string | null {
+  const relation = relations.find(
+    r => !r.isDeleted && ID.equals(r.spaceId, authorSpaceId) && ID.equals(r.type.id, SUBMITTED_TO_PROPERTY_ID)
+  );
+  return relation?.toEntity.id ?? null;
 }
 
 function parseEntityTimestampMs(raw: string | number | undefined | null): number {

--- a/apps/web/core/blocks/ranking/ranking-og-metadata.test.ts
+++ b/apps/web/core/blocks/ranking/ranking-og-metadata.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  buildGlobalRankingMetadata,
+  buildGlobalRankingMetadataFromParts,
+  buildPersonalRankingMetadata,
+  buildPersonalRankingMetadataFromParts,
+} from './ranking-og-metadata';
+import type { ResolvedGlobalRankingShare, ResolvedPersonalRankingShare } from './resolve-ranking-share';
+
+const SITE_URL = new URL('https://geobrowser.io');
+
+const personalResolved: ResolvedPersonalRankingShare = {
+  kind: 'personal',
+  rankEntityId: 'rank-1',
+  authorSpaceId: 'author-space',
+  blockEntityId: 'block-1',
+  blockEntitySpaceId: 'block-space',
+  parentEntityId: 'parent-1',
+  relationId: 'rel-1',
+  rankingStartDate: '2024-01-01',
+  rankingEndDate: '2024-02-01',
+  rankingName: 'My Ranking',
+  authorName: 'Alice',
+  ogVersion: 'ranking-og-v3-abcd1234',
+  cardData: {
+    kind: 'personal',
+    rankEntityId: 'rank-1',
+    authorSpaceId: 'author-space',
+    blockEntityId: 'block-1',
+    blockEntitySpaceId: 'block-space',
+    rankingName: 'My Ranking',
+    title: 'My Ranking',
+    periodLabel: null,
+    author: { name: 'Alice', avatarUrl: null, avatarSeed: 'seed' },
+    entries: [],
+  },
+};
+
+const globalResolved: ResolvedGlobalRankingShare = {
+  kind: 'global',
+  blockEntityId: 'block-1',
+  blockEntitySpaceId: 'block-space',
+  parentEntityId: 'parent-1',
+  relationId: 'rel-1',
+  rankingStartDate: '',
+  rankingEndDate: '',
+  rankingName: 'My Ranking',
+  globalOgVersion: 'ranking-global-og-v3-abcd1234',
+  cardData: {
+    kind: 'global',
+    rankEntityId: '',
+    authorSpaceId: '',
+    blockEntityId: 'block-1',
+    blockEntitySpaceId: 'block-space',
+    rankingName: 'My Ranking',
+    title: 'My Ranking',
+    periodLabel: null,
+    author: { name: '', avatarUrl: null, avatarSeed: 'block-1' },
+    entries: [],
+  },
+};
+
+describe('buildPersonalRankingMetadataFromParts', () => {
+  it('builds title, description and a summary_large_image card', () => {
+    const meta = buildPersonalRankingMetadataFromParts({
+      rankingName: 'My Ranking',
+      authorName: 'Alice',
+      imageUrl: 'https://cdn.example.com/og.png',
+      url: 'https://geobrowser.io/r/rank-1',
+    });
+
+    expect(meta.title).toBe('My Ranking');
+    expect(meta.openGraph?.url).toBe('https://geobrowser.io/r/rank-1');
+    expect(meta.openGraph?.images).toEqual([
+      expect.objectContaining({ url: 'https://cdn.example.com/og.png' }),
+    ]);
+    expect((meta.twitter as { card?: string }).card).toBe('summary_large_image');
+    expect(meta.twitter?.images).toEqual(['https://cdn.example.com/og.png']);
+  });
+
+  it('falls back to a generic title when there is no author', () => {
+    const meta = buildPersonalRankingMetadataFromParts({
+      rankingName: 'My Ranking',
+      authorName: '',
+      imageUrl: 'https://cdn.example.com/og.png',
+      url: 'https://geobrowser.io/r/rank-1',
+    });
+    expect(meta.openGraph?.title).toBe('My My Ranking');
+  });
+});
+
+describe('buildGlobalRankingMetadataFromParts', () => {
+  it('builds the global voting card', () => {
+    const meta = buildGlobalRankingMetadataFromParts({
+      rankingName: 'My Ranking',
+      imageUrl: 'https://cdn.example.com/og.png',
+      url: 'https://geobrowser.io/r/g/block-1',
+    });
+    expect(meta.title).toBe('My Ranking');
+    expect(meta.openGraph?.url).toBe('https://geobrowser.io/r/g/block-1');
+    expect(meta.description).toContain('global Geo ranking');
+  });
+});
+
+describe('image url selection (storage unconfigured)', () => {
+  let savedBaseUrl: string | undefined;
+
+  beforeEach(() => {
+    savedBaseUrl = process.env.SOCIAL_PREVIEW_PUBLIC_BASE_URL;
+    delete process.env.SOCIAL_PREVIEW_PUBLIC_BASE_URL;
+  });
+
+  afterEach(() => {
+    if (savedBaseUrl === undefined) delete process.env.SOCIAL_PREVIEW_PUBLIC_BASE_URL;
+    else process.env.SOCIAL_PREVIEW_PUBLIC_BASE_URL = savedBaseUrl;
+  });
+
+  it('uses the live preview endpoint and points the card at the short URL (personal)', async () => {
+    const meta = await buildPersonalRankingMetadata(personalResolved, SITE_URL, '/r/rank-1');
+    const imageUrl = meta.twitter?.images as string[];
+
+    expect(imageUrl[0]).toContain('/api/ranking-og/preview');
+    expect(imageUrl[0]).toContain('scope=personal');
+    expect(meta.openGraph?.url).toBe('https://geobrowser.io/r/rank-1');
+  });
+
+  it('uses the live preview endpoint and points the card at the short URL (global)', async () => {
+    const meta = await buildGlobalRankingMetadata(globalResolved, SITE_URL, '/r/g/block-1');
+    const imageUrl = meta.twitter?.images as string[];
+
+    expect(imageUrl[0]).toContain('/api/ranking-og/preview');
+    expect(imageUrl[0]).toContain('scope=global');
+    expect(meta.openGraph?.url).toBe('https://geobrowser.io/r/g/block-1');
+  });
+});

--- a/apps/web/core/blocks/ranking/ranking-og-metadata.ts
+++ b/apps/web/core/blocks/ranking/ranking-og-metadata.ts
@@ -1,0 +1,185 @@
+import type { Metadata } from 'next';
+
+import { buildRankingOgPreviewUrl } from './ranking-og-preview-url';
+import { formatSharedRankingOwnerLabel } from './ranking-owner-label';
+import {
+  RANKING_OG_VARIANT_SIZES,
+  buildGlobalRankingOgObjectKey,
+  buildRankingOgObjectKey,
+  buildRankingOgPublicUrl,
+  getRankingOgPublicBaseUrl,
+  getRankingOgStorageConfig,
+  isRankingOgStorageConfigured,
+  rankingOgObjectExists,
+} from './ranking-og-storage';
+import type { ResolvedGlobalRankingShare, ResolvedPersonalRankingShare } from './resolve-ranking-share';
+
+type PersonalMetadataParts = {
+  rankingName: string;
+  authorName: string;
+  imageUrl: string;
+  /** Absolute canonical URL the social card should point at. */
+  url: string;
+};
+
+type GlobalMetadataParts = {
+  rankingName: string;
+  imageUrl: string;
+  url: string;
+};
+
+/**
+ * Pure assembly of the personal ranking social card metadata. Shared by the long
+ * `ranking-compose` route (which computes `imageUrl` from pinned search params)
+ * and the short `/r/{rankEntityId}` route (which computes it from the resolver).
+ */
+export function buildPersonalRankingMetadataFromParts({
+  rankingName,
+  authorName,
+  imageUrl,
+  url,
+}: PersonalMetadataParts): Metadata {
+  const name = rankingName || 'ranking';
+  const trimmedAuthor = authorName.trim();
+  const shareTitle = trimmedAuthor ? formatSharedRankingOwnerLabel(trimmedAuthor) : `My ${name}`;
+  const description = trimmedAuthor ? `${shareTitle} for ${name}.` : `A personal Geo ranking for ${name}.`;
+
+  return {
+    title: name,
+    description,
+    openGraph: {
+      title: shareTitle,
+      description,
+      url,
+      images: [
+        {
+          url: imageUrl,
+          ...RANKING_OG_VARIANT_SIZES.landscape,
+          alt: shareTitle,
+        },
+      ],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: shareTitle,
+      description,
+      images: [imageUrl],
+    },
+  };
+}
+
+/** Pure assembly of the global ranking social card metadata. */
+export function buildGlobalRankingMetadataFromParts({ rankingName, imageUrl, url }: GlobalMetadataParts): Metadata {
+  const name = rankingName || 'ranking';
+  const description = `Vote on the global Geo ranking for ${name}.`;
+
+  return {
+    title: name,
+    description,
+    openGraph: {
+      title: name,
+      description,
+      url,
+      images: [
+        {
+          url: imageUrl,
+          ...RANKING_OG_VARIANT_SIZES.landscape,
+          alt: name,
+        },
+      ],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: name,
+      description,
+      images: [imageUrl],
+    },
+  };
+}
+
+/**
+ * R2-first with preview fallback: serve the pre-generated static R2 object when it
+ * exists for the (recomputed) version, otherwise fall back to the live preview
+ * render so the card is always correct even when the ranking changed since publish.
+ */
+async function rankingOgObjectExistsSafe(key: string): Promise<boolean> {
+  try {
+    if (!isRankingOgStorageConfigured()) return false;
+    return await rankingOgObjectExists(getRankingOgStorageConfig(), key);
+  } catch {
+    return false;
+  }
+}
+
+export async function buildPersonalRankingMetadata(
+  resolved: ResolvedPersonalRankingShare,
+  siteUrl: URL,
+  canonicalUrl: string
+): Promise<Metadata> {
+  const publicBaseUrl = getRankingOgPublicBaseUrl();
+  let imageUrl: string | null = null;
+  if (publicBaseUrl) {
+    const key = buildRankingOgObjectKey({
+      rankEntityId: resolved.rankEntityId,
+      version: resolved.ogVersion,
+      variant: 'landscape',
+    });
+    if (await rankingOgObjectExistsSafe(key)) {
+      imageUrl = buildRankingOgPublicUrl(publicBaseUrl, key);
+    }
+  }
+  if (!imageUrl) {
+    imageUrl = buildRankingOgPreviewUrl(siteUrl.toString(), {
+      scope: 'personal',
+      rankEntityId: resolved.rankEntityId,
+      authorSpaceId: resolved.authorSpaceId,
+      blockEntityId: resolved.blockEntityId,
+      blockEntitySpaceId: resolved.blockEntitySpaceId,
+      rankingStartDate: resolved.rankingStartDate,
+      rankingEndDate: resolved.rankingEndDate,
+      ogVersion: resolved.ogVersion,
+    });
+  }
+
+  return buildPersonalRankingMetadataFromParts({
+    rankingName: resolved.rankingName,
+    authorName: resolved.authorName,
+    imageUrl,
+    url: new URL(canonicalUrl, siteUrl).toString(),
+  });
+}
+
+export async function buildGlobalRankingMetadata(
+  resolved: ResolvedGlobalRankingShare,
+  siteUrl: URL,
+  canonicalUrl: string
+): Promise<Metadata> {
+  const publicBaseUrl = getRankingOgPublicBaseUrl();
+  let imageUrl: string | null = null;
+  if (publicBaseUrl) {
+    const key = buildGlobalRankingOgObjectKey({
+      blockEntityId: resolved.blockEntityId,
+      version: resolved.globalOgVersion,
+      variant: 'landscape',
+    });
+    if (await rankingOgObjectExistsSafe(key)) {
+      imageUrl = buildRankingOgPublicUrl(publicBaseUrl, key);
+    }
+  }
+  if (!imageUrl) {
+    imageUrl = buildRankingOgPreviewUrl(siteUrl.toString(), {
+      scope: 'global',
+      blockEntityId: resolved.blockEntityId,
+      blockEntitySpaceId: resolved.blockEntitySpaceId,
+      rankingStartDate: resolved.rankingStartDate,
+      rankingEndDate: resolved.rankingEndDate,
+      globalOgVersion: resolved.globalOgVersion,
+    });
+  }
+
+  return buildGlobalRankingMetadataFromParts({
+    rankingName: resolved.rankingName,
+    imageUrl,
+    url: new URL(canonicalUrl, siteUrl).toString(),
+  });
+}

--- a/apps/web/core/blocks/ranking/ranking-share.ts
+++ b/apps/web/core/blocks/ranking/ranking-share.ts
@@ -10,6 +10,20 @@ export function buildRankingSharePath(params: RankingComposeHrefParams & Partial
   return rankingComposeHref({ ...params, mode: 'view' });
 }
 
+/**
+ * Short, opaque personal ranking share path. Everything else (block, dates,
+ * placement, ogVersion, tab) is reconstructed server-side from the rank entity id
+ * by the `/r/[rankEntityId]` resolver route.
+ */
+export function buildShortPersonalRankingSharePath(rankEntityId: string): string {
+  return `/r/${rankEntityId}`;
+}
+
+/** Short, opaque global ranking share path resolved by `/r/g/[blockEntityId]`. */
+export function buildShortGlobalRankingSharePath(blockEntityId: string): string {
+  return `/r/g/${blockEntityId}`;
+}
+
 export function buildAbsoluteRankingShareUrl(path: string): string {
   if (typeof window === 'undefined') return path;
   return new URL(path, window.location.origin).toString();

--- a/apps/web/core/blocks/ranking/resolve-ranking-share.test.ts
+++ b/apps/web/core/blocks/ranking/resolve-ranking-share.test.ts
@@ -1,0 +1,330 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  RANKING_END_DATE_PROPERTY_ID,
+  RANKING_START_DATE_PROPERTY_ID,
+  RANK_POSITION_PROPERTY_ID,
+  RANK_TYPE_ID,
+  RANK_VOTES_RELATION_TYPE_ID,
+  SUBMITTED_TO_PROPERTY_ID,
+} from '~/core/ranking-block-ids';
+import type { Entity, Profile, Relation, Value } from '~/core/types';
+
+import { getMyRankingOrderedEntityIds } from './my-ranking-entity';
+import type { RankingOgCardData } from './ranking-og-data';
+import { buildGlobalRankingOgVersion, buildRankingOgVersion } from './ranking-og-version';
+import {
+  type ResolveRankingShareDeps,
+  resolveGlobalRankingShareImpl,
+  resolvePersonalRankingShareImpl,
+} from './resolve-ranking-share';
+
+const AUTHOR_SPACE = 'author-space';
+const OTHER_SPACE = 'other-space';
+const BLOCK_SPACE = 'block-space';
+const RANK_ID = 'aaaa1111bbbb2222cccc3333dddd4444';
+const BLOCK_ID = 'bbbb1111cccc2222dddd3333eeee4444';
+const PARENT_ID = 'parent-1';
+const REL_ID = 'rel-1';
+const START_DATE = '2024-01-01';
+const END_DATE = '2024-02-01';
+
+function rel(partial: Record<string, unknown>): Relation {
+  return { isDeleted: false, position: null, toSpaceId: undefined, ...partial } as unknown as Relation;
+}
+
+function dateValue(propertyId: string, value: string): Value {
+  return {
+    id: `${propertyId}-v`,
+    entity: { id: BLOCK_ID, name: null },
+    property: { id: propertyId, name: null },
+    value,
+    spaceId: BLOCK_SPACE,
+    isDeleted: false,
+  } as unknown as Value;
+}
+
+const submittedRel = rel({
+  id: 'sub-1',
+  spaceId: AUTHOR_SPACE,
+  type: { id: SUBMITTED_TO_PROPERTY_ID, name: 'Submitted to' },
+  fromEntity: { id: RANK_ID, name: null },
+  toEntity: { id: BLOCK_ID, name: null },
+});
+const voteRelA = rel({
+  id: 'v-a',
+  spaceId: AUTHOR_SPACE,
+  position: 'a0',
+  type: { id: RANK_VOTES_RELATION_TYPE_ID, name: null },
+  fromEntity: { id: RANK_ID, name: null },
+  toEntity: { id: 'ent-a', name: null },
+});
+const voteRelB = rel({
+  id: 'v-b',
+  spaceId: AUTHOR_SPACE,
+  position: 'a1',
+  type: { id: RANK_VOTES_RELATION_TYPE_ID, name: null },
+  fromEntity: { id: RANK_ID, name: null },
+  toEntity: { id: 'ent-b', name: null },
+});
+const rankRelations = [submittedRel, voteRelA, voteRelB];
+
+const rankEntity = {
+  id: RANK_ID,
+  name: 'Rank',
+  description: null,
+  spaces: [AUTHOR_SPACE],
+  types: [{ id: RANK_TYPE_ID, name: 'Rank' }],
+  relations: [],
+  values: [],
+} as unknown as Entity;
+
+const blockUnscoped = {
+  id: BLOCK_ID,
+  name: 'My Ranking',
+  description: null,
+  spaces: [BLOCK_SPACE],
+  types: [],
+  relations: [],
+  values: [],
+} as unknown as Entity;
+
+const blockScoped = {
+  ...blockUnscoped,
+  values: [dateValue(RANKING_START_DATE_PROPERTY_ID, START_DATE), dateValue(RANKING_END_DATE_PROPERTY_ID, END_DATE)],
+} as unknown as Entity;
+
+const personalCardData: RankingOgCardData = {
+  kind: 'personal',
+  rankEntityId: RANK_ID,
+  authorSpaceId: AUTHOR_SPACE,
+  blockEntityId: BLOCK_ID,
+  blockEntitySpaceId: BLOCK_SPACE,
+  rankingName: 'My Ranking',
+  title: 'My Ranking',
+  periodLabel: null,
+  author: { name: 'Alice', avatarUrl: null, avatarSeed: 'seed' },
+  entries: [
+    { entityId: 'ent-a', name: 'A', description: null, image: null },
+    { entityId: 'ent-b', name: 'B', description: null, image: null },
+  ],
+};
+
+const profile = {
+  id: 'profile-1',
+  spaceId: AUTHOR_SPACE,
+  name: 'Alice',
+  avatarUrl: null,
+  coverUrl: null,
+  profileLink: null,
+  address: '0x0',
+} as unknown as Profile;
+
+function personalDeps(overrides: Partial<ResolveRankingShareDeps> = {}): ResolveRankingShareDeps {
+  return {
+    fetchEntity: async (id, spaceId) => {
+      if (id === RANK_ID) return rankEntity;
+      if (id === BLOCK_ID) return spaceId ? blockScoped : blockUnscoped;
+      return null;
+    },
+    fetchEntityPage: async (id, spaceId) => {
+      if (id === RANK_ID && spaceId === AUTHOR_SPACE) return { entity: rankEntity, relations: rankRelations };
+      return null;
+    },
+    fetchRelationsByToEntity: async blockId =>
+      blockId === BLOCK_ID ? [{ id: REL_ID, fromEntityId: PARENT_ID, toEntityId: BLOCK_ID, spaceId: BLOCK_SPACE }] : [],
+    fetchProfile: async () => profile,
+    fetchPersonalCardData: async () => personalCardData,
+    fetchGlobalCardData: async () => null,
+    ...overrides,
+  };
+}
+
+describe('resolvePersonalRankingShareImpl', () => {
+  it('resolves all coordinates from the rank entity id', async () => {
+    const resolved = await resolvePersonalRankingShareImpl(RANK_ID, personalDeps());
+
+    expect(resolved).not.toBeNull();
+    expect(resolved?.kind).toBe('personal');
+    expect(resolved?.authorSpaceId).toBe(AUTHOR_SPACE);
+    expect(resolved?.blockEntityId).toBe(BLOCK_ID);
+    expect(resolved?.blockEntitySpaceId).toBe(BLOCK_SPACE);
+    expect(resolved?.parentEntityId).toBe(PARENT_ID);
+    expect(resolved?.relationId).toBe(REL_ID);
+    expect(resolved?.rankingStartDate).toBe(START_DATE);
+    expect(resolved?.rankingEndDate).toBe(END_DATE);
+    expect(resolved?.rankingName).toBe('My Ranking');
+    expect(resolved?.authorName).toBe('Alice');
+  });
+
+  it('recomputes ogVersion to match the publish-flow inputs (drift guard)', async () => {
+    const resolved = await resolvePersonalRankingShareImpl(RANK_ID, personalDeps());
+
+    const orderedEntityIds = getMyRankingOrderedEntityIds({ ...rankEntity, relations: rankRelations }, AUTHOR_SPACE);
+    expect(orderedEntityIds).toEqual(['ent-a', 'ent-b']);
+
+    const expectedVersion = buildRankingOgVersion({
+      rankEntityId: RANK_ID,
+      orderedEntityIds,
+      rankingName: 'My Ranking',
+      rankingStartDate: START_DATE,
+      rankingEndDate: END_DATE,
+      authorName: 'Alice',
+      authorAvatarUrl: null,
+    });
+
+    expect(resolved?.ogVersion).toBe(expectedVersion);
+  });
+
+  it('returns null for a non-RANK entity', async () => {
+    const notRank = { ...rankEntity, types: [{ id: 'something-else', name: 'Other' }] } as unknown as Entity;
+    const resolved = await resolvePersonalRankingShareImpl(
+      RANK_ID,
+      personalDeps({ fetchEntity: async () => notRank })
+    );
+    expect(resolved).toBeNull();
+  });
+
+  it('returns null when the rank was not submitted to a block', async () => {
+    const resolved = await resolvePersonalRankingShareImpl(
+      RANK_ID,
+      personalDeps({
+        fetchEntityPage: async () => ({ entity: rankEntity, relations: [voteRelA, voteRelB] }),
+      })
+    );
+    expect(resolved).toBeNull();
+  });
+
+  it('picks the author space that actually carries the SUBMITTED_TO relation (tie-break)', async () => {
+    const multiSpaceRank = { ...rankEntity, spaces: [OTHER_SPACE, AUTHOR_SPACE] } as unknown as Entity;
+    const resolved = await resolvePersonalRankingShareImpl(
+      RANK_ID,
+      personalDeps({
+        fetchEntity: async (id, spaceId) => {
+          if (id === RANK_ID) return multiSpaceRank;
+          if (id === BLOCK_ID) return spaceId ? blockScoped : blockUnscoped;
+          return null;
+        },
+        fetchEntityPage: async (id, spaceId) => {
+          // OTHER_SPACE has no submitted-to relation; AUTHOR_SPACE does.
+          if (id === RANK_ID && spaceId === AUTHOR_SPACE)
+            return { entity: multiSpaceRank, relations: rankRelations };
+          if (id === RANK_ID && spaceId === OTHER_SPACE)
+            return { entity: multiSpaceRank, relations: [voteRelA] };
+          return null;
+        },
+      })
+    );
+
+    expect(resolved?.authorSpaceId).toBe(AUTHOR_SPACE);
+    expect(resolved?.blockEntityId).toBe(BLOCK_ID);
+  });
+
+  it('degrades to empty placement when no BLOCKS relation is found', async () => {
+    const resolved = await resolvePersonalRankingShareImpl(
+      RANK_ID,
+      personalDeps({ fetchRelationsByToEntity: async () => [] })
+    );
+    expect(resolved).not.toBeNull();
+    expect(resolved?.parentEntityId).toBe('');
+    expect(resolved?.relationId).toBe('');
+  });
+
+  it('handles an empty date window', async () => {
+    const noDates = { ...blockUnscoped } as unknown as Entity;
+    const resolved = await resolvePersonalRankingShareImpl(
+      RANK_ID,
+      personalDeps({
+        fetchEntity: async (id, spaceId) => {
+          if (id === RANK_ID) return rankEntity;
+          if (id === BLOCK_ID) return spaceId ? noDates : blockUnscoped;
+          return null;
+        },
+        fetchPersonalCardData: async () => ({ ...personalCardData, periodLabel: null }),
+      })
+    );
+    expect(resolved?.rankingStartDate).toBe('');
+    expect(resolved?.rankingEndDate).toBe('');
+  });
+
+  it('returns null for an invalid id', async () => {
+    const resolved = await resolvePersonalRankingShareImpl('not-a-uuid', personalDeps());
+    expect(resolved).toBeNull();
+  });
+});
+
+describe('resolveGlobalRankingShareImpl', () => {
+  const globalRelA = rel({
+    id: 'g-a',
+    spaceId: BLOCK_SPACE,
+    position: 'a0',
+    type: { id: RANK_POSITION_PROPERTY_ID, name: null },
+    fromEntity: { id: BLOCK_ID, name: null },
+    toEntity: { id: 'ent-a', name: null },
+  });
+  const globalRelB = rel({
+    id: 'g-b',
+    spaceId: BLOCK_SPACE,
+    position: 'a1',
+    type: { id: RANK_POSITION_PROPERTY_ID, name: null },
+    fromEntity: { id: BLOCK_ID, name: null },
+    toEntity: { id: 'ent-b', name: null },
+  });
+  const globalRelations = [globalRelA, globalRelB];
+
+  const globalCardData: RankingOgCardData = {
+    kind: 'global',
+    rankEntityId: '',
+    authorSpaceId: '',
+    blockEntityId: BLOCK_ID,
+    blockEntitySpaceId: BLOCK_SPACE,
+    rankingName: 'My Ranking',
+    title: 'My Ranking',
+    periodLabel: null,
+    author: { name: '', avatarUrl: null, avatarSeed: BLOCK_ID },
+    entries: [
+      { entityId: 'ent-a', name: 'A', description: null, image: null },
+      { entityId: 'ent-b', name: 'B', description: null, image: null },
+    ],
+  };
+
+  function globalDeps(overrides: Partial<ResolveRankingShareDeps> = {}): ResolveRankingShareDeps {
+    return {
+      fetchEntity: async (id, spaceId) => (id === BLOCK_ID ? (spaceId ? blockScoped : blockUnscoped) : null),
+      fetchEntityPage: async (id, spaceId) =>
+        id === BLOCK_ID && spaceId === BLOCK_SPACE ? { entity: blockScoped, relations: globalRelations } : null,
+      fetchRelationsByToEntity: async () => [
+        { id: REL_ID, fromEntityId: PARENT_ID, toEntityId: BLOCK_ID, spaceId: BLOCK_SPACE },
+      ],
+      fetchProfile: async () => null,
+      fetchPersonalCardData: async () => null,
+      fetchGlobalCardData: async () => globalCardData,
+      ...overrides,
+    };
+  }
+
+  it('resolves global coordinates and ogVersion from the block id', async () => {
+    const resolved = await resolveGlobalRankingShareImpl(BLOCK_ID, globalDeps());
+
+    expect(resolved?.kind).toBe('global');
+    expect(resolved?.blockEntitySpaceId).toBe(BLOCK_SPACE);
+    expect(resolved?.parentEntityId).toBe(PARENT_ID);
+    expect(resolved?.relationId).toBe(REL_ID);
+    expect(resolved?.rankingStartDate).toBe(START_DATE);
+    expect(resolved?.rankingEndDate).toBe(END_DATE);
+
+    const expectedVersion = buildGlobalRankingOgVersion({
+      blockEntityId: BLOCK_ID,
+      orderedEntityIds: ['ent-a', 'ent-b'],
+      rankingName: 'My Ranking',
+      rankingStartDate: START_DATE,
+      rankingEndDate: END_DATE,
+    });
+    expect(resolved?.globalOgVersion).toBe(expectedVersion);
+  });
+
+  it('returns null when the block is missing', async () => {
+    const resolved = await resolveGlobalRankingShareImpl(BLOCK_ID, globalDeps({ fetchEntity: async () => null }));
+    expect(resolved).toBeNull();
+  });
+});

--- a/apps/web/core/blocks/ranking/resolve-ranking-share.ts
+++ b/apps/web/core/blocks/ranking/resolve-ranking-share.ts
@@ -1,0 +1,286 @@
+import { IdUtils, SystemIds } from '@geoprotocol/geo-sdk/lite';
+
+import { cache } from 'react';
+
+import { Effect } from 'effect';
+
+import { PLACEHOLDER_SPACE_IMAGE } from '~/core/constants';
+import { getEntity, getEntityPage, getRelationsByToEntityIds } from '~/core/io/queries';
+import { fetchProfileBySpaceId } from '~/core/io/subgraph/fetch-profile';
+import {
+  RANKING_END_DATE_PROPERTY_ID,
+  RANKING_START_DATE_PROPERTY_ID,
+  RANK_POSITION_PROPERTY_ID,
+  RANK_TYPE_ID,
+} from '~/core/ranking-block-ids';
+import type { Entity, Profile, Relation } from '~/core/types';
+
+import { getMyRankingOrderedEntityIds, getSubmittedBlockIdFromRank } from './my-ranking-entity';
+import { getOrderedRelationTargetIds } from './ranking-block-relations';
+import {
+  type RankingOgCardData,
+  getGlobalRankingOgCardData,
+  getRankingOgCardData,
+} from './ranking-og-data';
+import { buildGlobalRankingOgVersion, buildRankingOgVersion } from './ranking-og-version';
+
+export type ResolvedPersonalRankingShare = {
+  kind: 'personal';
+  rankEntityId: string;
+  authorSpaceId: string;
+  blockEntityId: string;
+  blockEntitySpaceId: string;
+  /** Block placement in its parent — may be '' when the BLOCKS relation can't be resolved. */
+  parentEntityId: string;
+  relationId: string;
+  rankingStartDate: string;
+  rankingEndDate: string;
+  rankingName: string;
+  /** Raw author display name (empty when the author has no profile name). */
+  authorName: string;
+  /** Recomputed to match the publish-time inputs so the R2 fast path hits. */
+  ogVersion: string;
+  cardData: RankingOgCardData;
+};
+
+export type ResolvedGlobalRankingShare = {
+  kind: 'global';
+  blockEntityId: string;
+  blockEntitySpaceId: string;
+  parentEntityId: string;
+  relationId: string;
+  rankingStartDate: string;
+  rankingEndDate: string;
+  rankingName: string;
+  globalOgVersion: string;
+  cardData: RankingOgCardData;
+};
+
+type ToEntityRelation = {
+  id: string;
+  fromEntityId: string;
+  toEntityId: string;
+  spaceId: string;
+};
+
+export type ResolveRankingShareDeps = {
+  fetchEntity: (entityId: string, spaceId?: string) => Promise<Entity | null>;
+  fetchEntityPage: (entityId: string, spaceId?: string) => Promise<{ entity: Entity; relations: Relation[] } | null>;
+  fetchRelationsByToEntity: (blockEntityId: string, typeId: string, spaceId: string) => Promise<ToEntityRelation[]>;
+  fetchProfile: (spaceId: string) => Promise<Profile | null>;
+  fetchPersonalCardData: typeof getRankingOgCardData;
+  fetchGlobalCardData: typeof getGlobalRankingOgCardData;
+};
+
+const defaultDeps: ResolveRankingShareDeps = {
+  fetchEntity: (entityId, spaceId) => Effect.runPromise(getEntity(entityId, spaceId)),
+  fetchEntityPage: async (entityId, spaceId) => {
+    const page = await Effect.runPromise(getEntityPage(entityId, spaceId));
+    if (!page?.entity) return null;
+    return { entity: page.entity, relations: page.relations };
+  },
+  fetchRelationsByToEntity: (blockEntityId, typeId, spaceId) =>
+    Effect.runPromise(
+      getRelationsByToEntityIds([blockEntityId], typeId, spaceId)
+    ) as unknown as Promise<ToEntityRelation[]>,
+  fetchProfile: async spaceId => {
+    try {
+      return await Effect.runPromise(fetchProfileBySpaceId(spaceId));
+    } catch {
+      return null;
+    }
+  },
+  fetchPersonalCardData: getRankingOgCardData,
+  fetchGlobalCardData: getGlobalRankingOgCardData,
+};
+
+function readDateValue(entity: Entity | null | undefined, propertyId: string, spaceId: string): string {
+  if (!entity?.values) return '';
+  const value = entity.values.find(v => v.property.id === propertyId && v.spaceId === spaceId && !v.isDeleted);
+  return value?.value ?? '';
+}
+
+function profileAvatar(profile: Profile | null): string | null {
+  if (!profile?.avatarUrl || profile.avatarUrl === PLACEHOLDER_SPACE_IMAGE) return null;
+  return profile.avatarUrl;
+}
+
+function pickPrimarySpace(spaceIds: string[] | undefined): string {
+  return spaceIds?.[0] ?? '';
+}
+
+/**
+ * Find where the block is embedded (its parent entity + the relation id of that
+ * containment). The block is the target of a `BLOCKS` relation from its parent.
+ * Best-effort: returns empty strings when the relation can't be found.
+ */
+async function resolveBlockPlacement(
+  deps: ResolveRankingShareDeps,
+  blockEntityId: string,
+  blockEntitySpaceId: string
+): Promise<{ parentEntityId: string; relationId: string }> {
+  try {
+    const relations = await deps.fetchRelationsByToEntity(blockEntityId, SystemIds.BLOCKS, blockEntitySpaceId);
+    if (!relations || relations.length === 0) return { parentEntityId: '', relationId: '' };
+    if (relations.length > 1) {
+      console.warn(`[resolve-ranking-share] multiple BLOCKS parents for block ${blockEntityId}; using first match`);
+    }
+    const match = relations.find(r => r.spaceId === blockEntitySpaceId) ?? relations[0];
+    return { parentEntityId: match.fromEntityId ?? '', relationId: match.id ?? '' };
+  } catch {
+    return { parentEntityId: '', relationId: '' };
+  }
+}
+
+export async function resolvePersonalRankingShareImpl(
+  rankEntityId: string,
+  deps: ResolveRankingShareDeps = defaultDeps
+): Promise<ResolvedPersonalRankingShare | null> {
+  if (!IdUtils.isValid(rankEntityId)) return null;
+
+  // 1. Resolve the rank entity unscoped to learn which space(s) it lives in.
+  const rank = await deps.fetchEntity(rankEntityId);
+  if (!rank || !rank.types.some(type => type.id === RANK_TYPE_ID)) return null;
+
+  // 2. Find the author space whose page actually carries the rank's SUBMITTED_TO
+  //    relation, and the block it points at. A RANK entity is created in exactly
+  //    one personal space, so this normally resolves on the first candidate.
+  let authorSpaceId = '';
+  let blockEntityId = '';
+  let rankRelations: Relation[] = [];
+  for (const candidate of rank.spaces ?? []) {
+    const page = await deps.fetchEntityPage(rankEntityId, candidate);
+    const relations = page?.relations?.length ? page.relations : (page?.entity.relations ?? []);
+    const submittedBlockId = getSubmittedBlockIdFromRank(relations, candidate);
+    if (submittedBlockId) {
+      authorSpaceId = candidate;
+      blockEntityId = submittedBlockId;
+      rankRelations = relations;
+      break;
+    }
+  }
+  if (!authorSpaceId || !blockEntityId) return null;
+
+  // 3. Resolve the block: its space, name, and persisted date window.
+  const blockUnscoped = await deps.fetchEntity(blockEntityId);
+  const blockEntitySpaceId = pickPrimarySpace(blockUnscoped?.spaces);
+  if (!blockEntitySpaceId) return null;
+  const blockScoped = await deps.fetchEntity(blockEntityId, blockEntitySpaceId);
+  const rankingName = blockScoped?.name?.trim() || 'Untitled ranking';
+  const rankingStartDate = readDateValue(blockScoped, RANKING_START_DATE_PROPERTY_ID, blockEntitySpaceId);
+  const rankingEndDate = readDateValue(blockScoped, RANKING_END_DATE_PROPERTY_ID, blockEntitySpaceId);
+
+  // 4. Build the OG card data with the resolved coordinates.
+  const cardData = await deps.fetchPersonalCardData({
+    rankEntityId,
+    authorSpaceId,
+    blockEntityId,
+    blockEntitySpaceId,
+    rankingStartDate,
+    rankingEndDate,
+  });
+  if (!cardData) return null;
+
+  // 5. Recompute ogVersion mirroring the publish flow's inputs
+  //    (use-ranking-block-state.ts `effectiveOgVersion`): the FULL ordered ids,
+  //    the block name, and the raw profile name/avatar — not the top-5 card slice.
+  const profile = await deps.fetchProfile(authorSpaceId);
+  const orderedEntityIds = getMyRankingOrderedEntityIds({ ...rank, relations: rankRelations }, authorSpaceId);
+  const authorName = profile?.name?.trim() ?? '';
+  const ogVersion = buildRankingOgVersion({
+    rankEntityId,
+    orderedEntityIds,
+    rankingName,
+    rankingStartDate,
+    rankingEndDate,
+    authorName,
+    authorAvatarUrl: profileAvatar(profile),
+  });
+
+  // 6. Resolve placement for back-navigation / vote / "add my ranking".
+  const { parentEntityId, relationId } = await resolveBlockPlacement(deps, blockEntityId, blockEntitySpaceId);
+
+  return {
+    kind: 'personal',
+    rankEntityId,
+    authorSpaceId,
+    blockEntityId,
+    blockEntitySpaceId,
+    parentEntityId,
+    relationId,
+    rankingStartDate,
+    rankingEndDate,
+    rankingName,
+    authorName,
+    ogVersion,
+    cardData,
+  };
+}
+
+export async function resolveGlobalRankingShareImpl(
+  blockEntityId: string,
+  deps: ResolveRankingShareDeps = defaultDeps
+): Promise<ResolvedGlobalRankingShare | null> {
+  if (!IdUtils.isValid(blockEntityId)) return null;
+
+  const blockUnscoped = await deps.fetchEntity(blockEntityId);
+  if (!blockUnscoped) return null;
+  const blockEntitySpaceId = pickPrimarySpace(blockUnscoped.spaces);
+  if (!blockEntitySpaceId) return null;
+
+  const page = await deps.fetchEntityPage(blockEntityId, blockEntitySpaceId);
+  const blockScoped = page?.entity ?? (await deps.fetchEntity(blockEntityId, blockEntitySpaceId));
+  const relations = page?.relations?.length ? page.relations : (blockScoped?.relations ?? []);
+  const rankingName = blockScoped?.name?.trim() || 'Untitled ranking';
+  const rankingStartDate = readDateValue(blockScoped, RANKING_START_DATE_PROPERTY_ID, blockEntitySpaceId);
+  const rankingEndDate = readDateValue(blockScoped, RANKING_END_DATE_PROPERTY_ID, blockEntitySpaceId);
+
+  const cardData = await deps.fetchGlobalCardData({
+    blockEntityId,
+    blockEntitySpaceId,
+    rankingStartDate,
+    rankingEndDate,
+  });
+  if (!cardData) return null;
+
+  // Mirror the publish flow's `effectiveGlobalOgVersion`: full ordered ids by
+  // RANK_POSITION, block name, dates.
+  const orderedEntityIds = getOrderedRelationTargetIds(
+    relations,
+    blockEntityId,
+    RANK_POSITION_PROPERTY_ID,
+    blockEntitySpaceId
+  );
+  const globalOgVersion = buildGlobalRankingOgVersion({
+    blockEntityId,
+    orderedEntityIds,
+    rankingName,
+    rankingStartDate,
+    rankingEndDate,
+  });
+
+  const { parentEntityId, relationId } = await resolveBlockPlacement(deps, blockEntityId, blockEntitySpaceId);
+
+  return {
+    kind: 'global',
+    blockEntityId,
+    blockEntitySpaceId,
+    parentEntityId,
+    relationId,
+    rankingStartDate,
+    rankingEndDate,
+    rankingName,
+    globalOgVersion,
+    cardData,
+  };
+}
+
+// Wrap in React cache so generateMetadata and the page share a single resolution
+// per request (Next.js dedupes within a render pass).
+export const resolvePersonalRankingShare = cache((rankEntityId: string) =>
+  resolvePersonalRankingShareImpl(rankEntityId)
+);
+
+export const resolveGlobalRankingShare = cache((blockEntityId: string) =>
+  resolveGlobalRankingShareImpl(blockEntityId)
+);

--- a/apps/web/partials/blocks/table/ranking-block-body.tsx
+++ b/apps/web/partials/blocks/table/ranking-block-body.tsx
@@ -7,7 +7,6 @@ import cx from 'classnames';
 import { PAGE_SIZE } from '~/core/blocks/data/use-data-block';
 
 import { Button } from '~/design-system/button';
-import { Dots } from '~/design-system/dots';
 import { RankingChart } from '~/design-system/icons/ranking-chart';
 import { XIcon } from '~/design-system/icons/x';
 
@@ -80,7 +79,6 @@ function buildMyRankingTabActions(state: RankingBlockState) {
     showEditRankingButton,
     canSharePersonalRanking,
     sharePersonalRanking,
-    isPreparingPersonalShare,
     isSaving,
     openRankingCompose,
   } = state;
@@ -106,17 +104,10 @@ function buildMyRankingTabActions(state: RankingBlockState) {
             'h-8 shrink-0 !rounded-full border-grey-02 bg-text !px-3 text-[16px] whitespace-nowrap text-white hover:bg-text/90 focus-visible:border-text focus-visible:shadow-inner-text',
             !showEditRankingButton && 'ml-auto'
           )}
-          disabled={isPreparingPersonalShare}
           onClick={sharePersonalRanking}
         >
-          {isPreparingPersonalShare ? (
-            <Dots color="bg-grey-02" />
-          ) : (
-            <>
-              Share
-              <XIcon color="white" />
-            </>
-          )}
+          Share
+          <XIcon color="white" />
         </Button>
       ) : null}
     </div>

--- a/apps/web/partials/blocks/table/table-block-context-menu.tsx
+++ b/apps/web/partials/blocks/table/table-block-context-menu.tsx
@@ -68,12 +68,14 @@ export function TableBlockContextMenu({
 
   const onCopyShareLink = async () => {
     if (!globalRankingSharePath) return;
-    try {
-      await onPrepareGlobalShareLink?.();
-    } catch (error) {
-      console.error('Failed to prepare global ranking share image:', error);
-    }
+    // Write to the clipboard first, inside the click's user activation. Awaiting the
+    // OG image pre-warm here would burn the activation and the clipboard write would
+    // be silently denied. The short link doesn't depend on the image existing, so the
+    // pre-warm runs in the background (and is already kicked off on menu open).
     const copied = await copyRankingShareLink(buildAbsoluteRankingShareUrl(globalRankingSharePath));
+    void Promise.resolve(onPrepareGlobalShareLink?.()).catch(error => {
+      console.error('Failed to prepare global ranking share image:', error);
+    });
     if (copied) {
       setIsMenuOpen(false);
       setIsEditingProperties(false);

--- a/apps/web/partials/blocks/table/use-ranking-block-state.ts
+++ b/apps/web/partials/blocks/table/use-ranking-block-state.ts
@@ -11,7 +11,6 @@ import { PAGE_SIZE, useDataBlock } from '~/core/blocks/data/use-data-block';
 import { useFilters } from '~/core/blocks/data/use-filters';
 import { loadLocalMyRankingDraft, saveLocalMyRankingDraft } from '~/core/blocks/ranking/local-ranking-my-draft';
 import {
-  RANKING_COMPOSE_TAB_GLOBAL,
   RANKING_COMPOSE_TAB_MY,
   type RankingComposeMode,
   rankingComposeHref,
@@ -26,7 +25,8 @@ import { formatRankingPeriodLabel, getRankingPeriodState } from '~/core/blocks/r
 import { getRowDescription, getRowDisplayName } from '~/core/blocks/ranking/ranking-rankable-list';
 import {
   buildAbsoluteRankingShareUrl,
-  buildRankingSharePath,
+  buildShortGlobalRankingSharePath,
+  buildShortPersonalRankingSharePath,
   shareRankingOnX,
 } from '~/core/blocks/ranking/ranking-share';
 import { useRankingBlockDates } from '~/core/blocks/ranking/use-ranking-block-dates';
@@ -556,20 +556,12 @@ export function useRankingBlockState({
       }),
     [displayName, entityId, globalRankingEntityIds, rankingEndDate, rankingStartDate]
   );
+  // Short, opaque deep link — the `/r/{rankEntityId}` resolver reconstructs the
+  // block, dates, placement, ogVersion and tab server-side. Gating stays the same
+  // so the share button's visibility is unchanged.
   const personalSharePath =
     shareRankEntityId && shareAuthorSpaceId && effectiveRelationId
-      ? buildRankingSharePath({
-          spaceId,
-          blockEntityId: entityId,
-          relationId: effectiveRelationId,
-          parentEntityId,
-          rankingStartDate,
-          rankingEndDate,
-          rankEntityId: shareRankEntityId,
-          authorSpaceId: shareAuthorSpaceId,
-          ...(effectiveOgVersion ? { ogVersion: effectiveOgVersion } : {}),
-          tab: RANKING_COMPOSE_TAB_MY,
-        })
+      ? buildShortPersonalRankingSharePath(shareRankEntityId)
       : null;
   const canSharePersonalRanking = Boolean(personalSharePath && !isSharedRankingView && hasMySubmission);
 
@@ -595,21 +587,17 @@ export function useRankingBlockState({
     spaceId,
   ]);
 
-  const [isPreparingPersonalShare, setIsPreparingPersonalShare] = React.useState(false);
-
   const sharePersonalRanking = React.useCallback(() => {
-    if (!personalSharePath || isPreparingPersonalShare) return;
+    if (!personalSharePath) return;
     const shareUrl = buildAbsoluteRankingShareUrl(personalSharePath);
-    const shareText = `I just published my "${displayName}" ranking. Check it out and add your vote 🔮`;
-
-    setIsPreparingPersonalShare(true);
-    void ensurePersonalRankingOg()
-      .catch(() => {})
-      .finally(() => {
-        setIsPreparingPersonalShare(false);
-        shareRankingOnX(shareUrl, shareText);
-      });
-  }, [displayName, ensurePersonalRankingOg, isPreparingPersonalShare, personalSharePath]);
+    const shareText = `Here's my ${name?.trim() || 'ranking'}. What's yours?`;
+    // Open X within the click's user activation — popup blockers drop window.open
+    // after an await. The OG image is pre-warmed in the background (and the share
+    // route falls back to a live preview render if the R2 object isn't ready yet),
+    // so the card still resolves even if the user posts immediately.
+    shareRankingOnX(shareUrl, shareText);
+    void ensurePersonalRankingOg().catch(() => {});
+  }, [name, ensurePersonalRankingOg, personalSharePath]);
 
   // Generate the personal OG image
   React.useEffect(() => {
@@ -620,18 +608,7 @@ export function useRankingBlockState({
     return () => window.clearTimeout(timer);
   }, [canSharePersonalRanking, effectiveOgVersion, ensurePersonalRankingOg]);
 
-  const globalSharePath = effectiveRelationId
-    ? buildRankingSharePath({
-        spaceId,
-        blockEntityId: entityId,
-        relationId: effectiveRelationId,
-        parentEntityId,
-        rankingStartDate,
-        rankingEndDate,
-        tab: RANKING_COMPOSE_TAB_GLOBAL,
-        ...(effectiveGlobalOgVersion ? { globalOgVersion: effectiveGlobalOgVersion } : {}),
-      })
-    : null;
+  const globalSharePath = effectiveRelationId ? buildShortGlobalRankingSharePath(entityId) : null;
 
   const ensureGlobalRankingOg = React.useCallback(async () => {
     if (!effectiveGlobalOgVersion) return;
@@ -702,7 +679,6 @@ export function useRankingBlockState({
     showEditRankingButton,
     canSharePersonalRanking,
     sharePersonalRanking,
-    isPreparingPersonalShare,
     globalSharePath,
     ensureGlobalRankingOg,
     personalSharePath,


### PR DESCRIPTION
Replace the long, param-heavy ranking share URL with short, opaque deep links that reconstruct everything server-side from a single ID:

- /r/{rankEntityId}  (personal)
- /r/g/{blockEntityId} (global)

New resolver (resolve-ranking-share.ts) resolves author space, block, date window, placement (BLOCKS reverse-lookup), OG card data, and a recomputed ogVersion that mirrors the publish-flow inputs so the pre-generated R2 image is hit. A shared OG-metadata builder (ranking-og-metadata.ts) is reused by both the new routes and the existing ranking-compose route (dedupe). Short routes use R2-first with a live preview fallback, so the social card resolves even when the ranking changed since publish. The long route stays for backward compat.

Also harden the share actions to run inside the click's user activation (clipboard write / window.open were being denied after the ~5s OG pre-warm await) and prefill the X tweet text with the ranking name.

Tests: resolve-ranking-share + ranking-og-metadata unit tests.