### PR TITLE
fix: count comments in explore data blocks

### DIFF
--- a/apps/web/core/io/entity-comment-count.test.ts
+++ b/apps/web/core/io/entity-comment-count.test.ts
@@ -1,0 +1,65 @@
+import * as Effect from 'effect/Effect';
+import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { COMMENT_REPLY_TO_ID, COMMENT_TYPE_ID } from '~/core/comment-ids';
+
+import { graphql } from './graphql-client';
+import { getEntityCommentCount } from './queries';
+
+vi.mock('./graphql-client', () => ({
+  graphql: vi.fn(),
+}));
+
+const graphqlMock = graphql as unknown as Mock;
+
+describe('getEntityCommentCount', () => {
+  beforeEach(() => {
+    graphqlMock.mockReset();
+  });
+
+  it('counts only distinct comment entities returned by the filtered Reply to backlink query', async () => {
+    graphqlMock.mockImplementation(({ decoder, variables }) => {
+      const ids = variables.offset === 0 ? ['comment-1', 'comment-1', 'comment-2'] : [];
+      return Effect.succeed(
+        decoder({
+          entity: {
+            backlinksList: ids.map(id => ({ fromEntity: { id } })),
+          },
+        })
+      );
+    });
+
+    const count = await Effect.runPromise(getEntityCommentCount('target-entity'));
+
+    expect(count).toBe(2);
+    expect(graphqlMock).toHaveBeenCalledOnce();
+    expect(graphqlMock.mock.calls[0]?.[0]?.variables).toMatchObject({
+      id: 'target-entity',
+      replyToTypeId: COMMENT_REPLY_TO_ID,
+      commentTypeId: COMMENT_TYPE_ID,
+      first: 1000,
+      offset: 0,
+    });
+  });
+
+  it('paginates counts beyond the backlink page size and deduplicates across pages', async () => {
+    const firstPageIds = Array.from({ length: 1000 }, (_, index) => `comment-${index}`);
+
+    graphqlMock.mockImplementation(({ decoder, variables }) => {
+      const ids = variables.offset === 0 ? firstPageIds : ['comment-999', 'comment-1000'];
+      return Effect.succeed(
+        decoder({
+          entity: {
+            backlinksList: ids.map(id => ({ fromEntity: { id } })),
+          },
+        })
+      );
+    });
+
+    const count = await Effect.runPromise(getEntityCommentCount('target-entity'));
+
+    expect(count).toBe(1001);
+    expect(graphqlMock).toHaveBeenCalledTimes(2);
+    expect(graphqlMock.mock.calls.map(call => call[0].variables.offset)).toEqual([0, 1000]);
+  });
+});

--- a/apps/web/core/io/queries.ts
+++ b/apps/web/core/io/queries.ts
@@ -522,14 +522,7 @@ export function getBatchEntitiesForComments(entityIds: string[], signal?: AbortC
   });
 }
 
-/**
- * Loads Comment entities from incoming "Reply to" backlinks on the parent entity.
- * Nested replies are included when they also backlink to the parent (same index pattern).
- */
-export function getCommentEntitiesViaParentEntityReplyBacklinks(
-  parentEntityId: string,
-  signal?: AbortController['signal']
-) {
+function getCommentEntityIdsViaParentEntityReplyBacklinks(parentEntityId: string, signal?: AbortController['signal']) {
   return Effect.gen(function* () {
     const seen = new Set<string>();
     const ids: string[] = [];
@@ -553,16 +546,34 @@ export function getCommentEntitiesViaParentEntityReplyBacklinks(
 
       for (const row of page) {
         const rawId = row?.fromEntity?.id;
-        if (typeof rawId !== 'string' || !rawId) continue;
-        if (!seen.has(rawId)) {
-          seen.add(rawId);
-          ids.push(rawId);
-        }
+        if (typeof rawId !== 'string' || !rawId || seen.has(rawId)) continue;
+        seen.add(rawId);
+        ids.push(rawId);
       }
 
       if (page.length < COMMENT_REPLY_BACKLINKS_PAGE_SIZE) break;
       offset += COMMENT_REPLY_BACKLINKS_PAGE_SIZE;
     }
+
+    return ids;
+  });
+}
+
+/** Counts distinct Comment entities connected to the target by incoming "Reply to" relations. */
+export function getEntityCommentCount(entityId: string, signal?: AbortController['signal']) {
+  return Effect.map(getCommentEntityIdsViaParentEntityReplyBacklinks(entityId, signal), ids => ids.length);
+}
+
+/**
+ * Loads Comment entities from incoming "Reply to" backlinks on the parent entity.
+ * Nested replies are included when they also backlink to the parent (same index pattern).
+ */
+export function getCommentEntitiesViaParentEntityReplyBacklinks(
+  parentEntityId: string,
+  signal?: AbortController['signal']
+) {
+  return Effect.gen(function* () {
+    const ids = yield* getCommentEntityIdsViaParentEntityReplyBacklinks(parentEntityId, signal);
 
     if (ids.length === 0) return [] as Entity[];
     return yield* getBatchEntitiesForComments(ids, signal);

--- a/apps/web/partials/blocks/table/use-block-explore-feed-item.ts
+++ b/apps/web/partials/blocks/table/use-block-explore-feed-item.ts
@@ -8,7 +8,7 @@ import { Effect } from 'effect';
 import { parseEntityUpdatedAtToUnixSec } from '~/core/explore/explore-relative-time';
 import type { ExploreFeedItem } from '~/core/explore/fetch-explore-feed';
 import { useSpace } from '~/core/hooks/use-space';
-import { getEntity, getEntityBacklinks } from '~/core/io/queries';
+import { getEntity, getEntityCommentCount } from '~/core/io/queries';
 import {
   useAvatar,
   useCover,
@@ -84,11 +84,8 @@ export function useBlockExploreFeedItem({
   const { space } = useSpace(hideSpaceLink ? undefined : entitySpaceId);
 
   const { data: commentCount = 0 } = useQuery({
-    queryKey: ['entity-backlink-count', rowEntityId],
-    queryFn: async ({ signal }) => {
-      const backlinks = await Effect.runPromise(getEntityBacklinks(rowEntityId, undefined, signal));
-      return backlinks.length;
-    },
+    queryKey: ['entity-comment-count', rowEntityId],
+    queryFn: ({ signal }) => Effect.runPromise(getEntityCommentCount(rowEntityId, signal)),
     staleTime: 60_000,
     enabled,
   });


### PR DESCRIPTION
## What changed

- Replace the Explore data-block badge's all-backlink count with a comment-specific count.
- Filter incoming relations to `Reply to` links from Comment entities.
- Count distinct comment entities across paginated backlink results.
- Share the filtered ID loader with the full comments query so both paths use identical semantics.

## Why

Explore-view data blocks were displaying every backlink to an entity as a comment. Type links, references, and other relations inflated the badge even though they were not comments.

## Impact

Comment icons in Explore-view data blocks now show the number of actual comments and replies associated with the entity.

## Validation

- `bun run test core/io/entity-comment-count.test.ts core/io/queries.test.ts`
- `bunx eslint core/io/queries.ts core/io/entity-comment-count.test.ts partials/blocks/table/use-block-explore-feed-item.ts`
- `bunx tsc --noEmit --pretty false`
- `git diff --check`
