### PR TITLE
feat: add cached Explore type filter

### DIFF
--- a/apps/web/app/api/explore/feed/route.ts
+++ b/apps/web/app/api/explore/feed/route.ts
@@ -5,7 +5,7 @@ import type { BrowseSidebarData } from '~/core/browse/fetch-browse-sidebar-data'
 import { fetchBrowseSidebarData } from '~/core/browse/fetch-browse-sidebar-data';
 import { resolveMemberSpaceFromWalletSafe } from '~/core/browse/resolve-member-space-from-wallet';
 import { WALLET_ADDRESS } from '~/core/cookie';
-import { EXPLORE_ENTITY_TYPE_IDS } from '~/core/explore/explore-constants';
+import { parseExploreTypeIdsParam } from '~/core/explore/explore-type-filter';
 import { type ExploreSort, type ExploreTime, fetchExploreFeed } from '~/core/explore/fetch-explore-feed';
 
 import { getGovernanceHomeSpaceContext } from '~/app/home/governance-home-space-ids';
@@ -33,6 +33,11 @@ export async function GET(request: Request) {
   const time = parseTime(searchParams.get('time'));
   const spaceId = searchParams.get('spaceId');
   const cursor = searchParams.get('cursor');
+  const typeIds = parseExploreTypeIdsParam(searchParams.get('typeIds'));
+
+  if (typeIds.length === 0) {
+    return NextResponse.json({ items: [], nextCursor: null });
+  }
 
   const cookieWallet = (await cookies()).get(WALLET_ADDRESS)?.value;
 
@@ -84,7 +89,7 @@ export async function GET(request: Request) {
       cursor,
       walletAddress: cookieWallet ?? null,
       memberOrEditorSpaceIds,
-      typeIds: EXPLORE_ENTITY_TYPE_IDS,
+      typeIds,
       requireName: true,
     });
     return NextResponse.json(result);

--- a/apps/web/core/explore/explore-constants.ts
+++ b/apps/web/core/explore/explore-constants.ts
@@ -8,6 +8,9 @@ export const EXPLORE_ENTITY_TYPES = [
   { id: '5e24fb52856c4189a9716af4387b1b89', label: 'Paper' },
   { id: '7ed45f2bc48b419e8e4664d5ff680b0d', label: 'Person' },
   { id: '484a18c5030a499cb0f2ef588ff16d50', label: 'Project' },
+  { id: '150db6defe2344f0805afa57502e2c32', label: 'Ranking block' },
+  { id: '0419ca20118b4cdb84dfdb9ed73b50c2', label: 'Community call event' },
+  { id: 'fd51f93520634617be397b672b23364c', label: 'Debate' },
 ] as const;
 
 export const EXPLORE_ENTITY_TYPE_IDS = EXPLORE_ENTITY_TYPES.map(type => type.id);

--- a/apps/web/core/explore/explore-constants.ts
+++ b/apps/web/core/explore/explore-constants.ts
@@ -1,14 +1,16 @@
 /** Entity types shown on Explore (Geo ontology IDs, hyphenless for GraphQL variables). */
