### PR TITLE
test(debates): verify wrap-up warning placement

### DIFF
--- a/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
@@ -1822,7 +1822,7 @@ describe('DebateRoomPageClient', () => {
     expect(document.querySelector('circle[stroke="var(--color-red-01)"]')).toBeInTheDocument();
   });
 
-  it('shows wrap it up only on the active remote speaker during the penultimate turn', async () => {
+  it('does not show the remote speaker wrap-up warning to the inactive local participant', async () => {
     vi.spyOn(Date, 'now').mockReturnValue(Date.parse('2026-07-02T00:00:26.500Z'));
     mocks.debate = {
       ...completedDebate(),
@@ -1838,9 +1838,8 @@ describe('DebateRoomPageClient', () => {
 
     render(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
 
-    const wrapItUp = await screen.findByText('Wrap it up!');
-    expect(debateVideoTile('remote')).toContainElement(wrapItUp);
-    expect(debateVideoTile('local')).not.toContainElement(wrapItUp);
+    expect(await screen.findByRole('dialog', { name: 'Debate recording' })).toBeInTheDocument();
+    expect(screen.queryByText('Wrap it up!')).not.toBeInTheDocument();
   });
 
   it('does not show wrap it up before the final five seconds', async () => {
@@ -1887,7 +1886,7 @@ describe('DebateRoomPageClient', () => {
     expect(document.querySelector('circle[stroke="var(--color-red-01)"]')).toBeInTheDocument();
   });
 
-  it('shows final-turn warnings only on their respective speaker tiles', async () => {
+  it('shows only debate ends soon to the inactive local participant on the final turn', async () => {
     vi.spyOn(Date, 'now').mockReturnValue(Date.parse('2026-07-02T00:02:26.500Z'));
     let clockElapsedMs = 0;
     vi.spyOn(performance, 'now').mockImplementation(() => clockElapsedMs);
@@ -1907,9 +1906,7 @@ describe('DebateRoomPageClient', () => {
     render(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
 
     const debateEndsSoon = await screen.findByText('Debate ends soon');
-    const wrapItUp = screen.getByText('Wrap it up!');
-    expect(debateVideoTile('remote')).toContainElement(wrapItUp);
-    expect(debateVideoTile('local')).not.toContainElement(wrapItUp);
+    expect(screen.queryByText('Wrap it up!')).not.toBeInTheDocument();
     expect(debateVideoTile('local')).toContainElement(debateEndsSoon);
     expect(debateVideoTile('remote')).not.toContainElement(debateEndsSoon);
     expect(screen.queryByText("You're up in")).not.toBeInTheDocument();
@@ -1924,6 +1921,29 @@ describe('DebateRoomPageClient', () => {
       expect(screen.queryByText('Debate ends soon')).not.toBeInTheDocument();
       expect(screen.getByText((_, element) => element?.textContent === 'Nice debate!Say thanks')).toBeInTheDocument();
     });
+  });
+
+  it('shows wrap it up to the active local participant on the final turn', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(Date.parse('2026-07-02T00:02:26.500Z'));
+    mocks.debate = {
+      ...completedDebate(),
+      status: 'in_progress',
+      first_participant_slot: 2,
+      current_turn_index: 3,
+      current_speaker_slot: 1,
+      turn_durations_ms: [45_000, 45_000, 30_000, 30_000],
+      started_at: '2026-07-02T00:00:00.000Z',
+      turn_started_at: '2026-07-02T00:02:00.000Z',
+      turn_ends_at: '2026-07-02T00:02:30.000Z',
+      completed_at: null,
+    };
+
+    render(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
+
+    const wrapItUp = await screen.findByText('Wrap it up!');
+    expect(debateVideoTile('local')).toContainElement(wrapItUp);
+    expect(debateVideoTile('remote')).not.toContainElement(wrapItUp);
+    expect(screen.queryByText('Debate ends soon')).not.toBeInTheDocument();
   });
 
   it('advances directly from the warning to GO without waiting for a debate refresh', async () => {

--- a/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
@@ -1798,7 +1798,7 @@ describe('DebateRoomPageClient', () => {
     expect(screen.queryByText("You're up in")).not.toBeInTheDocument();
   });
 
-  it('shows wrap it up only on the active local speaker in the final five seconds', async () => {
+  it('shows wrap it up only on the active local speaker during the penultimate turn', async () => {
     vi.spyOn(Date, 'now').mockReturnValue(Date.parse('2026-07-02T00:00:26.500Z'));
     mocks.debate = {
       ...completedDebate(),
@@ -1820,6 +1820,27 @@ describe('DebateRoomPageClient', () => {
     expect(screen.queryByText("You're up in")).not.toBeInTheDocument();
     expect(screen.queryByText('GO!')).not.toBeInTheDocument();
     expect(document.querySelector('circle[stroke="var(--color-red-01)"]')).toBeInTheDocument();
+  });
+
+  it('shows wrap it up only on the active remote speaker during the penultimate turn', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(Date.parse('2026-07-02T00:00:26.500Z'));
+    mocks.debate = {
+      ...completedDebate(),
+      status: 'in_progress',
+      first_participant_slot: 2,
+      current_turn_index: 0,
+      current_speaker_slot: 2,
+      started_at: '2026-07-02T00:00:00.000Z',
+      turn_started_at: '2026-07-02T00:00:00.000Z',
+      turn_ends_at: '2026-07-02T00:00:30.000Z',
+      completed_at: null,
+    };
+
+    render(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
+
+    const wrapItUp = await screen.findByText('Wrap it up!');
+    expect(debateVideoTile('remote')).toContainElement(wrapItUp);
+    expect(debateVideoTile('local')).not.toContainElement(wrapItUp);
   });
 
   it('does not show wrap it up before the final five seconds', async () => {
@@ -1868,6 +1889,8 @@ describe('DebateRoomPageClient', () => {
 
   it('shows final-turn warnings only on their respective speaker tiles', async () => {
     vi.spyOn(Date, 'now').mockReturnValue(Date.parse('2026-07-02T00:02:26.500Z'));
+    let clockElapsedMs = 0;
+    vi.spyOn(performance, 'now').mockImplementation(() => clockElapsedMs);
     mocks.debate = {
       ...completedDebate(),
       status: 'in_progress',
@@ -1893,6 +1916,14 @@ describe('DebateRoomPageClient', () => {
     expect(screen.queryByText('Rebut in')).not.toBeInTheDocument();
     expect(document.querySelector('[data-inactive-speaker="local"]')).toHaveAttribute('data-visible', 'false');
     expect(document.querySelector('circle[stroke="var(--color-red-01)"]')).toBeInTheDocument();
+
+    clockElapsedMs = 4_000;
+
+    await waitFor(() => {
+      expect(screen.queryByText('Wrap it up!')).not.toBeInTheDocument();
+      expect(screen.queryByText('Debate ends soon')).not.toBeInTheDocument();
+      expect(screen.getByText((_, element) => element?.textContent === 'Nice debate!Say thanks')).toBeInTheDocument();
+    });
   });
 
   it('advances directly from the warning to GO without waiting for a debate refresh', async () => {
@@ -1982,8 +2013,6 @@ describe('DebateRoomPageClient', () => {
     expect(
       await screen.findByText((_, element) => element?.textContent === 'Nice debate!Say thanks')
     ).toBeInTheDocument();
-    expect(screen.queryByText('Wrap it up!')).not.toBeInTheDocument();
-    expect(screen.queryByText('Debate ends soon')).not.toBeInTheDocument();
     expect(document.querySelector('[data-inactive-speaker="local"]')).toHaveAttribute('data-visible', 'false');
     expect(document.querySelector('[data-inactive-speaker="remote"]')).toHaveAttribute('data-visible', 'false');
     await waitFor(() => expect(audioTrack.mediaStreamTrack.enabled).toBe(true));

--- a/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
@@ -1798,7 +1798,7 @@ describe('DebateRoomPageClient', () => {
     expect(screen.queryByText("You're up in")).not.toBeInTheDocument();
   });
 
-  it('shows wrap it up with a red ring on the active speaker in the final five seconds', async () => {
+  it('shows wrap it up only on the active local speaker in the final five seconds', async () => {
     vi.spyOn(Date, 'now').mockReturnValue(Date.parse('2026-07-02T00:00:26.500Z'));
     mocks.debate = {
       ...completedDebate(),
@@ -1814,10 +1814,32 @@ describe('DebateRoomPageClient', () => {
 
     render(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
 
-    expect(await screen.findByText('Wrap it up!')).toBeInTheDocument();
+    const wrapItUp = await screen.findByText('Wrap it up!');
+    expect(debateVideoTile('local')).toContainElement(wrapItUp);
+    expect(debateVideoTile('remote')).not.toContainElement(wrapItUp);
     expect(screen.queryByText("You're up in")).not.toBeInTheDocument();
     expect(screen.queryByText('GO!')).not.toBeInTheDocument();
     expect(document.querySelector('circle[stroke="var(--color-red-01)"]')).toBeInTheDocument();
+  });
+
+  it('does not show wrap it up before the final five seconds', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(Date.parse('2026-07-02T00:00:24.000Z'));
+    mocks.debate = {
+      ...completedDebate(),
+      status: 'in_progress',
+      first_participant_slot: 1,
+      current_turn_index: 0,
+      current_speaker_slot: 1,
+      started_at: '2026-07-02T00:00:00.000Z',
+      turn_started_at: '2026-07-02T00:00:00.000Z',
+      turn_ends_at: '2026-07-02T00:00:30.000Z',
+      completed_at: null,
+    };
+
+    render(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
+
+    expect(await screen.findByRole('dialog', { name: 'Debate recording' })).toBeInTheDocument();
+    expect(screen.queryByText('Wrap it up!')).not.toBeInTheDocument();
   });
 
   it('labels the upcoming turn as a rebuttal in the final round', async () => {
@@ -1844,7 +1866,7 @@ describe('DebateRoomPageClient', () => {
     expect(document.querySelector('circle[stroke="var(--color-red-01)"]')).toBeInTheDocument();
   });
 
-  it('shows debate ends soon to the inactive speaker on the final turn', async () => {
+  it('shows final-turn warnings only on their respective speaker tiles', async () => {
     vi.spyOn(Date, 'now').mockReturnValue(Date.parse('2026-07-02T00:02:26.500Z'));
     mocks.debate = {
       ...completedDebate(),
@@ -1861,7 +1883,12 @@ describe('DebateRoomPageClient', () => {
 
     render(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
 
-    expect(await screen.findByText('Debate ends soon')).toBeInTheDocument();
+    const debateEndsSoon = await screen.findByText('Debate ends soon');
+    const wrapItUp = screen.getByText('Wrap it up!');
+    expect(debateVideoTile('remote')).toContainElement(wrapItUp);
+    expect(debateVideoTile('local')).not.toContainElement(wrapItUp);
+    expect(debateVideoTile('local')).toContainElement(debateEndsSoon);
+    expect(debateVideoTile('remote')).not.toContainElement(debateEndsSoon);
     expect(screen.queryByText("You're up in")).not.toBeInTheDocument();
     expect(screen.queryByText('Rebut in')).not.toBeInTheDocument();
     expect(document.querySelector('[data-inactive-speaker="local"]')).toHaveAttribute('data-visible', 'false');
@@ -1955,6 +1982,8 @@ describe('DebateRoomPageClient', () => {
     expect(
       await screen.findByText((_, element) => element?.textContent === 'Nice debate!Say thanks')
     ).toBeInTheDocument();
+    expect(screen.queryByText('Wrap it up!')).not.toBeInTheDocument();
+    expect(screen.queryByText('Debate ends soon')).not.toBeInTheDocument();
     expect(document.querySelector('[data-inactive-speaker="local"]')).toHaveAttribute('data-visible', 'false');
     expect(document.querySelector('[data-inactive-speaker="remote"]')).toHaveAttribute('data-visible', 'false');
     await waitFor(() => expect(audioTrack.mediaStreamTrack.enabled).toBe(true));
@@ -2295,9 +2324,13 @@ async function renderLiveDebate(overrides: Partial<Debate> = {}) {
 }
 
 function expectDebateVideoTileInColor(participant: 'local' | 'remote') {
+  expect(debateVideoTile(participant)).not.toHaveClass('grayscale');
+}
+
+function debateVideoTile(participant: 'local' | 'remote') {
   const tile = document.querySelector(`[data-inactive-speaker="${participant}"]`)?.closest('section');
-  expect(tile).not.toBeNull();
-  expect(tile).not.toHaveClass('grayscale');
+  if (!(tile instanceof HTMLElement)) throw new Error(`Missing ${participant} debate video tile`);
+  return tile;
 }
 
 function installRecordingMocks() {

--- a/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.tsx
@@ -1508,7 +1508,6 @@ function DebateRecordingModal({
   const localUpcomingLabel = upcomingTurnIsRebuttal(debate, countdown) ? 'Rebut in' : "You're up in";
   const showLocalGo = localTurnGoIsVisible(countdown, localSlot);
   const showLocalWrapItUp = wrapItUpIsVisible(countdown, localSlot);
-  const showRemoteWrapItUp = wrapItUpIsVisible(countdown, remoteParticipant?.participant_slot ?? null);
   const showLocalDebateEndsSoon = debateEndsSoonIsVisible(debate, countdown, localSlot);
   const thankingSlot = thankingParticipantSlot(debate, countdown);
   const localInactive = participantIsInactive(countdown.effectiveStatus, localSlot, countdown.activeSlot);
@@ -1580,7 +1579,6 @@ function DebateRecordingModal({
             ? null
             : 'Waiting for video'
       }
-      showWrapItUp={showRemoteWrapItUp}
       inactive={remoteInactive}
       inactiveOverlayId="remote"
       countdown={remoteCountdown}


### PR DESCRIPTION
## Summary

“Wrap it up!” is now private to the participant whose turn is ending: it appears over that participant’s own tile on their client, but the inactive participant does not see the warning over the opponent’s tile.

The behavior remains active during the final five seconds of every turn, including the final turn before thanking. On the final turn, the inactive participant sees “Debate ends soon,” and the warnings disappear when the countdown advances into the thanking phase.

## Validation

- Focused debate-room suite: 96 tests passed
- Full web suite: 157 files and 1,604 tests passed
- ESLint passed for the changed implementation and test files
- Prettier and `git diff --check` passed

## Post-Deploy Monitoring & Validation

No additional operational monitoring required. The behavior is covered from both the active and inactive participant perspectives, including the final-turn transition.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
