### PR TITLE
feat: add explore "Join spaces" panel with durable pending membership

### DIFF
--- a/apps/web/app/explore/page.tsx
+++ b/apps/web/app/explore/page.tsx
@@ -4,6 +4,7 @@ import type { BrowseSidebarData } from '~/core/browse/fetch-browse-sidebar-data'
 import { fetchBrowseSidebarData } from '~/core/browse/fetch-browse-sidebar-data';
 import { resolveMemberSpaceFromWalletSafe } from '~/core/browse/resolve-member-space-from-wallet';
 import { WALLET_ADDRESS } from '~/core/cookie';
+import { type FeaturedSpace, fetchFeaturedSpaces } from '~/core/io/subgraph/fetch-featured-spaces';
 import { type RootTopicChip, fetchFirstLevelSubtopics } from '~/core/io/subgraph/fetch-first-level-subtopics';
 import { type ParentTopicOption, fetchParentTopicOptions } from '~/core/io/subgraph/fetch-parent-topic-options';
 import { fetchActiveMemberRequest } from '~/core/io/subgraph/fetch-proposed-members';
@@ -38,19 +39,22 @@ export default async function ExploreRoutePage() {
     fetchBrowseSidebarData(null).catch(() => null)
   );
   const recentlyClaimedPromise = fetchRecentlyClaimedSpaces().catch(() => [] as RecentlyClaimedSpace[]);
+  const featuredSpacesPromise = fetchFeaturedSpaces().catch(() => [] as FeaturedSpace[]);
   const firstLevelSubtopicsPromise = fetchFirstLevelSubtopics().catch(() => [] as RootTopicChip[]);
   const parentTopicOptionsPromise = fetchParentTopicOptions().catch(() => [] as ParentTopicOption[]);
   const governancePromise = memberSpaceId
     ? getGovernanceHomeSpaceContext(memberSpaceId).catch(() => null)
     : Promise.resolve(null);
 
