### PR TITLE
Improve list and gallery data block readability

### DIFF
--- a/apps/web/partials/blocks/table/table-block-browse-layout.ts
+++ b/apps/web/partials/blocks/table/table-block-browse-layout.ts
@@ -1,11 +1,17 @@
 import { Cell, Property } from '~/core/types';
 
 /**
- * Description line + long-text property values in list/gallery browse.
+ * Entity name in list/gallery browse.
+ * Uses the card title token so names remain readable in both layouts.
+ */
+export const LIST_GALLERY_BROWSE_TITLE_CLASS = 'text-cardEntityTitle font-medium text-text';
+
+/**
+ * Description line + property values in list/gallery browse.
  * Uses explicit token sizes so property fields match the system description block (avoids `text-tableCell` bleed).
  */
 export const LIST_GALLERY_BROWSE_BODY_CLASS =
-  '!text-[length:var(--text-metadata)] !leading-[length:var(--text-metadata--line-height)] font-normal text-grey-04';
+  '!text-[length:var(--text-listItem)] !leading-[length:var(--text-listItem--line-height)] font-normal text-grey-04';
 
 /**
  * Vertical gap before the next row in list/gallery browse (Figma):

--- a/apps/web/partials/blocks/table/table-block-gallery-item.tsx
+++ b/apps/web/partials/blocks/table/table-block-gallery-item.tsx
@@ -27,6 +27,7 @@ import { EntityVoteButtons } from '~/partials/entity-page/entity-vote-buttons';
 
 import {
   LIST_GALLERY_BROWSE_BODY_CLASS,
+  LIST_GALLERY_BROWSE_TITLE_CLASS,
   browseListStackMarginTopForField,
   orderCellsForBrowseFigma,
 } from './table-block-browse-layout';
@@ -291,7 +292,7 @@ export function TableBlockGalleryItem({
         <div className="min-w-0">
           {source.type !== 'COLLECTION' ? (
             <Link entityId={rowEntityId} spaceId={currentSpaceId} href={href}>
-              <div className="text-smallTitle font-medium text-text">{name || rowEntityId}</div>
+              <div className={LIST_GALLERY_BROWSE_TITLE_CLASS}>{name || rowEntityId}</div>
             </Link>
           ) : (
             <CollectionMetadata
@@ -309,7 +310,7 @@ export function TableBlockGalleryItem({
               openedWithMainViewEditing={isEditing}
             >
               <Link entityId={rowEntityId} spaceId={currentSpaceId} href={href}>
-                <div className="text-smallTitle font-medium text-text">{name || rowEntityId}</div>
+                <div className={LIST_GALLERY_BROWSE_TITLE_CLASS}>{name || rowEntityId}</div>
               </Link>
             </CollectionMetadata>
           )}
@@ -344,7 +345,7 @@ export function TableBlockGalleryItem({
             </div>
           );
         })}
-        <div className="mt-2 flex items-center justify-between gap-2">
+        <div className="mt-1 flex items-center justify-between gap-2">
           <EntityVoteButtons entityId={rowEntityId} spaceId={currentSpaceId} />
           {!isPlaceholder && (
             <div className="invisible flex items-center opacity-0 transition duration-200 group-focus-within:visible group-focus-within:opacity-100 group-hover:visible group-hover:opacity-100 md:hidden [&_button]:h-5 [&_button]:w-5">

--- a/apps/web/partials/blocks/table/table-block-list-item.tsx
+++ b/apps/web/partials/blocks/table/table-block-list-item.tsx
@@ -27,6 +27,7 @@ import { EntityVoteButtons } from '~/partials/entity-page/entity-vote-buttons';
 
 import {
   LIST_GALLERY_BROWSE_BODY_CLASS,
+  LIST_GALLERY_BROWSE_TITLE_CLASS,
   browseListStackMarginTopForField,
   orderCellsForBrowseFigma,
 } from './table-block-browse-layout';
@@ -302,7 +303,7 @@ export function TableBlockListItem({
           <div>
             {source.type !== 'COLLECTION' ? (
               <Link entityId={rowEntityId} spaceId={currentSpaceId} href={href}>
-                <div className="text-smallTitle font-medium text-text">{name || rowEntityId}</div>
+                <div className={LIST_GALLERY_BROWSE_TITLE_CLASS}>{name || rowEntityId}</div>
               </Link>
             ) : (
               <CollectionMetadata
@@ -320,7 +321,7 @@ export function TableBlockListItem({
                 openedWithMainViewEditing={isEditing}
               >
                 <Link entityId={rowEntityId} spaceId={currentSpaceId} href={href}>
-                  <div className="text-smallTitle font-medium text-text">{name || rowEntityId}</div>
+                  <div className={LIST_GALLERY_BROWSE_TITLE_CLASS}>{name || rowEntityId}</div>
                 </Link>
               </CollectionMetadata>
             )}
@@ -353,7 +354,7 @@ export function TableBlockListItem({
               </div>
             );
           })}
-          <div className="mt-2 flex items-center justify-between gap-2">
+          <div className="mt-1 flex items-center justify-between gap-2">
             <EntityVoteButtons entityId={rowEntityId} spaceId={currentSpaceId} />
             {!isPlaceholder && (
               <div className="invisible flex items-center opacity-0 transition duration-200 group-focus-within:visible group-focus-within:opacity-100 group-hover:visible group-hover:opacity-100 md:hidden [&_button]:h-5 [&_button]:w-5">

--- a/apps/web/partials/blocks/table/table-block-property-field.tsx
+++ b/apps/web/partials/blocks/table/table-block-property-field.tsx
@@ -28,10 +28,10 @@ import { LIST_GALLERY_BROWSE_BODY_CLASS } from './table-block-browse-layout';
 
 /** Match description tokens in list/gallery browse (overrides tableCell / tableProperty on inner elements). */
 const BROWSE_LIST_VALUE_CLASS =
