### PR TITLE
fix: update Explore curator onboarding UI

### DIFF
--- a/apps/web/core/explore/curator-onboarding-steps.ts
+++ b/apps/web/core/explore/curator-onboarding-steps.ts
@@ -5,7 +5,6 @@ export type CuratorOnboardingStep = {
   id: CuratorOnboardingStepId;
   title: string;
   description: string;
-  points: number;
 };
 
 export const CURATOR_ONBOARDING_STEPS: CuratorOnboardingStep[] = [
@@ -13,34 +12,27 @@ export const CURATOR_ONBOARDING_STEPS: CuratorOnboardingStep[] = [
     id: 'join-space',
     title: 'Join a space',
     description: 'Spaces are communities of people organized around a shared interest',
-    points: 10,
   },
   {
     id: 'rsvp-community-call',
     title: 'RSVP for a community call',
     description: 'Community calls are a great way to find out how to get involved',
-    points: 10,
   },
   {
     id: 'vote-entity',
     title: 'Vote on an entity',
     description: 'Express your view on an entity using an upvote or downvote',
-    points: 10,
   },
   {
     id: 'submit-ranking',
     title: 'Submit a ranking',
     description: 'Rank top content to impact what people see',
-    points: 10,
   },
   {
     id: 'comment-entity',
     title: 'Comment on an entity',
     description: 'Join the conversation by leaving a comment on an entity of interest',
-    points: 10,
   },
 ];
-
-export const CURATOR_ONBOARDING_GEO_ICON_SRC = '/browse-nav/geo-curators.svg';
 
 export const CURATOR_ONBOARDING_PROGRESS_COLOR = '#6833FF';

--- a/apps/web/partials/explore/curator-onboarding-section.tsx
+++ b/apps/web/partials/explore/curator-onboarding-section.tsx
@@ -4,11 +4,7 @@ import * as React from 'react';
 
 import cx from 'classnames';
 
-import {
-  CURATOR_ONBOARDING_GEO_ICON_SRC,
-  CURATOR_ONBOARDING_PROGRESS_COLOR,
-  CURATOR_ONBOARDING_STEPS,
-} from '~/core/explore/curator-onboarding-steps';
+import { CURATOR_ONBOARDING_PROGRESS_COLOR, CURATOR_ONBOARDING_STEPS } from '~/core/explore/curator-onboarding-steps';
 import { useCuratorOnboardingStatus } from '~/core/hooks/use-curator-onboarding-status';
 
 import { ChevronDownSmall } from '~/design-system/icons/chevron-down-small';
@@ -33,22 +29,6 @@ function CuratorOnboardingStepIndicator({ complete }: { complete: boolean }) {
           />
         </svg>
       ) : null}
-    </span>
-  );
-}
-
-function CuratorOnboardingPointsBadge({ points }: { points: number }) {
-  return (
-    <span className="inline-flex items-center gap-1">
-      <img
-        src={CURATOR_ONBOARDING_GEO_ICON_SRC}
-        alt=""
-        width={16}
-        height={16}
-        className="h-4 w-4 shrink-0 object-contain"
-        draggable={false}
-      />
-      <span className="text-[16px] leading-[17px] font-medium tracking-[-0.35px] text-purple">{points}</span>
     </span>
   );
 }
@@ -100,10 +80,7 @@ export function CuratorOnboardingSection() {
               <li key={step.id} className="flex gap-3">
                 <CuratorOnboardingStepIndicator complete={complete} />
                 <div className="min-w-0 flex-1">
-                  <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
-                    <p className="text-[16px] leading-[17px] font-medium tracking-[-0.35px] text-text">{step.title}</p>
-                    <CuratorOnboardingPointsBadge points={step.points} />
-                  </div>
+                  <p className="text-[16px] leading-[17px] font-medium tracking-[-0.35px] text-text">{step.title}</p>
                   <p className="mt-1 text-[16px] leading-[16px] font-normal tracking-[-0.35px] text-grey-04">
                     {step.description}
                   </p>

--- a/apps/web/partials/explore/explore-welcome-banner.tsx
+++ b/apps/web/partials/explore/explore-welcome-banner.tsx
@@ -59,7 +59,7 @@ function WelcomeBanner() {
           </span>
           Welcome to Geo - Become a curator!
         </h2>
-        <p className="mt-2 max-w-[400px] text-metadata text-white">
+        <p className="mt-2 max-w-[338px] text-[16px] leading-[18px] font-normal tracking-[-0.48px] text-white">
           Help organize topics, questions, claims, and relevant sources to improve the quality of discourse. Join spaces
           and start contributing there.
         </p>


### PR DESCRIPTION
## What changed

- Removed the Geo point icon and point count from every curator onboarding item on Explore.
- Removed the now-unused points field and icon constant from the onboarding step model.
- Matched the Explore welcome banner body copy to Figma's 338px text width, 18px line height, and -0.48px letter spacing so it wraps on the intended lines.

## Why

The onboarding card should describe curator actions without displaying point rewards beside each item, and the associated welcome banner should follow the approved Figma typography and wrapping.

## Impact

Curator onboarding progress and completion indicators continue to work as before. The per-item point badges are removed, and the welcome copy now wraps consistently with the design.

## Validation

- `bun eslint partials/explore/curator-onboarding-section.tsx core/explore/curator-onboarding-steps.ts`
- `bun eslint partials/explore/explore-welcome-banner.tsx`
- `bun tsc --noEmit` (after building the local `@geogenesis/auth` workspace package)
- Prettier check for the changed files
- `git diff --check`

## Build note

`bun run build` reached the Next.js Turbopack optimization phase but produced no further progress for several minutes, so the local build was stopped. No build error was reported before it was stopped.
