### PR TITLE
fix: hide rolled-off ranking status

### DIFF
--- a/apps/web/core/blocks/ranking/ranking-rolling.test.ts
+++ b/apps/web/core/blocks/ranking/ranking-rolling.test.ts
@@ -75,10 +75,10 @@ describe('formatRollingSubmissionLabel', () => {
     ).toBeNull();
   });
 
-  it('prompts a fresh submission once rolled off', () => {
+  it('hides the label once the submission has rolled off', () => {
     expect(
       formatRollingSubmissionLabel({ hasSubmission: true, isLive: false, submittedAtMs: now, frequencyHours: 24, now })
-    ).toBe('Your ranking has rolled off — submit a fresh ranking');
+    ).toBeNull();
   });
 
   it('shows an hours countdown while live', () => {
@@ -105,7 +105,7 @@ describe('formatRollingSubmissionLabel', () => {
     ).toBe('Vote again in 7 days');
   });
 
-  it('rolls off when the window has elapsed even if flagged live', () => {
+  it('shows a negative countdown when the backend still considers an elapsed submission live', () => {
     expect(
       formatRollingSubmissionLabel({
         hasSubmission: true,
@@ -114,6 +114,6 @@ describe('formatRollingSubmissionLabel', () => {
         frequencyHours: 24,
         now,
       })
-    ).toBe('Your ranking has rolled off — submit a fresh ranking');
+    ).toBe('Vote again in -6 hrs');
   });
 });

--- a/apps/web/core/blocks/ranking/ranking-rolling.ts
+++ b/apps/web/core/blocks/ranking/ranking-rolling.ts
@@ -55,13 +55,11 @@ export function formatRollingSubmissionLabel({
   now: number;
 }): string | null {
   if (!hasSubmission) return null;
-  if (!isLive) return 'Your ranking has rolled off — submit a fresh ranking';
+  if (!isLive) return null;
 
   if (!frequencyHours || submittedAtMs === 0) return 'Your ranking is live';
 
   const expiresInMs = getRollingExpiryMs(submittedAtMs, frequencyHours) - now;
-  if (expiresInMs <= 0) return 'Your ranking has rolled off — submit a fresh ranking';
-
   const hours = Math.ceil(expiresInMs / MS_PER_HOUR);
   if (hours >= 48) return `Vote again in ${Math.ceil(hours / 24)} days`;
   if (hours === 1) return 'Vote again in 1 hr';


### PR DESCRIPTION
## What changed

- Removed the “Your ranking has rolled off — submit a fresh ranking” status entirely.
- Hide rolling status text when the backend no longer includes the viewer's ranking.
- Continue showing “Vote again in …” when the backend still includes an overdue ranking, allowing the countdown to become negative.
- Preserve the existing action-state behavior: an included personal ranking shows View, while a rolled-off ranking shows Vote.

## Why

The status formatter previously declared rollover from the client-side clock even when the backend still included the ranking. That created a contradictory state where the block said the ranking had rolled off but still showed View. Backend inclusion is the authoritative signal for whether the ranking remains visible.

## Impact

- Rolled off: no status text, Vote button.
- Still included and within the window: “Vote again in <time>”, View button.
- Still included after the expected expiry: negative “Vote again in <time>”, View button.

## Validation

- 27 ranking test suites passed (142 tests)
- `bunx tsc --noEmit --pretty false`
- `bunx eslint core/blocks/ranking/ranking-rolling.ts core/blocks/ranking/ranking-rolling.test.ts`
- `git diff --check`
