### PR TITLE
fix: include unscored entities in data block score sorts

### DIFF
--- a/apps/web/core/blocks/data/use-collection.ts
+++ b/apps/web/core/blocks/data/use-collection.ts
@@ -36,7 +36,7 @@ export interface CollectionProps {
   /** Forward offset (in *rows*) to apply on top of `after`. */
   offset?: number;
   where?: WhereCondition;
-  sort?: { propertyId: string; direction: 'asc' | 'desc'; dataType?: string };
+  sort?: { propertyId: string; direction: 'asc' | 'desc'; dataType?: string; includeWithoutValue?: boolean };
 }
 
 export function useCollection({ source, first, pageNumber = 0, after, offset, where, sort }: CollectionProps) {

--- a/apps/web/core/blocks/data/use-data-block.tsx
+++ b/apps/web/core/blocks/data/use-data-block.tsx
@@ -10,7 +10,7 @@ import { WhereCondition } from '~/core/sync/experimental_query-layer';
 import { useMutate } from '~/core/sync/use-mutate';
 import { useQueryEntities, useQueryEntity } from '~/core/sync/use-store';
 import { Cell, Property, Row } from '~/core/types';
-import { propertyForSort } from '~/core/utils/column-sort';
+import { propertyForSort, shouldIncludeWithoutValueForPropertySort } from '~/core/utils/column-sort';
 import { sortRows } from '~/core/utils/utils';
 
 import { useProperties } from '../../hooks/use-properties';
@@ -144,6 +144,7 @@ export function useDataBlock(options?: UseDataBlockOptions) {
       propertyId: sortState.columnId,
       direction: sortState.direction,
       dataType: property?.dataType?.toLowerCase(),
+      includeWithoutValue: shouldIncludeWithoutValueForPropertySort(sortState.columnId),
     };
   }, [sortState, propertiesSchema, filterableProperties]);
 

--- a/apps/web/core/io/entities-ordered-by-property-connection-document.ts
+++ b/apps/web/core/io/entities-ordered-by-property-connection-document.ts
@@ -25,6 +25,7 @@ const ENTITIES_ORDERED_BY_PROPERTY_CONNECTION_SOURCE = /* GraphQL */ `
     $propertyId: UUID
     $sortDirection: SortOrder
     $dataType: String
+    $includeWithoutValue: Boolean
     $spaceId: UUID
     $spaceIds: [UUID!]
     $typeIds: [UUID!]
@@ -37,6 +38,7 @@ const ENTITIES_ORDERED_BY_PROPERTY_CONNECTION_SOURCE = /* GraphQL */ `
       propertyId: $propertyId
       sortDirection: $sortDirection
       dataType: $dataType
+      includeWithoutValue: $includeWithoutValue
       spaceIds: $spaceIds
       typeIds: $typeIds
       first: $limit

--- a/apps/web/core/io/entities-ordered-by-property-connection.test.ts
+++ b/apps/web/core/io/entities-ordered-by-property-connection.test.ts
@@ -154,4 +154,10 @@ describe('getEntitiesOrderedByPropertyConnection', () => {
       filter: { name: { isNull: false, isNot: '' } },
     });
   });
+
+  it('forwards includeWithoutValue to the property-ordering query', async () => {
+    await runQuery({ includeWithoutValue: true });
+
+    expect(lastVariables()).toMatchObject({ includeWithoutValue: true });
+  });
 });

