### PR TITLE
fix: correct dataType for image Height/Width when uploading via file/URL

### DIFF
--- a/apps/web/core/sync/use-mutate.tsx
+++ b/apps/web/core/sync/use-mutate.tsx
@@ -53,8 +53,16 @@ function graphValueDataType(value: unknown): DataType {
       return 'TIME';
     case 'point':
       return 'POINT';
+    case 'bytes':
+      return 'BYTES';
+    case 'schedule':
+      return 'SCHEDULE';
+    case 'embedding':
+      return 'EMBEDDING';
     case 'text':
+      return 'TEXT';
     default:
+      console.warn(`[use-mutate] unrecognized GRC-20 value type "${String(type)}" in createImageOps; defaulting to TEXT`);
       return 'TEXT';
   }
 }

--- a/apps/web/core/sync/use-mutate.tsx
+++ b/apps/web/core/sync/use-mutate.tsx
@@ -28,6 +28,37 @@ const RENDERABLE_TYPE_ENTITY_LABELS: Record<string, string> = {
   [ADDRESS]: 'Address',
 };
 
+// Maps a GRC-20 v2 typed value's `type` discriminant to the local store's
+// DataType. `Graph.createImage` emits `text` for the IPFS URL value and
+// `float` for the Height/Width values — declaring all of them as TEXT (as
+// this used to do unconditionally) mis-types the numeric dimension
+// properties and trips the SDK's E005 property-type-mismatch check at
+// publish time.
+function graphValueDataType(value: unknown): DataType {
+  const type = value && typeof value === 'object' && 'type' in value ? (value as { type: unknown }).type : undefined;
+  switch (type) {
+    case 'integer':
+      return 'INTEGER';
+    case 'float':
+      return 'FLOAT';
+    case 'decimal':
+      return 'DECIMAL';
+    case 'boolean':
+      return 'BOOLEAN';
+    case 'date':
+      return 'DATE';
+    case 'datetime':
+      return 'DATETIME';
+    case 'time':
+      return 'TIME';
+    case 'point':
+      return 'POINT';
+    case 'text':
+    default:
+      return 'TEXT';
+  }
+}
+
 type Recipe<T> = (draft: Draft<T>) => void | T | undefined;
 type GeoProduceFn<T> = (base: T, recipe: Recipe<T>) => void;
 
@@ -397,6 +428,7 @@ function createMutator(store: GeoStore): Mutator {
             });
           } else if (op.type === 'createEntity') {
             for (const pv of op.values) {
+              const dataType = graphValueDataType(pv.value);
               store.setValue({
                 id: ID.createValueId({
                   entityId: toHexId(op.id),
@@ -410,8 +442,8 @@ function createMutator(store: GeoStore): Mutator {
                 property: {
                   id: toHexId(pv.property),
                   name: 'Image Property',
-                  dataType: 'TEXT',
-                  renderableType: 'URL',
+                  dataType,
+                  renderableType: dataType === 'TEXT' ? 'URL' : null,
                 },
                 spaceId,
                 value: extractValueString(pv.value),
@@ -478,6 +510,7 @@ function createMutator(store: GeoStore): Mutator {
             });
           } else if (op.type === 'createEntity') {
             for (const pv of op.values) {
+              const dataType = graphValueDataType(pv.value);
               store.setValue({
                 id: ID.createValueId({
                   entityId: toHexId(op.id),
@@ -491,8 +524,8 @@ function createMutator(store: GeoStore): Mutator {
                 property: {
                   id: toHexId(pv.property),
                   name: 'Image Property',
-                  dataType: 'TEXT',
-                  renderableType: 'URL',
+                  dataType,
+                  renderableType: dataType === 'TEXT' ? 'URL' : null,
                 },
                 spaceId,
                 value: extractValueString(pv.value),


### PR DESCRIPTION
## Summary
- `images.createAndLink` and `images.createOnly` (`apps/web/core/sync/use-mutate.tsx`) hardcoded `dataType: 'TEXT'` / `renderableType: 'URL'` for every property value returned by `Graph.createImage()`, including `Height`/`Width` (which the SDK returns as `float`).
- This mis-typed those properties in the client's local op batch, and the SDK's own type-registry check rejects the mismatch at publish time, surfacing as `[E005] property type mismatch for 7f6ad0433e214257a6d48bdad36b1d84` (the `Height` property).
- Reported by Doville: importing a news story via the AI assistant, then replacing the AI-generated cover image with a custom upload, gets stuck on "Uploading changes to IPFS" and then fails with this error. The AI-generated cover never hits this because its short-circuit path only ever sets the IPFS URL property, never Height/Width — it's only real file uploads (which carry actual pixel dimensions) that trigger it.
- Fix: added `graphValueDataType()`, which reads the SDK's actual per-value `type` discriminant (`text`/`float`/`integer`/etc., verified against the installed `@geoprotocol/geo-sdk` source) instead of hardcoding `TEXT`, and only sets `renderableType: 'URL'` for the text/IPFS-URL value.

## Test plan
- [x] `tsc --noEmit` on `apps/web` — zero new errors (pre-existing unrelated errors: `@geogenesis/auth` module resolution, two `unknown`-type issues elsewhere)
- [ ] Manually reproduce: import a news story via AI assistant, replace the generated cover with a custom upload, publish — confirm no E005 error
- Was not able to run the vitest suite locally — pinned `vitest`/`rolldown` requires a newer Node than this environment's system Node (v18.19.1); this is a pre-existing environment limitation, not something introduced by this change