### PR TITLE
fix(layout): restore side padding on space pages in the ~1280-1400px window

### DIFF
--- a/apps/web/app/entry.tsx
+++ b/apps/web/app/entry.tsx
@@ -99,7 +99,7 @@ export function App({ children }: { children: React.ReactNode }) {
       <div className="flex min-w-0 flex-1 flex-col">
         <Navbar onSearchClick={() => setOpen(true)} hideLogo={sidebarOpen && !rankingFullscreenActive} />
         <SearchDialog open={open} onDone={() => setOpen(false)} />
-        <div className="min-w-0 flex-1 xl:px-[2ch]">
+        <div className="min-w-0 flex-1 2xl:px-[2ch]">
           <Main>{children}</Main>
         </div>
       </div>


### PR DESCRIPTION
The main content column applied its horizontal gutter via `xl:px-[2ch]` in entry.tsx. Because this repo redefines breakpoints desktop-first (xl = max-width: 1279px, see styles.css), that gutter only applies at <=1279px. Extend the gutter to 2xl (max-width: 1535px) so it stays active across that window. 