### PR TITLE
feat(debates): add format selector feature flag

### DIFF
--- a/apps/web/core/debates/match-prompt.test.tsx
+++ b/apps/web/core/debates/match-prompt.test.tsx
@@ -3,6 +3,8 @@ import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import type { FeatureFlagId } from '~/core/state/feature-flags';
+
 import type { Debate, DebateMatch } from './api';
 import { defaultDebateFormatId } from './formats';
 import { DebateMatchPrompt } from './match-prompt';
@@ -12,10 +14,17 @@ const mocks = vi.hoisted(() => ({
   currentUserId: vi.fn(),
   acceptMutate: vi.fn(),
   declineMutate: vi.fn(),
+  featureFlags: {
+    debateFormatSelector: false,
+  } as Partial<Record<FeatureFlagId, boolean>>,
 }));
 
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: mocks.push }),
+}));
+
+vi.mock('~/core/state/feature-flags', () => ({
+  useFeatureFlag: (id: FeatureFlagId) => mocks.featureFlags[id] ?? false,
 }));
 
 vi.mock('./api', async importOriginal => {
@@ -42,6 +51,9 @@ beforeEach(() => {
   mocks.currentUserId.mockReturnValue('user-for');
   mocks.acceptMutate.mockReset();
   mocks.declineMutate.mockReset();
+  mocks.featureFlags = {
+    debateFormatSelector: false,
+  };
   document.body.style.overflow = '';
   document.documentElement.style.overflow = '';
 });
@@ -58,14 +70,26 @@ describe('DebateMatchPrompt', () => {
     expect(screen.getByText('Debate request')).toBeInTheDocument();
     expect(screen.getByText('Bri makes an argument')).toBeInTheDocument();
 
-    // The format selector is hidden to match the Figma design, so no format is chosen in the UI —
-    // the first participant accepts with the match's default format.
     expect(screen.queryByLabelText('Debate format')).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'Accept' }));
 
     expect(mocks.acceptMutate).toHaveBeenCalledWith(
       { matchId: 'match-1', formatId: defaultDebateFormatId },
+      expect.any(Object)
+    );
+  });
+
+  it('lets the first participant choose a format when the feature flag is enabled', () => {
+    mocks.featureFlags.debateFormatSelector = true;
+
+    render(<DebateMatchPrompt spaceId="space-1" matches={[match()]} />);
+
+    fireEvent.change(screen.getByLabelText('Debate format'), { target: { value: 'extended-standard' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Accept' }));
+
+    expect(mocks.acceptMutate).toHaveBeenCalledWith(
+      { matchId: 'match-1', formatId: 'extended-standard' },
       expect.any(Object)
     );
   });
@@ -94,6 +118,7 @@ describe('DebateMatchPrompt', () => {
 
   it('hides the format selector from the second participant', () => {
     mocks.currentUserId.mockReturnValue('user-against');
+    mocks.featureFlags.debateFormatSelector = true;
 
     render(<DebateMatchPrompt spaceId="space-1" matches={[match()]} />);
 
@@ -103,6 +128,17 @@ describe('DebateMatchPrompt', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Accept' }));
 
     expect(mocks.acceptMutate).toHaveBeenCalledWith({ matchId: 'match-1', formatId: undefined }, expect.any(Object));
+  });
+
+  it('hides the format selector after the first participant has accepted', () => {
+    mocks.featureFlags.debateFormatSelector = true;
+    const acceptedMatch = match();
+    acceptedMatch.participants[0]!.accepted = true;
+
+    render(<DebateMatchPrompt spaceId="space-1" matches={[acceptedMatch]} />);
+
+    expect(screen.getByText('Waiting for the other person')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Debate format')).not.toBeInTheDocument();
   });
 
   it('rejects the matched person for the question', () => {
@@ -115,6 +151,7 @@ describe('DebateMatchPrompt', () => {
   });
 
   it('moves the first accepter into the debate once polling shows it exists', () => {
+    mocks.featureFlags.debateFormatSelector = true;
     mocks.acceptMutate.mockImplementation((_variables, options) => {
       options.onSuccess({
         match: {
@@ -132,6 +169,7 @@ describe('DebateMatchPrompt', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Accept' }));
 
     expect(screen.getByText('Waiting for the other person')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Debate format')).not.toBeInTheDocument();
 
     rerender(<DebateMatchPrompt spaceId="space-1" matches={[]} debates={[debate()]} />);
 

--- a/apps/web/core/debates/match-prompt.tsx
+++ b/apps/web/core/debates/match-prompt.tsx
@@ -4,6 +4,8 @@ import * as React from 'react';
 
 import { useRouter } from 'next/navigation';
 
+import { useFeatureFlag } from '~/core/state/feature-flags';
+
 import { Avatar } from '~/design-system/avatar';
 import { Button } from '~/design-system/button';
 import { Text } from '~/design-system/text';
@@ -189,8 +191,7 @@ export function DebateMatchPrompt({ spaceId, matches, debates = [] }: DebateMatc
   );
 }
 
-// Built but hidden: the Figma match-request design omits these controls. Flip to re-enable.
-const SHOW_FORMAT_SELECTOR = false; // first participant picking the turn format
+// Built but hidden: the Figma match-request design omits these labels. Flip to re-enable.
 const SHOW_POSITION_LABELS = false; // Yes/No pills under each name + the "You chose X." line
 
 function MatchDialog({
@@ -214,6 +215,7 @@ function MatchDialog({
   onDecline: () => void;
   onFormatChange: (formatId: DebateFormatId) => void;
 }) {
+  const debateFormatSelectorEnabled = useFeatureFlag('debateFormatSelector');
   const myParticipant = participantForUser(match, currentUserId);
   const canChooseFormat = myParticipant?.participant_slot === 1 && !waiting;
   const participants = orderedParticipants(match);
@@ -258,7 +260,7 @@ function MatchDialog({
               <Text as="h3" variant="metadata" color="text">
                 Debate format
               </Text>
-              {SHOW_FORMAT_SELECTOR && !waiting && canChooseFormat && (
+              {debateFormatSelectorEnabled && canChooseFormat && (
                 <DebateFormatSelector
                   value={selectedFormatId}
                   selectedFormatId={match.turn_format_id}

--- a/apps/web/core/state/feature-flags.test.ts
+++ b/apps/web/core/state/feature-flags.test.ts
@@ -17,14 +17,24 @@ describe('feature flags', () => {
   it('defaults local feature flags to disabled', () => {
     expect(defaultFeatureFlags.questionsTab).toBe(false);
     expect(defaultFeatureFlags.debateDebugging).toBe(false);
-    expect(normalizeFeatureFlags(null)).toEqual({ questionsTab: false, debateDebugging: false });
+    expect(defaultFeatureFlags.debateFormatSelector).toBe(false);
+    expect(normalizeFeatureFlags(null)).toEqual({
+      questionsTab: false,
+      debateDebugging: false,
+      debateFormatSelector: false,
+    });
   });
 
   it('maps the legacy Debates flag into the combined flag', () => {
-    expect(normalizeFeatureFlags({ debatesTab: true })).toEqual({ questionsTab: true, debateDebugging: false });
+    expect(normalizeFeatureFlags({ debatesTab: true })).toEqual({
+      questionsTab: true,
+      debateDebugging: false,
+      debateFormatSelector: false,
+    });
     expect(normalizeFeatureFlags({ questionsTab: true, debatesTab: false })).toEqual({
       questionsTab: true,
       debateDebugging: false,
+      debateFormatSelector: false,
     });
   });
 
@@ -33,13 +43,15 @@ describe('feature flags', () => {
 
     store.set(featureFlagsAtom, currentFlags => {
       const flags = setFeatureFlagValue(normalizeFeatureFlags(currentFlags), 'questionsTab', true);
-      return setFeatureFlagValue(flags, 'debateDebugging', true);
+      const debuggingFlags = setFeatureFlagValue(flags, 'debateDebugging', true);
+      return setFeatureFlagValue(debuggingFlags, 'debateFormatSelector', true);
     });
 
     expect(store.get(featureFlagsAtom).questionsTab).toBe(true);
     expect(store.get(featureFlagsAtom).debateDebugging).toBe(true);
+    expect(store.get(featureFlagsAtom).debateFormatSelector).toBe(true);
     expect(window.localStorage.getItem(featureFlagsStorageKey)).toBe(
-      JSON.stringify({ questionsTab: true, debateDebugging: true })
+      JSON.stringify({ questionsTab: true, debateDebugging: true, debateFormatSelector: true })
     );
   });
 });

--- a/apps/web/core/state/feature-flags.ts
+++ b/apps/web/core/state/feature-flags.ts
@@ -16,6 +16,11 @@ export const featureFlagDefinitions = [
     label: 'Debate debugging',
     description: 'Show manual debugging controls during debate recording.',
   },
+  {
+    id: 'debateFormatSelector',
+    label: 'Debate format selector',
+    description: 'Allow the first matched debater to choose a format before accepting.',
+  },
 ] as const;
 
 export type FeatureFlagId = (typeof featureFlagDefinitions)[number]['id'];
@@ -25,12 +30,14 @@ type StoredFeatureFlags = Partial<Record<FeatureFlagId | 'debatesTab', boolean>>
 export const defaultFeatureFlags: FeatureFlags = {
   questionsTab: false,
   debateDebugging: false,
+  debateFormatSelector: false,
 };
 
 export function normalizeFeatureFlags(flags: StoredFeatureFlags | null | undefined): FeatureFlags {
   return {
     questionsTab: flags?.questionsTab ?? flags?.debatesTab ?? defaultFeatureFlags.questionsTab,
     debateDebugging: flags?.debateDebugging ?? defaultFeatureFlags.debateDebugging,
+    debateFormatSelector: flags?.debateFormatSelector ?? defaultFeatureFlags.debateFormatSelector,
   };
 }
 

--- a/apps/web/partials/feature-flags/feature-flags-dialog.test.tsx
+++ b/apps/web/partials/feature-flags/feature-flags-dialog.test.tsx
@@ -23,13 +23,15 @@ describe('FeatureFlagsDialog', () => {
 
     expect(await screen.findByRole('heading', { name: 'Feature flags' })).toBeTruthy();
     expect(screen.getByText('Debate debugging')).toBeTruthy();
+    expect(screen.getByText('Debate format selector')).toBeTruthy();
 
     fireEvent.click(screen.getByRole('button', { name: 'Claims and debates' }));
     fireEvent.click(screen.getByRole('button', { name: 'Debate debugging' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Debate format selector' }));
 
     await waitFor(() => {
       expect(window.localStorage.getItem(featureFlagsStorageKey)).toBe(
-        JSON.stringify({ questionsTab: true, debateDebugging: true })
+        JSON.stringify({ questionsTab: true, debateDebugging: true, debateFormatSelector: true })
       );
     });
   });


### PR DESCRIPTION
## Summary

The first matched debater can now opt into choosing a debate format before accepting when the browser-local preview flag is enabled. The flag defaults off, preserving the current matching experience; later participants and waiting or accepted matches remain unable to change the format.

The flag is available in the existing feature-flags dialog and persists with the other local preview settings.

## Validation

- Verified the enabled selector sends the selected format when the first participant accepts.
- Verified the selector stays hidden by default, for the second participant, and after acceptance or while waiting.
- Passed all 1,379 web tests, TypeScript checking, ESLint, and formatting checks.
