### PR TITLE
fix(debates): remove inactive speaker mute icon

### DIFF
--- a/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
@@ -1153,6 +1153,7 @@ describe('DebateRoomPageClient', () => {
     expect(screen.queryByText(/has the floor/i)).not.toBeInTheDocument();
     expect(document.querySelector('[data-inactive-speaker="local"]')).toHaveAttribute('data-visible', 'false');
     expect(document.querySelector('[data-inactive-speaker="remote"]')).toHaveAttribute('data-visible', 'true');
+    expect(document.querySelector('[data-inactive-speaker="remote"]')).toHaveClass('bg-black/45');
     expect(document.querySelector('[data-muted-indicator="true"]')).not.toBeInTheDocument();
     expectDebateVideoTileInColor('local');
     expectDebateVideoTileInColor('remote');

--- a/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
@@ -1153,9 +1153,7 @@ describe('DebateRoomPageClient', () => {
     expect(screen.queryByText(/has the floor/i)).not.toBeInTheDocument();
     expect(document.querySelector('[data-inactive-speaker="local"]')).toHaveAttribute('data-visible', 'false');
     expect(document.querySelector('[data-inactive-speaker="remote"]')).toHaveAttribute('data-visible', 'true');
-    expect(
-      document.querySelector('[data-inactive-speaker="remote"] [data-muted-indicator="true"]')
-    ).toBeInTheDocument();
+    expect(document.querySelector('[data-muted-indicator="true"]')).not.toBeInTheDocument();
     expectDebateVideoTileInColor('local');
     expectDebateVideoTileInColor('remote');
   });
@@ -1187,7 +1185,7 @@ describe('DebateRoomPageClient', () => {
     expect(tiles[1]?.querySelector('[data-inactive-speaker]')).toHaveAttribute('data-inactive-speaker', 'local');
     expect(document.querySelector('[data-inactive-speaker="local"]')).toHaveAttribute('data-visible', 'true');
     expect(document.querySelector('[data-inactive-speaker="local"]')).toHaveClass('bg-black/45');
-    expect(document.querySelector('[data-inactive-speaker="local"] [data-muted-indicator="true"]')).toBeInTheDocument();
+    expect(document.querySelector('[data-muted-indicator="true"]')).not.toBeInTheDocument();
     expectDebateVideoTileInColor('local');
     expectDebateVideoTileInColor('remote');
   });

--- a/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.tsx
@@ -20,7 +20,6 @@ import {
   CameraIcon,
   LeaveIcon,
   MicrophoneIcon,
-  MutedMicrophoneIndicator,
   RecordingCircleButton,
   SpeakerIcon,
 } from '~/core/debates/debate-room-controls';
@@ -1875,9 +1874,7 @@ function DebateVideoTile({
           'pointer-events-none absolute inset-0 z-10 grid place-items-center bg-black/45 transition-opacity duration-700 ease-out',
           inactive && !revealInactive ? 'opacity-100' : 'opacity-0'
         )}
-      >
-        <MutedMicrophoneIndicator />
-      </div>
+      />
       {countdown && <div className="pointer-events-none absolute top-3 right-3 z-20">{countdown}</div>}
 
       {closingMessage && (

--- a/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.tsx
@@ -1871,7 +1871,7 @@ function DebateVideoTile({
         data-inactive-speaker={inactiveOverlayId}
         data-visible={inactive && !revealInactive ? 'true' : 'false'}
         className={cx(
-          'pointer-events-none absolute inset-0 z-10 grid place-items-center bg-black/45 transition-opacity duration-700 ease-out',
+          'pointer-events-none absolute inset-0 z-10 bg-black/45 transition-opacity duration-700 ease-out',
           inactive && !revealInactive ? 'opacity-100' : 'opacity-0'
         )}
       />

--- a/apps/web/core/debates/debate-room-controls.tsx
+++ b/apps/web/core/debates/debate-room-controls.tsx
@@ -69,30 +69,6 @@ export function MicrophoneIcon({ muted }: { muted: boolean }) {
   );
 }
 
-export function MutedMicrophoneIndicator() {
-  return (
-    <svg
-      width="45"
-      height="45"
-      viewBox="0 0 45 45"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
-      aria-hidden="true"
-      data-muted-indicator="true"
-      className="size-[45px]"
-    >
-      <rect width="45" height="44.9989" rx="22.4994" fill="white" />
-      <rect x="17.6431" y="12.2852" width="9.71429" height="17.75" rx="4.85714" stroke="#151515" />
-      <path
-        d="M14.4644 24.1055V25.1769C14.4644 29.6149 18.0621 33.2126 22.5001 33.2126C26.9381 33.2126 30.5358 29.6149 30.5358 25.1769V24.1055"
-        stroke="#151515"
-        strokeLinecap="round"
-      />
-      <path d="M27.3216 16.6094L17.6787 25.7165" stroke="#151515" />
-    </svg>
-  );
-}
-
 export function CameraIcon({ disabled }: { disabled: boolean }) {
   return (
     <svg viewBox="0 0 24 24" aria-hidden="true" className="size-4" fill="none" stroke="currentColor" strokeWidth="2">


### PR DESCRIPTION
## Summary

During debate recording, the participant without the current turn was covered by a muted-microphone icon even though the UI was indicating speaking order rather than actual microphone state. Inactive tiles now retain their dimmed treatment without implying the participant manually muted; active-speaker transitions, recording, and microphone controls are unchanged.

## Validation

- Focused debate-room suite: 96 tests passed
- ESLint passed for the three changed files
- Full web TypeScript check passed
- Correctness and test-quality review completed with no findings

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: this is a presentational removal covered by recording-state regression tests and does not change runtime state, APIs, or persistence.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)

https://linear.app/geobrowser/issue/GEO-2446/improvement-muted-icon-location
