### PR TITLE
feat: add browse filters to Explore data blocks

### DIFF
--- a/apps/web/core/blocks/data/explore-browse-filters.test.ts
+++ b/apps/web/core/blocks/data/explore-browse-filters.test.ts
@@ -1,0 +1,83 @@
+import { SystemIds } from '@geoprotocol/geo-sdk/lite';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  applyExploreBrowseWhere,
+  getExploreBlockTypeOptions,
+  refineExploreBlockTypeFilters,
+} from './explore-browse-filters';
+import type { Filter } from './filters';
+
+function typeFilter(value: string, valueName: string | null = null): Filter {
+  return {
+    columnId: SystemIds.TYPES_PROPERTY,
+    columnName: 'Types',
+    valueType: 'RELATION',
+    value,
+    valueName,
+  };
+}
+
+const nameFilter: Filter = {
+  columnId: SystemIds.NAME_PROPERTY,
+  columnName: 'Name',
+  valueType: 'TEXT',
+  value: 'Geo',
+  valueName: 'Geo',
+};
+
+describe('getExploreBlockTypeOptions', () => {
+  it('returns only configured type filters and deduplicates their IDs', () => {
+    expect(
+      getExploreBlockTypeOptions([nameFilter, typeFilter('type-a', 'Person'), typeFilter('type-a', 'Person')])
+    ).toEqual([{ id: 'type-a', label: 'Person' }]);
+  });
+
+  it('returns no options when the block does not filter by type', () => {
+    expect(getExploreBlockTypeOptions([nameFilter])).toEqual([]);
+  });
+});
+
+describe('refineExploreBlockTypeFilters', () => {
+  const configured = [nameFilter, typeFilter('type-a', 'Person'), typeFilter('type-b', 'Project')];
+
+  it('preserves configured filters until the user narrows the type selection', () => {
+    expect(refineExploreBlockTypeFilters(configured, undefined)).toEqual({
+      filters: configured,
+      hasConfiguredTypes: true,
+      hasNoSelectedTypes: false,
+    });
+  });
+
+  it('keeps non-type filters and only the selected configured types', () => {
+    expect(refineExploreBlockTypeFilters(configured, ['type-b'])).toEqual({
+      filters: [nameFilter, configured[2]],
+      hasConfiguredTypes: true,
+      hasNoSelectedTypes: false,
+    });
+  });
+
+  it('marks an empty configured-type selection so the query can return no rows', () => {
+    expect(refineExploreBlockTypeFilters(configured, [])).toEqual({
+      filters: [nameFilter],
+      hasConfiguredTypes: true,
+      hasNoSelectedTypes: true,
+    });
+  });
+});
+
+describe('applyExploreBrowseWhere', () => {
+  it('ANDs the rolling cutoff with the configured block query', () => {
+    const baseWhere = { types: [{ id: { equals: 'type-a' } }] };
+    expect(applyExploreBrowseWhere(baseWhere, { hasNoSelectedTypes: false, timeThresholdSec: 123 })).toEqual({
+      AND: [baseWhere, { createdAt: { greaterThanOrEqualTo: '123' } }],
+    });
+  });
+
+  it('uses an impossible ID set when all configured types are unselected', () => {
+    expect(applyExploreBrowseWhere({}, { hasNoSelectedTypes: true, timeThresholdSec: null })).toEqual({
+      id: { in: [] },
+    });
+  });
+});

--- a/apps/web/core/blocks/data/explore-browse-filters.ts
+++ b/apps/web/core/blocks/data/explore-browse-filters.ts
@@ -1,0 +1,56 @@
+import { SystemIds } from '@geoprotocol/geo-sdk/lite';
+
+import { ID } from '~/core/id';
+import type { WhereCondition } from '~/core/sync/experimental_query-layer';
+
+import type { Filter } from './filters';
+
+export type ExploreBlockTypeOption = {
+  id: string;
+  label: string;
+};
+
+export function getExploreBlockTypeOptions(filters: readonly Filter[]): ExploreBlockTypeOption[] {
+  const options: ExploreBlockTypeOption[] = [];
+
+  for (const filter of filters) {
+    if (!ID.equals(filter.columnId, SystemIds.TYPES_PROPERTY)) continue;
+    if (options.some(option => ID.equals(option.id, filter.value))) continue;
+    options.push({ id: filter.value, label: filter.valueName ?? filter.value });
+  }
+
+  return options;
+}
+
+export function refineExploreBlockTypeFilters(
+  filters: readonly Filter[],
+  selectedTypeIds: readonly string[] | undefined
+): { filters: Filter[]; hasConfiguredTypes: boolean; hasNoSelectedTypes: boolean } {
+  const hasConfiguredTypes = filters.some(filter => ID.equals(filter.columnId, SystemIds.TYPES_PROPERTY));
+
+  if (!hasConfiguredTypes || selectedTypeIds === undefined) {
+    return { filters: [...filters], hasConfiguredTypes, hasNoSelectedTypes: false };
+  }
+
+  const selected = selectedTypeIds.map(ID.uuidToHex);
+  return {
+    filters: filters.filter(
+      filter => !ID.equals(filter.columnId, SystemIds.TYPES_PROPERTY) || selected.includes(ID.uuidToHex(filter.value))
+    ),
+    hasConfiguredTypes: true,
+    hasNoSelectedTypes: selected.length === 0,
+  };
+}
+
+export function applyExploreBrowseWhere(
+  baseWhere: WhereCondition,
+  options: { hasNoSelectedTypes: boolean; timeThresholdSec: number | null }
+): WhereCondition {
+  if (options.hasNoSelectedTypes) return { id: { in: [] } };
+  if (options.timeThresholdSec === null) return baseWhere;
+
+  const createdAtWhere: WhereCondition = {
+    createdAt: { greaterThanOrEqualTo: String(options.timeThresholdSec) },
+  };
+  return Object.keys(baseWhere).length === 0 ? createdAtWhere : { AND: [baseWhere, createdAtWhere] };
+}

