### PR TITLE
fix(debates): return to previous page after thanking

### DIFF
--- a/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
@@ -2427,6 +2427,34 @@ describe('DebateRoomPageClient', () => {
     expect(await screen.findByRole('button', { name: 'Waiting...' })).toBeDisabled();
   });
 
+  it('returns to the previous page after leaving during the thank-you phase', async () => {
+    setHistoryLength(2);
+    installRecordingMocks();
+    const view = await renderLiveDebate();
+    await waitFor(() => expect(mocks.mediaRecorderStart).toHaveBeenCalled());
+    mocks.debate = {
+      ...completedDebate(),
+      status: 'thanking',
+      turn_started_at: '2026-07-02T00:00:20.000Z',
+      turn_ends_at: '2026-07-02T00:00:40.000Z',
+      completed_at: null,
+      rematch_session_id: 'rematch-1',
+    };
+    mocks.rematch = rematchSession('deciding');
+    view.rerender(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Leave debate' }));
+
+    await waitFor(() => expect(mocks.leaveRematchMutateAsync).toHaveBeenCalledOnce());
+    expect(mocks.enqueueRecording).toHaveBeenCalledOnce();
+    expect(mocks.enqueueRecording.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.leaveRematchMutateAsync.mock.invocationCallOrder[0]!
+    );
+    expect(mocks.clearDebateActivity).toHaveBeenCalledWith('debate-1');
+    expect(mocks.back).toHaveBeenCalledOnce();
+    expect(mocks.replace).not.toHaveBeenCalled();
+  });
+
   it('does not leave the rematch flow when the local recording cannot be persisted', async () => {
     mocks.debate = {
       ...completedDebate(),

--- a/apps/web/core/debates/hooks.test.tsx
+++ b/apps/web/core/debates/hooks.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider, focusManager, onlineManager } from '@tanstack/react-query';
-import { act, renderHook, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, renderHook, screen, waitFor } from '@testing-library/react';
 
 import type { ReactNode } from 'react';
 
@@ -8,6 +8,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { setCachedIdentityToken } from '~/core/auth/identity-token';
 
 import { type Debate, type DebateActivity, type DebateRematchSession, GeoChatRequestError } from './api';
+import { DebateCoordinator } from './debate-coordinator';
 import {
   debateQueryKeys,
   useClearDebateActivity,
@@ -17,6 +18,7 @@ import {
   useDebateActivity,
   useEndDebateTurn,
   useGeoChatAuth,
+  useLeaveDebateRematch,
   useMarkDebateReady,
   useUpdateDebateAvailability,
 } from './hooks';
@@ -27,8 +29,22 @@ const mocks = vi.hoisted(() => ({
   identityToken: vi.fn(),
   consentToDebateRematch: vi.fn(),
   endDebateTurn: vi.fn(),
+  leaveDebateRematch: vi.fn(),
+  listDebateSharePrompts: vi.fn(),
   markDebateReady: vi.fn(),
+  pathname: '/space/space-1/debates/debate-1',
+  push: vi.fn(),
+  back: vi.fn(),
   updateDebateAvailability: vi.fn(),
+}));
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => mocks.pathname,
+  useRouter: () => ({ push: mocks.push, back: mocks.back }),
+}));
+
+vi.mock('~/core/state/feature-flags', () => ({
+  useDebatesEnabled: () => true,
 }));
 
 vi.mock('@geogenesis/auth', () => ({
@@ -38,7 +54,12 @@ vi.mock('@geogenesis/auth', () => ({
 }));
 
 vi.mock('./debate-gateway', () => ({
+  useDebateGateway: () => ({ status: 'ready', paused: false }),
   useDebateGatewayScope: vi.fn(),
+}));
+
+vi.mock('./match-prompt', () => ({
+  DebateMatchPrompt: () => null,
 }));
 
 vi.mock('./api', async importOriginal => {
@@ -47,6 +68,8 @@ vi.mock('./api', async importOriginal => {
     ...actual,
     consentToDebateRematch: mocks.consentToDebateRematch,
     endDebateTurn: mocks.endDebateTurn,
+    leaveDebateRematch: mocks.leaveDebateRematch,
+    listDebateSharePrompts: mocks.listDebateSharePrompts,
     markDebateReady: mocks.markDebateReady,
     updateDebateAvailability: mocks.updateDebateAvailability,
   };
@@ -57,6 +80,27 @@ function jwtExpiringIn(seconds: number) {
   return `header.${payload}.signature`;
 }
 
+function DebateExitHarness() {
+  const leaveRematch = useLeaveDebateRematch('rematch-1');
+  const clearDebateActivity = useClearDebateActivity();
+
+  const leave = () => {
+    void leaveRematch.mutateAsync().then(() => {
+      clearDebateActivity('debate-1');
+      mocks.back();
+    });
+  };
+
+  return (
+    <>
+      <DebateCoordinator />
+      <button type="button" onClick={leave}>
+        Leave debate
+      </button>
+    </>
+  );
+}
+
 describe('useGeoChatAuth', () => {
   beforeEach(() => {
     mocks.authenticated = true;
@@ -64,8 +108,14 @@ describe('useGeoChatAuth', () => {
     mocks.identityToken.mockReset();
     mocks.consentToDebateRematch.mockReset();
     mocks.endDebateTurn.mockReset();
+    mocks.leaveDebateRematch.mockReset();
+    mocks.listDebateSharePrompts.mockReset();
     mocks.markDebateReady.mockReset();
+    mocks.push.mockReset();
+    mocks.back.mockReset();
+    mocks.pathname = '/space/space-1/debates/debate-1';
     mocks.updateDebateAvailability.mockReset();
+    mocks.listDebateSharePrompts.mockResolvedValue({ prompts: [] });
     setCachedIdentityToken(null);
   });
 
@@ -268,6 +318,192 @@ describe('useConsentToDebateRematch', () => {
     expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: debateQueryKeys.rematch('user-a', session.id) });
     expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: debateQueryKeys.debate('debate-1') });
     expect(queryClient.getQueryData<Debate>(debateQueryKeys.debate('debate-1'))?.rematch_session_id).toBe(session.id);
+  });
+});
+
+describe('useLeaveDebateRematch', () => {
+  it('clears coordinator activity before returning to the previous page', async () => {
+    window.localStorage.setItem(
+      'geo:chat-session',
+      JSON.stringify({
+        account_key: 'user-a',
+        session: {
+          access_token: 'access-token',
+          refresh_token: 'refresh-token',
+          expires_at: new Date(Date.now() + 10 * 60_000).toISOString(),
+        },
+      })
+    );
+    const queryClient = new QueryClient({
+      defaultOptions: { mutations: { retry: false }, queries: { retry: false, staleTime: Infinity } },
+    });
+    const decidingSession = { ...rematchSession(), status: 'deciding' as const };
+    const endedSession = { ...decidingSession, status: 'ended' as const };
+    const staleActivity: DebateActivity = {
+      online: true,
+      available_to_debate: true,
+      cooldown_until: null,
+      match: null,
+      debate: {
+        id: 'debate-1',
+        status: 'thanking',
+        claim: { space_id: 'space-1' },
+      } as NonNullable<DebateActivity['debate']>,
+      rematch: decidingSession,
+    };
+    const clearedActivity: DebateActivity = { ...staleActivity, debate: null, rematch: null };
+    let activityAtBack: DebateActivity | undefined;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify(clearedActivity), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      )
+    );
+    mocks.leaveDebateRematch.mockResolvedValue(endedSession);
+    mocks.back.mockImplementation(() => {
+      activityAtBack = queryClient.getQueryData<DebateActivity>(debateQueryKeys.activity('user-a'));
+      mocks.pathname = '/space/space-1/claims';
+    });
+    queryClient.setQueryData(debateQueryKeys.activity('user-a'), staleActivity);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <DebateExitHarness />
+      </QueryClientProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Leave debate' }));
+
+    await waitFor(() => expect(mocks.back).toHaveBeenCalledOnce());
+    expect(activityAtBack).toEqual(clearedActivity);
+    await waitFor(() => expect(queryClient.getQueryData(debateQueryKeys.activity('user-a'))).toEqual(clearedActivity));
+    expect(mocks.push).not.toHaveBeenCalled();
+    vi.unstubAllGlobals();
+    window.localStorage.clear();
+  });
+
+  it('clears the ended rematch flow before reconciling activity', async () => {
+    const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false }, queries: { retry: false } } });
+    const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries').mockResolvedValue();
+    const decidingSession = { ...rematchSession(), status: 'deciding' as const };
+    const endedSession = { ...decidingSession, status: 'ended' as const };
+    const staleActivity: DebateActivity = {
+      online: true,
+      available_to_debate: true,
+      cooldown_until: '2026-07-02T00:02:00.000Z',
+      match: null,
+      debate: { id: 'debate-1' } as NonNullable<DebateActivity['debate']>,
+      rematch: decidingSession,
+    };
+    queryClient.setQueryData(debateQueryKeys.activity('user-a'), staleActivity);
+    mocks.leaveDebateRematch.mockResolvedValue(endedSession);
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    const { result } = renderHook(() => useLeaveDebateRematch('rematch-1'), { wrapper });
+
+    await act(() => result.current.mutateAsync());
+
+    expect(queryClient.getQueryData(debateQueryKeys.activity('user-a'))).toEqual({
+      ...staleActivity,
+      debate: null,
+      rematch: null,
+    });
+    expect(queryClient.getQueryData(debateQueryKeys.rematch('user-a', 'rematch-1'))).toEqual(endedSession);
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: debateQueryKeys.activity('user-a') });
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: debateQueryKeys.rematch('user-a', 'rematch-1') });
+  });
+
+  it('preserves a newer unrelated debate flow', async () => {
+    const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false }, queries: { retry: false } } });
+    const endedSession = { ...rematchSession(), status: 'ended' as const };
+    const currentActivity: DebateActivity = {
+      online: true,
+      available_to_debate: true,
+      cooldown_until: null,
+      match: null,
+      debate: { id: 'debate-2' } as NonNullable<DebateActivity['debate']>,
+      rematch: {
+        ...rematchSession(),
+        id: 'rematch-2',
+        source_debate_id: 'debate-2',
+        status: 'deciding',
+      },
+    };
+    queryClient.setQueryData(debateQueryKeys.activity('user-a'), currentActivity);
+    mocks.leaveDebateRematch.mockResolvedValue(endedSession);
+    const setQueryData = vi.spyOn(queryClient, 'setQueryData');
+    vi.spyOn(queryClient, 'invalidateQueries').mockResolvedValue();
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    const { result } = renderHook(() => useLeaveDebateRematch('rematch-1'), { wrapper });
+
+    await act(() => result.current.mutateAsync());
+
+    expect(queryClient.getQueryData(debateQueryKeys.activity('user-a'))).toEqual(currentActivity);
+    expect(setQueryData).not.toHaveBeenCalledWith(debateQueryKeys.activity('user-a'), expect.anything());
+  });
+
+  it.each([
+    {
+      name: 'debate',
+      debate: { id: 'debate-1' } as NonNullable<DebateActivity['debate']>,
+      rematch: { ...rematchSession(), id: 'rematch-2', source_debate_id: 'debate-2', status: 'deciding' as const },
+      expectedDebate: null,
+      expectedRematchId: 'rematch-2',
+    },
+    {
+      name: 'rematch',
+      debate: { id: 'debate-2' } as NonNullable<DebateActivity['debate']>,
+      rematch: { ...rematchSession(), status: 'deciding' as const },
+      expectedDebate: { id: 'debate-2' } as NonNullable<DebateActivity['debate']>,
+      expectedRematchId: undefined,
+    },
+  ])('clears only the matching $name from activity', async ({ debate, rematch, expectedDebate, expectedRematchId }) => {
+    const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false }, queries: { retry: false } } });
+    const endedSession = { ...rematchSession(), status: 'ended' as const };
+    queryClient.setQueryData<DebateActivity>(debateQueryKeys.activity('user-a'), {
+      online: true,
+      available_to_debate: true,
+      cooldown_until: null,
+      match: null,
+      debate,
+      rematch,
+    });
+    mocks.leaveDebateRematch.mockResolvedValue(endedSession);
+    vi.spyOn(queryClient, 'invalidateQueries').mockResolvedValue();
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    const { result } = renderHook(() => useLeaveDebateRematch('rematch-1'), { wrapper });
+
+    await act(() => result.current.mutateAsync());
+
+    const activity = queryClient.getQueryData<DebateActivity>(debateQueryKeys.activity('user-a'));
+    expect(activity?.debate).toEqual(expectedDebate);
+    expect(activity?.rematch?.id).toBe(expectedRematchId);
+  });
+
+  it('leaves an absent activity cache empty', async () => {
+    const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false }, queries: { retry: false } } });
+    const endedSession = { ...rematchSession(), status: 'ended' as const };
+    mocks.leaveDebateRematch.mockResolvedValue(endedSession);
+    const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries').mockResolvedValue();
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    const { result } = renderHook(() => useLeaveDebateRematch('rematch-1'), { wrapper });
+
+    await act(() => result.current.mutateAsync());
+
+    expect(queryClient.getQueryData(debateQueryKeys.activity('user-a'))).toBeUndefined();
+    expect(queryClient.getQueryData(debateQueryKeys.rematch('user-a', 'rematch-1'))).toEqual(endedSession);
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: debateQueryKeys.activity('user-a') });
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: debateQueryKeys.rematch('user-a', 'rematch-1') });
   });
 });
 

