### PR TITLE
fix(debates): keep yes participant on the left

### DIFF
--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -192,17 +192,18 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   const incomingRequest = pendingRequest?.recipient_user_id === currentUserId ? pendingRequest : null;
   const incomingRequestParticipants =
     incomingRequest && session
-      ? session.participants.map(participant => ({
-          ...participant,
-          position_label:
+      ? session.participants.map(participant => {
+          const position =
             participant.user_id === incomingRequest.requester_user_id
               ? incomingRequest.requester_position
-                ? 'Yes'
-                : 'No'
-              : incomingRequest.recipient_position
-                ? 'Yes'
-                : 'No',
-        }))
+              : incomingRequest.recipient_position;
+
+          return {
+            ...participant,
+            position,
+            position_label: position ? 'Yes' : 'No',
+          };
+        })
       : [];
 
   return (

--- a/apps/web/core/debates/debate-request-dialog.test.tsx
+++ b/apps/web/core/debates/debate-request-dialog.test.tsx
@@ -13,6 +13,7 @@ const participants: DebateRequestDialogParticipant[] = [
     display_name: 'Local speaker',
     avatar_cid: null,
     participant_slot: 1,
+    position: true,
     position_label: 'Yes',
   },
   {
@@ -21,6 +22,7 @@ const participants: DebateRequestDialogParticipant[] = [
     display_name: 'Remote speaker',
     avatar_cid: null,
     participant_slot: 2,
+    position: false,
     position_label: 'No',
   },
 ];
@@ -78,7 +80,7 @@ describe('DebateRequestDialog', () => {
     expect(reject).toHaveBeenCalledOnce();
   });
 
-  it('keeps the Yes participant on the left and the No participant on the right', () => {
+  it('keeps the positive participant on the left and the negative participant on the right', () => {
     render(
       <DebateRequestDialog
         claim="Position order should be stable"
@@ -86,12 +88,14 @@ describe('DebateRequestDialog', () => {
           {
             ...participants[0]!,
             avatar_cid: 'https://example.com/local-avatar.png',
-            position_label: 'No',
+            position: false,
+            position_label: 'Against',
           },
           {
             ...participants[1]!,
             avatar_cid: 'https://example.com/remote-avatar.png',
-            position_label: 'Yes',
+            position: true,
+            position_label: 'For',
           },
         ]}
         currentUserId="user-local"
@@ -108,9 +112,9 @@ describe('DebateRequestDialog', () => {
     const remoteParticipant = within(dialog).getByText('Remote speaker').parentElement!;
 
     expect(remoteParticipant.compareDocumentPosition(localParticipant) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
-    expect(within(remoteParticipant).getByText('Yes')).toBeInTheDocument();
+    expect(within(remoteParticipant).getByText('For')).toBeInTheDocument();
     expect(within(remoteParticipant).getByAltText('Remote speaker')).toBeInTheDocument();
-    expect(within(localParticipant).getByText('No')).toBeInTheDocument();
+    expect(within(localParticipant).getByText('Against')).toBeInTheDocument();
     expect(within(localParticipant).getByAltText('Local speaker')).toBeInTheDocument();
 
     const localFirstTurn = within(dialog).getByText('You make an argument');

--- a/apps/web/core/debates/debate-request-dialog.test.tsx
+++ b/apps/web/core/debates/debate-request-dialog.test.tsx
@@ -78,6 +78,46 @@ describe('DebateRequestDialog', () => {
     expect(reject).toHaveBeenCalledOnce();
   });
 
+  it('keeps the Yes participant on the left and the No participant on the right', () => {
+    render(
+      <DebateRequestDialog
+        claim="Position order should be stable"
+        participants={[
+          {
+            ...participants[0]!,
+            avatar_cid: 'https://example.com/local-avatar.png',
+            position_label: 'No',
+          },
+          {
+            ...participants[1]!,
+            avatar_cid: 'https://example.com/remote-avatar.png',
+            position_label: 'Yes',
+          },
+        ]}
+        currentUserId="user-local"
+        formatId="standard"
+        busy={false}
+        error={null}
+        onAccept={() => undefined}
+        onReject={() => undefined}
+      />
+    );
+
+    const dialog = screen.getByRole('dialog', { name: 'Position order should be stable' });
+    const localParticipant = within(dialog).getByText('You').parentElement!;
+    const remoteParticipant = within(dialog).getByText('Remote speaker').parentElement!;
+
+    expect(remoteParticipant.compareDocumentPosition(localParticipant) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(within(remoteParticipant).getByText('Yes')).toBeInTheDocument();
+    expect(within(remoteParticipant).getByAltText('Remote speaker')).toBeInTheDocument();
+    expect(within(localParticipant).getByText('No')).toBeInTheDocument();
+    expect(within(localParticipant).getByAltText('Local speaker')).toBeInTheDocument();
+
+    const localFirstTurn = within(dialog).getByText('You make an argument');
+    const remoteFirstTurn = within(dialog).getByText('Remote speaker makes an argument');
+    expect(localFirstTurn.compareDocumentPosition(remoteFirstTurn) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
   it('locks scrolling and surfaces busy and error states', () => {
     const { unmount } = render(
       <DebateRequestDialog

--- a/apps/web/core/debates/debate-request-dialog.tsx
+++ b/apps/web/core/debates/debate-request-dialog.tsx
@@ -13,6 +13,7 @@ import { speakerLabel } from './playback-utils';
 
 export type DebateRequestDialogParticipant = DebateParticipantSummary & {
   participant_slot: ParticipantSlot;
+  position: boolean;
   position_label: string;
 };
 
@@ -54,9 +55,7 @@ export function DebateRequestDialog({
   const positionParticipants = React.useMemo(
     () =>
       [...turnParticipants].sort(
-        (a, b) =>
-          positionRank(a.position_label) - positionRank(b.position_label) ||
-          a.participant_slot - b.participant_slot
+        (a, b) => Number(b.position) - Number(a.position) || a.participant_slot - b.participant_slot
       ),
     [turnParticipants]
   );
@@ -164,12 +163,6 @@ export function DebateRequestDialog({
       </section>
     </div>
   );
-}
-
-function positionRank(positionLabel: string) {
-  if (positionLabel === 'Yes') return 0;
-  if (positionLabel === 'No') return 1;
-  return 2;
 }
 
 function ParticipantSummary({

--- a/apps/web/core/debates/debate-request-dialog.tsx
+++ b/apps/web/core/debates/debate-request-dialog.tsx
@@ -47,12 +47,21 @@ export function DebateRequestDialog({
   onReject,
 }: DebateRequestDialogProps) {
   const titleId = React.useId();
-  const orderedParticipants = React.useMemo(
+  const turnParticipants = React.useMemo(
     () => [...participants].sort((a, b) => a.participant_slot - b.participant_slot),
     [participants]
   );
-  const firstParticipant = orderedParticipants[0];
-  const secondParticipant = orderedParticipants[1] ?? firstParticipant;
+  const positionParticipants = React.useMemo(
+    () =>
+      [...turnParticipants].sort(
+        (a, b) =>
+          positionRank(a.position_label) - positionRank(b.position_label) ||
+          a.participant_slot - b.participant_slot
+      ),
+    [turnParticipants]
+  );
+  const firstParticipant = positionParticipants[0];
+  const secondParticipant = positionParticipants[1] ?? firstParticipant;
 
   React.useEffect(() => {
     const originalBodyOverflow = document.body.style.overflow;
@@ -121,7 +130,7 @@ export function DebateRequestDialog({
             <div className="px-1 pb-1">
               <DebateFormatDetails
                 formatId={formatId}
-                participants={orderedParticipants}
+                participants={turnParticipants}
                 currentUserId={currentUserId}
               />
             </div>
@@ -155,6 +164,12 @@ export function DebateRequestDialog({
       </section>
     </div>
   );
+}
+
+function positionRank(positionLabel: string) {
+  if (positionLabel === 'Yes') return 0;
+  if (positionLabel === 'No') return 1;
+  return 2;
 }
 
 function ParticipantSummary({


### PR DESCRIPTION
## Summary

Debate requests now consistently place the positive/Yes participant on the left and the negative/No participant on the right, keeping each participant's name and avatar with their position. Speaker turns continue to follow participant-slot order rather than visual order.

The dialog orders by the semantic position value, so custom labels such as `For`/`Against` and rematch requests remain correctly oriented.

## Test plan

- `bun --cwd apps/web test core/debates/debate-request-dialog.test.tsx core/debates/match-prompt.test.tsx 'app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx'` - 30 tests passed
- `apps/web/node_modules/.bin/tsc -p apps/web/tsconfig.json --noEmit`
- ESLint on the three changed files

Automated component coverage verifies participant order, avatar association, custom labels, and unchanged speaker-turn order. A manual screenshot was not captured because the local browser session was logged out.
