### PR TITLE
fix(debates): link processed videos to recording page

### DIFF
--- a/apps/web/app/space/[id]/(space)/debates/debates-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/debates-page-client.test.tsx
@@ -11,10 +11,12 @@ const mocks = vi.hoisted(() => ({
   mediaMutate: vi.fn(),
   play: vi.fn(() => Promise.resolve()),
   pause: vi.fn(),
+  push: vi.fn(),
+  replace: vi.fn(),
 }));
 
 vi.mock('next/navigation', () => ({
-  useRouter: () => ({ replace: vi.fn() }),
+  useRouter: () => ({ push: mocks.push, replace: mocks.replace }),
 }));
 
 vi.mock('~/core/state/feature-flags', () => ({
@@ -43,6 +45,8 @@ beforeEach(() => {
   mocks.mediaMutate.mockReset();
   mocks.play.mockClear();
   mocks.pause.mockClear();
+  mocks.push.mockClear();
+  mocks.replace.mockClear();
   Object.defineProperty(HTMLMediaElement.prototype, 'play', {
     configurable: true,
     value: mocks.play,
@@ -56,11 +60,11 @@ beforeEach(() => {
 afterEach(cleanup);
 
 describe('DebatesPageClient', () => {
-  it('uses the preview poster and starts the processed video in its card', async () => {
+  it('links processed video actions to the public recording page', async () => {
     mocks.mediaMutate.mockImplementation((variables, options) => {
-      const url =
-        variables.request.kind === 'preview_image' ? 'https://media.test/preview.jpg' : 'https://media.test/final.mp4';
-      options.onSuccess({ upload: { url } });
+      if (variables.request.kind === 'preview_image') {
+        options.onSuccess({ upload: { url: 'https://media.test/preview.jpg' } });
+      }
     });
 
     const { container } = render(<DebatesPageClient spaceId="space-1" />);
@@ -69,13 +73,23 @@ describe('DebatesPageClient', () => {
       expect(container.querySelector('video')).toHaveAttribute('poster', 'https://media.test/preview.jpg')
     );
     expect(mocks.mediaMutate.mock.calls.some(([variables]) => variables.request.kind === 'final_video')).toBe(false);
+    expect(screen.getByRole('button', { name: 'Watch originals' })).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Processed video' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Watch processed video' }));
 
-    await waitFor(() =>
-      expect(container.querySelector('video')).toHaveAttribute('src', 'https://media.test/final.mp4')
+    expect(mocks.push).toHaveBeenCalledWith('/space/space-1/debates/debate-1/recording');
+    expect(mocks.mediaMutate.mock.calls.some(([variables]) => variables.request.kind === 'final_video')).toBe(false);
+    expect(mocks.play).not.toHaveBeenCalled();
+
+    mocks.push.mockClear();
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Play Processed video for Debates are useful',
+      })
     );
-    expect(mocks.play).toHaveBeenCalledTimes(1);
+
+    expect(mocks.push).toHaveBeenCalledWith('/space/space-1/debates/debate-1/recording');
+    expect(mocks.mediaMutate.mock.calls.some(([variables]) => variables.request.kind === 'final_video')).toBe(false);
   });
 });
 

--- a/apps/web/app/space/[id]/(space)/debates/debates-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/debates-page-client.tsx
@@ -17,7 +17,7 @@ import {
   useRequestDebateMediaProcessing,
   useSpaceDebates,
 } from '~/core/debates/hooks';
-import { ProcessedDebatePlayer, type ProcessedDebatePlayerHandle } from '~/core/debates/processed-debate-player';
+import { ProcessedDebatePlayer } from '~/core/debates/processed-debate-player';
 import { useFeatureFlag } from '~/core/state/feature-flags';
 
 import { Button, SquareButton } from '~/design-system/button';
@@ -44,6 +44,7 @@ export function DebatesPageClient({ spaceId }: DebatesPageClientProps) {
 }
 
 function DebatesTabSurface({ spaceId }: DebatesPageClientProps) {
+  const router = useRouter();
   const debatesQuery = useSpaceDebates(spaceId, true);
   const matches = debatesQuery.data?.matches ?? [];
   const debates = debatesQuery.data?.debates ?? [];
@@ -94,6 +95,7 @@ function DebatesTabSurface({ spaceId }: DebatesPageClientProps) {
                   key={debate.id}
                   debate={debate}
                   onWatch={() => setSelectedDebate(debate)}
+                  onWatchProcessed={() => router.push(`/space/${spaceId}/debates/${debate.id}/recording`)}
                   onTranscript={() => setSelectedTranscriptDebate(debate)}
                 />
               ))}
@@ -112,16 +114,17 @@ function DebatesTabSurface({ spaceId }: DebatesPageClientProps) {
 function DebateCard({
   debate,
   onWatch,
+  onWatchProcessed,
   onTranscript,
 }: {
   debate: Debate;
   onWatch: () => void;
+  onWatchProcessed: () => void;
   onTranscript: () => void;
 }) {
   const participants = orderedParticipants(debate);
   const mediaQuery = useDebateMedia(debate.id, debate.status === 'complete');
   const reprocessMediaMutation = useRequestDebateMediaProcessing(debate.id);
-  const processedVideoPlayerRef = React.useRef<ProcessedDebatePlayerHandle | null>(null);
   const currentUserId = getCurrentGeoChatUserId();
   const [reprocessError, setReprocessError] = React.useState<string | null>(null);
   const hasProcessedVideo =
@@ -148,11 +151,11 @@ function DebateCard({
   return (
     <article className="max-md:flex-col max-md:items-stretch flex min-w-0 items-center gap-4 rounded-lg border border-grey-02 bg-white p-3 shadow-light">
       <ProcessedDebatePlayer
-        ref={processedVideoPlayerRef}
         debateId={debate.id}
         label={`Processed video for ${debate.claim.claim}`}
         previewAvailable={hasPreviewImage}
         videoAvailable={hasProcessedVideo}
+        onActivate={onWatchProcessed}
         className="max-md:mx-auto max-md:w-[180px] w-[150px] shrink-0"
       />
       <div className="max-md:grid max-md:grid-cols-1 max-md:items-stretch flex min-w-0 flex-1 flex-wrap items-center justify-between gap-3">
@@ -186,7 +189,7 @@ function DebateCard({
         <div className="max-md:w-full grid gap-1">
           <div className="max-md:grid max-md:grid-cols-1 flex items-center justify-end gap-2">
             <Button type="button" variant="secondary" small className="max-md:w-full" onClick={onWatch}>
-              Watch
+              Watch originals
             </Button>
             <Button
               type="button"
@@ -194,9 +197,9 @@ function DebateCard({
               small
               className="max-md:w-full"
               disabled={!hasProcessedVideo}
-              onClick={() => processedVideoPlayerRef.current?.play()}
+              onClick={onWatchProcessed}
             >
-              Processed video
+              Watch processed video
             </Button>
             <Button
               type="button"

--- a/apps/web/core/debates/processed-debate-player.test.tsx
+++ b/apps/web/core/debates/processed-debate-player.test.tsx
@@ -86,6 +86,23 @@ describe('ProcessedDebatePlayer', () => {
     expect(container.querySelector('video')).toHaveAttribute('controls');
   });
 
+  it('delegates activation without requesting the final video when an external action is provided', async () => {
+    const onActivate = vi.fn();
+    mocks.mediaMutate.mockImplementation((variables, options) => {
+      if (variables.request.kind === 'preview_image') {
+        options.onSuccess({ upload: { url: 'https://media.test/preview.jpg' } });
+      }
+    });
+
+    render(<ProcessedDebatePlayer debateId="debate-1" label="Processed debate video" onActivate={onActivate} />);
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Play Processed debate video' }));
+
+    expect(onActivate).toHaveBeenCalledTimes(1);
+    expect(mocks.mediaMutate.mock.calls.some(([variables]) => variables.request.kind === 'final_video')).toBe(false);
+    expect(mocks.play).not.toHaveBeenCalled();
+  });
+
   it('keeps playback available when an older debate has no preview artifact', async () => {
     mocks.mediaMutate.mockImplementation((variables, options) => {
       if (variables.request.kind === 'final_video') {

--- a/apps/web/core/debates/processed-debate-player.tsx
+++ b/apps/web/core/debates/processed-debate-player.tsx
@@ -18,11 +18,15 @@ type ProcessedDebatePlayerProps = {
   label: string;
   previewAvailable?: boolean;
   videoAvailable?: boolean;
+  onActivate?: () => void;
   className?: string;
 };
 
 export const ProcessedDebatePlayer = React.forwardRef<ProcessedDebatePlayerHandle, ProcessedDebatePlayerProps>(
-  function ProcessedDebatePlayer({ debateId, label, previewAvailable = true, videoAvailable = true, className }, ref) {
+  function ProcessedDebatePlayer(
+    { debateId, label, previewAvailable = true, videoAvailable = true, onActivate, className },
+    ref
+  ) {
     const previewArtifact = useDebateMediaArtifactUrl();
     const videoArtifact = useDebateMediaArtifactUrl();
     const videoRef = React.useRef<HTMLVideoElement | null>(null);
@@ -85,6 +89,10 @@ export const ProcessedDebatePlayer = React.forwardRef<ProcessedDebatePlayerHandl
     const play = React.useCallback(() => {
       setPlaybackError(null);
       if (!videoAvailable || videoArtifact.isPending) return;
+      if (onActivate) {
+        onActivate();
+        return;
+      }
       if (videoUrl) {
         videoRef.current?.play().catch(error => {
           setPlaybackError(error instanceof Error ? error.message : 'Could not play this debate.');
@@ -103,7 +111,7 @@ export const ProcessedDebatePlayer = React.forwardRef<ProcessedDebatePlayerHandl
           },
         }
       );
-    }, [debateId, videoArtifact, videoAvailable, videoUrl]);
+    }, [debateId, onActivate, videoArtifact, videoAvailable, videoUrl]);
 
     React.useImperativeHandle(ref, () => ({ play }), [play]);
 


### PR DESCRIPTION
## Summary

Debate history now clearly separates original participant recordings from processed exports. The processed-video preview and action open the stable recording page used by sharing instead of playing inside the small overview card, while the share dialog keeps its inline player.

## Validation

- 7 focused Vitest tests passed for the debates overview and reusable processed-video player
- Prettier passed for all changed files
- ESLint passed for all changed files

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-Codex-000000)
