### PR TITLE
fix(debates): clarify pre-join readiness action

### DIFF
--- a/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
@@ -343,7 +343,7 @@ describe('DebateRoomPageClient', () => {
     expect(screen.getByText('Debate')).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'The protocol should ship debates' })).toBeInTheDocument();
     expect(screen.getByText('Bri')).toBeInTheDocument();
-    expect(await screen.findByRole('button', { name: 'Accept' })).toBeInTheDocument();
+    expect(await screen.findByRole('button', { name: "I'm ready" })).toBeInTheDocument();
     expect(screen.getByText('Waiting...')).toBeInTheDocument();
     expect(screen.queryByText('Not ready')).not.toBeInTheDocument();
     expect(screen.queryByText('VS')).not.toBeInTheDocument();
@@ -372,11 +372,11 @@ describe('DebateRoomPageClient', () => {
       })
     );
     expect(screen.getByText('Requesting access to your camera and microphone…')).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: 'Accept' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: "I'm ready" })).not.toBeInTheDocument();
 
     pendingTracks.resolve([createLocalAudioTrack(), { mediaStreamTrack: { kind: 'video' }, stop: vi.fn() }]);
 
-    expect(await screen.findByRole('button', { name: 'Accept' })).toBeEnabled();
+    expect(await screen.findByRole('button', { name: "I'm ready" })).toBeEnabled();
   });
 
   it('locks background scrolling while the pre-screen modal is open', () => {
@@ -441,12 +441,12 @@ describe('DebateRoomPageClient', () => {
     render(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
 
     expect(await screen.findByText('Allow access to your camera and microphone to continue.')).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: 'Accept' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: "I'm ready" })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Audio settings' })).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'Allow access' }));
 
-    expect(await screen.findByRole('button', { name: 'Accept' })).toBeEnabled();
+    expect(await screen.findByRole('button', { name: "I'm ready" })).toBeEnabled();
     expect(mocks.createLocalTracks).toHaveBeenCalledTimes(2);
   });
 
@@ -458,7 +458,7 @@ describe('DebateRoomPageClient', () => {
 
     expect(await screen.findByText('Connect a camera and microphone, then try again.')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Try again' })).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: 'Accept' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: "I'm ready" })).not.toBeInTheDocument();
   });
 
   it('cleans up acquired tracks when device enumeration fails', async () => {
@@ -479,7 +479,7 @@ describe('DebateRoomPageClient', () => {
     ).toBeInTheDocument();
     expect(audioTrack.stop).toHaveBeenCalled();
     expect(videoTrack.stop).toHaveBeenCalled();
-    expect(screen.queryByRole('button', { name: 'Accept' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: "I'm ready" })).not.toBeInTheDocument();
   });
 
   it('changes speaker output without restarting capture and hands the selection to LiveKit', async () => {
@@ -534,7 +534,7 @@ describe('DebateRoomPageClient', () => {
     expect(screen.getByRole('radio', { name: 'System default' })).toBeChecked();
     expect(screen.getByRole('radio', { name: 'System default' })).toBeDisabled();
     expect(screen.queryByRole('radio', { name: 'Studio Speakers' })).not.toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Accept' })).toBeEnabled();
+    expect(screen.getByRole('button', { name: "I'm ready" })).toBeEnabled();
   });
 
   it('falls back to System default when speaker authorization is rejected', async () => {
@@ -671,11 +671,11 @@ describe('DebateRoomPageClient', () => {
     fireEvent.click(screen.getByRole('radio', { name: 'Studio Mic' }));
 
     expect(screen.getByRole('dialog', { name: 'Audio settings' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Accept' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: "I'm ready" })).toBeDisabled();
 
     pendingTracks.resolve([createLocalAudioTrack(), { mediaStreamTrack: { kind: 'video' }, stop: vi.fn() }]);
     await waitFor(() => expect(screen.getByRole('radio', { name: 'Studio Mic' })).toBeChecked());
-    expect(screen.getByRole('button', { name: 'Accept' })).toBeEnabled();
+    expect(screen.getByRole('button', { name: "I'm ready" })).toBeEnabled();
   });
 
   it('opens mobile video settings as a bottom sheet using the existing preview stream', async () => {
@@ -757,7 +757,7 @@ describe('DebateRoomPageClient', () => {
     mocks.debate = readyDebate({ localReady: false, remoteReady: false });
 
     render(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
-    await screen.findByRole('button', { name: 'Accept' });
+    await screen.findByRole('button', { name: "I'm ready" });
     const olderEnumeration = deferred<MediaDeviceInfo[]>();
     mocks.enumerateDevices.mockReturnValueOnce(olderEnumeration.promise).mockResolvedValueOnce([
       { kind: 'audioinput', deviceId: 'mic-2', groupId: 'mic-group-2', label: 'Studio Mic' },
@@ -794,7 +794,7 @@ describe('DebateRoomPageClient', () => {
 
     expect(screen.getByText('Bri')).toBeInTheDocument();
     expect(screen.getByText('Ready')).toBeInTheDocument();
-    expect(await screen.findByRole('button', { name: 'Accept' })).toBeEnabled();
+    expect(await screen.findByRole('button', { name: "I'm ready" })).toBeEnabled();
   });
 
   it('disables the ready button while waiting for the opponent', async () => {
@@ -811,7 +811,7 @@ describe('DebateRoomPageClient', () => {
 
     render(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
 
-    fireEvent.click(await screen.findByRole('button', { name: 'Accept' }));
+    fireEvent.click(await screen.findByRole('button', { name: "I'm ready" }));
 
     await waitFor(() => {
       expect(mocks.readyMutateAsync).toHaveBeenCalled();

--- a/apps/web/core/debates/debate-pre-join-screen.tsx
+++ b/apps/web/core/debates/debate-pre-join-screen.tsx
@@ -221,7 +221,7 @@ export function DebatePreScreen({
             disabled={readyBusy || localReady || previewBusy}
             className="mt-3 flex min-h-11 w-full max-w-[272px] items-center justify-center rounded-full bg-text px-5 text-button text-white transition-colors hover:bg-text/90 disabled:opacity-50"
           >
-            {localReady ? 'Waiting...' : readyBusy ? 'Saving...' : 'Accept'}
+            {localReady ? 'Waiting...' : readyBusy ? 'Saving...' : "I'm ready"}
           </button>
         )}
 

--- a/apps/web/core/debates/match-prompt.test.tsx
+++ b/apps/web/core/debates/match-prompt.test.tsx
@@ -294,7 +294,7 @@ describe('DebateMatchPrompt', () => {
     const view = render(<DebateMatchPrompt spaceId="space-1" matches={[match()]} debates={[]} />);
 
     fireEvent.click(screen.getByRole('button', { name: 'Accept' }));
-    fireEvent.click(screen.getByRole('button', { name: 'Accept' }));
+    fireEvent.click(screen.getByRole('button', { name: "I'm ready" }));
 
     expect(screen.getByRole('button', { name: 'Waiting...' })).toBeDisabled();
     expect(mocks.markReadyMutate).not.toHaveBeenCalled();
@@ -318,14 +318,14 @@ describe('DebateMatchPrompt', () => {
 
     const view = render(<DebateMatchPrompt spaceId="space-1" matches={[acceptedMatch]} debates={[]} />);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Accept' }));
+    fireEvent.click(screen.getByRole('button', { name: "I'm ready" }));
     view.rerender(<DebateMatchPrompt spaceId="space-1" matches={[acceptedMatch]} debates={[debate()]} />);
 
     await waitFor(() => expect(mocks.markReadyMutate).toHaveBeenCalledTimes(1));
     act(failReadiness);
 
     expect(screen.getByText('Readiness failed')).toBeInTheDocument();
-    fireEvent.click(screen.getByRole('button', { name: 'Accept' }));
+    fireEvent.click(screen.getByRole('button', { name: "I'm ready" }));
 
     await waitFor(() => expect(mocks.markReadyMutate).toHaveBeenCalledTimes(2));
     expect(mocks.push).toHaveBeenCalledTimes(1);
@@ -342,14 +342,14 @@ describe('DebateMatchPrompt', () => {
     const view = render(<DebateMatchPrompt spaceId="space-1" matches={[acceptedMatch]} debates={[]} />);
 
     await waitFor(() => expect(mocks.ensurePreview).toHaveBeenCalledTimes(1));
-    fireEvent.click(screen.getByRole('button', { name: 'Accept' }));
+    fireEvent.click(screen.getByRole('button', { name: "I'm ready" }));
     view.rerender(<DebateMatchPrompt spaceId="space-1" matches={[acceptedMatch]} debates={[debate()]} />);
 
     await waitFor(() => expect(mocks.ensurePreview).toHaveBeenCalledTimes(2));
     await waitFor(() => expect(screen.getByText('Camera disconnected')).toBeInTheDocument());
     expect(mocks.markReadyMutate).not.toHaveBeenCalled();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Accept' }));
+    fireEvent.click(screen.getByRole('button', { name: "I'm ready" }));
 
     await waitFor(() => expect(mocks.markReadyMutate).toHaveBeenCalledTimes(1));
     expect(mocks.ensurePreview).toHaveBeenCalledTimes(3);
@@ -360,7 +360,7 @@ describe('DebateMatchPrompt', () => {
     acceptedMatch.participants[0]!.accepted = true;
     const view = render(<DebateMatchPrompt spaceId="space-1" matches={[acceptedMatch]} debates={[]} />);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Accept' }));
+    fireEvent.click(screen.getByRole('button', { name: "I'm ready" }));
     mocks.markReadyPending = true;
     view.rerender(<DebateMatchPrompt spaceId="space-1" matches={[acceptedMatch]} debates={[debate()]} />);
 


### PR DESCRIPTION
## Summary

The pre-join readiness action previously said “Accept,” which blurred the distinction between accepting a debate match and confirming that camera and audio setup is complete. It now says “I’m ready” in both direct debate and match-to-debate flows, while the existing saving and waiting states remain unchanged.

## Validation

- Full web test suite: 1,625 tests passed across 159 files
- ESLint: 0 errors

## Post-Deploy Monitoring & Validation

No additional operational monitoring is required because this is a copy-only UI change with no backend or control-flow impact. During the first post-deploy debate smoke test, the debates frontend owner should confirm that the camera/audio pre-join screen shows “I’m ready” and changes to “Waiting...” after selection; roll back if the label is missing, incorrect, or the readiness transition no longer works.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)


https://linear.app/geobrowser/issue/GEO-2411/bug-button-copy-incorrect