--- a/apps/web/core/debates/hooks.ts
+++ b/apps/web/core/debates/hooks.ts
@@ -407,8 +407,17 @@ export function useLeaveDebateRematch(sessionId: string) {
     mutationFn: () => leaveDebateRematch(sessionId, getPrivyIdentityToken, accountKey),
     onSuccess: session => {
       queryClient.setQueryData(debateQueryKeys.rematch(accountKey, session.id), session);
+      const activityKey = debateQueryKeys.activity(accountKey);
+      const activity = queryClient.getQueryData<DebateActivity>(activityKey);
+      if (activity) {
+        const debate = activity.debate?.id === session.source_debate_id ? null : activity.debate;
+        const rematch = activity.rematch?.id === session.id ? null : activity.rematch;
+        if (debate !== activity.debate || rematch !== activity.rematch) {
+          queryClient.setQueryData(activityKey, { ...activity, debate, rematch });
+        }
+      }
       void queryClient.invalidateQueries({ queryKey: debateQueryKeys.rematch(accountKey, session.id) });
-      void queryClient.invalidateQueries({ queryKey: debateQueryKeys.activity(accountKey) });
+      void queryClient.invalidateQueries({ queryKey: activityKey });
     },
   });
 }


### PR DESCRIPTION
## Summary

Leaving a debate during the thank-you phase now returns to the previous page instead of reopening the debate and showing "This debate is already open in another tab." The rematch leave response clears only the matching debate and rematch activity before navigation, while preserving any newer unrelated flow. Regression coverage exercises both the page-level exit ordering and the real coordinator/query-cache interaction.

## Test plan

- `bun run test` (177 files, 1,823 tests passed)
- `bun run lint` (0 errors; 94 existing warnings)
- 
https://linear.app/geobrowser/issue/CUR-870/fix-leaving-debate
