### PR TITLE
fix(debates): keep publish opt-out through thank-you

### DIFF
--- a/apps/web/app/api/debates/publish-sweep/route.ts
+++ b/apps/web/app/api/debates/publish-sweep/route.ts
@@ -40,6 +40,7 @@ export async function GET(request: Request) {
   let alreadyPublished = 0;
   let notEditor = 0;
   let pending = 0;
+  let skipped = 0;
 
   for (const spaceId of spaceIds) {
     let debateIds: string[];
@@ -59,8 +60,14 @@ export async function GET(request: Request) {
         else if (result.status === 'not_editor') notEditor += 1;
       } catch (error) {
         if (error instanceof DebateNotPublishableError) {
-          // Media still processing — retried next tick, not a failure.
-          pending += 1;
+          if (error.code === 'media_not_ready' || error.code === 'not_complete') {
+            // Media still processing or lifecycle state changed — retry next tick.
+            pending += 1;
+          } else {
+            // Cancelled or still settling: candidate discovery normally filters these, and a
+            // repeated source check keeps a stale sweep snapshot from publishing them.
+            skipped += 1;
+          }
           continue;
         }
         console.error(`[debate-acceptor] sweep failed to publish debate ${debateId}:`, error);
@@ -69,5 +76,5 @@ export async function GET(request: Request) {
     }
   }
 
-  return NextResponse.json({ ok: true, published, alreadyPublished, notEditor, pending, failed });
+  return NextResponse.json({ ok: true, published, alreadyPublished, notEditor, pending, skipped, failed });
 }

--- a/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
@@ -7,7 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { Debate, DebateRematchSession } from '~/core/debates/api';
 
-import { DebateRoomPageClient } from './debate-room-page-client';
+import { DebateRoomPageClient, isDebateInThankYouPeriod } from './debate-room-page-client';
 
 const mocks = vi.hoisted(() => ({
   back: vi.fn(),
@@ -291,6 +291,36 @@ afterEach(() => {
   vi.useRealTimers();
   vi.restoreAllMocks();
   vi.unstubAllGlobals();
+});
+
+describe('isDebateInThankYouPeriod', () => {
+  const deadline = Date.parse('2026-07-02T00:01:30.000Z');
+
+  it('keeps an early-completed debate in thanking until its authoritative deadline', () => {
+    expect(
+      isDebateInThankYouPeriod(
+        {
+          status: 'complete',
+          turn_ends_at: '2026-07-02T00:01:30.000Z',
+          completed_at: '2026-07-02T00:01:10.000Z',
+        },
+        deadline - 1
+      )
+    ).toBe(true);
+  });
+
+  it('ends thanking exactly at the authoritative deadline', () => {
+    expect(
+      isDebateInThankYouPeriod(
+        {
+          status: 'thanking',
+          turn_ends_at: '2026-07-02T00:01:30.000Z',
+          completed_at: null,
+        },
+        deadline
+      )
+    ).toBe(false);
+  });
 });
 
 describe('DebateRoomPageClient', () => {

--- a/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.tsx
@@ -56,7 +56,7 @@ import {
   requestPersistentRecordingStorage,
 } from '~/core/debates/recording-upload-queue';
 import { createLocalServerClock, synchronizeServerClock } from '~/core/debates/server-clock';
-import { useSetThankingDebateId } from '~/core/debates/thanking-debate-store';
+import { useSetThankingDebate } from '~/core/debates/thanking-debate-store';
 import { useDebatesEnabled, useFeatureFlag } from '~/core/state/feature-flags';
 
 import { Button } from '~/design-system/button';
@@ -274,12 +274,22 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
 
   // Publish opt-out in the global upload banner is only offered while the user is on this
   // debate's thank-you screen, so tell the banner which debate that is.
-  const setThankingDebateId = useSetThankingDebateId();
-  const thankingDebateId = countdown.effectiveStatus === 'thanking' ? (debate?.id ?? null) : null;
+  const setThankingDebate = useSetThankingDebate();
+  const thankingDebateId = debate && isDebateInThankYouPeriod(debate, serverClock.now()) ? debate.id : null;
+  const thankingHasUploadedRecording = Boolean(thankingDebateId && debate?.recordings.length);
+  const thankingRecordingCancelled = Boolean(thankingDebateId && debate?.recording_cancelled_at);
   React.useEffect(() => {
-    setThankingDebateId(thankingDebateId);
-    return () => setThankingDebateId(null);
-  }, [setThankingDebateId, thankingDebateId]);
+    setThankingDebate(
+      thankingDebateId
+        ? {
+            debateId: thankingDebateId,
+            hasUploadedRecording: thankingHasUploadedRecording,
+            recordingCancelled: thankingRecordingCancelled,
+          }
+        : null
+    );
+    return () => setThankingDebate(null);
+  }, [setThankingDebate, thankingDebateId, thankingHasUploadedRecording, thankingRecordingCancelled]);
   const localAudioEnabled = shouldEnableLocalAudio(
     debate ? countdown.effectiveStatus : null,
     countdown.activeSlot,
@@ -2413,6 +2423,15 @@ function countdownWindowForDebate(
     effectiveStatus: debate.status,
     turnIndex: null,
   };
+}
+
+export function isDebateInThankYouPeriod(
+  debate: Pick<Debate, 'status' | 'turn_ends_at' | 'completed_at'>,
+  now: number
+) {
+  if (debate.status !== 'thanking' && debate.status !== 'complete') return false;
+  const deadline = timestampMs(debate.turn_ends_at ?? debate.completed_at);
+  return deadline !== null && now < deadline;
 }
 
 function timedDebateCountdownWindow(

--- a/apps/web/core/debates/recording-upload-coordinator.integration.test.tsx
+++ b/apps/web/core/debates/recording-upload-coordinator.integration.test.tsx
@@ -22,6 +22,8 @@ const mocks = vi.hoisted(() => ({
   resolveUser: vi.fn(),
   scheduleRetry: vi.fn(),
   thankingDebateId: null as string | null,
+  thankingHasUploadedRecording: false,
+  thankingRecordingCancelled: false,
   // Set to hold the presigned PUT open, so a test can read the banner mid-transfer and drive
   // progress itself through `reportProgress`.
   holdUpload: null as Promise<void> | null,
@@ -72,7 +74,14 @@ vi.mock('./hooks', () => ({
 }));
 
 vi.mock('./thanking-debate-store', () => ({
-  useThankingDebateId: () => mocks.thankingDebateId,
+  useThankingDebate: () =>
+    mocks.thankingDebateId
+      ? {
+          debateId: mocks.thankingDebateId,
+          hasUploadedRecording: mocks.thankingHasUploadedRecording,
+          recordingCancelled: mocks.thankingRecordingCancelled,
+        }
+      : null,
 }));
 
 vi.mock('./api', async importOriginal => ({
@@ -155,6 +164,8 @@ beforeEach(() => {
   mocks.queue = [];
   mocks.resolveUser.mockReset().mockResolvedValue('user-a');
   mocks.scheduleRetry.mockReset().mockResolvedValue(undefined);
+  mocks.thankingHasUploadedRecording = false;
+  mocks.thankingRecordingCancelled = false;
   mocks.holdUpload = null;
   mocks.reportProgress = null;
   vi.stubGlobal('XMLHttpRequest', FakeUploadRequest);
@@ -437,6 +448,99 @@ describe('DebateRecordingUploadCoordinator', () => {
     await waitFor(() => expect(mocks.deleteUpload).toHaveBeenCalledWith('user-a:debate-1'));
     expect(await screen.findByText('Debate uploaded')).toBeInTheDocument();
     expect(screen.getByRole('checkbox', { name: 'Publish debate' })).toHaveAttribute('aria-checked', 'true');
+  });
+
+  it('restores the uploaded banner from the debate snapshot after a remount', async () => {
+    mocks.queue = [];
+    mocks.thankingHasUploadedRecording = true;
+
+    render(<DebateRecordingUploadCoordinator />);
+
+    expect(await screen.findByText('Debate uploaded')).toBeInTheDocument();
+    expect(screen.getByRole('checkbox', { name: 'Publish debate' })).toHaveAttribute('aria-checked', 'true');
+    expect(mocks.createUpload).not.toHaveBeenCalled();
+  });
+
+  it('keeps the uploaded thank-you message while an unrelated debate continues uploading', async () => {
+    mocks.completeUpload.mockImplementation(() => new Promise<void>(() => undefined));
+    mocks.thankingHasUploadedRecording = true;
+    mocks.queue = [queuedRecording('debate-2')];
+
+    render(<DebateRecordingUploadCoordinator />);
+
+    expect(await screen.findByText('Debate uploaded')).toBeInTheDocument();
+    expect(screen.getByRole('checkbox', { name: 'Publish debate' })).toBeInTheDocument();
+    await waitFor(() =>
+      expect(mocks.createUpload).toHaveBeenCalledWith(
+        'debate-2',
+        expect.objectContaining({ mime_type: 'video/webm' }),
+        expect.anything(),
+        'user-a'
+      )
+    );
+  });
+
+  it('cancels an uploaded recording restored from the debate snapshot', async () => {
+    mocks.queue = [];
+    mocks.thankingHasUploadedRecording = true;
+
+    render(<DebateRecordingUploadCoordinator />);
+
+    fireEvent.click(await screen.findByRole('checkbox', { name: 'Publish debate' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Delete debate forever' }));
+
+    await waitFor(() => expect(mocks.cancelRecording).toHaveBeenCalledWith('debate-1', expect.anything(), 'user-a'));
+    await waitFor(() => expect(screen.queryByRole('status')).not.toBeInTheDocument());
+    expect(mocks.invalidateQueries).toHaveBeenCalledWith({ queryKey: ['debate', 'debate-1'] });
+  });
+
+  it('does not offer publication again when a cancelled snapshot still has a stale local upload', async () => {
+    mocks.completeUpload.mockImplementation(() => new Promise<void>(() => undefined));
+    mocks.thankingRecordingCancelled = true;
+    mocks.queue = [queuedRecording('debate-1')];
+
+    render(<DebateRecordingUploadCoordinator />);
+
+    expect(await screen.findByText('Uploading 1 debate...')).toBeInTheDocument();
+    expect(screen.queryByRole('checkbox', { name: 'Publish debate' })).not.toBeInTheDocument();
+  });
+
+  it('keeps the confirmation and local upload when cancellation fails', async () => {
+    mocks.completeUpload.mockImplementation(() => new Promise<void>(() => undefined));
+    mocks.cancelRecording.mockRejectedValue(new Error('Cancellation failed'));
+    mocks.queue = [queuedRecording('debate-1')];
+
+    render(<DebateRecordingUploadCoordinator />);
+
+    fireEvent.click(await screen.findByRole('checkbox', { name: 'Publish debate' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Delete debate forever' }));
+
+    expect(await screen.findByText('Cancellation failed')).toBeInTheDocument();
+    expect(screen.getByRole('dialog', { name: 'Don’t want to publish?' })).toBeInTheDocument();
+    expect(mocks.deleteUpload).not.toHaveBeenCalled();
+    expect(mocks.queue).toHaveLength(1);
+  });
+
+  it('keeps publication cancelled when server cancellation succeeds but local cleanup fails', async () => {
+    mocks.completeUpload.mockImplementation(() => new Promise<void>(() => undefined));
+    mocks.deleteUpload.mockRejectedValue(new Error('IndexedDB unavailable'));
+    mocks.queue = [queuedRecording('debate-1')];
+
+    render(<DebateRecordingUploadCoordinator />);
+
+    fireEvent.click(await screen.findByRole('checkbox', { name: 'Publish debate' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Delete debate forever' }));
+
+    expect(
+      await screen.findByText(
+        'Publication was cancelled, but this device could not remove its local recording. Try again.'
+      )
+    ).toBeInTheDocument();
+    expect(mocks.cancelRecording).toHaveBeenCalledOnce();
+    expect(screen.getByRole('checkbox', { name: 'Publish debate' })).toHaveAttribute('aria-checked', 'false');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }));
+    await waitFor(() => expect(screen.queryByRole('checkbox', { name: 'Publish debate' })).not.toBeInTheDocument());
   });
 
   it('still cancels an already uploaded recording when publish is unchecked during thanking', async () => {

--- a/apps/web/core/debates/recording-upload-coordinator.tsx
+++ b/apps/web/core/debates/recording-upload-coordinator.tsx
@@ -32,7 +32,7 @@ import {
   observeDebateRecordingUploads,
   scheduleDebateRecordingRetry,
 } from './recording-upload-queue';
-import { useThankingDebateId } from './thanking-debate-store';
+import { useThankingDebate } from './thanking-debate-store';
 
 const initialRetryDelayMs = 5_000;
 const maxRetryDelayMs = 5 * 60_000;
@@ -123,6 +123,7 @@ export function DebateRecordingUploadCoordinator() {
   // row is deleted as soon as an upload completes, so nothing else can keep the banner, and its
   // publish opt-out, on screen for the rest of the thank-you period.
   const [uploadedDebateIds, setUploadedDebateIds] = React.useState<ReadonlySet<string>>(() => new Set());
+  const [cancelledDebateIds, setCancelledDebateIds] = React.useState<ReadonlySet<string>>(() => new Set());
   const activeUploadIdRef = React.useRef<string | null>(null);
   const lockRetryAtRef = React.useRef(0);
   const mountedRef = React.useRef(true);
@@ -143,6 +144,7 @@ export function DebateRecordingUploadCoordinator() {
       setUserId(null);
       setUploads([]);
       setUploadedDebateIds(new Set());
+      setCancelledDebateIds(new Set());
       return;
     }
     setUserId(null);
@@ -303,20 +305,28 @@ export function DebateRecordingUploadCoordinator() {
     waitingReason = latestFailedUpload ? 'retry' : 'waiting';
   }
 
-  const thankingDebateId = useThankingDebateId();
+  const thankingDebate = useThankingDebate();
+  const thankingDebateId = thankingDebate?.debateId ?? null;
   const normalizedThankingDebateId = thankingDebateId ? normalizeDebateId(thankingDebateId) : null;
 
   // Opting out of publishing is offered only during the thank-you period, and only for the debate
   // whose thank-you screen the user is on. Every other queued upload keeps going. The target is the
   // upload's own id, which is the form the queue and the cancel request use.
-  const thankingUpload = normalizedThankingDebateId
-    ? (uploads.find(upload => normalizeDebateId(upload.debateId) === normalizedThankingDebateId) ?? null)
-    : null;
+  const thankingUpload =
+    normalizedThankingDebateId &&
+    !thankingDebate?.recordingCancelled &&
+    !cancelledDebateIds.has(normalizedThankingDebateId)
+      ? (uploads.find(upload => normalizeDebateId(upload.debateId) === normalizedThankingDebateId) ?? null)
+      : null;
   // A fast connection finishes the upload before the user can reach the checkbox, so an already
   // uploaded debate keeps the banner open until thanking ends. The backend still accepts a cancel
   // for it. Debates dropped as unpublishable never enter `uploadedDebateIds`, so they get no opt-out.
   const thankingUploadFinished =
-    normalizedThankingDebateId !== null && !thankingUpload && uploadedDebateIds.has(normalizedThankingDebateId);
+    normalizedThankingDebateId !== null &&
+    !thankingUpload &&
+    !thankingDebate?.recordingCancelled &&
+    !cancelledDebateIds.has(normalizedThankingDebateId) &&
+    (uploadedDebateIds.has(normalizedThankingDebateId) || Boolean(thankingDebate?.hasUploadedRecording));
   const cancellableDebateId = thankingUpload?.debateId ?? (thankingUploadFinished ? thankingDebateId : null);
   const cancelPromptOpen = cancelTargetDebateId !== null;
 
@@ -327,7 +337,7 @@ export function DebateRecordingUploadCoordinator() {
     activity?.debate && ['connecting', 'preflight', 'in_progress'].includes(activity.debate.status)
   );
 
-  // Percent covers every queued recording, matching the "N debates" the banner names.
+  // When the banner is showing upload progress, its percentage covers every queued recording.
   const queuedBytes = uploads.reduce((total, upload) => total + upload.byteSize, 0);
   const transferredBytes = uploads.reduce((transferred, upload) => {
     if (upload.stage === 'uploaded') return transferred + upload.byteSize;
@@ -347,6 +357,7 @@ export function DebateRecordingUploadCoordinator() {
 
   const confirmCancel = React.useCallback(async () => {
     if (!cancelTargetDebateId) return;
+    const normalizedTargetDebateId = normalizeDebateId(cancelTargetDebateId);
     setCancelBusy(true);
     setCancelError(null);
     try {
@@ -358,18 +369,28 @@ export function DebateRecordingUploadCoordinator() {
           error instanceof GeoChatRequestError && (error.code === 'recording_cancelled' || error.status === 404);
         if (!terminal) throw error;
       }
-      await Promise.all(
-        uploads
-          .filter(upload => isSameDebateId(upload.debateId, cancelTargetDebateId))
-          .map(upload => deleteDebateRecordingUpload(upload.id))
-      );
       if (mountedRef.current) {
-        // Nothing left to publish, so the banner and its checkbox should go with it.
+        // The server opt-out is authoritative even if this device cannot clean IndexedDB. Mark it
+        // before local cleanup so a storage failure can never make Publish appear enabled again.
+        setCancelledDebateIds(current => new Set(current).add(normalizedTargetDebateId));
         setUploadedDebateIds(current => {
           const next = new Set(current);
-          next.delete(normalizeDebateId(cancelTargetDebateId));
+          next.delete(normalizedTargetDebateId);
           return next;
         });
+        void queryClient.invalidateQueries({ queryKey: debateQueryKeys.debate(cancelTargetDebateId) });
+        void queryClient.invalidateQueries({ queryKey: debateQueryKeys.media(cancelTargetDebateId) });
+      }
+      try {
+        await Promise.all(
+          uploads
+            .filter(upload => isSameDebateId(upload.debateId, cancelTargetDebateId))
+            .map(upload => deleteDebateRecordingUpload(upload.id))
+        );
+      } catch {
+        throw new Error('Publication was cancelled, but this device could not remove its local recording. Try again.');
+      }
+      if (mountedRef.current) {
         setCancelTargetDebateId(null);
       }
     } catch (error) {
@@ -377,7 +398,7 @@ export function DebateRecordingUploadCoordinator() {
     } finally {
       if (mountedRef.current) setCancelBusy(false);
     }
-  }, [accountKey, cancelTargetDebateId, getPrivyIdentityToken, uploads]);
+  }, [accountKey, cancelTargetDebateId, getPrivyIdentityToken, queryClient, uploads]);
 
   // Close the prompt only when there is nothing left to cancel. The upload finishing mid-prompt
   // must not close it, since the backend still cancels an uploaded recording.
@@ -385,8 +406,12 @@ export function DebateRecordingUploadCoordinator() {
     if (!cancelTargetDebateId) return;
     const target = normalizeDebateId(cancelTargetDebateId);
     const stillQueued = uploads.some(upload => normalizeDebateId(upload.debateId) === target);
-    if (!stillQueued && !uploadedDebateIds.has(target)) setCancelTargetDebateId(null);
-  }, [cancelTargetDebateId, uploadedDebateIds, uploads]);
+    const stillCancellableFromSnapshot =
+      cancellableDebateId !== null && normalizeDebateId(cancellableDebateId) === target;
+    if (!stillQueued && !uploadedDebateIds.has(target) && !stillCancellableFromSnapshot) {
+      setCancelTargetDebateId(null);
+    }
+  }, [cancelTargetDebateId, cancellableDebateId, uploadedDebateIds, uploads]);
 
   if ((uploads.length === 0 && !thankingUploadFinished) || inLiveDebate) return null;
 
@@ -394,6 +419,7 @@ export function DebateRecordingUploadCoordinator() {
     <>
       <DebateRecordingUploadBanner
         count={uploads.length}
+        thankingUploadFinished={thankingUploadFinished}
         percent={uploadPercent}
         waitingReason={waitingReason}
         errorMessage={latestFailedUpload?.lastError ?? null}
@@ -415,6 +441,7 @@ export function DebateRecordingUploadCoordinator() {
 
 export function DebateRecordingUploadBanner({
   count,
+  thankingUploadFinished = false,
   percent = null,
   waitingReason,
   errorMessage,
@@ -423,6 +450,7 @@ export function DebateRecordingUploadBanner({
   onUncheckPublish,
 }: {
   count: number;
+  thankingUploadFinished?: boolean;
   percent?: number | null;
   waitingReason: DebateRecordingUploadWaitingReason;
   errorMessage: string | null;
@@ -432,8 +460,8 @@ export function DebateRecordingUploadBanner({
 }) {
   const label = `${count} debate${count === 1 ? '' : 's'}`;
   let message: string;
-  if (count === 0) {
-    // The queue is empty but the thank-you screen and its opt-out are still up.
+  if (thankingUploadFinished) {
+    // The actionable thank-you debate takes priority while unrelated recordings keep uploading.
     message = 'Debate uploaded';
   } else if (waitingReason === 'offline') {
     message = `Waiting to upload ${label} — waiting for a connection`;

--- a/apps/web/core/debates/server/debate-source.test.ts
+++ b/apps/web/core/debates/server/debate-source.test.ts
@@ -1,10 +1,10 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { DebateNotPublishableError, loadDebatePublishSource } from './debate-source';
+import { DebateNotPublishableError, listSweepCandidateDebateIds, loadDebatePublishSource } from './debate-source';
 
 const DEBATE_ID = '019f89dc2124799193daafd5bc4ffa0a';
 
-function debateBody() {
+function debateBody(overrides: Record<string, unknown> = {}) {
   return {
     id: DEBATE_ID,
     status: 'complete',
@@ -13,11 +13,15 @@ function debateBody() {
       { profile_space_id: 'space-1', display_name: 'Specter', position: true, participant_slot: 1 },
       { profile_space_id: 'space-2', display_name: 'Antispecter', position: false, participant_slot: 2 },
     ],
+    turn_ends_at: '2026-07-30T11:58:00.000Z',
+    completed_at: '2026-07-30T11:58:00.000Z',
+    recording_cancelled_at: null,
+    ...overrides,
   };
 }
 
 /** Routes each geo-chat path the loader touches to a canned response. */
-function mockGeoChat(media: unknown) {
+function mockGeoChat(media: unknown, debate = debateBody()) {
   vi.stubGlobal(
     'fetch',
     vi.fn(async (input: string | URL) => {
@@ -28,17 +32,23 @@ function mockGeoChat(media: unknown) {
           ? { segments: [] }
           : url.includes('/media/artifacts/url')
             ? { upload: { url: 'https://r2.example/final.webm?X-Amz-Expires=900' } }
-            : debateBody();
+            : debate;
       return new Response(JSON.stringify(body), { status: 200 });
     })
   );
 }
 
 afterEach(() => {
+  vi.useRealTimers();
   vi.unstubAllGlobals();
 });
 
 describe('loadDebatePublishSource media gating', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-30T12:00:00.000Z'));
+  });
+
   it('publishes the processed final_video when the job succeeded', async () => {
     mockGeoChat({ job: { status: 'succeeded' }, artifacts: [{ kind: 'final_video' }] });
 
@@ -68,5 +78,45 @@ describe('loadDebatePublishSource media gating', () => {
     mockGeoChat({ job: { status }, artifacts: [] });
 
     await expect(loadDebatePublishSource(DEBATE_ID)).rejects.toThrow(/media is not ready/);
+  });
+
+  it('permanently rejects a cancelled debate even when media previously succeeded', async () => {
+    mockGeoChat(
+      { job: { status: 'succeeded' }, artifacts: [{ kind: 'final_video' }] },
+      debateBody({ recording_cancelled_at: '2026-07-30T11:59:00.000Z' })
+    );
+
+    await expect(loadDebatePublishSource(DEBATE_ID)).rejects.toMatchObject({ code: 'recording_cancelled' });
+  });
+
+  it('waits for the cancellation settlement window before publishing', async () => {
+    mockGeoChat(
+      { job: { status: 'succeeded' }, artifacts: [{ kind: 'final_video' }] },
+      debateBody({ turn_ends_at: '2026-07-30T11:59:30.001Z' })
+    );
+
+    await expect(loadDebatePublishSource(DEBATE_ID)).rejects.toMatchObject({ code: 'cancellation_window_open' });
+  });
+});
+
+describe('listSweepCandidateDebateIds', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-30T12:00:00.000Z'));
+  });
+
+  it('returns only complete, uncancelled debates whose settlement window has closed', async () => {
+    const eligible = debateBody({ id: 'eligible' });
+    const cancelled = debateBody({ id: 'cancelled', recording_cancelled_at: '2026-07-30T11:59:00.000Z' });
+    const settling = debateBody({ id: 'settling', turn_ends_at: '2026-07-30T11:59:30.001Z' });
+    const active = debateBody({ id: 'active', status: 'thanking' });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        async () => new Response(JSON.stringify({ debates: [eligible, cancelled, settling, active] }), { status: 200 })
+      )
+    );
+
+    await expect(listSweepCandidateDebateIds('space-1')).resolves.toEqual(['eligible']);
   });
 });

--- a/apps/web/core/debates/server/debate-source.ts
+++ b/apps/web/core/debates/server/debate-source.ts
@@ -6,6 +6,8 @@ import {
 } from '../debate-publish-draft';
 import { hasProcessedVideo } from '../playback-utils';
 
+const debatePublishSettlementMs = 60_000;
+
 function geoChatBaseUrl() {
   const base =
     process.env.GEO_CHAT_API_BASE_URL || process.env.NEXT_PUBLIC_GEO_CHAT_API_BASE_URL || 'http://localhost:8080';
@@ -50,8 +52,11 @@ export type DebateSource = {
 };
 
 export class DebateNotPublishableError extends Error {
-  code: 'not_complete' | 'media_not_ready';
-  constructor(code: 'not_complete' | 'media_not_ready', message: string) {
+  code: 'not_complete' | 'recording_cancelled' | 'cancellation_window_open' | 'media_not_ready';
+  constructor(
+    code: 'not_complete' | 'recording_cancelled' | 'cancellation_window_open' | 'media_not_ready',
+    message: string
+  ) {
     super(message);
     this.name = 'DebateNotPublishableError';
     this.code = code;
@@ -59,19 +64,22 @@ export class DebateNotPublishableError extends Error {
 }
 
 /**
- * The finished debates in a space, as candidate ids for the publish sweep. Only `complete`
- * debates can publish; media-readiness is re-checked per debate by {@link loadDebatePublishSource}.
- * Server-side (unauthenticated) read — the cron sweep has no user session.
+ * The finished debates in a space, as candidate ids for the publish sweep. Cancelled debates and
+ * debates still inside their settlement window are excluded; media-readiness is re-checked per
+ * debate by {@link loadDebatePublishSource}. Server-side (unauthenticated) read — the cron sweep
+ * has no user session.
  */
 export async function listSweepCandidateDebateIds(spaceId: string): Promise<string[]> {
   const response = await geoChatGet<SpaceDebatesResponse>(`/spaces/${spaceId}/debates`);
-  return response.debates.filter(debate => debate.status === 'complete').map(debate => debate.id);
+  const now = Date.now();
+  return response.debates.filter(debate => isDebatePublishableNow(debate, now)).map(debate => debate.id);
 }
 
 /**
  * Gather everything the KG publish needs for a finished debate straight from geo-chat, and
  * assemble the pure `DebatePublishInput`. Throws {@link DebateNotPublishableError} unless the
- * debate is complete and its media job has succeeded (the reliable "processing done" signal).
+ * debate is complete, its cancellation window has settled, and its media job has succeeded (the
+ * reliable "processing done" signal).
  */
 export async function loadDebatePublishSource(debateId: string): Promise<DebateSource> {
   const debate = await geoChatGet<Debate>(`/debates/${debateId}`);
@@ -81,6 +89,7 @@ export async function loadDebatePublishSource(debateId: string): Promise<DebateS
       `Debate ${debateId} is not complete (status ${debate.status}).`
     );
   }
+  assertDebateRecordingPublishable(debate, Date.now());
 
   const media = await geoChatGet<DebateMediaResponse>(`/debates/${debateId}/media`);
   if (media.job?.status !== 'succeeded') {
@@ -116,6 +125,35 @@ export async function loadDebatePublishSource(debateId: string): Promise<DebateS
   };
 
   return { debate, media, input };
+}
+
+export function isDebatePublishableNow(debate: Debate, now: number): boolean {
+  if (debate.status !== 'complete' || debate.recording_cancelled_at !== null) return false;
+  const deadline = debatePublicationDeadline(debate);
+  return deadline !== null && now >= deadline + debatePublishSettlementMs;
+}
+
+function assertDebateRecordingPublishable(debate: Debate, now: number) {
+  if (debate.recording_cancelled_at !== null) {
+    throw new DebateNotPublishableError(
+      'recording_cancelled',
+      `Debate ${debate.id} recording was cancelled and must never be published.`
+    );
+  }
+  const deadline = debatePublicationDeadline(debate);
+  if (deadline === null || now < deadline + debatePublishSettlementMs) {
+    throw new DebateNotPublishableError(
+      'cancellation_window_open',
+      `Debate ${debate.id} is still inside its recording cancellation settlement window.`
+    );
+  }
+}
+
+function debatePublicationDeadline(debate: Debate): number | null {
+  const value = debate.turn_ends_at ?? debate.completed_at;
+  if (!value) return null;
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp) ? timestamp : null;
 }
 
 async function resolveFinalVideoUrl(debateId: string): Promise<string> {

--- a/apps/web/core/debates/thanking-debate-store.ts
+++ b/apps/web/core/debates/thanking-debate-store.ts
@@ -2,11 +2,17 @@
 
 import { atom, useAtomValue, useSetAtom } from 'jotai';
 
-// The debate whose post-debate thank-you screen the user is currently on, or null. The room page
-// is the only thing that knows. `/me/debate-activity` nulls `active_debate_id` as soon as the
-// thank-you period starts, so the global upload banner can't read it back off the API.
-const thankingDebateIdAtom = atom<string | null>(null);
+export type ThankingDebate = {
+  debateId: string;
+  hasUploadedRecording: boolean;
+  recordingCancelled: boolean;
+};
 
-export const useThankingDebateId = () => useAtomValue(thankingDebateIdAtom);
+// The debate whose post-debate thank-you screen the user is currently on. The room page also
+// carries the authoritative server recording state so the global banner survives a remount after
+// IndexedDB's completed upload row has been removed.
+const thankingDebateAtom = atom<ThankingDebate | null>(null);
 
-export const useSetThankingDebateId = () => useSetAtom(thankingDebateIdAtom);
+export const useThankingDebate = () => useAtomValue(thankingDebateAtom);
+
+export const useSetThankingDebate = () => useSetAtom(thankingDebateAtom);


### PR DESCRIPTION
## Summary

People can now change their publication choice for the entire thank-you period, even after the recording upload finishes or the page remounts. The banner follows the authoritative deadline, survives early rematch completion, and treats a successful server cancellation as final even if local browser cleanup fails; unrelated queued debates continue uploading normally.

Automatic publication now excludes cancelled debates and waits until the thank-you deadline plus a 60-second settlement window before loading media into the knowledge graph.

## Validation

- Vitest: 175 files, 1,782 tests passed
- TypeScript: `bunx tsc --noEmit`
- ESLint and Prettier passed for all changed files

## Deployment

Deploy after [geo-chat#26](https://github.com/geobrowser/geo-chat/pull/26), which makes cancellation and worker revocation authoritative on the backend.
