### PR TITLE
fix(search): make canonical-only toggle off actually search everything

### DIFF
--- a/apps/web/core/hooks/search-additional-space-ids.test.ts
+++ b/apps/web/core/hooks/search-additional-space-ids.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+
+import { selectSearchAdditionalSpaceIds } from './search-additional-space-ids';
+
+const GLOBAL_IDS = ['root', 'current', 'personal'];
+
+describe('selectSearchAdditionalSpaceIds', () => {
+  it('returns globalAdditionalSpaceIds when includeNonCanonical is omitted (undefined) and unscoped', () => {
+    expect(
+      selectSearchAdditionalSpaceIds({
+        filterBySpace: undefined,
+        includeNonCanonical: undefined,
+        globalAdditionalSpaceIds: GLOBAL_IDS,
+      })
+    ).toEqual(GLOBAL_IDS);
+  });
+
+  it('returns globalAdditionalSpaceIds when includeNonCanonical is explicitly false and unscoped', () => {
+    expect(
+      selectSearchAdditionalSpaceIds({
+        filterBySpace: undefined,
+        includeNonCanonical: false,
+        globalAdditionalSpaceIds: GLOBAL_IDS,
+      })
+    ).toEqual(GLOBAL_IDS);
+  });
+
+  it('returns undefined when includeNonCanonical is explicitly true (unrestricted search), even unscoped', () => {
+    expect(
+      selectSearchAdditionalSpaceIds({
+        filterBySpace: undefined,
+        includeNonCanonical: true,
+        globalAdditionalSpaceIds: GLOBAL_IDS,
+      })
+    ).toBeUndefined();
+  });
+
+  it('returns undefined when scoped to a single space (filterBySpace), regardless of includeNonCanonical', () => {
+    expect(
+      selectSearchAdditionalSpaceIds({
+        filterBySpace: 'some-space-id',
+        includeNonCanonical: undefined,
+        globalAdditionalSpaceIds: GLOBAL_IDS,
+      })
+    ).toBeUndefined();
+
+    expect(
+      selectSearchAdditionalSpaceIds({
+        filterBySpace: 'some-space-id',
+        includeNonCanonical: false,
+        globalAdditionalSpaceIds: GLOBAL_IDS,
+      })
+    ).toBeUndefined();
+
+    expect(
+      selectSearchAdditionalSpaceIds({
+        filterBySpace: 'some-space-id',
+        includeNonCanonical: true,
+        globalAdditionalSpaceIds: GLOBAL_IDS,
+      })
+    ).toBeUndefined();
+  });
+
+  it('treats an empty-string filterBySpace as unscoped (falsy), not as scoping the query', () => {
+    expect(
+      selectSearchAdditionalSpaceIds({
+        filterBySpace: '',
+        includeNonCanonical: undefined,
+        globalAdditionalSpaceIds: GLOBAL_IDS,
+      })
+    ).toEqual(GLOBAL_IDS);
+  });
+});

--- a/apps/web/core/hooks/search-additional-space-ids.ts
+++ b/apps/web/core/hooks/search-additional-space-ids.ts
@@ -1,0 +1,31 @@
+/**
+ * Decides whether a search request should widen eligibility to the scoped
+ * spaces from useGlobalSearchSpaceIds (root/current/personal/member/editor),
+ * or search unrestricted.
+ *
+ * additionalSpaceIds is suppressed (returns `undefined`) when either:
+ * - the search is already scoped to one space (filterBySpace truthy) — the
+ *   single space filter already fully determines eligibility, or
+ * - the caller explicitly wants unrestricted, non-canonical results
+ *   (includeNonCanonical === true, not just omitted/false) — applying the
+ *   scoped-spaces widening here would silently narrow the request back down
+ *   to "canonical plus scoped spaces" instead of truly everything.
+ *
+ * Otherwise (includeNonCanonical omitted or false, no filterBySpace),
+ * globalAdditionalSpaceIds is returned unchanged.
+ */
+export function selectSearchAdditionalSpaceIds({
+  filterBySpace,
+  includeNonCanonical,
+  globalAdditionalSpaceIds,
+}: {
+  filterBySpace: string | undefined;
+  includeNonCanonical: boolean | undefined;
+  globalAdditionalSpaceIds: string[];
+}): string[] | undefined {
+  const isScopedToOneSpace = Boolean(filterBySpace);
+  const wantsUnrestrictedSearch = includeNonCanonical === true;
+  const skipAdditionalSpaceIds = isScopedToOneSpace || wantsUnrestrictedSearch;
+
+  return skipAdditionalSpaceIds ? undefined : globalAdditionalSpaceIds;
+}