-export const EXPLORE_ENTITY_TYPE_IDS = [
-  'e550fe517e904b2c8fffdf13408f5634',
-  '972d201ad78045689e01543f67b26bee',
-  'f3d4461486b74d2583d89709c9d84f65',
-  'd6f0506def324d8e9de4976b986e78ec',
-  '4d876b81787e41fcab5d075d4da66a3f',
-  '5e24fb52856c4189a9716af4387b1b89',
-  '7ed45f2bc48b419e8e4664d5ff680b0d',
-  '484a18c5030a499cb0f2ef588ff16d50',
+export const EXPLORE_ENTITY_TYPES = [
+  { id: 'e550fe517e904b2c8fffdf13408f5634', label: 'News story' },
+  { id: '972d201ad78045689e01543f67b26bee', label: 'Episode' },
+  { id: 'f3d4461486b74d2583d89709c9d84f65', label: 'Post' },
+  { id: 'd6f0506def324d8e9de4976b986e78ec', label: 'Tweet' },
+  { id: '4d876b81787e41fcab5d075d4da66a3f', label: 'Event' },
+  { id: '5e24fb52856c4189a9716af4387b1b89', label: 'Paper' },
+  { id: '7ed45f2bc48b419e8e4664d5ff680b0d', label: 'Person' },
+  { id: '484a18c5030a499cb0f2ef588ff16d50', label: 'Project' },
 ] as const;
+
+export const EXPLORE_ENTITY_TYPE_IDS = EXPLORE_ENTITY_TYPES.map(type => type.id);
 
 export const EXPLORE_ENTITY_NAME_PROPERTY_ID = 'a126ca530c8e48d5b88882c734c38935';
 export const EXPLORE_ENTITY_DESCRIPTION_PROPERTY_ID = '9b1f76ff9711404c861e59dc3fa7d037';

--- a/apps/web/core/explore/explore-type-filter.test.ts
+++ b/apps/web/core/explore/explore-type-filter.test.ts
@@ -61,6 +61,6 @@ describe('exploreTypeFilterLabel', () => {
   it('formats the selected type count', () => {
     expect(exploreTypeFilterLabel(0)).toBe('0 types');
     expect(exploreTypeFilterLabel(1)).toBe('1 type');
-    expect(exploreTypeFilterLabel(8)).toBe('8 types');
+    expect(exploreTypeFilterLabel(11)).toBe('11 types');
   });
 });

--- a/apps/web/core/explore/explore-type-filter.test.ts
+++ b/apps/web/core/explore/explore-type-filter.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+
+import { EXPLORE_ENTITY_TYPE_IDS } from './explore-constants';
+import {
+  exploreTypeFilterLabel,
+  parseExploreTypeIdsParam,
+  parseStoredExploreTypeIds,
+  sanitizeExploreTypeIds,
+  toggleExploreTypeId,
+} from './explore-type-filter';
+
+describe('parseStoredExploreTypeIds', () => {
+  it('defaults to every Explore type when cache is missing or corrupt', () => {
+    expect(parseStoredExploreTypeIds(null)).toEqual(EXPLORE_ENTITY_TYPE_IDS);
+    expect(parseStoredExploreTypeIds('not-json')).toEqual(EXPLORE_ENTITY_TYPE_IDS);
+    expect(parseStoredExploreTypeIds('{}')).toEqual(EXPLORE_ENTITY_TYPE_IDS);
+  });
+
+  it('preserves a deliberately empty cached selection', () => {
+    expect(parseStoredExploreTypeIds('[]')).toEqual([]);
+  });
+
+  it('keeps only allowed IDs in canonical Explore order', () => {
+    const [first, second] = EXPLORE_ENTITY_TYPE_IDS;
+    expect(parseStoredExploreTypeIds(JSON.stringify([second, 'unknown', first, second]))).toEqual([first, second]);
+  });
+});
+
+describe('parseExploreTypeIdsParam', () => {
+  it('defaults a missing parameter to all types and preserves an empty selection', () => {
+    expect(parseExploreTypeIdsParam(null)).toEqual(EXPLORE_ENTITY_TYPE_IDS);
+    expect(parseExploreTypeIdsParam('')).toEqual([]);
+  });
+
+  it('rejects unknown IDs and accepts hyphenated allowed IDs', () => {
+    const first = EXPLORE_ENTITY_TYPE_IDS[0];
+    const hyphenated = `${first.slice(0, 8)}-${first.slice(8, 12)}-${first.slice(12, 16)}-${first.slice(16, 20)}-${first.slice(20)}`;
+    expect(parseExploreTypeIdsParam(`${hyphenated},unknown`)).toEqual([first]);
+  });
+});
+
+describe('sanitizeExploreTypeIds', () => {
+  it('ignores non-string values', () => {
+    expect(sanitizeExploreTypeIds([null, 42, EXPLORE_ENTITY_TYPE_IDS[0]])).toEqual([EXPLORE_ENTITY_TYPE_IDS[0]]);
+  });
+});
+
+describe('toggleExploreTypeId', () => {
+  it('checks and unchecks types while preserving canonical order', () => {
+    const [first, second] = EXPLORE_ENTITY_TYPE_IDS;
+    expect(toggleExploreTypeId([first, second], first)).toEqual([second]);
+    expect(toggleExploreTypeId([second], first)).toEqual([first, second]);
+  });
+
+  it('ignores unknown type IDs', () => {
+    expect(toggleExploreTypeId(EXPLORE_ENTITY_TYPE_IDS, 'unknown')).toEqual(EXPLORE_ENTITY_TYPE_IDS);
+  });
+});
+
+describe('exploreTypeFilterLabel', () => {
+  it('formats the selected type count', () => {
+    expect(exploreTypeFilterLabel(0)).toBe('0 types');
+    expect(exploreTypeFilterLabel(1)).toBe('1 type');
+    expect(exploreTypeFilterLabel(8)).toBe('8 types');
+  });
+});

--- a/apps/web/core/explore/explore-type-filter.ts
+++ b/apps/web/core/explore/explore-type-filter.ts
@@ -1,0 +1,59 @@
+import { EXPLORE_ENTITY_TYPES } from './explore-constants';
+
+export const EXPLORE_TYPE_FILTER_STORAGE_KEY = 'exploreSelectedTypeIds';
+
+const allowedTypeByNormalizedId = new Map(EXPLORE_ENTITY_TYPES.map(type => [normalizeId(type.id), type.id]));
+
+function normalizeId(id: string): string {
+  return id.replace(/-/g, '').toLowerCase();
+}
+
+function defaultExploreTypeIds(): string[] {
+  return EXPLORE_ENTITY_TYPES.map(type => type.id);
+}
+
+export function sanitizeExploreTypeIds(ids: readonly unknown[]): string[] {
+  const selected = new Set<string>();
+
+  for (const id of ids) {
+    if (typeof id !== 'string') continue;
+    const canonical = allowedTypeByNormalizedId.get(normalizeId(id));
+    if (canonical) selected.add(canonical);
+  }
+
+  return EXPLORE_ENTITY_TYPES.map(type => type.id).filter(id => selected.has(id));
+}
+
+/** Missing or corrupt cache means the default: every Explore type selected. */
+export function parseStoredExploreTypeIds(raw: string | null): string[] {
+  if (raw === null) return defaultExploreTypeIds();
+
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    return Array.isArray(parsed) ? sanitizeExploreTypeIds(parsed) : defaultExploreTypeIds();
+  } catch {
+    return defaultExploreTypeIds();
+  }
+}
+
+/** Missing query params preserve the historical all-types API behavior; an empty value means none. */
+export function parseExploreTypeIdsParam(raw: string | null): string[] {
+  if (raw === null) return defaultExploreTypeIds();
+  if (raw === '') return [];
+  return sanitizeExploreTypeIds(raw.split(','));
+}
+
+export function toggleExploreTypeId(selectedTypeIds: readonly string[], typeId: string): string[] {
+  const selected = new Set(sanitizeExploreTypeIds(selectedTypeIds));
+  const canonicalTypeId = allowedTypeByNormalizedId.get(normalizeId(typeId));
+  if (!canonicalTypeId) return [...selected];
+
+  if (selected.has(canonicalTypeId)) selected.delete(canonicalTypeId);
+  else selected.add(canonicalTypeId);
+
+  return EXPLORE_ENTITY_TYPES.map(type => type.id).filter(id => selected.has(id));
+}
+
+export function exploreTypeFilterLabel(selectedCount: number): string {
+  return `${selectedCount} ${selectedCount === 1 ? 'type' : 'types'}`;
+}

