### PR TITLE
fix(debates): return to the previous page on exit

### DIFF
--- a/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
@@ -10,8 +10,11 @@ import type { Debate, DebateRematchSession } from '~/core/debates/api';
 import { DebateRoomPageClient } from './debate-room-page-client';
 
 const mocks = vi.hoisted(() => ({
+  back: vi.fn(),
   push: vi.fn(),
   replace: vi.fn(),
+  abortMutateAsync: vi.fn(),
+  clearDebateActivity: vi.fn(),
   consentMutateAsync: vi.fn(),
   leaveRematchMutateAsync: vi.fn(),
   enqueueRecording: vi.fn(),
@@ -56,7 +59,7 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock('next/navigation', () => ({
-  useRouter: () => ({ push: mocks.push, replace: mocks.replace }),
+  useRouter: () => ({ back: mocks.back, push: mocks.push, replace: mocks.replace }),
 }));
 
 vi.mock('~/core/state/feature-flags', () => ({
@@ -75,7 +78,8 @@ vi.mock('~/core/debates/api', async importOriginal => {
 });
 
 vi.mock('~/core/debates/hooks', () => ({
-  useAbortDebate: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useAbortDebate: () => ({ mutateAsync: mocks.abortMutateAsync, isPending: false }),
+  useClearDebateActivity: () => mocks.clearDebateActivity,
   useClearTimedOutDebateActivity: () => mocks.clearTimedOutDebateActivity,
   useConsentToDebateRematch: () => ({ mutateAsync: mocks.consentMutateAsync, isPending: false }),
   useDebate: () => ({ data: mocks.debate, isLoading: false, error: null, refetch: mocks.refetchDebate }),
@@ -153,8 +157,12 @@ function emitRoomEvent(event: string, payload?: unknown) {
 }
 
 beforeEach(() => {
+  setHistoryLength(1);
+  mocks.back.mockReset();
   mocks.push.mockReset();
   mocks.replace.mockReset();
+  mocks.abortMutateAsync.mockReset().mockResolvedValue(undefined);
+  mocks.clearDebateActivity.mockReset();
   mocks.consentMutateAsync.mockReset();
   mocks.leaveRematchMutateAsync.mockReset();
   mocks.enqueueRecording.mockReset();
@@ -286,6 +294,46 @@ afterEach(() => {
 });
 
 describe('DebateRoomPageClient', () => {
+  it('returns through browser history without rendering an already-completed room', async () => {
+    setHistoryLength(2);
+
+    render(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
+
+    expect(screen.queryByText('Debate complete.')).not.toBeInTheDocument();
+    await waitFor(() => expect(mocks.clearDebateActivity).toHaveBeenCalledWith('debate-1'));
+    expect(mocks.back).toHaveBeenCalledOnce();
+    expect(mocks.replace).not.toHaveBeenCalled();
+    expect(mocks.enqueueRecording).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the debates page when a cancelled room has no prior history', async () => {
+    setHistoryLength(1);
+    mocks.debate = { ...completedDebate(), status: 'cancelled', completed_at: null };
+
+    render(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
+
+    expect(screen.queryByText('Debate cancelled.')).not.toBeInTheDocument();
+    await waitFor(() => expect(mocks.clearDebateActivity).toHaveBeenCalledWith('debate-1'));
+    expect(mocks.back).not.toHaveBeenCalled();
+    expect(mocks.replace).toHaveBeenCalledWith('/space/space-1/debates');
+  });
+
+  it('does not render the terminal room while returning a recording canceller', async () => {
+    setHistoryLength(2);
+    mocks.debate = {
+      ...completedDebate(),
+      recording_cancelled_at: '2026-07-02T00:01:20.000Z',
+      recording_cancelled_by: 'user-a',
+      recordings: [],
+    };
+
+    render(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
+
+    expect(screen.queryByText('Debate complete.')).not.toBeInTheDocument();
+    await waitFor(() => expect(mocks.back).toHaveBeenCalledOnce());
+    expect(mocks.clearDebateActivity).toHaveBeenCalledWith('debate-1');
+  });
+
   it('shows the pre-screen while the debate is waiting for readiness', async () => {
     mocks.debate = readyDebate({ localReady: false, remoteReady: false });
 
@@ -1912,14 +1960,6 @@ describe('DebateRoomPageClient', () => {
     await waitFor(() => expect(audioTrack.mediaStreamTrack.enabled).toBe(true));
   });
 
-  it('does not restart completion work when revisiting an already-completed debate', async () => {
-    render(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
-
-    expect(await screen.findByText('Debate complete.')).toBeInTheDocument();
-    expect(mocks.enqueueRecording).not.toHaveBeenCalled();
-    expect(screen.queryByText('Continue debating this claim?')).not.toBeInTheDocument();
-  });
-
   it('shows rematch consent during thanking and records local consent', async () => {
     installRecordingMocks();
     const view = await renderLiveDebate();
@@ -2035,6 +2075,21 @@ describe('DebateRoomPageClient', () => {
     expect(screen.getByRole('button', { name: 'Saving local recording' })).toBeDisabled();
   });
 
+  it('waits for durable recording persistence before returning to the previous page', async () => {
+    setHistoryLength(2);
+    installRecordingMocks();
+    const view = await renderLiveDebate();
+    await waitFor(() => expect(mocks.mediaRecorderStart).toHaveBeenCalled());
+
+    mocks.debate = completedDebate();
+    view.rerender(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
+
+    await waitFor(() => expect(mocks.enqueueRecording).toHaveBeenCalledOnce());
+    await waitFor(() => expect(mocks.back).toHaveBeenCalledOnce());
+    expect(mocks.clearDebateActivity).toHaveBeenCalledWith('debate-1');
+    expect(mocks.replace).not.toHaveBeenCalled();
+  });
+
   it('persists the recording at the canonical debate deadline without waiting for thanking status', async () => {
     mocks.getServerTime.mockRejectedValue(new Error('Clock endpoint unavailable'));
     installRecordingMocks();
@@ -2101,6 +2156,19 @@ describe('DebateRoomPageClient', () => {
 
     expect(await screen.findAllByText('Storage unavailable')).not.toHaveLength(0);
     expect(mocks.replace).not.toHaveBeenCalled();
+  });
+
+  it('returns to the previous page after leaving an active debate', async () => {
+    setHistoryLength(2);
+    const view = await renderLiveDebate();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Leave debate' }));
+
+    await waitFor(() => expect(mocks.abortMutateAsync).toHaveBeenCalledOnce());
+    expect(mocks.clearDebateActivity).toHaveBeenCalledWith('debate-1');
+    expect(mocks.back).toHaveBeenCalledOnce();
+    expect(mocks.replace).not.toHaveBeenCalled();
+    view.unmount();
   });
 
   it('retains an in-memory recording after a quota failure and retries the same Blob', async () => {
@@ -2360,4 +2428,8 @@ function rematchSession(status: DebateRematchSession['status']): DebateRematchSe
     created_at: '2026-07-02T00:01:10.000Z',
     updated_at: '2026-07-02T00:01:10.000Z',
   };
+}
+
+function setHistoryLength(length: number) {
+  Object.defineProperty(window.history, 'length', { configurable: true, value: length });
 }

--- a/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
@@ -1348,7 +1348,7 @@ describe('DebateRoomPageClient', () => {
     expect(warning).toHaveBeenCalledWith('[DebateNoiseFilter] Krisp could not change state.', expect.any(Error));
   });
 
-  it('disables the Krisp switch while the recording is being saved', async () => {
+  it('hides debate controls while the terminal recording is being saved', async () => {
     const persistence = deferred<void>();
     mocks.featureFlags.debateDebugging = true;
     mocks.enqueueRecording.mockReturnValue(persistence.promise);
@@ -1361,7 +1361,7 @@ describe('DebateRoomPageClient', () => {
     view.rerender(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
 
     await waitFor(() => expect(mocks.enqueueRecording).toHaveBeenCalledOnce());
-    expect(noiseFilterSwitch).toBeDisabled();
+    expect(noiseFilterSwitch).not.toBeInTheDocument();
 
     persistence.resolve();
   });
@@ -2076,7 +2076,9 @@ describe('DebateRoomPageClient', () => {
   });
 
   it('waits for durable recording persistence before returning to the previous page', async () => {
+    const persistence = deferred<void>();
     setHistoryLength(2);
+    mocks.enqueueRecording.mockReturnValue(persistence.promise);
     installRecordingMocks();
     const view = await renderLiveDebate();
     await waitFor(() => expect(mocks.mediaRecorderStart).toHaveBeenCalled());
@@ -2085,9 +2087,25 @@ describe('DebateRoomPageClient', () => {
     view.rerender(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
 
     await waitFor(() => expect(mocks.enqueueRecording).toHaveBeenCalledOnce());
+    expect(screen.queryByText('Debate complete.')).not.toBeInTheDocument();
+    expect(mocks.back).not.toHaveBeenCalled();
+
+    persistence.resolve();
     await waitFor(() => expect(mocks.back).toHaveBeenCalledOnce());
     expect(mocks.clearDebateActivity).toHaveBeenCalledWith('debate-1');
     expect(mocks.replace).not.toHaveBeenCalled();
+  });
+
+  it('does not render a cancelled room while cleaning up an active debate', async () => {
+    setHistoryLength(2);
+    const view = await renderLiveDebate();
+
+    mocks.debate = { ...completedDebate(), status: 'cancelled', completed_at: null };
+    view.rerender(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
+
+    expect(screen.queryByText('Debate cancelled.')).not.toBeInTheDocument();
+    await waitFor(() => expect(mocks.back).toHaveBeenCalledOnce());
+    expect(mocks.clearDebateActivity).toHaveBeenCalledWith('debate-1');
   });
 
   it('persists the recording at the canonical debate deadline without waiting for thanking status', async () => {
@@ -2206,6 +2224,7 @@ describe('DebateRoomPageClient', () => {
 
     expect(await screen.findByText('Your debate was removed')).toBeInTheDocument();
     expect(screen.getByText('Bri cancelled the upload of your debate')).toBeInTheDocument();
+    expect(screen.queryByText('Debate complete.')).not.toBeInTheDocument();
     // The local blob must be dropped so this tab never publishes the cancelled recording.
     await waitFor(() => expect(mocks.deleteRecording).toHaveBeenCalledWith('user-a:debate-1'));
 

--- a/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.tsx
@@ -21,6 +21,7 @@ import {
 } from '~/core/debates/debate-room-ownership';
 import {
   useAbortDebate,
+  useClearDebateActivity,
   useClearTimedOutDebateActivity,
   useConsentToDebateRematch,
   useDebate,
@@ -158,6 +159,7 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
   const markJoined = useMarkDebateJoined(debateId);
   const markReady = useMarkDebateReady(debateId);
   const abortDebate = useAbortDebate(debateId);
+  const clearDebateActivity = useClearDebateActivity();
   const clearTimedOutDebateActivity = useClearTimedOutDebateActivity();
   const consentToRematch = useConsentToDebateRematch(debateId);
   const [joinResponse, setJoinResponse] = React.useState<LiveKitJoinResponse | null>(null);
@@ -225,6 +227,7 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
   const serverNowRef = React.useRef(serverClock.now);
   const preflightEndsAtMsRef = React.useRef<number | null>(null);
   const finalizedDebateRef = React.useRef<string | null>(null);
+  const debateExitStartedRef = React.useRef(false);
   const recordingPersistenceStartedRef = React.useRef<string | null>(null);
   const recordingPersistencePromiseRef = React.useRef<Promise<boolean> | null>(null);
   const persistedRecordingDebateIdRef = React.useRef<string | null>(null);
@@ -270,6 +273,26 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
   const canTakeOverConnection =
     connectionConflict && (countdown.effectiveStatus === 'connecting' || countdown.effectiveStatus === 'preflight');
   const connectionConflictWithoutTakeover = connectionConflict && !canTakeOverConnection;
+  const shouldReturnFromTerminalDebate = Boolean(
+    debate &&
+    roomState === 'idle' &&
+    recordingCancelledBy === null &&
+    ((debate.status === 'complete' && !debate.rematch_session_id) ||
+      (debate.status === 'cancelled' && debate.cancellation_reason !== 'connection_timeout'))
+  );
+  const shouldHideTerminalDebate =
+    shouldReturnFromTerminalDebate || (recordingCancelledBy !== null && !opponentCancelledRecording);
+
+  const returnFromDebate = React.useCallback(() => {
+    if (debateExitStartedRef.current) return;
+    debateExitStartedRef.current = true;
+    clearDebateActivity(debateId);
+    if (window.history.length > 1) {
+      router.back();
+      return;
+    }
+    router.replace(`/space/${spaceId}/debates`);
+  }, [clearDebateActivity, debateId, router, spaceId]);
 
   React.useEffect(() => {
     serverNowRef.current = serverClock.now;
@@ -1172,8 +1195,8 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
       router.replace(`/space/${session.source_space_id}/debates/rematches/${session.id}`);
       return;
     }
-    router.replace(`/space/${spaceId}/debates`);
-  }, [debate, finishAndPersist, rematchQuery.data, router, spaceId]);
+    returnFromDebate();
+  }, [debate, finishAndPersist, rematchQuery.data, returnFromDebate, router]);
 
   const retryLiveDebateFinalization = React.useCallback(() => {
     if (debate?.status === 'thanking') {
@@ -1248,7 +1271,7 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
         setRemoteVideoReady(false);
         await abortDebate.mutateAsync();
       }
-      router.push(`/space/${spaceId}/debates`);
+      returnFromDebate();
     } catch (error) {
       setRoomError(error instanceof Error ? error.message : 'Could not leave the debate.');
     }
@@ -1259,8 +1282,7 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
     finishLiveDebate,
     leaveRematch,
     persistStoppedLocalRecording,
-    router,
-    spaceId,
+    returnFromDebate,
   ]);
 
   const handleConnectionFailure = React.useCallback(() => {
@@ -1350,6 +1372,11 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
       localMediaStreamRef.current = null;
     };
   }, [clearRecordingTimers, discardLocalRecorder]);
+
+  React.useEffect(() => {
+    if (!shouldReturnFromTerminalDebate) return;
+    returnFromDebate();
+  }, [returnFromDebate, shouldReturnFromTerminalDebate]);
 
   React.useEffect(() => {
     if (!debate || storagePersistenceRequestedRef.current) return;
@@ -1477,11 +1504,13 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
     setRemoteVideoReady(false);
     setRoomState('idle');
     // The canceller already saw the confirmation in the upload banner; only the opponent needs
-    // the "your debate was removed" popup, so send the canceller straight back to the list.
+    // the "your debate was removed" popup, so return the canceller to their previous page.
     if (!opponentCancelledRecording) {
-      router.replace(`/space/${spaceId}/debates`);
+      returnFromDebate();
     }
-  }, [currentUserId, debate, discardLocalRecorder, opponentCancelledRecording, recordingCancelledBy, router, spaceId]);
+  }, [currentUserId, debate, discardLocalRecorder, opponentCancelledRecording, recordingCancelledBy, returnFromDebate]);
+
+  if (shouldHideTerminalDebate) return null;
 
   return (
     <div className="py-8">
@@ -1489,7 +1518,7 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
         <DebateRecordingRemovedDialog
           cancellerName={recordingCanceller ? speakerName(recordingCanceller) : 'Your opponent'}
           claim={debate.claim.claim}
-          onAcknowledge={() => router.replace(`/space/${spaceId}/debates`)}
+          onAcknowledge={returnFromDebate}
         />
       )}
 

--- a/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.tsx
@@ -273,15 +273,23 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
   const canTakeOverConnection =
     connectionConflict && (countdown.effectiveStatus === 'connecting' || countdown.effectiveStatus === 'preflight');
   const connectionConflictWithoutTakeover = connectionConflict && !canTakeOverConnection;
-  const shouldReturnFromTerminalDebate = Boolean(
+  const shouldExitTerminalDebate = Boolean(
     debate &&
-    roomState === 'idle' &&
     recordingCancelledBy === null &&
     ((debate.status === 'complete' && !debate.rematch_session_id) ||
       (debate.status === 'cancelled' && debate.cancellation_reason !== 'connection_timeout'))
   );
+  const shouldReturnFromTerminalDebate = shouldExitTerminalDebate && roomState === 'idle';
+  const hasRecordingPersistenceError = Boolean(
+    debate &&
+    debate.status === 'complete' &&
+    finalizedDebateRef.current === debate.id &&
+    roomState === 'connected' &&
+    roomError
+  );
   const shouldHideTerminalDebate =
-    shouldReturnFromTerminalDebate || (recordingCancelledBy !== null && !opponentCancelledRecording);
+    (shouldExitTerminalDebate && !hasRecordingPersistenceError) ||
+    (recordingCancelledBy !== null && !opponentCancelledRecording);
 
   const returnFromDebate = React.useCallback(() => {
     if (debateExitStartedRef.current) return;
@@ -1510,18 +1518,20 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
     }
   }, [currentUserId, debate, discardLocalRecorder, opponentCancelledRecording, recordingCancelledBy, returnFromDebate]);
 
+  if (debate && opponentCancelledRecording) {
+    return (
+      <DebateRecordingRemovedDialog
+        cancellerName={recordingCanceller ? speakerName(recordingCanceller) : 'Your opponent'}
+        claim={debate.claim.claim}
+        onAcknowledge={returnFromDebate}
+      />
+    );
+  }
+
   if (shouldHideTerminalDebate) return null;
 
   return (
     <div className="py-8">
-      {debate && opponentCancelledRecording && (
-        <DebateRecordingRemovedDialog
-          cancellerName={recordingCanceller ? speakerName(recordingCanceller) : 'Your opponent'}
-          claim={debate.claim.claim}
-          onAcknowledge={returnFromDebate}
-        />
-      )}
-
       {debate?.status !== 'ready' && (
         <div className="mb-5 flex flex-wrap items-center justify-between gap-3">
           <div className="min-w-0">

--- a/apps/web/core/debates/debate-coordinator.test.tsx
+++ b/apps/web/core/debates/debate-coordinator.test.tsx
@@ -140,6 +140,21 @@ describe('DebateCoordinator', () => {
     await waitFor(() => expect(mocks.push).not.toHaveBeenCalled());
   });
 
+  it.each(['complete', 'cancelled'] as const)('does not reopen a %s debate from stale activity', async status => {
+    mocks.pathname = '/space/space-1/claims';
+    mocks.activity = {
+      ...activityWithDebate(),
+      debate: {
+        ...activityWithDebate().debate!,
+        status,
+      },
+    };
+
+    render(<DebateCoordinator />);
+
+    await waitFor(() => expect(mocks.push).not.toHaveBeenCalled());
+  });
+
   it('copies a stable recording link when native sharing is unavailable', async () => {
     mocks.activity = {
       online: true,

--- a/apps/web/core/debates/debate-coordinator.tsx
+++ b/apps/web/core/debates/debate-coordinator.tsx
@@ -29,7 +29,8 @@ export function DebateCoordinator() {
   const activityQuery = useDebateActivity(isDebatesEnabled);
   const activity = activityQuery.data ?? null;
   const match = activity?.match ?? null;
-  const debate = activity?.debate ?? null;
+  const reportedDebate = activity?.debate ?? null;
+  const debate = reportedDebate && !['complete', 'cancelled'].includes(reportedDebate.status) ? reportedDebate : null;
   const lastMatchRef = React.useRef<DebateMatch | null>(null);
   const viewingDebate = Boolean(debate && pathname.includes(`/debates/${debate.id}`));
   const retainedMatch =
@@ -37,7 +38,7 @@ export function DebateCoordinator() {
       ? lastMatchRef.current
       : null;
   const visibleMatch = match ?? retainedMatch;
-  const activeFlow = Boolean(activity?.match || activity?.debate || activity?.rematch);
+  const activeFlow = Boolean(match || debate || activity?.rematch);
   const sharePromptsQuery = useDebateSharePrompts(Boolean(activity) && !activeFlow);
 
   React.useEffect(() => {
@@ -52,7 +53,6 @@ export function DebateCoordinator() {
 
   React.useEffect(() => {
     if (!activity) return;
-    const debate = activity.debate;
     const viewingRematch = pathname.includes('/debates/rematches/');
     if (debate && !viewingRematch && !pathname.includes(`/debates/${debate.id}`)) {
       // The retained match prompt owns this handoff so it can deduplicate
@@ -74,7 +74,7 @@ export function DebateCoordinator() {
       const path = `/space/${rematch.source_space_id}/debates/rematches/${rematch.id}`;
       if (pathname !== path) router.push(path);
     }
-  }, [activity, pathname, router, visibleMatch]);
+  }, [activity, debate, pathname, router, visibleMatch]);
 
   if (!isDebatesEnabled) return null;
 
@@ -93,7 +93,7 @@ export function DebateCoordinator() {
         <DebateMatchPrompt
           spaceId={visibleMatch.claim.space_id}
           matches={[visibleMatch]}
-          debates={activity?.debate ? [activity.debate] : []}
+          debates={debate ? [debate] : []}
         />
       )}
       {!activeFlow && sharePromptsQuery.data?.prompts[0] && (

--- a/apps/web/core/debates/hooks.test.tsx
+++ b/apps/web/core/debates/hooks.test.tsx
@@ -10,6 +10,7 @@ import { setCachedIdentityToken } from '~/core/auth/identity-token';
 import type { Debate, DebateActivity, DebateRematchSession } from './api';
 import {
   debateQueryKeys,
+  useClearDebateActivity,
   useClearTimedOutDebateActivity,
   useConsentToDebateRematch,
   useDebate,
@@ -305,6 +306,34 @@ describe('useClearTimedOutDebateActivity', () => {
       cooldown_until: null,
       debate: null,
     });
+  });
+});
+
+describe('useClearDebateActivity', () => {
+  it('removes only the specified debate from the coordinator cache', () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries').mockResolvedValue();
+    const activity: DebateActivity = {
+      online: true,
+      available_to_debate: true,
+      cooldown_until: '2026-07-02T00:10:00.000Z',
+      match: null,
+      debate: { id: 'debate-1' } as NonNullable<DebateActivity['debate']>,
+      rematch: null,
+    };
+    queryClient.setQueryData(debateQueryKeys.activity('user-a'), activity);
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    const { result } = renderHook(() => useClearDebateActivity(), { wrapper });
+
+    act(() => result.current('debate-1'));
+
+    expect(queryClient.getQueryData(debateQueryKeys.activity('user-a'))).toEqual({
+      ...activity,
+      debate: null,
+    });
+    expect(invalidateQueries).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/web/core/debates/hooks.ts
+++ b/apps/web/core/debates/hooks.ts
@@ -191,7 +191,7 @@ export function useUpdateDebateAvailability() {
   });
 }
 
-export function useClearTimedOutDebateActivity() {
+function useClearDebateActivityCache({ clearCooldown, reconcile }: { clearCooldown: boolean; reconcile: boolean }) {
   const queryClient = useQueryClient();
   const { accountKey } = useGeoChatAuth();
 
@@ -199,12 +199,22 @@ export function useClearTimedOutDebateActivity() {
     (debateId: string) => {
       queryClient.setQueryData<DebateActivity>(debateQueryKeys.activity(accountKey), current => {
         if (!current || current.debate?.id !== debateId) return current;
-        return { ...current, debate: null, cooldown_until: null };
+        return clearCooldown ? { ...current, debate: null, cooldown_until: null } : { ...current, debate: null };
       });
-      void queryClient.invalidateQueries({ queryKey: debateQueryKeys.activity(accountKey) });
+      if (reconcile) {
+        void queryClient.invalidateQueries({ queryKey: debateQueryKeys.activity(accountKey) });
+      }
     },
-    [accountKey, queryClient]
+    [accountKey, clearCooldown, queryClient, reconcile]
   );
+}
+
+export function useClearTimedOutDebateActivity() {
+  return useClearDebateActivityCache({ clearCooldown: true, reconcile: true });
+}
+
+export function useClearDebateActivity() {
+  return useClearDebateActivityCache({ clearCooldown: false, reconcile: false });
 }
 
 export function useAcceptDebateMatch(spaceId?: string) {


### PR DESCRIPTION
## Summary

Leaving or completing a debate no longer strands participants on a terminal “cancelled” or “complete” page. Participants return to the page they were viewing before the debate, with the space’s debates page as a fallback for directly opened room URLs.

The room clears its cached active-debate state before navigating, and the global coordinator ignores terminal debates so stale activity cannot bounce the participant back into the room. Intentional rematch handoffs and connection-timeout recovery keep their existing destinations.

## Validation

- Full web test suite: 151 files and 1,566 tests passed.
- TypeScript: `bun x tsc --noEmit` passed.
- ESLint: `bun run lint` completed with 0 errors; 81 pre-existing warnings remain.
- Prettier and `git diff --check` passed for the changed files.

## Post-Deploy Monitoring & Validation

- For 24 hours after deployment, watch Sentry and frontend logs for errors on `/debates/[debateId]` navigation and debate activity reconciliation.
- Expected healthy signal: participants leave terminal debates without remaining on or being returned to the live room route.
- Failure signals: reports or traces showing terminal room text, repeated room-route navigation, or users bouncing between their origin page and a debate.
- Owner: debates frontend team. Roll back this commit if repeated-navigation errors or blocked debate exits appear after release.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
