### PR TITLE
fix(debates): show thank-you controls at turn deadline

### DIFF
--- a/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
@@ -39,6 +39,7 @@ const mocks = vi.hoisted(() => ({
   publishTrack: vi.fn(),
   supportsAudioOutputSelection: vi.fn(),
   selectAudioOutput: vi.fn(),
+  setThankingDebate: vi.fn(),
   enumerateDevices: vi.fn(),
   getServerTime: vi.fn(),
   refetchDebate: vi.fn(),
@@ -99,6 +100,10 @@ vi.mock('~/core/debates/recording-upload-queue', () => ({
   isStorageQuotaError: (error: unknown) =>
     typeof error === 'object' && error !== null && 'name' in error && error.name === 'QuotaExceededError',
   requestPersistentRecordingStorage: mocks.requestPersistentStorage,
+}));
+
+vi.mock('~/core/debates/thanking-debate-store', () => ({
+  useSetThankingDebate: () => mocks.setThankingDebate,
 }));
 
 vi.mock('~/core/debates/debate-room-ownership', () => ({
@@ -195,6 +200,7 @@ beforeEach(() => {
       toJSON: () => ({}),
     })
   );
+  mocks.setThankingDebate.mockReset();
   mocks.enumerateDevices.mockReset().mockResolvedValue([
     { kind: 'audioinput', deviceId: 'mic-1', groupId: 'mic-group-1', label: 'Shure MV7+' },
     { kind: 'audioinput', deviceId: 'mic-2', groupId: 'mic-group-2', label: 'Studio Mic' },
@@ -2107,11 +2113,57 @@ describe('DebateRoomPageClient', () => {
     expect(
       await screen.findByText((_, element) => element?.textContent === 'Nice debate!Say thanks')
     ).toBeInTheDocument();
+    expect(screen.getByText('Debate again?')).toBeInTheDocument();
+    expect(screen.getByText('Bri')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Yes' })).toBeEnabled();
     expect(document.querySelector('[data-inactive-speaker="local"]')).toHaveAttribute('data-visible', 'false');
     expect(document.querySelector('[data-inactive-speaker="remote"]')).toHaveAttribute('data-visible', 'false');
     expectNoMutedIndicator('local');
     expectNoMutedIndicator('remote');
     await waitFor(() => expect(audioTrack.mediaStreamTrack.enabled).toBe(true));
+  });
+
+  it('renders thanking on the scheduled final-turn boundary instead of the display interval', async () => {
+    const now = Date.now();
+    const finalTurnEndsAt = now + 100;
+    mocks.debate = {
+      ...completedDebate(),
+      status: 'in_progress',
+      first_participant_slot: 1,
+      current_turn_index: 1,
+      current_speaker_slot: 2,
+      turn_durations_ms: [10_000, 10_000],
+      started_at: new Date(finalTurnEndsAt - 20_000).toISOString(),
+      turn_started_at: new Date(finalTurnEndsAt - 10_000).toISOString(),
+      turn_ends_at: new Date(finalTurnEndsAt).toISOString(),
+      completed_at: null,
+    };
+
+    render(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
+
+    expect(screen.queryByText('Debate again?')).not.toBeInTheDocument();
+    expect(await screen.findByText('Debate again?', undefined, { timeout: 350 })).toBeInTheDocument();
+    expect(mocks.refetchDebate).not.toHaveBeenCalled();
+  });
+
+  it('clears an early-completed thank-you snapshot on its authoritative deadline', async () => {
+    const now = Date.now();
+    mocks.debate = {
+      ...completedDebate(),
+      status: 'complete',
+      turn_started_at: new Date(now - 19_900).toISOString(),
+      turn_ends_at: new Date(now + 100).toISOString(),
+      completed_at: new Date(now - 5_000).toISOString(),
+      rematch_session_id: 'rematch-1',
+    };
+
+    render(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
+
+    await waitFor(() =>
+      expect(mocks.setThankingDebate).toHaveBeenCalledWith(expect.objectContaining({ debateId: 'debate-1' }))
+    );
+    await waitFor(() => expect(mocks.setThankingDebate).toHaveBeenLastCalledWith(null), { timeout: 350 });
+    expect(mocks.refetchDebate).not.toHaveBeenCalled();
   });
 
   it('shows rematch consent during thanking and records local consent', async () => {

--- a/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.tsx
@@ -275,21 +275,36 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
   // Publish opt-out in the global upload banner is only offered while the user is on this
   // debate's thank-you screen, so tell the banner which debate that is.
   const setThankingDebate = useSetThankingDebate();
-  const thankingDebateId = debate && isDebateInThankYouPeriod(debate, serverClock.now()) ? debate.id : null;
+  const locallyThanking = countdown.effectiveStatus === 'thanking' && countdown.remainingSeconds > 0;
+  const thankingDebateId =
+    debate && (locallyThanking || isDebateInThankYouPeriod(debate, serverClock.now())) ? debate.id : null;
   const thankingHasUploadedRecording = Boolean(thankingDebateId && debate?.recordings.length);
   const thankingRecordingCancelled = Boolean(thankingDebateId && debate?.recording_cancelled_at);
+  const thankingHasPendingLocalRecording = Boolean(
+    thankingDebateId &&
+    !thankingHasUploadedRecording &&
+    !thankingRecordingCancelled &&
+    (recordingStartedAtRef.current !== null || recordingPersistenceStartedRef.current === thankingDebateId)
+  );
   React.useEffect(() => {
     setThankingDebate(
       thankingDebateId
         ? {
             debateId: thankingDebateId,
+            hasPendingLocalRecording: thankingHasPendingLocalRecording,
             hasUploadedRecording: thankingHasUploadedRecording,
             recordingCancelled: thankingRecordingCancelled,
           }
         : null
     );
     return () => setThankingDebate(null);
-  }, [setThankingDebate, thankingDebateId, thankingHasUploadedRecording, thankingRecordingCancelled]);
+  }, [
+    setThankingDebate,
+    thankingDebateId,
+    thankingHasPendingLocalRecording,
+    thankingHasUploadedRecording,
+    thankingRecordingCancelled,
+  ]);
   const localAudioEnabled = shouldEnableLocalAudio(
     debate ? countdown.effectiveStatus : null,
     countdown.activeSlot,
@@ -1636,10 +1651,14 @@ function DebateRecordingModal({
         <div className="relative grid w-full gap-2">
           {orderedVideoTiles}
 
-          {countdown.effectiveStatus === 'thanking' && rematchSession && (
+          {countdown.effectiveStatus === 'thanking' && countdown.remainingSeconds > 0 && (
             <DebateAgainCard
               opponentName={
-                remoteRematchParticipant?.display_name || remoteRematchParticipant?.profile_space_id || 'Other debater'
+                remoteRematchParticipant?.display_name ||
+                remoteRematchParticipant?.profile_space_id ||
+                remoteParticipant?.display_name ||
+                remoteParticipant?.profile_space_id ||
+                'Other debater'
               }
               localConsented={localConsented || rematchConsentRequested}
               remoteConsented={remoteConsented}
@@ -2309,14 +2328,27 @@ function disconnectConnectingRoom(connectingRoomRef: React.MutableRefObject<Room
 
 function useDebateCountdown(debate: Debate | null, serverNow: () => number): DebateCountdown {
   const [now, setNow] = React.useState(serverNow);
+  const countdownWindow = debate ? countdownWindowForDebate(debate, now) : null;
+  const completedThankYouDeadlineMs =
+    debate?.status === 'complete' && isDebateInThankYouPeriod(debate, now)
+      ? timestampMs(debate.turn_ends_at ?? debate.completed_at)
+      : null;
+  const boundaryAtMs = countdownWindow?.targetMs ?? completedThankYouDeadlineMs;
 
   React.useEffect(() => {
-    setNow(serverNow());
+    const currentNow = serverNow();
+    setNow(currentNow);
     const timer = window.setInterval(() => setNow(serverNow()), 500);
-    return () => window.clearInterval(timer);
-  }, [serverNow]);
+    const boundaryTimer =
+      boundaryAtMs !== null && boundaryAtMs > currentNow
+        ? window.setTimeout(() => setNow(serverNow()), boundaryAtMs - currentNow + 1)
+        : null;
+    return () => {
+      window.clearInterval(timer);
+      if (boundaryTimer !== null) window.clearTimeout(boundaryTimer);
+    };
+  }, [boundaryAtMs, serverNow]);
 
-  const countdownWindow = debate ? countdownWindowForDebate(debate, now) : null;
   if (!countdownWindow || countdownWindow.targetMs === null) {
     return {
       label: '00:00',

--- a/apps/web/core/debates/api.test.ts
+++ b/apps/web/core/debates/api.test.ts
@@ -6,6 +6,7 @@ import {
   getDebateActivity,
   getGeoChatSession,
   resetGeoChatSession,
+  retryDebatePhaseBoundaryRequest,
   updateDebateAvailability,
 } from './api';
 
@@ -96,6 +97,31 @@ describe('geo-chat request errors', () => {
       code: null,
       status: 503,
     });
+  });
+});
+
+describe('debate phase boundary retries', () => {
+  it('retries a readiness error once after the boundary delay', async () => {
+    vi.useFakeTimers();
+    const request = vi
+      .fn<() => Promise<string>>()
+      .mockRejectedValueOnce(new GeoChatRequestError('Not ready', 'rematch_not_ready', 400))
+      .mockResolvedValueOnce('ready');
+
+    const result = retryDebatePhaseBoundaryRequest(request);
+    await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
+    await vi.advanceTimersByTimeAsync(200);
+
+    await expect(result).resolves.toBe('ready');
+    expect(request).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not retry unrelated request errors', async () => {
+    const error = new GeoChatRequestError('Invalid', 'invalid_recording', 400);
+    const request = vi.fn<() => Promise<string>>().mockRejectedValue(error);
+
+    await expect(retryDebatePhaseBoundaryRequest(request)).rejects.toBe(error);
+    expect(request).toHaveBeenCalledOnce();
   });
 });
 

--- a/apps/web/core/debates/api.ts
+++ b/apps/web/core/debates/api.ts
@@ -902,6 +902,24 @@ export class GeoChatRequestError extends Error {
   }
 }
 
+const debatePhaseBoundaryRetryCodes = new Set([
+  'rematch_not_ready',
+  'recording_not_cancellable',
+  'recording_not_ready',
+]);
+
+export async function retryDebatePhaseBoundaryRequest<T>(request: () => Promise<T>): Promise<T> {
+  try {
+    return await request();
+  } catch (error) {
+    if (!(error instanceof GeoChatRequestError) || !error.code || !debatePhaseBoundaryRetryCodes.has(error.code)) {
+      throw error;
+    }
+    await new Promise(resolve => setTimeout(resolve, 200));
+    return request();
+  }
+}
+
 async function requestError(response: Response) {
   let code: string | null = null;
   let message = `${response.status} ${response.statusText}`;

--- a/apps/web/core/debates/hooks.test.tsx
+++ b/apps/web/core/debates/hooks.test.tsx
@@ -239,6 +239,10 @@ describe('useConsentToDebateRematch', () => {
     };
     const session = rematchSession();
     queryClient.setQueryData(debateQueryKeys.activity('user-a'), staleActivity);
+    queryClient.setQueryData(debateQueryKeys.debate('debate-1'), {
+      id: 'debate-1',
+      rematch_session_id: null,
+    } as Debate);
     mocks.consentToDebateRematch.mockResolvedValue(session);
 
     const wrapper = ({ children }: { children: ReactNode }) => (
@@ -259,6 +263,7 @@ describe('useConsentToDebateRematch', () => {
     expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: debateQueryKeys.activity('user-a') });
     expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: debateQueryKeys.rematch('user-a', session.id) });
     expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: debateQueryKeys.debate('debate-1') });
+    expect(queryClient.getQueryData<Debate>(debateQueryKeys.debate('debate-1'))?.rematch_session_id).toBe(session.id);
   });
 });
 

--- a/apps/web/core/debates/hooks.ts
+++ b/apps/web/core/debates/hooks.ts
@@ -8,6 +8,7 @@ import * as React from 'react';
 import { getCachedIdentityToken, useIdentityTokenSync } from '~/core/auth/identity-token';
 
 import {
+  type Debate,
   type DebateActivity,
   type DebateMediaArtifactUrlRequest,
   type DebateMediaProcessRequest,
@@ -45,6 +46,7 @@ import {
   markDebateReady,
   rejectDebateRematchRequest,
   requestDebateMediaProcessing,
+  retryDebatePhaseBoundaryRequest,
   updateDebateAvailability,
   updateDebatePreference,
   updateDebateRematchPosition,
@@ -345,9 +347,13 @@ export function useConsentToDebateRematch(debateId: string) {
   const { accountKey, getPrivyIdentityToken } = useGeoChatAuth();
 
   return useMutation({
-    mutationFn: () => consentToDebateRematch(debateId, getPrivyIdentityToken, accountKey),
+    mutationFn: () =>
+      retryDebatePhaseBoundaryRequest(() => consentToDebateRematch(debateId, getPrivyIdentityToken, accountKey)),
     onSuccess: session => {
       queryClient.setQueryData(debateQueryKeys.rematch(accountKey, session.id), session);
+      queryClient.setQueryData<Debate>(debateQueryKeys.debate(debateId), current =>
+        current ? { ...current, rematch_session_id: session.id } : current
+      );
       queryClient.setQueryData<DebateActivity>(debateQueryKeys.activity(accountKey), current => ({
         online: current?.online ?? true,
         available_to_debate: current?.available_to_debate ?? true,

--- a/apps/web/core/debates/recording-upload-coordinator.integration.test.tsx
+++ b/apps/web/core/debates/recording-upload-coordinator.integration.test.tsx
@@ -8,6 +8,7 @@ import { DebateRecordingUploadCoordinator } from './recording-upload-coordinator
 import type { DebateRecordingUpload } from './recording-upload-queue';
 
 const mocks = vi.hoisted(() => ({
+  activityDebate: null as null | { id: string; status: string },
   cancelRecording: vi.fn(),
   completeUpload: vi.fn(),
   createUpload: vi.fn(),
@@ -22,6 +23,7 @@ const mocks = vi.hoisted(() => ({
   resolveUser: vi.fn(),
   scheduleRetry: vi.fn(),
   thankingDebateId: null as string | null,
+  thankingHasPendingLocalRecording: false,
   thankingHasUploadedRecording: false,
   thankingRecordingCancelled: false,
   // Set to hold the presigned PUT open, so a test can read the banner mid-transfer and drive
@@ -70,7 +72,7 @@ vi.mock('./hooks', () => ({
     accountKey: 'user-a',
     getPrivyIdentityToken: mocks.getToken,
   }),
-  useDebateActivity: () => ({ data: undefined }),
+  useDebateActivity: () => ({ data: mocks.activityDebate ? { debate: mocks.activityDebate } : undefined }),
 }));
 
 vi.mock('./thanking-debate-store', () => ({
@@ -78,6 +80,7 @@ vi.mock('./thanking-debate-store', () => ({
     mocks.thankingDebateId
       ? {
           debateId: mocks.thankingDebateId,
+          hasPendingLocalRecording: mocks.thankingHasPendingLocalRecording,
           hasUploadedRecording: mocks.thankingHasUploadedRecording,
           recordingCancelled: mocks.thankingRecordingCancelled,
         }
@@ -142,6 +145,7 @@ vi.mock('./recording-upload-queue', async importOriginal => ({
 }));
 
 beforeEach(() => {
+  mocks.activityDebate = null;
   mocks.thankingDebateId = 'debate-1';
   mocks.cancelRecording.mockReset().mockResolvedValue(undefined);
   mocks.completeUpload.mockReset().mockResolvedValue(undefined);
@@ -165,6 +169,7 @@ beforeEach(() => {
   mocks.resolveUser.mockReset().mockResolvedValue('user-a');
   mocks.scheduleRetry.mockReset().mockResolvedValue(undefined);
   mocks.thankingHasUploadedRecording = false;
+  mocks.thankingHasPendingLocalRecording = false;
   mocks.thankingRecordingCancelled = false;
   mocks.holdUpload = null;
   mocks.reportProgress = null;
@@ -183,6 +188,27 @@ afterEach(() => {
 });
 
 describe('DebateRecordingUploadCoordinator', () => {
+  it('shows the publish choice while the recording is still being prepared and ignores stale activity for that debate', async () => {
+    mocks.queue = [];
+    mocks.thankingHasPendingLocalRecording = true;
+    mocks.activityDebate = { id: 'debate-1', status: 'in_progress' };
+
+    render(<DebateRecordingUploadCoordinator />);
+
+    expect(await screen.findByText('Preparing debate upload')).toBeInTheDocument();
+    expect(screen.getByRole('checkbox', { name: 'Publish debate' })).toHaveAttribute('aria-checked', 'true');
+  });
+
+  it('still hides the pending thank-you banner during an unrelated live debate', async () => {
+    mocks.queue = [];
+    mocks.thankingHasPendingLocalRecording = true;
+    mocks.activityDebate = { id: 'debate-2', status: 'in_progress' };
+
+    render(<DebateRecordingUploadCoordinator />);
+
+    await waitFor(() => expect(screen.queryByRole('status')).not.toBeInTheDocument());
+  });
+
   it('recovers a persisted upload on app startup under the browser-wide lock', async () => {
     // App startup, not the thank-you screen, so nothing holds the banner open.
     mocks.thankingDebateId = null;
@@ -386,6 +412,25 @@ describe('DebateRecordingUploadCoordinator', () => {
     await waitFor(() => expect(screen.queryByRole('status')).not.toBeInTheDocument());
   });
 
+  it('drops a recording row that finishes persisting after publication was cancelled', async () => {
+    mocks.thankingHasPendingLocalRecording = true;
+
+    render(<DebateRecordingUploadCoordinator />);
+
+    fireEvent.click(await screen.findByRole('checkbox', { name: 'Publish debate' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Delete debate forever' }));
+
+    await waitFor(() => expect(mocks.cancelRecording).toHaveBeenCalledOnce());
+    await waitFor(() => expect(screen.queryByRole('status')).not.toBeInTheDocument());
+
+    mocks.queue = [queuedRecording('debate-1')];
+    mocks.observer?.(mocks.queue);
+
+    await waitFor(() => expect(mocks.deleteUpload).toHaveBeenCalledWith('user-a:debate-1'));
+    expect(mocks.createUpload).not.toHaveBeenCalled();
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  });
+
   it('cancels only the debate whose thank-you screen the user is on', async () => {
     mocks.completeUpload.mockImplementation(() => new Promise<void>(() => undefined));
     // The user is thanking for debate-2 while an earlier recording is still uploading.
@@ -494,14 +539,15 @@ describe('DebateRecordingUploadCoordinator', () => {
     expect(mocks.invalidateQueries).toHaveBeenCalledWith({ queryKey: ['debate', 'debate-1'] });
   });
 
-  it('does not offer publication again when a cancelled snapshot still has a stale local upload', async () => {
-    mocks.completeUpload.mockImplementation(() => new Promise<void>(() => undefined));
+  it('removes a stale local upload restored for an already cancelled debate', async () => {
     mocks.thankingRecordingCancelled = true;
     mocks.queue = [queuedRecording('debate-1')];
 
     render(<DebateRecordingUploadCoordinator />);
 
-    expect(await screen.findByText('Uploading 1 debate...')).toBeInTheDocument();
+    await waitFor(() => expect(mocks.deleteUpload).toHaveBeenCalledWith('user-a:debate-1'));
+    expect(mocks.completeUpload).not.toHaveBeenCalled();
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
     expect(screen.queryByRole('checkbox', { name: 'Publish debate' })).not.toBeInTheDocument();
   });
 
@@ -525,6 +571,7 @@ describe('DebateRecordingUploadCoordinator', () => {
     mocks.completeUpload.mockImplementation(() => new Promise<void>(() => undefined));
     mocks.deleteUpload.mockRejectedValue(new Error('IndexedDB unavailable'));
     mocks.queue = [queuedRecording('debate-1')];
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
 
     render(<DebateRecordingUploadCoordinator />);
 
@@ -537,7 +584,7 @@ describe('DebateRecordingUploadCoordinator', () => {
       )
     ).toBeInTheDocument();
     expect(mocks.cancelRecording).toHaveBeenCalledOnce();
-    expect(screen.getByRole('checkbox', { name: 'Publish debate' })).toHaveAttribute('aria-checked', 'false');
+    expect(screen.queryByRole('checkbox', { name: 'Publish debate' })).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'Close' }));
     await waitFor(() => expect(screen.queryByRole('checkbox', { name: 'Publish debate' })).not.toBeInTheDocument());

--- a/apps/web/core/debates/recording-upload-coordinator.tsx
+++ b/apps/web/core/debates/recording-upload-coordinator.tsx
@@ -22,6 +22,7 @@ import {
   completeLocalRecordingUpload,
   createLocalRecordingUpload,
   resolveCurrentGeoChatUserId,
+  retryDebatePhaseBoundaryRequest,
 } from './api';
 import { debateQueryKeys, useDebateActivity, useGeoChatAuth } from './hooks';
 import {
@@ -87,18 +88,20 @@ export async function processDebateRecordingUpload(
     await dependencies.markUploaded(upload.id, filename);
   }
 
-  await dependencies.completeUpload(upload.debateId, {
-    filename,
-    mime_type: upload.mimeType,
-    started_at_ms: startedAtMs,
-    ended_at_ms: endedAtMs,
-    duration_seconds: upload.durationSeconds,
-    byte_size: upload.byteSize,
-    width: upload.width,
-    height: upload.height,
-    framerate: upload.framerate,
-    video_bits_per_second: upload.videoBitsPerSecond,
-  });
+  await retryDebatePhaseBoundaryRequest(() =>
+    dependencies.completeUpload(upload.debateId, {
+      filename,
+      mime_type: upload.mimeType,
+      started_at_ms: startedAtMs,
+      ended_at_ms: endedAtMs,
+      duration_seconds: upload.durationSeconds,
+      byte_size: upload.byteSize,
+      width: upload.width,
+      height: upload.height,
+      framerate: upload.framerate,
+      video_bits_per_second: upload.videoBitsPerSecond,
+    })
+  );
   await dependencies.deleteUpload(upload.id);
 }
 
@@ -124,6 +127,23 @@ export function DebateRecordingUploadCoordinator() {
   // publish opt-out, on screen for the rest of the thank-you period.
   const [uploadedDebateIds, setUploadedDebateIds] = React.useState<ReadonlySet<string>>(() => new Set());
   const [cancelledDebateIds, setCancelledDebateIds] = React.useState<ReadonlySet<string>>(() => new Set());
+  const thankingDebate = useThankingDebate();
+  const thankingDebateId = thankingDebate?.debateId ?? null;
+  const normalizedThankingDebateId = thankingDebateId ? normalizeDebateId(thankingDebateId) : null;
+  const isUploadCancelled = React.useCallback(
+    (upload: DebateRecordingUpload) => {
+      const debateId = normalizeDebateId(upload.debateId);
+      return (
+        cancelledDebateIds.has(debateId) ||
+        (thankingDebate?.recordingCancelled === true && debateId === normalizedThankingDebateId)
+      );
+    },
+    [cancelledDebateIds, normalizedThankingDebateId, thankingDebate?.recordingCancelled]
+  );
+  const publishableUploads = React.useMemo(
+    () => uploads.filter(upload => !isUploadCancelled(upload)),
+    [isUploadCancelled, uploads]
+  );
   const activeUploadIdRef = React.useRef<string | null>(null);
   const lockRetryAtRef = React.useRef(0);
   const mountedRef = React.useRef(true);
@@ -186,6 +206,18 @@ export function DebateRecordingUploadCoordinator() {
     return () => subscription.unsubscribe();
   }, [userId]);
 
+  // Recording persistence and the publish opt-out can finish in either order at the phase
+  // boundary. If a cancelled debate appears in IndexedDB afterward, keep it hidden, never start
+  // its upload, and remove the late row as soon as the observer reports it.
+  React.useEffect(() => {
+    for (const upload of uploads) {
+      if (!isUploadCancelled(upload)) continue;
+      void deleteDebateRecordingUpload(upload.id).catch(error =>
+        console.warn('[DebateRecordingUploadCoordinator] could not remove cancelled upload:', error)
+      );
+    }
+  }, [isUploadCancelled, uploads]);
+
   React.useEffect(() => {
     const handleOnline = () => {
       setOnline(true);
@@ -210,17 +242,17 @@ export function DebateRecordingUploadCoordinator() {
   }, [userId]);
 
   React.useEffect(() => {
-    if (activeUploadId || uploads.length === 0) return;
-    const nextAttemptAt = Math.min(...uploads.map(upload => upload.nextAttemptAt));
+    if (activeUploadId || publishableUploads.length === 0) return;
+    const nextAttemptAt = Math.min(...publishableUploads.map(upload => upload.nextAttemptAt));
     const delay = Math.max(0, nextAttemptAt - Date.now());
     if (delay === 0) return;
     const timer = window.setTimeout(() => setWakeAt(Date.now()), delay);
     return () => window.clearTimeout(timer);
-  }, [activeUploadId, uploads]);
+  }, [activeUploadId, publishableUploads]);
 
   React.useEffect(() => {
     if (!userId || !online || activeUploadIdRef.current || Date.now() < lockRetryAtRef.current) return;
-    const upload = uploads.find(candidate => candidate.nextAttemptAt <= Date.now());
+    const upload = publishableUploads.find(candidate => candidate.nextAttemptAt <= Date.now());
     if (!upload) return;
 
     activeUploadIdRef.current = upload.id;
@@ -291,10 +323,10 @@ export function DebateRecordingUploadCoordinator() {
           setWakeAt(Date.now());
         }
       });
-  }, [accountKey, activeUploadId, getPrivyIdentityToken, online, queryClient, uploads, userId, wakeAt]);
+  }, [accountKey, activeUploadId, getPrivyIdentityToken, online, publishableUploads, queryClient, userId, wakeAt]);
 
-  const waiting = !online || (!activeUploadId && uploads.every(upload => upload.nextAttemptAt > Date.now()));
-  const latestFailedUpload = uploads.reduce<DebateRecordingUpload | null>((latest, upload) => {
+  const waiting = !online || (!activeUploadId && publishableUploads.every(upload => upload.nextAttemptAt > Date.now()));
+  const latestFailedUpload = publishableUploads.reduce<DebateRecordingUpload | null>((latest, upload) => {
     if (!upload.lastError) return latest;
     return !latest || upload.updatedAt > latest.updatedAt ? upload : latest;
   }, null);
@@ -305,10 +337,6 @@ export function DebateRecordingUploadCoordinator() {
     waitingReason = latestFailedUpload ? 'retry' : 'waiting';
   }
 
-  const thankingDebate = useThankingDebate();
-  const thankingDebateId = thankingDebate?.debateId ?? null;
-  const normalizedThankingDebateId = thankingDebateId ? normalizeDebateId(thankingDebateId) : null;
-
   // Opting out of publishing is offered only during the thank-you period, and only for the debate
   // whose thank-you screen the user is on. Every other queued upload keeps going. The target is the
   // upload's own id, which is the form the queue and the cancel request use.
@@ -316,7 +344,7 @@ export function DebateRecordingUploadCoordinator() {
     normalizedThankingDebateId &&
     !thankingDebate?.recordingCancelled &&
     !cancelledDebateIds.has(normalizedThankingDebateId)
-      ? (uploads.find(upload => normalizeDebateId(upload.debateId) === normalizedThankingDebateId) ?? null)
+      ? (publishableUploads.find(upload => normalizeDebateId(upload.debateId) === normalizedThankingDebateId) ?? null)
       : null;
   // A fast connection finishes the upload before the user can reach the checkbox, so an already
   // uploaded debate keeps the banner open until thanking ends. The backend still accepts a cancel
@@ -327,19 +355,32 @@ export function DebateRecordingUploadCoordinator() {
     !thankingDebate?.recordingCancelled &&
     !cancelledDebateIds.has(normalizedThankingDebateId) &&
     (uploadedDebateIds.has(normalizedThankingDebateId) || Boolean(thankingDebate?.hasUploadedRecording));
-  const cancellableDebateId = thankingUpload?.debateId ?? (thankingUploadFinished ? thankingDebateId : null);
+  const thankingRecordingPending =
+    normalizedThankingDebateId !== null &&
+    !thankingUpload &&
+    !thankingUploadFinished &&
+    Boolean(thankingDebate?.hasPendingLocalRecording) &&
+    !thankingDebate?.recordingCancelled &&
+    !cancelledDebateIds.has(normalizedThankingDebateId);
+  const cancellableDebateId =
+    thankingUpload?.debateId ?? (thankingUploadFinished || thankingRecordingPending ? thankingDebateId : null);
   const cancelPromptOpen = cancelTargetDebateId !== null;
 
   // Only poll debate activity while a banner might show, and hide it while the user is in a
   // live debate — the upload keeps running, it just shouldn't be on screen mid-debate.
-  const { data: activity } = useDebateActivity(uploads.length > 0 || thankingUploadFinished);
+  const { data: activity } = useDebateActivity(
+    publishableUploads.length > 0 || thankingUploadFinished || thankingRecordingPending
+  );
+  const activityDebateId = activity?.debate ? normalizeDebateId(activity.debate.id) : null;
   const inLiveDebate = Boolean(
-    activity?.debate && ['connecting', 'preflight', 'in_progress'].includes(activity.debate.status)
+    activity?.debate &&
+    ['connecting', 'preflight', 'in_progress'].includes(activity.debate.status) &&
+    activityDebateId !== normalizedThankingDebateId
   );
 
   // When the banner is showing upload progress, its percentage covers every queued recording.
-  const queuedBytes = uploads.reduce((total, upload) => total + upload.byteSize, 0);
-  const transferredBytes = uploads.reduce((transferred, upload) => {
+  const queuedBytes = publishableUploads.reduce((total, upload) => total + upload.byteSize, 0);
+  const transferredBytes = publishableUploads.reduce((transferred, upload) => {
     if (upload.stage === 'uploaded') return transferred + upload.byteSize;
     if (uploadProgress?.id === upload.id) return transferred + Math.min(uploadProgress.loaded, upload.byteSize);
     return transferred;
@@ -362,7 +403,9 @@ export function DebateRecordingUploadCoordinator() {
     setCancelError(null);
     try {
       try {
-        await cancelDebateRecording(cancelTargetDebateId, getPrivyIdentityToken, accountKey);
+        await retryDebatePhaseBoundaryRequest(() =>
+          cancelDebateRecording(cancelTargetDebateId, getPrivyIdentityToken, accountKey)
+        );
       } catch (error) {
         // Already cancelled or gone on the backend — still drop the local blob below.
         const terminal =
@@ -413,20 +456,26 @@ export function DebateRecordingUploadCoordinator() {
     }
   }, [cancelTargetDebateId, cancellableDebateId, uploadedDebateIds, uploads]);
 
-  if ((uploads.length === 0 && !thankingUploadFinished) || inLiveDebate) return null;
+  const bannerVisible = publishableUploads.length > 0 || thankingUploadFinished || thankingRecordingPending;
+  if ((!bannerVisible && !cancelPromptOpen) || inLiveDebate) {
+    return null;
+  }
 
   return (
     <>
-      <DebateRecordingUploadBanner
-        count={uploads.length}
-        thankingUploadFinished={thankingUploadFinished}
-        percent={uploadPercent}
-        waitingReason={waitingReason}
-        errorMessage={latestFailedUpload?.lastError ?? null}
-        canPublishOptOut={cancellableDebateId !== null || cancelPromptOpen}
-        publishChecked={!cancelPromptOpen}
-        onUncheckPublish={() => setCancelTargetDebateId(cancellableDebateId)}
-      />
+      {bannerVisible && (
+        <DebateRecordingUploadBanner
+          count={publishableUploads.length}
+          thankingRecordingPending={thankingRecordingPending}
+          thankingUploadFinished={thankingUploadFinished}
+          percent={uploadPercent}
+          waitingReason={waitingReason}
+          errorMessage={latestFailedUpload?.lastError ?? null}
+          canPublishOptOut={cancellableDebateId !== null || cancelPromptOpen}
+          publishChecked={!cancelPromptOpen}
+          onUncheckPublish={() => setCancelTargetDebateId(cancellableDebateId)}
+        />
+      )}
       {cancelPromptOpen && (
         <DebateCancelUploadDialog
           busy={cancelBusy}
@@ -441,6 +490,7 @@ export function DebateRecordingUploadCoordinator() {
 
 export function DebateRecordingUploadBanner({
   count,
+  thankingRecordingPending = false,
   thankingUploadFinished = false,
   percent = null,
   waitingReason,
@@ -450,6 +500,7 @@ export function DebateRecordingUploadBanner({
   onUncheckPublish,
 }: {
   count: number;
+  thankingRecordingPending?: boolean;
   thankingUploadFinished?: boolean;
   percent?: number | null;
   waitingReason: DebateRecordingUploadWaitingReason;
@@ -460,7 +511,9 @@ export function DebateRecordingUploadBanner({
 }) {
   const label = `${count} debate${count === 1 ? '' : 's'}`;
   let message: string;
-  if (thankingUploadFinished) {
+  if (thankingRecordingPending) {
+    message = 'Preparing debate upload';
+  } else if (thankingUploadFinished) {
     // The actionable thank-you debate takes priority while unrelated recordings keep uploading.
     message = 'Debate uploaded';
   } else if (waitingReason === 'offline') {

--- a/apps/web/core/debates/thanking-debate-store.ts
+++ b/apps/web/core/debates/thanking-debate-store.ts
@@ -4,6 +4,7 @@ import { atom, useAtomValue, useSetAtom } from 'jotai';
 
 export type ThankingDebate = {
   debateId: string;
+  hasPendingLocalRecording: boolean;
   hasUploadedRecording: boolean;
   recordingCancelled: boolean;
 };


### PR DESCRIPTION
## Summary

The rematch overlay and publish banner now appear on the first render at the synchronized final-turn deadline, without waiting for a websocket event or debate refetch. Before rematch data arrives, the overlay uses the debate participant snapshot and reconciles immediately when consent returns.

People can opt out while their recording is still being finalized: the banner starts at “Preparing debate upload,” survives stale activity snapshots for the same debate, and prevents late IndexedDB rows from uploading after cancellation. Boundary-only readiness errors receive one 200 ms retry; other failures still surface immediately without discarding local state.

Related: #2087
Related: geobrowser/geo-chat#27

## Validation

- Vitest: 175 files, 1,789 tests passed
- TypeScript: `bunx tsc --noEmit`
- ESLint and Prettier passed for every changed frontend file
- Boundary coverage verifies the controls appear before the 500 ms display tick and that early completion clears the banner on the authoritative deadline

## Deployment

Deploy after [geo-chat#27](https://github.com/geobrowser/geo-chat/pull/27). The existing two-second scheduler remains the fallback for inactive clients and lifecycle recovery.

## Post-Deploy Monitoring & Validation

- For 24 hours after rollout, the debate on-call should search frontend diagnostics for `DebateRecordingUploadCoordinator` failures and boundary responses containing `rematch_not_ready`, `recording_not_cancellable`, or `recording_not_ready`.
- Healthy: both thank-you controls appear at zero on the final-turn countdown; boundary retries are rare and resolve on the second request; cancelled debates create no later upload/finalization attempts.
- Failure: repeated readiness errors after the UI has entered thank-you, banners reappearing after cancellation, or increased recording persistence failures. Roll back this frontend PR while leaving geo-chat#27 deployed as a backward-compatible backend improvement.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
