### PR TITLE
feat(debates): share branded social videos

### DIFF
--- a/apps/web/app/space/[id]/(space)/debug-debates/debug-debates-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debug-debates/debug-debates-page-client.test.tsx
@@ -276,12 +276,13 @@ describe('DebugDebatesPageClient', () => {
     expect(within(card).queryByText('Could not reprocess video: Reprocessing unavailable')).not.toBeInTheDocument();
   });
 
-  it('loads available WebM and MOV renditions independently with links and fallbacks', async () => {
+  it('loads WebM, MOV, and share-video renditions independently in a responsive three-column layout', async () => {
     mocks.listResult.data.debates = [debate('both'), debate('webm-only')];
-    mocks.mediaByDebate.set('both', mediaResult('succeeded', {}, ['final_video', 'final_video_hevc']));
+    mocks.mediaByDebate.set('both', mediaResult('succeeded', {}, ['final_video', 'final_video_hevc', 'social_video']));
     mocks.mediaByDebate.set('webm-only', mediaResult('succeeded', {}, ['final_video']));
     mocks.artifactUrls.set('both:final_video', 'https://media.test/both.webm');
     mocks.artifactUrls.set('both:final_video_hevc', 'https://media.test/both.mov');
+    mocks.artifactUrls.set('both:social_video', 'https://media.test/both-social.mp4');
 
     render(<DebugDebatesPageClient spaceId="space-1" />);
 
@@ -292,10 +293,16 @@ describe('DebugDebatesPageClient', () => {
     const mov = within(both).getByLabelText('MOV processed video');
     expect(mov).toHaveAttribute('src', 'https://media.test/both.mov');
 
+    const shareVideo = within(both).getByLabelText('Share video processed video');
+    expect(shareVideo).toHaveAttribute('src', 'https://media.test/both-social.mp4');
+
+    expect(within(both).getByRole('region', { name: 'Processed videos' })).toHaveClass('lg:grid-cols-3');
+
     for (const video of [webm, mov]) {
       expect(video).toHaveClass('aspect-[8/9]', 'w-1/4', 'bg-white', 'sm:aspect-video', 'sm:w-full');
       expect(video).not.toHaveClass('bg-black');
     }
+    expect(shareVideo).toHaveClass('aspect-[9/16]', 'w-full', 'bg-white', 'object-contain');
     expect(within(both).getByRole('link', { name: 'Open WebM directly' })).toHaveAttribute(
       'href',
       'https://media.test/both.webm'
@@ -304,9 +311,14 @@ describe('DebugDebatesPageClient', () => {
       'href',
       'https://media.test/both.mov'
     );
+    expect(within(both).getByRole('link', { name: 'Open Share video directly' })).toHaveAttribute(
+      'href',
+      'https://media.test/both-social.mp4'
+    );
 
     const webmOnly = screen.getByTestId('debate-card-webm-only');
     expect(webmOnly).toHaveTextContent('MOV rendition is missing.');
+    expect(webmOnly).toHaveTextContent('Share video rendition is missing.');
   });
 
   it('shows independent URL and playback errors for a rendition', async () => {

--- a/apps/web/app/space/[id]/(space)/debug-debates/debug-debates-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debug-debates/debug-debates-page-client.test.tsx
@@ -276,7 +276,7 @@ describe('DebugDebatesPageClient', () => {
     expect(within(card).queryByText('Could not reprocess video: Reprocessing unavailable')).not.toBeInTheDocument();
   });
 
-  it('loads WebM, MOV, and share-video renditions independently in a responsive three-column layout', async () => {
+  it('loads all renditions in equal-size cards that wrap without stretching', async () => {
     mocks.listResult.data.debates = [debate('both'), debate('webm-only')];
     mocks.mediaByDebate.set('both', mediaResult('succeeded', {}, ['final_video', 'final_video_hevc', 'social_video']));
     mocks.mediaByDebate.set('webm-only', mediaResult('succeeded', {}, ['final_video']));
@@ -296,13 +296,17 @@ describe('DebugDebatesPageClient', () => {
     const shareVideo = within(both).getByLabelText('Share video processed video');
     expect(shareVideo).toHaveAttribute('src', 'https://media.test/both-social.mp4');
 
-    expect(within(both).getByRole('region', { name: 'Processed videos' })).toHaveClass('lg:grid-cols-3');
+    expect(within(both).getByRole('region', { name: 'Processed videos' })).toHaveClass(
+      'flex',
+      'flex-wrap',
+      'items-start'
+    );
 
-    for (const video of [webm, mov]) {
-      expect(video).toHaveClass('aspect-[8/9]', 'w-1/4', 'bg-white', 'sm:aspect-video', 'sm:w-full');
+    for (const video of [webm, mov, shareVideo]) {
+      expect(video).toHaveClass('aspect-video', 'w-full', 'bg-white', 'object-contain');
       expect(video).not.toHaveClass('bg-black');
+      expect(video.parentElement).toHaveClass('w-full', 'max-w-xs', 'flex-none');
     }
-    expect(shareVideo).toHaveClass('aspect-[9/16]', 'w-full', 'bg-white', 'object-contain');
     expect(within(both).getByRole('link', { name: 'Open WebM directly' })).toHaveAttribute(
       'href',
       'https://media.test/both.webm'

--- a/apps/web/app/space/[id]/(space)/debug-debates/debug-debates-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debug-debates/debug-debates-page-client.tsx
@@ -32,15 +32,14 @@ type DebugDebatesPageClientProps = {
 type Rendition = {
   kind: 'final_video' | 'final_video_hevc' | 'social_video';
   label: 'WebM' | 'MOV' | 'Share video';
-  videoClassName: string;
 };
 
 type ProcessingStatus = 'not started' | 'processing' | 'processed' | 'failed';
 
 const renditions: Rendition[] = [
-  { kind: 'final_video', label: 'WebM', videoClassName: 'aspect-[8/9] w-1/4 sm:aspect-video sm:w-full' },
-  { kind: 'final_video_hevc', label: 'MOV', videoClassName: 'aspect-[8/9] w-1/4 sm:aspect-video sm:w-full' },
-  { kind: 'social_video', label: 'Share video', videoClassName: 'aspect-[9/16] w-full' },
+  { kind: 'final_video', label: 'WebM' },
+  { kind: 'final_video_hevc', label: 'MOV' },
+  { kind: 'social_video', label: 'Share video' },
 ];
 
 export function DebugDebatesPageClient({ spaceId }: DebugDebatesPageClientProps) {
@@ -207,7 +206,7 @@ function DebateDiagnosticsCard({ debate, currentUserId }: { debate: Debate; curr
       </section>
 
       {status === 'processed' && media && (
-        <section aria-label="Processed videos" className="grid gap-4 lg:grid-cols-3">
+        <section aria-label="Processed videos" className="flex flex-wrap items-start gap-4">
           {renditions.map(rendition => (
             <ProcessedRendition
               key={rendition.kind}
@@ -305,7 +304,7 @@ function ProcessedRendition({ debateId, rendition, available }: { debateId: stri
   }, [available, debateId, rendition.kind]);
 
   return (
-    <div className="flex min-w-0 flex-col gap-2 rounded-lg border border-grey-02 p-3">
+    <div className="flex w-full max-w-xs min-w-0 flex-none flex-col gap-2 rounded-lg border border-grey-02 p-3">
       <Text as="h3" variant="bodySemibold">
         {rendition.label}
       </Text>
@@ -325,7 +324,7 @@ function ProcessedRendition({ debateId, rendition, available }: { debateId: stri
             playsInline
             preload="metadata"
             onError={() => setPlaybackError(true)}
-            className={`${rendition.videoClassName} rounded bg-white object-contain`}
+            className="aspect-video w-full rounded bg-white object-contain"
           />
           {playbackError && <StateMessage compact tone="error">{rendition.label} playback failed.</StateMessage>}
           <a

--- a/apps/web/app/space/[id]/(space)/debug-debates/debug-debates-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debug-debates/debug-debates-page-client.tsx
@@ -30,15 +30,17 @@ type DebugDebatesPageClientProps = {
 };
 
 type Rendition = {
-  kind: 'final_video' | 'final_video_hevc';
-  label: 'WebM' | 'MOV';
+  kind: 'final_video' | 'final_video_hevc' | 'social_video';
+  label: 'WebM' | 'MOV' | 'Share video';
+  videoClassName: string;
 };
 
 type ProcessingStatus = 'not started' | 'processing' | 'processed' | 'failed';
 
 const renditions: Rendition[] = [
-  { kind: 'final_video', label: 'WebM' },
-  { kind: 'final_video_hevc', label: 'MOV' },
+  { kind: 'final_video', label: 'WebM', videoClassName: 'aspect-[8/9] w-1/4 sm:aspect-video sm:w-full' },
+  { kind: 'final_video_hevc', label: 'MOV', videoClassName: 'aspect-[8/9] w-1/4 sm:aspect-video sm:w-full' },
+  { kind: 'social_video', label: 'Share video', videoClassName: 'aspect-[9/16] w-full' },
 ];
 
 export function DebugDebatesPageClient({ spaceId }: DebugDebatesPageClientProps) {
@@ -205,7 +207,7 @@ function DebateDiagnosticsCard({ debate, currentUserId }: { debate: Debate; curr
       </section>
 
       {status === 'processed' && media && (
-        <section aria-label="Processed videos" className="grid gap-4 lg:grid-cols-2">
+        <section aria-label="Processed videos" className="grid gap-4 lg:grid-cols-3">
           {renditions.map(rendition => (
             <ProcessedRendition
               key={rendition.kind}
@@ -323,7 +325,7 @@ function ProcessedRendition({ debateId, rendition, available }: { debateId: stri
             playsInline
             preload="metadata"
             onError={() => setPlaybackError(true)}
-            className="aspect-[8/9] w-1/4 rounded bg-white object-contain sm:aspect-video sm:w-full"
+            className={`${rendition.videoClassName} rounded bg-white object-contain`}
           />
           {playbackError && <StateMessage compact tone="error">{rendition.label} playback failed.</StateMessage>}
           <a

--- a/apps/web/core/debates/api.ts
+++ b/apps/web/core/debates/api.ts
@@ -73,6 +73,8 @@ export type DebateMediaArtifactKind =
   | 'final_video'
   | 'final_video_hevc'
   | 'preview_image'
+  | 'social_video'
+  | 'social_preview_image'
   | 'transcript_json'
   | 'subtitle_srt'
   | 'subtitle_vtt'

--- a/apps/web/core/debates/debate-coordinator.test.tsx
+++ b/apps/web/core/debates/debate-coordinator.test.tsx
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => ({
   activity: null as DebateActivity | null,
   pathname: '/space/space-1/debates',
   prompts: [] as DebateSharePrompt[],
+  promptsFetching: false,
   mediaMutate: vi.fn(),
   handleMutate: vi.fn(),
   fetch: vi.fn(),
@@ -34,7 +35,7 @@ vi.mock('~/core/analytics', () => ({ capture: mocks.capture }));
 vi.mock('./hooks', () => ({
   useGeoChatAuth: () => ({ ready: true, authenticated: mocks.authenticated, getPrivyIdentityToken: vi.fn() }),
   useDebateActivity: () => ({ data: mocks.activity }),
-  useDebateSharePrompts: () => ({ data: { prompts: mocks.prompts } }),
+  useDebateSharePrompts: () => ({ data: { prompts: mocks.prompts }, isFetching: mocks.promptsFetching }),
   useDebateMediaArtifactUrl: () => ({ mutate: mocks.mediaMutate, error: null }),
   useHandleDebateSharePrompt: () => ({ mutate: mocks.handleMutate, isPending: false }),
 }));
@@ -66,6 +67,7 @@ beforeEach(() => {
   mocks.activity = null;
   mocks.pathname = '/space/space-1/debates';
   mocks.prompts = [];
+  mocks.promptsFetching = false;
   mocks.authenticated = true;
   mocks.gatewayPaused = false;
   Object.defineProperty(navigator, 'share', { configurable: true, value: mocks.share });
@@ -251,6 +253,35 @@ describe('DebateCoordinator', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Done' }));
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
     expect(mocks.handleMutate).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not reopen a cached share prompt after an active debate flow', async () => {
+    showSharePrompt();
+    mockArtifactUrls();
+    const view = render(<DebateCoordinator />);
+
+    expect(await screen.findByRole('dialog')).toBeInTheDocument();
+
+    mocks.activity = activityWithMatch();
+    view.rerender(<DebateCoordinator />);
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+
+    mocks.activity = {
+      online: true,
+      available_to_debate: true,
+      cooldown_until: null,
+      match: null,
+      debate: null,
+      rematch: null,
+    };
+    mocks.promptsFetching = true;
+    view.rerender(<DebateCoordinator />);
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+
+    mocks.prompts = [];
+    mocks.promptsFetching = false;
+    view.rerender(<DebateCoordinator />);
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
   });
 
   it('keeps the prompt open when the native share sheet is cancelled', async () => {

--- a/apps/web/core/debates/debate-coordinator.test.tsx
+++ b/apps/web/core/debates/debate-coordinator.test.tsx
@@ -184,8 +184,8 @@ describe('DebateCoordinator', () => {
 
     render(<DebateCoordinator />);
 
-    expect(await screen.findByAltText('Social video preview for Debates are useful')).toHaveAttribute(
-      'src',
+    expect(await screen.findByLabelText('Social video for Debates are useful')).toHaveAttribute(
+      'poster',
       'https://video.test/social-preview.jpg'
     );
     expect(mocks.mediaMutate).toHaveBeenCalledWith(
@@ -202,6 +202,20 @@ describe('DebateCoordinator', () => {
 
     resolveDownload?.(videoResponse());
     expect(await screen.findByRole('button', { name: 'Download video' })).toBeEnabled();
+  });
+
+  it('allows the social video to play while share preparation is still in progress', async () => {
+    showSharePrompt();
+    mockArtifactUrls();
+    mocks.fetch.mockReturnValue(new Promise(() => undefined));
+
+    render(<DebateCoordinator />);
+
+    const player = await screen.findByLabelText('Social video for Debates are useful');
+    expect(player).toBeInstanceOf(HTMLVideoElement);
+    expect(player).toHaveAttribute('src', 'https://video.test/social.mp4');
+    expect(player).toHaveAttribute('controls');
+    expect(screen.getByRole('button', { name: 'Preparing video…' })).toBeDisabled();
   });
 
   it('shares only the prepared MP4 and claim through the native share sheet', async () => {
@@ -276,6 +290,9 @@ describe('DebateCoordinator', () => {
     fireEvent.click(await screen.findByRole('button', { name: 'Download video' }));
 
     expect(mocks.downloadClick).toHaveBeenCalledTimes(1);
+    const downloadLink = mocks.downloadClick.mock.instances[0] as HTMLAnchorElement;
+    expect(downloadLink.href).toBe('blob:https://geo.test/social-video');
+    expect(downloadLink.download).toBe('debate-debate-1-social.mp4');
     expect(mocks.share).not.toHaveBeenCalled();
     expect(mocks.capture).toHaveBeenCalledWith('debate_social_video_handoff_resolved', {
       debate_id: 'debate-1',
@@ -301,6 +318,34 @@ describe('DebateCoordinator', () => {
 
     expect(await screen.findByRole('button', { name: 'Download video' })).toBeEnabled();
     expect(mocks.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps active playback mounted while retrying share preparation', async () => {
+    showSharePrompt();
+    let socialVideoRequests = 0;
+    mocks.mediaMutate.mockImplementation((variables, options) => {
+      if (variables.request.kind === 'social_preview_image') {
+        options.onSuccess({ upload: { url: 'https://video.test/social-preview.jpg' } });
+        return;
+      }
+      socialVideoRequests += 1;
+      if (socialVideoRequests === 1) {
+        options.onSuccess({ upload: { url: 'https://video.test/social.mp4' } });
+      }
+    });
+    mocks.fetch.mockRejectedValueOnce(new Error('Network interrupted'));
+
+    render(<DebateCoordinator />);
+
+    expect(await screen.findByText('Network interrupted')).toBeInTheDocument();
+    const player = screen.getByLabelText('Social video for Debates are useful') as HTMLVideoElement;
+    player.currentTime = 23;
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry preparation' }));
+    await waitFor(() => expect(socialVideoRequests).toBe(2));
+
+    expect(screen.getByLabelText('Social video for Debates are useful')).toBe(player);
+    expect(player.currentTime).toBe(23);
   });
 
   it('revokes prepared playback URLs when the prompt closes', async () => {

--- a/apps/web/core/debates/debate-coordinator.test.tsx
+++ b/apps/web/core/debates/debate-coordinator.test.tsx
@@ -227,7 +227,7 @@ describe('DebateCoordinator', () => {
       throw new Error('Analytics unavailable');
     });
 
-    render(<DebateCoordinator />);
+    const view = render(<DebateCoordinator />);
     fireEvent.click(await screen.findByRole('button', { name: 'Share video' }));
 
     const file = mocks.canShare.mock.calls.at(-1)?.[0].files[0] as File;
@@ -244,6 +244,13 @@ describe('DebateCoordinator', () => {
       });
       expect(mocks.handleMutate).toHaveBeenCalledWith({ promptId: 'prompt-1', action: 'shared' }, expect.any(Object));
     });
+
+    mocks.prompts = [];
+    view.rerender(<DebateCoordinator />);
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Done' }));
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(mocks.handleMutate).toHaveBeenCalledTimes(1);
   });
 
   it('keeps the prompt open when the native share sheet is cancelled', async () => {
@@ -286,7 +293,7 @@ describe('DebateCoordinator', () => {
     mockArtifactUrls();
     mocks.canShare.mockReturnValue(false);
 
-    render(<DebateCoordinator />);
+    const view = render(<DebateCoordinator />);
     fireEvent.click(await screen.findByRole('button', { name: 'Download video' }));
 
     expect(mocks.downloadClick).toHaveBeenCalledTimes(1);
@@ -299,6 +306,13 @@ describe('DebateCoordinator', () => {
       method: 'download',
     });
     expect(mocks.handleMutate).toHaveBeenCalledWith({ promptId: 'prompt-1', action: 'shared' }, expect.any(Object));
+
+    mocks.prompts = [];
+    view.rerender(<DebateCoordinator />);
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Done' }));
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(mocks.handleMutate).toHaveBeenCalledTimes(1);
   });
 
   it('shows a retryable preparation error and retries the same social MP4', async () => {
@@ -427,7 +441,9 @@ describe('DebateCoordinator', () => {
     ).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: 'Finish sharing' }));
 
-    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+    expect(await screen.findByRole('button', { name: 'Done' })).toBeEnabled();
+    fireEvent.click(screen.getByRole('button', { name: 'Done' }));
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
     expect(mocks.share).toHaveBeenCalledTimes(1);
     expect(mocks.handleMutate).toHaveBeenCalledTimes(2);
   });

--- a/apps/web/core/debates/debate-coordinator.test.tsx
+++ b/apps/web/core/debates/debate-coordinator.test.tsx
@@ -13,9 +13,13 @@ const mocks = vi.hoisted(() => ({
   prompts: [] as DebateSharePrompt[],
   mediaMutate: vi.fn(),
   handleMutate: vi.fn(),
-  clipboardWrite: vi.fn(),
-  play: vi.fn(() => Promise.resolve()),
-  pause: vi.fn(),
+  fetch: vi.fn(),
+  share: vi.fn(),
+  canShare: vi.fn(),
+  createObjectURL: vi.fn(() => 'blob:https://geo.test/social-video'),
+  revokeObjectURL: vi.fn(),
+  downloadClick: vi.fn(),
+  capture: vi.fn(),
   authenticated: true,
   gatewayPaused: false,
 }));
@@ -24,6 +28,8 @@ vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: mocks.push }),
   usePathname: () => mocks.pathname,
 }));
+
+vi.mock('~/core/analytics', () => ({ capture: mocks.capture }));
 
 vi.mock('./hooks', () => ({
   useGeoChatAuth: () => ({ ready: true, authenticated: mocks.authenticated, getPrivyIdentityToken: vi.fn() }),
@@ -49,27 +55,36 @@ beforeEach(() => {
   mocks.push.mockReset();
   mocks.mediaMutate.mockReset();
   mocks.handleMutate.mockReset();
-  mocks.clipboardWrite.mockReset();
-  mocks.play.mockClear();
-  mocks.pause.mockClear();
+  mocks.handleMutate.mockImplementation((_variables, options) => options?.onSuccess?.());
+  mocks.fetch.mockReset();
+  mocks.share.mockReset();
+  mocks.canShare.mockReset();
+  mocks.createObjectURL.mockClear();
+  mocks.revokeObjectURL.mockClear();
+  mocks.downloadClick.mockClear();
+  mocks.capture.mockReset();
   mocks.activity = null;
   mocks.pathname = '/space/space-1/debates';
   mocks.prompts = [];
   mocks.authenticated = true;
   mocks.gatewayPaused = false;
-  Object.defineProperty(navigator, 'clipboard', {
+  Object.defineProperty(navigator, 'share', { configurable: true, value: mocks.share });
+  Object.defineProperty(navigator, 'canShare', { configurable: true, value: mocks.canShare });
+  Object.defineProperty(URL, 'createObjectURL', {
     configurable: true,
-    value: { writeText: mocks.clipboardWrite },
+    value: mocks.createObjectURL,
   });
-  Object.defineProperty(navigator, 'share', { configurable: true, value: undefined });
-  Object.defineProperty(HTMLMediaElement.prototype, 'play', {
+  Object.defineProperty(URL, 'revokeObjectURL', {
     configurable: true,
-    value: mocks.play,
+    value: mocks.revokeObjectURL,
   });
-  Object.defineProperty(HTMLMediaElement.prototype, 'pause', {
+  Object.defineProperty(HTMLAnchorElement.prototype, 'click', {
     configurable: true,
-    value: mocks.pause,
+    value: mocks.downloadClick,
   });
+  vi.stubGlobal('fetch', mocks.fetch);
+  mocks.canShare.mockReturnValue(false);
+  mocks.fetch.mockResolvedValue(videoResponse());
 });
 
 afterEach(cleanup);
@@ -155,81 +170,297 @@ describe('DebateCoordinator', () => {
     await waitFor(() => expect(mocks.push).not.toHaveBeenCalled());
   });
 
-  it('copies a stable recording link when native sharing is unavailable', async () => {
-    mocks.activity = {
-      online: true,
-      available_to_debate: true,
-      cooldown_until: null,
-      match: null,
-      debate: null,
-      rematch: null,
-    };
-    mocks.prompts = [
-      {
-        id: 'prompt-1',
-        debate_id: 'debate-1',
-        source_space_id: 'space-1',
-        claim: 'Debates are useful',
-        created_at: '2026-07-02T00:00:00.000Z',
-      },
-    ];
+  it('requests the exact social preview and starts preparing the MP4 on open', async () => {
+    showSharePrompt();
+    let resolveDownload: ((response: Response) => void) | undefined;
+    mocks.fetch.mockReturnValue(new Promise(resolve => (resolveDownload = resolve)));
     mocks.mediaMutate.mockImplementation((variables, options) => {
       const url =
-        variables.request.kind === 'preview_image' ? 'https://video.test/preview.jpg' : 'https://video.test/final.mp4';
+        variables.request.kind === 'social_preview_image'
+          ? 'https://video.test/social-preview.jpg'
+          : 'https://video.test/social.mp4';
       options.onSuccess({ upload: { url } });
     });
-    mocks.clipboardWrite.mockResolvedValue(undefined);
 
     render(<DebateCoordinator />);
-    fireEvent.click(await screen.findByRole('button', { name: 'Share' }));
 
-    await waitFor(() =>
-      expect(mocks.clipboardWrite).toHaveBeenCalledWith(
-        `${window.location.origin}/space/space-1/debates/debate-1/recording`
-      )
+    expect(await screen.findByAltText('Social video preview for Debates are useful')).toHaveAttribute(
+      'src',
+      'https://video.test/social-preview.jpg'
     );
-    expect(mocks.handleMutate).toHaveBeenCalledWith({ promptId: 'prompt-1', action: 'shared' });
+    expect(mocks.mediaMutate).toHaveBeenCalledWith(
+      { debateId: 'debate-1', request: { kind: 'social_preview_image' } },
+      expect.any(Object)
+    );
+    expect(mocks.mediaMutate).toHaveBeenCalledWith(
+      { debateId: 'debate-1', request: { kind: 'social_video' } },
+      expect.any(Object)
+    );
+    expect(mocks.fetch).toHaveBeenCalledWith('https://video.test/social.mp4', { signal: expect.any(AbortSignal) });
+    expect(screen.getAllByText('Preparing video…')).toHaveLength(2);
+    expect(screen.getByRole('progressbar', { name: 'Preparing social video' })).not.toHaveAttribute('aria-valuenow');
+
+    resolveDownload?.(videoResponse());
+    expect(await screen.findByRole('button', { name: 'Download video' })).toBeEnabled();
   });
 
-  it('uses the generated preview and loads the share video only after play', async () => {
-    mocks.activity = {
-      online: true,
-      available_to_debate: true,
-      cooldown_until: null,
-      match: null,
-      debate: null,
-      rematch: null,
-    };
-    mocks.prompts = [
-      {
-        id: 'prompt-1',
-        debate_id: 'debate-1',
-        source_space_id: 'space-1',
-        claim: 'Debates are useful',
-        created_at: '2026-07-02T00:00:00.000Z',
-      },
-    ];
-    mocks.mediaMutate.mockImplementation((variables, options) => {
-      const url =
-        variables.request.kind === 'preview_image' ? 'https://video.test/preview.jpg' : 'https://video.test/final.mp4';
-      options.onSuccess({ upload: { url } });
+  it('shares only the prepared MP4 and claim through the native share sheet', async () => {
+    showSharePrompt();
+    mockArtifactUrls();
+    mocks.canShare.mockReturnValue(true);
+    mocks.share.mockResolvedValue(undefined);
+    mocks.capture.mockImplementation(() => {
+      throw new Error('Analytics unavailable');
     });
 
-    const { container } = render(<DebateCoordinator />);
+    render(<DebateCoordinator />);
+    fireEvent.click(await screen.findByRole('button', { name: 'Share video' }));
 
+    const file = mocks.canShare.mock.calls.at(-1)?.[0].files[0] as File;
+    expect(file).toBeInstanceOf(File);
+    expect(file.name).toBe('debate-debate-1-social.mp4');
+    expect(file.type).toBe('video/mp4');
+    expect(mocks.share).toHaveBeenCalledWith({ title: 'Debates are useful', files: [file] });
+    expect(mocks.share.mock.calls[0]?.[0]).not.toHaveProperty('url');
+    expect(mocks.share.mock.calls[0]?.[0]).not.toHaveProperty('text');
+    await waitFor(() => {
+      expect(mocks.capture).toHaveBeenCalledWith('debate_social_video_handoff_resolved', {
+        debate_id: 'debate-1',
+        method: 'native_share',
+      });
+      expect(mocks.handleMutate).toHaveBeenCalledWith({ promptId: 'prompt-1', action: 'shared' }, expect.any(Object));
+    });
+  });
+
+  it('keeps the prompt open when the native share sheet is cancelled', async () => {
+    showSharePrompt();
+    mockArtifactUrls();
+    mocks.canShare.mockReturnValue(true);
+    mocks.share.mockRejectedValue(new DOMException('Cancelled', 'AbortError'));
+
+    render(<DebateCoordinator />);
+    fireEvent.click(await screen.findByRole('button', { name: 'Share video' }));
+
+    await waitFor(() => expect(mocks.share).toHaveBeenCalled());
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(mocks.handleMutate).not.toHaveBeenCalledWith({ promptId: 'prompt-1', action: 'shared' });
+    expect(screen.queryByText('Cancelled')).not.toBeInTheDocument();
+  });
+
+  it('shows sharing failures without handling the prompt and allows retry', async () => {
+    showSharePrompt();
+    mockArtifactUrls();
+    mocks.canShare.mockReturnValue(true);
+    mocks.share.mockRejectedValueOnce(new Error('Share service unavailable')).mockResolvedValueOnce(undefined);
+
+    render(<DebateCoordinator />);
+    const shareButton = await screen.findByRole('button', { name: 'Share video' });
+    fireEvent.click(shareButton);
+
+    expect(await screen.findByText('Share service unavailable')).toBeInTheDocument();
+    expect(mocks.handleMutate).not.toHaveBeenCalledWith({ promptId: 'prompt-1', action: 'shared' });
+
+    fireEvent.click(shareButton);
     await waitFor(() =>
-      expect(container.querySelector('video')).toHaveAttribute('poster', 'https://video.test/preview.jpg')
+      expect(mocks.handleMutate).toHaveBeenCalledWith({ promptId: 'prompt-1', action: 'shared' }, expect.any(Object))
     );
-    expect(mocks.mediaMutate.mock.calls.some(([variables]) => variables.request.kind === 'final_video')).toBe(false);
+    expect(mocks.share).toHaveBeenCalledTimes(2);
+  });
 
-    fireEvent.click(screen.getByRole('button', { name: 'Play Processed video for Debates are useful' }));
+  it('downloads the prepared MP4 when browser file sharing is unsupported', async () => {
+    showSharePrompt();
+    mockArtifactUrls();
+    mocks.canShare.mockReturnValue(false);
 
-    await waitFor(() =>
-      expect(container.querySelector('video')).toHaveAttribute('src', 'https://video.test/final.mp4')
-    );
-    expect(mocks.play).toHaveBeenCalledTimes(1);
+    render(<DebateCoordinator />);
+    fireEvent.click(await screen.findByRole('button', { name: 'Download video' }));
+
+    expect(mocks.downloadClick).toHaveBeenCalledTimes(1);
+    expect(mocks.share).not.toHaveBeenCalled();
+    expect(mocks.capture).toHaveBeenCalledWith('debate_social_video_handoff_resolved', {
+      debate_id: 'debate-1',
+      method: 'download',
+    });
+    expect(mocks.handleMutate).toHaveBeenCalledWith({ promptId: 'prompt-1', action: 'shared' }, expect.any(Object));
+  });
+
+  it('shows a retryable preparation error and retries the same social MP4', async () => {
+    showSharePrompt();
+    mockArtifactUrls();
+    mocks.fetch.mockRejectedValueOnce(new Error('Network interrupted')).mockResolvedValueOnce(videoResponse());
+
+    render(<DebateCoordinator />);
+
+    expect(await screen.findByText('Network interrupted')).toBeInTheDocument();
+    expect(mocks.capture).toHaveBeenCalledWith('debate_social_video_preparation_failed', {
+      debate_id: 'debate-1',
+      stage: 'video_download',
+      error_name: 'Error',
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Retry preparation' }));
+
+    expect(await screen.findByRole('button', { name: 'Download video' })).toBeEnabled();
+    expect(mocks.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('revokes prepared playback URLs when the prompt closes', async () => {
+    showSharePrompt();
+    mockArtifactUrls();
+
+    const { rerender } = render(<DebateCoordinator />);
+    await screen.findByRole('button', { name: 'Download video' });
+    fireEvent.click(screen.getByRole('button', { name: 'Close share prompt' }));
+
+    rerender(<DebateCoordinator />);
+    await waitFor(() => expect(mocks.revokeObjectURL).toHaveBeenCalledWith('blob:https://geo.test/social-video'));
+    expect(document.body.style.overflow).toBe('');
+    expect(document.documentElement.style.overflow).toBe('');
+    expect(mocks.handleMutate).toHaveBeenCalledWith({ promptId: 'prompt-1', action: 'dismissed' }, expect.any(Object));
+  });
+
+  it('uses download fallback when the browser capability probe throws', async () => {
+    showSharePrompt();
+    mockArtifactUrls();
+    mocks.canShare.mockImplementation(() => {
+      throw new TypeError('Unsupported share payload');
+    });
+
+    render(<DebateCoordinator />);
+
+    expect(await screen.findByRole('button', { name: 'Download video' })).toBeEnabled();
+  });
+
+  it('aborts an in-flight MP4 download when the prompt closes', async () => {
+    showSharePrompt();
+    mockArtifactUrls();
+    let downloadSignal: AbortSignal | undefined;
+    mocks.fetch.mockImplementation((_url, init) => {
+      downloadSignal = init.signal;
+      return new Promise(() => undefined);
+    });
+
+    render(<DebateCoordinator />);
+    await waitFor(() => expect(downloadSignal).toBeDefined());
+    fireEvent.click(screen.getByRole('button', { name: 'Close share prompt' }));
+
+    await waitFor(() => expect(downloadSignal?.aborted).toBe(true));
+  });
+
+  it('prevents duplicate native share requests while the share sheet is open', async () => {
+    showSharePrompt();
+    mockArtifactUrls();
+    mocks.canShare.mockReturnValue(true);
+    let resolveShare: (() => void) | undefined;
+    mocks.share.mockReturnValue(new Promise<void>(resolve => (resolveShare = resolve)));
+
+    render(<DebateCoordinator />);
+    const shareButton = await screen.findByRole('button', { name: 'Share video' });
+    fireEvent.click(shareButton);
+    fireEvent.click(shareButton);
+
+    expect(mocks.share).toHaveBeenCalledTimes(1);
+    expect(await screen.findByRole('button', { name: 'Sharing…' })).toBeDisabled();
+
+    resolveShare?.();
+    await waitFor(() => expect(mocks.handleMutate).toHaveBeenCalledTimes(1));
+  });
+
+  it('retries prompt completion without sharing the video a second time', async () => {
+    showSharePrompt();
+    mockArtifactUrls();
+    mocks.canShare.mockReturnValue(true);
+    mocks.share.mockResolvedValue(undefined);
+    mocks.handleMutate
+      .mockImplementationOnce((_variables, options) => options?.onError?.(new Error('Network unavailable')))
+      .mockImplementationOnce((_variables, options) => options?.onSuccess?.());
+
+    render(<DebateCoordinator />);
+    fireEvent.click(await screen.findByRole('button', { name: 'Share video' }));
+
+    expect(
+      await screen.findByText("The video was handed off, but Geo couldn't finish updating this prompt. Try again.")
+    ).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Finish sharing' }));
+
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+    expect(mocks.share).toHaveBeenCalledTimes(1);
+    expect(mocks.handleMutate).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps the prompt visible when dismissing it fails and allows retry', async () => {
+    showSharePrompt();
+    mockArtifactUrls();
+    mocks.handleMutate
+      .mockImplementationOnce((_variables, options) => options?.onError?.(new Error('Network unavailable')))
+      .mockImplementationOnce((_variables, options) => options?.onSuccess?.());
+
+    render(<DebateCoordinator />);
+    fireEvent.click(screen.getByRole('button', { name: 'Close share prompt' }));
+
+    expect(await screen.findByText('Could not dismiss the share prompt. Try again.')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Close share prompt' }));
+
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+    expect(mocks.handleMutate).toHaveBeenCalledTimes(2);
+  });
+
+  it('prevents duplicate prompt mutations while dismissal is in flight', async () => {
+    showSharePrompt();
+    mockArtifactUrls();
+    let completeDismissal: (() => void) | undefined;
+    mocks.handleMutate.mockImplementation((_variables, options) => {
+      completeDismissal = options?.onSuccess;
+    });
+
+    render(<DebateCoordinator />);
+    const closeButton = screen.getByRole('button', { name: 'Close share prompt' });
+    fireEvent.click(closeButton);
+    fireEvent.click(closeButton);
+
+    expect(mocks.handleMutate).toHaveBeenCalledTimes(1);
+    expect(closeButton).toBeDisabled();
+
+    completeDismissal?.();
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
   });
 });
+
+function showSharePrompt() {
+  mocks.activity = {
+    online: true,
+    available_to_debate: true,
+    cooldown_until: null,
+    match: null,
+    debate: null,
+    rematch: null,
+  };
+  mocks.prompts = [
+    {
+      id: 'prompt-1',
+      debate_id: 'debate-1',
+      source_space_id: 'space-1',
+      claim: 'Debates are useful',
+      created_at: '2026-07-02T00:00:00.000Z',
+    },
+  ];
+}
+
+function mockArtifactUrls() {
+  mocks.mediaMutate.mockImplementation((variables, options) => {
+    const url =
+      variables.request.kind === 'social_preview_image'
+        ? 'https://video.test/social-preview.jpg'
+        : 'https://video.test/social.mp4';
+    options.onSuccess({ upload: { url } });
+  });
+}
+
+function videoResponse() {
+  return new Response(new Uint8Array([1, 2, 3, 4]), {
+    status: 200,
+    headers: { 'content-type': 'video/mp4', 'content-length': '4' },
+  });
+}
 
 function activityWithRematch(status: 'deciding' | 'browsing'): DebateActivity {
   return {

--- a/apps/web/core/debates/debate-coordinator.tsx
+++ b/apps/web/core/debates/debate-coordinator.tsx
@@ -11,7 +11,7 @@ import { Upload } from '~/design-system/icons/upload';
 import { Spinner } from '~/design-system/spinner';
 import { Text } from '~/design-system/text';
 
-import type { DebateMatch } from './api';
+import type { DebateMatch, DebateSharePrompt } from './api';
 import { useDebateGateway } from './debate-gateway';
 import { useDebateActivity, useDebateSharePrompts, useGeoChatAuth, useHandleDebateSharePrompt } from './hooks';
 import { DebateMatchPrompt } from './match-prompt';
@@ -41,6 +41,14 @@ export function DebateCoordinator() {
   const visibleMatch = match ?? retainedMatch;
   const activeFlow = Boolean(match || debate || activity?.rematch);
   const sharePromptsQuery = useDebateSharePrompts(Boolean(activity) && !activeFlow);
+  const queriedSharePrompt = sharePromptsQuery.data?.prompts[0] ?? null;
+  const [retainedSharePrompt, setRetainedSharePrompt] = React.useState<DebateSharePrompt | null>(null);
+  const [closedSharePromptId, setClosedSharePromptId] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    if (!queriedSharePrompt || retainedSharePrompt || queriedSharePrompt.id === closedSharePromptId) return;
+    setRetainedSharePrompt(queriedSharePrompt);
+  }, [closedSharePromptId, queriedSharePrompt, retainedSharePrompt]);
 
   React.useEffect(() => {
     if (match) {
@@ -78,6 +86,8 @@ export function DebateCoordinator() {
   }, [activity, debate, pathname, router, visibleMatch]);
 
   if (!isDebatesEnabled) return null;
+  const visibleSharePrompt =
+    retainedSharePrompt ?? (queriedSharePrompt?.id === closedSharePromptId ? null : queriedSharePrompt);
 
   return (
     <>
@@ -97,11 +107,15 @@ export function DebateCoordinator() {
           debates={debate ? [debate] : []}
         />
       )}
-      {!activeFlow && sharePromptsQuery.data?.prompts[0] && (
+      {!activeFlow && visibleSharePrompt && (
         <DebateSharePromptDialog
-          key={sharePromptsQuery.data.prompts[0].id}
-          prompt={sharePromptsQuery.data.prompts[0]}
-          stackCount={sharePromptsQuery.data.prompts.length}
+          key={visibleSharePrompt.id}
+          prompt={visibleSharePrompt}
+          stackCount={sharePromptsQuery.data?.prompts.length ?? 1}
+          onClose={() => {
+            setClosedSharePromptId(visibleSharePrompt.id);
+            setRetainedSharePrompt(null);
+          }}
         />
       )}
     </>
@@ -111,22 +125,23 @@ export function DebateCoordinator() {
 function DebateSharePromptDialog({
   prompt,
   stackCount,
+  onClose,
 }: {
   prompt: { id: string; debate_id: string; source_space_id: string; claim: string };
   stackCount: number;
+  onClose: () => void;
 }) {
   const handlePrompt = useHandleDebateSharePrompt();
-  const [visible, setVisible] = React.useState(true);
   const [shareError, setShareError] = React.useState<string | null>(null);
   const [isSharing, setIsSharing] = React.useState(false);
   const [isUpdatingPrompt, setIsUpdatingPrompt] = React.useState(false);
   const [handoffCompleted, setHandoffCompleted] = React.useState(false);
+  const [promptHandled, setPromptHandled] = React.useState(false);
   const sharingRef = React.useRef(false);
   const promptActionRef = React.useRef(false);
-  const preparedVideo = usePreparedSocialVideo(prompt.debate_id, visible);
+  const preparedVideo = usePreparedSocialVideo(prompt.debate_id, true);
 
   React.useEffect(() => {
-    if (!visible) return;
     const previousBodyOverflow = document.body.style.overflow;
     const previousDocumentOverflow = document.documentElement.style.overflow;
     document.body.style.overflow = 'hidden';
@@ -135,11 +150,12 @@ function DebateSharePromptDialog({
       document.body.style.overflow = previousBodyOverflow;
       document.documentElement.style.overflow = previousDocumentOverflow;
     };
-  }, [visible]);
+  }, []);
 
-  if (!visible) return null;
-
-  const finishPrompt = (action: 'shared' | 'dismissed') => {
+  const closeDialog = () => {
+    onClose();
+  };
+  const finishPrompt = (action: 'shared' | 'dismissed', keepOpen = false) => {
     if (promptActionRef.current) return;
     promptActionRef.current = true;
     setIsUpdatingPrompt(true);
@@ -150,7 +166,8 @@ function DebateSharePromptDialog({
         onSuccess: () => {
           promptActionRef.current = false;
           setIsUpdatingPrompt(false);
-          setVisible(false);
+          if (action === 'shared') setPromptHandled(true);
+          if (!keepOpen) closeDialog();
         },
         onError: () => {
           promptActionRef.current = false;
@@ -165,12 +182,17 @@ function DebateSharePromptDialog({
     );
   };
   const dismiss = () => {
+    if (promptHandled) {
+      closeDialog();
+      return;
+    }
     finishPrompt(handoffCompleted ? 'shared' : 'dismissed');
   };
   const canShareFile = preparedVideo.file ? canNativeShareFile(preparedVideo.file) : false;
   const share = async () => {
     if (handoffCompleted) {
-      finishPrompt('shared');
+      if (promptHandled) closeDialog();
+      else finishPrompt('shared', true);
       return;
     }
     if (!preparedVideo.file || !preparedVideo.downloadUrl) return;
@@ -189,7 +211,7 @@ function DebateSharePromptDialog({
         method: canShareFile ? 'native_share' : 'download',
       });
       setHandoffCompleted(true);
-      finishPrompt('shared');
+      finishPrompt('shared', true);
     } catch (error) {
       if (isAbortError(error)) return;
       captureSocialVideoEvent('debate_social_video_handoff_failed', {
@@ -208,7 +230,9 @@ function DebateSharePromptDialog({
     : isUpdatingPrompt
       ? 'Finishing…'
       : handoffCompleted
-        ? 'Finish sharing'
+        ? promptHandled
+          ? 'Done'
+          : 'Finish sharing'
         : preparedVideo.status !== 'ready'
           ? 'Preparing video…'
           : canShareFile

--- a/apps/web/core/debates/debate-coordinator.tsx
+++ b/apps/web/core/debates/debate-coordinator.tsx
@@ -173,7 +173,7 @@ function DebateSharePromptDialog({
       finishPrompt('shared');
       return;
     }
-    if (!preparedVideo.file || !preparedVideo.playbackUrl) return;
+    if (!preparedVideo.file || !preparedVideo.downloadUrl) return;
     if (sharingRef.current) return;
     sharingRef.current = true;
     setIsSharing(true);
@@ -182,7 +182,7 @@ function DebateSharePromptDialog({
       if (canShareFile) {
         await navigator.share({ title: prompt.claim, files: [preparedVideo.file] });
       } else {
-        downloadPreparedVideo(preparedVideo.playbackUrl, preparedVideo.file.name);
+        downloadPreparedVideo(preparedVideo.downloadUrl, preparedVideo.file.name);
       }
       captureSocialVideoEvent('debate_social_video_handoff_resolved', {
         debate_id: prompt.debate_id,

--- a/apps/web/core/debates/debate-coordinator.tsx
+++ b/apps/web/core/debates/debate-coordinator.tsx
@@ -41,7 +41,8 @@ export function DebateCoordinator() {
   const visibleMatch = match ?? retainedMatch;
   const activeFlow = Boolean(match || debate || activity?.rematch);
   const sharePromptsQuery = useDebateSharePrompts(Boolean(activity) && !activeFlow);
-  const queriedSharePrompt = sharePromptsQuery.data?.prompts[0] ?? null;
+  const queriedSharePrompt =
+    activeFlow || sharePromptsQuery.isFetching ? null : (sharePromptsQuery.data?.prompts[0] ?? null);
   const [retainedSharePrompt, setRetainedSharePrompt] = React.useState<DebateSharePrompt | null>(null);
   const [closedSharePromptId, setClosedSharePromptId] = React.useState<string | null>(null);
 
@@ -49,6 +50,10 @@ export function DebateCoordinator() {
     if (!queriedSharePrompt || retainedSharePrompt || queriedSharePrompt.id === closedSharePromptId) return;
     setRetainedSharePrompt(queriedSharePrompt);
   }, [closedSharePromptId, queriedSharePrompt, retainedSharePrompt]);
+
+  React.useEffect(() => {
+    if (activeFlow) setRetainedSharePrompt(null);
+  }, [activeFlow]);
 
   React.useEffect(() => {
     if (match) {

--- a/apps/web/core/debates/debate-coordinator.tsx
+++ b/apps/web/core/debates/debate-coordinator.tsx
@@ -8,13 +8,14 @@ import { useDebatesEnabled } from '~/core/state/feature-flags';
 
 import { Button } from '~/design-system/button';
 import { Upload } from '~/design-system/icons/upload';
+import { Spinner } from '~/design-system/spinner';
 import { Text } from '~/design-system/text';
 
 import type { DebateMatch } from './api';
 import { useDebateGateway } from './debate-gateway';
 import { useDebateActivity, useDebateSharePrompts, useGeoChatAuth, useHandleDebateSharePrompt } from './hooks';
 import { DebateMatchPrompt } from './match-prompt';
-import { ProcessedDebatePlayer } from './processed-debate-player';
+import { captureSocialVideoEvent, isAbortError, usePreparedSocialVideo } from './social-video-share';
 
 export function DebateCoordinator() {
   const router = useRouter();
@@ -115,13 +116,17 @@ function DebateSharePromptDialog({
   stackCount: number;
 }) {
   const handlePrompt = useHandleDebateSharePrompt();
+  const [visible, setVisible] = React.useState(true);
   const [shareError, setShareError] = React.useState<string | null>(null);
-  const publicUrl =
-    typeof window === 'undefined'
-      ? ''
-      : `${window.location.origin}/space/${prompt.source_space_id}/debates/${prompt.debate_id}/recording`;
+  const [isSharing, setIsSharing] = React.useState(false);
+  const [isUpdatingPrompt, setIsUpdatingPrompt] = React.useState(false);
+  const [handoffCompleted, setHandoffCompleted] = React.useState(false);
+  const sharingRef = React.useRef(false);
+  const promptActionRef = React.useRef(false);
+  const preparedVideo = usePreparedSocialVideo(prompt.debate_id, visible);
 
   React.useEffect(() => {
+    if (!visible) return;
     const previousBodyOverflow = document.body.style.overflow;
     const previousDocumentOverflow = document.documentElement.style.overflow;
     document.body.style.overflow = 'hidden';
@@ -130,23 +135,85 @@ function DebateSharePromptDialog({
       document.body.style.overflow = previousBodyOverflow;
       document.documentElement.style.overflow = previousDocumentOverflow;
     };
-  }, []);
+  }, [visible]);
 
-  const dismiss = () => handlePrompt.mutate({ promptId: prompt.id, action: 'dismissed' });
+  if (!visible) return null;
+
+  const finishPrompt = (action: 'shared' | 'dismissed') => {
+    if (promptActionRef.current) return;
+    promptActionRef.current = true;
+    setIsUpdatingPrompt(true);
+    setShareError(null);
+    handlePrompt.mutate(
+      { promptId: prompt.id, action },
+      {
+        onSuccess: () => {
+          promptActionRef.current = false;
+          setIsUpdatingPrompt(false);
+          setVisible(false);
+        },
+        onError: () => {
+          promptActionRef.current = false;
+          setIsUpdatingPrompt(false);
+          setShareError(
+            action === 'shared'
+              ? "The video was handed off, but Geo couldn't finish updating this prompt. Try again."
+              : 'Could not dismiss the share prompt. Try again.'
+          );
+        },
+      }
+    );
+  };
+  const dismiss = () => {
+    finishPrompt(handoffCompleted ? 'shared' : 'dismissed');
+  };
+  const canShareFile = preparedVideo.file ? canNativeShareFile(preparedVideo.file) : false;
   const share = async () => {
+    if (handoffCompleted) {
+      finishPrompt('shared');
+      return;
+    }
+    if (!preparedVideo.file || !preparedVideo.playbackUrl) return;
+    if (sharingRef.current) return;
+    sharingRef.current = true;
+    setIsSharing(true);
     setShareError(null);
     try {
-      if (navigator.share) {
-        await navigator.share({ title: prompt.claim, url: publicUrl });
+      if (canShareFile) {
+        await navigator.share({ title: prompt.claim, files: [preparedVideo.file] });
       } else {
-        await navigator.clipboard.writeText(publicUrl);
+        downloadPreparedVideo(preparedVideo.playbackUrl, preparedVideo.file.name);
       }
-      handlePrompt.mutate({ promptId: prompt.id, action: 'shared' });
+      captureSocialVideoEvent('debate_social_video_handoff_resolved', {
+        debate_id: prompt.debate_id,
+        method: canShareFile ? 'native_share' : 'download',
+      });
+      setHandoffCompleted(true);
+      finishPrompt('shared');
     } catch (error) {
-      if (error instanceof DOMException && error.name === 'AbortError') return;
-      setShareError(error instanceof Error ? error.message : 'Could not share the debate.');
+      if (isAbortError(error)) return;
+      captureSocialVideoEvent('debate_social_video_handoff_failed', {
+        debate_id: prompt.debate_id,
+        method: canShareFile ? 'native_share' : 'download',
+        error_name: error instanceof Error ? error.name : 'UnknownError',
+      });
+      setShareError(error instanceof Error ? error.message : 'Could not share the video.');
+    } finally {
+      sharingRef.current = false;
+      setIsSharing(false);
     }
   };
+  const shareButtonLabel = isSharing
+    ? 'Sharing…'
+    : isUpdatingPrompt
+      ? 'Finishing…'
+      : handoffCompleted
+        ? 'Finish sharing'
+        : preparedVideo.status !== 'ready'
+          ? 'Preparing video…'
+          : canShareFile
+            ? 'Share video'
+            : 'Download video';
 
   return (
     <div className="fixed inset-0 z-[1300] flex items-center justify-center overflow-y-auto bg-text/55 p-4 backdrop-blur-sm">
@@ -170,27 +237,74 @@ function DebateSharePromptDialog({
             type="button"
             aria-label="Close share prompt"
             onClick={dismiss}
-            disabled={handlePrompt.isPending}
+            disabled={isSharing || isUpdatingPrompt || handlePrompt.isPending}
             className="grid size-9 shrink-0 place-items-center rounded-full text-2xl text-grey-04 hover:bg-grey-02"
           >
             ×
           </button>
         </header>
 
-        <div className="mx-auto mt-5 w-full max-w-[270px] overflow-hidden rounded-lg bg-text text-white shadow-card">
-          <div className="bg-purple px-4 py-3 text-center">
-            <Text as="div" variant="smallButton" color="white">
-              Geo
-            </Text>
-            <div className="mt-1 text-[1.25rem] leading-[1.2] font-medium">{prompt.claim}</div>
-          </div>
-          <ProcessedDebatePlayer
-            debateId={prompt.debate_id}
-            label={`Processed video for ${prompt.claim}`}
-            className="w-full rounded-none shadow-none"
-          />
+        <div className="relative mx-auto mt-5 aspect-[9/16] w-full max-w-[270px] overflow-hidden rounded-lg bg-text text-white shadow-card">
+          {preparedVideo.playbackUrl ? (
+            <video
+              src={preparedVideo.playbackUrl}
+              poster={preparedVideo.previewUrl ?? undefined}
+              controls
+              playsInline
+              preload="metadata"
+              aria-label={`Social video for ${prompt.claim}`}
+              className="size-full object-contain"
+            />
+          ) : preparedVideo.previewUrl ? (
+            // The preview is extracted from the MP4, so this is the exact social composition.
+            <img
+              src={preparedVideo.previewUrl}
+              alt={`Social video preview for ${prompt.claim}`}
+              className="size-full object-cover"
+            />
+          ) : (
+            <div className="grid size-full place-items-center bg-purple px-6 text-center">
+              <Text color="white">{preparedVideo.previewFailed ? 'Preview unavailable' : 'Loading preview…'}</Text>
+            </div>
+          )}
         </div>
 
+        {preparedVideo.status === 'preparing' && (
+          <div aria-live="polite" className="mt-4">
+            <div className="flex items-center justify-center gap-2 text-center">
+              <Spinner />
+              <Text>
+                Preparing video…
+                {preparedVideo.progressPercent !== null ? ` ${preparedVideo.progressPercent}%` : ''}
+              </Text>
+            </div>
+            <div
+              role="progressbar"
+              aria-label="Preparing social video"
+              aria-valuemin={0}
+              aria-valuemax={100}
+              aria-valuenow={preparedVideo.progressPercent ?? undefined}
+              className="mt-2 h-1.5 overflow-hidden rounded-full bg-grey-02"
+            >
+              <div
+                className={`h-full rounded-full bg-purple transition-[width] ${
+                  preparedVideo.progressPercent === null ? 'w-1/3 animate-pulse' : ''
+                }`}
+                style={
+                  preparedVideo.progressPercent === null ? undefined : { width: `${preparedVideo.progressPercent}%` }
+                }
+              />
+            </div>
+          </div>
+        )}
+        {preparedVideo.error && (
+          <div className="mt-3 text-center">
+            <Text color="red-01">{preparedVideo.error}</Text>
+            <Button type="button" variant="secondary" onClick={preparedVideo.retry} className="mt-2 rounded-full">
+              Retry preparation
+            </Button>
+          </div>
+        )}
         {shareError && (
           <Text color="red-01" className="mt-3 text-center">
             {shareError}
@@ -200,14 +314,36 @@ function DebateSharePromptDialog({
           <Button
             type="button"
             onClick={share}
-            disabled={handlePrompt.isPending || !publicUrl}
+            disabled={isSharing || isUpdatingPrompt || handlePrompt.isPending || preparedVideo.status !== 'ready'}
             icon={<Upload />}
             className="gap-2 rounded-full"
           >
-            Share
+            {shareButtonLabel}
           </Button>
         </div>
       </section>
     </div>
   );
+}
+
+function downloadPreparedVideo(url: string, filename: string) {
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  link.style.display = 'none';
+  document.body.append(link);
+  link.click();
+  link.remove();
+}
+
+function canNativeShareFile(file: File) {
+  if (typeof navigator === 'undefined') return false;
+  const share = navigator.share as typeof navigator.share | undefined;
+  const canShare = navigator.canShare as typeof navigator.canShare | undefined;
+  if (typeof share !== 'function' || typeof canShare !== 'function') return false;
+  try {
+    return canShare.call(navigator, { files: [file] });
+  } catch {
+    return false;
+  }
 }

--- a/apps/web/core/debates/social-video-share.test.ts
+++ b/apps/web/core/debates/social-video-share.test.ts
@@ -64,6 +64,14 @@ describe('downloadSocialVideo', () => {
     ).rejects.toThrow('Could not download the social video (503).');
   });
 
+  it('turns browser fetch failures into an actionable preparation error', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new TypeError('Failed to fetch')));
+
+    await expect(
+      downloadSocialVideo('https://video.test/social.mp4', new AbortController().signal, vi.fn())
+    ).rejects.toThrow('Could not download the social video. Check your connection and try again.');
+  });
+
   it('rejects an empty or truncated successful response', async () => {
     vi.stubGlobal(
       'fetch',

--- a/apps/web/core/debates/social-video-share.test.ts
+++ b/apps/web/core/debates/social-video-share.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { downloadSocialVideo } from './social-video-share';
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe('downloadSocialVideo', () => {
+  it('streams the MP4 and reports determinate byte progress when content length is present', async () => {
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array([1, 2]));
+        controller.enqueue(new Uint8Array([3, 4]));
+        controller.close();
+      },
+    });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(stream, {
+          status: 200,
+          headers: { 'content-length': '4', 'content-type': 'video/mp4' },
+        })
+      )
+    );
+    const progress = vi.fn();
+
+    const blob = await downloadSocialVideo('https://video.test/social.mp4', new AbortController().signal, progress);
+
+    expect(blob.type).toBe('video/mp4');
+    expect(blob.size).toBe(4);
+    expect(progress.mock.calls.map(([value]) => value)).toEqual([
+      { receivedBytes: 0, totalBytes: 4 },
+      { receivedBytes: 2, totalBytes: 4 },
+      { receivedBytes: 4, totalBytes: 4 },
+    ]);
+  });
+
+  it('keeps progress indeterminate when content length is unavailable', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(new Uint8Array([1, 2, 3]), {
+          status: 200,
+          headers: { 'content-type': 'application/octet-stream' },
+        })
+      )
+    );
+    const progress = vi.fn();
+
+    const blob = await downloadSocialVideo('https://video.test/social.mp4', new AbortController().signal, progress);
+
+    expect(blob.type).toBe('video/mp4');
+    expect(progress.mock.calls.every(([value]) => value.totalBytes === null)).toBe(true);
+  });
+
+  it('surfaces failed downloads as retryable preparation errors', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(null, { status: 503 })));
+
+    await expect(
+      downloadSocialVideo('https://video.test/social.mp4', new AbortController().signal, vi.fn())
+    ).rejects.toThrow('Could not download the social video (503).');
+  });
+
+  it('rejects an empty or truncated successful response', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(new Uint8Array([1, 2]), {
+          status: 200,
+          headers: { 'content-length': '4', 'content-type': 'video/mp4' },
+        })
+      )
+    );
+
+    await expect(
+      downloadSocialVideo('https://video.test/social.mp4', new AbortController().signal, vi.fn())
+    ).rejects.toThrow('The social video download was incomplete.');
+  });
+
+  it('turns a stalled request into a retryable preparation error', async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((_url: string | URL | Request, init?: RequestInit) => {
+        return new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener('abort', () => reject(init.signal?.reason), { once: true });
+        });
+      })
+    );
+
+    const download = downloadSocialVideo('https://video.test/social.mp4', new AbortController().signal, vi.fn(), 1_000);
+    const rejection = expect(download).rejects.toThrow(
+      'Video preparation stalled. Check your connection and try again.'
+    );
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    await rejection;
+  });
+});

--- a/apps/web/core/debates/social-video-share.ts
+++ b/apps/web/core/debates/social-video-share.ts
@@ -236,6 +236,9 @@ export async function downloadSocialVideo(
     return new Blob(chunks, { type: 'video/mp4' });
   } catch (error) {
     if (stalled) throw new Error('Video preparation stalled. Check your connection and try again.');
+    if (error instanceof TypeError) {
+      throw new Error('Could not download the social video. Check your connection and try again.');
+    }
     throw error;
   } finally {
     if (stallTimer !== null) clearTimeout(stallTimer);

--- a/apps/web/core/debates/social-video-share.ts
+++ b/apps/web/core/debates/social-video-share.ts
@@ -1,0 +1,246 @@
+'use client';
+
+import * as React from 'react';
+
+import { capture } from '~/core/analytics';
+
+import { useDebateMediaArtifactUrl } from './hooks';
+
+type PreparationStatus = 'preparing' | 'ready' | 'error';
+
+export type PreparedSocialVideo = {
+  status: PreparationStatus;
+  previewUrl: string | null;
+  previewFailed: boolean;
+  file: File | null;
+  playbackUrl: string | null;
+  progressPercent: number | null;
+  error: string | null;
+  retry: () => void;
+};
+
+type DownloadProgress = {
+  receivedBytes: number;
+  totalBytes: number | null;
+};
+
+const SOCIAL_VIDEO_DOWNLOAD_STALL_TIMEOUT_MS = 30_000;
+
+export function usePreparedSocialVideo(debateId: string, enabled = true): PreparedSocialVideo {
+  const previewArtifact = useDebateMediaArtifactUrl();
+  const videoArtifact = useDebateMediaArtifactUrl();
+  const previewMutateRef = React.useRef(previewArtifact.mutate);
+  const videoMutateRef = React.useRef(videoArtifact.mutate);
+  const [retryCount, setRetryCount] = React.useState(0);
+  const [state, setState] = React.useState<Omit<PreparedSocialVideo, 'retry'>>({
+    status: 'preparing',
+    previewUrl: null,
+    previewFailed: false,
+    file: null,
+    playbackUrl: null,
+    progressPercent: null,
+    error: null,
+  });
+
+  React.useEffect(() => {
+    previewMutateRef.current = previewArtifact.mutate;
+  }, [previewArtifact.mutate]);
+
+  React.useEffect(() => {
+    videoMutateRef.current = videoArtifact.mutate;
+  }, [videoArtifact.mutate]);
+
+  React.useEffect(() => {
+    if (!enabled) return;
+
+    let active = true;
+    let playbackUrl: string | null = null;
+    const controller = new AbortController();
+    setState({
+      status: 'preparing',
+      previewUrl: null,
+      previewFailed: false,
+      file: null,
+      playbackUrl: null,
+      progressPercent: null,
+      error: null,
+    });
+
+    previewMutateRef.current(
+      { debateId, request: { kind: 'social_preview_image' } },
+      {
+        onSuccess: response => {
+          if (active) setState(current => ({ ...current, previewUrl: response.upload.url }));
+        },
+        onError: () => {
+          if (!active) return;
+          captureSocialVideoEvent('debate_social_video_preparation_failed', {
+            debate_id: debateId,
+            stage: 'preview_url',
+          });
+          setState(current => ({ ...current, previewFailed: true }));
+        },
+      }
+    );
+
+    videoMutateRef.current(
+      { debateId, request: { kind: 'social_video' } },
+      {
+        onSuccess: response => {
+          void downloadSocialVideo(response.upload.url, controller.signal, progress => {
+            if (!active) return;
+            const progressPercent = progress.totalBytes
+              ? Math.min(100, Math.round((progress.receivedBytes / progress.totalBytes) * 100))
+              : null;
+            setState(current =>
+              current.progressPercent === progressPercent ? current : { ...current, progressPercent }
+            );
+          })
+            .then(blob => {
+              if (!active) return;
+              const file = new File([blob], `debate-${debateId}-social.mp4`, {
+                type: 'video/mp4',
+                lastModified: Date.now(),
+              });
+              playbackUrl = URL.createObjectURL(file);
+              setState(current => ({
+                ...current,
+                status: 'ready',
+                file,
+                playbackUrl,
+                progressPercent: 100,
+                error: null,
+              }));
+            })
+            .catch(error => {
+              if (!active || isAbortError(error)) return;
+              captureSocialVideoEvent('debate_social_video_preparation_failed', {
+                debate_id: debateId,
+                stage: 'video_download',
+                error_name: error instanceof Error ? error.name : 'UnknownError',
+              });
+              setState(current => ({
+                ...current,
+                status: 'error',
+                error: error instanceof Error ? error.message : 'Could not prepare the social video.',
+              }));
+            });
+        },
+        onError: error => {
+          if (!active) return;
+          captureSocialVideoEvent('debate_social_video_preparation_failed', {
+            debate_id: debateId,
+            stage: 'video_url',
+            error_name: error instanceof Error ? error.name : 'UnknownError',
+          });
+          setState(current => ({
+            ...current,
+            status: 'error',
+            error: error instanceof Error ? error.message : 'Could not prepare the social video.',
+          }));
+        },
+      }
+    );
+
+    return () => {
+      active = false;
+      controller.abort();
+      if (playbackUrl) URL.revokeObjectURL(playbackUrl);
+    };
+  }, [debateId, enabled, retryCount]);
+
+  return {
+    ...state,
+    retry: () => setRetryCount(count => count + 1),
+  };
+}
+
+export async function downloadSocialVideo(
+  url: string,
+  signal: AbortSignal,
+  onProgress: (progress: DownloadProgress) => void,
+  stallTimeoutMs = SOCIAL_VIDEO_DOWNLOAD_STALL_TIMEOUT_MS
+): Promise<Blob> {
+  const requestController = new AbortController();
+  let stalled = false;
+  let stallTimer: ReturnType<typeof setTimeout> | null = null;
+  let reader: ReadableStreamDefaultReader<Uint8Array> | null = null;
+  const abortRequest = () => requestController.abort(signal.reason);
+  const resetStallTimer = () => {
+    if (stallTimer !== null) clearTimeout(stallTimer);
+    stallTimer = setTimeout(
+      () => {
+        stalled = true;
+        requestController.abort();
+      },
+      Math.max(1, stallTimeoutMs)
+    );
+  };
+
+  if (signal.aborted) abortRequest();
+  else signal.addEventListener('abort', abortRequest, { once: true });
+  resetStallTimer();
+
+  try {
+    const response = await fetch(url, { signal: requestController.signal });
+    resetStallTimer();
+    if (!response.ok) {
+      throw new Error(`Could not download the social video (${response.status}).`);
+    }
+
+    const totalBytesHeader = response.headers.get('content-length');
+    const parsedTotalBytes = totalBytesHeader ? Number(totalBytesHeader) : Number.NaN;
+    const totalBytes = Number.isFinite(parsedTotalBytes) && parsedTotalBytes > 0 ? parsedTotalBytes : null;
+    onProgress({ receivedBytes: 0, totalBytes });
+
+    if (!response.body) {
+      const blob = await response.blob();
+      assertCompleteVideoDownload(blob.size, totalBytes);
+      onProgress({ receivedBytes: blob.size, totalBytes });
+      return blob.type === 'video/mp4' ? blob : new Blob([blob], { type: 'video/mp4' });
+    }
+
+    reader = response.body.getReader();
+    const chunks: ArrayBuffer[] = [];
+    let receivedBytes = 0;
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      resetStallTimer();
+      if (!value) continue;
+      const chunk = new Uint8Array(value.byteLength);
+      chunk.set(value);
+      chunks.push(chunk.buffer);
+      receivedBytes += value.byteLength;
+      onProgress({ receivedBytes, totalBytes });
+    }
+
+    assertCompleteVideoDownload(receivedBytes, totalBytes);
+    return new Blob(chunks, { type: 'video/mp4' });
+  } catch (error) {
+    if (stalled) throw new Error('Video preparation stalled. Check your connection and try again.');
+    throw error;
+  } finally {
+    if (stallTimer !== null) clearTimeout(stallTimer);
+    signal.removeEventListener('abort', abortRequest);
+    reader?.releaseLock();
+  }
+}
+
+export function isAbortError(error: unknown): boolean {
+  return typeof error === 'object' && error !== null && 'name' in error && error.name === 'AbortError';
+}
+
+export function captureSocialVideoEvent(eventName: string, properties: Record<string, unknown>) {
+  try {
+    capture(eventName, properties);
+  } catch {
+    // Analytics is best-effort and must not change preparation or sharing semantics.
+  }
+}
+
+function assertCompleteVideoDownload(receivedBytes: number, totalBytes: number | null) {
+  if (receivedBytes <= 0 || (totalBytes !== null && receivedBytes !== totalBytes)) {
+    throw new Error('The social video download was incomplete.');
+  }
+}

--- a/apps/web/core/debates/social-video-share.ts
+++ b/apps/web/core/debates/social-video-share.ts
@@ -14,6 +14,7 @@ export type PreparedSocialVideo = {
   previewFailed: boolean;
   file: File | null;
   playbackUrl: string | null;
+  downloadUrl: string | null;
   progressPercent: number | null;
   error: string | null;
   retry: () => void;
@@ -26,21 +27,25 @@ type DownloadProgress = {
 
 const SOCIAL_VIDEO_DOWNLOAD_STALL_TIMEOUT_MS = 30_000;
 
+const EMPTY_PREPARED_SOCIAL_VIDEO: Omit<PreparedSocialVideo, 'retry'> = {
+  status: 'preparing',
+  previewUrl: null,
+  previewFailed: false,
+  file: null,
+  playbackUrl: null,
+  downloadUrl: null,
+  progressPercent: null,
+  error: null,
+};
+
 export function usePreparedSocialVideo(debateId: string, enabled = true): PreparedSocialVideo {
   const previewArtifact = useDebateMediaArtifactUrl();
   const videoArtifact = useDebateMediaArtifactUrl();
   const previewMutateRef = React.useRef(previewArtifact.mutate);
   const videoMutateRef = React.useRef(videoArtifact.mutate);
+  const playbackDebateIdRef = React.useRef<string | null>(null);
   const [retryCount, setRetryCount] = React.useState(0);
-  const [state, setState] = React.useState<Omit<PreparedSocialVideo, 'retry'>>({
-    status: 'preparing',
-    previewUrl: null,
-    previewFailed: false,
-    file: null,
-    playbackUrl: null,
-    progressPercent: null,
-    error: null,
-  });
+  const [state, setState] = React.useState<Omit<PreparedSocialVideo, 'retry'>>(EMPTY_PREPARED_SOCIAL_VIDEO);
 
   React.useEffect(() => {
     previewMutateRef.current = previewArtifact.mutate;
@@ -51,20 +56,27 @@ export function usePreparedSocialVideo(debateId: string, enabled = true): Prepar
   }, [videoArtifact.mutate]);
 
   React.useEffect(() => {
-    if (!enabled) return;
+    if (!enabled) {
+      playbackDebateIdRef.current = null;
+      setState(EMPTY_PREPARED_SOCIAL_VIDEO);
+      return;
+    }
 
     let active = true;
-    let playbackUrl: string | null = null;
+    let downloadUrl: string | null = null;
     const controller = new AbortController();
-    setState({
+    const retainPlayback = playbackDebateIdRef.current === debateId;
+    playbackDebateIdRef.current = debateId;
+    setState(current => ({
       status: 'preparing',
-      previewUrl: null,
+      previewUrl: retainPlayback ? current.previewUrl : null,
       previewFailed: false,
       file: null,
-      playbackUrl: null,
+      playbackUrl: retainPlayback ? current.playbackUrl : null,
+      downloadUrl: null,
       progressPercent: null,
       error: null,
-    });
+    }));
 
     previewMutateRef.current(
       { debateId, request: { kind: 'social_preview_image' } },
@@ -87,6 +99,11 @@ export function usePreparedSocialVideo(debateId: string, enabled = true): Prepar
       { debateId, request: { kind: 'social_video' } },
       {
         onSuccess: response => {
+          if (active) {
+            setState(current =>
+              current.playbackUrl ? current : { ...current, playbackUrl: response.upload.url }
+            );
+          }
           void downloadSocialVideo(response.upload.url, controller.signal, progress => {
             if (!active) return;
             const progressPercent = progress.totalBytes
@@ -102,12 +119,12 @@ export function usePreparedSocialVideo(debateId: string, enabled = true): Prepar
                 type: 'video/mp4',
                 lastModified: Date.now(),
               });
-              playbackUrl = URL.createObjectURL(file);
+              downloadUrl = URL.createObjectURL(file);
               setState(current => ({
                 ...current,
                 status: 'ready',
                 file,
-                playbackUrl,
+                downloadUrl,
                 progressPercent: 100,
                 error: null,
               }));
@@ -145,7 +162,7 @@ export function usePreparedSocialVideo(debateId: string, enabled = true): Prepar
     return () => {
       active = false;
       controller.abort();
-      if (playbackUrl) URL.revokeObjectURL(playbackUrl);
+      if (downloadUrl) URL.revokeObjectURL(downloadUrl);
     };
   }, [debateId, enabled, retryCount]);
 


### PR DESCRIPTION
## Summary

Completed debates can now be shared as dedicated branded social videos. Opening the share prompt immediately shows the exact social composition, begins preparing the MP4, and exposes video controls as soon as the signed media URL is available, so the video can play while the share file continues downloading.

Once preparation finishes, supported mobile browsers hand the MP4 to the native share sheet with the claim title only; other browsers download the same file. A successful handoff records the prompt as shared but leaves the modal open until the user explicitly presses Done or closes it, including after a failed prompt update is retried. Preparation progress, retryable failures, share-sheet cancellation, and cleanup remain explicit, and retrying preparation does not interrupt an already-playing preview.

The debate diagnostics page shows all three renditions in equal-size 16:9 viewports. Cards are capped at 320px, sit side by side when space permits, and wrap without stretching across the available width.

## Related

Related: geobrowser/geo-chat#22

The backend migration, libx264 worker deployment, and social-artifact backfill must complete before this web experience is deployed.

## Validation

- Focused social-sharing suites: 27 tests passed
- Focused debate-diagnostics suite: 20 tests passed
- Full web suite: 1,724 tests passed
- TypeScript typecheck and targeted ESLint checks passed
- Regression coverage verifies playback during preparation, native sharing and download fallback, modal retention through prompt-query invalidation, explicit closure after handoff, prompt-update retry, cancellation, stalled downloads, duplicate-action guards, cleanup, and equal-size non-stretching diagnostics cards

Physical-device acceptance on current iOS Safari and Chrome Android remains a release gate.

## Post-Deploy Monitoring & Validation

- For the first 24 hours, the Debate/web owner should monitor `debate_social_video_preparation_failed`, `debate_social_video_handoff_failed`, and `debate_social_video_handoff_resolved`, split by native share and download.
- Healthy behavior means the player loads while preparation progresses, preparation completes without an elevated failure rate, resolved handoffs remain stable, and the modal stays visible until an explicit Done/close action.
- Also monitor R2 delivery errors and browser CORS failures because playback and file preparation both depend on the social MP4 being deliverable from its signed URL.
- Roll back the web deployment if preparation, playback, or handoff failures remain elevated, or if successful handoffs dismiss the modal automatically; the additive backend artifacts can remain deployed.
