### PR TITLE
fix(debates): diagnose and recover recording uploads

### DIFF
--- a/apps/web/core/debates/api.test.ts
+++ b/apps/web/core/debates/api.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { GeoChatRequestError, completeLocalRecordingUpload } from './api';
+
+const completeRequest = {
+  filename: 'recordings/debate-1/recording.webm',
+  mime_type: 'video/webm',
+  started_at_ms: 1_000,
+  ended_at_ms: 11_000,
+  duration_seconds: 10,
+  byte_size: 42,
+  framerate: 29.97,
+};
+
+beforeEach(() => {
+  window.localStorage.setItem(
+    'geo:chat-session',
+    JSON.stringify({
+      access_token: 'access-token',
+      refresh_token: 'refresh-token',
+      expires_at: new Date(Date.now() + 60_000).toISOString(),
+    })
+  );
+});
+
+afterEach(() => {
+  window.localStorage.clear();
+  vi.unstubAllGlobals();
+});
+
+describe('geo-chat request errors', () => {
+  it('preserves structured API error messages and codes', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ error: { code: 'invalid_recording', message: 'Invalid frame rate' } }), {
+          status: 400,
+          statusText: 'Bad Request',
+          headers: { 'Content-Type': 'application/json' },
+        })
+      )
+    );
+
+    await expect(completeLocalRecordingUpload('debate-1', completeRequest, vi.fn())).rejects.toMatchObject({
+      name: 'GeoChatRequestError',
+      message: 'Invalid frame rate',
+      code: 'invalid_recording',
+      status: 400,
+    } satisfies Partial<GeoChatRequestError>);
+  });
+
+  it('preserves plain-text extraction errors', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response('Failed to deserialize the JSON body: framerate must be a number', {
+          status: 422,
+          statusText: 'Unprocessable Entity',
+          headers: { 'Content-Type': 'text/plain' },
+        })
+      )
+    );
+
+    await expect(completeLocalRecordingUpload('debate-1', completeRequest, vi.fn())).rejects.toMatchObject({
+      message: 'Failed to deserialize the JSON body: framerate must be a number',
+      code: null,
+      status: 422,
+    });
+  });
+
+  it('falls back to the HTTP status when the error body is empty', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response('', {
+          status: 503,
+          statusText: 'Service Unavailable',
+        })
+      )
+    );
+
+    await expect(completeLocalRecordingUpload('debate-1', completeRequest, vi.fn())).rejects.toMatchObject({
+      message: '503 Service Unavailable',
+      code: null,
+      status: 503,
+    });
+  });
+});