-  '!text-[length:var(--text-metadata)] !leading-[length:var(--text-metadata--line-height)] !font-normal !text-grey-04 !text-left';
+  '!text-[length:var(--text-listItem)] !leading-[length:var(--text-listItem--line-height)] !font-normal !text-grey-04 !text-left';
 
 const BROWSE_LIST_URL_CLASS =
-  '!text-[length:var(--text-metadata)] !leading-[length:var(--text-metadata--line-height)] !font-normal !text-ctaPrimary hover:!text-ctaHover !text-left break-all';
+  '!text-[length:var(--text-listItem)] !leading-[length:var(--text-listItem--line-height)] !font-normal !text-ctaPrimary hover:!text-ctaHover !text-left break-all';
 
 function BrowsePropertyLabel({ name }: { name: string }) {
   return <div className="mb-0.5 text-footnote text-grey-04">{name}</div>;

--- a/apps/web/partials/space-page/subtopic-gallery.tsx
+++ b/apps/web/partials/space-page/subtopic-gallery.tsx
@@ -57,10 +57,10 @@ export function SubtopicGallery({ spaceId, subtopics }: SubtopicGalleryProps) {
               <div className="flex w-full flex-col px-1">
                 <div className="min-w-0">
                   <Link href={href}>
-                    <div className="text-smallTitle font-medium text-text">{subtopic.name}</div>
+                    <div className="text-cardEntityTitle font-medium text-text">{subtopic.name}</div>
                   </Link>
                 </div>
-                <div className="mt-2 flex items-center justify-between gap-2">
+                <div className="mt-1 flex items-center justify-between gap-2">
                   <EntityVoteButtons entityId={subtopic.id} spaceId={spaceId} />
                 </div>
               </div>


### PR DESCRIPTION
## Summary

- increase list and gallery entity titles from the 19px small-title token to the 21px card-title token
- increase descriptions and displayed property values from 16px metadata text to the 18px list-item token
- reduce the space above vote controls from 8px to 4px in both views
- centralize the shared browse title class so list and gallery typography remain aligned

## Why

List and gallery data-block cards were difficult to scan because entity names and descriptions rendered too small, while the vote controls had more vertical separation from the content than needed.

## Impact

Entity names and supporting content are easier to read, and the vote row sits closer to each card's content in both list and gallery layouts.

## Validation

- Prettier check on all changed files
- ESLint on all changed files
- `bunx tsc --noEmit --pretty false`
- `git diff --check`
