### PR TITLE
fix(debates): highlight active recording speaker

### DIFF
--- a/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
@@ -1154,6 +1154,7 @@ describe('DebateRoomPageClient', () => {
     expectActiveDebateVideoTile('local');
     expectInactiveDebateVideoTile('remote');
     expect(document.querySelector('[data-inactive-speaker="local"]')).toHaveAttribute('data-visible', 'false');
+    expect(document.querySelector('[data-inactive-speaker="local"]')).toHaveClass('opacity-0');
     expect(document.querySelector('[data-inactive-speaker="remote"]')).toHaveAttribute('data-visible', 'true');
     expect(document.querySelector('[data-inactive-speaker="remote"]')).toHaveClass('bg-[#151515]/75', 'opacity-60');
     expect(document.querySelector('[data-inactive-speaker="remote"]')).not.toHaveClass('opacity-100');
@@ -1192,6 +1193,8 @@ describe('DebateRoomPageClient', () => {
     expect(document.querySelector('[data-inactive-speaker="local"]')).toHaveAttribute('data-visible', 'true');
     expect(document.querySelector('[data-inactive-speaker="local"]')).toHaveClass('bg-[#151515]/75', 'opacity-60');
     expect(document.querySelector('[data-inactive-speaker="local"]')).not.toHaveClass('opacity-100');
+    expect(document.querySelector('[data-inactive-speaker="remote"]')).toHaveAttribute('data-visible', 'false');
+    expect(document.querySelector('[data-inactive-speaker="remote"]')).toHaveClass('opacity-0');
     expect(document.querySelector('[data-muted-indicator="true"]')).not.toBeInTheDocument();
     expectDebateVideoTileInColor('local');
     expectDebateVideoTileInColor('remote');

--- a/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
@@ -1152,7 +1152,7 @@ describe('DebateRoomPageClient', () => {
     expect(screen.getByRole('button', { name: 'Leave debate' })).toBeInTheDocument();
     expect(screen.queryByText(/has the floor/i)).not.toBeInTheDocument();
     expectActiveDebateVideoTile('local');
-    expect(debateVideoTile('remote')).toHaveAttribute('data-active-speaker', 'false');
+    expectInactiveDebateVideoTile('remote');
     expect(document.querySelector('[data-inactive-speaker="local"]')).toHaveAttribute('data-visible', 'false');
     expect(document.querySelector('[data-inactive-speaker="remote"]')).toHaveAttribute('data-visible', 'true');
     expect(document.querySelector('[data-inactive-speaker="remote"]')).toHaveClass('bg-[#151515]/75');
@@ -1187,7 +1187,7 @@ describe('DebateRoomPageClient', () => {
     expect(tiles[0]?.querySelector('[data-inactive-speaker]')).toHaveAttribute('data-inactive-speaker', 'remote');
     expect(tiles[1]?.querySelector('[data-inactive-speaker]')).toHaveAttribute('data-inactive-speaker', 'local');
     expectActiveDebateVideoTile('remote');
-    expect(debateVideoTile('local')).toHaveAttribute('data-active-speaker', 'false');
+    expectInactiveDebateVideoTile('local');
     expect(document.querySelector('[data-inactive-speaker="local"]')).toHaveAttribute('data-visible', 'true');
     expect(document.querySelector('[data-inactive-speaker="local"]')).toHaveClass('bg-[#151515]/75');
     expect(document.querySelector('[data-muted-indicator="true"]')).not.toBeInTheDocument();
@@ -2381,7 +2381,15 @@ function expectDebateVideoTileInColor(participant: 'local' | 'remote') {
 
 function expectActiveDebateVideoTile(participant: 'local' | 'remote') {
   expect(debateVideoTile(participant)).toHaveAttribute('data-active-speaker', 'true');
-  expect(debateVideoTile(participant)).toHaveClass('outline-[3px]', 'outline-purple');
+  expect(debateVideoTile(participant)).toHaveClass('outline-[3px]', 'outline-offset-0', 'outline-purple');
+}
+
+function expectInactiveDebateVideoTile(participant: 'local' | 'remote') {
+  const tile = debateVideoTile(participant);
+  expect(tile).toHaveAttribute('data-active-speaker', 'false');
+  expect(tile).not.toHaveClass('outline-[3px]');
+  expect(tile).not.toHaveClass('outline-offset-0');
+  expect(tile).not.toHaveClass('outline-purple');
 }
 
 function debateVideoTile(participant: 'local' | 'remote') {

--- a/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
@@ -1155,7 +1155,8 @@ describe('DebateRoomPageClient', () => {
     expectInactiveDebateVideoTile('remote');
     expect(document.querySelector('[data-inactive-speaker="local"]')).toHaveAttribute('data-visible', 'false');
     expect(document.querySelector('[data-inactive-speaker="remote"]')).toHaveAttribute('data-visible', 'true');
-    expect(document.querySelector('[data-inactive-speaker="remote"]')).toHaveClass('bg-[#151515]/75');
+    expect(document.querySelector('[data-inactive-speaker="remote"]')).toHaveClass('bg-[#151515]/75', 'opacity-60');
+    expect(document.querySelector('[data-inactive-speaker="remote"]')).not.toHaveClass('opacity-100');
     expect(document.querySelector('[data-muted-indicator="true"]')).not.toBeInTheDocument();
     expectDebateVideoTileInColor('local');
     expectDebateVideoTileInColor('remote');
@@ -1189,7 +1190,8 @@ describe('DebateRoomPageClient', () => {
     expectActiveDebateVideoTile('remote');
     expectInactiveDebateVideoTile('local');
     expect(document.querySelector('[data-inactive-speaker="local"]')).toHaveAttribute('data-visible', 'true');
-    expect(document.querySelector('[data-inactive-speaker="local"]')).toHaveClass('bg-[#151515]/75');
+    expect(document.querySelector('[data-inactive-speaker="local"]')).toHaveClass('bg-[#151515]/75', 'opacity-60');
+    expect(document.querySelector('[data-inactive-speaker="local"]')).not.toHaveClass('opacity-100');
     expect(document.querySelector('[data-muted-indicator="true"]')).not.toBeInTheDocument();
     expectDebateVideoTileInColor('local');
     expectDebateVideoTileInColor('remote');

--- a/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
@@ -1151,9 +1151,11 @@ describe('DebateRoomPageClient', () => {
     expect(screen.queryByRole('button', { name: 'Disable audio' })).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Leave debate' })).toBeInTheDocument();
     expect(screen.queryByText(/has the floor/i)).not.toBeInTheDocument();
+    expectActiveDebateVideoTile('local');
+    expect(debateVideoTile('remote')).toHaveAttribute('data-active-speaker', 'false');
     expect(document.querySelector('[data-inactive-speaker="local"]')).toHaveAttribute('data-visible', 'false');
     expect(document.querySelector('[data-inactive-speaker="remote"]')).toHaveAttribute('data-visible', 'true');
-    expect(document.querySelector('[data-inactive-speaker="remote"]')).toHaveClass('bg-black/45');
+    expect(document.querySelector('[data-inactive-speaker="remote"]')).toHaveClass('bg-[#151515]/75');
     expect(document.querySelector('[data-muted-indicator="true"]')).not.toBeInTheDocument();
     expectDebateVideoTileInColor('local');
     expectDebateVideoTileInColor('remote');
@@ -1184,8 +1186,10 @@ describe('DebateRoomPageClient', () => {
     expect(tiles.map(tile => tile.getAttribute('data-debate-video-position'))).toEqual(['yes', 'no']);
     expect(tiles[0]?.querySelector('[data-inactive-speaker]')).toHaveAttribute('data-inactive-speaker', 'remote');
     expect(tiles[1]?.querySelector('[data-inactive-speaker]')).toHaveAttribute('data-inactive-speaker', 'local');
+    expectActiveDebateVideoTile('remote');
+    expect(debateVideoTile('local')).toHaveAttribute('data-active-speaker', 'false');
     expect(document.querySelector('[data-inactive-speaker="local"]')).toHaveAttribute('data-visible', 'true');
-    expect(document.querySelector('[data-inactive-speaker="local"]')).toHaveClass('bg-black/45');
+    expect(document.querySelector('[data-inactive-speaker="local"]')).toHaveClass('bg-[#151515]/75');
     expect(document.querySelector('[data-muted-indicator="true"]')).not.toBeInTheDocument();
     expectDebateVideoTileInColor('local');
     expectDebateVideoTileInColor('remote');
@@ -2373,6 +2377,11 @@ async function renderLiveDebate(overrides: Partial<Debate> = {}) {
 
 function expectDebateVideoTileInColor(participant: 'local' | 'remote') {
   expect(debateVideoTile(participant)).not.toHaveClass('grayscale');
+}
+
+function expectActiveDebateVideoTile(participant: 'local' | 'remote') {
+  expect(debateVideoTile(participant)).toHaveAttribute('data-active-speaker', 'true');
+  expect(debateVideoTile(participant)).toHaveClass('outline-[3px]', 'outline-purple');
 }
 
 function debateVideoTile(participant: 'local' | 'remote') {

--- a/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.tsx
@@ -1862,16 +1862,19 @@ function DebateVideoTile({
   return (
     <section
       data-debate-video-position={participantPosition === null ? undefined : participantPosition ? 'yes' : 'no'}
-      className="relative aspect-[5/3] min-h-0 overflow-hidden rounded-lg bg-black shadow-card"
+      data-active-speaker={active ? 'true' : 'false'}
+      className={cx(
+        'relative aspect-[5/3] min-h-0 overflow-hidden rounded-lg bg-black shadow-card',
+        active && 'outline-[3px] outline-offset-0 outline-purple'
+      )}
     >
       <div className="absolute inset-0 z-0">{children}</div>
-      {active && <div className="pointer-events-none absolute inset-0 z-10 ring-2 ring-white/80 ring-inset" />}
       <div
         aria-hidden="true"
         data-inactive-speaker={inactiveOverlayId}
         data-visible={inactive && !revealInactive ? 'true' : 'false'}
         className={cx(
-          'pointer-events-none absolute inset-0 z-10 bg-black/45 transition-opacity duration-700 ease-out',
+          'pointer-events-none absolute inset-0 z-10 bg-[#151515]/75 transition-opacity duration-700 ease-out',
           inactive && !revealInactive ? 'opacity-100' : 'opacity-0'
         )}
       />

--- a/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.tsx
@@ -1875,7 +1875,7 @@ function DebateVideoTile({
         data-visible={inactive && !revealInactive ? 'true' : 'false'}
         className={cx(
           'pointer-events-none absolute inset-0 z-10 bg-[#151515]/75 transition-opacity duration-700 ease-out',
-          inactive && !revealInactive ? 'opacity-100' : 'opacity-0'
+          inactive && !revealInactive ? 'opacity-60' : 'opacity-0'
         )}
       />
       {countdown && <div className="pointer-events-none absolute top-3 right-3 z-20">{countdown}</div>}


### PR DESCRIPTION
## Summary

During debate recording, the current speaker is now framed with a 3px purple outline outside the video tile, while the inactive participant is dimmed with the requested darker overlay. The external outline preserves tile dimensions, so speaker changes do not shift the recording layout.

## Validation

- Focused debate-room suite: 96 tests passed
- Full web suite: 159 files and 1,625 tests passed
- Full web lint: 0 errors; 81 existing warnings in unrelated files
- Focused code review: no actionable findings

## Post-Deploy Monitoring & Validation

No additional operational monitoring is required because this is a presentation-only change with no backend or persistent-state impact. During the first live debate after deployment, confirm that the purple outline follows the active turn and the dark overlay follows the inactive participant; revert this commit if either treatment clips or affects tile layout.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
