### PR TITLE
fix: use Types relation for rolling rankings

### DIFF
--- a/apps/web/core/blocks/ranking/ensure-ranking-type.test.ts
+++ b/apps/web/core/blocks/ranking/ensure-ranking-type.test.ts
@@ -1,20 +1,24 @@
+import { SystemIds } from '@geoprotocol/geo-sdk/lite';
+
 import { describe, expect, it } from 'vitest';
 
-import { RANKING_TYPE_PROPERTY_ID, ROLLING_RANKING_TYPE_ID } from '~/core/ranking-block-ids';
+import { ROLLING_RANKING_TYPE_ID } from '~/core/ranking-block-ids';
 import type { Relation } from '~/core/types';
 
-import { isRollingRankingBlock } from './ensure-ranking-type';
+import { isRollingRankingBlock, makeRollingRankingTypeRelation } from './ensure-ranking-type';
 
 const BLOCK = 'block-1';
 const SPACE = 'space-1';
 
-function rankingTypeRelation(overrides: Partial<Relation> = {}): Relation {
+const LEGACY_RANKING_TYPE_PROPERTY_ID = '48e01bc8324e48c2a6c9cab3f49290c6';
+
+function rollingTypeRelation(overrides: Partial<Relation> = {}): Relation {
   return {
     id: 'rel-1',
     entityId: 'rel-entity-1',
     spaceId: SPACE,
     renderableType: 'RELATION',
-    type: { id: RANKING_TYPE_PROPERTY_ID, name: 'Ranking type' },
+    type: { id: SystemIds.TYPES_PROPERTY, name: 'Types' },
     toEntity: { id: ROLLING_RANKING_TYPE_ID, name: 'Rolling ranking', value: ROLLING_RANKING_TYPE_ID },
     fromEntity: { id: BLOCK, name: null },
     ...overrides,
@@ -22,22 +26,22 @@ function rankingTypeRelation(overrides: Partial<Relation> = {}): Relation {
 }
 
 describe('isRollingRankingBlock', () => {
-  it('is true when the block has a Ranking type → Rolling relation', () => {
-    expect(isRollingRankingBlock([rankingTypeRelation()], BLOCK, SPACE)).toBe(true);
+  it('is true when the block has a Types → Rolling relation', () => {
+    expect(isRollingRankingBlock([rollingTypeRelation()], BLOCK, SPACE)).toBe(true);
   });
 
-  it('is false when there is no ranking-type relation', () => {
+  it('is false when there is no rolling type relation', () => {
     expect(isRollingRankingBlock([], BLOCK, SPACE)).toBe(false);
   });
 
   it('ignores a deleted rolling relation', () => {
-    expect(isRollingRankingBlock([rankingTypeRelation({ isDeleted: true })], BLOCK, SPACE)).toBe(false);
+    expect(isRollingRankingBlock([rollingTypeRelation({ isDeleted: true })], BLOCK, SPACE)).toBe(false);
   });
 
-  it('ignores a relation pointing at a different ranking type', () => {
+  it('ignores a Types relation pointing at a different type', () => {
     expect(
       isRollingRankingBlock(
-        [rankingTypeRelation({ toEntity: { id: 'some-other-type', name: 'Other', value: 'some-other-type' } })],
+        [rollingTypeRelation({ toEntity: { id: 'some-other-type', name: 'Other', value: 'some-other-type' } })],
         BLOCK,
         SPACE
       )
@@ -46,11 +50,29 @@ describe('isRollingRankingBlock', () => {
 
   it('ignores a relation from a different block', () => {
     expect(
-      isRollingRankingBlock([rankingTypeRelation({ fromEntity: { id: 'other-block', name: null } })], BLOCK, SPACE)
+      isRollingRankingBlock([rollingTypeRelation({ fromEntity: { id: 'other-block', name: null } })], BLOCK, SPACE)
     ).toBe(false);
   });
 
   it('ignores a relation in a different space', () => {
-    expect(isRollingRankingBlock([rankingTypeRelation({ spaceId: 'space-2' })], BLOCK, SPACE)).toBe(false);
+    expect(isRollingRankingBlock([rollingTypeRelation({ spaceId: 'space-2' })], BLOCK, SPACE)).toBe(false);
+  });
+
+  it('ignores the legacy Ranking type property relation', () => {
+    const legacyRelation = rollingTypeRelation({
+      type: { id: LEGACY_RANKING_TYPE_PROPERTY_ID, name: 'Ranking type' },
+    });
+
+    expect(isRollingRankingBlock([legacyRelation], BLOCK, SPACE)).toBe(false);
+  });
+});
+
+describe('makeRollingRankingTypeRelation', () => {
+  it('creates an additional Types relation to Rolling', () => {
+    const relation = makeRollingRankingTypeRelation(BLOCK, SPACE);
+
+    expect(relation.type).toEqual({ id: SystemIds.TYPES_PROPERTY, name: 'Types' });
+    expect(relation.fromEntity.id).toBe(BLOCK);
+    expect(relation.toEntity.id).toBe(ROLLING_RANKING_TYPE_ID);
   });
 });

--- a/apps/web/core/blocks/ranking/ensure-ranking-type.ts
+++ b/apps/web/core/blocks/ranking/ensure-ranking-type.ts
@@ -1,13 +1,8 @@
-import { IdUtils, Position } from '@geoprotocol/geo-sdk/lite';
+import { IdUtils, Position, SystemIds } from '@geoprotocol/geo-sdk/lite';
 
 import { ID } from '~/core/id';
 import { EntityId } from '~/core/io/substream-schema';
-import {
-  RANKING_TYPE_PROPERTY_ID,
-  RANKING_TYPE_PROPERTY_NAME,
-  ROLLING_RANKING_TYPE_ID,
-  ROLLING_RANKING_TYPE_NAME,
-} from '~/core/ranking-block-ids';
+import { ROLLING_RANKING_TYPE_ID, ROLLING_RANKING_TYPE_NAME } from '~/core/ranking-block-ids';
 import type { Mutator } from '~/core/sync/use-mutate';
 import type { Relation } from '~/core/types';
 
@@ -19,8 +14,8 @@ export function makeRollingRankingTypeRelation(blockId: string, spaceId: string)
     position: Position.generate(),
     renderableType: 'RELATION',
     type: {
-      id: EntityId(RANKING_TYPE_PROPERTY_ID),
-      name: RANKING_TYPE_PROPERTY_NAME,
+      id: EntityId(SystemIds.TYPES_PROPERTY),
+      name: 'Types',
     },
     toEntity: {
       id: EntityId(ROLLING_RANKING_TYPE_ID),
@@ -40,7 +35,7 @@ export function isRollingRankingBlock(relations: Relation[], blockId: string, sp
       !r.isDeleted &&
       ID.equals(r.spaceId, spaceId) &&
       ID.equals(r.fromEntity.id, blockId) &&
-      ID.equals(r.type.id, RANKING_TYPE_PROPERTY_ID) &&
+      ID.equals(r.type.id, SystemIds.TYPES_PROPERTY) &&
       ID.equals(r.toEntity.id, ROLLING_RANKING_TYPE_ID)
   );
 }
@@ -51,7 +46,7 @@ function findRollingRankingTypeRelation(relations: Relation[], blockId: string, 
       !r.isDeleted &&
       ID.equals(r.spaceId, spaceId) &&
       ID.equals(r.fromEntity.id, blockId) &&
-      ID.equals(r.type.id, RANKING_TYPE_PROPERTY_ID) &&
+      ID.equals(r.type.id, SystemIds.TYPES_PROPERTY) &&
       ID.equals(r.toEntity.id, ROLLING_RANKING_TYPE_ID)
   );
 }

--- a/apps/web/core/ranking-block-ids.ts
+++ b/apps/web/core/ranking-block-ids.ts
@@ -23,9 +23,6 @@ export const RANK_VOTES_RELATION_TYPE_ID = '19a4cfff45f24150abf2af0f43eb2eec';
 
 export const RANKING_VIEW_PILL_ID = '60022d24d9df4e1888faa71e915f8101';
 
-export const RANKING_TYPE_PROPERTY_ID = '48e01bc8324e48c2a6c9cab3f49290c6';
-export const RANKING_TYPE_PROPERTY_NAME = 'Ranking type';
-
 export const ROLLING_RANKING_TYPE_ID = 'd00ddc89b23c4a20a63febf545ddc139';
 export const ROLLING_RANKING_TYPE_NAME = 'Rolling ranking';
 


### PR DESCRIPTION
## What changed

- create rolling ranking metadata as an additional `Types → Rolling` relation
- detect and remove rolling configuration through the canonical Types property
- remove the obsolete Ranking type property constants
- add regression coverage for relation creation and detection

## Why

PR #1987 modeled rolling rankings with the custom `Ranking type` property. Rolling is an entity type, so ranking blocks should receive it through the standard `Types` relation alongside their existing Ranking Block type.

## Impact

New rolling ranking blocks are represented consistently with other typed entities and can be discovered through standard type relations.

## Validation

- `bun run test core/blocks/ranking/ensure-ranking-type.test.ts` (8 tests passed)
- `bunx tsc --noEmit`
- ESLint on changed files
- Prettier check on changed files
- `git diff --check`

The full Next.js production build was stopped after hanging during the documented outer-lockfile/Turbopack workspace-root condition; the auth package build completed successfully.