--- a/apps/web/core/io/queries.ts
+++ b/apps/web/core/io/queries.ts
@@ -266,6 +266,7 @@ type GetEntitiesOrderedByPropertyOptions = {
   propertyId: string;
   sortDirection: SortOrder;
   dataType?: string;
+  includeWithoutValue?: boolean;
   spaceId?: string;
   spaceIds?: string[];
   typeIds?: string[];
@@ -300,6 +301,7 @@ export function getEntitiesOrderedByPropertyConnection(
     propertyId,
     sortDirection,
     dataType,
+    includeWithoutValue,
     spaceId,
     spaceIds,
     typeIds,
@@ -338,6 +340,7 @@ export function getEntitiesOrderedByPropertyConnection(
       propertyId,
       sortDirection,
       dataType,
+      includeWithoutValue,
       spaceId: topLevelSpaceId,
       spaceIds: topLevelSpaceIds,
       typeIds: topLevelTypeIds,

--- a/apps/web/core/sync/orm.sync-many.test.ts
+++ b/apps/web/core/sync/orm.sync-many.test.ts
@@ -4,7 +4,7 @@ import { QueryClient } from '@tanstack/react-query';
 import { Effect } from 'effect';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { getAllEntities, getBatchEntities } from '../io/queries';
+import { getAllEntities, getBatchEntities, getEntitiesOrderedByPropertyConnection } from '../io/queries';
 import type { Entity, Value } from '../types';
 import { E } from './orm';
 import { GeoStore, reactiveRelations, reactiveValues, syncedEntities } from './store';
@@ -123,5 +123,31 @@ describe('E.syncMany pagination', () => {
     expect(vi.mocked(getBatchEntities).mock.calls.map(call => call[0].length)).toEqual([50, 50, 17]);
     expect(result.merged.map(e => e.id)).toEqual(ids);
     expect(result.remote).toHaveLength(ids.length);
+  });
+
+  it.each([
+    ['regular queries', {}],
+    ['collection id queries', { id: { in: ['entity-a'] } }],
+  ])('forwards includeWithoutValue for sorted %s', async (_label, where) => {
+    vi.mocked(getEntitiesOrderedByPropertyConnection).mockReturnValue(
+      Effect.succeed({ entities: [], endCursor: null, hasNextPage: false })
+    );
+
+    await E.syncMany({
+      store,
+      cache,
+      where,
+      first: 9,
+      sort: {
+        propertyId: 'score-property',
+        direction: 'desc',
+        dataType: 'integer',
+        includeWithoutValue: true,
+      },
+    });
+
+    expect(vi.mocked(getEntitiesOrderedByPropertyConnection)).toHaveBeenCalledWith(
+      expect.objectContaining({ includeWithoutValue: true })
+    );
   });
 });

--- a/apps/web/core/sync/orm.ts
+++ b/apps/web/core/sync/orm.ts
@@ -257,7 +257,7 @@ export class E {
     after?: string;
     offset?: number;
     spaceId?: string;
-    sort?: { propertyId: string; direction: 'asc' | 'desc'; dataType?: string };
+    sort?: { propertyId: string; direction: 'asc' | 'desc'; dataType?: string; includeWithoutValue?: boolean };
   }): Promise<Entity[]> {
     const { merged } = await this.syncMany(args);
     return merged;
@@ -288,7 +288,7 @@ export class E {
     after?: string;
     offset?: number;
     spaceId?: string;
-    sort?: { propertyId: string; direction: 'asc' | 'desc'; dataType?: string };
+    sort?: { propertyId: string; direction: 'asc' | 'desc'; dataType?: string; includeWithoutValue?: boolean };
     orderBy?: EntitiesOrderBy[];
   }): Promise<{ merged: Entity[]; remote: Entity[]; endCursor: string | null; hasNextPage: boolean }> {
     if (where?.id?.in) {
@@ -301,6 +301,7 @@ export class E {
             propertyId: sort.propertyId,
             sortDirection: sort.direction === 'asc' ? SortOrder.Asc : SortOrder.Desc,
             dataType: sort.dataType,
+            includeWithoutValue: sort.includeWithoutValue,
             spaceId,
             limit: first,
             after,
@@ -355,6 +356,7 @@ export class E {
             propertyId: sort.propertyId,
             sortDirection: sort.direction === 'asc' ? SortOrder.Asc : SortOrder.Desc,
             dataType: sort.dataType,
+            includeWithoutValue: sort.includeWithoutValue,
             spaceId,
             limit: first,
             after,

--- a/apps/web/core/sync/use-store.tsx
+++ b/apps/web/core/sync/use-store.tsx
@@ -316,7 +316,7 @@ export function useQueryEntities({
   sort,
   orderBy,
 }: QueryEntitiesOptions & {
-  sort?: { propertyId: string; direction: 'asc' | 'desc'; dataType?: string };
+  sort?: { propertyId: string; direction: 'asc' | 'desc'; dataType?: string; includeWithoutValue?: boolean };
   /** Entity-level ordering (e.g. created-at) applied server-side when no property `sort` is set. */
   orderBy?: EntitiesOrderBy[];
 }) {

--- a/apps/web/core/utils/column-sort.test.ts
+++ b/apps/web/core/utils/column-sort.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+
+import { SCORE_SYSTEM_PROPERTY } from '~/core/constants';
+
+import { shouldIncludeWithoutValueForPropertySort } from './column-sort';
+
+describe('shouldIncludeWithoutValueForPropertySort', () => {
+  it('includes entities without a value when sorting by score', () => {
+    expect(shouldIncludeWithoutValueForPropertySort(SCORE_SYSTEM_PROPERTY)).toBe(true);
+  });
+
+  it('does not include missing values for other property sorts', () => {
+    expect(shouldIncludeWithoutValueForPropertySort('other-property')).toBe(false);
+  });
+});

--- a/apps/web/core/utils/column-sort.ts
+++ b/apps/web/core/utils/column-sort.ts
@@ -37,6 +37,10 @@ export function propertyForSort(columnId: string, properties: Property[]): Prope
   );
 }
 
+export function shouldIncludeWithoutValueForPropertySort(propertyId: string): boolean {
+  return ID.equals(propertyId, SCORE_SYSTEM_PROPERTY);
+}
+
 export function propertySortLabel(property: Property): string {
   const known = DEFAULT_TABLE_SORT_PROPERTIES.find(p => ID.equals(p.id, property.id));
   if (known?.name) return known.name;


### PR DESCRIPTION
## What changed

- Set `includeWithoutValue: true` when a data block sorts by the system Score property.
- Propagate the option through regular and collection-backed property-sort query paths.
- Add the optional variable to the shared `entitiesOrderedByPropertyConnection` document.
- Keep existing behavior for non-Score property sorts.

## Why

Property sorting normally returns only entities that already have a value for the selected property. For Score sorts, entities without a score should be treated as empty/unscored and remain in the result set, matching the Explore page's Top sort behavior.

## Impact

Data blocks sorted by Score now show the complete filtered entity set, including entities that do not yet have a Score value.

## Validation

- `bun run test core/utils/column-sort.test.ts core/io/entities-ordered-by-property-connection.test.ts core/sync/orm.sync-many.test.ts`
- `bunx tsc --noEmit --pretty false`
- ESLint on all changed files
- `git diff --check`
