### PR TITLE
feat(inject): surface enrich outcome with target pill and review-panel preview

### DIFF
--- a/apps/web/app/api/chat/inject/[jobId]/route.ts
+++ b/apps/web/app/api/chat/inject/[jobId]/route.ts
@@ -7,6 +7,7 @@ import { type Edit, decodeEdit } from '@geoprotocol/grc-20';
 import { cookies } from 'next/headers';
 
 import type {
+  InjectEnrichInfo,
   InjectPollResponse,
   SerializedOp,
   SerializedPropertyValue,
@@ -274,7 +275,29 @@ type InjectPollBody = {
   story?: { edit?: InjectEditEnvelope | null } | null;
   posts?: Array<{ edit?: InjectEditEnvelope | null } | null> | null;
   errors?: unknown;
+  enrich?: {
+    mode?: string;
+    targetGeoId?: string;
+    targetHeadline?: string;
+    newClaims?: number;
+    sourcesMinted?: number;
+  } | null;
 };
+
+// The worker sets `enrich` when the injected URL matched an existing on-chain
+// story and the edit updates it instead of creating a new entity. Only the
+// 'enriched' mode is surfaced to the UI (it carries ops to preview).
+function extractEnrichInfo(body: InjectPollBody): InjectEnrichInfo | null {
+  const e = body.enrich;
+  if (!e || e.mode !== 'enriched') return null;
+  if (typeof e.targetGeoId !== 'string' || !/^[0-9a-f]{32}$/.test(e.targetGeoId)) return null;
+  return {
+    targetGeoId: e.targetGeoId,
+    targetHeadline: typeof e.targetHeadline === 'string' ? e.targetHeadline : '',
+    newClaims: typeof e.newClaims === 'number' ? e.newClaims : 0,
+    sourcesMinted: typeof e.sourcesMinted === 'number' ? e.sourcesMinted : 0,
+  };
+}
 
 function extractEditEnvelope(body: InjectPollBody): InjectEditEnvelope | null {
   if (body.story?.edit) return body.story.edit;
@@ -391,5 +414,5 @@ export async function GET(req: Request, ctx: { params: Promise<{ jobId: string }
     console.warn('[chat/inject/poll] completed with errors', body.errors);
   }
 
-  return jsonOk({ status: 'completed', name: decoded.name ?? envelope.name ?? '', ops });
+  return jsonOk({ status: 'completed', name: decoded.name ?? envelope.name ?? '', ops, enrich: extractEnrichInfo(body) });
 }

--- a/apps/web/core/chat/inject-types.ts
+++ b/apps/web/core/chat/inject-types.ts
@@ -78,7 +78,18 @@ export type SerializedOp =
       space?: string;
     };
 
+// Enrich-track outcome surfaced by the worker when the injected URL matched a
+// story that already exists on Geo — the edit updates that entity instead of
+// creating a new one, so the UI previews the enriched target rather than
+// looking for a newly created primary entity.
+export type InjectEnrichInfo = {
+  targetGeoId: string;
+  targetHeadline: string;
+  newClaims: number;
+  sourcesMinted: number;
+};
+
 export type InjectPollResponse =
   | { status: 'pending' }
-  | { status: 'completed'; name: string; ops: SerializedOp[] }
+  | { status: 'completed'; name: string; ops: SerializedOp[]; enrich?: InjectEnrichInfo | null }
   | { status: 'failed'; error?: string };

--- a/apps/web/core/hooks/use-inject-job.ts
+++ b/apps/web/core/hooks/use-inject-job.ts
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 
-import type { InjectPollResponse, SerializedOp } from '~/core/chat/inject-types';
+import type { InjectEnrichInfo, InjectPollResponse, SerializedOp } from '~/core/chat/inject-types';
 
 const POLL_INTERVAL_MS = 6_000;
 // Real news-story-single runs against the inject worker complete in ~170s
@@ -27,6 +27,7 @@ export type InjectJobState = {
   status: InjectJobStatus;
   name: string | null;
   ops: SerializedOp[] | null;
+  enrich: InjectEnrichInfo | null;
   error: string | null;
 };
 
@@ -34,6 +35,7 @@ const INITIAL_STATE: InjectJobState = {
   status: 'idle',
   name: null,
   ops: null,
+  enrich: null,
   error: null,
 };
 
@@ -60,6 +62,7 @@ export function useInjectJob(opts: { jobId: string | null; enabled: boolean }): 
       status: 'pending',
       name: null,
       ops: null,
+      enrich: null,
       error: null,
     });
 
@@ -118,12 +121,12 @@ export function useInjectJob(opts: { jobId: string | null; enabled: boolean }): 
 
       if (body.status === 'completed') {
         stopPolling();
-        setState({ status: 'completed', name: body.name, ops: body.ops, error: null });
+        setState({ status: 'completed', name: body.name, ops: body.ops, enrich: body.enrich ?? null, error: null });
         return;
       }
       if (body.status === 'failed') {
         stopPolling();
-        setState({ status: 'failed', name: null, ops: null, error: body.error ?? 'Inject job failed.' });
+        setState({ status: 'failed', name: null, ops: null, enrich: null, error: body.error ?? 'Inject job failed.' });
         return;
       }
       // Still pending — no state update; the inline progress UI animates on its

