### PR TITLE
fix: hide submitters from ranking pill view

### DIFF
--- a/apps/web/partials/blocks/table/ranking-pill-view.tsx
+++ b/apps/web/partials/blocks/table/ranking-pill-view.tsx
@@ -12,7 +12,6 @@ import { PrefetchLink as Link } from '~/design-system/prefetch-link';
 import { Skeleton } from '~/design-system/skeleton';
 
 import { RankingBlockGlobalPagination } from './ranking-block-global-pagination';
-import { RankingPeriodMetadata } from './ranking-period-metadata';
 import type { RankingBlockState } from './use-ranking-block-state';
 
 function RankingPillItem({
@@ -67,11 +66,6 @@ export function RankingPillView({ state }: Props) {
     globalRankingEntryByEntityId,
     totalGlobalRankingEntityCount,
     entriesResolving,
-    hasRankedByOthers,
-    submissions,
-    aggregatedSubmitterSpaceIds,
-    aggregatedRankingCount,
-    periodState,
     showEmbeddedGlobalPagination,
     embeddedGlobalPageNumber,
     hasEmbeddedGlobalPreviousPage,
@@ -112,18 +106,8 @@ export function RankingPillView({ state }: Props) {
         <p className="text-metadata text-grey-04">No published items yet</p>
       ) : null}
 
-      <div className="mt-1 flex w-full items-end justify-between gap-3">
-        <RankingPeriodMetadata
-          className="mt-0"
-          periodState={periodState}
-          periodLabel={null}
-          hasRankedByOthers={hasRankedByOthers}
-          submissions={submissions}
-          aggregatedSubmitterSpaceIds={aggregatedSubmitterSpaceIds}
-          aggregatedRankingCount={aggregatedRankingCount}
-        />
-
-        {showEmbeddedGlobalPagination ? (
+      {showEmbeddedGlobalPagination ? (
+        <div className="mt-1 flex w-full items-end justify-end">
           <div className="ml-auto self-end [&>div:first-child]:hidden [&>div:last-child]:!mt-0 [&>div:last-child]:!mb-0 [&>div:last-child]:!justify-end">
             <RankingBlockGlobalPagination
               pageNumber={embeddedGlobalPageNumber}
@@ -132,8 +116,8 @@ export function RankingPillView({ state }: Props) {
               onSetPage={setEmbeddedGlobalPage}
             />
           </div>
-        ) : null}
-      </div>
+        </div>
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
## What changed

- Removed the submitter avatar group and additional-user count from ranking blocks using Pill view.
- Kept embedded pagination aligned at the bottom right when pagination is available.
- Left submitter metadata unchanged in the other ranking views.

## Why

Pill view should focus on the ranked entity pills and should not show the ranking-submission avatars/count in its bottom-left footer.

## Impact

Ranking Pill view no longer leaves submission metadata or an otherwise-empty footer beneath the pills. Other views continue to show their existing metadata.

## Validation

- 27 ranking test suites passed (142 tests)
- `bunx tsc --noEmit --pretty false`
- `bunx eslint partials/blocks/table/ranking-pill-view.tsx`
- `git diff --check`
