### PR TITLE
fix(ranking-og): prevent last-line clipping in title

### DIFF
--- a/apps/web/core/blocks/ranking/ranking-og-image.tsx
+++ b/apps/web/core/blocks/ranking/ranking-og-image.tsx
@@ -636,12 +636,14 @@ function EmptyRows({ variant, scale }: { variant: RankingOgVariant; scale: numbe
   );
 }
 
-const TITLE_LINE_HEIGHT = 0.95;
+const TITLE_LINE_HEIGHT = 1.05;
+const TITLE_BOTTOM_PADDING_RATIO = 0.12;
 const TITLE_MAX_HEIGHT_LANDSCAPE = 440;
 const TITLE_MAX_HEIGHT_STORY = 400;
 
 function TitleText({ title, variant, scale }: { title: string; variant: RankingOgVariant; scale: number }) {
   const isStory = variant === 'story';
+  const maxHeight = isStory ? TITLE_MAX_HEIGHT_STORY : TITLE_MAX_HEIGHT_LANDSCAPE;
   const textFit = fitWrappedText(
     title,
     isStory ? 112 : 58,
@@ -649,7 +651,7 @@ function TitleText({ title, variant, scale }: { title: string; variant: RankingO
     isStory ? 680 : 318,
     5,
     'My ranking',
-    { maxHeight: isStory ? TITLE_MAX_HEIGHT_STORY : TITLE_MAX_HEIGHT_LANDSCAPE, lineHeight: TITLE_LINE_HEIGHT }
+    { maxHeight, lineHeight: TITLE_LINE_HEIGHT + TITLE_BOTTOM_PADDING_RATIO }
   );
 
   return (
@@ -661,6 +663,7 @@ function TitleText({ title, variant, scale }: { title: string; variant: RankingO
         fontSize: scaled(textFit.fontSize, scale),
         fontWeight: 800,
         lineHeight: TITLE_LINE_HEIGHT,
+        paddingBottom: scaled(textFit.fontSize * TITLE_BOTTOM_PADDING_RATIO, scale),
       }}
     >
       {textFit.lines.map((lineText, index) => (


### PR DESCRIPTION
## Summary
The ranking OG title was rendering with `lineHeight: 0.95`, which is tighter than the font's natural vertical metrics. The last line's glyph extended below its line box and got clipped by the title wrapper's `overflow: hidden`.

- Raise `TITLE_LINE_HEIGHT` from `0.95` to `1.05` so the line box fully contains the glyph.
- Add `paddingBottom = fontSize * 0.12` to the title block so the last line has breathing room before the clip boundary.
- Include the same padding ratio in the height that the fitter uses for sizing, so long titles still scale down to fit.

## Test plan
- [ ] Regenerate the OG image for a 4–5 word landscape title (e.g. "Books everyone should read once") and confirm the last word is no longer clipped
- [ ] Check the story variant
- [ ] Sanity-check a short single-line title still renders without odd spacing