### PR TITLE
fix: hide collection browse header actions

### DIFF
--- a/apps/web/partials/blocks/table/data-block-header-action-visibility.test.ts
+++ b/apps/web/partials/blocks/table/data-block-header-action-visibility.test.ts
@@ -9,17 +9,28 @@ import {
 
 describe('shouldShowFilterAndFullscreenActions', () => {
   it('hides both actions for Explore view in browse mode', () => {
-    expect(shouldShowFilterAndFullscreenActions('EXPLORE', false)).toBe(false);
+    expect(shouldShowFilterAndFullscreenActions('EXPLORE', 'SPACES', false)).toBe(false);
   });
 
   it('keeps both actions for Explore view in edit mode', () => {
-    expect(shouldShowFilterAndFullscreenActions('EXPLORE', true)).toBe(true);
+    expect(shouldShowFilterAndFullscreenActions('EXPLORE', 'SPACES', true)).toBe(true);
+  });
+
+  it.each<DataBlockView>(['TABLE', 'LIST', 'GALLERY', 'BULLETED_LIST', 'PILL', 'EXPLORE'])(
+    'hides both actions for a Collection source using %s view in browse mode',
+    view => {
+      expect(shouldShowFilterAndFullscreenActions(view, 'COLLECTION', false)).toBe(false);
+    }
+  );
+
+  it('keeps both actions for a Collection source in edit mode', () => {
+    expect(shouldShowFilterAndFullscreenActions('TABLE', 'COLLECTION', true)).toBe(true);
   });
 
   it.each<DataBlockView>(['TABLE', 'LIST', 'GALLERY', 'BULLETED_LIST', 'PILL'])(
-    'keeps both actions for %s view in browse mode',
+    'keeps both actions for a query source using %s view in browse mode',
     view => {
-      expect(shouldShowFilterAndFullscreenActions(view, false)).toBe(true);
+      expect(shouldShowFilterAndFullscreenActions(view, 'SPACES', false)).toBe(true);
     }
   );
 });

--- a/apps/web/partials/blocks/table/data-block-header-action-visibility.ts
+++ b/apps/web/partials/blocks/table/data-block-header-action-visibility.ts
@@ -1,8 +1,13 @@
+import type { Source } from '~/core/blocks/data/source';
 import type { DataBlockView } from '~/core/blocks/data/use-view';
 
-/** Explore browse is an infinite feed and does not expose filter/fullscreen header actions. */
-export function shouldShowFilterAndFullscreenActions(view: DataBlockView, isEditing: boolean): boolean {
-  return isEditing || view !== 'EXPLORE';
+/** Explore and collection browse surfaces do not expose filter/fullscreen header actions. */
+export function shouldShowFilterAndFullscreenActions(
+  view: DataBlockView,
+  sourceType: Source['type'],
+  isEditing: boolean
+): boolean {
+  return isEditing || (view !== 'EXPLORE' && sourceType !== 'COLLECTION');
 }
 
 /** A hidden filter toggle must not leave its panel open with no way to close it. */

--- a/apps/web/partials/blocks/table/table-block.tsx
+++ b/apps/web/partials/blocks/table/table-block.tsx
@@ -970,7 +970,7 @@ const ConfiguredTableBlock = ({
 
   const showToolbarSort = isEditing || sortState !== null;
   const showToolbarDividerAfterScope = showToolbarSort || isEditing;
-  const showFilterAndFullscreenActions = shouldShowFilterAndFullscreenActions(view, isEditing);
+  const showFilterAndFullscreenActions = shouldShowFilterAndFullscreenActions(view, source.type, isEditing);
 
   React.useEffect(() => {
     setIsFilterOpen(current => filterPanelOpenStateForActions(current, showFilterAndFullscreenActions));


### PR DESCRIPTION
## Summary

- hide the Filter and Fullscreen header actions for collection-source data blocks in browse mode
- keep both actions available for collection blocks in edit mode
- preserve the existing Explore browse-mode behavior and query-source controls

## Why

Collection data blocks represent a curated set of entities, so their browse surface should not expose the query-oriented Filter or Fullscreen controls. The previous visibility rule only handled Explore view and did not consider the block's data source.

## Validation

- `bun run test partials/blocks/table/data-block-header-action-visibility.test.ts` (16 tests)
- `bun x tsc --noEmit --pretty false`
- targeted ESLint (no errors)
