### PR TITLE
feat: add gated Questions tab

### DIFF
--- a/apps/web/app/entry.tsx
+++ b/apps/web/app/entry.tsx
@@ -19,6 +19,7 @@ import { ClientOnly } from '~/design-system/client-only';
 import { BrowseSidebar } from '~/partials/browse-sidebar/browse-sidebar';
 import { CreateSpaceDialog } from '~/partials/create-space/create-space-dialog';
 import { EntitySidePanel } from '~/partials/entity-page/entity-side-panel';
+import { FeatureFlagsDialog } from '~/partials/feature-flags/feature-flags-dialog';
 import { GovernanceReopenEditLoadingBar } from '~/partials/governance/governance-reopen-edit-loading-bar';
 import { Main } from '~/partials/main';
 import { Navbar } from '~/partials/navbar/navbar';
@@ -114,6 +115,7 @@ export function App({ children }: { children: React.ReactNode }) {
         <StatusBar />
         <ReviewChanges />
         <ChatWidget />
+        <FeatureFlagsDialog />
         <Persistence />
       </ClientOnly>
       {process.env.NODE_ENV === 'production' && <Analytics />}

--- a/apps/web/app/space/[id]/(space)/questions/page.tsx
+++ b/apps/web/app/space/[id]/(space)/questions/page.tsx
@@ -1,0 +1,19 @@
+import { IdUtils } from '@geoprotocol/geo-sdk/lite';
+
+import { notFound } from 'next/navigation';
+
+import { QuestionsPageClient } from './questions-page-client';
+
+interface Props {
+  params: Promise<{ id: string }>;
+}
+
+export default async function QuestionsPage(props: Props) {
+  const params = await props.params;
+
+  if (!IdUtils.isValid(params.id)) {
+    notFound();
+  }
+
+  return <QuestionsPageClient spaceId={params.id} />;
+}

--- a/apps/web/app/space/[id]/(space)/questions/questions-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/questions/questions-page-client.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import * as React from 'react';
+
+import { useRouter } from 'next/navigation';
+
+import { useFeatureFlag } from '~/core/state/feature-flags';
+
+type QuestionsPageClientProps = {
+  spaceId: string;
+};
+
+export function QuestionsPageClient({ spaceId }: QuestionsPageClientProps) {
+  const questionsTabEnabled = useFeatureFlag('questionsTab');
+  const router = useRouter();
+
+  React.useEffect(() => {
+    if (!questionsTabEnabled) {
+      router.replace(`/space/${spaceId}`);
+    }
+  }, [questionsTabEnabled, router, spaceId]);
+
+  if (!questionsTabEnabled) return null;
+
+  return (
+    <div className="py-8">
+      <div className="rounded-lg border border-grey-02 bg-white px-5 py-6">
+        <h2 className="text-smallTitle text-text">Questions</h2>
+        <p className="mt-2 max-w-[560px] text-body text-grey-04">
+          Questions for this space will live here. This preview tab is ready for the next Q&amp;A workflow.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/core/state/feature-flags.test.ts
+++ b/apps/web/core/state/feature-flags.test.ts
@@ -1,0 +1,32 @@
+import { createStore } from 'jotai';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  defaultFeatureFlags,
+  featureFlagsAtom,
+  featureFlagsStorageKey,
+  normalizeFeatureFlags,
+  setFeatureFlagValue,
+} from './feature-flags';
+
+describe('feature flags', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('defaults the Questions tab flag to disabled', () => {
+    expect(defaultFeatureFlags.questionsTab).toBe(false);
+    expect(normalizeFeatureFlags(null)).toEqual({ questionsTab: false });
+  });
+
+  it('persists toggled feature flag values', () => {
+    const store = createStore();
+
+    store.set(featureFlagsAtom, currentFlags =>
+      setFeatureFlagValue(normalizeFeatureFlags(currentFlags), 'questionsTab', true)
+    );
+
+    expect(store.get(featureFlagsAtom).questionsTab).toBe(true);
+    expect(window.localStorage.getItem(featureFlagsStorageKey)).toBe(JSON.stringify({ questionsTab: true }));
+  });
+});

--- a/apps/web/core/state/feature-flags.ts
+++ b/apps/web/core/state/feature-flags.ts
@@ -1,0 +1,63 @@
+'use client';
+
+import { useAtom, useAtomValue } from 'jotai';
+import { atomWithStorage } from 'jotai/utils';
+
+export const featureFlagsStorageKey = 'geo:feature-flags';
+
+export const featureFlagDefinitions = [
+  {
+    id: 'questionsTab',
+    label: 'Questions tab',
+    description: 'Show the Questions tab on spaces.',
+  },
+] as const;
+
+export type FeatureFlagId = (typeof featureFlagDefinitions)[number]['id'];
+export type FeatureFlags = Record<FeatureFlagId, boolean>;
+
+export const defaultFeatureFlags: FeatureFlags = {
+  questionsTab: false,
+};
+
+export function normalizeFeatureFlags(flags: Partial<Record<FeatureFlagId, boolean>> | null | undefined): FeatureFlags {
+  return {
+    ...defaultFeatureFlags,
+    ...flags,
+  };
+}
+
+export function setFeatureFlagValue(flags: FeatureFlags, id: FeatureFlagId, enabled: boolean): FeatureFlags {
+  return {
+    ...flags,
+    [id]: enabled,
+  };
+}
+
+export const featureFlagsAtom = atomWithStorage<FeatureFlags>(
+  featureFlagsStorageKey,
+  defaultFeatureFlags,
+  undefined,
+  {
+    getOnInit: true,
+  }
+);
+
+export function useFeatureFlag(id: FeatureFlagId) {
+  const flags = useAtomValue(featureFlagsAtom);
+  return normalizeFeatureFlags(flags)[id];
+}
+
+export function useFeatureFlags() {
+  const [flags, setFlags] = useAtom(featureFlagsAtom);
+  const normalizedFlags = normalizeFeatureFlags(flags);
+
+  const setFeatureFlag = (id: FeatureFlagId, enabled: boolean) => {
+    setFlags(currentFlags => setFeatureFlagValue(normalizeFeatureFlags(currentFlags), id, enabled));
+  };
+
+  return {
+    flags: normalizedFlags,
+    setFeatureFlag,
+  };
+}

--- a/apps/web/partials/feature-flags/feature-flags-dialog.test.tsx
+++ b/apps/web/partials/feature-flags/feature-flags-dialog.test.tsx
@@ -1,0 +1,31 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { Provider, createStore } from 'jotai';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { featureFlagsStorageKey } from '~/core/state/feature-flags';
+
+import { FeatureFlagsDialog } from './feature-flags-dialog';
+
+describe('FeatureFlagsDialog', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('opens with Cmd/Ctrl+Shift+F and toggles the Questions tab flag', async () => {
+    render(
+      <Provider store={createStore()}>
+        <FeatureFlagsDialog />
+      </Provider>
+    );
+
+    fireEvent.keyDown(window, { key: 'f', ctrlKey: true, shiftKey: true });
+
+    expect(await screen.findByRole('heading', { name: 'Feature flags' })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Questions tab' }));
+
+    await waitFor(() => {
+      expect(window.localStorage.getItem(featureFlagsStorageKey)).toBe(JSON.stringify({ questionsTab: true }));
+    });
+  });
+});

--- a/apps/web/partials/feature-flags/feature-flags-dialog.tsx
+++ b/apps/web/partials/feature-flags/feature-flags-dialog.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import { Content, Description, Overlay, Portal, Root, Title } from '@radix-ui/react-dialog';
+
+import * as React from 'react';
+
+import { featureFlagDefinitions, useFeatureFlags } from '~/core/state/feature-flags';
+
+import { SquareButton } from '~/design-system/button';
+import { Checkbox } from '~/design-system/checkbox';
+import { Close } from '~/design-system/icons/close';
+import { Text } from '~/design-system/text';
+
+export function FeatureFlagsDialog() {
+  const [open, setOpen] = React.useState(false);
+  const { flags, setFeatureFlag } = useFeatureFlags();
+
+  React.useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (!(event.metaKey || event.ctrlKey) || !event.shiftKey || event.key.toLowerCase() !== 'f') return;
+
+      event.preventDefault();
+      setOpen(value => !value);
+    };
+
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, []);
+
+  return (
+    <Root open={open} onOpenChange={setOpen}>
+      <Portal>
+        <Overlay className="fixed inset-0 z-100 bg-text/20" />
+
+        <Content className="fixed inset-0 z-101 flex items-start justify-center focus:outline-hidden">
+          <div className="mt-32 flex w-[420px] max-w-[calc(100vw-32px)] flex-col gap-4 rounded-xl bg-white p-4 shadow-lg">
+            <div className="flex items-start justify-between gap-4">
+              <Title asChild>
+                <Text variant="smallTitle" as="h2">
+                  Feature flags
+                </Text>
+              </Title>
+              <Description className="sr-only">Toggle local preview features for this browser.</Description>
+              <SquareButton onClick={() => setOpen(false)} icon={<Close />} aria-label="Close feature flags" />
+            </div>
+
+            <div className="flex flex-col divide-y divide-grey-02">
+              {featureFlagDefinitions.map(feature => (
+                <div key={feature.id} className="flex items-start justify-between gap-4 py-3 first:pt-0 last:pb-0">
+                  <div className="flex min-w-0 flex-col gap-1">
+                    <span className="text-button text-text">{feature.label}</span>
+                    <span className="text-footnote text-grey-04">{feature.description}</span>
+                  </div>
+                  <Checkbox
+                    checked={flags[feature.id]}
+                    onChange={() => setFeatureFlag(feature.id, !flags[feature.id])}
+                    aria-label={feature.label}
+                    aria-pressed={flags[feature.id]}
+                    className="mt-0.5 shrink-0"
+                  />
+                </div>
+              ))}
+            </div>
+          </div>
+        </Content>
+      </Portal>
+    </Root>
+  );
+}

