### PR TITLE
feat(debates): replace polling with gateway invalidations

### DIFF
--- a/apps/web/core/debates/api.test.ts
+++ b/apps/web/core/debates/api.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { GeoChatRequestError, completeLocalRecordingUpload } from './api';
+import { GeoChatRequestError, completeLocalRecordingUpload, getGeoChatSession } from './api';
 
 const completeRequest = {
   filename: 'recordings/debate-1/recording.webm',
@@ -84,5 +84,43 @@ describe('geo-chat request errors', () => {
       code: null,
       status: 503,
     });
+  });
+});
+
+describe('geo-chat session sharing', () => {
+  it('exposes the fresh session and its expiry to websocket callers', async () => {
+    await expect(getGeoChatSession(vi.fn())).resolves.toEqual({
+      access_token: 'access-token',
+      refresh_token: 'refresh-token',
+      expires_at: expect.any(String),
+    });
+  });
+
+  it('refreshes one session for concurrent callers when expiry is near', async () => {
+    window.localStorage.setItem(
+      'geo:chat-session',
+      JSON.stringify({
+        access_token: 'stale-access-token',
+        refresh_token: 'refresh-token',
+        expires_at: new Date(Date.now() + 10_000).toISOString(),
+      })
+    );
+    const fetch = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          access_token: 'fresh-access-token',
+          refresh_token: 'fresh-refresh-token',
+          expires_at: new Date(Date.now() + 60_000).toISOString(),
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
+    );
+    vi.stubGlobal('fetch', fetch);
+
+    const [first, second] = await Promise.all([getGeoChatSession(vi.fn()), getGeoChatSession(vi.fn())]);
+
+    expect(first.access_token).toBe('fresh-access-token');
+    expect(second.access_token).toBe('fresh-access-token');
+    expect(fetch).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/core/debates/api.test.ts
+++ b/apps/web/core/debates/api.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { GeoChatRequestError, completeLocalRecordingUpload, getGeoChatSession, resetGeoChatSession } from './api';
+import {
+  GeoChatRequestError,
+  completeLocalRecordingUpload,
+  getDebateActivity,
+  getGeoChatSession,
+  resetGeoChatSession,
+} from './api';
 
 const completeRequest = {
   filename: 'recordings/debate-1/recording.webm',
@@ -46,7 +52,7 @@ describe('geo-chat request errors', () => {
       )
     );
 
-    await expect(completeLocalRecordingUpload('debate-1', completeRequest, vi.fn())).rejects.toMatchObject({
+    await expect(completeLocalRecordingUpload('debate-1', completeRequest, vi.fn(), 'user-a')).rejects.toMatchObject({
       name: 'GeoChatRequestError',
       message: 'Invalid frame rate',
       code: 'invalid_recording',
@@ -66,7 +72,7 @@ describe('geo-chat request errors', () => {
       )
     );
 
-    await expect(completeLocalRecordingUpload('debate-1', completeRequest, vi.fn())).rejects.toMatchObject({
+    await expect(completeLocalRecordingUpload('debate-1', completeRequest, vi.fn(), 'user-a')).rejects.toMatchObject({
       message: 'Failed to deserialize the JSON body: framerate must be a number',
       code: null,
       status: 422,
@@ -84,7 +90,7 @@ describe('geo-chat request errors', () => {
       )
     );
 
-    await expect(completeLocalRecordingUpload('debate-1', completeRequest, vi.fn())).rejects.toMatchObject({
+    await expect(completeLocalRecordingUpload('debate-1', completeRequest, vi.fn(), 'user-a')).rejects.toMatchObject({
       message: '503 Service Unavailable',
       code: null,
       status: 503,
@@ -99,6 +105,15 @@ describe('geo-chat session sharing', () => {
       refresh_token: 'refresh-token',
       expires_at: expect.any(String),
     });
+  });
+
+  it('never reuses a stored account when an authenticated request has no current account', async () => {
+    const fetch = vi.fn();
+    vi.stubGlobal('fetch', fetch);
+
+    await expect(getDebateActivity(vi.fn(), null)).rejects.toThrow('Sign in to use debates.');
+
+    expect(fetch).not.toHaveBeenCalled();
   });
 
   it('refreshes one session for concurrent callers when expiry is near', async () => {
@@ -167,6 +182,46 @@ describe('geo-chat session sharing', () => {
     });
   });
 
+  it('uses the current account session for authenticated REST requests', async () => {
+    const fetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            access_token: 'user-b-access-token',
+            refresh_token: 'user-b-refresh-token',
+            expires_at: new Date(Date.now() + 60_000).toISOString(),
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ recording: {}, debate: {} }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      );
+    vi.stubGlobal('fetch', fetch);
+
+    await completeLocalRecordingUpload(
+      'debate-1',
+      completeRequest,
+      vi.fn(async () => 'user-b-identity-token'),
+      'user-b'
+    );
+
+    expect(fetch).toHaveBeenNthCalledWith(
+      1,
+      'http://localhost:8080/auth/session',
+      expect.objectContaining({ headers: { Authorization: 'Bearer user-b-identity-token' } })
+    );
+    expect(fetch).toHaveBeenNthCalledWith(
+      2,
+      'http://localhost:8080/debates/debate-1/recordings/local-upload-complete',
+      expect.objectContaining({ headers: expect.objectContaining({ Authorization: 'Bearer user-b-access-token' }) })
+    );
+  });
+
   it('retires an in-flight exchange when the account changes', async () => {
     resetGeoChatSession();
     let resolveFirst!: (response: Response) => void;
@@ -215,9 +270,13 @@ describe('geo-chat session sharing', () => {
   it('times out a stalled session exchange', async () => {
     resetGeoChatSession();
     vi.useFakeTimers();
+    let requestSignal: AbortSignal | null = null;
     vi.stubGlobal(
       'fetch',
-      vi.fn(() => new Promise<Response>(() => undefined))
+      vi.fn((_input: RequestInfo | URL, init?: RequestInit) => {
+        requestSignal = init?.signal ?? null;
+        return new Promise<Response>(() => undefined);
+      })
     );
 
     const result = expect(
@@ -229,5 +288,6 @@ describe('geo-chat session sharing', () => {
     await vi.advanceTimersByTimeAsync(10_000);
 
     await result;
+    expect((requestSignal as AbortSignal | null)?.aborted).toBe(true);
   });
 });

--- a/apps/web/core/debates/api.test.ts
+++ b/apps/web/core/debates/api.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { GeoChatRequestError, completeLocalRecordingUpload, getGeoChatSession } from './api';
+import { GeoChatRequestError, completeLocalRecordingUpload, getGeoChatSession, resetGeoChatSession } from './api';
 
 const completeRequest = {
   filename: 'recordings/debate-1/recording.webm',
@@ -13,19 +13,24 @@ const completeRequest = {
 };
 
 beforeEach(() => {
+  resetGeoChatSession();
   window.localStorage.setItem(
     'geo:chat-session',
     JSON.stringify({
-      access_token: 'access-token',
-      refresh_token: 'refresh-token',
-      expires_at: new Date(Date.now() + 60_000).toISOString(),
+      account_key: 'user-a',
+      session: {
+        access_token: 'access-token',
+        refresh_token: 'refresh-token',
+        expires_at: new Date(Date.now() + 60_000).toISOString(),
+      },
     })
   );
 });
 
 afterEach(() => {
-  window.localStorage.clear();
+  resetGeoChatSession();
   vi.unstubAllGlobals();
+  vi.useRealTimers();
 });
 
 describe('geo-chat request errors', () => {
@@ -89,7 +94,7 @@ describe('geo-chat request errors', () => {
 
 describe('geo-chat session sharing', () => {
   it('exposes the fresh session and its expiry to websocket callers', async () => {
-    await expect(getGeoChatSession(vi.fn())).resolves.toEqual({
+    await expect(getGeoChatSession(vi.fn(), 'user-a')).resolves.toEqual({
       access_token: 'access-token',
       refresh_token: 'refresh-token',
       expires_at: expect.any(String),
@@ -100,9 +105,12 @@ describe('geo-chat session sharing', () => {
     window.localStorage.setItem(
       'geo:chat-session',
       JSON.stringify({
-        access_token: 'stale-access-token',
-        refresh_token: 'refresh-token',
-        expires_at: new Date(Date.now() + 10_000).toISOString(),
+        account_key: 'user-a',
+        session: {
+          access_token: 'stale-access-token',
+          refresh_token: 'refresh-token',
+          expires_at: new Date(Date.now() + 10_000).toISOString(),
+        },
       })
     );
     const fetch = vi.fn().mockResolvedValue(
@@ -117,10 +125,109 @@ describe('geo-chat session sharing', () => {
     );
     vi.stubGlobal('fetch', fetch);
 
-    const [first, second] = await Promise.all([getGeoChatSession(vi.fn()), getGeoChatSession(vi.fn())]);
+    const [first, second] = await Promise.all([
+      getGeoChatSession(vi.fn(), 'user-a'),
+      getGeoChatSession(vi.fn(), 'user-a'),
+    ]);
 
     expect(first.access_token).toBe('fresh-access-token');
     expect(second.access_token).toBe('fresh-access-token');
     expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not reuse a stored session owned by another account', async () => {
+    const fetch = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          access_token: 'user-b-access-token',
+          refresh_token: 'user-b-refresh-token',
+          expires_at: new Date(Date.now() + 60_000).toISOString(),
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
+    );
+    vi.stubGlobal('fetch', fetch);
+
+    await expect(
+      getGeoChatSession(
+        vi.fn(async () => 'user-b-identity-token'),
+        'user-b'
+      )
+    ).resolves.toMatchObject({
+      access_token: 'user-b-access-token',
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      'http://localhost:8080/auth/session',
+      expect.objectContaining({ headers: { Authorization: 'Bearer user-b-identity-token' } })
+    );
+    expect(JSON.parse(window.localStorage.getItem('geo:chat-session')!)).toMatchObject({
+      account_key: 'user-b',
+      session: { access_token: 'user-b-access-token' },
+    });
+  });
+
+  it('retires an in-flight exchange when the account changes', async () => {
+    resetGeoChatSession();
+    let resolveFirst!: (response: Response) => void;
+    const fetch = vi
+      .fn()
+      .mockReturnValueOnce(new Promise<Response>(resolve => (resolveFirst = resolve)))
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            access_token: 'user-b-access-token',
+            refresh_token: 'user-b-refresh-token',
+            expires_at: new Date(Date.now() + 60_000).toISOString(),
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        )
+      );
+    vi.stubGlobal('fetch', fetch);
+
+    const first = getGeoChatSession(
+      vi.fn(async () => 'user-a-identity-token'),
+      'user-a'
+    );
+    await vi.waitFor(() => expect(fetch).toHaveBeenCalledTimes(1));
+    const second = getGeoChatSession(
+      vi.fn(async () => 'user-b-identity-token'),
+      'user-b'
+    );
+    await expect(second).resolves.toMatchObject({ access_token: 'user-b-access-token' });
+
+    resolveFirst(
+      new Response(
+        JSON.stringify({
+          access_token: 'user-a-access-token',
+          refresh_token: 'user-a-refresh-token',
+          expires_at: new Date(Date.now() + 60_000).toISOString(),
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
+    );
+    await expect(first).rejects.toThrow('Geo Chat session changed');
+    expect(JSON.parse(window.localStorage.getItem('geo:chat-session')!)).toMatchObject({
+      account_key: 'user-b',
+    });
+  });
+
+  it('times out a stalled session exchange', async () => {
+    resetGeoChatSession();
+    vi.useFakeTimers();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => new Promise<Response>(() => undefined))
+    );
+
+    const result = expect(
+      getGeoChatSession(
+        vi.fn(async () => 'identity-token'),
+        'user-a'
+      )
+    ).rejects.toThrow('Geo Chat session request timed out.');
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    await result;
   });
 });

--- a/apps/web/core/debates/api.ts
+++ b/apps/web/core/debates/api.ts
@@ -365,6 +365,8 @@ type RequestOptions = {
   body?: unknown;
   auth?: boolean | 'optional';
   getPrivyIdentityToken?: GetPrivyIdentityToken;
+  accountKey?: string | null;
+  signal?: AbortSignal;
 };
 
 const geoChatSessionStorageKey = 'geo:chat-session';
@@ -392,34 +394,53 @@ export async function getServerTime() {
   return geoChatRequest<{ server_time_ms: number }>('/time');
 }
 
-export async function resolveCurrentGeoChatUserId(getPrivyIdentityToken: GetPrivyIdentityToken) {
-  const accessToken = await getGeoChatAccessToken(getPrivyIdentityToken);
+export async function resolveCurrentGeoChatUserId(
+  getPrivyIdentityToken: GetPrivyIdentityToken,
+  accountKey: string | null
+) {
+  const accessToken = await getGeoChatAccessToken(getPrivyIdentityToken, accountKey);
   return decodeGeoChatAccessToken(accessToken)?.user_id ?? null;
 }
 
-export async function getDebateActivity(getPrivyIdentityToken: GetPrivyIdentityToken) {
+export async function getDebateActivity(
+  getPrivyIdentityToken: GetPrivyIdentityToken,
+  accountKey: string | null,
+  signal?: AbortSignal
+) {
   return geoChatRequest<DebateActivity>('/me/debate-activity', {
     auth: true,
     getPrivyIdentityToken,
+    accountKey,
+    signal,
   });
 }
 
-export async function listDebateSharePrompts(getPrivyIdentityToken: GetPrivyIdentityToken) {
+export async function listDebateSharePrompts(
+  getPrivyIdentityToken: GetPrivyIdentityToken,
+  accountKey: string | null,
+  signal?: AbortSignal
+) {
   return geoChatRequest<DebateSharePromptsResponse>('/me/debate-share-prompts', {
     auth: true,
     getPrivyIdentityToken,
+    accountKey,
+    signal,
   });
 }
 
 export async function listDebateClaims(
   spaceId: string,
   claimIds: string[],
-  getPrivyIdentityToken?: GetPrivyIdentityToken
+  getPrivyIdentityToken?: GetPrivyIdentityToken,
+  accountKey?: string | null,
+  signal?: AbortSignal
 ) {
   const query = claimIds.length > 0 ? `?claim_ids=${encodeURIComponent(claimIds.join(','))}` : '';
   return geoChatRequest<DebateClaimsResponse>(`/spaces/${spaceId}/debate-claims${query}`, {
     auth: 'optional',
     getPrivyIdentityToken,
+    accountKey,
+    signal,
   });
 }
 
@@ -427,21 +448,29 @@ export async function joinDebateQueue(
   spaceId: string,
   claimId: string,
   request: JoinDebateQueueRequest,
-  getPrivyIdentityToken: GetPrivyIdentityToken
+  getPrivyIdentityToken: GetPrivyIdentityToken,
+  accountKey: string | null
 ) {
   return geoChatRequest<JoinDebateQueueResponse>(`/spaces/${spaceId}/claims/${claimId}/debate-queue`, {
     method: 'POST',
     body: request,
     auth: true,
     getPrivyIdentityToken,
+    accountKey,
   });
 }
 
-export async function leaveDebateQueue(spaceId: string, claimId: string, getPrivyIdentityToken: GetPrivyIdentityToken) {
+export async function leaveDebateQueue(
+  spaceId: string,
+  claimId: string,
+  getPrivyIdentityToken: GetPrivyIdentityToken,
+  accountKey: string | null
+) {
   return geoChatRequest<JoinDebateQueueResponse>(`/spaces/${spaceId}/claims/${claimId}/debate-queue`, {
     method: 'DELETE',
     auth: true,
     getPrivyIdentityToken,
+    accountKey,
   });
 }
 
@@ -449,19 +478,22 @@ export async function updateDebatePreference(
   spaceId: string,
   claimId: string,
   request: JoinDebateQueueRequest,
-  getPrivyIdentityToken: GetPrivyIdentityToken
+  getPrivyIdentityToken: GetPrivyIdentityToken,
+  accountKey: string | null
 ) {
   return geoChatRequest<JoinDebateQueueResponse>(`/spaces/${spaceId}/claims/${claimId}/debate-preference`, {
     method: 'PUT',
     body: request,
     auth: true,
     getPrivyIdentityToken,
+    accountKey,
   });
 }
 
 export async function acceptDebateMatch(
   matchId: string,
   getPrivyIdentityToken: GetPrivyIdentityToken,
+  accountKey: string | null,
   formatId?: string
 ) {
   return geoChatRequest<MatchActionResponse>(`/debate-matches/${matchId}/accept`, {
@@ -469,103 +501,169 @@ export async function acceptDebateMatch(
     body: { format_id: formatId },
     auth: true,
     getPrivyIdentityToken,
+    accountKey,
   });
 }
 
-export async function declineDebateMatch(matchId: string, getPrivyIdentityToken: GetPrivyIdentityToken) {
+export async function declineDebateMatch(
+  matchId: string,
+  getPrivyIdentityToken: GetPrivyIdentityToken,
+  accountKey: string | null
+) {
   return geoChatRequest<MatchActionResponse>(`/debate-matches/${matchId}/decline`, {
     method: 'POST',
     auth: true,
     getPrivyIdentityToken,
+    accountKey,
   });
 }
 
-export async function listSpaceDebates(spaceId: string, getPrivyIdentityToken?: GetPrivyIdentityToken) {
+export async function listSpaceDebates(
+  spaceId: string,
+  getPrivyIdentityToken?: GetPrivyIdentityToken,
+  accountKey?: string | null,
+  signal?: AbortSignal
+) {
   return geoChatRequest<SpaceDebatesResponse>(`/spaces/${spaceId}/debates`, {
     auth: 'optional',
     getPrivyIdentityToken,
+    accountKey,
+    signal,
   });
 }
 
-export async function getDebate(debateId: string, getPrivyIdentityToken?: GetPrivyIdentityToken) {
+export async function getDebate(
+  debateId: string,
+  getPrivyIdentityToken?: GetPrivyIdentityToken,
+  accountKey?: string | null,
+  signal?: AbortSignal
+) {
   return geoChatRequest<Debate>(`/debates/${debateId}`, {
     auth: 'optional',
     getPrivyIdentityToken,
+    accountKey,
+    signal,
   });
 }
 
-export async function getLiveKitToken(debateId: string, getPrivyIdentityToken: GetPrivyIdentityToken) {
+export async function getLiveKitToken(
+  debateId: string,
+  getPrivyIdentityToken: GetPrivyIdentityToken,
+  accountKey: string | null
+) {
   return geoChatRequest<LiveKitJoinResponse>(`/debates/${debateId}/livekit-token`, {
     method: 'POST',
     auth: true,
     getPrivyIdentityToken,
+    accountKey,
   });
 }
 
-export async function markDebateJoined(debateId: string, getPrivyIdentityToken: GetPrivyIdentityToken) {
+export async function markDebateJoined(
+  debateId: string,
+  getPrivyIdentityToken: GetPrivyIdentityToken,
+  accountKey: string | null
+) {
   return geoChatRequest<Debate>(`/debates/${debateId}/joined`, {
     method: 'POST',
     auth: true,
     getPrivyIdentityToken,
+    accountKey,
   });
 }
 
-export async function markDebateReady(debateId: string, getPrivyIdentityToken: GetPrivyIdentityToken) {
+export async function markDebateReady(
+  debateId: string,
+  getPrivyIdentityToken: GetPrivyIdentityToken,
+  accountKey: string | null
+) {
   return geoChatRequest<Debate>(`/debates/${debateId}/ready`, {
     method: 'POST',
     auth: true,
     getPrivyIdentityToken,
+    accountKey,
   });
 }
 
-export async function abortDebate(debateId: string, getPrivyIdentityToken: GetPrivyIdentityToken) {
+export async function abortDebate(
+  debateId: string,
+  getPrivyIdentityToken: GetPrivyIdentityToken,
+  accountKey: string | null
+) {
   return geoChatRequest<Debate>(`/debates/${debateId}/abort`, {
     method: 'POST',
     auth: true,
     getPrivyIdentityToken,
+    accountKey,
   });
 }
 
-export async function cancelDebateRecording(debateId: string, getPrivyIdentityToken: GetPrivyIdentityToken) {
+export async function cancelDebateRecording(
+  debateId: string,
+  getPrivyIdentityToken: GetPrivyIdentityToken,
+  accountKey: string | null
+) {
   return geoChatRequest<Debate>(`/debates/${debateId}/recordings/cancel`, {
     method: 'POST',
     auth: true,
     getPrivyIdentityToken,
+    accountKey,
   });
 }
 
-export async function consentToDebateRematch(debateId: string, getPrivyIdentityToken: GetPrivyIdentityToken) {
+export async function consentToDebateRematch(
+  debateId: string,
+  getPrivyIdentityToken: GetPrivyIdentityToken,
+  accountKey: string | null
+) {
   return geoChatRequest<DebateRematchSession>(`/debates/${debateId}/rematch/consent`, {
     method: 'POST',
     auth: true,
     getPrivyIdentityToken,
+    accountKey,
   });
 }
 
-export async function getDebateRematch(sessionId: string, getPrivyIdentityToken: GetPrivyIdentityToken) {
+export async function getDebateRematch(
+  sessionId: string,
+  getPrivyIdentityToken: GetPrivyIdentityToken,
+  accountKey: string | null,
+  signal?: AbortSignal
+) {
   return geoChatRequest<DebateRematchSession>(`/debate-rematches/${sessionId}`, {
     auth: true,
     getPrivyIdentityToken,
+    accountKey,
+    signal,
   });
 }
 
-export async function leaveDebateRematch(sessionId: string, getPrivyIdentityToken: GetPrivyIdentityToken) {
+export async function leaveDebateRematch(
+  sessionId: string,
+  getPrivyIdentityToken: GetPrivyIdentityToken,
+  accountKey: string | null
+) {
   return geoChatRequest<DebateRematchSession>(`/debate-rematches/${sessionId}/leave`, {
     method: 'POST',
     auth: true,
     getPrivyIdentityToken,
+    accountKey,
   });
 }
 
 export async function listDebateRematchClaims(
   sessionId: string,
   claimIds: string[],
-  getPrivyIdentityToken: GetPrivyIdentityToken
+  getPrivyIdentityToken: GetPrivyIdentityToken,
+  accountKey: string | null,
+  signal?: AbortSignal
 ) {
   const query = claimIds.length > 0 ? `?claim_ids=${encodeURIComponent(claimIds.join(','))}` : '';
   return geoChatRequest<DebateRematchClaimsResponse>(`/debate-rematches/${sessionId}/claims${query}`, {
     auth: true,
     getPrivyIdentityToken,
+    accountKey,
+    signal,
   });
 }
 
@@ -574,107 +672,137 @@ export async function updateDebateRematchPosition(
   claimId: string,
   position: boolean,
   sourceSpaceId: string,
-  getPrivyIdentityToken: GetPrivyIdentityToken
+  getPrivyIdentityToken: GetPrivyIdentityToken,
+  accountKey: string | null
 ) {
   return geoChatRequest<DebateRematchClaimsResponse>(`/debate-rematches/${sessionId}/claims/${claimId}/position`, {
     method: 'PUT',
     body: { position, source_space_id: sourceSpaceId },
     auth: true,
     getPrivyIdentityToken,
+    accountKey,
   });
 }
 
 export async function createDebateRematchRequest(
   sessionId: string,
   request: { source_space_id: string; claim_id: string; format_id: string },
-  getPrivyIdentityToken: GetPrivyIdentityToken
+  getPrivyIdentityToken: GetPrivyIdentityToken,
+  accountKey: string | null
 ) {
   return geoChatRequest<DebateRematchActionResponse>(`/debate-rematches/${sessionId}/requests`, {
     method: 'POST',
     body: request,
     auth: true,
     getPrivyIdentityToken,
+    accountKey,
   });
 }
 
-export async function acceptDebateRematchRequest(requestId: string, getPrivyIdentityToken: GetPrivyIdentityToken) {
+export async function acceptDebateRematchRequest(
+  requestId: string,
+  getPrivyIdentityToken: GetPrivyIdentityToken,
+  accountKey: string | null
+) {
   return geoChatRequest<DebateRematchActionResponse>(`/debate-rematch-requests/${requestId}/accept`, {
     method: 'POST',
     auth: true,
     getPrivyIdentityToken,
+    accountKey,
   });
 }
 
-export async function rejectDebateRematchRequest(requestId: string, getPrivyIdentityToken: GetPrivyIdentityToken) {
+export async function rejectDebateRematchRequest(
+  requestId: string,
+  getPrivyIdentityToken: GetPrivyIdentityToken,
+  accountKey: string | null
+) {
   return geoChatRequest<DebateRematchActionResponse>(`/debate-rematch-requests/${requestId}/reject`, {
     method: 'POST',
     auth: true,
     getPrivyIdentityToken,
+    accountKey,
   });
 }
 
 export async function handleDebateSharePrompt(
   promptId: string,
   action: 'shared' | 'dismissed',
-  getPrivyIdentityToken: GetPrivyIdentityToken
+  getPrivyIdentityToken: GetPrivyIdentityToken,
+  accountKey: string | null
 ) {
   return geoChatRequest<DebateSharePrompt>(`/debate-share-prompts/${promptId}/handled`, {
     method: 'POST',
     body: { action },
     auth: true,
     getPrivyIdentityToken,
+    accountKey,
   });
 }
 
 export async function createLocalRecordingUpload(
   debateId: string,
   request: LocalRecordingUploadRequest,
-  getPrivyIdentityToken: GetPrivyIdentityToken
+  getPrivyIdentityToken: GetPrivyIdentityToken,
+  accountKey: string | null
 ) {
   return geoChatRequest<LocalRecordingUploadResponse>(`/debates/${debateId}/recordings/local-upload-url`, {
     method: 'POST',
     body: request,
     auth: true,
     getPrivyIdentityToken,
+    accountKey,
   });
 }
 
 export async function completeLocalRecordingUpload(
   debateId: string,
   request: LocalRecordingCompleteRequest,
-  getPrivyIdentityToken: GetPrivyIdentityToken
+  getPrivyIdentityToken: GetPrivyIdentityToken,
+  accountKey: string | null
 ) {
   return geoChatRequest<RecordingCompleteResponse>(`/debates/${debateId}/recordings/local-upload-complete`, {
     method: 'POST',
     body: request,
     auth: true,
     getPrivyIdentityToken,
+    accountKey,
   });
 }
 
 export async function getRecordingUrl(
   debateId: string,
   filename: string,
-  getPrivyIdentityToken?: GetPrivyIdentityToken
+  getPrivyIdentityToken?: GetPrivyIdentityToken,
+  accountKey?: string | null
 ) {
   return geoChatRequest<{ url: string }>(`/debates/${debateId}/recordings/url`, {
     method: 'POST',
     body: { filename },
     auth: 'optional',
     getPrivyIdentityToken,
+    accountKey,
   });
 }
 
-export async function getDebateMedia(debateId: string, getPrivyIdentityToken?: GetPrivyIdentityToken) {
+export async function getDebateMedia(
+  debateId: string,
+  getPrivyIdentityToken?: GetPrivyIdentityToken,
+  accountKey?: string | null,
+  signal?: AbortSignal
+) {
   return geoChatRequest<DebateMediaResponse>(`/debates/${debateId}/media`, {
     auth: 'optional',
     getPrivyIdentityToken,
+    accountKey,
+    signal,
   });
 }
 
 export async function requestDebateMediaProcessing(
   debateId: string,
   getPrivyIdentityToken: GetPrivyIdentityToken,
+  accountKey: string | null,
   request: DebateMediaProcessRequest = {}
 ) {
   return geoChatRequest<DebateMediaResponse>(`/debates/${debateId}/media/process`, {
@@ -682,32 +810,39 @@ export async function requestDebateMediaProcessing(
     body: request,
     auth: true,
     getPrivyIdentityToken,
+    accountKey,
   });
 }
 
 export async function getDebateMediaArtifactUrl(
   debateId: string,
   request: DebateMediaArtifactUrlRequest,
-  getPrivyIdentityToken?: GetPrivyIdentityToken
+  getPrivyIdentityToken?: GetPrivyIdentityToken,
+  accountKey?: string | null
 ) {
   return geoChatRequest<DebateMediaArtifactUrlResponse>(`/debates/${debateId}/media/artifacts/url`, {
     method: 'POST',
     body: request,
     auth: 'optional',
     getPrivyIdentityToken,
+    accountKey,
   });
 }
 
 export async function getDebateTranscript(
   debateId: string,
   format: TranscriptFormat = 'json',
-  getPrivyIdentityToken?: GetPrivyIdentityToken
+  getPrivyIdentityToken?: GetPrivyIdentityToken,
+  accountKey?: string | null,
+  signal?: AbortSignal
 ) {
   return geoChatRequest<DebateTranscriptResponse>(
     `/debates/${debateId}/transcript?format=${encodeURIComponent(format)}`,
     {
       auth: 'optional',
       getPrivyIdentityToken,
+      accountKey,
+      signal,
     }
   );
 }
@@ -727,6 +862,7 @@ async function geoChatRequest<T>(path: string, options: RequestOptions = {}): Pr
     method: options.method ?? 'GET',
     headers,
     body: options.body === undefined ? undefined : JSON.stringify(options.body),
+    signal: options.signal,
   });
 
   if (!response.ok) {
@@ -770,9 +906,13 @@ async function requestError(response: Response) {
 
 async function accessTokenForRequest(options: RequestOptions) {
   if (!options.auth) return null;
+  if (!options.accountKey) {
+    if (options.auth === 'optional') return null;
+    throw new Error('Sign in to use debates.');
+  }
 
   try {
-    return await getGeoChatAccessToken(options.getPrivyIdentityToken);
+    return await getGeoChatAccessToken(options.getPrivyIdentityToken, options.accountKey ?? null);
   } catch (error) {
     if (options.auth === 'optional') return null;
     throw error;
@@ -843,8 +983,9 @@ export function resetGeoChatSession() {
   removeStoredSession();
 }
 
-async function getGeoChatAccessToken(getPrivyIdentityToken?: GetPrivyIdentityToken) {
-  return (await getGeoChatSession(getPrivyIdentityToken)).access_token;
+async function getGeoChatAccessToken(getPrivyIdentityToken?: GetPrivyIdentityToken, accountKey: string | null = null) {
+  if (!accountKey) throw new Error('Sign in to use debates.');
+  return (await getGeoChatSession(getPrivyIdentityToken, accountKey)).access_token;
 }
 
 async function createGeoChatSession(privyToken: string): Promise<GeoChatSession> {

--- a/apps/web/core/debates/api.ts
+++ b/apps/web/core/debates/api.ts
@@ -368,14 +368,23 @@ type RequestOptions = {
 };
 
 const geoChatSessionStorageKey = 'geo:chat-session';
-let geoChatSessionRequest: Promise<GeoChatSession> | null = null;
+const geoChatSessionRequestTimeoutMs = 10_000;
+
+type StoredGeoChatSession = {
+  account_key: string | null;
+  session: GeoChatSession;
+};
+
+const geoChatSessionRequests = new Map<string, Promise<GeoChatSession>>();
+let geoChatSessionEpoch = 0;
+let geoChatSessionAccountKey: string | null = null;
 
 export function getGeoChatApiBaseUrl() {
   return (process.env.NEXT_PUBLIC_GEO_CHAT_API_BASE_URL || 'http://localhost:8080').replace(/\/+$/, '');
 }
 
 export function getCurrentGeoChatUserId() {
-  const session = loadSession();
+  const session = loadSession(null);
   return decodeGeoChatAccessToken(session?.access_token)?.user_id ?? null;
 }
 
@@ -770,20 +779,41 @@ async function accessTokenForRequest(options: RequestOptions) {
   }
 }
 
-export async function getGeoChatSession(getPrivyIdentityToken?: GetPrivyIdentityToken) {
-  const stored = loadSession();
+export async function getGeoChatSession(
+  getPrivyIdentityToken?: GetPrivyIdentityToken,
+  accountKey: string | null = null
+) {
+  const storedRecord = loadStoredSession();
+  if (
+    accountKey !== null &&
+    ((geoChatSessionAccountKey !== null && geoChatSessionAccountKey !== accountKey) ||
+      (storedRecord && storedRecord.account_key !== accountKey))
+  ) {
+    resetGeoChatSession();
+  }
+  if (accountKey !== null) geoChatSessionAccountKey = accountKey;
+
+  const effectiveAccountKey = accountKey ?? geoChatSessionAccountKey ?? loadStoredSession()?.account_key ?? null;
+  const stored = loadSession(effectiveAccountKey);
   if (stored && new Date(stored.expires_at).getTime() > Date.now() + 30_000) {
     return stored;
   }
 
-  geoChatSessionRequest ??= (async () => {
+  const requestKey = effectiveAccountKey ?? '';
+  const existingRequest = geoChatSessionRequests.get(requestKey);
+  if (existingRequest) return existingRequest;
+
+  const issuedForEpoch = geoChatSessionEpoch;
+  const request = (async () => {
     if (stored?.refresh_token) {
       try {
         const refreshed = await refreshGeoChatSession(stored.refresh_token);
-        saveSession(refreshed);
+        assertCurrentGeoChatSessionEpoch(issuedForEpoch);
+        saveSession(refreshed, effectiveAccountKey);
         return refreshed;
       } catch {
-        clearSession();
+        assertCurrentGeoChatSessionEpoch(issuedForEpoch);
+        removeStoredSession();
       }
     }
 
@@ -793,13 +823,24 @@ export async function getGeoChatSession(getPrivyIdentityToken?: GetPrivyIdentity
     }
 
     const session = await createGeoChatSession(privyIdentityToken);
-    saveSession(session);
+    assertCurrentGeoChatSessionEpoch(issuedForEpoch);
+    saveSession(session, effectiveAccountKey);
     return session;
   })().finally(() => {
-    geoChatSessionRequest = null;
+    if (geoChatSessionRequests.get(requestKey) === request) {
+      geoChatSessionRequests.delete(requestKey);
+    }
   });
 
-  return geoChatSessionRequest;
+  geoChatSessionRequests.set(requestKey, request);
+  return request;
+}
+
+export function resetGeoChatSession() {
+  geoChatSessionEpoch += 1;
+  geoChatSessionAccountKey = null;
+  geoChatSessionRequests.clear();
+  removeStoredSession();
 }
 
 async function getGeoChatAccessToken(getPrivyIdentityToken?: GetPrivyIdentityToken) {
@@ -807,7 +848,7 @@ async function getGeoChatAccessToken(getPrivyIdentityToken?: GetPrivyIdentityTok
 }
 
 async function createGeoChatSession(privyToken: string): Promise<GeoChatSession> {
-  const response = await fetch(`${getGeoChatApiBaseUrl()}/auth/session`, {
+  const response = await fetchGeoChatSession(`${getGeoChatApiBaseUrl()}/auth/session`, {
     method: 'POST',
     headers: { Authorization: `Bearer ${privyToken}` },
   });
@@ -817,7 +858,7 @@ async function createGeoChatSession(privyToken: string): Promise<GeoChatSession>
 }
 
 async function refreshGeoChatSession(refreshToken: string): Promise<GeoChatSession> {
-  const response = await fetch(`${getGeoChatApiBaseUrl()}/auth/session/refresh`, {
+  const response = await fetchGeoChatSession(`${getGeoChatApiBaseUrl()}/auth/session/refresh`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ refresh_token: refreshToken }),
@@ -827,25 +868,62 @@ async function refreshGeoChatSession(refreshToken: string): Promise<GeoChatSessi
   return response.json() as Promise<GeoChatSession>;
 }
 
-function loadSession(): GeoChatSession | null {
+async function fetchGeoChatSession(input: string, init: RequestInit) {
+  const controller = new AbortController();
+  let timeout: ReturnType<typeof setTimeout> | null = null;
+
+  try {
+    return await Promise.race([
+      fetch(input, { ...init, signal: controller.signal }),
+      new Promise<never>((_, reject) => {
+        timeout = setTimeout(() => {
+          controller.abort();
+          reject(new Error('Geo Chat session request timed out.'));
+        }, geoChatSessionRequestTimeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}
+
+function loadSession(accountKey: string | null): GeoChatSession | null {
+  const stored = loadStoredSession();
+  if (!stored || (accountKey !== null && stored.account_key !== accountKey)) return null;
+  return stored.session;
+}
+
+function loadStoredSession(): StoredGeoChatSession | null {
   if (typeof window === 'undefined') return null;
   try {
     const raw = window.localStorage.getItem(geoChatSessionStorageKey);
-    return raw ? (JSON.parse(raw) as GeoChatSession) : null;
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as StoredGeoChatSession | GeoChatSession;
+    if ('session' in parsed) return parsed;
+    return { account_key: null, session: parsed };
   } catch {
     return null;
   }
 }
 
-function saveSession(session: GeoChatSession) {
+function saveSession(session: GeoChatSession, accountKey: string | null) {
   if (typeof window !== 'undefined') {
-    window.localStorage.setItem(geoChatSessionStorageKey, JSON.stringify(session));
+    window.localStorage.setItem(
+      geoChatSessionStorageKey,
+      JSON.stringify({ account_key: accountKey, session } satisfies StoredGeoChatSession)
+    );
   }
 }
 
-function clearSession() {
+function removeStoredSession() {
   if (typeof window !== 'undefined') {
     window.localStorage.removeItem(geoChatSessionStorageKey);
+  }
+}
+
+function assertCurrentGeoChatSessionEpoch(issuedForEpoch: number) {
+  if (issuedForEpoch !== geoChatSessionEpoch) {
+    throw new Error('Geo Chat session changed while authentication was in progress.');
   }
 }
 

--- a/apps/web/core/debates/api.ts
+++ b/apps/web/core/debates/api.ts
@@ -352,7 +352,7 @@ export type RecordingCompleteResponse = {
   debate: Debate;
 };
 
-type GeoChatSession = {
+export type GeoChatSession = {
   access_token: string;
   refresh_token: string;
   expires_at: string;
@@ -368,6 +368,7 @@ type RequestOptions = {
 };
 
 const geoChatSessionStorageKey = 'geo:chat-session';
+let geoChatSessionRequest: Promise<GeoChatSession> | null = null;
 
 export function getGeoChatApiBaseUrl() {
   return (process.env.NEXT_PUBLIC_GEO_CHAT_API_BASE_URL || 'http://localhost:8080').replace(/\/+$/, '');
@@ -777,30 +778,40 @@ async function accessTokenForRequest(options: RequestOptions) {
   }
 }
 
-async function getGeoChatAccessToken(getPrivyIdentityToken?: GetPrivyIdentityToken) {
+export async function getGeoChatSession(getPrivyIdentityToken?: GetPrivyIdentityToken) {
   const stored = loadSession();
   if (stored && new Date(stored.expires_at).getTime() > Date.now() + 30_000) {
-    return stored.access_token;
+    return stored;
   }
 
-  if (stored?.refresh_token) {
-    try {
-      const refreshed = await refreshGeoChatSession(stored.refresh_token);
-      saveSession(refreshed);
-      return refreshed.access_token;
-    } catch {
-      clearSession();
+  geoChatSessionRequest ??= (async () => {
+    if (stored?.refresh_token) {
+      try {
+        const refreshed = await refreshGeoChatSession(stored.refresh_token);
+        saveSession(refreshed);
+        return refreshed;
+      } catch {
+        clearSession();
+      }
     }
-  }
 
-  const privyIdentityToken = await getPrivyIdentityToken?.();
-  if (!privyIdentityToken) {
-    throw new Error('Sign in to use debates.');
-  }
+    const privyIdentityToken = await getPrivyIdentityToken?.();
+    if (!privyIdentityToken) {
+      throw new Error('Sign in to use debates.');
+    }
 
-  const session = await createGeoChatSession(privyIdentityToken);
-  saveSession(session);
-  return session.access_token;
+    const session = await createGeoChatSession(privyIdentityToken);
+    saveSession(session);
+    return session;
+  })().finally(() => {
+    geoChatSessionRequest = null;
+  });
+
+  return geoChatSessionRequest;
+}
+
+async function getGeoChatAccessToken(getPrivyIdentityToken?: GetPrivyIdentityToken) {
+  return (await getGeoChatSession(getPrivyIdentityToken)).access_token;
 }
 
 async function createGeoChatSession(privyToken: string): Promise<GeoChatSession> {

--- a/apps/web/core/debates/api.ts
+++ b/apps/web/core/debates/api.ts
@@ -388,14 +388,6 @@ export async function resolveCurrentGeoChatUserId(getPrivyIdentityToken: GetPriv
   return decodeGeoChatAccessToken(accessToken)?.user_id ?? null;
 }
 
-export async function heartbeatDebatePresence(getPrivyIdentityToken: GetPrivyIdentityToken) {
-  return geoChatRequest<DebateActivity>('/me/debate-presence/heartbeat', {
-    method: 'POST',
-    auth: true,
-    getPrivyIdentityToken,
-  });
-}
-
 export async function getDebateActivity(getPrivyIdentityToken: GetPrivyIdentityToken) {
   return geoChatRequest<DebateActivity>('/me/debate-activity', {
     auth: true,

--- a/apps/web/core/debates/debate-coordinator.test.tsx
+++ b/apps/web/core/debates/debate-coordinator.test.tsx
@@ -16,6 +16,8 @@ const mocks = vi.hoisted(() => ({
   clipboardWrite: vi.fn(),
   play: vi.fn(() => Promise.resolve()),
   pause: vi.fn(),
+  authenticated: true,
+  gatewayPaused: false,
 }));
 
 vi.mock('next/navigation', () => ({
@@ -24,11 +26,15 @@ vi.mock('next/navigation', () => ({
 }));
 
 vi.mock('./hooks', () => ({
-  useDebatePresenceHeartbeat: vi.fn(),
+  useGeoChatAuth: () => ({ ready: true, authenticated: mocks.authenticated, getPrivyIdentityToken: vi.fn() }),
   useDebateActivity: () => ({ data: mocks.activity }),
   useDebateSharePrompts: () => ({ data: { prompts: mocks.prompts } }),
   useDebateMediaArtifactUrl: () => ({ mutate: mocks.mediaMutate, error: null }),
   useHandleDebateSharePrompt: () => ({ mutate: mocks.handleMutate, isPending: false }),
+}));
+
+vi.mock('./debate-gateway', () => ({
+  useDebateGateway: () => ({ status: mocks.gatewayPaused ? 'degraded' : 'ready', paused: mocks.gatewayPaused }),
 }));
 
 vi.mock('~/core/state/feature-flags', () => ({
@@ -49,6 +55,8 @@ beforeEach(() => {
   mocks.activity = null;
   mocks.pathname = '/space/space-1/debates';
   mocks.prompts = [];
+  mocks.authenticated = true;
+  mocks.gatewayPaused = false;
   Object.defineProperty(navigator, 'clipboard', {
     configurable: true,
     value: { writeText: mocks.clipboardWrite },
@@ -67,6 +75,17 @@ beforeEach(() => {
 afterEach(cleanup);
 
 describe('DebateCoordinator', () => {
+  it('shows a non-blocking warning while live updates are paused and clears it on recovery', () => {
+    mocks.gatewayPaused = true;
+    const { rerender } = render(<DebateCoordinator />);
+
+    expect(screen.getByRole('status')).toHaveTextContent('Live debate updates are paused while reconnecting.');
+
+    mocks.gatewayPaused = false;
+    rerender(<DebateCoordinator />);
+    expect(screen.queryByText('Live debate updates are paused while reconnecting.')).not.toBeInTheDocument();
+  });
+
   it('routes an available participant into a shared rematch browser', async () => {
     mocks.activity = activityWithRematch('browsing');
 

--- a/apps/web/core/debates/debate-coordinator.tsx
+++ b/apps/web/core/debates/debate-coordinator.tsx
@@ -22,7 +22,8 @@ export function DebateCoordinator() {
   const geoChatAuth = useGeoChatAuth();
   const gateway = useDebateGateway(
     isDebatesEnabled && geoChatAuth.ready && geoChatAuth.authenticated,
-    geoChatAuth.getPrivyIdentityToken
+    geoChatAuth.getPrivyIdentityToken,
+    geoChatAuth.accountKey
   );
   const activityQuery = useDebateActivity(isDebatesEnabled);
   const activity = activityQuery.data ?? null;

--- a/apps/web/core/debates/debate-coordinator.tsx
+++ b/apps/web/core/debates/debate-coordinator.tsx
@@ -10,12 +10,8 @@ import { Button } from '~/design-system/button';
 import { Upload } from '~/design-system/icons/upload';
 import { Text } from '~/design-system/text';
 
-import {
-  useDebateActivity,
-  useDebatePresenceHeartbeat,
-  useDebateSharePrompts,
-  useHandleDebateSharePrompt,
-} from './hooks';
+import { useDebateGateway } from './debate-gateway';
+import { useDebateActivity, useDebateSharePrompts, useGeoChatAuth, useHandleDebateSharePrompt } from './hooks';
 import { DebateMatchPrompt } from './match-prompt';
 import { ProcessedDebatePlayer } from './processed-debate-player';
 
@@ -23,7 +19,11 @@ export function DebateCoordinator() {
   const router = useRouter();
   const pathname = usePathname();
   const isDebatesEnabled = useDebatesEnabled();
-  useDebatePresenceHeartbeat(isDebatesEnabled);
+  const geoChatAuth = useGeoChatAuth();
+  const gateway = useDebateGateway(
+    isDebatesEnabled && geoChatAuth.ready && geoChatAuth.authenticated,
+    geoChatAuth.getPrivyIdentityToken
+  );
   const activityQuery = useDebateActivity(isDebatesEnabled);
   const activity = activityQuery.data ?? null;
   const activeFlow = Boolean(activity?.match || activity?.debate || activity?.rematch);
@@ -58,6 +58,15 @@ export function DebateCoordinator() {
 
   return (
     <>
+      {gateway.paused && (
+        <div
+          role="status"
+          aria-live="polite"
+          className="pointer-events-none fixed top-3 left-1/2 z-[1400] w-[calc(100%-1.5rem)] max-w-md -translate-x-1/2 rounded-full bg-text px-4 py-2 text-center text-sm text-white shadow-card sm:w-auto"
+        >
+          Live debate updates are paused while reconnecting.
+        </div>
+      )}
       {match && (
         <DebateMatchPrompt
           spaceId={match.claim.space_id}

--- a/apps/web/core/debates/debate-gateway.test.ts
+++ b/apps/web/core/debates/debate-gateway.test.ts
@@ -1,0 +1,324 @@
+import { QueryClient } from '@tanstack/react-query';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { DebateGatewayClient, type DebateGatewaySession } from './debate-gateway';
+
+type MessageHandler = (event: { data: unknown }) => void;
+
+class FakeWebSocket {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSING = 2;
+  static readonly CLOSED = 3;
+
+  readyState = FakeWebSocket.CONNECTING;
+  sent: Array<Record<string, unknown>> = [];
+  onopen: (() => void) | null = null;
+  onmessage: MessageHandler | null = null;
+  onerror: (() => void) | null = null;
+  onclose: (() => void) | null = null;
+
+  constructor(readonly url: string) {}
+
+  open() {
+    this.readyState = FakeWebSocket.OPEN;
+    this.onopen?.();
+  }
+
+  receive(op: string, payload: unknown, seq?: number) {
+    this.onmessage?.(
+      new MessageEvent('message', {
+        data: JSON.stringify({
+          v: 1,
+          op,
+          seq: seq ?? null,
+          request_id: null,
+          space_id: null,
+          room_id: null,
+          room_kind: null,
+          payload,
+        }),
+      })
+    );
+  }
+
+  close() {
+    if (this.readyState === FakeWebSocket.CLOSED) return;
+    this.readyState = FakeWebSocket.CLOSED;
+    this.onclose?.();
+  }
+
+  serverClose() {
+    this.close();
+  }
+
+  send(value: string) {
+    this.sent.push(JSON.parse(value) as Record<string, unknown>);
+  }
+}
+
+describe('DebateGatewayClient', () => {
+  let sockets: FakeWebSocket[];
+  let queryClient: QueryClient;
+  let invalidateQueries: ReturnType<typeof vi.spyOn>;
+  let session: DebateGatewaySession;
+  let client: DebateGatewayClient;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-20T12:00:00.000Z'));
+    sockets = [];
+    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries').mockResolvedValue();
+    session = {
+      access_token: 'access token',
+      refresh_token: 'refresh-token',
+      expires_at: '2026-07-20T12:10:00.000Z',
+    };
+    client = new DebateGatewayClient({
+      queryClient,
+      getSession: vi.fn(async () => session),
+      getApiBaseUrl: () => 'https://chat.example.com/',
+      createWebSocket: url => {
+        const socket = new FakeWebSocket(url);
+        sockets.push(socket);
+        return socket;
+      },
+      random: () => 0,
+    });
+  });
+
+  afterEach(() => {
+    client.stop();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('authenticates, reference-counts scopes, and reconciles the subscribe/READY race', async () => {
+    const releaseFirst = client.retainScope({ scope: 'space', space_id: 'space-1' });
+    const releaseSecond = client.retainScope({ scope: 'space', space_id: 'space-1' });
+
+    client.start(vi.fn(async () => 'privy-token'));
+    await vi.runAllTicks();
+
+    expect(sockets[0]?.url).toBe('wss://chat.example.com/gateway/ws?access_token=access+token');
+    sockets[0]!.open();
+    sockets[0]!.receive('READY', readyPayload([]));
+
+    expect(sockets[0]!.sent).toContainEqual(
+      expect.objectContaining({ op: 'SUBSCRIBE', payload: { scope: 'space', space_id: 'space-1' } })
+    );
+
+    sockets[0]!.receive('READY', readyPayload([{ scope: 'space', space_id: 'space-1' }]));
+    await vi.runAllTicks();
+
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ['debates', 'claims', 'space-1'],
+      refetchType: 'active',
+    });
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ['debates', 'space', 'space-1'],
+      refetchType: 'active',
+    });
+
+    releaseFirst();
+    expect(sockets[0]!.sent.some(message => message.op === 'UNSUBSCRIBE')).toBe(false);
+    releaseSecond();
+    expect(sockets[0]!.sent).toContainEqual(
+      expect.objectContaining({ op: 'UNSUBSCRIBE', payload: { scope: 'space', space_id: 'space-1' } })
+    );
+  });
+
+  it('deduplicates events and coalesces targeted invalidations in the same turn', async () => {
+    client.start(vi.fn(async () => 'privy-token'));
+    await vi.runAllTicks();
+    sockets[0]!.open();
+    sockets[0]!.receive('READY', readyPayload([]));
+    invalidateQueries.mockClear();
+
+    const event = {
+      event_id: 'event-1',
+      event_type: 'debate.media_changed',
+      payload: { debate_id: 'debate-1', space_id: 'space-1' },
+    };
+    sockets[0]!.receive('EVENT', event, 1);
+    sockets[0]!.receive('EVENT', event, 2);
+    await vi.runAllTicks();
+
+    expect(invalidateQueries.mock.calls).toEqual(
+      expect.arrayContaining([
+        [{ queryKey: ['debates', 'media', 'debate-1'], refetchType: 'active' }],
+        [{ queryKey: ['debates', 'detail', 'debate-1'], refetchType: 'active' }],
+        [{ queryKey: ['debates', 'space', 'space-1'], refetchType: 'active' }],
+      ])
+    );
+    expect(invalidateQueries).toHaveBeenCalledTimes(3);
+  });
+
+  it.each([
+    ['activity', { event_type: 'debate.activity_changed', payload: {} }, [['debates', 'activity']]],
+    [
+      'state',
+      { event_type: 'debate.state_changed', payload: { debate_id: 'debate-1', space_id: 'space-1' } },
+      [
+        ['debates', 'detail', 'debate-1'],
+        ['debates', 'space', 'space-1'],
+        ['debates', 'activity'],
+      ],
+    ],
+    [
+      'rematch',
+      { event_type: 'debate.rematch_changed', payload: { rematch_session_id: 'rematch-1' } },
+      [
+        ['debates', 'rematch', 'rematch-1'],
+        ['debates', 'activity'],
+      ],
+    ],
+    ['share prompts', { event_type: 'debate.share_prompts_changed', payload: {} }, [['debates', 'share-prompts']]],
+  ])('maps %s events to their authoritative query families', async (_label, event, expectedKeys) => {
+    client.start(vi.fn(async () => 'privy-token'));
+    await vi.runAllTicks();
+    sockets[0]!.open();
+    sockets[0]!.receive('READY', readyPayload([]));
+    invalidateQueries.mockClear();
+
+    sockets[0]!.receive('EVENT', { event_id: `event-${String(_label)}`, ...event });
+    await vi.runAllTicks();
+
+    for (const queryKey of expectedKeys) {
+      expect(invalidateQueries).toHaveBeenCalledWith({ queryKey, refetchType: 'active' });
+    }
+    expect(invalidateQueries).toHaveBeenCalledTimes(expectedKeys.length);
+  });
+
+  it('filters claim invalidations to active claim queries that intersect the event', async () => {
+    queryClient.setQueryData(['debates', 'claims', 'space-1', ['claim-1']], {});
+    queryClient.setQueryData(['debates', 'claims', 'space-1', ['claim-2']], {});
+    const refetchQueries = vi.spyOn(queryClient, 'refetchQueries').mockResolvedValue();
+
+    client.start(vi.fn(async () => 'privy-token'));
+    await vi.runAllTicks();
+    sockets[0]!.open();
+    sockets[0]!.receive('READY', readyPayload([]));
+    sockets[0]!.receive('EVENT', {
+      event_id: 'event-claims',
+      event_type: 'debate.claims_changed',
+      payload: { space_id: 'space-1', claim_entity_ids: ['claim-2'] },
+    });
+    await vi.runAllTicks();
+
+    type InvalidationFilters = NonNullable<Parameters<QueryClient['invalidateQueries']>[0]>;
+    const invalidationCalls = invalidateQueries.mock.calls as unknown as Array<[InvalidationFilters]>;
+    const predicate = invalidationCalls.map(call => call[0]).find(filters => 'predicate' in filters)?.predicate;
+    expect(predicate).toBeTypeOf('function');
+    expect(
+      predicate!(queryClient.getQueryCache().find({ queryKey: ['debates', 'claims', 'space-1', ['claim-1']] })!)
+    ).toBe(false);
+    expect(
+      predicate!(queryClient.getQueryCache().find({ queryKey: ['debates', 'claims', 'space-1', ['claim-2']] })!)
+    ).toBe(true);
+    expect(refetchQueries).not.toHaveBeenCalled();
+  });
+
+  it('sends presence heartbeats and reconnects after two missed acknowledgements', async () => {
+    client.start(vi.fn(async () => 'privy-token'));
+    await vi.runAllTicks();
+    sockets[0]!.open();
+    sockets[0]!.receive('HELLO', { heartbeat_interval_ms: 1_000 });
+    sockets[0]!.receive('READY', readyPayload([]));
+
+    expect(sockets[0]!.sent).toContainEqual(
+      expect.objectContaining({ op: 'HEARTBEAT', payload: { debate_presence: true } })
+    );
+
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(sockets[0]!.readyState).toBe(FakeWebSocket.CLOSED);
+    expect(client.getSnapshot().paused).toBe(true);
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(sockets).toHaveLength(2);
+  });
+
+  it('resets missed acknowledgements and keeps the live socket connected', async () => {
+    client.start(vi.fn(async () => 'privy-token'));
+    await vi.runAllTicks();
+    sockets[0]!.open();
+    sockets[0]!.receive('HELLO', { heartbeat_interval_ms: 1_000 });
+    sockets[0]!.receive('READY', readyPayload([]));
+
+    await vi.advanceTimersByTimeAsync(900);
+    sockets[0]!.receive('HEARTBEAT_ACK', {});
+    await vi.advanceTimersByTimeAsync(1_100);
+
+    expect(sockets[0]!.readyState).toBe(FakeWebSocket.OPEN);
+  });
+
+  it('uses bounded exponential reconnects and broadly reconciles after reconnect or lag', async () => {
+    client.start(vi.fn(async () => 'privy-token'));
+    await vi.runAllTicks();
+    sockets[0]!.open();
+    sockets[0]!.receive('READY', readyPayload([]));
+    invalidateQueries.mockClear();
+
+    sockets[0]!.serverClose();
+    expect(client.getSnapshot().paused).toBe(true);
+    await vi.advanceTimersByTimeAsync(999);
+    expect(sockets).toHaveLength(1);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(sockets).toHaveLength(2);
+
+    sockets[1]!.open();
+    sockets[1]!.receive('READY', readyPayload([]));
+    await vi.runAllTicks();
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['debates'], refetchType: 'active' });
+
+    invalidateQueries.mockClear();
+    sockets[1]!.receive('ERROR', { code: 'events_lagged', message: 'events skipped' });
+    await vi.runAllTicks();
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['debates'], refetchType: 'active' });
+  });
+
+  it('rotates the socket thirty seconds before token expiry', async () => {
+    session = { ...session, expires_at: '2026-07-20T12:01:00.000Z' };
+    client.start(vi.fn(async () => 'privy-token'));
+    await vi.runAllTicks();
+    sockets[0]!.open();
+    sockets[0]!.receive('READY', readyPayload([]));
+
+    await vi.advanceTimersByTimeAsync(29_999);
+    expect(sockets).toHaveLength(1);
+    await vi.advanceTimersByTimeAsync(1_001);
+    expect(sockets).toHaveLength(2);
+  });
+
+  it('never opens a socket while stopped, which keeps signed-out views snapshot-only', async () => {
+    client.stop();
+    client.retainScope({ scope: 'debate', debate_id: 'public-debate' });
+    await vi.runAllTicks();
+
+    expect(sockets).toHaveLength(0);
+    expect(client.getSnapshot()).toEqual({ status: 'idle', paused: false });
+  });
+
+  it('enters degraded mode when the server lacks the required capability and recovers on READY', async () => {
+    client.start(vi.fn(async () => 'privy-token'));
+    await vi.runAllTicks();
+    sockets[0]!.open();
+    sockets[0]!.receive('READY', { ...readyPayload([]), capabilities: [] });
+
+    expect(client.getSnapshot()).toEqual({ status: 'degraded', paused: true });
+
+    sockets[0]!.receive('READY', readyPayload([]));
+    expect(client.getSnapshot()).toEqual({ status: 'ready', paused: false });
+  });
+});
+
+function readyPayload(subscriptions: unknown[]) {
+  return {
+    session_id: 'session-1',
+    heartbeat_interval_ms: 30_000,
+    capabilities: ['debate_invalidations_v1'],
+    subscriptions,
+  };
+}

--- a/apps/web/core/debates/debate-gateway.test.ts
+++ b/apps/web/core/debates/debate-gateway.test.ts
@@ -43,6 +43,10 @@ class FakeWebSocket {
     );
   }
 
+  receiveRaw(data: string) {
+    this.onmessage?.(new MessageEvent('message', { data }));
+  }
+
   close() {
     if (this.readyState === FakeWebSocket.CLOSED) return;
     this.readyState = FakeWebSocket.CLOSED;
@@ -126,14 +130,8 @@ describe('DebateGatewayClient', () => {
     sockets[0]!.receive('READY', readyPayload([{ scope: 'space', space_id: 'space-1' }]));
     await flushInvalidations();
 
-    expect(invalidateQueries).toHaveBeenCalledWith({
-      queryKey: ['debates', 'claims', 'space-1'],
-      refetchType: 'active',
-    });
-    expect(invalidateQueries).toHaveBeenCalledWith({
-      queryKey: ['debates', 'space', 'space-1'],
-      refetchType: 'active',
-    });
+    expectInvalidated(invalidateQueries, { queryKey: ['debates', 'claims', 'space-1'], refetchType: 'active' });
+    expectInvalidated(invalidateQueries, { queryKey: ['debates', 'space', 'space-1'], refetchType: 'active' });
 
     releaseFirst();
     expect(sockets[0]!.sent.some(message => message.op === 'UNSUBSCRIBE')).toBe(false);
@@ -152,7 +150,7 @@ describe('DebateGatewayClient', () => {
     sockets[0]!.open();
     sockets[0]!.receive('READY', readyPayload([]));
     await flushInvalidations();
-    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['debates'], refetchType: 'active' });
+    expectInvalidated(invalidateQueries, { queryKey: ['debates'], refetchType: 'active' });
     invalidateQueries.mockClear();
 
     const event = {
@@ -168,35 +166,43 @@ describe('DebateGatewayClient', () => {
 
     expect(invalidateQueries.mock.calls).toEqual(
       expect.arrayContaining([
-        [{ queryKey: ['debates', 'media', 'debate-1'], refetchType: 'active' }],
-        [{ queryKey: ['debates', 'detail', 'debate-1'], refetchType: 'active' }],
-        [{ queryKey: ['debates', 'transcript', 'debate-1'], refetchType: 'active' }],
-        [{ queryKey: ['debates', 'space', 'space-1'], refetchType: 'active' }],
+        [{ queryKey: ['debates', 'media', 'debate-1'], refetchType: 'active' }, { throwOnError: true }],
+        [{ queryKey: ['debates', 'detail', 'debate-1'], refetchType: 'active' }, { throwOnError: true }],
+        [{ queryKey: ['debates', 'transcript', 'debate-1'], refetchType: 'active' }, { throwOnError: true }],
+        [{ queryKey: ['debates', 'space', 'space-1'], refetchType: 'active' }, { throwOnError: true }],
       ])
     );
     expect(invalidateQueries).toHaveBeenCalledTimes(4);
   });
 
   it.each([
-    ['activity', { event_type: 'debate.activity_changed', payload: {} }, [['debates', 'activity']]],
+    [
+      'activity',
+      { event_type: 'debate.activity_changed', payload: {} },
+      [['debates', 'account', 'user-a', 'activity']],
+    ],
     [
       'state',
       { event_type: 'debate.state_changed', payload: { debate_id: 'debate-1', space_id: 'space-1' } },
       [
         ['debates', 'detail', 'debate-1'],
         ['debates', 'space', 'space-1'],
-        ['debates', 'activity'],
+        ['debates', 'account', 'user-a', 'activity'],
       ],
     ],
     [
       'rematch',
       { event_type: 'debate.rematch_changed', payload: { rematch_session_id: 'rematch-1' } },
       [
-        ['debates', 'rematch', 'rematch-1'],
-        ['debates', 'activity'],
+        ['debates', 'account', 'user-a', 'rematch', 'rematch-1'],
+        ['debates', 'account', 'user-a', 'activity'],
       ],
     ],
-    ['share prompts', { event_type: 'debate.share_prompts_changed', payload: {} }, [['debates', 'share-prompts']]],
+    [
+      'share prompts',
+      { event_type: 'debate.share_prompts_changed', payload: {} },
+      [['debates', 'account', 'user-a', 'share-prompts']],
+    ],
   ])('maps %s events to their authoritative query families', async (_label, event, expectedKeys) => {
     client.start(
       vi.fn(async () => 'privy-token'),
@@ -212,7 +218,7 @@ describe('DebateGatewayClient', () => {
     await flushInvalidations();
 
     for (const queryKey of expectedKeys) {
-      expect(invalidateQueries).toHaveBeenCalledWith({ queryKey, refetchType: 'active' });
+      expectInvalidated(invalidateQueries, { queryKey, refetchType: 'active' });
     }
     expect(invalidateQueries).toHaveBeenCalledTimes(expectedKeys.length);
   });
@@ -311,12 +317,61 @@ describe('DebateGatewayClient', () => {
     sockets[1]!.open();
     sockets[1]!.receive('READY', readyPayload([]));
     await flushInvalidations();
-    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['debates'], refetchType: 'active' });
+    expectInvalidated(invalidateQueries, { queryKey: ['debates'], refetchType: 'active' });
 
     invalidateQueries.mockClear();
     sockets[1]!.receive('ERROR', { code: 'events_lagged', message: 'events skipped' });
     await flushInvalidations();
-    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['debates'], refetchType: 'active' });
+    expectInvalidated(invalidateQueries, { queryKey: ['debates'], refetchType: 'active' });
+  });
+
+  it('abandons a socket that never completes the protocol handshake', async () => {
+    client.start(
+      vi.fn(async () => 'privy-token'),
+      'user-a'
+    );
+    await vi.runAllTicks();
+
+    await vi.advanceTimersByTimeAsync(9_999);
+    expect(sockets[0]!.readyState).toBe(FakeWebSocket.CONNECTING);
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(sockets[0]!.readyState).toBe(FakeWebSocket.CLOSED);
+    expect(client.getSnapshot()).toEqual({ status: 'degraded', paused: true });
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(sockets).toHaveLength(2);
+  });
+
+  it('reconnects when an authoritative invalidation refetch fails', async () => {
+    invalidateQueries.mockRejectedValueOnce(new Error('snapshot unavailable'));
+    client.start(
+      vi.fn(async () => 'privy-token'),
+      'user-a'
+    );
+    await vi.runAllTicks();
+    sockets[0]!.open();
+    sockets[0]!.receive('READY', readyPayload([]));
+    await flushInvalidations();
+
+    expect(sockets[0]!.readyState).toBe(FakeWebSocket.CLOSED);
+    expect(client.getSnapshot()).toEqual({ status: 'degraded', paused: true });
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(sockets).toHaveLength(2);
+  });
+
+  it('cancels an in-flight snapshot before invalidating it', async () => {
+    const cancelQueries = vi.spyOn(queryClient, 'cancelQueries').mockResolvedValue();
+    client.start(
+      vi.fn(async () => 'privy-token'),
+      'user-a'
+    );
+    await vi.runAllTicks();
+    sockets[0]!.open();
+    sockets[0]!.receive('READY', readyPayload([]));
+    await flushInvalidations();
+
+    expect(cancelQueries).toHaveBeenCalledWith({ queryKey: ['debates'], refetchType: 'active' });
+    expect(cancelQueries.mock.invocationCallOrder[0]).toBeLessThan(invalidateQueries.mock.invocationCallOrder[0]!);
   });
 
   it('rotates the socket thirty seconds before token expiry', async () => {
@@ -354,14 +409,8 @@ describe('DebateGatewayClient', () => {
     sockets[0]!.receive('READY', readyPayload([{ scope: 'space', space_id: 'space-1' }]));
     await flushInvalidations();
 
-    expect(invalidateQueries).toHaveBeenCalledWith({
-      queryKey: ['debates', 'claims', 'space-1'],
-      refetchType: 'active',
-    });
-    expect(invalidateQueries).toHaveBeenCalledWith({
-      queryKey: ['debates', 'space', 'space-1'],
-      refetchType: 'active',
-    });
+    expectInvalidated(invalidateQueries, { queryKey: ['debates', 'claims', 'space-1'], refetchType: 'active' });
+    expectInvalidated(invalidateQueries, { queryKey: ['debates', 'space', 'space-1'], refetchType: 'active' });
     releaseAgain();
   });
 
@@ -391,6 +440,23 @@ describe('DebateGatewayClient', () => {
     );
   });
 
+  it('honors server retry hints longer than the normal reconnect cap', async () => {
+    client.start(
+      vi.fn(async () => 'privy-token'),
+      'user-a'
+    );
+    await vi.runAllTicks();
+    sockets[0]!.open();
+    sockets[0]!.receive('READY', readyPayload([]));
+    await flushInvalidations();
+
+    sockets[0]!.receive('ERROR', { code: 'rate_limited', message: 'retry after 45 seconds' });
+    await vi.advanceTimersByTimeAsync(44_999);
+    expect(sockets).toHaveLength(1);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(sockets).toHaveLength(2);
+  });
+
   it('shows degraded mode without reconnecting when the subscription cap is reached', async () => {
     client.start(
       vi.fn(async () => 'privy-token'),
@@ -406,7 +472,22 @@ describe('DebateGatewayClient', () => {
     expect(client.getSnapshot()).toEqual({ status: 'degraded', paused: true });
   });
 
+  it('pauses live updates when a subscription is rejected', async () => {
+    client.start(
+      vi.fn(async () => 'privy-token'),
+      'user-a'
+    );
+    await vi.runAllTicks();
+    sockets[0]!.open();
+    sockets[0]!.receive('READY', readyPayload([]));
+
+    sockets[0]!.receive('ERROR', { code: 'subscription_forbidden', message: 'not authorized' });
+
+    expect(client.getSnapshot()).toEqual({ status: 'degraded', paused: true });
+  });
+
   it('reconnects with a new session when the authenticated account changes', async () => {
+    queryClient.setQueryData(['debates', 'account', 'user-a', 'activity'], { private: 'user-a' });
     client.start(
       vi.fn(async () => 'user-a-privy-token'),
       'user-a'
@@ -422,6 +503,7 @@ describe('DebateGatewayClient', () => {
     await vi.runAllTicks();
 
     expect(sockets[0]!.readyState).toBe(FakeWebSocket.CLOSED);
+    expect(queryClient.getQueryData(['debates', 'account', 'user-a', 'activity'])).toBeUndefined();
     expect(getSession.mock.calls[1]?.[1]).toBe('user-b');
     expect(sockets[1]!.url).toContain('access_token=user-b-access-token');
   });
@@ -449,6 +531,22 @@ describe('DebateGatewayClient', () => {
     sockets[0]!.receive('READY', readyPayload([]));
     expect(client.getSnapshot()).toEqual({ status: 'ready', paused: false });
   });
+
+  it('ignores malformed protocol envelopes', async () => {
+    client.start(
+      vi.fn(async () => 'privy-token'),
+      'user-a'
+    );
+    await vi.runAllTicks();
+    sockets[0]!.open();
+
+    expect(() => {
+      sockets[0]!.receiveRaw('null');
+      sockets[0]!.receiveRaw('42');
+      sockets[0]!.receiveRaw(JSON.stringify({ v: 1, op: 5, payload: {} }));
+    }).not.toThrow();
+    expect(client.getSnapshot()).toEqual({ status: 'connecting', paused: false });
+  });
 });
 
 function readyPayload(subscriptions: unknown[]) {
@@ -462,4 +560,8 @@ function readyPayload(subscriptions: unknown[]) {
 
 async function flushInvalidations() {
   await vi.advanceTimersByTimeAsync(50);
+}
+
+function expectInvalidated(invalidateQueries: ReturnType<typeof vi.spyOn>, filters: unknown) {
+  expect(invalidateQueries.mock.calls).toContainEqual([filters, { throwOnError: true }]);
 }

--- a/apps/web/core/debates/debate-gateway.test.ts
+++ b/apps/web/core/debates/debate-gateway.test.ts
@@ -63,6 +63,14 @@ describe('DebateGatewayClient', () => {
   let queryClient: QueryClient;
   let invalidateQueries: ReturnType<typeof vi.spyOn>;
   let session: DebateGatewaySession;
+  let getSession: ReturnType<
+    typeof vi.fn<
+      (
+        getPrivyIdentityToken: () => Promise<string | null | undefined>,
+        accountKey: string
+      ) => Promise<DebateGatewaySession>
+    >
+  >;
   let client: DebateGatewayClient;
 
   beforeEach(() => {
@@ -76,9 +84,10 @@ describe('DebateGatewayClient', () => {
       refresh_token: 'refresh-token',
       expires_at: '2026-07-20T12:10:00.000Z',
     };
+    getSession = vi.fn(async () => session);
     client = new DebateGatewayClient({
       queryClient,
-      getSession: vi.fn(async () => session),
+      getSession,
       getApiBaseUrl: () => 'https://chat.example.com/',
       createWebSocket: url => {
         const socket = new FakeWebSocket(url);
@@ -99,19 +108,23 @@ describe('DebateGatewayClient', () => {
     const releaseFirst = client.retainScope({ scope: 'space', space_id: 'space-1' });
     const releaseSecond = client.retainScope({ scope: 'space', space_id: 'space-1' });
 
-    client.start(vi.fn(async () => 'privy-token'));
+    client.start(
+      vi.fn(async () => 'privy-token'),
+      'user-a'
+    );
     await vi.runAllTicks();
 
     expect(sockets[0]?.url).toBe('wss://chat.example.com/gateway/ws?access_token=access+token');
     sockets[0]!.open();
     sockets[0]!.receive('READY', readyPayload([]));
+    await flushInvalidations();
 
     expect(sockets[0]!.sent).toContainEqual(
       expect.objectContaining({ op: 'SUBSCRIBE', payload: { scope: 'space', space_id: 'space-1' } })
     );
 
     sockets[0]!.receive('READY', readyPayload([{ scope: 'space', space_id: 'space-1' }]));
-    await vi.runAllTicks();
+    await flushInvalidations();
 
     expect(invalidateQueries).toHaveBeenCalledWith({
       queryKey: ['debates', 'claims', 'space-1'],
@@ -130,11 +143,16 @@ describe('DebateGatewayClient', () => {
     );
   });
 
-  it('deduplicates events and coalesces targeted invalidations in the same turn', async () => {
-    client.start(vi.fn(async () => 'privy-token'));
+  it('deduplicates events and coalesces invalidations across adjacent gateway messages', async () => {
+    client.start(
+      vi.fn(async () => 'privy-token'),
+      'user-a'
+    );
     await vi.runAllTicks();
     sockets[0]!.open();
     sockets[0]!.receive('READY', readyPayload([]));
+    await flushInvalidations();
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['debates'], refetchType: 'active' });
     invalidateQueries.mockClear();
 
     const event = {
@@ -144,16 +162,19 @@ describe('DebateGatewayClient', () => {
     };
     sockets[0]!.receive('EVENT', event, 1);
     sockets[0]!.receive('EVENT', event, 2);
-    await vi.runAllTicks();
+    await vi.advanceTimersByTimeAsync(25);
+    sockets[0]!.receive('EVENT', { ...event, event_id: 'event-2' }, 3);
+    await vi.advanceTimersByTimeAsync(25);
 
     expect(invalidateQueries.mock.calls).toEqual(
       expect.arrayContaining([
         [{ queryKey: ['debates', 'media', 'debate-1'], refetchType: 'active' }],
         [{ queryKey: ['debates', 'detail', 'debate-1'], refetchType: 'active' }],
+        [{ queryKey: ['debates', 'transcript', 'debate-1'], refetchType: 'active' }],
         [{ queryKey: ['debates', 'space', 'space-1'], refetchType: 'active' }],
       ])
     );
-    expect(invalidateQueries).toHaveBeenCalledTimes(3);
+    expect(invalidateQueries).toHaveBeenCalledTimes(4);
   });
 
   it.each([
@@ -177,14 +198,18 @@ describe('DebateGatewayClient', () => {
     ],
     ['share prompts', { event_type: 'debate.share_prompts_changed', payload: {} }, [['debates', 'share-prompts']]],
   ])('maps %s events to their authoritative query families', async (_label, event, expectedKeys) => {
-    client.start(vi.fn(async () => 'privy-token'));
+    client.start(
+      vi.fn(async () => 'privy-token'),
+      'user-a'
+    );
     await vi.runAllTicks();
     sockets[0]!.open();
     sockets[0]!.receive('READY', readyPayload([]));
+    await flushInvalidations();
     invalidateQueries.mockClear();
 
     sockets[0]!.receive('EVENT', { event_id: `event-${String(_label)}`, ...event });
-    await vi.runAllTicks();
+    await flushInvalidations();
 
     for (const queryKey of expectedKeys) {
       expect(invalidateQueries).toHaveBeenCalledWith({ queryKey, refetchType: 'active' });
@@ -197,16 +222,21 @@ describe('DebateGatewayClient', () => {
     queryClient.setQueryData(['debates', 'claims', 'space-1', ['claim-2']], {});
     const refetchQueries = vi.spyOn(queryClient, 'refetchQueries').mockResolvedValue();
 
-    client.start(vi.fn(async () => 'privy-token'));
+    client.start(
+      vi.fn(async () => 'privy-token'),
+      'user-a'
+    );
     await vi.runAllTicks();
     sockets[0]!.open();
     sockets[0]!.receive('READY', readyPayload([]));
+    await flushInvalidations();
+    invalidateQueries.mockClear();
     sockets[0]!.receive('EVENT', {
       event_id: 'event-claims',
       event_type: 'debate.claims_changed',
       payload: { space_id: 'space-1', claim_entity_ids: ['claim-2'] },
     });
-    await vi.runAllTicks();
+    await flushInvalidations();
 
     type InvalidationFilters = NonNullable<Parameters<QueryClient['invalidateQueries']>[0]>;
     const invalidationCalls = invalidateQueries.mock.calls as unknown as Array<[InvalidationFilters]>;
@@ -222,7 +252,10 @@ describe('DebateGatewayClient', () => {
   });
 
   it('sends presence heartbeats and reconnects after two missed acknowledgements', async () => {
-    client.start(vi.fn(async () => 'privy-token'));
+    client.start(
+      vi.fn(async () => 'privy-token'),
+      'user-a'
+    );
     await vi.runAllTicks();
     sockets[0]!.open();
     sockets[0]!.receive('HELLO', { heartbeat_interval_ms: 1_000 });
@@ -241,7 +274,10 @@ describe('DebateGatewayClient', () => {
   });
 
   it('resets missed acknowledgements and keeps the live socket connected', async () => {
-    client.start(vi.fn(async () => 'privy-token'));
+    client.start(
+      vi.fn(async () => 'privy-token'),
+      'user-a'
+    );
     await vi.runAllTicks();
     sockets[0]!.open();
     sockets[0]!.receive('HELLO', { heartbeat_interval_ms: 1_000 });
@@ -255,10 +291,14 @@ describe('DebateGatewayClient', () => {
   });
 
   it('uses bounded exponential reconnects and broadly reconciles after reconnect or lag', async () => {
-    client.start(vi.fn(async () => 'privy-token'));
+    client.start(
+      vi.fn(async () => 'privy-token'),
+      'user-a'
+    );
     await vi.runAllTicks();
     sockets[0]!.open();
     sockets[0]!.receive('READY', readyPayload([]));
+    await flushInvalidations();
     invalidateQueries.mockClear();
 
     sockets[0]!.serverClose();
@@ -270,18 +310,21 @@ describe('DebateGatewayClient', () => {
 
     sockets[1]!.open();
     sockets[1]!.receive('READY', readyPayload([]));
-    await vi.runAllTicks();
+    await flushInvalidations();
     expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['debates'], refetchType: 'active' });
 
     invalidateQueries.mockClear();
     sockets[1]!.receive('ERROR', { code: 'events_lagged', message: 'events skipped' });
-    await vi.runAllTicks();
+    await flushInvalidations();
     expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['debates'], refetchType: 'active' });
   });
 
   it('rotates the socket thirty seconds before token expiry', async () => {
     session = { ...session, expires_at: '2026-07-20T12:01:00.000Z' };
-    client.start(vi.fn(async () => 'privy-token'));
+    client.start(
+      vi.fn(async () => 'privy-token'),
+      'user-a'
+    );
     await vi.runAllTicks();
     sockets[0]!.open();
     sockets[0]!.receive('READY', readyPayload([]));
@@ -290,6 +333,97 @@ describe('DebateGatewayClient', () => {
     expect(sockets).toHaveLength(1);
     await vi.advanceTimersByTimeAsync(1_001);
     expect(sockets).toHaveLength(2);
+  });
+
+  it('reconciles a scope again when READY confirms an unsubscribe/resubscribe race', async () => {
+    const release = client.retainScope({ scope: 'space', space_id: 'space-1' });
+    client.start(
+      vi.fn(async () => 'privy-token'),
+      'user-a'
+    );
+    await vi.runAllTicks();
+    sockets[0]!.open();
+    sockets[0]!.receive('READY', readyPayload([{ scope: 'space', space_id: 'space-1' }]));
+    await flushInvalidations();
+    invalidateQueries.mockClear();
+
+    release();
+    const releaseAgain = client.retainScope({ scope: 'space', space_id: 'space-1' });
+    sockets[0]!.receive('READY', readyPayload([]));
+    await flushInvalidations();
+    sockets[0]!.receive('READY', readyPayload([{ scope: 'space', space_id: 'space-1' }]));
+    await flushInvalidations();
+
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ['debates', 'claims', 'space-1'],
+      refetchType: 'active',
+    });
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ['debates', 'space', 'space-1'],
+      refetchType: 'active',
+    });
+    releaseAgain();
+  });
+
+  it('reconnects and replays desired subscriptions after a rate-limited command', async () => {
+    client.retainScope({ scope: 'space', space_id: 'space-1' });
+    client.start(
+      vi.fn(async () => 'privy-token'),
+      'user-a'
+    );
+    await vi.runAllTicks();
+    sockets[0]!.open();
+    sockets[0]!.receive('READY', readyPayload([]));
+    await flushInvalidations();
+
+    sockets[0]!.receive('ERROR', { code: 'rate_limited', message: 'retry after 5 seconds' });
+    expect(sockets[0]!.readyState).toBe(FakeWebSocket.CLOSED);
+    expect(client.getSnapshot()).toEqual({ status: 'degraded', paused: true });
+
+    await vi.advanceTimersByTimeAsync(4_999);
+    expect(sockets).toHaveLength(1);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(sockets).toHaveLength(2);
+    sockets[1]!.open();
+    sockets[1]!.receive('READY', readyPayload([]));
+    expect(sockets[1]!.sent).toContainEqual(
+      expect.objectContaining({ op: 'SUBSCRIBE', payload: { scope: 'space', space_id: 'space-1' } })
+    );
+  });
+
+  it('shows degraded mode without reconnecting when the subscription cap is reached', async () => {
+    client.start(
+      vi.fn(async () => 'privy-token'),
+      'user-a'
+    );
+    await vi.runAllTicks();
+    sockets[0]!.open();
+    sockets[0]!.receive('READY', readyPayload([]));
+
+    sockets[0]!.receive('ERROR', { code: 'subscription_limit_reached', message: 'too many subscriptions' });
+
+    expect(sockets[0]!.readyState).toBe(FakeWebSocket.OPEN);
+    expect(client.getSnapshot()).toEqual({ status: 'degraded', paused: true });
+  });
+
+  it('reconnects with a new session when the authenticated account changes', async () => {
+    client.start(
+      vi.fn(async () => 'user-a-privy-token'),
+      'user-a'
+    );
+    await vi.runAllTicks();
+    expect(getSession.mock.calls[0]?.[1]).toBe('user-a');
+
+    session = { ...session, access_token: 'user-b-access-token' };
+    client.start(
+      vi.fn(async () => 'user-b-privy-token'),
+      'user-b'
+    );
+    await vi.runAllTicks();
+
+    expect(sockets[0]!.readyState).toBe(FakeWebSocket.CLOSED);
+    expect(getSession.mock.calls[1]?.[1]).toBe('user-b');
+    expect(sockets[1]!.url).toContain('access_token=user-b-access-token');
   });
 
   it('never opens a socket while stopped, which keeps signed-out views snapshot-only', async () => {
@@ -302,7 +436,10 @@ describe('DebateGatewayClient', () => {
   });
 
   it('enters degraded mode when the server lacks the required capability and recovers on READY', async () => {
-    client.start(vi.fn(async () => 'privy-token'));
+    client.start(
+      vi.fn(async () => 'privy-token'),
+      'user-a'
+    );
     await vi.runAllTicks();
     sockets[0]!.open();
     sockets[0]!.receive('READY', { ...readyPayload([]), capabilities: [] });
@@ -321,4 +458,8 @@ function readyPayload(subscriptions: unknown[]) {
     capabilities: ['debate_invalidations_v1'],
     subscriptions,
   };
+}
+
+async function flushInvalidations() {
+  await vi.advanceTimersByTimeAsync(50);
 }

--- a/apps/web/core/debates/debate-gateway.ts
+++ b/apps/web/core/debates/debate-gateway.ts
@@ -54,7 +54,7 @@ type WebSocketLike = {
 
 type DebateGatewayClientOptions = {
   queryClient: QueryClient;
-  getSession: (getPrivyIdentityToken: GetPrivyIdentityToken) => Promise<DebateGatewaySession>;
+  getSession: (getPrivyIdentityToken: GetPrivyIdentityToken, accountKey: string) => Promise<DebateGatewaySession>;
   getApiBaseUrl: () => string;
   createWebSocket?: (url: string) => WebSocketLike;
   random?: () => number;
@@ -66,6 +66,8 @@ const OPEN = 1;
 const CAPABILITY = 'debate_invalidations_v1';
 const MAX_RECENT_EVENT_IDS = 256;
 const DEFAULT_HEARTBEAT_INTERVAL_MS = 30_000;
+const INVALIDATION_COALESCE_MS = 50;
+const BROAD_INVALIDATION_KEY = 'debates:all';
 
 export class DebateGatewayClient {
   private readonly queryClient: QueryClient;
@@ -83,6 +85,7 @@ export class DebateGatewayClient {
 
   private snapshot: DebateGatewaySnapshot = { status: 'idle', paused: false };
   private getPrivyIdentityToken: GetPrivyIdentityToken | null = null;
+  private accountKey: string | null = null;
   private socket: WebSocketLike | null = null;
   private enabled = false;
   private hasReachedReady = false;
@@ -94,7 +97,7 @@ export class DebateGatewayClient {
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private heartbeatTimer: ReturnType<typeof setTimeout> | null = null;
   private tokenRotationTimer: ReturnType<typeof setTimeout> | null = null;
-  private invalidationFlushQueued = false;
+  private invalidationTimer: ReturnType<typeof setTimeout> | null = null;
   private connectionGeneration = 0;
 
   constructor(options: DebateGatewayClientOptions) {
@@ -112,8 +115,10 @@ export class DebateGatewayClient {
     return () => this.listeners.delete(listener);
   };
 
-  start(getPrivyIdentityToken: GetPrivyIdentityToken) {
+  start(getPrivyIdentityToken: GetPrivyIdentityToken, accountKey: string) {
+    if (this.enabled && this.accountKey !== accountKey) this.stop();
     this.getPrivyIdentityToken = getPrivyIdentityToken;
+    this.accountKey = accountKey;
     if (this.enabled) return;
     this.enabled = true;
     this.setSnapshot({ status: 'connecting', paused: false });
@@ -123,6 +128,7 @@ export class DebateGatewayClient {
   stop() {
     this.enabled = false;
     this.getPrivyIdentityToken = null;
+    this.accountKey = null;
     this.hasReachedReady = false;
     this.lastSequence = null;
     this.reconnectAttempt = 0;
@@ -130,6 +136,7 @@ export class DebateGatewayClient {
     this.disposeSocket();
     this.sentScopes.clear();
     this.confirmedScopes.clear();
+    this.pendingInvalidations.clear();
     this.setSnapshot({ status: 'idle', paused: false });
   }
 
@@ -160,11 +167,12 @@ export class DebateGatewayClient {
 
   private async connect() {
     const getPrivyIdentityToken = this.getPrivyIdentityToken;
-    if (!this.enabled || !getPrivyIdentityToken || this.socket) return;
+    const accountKey = this.accountKey;
+    if (!this.enabled || !getPrivyIdentityToken || !accountKey || this.socket) return;
     const generation = ++this.connectionGeneration;
 
     try {
-      const session = await this.getSession(getPrivyIdentityToken);
+      const session = await this.getSession(getPrivyIdentityToken, accountKey);
       if (!this.enabled || generation !== this.connectionGeneration) return;
 
       const socket = this.createWebSocket(gatewayWebSocketUrl(this.getApiBaseUrl(), session.access_token));
@@ -214,7 +222,13 @@ export class DebateGatewayClient {
         this.queueBroadReconcile();
         break;
       case 'ERROR':
-        if (isEventsLagged(envelope.payload)) this.queueBroadReconcile();
+        if (isEventsLagged(envelope.payload)) {
+          this.queueBroadReconcile();
+        } else if (isRateLimited(envelope.payload)) {
+          this.forceReconnect(socket, rateLimitRetryDelayMs(envelope.payload));
+        } else if (isSubscriptionLimitReached(envelope.payload)) {
+          this.setSnapshot({ status: 'degraded', paused: true });
+        }
         break;
     }
   }
@@ -242,17 +256,26 @@ export class DebateGatewayClient {
     this.setSnapshot({ status: 'ready', paused: false });
 
     if (firstReadyForSocket) {
+      this.queueBroadReconcile();
       if (this.hasReachedReady) {
-        this.queueBroadReconcile();
         if (this.lastSequence !== null) this.sendEnvelope('RESUME', {}, this.lastSequence);
       }
       this.hasReachedReady = true;
     }
 
+    const readyScopes = new Map<string, DebateGatewayScope>();
     for (const subscription of Array.isArray(ready.subscriptions) ? ready.subscriptions : []) {
       const scope = parseScope(subscription);
       if (!scope) continue;
       const key = scopeKey(scope);
+      readyScopes.set(key, scope);
+    }
+
+    for (const key of this.confirmedScopes) {
+      if (!readyScopes.has(key)) this.confirmedScopes.delete(key);
+    }
+
+    for (const [key, scope] of readyScopes) {
       if (!this.scopes.has(key) || this.confirmedScopes.has(key)) continue;
       this.confirmedScopes.add(key);
       this.queueScopeReconcile(scope);
@@ -290,6 +313,7 @@ export class DebateGatewayClient {
         if (identifiers.debate_id) {
           this.queueQuery(['debates', 'media', identifiers.debate_id]);
           this.queueQuery(['debates', 'detail', identifiers.debate_id]);
+          this.queueQuery(['debates', 'transcript', identifiers.debate_id]);
         }
         if (identifiers.space_id) this.queueQuery(['debates', 'space', identifiers.space_id]);
         break;
@@ -319,7 +343,7 @@ export class DebateGatewayClient {
   }
 
   private queueBroadReconcile() {
-    this.queueQuery(['debates']);
+    this.queueInvalidation(BROAD_INVALIDATION_KEY, { queryKey: ['debates'], refetchType: 'active' });
   }
 
   private queueClaims(spaceId: string, claimEntityIds?: string[]) {
@@ -348,15 +372,19 @@ export class DebateGatewayClient {
   }
 
   private queueInvalidation(key: string, filters: InvalidationFilters) {
+    if (key === BROAD_INVALIDATION_KEY) {
+      this.pendingInvalidations.clear();
+    } else if (this.pendingInvalidations.has(BROAD_INVALIDATION_KEY)) {
+      return;
+    }
     this.pendingInvalidations.set(key, filters);
-    if (this.invalidationFlushQueued) return;
-    this.invalidationFlushQueued = true;
-    queueMicrotask(() => {
-      this.invalidationFlushQueued = false;
+    if (this.invalidationTimer) return;
+    this.invalidationTimer = setTimeout(() => {
+      this.invalidationTimer = null;
       const invalidations = [...this.pendingInvalidations.values()];
       this.pendingInvalidations.clear();
       for (const queryFilters of invalidations) void this.queryClient.invalidateQueries(queryFilters);
-    });
+    }, INVALIDATION_COALESCE_MS);
   }
 
   private sendSubscription(scope: DebateGatewayScope, op: 'SUBSCRIBE' | 'UNSUBSCRIBE') {
@@ -415,7 +443,7 @@ export class DebateGatewayClient {
     this.scheduleReconnect();
   }
 
-  private forceReconnect(socket: WebSocketLike) {
+  private forceReconnect(socket: WebSocketLike, minimumDelayMs = 0) {
     if (socket !== this.socket) return;
     this.socket = null;
     this.readyForDebates = false;
@@ -424,13 +452,13 @@ export class DebateGatewayClient {
     socket.close();
     if (!this.enabled) return;
     this.setSnapshot({ status: 'degraded', paused: true });
-    this.scheduleReconnect();
+    this.scheduleReconnect(minimumDelayMs);
   }
 
-  private scheduleReconnect() {
+  private scheduleReconnect(minimumDelayMs = 0) {
     if (!this.enabled || this.reconnectTimer) return;
     const baseDelay = Math.min(30_000, 1_000 * 2 ** this.reconnectAttempt);
-    const delay = Math.min(30_000, Math.round(baseDelay + baseDelay * 0.2 * this.random()));
+    const delay = Math.min(30_000, Math.max(minimumDelayMs, Math.round(baseDelay + baseDelay * 0.2 * this.random())));
     this.reconnectAttempt += 1;
     this.reconnectTimer = setTimeout(() => {
       this.reconnectTimer = null;
@@ -456,6 +484,8 @@ export class DebateGatewayClient {
   private clearAllTimers() {
     this.clearConnectionTimers();
     this.clearTimer('reconnect');
+    if (this.invalidationTimer) clearTimeout(this.invalidationTimer);
+    this.invalidationTimer = null;
   }
 
   private clearTimer(timer: 'heartbeat' | 'reconnect' | 'token') {
@@ -479,15 +509,19 @@ const debateGateway = new DebateGatewayClient({
   getApiBaseUrl: getGeoChatApiBaseUrl,
 });
 
-export function useDebateGateway(enabled: boolean, getPrivyIdentityToken: GetPrivyIdentityToken) {
+export function useDebateGateway(
+  enabled: boolean,
+  getPrivyIdentityToken: GetPrivyIdentityToken,
+  accountKey: string | null
+) {
   React.useEffect(() => {
-    if (!enabled) {
+    if (!enabled || !accountKey) {
       debateGateway.stop();
       return;
     }
-    debateGateway.start(getPrivyIdentityToken);
+    debateGateway.start(getPrivyIdentityToken, accountKey);
     return () => debateGateway.stop();
-  }, [enabled, getPrivyIdentityToken]);
+  }, [accountKey, enabled, getPrivyIdentityToken]);
 
   return React.useSyncExternalStore(debateGateway.subscribe, debateGateway.getSnapshot, debateGateway.getSnapshot);
 }
@@ -530,6 +564,20 @@ function parseScope(value: unknown): DebateGatewayScope | null {
 
 function isEventsLagged(payload: unknown) {
   return isRecord(payload) && payload.code === 'events_lagged';
+}
+
+function isRateLimited(payload: unknown) {
+  return isRecord(payload) && payload.code === 'rate_limited';
+}
+
+function isSubscriptionLimitReached(payload: unknown) {
+  return isRecord(payload) && payload.code === 'subscription_limit_reached';
+}
+
+function rateLimitRetryDelayMs(payload: unknown) {
+  if (!isRecord(payload) || typeof payload.message !== 'string') return 1_000;
+  const seconds = payload.message.match(/retry after (\d+) seconds/)?.[1];
+  return seconds ? Number(seconds) * 1_000 : 1_000;
 }
 
 function isDebateEvent(value: unknown): value is DebateInvalidationEvent {

--- a/apps/web/core/debates/debate-gateway.ts
+++ b/apps/web/core/debates/debate-gateway.ts
@@ -1,0 +1,546 @@
+'use client';
+
+import type { QueryClient, QueryKey } from '@tanstack/react-query';
+
+import * as React from 'react';
+
+import { queryClient } from '~/core/query-client';
+
+import { type GeoChatSession, type GetPrivyIdentityToken, getGeoChatApiBaseUrl, getGeoChatSession } from './api';
+
+export type DebateGatewaySession = GeoChatSession;
+
+export type DebateGatewayScope = { scope: 'space'; space_id: string } | { scope: 'debate'; debate_id: string };
+
+export type DebateGatewaySnapshot = {
+  status: 'idle' | 'connecting' | 'ready' | 'degraded';
+  paused: boolean;
+};
+
+type DebateEventPayload = {
+  space_id?: string;
+  debate_id?: string;
+  rematch_session_id?: string;
+  claim_entity_ids?: string[];
+};
+
+type DebateInvalidationEvent = {
+  event_id: string;
+  event_type: string;
+  payload: DebateEventPayload;
+};
+
+type GatewayEnvelope = {
+  v: number;
+  op: string;
+  seq?: number | null;
+  payload: unknown;
+};
+
+type ReadyPayload = {
+  capabilities?: string[];
+  subscriptions?: unknown[];
+};
+
+type WebSocketLike = {
+  readyState: number;
+  onopen: (() => void) | null;
+  onmessage: ((event: { data: unknown }) => void) | null;
+  onerror: (() => void) | null;
+  onclose: (() => void) | null;
+  send(value: string): void;
+  close(): void;
+};
+
+type DebateGatewayClientOptions = {
+  queryClient: QueryClient;
+  getSession: (getPrivyIdentityToken: GetPrivyIdentityToken) => Promise<DebateGatewaySession>;
+  getApiBaseUrl: () => string;
+  createWebSocket?: (url: string) => WebSocketLike;
+  random?: () => number;
+};
+
+type InvalidationFilters = NonNullable<Parameters<QueryClient['invalidateQueries']>[0]>;
+
+const OPEN = 1;
+const CAPABILITY = 'debate_invalidations_v1';
+const MAX_RECENT_EVENT_IDS = 256;
+const DEFAULT_HEARTBEAT_INTERVAL_MS = 30_000;
+
+export class DebateGatewayClient {
+  private readonly queryClient: QueryClient;
+  private readonly getSession: DebateGatewayClientOptions['getSession'];
+  private readonly getApiBaseUrl: DebateGatewayClientOptions['getApiBaseUrl'];
+  private readonly createWebSocket: NonNullable<DebateGatewayClientOptions['createWebSocket']>;
+  private readonly random: () => number;
+  private readonly listeners = new Set<() => void>();
+  private readonly scopes = new Map<string, { scope: DebateGatewayScope; count: number }>();
+  private readonly sentScopes = new Set<string>();
+  private readonly confirmedScopes = new Set<string>();
+  private readonly recentEventIds = new Set<string>();
+  private readonly recentEventIdOrder: string[] = [];
+  private readonly pendingInvalidations = new Map<string, InvalidationFilters>();
+
+  private snapshot: DebateGatewaySnapshot = { status: 'idle', paused: false };
+  private getPrivyIdentityToken: GetPrivyIdentityToken | null = null;
+  private socket: WebSocketLike | null = null;
+  private enabled = false;
+  private hasReachedReady = false;
+  private readyForDebates = false;
+  private lastSequence: number | null = null;
+  private reconnectAttempt = 0;
+  private heartbeatIntervalMs = DEFAULT_HEARTBEAT_INTERVAL_MS;
+  private heartbeatsAwaitingAck = 0;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private heartbeatTimer: ReturnType<typeof setTimeout> | null = null;
+  private tokenRotationTimer: ReturnType<typeof setTimeout> | null = null;
+  private invalidationFlushQueued = false;
+  private connectionGeneration = 0;
+
+  constructor(options: DebateGatewayClientOptions) {
+    this.queryClient = options.queryClient;
+    this.getSession = options.getSession;
+    this.getApiBaseUrl = options.getApiBaseUrl;
+    this.createWebSocket = options.createWebSocket ?? (url => new WebSocket(url) as unknown as WebSocketLike);
+    this.random = options.random ?? Math.random;
+  }
+
+  getSnapshot = () => this.snapshot;
+
+  subscribe = (listener: () => void) => {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  };
+
+  start(getPrivyIdentityToken: GetPrivyIdentityToken) {
+    this.getPrivyIdentityToken = getPrivyIdentityToken;
+    if (this.enabled) return;
+    this.enabled = true;
+    this.setSnapshot({ status: 'connecting', paused: false });
+    void this.connect();
+  }
+
+  stop() {
+    this.enabled = false;
+    this.getPrivyIdentityToken = null;
+    this.hasReachedReady = false;
+    this.lastSequence = null;
+    this.reconnectAttempt = 0;
+    this.clearAllTimers();
+    this.disposeSocket();
+    this.sentScopes.clear();
+    this.confirmedScopes.clear();
+    this.setSnapshot({ status: 'idle', paused: false });
+  }
+
+  retainScope(scope: DebateGatewayScope) {
+    const key = scopeKey(scope);
+    const retained = this.scopes.get(key);
+    if (retained) {
+      retained.count += 1;
+    } else {
+      this.scopes.set(key, { scope, count: 1 });
+      this.sendSubscription(scope, 'SUBSCRIBE');
+    }
+
+    let released = false;
+    return () => {
+      if (released) return;
+      released = true;
+      const current = this.scopes.get(key);
+      if (!current) return;
+      current.count -= 1;
+      if (current.count > 0) return;
+      this.scopes.delete(key);
+      this.sentScopes.delete(key);
+      this.confirmedScopes.delete(key);
+      this.sendSubscription(scope, 'UNSUBSCRIBE');
+    };
+  }
+
+  private async connect() {
+    const getPrivyIdentityToken = this.getPrivyIdentityToken;
+    if (!this.enabled || !getPrivyIdentityToken || this.socket) return;
+    const generation = ++this.connectionGeneration;
+
+    try {
+      const session = await this.getSession(getPrivyIdentityToken);
+      if (!this.enabled || generation !== this.connectionGeneration) return;
+
+      const socket = this.createWebSocket(gatewayWebSocketUrl(this.getApiBaseUrl(), session.access_token));
+      this.socket = socket;
+      this.readyForDebates = false;
+      this.sentScopes.clear();
+      this.confirmedScopes.clear();
+      this.scheduleTokenRotation(session);
+
+      socket.onopen = () => undefined;
+      socket.onmessage = event => this.handleMessage(socket, event.data);
+      socket.onerror = () => this.forceReconnect(socket);
+      socket.onclose = () => this.handleClose(socket);
+    } catch {
+      if (!this.enabled || generation !== this.connectionGeneration) return;
+      this.setSnapshot({ status: 'degraded', paused: true });
+      this.scheduleReconnect();
+    }
+  }
+
+  private handleMessage(socket: WebSocketLike, value: unknown) {
+    if (socket !== this.socket || typeof value !== 'string') return;
+
+    let envelope: GatewayEnvelope;
+    try {
+      envelope = JSON.parse(value) as GatewayEnvelope;
+    } catch {
+      return;
+    }
+    if (envelope.v !== 1) return;
+    if (typeof envelope.seq === 'number') this.lastSequence = Math.max(this.lastSequence ?? 0, envelope.seq);
+
+    switch (envelope.op) {
+      case 'HELLO':
+        this.handleHello(envelope.payload);
+        break;
+      case 'READY':
+        this.handleReady(envelope.payload);
+        break;
+      case 'EVENT':
+        this.handleEvent(envelope.payload);
+        break;
+      case 'HEARTBEAT_ACK':
+        this.heartbeatsAwaitingAck = 0;
+        break;
+      case 'RESUME':
+        this.queueBroadReconcile();
+        break;
+      case 'ERROR':
+        if (isEventsLagged(envelope.payload)) this.queueBroadReconcile();
+        break;
+    }
+  }
+
+  private handleHello(payload: unknown) {
+    if (isRecord(payload) && typeof payload.heartbeat_interval_ms === 'number') {
+      this.heartbeatIntervalMs = Math.max(1_000, payload.heartbeat_interval_ms);
+    }
+    this.heartbeatsAwaitingAck = 0;
+    this.sendHeartbeat();
+  }
+
+  private handleReady(payload: unknown) {
+    const ready = isRecord(payload) ? (payload as ReadyPayload) : {};
+    const supportsDebates = Array.isArray(ready.capabilities) && ready.capabilities.includes(CAPABILITY);
+    if (!supportsDebates) {
+      this.readyForDebates = false;
+      this.setSnapshot({ status: 'degraded', paused: true });
+      return;
+    }
+
+    const firstReadyForSocket = !this.readyForDebates;
+    this.readyForDebates = true;
+    this.reconnectAttempt = 0;
+    this.setSnapshot({ status: 'ready', paused: false });
+
+    if (firstReadyForSocket) {
+      if (this.hasReachedReady) {
+        this.queueBroadReconcile();
+        if (this.lastSequence !== null) this.sendEnvelope('RESUME', {}, this.lastSequence);
+      }
+      this.hasReachedReady = true;
+    }
+
+    for (const subscription of Array.isArray(ready.subscriptions) ? ready.subscriptions : []) {
+      const scope = parseScope(subscription);
+      if (!scope) continue;
+      const key = scopeKey(scope);
+      if (!this.scopes.has(key) || this.confirmedScopes.has(key)) continue;
+      this.confirmedScopes.add(key);
+      this.queueScopeReconcile(scope);
+    }
+
+    for (const { scope } of this.scopes.values()) this.sendSubscription(scope, 'SUBSCRIBE');
+  }
+
+  private handleEvent(payload: unknown) {
+    if (!isDebateEvent(payload) || this.recentEventIds.has(payload.event_id)) return;
+    this.rememberEvent(payload.event_id);
+    const identifiers = payload.payload;
+
+    switch (payload.event_type) {
+      case 'debate.activity_changed':
+        this.queueQuery(['debates', 'activity']);
+        break;
+      case 'debate.claims_changed':
+        if (identifiers.space_id) {
+          this.queueClaims(identifiers.space_id, identifiers.claim_entity_ids);
+        }
+        break;
+      case 'debate.state_changed':
+        if (identifiers.debate_id) this.queueQuery(['debates', 'detail', identifiers.debate_id]);
+        if (identifiers.space_id) this.queueQuery(['debates', 'space', identifiers.space_id]);
+        this.queueQuery(['debates', 'activity']);
+        break;
+      case 'debate.rematch_changed':
+        if (identifiers.rematch_session_id) {
+          this.queueQuery(['debates', 'rematch', identifiers.rematch_session_id]);
+        }
+        this.queueQuery(['debates', 'activity']);
+        break;
+      case 'debate.media_changed':
+        if (identifiers.debate_id) {
+          this.queueQuery(['debates', 'media', identifiers.debate_id]);
+          this.queueQuery(['debates', 'detail', identifiers.debate_id]);
+        }
+        if (identifiers.space_id) this.queueQuery(['debates', 'space', identifiers.space_id]);
+        break;
+      case 'debate.share_prompts_changed':
+        this.queueQuery(['debates', 'share-prompts']);
+        break;
+    }
+  }
+
+  private rememberEvent(eventId: string) {
+    this.recentEventIds.add(eventId);
+    this.recentEventIdOrder.push(eventId);
+    if (this.recentEventIdOrder.length <= MAX_RECENT_EVENT_IDS) return;
+    const expired = this.recentEventIdOrder.shift();
+    if (expired) this.recentEventIds.delete(expired);
+  }
+
+  private queueScopeReconcile(scope: DebateGatewayScope) {
+    if (scope.scope === 'space') {
+      this.queueQuery(['debates', 'claims', scope.space_id]);
+      this.queueQuery(['debates', 'space', scope.space_id]);
+      return;
+    }
+    this.queueQuery(['debates', 'detail', scope.debate_id]);
+    this.queueQuery(['debates', 'media', scope.debate_id]);
+    this.queueQuery(['debates', 'transcript', scope.debate_id]);
+  }
+
+  private queueBroadReconcile() {
+    this.queueQuery(['debates']);
+  }
+
+  private queueClaims(spaceId: string, claimEntityIds?: string[]) {
+    if (!claimEntityIds?.length) {
+      this.queueQuery(['debates', 'claims', spaceId]);
+      return;
+    }
+    const changedClaims = new Set(claimEntityIds);
+    this.queueInvalidation(`claims:${spaceId}:${claimEntityIds.slice().sort().join(',')}`, {
+      predicate: query => {
+        const [root, kind, querySpaceId, queryClaimIds] = query.queryKey;
+        return (
+          root === 'debates' &&
+          kind === 'claims' &&
+          querySpaceId === spaceId &&
+          Array.isArray(queryClaimIds) &&
+          queryClaimIds.some(claimId => typeof claimId === 'string' && changedClaims.has(claimId))
+        );
+      },
+      refetchType: 'active',
+    });
+  }
+
+  private queueQuery(queryKey: QueryKey) {
+    this.queueInvalidation(`query:${JSON.stringify(queryKey)}`, { queryKey, refetchType: 'active' });
+  }
+
+  private queueInvalidation(key: string, filters: InvalidationFilters) {
+    this.pendingInvalidations.set(key, filters);
+    if (this.invalidationFlushQueued) return;
+    this.invalidationFlushQueued = true;
+    queueMicrotask(() => {
+      this.invalidationFlushQueued = false;
+      const invalidations = [...this.pendingInvalidations.values()];
+      this.pendingInvalidations.clear();
+      for (const queryFilters of invalidations) void this.queryClient.invalidateQueries(queryFilters);
+    });
+  }
+
+  private sendSubscription(scope: DebateGatewayScope, op: 'SUBSCRIBE' | 'UNSUBSCRIBE') {
+    if (!this.readyForDebates || !this.socket || this.socket.readyState !== OPEN) return;
+    const key = scopeKey(scope);
+    if (op === 'SUBSCRIBE') {
+      if (this.sentScopes.has(key)) return;
+      this.sentScopes.add(key);
+    }
+    this.sendEnvelope(op, scope);
+  }
+
+  private sendHeartbeat() {
+    this.clearTimer('heartbeat');
+    if (!this.socket || this.socket.readyState !== OPEN) return;
+    if (this.heartbeatsAwaitingAck >= 2) {
+      this.forceReconnect(this.socket);
+      return;
+    }
+    this.heartbeatsAwaitingAck += 1;
+    this.sendEnvelope('HEARTBEAT', { debate_presence: true }, this.lastSequence);
+    this.heartbeatTimer = setTimeout(() => this.sendHeartbeat(), this.heartbeatIntervalMs);
+  }
+
+  private sendEnvelope(op: string, payload: unknown, seq: number | null = null) {
+    if (!this.socket || this.socket.readyState !== OPEN) return;
+    this.socket.send(
+      JSON.stringify({
+        v: 1,
+        op,
+        seq,
+        request_id: null,
+        space_id: null,
+        room_id: null,
+        room_kind: null,
+        payload,
+      })
+    );
+  }
+
+  private scheduleTokenRotation(session: DebateGatewaySession) {
+    this.clearTimer('token');
+    const delay = Math.max(0, new Date(session.expires_at).getTime() - Date.now() - 30_000);
+    this.tokenRotationTimer = setTimeout(() => {
+      if (this.socket) this.forceReconnect(this.socket);
+    }, delay);
+  }
+
+  private handleClose(socket: WebSocketLike) {
+    if (socket !== this.socket) return;
+    this.socket = null;
+    this.readyForDebates = false;
+    this.clearConnectionTimers();
+    if (!this.enabled) return;
+    this.setSnapshot({ status: 'degraded', paused: true });
+    this.scheduleReconnect();
+  }
+
+  private forceReconnect(socket: WebSocketLike) {
+    if (socket !== this.socket) return;
+    this.socket = null;
+    this.readyForDebates = false;
+    this.clearConnectionTimers();
+    socket.onclose = null;
+    socket.close();
+    if (!this.enabled) return;
+    this.setSnapshot({ status: 'degraded', paused: true });
+    this.scheduleReconnect();
+  }
+
+  private scheduleReconnect() {
+    if (!this.enabled || this.reconnectTimer) return;
+    const baseDelay = Math.min(30_000, 1_000 * 2 ** this.reconnectAttempt);
+    const delay = Math.min(30_000, Math.round(baseDelay + baseDelay * 0.2 * this.random()));
+    this.reconnectAttempt += 1;
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      void this.connect();
+    }, delay);
+  }
+
+  private disposeSocket() {
+    const socket = this.socket;
+    this.socket = null;
+    this.readyForDebates = false;
+    if (!socket) return;
+    socket.onclose = null;
+    socket.close();
+  }
+
+  private clearConnectionTimers() {
+    this.clearTimer('heartbeat');
+    this.clearTimer('token');
+    this.heartbeatsAwaitingAck = 0;
+  }
+
+  private clearAllTimers() {
+    this.clearConnectionTimers();
+    this.clearTimer('reconnect');
+  }
+
+  private clearTimer(timer: 'heartbeat' | 'reconnect' | 'token') {
+    const field =
+      timer === 'heartbeat' ? 'heartbeatTimer' : timer === 'reconnect' ? 'reconnectTimer' : 'tokenRotationTimer';
+    const current = this[field];
+    if (current) clearTimeout(current);
+    this[field] = null;
+  }
+
+  private setSnapshot(snapshot: DebateGatewaySnapshot) {
+    if (snapshot.status === this.snapshot.status && snapshot.paused === this.snapshot.paused) return;
+    this.snapshot = snapshot;
+    for (const listener of this.listeners) listener();
+  }
+}
+
+const debateGateway = new DebateGatewayClient({
+  queryClient,
+  getSession: getGeoChatSession,
+  getApiBaseUrl: getGeoChatApiBaseUrl,
+});
+
+export function useDebateGateway(enabled: boolean, getPrivyIdentityToken: GetPrivyIdentityToken) {
+  React.useEffect(() => {
+    if (!enabled) {
+      debateGateway.stop();
+      return;
+    }
+    debateGateway.start(getPrivyIdentityToken);
+    return () => debateGateway.stop();
+  }, [enabled, getPrivyIdentityToken]);
+
+  return React.useSyncExternalStore(debateGateway.subscribe, debateGateway.getSnapshot, debateGateway.getSnapshot);
+}
+
+export function useDebateGatewayScope(scope: DebateGatewayScope, enabled: boolean) {
+  const scopeType = scope.scope;
+  const scopeId = scope.scope === 'space' ? scope.space_id : scope.debate_id;
+
+  React.useEffect(() => {
+    if (!enabled || !scopeId) return;
+    return debateGateway.retainScope(
+      scopeType === 'space' ? { scope: 'space', space_id: scopeId } : { scope: 'debate', debate_id: scopeId }
+    );
+  }, [enabled, scopeId, scopeType]);
+}
+
+function gatewayWebSocketUrl(apiBaseUrl: string, accessToken: string) {
+  const url = new URL(apiBaseUrl);
+  url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
+  url.pathname = `${url.pathname.replace(/\/+$/, '')}/gateway/ws`;
+  url.search = '';
+  url.searchParams.set('access_token', accessToken);
+  return url.toString();
+}
+
+function scopeKey(scope: DebateGatewayScope) {
+  return scope.scope === 'space' ? `space:${scope.space_id}` : `debate:${scope.debate_id}`;
+}
+
+function parseScope(value: unknown): DebateGatewayScope | null {
+  if (!isRecord(value)) return null;
+  if (value.scope === 'space' && typeof value.space_id === 'string') {
+    return { scope: 'space', space_id: value.space_id };
+  }
+  if (value.scope === 'debate' && typeof value.debate_id === 'string') {
+    return { scope: 'debate', debate_id: value.debate_id };
+  }
+  return null;
+}
+
+function isEventsLagged(payload: unknown) {
+  return isRecord(payload) && payload.code === 'events_lagged';
+}
+
+function isDebateEvent(value: unknown): value is DebateInvalidationEvent {
+  return (
+    isRecord(value) &&
+    typeof value.event_id === 'string' &&
+    typeof value.event_type === 'string' &&
+    isRecord(value.payload)
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}

--- a/apps/web/core/debates/debate-gateway.ts
+++ b/apps/web/core/debates/debate-gateway.ts
@@ -66,6 +66,7 @@ const OPEN = 1;
 const CAPABILITY = 'debate_invalidations_v1';
 const MAX_RECENT_EVENT_IDS = 256;
 const DEFAULT_HEARTBEAT_INTERVAL_MS = 30_000;
+const HANDSHAKE_TIMEOUT_MS = 10_000;
 const INVALIDATION_COALESCE_MS = 50;
 const BROAD_INVALIDATION_KEY = 'debates:all';
 
@@ -96,6 +97,7 @@ export class DebateGatewayClient {
   private heartbeatsAwaitingAck = 0;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private heartbeatTimer: ReturnType<typeof setTimeout> | null = null;
+  private handshakeTimer: ReturnType<typeof setTimeout> | null = null;
   private tokenRotationTimer: ReturnType<typeof setTimeout> | null = null;
   private invalidationTimer: ReturnType<typeof setTimeout> | null = null;
   private connectionGeneration = 0;
@@ -126,6 +128,7 @@ export class DebateGatewayClient {
   }
 
   stop() {
+    const accountKey = this.accountKey;
     this.enabled = false;
     this.getPrivyIdentityToken = null;
     this.accountKey = null;
@@ -137,6 +140,7 @@ export class DebateGatewayClient {
     this.sentScopes.clear();
     this.confirmedScopes.clear();
     this.pendingInvalidations.clear();
+    if (accountKey) this.queryClient.removeQueries({ queryKey: ['debates'] });
     this.setSnapshot({ status: 'idle', paused: false });
   }
 
@@ -181,6 +185,7 @@ export class DebateGatewayClient {
       this.sentScopes.clear();
       this.confirmedScopes.clear();
       this.scheduleTokenRotation(session);
+      this.handshakeTimer = setTimeout(() => this.forceReconnect(socket), HANDSHAKE_TIMEOUT_MS);
 
       socket.onopen = () => undefined;
       socket.onmessage = event => this.handleMessage(socket, event.data);
@@ -196,13 +201,14 @@ export class DebateGatewayClient {
   private handleMessage(socket: WebSocketLike, value: unknown) {
     if (socket !== this.socket || typeof value !== 'string') return;
 
-    let envelope: GatewayEnvelope;
+    let parsed: unknown;
     try {
-      envelope = JSON.parse(value) as GatewayEnvelope;
+      parsed = JSON.parse(value) as unknown;
     } catch {
       return;
     }
-    if (envelope.v !== 1) return;
+    if (!isGatewayEnvelope(parsed)) return;
+    const envelope = parsed;
     if (typeof envelope.seq === 'number') this.lastSequence = Math.max(this.lastSequence ?? 0, envelope.seq);
 
     switch (envelope.op) {
@@ -228,6 +234,8 @@ export class DebateGatewayClient {
           this.forceReconnect(socket, rateLimitRetryDelayMs(envelope.payload));
         } else if (isSubscriptionLimitReached(envelope.payload)) {
           this.setSnapshot({ status: 'degraded', paused: true });
+        } else {
+          this.setSnapshot({ status: 'degraded', paused: true });
         }
         break;
     }
@@ -242,6 +250,7 @@ export class DebateGatewayClient {
   }
 
   private handleReady(payload: unknown) {
+    this.clearTimer('handshake');
     const ready = isRecord(payload) ? (payload as ReadyPayload) : {};
     const supportsDebates = Array.isArray(ready.capabilities) && ready.capabilities.includes(CAPABILITY);
     if (!supportsDebates) {
@@ -252,7 +261,6 @@ export class DebateGatewayClient {
 
     const firstReadyForSocket = !this.readyForDebates;
     this.readyForDebates = true;
-    this.reconnectAttempt = 0;
     this.setSnapshot({ status: 'ready', paused: false });
 
     if (firstReadyForSocket) {
@@ -291,7 +299,7 @@ export class DebateGatewayClient {
 
     switch (payload.event_type) {
       case 'debate.activity_changed':
-        this.queueQuery(['debates', 'activity']);
+        this.queueAccountQuery('activity');
         break;
       case 'debate.claims_changed':
         if (identifiers.space_id) {
@@ -301,13 +309,13 @@ export class DebateGatewayClient {
       case 'debate.state_changed':
         if (identifiers.debate_id) this.queueQuery(['debates', 'detail', identifiers.debate_id]);
         if (identifiers.space_id) this.queueQuery(['debates', 'space', identifiers.space_id]);
-        this.queueQuery(['debates', 'activity']);
+        this.queueAccountQuery('activity');
         break;
       case 'debate.rematch_changed':
         if (identifiers.rematch_session_id) {
-          this.queueQuery(['debates', 'rematch', identifiers.rematch_session_id]);
+          this.queueAccountQuery('rematch', identifiers.rematch_session_id);
         }
-        this.queueQuery(['debates', 'activity']);
+        this.queueAccountQuery('activity');
         break;
       case 'debate.media_changed':
         if (identifiers.debate_id) {
@@ -318,7 +326,7 @@ export class DebateGatewayClient {
         if (identifiers.space_id) this.queueQuery(['debates', 'space', identifiers.space_id]);
         break;
       case 'debate.share_prompts_changed':
-        this.queueQuery(['debates', 'share-prompts']);
+        this.queueAccountQuery('share-prompts');
         break;
     }
   }
@@ -344,6 +352,13 @@ export class DebateGatewayClient {
 
   private queueBroadReconcile() {
     this.queueInvalidation(BROAD_INVALIDATION_KEY, { queryKey: ['debates'], refetchType: 'active' });
+  }
+
+  private queueAccountQuery(kind: 'activity' | 'rematch' | 'share-prompts', id?: string) {
+    if (!this.accountKey) return;
+    this.queueQuery(
+      id ? ['debates', 'account', this.accountKey, kind, id] : ['debates', 'account', this.accountKey, kind]
+    );
   }
 
   private queueClaims(spaceId: string, claimEntityIds?: string[]) {
@@ -383,8 +398,24 @@ export class DebateGatewayClient {
       this.invalidationTimer = null;
       const invalidations = [...this.pendingInvalidations.values()];
       this.pendingInvalidations.clear();
-      for (const queryFilters of invalidations) void this.queryClient.invalidateQueries(queryFilters);
+      void this.flushInvalidations(invalidations);
     }, INVALIDATION_COALESCE_MS);
+  }
+
+  private async flushInvalidations(invalidations: InvalidationFilters[]) {
+    const results = await Promise.allSettled(
+      invalidations.map(async queryFilters => {
+        await this.queryClient.cancelQueries(queryFilters);
+        await this.queryClient.invalidateQueries(queryFilters, { throwOnError: true });
+      })
+    );
+    if (results.some(result => result.status === 'rejected')) {
+      this.recentEventIds.clear();
+      this.recentEventIdOrder.length = 0;
+      if (this.socket) this.forceReconnect(this.socket);
+      return;
+    }
+    this.reconnectAttempt = 0;
   }
 
   private sendSubscription(scope: DebateGatewayScope, op: 'SUBSCRIBE' | 'UNSUBSCRIBE') {
@@ -458,7 +489,7 @@ export class DebateGatewayClient {
   private scheduleReconnect(minimumDelayMs = 0) {
     if (!this.enabled || this.reconnectTimer) return;
     const baseDelay = Math.min(30_000, 1_000 * 2 ** this.reconnectAttempt);
-    const delay = Math.min(30_000, Math.max(minimumDelayMs, Math.round(baseDelay + baseDelay * 0.2 * this.random())));
+    const delay = Math.max(minimumDelayMs, Math.min(30_000, Math.round(baseDelay + baseDelay * 0.2 * this.random())));
     this.reconnectAttempt += 1;
     this.reconnectTimer = setTimeout(() => {
       this.reconnectTimer = null;
@@ -477,6 +508,7 @@ export class DebateGatewayClient {
 
   private clearConnectionTimers() {
     this.clearTimer('heartbeat');
+    this.clearTimer('handshake');
     this.clearTimer('token');
     this.heartbeatsAwaitingAck = 0;
   }
@@ -488,9 +520,15 @@ export class DebateGatewayClient {
     this.invalidationTimer = null;
   }
 
-  private clearTimer(timer: 'heartbeat' | 'reconnect' | 'token') {
+  private clearTimer(timer: 'handshake' | 'heartbeat' | 'reconnect' | 'token') {
     const field =
-      timer === 'heartbeat' ? 'heartbeatTimer' : timer === 'reconnect' ? 'reconnectTimer' : 'tokenRotationTimer';
+      timer === 'handshake'
+        ? 'handshakeTimer'
+        : timer === 'heartbeat'
+          ? 'heartbeatTimer'
+          : timer === 'reconnect'
+            ? 'reconnectTimer'
+            : 'tokenRotationTimer';
     const current = this[field];
     if (current) clearTimeout(current);
     this[field] = null;
@@ -578,6 +616,10 @@ function rateLimitRetryDelayMs(payload: unknown) {
   if (!isRecord(payload) || typeof payload.message !== 'string') return 1_000;
   const seconds = payload.message.match(/retry after (\d+) seconds/)?.[1];
   return seconds ? Number(seconds) * 1_000 : 1_000;
+}
+
+function isGatewayEnvelope(value: unknown): value is GatewayEnvelope {
+  return isRecord(value) && value.v === 1 && typeof value.op === 'string' && 'payload' in value;
 }
 
 function isDebateEvent(value: unknown): value is DebateInvalidationEvent {

--- a/apps/web/core/debates/hooks-query-network.test.tsx
+++ b/apps/web/core/debates/hooks-query-network.test.tsx
@@ -21,7 +21,7 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock('@geogenesis/auth', () => ({
-  usePrivy: () => ({ ready: true, authenticated: mocks.authenticated }),
+  usePrivy: () => ({ ready: true, authenticated: mocks.authenticated, user: { id: 'user-a' } }),
 }));
 
 vi.mock('@tanstack/react-query', async importOriginal => ({
@@ -60,7 +60,7 @@ describe('debate query network ownership', () => {
 
     expect(mocks.useQuery).toHaveBeenCalledTimes(9);
     for (const [options] of mocks.useQuery.mock.calls) {
-      expect(options).toMatchObject({ refetchOnReconnect: false, refetchOnWindowFocus: false });
+      expect(options).toMatchObject({ retry: false, refetchOnReconnect: false, refetchOnWindowFocus: false });
       expect(options).not.toHaveProperty('refetchInterval');
     }
   });

--- a/apps/web/core/debates/hooks-query-network.test.tsx
+++ b/apps/web/core/debates/hooks-query-network.test.tsx
@@ -1,0 +1,90 @@
+import { renderHook } from '@testing-library/react';
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  useDebate,
+  useDebateActivity,
+  useDebateClaims,
+  useDebateMedia,
+  useDebateRematch,
+  useDebateRematchClaims,
+  useDebateSharePrompts,
+  useDebateTranscript,
+  useSpaceDebates,
+} from './hooks';
+
+const mocks = vi.hoisted(() => ({
+  authenticated: true,
+  useQuery: vi.fn((options: unknown) => options),
+  useScope: vi.fn(),
+}));
+
+vi.mock('@geogenesis/auth', () => ({
+  usePrivy: () => ({ ready: true, authenticated: mocks.authenticated }),
+}));
+
+vi.mock('@tanstack/react-query', async importOriginal => ({
+  ...(await importOriginal<typeof import('@tanstack/react-query')>()),
+  useQuery: mocks.useQuery,
+}));
+
+vi.mock('~/core/auth/identity-token', () => ({
+  getCachedIdentityToken: vi.fn(),
+  useIdentityTokenSync: vi.fn(),
+}));
+
+vi.mock('./debate-gateway', () => ({
+  useDebateGatewayScope: mocks.useScope,
+}));
+
+beforeEach(() => {
+  mocks.authenticated = true;
+  mocks.useQuery.mockClear();
+  mocks.useScope.mockClear();
+});
+
+describe('debate query network ownership', () => {
+  it('disables polling and generic browser refetches for every debate query', () => {
+    renderHook(() => {
+      useDebateClaims('space-1', ['claim-1'], true);
+      useDebateActivity();
+      useSpaceDebates('space-1', true);
+      useDebate('debate-1', true);
+      useDebateRematch('rematch-1');
+      useDebateRematchClaims('rematch-1', ['claim-1']);
+      useDebateSharePrompts();
+      useDebateMedia('debate-1', true);
+      useDebateTranscript('debate-1');
+    });
+
+    expect(mocks.useQuery).toHaveBeenCalledTimes(9);
+    for (const [options] of mocks.useQuery.mock.calls) {
+      expect(options).toMatchObject({ refetchOnReconnect: false, refetchOnWindowFocus: false });
+      expect(options).not.toHaveProperty('refetchInterval');
+    }
+  });
+
+  it('registers only authenticated space and debate scopes', () => {
+    const { rerender } = renderHook(() => {
+      useDebateClaims('space-1', ['claim-1'], true);
+      useSpaceDebates('space-1', true);
+      useDebate('debate-1', true);
+      useDebateMedia('debate-1', true);
+      useDebateTranscript('debate-1');
+    });
+
+    expect(mocks.useScope.mock.calls).toEqual([
+      [{ scope: 'space', space_id: 'space-1' }, true],
+      [{ scope: 'space', space_id: 'space-1' }, true],
+      [{ scope: 'debate', debate_id: 'debate-1' }, true],
+      [{ scope: 'debate', debate_id: 'debate-1' }, true],
+      [{ scope: 'debate', debate_id: 'debate-1' }, true],
+    ]);
+
+    mocks.authenticated = false;
+    mocks.useScope.mockClear();
+    rerender();
+    expect(mocks.useScope.mock.calls.every(([, enabled]) => enabled === false)).toBe(true);
+  });
+});

--- a/apps/web/core/debates/hooks.test.tsx
+++ b/apps/web/core/debates/hooks.test.tsx
@@ -8,7 +8,13 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { setCachedIdentityToken } from '~/core/auth/identity-token';
 
 import type { DebateActivity, DebateRematchSession } from './api';
-import { debateQueryKeys, useClearTimedOutDebateActivity, useConsentToDebateRematch, useGeoChatAuth } from './hooks';
+import {
+  debateQueryKeys,
+  useClearTimedOutDebateActivity,
+  useConsentToDebateRematch,
+  useDebateActivity,
+  useGeoChatAuth,
+} from './hooks';
 
 const mocks = vi.hoisted(() => ({
   getIdentityToken: vi.fn(),
@@ -192,6 +198,41 @@ describe('useClearTimedOutDebateActivity', () => {
       cooldown_until: null,
       debate: null,
     });
+  });
+});
+
+describe('debate query refresh behavior', () => {
+  it('does not issue periodic debate reads while time advances', async () => {
+    vi.useFakeTimers();
+    window.localStorage.setItem(
+      'geo:chat-session',
+      JSON.stringify({
+        access_token: 'access-token',
+        refresh_token: 'refresh-token',
+        expires_at: new Date(Date.now() + 10 * 60_000).toISOString(),
+      })
+    );
+    const fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ online: true, cooldown_until: null, match: null, debate: null, rematch: null }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+    vi.stubGlobal('fetch', fetch);
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+
+    renderHook(() => useDebateActivity(), { wrapper });
+    await vi.waitFor(() => expect(fetch).toHaveBeenCalledTimes(1));
+
+    await act(async () => vi.advanceTimersByTimeAsync(60_000));
+    expect(fetch).toHaveBeenCalledTimes(1);
+
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    window.localStorage.clear();
   });
 });
 

--- a/apps/web/core/debates/hooks.test.tsx
+++ b/apps/web/core/debates/hooks.test.tsx
@@ -1,4 +1,4 @@
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClient, QueryClientProvider, focusManager, onlineManager } from '@tanstack/react-query';
 import { act, renderHook } from '@testing-library/react';
 
 import type { ReactNode } from 'react';
@@ -7,30 +7,42 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { setCachedIdentityToken } from '~/core/auth/identity-token';
 
-import type { DebateActivity, DebateRematchSession } from './api';
+import type { Debate, DebateActivity, DebateRematchSession } from './api';
 import {
   debateQueryKeys,
   useClearTimedOutDebateActivity,
   useConsentToDebateRematch,
+  useDebate,
   useDebateActivity,
   useGeoChatAuth,
+  useMarkDebateReady,
 } from './hooks';
 
 const mocks = vi.hoisted(() => ({
+  authenticated: true,
   getIdentityToken: vi.fn(),
   identityToken: vi.fn(),
   consentToDebateRematch: vi.fn(),
+  markDebateReady: vi.fn(),
 }));
 
 vi.mock('@geogenesis/auth', () => ({
   getIdentityToken: mocks.getIdentityToken,
   useIdentityToken: () => ({ identityToken: mocks.identityToken() }),
-  usePrivy: () => ({ ready: true, authenticated: true }),
+  usePrivy: () => ({ ready: true, authenticated: mocks.authenticated, user: { id: 'user-a' } }),
+}));
+
+vi.mock('./debate-gateway', () => ({
+  useDebateGatewayScope: vi.fn(),
 }));
 
 vi.mock('./api', async importOriginal => {
   const actual = await importOriginal<typeof import('./api')>();
-  return { ...actual, consentToDebateRematch: mocks.consentToDebateRematch };
+  return {
+    ...actual,
+    consentToDebateRematch: mocks.consentToDebateRematch,
+    markDebateReady: mocks.markDebateReady,
+  };
 });
 
 function jwtExpiringIn(seconds: number) {
@@ -40,9 +52,11 @@ function jwtExpiringIn(seconds: number) {
 
 describe('useGeoChatAuth', () => {
   beforeEach(() => {
+    mocks.authenticated = true;
     mocks.getIdentityToken.mockReset();
     mocks.identityToken.mockReset();
     mocks.consentToDebateRematch.mockReset();
+    mocks.markDebateReady.mockReset();
     setCachedIdentityToken(null);
   });
 
@@ -147,6 +161,7 @@ describe('useGeoChatAuth', () => {
 describe('useConsentToDebateRematch', () => {
   it('replaces stale debate activity with the authoritative rematch session', async () => {
     const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false }, queries: { retry: false } } });
+    const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries').mockResolvedValue();
     const staleActivity: DebateActivity = {
       online: true,
       cooldown_until: null,
@@ -155,7 +170,7 @@ describe('useConsentToDebateRematch', () => {
       rematch: null,
     };
     const session = rematchSession();
-    queryClient.setQueryData(debateQueryKeys.activity, staleActivity);
+    queryClient.setQueryData(debateQueryKeys.activity('user-a'), staleActivity);
     mocks.consentToDebateRematch.mockResolvedValue(session);
 
     const wrapper = ({ children }: { children: ReactNode }) => (
@@ -165,13 +180,36 @@ describe('useConsentToDebateRematch', () => {
 
     await act(() => result.current.mutateAsync());
 
-    expect(queryClient.getQueryData(debateQueryKeys.activity)).toEqual({
+    expect(queryClient.getQueryData(debateQueryKeys.activity('user-a'))).toEqual({
       online: true,
       cooldown_until: null,
       match: null,
       debate: null,
       rematch: session,
     });
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: debateQueryKeys.activity('user-a') });
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: debateQueryKeys.rematch('user-a', session.id) });
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: debateQueryKeys.debate('debate-1') });
+  });
+});
+
+describe('authoritative mutation reconciliation', () => {
+  it('invalidates debate detail after applying the mutation response', async () => {
+    const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false }, queries: { retry: false } } });
+    const debate = { id: 'debate-1', status: 'ready' } as unknown as Debate;
+    mocks.markDebateReady.mockResolvedValue(debate);
+    const setQueryData = vi.spyOn(queryClient, 'setQueryData');
+    const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries').mockResolvedValue();
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    const { result } = renderHook(() => useMarkDebateReady('debate-1'), { wrapper });
+
+    await act(() => result.current.mutateAsync());
+
+    expect(setQueryData).toHaveBeenCalledWith(debateQueryKeys.debate('debate-1'), debate);
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: debateQueryKeys.debate('debate-1') });
+    expect(setQueryData.mock.invocationCallOrder[0]).toBeLessThan(invalidateQueries.mock.invocationCallOrder[0]!);
   });
 });
 
@@ -185,7 +223,7 @@ describe('useClearTimedOutDebateActivity', () => {
       debate: { id: 'debate-1' } as NonNullable<DebateActivity['debate']>,
       rematch: null,
     };
-    queryClient.setQueryData(debateQueryKeys.activity, activity);
+    queryClient.setQueryData(debateQueryKeys.activity('user-a'), activity);
     const wrapper = ({ children }: { children: ReactNode }) => (
       <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
     );
@@ -193,7 +231,7 @@ describe('useClearTimedOutDebateActivity', () => {
 
     act(() => result.current('debate-1'));
 
-    expect(queryClient.getQueryData(debateQueryKeys.activity)).toEqual({
+    expect(queryClient.getQueryData(debateQueryKeys.activity('user-a'))).toEqual({
       ...activity,
       cooldown_until: null,
       debate: null,
@@ -207,9 +245,12 @@ describe('debate query refresh behavior', () => {
     window.localStorage.setItem(
       'geo:chat-session',
       JSON.stringify({
-        access_token: 'access-token',
-        refresh_token: 'refresh-token',
-        expires_at: new Date(Date.now() + 10 * 60_000).toISOString(),
+        account_key: 'user-a',
+        session: {
+          access_token: 'access-token',
+          refresh_token: 'refresh-token',
+          expires_at: new Date(Date.now() + 10 * 60_000).toISOString(),
+        },
       })
     );
     const fetch = vi.fn().mockResolvedValue(
@@ -233,6 +274,66 @@ describe('debate query refresh behavior', () => {
     vi.useRealTimers();
     vi.unstubAllGlobals();
     window.localStorage.clear();
+  });
+
+  it('does not refetch active debate queries on focus or generic reconnect', async () => {
+    const wasFocused = focusManager.isFocused();
+    const wasOnline = onlineManager.isOnline();
+    window.localStorage.setItem(
+      'geo:chat-session',
+      JSON.stringify({
+        account_key: 'user-a',
+        session: {
+          access_token: 'access-token',
+          refresh_token: 'refresh-token',
+          expires_at: new Date(Date.now() + 10 * 60_000).toISOString(),
+        },
+      })
+    );
+    const fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ id: 'debate-1' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+    vi.stubGlobal('fetch', fetch);
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+
+    renderHook(() => useDebate('debate-1', true), { wrapper });
+    await vi.waitFor(() => expect(fetch).toHaveBeenCalledTimes(1));
+
+    act(() => focusManager.setFocused(false));
+    act(() => focusManager.setFocused(true));
+    act(() => onlineManager.setOnline(false));
+    act(() => onlineManager.setOnline(true));
+    await Promise.resolve();
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    focusManager.setFocused(wasFocused);
+    onlineManager.setOnline(wasOnline);
+    vi.unstubAllGlobals();
+    window.localStorage.clear();
+  });
+
+  it('performs only one failed public snapshot request while signed out', async () => {
+    mocks.authenticated = false;
+    setCachedIdentityToken(null);
+    window.localStorage.clear();
+    const fetch = vi.fn().mockResolvedValue(new Response('', { status: 503, statusText: 'Service Unavailable' }));
+    vi.stubGlobal('fetch', fetch);
+    const queryClient = new QueryClient();
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+
+    const { result } = renderHook(() => useDebate('public-debate', true), { wrapper });
+    await vi.waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    vi.unstubAllGlobals();
   });
 });
 

--- a/apps/web/core/debates/hooks.ts
+++ b/apps/web/core/debates/hooks.ts
@@ -33,7 +33,6 @@ import {
   getLiveKitToken,
   getRecordingUrl,
   handleDebateSharePrompt,
-  heartbeatDebatePresence,
   joinDebateQueue,
   leaveDebateQueue,
   leaveDebateRematch,
@@ -48,6 +47,12 @@ import {
   updateDebatePreference,
   updateDebateRematchPosition,
 } from './api';
+import { useDebateGatewayScope } from './debate-gateway';
+
+const debateQueryNetworkOptions = {
+  refetchOnReconnect: false,
+  refetchOnWindowFocus: false,
+} as const;
 
 export const debateQueryKeys = {
   claims: (spaceId: string, claimIds: string[]) => ['debates', 'claims', spaceId, claimIds] as const,
@@ -74,13 +79,14 @@ export function useGeoChatAuth() {
 }
 
 export function useDebateClaims(spaceId: string, claimIds: string[], enabled: boolean) {
-  const { getPrivyIdentityToken } = useGeoChatAuth();
+  const { authenticated, getPrivyIdentityToken } = useGeoChatAuth();
+  useDebateGatewayScope({ scope: 'space', space_id: spaceId }, enabled && authenticated && claimIds.length > 0);
 
   return useQuery({
+    ...debateQueryNetworkOptions,
     queryKey: debateQueryKeys.claims(spaceId, claimIds),
     queryFn: () => listDebateClaims(spaceId, claimIds, getPrivyIdentityToken),
     enabled: enabled && claimIds.length > 0,
-    refetchInterval: 5_000,
   });
 }
 
@@ -124,10 +130,10 @@ export function useDebateActivity(enabled = true) {
   const { authenticated, getPrivyIdentityToken } = useGeoChatAuth();
 
   return useQuery({
+    ...debateQueryNetworkOptions,
     queryKey: debateQueryKeys.activity,
     queryFn: () => getDebateActivity(getPrivyIdentityToken),
     enabled: enabled && authenticated,
-    refetchInterval: 2_000,
   });
 }
 
@@ -144,23 +150,6 @@ export function useClearTimedOutDebateActivity() {
     },
     [queryClient]
   );
-}
-
-export function useDebatePresenceHeartbeat(enabled = true) {
-  const queryClient = useQueryClient();
-  const { authenticated, getPrivyIdentityToken } = useGeoChatAuth();
-
-  return useQuery({
-    queryKey: ['debates', 'presence-heartbeat'],
-    queryFn: async () => {
-      const activity = await heartbeatDebatePresence(getPrivyIdentityToken);
-      await queryClient.invalidateQueries({ queryKey: debateQueryKeys.activity });
-      return activity;
-    },
-    enabled: enabled && authenticated,
-    refetchInterval: 15_000,
-    refetchIntervalInBackground: true,
-  });
 }
 
 export function useAcceptDebateMatch(spaceId?: string) {
@@ -194,24 +183,26 @@ export function useDeclineDebateMatch(spaceId?: string) {
 }
 
 export function useSpaceDebates(spaceId: string, enabled: boolean) {
-  const { getPrivyIdentityToken } = useGeoChatAuth();
+  const { authenticated, getPrivyIdentityToken } = useGeoChatAuth();
+  useDebateGatewayScope({ scope: 'space', space_id: spaceId }, enabled && authenticated);
 
   return useQuery({
+    ...debateQueryNetworkOptions,
     queryKey: debateQueryKeys.spaceDebates(spaceId),
     queryFn: () => listSpaceDebates(spaceId, getPrivyIdentityToken),
     enabled,
-    refetchInterval: 5_000,
   });
 }
 
 export function useDebate(debateId: string, enabled: boolean) {
-  const { getPrivyIdentityToken } = useGeoChatAuth();
+  const { authenticated, getPrivyIdentityToken } = useGeoChatAuth();
+  useDebateGatewayScope({ scope: 'debate', debate_id: debateId }, enabled && authenticated);
 
   return useQuery({
+    ...debateQueryNetworkOptions,
     queryKey: debateQueryKeys.debate(debateId),
     queryFn: () => getDebate(debateId, getPrivyIdentityToken),
     enabled,
-    refetchInterval: 1_000,
   });
 }
 
@@ -288,10 +279,10 @@ export function useDebateRematch(sessionId: string, enabled = true) {
   const { getPrivyIdentityToken } = useGeoChatAuth();
 
   return useQuery({
+    ...debateQueryNetworkOptions,
     queryKey: debateQueryKeys.rematch(sessionId),
     queryFn: () => getDebateRematch(sessionId, getPrivyIdentityToken),
     enabled: enabled && Boolean(sessionId),
-    refetchInterval: 1_000,
   });
 }
 
@@ -312,10 +303,10 @@ export function useDebateRematchClaims(sessionId: string, claimIds: string[] = [
   const { getPrivyIdentityToken } = useGeoChatAuth();
 
   return useQuery({
+    ...debateQueryNetworkOptions,
     queryKey: debateQueryKeys.rematchClaims(sessionId, claimIds),
     queryFn: () => listDebateRematchClaims(sessionId, claimIds, getPrivyIdentityToken),
     enabled: enabled && Boolean(sessionId),
-    refetchInterval: 2_000,
   });
 }
 
@@ -375,10 +366,10 @@ export function useDebateSharePrompts(enabled = true) {
   const { authenticated, getPrivyIdentityToken } = useGeoChatAuth();
 
   return useQuery({
+    ...debateQueryNetworkOptions,
     queryKey: debateQueryKeys.sharePrompts,
     queryFn: () => listDebateSharePrompts(getPrivyIdentityToken),
     enabled: enabled && authenticated,
-    refetchInterval: 5_000,
   });
 }
 
@@ -426,13 +417,14 @@ export function useRecordingUrl() {
 }
 
 export function useDebateMedia(debateId: string, enabled: boolean) {
-  const { getPrivyIdentityToken } = useGeoChatAuth();
+  const { authenticated, getPrivyIdentityToken } = useGeoChatAuth();
+  useDebateGatewayScope({ scope: 'debate', debate_id: debateId }, enabled && authenticated);
 
   return useQuery({
+    ...debateQueryNetworkOptions,
     queryKey: debateQueryKeys.media(debateId),
     queryFn: () => getDebateMedia(debateId, getPrivyIdentityToken),
     enabled,
-    refetchInterval: 5_000,
   });
 }
 
@@ -457,9 +449,11 @@ export function useDebateMediaArtifactUrl() {
 }
 
 export function useDebateTranscript(debateId: string, format: TranscriptFormat = 'json', enabled = true) {
-  const { getPrivyIdentityToken } = useGeoChatAuth();
+  const { authenticated, getPrivyIdentityToken } = useGeoChatAuth();
+  useDebateGatewayScope({ scope: 'debate', debate_id: debateId }, enabled && authenticated);
 
   return useQuery({
+    ...debateQueryNetworkOptions,
     queryKey: debateQueryKeys.transcript(debateId, format),
     queryFn: () => getDebateTranscript(debateId, format, getPrivyIdentityToken),
     enabled,

--- a/apps/web/core/debates/hooks.ts
+++ b/apps/web/core/debates/hooks.ts
@@ -74,6 +74,7 @@ export function useGeoChatAuth() {
   return {
     ready: privy.ready,
     authenticated: privy.authenticated,
+    accountKey: privy.user?.id ?? null,
     getPrivyIdentityToken: getCachedIdentityToken,
   };
 }

--- a/apps/web/core/debates/hooks.ts
+++ b/apps/web/core/debates/hooks.ts
@@ -50,6 +50,7 @@ import {
 import { useDebateGatewayScope } from './debate-gateway';
 
 const debateQueryNetworkOptions = {
+  retry: false,
   refetchOnReconnect: false,
   refetchOnWindowFocus: false,
 } as const;
@@ -60,11 +61,12 @@ export const debateQueryKeys = {
   debate: (debateId: string) => ['debates', 'detail', debateId] as const,
   media: (debateId: string) => ['debates', 'media', debateId] as const,
   transcript: (debateId: string, format: TranscriptFormat) => ['debates', 'transcript', debateId, format] as const,
-  activity: ['debates', 'activity'] as const,
-  rematch: (sessionId: string) => ['debates', 'rematch', sessionId] as const,
-  rematchClaims: (sessionId: string, claimIds: string[]) =>
-    ['debates', 'rematch', sessionId, 'claims', claimIds] as const,
-  sharePrompts: ['debates', 'share-prompts'] as const,
+  activity: (accountKey: string | null) => ['debates', 'account', accountKey, 'activity'] as const,
+  rematch: (accountKey: string | null, sessionId: string) =>
+    ['debates', 'account', accountKey, 'rematch', sessionId] as const,
+  rematchClaims: (accountKey: string | null, sessionId: string, claimIds: string[]) =>
+    ['debates', 'account', accountKey, 'rematch', sessionId, 'claims', claimIds] as const,
+  sharePrompts: (accountKey: string | null) => ['debates', 'account', accountKey, 'share-prompts'] as const,
 };
 
 export function useGeoChatAuth() {
@@ -80,24 +82,31 @@ export function useGeoChatAuth() {
 }
 
 export function useDebateClaims(spaceId: string, claimIds: string[], enabled: boolean) {
-  const { authenticated, getPrivyIdentityToken } = useGeoChatAuth();
+  const { accountKey, authenticated, getPrivyIdentityToken } = useGeoChatAuth();
   useDebateGatewayScope({ scope: 'space', space_id: spaceId }, enabled && authenticated && claimIds.length > 0);
 
   return useQuery({
     ...debateQueryNetworkOptions,
     queryKey: debateQueryKeys.claims(spaceId, claimIds),
-    queryFn: () => listDebateClaims(spaceId, claimIds, getPrivyIdentityToken),
+    queryFn: ({ signal }) =>
+      listDebateClaims(
+        spaceId,
+        claimIds,
+        authenticated ? getPrivyIdentityToken : undefined,
+        authenticated ? accountKey : null,
+        signal
+      ),
     enabled: enabled && claimIds.length > 0,
   });
 }
 
 export function useJoinDebateQueue(spaceId: string) {
   const queryClient = useQueryClient();
-  const { getPrivyIdentityToken } = useGeoChatAuth();
+  const { accountKey, getPrivyIdentityToken } = useGeoChatAuth();
 
   return useMutation({
     mutationFn: ({ claimId, request }: { claimId: string; request: JoinDebateQueueRequest }) =>
-      joinDebateQueue(spaceId, claimId, request, getPrivyIdentityToken),
+      joinDebateQueue(spaceId, claimId, request, getPrivyIdentityToken, accountKey),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['debates'] });
     },
@@ -106,10 +115,11 @@ export function useJoinDebateQueue(spaceId: string) {
 
 export function useLeaveDebateQueue(spaceId: string) {
   const queryClient = useQueryClient();
-  const { getPrivyIdentityToken } = useGeoChatAuth();
+  const { accountKey, getPrivyIdentityToken } = useGeoChatAuth();
 
   return useMutation({
-    mutationFn: ({ claimId }: { claimId: string }) => leaveDebateQueue(spaceId, claimId, getPrivyIdentityToken),
+    mutationFn: ({ claimId }: { claimId: string }) =>
+      leaveDebateQueue(spaceId, claimId, getPrivyIdentityToken, accountKey),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['debates'] });
     },
@@ -118,64 +128,65 @@ export function useLeaveDebateQueue(spaceId: string) {
 
 export function useUpdateDebatePreference(spaceId: string) {
   const queryClient = useQueryClient();
-  const { getPrivyIdentityToken } = useGeoChatAuth();
+  const { accountKey, getPrivyIdentityToken } = useGeoChatAuth();
 
   return useMutation({
     mutationFn: ({ claimId, position }: { claimId: string; position: boolean }) =>
-      updateDebatePreference(spaceId, claimId, { position }, getPrivyIdentityToken),
+      updateDebatePreference(spaceId, claimId, { position }, getPrivyIdentityToken, accountKey),
     onSuccess: () => void queryClient.invalidateQueries({ queryKey: ['debates'] }),
   });
 }
 
 export function useDebateActivity(enabled = true) {
-  const { authenticated, getPrivyIdentityToken } = useGeoChatAuth();
+  const { accountKey, authenticated, getPrivyIdentityToken } = useGeoChatAuth();
 
   return useQuery({
     ...debateQueryNetworkOptions,
-    queryKey: debateQueryKeys.activity,
-    queryFn: () => getDebateActivity(getPrivyIdentityToken),
+    queryKey: debateQueryKeys.activity(accountKey),
+    queryFn: ({ signal }) => getDebateActivity(getPrivyIdentityToken, accountKey, signal),
     enabled: enabled && authenticated,
   });
 }
 
 export function useClearTimedOutDebateActivity() {
   const queryClient = useQueryClient();
+  const { accountKey } = useGeoChatAuth();
 
   return React.useCallback(
     (debateId: string) => {
-      queryClient.setQueryData<DebateActivity>(debateQueryKeys.activity, current => {
+      queryClient.setQueryData<DebateActivity>(debateQueryKeys.activity(accountKey), current => {
         if (!current || current.debate?.id !== debateId) return current;
         return { ...current, debate: null, cooldown_until: null };
       });
-      void queryClient.invalidateQueries({ queryKey: debateQueryKeys.activity });
+      void queryClient.invalidateQueries({ queryKey: debateQueryKeys.activity(accountKey) });
     },
-    [queryClient]
+    [accountKey, queryClient]
   );
 }
 
 export function useAcceptDebateMatch(spaceId?: string) {
   const queryClient = useQueryClient();
-  const { getPrivyIdentityToken } = useGeoChatAuth();
+  const { accountKey, getPrivyIdentityToken } = useGeoChatAuth();
 
   return useMutation({
     mutationFn: ({ matchId, formatId }: { matchId: string; formatId?: string }) =>
-      acceptDebateMatch(matchId, getPrivyIdentityToken, formatId),
+      acceptDebateMatch(matchId, getPrivyIdentityToken, accountKey, formatId),
     onSuccess: result => {
-      void queryClient.invalidateQueries({ queryKey: ['debates'] });
-      if (spaceId) void queryClient.invalidateQueries({ queryKey: debateQueryKeys.spaceDebates(spaceId) });
       if (result.debate) {
         queryClient.setQueryData(debateQueryKeys.debate(result.debate.id), result.debate);
       }
+      void queryClient.invalidateQueries({ queryKey: ['debates'] });
+      if (spaceId) void queryClient.invalidateQueries({ queryKey: debateQueryKeys.spaceDebates(spaceId) });
     },
   });
 }
 
 export function useDeclineDebateMatch(spaceId?: string) {
   const queryClient = useQueryClient();
-  const { getPrivyIdentityToken } = useGeoChatAuth();
+  const { accountKey, getPrivyIdentityToken } = useGeoChatAuth();
 
   return useMutation({
-    mutationFn: (matchId: string) => declineDebateMatch(matchId, getPrivyIdentityToken),
+    mutationFn: (matchId: string) => declineDebateMatch(matchId, getPrivyIdentityToken, accountKey),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['debates'] });
       if (spaceId) void queryClient.invalidateQueries({ queryKey: debateQueryKeys.spaceDebates(spaceId) });
@@ -184,279 +195,328 @@ export function useDeclineDebateMatch(spaceId?: string) {
 }
 
 export function useSpaceDebates(spaceId: string, enabled: boolean) {
-  const { authenticated, getPrivyIdentityToken } = useGeoChatAuth();
+  const { accountKey, authenticated, getPrivyIdentityToken } = useGeoChatAuth();
   useDebateGatewayScope({ scope: 'space', space_id: spaceId }, enabled && authenticated);
 
   return useQuery({
     ...debateQueryNetworkOptions,
     queryKey: debateQueryKeys.spaceDebates(spaceId),
-    queryFn: () => listSpaceDebates(spaceId, getPrivyIdentityToken),
+    queryFn: ({ signal }) =>
+      listSpaceDebates(
+        spaceId,
+        authenticated ? getPrivyIdentityToken : undefined,
+        authenticated ? accountKey : null,
+        signal
+      ),
     enabled,
   });
 }
 
 export function useDebate(debateId: string, enabled: boolean) {
-  const { authenticated, getPrivyIdentityToken } = useGeoChatAuth();
+  const { accountKey, authenticated, getPrivyIdentityToken } = useGeoChatAuth();
   useDebateGatewayScope({ scope: 'debate', debate_id: debateId }, enabled && authenticated);
 
   return useQuery({
     ...debateQueryNetworkOptions,
     queryKey: debateQueryKeys.debate(debateId),
-    queryFn: () => getDebate(debateId, getPrivyIdentityToken),
+    queryFn: ({ signal }) =>
+      getDebate(debateId, authenticated ? getPrivyIdentityToken : undefined, authenticated ? accountKey : null, signal),
     enabled,
   });
 }
 
 export function useLiveKitJoin(debateId: string) {
-  const { getPrivyIdentityToken } = useGeoChatAuth();
+  const { accountKey, getPrivyIdentityToken } = useGeoChatAuth();
 
   return useMutation({
-    mutationFn: () => getLiveKitToken(debateId, getPrivyIdentityToken),
+    mutationFn: () => getLiveKitToken(debateId, getPrivyIdentityToken, accountKey),
   });
 }
 
 export function useMarkDebateJoined(debateId: string) {
   const queryClient = useQueryClient();
-  const { getPrivyIdentityToken } = useGeoChatAuth();
+  const { accountKey, getPrivyIdentityToken } = useGeoChatAuth();
 
   return useMutation({
-    mutationFn: () => markDebateJoined(debateId, getPrivyIdentityToken),
-    onSuccess: debate => queryClient.setQueryData(debateQueryKeys.debate(debate.id), debate),
+    mutationFn: () => markDebateJoined(debateId, getPrivyIdentityToken, accountKey),
+    onSuccess: debate => {
+      queryClient.setQueryData(debateQueryKeys.debate(debate.id), debate);
+      void queryClient.invalidateQueries({ queryKey: debateQueryKeys.debate(debate.id) });
+    },
   });
 }
 
 export function useMarkDebateReady(debateId: string) {
   const queryClient = useQueryClient();
-  const { getPrivyIdentityToken } = useGeoChatAuth();
+  const { accountKey, getPrivyIdentityToken } = useGeoChatAuth();
 
   return useMutation({
-    mutationFn: () => markDebateReady(debateId, getPrivyIdentityToken),
-    onSuccess: debate => queryClient.setQueryData(debateQueryKeys.debate(debate.id), debate),
+    mutationFn: () => markDebateReady(debateId, getPrivyIdentityToken, accountKey),
+    onSuccess: debate => {
+      queryClient.setQueryData(debateQueryKeys.debate(debate.id), debate);
+      void queryClient.invalidateQueries({ queryKey: debateQueryKeys.debate(debate.id) });
+    },
   });
 }
 
 export function useAbortDebate(debateId: string) {
   const queryClient = useQueryClient();
-  const { getPrivyIdentityToken } = useGeoChatAuth();
+  const { accountKey, getPrivyIdentityToken } = useGeoChatAuth();
 
   return useMutation({
-    mutationFn: () => abortDebate(debateId, getPrivyIdentityToken),
-    onSuccess: debate => queryClient.setQueryData(debateQueryKeys.debate(debate.id), debate),
+    mutationFn: () => abortDebate(debateId, getPrivyIdentityToken, accountKey),
+    onSuccess: debate => {
+      queryClient.setQueryData(debateQueryKeys.debate(debate.id), debate);
+      void queryClient.invalidateQueries({ queryKey: debateQueryKeys.debate(debate.id) });
+    },
   });
 }
 
 export function useCancelDebateRecording(debateId: string) {
   const queryClient = useQueryClient();
-  const { getPrivyIdentityToken } = useGeoChatAuth();
+  const { accountKey, getPrivyIdentityToken } = useGeoChatAuth();
 
   return useMutation({
-    mutationFn: () => cancelDebateRecording(debateId, getPrivyIdentityToken),
-    onSuccess: debate => queryClient.setQueryData(debateQueryKeys.debate(debate.id), debate),
+    mutationFn: () => cancelDebateRecording(debateId, getPrivyIdentityToken, accountKey),
+    onSuccess: debate => {
+      queryClient.setQueryData(debateQueryKeys.debate(debate.id), debate);
+      void queryClient.invalidateQueries({ queryKey: debateQueryKeys.debate(debate.id) });
+    },
   });
 }
 
 export function useConsentToDebateRematch(debateId: string) {
   const queryClient = useQueryClient();
-  const { getPrivyIdentityToken } = useGeoChatAuth();
+  const { accountKey, getPrivyIdentityToken } = useGeoChatAuth();
 
   return useMutation({
-    mutationFn: () => consentToDebateRematch(debateId, getPrivyIdentityToken),
-    onSuccess: async session => {
-      await queryClient.cancelQueries({ queryKey: debateQueryKeys.activity });
-      queryClient.setQueryData(debateQueryKeys.rematch(session.id), session);
-      queryClient.setQueryData<DebateActivity>(debateQueryKeys.activity, current => ({
+    mutationFn: () => consentToDebateRematch(debateId, getPrivyIdentityToken, accountKey),
+    onSuccess: session => {
+      queryClient.setQueryData(debateQueryKeys.rematch(accountKey, session.id), session);
+      queryClient.setQueryData<DebateActivity>(debateQueryKeys.activity(accountKey), current => ({
         online: current?.online ?? true,
         cooldown_until: null,
         match: null,
         debate: null,
         rematch: session,
       }));
+      void queryClient.invalidateQueries({ queryKey: debateQueryKeys.rematch(accountKey, session.id) });
+      void queryClient.invalidateQueries({ queryKey: debateQueryKeys.activity(accountKey) });
       void queryClient.invalidateQueries({ queryKey: debateQueryKeys.debate(debateId) });
     },
   });
 }
 
 export function useDebateRematch(sessionId: string, enabled = true) {
-  const { getPrivyIdentityToken } = useGeoChatAuth();
+  const { accountKey, getPrivyIdentityToken } = useGeoChatAuth();
 
   return useQuery({
     ...debateQueryNetworkOptions,
-    queryKey: debateQueryKeys.rematch(sessionId),
-    queryFn: () => getDebateRematch(sessionId, getPrivyIdentityToken),
+    queryKey: debateQueryKeys.rematch(accountKey, sessionId),
+    queryFn: ({ signal }) => getDebateRematch(sessionId, getPrivyIdentityToken, accountKey, signal),
     enabled: enabled && Boolean(sessionId),
   });
 }
 
 export function useLeaveDebateRematch(sessionId: string) {
   const queryClient = useQueryClient();
-  const { getPrivyIdentityToken } = useGeoChatAuth();
+  const { accountKey, getPrivyIdentityToken } = useGeoChatAuth();
 
   return useMutation({
-    mutationFn: () => leaveDebateRematch(sessionId, getPrivyIdentityToken),
+    mutationFn: () => leaveDebateRematch(sessionId, getPrivyIdentityToken, accountKey),
     onSuccess: session => {
-      queryClient.setQueryData(debateQueryKeys.rematch(session.id), session);
-      void queryClient.invalidateQueries({ queryKey: debateQueryKeys.activity });
+      queryClient.setQueryData(debateQueryKeys.rematch(accountKey, session.id), session);
+      void queryClient.invalidateQueries({ queryKey: debateQueryKeys.rematch(accountKey, session.id) });
+      void queryClient.invalidateQueries({ queryKey: debateQueryKeys.activity(accountKey) });
     },
   });
 }
 
 export function useDebateRematchClaims(sessionId: string, claimIds: string[] = [], enabled = true) {
-  const { getPrivyIdentityToken } = useGeoChatAuth();
+  const { accountKey, getPrivyIdentityToken } = useGeoChatAuth();
 
   return useQuery({
     ...debateQueryNetworkOptions,
-    queryKey: debateQueryKeys.rematchClaims(sessionId, claimIds),
-    queryFn: () => listDebateRematchClaims(sessionId, claimIds, getPrivyIdentityToken),
+    queryKey: debateQueryKeys.rematchClaims(accountKey, sessionId, claimIds),
+    queryFn: ({ signal }) => listDebateRematchClaims(sessionId, claimIds, getPrivyIdentityToken, accountKey, signal),
     enabled: enabled && Boolean(sessionId),
   });
 }
 
 export function useUpdateDebateRematchPosition(sessionId: string) {
   const queryClient = useQueryClient();
-  const { getPrivyIdentityToken } = useGeoChatAuth();
+  const { accountKey, getPrivyIdentityToken } = useGeoChatAuth();
 
   return useMutation({
     mutationFn: ({ claimId, position, sourceSpaceId }: { claimId: string; position: boolean; sourceSpaceId: string }) =>
-      updateDebateRematchPosition(sessionId, claimId, position, sourceSpaceId, getPrivyIdentityToken),
-    onSuccess: () => void queryClient.invalidateQueries({ queryKey: ['debates', 'rematch', sessionId, 'claims'] }),
+      updateDebateRematchPosition(sessionId, claimId, position, sourceSpaceId, getPrivyIdentityToken, accountKey),
+    onSuccess: () =>
+      void queryClient.invalidateQueries({
+        queryKey: ['debates', 'account', accountKey, 'rematch', sessionId, 'claims'],
+      }),
   });
 }
 
 export function useCreateDebateRematchRequest(sessionId: string) {
   const queryClient = useQueryClient();
-  const { getPrivyIdentityToken } = useGeoChatAuth();
+  const { accountKey, getPrivyIdentityToken } = useGeoChatAuth();
 
   return useMutation({
     mutationFn: (request: { source_space_id: string; claim_id: string; format_id: string }) =>
-      createDebateRematchRequest(sessionId, request, getPrivyIdentityToken),
+      createDebateRematchRequest(sessionId, request, getPrivyIdentityToken, accountKey),
     onSuccess: result => {
-      queryClient.setQueryData(debateQueryKeys.rematch(sessionId), result.session);
-      void queryClient.invalidateQueries({ queryKey: debateQueryKeys.activity });
+      queryClient.setQueryData(debateQueryKeys.rematch(accountKey, sessionId), result.session);
+      void queryClient.invalidateQueries({ queryKey: debateQueryKeys.rematch(accountKey, sessionId) });
+      void queryClient.invalidateQueries({ queryKey: debateQueryKeys.activity(accountKey) });
     },
   });
 }
 
 export function useAcceptDebateRematchRequest() {
   const queryClient = useQueryClient();
-  const { getPrivyIdentityToken } = useGeoChatAuth();
+  const { accountKey, getPrivyIdentityToken } = useGeoChatAuth();
 
   return useMutation({
-    mutationFn: (requestId: string) => acceptDebateRematchRequest(requestId, getPrivyIdentityToken),
+    mutationFn: (requestId: string) => acceptDebateRematchRequest(requestId, getPrivyIdentityToken, accountKey),
     onSuccess: result => {
-      queryClient.setQueryData(debateQueryKeys.rematch(result.session.id), result.session);
-      if (result.debate) queryClient.setQueryData(debateQueryKeys.debate(result.debate.id), result.debate);
-      void queryClient.invalidateQueries({ queryKey: debateQueryKeys.activity });
+      queryClient.setQueryData(debateQueryKeys.rematch(accountKey, result.session.id), result.session);
+      void queryClient.invalidateQueries({ queryKey: debateQueryKeys.rematch(accountKey, result.session.id) });
+      if (result.debate) {
+        queryClient.setQueryData(debateQueryKeys.debate(result.debate.id), result.debate);
+        void queryClient.invalidateQueries({ queryKey: debateQueryKeys.debate(result.debate.id) });
+      }
+      void queryClient.invalidateQueries({ queryKey: debateQueryKeys.activity(accountKey) });
     },
   });
 }
 
 export function useRejectDebateRematchRequest() {
   const queryClient = useQueryClient();
-  const { getPrivyIdentityToken } = useGeoChatAuth();
+  const { accountKey, getPrivyIdentityToken } = useGeoChatAuth();
 
   return useMutation({
-    mutationFn: (requestId: string) => rejectDebateRematchRequest(requestId, getPrivyIdentityToken),
+    mutationFn: (requestId: string) => rejectDebateRematchRequest(requestId, getPrivyIdentityToken, accountKey),
     onSuccess: result => {
-      queryClient.setQueryData(debateQueryKeys.rematch(result.session.id), result.session);
-      void queryClient.invalidateQueries({ queryKey: ['debates', 'rematch', result.session.id, 'claims'] });
+      queryClient.setQueryData(debateQueryKeys.rematch(accountKey, result.session.id), result.session);
+      void queryClient.invalidateQueries({ queryKey: debateQueryKeys.rematch(accountKey, result.session.id) });
+      void queryClient.invalidateQueries({
+        queryKey: ['debates', 'account', accountKey, 'rematch', result.session.id, 'claims'],
+      });
     },
   });
 }
 
 export function useDebateSharePrompts(enabled = true) {
-  const { authenticated, getPrivyIdentityToken } = useGeoChatAuth();
+  const { accountKey, authenticated, getPrivyIdentityToken } = useGeoChatAuth();
 
   return useQuery({
     ...debateQueryNetworkOptions,
-    queryKey: debateQueryKeys.sharePrompts,
-    queryFn: () => listDebateSharePrompts(getPrivyIdentityToken),
+    queryKey: debateQueryKeys.sharePrompts(accountKey),
+    queryFn: ({ signal }) => listDebateSharePrompts(getPrivyIdentityToken, accountKey, signal),
     enabled: enabled && authenticated,
   });
 }
 
 export function useHandleDebateSharePrompt() {
   const queryClient = useQueryClient();
-  const { getPrivyIdentityToken } = useGeoChatAuth();
+  const { accountKey, getPrivyIdentityToken } = useGeoChatAuth();
 
   return useMutation({
     mutationFn: ({ promptId, action }: { promptId: string; action: 'shared' | 'dismissed' }) =>
-      handleDebateSharePrompt(promptId, action, getPrivyIdentityToken),
-    onSuccess: () => void queryClient.invalidateQueries({ queryKey: debateQueryKeys.sharePrompts }),
+      handleDebateSharePrompt(promptId, action, getPrivyIdentityToken, accountKey),
+    onSuccess: () => void queryClient.invalidateQueries({ queryKey: debateQueryKeys.sharePrompts(accountKey) }),
   });
 }
 
 export function useCreateLocalRecordingUpload(debateId: string) {
-  const { getPrivyIdentityToken } = useGeoChatAuth();
+  const { accountKey, getPrivyIdentityToken } = useGeoChatAuth();
 
   return useMutation({
     mutationFn: (request: LocalRecordingUploadRequest) =>
-      createLocalRecordingUpload(debateId, request, getPrivyIdentityToken),
+      createLocalRecordingUpload(debateId, request, getPrivyIdentityToken, accountKey),
   });
 }
 
 export function useCompleteLocalRecordingUpload(debateId: string) {
   const queryClient = useQueryClient();
-  const { getPrivyIdentityToken } = useGeoChatAuth();
+  const { accountKey, getPrivyIdentityToken } = useGeoChatAuth();
 
   return useMutation({
     mutationFn: (request: LocalRecordingCompleteRequest) =>
-      completeLocalRecordingUpload(debateId, request, getPrivyIdentityToken),
+      completeLocalRecordingUpload(debateId, request, getPrivyIdentityToken, accountKey),
     onSuccess: result => {
       queryClient.setQueryData(debateQueryKeys.debate(result.debate.id), result.debate);
+      void queryClient.invalidateQueries({ queryKey: debateQueryKeys.debate(result.debate.id) });
       void queryClient.invalidateQueries({ queryKey: debateQueryKeys.media(result.debate.id) });
     },
   });
 }
 
 export function useRecordingUrl() {
-  const { getPrivyIdentityToken } = useGeoChatAuth();
+  const { accountKey, getPrivyIdentityToken } = useGeoChatAuth();
 
   return useMutation({
     mutationFn: ({ debateId, filename }: { debateId: string; filename: string }) =>
-      getRecordingUrl(debateId, filename, getPrivyIdentityToken),
+      getRecordingUrl(debateId, filename, getPrivyIdentityToken, accountKey),
   });
 }
 
 export function useDebateMedia(debateId: string, enabled: boolean) {
-  const { authenticated, getPrivyIdentityToken } = useGeoChatAuth();
+  const { accountKey, authenticated, getPrivyIdentityToken } = useGeoChatAuth();
   useDebateGatewayScope({ scope: 'debate', debate_id: debateId }, enabled && authenticated);
 
   return useQuery({
     ...debateQueryNetworkOptions,
     queryKey: debateQueryKeys.media(debateId),
-    queryFn: () => getDebateMedia(debateId, getPrivyIdentityToken),
+    queryFn: ({ signal }) =>
+      getDebateMedia(
+        debateId,
+        authenticated ? getPrivyIdentityToken : undefined,
+        authenticated ? accountKey : null,
+        signal
+      ),
     enabled,
   });
 }
 
 export function useRequestDebateMediaProcessing(debateId: string) {
   const queryClient = useQueryClient();
-  const { getPrivyIdentityToken } = useGeoChatAuth();
+  const { accountKey, getPrivyIdentityToken } = useGeoChatAuth();
 
   return useMutation({
     mutationFn: (request?: DebateMediaProcessRequest) =>
-      requestDebateMediaProcessing(debateId, getPrivyIdentityToken, request),
-    onSuccess: media => queryClient.setQueryData(debateQueryKeys.media(debateId), media),
+      requestDebateMediaProcessing(debateId, getPrivyIdentityToken, accountKey, request),
+    onSuccess: media => {
+      queryClient.setQueryData(debateQueryKeys.media(debateId), media);
+      void queryClient.invalidateQueries({ queryKey: debateQueryKeys.media(debateId) });
+    },
   });
 }
 
 export function useDebateMediaArtifactUrl() {
-  const { getPrivyIdentityToken } = useGeoChatAuth();
+  const { accountKey, getPrivyIdentityToken } = useGeoChatAuth();
 
   return useMutation({
     mutationFn: ({ debateId, request }: { debateId: string; request: DebateMediaArtifactUrlRequest }) =>
-      getDebateMediaArtifactUrl(debateId, request, getPrivyIdentityToken),
+      getDebateMediaArtifactUrl(debateId, request, getPrivyIdentityToken, accountKey),
   });
 }
 
 export function useDebateTranscript(debateId: string, format: TranscriptFormat = 'json', enabled = true) {
-  const { authenticated, getPrivyIdentityToken } = useGeoChatAuth();
+  const { accountKey, authenticated, getPrivyIdentityToken } = useGeoChatAuth();
   useDebateGatewayScope({ scope: 'debate', debate_id: debateId }, enabled && authenticated);
 
   return useQuery({
     ...debateQueryNetworkOptions,
     queryKey: debateQueryKeys.transcript(debateId, format),
-    queryFn: () => getDebateTranscript(debateId, format, getPrivyIdentityToken),
+    queryFn: ({ signal }) =>
+      getDebateTranscript(
+        debateId,
+        format,
+        authenticated ? getPrivyIdentityToken : undefined,
+        authenticated ? accountKey : null,
+        signal
+      ),
     enabled,
   });
 }

--- a/apps/web/core/debates/recording-upload-coordinator.integration.test.tsx
+++ b/apps/web/core/debates/recording-upload-coordinator.integration.test.tsx
@@ -36,6 +36,7 @@ vi.mock('./hooks', () => ({
   useGeoChatAuth: () => ({
     ready: true,
     authenticated: true,
+    accountKey: 'user-a',
     getPrivyIdentityToken: mocks.getToken,
   }),
   useDebateActivity: () => ({ data: undefined }),
@@ -145,7 +146,8 @@ describe('DebateRecordingUploadCoordinator', () => {
     expect(mocks.completeUpload).toHaveBeenCalledWith(
       'debate-1',
       expect.objectContaining({ framerate: 29.97 }),
-      expect.anything()
+      expect.anything(),
+      'user-a'
     );
     expect(mocks.lockRequest).toHaveBeenCalledWith(
       'geo:debate-recording-uploader',
@@ -190,15 +192,15 @@ describe('DebateRecordingUploadCoordinator', () => {
     render(<DebateRecordingUploadCoordinator />);
 
     await waitFor(() =>
-      expect(mocks.completeUpload).toHaveBeenCalledWith('debate-1', expect.anything(), expect.anything())
+      expect(mocks.completeUpload).toHaveBeenCalledWith('debate-1', expect.anything(), expect.anything(), 'user-a')
     );
     expect(screen.getByText('Uploading 2 debates')).toBeInTheDocument();
-    expect(mocks.createUpload).not.toHaveBeenCalledWith('debate-2', expect.anything(), expect.anything());
+    expect(mocks.createUpload).not.toHaveBeenCalledWith('debate-2', expect.anything(), expect.anything(), 'user-a');
 
     firstCompletion.resolve();
 
     await waitFor(() =>
-      expect(mocks.completeUpload).toHaveBeenCalledWith('debate-2', expect.anything(), expect.anything())
+      expect(mocks.completeUpload).toHaveBeenCalledWith('debate-2', expect.anything(), expect.anything(), 'user-a')
     );
   });
 
@@ -315,7 +317,7 @@ describe('DebateRecordingUploadCoordinator', () => {
     fireEvent.click(await screen.findByRole('checkbox', { name: 'Publish debate' }));
     fireEvent.click(await screen.findByRole('button', { name: 'Delete debate forever' }));
 
-    await waitFor(() => expect(mocks.cancelRecording).toHaveBeenCalledWith('debate-1', expect.anything()));
+    await waitFor(() => expect(mocks.cancelRecording).toHaveBeenCalledWith('debate-1', expect.anything(), 'user-a'));
     await waitFor(() => expect(mocks.deleteUpload).toHaveBeenCalledWith('user-a:debate-1'));
     await waitFor(() => expect(screen.queryByRole('status')).not.toBeInTheDocument());
   });

--- a/apps/web/core/debates/recording-upload-coordinator.tsx
+++ b/apps/web/core/debates/recording-upload-coordinator.tsx
@@ -84,7 +84,7 @@ export function recordingUploadRetryDelay(attemptCount: number) {
 
 export function DebateRecordingUploadCoordinator() {
   const queryClient = useQueryClient();
-  const { ready, authenticated, getPrivyIdentityToken } = useGeoChatAuth();
+  const { ready, authenticated, accountKey, getPrivyIdentityToken } = useGeoChatAuth();
   const [userId, setUserId] = React.useState<string | null>(null);
   const [uploads, setUploads] = React.useState<DebateRecordingUpload[]>([]);
   const [activeUploadId, setActiveUploadId] = React.useState<string | null>(null);
@@ -119,7 +119,7 @@ export function DebateRecordingUploadCoordinator() {
     setUploads([]);
     let cancelled = false;
     let retryTimer: number | null = null;
-    void resolveCurrentGeoChatUserId(getPrivyIdentityToken)
+    void resolveCurrentGeoChatUserId(getPrivyIdentityToken, accountKey)
       .then(id => {
         if (!id) throw new Error('The debate upload user could not be resolved.');
         if (!cancelled) {
@@ -140,7 +140,7 @@ export function DebateRecordingUploadCoordinator() {
       cancelled = true;
       if (retryTimer !== null) window.clearTimeout(retryTimer);
     };
-  }, [authenticated, getPrivyIdentityToken, identityRetrySignal, ready]);
+  }, [accountKey, authenticated, getPrivyIdentityToken, identityRetrySignal, ready]);
 
   React.useEffect(() => {
     if (!userId) {
@@ -193,7 +193,7 @@ export function DebateRecordingUploadCoordinator() {
 
     activeUploadIdRef.current = upload.id;
     setActiveUploadId(upload.id);
-    const dependencies = recordingUploadDependencies(getPrivyIdentityToken);
+    const dependencies = recordingUploadDependencies(getPrivyIdentityToken, accountKey);
     let attemptStage = upload.stage;
     let attemptCount = upload.attemptCount;
     void withRecordingUploadLock(async () => {
@@ -251,7 +251,7 @@ export function DebateRecordingUploadCoordinator() {
           setWakeAt(Date.now());
         }
       });
-  }, [activeUploadId, getPrivyIdentityToken, online, queryClient, uploads, userId, wakeAt]);
+  }, [accountKey, activeUploadId, getPrivyIdentityToken, online, queryClient, uploads, userId, wakeAt]);
 
   const waiting = !online || (!activeUploadId && uploads.every(upload => upload.nextAttemptAt > Date.now()));
   const latestFailedUpload = uploads.reduce<DebateRecordingUpload | null>((latest, upload) => {
@@ -285,7 +285,7 @@ export function DebateRecordingUploadCoordinator() {
       const debateIds = [...new Set(uploads.map(upload => upload.debateId))];
       for (const debateId of debateIds) {
         try {
-          await cancelDebateRecording(debateId, getPrivyIdentityToken);
+          await cancelDebateRecording(debateId, getPrivyIdentityToken, accountKey);
         } catch (error) {
           // Already cancelled or gone on the backend — still drop the local blob below.
           const terminal =
@@ -300,7 +300,7 @@ export function DebateRecordingUploadCoordinator() {
     } finally {
       if (mountedRef.current) setCancelBusy(false);
     }
-  }, [getPrivyIdentityToken, uploads]);
+  }, [accountKey, getPrivyIdentityToken, uploads]);
 
   // If the upload finishes while the prompt is open, there is nothing left to delete, so the
   // user can no longer choose to cancel — close it automatically.
@@ -451,12 +451,17 @@ export function DebateCancelUploadDialog({
   );
 }
 
-function recordingUploadDependencies(getPrivyIdentityToken: GetPrivyIdentityToken): RecordingUploadDependencies {
+function recordingUploadDependencies(
+  getPrivyIdentityToken: GetPrivyIdentityToken,
+  accountKey: string | null
+): RecordingUploadDependencies {
   return {
-    createUpload: (debateId, request) => createLocalRecordingUpload(debateId, request, getPrivyIdentityToken),
+    createUpload: (debateId, request) =>
+      createLocalRecordingUpload(debateId, request, getPrivyIdentityToken, accountKey),
     putRecording: putRecording,
     markUploaded: markDebateRecordingUploaded,
-    completeUpload: (debateId, request) => completeLocalRecordingUpload(debateId, request, getPrivyIdentityToken),
+    completeUpload: (debateId, request) =>
+      completeLocalRecordingUpload(debateId, request, getPrivyIdentityToken, accountKey),
     deleteUpload: deleteDebateRecordingUpload,
   };
 }

--- a/apps/web/core/hooks/use-geo-logout.test.tsx
+++ b/apps/web/core/hooks/use-geo-logout.test.tsx
@@ -1,0 +1,68 @@
+import { renderHook } from '@testing-library/react';
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useGeoLogoutCleanup } from './use-geo-logout';
+
+const mocks = vi.hoisted(() => ({
+  clearQueries: vi.fn(),
+  disconnectCookie: vi.fn(),
+  logoutSuccess: null as null | (() => Promise<void>),
+  resetGeoChatSession: vi.fn(),
+  setAtom: vi.fn(),
+  setEditable: vi.fn(),
+}));
+
+vi.mock('@geogenesis/auth', () => ({
+  useLogout: ({ onSuccess }: { onSuccess: () => Promise<void> }) => {
+    mocks.logoutSuccess = onSuccess;
+  },
+}));
+
+vi.mock('@tanstack/react-query', () => ({
+  useQueryClient: () => ({ clear: mocks.clearQueries }),
+}));
+
+vi.mock('jotai', () => ({ useSetAtom: () => mocks.setAtom }));
+vi.mock('~/core/analytics', () => ({ loggedOut: vi.fn() }));
+vi.mock('~/core/cookie', () => ({ Cookie: { onConnectionChange: mocks.disconnectCookie } }));
+vi.mock('~/core/debates/api', () => ({ resetGeoChatSession: mocks.resetGeoChatSession }));
+vi.mock('~/core/hooks/use-personal-space-id', () => ({ usePersonalSpaceId: () => ({ personalSpaceId: null }) }));
+vi.mock('~/core/state/editable-store', () => ({ useEditable: () => ({ setEditable: mocks.setEditable }) }));
+vi.mock('~/core/state/pending-personal-space', () => ({ pendingPersonalSpaceAtom: {} }));
+vi.mock('~/partials/onboarding/dialog', () => ({
+  avatarAtom: {},
+  nameAtom: {},
+  spaceIdAtom: {},
+  stepAtom: {},
+  topicIdAtom: {},
+}));
+vi.mock('~/atoms/dismissed-hints', () => ({ dismissedHintsAtom: {} }));
+
+describe('useGeoLogoutCleanup', () => {
+  beforeEach(() => {
+    mocks.clearQueries.mockReset();
+    mocks.disconnectCookie.mockReset();
+    mocks.logoutSuccess = null;
+    mocks.resetGeoChatSession.mockReset();
+    mocks.setAtom.mockReset();
+    mocks.setEditable.mockReset();
+  });
+
+  it('clears Geo Chat credentials and queries even when cookie disconnect fails', async () => {
+    mocks.disconnectCookie.mockRejectedValue(new Error('cookie disconnect failed'));
+    renderHook(() => useGeoLogoutCleanup());
+
+    await expect(mocks.logoutSuccess!()).rejects.toThrow('cookie disconnect failed');
+
+    expect(mocks.resetGeoChatSession).toHaveBeenCalledOnce();
+    expect(mocks.clearQueries).toHaveBeenCalledOnce();
+    expect(mocks.resetGeoChatSession.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.disconnectCookie.mock.invocationCallOrder[0]!
+    );
+    expect(mocks.clearQueries.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.disconnectCookie.mock.invocationCallOrder[0]!
+    );
+    expect(mocks.setAtom).toHaveBeenCalled();
+  });
+});

--- a/apps/web/core/hooks/use-geo-logout.ts
+++ b/apps/web/core/hooks/use-geo-logout.ts
@@ -7,6 +7,7 @@ import { useSetAtom } from 'jotai';
 
 import { loggedOut } from '~/core/analytics';
 import { Cookie } from '~/core/cookie';
+import { resetGeoChatSession } from '~/core/debates/api';
 import { usePersonalSpaceId } from '~/core/hooks/use-personal-space-id';
 import { useEditable } from '~/core/state/editable-store';
 import { pendingPersonalSpaceAtom } from '~/core/state/pending-personal-space';
@@ -57,6 +58,7 @@ export function useGeoLogoutCleanup() {
       setStep('enter-profile');
       setDismissedHints([]);
       setPending(null);
+      resetGeoChatSession();
       queryClient.clear();
       // Bulletproof reset — see the doc comment. `/root` is the public home and
       // drops the user out of any onboarding/pending context they logged out of.

--- a/apps/web/core/hooks/use-geo-logout.ts
+++ b/apps/web/core/hooks/use-geo-logout.ts
@@ -50,19 +50,22 @@ export function useGeoLogoutCleanup() {
       // Drop out of edit mode so the flow bar / "Review edits" popup hides — on
       // sign-out ModeToggle unmounts and can no longer reset `editable` itself.
       setEditable(false);
-      await Cookie.onConnectionChange({ type: 'disconnect' });
-      setName('');
-      setTopicId('');
-      setAvatar('');
-      setSpaceId('');
-      setStep('enter-profile');
-      setDismissedHints([]);
-      setPending(null);
       resetGeoChatSession();
       queryClient.clear();
-      // Bulletproof reset — see the doc comment. `/root` is the public home and
-      // drops the user out of any onboarding/pending context they logged out of.
-      window.location.assign('/root');
+      try {
+        await Cookie.onConnectionChange({ type: 'disconnect' });
+      } finally {
+        setName('');
+        setTopicId('');
+        setAvatar('');
+        setSpaceId('');
+        setStep('enter-profile');
+        setDismissedHints([]);
+        setPending(null);
+        // Bulletproof reset — see the doc comment. `/root` is the public home and
+        // drops the user out of any onboarding/pending context they logged out of.
+        window.location.assign('/root');
+      }
     },
   });
 }


### PR DESCRIPTION
## Summary

An idle signed-in browser no longer sends periodic debate reads. It loads authoritative HTTP snapshots initially and after mutations, then uses small gateway events to invalidate only the affected TanStack Query families when remote debate state changes.

When the gateway disconnects or reports lag, cached state remains visible and a non-blocking paused-updates notice appears. The client never falls back to polling; the first successful `READY` and every reconnect perform an authoritative active-query reconciliation.

| Context | Result |
|---|---|
| Connected and idle | WebSocket presence heartbeats, with no recurring debate HTTP traffic |
| Remote state change | Targeted cache invalidation followed by an HTTP snapshot |
| Disconnected | Cached state and local countdowns continue; live-update notice is shown |
| Reconnected or lagged | Active debate queries are broadly reconciled once |
| Signed out | One public HTTP snapshot per mount, without debate subscriptions or polling |

The singleton client reference-counts space and debate subscriptions, deduplicates event IDs, coalesces adjacent invalidations, rotates authentication before expiry, and replays desired subscriptions after recoverable command failures. `READY` is treated as the exact confirmed subscription set so mount/unmount churn cannot leave a scope falsely confirmed. A stalled handshake is bounded, malformed envelopes are ignored, and failed authoritative refetches force a recoverable reconnect so an event cannot be permanently deduplicated before its snapshot is refreshed.

HTTP mutations remain authoritative. Their immediate responses can update the cache for responsiveness, then the affected queries are invalidated so concurrent remote transitions cannot be overwritten. The debate room's local countdown timer also remains local; only browser reads of server-owned debate state were removed.

Authentication sessions are account-scoped, cleared on logout, retired across account changes, and bounded by a session-exchange timeout. The WebSocket handshake still transports the existing app access token in the URL query string; proxy access-log redaction is required, and a single-use WebSocket ticket remains a follow-up hardening option.

## Rollout

Requires the backend capability from [geobrowser/geo-chat#12](https://github.com/geobrowser/geo-chat/pull/12). Deploy the presence migration, event producers, Kafka consumer, gateway routing, and `debate_invalidations_v1` advertisement before this frontend; a missing capability intentionally shows degraded mode instead of enabling polling.

## Validation

- `bunx tsc -p tsconfig.json --noEmit`
- `bun run test` — 141 files and 1,443 tests passed
- `bun run lint` — 0 errors; 81 pre-existing warnings remain outside this change
- GitHub Build, Lint, and Test checks and the Vercel preview passed
- Fake-timer coverage proves debate activity makes one initial request over 60 seconds; gateway tests separately cover heartbeat cadence

## New concepts

### Event-driven cache invalidation

The socket is a notification channel, not a second state store. Events identify which snapshot may be stale, and TanStack Query continues to own fetching, caching, and mutation reconciliation.

```mermaid
flowchart LR
    A["Identifier-only gateway event"] --> B["Coalesced query invalidation"]
    B --> C["Authoritative HTTP snapshot"]
```

This avoids ordering-sensitive client replication and makes duplicate events harmless. It is not appropriate when the browser must work through a durable offline event history or render every intermediate server transition.