-  const [browseRaw, recentlyClaimedSpaces, firstLevelSubtopics, parentTopicOptions, governance] = await Promise.all([
-    browsePromise,
-    recentlyClaimedPromise,
-    firstLevelSubtopicsPromise,
-    parentTopicOptionsPromise,
-    governancePromise,
-  ]);
+  const [browseRaw, recentlyClaimedSpaces, featuredSpaces, firstLevelSubtopics, parentTopicOptions, governance] =
+    await Promise.all([
+      browsePromise,
+      recentlyClaimedPromise,
+      featuredSpacesPromise,
+      firstLevelSubtopicsPromise,
+      parentTopicOptionsPromise,
+      governancePromise,
+    ]);
 
   const browse: BrowseSidebarData = browseRaw ?? {
     featured: [],
@@ -66,19 +70,24 @@ export default async function ExploreRoutePage() {
       : [memberSpaceId]
     : [];
 
-  // For recently-claimed spaces the user isn't already part of, check whether they
-  // have an active ADD_MEMBER proposal so the Join button can render "Membership
-  // pending" without a client roundtrip.
+  // For featured + recently-claimed spaces the user isn't already part of, check
+  // whether they have an active ADD_MEMBER proposal so the Join button can render
+  // "Membership pending" without a client roundtrip.
   let pendingMembershipSpaceIds: string[] = [];
-  if (memberSpaceId && recentlyClaimedSpaces.length > 0) {
+  if (memberSpaceId) {
     const memberOrEditorSet = new Set(memberOrEditorSpaceIds.map(normId));
-    const candidates = recentlyClaimedSpaces.filter(s => !memberOrEditorSet.has(normId(s.spaceId)));
+    const candidateIds = new Map<string, string>();
+    for (const s of [...featuredSpaces, ...recentlyClaimedSpaces]) {
+      const normalized = normId(s.spaceId);
+      if (memberOrEditorSet.has(normalized) || candidateIds.has(normalized)) continue;
+      candidateIds.set(normalized, s.spaceId);
+    }
     const checks = await Promise.all(
-      candidates.map(async s => {
+      [...candidateIds.values()].map(async spaceId => {
         try {
           // Only an open vote is "pending"; a stuck request lets the Join button reappear.
-          const req = await fetchActiveMemberRequest(s.spaceId, memberSpaceId!);
-          return req != null && !req.isVotingEnded ? s.spaceId : null;
+          const req = await fetchActiveMemberRequest(spaceId, memberSpaceId!);
+          return req != null && !req.isVotingEnded ? spaceId : null;
         } catch {
           return null;
         }
@@ -99,6 +108,7 @@ export default async function ExploreRoutePage() {
   return (
     <ExplorePage
       initialSpaceOptions={initialSpaceOptions}
+      featuredSpaces={featuredSpaces}
       unclaimedTopics={firstLevelSubtopics}
       recentlyClaimedSpaces={recentlyClaimedSpaces}
       parentTopicOptions={parentTopicOptions}

--- a/apps/web/app/explore/page.tsx
+++ b/apps/web/app/explore/page.tsx
@@ -12,6 +12,7 @@ import {
   type RecentlyClaimedSpace,
   fetchRecentlyClaimedSpaces,
 } from '~/core/io/subgraph/fetch-recently-claimed-spaces';
+import { mapWithConcurrency } from '~/core/utils/map-with-concurrency';
 import { normId } from '~/core/utils/norm-id';
 
 import { ExplorePage } from '~/partials/explore/explore-page';
@@ -82,17 +83,17 @@ export default async function ExploreRoutePage() {
       if (memberOrEditorSet.has(normalized) || candidateIds.has(normalized)) continue;
       candidateIds.set(normalized, s.spaceId);
     }
-    const checks = await Promise.all(
-      [...candidateIds.values()].map(async spaceId => {
-        try {
-          // Only an open vote is "pending"; a stuck request lets the Join button reappear.
-          const req = await fetchActiveMemberRequest(spaceId, memberSpaceId!);
-          return req != null && !req.isVotingEnded ? spaceId : null;
-        } catch {
-          return null;
-        }
-      })
-    );
+    // Cap concurrency: with up to ~60 featured + recently-claimed candidates this
+    // is one REST call each, and an unbounded fan-out would burst the indexer.
+    const checks = await mapWithConcurrency([...candidateIds.values()], 8, async spaceId => {
+      try {
+        // Only an open vote is "pending"; a stuck request lets the Join button reappear.
+        const req = await fetchActiveMemberRequest(spaceId, memberSpaceId!);
+        return req != null && !req.isVotingEnded ? spaceId : null;
+      } catch {
+        return null;
+      }
+    });
     pendingMembershipSpaceIds = checks.filter((id): id is string => id !== null);
   }
 

--- a/apps/web/core/browse/fetch-browse-sidebar-data.ts
+++ b/apps/web/core/browse/fetch-browse-sidebar-data.ts
@@ -2,11 +2,13 @@ import * as Effect from 'effect/Effect';
 import * as Either from 'effect/Either';
 
 import { DOCUMENTATION_SPACE_ID, PLACEHOLDER_SPACE_IMAGE } from '~/core/constants';
-import { Environment } from '~/core/environment';
 import type { Space } from '~/core/io/dto/spaces';
 import { getSpaces, getSpacesWhereMember } from '~/core/io/queries';
 import { fetchEditorSpaceIds } from '~/core/io/subgraph/fetch-editor-space-ids';
-import { graphql } from '~/core/io/subgraph/graphql';
+import {
+  fetchPendingEditorshipSpaceIds,
+  fetchPendingMembershipSpaceIds,
+} from '~/core/io/subgraph/fetch-pending-membership-space-ids';
 import { sortSpaceListByRankNameId } from '~/core/utils/space/browse-space-list-sort';
 
 import { FEATURED_BROWSE_SPACES } from './featured-spaces';
@@ -77,68 +79,13 @@ async function fetchSpaceRows(ids: string[]): Promise<Map<string, BrowseSpaceRow
   return map;
 }
 
-type PendingSpaceIdsResult = {
-  pendingMember: { nodes: { spaceId: string }[] };
-  pendingEditor: { nodes: { spaceId: string }[] };
-};
-
-function pendingSpaceIdsQuery(memberSpaceId: string, nowSec: string): string {
-  return `query {
-    pendingMember: proposalsConnection(
-      first: 100
-      filter: {
-        executedAt: { isNull: true }
-        endTime: { greaterThanOrEqualTo: "${nowSec}" }
-        proposalActionsConnection: {
-          some: {
-            actionType: { is: ADD_MEMBER }
-            targetId: { is: "${memberSpaceId}" }
-          }
-        }
-      }
-    ) {
-      nodes { spaceId }
-    }
-    pendingEditor: proposalsConnection(
-      first: 100
-      filter: {
-        executedAt: { isNull: true }
-        endTime: { greaterThanOrEqualTo: "${nowSec}" }
-        proposalActionsConnection: {
-          some: {
-            actionType: { is: ADD_EDITOR }
-            targetId: { is: "${memberSpaceId}" }
-          }
-        }
-      }
-    ) {
-      nodes { spaceId }
-    }
-  }`;
-}
-
 async function fetchBrowseSidebarSources(memberSpaceId: string) {
-  const nowSec = String(Math.floor(Date.now() / 1000));
-
-  const [editorIds, memberSpaces, pendingResult] = await Promise.all([
+  const [editorIds, memberSpaces, pendingMemberIds, pendingEditorIds] = await Promise.all([
     fetchEditorSpaceIds(memberSpaceId),
     Effect.runPromise(getSpacesWhereMember(memberSpaceId)),
-    Effect.runPromise(
-      Effect.either(
-        graphql<PendingSpaceIdsResult>({
-          endpoint: Environment.getConfig().api,
-          query: pendingSpaceIdsQuery(memberSpaceId, nowSec),
-        })
-      )
-    ),
+    fetchPendingMembershipSpaceIds(memberSpaceId).catch(() => [] as string[]),
+    fetchPendingEditorshipSpaceIds(memberSpaceId).catch(() => [] as string[]),
   ]);
-
-  const pendingMemberIds = Either.isRight(pendingResult)
-    ? (pendingResult.right.pendingMember?.nodes ?? []).map(n => n.spaceId)
-    : [];
-  const pendingEditorIds = Either.isRight(pendingResult)
-    ? (pendingResult.right.pendingEditor?.nodes ?? []).map(n => n.spaceId)
-    : [];
 
   return { editorIds, memberSpaces, pendingMemberIds, pendingEditorIds };
 }

--- a/apps/web/core/hooks/use-pending-memberships.ts
+++ b/apps/web/core/hooks/use-pending-memberships.ts
@@ -1,0 +1,67 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+
+import * as React from 'react';
+
+import { useAtomValue } from 'jotai';
+
+import { usePersonalSpaceId } from '~/core/hooks/use-personal-space-id';
+import { fetchPendingMembershipSpaceIds } from '~/core/io/subgraph/fetch-pending-membership-space-ids';
+import {
+  requestedMembershipIdSet,
+  requestedMembershipSpacesAtom,
+  requestedSpacesForOwner,
+} from '~/core/state/requested-membership';
+import { normId } from '~/core/utils/norm-id';
+
+export function pendingMembershipsQueryKey(memberSpaceId: string | null | undefined) {
+  return ['pending-memberships', memberSpaceId ?? null] as const;
+}
+
+/**
+ * Durable source of truth for every space the signed-in user has a pending
+ * membership request in. Backed by {@link fetchPendingMembershipSpaceIds} and
+ * keyed by personal space id so it survives refreshes and is invalidated by
+ * {@link useRequestToBeMember} after a new request lands.
+ */
+export function usePendingMembershipSpaceIds() {
+  const { personalSpaceId } = usePersonalSpaceId();
+
+  const { data } = useQuery({
+    queryKey: pendingMembershipsQueryKey(personalSpaceId),
+    queryFn: () => (personalSpaceId ? fetchPendingMembershipSpaceIds(personalSpaceId) : Promise.resolve([])),
+    enabled: !!personalSpaceId,
+    staleTime: 30_000,
+  });
+
+  return React.useMemo(() => new Set(data ?? []), [data]);
+}
+
+/**
+ * Combined pending set: the durable server query unioned with the optimistic,
+ * persisted local atom (which bridges indexer lag right after a request). All
+ * ids are normalized.
+ */
+export function usePendingMembershipSet(): Set<string> {
+  const { personalSpaceId } = usePersonalSpaceId();
+  const serverSet = usePendingMembershipSpaceIds();
+  const requested = useAtomValue(requestedMembershipSpacesAtom);
+
+  return React.useMemo(() => {
+    const combined = new Set(serverSet);
+    // Only this account's optimistic entries — never a signed-out user's or a
+    // prior account's leftover localStorage state.
+    for (const id of requestedMembershipIdSet(requestedSpacesForOwner(requested, personalSpaceId))) {
+      combined.add(id);
+    }
+    return combined;
+  }, [serverSet, requested, personalSpaceId]);
+}
+
+/** Whether the given space currently has a pending membership request for the user. */
+export function useIsMembershipPending(spaceId: string | null | undefined): boolean {
+  const pendingSet = usePendingMembershipSet();
+  if (!spaceId) return false;
+  return pendingSet.has(normId(spaceId));
+}

--- a/apps/web/core/hooks/use-pending-memberships.ts
+++ b/apps/web/core/hooks/use-pending-memberships.ts
@@ -9,9 +9,9 @@ import { useAtomValue } from 'jotai';
 import { usePersonalSpaceId } from '~/core/hooks/use-personal-space-id';
 import { fetchPendingMembershipSpaceIds } from '~/core/io/subgraph/fetch-pending-membership-space-ids';
 import {
+  activeRequestedSpacesForOwner,
   requestedMembershipIdSet,
   requestedMembershipSpacesAtom,
-  requestedSpacesForOwner,
 } from '~/core/state/requested-membership';
 import { normId } from '~/core/utils/norm-id';
 
@@ -50,11 +50,11 @@ export function usePendingMembershipSet(): Set<string> {
 
   return React.useMemo(() => {
     const combined = new Set(serverSet);
-    // Only this account's optimistic entries — never a signed-out user's or a
-    // prior account's leftover localStorage state.
-    for (const id of requestedMembershipIdSet(requestedSpacesForOwner(requested, personalSpaceId))) {
-      combined.add(id);
-    }
+    // Only this account's still-active optimistic entries — never a signed-out
+    // user's or prior account's leftover state, and never an expired bridge
+    // entry (so a later-rejected request stops showing as pending).
+    const active = activeRequestedSpacesForOwner(requested, personalSpaceId, Date.now());
+    for (const id of requestedMembershipIdSet(active)) combined.add(id);
     return combined;
   }, [serverSet, requested, personalSpaceId]);
 }

--- a/apps/web/core/hooks/use-request-to-be-member.ts
+++ b/apps/web/core/hooks/use-request-to-be-member.ts
@@ -117,6 +117,7 @@ export function useRequestToBeMember({ spaceId, space }: UseRequestToBeMemberArg
         upsertRequestedMembershipSpace(prev, {
           id: spaceId,
           ownerId: personalSpaceId,
+          requestedAt: Date.now(),
           name: space?.name,
           image: space?.image,
         })

--- a/apps/web/core/hooks/use-request-to-be-member.ts
+++ b/apps/web/core/hooks/use-request-to-be-member.ts
@@ -1,11 +1,12 @@
 'use client';
 
 import { daoSpace } from '@geoprotocol/geo-sdk';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { useCallback } from 'react';
 
 import { Effect, Either } from 'effect';
+import { useSetAtom } from 'jotai';
 
 import { normalizeSpaceId } from '~/core/access/space-access';
 import { usePersonalSpaceId } from '~/core/hooks/use-personal-space-id';
@@ -13,6 +14,7 @@ import { useSmartAccount } from '~/core/hooks/use-smart-account';
 import { useSmartAccountTransaction } from '~/core/hooks/use-smart-account-transaction';
 import { getIsEditorOfSpace, getIsMemberOfSpace } from '~/core/io/queries';
 import { usePendingPersonalSpace } from '~/core/state/pending-personal-space';
+import { requestedMembershipSpacesAtom, upsertRequestedMembershipSpace } from '~/core/state/requested-membership';
 import { useStatusBar } from '~/core/state/status-bar-store';
 import { runEffectEither } from '~/core/telemetry/effect-runtime';
 import { SPACE_REGISTRY_ADDRESS } from '~/core/utils/contracts/space-registry';
@@ -21,14 +23,18 @@ import { validateSpaceId } from '~/core/utils/utils';
 interface UseRequestToBeMemberArgs {
   /** The space ID (bytes16 hex without 0x, e.g., UUID format) of the space to join */
   spaceId: string | null;
+  /** Optional display data so the optimistic "pending" row can render a name/image immediately. */
+  space?: { name?: string; image?: string | null };
 }
 
-export function useRequestToBeMember({ spaceId }: UseRequestToBeMemberArgs) {
+export function useRequestToBeMember({ spaceId, space }: UseRequestToBeMemberArgs) {
   const { dispatch } = useStatusBar();
 
   const { smartAccount } = useSmartAccount();
   const { personalSpaceId, isRegistered } = usePersonalSpaceId();
   const { isPending: isAccountSetupPending } = usePendingPersonalSpace();
+  const queryClient = useQueryClient();
+  const setRequestedSpaces = useSetAtom(requestedMembershipSpacesAtom);
 
   const tx = useSmartAccountTransaction({
     address: SPACE_REGISTRY_ADDRESS,
@@ -100,6 +106,25 @@ export function useRequestToBeMember({ spaceId }: UseRequestToBeMemberArgs) {
 
   const { mutate, status } = useMutation({
     mutationFn: handleRequestToBeMember,
+    onSuccess: () => {
+      // personalSpaceId is guaranteed here (the request would have thrown without
+      // it); the guard also scopes the persisted entry to this account.
+      if (!spaceId || !personalSpaceId) return;
+      // Optimistic, persisted bridge so the "Membership pending" state shows
+      // instantly (and survives a refresh) regardless of where the request was
+      // made, while the indexer catches up.
+      setRequestedSpaces(prev =>
+        upsertRequestedMembershipSpace(prev, {
+          id: spaceId,
+          ownerId: personalSpaceId,
+          name: space?.name,
+          image: space?.image,
+        })
+      );
+      // Refetch the durable sources so every surface converges on the server state.
+      queryClient.invalidateQueries({ queryKey: ['pending-memberships'] });
+      queryClient.invalidateQueries({ queryKey: ['browse-sidebar-data'] });
+    },
   });
 
   return {

--- a/apps/web/core/io/subgraph/fetch-featured-spaces.test.ts
+++ b/apps/web/core/io/subgraph/fetch-featured-spaces.test.ts
@@ -1,0 +1,133 @@
+import { Effect } from 'effect';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { fetchFeaturedSpaces } from './fetch-featured-spaces';
+
+const graphqlMock = vi.fn();
+
+vi.mock('~/core/environment', () => ({
+  Environment: {
+    getConfig: () => ({ api: 'https://example.com/graphql', bundler: '', chainId: '19411', rpc: '' }),
+  },
+}));
+
+vi.mock('./graphql', () => ({
+  graphql: (...args: unknown[]) => graphqlMock(...args),
+}));
+
+// Curated rank ids (from space-ranking): Crypto=2, AI=3.
+const AI_SPACE = '41e851610e13a19441c4d980f2f2ce6b';
+const CRYPTO_SPACE = 'c9f267dcb0d270718c2a3c45a64afd32';
+
+function spaceNode(id: string, name: string) {
+  return { id, page: { id: `page-${id}`, name, relationsList: [] }, members: { totalCount: 1 } };
+}
+
+function query(arg: unknown): string {
+  return (arg as { query?: string } | undefined)?.query ?? '';
+}
+
+describe('fetchFeaturedSpaces', () => {
+  beforeEach(() => graphqlMock.mockReset());
+
+  it('walks the subtopic tree, excludes the root topic, and orders by space rank', async () => {
+    // Tree: root t0 -> [t1 (AI space), t2 (no space) -> t3 (Crypto space)].
+    // BFS discovers AI before Crypto, but the result must be rank-sorted (Crypto 2, AI 3).
+    graphqlMock.mockImplementation((arg: unknown) => {
+      const q = query(arg);
+      if (q.includes('space(id:')) return Effect.succeed({ space: { topicId: 't0' } });
+      if (q.includes('"t3"')) {
+        return Effect.succeed({
+          entities: [
+            {
+              id: 't3',
+              name: 'Crypto',
+              spacesByTopicIdConnection: { totalCount: 1, nodes: [spaceNode(CRYPTO_SPACE, 'Crypto')] },
+              subtopics: [],
+            },
+          ],
+        });
+      }
+      if (q.includes('"t1"')) {
+        return Effect.succeed({
+          entities: [
+            {
+              id: 't1',
+              name: 'AI',
+              spacesByTopicIdConnection: { totalCount: 1, nodes: [spaceNode(AI_SPACE, 'AI')] },
+              subtopics: [],
+            },
+            {
+              id: 't2',
+              name: 'Science',
+              spacesByTopicIdConnection: { totalCount: 0, nodes: [] },
+              subtopics: [{ toEntity: { id: 't3' } }],
+            },
+          ],
+        });
+      }
+      // Root topic frontier (t0): no space of its own, two children.
+      return Effect.succeed({
+        entities: [
+          {
+            id: 't0',
+            name: 'Geo',
+            spacesByTopicIdConnection: { totalCount: 0, nodes: [] },
+            subtopics: [{ toEntity: { id: 't1' } }, { toEntity: { id: 't2' } }],
+          },
+        ],
+      });
+    });
+
+    const result = await fetchFeaturedSpaces();
+
+    expect(result.map(r => r.spaceId)).toEqual([CRYPTO_SPACE, AI_SPACE]);
+    expect(result.map(r => r.name)).toEqual(['Crypto', 'AI']);
+    // Root topic ("Geo") is only a seed — never featured.
+    expect(result.some(r => r.name === 'Geo')).toBe(false);
+  });
+
+  it('dedupes a space that claims more than one topic', async () => {
+    graphqlMock.mockImplementation((arg: unknown) => {
+      const q = query(arg);
+      if (q.includes('space(id:')) return Effect.succeed({ space: { topicId: 't0' } });
+      if (q.includes('"t1"')) {
+        // Both children resolve to the same claiming space.
+        return Effect.succeed({
+          entities: [
+            {
+              id: 't1',
+              name: 'AI',
+              spacesByTopicIdConnection: { totalCount: 1, nodes: [spaceNode(AI_SPACE, 'AI')] },
+              subtopics: [],
+            },
+            {
+              id: 't2',
+              name: 'AI (alias)',
+              spacesByTopicIdConnection: { totalCount: 1, nodes: [spaceNode(AI_SPACE, 'AI')] },
+              subtopics: [],
+            },
+          ],
+        });
+      }
+      return Effect.succeed({
+        entities: [
+          {
+            id: 't0',
+            name: 'Geo',
+            spacesByTopicIdConnection: { totalCount: 0, nodes: [] },
+            subtopics: [{ toEntity: { id: 't1' } }, { toEntity: { id: 't2' } }],
+          },
+        ],
+      });
+    });
+
+    const result = await fetchFeaturedSpaces();
+    expect(result.map(r => r.spaceId)).toEqual([AI_SPACE]);
+  });
+
+  it('returns [] when the root space has no topic', async () => {
+    graphqlMock.mockImplementation(() => Effect.succeed({ space: { topicId: null } }));
+    expect(await fetchFeaturedSpaces()).toEqual([]);
+  });
+});

--- a/apps/web/core/io/subgraph/fetch-featured-spaces.ts
+++ b/apps/web/core/io/subgraph/fetch-featured-spaces.ts
@@ -1,0 +1,219 @@
+import { Effect, Either } from 'effect';
+
+import { ROOT_SPACE, SUBTOPIC_RELATION_TYPE_ID } from '~/core/constants';
+import { Environment } from '~/core/environment';
+import { getSpaceRank, getTopRankedSpaceId } from '~/core/utils/space/space-ranking';
+
+import { graphql } from './graphql';
+import {
+  AVATAR_PROPERTY_ID,
+  COVER_PROPERTY_ID,
+  IMAGE_URL_PROPERTY_ID,
+  type SpaceImageRelationNode,
+  resolveSpaceImage,
+} from './space-image';
+import { PLACEHOLDER_TOPIC_NAME } from './topic-space-usage';
+
+// Featured spaces are discovered by walking the Subtopic relation tree that
+// hangs off the Root space's topic entity, breadth-first. We start at the top
+// (Root's direct subtopics) and work down, so shallow — i.e. most prominent —
+// topics surface first. A topic becomes a pill only if it has at least one
+// space claiming it; when several spaces share a topic we feature the
+// top-ranked one (see getTopRankedSpaceId).
+
+// How many entity ids we expand per round. Batching keeps the number of
+// sequential round-trips small while staying well under any query-size limit.
+const BATCH_SIZE = 200;
+
+// Hard ceilings so a pathological tree (the subtopic graph has cycles and
+// duplicate relations) can't balloon the SSR cost. Top-down BFS means the cap
+// trims the deepest, least-prominent topics first — exactly what we'd drop.
+const MAX_NODES = 2500;
+const MAX_FEATURED = 60;
+
+export interface FeaturedSpace {
+  spaceId: string;
+  topicId: string;
+  name: string;
+  image: string;
+  memberCount: number;
+}
+
+interface SpaceNode {
+  id: string;
+  page: {
+    id: string;
+    name: string | null;
+    relationsList: SpaceImageRelationNode[];
+  } | null;
+  members: { totalCount: number } | null;
+}
+
+interface TopicNode {
+  id: string;
+  name: string | null;
+  spacesByTopicIdConnection: {
+    totalCount: number;
+    nodes: SpaceNode[];
+  } | null;
+  subtopics: Array<{ toEntity: { id: string } | null }> | null;
+}
+
+interface RootResult {
+  space: { topicId: string | null } | null;
+}
+
+interface FrontierResult {
+  entities: TopicNode[];
+}
+
+const ROOT_QUERY = `
+  {
+    space(id: ${JSON.stringify(ROOT_SPACE)}) {
+      topicId
+    }
+  }
+`;
+
+// Resolve one frontier batch: each topic's claiming spaces (for pill data) and
+// its immediate subtopics (for the next frontier).
+function frontierQuery(ids: string[]): string {
+  return `
+  {
+    entities(filter: { id: { in: ${JSON.stringify(ids)} } }) {
+      id
+      name
+      spacesByTopicIdConnection(first: 20) {
+        totalCount
+        nodes {
+          id
+          page {
+            id
+            name
+            relationsList(filter: { typeId: { in: [${JSON.stringify(AVATAR_PROPERTY_ID)}, ${JSON.stringify(COVER_PROPERTY_ID)}] } }) {
+              typeId
+              toEntity {
+                valuesList(filter: { propertyId: { is: ${JSON.stringify(IMAGE_URL_PROPERTY_ID)} } }) {
+                  propertyId
+                  text
+                }
+              }
+            }
+          }
+          members {
+            totalCount
+          }
+        }
+      }
+      subtopics: relationsList(filter: { typeId: { is: ${JSON.stringify(SUBTOPIC_RELATION_TYPE_ID)} } }) {
+        toEntity {
+          id
+        }
+      }
+    }
+  }
+`;
+}
+
+function resolveTopicName(name: string | null | undefined): string {
+  if (!name || !name.trim()) return PLACEHOLDER_TOPIC_NAME;
+  return name;
+}
+
+async function runQuery<T>(query: string): Promise<T | null> {
+  const resultOrError = await Effect.runPromise(
+    Effect.either(graphql<T>({ query, endpoint: Environment.getConfig().api }))
+  );
+
+  if (Either.isLeft(resultOrError)) {
+    const error = resultOrError.left;
+    if (error._tag === 'AbortError') throw error;
+    console.error(`${error._tag}: Unable to fetch featured spaces`);
+    return null;
+  }
+
+  return resultOrError.right;
+}
+
+/**
+ * Builds the explore panel's "Join spaces" list by walking the Root space's
+ * subtopic tree top-down and emitting one entry per topic that has a claiming
+ * space. The Root topic itself is used only as the traversal seed — it is not
+ * featured. Spaces are deduped (a space can claim multiple topics). Traversal
+ * order is top-down only so the node cap trims the deepest topics first; the
+ * returned list is ordered by space rank (then name), not tree position.
+ */
+export async function fetchFeaturedSpaces(): Promise<FeaturedSpace[]> {
+  const root = await runQuery<RootResult>(ROOT_QUERY);
+  const rootTopicId = root?.space?.topicId;
+  if (!rootTopicId) return [];
+
+  // Seed the traversal with the Root topic's children so the Root topic (and
+  // therefore the Root space) is never featured in its own panel.
+  const visited = new Set<string>([rootTopicId]);
+  const seenSpaceIds = new Set<string>();
+  const featured: FeaturedSpace[] = [];
+
+  let frontier: string[] = [rootTopicId];
+
+  while (frontier.length > 0 && visited.size < MAX_NODES && featured.length < MAX_FEATURED) {
+    const batch = frontier.slice(0, BATCH_SIZE);
+    const overflow = frontier.slice(BATCH_SIZE);
+
+    const result = await runQuery<FrontierResult>(frontierQuery(batch));
+    const topics = result?.entities ?? [];
+
+    const nextFrontier: string[] = [];
+
+    for (const topic of topics) {
+      // Emit a pill for this topic if a space claims it. Skip the Root topic
+      // seed (its id was pre-marked visited but it still comes back in round 1).
+      if (topic.id !== rootTopicId) {
+        addFeaturedFromTopic(topic, seenSpaceIds, featured);
+      }
+
+      for (const rel of topic.subtopics ?? []) {
+        const childId = rel.toEntity?.id;
+        if (!childId || visited.has(childId)) continue;
+        visited.add(childId);
+        nextFrontier.push(childId);
+      }
+    }
+
+    frontier = [...overflow, ...nextFrontier];
+  }
+
+  // Display order is by curated space rank, then name — independent of where
+  // the space sat in the subtopic tree.
+  featured.sort((a, b) => {
+    const rankDelta = getSpaceRank(a.spaceId) - getSpaceRank(b.spaceId);
+    if (rankDelta !== 0) return rankDelta;
+    return a.name.localeCompare(b.name);
+  });
+
+  return featured.slice(0, MAX_FEATURED);
+}
+
+function addFeaturedFromTopic(topic: TopicNode, seenSpaceIds: Set<string>, featured: FeaturedSpace[]): void {
+  const spaceNodes = topic.spacesByTopicIdConnection?.nodes ?? [];
+  if (spaceNodes.length === 0) return;
+
+  const topRankedId = getTopRankedSpaceId(spaceNodes.map(s => s.id));
+  if (!topRankedId) return;
+
+  const space = spaceNodes.find(s => s.id === topRankedId);
+  if (!space || seenSpaceIds.has(space.id)) return;
+  seenSpaceIds.add(space.id);
+
+  const topicName = resolveTopicName(topic.name);
+  const name = space.page?.name?.trim() ? space.page.name : topicName;
+  const image = resolveSpaceImage(space.page?.relationsList ?? [], space.id);
+
+  featured.push({
+    spaceId: space.id,
+    topicId: topic.id,
+    name,
+    image,
+    memberCount: space.members?.totalCount ?? 0,
+  });
+}

--- a/apps/web/core/io/subgraph/fetch-pending-membership-space-ids.test.ts
+++ b/apps/web/core/io/subgraph/fetch-pending-membership-space-ids.test.ts
@@ -1,0 +1,76 @@
+import { Effect } from 'effect';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { fetchPendingMembershipSpaceIds } from './fetch-pending-membership-space-ids';
+
+const graphqlMock = vi.fn();
+const fetchActiveMemberRequestMock = vi.fn();
+
+vi.mock('~/core/environment', () => ({
+  Environment: {
+    getConfig: () => ({ api: 'https://example.com/graphql', bundler: '', chainId: '19411', rpc: '' }),
+  },
+}));
+
+vi.mock('./graphql', () => ({
+  graphql: (...args: unknown[]) => graphqlMock(...args),
+}));
+
+vi.mock('./fetch-proposed-members', () => ({
+  fetchActiveMemberRequest: (spaceId: string, memberSpaceId: string) =>
+    fetchActiveMemberRequestMock(spaceId, memberSpaceId),
+}));
+
+const MEMBER = 'member00000000000000000000000000';
+
+describe('fetchPendingMembershipSpaceIds', () => {
+  beforeEach(() => {
+    graphqlMock.mockReset();
+    fetchActiveMemberRequestMock.mockReset();
+  });
+
+  function mockCandidates(spaceIds: string[]) {
+    graphqlMock.mockImplementation(({ query }: { query: string }) => {
+      if (query.includes('proposalActionsConnection')) {
+        return Effect.succeed({
+          proposalActionsConnection: { nodes: spaceIds.map((_, i) => ({ proposalId: `p${i}` })) },
+        });
+      }
+      // proposalsConnection: resolve each proposal to its space (all not-executed).
+      return Effect.succeed({
+        proposalsConnection: { nodes: spaceIds.map((spaceId, i) => ({ id: `p${i}`, spaceId })) },
+      });
+    });
+  }
+
+  it('keeps only active, not-stuck requests (drops stuck and non-existent)', async () => {
+    mockCandidates(['aaaa', 'bbbb', 'cccc']);
+    fetchActiveMemberRequestMock.mockImplementation((spaceId: string) => {
+      if (spaceId === 'aaaa') return Promise.resolve({ proposalId: 'x', isVotingEnded: false }); // active
+      if (spaceId === 'bbbb') return Promise.resolve({ proposalId: 'y', isVotingEnded: true }); // stuck
+      return Promise.resolve(null); // no active request
+    });
+
+    const result = await fetchPendingMembershipSpaceIds(MEMBER);
+    expect(result).toEqual(['aaaa']);
+  });
+
+  it('returns [] when there are no candidate actions (skips the second query)', async () => {
+    graphqlMock.mockImplementation(() => Effect.succeed({ proposalActionsConnection: { nodes: [] } }));
+
+    const result = await fetchPendingMembershipSpaceIds(MEMBER);
+    expect(result).toEqual([]);
+    expect(fetchActiveMemberRequestMock).not.toHaveBeenCalled();
+    // Only the actions query runs; no proposals lookup.
+    expect(graphqlMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('dedupes candidate spaces before confirming', async () => {
+    mockCandidates(['dupe', 'dupe']);
+    fetchActiveMemberRequestMock.mockResolvedValue({ proposalId: 'x', isVotingEnded: false });
+
+    const result = await fetchPendingMembershipSpaceIds(MEMBER);
+    expect(result).toEqual(['dupe']);
+    expect(fetchActiveMemberRequestMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/core/io/subgraph/fetch-pending-membership-space-ids.ts
+++ b/apps/web/core/io/subgraph/fetch-pending-membership-space-ids.ts
@@ -1,0 +1,130 @@
+import { Effect, Either } from 'effect';
+
+import { Environment } from '~/core/environment';
+import { normId } from '~/core/utils/norm-id';
+
+import { fetchActiveEditorRequest } from './fetch-proposed-editors';
+import { fetchActiveMemberRequest } from './fetch-proposed-members';
+import { graphql } from './graphql';
+
+// "Pending request" = the space page's exact definition: a proposal whose status
+// is PROPOSED or EXECUTABLE (active), as decided by the REST `/active` endpoint.
+//
+// GraphQL alone can't express that — `ProposalFilter` exposes neither the
+// proposal's actions nor its status. So we use GraphQL only to *enumerate*
+// candidate spaces (any not-yet-executed proposal with an ADD_MEMBER/ADD_EDITOR
+// action targeting the member), then confirm each candidate through the same
+// REST endpoint the space page uses. That confirmation step is what drops
+// rejected/voting-ended proposals (executedAt is null but status is REJECTED),
+// giving exact parity with the per-space "Requested" state.
+
+type ProposalActionType = 'ADD_MEMBER' | 'ADD_EDITOR';
+
+type ActionsResult = {
+  proposalActionsConnection: { nodes: { proposalId: string }[] };
+};
+
+type ProposalsResult = {
+  proposalsConnection: { nodes: { id: string; spaceId: string }[] };
+};
+
+function actionsQuery(memberSpaceId: string, actionType: ProposalActionType): string {
+  return `{
+    proposalActionsConnection(
+      first: 500
+      filter: { actionType: { is: ${actionType} }, targetId: { is: ${JSON.stringify(memberSpaceId)} } }
+    ) {
+      nodes { proposalId }
+    }
+  }`;
+}
+
+function proposalsByIdQuery(proposalIds: string[]): string {
+  return `{
+    proposalsConnection(
+      first: ${proposalIds.length}
+      filter: { id: { in: ${JSON.stringify(proposalIds)} }, executedAt: { isNull: true } }
+    ) {
+      nodes { id spaceId }
+    }
+  }`;
+}
+
+// Confirming candidates is one REST call per space. Cap concurrency so a member
+// with many outstanding actions can't fan out into hundreds of simultaneous
+// requests (SSR latency / rate limits).
+const CONFIRM_CONCURRENCY = 8;
+
+async function mapWithConcurrency<T, R>(items: T[], limit: number, fn: (item: T) => Promise<R>): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let cursor = 0;
+  const worker = async () => {
+    while (cursor < items.length) {
+      const index = cursor++;
+      results[index] = await fn(items[index]);
+    }
+  };
+  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, worker));
+  return results;
+}
+
+async function runQuery<T>(query: string, label: string): Promise<T | null> {
+  const resultOrError = await Effect.runPromise(
+    Effect.either(graphql<T>({ query, endpoint: Environment.getConfig().api }))
+  );
+
+  if (Either.isLeft(resultOrError)) {
+    const error = resultOrError.left;
+    if (error._tag === 'AbortError') throw error;
+    console.error(`${error._tag}: Unable to fetch ${label}`);
+    return null;
+  }
+
+  return resultOrError.right;
+}
+
+/**
+ * Distinct, normalized space ids that have a not-yet-executed proposal of the
+ * given action type targeting the member. These are *candidates* — REST
+ * confirmation narrows them to the truly-active set.
+ */
+async function fetchCandidateSpaceIds(memberSpaceId: string, actionType: ProposalActionType): Promise<string[]> {
+  const actions = await runQuery<ActionsResult>(actionsQuery(memberSpaceId, actionType), `${actionType} actions`);
+  const proposalIds = [...new Set((actions?.proposalActionsConnection?.nodes ?? []).map(n => n.proposalId))];
+  if (proposalIds.length === 0) return [];
+
+  const proposals = await runQuery<ProposalsResult>(proposalsByIdQuery(proposalIds), `${actionType} proposals`);
+  const nodes = proposals?.proposalsConnection?.nodes ?? [];
+  return [...new Set(nodes.map(n => normId(n.spaceId)))];
+}
+
+/**
+ * All spaces where the member has an active, not-stuck membership request —
+ * exact parity with the space page's `fetchActiveMemberRequest` check (a
+ * vote-ended "stuck" request no longer counts as pending).
+ */
+export async function fetchPendingMembershipSpaceIds(memberSpaceId: string): Promise<string[]> {
+  const candidates = await fetchCandidateSpaceIds(memberSpaceId, 'ADD_MEMBER');
+  if (candidates.length === 0) return [];
+
+  const confirmed = await mapWithConcurrency(candidates, CONFIRM_CONCURRENCY, async spaceId => {
+    const request = await fetchActiveMemberRequest(spaceId, memberSpaceId).catch(() => null);
+    return request != null && !request.isVotingEnded ? spaceId : null;
+  });
+  return confirmed.filter((id): id is string => id !== null);
+}
+
+/**
+ * All spaces where the member has an active, not-stuck editorship request —
+ * exact parity with the space page's editor-request check.
+ */
+export async function fetchPendingEditorshipSpaceIds(memberSpaceId: string): Promise<string[]> {
+  const candidates = await fetchCandidateSpaceIds(memberSpaceId, 'ADD_EDITOR');
+  if (candidates.length === 0) return [];
+
+  const confirmed = await mapWithConcurrency(candidates, CONFIRM_CONCURRENCY, async spaceId => {
+    const request = await fetchActiveEditorRequest(spaceId, memberSpaceId).catch(() => null);
+    return request != null && !request.isVotingEnded ? spaceId : null;
+  });
+  return confirmed.filter((id): id is string => id !== null);
+}

--- a/apps/web/core/io/subgraph/fetch-pending-membership-space-ids.ts
+++ b/apps/web/core/io/subgraph/fetch-pending-membership-space-ids.ts
@@ -1,6 +1,7 @@
 import { Effect, Either } from 'effect';
 
 import { Environment } from '~/core/environment';
+import { mapWithConcurrency } from '~/core/utils/map-with-concurrency';
 import { normId } from '~/core/utils/norm-id';
 
 import { fetchActiveEditorRequest } from './fetch-proposed-editors';
@@ -54,19 +55,6 @@ function proposalsByIdQuery(proposalIds: string[]): string {
 // with many outstanding actions can't fan out into hundreds of simultaneous
 // requests (SSR latency / rate limits).
 const CONFIRM_CONCURRENCY = 8;
-
-async function mapWithConcurrency<T, R>(items: T[], limit: number, fn: (item: T) => Promise<R>): Promise<R[]> {
-  const results: R[] = new Array(items.length);
-  let cursor = 0;
-  const worker = async () => {
-    while (cursor < items.length) {
-      const index = cursor++;
-      results[index] = await fn(items[index]);
-    }
-  };
-  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, worker));
-  return results;
-}
 
 async function runQuery<T>(query: string, label: string): Promise<T | null> {
   const resultOrError = await Effect.runPromise(

--- a/apps/web/core/state/requested-membership.ts
+++ b/apps/web/core/state/requested-membership.ts
@@ -1,0 +1,53 @@
+import { atomWithStorage } from 'jotai/utils';
+
+import { normId } from '~/core/utils/norm-id';
+
+export type RequestedMembershipSpace = {
+  id: string;
+  /** Personal space id of the requester — scopes the entry so it never leaks across accounts. */
+  ownerId: string;
+  /** Optional display data; absent when the request originates somewhere without it (e.g. a space page). */
+  name?: string;
+  image?: string | null;
+};
+
+const STORAGE_KEY = 'geo:requested-membership-spaces';
+
+/**
+ * Spaces the user has requested membership for, persisted to localStorage so the
+ * optimistic "Membership pending" state survives a refresh while the indexer
+ * catches up. This is only a bridge — {@link fetchPendingMembershipSpaceIds} is
+ * the durable source of truth, and reconciliation drops entries once the server
+ * reports the membership (pending or granted).
+ *
+ * Each entry carries its `ownerId` (the requester's personal space id); readers
+ * MUST filter by the current personal space id via {@link requestedSpacesForOwner}
+ * so a signed-out user — or the next account in the same browser — never inherits
+ * a prior user's optimistic pending state.
+ *
+ * Stored as an array (Maps don't serialize to JSON). Helpers below keep callers
+ * from hand-rolling the normId dedup.
+ */
+export const requestedMembershipSpacesAtom = atomWithStorage<RequestedMembershipSpace[]>(STORAGE_KEY, []);
+
+export function upsertRequestedMembershipSpace(
+  current: RequestedMembershipSpace[],
+  space: RequestedMembershipSpace
+): RequestedMembershipSpace[] {
+  const key = normId(space.id);
+  if (current.some(s => normId(s.id) === key && s.ownerId === space.ownerId)) return current;
+  return [...current, space];
+}
+
+/** Entries owned by the given personal space id. Empty when signed out (no owner). */
+export function requestedSpacesForOwner(
+  current: RequestedMembershipSpace[],
+  ownerId: string | null | undefined
+): RequestedMembershipSpace[] {
+  if (!ownerId) return [];
+  return current.filter(s => s.ownerId === ownerId);
+}
+
+export function requestedMembershipIdSet(current: RequestedMembershipSpace[]): Set<string> {
+  return new Set(current.map(s => normId(s.id)));
+}

--- a/apps/web/core/state/requested-membership.ts
+++ b/apps/web/core/state/requested-membership.ts
@@ -6,6 +6,8 @@ export type RequestedMembershipSpace = {
   id: string;
   /** Personal space id of the requester — scopes the entry so it never leaks across accounts. */
   ownerId: string;
+  /** Epoch ms when the request was made — the bridge is ignored past {@link REQUEST_BRIDGE_TTL_MS}. */
+  requestedAt: number;
   /** Optional display data; absent when the request originates somewhere without it (e.g. a space page). */
   name?: string;
   image?: string | null;
@@ -14,38 +16,73 @@ export type RequestedMembershipSpace = {
 const STORAGE_KEY = 'geo:requested-membership-spaces';
 
 /**
+ * How long an optimistic entry is trusted. The bridge only needs to cover the
+ * gap between a successful request tx and the indexer reporting the proposal
+ * (seconds). Past this window the durable server query is authoritative, so an
+ * entry the server no longer reports as pending (e.g. the request was rejected
+ * or its vote ended) stops showing as "Membership pending" instead of lingering
+ * forever.
+ */
+export const REQUEST_BRIDGE_TTL_MS = 5 * 60_000;
+
+/**
  * Spaces the user has requested membership for, persisted to localStorage so the
  * optimistic "Membership pending" state survives a refresh while the indexer
  * catches up. This is only a bridge — {@link fetchPendingMembershipSpaceIds} is
- * the durable source of truth, and reconciliation drops entries once the server
- * reports the membership (pending or granted).
+ * the durable source of truth.
  *
- * Each entry carries its `ownerId` (the requester's personal space id); readers
- * MUST filter by the current personal space id via {@link requestedSpacesForOwner}
- * so a signed-out user — or the next account in the same browser — never inherits
- * a prior user's optimistic pending state.
+ * Reads MUST go through {@link activeRequestedSpacesForOwner} so entries are
+ * scoped to the current account (never leak across sign-out / account switch)
+ * and expired entries drop out.
  *
- * Stored as an array (Maps don't serialize to JSON). Helpers below keep callers
- * from hand-rolling the normId dedup.
+ * Stored as an array (Maps don't serialize to JSON).
  */
 export const requestedMembershipSpacesAtom = atomWithStorage<RequestedMembershipSpace[]>(STORAGE_KEY, []);
 
+/** Insert a new entry, or merge newly-available display data into an existing one for the same owner+space. */
 export function upsertRequestedMembershipSpace(
   current: RequestedMembershipSpace[],
   space: RequestedMembershipSpace
 ): RequestedMembershipSpace[] {
   const key = normId(space.id);
-  if (current.some(s => normId(s.id) === key && s.ownerId === space.ownerId)) return current;
-  return [...current, space];
+  const index = current.findIndex(s => normId(s.id) === key && s.ownerId === space.ownerId);
+  if (index === -1) return [...current, space];
+
+  const existing = current[index];
+  const merged: RequestedMembershipSpace = {
+    ...existing,
+    requestedAt: space.requestedAt,
+    name: space.name ?? existing.name,
+    image: space.image ?? existing.image,
+  };
+  const next = [...current];
+  next[index] = merged;
+  return next;
 }
 
-/** Entries owned by the given personal space id. Empty when signed out (no owner). */
-export function requestedSpacesForOwner(
+/** This account's still-active (non-expired) optimistic entries. Empty when signed out. */
+export function activeRequestedSpacesForOwner(
   current: RequestedMembershipSpace[],
-  ownerId: string | null | undefined
+  ownerId: string | null | undefined,
+  now: number
 ): RequestedMembershipSpace[] {
   if (!ownerId) return [];
-  return current.filter(s => s.ownerId === ownerId);
+  return current.filter(s => s.ownerId === ownerId && now - s.requestedAt < REQUEST_BRIDGE_TTL_MS);
+}
+
+/** Drop entries that are expired, or belong to `ownerId` and are now server-tracked. Returns `current` if unchanged. */
+export function reconcileRequestedSpaces(
+  current: RequestedMembershipSpace[],
+  ownerId: string | null | undefined,
+  serverTrackedIds: Set<string>,
+  now: number
+): RequestedMembershipSpace[] {
+  const next = current.filter(s => {
+    if (now - s.requestedAt >= REQUEST_BRIDGE_TTL_MS) return false;
+    if (ownerId && s.ownerId === ownerId && serverTrackedIds.has(normId(s.id))) return false;
+    return true;
+  });
+  return next.length === current.length ? current : next;
 }
 
 export function requestedMembershipIdSet(current: RequestedMembershipSpace[]): Set<string> {

--- a/apps/web/core/utils/map-with-concurrency.ts
+++ b/apps/web/core/utils/map-with-concurrency.ts
@@ -1,0 +1,21 @@
+/**
+ * Map over `items` running at most `limit` calls of `fn` concurrently, preserving
+ * input order in the result. Use to cap fan-out of per-item network calls so a
+ * large input can't burst into hundreds of simultaneous requests.
+ */
+export async function mapWithConcurrency<T, R>(
+  items: T[],
+  limit: number,
+  fn: (item: T, index: number) => Promise<R>
+): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let cursor = 0;
+  const worker = async () => {
+    while (cursor < items.length) {
+      const index = cursor++;
+      results[index] = await fn(items[index], index);
+    }
+  };
+  await Promise.all(Array.from({ length: Math.min(Math.max(limit, 1), items.length) }, worker));
+  return results;
+}

--- a/apps/web/partials/browse-sidebar/browse-sidebar.tsx
+++ b/apps/web/partials/browse-sidebar/browse-sidebar.tsx
@@ -5,7 +5,7 @@ import { useQuery, useQueryClient } from '@tanstack/react-query';
 import * as React from 'react';
 
 import cx from 'classnames';
-import { useAtom, useAtomValue } from 'jotai';
+import { useAtom, useAtomValue, useSetAtom } from 'jotai';
 import { usePathname } from 'next/navigation';
 
 import { personalSpaceViewed } from '~/core/analytics';
@@ -21,6 +21,8 @@ import { useSmartAccount } from '~/core/hooks/use-smart-account';
 import { useSpaceId } from '~/core/hooks/use-space-id';
 import { browseSidebarOpenAtom } from '~/core/state/browse-sidebar-state';
 import { usePendingPersonalSpace } from '~/core/state/pending-personal-space';
+import { requestedMembershipSpacesAtom, requestedSpacesForOwner } from '~/core/state/requested-membership';
+import { normId } from '~/core/utils/norm-id';
 import { NavUtils, getImagePath } from '~/core/utils/utils';
 
 import { Avatar } from '~/design-system/avatar';
@@ -224,8 +226,11 @@ function SpaceRowLink({ row }: { row: BrowseSpaceRow }) {
       )}
     >
       <SpaceRowThumb row={row} />
-      <span className="min-w-0 flex-1 overflow-hidden">
+      <span className="flex min-w-0 flex-1 flex-col justify-center overflow-hidden">
         <p className="-my-0.5 truncate leading-5">{row.name}</p>
+        {row.pendingLabel ? (
+          <p className="truncate text-browseSection leading-4 text-grey-04 not-italic">{row.pendingLabel}</p>
+        ) : null}
       </span>
     </Link>
   );
@@ -294,6 +299,50 @@ export function BrowseSidebar() {
     staleTime: 60_000,
   });
   const personalSpaceId = data?.personalSpaceId ?? personalSpaceIdFromHook;
+
+  // Optimistic, persisted bridge: spaces requested this session (from anywhere)
+  // show under "Member of" as "Membership pending" until the server-fetched data
+  // reports them, which then wins via id dedup. Scoped to this account so a
+  // signed-out user or a prior account never inherits the localStorage state.
+  const allRequestedSpaces = useAtomValue(requestedMembershipSpacesAtom);
+  const setRequestedSpaces = useSetAtom(requestedMembershipSpacesAtom);
+  const requestedSpaces = React.useMemo(
+    () => requestedSpacesForOwner(allRequestedSpaces, personalSpaceId),
+    [allRequestedSpaces, personalSpaceId]
+  );
+
+  const serverTrackedIds = React.useMemo(() => {
+    const ids = new Set<string>();
+    for (const row of data?.editorOf ?? []) ids.add(normId(row.id));
+    for (const row of data?.memberOf ?? []) ids.add(normId(row.id));
+    return ids;
+  }, [data?.editorOf, data?.memberOf]);
+
+  // Once the server tracks a requested space (pending row, member, or editor),
+  // drop this account's optimistic entry so it can't linger after approval/refresh.
+  React.useEffect(() => {
+    if (!personalSpaceId || serverTrackedIds.size === 0) return;
+    setRequestedSpaces(prev => {
+      const next = prev.filter(s => !(s.ownerId === personalSpaceId && serverTrackedIds.has(normId(s.id))));
+      return next.length === prev.length ? prev : next;
+    });
+  }, [serverTrackedIds, setRequestedSpaces, personalSpaceId]);
+
+  const memberOfRows = React.useMemo<BrowseSpaceRow[]>(() => {
+    const base = data?.memberOf ?? [];
+    if (requestedSpaces.length === 0) return base;
+    const extras: BrowseSpaceRow[] = [];
+    for (const space of requestedSpaces) {
+      if (serverTrackedIds.has(normId(space.id))) continue;
+      extras.push({
+        id: space.id,
+        name: space.name ?? space.id.slice(0, 8),
+        image: space.image ?? null,
+        pendingLabel: 'Membership pending',
+      });
+    }
+    return [...base, ...extras];
+  }, [data?.memberOf, requestedSpaces, serverTrackedIds]);
 
   React.useEffect(() => {
     if (!data?.personalSpaceId) return;
@@ -375,22 +424,12 @@ export function BrowseSidebar() {
             </CollapsibleSection>
             <CollapsibleSection title="Editor of" hidden={data.editorOf.length === 0}>
               {data.editorOf.map(row => (
-                <div key={row.id}>
-                  <SpaceRowLink row={row} />
-                  {row.pendingLabel ? (
-                    <p className="px-2 pb-1 pl-9 text-browseSection text-grey-04 not-italic">{row.pendingLabel}</p>
-                  ) : null}
-                </div>
+                <SpaceRowLink key={row.id} row={row} />
               ))}
             </CollapsibleSection>
-            <CollapsibleSection title="Member of" hidden={data.memberOf.length === 0}>
-              {data.memberOf.map(row => (
-                <div key={row.id}>
-                  <SpaceRowLink row={row} />
-                  {row.pendingLabel ? (
-                    <p className="px-2 pb-1 pl-9 text-browseSection text-grey-04 not-italic">{row.pendingLabel}</p>
-                  ) : null}
-                </div>
+            <CollapsibleSection title="Member of" hidden={memberOfRows.length === 0}>
+              {memberOfRows.map(row => (
+                <SpaceRowLink key={row.id} row={row} />
               ))}
             </CollapsibleSection>
           </>

--- a/apps/web/partials/browse-sidebar/browse-sidebar.tsx
+++ b/apps/web/partials/browse-sidebar/browse-sidebar.tsx
@@ -21,7 +21,11 @@ import { useSmartAccount } from '~/core/hooks/use-smart-account';
 import { useSpaceId } from '~/core/hooks/use-space-id';
 import { browseSidebarOpenAtom } from '~/core/state/browse-sidebar-state';
 import { usePendingPersonalSpace } from '~/core/state/pending-personal-space';
-import { requestedMembershipSpacesAtom, requestedSpacesForOwner } from '~/core/state/requested-membership';
+import {
+  activeRequestedSpacesForOwner,
+  reconcileRequestedSpaces,
+  requestedMembershipSpacesAtom,
+} from '~/core/state/requested-membership';
 import { normId } from '~/core/utils/norm-id';
 import { NavUtils, getImagePath } from '~/core/utils/utils';
 
@@ -302,12 +306,12 @@ export function BrowseSidebar() {
 
   // Optimistic, persisted bridge: spaces requested this session (from anywhere)
   // show under "Member of" as "Membership pending" until the server-fetched data
-  // reports them, which then wins via id dedup. Scoped to this account so a
-  // signed-out user or a prior account never inherits the localStorage state.
+  // reports them, which then wins via id dedup. Scoped to this account (never
+  // leaks across accounts) and expired entries drop out.
   const allRequestedSpaces = useAtomValue(requestedMembershipSpacesAtom);
   const setRequestedSpaces = useSetAtom(requestedMembershipSpacesAtom);
   const requestedSpaces = React.useMemo(
-    () => requestedSpacesForOwner(allRequestedSpaces, personalSpaceId),
+    () => activeRequestedSpacesForOwner(allRequestedSpaces, personalSpaceId, Date.now()),
     [allRequestedSpaces, personalSpaceId]
   );
 
@@ -318,14 +322,10 @@ export function BrowseSidebar() {
     return ids;
   }, [data?.editorOf, data?.memberOf]);
 
-  // Once the server tracks a requested space (pending row, member, or editor),
-  // drop this account's optimistic entry so it can't linger after approval/refresh.
+  // Persist reconciliation: drop expired entries and this account's entries the
+  // server now tracks (pending row, member, or editor) so localStorage self-cleans.
   React.useEffect(() => {
-    if (!personalSpaceId || serverTrackedIds.size === 0) return;
-    setRequestedSpaces(prev => {
-      const next = prev.filter(s => !(s.ownerId === personalSpaceId && serverTrackedIds.has(normId(s.id))));
-      return next.length === prev.length ? prev : next;
-    });
+    setRequestedSpaces(prev => reconcileRequestedSpaces(prev, personalSpaceId, serverTrackedIds, Date.now()));
   }, [serverTrackedIds, setRequestedSpaces, personalSpaceId]);
 
   const memberOfRows = React.useMemo<BrowseSpaceRow[]>(() => {

--- a/apps/web/partials/explore/explore-join-space-button.tsx
+++ b/apps/web/partials/explore/explore-join-space-button.tsx
@@ -1,9 +1,6 @@
 'use client';
 
-import * as React from 'react';
-
-import { atom, useAtom } from 'jotai';
-
+import { useIsMembershipPending } from '~/core/hooks/use-pending-memberships';
 import { useRequestToBeMember } from '~/core/hooks/use-request-to-be-member';
 import { useSmartAccount } from '~/core/hooks/use-smart-account';
 import { useSignInPrompt } from '~/core/state/sign-in-prompt-store';
@@ -15,43 +12,25 @@ type ExploreJoinSpaceButtonProps = {
   hasRequestedSpaceMembership: boolean;
   /** Render style. 'text' (default) for inline article-card use; 'button' for the chip-styled button. */
   variant?: 'text' | 'button';
+  /** CTA label for the idle state. Defaults to 'Join space'; pill use passes 'Join'. */
+  label?: string;
 };
-
-function normId(id: string): string {
-  return id.replace(/-/g, '').toLowerCase();
-}
-
-/**
- * Space IDs the user has requested membership for in this session. Shared across all
- * explore cards so every card for the same space flips to "Membership pending" after
- * one click — no need to refetch the feed.
- */
-const locallyRequestedSpaceIdsAtom = atom<Set<string>>(new Set<string>());
 
 export function ExploreJoinSpaceButton({
   spaceId,
   hasRequestedSpaceMembership,
   variant = 'text',
+  label = 'Join space',
 }: ExploreJoinSpaceButtonProps) {
   const { requestToBeMember, status } = useRequestToBeMember({ spaceId });
-  const [locallyRequested, setLocallyRequested] = useAtom(locallyRequestedSpaceIdsAtom);
   const { smartAccount } = useSmartAccount();
   const { open: openSignInPrompt } = useSignInPrompt();
 
-  const normalizedId = normId(spaceId);
-  const locallyRequestedThisSpace = locallyRequested.has(normalizedId);
-
-  React.useEffect(() => {
-    if (status === 'success' && !locallyRequestedThisSpace) {
-      setLocallyRequested(prev => {
-        const next = new Set(prev);
-        next.add(normalizedId);
-        return next;
-      });
-    }
-  }, [status, normalizedId, locallyRequestedThisSpace, setLocallyRequested]);
-
-  const showPendingLabel = hasRequestedSpaceMembership || locallyRequestedThisSpace;
+  // Durable + persisted pending state so a request made anywhere (space page,
+  // the "Join spaces" pills) flips every card for this space to "Membership
+  // pending" without a refresh.
+  const isPending = useIsMembershipPending(spaceId);
+  const showPendingLabel = hasRequestedSpaceMembership || isPending;
 
   return (
     <Pending isPending={status === 'pending'} position="end">
@@ -70,7 +49,7 @@ export function ExploreJoinSpaceButton({
             requestToBeMember();
           }}
         >
-          Join space
+          {label}
         </button>
       ) : (
         <button
@@ -85,7 +64,7 @@ export function ExploreJoinSpaceButton({
             requestToBeMember();
           }}
         >
-          Join space
+          {label}
         </button>
       )}
     </Pending>

--- a/apps/web/partials/explore/explore-page.tsx
+++ b/apps/web/partials/explore/explore-page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import type { FeaturedSpace } from '~/core/io/subgraph/fetch-featured-spaces';
 import type { RootTopicChip } from '~/core/io/subgraph/fetch-first-level-subtopics';
 import type { ParentTopicOption } from '~/core/io/subgraph/fetch-parent-topic-options';
 import type { RecentlyClaimedSpace } from '~/core/io/subgraph/fetch-recently-claimed-spaces';
@@ -10,6 +11,7 @@ import { ExploreSidePanel } from './explore-side-panel';
 
 type Props = {
   initialSpaceOptions: SpaceOption[];
+  featuredSpaces: FeaturedSpace[];
   unclaimedTopics: RootTopicChip[];
   recentlyClaimedSpaces: RecentlyClaimedSpace[];
   parentTopicOptions: ParentTopicOption[];
@@ -19,6 +21,7 @@ type Props = {
 
 export function ExplorePage({
   initialSpaceOptions,
+  featuredSpaces,
   unclaimedTopics,
   recentlyClaimedSpaces,
   parentTopicOptions,
@@ -42,6 +45,7 @@ export function ExplorePage({
         className="sticky top-11 h-[calc(100dvh-2.75rem)] w-px shrink-0 self-start bg-divider lg:hidden"
       />
       <ExploreSidePanel
+        featuredSpaces={featuredSpaces}
         unclaimedTopics={unclaimedTopics}
         recentlyClaimedSpaces={recentlyClaimedSpaces}
         parentTopicOptions={parentTopicOptions}

--- a/apps/web/partials/explore/explore-side-panel.tsx
+++ b/apps/web/partials/explore/explore-side-panel.tsx
@@ -48,23 +48,29 @@ export function ExploreSidePanel({
   if (!hasContent) return null;
 
   // Build only the sections that have content, then join them with dividers so
-  // an empty section never leaves a dangling <hr> (e.g. join-spaces-only).
-  const sections: React.ReactNode[] = [];
+  // an empty section never leaves a dangling <hr> (e.g. join-spaces-only). Each
+  // carries a stable key so appearing/disappearing sections don't remount others.
+  const sections: { key: string; node: React.ReactNode }[] = [];
   if (joinableSpaces.length > 0) {
-    sections.push(<JoinSpacesSection key="join-spaces" spaces={joinableSpaces} />);
+    sections.push({ key: 'join-spaces', node: <JoinSpacesSection spaces={joinableSpaces} /> });
   }
   if (unclaimedTopics.length > 0 || parentTopicOptions.length > 0) {
-    sections.push(<ClaimATopicSection key="claim" topics={unclaimedTopics} parentTopicOptions={parentTopicOptions} />);
+    sections.push({
+      key: 'claim',
+      node: <ClaimATopicSection topics={unclaimedTopics} parentTopicOptions={parentTopicOptions} />,
+    });
   }
   if (recentlyClaimedSpaces.length > 0) {
-    sections.push(
-      <RecentlyClaimedSection
-        key="recently-claimed"
-        spaces={recentlyClaimedSpaces}
-        pendingMembershipSpaceIds={pendingSet}
-        memberOrEditorSpaceIds={memberOrEditorSet}
-      />
-    );
+    sections.push({
+      key: 'recently-claimed',
+      node: (
+        <RecentlyClaimedSection
+          spaces={recentlyClaimedSpaces}
+          pendingMembershipSpaceIds={pendingSet}
+          memberOrEditorSpaceIds={memberOrEditorSet}
+        />
+      ),
+    });
   }
 
   return (
@@ -79,9 +85,9 @@ export function ExploreSidePanel({
       <div className="no-scrollbar min-h-0 flex-1 overflow-x-hidden overflow-y-auto overscroll-contain">
         <div className="flex flex-col pt-5 pb-6">
           {sections.map((section, index) => (
-            <React.Fragment key={index}>
+            <React.Fragment key={section.key}>
               {index > 0 ? <hr className="my-6 border-t border-divider" /> : null}
-              {section}
+              {section.node}
             </React.Fragment>
           ))}
         </div>

--- a/apps/web/partials/explore/explore-side-panel.tsx
+++ b/apps/web/partials/explore/explore-side-panel.tsx
@@ -1,14 +1,20 @@
 'use client';
 
+import * as React from 'react';
+
+import { usePendingMembershipSet } from '~/core/hooks/use-pending-memberships';
+import type { FeaturedSpace } from '~/core/io/subgraph/fetch-featured-spaces';
 import type { RootTopicChip } from '~/core/io/subgraph/fetch-first-level-subtopics';
 import type { ParentTopicOption } from '~/core/io/subgraph/fetch-parent-topic-options';
 import type { RecentlyClaimedSpace } from '~/core/io/subgraph/fetch-recently-claimed-spaces';
 import { normId } from '~/core/utils/norm-id';
 
 import { ClaimATopicSection } from './claim-a-topic-section';
+import { JoinSpacesSection } from './join-spaces-section';
 import { RecentlyClaimedSection } from './recently-claimed-section';
 
 export type ExploreSidePanelProps = {
+  featuredSpaces: FeaturedSpace[];
   unclaimedTopics: RootTopicChip[];
   recentlyClaimedSpaces: RecentlyClaimedSpace[];
   parentTopicOptions: ParentTopicOption[];
@@ -17,17 +23,49 @@ export type ExploreSidePanelProps = {
 };
 
 export function ExploreSidePanel({
+  featuredSpaces,
   unclaimedTopics,
   recentlyClaimedSpaces,
   parentTopicOptions,
   pendingMembershipSpaceIds,
   memberOrEditorSpaceIds,
 }: ExploreSidePanelProps) {
-  const hasContent = unclaimedTopics.length > 0 || recentlyClaimedSpaces.length > 0;
-  if (!hasContent) return null;
+  // Durable (server) + optimistic (persisted) pending requests, unioned with the
+  // SSR-seeded set for first paint.
+  const dynamicPendingSet = usePendingMembershipSet();
 
   const pendingSet = new Set(pendingMembershipSpaceIds.map(normId));
   const memberOrEditorSet = new Set(memberOrEditorSpaceIds.map(normId));
+
+  // A space drops out of "Join spaces" once the user belongs to it, already has
+  // a pending request from a prior visit, or just requested one this session.
+  const joinableSpaces = featuredSpaces.filter(space => {
+    const normalized = normId(space.spaceId);
+    return !memberOrEditorSet.has(normalized) && !pendingSet.has(normalized) && !dynamicPendingSet.has(normalized);
+  });
+
+  const hasContent = joinableSpaces.length > 0 || unclaimedTopics.length > 0 || recentlyClaimedSpaces.length > 0;
+  if (!hasContent) return null;
+
+  // Build only the sections that have content, then join them with dividers so
+  // an empty section never leaves a dangling <hr> (e.g. join-spaces-only).
+  const sections: React.ReactNode[] = [];
+  if (joinableSpaces.length > 0) {
+    sections.push(<JoinSpacesSection key="join-spaces" spaces={joinableSpaces} />);
+  }
+  if (unclaimedTopics.length > 0 || parentTopicOptions.length > 0) {
+    sections.push(<ClaimATopicSection key="claim" topics={unclaimedTopics} parentTopicOptions={parentTopicOptions} />);
+  }
+  if (recentlyClaimedSpaces.length > 0) {
+    sections.push(
+      <RecentlyClaimedSection
+        key="recently-claimed"
+        spaces={recentlyClaimedSpaces}
+        pendingMembershipSpaceIds={pendingSet}
+        memberOrEditorSpaceIds={memberOrEditorSet}
+      />
+    );
+  }
 
   return (
     // Independent scroll surface mirroring BrowseSidebar pattern
@@ -40,13 +78,12 @@ export function ExploreSidePanel({
     <aside className="sticky top-11 flex h-[calc(100dvh-2.75rem)] w-[360px] shrink-0 flex-col self-start lg:hidden">
       <div className="no-scrollbar min-h-0 flex-1 overflow-x-hidden overflow-y-auto overscroll-contain">
         <div className="flex flex-col pt-5 pb-6">
-          <ClaimATopicSection topics={unclaimedTopics} parentTopicOptions={parentTopicOptions} />
-          <hr className="my-6 border-t border-divider" />
-          <RecentlyClaimedSection
-            spaces={recentlyClaimedSpaces}
-            pendingMembershipSpaceIds={pendingSet}
-            memberOrEditorSpaceIds={memberOrEditorSet}
-          />
+          {sections.map((section, index) => (
+            <React.Fragment key={index}>
+              {index > 0 ? <hr className="my-6 border-t border-divider" /> : null}
+              {section}
+            </React.Fragment>
+          ))}
         </div>
       </div>
     </aside>

--- a/apps/web/partials/explore/join-spaces-section.tsx
+++ b/apps/web/partials/explore/join-spaces-section.tsx
@@ -7,8 +7,8 @@ import { useSmartAccount } from '~/core/hooks/use-smart-account';
 import type { FeaturedSpace } from '~/core/io/subgraph/fetch-featured-spaces';
 import { useSignInPrompt } from '~/core/state/sign-in-prompt-store';
 
+import { Dots } from '~/design-system/dots';
 import { FallbackImage } from '~/design-system/fallback-image';
-import { Pending } from '~/design-system/pending';
 
 type Props = {
   // Already filtered by the side panel to spaces the user can still join.
@@ -72,20 +72,28 @@ function JoinSpacePill({ space }: { space: FeaturedSpace }) {
     requestToBeMember();
   };
 
+  const isPending = status === 'pending';
+
   return (
-    <Pending isPending={status === 'pending'} position="center">
-      <button
-        type="button"
-        aria-label={`Join ${space.name}`}
-        disabled={status !== 'idle'}
-        onClick={handleClick}
-        className="inline-flex items-center gap-1.5 rounded-full border border-grey-02 py-1.5 pr-2.5 pl-2 text-[16px] leading-[18px] text-text transition-colors hover:border-text disabled:cursor-default"
-      >
-        <span className="relative h-4 w-4 shrink-0 overflow-hidden rounded-full bg-grey-01">
-          <FallbackImage value={space.image} sizes="16px" className="object-cover" />
+    // While the request is in flight keep the icon and outline in place and swap
+    // just the name for the oscillating dots, so the pill doesn't blink out.
+    <button
+      type="button"
+      aria-label={`Join ${space.name}`}
+      disabled={status !== 'idle'}
+      onClick={handleClick}
+      className="inline-flex items-center gap-1.5 rounded-full border border-grey-02 py-1.5 pr-2.5 pl-2 text-[16px] leading-[18px] text-text transition-colors hover:border-text disabled:cursor-default"
+    >
+      <span className="relative h-4 w-4 shrink-0 overflow-hidden rounded-full bg-grey-01">
+        <FallbackImage value={space.image} sizes="16px" className="object-cover" />
+      </span>
+      {isPending ? (
+        <span className="flex h-[18px] items-center px-1">
+          <Dots />
         </span>
+      ) : (
         <span className="truncate">{space.name}</span>
-      </button>
-    </Pending>
+      )}
+    </button>
   );
 }

--- a/apps/web/partials/explore/join-spaces-section.tsx
+++ b/apps/web/partials/explore/join-spaces-section.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+import * as React from 'react';
+
+import { useRequestToBeMember } from '~/core/hooks/use-request-to-be-member';
+import { useSmartAccount } from '~/core/hooks/use-smart-account';
+import type { FeaturedSpace } from '~/core/io/subgraph/fetch-featured-spaces';
+import { useSignInPrompt } from '~/core/state/sign-in-prompt-store';
+
+import { FallbackImage } from '~/design-system/fallback-image';
+import { Pending } from '~/design-system/pending';
+
+type Props = {
+  // Already filtered by the side panel to spaces the user can still join.
+  spaces: FeaturedSpace[];
+};
+
+// Match the design: nine space pills, with a tenth "Show more" pill that
+// reveals the rest.
+const INITIAL_VISIBLE_COUNT = 9;
+
+export function JoinSpacesSection({ spaces }: Props) {
+  const [showAll, setShowAll] = React.useState(false);
+
+  if (spaces.length === 0) return null;
+
+  const visible = showAll ? spaces : spaces.slice(0, INITIAL_VISIBLE_COUNT);
+  const hasMore = spaces.length > INITIAL_VISIBLE_COUNT;
+
+  return (
+    <section className="flex flex-col">
+      <h2 className="sticky top-0 z-20 bg-white pt-1 pb-4 text-[19px] leading-[23px] font-semibold tracking-[-0.02em] text-text">
+        Join spaces
+      </h2>
+
+      <div className="flex flex-wrap gap-2">
+        {visible.map(space => (
+          <JoinSpacePill key={space.spaceId} space={space} />
+        ))}
+
+        {hasMore ? (
+          <button
+            type="button"
+            onClick={() => setShowAll(prev => !prev)}
+            className="inline-flex items-center rounded-full border border-grey-02 py-1.5 pr-2.5 pl-2 text-[16px] leading-[18px] text-grey-04 transition-colors hover:border-text hover:text-text"
+          >
+            {showAll ? 'Show less' : 'Show more'}
+          </button>
+        ) : null}
+      </div>
+    </section>
+  );
+}
+
+function JoinSpacePill({ space }: { space: FeaturedSpace }) {
+  // On success useRequestToBeMember records the request (persisted) and
+  // invalidates the durable pending sources, so the pill drops out of this list
+  // — the side panel re-filters off the same state — and the space surfaces as
+  // "Membership pending" in the browse sidebar.
+  const { requestToBeMember, status } = useRequestToBeMember({
+    spaceId: space.spaceId,
+    space: { name: space.name, image: space.image },
+  });
+  const { smartAccount } = useSmartAccount();
+  const { open: openSignInPrompt } = useSignInPrompt();
+
+  const handleClick = () => {
+    if (!smartAccount) {
+      openSignInPrompt('join');
+      return;
+    }
+    requestToBeMember();
+  };
+
+  return (
+    <Pending isPending={status === 'pending'} position="center">
+      <button
+        type="button"
+        aria-label={`Join ${space.name}`}
+        disabled={status !== 'idle'}
+        onClick={handleClick}
+        className="inline-flex items-center gap-1.5 rounded-full border border-grey-02 py-1.5 pr-2.5 pl-2 text-[16px] leading-[18px] text-text transition-colors hover:border-text disabled:cursor-default"
+      >
+        <span className="relative h-4 w-4 shrink-0 overflow-hidden rounded-full bg-grey-01">
+          <FallbackImage value={space.image} sizes="16px" className="object-cover" />
+        </span>
+        <span className="truncate">{space.name}</span>
+      </button>
+    </Pending>
+  );
+}

--- a/apps/web/partials/space-page/space-members-join-button.tsx
+++ b/apps/web/partials/space-page/space-members-join-button.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useIsMembershipPending } from '~/core/hooks/use-pending-memberships';
 import { useRequestToBeMember } from '~/core/hooks/use-request-to-be-member';
 import { useSmartAccount } from '~/core/hooks/use-smart-account';
 import { type ActiveMemberRequest } from '~/core/io/subgraph/fetch-proposed-members';
@@ -18,13 +19,18 @@ export function SpaceMembersJoinButton({ spaceId, memberRequest }: SpaceMembersJ
   const { requestToBeMember, status } = useRequestToBeMember({ spaceId });
   const { smartAccount } = useSmartAccount();
   const { open: openSignInPrompt } = useSignInPrompt();
+  // Durable + optimistic pending state so a request made anywhere (and surviving
+  // refresh) reflects here without waiting on this page's SSR memberRequest.
+  const isPending = useIsMembershipPending(spaceId);
 
   // A still-listed request whose vote has ended is busted: executed requests drop
   // off the list, so this one can no longer execute and the vote can't be revived.
   const isStuck = Boolean(memberRequest?.isVotingEnded);
 
-  // Open vote, or just submitted (before the indexer catches up) — show the live vote.
-  const showUnderVote = status === 'success' || (memberRequest != null && !isStuck);
+  // Open vote, or just submitted (before the indexer catches up) — show the live
+  // vote. A stuck request never counts as under vote, so the Join button can
+  // reappear.
+  const showUnderVote = status === 'success' || (!isStuck && (memberRequest != null || isPending));
 
   return (
     <>

--- a/apps/web/partials/space-page/space-members-popover-members-request-button.tsx
+++ b/apps/web/partials/space-page/space-members-popover-members-request-button.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useIsMembershipPending } from '~/core/hooks/use-pending-memberships';
 import { useRequestToBeMember } from '~/core/hooks/use-request-to-be-member';
 import { useSmartAccount } from '~/core/hooks/use-smart-account';
 import { type ActiveMemberRequest } from '~/core/io/subgraph/fetch-proposed-members';
@@ -21,14 +22,17 @@ export function SpaceMembersPopoverMemberRequestButton({
   const { requestToBeMember, status } = useRequestToBeMember({ spaceId });
   const { smartAccount } = useSmartAccount();
   const { open: openSignInPrompt } = useSignInPrompt();
+  // Durable + optimistic pending state so a request made anywhere (and surviving
+  // refresh) reflects here without waiting on this page's SSR memberRequest.
+  const isPending = useIsMembershipPending(spaceId);
 
   // A still-listed request whose vote has ended is busted: executed requests drop
   // off the list, so this one can no longer execute and the vote can't be revived.
   const isStuck = Boolean(memberRequest?.isVotingEnded);
 
   // Open vote, or just submitted (before the indexer catches up) — show the live
-  // vote so we never flip back to "Request again".
-  if (status === 'success' || (memberRequest && !isStuck)) {
+  // vote so we never flip back to "Request again". A stuck request never counts.
+  if (status === 'success' || (!isStuck && (memberRequest != null || isPending))) {
     return (
       <span className="text-smallButton text-grey-04">
         <UnderVote />


### PR DESCRIPTION
Adds a "Join spaces" section to the explore side panel: walks the root space's subtopic tree to surface one pill per topic that has a space (top-ranked when multiple), ordered by space rank. Clicking a pill requests membership; the pill drops out and the space appears under "Member of" in the browse sidebar as "Membership pending".

Pending state is now durable and consistent across surfaces:
- fetch-pending-membership-space-ids: enumerate candidate spaces via GraphQL proposalActionsConnection, then confirm each through the REST /active endpoint for exact parity with the space page (drops rejected/voting-ended proposals the old executedAt-null heuristic kept).
- Fixes the browse sidebar's pending query, which filtered proposalsConnection by fields ProposalFilter doesn't expose and so silently returned nothing.
- useRequestToBeMember centralizes the optimistic, persisted write and invalidates the durable sources, so a request from anywhere reflects in the sidebar and space-page Join buttons and survives refresh.