--- a/apps/web/core/blocks/data/use-data-block.tsx
+++ b/apps/web/core/blocks/data/use-data-block.tsx
@@ -5,6 +5,7 @@ import * as React from 'react';
 
 import { Effect } from 'effect';
 
+import { type ExploreTime, exploreTimeThresholdSec } from '~/core/explore/explore-time';
 import { ID } from '~/core/id';
 import { WhereCondition } from '~/core/sync/experimental_query-layer';
 import { useMutate } from '~/core/sync/use-mutate';
@@ -16,6 +17,7 @@ import { sortRows } from '~/core/utils/utils';
 import { useProperties } from '../../hooks/use-properties';
 import { DEFAULT_DATA_BLOCK_PAGE_SIZE } from './block-ontology-ids';
 import { mapSelectorLexiconToSourceEntity, parseSelectorIntoLexicon } from './data-selectors';
+import { applyExploreBrowseWhere, refineExploreBlockTypeFilters } from './explore-browse-filters';
 import { Filter, FilterMode } from './filters';
 import { Source } from './source';
 import { useBlockPageSize } from './use-block-page-size';
@@ -48,6 +50,10 @@ interface UseDataBlockOptions {
   filterState?: Filter[];
   filterMode?: FilterMode;
   canEdit?: boolean;
+  exploreBrowseFilters?: {
+    time: ExploreTime;
+    selectedTypeIds: readonly string[] | undefined;
+  };
 }
 
 export function useDataBlock(options?: UseDataBlockOptions) {
@@ -99,7 +105,7 @@ export function useDataBlock(options?: UseDataBlockOptions) {
 
   const activeFilterState = options?.canEdit ? dbResolvedFilterState : temporaryFilters;
   const activeFilterMode = options?.canEdit ? dbFilterMode : temporaryFilterMode;
-  const effectiveFilterState = options?.filterState ?? activeFilterState;
+  const baseFilterState = options?.filterState ?? activeFilterState;
   const effectiveFilterMode = options?.filterMode ?? activeFilterMode;
   const {
     shownColumnIds,
@@ -120,11 +126,33 @@ export function useDataBlock(options?: UseDataBlockOptions) {
   const { sortState, setSortState } = useSort(options?.canEdit);
   const pageSize = useBlockPageSize();
 
+  const applyExploreBrowseFilters = view === 'EXPLORE' && options?.exploreBrowseFilters !== undefined;
+  const typeRefinement = React.useMemo(
+    () =>
+      applyExploreBrowseFilters
+        ? refineExploreBlockTypeFilters(baseFilterState, options.exploreBrowseFilters?.selectedTypeIds)
+        : { filters: baseFilterState, hasConfiguredTypes: false, hasNoSelectedTypes: false },
+    [applyExploreBrowseFilters, baseFilterState, options?.exploreBrowseFilters?.selectedTypeIds]
+  );
+  const effectiveFilterState = typeRefinement.filters;
+
   const filterStateKey = React.useMemo(() => stableStringify(effectiveFilterState), [effectiveFilterState]);
-  const where = React.useMemo(
+  const baseWhere = React.useMemo(
     () => filterStateToWhere(effectiveFilterState, effectiveFilterMode),
     [filterStateKey, effectiveFilterMode]
   );
+  const exploreTime = applyExploreBrowseFilters ? options.exploreBrowseFilters?.time : undefined;
+  const exploreTimeThreshold = React.useMemo(
+    () => (exploreTime ? exploreTimeThresholdSec(exploreTime) : null),
+    [exploreTime]
+  );
+  const where = React.useMemo<WhereCondition>(() => {
+    return applyExploreBrowseWhere(baseWhere, {
+      hasNoSelectedTypes: typeRefinement.hasNoSelectedTypes,
+      timeThresholdSec: exploreTimeThreshold,
+    });
+  }, [baseWhere, exploreTimeThreshold, typeRefinement.hasNoSelectedTypes]);
+  const whereKey = React.useMemo(() => stableStringify(where), [where]);
 
   // Use the mapping to get the potential renderable properties.
   const propertiesSchema = useProperties(shownColumnIds, spaceId);
@@ -368,12 +396,12 @@ export function useDataBlock(options?: UseDataBlockOptions) {
   const sortKey = React.useMemo(() => stableStringify(serverSort ?? null), [serverSort]);
   const lastResetKeyRef = React.useRef<string | null>(null);
   React.useEffect(() => {
-    const key = `${filterStateKey}::${sortKey}::${pageSize}`;
+    const key = `${whereKey}::${sortKey}::${pageSize}`;
     if (lastResetKeyRef.current !== null && lastResetKeyRef.current !== key) {
       resetPagination();
     }
     lastResetKeyRef.current = key;
-  }, [filterStateKey, sortKey, pageSize, resetPagination]);
+  }, [whereKey, sortKey, pageSize, resetPagination]);
 
   const totalPages = Math.ceil(collectionData.totalCount / pageSize);
   const sortedRows = React.useMemo(

--- a/apps/web/core/explore/explore-time.test.ts
+++ b/apps/web/core/explore/explore-time.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+
+import { exploreTimeThresholdSec } from './explore-time';
+
+describe('exploreTimeThresholdSec', () => {
+  const nowMs = 2_000_000_000 * 1000;
+
+  it('uses the same rolling windows as the Explore feed', () => {
+    expect(exploreTimeThresholdSec('today', nowMs)).toBe(2_000_000_000 - 86400);
+    expect(exploreTimeThresholdSec('week', nowMs)).toBe(2_000_000_000 - 7 * 86400);
+    expect(exploreTimeThresholdSec('month', nowMs)).toBe(2_000_000_000 - 30 * 86400);
+    expect(exploreTimeThresholdSec('year', nowMs)).toBe(2_000_000_000 - 365 * 86400);
+  });
+
+  it('does not add a cutoff for all time', () => {
+    expect(exploreTimeThresholdSec('all', nowMs)).toBeNull();
+  });
+});

--- a/apps/web/core/explore/explore-time.ts
+++ b/apps/web/core/explore/explore-time.ts
@@ -1,0 +1,26 @@
+export type ExploreTime = 'today' | 'week' | 'month' | 'year' | 'all';
+
+export const EXPLORE_TIME_OPTIONS: readonly { value: ExploreTime; label: string }[] = [
+  { value: 'today', label: 'Today' },
+  { value: 'week', label: 'This week' },
+  { value: 'month', label: 'Last month' },
+  { value: 'year', label: 'Last year' },
+  { value: 'all', label: 'All time' },
+];
+
+export function exploreTimeThresholdSec(filter: ExploreTime, nowMs = Date.now()): number | null {
+  const now = Math.floor(nowMs / 1000);
+  switch (filter) {
+    case 'today':
+      return now - 86400;
+    case 'week':
+      return now - 7 * 86400;
+    case 'month':
+      return now - 30 * 86400;
+    case 'year':
+      return now - 365 * 86400;
+    case 'all':
+    default:
+      return null;
+  }
+}

--- a/apps/web/core/explore/fetch-explore-feed.ts
+++ b/apps/web/core/explore/fetch-explore-feed.ts
@@ -21,9 +21,10 @@ import {
 import { exploreEntitiesByPropertyConnectionDocument } from './explore-entities-by-property-document';
 import { exploreEntitiesConnectionDocument } from './explore-entities-document';
 import { parseEntityUpdatedAtToUnixSec } from './explore-relative-time';
+import { type ExploreTime, exploreTimeThresholdSec } from './explore-time';
 
 export type ExploreSort = 'new' | 'top';
-export type ExploreTime = 'today' | 'week' | 'month' | 'year' | 'all';
+export type { ExploreTime } from './explore-time';
 
 export type ExploreFeedItem = {
   entityId: string;
@@ -71,23 +72,6 @@ const FEED_EXCLUDED_RELATIONS_FILTER = {
     },
   },
 } satisfies EntityFilter;
-
-function timeThresholdSec(filter: ExploreTime): number | null {
-  const now = Math.floor(Date.now() / 1000);
-  switch (filter) {
-    case 'today':
-      return now - 86400;
-    case 'week':
-      return now - 7 * 86400;
-    case 'month':
-      return now - 30 * 86400;
-    case 'year':
-      return now - 365 * 86400;
-    case 'all':
-    default:
-      return null;
-  }
-}
 
 function pickDisplaySpaceId(entity: Entity, allowed: Set<string>): string | null {
   for (const sid of entity.spaces) {
@@ -185,7 +169,7 @@ function buildFeedFilter(args: {
   requireName?: boolean;
   includeEntityScopeInFilter?: boolean;
 }): EntityFilter {
-  const t = timeThresholdSec(args.time);
+  const t = exploreTimeThresholdSec(args.time);
   return {
     ...FEED_EXCLUDED_RELATIONS_FILTER,
     ...(args.includeEntityScopeInFilter

--- a/apps/web/core/io/converters.test.ts
+++ b/apps/web/core/io/converters.test.ts
@@ -98,3 +98,11 @@ describe('convertWhereConditionToEntityFilter empty-name exclusion', () => {
     });
   });
 });
+
+describe('convertWhereConditionToEntityFilter created-at filtering', () => {
+  it('passes a rolling time cutoff to the entity filter', () => {
+    expect(convertWhereConditionToEntityFilter({ createdAt: { greaterThanOrEqualTo: '1900000000' } })).toEqual({
+      and: [{ createdAt: { greaterThanOrEqualTo: '1900000000' } }, { name: { isNull: false, isNot: '' } }],
+    });
+  });
+});

--- a/apps/web/core/io/converters.ts
+++ b/apps/web/core/io/converters.ts
@@ -58,6 +58,10 @@ function convertStringConditionToStringFilter(condition: StringCondition | undef
     filter.in = condition.in;
   }
 
+  if (condition.greaterThanOrEqualTo !== undefined) {
+    filter.greaterThanOrEqualTo = condition.greaterThanOrEqualTo;
+  }
+
   return Object.keys(filter).length > 0 ? filter : undefined;
 }
 
@@ -262,6 +266,10 @@ function convertWhereConditionToEntityFilterInner(where: WhereCondition): Entity
 
   if (where.description) {
     filter.description = convertStringConditionToStringFilter(where.description);
+  }
+
+  if (where.createdAt) {
+    filter.createdAt = convertStringConditionToStringFilter(where.createdAt);
   }
 
   // Handle types - convert to typeIds filter field.

--- a/apps/web/core/sync/experimental_query-layer.test.ts
+++ b/apps/web/core/sync/experimental_query-layer.test.ts
@@ -4,7 +4,7 @@ import type { Entity } from '~/core/types';
 
 import { EntityQuery } from './experimental_query-layer';
 
-function entity(id: string, createdAt: string | number): Entity {
+function entity(id: string, createdAt: string | number | undefined): Entity {
   return {
     id,
     name: id,
@@ -27,5 +27,16 @@ describe('EntityQuery createdAt filtering', () => {
         .execute()
         .map(item => item.id)
     ).toEqual(['new', 'iso']);
+  });
+
+  it('does not treat a missing timestamp as the Unix epoch', () => {
+    const entities = [entity('missing', undefined), entity('epoch', 0)];
+
+    expect(
+      new EntityQuery(entities)
+        .where({ createdAt: { greaterThanOrEqualTo: '0' } })
+        .execute()
+        .map(item => item.id)
+    ).toEqual(['epoch']);
   });
 });

--- a/apps/web/core/sync/experimental_query-layer.test.ts
+++ b/apps/web/core/sync/experimental_query-layer.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+
+import type { Entity } from '~/core/types';
+
+import { EntityQuery } from './experimental_query-layer';
+
+function entity(id: string, createdAt: string | number): Entity {
+  return {
+    id,
+    name: id,
+    description: null,
+    spaces: [],
+    types: [],
+    relations: [],
+    values: [],
+    createdAt,
+  };
+}
+
+describe('EntityQuery createdAt filtering', () => {
+  it('supports numeric rolling-time cutoffs for locally filtered collection rows', () => {
+    const entities = [entity('old', 100), entity('new', '200'), entity('iso', '1970-01-01T00:03:20.000Z')];
+
+    expect(
+      new EntityQuery(entities)
+        .where({ createdAt: { greaterThanOrEqualTo: '150' } })
+        .execute()
+        .map(item => item.id)
+    ).toEqual(['new', 'iso']);
+  });
+});

--- a/apps/web/core/sync/experimental_query-layer.ts
+++ b/apps/web/core/sync/experimental_query-layer.ts
@@ -22,6 +22,14 @@ const compareOperators = {
   },
 };
 
+function parseTimestampSec(value: string): number | null {
+  const numeric = Number(value);
+  if (Number.isFinite(numeric)) return numeric > 1e12 ? Math.floor(numeric / 1000) : numeric;
+
+  const milliseconds = Date.parse(value);
+  return Number.isFinite(milliseconds) ? Math.floor(milliseconds / 1000) : null;
+}
+
 /**
  * Types for query conditions
  */
@@ -32,6 +40,7 @@ export type StringCondition = {
   startsWith?: string;
   endsWith?: string;
   in?: string[];
+  greaterThanOrEqualTo?: string;
 };
 
 export type NumberCondition = {
@@ -68,6 +77,7 @@ export type WhereCondition = {
   id?: StringCondition;
   name?: StringCondition;
   description?: StringCondition;
+  createdAt?: StringCondition;
   types?: { id?: StringCondition; name?: StringCondition }[];
   spaces?: StringCondition[];
   space?: { id?: StringCondition };
@@ -283,6 +293,9 @@ export class EntityQuery {
 
       case 'description':
         return this.matchesStringCondition(entity.description || '', condition);
+
+      case 'createdAt':
+        return this.matchesStringCondition(String(entity.createdAt ?? ''), condition);
 
       case 'spaces':
         if (condition === undefined) {
@@ -510,6 +523,16 @@ export class EntityQuery {
       if (!condition.in.includes(value)) {
         return false;
       }
+    }
+
+    if (condition.greaterThanOrEqualTo !== undefined) {
+      const actualNumber = parseTimestampSec(value);
+      const thresholdNumber = parseTimestampSec(condition.greaterThanOrEqualTo);
+      const matches =
+        actualNumber !== null && thresholdNumber !== null
+          ? actualNumber >= thresholdNumber
+          : value >= condition.greaterThanOrEqualTo;
+      if (!matches) return false;
     }
 
     return true;

--- a/apps/web/core/sync/experimental_query-layer.ts
+++ b/apps/web/core/sync/experimental_query-layer.ts
@@ -23,10 +23,13 @@ const compareOperators = {
 };
 
 function parseTimestampSec(value: string): number | null {
-  const numeric = Number(value);
+  const trimmed = value.trim();
+  if (trimmed === '') return null;
+
+  const numeric = Number(trimmed);
   if (Number.isFinite(numeric)) return numeric > 1e12 ? Math.floor(numeric / 1000) : numeric;
 
-  const milliseconds = Date.parse(value);
+  const milliseconds = Date.parse(trimmed);
   return Number.isFinite(milliseconds) ? Math.floor(milliseconds / 1000) : null;
 }
 

--- a/apps/web/partials/blocks/table/data-block-explore-browse-filters.test.tsx
+++ b/apps/web/partials/blocks/table/data-block-explore-browse-filters.test.tsx
@@ -1,0 +1,70 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+
+import * as React from 'react';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { DataBlockExploreBrowseFilters } from './data-block-explore-browse-filters';
+
+vi.mock('~/design-system/menu', () => ({
+  Menu: ({ trigger, children }: { trigger: React.ReactNode; children: React.ReactNode }) => (
+    <>
+      {trigger}
+      {children}
+    </>
+  ),
+  MenuItem: ({ children, onClick }: { children: React.ReactNode; onClick?: () => void }) => (
+    <button type="button" onClick={onClick}>
+      {children}
+    </button>
+  ),
+}));
+
+afterEach(cleanup);
+
+describe('DataBlockExploreBrowseFilters', () => {
+  it('always shows time but hides the type menu without configured type filters', () => {
+    render(
+      <DataBlockExploreBrowseFilters
+        time="all"
+        onTimeChange={vi.fn()}
+        typeOptions={[]}
+        selectedTypeIds={[]}
+        onToggleType={vi.fn()}
+        onToggleAllTypes={vi.fn()}
+      />
+    );
+
+    expect(screen.getAllByText('All time').length).toBeGreaterThan(0);
+    expect(screen.queryByText('0 types')).toBeNull();
+  });
+
+  it('only lists configured types and forwards time and type actions', () => {
+    const onTimeChange = vi.fn();
+    const onToggleType = vi.fn();
+    const onToggleAllTypes = vi.fn();
+
+    render(
+      <DataBlockExploreBrowseFilters
+        time="month"
+        onTimeChange={onTimeChange}
+        typeOptions={[
+          { id: 'type-a', label: 'Person' },
+          { id: 'type-b', label: 'Project' },
+        ]}
+        selectedTypeIds={['type-a', 'type-b']}
+        onToggleType={onToggleType}
+        onToggleAllTypes={onToggleAllTypes}
+      />
+    );
+
+    expect(screen.getByText('2 types')).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: /Person/ }));
+    fireEvent.click(screen.getByRole('button', { name: 'Unselect all' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Last year' }));
+
+    expect(onToggleType).toHaveBeenCalledWith('type-a');
+    expect(onToggleAllTypes).toHaveBeenCalledOnce();
+    expect(onTimeChange).toHaveBeenCalledWith('year');
+  });
+});

--- a/apps/web/partials/blocks/table/data-block-explore-browse-filters.tsx
+++ b/apps/web/partials/blocks/table/data-block-explore-browse-filters.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import * as React from 'react';
+
+import cx from 'classnames';
+
+import type { ExploreBlockTypeOption } from '~/core/blocks/data/explore-browse-filters';
+import { EXPLORE_TIME_OPTIONS, type ExploreTime } from '~/core/explore/explore-time';
+
+import { CheckboxVisual } from '~/design-system/checkbox';
+import { ChevronDownSmall } from '~/design-system/icons/chevron-down-small';
+import { Menu, MenuItem } from '~/design-system/menu';
+
+type Props = {
+  time: ExploreTime;
+  onTimeChange: (time: ExploreTime) => void;
+  typeOptions: readonly ExploreBlockTypeOption[];
+  selectedTypeIds: readonly string[];
+  onToggleType: (typeId: string) => void;
+  onToggleAllTypes: () => void;
+};
+
+const triggerClassName =
+  'flex h-6 items-center gap-1.5 rounded border border-grey-02 pr-2 pl-1.5 text-metadata text-grey-04 shadow-button transition-colors duration-150 focus-within:border-text';
+
+export function DataBlockExploreBrowseFilters({
+  time,
+  onTimeChange,
+  typeOptions,
+  selectedTypeIds,
+  onToggleType,
+  onToggleAllTypes,
+}: Props) {
+  const [timeMenuOpen, setTimeMenuOpen] = React.useState(false);
+  const [typeMenuOpen, setTypeMenuOpen] = React.useState(false);
+  const selectedTypes = React.useMemo(() => new Set(selectedTypeIds), [selectedTypeIds]);
+  const timeLabel = EXPLORE_TIME_OPTIONS.find(option => option.value === time)?.label ?? time;
+  const typeLabel = `${selectedTypes.size} ${selectedTypes.size === 1 ? 'type' : 'types'}`;
+  const allTypesSelected = selectedTypes.size === typeOptions.length;
+
+  return (
+    <>
+      <Menu
+        asChild
+        open={timeMenuOpen}
+        onOpenChange={setTimeMenuOpen}
+        sideOffset={8}
+        className="max-w-60 bg-white"
+        trigger={
+          <button type="button" className={triggerClassName}>
+            <span>{timeLabel}</span>
+            <span className={cx('inline-flex transition-transform duration-200', timeMenuOpen && 'rotate-180')}>
+              <ChevronDownSmall color="grey-04" />
+            </span>
+          </button>
+        }
+      >
+        {EXPLORE_TIME_OPTIONS.map(option => (
+          <MenuItem
+            key={option.value}
+            active={option.value === time}
+            onClick={() => {
+              onTimeChange(option.value);
+              setTimeMenuOpen(false);
+            }}
+          >
+            {option.label}
+          </MenuItem>
+        ))}
+      </Menu>
+
+      {typeOptions.length > 0 ? (
+        <Menu
+          asChild
+          open={typeMenuOpen}
+          onOpenChange={setTypeMenuOpen}
+          sideOffset={8}
+          className="max-w-60 bg-white"
+          trigger={
+            <button type="button" className={triggerClassName}>
+              <span>{typeLabel}</span>
+              <span className={cx('inline-flex transition-transform duration-200', typeMenuOpen && 'rotate-180')}>
+                <ChevronDownSmall color="grey-04" />
+              </span>
+            </button>
+          }
+        >
+          <MenuItem className="border-b border-grey-02" onClick={onToggleAllTypes}>
+            {allTypesSelected ? 'Unselect all' : 'Select all'}
+          </MenuItem>
+          {typeOptions.map(type => {
+            const checked = selectedTypes.has(type.id);
+            return (
+              <MenuItem key={type.id} onClick={() => onToggleType(type.id)}>
+                <CheckboxVisual checked={checked} />
+                <span>{type.label}</span>
+                <span className="sr-only">{checked ? 'Selected' : 'Not selected'}</span>
+              </MenuItem>
+            );
+          })}
+        </Menu>
+      ) : null}
+    </>
+  );
+}

--- a/apps/web/partials/blocks/table/data-block-header-action-visibility.test.ts
+++ b/apps/web/partials/blocks/table/data-block-header-action-visibility.test.ts
@@ -4,6 +4,7 @@ import type { DataBlockView } from '~/core/blocks/data/use-view';
 
 import {
   filterPanelOpenStateForActions,
+  shouldShowExploreBrowseFilters,
   shouldShowFilterAndFullscreenActions,
 } from './data-block-header-action-visibility';
 
@@ -22,6 +23,14 @@ describe('shouldShowFilterAndFullscreenActions', () => {
       expect(shouldShowFilterAndFullscreenActions(view, false)).toBe(true);
     }
   );
+});
+
+describe('shouldShowExploreBrowseFilters', () => {
+  it('only shows the controls for Explore view in browse mode', () => {
+    expect(shouldShowExploreBrowseFilters('EXPLORE', false)).toBe(true);
+    expect(shouldShowExploreBrowseFilters('EXPLORE', true)).toBe(false);
+    expect(shouldShowExploreBrowseFilters('TABLE', false)).toBe(false);
+  });
 });
 
 describe('filterPanelOpenStateForActions', () => {

--- a/apps/web/partials/blocks/table/data-block-header-action-visibility.ts
+++ b/apps/web/partials/blocks/table/data-block-header-action-visibility.ts
@@ -5,6 +5,10 @@ export function shouldShowFilterAndFullscreenActions(view: DataBlockView, isEdit
   return isEditing || view !== 'EXPLORE';
 }
 
+export function shouldShowExploreBrowseFilters(view: DataBlockView, isEditing: boolean): boolean {
+  return view === 'EXPLORE' && !isEditing;
+}
+
 /** A hidden filter toggle must not leave its panel open with no way to close it. */
 export function filterPanelOpenStateForActions(isFilterOpen: boolean, showActions: boolean): boolean {
   return showActions && isFilterOpen;

--- a/apps/web/partials/blocks/table/table-block.tsx
+++ b/apps/web/partials/blocks/table/table-block.tsx
@@ -11,6 +11,7 @@ import { produce } from 'immer';
 
 import { type RowPage, flattenRowPages, upsertRowPage } from '~/core/blocks/data/accumulate-row-pages';
 import { upsertCollectionItemRelation } from '~/core/blocks/data/collection';
+import { getExploreBlockTypeOptions } from '~/core/blocks/data/explore-browse-filters';
 import { Filter, FilterMode } from '~/core/blocks/data/filters';
 import { columnPropertyIdFromRelation } from '~/core/blocks/data/shown-column-relations';
 import { Source } from '~/core/blocks/data/source';
@@ -22,6 +23,7 @@ import {
   useOptimisticRows,
 } from '~/core/blocks/data/use-optimistic-rows';
 import { useSource } from '~/core/blocks/data/use-source';
+import { type ExploreTime } from '~/core/explore/explore-time';
 import { useCreatableSpaceIds } from '~/core/hooks/use-creatable-space-ids';
 import { useCreateEntityWithFilters } from '~/core/hooks/use-create-entity-with-filters';
 import { useInfiniteScrollSentinel } from '~/core/hooks/use-infinite-scroll-sentinel';
@@ -54,10 +56,12 @@ import { NextButton, PageNumber, PreviousButton } from '~/design-system/table/ta
 import { Text } from '~/design-system/text';
 
 import { onChangeEntryFn, writeValue } from './change-entry';
-import { shouldShowCreateEntityAction } from './data-block-create-entity-visibility';
 import { DataBlockCreateEntitySpaceDropdown } from './data-block-create-entity-space-dropdown';
+import { shouldShowCreateEntityAction } from './data-block-create-entity-visibility';
+import { DataBlockExploreBrowseFilters } from './data-block-explore-browse-filters';
 import {
   filterPanelOpenStateForActions,
+  shouldShowExploreBrowseFilters,
   shouldShowFilterAndFullscreenActions,
 } from './data-block-header-action-visibility';
 import { DataBlockScopeDropdown } from './data-block-scope-dropdown';
@@ -549,6 +553,8 @@ const ConfiguredTableBlock = ({
   const { setEditable } = useEditable();
   const isEditing = useUserIsEditing(spaceId);
   const canEdit = useCanUserEdit(spaceId);
+  const [exploreTime, setExploreTime] = React.useState<ExploreTime>('all');
+  const [selectedExploreTypeIds, setSelectedExploreTypeIds] = React.useState<string[] | undefined>(undefined);
 
   // Track if unfiltered data has multiple pages (to keep pagination visible when filtering)
   const [hasMultiplePagesWhenUnfiltered, setHasMultiplePagesWhenUnfiltered] = React.useState(false);
@@ -587,7 +593,51 @@ const ConfiguredTableBlock = ({
     hideAllShownPropertyColumns,
     orderedShownColumnRelations,
     reorderShownPropertyRelations,
-  } = useDataBlock({ canEdit });
+    resolvedFilterState: configuredFilters,
+  } = useDataBlock({
+    canEdit,
+    exploreBrowseFilters: !isEditing
+      ? {
+          time: exploreTime,
+          selectedTypeIds: selectedExploreTypeIds,
+        }
+      : undefined,
+  });
+
+  const exploreTypeOptions = React.useMemo(() => getExploreBlockTypeOptions(configuredFilters), [configuredFilters]);
+  const exploreTypeOptionsKey = React.useMemo(
+    () => exploreTypeOptions.map(option => ID.uuidToHex(option.id)).join(','),
+    [exploreTypeOptions]
+  );
+  const allExploreTypeIds = React.useMemo(() => exploreTypeOptions.map(option => option.id), [exploreTypeOptions]);
+  const visibleExploreTypeIds = selectedExploreTypeIds ?? allExploreTypeIds;
+
+  React.useEffect(() => {
+    setSelectedExploreTypeIds(undefined);
+  }, [blockEntityId, exploreTypeOptionsKey]);
+
+  React.useEffect(() => {
+    setExploreTime('all');
+  }, [blockEntityId]);
+
+  const toggleExploreType = React.useCallback(
+    (typeId: string) => {
+      setSelectedExploreTypeIds(current => {
+        const selected = new Set((current ?? allExploreTypeIds).map(ID.uuidToHex));
+        const normalizedTypeId = ID.uuidToHex(typeId);
+        if (selected.has(normalizedTypeId)) selected.delete(normalizedTypeId);
+        else selected.add(normalizedTypeId);
+        return allExploreTypeIds.filter(id => selected.has(ID.uuidToHex(id)));
+      });
+    },
+    [allExploreTypeIds]
+  );
+
+  const toggleAllExploreTypes = React.useCallback(() => {
+    setSelectedExploreTypeIds(current =>
+      (current ?? allExploreTypeIds).length === allExploreTypeIds.length ? [] : undefined
+    );
+  }, [allExploreTypeIds]);
 
   const initialFiltersOpenConsumedRef = React.useRef(false);
   React.useEffect(() => {
@@ -723,8 +773,9 @@ const ConfiguredTableBlock = ({
         filters: activeFilters.map(f => ({ c: f.columnId, v: f.value })),
         filterMode: activeFilterMode,
         sort: sortState ?? null,
+        time: isInfiniteExplore ? exploreTime : 'all',
       }),
-    [isInfiniteExplore, pageSize, source, activeFilters, activeFilterMode, sortState]
+    [isInfiniteExplore, pageSize, source, activeFilters, activeFilterMode, sortState, exploreTime]
   );
 
   React.useEffect(() => {
@@ -971,6 +1022,7 @@ const ConfiguredTableBlock = ({
   const showToolbarSort = isEditing || sortState !== null;
   const showToolbarDividerAfterScope = showToolbarSort || isEditing;
   const showFilterAndFullscreenActions = shouldShowFilterAndFullscreenActions(view, isEditing);
+  const showExploreBrowseFilters = shouldShowExploreBrowseFilters(view, isEditing);
 
   React.useEffect(() => {
     setIsFilterOpen(current => filterPanelOpenStateForActions(current, showFilterAndFullscreenActions));
@@ -1012,6 +1064,16 @@ const ConfiguredTableBlock = ({
               </Link>
             </>
           )}
+          {showExploreBrowseFilters ? (
+            <DataBlockExploreBrowseFilters
+              time={exploreTime}
+              onTimeChange={setExploreTime}
+              typeOptions={exploreTypeOptions}
+              selectedTypeIds={visibleExploreTypeIds}
+              onToggleType={toggleExploreType}
+              onToggleAllTypes={toggleAllExploreTypes}
+            />
+          ) : null}
           <DataBlockViewMenu activeView={view} isLoading={isLoading} />
           <TableBlockContextMenu sourceType={source.type} />
           {showCreateEntityPlus &&

--- a/apps/web/partials/feed/entity-feed.tsx
+++ b/apps/web/partials/feed/entity-feed.tsx
@@ -7,12 +7,13 @@ import * as React from 'react';
 import cx from 'classnames';
 
 import { EXPLORE_ENTITY_TYPE_IDS } from '~/core/explore/explore-constants';
+import { EXPLORE_TIME_OPTIONS, type ExploreTime } from '~/core/explore/explore-time';
 import {
   EXPLORE_TYPE_FILTER_STORAGE_KEY,
   parseStoredExploreTypeIds,
   toggleExploreTypeId,
 } from '~/core/explore/explore-type-filter';
-import type { ExploreFeedItem, ExploreFeedResult, ExploreSort, ExploreTime } from '~/core/explore/fetch-explore-feed';
+import type { ExploreFeedItem, ExploreFeedResult, ExploreSort } from '~/core/explore/fetch-explore-feed';
 import { useSmartAccount } from '~/core/hooks/use-smart-account';
 
 import { ChevronDownSmall } from '~/design-system/icons/chevron-down-small';
@@ -38,14 +39,6 @@ function LoadingSkeleton() {
 const SORT_OPTIONS: { value: ExploreSort; label: string }[] = [
   { value: 'new', label: 'New' },
   { value: 'top', label: 'Top' },
-];
-
-const TIME_OPTIONS: { value: ExploreTime; label: string }[] = [
-  { value: 'today', label: 'Today' },
-  { value: 'week', label: 'This week' },
-  { value: 'month', label: 'Last month' },
-  { value: 'year', label: 'Last year' },
-  { value: 'all', label: 'All time' },
 ];
 
 export type SpaceOption = { value: string; label: string };
@@ -196,7 +189,7 @@ export function EntityFeed({
     return flat;
   }, [data?.pages]);
 
-  const timeLabel = TIME_OPTIONS.find(o => o.value === time)?.label ?? time;
+  const timeLabel = EXPLORE_TIME_OPTIONS.find(o => o.value === time)?.label ?? time;
   const sortLabel = SORT_OPTIONS.find(o => o.value === sort)?.label ?? sort;
   const spaceLabel =
     selectedSpaceId === 'all'
@@ -259,7 +252,7 @@ export function EntityFeed({
                 </button>
               }
             >
-              {TIME_OPTIONS.map(o => (
+              {EXPLORE_TIME_OPTIONS.map(o => (
                 <MenuItem
                   key={o.value}
                   active={o.value === time}


### PR DESCRIPTION
## What changed

- added an `All time` / `Today` / `This week` / `Last month` / `Last year` dropdown to Explore-view data blocks
- added a type checklist containing only the types configured in the data block's saved filters
- hid the type dropdown when the block has no type filter and hid both controls outside Browse-mode Explore view
- positioned both controls in the right-side header immediately before the context menu
- applied both choices to the existing paginated query and reset infinite-scroll accumulation when they change
- kept browse choices ephemeral; no knowledge-graph values are written

## Implementation notes

The shared Explore time options and rolling cutoff are reused by the main Explore feed and data blocks. The query layer now supports `createdAt >=` for both remote paginated queries and locally filtered collection rows. An empty type selection produces an intentionally empty query instead of broadening the block.

## Validation

- 40 focused Explore/data-block tests
- 84 broader data-block/query regression tests
- `bunx tsc --noEmit --pretty false`
- ESLint on all changed files: no errors (three pre-existing `table-block.tsx` warnings also occur on `origin/master`)
- Prettier and `git diff --check`
