### PR TITLE
Fix stacked block spacing and ranking pagination

### DIFF
--- a/apps/web/design-system/table/table-pagination.tsx
+++ b/apps/web/design-system/table/table-pagination.tsx
@@ -32,7 +32,7 @@ export function PreviousButton({ onClick, isDisabled }: PageButtonProps) {
   const color: ColorName = isDisabled ? 'grey-03' : 'text';
 
   return (
-    <TextButton disabled={isDisabled} onClick={isDisabled ? undefined : onClick}>
+    <TextButton aria-label="Previous page" disabled={isDisabled} onClick={isDisabled ? undefined : onClick}>
       <LeftArrowLong color={color} />
     </TextButton>
   );
@@ -42,7 +42,7 @@ export function NextButton({ onClick, isDisabled }: PageButtonProps) {
   const color: ColorName = isDisabled ? 'grey-03' : 'text';
 
   return (
-    <TextButton disabled={isDisabled} onClick={isDisabled ? undefined : onClick}>
+    <TextButton aria-label="Next page" disabled={isDisabled} onClick={isDisabled ? undefined : onClick}>
       <span
         style={{
           transform: 'rotate(180deg)',

--- a/apps/web/partials/blocks/table/ranking-block-body.tsx
+++ b/apps/web/partials/blocks/table/ranking-block-body.tsx
@@ -136,7 +136,6 @@ export function RankingBlockBody({ state, presentation = 'embedded' }: Props) {
     pendingEntityIds,
     entriesResolving,
     showEmbeddedGlobalPagination,
-    embeddedGlobalPageNumber,
     hasEmbeddedGlobalPreviousPage,
     hasEmbeddedGlobalNextPage,
     setEmbeddedGlobalPage,
@@ -214,7 +213,6 @@ export function RankingBlockBody({ state, presentation = 'embedded' }: Props) {
   const globalRankingPagination =
     presentation === 'embedded' && showEmbeddedGlobalPagination ? (
       <RankingBlockGlobalPagination
-        pageNumber={embeddedGlobalPageNumber}
         hasPreviousPage={hasEmbeddedGlobalPreviousPage}
         hasNextPage={hasEmbeddedGlobalNextPage}
         onSetPage={setEmbeddedGlobalPage}
@@ -290,7 +288,6 @@ export function RankingBlockBody({ state, presentation = 'embedded' }: Props) {
   const myRankingPagination =
     presentation === 'embedded' && showEmbeddedMyPagination ? (
       <RankingBlockGlobalPagination
-        pageNumber={embeddedMyPageNumber}
         hasPreviousPage={hasEmbeddedMyPreviousPage}
         hasNextPage={hasEmbeddedMyNextPage}
         onSetPage={setEmbeddedMyPage}

--- a/apps/web/partials/blocks/table/ranking-block-global-pagination.test.tsx
+++ b/apps/web/partials/blocks/table/ranking-block-global-pagination.test.tsx
@@ -10,13 +10,14 @@ describe('RankingBlockGlobalPagination', () => {
 
     const { container } = render(<RankingBlockGlobalPagination hasPreviousPage hasNextPage onSetPage={onSetPage} />);
 
-    const buttons = screen.getAllByRole('button');
+    const previousButton = screen.getByRole('button', { name: 'Previous page' });
+    const nextButton = screen.getByRole('button', { name: 'Next page' });
 
-    expect(buttons).toHaveLength(2);
+    expect(screen.getAllByRole('button')).toHaveLength(2);
     expect(container.textContent).toBe('');
 
-    fireEvent.click(buttons[0]);
-    fireEvent.click(buttons[1]);
+    fireEvent.click(previousButton);
+    fireEvent.click(nextButton);
 
     expect(onSetPage).toHaveBeenNthCalledWith(1, 'previous');
     expect(onSetPage).toHaveBeenNthCalledWith(2, 'next');

--- a/apps/web/partials/blocks/table/ranking-block-global-pagination.test.tsx
+++ b/apps/web/partials/blocks/table/ranking-block-global-pagination.test.tsx
@@ -1,0 +1,24 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { RankingBlockGlobalPagination } from './ranking-block-global-pagination';
+
+describe('RankingBlockGlobalPagination', () => {
+  it('renders arrow-only pagination and changes pages in either direction', () => {
+    const onSetPage = vi.fn();
+
+    const { container } = render(<RankingBlockGlobalPagination hasPreviousPage hasNextPage onSetPage={onSetPage} />);
+
+    const buttons = screen.getAllByRole('button');
+
+    expect(buttons).toHaveLength(2);
+    expect(container.textContent).toBe('');
+
+    fireEvent.click(buttons[0]);
+    fireEvent.click(buttons[1]);
+
+    expect(onSetPage).toHaveBeenNthCalledWith(1, 'previous');
+    expect(onSetPage).toHaveBeenNthCalledWith(2, 'next');
+  });
+});

--- a/apps/web/partials/blocks/table/ranking-block-global-pagination.tsx
+++ b/apps/web/partials/blocks/table/ranking-block-global-pagination.tsx
@@ -2,35 +2,19 @@
 
 import { Spacer } from '~/design-system/spacer';
 import { PageNumberContainer } from '~/design-system/table/styles';
-import { NextButton, PageNumber, PreviousButton } from '~/design-system/table/table-pagination';
-import { Text } from '~/design-system/text';
+import { NextButton, PreviousButton } from '~/design-system/table/table-pagination';
 
 type Props = {
-  pageNumber: number;
   hasPreviousPage: boolean;
   hasNextPage: boolean;
   onSetPage: (page: number | 'previous' | 'next') => void;
 };
 
-export function RankingBlockGlobalPagination({ pageNumber, hasPreviousPage, hasNextPage, onSetPage }: Props) {
+export function RankingBlockGlobalPagination({ hasPreviousPage, hasNextPage, onSetPage }: Props) {
   return (
     <>
       <Spacer height={12} />
-      <PageNumberContainer>
-        {pageNumber > 1 ? (
-          <>
-            <PageNumber number={1} onClick={() => onSetPage(0)} />
-            {pageNumber > 2 ? (
-              <Text color="grey-03" variant="metadataMedium">
-                ...
-              </Text>
-            ) : null}
-          </>
-        ) : null}
-        {hasPreviousPage ? <PageNumber number={pageNumber} onClick={() => onSetPage('previous')} /> : null}
-        <PageNumber isActive number={pageNumber + 1} />
-        {hasNextPage ? <PageNumber number={pageNumber + 2} onClick={() => onSetPage('next')} /> : null}
-        <Spacer width={8} />
+      <PageNumberContainer className="gap-5!">
         <PreviousButton isDisabled={!hasPreviousPage} onClick={() => onSetPage('previous')} />
         <NextButton isDisabled={!hasNextPage} onClick={() => onSetPage('next')} />
       </PageNumberContainer>

--- a/apps/web/partials/blocks/table/ranking-explore-view.tsx
+++ b/apps/web/partials/blocks/table/ranking-explore-view.tsx
@@ -31,7 +31,6 @@ export function RankingExploreView({ state }: Props) {
     embeddedBrowseEntryByEntityId,
     embeddedBrowseTotalCount,
     embeddedBrowseShowPagination,
-    embeddedBrowsePageNumber,
     embeddedBrowseHasPreviousPage,
     embeddedBrowseHasNextPage,
     embeddedBrowseSetPage,
@@ -91,7 +90,6 @@ export function RankingExploreView({ state }: Props) {
         {embeddedBrowseShowPagination ? (
           <div className="ml-auto self-end [&>div:first-child]:hidden [&>div:last-child]:!mt-0 [&>div:last-child]:!mb-0 [&>div:last-child]:!justify-end">
             <RankingBlockGlobalPagination
-              pageNumber={embeddedBrowsePageNumber}
               hasPreviousPage={embeddedBrowseHasPreviousPage}
               hasNextPage={embeddedBrowseHasNextPage}
               onSetPage={embeddedBrowseSetPage}

--- a/apps/web/partials/blocks/table/ranking-gallery-view.tsx
+++ b/apps/web/partials/blocks/table/ranking-gallery-view.tsx
@@ -187,7 +187,6 @@ export function RankingGalleryView({ state }: Props) {
     aggregatedRankingCount,
     periodState,
     showEmbeddedGlobalPagination,
-    embeddedGlobalPageNumber,
     hasEmbeddedGlobalPreviousPage,
     hasEmbeddedGlobalNextPage,
     setEmbeddedGlobalPage,
@@ -239,7 +238,6 @@ export function RankingGalleryView({ state }: Props) {
         {showEmbeddedGlobalPagination ? (
           <div className="ml-auto self-end [&>div:first-child]:hidden [&>div:last-child]:!mt-0 [&>div:last-child]:!mb-0 [&>div:last-child]:!justify-end">
             <RankingBlockGlobalPagination
-              pageNumber={embeddedGlobalPageNumber}
               hasPreviousPage={hasEmbeddedGlobalPreviousPage}
               hasNextPage={hasEmbeddedGlobalNextPage}
               onSetPage={setEmbeddedGlobalPage}

--- a/apps/web/partials/blocks/table/ranking-list-view.tsx
+++ b/apps/web/partials/blocks/table/ranking-list-view.tsx
@@ -76,7 +76,6 @@ export function RankingListView({ state }: Props) {
     aggregatedRankingCount,
     periodState,
     showEmbeddedGlobalPagination,
-    embeddedGlobalPageNumber,
     hasEmbeddedGlobalPreviousPage,
     hasEmbeddedGlobalNextPage,
     setEmbeddedGlobalPage,
@@ -135,7 +134,6 @@ export function RankingListView({ state }: Props) {
         {showEmbeddedGlobalPagination ? (
           <div className="ml-auto self-end [&>div:first-child]:hidden [&>div:last-child]:!mt-0 [&>div:last-child]:!mb-0 [&>div:last-child]:!justify-end">
             <RankingBlockGlobalPagination
-              pageNumber={embeddedGlobalPageNumber}
               hasPreviousPage={hasEmbeddedGlobalPreviousPage}
               hasNextPage={hasEmbeddedGlobalNextPage}
               onSetPage={setEmbeddedGlobalPage}

--- a/apps/web/partials/blocks/table/ranking-pill-view.tsx
+++ b/apps/web/partials/blocks/table/ranking-pill-view.tsx
@@ -67,7 +67,6 @@ export function RankingPillView({ state }: Props) {
     totalGlobalRankingEntityCount,
     entriesResolving,
     showEmbeddedGlobalPagination,
-    embeddedGlobalPageNumber,
     hasEmbeddedGlobalPreviousPage,
     hasEmbeddedGlobalNextPage,
     setEmbeddedGlobalPage,
@@ -110,7 +109,6 @@ export function RankingPillView({ state }: Props) {
         <div className="mt-1 flex w-full items-end justify-end">
           <div className="ml-auto self-end [&>div:first-child]:hidden [&>div:last-child]:!mt-0 [&>div:last-child]:!mb-0 [&>div:last-child]:!justify-end">
             <RankingBlockGlobalPagination
-              pageNumber={embeddedGlobalPageNumber}
               hasPreviousPage={hasEmbeddedGlobalPreviousPage}
               hasNextPage={hasEmbeddedGlobalNextPage}
               onSetPage={setEmbeddedGlobalPage}

--- a/apps/web/styles/tiptap.css
+++ b/apps/web/styles/tiptap.css
@@ -159,8 +159,9 @@
   margin-bottom: 16px;
 }
 
-.ProseMirror .node-tableNode {
-  @apply not-first:mt-12;
+.ProseMirror .node-tableNode,
+.ProseMirror .node-rankingNode {
+  @apply not-first:mt-8;
 }
 
 .ProseMirror ul {


### PR DESCRIPTION
## What

- normalize editor spacing between ranking and data blocks to the Figma-defined 32px gap
- remove page numbers and ellipses from embedded ranking pagination, leaving only previous/next arrows
- match the Figma pagination arrow spacing and add focused interaction coverage

## Why

Ranking nodes previously inherited only the editor's 16px bottom margin, while table nodes added a 48px top margin. That made ranking-to-ranking and ranking-to-data transitions visibly inconsistent. Ranking pagination also rendered numbered controls that are not present in the current design.

## Impact

- stacked ranking/data blocks now use a consistent vertical rhythm in editor browse and edit surfaces
- ranking pagination remains fully navigable through previous/next controls without page numbers
- standard data-block pagination is unchanged

## Checks

- `bun run test partials/blocks/table/ranking-block-global-pagination.test.tsx partials/blocks/table/ranking-list-view.test.tsx partials/blocks/table/ranking-gallery-pill-votes.test.tsx partials/blocks/table/ranking-block-body-votes.test.tsx` (6 tests passed)
- `bun x tsc --noEmit --pretty false`
- `bun run lint` (passes with the repository's existing warning baseline)
- `bun x prettier --check ...` for all changed TSX/CSS files
- `bun run build` was attempted but stopped after the known Turbopack workspace-root detection issue caused compilation to stall without progress
