### PR TITLE
fix: close onboarding dialog after completion

### DIFF
--- a/apps/web/partials/onboarding/dialog.tsx
+++ b/apps/web/partials/onboarding/dialog.tsx
@@ -44,17 +44,17 @@ import { Truncate } from '~/design-system/truncate';
 
 import { postOnboardingRedirectAtom } from '~/atoms/post-onboarding-redirect';
 
+import { type OnboardingStep, shouldOpenOnboardingDialog } from './onboarding-dialog-visibility';
+
 export const nameAtom = atomWithStorage<string>('onboardingName', '');
 export const topicIdAtom = atomWithStorage<string>('onboardingEntityId', '');
 export const avatarAtom = atomWithStorage<string>('onboardingAvatar', '');
 export const spaceIdAtom = atomWithStorage<string>('onboardingSpaceId', '');
 
-type Step = 'start' | 'enter-profile' | 'existing-entity-match' | 'create-space' | 'completed' | 'done';
-
 // 'start' and 'create-space' linger in the type only to normalize values
 // persisted by an older version — onboarding now opens straight on name/avatar
 // and runs to 'completed' with no separate create step (see effectiveStep).
-export const stepAtom = atomWithStorage<Step>('onboardingStep', 'enter-profile');
+export const stepAtom = atomWithStorage<OnboardingStep>('onboardingStep', 'enter-profile');
 
 const ONBOARDING_DESTINATION = NavUtils.toExplore();
 // How long the "Finalizing details…" animation plays before we route the user
@@ -183,7 +183,7 @@ export const OnboardingDialog = () => {
   return (
     // Stay open through the completion animation — `setPending` flips
     // `isOnboardingVisible` false, but we want the animation to finish first.
-    <Root open={isOnboardingVisible || step === 'completed'}>
+    <Root open={shouldOpenOnboardingDialog(isOnboardingVisible, step)}>
       <Portal>
         <Overlay className="fixed inset-0 z-100 bg-text opacity-20" />
         <Content

--- a/apps/web/partials/onboarding/onboarding-dialog-visibility.test.ts
+++ b/apps/web/partials/onboarding/onboarding-dialog-visibility.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+
+import { shouldOpenOnboardingDialog } from './onboarding-dialog-visibility';
+
+describe('shouldOpenOnboardingDialog', () => {
+  it('keeps the optimistic completion screen open after onboarding visibility clears', () => {
+    expect(shouldOpenOnboardingDialog(false, 'completed')).toBe(true);
+  });
+
+  it('keeps the terminal done state closed when onboarding visibility briefly re-arms', () => {
+    expect(shouldOpenOnboardingDialog(true, 'done')).toBe(false);
+  });
+
+  it('follows onboarding visibility for interactive steps', () => {
+    expect(shouldOpenOnboardingDialog(true, 'enter-profile')).toBe(true);
+    expect(shouldOpenOnboardingDialog(false, 'enter-profile')).toBe(false);
+  });
+});

--- a/apps/web/partials/onboarding/onboarding-dialog-visibility.ts
+++ b/apps/web/partials/onboarding/onboarding-dialog-visibility.ts
@@ -1,0 +1,17 @@
+export type OnboardingStep =
+  | 'start'
+  | 'enter-profile'
+  | 'existing-entity-match'
+  | 'create-space'
+  | 'completed'
+  | 'done';
+
+/**
+ * The completion screen intentionally stays mounted after optimistic setup hides
+ * onboarding. Once the flow reaches `done`, however, it has no renderable body and
+ * must stay closed even if registration state briefly re-arms onboarding visibility.
+ */
+export function shouldOpenOnboardingDialog(isOnboardingVisible: boolean, step: OnboardingStep): boolean {
+  if (step === 'done') return false;
+  return isOnboardingVisible || step === 'completed';
+}


### PR DESCRIPTION
## Summary

- prevent the onboarding dialog shell from reopening after optimistic account creation reaches its terminal `done` state
- preserve the intended completion animation even after optimistic setup hides onboarding
- add focused regression coverage for completion, terminal, and interactive dialog states

## Root cause

After the completion timer changed the persisted onboarding step to `done`, a briefly stale onboarding visibility signal could reopen the dialog. The `done` step has no body component, so users saw an empty modal containing only the “Log out” header until registration state settled.

## User impact

The onboarding modal now closes immediately after its completion animation and cannot flash the empty shell while the optimistic account setup finishes in the background.

## Validation

- `bun run test partials/onboarding/onboarding-dialog-visibility.test.ts core/hooks/use-geo-logout.test.tsx` (2 files, 4 tests)
- `bunx tsc --noEmit --pretty false`
- `bunx eslint partials/onboarding/dialog.tsx partials/onboarding/onboarding-dialog-visibility.ts partials/onboarding/onboarding-dialog-visibility.test.ts`
- `git diff --check`
