### PR TITLE
fix: hide data block add action in browse mode

### DIFF
--- a/apps/web/partials/blocks/table/data-block-create-entity-visibility.test.ts
+++ b/apps/web/partials/blocks/table/data-block-create-entity-visibility.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+
+import { shouldShowCreateEntityAction } from './data-block-create-entity-visibility';
+
+const editableQuery = {
+  canEdit: true,
+  sourceType: 'GEO' as const,
+  singleSpaceTarget: null,
+  singleSpaceAccessResolved: true,
+  canCreateInSingleSpace: true,
+};
+
+describe('shouldShowCreateEntityAction', () => {
+  it('hides the add action in browse mode even when the user can edit', () => {
+    expect(shouldShowCreateEntityAction({ ...editableQuery, isEditing: false })).toBe(false);
+  });
+
+  it('shows the add action in edit mode when the user can edit', () => {
+    expect(shouldShowCreateEntityAction({ ...editableQuery, isEditing: true })).toBe(true);
+  });
+
+  it('keeps the add action hidden without edit permission or for relation sources', () => {
+    expect(shouldShowCreateEntityAction({ ...editableQuery, isEditing: true, canEdit: false })).toBe(false);
+    expect(shouldShowCreateEntityAction({ ...editableQuery, isEditing: true, sourceType: 'RELATIONS' })).toBe(false);
+  });
+
+  it('waits for confirmed create access when the query targets one space', () => {
+    const singleSpaceQuery = { ...editableQuery, isEditing: true, singleSpaceTarget: 'space-id' };
+
+    expect(shouldShowCreateEntityAction({ ...singleSpaceQuery, singleSpaceAccessResolved: false })).toBe(false);
+    expect(shouldShowCreateEntityAction({ ...singleSpaceQuery, canCreateInSingleSpace: false })).toBe(false);
+    expect(shouldShowCreateEntityAction(singleSpaceQuery)).toBe(true);
+  });
+});

--- a/apps/web/partials/blocks/table/data-block-create-entity-visibility.test.ts
+++ b/apps/web/partials/blocks/table/data-block-create-entity-visibility.test.ts
@@ -31,4 +31,15 @@ describe('shouldShowCreateEntityAction', () => {
     expect(shouldShowCreateEntityAction({ ...singleSpaceQuery, canCreateInSingleSpace: false })).toBe(false);
     expect(shouldShowCreateEntityAction(singleSpaceQuery)).toBe(true);
   });
+
+  it('only treats null, not an empty target id, as the absence of a single-space target', () => {
+    expect(
+      shouldShowCreateEntityAction({
+        ...editableQuery,
+        isEditing: true,
+        singleSpaceTarget: '',
+        singleSpaceAccessResolved: false,
+      })
+    ).toBe(false);
+  });
 });

--- a/apps/web/partials/blocks/table/data-block-create-entity-visibility.ts
+++ b/apps/web/partials/blocks/table/data-block-create-entity-visibility.ts
@@ -21,5 +21,5 @@ export function shouldShowCreateEntityAction({
     return false;
   }
 
-  return !singleSpaceTarget || (singleSpaceAccessResolved && canCreateInSingleSpace);
+  return singleSpaceTarget === null || (singleSpaceAccessResolved && canCreateInSingleSpace);
 }

--- a/apps/web/partials/blocks/table/data-block-create-entity-visibility.ts
+++ b/apps/web/partials/blocks/table/data-block-create-entity-visibility.ts
@@ -1,0 +1,25 @@
+import type { Source } from '~/core/blocks/data/source';
+
+type Args = {
+  isEditing: boolean;
+  canEdit: boolean;
+  sourceType: Source['type'];
+  singleSpaceTarget: string | null;
+  singleSpaceAccessResolved: boolean;
+  canCreateInSingleSpace: boolean;
+};
+
+export function shouldShowCreateEntityAction({
+  isEditing,
+  canEdit,
+  sourceType,
+  singleSpaceTarget,
+  singleSpaceAccessResolved,
+  canCreateInSingleSpace,
+}: Args): boolean {
+  if (!isEditing || !canEdit || sourceType === 'RELATIONS') {
+    return false;
+  }
+
+  return !singleSpaceTarget || (singleSpaceAccessResolved && canCreateInSingleSpace);
+}

--- a/apps/web/partials/blocks/table/table-block.tsx
+++ b/apps/web/partials/blocks/table/table-block.tsx
@@ -54,6 +54,7 @@ import { NextButton, PageNumber, PreviousButton } from '~/design-system/table/ta
 import { Text } from '~/design-system/text';
 
 import { onChangeEntryFn, writeValue } from './change-entry';
+import { shouldShowCreateEntityAction } from './data-block-create-entity-visibility';
 import { DataBlockCreateEntitySpaceDropdown } from './data-block-create-entity-space-dropdown';
 import { DataBlockScopeDropdown } from './data-block-scope-dropdown';
 import { DataBlockSortMenu } from './data-block-sort-menu';
@@ -936,8 +937,6 @@ const ConfiguredTableBlock = ({
     );
   }
 
-  const renderPlusButtonAsInline = source.type !== 'RELATIONS' && canEdit;
-
   const isQueryDataBlock = source.type !== 'COLLECTION';
 
   // Query data blocks let the user pick which space the new entity lives in:
@@ -952,8 +951,14 @@ const ConfiguredTableBlock = ({
     Boolean(singleSpaceTarget)
   );
   const canCreateInSingleSpace = singleSpaceTarget ? canCreateInTargetSpace(singleSpaceTarget) : true;
-  const showCreateEntityPlus =
-    renderPlusButtonAsInline && (!singleSpaceTarget || (singleSpaceAccessResolved && canCreateInSingleSpace));
+  const showCreateEntityPlus = shouldShowCreateEntityAction({
+    isEditing,
+    canEdit,
+    sourceType: source.type,
+    singleSpaceTarget,
+    singleSpaceAccessResolved,
+    canCreateInSingleSpace,
+  });
 
   const onAddPlaceholderClick = React.useCallback(() => {
     onAddPlaceholder(singleSpaceTarget ?? null);


### PR DESCRIPTION
## Summary

- hide the data-block create-entity action while the page is in browse mode
- keep the add action available in edit mode when the user has edit and target-space create access
- apply the same visibility rule to both the plain plus button and the space-picker variant
- add focused regression coverage for mode, source type, and permission behavior

## Root cause

The header action checked whether the user could edit the space, but did not check whether the page was currently in edit mode. As a result, editors saw the plus control while browsing and clicking it implicitly entered the editing flow.

## Validation

- `bun run test partials/blocks/table/data-block-create-entity-visibility.test.ts`
- `bunx tsc --noEmit --pretty false`
- `bunx eslint partials/blocks/table/table-block.tsx partials/blocks/table/data-block-create-entity-visibility.ts partials/blocks/table/data-block-create-entity-visibility.test.ts` (no errors; three existing unused-variable warnings in `table-block.tsx`)
- `git diff --check`
