### PR TITLE
feat: build questions tab workflow

### DIFF
--- a/apps/web/app/space/[id]/(space)/questions/questions-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/questions/questions-page-client.test.tsx
@@ -30,6 +30,7 @@ let questions: Entity[] = [];
 let namesByEntityId = new Map<string, string>();
 let stagedRelations: Relation[] = [];
 let questionsTabEnabled = true;
+let lastQueryEntitiesOptions: unknown = null;
 
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ replace: mocks.replace }),
@@ -48,7 +49,10 @@ vi.mock('~/core/state/diff-store', () => ({
 }));
 
 vi.mock('~/core/sync/use-store', () => ({
-  useQueryEntities: () => ({ entities: questions, isLoading: false }),
+  useQueryEntities: (options: unknown) => {
+    lastQueryEntitiesOptions = options;
+    return { entities: questions, isLoading: false };
+  },
 }));
 
 vi.mock('~/core/sync/use-mutate', () => ({
@@ -93,6 +97,7 @@ beforeEach(() => {
   namesByEntityId = new Map();
   stagedRelations = [];
   questionsTabEnabled = true;
+  lastQueryEntitiesOptions = null;
   vi.clearAllMocks();
 
   mocks.nameSet.mockImplementation((entityId: string, _spaceId: string, value: string) => {
@@ -117,6 +122,18 @@ describe('QuestionsPageClient', () => {
     expect(screen.getByRole('heading', { name: 'Questions' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Add question' })).toBeInTheDocument();
     expect(screen.getByText('No questions yet')).toBeInTheDocument();
+  });
+
+  it('queries questions by current space and includes unpublished local edits', () => {
+    render(<QuestionsPageClient spaceId="space-1" />);
+
+    expect(lastQueryEntitiesOptions).toMatchObject({
+      where: {
+        spaces: [{ equals: 'space-1' }],
+        types: [{ id: { equals: QUESTION_TYPE_ID } }],
+      },
+      includeUnpublishedLocal: true,
+    });
   });
 
   it('expands and cancels the add question form', () => {

--- a/apps/web/app/space/[id]/(space)/questions/questions-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/questions/questions-page-client.test.tsx
@@ -1,0 +1,179 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ANSWERS_PROPERTY_ID, QUESTION_TYPE_ID } from '~/core/questions/ontology';
+import type { Entity, Relation } from '~/core/types';
+
+import { QuestionsPageClient } from './questions-page-client';
+
+const mocks = vi.hoisted(() => {
+  const replace = vi.fn();
+  const setActiveSpace = vi.fn();
+  const bumpReviewVersion = vi.fn();
+  const setIsReviewOpen = vi.fn();
+  const nameSet = vi.fn();
+  const relationSet = vi.fn();
+
+  return {
+    replace,
+    setActiveSpace,
+    bumpReviewVersion,
+    setIsReviewOpen,
+    nameSet,
+    relationSet,
+  };
+});
+
+let questions: Entity[] = [];
+let namesByEntityId = new Map<string, string>();
+let stagedRelations: Relation[] = [];
+let questionsTabEnabled = true;
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: mocks.replace }),
+}));
+
+vi.mock('~/core/state/feature-flags', () => ({
+  useFeatureFlag: () => questionsTabEnabled,
+}));
+
+vi.mock('~/core/state/diff-store', () => ({
+  useDiff: () => ({
+    setActiveSpace: mocks.setActiveSpace,
+    bumpReviewVersion: mocks.bumpReviewVersion,
+    setIsReviewOpen: mocks.setIsReviewOpen,
+  }),
+}));
+
+vi.mock('~/core/sync/use-store', () => ({
+  useQueryEntities: () => ({ entities: questions, isLoading: false }),
+}));
+
+vi.mock('~/core/sync/use-mutate', () => ({
+  useMutate: () => ({
+    storage: {
+      entities: {
+        name: {
+          set: mocks.nameSet,
+        },
+      },
+      relations: {
+        set: mocks.relationSet,
+      },
+    },
+  }),
+}));
+
+vi.mock('~/design-system/select-entity-compact', () => ({
+  SelectEntityCompact: ({ placeholder }: { placeholder: string }) => (
+    <div data-testid={`selector-${placeholder}`}>{placeholder}</div>
+  ),
+}));
+
+function rebuildQuestions() {
+  const questionIds = stagedRelations
+    .filter(relation => relation.toEntity.id === QUESTION_TYPE_ID)
+    .map(relation => relation.fromEntity.id);
+
+  questions = questionIds.map(questionId => ({
+    id: questionId,
+    name: namesByEntityId.get(questionId) ?? null,
+    description: null,
+    spaces: ['space-1'],
+    types: [{ id: QUESTION_TYPE_ID, name: 'Question' }],
+    values: [],
+    relations: stagedRelations.filter(relation => relation.fromEntity.id === questionId),
+  }));
+}
+
+beforeEach(() => {
+  questions = [];
+  namesByEntityId = new Map();
+  stagedRelations = [];
+  questionsTabEnabled = true;
+  vi.clearAllMocks();
+
+  mocks.nameSet.mockImplementation((entityId: string, _spaceId: string, value: string) => {
+    namesByEntityId.set(entityId, value);
+    rebuildQuestions();
+  });
+
+  mocks.relationSet.mockImplementation((relation: Relation) => {
+    stagedRelations.push(relation);
+    rebuildQuestions();
+  });
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('QuestionsPageClient', () => {
+  it('renders the empty state with Add question', () => {
+    render(<QuestionsPageClient spaceId="space-1" />);
+
+    expect(screen.getByRole('heading', { name: 'Questions' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Add question' })).toBeInTheDocument();
+    expect(screen.getByText('No questions yet')).toBeInTheDocument();
+  });
+
+  it('expands and cancels the add question form', () => {
+    render(<QuestionsPageClient spaceId="space-1" />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add question' }));
+
+    expect(screen.getByLabelText('Question')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('Yes')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('No')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(screen.queryByLabelText('Question')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Add question' })).toBeInTheDocument();
+  });
+
+  it('stages a valid question and opens Review edits for the current space', async () => {
+    render(<QuestionsPageClient spaceId="space-1" />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add question' }));
+    fireEvent.change(screen.getByLabelText('Question'), {
+      target: { value: 'Should we launch the questions workflow?' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Open proposal' }));
+
+    await waitFor(() => {
+      expect(mocks.nameSet).toHaveBeenCalled();
+      expect(mocks.relationSet).toHaveBeenCalled();
+      expect(mocks.setActiveSpace).toHaveBeenCalledWith('space-1');
+      expect(mocks.bumpReviewVersion).toHaveBeenCalled();
+      expect(mocks.setIsReviewOpen).toHaveBeenCalledWith(true);
+    });
+  });
+
+  it('shows the locally staged question in the list after submit', async () => {
+    render(<QuestionsPageClient spaceId="space-1" />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add question' }));
+    fireEvent.change(screen.getByLabelText('Question'), {
+      target: { value: 'Should we add ranking signals?' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Open proposal' }));
+
+    expect(await screen.findByText('Should we add ranking signals?')).toBeInTheDocument();
+    expect(screen.getByText('Answers')).toBeInTheDocument();
+    const answerRelations = stagedRelations.filter(relation => relation.type.id === ANSWERS_PROPERTY_ID);
+    expect(answerRelations.map(relation => relation.toEntity.name)).toEqual(['Yes', 'No']);
+  });
+
+  it('redirects direct visits when the feature flag is disabled', async () => {
+    questionsTabEnabled = false;
+
+    render(<QuestionsPageClient spaceId="space-1" />);
+
+    await waitFor(() => {
+      expect(mocks.replace).toHaveBeenCalledWith('/space/space-1');
+    });
+  });
+});

--- a/apps/web/app/space/[id]/(space)/questions/questions-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/questions/questions-page-client.tsx
@@ -2,13 +2,65 @@
 
 import * as React from 'react';
 
+import { keepPreviousData } from '@tanstack/react-query';
+import cx from 'classnames';
 import { useRouter } from 'next/navigation';
 
+import { Button } from '~/design-system/button';
+import { Plus } from '~/design-system/icons/plus';
+import { SelectEntityCompact, type SelectEntityCompactResult } from '~/design-system/select-entity-compact';
+import { Text } from '~/design-system/text';
+
+import { buildQuestionDraft } from '~/core/questions/question-draft';
+import {
+  ANSWERS_PROPERTY_ID,
+  PERSON_TYPE_ID,
+  PROJECT_TYPE_ID,
+  QUESTION_TYPE_ID,
+  RELATED_PEOPLE_PROPERTY_ID,
+  RELATED_PROJECTS_PROPERTY_ID,
+  TOPICS_PROPERTY_ID,
+  TOPIC_TYPE_ID,
+} from '~/core/questions/ontology';
+import { useDiff } from '~/core/state/diff-store';
 import { useFeatureFlag } from '~/core/state/feature-flags';
+import { useMutate } from '~/core/sync/use-mutate';
+import { useQueryEntities } from '~/core/sync/use-store';
+import type { Entity, Relation } from '~/core/types';
 
 type QuestionsPageClientProps = {
   spaceId: string;
 };
+
+type RelatedSelectionKey = 'topics' | 'relatedPeople' | 'relatedProjects';
+
+type RelatedField = {
+  key: RelatedSelectionKey;
+  label: string;
+  placeholder: string;
+  typeId: string;
+};
+
+const relatedFields: RelatedField[] = [
+  {
+    key: 'topics',
+    label: 'Topics',
+    placeholder: 'Search topics...',
+    typeId: TOPIC_TYPE_ID,
+  },
+  {
+    key: 'relatedPeople',
+    label: 'Related people',
+    placeholder: 'Search people...',
+    typeId: PERSON_TYPE_ID,
+  },
+  {
+    key: 'relatedProjects',
+    label: 'Related projects',
+    placeholder: 'Search projects...',
+    typeId: PROJECT_TYPE_ID,
+  },
+];
 
 export function QuestionsPageClient({ spaceId }: QuestionsPageClientProps) {
   const questionsTabEnabled = useFeatureFlag('questionsTab');
@@ -22,14 +74,270 @@ export function QuestionsPageClient({ spaceId }: QuestionsPageClientProps) {
 
   if (!questionsTabEnabled) return null;
 
+  return <QuestionsTabSurface spaceId={spaceId} />;
+}
+
+function QuestionsTabSurface({ spaceId }: QuestionsPageClientProps) {
+  const [formOpen, setFormOpen] = React.useState(false);
+  const { entities: questions, isLoading } = useQueryEntities({
+    where: {
+      space: { id: { equals: spaceId } },
+      types: [{ id: { equals: QUESTION_TYPE_ID } }],
+    },
+    first: 50,
+    placeholderData: keepPreviousData,
+    includeUnpublishedLocal: true,
+  });
+
   return (
     <div className="py-8">
-      <div className="rounded-lg border border-grey-02 bg-white px-5 py-6">
-        <h2 className="text-smallTitle text-text">Questions</h2>
-        <p className="mt-2 max-w-[560px] text-body text-grey-04">
-          Questions for this space will live here. This preview tab is ready for the next Q&amp;A workflow.
-        </p>
+      <div className="mb-5 flex flex-wrap items-center justify-between gap-3">
+        <Text as="h2" variant="smallTitle" color="text">
+          Questions
+        </Text>
+        {!formOpen && (
+          <Button type="button" variant="secondary" icon={<Plus />} onClick={() => setFormOpen(true)}>
+            Add question
+          </Button>
+        )}
+      </div>
+
+      {formOpen && <AddQuestionForm spaceId={spaceId} onCancel={() => setFormOpen(false)} />}
+
+      <div className={cx(formOpen && 'mt-6')}>
+        <QuestionsList questions={questions} isLoading={isLoading} />
       </div>
     </div>
   );
+}
+
+function AddQuestionForm({ spaceId, onCancel }: { spaceId: string; onCancel: () => void }) {
+  const { storage } = useMutate();
+  const { setActiveSpace, bumpReviewVersion, setIsReviewOpen } = useDiff();
+  const [questionText, setQuestionText] = React.useState('');
+  const [answerA, setAnswerA] = React.useState('Yes');
+  const [answerB, setAnswerB] = React.useState('No');
+  const [topics, setTopics] = React.useState<SelectEntityCompactResult[]>([]);
+  const [relatedPeople, setRelatedPeople] = React.useState<SelectEntityCompactResult[]>([]);
+  const [relatedProjects, setRelatedProjects] = React.useState<SelectEntityCompactResult[]>([]);
+  const [error, setError] = React.useState<string | null>(null);
+
+  const selectionsByKey = {
+    topics,
+    relatedPeople,
+    relatedProjects,
+  };
+
+  const setSelectionsByKey = {
+    topics: setTopics,
+    relatedPeople: setRelatedPeople,
+    relatedProjects: setRelatedProjects,
+  };
+
+  const addSelection = (key: RelatedSelectionKey, selection: SelectEntityCompactResult) => {
+    setSelectionsByKey[key](current => {
+      if (current.some(item => item.id === selection.id)) return current;
+      return [...current, selection];
+    });
+  };
+
+  const removeSelection = (key: RelatedSelectionKey, id: string) => {
+    setSelectionsByKey[key](current => current.filter(item => item.id !== id));
+  };
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setError(null);
+
+    try {
+      const draft = buildQuestionDraft({
+        spaceId,
+        questionText,
+        answerLabels: [answerA, answerB],
+        topics,
+        relatedPeople,
+        relatedProjects,
+      });
+
+      for (const name of draft.names) {
+        storage.entities.name.set(name.entityId, name.spaceId, name.value);
+      }
+
+      for (const relation of draft.relations) {
+        storage.relations.set(relation);
+      }
+
+      setActiveSpace(spaceId);
+      bumpReviewVersion();
+      setIsReviewOpen(true);
+      onCancel();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Could not stage the question.');
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="rounded-lg border border-grey-02 bg-white p-5 shadow-light">
+      <div className="space-y-4">
+        <label className="block">
+          <Text as="span" variant="metadataMedium" color="text">
+            Question
+          </Text>
+          <textarea
+            value={questionText}
+            onChange={event => setQuestionText(event.target.value)}
+            rows={3}
+            className="mt-2 block w-full resize-y rounded-md border border-grey-02 bg-white px-3 py-2 text-body text-text shadow-inner shadow-grey-02 outline-hidden placeholder:text-grey-03 focus:shadow-inner-lg focus:shadow-text"
+            placeholder="What should this space decide?"
+          />
+        </label>
+
+        <div className="grid gap-3 sm:grid-cols-2">
+          <label className="block">
+            <Text as="span" variant="metadataMedium" color="text">
+              Answer 1
+            </Text>
+            <input
+              type="text"
+              value={answerA}
+              onChange={event => setAnswerA(event.target.value)}
+              className="mt-2 block w-full rounded-md border border-grey-02 bg-white px-3 py-2 text-body text-text shadow-inner shadow-grey-02 outline-hidden placeholder:text-grey-03 focus:shadow-inner-lg focus:shadow-text"
+            />
+          </label>
+          <label className="block">
+            <Text as="span" variant="metadataMedium" color="text">
+              Answer 2
+            </Text>
+            <input
+              type="text"
+              value={answerB}
+              onChange={event => setAnswerB(event.target.value)}
+              className="mt-2 block w-full rounded-md border border-grey-02 bg-white px-3 py-2 text-body text-text shadow-inner shadow-grey-02 outline-hidden placeholder:text-grey-03 focus:shadow-inner-lg focus:shadow-text"
+            />
+          </label>
+        </div>
+
+        <div className="grid gap-4 lg:grid-cols-3">
+          {relatedFields.map(field => (
+            <div key={field.key} className="min-w-0">
+              <Text as="div" variant="metadataMedium" color="text" className="mb-2">
+                {field.label}
+              </Text>
+              <SelectEntityCompact
+                spaceId={spaceId}
+                placeholder={field.placeholder}
+                relationValueTypes={[{ id: field.typeId }]}
+                selected={selectionsByKey[field.key]}
+                onDone={selection => addSelection(field.key, selection)}
+                onRemoveSelected={id => removeSelection(field.key, id)}
+              />
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {error && (
+        <Text as="p" variant="body" color="red-01" className="mt-4">
+          {error}
+        </Text>
+      )}
+
+      <div className="mt-5 flex justify-end gap-2">
+        <Button type="button" variant="secondary" onClick={onCancel}>
+          Cancel
+        </Button>
+        <Button type="submit">Open proposal</Button>
+      </div>
+    </form>
+  );
+}
+
+function QuestionsList({ questions, isLoading }: { questions: Entity[]; isLoading: boolean }) {
+  if (isLoading && questions.length === 0) {
+    return (
+      <div className="rounded-lg border border-grey-02 bg-white px-5 py-6">
+        <Text color="grey-04">Loading questions...</Text>
+      </div>
+    );
+  }
+
+  if (questions.length === 0) {
+    return (
+      <div className="rounded-lg border border-grey-02 bg-white px-5 py-6">
+        <Text as="h3" variant="bodySemibold" color="text">
+          No questions yet
+        </Text>
+        <Text as="p" variant="body" color="grey-04" className="mt-2 max-w-[560px]">
+          Add a question to stage it as an edit, then publish it through Review edits.
+        </Text>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {questions.map(question => (
+        <QuestionListItem key={question.id} question={question} />
+      ))}
+    </div>
+  );
+}
+
+function QuestionListItem({ question }: { question: Entity }) {
+  const answers = relationsForProperty(question.relations, ANSWERS_PROPERTY_ID);
+  const topics = relationsForProperty(question.relations, TOPICS_PROPERTY_ID);
+  const relatedPeople = relationsForProperty(question.relations, RELATED_PEOPLE_PROPERTY_ID);
+  const relatedProjects = relationsForProperty(question.relations, RELATED_PROJECTS_PROPERTY_ID);
+
+  return (
+    <article className="rounded-lg border border-grey-02 bg-white px-5 py-4 shadow-light">
+      <Text as="h3" variant="bodySemibold" color="text" className="block">
+        {question.name ?? question.id}
+      </Text>
+
+      <RelationChipGroup label="Answers" relations={answers} className="mt-3" />
+
+      {(topics.length > 0 || relatedPeople.length > 0 || relatedProjects.length > 0) && (
+        <div className="mt-3 grid gap-2 md:grid-cols-3">
+          <RelationChipGroup label="Topics" relations={topics} />
+          <RelationChipGroup label="People" relations={relatedPeople} />
+          <RelationChipGroup label="Projects" relations={relatedProjects} />
+        </div>
+      )}
+    </article>
+  );
+}
+
+function RelationChipGroup({
+  label,
+  relations,
+  className,
+}: {
+  label: string;
+  relations: Relation[];
+  className?: string;
+}) {
+  if (relations.length === 0) return null;
+
+  return (
+    <div className={className}>
+      <Text as="div" variant="metadataMedium" color="grey-04" className="mb-1">
+        {label}
+      </Text>
+      <div className="flex flex-wrap gap-1.5">
+        {relations.map(relation => (
+          <span
+            key={relation.id}
+            className="inline-flex max-w-full items-center rounded-md border border-grey-02 bg-bg px-2 py-1 text-[0.8125rem] text-text"
+          >
+            <span className="truncate">{relation.toEntity.name ?? relation.toEntity.id}</span>
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function relationsForProperty(relations: Relation[], propertyId: string): Relation[] {
+  return relations.filter(relation => relation.type.id === propertyId && relation.isDeleted !== true);
 }

--- a/apps/web/app/space/[id]/(space)/questions/questions-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/questions/questions-page-client.tsx
@@ -81,7 +81,7 @@ function QuestionsTabSurface({ spaceId }: QuestionsPageClientProps) {
   const [formOpen, setFormOpen] = React.useState(false);
   const { entities: questions, isLoading } = useQueryEntities({
     where: {
-      space: { id: { equals: spaceId } },
+      spaces: [{ equals: spaceId }],
       types: [{ id: { equals: QUESTION_TYPE_ID } }],
     },
     first: 50,

--- a/apps/web/core/questions/ontology.ts
+++ b/apps/web/core/questions/ontology.ts
@@ -1,0 +1,18 @@
+export const QUESTION_TYPE_ID = '4318a1d2c441455cb76544049c45e6cf';
+export const ANSWER_TYPE_ID = 'a4fa26b57a4b41559d5cd571519fe527';
+
+export const ANSWERS_PROPERTY_ID = '73609ae8644c4463a50a90a3ee585746';
+export const TOPICS_PROPERTY_ID = '806d52bc27e94c9193c057978b093351';
+export const RELATED_PEOPLE_PROPERTY_ID = '5df8e4329cc54f038f854ac82e157ada';
+export const RELATED_PROJECTS_PROPERTY_ID = '6e3503fab974460ea3dbab8af9a41427';
+
+export const TOPIC_TYPE_ID = '5ef5a5860f274d8e8f6c59ae5b3e89e2';
+export const PERSON_TYPE_ID = '7ed45f2bc48b419e8e4664d5ff680b0d';
+export const PROJECT_TYPE_ID = '484a18c5030a499cb0f2ef588ff16d50';
+
+export const CANONICAL_ANSWERS = [
+  { id: '41b02171457c433d8ecdb0e8d628a9a9', label: 'Yes' },
+  { id: '8d9154a4f8df404fbaf283b3c2400a58', label: 'No' },
+  { id: '507d409bed0c4539ba61dddb8e2a8591', label: 'For' },
+  { id: '3423179a222148eabaf9352efc93660a', label: 'Against' },
+] as const;

--- a/apps/web/core/questions/question-draft.test.ts
+++ b/apps/web/core/questions/question-draft.test.ts
@@ -1,0 +1,165 @@
+import { SystemIds } from '@geoprotocol/geo-sdk/lite';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  ANSWERS_PROPERTY_ID,
+  ANSWER_TYPE_ID,
+  QUESTION_TYPE_ID,
+  RELATED_PEOPLE_PROPERTY_ID,
+  RELATED_PROJECTS_PROPERTY_ID,
+  TOPICS_PROPERTY_ID,
+} from './ontology';
+import { buildQuestionDraft, normalizeAnswerLabel, resolveCanonicalAnswer } from './question-draft';
+
+function makeIdFactory() {
+  let index = 0;
+  return () => `id-${++index}`;
+}
+
+function makePositionFactory() {
+  let index = 0;
+  return () => `pos-${++index}`;
+}
+
+describe('question draft helpers', () => {
+  it('normalizes answer labels for canonical matching', () => {
+    expect(normalizeAnswerLabel('  YES  ')).toBe('yes');
+    expect(normalizeAnswerLabel('For   now')).toBe('for now');
+    expect(resolveCanonicalAnswer(' yes ')?.id).toBe('41b02171457c433d8ecdb0e8d628a9a9');
+    expect(resolveCanonicalAnswer('custom')).toBeNull();
+  });
+
+  it('creates a question name and Question type relation', () => {
+    const draft = buildQuestionDraft(
+      {
+        spaceId: 'space-1',
+        questionText: 'Should we publish this?',
+        answerLabels: ['Yes', 'No'],
+      },
+      { createEntityId: makeIdFactory(), createPosition: makePositionFactory() }
+    );
+
+    expect(draft.questionId).toBe('id-1');
+    expect(draft.names).toEqual([
+      { entityId: 'id-1', spaceId: 'space-1', value: 'Should we publish this?' },
+    ]);
+    expect(draft.relations[0]).toMatchObject({
+      id: 'id-2',
+      entityId: 'id-3',
+      spaceId: 'space-1',
+      position: 'pos-1',
+      type: { id: SystemIds.TYPES_PROPERTY, name: 'Types' },
+      fromEntity: { id: 'id-1', name: 'Should we publish this?' },
+      toEntity: { id: QUESTION_TYPE_ID, name: 'Question', value: QUESTION_TYPE_ID },
+    });
+  });
+
+  it('links canonical answers without creating duplicate Answer entities', () => {
+    const draft = buildQuestionDraft(
+      {
+        spaceId: 'space-1',
+        questionText: 'Ship it?',
+        answerLabels: ['For', 'Against'],
+      },
+      { createEntityId: makeIdFactory(), createPosition: makePositionFactory() }
+    );
+
+    const answerRelations = draft.relations.filter(relation => relation.type.id === ANSWERS_PROPERTY_ID);
+    const answerTypeRelations = draft.relations.filter(
+      relation => relation.type.id === SystemIds.TYPES_PROPERTY && relation.toEntity.id === ANSWER_TYPE_ID
+    );
+
+    expect(draft.names).toEqual([{ entityId: 'id-1', spaceId: 'space-1', value: 'Ship it?' }]);
+    expect(answerTypeRelations).toEqual([]);
+    expect(answerRelations.map(relation => relation.toEntity)).toEqual([
+      { id: '507d409bed0c4539ba61dddb8e2a8591', name: 'For', value: '507d409bed0c4539ba61dddb8e2a8591' },
+      {
+        id: '3423179a222148eabaf9352efc93660a',
+        name: 'Against',
+        value: '3423179a222148eabaf9352efc93660a',
+      },
+    ]);
+  });
+
+  it('creates custom Answer entities with Answer type relations', () => {
+    const draft = buildQuestionDraft(
+      {
+        spaceId: 'space-1',
+        questionText: 'Choose a path?',
+        answerLabels: ['Path A', 'Path B'],
+      },
+      { createEntityId: makeIdFactory(), createPosition: makePositionFactory() }
+    );
+
+    expect(draft.names).toEqual([
+      { entityId: 'id-1', spaceId: 'space-1', value: 'Choose a path?' },
+      { entityId: 'id-4', spaceId: 'space-1', value: 'Path A' },
+      { entityId: 'id-7', spaceId: 'space-1', value: 'Path B' },
+    ]);
+
+    const answerTypeRelations = draft.relations.filter(
+      relation => relation.type.id === SystemIds.TYPES_PROPERTY && relation.toEntity.id === ANSWER_TYPE_ID
+    );
+    expect(answerTypeRelations.map(relation => relation.fromEntity)).toEqual([
+      { id: 'id-4', name: 'Path A' },
+      { id: 'id-7', name: 'Path B' },
+    ]);
+
+    const answerRelations = draft.relations.filter(relation => relation.type.id === ANSWERS_PROPERTY_ID);
+    expect(answerRelations.map(relation => relation.toEntity)).toEqual([
+      { id: 'id-4', name: 'Path A', value: 'id-4' },
+      { id: 'id-7', name: 'Path B', value: 'id-7' },
+    ]);
+  });
+
+  it('rejects empty question text and answer labels', () => {
+    expect(() =>
+      buildQuestionDraft({
+        spaceId: 'space-1',
+        questionText: '   ',
+        answerLabels: ['Yes', 'No'],
+      })
+    ).toThrow('Question text is required.');
+
+    expect(() =>
+      buildQuestionDraft({
+        spaceId: 'space-1',
+        questionText: 'Ready?',
+        answerLabels: ['Yes', '   '],
+      })
+    ).toThrow('Two answer labels are required.');
+  });
+
+  it('links optional topic, person, and project relations', () => {
+    const draft = buildQuestionDraft(
+      {
+        spaceId: 'space-1',
+        questionText: 'Who owns launch?',
+        answerLabels: ['Yes', 'No'],
+        topics: [{ id: 'topic-1', name: 'Launch' }],
+        relatedPeople: [{ id: 'person-1', name: 'Ada' }],
+        relatedProjects: [{ id: 'project-1', name: 'Website' }],
+      },
+      { createEntityId: makeIdFactory(), createPosition: makePositionFactory() }
+    );
+
+    expect(draft.relations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: { id: TOPICS_PROPERTY_ID, name: 'Topics' },
+          toEntity: { id: 'topic-1', name: 'Launch', value: 'topic-1' },
+        }),
+        expect.objectContaining({
+          type: { id: RELATED_PEOPLE_PROPERTY_ID, name: 'Related people' },
+          toEntity: { id: 'person-1', name: 'Ada', value: 'person-1' },
+        }),
+        expect.objectContaining({
+          type: { id: RELATED_PROJECTS_PROPERTY_ID, name: 'Related projects' },
+          toEntity: { id: 'project-1', name: 'Website', value: 'project-1' },
+        }),
+      ])
+    );
+  });
+});
+

--- a/apps/web/core/questions/question-draft.test.ts
+++ b/apps/web/core/questions/question-draft.test.ts
@@ -131,6 +131,24 @@ describe('question draft helpers', () => {
     ).toThrow('Two answer labels are required.');
   });
 
+  it('rejects duplicate answer labels after normalization', () => {
+    expect(() =>
+      buildQuestionDraft({
+        spaceId: 'space-1',
+        questionText: 'Ready?',
+        answerLabels: ['Yes', ' yes '],
+      })
+    ).toThrow('Answer labels must be different.');
+
+    expect(() =>
+      buildQuestionDraft({
+        spaceId: 'space-1',
+        questionText: 'Choose one?',
+        answerLabels: ['Path A', 'path   a'],
+      })
+    ).toThrow('Answer labels must be different.');
+  });
+
   it('links optional topic, person, and project relations', () => {
     const draft = buildQuestionDraft(
       {
@@ -162,4 +180,3 @@ describe('question draft helpers', () => {
     );
   });
 });
-

--- a/apps/web/core/questions/question-draft.ts
+++ b/apps/web/core/questions/question-draft.ts
@@ -72,6 +72,11 @@ export function buildQuestionDraft(
     throw new Error('Two answer labels are required.');
   }
 
+  const normalizedAnswerLabels = answerLabels.map(normalizeAnswerLabel);
+  if (new Set(normalizedAnswerLabels).size !== normalizedAnswerLabels.length) {
+    throw new Error('Answer labels must be different.');
+  }
+
   const questionId = createEntityId();
   const names: QuestionDraft['names'] = [{ entityId: questionId, spaceId: input.spaceId, value: questionText }];
   const relations: Relation[] = [];

--- a/apps/web/core/questions/question-draft.ts
+++ b/apps/web/core/questions/question-draft.ts
@@ -1,0 +1,188 @@
+import { Position, SystemIds } from '@geoprotocol/geo-sdk/lite';
+
+import { ID } from '~/core/id';
+import type { Relation } from '~/core/types';
+
+import {
+  ANSWERS_PROPERTY_ID,
+  ANSWER_TYPE_ID,
+  CANONICAL_ANSWERS,
+  QUESTION_TYPE_ID,
+  RELATED_PEOPLE_PROPERTY_ID,
+  RELATED_PROJECTS_PROPERTY_ID,
+  TOPICS_PROPERTY_ID,
+} from './ontology';
+
+export type QuestionDraftSelection = {
+  id: string;
+  name: string | null;
+};
+
+export type BuildQuestionDraftInput = {
+  spaceId: string;
+  questionText: string;
+  answerLabels: [string, string];
+  topics?: QuestionDraftSelection[];
+  relatedPeople?: QuestionDraftSelection[];
+  relatedProjects?: QuestionDraftSelection[];
+};
+
+export type QuestionDraft = {
+  questionId: string;
+  names: Array<{ entityId: string; spaceId: string; value: string }>;
+  relations: Relation[];
+};
+
+type BuildQuestionDraftOptions = {
+  createEntityId?: () => string;
+  createPosition?: () => string;
+};
+
+type ResolvedAnswer = {
+  id: string;
+  label: string;
+};
+
+const canonicalAnswerByNormalizedLabel = new Map(
+  CANONICAL_ANSWERS.map(answer => [normalizeAnswerLabel(answer.label), answer])
+);
+
+export function normalizeAnswerLabel(label: string): string {
+  return label.trim().replace(/\s+/g, ' ').toLowerCase();
+}
+
+export function resolveCanonicalAnswer(label: string): (typeof CANONICAL_ANSWERS)[number] | null {
+  return canonicalAnswerByNormalizedLabel.get(normalizeAnswerLabel(label)) ?? null;
+}
+
+export function buildQuestionDraft(
+  input: BuildQuestionDraftInput,
+  options: BuildQuestionDraftOptions = {}
+): QuestionDraft {
+  const createEntityId = options.createEntityId ?? ID.createEntityId;
+  const createPosition = options.createPosition ?? Position.generate;
+  const questionText = input.questionText.trim();
+  const answerLabels = input.answerLabels.map(label => label.trim()) as [string, string];
+
+  if (questionText.length === 0) {
+    throw new Error('Question text is required.');
+  }
+
+  if (answerLabels.some(label => label.length === 0)) {
+    throw new Error('Two answer labels are required.');
+  }
+
+  const questionId = createEntityId();
+  const names: QuestionDraft['names'] = [{ entityId: questionId, spaceId: input.spaceId, value: questionText }];
+  const relations: Relation[] = [];
+
+  const makeRelation = ({
+    fromEntityId,
+    fromEntityName,
+    propertyId,
+    propertyName,
+    toEntityId,
+    toEntityName,
+  }: {
+    fromEntityId: string;
+    fromEntityName: string | null;
+    propertyId: string;
+    propertyName: string;
+    toEntityId: string;
+    toEntityName: string | null;
+  }): Relation => ({
+    id: createEntityId(),
+    entityId: createEntityId(),
+    spaceId: input.spaceId,
+    renderableType: 'RELATION',
+    verified: false,
+    position: createPosition(),
+    type: {
+      id: propertyId,
+      name: propertyName,
+    },
+    fromEntity: {
+      id: fromEntityId,
+      name: fromEntityName,
+    },
+    toEntity: {
+      id: toEntityId,
+      name: toEntityName,
+      value: toEntityId,
+    },
+  });
+
+  const addQuestionRelation = (propertyId: string, propertyName: string, selection: QuestionDraftSelection) => {
+    relations.push(
+      makeRelation({
+        fromEntityId: questionId,
+        fromEntityName: questionText,
+        propertyId,
+        propertyName,
+        toEntityId: selection.id,
+        toEntityName: selection.name,
+      })
+    );
+  };
+
+  relations.push(
+    makeRelation({
+      fromEntityId: questionId,
+      fromEntityName: questionText,
+      propertyId: SystemIds.TYPES_PROPERTY,
+      propertyName: 'Types',
+      toEntityId: QUESTION_TYPE_ID,
+      toEntityName: 'Question',
+    })
+  );
+
+  const answers = answerLabels.map(label => {
+    const canonical = resolveCanonicalAnswer(label);
+
+    if (canonical) {
+      return {
+        id: canonical.id,
+        label: canonical.label,
+      };
+    }
+
+    const answerId = createEntityId();
+    names.push({ entityId: answerId, spaceId: input.spaceId, value: label });
+    relations.push(
+      makeRelation({
+        fromEntityId: answerId,
+        fromEntityName: label,
+        propertyId: SystemIds.TYPES_PROPERTY,
+        propertyName: 'Types',
+        toEntityId: ANSWER_TYPE_ID,
+        toEntityName: 'Answer',
+      })
+    );
+
+    return {
+      id: answerId,
+      label,
+    };
+  }) satisfies ResolvedAnswer[];
+
+  for (const answer of answers) {
+    addQuestionRelation(ANSWERS_PROPERTY_ID, 'Answers', {
+      id: answer.id,
+      name: answer.label,
+    });
+  }
+
+  for (const topic of input.topics ?? []) {
+    addQuestionRelation(TOPICS_PROPERTY_ID, 'Topics', topic);
+  }
+
+  for (const person of input.relatedPeople ?? []) {
+    addQuestionRelation(RELATED_PEOPLE_PROPERTY_ID, 'Related people', person);
+  }
+
+  for (const project of input.relatedProjects ?? []) {
+    addQuestionRelation(RELATED_PROJECTS_PROPERTY_ID, 'Related projects', project);
+  }
+
+  return { questionId, names, relations };
+}


### PR DESCRIPTION
## Summary

Spaces can now use the feature-flagged Questions tab as a real v1 workflow instead of a placeholder. Users can see existing Question entities for the current space, add a new question with two answers, optionally attach topics, people, and projects, and then hand the staged edits to the existing Review edits proposal flow.

The question creation path stays local-only until review: it writes the question name, Question type, answer relations, optional organization relations, and custom Answer entities into the local edit store, then opens Review edits for the current space.

## Implementation Notes

- Canonical answers reuse the provided Yes, No, For, and Against answer entity IDs.
- Custom answer labels create new Answer-typed entities.
- The Questions list queries current-space Question entities and includes unpublished local edits so newly staged questions appear immediately.
- The tab remains gated behind the existing `questionsTab` feature flag and direct disabled visits still redirect to the space overview.

## Validation

- `bun --cwd apps/web test`
  - Passed: 109 test files, 1148 tests.
- `bun --cwd apps/web lint`
  - Passed with existing unrelated warnings.
- `bun --cwd apps/web tsc --noEmit`
  - Not used as a gate because it still fails on pre-existing unrelated test fixture type errors in ranking/chat tests.

## Post-Deploy Monitoring & Validation

- Log/search terms: watch client error reporting for `questions`, `questionsTab`, `Review edits`, `Question text is required`, and `Two answer labels are required`.
- Healthy signals: enabling the local `questionsTab` flag shows the Questions tab; adding a question opens Review edits with local relation/name changes; direct `/questions` visits redirect when the flag is disabled.
- Failure signals: Review edits opens empty after question submission, custom answers do not appear as Answer-typed entities, or the Questions tab appears while the flag is disabled.
- Rollback trigger: disable or revert the Questions route/form changes if users can stage malformed question relations or the Review edits flow is blocked.
- Validation window and owner: first deploy smoke test by the feature owner after release.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT--5](https://img.shields.io/badge/GPT--5-000000)
