### PR TITLE
feat(debates): add matchmaking availability control

### DIFF
--- a/apps/web/core/debates/api.test.ts
+++ b/apps/web/core/debates/api.test.ts
@@ -6,6 +6,7 @@ import {
   getDebateActivity,
   getGeoChatSession,
   resetGeoChatSession,
+  updateDebateAvailability,
 } from './api';
 
 const completeRequest = {
@@ -95,6 +96,40 @@ describe('geo-chat request errors', () => {
       code: null,
       status: 503,
     });
+  });
+});
+
+describe('debate availability', () => {
+  it('updates the authenticated availability preference', async () => {
+    const activity = {
+      online: true,
+      available_to_debate: false,
+      cooldown_until: null,
+      match: null,
+      debate: null,
+      rematch: null,
+    };
+    const fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(activity), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+    vi.stubGlobal('fetch', fetch);
+
+    await expect(updateDebateAvailability(false, vi.fn(), 'user-a')).resolves.toEqual(activity);
+
+    expect(fetch).toHaveBeenCalledWith(
+      'http://localhost:8080/me/debate-availability',
+      expect.objectContaining({
+        method: 'PUT',
+        headers: {
+          Authorization: 'Bearer access-token',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ available_to_debate: false }),
+      })
+    );
   });
 });
 

--- a/apps/web/core/debates/api.ts
+++ b/apps/web/core/debates/api.ts
@@ -189,6 +189,7 @@ export type Debate = {
 
 export type DebateActivity = {
   online: boolean;
+  available_to_debate: boolean;
   cooldown_until: string | null;
   match: DebateMatch | null;
   debate: Debate | null;
@@ -413,6 +414,20 @@ export async function getDebateActivity(
     getPrivyIdentityToken,
     accountKey,
     signal,
+  });
+}
+
+export async function updateDebateAvailability(
+  availableToDebate: boolean,
+  getPrivyIdentityToken: GetPrivyIdentityToken,
+  accountKey: string | null
+) {
+  return geoChatRequest<DebateActivity>('/me/debate-availability', {
+    method: 'PUT',
+    body: { available_to_debate: availableToDebate },
+    auth: true,
+    getPrivyIdentityToken,
+    accountKey,
   });
 }
 

