### PR TITLE
feat: improve debate pre-join device setup

### DIFF
--- a/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-pre-join-screen.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-pre-join-screen.tsx
@@ -15,6 +15,7 @@ import { Avatar } from '~/design-system/avatar';
 import { Check } from '~/design-system/icons/check';
 import { ChevronDownSmall } from '~/design-system/icons/chevron-down-small';
 import { Text } from '~/design-system/text';
+import { useElevatedPopoverPortal } from '~/design-system/use-elevated-popover-portal';
 
 import { CameraIcon, CloseIcon, LeaveIcon, MicrophoneIcon, RecordingCircleButton } from './debate-room-controls';
 
@@ -336,29 +337,33 @@ function DesktopSettingsPopover({
   children: React.ReactNode;
 }) {
   const triggerRef = React.useRef<HTMLButtonElement>(null);
+  const elevatedPopoverPortal = useElevatedPopoverPortal();
 
   return (
     <Popover.Root open={open} onOpenChange={onOpenChange}>
       <Popover.Trigger asChild>
         <PreScreenSettingsTrigger ref={triggerRef} ariaLabel={ariaLabel} icon={icon} label={label} open={open} />
       </Popover.Trigger>
-      <Popover.Portal>
-        <Popover.Content
-          role="dialog"
-          aria-label={ariaLabel}
-          side="top"
-          align="start"
-          sideOffset={-1}
-          avoidCollisions={false}
-          onCloseAutoFocus={event => {
-            event.preventDefault();
-            triggerRef.current?.focus();
-          }}
-          className="z-[1010] max-h-[360px] w-[var(--radix-popover-trigger-width)] overflow-y-auto rounded-lg border border-grey-02 bg-white p-2 text-left text-text shadow-lg outline-none"
-        >
-          {children}
-        </Popover.Content>
-      </Popover.Portal>
+      {/* The default Radix wrapper is globally capped at z-60, below this screen's z-1000 overlay. */}
+      {elevatedPopoverPortal && (
+        <Popover.Portal container={elevatedPopoverPortal}>
+          <Popover.Content
+            role="dialog"
+            aria-label={ariaLabel}
+            side="top"
+            align="start"
+            sideOffset={-1}
+            avoidCollisions={false}
+            onCloseAutoFocus={event => {
+              event.preventDefault();
+              triggerRef.current?.focus();
+            }}
+            className="z-[1010] max-h-[360px] w-[var(--radix-popover-trigger-width)] overflow-y-auto rounded-lg border border-grey-02 bg-white p-2 text-left text-text shadow-lg outline-none"
+          >
+            {children}
+          </Popover.Content>
+        </Popover.Portal>
+      )}
     </Popover.Root>
   );
 }

--- a/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-pre-join-screen.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-pre-join-screen.tsx
@@ -1,0 +1,592 @@
+'use client';
+
+import * as Dialog from '@radix-ui/react-dialog';
+import * as Popover from '@radix-ui/react-popover';
+import * as RadioGroup from '@radix-ui/react-radio-group';
+
+import * as React from 'react';
+
+import cx from 'classnames';
+
+import { useIsMobileCallLayout } from '~/core/community-calls/use-is-mobile-call-layout';
+import type { Debate } from '~/core/debates/api';
+
+import { Avatar } from '~/design-system/avatar';
+import { Check } from '~/design-system/icons/check';
+import { ChevronDownSmall } from '~/design-system/icons/chevron-down-small';
+import { Text } from '~/design-system/text';
+
+import { CameraIcon, CloseIcon, LeaveIcon, MicrophoneIcon, RecordingCircleButton } from './debate-room-controls';
+
+export type MediaDeviceOption = {
+  deviceId: string;
+  groupId: string;
+  kind: 'audioinput' | 'audiooutput' | 'videoinput';
+  label: string;
+};
+
+export type PreJoinMediaState = 'requesting' | 'ready' | 'denied' | 'unavailable' | 'error';
+
+export const systemDefaultAudioOutput: MediaDeviceOption = {
+  deviceId: 'default',
+  groupId: 'default',
+  kind: 'audiooutput',
+  label: 'System default',
+};
+
+export function DebatePreScreen({
+  debate,
+  currentUserId,
+  localVideoRef,
+  previewStream,
+  previewState,
+  previewBusy,
+  error,
+  audioInputDevices,
+  audioOutputDevices,
+  videoInputDevices,
+  selectedAudioInputId,
+  selectedAudioOutputId,
+  selectedVideoInputId,
+  audioOutputSupported,
+  audioOutputError,
+  onAudioInputChange,
+  onAudioOutputChange,
+  onVideoInputChange,
+  onRetryMedia,
+  readyBusy,
+  onReady,
+  onLeave,
+  leaveDisabled,
+}: {
+  debate: Debate;
+  currentUserId: string | null;
+  localVideoRef: React.RefObject<HTMLVideoElement | null>;
+  previewStream: MediaStream | null;
+  previewState: PreJoinMediaState;
+  previewBusy: boolean;
+  error: string | null;
+  audioInputDevices: MediaDeviceOption[];
+  audioOutputDevices: MediaDeviceOption[];
+  videoInputDevices: MediaDeviceOption[];
+  selectedAudioInputId: string;
+  selectedAudioOutputId: string;
+  selectedVideoInputId: string;
+  audioOutputSupported: boolean;
+  audioOutputError: string | null;
+  onAudioInputChange: (deviceId: string) => void;
+  onAudioOutputChange: (deviceId: string) => void;
+  onVideoInputChange: (deviceId: string) => void;
+  onRetryMedia: () => void;
+  readyBusy: boolean;
+  onReady: () => void;
+  onLeave: () => void;
+  leaveDisabled: boolean;
+}) {
+  const isMobile = useIsMobileCallLayout();
+  const [openSettings, setOpenSettings] = React.useState<'audio' | 'video' | null>(null);
+  const audioTriggerRef = React.useRef<HTMLButtonElement>(null);
+  const videoTriggerRef = React.useRef<HTMLButtonElement>(null);
+  const participants = [...debate.participants].sort((a, b) => a.participant_slot - b.participant_slot);
+  const localParticipant =
+    participants.find(participant => participant.user_id === currentUserId) ?? participants[0] ?? null;
+  const remoteParticipant =
+    participants.find(participant => participant.user_id !== localParticipant?.user_id) ?? participants[1] ?? null;
+  const localReady = Boolean(localParticipant?.ready_at);
+  const remoteReady = Boolean(remoteParticipant?.ready_at);
+  const mediaReady = previewState === 'ready';
+  const selectedCameraLabel =
+    videoInputDevices.find(device => device.deviceId === selectedVideoInputId)?.label ?? 'Camera';
+
+  React.useEffect(() => {
+    const originalBodyOverflow = document.body.style.overflow;
+    const originalDocumentOverflow = document.documentElement.style.overflow;
+
+    document.body.style.overflow = 'hidden';
+    document.documentElement.style.overflow = 'hidden';
+
+    return () => {
+      document.body.style.overflow = originalBodyOverflow;
+      document.documentElement.style.overflow = originalDocumentOverflow;
+    };
+  }, []);
+
+  React.useEffect(() => {
+    const video = localVideoRef.current;
+    if (!video || !mediaReady) return;
+    video.srcObject = previewStream;
+    video.muted = true;
+    if (previewStream) void video.play().catch(() => undefined);
+  }, [localVideoRef, mediaReady, previewStream]);
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Debate readiness"
+      className="fixed inset-0 z-[1000] overflow-y-auto bg-white text-text"
+    >
+      <section className="mx-auto flex min-h-dvh w-full max-w-[920px] flex-col items-center justify-center px-5 py-6 text-center md:justify-start">
+        <Text as="p" variant="cardEntityTitle" color="grey-04">
+          Debate
+        </Text>
+        <h1 className="mt-3 max-w-[870px] text-[2.5rem] leading-[1.05] font-semibold text-text md:max-w-[560px] md:text-[2rem]">
+          {debate.claim.claim}
+        </h1>
+
+        <div className="mt-10 w-full max-w-[272px]">
+          <PreScreenOpponent
+            participant={remoteParticipant}
+            label={
+              remoteParticipant ? remoteParticipant.display_name || remoteParticipant.profile_space_id : 'Other speaker'
+            }
+            ready={remoteReady}
+          />
+        </div>
+
+        {mediaReady ? (
+          <div className="mt-3 w-full max-w-[272px] rounded-lg border border-grey-02 bg-white p-3">
+            <div className="relative aspect-[4/3] w-full overflow-hidden rounded bg-grey-01">
+              <video ref={localVideoRef} className="h-full w-full object-cover" playsInline muted autoPlay />
+            </div>
+
+            <div className="mt-3 flex flex-col gap-2">
+              {isMobile ? (
+                <>
+                  <PreScreenSettingsTrigger
+                    buttonRef={audioTriggerRef}
+                    ariaLabel="Audio settings"
+                    icon={<MicrophoneIcon muted={false} />}
+                    label="Custom combination"
+                    open={openSettings === 'audio'}
+                    onClick={() => setOpenSettings(current => (current === 'audio' ? null : 'audio'))}
+                  />
+                  <PreScreenSettingsTrigger
+                    buttonRef={videoTriggerRef}
+                    ariaLabel="Video settings"
+                    icon={<CameraIcon disabled={false} />}
+                    label={selectedCameraLabel}
+                    open={openSettings === 'video'}
+                    onClick={() => setOpenSettings(current => (current === 'video' ? null : 'video'))}
+                  />
+                </>
+              ) : (
+                <>
+                  <DesktopSettingsPopover
+                    ariaLabel="Audio settings"
+                    icon={<MicrophoneIcon muted={false} />}
+                    label="Custom combination"
+                    open={openSettings === 'audio'}
+                    onOpenChange={open => setOpenSettings(open ? 'audio' : null)}
+                  >
+                    <AudioSettings
+                      audioInputDevices={audioInputDevices}
+                      audioOutputDevices={audioOutputDevices}
+                      selectedAudioInputId={selectedAudioInputId}
+                      selectedAudioOutputId={selectedAudioOutputId}
+                      audioOutputSupported={audioOutputSupported}
+                      error={audioOutputError}
+                      onAudioInputChange={onAudioInputChange}
+                      onAudioOutputChange={onAudioOutputChange}
+                    />
+                  </DesktopSettingsPopover>
+                  <DesktopSettingsPopover
+                    ariaLabel="Video settings"
+                    icon={<CameraIcon disabled={false} />}
+                    label={selectedCameraLabel}
+                    open={openSettings === 'video'}
+                    onOpenChange={open => setOpenSettings(open ? 'video' : null)}
+                  >
+                    <DeviceOptionGroup
+                      label="Select a camera"
+                      options={videoInputDevices}
+                      selectedDeviceId={selectedVideoInputId}
+                      onChange={onVideoInputChange}
+                    />
+                  </DesktopSettingsPopover>
+                </>
+              )}
+            </div>
+          </div>
+        ) : (
+          <PreScreenMediaUnavailable state={previewState} message={error} onRetry={onRetryMedia} />
+        )}
+
+        {mediaReady && error && (
+          <Text as="p" variant="metadata" color="red-01" className="mt-3">
+            {error}
+          </Text>
+        )}
+
+        {mediaReady && (
+          <button
+            type="button"
+            onClick={onReady}
+            disabled={readyBusy || localReady || previewBusy}
+            className="mt-3 flex min-h-11 w-full max-w-[272px] items-center justify-center rounded-full bg-text px-5 text-button text-white transition-colors hover:bg-text/90 disabled:opacity-50"
+          >
+            {localReady ? 'Waiting...' : readyBusy ? 'Saving...' : 'Accept'}
+          </button>
+        )}
+
+        <div className="mt-5">
+          <RecordingCircleButton
+            ariaLabel="Leave debate"
+            title="Leave debate"
+            onClick={onLeave}
+            disabled={leaveDisabled}
+          >
+            <LeaveIcon />
+          </RecordingCircleButton>
+        </div>
+      </section>
+
+      {isMobile && (
+        <>
+          <MobileSettingsSheet
+            title="Audio settings"
+            open={openSettings === 'audio'}
+            onOpenChange={open => setOpenSettings(open ? 'audio' : null)}
+            returnFocusRef={audioTriggerRef}
+          >
+            <AudioSettings
+              audioInputDevices={audioInputDevices}
+              audioOutputDevices={audioOutputDevices}
+              selectedAudioInputId={selectedAudioInputId}
+              selectedAudioOutputId={selectedAudioOutputId}
+              audioOutputSupported={audioOutputSupported}
+              error={audioOutputError}
+              onAudioInputChange={onAudioInputChange}
+              onAudioOutputChange={onAudioOutputChange}
+            />
+          </MobileSettingsSheet>
+          <MobileSettingsSheet
+            title="Video settings"
+            open={openSettings === 'video'}
+            onOpenChange={open => setOpenSettings(open ? 'video' : null)}
+            returnFocusRef={videoTriggerRef}
+          >
+            <SharedPreviewVideo stream={previewStream} />
+            <div className="mt-5">
+              <DeviceOptionGroup
+                label="Select a camera"
+                options={videoInputDevices}
+                selectedDeviceId={selectedVideoInputId}
+                onChange={onVideoInputChange}
+              />
+            </div>
+          </MobileSettingsSheet>
+        </>
+      )}
+    </div>
+  );
+}
+
+function PreScreenSettingsTrigger({
+  buttonRef,
+  ariaLabel,
+  icon,
+  label,
+  open,
+  onClick,
+}: {
+  buttonRef?: React.Ref<HTMLButtonElement>;
+  ariaLabel: string;
+  icon: React.ReactNode;
+  label: string;
+  open: boolean;
+  onClick?: () => void;
+}) {
+  return (
+    <button
+      ref={buttonRef}
+      type="button"
+      aria-label={ariaLabel}
+      aria-expanded={open}
+      onClick={onClick}
+      className={cx(
+        'relative flex min-h-9 w-full min-w-0 items-center rounded-full border bg-white px-3 py-2 text-left text-metadata text-text transition outline-none',
+        open ? 'border-text ring-1 ring-text' : 'border-grey-02 hover:border-grey-04',
+        'focus-visible:border-text focus-visible:ring-1 focus-visible:ring-text'
+      )}
+    >
+      <span className="mr-2 shrink-0 text-text">{icon}</span>
+      <span className="min-w-0 flex-1 truncate pr-6">{label}</span>
+      <span
+        className={cx(
+          'pointer-events-none absolute right-3 grid size-4 place-items-center transition-transform',
+          open && 'rotate-180'
+        )}
+      >
+        <ChevronDownSmall color={open ? 'text' : 'grey-04'} />
+      </span>
+    </button>
+  );
+}
+
+function DesktopSettingsPopover({
+  ariaLabel,
+  icon,
+  label,
+  open,
+  onOpenChange,
+  children,
+}: {
+  ariaLabel: string;
+  icon: React.ReactNode;
+  label: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  children: React.ReactNode;
+}) {
+  const triggerRef = React.useRef<HTMLButtonElement>(null);
+
+  return (
+    <Popover.Root open={open} onOpenChange={onOpenChange}>
+      <Popover.Trigger asChild>
+        <PreScreenSettingsTrigger buttonRef={triggerRef} ariaLabel={ariaLabel} icon={icon} label={label} open={open} />
+      </Popover.Trigger>
+      <Popover.Portal>
+        <Popover.Content
+          role="dialog"
+          aria-label={ariaLabel}
+          side="top"
+          align="start"
+          sideOffset={-1}
+          avoidCollisions={false}
+          onCloseAutoFocus={event => {
+            event.preventDefault();
+            triggerRef.current?.focus();
+          }}
+          className="z-[1010] max-h-[360px] w-[var(--radix-popover-trigger-width)] overflow-y-auto rounded-lg border border-grey-02 bg-white p-2 text-left text-text shadow-lg outline-none"
+        >
+          {children}
+        </Popover.Content>
+      </Popover.Portal>
+    </Popover.Root>
+  );
+}
+
+function MobileSettingsSheet({
+  title,
+  open,
+  onOpenChange,
+  returnFocusRef,
+  children,
+}: {
+  title: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  returnFocusRef: React.RefObject<HTMLButtonElement | null>;
+  children: React.ReactNode;
+}) {
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-[1010] bg-black/55" />
+        <Dialog.Content
+          aria-label={title}
+          data-layout="bottom-sheet"
+          onCloseAutoFocus={event => {
+            event.preventDefault();
+            returnFocusRef.current?.focus();
+          }}
+          className="rounded-t-2xl fixed inset-x-0 bottom-0 z-[1011] max-h-[88dvh] overflow-y-auto bg-white px-5 pt-5 pb-[max(24px,env(safe-area-inset-bottom))] text-left text-text shadow-lg outline-none"
+        >
+          <div className="flex items-center justify-between border-b border-grey-02 pb-4">
+            <Dialog.Title className="text-bodySemibold">{title}</Dialog.Title>
+            <Dialog.Close asChild>
+              <button
+                type="button"
+                aria-label={`Close ${title}`}
+                className="grid size-8 place-items-center rounded-full text-grey-04 hover:bg-grey-01 hover:text-text focus-visible:outline focus-visible:outline-2 focus-visible:outline-text"
+              >
+                <CloseIcon />
+              </button>
+            </Dialog.Close>
+          </div>
+          <div className="pt-4">{children}</div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}
+
+function AudioSettings({
+  audioInputDevices,
+  audioOutputDevices,
+  selectedAudioInputId,
+  selectedAudioOutputId,
+  audioOutputSupported,
+  error,
+  onAudioInputChange,
+  onAudioOutputChange,
+}: {
+  audioInputDevices: MediaDeviceOption[];
+  audioOutputDevices: MediaDeviceOption[];
+  selectedAudioInputId: string;
+  selectedAudioOutputId: string;
+  audioOutputSupported: boolean;
+  error: string | null;
+  onAudioInputChange: (deviceId: string) => void;
+  onAudioOutputChange: (deviceId: string) => void;
+}) {
+  return (
+    <div className="space-y-3">
+      <DeviceOptionGroup
+        label="Select a microphone"
+        options={audioInputDevices}
+        selectedDeviceId={selectedAudioInputId}
+        onChange={onAudioInputChange}
+      />
+      <div className="border-t border-grey-02 pt-3">
+        <DeviceOptionGroup
+          label="Select a speaker"
+          options={audioOutputSupported ? audioOutputDevices : [systemDefaultAudioOutput]}
+          selectedDeviceId={audioOutputSupported ? selectedAudioOutputId : systemDefaultAudioOutput.deviceId}
+          disabled={!audioOutputSupported}
+          onChange={onAudioOutputChange}
+        />
+      </div>
+      {error && (
+        <Text as="p" variant="metadata" color="red-01">
+          {error}
+        </Text>
+      )}
+    </div>
+  );
+}
+
+function DeviceOptionGroup({
+  label,
+  options,
+  selectedDeviceId,
+  disabled = false,
+  onChange,
+}: {
+  label: string;
+  options: MediaDeviceOption[];
+  selectedDeviceId: string;
+  disabled?: boolean;
+  onChange: (deviceId: string) => void;
+}) {
+  return (
+    <RadioGroup.Root aria-label={label} value={selectedDeviceId} disabled={disabled} onValueChange={onChange}>
+      <Text as="p" variant="metadata" color="grey-04" className="px-1 pb-1">
+        {label}
+      </Text>
+      <div className="space-y-0.5">
+        {options.map(device => {
+          const selected = device.deviceId === selectedDeviceId;
+          return (
+            <RadioGroup.Item
+              key={`${device.kind}:${device.deviceId}`}
+              value={device.deviceId}
+              className={cx(
+                'flex min-h-9 w-full items-center justify-between gap-3 rounded-md px-3 py-2 text-left text-metadata text-text outline-none',
+                selected ? 'bg-grey-01' : 'hover:bg-grey-01',
+                'focus-visible:ring-1 focus-visible:ring-text disabled:cursor-default disabled:opacity-100'
+              )}
+            >
+              <span className="min-w-0 truncate">{device.label}</span>
+              {selected && (
+                <span aria-hidden="true" className="shrink-0">
+                  <Check />
+                </span>
+              )}
+            </RadioGroup.Item>
+          );
+        })}
+      </div>
+    </RadioGroup.Root>
+  );
+}
+
+function SharedPreviewVideo({ stream }: { stream: MediaStream | null }) {
+  const videoRef = React.useRef<HTMLVideoElement>(null);
+
+  React.useEffect(() => {
+    const video = videoRef.current;
+    if (!video) return;
+    video.srcObject = stream;
+    video.muted = true;
+    if (stream) void video.play().catch(() => undefined);
+    return () => {
+      video.srcObject = null;
+    };
+  }, [stream]);
+
+  return (
+    <div className="aspect-[4/3] w-full overflow-hidden rounded-lg bg-grey-01">
+      <video ref={videoRef} className="h-full w-full object-cover" playsInline muted autoPlay />
+    </div>
+  );
+}
+
+function PreScreenMediaUnavailable({
+  state,
+  message,
+  onRetry,
+}: {
+  state: Exclude<PreJoinMediaState, 'ready'>;
+  message: string | null;
+  onRetry: () => void;
+}) {
+  const requesting = state === 'requesting';
+  return (
+    <div className="mt-3 w-full max-w-[272px] rounded-lg border border-grey-02 bg-white p-3">
+      <div className="grid aspect-[4/3] w-full place-items-center rounded bg-grey-01 text-grey-04">
+        <CameraIcon disabled />
+      </div>
+      <Text as="p" variant="metadata" color="text" className="mx-auto mt-3 max-w-[220px]">
+        {requesting ? 'Requesting access to your camera and microphone…' : message}
+      </Text>
+      {!requesting && (
+        <button
+          type="button"
+          onClick={onRetry}
+          className="mt-3 inline-flex min-h-8 items-center justify-center rounded-full bg-text px-4 text-button text-white hover:bg-text/90"
+        >
+          {state === 'denied' ? 'Allow access' : 'Try again'}
+        </button>
+      )}
+    </div>
+  );
+}
+
+function PreScreenOpponent({
+  participant,
+  label,
+  ready,
+}: {
+  participant: Debate['participants'][number] | null;
+  label: string;
+  ready: boolean;
+}) {
+  return (
+    <div className="flex min-h-[52px] w-full items-center justify-between gap-4 rounded-lg border border-grey-02 bg-white px-3">
+      <div className="flex min-w-0 items-center gap-2">
+        <span className="h-5 w-5 shrink-0 overflow-hidden rounded-full">
+          <Avatar
+            avatarUrl={participant?.avatar_cid ?? null}
+            value={participant?.profile_space_id ?? label}
+            alt={label}
+            size={20}
+          />
+        </span>
+        <Text as="div" variant="metadata" color="text" className="min-w-0 truncate text-left">
+          {label}
+        </Text>
+      </div>
+      <span
+        className={cx(
+          'inline-flex shrink-0 items-center gap-2 rounded-full px-3 py-1.5 text-metadata leading-none',
+          ready ? 'bg-green text-text' : 'bg-grey-01 text-grey-04'
+        )}
+      >
+        {ready && <Check />}
+        {ready ? 'Ready' : 'Waiting...'}
+      </span>
+    </div>
+  );
+}

