### PR TITLE
fix(rankings): SSR-seed personal share pages to stop first-paint flashing

### DIFF
--- a/apps/web/app/r/[rankEntityId]/page.tsx
+++ b/apps/web/app/r/[rankEntityId]/page.tsx
@@ -37,6 +37,11 @@ export default async function ShortPersonalRankingPage({ params }: Props) {
       rankEntityId={resolved.rankEntityId}
       authorSpaceId={resolved.authorSpaceId}
       ogVersion={resolved.ogVersion}
+      initialSharedRanking={{
+        rankingName: resolved.rankingName,
+        orderedEntityIds: resolved.orderedEntityIds,
+        entries: resolved.entries,
+      }}
     />
   );
 }

--- a/apps/web/app/space/(entity)/[id]/[entityId]/ranking-compose/ranking-compose-client-page.tsx
+++ b/apps/web/app/space/(entity)/[id]/[entityId]/ranking-compose/ranking-compose-client-page.tsx
@@ -14,7 +14,7 @@ import { EntityStoreProvider } from '~/core/state/entity-page-store/entity-store
 
 import { RankingComposeScreen } from '~/partials/blocks/table/ranking-compose-screen';
 import { RankingViewScreen } from '~/partials/blocks/table/ranking-view-screen';
-import { type InitialGlobalRanking } from '~/partials/blocks/table/use-ranking-block-state';
+import { type InitialGlobalRanking, type InitialSharedRanking } from '~/partials/blocks/table/use-ranking-block-state';
 
 type Props = {
   spaceId: string;
@@ -28,6 +28,7 @@ type Props = {
   authorSpaceId?: string;
   ogVersion?: string;
   initialGlobalRanking?: InitialGlobalRanking;
+  initialSharedRanking?: InitialSharedRanking;
 };
 
 function RankingComposeLoadingState({ message }: { message: string }) {
@@ -50,6 +51,7 @@ export function RankingComposeClientPage({
   authorSpaceId = '',
   ogVersion = '',
   initialGlobalRanking,
+  initialSharedRanking,
 }: Props) {
   const { hasValidParams, isLoading, parentEntityId, blocks, blockRelations } = useRankingComposePage({
     spaceId,
@@ -67,7 +69,7 @@ export function RankingComposeClientPage({
 
   // Seeded view pages render immediately instead of waiting on the client block
   // resolution; the live store reconciles in the background with no visible swap.
-  const hasSeededRanking = mode === 'view' && initialGlobalRanking != null;
+  const hasSeededRanking = mode === 'view' && (initialGlobalRanking != null || initialSharedRanking != null);
 
   if (!hasValidParams) {
     return <RankingComposeLoadingState message="Invalid parameters" />;
@@ -103,6 +105,7 @@ export function RankingComposeClientPage({
               authorSpaceId={authorSpaceId}
               ogVersion={ogVersion}
               initialGlobalRanking={initialGlobalRanking}
+              initialSharedRanking={initialSharedRanking}
             />
           ) : (
             <RankingComposeScreen

--- a/apps/web/core/blocks/ranking/ranking-og-metadata.test.ts
+++ b/apps/web/core/blocks/ranking/ranking-og-metadata.test.ts
@@ -35,6 +35,8 @@ const personalResolved: ResolvedPersonalRankingShare = {
     author: { name: 'Alice', avatarUrl: null, avatarSeed: 'seed' },
     entries: [],
   },
+  orderedEntityIds: [],
+  entries: [],
 };
 
 const globalResolved: ResolvedGlobalRankingShare = {
@@ -59,6 +61,8 @@ const globalResolved: ResolvedGlobalRankingShare = {
     author: { name: '', avatarUrl: null, avatarSeed: 'block-1' },
     entries: [],
   },
+  orderedEntityIds: [],
+  entries: [],
 };
 
 describe('buildPersonalRankingMetadataFromParts', () => {

--- a/apps/web/core/blocks/ranking/resolve-ranking-share.test.ts
+++ b/apps/web/core/blocks/ranking/resolve-ranking-share.test.ts
@@ -243,6 +243,38 @@ describe('resolvePersonalRankingShareImpl', () => {
     expect(resolved?.rankingEndDate).toBe('');
   });
 
+  it('resolves the full ordered list with display data to seed first paint', async () => {
+    const resolved = await resolvePersonalRankingShareImpl(
+      RANK_ID,
+      personalDeps({
+        fetchEntities: async ids =>
+          ids.map(id => ({
+            id,
+            name: id === 'ent-a' ? 'Alpha' : 'Beta',
+            description: id === 'ent-a' ? 'first' : null,
+            relations: [],
+            values: [],
+          })) as unknown as Entity[],
+      })
+    );
+
+    expect(resolved?.orderedEntityIds).toEqual(['ent-a', 'ent-b']);
+    expect(resolved?.entries).toEqual([
+      { entityId: 'ent-a', name: 'Alpha', description: 'first', image: null },
+      { entityId: 'ent-b', name: 'Beta', description: null, image: null },
+    ]);
+  });
+
+  it('falls back to "Untitled" entries when entity details are missing', async () => {
+    const resolved = await resolvePersonalRankingShareImpl(RANK_ID, personalDeps({ fetchEntities: async () => [] }));
+
+    expect(resolved?.orderedEntityIds).toEqual(['ent-a', 'ent-b']);
+    expect(resolved?.entries).toEqual([
+      { entityId: 'ent-a', name: 'Untitled', description: null, image: null },
+      { entityId: 'ent-b', name: 'Untitled', description: null, image: null },
+    ]);
+  });
+
   it('returns null for an invalid id', async () => {
     const resolved = await resolvePersonalRankingShareImpl('not-a-uuid', personalDeps());
     expect(resolved).toBeNull();

--- a/apps/web/core/blocks/ranking/resolve-ranking-share.ts
+++ b/apps/web/core/blocks/ranking/resolve-ranking-share.ts
@@ -43,6 +43,9 @@ export type ResolvedPersonalRankingShare = {
   /** Recomputed to match the publish-time inputs so the R2 fast path hits. */
   ogVersion: string;
   cardData: RankingOgCardData;
+  /** Full ordered ranking, resolved server-side so the shared ranking renders all rows on first paint. */
+  orderedEntityIds: string[];
+  entries: RankingOgEntryData[];
 };
 
 export type ResolvedGlobalRankingShare = {
@@ -213,6 +216,23 @@ export async function resolvePersonalRankingShareImpl(
   // 6. Resolve placement for back-navigation / vote / "add my ranking".
   const { parentEntityId, relationId } = await resolveBlockPlacement(deps, blockEntityId, blockEntitySpaceId);
 
+  // 7. Resolve the full ordered ranking (names + images) server-side so the
+  //    shared view paints every row immediately instead of cascading through
+  //    "loading" -> "empty" -> "Untitled" -> resolved on the client. Shape
+  //    matches the client's RankingEntryDisplay so seeded rows reconcile against
+  //    the live query without a swap (mirrors the global resolver).
+  const rankedEntities = await deps.fetchEntities(orderedEntityIds, blockEntitySpaceId);
+  const rankedEntityById = new Map(rankedEntities.map(e => [e.id, e]));
+  const entries: RankingOgEntryData[] = orderedEntityIds.map(id => {
+    const entity = rankedEntityById.get(id);
+    return {
+      entityId: id,
+      name: entity?.name?.trim() || 'Untitled',
+      description: entity?.description?.trim() || null,
+      image: Entities.avatar(entity?.relations) ?? Entities.cover(entity?.relations) ?? null,
+    };
+  });
+
   return {
     kind: 'personal',
     rankEntityId,
@@ -227,6 +247,8 @@ export async function resolvePersonalRankingShareImpl(
     authorName,
     ogVersion,
     cardData,
+    orderedEntityIds,
+    entries,
   };
 }
 

--- a/apps/web/partials/blocks/table/ranking-table-view.tsx
+++ b/apps/web/partials/blocks/table/ranking-table-view.tsx
@@ -8,7 +8,7 @@ import { Text } from '~/design-system/text';
 
 import { RankingBlockBody } from './ranking-block-body';
 import { RankingPeriodMetadata } from './ranking-period-metadata';
-import { type InitialGlobalRanking, useRankingBlockState } from './use-ranking-block-state';
+import { type InitialGlobalRanking, type InitialSharedRanking, useRankingBlockState } from './use-ranking-block-state';
 
 type Props = {
   spaceId: string;
@@ -18,6 +18,7 @@ type Props = {
   authorSpaceId?: string;
   ogVersion?: string;
   initialGlobalRanking?: InitialGlobalRanking;
+  initialSharedRanking?: InitialSharedRanking;
 };
 
 /** Fullscreen ranking browse view with compose-aligned title and metadata typography. */
@@ -29,6 +30,7 @@ export function RankingTableView({
   authorSpaceId = '',
   ogVersion = '',
   initialGlobalRanking,
+  initialSharedRanking,
 }: Props) {
   const isMobile = useIsMobileLayout();
   const state = useRankingBlockState({
@@ -39,6 +41,7 @@ export function RankingTableView({
     sharedAuthorSpaceId: authorSpaceId,
     sharedOgVersion: ogVersion,
     initialGlobalRanking,
+    initialSharedRanking,
   });
   const {
     displayName,

--- a/apps/web/partials/blocks/table/ranking-view-screen.tsx
+++ b/apps/web/partials/blocks/table/ranking-view-screen.tsx
@@ -6,7 +6,7 @@ import { useIsMobileLayout } from '~/core/hooks/use-is-mobile-layout';
 
 import { RankingComposeFullscreen } from './ranking-compose-fullscreen';
 import { RankingTableView } from './ranking-table-view';
-import { type InitialGlobalRanking } from './use-ranking-block-state';
+import { type InitialGlobalRanking, type InitialSharedRanking } from './use-ranking-block-state';
 
 type Props = {
   spaceId: string;
@@ -16,6 +16,7 @@ type Props = {
   authorSpaceId?: string;
   ogVersion?: string;
   initialGlobalRanking?: InitialGlobalRanking;
+  initialSharedRanking?: InitialSharedRanking;
 };
 
 /** Fullscreen ranking browse view — compose-aligned typography, separate from the embedded block. */
@@ -27,6 +28,7 @@ export function RankingViewScreen({
   authorSpaceId = '',
   ogVersion = '',
   initialGlobalRanking,
+  initialSharedRanking,
 }: Props) {
   const isMobile = useIsMobileLayout();
 
@@ -46,6 +48,7 @@ export function RankingViewScreen({
           authorSpaceId={authorSpaceId}
           ogVersion={ogVersion}
           initialGlobalRanking={initialGlobalRanking}
+          initialSharedRanking={initialSharedRanking}
         />
       </div>
     </RankingComposeFullscreen>

--- a/apps/web/partials/blocks/table/use-ranking-block-state.ts
+++ b/apps/web/partials/blocks/table/use-ranking-block-state.ts
@@ -86,6 +86,11 @@ type UseRankingBlockStateParams = {
   initialSharedRanking?: InitialSharedRanking;
 };
 
+// Stable empty fallbacks so absent SSR seeds don't produce a fresh `[]` each
+// render, which would defeat the `useMemo`s that depend on these values.
+const EMPTY_ENTITY_IDS: string[] = [];
+const EMPTY_RANKING_ENTRIES: RankingEntryDisplay[] = [];
+
 export function useRankingBlockState({
   spaceId,
   rankingStartDate = '',
@@ -147,10 +152,10 @@ export function useRankingBlockState({
 
   const { globalRankingEntityIds, aggregatedSubmitterSpaceIds, aggregatedRankingCount } = useRankingBlockRelations();
 
-  const initialOrderedIds = initialGlobalRanking?.orderedEntityIds ?? [];
-  const initialGlobalEntries = initialGlobalRanking?.entries ?? [];
-  const initialSharedOrderedIds = initialSharedRanking?.orderedEntityIds ?? [];
-  const initialSharedEntries = initialSharedRanking?.entries ?? [];
+  const initialOrderedIds = initialGlobalRanking?.orderedEntityIds ?? EMPTY_ENTITY_IDS;
+  const initialGlobalEntries = initialGlobalRanking?.entries ?? EMPTY_RANKING_ENTRIES;
+  const initialSharedOrderedIds = initialSharedRanking?.orderedEntityIds ?? EMPTY_ENTITY_IDS;
+  const initialSharedEntries = initialSharedRanking?.entries ?? EMPTY_RANKING_ENTRIES;
 
   const { smartAccount } = useSmartAccount();
   const walletAddress = smartAccount?.account.address;

--- a/apps/web/partials/blocks/table/use-ranking-block-state.ts
+++ b/apps/web/partials/blocks/table/use-ranking-block-state.ts
@@ -61,6 +61,17 @@ export type InitialGlobalRanking = {
   entries: RankingEntryDisplay[];
 };
 
+/**
+ * Server-resolved shared submission (a personal `/r/{rankEntityId}` link). Seeds
+ * the my/shared ranking list so the page paints every row with real names on
+ * first paint instead of cascading loading -> empty -> "Untitled" -> resolved.
+ */
+export type InitialSharedRanking = {
+  rankingName: string;
+  orderedEntityIds: string[];
+  entries: RankingEntryDisplay[];
+};
+
 type UseRankingBlockStateParams = {
   spaceId: string;
   rankingStartDate?: string;
@@ -71,6 +82,8 @@ type UseRankingBlockStateParams = {
   sharedOgVersion?: string;
   /** Server-resolved full ranking, seeds first paint so rows don't flash placeholders. */
   initialGlobalRanking?: InitialGlobalRanking;
+  /** Server-resolved shared submission, seeds the my/shared ranking on first paint. */
+  initialSharedRanking?: InitialSharedRanking;
 };
 
 export function useRankingBlockState({
@@ -82,6 +95,7 @@ export function useRankingBlockState({
   sharedAuthorSpaceId = '',
   sharedOgVersion = '',
   initialGlobalRanking,
+  initialSharedRanking,
 }: UseRankingBlockStateParams) {
   const isMobile = useIsMobileLayout();
   const router = useRouter();
@@ -108,7 +122,11 @@ export function useRankingBlockState({
     endDate: rankingEndDate,
   });
 
-  const displayName = name?.trim() || initialGlobalRanking?.rankingName?.trim() || 'Untitled ranking';
+  const displayName =
+    name?.trim() ||
+    initialGlobalRanking?.rankingName?.trim() ||
+    initialSharedRanking?.rankingName?.trim() ||
+    'Untitled ranking';
 
   const { submissions, hasMySubmission, mySubmission, saveMySubmission, isSaving, personalSpaceId } =
     useRankingSubmissions(entityId, spaceId, displayName);
@@ -131,6 +149,8 @@ export function useRankingBlockState({
 
   const initialOrderedIds = initialGlobalRanking?.orderedEntityIds ?? [];
   const initialGlobalEntries = initialGlobalRanking?.entries ?? [];
+  const initialSharedOrderedIds = initialSharedRanking?.orderedEntityIds ?? [];
+  const initialSharedEntries = initialSharedRanking?.entries ?? [];
 
   const { smartAccount } = useSmartAccount();
   const walletAddress = smartAccount?.account.address;
@@ -268,8 +288,10 @@ export function useRankingBlockState({
   const myDisplayEntityIds = React.useMemo(() => {
     if (myOrderIds.length > 0) return myOrderIds;
     if (hasSavedDraft) return myOrderIds;
-    return displayedSubmission?.orderedEntityIds ?? [];
-  }, [displayedSubmission, hasSavedDraft, myOrderIds]);
+    // Fall back to the server-resolved shared order until the live submission
+    // loads client-side, so the shared view doesn't flash an empty ranking.
+    return displayedSubmission?.orderedEntityIds ?? initialSharedOrderedIds;
+  }, [displayedSubmission, hasSavedDraft, myOrderIds, initialSharedOrderedIds]);
 
   const myRankingIdsKey = myDisplayEntityIds.join('|');
 
@@ -375,6 +397,12 @@ export function useRankingBlockState({
   const myRankingEntryByEntityId = React.useMemo(() => {
     const map = new Map<string, RankingEntryDisplay>();
 
+    // Seed from the server-resolved shared ranking; live `rows`/`myEntries`
+    // below override with the same data once they hydrate.
+    for (const entry of initialSharedEntries) {
+      map.set(entry.entityId, entry);
+    }
+
     for (const row of rows) {
       if (!row.entityId || row.placeholder) continue;
       map.set(row.entityId, {
@@ -396,7 +424,7 @@ export function useRankingBlockState({
     }
 
     return map;
-  }, [myEntries, rows]);
+  }, [myEntries, rows, initialSharedEntries]);
 
   const resolveEntitySpaceId = React.useCallback(
     (targetEntityId: string) => {


### PR DESCRIPTION
Personal /r/{rankEntityId} share pages flashed through 4 states (loading -> empty -> all-"Untitled" -> resolved) because SSR seeding (upstream #1895) was only wired into the global /r/g path.

Mirror the global seeding for the personal/shared path so the page paints the full ranking with real names on first paint:
- resolvePersonalRankingShare now returns orderedEntityIds + entries (full ordered list, names/images) via the existing fetchEntities dep
- pass initialSharedRanking through page -> client page -> view -> state
- extend hasSeededRanking to the personal seed (skips loading gate)
- useRankingBlockState seeds myDisplayEntityIds + myRankingEntryByEntityId