### PR TITLE
fix(debates): prevent flashes during flow handoffs

### DIFF
--- a/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
@@ -2031,6 +2031,8 @@ describe('DebateRoomPageClient', () => {
 
     persistence.resolve();
     await waitFor(() => expect(mocks.replace).toHaveBeenCalledWith('/space/space-1/debates/rematches/rematch-1'));
+    expect(screen.getByRole('dialog', { name: 'Debate recording' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Saving local recording' })).toBeDisabled();
   });
 
   it('persists the recording at the canonical debate deadline without waiting for thanking status', async () => {

--- a/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.tsx
@@ -1149,7 +1149,6 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
       disconnectRoom(roomRef, localTracksRef, localVideoRef, remoteMediaRef);
       localMediaStreamRef.current = null;
       setRemoteVideoReady(false);
-      setRoomState('idle');
       return true;
     } catch (error) {
       setRoomError(error instanceof Error ? error.message : 'Could not save the local recording.');

--- a/apps/web/core/debates/debate-coordinator.test.tsx
+++ b/apps/web/core/debates/debate-coordinator.test.tsx
@@ -94,6 +94,24 @@ describe('DebateCoordinator', () => {
     await waitFor(() => expect(mocks.push).toHaveBeenCalledWith('/space/space-1/debates/rematches/rematch-1'));
   });
 
+  it('keeps the match prompt mounted until the debate route takes over', async () => {
+    mocks.activity = activityWithMatch();
+    const view = render(<DebateCoordinator />);
+
+    expect(screen.getByText('Global match prompt')).toBeInTheDocument();
+
+    mocks.activity = activityWithDebate();
+    view.rerender(<DebateCoordinator />);
+
+    expect(screen.getByText('Global match prompt')).toBeInTheDocument();
+    await waitFor(() => expect(mocks.push).toHaveBeenCalledWith('/space/space-1/debates/debate-1'));
+
+    mocks.pathname = '/space/space-1/debates/debate-1';
+    view.rerender(<DebateCoordinator />);
+
+    expect(screen.queryByText('Global match prompt')).not.toBeInTheDocument();
+  });
+
   it('waits for the debate room to finalize its recording before routing to a rematch', async () => {
     mocks.pathname = '/space/space-1/debates/debate-1';
     mocks.activity = activityWithRematch('browsing');
@@ -219,5 +237,43 @@ function activityWithRematch(status: 'deciding' | 'browsing'): DebateActivity {
       created_at: '2026-07-02T00:00:00.000Z',
       updated_at: '2026-07-02T00:00:00.000Z',
     },
+  };
+}
+
+function activityWithMatch(): DebateActivity {
+  return {
+    online: true,
+    available_to_debate: true,
+    cooldown_until: null,
+    match: {
+      id: 'match-1',
+      status: 'pending',
+      claim: {
+        id: 'claim-1',
+        space_id: 'space-1',
+        claim_entity_id: 'claim-entity-1',
+        claim: 'Debates should hand off without flashing the page',
+        description: null,
+      },
+      participants: [],
+      turn_format_id: null,
+      debate_id: null,
+      created_at: '2026-07-02T00:00:00.000Z',
+      updated_at: '2026-07-02T00:00:00.000Z',
+    },
+    debate: null,
+    rematch: null,
+  };
+}
+
+function activityWithDebate(): DebateActivity {
+  const matchActivity = activityWithMatch();
+  return {
+    ...matchActivity,
+    match: null,
+    debate: {
+      id: 'debate-1',
+      claim: matchActivity.match!.claim,
+    } as NonNullable<DebateActivity['debate']>,
   };
 }

--- a/apps/web/core/debates/debate-coordinator.test.tsx
+++ b/apps/web/core/debates/debate-coordinator.test.tsx
@@ -104,7 +104,7 @@ describe('DebateCoordinator', () => {
     view.rerender(<DebateCoordinator />);
 
     expect(screen.getByText('Global match prompt')).toBeInTheDocument();
-    await waitFor(() => expect(mocks.push).toHaveBeenCalledWith('/space/space-1/debates/debate-1'));
+    expect(mocks.push).not.toHaveBeenCalledWith('/space/space-1/debates/debate-1');
 
     mocks.pathname = '/space/space-1/debates/debate-1';
     view.rerender(<DebateCoordinator />);

--- a/apps/web/core/debates/debate-coordinator.tsx
+++ b/apps/web/core/debates/debate-coordinator.tsx
@@ -55,7 +55,9 @@ export function DebateCoordinator() {
     const debate = activity.debate;
     const viewingRematch = pathname.includes('/debates/rematches/');
     if (debate && !viewingRematch && !pathname.includes(`/debates/${debate.id}`)) {
-      router.push(`/space/${debate.claim.space_id}/debates/${debate.id}`);
+      // The retained match prompt owns this handoff so it can deduplicate
+      // navigation from the accept response and the activity update.
+      if (!visibleMatch) router.push(`/space/${debate.claim.space_id}/debates/${debate.id}`);
       return;
     }
     const rematch = activity.rematch;
@@ -72,7 +74,7 @@ export function DebateCoordinator() {
       const path = `/space/${rematch.source_space_id}/debates/rematches/${rematch.id}`;
       if (pathname !== path) router.push(path);
     }
-  }, [activity, pathname, router]);
+  }, [activity, pathname, router, visibleMatch]);
 
   if (!isDebatesEnabled) return null;
 

--- a/apps/web/core/debates/debate-coordinator.tsx
+++ b/apps/web/core/debates/debate-coordinator.tsx
@@ -10,6 +10,7 @@ import { Button } from '~/design-system/button';
 import { Upload } from '~/design-system/icons/upload';
 import { Text } from '~/design-system/text';
 
+import type { DebateMatch } from './api';
 import { useDebateGateway } from './debate-gateway';
 import { useDebateActivity, useDebateSharePrompts, useGeoChatAuth, useHandleDebateSharePrompt } from './hooks';
 import { DebateMatchPrompt } from './match-prompt';
@@ -27,8 +28,27 @@ export function DebateCoordinator() {
   );
   const activityQuery = useDebateActivity(isDebatesEnabled);
   const activity = activityQuery.data ?? null;
+  const match = activity?.match ?? null;
+  const debate = activity?.debate ?? null;
+  const lastMatchRef = React.useRef<DebateMatch | null>(null);
+  const viewingDebate = Boolean(debate && pathname.includes(`/debates/${debate.id}`));
+  const retainedMatch =
+    !match && debate && !viewingDebate && lastMatchRef.current?.claim.id === debate.claim.id
+      ? lastMatchRef.current
+      : null;
+  const visibleMatch = match ?? retainedMatch;
   const activeFlow = Boolean(activity?.match || activity?.debate || activity?.rematch);
   const sharePromptsQuery = useDebateSharePrompts(Boolean(activity) && !activeFlow);
+
+  React.useEffect(() => {
+    if (match) {
+      lastMatchRef.current = match;
+      return;
+    }
+    if (!debate || viewingDebate) {
+      lastMatchRef.current = null;
+    }
+  }, [debate, match, viewingDebate]);
 
   React.useEffect(() => {
     if (!activity) return;
@@ -54,7 +74,6 @@ export function DebateCoordinator() {
     }
   }, [activity, pathname, router]);
 
-  const match = activity?.match;
   if (!isDebatesEnabled) return null;
 
   return (
@@ -68,10 +87,10 @@ export function DebateCoordinator() {
           Live debate updates are paused while reconnecting.
         </div>
       )}
-      {match && (
+      {visibleMatch && (
         <DebateMatchPrompt
-          spaceId={match.claim.space_id}
-          matches={[match]}
+          spaceId={visibleMatch.claim.space_id}
+          matches={[visibleMatch]}
           debates={activity?.debate ? [activity.debate] : []}
         />
       )}

--- a/apps/web/core/debates/hooks-query-network.test.tsx
+++ b/apps/web/core/debates/hooks-query-network.test.tsx
@@ -16,6 +16,7 @@ import {
 
 const mocks = vi.hoisted(() => ({
   authenticated: true,
+  queryClient: { setQueryData: vi.fn() },
   useQuery: vi.fn((options: unknown) => options),
   useScope: vi.fn(),
 }));
@@ -27,6 +28,7 @@ vi.mock('@geogenesis/auth', () => ({
 vi.mock('@tanstack/react-query', async importOriginal => ({
   ...(await importOriginal<typeof import('@tanstack/react-query')>()),
   useQuery: mocks.useQuery,
+  useQueryClient: () => mocks.queryClient,
 }));
 
 vi.mock('~/core/auth/identity-token', () => ({
@@ -40,6 +42,7 @@ vi.mock('./debate-gateway', () => ({
 
 beforeEach(() => {
   mocks.authenticated = true;
+  mocks.queryClient.setQueryData.mockClear();
   mocks.useQuery.mockClear();
   mocks.useScope.mockClear();
 });

--- a/apps/web/core/debates/hooks.test.tsx
+++ b/apps/web/core/debates/hooks.test.tsx
@@ -309,6 +309,67 @@ describe('useClearTimedOutDebateActivity', () => {
 });
 
 describe('debate query refresh behavior', () => {
+  it('hydrates debate and rematch detail caches from activity responses', async () => {
+    window.localStorage.setItem(
+      'geo:chat-session',
+      JSON.stringify({
+        account_key: 'user-a',
+        session: {
+          access_token: 'access-token',
+          refresh_token: 'refresh-token',
+          expires_at: new Date(Date.now() + 10 * 60_000).toISOString(),
+        },
+      })
+    );
+    const debate = { id: 'debate-1' } as Debate;
+    const rematch = rematchSession();
+    const fetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            online: true,
+            available_to_debate: true,
+            cooldown_until: null,
+            match: null,
+            debate,
+            rematch: null,
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            online: true,
+            available_to_debate: true,
+            cooldown_until: null,
+            match: null,
+            debate: null,
+            rematch,
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        )
+      );
+    vi.stubGlobal('fetch', fetch);
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+
+    const { result } = renderHook(() => useDebateActivity(), { wrapper });
+
+    await waitFor(() => expect(queryClient.getQueryData(debateQueryKeys.debate('debate-1'))).toEqual(debate));
+
+    await act(async () => {
+      await result.current.refetch();
+    });
+
+    expect(queryClient.getQueryData(debateQueryKeys.rematch('user-a', 'rematch-1'))).toEqual(rematch);
+    vi.unstubAllGlobals();
+    window.localStorage.clear();
+  });
+
   it('does not issue periodic debate reads while time advances', async () => {
     vi.useFakeTimers();
     window.localStorage.setItem(

--- a/apps/web/core/debates/hooks.ts
+++ b/apps/web/core/debates/hooks.ts
@@ -143,12 +143,22 @@ export function useUpdateDebatePreference(spaceId: string) {
 }
 
 export function useDebateActivity(enabled = true) {
+  const queryClient = useQueryClient();
   const { accountKey, authenticated, getPrivyIdentityToken } = useGeoChatAuth();
 
   return useQuery({
     ...debateQueryNetworkOptions,
     queryKey: debateQueryKeys.activity(accountKey),
-    queryFn: ({ signal }) => getDebateActivity(getPrivyIdentityToken, accountKey, signal),
+    queryFn: async ({ signal }) => {
+      const activity = await getDebateActivity(getPrivyIdentityToken, accountKey, signal);
+      if (activity.debate) {
+        queryClient.setQueryData(debateQueryKeys.debate(activity.debate.id), activity.debate);
+      }
+      if (activity.rematch) {
+        queryClient.setQueryData(debateQueryKeys.rematch(accountKey, activity.rematch.id), activity.rematch);
+      }
+      return activity;
+    },
     enabled: enabled && authenticated,
   });
 }

--- a/apps/web/core/debates/match-prompt.test.tsx
+++ b/apps/web/core/debates/match-prompt.test.tsx
@@ -175,6 +175,16 @@ describe('DebateMatchPrompt', () => {
 
     expect(mocks.push).toHaveBeenCalledWith('/space/space-1/debates/debate-1');
   });
+
+  it('moves a server-accepted participant into a debate while retaining the match', () => {
+    const acceptedMatch = match();
+    acceptedMatch.participants[0]!.accepted = true;
+
+    render(<DebateMatchPrompt spaceId="space-1" matches={[acceptedMatch]} debates={[debate()]} />);
+
+    expect(mocks.push).toHaveBeenCalledTimes(1);
+    expect(mocks.push).toHaveBeenCalledWith('/space/space-1/debates/debate-1');
+  });
 });
 
 function match(): DebateMatch {

--- a/apps/web/core/debates/match-prompt.test.tsx
+++ b/apps/web/core/debates/match-prompt.test.tsx
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom/vitest';
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -63,7 +63,11 @@ afterEach(() => {
 });
 
 describe('DebateMatchPrompt', () => {
-  it('opens a match modal and the first participant accepts with the default format', () => {
+  it('opens a match modal and disables accept immediately after submitting the default format', () => {
+    mocks.acceptMutate.mockImplementation((_variables, options) => {
+      options.onSuccess({ match: { ...match(), debate_id: 'debate-1' }, debate: debate() });
+    });
+
     render(<DebateMatchPrompt spaceId="space-1" matches={[match()]} />);
 
     expect(screen.getByRole('dialog', { name: 'The protocol should ship debates' })).toBeInTheDocument();
@@ -72,12 +76,17 @@ describe('DebateMatchPrompt', () => {
 
     expect(screen.queryByLabelText('Debate format')).not.toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Accept' }));
+    const acceptButton = screen.getByRole('button', { name: 'Accept' });
+    expect(acceptButton).toBeEnabled();
+
+    fireEvent.click(acceptButton);
 
     expect(mocks.acceptMutate).toHaveBeenCalledWith(
       { matchId: 'match-1', formatId: defaultDebateFormatId },
       expect.any(Object)
     );
+    expect(mocks.push).toHaveBeenCalledWith('/space/space-1/debates/debate-1');
+    expect(acceptButton).toBeDisabled();
   });
 
   it('lets the first participant choose a format when the feature flag is enabled', () => {
@@ -92,6 +101,24 @@ describe('DebateMatchPrompt', () => {
       { matchId: 'match-1', formatId: 'extended-standard' },
       expect.any(Object)
     );
+  });
+
+  it('re-enables accept when submitting the match fails', () => {
+    let failRequest = () => {};
+    mocks.acceptMutate.mockImplementation((_variables, options) => {
+      failRequest = () => options.onError();
+    });
+
+    render(<DebateMatchPrompt spaceId="space-1" matches={[match()]} />);
+
+    const acceptButton = screen.getByRole('button', { name: 'Accept' });
+    fireEvent.click(acceptButton);
+
+    expect(acceptButton).toBeDisabled();
+
+    act(failRequest);
+
+    expect(acceptButton).toBeEnabled();
   });
 
   it('renders participants as avatar and name without a per-participant menu or position pill', () => {

--- a/apps/web/core/debates/match-prompt.tsx
+++ b/apps/web/core/debates/match-prompt.tsx
@@ -68,7 +68,12 @@ export function DebateMatchPrompt({ spaceId, matches, debates = [] }: DebateMatc
       return;
     }
 
-    const waitingClaimIdSet = new Set(waitingClaimIds);
+    const waitingClaimIdSet = new Set([
+      ...waitingClaimIds,
+      ...matches
+        .filter(match => participantForUser(match, currentUserId)?.accepted === true)
+        .map(match => match.claim.id),
+    ]);
     if (waitingClaimIdSet.size === 0) return;
 
     const debate = debates.find(

--- a/apps/web/core/debates/match-prompt.tsx
+++ b/apps/web/core/debates/match-prompt.tsx
@@ -29,6 +29,7 @@ export function DebateMatchPrompt({ spaceId, matches, debates = [] }: DebateMatc
   const currentUserId = getCurrentGeoChatUserId();
   const [selectedFormatIds, setSelectedFormatIds] = React.useState<Record<string, DebateFormatId>>({});
   const [acceptedMatchIds, setAcceptedMatchIds] = React.useState<string[]>([]);
+  const [acceptingMatchId, setAcceptingMatchId] = React.useState<string | null>(null);
   const [waitingClaimIds, setWaitingClaimIds] = React.useState<string[]>([]);
   const [dismissedMatchIds, setDismissedMatchIds] = React.useState<string[]>([]);
   const [minimizedMatchIds, setMinimizedMatchIds] = React.useState<string[]>([]);
@@ -46,6 +47,7 @@ export function DebateMatchPrompt({ spaceId, matches, debates = [] }: DebateMatc
   React.useEffect(() => {
     const activeIds = new Set(matches.map(match => match.id));
     setAcceptedMatchIds(current => current.filter(id => activeIds.has(id)));
+    setAcceptingMatchId(current => (current && activeIds.has(current) ? current : null));
     setDismissedMatchIds(current => current.filter(id => activeIds.has(id)));
     setMinimizedMatchIds(current => current.filter(id => activeIds.has(id)));
     setSelectedFormatIds(
@@ -131,13 +133,14 @@ export function DebateMatchPrompt({ spaceId, matches, debates = [] }: DebateMatc
       : declineMatch.error instanceof Error
         ? declineMatch.error.message
         : null;
-  const busy = acceptMatch.isPending || declineMatch.isPending;
+  const busy = acceptingMatchId === activeMatch.id || acceptMatch.isPending || declineMatch.isPending;
 
   const setSelectedFormatId = (formatId: DebateFormatId) => {
     setSelectedFormatIds(current => ({ ...current, [activeMatch.id]: formatId }));
   };
 
   const accept = () => {
+    setAcceptingMatchId(activeMatch.id);
     acceptMatch.mutate(
       {
         matchId: activeMatch.id,
@@ -151,8 +154,12 @@ export function DebateMatchPrompt({ spaceId, matches, debates = [] }: DebateMatc
             navigateToDebate(debateId);
             return;
           }
+          setAcceptingMatchId(null);
           setAcceptedMatchIds(current => Array.from(new Set([...current, activeMatch.id])));
           setWaitingClaimIds(current => Array.from(new Set([...current, activeMatch.claim.id])));
+        },
+        onError: () => {
+          setAcceptingMatchId(current => (current === activeMatch.id ? null : current));
         },
       }
     );


### PR DESCRIPTION
Accepting a match now keeps the matching prompt visible until the debate pre-screen takes over, eliminating the brief return to the underlying page. Likewise, agreeing to rematch keeps the thanking and recording UI mounted until the rematch browser commits instead of flashing away.

Activity responses prime debate and rematch caches so each destination can render immediately when navigation completes. The full web suite passed with 1,557 tests across 151 files; TypeScript and ESLint also completed with no errors. Route-commit behavior is covered in component tests; live two-participant browser QA was not run.
