### PR TITLE
fix: keep rolling ranking candidates filter-driven

### DIFF
--- a/apps/web/core/blocks/ranking/ranking-rolling.test.ts
+++ b/apps/web/core/blocks/ranking/ranking-rolling.test.ts
@@ -4,7 +4,6 @@ import type { AggregatedRankingSubmitterRef } from './ranking-block-relations';
 import {
   formatRollingSubmissionLabel,
   getRollingExpiryMs,
-  isCreatedWithinWindow,
   isRollingSubmissionLive,
   parseTimestampMs,
 } from './ranking-rolling';
@@ -63,21 +62,6 @@ describe('isRollingSubmissionLive', () => {
   });
 });
 
-describe('isCreatedWithinWindow', () => {
-  it('keeps entities created inside the window', () => {
-    expect(isCreatedWithinWindow(now - 2 * HOUR, 24, now)).toBe(true);
-  });
-
-  it('drops entities created before the window', () => {
-    expect(isCreatedWithinWindow(now - 48 * HOUR, 24, now)).toBe(false);
-  });
-
-  it('keeps entities with an unknown creation time', () => {
-    expect(isCreatedWithinWindow(undefined, 24, now)).toBe(true);
-    expect(isCreatedWithinWindow('', 24, now)).toBe(true);
-  });
-});
-
 describe('getRollingExpiryMs', () => {
   it('adds the frequency window to the submission time', () => {
     expect(getRollingExpiryMs(now, 24)).toBe(now + 24 * HOUR);
@@ -106,7 +90,7 @@ describe('formatRollingSubmissionLabel', () => {
         frequencyHours: 24,
         now,
       })
-    ).toBe('Your ranking expires in 4 hrs');
+    ).toBe('Vote again in 4 hrs');
   });
 
   it('shows a days countdown for long windows', () => {
@@ -118,7 +102,7 @@ describe('formatRollingSubmissionLabel', () => {
         frequencyHours: 168,
         now,
       })
-    ).toBe('Your ranking expires in 7 days');
+    ).toBe('Vote again in 7 days');
   });
 
   it('rolls off when the window has elapsed even if flagged live', () => {

--- a/apps/web/core/blocks/ranking/ranking-rolling.ts
+++ b/apps/web/core/blocks/ranking/ranking-rolling.ts
@@ -41,16 +41,6 @@ export function getRollingExpiryMs(submittedAtMs: number, frequencyHours: number
   return submittedAtMs + frequencyHours * MS_PER_HOUR;
 }
 
-export function isCreatedWithinWindow(
-  createdAt: string | number | undefined | null,
-  frequencyHours: number,
-  now: number
-): boolean {
-  const createdAtMs = parseTimestampMs(createdAt);
-  if (createdAtMs === 0) return true;
-  return createdAtMs >= now - frequencyHours * MS_PER_HOUR;
-}
-
 export function formatRollingSubmissionLabel({
   hasSubmission,
   isLive,
@@ -73,7 +63,7 @@ export function formatRollingSubmissionLabel({
   if (expiresInMs <= 0) return 'Your ranking has rolled off — submit a fresh ranking';
 
   const hours = Math.ceil(expiresInMs / MS_PER_HOUR);
-  if (hours >= 48) return `Your ranking expires in ${Math.ceil(hours / 24)} days`;
-  if (hours === 1) return 'Your ranking expires in 1 hr';
-  return `Your ranking expires in ${hours} hrs`;
+  if (hours >= 48) return `Vote again in ${Math.ceil(hours / 24)} days`;
+  if (hours === 1) return 'Vote again in 1 hr';
+  return `Vote again in ${hours} hrs`;
 }

--- a/apps/web/core/blocks/ranking/use-ranking-accumulated-rows.test.ts
+++ b/apps/web/core/blocks/ranking/use-ranking-accumulated-rows.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import type { Row } from '~/core/types';
 
-import { flattenRowPages, upsertRowPage } from './use-ranking-accumulated-rows';
+import { flattenRowPages, rankingFeedPageSize, upsertRowPage } from './use-ranking-accumulated-rows';
 
 function row(entityId: string): Row {
   return { entityId, placeholder: false, columns: {} } as Row;
@@ -30,5 +30,17 @@ describe('flattenRowPages', () => {
       { page: 1, rows: [row('b'), row('c')] },
     ];
     expect(flattenRowPages(pages).map(r => r.entityId)).toEqual(['a', 'b', 'c']);
+  });
+});
+
+describe('rankingFeedPageSize', () => {
+  it('uses at least ten rows for the infinite feed', () => {
+    expect(rankingFeedPageSize(1)).toBe(10);
+    expect(rankingFeedPageSize(9)).toBe(10);
+  });
+
+  it('preserves configured page sizes above the minimum', () => {
+    expect(rankingFeedPageSize(10)).toBe(10);
+    expect(rankingFeedPageSize(25)).toBe(25);
   });
 });

--- a/apps/web/core/blocks/ranking/use-ranking-accumulated-rows.ts
+++ b/apps/web/core/blocks/ranking/use-ranking-accumulated-rows.ts
@@ -11,9 +11,6 @@ import { useView } from '~/core/blocks/data/use-view';
 import { EntitiesOrderBy } from '~/core/gql/graphql';
 import { useQueryEntities } from '~/core/sync/use-store';
 
-import { isCreatedWithinWindow } from './ranking-rolling';
-import { useRankingBlockConfig } from './use-ranking-block-config';
-
 export type { RowPage };
 export { flattenRowPages, upsertRowPage };
 
@@ -24,7 +21,6 @@ function rowEntityIdsSignature(rows: { entityId: string }[]): string {
 export function useRankingAccumulatedRows() {
   const { entityId, source, filterState, filterMode, pageSize } = useDataBlock();
   const { shownColumnIds } = useView();
-  const { isRolling, submissionFrequencyHours } = useRankingBlockConfig();
 
   const enabled = source.type === 'SPACES' || source.type === 'GEO';
 
@@ -45,23 +41,13 @@ export function useRankingAccumulatedRows() {
     orderBy: [EntitiesOrderBy.CreatedAtDesc],
   });
 
-  // Rolling rankings only rank entities created within the submission-frequency window.
-  const applyCreationWindow = isRolling && submissionFrequencyHours != null;
-  const { windowedEntities, reachedWindowBoundary } = React.useMemo(() => {
-    const list = entities ?? [];
-    if (!applyCreationWindow || submissionFrequencyHours == null) {
-      return { windowedEntities: list, reachedWindowBoundary: false };
-    }
-    const now = Date.now();
-    const inWindow = list.filter(e => isCreatedWithinWindow(e.createdAt, submissionFrequencyHours, now));
-    return { windowedEntities: inWindow, reachedWindowBoundary: inWindow.length < list.length };
-  }, [entities, applyCreationWindow, submissionFrequencyHours]);
-
-  const effectiveHasNextPage = reachedWindowBoundary ? false : hasNextPage;
-
+  // Submission frequency controls how long a user's ranking remains live; it is
+  // not an implicit filter on the entities they can rank. Keep browse mode in
+  // sync with typed search by exposing every entity that matches the block's
+  // persisted filters, including older entities in a rolling ranking.
   const pageRows = React.useMemo(
-    () => mappingToRows(windowedEntities, shownColumnIds, []),
-    [windowedEntities, shownColumnIds]
+    () => mappingToRows(entities ?? [], shownColumnIds, []),
+    [entities, shownColumnIds]
   );
 
   const [rowPages, setRowPages] = React.useState<RowPage[]>([]);
@@ -94,16 +80,16 @@ export function useRankingAccumulatedRows() {
   const accumulatedRows = React.useMemo(() => flattenRowPages(rowPages), [rowPages]);
 
   const fetchNextPage = React.useCallback(() => {
-    if (!effectiveHasNextPage || !hasCurrentPage || isPlaceholderData || !endCursor) return;
+    if (!hasNextPage || !hasCurrentPage || isPlaceholderData || !endCursor) return;
     setAfterChain(prev => (prev[prev.length - 1] === endCursor ? prev : [...prev, endCursor]));
-  }, [effectiveHasNextPage, hasCurrentPage, isPlaceholderData, endCursor]);
+  }, [hasNextPage, hasCurrentPage, isPlaceholderData, endCursor]);
 
   const isFetchingNextPage = pageIndex > 0 && !hasCurrentPage;
 
   return {
     rows: accumulatedRows,
     isLoading: isLoading && !isFetched,
-    hasNextPage: effectiveHasNextPage,
+    hasNextPage,
     isFetchingNextPage,
     fetchNextPage,
   };

--- a/apps/web/core/blocks/ranking/use-ranking-accumulated-rows.ts
+++ b/apps/web/core/blocks/ranking/use-ranking-accumulated-rows.ts
@@ -14,6 +14,12 @@ import { useQueryEntities } from '~/core/sync/use-store';
 export type { RowPage };
 export { flattenRowPages, upsertRowPage };
 
+export const MIN_RANKING_FEED_PAGE_SIZE = 10;
+
+export function rankingFeedPageSize(pageSize: number): number {
+  return Math.max(MIN_RANKING_FEED_PAGE_SIZE, pageSize);
+}
+
 function rowEntityIdsSignature(rows: { entityId: string }[]): string {
   return rows.map(row => row.entityId).join('|');
 }
@@ -21,6 +27,7 @@ function rowEntityIdsSignature(rows: { entityId: string }[]): string {
 export function useRankingAccumulatedRows() {
   const { entityId, source, filterState, filterMode, pageSize } = useDataBlock();
   const { shownColumnIds } = useView();
+  const feedPageSize = rankingFeedPageSize(pageSize);
 
   const enabled = source.type === 'SPACES' || source.type === 'GEO';
 
@@ -33,7 +40,7 @@ export function useRankingAccumulatedRows() {
   const { entities, isLoading, isFetched, isPlaceholderData, endCursor, hasNextPage } = useQueryEntities({
     where,
     enabled,
-    first: pageSize,
+    first: feedPageSize,
     after,
     placeholderData: keepPreviousData,
     deferUntilFetched: true,
@@ -60,10 +67,10 @@ export function useRankingAccumulatedRows() {
         sourceValue: 'value' in source ? source.value : null,
         filterState: filterState.map(f => ({ columnId: f.columnId, value: f.value })),
         filterMode,
-        pageSize,
+        feedPageSize,
         shownColumnIds,
       }),
-    [entityId, filterMode, filterState, pageSize, shownColumnIds, source]
+    [entityId, feedPageSize, filterMode, filterState, shownColumnIds, source]
   );
 
   React.useEffect(() => {

--- a/apps/web/core/blocks/ranking/use-ranking-accumulated-rows.ts
+++ b/apps/web/core/blocks/ranking/use-ranking-accumulated-rows.ts
@@ -59,8 +59,9 @@ export function useRankingAccumulatedRows() {
         sourceType: source.type,
         sourceValue: 'value' in source ? source.value : null,
         filterState: filterState.map(f => ({ columnId: f.columnId, value: f.value })),
+        shownColumnIds,
       }),
-    [entityId, filterState, source]
+    [entityId, filterState, shownColumnIds, source]
   );
 
   React.useEffect(() => {
@@ -73,7 +74,7 @@ export function useRankingAccumulatedRows() {
   React.useEffect(() => {
     if (!isFetched || isPlaceholderData) return;
     setRowPages(prev => upsertRowPage(prev, pageIndex, pageRows));
-  }, [pageIndex, rowsSignature, isFetched, isPlaceholderData]);
+  }, [pageIndex, rowsSignature, isFetched, isPlaceholderData, resetKey]);
 
   const hasCurrentPage = React.useMemo(() => rowPages.some(p => p.page === pageIndex), [rowPages, pageIndex]);
 

--- a/apps/web/core/blocks/ranking/use-ranking-accumulated-rows.ts
+++ b/apps/web/core/blocks/ranking/use-ranking-accumulated-rows.ts
@@ -59,9 +59,11 @@ export function useRankingAccumulatedRows() {
         sourceType: source.type,
         sourceValue: 'value' in source ? source.value : null,
         filterState: filterState.map(f => ({ columnId: f.columnId, value: f.value })),
+        filterMode,
+        pageSize,
         shownColumnIds,
       }),
-    [entityId, filterState, shownColumnIds, source]
+    [entityId, filterMode, filterState, pageSize, shownColumnIds, source]
   );
 
   React.useEffect(() => {


### PR DESCRIPTION
## What changed

- Remove the implicit creation-time cutoff from rolling ranking candidate feeds.
- Keep cursor pagination enabled so the add-ranking flow can infinite-scroll through all entities matching the block's explicit filters.
- Change the live rolling countdown from "Your ranking expires in ..." to "Vote again in ...".

## Why

The add-ranking browse feed silently filtered candidates to entities created within the submission-frequency window, while typed search did not. For a 24-hour rolling Claim ranking whose newest matching entities were older than 24 hours, the initial feed was empty even though search returned matching Claims.

Submission frequency now controls ballot lifetime only. Candidate eligibility is driven by the ranking block's persisted filters; an explicit time filter can still constrain the feed.

## Validation

- `bun run test core/blocks/ranking/ranking-rolling.test.ts core/blocks/ranking/use-ranking-accumulated-rows.test.ts`
- `bunx tsc --noEmit --pretty false`
- Focused ESLint on the three changed ranking files
- `git diff --check`

The full Next build was attempted but Turbopack stalled after inferring the workspace root above the repository because of an outer lockfile, matching the documented local-environment issue.
