### PR TITLE
fix: simplify Explore data block browse actions

### DIFF
--- a/apps/web/partials/blocks/table/data-block-header-action-visibility.test.ts
+++ b/apps/web/partials/blocks/table/data-block-header-action-visibility.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it } from 'vitest';
 
 import type { DataBlockView } from '~/core/blocks/data/use-view';
 
-import { shouldShowFilterAndFullscreenActions } from './data-block-header-action-visibility';
+import {
+  filterPanelOpenStateForActions,
+  shouldShowFilterAndFullscreenActions,
+} from './data-block-header-action-visibility';
 
 describe('shouldShowFilterAndFullscreenActions', () => {
   it('hides both actions for Explore view in browse mode', () => {
@@ -19,4 +22,15 @@ describe('shouldShowFilterAndFullscreenActions', () => {
       expect(shouldShowFilterAndFullscreenActions(view, false)).toBe(true);
     }
   );
+});
+
+describe('filterPanelOpenStateForActions', () => {
+  it('closes an open filter panel when its actions are hidden', () => {
+    expect(filterPanelOpenStateForActions(true, false)).toBe(false);
+  });
+
+  it('preserves the filter panel state while its actions remain visible', () => {
+    expect(filterPanelOpenStateForActions(true, true)).toBe(true);
+    expect(filterPanelOpenStateForActions(false, true)).toBe(false);
+  });
 });

--- a/apps/web/partials/blocks/table/data-block-header-action-visibility.test.ts
+++ b/apps/web/partials/blocks/table/data-block-header-action-visibility.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+
+import type { DataBlockView } from '~/core/blocks/data/use-view';
+
+import { shouldShowFilterAndFullscreenActions } from './data-block-header-action-visibility';
+
+describe('shouldShowFilterAndFullscreenActions', () => {
+  it('hides both actions for Explore view in browse mode', () => {
+    expect(shouldShowFilterAndFullscreenActions('EXPLORE', false)).toBe(false);
+  });
+
+  it('keeps both actions for Explore view in edit mode', () => {
+    expect(shouldShowFilterAndFullscreenActions('EXPLORE', true)).toBe(true);
+  });
+
+  it.each<DataBlockView>(['TABLE', 'LIST', 'GALLERY', 'BULLETED_LIST', 'PILL'])(
+    'keeps both actions for %s view in browse mode',
+    view => {
+      expect(shouldShowFilterAndFullscreenActions(view, false)).toBe(true);
+    }
+  );
+});

--- a/apps/web/partials/blocks/table/data-block-header-action-visibility.ts
+++ b/apps/web/partials/blocks/table/data-block-header-action-visibility.ts
@@ -4,3 +4,8 @@ import type { DataBlockView } from '~/core/blocks/data/use-view';
 export function shouldShowFilterAndFullscreenActions(view: DataBlockView, isEditing: boolean): boolean {
   return isEditing || view !== 'EXPLORE';
 }
+
+/** A hidden filter toggle must not leave its panel open with no way to close it. */
+export function filterPanelOpenStateForActions(isFilterOpen: boolean, showActions: boolean): boolean {
+  return showActions && isFilterOpen;
+}

--- a/apps/web/partials/blocks/table/data-block-header-action-visibility.ts
+++ b/apps/web/partials/blocks/table/data-block-header-action-visibility.ts
@@ -1,0 +1,6 @@
+import type { DataBlockView } from '~/core/blocks/data/use-view';
+
+/** Explore browse is an infinite feed and does not expose filter/fullscreen header actions. */
+export function shouldShowFilterAndFullscreenActions(view: DataBlockView, isEditing: boolean): boolean {
+  return isEditing || view !== 'EXPLORE';
+}

--- a/apps/web/partials/blocks/table/table-block.tsx
+++ b/apps/web/partials/blocks/table/table-block.tsx
@@ -56,6 +56,7 @@ import { Text } from '~/design-system/text';
 import { onChangeEntryFn, writeValue } from './change-entry';
 import { shouldShowCreateEntityAction } from './data-block-create-entity-visibility';
 import { DataBlockCreateEntitySpaceDropdown } from './data-block-create-entity-space-dropdown';
+import { shouldShowFilterAndFullscreenActions } from './data-block-header-action-visibility';
 import { DataBlockScopeDropdown } from './data-block-scope-dropdown';
 import { DataBlockSortMenu } from './data-block-sort-menu';
 import { DataBlockViewMenu } from './data-block-view-menu';
@@ -966,6 +967,7 @@ const ConfiguredTableBlock = ({
 
   const showToolbarSort = isEditing || sortState !== null;
   const showToolbarDividerAfterScope = showToolbarSort || isEditing;
+  const showFilterAndFullscreenActions = shouldShowFilterAndFullscreenActions(view, isEditing);
 
   const toggleFilterHandler = () => setIsFilterOpen(!isFilterOpen);
 
@@ -987,18 +989,22 @@ const ConfiguredTableBlock = ({
               disabled={!canEdit}
             />
           )}
-          <IconButton
-            onClick={toggleFilterHandler}
-            icon={activeFilters.length > 0 ? <FilterTableWithFilters /> : <FilterTable />}
-            color="grey-04"
-          />
-          <Link
-            href={`/space/${spaceId}/${entityId}/power-tools?relationId=${relationId}`}
-            className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded border-none bg-transparent text-grey-04 transition hover:bg-bg focus:outline-hidden focus-visible:ring-2 focus-visible:ring-grey-04"
-            aria-label="Open fullscreen"
-          >
-            <Fullscreen color="grey-04" />
-          </Link>
+          {showFilterAndFullscreenActions && (
+            <>
+              <IconButton
+                onClick={toggleFilterHandler}
+                icon={activeFilters.length > 0 ? <FilterTableWithFilters /> : <FilterTable />}
+                color="grey-04"
+              />
+              <Link
+                href={`/space/${spaceId}/${entityId}/power-tools?relationId=${relationId}`}
+                className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded border-none bg-transparent text-grey-04 transition hover:bg-bg focus:outline-hidden focus-visible:ring-2 focus-visible:ring-grey-04"
+                aria-label="Open fullscreen"
+              >
+                <Fullscreen color="grey-04" />
+              </Link>
+            </>
+          )}
           <DataBlockViewMenu activeView={view} isLoading={isLoading} />
           <TableBlockContextMenu sourceType={source.type} />
           {showCreateEntityPlus &&

--- a/apps/web/partials/blocks/table/table-block.tsx
+++ b/apps/web/partials/blocks/table/table-block.tsx
@@ -56,7 +56,10 @@ import { Text } from '~/design-system/text';
 import { onChangeEntryFn, writeValue } from './change-entry';
 import { shouldShowCreateEntityAction } from './data-block-create-entity-visibility';
 import { DataBlockCreateEntitySpaceDropdown } from './data-block-create-entity-space-dropdown';
-import { shouldShowFilterAndFullscreenActions } from './data-block-header-action-visibility';
+import {
+  filterPanelOpenStateForActions,
+  shouldShowFilterAndFullscreenActions,
+} from './data-block-header-action-visibility';
 import { DataBlockScopeDropdown } from './data-block-scope-dropdown';
 import { DataBlockSortMenu } from './data-block-sort-menu';
 import { DataBlockViewMenu } from './data-block-view-menu';
@@ -969,7 +972,11 @@ const ConfiguredTableBlock = ({
   const showToolbarDividerAfterScope = showToolbarSort || isEditing;
   const showFilterAndFullscreenActions = shouldShowFilterAndFullscreenActions(view, isEditing);
 
-  const toggleFilterHandler = () => setIsFilterOpen(!isFilterOpen);
+  React.useEffect(() => {
+    setIsFilterOpen(current => filterPanelOpenStateForActions(current, showFilterAndFullscreenActions));
+  }, [showFilterAndFullscreenActions]);
+
+  const toggleFilterHandler = () => setIsFilterOpen(current => !current);
 
   return (
     <motion.div layout="position" transition={{ duration: 0.15 }}>


### PR DESCRIPTION
## Summary

- hide the Filter action for Explore-view data blocks in browse mode
- hide the Fullscreen action for Explore-view data blocks in browse mode
- preserve both actions for Explore view in edit mode
- preserve both actions for every non-Explore view in browse and edit modes
- add focused coverage for the complete data-block view matrix

## Why

Explore browse mode is an infinite feed and should not expose the Filter or Fullscreen header controls. Configuration and power tools remain available while editing, and other data-block views retain their existing browse controls.

## Validation

- `bun run test partials/blocks/table/data-block-header-action-visibility.test.ts partials/blocks/table/data-block-create-entity-visibility.test.ts` (2 files, 12 tests)
- `bunx tsc --noEmit --pretty false`
- `bunx eslint partials/blocks/table/table-block.tsx partials/blocks/table/data-block-header-action-visibility.ts partials/blocks/table/data-block-header-action-visibility.test.ts` (no errors; three existing unused-variable warnings in `table-block.tsx`)
- `git diff --check`
