### PR TITLE
feat: add per-space debate diagnostics

### DIFF
--- a/apps/web/app/space/[id]/(space)/debug-debates/debug-debates-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debug-debates/debug-debates-page-client.test.tsx
@@ -64,7 +64,8 @@ vi.mock('~/core/debates/hooks', () => ({
 beforeEach(() => {
   mocks.debugEnabled = true;
   mocks.replace.mockReset();
-  mocks.invalidateQueries.mockClear();
+  mocks.invalidateQueries.mockReset();
+  mocks.invalidateQueries.mockResolvedValue(undefined);
   mocks.listResult = { data: { debates: [], matches: [] }, isLoading: false, isFetching: false, error: null };
   mocks.mediaByDebate.clear();
   mocks.transcriptByDebate.clear();
@@ -120,6 +121,22 @@ describe('DebugDebatesPageClient', () => {
     expect(screen.getByRole('button', { name: 'Refreshing…' })).toBeDisabled();
   });
 
+  it('keeps the refresh state until both list and media invalidations finish', async () => {
+    let resolveRefresh: (() => void) | undefined;
+    const refreshFinished = new Promise<void>(resolve => {
+      resolveRefresh = resolve;
+    });
+    mocks.invalidateQueries.mockReturnValue(refreshFinished);
+
+    render(<DebugDebatesPageClient spaceId="space-1" />);
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh diagnostics' }));
+
+    expect(screen.getByRole('button', { name: 'Refreshing…' })).toBeDisabled();
+
+    resolveRefresh?.();
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Refresh diagnostics' })).toBeEnabled());
+  });
+
   it('shows all simplified processing states alongside raw debate lifecycles', () => {
     const statuses: Array<[string, DebateMediaJobStatus | null, string]> = [
       ['not-started', null, 'not started'],
@@ -149,8 +166,10 @@ describe('DebugDebatesPageClient', () => {
     render(<DebugDebatesPageClient spaceId="space-1" />);
 
     expect(screen.getByTestId('debate-card-loading')).toHaveTextContent('Loading processing status…');
+    expect(screen.getByTestId('debate-card-loading')).toHaveTextContent('Media jobloading');
     expect(screen.getByTestId('debate-card-loading')).toHaveTextContent('Transcript · count unavailable');
     expect(screen.getByTestId('debate-card-media-error')).toHaveTextContent('Could not load media: Media failed');
+    expect(screen.getByTestId('debate-card-media-error')).toHaveTextContent('Media jobunavailable');
     expect(screen.getByTestId('debate-card-failed')).toHaveTextContent('Attempts: 3');
     expect(screen.getByTestId('debate-card-failed')).toHaveTextContent('Latest error: ffmpeg exited 1');
   });

--- a/apps/web/app/space/[id]/(space)/debug-debates/debug-debates-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debug-debates/debug-debates-page-client.test.tsx
@@ -1,0 +1,321 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Debate, DebateMediaArtifactKind, DebateMediaJobStatus, DebateMediaResponse } from '~/core/debates/api';
+
+import { DebugDebatesPageClient } from './debug-debates-page-client';
+
+const mocks = vi.hoisted(() => ({
+  debugEnabled: true,
+  replace: vi.fn(),
+  invalidateQueries: vi.fn(() => Promise.resolve()),
+  listResult: {
+    data: { debates: [] as Debate[], matches: [] },
+    isLoading: false,
+    isFetching: false,
+    error: null as Error | null,
+  },
+  mediaByDebate: new Map<string, { data?: DebateMediaResponse; isLoading: boolean; error: Error | null }>(),
+  transcriptByDebate: new Map<string, { data?: unknown; isLoading: boolean; error: Error | null }>(),
+  transcriptCalls: [] as Array<{ debateId: string; enabled: boolean }>,
+  artifactUrls: new Map<string, string>(),
+  artifactErrors: new Set<string>(),
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: mocks.replace }),
+}));
+
+vi.mock('@tanstack/react-query', () => ({
+  useQueryClient: () => ({ invalidateQueries: mocks.invalidateQueries }),
+}));
+
+vi.mock('~/core/state/feature-flags', () => ({
+  useDebugDebatesPageEnabled: () => mocks.debugEnabled,
+}));
+
+vi.mock('~/core/debates/hooks', () => ({
+  debateQueryKeys: {
+    spaceDebates: (spaceId: string) => ['debates', 'space', spaceId],
+  },
+  useSpaceDebates: () => mocks.listResult,
+  useDebateMedia: (debateId: string) =>
+    mocks.mediaByDebate.get(debateId) ?? { data: undefined, isLoading: false, error: null },
+  useDebateMediaArtifactUrl: () => ({
+    mutate: (
+      { debateId, request }: { debateId: string; request: { kind: DebateMediaArtifactKind } },
+      callbacks: { onSuccess: (value: { upload: { url: string } }) => void; onError: (error: Error) => void }
+    ) => {
+      const key = `${debateId}:${request.kind}`;
+      if (mocks.artifactErrors.has(key)) callbacks.onError(new Error('URL unavailable'));
+      else callbacks.onSuccess({ upload: { url: mocks.artifactUrls.get(key) ?? `https://media.test/${key}` } });
+    },
+  }),
+  useDebateTranscript: (debateId: string, _format: string, enabled: boolean) => {
+    mocks.transcriptCalls.push({ debateId, enabled });
+    return enabled
+      ? (mocks.transcriptByDebate.get(debateId) ?? { data: { segments: [] }, isLoading: false, error: null })
+      : { data: undefined, isLoading: false, error: null };
+  },
+}));
+
+beforeEach(() => {
+  mocks.debugEnabled = true;
+  mocks.replace.mockReset();
+  mocks.invalidateQueries.mockClear();
+  mocks.listResult = { data: { debates: [], matches: [] }, isLoading: false, isFetching: false, error: null };
+  mocks.mediaByDebate.clear();
+  mocks.transcriptByDebate.clear();
+  mocks.transcriptCalls.length = 0;
+  mocks.artifactUrls.clear();
+  mocks.artifactErrors.clear();
+});
+
+afterEach(cleanup);
+
+describe('DebugDebatesPageClient', () => {
+  it('redirects to the space when its independent flag is disabled', () => {
+    mocks.debugEnabled = false;
+
+    const { container } = render(<DebugDebatesPageClient spaceId="space-1" />);
+
+    expect(container).toBeEmptyDOMElement();
+    expect(mocks.replace).toHaveBeenCalledWith('/space/space-1');
+  });
+
+  it.each([
+    [{ data: undefined, isLoading: true, isFetching: true, error: null }, 'Loading debate diagnostics…'],
+    [{ data: undefined, isLoading: false, isFetching: false, error: new Error('List failed') }, 'Could not load debates: List failed'],
+    [{ data: { debates: [], matches: [] }, isLoading: false, isFetching: false, error: null }, 'No debates found for this space.'],
+  ])('renders the list state %#', (result, message) => {
+    mocks.listResult = result as typeof mocks.listResult;
+
+    render(<DebugDebatesPageClient spaceId="space-1" />);
+
+    expect(screen.getByText(message)).toBeInTheDocument();
+  });
+
+  it('sorts debates newest first and refreshes the list and media queries', async () => {
+    mocks.listResult.data.debates = [debate('older', '2026-07-01T00:00:00.000Z'), debate('newer', '2026-07-03T00:00:00.000Z')];
+
+    render(<DebugDebatesPageClient spaceId="space-1" />);
+
+    const cards = document.querySelectorAll('[data-debug-debate-card]');
+    expect(cards[0]).toHaveTextContent('Claim newer');
+    expect(cards[1]).toHaveTextContent('Claim older');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh diagnostics' }));
+    await waitFor(() => expect(mocks.invalidateQueries).toHaveBeenCalledTimes(2));
+    expect(mocks.invalidateQueries).toHaveBeenCalledWith({ queryKey: ['debates', 'space', 'space-1'] });
+    expect(mocks.invalidateQueries).toHaveBeenCalledWith({ queryKey: ['debates', 'media'] });
+  });
+
+  it('shows a disabled refresh state while queries are refreshing', () => {
+    mocks.listResult.isFetching = true;
+
+    render(<DebugDebatesPageClient spaceId="space-1" />);
+
+    expect(screen.getByRole('button', { name: 'Refreshing…' })).toBeDisabled();
+  });
+
+  it('shows all simplified processing states alongside raw debate lifecycles', () => {
+    const statuses: Array<[string, DebateMediaJobStatus | null, string]> = [
+      ['not-started', null, 'not started'],
+      ['queued', 'queued', 'processing'],
+      ['running', 'running', 'processing'],
+      ['processed', 'succeeded', 'processed'],
+      ['failed', 'failed', 'failed'],
+    ];
+    mocks.listResult.data.debates = statuses.map(([id]) => debate(id));
+    for (const [id, status] of statuses) mocks.mediaByDebate.set(id, mediaResult(status));
+
+    render(<DebugDebatesPageClient spaceId="space-1" />);
+
+    for (const [id, , label] of statuses) {
+      const card = screen.getByTestId(`debate-card-${id}`);
+      expect(card).toHaveTextContent(`Processing: ${label}`);
+      expect(card).toHaveTextContent('Lifecyclecomplete');
+    }
+  });
+
+  it('shows media loading/errors and failed-job attempt details', () => {
+    mocks.listResult.data.debates = [debate('loading'), debate('media-error'), debate('failed')];
+    mocks.mediaByDebate.set('loading', { data: undefined, isLoading: true, error: null });
+    mocks.mediaByDebate.set('media-error', { data: undefined, isLoading: false, error: new Error('Media failed') });
+    mocks.mediaByDebate.set('failed', mediaResult('failed', { attempt_count: 3, last_error: 'ffmpeg exited 1' }));
+
+    render(<DebugDebatesPageClient spaceId="space-1" />);
+
+    expect(screen.getByTestId('debate-card-loading')).toHaveTextContent('Loading processing status…');
+    expect(screen.getByTestId('debate-card-loading')).toHaveTextContent('Transcript · count unavailable');
+    expect(screen.getByTestId('debate-card-media-error')).toHaveTextContent('Could not load media: Media failed');
+    expect(screen.getByTestId('debate-card-failed')).toHaveTextContent('Attempts: 3');
+    expect(screen.getByTestId('debate-card-failed')).toHaveTextContent('Latest error: ffmpeg exited 1');
+  });
+
+  it('loads available WebM and MOV renditions independently with links and fallbacks', async () => {
+    mocks.listResult.data.debates = [debate('both'), debate('webm-only')];
+    mocks.mediaByDebate.set('both', mediaResult('succeeded', {}, ['final_video', 'final_video_hevc']));
+    mocks.mediaByDebate.set('webm-only', mediaResult('succeeded', {}, ['final_video']));
+    mocks.artifactUrls.set('both:final_video', 'https://media.test/both.webm');
+    mocks.artifactUrls.set('both:final_video_hevc', 'https://media.test/both.mov');
+
+    render(<DebugDebatesPageClient spaceId="space-1" />);
+
+    const both = screen.getByTestId('debate-card-both');
+    expect(await within(both).findByLabelText('WebM processed video')).toHaveAttribute('src', 'https://media.test/both.webm');
+    expect(within(both).getByLabelText('MOV processed video')).toHaveAttribute('src', 'https://media.test/both.mov');
+    expect(within(both).getByRole('link', { name: 'Open WebM directly' })).toHaveAttribute(
+      'href',
+      'https://media.test/both.webm'
+    );
+    expect(within(both).getByRole('link', { name: 'Open MOV directly' })).toHaveAttribute(
+      'href',
+      'https://media.test/both.mov'
+    );
+
+    const webmOnly = screen.getByTestId('debate-card-webm-only');
+    expect(webmOnly).toHaveTextContent('MOV rendition is missing.');
+  });
+
+  it('shows independent URL and playback errors for a rendition', async () => {
+    mocks.listResult.data.debates = [debate('errors')];
+    mocks.mediaByDebate.set('errors', mediaResult('succeeded', {}, ['final_video', 'final_video_hevc']));
+    mocks.artifactErrors.add('errors:final_video_hevc');
+
+    render(<DebugDebatesPageClient spaceId="space-1" />);
+
+    const card = screen.getByTestId('debate-card-errors');
+    expect(await within(card).findByText('Could not load the MOV URL: URL unavailable')).toBeInTheDocument();
+    const webm = await within(card).findByLabelText('WebM processed video');
+    fireEvent.error(webm);
+    expect(within(card).getByText('WebM playback failed.')).toBeInTheDocument();
+  });
+
+  it('does not enable transcripts until expanded, then renders segments', () => {
+    mocks.listResult.data.debates = [debate('transcript')];
+    mocks.mediaByDebate.set('transcript', mediaResult('succeeded', {}, [], 1));
+    mocks.transcriptByDebate.set('transcript', {
+      data: {
+        segments: [
+          {
+            id: 'segment-1',
+            participant_slot: 2,
+            position: false,
+            position_label: 'Against',
+            sequence_index: 0,
+            start_ms: 1_250,
+            end_ms: 3_500,
+            text: 'This is the transcript.',
+            metadata: {},
+            created_at: '2026-07-01T00:00:00.000Z',
+          },
+        ],
+      },
+      isLoading: false,
+      error: null,
+    });
+
+    render(<DebugDebatesPageClient spaceId="space-1" />);
+
+    expect(mocks.transcriptCalls.every(call => call.enabled === false)).toBe(true);
+    fireEvent.click(screen.getByRole('button', { name: 'Show transcript (1 segment)' }));
+    expect(mocks.transcriptCalls.some(call => call.enabled)).toBe(true);
+    expect(screen.getByText('00:01.250–00:03.500')).toBeInTheDocument();
+    expect(screen.getByText('Slot 2 · Against')).toBeInTheDocument();
+    expect(screen.getByText('This is the transcript.')).toBeInTheDocument();
+  });
+
+  it.each([
+    [{ data: undefined, isLoading: true, error: null }, 'Loading transcript…'],
+    [{ data: { segments: [] }, isLoading: false, error: null }, 'No transcript segments found.'],
+    [{ data: undefined, isLoading: false, error: new Error('Transcript failed') }, 'Could not load transcript: Transcript failed'],
+  ])('renders the expanded transcript state %#', (result, message) => {
+    mocks.listResult.data.debates = [debate('transcript-state')];
+    mocks.mediaByDebate.set('transcript-state', mediaResult('succeeded', {}, [], 2));
+    mocks.transcriptByDebate.set('transcript-state', result);
+
+    render(<DebugDebatesPageClient spaceId="space-1" />);
+    fireEvent.click(screen.getByRole('button', { name: 'Show transcript (2 segments)' }));
+
+    expect(screen.getByText(message)).toBeInTheDocument();
+  });
+});
+
+function debate(id: string, createdAt = '2026-07-02T00:00:00.000Z'): Debate {
+  return {
+    id,
+    claim: { id: `claim-${id}`, space_id: 'space-1', claim_entity_id: `entity-${id}`, claim: `Claim ${id}`, description: null },
+    status: 'complete',
+    room_name: id,
+    first_participant_slot: 1,
+    current_turn_index: 1,
+    current_speaker_slot: null,
+    connecting_started_at: null,
+    connecting_deadline_at: null,
+    turn_started_at: null,
+    turn_ends_at: null,
+    preflight_ends_at: null,
+    turn_format_id: 'standard',
+    turn_durations_ms: [30_000],
+    created_at: createdAt,
+    started_at: null,
+    completed_at: null,
+    participants: [
+      {
+        user_id: 'user-1', profile_space_id: 'profile-1', display_name: 'Alex', avatar_cid: null,
+        participant_slot: 1, position: true, position_label: 'For', joined_at: null, ready_at: null,
+      },
+      {
+        user_id: 'user-2', profile_space_id: 'profile-2', display_name: null, avatar_cid: null,
+        participant_slot: 2, position: false, position_label: 'Against', joined_at: null, ready_at: null,
+      },
+    ],
+    recordings: [],
+    recording_error: null,
+    cancellation_reason: null,
+    recording_cancelled_at: null,
+    recording_cancelled_by: null,
+  };
+}
+
+function mediaResult(
+  status: DebateMediaJobStatus | null,
+  jobOverrides: Record<string, unknown> = {},
+  artifactKinds: DebateMediaArtifactKind[] = [],
+  transcriptSegmentCount = 0
+) {
+  const data: DebateMediaResponse = {
+    job: status
+      ? {
+          id: `job-${status}`,
+          status,
+          attempt_count: 1,
+          locked_at: null,
+          locked_by: null,
+          available_at: '2026-07-01T00:00:00.000Z',
+          last_error: null,
+          created_at: '2026-07-01T00:00:00.000Z',
+          updated_at: '2026-07-01T00:00:00.000Z',
+          completed_at: status === 'succeeded' ? '2026-07-01T00:01:00.000Z' : null,
+          ...jobOverrides,
+        }
+      : null,
+    artifacts: artifactKinds.map(kind => ({
+      id: `${kind}-id`, kind, filename: `${kind}.video`, content_type: 'video/test', byte_size: 1, metadata: {},
+      created_at: '2026-07-01T00:00:00.000Z',
+    })),
+    transcript_segment_count: transcriptSegmentCount,
+    layout: {
+      output_width: 1920,
+      output_height: 1080,
+      slot_1: { x: 0, y: 0, width: 900, height: 1080 },
+      subtitles: { x: 900, y: 0, width: 120, height: 1080 },
+      slot_2: { x: 1020, y: 0, width: 900, height: 1080 },
+    },
+    whisper_model_id: 'whisper-1',
+  };
+  return { data, isLoading: false, error: null };
+}

--- a/apps/web/app/space/[id]/(space)/debug-debates/debug-debates-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debug-debates/debug-debates-page-client.test.tsx
@@ -154,6 +154,10 @@ describe('DebugDebatesPageClient', () => {
       const card = screen.getByTestId(`debate-card-${id}`);
       expect(card).toHaveTextContent(`Processing: ${label}`);
       expect(card).toHaveTextContent('Lifecyclecomplete');
+
+      const lifecycleField = within(card).getByText('Lifecycle').parentElement;
+      const processingDetails = within(card).getByRole('region', { name: 'Processing details' });
+      expect(lifecycleField?.querySelector('dd')?.nextElementSibling).toContainElement(processingDetails);
     }
   });
 
@@ -184,8 +188,16 @@ describe('DebugDebatesPageClient', () => {
     render(<DebugDebatesPageClient spaceId="space-1" />);
 
     const both = screen.getByTestId('debate-card-both');
-    expect(await within(both).findByLabelText('WebM processed video')).toHaveAttribute('src', 'https://media.test/both.webm');
-    expect(within(both).getByLabelText('MOV processed video')).toHaveAttribute('src', 'https://media.test/both.mov');
+    const webm = await within(both).findByLabelText('WebM processed video');
+    expect(webm).toHaveAttribute('src', 'https://media.test/both.webm');
+
+    const mov = within(both).getByLabelText('MOV processed video');
+    expect(mov).toHaveAttribute('src', 'https://media.test/both.mov');
+
+    for (const video of [webm, mov]) {
+      expect(video).toHaveClass('aspect-[8/9]', 'w-1/4', 'bg-white', 'sm:aspect-video', 'sm:w-full');
+      expect(video).not.toHaveClass('bg-black');
+    }
     expect(within(both).getByRole('link', { name: 'Open WebM directly' })).toHaveAttribute(
       'href',
       'https://media.test/both.webm'

--- a/apps/web/app/space/[id]/(space)/debug-debates/debug-debates-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debug-debates/debug-debates-page-client.tsx
@@ -123,17 +123,25 @@ function DebateDiagnosticsCard({ debate }: { debate: Debate }) {
       className="flex scroll-mt-24 flex-col gap-5 rounded-xl border border-grey-02 bg-white p-4 shadow-light md:p-6"
     >
       <header className="flex flex-col gap-3">
-        <div className="flex flex-wrap items-start justify-between gap-3">
-          <Text as="h2" variant="smallTitle" className="max-w-3xl">
-            {debate.claim.claim}
-          </Text>
-          {!mediaQuery.isLoading && !mediaQuery.error && <ProcessingBadge status={status} />}
-        </div>
+        <Text as="h2" variant="smallTitle" className="max-w-3xl">
+          {debate.claim.claim}
+        </Text>
 
         <dl className="grid gap-x-6 gap-y-2 text-sm sm:grid-cols-2 lg:grid-cols-4">
           <DiagnosticField label="Debate ID" value={debate.id} code />
           <DiagnosticField label="Created" value={formatDate(debate.created_at)} />
-          <DiagnosticField label="Lifecycle" value={debate.status} />
+          <div className="min-w-0">
+            <dt className="text-grey-04">Lifecycle</dt>
+            <dd>{debate.status}</dd>
+            <dd className="mt-2">
+              <ProcessingDetails
+                isLoading={mediaQuery.isLoading}
+                error={mediaQuery.error}
+                media={media}
+                status={status}
+              />
+            </dd>
+          </div>
           <DiagnosticField
             label="Media job"
             value={mediaQuery.isLoading ? 'loading' : mediaQuery.error ? 'unavailable' : (media?.job?.status ?? 'none')}
@@ -156,22 +164,6 @@ function DebateDiagnosticsCard({ debate }: { debate: Debate }) {
           ))}
       </section>
 
-      <section aria-label="Processing details" className="flex flex-col gap-2">
-        {mediaQuery.isLoading && <StateMessage compact>Loading processing status…</StateMessage>}
-        {mediaQuery.error && (
-          <StateMessage compact tone="error">
-            Could not load media: {errorMessage(mediaQuery.error)}
-          </StateMessage>
-        )}
-        {media && (
-          <div className="flex flex-wrap gap-x-6 gap-y-1 text-sm">
-            <span>Processing: {status}</span>
-            <span>Attempts: {media.job?.attempt_count ?? 0}</span>
-            {media.job?.last_error && <span className="text-red-02">Latest error: {media.job.last_error}</span>}
-          </div>
-        )}
-      </section>
-
       {status === 'processed' && media && (
         <section aria-label="Processed videos" className="grid gap-4 lg:grid-cols-2">
           {renditions.map(rendition => (
@@ -187,6 +179,36 @@ function DebateDiagnosticsCard({ debate }: { debate: Debate }) {
 
       <TranscriptSection debateId={debate.id} segmentCount={media?.transcript_segment_count} />
     </article>
+  );
+}
+
+function ProcessingDetails({
+  isLoading,
+  error,
+  media,
+  status,
+}: {
+  isLoading: boolean;
+  error: Error | null;
+  media: DebateMediaResponse | undefined;
+  status: ProcessingStatus;
+}) {
+  return (
+    <section aria-label="Processing details" className="flex flex-col items-start gap-1">
+      {isLoading && <StateMessage compact>Loading processing status…</StateMessage>}
+      {error && (
+        <StateMessage compact tone="error">
+          Could not load media: {errorMessage(error)}
+        </StateMessage>
+      )}
+      {!isLoading && !error && <ProcessingBadge status={status} />}
+      {media && (
+        <div className="flex flex-col gap-1 text-sm">
+          <span>Attempts: {media.job?.attempt_count ?? 0}</span>
+          {media.job?.last_error && <span className="text-red-02">Latest error: {media.job.last_error}</span>}
+        </div>
+      )}
+    </section>
   );
 }
 
@@ -261,7 +283,7 @@ function ProcessedRendition({ debateId, rendition, available }: { debateId: stri
             playsInline
             preload="metadata"
             onError={() => setPlaybackError(true)}
-            className="aspect-video w-full rounded bg-black object-contain"
+            className="aspect-[8/9] w-1/4 rounded bg-white object-contain sm:aspect-video sm:w-full"
           />
           {playbackError && <StateMessage compact tone="error">{rendition.label} playback failed.</StateMessage>}
           <a

--- a/apps/web/app/space/[id]/(space)/debug-debates/debug-debates-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debug-debates/debug-debates-page-client.tsx
@@ -1,0 +1,374 @@
+'use client';
+
+import { useQueryClient } from '@tanstack/react-query';
+
+import * as React from 'react';
+
+import { useRouter } from 'next/navigation';
+
+import type {
+  Debate,
+  DebateMediaResponse,
+  DebateTranscriptSegment,
+} from '~/core/debates/api';
+import {
+  debateQueryKeys,
+  useDebateMedia,
+  useDebateMediaArtifactUrl,
+  useDebateTranscript,
+  useSpaceDebates,
+} from '~/core/debates/hooks';
+import { useDebugDebatesPageEnabled } from '~/core/state/feature-flags';
+
+import { Button } from '~/design-system/button';
+import { Text } from '~/design-system/text';
+
+type DebugDebatesPageClientProps = {
+  spaceId: string;
+};
+
+type Rendition = {
+  kind: 'final_video' | 'final_video_hevc';
+  label: 'WebM' | 'MOV';
+};
+
+type ProcessingStatus = 'not started' | 'processing' | 'processed' | 'failed';
+
+const renditions: Rendition[] = [
+  { kind: 'final_video', label: 'WebM' },
+  { kind: 'final_video_hevc', label: 'MOV' },
+];
+
+export function DebugDebatesPageClient({ spaceId }: DebugDebatesPageClientProps) {
+  const enabled = useDebugDebatesPageEnabled();
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const debatesQuery = useSpaceDebates(spaceId, enabled);
+
+  React.useEffect(() => {
+    if (!enabled) router.replace(`/space/${spaceId}`);
+  }, [enabled, router, spaceId]);
+
+  const debates = React.useMemo(
+    () => [...(debatesQuery.data?.debates ?? [])].sort((a, b) => Date.parse(b.created_at) - Date.parse(a.created_at)),
+    [debatesQuery.data?.debates]
+  );
+
+  const refresh = React.useCallback(async () => {
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: debateQueryKeys.spaceDebates(spaceId) }),
+      queryClient.invalidateQueries({ queryKey: ['debates', 'media'] }),
+    ]);
+  }, [queryClient, spaceId]);
+
+  if (!enabled) return null;
+
+  return (
+    <main className="mx-auto flex w-full max-w-[1200px] flex-col gap-6 px-4 py-8 md:px-8">
+      <header className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="flex max-w-3xl flex-col gap-2">
+          <Text as="h1" variant="largeTitle">
+            Debug debates
+          </Text>
+          <Text as="p" color="grey-04">
+            Processing diagnostics for at most the latest 50 completed debates, plus active or cancelled debates visible
+            to the signed-in participant.
+          </Text>
+        </div>
+        <Button type="button" variant="secondary" disabled={debatesQuery.isFetching} onClick={() => void refresh()}>
+          {debatesQuery.isFetching ? 'Refreshing…' : 'Refresh diagnostics'}
+        </Button>
+      </header>
+
+      {debatesQuery.isLoading && <StateMessage>Loading debate diagnostics…</StateMessage>}
+      {debatesQuery.error && (
+        <StateMessage tone="error">Could not load debates: {errorMessage(debatesQuery.error)}</StateMessage>
+      )}
+      {!debatesQuery.isLoading && !debatesQuery.error && debates.length === 0 && (
+        <StateMessage>No debates found for this space.</StateMessage>
+      )}
+
+      {debates.length > 0 && (
+        <div className="flex flex-col gap-5">
+          {debates.map(debate => (
+            <DebateDiagnosticsCard key={debate.id} debate={debate} />
+          ))}
+        </div>
+      )}
+    </main>
+  );
+}
+
+function DebateDiagnosticsCard({ debate }: { debate: Debate }) {
+  const mediaQuery = useDebateMedia(debate.id, true);
+  const media = mediaQuery.data;
+  const status = processingStatus(media);
+
+  return (
+    <article
+      data-debug-debate-card
+      data-testid={`debate-card-${debate.id}`}
+      id={`debate-${debate.id}`}
+      className="flex scroll-mt-24 flex-col gap-5 rounded-xl border border-grey-02 bg-white p-4 shadow-light md:p-6"
+    >
+      <header className="flex flex-col gap-3">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <Text as="h2" variant="smallTitle" className="max-w-3xl">
+            {debate.claim.claim}
+          </Text>
+          {!mediaQuery.isLoading && !mediaQuery.error && <ProcessingBadge status={status} />}
+        </div>
+
+        <dl className="grid gap-x-6 gap-y-2 text-sm sm:grid-cols-2 lg:grid-cols-4">
+          <DiagnosticField label="Debate ID" value={debate.id} code />
+          <DiagnosticField label="Created" value={formatDate(debate.created_at)} />
+          <DiagnosticField label="Lifecycle" value={debate.status} />
+          <DiagnosticField label="Media job" value={media?.job?.status ?? 'none'} />
+        </dl>
+      </header>
+
+      <section aria-label="Participants" className="grid gap-3 sm:grid-cols-2">
+        {[...debate.participants]
+          .sort((a, b) => a.participant_slot - b.participant_slot)
+          .map(participant => (
+            <div key={participant.user_id} className="rounded-lg bg-bg px-3 py-2">
+              <Text as="p" variant="bodySemibold">
+                Slot {participant.participant_slot}: {participant.display_name ?? 'Unnamed participant'}
+              </Text>
+              <Text as="p" variant="metadata" color="grey-04">
+                {participant.position_label} · user {participant.user_id} · profile {participant.profile_space_id}
+              </Text>
+            </div>
+          ))}
+      </section>
+
+      <section aria-label="Processing details" className="flex flex-col gap-2">
+        {mediaQuery.isLoading && <StateMessage compact>Loading processing status…</StateMessage>}
+        {mediaQuery.error && (
+          <StateMessage compact tone="error">
+            Could not load media: {errorMessage(mediaQuery.error)}
+          </StateMessage>
+        )}
+        {media && (
+          <div className="flex flex-wrap gap-x-6 gap-y-1 text-sm">
+            <span>Processing: {status}</span>
+            <span>Attempts: {media.job?.attempt_count ?? 0}</span>
+            {media.job?.last_error && <span className="text-red-02">Latest error: {media.job.last_error}</span>}
+          </div>
+        )}
+      </section>
+
+      {status === 'processed' && media && (
+        <section aria-label="Processed videos" className="grid gap-4 lg:grid-cols-2">
+          {renditions.map(rendition => (
+            <ProcessedRendition
+              key={rendition.kind}
+              debateId={debate.id}
+              rendition={rendition}
+              available={media.artifacts.some(artifact => artifact.kind === rendition.kind)}
+            />
+          ))}
+        </section>
+      )}
+
+      <TranscriptSection debateId={debate.id} segmentCount={media?.transcript_segment_count} />
+    </article>
+  );
+}
+
+const processingStatusColor: Record<ProcessingStatus, string> = {
+  'not started': 'bg-bg text-grey-04',
+  processing: 'bg-orange/15 text-orange',
+  processed: 'bg-green/15 text-green',
+  failed: 'bg-red-01/10 text-red-02',
+};
+
+function ProcessingBadge({ status }: { status: ProcessingStatus }) {
+  return (
+    <span className={`rounded-full px-2.5 py-1 text-sm font-medium ${processingStatusColor[status]}`}>
+      Processing: {status}
+    </span>
+  );
+}
+
+function ProcessedRendition({ debateId, rendition, available }: { debateId: string; rendition: Rendition; available: boolean }) {
+  const artifactUrl = useDebateMediaArtifactUrl();
+  const loadUrlRef = React.useRef(artifactUrl.mutate);
+  const [url, setUrl] = React.useState<string | null>(null);
+  const [loadError, setLoadError] = React.useState<string | null>(null);
+  const [playbackError, setPlaybackError] = React.useState(false);
+
+  React.useEffect(() => {
+    loadUrlRef.current = artifactUrl.mutate;
+  }, [artifactUrl.mutate]);
+
+  React.useEffect(() => {
+    let active = true;
+    setUrl(null);
+    setLoadError(null);
+    setPlaybackError(false);
+    if (!available) return;
+
+    loadUrlRef.current(
+      { debateId, request: { kind: rendition.kind } },
+      {
+        onSuccess: response => {
+          if (active) setUrl(response.upload.url);
+        },
+        onError: error => {
+          if (active) setLoadError(errorMessage(error));
+        },
+      }
+    );
+
+    return () => {
+      active = false;
+    };
+  }, [available, debateId, rendition.kind]);
+
+  return (
+    <div className="flex min-w-0 flex-col gap-2 rounded-lg border border-grey-02 p-3">
+      <Text as="h3" variant="bodySemibold">
+        {rendition.label}
+      </Text>
+      {!available && <StateMessage compact>{rendition.label} rendition is missing.</StateMessage>}
+      {available && !url && !loadError && <StateMessage compact>Loading {rendition.label} URL…</StateMessage>}
+      {loadError && (
+        <StateMessage compact tone="error">
+          Could not load the {rendition.label} URL: {loadError}
+        </StateMessage>
+      )}
+      {url && (
+        <>
+          <video
+            src={url}
+            aria-label={`${rendition.label} processed video`}
+            controls
+            playsInline
+            preload="metadata"
+            onError={() => setPlaybackError(true)}
+            className="aspect-video w-full rounded bg-black object-contain"
+          />
+          {playbackError && <StateMessage compact tone="error">{rendition.label} playback failed.</StateMessage>}
+          <a
+            href={url}
+            target="_blank"
+            rel="noreferrer"
+            className="w-fit text-sm font-medium text-ctaPrimary hover:underline"
+          >
+            Open {rendition.label} directly
+          </a>
+        </>
+      )}
+    </div>
+  );
+}
+
+function TranscriptSection({ debateId, segmentCount }: { debateId: string; segmentCount: number | undefined }) {
+  const [expanded, setExpanded] = React.useState(false);
+  const transcriptQuery = useDebateTranscript(debateId, 'json', expanded);
+  const label = segmentCount === undefined ? 'count unavailable' : `${segmentCount} ${segmentCount === 1 ? 'segment' : 'segments'}`;
+  const segments = transcriptQuery.data?.segments ?? [];
+
+  return (
+    <section aria-label="Transcript" className="flex flex-col gap-3 border-t border-grey-02 pt-4">
+      <button
+        type="button"
+        aria-expanded={expanded}
+        aria-label={expanded ? `Hide transcript (${label})` : `Show transcript (${label})`}
+        onClick={() => setExpanded(current => !current)}
+        className="flex w-full cursor-pointer items-center justify-between gap-3 text-left"
+      >
+        <Text as="span" variant="bodySemibold">
+          Transcript · {label}
+        </Text>
+        <Text as="span" variant="metadata" color="grey-04">
+          {expanded ? `Hide transcript (${label})` : `Show transcript (${label})`}
+        </Text>
+      </button>
+
+      {expanded && (
+        <div className="flex flex-col gap-3">
+          {transcriptQuery.isLoading && <StateMessage compact>Loading transcript…</StateMessage>}
+          {transcriptQuery.error && (
+            <StateMessage compact tone="error">
+              Could not load transcript: {errorMessage(transcriptQuery.error)}
+            </StateMessage>
+          )}
+          {!transcriptQuery.isLoading && !transcriptQuery.error && segments.length === 0 && (
+            <StateMessage compact>No transcript segments found.</StateMessage>
+          )}
+          {segments.map(segment => (
+            <TranscriptSegment key={segment.id} segment={segment} />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function TranscriptSegment({ segment }: { segment: DebateTranscriptSegment }) {
+  return (
+    <div className="grid gap-2 rounded-lg bg-bg p-3 sm:grid-cols-[150px_1fr]">
+      <div className="flex flex-col">
+        <Text as="span" variant="metadataMedium">
+          {formatTimestamp(segment.start_ms)}–{formatTimestamp(segment.end_ms)}
+        </Text>
+        <Text as="span" variant="metadata" color="grey-04">
+          Slot {segment.participant_slot} · {segment.position_label}
+        </Text>
+      </div>
+      <Text as="p">{segment.text}</Text>
+    </div>
+  );
+}
+
+function DiagnosticField({ label, value, code = false }: { label: string; value: string; code?: boolean }) {
+  return (
+    <div className="min-w-0">
+      <dt className="text-grey-04">{label}</dt>
+      <dd className={code ? 'truncate font-mono text-xs' : ''}>{value}</dd>
+    </div>
+  );
+}
+
+function StateMessage({
+  children,
+  tone = 'muted',
+  compact = false,
+}: {
+  children: React.ReactNode;
+  tone?: 'muted' | 'error';
+  compact?: boolean;
+}) {
+  return (
+    <p className={`${compact ? 'text-sm' : 'rounded-lg border border-grey-02 p-4'} ${tone === 'error' ? 'text-red-02' : 'text-grey-04'}`}>
+      {children}
+    </p>
+  );
+}
+
+function processingStatus(media: DebateMediaResponse | undefined): ProcessingStatus {
+  const status = media?.job?.status;
+  if (!status) return 'not started' as const;
+  if (status === 'queued' || status === 'running') return 'processing' as const;
+  if (status === 'succeeded') return 'processed' as const;
+  return 'failed' as const;
+}
+
+function errorMessage(error: unknown) {
+  return error instanceof Error ? error.message : 'Unknown error';
+}
+
+function formatDate(value: string) {
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? value : date.toISOString();
+}
+
+function formatTimestamp(milliseconds: number) {
+  const safeMilliseconds = Math.max(0, milliseconds);
+  const minutes = Math.floor(safeMilliseconds / 60_000);
+  const seconds = Math.floor((safeMilliseconds % 60_000) / 1_000);
+  const remainder = Math.floor(safeMilliseconds % 1_000);
+  return `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}.${String(remainder).padStart(3, '0')}`;
+}

--- a/apps/web/app/space/[id]/(space)/debug-debates/debug-debates-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debug-debates/debug-debates-page-client.tsx
@@ -44,6 +44,7 @@ export function DebugDebatesPageClient({ spaceId }: DebugDebatesPageClientProps)
   const router = useRouter();
   const queryClient = useQueryClient();
   const debatesQuery = useSpaceDebates(spaceId, enabled);
+  const [isRefreshing, setIsRefreshing] = React.useState(false);
 
   React.useEffect(() => {
     if (!enabled) router.replace(`/space/${spaceId}`);
@@ -55,10 +56,15 @@ export function DebugDebatesPageClient({ spaceId }: DebugDebatesPageClientProps)
   );
 
   const refresh = React.useCallback(async () => {
-    await Promise.all([
-      queryClient.invalidateQueries({ queryKey: debateQueryKeys.spaceDebates(spaceId) }),
-      queryClient.invalidateQueries({ queryKey: ['debates', 'media'] }),
-    ]);
+    setIsRefreshing(true);
+    try {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: debateQueryKeys.spaceDebates(spaceId) }),
+        queryClient.invalidateQueries({ queryKey: ['debates', 'media'] }),
+      ]);
+    } finally {
+      setIsRefreshing(false);
+    }
   }, [queryClient, spaceId]);
 
   if (!enabled) return null;
@@ -75,8 +81,13 @@ export function DebugDebatesPageClient({ spaceId }: DebugDebatesPageClientProps)
             to the signed-in participant.
           </Text>
         </div>
-        <Button type="button" variant="secondary" disabled={debatesQuery.isFetching} onClick={() => void refresh()}>
-          {debatesQuery.isFetching ? 'Refreshing…' : 'Refresh diagnostics'}
+        <Button
+          type="button"
+          variant="secondary"
+          disabled={debatesQuery.isFetching || isRefreshing}
+          onClick={() => void refresh()}
+        >
+          {debatesQuery.isFetching || isRefreshing ? 'Refreshing…' : 'Refresh diagnostics'}
         </Button>
       </header>
 
@@ -123,7 +134,10 @@ function DebateDiagnosticsCard({ debate }: { debate: Debate }) {
           <DiagnosticField label="Debate ID" value={debate.id} code />
           <DiagnosticField label="Created" value={formatDate(debate.created_at)} />
           <DiagnosticField label="Lifecycle" value={debate.status} />
-          <DiagnosticField label="Media job" value={media?.job?.status ?? 'none'} />
+          <DiagnosticField
+            label="Media job"
+            value={mediaQuery.isLoading ? 'loading' : mediaQuery.error ? 'unavailable' : (media?.job?.status ?? 'none')}
+          />
         </dl>
       </header>
 

--- a/apps/web/app/space/[id]/(space)/debug-debates/page.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debug-debates/page.test.tsx
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  isValid: vi.fn(),
+  notFound: vi.fn(() => {
+    throw new Error('not found');
+  }),
+}));
+
+vi.mock('@geoprotocol/geo-sdk/lite', () => ({
+  IdUtils: { isValid: mocks.isValid },
+}));
+
+vi.mock('next/navigation', () => ({ notFound: mocks.notFound }));
+
+vi.mock('./debug-debates-page-client', () => ({
+  DebugDebatesPageClient: ({ spaceId }: { spaceId: string }) => <div data-space-id={spaceId} />,
+}));
+
+import DebugDebatesPage from './page';
+
+describe('DebugDebatesPage', () => {
+  it('rejects an invalid space ID', async () => {
+    mocks.isValid.mockReturnValue(false);
+
+    await expect(DebugDebatesPage({ params: Promise.resolve({ id: 'invalid' }) })).rejects.toThrow('not found');
+    expect(mocks.notFound).toHaveBeenCalled();
+  });
+
+  it('passes a valid space ID to the client page', async () => {
+    mocks.isValid.mockReturnValue(true);
+
+    const result = await DebugDebatesPage({ params: Promise.resolve({ id: 'valid-space-id' }) });
+
+    expect(result.props.spaceId).toBe('valid-space-id');
+  });
+});

--- a/apps/web/app/space/[id]/(space)/debug-debates/page.tsx
+++ b/apps/web/app/space/[id]/(space)/debug-debates/page.tsx
@@ -1,0 +1,17 @@
+import { IdUtils } from '@geoprotocol/geo-sdk/lite';
+
+import { notFound } from 'next/navigation';
+
+import { DebugDebatesPageClient } from './debug-debates-page-client';
+
+interface Props {
+  params: Promise<{ id: string }>;
+}
+
+export default async function DebugDebatesPage({ params }: Props) {
+  const { id } = await params;
+
+  if (!IdUtils.isValid(id)) notFound();
+
+  return <DebugDebatesPageClient spaceId={id} />;
+}

--- a/apps/web/core/state/feature-flags.test.ts
+++ b/apps/web/core/state/feature-flags.test.ts
@@ -16,10 +16,12 @@ describe('feature flags', () => {
 
   it('defaults local feature flags to disabled', () => {
     expect(defaultFeatureFlags.questionsTab).toBe(false);
+    expect(defaultFeatureFlags.debugDebatesPage).toBe(false);
     expect(defaultFeatureFlags.debateDebugging).toBe(false);
     expect(defaultFeatureFlags.debateFormatSelector).toBe(false);
     expect(normalizeFeatureFlags(null)).toEqual({
       questionsTab: false,
+      debugDebatesPage: false,
       debateDebugging: false,
       debateFormatSelector: false,
     });
@@ -28,11 +30,13 @@ describe('feature flags', () => {
   it('maps the legacy Debates flag into the combined flag', () => {
     expect(normalizeFeatureFlags({ debatesTab: true })).toEqual({
       questionsTab: true,
+      debugDebatesPage: false,
       debateDebugging: false,
       debateFormatSelector: false,
     });
     expect(normalizeFeatureFlags({ questionsTab: true, debatesTab: false })).toEqual({
       questionsTab: true,
+      debugDebatesPage: false,
       debateDebugging: false,
       debateFormatSelector: false,
     });
@@ -43,15 +47,22 @@ describe('feature flags', () => {
 
     store.set(featureFlagsAtom, currentFlags => {
       const flags = setFeatureFlagValue(normalizeFeatureFlags(currentFlags), 'questionsTab', true);
-      const debuggingFlags = setFeatureFlagValue(flags, 'debateDebugging', true);
+      const debugPageFlags = setFeatureFlagValue(flags, 'debugDebatesPage', true);
+      const debuggingFlags = setFeatureFlagValue(debugPageFlags, 'debateDebugging', true);
       return setFeatureFlagValue(debuggingFlags, 'debateFormatSelector', true);
     });
 
     expect(store.get(featureFlagsAtom).questionsTab).toBe(true);
+    expect(store.get(featureFlagsAtom).debugDebatesPage).toBe(true);
     expect(store.get(featureFlagsAtom).debateDebugging).toBe(true);
     expect(store.get(featureFlagsAtom).debateFormatSelector).toBe(true);
     expect(window.localStorage.getItem(featureFlagsStorageKey)).toBe(
-      JSON.stringify({ questionsTab: true, debateDebugging: true, debateFormatSelector: true })
+      JSON.stringify({
+        questionsTab: true,
+        debugDebatesPage: true,
+        debateDebugging: true,
+        debateFormatSelector: true,
+      })
     );
   });
 });

--- a/apps/web/core/state/feature-flags.ts
+++ b/apps/web/core/state/feature-flags.ts
@@ -12,11 +12,6 @@ export const featureFlagDefinitions = [
     description: 'Show the Claims and Debates tabs on spaces.',
   },
   {
-    id: 'debugDebatesPage',
-    label: 'Debug debates',
-    description: 'Enable per-space debate processing diagnostics.',
-  },
-  {
     id: 'debateDebugging',
     label: 'Debate debugging',
     description: 'Show manual debugging controls during debate recording.',
@@ -25,6 +20,11 @@ export const featureFlagDefinitions = [
     id: 'debateFormatSelector',
     label: 'Debate format selector',
     description: 'Allow the first matched debater to choose a format before accepting.',
+  },
+  {
+    id: 'debugDebatesPage',
+    label: 'Debates debug tab per space',
+    description: 'Enable per-space debate processing diagnostics.',
   },
 ] as const;
 

--- a/apps/web/core/state/feature-flags.ts
+++ b/apps/web/core/state/feature-flags.ts
@@ -12,6 +12,11 @@ export const featureFlagDefinitions = [
     description: 'Show the Claims and Debates tabs on spaces.',
   },
   {
+    id: 'debugDebatesPage',
+    label: 'Debug debates',
+    description: 'Enable per-space debate processing diagnostics.',
+  },
+  {
     id: 'debateDebugging',
     label: 'Debate debugging',
     description: 'Show manual debugging controls during debate recording.',
@@ -29,6 +34,7 @@ type StoredFeatureFlags = Partial<Record<FeatureFlagId | 'debatesTab', boolean>>
 
 export const defaultFeatureFlags: FeatureFlags = {
   questionsTab: false,
+  debugDebatesPage: false,
   debateDebugging: false,
   debateFormatSelector: false,
 };
@@ -36,6 +42,7 @@ export const defaultFeatureFlags: FeatureFlags = {
 export function normalizeFeatureFlags(flags: StoredFeatureFlags | null | undefined): FeatureFlags {
   return {
     questionsTab: flags?.questionsTab ?? flags?.debatesTab ?? defaultFeatureFlags.questionsTab,
+    debugDebatesPage: flags?.debugDebatesPage ?? defaultFeatureFlags.debugDebatesPage,
     debateDebugging: flags?.debateDebugging ?? defaultFeatureFlags.debateDebugging,
     debateFormatSelector: flags?.debateFormatSelector ?? defaultFeatureFlags.debateFormatSelector,
   };
@@ -65,6 +72,10 @@ export function useFeatureFlag(id: FeatureFlagId) {
  */
 export function useDebatesEnabled() {
   return useFeatureFlag('questionsTab');
+}
+
+export function useDebugDebatesPageEnabled() {
+  return useFeatureFlag('debugDebatesPage');
 }
 
 export function useFeatureFlags() {

--- a/apps/web/partials/feature-flags/feature-flags-dialog.test.tsx
+++ b/apps/web/partials/feature-flags/feature-flags-dialog.test.tsx
@@ -36,16 +36,23 @@ describe('FeatureFlagsDialog', () => {
     fireEvent.keyDown(window, { key: 'f', ctrlKey: true, shiftKey: true });
 
     expect(await screen.findByRole('heading', { name: 'Feature flags' })).toBeTruthy();
+    expect(screen.getByText('Debug debates')).toBeTruthy();
     expect(screen.getByText('Debate debugging')).toBeTruthy();
     expect(screen.getByText('Debate format selector')).toBeTruthy();
 
     fireEvent.click(screen.getByRole('button', { name: 'Claims and debates' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Debug debates' }));
     fireEvent.click(screen.getByRole('button', { name: 'Debate debugging' }));
     fireEvent.click(screen.getByRole('button', { name: 'Debate format selector' }));
 
     await waitFor(() => {
       expect(window.localStorage.getItem(featureFlagsStorageKey)).toBe(
-        JSON.stringify({ questionsTab: true, debateDebugging: true, debateFormatSelector: true })
+        JSON.stringify({
+          questionsTab: true,
+          debugDebatesPage: true,
+          debateDebugging: true,
+          debateFormatSelector: true,
+        })
       );
     });
   });

--- a/apps/web/partials/feature-flags/feature-flags-dialog.test.tsx
+++ b/apps/web/partials/feature-flags/feature-flags-dialog.test.tsx
@@ -36,14 +36,24 @@ describe('FeatureFlagsDialog', () => {
     fireEvent.keyDown(window, { key: 'f', ctrlKey: true, shiftKey: true });
 
     expect(await screen.findByRole('heading', { name: 'Feature flags' })).toBeTruthy();
-    expect(screen.getByText('Debug debates')).toBeTruthy();
     expect(screen.getByText('Debate debugging')).toBeTruthy();
     expect(screen.getByText('Debate format selector')).toBeTruthy();
+    expect(screen.getByText('Debates debug tab per space')).toBeTruthy();
+
+    const featureFlagButtons = screen
+      .getAllByRole('button')
+      .filter(button => button.getAttribute('aria-label') !== 'Close feature flags');
+    expect(featureFlagButtons.map(button => button.getAttribute('aria-label'))).toEqual([
+      'Claims and debates',
+      'Debate debugging',
+      'Debate format selector',
+      'Debates debug tab per space',
+    ]);
 
     fireEvent.click(screen.getByRole('button', { name: 'Claims and debates' }));
-    fireEvent.click(screen.getByRole('button', { name: 'Debug debates' }));
     fireEvent.click(screen.getByRole('button', { name: 'Debate debugging' }));
     fireEvent.click(screen.getByRole('button', { name: 'Debate format selector' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Debates debug tab per space' }));
 
     await waitFor(() => {
       expect(window.localStorage.getItem(featureFlagsStorageKey)).toBe(

--- a/apps/web/partials/space-page/space-tabs.test.ts
+++ b/apps/web/partials/space-page/space-tabs.test.ts
@@ -19,6 +19,7 @@ describe('buildSpaceTabs', () => {
       dynamicTabs,
       typeIds: [SystemIds.SPACE_TYPE],
       isDebatesEnabled: false,
+      isDebugDebatesPageEnabled: false,
     });
 
     expect(tabs.map(tab => tab.label)).toEqual(['Overview', 'Facts', 'Sources', 'Governance', 'Activity']);
@@ -31,6 +32,7 @@ describe('buildSpaceTabs', () => {
       dynamicTabs,
       typeIds: [SystemIds.SPACE_TYPE],
       isDebatesEnabled: true,
+      isDebugDebatesPageEnabled: false,
     });
 
     expect(tabs.map(tab => tab.label)).toEqual([
@@ -53,6 +55,7 @@ describe('buildSpaceTabs', () => {
       dynamicTabs,
       typeIds: [SystemIds.SPACE_TYPE, SystemIds.PERSON_TYPE],
       isDebatesEnabled: true,
+      isDebugDebatesPageEnabled: false,
     });
 
     expect(tabs.map(tab => tab.label)).toEqual(['Overview', 'Facts', 'Sources', 'Claims', 'Debates', 'Activity']);
@@ -65,6 +68,7 @@ describe('buildSpaceTabs', () => {
       dynamicTabs: [...dynamicTabs, { label: 'Claims', href: `${overviewHref}?tabId=dynamic-claims` }],
       typeIds: [SystemIds.SPACE_TYPE],
       isDebatesEnabled: true,
+      isDebugDebatesPageEnabled: false,
     });
 
     expect(tabs.map(tab => tab.label)).toEqual([
@@ -86,6 +90,7 @@ describe('buildSpaceTabs', () => {
       dynamicTabs: [...dynamicTabs, { label: 'Debates', href: `${overviewHref}?tabId=dynamic-debates` }],
       typeIds: [SystemIds.SPACE_TYPE],
       isDebatesEnabled: true,
+      isDebugDebatesPageEnabled: false,
     });
 
     expect(tabs.map(tab => tab.label)).toEqual([
@@ -98,5 +103,76 @@ describe('buildSpaceTabs', () => {
       'Activity',
     ]);
     expect(tabs.find(tab => tab.label === 'Debates')?.href).toBe(`/space/${spaceId}/debates`);
+  });
+
+  it('inserts Debug debates after authored tabs when only its flag is enabled', () => {
+    const tabs = buildSpaceTabs({
+      spaceId,
+      overviewHref,
+      dynamicTabs,
+      typeIds: [SystemIds.SPACE_TYPE],
+      isDebatesEnabled: false,
+      isDebugDebatesPageEnabled: true,
+    });
+
+    expect(tabs.map(tab => tab.label)).toEqual([
+      'Overview',
+      'Facts',
+      'Sources',
+      'Debug debates',
+      'Governance',
+      'Activity',
+    ]);
+    expect(tabs.find(tab => tab.label === 'Debug debates')?.href).toBe(`/space/${spaceId}/debug-debates`);
+  });
+
+  it('inserts Debug debates after Debates when both flags are enabled', () => {
+    const tabs = buildSpaceTabs({
+      spaceId,
+      overviewHref,
+      dynamicTabs,
+      typeIds: [SystemIds.SPACE_TYPE],
+      isDebatesEnabled: true,
+      isDebugDebatesPageEnabled: true,
+    });
+
+    expect(tabs.map(tab => tab.label)).toEqual([
+      'Overview',
+      'Facts',
+      'Sources',
+      'Claims',
+      'Debates',
+      'Debug debates',
+      'Governance',
+      'Activity',
+    ]);
+  });
+
+  it('shows Debug debates in personal spaces without Governance', () => {
+    const tabs = buildSpaceTabs({
+      spaceId,
+      overviewHref,
+      dynamicTabs,
+      typeIds: [SystemIds.SPACE_TYPE, SystemIds.PERSON_TYPE],
+      isDebatesEnabled: false,
+      isDebugDebatesPageEnabled: true,
+    });
+
+    expect(tabs.map(tab => tab.label)).toEqual(['Overview', 'Facts', 'Sources', 'Debug debates', 'Activity']);
+  });
+
+  it('keeps the system Debug debates route when an authored tab has the same label', () => {
+    const tabs = buildSpaceTabs({
+      spaceId,
+      overviewHref,
+      dynamicTabs: [...dynamicTabs, { label: 'Debug debates', href: `${overviewHref}?tabId=debug-debates` }],
+      typeIds: [SystemIds.SPACE_TYPE],
+      isDebatesEnabled: false,
+      isDebugDebatesPageEnabled: true,
+    });
+
+    expect(tabs.filter(tab => tab.label === 'Debug debates')).toEqual([
+      { label: 'Debug debates', href: `/space/${spaceId}/debug-debates`, priority: 3 },
+    ]);
   });
 });

--- a/apps/web/partials/space-page/space-tabs.tsx
+++ b/apps/web/partials/space-page/space-tabs.tsx
@@ -5,7 +5,7 @@ import { SystemIds } from '@geoprotocol/geo-sdk/lite';
 import * as React from 'react';
 
 import { useEditable } from '~/core/state/editable-store';
-import { useDebatesEnabled } from '~/core/state/feature-flags';
+import { useDebatesEnabled, useDebugDebatesPageEnabled } from '~/core/state/feature-flags';
 import { useRelations, useValues } from '~/core/sync/use-store';
 import { TabEntity } from '~/core/types';
 import { Relation } from '~/core/types';
@@ -35,6 +35,7 @@ type BuildSpaceTabsParams = {
   dynamicTabs: Array<{ label: string; href: string }>;
   typeIds: string[];
   isDebatesEnabled: boolean;
+  isDebugDebatesPageEnabled: boolean;
 };
 
 export function buildSpaceTabs({
@@ -43,6 +44,7 @@ export function buildSpaceTabs({
   dynamicTabs,
   typeIds,
   isDebatesEnabled,
+  isDebugDebatesPageEnabled,
 }: BuildSpaceTabsParams): BuiltSpaceTab[] {
   const tabs: BuiltSpaceTab[] = [];
 
@@ -66,6 +68,12 @@ export function buildSpaceTabs({
     priority: 3,
   };
 
+  const DEBUG_DEBATES_TAB: BuiltSpaceTab = {
+    label: 'Debug debates',
+    href: `/space/${spaceId}/debug-debates`,
+    priority: 3,
+  };
+
   const SOME_SPACES_TABS: BuiltSpaceTab[] = [
     {
       label: 'Governance',
@@ -84,7 +92,10 @@ export function buildSpaceTabs({
 
   if (typeIds.includes(SystemIds.SPACE_TYPE)) {
     if (dynamicTabs.length > 0) {
-      const reservedLabels = new Set(isDebatesEnabled ? [QUESTION_TAB.label, DEBATE_TAB.label] : []);
+      const reservedLabels = new Set([
+        ...(isDebatesEnabled ? [QUESTION_TAB.label, DEBATE_TAB.label] : []),
+        ...(isDebugDebatesPageEnabled ? [DEBUG_DEBATES_TAB.label] : []),
+      ]);
       const visibleDynamicTabs =
         reservedLabels.size > 0 ? dynamicTabs.filter(tab => !reservedLabels.has(tab.label)) : dynamicTabs;
 
@@ -96,6 +107,8 @@ export function buildSpaceTabs({
     tabs.push(QUESTION_TAB);
     tabs.push(DEBATE_TAB);
   }
+
+  if (isDebugDebatesPageEnabled) tabs.push(DEBUG_DEBATES_TAB);
 
   if (typeIds.includes(SystemIds.SPACE_TYPE) && !typeIds.includes(SystemIds.PERSON_TYPE)) {
     tabs.push(...SOME_SPACES_TABS);
@@ -117,6 +130,7 @@ export function buildSpaceTabs({
 export function SpaceTabs({ spaceId, entityId, initialTabRelations, tabEntities, typeIds }: SpaceTabsProps) {
   const { editable } = useEditable();
   const isDebatesEnabled = useDebatesEnabled();
+  const isDebugDebatesPageEnabled = useDebugDebatesPageEnabled();
 
   // Merge local tab relation changes with server data
   const mergedTabRelations = useRelations({
@@ -167,6 +181,10 @@ export function SpaceTabs({ spaceId, entityId, initialTabRelations, tabEntities,
     systemTabsAfter.push({ label: 'Debates', href: `/space/${spaceId}/debates` });
   }
 
+  if (isDebugDebatesPageEnabled) {
+    systemTabsAfter.push({ label: 'Debug debates', href: `/space/${spaceId}/debug-debates` });
+  }
+
   if (showCommunity) systemTabsAfter.push({ label: 'Governance', href: `/space/${spaceId}/governance` });
 
   systemTabsAfter.push({ label: 'Activity', href: `/space/${spaceId}/activity` });
@@ -197,7 +215,14 @@ export function SpaceTabs({ spaceId, entityId, initialTabRelations, tabEntities,
     href: `${overviewHref}?tabId=${entity.id}`,
   }));
 
-  const baseTabs = buildSpaceTabs({ spaceId, overviewHref, dynamicTabs, typeIds, isDebatesEnabled });
+  const baseTabs = buildSpaceTabs({
+    spaceId,
+    overviewHref,
+    dynamicTabs,
+    typeIds,
+    isDebatesEnabled,
+    isDebugDebatesPageEnabled,
+  });
 
   const tabs = showCommunity
     ? [


### PR DESCRIPTION
## Summary

Spaces can now expose an opt-in debate diagnostics page at `/space/:spaceId/debug-debates` without any geo-chat changes. The page makes debate lifecycle, media-processing status, WebM/MOV outputs, and lazy-loaded transcripts inspectable in one place, ordered newest first.

The independent local “Debug debates” feature flag controls both direct-route access and the space tab. The tab remains available independently of Claims and Debates and cannot be replaced by an authored tab with the same label.

## Validation

- Full web suite: 159 test files and 1,624 tests passed.
- Focused feature coverage: 31 tests passed across routing, flags, tabs, processing states, media renditions, refresh, and transcripts.
- TypeScript: `tsc --noEmit` passed.
- ESLint: 0 errors; 81 pre-existing warnings outside this change.
- Production build: the repository's Turbopack build remained at “Creating an optimized production build” with no further output in both full and route-targeted attempts. The supported Webpack fallback cannot run because `turbopackRustReactCompiler` is enabled.
- Browser smoke testing: not completed because the existing local dev server was not reachable from the in-app browser sandbox.

## Post-Deploy Monitoring & Validation

- Owner/window: deploying engineer for 30 minutes after enabling the flag.
- Check application logs for failures on space debate list, debate media, artifact URL, and transcript requests while loading and expanding several debate cards.
- Healthy signal: the diagnostics page loads newest-first, media statuses settle, available WebM/MOV players receive presigned URLs, and transcript expansion returns segments or explicit empty states.
- Failure signal: elevated 4xx/5xx responses, repeated artifact URL failures, client render errors, or excessive request fan-out. Disable the local feature flag immediately; revert this PR if failures reproduce across spaces.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)

https://linear.app/geobrowser/issue/GEO-2413/add-a-debates-debug-page