### PR TITLE
feat(debates): make recording uploads durable

### DIFF
--- a/apps/web/app/entry.tsx
+++ b/apps/web/app/entry.tsx
@@ -8,6 +8,7 @@ import { useAtomValue } from 'jotai';
 import dynamic from 'next/dynamic';
 
 import { DebateCoordinator } from '~/core/debates/debate-coordinator';
+import { DebateRecordingUploadCoordinator } from '~/core/debates/recording-upload-coordinator';
 import { useGeoLogoutCleanup } from '~/core/hooks/use-geo-logout';
 import { useKeyboardShortcuts } from '~/core/hooks/use-keyboard-shortcuts';
 import { Toast } from '~/core/hooks/use-toast';
@@ -118,6 +119,7 @@ export function App({ children }: { children: React.ReactNode }) {
         <ChatWidget />
         <FeatureFlagsDialog />
         <DebateCoordinator />
+        <DebateRecordingUploadCoordinator />
         <Persistence />
       </ClientOnly>
       {process.env.NODE_ENV === 'production' && <Analytics />}

--- a/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
@@ -15,6 +15,7 @@ const mocks = vi.hoisted(() => ({
   consentMutateAsync: vi.fn(),
   leaveRematchMutateAsync: vi.fn(),
   enqueueRecording: vi.fn(),
+  getRecording: vi.fn(),
   requestPersistentStorage: vi.fn(),
   estimateStorage: vi.fn(),
   mediaRecorderStart: vi.fn(),
@@ -62,8 +63,10 @@ vi.mock('~/core/debates/hooks', () => ({
 }));
 
 vi.mock('~/core/debates/recording-upload-queue', () => ({
+  debateRecordingUploadId: (userId: string, debateId: string) => `${userId}:${debateId}`,
   enqueueDebateRecordingUpload: mocks.enqueueRecording,
   estimateRecordingStorage: mocks.estimateStorage,
+  getDebateRecordingUpload: mocks.getRecording,
   isStorageQuotaError: (error: unknown) =>
     typeof error === 'object' && error !== null && 'name' in error && error.name === 'QuotaExceededError',
   requestPersistentRecordingStorage: mocks.requestPersistentStorage,
@@ -91,6 +94,7 @@ beforeEach(() => {
   mocks.consentMutateAsync.mockReset();
   mocks.leaveRematchMutateAsync.mockReset();
   mocks.enqueueRecording.mockReset();
+  mocks.getRecording.mockReset();
   mocks.requestPersistentStorage.mockReset();
   mocks.estimateStorage.mockReset();
   mocks.mediaRecorderStart.mockReset();
@@ -124,6 +128,7 @@ beforeEach(() => {
   mocks.roomConnect.mockResolvedValue(undefined);
   mocks.publishTrack.mockResolvedValue(undefined);
   mocks.enqueueRecording.mockResolvedValue(undefined);
+  mocks.getRecording.mockResolvedValue(undefined);
   mocks.requestPersistentStorage.mockResolvedValue(true);
   mocks.estimateStorage.mockResolvedValue({ quota: 1_000_000_000, usage: 0 });
   vi.stubGlobal(
@@ -737,6 +742,40 @@ describe('DebateRoomPageClient', () => {
 
     persistence.resolve();
     await waitFor(() => expect(mocks.replace).toHaveBeenCalledWith('/space/space-1/debates/rematches/rematch-1'));
+  });
+
+  it('persists the recording at the canonical debate deadline without waiting for thanking status', async () => {
+    installRecordingMocks();
+    const view = await renderLiveDebate();
+    await waitFor(() => expect(mocks.mediaRecorderStart).toHaveBeenCalled());
+
+    vi.mocked(Date.now).mockReturnValue(Date.parse('2026-07-02T00:01:10.001Z'));
+    mocks.debate = { ...mocks.debate! };
+    view.rerender(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
+
+    await waitFor(() => expect(mocks.enqueueRecording).toHaveBeenCalledOnce());
+    expect(mocks.debate.status).toBe('in_progress');
+  });
+
+  it('recognizes a durable queued recording after the debate room reloads', async () => {
+    mocks.getRecording.mockResolvedValue({ id: 'user-a:debate-1' });
+    mocks.debate = {
+      ...completedDebate(),
+      status: 'thanking',
+      completed_at: null,
+      rematch_session_id: 'rematch-1',
+    };
+    mocks.rematch = rematchSession('browsing');
+    const view = render(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
+
+    await waitFor(() => expect(mocks.getRecording).toHaveBeenCalledWith('user-a:debate-1'));
+    expect(mocks.enqueueRecording).not.toHaveBeenCalled();
+
+    mocks.debate = { ...completedDebate(), rematch_session_id: 'rematch-1' };
+    view.rerender(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
+
+    await waitFor(() => expect(mocks.replace).toHaveBeenCalledWith('/space/space-1/debates/rematches/rematch-1'));
+    expect(mocks.enqueueRecording).not.toHaveBeenCalled();
   });
 
   it('waits for a deciding rematch session to resolve before finalizing the completed debate', async () => {

--- a/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
@@ -14,8 +14,9 @@ const mocks = vi.hoisted(() => ({
   replace: vi.fn(),
   consentMutateAsync: vi.fn(),
   leaveRematchMutateAsync: vi.fn(),
-  createUploadMutateAsync: vi.fn(),
-  completeUploadMutateAsync: vi.fn(),
+  enqueueRecording: vi.fn(),
+  requestPersistentStorage: vi.fn(),
+  estimateStorage: vi.fn(),
   mediaRecorderStart: vi.fn(),
   readyMutateAsync: vi.fn(),
   liveKitJoinMutateAsync: vi.fn(),
@@ -51,15 +52,21 @@ vi.mock('~/core/debates/api', async importOriginal => {
 
 vi.mock('~/core/debates/hooks', () => ({
   useAbortDebate: () => ({ mutateAsync: vi.fn(), isPending: false }),
-  useCompleteLocalRecordingUpload: () => ({ mutateAsync: mocks.completeUploadMutateAsync }),
   useConsentToDebateRematch: () => ({ mutateAsync: mocks.consentMutateAsync, isPending: false }),
-  useCreateLocalRecordingUpload: () => ({ mutateAsync: mocks.createUploadMutateAsync }),
   useDebate: () => ({ data: mocks.debate, isLoading: false, error: null }),
   useDebateRematch: () => ({ data: mocks.rematch, isLoading: false, error: null }),
   useLeaveDebateRematch: () => ({ mutateAsync: mocks.leaveRematchMutateAsync, isPending: false }),
   useLiveKitJoin: () => ({ mutateAsync: mocks.liveKitJoinMutateAsync, isPending: false }),
   useMarkDebateJoined: () => ({ mutateAsync: mocks.markJoinedMutateAsync, isPending: false }),
   useMarkDebateReady: () => ({ mutateAsync: mocks.readyMutateAsync, isPending: false }),
+}));
+
+vi.mock('~/core/debates/recording-upload-queue', () => ({
+  enqueueDebateRecordingUpload: mocks.enqueueRecording,
+  estimateRecordingStorage: mocks.estimateStorage,
+  isStorageQuotaError: (error: unknown) =>
+    typeof error === 'object' && error !== null && 'name' in error && error.name === 'QuotaExceededError',
+  requestPersistentRecordingStorage: mocks.requestPersistentStorage,
 }));
 
 vi.mock('livekit-client', () => ({
@@ -83,8 +90,9 @@ beforeEach(() => {
   mocks.replace.mockReset();
   mocks.consentMutateAsync.mockReset();
   mocks.leaveRematchMutateAsync.mockReset();
-  mocks.createUploadMutateAsync.mockReset();
-  mocks.completeUploadMutateAsync.mockReset();
+  mocks.enqueueRecording.mockReset();
+  mocks.requestPersistentStorage.mockReset();
+  mocks.estimateStorage.mockReset();
   mocks.mediaRecorderStart.mockReset();
   mocks.readyMutateAsync.mockReset();
   mocks.liveKitJoinMutateAsync.mockReset();
@@ -115,15 +123,9 @@ beforeEach(() => {
   ]);
   mocks.roomConnect.mockResolvedValue(undefined);
   mocks.publishTrack.mockResolvedValue(undefined);
-  mocks.createUploadMutateAsync.mockResolvedValue({
-    filename: 'debate.webm',
-    upload: {
-      url: 'https://uploads.test/debate.webm',
-      method: 'PUT',
-      headers: {},
-    },
-  });
-  mocks.completeUploadMutateAsync.mockResolvedValue(undefined);
+  mocks.enqueueRecording.mockResolvedValue(undefined);
+  mocks.requestPersistentStorage.mockResolvedValue(true);
+  mocks.estimateStorage.mockResolvedValue({ quota: 1_000_000_000, usage: 0 });
   vi.stubGlobal(
     'MediaStream',
     class {
@@ -184,6 +186,7 @@ describe('DebateRoomPageClient', () => {
     await waitFor(() => {
       expect(mocks.createLocalTracks).toHaveBeenCalled();
     });
+    expect(mocks.requestPersistentStorage).toHaveBeenCalledOnce();
     expect(mocks.liveKitJoinMutateAsync).not.toHaveBeenCalled();
   });
 
@@ -619,7 +622,7 @@ describe('DebateRoomPageClient', () => {
     render(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
 
     expect(await screen.findByText('Debate complete.')).toBeInTheDocument();
-    expect(mocks.createUploadMutateAsync).not.toHaveBeenCalled();
+    expect(mocks.enqueueRecording).not.toHaveBeenCalled();
     expect(screen.queryByText('Continue debating this claim?')).not.toBeInTheDocument();
   });
 
@@ -667,7 +670,7 @@ describe('DebateRoomPageClient', () => {
     expect(await screen.findByRole('button', { name: 'Waiting...' })).toBeDisabled();
   });
 
-  it('does not leave the rematch flow when the local recording cannot be finalized', async () => {
+  it('does not leave the rematch flow when the local recording cannot be persisted', async () => {
     mocks.debate = {
       ...completedDebate(),
       status: 'thanking',
@@ -682,7 +685,7 @@ describe('DebateRoomPageClient', () => {
     fireEvent.click(await screen.findByRole('button', { name: 'Leave debate' }));
 
     expect(
-      await screen.findByText('Could not finalize the local recording. Please try leaving again.')
+      await screen.findByText('Could not save the local recording. Please try leaving again.')
     ).toBeInTheDocument();
     expect(mocks.leaveRematchMutateAsync).not.toHaveBeenCalled();
     expect(mocks.push).not.toHaveBeenCalled();
@@ -709,9 +712,9 @@ describe('DebateRoomPageClient', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('waits for recording finalization before entering the rematch browser', async () => {
-    const upload = deferred<void>();
-    mocks.completeUploadMutateAsync.mockReturnValue(upload.promise);
+  it('waits for durable recording persistence before entering the rematch browser', async () => {
+    const persistence = deferred<void>();
+    mocks.enqueueRecording.mockReturnValue(persistence.promise);
     installRecordingMocks();
     const view = await renderLiveDebate();
     await waitFor(() => expect(mocks.mediaRecorderStart).toHaveBeenCalled());
@@ -720,10 +723,19 @@ describe('DebateRoomPageClient', () => {
     mocks.debate = { ...completedDebate(), rematch_session_id: 'rematch-1' };
     view.rerender(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
 
-    await waitFor(() => expect(mocks.completeUploadMutateAsync).toHaveBeenCalled());
+    await waitFor(() => expect(mocks.enqueueRecording).toHaveBeenCalled());
+    expect(mocks.enqueueRecording).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: 'user-a',
+        debateId: 'debate-1',
+        blob: expect.any(Blob),
+        mimeType: 'video/webm',
+      })
+    );
+    expect(fetch).not.toHaveBeenCalled();
     expect(mocks.replace).not.toHaveBeenCalledWith('/space/space-1/debates/rematches/rematch-1');
 
-    upload.resolve();
+    persistence.resolve();
     await waitFor(() => expect(mocks.replace).toHaveBeenCalledWith('/space/space-1/debates/rematches/rematch-1'));
   });
 
@@ -737,18 +749,18 @@ describe('DebateRoomPageClient', () => {
     view.rerender(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
 
     await waitFor(() => expect(screen.getByText('Debate complete.')).toBeInTheDocument());
-    expect(mocks.completeUploadMutateAsync).not.toHaveBeenCalled();
+    expect(mocks.enqueueRecording).not.toHaveBeenCalled();
     expect(mocks.replace).not.toHaveBeenCalledWith('/space/space-1/debates');
 
     mocks.rematch = rematchSession('browsing');
     view.rerender(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
 
-    await waitFor(() => expect(mocks.completeUploadMutateAsync).toHaveBeenCalled());
+    await waitFor(() => expect(mocks.enqueueRecording).toHaveBeenCalled());
     await waitFor(() => expect(mocks.replace).toHaveBeenCalledWith('/space/space-1/debates/rematches/rematch-1'));
   });
 
-  it('keeps the completion screen available when recording finalization fails', async () => {
-    mocks.completeUploadMutateAsync.mockRejectedValue(new Error('Upload unavailable'));
+  it('keeps the completion screen available when recording persistence fails', async () => {
+    mocks.enqueueRecording.mockRejectedValue(new Error('Storage unavailable'));
     installRecordingMocks();
     const view = await renderLiveDebate();
     await waitFor(() => expect(mocks.mediaRecorderStart).toHaveBeenCalled());
@@ -756,8 +768,31 @@ describe('DebateRoomPageClient', () => {
     mocks.debate = completedDebate();
     view.rerender(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
 
-    expect(await screen.findAllByText('Upload unavailable')).not.toHaveLength(0);
+    expect(await screen.findAllByText('Storage unavailable')).not.toHaveLength(0);
     expect(mocks.replace).not.toHaveBeenCalled();
+  });
+
+  it('retains an in-memory recording after a quota failure and retries the same Blob', async () => {
+    mocks.enqueueRecording.mockRejectedValueOnce(new DOMException('Storage full', 'QuotaExceededError'));
+    installRecordingMocks();
+    const view = await renderLiveDebate();
+    await waitFor(() => expect(mocks.mediaRecorderStart).toHaveBeenCalled());
+
+    mocks.debate = completedDebate();
+    view.rerender(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
+
+    expect(
+      await screen.findByText(
+        'There is not enough browser storage to save this recording. Free some device storage, then retry.'
+      )
+    ).toBeInTheDocument();
+    const firstBlob = mocks.enqueueRecording.mock.calls[0]?.[0].blob;
+    mocks.enqueueRecording.mockResolvedValueOnce(undefined);
+    fireEvent.click(screen.getByRole('button', { name: 'Retry save' }));
+
+    await waitFor(() => expect(mocks.enqueueRecording).toHaveBeenCalledTimes(2));
+    expect(mocks.enqueueRecording.mock.calls[1]?.[0].blob).toBe(firstBlob);
+    await waitFor(() => expect(mocks.replace).toHaveBeenCalledWith('/space/space-1/debates'));
   });
 });
 

--- a/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.tsx
@@ -9,15 +9,12 @@ import {
   type Debate,
   type DebateRematchSession,
   type LiveKitJoinResponse,
-  type LocalRecordingCompleteRequest,
   type ParticipantSlot,
   getCurrentGeoChatUserId,
 } from '~/core/debates/api';
 import {
   useAbortDebate,
-  useCompleteLocalRecordingUpload,
   useConsentToDebateRematch,
-  useCreateLocalRecordingUpload,
   useDebate,
   useDebateRematch,
   useLeaveDebateRematch,
@@ -25,6 +22,12 @@ import {
   useMarkDebateJoined,
   useMarkDebateReady,
 } from '~/core/debates/hooks';
+import {
+  enqueueDebateRecordingUpload,
+  estimateRecordingStorage,
+  isStorageQuotaError,
+  requestPersistentRecordingStorage,
+} from '~/core/debates/recording-upload-queue';
 import { useFeatureFlag } from '~/core/state/feature-flags';
 
 import { Avatar } from '~/design-system/avatar';
@@ -81,8 +84,6 @@ const recordingCountdownSize = 68;
 const recordingCountdownRadius = 25;
 const recordingCountdownCircumference = 2 * Math.PI * recordingCountdownRadius;
 
-const localRecordingUploadMaxAttempts = 3;
-const localRecordingUploadRetryDelayMs = 1_000;
 const debateThankingDurationMs = 20_000;
 
 export function DebateRoomPageClient({ spaceId, debateId }: DebateRoomPageClientProps) {
@@ -107,11 +108,9 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
   const markJoined = useMarkDebateJoined(debateId);
   const markReady = useMarkDebateReady(debateId);
   const abortDebate = useAbortDebate(debateId);
-  const createUpload = useCreateLocalRecordingUpload(debateId);
-  const completeUpload = useCompleteLocalRecordingUpload(debateId);
   const consentToRematch = useConsentToDebateRematch(debateId);
   const [joinResponse, setJoinResponse] = React.useState<LiveKitJoinResponse | null>(null);
-  const [roomState, setRoomState] = React.useState<'idle' | 'connecting' | 'connected' | 'uploading'>('idle');
+  const [roomState, setRoomState] = React.useState<'idle' | 'connecting' | 'connected' | 'saving'>('idle');
   const [roomError, setRoomError] = React.useState<string | null>(null);
   const [remoteVideoReady, setRemoteVideoReady] = React.useState(false);
   const [previewState, setPreviewState] = React.useState<'idle' | 'starting' | 'ready'>('idle');
@@ -144,9 +143,21 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
   const recordingStopTimerRef = React.useRef<number | null>(null);
   const autoConnectAttemptedRef = React.useRef<string | null>(null);
   const finalizedDebateRef = React.useRef<string | null>(null);
-  const recordingUploadStartedRef = React.useRef<string | null>(null);
-  const recordingUploadPromiseRef = React.useRef<Promise<boolean> | null>(null);
-  const pendingRecordingUploadRef = React.useRef<LocalRecordingCompleteRequest | null>(null);
+  const recordingPersistenceStartedRef = React.useRef<string | null>(null);
+  const recordingPersistencePromiseRef = React.useRef<Promise<boolean> | null>(null);
+  const persistedRecordingDebateIdRef = React.useRef<string | null>(null);
+  const stoppedRecordingRef = React.useRef<{
+    blob: Blob;
+    mimeType: string;
+    startedAtMs: number;
+    endedAtMs: number;
+    durationSeconds: number;
+    width: number | null;
+    height: number | null;
+    framerate: number | null;
+    videoBitsPerSecond: number | null;
+  } | null>(null);
+  const storagePersistenceRequestedRef = React.useRef(false);
   const debate = debateQuery.data ?? null;
   const rematchQuery = useDebateRematch(
     debate?.rematch_session_id ?? '',
@@ -231,76 +242,91 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
     recordingEndedAtRef.current = Date.now();
   }, []);
 
-  const performStoppedLocalRecordingUpload = React.useCallback(async () => {
-    if (pendingRecordingUploadRef.current) return true;
+  const performStoppedLocalRecordingPersistence = React.useCallback(async () => {
+    if (persistedRecordingDebateIdRef.current === debate?.id) return true;
     await stopLocalRecorder();
 
     const recorder = recorderRef.current;
     const startedAtMs = recordingStartedAtRef.current;
     const endedAtMs = recordingEndedAtRef.current;
-    if (!recorder || !startedAtMs || !endedAtMs || !joinResponse) return false;
+    if (!recorder || !startedAtMs || !endedAtMs || !joinResponse || !debate) return false;
 
-    const mimeType = recorder.mimeType || preferredRecordingMimeType() || 'video/webm';
-    const blob = new Blob(recordingChunksRef.current, { type: mimeType });
-    if (blob.size === 0) return false;
+    if (!stoppedRecordingRef.current) {
+      const mimeType = recorder.mimeType || preferredRecordingMimeType() || 'video/webm';
+      const blob = new Blob(recordingChunksRef.current, { type: mimeType });
+      if (blob.size === 0) return false;
+      const videoSettings = localMediaStreamRef.current?.getVideoTracks()[0]?.getSettings?.();
+      stoppedRecordingRef.current = {
+        blob,
+        mimeType,
+        startedAtMs,
+        endedAtMs,
+        durationSeconds: Math.max(1, Math.round((endedAtMs - startedAtMs) / 1_000)),
+        width: videoSettings?.width ?? null,
+        height: videoSettings?.height ?? null,
+        framerate: videoSettings?.frameRate ?? null,
+        videoBitsPerSecond: recorder.videoBitsPerSecond || null,
+      };
+    }
 
-    let uploadedFilename: string | null = null;
-    for (let attempt = 1; attempt <= localRecordingUploadMaxAttempts; attempt += 1) {
-      try {
-        const upload = await createUpload.mutateAsync({ mime_type: mimeType, started_at_ms: startedAtMs });
-        const headers = new Headers(upload.upload.headers);
-        headers.set('Content-Type', mimeType);
-        const uploadResponse = await fetch(upload.upload.url, {
-          method: upload.upload.method,
-          headers,
-          body: blob,
+    const localParticipant = debate.participants.find(
+      participant => participant.participant_slot === joinResponse.participant_slot
+    );
+    if (!localParticipant) return false;
+
+    const recording = stoppedRecordingRef.current;
+    const storage = await estimateRecordingStorage();
+    if (storage?.quota !== undefined && storage.usage !== undefined) {
+      const availableBytes = storage.quota - storage.usage;
+      if (availableBytes < recording.blob.size) {
+        console.warn('[DebateRecording] browser storage estimate is below recording size', {
+          availableBytes,
+          recordingBytes: recording.blob.size,
         });
-        if (!uploadResponse.ok) {
-          throw new Error(`Recording upload failed (${uploadResponse.status})`);
-        }
-        uploadedFilename = upload.filename;
-        break;
-      } catch (error) {
-        if (attempt >= localRecordingUploadMaxAttempts) {
-          throw error;
-        }
-        await delay(localRecordingUploadRetryDelayMs * attempt);
       }
     }
-    if (!uploadedFilename) throw new Error('Recording upload failed.');
 
-    pendingRecordingUploadRef.current = {
-      filename: uploadedFilename,
-      mime_type: mimeType,
-      started_at_ms: startedAtMs,
-      ended_at_ms: endedAtMs,
-      duration_seconds: Math.max(1, Math.round((endedAtMs - startedAtMs) / 1_000)),
-      byte_size: blob.size,
-    };
+    try {
+      await enqueueDebateRecordingUpload({
+        userId: localParticipant.user_id,
+        debateId: debate.id,
+        blob: recording.blob,
+        mimeType: recording.mimeType,
+        startedAtMs: recording.startedAtMs,
+        endedAtMs: recording.endedAtMs,
+        durationSeconds: recording.durationSeconds,
+        width: recording.width,
+        height: recording.height,
+        framerate: recording.framerate,
+        videoBitsPerSecond: recording.videoBitsPerSecond,
+      });
+    } catch (error) {
+      if (isStorageQuotaError(error)) {
+        throw new Error(
+          'There is not enough browser storage to save this recording. Free some device storage, then retry.'
+        );
+      }
+      throw error;
+    }
+
+    persistedRecordingDebateIdRef.current = debate.id;
     recorderRef.current = null;
     recordingChunksRef.current = [];
-    return true;
-  }, [createUpload, joinResponse, stopLocalRecorder]);
-
-  const uploadStoppedLocalRecording = React.useCallback(() => {
-    if (pendingRecordingUploadRef.current) return Promise.resolve(true);
-    if (recordingUploadPromiseRef.current) return recordingUploadPromiseRef.current;
-    const upload = performStoppedLocalRecordingUpload().finally(() => {
-      recordingUploadPromiseRef.current = null;
-    });
-    recordingUploadPromiseRef.current = upload;
-    return upload;
-  }, [performStoppedLocalRecordingUpload]);
-
-  const finalizeLocalRecordingUpload = React.useCallback(async () => {
-    const uploaded = await uploadStoppedLocalRecording();
-    if (!uploaded || !pendingRecordingUploadRef.current) return false;
-    await completeUpload.mutateAsync(pendingRecordingUploadRef.current);
-    pendingRecordingUploadRef.current = null;
+    stoppedRecordingRef.current = null;
     recordingStartedAtRef.current = null;
     recordingEndedAtRef.current = null;
     return true;
-  }, [completeUpload, uploadStoppedLocalRecording]);
+  }, [debate, joinResponse, stopLocalRecorder]);
+
+  const persistStoppedLocalRecording = React.useCallback(() => {
+    if (persistedRecordingDebateIdRef.current === debate?.id) return Promise.resolve(true);
+    if (recordingPersistencePromiseRef.current) return recordingPersistencePromiseRef.current;
+    const persistence = performStoppedLocalRecordingPersistence().finally(() => {
+      recordingPersistencePromiseRef.current = null;
+    });
+    recordingPersistencePromiseRef.current = persistence;
+    return persistence;
+  }, [debate?.id, performStoppedLocalRecordingPersistence]);
 
   const discardLocalRecorder = React.useCallback(async () => {
     clearRecordingTimers();
@@ -309,9 +335,10 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
       recordingChunksRef.current = [];
       recordingStartedAtRef.current = null;
       recordingEndedAtRef.current = null;
-      pendingRecordingUploadRef.current = null;
-      recordingUploadStartedRef.current = null;
-      recordingUploadPromiseRef.current = null;
+      stoppedRecordingRef.current = null;
+      recordingPersistenceStartedRef.current = null;
+      recordingPersistencePromiseRef.current = null;
+      persistedRecordingDebateIdRef.current = null;
       return;
     }
 
@@ -326,9 +353,10 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
     recordingChunksRef.current = [];
     recordingStartedAtRef.current = null;
     recordingEndedAtRef.current = null;
-    pendingRecordingUploadRef.current = null;
-    recordingUploadStartedRef.current = null;
-    recordingUploadPromiseRef.current = null;
+    stoppedRecordingRef.current = null;
+    recordingPersistenceStartedRef.current = null;
+    recordingPersistencePromiseRef.current = null;
+    persistedRecordingDebateIdRef.current = null;
   }, [clearRecordingTimers]);
 
   const refreshMediaDevices = React.useCallback(async () => {
@@ -590,13 +618,13 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
     setVideoEnabled(current => !current);
   }, []);
 
-  const finishAndUpload = React.useCallback(async () => {
+  const finishAndPersist = React.useCallback(async () => {
     setRoomError(null);
-    setRoomState('uploading');
+    setRoomState('saving');
     try {
-      const uploaded = await finalizeLocalRecordingUpload();
-      if (!uploaded) {
-        throw new Error('No local recording was available to upload.');
+      const persisted = await persistStoppedLocalRecording();
+      if (!persisted) {
+        throw new Error('No local recording was available to save.');
       }
       disconnectRoom(roomRef, localTracksRef, localVideoRef, remoteMediaRef);
       localMediaStreamRef.current = null;
@@ -604,19 +632,19 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
       setRoomState('idle');
       return true;
     } catch (error) {
-      setRoomError(error instanceof Error ? error.message : 'Could not upload the local recording.');
+      setRoomError(error instanceof Error ? error.message : 'Could not save the local recording.');
       setRoomState('connected');
       return false;
     }
-  }, [finalizeLocalRecordingUpload]);
+  }, [persistStoppedLocalRecording]);
 
   const finishLiveDebate = React.useCallback(async () => {
     if (!debate || finalizedDebateRef.current === debate.id) return;
     const session = rematchQuery.data;
     if (debate.rematch_session_id && (!session || session.status === 'deciding')) return;
     finalizedDebateRef.current = debate.id;
-    const uploaded = await finishAndUpload();
-    if (!uploaded) return;
+    const persisted = await finishAndPersist();
+    if (!persisted) return;
     if (session?.status === 'converted' && session.converted_debate_id) {
       router.replace(`/space/${session.source_space_id}/debates/${session.converted_debate_id}`);
       return;
@@ -626,12 +654,28 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
       return;
     }
     router.replace(`/space/${spaceId}/debates`);
-  }, [debate, finishAndUpload, rematchQuery.data, router, spaceId]);
+  }, [debate, finishAndPersist, rematchQuery.data, router, spaceId]);
 
   const retryLiveDebateFinalization = React.useCallback(() => {
+    if (debate?.status === 'thanking') {
+      setRoomError(null);
+      setRoomState('saving');
+      recordingPersistenceStartedRef.current = debate.id;
+      void persistStoppedLocalRecording()
+        .then(persisted => {
+          if (!persisted) throw new Error('No local recording was available to save.');
+          setRoomState('connected');
+        })
+        .catch(error => {
+          recordingPersistenceStartedRef.current = null;
+          setRoomError(error instanceof Error ? error.message : 'Could not save the local recording.');
+          setRoomState('connected');
+        });
+      return;
+    }
     finalizedDebateRef.current = null;
     void finishLiveDebate();
-  }, [finishLiveDebate]);
+  }, [debate?.id, debate?.status, finishLiveDebate, persistStoppedLocalRecording]);
 
   const requestRematch = React.useCallback(async () => {
     if (rematchConsentRequested) return;
@@ -664,9 +708,9 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
         await finishLiveDebate();
         return;
       } else if (debate.status === 'thanking' && debate.rematch_session_id) {
-        const finalized = await finalizeLocalRecordingUpload();
-        if (!finalized) {
-          throw new Error('Could not finalize the local recording. Please try leaving again.');
+        const persisted = await persistStoppedLocalRecording();
+        if (!persisted) {
+          throw new Error('Could not save the local recording. Please try leaving again.');
         }
         await leaveRematch.mutateAsync();
         disconnectRoom(roomRef, localTracksRef, localVideoRef, remoteMediaRef);
@@ -693,9 +737,9 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
     abortDebate,
     debate,
     discardLocalRecorder,
-    finalizeLocalRecordingUpload,
     finishLiveDebate,
     leaveRematch,
+    persistStoppedLocalRecording,
     router,
     spaceId,
   ]);
@@ -717,6 +761,13 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
       localMediaStreamRef.current = null;
     };
   }, [clearRecordingTimers, discardLocalRecorder]);
+
+  React.useEffect(() => {
+    if (!debate || storagePersistenceRequestedRef.current) return;
+    if (['complete', 'cancelled'].includes(debate.status)) return;
+    storagePersistenceRequestedRef.current = true;
+    void requestPersistentRecordingStorage();
+  }, [debate]);
 
   React.useEffect(() => {
     if (!debate || debate.status !== 'ready' || roomState !== 'idle') return;
@@ -743,11 +794,11 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
     if (!recordingWindow) return;
 
     if (debate.status === 'thanking') {
-      if (recordingUploadStartedRef.current !== debate.id) {
-        recordingUploadStartedRef.current = debate.id;
-        void uploadStoppedLocalRecording().catch(error => {
-          recordingUploadStartedRef.current = null;
-          setRoomError(error instanceof Error ? error.message : 'Could not upload the local recording.');
+      if (recordingPersistenceStartedRef.current !== debate.id) {
+        recordingPersistenceStartedRef.current = debate.id;
+        void persistStoppedLocalRecording().catch(error => {
+          recordingPersistenceStartedRef.current = null;
+          setRoomError(error instanceof Error ? error.message : 'Could not save the local recording.');
         });
       }
       return;
@@ -774,7 +825,7 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
     );
 
     return clearRecordingTimers;
-  }, [clearRecordingTimers, debate, roomState, startLocalRecorder, stopLocalRecorder, uploadStoppedLocalRecording]);
+  }, [clearRecordingTimers, debate, persistStoppedLocalRecording, roomState, startLocalRecorder, stopLocalRecorder]);
 
   React.useEffect(() => {
     if (!debate) return;
@@ -910,7 +961,7 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
                 rematchBusy={consentToRematch.isPending}
                 onRetryFinalization={retryLiveDebateFinalization}
                 onLeave={leave}
-                leaveDisabled={abortDebate.isPending || roomState === 'uploading'}
+                leaveDisabled={abortDebate.isPending || roomState === 'saving'}
               />
             )}
           </>
@@ -1152,7 +1203,7 @@ function DebateRecordingModal({
   leaveDisabled,
 }: {
   debate: Debate;
-  roomState: 'connecting' | 'connected' | 'uploading';
+  roomState: 'connecting' | 'connected' | 'saving';
   roomError: string | null;
   countdown: DebateCountdown;
   localSlot: ParticipantSlot | null;
@@ -1292,9 +1343,9 @@ function DebateRecordingModal({
         {roomError && (
           <div className="mt-3 flex w-full flex-wrap items-center justify-between gap-3 rounded-lg border border-red-01 bg-white px-4 py-3">
             <Text color="red-01">{roomError}</Text>
-            {debate.status === 'complete' && (
-              <Button type="button" onClick={onRetryFinalization} disabled={roomState === 'uploading'}>
-                Retry upload
+            {['thanking', 'complete'].includes(debate.status) && (
+              <Button type="button" onClick={onRetryFinalization} disabled={roomState === 'saving'}>
+                Retry save
               </Button>
             )}
           </div>
@@ -1302,8 +1353,8 @@ function DebateRecordingModal({
 
         <div className="mt-5 flex w-full justify-end">
           <RecordingCircleButton
-            ariaLabel={roomState === 'uploading' ? 'Uploading local recording' : 'Leave debate'}
-            title={roomState === 'uploading' ? 'Uploading local recording' : 'Leave debate'}
+            ariaLabel={roomState === 'saving' ? 'Saving local recording' : 'Leave debate'}
+            title={roomState === 'saving' ? 'Saving local recording' : 'Leave debate'}
             onClick={onLeave}
             disabled={leaveDisabled}
           >
@@ -1328,7 +1379,7 @@ function DebateDebugMenu({
 }: {
   debate: Debate;
   countdown: DebateCountdown;
-  roomState: 'connecting' | 'connected' | 'uploading';
+  roomState: 'connecting' | 'connected' | 'saving';
   audioMuted: boolean;
   remoteAudioEnabled: boolean;
   videoEnabled: boolean;
@@ -1349,7 +1400,7 @@ function DebateDebugMenu({
             ariaLabel={audioMuted ? 'Unmute microphone' : 'Mute microphone'}
             title={audioMuted ? 'Unmute microphone' : 'Mute microphone'}
             onClick={onToggleAudioMuted}
-            disabled={roomState === 'uploading'}
+            disabled={roomState === 'saving'}
             active={audioMuted}
           >
             <MicrophoneIcon muted={audioMuted} />
@@ -1358,7 +1409,7 @@ function DebateDebugMenu({
             ariaLabel={remoteAudioEnabled ? 'Disable audio' : 'Enable audio'}
             title={remoteAudioEnabled ? 'Disable audio' : 'Enable audio'}
             onClick={onToggleRemoteAudioEnabled}
-            disabled={roomState === 'uploading'}
+            disabled={roomState === 'saving'}
             active={!remoteAudioEnabled}
           >
             <SpeakerIcon disabled={!remoteAudioEnabled} />
@@ -1367,7 +1418,7 @@ function DebateDebugMenu({
             ariaLabel={videoEnabled ? 'Turn camera off' : 'Turn camera on'}
             title={videoEnabled ? 'Turn camera off' : 'Turn camera on'}
             onClick={onToggleVideoEnabled}
-            disabled={roomState === 'uploading'}
+            disabled={roomState === 'saving'}
             active={!videoEnabled}
           >
             <CameraIcon disabled={!videoEnabled} />
@@ -2023,10 +2074,6 @@ function timestampMs(value: string | null) {
   if (!value) return null;
   const timestamp = Date.parse(value);
   return Number.isFinite(timestamp) ? timestamp : null;
-}
-
-function delay(ms: number): Promise<void> {
-  return new Promise(resolve => window.setTimeout(resolve, ms));
 }
 
 function preferredRecordingMimeType() {

--- a/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.tsx
@@ -23,8 +23,10 @@ import {
   useMarkDebateReady,
 } from '~/core/debates/hooks';
 import {
+  debateRecordingUploadId,
   enqueueDebateRecordingUpload,
   estimateRecordingStorage,
+  getDebateRecordingUpload,
   isStorageQuotaError,
   requestPersistentRecordingStorage,
 } from '~/core/debates/recording-upload-queue';
@@ -244,12 +246,28 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
 
   const performStoppedLocalRecordingPersistence = React.useCallback(async () => {
     if (persistedRecordingDebateIdRef.current === debate?.id) return true;
+
+    const localParticipant =
+      debate?.participants.find(participant => participant.participant_slot === joinResponse?.participant_slot) ??
+      debate?.participants.find(participant => participant.user_id === currentUserId) ??
+      null;
+    if (!localParticipant || !debate) return false;
+
+    const backendRecordingExists = debate.recordings.some(recording => recording.user_id === localParticipant.user_id);
+    const queuedRecording = backendRecordingExists
+      ? undefined
+      : await getDebateRecordingUpload(debateRecordingUploadId(localParticipant.user_id, debate.id));
+    if (backendRecordingExists || queuedRecording) {
+      persistedRecordingDebateIdRef.current = debate.id;
+      return true;
+    }
+
     await stopLocalRecorder();
 
     const recorder = recorderRef.current;
     const startedAtMs = recordingStartedAtRef.current;
     const endedAtMs = recordingEndedAtRef.current;
-    if (!recorder || !startedAtMs || !endedAtMs || !joinResponse || !debate) return false;
+    if (!recorder || !startedAtMs || !endedAtMs) return false;
 
     if (!stoppedRecordingRef.current) {
       const mimeType = recorder.mimeType || preferredRecordingMimeType() || 'video/webm';
@@ -268,11 +286,6 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
         videoBitsPerSecond: recorder.videoBitsPerSecond || null,
       };
     }
-
-    const localParticipant = debate.participants.find(
-      participant => participant.participant_slot === joinResponse.participant_slot
-    );
-    if (!localParticipant) return false;
 
     const recording = stoppedRecordingRef.current;
     const storage = await estimateRecordingStorage();
@@ -316,7 +329,7 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
     recordingStartedAtRef.current = null;
     recordingEndedAtRef.current = null;
     return true;
-  }, [debate, joinResponse, stopLocalRecorder]);
+  }, [currentUserId, debate, joinResponse?.participant_slot, stopLocalRecorder]);
 
   const persistStoppedLocalRecording = React.useCallback(() => {
     if (persistedRecordingDebateIdRef.current === debate?.id) return Promise.resolve(true);
@@ -327,6 +340,15 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
     recordingPersistencePromiseRef.current = persistence;
     return persistence;
   }, [debate?.id, performStoppedLocalRecordingPersistence]);
+
+  const persistRecordingAfterCapture = React.useCallback(() => {
+    if (!debate || recordingPersistenceStartedRef.current === debate.id) return;
+    recordingPersistenceStartedRef.current = debate.id;
+    void persistStoppedLocalRecording().catch(error => {
+      recordingPersistenceStartedRef.current = null;
+      setRoomError(error instanceof Error ? error.message : 'Could not save the local recording.');
+    });
+  }, [debate, persistStoppedLocalRecording]);
 
   const discardLocalRecorder = React.useCallback(async () => {
     clearRecordingTimers();
@@ -794,20 +816,14 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
     if (!recordingWindow) return;
 
     if (debate.status === 'thanking') {
-      if (recordingPersistenceStartedRef.current !== debate.id) {
-        recordingPersistenceStartedRef.current = debate.id;
-        void persistStoppedLocalRecording().catch(error => {
-          recordingPersistenceStartedRef.current = null;
-          setRoomError(error instanceof Error ? error.message : 'Could not save the local recording.');
-        });
-      }
+      persistRecordingAfterCapture();
       return;
     }
     if (debate.status !== 'preflight' && debate.status !== 'in_progress') return;
 
     const now = Date.now();
     if (now >= recordingWindow.endAtMs) {
-      void stopLocalRecorder();
+      persistRecordingAfterCapture();
       return;
     }
 
@@ -819,13 +835,13 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
     }
     recordingStopTimerRef.current = window.setTimeout(
       () => {
-        void stopLocalRecorder();
+        persistRecordingAfterCapture();
       },
       Math.max(0, recordingWindow.endAtMs - now)
     );
 
     return clearRecordingTimers;
-  }, [clearRecordingTimers, debate, persistStoppedLocalRecording, roomState, startLocalRecorder, stopLocalRecorder]);
+  }, [clearRecordingTimers, debate, persistRecordingAfterCapture, roomState, startLocalRecorder]);
 
   React.useEffect(() => {
     if (!debate) return;

--- a/apps/web/core/database/indexeddb.ts
+++ b/apps/web/core/database/indexeddb.ts
@@ -1,21 +1,29 @@
 import Dexie, { Table } from 'dexie';
 
+import type { DebateRecordingUpload } from '../debates/recording-upload-queue';
 import { Relation, Value } from '../types';
 
 const OLD_DB_NAME = 'geogenesis';
 const DB_NAME = 'geogenesis-local';
-const VERSION = 1;
+const VERSION = 2;
 
 class Geo extends Dexie {
   values!: Table<Value>;
   relations!: Table<Relation>;
+  debateRecordingUploads!: Table<DebateRecordingUpload, string>;
 
   constructor() {
     super(DB_NAME);
 
+    this.version(1).stores({
+      values: 'id, spaceId',
+      relations: 'id, spaceId',
+    });
+
     this.version(VERSION).stores({
       values: 'id, spaceId',
       relations: 'id, spaceId',
+      debateRecordingUploads: 'id, userId, debateId, stage, nextAttemptAt, createdAt',
     });
   }
 }

--- a/apps/web/core/debates/api.ts
+++ b/apps/web/core/debates/api.ts
@@ -379,6 +379,11 @@ export function getCurrentGeoChatUserId() {
   return decodeGeoChatAccessToken(session?.access_token)?.user_id ?? null;
 }
 
+export async function resolveCurrentGeoChatUserId(getPrivyIdentityToken: GetPrivyIdentityToken) {
+  const accessToken = await getGeoChatAccessToken(getPrivyIdentityToken);
+  return decodeGeoChatAccessToken(accessToken)?.user_id ?? null;
+}
+
 export async function heartbeatDebatePresence(getPrivyIdentityToken: GetPrivyIdentityToken) {
   return geoChatRequest<DebateActivity>('/me/debate-presence/heartbeat', {
     method: 'POST',

--- a/apps/web/core/debates/recording-upload-coordinator.integration.test.tsx
+++ b/apps/web/core/debates/recording-upload-coordinator.integration.test.tsx
@@ -1,0 +1,199 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { DebateRecordingUploadCoordinator } from './recording-upload-coordinator';
+import type { DebateRecordingUpload } from './recording-upload-queue';
+
+const mocks = vi.hoisted(() => ({
+  completeUpload: vi.fn(),
+  createUpload: vi.fn(),
+  deleteUpload: vi.fn(),
+  getUpload: vi.fn(),
+  invalidateQueries: vi.fn(),
+  lockRequest: vi.fn(),
+  markUploaded: vi.fn(),
+  observer: null as null | ((uploads: DebateRecordingUpload[]) => void),
+  putRecording: vi.fn(),
+  queue: [] as DebateRecordingUpload[],
+  resolveUser: vi.fn(),
+  scheduleRetry: vi.fn(),
+}));
+
+vi.mock('@tanstack/react-query', async importOriginal => ({
+  ...(await importOriginal<typeof import('@tanstack/react-query')>()),
+  useQueryClient: () => ({ invalidateQueries: mocks.invalidateQueries }),
+}));
+
+vi.mock('./hooks', () => ({
+  debateQueryKeys: {
+    debate: (id: string) => ['debate', id],
+    media: (id: string) => ['media', id],
+  },
+  useGeoChatAuth: () => ({
+    ready: true,
+    authenticated: true,
+    getPrivyIdentityToken: vi.fn(),
+  }),
+}));
+
+vi.mock('./api', async importOriginal => ({
+  ...(await importOriginal<typeof import('./api')>()),
+  completeLocalRecordingUpload: mocks.completeUpload,
+  createLocalRecordingUpload: mocks.createUpload,
+  resolveCurrentGeoChatUserId: mocks.resolveUser,
+}));
+
+vi.mock('./recording-upload-queue', async importOriginal => ({
+  ...(await importOriginal<typeof import('./recording-upload-queue')>()),
+  deleteDebateRecordingUpload: async (id: string) => {
+    await mocks.deleteUpload(id);
+    mocks.queue = mocks.queue.filter(upload => upload.id !== id);
+    mocks.observer?.(mocks.queue);
+  },
+  getDebateRecordingUpload: (id: string) => mocks.getUpload(id),
+  markDebateRecordingUploaded: mocks.markUploaded,
+  observeDebateRecordingUploads: () => ({
+    subscribe: ({ next }: { next: (uploads: DebateRecordingUpload[]) => void }) => {
+      mocks.observer = next;
+      next(mocks.queue);
+      return { unsubscribe: () => (mocks.observer = null) };
+    },
+  }),
+  scheduleDebateRecordingRetry: mocks.scheduleRetry,
+}));
+
+beforeEach(() => {
+  mocks.completeUpload.mockReset().mockResolvedValue(undefined);
+  mocks.createUpload.mockReset().mockImplementation(async (debateId: string) => ({
+    filename: `recordings/${debateId}.webm`,
+    upload: {
+      url: `https://upload.test/${debateId}`,
+      method: 'PUT',
+      headers: {},
+      expires_at: '2026-07-13T23:59:59.000Z',
+    },
+  }));
+  mocks.deleteUpload.mockReset().mockResolvedValue(undefined);
+  mocks.getUpload.mockReset().mockImplementation(async (id: string) => mocks.queue.find(upload => upload.id === id));
+  mocks.invalidateQueries.mockReset();
+  mocks.lockRequest.mockReset().mockImplementation(async (_name, _options, callback) => callback({ name: 'lock' }));
+  mocks.markUploaded.mockReset().mockResolvedValue(undefined);
+  mocks.observer = null;
+  mocks.putRecording.mockReset().mockResolvedValue({ ok: true });
+  mocks.queue = [];
+  mocks.resolveUser.mockReset().mockResolvedValue('user-a');
+  mocks.scheduleRetry.mockReset().mockResolvedValue(undefined);
+  vi.stubGlobal('fetch', mocks.putRecording);
+  Object.defineProperty(navigator, 'locks', {
+    configurable: true,
+    value: { request: mocks.lockRequest },
+  });
+  Object.defineProperty(navigator, 'onLine', { configurable: true, value: true });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe('DebateRecordingUploadCoordinator', () => {
+  it('recovers a persisted upload on app startup under the browser-wide lock', async () => {
+    mocks.queue = [queuedRecording('debate-1')];
+
+    render(<DebateRecordingUploadCoordinator />);
+
+    await waitFor(() => expect(mocks.completeUpload).toHaveBeenCalledOnce());
+    expect(mocks.lockRequest).toHaveBeenCalledWith(
+      'geo:debate-recording-uploader',
+      { ifAvailable: true },
+      expect.any(Function)
+    );
+    await waitFor(() => expect(screen.queryByRole('status')).not.toBeInTheDocument());
+  });
+
+  it('waits while offline and resumes when the browser reconnects', async () => {
+    Object.defineProperty(navigator, 'onLine', { configurable: true, value: false });
+    mocks.queue = [queuedRecording('debate-1')];
+
+    render(<DebateRecordingUploadCoordinator />);
+
+    expect(await screen.findByText('Waiting to upload 1 debate')).toBeInTheDocument();
+    expect(mocks.createUpload).not.toHaveBeenCalled();
+
+    Object.defineProperty(navigator, 'onLine', { configurable: true, value: true });
+    window.dispatchEvent(new Event('online'));
+
+    await waitFor(() => expect(mocks.completeUpload).toHaveBeenCalledOnce());
+  });
+
+  it('uploads queued recordings sequentially', async () => {
+    const firstCompletion = deferred<void>();
+    mocks.completeUpload.mockImplementation((debateId: string) =>
+      debateId === 'debate-1' ? firstCompletion.promise : Promise.resolve()
+    );
+    mocks.queue = [queuedRecording('debate-1'), queuedRecording('debate-2')];
+
+    render(<DebateRecordingUploadCoordinator />);
+
+    await waitFor(() =>
+      expect(mocks.completeUpload).toHaveBeenCalledWith('debate-1', expect.anything(), expect.anything())
+    );
+    expect(mocks.createUpload).not.toHaveBeenCalledWith('debate-2', expect.anything(), expect.anything());
+
+    firstCompletion.resolve();
+
+    await waitFor(() =>
+      expect(mocks.completeUpload).toHaveBeenCalledWith('debate-2', expect.anything(), expect.anything())
+    );
+  });
+
+  it('restores a dismissed upload pill after the app remounts', async () => {
+    Object.defineProperty(navigator, 'onLine', { configurable: true, value: false });
+    mocks.queue = [queuedRecording('debate-1')];
+
+    const firstMount = render(<DebateRecordingUploadCoordinator />);
+    fireEvent.click(await screen.findByRole('button', { name: 'Hide recording upload status' }));
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+
+    firstMount.unmount();
+    render(<DebateRecordingUploadCoordinator />);
+
+    expect(await screen.findByText('Waiting to upload 1 debate')).toBeInTheDocument();
+  });
+});
+
+function queuedRecording(debateId: string): DebateRecordingUpload {
+  return {
+    id: `user-a:${debateId}`,
+    userId: 'user-a',
+    debateId,
+    blob: new Blob(['recording'], { type: 'video/webm' }),
+    mimeType: 'video/webm',
+    startedAtMs: 1_000,
+    endedAtMs: 11_000,
+    durationSeconds: 10,
+    byteSize: 9,
+    width: null,
+    height: null,
+    framerate: null,
+    videoBitsPerSecond: null,
+    stage: 'queued',
+    filename: null,
+    attemptCount: 0,
+    nextAttemptAt: 0,
+    lastError: null,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>(resolvePromise => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}

--- a/apps/web/core/debates/recording-upload-coordinator.integration.test.tsx
+++ b/apps/web/core/debates/recording-upload-coordinator.integration.test.tsx
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => ({
   createUpload: vi.fn(),
   deleteUpload: vi.fn(),
   getUpload: vi.fn(),
+  getToken: vi.fn(),
   invalidateQueries: vi.fn(),
   lockRequest: vi.fn(),
   markUploaded: vi.fn(),
@@ -34,7 +35,7 @@ vi.mock('./hooks', () => ({
   useGeoChatAuth: () => ({
     ready: true,
     authenticated: true,
-    getPrivyIdentityToken: vi.fn(),
+    getPrivyIdentityToken: mocks.getToken,
   }),
 }));
 
@@ -77,6 +78,7 @@ beforeEach(() => {
   }));
   mocks.deleteUpload.mockReset().mockResolvedValue(undefined);
   mocks.getUpload.mockReset().mockImplementation(async (id: string) => mocks.queue.find(upload => upload.id === id));
+  mocks.getToken.mockReset().mockResolvedValue('identity-token');
   mocks.invalidateQueries.mockReset();
   mocks.lockRequest.mockReset().mockImplementation(async (_name, _options, callback) => callback({ name: 'lock' }));
   mocks.markUploaded.mockReset().mockResolvedValue(undefined);
@@ -162,6 +164,19 @@ describe('DebateRecordingUploadCoordinator', () => {
     render(<DebateRecordingUploadCoordinator />);
 
     expect(await screen.findByText('Waiting to upload 1 debate')).toBeInTheDocument();
+  });
+
+  it('retries transient user resolution failures when the browser reconnects', async () => {
+    mocks.queue = [queuedRecording('debate-1')];
+    mocks.resolveUser.mockRejectedValueOnce(new Error('auth unavailable')).mockResolvedValue('user-a');
+
+    render(<DebateRecordingUploadCoordinator />);
+
+    await waitFor(() => expect(mocks.resolveUser).toHaveBeenCalledOnce());
+    window.dispatchEvent(new Event('online'));
+
+    await waitFor(() => expect(mocks.resolveUser).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(mocks.completeUpload).toHaveBeenCalledOnce());
   });
 });
 

--- a/apps/web/core/debates/recording-upload-coordinator.test.tsx
+++ b/apps/web/core/debates/recording-upload-coordinator.test.tsx
@@ -1,0 +1,133 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  DebateRecordingUploadPill,
+  processDebateRecordingUpload,
+  recordingUploadRetryDelay,
+} from './recording-upload-coordinator';
+import type { DebateRecordingUpload } from './recording-upload-queue';
+
+afterEach(cleanup);
+
+describe('debate recording uploader', () => {
+  it('uploads, persists the filename, finalizes, and deletes a queued recording', async () => {
+    const upload = queuedRecording();
+    const dependencies = uploadDependencies();
+
+    await processDebateRecordingUpload(upload, dependencies);
+
+    expect(dependencies.createUpload).toHaveBeenCalledWith('debate-1', {
+      mime_type: 'video/webm',
+      started_at_ms: 1_000,
+    });
+    expect(dependencies.putRecording).toHaveBeenCalledWith(
+      expect.objectContaining({ url: 'https://upload.test/recording', method: 'PUT' }),
+      upload.blob,
+      'video/webm'
+    );
+    expect(dependencies.markUploaded).toHaveBeenCalledWith(upload.id, 'recordings/debate-1/recording.webm');
+    expect(dependencies.completeUpload).toHaveBeenCalledWith(
+      'debate-1',
+      expect.objectContaining({
+        filename: 'recordings/debate-1/recording.webm',
+        byte_size: upload.blob.size,
+        started_at_ms: 1_000,
+        ended_at_ms: 11_000,
+      })
+    );
+    expect(dependencies.deleteUpload).toHaveBeenCalledWith(upload.id);
+  });
+
+  it('retries only finalization after the object upload was persisted', async () => {
+    const upload = {
+      ...queuedRecording(),
+      stage: 'uploaded' as const,
+      filename: 'recordings/debate-1/recording.webm',
+    };
+    const dependencies = uploadDependencies();
+
+    await processDebateRecordingUpload(upload, dependencies);
+
+    expect(dependencies.createUpload).not.toHaveBeenCalled();
+    expect(dependencies.putRecording).not.toHaveBeenCalled();
+    expect(dependencies.markUploaded).not.toHaveBeenCalled();
+    expect(dependencies.completeUpload).toHaveBeenCalledOnce();
+    expect(dependencies.deleteUpload).toHaveBeenCalledWith(upload.id);
+  });
+
+  it('does not delete a recording when object upload or finalization fails', async () => {
+    const dependencies = uploadDependencies();
+    dependencies.completeUpload.mockRejectedValue(new Error('finalization unavailable'));
+
+    await expect(processDebateRecordingUpload(queuedRecording(), dependencies)).rejects.toThrow(
+      'finalization unavailable'
+    );
+
+    expect(dependencies.markUploaded).toHaveBeenCalledOnce();
+    expect(dependencies.deleteUpload).not.toHaveBeenCalled();
+  });
+
+  it('uses bounded exponential retry delays', () => {
+    expect(recordingUploadRetryDelay(0)).toBe(5_000);
+    expect(recordingUploadRetryDelay(1)).toBe(10_000);
+    expect(recordingUploadRetryDelay(12)).toBe(300_000);
+  });
+});
+
+describe('DebateRecordingUploadPill', () => {
+  it('shows upload count and dismisses only its presentation', () => {
+    const dismiss = vi.fn();
+    render(<DebateRecordingUploadPill count={1} waiting={false} onDismiss={dismiss} />);
+
+    expect(screen.getByText('Uploading 1 debate')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Hide recording upload status' }));
+    expect(dismiss).toHaveBeenCalledOnce();
+  });
+
+  it('shows plural waiting copy while offline or backing off', () => {
+    render(<DebateRecordingUploadPill count={2} waiting onDismiss={() => undefined} />);
+
+    expect(screen.getByText('Waiting to upload 2 debates')).toBeInTheDocument();
+  });
+});
+
+function queuedRecording(): DebateRecordingUpload {
+  return {
+    id: 'user-a:debate-1',
+    userId: 'user-a',
+    debateId: 'debate-1',
+    blob: new Blob(['recording'], { type: 'video/webm' }),
+    mimeType: 'video/webm',
+    startedAtMs: 1_000,
+    endedAtMs: 11_000,
+    durationSeconds: 10,
+    byteSize: 9,
+    width: null,
+    height: null,
+    framerate: null,
+    videoBitsPerSecond: null,
+    stage: 'queued',
+    filename: null,
+    attemptCount: 0,
+    nextAttemptAt: 0,
+    lastError: null,
+    createdAt: 0,
+    updatedAt: 0,
+  };
+}
+
+function uploadDependencies() {
+  return {
+    createUpload: vi.fn().mockResolvedValue({
+      filename: 'recordings/debate-1/recording.webm',
+      upload: { url: 'https://upload.test/recording', method: 'PUT', headers: { 'x-upload': 'yes' } },
+    }),
+    putRecording: vi.fn().mockResolvedValue(undefined),
+    markUploaded: vi.fn().mockResolvedValue(undefined),
+    completeUpload: vi.fn().mockResolvedValue(undefined),
+    deleteUpload: vi.fn().mockResolvedValue(undefined),
+  };
+}

--- a/apps/web/core/debates/recording-upload-coordinator.tsx
+++ b/apps/web/core/debates/recording-upload-coordinator.tsx
@@ -1,0 +1,258 @@
+'use client';
+
+import { useQueryClient } from '@tanstack/react-query';
+
+import * as React from 'react';
+
+import { Z_LAYER_CLASS } from '~/core/z-layers';
+
+import { CloseSmall } from '~/design-system/icons/close-small';
+
+import {
+  type GetPrivyIdentityToken,
+  type LocalRecordingCompleteRequest,
+  type LocalRecordingUploadRequest,
+  type LocalRecordingUploadResponse,
+  completeLocalRecordingUpload,
+  createLocalRecordingUpload,
+  resolveCurrentGeoChatUserId,
+} from './api';
+import { debateQueryKeys, useGeoChatAuth } from './hooks';
+import {
+  type DebateRecordingUpload,
+  deleteDebateRecordingUpload,
+  getDebateRecordingUpload,
+  markDebateRecordingUploaded,
+  observeDebateRecordingUploads,
+  scheduleDebateRecordingRetry,
+} from './recording-upload-queue';
+
+const initialRetryDelayMs = 5_000;
+const maxRetryDelayMs = 5 * 60_000;
+
+type RecordingUploadDependencies = {
+  createUpload: (debateId: string, request: LocalRecordingUploadRequest) => Promise<LocalRecordingUploadResponse>;
+  putRecording: (upload: LocalRecordingUploadResponse['upload'], blob: Blob, mimeType: string) => Promise<void>;
+  markUploaded: (id: string, filename: string) => Promise<void>;
+  completeUpload: (debateId: string, request: LocalRecordingCompleteRequest) => Promise<unknown>;
+  deleteUpload: (id: string) => Promise<void>;
+};
+
+export async function processDebateRecordingUpload(
+  upload: DebateRecordingUpload,
+  dependencies: RecordingUploadDependencies
+) {
+  let filename = upload.filename;
+  if (upload.stage === 'queued' || !filename) {
+    const target = await dependencies.createUpload(upload.debateId, {
+      mime_type: upload.mimeType,
+      started_at_ms: upload.startedAtMs,
+    });
+    await dependencies.putRecording(target.upload, upload.blob, upload.mimeType);
+    filename = target.filename;
+    await dependencies.markUploaded(upload.id, filename);
+  }
+
+  await dependencies.completeUpload(upload.debateId, {
+    filename,
+    mime_type: upload.mimeType,
+    started_at_ms: upload.startedAtMs,
+    ended_at_ms: upload.endedAtMs,
+    duration_seconds: upload.durationSeconds,
+    byte_size: upload.byteSize,
+    width: upload.width,
+    height: upload.height,
+    framerate: upload.framerate,
+    video_bits_per_second: upload.videoBitsPerSecond,
+  });
+  await dependencies.deleteUpload(upload.id);
+}
+
+export function recordingUploadRetryDelay(attemptCount: number) {
+  return Math.min(maxRetryDelayMs, initialRetryDelayMs * 2 ** Math.max(0, attemptCount));
+}
+
+export function DebateRecordingUploadCoordinator() {
+  const queryClient = useQueryClient();
+  const { ready, authenticated, getPrivyIdentityToken } = useGeoChatAuth();
+  const [userId, setUserId] = React.useState<string | null>(null);
+  const [uploads, setUploads] = React.useState<DebateRecordingUpload[]>([]);
+  const [activeUploadId, setActiveUploadId] = React.useState<string | null>(null);
+  const [online, setOnline] = React.useState(() => typeof navigator === 'undefined' || navigator.onLine);
+  const [wakeAt, setWakeAt] = React.useState(() => Date.now());
+  const [toastDismissed, setToastDismissed] = React.useState(false);
+  const activeUploadIdRef = React.useRef<string | null>(null);
+  const lockRetryAtRef = React.useRef(0);
+  const mountedRef = React.useRef(true);
+
+  React.useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  React.useEffect(() => {
+    if (!ready || !authenticated) {
+      setUserId(null);
+      return;
+    }
+    let cancelled = false;
+    void resolveCurrentGeoChatUserId(getPrivyIdentityToken)
+      .then(id => {
+        if (!cancelled) setUserId(id);
+      })
+      .catch(error => {
+        console.warn('[DebateRecordingUploadCoordinator] could not resolve user:', error);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [authenticated, getPrivyIdentityToken, ready]);
+
+  React.useEffect(() => {
+    if (!userId) {
+      setUploads([]);
+      return;
+    }
+    const subscription = observeDebateRecordingUploads(userId).subscribe({
+      next: setUploads,
+      error: error => console.warn('[DebateRecordingUploadCoordinator] queue observation failed:', error),
+    });
+    return () => subscription.unsubscribe();
+  }, [userId]);
+
+  React.useEffect(() => {
+    const handleOnline = () => {
+      setOnline(true);
+      setWakeAt(Date.now());
+    };
+    const handleOffline = () => setOnline(false);
+    const handleVisibility = () => {
+      if (document.visibilityState === 'visible') setWakeAt(Date.now());
+    };
+    window.addEventListener('online', handleOnline);
+    window.addEventListener('offline', handleOffline);
+    document.addEventListener('visibilitychange', handleVisibility);
+    return () => {
+      window.removeEventListener('online', handleOnline);
+      window.removeEventListener('offline', handleOffline);
+      document.removeEventListener('visibilitychange', handleVisibility);
+    };
+  }, []);
+
+  React.useEffect(() => {
+    if (activeUploadId || uploads.length === 0) return;
+    const nextAttemptAt = Math.min(...uploads.map(upload => upload.nextAttemptAt));
+    const delay = Math.max(0, nextAttemptAt - Date.now());
+    if (delay === 0) return;
+    const timer = window.setTimeout(() => setWakeAt(Date.now()), delay);
+    return () => window.clearTimeout(timer);
+  }, [activeUploadId, uploads]);
+
+  React.useEffect(() => {
+    if (!userId || !online || activeUploadIdRef.current || Date.now() < lockRetryAtRef.current) return;
+    const upload = uploads.find(candidate => candidate.nextAttemptAt <= Date.now());
+    if (!upload) return;
+
+    activeUploadIdRef.current = upload.id;
+    setActiveUploadId(upload.id);
+    const dependencies = recordingUploadDependencies(getPrivyIdentityToken);
+    void withRecordingUploadLock(async () => {
+      const latestUpload = await getDebateRecordingUpload(upload.id);
+      if (!latestUpload || latestUpload.userId !== userId) return;
+      await processDebateRecordingUpload(latestUpload, dependencies);
+      void queryClient.invalidateQueries({ queryKey: debateQueryKeys.debate(upload.debateId) });
+      void queryClient.invalidateQueries({ queryKey: debateQueryKeys.media(upload.debateId) });
+    })
+      .then(acquired => {
+        if (!acquired) {
+          lockRetryAtRef.current = Date.now() + 1_000;
+          window.setTimeout(() => setWakeAt(Date.now()), 1_000);
+        }
+      })
+      .catch(async error => {
+        const nextAttemptAt = Date.now() + recordingUploadRetryDelay(upload.attemptCount);
+        try {
+          await scheduleDebateRecordingRetry(upload.id, error, nextAttemptAt);
+        } catch (queueError) {
+          console.warn('[DebateRecordingUploadCoordinator] could not persist retry state:', queueError);
+        }
+      })
+      .finally(() => {
+        activeUploadIdRef.current = null;
+        if (mountedRef.current) {
+          setActiveUploadId(null);
+          setWakeAt(Date.now());
+        }
+      });
+  }, [activeUploadId, getPrivyIdentityToken, online, queryClient, uploads, userId, wakeAt]);
+
+  const waiting = !online || (!activeUploadId && uploads.every(upload => upload.nextAttemptAt > Date.now()));
+  if (uploads.length === 0 || toastDismissed) return null;
+
+  return (
+    <DebateRecordingUploadPill count={uploads.length} waiting={waiting} onDismiss={() => setToastDismissed(true)} />
+  );
+}
+
+export function DebateRecordingUploadPill({
+  count,
+  waiting,
+  onDismiss,
+}: {
+  count: number;
+  waiting: boolean;
+  onDismiss: () => void;
+}) {
+  const label = `${count} debate${count === 1 ? '' : 's'}`;
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className={`fixed bottom-16 left-1/2 inline-flex -translate-x-1/2 items-center gap-3 rounded-full border border-grey-02 bg-white py-2 pr-2 pl-3 text-sm font-medium whitespace-nowrap text-text shadow-card ${Z_LAYER_CLASS.toast}`}
+    >
+      <span aria-hidden="true" className="size-5 animate-spin rounded-full border-2 border-grey-02 border-t-grey-04" />
+      <span>{waiting ? `Waiting to upload ${label}` : `Uploading ${label}`}</span>
+      <button
+        type="button"
+        aria-label="Hide recording upload status"
+        onClick={onDismiss}
+        className="grid size-7 place-items-center rounded-full text-grey-04 hover:bg-grey-01"
+      >
+        <CloseSmall />
+      </button>
+    </div>
+  );
+}
+
+function recordingUploadDependencies(getPrivyIdentityToken: GetPrivyIdentityToken): RecordingUploadDependencies {
+  return {
+    createUpload: (debateId, request) => createLocalRecordingUpload(debateId, request, getPrivyIdentityToken),
+    putRecording: putRecording,
+    markUploaded: markDebateRecordingUploaded,
+    completeUpload: (debateId, request) => completeLocalRecordingUpload(debateId, request, getPrivyIdentityToken),
+    deleteUpload: deleteDebateRecordingUpload,
+  };
+}
+
+async function putRecording(upload: LocalRecordingUploadResponse['upload'], blob: Blob, mimeType: string) {
+  const headers = new Headers(upload.headers);
+  headers.set('Content-Type', mimeType);
+  const response = await fetch(upload.url, { method: upload.method, headers, body: blob });
+  if (!response.ok) throw new Error(`Recording upload failed (${response.status})`);
+}
+
+async function withRecordingUploadLock(task: () => Promise<void>) {
+  if (typeof navigator !== 'undefined' && navigator.locks?.request) {
+    let acquired = false;
+    await navigator.locks.request('geo:debate-recording-uploader', { ifAvailable: true }, async lock => {
+      if (!lock) return;
+      acquired = true;
+      await task();
+    });
+    return acquired;
+  }
+  await task();
+  return true;
+}

--- a/apps/web/core/debates/recording-upload-coordinator.tsx
+++ b/apps/web/core/debates/recording-upload-coordinator.tsx
@@ -80,6 +80,7 @@ export function DebateRecordingUploadCoordinator() {
   const [activeUploadId, setActiveUploadId] = React.useState<string | null>(null);
   const [online, setOnline] = React.useState(() => typeof navigator === 'undefined' || navigator.onLine);
   const [wakeAt, setWakeAt] = React.useState(() => Date.now());
+  const [identityRetrySignal, setIdentityRetrySignal] = React.useState(0);
   const [toastDismissed, setToastDismissed] = React.useState(false);
   const activeUploadIdRef = React.useRef<string | null>(null);
   const lockRetryAtRef = React.useRef(0);
@@ -95,20 +96,29 @@ export function DebateRecordingUploadCoordinator() {
   React.useEffect(() => {
     if (!ready || !authenticated) {
       setUserId(null);
+      setUploads([]);
       return;
     }
+    setUserId(null);
+    setUploads([]);
     let cancelled = false;
+    let retryTimer: number | null = null;
     void resolveCurrentGeoChatUserId(getPrivyIdentityToken)
       .then(id => {
+        if (!id) throw new Error('The debate upload user could not be resolved.');
         if (!cancelled) setUserId(id);
       })
       .catch(error => {
         console.warn('[DebateRecordingUploadCoordinator] could not resolve user:', error);
+        if (!cancelled) {
+          retryTimer = window.setTimeout(() => setIdentityRetrySignal(current => current + 1), initialRetryDelayMs);
+        }
       });
     return () => {
       cancelled = true;
+      if (retryTimer !== null) window.clearTimeout(retryTimer);
     };
-  }, [authenticated, getPrivyIdentityToken, ready]);
+  }, [authenticated, getPrivyIdentityToken, identityRetrySignal, ready]);
 
   React.useEffect(() => {
     if (!userId) {
@@ -126,10 +136,14 @@ export function DebateRecordingUploadCoordinator() {
     const handleOnline = () => {
       setOnline(true);
       setWakeAt(Date.now());
+      if (!userId) setIdentityRetrySignal(current => current + 1);
     };
     const handleOffline = () => setOnline(false);
     const handleVisibility = () => {
-      if (document.visibilityState === 'visible') setWakeAt(Date.now());
+      if (document.visibilityState === 'visible') {
+        setWakeAt(Date.now());
+        if (!userId) setIdentityRetrySignal(current => current + 1);
+      }
     };
     window.addEventListener('online', handleOnline);
     window.addEventListener('offline', handleOffline);
@@ -139,7 +153,7 @@ export function DebateRecordingUploadCoordinator() {
       window.removeEventListener('offline', handleOffline);
       document.removeEventListener('visibilitychange', handleVisibility);
     };
-  }, []);
+  }, [userId]);
 
   React.useEffect(() => {
     if (activeUploadId || uploads.length === 0) return;

--- a/apps/web/core/debates/recording-upload-queue.test.ts
+++ b/apps/web/core/debates/recording-upload-queue.test.ts
@@ -1,0 +1,152 @@
+import { IDBKeyRange, indexedDB } from 'fake-indexeddb';
+import { Blob as NodeBlob } from 'node:buffer';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+
+import type { db as database } from '~/core/database/indexeddb';
+
+import type * as RecordingUploadQueue from './recording-upload-queue';
+
+let db: typeof database;
+let queue: typeof RecordingUploadQueue;
+
+describe('debate recording upload queue', () => {
+  beforeAll(async () => {
+    globalThis.indexedDB = indexedDB;
+    globalThis.IDBKeyRange = IDBKeyRange;
+    globalThis.Blob = NodeBlob as typeof Blob;
+    ({ db } = await import('~/core/database/indexeddb'));
+    queue = await import('./recording-upload-queue');
+  });
+
+  beforeEach(async () => {
+    db.close();
+    await db.delete();
+    await db.open();
+  });
+
+  afterEach(async () => {
+    db.close();
+    await db.delete();
+  });
+
+  afterAll(() => {
+    db.close();
+  });
+
+  it('round-trips a 60 MiB recording blob and its upload metadata', async () => {
+    const blob = new Blob([new Uint8Array(60 * 1024 * 1024)], { type: 'video/webm' });
+
+    const queued = await queue.enqueueDebateRecordingUpload({
+      userId: 'user-a',
+      debateId: 'debate-1',
+      blob,
+      mimeType: 'video/webm',
+      startedAtMs: 1_000,
+      endedAtMs: 11_000,
+      durationSeconds: 10,
+    });
+
+    db.close();
+    await db.open();
+    const [restored] = await queue.listDebateRecordingUploads('user-a');
+    expect(restored).toMatchObject({
+      id: queued.id,
+      userId: 'user-a',
+      debateId: 'debate-1',
+      stage: 'queued',
+      filename: null,
+      attemptCount: 0,
+    });
+    expect(restored?.blob).toBeInstanceOf(Blob);
+    expect(restored?.blob.size).toBe(60 * 1024 * 1024);
+    expect(restored?.blob.type).toBe('video/webm');
+  });
+
+  it('upgrades the database without removing existing graph data', async () => {
+    db.close();
+    await db.delete();
+    const { default: Dexie } = await import('dexie');
+    const legacyDb = new Dexie('geogenesis-local');
+    legacyDb.version(1).stores({ values: 'id, spaceId', relations: 'id, spaceId' });
+    await legacyDb.open();
+    await legacyDb.table('values').add({ id: 'value-1', spaceId: 'space-1', value: 'Preserved' });
+    legacyDb.close();
+
+    await db.open();
+
+    expect(await db.values.get('value-1')).toMatchObject({ id: 'value-1', spaceId: 'space-1' });
+    expect(db.debateRecordingUploads).toBeDefined();
+  });
+
+  it('deduplicates a recording by user and debate', async () => {
+    const input = {
+      userId: 'user-a',
+      debateId: 'debate-1',
+      blob: new Blob(['recording'], { type: 'video/webm' }),
+      mimeType: 'video/webm',
+      startedAtMs: 1_000,
+      endedAtMs: 11_000,
+      durationSeconds: 10,
+    };
+
+    const first = await queue.enqueueDebateRecordingUpload(input);
+    const second = await queue.enqueueDebateRecordingUpload({ ...input, blob: new Blob(['replacement']) });
+
+    expect(second.id).toBe(first.id);
+    expect(await queue.listDebateRecordingUploads('user-a')).toHaveLength(1);
+    expect((await queue.listDebateRecordingUploads('user-a'))[0]?.blob.size).toBe(input.blob.size);
+  });
+
+  it('preserves an uploaded filename across finalization retries', async () => {
+    const queued = await queue.enqueueDebateRecordingUpload({
+      userId: 'user-a',
+      debateId: 'debate-1',
+      blob: new Blob(['recording'], { type: 'video/webm' }),
+      mimeType: 'video/webm',
+      startedAtMs: 1_000,
+      endedAtMs: 11_000,
+      durationSeconds: 10,
+    });
+
+    await queue.markDebateRecordingUploaded(queued.id, 'recordings/debate-1/recording.webm');
+    await queue.scheduleDebateRecordingRetry(queued.id, new Error('finalization unavailable'), 12_345);
+
+    const [restored] = await queue.listDebateRecordingUploads('user-a');
+    expect(restored).toMatchObject({
+      stage: 'uploaded',
+      filename: 'recordings/debate-1/recording.webm',
+      attemptCount: 1,
+      nextAttemptAt: 12_345,
+      lastError: 'finalization unavailable',
+    });
+  });
+
+  it('isolates recordings by user and deletes only confirmed uploads', async () => {
+    const first = await queue.enqueueDebateRecordingUpload({
+      userId: 'user-a',
+      debateId: 'debate-1',
+      blob: new Blob(['a']),
+      mimeType: 'video/webm',
+      startedAtMs: 1_000,
+      endedAtMs: 11_000,
+      durationSeconds: 10,
+    });
+    await queue.enqueueDebateRecordingUpload({
+      userId: 'user-b',
+      debateId: 'debate-2',
+      blob: new Blob(['b']),
+      mimeType: 'video/webm',
+      startedAtMs: 2_000,
+      endedAtMs: 12_000,
+      durationSeconds: 10,
+    });
+
+    expect(await queue.listDebateRecordingUploads('user-a')).toHaveLength(1);
+    expect(await queue.listDebateRecordingUploads('user-b')).toHaveLength(1);
+
+    await queue.deleteDebateRecordingUpload(first.id);
+
+    expect(await queue.listDebateRecordingUploads('user-a')).toHaveLength(0);
+    expect(await queue.listDebateRecordingUploads('user-b')).toHaveLength(1);
+  });
+});

--- a/apps/web/core/debates/recording-upload-queue.ts
+++ b/apps/web/core/debates/recording-upload-queue.ts
@@ -1,0 +1,149 @@
+import { liveQuery } from 'dexie';
+
+import { db } from '~/core/database/indexeddb';
+
+export type DebateRecordingUploadStage = 'queued' | 'uploaded';
+
+export type DebateRecordingUpload = {
+  id: string;
+  userId: string;
+  debateId: string;
+  blob: Blob;
+  mimeType: string;
+  startedAtMs: number;
+  endedAtMs: number;
+  durationSeconds: number;
+  byteSize: number;
+  width: number | null;
+  height: number | null;
+  framerate: number | null;
+  videoBitsPerSecond: number | null;
+  stage: DebateRecordingUploadStage;
+  filename: string | null;
+  attemptCount: number;
+  nextAttemptAt: number;
+  lastError: string | null;
+  createdAt: number;
+  updatedAt: number;
+};
+
+export type EnqueueDebateRecordingUpload = {
+  userId: string;
+  debateId: string;
+  blob: Blob;
+  mimeType: string;
+  startedAtMs: number;
+  endedAtMs: number;
+  durationSeconds: number;
+  width?: number | null;
+  height?: number | null;
+  framerate?: number | null;
+  videoBitsPerSecond?: number | null;
+};
+
+export async function enqueueDebateRecordingUpload(
+  input: EnqueueDebateRecordingUpload
+): Promise<DebateRecordingUpload> {
+  const id = debateRecordingUploadId(input.userId, input.debateId);
+
+  return db.transaction('rw', db.debateRecordingUploads, async () => {
+    const existing = await db.debateRecordingUploads.get(id);
+    if (existing) return existing;
+
+    const now = Date.now();
+    const upload: DebateRecordingUpload = {
+      id,
+      userId: input.userId,
+      debateId: input.debateId,
+      blob: input.blob,
+      mimeType: input.mimeType,
+      startedAtMs: input.startedAtMs,
+      endedAtMs: input.endedAtMs,
+      durationSeconds: input.durationSeconds,
+      byteSize: input.blob.size,
+      width: input.width ?? null,
+      height: input.height ?? null,
+      framerate: input.framerate ?? null,
+      videoBitsPerSecond: input.videoBitsPerSecond ?? null,
+      stage: 'queued',
+      filename: null,
+      attemptCount: 0,
+      nextAttemptAt: now,
+      lastError: null,
+      createdAt: now,
+      updatedAt: now,
+    };
+    await db.debateRecordingUploads.add(upload);
+    return upload;
+  });
+}
+
+export function observeDebateRecordingUploads(userId: string) {
+  return liveQuery(() => listDebateRecordingUploads(userId));
+}
+
+export async function listDebateRecordingUploads(userId: string): Promise<DebateRecordingUpload[]> {
+  return db.debateRecordingUploads.where('userId').equals(userId).sortBy('createdAt');
+}
+
+export async function getDebateRecordingUpload(id: string): Promise<DebateRecordingUpload | undefined> {
+  return db.debateRecordingUploads.get(id);
+}
+
+export async function markDebateRecordingUploaded(id: string, filename: string): Promise<void> {
+  await db.debateRecordingUploads.update(id, {
+    stage: 'uploaded',
+    filename,
+    attemptCount: 0,
+    nextAttemptAt: Date.now(),
+    lastError: null,
+    updatedAt: Date.now(),
+  });
+}
+
+export async function scheduleDebateRecordingRetry(id: string, error: unknown, nextAttemptAt: number): Promise<void> {
+  await db.transaction('rw', db.debateRecordingUploads, async () => {
+    const upload = await db.debateRecordingUploads.get(id);
+    if (!upload) return;
+    await db.debateRecordingUploads.update(id, {
+      attemptCount: upload.attemptCount + 1,
+      nextAttemptAt,
+      lastError: uploadErrorMessage(error),
+      updatedAt: Date.now(),
+    });
+  });
+}
+
+export async function deleteDebateRecordingUpload(id: string): Promise<void> {
+  await db.debateRecordingUploads.delete(id);
+}
+
+export async function requestPersistentRecordingStorage(): Promise<boolean | null> {
+  if (typeof navigator === 'undefined' || !navigator.storage?.persist) return null;
+  try {
+    return await navigator.storage.persist();
+  } catch {
+    return null;
+  }
+}
+
+export async function estimateRecordingStorage(): Promise<StorageEstimate | null> {
+  if (typeof navigator === 'undefined' || !navigator.storage?.estimate) return null;
+  try {
+    return await navigator.storage.estimate();
+  } catch {
+    return null;
+  }
+}
+
+export function isStorageQuotaError(error: unknown): boolean {
+  return typeof error === 'object' && error !== null && 'name' in error && error.name === 'QuotaExceededError';
+}
+
+export function debateRecordingUploadId(userId: string, debateId: string) {
+  return `${userId}:${debateId}`;
+}
+
+function uploadErrorMessage(error: unknown) {
+  return error instanceof Error ? error.message : 'Recording upload failed.';
+}


### PR DESCRIPTION
## Summary

Finished debate recordings no longer depend on the tab staying open until a network upload completes. Once capture stops, Geo saves the Blob and its media metadata in IndexedDB before allowing navigation, then resumes the current user's pending uploads whenever the app starts, reconnects, or becomes visible again.

The upload coordinator processes one recording at a time under a browser-wide lock. It checkpoints a successful object upload before backend finalization, so a failed finalization retries only that final step, and removes the local Blob only after the backend confirms completion. Storage exhaustion keeps the recording in memory and blocks navigation with a retry action instead of discarding it.

A compact app-wide pill reports active and waiting uploads. Dismissing it hides only the presentation for the current page lifetime; the queue continues and the pill returns after refresh while work remains.

## Validation

- 46 focused tests pass, including a 60 MiB Blob round-trip, Dexie schema upgrade preservation, quota recovery, startup/offline recovery, sequential processing, staged finalization retry, cross-tab locking, and upload-pill restoration.
- Focused lint and Prettier checks pass. The changed source files pass isolated TypeScript checking.
- The production bundle compiles successfully. Repo-wide TypeScript validation remains blocked by the existing `prosemirror-model` 1.25.4/1.25.9 mismatch in `partials/editor/id-extension.tsx`.

## New concepts

### Browser-owned upload outbox

The recording queue is an outbox: the browser first commits work locally, then a separate coordinator delivers it to the server. This lets debate navigation depend on durable local state instead of network availability.

```mermaid
flowchart LR
  Capture["Capture stops"] --> IndexedDB["Persist Blob + metadata"]
  IndexedDB --> Navigate["Allow navigation"]
  IndexedDB --> Put["Upload object"]
  Put --> Checkpoint["Checkpoint filename"]
  Checkpoint --> Finalize["Finalize with backend"]
  Finalize --> Delete["Delete local Blob"]
```

The coordinator combines a staged queue with the Web Locks API so multiple tabs cannot upload concurrently or act on stale queue state. This pattern is appropriate for recoverable browser work that must survive reloads, but it is not true background execution: Geo must be open, and clearing site data still removes pending recordings.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
