### PR TITLE
feat: require featured tag for Join spaces

### DIFF
--- a/apps/web/core/io/subgraph/fetch-featured-spaces.test.ts
+++ b/apps/web/core/io/subgraph/fetch-featured-spaces.test.ts
@@ -1,7 +1,7 @@
 import { Effect } from 'effect';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { FEATURED_TAG_ID, TAG_PROPERTY_ID } from '~/core/constants';
+import { FEATURED_TAG_ID, ROOT_SPACE, TAG_PROPERTY_ID } from '~/core/constants';
 
 import { fetchFeaturedSpaces } from './fetch-featured-spaces';
 
@@ -25,8 +25,8 @@ function spaceNode(id: string, name: string) {
   return { id, page: { id: `page-${id}`, name, relationsList: [] }, members: { totalCount: 1 } };
 }
 
-function featuredTags(isFeatured = true) {
-  return isFeatured ? [{ toEntity: { id: FEATURED_TAG_ID } }] : [];
+function featuredTags(isFeatured = true, spaceId = ROOT_SPACE) {
+  return isFeatured ? [{ spaceId, toEntity: { id: FEATURED_TAG_ID } }] : [];
 }
 
 function query(arg: unknown): string {
@@ -101,6 +101,7 @@ describe('fetchFeaturedSpaces', () => {
       .filter(q => q.includes('entities(filter:'));
     expect(frontierQueries[0]).toContain(TAG_PROPERTY_ID);
     expect(frontierQueries[0]).toContain(FEATURED_TAG_ID);
+    expect(frontierQueries[0]).toContain(`spaceId: { is: "${ROOT_SPACE}" }`);
   });
 
   it('dedupes a space that claims more than one topic', async () => {
@@ -194,6 +195,39 @@ describe('fetchFeaturedSpaces', () => {
 
     expect(result.map(r => r.spaceId)).toEqual([AI_SPACE]);
     expect(result.some(r => r.spaceId === untaggedSpace)).toBe(false);
+  });
+
+  it('ignores a Featured tag attributed in a space other than Root', async () => {
+    graphqlMock.mockImplementation((arg: unknown) => {
+      const q = query(arg);
+      if (q.includes('space(id:')) return Effect.succeed({ space: { topicId: 'root' } });
+      if (q.includes('"topic"')) {
+        return Effect.succeed({
+          entities: [
+            {
+              id: 'topic',
+              name: 'AI',
+              spacesByTopicIdConnection: { totalCount: 1, nodes: [spaceNode(AI_SPACE, 'AI')] },
+              featuredTags: featuredTags(true, '11111111111111111111111111111111'),
+              subtopics: [],
+            },
+          ],
+        });
+      }
+      return Effect.succeed({
+        entities: [
+          {
+            id: 'root',
+            name: 'Geo',
+            spacesByTopicIdConnection: { totalCount: 0, nodes: [] },
+            featuredTags: featuredTags(false),
+            subtopics: [{ toEntity: { id: 'topic' } }],
+          },
+        ],
+      });
+    });
+
+    expect(await fetchFeaturedSpaces()).toEqual([]);
   });
 
   it('returns [] when the root space has no topic', async () => {

--- a/apps/web/core/io/subgraph/fetch-featured-spaces.test.ts
+++ b/apps/web/core/io/subgraph/fetch-featured-spaces.test.ts
@@ -1,6 +1,8 @@
 import { Effect } from 'effect';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { FEATURED_TAG_ID, TAG_PROPERTY_ID } from '~/core/constants';
+
 import { fetchFeaturedSpaces } from './fetch-featured-spaces';
 
 const graphqlMock = vi.fn();
@@ -23,6 +25,10 @@ function spaceNode(id: string, name: string) {
   return { id, page: { id: `page-${id}`, name, relationsList: [] }, members: { totalCount: 1 } };
 }
 
+function featuredTags(isFeatured = true) {
+  return isFeatured ? [{ toEntity: { id: FEATURED_TAG_ID } }] : [];
+}
+
 function query(arg: unknown): string {
   return (arg as { query?: string } | undefined)?.query ?? '';
 }
@@ -43,6 +49,7 @@ describe('fetchFeaturedSpaces', () => {
               id: 't3',
               name: 'Crypto',
               spacesByTopicIdConnection: { totalCount: 1, nodes: [spaceNode(CRYPTO_SPACE, 'Crypto')] },
+              featuredTags: featuredTags(),
               subtopics: [],
             },
           ],
@@ -55,12 +62,14 @@ describe('fetchFeaturedSpaces', () => {
               id: 't1',
               name: 'AI',
               spacesByTopicIdConnection: { totalCount: 1, nodes: [spaceNode(AI_SPACE, 'AI')] },
+              featuredTags: featuredTags(),
               subtopics: [],
             },
             {
               id: 't2',
               name: 'Science',
               spacesByTopicIdConnection: { totalCount: 0, nodes: [] },
+              featuredTags: featuredTags(false),
               subtopics: [{ toEntity: { id: 't3' } }],
             },
           ],
@@ -73,6 +82,7 @@ describe('fetchFeaturedSpaces', () => {
             id: 't0',
             name: 'Geo',
             spacesByTopicIdConnection: { totalCount: 0, nodes: [] },
+            featuredTags: featuredTags(false),
             subtopics: [{ toEntity: { id: 't1' } }, { toEntity: { id: 't2' } }],
           },
         ],
@@ -85,6 +95,12 @@ describe('fetchFeaturedSpaces', () => {
     expect(result.map(r => r.name)).toEqual(['Crypto', 'AI']);
     // Root topic ("Geo") is only a seed — never featured.
     expect(result.some(r => r.name === 'Geo')).toBe(false);
+
+    const frontierQueries = graphqlMock.mock.calls
+      .map(([arg]) => query(arg))
+      .filter(q => q.includes('entities(filter:'));
+    expect(frontierQueries[0]).toContain(TAG_PROPERTY_ID);
+    expect(frontierQueries[0]).toContain(FEATURED_TAG_ID);
   });
 
   it('dedupes a space that claims more than one topic', async () => {
@@ -99,12 +115,14 @@ describe('fetchFeaturedSpaces', () => {
               id: 't1',
               name: 'AI',
               spacesByTopicIdConnection: { totalCount: 1, nodes: [spaceNode(AI_SPACE, 'AI')] },
+              featuredTags: featuredTags(),
               subtopics: [],
             },
             {
               id: 't2',
               name: 'AI (alias)',
               spacesByTopicIdConnection: { totalCount: 1, nodes: [spaceNode(AI_SPACE, 'AI')] },
+              featuredTags: featuredTags(),
               subtopics: [],
             },
           ],
@@ -116,6 +134,7 @@ describe('fetchFeaturedSpaces', () => {
             id: 't0',
             name: 'Geo',
             spacesByTopicIdConnection: { totalCount: 0, nodes: [] },
+            featuredTags: featuredTags(false),
             subtopics: [{ toEntity: { id: 't1' } }, { toEntity: { id: 't2' } }],
           },
         ],
@@ -124,6 +143,57 @@ describe('fetchFeaturedSpaces', () => {
 
     const result = await fetchFeaturedSpaces();
     expect(result.map(r => r.spaceId)).toEqual([AI_SPACE]);
+  });
+
+  it('skips untagged topics but still traverses them to find featured descendants', async () => {
+    const untaggedSpace = '11111111111111111111111111111111';
+
+    graphqlMock.mockImplementation((arg: unknown) => {
+      const q = query(arg);
+      if (q.includes('space(id:')) return Effect.succeed({ space: { topicId: 'root' } });
+      if (q.includes('"featured-child"')) {
+        return Effect.succeed({
+          entities: [
+            {
+              id: 'featured-child',
+              name: 'AI',
+              spacesByTopicIdConnection: { totalCount: 1, nodes: [spaceNode(AI_SPACE, 'AI')] },
+              featuredTags: featuredTags(),
+              subtopics: [],
+            },
+          ],
+        });
+      }
+      if (q.includes('"untagged-parent"')) {
+        return Effect.succeed({
+          entities: [
+            {
+              id: 'untagged-parent',
+              name: 'Unfeatured',
+              spacesByTopicIdConnection: { totalCount: 1, nodes: [spaceNode(untaggedSpace, 'Unfeatured')] },
+              featuredTags: featuredTags(false),
+              subtopics: [{ toEntity: { id: 'featured-child' } }],
+            },
+          ],
+        });
+      }
+      return Effect.succeed({
+        entities: [
+          {
+            id: 'root',
+            name: 'Geo',
+            spacesByTopicIdConnection: { totalCount: 0, nodes: [] },
+            featuredTags: featuredTags(false),
+            subtopics: [{ toEntity: { id: 'untagged-parent' } }],
+          },
+        ],
+      });
+    });
+
+    const result = await fetchFeaturedSpaces();
+
+    expect(result.map(r => r.spaceId)).toEqual([AI_SPACE]);
+    expect(result.some(r => r.spaceId === untaggedSpace)).toBe(false);
   });
 
   it('returns [] when the root space has no topic', async () => {

--- a/apps/web/core/io/subgraph/fetch-featured-spaces.ts
+++ b/apps/web/core/io/subgraph/fetch-featured-spaces.ts
@@ -1,6 +1,6 @@
 import { Effect, Either } from 'effect';
 
-import { ROOT_SPACE, SUBTOPIC_RELATION_TYPE_ID } from '~/core/constants';
+import { FEATURED_TAG_ID, ROOT_SPACE, SUBTOPIC_RELATION_TYPE_ID, TAG_PROPERTY_ID } from '~/core/constants';
 import { Environment } from '~/core/environment';
 import { getSpaceRank, getTopRankedSpaceId } from '~/core/utils/space/space-ranking';
 
@@ -17,9 +17,9 @@ import { PLACEHOLDER_TOPIC_NAME } from './topic-space-usage';
 // Featured spaces are discovered by walking the Subtopic relation tree that
 // hangs off the Root space's topic entity, breadth-first. We start at the top
 // (Root's direct subtopics) and work down, so shallow — i.e. most prominent —
-// topics surface first. A topic becomes a pill only if it has at least one
-// space claiming it; when several spaces share a topic we feature the
-// top-ranked one (see getTopRankedSpaceId).
+// topics surface first. A topic becomes a pill only if it is tagged Featured
+// and has at least one space claiming it; when several spaces share a topic we
+// feature the top-ranked one (see getTopRankedSpaceId).
 
 // How many entity ids we expand per round. Batching keeps the number of
 // sequential round-trips small while staying well under any query-size limit.
@@ -56,6 +56,7 @@ interface TopicNode {
     totalCount: number;
     nodes: SpaceNode[];
   } | null;
+  featuredTags: Array<{ toEntity: { id: string } | null }> | null;
   subtopics: Array<{ toEntity: { id: string } | null }> | null;
 }
 
@@ -105,6 +106,14 @@ function frontierQuery(ids: string[]): string {
           }
         }
       }
+      featuredTags: relationsList(filter: {
+        typeId: { is: ${JSON.stringify(TAG_PROPERTY_ID)} }
+        toEntityId: { is: ${JSON.stringify(FEATURED_TAG_ID)} }
+      }) {
+        toEntity {
+          id
+        }
+      }
       subtopics: relationsList(filter: { typeId: { is: ${JSON.stringify(SUBTOPIC_RELATION_TYPE_ID)} } }) {
         toEntity {
           id
@@ -137,11 +146,13 @@ async function runQuery<T>(query: string): Promise<T | null> {
 
 /**
  * Builds the explore panel's "Join spaces" list by walking the Root space's
- * subtopic tree top-down and emitting one entry per topic that has a claiming
- * space. The Root topic itself is used only as the traversal seed — it is not
- * featured. Spaces are deduped (a space can claim multiple topics). Traversal
- * order is top-down only so the node cap trims the deepest topics first; the
- * returned list is ordered by space rank (then name), not tree position.
+ * subtopic tree top-down and emitting one entry per Featured-tagged topic that
+ * has a claiming space. The Root topic itself is used only as the traversal
+ * seed — it is not featured. Untagged topics are still traversed so featured
+ * descendants remain discoverable. Spaces are deduped (a space can claim
+ * multiple topics). Traversal order is top-down only so the node cap trims the
+ * deepest topics first; the returned list is ordered by space rank (then name),
+ * not tree position.
  */
 export async function fetchFeaturedSpaces(): Promise<FeaturedSpace[]> {
   const root = await runQuery<RootResult>(ROOT_QUERY);
@@ -166,8 +177,8 @@ export async function fetchFeaturedSpaces(): Promise<FeaturedSpace[]> {
     const nextFrontier: string[] = [];
 
     for (const topic of topics) {
-      // Emit a pill for this topic if a space claims it. Skip the Root topic
-      // seed (its id was pre-marked visited but it still comes back in round 1).
+      // Emit a pill for this topic if it is tagged Featured and a space claims
+      // it. Skip the Root topic seed (it still comes back in round 1).
       if (topic.id !== rootTopicId) {
         addFeaturedFromTopic(topic, seenSpaceIds, featured);
       }
@@ -195,6 +206,9 @@ export async function fetchFeaturedSpaces(): Promise<FeaturedSpace[]> {
 }
 
 function addFeaturedFromTopic(topic: TopicNode, seenSpaceIds: Set<string>, featured: FeaturedSpace[]): void {
+  const hasFeaturedTag = (topic.featuredTags ?? []).some(relation => relation.toEntity?.id === FEATURED_TAG_ID);
+  if (!hasFeaturedTag) return;
+
   const spaceNodes = topic.spacesByTopicIdConnection?.nodes ?? [];
   if (spaceNodes.length === 0) return;
 

--- a/apps/web/core/io/subgraph/fetch-featured-spaces.ts
+++ b/apps/web/core/io/subgraph/fetch-featured-spaces.ts
@@ -17,9 +17,9 @@ import { PLACEHOLDER_TOPIC_NAME } from './topic-space-usage';
 // Featured spaces are discovered by walking the Subtopic relation tree that
 // hangs off the Root space's topic entity, breadth-first. We start at the top
 // (Root's direct subtopics) and work down, so shallow — i.e. most prominent —
-// topics surface first. A topic becomes a pill only if it is tagged Featured
-// and has at least one space claiming it; when several spaces share a topic we
-// feature the top-ranked one (see getTopRankedSpaceId).
+// topics surface first. A topic becomes a pill only if it is tagged Featured in
+// the Root space and has at least one space claiming it; when several spaces
+// share a topic we feature the top-ranked one (see getTopRankedSpaceId).
 
 // How many entity ids we expand per round. Batching keeps the number of
 // sequential round-trips small while staying well under any query-size limit.
@@ -56,7 +56,7 @@ interface TopicNode {
     totalCount: number;
     nodes: SpaceNode[];
   } | null;
-  featuredTags: Array<{ toEntity: { id: string } | null }> | null;
+  featuredTags: Array<{ spaceId: string; toEntity: { id: string } | null }> | null;
   subtopics: Array<{ toEntity: { id: string } | null }> | null;
 }
 
@@ -109,7 +109,9 @@ function frontierQuery(ids: string[]): string {
       featuredTags: relationsList(filter: {
         typeId: { is: ${JSON.stringify(TAG_PROPERTY_ID)} }
         toEntityId: { is: ${JSON.stringify(FEATURED_TAG_ID)} }
+        spaceId: { is: ${JSON.stringify(ROOT_SPACE)} }
       }) {
+        spaceId
         toEntity {
           id
         }
@@ -146,13 +148,13 @@ async function runQuery<T>(query: string): Promise<T | null> {
 
 /**
  * Builds the explore panel's "Join spaces" list by walking the Root space's
- * subtopic tree top-down and emitting one entry per Featured-tagged topic that
- * has a claiming space. The Root topic itself is used only as the traversal
- * seed — it is not featured. Untagged topics are still traversed so featured
- * descendants remain discoverable. Spaces are deduped (a space can claim
- * multiple topics). Traversal order is top-down only so the node cap trims the
- * deepest topics first; the returned list is ordered by space rank (then name),
- * not tree position.
+ * subtopic tree top-down and emitting one entry per topic tagged Featured in
+ * the Root space that has a claiming space. The Root topic itself is used only
+ * as the traversal seed — it is not featured. Untagged topics are still
+ * traversed so featured descendants remain discoverable. Spaces are deduped (a
+ * space can claim multiple topics). Traversal order is top-down only so the node
+ * cap trims the deepest topics first; the returned list is ordered by space rank
+ * (then name), not tree position.
  */
 export async function fetchFeaturedSpaces(): Promise<FeaturedSpace[]> {
   const root = await runQuery<RootResult>(ROOT_QUERY);
@@ -177,7 +179,7 @@ export async function fetchFeaturedSpaces(): Promise<FeaturedSpace[]> {
     const nextFrontier: string[] = [];
 
     for (const topic of topics) {
-      // Emit a pill for this topic if it is tagged Featured and a space claims
+      // Emit a pill if this topic is tagged Featured in Root and a space claims
       // it. Skip the Root topic seed (it still comes back in round 1).
       if (topic.id !== rootTopicId) {
         addFeaturedFromTopic(topic, seenSpaceIds, featured);
@@ -206,8 +208,10 @@ export async function fetchFeaturedSpaces(): Promise<FeaturedSpace[]> {
 }
 
 function addFeaturedFromTopic(topic: TopicNode, seenSpaceIds: Set<string>, featured: FeaturedSpace[]): void {
-  const hasFeaturedTag = (topic.featuredTags ?? []).some(relation => relation.toEntity?.id === FEATURED_TAG_ID);
-  if (!hasFeaturedTag) return;
+  const hasRootFeaturedTag = (topic.featuredTags ?? []).some(
+    relation => relation.spaceId === ROOT_SPACE && relation.toEntity?.id === FEATURED_TAG_ID
+  );
+  if (!hasRootFeaturedTag) return;
 
   const spaceNodes = topic.spacesByTopicIdConnection?.nodes ?? [];
   if (spaceNodes.length === 0) return;


### PR DESCRIPTION
## Summary

- require topics in the Root subtopic tree to carry a Featured tag attributed in the Root space before they can contribute a space to the Explore side panel
- continue traversing untagged topics so Featured-tagged descendants remain discoverable
- add focused coverage for the GraphQL filter and tagged-descendant behavior

## Why

The Join spaces candidate builder previously treated every topic in the Root subtopic tree as eligible when it had a claiming space. This change makes inclusion explicitly editorial by requiring a Tags relation (`257090341ba5406f94e4d4af90042fba`) to the Featured entity (`ec3086a54ddf43d8aaefd6cc6e1b0556`) attributed in the Root space.

## Impact

Explore now shows spaces only for topics with a Root-attributed Featured tag. A Featured tag contributed from another space does not qualify the topic. Existing space ranking, deduplication, membership filtering, and Show more behavior are unchanged.

## Validation

- `bun run test core/io/subgraph/fetch-featured-spaces.test.ts` — 5 tests passed
- `bunx eslint core/io/subgraph/fetch-featured-spaces.ts core/io/subgraph/fetch-featured-spaces.test.ts`
- `bunx prettier --check core/io/subgraph/fetch-featured-spaces.ts core/io/subgraph/fetch-featured-spaces.test.ts`
- `git diff --check`
