### PR TITLE
fix(debates): show positions in match requests

### DIFF
--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
@@ -154,8 +154,8 @@ describe('DebateRematchPageClient', () => {
     expect(within(dialog).getByText('You')).toBeInTheDocument();
     expect(within(dialog).getByText('Salina')).toBeInTheDocument();
     expect(within(dialog).getByText('vs')).toBeInTheDocument();
-    expect(within(dialog).queryByText('Yes')).not.toBeInTheDocument();
-    expect(within(dialog).queryByText('No')).not.toBeInTheDocument();
+    expect(within(within(dialog).getByText('You').parentElement!).getByText('Yes')).toBeInTheDocument();
+    expect(within(within(dialog).getByText('Salina').parentElement!).getByText('No')).toBeInTheDocument();
     expect(within(dialog).getAllByText('1m')).toHaveLength(2);
     expect(within(dialog).getAllByText('45s')).toHaveLength(2);
     expect(document.body.style.overflow).toBe('hidden');

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -190,6 +190,20 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
 
   const pendingRequest = session?.status === 'request_pending' ? session.request : null;
   const incomingRequest = pendingRequest?.recipient_user_id === currentUserId ? pendingRequest : null;
+  const incomingRequestParticipants =
+    incomingRequest && session
+      ? session.participants.map(participant => ({
+          ...participant,
+          position_label:
+            participant.user_id === incomingRequest.requester_user_id
+              ? incomingRequest.requester_position
+                ? 'Yes'
+                : 'No'
+              : incomingRequest.recipient_position
+                ? 'Yes'
+                : 'No',
+        }))
+      : [];
 
   return (
     <div className="fixed inset-0 z-[1000] overflow-y-auto bg-white text-text">
@@ -314,7 +328,7 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
       {incomingRequest && session && currentUserId && (
         <DebateRequestDialog
           claim={incomingRequest.claim.claim}
-          participants={session.participants}
+          participants={incomingRequestParticipants}
           currentUserId={currentUserId}
           formatId={incomingRequest.turn_format_id}
           busy={acceptRequest.isPending || rejectRequest.isPending}

--- a/apps/web/core/debates/debate-request-dialog.test.tsx
+++ b/apps/web/core/debates/debate-request-dialog.test.tsx
@@ -13,6 +13,7 @@ const participants: DebateRequestDialogParticipant[] = [
     display_name: 'Local speaker',
     avatar_cid: null,
     participant_slot: 1,
+    position_label: 'Yes',
   },
   {
     user_id: 'user-remote',
@@ -20,6 +21,7 @@ const participants: DebateRequestDialogParticipant[] = [
     display_name: 'Remote speaker',
     avatar_cid: null,
     participant_slot: 2,
+    position_label: 'No',
   },
 ];
 
@@ -60,8 +62,8 @@ describe('DebateRequestDialog', () => {
     expect(within(dialog).getByText('You')).toBeInTheDocument();
     expect(within(dialog).getByText('Remote speaker')).toBeInTheDocument();
     expect(within(dialog).getByText('vs')).toBeInTheDocument();
-    expect(within(dialog).queryByText('Yes')).not.toBeInTheDocument();
-    expect(within(dialog).queryByText('No')).not.toBeInTheDocument();
+    expect(within(within(dialog).getByText('You').parentElement!).getByText('Yes')).toBeInTheDocument();
+    expect(within(within(dialog).getByText('Remote speaker').parentElement!).getByText('No')).toBeInTheDocument();
     expect(within(dialog).getAllByText('1m')).toHaveLength(2);
     expect(within(dialog).getAllByText('45s')).toHaveLength(2);
 

--- a/apps/web/core/debates/debate-request-dialog.tsx
+++ b/apps/web/core/debates/debate-request-dialog.tsx
@@ -13,6 +13,7 @@ import { speakerLabel } from './playback-utils';
 
 export type DebateRequestDialogParticipant = DebateParticipantSummary & {
   participant_slot: ParticipantSlot;
+  position_label: string;
 };
 
 type DebateRequestDialogFormatSelector = {
@@ -177,6 +178,9 @@ function ParticipantSummary({
       </span>
       <Text as="div" variant="metadata" color="text" className="max-w-full truncate">
         {label}
+      </Text>
+      <Text as="span" variant="smallButton" color="text" className="rounded-full bg-grey-02 px-2 py-0.5">
+        {participant.position_label}
       </Text>
     </div>
   );

--- a/apps/web/core/debates/match-prompt.test.tsx
+++ b/apps/web/core/debates/match-prompt.test.tsx
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom/vitest';
-import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 
 import type React from 'react';
 
@@ -177,14 +177,13 @@ describe('DebateMatchPrompt', () => {
     expect(acceptButton).toBeEnabled();
   });
 
-  it('renders participants as avatar and name without a per-participant menu or position pill', () => {
+  it('renders each participant position without a per-participant menu', () => {
     render(<DebateMatchPrompt spaceId="space-1" matches={[match()]} />);
 
-    // The design shows only the avatar + name in the VS card — no "..." menu, no Yes/No pill.
     expect(screen.queryByRole('button', { name: 'More actions for You' })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'More actions for Bri' })).not.toBeInTheDocument();
-    expect(screen.getByText('Bri')).toBeInTheDocument();
-    expect(screen.queryByText('You chose Yes.')).not.toBeInTheDocument();
+    expect(within(screen.getByText('You').parentElement!).getByText('Yes')).toBeInTheDocument();
+    expect(within(screen.getByText('Bri').parentElement!).getByText('No')).toBeInTheDocument();
   });
 
   it('locks background scrolling while the match dialog is open', () => {


### PR DESCRIPTION
## Summary

Matching requests previously showed only each participant's name, leaving their Yes/No position unclear. They now show each position beneath the correct participant, using backend-provided labels for regular matches and the request's stored positions for rematches.

## Validation

- GitHub CI passed Build, Test, and Lint on `d3ce13be`; the Vercel preview also passed
- `bun --cwd apps/web test` passed locally before the rematch follow-up (159 files, 1,625 tests)
- The focused rematch suite passed after the follow-up (11 tests), along with TypeScript and ESLint
- Automated coverage verifies each position label is rendered under the correct participant in matching and rematch requests
- Browser screenshot validation was unavailable because the in-app browser could not connect to the existing localhost development server

## Post-Deploy Monitoring & Validation

- Smoke-check one matching request and confirm both participant cards show the expected positions without overflow
- Watch Sentry/client errors for the matching flow; healthy behavior has no new render errors and Accept/Reject remains unchanged
- Roll back this commit if position pills are missing, swapped, or disrupt the request-dialog layout
- Validation window: first production smoke check after deploy; owner: web on-call or deploying reviewer

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)

https://linear.app/geobrowser/issue/GEO-2429/bug-debate-request-screen-ui