--- a/apps/web/partials/space-page/space-tabs.test.ts
+++ b/apps/web/partials/space-page/space-tabs.test.ts
@@ -48,4 +48,17 @@ describe('buildSpaceTabs', () => {
 
     expect(tabs.map(tab => tab.label)).toEqual(['Overview', 'Facts', 'Sources', 'Questions', 'Activity']);
   });
+
+  it('keeps the system Questions route when a dynamic tab has the same label', () => {
+    const tabs = buildSpaceTabs({
+      spaceId,
+      overviewHref,
+      dynamicTabs: [...dynamicTabs, { label: 'Questions', href: `${overviewHref}?tabId=dynamic-questions` }],
+      typeIds: [SystemIds.SPACE_TYPE],
+      questionsTabEnabled: true,
+    });
+
+    expect(tabs.map(tab => tab.label)).toEqual(['Overview', 'Facts', 'Sources', 'Questions', 'Governance', 'Activity']);
+    expect(tabs.find(tab => tab.label === 'Questions')?.href).toBe(`/space/${spaceId}/questions`);
+  });
 });

--- a/apps/web/partials/space-page/space-tabs.test.ts
+++ b/apps/web/partials/space-page/space-tabs.test.ts
@@ -1,0 +1,51 @@
+import { SystemIds } from '@geoprotocol/geo-sdk/lite';
+
+import { describe, expect, it } from 'vitest';
+
+import { buildSpaceTabs } from './space-tabs';
+
+const spaceId = 'space-id';
+const overviewHref = `/space/${spaceId}`;
+const dynamicTabs = [
+  { label: 'Facts', href: `${overviewHref}?tabId=facts` },
+  { label: 'Sources', href: `${overviewHref}?tabId=sources` },
+];
+
+describe('buildSpaceTabs', () => {
+  it('omits Questions when the feature flag is disabled', () => {
+    const tabs = buildSpaceTabs({
+      spaceId,
+      overviewHref,
+      dynamicTabs,
+      typeIds: [SystemIds.SPACE_TYPE],
+      questionsTabEnabled: false,
+    });
+
+    expect(tabs.map(tab => tab.label)).toEqual(['Overview', 'Facts', 'Sources', 'Governance', 'Activity']);
+  });
+
+  it('inserts Questions after content tabs and before Governance when enabled', () => {
+    const tabs = buildSpaceTabs({
+      spaceId,
+      overviewHref,
+      dynamicTabs,
+      typeIds: [SystemIds.SPACE_TYPE],
+      questionsTabEnabled: true,
+    });
+
+    expect(tabs.map(tab => tab.label)).toEqual(['Overview', 'Facts', 'Sources', 'Questions', 'Governance', 'Activity']);
+    expect(tabs.find(tab => tab.label === 'Questions')?.href).toBe(`/space/${spaceId}/questions`);
+  });
+
+  it('keeps personal spaces from showing Governance while still showing Questions', () => {
+    const tabs = buildSpaceTabs({
+      spaceId,
+      overviewHref,
+      dynamicTabs,
+      typeIds: [SystemIds.SPACE_TYPE, SystemIds.PERSON_TYPE],
+      questionsTabEnabled: true,
+    });
+
+    expect(tabs.map(tab => tab.label)).toEqual(['Overview', 'Facts', 'Sources', 'Questions', 'Activity']);
+  });
+});

