### PR TITLE
fix(ranking-og): allow taller ranking share titles

### DIFF
--- a/apps/web/core/blocks/ranking/ranking-og-image.tsx
+++ b/apps/web/core/blocks/ranking/ranking-og-image.tsx
@@ -220,14 +220,19 @@ function fitWrappedText(
   minFontSize: number,
   maxWidth: number,
   maxLines: number,
-  fallback: string
+  fallback: string,
+  options: { maxHeight?: number; lineHeight?: number } = {}
 ): WrappedTextFit {
   const normalized = normalizeDisplayText(text, fallback);
+  const { maxHeight = Infinity, lineHeight = 1 } = options;
 
   for (let fontSize = targetFontSize; fontSize >= minFontSize; fontSize -= 1) {
     const lines = wrapTextToLines(normalized, fontSize, maxWidth);
     const allLinesFit = lines.every(lineText => measureTextWidth(lineText, fontSize) <= maxWidth);
-    if (lines.length <= maxLines && allLinesFit) return { fontSize, lines };
+    const totalHeight = Math.ceil(lines.length * fontSize * lineHeight);
+    if (lines.length <= maxLines && allLinesFit && totalHeight <= maxHeight) {
+      return { fontSize, lines };
+    }
   }
 
   const wrappedLines = wrapTextToLines(normalized, minFontSize, maxWidth);
@@ -631,9 +636,21 @@ function EmptyRows({ variant, scale }: { variant: RankingOgVariant; scale: numbe
   );
 }
 
+const TITLE_LINE_HEIGHT = 0.95;
+const TITLE_MAX_HEIGHT_LANDSCAPE = 440;
+const TITLE_MAX_HEIGHT_STORY = 400;
+
 function TitleText({ title, variant, scale }: { title: string; variant: RankingOgVariant; scale: number }) {
   const isStory = variant === 'story';
-  const textFit = fitWrappedText(title, isStory ? 112 : 58, isStory ? 58 : 34, isStory ? 680 : 318, 5, 'My ranking');
+  const textFit = fitWrappedText(
+    title,
+    isStory ? 112 : 58,
+    isStory ? 58 : 34,
+    isStory ? 680 : 318,
+    5,
+    'My ranking',
+    { maxHeight: isStory ? TITLE_MAX_HEIGHT_STORY : TITLE_MAX_HEIGHT_LANDSCAPE, lineHeight: TITLE_LINE_HEIGHT }
+  );
 
   return (
     <div
@@ -643,7 +660,7 @@ function TitleText({ title, variant, scale }: { title: string; variant: RankingO
         flexDirection: 'column',
         fontSize: scaled(textFit.fontSize, scale),
         fontWeight: 800,
-        lineHeight: 0.95,
+        lineHeight: TITLE_LINE_HEIGHT,
       }}
     >
       {textFit.lines.map((lineText, index) => (
@@ -690,7 +707,7 @@ function Card({ data, variant }: { data: RankingOgCardData; variant: RankingOgVa
           style={{
             color: '#111111',
             display: 'flex',
-            maxHeight: scaled(isStory ? 400 : 440, scale),
+            maxHeight: scaled(isStory ? TITLE_MAX_HEIGHT_STORY : TITLE_MAX_HEIGHT_LANDSCAPE, scale),
             overflow: 'hidden',
           }}
         >

--- a/apps/web/core/blocks/ranking/ranking-og-image.tsx
+++ b/apps/web/core/blocks/ranking/ranking-og-image.tsx
@@ -690,7 +690,7 @@ function Card({ data, variant }: { data: RankingOgCardData; variant: RankingOgVa
           style={{
             color: '#111111',
             display: 'flex',
-            maxHeight: scaled(isStory ? 390 : 360, scale),
+            maxHeight: scaled(isStory ? 400 : 440, scale),
             overflow: 'hidden',
           }}
         >

--- a/apps/web/core/blocks/ranking/ranking-og-image.tsx
+++ b/apps/web/core/blocks/ranking/ranking-og-image.tsx
@@ -633,7 +633,7 @@ function EmptyRows({ variant, scale }: { variant: RankingOgVariant; scale: numbe
 
 function TitleText({ title, variant, scale }: { title: string; variant: RankingOgVariant; scale: number }) {
   const isStory = variant === 'story';
-  const textFit = fitWrappedText(title, isStory ? 112 : 58, isStory ? 58 : 34, isStory ? 680 : 318, 3, 'My ranking');
+  const textFit = fitWrappedText(title, isStory ? 112 : 58, isStory ? 58 : 34, isStory ? 680 : 318, 5, 'My ranking');
 
   return (
     <div
@@ -690,7 +690,7 @@ function Card({ data, variant }: { data: RankingOgCardData; variant: RankingOgVa
           style={{
             color: '#111111',
             display: 'flex',
-            maxHeight: scaled(isStory ? 330 : 190, scale),
+            maxHeight: scaled(isStory ? 390 : 360, scale),
             overflow: 'hidden',
           }}
         >


### PR DESCRIPTION
## Summary
- Raise the title wrapper `maxHeight` on ranking OG cards from `190/330` to `360/390` so longer wrapped titles aren't clipped.
- Raise the wrap cap in `TitleText` from 3 lines to 5 lines so multi-word titles (e.g. "Books everyone should read once") render fully on their own lines instead of being squeezed.

## Test plan
- [x] Preview the social share image for a ranking with a 4–5 word title and confirm the title fully renders without clipping
- [x] Check both landscape and story variants
- [x] Verify short titles still look correct