--- a/apps/web/core/hooks/use-search.ts
+++ b/apps/web/core/hooks/use-search.ts
@@ -39,9 +39,12 @@ interface SearchOptions {
    * - `undefined` (omitted): same eligibility restriction as `false` —
    *   additionalSpaceIds is still applied. Callers with no opinion on
    *   canonical-only should just omit this.
-   * - `true` (explicit): drop the eligibility restriction entirely —
-   *   additionalSpaceIds is NOT applied — and search everything. Only pass
-   *   this when the caller genuinely wants unrestricted search.
+   * - `true` (explicit): drop the canonical/scoped-spaces eligibility
+   *   restriction — additionalSpaceIds is NOT applied. Any other filters
+   *   the caller passes (filterBySpace, filterByTypes, etc.) still apply as
+   *   normal; this only lifts the canonical-graph-and-scoped-spaces gating,
+   *   not every constraint on the search. Only pass this when the caller
+   *   genuinely wants that specific restriction lifted.
    */
   includeNonCanonical?: boolean;
 }

--- a/apps/web/core/hooks/use-search.ts
+++ b/apps/web/core/hooks/use-search.ts
@@ -26,8 +26,12 @@ interface SearchOptions {
   pageSize?: number;
   /**
    * Tri-state, not a plain boolean — `undefined` and `true` are different.
-   * Only affects unscoped (global) searches — when `filterBySpace` is set,
-   * additionalSpaceIds is never applied regardless of this value:
+   * Always threaded through to E.findFuzzyPage/getResultsPage, where it
+   * drives client-side canonical gating (shouldIncludeRestSearchResult) —
+   * that part applies regardless of `filterBySpace`. The additionalSpaceIds
+   * widening described below is the part that's specific to unscoped
+   * (global) searches: when `filterBySpace` is set, additionalSpaceIds is
+   * never applied, no matter what this value is.
    * - `false`: restrict results to the canonical graph plus the scoped spaces
    *   from useGlobalSearchSpaceIds (root/current/personal/member/editor —
    *   additionalSpaceIds applied).
@@ -99,7 +103,11 @@ export function useSearch({
   // non-canonical results (includeNonCanonical === true, not just unset), so
   // the request isn't silently narrowed back down to canonical-plus-scoped.
   const wantsUnrestrictedSearch = includeNonCanonical === true;
-  const isScopedToOneSpace = filterBySpace !== undefined;
+  // Truthy, not just !== undefined, to match the space filter's own
+  // truthiness check below (`filterBySpace ? { space: ... } : {}`) — an
+  // empty-string filterBySpace must not suppress additionalSpaceIds while
+  // also not actually scoping the query.
+  const isScopedToOneSpace = Boolean(filterBySpace);
   const skipAdditionalSpaceIds = isScopedToOneSpace || wantsUnrestrictedSearch;
   const additionalSpaceIds = skipAdditionalSpaceIds ? undefined : globalAdditionalSpaceIds;
 

--- a/apps/web/core/hooks/use-search.ts
+++ b/apps/web/core/hooks/use-search.ts
@@ -24,7 +24,13 @@ interface SearchOptions {
   restrictToFilterTypes?: boolean;
   enabled?: boolean;
   pageSize?: number;
-  /** Pass `false` to restrict results to the canonical graph. Defaults to including everything. */
+  /**
+   * Pass `false` to restrict results to the canonical graph plus your spaces.
+   * Pass explicit `true` to drop that eligibility restriction entirely and
+   * search everything. Omitting it behaves like `true` for search purposes,
+   * but doesn't suppress the additional-spaces widening the way an explicit
+   * `true` does — callers with no opinion on this should just omit it.
+   */
   includeNonCanonical?: boolean;
 }
 
