### PR TITLE
feat: add hidden feature flags route

### DIFF
--- a/apps/web/app/feature-flags/page.tsx
+++ b/apps/web/app/feature-flags/page.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  robots: {
+    index: false,
+    follow: false,
+  },
+};
+
+export default function FeatureFlagsPage() {
+  return null;
+}

--- a/apps/web/partials/feature-flags/feature-flags-dialog.test.tsx
+++ b/apps/web/partials/feature-flags/feature-flags-dialog.test.tsx
@@ -62,7 +62,7 @@ describe('FeatureFlagsDialog', () => {
     expect(await screen.findByRole('heading', { name: 'Feature flags' })).toBeTruthy();
   });
 
-  it('returns home when closing the dialog from the hidden flags route', async () => {
+  it('returns to the root space when closing the dialog from the hidden flags route', async () => {
     navigation.pathname = '/feature-flags';
 
     render(
@@ -73,6 +73,6 @@ describe('FeatureFlagsDialog', () => {
 
     fireEvent.click(await screen.findByRole('button', { name: 'Close feature flags' }));
 
-    expect(navigation.replace).toHaveBeenCalledWith('/');
+    expect(navigation.replace).toHaveBeenCalledWith('/root');
   });
 });

--- a/apps/web/partials/feature-flags/feature-flags-dialog.test.tsx
+++ b/apps/web/partials/feature-flags/feature-flags-dialog.test.tsx
@@ -1,16 +1,30 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 import { Provider, createStore } from 'jotai';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { featureFlagsStorageKey } from '~/core/state/feature-flags';
 
 import { FeatureFlagsDialog } from './feature-flags-dialog';
 
+const navigation = vi.hoisted(() => ({
+  pathname: '/',
+  replace: vi.fn(),
+}));
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => navigation.pathname,
+  useRouter: () => ({ replace: navigation.replace }),
+}));
+
 describe('FeatureFlagsDialog', () => {
   beforeEach(() => {
     window.localStorage.clear();
+    navigation.pathname = '/';
+    navigation.replace.mockReset();
   });
+
+  afterEach(cleanup);
 
   it('opens with Cmd/Ctrl+Shift+F and toggles local feature flags', async () => {
     render(
@@ -34,5 +48,31 @@ describe('FeatureFlagsDialog', () => {
         JSON.stringify({ questionsTab: true, debateDebugging: true, debateFormatSelector: true })
       );
     });
+  });
+
+  it('opens when visiting the hidden flags route', async () => {
+    navigation.pathname = '/feature-flags';
+
+    render(
+      <Provider store={createStore()}>
+        <FeatureFlagsDialog />
+      </Provider>
+    );
+
+    expect(await screen.findByRole('heading', { name: 'Feature flags' })).toBeTruthy();
+  });
+
+  it('returns home when closing the dialog from the hidden flags route', async () => {
+    navigation.pathname = '/feature-flags';
+
+    render(
+      <Provider store={createStore()}>
+        <FeatureFlagsDialog />
+      </Provider>
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Close feature flags' }));
+
+    expect(navigation.replace).toHaveBeenCalledWith('/');
   });
 });

--- a/apps/web/partials/feature-flags/feature-flags-dialog.tsx
+++ b/apps/web/partials/feature-flags/feature-flags-dialog.tsx
@@ -4,6 +4,8 @@ import { Content, Description, Overlay, Portal, Root, Title } from '@radix-ui/re
 
 import * as React from 'react';
 
+import { usePathname, useRouter } from 'next/navigation';
+
 import { featureFlagDefinitions, useFeatureFlags } from '~/core/state/feature-flags';
 
 import { SquareButton } from '~/design-system/button';
@@ -12,23 +14,38 @@ import { Close } from '~/design-system/icons/close';
 import { Text } from '~/design-system/text';
 
 export function FeatureFlagsDialog() {
-  const [open, setOpen] = React.useState(false);
+  const pathname = usePathname();
+  const router = useRouter();
+  const [shortcutOpen, setShortcutOpen] = React.useState(false);
   const { flags, setFeatureFlag } = useFeatureFlags();
+  const routeOpen = pathname === '/feature-flags';
+  const open = shortcutOpen || routeOpen;
+
+  const close = React.useCallback(() => {
+    setShortcutOpen(false);
+    if (routeOpen) router.replace('/');
+  }, [routeOpen, router]);
 
   React.useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
       if (!(event.metaKey || event.ctrlKey) || !event.shiftKey || event.key.toLowerCase() !== 'f') return;
 
       event.preventDefault();
-      setOpen(value => !value);
+      if (open) close();
+      else setShortcutOpen(true);
     };
 
     window.addEventListener('keydown', onKeyDown);
     return () => window.removeEventListener('keydown', onKeyDown);
-  }, []);
+  }, [close, open]);
+
+  const onOpenChange = (nextOpen: boolean) => {
+    if (nextOpen) setShortcutOpen(true);
+    else close();
+  };
 
   return (
-    <Root open={open} onOpenChange={setOpen}>
+    <Root open={open} onOpenChange={onOpenChange}>
       <Portal>
         <Overlay className="fixed inset-0 z-100 bg-text/20" />
 
@@ -41,7 +58,7 @@ export function FeatureFlagsDialog() {
                 </Text>
               </Title>
               <Description className="sr-only">Toggle local preview features for this browser.</Description>
-              <SquareButton onClick={() => setOpen(false)} icon={<Close />} aria-label="Close feature flags" />
+              <SquareButton onClick={close} icon={<Close />} aria-label="Close feature flags" />
             </div>
 
             <div className="flex flex-col divide-y divide-grey-02">

--- a/apps/web/partials/feature-flags/feature-flags-dialog.tsx
+++ b/apps/web/partials/feature-flags/feature-flags-dialog.tsx
@@ -23,7 +23,7 @@ export function FeatureFlagsDialog() {
 
   const close = React.useCallback(() => {
     setShortcutOpen(false);
-    if (routeOpen) router.replace('/');
+    if (routeOpen) router.replace('/root');
   }, [routeOpen, router]);
 
   React.useEffect(() => {


### PR DESCRIPTION
## Summary

Feature flags can now be opened on mobile or desktop by navigating directly to `/feature-flags`, without exposing a discoverable UI control. The existing keyboard shortcut continues to work, and dismissing a route-opened dialog returns to the home page. The hidden route is excluded from search indexing.

## Validation

- `bun run test` — 1,449 tests passed across 142 files
- ESLint passed for the changed files
- `tsc --noEmit` passed

## Post-Deploy Monitoring & Validation

No additional operational monitoring is required because this route only controls browser-local preview state. During the standard post-deploy smoke check, the feature owner should verify that `/feature-flags` opens the modal on mobile and that closing it returns home. A 404, a modal that does not open, or a modal that cannot be dismissed is the rollback trigger.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)

https://linear.app/geobrowser/issue/GEO-2414/allow-feature-flags-on-mobile
