### PR TITLE
fix(debates): improve microphone audio with Krisp

### DIFF
--- a/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
@@ -20,10 +20,15 @@ const mocks = vi.hoisted(() => ({
   requestPersistentStorage: vi.fn(),
   estimateStorage: vi.fn(),
   mediaRecorderStart: vi.fn(),
+  mediaRecorderConstruct: vi.fn(),
   readyMutateAsync: vi.fn(),
   liveKitJoinMutateAsync: vi.fn(),
   markJoinedMutateAsync: vi.fn(),
   createLocalTracks: vi.fn(),
+  krispNoiseFilter: vi.fn(),
+  krispSupported: vi.fn(),
+  krispSetEnabled: vi.fn(),
+  krispIsEnabled: vi.fn(),
   roomConnect: vi.fn(),
   roomDisconnect: vi.fn(),
   publishTrack: vi.fn(),
@@ -125,6 +130,11 @@ vi.mock('livekit-client', () => ({
   },
 }));
 
+vi.mock('@livekit/krisp-noise-filter', () => ({
+  isKrispNoiseFilterSupported: mocks.krispSupported,
+  KrispNoiseFilter: mocks.krispNoiseFilter,
+}));
+
 function emitRoomEvent(event: string, payload?: unknown) {
   for (const [registeredEvent, callback] of mocks.roomOn.mock.calls) {
     if (registeredEvent === event) callback(payload);
@@ -142,10 +152,15 @@ beforeEach(() => {
   mocks.requestPersistentStorage.mockReset();
   mocks.estimateStorage.mockReset();
   mocks.mediaRecorderStart.mockReset();
+  mocks.mediaRecorderConstruct.mockReset();
   mocks.readyMutateAsync.mockReset();
   mocks.liveKitJoinMutateAsync.mockReset();
   mocks.markJoinedMutateAsync.mockReset();
   mocks.createLocalTracks.mockReset();
+  mocks.krispNoiseFilter.mockReset();
+  mocks.krispSupported.mockReset().mockReturnValue(true);
+  mocks.krispSetEnabled.mockReset().mockResolvedValue(undefined);
+  mocks.krispIsEnabled.mockReset().mockReturnValue(true);
   mocks.roomConnect.mockReset();
   mocks.roomDisconnect.mockReset();
   mocks.publishTrack.mockReset();
@@ -174,8 +189,13 @@ beforeEach(() => {
     position: true,
     position_label: 'Yes',
   });
+  mocks.krispNoiseFilter.mockImplementation(() => ({
+    processedTrack: { kind: 'audio', enabled: true, id: 'krisp-processed-audio' },
+    setEnabled: mocks.krispSetEnabled,
+    isEnabled: mocks.krispIsEnabled,
+  }));
   mocks.createLocalTracks.mockResolvedValue([
-    { mediaStreamTrack: { kind: 'audio', enabled: true }, stop: vi.fn(), detach: vi.fn() },
+    createLocalAudioTrack(),
     { mediaStreamTrack: { kind: 'video', enabled: true }, stop: vi.fn(), detach: vi.fn() },
   ]);
   mocks.roomConnect.mockResolvedValue(undefined);
@@ -746,6 +766,202 @@ describe('DebateRoomPageClient', () => {
 
     await waitFor(() => expect(remoteVideo.muted).toBe(true));
     expectDebateVideoTileInColor('remote');
+  });
+
+  it('enables Krisp by default and records the processed microphone track', async () => {
+    const audioTrack = createLocalAudioTrack();
+    mocks.createLocalTracks.mockResolvedValue([
+      audioTrack,
+      { mediaStreamTrack: { kind: 'video', enabled: true }, stop: vi.fn(), detach: vi.fn() },
+    ]);
+    installRecordingMocks();
+
+    await renderLiveDebate();
+
+    await waitFor(() => expect(audioTrack.setProcessor).toHaveBeenCalledOnce());
+    expect(audioTrack.setProcessor.mock.invocationCallOrder[0]).toBeGreaterThan(
+      mocks.publishTrack.mock.invocationCallOrder[0]
+    );
+    expect(mocks.krispSetEnabled).toHaveBeenCalledWith(true);
+    await waitFor(() => expect(mocks.mediaRecorderConstruct).toHaveBeenCalledOnce());
+    const recordedStream = mocks.mediaRecorderConstruct.mock.calls[0]?.[0] as MediaStream;
+    expect(recordedStream.getAudioTracks()[0]).toMatchObject({ id: 'krisp-processed-audio' });
+    expect(screen.queryByRole('switch', { name: 'Krisp noise filter' })).not.toBeInTheDocument();
+  });
+
+  it('toggles Krisp from the debate debug controls without restarting the recorder', async () => {
+    mocks.featureFlags.debateDebugging = true;
+    installRecordingMocks();
+
+    await renderLiveDebate();
+
+    const noiseFilterSwitch = await screen.findByRole('switch', { name: 'Krisp noise filter' });
+    await waitFor(() => expect(noiseFilterSwitch).toHaveAttribute('aria-checked', 'true'));
+    expect(mocks.mediaRecorderStart).toHaveBeenCalledOnce();
+
+    fireEvent.click(noiseFilterSwitch);
+
+    await waitFor(() => expect(mocks.krispSetEnabled).toHaveBeenLastCalledWith(false));
+    expect(noiseFilterSwitch).toHaveAttribute('aria-checked', 'false');
+    expect(mocks.mediaRecorderStart).toHaveBeenCalledOnce();
+
+    fireEvent.click(noiseFilterSwitch);
+
+    await waitFor(() => expect(mocks.krispSetEnabled).toHaveBeenLastCalledWith(true));
+    expect(noiseFilterSwitch).toHaveAttribute('aria-checked', 'true');
+    expect(mocks.mediaRecorderStart).toHaveBeenCalledOnce();
+  });
+
+  it('disables the Krisp switch while a toggle is pending', async () => {
+    const disabling = deferred<void>();
+    mocks.featureFlags.debateDebugging = true;
+
+    await renderLiveDebate();
+
+    const noiseFilterSwitch = await screen.findByRole('switch', { name: 'Krisp noise filter' });
+    await waitFor(() => expect(noiseFilterSwitch).toBeEnabled());
+    mocks.krispSetEnabled.mockReturnValueOnce(disabling.promise);
+    fireEvent.click(noiseFilterSwitch);
+
+    expect(noiseFilterSwitch).toBeDisabled();
+    expect(screen.getByText('Saving…')).toBeInTheDocument();
+
+    disabling.resolve();
+
+    await waitFor(() => expect(noiseFilterSwitch).toBeEnabled());
+    expect(noiseFilterSwitch).toHaveAttribute('aria-checked', 'false');
+  });
+
+  it('marks Krisp unavailable when a live toggle fails', async () => {
+    mocks.featureFlags.debateDebugging = true;
+    const warning = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    await renderLiveDebate();
+
+    const noiseFilterSwitch = await screen.findByRole('switch', { name: 'Krisp noise filter' });
+    await waitFor(() => expect(noiseFilterSwitch).toBeEnabled());
+    mocks.krispSetEnabled.mockRejectedValueOnce(new Error('Processor stopped'));
+    fireEvent.click(noiseFilterSwitch);
+
+    expect(await screen.findByText('Failed')).toBeInTheDocument();
+    expect(noiseFilterSwitch).toBeDisabled();
+    expect(warning).toHaveBeenCalledWith('[DebateNoiseFilter] Krisp could not change state.', expect.any(Error));
+  });
+
+  it('disables the Krisp switch while the recording is being saved', async () => {
+    const persistence = deferred<void>();
+    mocks.featureFlags.debateDebugging = true;
+    mocks.enqueueRecording.mockReturnValue(persistence.promise);
+    installRecordingMocks();
+    const view = await renderLiveDebate();
+    const noiseFilterSwitch = await screen.findByRole('switch', { name: 'Krisp noise filter' });
+    await waitFor(() => expect(noiseFilterSwitch).toBeEnabled());
+
+    mocks.debate = completedDebate();
+    view.rerender(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
+
+    await waitFor(() => expect(mocks.enqueueRecording).toHaveBeenCalledOnce());
+    expect(noiseFilterSwitch).toBeDisabled();
+
+    persistence.resolve();
+  });
+
+  it('keeps the debate connected with the browser microphone track when Krisp is unsupported', async () => {
+    const audioTrack = createLocalAudioTrack();
+    mocks.krispSupported.mockReturnValue(false);
+    mocks.createLocalTracks.mockResolvedValue([
+      audioTrack,
+      { mediaStreamTrack: { kind: 'video', enabled: true }, stop: vi.fn(), detach: vi.fn() },
+    ]);
+    mocks.featureFlags.debateDebugging = true;
+    installRecordingMocks();
+
+    await renderLiveDebate();
+
+    expect(await screen.findByText('Unavailable')).toBeInTheDocument();
+    expect(screen.getByRole('switch', { name: 'Krisp noise filter' })).toBeDisabled();
+    expect(audioTrack.setProcessor).not.toHaveBeenCalled();
+    await waitFor(() => expect(mocks.mediaRecorderConstruct).toHaveBeenCalledOnce());
+    const recordedStream = mocks.mediaRecorderConstruct.mock.calls[0]?.[0] as MediaStream;
+    expect(recordedStream.getAudioTracks()[0]).toMatchObject({ id: 'browser-audio' });
+    expect(screen.queryByText(/Could not join the debate room/)).not.toBeInTheDocument();
+  });
+
+  it('shows Krisp as loading and disables the debug switch while initialization is pending', async () => {
+    const initialization = deferred<void>();
+    mocks.featureFlags.debateDebugging = true;
+    mocks.krispSetEnabled.mockReturnValue(initialization.promise);
+
+    await renderLiveDebate();
+
+    const noiseFilterSwitch = await screen.findByRole('switch', { name: 'Krisp noise filter' });
+    expect(noiseFilterSwitch).toBeDisabled();
+    expect(screen.getByText('Loading…')).toBeInTheDocument();
+
+    initialization.resolve();
+
+    await waitFor(() => expect(noiseFilterSwitch).toBeEnabled());
+    expect(noiseFilterSwitch).toHaveAttribute('aria-checked', 'true');
+  });
+
+  it('falls back to the browser microphone track when Krisp initialization fails', async () => {
+    const audioTrack = createLocalAudioTrack();
+    audioTrack.setProcessor.mockRejectedValue(new Error('Model download failed'));
+    mocks.createLocalTracks.mockResolvedValue([
+      audioTrack,
+      { mediaStreamTrack: { kind: 'video', enabled: true }, stop: vi.fn(), detach: vi.fn() },
+    ]);
+    mocks.featureFlags.debateDebugging = true;
+    installRecordingMocks();
+    const warning = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    await renderLiveDebate();
+
+    expect(await screen.findByText('Failed')).toBeInTheDocument();
+    expect(screen.getByRole('switch', { name: 'Krisp noise filter' })).toBeDisabled();
+    await waitFor(() => expect(mocks.mediaRecorderConstruct).toHaveBeenCalledOnce());
+    const recordedStream = mocks.mediaRecorderConstruct.mock.calls[0]?.[0] as MediaStream;
+    expect(recordedStream.getAudioTracks()[0]).toMatchObject({ id: 'browser-audio' });
+    expect(screen.queryByText(/Could not join the debate room/)).not.toBeInTheDocument();
+    expect(warning).toHaveBeenCalledWith(
+      '[DebateNoiseFilter] Krisp initialization failed; using the browser microphone track.',
+      expect.any(Error)
+    );
+  });
+
+  it('reapplies the local Krisp preference after a manual connection retry', async () => {
+    const disabling = deferred<void>();
+    const firstAudioTrack = createLocalAudioTrack();
+    const retriedAudioTrack = createLocalAudioTrack();
+    mocks.krispSetEnabled.mockImplementation((enabled: boolean) =>
+      enabled ? Promise.resolve(undefined) : disabling.promise
+    );
+    mocks.createLocalTracks
+      .mockResolvedValueOnce([
+        firstAudioTrack,
+        { mediaStreamTrack: { kind: 'video', enabled: true }, stop: vi.fn(), detach: vi.fn() },
+      ])
+      .mockResolvedValueOnce([
+        retriedAudioTrack,
+        { mediaStreamTrack: { kind: 'video', enabled: true }, stop: vi.fn(), detach: vi.fn() },
+      ]);
+    mocks.featureFlags.debateDebugging = true;
+
+    await renderLiveDebate();
+
+    const noiseFilterSwitch = await screen.findByRole('switch', { name: 'Krisp noise filter' });
+    await waitFor(() => expect(noiseFilterSwitch).toHaveAttribute('aria-checked', 'true'));
+    fireEvent.click(noiseFilterSwitch);
+    await waitFor(() => expect(mocks.krispSetEnabled).toHaveBeenLastCalledWith(false));
+
+    act(() => emitRoomEvent('disconnected', 99));
+    fireEvent.click(await screen.findByRole('button', { name: 'Retry connection' }));
+
+    await waitFor(() => expect(retriedAudioTrack.setProcessor).toHaveBeenCalledOnce());
+    disabling.resolve();
+    await waitFor(() => expect(mocks.krispSetEnabled).toHaveBeenLastCalledWith(false));
+    expect(mocks.krispSetEnabled.mock.calls.filter(([enabled]) => enabled === false)).toHaveLength(2);
+    expect(await screen.findByRole('switch', { name: 'Krisp noise filter' })).toHaveAttribute('aria-checked', 'false');
   });
 
   it('shows the circular phase timer during a timed debate turn', async () => {
@@ -1449,6 +1665,11 @@ function installRecordingMocks() {
       mimeType = 'video/webm';
       ondataavailable: ((event: BlobEvent) => void) | null = null;
 
+      constructor(stream: MediaStream) {
+        super();
+        mocks.mediaRecorderConstruct(stream);
+      }
+
       start() {
         this.state = 'recording';
         mocks.mediaRecorderStart();
@@ -1466,6 +1687,25 @@ function installRecordingMocks() {
     }
   );
   vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true }));
+}
+
+function createLocalAudioTrack() {
+  const browserTrack = { kind: 'audio', enabled: true, id: 'browser-audio' };
+  let processor: { processedTrack?: { kind: string; enabled: boolean; id: string } } | null = null;
+
+  return {
+    get mediaStreamTrack() {
+      return processor?.processedTrack ?? browserTrack;
+    },
+    setProcessor: vi.fn(async (nextProcessor: typeof processor) => {
+      processor = nextProcessor;
+    }),
+    stopProcessor: vi.fn(async () => {
+      processor = null;
+    }),
+    stop: vi.fn(),
+    detach: vi.fn(),
+  };
 }
 
 function deferred<T>() {

--- a/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
@@ -29,6 +29,7 @@ const mocks = vi.hoisted(() => ({
   krispSupported: vi.fn(),
   krispSetEnabled: vi.fn(),
   krispIsEnabled: vi.fn(),
+  krispDestroy: vi.fn(),
   roomConnect: vi.fn(),
   roomDisconnect: vi.fn(),
   publishTrack: vi.fn(),
@@ -161,6 +162,7 @@ beforeEach(() => {
   mocks.krispSupported.mockReset().mockReturnValue(true);
   mocks.krispSetEnabled.mockReset().mockResolvedValue(undefined);
   mocks.krispIsEnabled.mockReset().mockReturnValue(true);
+  mocks.krispDestroy.mockReset().mockResolvedValue(undefined);
   mocks.roomConnect.mockReset();
   mocks.roomDisconnect.mockReset();
   mocks.publishTrack.mockReset();
@@ -193,6 +195,7 @@ beforeEach(() => {
     processedTrack: { kind: 'audio', enabled: true, id: 'krisp-processed-audio' },
     setEnabled: mocks.krispSetEnabled,
     isEnabled: mocks.krispIsEnabled,
+    destroy: mocks.krispDestroy,
   }));
   mocks.createLocalTracks.mockResolvedValue([
     createLocalAudioTrack(),
@@ -789,6 +792,44 @@ describe('DebateRoomPageClient', () => {
     expect(screen.queryByRole('switch', { name: 'Krisp noise filter' })).not.toBeInTheDocument();
   });
 
+  it('keeps the Krisp source and processed tracks aligned with turn-based microphone state', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(Date.parse('2026-07-02T00:00:20.000Z'));
+    const audioTrack = createLocalAudioTrack();
+    const processedTrack = { kind: 'audio', enabled: true, id: 'krisp-processed-audio' };
+    mocks.krispNoiseFilter.mockReturnValue({
+      processedTrack,
+      setEnabled: mocks.krispSetEnabled,
+      isEnabled: mocks.krispIsEnabled,
+      destroy: mocks.krispDestroy,
+    });
+    mocks.createLocalTracks.mockResolvedValue([
+      audioTrack,
+      { mediaStreamTrack: { kind: 'video', enabled: true }, stop: vi.fn(), detach: vi.fn() },
+    ]);
+
+    const view = await renderLiveDebate({
+      first_participant_slot: 2,
+      current_speaker_slot: 2,
+    });
+
+    await waitFor(() => expect(audioTrack.setProcessor).toHaveBeenCalledOnce());
+    expect(audioTrack.sourceMediaStreamTrack.enabled).toBe(false);
+    expect(processedTrack.enabled).toBe(false);
+
+    mocks.debate = {
+      ...mocks.debate!,
+      started_at: '2026-07-01T23:59:40.000Z',
+      current_turn_index: 1,
+      current_speaker_slot: 1,
+      turn_started_at: '2026-07-02T00:00:10.000Z',
+      turn_ends_at: '2026-07-02T00:00:40.000Z',
+    };
+    view.rerender(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
+
+    await waitFor(() => expect(audioTrack.sourceMediaStreamTrack.enabled).toBe(true));
+    expect(processedTrack.enabled).toBe(true);
+  });
+
   it('toggles Krisp from the debate debug controls without restarting the recorder', async () => {
     mocks.featureFlags.debateDebugging = true;
     installRecordingMocks();
@@ -927,6 +968,8 @@ describe('DebateRoomPageClient', () => {
       '[DebateNoiseFilter] Krisp initialization failed; using the browser microphone track.',
       expect.any(Error)
     );
+    expect(mocks.krispDestroy).toHaveBeenCalledOnce();
+    expect(audioTrack.stopProcessor).not.toHaveBeenCalled();
   });
 
   it('reapplies the local Krisp preference after a manual connection retry', async () => {
@@ -962,6 +1005,68 @@ describe('DebateRoomPageClient', () => {
     await waitFor(() => expect(mocks.krispSetEnabled).toHaveBeenLastCalledWith(false));
     expect(mocks.krispSetEnabled.mock.calls.filter(([enabled]) => enabled === false)).toHaveLength(2);
     expect(await screen.findByRole('switch', { name: 'Krisp noise filter' })).toHaveAttribute('aria-checked', 'false');
+  });
+
+  it('does not let an old toggle clear a newer processor toggle after reconnecting', async () => {
+    const oldDisabling = deferred<void>();
+    const newEnabling = deferred<void>();
+    const firstAudioTrack = createLocalAudioTrack();
+    const retriedAudioTrack = createLocalAudioTrack();
+    const oldSetEnabled = vi.fn((enabled: boolean) =>
+      enabled ? Promise.resolve(undefined) : oldDisabling.promise
+    );
+    const newSetEnabled = vi.fn((enabled: boolean) =>
+      enabled ? newEnabling.promise : Promise.resolve(undefined)
+    );
+    mocks.krispNoiseFilter
+      .mockReturnValueOnce({
+        processedTrack: { kind: 'audio', enabled: true, id: 'old-krisp-audio' },
+        setEnabled: oldSetEnabled,
+        isEnabled: mocks.krispIsEnabled,
+        destroy: mocks.krispDestroy,
+      })
+      .mockReturnValueOnce({
+        processedTrack: { kind: 'audio', enabled: true, id: 'new-krisp-audio' },
+        setEnabled: newSetEnabled,
+        isEnabled: mocks.krispIsEnabled,
+        destroy: mocks.krispDestroy,
+      });
+    mocks.createLocalTracks
+      .mockResolvedValueOnce([
+        firstAudioTrack,
+        { mediaStreamTrack: { kind: 'video', enabled: true }, stop: vi.fn(), detach: vi.fn() },
+      ])
+      .mockResolvedValueOnce([
+        retriedAudioTrack,
+        { mediaStreamTrack: { kind: 'video', enabled: true }, stop: vi.fn(), detach: vi.fn() },
+      ]);
+    mocks.featureFlags.debateDebugging = true;
+
+    await renderLiveDebate();
+
+    const firstSwitch = await screen.findByRole('switch', { name: 'Krisp noise filter' });
+    await waitFor(() => expect(firstSwitch).toBeEnabled());
+    fireEvent.click(firstSwitch);
+    await waitFor(() => expect(oldSetEnabled).toHaveBeenLastCalledWith(false));
+
+    act(() => emitRoomEvent('disconnected', 99));
+    fireEvent.click(await screen.findByRole('button', { name: 'Retry connection' }));
+
+    const retriedSwitch = await screen.findByRole('switch', { name: 'Krisp noise filter' });
+    await waitFor(() => expect(retriedSwitch).toBeEnabled());
+    expect(retriedSwitch).toHaveAttribute('aria-checked', 'false');
+    fireEvent.click(retriedSwitch);
+    expect(retriedSwitch).toBeDisabled();
+
+    oldDisabling.resolve();
+
+    await waitFor(() => expect(oldSetEnabled).toHaveResolved());
+    expect(retriedSwitch).toBeDisabled();
+
+    newEnabling.resolve();
+
+    await waitFor(() => expect(retriedSwitch).toBeEnabled());
+    expect(retriedSwitch).toHaveAttribute('aria-checked', 'true');
   });
 
   it('shows the circular phase timer during a timed debate turn', async () => {
@@ -1632,7 +1737,7 @@ describe('DebateRoomPageClient', () => {
   });
 });
 
-async function renderLiveDebate() {
+async function renderLiveDebate(overrides: Partial<Debate> = {}) {
   mocks.debate = {
     ...completedDebate(),
     status: 'in_progress',
@@ -1640,6 +1745,7 @@ async function renderLiveDebate() {
     turn_started_at: '2026-07-02T00:00:10.000Z',
     turn_ends_at: '2026-07-02T00:00:40.000Z',
     completed_at: null,
+    ...overrides,
   };
   const view = render(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
   await waitFor(() => expect(mocks.markJoinedMutateAsync).toHaveBeenCalled());
@@ -1694,6 +1800,7 @@ function createLocalAudioTrack() {
   let processor: { processedTrack?: { kind: string; enabled: boolean; id: string } } | null = null;
 
   return {
+    sourceMediaStreamTrack: browserTrack,
     get mediaStreamTrack() {
       return processor?.processedTrack ?? browserTrack;
     },

--- a/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import type { KrispNoiseFilterProcessor } from '@livekit/krisp-noise-filter';
+
 import * as React from 'react';
 
 import cx from 'classnames';
@@ -53,8 +55,20 @@ type DebateRoomPageClientProps = {
 
 type LocalTrackLike = {
   mediaStreamTrack: MediaStreamTrack;
+  setProcessor?: (processor: KrispNoiseFilterProcessor) => Promise<void>;
+  stopProcessor?: () => Promise<void>;
   stop: () => void;
   detach?: () => void;
+};
+
+type DebateNoiseFilterStatus = 'initializing' | 'enabled' | 'disabled' | 'unsupported' | 'failed';
+
+const debateNoiseFilterStatusLabel: Record<DebateNoiseFilterStatus, string> = {
+  initializing: 'Loading…',
+  enabled: 'On',
+  disabled: 'Off',
+  unsupported: 'Unavailable',
+  failed: 'Failed',
 };
 
 type MediaDeviceOption = {
@@ -157,8 +171,13 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
   const [videoInputDevices, setVideoInputDevices] = React.useState<MediaDeviceOption[]>([]);
   const [selectedAudioInputId, setSelectedAudioInputId] = React.useState('');
   const [selectedVideoInputId, setSelectedVideoInputId] = React.useState('');
+  const [noiseFilterStatus, setNoiseFilterStatus] = React.useState<DebateNoiseFilterStatus>('initializing');
+  const [noiseFilterTogglePending, setNoiseFilterTogglePending] = React.useState(false);
   const selectedAudioInputIdRef = React.useRef('');
   const selectedVideoInputIdRef = React.useRef('');
+  const noiseFilterProcessorRef = React.useRef<KrispNoiseFilterProcessor | null>(null);
+  const noiseFilterEnabledRef = React.useRef(true);
+  const noiseFilterTogglePendingRef = React.useRef(false);
   const mountedRef = React.useRef(true);
   const previewGenerationRef = React.useRef(0);
   const connectionGenerationRef = React.useRef(0);
@@ -623,6 +642,60 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
     [ensureLocalPreview]
   );
 
+  const initializeNoiseFilter = React.useCallback(async (tracks: LocalTrackLike[], isCurrent: () => boolean) => {
+    noiseFilterProcessorRef.current = null;
+    if (isCurrent()) {
+      setNoiseFilterStatus('initializing');
+      setNoiseFilterTogglePending(false);
+      noiseFilterTogglePendingRef.current = false;
+    }
+
+    const audioTrack = tracks.find(track => track.mediaStreamTrack.kind === 'audio');
+    if (!audioTrack?.setProcessor) {
+      if (isCurrent()) setNoiseFilterStatus('failed');
+      console.warn('[DebateNoiseFilter] Krisp could not attach because the local microphone track is unavailable.');
+      return;
+    }
+
+    try {
+      const { KrispNoiseFilter, isKrispNoiseFilterSupported } = await import('@livekit/krisp-noise-filter');
+      if (!isCurrent()) return;
+      if (!isKrispNoiseFilterSupported()) {
+        setNoiseFilterStatus('unsupported');
+        console.info('[DebateNoiseFilter] Krisp is unavailable in this browser; using the browser microphone track.');
+        return;
+      }
+
+      const processor = KrispNoiseFilter();
+      await audioTrack.setProcessor(processor);
+      if (!isCurrent()) {
+        await audioTrack.stopProcessor?.().catch(stopError => {
+          console.warn('[DebateNoiseFilter] Krisp cleanup failed after the connection changed.', stopError);
+        });
+        return;
+      }
+      await processor.setEnabled(noiseFilterEnabledRef.current);
+      if (!isCurrent()) {
+        await audioTrack.stopProcessor?.().catch(stopError => {
+          console.warn('[DebateNoiseFilter] Krisp cleanup failed after the connection changed.', stopError);
+        });
+        return;
+      }
+
+      noiseFilterProcessorRef.current = processor;
+      setNoiseFilterStatus(noiseFilterEnabledRef.current ? 'enabled' : 'disabled');
+    } catch (error) {
+      await audioTrack.stopProcessor?.().catch(stopError => {
+        console.warn('[DebateNoiseFilter] Krisp cleanup failed after initialization.', stopError);
+      });
+      if (isCurrent()) {
+        noiseFilterProcessorRef.current = null;
+        setNoiseFilterStatus('failed');
+      }
+      console.warn('[DebateNoiseFilter] Krisp initialization failed; using the browser microphone track.', error);
+    }
+  }, []);
+
   const connect = React.useCallback(async (options: { takeover?: boolean } = {}) => {
     const generation = connectionGenerationRef.current + 1;
     connectionGenerationRef.current = generation;
@@ -630,9 +703,7 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
     let connectingRoom: RoomLike | null = null;
     let newlyCreatedTracks: LocalTrackLike[] = [];
     const ownership = ownershipRef.current;
-    const ownsConnection = options.takeover
-      ? await ownership?.requestTakeover()
-      : await ownership?.acquire();
+    const ownsConnection = options.takeover ? await ownership?.requestTakeover() : await ownership?.acquire();
     if (!isCurrent()) return;
     if (ownsConnection === false) {
       setConnectionConflict(true);
@@ -740,13 +811,16 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
         // call room.disconnect() a second time and could re-enter this handler.
         roomRef.current = null;
         disconnectRoom(roomRef, localTracksRef, localVideoRef, remoteMediaRef);
+        noiseFilterProcessorRef.current = null;
         ownershipRef.current?.release();
         localMediaStreamRef.current = null;
         setRemoteVideoReady(false);
         const duplicateIdentity = payload === livekit.DisconnectReason.DUPLICATE_IDENTITY;
         setConnectionConflict(duplicateIdentity);
         setRoomError(
-          duplicateIdentity ? 'This debate is active in another tab or device.' : 'Lost connection to the debate room.'
+          duplicateIdentity
+            ? 'This debate is active in another tab or device.'
+            : 'Lost connection to the debate room.'
         );
         setRoomState('idle');
         logDebateConnectionDiagnostic('livekit-disconnected', {
@@ -814,6 +888,17 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
         }
       }
 
+      // LiveKit supplies the audio context required by audio processors while publishing the
+      // microphone. Attach Krisp afterwards, then read mediaStreamTrack so this stream contains
+      // the same processed track used by the outbound publication.
+      await initializeNoiseFilter(tracks, isCurrent);
+      if (!isCurrent()) {
+        room.disconnect();
+        stopLocalTracks(localTracksRef);
+        localMediaStreamRef.current = null;
+        if (roomRef.current === room) roomRef.current = null;
+        return;
+      }
       const stream = new MediaStream(tracks.map(track => track.mediaStreamTrack));
       localMediaStreamRef.current = stream;
       if (localVideoRef.current) {
@@ -852,6 +937,7 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
     countdown.effectiveStatus,
     debateId,
     debate?.status,
+    initializeNoiseFilter,
     liveKitJoin,
     markJoined,
     refetchDebate,
@@ -876,6 +962,31 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
 
   const toggleVideoEnabled = React.useCallback(() => {
     setVideoEnabled(current => !current);
+  }, []);
+
+  const toggleNoiseFilter = React.useCallback(async () => {
+    const processor = noiseFilterProcessorRef.current;
+    if (!processor || noiseFilterTogglePendingRef.current) return;
+
+    const previousEnabled = noiseFilterEnabledRef.current;
+    const enabled = !previousEnabled;
+    noiseFilterEnabledRef.current = enabled;
+    noiseFilterTogglePendingRef.current = true;
+    setNoiseFilterTogglePending(true);
+    try {
+      await processor.setEnabled(enabled);
+      if (!mountedRef.current || noiseFilterProcessorRef.current !== processor) return;
+      setNoiseFilterStatus(enabled ? 'enabled' : 'disabled');
+    } catch (error) {
+      if (mountedRef.current && noiseFilterProcessorRef.current === processor) {
+        noiseFilterEnabledRef.current = previousEnabled;
+        setNoiseFilterStatus('failed');
+      }
+      console.warn('[DebateNoiseFilter] Krisp could not change state.', error);
+    } finally {
+      noiseFilterTogglePendingRef.current = false;
+      if (mountedRef.current) setNoiseFilterTogglePending(false);
+    }
   }, []);
 
   const finishAndPersist = React.useCallback(async () => {
@@ -1328,6 +1439,9 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
                 onToggleAudioMuted={toggleAudioMuted}
                 onToggleRemoteAudioEnabled={toggleRemoteAudioEnabled}
                 onToggleVideoEnabled={toggleVideoEnabled}
+                noiseFilterStatus={noiseFilterStatus}
+                noiseFilterTogglePending={noiseFilterTogglePending}
+                onToggleNoiseFilter={toggleNoiseFilter}
                 rematchSession={rematchQuery.data ?? null}
                 currentUserId={currentUserId}
                 onRequestRematch={requestRematch}
@@ -1575,6 +1689,9 @@ function DebateRecordingModal({
   onToggleAudioMuted,
   onToggleRemoteAudioEnabled,
   onToggleVideoEnabled,
+  noiseFilterStatus,
+  noiseFilterTogglePending,
+  onToggleNoiseFilter,
   rematchSession,
   currentUserId,
   onRequestRematch,
@@ -1599,6 +1716,9 @@ function DebateRecordingModal({
   onToggleAudioMuted: () => void;
   onToggleRemoteAudioEnabled: () => void;
   onToggleVideoEnabled: () => void;
+  noiseFilterStatus: DebateNoiseFilterStatus;
+  noiseFilterTogglePending: boolean;
+  onToggleNoiseFilter: () => void;
   rematchSession: DebateRematchSession | null;
   currentUserId: string | null;
   onRequestRematch: () => void;
@@ -1724,6 +1844,9 @@ function DebateRecordingModal({
           onToggleAudioMuted={onToggleAudioMuted}
           onToggleRemoteAudioEnabled={onToggleRemoteAudioEnabled}
           onToggleVideoEnabled={onToggleVideoEnabled}
+          noiseFilterStatus={noiseFilterStatus}
+          noiseFilterTogglePending={noiseFilterTogglePending}
+          onToggleNoiseFilter={onToggleNoiseFilter}
         />
       )}
 
@@ -1795,6 +1918,9 @@ function DebateDebugMenu({
   onToggleAudioMuted,
   onToggleRemoteAudioEnabled,
   onToggleVideoEnabled,
+  noiseFilterStatus,
+  noiseFilterTogglePending,
+  onToggleNoiseFilter,
 }: {
   debate: Debate;
   countdown: DebateCountdown;
@@ -1805,8 +1931,13 @@ function DebateDebugMenu({
   onToggleAudioMuted: () => void;
   onToggleRemoteAudioEnabled: () => void;
   onToggleVideoEnabled: () => void;
+  noiseFilterStatus: DebateNoiseFilterStatus;
+  noiseFilterTogglePending: boolean;
+  onToggleNoiseFilter: () => void;
 }) {
   const phases = debateDebugPhases(debate, countdown);
+  const noiseFilterAvailable = noiseFilterStatus === 'enabled' || noiseFilterStatus === 'disabled';
+  const noiseFilterDisabled = roomState === 'saving' || noiseFilterTogglePending || !noiseFilterAvailable;
 
   return (
     <aside className="fixed top-4 right-4 z-[1010] w-[min(280px,calc(100vw-2rem))] rounded-lg border border-grey-02 bg-white/95 p-3 shadow-card backdrop-blur">
@@ -1844,6 +1975,39 @@ function DebateDebugMenu({
           </RecordingCircleButton>
         </div>
       </div>
+
+      <button
+        type="button"
+        role="switch"
+        aria-label="Krisp noise filter"
+        aria-checked={noiseFilterStatus === 'enabled'}
+        disabled={noiseFilterDisabled}
+        onClick={onToggleNoiseFilter}
+        className="mt-3 flex min-h-10 w-full items-center justify-between gap-3 border-t border-grey-02 pt-3 text-left disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        <Text as="span" variant="metadata" color="text">
+          Krisp noise filter
+        </Text>
+        <span className="flex shrink-0 items-center gap-2">
+          <Text as="span" variant="metadata" color="grey-04">
+            {noiseFilterTogglePending ? 'Saving…' : debateNoiseFilterStatusLabel[noiseFilterStatus]}
+          </Text>
+          <span
+            aria-hidden="true"
+            className={cx(
+              'relative inline-flex h-5 w-9 rounded-full transition-colors',
+              noiseFilterStatus === 'enabled' ? 'bg-ctaPrimary' : 'bg-grey-02'
+            )}
+          >
+            <span
+              className={cx(
+                'shadow-sm absolute top-0.5 size-4 rounded-full bg-white transition-transform',
+                noiseFilterStatus === 'enabled' ? 'translate-x-[18px]' : 'translate-x-0.5'
+              )}
+            />
+          </span>
+        </span>
+      </button>
 
       <ol aria-label="Debate phases" className="mt-3 grid gap-1 border-t border-grey-02 pt-3">
         {phases.map(phase => (

--- a/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.tsx
@@ -178,6 +178,7 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
   const noiseFilterProcessorRef = React.useRef<KrispNoiseFilterProcessor | null>(null);
   const noiseFilterEnabledRef = React.useRef(true);
   const noiseFilterTogglePendingRef = React.useRef(false);
+  const sourceMediaStreamTracksRef = React.useRef(new WeakMap<LocalTrackLike, MediaStreamTrack>());
   const mountedRef = React.useRef(true);
   const previewGenerationRef = React.useRef(0);
   const connectionGenerationRef = React.useRef(0);
@@ -255,7 +256,11 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
   }, [serverClock]);
 
   React.useEffect(() => {
-    setLocalTrackPreferences(localTracksRef.current, { audioEnabled: localAudioEnabled, videoEnabled });
+    setLocalTrackPreferences(
+      localTracksRef.current,
+      { audioEnabled: localAudioEnabled, videoEnabled },
+      sourceMediaStreamTracksRef.current
+    );
   }, [localAudioEnabled, videoEnabled]);
 
   React.useEffect(() => {
@@ -657,6 +662,8 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
       return;
     }
 
+    let processor: KrispNoiseFilterProcessor | null = null;
+    let processorAttached = false;
     try {
       const { KrispNoiseFilter, isKrispNoiseFilterSupported } = await import('@livekit/krisp-noise-filter');
       if (!isCurrent()) return;
@@ -666,14 +673,18 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
         return;
       }
 
-      const processor = KrispNoiseFilter();
+      const sourceMediaStreamTrack = audioTrack.mediaStreamTrack;
+      sourceMediaStreamTracksRef.current.set(audioTrack, sourceMediaStreamTrack);
+      processor = KrispNoiseFilter();
       await audioTrack.setProcessor(processor);
+      processorAttached = true;
       if (!isCurrent()) {
         await audioTrack.stopProcessor?.().catch(stopError => {
           console.warn('[DebateNoiseFilter] Krisp cleanup failed after the connection changed.', stopError);
         });
         return;
       }
+      audioTrack.mediaStreamTrack.enabled = sourceMediaStreamTrack.enabled;
       await processor.setEnabled(noiseFilterEnabledRef.current);
       if (!isCurrent()) {
         await audioTrack.stopProcessor?.().catch(stopError => {
@@ -685,7 +696,8 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
       noiseFilterProcessorRef.current = processor;
       setNoiseFilterStatus(noiseFilterEnabledRef.current ? 'enabled' : 'disabled');
     } catch (error) {
-      await audioTrack.stopProcessor?.().catch(stopError => {
+      const cleanup = processorAttached ? audioTrack.stopProcessor?.() : processor?.destroy();
+      await cleanup?.catch(stopError => {
         console.warn('[DebateNoiseFilter] Krisp cleanup failed after initialization.', stopError);
       });
       if (isCurrent()) {
@@ -854,15 +866,19 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
         return;
       }
       localTracksRef.current = tracks;
-      setLocalTrackPreferences(tracks, {
-        audioEnabled: shouldEnableLocalAudio(
-          countdown.effectiveStatus,
-          countdown.activeSlot,
-          token.participant_slot,
-          audioMuted
-        ),
-        videoEnabled,
-      });
+      setLocalTrackPreferences(
+        tracks,
+        {
+          audioEnabled: shouldEnableLocalAudio(
+            countdown.effectiveStatus,
+            countdown.activeSlot,
+            token.participant_slot,
+            audioMuted
+          ),
+          videoEnabled,
+        },
+        sourceMediaStreamTracksRef.current
+      );
 
       // Mark joined now that we're in the room and hold local media, before publishing. publishTrack
       // awaits WebRTC media negotiation (ICE/TURN), which between two peers behind NAT can take
@@ -984,8 +1000,10 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
       }
       console.warn('[DebateNoiseFilter] Krisp could not change state.', error);
     } finally {
-      noiseFilterTogglePendingRef.current = false;
-      if (mountedRef.current) setNoiseFilterTogglePending(false);
+      if (noiseFilterProcessorRef.current === processor) {
+        noiseFilterTogglePendingRef.current = false;
+        if (mountedRef.current) setNoiseFilterTogglePending(false);
+      }
     }
   }, []);
 
@@ -2477,10 +2495,15 @@ function SpeakerIcon({ disabled }: { disabled: boolean }) {
 
 function setLocalTrackPreferences(
   tracks: LocalTrackLike[],
-  preferences: { audioEnabled: boolean; videoEnabled: boolean }
+  preferences: { audioEnabled: boolean; videoEnabled: boolean },
+  sourceMediaStreamTracks?: WeakMap<LocalTrackLike, MediaStreamTrack>
 ) {
   for (const track of tracks) {
     if (track.mediaStreamTrack.kind === 'audio') {
+      const sourceMediaStreamTrack = sourceMediaStreamTracks?.get(track);
+      if (sourceMediaStreamTrack && sourceMediaStreamTrack !== track.mediaStreamTrack) {
+        sourceMediaStreamTrack.enabled = preferences.audioEnabled;
+      }
       track.mediaStreamTrack.enabled = preferences.audioEnabled;
     }
     if (track.mediaStreamTrack.kind === 'video') {


### PR DESCRIPTION
## Summary

Debate participants now use Krisp noise filtering by default, improving noise handling for both live audio and each participant's locally recorded lane. When debate debugging is enabled, participants can bypass and reactivate Krisp during an active call for direct comparisons without replacing the microphone track or restarting the recorder.

Krisp attaches only after LiveKit publishes the microphone and provides its audio context. Unsupported browsers and processor/model failures continue with the original browser-processed microphone, while the local on/off preference survives connection retries within the page session.

## Validation

- Full web test suite: 1,500 tests passed across 146 files
- Debate room suite: 65 tests passed
- TypeScript check passed
- Targeted ESLint passed with no warnings or errors
- Two-device listening comparison remains to be performed in quiet and noisy environments

## Post-Deploy Monitoring & Validation

- Search browser diagnostics for `[DebateNoiseFilter]`, especially `Krisp initialization failed`, `Krisp cleanup failed`, and `Krisp could not change state`.
- Healthy signals: debates continue connecting and recording normally, initialization failures remain rare, and final recordings show improved background-noise handling.
- Failure signals: a sustained increase in Krisp failure diagnostics, debate connection/recording regressions, missing microphone audio, or reports of worse voice quality.
- Validate live and final recorded audio from two devices with Krisp on and off in quiet and noisy conditions during the first 24 hours after deployment.
- Owner: debates engineering/on-call. Roll back this commit if microphone loss or connection/recording regressions are reproducible; use the debug bypass for isolated quality issues while investigating.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