--- a/apps/web/core/debates/api.ts
+++ b/apps/web/core/debates/api.ts
@@ -750,9 +750,16 @@ async function requestError(response: Response) {
   let code: string | null = null;
   let message = `${response.status} ${response.statusText}`;
   try {
-    const body = (await response.json()) as { error?: { code?: string; message?: string } };
-    code = body.error?.code ?? null;
-    message = body.error?.message || message;
+    const responseBody = (await response.text()).trim();
+    if (responseBody) {
+      try {
+        const body = JSON.parse(responseBody) as { error?: { code?: string; message?: string } };
+        code = body.error?.code ?? null;
+        message = body.error?.message || message;
+      } catch {
+        message = responseBody;
+      }
+    }
   } catch {
     // fall back to the status line built above
   }

--- a/apps/web/core/debates/recording-upload-coordinator.integration.test.tsx
+++ b/apps/web/core/debates/recording-upload-coordinator.integration.test.tsx
@@ -57,7 +57,23 @@ vi.mock('./recording-upload-queue', async importOriginal => ({
     mocks.observer?.(mocks.queue);
   },
   getDebateRecordingUpload: (id: string) => mocks.getUpload(id),
-  markDebateRecordingUploaded: mocks.markUploaded,
+  markDebateRecordingUploaded: async (id: string, filename: string) => {
+    await mocks.markUploaded(id, filename);
+    mocks.queue = mocks.queue.map(upload =>
+      upload.id === id
+        ? {
+            ...upload,
+            stage: 'uploaded',
+            filename,
+            attemptCount: 0,
+            nextAttemptAt: Date.now(),
+            lastError: null,
+            updatedAt: Date.now(),
+          }
+        : upload
+    );
+    mocks.observer?.(mocks.queue);
+  },
   observeDebateRecordingUploads: () => ({
     subscribe: ({ next }: { next: (uploads: DebateRecordingUpload[]) => void }) => {
       mocks.observer = next;
@@ -65,7 +81,21 @@ vi.mock('./recording-upload-queue', async importOriginal => ({
       return { unsubscribe: () => (mocks.observer = null) };
     },
   }),
-  scheduleDebateRecordingRetry: mocks.scheduleRetry,
+  scheduleDebateRecordingRetry: async (id: string, error: unknown, nextAttemptAt: number) => {
+    await mocks.scheduleRetry(id, error, nextAttemptAt);
+    mocks.queue = mocks.queue.map(upload =>
+      upload.id === id
+        ? {
+            ...upload,
+            attemptCount: upload.attemptCount + 1,
+            nextAttemptAt,
+            lastError: error instanceof Error ? error.message : 'Recording upload failed.',
+            updatedAt: Date.now(),
+          }
+        : upload
+    );
+    mocks.observer?.(mocks.queue);
+  },
 }));
 
 beforeEach(() => {
@@ -122,13 +152,23 @@ describe('DebateRecordingUploadCoordinator', () => {
 
   it('waits while offline and resumes when the browser reconnects', async () => {
     Object.defineProperty(navigator, 'onLine', { configurable: true, value: false });
-    mocks.queue = [queuedRecording('debate-1')];
+    mocks.queue = [
+      {
+        ...queuedRecording('debate-1'),
+        attemptCount: 2,
+        nextAttemptAt: Date.now() + 60_000,
+        lastError: 'stale upload failure',
+      },
+    ];
 
     render(<DebateRecordingUploadCoordinator />);
 
-    expect(await screen.findByText('Waiting to upload 1 debate')).toBeInTheDocument();
+    expect(await screen.findByText('Waiting to upload 1 debate — waiting for a connection')).toBeInTheDocument();
+    expect(screen.queryByText(/stale upload failure/)).not.toBeInTheDocument();
     expect(mocks.createUpload).not.toHaveBeenCalled();
 
+    mocks.queue = mocks.queue.map(upload => ({ ...upload, nextAttemptAt: 0 }));
+    mocks.observer?.(mocks.queue);
     Object.defineProperty(navigator, 'onLine', { configurable: true, value: true });
     window.dispatchEvent(new Event('online'));
 
@@ -147,6 +187,7 @@ describe('DebateRecordingUploadCoordinator', () => {
     await waitFor(() =>
       expect(mocks.completeUpload).toHaveBeenCalledWith('debate-1', expect.anything(), expect.anything())
     );
+    expect(screen.getByText('Uploading 2 debates')).toBeInTheDocument();
     expect(mocks.createUpload).not.toHaveBeenCalledWith('debate-2', expect.anything(), expect.anything());
 
     firstCompletion.resolve();
@@ -154,6 +195,109 @@ describe('DebateRecordingUploadCoordinator', () => {
     await waitFor(() =>
       expect(mocks.completeUpload).toHaveBeenCalledWith('debate-2', expect.anything(), expect.anything())
     );
+  });
+
+  it('persists and displays a failed attempt while keeping it queued for automatic retry', async () => {
+    const error = new Error('Finalization unavailable');
+    const warning = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    mocks.completeUpload.mockRejectedValueOnce(error);
+    mocks.queue = [queuedRecording('debate-1')];
+
+    render(<DebateRecordingUploadCoordinator />);
+
+    await waitFor(() => expect(mocks.scheduleRetry).toHaveBeenCalledOnce());
+    expect(
+      screen.getByText('Waiting to upload 1 debate — Finalization unavailable. Retrying automatically.')
+    ).toBeInTheDocument();
+    expect(mocks.deleteUpload).not.toHaveBeenCalled();
+    expect(warning).toHaveBeenCalledWith(
+      '[DebateRecordingUploadCoordinator] upload attempt failed:',
+      expect.objectContaining({
+        debateId: 'debate-1',
+        stage: 'uploaded',
+        attemptCount: 1,
+        nextAttemptAt: expect.any(Number),
+        error,
+      })
+    );
+  });
+
+  it('shows a persisted failure immediately on startup without changing the queue entry', async () => {
+    const persisted = {
+      ...queuedRecording('debate-1'),
+      attemptCount: 4,
+      nextAttemptAt: Date.now() + 60_000,
+      lastError: 'Upload authorization expired',
+    };
+    mocks.queue = [persisted];
+
+    render(<DebateRecordingUploadCoordinator />);
+
+    expect(
+      await screen.findByText('Waiting to upload 1 debate — Upload authorization expired. Retrying automatically.')
+    ).toBeInTheDocument();
+    expect(mocks.queue[0]).toBe(persisted);
+    expect(mocks.createUpload).not.toHaveBeenCalled();
+  });
+
+  it('shows the newest failure while preserving the aggregate queue count', async () => {
+    mocks.queue = [
+      {
+        ...queuedRecording('debate-1'),
+        nextAttemptAt: Date.now() + 60_000,
+        lastError: 'Older failure',
+        updatedAt: 100,
+      },
+      {
+        ...queuedRecording('debate-2'),
+        nextAttemptAt: Date.now() + 60_000,
+        lastError: 'Newest failure',
+        updatedAt: 200,
+      },
+    ];
+
+    render(<DebateRecordingUploadCoordinator />);
+
+    expect(
+      await screen.findByText('Waiting to upload 2 debates — Newest failure. Retrying automatically.')
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/Older failure/)).not.toBeInTheDocument();
+  });
+
+  it('removes the diagnostic banner after a later retry succeeds', async () => {
+    mocks.completeUpload.mockRejectedValueOnce(new Error('Temporary failure')).mockResolvedValue(undefined);
+    mocks.queue = [queuedRecording('debate-1')];
+
+    render(<DebateRecordingUploadCoordinator />);
+
+    expect(
+      await screen.findByText('Waiting to upload 1 debate — Temporary failure. Retrying automatically.')
+    ).toBeInTheDocument();
+
+    mocks.queue = mocks.queue.map(upload => ({ ...upload, nextAttemptAt: 0 }));
+    mocks.observer?.(mocks.queue);
+
+    await waitFor(() => expect(mocks.completeUpload).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(screen.queryByRole('status')).not.toBeInTheDocument());
+  });
+
+  it('keeps retrying entries with very high attempt counts', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    mocks.completeUpload.mockRejectedValueOnce(new Error('Still unavailable'));
+    mocks.queue = [
+      {
+        ...queuedRecording('debate-1'),
+        stage: 'uploaded',
+        filename: 'recordings/debate-1.webm',
+        attemptCount: 1_000,
+      },
+    ];
+
+    render(<DebateRecordingUploadCoordinator />);
+
+    await waitFor(() => expect(mocks.scheduleRetry).toHaveBeenCalledOnce());
+    expect(mocks.queue[0]?.attemptCount).toBe(1_001);
+    expect(mocks.deleteUpload).not.toHaveBeenCalled();
   });
 
   it('cancels the upload and drops the local blob when publish is unchecked', async () => {

--- a/apps/web/core/debates/recording-upload-coordinator.integration.test.tsx
+++ b/apps/web/core/debates/recording-upload-coordinator.integration.test.tsx
@@ -142,6 +142,11 @@ describe('DebateRecordingUploadCoordinator', () => {
     render(<DebateRecordingUploadCoordinator />);
 
     await waitFor(() => expect(mocks.completeUpload).toHaveBeenCalledOnce());
+    expect(mocks.completeUpload).toHaveBeenCalledWith(
+      'debate-1',
+      expect.objectContaining({ framerate: 29.97 }),
+      expect.anything()
+    );
     expect(mocks.lockRequest).toHaveBeenCalledWith(
       'geo:debate-recording-uploader',
       { ifAvailable: true },
@@ -342,7 +347,7 @@ function queuedRecording(debateId: string): DebateRecordingUpload {
     byteSize: 9,
     width: null,
     height: null,
-    framerate: null,
+    framerate: 29.97,
     videoBitsPerSecond: null,
     stage: 'queued',
     filename: null,

--- a/apps/web/core/debates/recording-upload-coordinator.test.tsx
+++ b/apps/web/core/debates/recording-upload-coordinator.test.tsx
@@ -37,6 +37,7 @@ describe('debate recording uploader', () => {
         byte_size: upload.blob.size,
         started_at_ms: 1_000,
         ended_at_ms: 11_000,
+        framerate: 29.97,
       })
     );
     expect(dependencies.deleteUpload).toHaveBeenCalledWith(upload.id);
@@ -224,7 +225,7 @@ function queuedRecording(): DebateRecordingUpload {
     byteSize: 9,
     width: null,
     height: null,
-    framerate: null,
+    framerate: 29.97,
     videoBitsPerSecond: null,
     stage: 'queued',
     filename: null,

--- a/apps/web/core/debates/recording-upload-coordinator.test.tsx
+++ b/apps/web/core/debates/recording-upload-coordinator.test.tsx
@@ -75,34 +75,111 @@ describe('debate recording uploader', () => {
     expect(recordingUploadRetryDelay(0)).toBe(5_000);
     expect(recordingUploadRetryDelay(1)).toBe(10_000);
     expect(recordingUploadRetryDelay(12)).toBe(300_000);
+    expect(recordingUploadRetryDelay(1_000)).toBe(300_000);
   });
 });
 
 describe('DebateRecordingUploadBanner', () => {
   it('shows the upload count with the publish checkbox checked', () => {
-    render(<DebateRecordingUploadBanner count={1} waiting={false} publishChecked onUncheckPublish={() => undefined} />);
+    render(
+      <DebateRecordingUploadBanner
+        count={1}
+        waitingReason={null}
+        errorMessage={null}
+        publishChecked
+        onUncheckPublish={() => undefined}
+      />
+    );
 
     expect(screen.getByText('Uploading 1 debate')).toBeInTheDocument();
     expect(screen.getByRole('checkbox', { name: 'Publish debate' })).toHaveAttribute('aria-checked', 'true');
   });
 
-  it('shows plural waiting copy while offline or backing off', () => {
-    render(<DebateRecordingUploadBanner count={2} waiting publishChecked onUncheckPublish={() => undefined} />);
+  it('shows generic plural waiting copy when no reason is available', () => {
+    render(
+      <DebateRecordingUploadBanner
+        count={2}
+        waitingReason="waiting"
+        errorMessage={null}
+        publishChecked
+        onUncheckPublish={() => undefined}
+      />
+    );
 
     expect(screen.getByText('Waiting to upload 2 debates')).toBeInTheDocument();
+  });
+
+  it('explains that offline uploads are waiting for a connection', () => {
+    render(
+      <DebateRecordingUploadBanner
+        count={1}
+        waitingReason="offline"
+        errorMessage="stale upload failure"
+        publishChecked
+        onUncheckPublish={() => undefined}
+      />
+    );
+
+    expect(screen.getByText('Waiting to upload 1 debate — waiting for a connection')).toBeInTheDocument();
+    expect(screen.queryByText(/stale upload failure/)).not.toBeInTheDocument();
+  });
+
+  it('shows the latest failure and says retries are automatic', () => {
+    render(
+      <DebateRecordingUploadBanner
+        count={2}
+        waitingReason="retry"
+        errorMessage="Finalization unavailable"
+        publishChecked
+        onUncheckPublish={() => undefined}
+      />
+    );
+
+    expect(
+      screen.getByText('Waiting to upload 2 debates — Finalization unavailable. Retrying automatically.')
+    ).toBeInTheDocument();
+  });
+
+  it('keeps long failure text in the live region while visually truncating it', () => {
+    const longError = `Upload failed: ${'connection reset '.repeat(30)}`.trim();
+    render(
+      <DebateRecordingUploadBanner
+        count={1}
+        waitingReason="retry"
+        errorMessage={longError}
+        publishChecked
+        onUncheckPublish={() => undefined}
+      />
+    );
+
+    const message = `Waiting to upload 1 debate — ${longError}. Retrying automatically.`;
+    expect(screen.getByRole('status')).toHaveTextContent(message);
+    expect(screen.getByText(message)).toHaveClass('truncate');
   });
 
   it('asks to cancel only when unchecking a checked publish box', () => {
     const uncheck = vi.fn();
     const { rerender } = render(
-      <DebateRecordingUploadBanner count={1} waiting={false} publishChecked onUncheckPublish={uncheck} />
+      <DebateRecordingUploadBanner
+        count={1}
+        waitingReason={null}
+        errorMessage={null}
+        publishChecked
+        onUncheckPublish={uncheck}
+      />
     );
 
     fireEvent.click(screen.getByRole('checkbox', { name: 'Publish debate' }));
     expect(uncheck).toHaveBeenCalledOnce();
 
     rerender(
-      <DebateRecordingUploadBanner count={1} waiting={false} publishChecked={false} onUncheckPublish={uncheck} />
+      <DebateRecordingUploadBanner
+        count={1}
+        waitingReason={null}
+        errorMessage={null}
+        publishChecked={false}
+        onUncheckPublish={uncheck}
+      />
     );
     fireEvent.click(screen.getByRole('checkbox', { name: 'Publish debate' }));
     expect(uncheck).toHaveBeenCalledOnce();

--- a/apps/web/core/debates/recording-upload-coordinator.test.tsx
+++ b/apps/web/core/debates/recording-upload-coordinator.test.tsx
@@ -43,6 +43,29 @@ describe('debate recording uploader', () => {
     expect(dependencies.deleteUpload).toHaveBeenCalledWith(upload.id);
   });
 
+  it('rounds fractional timestamps from a persisted queue entry', async () => {
+    const upload = {
+      ...queuedRecording(),
+      startedAtMs: 1_784_542_272_505.1,
+      endedAtMs: 1_784_542_282_505.6,
+    };
+    const dependencies = uploadDependencies();
+
+    await processDebateRecordingUpload(upload, dependencies);
+
+    expect(dependencies.createUpload).toHaveBeenCalledWith(
+      upload.debateId,
+      expect.objectContaining({ started_at_ms: 1_784_542_272_505 })
+    );
+    expect(dependencies.completeUpload).toHaveBeenCalledWith(
+      upload.debateId,
+      expect.objectContaining({
+        started_at_ms: 1_784_542_272_505,
+        ended_at_ms: 1_784_542_282_506,
+      })
+    );
+  });
+
   it('retries only finalization after the object upload was persisted', async () => {
     const upload = {
       ...queuedRecording(),

--- a/apps/web/core/debates/recording-upload-coordinator.tsx
+++ b/apps/web/core/debates/recording-upload-coordinator.tsx
@@ -36,6 +36,8 @@ import {
 const initialRetryDelayMs = 5_000;
 const maxRetryDelayMs = 5 * 60_000;
 
+type DebateRecordingUploadWaitingReason = 'offline' | 'retry' | 'waiting' | null;
+
 type RecordingUploadDependencies = {
   createUpload: (debateId: string, request: LocalRecordingUploadRequest) => Promise<LocalRecordingUploadResponse>;
   putRecording: (upload: LocalRecordingUploadResponse['upload'], blob: Blob, mimeType: string) => Promise<void>;
@@ -190,10 +192,21 @@ export function DebateRecordingUploadCoordinator() {
     activeUploadIdRef.current = upload.id;
     setActiveUploadId(upload.id);
     const dependencies = recordingUploadDependencies(getPrivyIdentityToken);
+    let attemptStage = upload.stage;
+    let attemptCount = upload.attemptCount;
     void withRecordingUploadLock(async () => {
       const latestUpload = await getDebateRecordingUpload(upload.id);
       if (!latestUpload || latestUpload.userId !== userId) return;
-      await processDebateRecordingUpload(latestUpload, dependencies);
+      attemptStage = latestUpload.stage;
+      attemptCount = latestUpload.attemptCount;
+      await processDebateRecordingUpload(latestUpload, {
+        ...dependencies,
+        markUploaded: async (id, filename) => {
+          await dependencies.markUploaded(id, filename);
+          attemptStage = 'uploaded';
+          attemptCount = 0;
+        },
+      });
       void queryClient.invalidateQueries({ queryKey: debateQueryKeys.debate(upload.debateId) });
       void queryClient.invalidateQueries({ queryKey: debateQueryKeys.media(upload.debateId) });
     })
@@ -215,6 +228,14 @@ export function DebateRecordingUploadCoordinator() {
           return;
         }
         const nextAttemptAt = Date.now() + recordingUploadRetryDelay(upload.attemptCount);
+        console.warn('[DebateRecordingUploadCoordinator] upload attempt failed:', {
+          uploadId: upload.id,
+          debateId: upload.debateId,
+          stage: attemptStage,
+          attemptCount: attemptCount + 1,
+          nextAttemptAt,
+          error,
+        });
         try {
           await scheduleDebateRecordingRetry(upload.id, error, nextAttemptAt);
         } catch (queueError) {
@@ -231,6 +252,16 @@ export function DebateRecordingUploadCoordinator() {
   }, [activeUploadId, getPrivyIdentityToken, online, queryClient, uploads, userId, wakeAt]);
 
   const waiting = !online || (!activeUploadId && uploads.every(upload => upload.nextAttemptAt > Date.now()));
+  const latestFailedUpload = uploads.reduce<DebateRecordingUpload | null>((latest, upload) => {
+    if (!upload.lastError) return latest;
+    return !latest || upload.updatedAt > latest.updatedAt ? upload : latest;
+  }, null);
+  let waitingReason: DebateRecordingUploadWaitingReason = null;
+  if (!online) {
+    waitingReason = 'offline';
+  } else if (waiting) {
+    waitingReason = latestFailedUpload ? 'retry' : 'waiting';
+  }
 
   // Only poll debate activity while a banner might show, and hide it while the user is in a
   // live debate — the upload keeps running, it just shouldn't be on screen mid-debate.
@@ -281,7 +312,8 @@ export function DebateRecordingUploadCoordinator() {
     <>
       <DebateRecordingUploadBanner
         count={uploads.length}
-        waiting={waiting}
+        waitingReason={waitingReason}
+        errorMessage={latestFailedUpload?.lastError ?? null}
         publishChecked={!cancelPromptOpen}
         onUncheckPublish={() => setCancelPromptOpen(true)}
       />
@@ -299,24 +331,41 @@ export function DebateRecordingUploadCoordinator() {
 
 export function DebateRecordingUploadBanner({
   count,
-  waiting,
+  waitingReason,
+  errorMessage,
   publishChecked,
   onUncheckPublish,
 }: {
   count: number;
-  waiting: boolean;
+  waitingReason: DebateRecordingUploadWaitingReason;
+  errorMessage: string | null;
   publishChecked: boolean;
   onUncheckPublish: () => void;
 }) {
   const label = `${count} debate${count === 1 ? '' : 's'}`;
+  let message = `Uploading ${label}`;
+  if (waitingReason === 'offline') {
+    message = `Waiting to upload ${label} — waiting for a connection`;
+  } else if (waitingReason === 'retry' && errorMessage) {
+    const failure = errorMessage.trim();
+    const punctuation = /[.!?]$/.test(failure) ? '' : '.';
+    message = `Waiting to upload ${label} — ${failure}${punctuation} Retrying automatically.`;
+  } else if (waitingReason) {
+    message = `Waiting to upload ${label}`;
+  }
+
   return (
     <div
       role="status"
       aria-live="polite"
-      className={`fixed inset-x-0 bottom-0 flex items-center justify-center gap-2 bg-divider px-4 py-2 text-metadata text-grey-04 ${Z_LAYER_CLASS.toast}`}
+      className={`fixed inset-x-0 bottom-0 flex min-w-0 items-center justify-center gap-2 bg-divider px-4 py-2 text-metadata text-grey-04 ${Z_LAYER_CLASS.toast}`}
     >
-      <span>{waiting ? `Waiting to upload ${label}` : `Uploading ${label}`}</span>
-      <span aria-hidden="true">·</span>
+      <span className="min-w-0 truncate">
+        {message}
+      </span>
+      <span aria-hidden="true" className="shrink-0">
+        ·
+      </span>
       <button
         type="button"
         role="checkbox"
@@ -325,7 +374,7 @@ export function DebateRecordingUploadBanner({
         onClick={() => {
           if (publishChecked) onUncheckPublish();
         }}
-        className="inline-flex items-center gap-1.5 text-text"
+        className="inline-flex shrink-0 items-center gap-1.5 text-text"
       >
         Publish
         <span

--- a/apps/web/core/debates/recording-upload-coordinator.tsx
+++ b/apps/web/core/debates/recording-upload-coordinator.tsx
@@ -50,11 +50,13 @@ export async function processDebateRecordingUpload(
   upload: DebateRecordingUpload,
   dependencies: RecordingUploadDependencies
 ) {
+  const startedAtMs = Math.round(upload.startedAtMs);
+  const endedAtMs = Math.round(upload.endedAtMs);
   let filename = upload.filename;
   if (upload.stage === 'queued' || !filename) {
     const target = await dependencies.createUpload(upload.debateId, {
       mime_type: upload.mimeType,
-      started_at_ms: upload.startedAtMs,
+      started_at_ms: startedAtMs,
     });
     await dependencies.putRecording(target.upload, upload.blob, upload.mimeType);
     filename = target.filename;
@@ -64,8 +66,8 @@ export async function processDebateRecordingUpload(
   await dependencies.completeUpload(upload.debateId, {
     filename,
     mime_type: upload.mimeType,
-    started_at_ms: upload.startedAtMs,
-    ended_at_ms: upload.endedAtMs,
+    started_at_ms: startedAtMs,
+    ended_at_ms: endedAtMs,
     duration_seconds: upload.durationSeconds,
     byte_size: upload.byteSize,
     width: upload.width,


### PR DESCRIPTION
## Summary

Recording upload failures now explain what is blocking them, and queued browser recordings preserve fractional frame rates such as `29.97` so they can recover automatically once the matching API release is deployed. Structured API errors keep their code and message, Axum plain-text extraction failures are shown verbatim, and empty responses fall back to the HTTP status.

The uploader now rounds `startedAtMs` and `endedAtMs` at the network boundary. This repairs existing IndexedDB entries created from the synchronized fractional browser clock on their next retry, while leaving persisted queue data and retry behavior unchanged. The matching API change also accepts and normalizes fractional timestamps for defense in depth and future native clients.

Offline queues still take precedence over stale failures, multi-debate queues keep their aggregate count, and existing persisted errors reappear after restart. Retry attempts remain unbounded with the existing exponential backoff capped at five minutes; Publish and cancellation behavior are unchanged.

Session-settled decisions carried from planning: unbounded automatic retries (user-directed, over bounded retries); diagnostics-only recovery UI (user-directed, over adding a manual Retry action or redesigning Publish).

## Testing

- Targeted upload coordinator and API error tests passed, including a persisted fractional-timestamp regression
- Complete web suite: 1,391 passed
- Web lint: passed with no errors (81 pre-existing unrelated warnings)

## Post-Deploy Monitoring & Validation

- Search browser diagnostics for `[DebateRecordingUploadCoordinator] upload attempt failed:` and confirm entries include debate, stage, attempt count, next retry time, and the original error.
- After the matching backend release is deployed, allow the two queued recordings to retry and confirm they disappear from the banner without manual intervention.
- Healthy signals: `29.97` remains unchanged, recording timestamps are sent as integer milliseconds, failed recordings remain queued at the expected cadence, and successful retries remove the banner.
- Failure signals: continued `422` frame-rate or timestamp extraction errors, retries faster than the five-minute cap, errors disappearing while queued, or a banner remaining after success.
- Validation window and owner: first 24 hours after the coordinated backend and web deployment; web/debates owner.
- Mitigation: keep the backend maintenance pause in place if the API contract is not ready; revert the web commit if error parsing or queue cleanup regresses.