--- a/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-pre-join-screen.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-pre-join-screen.tsx
@@ -154,7 +154,7 @@ export function DebatePreScreen({
               {isMobile ? (
                 <>
                   <PreScreenSettingsTrigger
-                    buttonRef={audioTriggerRef}
+                    ref={audioTriggerRef}
                     ariaLabel="Audio settings"
                     icon={<MicrophoneIcon muted={false} />}
                     label="Custom combination"
@@ -162,7 +162,7 @@ export function DebatePreScreen({
                     onClick={() => setOpenSettings(current => (current === 'audio' ? null : 'audio'))}
                   />
                   <PreScreenSettingsTrigger
-                    buttonRef={videoTriggerRef}
+                    ref={videoTriggerRef}
                     ariaLabel="Video settings"
                     icon={<CameraIcon disabled={false} />}
                     label={selectedCameraLabel}
@@ -282,47 +282,43 @@ export function DebatePreScreen({
   );
 }
 
-function PreScreenSettingsTrigger({
-  buttonRef,
-  ariaLabel,
-  icon,
-  label,
-  open,
-  onClick,
-}: {
-  buttonRef?: React.Ref<HTMLButtonElement>;
+type PreScreenSettingsTriggerProps = Omit<React.ComponentPropsWithoutRef<'button'>, 'aria-label'> & {
   ariaLabel: string;
   icon: React.ReactNode;
   label: string;
   open: boolean;
-  onClick?: () => void;
-}) {
-  return (
-    <button
-      ref={buttonRef}
-      type="button"
-      aria-label={ariaLabel}
-      aria-expanded={open}
-      onClick={onClick}
-      className={cx(
-        'relative flex min-h-9 w-full min-w-0 items-center rounded-full border bg-white px-3 py-2 text-left text-metadata text-text transition outline-none',
-        open ? 'border-text ring-1 ring-text' : 'border-grey-02 hover:border-grey-04',
-        'focus-visible:border-text focus-visible:ring-1 focus-visible:ring-text'
-      )}
-    >
-      <span className="mr-2 shrink-0 text-text">{icon}</span>
-      <span className="min-w-0 flex-1 truncate pr-6">{label}</span>
-      <span
+};
+
+const PreScreenSettingsTrigger = React.forwardRef<HTMLButtonElement, PreScreenSettingsTriggerProps>(
+  function PreScreenSettingsTrigger({ ariaLabel, icon, label, open, className, ...buttonProps }, forwardedRef) {
+    return (
+      <button
+        {...buttonProps}
+        ref={forwardedRef}
+        type="button"
+        aria-label={ariaLabel}
+        aria-expanded={open}
         className={cx(
-          'pointer-events-none absolute right-3 grid size-4 place-items-center transition-transform',
-          open && 'rotate-180'
+          'relative flex min-h-9 w-full min-w-0 items-center rounded-full border bg-white px-3 py-2 text-left text-metadata text-text transition outline-none',
+          open ? 'border-text ring-1 ring-text' : 'border-grey-02 hover:border-grey-04',
+          'focus-visible:border-text focus-visible:ring-1 focus-visible:ring-text',
+          className
         )}
       >
-        <ChevronDownSmall color={open ? 'text' : 'grey-04'} />
-      </span>
-    </button>
-  );
-}
+        <span className="mr-2 shrink-0 text-text">{icon}</span>
+        <span className="min-w-0 flex-1 truncate pr-6">{label}</span>
+        <span
+          className={cx(
+            'pointer-events-none absolute right-3 grid size-4 place-items-center transition-transform',
+            open && 'rotate-180'
+          )}
+        >
+          <ChevronDownSmall color={open ? 'text' : 'grey-04'} />
+        </span>
+      </button>
+    );
+  }
+);
 
 function DesktopSettingsPopover({
   ariaLabel,
@@ -344,7 +340,7 @@ function DesktopSettingsPopover({
   return (
     <Popover.Root open={open} onOpenChange={onOpenChange}>
       <Popover.Trigger asChild>
-        <PreScreenSettingsTrigger buttonRef={triggerRef} ariaLabel={ariaLabel} icon={icon} label={label} open={open} />
+        <PreScreenSettingsTrigger ref={triggerRef} ariaLabel={ariaLabel} icon={icon} label={label} open={open} />
       </Popover.Trigger>
       <Popover.Portal>
         <Popover.Content

--- a/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-controls.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-controls.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+import * as React from 'react';
+
+import cx from 'classnames';
+
+export function RecordingCircleButton({
+  ariaLabel,
+  title,
+  onClick,
+  disabled,
+  active = false,
+  className,
+  children,
+}: {
+  ariaLabel: string;
+  title: string;
+  onClick: () => void;
+  disabled?: boolean;
+  active?: boolean;
+  className?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={ariaLabel}
+      title={title}
+      onClick={onClick}
+      disabled={disabled}
+      className={cx(
+        'grid size-10 place-items-center rounded-full border border-grey-02 bg-white text-text shadow-light transition disabled:opacity-50',
+        active && 'bg-bg',
+        className
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
+export function LeaveIcon() {
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden="true" className="size-4" fill="none" stroke="currentColor" strokeWidth="2">
+      <path d="M9 7V5a2 2 0 0 1 2-2h7v18h-7a2 2 0 0 1-2-2v-2" />
+      <path d="M13 12H3" />
+      <path d="M6 9l-3 3 3 3" />
+    </svg>
+  );
+}
+
+export function CloseIcon() {
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden="true" className="size-4" fill="none" stroke="currentColor" strokeWidth="2">
+      <path d="M6 6l12 12M18 6 6 18" />
+    </svg>
+  );
+}
+
+export function MicrophoneIcon({ muted }: { muted: boolean }) {
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden="true" className="size-4" fill="none" stroke="currentColor" strokeWidth="2">
+      <path d="M12 14a4 4 0 0 0 4-4V6a4 4 0 1 0-8 0v4a4 4 0 0 0 4 4Z" />
+      <path d="M5 10a7 7 0 0 0 14 0" />
+      <path d="M12 17v4" />
+      <path d="M9 21h6" />
+      {muted && <path d="M4 4l16 16" />}
+    </svg>
+  );
+}
+
+export function MutedMicrophoneIndicator() {
+  return (
+    <svg
+      width="45"
+      height="45"
+      viewBox="0 0 45 45"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+      data-muted-indicator="true"
+      className="size-[45px]"
+    >
+      <rect width="45" height="44.9989" rx="22.4994" fill="white" />
+      <rect x="17.6431" y="12.2852" width="9.71429" height="17.75" rx="4.85714" stroke="#151515" />
+      <path
+        d="M14.4644 24.1055V25.1769C14.4644 29.6149 18.0621 33.2126 22.5001 33.2126C26.9381 33.2126 30.5358 29.6149 30.5358 25.1769V24.1055"
+        stroke="#151515"
+        strokeLinecap="round"
+      />
+      <path d="M27.3216 16.6094L17.6787 25.7165" stroke="#151515" />
+    </svg>
+  );
+}
+
+export function CameraIcon({ disabled }: { disabled: boolean }) {
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden="true" className="size-4" fill="none" stroke="currentColor" strokeWidth="2">
+      <path d="M4 7h10a2 2 0 0 1 2 2v6a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V9a2 2 0 0 1 2-2Z" />
+      <path d="M16 10l5-3v10l-5-3" />
+      {disabled && <path d="M3 3l18 18" />}
+    </svg>
+  );
+}
+
+export function SpeakerIcon({ disabled }: { disabled: boolean }) {
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden="true" className="size-4" fill="none" stroke="currentColor" strokeWidth="2">
+      <path d="M4 9v6h4l5 4V5L8 9H4Z" />
+      <path d="M16 9.5a4 4 0 0 1 0 5" />
+      <path d="M19 7a8 8 0 0 1 0 10" />
+      {disabled && <path d="M3 3l18 18" />}
+    </svg>
+  );
+}

--- a/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
@@ -351,8 +351,12 @@ describe('DebateRoomPageClient', () => {
     render(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
 
     const audioTrigger = await screen.findByRole('button', { name: 'Audio settings' });
+    expect(audioTrigger).toHaveAttribute('data-state', 'closed');
     fireEvent.click(audioTrigger);
-    expect(screen.getByRole('dialog', { name: 'Audio settings' })).toHaveAttribute('data-side', 'top');
+    const audioSettings = screen.getByRole('dialog', { name: 'Audio settings' });
+    expect(audioSettings).toHaveAttribute('data-side', 'top');
+    expect(audioTrigger).toHaveAttribute('data-state', 'open');
+    expect(audioTrigger).toHaveAttribute('aria-controls', audioSettings.id);
     expect(screen.getByText('Select a microphone')).toBeInTheDocument();
     expect(screen.getByText('Select a speaker')).toBeInTheDocument();
 
@@ -551,6 +555,22 @@ describe('DebateRoomPageClient', () => {
     const settings = screen.getByRole('dialog', { name: 'Audio settings' });
 
     fireEvent.keyDown(settings, { key: 'Escape' });
+
+    await waitFor(() => expect(screen.queryByRole('dialog', { name: 'Audio settings' })).not.toBeInTheDocument());
+    expect(trigger).toHaveFocus();
+  });
+
+  it('closes desktop settings on outside click and returns focus to the trigger', async () => {
+    mocks.debate = readyDebate({ localReady: false, remoteReady: false });
+
+    render(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
+    const trigger = await screen.findByRole('button', { name: 'Audio settings' });
+    fireEvent.click(trigger);
+    expect(screen.getByRole('dialog', { name: 'Audio settings' })).toBeInTheDocument();
+    await act(() => new Promise(resolve => window.setTimeout(resolve, 0)));
+
+    fireEvent.pointerDown(document.body, { button: 0, pointerType: 'mouse' });
+    fireEvent.click(document.body);
 
     await waitFor(() => expect(screen.queryByRole('dialog', { name: 'Audio settings' })).not.toBeInTheDocument());
     expect(trigger).toHaveFocus();

--- a/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
@@ -355,6 +355,7 @@ describe('DebateRoomPageClient', () => {
     fireEvent.click(audioTrigger);
     const audioSettings = screen.getByRole('dialog', { name: 'Audio settings' });
     expect(audioSettings).toHaveAttribute('data-side', 'top');
+    expect(audioSettings.closest('[data-radix-popper-content-wrapper]')?.parentElement).toHaveClass('elevated-popover');
     expect(audioTrigger).toHaveAttribute('data-state', 'open');
     expect(audioTrigger).toHaveAttribute('aria-controls', audioSettings.id);
     expect(screen.getByText('Select a microphone')).toBeInTheDocument();

--- a/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
@@ -31,8 +31,12 @@ const mocks = vi.hoisted(() => ({
   krispIsEnabled: vi.fn(),
   krispDestroy: vi.fn(),
   roomConnect: vi.fn(),
+  roomConstruct: vi.fn(),
   roomDisconnect: vi.fn(),
   publishTrack: vi.fn(),
+  supportsAudioOutputSelection: vi.fn(),
+  selectAudioOutput: vi.fn(),
+  enumerateDevices: vi.fn(),
   getServerTime: vi.fn(),
   refetchDebate: vi.fn(),
   clearTimedOutDebateActivity: vi.fn(),
@@ -42,6 +46,7 @@ const mocks = vi.hoisted(() => ({
   ownershipRelease: vi.fn(),
   ownershipClose: vi.fn(),
   ownershipTakeoverHandler: null as null | (() => boolean | Promise<boolean>),
+  deviceChangeHandler: null as null | (() => void),
   debate: null as Debate | null,
   rematch: null as DebateRematchSession | null,
   featureFlags: {
@@ -109,6 +114,10 @@ vi.mock('~/core/debates/debate-room-ownership', () => ({
 vi.mock('livekit-client', () => ({
   createLocalTracks: mocks.createLocalTracks,
   Room: class {
+    constructor(options: unknown) {
+      mocks.roomConstruct(options);
+    }
+
     localParticipant = {
       publishTrack: mocks.publishTrack,
     };
@@ -117,6 +126,7 @@ vi.mock('livekit-client', () => ({
     connect = mocks.roomConnect;
     disconnect = mocks.roomDisconnect;
   },
+  supportsAudioOutputSelection: mocks.supportsAudioOutputSelection,
   RoomEvent: {
     TrackSubscribed: 'trackSubscribed',
     TrackUnsubscribed: 'trackUnsubscribed',
@@ -164,8 +174,27 @@ beforeEach(() => {
   mocks.krispIsEnabled.mockReset().mockReturnValue(true);
   mocks.krispDestroy.mockReset().mockResolvedValue(undefined);
   mocks.roomConnect.mockReset();
+  mocks.roomConstruct.mockReset();
   mocks.roomDisconnect.mockReset();
   mocks.publishTrack.mockReset();
+  mocks.supportsAudioOutputSelection.mockReset().mockReturnValue(true);
+  mocks.selectAudioOutput.mockReset().mockImplementation(({ deviceId }: { deviceId: string }) =>
+    Promise.resolve({
+      kind: 'audiooutput',
+      deviceId,
+      groupId: 'speaker-group',
+      label: deviceId === 'speaker-2' ? 'Studio Speakers' : 'System default',
+      toJSON: () => ({}),
+    })
+  );
+  mocks.enumerateDevices.mockReset().mockResolvedValue([
+    { kind: 'audioinput', deviceId: 'mic-1', groupId: 'mic-group-1', label: 'Shure MV7+' },
+    { kind: 'audioinput', deviceId: 'mic-2', groupId: 'mic-group-2', label: 'Studio Mic' },
+    { kind: 'audiooutput', deviceId: 'default', groupId: 'speaker-group-1', label: 'System default' },
+    { kind: 'audiooutput', deviceId: 'speaker-2', groupId: 'speaker-group-2', label: 'Studio Speakers' },
+    { kind: 'videoinput', deviceId: 'camera-1', groupId: 'camera-group-1', label: 'HD Pro Webcam' },
+    { kind: 'videoinput', deviceId: 'camera-2', groupId: 'camera-group-2', label: 'Desk Camera' },
+  ]);
   mocks.getServerTime.mockReset();
   mocks.refetchDebate.mockReset();
   mocks.clearTimedOutDebateActivity.mockReset();
@@ -175,6 +204,7 @@ beforeEach(() => {
   mocks.ownershipRelease.mockReset();
   mocks.ownershipClose.mockReset();
   mocks.ownershipTakeoverHandler = null;
+  mocks.deviceChangeHandler = null;
   mocks.debate = completedDebate();
   mocks.rematch = null;
   mocks.featureFlags = {
@@ -231,14 +261,17 @@ beforeEach(() => {
     configurable: true,
     value: {
       getUserMedia: vi.fn().mockResolvedValue(new MediaStream()),
-      enumerateDevices: vi.fn().mockResolvedValue([
-        { kind: 'audioinput', deviceId: 'mic-1', label: 'Shure MV7+' },
-        { kind: 'audioinput', deviceId: 'mic-2', label: 'Studio Mic' },
-        { kind: 'videoinput', deviceId: 'camera-1', label: 'HD Pro Webcam' },
-        { kind: 'videoinput', deviceId: 'camera-2', label: 'Desk Camera' },
-      ]),
+      enumerateDevices: mocks.enumerateDevices,
+      selectAudioOutput: mocks.selectAudioOutput,
+      addEventListener: vi.fn((event: string, handler: () => void) => {
+        if (event === 'devicechange') mocks.deviceChangeHandler = handler;
+      }),
+      removeEventListener: vi.fn((event: string, handler: () => void) => {
+        if (event === 'devicechange' && mocks.deviceChangeHandler === handler) mocks.deviceChangeHandler = null;
+      }),
     },
   });
+  setMobileLayout(false);
   Object.defineProperty(HTMLMediaElement.prototype, 'play', {
     configurable: true,
     value: vi.fn().mockResolvedValue(undefined),
@@ -262,7 +295,7 @@ describe('DebateRoomPageClient', () => {
     expect(screen.getByText('Debate')).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'The protocol should ship debates' })).toBeInTheDocument();
     expect(screen.getByText('Bri')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Accept' })).toBeInTheDocument();
+    expect(await screen.findByRole('button', { name: 'Accept' })).toBeInTheDocument();
     expect(screen.getByText('Waiting...')).toBeInTheDocument();
     expect(screen.queryByText('Not ready')).not.toBeInTheDocument();
     expect(screen.queryByText('VS')).not.toBeInTheDocument();
@@ -274,17 +307,28 @@ describe('DebateRoomPageClient', () => {
     expect(mocks.liveKitJoinMutateAsync).not.toHaveBeenCalled();
   });
 
-  it('starts the camera preview after the Strict Mode effect rehearsal', async () => {
+  it('blocks readiness while the combined camera and microphone request is pending', async () => {
+    const pendingTracks =
+      deferred<
+        Array<ReturnType<typeof createLocalAudioTrack> | { mediaStreamTrack: { kind: string }; stop: () => void }>
+      >();
+    mocks.createLocalTracks.mockReturnValue(pendingTracks.promise);
     mocks.debate = readyDebate({ localReady: false, remoteReady: false });
 
-    render(
-      <StrictMode>
-        <DebateRoomPageClient spaceId="space-1" debateId="debate-1" />
-      </StrictMode>
-    );
+    render(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
 
-    await waitFor(() => expect(screen.queryByText('Starting camera...')).not.toBeInTheDocument());
-    expect(document.querySelector('video')?.srcObject).toBeInstanceOf(MediaStream);
+    await waitFor(() =>
+      expect(mocks.createLocalTracks).toHaveBeenCalledWith({
+        audio: true,
+        video: true,
+      })
+    );
+    expect(screen.getByText('Requesting access to your camera and microphone…')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Accept' })).not.toBeInTheDocument();
+
+    pendingTracks.resolve([createLocalAudioTrack(), { mediaStreamTrack: { kind: 'video' }, stop: vi.fn() }]);
+
+    expect(await screen.findByRole('button', { name: 'Accept' })).toBeEnabled();
   });
 
   it('locks background scrolling while the pre-screen modal is open', () => {
@@ -301,18 +345,18 @@ describe('DebateRoomPageClient', () => {
     expect(document.documentElement.style.overflow).toBe('');
   });
 
-  it('lets participants choose microphone and camera devices from the pre-screen', async () => {
+  it('lets participants choose microphone and camera devices from desktop settings menus', async () => {
     mocks.debate = readyDebate({ localReady: false, remoteReady: false });
 
     render(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
 
-    await waitFor(() => {
-      expect(screen.getByRole('combobox', { name: 'Select microphone' })).toHaveValue('mic-1');
-    });
-    expect(screen.getByRole('combobox', { name: 'Select camera' })).toHaveValue('camera-1');
+    const audioTrigger = await screen.findByRole('button', { name: 'Audio settings' });
+    fireEvent.click(audioTrigger);
+    expect(screen.getByRole('dialog', { name: 'Audio settings' })).toHaveAttribute('data-side', 'top');
+    expect(screen.getByText('Select a microphone')).toBeInTheDocument();
+    expect(screen.getByText('Select a speaker')).toBeInTheDocument();
 
-    fireEvent.change(screen.getByRole('combobox', { name: 'Select microphone' }), { target: { value: 'mic-2' } });
-    fireEvent.change(screen.getByRole('combobox', { name: 'Select camera' }), { target: { value: 'camera-2' } });
+    fireEvent.click(screen.getByRole('radio', { name: 'Studio Mic' }));
 
     await waitFor(() => {
       expect(mocks.createLocalTracks).toHaveBeenCalledWith({
@@ -320,6 +364,13 @@ describe('DebateRoomPageClient', () => {
         video: { deviceId: 'camera-1' },
       });
     });
+    expect(screen.getByRole('dialog', { name: 'Audio settings' })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Video settings' }));
+    expect(screen.queryByRole('dialog', { name: 'Audio settings' })).not.toBeInTheDocument();
+    expect(screen.getByRole('dialog', { name: 'Video settings' })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('radio', { name: 'Desk Camera' }));
+
     await waitFor(() => {
       expect(mocks.createLocalTracks).toHaveBeenCalledWith({
         audio: { deviceId: 'mic-2' },
@@ -328,22 +379,361 @@ describe('DebateRoomPageClient', () => {
     });
   });
 
-  it('shows the opponent as ready while the local participant can still become ready', () => {
+  it('shows the designed permission recovery state and retries access', async () => {
+    mocks.debate = readyDebate({ localReady: false, remoteReady: false });
+    mocks.createLocalTracks.mockRejectedValueOnce(
+      Object.assign(new Error('Permission denied by system policy'), { name: 'NotAllowedError' })
+    );
+
+    render(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
+
+    expect(await screen.findByText('Allow access to your camera and microphone to continue.')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Accept' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Audio settings' })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Allow access' }));
+
+    expect(await screen.findByRole('button', { name: 'Accept' })).toBeEnabled();
+    expect(mocks.createLocalTracks).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps readiness blocked when either required input is unavailable', async () => {
+    mocks.debate = readyDebate({ localReady: false, remoteReady: false });
+    mocks.createLocalTracks.mockResolvedValueOnce([createLocalAudioTrack()]);
+
+    render(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
+
+    expect(await screen.findByText('Connect a camera and microphone, then try again.')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Try again' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Accept' })).not.toBeInTheDocument();
+  });
+
+  it('cleans up acquired tracks when device enumeration fails', async () => {
+    mocks.debate = readyDebate({ localReady: false, remoteReady: false });
+    const audioTrack = createLocalAudioTrack();
+    const videoTrack = {
+      mediaStreamTrack: { kind: 'video', enabled: true },
+      stop: vi.fn(),
+      detach: vi.fn(),
+    };
+    mocks.createLocalTracks.mockResolvedValueOnce([audioTrack, videoTrack]);
+    mocks.enumerateDevices.mockRejectedValueOnce(new Error('Device enumeration failed'));
+
+    render(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
+
+    expect(
+      await screen.findByText('We could not start your camera and microphone. Check your devices and try again.')
+    ).toBeInTheDocument();
+    expect(audioTrack.stop).toHaveBeenCalled();
+    expect(videoTrack.stop).toHaveBeenCalled();
+    expect(screen.queryByRole('button', { name: 'Accept' })).not.toBeInTheDocument();
+  });
+
+  it('changes speaker output without restarting capture and hands the selection to LiveKit', async () => {
+    mocks.debate = readyDebate({ localReady: false, remoteReady: false });
+    const selectedOutput = deferred<MediaDeviceInfo>();
+    mocks.selectAudioOutput.mockReturnValueOnce(selectedOutput.promise);
+
+    const view = render(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
+    fireEvent.click(await screen.findByRole('button', { name: 'Audio settings' }));
+    await waitFor(() => expect(mocks.createLocalTracks).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(screen.getByRole('radio', { name: 'Studio Speakers' }));
+    await waitFor(() => expect(mocks.selectAudioOutput).toHaveBeenCalledWith({ deviceId: 'speaker-2' }));
+    expect(mocks.createLocalTracks).toHaveBeenCalledTimes(1);
+
+    mocks.debate = {
+      ...readyDebate({ localReady: true, remoteReady: true }),
+      status: 'connecting',
+      connecting_started_at: '2099-07-02T00:00:00.000Z',
+      connecting_deadline_at: '2099-07-02T00:00:10.000Z',
+    };
+    view.rerender(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
+    await waitFor(() => expect(mocks.liveKitJoinMutateAsync).toHaveBeenCalled());
+    expect(mocks.roomConstruct).not.toHaveBeenCalled();
+
+    act(() =>
+      selectedOutput.resolve({
+        kind: 'audiooutput',
+        deviceId: 'speaker-2',
+        groupId: 'speaker-group-2',
+        label: 'Studio Speakers',
+        toJSON: () => ({}),
+      })
+    );
+
+    await waitFor(() =>
+      expect(mocks.roomConstruct).toHaveBeenCalledWith({
+        adaptiveStream: false,
+        dynacast: false,
+        audioOutput: { deviceId: 'speaker-2' },
+      })
+    );
+  });
+
+  it('falls back to a non-editable System default when speaker routing is unsupported', async () => {
+    mocks.debate = readyDebate({ localReady: false, remoteReady: false });
+    mocks.supportsAudioOutputSelection.mockReturnValue(false);
+
+    render(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
+    fireEvent.click(await screen.findByRole('button', { name: 'Audio settings' }));
+
+    expect(screen.getByRole('radio', { name: 'System default' })).toBeChecked();
+    expect(screen.getByRole('radio', { name: 'System default' })).toBeDisabled();
+    expect(screen.queryByRole('radio', { name: 'Studio Speakers' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Accept' })).toBeEnabled();
+  });
+
+  it('falls back to System default when speaker authorization is rejected', async () => {
+    mocks.debate = readyDebate({ localReady: false, remoteReady: false });
+    mocks.selectAudioOutput.mockRejectedValueOnce(Object.assign(new Error('Not allowed'), { name: 'NotAllowedError' }));
+
+    render(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
+    fireEvent.click(await screen.findByRole('button', { name: 'Audio settings' }));
+    await waitFor(() => expect(mocks.createLocalTracks).toHaveBeenCalledTimes(1));
+    fireEvent.click(screen.getByRole('radio', { name: 'Studio Speakers' }));
+
+    await waitFor(() => expect(screen.getByRole('radio', { name: 'System default' })).toBeDisabled());
+    expect(screen.getByRole('radio', { name: 'System default' })).toBeChecked();
+    expect(screen.getByText('This browser could not route audio to that speaker. Using System default.')).toBeVisible();
+    expect(mocks.createLocalTracks).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole('radio', { name: 'Studio Mic' }));
+    await waitFor(() => expect(mocks.createLocalTracks).toHaveBeenCalledTimes(2));
+    expect(screen.getByRole('radio', { name: 'System default' })).toBeDisabled();
+    expect(screen.queryByRole('radio', { name: 'Studio Speakers' })).not.toBeInTheDocument();
+  });
+
+  it('ignores an older speaker authorization that finishes after the latest choice', async () => {
+    mocks.debate = readyDebate({ localReady: false, remoteReady: false });
+    mocks.enumerateDevices.mockResolvedValue([
+      { kind: 'audioinput', deviceId: 'mic-1', groupId: 'mic-group-1', label: 'Shure MV7+' },
+      { kind: 'audiooutput', deviceId: 'default', groupId: 'speaker-group-1', label: 'System default' },
+      { kind: 'audiooutput', deviceId: 'speaker-2', groupId: 'speaker-group-2', label: 'Studio Speakers' },
+      { kind: 'audiooutput', deviceId: 'speaker-3', groupId: 'speaker-group-3', label: 'Display Speakers' },
+      { kind: 'videoinput', deviceId: 'camera-1', groupId: 'camera-group-1', label: 'HD Pro Webcam' },
+    ]);
+    const olderSelection = deferred<MediaDeviceInfo>();
+    const latestSelection = deferred<MediaDeviceInfo>();
+    mocks.selectAudioOutput.mockImplementation(({ deviceId }: { deviceId: string }) =>
+      deviceId === 'speaker-2' ? olderSelection.promise : latestSelection.promise
+    );
+
+    render(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
+    fireEvent.click(await screen.findByRole('button', { name: 'Audio settings' }));
+    fireEvent.click(screen.getByRole('radio', { name: 'Studio Speakers' }));
+    fireEvent.click(screen.getByRole('radio', { name: 'Display Speakers' }));
+
+    act(() =>
+      latestSelection.resolve({
+        kind: 'audiooutput',
+        deviceId: 'speaker-3',
+        groupId: 'speaker-group-3',
+        label: 'Display Speakers',
+        toJSON: () => ({}),
+      })
+    );
+    await waitFor(() => expect(screen.getByRole('radio', { name: 'Display Speakers' })).toBeChecked());
+
+    act(() => olderSelection.reject(Object.assign(new Error('Not allowed'), { name: 'NotAllowedError' })));
+
+    await waitFor(() => expect(screen.getByRole('radio', { name: 'Display Speakers' })).toBeChecked());
+    expect(screen.queryByText(/could not route audio/i)).not.toBeInTheDocument();
+  });
+
+  it('closes desktop settings with Escape and returns focus to the trigger', async () => {
+    mocks.debate = readyDebate({ localReady: false, remoteReady: false });
+
+    render(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
+    const trigger = await screen.findByRole('button', { name: 'Audio settings' });
+    trigger.focus();
+    fireEvent.click(trigger);
+    const settings = screen.getByRole('dialog', { name: 'Audio settings' });
+
+    fireEvent.keyDown(settings, { key: 'Escape' });
+
+    await waitFor(() => expect(screen.queryByRole('dialog', { name: 'Audio settings' })).not.toBeInTheDocument());
+    expect(trigger).toHaveFocus();
+  });
+
+  it('toggles desktop settings closed from the active trigger', async () => {
+    mocks.debate = readyDebate({ localReady: false, remoteReady: false });
+
+    render(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
+    const trigger = await screen.findByRole('button', { name: 'Audio settings' });
+    fireEvent.click(trigger);
+    expect(screen.getByRole('dialog', { name: 'Audio settings' })).toBeInTheDocument();
+
+    fireEvent.click(trigger);
+
+    await waitFor(() => expect(screen.queryByRole('dialog', { name: 'Audio settings' })).not.toBeInTheDocument());
+  });
+
+  it('supports keyboard device selection without closing the desktop menu', async () => {
+    mocks.debate = readyDebate({ localReady: false, remoteReady: false });
+
+    render(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
+    fireEvent.click(await screen.findByRole('button', { name: 'Video settings' }));
+    const selectedCamera = screen.getByRole('radio', { name: 'HD Pro Webcam' });
+    selectedCamera.focus();
+
+    fireEvent.keyDown(selectedCamera, { key: 'ArrowDown' });
+
+    await waitFor(() =>
+      expect(mocks.createLocalTracks).toHaveBeenCalledWith({
+        audio: { deviceId: 'mic-1' },
+        video: { deviceId: 'camera-2' },
+      })
+    );
+    expect(screen.getByRole('dialog', { name: 'Video settings' })).toBeInTheDocument();
+  });
+
+  it('keeps the desktop menu open while a selected input is restarting', async () => {
+    mocks.debate = readyDebate({ localReady: false, remoteReady: false });
+
+    render(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
+    fireEvent.click(await screen.findByRole('button', { name: 'Audio settings' }));
+    const pendingTracks =
+      deferred<
+        Array<ReturnType<typeof createLocalAudioTrack> | { mediaStreamTrack: { kind: string }; stop: () => void }>
+      >();
+    mocks.createLocalTracks.mockReturnValueOnce(pendingTracks.promise);
+
+    fireEvent.click(screen.getByRole('radio', { name: 'Studio Mic' }));
+
+    expect(screen.getByRole('dialog', { name: 'Audio settings' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Accept' })).toBeDisabled();
+
+    pendingTracks.resolve([createLocalAudioTrack(), { mediaStreamTrack: { kind: 'video' }, stop: vi.fn() }]);
+    await waitFor(() => expect(screen.getByRole('radio', { name: 'Studio Mic' })).toBeChecked());
+    expect(screen.getByRole('button', { name: 'Accept' })).toBeEnabled();
+  });
+
+  it('opens mobile video settings as a bottom sheet using the existing preview stream', async () => {
+    mocks.debate = readyDebate({ localReady: false, remoteReady: false });
+    setMobileLayout(true);
+
+    render(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
+    fireEvent.click(await screen.findByRole('button', { name: 'Video settings' }));
+
+    expect(screen.getByRole('dialog', { name: 'Video settings' })).toHaveAttribute('data-layout', 'bottom-sheet');
+    const videos = document.querySelectorAll('video');
+    expect(videos).toHaveLength(2);
+    expect(videos[0]?.srcObject).toBe(videos[1]?.srcObject);
+    expect(mocks.createLocalTracks).toHaveBeenCalledTimes(1);
+  });
+
+  it('opens mobile audio settings with microphone and speaker groups', async () => {
+    mocks.debate = readyDebate({ localReady: false, remoteReady: false });
+    setMobileLayout(true);
+
+    render(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
+    fireEvent.click(await screen.findByRole('button', { name: 'Audio settings' }));
+
+    expect(screen.getByRole('dialog', { name: 'Audio settings' })).toHaveAttribute('data-layout', 'bottom-sheet');
+    expect(screen.getByText('Select a microphone')).toBeInTheDocument();
+    expect(screen.getByText('Select a speaker')).toBeInTheDocument();
+  });
+
+  it('returns focus to the mobile settings trigger after closing the sheet', async () => {
+    mocks.debate = readyDebate({ localReady: false, remoteReady: false });
+    setMobileLayout(true);
+
+    render(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
+    const trigger = await screen.findByRole('button', { name: 'Audio settings' });
+    fireEvent.click(trigger);
+    expect(screen.getByRole('dialog', { name: 'Audio settings' })).toHaveAttribute('data-layout', 'bottom-sheet');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close Audio settings' }));
+
+    await waitFor(() => expect(screen.queryByRole('dialog', { name: 'Audio settings' })).not.toBeInTheDocument());
+    expect(trigger).toHaveFocus();
+  });
+
+  it('preserves valid device selections and restarts capture when a selected device is removed', async () => {
+    mocks.debate = readyDebate({ localReady: false, remoteReady: false });
+
+    render(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
+    fireEvent.click(await screen.findByRole('button', { name: 'Audio settings' }));
+    fireEvent.click(screen.getByRole('radio', { name: 'Studio Mic' }));
+    await waitFor(() =>
+      expect(mocks.createLocalTracks).toHaveBeenCalledWith({
+        audio: { deviceId: 'mic-2' },
+        video: { deviceId: 'camera-1' },
+      })
+    );
+    const callCountWithValidSelection = mocks.createLocalTracks.mock.calls.length;
+
+    act(() => mocks.deviceChangeHandler?.());
+    await waitFor(() => expect(mocks.enumerateDevices).toHaveBeenCalled());
+    expect(mocks.createLocalTracks).toHaveBeenCalledTimes(callCountWithValidSelection);
+
+    mocks.enumerateDevices.mockResolvedValue([
+      { kind: 'audioinput', deviceId: 'mic-1', groupId: 'mic-group-1', label: 'Shure MV7+' },
+      { kind: 'audiooutput', deviceId: 'default', groupId: 'speaker-group-1', label: 'System default' },
+      { kind: 'videoinput', deviceId: 'camera-1', groupId: 'camera-group-1', label: 'HD Pro Webcam' },
+      { kind: 'videoinput', deviceId: 'camera-2', groupId: 'camera-group-2', label: 'Desk Camera' },
+    ]);
+    act(() => mocks.deviceChangeHandler?.());
+
+    await waitFor(() =>
+      expect(mocks.createLocalTracks).toHaveBeenCalledWith({
+        audio: { deviceId: 'mic-1' },
+        video: { deviceId: 'camera-1' },
+      })
+    );
+  });
+
+  it('ignores stale device enumeration results during rapid hardware changes', async () => {
+    mocks.debate = readyDebate({ localReady: false, remoteReady: false });
+
+    render(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
+    await screen.findByRole('button', { name: 'Accept' });
+    const olderEnumeration = deferred<MediaDeviceInfo[]>();
+    mocks.enumerateDevices.mockReturnValueOnce(olderEnumeration.promise).mockResolvedValueOnce([
+      { kind: 'audioinput', deviceId: 'mic-2', groupId: 'mic-group-2', label: 'Studio Mic' },
+      { kind: 'audiooutput', deviceId: 'default', groupId: 'speaker-group-1', label: 'System default' },
+      { kind: 'videoinput', deviceId: 'camera-1', groupId: 'camera-group-1', label: 'HD Pro Webcam' },
+    ]);
+
+    act(() => mocks.deviceChangeHandler?.());
+    act(() => mocks.deviceChangeHandler?.());
+
+    await waitFor(() =>
+      expect(mocks.createLocalTracks).toHaveBeenCalledWith({
+        audio: { deviceId: 'mic-2' },
+        video: { deviceId: 'camera-1' },
+      })
+    );
+
+    act(() =>
+      olderEnumeration.resolve([
+        { kind: 'audioinput', deviceId: 'mic-1', groupId: 'mic-group-1', label: 'Shure MV7+' },
+        { kind: 'audiooutput', deviceId: 'default', groupId: 'speaker-group-1', label: 'System default' },
+        { kind: 'videoinput', deviceId: 'camera-1', groupId: 'camera-group-1', label: 'HD Pro Webcam' },
+      ] as MediaDeviceInfo[])
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Audio settings' }));
+    await waitFor(() => expect(screen.getByRole('radio', { name: 'Studio Mic' })).toBeChecked());
+  });
+
+  it('shows the opponent as ready while the local participant can still become ready', async () => {
     mocks.debate = readyDebate({ localReady: false, remoteReady: true });
 
     render(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
 
     expect(screen.getByText('Bri')).toBeInTheDocument();
     expect(screen.getByText('Ready')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Accept' })).toBeEnabled();
+    expect(await screen.findByRole('button', { name: 'Accept' })).toBeEnabled();
   });
 
-  it('disables the ready button while waiting for the opponent', () => {
+  it('disables the ready button while waiting for the opponent', async () => {
     mocks.debate = readyDebate({ localReady: true, remoteReady: false });
 
     render(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
 
-    expect(screen.getByRole('button', { name: 'Waiting...' })).toBeDisabled();
+    expect(await screen.findByRole('button', { name: 'Waiting...' })).toBeDisabled();
     expect(screen.getAllByText('Waiting...')).toHaveLength(2);
   });
 
@@ -352,7 +742,7 @@ describe('DebateRoomPageClient', () => {
 
     render(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Accept' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Accept' }));
 
     await waitFor(() => {
       expect(mocks.readyMutateAsync).toHaveBeenCalled();
@@ -1012,12 +1402,8 @@ describe('DebateRoomPageClient', () => {
     const newEnabling = deferred<void>();
     const firstAudioTrack = createLocalAudioTrack();
     const retriedAudioTrack = createLocalAudioTrack();
-    const oldSetEnabled = vi.fn((enabled: boolean) =>
-      enabled ? Promise.resolve(undefined) : oldDisabling.promise
-    );
-    const newSetEnabled = vi.fn((enabled: boolean) =>
-      enabled ? newEnabling.promise : Promise.resolve(undefined)
-    );
+    const oldSetEnabled = vi.fn((enabled: boolean) => (enabled ? Promise.resolve(undefined) : oldDisabling.promise));
+    const newSetEnabled = vi.fn((enabled: boolean) => (enabled ? newEnabling.promise : Promise.resolve(undefined)));
     mocks.krispNoiseFilter
       .mockReturnValueOnce({
         processedTrack: { kind: 'audio', enabled: true, id: 'old-krisp-audio' },
@@ -1817,10 +2203,28 @@ function createLocalAudioTrack() {
 
 function deferred<T>() {
   let resolve!: (value: T | PromiseLike<T>) => void;
-  const promise = new Promise<T>(resolvePromise => {
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
     resolve = resolvePromise;
+    reject = rejectPromise;
   });
-  return { promise, resolve };
+  return { promise, resolve, reject };
+}
+
+function setMobileLayout(matches: boolean) {
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn().mockImplementation((query: string) => ({
+      matches: query === '(max-width: 767px)' ? matches : false,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }))
+  );
 }
 
 function completedDebate(): Debate {

--- a/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.tsx
@@ -42,11 +42,24 @@ import {
 import { createLocalServerClock, synchronizeServerClock } from '~/core/debates/server-clock';
 import { useDebatesEnabled, useFeatureFlag } from '~/core/state/feature-flags';
 
-import { Avatar } from '~/design-system/avatar';
 import { Button } from '~/design-system/button';
 import { Check } from '~/design-system/icons/check';
-import { ChevronDownSmall } from '~/design-system/icons/chevron-down-small';
 import { Text } from '~/design-system/text';
+
+import {
+  DebatePreScreen,
+  type MediaDeviceOption,
+  type PreJoinMediaState,
+  systemDefaultAudioOutput,
+} from './debate-pre-join-screen';
+import {
+  CameraIcon,
+  LeaveIcon,
+  MicrophoneIcon,
+  MutedMicrophoneIndicator,
+  RecordingCircleButton,
+  SpeakerIcon,
+} from './debate-room-controls';
 
 type DebateRoomPageClientProps = {
   spaceId: string;
@@ -69,11 +82,6 @@ const debateNoiseFilterStatusLabel: Record<DebateNoiseFilterStatus, string> = {
   disabled: 'Off',
   unsupported: 'Unavailable',
   failed: 'Failed',
-};
-
-type MediaDeviceOption = {
-  deviceId: string;
-  label: string;
 };
 
 type RemoteTrackLike = {
@@ -159,8 +167,10 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
   const [roomError, setRoomError] = React.useState<string | null>(null);
   const [connectionConflict, setConnectionConflict] = React.useState(false);
   const [remoteVideoReady, setRemoteVideoReady] = React.useState(false);
-  const [previewState, setPreviewState] = React.useState<'idle' | 'starting' | 'ready'>('idle');
+  const [previewState, setPreviewState] = React.useState<PreJoinMediaState>('requesting');
+  const [previewBusy, setPreviewBusy] = React.useState(true);
   const [previewError, setPreviewError] = React.useState<string | null>(null);
+  const [previewStream, setPreviewStream] = React.useState<MediaStream | null>(null);
   const [rematchConsentRequested, setRematchConsentRequested] = React.useState(false);
   const [audioMuted, setAudioMuted] = React.useState(false);
   const [remoteAudioEnabled, setRemoteAudioEnabled] = React.useState(true);
@@ -168,19 +178,28 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
   const [serverClock, setServerClock] = React.useState(createLocalServerClock);
   const [serverClockSettled, setServerClockSettled] = React.useState(false);
   const [audioInputDevices, setAudioInputDevices] = React.useState<MediaDeviceOption[]>([]);
+  const [audioOutputDevices, setAudioOutputDevices] = React.useState<MediaDeviceOption[]>([systemDefaultAudioOutput]);
   const [videoInputDevices, setVideoInputDevices] = React.useState<MediaDeviceOption[]>([]);
   const [selectedAudioInputId, setSelectedAudioInputId] = React.useState('');
+  const [selectedAudioOutputId, setSelectedAudioOutputId] = React.useState(systemDefaultAudioOutput.deviceId);
   const [selectedVideoInputId, setSelectedVideoInputId] = React.useState('');
+  const [audioOutputSupported, setAudioOutputSupported] = React.useState(false);
+  const [audioOutputError, setAudioOutputError] = React.useState<string | null>(null);
   const [noiseFilterStatus, setNoiseFilterStatus] = React.useState<DebateNoiseFilterStatus>('initializing');
   const [noiseFilterTogglePending, setNoiseFilterTogglePending] = React.useState(false);
   const selectedAudioInputIdRef = React.useRef('');
+  const selectedAudioOutputIdRef = React.useRef(systemDefaultAudioOutput.deviceId);
   const selectedVideoInputIdRef = React.useRef('');
+  const audioOutputSupportedRef = React.useRef(false);
+  const audioOutputSelectionFailedRef = React.useRef(false);
   const noiseFilterProcessorRef = React.useRef<KrispNoiseFilterProcessor | null>(null);
   const noiseFilterEnabledRef = React.useRef(true);
   const noiseFilterTogglePendingRef = React.useRef(false);
   const sourceMediaStreamTracksRef = React.useRef(new WeakMap<LocalTrackLike, MediaStreamTrack>());
   const mountedRef = React.useRef(true);
   const previewGenerationRef = React.useRef(0);
+  const mediaDeviceRefreshGenerationRef = React.useRef(0);
+  const audioOutputSelectionGenerationRef = React.useRef(0);
   const connectionGenerationRef = React.useRef(0);
   const localVideoRef = React.useRef<HTMLVideoElement>(null);
   const remoteMediaRef = React.useRef<HTMLDivElement>(null);
@@ -192,6 +211,7 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
   const localTracksRef = React.useRef<LocalTrackLike[]>([]);
   const localMediaStreamRef = React.useRef<MediaStream | null>(null);
   const localPreviewPromiseRef = React.useRef<Promise<LocalTrackLike[]> | null>(null);
+  const audioOutputSelectionPromiseRef = React.useRef<Promise<void> | null>(null);
   const recorderRef = React.useRef<MediaRecorder | null>(null);
   const recordingChunksRef = React.useRef<Blob[]>([]);
   const recordingStartedAtRef = React.useRef<number | null>(null);
@@ -509,35 +529,56 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
 
   const refreshMediaDevices = React.useCallback(async () => {
     if (!navigator.mediaDevices?.enumerateDevices) return;
+    const generation = mediaDeviceRefreshGenerationRef.current + 1;
+    mediaDeviceRefreshGenerationRef.current = generation;
     const devices = await navigator.mediaDevices.enumerateDevices();
-    if (!mountedRef.current) return;
+    if (!mountedRef.current || mediaDeviceRefreshGenerationRef.current !== generation) return;
     const audioInputs = devices
       .filter(device => device.kind === 'audioinput')
       .map((device, index) => ({
         deviceId: device.deviceId,
+        groupId: device.groupId,
+        kind: 'audioinput' as const,
         label: device.label || `Microphone ${index + 1}`,
       }));
+    const audioOutputs = audioOutputSupportedRef.current
+      ? devices
+          .filter(device => device.kind === 'audiooutput')
+          .map((device, index) => ({
+            deviceId: device.deviceId,
+            groupId: device.groupId,
+            kind: 'audiooutput' as const,
+            label: device.label || `Speaker ${index + 1}`,
+          }))
+      : [systemDefaultAudioOutput];
     const videoInputs = devices
       .filter(device => device.kind === 'videoinput')
       .map((device, index) => ({
         deviceId: device.deviceId,
+        groupId: device.groupId,
+        kind: 'videoinput' as const,
         label: device.label || `Camera ${index + 1}`,
       }));
 
-    setAudioInputDevices(audioInputs);
-    setVideoInputDevices(videoInputs);
-    setSelectedAudioInputId(current => {
-      const next =
-        current && audioInputs.some(device => device.deviceId === current) ? current : (audioInputs[0]?.deviceId ?? '');
-      selectedAudioInputIdRef.current = next;
-      return next;
-    });
-    setSelectedVideoInputId(current => {
-      const next =
-        current && videoInputs.some(device => device.deviceId === current) ? current : (videoInputs[0]?.deviceId ?? '');
-      selectedVideoInputIdRef.current = next;
-      return next;
-    });
+    const availableOutputs = audioOutputs.length > 0 ? audioOutputs : [systemDefaultAudioOutput];
+    setAudioInputDevices(current => (sameMediaDeviceOptions(current, audioInputs) ? current : audioInputs));
+    setAudioOutputDevices(current => (sameMediaDeviceOptions(current, availableOutputs) ? current : availableOutputs));
+    setVideoInputDevices(current => (sameMediaDeviceOptions(current, videoInputs) ? current : videoInputs));
+    const nextAudioInputId = retainOrPreferDefaultDevice(selectedAudioInputIdRef.current, audioInputs);
+    const nextAudioOutputId = retainOrPreferDefaultDevice(selectedAudioOutputIdRef.current, availableOutputs);
+    const nextVideoInputId = retainOrPreferDefaultDevice(selectedVideoInputIdRef.current, videoInputs);
+
+    selectedAudioInputIdRef.current = nextAudioInputId;
+    selectedAudioOutputIdRef.current = nextAudioOutputId;
+    selectedVideoInputIdRef.current = nextVideoInputId;
+    setSelectedAudioInputId(nextAudioInputId);
+    setSelectedAudioOutputId(nextAudioOutputId);
+    setSelectedVideoInputId(nextVideoInputId);
+
+    return {
+      audioInputId: nextAudioInputId,
+      videoInputId: nextVideoInputId,
+    };
   }, []);
 
   const ensureLocalPreview = React.useCallback(
@@ -554,7 +595,9 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
           localVideoRef.current.muted = true;
           await localVideoRef.current.play().catch(() => undefined);
         }
+        setPreviewStream(localMediaStreamRef.current);
         setPreviewState('ready');
+        setPreviewBusy(false);
         return localTracksRef.current;
       }
       if (localPreviewPromiseRef.current) {
@@ -562,16 +605,31 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
         await localPreviewPromiseRef.current.catch(() => undefined);
       }
 
+      const replacingReadyPreview =
+        Boolean(options.forceRestart) && localTracksRef.current.length > 0 && localMediaStreamRef.current !== null;
       setPreviewError(null);
-      setPreviewState('starting');
+      setPreviewBusy(true);
+      if (!replacingReadyPreview) setPreviewState('requesting');
       const generation = previewGenerationRef.current + 1;
       previewGenerationRef.current = generation;
       const isCurrent = () => mountedRef.current && previewGenerationRef.current === generation;
       const previewPromise = (async () => {
         const livekit = await import('livekit-client');
         if (!isCurrent()) return [];
+        const supportsOutput =
+          !audioOutputSelectionFailedRef.current &&
+          typeof livekit.supportsAudioOutputSelection === 'function' &&
+          livekit.supportsAudioOutputSelection();
+        audioOutputSupportedRef.current = supportsOutput;
+        setAudioOutputSupported(supportsOutput);
+        if (!supportsOutput) {
+          selectedAudioOutputIdRef.current = systemDefaultAudioOutput.deviceId;
+          setSelectedAudioOutputId(systemDefaultAudioOutput.deviceId);
+          setAudioOutputDevices([systemDefaultAudioOutput]);
+        }
         stopLocalTracks(localTracksRef);
         localMediaStreamRef.current = null;
+        if (!replacingReadyPreview) setPreviewStream(null);
         const audioInputId = options.audioInputId ?? selectedAudioInputIdRef.current;
         const videoInputId = options.videoInputId ?? selectedVideoInputIdRef.current;
         const tracks = (await livekit.createLocalTracks({
@@ -582,6 +640,13 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
           stopTracks(tracks);
           return [];
         }
+        if (
+          !tracks.some(track => track.mediaStreamTrack.kind === 'audio') ||
+          !tracks.some(track => track.mediaStreamTrack.kind === 'video')
+        ) {
+          stopTracks(tracks);
+          throw Object.assign(new Error('Required media tracks are unavailable.'), { name: 'NotFoundError' });
+        }
         localTracksRef.current = tracks;
         setLocalTrackPreferences(tracks, {
           audioEnabled: shouldEnableLocalAudio(countdown.effectiveStatus, countdown.activeSlot, localSlot, audioMuted),
@@ -589,6 +654,7 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
         });
         const stream = new MediaStream(tracks.map(track => track.mediaStreamTrack));
         localMediaStreamRef.current = stream;
+        setPreviewStream(stream);
         if (localVideoRef.current) {
           localVideoRef.current.srcObject = stream;
           localVideoRef.current.muted = true;
@@ -598,9 +664,11 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
         if (!isCurrent()) {
           stopLocalTracks(localTracksRef);
           localMediaStreamRef.current = null;
+          setPreviewStream(null);
           return [];
         }
         setPreviewState('ready');
+        setPreviewBusy(false);
         return tracks;
       })();
       localPreviewPromiseRef.current = previewPromise;
@@ -608,8 +676,13 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
         return await previewPromise;
       } catch (error) {
         if (isCurrent()) {
-          setPreviewError(error instanceof Error ? error.message : 'Could not start your camera preview.');
-          setPreviewState('idle');
+          stopLocalTracks(localTracksRef);
+          localMediaStreamRef.current = null;
+          const failure = preJoinMediaFailure(error);
+          setPreviewError(failure.message);
+          setPreviewState(failure.state);
+          setPreviewBusy(false);
+          setPreviewStream(null);
         }
         throw error;
       } finally {
@@ -646,6 +719,58 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
     },
     [ensureLocalPreview]
   );
+
+  const changeAudioOutput = React.useCallback(async (deviceId: string) => {
+    if (!audioOutputSupportedRef.current) return;
+    const generation = audioOutputSelectionGenerationRef.current + 1;
+    audioOutputSelectionGenerationRef.current = generation;
+    setAudioOutputError(null);
+
+    const selectionPromise = (async () => {
+      const isCurrent = () => mountedRef.current && audioOutputSelectionGenerationRef.current === generation;
+      try {
+        let selectedId = deviceId;
+        const mediaDevices = navigator.mediaDevices as MediaDevices & {
+          selectAudioOutput?: (options: { deviceId: string }) => Promise<MediaDeviceInfo>;
+        };
+        if (deviceId !== systemDefaultAudioOutput.deviceId && mediaDevices.selectAudioOutput) {
+          const authorizedDevice = await mediaDevices.selectAudioOutput({ deviceId });
+          if (!isCurrent()) return;
+          selectedId = authorizedDevice.deviceId;
+          setAudioOutputDevices(current =>
+            current.some(device => device.deviceId === selectedId)
+              ? current
+              : [
+                  ...current,
+                  {
+                    deviceId: authorizedDevice.deviceId,
+                    groupId: authorizedDevice.groupId,
+                    kind: 'audiooutput',
+                    label: authorizedDevice.label || 'Selected speaker',
+                  },
+                ]
+          );
+        }
+        if (!isCurrent()) return;
+        selectedAudioOutputIdRef.current = selectedId;
+        setSelectedAudioOutputId(selectedId);
+      } catch {
+        if (!isCurrent()) return;
+        audioOutputSelectionFailedRef.current = true;
+        audioOutputSupportedRef.current = false;
+        selectedAudioOutputIdRef.current = systemDefaultAudioOutput.deviceId;
+        setAudioOutputSupported(false);
+        setAudioOutputDevices([systemDefaultAudioOutput]);
+        setSelectedAudioOutputId(systemDefaultAudioOutput.deviceId);
+        setAudioOutputError('This browser could not route audio to that speaker. Using System default.');
+      }
+    })();
+    audioOutputSelectionPromiseRef.current = selectionPromise;
+    await selectionPromise;
+    if (audioOutputSelectionPromiseRef.current === selectionPromise) {
+      audioOutputSelectionPromiseRef.current = null;
+    }
+  }, []);
 
   const initializeNoiseFilter = React.useCallback(async (tracks: LocalTrackLike[], isCurrent: () => boolean) => {
     noiseFilterProcessorRef.current = null;
@@ -708,193 +833,187 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
     }
   }, []);
 
-  const connect = React.useCallback(async (options: { takeover?: boolean } = {}) => {
-    const generation = connectionGenerationRef.current + 1;
-    connectionGenerationRef.current = generation;
-    const isCurrent = () => mountedRef.current && connectionGenerationRef.current === generation;
-    let connectingRoom: RoomLike | null = null;
-    let newlyCreatedTracks: LocalTrackLike[] = [];
-    const ownership = ownershipRef.current;
-    const ownsConnection = options.takeover ? await ownership?.requestTakeover() : await ownership?.acquire();
-    if (!isCurrent()) return;
-    if (ownsConnection === false) {
-      setConnectionConflict(true);
-      setRoomError('This debate is already open in another tab.');
-      setRoomState('idle');
-      logDebateConnectionDiagnostic('ownership-blocked', {
-        debateId,
-        instanceId: connectionInstanceIdRef.current,
-        roomState: roomStateRef.current,
-      });
-      return;
-    }
-
-    setConnectionConflict(false);
-    setRoomError(null);
-    setRoomState('connecting');
-    setServerClockSettled(false);
-    setRemoteVideoReady(false);
-    if (remoteParticipantRefetchTimerRef.current !== null) {
-      window.clearTimeout(remoteParticipantRefetchTimerRef.current);
-      remoteParticipantRefetchTimerRef.current = null;
-    }
-    remoteMediaRef.current?.replaceChildren();
-    void synchronizeServerClock(getServerTime)
-      .then(clock => {
-        if (isCurrent()) setServerClock(clock);
-      })
-      .catch(() => null)
-      .finally(() => {
-        if (isCurrent()) setServerClockSettled(true);
-      });
-
-    try {
-      const token = await liveKitJoin.mutateAsync();
+  const connect = React.useCallback(
+    async (options: { takeover?: boolean } = {}) => {
+      const generation = connectionGenerationRef.current + 1;
+      connectionGenerationRef.current = generation;
+      const isCurrent = () => mountedRef.current && connectionGenerationRef.current === generation;
+      let connectingRoom: RoomLike | null = null;
+      let newlyCreatedTracks: LocalTrackLike[] = [];
+      const ownership = ownershipRef.current;
+      const ownsConnection = options.takeover ? await ownership?.requestTakeover() : await ownership?.acquire();
       if (!isCurrent()) return;
-      setJoinResponse(token);
-
-      const livekit = await import('livekit-client');
-      if (!isCurrent()) return;
-      // A debate is a live, recorded 1:1 call, so both cameras must stream the whole time.
-      // adaptiveStream pauses a subscribed remote video when it judges the element off-screen or
-      // too small, and dynacast stops publishing layers no one is consuming; together they black
-      // out a tile mid-turn.
-      const room = new livekit.Room({ adaptiveStream: false, dynacast: false }) as unknown as RoomLike;
-      connectingRoom = room;
-      connectingRoomRef.current = room;
-      room.on(livekit.RoomEvent.TrackSubscribed, payload => {
-        // Auto-subscribe can deliver a track during room.connect(), before roomRef is assigned, so
-        // reject only a different room here rather than a not-yet-set one.
-        if (!isCurrent() || (roomRef.current && roomRef.current !== room)) return;
-        const track = payload as RemoteTrackLike;
-        const element = track.attach();
-        if (element instanceof HTMLMediaElement) {
-          element.muted = !remoteAudioEnabledRef.current;
-        }
-        if (element instanceof HTMLVideoElement) {
-          element.className = 'h-full w-full object-contain';
-          element.playsInline = true;
-          setRemoteVideoReady(true);
-        } else if (element instanceof HTMLAudioElement) {
-          element.className = 'hidden';
-        }
-        remoteMediaRef.current?.appendChild(element);
-        void refetchDebate();
-      });
-      // When a remote track drops mid-debate, detach its element instead of leaving a frozen black
-      // tile. Resetting remoteVideoReady flips the tile back to "Waiting for video" so a later
-      // re-subscribe attaches a fresh element rather than stacking a second one behind it.
-      room.on(livekit.RoomEvent.TrackUnsubscribed, payload => {
-        if (!isCurrent() || (roomRef.current && roomRef.current !== room)) return;
-        const track = payload as RemoteTrackLike;
-        for (const element of track.detach()) element.remove();
-        if (track.kind === 'video') setRemoteVideoReady(false);
-      });
-      room.on(livekit.RoomEvent.ParticipantConnected, () => {
-        if (!isCurrent()) return;
-        void refetchDebate();
-        remoteParticipantRefetchTimerRef.current = window.setTimeout(() => {
-          remoteParticipantRefetchTimerRef.current = null;
-          if (isCurrent()) void refetchDebate();
-        }, 250);
-      });
-      // LiveKit runs its own ICE-restart reconnection; surface it so a debater whose connection
-      // blips sees "Reconnecting" instead of a silently frozen call. Clear the remote
-      // tiles on the way out so stale elements from the dropped session don't linger behind the
-      // re-subscribed tracks.
-      room.on(livekit.RoomEvent.Reconnecting, () => {
-        if (!isCurrent() || roomRef.current !== room) return;
-        remoteMediaRef.current?.replaceChildren();
-        setRemoteVideoReady(false);
-        setRoomState('reconnecting');
-      });
-      room.on(livekit.RoomEvent.Reconnected, () => {
-        if (!isCurrent() || roomRef.current !== room) return;
-        setRoomState('connected');
-      });
-      // A non-client-initiated Disconnected means auto-reconnect gave up. Our own teardown always
-      // disconnects with CLIENT_INITIATED, so this branch only fires on a genuinely dropped call:
-      // tear the room down and return to idle, where the "Retry connection" affordance lives.
-      room.on(livekit.RoomEvent.Disconnected, payload => {
-        if (!isCurrent() || roomRef.current !== room) return;
-        if (payload === livekit.DisconnectReason.CLIENT_INITIATED) return;
-        connectionGenerationRef.current += 1;
-        // The room is already gone, so null the ref before cleanup: disconnectRoom would otherwise
-        // call room.disconnect() a second time and could re-enter this handler.
-        roomRef.current = null;
-        disconnectRoom(roomRef, localTracksRef, localVideoRef, remoteMediaRef);
-        noiseFilterProcessorRef.current = null;
-        ownershipRef.current?.release();
-        localMediaStreamRef.current = null;
-        setRemoteVideoReady(false);
-        const duplicateIdentity = payload === livekit.DisconnectReason.DUPLICATE_IDENTITY;
-        setConnectionConflict(duplicateIdentity);
-        setRoomError(
-          duplicateIdentity
-            ? 'This debate is active in another tab or device.'
-            : 'Lost connection to the debate room.'
-        );
+      if (ownsConnection === false) {
+        setConnectionConflict(true);
+        setRoomError('This debate is already open in another tab.');
         setRoomState('idle');
-        logDebateConnectionDiagnostic('livekit-disconnected', {
+        logDebateConnectionDiagnostic('ownership-blocked', {
           debateId,
           instanceId: connectionInstanceIdRef.current,
           roomState: roomStateRef.current,
-          disconnectReason: payload,
         });
-      });
-
-      await room.connect(token.url, token.token);
-      if (!isCurrent()) {
-        room.disconnect();
-        if (connectingRoomRef.current === room) connectingRoomRef.current = null;
-        return;
-      }
-      connectingRoomRef.current = null;
-      roomRef.current = room;
-      const hasPreviewTracks = localTracksRef.current.length > 0;
-      const tracks = hasPreviewTracks
-        ? localTracksRef.current
-        : ((await livekit.createLocalTracks({
-            audio: selectedAudioInputIdRef.current ? { deviceId: selectedAudioInputIdRef.current } : true,
-            video: selectedVideoInputIdRef.current ? { deviceId: selectedVideoInputIdRef.current } : true,
-          })) as LocalTrackLike[]);
-      if (!hasPreviewTracks) newlyCreatedTracks = tracks;
-      if (!isCurrent()) {
-        room.disconnect();
-        stopTracks(newlyCreatedTracks);
-        if (roomRef.current === room) roomRef.current = null;
-        return;
-      }
-      localTracksRef.current = tracks;
-      setLocalTrackPreferences(
-        tracks,
-        {
-          audioEnabled: shouldEnableLocalAudio(
-            countdown.effectiveStatus,
-            countdown.activeSlot,
-            token.participant_slot,
-            audioMuted
-          ),
-          videoEnabled,
-        },
-        sourceMediaStreamTracksRef.current
-      );
-
-      // Mark joined now that we're in the room and hold local media, before publishing. publishTrack
-      // awaits WebRTC media negotiation (ICE/TURN), which between two peers behind NAT can take
-      // several seconds; that's long enough to miss the server's connecting deadline and get the
-      // debate cancelled with connection_timeout even though both participants are present.
-      await markJoined.mutateAsync();
-      if (!isCurrent()) {
-        room.disconnect();
-        stopLocalTracks(localTracksRef);
-        localMediaStreamRef.current = null;
-        if (roomRef.current === room) roomRef.current = null;
         return;
       }
 
-      for (const track of tracks) {
-        await publishTrackWithRetry(room, track, isCurrent);
+      setConnectionConflict(false);
+      setRoomError(null);
+      setRoomState('connecting');
+      setServerClockSettled(false);
+      setRemoteVideoReady(false);
+      if (remoteParticipantRefetchTimerRef.current !== null) {
+        window.clearTimeout(remoteParticipantRefetchTimerRef.current);
+        remoteParticipantRefetchTimerRef.current = null;
+      }
+      remoteMediaRef.current?.replaceChildren();
+      void synchronizeServerClock(getServerTime)
+        .then(clock => {
+          if (isCurrent()) setServerClock(clock);
+        })
+        .catch(() => null)
+        .finally(() => {
+          if (isCurrent()) setServerClockSettled(true);
+        });
+
+      try {
+        const token = await liveKitJoin.mutateAsync();
+        if (!isCurrent()) return;
+        setJoinResponse(token);
+
+        const livekit = await import('livekit-client');
+        if (!isCurrent()) return;
+        await audioOutputSelectionPromiseRef.current;
+        if (!isCurrent()) return;
+        // A debate is a live, recorded 1:1 call, so both cameras must stream the whole time.
+        // adaptiveStream pauses a subscribed remote video when it judges the element off-screen or
+        // too small, and dynacast stops publishing layers no one is consuming; together they black
+        // out a tile mid-turn.
+        const roomOptions = debateRoomOptions(audioOutputSupportedRef.current, selectedAudioOutputIdRef.current);
+        const room = new livekit.Room(roomOptions) as unknown as RoomLike;
+        connectingRoom = room;
+        connectingRoomRef.current = room;
+        room.on(livekit.RoomEvent.TrackSubscribed, payload => {
+          // Auto-subscribe can deliver a track during room.connect(), before roomRef is assigned, so
+          // reject only a different room here rather than a not-yet-set one.
+          if (!isCurrent() || (roomRef.current && roomRef.current !== room)) return;
+          const track = payload as RemoteTrackLike;
+          const element = track.attach();
+          if (element instanceof HTMLMediaElement) {
+            element.muted = !remoteAudioEnabledRef.current;
+          }
+          if (element instanceof HTMLVideoElement) {
+            element.className = 'h-full w-full object-contain';
+            element.playsInline = true;
+            setRemoteVideoReady(true);
+          } else if (element instanceof HTMLAudioElement) {
+            element.className = 'hidden';
+          }
+          remoteMediaRef.current?.appendChild(element);
+          void refetchDebate();
+        });
+        // When a remote track drops mid-debate, detach its element instead of leaving a frozen black
+        // tile. Resetting remoteVideoReady flips the tile back to "Waiting for video" so a later
+        // re-subscribe attaches a fresh element rather than stacking a second one behind it.
+        room.on(livekit.RoomEvent.TrackUnsubscribed, payload => {
+          if (!isCurrent() || (roomRef.current && roomRef.current !== room)) return;
+          const track = payload as RemoteTrackLike;
+          for (const element of track.detach()) element.remove();
+          if (track.kind === 'video') setRemoteVideoReady(false);
+        });
+        room.on(livekit.RoomEvent.ParticipantConnected, () => {
+          if (!isCurrent()) return;
+          void refetchDebate();
+          remoteParticipantRefetchTimerRef.current = window.setTimeout(() => {
+            remoteParticipantRefetchTimerRef.current = null;
+            if (isCurrent()) void refetchDebate();
+          }, 250);
+        });
+        // LiveKit runs its own ICE-restart reconnection; surface it so a debater whose connection
+        // blips sees "Reconnecting" instead of a silently frozen call. Clear the remote
+        // tiles on the way out so stale elements from the dropped session don't linger behind the
+        // re-subscribed tracks.
+        room.on(livekit.RoomEvent.Reconnecting, () => {
+          if (!isCurrent() || roomRef.current !== room) return;
+          remoteMediaRef.current?.replaceChildren();
+          setRemoteVideoReady(false);
+          setRoomState('reconnecting');
+        });
+        room.on(livekit.RoomEvent.Reconnected, () => {
+          if (!isCurrent() || roomRef.current !== room) return;
+          setRoomState('connected');
+        });
+        // A non-client-initiated Disconnected means auto-reconnect gave up. Our own teardown always
+        // disconnects with CLIENT_INITIATED, so this branch only fires on a genuinely dropped call:
+        // tear the room down and return to idle, where the "Retry connection" affordance lives.
+        room.on(livekit.RoomEvent.Disconnected, payload => {
+          if (!isCurrent() || roomRef.current !== room) return;
+          if (payload === livekit.DisconnectReason.CLIENT_INITIATED) return;
+          connectionGenerationRef.current += 1;
+          // The room is already gone, so null the ref before cleanup: disconnectRoom would otherwise
+          // call room.disconnect() a second time and could re-enter this handler.
+          roomRef.current = null;
+          disconnectRoom(roomRef, localTracksRef, localVideoRef, remoteMediaRef);
+          noiseFilterProcessorRef.current = null;
+          ownershipRef.current?.release();
+          localMediaStreamRef.current = null;
+          setRemoteVideoReady(false);
+          const duplicateIdentity = payload === livekit.DisconnectReason.DUPLICATE_IDENTITY;
+          setConnectionConflict(duplicateIdentity);
+          setRoomError(
+            duplicateIdentity
+              ? 'This debate is active in another tab or device.'
+              : 'Lost connection to the debate room.'
+          );
+          setRoomState('idle');
+          logDebateConnectionDiagnostic('livekit-disconnected', {
+            debateId,
+            instanceId: connectionInstanceIdRef.current,
+            roomState: roomStateRef.current,
+            disconnectReason: payload,
+          });
+        });
+
+        await room.connect(token.url, token.token);
+        if (!isCurrent()) {
+          room.disconnect();
+          if (connectingRoomRef.current === room) connectingRoomRef.current = null;
+          return;
+        }
+        connectingRoomRef.current = null;
+        roomRef.current = room;
+        const hasPreviewTracks = localTracksRef.current.length > 0;
+        const tracks = hasPreviewTracks
+          ? localTracksRef.current
+          : ((await livekit.createLocalTracks({
+              audio: selectedAudioInputIdRef.current ? { deviceId: selectedAudioInputIdRef.current } : true,
+              video: selectedVideoInputIdRef.current ? { deviceId: selectedVideoInputIdRef.current } : true,
+            })) as LocalTrackLike[]);
+        if (!hasPreviewTracks) newlyCreatedTracks = tracks;
+        if (!isCurrent()) {
+          room.disconnect();
+          stopTracks(newlyCreatedTracks);
+          if (roomRef.current === room) roomRef.current = null;
+          return;
+        }
+        localTracksRef.current = tracks;
+        setLocalTrackPreferences(
+          tracks,
+          {
+            audioEnabled: shouldEnableLocalAudio(
+              countdown.effectiveStatus,
+              countdown.activeSlot,
+              token.participant_slot,
+              audioMuted
+            ),
+            videoEnabled,
+          },
+          sourceMediaStreamTracksRef.current
+        );
+
+        // Mark joined now that we're in the room and hold local media, before publishing. publishTrack
+        // awaits WebRTC media negotiation (ICE/TURN), which between two peers behind NAT can take
+        // several seconds; that's long enough to miss the server's connecting deadline and get the
+        // debate cancelled with connection_timeout even though both participants are present.
+        await markJoined.mutateAsync();
         if (!isCurrent()) {
           room.disconnect();
           stopLocalTracks(localTracksRef);
@@ -902,63 +1021,75 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
           if (roomRef.current === room) roomRef.current = null;
           return;
         }
-      }
 
-      // LiveKit supplies the audio context required by audio processors while publishing the
-      // microphone. Attach Krisp afterwards, then read mediaStreamTrack so this stream contains
-      // the same processed track used by the outbound publication.
-      await initializeNoiseFilter(tracks, isCurrent);
-      if (!isCurrent()) {
-        room.disconnect();
-        stopLocalTracks(localTracksRef);
-        localMediaStreamRef.current = null;
-        if (roomRef.current === room) roomRef.current = null;
-        return;
-      }
-      const stream = new MediaStream(tracks.map(track => track.mediaStreamTrack));
-      localMediaStreamRef.current = stream;
-      if (localVideoRef.current) {
-        localVideoRef.current.srcObject = stream;
-        localVideoRef.current.muted = true;
-        await localVideoRef.current.play().catch(() => undefined);
-      }
+        for (const track of tracks) {
+          await publishTrackWithRetry(room, track, isCurrent);
+          if (!isCurrent()) {
+            room.disconnect();
+            stopLocalTracks(localTracksRef);
+            localMediaStreamRef.current = null;
+            if (roomRef.current === room) roomRef.current = null;
+            return;
+          }
+        }
 
-      if (!isCurrent()) {
-        room.disconnect();
-        stopLocalTracks(localTracksRef);
-        localMediaStreamRef.current = null;
-        if (roomRef.current === room) roomRef.current = null;
-        return;
-      }
-      setConnectionConflict(false);
-      setRoomState('connected');
-    } catch (error) {
-      if (connectingRoom && connectingRoomRef.current === connectingRoom) connectingRoomRef.current = null;
-      if (connectingRoom && roomRef.current !== connectingRoom) {
-        connectingRoom.disconnect();
-        stopTracks(newlyCreatedTracks);
-      }
-      disconnectRoom(roomRef, localTracksRef, localVideoRef, remoteMediaRef);
-      localMediaStreamRef.current = null;
-      if (isCurrent()) {
-        ownershipRef.current?.release();
+        // LiveKit supplies the audio context required by audio processors while publishing the
+        // microphone. Attach Krisp afterwards, then read mediaStreamTrack so this stream contains
+        // the same processed track used by the outbound publication.
+        await initializeNoiseFilter(tracks, isCurrent);
+        if (!isCurrent()) {
+          room.disconnect();
+          stopLocalTracks(localTracksRef);
+          localMediaStreamRef.current = null;
+          if (roomRef.current === room) roomRef.current = null;
+          return;
+        }
+        const stream = new MediaStream(tracks.map(track => track.mediaStreamTrack));
+        localMediaStreamRef.current = stream;
+        if (localVideoRef.current) {
+          localVideoRef.current.srcObject = stream;
+          localVideoRef.current.muted = true;
+          await localVideoRef.current.play().catch(() => undefined);
+        }
+
+        if (!isCurrent()) {
+          room.disconnect();
+          stopLocalTracks(localTracksRef);
+          localMediaStreamRef.current = null;
+          if (roomRef.current === room) roomRef.current = null;
+          return;
+        }
         setConnectionConflict(false);
-        setRoomError(error instanceof Error ? error.message : 'Could not join the debate room.');
-        setRoomState(debate?.status === 'connecting' ? 'connecting' : 'idle');
+        setRoomState('connected');
+      } catch (error) {
+        if (connectingRoom && connectingRoomRef.current === connectingRoom) connectingRoomRef.current = null;
+        if (connectingRoom && roomRef.current !== connectingRoom) {
+          connectingRoom.disconnect();
+          stopTracks(newlyCreatedTracks);
+        }
+        disconnectRoom(roomRef, localTracksRef, localVideoRef, remoteMediaRef);
+        localMediaStreamRef.current = null;
+        if (isCurrent()) {
+          ownershipRef.current?.release();
+          setConnectionConflict(false);
+          setRoomError(error instanceof Error ? error.message : 'Could not join the debate room.');
+          setRoomState(debate?.status === 'connecting' ? 'connecting' : 'idle');
+        }
       }
-    }
-  }, [
-    audioMuted,
-    countdown.activeSlot,
-    countdown.effectiveStatus,
-    debateId,
-    debate?.status,
-    initializeNoiseFilter,
-    liveKitJoin,
-    markJoined,
-    refetchDebate,
-    videoEnabled,
-  ]);
+    },
+    [
+      audioMuted,
+      countdown.activeSlot,
+      countdown.effectiveStatus,
+      debateId,
+      debate?.status,
+      initializeNoiseFilter,
+      liveKitJoin,
+      markJoined,
+      refetchDebate,
+      videoEnabled,
+    ]
+  );
 
   const retryConnection = React.useCallback(() => {
     void connect();
@@ -1202,6 +1333,8 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
     return () => {
       mountedRef.current = false;
       previewGenerationRef.current += 1;
+      mediaDeviceRefreshGenerationRef.current += 1;
+      audioOutputSelectionGenerationRef.current += 1;
       connectionGenerationRef.current += 1;
       if (connectionFailureRedirectTimerRef.current !== null) {
         window.clearTimeout(connectionFailureRedirectTimerRef.current);
@@ -1230,6 +1363,30 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
     if (!debate || debate.status !== 'ready' || roomState !== 'idle') return;
     void ensureLocalPreview().catch(() => undefined);
   }, [debate, ensureLocalPreview, roomState]);
+
+  React.useEffect(() => {
+    const mediaDevices = navigator.mediaDevices;
+    if (!mediaDevices?.addEventListener) return;
+    const handleDeviceChange = () => {
+      const previousAudioInputId = selectedAudioInputIdRef.current;
+      const previousVideoInputId = selectedVideoInputIdRef.current;
+      void refreshMediaDevices()
+        .then(selection => {
+          if (!selection || localTracksRef.current.length === 0) return;
+          if (selection.audioInputId === previousAudioInputId && selection.videoInputId === previousVideoInputId) {
+            return;
+          }
+          void ensureLocalPreview({
+            forceRestart: true,
+            audioInputId: selection.audioInputId,
+            videoInputId: selection.videoInputId,
+          }).catch(() => undefined);
+        })
+        .catch(() => undefined);
+    };
+    mediaDevices.addEventListener('devicechange', handleDeviceChange);
+    return () => mediaDevices.removeEventListener('devicechange', handleDeviceChange);
+  }, [ensureLocalPreview, refreshMediaDevices]);
 
   React.useEffect(() => {
     if (!debate || roomState !== 'idle') return;
@@ -1373,14 +1530,22 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
             debate={debate}
             currentUserId={currentUserId}
             localVideoRef={localVideoRef}
+            previewStream={previewStream}
             previewState={previewState}
+            previewBusy={previewBusy}
             error={roomError ?? previewError}
             audioInputDevices={audioInputDevices}
+            audioOutputDevices={audioOutputDevices}
             videoInputDevices={videoInputDevices}
             selectedAudioInputId={selectedAudioInputId}
+            selectedAudioOutputId={selectedAudioOutputId}
             selectedVideoInputId={selectedVideoInputId}
+            audioOutputSupported={audioOutputSupported}
+            audioOutputError={audioOutputError}
             onAudioInputChange={changeAudioInput}
+            onAudioOutputChange={changeAudioOutput}
             onVideoInputChange={changeVideoInput}
+            onRetryMedia={() => void ensureLocalPreview({ forceRestart: true }).catch(() => undefined)}
             readyBusy={markReady.isPending}
             onReady={markLocalReady}
             onLeave={leave}
@@ -1473,221 +1638,6 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
             )}
           </>
         ))}
-    </div>
-  );
-}
-
-function DebatePreScreen({
-  debate,
-  currentUserId,
-  localVideoRef,
-  previewState,
-  error,
-  audioInputDevices,
-  videoInputDevices,
-  selectedAudioInputId,
-  selectedVideoInputId,
-  onAudioInputChange,
-  onVideoInputChange,
-  readyBusy,
-  onReady,
-  onLeave,
-  leaveDisabled,
-}: {
-  debate: Debate;
-  currentUserId: string | null;
-  localVideoRef: React.RefObject<HTMLVideoElement | null>;
-  previewState: 'idle' | 'starting' | 'ready';
-  error: string | null;
-  audioInputDevices: MediaDeviceOption[];
-  videoInputDevices: MediaDeviceOption[];
-  selectedAudioInputId: string;
-  selectedVideoInputId: string;
-  onAudioInputChange: (deviceId: string) => void;
-  onVideoInputChange: (deviceId: string) => void;
-  readyBusy: boolean;
-  onReady: () => void;
-  onLeave: () => void;
-  leaveDisabled: boolean;
-}) {
-  const participants = [...debate.participants].sort((a, b) => a.participant_slot - b.participant_slot);
-  const localParticipant =
-    participants.find(participant => participant.user_id === currentUserId) ?? participants[0] ?? null;
-  const remoteParticipant =
-    participants.find(participant => participant.user_id !== localParticipant?.user_id) ?? participants[1] ?? null;
-  const localReady = Boolean(localParticipant?.ready_at);
-  const remoteReady = Boolean(remoteParticipant?.ready_at);
-
-  React.useEffect(() => {
-    const originalBodyOverflow = document.body.style.overflow;
-    const originalDocumentOverflow = document.documentElement.style.overflow;
-
-    document.body.style.overflow = 'hidden';
-    document.documentElement.style.overflow = 'hidden';
-
-    return () => {
-      document.body.style.overflow = originalBodyOverflow;
-      document.documentElement.style.overflow = originalDocumentOverflow;
-    };
-  }, []);
-
-  return (
-    <div
-      role="dialog"
-      aria-modal="true"
-      aria-label="Debate readiness"
-      className="fixed inset-0 z-[1000] overflow-y-auto bg-white text-text"
-    >
-      <section className="mx-auto flex min-h-dvh w-full max-w-[920px] flex-col items-center justify-start px-5 py-6 text-center md:justify-center">
-        <Text as="p" variant="cardEntityTitle" color="grey-04">
-          Debate
-        </Text>
-        <h1 className="mt-3 max-w-[560px] text-[2.5rem] leading-[1.05] font-semibold text-text md:max-w-[870px] md:text-[3.625rem] md:leading-[0.93]">
-          {debate.claim.claim}
-        </h1>
-
-        <div className="mt-10 w-full max-w-[272px]">
-          <PreScreenOpponent
-            participant={remoteParticipant}
-            label={remoteParticipant ? speakerName(remoteParticipant) : 'Other speaker'}
-            ready={remoteReady}
-          />
-        </div>
-
-        <div className="mt-3 w-full max-w-[272px] rounded-lg border border-grey-02 bg-white p-3">
-          <div className="relative aspect-[4/3] w-full overflow-hidden rounded bg-grey-01">
-            <video ref={localVideoRef} className="h-full w-full object-cover" playsInline muted autoPlay />
-            {previewState !== 'ready' && (
-              <div className="absolute inset-0 grid place-items-center bg-grey-01">
-                <Text variant="body" color="grey-04">
-                  {previewState === 'starting' ? 'Starting camera...' : 'Camera preview unavailable'}
-                </Text>
-              </div>
-            )}
-          </div>
-          <div className="mt-3 grid grid-cols-2 gap-3">
-            <PreScreenDeviceSelect
-              ariaLabel="Select microphone"
-              icon={<MicrophoneIcon muted={false} />}
-              value={selectedAudioInputId}
-              options={audioInputDevices}
-              fallbackLabel="Microphone"
-              onChange={onAudioInputChange}
-            />
-            <PreScreenDeviceSelect
-              ariaLabel="Select camera"
-              icon={<CameraIcon disabled={false} />}
-              value={selectedVideoInputId}
-              options={videoInputDevices}
-              fallbackLabel="Camera"
-              onChange={onVideoInputChange}
-            />
-          </div>
-        </div>
-
-        {error && (
-          <Text as="p" variant="metadata" color="red-01" className="mt-3">
-            {error}
-          </Text>
-        )}
-
-        <button
-          type="button"
-          onClick={onReady}
-          disabled={readyBusy || localReady}
-          className="mt-3 flex min-h-11 w-full max-w-[272px] items-center justify-center rounded-full bg-text px-5 text-button text-white transition-colors hover:bg-text/90 disabled:opacity-50"
-        >
-          {localReady ? 'Waiting...' : readyBusy ? 'Saving...' : 'Accept'}
-        </button>
-
-        <div className="mt-5">
-          <RecordingCircleButton
-            ariaLabel="Leave debate"
-            title="Leave debate"
-            onClick={onLeave}
-            disabled={leaveDisabled}
-          >
-            <LeaveIcon />
-          </RecordingCircleButton>
-        </div>
-      </section>
-    </div>
-  );
-}
-
-function PreScreenDeviceSelect({
-  ariaLabel,
-  icon,
-  value,
-  options,
-  fallbackLabel,
-  onChange,
-}: {
-  ariaLabel: string;
-  icon: React.ReactNode;
-  value: string;
-  options: MediaDeviceOption[];
-  fallbackLabel: string;
-  onChange: (deviceId: string) => void;
-}) {
-  const selectOptions = options.length > 0 ? options : [{ deviceId: '', label: fallbackLabel }];
-
-  return (
-    <label className="relative flex min-w-0 items-center rounded-full border border-grey-02 bg-white px-3 py-2 text-left text-metadata text-text">
-      <span className="mr-2 shrink-0 text-text">{icon}</span>
-      <select
-        aria-label={ariaLabel}
-        value={value}
-        onChange={event => onChange(event.target.value)}
-        disabled={options.length === 0}
-        className="min-w-0 flex-1 appearance-none bg-transparent pr-6 text-metadata text-text outline-none disabled:text-grey-04"
-      >
-        {selectOptions.map(device => (
-          <option key={device.deviceId || fallbackLabel} value={device.deviceId}>
-            {device.label}
-          </option>
-        ))}
-      </select>
-      <span className="pointer-events-none absolute right-3 grid size-4 place-items-center">
-        <ChevronDownSmall color="grey-04" />
-      </span>
-    </label>
-  );
-}
-
-function PreScreenOpponent({
-  participant,
-  label,
-  ready,
-}: {
-  participant: Debate['participants'][number] | null;
-  label: string;
-  ready: boolean;
-}) {
-  return (
-    <div className="flex min-h-[52px] w-full items-center justify-between gap-4 rounded-lg border border-grey-02 bg-white px-3">
-      <div className="flex min-w-0 items-center gap-2">
-        <span className="h-5 w-5 shrink-0 overflow-hidden rounded-full">
-          <Avatar
-            avatarUrl={participant?.avatar_cid ?? null}
-            value={participant?.profile_space_id ?? label}
-            alt={label}
-            size={20}
-          />
-        </span>
-        <Text as="div" variant="metadata" color="text" className="min-w-0 truncate text-left">
-          {label}
-        </Text>
-      </div>
-      <span
-        className={cx(
-          'inline-flex shrink-0 items-center gap-2 rounded-full px-3 py-1.5 text-metadata leading-none',
-          ready ? 'bg-green text-text' : 'bg-grey-01 text-grey-04'
-        )}
-      >
-        {ready && <Check />}
-        {ready ? 'Ready' : 'Waiting...'}
-      </span>
     </div>
   );
 }
@@ -2391,108 +2341,6 @@ function RecordingCountdownRing({ countdown }: { countdown: DebateCountdown }) {
   );
 }
 
-function RecordingCircleButton({
-  ariaLabel,
-  title,
-  onClick,
-  disabled,
-  active = false,
-  className,
-  children,
-}: {
-  ariaLabel: string;
-  title: string;
-  onClick: () => void;
-  disabled?: boolean;
-  active?: boolean;
-  className?: string;
-  children: React.ReactNode;
-}) {
-  return (
-    <button
-      type="button"
-      aria-label={ariaLabel}
-      title={title}
-      onClick={onClick}
-      disabled={disabled}
-      className={cx(
-        'grid size-10 place-items-center rounded-full border border-grey-02 bg-white text-text shadow-light transition disabled:opacity-50',
-        active && 'bg-bg',
-        className
-      )}
-    >
-      {children}
-    </button>
-  );
-}
-
-function LeaveIcon() {
-  return (
-    <svg viewBox="0 0 24 24" aria-hidden="true" className="size-4" fill="none" stroke="currentColor" strokeWidth="2">
-      <path d="M9 7V5a2 2 0 0 1 2-2h7v18h-7a2 2 0 0 1-2-2v-2" />
-      <path d="M13 12H3" />
-      <path d="M6 9l-3 3 3 3" />
-    </svg>
-  );
-}
-
-function MicrophoneIcon({ muted }: { muted: boolean }) {
-  return (
-    <svg viewBox="0 0 24 24" aria-hidden="true" className="size-4" fill="none" stroke="currentColor" strokeWidth="2">
-      <path d="M12 14a4 4 0 0 0 4-4V6a4 4 0 1 0-8 0v4a4 4 0 0 0 4 4Z" />
-      <path d="M5 10a7 7 0 0 0 14 0" />
-      <path d="M12 17v4" />
-      <path d="M9 21h6" />
-      {muted && <path d="M4 4l16 16" />}
-    </svg>
-  );
-}
-
-function MutedMicrophoneIndicator() {
-  return (
-    <svg
-      width="45"
-      height="45"
-      viewBox="0 0 45 45"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
-      aria-hidden="true"
-      data-muted-indicator="true"
-      className="size-[45px]"
-    >
-      <rect width="45" height="44.9989" rx="22.4994" fill="white" />
-      <rect x="17.6431" y="12.2852" width="9.71429" height="17.75" rx="4.85714" stroke="#151515" />
-      <path
-        d="M14.4644 24.1055V25.1769C14.4644 29.6149 18.0621 33.2126 22.5001 33.2126C26.9381 33.2126 30.5358 29.6149 30.5358 25.1769V24.1055"
-        stroke="#151515"
-        strokeLinecap="round"
-      />
-      <path d="M27.3216 16.6094L17.6787 25.7165" stroke="#151515" />
-    </svg>
-  );
-}
-
-function CameraIcon({ disabled }: { disabled: boolean }) {
-  return (
-    <svg viewBox="0 0 24 24" aria-hidden="true" className="size-4" fill="none" stroke="currentColor" strokeWidth="2">
-      <path d="M4 7h10a2 2 0 0 1 2 2v6a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V9a2 2 0 0 1 2-2Z" />
-      <path d="M16 10l5-3v10l-5-3" />
-      {disabled && <path d="M3 3l18 18" />}
-    </svg>
-  );
-}
-
-function SpeakerIcon({ disabled }: { disabled: boolean }) {
-  return (
-    <svg viewBox="0 0 24 24" aria-hidden="true" className="size-4" fill="none" stroke="currentColor" strokeWidth="2">
-      <path d="M4 9v6h4l5 4V5L8 9H4Z" />
-      <path d="M16 9.5a4 4 0 0 1 0 5" />
-      <path d="M19 7a8 8 0 0 1 0 10" />
-      {disabled && <path d="M3 3l18 18" />}
-    </svg>
-  );
-}
-
 function setLocalTrackPreferences(
   tracks: LocalTrackLike[],
   preferences: { audioEnabled: boolean; videoEnabled: boolean },
@@ -2559,6 +2407,61 @@ function localTurnStartsInSeconds(
 function participantSlotForTurn(firstParticipantSlot: ParticipantSlot, turnIndex: number): ParticipantSlot {
   if (turnIndex % 2 === 0) return firstParticipantSlot;
   return firstParticipantSlot === 1 ? 2 : 1;
+}
+
+function retainOrPreferDefaultDevice(current: string, devices: MediaDeviceOption[]) {
+  if (current && devices.some(device => device.deviceId === current)) return current;
+  return devices.find(device => device.deviceId === 'default')?.deviceId ?? devices[0]?.deviceId ?? '';
+}
+
+function debateRoomOptions(audioOutputSupported: boolean, selectedAudioOutputId: string) {
+  return {
+    adaptiveStream: false,
+    dynacast: false,
+    ...(audioOutputSupported ? { audioOutput: { deviceId: selectedAudioOutputId } } : {}),
+  };
+}
+
+function sameMediaDeviceOptions(current: MediaDeviceOption[], next: MediaDeviceOption[]) {
+  return (
+    current.length === next.length &&
+    current.every(
+      (device, index) =>
+        device.deviceId === next[index]?.deviceId &&
+        device.groupId === next[index]?.groupId &&
+        device.kind === next[index]?.kind &&
+        device.label === next[index]?.label
+    )
+  );
+}
+
+function preJoinMediaFailure(error: unknown): {
+  state: Exclude<PreJoinMediaState, 'requesting' | 'ready'>;
+  message: string;
+} {
+  const name = error instanceof DOMException || error instanceof Error ? error.name : '';
+  if (name === 'NotAllowedError' || name === 'SecurityError') {
+    return {
+      state: 'denied',
+      message: 'Allow access to your camera and microphone to continue.',
+    };
+  }
+  if (name === 'NotFoundError' || name === 'DevicesNotFoundError') {
+    return {
+      state: 'unavailable',
+      message: 'Connect a camera and microphone, then try again.',
+    };
+  }
+  if (name === 'NotReadableError' || name === 'TrackStartError' || name === 'AbortError') {
+    return {
+      state: 'error',
+      message: 'Your camera or microphone may be in use by another app. Close it and try again.',
+    };
+  }
+  return {
+    state: 'error',
+    message: 'We could not start your camera and microphone. Check your devices and try again.',
+  };
 }
 
 function stopLocalTracks(localTracksRef: React.MutableRefObject<LocalTrackLike[]>) {


### PR DESCRIPTION
## Summary

Debaters are now prompted for camera and microphone access as soon as the pre-join screen opens, and they cannot accept until both required inputs are available.

The redesigned flow adds responsive microphone, speaker, and camera selection: modal bottom sheets on mobile and upward, non-reflowing dropdowns on desktop. Permission denials, unavailable devices, and retryable capture failures now show actionable recovery states instead of raw browser errors.

## What changed

- Reworked pre-join media initialization, permission recovery, device enumeration, and hardware-change handling
- Added accessible Radix audio/video settings surfaces with shared preview tracks and single-surface dismissal behavior
- Preserved complementary input choices when restarting capture and avoided input restarts for speaker changes
- Passed supported audio-output selection and existing preview tracks into the current LiveKit connection
- Kept all selections client-side for the current debate with no backend or lifecycle API changes

## Testing

- [x] `bunx vitest run` — 1,531 tests passed
- [x] `bunx tsc --noEmit`
- [x] ESLint on all four changed debate-room files
- [x] Prettier check on all four changed debate-room files
- [x] `git diff --check`
- [x] Real-device QA in desktop Chromium and mobile Safari (requires an authenticated seeded debate and physical media devices)

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
