### PR TITLE
fix(debates): share debate request modal

### DIFF
--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
@@ -15,6 +15,8 @@ const mocks = vi.hoisted(() => ({
   claims: [] as DebateRematchClaim[],
   replace: vi.fn(),
   mutate: vi.fn(),
+  acceptMutate: vi.fn(),
+  rejectMutate: vi.fn(),
 }));
 
 vi.mock('next/navigation', () => ({
@@ -37,8 +39,8 @@ vi.mock('~/core/debates/hooks', () => ({
   useUpdateDebateRematchPosition: () => mutation(),
   useCreateDebateRematchRequest: () => mutation(),
   useLeaveDebateRematch: () => mutation(),
-  useAcceptDebateRematchRequest: () => mutation(),
-  useRejectDebateRematchRequest: () => mutation(),
+  useAcceptDebateRematchRequest: () => mutation(mocks.acceptMutate),
+  useRejectDebateRematchRequest: () => mutation(mocks.rejectMutate),
 }));
 
 vi.mock('~/core/sync/use-store', () => ({
@@ -62,15 +64,19 @@ vi.mock('~/core/sync/use-store', () => ({
   }),
 }));
 
-function mutation() {
-  return { mutate: mocks.mutate, mutateAsync: mocks.mutate, isPending: false, error: null };
+function mutation(mutate = mocks.mutate) {
+  return { mutate, mutateAsync: mutate, isPending: false, error: null };
 }
 
 beforeEach(() => {
   mocks.replace.mockReset();
   mocks.mutate.mockReset();
+  mocks.acceptMutate.mockReset();
+  mocks.rejectMutate.mockReset();
   mocks.session = session();
   mocks.claims = [sharedClaim()];
+  document.body.style.overflow = '';
+  document.documentElement.style.overflow = '';
 });
 
 afterEach(cleanup);
@@ -124,7 +130,7 @@ describe('DebateRematchPageClient', () => {
     expect(within(sharedClaimCard!).getByRole('button', { name: 'No' }).querySelector('img, svg')).not.toBeNull();
   });
 
-  it('shows an incoming request with the snapshotted format details', () => {
+  it('shows an incoming request in the shared dialog and preserves rematch actions', () => {
     mocks.session = session({
       status: 'request_pending',
       request: {
@@ -141,13 +147,30 @@ describe('DebateRematchPageClient', () => {
       },
     });
 
-    render(<DebateRematchPageClient sessionId="rematch-1" />);
+    const { unmount } = render(<DebateRematchPageClient sessionId="rematch-1" />);
 
-    expect(screen.getByRole('dialog', { name: 'A claim both participants chose' })).toBeInTheDocument();
-    expect(screen.getAllByText('1m')).toHaveLength(2);
-    expect(screen.getAllByText('45s')).toHaveLength(2);
-    expect(screen.getByRole('button', { name: 'Accept' })).toBeEnabled();
-    expect(screen.getByRole('button', { name: 'Reject' })).toBeEnabled();
+    const dialog = screen.getByRole('dialog', { name: 'A claim both participants chose' });
+    expect(within(dialog).getByText('Debate request')).toBeInTheDocument();
+    expect(within(dialog).getByText('You')).toBeInTheDocument();
+    expect(within(dialog).getByText('Salina')).toBeInTheDocument();
+    expect(within(dialog).getByText('vs')).toBeInTheDocument();
+    expect(within(dialog).queryByText('Yes')).not.toBeInTheDocument();
+    expect(within(dialog).queryByText('No')).not.toBeInTheDocument();
+    expect(within(dialog).getAllByText('1m')).toHaveLength(2);
+    expect(within(dialog).getAllByText('45s')).toHaveLength(2);
+    expect(document.body.style.overflow).toBe('hidden');
+    expect(document.documentElement.style.overflow).toBe('hidden');
+
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Accept' }));
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Reject' }));
+
+    expect(mocks.acceptMutate).toHaveBeenCalledWith('request-1');
+    expect(mocks.rejectMutate).toHaveBeenCalledWith('request-1');
+
+    unmount();
+
+    expect(document.body.style.overflow).toBe('');
+    expect(document.documentElement.style.overflow).toBe('');
   });
 
   it('disables every claim card while a rematch request is pending', () => {

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -11,11 +11,9 @@ import { CLAIM_TYPE_ID, TOPICS_PROPERTY_ID } from '~/core/claims/ontology';
 import {
   type DebateRematchClaim,
   type DebateRematchParticipant,
-  type DebateRematchRequest,
   type DebateRematchSession,
   getCurrentGeoChatUserId,
 } from '~/core/debates/api';
-import { DebateFormatDetails } from '~/core/debates/format-details';
 import { defaultDebateFormatId } from '~/core/debates/formats';
 import {
   useAcceptDebateRematchRequest,
@@ -27,6 +25,7 @@ import {
   useRejectDebateRematchRequest,
   useUpdateDebateRematchPosition,
 } from '~/core/debates/hooks';
+import { DebateRequestDialog } from '~/core/debates/debate-request-dialog';
 import { useQueryEntities } from '~/core/sync/use-store';
 
 import { Avatar } from '~/design-system/avatar';
@@ -311,11 +310,12 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
         )}
       </main>
 
-      {incomingRequest && session && (
-        <RematchRequestDialog
-          session={session}
-          request={incomingRequest}
+      {incomingRequest && session && currentUserId && (
+        <DebateRequestDialog
+          claim={incomingRequest.claim.claim}
+          participants={session.participants}
           currentUserId={currentUserId}
+          formatId={incomingRequest.turn_format_id}
           busy={acceptRequest.isPending || rejectRequest.isPending}
           error={
             acceptRequest.error instanceof Error
@@ -480,95 +480,5 @@ function LeaveIcon() {
       <path d="M13 12H3" />
       <path d="M6 9l-3 3 3 3" />
     </svg>
-  );
-}
-
-function RematchRequestDialog({
-  session,
-  request,
-  currentUserId,
-  busy,
-  error,
-  onAccept,
-  onReject,
-}: {
-  session: DebateRematchSession;
-  request: DebateRematchRequest;
-  currentUserId: string | null;
-  busy: boolean;
-  error: string | null;
-  onAccept: () => void;
-  onReject: () => void;
-}) {
-  const requester = session.participants.find(participant => participant.user_id === request.requester_user_id)!;
-  const recipient = session.participants.find(participant => participant.user_id === request.recipient_user_id)!;
-  const ordered = [recipient, requester];
-
-  return (
-    <div className="fixed inset-0 z-[1200] flex items-center justify-center overflow-y-auto bg-text/45 p-4 backdrop-blur-sm">
-      <section
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="rematch-request-title"
-        className="w-[min(620px,100%)] rounded-xl bg-bg p-6 shadow-card"
-      >
-        <Text as="div" variant="body" color="grey-04" className="text-center">
-          Debate request
-        </Text>
-        <h2
-          id="rematch-request-title"
-          className="mx-auto mt-2 max-w-[500px] text-center text-[1.6rem] leading-[1.12] font-semibold"
-        >
-          {request.claim.claim}
-        </h2>
-        <div className="mt-5 grid grid-cols-2 gap-3 rounded-xl border border-grey-02 bg-white p-4">
-          {ordered.map(participant => {
-            const isRequester = participant.user_id === request.requester_user_id;
-            const position = isRequester ? request.requester_position : request.recipient_position;
-            return (
-              <div key={participant.user_id} className="grid justify-items-center gap-2 text-center">
-                <Avatar avatarUrl={participant.avatar_cid} value={participant.profile_space_id} size={32} />
-                <Text variant="body">
-                  {participant.user_id === currentUserId
-                    ? 'You'
-                    : participant.display_name || participant.profile_space_id}
-                </Text>
-                <span className="rounded-full bg-grey-02 px-3 py-1 text-metadataMedium">{position ? 'Yes' : 'No'}</span>
-              </div>
-            );
-          })}
-        </div>
-        <div className="mt-4 rounded-lg border border-grey-02 bg-white px-4 py-3">
-          <Text variant="metadata" color="grey-04">
-            Debate format
-          </Text>
-          <div className="mt-3">
-            <DebateFormatDetails
-              formatId={request.turn_format_id}
-              participants={[requester, recipient]}
-              currentUserId={currentUserId ?? ''}
-            />
-          </div>
-        </div>
-        {error && (
-          <Text color="red-01" className="mt-3">
-            {error}
-          </Text>
-        )}
-        <div className="mt-5 grid gap-2">
-          <Button type="button" onClick={onAccept} disabled={busy}>
-            Accept
-          </Button>
-          <button
-            type="button"
-            onClick={onReject}
-            disabled={busy}
-            className="mx-auto min-h-10 px-5 text-button text-grey-04 hover:text-text disabled:opacity-50"
-          >
-            Reject
-          </button>
-        </div>
-      </section>
-    </div>
   );
 }

--- a/apps/web/core/debates/debate-request-dialog.test.tsx
+++ b/apps/web/core/debates/debate-request-dialog.test.tsx
@@ -1,0 +1,110 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { DebateRequestDialogParticipant } from './debate-request-dialog';
+import { DebateRequestDialog } from './debate-request-dialog';
+
+const participants: DebateRequestDialogParticipant[] = [
+  {
+    user_id: 'user-local',
+    profile_space_id: 'profile-local',
+    display_name: 'Local speaker',
+    avatar_cid: null,
+    participant_slot: 1,
+  },
+  {
+    user_id: 'user-remote',
+    profile_space_id: 'profile-remote',
+    display_name: 'Remote speaker',
+    avatar_cid: null,
+    participant_slot: 2,
+  },
+];
+
+beforeEach(() => {
+  document.body.style.overflow = '';
+  document.documentElement.style.overflow = '';
+});
+
+afterEach(cleanup);
+
+describe('DebateRequestDialog', () => {
+  it('renders the canonical request layout and optional format selector', () => {
+    const accept = vi.fn();
+    const reject = vi.fn();
+    const changeFormat = vi.fn();
+
+    render(
+      <DebateRequestDialog
+        claim="The protocol should ship debates"
+        participants={[...participants].reverse()}
+        currentUserId="user-local"
+        formatId="standard"
+        formatSelector={{
+          value: 'standard',
+          selectedFormatId: 'standard',
+          name: 'request-format',
+          onChange: changeFormat,
+        }}
+        busy={false}
+        error={null}
+        onAccept={accept}
+        onReject={reject}
+      />
+    );
+
+    const dialog = screen.getByRole('dialog', { name: 'The protocol should ship debates' });
+    expect(within(dialog).getByText('Debate request')).toBeInTheDocument();
+    expect(within(dialog).getByText('You')).toBeInTheDocument();
+    expect(within(dialog).getByText('Remote speaker')).toBeInTheDocument();
+    expect(within(dialog).getByText('vs')).toBeInTheDocument();
+    expect(within(dialog).queryByText('Yes')).not.toBeInTheDocument();
+    expect(within(dialog).queryByText('No')).not.toBeInTheDocument();
+    expect(within(dialog).getAllByText('1m')).toHaveLength(2);
+    expect(within(dialog).getAllByText('45s')).toHaveLength(2);
+
+    fireEvent.change(within(dialog).getByLabelText('Debate format'), {
+      target: { value: 'extended-standard' },
+    });
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Accept' }));
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Reject' }));
+
+    expect(changeFormat).toHaveBeenCalledWith('extended-standard');
+    expect(accept).toHaveBeenCalledOnce();
+    expect(reject).toHaveBeenCalledOnce();
+  });
+
+  it('locks scrolling and surfaces busy and error states', () => {
+    const { unmount } = render(
+      <DebateRequestDialog
+        claim="A claim with an error"
+        participants={participants}
+        currentUserId="user-local"
+        formatId="standard"
+        formatSelector={{
+          value: 'standard',
+          name: 'busy-request-format',
+          onChange: () => undefined,
+        }}
+        busy
+        error="Could not accept the request."
+        onAccept={() => undefined}
+        onReject={() => undefined}
+      />
+    );
+
+    expect(document.body.style.overflow).toBe('hidden');
+    expect(document.documentElement.style.overflow).toBe('hidden');
+    expect(screen.getByText('Could not accept the request.')).toBeInTheDocument();
+    expect(screen.getByLabelText('Debate format')).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Accept' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Reject' })).toBeDisabled();
+
+    unmount();
+
+    expect(document.body.style.overflow).toBe('');
+    expect(document.documentElement.style.overflow).toBe('');
+  });
+});

--- a/apps/web/core/debates/debate-request-dialog.tsx
+++ b/apps/web/core/debates/debate-request-dialog.tsx
@@ -1,0 +1,183 @@
+'use client';
+
+import * as React from 'react';
+
+import { Avatar } from '~/design-system/avatar';
+import { Text } from '~/design-system/text';
+
+import type { DebateParticipantSummary, ParticipantSlot } from './api';
+import { DebateFormatDetails } from './format-details';
+import { DebateFormatSelector } from './format-selector';
+import type { DebateFormatId } from './formats';
+import { speakerLabel } from './playback-utils';
+
+export type DebateRequestDialogParticipant = DebateParticipantSummary & {
+  participant_slot: ParticipantSlot;
+};
+
+type DebateRequestDialogFormatSelector = {
+  value: DebateFormatId;
+  selectedFormatId?: string | null;
+  name: string;
+  onChange: (formatId: DebateFormatId) => void;
+};
+
+type DebateRequestDialogProps = {
+  claim: string;
+  participants: readonly DebateRequestDialogParticipant[];
+  currentUserId: string;
+  formatId: string | null | undefined;
+  formatSelector?: DebateRequestDialogFormatSelector;
+  busy: boolean;
+  error: string | null;
+  onAccept: () => void;
+  onReject: () => void;
+};
+
+export function DebateRequestDialog({
+  claim,
+  participants,
+  currentUserId,
+  formatId,
+  formatSelector,
+  busy,
+  error,
+  onAccept,
+  onReject,
+}: DebateRequestDialogProps) {
+  const titleId = React.useId();
+  const orderedParticipants = React.useMemo(
+    () => [...participants].sort((a, b) => a.participant_slot - b.participant_slot),
+    [participants]
+  );
+  const firstParticipant = orderedParticipants[0];
+  const secondParticipant = orderedParticipants[1] ?? firstParticipant;
+
+  React.useEffect(() => {
+    const originalBodyOverflow = document.body.style.overflow;
+    const originalDocumentOverflow = document.documentElement.style.overflow;
+
+    document.body.style.overflow = 'hidden';
+    document.documentElement.style.overflow = 'hidden';
+
+    return () => {
+      document.body.style.overflow = originalBodyOverflow;
+      document.documentElement.style.overflow = originalDocumentOverflow;
+    };
+  }, []);
+
+  if (!firstParticipant || !secondParticipant) return null;
+
+  return (
+    <div className="max-sm:items-end max-sm:p-0 fixed inset-0 z-1200 flex items-center justify-center bg-text/45 p-5 backdrop-blur-sm">
+      <section
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        className="max-sm:max-h-[calc(100dvh-1rem)] max-sm:rounded-b-none max-sm:border-b-0 max-sm:px-4 max-sm:py-5 grid max-h-[calc(100dvh-2rem)] w-[min(370px,100%)] grid-rows-[auto_minmax(0,1fr)_auto] gap-4 overflow-hidden rounded-lg bg-bg p-5 text-text shadow-card"
+      >
+        <header className="min-w-0 text-center">
+          <Text as="div" variant="metadata" color="text">
+            Debate request
+          </Text>
+          <h2 id={titleId} className="mt-3 text-cardEntityTitle leading-[1.375rem]">
+            {claim}
+          </h2>
+        </header>
+
+        <div className="min-h-0 overflow-y-auto pr-1">
+          <div className="grid grid-cols-[1fr_auto_1fr] items-center rounded-lg bg-white py-5">
+            <ParticipantSummary participant={firstParticipant} currentUserId={currentUserId} />
+            <div className="relative grid w-16 place-items-center">
+              <span
+                aria-hidden="true"
+                className="absolute top-1/2 left-1/2 h-14 w-px -translate-x-1/2 -translate-y-1/2 bg-divider"
+              />
+              <span className="relative grid h-7 w-7 place-items-center rounded-full border border-divider bg-white text-smallButton text-text">
+                vs
+              </span>
+            </div>
+            <ParticipantSummary participant={secondParticipant} currentUserId={currentUserId} />
+          </div>
+
+          <section className="mt-4 overflow-hidden rounded-lg border border-grey-02 bg-white">
+            <div className="flex flex-wrap items-center justify-between gap-3 px-4 py-3">
+              <Text as="h3" variant="metadata" color="text">
+                Debate format
+              </Text>
+              {formatSelector && (
+                <DebateFormatSelector
+                  value={formatSelector.value}
+                  selectedFormatId={formatSelector.selectedFormatId}
+                  canChoose
+                  disabled={busy}
+                  onChange={formatSelector.onChange}
+                  name={formatSelector.name}
+                  className="w-[min(260px,100%)]"
+                />
+              )}
+            </div>
+            <div className="px-1 pb-1">
+              <DebateFormatDetails
+                formatId={formatId}
+                participants={orderedParticipants}
+                currentUserId={currentUserId}
+              />
+            </div>
+          </section>
+
+          {error && (
+            <Text as="p" variant="body" color="red-01" className="mt-3">
+              {error}
+            </Text>
+          )}
+        </div>
+
+        <footer className="grid gap-3">
+          <button
+            type="button"
+            onClick={onAccept}
+            disabled={busy}
+            className="flex min-h-11 w-full items-center justify-center rounded-full bg-text px-5 text-button text-white transition-colors hover:bg-text/90 disabled:opacity-50"
+          >
+            Accept
+          </button>
+          <button
+            type="button"
+            onClick={onReject}
+            disabled={busy}
+            className="mx-auto min-h-10 px-4 text-button text-grey-04 hover:text-text disabled:opacity-50"
+          >
+            Reject
+          </button>
+        </footer>
+      </section>
+    </div>
+  );
+}
+
+function ParticipantSummary({
+  participant,
+  currentUserId,
+}: {
+  participant: DebateRequestDialogParticipant;
+  currentUserId: string;
+}) {
+  const label = participant.user_id === currentUserId ? 'You' : speakerLabel(participant);
+
+  return (
+    <div className="grid min-w-0 justify-items-center gap-2 text-center">
+      <span className="h-5 w-5 overflow-hidden rounded-full">
+        <Avatar
+          avatarUrl={participant.avatar_cid}
+          value={participant.profile_space_id}
+          alt={speakerLabel(participant)}
+          size={20}
+        />
+      </span>
+      <Text as="div" variant="metadata" color="text" className="max-w-full truncate">
+        {label}
+      </Text>
+    </div>
+  );
+}

--- a/apps/web/core/debates/match-prompt.tsx
+++ b/apps/web/core/debates/match-prompt.tsx
@@ -6,14 +6,12 @@ import { useRouter } from 'next/navigation';
 
 import { useFeatureFlag } from '~/core/state/feature-flags';
 
-import { Avatar } from '~/design-system/avatar';
 import { Button } from '~/design-system/button';
 import { Text } from '~/design-system/text';
 
 import { type Debate, type DebateMatch, type DebateMatchParticipant, getCurrentGeoChatUserId } from './api';
 import { DebatePreScreen } from './debate-pre-join-screen';
-import { DebateFormatDetails } from './format-details';
-import { DebateFormatSelector } from './format-selector';
+import { DebateRequestDialog } from './debate-request-dialog';
 import { type DebateFormatId, debateFormatById, defaultDebateFormatId } from './formats';
 import { useAbortDebate, useAcceptDebateMatch, useDeclineDebateMatch, useMarkDebateReady } from './hooks';
 import {
@@ -39,6 +37,7 @@ export function DebateMatchPrompt({ spaceId, matches, debates = [] }: DebateMatc
 
 function DebateMatchPromptContent({ spaceId, matches, debates = [] }: DebateMatchPromptProps) {
   const router = useRouter();
+  const debateFormatSelectorEnabled = useFeatureFlag('debateFormatSelector');
   const mediaSession = useDebateMediaSession();
   const { activeSessionKey, beginSession, promoteSession, releaseSession, ensurePreview } = mediaSession;
   const acceptMatch = useAcceptDebateMatch(spaceId);
@@ -224,21 +223,6 @@ function DebateMatchPromptContent({ spaceId, matches, debates = [] }: DebateMatc
     submitReady,
   ]);
 
-  React.useEffect(() => {
-    if (!activeMatch || !currentUserId || minimizedMatch) return;
-
-    const originalBodyOverflow = document.body.style.overflow;
-    const originalDocumentOverflow = document.documentElement.style.overflow;
-
-    document.body.style.overflow = 'hidden';
-    document.documentElement.style.overflow = 'hidden';
-
-    return () => {
-      document.body.style.overflow = originalBodyOverflow;
-      document.documentElement.style.overflow = originalDocumentOverflow;
-    };
-  }, [activeMatch, currentUserId, minimizedMatch]);
-
   if (!activeMatch || !currentUserId) return null;
 
   const selectedFormatId = selectedFormatIds[activeMatch.id] ?? formatIdForMatch(activeMatch);
@@ -376,187 +360,26 @@ function DebateMatchPromptContent({ spaceId, matches, debates = [] }: DebateMatc
   }
 
   return (
-    <MatchDialog
-      match={activeMatch}
+    <DebateRequestDialog
+      claim={activeMatch.claim.claim}
+      participants={activeMatch.participants}
       currentUserId={currentUserId}
-      selectedFormatId={selectedFormatId}
-      waiting={waiting}
+      formatId={selectedFormatId}
+      formatSelector={
+        debateFormatSelectorEnabled && myParticipant?.participant_slot === 1
+          ? {
+              value: selectedFormatId,
+              selectedFormatId: activeMatch.turn_format_id,
+              name: `debate-match-format-${activeMatch.id}`,
+              onChange: setSelectedFormatId,
+            }
+          : undefined
+      }
       busy={busy}
       error={error}
       onAccept={accept}
-      onDecline={decline}
-      onFormatChange={setSelectedFormatId}
+      onReject={decline}
     />
-  );
-}
-
-// Built but hidden: the Figma match-request design omits these labels. Flip to re-enable.
-const SHOW_POSITION_LABELS = false; // Yes/No pills under each name + the "You chose X." line
-
-function MatchDialog({
-  match,
-  currentUserId,
-  selectedFormatId,
-  waiting,
-  busy,
-  error,
-  onAccept,
-  onDecline,
-  onFormatChange,
-}: {
-  match: DebateMatch;
-  currentUserId: string;
-  selectedFormatId: DebateFormatId;
-  waiting: boolean;
-  busy: boolean;
-  error: string | null;
-  onAccept: () => void;
-  onDecline: () => void;
-  onFormatChange: (formatId: DebateFormatId) => void;
-}) {
-  const debateFormatSelectorEnabled = useFeatureFlag('debateFormatSelector');
-  const myParticipant = participantForUser(match, currentUserId);
-  const canChooseFormat = myParticipant?.participant_slot === 1 && !waiting;
-  const participants = orderedParticipants(match);
-  const firstParticipant = participants[0]!;
-  const secondParticipant = participants[1] ?? firstParticipant;
-  const selectedFormat = debateFormatById(selectedFormatId) ?? debateFormatById(defaultDebateFormatId)!;
-
-  return (
-    <div className="max-sm:items-end max-sm:p-0 fixed inset-0 z-1200 flex items-center justify-center bg-text/45 p-5 backdrop-blur-sm">
-      <section
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="debate-match-title"
-        className="max-sm:max-h-[calc(100dvh-1rem)] max-sm:rounded-b-none max-sm:border-b-0 max-sm:px-4 max-sm:py-5 grid max-h-[calc(100dvh-2rem)] w-[min(370px,100%)] grid-rows-[auto_minmax(0,1fr)_auto] gap-4 overflow-hidden rounded-lg bg-bg p-5 text-text shadow-card"
-      >
-        <header className="min-w-0 text-center">
-          <Text as="div" variant="metadata" color="text">
-            Debate request
-          </Text>
-          <h2 id="debate-match-title" className="mt-3 text-cardEntityTitle leading-[1.375rem]">
-            {waiting ? 'Waiting for the other person' : match.claim.claim}
-          </h2>
-        </header>
-
-        <div className="min-h-0 overflow-y-auto pr-1">
-          <div className="grid grid-cols-[1fr_auto_1fr] items-center rounded-lg bg-white py-5">
-            <ParticipantSummary participant={firstParticipant} currentUserId={currentUserId} />
-            <div className="relative grid w-16 place-items-center">
-              <span
-                aria-hidden="true"
-                className="absolute top-1/2 left-1/2 h-14 w-px -translate-x-1/2 -translate-y-1/2 bg-divider"
-              />
-              <span className="relative grid h-7 w-7 place-items-center rounded-full border border-divider bg-white text-smallButton text-text">
-                vs
-              </span>
-            </div>
-            <ParticipantSummary participant={secondParticipant} currentUserId={currentUserId} />
-          </div>
-
-          <section className="mt-4 overflow-hidden rounded-lg border border-grey-02 bg-white">
-            <div className="flex flex-wrap items-center justify-between gap-3 px-4 py-3">
-              <Text as="h3" variant="metadata" color="text">
-                Debate format
-              </Text>
-              {debateFormatSelectorEnabled && canChooseFormat && (
-                <DebateFormatSelector
-                  value={selectedFormatId}
-                  selectedFormatId={match.turn_format_id}
-                  canChoose={canChooseFormat}
-                  disabled={busy}
-                  onChange={onFormatChange}
-                  name={`debate-match-format-${match.id}`}
-                  className="w-[min(260px,100%)]"
-                />
-              )}
-            </div>
-            <div className="px-1 pb-1">
-              <DebateFormatDetails
-                formatId={selectedFormat.id}
-                participants={participants}
-                currentUserId={currentUserId}
-              />
-            </div>
-          </section>
-
-          {SHOW_POSITION_LABELS && myParticipant && (
-            <Text as="p" variant="metadata" color="grey-04" className="mt-3 text-center">
-              You chose {myParticipant.position_label}.
-            </Text>
-          )}
-
-          {error && (
-            <Text as="p" variant="body" color="red-01" className="mt-3">
-              {error}
-            </Text>
-          )}
-        </div>
-
-        <footer className="grid gap-3">
-          {waiting ? (
-            <>
-              <Text as="p" variant="body" color="grey-04" className="text-center">
-                Waiting for the other person to say yes.
-              </Text>
-              <Button type="button" variant="secondary" onClick={onDecline} disabled={busy} className="w-full">
-                Cancel
-              </Button>
-            </>
-          ) : (
-            <>
-              <button
-                type="button"
-                onClick={onAccept}
-                disabled={busy}
-                className="flex min-h-11 w-full items-center justify-center rounded-full bg-text px-5 text-button text-white transition-colors hover:bg-text/90 disabled:opacity-50"
-              >
-                Accept
-              </button>
-              <button
-                type="button"
-                onClick={onDecline}
-                disabled={busy}
-                className="mx-auto min-h-10 px-4 text-button text-grey-04 hover:text-text disabled:opacity-50"
-              >
-                Reject
-              </button>
-            </>
-          )}
-        </footer>
-      </section>
-    </div>
-  );
-}
-
-function ParticipantSummary({
-  participant,
-  currentUserId,
-}: {
-  participant: DebateMatchParticipant;
-  currentUserId: string;
-}) {
-  const label = participant.user_id === currentUserId ? 'You' : speakerLabel(participant);
-
-  return (
-    <div className="grid min-w-0 justify-items-center gap-2 text-center">
-      <span className="h-5 w-5 overflow-hidden rounded-full">
-        <Avatar
-          avatarUrl={participant.avatar_cid}
-          value={participant.profile_space_id}
-          alt={speakerLabel(participant)}
-          size={20}
-        />
-      </span>
-      <Text as="div" variant="metadata" color="text" className="max-w-full truncate">
-        {label}
-      </Text>
-      {SHOW_POSITION_LABELS && (
-        <span className="rounded-full bg-grey-02 px-3 py-1 text-metadataMedium text-text">
-          {participant.position_label}
-        </span>
-      )}
-    </div>
   );
 }
 
@@ -598,10 +421,6 @@ function participantForUser(match: DebateMatch, userId: string): DebateMatchPart
 
 function otherParticipant(match: DebateMatch, userId: string): DebateMatchParticipant {
   return match.participants.find(participant => participant.user_id !== userId) ?? match.participants[0]!;
-}
-
-function orderedParticipants(match: DebateMatch) {
-  return [...match.participants].sort((a, b) => a.participant_slot - b.participant_slot);
 }
 
 function speakerLabel(participant: { display_name: string | null; profile_space_id: string }) {


### PR DESCRIPTION
## Summary

Incoming rematch requests now use the same polished, responsive debate-request dialog as matching-claim requests. This replaces the oversized rematch presentation, removes the rematch-only Yes/No pills, and keeps participants in debate-slot order.

Each flow retains its existing behavior: matching claims still support the feature-flagged format selector and post-accept pre-screen, while rematches still use the request's snapshotted format and their own accept/reject mutations.

## Validation

- `bun run test` — 154 test files and 1,582 tests passed
- `bun lint` — 0 errors; existing unrelated warnings remain
- `bunx tsc --noEmit --pretty false`
- Loaded the local app in the browser; a live desktop/mobile modal comparison could not be completed because the browser session did not have an authenticated active debate/rematch request

## Post-Deploy Monitoring & Validation

- Search client error monitoring and support reports for debate match/rematch accept or reject failures, including messages containing `Could not accept` or `Could not reject`.
- Watch debate and rematch request acceptance/rejection success rates for regressions from their pre-deploy baseline.
- Healthy signals: incoming requests render with both participants and the snapshotted format, actions transition normally, and no increase appears in mutation failures.
- Failure signals: requests cannot be accepted/rejected, the modal remains stuck after a successful action, or participant/format details are missing. Revert this PR if those failures reproduce after deploy.
- Validation window: first 24 hours after deploy; owner: debates feature owner/on-call.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
