### PR TITLE
fix(debates): keep match acceptance local to one tab

### DIFF
--- a/apps/web/core/debates/debate-coordinator.test.tsx
+++ b/apps/web/core/debates/debate-coordinator.test.tsx
@@ -23,6 +23,9 @@ const mocks = vi.hoisted(() => ({
   capture: vi.fn(),
   authenticated: true,
   gatewayPaused: false,
+  currentUserId: 'user-for' as string | null,
+  refetch: vi.fn(),
+  reconcileActivity: null as (() => Promise<DebateActivity | null>) | null,
 }));
 
 vi.mock('next/navigation', () => ({
@@ -32,9 +35,14 @@ vi.mock('next/navigation', () => ({
 
 vi.mock('~/core/analytics', () => ({ capture: mocks.capture }));
 
+vi.mock('./api', async importOriginal => {
+  const actual = await importOriginal<typeof import('./api')>();
+  return { ...actual, getCurrentGeoChatUserId: () => mocks.currentUserId };
+});
+
 vi.mock('./hooks', () => ({
   useGeoChatAuth: () => ({ ready: true, authenticated: mocks.authenticated, getPrivyIdentityToken: vi.fn() }),
-  useDebateActivity: () => ({ data: mocks.activity }),
+  useDebateActivity: () => ({ data: mocks.activity, refetch: mocks.refetch }),
   useDebateSharePrompts: () => ({ data: { prompts: mocks.prompts }, isFetching: mocks.promptsFetching }),
   useDebateMediaArtifactUrl: () => ({ mutate: mocks.mediaMutate, error: null }),
   useHandleDebateSharePrompt: () => ({ mutate: mocks.handleMutate, isPending: false }),
@@ -49,10 +57,14 @@ vi.mock('~/core/state/feature-flags', () => ({
 }));
 
 vi.mock('./match-prompt', () => ({
-  DebateMatchPrompt: () => <div>Global match prompt</div>,
+  DebateMatchPrompt: ({ reconcileActivity }: { reconcileActivity?: () => Promise<DebateActivity | null> }) => {
+    mocks.reconcileActivity = reconcileActivity ?? null;
+    return <div>Global match prompt</div>;
+  },
 }));
 
 beforeEach(() => {
+  sessionStorage.clear();
   mocks.push.mockReset();
   mocks.mediaMutate.mockReset();
   mocks.handleMutate.mockReset();
@@ -70,6 +82,9 @@ beforeEach(() => {
   mocks.promptsFetching = false;
   mocks.authenticated = true;
   mocks.gatewayPaused = false;
+  mocks.currentUserId = 'user-for';
+  mocks.refetch.mockReset();
+  mocks.reconcileActivity = null;
   Object.defineProperty(navigator, 'share', { configurable: true, value: mocks.share });
   Object.defineProperty(navigator, 'canShare', { configurable: true, value: mocks.canShare });
   Object.defineProperty(URL, 'createObjectURL', {
@@ -89,7 +104,11 @@ beforeEach(() => {
   mocks.fetch.mockResolvedValue(videoResponse());
 });
 
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  sessionStorage.clear();
+  vi.restoreAllMocks();
+});
 
 describe('DebateCoordinator', () => {
   it('shows a non-blocking warning while live updates are paused and clears it on recovery', () => {
@@ -129,6 +148,61 @@ describe('DebateCoordinator', () => {
     expect(screen.queryByText('Global match prompt')).not.toBeInTheDocument();
   });
 
+  it('leaves a secondary tab on its current page when shared activity contains a debate', async () => {
+    mocks.pathname = '/space/space-1/claims';
+    mocks.activity = activityWithDebate();
+
+    render(<DebateCoordinator />);
+
+    await waitFor(() => expect(mocks.push).not.toHaveBeenCalled());
+    expect(screen.queryByText('Global match prompt')).not.toBeInTheDocument();
+  });
+
+  it('routes only a reloaded owning tab when activity contains only the debate', async () => {
+    mocks.pathname = '/space/space-1/claims';
+    mocks.activity = activityWithDebate();
+    seedConfirmedOwnership();
+
+    render(<DebateCoordinator />);
+
+    await waitFor(() => expect(mocks.push).toHaveBeenCalledWith('/space/space-1/debates/debate-1'));
+  });
+
+  it('makes activity reconciliation throw when refetch fails', async () => {
+    mocks.activity = activityWithMatch();
+    mocks.refetch.mockRejectedValue(new Error('Offline'));
+
+    render(<DebateCoordinator />);
+
+    await expect(mocks.reconcileActivity?.()).rejects.toThrow('Offline');
+    expect(mocks.refetch).toHaveBeenCalledWith({ throwOnError: true });
+  });
+
+  it('clears stale handoff ownership when an unrelated debate becomes active', async () => {
+    mocks.activity = activityWithDebate();
+    mocks.activity.debate = {
+      ...mocks.activity.debate!,
+      claim: { ...mocks.activity.debate!.claim, id: 'claim-2' },
+    };
+    seedConfirmedOwnership();
+
+    render(<DebateCoordinator />);
+
+    await waitFor(() => expect(sessionStorage.getItem('geo:debate-match-owner:user-for')).toBeNull());
+    expect(mocks.push).not.toHaveBeenCalled();
+  });
+
+  it('clears match handoff state after explicitly reaching the debate URL', async () => {
+    mocks.pathname = '/space/space-1/debates/debate-1';
+    mocks.activity = activityWithDebate();
+    seedConfirmedOwnership();
+
+    render(<DebateCoordinator />);
+
+    await waitFor(() => expect(sessionStorage.getItem('geo:debate-match-owner:user-for')).toBeNull());
+    expect(mocks.push).not.toHaveBeenCalled();
+  });
+
   it('waits for the debate room to finalize its recording before routing to a rematch', async () => {
     mocks.pathname = '/space/space-1/debates/debate-1';
     mocks.activity = activityWithRematch('browsing');
@@ -166,10 +240,12 @@ describe('DebateCoordinator', () => {
         status,
       },
     };
+    seedConfirmedOwnership();
 
     render(<DebateCoordinator />);
 
     await waitFor(() => expect(mocks.push).not.toHaveBeenCalled());
+    expect(sessionStorage.getItem('geo:debate-match-owner:user-for')).toBeNull();
   });
 
   it('requests the exact social preview and starts preparing the MP4 on open', async () => {
@@ -554,6 +630,27 @@ function videoResponse() {
   });
 }
 
+function seedConfirmedOwnership() {
+  const now = Date.now();
+  sessionStorage.setItem(
+    'geo:debate-match-owner:user-for',
+    JSON.stringify({
+      version: 1,
+      state: 'confirmed',
+      userId: 'user-for',
+      matchId: 'match-1',
+      claimId: 'claim-1',
+      spaceId: 'space-1',
+      instanceId: 'previous-instance',
+      createdAt: now,
+      acceptedAt: now,
+    })
+  );
+  vi.spyOn(performance, 'getEntriesByType').mockImplementation(type =>
+    type === 'navigation' ? ([{ type: 'reload' }] as PerformanceNavigationTiming[]) : []
+  );
+}
+
 function activityWithRematch(status: 'deciding' | 'browsing'): DebateActivity {
   return {
     online: true,
@@ -612,6 +709,7 @@ function activityWithDebate(): DebateActivity {
     debate: {
       id: 'debate-1',
       claim: matchActivity.match!.claim,
+      participants: [{ user_id: 'user-for' }],
     } as NonNullable<DebateActivity['debate']>,
   };
 }

--- a/apps/web/core/debates/debate-coordinator.test.tsx
+++ b/apps/web/core/debates/debate-coordinator.test.tsx
@@ -148,6 +148,19 @@ describe('DebateCoordinator', () => {
     expect(screen.queryByText('Global match prompt')).not.toBeInTheDocument();
   });
 
+  it('leaves retained handoff ownership with the mounted match prompt', () => {
+    mocks.activity = activityWithMatch();
+    seedConfirmedOwnership();
+    const view = render(<DebateCoordinator />);
+
+    mocks.activity = activityWithDebate();
+    view.rerender(<DebateCoordinator />);
+
+    expect(screen.getByText('Global match prompt')).toBeInTheDocument();
+    expect(sessionStorage.getItem('geo:debate-match-owner:user-for')).not.toBeNull();
+    expect(mocks.push).not.toHaveBeenCalled();
+  });
+
   it('leaves a secondary tab on its current page when shared activity contains a debate', async () => {
     mocks.pathname = '/space/space-1/claims';
     mocks.activity = activityWithDebate();
@@ -246,6 +259,43 @@ describe('DebateCoordinator', () => {
 
     await waitFor(() => expect(mocks.push).not.toHaveBeenCalled());
     expect(sessionStorage.getItem('geo:debate-match-owner:user-for')).toBeNull();
+  });
+
+  it('clears ownership when loaded activity confirms the match flow expired', async () => {
+    mocks.activity = activityWithMatch();
+    seedConfirmedOwnership();
+    const view = render(<DebateCoordinator />);
+
+    expect(screen.getByText('Global match prompt')).toBeInTheDocument();
+
+    mocks.activity = { ...activityWithMatch(), match: null };
+    view.rerender(<DebateCoordinator />);
+
+    await waitFor(() => expect(sessionStorage.getItem('geo:debate-match-owner:user-for')).toBeNull());
+    expect(mocks.push).not.toHaveBeenCalled();
+  });
+
+  it('clears ownership when a different match replaces the owned flow', async () => {
+    const replacementActivity = activityWithMatch();
+    replacementActivity.match = {
+      ...replacementActivity.match!,
+      id: 'match-2',
+      claim: {
+        ...replacementActivity.match!.claim,
+        id: 'claim-2',
+        claim_entity_id: 'claim-entity-2',
+      },
+    };
+    mocks.activity = replacementActivity;
+    seedConfirmedOwnership();
+    const view = render(<DebateCoordinator />);
+
+    await waitFor(() => expect(sessionStorage.getItem('geo:debate-match-owner:user-for')).toBeNull());
+
+    mocks.activity = activityWithDebate();
+    view.rerender(<DebateCoordinator />);
+
+    await waitFor(() => expect(mocks.push).not.toHaveBeenCalled());
   });
 
   it('requests the exact social preview and starts preparing the MP4 on open', async () => {

--- a/apps/web/core/debates/debate-coordinator.tsx
+++ b/apps/web/core/debates/debate-coordinator.tsx
@@ -91,20 +91,26 @@ export function DebateCoordinator() {
   }, [activity, pathname, router]);
 
   React.useEffect(() => {
-    if (!currentUserId) return;
+    if (!currentUserId || !activity) return;
     if (debate && pathname.includes(`/debates/${debate.id}`)) {
       clearDebateMatchTabOwnership(currentUserId);
       return;
     }
     const record = readDebateMatchTabOwnership(currentUserId);
     if (!record) return;
-    if (reportedDebate && ['complete', 'cancelled'].includes(reportedDebate.status)) {
-      if (debateMatchOwnershipMatchesDebate(record, reportedDebate, currentUserId)) {
-        clearDebateMatchTabOwnership(currentUserId);
-      }
+    if (match) {
+      if (match.id !== record.matchId) clearDebateMatchTabOwnership(currentUserId);
       return;
     }
-    if (!debate || visibleMatch || pathname.includes('/debates/rematches/')) return;
+    if (reportedDebate && ['complete', 'cancelled'].includes(reportedDebate.status)) {
+      clearDebateMatchTabOwnership(currentUserId);
+      return;
+    }
+    if (!debate || pathname.includes('/debates/rematches/')) {
+      clearDebateMatchTabOwnership(currentUserId);
+      return;
+    }
+    if (visibleMatch) return;
     if (!debateMatchOwnershipMatchesDebate(record, debate, currentUserId)) {
       clearDebateMatchTabOwnership(currentUserId);
       return;
@@ -127,7 +133,7 @@ export function DebateCoordinator() {
       active = false;
       ownership.close();
     };
-  }, [currentUserId, debate, pathname, reportedDebate, router, visibleMatch]);
+  }, [activity, currentUserId, debate, match, pathname, reportedDebate, router, visibleMatch]);
 
   if (!isDebatesEnabled) return null;
   const visibleSharePrompt =

--- a/apps/web/core/debates/debate-coordinator.tsx
+++ b/apps/web/core/debates/debate-coordinator.tsx
@@ -11,8 +11,14 @@ import { Upload } from '~/design-system/icons/upload';
 import { Spinner } from '~/design-system/spinner';
 import { Text } from '~/design-system/text';
 
-import type { DebateMatch, DebateSharePrompt } from './api';
+import { type DebateMatch, type DebateSharePrompt, getCurrentGeoChatUserId } from './api';
 import { useDebateGateway } from './debate-gateway';
+import {
+  clearDebateMatchTabOwnership,
+  createDebateMatchTabOwnershipCoordinator,
+  debateMatchOwnershipMatchesDebate,
+  readDebateMatchTabOwnership,
+} from './debate-match-tab-ownership';
 import { useDebateActivity, useDebateSharePrompts, useGeoChatAuth, useHandleDebateSharePrompt } from './hooks';
 import { DebateMatchPrompt } from './match-prompt';
 import { captureSocialVideoEvent, isAbortError, usePreparedSocialVideo } from './social-video-share';
@@ -28,6 +34,7 @@ export function DebateCoordinator() {
     geoChatAuth.accountKey
   );
   const activityQuery = useDebateActivity(isDebatesEnabled);
+  const currentUserId = getCurrentGeoChatUserId();
   const activity = activityQuery.data ?? null;
   const match = activity?.match ?? null;
   const reportedDebate = activity?.debate ?? null;
@@ -67,13 +74,6 @@ export function DebateCoordinator() {
 
   React.useEffect(() => {
     if (!activity) return;
-    const viewingRematch = pathname.includes('/debates/rematches/');
-    if (debate && !viewingRematch && !pathname.includes(`/debates/${debate.id}`)) {
-      // The retained match prompt owns this handoff so it can deduplicate
-      // navigation from the accept response and the activity update.
-      if (!visibleMatch) router.push(`/space/${debate.claim.space_id}/debates/${debate.id}`);
-      return;
-    }
     const rematch = activity.rematch;
     if (!rematch) return;
     if (rematch.status === 'deciding') {
@@ -88,7 +88,46 @@ export function DebateCoordinator() {
       const path = `/space/${rematch.source_space_id}/debates/rematches/${rematch.id}`;
       if (pathname !== path) router.push(path);
     }
-  }, [activity, debate, pathname, router, visibleMatch]);
+  }, [activity, pathname, router]);
+
+  React.useEffect(() => {
+    if (!currentUserId) return;
+    if (debate && pathname.includes(`/debates/${debate.id}`)) {
+      clearDebateMatchTabOwnership(currentUserId);
+      return;
+    }
+    const record = readDebateMatchTabOwnership(currentUserId);
+    if (!record) return;
+    if (reportedDebate && ['complete', 'cancelled'].includes(reportedDebate.status)) {
+      if (debateMatchOwnershipMatchesDebate(record, reportedDebate, currentUserId)) {
+        clearDebateMatchTabOwnership(currentUserId);
+      }
+      return;
+    }
+    if (!debate || visibleMatch || pathname.includes('/debates/rematches/')) return;
+    if (!debateMatchOwnershipMatchesDebate(record, debate, currentUserId)) {
+      clearDebateMatchTabOwnership(currentUserId);
+      return;
+    }
+
+    const ownership = createDebateMatchTabOwnershipCoordinator({
+      matchId: record.matchId,
+      claimId: record.claimId,
+      spaceId: record.spaceId,
+      userId: currentUserId,
+      onAcceptedElsewhere: () => undefined,
+    });
+    let active = true;
+    void ownership.recover().then(recovered => {
+      if (!active || !recovered) return;
+      if (record.state === 'pending') ownership.confirmAcceptance();
+      router.push(`/space/${debate.claim.space_id}/debates/${debate.id}`);
+    });
+    return () => {
+      active = false;
+      ownership.close();
+    };
+  }, [currentUserId, debate, pathname, reportedDebate, router, visibleMatch]);
 
   if (!isDebatesEnabled) return null;
   const visibleSharePrompt =
@@ -110,6 +149,7 @@ export function DebateCoordinator() {
           spaceId={visibleMatch.claim.space_id}
           matches={[visibleMatch]}
           debates={debate ? [debate] : []}
+          reconcileActivity={async () => (await activityQuery.refetch({ throwOnError: true })).data ?? null}
         />
       )}
       {!activeFlow && visibleSharePrompt && (

--- a/apps/web/core/debates/debate-match-tab-ownership.test.ts
+++ b/apps/web/core/debates/debate-match-tab-ownership.test.ts
@@ -87,6 +87,32 @@ class MemoryStorage implements Storage {
   }
 }
 
+class ThrowingStorage implements Storage {
+  get length(): number {
+    throw new Error('Storage unavailable');
+  }
+
+  clear(): void {
+    throw new Error('Storage unavailable');
+  }
+
+  getItem(): string | null {
+    throw new Error('Storage unavailable');
+  }
+
+  key(): string | null {
+    throw new Error('Storage unavailable');
+  }
+
+  removeItem(): void {
+    throw new Error('Storage unavailable');
+  }
+
+  setItem(): void {
+    throw new Error('Storage unavailable');
+  }
+}
+
 beforeEach(() => {
   FakeBroadcastChannel.channels.clear();
   Object.defineProperty(navigator, 'locks', { configurable: true, value: new FakeLockManager() });
@@ -185,6 +211,26 @@ describe('debate match tab ownership', () => {
     duplicate.close();
   });
 
+  it('rejects reload recovery while the original tab still holds the lock', async () => {
+    const ownerStorage = new MemoryStorage();
+    const owner = coordinator({ storage: ownerStorage });
+    await owner.acquire();
+    owner.beginAcceptance();
+    owner.confirmAcceptance();
+
+    const reloadStorage = new MemoryStorage();
+    reloadStorage.setItem('geo:debate-match-owner:user-a', ownerStorage.getItem('geo:debate-match-owner:user-a')!);
+    const reload = coordinator({ storage: reloadStorage, isReloadNavigation: () => true });
+
+    await expect(reload.recover()).resolves.toBe(false);
+    expect(reload.ownsFlow()).toBe(false);
+    expect(readDebateMatchTabOwnership('user-a', { storage: reloadStorage, now: () => 1_000 })).toBeNull();
+    expect(owner.ownsFlow()).toBe(true);
+
+    owner.close();
+    reload.close();
+  });
+
   it('does not promote a duplicate after the owner closes', async () => {
     const ownerStorage = new MemoryStorage();
     const owner = coordinator({ storage: ownerStorage });
@@ -247,6 +293,25 @@ describe('debate match tab ownership', () => {
     owner.close();
   });
 
+  it('degrades when browser coordination APIs throw or reject', async () => {
+    vi.stubGlobal(
+      'BroadcastChannel',
+      class {
+        constructor() {
+          throw new Error('BroadcastChannel unavailable');
+        }
+      }
+    );
+    Object.defineProperty(navigator, 'locks', {
+      configurable: true,
+      value: { request: vi.fn().mockRejectedValue(new Error('Lock request unavailable')) },
+    });
+    const owner = coordinator({ storage: new MemoryStorage() });
+
+    await expect(owner.acquire()).resolves.toBe(false);
+    owner.close();
+  });
+
   it('uses a confirmation broadcast to stop a late fallback success when Web Locks are unavailable', async () => {
     Object.defineProperty(navigator, 'locks', { configurable: true, value: undefined });
     const first = coordinator({ storage: new MemoryStorage() });
@@ -270,6 +335,28 @@ describe('debate match tab ownership', () => {
     const secondAcceptedElsewhere = vi.fn();
     const first = coordinator({ storage: new MemoryStorage(), onAcceptedElsewhere: firstAcceptedElsewhere });
     const second = coordinator({ storage: new MemoryStorage(), onAcceptedElsewhere: secondAcceptedElsewhere });
+    await first.acquire();
+    await second.acquire();
+    first.beginAcceptance();
+    second.beginAcceptance();
+
+    first.confirmAcceptance();
+    second.confirmAcceptance();
+
+    await vi.waitFor(() => expect(second.ownsFlow()).toBe(false));
+    expect(first.ownsFlow()).toBe(true);
+    expect(firstAcceptedElsewhere).not.toHaveBeenCalled();
+    expect(secondAcceptedElsewhere).toHaveBeenCalledWith('match-1');
+    first.close();
+    second.close();
+  });
+
+  it('keeps one deterministic fallback owner when session storage is unavailable', async () => {
+    Object.defineProperty(navigator, 'locks', { configurable: true, value: undefined });
+    const firstAcceptedElsewhere = vi.fn();
+    const secondAcceptedElsewhere = vi.fn();
+    const first = coordinator({ storage: new ThrowingStorage(), onAcceptedElsewhere: firstAcceptedElsewhere });
+    const second = coordinator({ storage: new ThrowingStorage(), onAcceptedElsewhere: secondAcceptedElsewhere });
     await first.acquire();
     await second.acquire();
     first.beginAcceptance();

--- a/apps/web/core/debates/debate-match-tab-ownership.test.ts
+++ b/apps/web/core/debates/debate-match-tab-ownership.test.ts
@@ -1,0 +1,309 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  createDebateMatchTabOwnershipCoordinator,
+  debateMatchTabOwnershipTtlMs,
+  readDebateMatchTabOwnership,
+} from './debate-match-tab-ownership';
+
+type QueuedLock = {
+  callback: (lock: Lock | null) => Promise<void> | void;
+  resolve: () => void;
+  reject: (error: unknown) => void;
+};
+
+class FakeLockManager {
+  private held = new Set<string>();
+
+  request(name: string, options: LockOptions, callback: (lock: Lock | null) => Promise<void> | void): Promise<void> {
+    if (options.ifAvailable && this.held.has(name)) return Promise.resolve(callback(null));
+
+    return new Promise<void>((resolve, reject) => {
+      const queued: QueuedLock = { callback, resolve, reject };
+      void this.run(name, queued);
+    });
+  }
+
+  private async run(name: string, queued: QueuedLock) {
+    this.held.add(name);
+    try {
+      await queued.callback({ name, mode: 'exclusive' });
+      queued.resolve();
+    } catch (error) {
+      queued.reject(error);
+    } finally {
+      this.held.delete(name);
+    }
+  }
+}
+
+class FakeBroadcastChannel {
+  static channels = new Map<string, Set<FakeBroadcastChannel>>();
+
+  onmessage: ((event: MessageEvent) => void) | null = null;
+
+  constructor(private readonly name: string) {
+    const channels = FakeBroadcastChannel.channels.get(name) ?? new Set();
+    channels.add(this);
+    FakeBroadcastChannel.channels.set(name, channels);
+  }
+
+  postMessage(data: unknown) {
+    for (const channel of FakeBroadcastChannel.channels.get(this.name) ?? []) {
+      if (channel !== this) queueMicrotask(() => channel.onmessage?.(new MessageEvent('message', { data })));
+    }
+  }
+
+  close() {
+    FakeBroadcastChannel.channels.get(this.name)?.delete(this);
+  }
+}
+
+class MemoryStorage implements Storage {
+  private values = new Map<string, string>();
+
+  get length() {
+    return this.values.size;
+  }
+
+  clear() {
+    this.values.clear();
+  }
+
+  getItem(key: string) {
+    return this.values.get(key) ?? null;
+  }
+
+  key(index: number) {
+    return Array.from(this.values.keys())[index] ?? null;
+  }
+
+  removeItem(key: string) {
+    this.values.delete(key);
+  }
+
+  setItem(key: string, value: string) {
+    this.values.set(key, value);
+  }
+}
+
+beforeEach(() => {
+  FakeBroadcastChannel.channels.clear();
+  Object.defineProperty(navigator, 'locks', { configurable: true, value: new FakeLockManager() });
+  vi.stubGlobal('BroadcastChannel', FakeBroadcastChannel);
+  let instanceNumber = 0;
+  vi.stubGlobal('crypto', { randomUUID: vi.fn(() => `instance-${++instanceNumber}`) });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  Object.defineProperty(navigator, 'locks', { configurable: true, value: undefined });
+});
+
+describe('debate match tab ownership', () => {
+  it('allows only one tab to begin an action for the same match', async () => {
+    const first = coordinator({ storage: new MemoryStorage() });
+    const second = coordinator({ storage: new MemoryStorage() });
+
+    await expect(first.acquire()).resolves.toBe(true);
+    await expect(second.acquire()).resolves.toBe(false);
+
+    first.close();
+    second.close();
+  });
+
+  it('persists pending ownership before confirmation and broadcasts only after success', async () => {
+    const firstStorage = new MemoryStorage();
+    const secondStorage = new MemoryStorage();
+    const acceptedElsewhere = vi.fn();
+    const first = coordinator({ storage: firstStorage });
+    const second = coordinator({ storage: secondStorage, onAcceptedElsewhere: acceptedElsewhere });
+
+    await first.acquire();
+    expect(first.beginAcceptance()).toMatchObject({ state: 'pending', instanceId: first.instanceId });
+    expect(readDebateMatchTabOwnership('user-a', { storage: firstStorage, now: () => 1_000 })).toMatchObject({
+      state: 'pending',
+    });
+    expect(readDebateMatchTabOwnership('user-a', { storage: secondStorage, now: () => 1_000 })).toBeNull();
+    expect(acceptedElsewhere).not.toHaveBeenCalled();
+
+    expect(first.confirmAcceptance()).toMatchObject({ state: 'confirmed', acceptedAt: 1_000 });
+    expect(first.confirmAcceptance()).toMatchObject({ state: 'confirmed', acceptedAt: 1_000 });
+    await vi.waitFor(() => expect(acceptedElsewhere).toHaveBeenCalledWith('match-1'));
+    expect(acceptedElsewhere).toHaveBeenCalledTimes(1);
+    expect(readDebateMatchTabOwnership('user-a', { storage: firstStorage, now: () => 1_000 })).toMatchObject({
+      state: 'confirmed',
+    });
+
+    first.close();
+    second.close();
+  });
+
+  it('clears a failed pending attempt when its owner releases it', async () => {
+    const storage = new MemoryStorage();
+    const owner = coordinator({ storage });
+    const retryingTab = coordinator({ storage: new MemoryStorage() });
+
+    await owner.acquire();
+    owner.beginAcceptance();
+    await owner.release({ clearRecord: true });
+
+    expect(readDebateMatchTabOwnership('user-a', { storage, now: () => 1_000 })).toBeNull();
+    await expect(retryingTab.acquire()).resolves.toBe(true);
+
+    owner.close();
+    retryingTab.close();
+  });
+
+  it('recovers ownership only for an actual reload and rejects a duplicated-tab marker', async () => {
+    const originalStorage = new MemoryStorage();
+    const original = coordinator({ storage: originalStorage });
+    await original.acquire();
+    original.beginAcceptance();
+    original.confirmAcceptance();
+    const clonedRecord = originalStorage.getItem('geo:debate-match-owner:user-a')!;
+    await original.release();
+    original.close();
+
+    const reloadStorage = new MemoryStorage();
+    reloadStorage.setItem('geo:debate-match-owner:user-a', clonedRecord);
+    const reload = coordinator({ storage: reloadStorage, isReloadNavigation: () => true });
+    await expect(reload.recover()).resolves.toBe(true);
+    expect(reload.ownsFlow()).toBe(true);
+    expect(readDebateMatchTabOwnership('user-a', { storage: reloadStorage, now: () => 1_000 })).toMatchObject({
+      instanceId: reload.instanceId,
+      state: 'confirmed',
+    });
+    await reload.release();
+    reload.close();
+
+    const duplicateStorage = new MemoryStorage();
+    duplicateStorage.setItem('geo:debate-match-owner:user-a', clonedRecord);
+    const duplicate = coordinator({ storage: duplicateStorage, isReloadNavigation: () => false });
+    await expect(duplicate.recover()).resolves.toBe(false);
+    expect(readDebateMatchTabOwnership('user-a', { storage: duplicateStorage, now: () => 1_000 })).toBeNull();
+    duplicate.close();
+  });
+
+  it('does not promote a duplicate after the owner closes', async () => {
+    const ownerStorage = new MemoryStorage();
+    const owner = coordinator({ storage: ownerStorage });
+    await owner.acquire();
+    owner.beginAcceptance();
+    owner.confirmAcceptance();
+
+    const duplicateStorage = new MemoryStorage();
+    duplicateStorage.setItem('geo:debate-match-owner:user-a', ownerStorage.getItem('geo:debate-match-owner:user-a')!);
+    const duplicate = coordinator({ storage: duplicateStorage, isReloadNavigation: () => false });
+    await owner.release();
+    owner.close();
+
+    await expect(duplicate.recover()).resolves.toBe(false);
+    expect(duplicate.ownsFlow()).toBe(false);
+    duplicate.close();
+  });
+
+  it('removes malformed and expired records before they can recover', () => {
+    const storage = new MemoryStorage();
+    storage.setItem('geo:debate-match-owner:user-a', '{not json');
+    expect(readDebateMatchTabOwnership('user-a', { storage })).toBeNull();
+
+    storage.setItem(
+      'geo:debate-match-owner:user-a',
+      JSON.stringify({
+        version: 1,
+        state: 'confirmed',
+        userId: 'user-a',
+        matchId: 'match-1',
+        claimId: 'claim-1',
+        spaceId: 'space-1',
+        instanceId: 'old',
+        createdAt: 1_000,
+        acceptedAt: 1_000,
+      })
+    );
+    expect(
+      readDebateMatchTabOwnership('user-a', {
+        storage,
+        now: () => 1_000 + debateMatchTabOwnershipTtlMs,
+      })
+    ).toMatchObject({ state: 'confirmed' });
+    expect(
+      readDebateMatchTabOwnership('user-a', {
+        storage,
+        now: () => 1_000 + debateMatchTabOwnershipTtlMs + 1,
+      })
+    ).toBeNull();
+  });
+
+  it('degrades without Web Locks or BroadcastChannel without crashing', async () => {
+    Object.defineProperty(navigator, 'locks', { configurable: true, value: undefined });
+    vi.stubGlobal('BroadcastChannel', undefined);
+    const owner = coordinator({ storage: new MemoryStorage() });
+
+    await expect(owner.acquire()).resolves.toBe(true);
+    expect(() => owner.beginAcceptance()).not.toThrow();
+    expect(() => owner.confirmAcceptance()).not.toThrow();
+    owner.close();
+  });
+
+  it('uses a confirmation broadcast to stop a late fallback success when Web Locks are unavailable', async () => {
+    Object.defineProperty(navigator, 'locks', { configurable: true, value: undefined });
+    const first = coordinator({ storage: new MemoryStorage() });
+    const second = coordinator({ storage: new MemoryStorage() });
+    await first.acquire();
+    await second.acquire();
+    first.beginAcceptance();
+    second.beginAcceptance();
+
+    first.confirmAcceptance();
+
+    await vi.waitFor(() => expect(second.ownsFlow()).toBe(false));
+    expect(second.confirmAcceptance()).toBeNull();
+    first.close();
+    second.close();
+  });
+
+  it('keeps one deterministic fallback owner when two tabs confirm before broadcasts arrive', async () => {
+    Object.defineProperty(navigator, 'locks', { configurable: true, value: undefined });
+    const firstAcceptedElsewhere = vi.fn();
+    const secondAcceptedElsewhere = vi.fn();
+    const first = coordinator({ storage: new MemoryStorage(), onAcceptedElsewhere: firstAcceptedElsewhere });
+    const second = coordinator({ storage: new MemoryStorage(), onAcceptedElsewhere: secondAcceptedElsewhere });
+    await first.acquire();
+    await second.acquire();
+    first.beginAcceptance();
+    second.beginAcceptance();
+
+    first.confirmAcceptance();
+    second.confirmAcceptance();
+
+    await vi.waitFor(() => expect(second.ownsFlow()).toBe(false));
+    expect(first.ownsFlow()).toBe(true);
+    expect(firstAcceptedElsewhere).not.toHaveBeenCalled();
+    expect(secondAcceptedElsewhere).toHaveBeenCalledWith('match-1');
+    first.close();
+    second.close();
+  });
+});
+
+function coordinator({
+  storage,
+  onAcceptedElsewhere = vi.fn(),
+  isReloadNavigation = () => false,
+}: {
+  storage: Storage;
+  onAcceptedElsewhere?: (matchId: string) => void;
+  isReloadNavigation?: () => boolean;
+}) {
+  return createDebateMatchTabOwnershipCoordinator({
+    matchId: 'match-1',
+    claimId: 'claim-1',
+    spaceId: 'space-1',
+    userId: 'user-a',
+    storage,
+    now: () => 1_000,
+    isReloadNavigation,
+    onAcceptedElsewhere,
+  });
+}

--- a/apps/web/core/debates/debate-match-tab-ownership.ts
+++ b/apps/web/core/debates/debate-match-tab-ownership.ts
@@ -1,0 +1,336 @@
+export const debateMatchTabOwnershipTtlMs = 60 * 60 * 1_000;
+
+const recordVersion = 1 as const;
+const storageKeyPrefix = 'geo:debate-match-owner:';
+
+export type DebateMatchTabOwnershipRecord = {
+  version: typeof recordVersion;
+  state: 'pending' | 'confirmed';
+  userId: string;
+  matchId: string;
+  claimId: string;
+  spaceId: string;
+  instanceId: string;
+  createdAt: number;
+  acceptedAt: number | null;
+};
+
+type OwnershipMessage = {
+  type: 'accept-confirmed';
+  matchId: string;
+  instanceId: string;
+};
+
+type CreateDebateMatchTabOwnershipCoordinatorOptions = {
+  matchId: string;
+  claimId: string;
+  spaceId: string;
+  userId: string;
+  onAcceptedElsewhere: (matchId: string) => void;
+  storage?: Storage | null;
+  now?: () => number;
+  isReloadNavigation?: () => boolean;
+};
+
+export type DebateMatchTabOwnershipCoordinator = {
+  readonly instanceId: string;
+  acquire: () => Promise<boolean>;
+  beginAcceptance: () => DebateMatchTabOwnershipRecord | null;
+  confirmAcceptance: () => DebateMatchTabOwnershipRecord | null;
+  recover: () => Promise<boolean>;
+  release: (options?: { clearRecord?: boolean }) => Promise<void>;
+  close: () => void;
+  ownsFlow: () => boolean;
+};
+
+export function createDebateMatchTabOwnershipCoordinator({
+  matchId,
+  claimId,
+  spaceId,
+  userId,
+  onAcceptedElsewhere,
+  storage = defaultSessionStorage(),
+  now = Date.now,
+  isReloadNavigation = defaultIsReloadNavigation,
+}: CreateDebateMatchTabOwnershipCoordinatorOptions): DebateMatchTabOwnershipCoordinator {
+  const instanceId = createInstanceId();
+  const coordinationName = `geo:debate-match:${matchId}:${userId}`;
+  const browserLockManager =
+    typeof navigator !== 'undefined' ? (navigator as Navigator & { locks?: LockManager }).locks : undefined;
+  const lockManager = typeof browserLockManager?.request === 'function' ? browserLockManager : null;
+  let channel: BroadcastChannel | null = null;
+  if (typeof BroadcastChannel !== 'undefined') {
+    try {
+      channel = new BroadcastChannel(coordinationName);
+    } catch {
+      channel = null;
+    }
+  }
+
+  let ownsFlow = false;
+  let closed = false;
+  let releaseLock: (() => void) | null = null;
+  let lockRequest: Promise<void> | null = null;
+  let releaseRequest: Promise<void> | null = null;
+  let acquisition: Promise<boolean> | null = null;
+
+  const recordBelongsToInstance = () => {
+    const record = readDebateMatchTabOwnership(userId, { storage, now });
+    return record?.matchId === matchId && record.instanceId === instanceId;
+  };
+
+  const clearRecord = () => {
+    if (!recordBelongsToInstance()) return;
+    removeRecord(userId, storage);
+  };
+
+  const acquire = (): Promise<boolean> => {
+    if (releaseRequest) return releaseRequest.then(acquire);
+    if (ownsFlow) return Promise.resolve(true);
+    if (closed) return Promise.resolve(false);
+    if (!lockManager) {
+      ownsFlow = true;
+      return Promise.resolve(true);
+    }
+    if (acquisition) return acquisition;
+
+    acquisition = new Promise<boolean>(resolve => {
+      const request = lockManager.request(coordinationName, { ifAvailable: true, mode: 'exclusive' }, async lock => {
+        const acquired = Boolean(lock) && !closed;
+        resolve(acquired);
+        if (!acquired) return;
+        ownsFlow = true;
+        await new Promise<void>(release => {
+          releaseLock = release;
+        });
+        releaseLock = null;
+        ownsFlow = false;
+      });
+      lockRequest = request.then(
+        () => undefined,
+        () => resolve(false)
+      );
+    })
+      .catch(() => false)
+      .finally(() => {
+        acquisition = null;
+      });
+
+    return acquisition;
+  };
+
+  const release = async ({ clearRecord: shouldClearRecord = false }: { clearRecord?: boolean } = {}) => {
+    if (shouldClearRecord) clearRecord();
+    if (releaseRequest) {
+      await releaseRequest;
+      return;
+    }
+    if (!lockManager) {
+      ownsFlow = false;
+      return;
+    }
+    if (!releaseLock) return;
+    const activeRequest = lockRequest;
+    const releaseCurrentLock = releaseLock;
+    ownsFlow = false;
+    releaseCurrentLock();
+    const completion = (activeRequest ?? Promise.resolve()).finally(() => {
+      if (releaseRequest === completion) releaseRequest = null;
+    });
+    releaseRequest = completion;
+    await completion;
+  };
+
+  if (channel) {
+    channel.onmessage = event => {
+      const message = event.data as OwnershipMessage;
+      if (
+        !message ||
+        typeof message !== 'object' ||
+        message.type !== 'accept-confirmed' ||
+        message.matchId !== matchId ||
+        message.instanceId === instanceId
+      ) {
+        return;
+      }
+      const record = readDebateMatchTabOwnership(userId, { storage, now });
+      if (
+        !lockManager &&
+        ownsFlow &&
+        record?.matchId === matchId &&
+        record.instanceId === instanceId &&
+        record.state === 'confirmed' &&
+        instanceId.localeCompare(message.instanceId) < 0
+      ) {
+        return;
+      }
+      void release({ clearRecord: true });
+      onAcceptedElsewhere(matchId);
+    };
+  }
+
+  const writeState = (state: DebateMatchTabOwnershipRecord['state']) => {
+    if (!ownsFlow || closed) return null;
+    const existing = readDebateMatchTabOwnership(userId, { storage, now });
+    const timestamp = now();
+    const record: DebateMatchTabOwnershipRecord = {
+      version: recordVersion,
+      state,
+      userId,
+      matchId,
+      claimId,
+      spaceId,
+      instanceId,
+      createdAt: existing?.matchId === matchId ? existing.createdAt : timestamp,
+      acceptedAt: state === 'confirmed' ? timestamp : null,
+    };
+    writeRecord(record, storage);
+    return record;
+  };
+
+  return {
+    instanceId,
+    acquire,
+    beginAcceptance: () => writeState('pending'),
+    confirmAcceptance: () => {
+      const existing = readDebateMatchTabOwnership(userId, { storage, now });
+      if (existing?.matchId === matchId && existing.instanceId === instanceId && existing.state === 'confirmed') {
+        return existing;
+      }
+      const record = writeState('confirmed');
+      if (record && channel) {
+        try {
+          channel.postMessage({ type: 'accept-confirmed', matchId, instanceId } satisfies OwnershipMessage);
+        } catch {
+          // Shared activity still dismisses secondary tabs if the channel closes or rejects the message.
+        }
+      }
+      return record;
+    },
+    recover: async () => {
+      const record = readDebateMatchTabOwnership(userId, { storage, now });
+      if (!record || record.matchId !== matchId || record.claimId !== claimId || record.spaceId !== spaceId) {
+        return false;
+      }
+      if (!isReloadNavigation()) {
+        removeRecord(userId, storage);
+        return false;
+      }
+      if (!(await acquire())) {
+        removeRecord(userId, storage);
+        return false;
+      }
+      writeRecord({ ...record, instanceId }, storage);
+      return true;
+    },
+    release,
+    close: () => {
+      closed = true;
+      void release();
+      channel?.close();
+    },
+    ownsFlow: () => ownsFlow,
+  };
+}
+
+export function readDebateMatchTabOwnership(
+  userId: string,
+  { storage = defaultSessionStorage(), now = Date.now }: { storage?: Storage | null; now?: () => number } = {}
+): DebateMatchTabOwnershipRecord | null {
+  if (!storage) return null;
+  let raw: string | null = null;
+  try {
+    raw = storage.getItem(storageKey(userId));
+  } catch {
+    return null;
+  }
+  if (!raw) return null;
+
+  try {
+    const record = JSON.parse(raw) as Partial<DebateMatchTabOwnershipRecord>;
+    if (!isValidRecord(record) || now() - recordTimestamp(record) > debateMatchTabOwnershipTtlMs) {
+      removeRecord(userId, storage);
+      return null;
+    }
+    return record;
+  } catch {
+    removeRecord(userId, storage);
+    return null;
+  }
+}
+
+export function clearDebateMatchTabOwnership(userId: string, storage: Storage | null = defaultSessionStorage()) {
+  removeRecord(userId, storage);
+}
+
+export function debateMatchOwnershipMatchesDebate(
+  record: Pick<DebateMatchTabOwnershipRecord, 'userId' | 'claimId' | 'spaceId'>,
+  debate: { claim: { id: string; space_id: string }; participants: { user_id: string }[] },
+  userId: string
+) {
+  return (
+    record.userId === userId &&
+    record.claimId === debate.claim.id &&
+    record.spaceId === debate.claim.space_id &&
+    debate.participants.some(participant => participant.user_id === userId)
+  );
+}
+
+function isValidRecord(record: Partial<DebateMatchTabOwnershipRecord>): record is DebateMatchTabOwnershipRecord {
+  return (
+    record.version === recordVersion &&
+    (record.state === 'pending' || record.state === 'confirmed') &&
+    typeof record.userId === 'string' &&
+    typeof record.matchId === 'string' &&
+    typeof record.claimId === 'string' &&
+    typeof record.spaceId === 'string' &&
+    typeof record.instanceId === 'string' &&
+    typeof record.createdAt === 'number' &&
+    (record.state === 'pending' ? record.acceptedAt === null : typeof record.acceptedAt === 'number')
+  );
+}
+
+function recordTimestamp(record: DebateMatchTabOwnershipRecord) {
+  return record.state === 'confirmed' ? (record.acceptedAt ?? record.createdAt) : record.createdAt;
+}
+
+function writeRecord(record: DebateMatchTabOwnershipRecord, storage: Storage | null) {
+  if (!storage) return;
+  try {
+    storage.setItem(storageKey(record.userId), JSON.stringify(record));
+  } catch {
+    // Storage is a recovery aid. Ownership still remains protected by the live Web Lock.
+  }
+}
+
+function removeRecord(userId: string, storage: Storage | null) {
+  if (!storage) return;
+  try {
+    storage.removeItem(storageKey(userId));
+  } catch {
+    // Ignore unavailable or privacy-restricted storage.
+  }
+}
+
+function storageKey(userId: string) {
+  return `${storageKeyPrefix}${userId}`;
+}
+
+function defaultSessionStorage() {
+  if (typeof sessionStorage === 'undefined') return null;
+  try {
+    return sessionStorage;
+  } catch {
+    return null;
+  }
+}
+
+function defaultIsReloadNavigation() {
+  if (typeof performance === 'undefined') return false;
+  const navigation = performance.getEntriesByType?.('navigation')[0] as PerformanceNavigationTiming | undefined;
+  return navigation?.type === 'reload';
+}
+
+function createInstanceId() {
+  return globalThis.crypto?.randomUUID?.() ?? `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}

--- a/apps/web/core/debates/debate-match-tab-ownership.ts
+++ b/apps/web/core/debates/debate-match-tab-ownership.ts
@@ -73,15 +73,19 @@ export function createDebateMatchTabOwnershipCoordinator({
   let lockRequest: Promise<void> | null = null;
   let releaseRequest: Promise<void> | null = null;
   let acquisition: Promise<boolean> | null = null;
+  let localRecord: DebateMatchTabOwnershipRecord | null = null;
+
+  const currentRecord = () => readDebateMatchTabOwnership(userId, { storage, now }) ?? localRecord;
 
   const recordBelongsToInstance = () => {
-    const record = readDebateMatchTabOwnership(userId, { storage, now });
+    const record = currentRecord();
     return record?.matchId === matchId && record.instanceId === instanceId;
   };
 
   const clearRecord = () => {
     if (!recordBelongsToInstance()) return;
     removeRecord(userId, storage);
+    localRecord = null;
   };
 
   const acquire = (): Promise<boolean> => {
@@ -153,7 +157,7 @@ export function createDebateMatchTabOwnershipCoordinator({
       ) {
         return;
       }
-      const record = readDebateMatchTabOwnership(userId, { storage, now });
+      const record = currentRecord();
       if (
         !lockManager &&
         ownsFlow &&
@@ -171,7 +175,7 @@ export function createDebateMatchTabOwnershipCoordinator({
 
   const writeState = (state: DebateMatchTabOwnershipRecord['state']) => {
     if (!ownsFlow || closed) return null;
-    const existing = readDebateMatchTabOwnership(userId, { storage, now });
+    const existing = currentRecord();
     const timestamp = now();
     const record: DebateMatchTabOwnershipRecord = {
       version: recordVersion,
@@ -184,6 +188,7 @@ export function createDebateMatchTabOwnershipCoordinator({
       createdAt: existing?.matchId === matchId ? existing.createdAt : timestamp,
       acceptedAt: state === 'confirmed' ? timestamp : null,
     };
+    localRecord = record;
     writeRecord(record, storage);
     return record;
   };
@@ -193,7 +198,7 @@ export function createDebateMatchTabOwnershipCoordinator({
     acquire,
     beginAcceptance: () => writeState('pending'),
     confirmAcceptance: () => {
-      const existing = readDebateMatchTabOwnership(userId, { storage, now });
+      const existing = currentRecord();
       if (existing?.matchId === matchId && existing.instanceId === instanceId && existing.state === 'confirmed') {
         return existing;
       }
@@ -218,9 +223,11 @@ export function createDebateMatchTabOwnershipCoordinator({
       }
       if (!(await acquire())) {
         removeRecord(userId, storage);
+        localRecord = null;
         return false;
       }
-      writeRecord({ ...record, instanceId }, storage);
+      localRecord = { ...record, instanceId };
+      writeRecord(localRecord, storage);
       return true;
     },
     release,

--- a/apps/web/core/debates/match-prompt.test.tsx
+++ b/apps/web/core/debates/match-prompt.test.tsx
@@ -1,13 +1,14 @@
 import '@testing-library/jest-dom/vitest';
 import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 
-import type React from 'react';
+import { type ReactNode, StrictMode } from 'react';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { FeatureFlagId } from '~/core/state/feature-flags';
 
-import type { Debate, DebateMatch } from './api';
+import type { Debate, DebateActivity, DebateMatch } from './api';
+import { createDebateMatchTabOwnershipCoordinator } from './debate-match-tab-ownership';
 import { defaultDebateFormatId } from './formats';
 import { DebateMatchPrompt } from './match-prompt';
 
@@ -15,6 +16,7 @@ const mocks = vi.hoisted(() => ({
   push: vi.fn(),
   currentUserId: vi.fn(),
   acceptMutate: vi.fn(),
+  acceptError: null as Error | null,
   declineMutate: vi.fn(),
   markReadyMutate: vi.fn(),
   markReadyPending: false,
@@ -54,7 +56,7 @@ vi.mock('./hooks', async importOriginal => {
 
   return {
     ...actual,
-    useAcceptDebateMatch: () => ({ mutate: mocks.acceptMutate, isPending: false, error: null }),
+    useAcceptDebateMatch: () => ({ mutate: mocks.acceptMutate, isPending: false, error: mocks.acceptError }),
     useDeclineDebateMatch: () => ({ mutate: mocks.declineMutate, isPending: false, error: null }),
     useMarkDebateReady: () => ({ mutate: mocks.markReadyMutate, isPending: mocks.markReadyPending, error: null }),
     useAbortDebate: () => ({ mutate: mocks.abortMutate, isPending: false, error: null }),
@@ -62,7 +64,7 @@ vi.mock('./hooks', async importOriginal => {
 });
 
 vi.mock('./media-session', () => ({
-  DebateMediaSessionBoundary: ({ children }: { children: React.ReactNode }) => children,
+  DebateMediaSessionBoundary: ({ children }: { children: ReactNode }) => children,
   debateMatchMediaSessionKey: (matchId: string) => `match:${matchId}`,
   debateMediaSessionKey: (debateId: string) => `debate:${debateId}`,
   systemDefaultAudioOutput: {
@@ -95,10 +97,62 @@ vi.mock('./media-session', () => ({
   }),
 }));
 
+class FakeBroadcastChannel {
+  static channels = new Map<string, Set<FakeBroadcastChannel>>();
+
+  onmessage: ((event: MessageEvent) => void) | null = null;
+
+  constructor(private readonly name: string) {
+    const channels = FakeBroadcastChannel.channels.get(name) ?? new Set();
+    channels.add(this);
+    FakeBroadcastChannel.channels.set(name, channels);
+  }
+
+  postMessage(data: unknown) {
+    for (const channel of FakeBroadcastChannel.channels.get(this.name) ?? []) {
+      if (channel !== this) queueMicrotask(() => channel.onmessage?.(new MessageEvent('message', { data })));
+    }
+  }
+
+  close() {
+    FakeBroadcastChannel.channels.get(this.name)?.delete(this);
+  }
+}
+
+class MemoryStorage implements Storage {
+  private values = new Map<string, string>();
+
+  get length() {
+    return this.values.size;
+  }
+
+  clear() {
+    this.values.clear();
+  }
+
+  getItem(key: string) {
+    return this.values.get(key) ?? null;
+  }
+
+  key(index: number) {
+    return Array.from(this.values.keys())[index] ?? null;
+  }
+
+  removeItem(key: string) {
+    this.values.delete(key);
+  }
+
+  setItem(key: string, value: string) {
+    this.values.set(key, value);
+  }
+}
+
 beforeEach(() => {
+  sessionStorage.clear();
   mocks.push.mockReset();
   mocks.currentUserId.mockReturnValue('user-for');
   mocks.acceptMutate.mockReset();
+  mocks.acceptError = null;
   mocks.declineMutate.mockReset();
   mocks.markReadyMutate.mockReset();
   mocks.markReadyPending = false;
@@ -112,14 +166,21 @@ beforeEach(() => {
   };
   document.body.style.overflow = '';
   document.documentElement.style.overflow = '';
+  FakeBroadcastChannel.channels.clear();
+  vi.stubGlobal('BroadcastChannel', FakeBroadcastChannel);
 });
 
 afterEach(() => {
   cleanup();
+  sessionStorage.clear();
+  FakeBroadcastChannel.channels.clear();
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
 });
 
 describe('DebateMatchPrompt', () => {
-  it('opens a match modal and disables accept immediately after submitting the default format', () => {
+  it('opens a match modal and disables accept immediately after submitting the default format', async () => {
     mocks.acceptMutate.mockImplementation((_variables, options) => {
       options.onSuccess({ match: { ...match(), debate_id: 'debate-1' }, debate: debate() });
     });
@@ -137,15 +198,40 @@ describe('DebateMatchPrompt', () => {
 
     fireEvent.click(acceptButton);
 
-    expect(mocks.acceptMutate).toHaveBeenCalledWith(
-      { matchId: 'match-1', formatId: defaultDebateFormatId },
-      expect.any(Object)
+    expect(acceptButton).toBeDisabled();
+    await waitFor(() =>
+      expect(mocks.acceptMutate).toHaveBeenCalledWith(
+        { matchId: 'match-1', formatId: defaultDebateFormatId },
+        expect.any(Object)
+      )
     );
     expect(mocks.push).toHaveBeenCalledWith('/space/space-1/debates/debate-1');
-    expect(acceptButton).toBeDisabled();
   });
 
-  it('lets the first participant choose a format when the feature flag is enabled', () => {
+  it('keeps ownership coordination usable through Strict Mode effect replay', async () => {
+    render(
+      <StrictMode>
+        <DebateMatchPrompt spaceId="space-1" matches={[match()]} />
+      </StrictMode>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Accept' }));
+
+    await waitFor(() => expect(mocks.acceptMutate).toHaveBeenCalledOnce());
+  });
+
+  it('serializes repeated actions while ownership acquisition is in flight', async () => {
+    render(<DebateMatchPrompt spaceId="space-1" matches={[match()]} />);
+    const acceptButton = screen.getByRole('button', { name: 'Accept' });
+
+    fireEvent.click(acceptButton);
+    fireEvent.click(acceptButton);
+
+    await waitFor(() => expect(mocks.acceptMutate).toHaveBeenCalledOnce());
+    expect(mocks.declineMutate).not.toHaveBeenCalled();
+  });
+
+  it('lets the first participant choose a format when the feature flag is enabled', async () => {
     mocks.featureFlags.debateFormatSelector = true;
 
     render(<DebateMatchPrompt spaceId="space-1" matches={[match()]} />);
@@ -153,13 +239,15 @@ describe('DebateMatchPrompt', () => {
     fireEvent.change(screen.getByLabelText('Debate format'), { target: { value: 'extended-standard' } });
     fireEvent.click(screen.getByRole('button', { name: 'Accept' }));
 
-    expect(mocks.acceptMutate).toHaveBeenCalledWith(
-      { matchId: 'match-1', formatId: 'extended-standard' },
-      expect.any(Object)
+    await waitFor(() =>
+      expect(mocks.acceptMutate).toHaveBeenCalledWith(
+        { matchId: 'match-1', formatId: 'extended-standard' },
+        expect.any(Object)
+      )
     );
   });
 
-  it('re-enables accept when submitting the match fails', () => {
+  it('re-enables accept when submitting the match fails', async () => {
     let failRequest = () => {};
     mocks.acceptMutate.mockImplementation((_variables, options) => {
       failRequest = () => options.onError();
@@ -172,9 +260,113 @@ describe('DebateMatchPrompt', () => {
 
     expect(acceptButton).toBeDisabled();
 
+    await waitFor(() => expect(mocks.acceptMutate).toHaveBeenCalledOnce());
     act(failRequest);
 
+    await waitFor(() => expect(acceptButton).toBeEnabled());
+    expect(sessionStorage.getItem('geo:debate-match-owner:user-for')).toBeNull();
+    expect(mocks.push).not.toHaveBeenCalled();
+    expect(mocks.ensurePreview).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['rejects', () => Promise.reject(new Error('Offline'))],
+    ['returns no activity', () => Promise.resolve(null)],
+  ])('keeps ambiguous ownership retryable when reconciliation %s', async (_label, reconcileActivity) => {
+    let failRequest = () => {};
+    mocks.acceptMutate.mockImplementation((_variables, options) => {
+      failRequest = () => options.onError(new Error('Response lost'));
+    });
+
+    render(<DebateMatchPrompt spaceId="space-1" matches={[match()]} reconcileActivity={reconcileActivity} />);
+    const acceptButton = screen.getByRole('button', { name: 'Accept' });
+    fireEvent.click(acceptButton);
+    await waitFor(() => expect(mocks.acceptMutate).toHaveBeenCalledOnce());
+
+    act(failRequest);
+
+    await waitFor(() => expect(acceptButton).toBeEnabled());
+    expect(JSON.parse(sessionStorage.getItem('geo:debate-match-owner:user-for')!)).toMatchObject({ state: 'pending' });
+    expect(mocks.push).not.toHaveBeenCalled();
+    expect(mocks.ensurePreview).not.toHaveBeenCalled();
+  });
+
+  it('releases ownership when reconciliation confirms the match was not accepted', async () => {
+    let failRequest = () => {};
+    mocks.acceptMutate.mockImplementation((_variables, options) => {
+      failRequest = () => options.onError(new Error('Rejected'));
+    });
+    const reconcileActivity = vi.fn().mockResolvedValue({
+      online: true,
+      available_to_debate: true,
+      cooldown_until: null,
+      match: match(),
+      debate: null,
+      rematch: null,
+    } satisfies DebateActivity);
+
+    render(<DebateMatchPrompt spaceId="space-1" matches={[match()]} reconcileActivity={reconcileActivity} />);
+    const acceptButton = screen.getByRole('button', { name: 'Accept' });
+    fireEvent.click(acceptButton);
+    await waitFor(() => expect(mocks.acceptMutate).toHaveBeenCalledOnce());
+
+    act(failRequest);
+
+    await waitFor(() => expect(acceptButton).toBeEnabled());
+    expect(sessionStorage.getItem('geo:debate-match-owner:user-for')).toBeNull();
+    expect(mocks.push).not.toHaveBeenCalled();
+    expect(mocks.ensurePreview).not.toHaveBeenCalled();
+  });
+
+  it('makes an ambiguous acceptance retryable when reconciliation never settles', async () => {
+    vi.useFakeTimers();
+    let failRequest = () => {};
+    mocks.acceptMutate.mockImplementation((_variables, options) => {
+      failRequest = () => options.onError(new Error('Response lost'));
+    });
+
+    render(
+      <DebateMatchPrompt spaceId="space-1" matches={[match()]} reconcileActivity={() => new Promise(() => undefined)} />
+    );
+    const acceptButton = screen.getByRole('button', { name: 'Accept' });
+    await act(async () => fireEvent.click(acceptButton));
+    expect(mocks.acceptMutate).toHaveBeenCalledOnce();
+    act(failRequest);
+
+    await act(async () => vi.advanceTimersByTimeAsync(10_000));
+
     expect(acceptButton).toBeEnabled();
+    expect(JSON.parse(sessionStorage.getItem('geo:debate-match-owner:user-for')!)).toMatchObject({ state: 'pending' });
+  });
+
+  it('keeps ownership when a failed response reconciles to canonical acceptance', async () => {
+    let failRequest = () => {};
+    mocks.acceptMutate.mockImplementation((_variables, options) => {
+      failRequest = () => options.onError(new Error('Response lost'));
+    });
+    const acceptedMatch = match();
+    acceptedMatch.participants[0]!.accepted = true;
+    const reconcileActivity = vi.fn().mockResolvedValue({
+      online: true,
+      available_to_debate: true,
+      cooldown_until: null,
+      match: acceptedMatch,
+      debate: null,
+      rematch: null,
+    } satisfies DebateActivity);
+
+    render(<DebateMatchPrompt spaceId="space-1" matches={[match()]} reconcileActivity={reconcileActivity} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Accept' }));
+    await waitFor(() => expect(mocks.acceptMutate).toHaveBeenCalledOnce());
+
+    act(failRequest);
+
+    expect(await screen.findByRole('dialog', { name: 'Debate readiness' })).toBeInTheDocument();
+    expect(reconcileActivity).toHaveBeenCalledOnce();
+    expect(JSON.parse(sessionStorage.getItem('geo:debate-match-owner:user-for')!)).toMatchObject({
+      state: 'confirmed',
+    });
+    expect(screen.queryByText('Response lost')).not.toBeInTheDocument();
   });
 
   it('renders each participant position without a per-participant menu', () => {
@@ -198,7 +390,7 @@ describe('DebateMatchPrompt', () => {
     expect(document.documentElement.style.overflow).toBe('');
   });
 
-  it('hides the format selector from the second participant', () => {
+  it('hides the format selector from the second participant', async () => {
     mocks.currentUserId.mockReturnValue('user-against');
     mocks.featureFlags.debateFormatSelector = true;
 
@@ -209,31 +401,34 @@ describe('DebateMatchPrompt', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Accept' }));
 
-    expect(mocks.acceptMutate).toHaveBeenCalledWith({ matchId: 'match-1', formatId: undefined }, expect.any(Object));
+    await waitFor(() =>
+      expect(mocks.acceptMutate).toHaveBeenCalledWith({ matchId: 'match-1', formatId: undefined }, expect.any(Object))
+    );
   });
 
-  it('hides the format selector after the first participant has accepted', () => {
+  it('hides the format selector after the owning participant has accepted', async () => {
     mocks.featureFlags.debateFormatSelector = true;
     const acceptedMatch = match();
     acceptedMatch.participants[0]!.accepted = true;
+    seedConfirmedOwnership(acceptedMatch);
 
     render(<DebateMatchPrompt spaceId="space-1" matches={[acceptedMatch]} />);
 
-    expect(screen.getByRole('dialog', { name: 'Debate readiness' })).toBeInTheDocument();
+    expect(await screen.findByRole('dialog', { name: 'Debate readiness' })).toBeInTheDocument();
     expect(screen.getByText('Waiting...')).toBeInTheDocument();
     expect(screen.queryByLabelText('Debate format')).not.toBeInTheDocument();
   });
 
-  it('rejects the matched person for the question', () => {
+  it('rejects the matched person for the question', async () => {
     render(<DebateMatchPrompt spaceId="space-1" matches={[match()]} />);
 
     fireEvent.click(screen.getByRole('button', { name: 'Reject' }));
 
-    expect(mocks.declineMutate).toHaveBeenCalledWith('match-1', expect.any(Object));
-    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    await waitFor(() => expect(mocks.declineMutate).toHaveBeenCalledWith('match-1', expect.any(Object)));
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
   });
 
-  it('shows the device pre-screen immediately and moves the first accepter once the debate exists', () => {
+  it('shows the device pre-screen immediately and moves the first accepter once the debate exists', async () => {
     mocks.featureFlags.debateFormatSelector = true;
     mocks.acceptMutate.mockImplementation((_variables, options) => {
       options.onSuccess({
@@ -251,27 +446,91 @@ describe('DebateMatchPrompt', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Accept' }));
 
-    expect(screen.getByRole('dialog', { name: 'Debate readiness' })).toBeInTheDocument();
+    expect(await screen.findByRole('dialog', { name: 'Debate readiness' })).toBeInTheDocument();
     expect(screen.queryByText('Waiting for the other person')).not.toBeInTheDocument();
     expect(screen.queryByLabelText('Debate format')).not.toBeInTheDocument();
     expect(mocks.push).not.toHaveBeenCalled();
 
-    rerender(<DebateMatchPrompt spaceId="space-1" matches={[]} debates={[debate()]} />);
+    const acceptedMatch = match();
+    acceptedMatch.participants[0]!.accepted = true;
+    rerender(<DebateMatchPrompt spaceId="space-1" matches={[acceptedMatch]} debates={[debate()]} />);
 
-    expect(mocks.push).toHaveBeenCalledWith('/space/space-1/debates/debate-1');
+    await waitFor(() => expect(mocks.push).toHaveBeenCalledWith('/space/space-1/debates/debate-1'));
   });
 
-  it('moves a server-accepted participant into a debate while retaining the match', () => {
+  it('does not move a server-accepted participant without local ownership', () => {
     const acceptedMatch = match();
     acceptedMatch.participants[0]!.accepted = true;
 
     render(<DebateMatchPrompt spaceId="space-1" matches={[acceptedMatch]} debates={[debate()]} />);
 
-    expect(mocks.push).toHaveBeenCalledTimes(1);
-    expect(mocks.push).toHaveBeenCalledWith('/space/space-1/debates/debate-1');
-    expect(mocks.beginMediaSession).toHaveBeenCalledTimes(1);
-    expect(mocks.promoteMediaSession).toHaveBeenCalledWith('match:match-1', 'debate:debate-1');
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(mocks.push).not.toHaveBeenCalled();
+    expect(mocks.beginMediaSession).not.toHaveBeenCalled();
+    expect(mocks.promoteMediaSession).not.toHaveBeenCalled();
     expect(mocks.ensurePreview).not.toHaveBeenCalled();
+  });
+
+  it('closes a secondary prompt when shared activity reports acceptance and stays on the current page', async () => {
+    const underlyingControl = document.createElement('button');
+    underlyingControl.textContent = 'Underlying page control';
+    document.body.append(underlyingControl);
+    underlyingControl.focus();
+    const view = render(<DebateMatchPrompt spaceId="space-1" matches={[match()]} debates={[]} />);
+    expect(screen.getByRole('dialog', { name: 'The protocol should ship debates' })).toBeInTheDocument();
+
+    const acceptedMatch = match();
+    acceptedMatch.participants[0]!.accepted = true;
+    view.rerender(<DebateMatchPrompt spaceId="space-1" matches={[acceptedMatch]} debates={[debate()]} />);
+
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+    expect(screen.getByRole('status')).toHaveTextContent('Debate accepted in another tab.');
+    await waitFor(() => expect(underlyingControl).toHaveFocus());
+    expect(mocks.push).not.toHaveBeenCalled();
+    expect(mocks.beginMediaSession).not.toHaveBeenCalled();
+    expect(mocks.ensurePreview).not.toHaveBeenCalled();
+    underlyingControl.remove();
+  });
+
+  it('closes a retained prompt when shared activity jumps directly to the debate', async () => {
+    const view = render(<DebateMatchPrompt spaceId="space-1" matches={[match()]} debates={[]} />);
+    expect(screen.getByRole('dialog', { name: 'The protocol should ship debates' })).toBeInTheDocument();
+
+    view.rerender(<DebateMatchPrompt spaceId="space-1" matches={[match()]} debates={[debate()]} />);
+
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+    expect(screen.getByRole('status')).toHaveTextContent('Debate accepted in another tab.');
+    expect(mocks.push).not.toHaveBeenCalled();
+    expect(mocks.beginMediaSession).not.toHaveBeenCalled();
+    expect(mocks.ensurePreview).not.toHaveBeenCalled();
+  });
+
+  it('dismisses a secondary prompt immediately after another tab broadcasts acceptance', async () => {
+    const underlyingControl = document.createElement('button');
+    document.body.append(underlyingControl);
+    underlyingControl.focus();
+    render(<DebateMatchPrompt spaceId="space-1" matches={[match()]} />);
+    const owner = createDebateMatchTabOwnershipCoordinator({
+      matchId: 'match-1',
+      claimId: 'claim-1',
+      spaceId: 'space-1',
+      userId: 'user-for',
+      storage: new MemoryStorage(),
+      onAcceptedElsewhere: vi.fn(),
+    });
+    await owner.acquire();
+    owner.beginAcceptance();
+
+    owner.confirmAcceptance();
+
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+    expect(screen.getByRole('status')).toHaveTextContent('Debate accepted in another tab.');
+    await waitFor(() => expect(underlyingControl).toHaveFocus());
+    expect(mocks.push).not.toHaveBeenCalled();
+    expect(mocks.beginMediaSession).not.toHaveBeenCalled();
+    expect(mocks.ensurePreview).not.toHaveBeenCalled();
+    owner.close();
+    underlyingControl.remove();
   });
 
   it('queues readiness on the match pre-screen and submits it once the debate exists', async () => {
@@ -293,7 +552,7 @@ describe('DebateMatchPrompt', () => {
     const view = render(<DebateMatchPrompt spaceId="space-1" matches={[match()]} debates={[]} />);
 
     fireEvent.click(screen.getByRole('button', { name: 'Accept' }));
-    fireEvent.click(screen.getByRole('button', { name: "I'm ready" }));
+    fireEvent.click(await screen.findByRole('button', { name: "I'm ready" }));
 
     expect(screen.getByRole('button', { name: 'Waiting...' })).toBeDisabled();
     expect(mocks.markReadyMutate).not.toHaveBeenCalled();
@@ -308,6 +567,7 @@ describe('DebateMatchPrompt', () => {
   it('lets the participant retry queued readiness when the first submission fails', async () => {
     const acceptedMatch = match();
     acceptedMatch.participants[0]!.accepted = true;
+    seedConfirmedOwnership(acceptedMatch);
     let failReadiness = () => {};
     mocks.markReadyMutate
       .mockImplementationOnce((_variables, options) => {
@@ -317,7 +577,7 @@ describe('DebateMatchPrompt', () => {
 
     const view = render(<DebateMatchPrompt spaceId="space-1" matches={[acceptedMatch]} debates={[]} />);
 
-    fireEvent.click(screen.getByRole('button', { name: "I'm ready" }));
+    fireEvent.click(await screen.findByRole('button', { name: "I'm ready" }));
     view.rerender(<DebateMatchPrompt spaceId="space-1" matches={[acceptedMatch]} debates={[debate()]} />);
 
     await waitFor(() => expect(mocks.markReadyMutate).toHaveBeenCalledTimes(1));
@@ -333,6 +593,7 @@ describe('DebateMatchPrompt', () => {
   it('revalidates media before submitting queued readiness', async () => {
     const acceptedMatch = match();
     acceptedMatch.participants[0]!.accepted = true;
+    seedConfirmedOwnership(acceptedMatch);
     mocks.ensurePreview
       .mockResolvedValueOnce(previewTracks())
       .mockRejectedValueOnce(new Error('Camera disconnected'))
@@ -357,9 +618,10 @@ describe('DebateMatchPrompt', () => {
   it('prevents leaving while queued readiness is being submitted', async () => {
     const acceptedMatch = match();
     acceptedMatch.participants[0]!.accepted = true;
+    seedConfirmedOwnership(acceptedMatch);
     const view = render(<DebateMatchPrompt spaceId="space-1" matches={[acceptedMatch]} debates={[]} />);
 
-    fireEvent.click(screen.getByRole('button', { name: "I'm ready" }));
+    fireEvent.click(await screen.findByRole('button', { name: "I'm ready" }));
     mocks.markReadyPending = true;
     view.rerender(<DebateMatchPrompt spaceId="space-1" matches={[acceptedMatch]} debates={[debate()]} />);
 
@@ -370,12 +632,13 @@ describe('DebateMatchPrompt', () => {
   it('releases the pending media session when the participant leaves the pre-screen', async () => {
     const acceptedMatch = match();
     acceptedMatch.participants[0]!.accepted = true;
+    seedConfirmedOwnership(acceptedMatch);
 
     render(<DebateMatchPrompt spaceId="space-1" matches={[acceptedMatch]} debates={[]} />);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Leave debate' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Leave debate' }));
 
-    expect(mocks.declineMutate).toHaveBeenCalledWith('match-1', expect.any(Object));
+    await waitFor(() => expect(mocks.declineMutate).toHaveBeenCalledWith('match-1', expect.any(Object)));
     await waitFor(() => expect(mocks.releaseMediaSession).toHaveBeenCalledWith('match:match-1'));
     expect(screen.queryByRole('dialog', { name: 'Debate readiness' })).not.toBeInTheDocument();
   });
@@ -383,7 +646,10 @@ describe('DebateMatchPrompt', () => {
   it('releases the pending media session when the accepted match expires', async () => {
     const acceptedMatch = match();
     acceptedMatch.participants[0]!.accepted = true;
+    seedConfirmedOwnership(acceptedMatch);
     const view = render(<DebateMatchPrompt spaceId="space-1" matches={[acceptedMatch]} debates={[]} />);
+
+    await screen.findByRole('dialog', { name: 'Debate readiness' });
 
     view.rerender(<DebateMatchPrompt spaceId="space-1" matches={[]} debates={[]} />);
 
@@ -391,6 +657,27 @@ describe('DebateMatchPrompt', () => {
     expect(screen.queryByRole('dialog', { name: 'Debate readiness' })).not.toBeInTheDocument();
   });
 });
+
+function seedConfirmedOwnership(ownedMatch: DebateMatch) {
+  const now = Date.now();
+  sessionStorage.setItem(
+    'geo:debate-match-owner:user-for',
+    JSON.stringify({
+      version: 1,
+      state: 'confirmed',
+      userId: 'user-for',
+      matchId: ownedMatch.id,
+      claimId: ownedMatch.claim.id,
+      spaceId: ownedMatch.claim.space_id,
+      instanceId: 'previous-instance',
+      createdAt: now,
+      acceptedAt: now,
+    })
+  );
+  vi.spyOn(performance, 'getEntriesByType').mockImplementation(type =>
+    type === 'navigation' ? ([{ type: 'reload' }] as PerformanceNavigationTiming[]) : []
+  );
+}
 
 function match(): DebateMatch {
   return {

--- a/apps/web/core/debates/match-prompt.test.tsx
+++ b/apps/web/core/debates/match-prompt.test.tsx
@@ -369,6 +369,64 @@ describe('DebateMatchPrompt', () => {
     expect(screen.queryByText('Response lost')).not.toBeInTheDocument();
   });
 
+  it('keeps ownership when a failed response reconciles directly to an active debate', async () => {
+    let failRequest = () => {};
+    mocks.acceptMutate.mockImplementation((_variables, options) => {
+      failRequest = () => options.onError(new Error('Response lost'));
+    });
+    const reconcileActivity = vi.fn().mockResolvedValue({
+      online: true,
+      available_to_debate: true,
+      cooldown_until: null,
+      match: null,
+      debate: debate(),
+      rematch: null,
+    } satisfies DebateActivity);
+
+    render(<DebateMatchPrompt spaceId="space-1" matches={[match()]} reconcileActivity={reconcileActivity} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Accept' }));
+    await waitFor(() => expect(mocks.acceptMutate).toHaveBeenCalledOnce());
+
+    act(failRequest);
+
+    await waitFor(() => expect(mocks.push).toHaveBeenCalledWith('/space/space-1/debates/debate-1'));
+    expect(JSON.parse(sessionStorage.getItem('geo:debate-match-owner:user-for')!)).toMatchObject({
+      state: 'confirmed',
+    });
+    expect(screen.queryByText('Response lost')).not.toBeInTheDocument();
+  });
+
+  it.each(['complete', 'cancelled'] as const)(
+    'rejects a failed response that reconciles to a %s debate',
+    async status => {
+      let failRequest = () => {};
+      mocks.acceptMutate.mockImplementation((_variables, options) => {
+        failRequest = () => options.onError(new Error('Response lost'));
+      });
+      const terminalDebate = { ...debate(), status };
+      const reconcileActivity = vi.fn().mockResolvedValue({
+        online: true,
+        available_to_debate: true,
+        cooldown_until: null,
+        match: null,
+        debate: terminalDebate,
+        rematch: null,
+      } satisfies DebateActivity);
+
+      render(<DebateMatchPrompt spaceId="space-1" matches={[match()]} reconcileActivity={reconcileActivity} />);
+      const acceptButton = screen.getByRole('button', { name: 'Accept' });
+      fireEvent.click(acceptButton);
+      await waitFor(() => expect(mocks.acceptMutate).toHaveBeenCalledOnce());
+
+      act(failRequest);
+
+      await waitFor(() => expect(acceptButton).toBeEnabled());
+      expect(sessionStorage.getItem('geo:debate-match-owner:user-for')).toBeNull();
+      expect(mocks.push).not.toHaveBeenCalled();
+      expect(screen.queryByRole('dialog', { name: 'Debate readiness' })).not.toBeInTheDocument();
+    }
+  );
+
   it('renders each participant position without a per-participant menu', () => {
     render(<DebateMatchPrompt spaceId="space-1" matches={[match()]} />);
 
@@ -655,6 +713,38 @@ describe('DebateMatchPrompt', () => {
 
     await waitFor(() => expect(mocks.releaseMediaSession).toHaveBeenCalledWith('match:match-1'));
     expect(screen.queryByRole('dialog', { name: 'Debate readiness' })).not.toBeInTheDocument();
+  });
+
+  it('does not carry confirmed ownership into a replacement match', async () => {
+    const acceptedMatch = match();
+    acceptedMatch.participants[0]!.accepted = true;
+    seedConfirmedOwnership(acceptedMatch);
+    const view = render(<DebateMatchPrompt spaceId="space-1" matches={[acceptedMatch]} debates={[]} />);
+
+    await screen.findByRole('dialog', { name: 'Debate readiness' });
+    mocks.beginMediaSession.mockClear();
+    mocks.ensurePreview.mockClear();
+    mocks.push.mockClear();
+
+    const replacementMatch = match();
+    replacementMatch.id = 'match-2';
+    replacementMatch.claim = {
+      ...replacementMatch.claim,
+      id: 'claim-2',
+      claim_entity_id: 'claim-entity-2',
+      claim: 'The replacement match stays local',
+    };
+    const replacementDebate = debate();
+    replacementDebate.id = 'debate-2';
+    replacementDebate.claim = replacementMatch.claim;
+
+    view.rerender(<DebateMatchPrompt spaceId="space-1" matches={[replacementMatch]} debates={[replacementDebate]} />);
+
+    expect(await screen.findByRole('status')).toHaveTextContent('Debate accepted in another tab.');
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(mocks.beginMediaSession).not.toHaveBeenCalled();
+    expect(mocks.ensurePreview).not.toHaveBeenCalled();
+    expect(mocks.push).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/web/core/debates/match-prompt.tsx
+++ b/apps/web/core/debates/match-prompt.tsx
@@ -41,31 +41,45 @@ type DebateMatchPromptProps = {
 };
 
 export function DebateMatchPrompt({ spaceId, matches, debates = [], reconcileActivity }: DebateMatchPromptProps) {
+  const currentUserId = getCurrentGeoChatUserId();
+  const ownershipScopeKey = `${currentUserId ?? 'anonymous'}:${matches[0]?.id ?? 'none'}`;
+
   return (
     <DebateMediaSessionBoundary>
       <DebateMatchPromptContent
+        key={ownershipScopeKey}
         spaceId={spaceId}
         matches={matches}
         debates={debates}
         reconcileActivity={reconcileActivity}
+        currentUserId={currentUserId}
       />
     </DebateMediaSessionBoundary>
   );
 }
+
+type DebateMatchPromptContentProps = DebateMatchPromptProps & {
+  currentUserId: string | null;
+};
 
 type OwnershipState = 'checking' | 'none' | 'pending' | 'confirmed' | 'other-tab';
 
 const acceptanceReconciliationTimeoutMs = 10_000;
 const acceptanceReconciliationTimedOut = Symbol('acceptance-reconciliation-timed-out');
 
-function DebateMatchPromptContent({ spaceId, matches, debates = [], reconcileActivity }: DebateMatchPromptProps) {
+function DebateMatchPromptContent({
+  spaceId,
+  matches,
+  debates = [],
+  reconcileActivity,
+  currentUserId,
+}: DebateMatchPromptContentProps) {
   const router = useRouter();
   const debateFormatSelectorEnabled = useFeatureFlag('debateFormatSelector');
   const mediaSession = useDebateMediaSession();
   const { activeSessionKey, beginSession, promoteSession, releaseSession, ensurePreview } = mediaSession;
   const acceptMatch = useAcceptDebateMatch(spaceId);
   const declineMatch = useDeclineDebateMatch(spaceId);
-  const currentUserId = getCurrentGeoChatUserId();
   const ownershipMatch = matches[0] ?? null;
   const [ownershipState, setOwnershipState] = React.useState<OwnershipState>(() =>
     initialOwnershipState(ownershipMatch, currentUserId)
@@ -599,6 +613,11 @@ async function reconcileFailedAcceptance(
     )
       ? activity.debate
       : null;
+
+  if (debate && ['complete', 'cancelled'].includes(debate.status)) {
+    await ownershipCoordinator.release({ clearRecord: true });
+    return { status: 'rejected' };
+  }
 
   if (accepted || debate) {
     return ownershipCoordinator.confirmAcceptance() ? { status: 'confirmed', debate } : { status: 'inconclusive' };

--- a/apps/web/core/debates/match-prompt.tsx
+++ b/apps/web/core/debates/match-prompt.tsx
@@ -9,7 +9,19 @@ import { useFeatureFlag } from '~/core/state/feature-flags';
 import { Button } from '~/design-system/button';
 import { Text } from '~/design-system/text';
 
-import { type Debate, type DebateMatch, type DebateMatchParticipant, getCurrentGeoChatUserId } from './api';
+import {
+  type Debate,
+  type DebateActivity,
+  type DebateMatch,
+  type DebateMatchParticipant,
+  getCurrentGeoChatUserId,
+} from './api';
+import {
+  type DebateMatchTabOwnershipCoordinator,
+  createDebateMatchTabOwnershipCoordinator,
+  debateMatchOwnershipMatchesDebate,
+  readDebateMatchTabOwnership,
+} from './debate-match-tab-ownership';
 import { DebatePreScreen } from './debate-pre-join-screen';
 import { DebateRequestDialog } from './debate-request-dialog';
 import { type DebateFormatId, debateFormatById, defaultDebateFormatId } from './formats';
@@ -25,17 +37,28 @@ type DebateMatchPromptProps = {
   spaceId: string;
   matches: DebateMatch[];
   debates?: Debate[];
+  reconcileActivity?: () => Promise<DebateActivity | null>;
 };
 
-export function DebateMatchPrompt({ spaceId, matches, debates = [] }: DebateMatchPromptProps) {
+export function DebateMatchPrompt({ spaceId, matches, debates = [], reconcileActivity }: DebateMatchPromptProps) {
   return (
     <DebateMediaSessionBoundary>
-      <DebateMatchPromptContent spaceId={spaceId} matches={matches} debates={debates} />
+      <DebateMatchPromptContent
+        spaceId={spaceId}
+        matches={matches}
+        debates={debates}
+        reconcileActivity={reconcileActivity}
+      />
     </DebateMediaSessionBoundary>
   );
 }
 
-function DebateMatchPromptContent({ spaceId, matches, debates = [] }: DebateMatchPromptProps) {
+type OwnershipState = 'checking' | 'none' | 'pending' | 'confirmed' | 'other-tab';
+
+const acceptanceReconciliationTimeoutMs = 10_000;
+const acceptanceReconciliationTimedOut = Symbol('acceptance-reconciliation-timed-out');
+
+function DebateMatchPromptContent({ spaceId, matches, debates = [], reconcileActivity }: DebateMatchPromptProps) {
   const router = useRouter();
   const debateFormatSelectorEnabled = useFeatureFlag('debateFormatSelector');
   const mediaSession = useDebateMediaSession();
@@ -43,18 +66,30 @@ function DebateMatchPromptContent({ spaceId, matches, debates = [] }: DebateMatc
   const acceptMatch = useAcceptDebateMatch(spaceId);
   const declineMatch = useDeclineDebateMatch(spaceId);
   const currentUserId = getCurrentGeoChatUserId();
+  const ownershipMatch = matches[0] ?? null;
+  const [ownershipState, setOwnershipState] = React.useState<OwnershipState>(() =>
+    initialOwnershipState(ownershipMatch, currentUserId)
+  );
   const [selectedFormatIds, setSelectedFormatIds] = React.useState<Record<string, DebateFormatId>>({});
-  const [acceptedMatchIds, setAcceptedMatchIds] = React.useState<string[]>([]);
   const [queuedReadyMatchIds, setQueuedReadyMatchIds] = React.useState<string[]>([]);
   const [readyError, setReadyError] = React.useState<string | null>(null);
   const [acceptingMatchId, setAcceptingMatchId] = React.useState<string | null>(null);
-  const [waitingClaimIds, setWaitingClaimIds] = React.useState<string[]>([]);
   const [dismissedMatchIds, setDismissedMatchIds] = React.useState<string[]>([]);
   const [minimizedMatchIds, setMinimizedMatchIds] = React.useState<string[]>([]);
   const navigatedDebateIdRef = React.useRef<string | null>(null);
   const readyHandoffDebateIdRef = React.useRef<string | null>(null);
   const readyValidationDebateIdRef = React.useRef<string | null>(null);
+  const matchActionInFlightRef = React.useRef(false);
   const localVideoRef = React.useRef<HTMLVideoElement>(null);
+  const returnFocusRef = React.useRef<HTMLElement | null>(
+    typeof document !== 'undefined' && document.activeElement instanceof HTMLElement ? document.activeElement : null
+  );
+  const handleAcceptedElsewhere = React.useCallback(() => setOwnershipState('other-tab'), []);
+  const ownershipCoordinator = useMatchTabOwnershipCoordinator(ownershipMatch, currentUserId, handleAcceptedElsewhere);
+  const ownershipDebate =
+    ownershipMatch && currentUserId
+      ? (debates.find(debate => debateMatchesMatch(debate, ownershipMatch, currentUserId)) ?? null)
+      : null;
 
   const navigateToDebate = React.useCallback(
     (debateId: string, matchId: string) => {
@@ -73,7 +108,6 @@ function DebateMatchPromptContent({ spaceId, matches, debates = [] }: DebateMatc
 
   React.useEffect(() => {
     const activeIds = new Set(matches.map(match => match.id));
-    setAcceptedMatchIds(current => current.filter(id => activeIds.has(id)));
     setQueuedReadyMatchIds(current => current.filter(id => activeIds.has(id)));
     setAcceptingMatchId(current => (current && activeIds.has(current) ? current : null));
     setDismissedMatchIds(current => current.filter(id => activeIds.has(id)));
@@ -88,67 +122,100 @@ function DebateMatchPromptContent({ spaceId, matches, debates = [] }: DebateMatc
   }, [matches]);
 
   React.useEffect(() => {
-    if (!currentUserId) return;
+    if (!ownershipMatch || !currentUserId) {
+      setOwnershipState('none');
+      return;
+    }
+    if (!ownershipCoordinator) return;
 
-    const matchWithDebate = matches.find(
-      match => match.debate_id && participantForUser(match, currentUserId)?.accepted === true
-    );
+    let active = true;
+    const record = readDebateMatchTabOwnership(currentUserId);
+    const participantAccepted = participantForUser(ownershipMatch, currentUserId)?.accepted === true;
+    if (
+      !record ||
+      record.matchId !== ownershipMatch.id ||
+      record.claimId !== ownershipMatch.claim.id ||
+      record.spaceId !== ownershipMatch.claim.space_id
+    ) {
+      setOwnershipState(participantAccepted ? 'other-tab' : 'none');
+    } else {
+      setOwnershipState('checking');
+      void ownershipCoordinator.recover().then(recovered => {
+        if (!active) return;
+        setOwnershipState(recovered ? record.state : participantAccepted ? 'other-tab' : 'none');
+      });
+    }
+    return () => {
+      active = false;
+    };
+  }, [
+    currentUserId,
+    ownershipCoordinator,
+    ownershipMatch?.claim.id,
+    ownershipMatch?.claim.space_id,
+    ownershipMatch?.id,
+  ]);
+
+  React.useEffect(() => {
+    if (!ownershipCoordinator || !ownershipMatch || !currentUserId) return;
+    if (participantForUser(ownershipMatch, currentUserId)?.accepted !== true && !ownershipDebate) return;
+    if (ownershipState === 'pending') {
+      ownershipCoordinator.confirmAcceptance();
+      setOwnershipState('confirmed');
+    } else if (ownershipState === 'none') {
+      setOwnershipState('other-tab');
+    }
+  }, [currentUserId, ownershipCoordinator, ownershipDebate, ownershipMatch, ownershipState]);
+
+  React.useEffect(() => {
+    const otherTabMatchId = ownershipState === 'other-tab' ? ownershipMatch?.id : null;
+    if (!otherTabMatchId) return;
+    setQueuedReadyMatchIds(current => current.filter(id => id !== otherTabMatchId));
+    setMinimizedMatchIds(current => current.filter(id => id !== otherTabMatchId));
+    releaseSession(debateMatchMediaSessionKey(otherTabMatchId));
+
+    const frame = window.requestAnimationFrame(() => restorePageFocus(returnFocusRef.current));
+    return () => window.cancelAnimationFrame(frame);
+  }, [ownershipMatch?.id, ownershipState, releaseSession]);
+
+  React.useEffect(() => {
+    if (!currentUserId || ownershipState !== 'confirmed' || !ownershipMatch) return;
+
+    const matchWithDebate = matches.find(match => match.id === ownershipMatch.id && match.debate_id);
     if (matchWithDebate?.debate_id) {
       if (queuedReadyMatchIds.includes(matchWithDebate.id)) return;
       navigateToDebate(matchWithDebate.debate_id, matchWithDebate.id);
       return;
     }
 
-    const waitingClaimIdSet = new Set([
-      ...waitingClaimIds,
-      ...matches
-        .filter(match => participantForUser(match, currentUserId)?.accepted === true)
-        .map(match => match.claim.id),
-    ]);
-    if (waitingClaimIdSet.size === 0) return;
-
     const debate = debates.find(
       debate =>
-        waitingClaimIdSet.has(debate.claim.id) &&
+        debate.claim.id === ownershipMatch.claim.id &&
         debate.participants.some(participant => participant.user_id === currentUserId) &&
         !['complete', 'cancelled'].includes(debate.status)
     );
     if (debate) {
-      const matchId =
-        matches.find(match => match.claim.id === debate.claim.id)?.id ?? acceptedMatchIds[0] ?? queuedReadyMatchIds[0];
+      const matchId = matches.find(match => match.claim.id === debate.claim.id)?.id ?? ownershipMatch.id;
       if (matchId && !queuedReadyMatchIds.includes(matchId)) navigateToDebate(debate.id, matchId);
     }
-  }, [acceptedMatchIds, currentUserId, debates, matches, navigateToDebate, queuedReadyMatchIds, waitingClaimIds]);
+  }, [currentUserId, debates, matches, navigateToDebate, ownershipMatch, ownershipState, queuedReadyMatchIds]);
 
   const waitingMatch =
     matches.find(match => {
       if (!currentUserId || dismissedMatchIds.includes(match.id)) return false;
-      const participant = participantForUser(match, currentUserId);
-      return (
-        acceptedMatchIds.includes(match.id) ||
-        waitingClaimIds.includes(match.claim.id) ||
-        participant?.accepted === true
-      );
+      return ownershipState === 'confirmed' && match.id === ownershipMatch?.id;
     }) ?? null;
   const activeMatch =
     waitingMatch ??
-    (waitingClaimIds.length === 0 ? (matches.find(match => !dismissedMatchIds.includes(match.id)) ?? null) : null);
+    (ownershipState === 'none' || ownershipState === 'pending'
+      ? (matches.find(match => !dismissedMatchIds.includes(match.id)) ?? null)
+      : null);
   const activeMatchId = activeMatch?.id ?? null;
   const minimizedMatch = activeMatch && minimizedMatchIds.includes(activeMatch.id) ? activeMatch : null;
   const myParticipant = activeMatch && currentUserId ? participantForUser(activeMatch, currentUserId) : null;
-  const waiting = Boolean(
-    activeMatch &&
-    (acceptedMatchIds.includes(activeMatch.id) ||
-      waitingClaimIds.includes(activeMatch.claim.id) ||
-      myParticipant?.accepted === true)
-  );
+  const waiting = Boolean(activeMatch && ownershipState === 'confirmed');
   const matchedDebate = activeMatch
-    ? (debates.find(
-        debate =>
-          debate.claim.id === activeMatch.claim.id &&
-          Boolean(currentUserId && debate.participants.some(participant => participant.user_id === currentUserId)) &&
-          !['complete', 'cancelled'].includes(debate.status)
-      ) ?? null)
+    ? (debates.find(debate => Boolean(currentUserId && debateMatchesMatch(debate, activeMatch, currentUserId))) ?? null)
     : null;
   const debateLocalParticipant =
     matchedDebate?.participants.find(participant => participant.user_id === currentUserId) ?? null;
@@ -223,12 +290,18 @@ function DebateMatchPromptContent({ spaceId, matches, debates = [] }: DebateMatc
     submitReady,
   ]);
 
-  if (!activeMatch || !currentUserId) return null;
+  if (!activeMatch || !currentUserId) {
+    return ownershipState === 'other-tab' ? (
+      <p role="status" aria-live="polite" className="sr-only">
+        Debate accepted in another tab.
+      </p>
+    ) : null;
+  }
 
   const selectedFormatId = selectedFormatIds[activeMatch.id] ?? formatIdForMatch(activeMatch);
   const error =
     readyError ??
-    (acceptMatch.error instanceof Error
+    (ownershipState !== 'confirmed' && acceptMatch.error instanceof Error
       ? acceptMatch.error.message
       : declineMatch.error instanceof Error
         ? declineMatch.error.message
@@ -246,9 +319,18 @@ function DebateMatchPromptContent({ spaceId, matches, debates = [] }: DebateMatc
     setSelectedFormatIds(current => ({ ...current, [activeMatch.id]: formatId }));
   };
 
-  const accept = () => {
+  const accept = async () => {
+    if (!ownershipCoordinator || matchActionInFlightRef.current) return;
+    matchActionInFlightRef.current = true;
     setReadyError(null);
     setAcceptingMatchId(activeMatch.id);
+    if (!(await ownershipCoordinator.acquire())) {
+      matchActionInFlightRef.current = false;
+      setAcceptingMatchId(current => (current === activeMatch.id ? null : current));
+      return;
+    }
+    ownershipCoordinator.beginAcceptance();
+    setOwnershipState('pending');
     acceptMatch.mutate(
       {
         matchId: activeMatch.id,
@@ -256,18 +338,31 @@ function DebateMatchPromptContent({ spaceId, matches, debates = [] }: DebateMatc
       },
       {
         onSuccess: result => {
+          matchActionInFlightRef.current = false;
+          setAcceptingMatchId(current => (current === activeMatch.id ? null : current));
+          if (!ownershipCoordinator.confirmAcceptance()) return;
+          setOwnershipState('confirmed');
           setMinimizedMatchIds(current => current.filter(id => id !== activeMatch.id));
           const debateId = result.debate?.id ?? result.match.debate_id;
           if (debateId) {
             navigateToDebate(debateId, activeMatch.id);
             return;
           }
-          setAcceptingMatchId(null);
-          setAcceptedMatchIds(current => Array.from(new Set([...current, activeMatch.id])));
-          setWaitingClaimIds(current => Array.from(new Set([...current, activeMatch.claim.id])));
         },
         onError: () => {
-          setAcceptingMatchId(current => (current === activeMatch.id ? null : current));
+          void reconcileFailedAcceptance(activeMatch, currentUserId, ownershipCoordinator, reconcileActivity)
+            .then(result => {
+              if (result.status === 'confirmed') {
+                setOwnershipState('confirmed');
+                if (result.debate) navigateToDebate(result.debate.id, activeMatch.id);
+              } else if (result.status === 'rejected') {
+                setOwnershipState('none');
+              }
+            })
+            .finally(() => {
+              matchActionInFlightRef.current = false;
+              setAcceptingMatchId(current => (current === activeMatch.id ? null : current));
+            });
         },
       }
     );
@@ -276,18 +371,33 @@ function DebateMatchPromptContent({ spaceId, matches, debates = [] }: DebateMatc
   const dismiss = () => {
     readyValidationDebateIdRef.current = null;
     setDismissedMatchIds(current => Array.from(new Set([...current, activeMatch.id])));
-    setAcceptedMatchIds(current => current.filter(id => id !== activeMatch.id));
     setQueuedReadyMatchIds(current => current.filter(id => id !== activeMatch.id));
-    setWaitingClaimIds(current => current.filter(id => id !== activeMatch.claim.id));
     setMinimizedMatchIds(current => current.filter(id => id !== activeMatch.id));
     setReadyError(null);
   };
 
-  const decline = () => {
+  const decline = async () => {
+    if (!ownershipCoordinator || matchActionInFlightRef.current) return;
+    matchActionInFlightRef.current = true;
+    setAcceptingMatchId(activeMatch.id);
+    if (!(await ownershipCoordinator.acquire())) {
+      matchActionInFlightRef.current = false;
+      setAcceptingMatchId(current => (current === activeMatch.id ? null : current));
+      return;
+    }
     dismiss();
     declineMatch.mutate(activeMatch.id, {
+      onSuccess: () => {
+        matchActionInFlightRef.current = false;
+        setAcceptingMatchId(current => (current === activeMatch.id ? null : current));
+        setOwnershipState('none');
+        void ownershipCoordinator.release({ clearRecord: true });
+      },
       onError: () => {
+        matchActionInFlightRef.current = false;
+        setAcceptingMatchId(current => (current === activeMatch.id ? null : current));
         setDismissedMatchIds(current => current.filter(id => id !== activeMatch.id));
+        void ownershipCoordinator.release({ clearRecord: ownershipState !== 'confirmed' });
       },
     });
   };
@@ -305,6 +415,8 @@ function DebateMatchPromptContent({ spaceId, matches, debates = [] }: DebateMatc
     abortDebate.mutate(undefined, {
       onSuccess: () => {
         dismiss();
+        setOwnershipState('none');
+        void ownershipCoordinator?.release({ clearRecord: true });
         releaseSession(debateMatchMediaSessionKey(activeMatch.id));
       },
     });
@@ -429,4 +541,125 @@ function speakerLabel(participant: { display_name: string | null; profile_space_
 
 function formatIdForMatch(match: DebateMatch): DebateFormatId {
   return debateFormatById(match.turn_format_id)?.id ?? defaultDebateFormatId;
+}
+
+function initialOwnershipState(match: DebateMatch | null, currentUserId: string | null): OwnershipState {
+  if (!match || !currentUserId) return 'none';
+  const record = readDebateMatchTabOwnership(currentUserId);
+  if (record?.matchId === match.id && record.claimId === match.claim.id && record.spaceId === match.claim.space_id) {
+    return 'checking';
+  }
+  return participantForUser(match, currentUserId)?.accepted === true ? 'other-tab' : 'none';
+}
+
+type AcceptanceReconciliation =
+  { status: 'confirmed'; debate: Debate | null } | { status: 'rejected' } | { status: 'inconclusive' };
+
+async function reconcileFailedAcceptance(
+  match: DebateMatch,
+  currentUserId: string,
+  ownershipCoordinator: DebateMatchTabOwnershipCoordinator,
+  reconcileActivity?: () => Promise<DebateActivity | null>
+): Promise<AcceptanceReconciliation> {
+  if (!reconcileActivity) {
+    await ownershipCoordinator.release({ clearRecord: true });
+    return { status: 'rejected' };
+  }
+
+  let activity: DebateActivity | null;
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    const result = await Promise.race([
+      reconcileActivity(),
+      new Promise<typeof acceptanceReconciliationTimedOut>(resolve => {
+        timeout = setTimeout(() => resolve(acceptanceReconciliationTimedOut), acceptanceReconciliationTimeoutMs);
+      }),
+    ]);
+    if (result === acceptanceReconciliationTimedOut) return { status: 'inconclusive' };
+    activity = result;
+  } catch {
+    return { status: 'inconclusive' };
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+  if (!activity) return { status: 'inconclusive' };
+
+  const activityMatch = activity.match?.id === match.id ? activity.match : null;
+  const accepted = activityMatch && participantForUser(activityMatch, currentUserId)?.accepted === true;
+  const debate =
+    activity.debate &&
+    debateMatchOwnershipMatchesDebate(
+      {
+        userId: currentUserId,
+        claimId: match.claim.id,
+        spaceId: match.claim.space_id,
+      },
+      activity.debate,
+      currentUserId
+    )
+      ? activity.debate
+      : null;
+
+  if (accepted || debate) {
+    return ownershipCoordinator.confirmAcceptance() ? { status: 'confirmed', debate } : { status: 'inconclusive' };
+  }
+
+  if (activityMatch || (!activity.match && !activity.debate)) {
+    await ownershipCoordinator.release({ clearRecord: true });
+    return { status: 'rejected' };
+  }
+  return { status: 'inconclusive' };
+}
+
+function useMatchTabOwnershipCoordinator(
+  match: DebateMatch | null,
+  currentUserId: string | null,
+  onAcceptedElsewhere: () => void
+) {
+  const [state, setState] = React.useState<{
+    matchId: string;
+    userId: string;
+    coordinator: DebateMatchTabOwnershipCoordinator;
+  } | null>(null);
+
+  React.useEffect(() => {
+    if (!match || !currentUserId) return;
+    const coordinator = createDebateMatchTabOwnershipCoordinator({
+      matchId: match.id,
+      claimId: match.claim.id,
+      spaceId: match.claim.space_id,
+      userId: currentUserId,
+      onAcceptedElsewhere,
+    });
+    setState({ matchId: match.id, userId: currentUserId, coordinator });
+    return () => coordinator.close();
+  }, [currentUserId, match?.claim.id, match?.claim.space_id, match?.id, onAcceptedElsewhere]);
+
+  if (!state || state.matchId !== match?.id || state.userId !== currentUserId) return null;
+  return state.coordinator;
+}
+
+function debateMatchesMatch(debate: Debate, match: DebateMatch, currentUserId: string) {
+  return (
+    debate.claim.id === match.claim.id &&
+    debate.claim.space_id === match.claim.space_id &&
+    debate.participants.some(participant => participant.user_id === currentUserId) &&
+    !['complete', 'cancelled'].includes(debate.status)
+  );
+}
+
+function restorePageFocus(previouslyFocused: HTMLElement | null) {
+  if (previouslyFocused?.isConnected && previouslyFocused !== document.body) {
+    previouslyFocused.focus();
+    return;
+  }
+
+  const main = document.querySelector<HTMLElement>('main');
+  if (!main) return;
+  const hadTabIndex = main.hasAttribute('tabindex');
+  if (!hadTabIndex) main.tabIndex = -1;
+  main.focus();
+  if (!hadTabIndex) {
+    main.addEventListener('blur', () => main.removeAttribute('tabindex'), { once: true });
+  }
 }

--- a/docs/plans/2026-07-31-001-fix-debate-match-tab-ownership-plan.md
+++ b/docs/plans/2026-07-31-001-fix-debate-match-tab-ownership-plan.md
@@ -1,0 +1,160 @@
+---
+title: Keep Match Acceptance Local to One Tab - Plan
+type: fix
+date: 2026-07-31
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+product_contract_source: ce-plan-bootstrap
+execution: code
+---
+
+# Keep Match Acceptance Local to One Tab
+
+## Goal Capsule
+
+Keep match discovery global so every signed-in tab can show the incoming match, but make acceptance and the resulting pre-join/debate handoff local to one tab when Web Locks are available. Secondary tabs must close the prompt and remain on their current page, while an explicit visit to the debate URL continues to use the existing debate-room ownership message and takeover flow. Unsupported browsers retain best-effort arbitration plus the existing backend and debate-room ownership safety nets.
+
+## Product Contract
+
+### Problem
+
+`DebateCoordinator` is mounted globally and receives the same server activity in every tab. Today, `participant.accepted` and active debate activity are treated as instructions to start pre-join media and navigate, so accepting a match in one tab redirects every open tab. That violates the expected UX and can start duplicate media/debate flows.
+
+### Requirements
+
+- R1: A pending match remains visible in every tab until a user accepts or declines it.
+- R2: When Web Locks are available, acceptance is arbitrated before the accept request so only one same-browser tab becomes the local flow owner. Unsupported browsers degrade to best-effort client arbitration without changing stable backend identity.
+- R3: After successful acceptance, secondary tabs immediately hide the prompt and stay on their current URL through the match-to-debate transition.
+- R4: Only the owning tab may start pre-join media, queue readiness, promote the media session, or navigate automatically to the debate.
+- R5: The owning tab recovers after reload through tab-local persisted state; a duplicated or secondary tab must not inherit an active flow while the original owner exists.
+- R6: Closing the owner does not promote or auto-route another tab. Normal server expiry/cancellation remains authoritative.
+- R7: Direct navigation to a debate URL retains the existing debate-room ownership conflict and explicit takeover experience.
+
+### Acceptance Examples
+
+1. Two tabs receive the same match. Both show the request. Accepting in tab A opens pre-join there, closes the request in tab B, and leaves tab B's pathname unchanged after the debate appears.
+2. Tabs A and B click Accept at nearly the same time. Only the Web Lock winner calls the accept mutation; the other tab remains a non-owner and dismisses when acceptance becomes canonical.
+3. Tab A accepts and reloads before the debate exists. It restores the locally owned pre-join flow. Tab B, which has no valid local ownership, does not start media or navigate.
+4. Tab A accepts and then closes. Tab B remains on its current page and is not automatically promoted.
+5. A user explicitly opens the debate URL in tab B while tab A owns the room. Tab B sees the existing “already open in another tab” UI and may explicitly choose takeover where allowed.
+6. The accept request fails before reaching the server. Refreshed activity confirms the match is still unaccepted, so the attempted owner clears its pending marker, releases arbitration, and can retry; no other tab is redirected.
+7. The accept request commits but its response is lost. The pending owner retains arbitration while refreshing activity, observes canonical acceptance, upgrades to confirmed ownership, and continues; an inconclusive refresh remains an explicit retryable error instead of silently orphaning the flow.
+
+### Scope Boundaries
+
+In scope: same-browser match acceptance arbitration, tab-local persistence, immediate cross-tab dismissal, owner-only pre-join/media/readiness/navigation, reload recovery, and regression coverage.
+
+Out of scope: backend token or identity changes, automatic owner election after a tab closes, cross-device arbitration before LiveKit, and changes to the explicit debate-room ownership/takeover experience.
+
+## Settled Decisions
+
+- Product — secondary tabs close the accepted match and remain on their current page, chosen by the user over redirecting them to the debate or an ownership screen.
+- Product — only an explicit debate URL shows the existing “debate running in another tab” experience, chosen over surfacing it after an unrelated tab accepts a match.
+- Product — no tab is automatically promoted if the accepting tab closes, chosen over an owner-election flow.
+- Technical — same-tab reload recovery uses `sessionStorage`, chosen by the user over losing the local flow on reload. A Web Lock revalidates ownership because duplicated tabs may clone session storage.
+- Technical — retain stable backend user identity and the existing API. Frontend Web Locks plus broadcast/activity reconciliation are sufficient for same-browser arbitration, while the existing debate-room coordinator remains the final direct-URL/LiveKit guard.
+
+## Planning Contract
+
+### Key Technical Decisions
+
+- Add a match-specific ownership helper rather than extending the debate-room coordinator. Match ownership has no takeover or promotion semantics, while room ownership intentionally supports explicit takeover.
+- Key coordination by current user and match ID. Persist a versioned owner marker with the user, match, claim, space, timestamp, and local instance ID so debate-only activity can be correlated after the match disappears.
+- Acquire an exclusive Web Lock before any accept or decline mutation so conflicting same-browser actions cannot race. After acquiring for acceptance, persist a `pending` owner marker before sending the request, upgrade it to `confirmed` after a successful response or canonical activity reconciliation, and broadcast only confirmed acceptance.
+- Treat transport failure as an ambiguous outcome: retain arbitration while forcing an activity refresh. Promote the pending marker if the same match or correlated debate shows this user accepted; clear and release only when refreshed activity confirms unaccepted or terminal state. A bounded inconclusive result stays retryable in the owning tab rather than creating an ownerless accepted flow.
+- Use a one-hour TTL measured from `acceptedAt` for confirmed markers and from `createdAt` for pending markers. Remove expired records before lock acquisition or routing. Also clear on confirmed failed acceptance, decline, successful abort, terminal/mismatched activity, or explicit debate-route handoff.
+- Treat broadcast as an immediate UI signal, not the source of truth. A tab that missed the message still becomes a non-owner when server activity reports acceptance/debate without a valid local owner marker.
+- Treat Web Locks and BroadcastChannel as independent capabilities. Unsupported APIs degrade without crashing; the backend's idempotent state and existing room ownership remain the final safety net.
+- Gate every local side effect on validated ownership. Server `participant.accepted` is canonical match state, but is not proof that the current tab owns the flow.
+- Represent reload recovery as a non-interactive revalidation state. Until the persisted marker and Web Lock are validated, do not expose match actions, start media, submit readiness, or navigate; failure clears the marker before reconciling as a non-owner.
+- Preserve current match retention, pre-join device setup, queued readiness retry, media-session promotion, rematch routing, share-prompt suppression, and explicit room ownership behavior.
+
+### Assumptions
+
+- The activity payload continues to expose at most one active match/debate flow per user.
+- A debate can be correlated to the accepted match by claim ID, space ID, and current-user participation even when the match is no longer returned; the one-hour TTL bounds false correlation with a later debate on the same claim.
+- Strict simultaneous-click exclusion is best-effort in browsers without Web Locks; no new backend owner nonce is introduced in this change.
+- Queued “I’m ready” intent is not restored across reload. The owner may re-enter pre-join and confirm readiness again.
+
+## High-Level Design
+
+```mermaid
+sequenceDiagram
+    participant A as Accepting tab
+    participant L as Web Lock
+    participant API as Debate API/activity
+    participant B as Secondary tab
+
+    A->>L: Acquire user + match ownership
+    L-->>A: Granted
+    A->>API: Accept match
+    API-->>A: Accepted match/debate
+    A->>A: Persist tab-local owner marker
+    A-->>B: Broadcast acceptance confirmed
+    B->>B: Hide prompt; keep current URL
+    API-->>B: Accepted/debate activity
+    B->>B: No valid owner marker; no media/navigation
+    API-->>A: Accepted/debate activity
+    A->>A: Start/restore pre-join, ready, navigate
+```
+
+## Implementation Units
+
+### U1 — Match tab ownership coordinator
+
+Files:
+
+- `apps/web/core/debates/debate-match-tab-ownership.ts`
+- `apps/web/core/debates/debate-match-tab-ownership.test.ts`
+
+Implement versioned pending/confirmed session-storage records, defensive parsing with the exact one-hour TTL and activity correlation, per-user/per-match Web Lock acquisition and release, and BroadcastChannel acceptance notifications. Persist pending ownership after acquiring the lock but before sending accept; only confirmed ownership is broadcast. The coordinator must not implement takeover or automatic reacquisition for a secondary tab. Reload recovery may perform only an `ifAvailable` lock probe when the current tab has a matching persisted marker and the Navigation Timing entry identifies an actual reload; ordinary navigation or a duplicated tab invalidates the cloned marker before acquisition, and a failed reload acquisition invalidates it as well.
+
+Tests cover concurrent action acquisition, pending-before-request persistence, success upgrade/broadcast, definite failure release, ambiguous failure reconciliation, same-tab recovery, duplicate-tab recovery losing arbitration, owner close without promotion, exact TTL/stale/malformed records, and unsupported/throwing APIs.
+
+### U2 — Owner-only match prompt behavior
+
+Files:
+
+- `apps/web/core/debates/match-prompt.tsx`
+- `apps/web/core/debates/match-prompt.test.tsx`
+
+Instantiate ownership for the current match/user, acquire it before calling accept or decline, persist pending acceptance before calling the accept mutation, confirm ownership on success or canonical reconciliation, and consume cross-tab confirmation to hide secondary UI immediately. Replace every `participant.accepted`-driven local side effect with validated local ownership: waiting/pre-screen state, media preview, debate lookup/navigation, queued readiness, and media-session promotion. While ownership is revalidating or reconciling an ambiguous response, render no conflicting match actions and trigger no unvalidated side effects. Preserve the current accepting-tab experience and cleanup ownership on confirmed decline, successful abort, and terminal/mismatched flow state. On cross-tab dismissal, rely on the existing dialog focus restoration where available, fall back to the page's main landmark, and expose a polite screen-reader-only acceptance status without routing or showing an ownership screen.
+
+Tests prove a server-accepted non-owner neither renders pre-join nor starts media/readiness/navigation; a confirmed or recovered owner keeps current behavior; revalidation and ambiguous-failure reconciliation expose no conflicting intermediate action; cross-tab dismissal restores an accessible page context; accept/decline races call only the winning mutation; definite failures stay retryable; committed-but-lost responses recover through activity; and existing device/readiness/session-promotion cases remain green.
+
+### U3 — Ownership-aware global routing
+
+Files:
+
+- `apps/web/core/debates/debate-coordinator.tsx`
+- `apps/web/core/debates/debate-coordinator.test.tsx`
+
+Remove unconditional active-debate auto-routing. Keep the retained match as a handoff guard, but render or route only for the locally owning tab once shared activity shows acceptance. When an owner reloads after the match has disappeared, correlate the persisted marker with active debate activity, revalidate the Web Lock, and route that tab. A non-owner stays on its current pathname. Preserve rematch and share-prompt routing rules. Reaching the explicit debate route hands responsibility to the existing room coordinator and clears stale match handoff state.
+
+Tests cover initial prompt visibility, immediate secondary dismissal, no redirect through match-to-debate activity, retained owner handoff, owner-only reload recovery, secondary reload behavior, and unchanged rematch/share routing.
+
+## Verification Contract
+
+Run from `apps/web`:
+
+```bash
+bun vitest run core/debates/debate-match-tab-ownership.test.ts core/debates/match-prompt.test.tsx core/debates/debate-coordinator.test.tsx
+bun vitest run core/debates/debate-room-ownership.test.ts 'app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx'
+bun eslint core/debates/debate-match-tab-ownership.ts core/debates/debate-match-tab-ownership.test.ts core/debates/match-prompt.tsx core/debates/match-prompt.test.tsx core/debates/debate-coordinator.tsx core/debates/debate-coordinator.test.tsx
+```
+
+Browser verification:
+
+- Open two authenticated tabs on different non-debate pages and confirm both display a new match.
+- Accept in one tab and confirm only that tab requests camera/microphone and moves through pre-join; the other closes the prompt and its URL does not change.
+- Reload the accepting tab before joining and confirm it recovers. Close it and confirm the secondary remains stationary.
+- Explicitly open the debate URL in the secondary and confirm the existing room ownership/takeover message appears.
+- Repeat with two different users to confirm the normal two-participant debate still connects.
+
+## Definition of Done
+
+- With Web Locks available, match acceptance and all pre-join side effects are local to one same-browser tab; unsupported-browser fallback is documented and remains protected by backend identity and debate-room ownership.
+- Secondary tabs dismiss the accepted match without redirecting or starting media.
+- The accepting tab recovers after reload; closing it never promotes another tab.
+- Direct debate URLs retain the existing ownership message and takeover behavior.
+- Focused ownership, prompt, coordinator, and room-ownership tests pass, lint is clean, and manual two-tab/two-participant verification is recorded in the PR.


### PR DESCRIPTION
## Summary

Accepting a debate match in one tab now keeps every other tab on its current page. Only the accepting tab enters pre-join, starts media, or follows the automatic debate handoff; an explicit debate URL still uses the existing room ownership and takeover experience.

## Design

- Arbitrate same-browser acceptance with a per-user, per-match Web Lock before the API mutation, then persist pending/confirmed tab-local ownership for reload recovery.
- Broadcast only confirmed acceptance so secondary tabs dismiss the prompt immediately, while shared activity remains the fallback source of truth when a broadcast is missed.
- Treat server acceptance as canonical match state, not proof that the current tab owns the flow. Debate-only activity dismisses non-owners without redirecting them.
- Reset ownership state when the current user or match changes, and clear stale markers after authoritative empty, replacement-match, terminal-debate, or mismatched-debate activity.
- Bound ambiguous acceptance reconciliation, reject terminal debate handoffs, and keep one deterministic fallback owner when Web Locks, BroadcastChannel, or session storage are unavailable.

## Validation

- `bun vitest run core/debates` (26 files, 309 tests passed)
- `bun x tsc --noEmit --pretty false`
- Focused ESLint for all changed debate ownership, prompt, coordinator, and test files
- Local browser smoke test on a real space route; the page rendered with no new console errors
- Authenticated two-user and duplicate-tab production flow not run locally because the browser session was logged out; the ownership, reload, broadcast, fallback-race, media, and routing paths are covered by the debate suite

https://linear.app/geobrowser/issue/GEO-2472/bug-this-debate-is-open-in-another-tab