--- a/apps/web/core/debates/debate-coordinator.test.tsx
+++ b/apps/web/core/debates/debate-coordinator.test.tsx
@@ -107,6 +107,7 @@ describe('DebateCoordinator', () => {
     mocks.pathname = '/space/space-1/debates/rematches/rematch-1';
     mocks.activity = {
       online: true,
+      available_to_debate: true,
       cooldown_until: null,
       match: null,
       debate: {
@@ -122,7 +123,14 @@ describe('DebateCoordinator', () => {
   });
 
   it('copies a stable recording link when native sharing is unavailable', async () => {
-    mocks.activity = { online: true, cooldown_until: null, match: null, debate: null, rematch: null };
+    mocks.activity = {
+      online: true,
+      available_to_debate: true,
+      cooldown_until: null,
+      match: null,
+      debate: null,
+      rematch: null,
+    };
     mocks.prompts = [
       {
         id: 'prompt-1',
@@ -151,7 +159,14 @@ describe('DebateCoordinator', () => {
   });
 
   it('uses the generated preview and loads the share video only after play', async () => {
-    mocks.activity = { online: true, cooldown_until: null, match: null, debate: null, rematch: null };
+    mocks.activity = {
+      online: true,
+      available_to_debate: true,
+      cooldown_until: null,
+      match: null,
+      debate: null,
+      rematch: null,
+    };
     mocks.prompts = [
       {
         id: 'prompt-1',
@@ -186,6 +201,7 @@ describe('DebateCoordinator', () => {
 function activityWithRematch(status: 'deciding' | 'browsing'): DebateActivity {
   return {
     online: true,
+    available_to_debate: true,
     cooldown_until: null,
     match: null,
     debate: null,

--- a/apps/web/core/debates/hooks.test.tsx
+++ b/apps/web/core/debates/hooks.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider, focusManager, onlineManager } from '@tanstack/react-query';
-import { act, renderHook } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 
 import type { ReactNode } from 'react';
 
@@ -16,6 +16,7 @@ import {
   useDebateActivity,
   useGeoChatAuth,
   useMarkDebateReady,
+  useUpdateDebateAvailability,
 } from './hooks';
 
 const mocks = vi.hoisted(() => ({
@@ -24,6 +25,7 @@ const mocks = vi.hoisted(() => ({
   identityToken: vi.fn(),
   consentToDebateRematch: vi.fn(),
   markDebateReady: vi.fn(),
+  updateDebateAvailability: vi.fn(),
 }));
 
 vi.mock('@geogenesis/auth', () => ({
@@ -42,6 +44,7 @@ vi.mock('./api', async importOriginal => {
     ...actual,
     consentToDebateRematch: mocks.consentToDebateRematch,
     markDebateReady: mocks.markDebateReady,
+    updateDebateAvailability: mocks.updateDebateAvailability,
   };
 });
 
@@ -57,6 +60,7 @@ describe('useGeoChatAuth', () => {
     mocks.identityToken.mockReset();
     mocks.consentToDebateRematch.mockReset();
     mocks.markDebateReady.mockReset();
+    mocks.updateDebateAvailability.mockReset();
     setCachedIdentityToken(null);
   });
 
@@ -158,12 +162,75 @@ describe('useGeoChatAuth', () => {
   });
 });
 
+describe('useUpdateDebateAvailability', () => {
+  const availableActivity: DebateActivity = {
+    online: true,
+    available_to_debate: true,
+    cooldown_until: null,
+    match: null,
+    debate: null,
+    rematch: null,
+  };
+
+  it('optimistically updates then reconciles the authoritative activity', async () => {
+    const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false }, queries: { retry: false } } });
+    const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries').mockResolvedValue();
+    queryClient.setQueryData(debateQueryKeys.activity('user-a'), availableActivity);
+    let resolveUpdate!: (activity: DebateActivity) => void;
+    mocks.updateDebateAvailability.mockReturnValue(
+      new Promise<DebateActivity>(resolve => {
+        resolveUpdate = resolve;
+      })
+    );
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    const { result } = renderHook(() => useUpdateDebateAvailability(), { wrapper });
+
+    let mutation!: Promise<DebateActivity>;
+    act(() => {
+      mutation = result.current.mutateAsync(false);
+    });
+    await waitFor(() =>
+      expect(queryClient.getQueryData(debateQueryKeys.activity('user-a'))).toEqual({
+        ...availableActivity,
+        available_to_debate: false,
+      })
+    );
+
+    const authoritative = { ...availableActivity, online: false, available_to_debate: false };
+    resolveUpdate(authoritative);
+    await act(async () => mutation);
+
+    expect(mocks.updateDebateAvailability).toHaveBeenCalledWith(false, expect.any(Function), 'user-a');
+    expect(queryClient.getQueryData(debateQueryKeys.activity('user-a'))).toEqual(authoritative);
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['debates'] });
+  });
+
+  it('rolls the optimistic activity back when the request fails', async () => {
+    const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false }, queries: { retry: false } } });
+    queryClient.setQueryData(debateQueryKeys.activity('user-a'), availableActivity);
+    mocks.updateDebateAvailability.mockRejectedValue(new Error('unavailable'));
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    const { result } = renderHook(() => useUpdateDebateAvailability(), { wrapper });
+
+    await act(async () => {
+      await expect(result.current.mutateAsync(false)).rejects.toThrow('unavailable');
+    });
+
+    expect(queryClient.getQueryData(debateQueryKeys.activity('user-a'))).toEqual(availableActivity);
+  });
+});
+
 describe('useConsentToDebateRematch', () => {
   it('replaces stale debate activity with the authoritative rematch session', async () => {
     const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false }, queries: { retry: false } } });
     const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries').mockResolvedValue();
     const staleActivity: DebateActivity = {
       online: true,
+      available_to_debate: true,
       cooldown_until: null,
       match: null,
       debate: { id: 'debate-1' } as NonNullable<DebateActivity['debate']>,
@@ -182,6 +249,7 @@ describe('useConsentToDebateRematch', () => {
 
     expect(queryClient.getQueryData(debateQueryKeys.activity('user-a'))).toEqual({
       online: true,
+      available_to_debate: true,
       cooldown_until: null,
       match: null,
       debate: null,
@@ -218,6 +286,7 @@ describe('useClearTimedOutDebateActivity', () => {
     const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
     const activity: DebateActivity = {
       online: true,
+      available_to_debate: true,
       cooldown_until: '2026-07-02T00:10:00.000Z',
       match: null,
       debate: { id: 'debate-1' } as NonNullable<DebateActivity['debate']>,
@@ -254,10 +323,20 @@ describe('debate query refresh behavior', () => {
       })
     );
     const fetch = vi.fn().mockResolvedValue(
-      new Response(JSON.stringify({ online: true, cooldown_until: null, match: null, debate: null, rematch: null }), {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
-      })
+      new Response(
+        JSON.stringify({
+          online: true,
+          available_to_debate: true,
+          cooldown_until: null,
+          match: null,
+          debate: null,
+          rematch: null,
+        }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }
+      )
     );
     vi.stubGlobal('fetch', fetch);
     const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });

--- a/apps/web/core/debates/hooks.ts
+++ b/apps/web/core/debates/hooks.ts
@@ -44,6 +44,7 @@ import {
   markDebateReady,
   rejectDebateRematchRequest,
   requestDebateMediaProcessing,
+  updateDebateAvailability,
   updateDebatePreference,
   updateDebateRematchPosition,
 } from './api';
@@ -145,6 +146,34 @@ export function useDebateActivity(enabled = true) {
     queryKey: debateQueryKeys.activity(accountKey),
     queryFn: ({ signal }) => getDebateActivity(getPrivyIdentityToken, accountKey, signal),
     enabled: enabled && authenticated,
+  });
+}
+
+export function useUpdateDebateAvailability() {
+  const queryClient = useQueryClient();
+  const { accountKey, getPrivyIdentityToken } = useGeoChatAuth();
+  const activityKey = debateQueryKeys.activity(accountKey);
+
+  return useMutation({
+    mutationFn: (availableToDebate: boolean) =>
+      updateDebateAvailability(availableToDebate, getPrivyIdentityToken, accountKey),
+    onMutate: async availableToDebate => {
+      await queryClient.cancelQueries({ queryKey: activityKey });
+      const previous = queryClient.getQueryData<DebateActivity>(activityKey);
+      queryClient.setQueryData<DebateActivity>(activityKey, current =>
+        current ? { ...current, available_to_debate: availableToDebate } : current
+      );
+      return { previous };
+    },
+    onError: (_error, _availableToDebate, context) => {
+      queryClient.setQueryData(activityKey, context?.previous);
+    },
+    onSuccess: activity => {
+      queryClient.setQueryData(activityKey, activity);
+    },
+    onSettled: () => {
+      void queryClient.invalidateQueries({ queryKey: ['debates'] });
+    },
   });
 }
 
@@ -295,6 +324,7 @@ export function useConsentToDebateRematch(debateId: string) {
       queryClient.setQueryData(debateQueryKeys.rematch(accountKey, session.id), session);
       queryClient.setQueryData<DebateActivity>(debateQueryKeys.activity(accountKey), current => ({
         online: current?.online ?? true,
+        available_to_debate: current?.available_to_debate ?? true,
         cooldown_until: null,
         match: null,
         debate: null,

--- a/apps/web/partials/navbar/navbar-actions.test.tsx
+++ b/apps/web/partials/navbar/navbar-actions.test.tsx
@@ -183,7 +183,7 @@ describe('NavbarActions debate availability menu', () => {
     expect(screen.getByText('Max')).toHaveClass(
       'font-[family-name:var(--font-calibre)]',
       'text-[1rem]',
-      'leading-[0.9375rem]',
+      'leading-5',
       'font-medium',
       'tracking-[-0.03125rem]',
       'not-italic'
@@ -191,7 +191,7 @@ describe('NavbarActions debate availability menu', () => {
     expect(screen.getByText('max@example.com')).toHaveClass(
       'font-[family-name:var(--font-calibre)]',
       'text-[1rem]',
-      'leading-[0.9375rem]',
+      'leading-5',
       'font-medium',
       'tracking-[-0.03125rem]',
       'not-italic'
@@ -200,6 +200,7 @@ describe('NavbarActions debate availability menu', () => {
     expect(screen.getByRole('switch', { name: 'Available to debate' })).toHaveClass(
       'px-3',
       'py-2.5',
+      'gap-1',
       'font-[family-name:var(--font-calibre)]',
       'text-[1rem]',
       'leading-[0.9375rem]',

--- a/apps/web/partials/navbar/navbar-actions.test.tsx
+++ b/apps/web/partials/navbar/navbar-actions.test.tsx
@@ -182,6 +182,26 @@ describe('NavbarActions debate availability menu', () => {
       '/space/personal-space'
     );
     expect(screen.getByRole('switch', { name: 'Available to debate' })).toHaveAttribute('aria-checked', 'true');
+    expect(screen.getByRole('switch', { name: 'Available to debate' })).toHaveClass(
+      'px-3',
+      'py-2.5',
+      'font-[family-name:var(--font-calibre)]',
+      'text-[1rem]',
+      'leading-[0.9375rem]',
+      'font-medium',
+      'tracking-[-0.03125rem]',
+      'not-italic'
+    );
+    expect(screen.getByRole('button', { name: 'Sign out' })).toHaveClass(
+      'px-3',
+      'py-2.5',
+      'font-[family-name:var(--font-calibre)]',
+      'text-[1rem]',
+      'leading-[0.9375rem]',
+      'font-medium',
+      'tracking-[-0.03125rem]',
+      'not-italic'
+    );
     expect(screen.queryByText('Personal space')).not.toBeInTheDocument();
     expect(screen.getByText('Sign out')).toBeInTheDocument();
   });

--- a/apps/web/partials/navbar/navbar-actions.test.tsx
+++ b/apps/web/partials/navbar/navbar-actions.test.tsx
@@ -180,6 +180,7 @@ describe('NavbarActions debate availability menu', () => {
     const identityLink = screen.getByRole('link', { name: /Max max@example\.com/ });
     expect(identityLink).toHaveAttribute('href', '/space/personal-space');
     expect(identityLink).toHaveClass('px-3', 'py-2.5');
+    expect(identityLink.querySelector('.h-8.w-8')).toBeInTheDocument();
     expect(screen.getByText('Max')).toHaveClass(
       'font-[family-name:var(--font-calibre)]',
       'text-[1rem]',

--- a/apps/web/partials/navbar/navbar-actions.test.tsx
+++ b/apps/web/partials/navbar/navbar-actions.test.tsx
@@ -32,7 +32,7 @@ const mocks = vi.hoisted(() => ({
   pendingPersonalSpace: { isPending: false, topicId: null as string | null },
   privyUser: {
     id: 'user-a',
-    email: { address: 'nate@geobrowser.io' },
+    email: { address: 'max@example.com' },
     linkedAccounts: [],
   } as Record<string, unknown> | null,
 }));
@@ -150,7 +150,7 @@ describe('NavbarActions debate availability menu', () => {
     mocks.pendingPersonalSpace = { isPending: false, topicId: null };
     mocks.privyUser = {
       id: 'user-a',
-      email: { address: 'nate@geobrowser.io' },
+      email: { address: 'max@example.com' },
       linkedAccounts: [],
     };
   });
@@ -165,7 +165,7 @@ describe('NavbarActions debate availability menu', () => {
     expect(screen.getByText('Personal space')).toBeInTheDocument();
     expect(screen.getByText('Sign out')).toBeInTheDocument();
     expect(screen.queryByRole('switch')).not.toBeInTheDocument();
-    expect(screen.queryByText('nate@geobrowser.io')).not.toBeInTheDocument();
+    expect(screen.queryByText('max@example.com')).not.toBeInTheDocument();
     expect(mocks.debateActivityHook).toHaveBeenCalledWith(false);
     expect(mocks.mutateAvailability).not.toHaveBeenCalled();
   });
@@ -177,7 +177,7 @@ describe('NavbarActions debate availability menu', () => {
     await user.click(screen.getByRole('button', { name: 'Open profile menu' }));
 
     expect(screen.getByTestId('profile-menu')).toHaveClass('sm:w-[322px]');
-    expect(screen.getByRole('link', { name: /Nate nate@geobrowser\.io/ })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: /Nate max@example\.com/ })).toHaveAttribute(
       'href',
       '/space/personal-space'
     );

--- a/apps/web/partials/navbar/navbar-actions.test.tsx
+++ b/apps/web/partials/navbar/navbar-actions.test.tsx
@@ -25,7 +25,7 @@ const mocks = vi.hoisted(() => ({
     rematch: null,
   },
   profile: {
-    name: 'Nate',
+    name: 'Max',
     avatarUrl: 'ipfs://avatar',
   } as { name: string | null; avatarUrl: string | null } | null,
   personalSpaceId: 'personal-space' as string | null,
@@ -145,7 +145,7 @@ describe('NavbarActions debate availability menu', () => {
       debate: null,
       rematch: null,
     };
-    mocks.profile = { name: 'Nate', avatarUrl: 'ipfs://avatar' };
+    mocks.profile = { name: 'Max', avatarUrl: 'ipfs://avatar' };
     mocks.personalSpaceId = 'personal-space';
     mocks.pendingPersonalSpace = { isPending: false, topicId: null };
     mocks.privyUser = {
@@ -177,7 +177,7 @@ describe('NavbarActions debate availability menu', () => {
     await user.click(screen.getByRole('button', { name: 'Open profile menu' }));
 
     expect(screen.getByTestId('profile-menu')).toHaveClass('sm:w-[322px]');
-    expect(screen.getByRole('link', { name: /Nate max@example\.com/ })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: /Max max@example\.com/ })).toHaveAttribute(
       'href',
       '/space/personal-space'
     );

--- a/apps/web/partials/navbar/navbar-actions.test.tsx
+++ b/apps/web/partials/navbar/navbar-actions.test.tsx
@@ -1,0 +1,243 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup, render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { NavbarActions } from './navbar-actions';
+
+const address = '0x1234567890abcdef1234567890abcdef12345678';
+
+const mocks = vi.hoisted(() => ({
+  debatesEnabled: true,
+  logout: vi.fn(),
+  setToast: vi.fn(),
+  debateActivityHook: vi.fn(),
+  mutateAvailability: vi.fn(),
+  mutationPending: false,
+  activityPending: false,
+  activity: {
+    online: true,
+    available_to_debate: true,
+    cooldown_until: null,
+    match: null,
+    debate: null,
+    rematch: null,
+  },
+  profile: {
+    name: 'Nate',
+    avatarUrl: 'ipfs://avatar',
+  } as { name: string | null; avatarUrl: string | null } | null,
+  personalSpaceId: 'personal-space' as string | null,
+  pendingPersonalSpace: { isPending: false, topicId: null as string | null },
+  privyUser: {
+    id: 'user-a',
+    email: { address: 'nate@geobrowser.io' },
+    linkedAccounts: [],
+  } as Record<string, unknown> | null,
+}));
+
+vi.mock('@geogenesis/auth', () => ({
+  useLogout: () => ({ logout: mocks.logout }),
+  usePrivy: () => ({ ready: true, authenticated: true, user: mocks.privyUser }),
+}));
+
+vi.mock('jotai', () => ({ useAtomValue: () => '' }));
+
+vi.mock('~/core/hooks/use-smart-account', () => ({
+  useSmartAccount: () => ({ smartAccount: { account: { address } }, isLoading: false }),
+}));
+vi.mock('~/core/hooks/use-geo-profile', () => ({
+  useGeoProfile: () => ({ profile: mocks.profile, isLoading: false }),
+}));
+vi.mock('~/core/hooks/use-personal-space-id', () => ({
+  usePersonalSpaceId: () => ({ personalSpaceId: mocks.personalSpaceId }),
+}));
+vi.mock('~/core/state/pending-personal-space', () => ({
+  usePendingPersonalSpace: () => mocks.pendingPersonalSpace,
+}));
+vi.mock('~/core/state/feature-flags', () => ({
+  useDebatesEnabled: () => mocks.debatesEnabled,
+}));
+vi.mock('~/core/debates/hooks', () => ({
+  useDebateActivity: (enabled: boolean) => {
+    mocks.debateActivityHook(enabled);
+    return { data: mocks.activity, isPending: mocks.activityPending };
+  },
+  useUpdateDebateAvailability: () => ({
+    mutate: mocks.mutateAvailability,
+    isPending: mocks.mutationPending,
+  }),
+}));
+vi.mock('~/core/hooks/use-toast', () => ({
+  useToast: () => [null, mocks.setToast],
+}));
+vi.mock('~/core/hooks/use-space-id', () => ({ useSpaceId: () => null }));
+vi.mock('~/core/hooks/use-access-control', () => ({
+  useAccessControl: () => ({ canEdit: false, isLoading: false }),
+}));
+vi.mock('~/core/hooks/use-keyboard-shortcuts', () => ({ useKeyboardShortcuts: vi.fn() }));
+vi.mock('~/core/state/editable-store', () => ({
+  useEditable: () => ({ editable: false, setEditable: vi.fn() }),
+}));
+vi.mock('~/partials/hints/edit-mode-toggle-tip', () => ({
+  EditModeToggleTip: () => null,
+  useEditModeToggleTip: () => ({ open: false, dismiss: vi.fn(), isActive: false }),
+}));
+vi.mock('~/partials/onboarding/dialog', () => ({ avatarAtom: {} }));
+vi.mock('~/core/wallet', () => ({ GeoConnectButton: () => <button>Connect</button> }));
+vi.mock('~/design-system/fallback-image', () => ({
+  FallbackImage: ({ value }: { value: string }) => <img src={value} alt="" />,
+}));
+vi.mock('~/design-system/avatar', () => ({
+  Avatar: ({ value }: { value: string }) => <div data-testid="fallback-avatar">{value}</div>,
+}));
+vi.mock('~/design-system/prefetch-link', () => ({
+  PrefetchLink: ({ href, children, ...props }: React.ComponentProps<'a'>) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+vi.mock('~/design-system/menu', () => ({
+  Menu: ({
+    trigger,
+    children,
+    open,
+    onOpenChange,
+    className,
+  }: {
+    trigger: React.ReactNode;
+    children: React.ReactNode;
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    className?: string;
+  }) => (
+    <div>
+      <button aria-label="Open profile menu" onClick={() => onOpenChange(!open)}>
+        {trigger}
+      </button>
+      {open && (
+        <div data-testid="profile-menu" className={className}>
+          {children}
+        </div>
+      )}
+    </div>
+  ),
+}));
+
+describe('NavbarActions debate availability menu', () => {
+  afterEach(cleanup);
+
+  beforeEach(() => {
+    mocks.debatesEnabled = true;
+    mocks.logout.mockReset();
+    mocks.setToast.mockReset();
+    mocks.debateActivityHook.mockReset();
+    mocks.mutateAvailability.mockReset();
+    mocks.mutationPending = false;
+    mocks.activityPending = false;
+    mocks.activity = {
+      online: true,
+      available_to_debate: true,
+      cooldown_until: null,
+      match: null,
+      debate: null,
+      rematch: null,
+    };
+    mocks.profile = { name: 'Nate', avatarUrl: 'ipfs://avatar' };
+    mocks.personalSpaceId = 'personal-space';
+    mocks.pendingPersonalSpace = { isPending: false, topicId: null };
+    mocks.privyUser = {
+      id: 'user-a',
+      email: { address: 'nate@geobrowser.io' },
+      linkedAccounts: [],
+    };
+  });
+
+  it('keeps the legacy menu when the debate flag is off', async () => {
+    mocks.debatesEnabled = false;
+    const user = userEvent.setup();
+    render(<NavbarActions />);
+
+    await user.click(screen.getByRole('button', { name: 'Open profile menu' }));
+
+    expect(screen.getByText('Personal space')).toBeInTheDocument();
+    expect(screen.getByText('Sign out')).toBeInTheDocument();
+    expect(screen.queryByRole('switch')).not.toBeInTheDocument();
+    expect(screen.queryByText('nate@geobrowser.io')).not.toBeInTheDocument();
+    expect(mocks.debateActivityHook).toHaveBeenCalledWith(false);
+    expect(mocks.mutateAvailability).not.toHaveBeenCalled();
+  });
+
+  it('renders the wider flagged identity layout and personal-space link', async () => {
+    const user = userEvent.setup();
+    render(<NavbarActions />);
+
+    await user.click(screen.getByRole('button', { name: 'Open profile menu' }));
+
+    expect(screen.getByTestId('profile-menu')).toHaveClass('sm:w-[322px]');
+    expect(screen.getByRole('link', { name: /Nate nate@geobrowser\.io/ })).toHaveAttribute(
+      'href',
+      '/space/personal-space'
+    );
+    expect(screen.getByRole('switch', { name: 'Available to debate' })).toHaveAttribute('aria-checked', 'true');
+    expect(screen.queryByText('Personal space')).not.toBeInTheDocument();
+    expect(screen.getByText('Sign out')).toBeInTheDocument();
+  });
+
+  it('uses identity fallbacks and the pending personal-space destination', async () => {
+    mocks.profile = { name: null, avatarUrl: null };
+    mocks.personalSpaceId = null;
+    mocks.pendingPersonalSpace = { isPending: true, topicId: 'topic-1' };
+    mocks.privyUser = { id: 'user-a', linkedAccounts: [] };
+    const user = userEvent.setup();
+    render(<NavbarActions />);
+
+    await user.click(screen.getByRole('button', { name: 'Open profile menu' }));
+
+    const identityLink = screen.getByRole('link', { name: /0x1234…5678/ });
+    expect(identityLink).toHaveAttribute('href', '/space/pending/topic-1');
+    expect(within(identityLink).getByText(address, { selector: 'p' })).toBeInTheDocument();
+  });
+
+  it('toggles with the keyboard and disables the switch while pending', async () => {
+    const user = userEvent.setup();
+    const { rerender } = render(<NavbarActions />);
+    await user.click(screen.getByRole('button', { name: 'Open profile menu' }));
+    const availabilitySwitch = screen.getByRole('switch', { name: 'Available to debate' });
+
+    availabilitySwitch.focus();
+    await user.keyboard('[Space]');
+    expect(mocks.mutateAvailability).toHaveBeenCalledWith(false, expect.any(Object));
+
+    mocks.activity.available_to_debate = false;
+    rerender(<NavbarActions />);
+    expect(screen.getByRole('switch', { name: 'Available to debate' })).toHaveAttribute('aria-checked', 'false');
+
+    mocks.mutationPending = true;
+    rerender(<NavbarActions />);
+    expect(screen.getByRole('switch', { name: 'Available to debate' })).toBeDisabled();
+
+    mocks.mutationPending = false;
+    mocks.activityPending = true;
+    rerender(<NavbarActions />);
+    expect(screen.getByRole('switch', { name: 'Available to debate' })).toBeDisabled();
+  });
+
+  it('keeps sign out usable on load failure and shows the existing toast treatment on mutation failure', async () => {
+    mocks.activity = undefined as never;
+    mocks.mutateAvailability.mockImplementation((_value, options) => options.onError());
+    const user = userEvent.setup();
+    render(<NavbarActions />);
+    await user.click(screen.getByRole('button', { name: 'Open profile menu' }));
+
+    await user.click(screen.getByRole('switch', { name: 'Available to debate' }));
+    expect(mocks.setToast).toHaveBeenCalledWith(
+      expect.objectContaining({ props: expect.objectContaining({ children: 'Couldn’t update debate availability.' }) })
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Sign out' }));
+    expect(mocks.logout).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/web/partials/navbar/navbar-actions.test.tsx
+++ b/apps/web/partials/navbar/navbar-actions.test.tsx
@@ -179,7 +179,7 @@ describe('NavbarActions debate availability menu', () => {
     expect(screen.getByTestId('profile-menu')).toHaveClass('sm:w-[322px]');
     const identityLink = screen.getByRole('link', { name: /Max max@example\.com/ });
     expect(identityLink).toHaveAttribute('href', '/space/personal-space');
-    expect(identityLink).toHaveClass('px-3', 'py-2.5');
+    expect(identityLink).toHaveClass('gap-3', 'px-3', 'py-2.5');
     expect(identityLink.querySelector('.h-8.w-8')).toBeInTheDocument();
     expect(screen.getByText('Max')).toHaveClass(
       'font-[family-name:var(--font-calibre)]',

--- a/apps/web/partials/navbar/navbar-actions.test.tsx
+++ b/apps/web/partials/navbar/navbar-actions.test.tsx
@@ -177,9 +177,24 @@ describe('NavbarActions debate availability menu', () => {
     await user.click(screen.getByRole('button', { name: 'Open profile menu' }));
 
     expect(screen.getByTestId('profile-menu')).toHaveClass('sm:w-[322px]');
-    expect(screen.getByRole('link', { name: /Max max@example\.com/ })).toHaveAttribute(
-      'href',
-      '/space/personal-space'
+    const identityLink = screen.getByRole('link', { name: /Max max@example\.com/ });
+    expect(identityLink).toHaveAttribute('href', '/space/personal-space');
+    expect(identityLink).toHaveClass('px-3', 'py-2.5');
+    expect(screen.getByText('Max')).toHaveClass(
+      'font-[family-name:var(--font-calibre)]',
+      'text-[1rem]',
+      'leading-[0.9375rem]',
+      'font-medium',
+      'tracking-[-0.03125rem]',
+      'not-italic'
+    );
+    expect(screen.getByText('max@example.com')).toHaveClass(
+      'font-[family-name:var(--font-calibre)]',
+      'text-[1rem]',
+      'leading-[0.9375rem]',
+      'font-medium',
+      'tracking-[-0.03125rem]',
+      'not-italic'
     );
     expect(screen.getByRole('switch', { name: 'Available to debate' })).toHaveAttribute('aria-checked', 'true');
     expect(screen.getByRole('switch', { name: 'Available to debate' })).toHaveClass(

--- a/apps/web/partials/navbar/navbar-actions.tsx
+++ b/apps/web/partials/navbar/navbar-actions.tsx
@@ -196,11 +196,11 @@ function IdentityHeader({
 }) {
   const content = (
     <>
-      <div className="relative h-12 w-12 shrink-0 overflow-hidden rounded-full">
+      <div className="relative h-8 w-8 shrink-0 overflow-hidden rounded-full">
         {avatarValue ? (
-          <FallbackImage value={avatarValue} sizes="48px" className="object-cover" />
+          <FallbackImage value={avatarValue} sizes="32px" className="object-cover" />
         ) : (
-          <Avatar value={address} size={48} />
+          <Avatar value={address} size={32} />
         )}
       </div>
       <div className="min-w-0">

--- a/apps/web/partials/navbar/navbar-actions.tsx
+++ b/apps/web/partials/navbar/navbar-actions.tsx
@@ -219,14 +219,14 @@ function IdentityHeader({
       <Link
         href={href}
         onClick={onNavigate}
-        className="flex w-full flex-col items-start gap-4 px-3 py-2.5 transition-colors hover:bg-bg focus-visible:bg-bg focus-visible:outline-none"
+        className="flex w-full flex-col items-start gap-3 px-3 py-2.5 transition-colors hover:bg-bg focus-visible:bg-bg focus-visible:outline-none"
       >
         {content}
       </Link>
     );
   }
 
-  return <div className="flex w-full flex-col items-start gap-4 px-3 py-2.5">{content}</div>;
+  return <div className="flex w-full flex-col items-start gap-3 px-3 py-2.5">{content}</div>;
 }
 
 function shortAddress(address: string) {

--- a/apps/web/partials/navbar/navbar-actions.tsx
+++ b/apps/web/partials/navbar/navbar-actions.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useLogout } from '@geogenesis/auth';
+import { useLogout, usePrivy } from '@geogenesis/auth';
 import * as Popover from '@radix-ui/react-popover';
 
 import * as React from 'react';
@@ -11,13 +11,16 @@ import { AnimatePresence, motion, useAnimation } from 'framer-motion';
 import { useAtomValue } from 'jotai';
 
 import { browseModeToggled, editModeToggled } from '~/core/analytics';
+import { useDebateActivity, useUpdateDebateAvailability } from '~/core/debates/hooks';
 import { useAccessControl } from '~/core/hooks/use-access-control';
 import { useGeoProfile } from '~/core/hooks/use-geo-profile';
 import { useKeyboardShortcuts } from '~/core/hooks/use-keyboard-shortcuts';
 import { usePersonalSpaceId } from '~/core/hooks/use-personal-space-id';
 import { useSmartAccount } from '~/core/hooks/use-smart-account';
 import { useSpaceId } from '~/core/hooks/use-space-id';
+import { useToast } from '~/core/hooks/use-toast';
 import { useEditable } from '~/core/state/editable-store';
+import { useDebatesEnabled } from '~/core/state/feature-flags';
 import { usePendingPersonalSpace } from '~/core/state/pending-personal-space';
 import { NavUtils } from '~/core/utils/utils';
 import { GeoConnectButton } from '~/core/wallet';
@@ -50,6 +53,11 @@ export function NavbarActions() {
   const { personalSpaceId } = usePersonalSpaceId();
   const { isPending, topicId } = usePendingPersonalSpace();
   const pendingAvatar = useAtomValue(avatarAtom);
+  const isDebatesEnabled = useDebatesEnabled();
+  const activityQuery = useDebateActivity(isDebatesEnabled);
+  const availabilityMutation = useUpdateDebateAvailability();
+  const { user } = usePrivy();
+  const [, setToast] = useToast();
   // Cleanup is registered once at the app root (useGeoLogoutCleanup); here we
   // only trigger the logout.
   const { logout } = useLogout();
@@ -76,6 +84,17 @@ export function NavbarActions() {
     : isPending && topicId
       ? `/space/pending/${topicId}`
       : null;
+  const displayName = profile?.name?.trim() || shortAddress(address);
+  const email = userEmail(user);
+  const identityDetail = email ?? address;
+  const availableToDebate = activityQuery.data?.available_to_debate ?? true;
+  const availabilityPending = activityQuery.isPending || availabilityMutation.isPending;
+
+  const toggleDebateAvailability = () => {
+    availabilityMutation.mutate(!availableToDebate, {
+      onError: () => setToast(<span>Couldn’t update debate availability.</span>),
+    });
+  };
 
   return (
     <div className="flex items-center gap-4">
@@ -94,20 +113,156 @@ export function NavbarActions() {
         open={open}
         onOpenChange={onOpenChange}
         sideOffset={12}
-        className="max-w-[165px]"
+        className={
+          isDebatesEnabled ? 'w-[calc(100vw-16px)] max-w-[322px] rounded-[20px] sm:w-[322px]' : 'max-w-[165px]'
+        }
       >
-        {personalHref && (
-          <AvatarMenuItem href={personalHref}>
-            <p className="text-button">Personal space</p>
-          </AvatarMenuItem>
+        {isDebatesEnabled ? (
+          <>
+            <IdentityHeader
+              address={address}
+              avatarValue={avatarValue}
+              displayName={displayName}
+              detail={identityDetail}
+              href={personalHref}
+              onNavigate={() => onOpenChange(false)}
+            />
+            <div className="border-t border-grey-02">
+              <button
+                type="button"
+                role="switch"
+                aria-checked={availableToDebate}
+                disabled={availabilityPending}
+                onClick={toggleDebateAvailability}
+                className="flex w-full items-center justify-between px-5 py-4 text-left text-bodySemibold text-text transition-colors hover:bg-bg focus-visible:bg-bg focus-visible:outline-none disabled:cursor-wait disabled:text-grey-03"
+              >
+                <span>Available to debate</span>
+                <span
+                  aria-hidden="true"
+                  className={cx(
+                    'relative h-4 w-6 shrink-0 rounded-full transition-colors',
+                    availableToDebate ? 'bg-text' : 'bg-grey-03'
+                  )}
+                >
+                  <span
+                    className={cx(
+                      'absolute top-0.5 left-0.5 h-3 w-3 rounded-full bg-white transition-transform',
+                      availableToDebate && 'translate-x-2'
+                    )}
+                  />
+                </span>
+              </button>
+              <button
+                type="button"
+                onClick={logout}
+                className="flex w-full items-center px-5 py-4 text-left text-bodySemibold text-text transition-colors hover:bg-bg focus-visible:bg-bg focus-visible:outline-none"
+              >
+                Sign out
+              </button>
+            </div>
+          </>
+        ) : (
+          <>
+            {personalHref && (
+              <AvatarMenuItem href={personalHref}>
+                <p className="text-button">Personal space</p>
+              </AvatarMenuItem>
+            )}
+            <AvatarMenuItem onClick={logout}>
+              <p className="text-button">Sign out</p>
+              <DisconnectWallet />
+            </AvatarMenuItem>
+          </>
         )}
-        <AvatarMenuItem onClick={logout}>
-          <p className="text-button">Sign out</p>
-          <DisconnectWallet />
-        </AvatarMenuItem>
       </Menu>
     </div>
   );
+}
+
+function IdentityHeader({
+  address,
+  avatarValue,
+  displayName,
+  detail,
+  href,
+  onNavigate,
+}: {
+  address: `0x${string}`;
+  avatarValue: string;
+  displayName: string;
+  detail: string;
+  href: string | null;
+  onNavigate: () => void;
+}) {
+  const content = (
+    <>
+      <div className="relative h-12 w-12 shrink-0 overflow-hidden rounded-full">
+        {avatarValue ? (
+          <FallbackImage value={avatarValue} sizes="48px" className="object-cover" />
+        ) : (
+          <Avatar value={address} size={48} />
+        )}
+      </div>
+      <div className="min-w-0">
+        <p className="truncate text-bodySemibold text-text">{displayName}</p>
+        <p className="truncate text-body text-grey-04">{detail}</p>
+      </div>
+    </>
+  );
+
+  if (href) {
+    return (
+      <Link
+        href={href}
+        onClick={onNavigate}
+        className="flex w-full flex-col items-start gap-4 px-6 py-5 transition-colors hover:bg-bg focus-visible:bg-bg focus-visible:outline-none"
+      >
+        {content}
+      </Link>
+    );
+  }
+
+  return <div className="flex w-full flex-col items-start gap-4 px-6 py-5">{content}</div>;
+}
+
+function shortAddress(address: string) {
+  return `${address.slice(0, 6)}…${address.slice(-4)}`;
+}
+
+function userEmail(user: unknown) {
+  if (!isRecord(user)) return undefined;
+  const primary = emailFromUnknown(user.email);
+  if (primary) return primary;
+  if (!Array.isArray(user.linkedAccounts)) return undefined;
+
+  for (const account of user.linkedAccounts) {
+    const email = emailFromUnknown(account);
+    if (email) return email;
+  }
+
+  return undefined;
+}
+
+function emailFromUnknown(value: unknown) {
+  if (typeof value === 'string') return normalizeEmail(value);
+  if (!isRecord(value)) return undefined;
+
+  for (const key of ['address', 'email', 'emailAddress']) {
+    const email = normalizeEmail(value[key]);
+    if (email) return email;
+  }
+
+  return undefined;
+}
+
+function normalizeEmail(value: unknown) {
+  if (typeof value !== 'string') return undefined;
+  const email = value.trim().toLowerCase();
+  return email.includes('@') ? email : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
 }
 
 const avatarMenuItemStyles = cva(

--- a/apps/web/partials/navbar/navbar-actions.tsx
+++ b/apps/web/partials/navbar/navbar-actions.tsx
@@ -134,9 +134,9 @@ export function NavbarActions() {
                 aria-checked={availableToDebate}
                 disabled={availabilityPending}
                 onClick={toggleDebateAvailability}
-                className="flex w-full items-center justify-between px-3 py-2.5 text-left font-[family-name:var(--font-calibre)] text-[1rem] leading-[0.9375rem] font-medium tracking-[-0.03125rem] text-text not-italic transition-colors hover:bg-bg focus-visible:bg-bg focus-visible:outline-none disabled:cursor-wait disabled:text-grey-03"
+                className="flex w-full items-center justify-between gap-1 px-3 py-2.5 text-left font-[family-name:var(--font-calibre)] text-[1rem] leading-[0.9375rem] font-medium tracking-[-0.03125rem] text-text not-italic transition-colors hover:bg-bg focus-visible:bg-bg focus-visible:outline-none disabled:cursor-wait disabled:text-grey-03"
               >
-                <span>Available to debate</span>
+                <span className="min-w-0 truncate">Available to debate</span>
                 <span
                   aria-hidden="true"
                   className={cx(
@@ -204,10 +204,10 @@ function IdentityHeader({
         )}
       </div>
       <div className="min-w-0">
-        <p className="truncate font-[family-name:var(--font-calibre)] text-[1rem] leading-[0.9375rem] font-medium tracking-[-0.03125rem] text-text not-italic">
+        <p className="truncate font-[family-name:var(--font-calibre)] text-[1rem] leading-5 font-medium tracking-[-0.03125rem] text-text not-italic">
           {displayName}
         </p>
-        <p className="truncate font-[family-name:var(--font-calibre)] text-[1rem] leading-[0.9375rem] font-medium tracking-[-0.03125rem] text-grey-04 not-italic">
+        <p className="truncate font-[family-name:var(--font-calibre)] text-[1rem] leading-5 font-medium tracking-[-0.03125rem] text-grey-04 not-italic">
           {detail}
         </p>
       </div>

--- a/apps/web/partials/navbar/navbar-actions.tsx
+++ b/apps/web/partials/navbar/navbar-actions.tsx
@@ -204,8 +204,12 @@ function IdentityHeader({
         )}
       </div>
       <div className="min-w-0">
-        <p className="truncate text-bodySemibold text-text">{displayName}</p>
-        <p className="truncate text-body text-grey-04">{detail}</p>
+        <p className="truncate font-[family-name:var(--font-calibre)] text-[1rem] leading-[0.9375rem] font-medium tracking-[-0.03125rem] text-text not-italic">
+          {displayName}
+        </p>
+        <p className="truncate font-[family-name:var(--font-calibre)] text-[1rem] leading-[0.9375rem] font-medium tracking-[-0.03125rem] text-grey-04 not-italic">
+          {detail}
+        </p>
       </div>
     </>
   );
@@ -215,14 +219,14 @@ function IdentityHeader({
       <Link
         href={href}
         onClick={onNavigate}
-        className="flex w-full flex-col items-start gap-4 px-6 py-5 transition-colors hover:bg-bg focus-visible:bg-bg focus-visible:outline-none"
+        className="flex w-full flex-col items-start gap-4 px-3 py-2.5 transition-colors hover:bg-bg focus-visible:bg-bg focus-visible:outline-none"
       >
         {content}
       </Link>
     );
   }
 
-  return <div className="flex w-full flex-col items-start gap-4 px-6 py-5">{content}</div>;
+  return <div className="flex w-full flex-col items-start gap-4 px-3 py-2.5">{content}</div>;
 }
 
 function shortAddress(address: string) {

--- a/apps/web/partials/navbar/navbar-actions.tsx
+++ b/apps/web/partials/navbar/navbar-actions.tsx
@@ -134,7 +134,7 @@ export function NavbarActions() {
                 aria-checked={availableToDebate}
                 disabled={availabilityPending}
                 onClick={toggleDebateAvailability}
-                className="flex w-full items-center justify-between px-5 py-4 text-left text-bodySemibold text-text transition-colors hover:bg-bg focus-visible:bg-bg focus-visible:outline-none disabled:cursor-wait disabled:text-grey-03"
+                className="flex w-full items-center justify-between px-3 py-2.5 text-left font-[family-name:var(--font-calibre)] text-[1rem] leading-[0.9375rem] font-medium tracking-[-0.03125rem] text-text not-italic transition-colors hover:bg-bg focus-visible:bg-bg focus-visible:outline-none disabled:cursor-wait disabled:text-grey-03"
               >
                 <span>Available to debate</span>
                 <span
@@ -155,7 +155,7 @@ export function NavbarActions() {
               <button
                 type="button"
                 onClick={logout}
-                className="flex w-full items-center px-5 py-4 text-left text-bodySemibold text-text transition-colors hover:bg-bg focus-visible:bg-bg focus-visible:outline-none"
+                className="flex w-full items-center px-3 py-2.5 text-left font-[family-name:var(--font-calibre)] text-[1rem] leading-[0.9375rem] font-medium tracking-[-0.03125rem] text-text not-italic transition-colors hover:bg-bg focus-visible:bg-bg focus-visible:outline-none"
               >
                 Sign out
               </button>


### PR DESCRIPTION
## Summary

Users can control future debate matchmaking from the profile menu while keeping their saved For/Against positions. Under the existing Claims and debates flag, the menu now presents the user’s identity and personal-space destination, an accessible availability switch, and Sign out; with the flag off, the legacy menu remains unchanged and no availability request is made.

The switch updates immediately, reconciles with the server’s authoritative activity response, and rolls back with the existing toast treatment on failure. Loading and mutation states disable only the switch, so navigation and sign out remain usable.

The server PR must deploy first; this treatment remains disabled by default behind `questionsTab`.

## Related

Related: geobrowser/geo-chat#15

## Validation

- Focused Vitest suites — 5 files, 39 tests passed
- `bunx tsc --noEmit --pretty false`
- ESLint on all changed frontend files
- Prettier and `git diff --check`

The menu’s layout, keyboard activation, flag-off behavior, pending states, and rollback path are covered by component tests. A live browser smoke test was not completed because a pre-existing Next dev process held the build lock while its localhost port was unreachable.

## New concepts

### Optimistic mutation with authoritative reconciliation

An optimistic mutation updates the local view before the network request finishes, then treats the server response as the final truth. Here it keeps the availability switch responsive without allowing client state to become authoritative.

| Stage | Activity cache behavior |
| --- | --- |
| Mutation starts | Save the previous activity and show the requested value |
| Request succeeds | Replace the cache with the complete server response |
| Request fails | Restore the saved activity and show the error toast |
| Mutation settles | Invalidate debate queries so pools and positions refresh |

This is preferable to waiting for the request because the state is reversible and the prior snapshot is available. Avoid it when an action cannot be safely rolled back or its server outcome cannot be predicted locally.