--- a/apps/web/partials/explore/explore-page.tsx
+++ b/apps/web/partials/explore/explore-page.tsx
@@ -40,6 +40,7 @@ export function ExplorePage({
           initialTime="month"
           initialSort="top"
           showSortFilter
+          showTypeFilter
           dividerBeforeFeed
           feedTopSpacingClassName=""
         />

--- a/apps/web/partials/feed/entity-feed.test.tsx
+++ b/apps/web/partials/feed/entity-feed.test.tsx
@@ -79,6 +79,19 @@ afterEach(() => {
 });
 
 describe('EntityFeed Explore type filter', () => {
+  it('omits the type parameter and does not persist before the user changes the default selection', async () => {
+    render(<EntityFeed apiEndpoint="/api/explore/feed" initialSpaceOptions={[]} showSortFilter showTypeFilter />);
+
+    await screen.findByText('11 types');
+    await waitFor(() => expect(mocks.queryOptions?.enabled).toBe(true));
+    expect(window.localStorage.getItem(EXPLORE_TYPE_FILTER_STORAGE_KEY)).toBeNull();
+
+    const queryFn = mocks.queryOptions?.queryFn as (args: { pageParam?: string }) => Promise<unknown>;
+    await queryFn({ pageParam: undefined });
+    const requestUrl = mocks.fetch.mock.calls[0]?.[0] as string;
+    expect(requestUrl).not.toContain('typeIds=');
+  });
+
   it('restores cached types, sends them to the feed, and persists checklist changes', async () => {
     const selectedTypeId = EXPLORE_ENTITY_TYPE_IDS[0];
     window.localStorage.setItem(EXPLORE_TYPE_FILTER_STORAGE_KEY, JSON.stringify([selectedTypeId]));
@@ -98,5 +111,11 @@ describe('EntityFeed Explore type filter', () => {
     fireEvent.click(screen.getByRole('button', { name: 'News story' }));
     await screen.findByText('0 types');
     await waitFor(() => expect(window.localStorage.getItem(EXPLORE_TYPE_FILTER_STORAGE_KEY)).toBe('[]'));
+  });
+
+  it('preserves the historical query key for feeds without the Explore type filter', () => {
+    render(<EntityFeed apiEndpoint="/api/activity/feed" lockedSpaceId="space-id" />);
+
+    expect(mocks.queryOptions?.queryKey).toEqual(['/api/activity/feed', 'new', 'week', 'space-id', null]);
   });
 });

--- a/apps/web/partials/feed/entity-feed.test.tsx
+++ b/apps/web/partials/feed/entity-feed.test.tsx
@@ -1,0 +1,102 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import * as React from 'react';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { EXPLORE_ENTITY_TYPE_IDS } from '~/core/explore/explore-constants';
+import { EXPLORE_TYPE_FILTER_STORAGE_KEY } from '~/core/explore/explore-type-filter';
+
+import { EntityFeed } from './entity-feed';
+
+const mocks = vi.hoisted(() => ({
+  queryOptions: null as Record<string, unknown> | null,
+  fetch: vi.fn(),
+}));
+
+function createLocalStorage(): Storage {
+  const values = new Map<string, string>();
+
+  return {
+    get length() {
+      return values.size;
+    },
+    clear: () => values.clear(),
+    getItem: key => values.get(key) ?? null,
+    key: index => [...values.keys()][index] ?? null,
+    removeItem: key => values.delete(key),
+    setItem: (key, value) => values.set(key, value),
+  };
+}
+
+vi.mock('@tanstack/react-query', () => ({
+  useInfiniteQuery: (options: Record<string, unknown>) => {
+    mocks.queryOptions = options;
+    return {
+      data: undefined,
+      isLoading: false,
+      isFetchingNextPage: false,
+      fetchNextPage: vi.fn(),
+      hasNextPage: false,
+      error: null,
+    };
+  },
+}));
+
+vi.mock('~/core/hooks/use-smart-account', () => ({
+  useSmartAccount: () => ({ smartAccount: null }),
+}));
+
+vi.mock('~/design-system/menu', () => ({
+  Menu: ({ trigger, children }: { trigger: React.ReactNode; children: React.ReactNode }) => (
+    <>
+      {trigger}
+      {children}
+    </>
+  ),
+  MenuItem: ({ children, onClick }: { children: React.ReactNode; onClick?: () => void }) => (
+    <button type="button" onClick={onClick}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock('~/partials/explore/explore-feed-card', () => ({
+  ExploreFeedCard: () => null,
+}));
+
+beforeEach(() => {
+  vi.stubGlobal('localStorage', createLocalStorage());
+  mocks.queryOptions = null;
+  mocks.fetch.mockReset();
+  mocks.fetch.mockResolvedValue({ ok: true, json: async () => ({ items: [], nextCursor: null }) });
+  vi.stubGlobal('fetch', mocks.fetch);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe('EntityFeed Explore type filter', () => {
+  it('restores cached types, sends them to the feed, and persists checklist changes', async () => {
+    const selectedTypeId = EXPLORE_ENTITY_TYPE_IDS[0];
+    window.localStorage.setItem(EXPLORE_TYPE_FILTER_STORAGE_KEY, JSON.stringify([selectedTypeId]));
+
+    render(<EntityFeed apiEndpoint="/api/explore/feed" initialSpaceOptions={[]} showSortFilter showTypeFilter />);
+
+    await screen.findByText('1 type');
+    await waitFor(() => expect(mocks.queryOptions?.enabled).toBe(true));
+
+    const queryFn = mocks.queryOptions?.queryFn as (args: { pageParam?: string }) => Promise<unknown>;
+    await queryFn({ pageParam: undefined });
+    expect(mocks.fetch).toHaveBeenCalledWith(
+      expect.stringContaining(`typeIds=${selectedTypeId}`),
+      expect.objectContaining({ credentials: 'include' })
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'News story' }));
+    await screen.findByText('0 types');
+    await waitFor(() => expect(window.localStorage.getItem(EXPLORE_TYPE_FILTER_STORAGE_KEY)).toBe('[]'));
+  });
+});

--- a/apps/web/partials/feed/entity-feed.test.tsx
+++ b/apps/web/partials/feed/entity-feed.test.tsx
@@ -131,6 +131,21 @@ describe('EntityFeed Explore type filter', () => {
     );
   });
 
+  it('selects and unselects all types from the menu action', async () => {
+    render(<EntityFeed apiEndpoint="/api/explore/feed" initialSpaceOptions={[]} showSortFilter showTypeFilter />);
+    await screen.findByText(exploreTypeFilterLabel(EXPLORE_ENTITY_TYPE_IDS.length));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Unselect all' }));
+    await screen.findByText('0 types');
+    await waitFor(() => expect(window.localStorage.getItem(EXPLORE_TYPE_FILTER_STORAGE_KEY)).toBe('[]'));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Select all' }));
+    await screen.findByText(exploreTypeFilterLabel(EXPLORE_ENTITY_TYPE_IDS.length));
+    await waitFor(() =>
+      expect(window.localStorage.getItem(EXPLORE_TYPE_FILTER_STORAGE_KEY)).toBe(JSON.stringify(EXPLORE_ENTITY_TYPE_IDS))
+    );
+  });
+
   it('preserves the historical query key for feeds without the Explore type filter', () => {
     render(<EntityFeed apiEndpoint="/api/activity/feed" lockedSpaceId="space-id" />);
 

--- a/apps/web/partials/feed/entity-feed.test.tsx
+++ b/apps/web/partials/feed/entity-feed.test.tsx
@@ -1,11 +1,11 @@
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 import * as React from 'react';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { EXPLORE_ENTITY_TYPE_IDS } from '~/core/explore/explore-constants';
-import { EXPLORE_TYPE_FILTER_STORAGE_KEY } from '~/core/explore/explore-type-filter';
+import { EXPLORE_TYPE_FILTER_STORAGE_KEY, exploreTypeFilterLabel } from '~/core/explore/explore-type-filter';
 
 import { EntityFeed } from './entity-feed';
 
@@ -82,7 +82,7 @@ describe('EntityFeed Explore type filter', () => {
   it('omits the type parameter and does not persist before the user changes the default selection', async () => {
     render(<EntityFeed apiEndpoint="/api/explore/feed" initialSpaceOptions={[]} showSortFilter showTypeFilter />);
 
-    await screen.findByText('11 types');
+    await screen.findByText(exploreTypeFilterLabel(EXPLORE_ENTITY_TYPE_IDS.length));
     await waitFor(() => expect(mocks.queryOptions?.enabled).toBe(true));
     expect(window.localStorage.getItem(EXPLORE_TYPE_FILTER_STORAGE_KEY)).toBeNull();
 
@@ -108,9 +108,27 @@ describe('EntityFeed Explore type filter', () => {
       expect.objectContaining({ credentials: 'include' })
     );
 
-    fireEvent.click(screen.getByRole('button', { name: 'News story' }));
+    fireEvent.click(screen.getByRole('button', { name: /News story/ }));
     await screen.findByText('0 types');
     await waitFor(() => expect(window.localStorage.getItem(EXPLORE_TYPE_FILTER_STORAGE_KEY)).toBe('[]'));
+  });
+
+  it('applies rapid toggles to the latest selection', async () => {
+    const [first, second, third] = EXPLORE_ENTITY_TYPE_IDS;
+    window.localStorage.setItem(EXPLORE_TYPE_FILTER_STORAGE_KEY, JSON.stringify([first]));
+
+    render(<EntityFeed apiEndpoint="/api/explore/feed" initialSpaceOptions={[]} showSortFilter showTypeFilter />);
+    await screen.findByText('1 type');
+
+    act(() => {
+      screen.getByRole('button', { name: /Episode/ }).click();
+      screen.getByRole('button', { name: /Post/ }).click();
+    });
+
+    await screen.findByText('3 types');
+    await waitFor(() =>
+      expect(window.localStorage.getItem(EXPLORE_TYPE_FILTER_STORAGE_KEY)).toBe(JSON.stringify([first, second, third]))
+    );
   });
 
   it('preserves the historical query key for feeds without the Explore type filter', () => {

--- a/apps/web/partials/feed/entity-feed.tsx
+++ b/apps/web/partials/feed/entity-feed.tsx
@@ -120,6 +120,7 @@ export function EntityFeed({
   const [spaceMenuOpen, setSpaceMenuOpen] = React.useState(false);
   const [selectedTypeIds, setSelectedTypeIds] = React.useState<string[]>([...EXPLORE_ENTITY_TYPE_IDS]);
   const [typeSelectionLoaded, setTypeSelectionLoaded] = React.useState(!showTypeFilter);
+  const shouldPersistTypeSelectionRef = React.useRef(false);
   const spaceId = lockedSpaceId ?? selectedSpaceId;
   const typeIds =
     showTypeFilter && selectedTypeIds.length !== EXPLORE_ENTITY_TYPE_IDS.length ? selectedTypeIds : undefined;
@@ -132,14 +133,16 @@ export function EntityFeed({
     setTypeSelectionLoaded(true);
   }, [showTypeFilter]);
 
-  const toggleType = React.useCallback(
-    (typeId: string) => {
-      const nextTypeIds = toggleExploreTypeId(selectedTypeIds, typeId);
-      setSelectedTypeIds(nextTypeIds);
-      window.localStorage.setItem(EXPLORE_TYPE_FILTER_STORAGE_KEY, JSON.stringify(nextTypeIds));
-    },
-    [selectedTypeIds]
-  );
+  React.useEffect(() => {
+    if (!showTypeFilter || !typeSelectionLoaded || !shouldPersistTypeSelectionRef.current) return;
+    shouldPersistTypeSelectionRef.current = false;
+    window.localStorage.setItem(EXPLORE_TYPE_FILTER_STORAGE_KEY, JSON.stringify(selectedTypeIds));
+  }, [selectedTypeIds, showTypeFilter, typeSelectionLoaded]);
+
+  const toggleType = React.useCallback((typeId: string) => {
+    shouldPersistTypeSelectionRef.current = true;
+    setSelectedTypeIds(current => toggleExploreTypeId(current, typeId));
+  }, []);
 
   // Key the query on the smart-account address because that hook is what writes the
   // WALLET_ADDRESS cookie the server route reads. Privy's user.id updates earlier

--- a/apps/web/partials/feed/entity-feed.tsx
+++ b/apps/web/partials/feed/entity-feed.tsx
@@ -144,6 +144,13 @@ export function EntityFeed({
     setSelectedTypeIds(current => toggleExploreTypeId(current, typeId));
   }, []);
 
+  const toggleAllTypes = React.useCallback(() => {
+    shouldPersistTypeSelectionRef.current = true;
+    setSelectedTypeIds(current =>
+      current.length === EXPLORE_ENTITY_TYPE_IDS.length ? [] : [...EXPLORE_ENTITY_TYPE_IDS]
+    );
+  }, []);
+
   // Key the query on the smart-account address because that hook is what writes the
   // WALLET_ADDRESS cookie the server route reads. Privy's user.id updates earlier
   // (before the cookie is set), which caused refetches to return anonymous data on
@@ -313,7 +320,11 @@ export function EntityFeed({
                 </Menu>
               ) : null}
               {showTypeFilter ? (
-                <ExploreTypeFilterMenu selectedTypeIds={selectedTypeIds} onToggleType={toggleType} />
+                <ExploreTypeFilterMenu
+                  selectedTypeIds={selectedTypeIds}
+                  onToggleType={toggleType}
+                  onToggleAll={toggleAllTypes}
+                />
               ) : null}
             </div>
           ) : null}

--- a/apps/web/partials/feed/entity-feed.tsx
+++ b/apps/web/partials/feed/entity-feed.tsx
@@ -121,7 +121,8 @@ export function EntityFeed({
   const [selectedTypeIds, setSelectedTypeIds] = React.useState<string[]>([...EXPLORE_ENTITY_TYPE_IDS]);
   const [typeSelectionLoaded, setTypeSelectionLoaded] = React.useState(!showTypeFilter);
   const spaceId = lockedSpaceId ?? selectedSpaceId;
-  const typeIds = showTypeFilter ? selectedTypeIds : undefined;
+  const typeIds =
+    showTypeFilter && selectedTypeIds.length !== EXPLORE_ENTITY_TYPE_IDS.length ? selectedTypeIds : undefined;
   const typeIdsKey = typeIds?.join(',') ?? null;
   const showFilterRow = showSortFilter || showTimeFilter || lockedSpaceId == null || showTypeFilter;
 
@@ -131,14 +132,14 @@ export function EntityFeed({
     setTypeSelectionLoaded(true);
   }, [showTypeFilter]);
 
-  React.useEffect(() => {
-    if (!showTypeFilter || !typeSelectionLoaded) return;
-    window.localStorage.setItem(EXPLORE_TYPE_FILTER_STORAGE_KEY, JSON.stringify(selectedTypeIds));
-  }, [selectedTypeIds, showTypeFilter, typeSelectionLoaded]);
-
-  const toggleType = React.useCallback((typeId: string) => {
-    setSelectedTypeIds(current => toggleExploreTypeId(current, typeId));
-  }, []);
+  const toggleType = React.useCallback(
+    (typeId: string) => {
+      const nextTypeIds = toggleExploreTypeId(selectedTypeIds, typeId);
+      setSelectedTypeIds(nextTypeIds);
+      window.localStorage.setItem(EXPLORE_TYPE_FILTER_STORAGE_KEY, JSON.stringify(nextTypeIds));
+    },
+    [selectedTypeIds]
+  );
 
   // Key the query on the smart-account address because that hook is what writes the
   // WALLET_ADDRESS cookie the server route reads. Privy's user.id updates earlier
@@ -146,9 +147,12 @@ export function EntityFeed({
   // sign-in and leave "Join space" buttons stuck for a few seconds.
   const { smartAccount } = useSmartAccount();
   const smartAccountAddress = smartAccount?.account.address ?? null;
+  const queryKey = showTypeFilter
+    ? [apiEndpoint, sort, time, spaceId, typeIdsKey, smartAccountAddress]
+    : [apiEndpoint, sort, time, spaceId, smartAccountAddress];
 
   const { data, isLoading, isFetchingNextPage, fetchNextPage, hasNextPage, error } = useInfiniteQuery({
-    queryKey: [apiEndpoint, sort, time, spaceId, typeIdsKey, smartAccountAddress],
+    queryKey,
     queryFn: ({ pageParam }) =>
       fetchFeedPage(apiEndpoint, { sort, time, spaceId, typeIds, cursor: pageParam as string | undefined }),
     initialPageParam: undefined as string | undefined,

--- a/apps/web/partials/feed/entity-feed.tsx
+++ b/apps/web/partials/feed/entity-feed.tsx
@@ -6,6 +6,12 @@ import * as React from 'react';
 
 import cx from 'classnames';
 
+import { EXPLORE_ENTITY_TYPE_IDS } from '~/core/explore/explore-constants';
+import {
+  EXPLORE_TYPE_FILTER_STORAGE_KEY,
+  parseStoredExploreTypeIds,
+  toggleExploreTypeId,
+} from '~/core/explore/explore-type-filter';
 import type { ExploreFeedItem, ExploreFeedResult, ExploreSort, ExploreTime } from '~/core/explore/fetch-explore-feed';
 import { useSmartAccount } from '~/core/hooks/use-smart-account';
 
@@ -14,6 +20,8 @@ import { Menu, MenuItem } from '~/design-system/menu';
 import { Skeleton } from '~/design-system/skeleton';
 
 import { ExploreFeedCard } from '~/partials/explore/explore-feed-card';
+
+import { ExploreTypeFilterMenu } from './explore-type-filter-menu';
 
 function LoadingSkeleton() {
   return (
@@ -57,6 +65,8 @@ type EntityFeedProps = {
   showTimeFilter?: boolean;
   /** Whether to render the sort dropdown (New / Top). Defaults to false. */
   showSortFilter?: boolean;
+  /** Whether to render the Explore-only, locally persisted type checklist. Defaults to false. */
+  showTypeFilter?: boolean;
   /** Override the spacing between the filter row and the feed. Defaults to `mt-8`. */
   feedTopSpacingClassName?: string;
   /** When true, renders a divider line between the filter row and the first feed card. */
@@ -69,6 +79,7 @@ async function fetchFeedPage(
     sort: ExploreSort;
     time: ExploreTime;
     spaceId: string;
+    typeIds: readonly string[] | undefined;
     cursor: string | undefined;
   }
 ): Promise<ExploreFeedResult> {
@@ -76,6 +87,7 @@ async function fetchFeedPage(
   sp.set('sort', params.sort);
   sp.set('time', params.time);
   sp.set('spaceId', params.spaceId);
+  if (params.typeIds !== undefined) sp.set('typeIds', params.typeIds.join(','));
   if (params.cursor) sp.set('cursor', params.cursor);
   const res = await fetch(`${apiEndpoint}?${sp.toString()}`, { credentials: 'include' });
   if (!res.ok) {
@@ -96,6 +108,7 @@ export function EntityFeed({
   initialSort = 'new',
   showTimeFilter = true,
   showSortFilter = false,
+  showTypeFilter = false,
   feedTopSpacingClassName,
   dividerBeforeFeed = false,
 }: EntityFeedProps) {
@@ -105,7 +118,27 @@ export function EntityFeed({
   const [sortMenuOpen, setSortMenuOpen] = React.useState(false);
   const [timeMenuOpen, setTimeMenuOpen] = React.useState(false);
   const [spaceMenuOpen, setSpaceMenuOpen] = React.useState(false);
+  const [selectedTypeIds, setSelectedTypeIds] = React.useState<string[]>([...EXPLORE_ENTITY_TYPE_IDS]);
+  const [typeSelectionLoaded, setTypeSelectionLoaded] = React.useState(!showTypeFilter);
   const spaceId = lockedSpaceId ?? selectedSpaceId;
+  const typeIds = showTypeFilter ? selectedTypeIds : undefined;
+  const typeIdsKey = typeIds?.join(',') ?? null;
+  const showFilterRow = showSortFilter || showTimeFilter || lockedSpaceId == null || showTypeFilter;
+
+  React.useEffect(() => {
+    if (!showTypeFilter) return;
+    setSelectedTypeIds(parseStoredExploreTypeIds(window.localStorage.getItem(EXPLORE_TYPE_FILTER_STORAGE_KEY)));
+    setTypeSelectionLoaded(true);
+  }, [showTypeFilter]);
+
+  React.useEffect(() => {
+    if (!showTypeFilter || !typeSelectionLoaded) return;
+    window.localStorage.setItem(EXPLORE_TYPE_FILTER_STORAGE_KEY, JSON.stringify(selectedTypeIds));
+  }, [selectedTypeIds, showTypeFilter, typeSelectionLoaded]);
+
+  const toggleType = React.useCallback((typeId: string) => {
+    setSelectedTypeIds(current => toggleExploreTypeId(current, typeId));
+  }, []);
 
   // Key the query on the smart-account address because that hook is what writes the
   // WALLET_ADDRESS cookie the server route reads. Privy's user.id updates earlier
@@ -115,13 +148,14 @@ export function EntityFeed({
   const smartAccountAddress = smartAccount?.account.address ?? null;
 
   const { data, isLoading, isFetchingNextPage, fetchNextPage, hasNextPage, error } = useInfiniteQuery({
-    queryKey: [apiEndpoint, sort, time, spaceId, smartAccountAddress],
+    queryKey: [apiEndpoint, sort, time, spaceId, typeIdsKey, smartAccountAddress],
     queryFn: ({ pageParam }) =>
-      fetchFeedPage(apiEndpoint, { sort, time, spaceId, cursor: pageParam as string | undefined }),
+      fetchFeedPage(apiEndpoint, { sort, time, spaceId, typeIds, cursor: pageParam as string | undefined }),
     initialPageParam: undefined as string | undefined,
     getNextPageParam: last => last.nextCursor ?? undefined,
     retry: 2,
     retryDelay: attemptIndex => Math.min(1000 * 2 ** attemptIndex, 8000),
+    enabled: typeSelectionLoaded,
   });
 
   const sentinelRef = React.useRef<HTMLDivElement | null>(null);
@@ -157,7 +191,7 @@ export function EntityFeed({
 
   return (
     <div className="mx-auto w-full max-w-[880px]">
-      {showSortFilter || showTimeFilter || lockedSpaceId == null ? (
+      {showFilterRow ? (
         <div className="flex flex-wrap items-center gap-3">
           {showSortFilter ? (
             <Menu
@@ -225,64 +259,65 @@ export function EntityFeed({
               ))}
             </Menu>
           ) : null}
-          {lockedSpaceId == null ? (
-            <div className="ml-auto">
-              <Menu
-                asChild
-                open={spaceMenuOpen}
-                onOpenChange={setSpaceMenuOpen}
-                sideOffset={8}
-                className="max-w-60 bg-white"
-                trigger={
-                  <button
-                    type="button"
-                    className="flex h-6 items-center gap-1.5 rounded border border-grey-02 pr-2 pl-1.5 text-metadata text-grey-04 shadow-button transition-colors duration-150 focus-within:border-text"
-                  >
-                    <span>{spaceLabel}</span>
-                    <span
-                      className={cx('inline-flex transition-transform duration-200', spaceMenuOpen && 'rotate-180')}
+          {lockedSpaceId == null || showTypeFilter ? (
+            <div className="ml-auto flex items-center gap-3">
+              {lockedSpaceId == null ? (
+                <Menu
+                  asChild
+                  open={spaceMenuOpen}
+                  onOpenChange={setSpaceMenuOpen}
+                  sideOffset={8}
+                  className="max-w-60 bg-white"
+                  trigger={
+                    <button
+                      type="button"
+                      className="flex h-6 items-center gap-1.5 rounded border border-grey-02 pr-2 pl-1.5 text-metadata text-grey-04 shadow-button transition-colors duration-150 focus-within:border-text"
                     >
-                      <ChevronDownSmall color="grey-04" />
-                    </span>
-                  </button>
-                }
-              >
-                <MenuItem
-                  active={selectedSpaceId === 'all'}
-                  onClick={() => {
-                    setSelectedSpaceId('all');
-                    setSpaceMenuOpen(false);
-                  }}
+                      <span>{spaceLabel}</span>
+                      <span
+                        className={cx('inline-flex transition-transform duration-200', spaceMenuOpen && 'rotate-180')}
+                      >
+                        <ChevronDownSmall color="grey-04" />
+                      </span>
+                    </button>
+                  }
                 >
-                  Any space
-                </MenuItem>
-                {initialSpaceOptions.map(o => (
                   <MenuItem
-                    key={o.value}
-                    active={o.value === selectedSpaceId}
+                    active={selectedSpaceId === 'all'}
                     onClick={() => {
-                      setSelectedSpaceId(o.value);
+                      setSelectedSpaceId('all');
                       setSpaceMenuOpen(false);
                     }}
                   >
-                    {o.label}
+                    Any space
                   </MenuItem>
-                ))}
-              </Menu>
+                  {initialSpaceOptions.map(o => (
+                    <MenuItem
+                      key={o.value}
+                      active={o.value === selectedSpaceId}
+                      onClick={() => {
+                        setSelectedSpaceId(o.value);
+                        setSpaceMenuOpen(false);
+                      }}
+                    >
+                      {o.label}
+                    </MenuItem>
+                  ))}
+                </Menu>
+              ) : null}
+              {showTypeFilter ? (
+                <ExploreTypeFilterMenu selectedTypeIds={selectedTypeIds} onToggleType={toggleType} />
+              ) : null}
             </div>
           ) : null}
         </div>
       ) : null}
 
       {dividerBeforeFeed ? <hr className="mt-5 border-t border-divider" /> : null}
-      <div
-        className={
-          feedTopSpacingClassName ?? (showSortFilter || showTimeFilter || lockedSpaceId == null ? 'mt-8' : '-mt-1')
-        }
-      >
+      <div className={feedTopSpacingClassName ?? (showFilterRow ? 'mt-8' : '-mt-1')}>
         {error ? (
           <p className="text-browseMenu text-red-01">Could not load the feed.</p>
-        ) : isLoading ? (
+        ) : isLoading || !typeSelectionLoaded ? (
           <div className="space-y-4">
             {Array.from({ length: 5 }).map((_, i) => (
               <LoadingSkeleton key={i} />

--- a/apps/web/partials/feed/explore-type-filter-menu.tsx
+++ b/apps/web/partials/feed/explore-type-filter-menu.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import * as React from 'react';
+
+import cx from 'classnames';
+
+import { EXPLORE_ENTITY_TYPES } from '~/core/explore/explore-constants';
+import { exploreTypeFilterLabel } from '~/core/explore/explore-type-filter';
+
+import { CheckboxVisual } from '~/design-system/checkbox';
+import { ChevronDownSmall } from '~/design-system/icons/chevron-down-small';
+import { Menu, MenuItem } from '~/design-system/menu';
+
+type Props = {
+  selectedTypeIds: readonly string[];
+  onToggleType: (typeId: string) => void;
+};
+
+export function ExploreTypeFilterMenu({ selectedTypeIds, onToggleType }: Props) {
+  const [open, setOpen] = React.useState(false);
+  const selected = React.useMemo(() => new Set(selectedTypeIds), [selectedTypeIds]);
+  const label = exploreTypeFilterLabel(selected.size);
+
+  return (
+    <Menu
+      asChild
+      open={open}
+      onOpenChange={setOpen}
+      sideOffset={8}
+      className="max-w-60 bg-white"
+      trigger={
+        <button
+          type="button"
+          className="flex h-6 items-center gap-1.5 rounded border border-grey-02 pr-2 pl-1.5 text-metadata text-grey-04 shadow-button transition-colors duration-150 focus-within:border-text"
+        >
+          <span>{label}</span>
+          <span className={cx('inline-flex transition-transform duration-200', open && 'rotate-180')}>
+            <ChevronDownSmall color="grey-04" />
+          </span>
+        </button>
+      }
+    >
+      {EXPLORE_ENTITY_TYPES.map(type => {
+        const checked = selected.has(type.id);
+        return (
+          <MenuItem key={type.id} onClick={() => onToggleType(type.id)}>
+            <CheckboxVisual checked={checked} />
+            <span>{type.label}</span>
+          </MenuItem>
+        );
+      })}
+    </Menu>
+  );
+}

--- a/apps/web/partials/feed/explore-type-filter-menu.tsx
+++ b/apps/web/partials/feed/explore-type-filter-menu.tsx
@@ -46,6 +46,7 @@ export function ExploreTypeFilterMenu({ selectedTypeIds, onToggleType }: Props) 
           <MenuItem key={type.id} onClick={() => onToggleType(type.id)}>
             <CheckboxVisual checked={checked} />
             <span>{type.label}</span>
+            <span className="sr-only">{checked ? 'Selected' : 'Not selected'}</span>
           </MenuItem>
         );
       })}

--- a/apps/web/partials/feed/explore-type-filter-menu.tsx
+++ b/apps/web/partials/feed/explore-type-filter-menu.tsx
@@ -14,12 +14,14 @@ import { Menu, MenuItem } from '~/design-system/menu';
 type Props = {
   selectedTypeIds: readonly string[];
   onToggleType: (typeId: string) => void;
+  onToggleAll: () => void;
 };
 
-export function ExploreTypeFilterMenu({ selectedTypeIds, onToggleType }: Props) {
+export function ExploreTypeFilterMenu({ selectedTypeIds, onToggleType, onToggleAll }: Props) {
   const [open, setOpen] = React.useState(false);
   const selected = React.useMemo(() => new Set(selectedTypeIds), [selectedTypeIds]);
   const label = exploreTypeFilterLabel(selected.size);
+  const allSelected = selected.size === EXPLORE_ENTITY_TYPES.length;
 
   return (
     <Menu
@@ -40,6 +42,9 @@ export function ExploreTypeFilterMenu({ selectedTypeIds, onToggleType }: Props) 
         </button>
       }
     >
+      <MenuItem className="border-b border-grey-02" onClick={onToggleAll}>
+        {allSelected ? 'Unselect all' : 'Select all'}
+      </MenuItem>
       {EXPLORE_ENTITY_TYPES.map(type => {
         const checked = selected.has(type.id);
         return (


### PR DESCRIPTION
## What changed

- added a type checklist to the right side of the Explore feed controls
- included all 11 hardcoded Explore entity types by default and showed the selected count in the trigger
- persisted the selection in browser local storage only
- passed selected type IDs through the Explore feed endpoint, including an explicit empty-selection response
- added unit and component coverage for cache parsing, filtering, request parameters, and persistence

## Why

Explore users need to narrow the feed by entity type without changing knowledge-graph data. The local cache remembers the preference on that browser and naturally resets to all types if storage is cleared.

## Validation

- `bun run test core/explore/explore-type-filter.test.ts partials/feed/entity-feed.test.tsx`
- `bun run test core/explore`
- ESLint on all changed files
- `bunx tsc --noEmit --pretty false`
- `git diff --check`
