### PR TITLE
fix(debates): prevent duplicate LiveKit session eviction

### DIFF
--- a/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
@@ -426,8 +426,32 @@ describe('DebateRoomPageClient', () => {
 
     expect(await screen.findByText('This debate is already open in another tab.')).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Continue here' })).not.toBeInTheDocument();
-    expect(screen.getByText('Continue the debate in the original tab to preserve its recording.')).toBeInTheDocument();
+    expect(
+      screen.getByText('Continue the debate in the original tab or device to preserve its recording.')
+    ).toBeInTheDocument();
     expect(mocks.liveKitJoinMutateAsync).not.toHaveBeenCalled();
+  });
+
+  it('does not hand off a stale preflight after the first turn has started locally', async () => {
+    const now = vi.spyOn(Date, 'now').mockReturnValue(Date.parse('2026-07-02T00:00:09.000Z'));
+    const monotonicNow = vi.spyOn(performance, 'now').mockReturnValue(1_000);
+    mocks.debate = {
+      ...readyDebate({ localReady: true, remoteReady: true }),
+      status: 'preflight',
+      preflight_ends_at: '2026-07-02T00:00:10.000Z',
+      started_at: null,
+    };
+
+    render(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
+    await waitFor(() => expect(mocks.roomConnect).toHaveBeenCalledOnce());
+    await waitFor(() => expect(mocks.getServerTime).toHaveBeenCalledTimes(3));
+
+    // Cross the boundary without advancing React's 500ms countdown timer. The ownership callback
+    // must compare against the clock directly instead of trusting the last rendered status.
+    now.mockReturnValue(Date.parse('2026-07-02T00:00:11.000Z'));
+    monotonicNow.mockReturnValue(3_000);
+    await expect(Promise.resolve(mocks.ownershipTakeoverHandler?.())).resolves.toBe(false);
+    expect(mocks.roomDisconnect).not.toHaveBeenCalled();
   });
 
   it('retries publishing when the media engine is slow to connect', async () => {
@@ -529,6 +553,28 @@ describe('DebateRoomPageClient', () => {
     expect(screen.getByRole('button', { name: 'Continue here' })).toBeInTheDocument();
     expect(screen.queryByText('Lost connection to the debate room.')).not.toBeInTheDocument();
     expect(mocks.ownershipRelease).toHaveBeenCalled();
+  });
+
+  it('does not resume an in-flight join after a duplicate-identity disconnect', async () => {
+    const pendingJoin = deferred<void>();
+    mocks.markJoinedMutateAsync.mockReturnValue(pendingJoin.promise);
+    mocks.debate = {
+      ...readyDebate({ localReady: true, remoteReady: true }),
+      status: 'connecting',
+      connecting_started_at: '2099-07-02T00:00:00.000Z',
+      connecting_deadline_at: '2099-07-02T00:00:10.000Z',
+    };
+
+    render(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
+    await waitFor(() => expect(mocks.markJoinedMutateAsync).toHaveBeenCalledOnce());
+
+    act(() => emitRoomEvent('disconnected', 2));
+    expect(await screen.findByText('This debate is active in another tab or device.')).toBeInTheDocument();
+
+    pendingJoin.resolve();
+    await waitFor(() => expect(mocks.roomDisconnect).toHaveBeenCalled());
+    expect(mocks.publishTrack).not.toHaveBeenCalled();
+    expect(screen.getByText('This debate is active in another tab or device.')).toBeInTheDocument();
   });
 
   it('connects to LiveKit after the Strict Mode effect rehearsal', async () => {

--- a/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
@@ -31,6 +31,11 @@ const mocks = vi.hoisted(() => ({
   refetchDebate: vi.fn(),
   clearTimedOutDebateActivity: vi.fn(),
   roomOn: vi.fn(),
+  ownershipAcquire: vi.fn(),
+  ownershipRequestTakeover: vi.fn(),
+  ownershipRelease: vi.fn(),
+  ownershipClose: vi.fn(),
+  ownershipTakeoverHandler: null as null | (() => boolean | Promise<boolean>),
   debate: null as Debate | null,
   rematch: null as DebateRematchSession | null,
   featureFlags: {
@@ -81,6 +86,20 @@ vi.mock('~/core/debates/recording-upload-queue', () => ({
   requestPersistentRecordingStorage: mocks.requestPersistentStorage,
 }));
 
+vi.mock('~/core/debates/debate-room-ownership', () => ({
+  createDebateRoomOwnershipCoordinator: (options: { onTakeoverRequested: () => boolean | Promise<boolean> }) => {
+    mocks.ownershipTakeoverHandler = options.onTakeoverRequested;
+    return {
+      instanceId: 'connection-instance-1',
+      acquire: mocks.ownershipAcquire,
+      requestTakeover: mocks.ownershipRequestTakeover,
+      release: mocks.ownershipRelease,
+      close: mocks.ownershipClose,
+      ownsConnection: () => true,
+    };
+  },
+}));
+
 vi.mock('livekit-client', () => ({
   createLocalTracks: mocks.createLocalTracks,
   Room: class {
@@ -102,6 +121,7 @@ vi.mock('livekit-client', () => ({
   },
   DisconnectReason: {
     CLIENT_INITIATED: 1,
+    DUPLICATE_IDENTITY: 2,
   },
 }));
 
@@ -133,6 +153,11 @@ beforeEach(() => {
   mocks.refetchDebate.mockReset();
   mocks.clearTimedOutDebateActivity.mockReset();
   mocks.roomOn.mockReset();
+  mocks.ownershipAcquire.mockReset().mockResolvedValue(true);
+  mocks.ownershipRequestTakeover.mockReset().mockResolvedValue(true);
+  mocks.ownershipRelease.mockReset();
+  mocks.ownershipClose.mockReset();
+  mocks.ownershipTakeoverHandler = null;
   mocks.debate = completedDebate();
   mocks.rematch = null;
   mocks.featureFlags = {
@@ -334,6 +359,77 @@ describe('DebateRoomPageClient', () => {
     expect(mocks.publishTrack.mock.invocationCallOrder.every(callOrder => callOrder > joinedCallOrder)).toBe(true);
   });
 
+  it('does not mint a token when another tab owns the participant connection', async () => {
+    mocks.ownershipAcquire.mockResolvedValue(false);
+    mocks.debate = {
+      ...readyDebate({ localReady: true, remoteReady: true }),
+      status: 'connecting',
+      connecting_started_at: '2099-07-02T00:00:00.000Z',
+      connecting_deadline_at: '2099-07-02T00:00:10.000Z',
+    };
+
+    render(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
+
+    expect(await screen.findByText('This debate is already open in another tab.')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Continue here' })).toBeInTheDocument();
+    expect(mocks.liveKitJoinMutateAsync).not.toHaveBeenCalled();
+    expect(mocks.roomConnect).not.toHaveBeenCalled();
+  });
+
+  it('takes over a connection-phase debate before minting a new token', async () => {
+    mocks.ownershipAcquire.mockResolvedValue(false);
+    mocks.debate = {
+      ...readyDebate({ localReady: true, remoteReady: true }),
+      status: 'connecting',
+      connecting_started_at: '2099-07-02T00:00:00.000Z',
+      connecting_deadline_at: '2099-07-02T00:00:10.000Z',
+    };
+
+    render(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
+    fireEvent.click(await screen.findByRole('button', { name: 'Continue here' }));
+
+    await waitFor(() => expect(mocks.ownershipRequestTakeover).toHaveBeenCalledOnce());
+    await waitFor(() => expect(mocks.liveKitJoinMutateAsync).toHaveBeenCalledOnce());
+    expect(mocks.ownershipRequestTakeover.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.liveKitJoinMutateAsync.mock.invocationCallOrder[0]
+    );
+  });
+
+  it('disconnects an in-flight LiveKit room before handing ownership to another tab', async () => {
+    const pendingConnection = deferred<void>();
+    mocks.roomConnect.mockReturnValue(pendingConnection.promise);
+    mocks.debate = {
+      ...readyDebate({ localReady: true, remoteReady: true }),
+      status: 'connecting',
+      connecting_started_at: '2099-07-02T00:00:00.000Z',
+      connecting_deadline_at: '2099-07-02T00:00:10.000Z',
+    };
+
+    render(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
+    await waitFor(() => expect(mocks.roomConnect).toHaveBeenCalledOnce());
+
+    await expect(Promise.resolve(mocks.ownershipTakeoverHandler?.())).resolves.toBe(true);
+    expect(mocks.roomDisconnect).toHaveBeenCalledOnce();
+
+    pendingConnection.resolve();
+  });
+
+  it('does not allow a secondary tab to take over an active debate recording', async () => {
+    mocks.ownershipAcquire.mockResolvedValue(false);
+    mocks.debate = {
+      ...completedDebate(),
+      status: 'in_progress',
+      completed_at: null,
+    };
+
+    render(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
+
+    expect(await screen.findByText('This debate is already open in another tab.')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Continue here' })).not.toBeInTheDocument();
+    expect(screen.getByText('Continue the debate in the original tab to preserve its recording.')).toBeInTheDocument();
+    expect(mocks.liveKitJoinMutateAsync).not.toHaveBeenCalled();
+  });
+
   it('retries publishing when the media engine is slow to connect', async () => {
     vi.useFakeTimers();
     mocks.debate = {
@@ -414,6 +510,25 @@ describe('DebateRoomPageClient', () => {
 
     act(() => emitRoomEvent('disconnected', 99));
     expect(await screen.findByText('Lost connection to the debate room.')).toBeInTheDocument();
+  });
+
+  it('explains when LiveKit disconnects a duplicate participant identity', async () => {
+    mocks.debate = {
+      ...readyDebate({ localReady: true, remoteReady: true }),
+      status: 'connecting',
+      connecting_started_at: '2099-07-02T00:00:00.000Z',
+      connecting_deadline_at: '2099-07-02T00:00:10.000Z',
+    };
+
+    render(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
+    await waitFor(() => expect(mocks.markJoinedMutateAsync).toHaveBeenCalled());
+
+    act(() => emitRoomEvent('disconnected', 2));
+
+    expect(await screen.findByText('This debate is active in another tab or device.')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Continue here' })).toBeInTheDocument();
+    expect(screen.queryByText('Lost connection to the debate room.')).not.toBeInTheDocument();
+    expect(mocks.ownershipRelease).toHaveBeenCalled();
   });
 
   it('connects to LiveKit after the Strict Mode effect rehearsal', async () => {

--- a/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.tsx
@@ -183,6 +183,7 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
   const connectionFailureRedirectTimerRef = React.useRef<number | null>(null);
   const remoteParticipantRefetchTimerRef = React.useRef<number | null>(null);
   const serverNowRef = React.useRef(serverClock.now);
+  const preflightEndsAtMsRef = React.useRef<number | null>(null);
   const finalizedDebateRef = React.useRef<string | null>(null);
   const recordingPersistenceStartedRef = React.useRef<string | null>(null);
   const recordingPersistencePromiseRef = React.useRef<Promise<boolean> | null>(null);
@@ -201,9 +202,9 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
   const storagePersistenceRequestedRef = React.useRef(false);
   const recordingCancellationHandledRef = React.useRef<string | null>(null);
   const debate = debateQuery.data ?? null;
+  preflightEndsAtMsRef.current = timestampMs(debate?.preflight_ends_at ?? null);
   const debateStatusRef = React.useRef<Debate['status'] | null>(debate?.status ?? null);
   const roomStateRef = React.useRef(roomState);
-  debateStatusRef.current = debate?.status ?? null;
   roomStateRef.current = roomState;
   const rematchQuery = useDebateRematch(
     debate?.rematch_session_id ?? '',
@@ -211,6 +212,7 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
   );
   const leaveRematch = useLeaveDebateRematch(debate?.rematch_session_id ?? '');
   const countdown = useDebateCountdown(debate, serverClock.now);
+  debateStatusRef.current = countdown.effectiveStatus;
   const currentUserId = getCurrentGeoChatUserId();
   const localSlot = joinResponse?.participant_slot ?? null;
   const recordingCancelledBy = debate?.recording_cancelled_by ?? null;
@@ -226,8 +228,8 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
     audioMuted
   );
   const canTakeOverConnection =
-    connectionConflict && (debate?.status === 'connecting' || debate?.status === 'preflight');
-  const connectionConflictDuringActiveDebate = connectionConflict && debate?.status === 'in_progress';
+    connectionConflict && (countdown.effectiveStatus === 'connecting' || countdown.effectiveStatus === 'preflight');
+  const connectionConflictWithoutTakeover = connectionConflict && !canTakeOverConnection;
 
   React.useEffect(() => {
     serverNowRef.current = serverClock.now;
@@ -249,7 +251,12 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
       userId: currentUserId,
       onTakeoverRequested: () => {
         const status = debateStatusRef.current;
-        if (status !== 'connecting' && status !== 'preflight') return false;
+        const preflightStillPending =
+          status === 'preflight' &&
+          recordingStartedAtRef.current === null &&
+          (preflightEndsAtMsRef.current === null || serverNowRef.current() < preflightEndsAtMsRef.current);
+        const canReleaseOwnership = status === 'connecting' || preflightStillPending;
+        if (!canReleaseOwnership) return false;
 
         connectionGenerationRef.current += 1;
         disconnectConnectingRoom(connectingRoomRef);
@@ -728,6 +735,7 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
       room.on(livekit.RoomEvent.Disconnected, payload => {
         if (!isCurrent() || roomRef.current !== room) return;
         if (payload === livekit.DisconnectReason.CLIENT_INITIATED) return;
+        connectionGenerationRef.current += 1;
         // The room is already gone, so null the ref before cleanup: disconnectRoom would otherwise
         // call room.disconnect() a second time and could re-enter this handler.
         roomRef.current = null;
@@ -1295,9 +1303,9 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
               {roomError && roomState === 'idle' && (
                 <div className="mt-4 rounded-lg border border-red-01 bg-white px-5 py-4">
                   <Text color="red-01">{roomError}</Text>
-                  {connectionConflictDuringActiveDebate && (
+                  {connectionConflictWithoutTakeover && (
                     <Text as="p" color="grey-04" className="mt-2">
-                      Continue the debate in the original tab to preserve its recording.
+                      Continue the debate in the original tab or device to preserve its recording.
                     </Text>
                   )}
                 </div>

--- a/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.tsx
@@ -14,6 +14,10 @@ import {
   getServerTime,
 } from '~/core/debates/api';
 import {
+  type DebateRoomOwnershipCoordinator,
+  createDebateRoomOwnershipCoordinator,
+} from '~/core/debates/debate-room-ownership';
+import {
   useAbortDebate,
   useClearTimedOutDebateActivity,
   useConsentToDebateRematch,
@@ -139,6 +143,7 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
     'idle'
   );
   const [roomError, setRoomError] = React.useState<string | null>(null);
+  const [connectionConflict, setConnectionConflict] = React.useState(false);
   const [remoteVideoReady, setRemoteVideoReady] = React.useState(false);
   const [previewState, setPreviewState] = React.useState<'idle' | 'starting' | 'ready'>('idle');
   const [previewError, setPreviewError] = React.useState<string | null>(null);
@@ -161,6 +166,9 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
   const remoteMediaRef = React.useRef<HTMLDivElement>(null);
   const remoteAudioEnabledRef = React.useRef(remoteAudioEnabled);
   const roomRef = React.useRef<RoomLike | null>(null);
+  const connectingRoomRef = React.useRef<RoomLike | null>(null);
+  const ownershipRef = React.useRef<DebateRoomOwnershipCoordinator | null>(null);
+  const connectionInstanceIdRef = React.useRef('uncoordinated');
   const localTracksRef = React.useRef<LocalTrackLike[]>([]);
   const localMediaStreamRef = React.useRef<MediaStream | null>(null);
   const localPreviewPromiseRef = React.useRef<Promise<LocalTrackLike[]> | null>(null);
@@ -193,6 +201,10 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
   const storagePersistenceRequestedRef = React.useRef(false);
   const recordingCancellationHandledRef = React.useRef<string | null>(null);
   const debate = debateQuery.data ?? null;
+  const debateStatusRef = React.useRef<Debate['status'] | null>(debate?.status ?? null);
+  const roomStateRef = React.useRef(roomState);
+  debateStatusRef.current = debate?.status ?? null;
+  roomStateRef.current = roomState;
   const rematchQuery = useDebateRematch(
     debate?.rematch_session_id ?? '',
     Boolean(debate?.rematch_session_id) && debate?.status !== 'cancelled'
@@ -213,6 +225,9 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
     localSlot,
     audioMuted
   );
+  const canTakeOverConnection =
+    connectionConflict && (debate?.status === 'connecting' || debate?.status === 'preflight');
+  const connectionConflictDuringActiveDebate = connectionConflict && debate?.status === 'in_progress';
 
   React.useEffect(() => {
     serverNowRef.current = serverClock.now;
@@ -226,6 +241,40 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
     remoteAudioEnabledRef.current = remoteAudioEnabled;
     setRemoteMediaAudioEnabled(remoteMediaRef, remoteAudioEnabled);
   }, [remoteAudioEnabled]);
+
+  React.useEffect(() => {
+    if (!currentUserId) return;
+    const coordinator = createDebateRoomOwnershipCoordinator({
+      debateId,
+      userId: currentUserId,
+      onTakeoverRequested: () => {
+        const status = debateStatusRef.current;
+        if (status !== 'connecting' && status !== 'preflight') return false;
+
+        connectionGenerationRef.current += 1;
+        disconnectConnectingRoom(connectingRoomRef);
+        disconnectRoom(roomRef, localTracksRef, localVideoRef, remoteMediaRef);
+        localMediaStreamRef.current = null;
+        setRemoteVideoReady(false);
+        setConnectionConflict(true);
+        setRoomError('This debate moved to another tab.');
+        setRoomState('idle');
+        logDebateConnectionDiagnostic('ownership-released', {
+          debateId,
+          instanceId: connectionInstanceIdRef.current,
+          roomState: roomStateRef.current,
+        });
+        return true;
+      },
+    });
+    connectionInstanceIdRef.current = coordinator.instanceId;
+    ownershipRef.current = coordinator;
+
+    return () => {
+      if (ownershipRef.current === coordinator) ownershipRef.current = null;
+      coordinator.close();
+    };
+  }, [currentUserId, debateId]);
 
   const clearRecordingTimers = React.useCallback(() => {
     if (recordingStartTimerRef.current !== null) {
@@ -567,12 +616,30 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
     [ensureLocalPreview]
   );
 
-  const connect = React.useCallback(async () => {
+  const connect = React.useCallback(async (options: { takeover?: boolean } = {}) => {
     const generation = connectionGenerationRef.current + 1;
     connectionGenerationRef.current = generation;
     const isCurrent = () => mountedRef.current && connectionGenerationRef.current === generation;
     let connectingRoom: RoomLike | null = null;
     let newlyCreatedTracks: LocalTrackLike[] = [];
+    const ownership = ownershipRef.current;
+    const ownsConnection = options.takeover
+      ? await ownership?.requestTakeover()
+      : await ownership?.acquire();
+    if (!isCurrent()) return;
+    if (ownsConnection === false) {
+      setConnectionConflict(true);
+      setRoomError('This debate is already open in another tab.');
+      setRoomState('idle');
+      logDebateConnectionDiagnostic('ownership-blocked', {
+        debateId,
+        instanceId: connectionInstanceIdRef.current,
+        roomState: roomStateRef.current,
+      });
+      return;
+    }
+
+    setConnectionConflict(false);
     setRoomError(null);
     setRoomState('connecting');
     setServerClockSettled(false);
@@ -604,6 +671,7 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
       // out a tile mid-turn.
       const room = new livekit.Room({ adaptiveStream: false, dynacast: false }) as unknown as RoomLike;
       connectingRoom = room;
+      connectingRoomRef.current = room;
       room.on(livekit.RoomEvent.TrackSubscribed, payload => {
         // Auto-subscribe can deliver a track during room.connect(), before roomRef is assigned, so
         // reject only a different room here rather than a not-yet-set one.
@@ -664,17 +732,30 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
         // call room.disconnect() a second time and could re-enter this handler.
         roomRef.current = null;
         disconnectRoom(roomRef, localTracksRef, localVideoRef, remoteMediaRef);
+        ownershipRef.current?.release();
         localMediaStreamRef.current = null;
         setRemoteVideoReady(false);
-        setRoomError('Lost connection to the debate room.');
+        const duplicateIdentity = payload === livekit.DisconnectReason.DUPLICATE_IDENTITY;
+        setConnectionConflict(duplicateIdentity);
+        setRoomError(
+          duplicateIdentity ? 'This debate is active in another tab or device.' : 'Lost connection to the debate room.'
+        );
         setRoomState('idle');
+        logDebateConnectionDiagnostic('livekit-disconnected', {
+          debateId,
+          instanceId: connectionInstanceIdRef.current,
+          roomState: roomStateRef.current,
+          disconnectReason: payload,
+        });
       });
 
       await room.connect(token.url, token.token);
       if (!isCurrent()) {
         room.disconnect();
+        if (connectingRoomRef.current === room) connectingRoomRef.current = null;
         return;
       }
+      connectingRoomRef.current = null;
       roomRef.current = room;
       const hasPreviewTracks = localTracksRef.current.length > 0;
       const tracks = hasPreviewTracks
@@ -740,8 +821,10 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
         if (roomRef.current === room) roomRef.current = null;
         return;
       }
+      setConnectionConflict(false);
       setRoomState('connected');
     } catch (error) {
+      if (connectingRoom && connectingRoomRef.current === connectingRoom) connectingRoomRef.current = null;
       if (connectingRoom && roomRef.current !== connectingRoom) {
         connectingRoom.disconnect();
         stopTracks(newlyCreatedTracks);
@@ -749,6 +832,8 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
       disconnectRoom(roomRef, localTracksRef, localVideoRef, remoteMediaRef);
       localMediaStreamRef.current = null;
       if (isCurrent()) {
+        ownershipRef.current?.release();
+        setConnectionConflict(false);
         setRoomError(error instanceof Error ? error.message : 'Could not join the debate room.');
         setRoomState(debate?.status === 'connecting' ? 'connecting' : 'idle');
       }
@@ -757,12 +842,21 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
     audioMuted,
     countdown.activeSlot,
     countdown.effectiveStatus,
+    debateId,
     debate?.status,
     liveKitJoin,
     markJoined,
     refetchDebate,
     videoEnabled,
   ]);
+
+  const retryConnection = React.useCallback(() => {
+    void connect();
+  }, [connect]);
+
+  const takeOverConnection = React.useCallback(() => {
+    void connect({ takeover: true });
+  }, [connect]);
 
   const toggleAudioMuted = React.useCallback(() => {
     setAudioMuted(current => !current);
@@ -913,7 +1007,9 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
     clearTimedOutDebateActivity(debateId);
     clearRecordingTimers();
     void discardLocalRecorder();
+    disconnectConnectingRoom(connectingRoomRef);
     disconnectRoom(roomRef, localTracksRef, localVideoRef, remoteMediaRef);
+    ownershipRef.current?.release();
     localMediaStreamRef.current = null;
     setRemoteVideoReady(false);
     setRoomError('Connection failed. Finding another match.');
@@ -980,6 +1076,7 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
       }
       clearRecordingTimers();
       void discardLocalRecorder();
+      disconnectConnectingRoom(connectingRoomRef);
       disconnectRoom(roomRef, localTracksRef, localVideoRef, remoteMediaRef);
       localMediaStreamRef.current = null;
     };
@@ -1177,11 +1274,18 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
                   </div>
                 </div>
                 <div className="flex shrink-0 flex-wrap gap-2">
-                  {roomError && roomState === 'idle' && !['complete', 'cancelled'].includes(debate.status) && (
-                    <Button type="button" onClick={connect} disabled={liveKitJoin.isPending || markJoined.isPending}>
-                      Retry connection
-                    </Button>
-                  )}
+                  {roomError &&
+                    roomState === 'idle' &&
+                    !['complete', 'cancelled'].includes(debate.status) &&
+                    (!connectionConflict || canTakeOverConnection) && (
+                      <Button
+                        type="button"
+                        onClick={connectionConflict ? takeOverConnection : retryConnection}
+                        disabled={liveKitJoin.isPending || markJoined.isPending}
+                      >
+                        {connectionConflict ? 'Continue here' : 'Retry connection'}
+                      </Button>
+                    )}
                   <Button type="button" variant="secondary" onClick={() => router.push(`/space/${spaceId}/debates`)}>
                     Back to debates
                   </Button>
@@ -1191,6 +1295,11 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
               {roomError && roomState === 'idle' && (
                 <div className="mt-4 rounded-lg border border-red-01 bg-white px-5 py-4">
                   <Text color="red-01">{roomError}</Text>
+                  {connectionConflictDuringActiveDebate && (
+                    <Text as="p" color="grey-04" className="mt-2">
+                      Continue the debate in the original tab to preserve its recording.
+                    </Text>
+                  )}
                 </div>
               )}
             </section>
@@ -1217,7 +1326,7 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
                 rematchConsentRequested={rematchConsentRequested}
                 rematchBusy={consentToRematch.isPending}
                 onRetryFinalization={retryLiveDebateFinalization}
-                onRetryConnection={connect}
+                onRetryConnection={retryConnection}
                 onLeave={leave}
                 leaveDisabled={abortDebate.isPending || roomState === 'saving'}
               />
@@ -2269,6 +2378,18 @@ function stopTracks(tracks: LocalTrackLike[]) {
   }
 }
 
+function logDebateConnectionDiagnostic(
+  event: 'ownership-blocked' | 'ownership-released' | 'livekit-disconnected',
+  details: {
+    debateId: string;
+    instanceId: string;
+    roomState: string;
+    disconnectReason?: unknown;
+  }
+) {
+  console.info('[DebateRoomConnection]', { event, ...details });
+}
+
 // Mobile browsers behind cellular/symmetric NAT can take several seconds to establish the publisher
 // PeerConnection, and the first publishTrack often rejects with "engine not connected within
 // timeout" before ICE settles. Retry a couple times so a slow-but-viable connection isn't surfaced
@@ -2305,6 +2426,11 @@ function disconnectRoom(
   if (remoteMediaRef.current) {
     remoteMediaRef.current.replaceChildren();
   }
+}
+
+function disconnectConnectingRoom(connectingRoomRef: React.MutableRefObject<RoomLike | null>) {
+  connectingRoomRef.current?.disconnect();
+  connectingRoomRef.current = null;
 }
 
 function useDebateCountdown(debate: Debate | null, serverNow: () => number): DebateCountdown {

--- a/apps/web/core/debates/debate-room-ownership.test.ts
+++ b/apps/web/core/debates/debate-room-ownership.test.ts
@@ -1,0 +1,205 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createDebateRoomOwnershipCoordinator } from './debate-room-ownership';
+
+type QueuedLock = {
+  callback: (lock: Lock | null) => Promise<void> | void;
+  resolve: () => void;
+  reject: (error: unknown) => void;
+  signal?: AbortSignal;
+};
+
+class FakeLockManager {
+  private held = false;
+  private queue: QueuedLock[] = [];
+
+  request(
+    _name: string,
+    options: LockOptions,
+    callback: (lock: Lock | null) => Promise<void> | void
+  ): Promise<void> {
+    if (options.ifAvailable && this.held) {
+      return Promise.resolve(callback(null));
+    }
+
+    return new Promise<void>((resolve, reject) => {
+      const queued = { callback, resolve, reject, signal: options.signal };
+      if (options.signal?.aborted) {
+        reject(options.signal.reason);
+        return;
+      }
+      options.signal?.addEventListener(
+        'abort',
+        () => {
+          this.queue = this.queue.filter(candidate => candidate !== queued);
+          reject(options.signal?.reason);
+        },
+        { once: true }
+      );
+      if (this.held) {
+        this.queue.push(queued);
+      } else {
+        void this.run(queued);
+      }
+    });
+  }
+
+  private async run(queued: QueuedLock) {
+    this.held = true;
+    try {
+      await queued.callback({ name: 'debate-room', mode: 'exclusive' });
+      queued.resolve();
+    } catch (error) {
+      queued.reject(error);
+    } finally {
+      this.held = false;
+      const next = this.queue.shift();
+      if (next) void this.run(next);
+    }
+  }
+}
+
+class FakeBroadcastChannel {
+  static channels = new Map<string, Set<FakeBroadcastChannel>>();
+
+  onmessage: ((event: MessageEvent) => void) | null = null;
+
+  constructor(private readonly name: string) {
+    const channels = FakeBroadcastChannel.channels.get(name) ?? new Set();
+    channels.add(this);
+    FakeBroadcastChannel.channels.set(name, channels);
+  }
+
+  postMessage(data: unknown) {
+    for (const channel of FakeBroadcastChannel.channels.get(this.name) ?? []) {
+      if (channel !== this) queueMicrotask(() => channel.onmessage?.(new MessageEvent('message', { data })));
+    }
+  }
+
+  close() {
+    FakeBroadcastChannel.channels.get(this.name)?.delete(this);
+  }
+}
+
+beforeEach(() => {
+  FakeBroadcastChannel.channels.clear();
+  Object.defineProperty(navigator, 'locks', {
+    configurable: true,
+    value: new FakeLockManager(),
+  });
+  vi.stubGlobal('BroadcastChannel', FakeBroadcastChannel);
+  let instanceNumber = 0;
+  vi.stubGlobal('crypto', { randomUUID: vi.fn(() => `instance-${++instanceNumber}`) });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  Object.defineProperty(navigator, 'locks', { configurable: true, value: undefined });
+});
+
+describe('debate room ownership', () => {
+  it('allows only one tab to own a participant connection', async () => {
+    const first = createDebateRoomOwnershipCoordinator({
+      debateId: 'debate-1',
+      userId: 'user-a',
+      onTakeoverRequested: () => true,
+    });
+    const second = createDebateRoomOwnershipCoordinator({
+      debateId: 'debate-1',
+      userId: 'user-a',
+      onTakeoverRequested: () => true,
+    });
+
+    await expect(first.acquire()).resolves.toBe(true);
+    await expect(second.acquire()).resolves.toBe(false);
+
+    first.close();
+    second.close();
+  });
+
+  it('hands ownership to another tab only after the current owner releases it', async () => {
+    const onTakeoverRequested = vi.fn().mockResolvedValue(true);
+    const first = createDebateRoomOwnershipCoordinator({
+      debateId: 'debate-1',
+      userId: 'user-a',
+      onTakeoverRequested,
+    });
+    const second = createDebateRoomOwnershipCoordinator({
+      debateId: 'debate-1',
+      userId: 'user-a',
+      onTakeoverRequested: () => true,
+    });
+    await first.acquire();
+    await second.acquire();
+
+    await expect(second.requestTakeover()).resolves.toBe(true);
+    expect(onTakeoverRequested).toHaveBeenCalledOnce();
+    expect(first.ownsConnection()).toBe(false);
+    expect(second.ownsConnection()).toBe(true);
+
+    first.close();
+    second.close();
+  });
+
+  it('keeps the original owner when an active debate refuses takeover', async () => {
+    const first = createDebateRoomOwnershipCoordinator({
+      debateId: 'debate-1',
+      userId: 'user-a',
+      onTakeoverRequested: () => false,
+    });
+    const second = createDebateRoomOwnershipCoordinator({
+      debateId: 'debate-1',
+      userId: 'user-a',
+      onTakeoverRequested: () => true,
+    });
+    await first.acquire();
+    await second.acquire();
+
+    await expect(second.requestTakeover()).resolves.toBe(false);
+    expect(first.ownsConnection()).toBe(true);
+    expect(second.ownsConnection()).toBe(false);
+
+    first.close();
+    second.close();
+  });
+
+  it('reclaims a free local lock after a duplicate connection displaced the tab', async () => {
+    const first = createDebateRoomOwnershipCoordinator({
+      debateId: 'debate-1',
+      userId: 'user-a',
+      onTakeoverRequested: () => true,
+    });
+    const second = createDebateRoomOwnershipCoordinator({
+      debateId: 'debate-1',
+      userId: 'user-a',
+      onTakeoverRequested: () => true,
+    });
+    await first.acquire();
+    await first.release();
+
+    await expect(second.requestTakeover()).resolves.toBe(true);
+
+    first.close();
+    second.close();
+  });
+
+  it('falls back to LiveKit identity handling when BroadcastChannel is unavailable', async () => {
+    vi.stubGlobal('BroadcastChannel', undefined);
+    const first = createDebateRoomOwnershipCoordinator({
+      debateId: 'debate-1',
+      userId: 'user-a',
+      onTakeoverRequested: () => true,
+    });
+    const second = createDebateRoomOwnershipCoordinator({
+      debateId: 'debate-1',
+      userId: 'user-a',
+      onTakeoverRequested: () => true,
+    });
+
+    await expect(first.acquire()).resolves.toBe(true);
+    await expect(second.acquire()).resolves.toBe(true);
+
+    first.close();
+    second.close();
+  });
+});

--- a/apps/web/core/debates/debate-room-ownership.ts
+++ b/apps/web/core/debates/debate-room-ownership.ts
@@ -1,0 +1,207 @@
+type TakeoverRequest = {
+  type: 'takeover-request';
+  requestId: string;
+  requesterId: string;
+};
+
+type TakeoverResponse = {
+  type: 'takeover-response';
+  requestId: string;
+  requesterId: string;
+  released: boolean;
+};
+
+type OwnershipMessage = TakeoverRequest | TakeoverResponse;
+
+type CreateDebateRoomOwnershipCoordinatorOptions = {
+  debateId: string;
+  userId: string;
+  onTakeoverRequested: () => boolean | Promise<boolean>;
+};
+
+export type DebateRoomOwnershipCoordinator = {
+  readonly instanceId: string;
+  acquire: () => Promise<boolean>;
+  requestTakeover: () => Promise<boolean>;
+  release: () => Promise<void>;
+  close: () => void;
+  ownsConnection: () => boolean;
+};
+
+const takeoverResponseTimeoutMs = 1_500;
+
+export function createDebateRoomOwnershipCoordinator({
+  debateId,
+  userId,
+  onTakeoverRequested,
+}: CreateDebateRoomOwnershipCoordinatorOptions): DebateRoomOwnershipCoordinator {
+  const instanceId = createInstanceId();
+  const coordinationName = `geo:debate-room:${debateId}:${userId}`;
+  const canCoordinate =
+    typeof navigator !== 'undefined' &&
+    Boolean(navigator.locks?.request) &&
+    typeof BroadcastChannel !== 'undefined';
+  let channel: BroadcastChannel | null = null;
+  if (canCoordinate) {
+    try {
+      channel = new BroadcastChannel(coordinationName);
+    } catch {
+      channel = null;
+    }
+  }
+  const supportsCoordination = channel !== null;
+  let ownsConnection = false;
+  let closed = false;
+  let releaseLock: (() => void) | null = null;
+  let lockRequest: Promise<void> | null = null;
+  let releaseRequest: Promise<void> | null = null;
+  let acquisition: Promise<boolean> | null = null;
+  const pendingTakeovers = new Map<string, (released: boolean) => void>();
+
+  const postTakeoverResponse = (message: TakeoverRequest, released: boolean) => {
+    if (!channel || closed) return;
+    try {
+      channel.postMessage({
+        type: 'takeover-response',
+        requestId: message.requestId,
+        requesterId: message.requesterId,
+        released,
+      } satisfies TakeoverResponse);
+    } catch {
+      // The channel may close while an async takeover decision is finishing. The requester will
+      // time out and retain its current non-owner state.
+    }
+  };
+
+  const acquireLock = (): Promise<boolean> => {
+    if (releaseRequest) return releaseRequest.then(acquireLock);
+    if (ownsConnection) return Promise.resolve(true);
+    if (!supportsCoordination) {
+      ownsConnection = true;
+      return Promise.resolve(true);
+    }
+    if (closed) return Promise.resolve(false);
+    if (acquisition) return acquisition;
+
+    acquisition = new Promise<boolean>(resolve => {
+      const request = navigator.locks.request(
+        coordinationName,
+        { ifAvailable: true, mode: 'exclusive' },
+        async lock => {
+          resolve(Boolean(lock));
+          if (!lock || closed) return;
+          ownsConnection = true;
+          await new Promise<void>(release => {
+            releaseLock = release;
+          });
+          releaseLock = null;
+          ownsConnection = false;
+        }
+      );
+      lockRequest = request.then(
+        () => undefined,
+        () => resolve(false)
+      );
+    })
+      .catch(() => false)
+      .finally(() => {
+        acquisition = null;
+      });
+
+    return acquisition;
+  };
+
+  const release = async () => {
+    if (releaseRequest) {
+      await releaseRequest;
+      return;
+    }
+    if (!supportsCoordination) {
+      ownsConnection = false;
+      return;
+    }
+    if (!releaseLock) return;
+    const activeRequest = lockRequest;
+    const releaseCurrentLock = releaseLock;
+    ownsConnection = false;
+    releaseCurrentLock();
+    const request = activeRequest ?? Promise.resolve();
+    const completion = request.finally(() => {
+      if (releaseRequest === completion) releaseRequest = null;
+    });
+    releaseRequest = completion;
+    await releaseRequest;
+  };
+
+  if (channel) {
+    channel.onmessage = event => {
+      const message = event.data as OwnershipMessage;
+      if (!message || typeof message !== 'object') return;
+
+      if (message.type === 'takeover-response' && message.requesterId === instanceId) {
+        pendingTakeovers.get(message.requestId)?.(message.released);
+        return;
+      }
+
+      if (message.type !== 'takeover-request' || message.requesterId === instanceId || !ownsConnection) return;
+      void Promise.resolve(onTakeoverRequested())
+        .then(async released => {
+          if (released) await release();
+          postTakeoverResponse(message, released);
+        })
+        .catch(() => {
+          postTakeoverResponse(message, false);
+        });
+    };
+  }
+
+  return {
+    instanceId,
+    acquire: acquireLock,
+    requestTakeover: async () => {
+      if (ownsConnection) return true;
+      if (!supportsCoordination) return acquireLock();
+      if (!channel || closed) return false;
+      if (await acquireLock()) return true;
+
+      const requestId = createInstanceId();
+      const released = await new Promise<boolean>(resolve => {
+        const timeout = window.setTimeout(() => {
+          pendingTakeovers.delete(requestId);
+          resolve(false);
+        }, takeoverResponseTimeoutMs);
+        pendingTakeovers.set(requestId, result => {
+          window.clearTimeout(timeout);
+          pendingTakeovers.delete(requestId);
+          resolve(result);
+        });
+        try {
+          channel.postMessage({
+            type: 'takeover-request',
+            requestId,
+            requesterId: instanceId,
+          } satisfies TakeoverRequest);
+        } catch {
+          window.clearTimeout(timeout);
+          pendingTakeovers.delete(requestId);
+          resolve(false);
+        }
+      });
+      if (!released) return false;
+      return acquireLock();
+    },
+    release,
+    close: () => {
+      closed = true;
+      void release();
+      for (const resolve of pendingTakeovers.values()) resolve(false);
+      pendingTakeovers.clear();
+      channel?.close();
+    },
+    ownsConnection: () => ownsConnection,
+  };
+}
+
+function createInstanceId() {
+  return globalThis.crypto?.randomUUID?.() ?? `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}


### PR DESCRIPTION
## Summary

Opening the same debate in another tab no longer silently evicts the existing LiveKit participant and surfaces a misleading network error. The browser now claims one connection per debate and user before minting a token, offers an explicit handoff while participants are still connecting, and protects the original tab once recording is active.

LiveKit disconnect reason `DUPLICATE_IDENTITY` now gets a specific tab/device explanation while other unexpected disconnects retain the existing generic recovery path. The stable user UUID remains the LiveKit identity, and connection diagnostics contain only the debate ID, room state, disconnect reason, and a local connection-instance ID.

Browsers without both Web Locks and BroadcastChannel continue using LiveKit's single-identity behavior with the improved duplicate-session message.

## Validation

- `bun run --cwd apps/web test`: 144 test files and 1,480 tests passed
- Focused debate-room suite: 61 tests passed
- `bunx tsc --noEmit`: passed
- ESLint on the four changed files: passed
- Production two-participant plus duplicate-tab validation was not run because it requires authenticated participant sessions