@@ -80,7 +86,12 @@ export function useSearch({
   const debouncedQuery = useDebouncedValue(query);
 
   const globalAdditionalSpaceIds = useGlobalSearchSpaceIds();
-  const additionalSpaceIds = filterBySpace ? undefined : globalAdditionalSpaceIds;
+  // additionalSpaceIds widens eligibility to "canonical graph plus these
+  // spaces" — that's a restriction relative to true unrestricted search.
+  // When a caller explicitly asks for non-canonical results (includeNonCanonical
+  // === true, not just unset), drop it entirely so the request isn't silently
+  // narrowed back down to canonical-plus-your-spaces.
+  const additionalSpaceIds = filterBySpace || includeNonCanonical === true ? undefined : globalAdditionalSpaceIds;
 
   const maybeEntityId = debouncedQuery.trim();
   const filterTypeKey = React.useMemo(() => (filterByTypes ? [...filterByTypes].sort() : undefined), [filterByTypes]);

--- a/apps/web/core/hooks/use-search.ts
+++ b/apps/web/core/hooks/use-search.ts
@@ -26,8 +26,9 @@ interface SearchOptions {
   pageSize?: number;
   /**
    * Tri-state, not a plain boolean — `undefined` and `true` are different:
-   * - `false`: restrict results to the canonical graph plus your own spaces
-   *   (additionalSpaceIds applied).
+   * - `false`: restrict results to the canonical graph plus the scoped spaces
+   *   from useGlobalSearchSpaceIds (root/current/personal/member/editor —
+   *   additionalSpaceIds applied).
    * - `undefined` (omitted): same eligibility restriction as `false` —
    *   additionalSpaceIds is still applied. Callers with no opinion on
    *   canonical-only should just omit this.
@@ -91,10 +92,10 @@ export function useSearch({
 
   const globalAdditionalSpaceIds = useGlobalSearchSpaceIds();
   // additionalSpaceIds widens eligibility to "canonical graph plus these
-  // spaces" — that's a restriction relative to true unrestricted search. Drop
-  // it entirely when the caller explicitly wants unrestricted, non-canonical
-  // results (includeNonCanonical === true, not just unset), so the request
-  // isn't silently narrowed back down to canonical-plus-your-spaces.
+  // scoped spaces" — that's a restriction relative to true unrestricted
+  // search. Drop it entirely when the caller explicitly wants unrestricted,
+  // non-canonical results (includeNonCanonical === true, not just unset), so
+  // the request isn't silently narrowed back down to canonical-plus-scoped.
   const wantsUnrestrictedSearch = includeNonCanonical === true;
   const additionalSpaceIds = filterBySpace || wantsUnrestrictedSearch ? undefined : globalAdditionalSpaceIds;
 

--- a/apps/web/core/hooks/use-search.ts
+++ b/apps/web/core/hooks/use-search.ts
@@ -25,11 +25,15 @@ interface SearchOptions {
   enabled?: boolean;
   pageSize?: number;
   /**
-   * Pass `false` to restrict results to the canonical graph plus your spaces.
-   * Pass explicit `true` to drop that eligibility restriction entirely and
-   * search everything. Omitting it behaves like `true` for search purposes,
-   * but doesn't suppress the additional-spaces widening the way an explicit
-   * `true` does — callers with no opinion on this should just omit it.
+   * Tri-state, not a plain boolean — `undefined` and `true` are different:
+   * - `false`: restrict results to the canonical graph plus your own spaces
+   *   (additionalSpaceIds applied).
+   * - `undefined` (omitted): same eligibility restriction as `false` —
+   *   additionalSpaceIds is still applied. Callers with no opinion on
+   *   canonical-only should just omit this.
+   * - `true` (explicit): drop the eligibility restriction entirely —
+   *   additionalSpaceIds is NOT applied — and search everything. Only pass
+   *   this when the caller genuinely wants unrestricted search.
    */
   includeNonCanonical?: boolean;
 }
@@ -87,11 +91,12 @@ export function useSearch({
 
   const globalAdditionalSpaceIds = useGlobalSearchSpaceIds();
   // additionalSpaceIds widens eligibility to "canonical graph plus these
-  // spaces" — that's a restriction relative to true unrestricted search.
-  // When a caller explicitly asks for non-canonical results (includeNonCanonical
-  // === true, not just unset), drop it entirely so the request isn't silently
-  // narrowed back down to canonical-plus-your-spaces.
-  const additionalSpaceIds = filterBySpace || includeNonCanonical === true ? undefined : globalAdditionalSpaceIds;
+  // spaces" — that's a restriction relative to true unrestricted search. Drop
+  // it entirely when the caller explicitly wants unrestricted, non-canonical
+  // results (includeNonCanonical === true, not just unset), so the request
+  // isn't silently narrowed back down to canonical-plus-your-spaces.
+  const wantsUnrestrictedSearch = includeNonCanonical === true;
+  const additionalSpaceIds = filterBySpace || wantsUnrestrictedSearch ? undefined : globalAdditionalSpaceIds;
 
   const maybeEntityId = debouncedQuery.trim();
   const filterTypeKey = React.useMemo(() => (filterByTypes ? [...filterByTypes].sort() : undefined), [filterByTypes]);

--- a/apps/web/core/hooks/use-search.ts
+++ b/apps/web/core/hooks/use-search.ts
@@ -13,6 +13,7 @@ import { mergeSearchResult } from '../database/result';
 import { E } from '../sync/orm';
 import { useSyncEngine } from '../sync/use-sync-engine';
 import type { SearchResult } from '../types';
+import { selectSearchAdditionalSpaceIds } from './search-additional-space-ids';
 import { useDebouncedValue } from './use-debounced-value';
 import { useGlobalSearchSpaceIds } from './use-global-search-space-ids';
 
@@ -97,19 +98,11 @@ export function useSearch({
   const debouncedQuery = useDebouncedValue(query);
 
   const globalAdditionalSpaceIds = useGlobalSearchSpaceIds();
-  // additionalSpaceIds widens eligibility to "canonical graph plus these
-  // scoped spaces" — that's a restriction relative to true unrestricted
-  // search. Drop it entirely when the caller explicitly wants unrestricted,
-  // non-canonical results (includeNonCanonical === true, not just unset), so
-  // the request isn't silently narrowed back down to canonical-plus-scoped.
-  const wantsUnrestrictedSearch = includeNonCanonical === true;
-  // Truthy, not just !== undefined, to match the space filter's own
-  // truthiness check below (`filterBySpace ? { space: ... } : {}`) — an
-  // empty-string filterBySpace must not suppress additionalSpaceIds while
-  // also not actually scoping the query.
-  const isScopedToOneSpace = Boolean(filterBySpace);
-  const skipAdditionalSpaceIds = isScopedToOneSpace || wantsUnrestrictedSearch;
-  const additionalSpaceIds = skipAdditionalSpaceIds ? undefined : globalAdditionalSpaceIds;
+  const additionalSpaceIds = selectSearchAdditionalSpaceIds({
+    filterBySpace,
+    includeNonCanonical,
+    globalAdditionalSpaceIds,
+  });
 
   const maybeEntityId = debouncedQuery.trim();
   const filterTypeKey = React.useMemo(() => (filterByTypes ? [...filterByTypes].sort() : undefined), [filterByTypes]);

--- a/apps/web/core/hooks/use-search.ts
+++ b/apps/web/core/hooks/use-search.ts
@@ -25,7 +25,9 @@ interface SearchOptions {
   enabled?: boolean;
   pageSize?: number;
   /**
-   * Tri-state, not a plain boolean — `undefined` and `true` are different:
+   * Tri-state, not a plain boolean — `undefined` and `true` are different.
+   * Only affects unscoped (global) searches — when `filterBySpace` is set,
+   * additionalSpaceIds is never applied regardless of this value:
    * - `false`: restrict results to the canonical graph plus the scoped spaces
    *   from useGlobalSearchSpaceIds (root/current/personal/member/editor —
    *   additionalSpaceIds applied).
@@ -97,7 +99,9 @@ export function useSearch({
   // non-canonical results (includeNonCanonical === true, not just unset), so
   // the request isn't silently narrowed back down to canonical-plus-scoped.
   const wantsUnrestrictedSearch = includeNonCanonical === true;
-  const additionalSpaceIds = filterBySpace || wantsUnrestrictedSearch ? undefined : globalAdditionalSpaceIds;
+  const isScopedToOneSpace = filterBySpace !== undefined;
+  const skipAdditionalSpaceIds = isScopedToOneSpace || wantsUnrestrictedSearch;
+  const additionalSpaceIds = skipAdditionalSpaceIds ? undefined : globalAdditionalSpaceIds;
 
   const maybeEntityId = debouncedQuery.trim();
   const filterTypeKey = React.useMemo(() => (filterByTypes ? [...filterByTypes].sort() : undefined), [filterByTypes]);

--- a/apps/web/partials/search/dialog.tsx
+++ b/apps/web/partials/search/dialog.tsx
@@ -54,7 +54,7 @@ const SearchDialogComponent = ({ open, onDone }: Props) => {
   const [isShowingAdvanced, setIsShowingAdvanced] = useState<boolean>(false);
   // Explicit `true` (not just omitted) when off — useSearch uses this to tell
   // "user asked for unrestricted search" apart from "caller has no opinion",
-  // and drops the canonical-plus-your-spaces eligibility filter accordingly.
+  // and drops the canonical-plus-scoped-spaces eligibility filter accordingly.
   const autocomplete = useSearch({ enabled: open, includeNonCanonical: canonicalOnly ? false : true });
   const { fetchNextPage, hasNextPage, isFetchingNextPage } = autocomplete;
 

--- a/apps/web/partials/search/dialog.tsx
+++ b/apps/web/partials/search/dialog.tsx
@@ -52,7 +52,10 @@ const SearchDialogComponent = ({ open, onDone }: Props) => {
   const router = useRouter();
   const [canonicalOnly, setCanonicalOnly] = useState<boolean>(readCanonicalOnly);
   const [isShowingAdvanced, setIsShowingAdvanced] = useState<boolean>(false);
-  const autocomplete = useSearch({ enabled: open, includeNonCanonical: canonicalOnly ? false : undefined });
+  // Explicit `true` (not just omitted) when off — useSearch uses this to tell
+  // "user asked for unrestricted search" apart from "caller has no opinion",
+  // and drops the canonical-plus-your-spaces eligibility filter accordingly.
+  const autocomplete = useSearch({ enabled: open, includeNonCanonical: canonicalOnly ? false : true });
   const { fetchNextPage, hasNextPage, isFetchingNextPage } = autocomplete;
 
   const toggleCanonicalOnly = useCallback(() => {


### PR DESCRIPTION
## Summary
- Preston reported he couldn't find "Dan" or "CptMoh" by name in the global search dialog even with "Canonical only" toggled off. The dialog's own tooltip promises "Turn off to search all entities."
- Traced the real cause: toggling off only set `includeNonCanonical` to `undefined` (same as never setting it), and `useSearch` always attaches `additionalSpaceIds` (the user's own joined spaces) regardless of the toggle. The gaia API treats a present `additional_space_ids` as a standing eligibility filter — "canonical OR listed spaces" — applied whenever canonical-only isn't explicitly requested. So the toggle never actually removed that restriction; entities in spaces the user hasn't joined stayed unsearchable either way.
- Verified directly against production data (via `geobrowser/gaia`) that both reported entities exist and are simply non-canonical, living in spaces outside the reporting user's own spaces — consistent with this being the actual mechanism.

## Changes
- `dialog.tsx`: pass explicit `includeNonCanonical: true` (not `undefined`) when the toggle is off, so downstream code can distinguish "user wants everything" from "caller has no opinion."
- `use-search.ts`: drop `additionalSpaceIds` entirely when `includeNonCanonical === true`, so the request is genuinely unrestricted. Other `useSearch` callers that never set `includeNonCanonical` are unaffected (still `undefined`, not `true`).

Companion fix: geobrowser/gaia#817 (a related but distinct gap — root-space `SPACE`-scope search also ignored the toggle, though that path isn't currently reachable from this frontend).

## Test plan
- [x] `queries.test.ts` (`buildSearchPath`, `shouldIncludeRestSearchResult`) — 14/14 passing, unaffected by this change (neither function was touched)
- [x] `tsc --noEmit` clean on both changed files (pre-existing unrelated `@geogenesis/auth` linking errors elsewhere in the repo, not touched by this change)
- [x] `eslint` clean on both changed files
- [ ] Manual: toggle "Canonical only" off in the search dialog and confirm previously-missing non-canonical entities (e.g. from spaces you haven't joined) now appear