--- a/apps/web/partials/chat/chat-widget.tsx
+++ b/apps/web/partials/chat/chat-widget.tsx
@@ -991,6 +991,31 @@ export function ChatWidget() {
         return;
       }
       const result = applyInjectOpsToStore(injectState.ops, injectJob.spaceId);
+      // Enrich outcome: the edit updates a story that already exists on Geo, so
+      // there is no newly created primary entity to key the preview off — use
+      // the worker-reported target instead for the pill and the navigation.
+      if (injectState.enrich) {
+        const enrich = injectState.enrich;
+        const targetPill = `[${(enrich.targetHeadline || 'the existing story').replace(/[\[\]]/g, '')}](geo://entity/${enrich.targetGeoId}?space=${injectJob.spaceId})`;
+        const claimsClause = `${enrich.newClaims} new ${enrich.newClaims === 1 ? 'claim' : 'claims'}`;
+        const sourcesClause =
+          enrich.sourcesMinted > 0
+            ? ` and ${enrich.sourcesMinted} ${enrich.sourcesMinted === 1 ? 'source' : 'sources'}`
+            : '';
+        updateAssistantText(`Enriched ${targetPill} with ${claimsClause}${sourcesClause}. Review and publish when ready.`);
+        setInjectInline(null);
+        void appendInjectFollowUps(injectJob.assistantMessageId, enrich.targetHeadline || injectState.name || '', injectJob.injectType);
+        modeRef.current = 'default';
+        // Navigate to the enriched entity, then open the review panel: unlike
+        // the create path (whole page is staged data), an existing story
+        // renders its claims through server-seeded data blocks, so the staged
+        // additions are only visible as a diff.
+        router.push(NavUtils.toEntity(injectJob.spaceId, enrich.targetGeoId));
+        bumpReviewVersion();
+        setIsReviewOpen(true);
+        setInjectJob({ ...injectJob, applied: true });
+        return;
+      }
       const primaryPill =
         result.primaryEntityId && result.primaryEntityName
           ? `[${result.primaryEntityName.replace(/[\[\]]/g, '')}](geo://entity/${result.primaryEntityId}?space=${injectJob.spaceId})`
@@ -1032,7 +1057,7 @@ export function ChatWidget() {
       sendMessageRef.current({ text: fallbackText });
       setInjectJob(null);
     }
-  }, [injectJob, injectState, setMessages, setInjectInline, trackAssistantMessage, router, appendInjectFollowUps]);
+  }, [injectJob, injectState, setMessages, setInjectInline, trackAssistantMessage, router, appendInjectFollowUps, bumpReviewVersion, setIsReviewOpen]);
 
   React.useEffect(() => {
     const onKey = (event: KeyboardEvent) => {


### PR DESCRIPTION
## Problem

The chat inject flow has two outcomes from the news pipeline: a **create** (new story entity) and an **enrich** (the URL matches a story that already exists on-chain, and the edit updates it with new claims/sources instead of minting a duplicate). The create path has a preview: the widget picks the first named `createEntity` op as the primary entity,
pills it in the summary, and navigates to its page where the staged data renders.

The enrich path had none of that: an enrich edit contains no named `createEntity` for the story, so `primaryEntityId` stays null - no pill, no navigation, and the summary degrades to a generic "Imported N entities". The staged changes were only discoverable by manually entering edit mode and opening Review edits. The worker already reports the enrich outcome in its job status (`enrich: { mode, targetGeoId, targetHeadline, newClaims, sourcesMinted }`), but the poll proxy dropped the field.

## Change

- `core/chat/inject-types.ts` — new `InjectEnrichInfo` type; the `completed` poll response optionally carries `enrich`.
- `app/api/chat/inject/[jobId]/route.ts` — `extractEnrichInfo()` validates and passes the worker's `enrich` field through (only `mode: 'enriched'`; the target id is format-checked like the route's other inputs).
- `core/hooks/use-inject-job.ts` — job state carries `enrich` to the widget.
- `partials/chat/chat-widget.tsx` — when the completed job is an enrichment: summary becomes "Enriched [story pill] with N new claims and M sources", the widget navigates to the enriched story, and opens the review panel (`bumpReviewVersion()` +
  `setIsReviewOpen(true)`, same calls the chat's `openReviewPanel` tool uses).

Why open the review panel instead of relying on the entity page: an existing story renders its claims through server-seeded data blocks, so locally staged additions are not visible in read mode - the review diff is the only surface that can show what the enrichment adds. The create path renders a brand-new entity entirely from the local store, which is why navigation alone works there.

## Scope / safety

- Ops staging is unchanged: `applyInjectOpsToStore` runs before the branch for every inject type, exactly as before.
- Post, tweet, and create injects are unaffected: the worker only sets `mode: 'enriched'` on the news enrich track, so `extractEnrichInfo` returns null for everything else and the pre-existing code path runs unchanged. The poll response
  change is an additive optional field.
- If the worker doesn't send `enrich` (older deploys), behavior is identical to today.
- No other global state is touched — no `activeSpace`, publish, or editor state writes; the review panel self-selects the space containing the staged actions as it does for a manual open.

## Testing

Tested locally against the live inject worker: enrich inject (existing World Affairs story) → "Enriched …" summary with pill - navigation to the story - review panel opens showing the staged claims/sources diff; create inject on a fresh article - unchanged
behavior (new-entity preview + navigation); typecheck clean on all four files.