--- a/apps/web/partials/space-page/space-tabs.tsx
+++ b/apps/web/partials/space-page/space-tabs.tsx
@@ -5,6 +5,7 @@ import { SystemIds } from '@geoprotocol/geo-sdk/lite';
 import * as React from 'react';
 
 import { useEditable } from '~/core/state/editable-store';
+import { useFeatureFlag } from '~/core/state/feature-flags';
 import { useRelations, useValues } from '~/core/sync/use-store';
 import { TabEntity } from '~/core/types';
 import { Relation } from '~/core/types';
@@ -22,8 +23,89 @@ type SpaceTabsProps = {
   typeIds: string[];
 };
 
+type BuiltSpaceTab = {
+  label: string;
+  href: string;
+  priority: 1 | 2 | 3 | 4;
+};
+
+type BuildSpaceTabsParams = {
+  spaceId: string;
+  overviewHref: string;
+  dynamicTabs: Array<{ label: string; href: string }>;
+  typeIds: string[];
+  questionsTabEnabled: boolean;
+};
+
+export function buildSpaceTabs({
+  spaceId,
+  overviewHref,
+  dynamicTabs,
+  typeIds,
+  questionsTabEnabled,
+}: BuildSpaceTabsParams): BuiltSpaceTab[] {
+  const tabs: BuiltSpaceTab[] = [];
+
+  const ALL_SPACES_TABS: BuiltSpaceTab[] = [
+    {
+      label: 'Overview',
+      href: overviewHref,
+      priority: 1,
+    },
+  ];
+
+  const QUESTION_TAB: BuiltSpaceTab = {
+    label: 'Questions',
+    href: `/space/${spaceId}/questions`,
+    priority: 2,
+  };
+
+  const SOME_SPACES_TABS: BuiltSpaceTab[] = [
+    {
+      label: 'Governance',
+      href: `/space/${spaceId}/governance`,
+      priority: 3,
+    },
+  ];
+
+  const ACTIVITY_TAB: BuiltSpaceTab = {
+    label: 'Activity',
+    href: `/space/${spaceId}/activity`,
+    priority: 4,
+  };
+
+  tabs.push(...ALL_SPACES_TABS);
+
+  if (typeIds.includes(SystemIds.SPACE_TYPE)) {
+    if (dynamicTabs.length > 0) {
+      tabs.push(...dynamicTabs.map(tab => ({ ...tab, priority: 1 as const })));
+    }
+  }
+
+  if (questionsTabEnabled) {
+    tabs.push(QUESTION_TAB);
+  }
+
+  if (typeIds.includes(SystemIds.SPACE_TYPE) && !typeIds.includes(SystemIds.PERSON_TYPE)) {
+    tabs.push(...SOME_SPACES_TABS);
+  }
+
+  tabs.push(ACTIVITY_TAB);
+
+  const seen = new Map<string, BuiltSpaceTab>();
+
+  for (const tab of tabs) {
+    if (!seen.has(tab.label)) {
+      seen.set(tab.label, tab);
+    }
+  }
+
+  return [...seen.values()].sort((a, b) => a.priority - b.priority);
+}
+
 export function SpaceTabs({ spaceId, entityId, initialTabRelations, tabEntities, typeIds }: SpaceTabsProps) {
   const { editable } = useEditable();
+  const questionsTabEnabled = useFeatureFlag('questionsTab');
 
   // Merge local tab relation changes with server data
   const mergedTabRelations = useRelations({
@@ -61,6 +143,10 @@ export function SpaceTabs({ spaceId, entityId, initialTabRelations, tabEntities,
   // Build system tabs that appear after dynamic tabs
   const systemTabsAfter: Array<{ label: string; href: string }> = [];
 
+  if (questionsTabEnabled) {
+    systemTabsAfter.push({ label: 'Questions', href: `/space/${spaceId}/questions` });
+  }
+
   if (typeIds.includes(SystemIds.SPACE_TYPE) && !typeIds.includes(SystemIds.PERSON_TYPE)) {
     systemTabsAfter.push({ label: 'Governance', href: `/space/${spaceId}/governance` });
   }
@@ -91,57 +177,9 @@ export function SpaceTabs({ spaceId, entityId, initialTabRelations, tabEntities,
   const dynamicTabs = sortedTabEntities.map(entity => ({
     label: entity.name ?? '',
     href: `${overviewHref}?tabId=${entity.id}`,
-    priority: 1 as const,
   }));
 
-  const tabs = [];
+  const tabs = buildSpaceTabs({ spaceId, overviewHref, dynamicTabs, typeIds, questionsTabEnabled });
 
-  const ALL_SPACES_TABS = [
-    {
-      label: 'Overview',
-      href: overviewHref,
-      priority: 1 as const,
-    },
-  ];
-
-  const SOME_SPACES_TABS = [
-    {
-      label: 'Governance',
-      href: `/space/${spaceId}/governance`,
-      priority: 2 as const,
-    },
-  ];
-
-  const ACTIVITY_TAB = {
-    label: 'Activity',
-    href: `/space/${spaceId}/activity`,
-    priority: 3 as const,
-  };
-
-  // Order of how we add the tabs matters. We want to
-  // show "content-based" tabs first, then "space-based" tabs.
-
-  tabs.push(...ALL_SPACES_TABS);
-
-  if (typeIds.includes(SystemIds.SPACE_TYPE)) {
-    if (dynamicTabs.length > 0) {
-      tabs.push(...dynamicTabs);
-    }
-
-    if (!typeIds.includes(SystemIds.PERSON_TYPE)) {
-      tabs.push(...SOME_SPACES_TABS);
-    }
-  }
-
-  tabs.push(ACTIVITY_TAB);
-
-  const seen = new Map<string, (typeof tabs)[0]>();
-
-  for (const tab of tabs) {
-    if (!seen.has(tab.label)) {
-      seen.set(tab.label, tab);
-    }
-  }
-
-  return <TabGroup tabs={[...seen.values()].sort((a, b) => a.priority - b.priority)} />;
+  return <TabGroup tabs={tabs} />;
 }

--- a/apps/web/partials/space-page/space-tabs.tsx
+++ b/apps/web/partials/space-page/space-tabs.tsx
@@ -78,7 +78,11 @@ export function buildSpaceTabs({
 
   if (typeIds.includes(SystemIds.SPACE_TYPE)) {
     if (dynamicTabs.length > 0) {
-      tabs.push(...dynamicTabs.map(tab => ({ ...tab, priority: 1 as const })));
+      const visibleDynamicTabs = questionsTabEnabled
+        ? dynamicTabs.filter(tab => tab.label !== QUESTION_TAB.label)
+        : dynamicTabs;
+
+      tabs.push(...visibleDynamicTabs.map(tab => ({ ...tab, priority: 1 as const })));
     }
   }
 


### PR DESCRIPTION
## Summary

Space pages can now expose a preview-only Questions tab without making it visible to everyone. A hidden local feature flag modal, opened with `Cmd/Ctrl+Shift+F`, lets a browser opt into the `questionsTab` flag; users without the flag keep the existing space tabs, and direct Questions URLs redirect back to the space overview.

The flag is stored locally in Jotai/localStorage, so this is a lightweight browser preference rather than a server rollout system. The tab is wired through both regular and editable space tab paths, and the first Questions route is a guarded placeholder ready for the future Q&A workflow.

## Validation

- `bun --cwd apps/web test`
- `bun --cwd apps/web lint` passes with existing warnings

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
