### PR TITLE
fix: match ranking actions to Figma

### DIFF
--- a/apps/web/partials/blocks/table/ranking-header-actions.test.tsx
+++ b/apps/web/partials/blocks/table/ranking-header-actions.test.tsx
@@ -22,6 +22,8 @@ describe('RankingHeaderActions', () => {
     expect(markup).toContain('View');
     expect(markup).toContain('h-7');
     expect(markup).toContain('!border-grey-02');
+    expect(markup).toContain('focus-visible:!border-text');
+    expect(markup).toContain('focus-visible:!shadow-inner-text');
     expect(markup).not.toContain('<svg');
   });
 
@@ -31,6 +33,8 @@ describe('RankingHeaderActions', () => {
     expect(markup).toContain('Rank');
     expect(markup).not.toContain('Vote');
     expect(markup).toContain('!bg-[#151515]');
+    expect(markup).toContain('focus-visible:!border-text');
+    expect(markup).toContain('focus-visible:!shadow-inner-text');
     expect(markup).not.toContain('<svg');
   });
 });

--- a/apps/web/partials/blocks/table/ranking-header-actions.test.tsx
+++ b/apps/web/partials/blocks/table/ranking-header-actions.test.tsx
@@ -1,0 +1,36 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { RankingHeaderActions } from './ranking-header-actions';
+import type { RankingBlockState } from './use-ranking-block-state';
+
+function state(hasMySubmission: boolean): RankingBlockState {
+  return {
+    periodState: 'in-progress',
+    periodLabel: null,
+    hasMySubmission,
+    isSaving: false,
+    openRankingCompose: vi.fn(),
+  } as unknown as RankingBlockState;
+}
+
+describe('RankingHeaderActions', () => {
+  it('renders the icon-free Figma View button for an existing ranking', () => {
+    const markup = renderToStaticMarkup(<RankingHeaderActions state={state(true)} />);
+
+    expect(markup).toContain('View');
+    expect(markup).toContain('h-7');
+    expect(markup).toContain('!border-grey-02');
+    expect(markup).not.toContain('<svg');
+  });
+
+  it('renders the icon-free Figma Rank button when the viewer can rank', () => {
+    const markup = renderToStaticMarkup(<RankingHeaderActions state={state(false)} />);
+
+    expect(markup).toContain('Rank');
+    expect(markup).not.toContain('Vote');
+    expect(markup).toContain('!bg-[#151515]');
+    expect(markup).not.toContain('<svg');
+  });
+});

--- a/apps/web/partials/blocks/table/ranking-header-actions.tsx
+++ b/apps/web/partials/blocks/table/ranking-header-actions.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { Button } from '~/design-system/button';
-import { RankingChart } from '~/design-system/icons/ranking-chart';
 
 import { getRankingPeriodIcon } from './ranking-period-metadata';
 import type { RankingBlockState } from './use-ranking-block-state';
@@ -10,8 +9,11 @@ type Props = {
   state: RankingBlockState;
 };
 
+const ACTION_BUTTON_CLASS =
+  'h-7 shrink-0 !gap-0 !rounded-full !px-2.5 !py-0 !text-[16px] !leading-[13px] font-normal tracking-[-0.35px] whitespace-nowrap !shadow-none disabled:!border-transparent disabled:!bg-divider disabled:!text-grey-03';
+
 /**
- * Period label + Vote/View action. Rendered by the block header so it shares a row
+ * Period label + Rank/View action. Rendered by the block header so it shares a row
  * with the block title rather than sitting above the entries.
  */
 export function RankingHeaderActions({ state }: Props) {
@@ -28,8 +30,7 @@ export function RankingHeaderActions({ state }: Props) {
       {hasMySubmission ? (
         <Button
           variant="secondary"
-          className="h-8 shrink-0 !rounded-full !border-text !bg-white !px-3 text-[16px] whitespace-nowrap !text-text"
-          icon={<RankingChart />}
+          className={`${ACTION_BUTTON_CLASS} !border-grey-02 !bg-white !text-text hover:!border-grey-02 hover:!bg-white`}
           disabled={isSaving}
           onClick={() => void openRankingCompose('view')}
         >
@@ -38,12 +39,11 @@ export function RankingHeaderActions({ state }: Props) {
       ) : (
         <Button
           variant="primary"
-          className="h-8 shrink-0 !rounded-full border-grey-02 bg-text !px-3 text-[16px] whitespace-nowrap text-white hover:bg-text/90 focus-visible:border-text focus-visible:shadow-inner-text"
-          icon={<RankingChart color="white" />}
+          className={`${ACTION_BUTTON_CLASS} !border-transparent !bg-[#151515] !text-white hover:!bg-[#151515] focus-visible:!border-text`}
           disabled={isSaving}
           onClick={() => void openRankingCompose('edit')}
         >
-          Vote
+          Rank
         </Button>
       )}
     </>

--- a/apps/web/partials/blocks/table/ranking-header-actions.tsx
+++ b/apps/web/partials/blocks/table/ranking-header-actions.tsx
@@ -10,7 +10,7 @@ type Props = {
 };
 
 const ACTION_BUTTON_CLASS =
-  'h-7 shrink-0 !gap-0 !rounded-full !px-2.5 !py-0 !text-[16px] !leading-[13px] font-normal tracking-[-0.35px] whitespace-nowrap !shadow-none disabled:!border-transparent disabled:!bg-divider disabled:!text-grey-03';
+  'h-7 shrink-0 !gap-0 !rounded-full !px-2.5 !py-0 !text-[16px] !leading-[13px] font-normal tracking-[-0.35px] whitespace-nowrap !shadow-none focus-visible:!border-text focus-visible:!shadow-inner-text disabled:!border-transparent disabled:!bg-divider disabled:!text-grey-03';
 
 /**
  * Period label + Rank/View action. Rendered by the block header so it shares a row
@@ -39,7 +39,7 @@ export function RankingHeaderActions({ state }: Props) {
       ) : (
         <Button
           variant="primary"
-          className={`${ACTION_BUTTON_CLASS} !border-transparent !bg-[#151515] !text-white hover:!bg-[#151515] focus-visible:!border-text`}
+          className={`${ACTION_BUTTON_CLASS} !border-transparent !bg-[#151515] !text-white hover:!bg-[#151515]`}
           disabled={isSaving}
           onClick={() => void openRankingCompose('edit')}
         >


### PR DESCRIPTION
## What changed

- Renamed the ranking block's Vote action to Rank.
- Removed the ranking-chart icon from both Rank and View.
- Matched the linked Figma design's 28px pill size, 10px horizontal padding, regular 16px typography, and fully rounded shape.
- Updated View to the lighter white/`grey-02` outlined treatment.
- Updated Rank to the Figma's `#151515` fill.
- Added render-level tests for both action states.

## Why

The existing ranking header buttons were larger, used stronger outlines, included chart icons, and used the Vote label. These did not match the current Geo Web ranking-block design.

## Impact

Ranking blocks now present compact, icon-free Rank and View actions consistent with the linked Figma node while preserving the existing click behavior and disabled states.

## Design

Figma: https://www.figma.com/design/iWKsYButqqKWd1bqeBrUUj/Geo---Web?node-id=73227-166363&m=dev

## Validation

- 28 test files passed (144 tests)
- `bunx tsc --noEmit --pretty false`
- `bunx eslint partials/blocks/table/ranking-header-actions.tsx partials/blocks/table/ranking-header-actions.test.tsx`
- `git diff --check`
