### PR TITLE
fix(debates): share videos from the debate feed

### DIFF
--- a/apps/web/app/space/[id]/(space)/debates/debates-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/debates-page-client.test.tsx
@@ -12,6 +12,7 @@ const mocks = vi.hoisted(() => ({
   pause: vi.fn(),
   replace: vi.fn(),
   recordingUrl: vi.fn(() => Promise.resolve({ url: 'https://media.test/slot.webm' })),
+  mediaArtifactMutate: vi.fn(),
   openSidePanel: vi.fn(),
   // Second stage of the feed's gate: which debates the media worker has composed a final_video for.
   media: { processedIds: ['debate-1'] as string[], isLoading: false, hasError: false },
@@ -44,6 +45,7 @@ vi.mock('~/core/debates/hooks', () => ({
   useSpaceDebates: () => ({ data: { debates: [completedDebate()], matches: [] }, isLoading: false, error: null }),
   useProcessedVideoDebateIds: () => mocks.media,
   useRecordingUrl: () => ({ mutateAsync: mocks.recordingUrl }),
+  useDebateMediaArtifactUrl: () => ({ mutate: mocks.mediaArtifactMutate }),
   useDebateTranscript: () => ({ data: { segments: [] }, isLoading: false, error: null }),
   useDebateClaims: () => ({ data: { claims: [] } }),
   useJoinDebateQueue: () => ({ mutate: vi.fn(), isPending: false }),
@@ -65,6 +67,7 @@ beforeEach(() => {
   mocks.play.mockClear();
   mocks.pause.mockClear();
   mocks.replace.mockClear();
+  mocks.mediaArtifactMutate.mockClear();
   mocks.media = { processedIds: ['debate-1'], isLoading: false, hasError: false };
   Object.defineProperty(HTMLMediaElement.prototype, 'play', { configurable: true, value: mocks.play });
   Object.defineProperty(HTMLMediaElement.prototype, 'pause', { configurable: true, value: mocks.pause });

--- a/apps/web/core/debates/browse/debate-feed.test.tsx
+++ b/apps/web/core/debates/browse/debate-feed.test.tsx
@@ -246,6 +246,9 @@ describe('DebatesBrowseFeed video sharing', () => {
     const shareButtons = screen.getAllByRole('button', { name: 'Share debate video' });
     expect(shareButtons).toHaveLength(2);
     expect(shareButtons.every(button => button.getAttribute('aria-disabled') === 'false')).toBe(true);
+    fireEvent.focus(shareButtons[0]);
+    await advance(300);
+    expect(screen.queryByText('Share the debate video.')).not.toBeInTheDocument();
 
     fireEvent.click(shareButtons[1]);
     const file = mocks.share.mock.calls[0]?.[0].files[0] as File;
@@ -314,6 +317,9 @@ describe('DebatesBrowseFeed video sharing', () => {
     const sharingButtons = screen.getAllByRole('button', { name: 'Sharing debate video' });
     expect(sharingButtons).toHaveLength(2);
     expect(sharingButtons.every(button => button.getAttribute('aria-disabled') === 'true')).toBe(true);
+    fireEvent.focus(sharingButtons[0]);
+    await advance(300);
+    expect(screen.queryByText('Opening sharing options…')).not.toBeInTheDocument();
 
     resolveShare?.();
     await flushPromises();

--- a/apps/web/core/debates/browse/debate-feed.test.tsx
+++ b/apps/web/core/debates/browse/debate-feed.test.tsx
@@ -1,0 +1,412 @@
+import '@testing-library/jest-dom/vitest';
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Debate } from '~/core/debates/api';
+
+import { DebatesBrowseFeed } from './debate-feed';
+
+const mocks = vi.hoisted(() => ({
+  debates: [] as Debate[],
+  mediaMutate: vi.fn(),
+  fetch: vi.fn(),
+  share: vi.fn(),
+  canShare: vi.fn(),
+  createObjectURL: vi.fn(() => 'blob:https://geo.test/social-video'),
+  revokeObjectURL: vi.fn(),
+  downloadClick: vi.fn(),
+}));
+
+type ObserverRecord = {
+  callback: IntersectionObserverCallback;
+  elements: Set<Element>;
+  instance: IntersectionObserver;
+};
+
+let observers: ObserverRecord[] = [];
+
+vi.mock('~/core/debates/hooks', () => ({
+  useSpaceDebates: () => ({ data: { debates: mocks.debates }, isLoading: false, error: null }),
+  useProcessedVideoDebateIds: () => ({
+    processedIds: mocks.debates.map(debate => debate.id),
+    isLoading: false,
+    hasError: false,
+  }),
+  useDebateMediaArtifactUrl: () => ({ mutate: mocks.mediaMutate }),
+}));
+
+vi.mock('~/core/debates/use-debate-votes', () => ({
+  useDebateVotes: () => ({
+    sharePercentFor: () => null,
+    isMyPick: () => false,
+    hasVoted: false,
+    isVoting: false,
+    castVote: vi.fn(),
+  }),
+}));
+
+vi.mock('~/core/hooks/use-space', () => ({
+  useSpace: () => ({ space: { entity: { name: 'Fashion', image: null } }, isLoading: false }),
+}));
+
+vi.mock('~/core/sync/use-store', () => ({
+  useQueryEntities: () => ({ entities: [], isLoading: false }),
+}));
+
+vi.mock('./debate-feed-player', () => ({
+  DebateFeedPlayer: ({ debate, active }: { debate: Debate; active: boolean }) => (
+    <div data-testid={`player-${debate.id}`} data-active={active} />
+  ),
+}));
+
+vi.mock('./debate-claims-panel', () => ({ DebateClaimsPanel: () => <div>Claims panel</div> }));
+vi.mock('./join-debate-panel', () => ({ JoinDebatePanel: () => <div>Join panel</div> }));
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.resetAllMocks();
+  observers = [];
+  mocks.debates = [completedDebate('debate-1', 'Debates are useful', '2026-07-02T00:01:10.000Z')];
+  mocks.createObjectURL.mockReturnValue('blob:https://geo.test/social-video');
+  mocks.fetch.mockResolvedValue(videoResponse());
+  mocks.canShare.mockReturnValue(false);
+  mocks.mediaMutate.mockImplementation((variables, options) => {
+    if (variables.request.kind === 'social_video') {
+      options.onSuccess({ upload: { url: `https://video.test/${variables.debateId}.mp4` } });
+    }
+  });
+
+  class MockIntersectionObserver implements IntersectionObserver {
+    readonly root = null;
+    readonly rootMargin = '0px';
+    readonly scrollMargin = '0px';
+    readonly thresholds = [0.6];
+    private readonly record: ObserverRecord;
+
+    constructor(callback: IntersectionObserverCallback) {
+      this.record = { callback, elements: new Set(), instance: this };
+      observers.push(this.record);
+    }
+
+    observe = (element: Element) => this.record.elements.add(element);
+    unobserve = (element: Element) => this.record.elements.delete(element);
+    disconnect = () => this.record.elements.clear();
+    takeRecords = () => [];
+  }
+
+  vi.stubGlobal('IntersectionObserver', MockIntersectionObserver);
+  vi.stubGlobal(
+    'ResizeObserver',
+    class MockResizeObserver {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+  );
+  vi.stubGlobal('fetch', mocks.fetch);
+  Object.defineProperty(navigator, 'share', { configurable: true, value: mocks.share });
+  Object.defineProperty(navigator, 'canShare', { configurable: true, value: mocks.canShare });
+  Object.defineProperty(URL, 'createObjectURL', { configurable: true, value: mocks.createObjectURL });
+  Object.defineProperty(URL, 'revokeObjectURL', { configurable: true, value: mocks.revokeObjectURL });
+  Object.defineProperty(HTMLAnchorElement.prototype, 'click', {
+    configurable: true,
+    value: mocks.downloadClick,
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe('DebatesBrowseFeed video sharing', () => {
+  it('waits for five seconds of active dwell and never prepares an adjacent debate', async () => {
+    mocks.debates.push(completedDebate('debate-2', 'Adjacent debate', '2026-07-01T00:01:10.000Z'));
+    render(<DebatesBrowseFeed spaceId="space-1" />);
+
+    await advance(4_999);
+    expect(mocks.mediaMutate).not.toHaveBeenCalled();
+
+    await advance(1);
+    expect(mocks.mediaMutate).toHaveBeenCalledTimes(1);
+    expect(mocks.mediaMutate).toHaveBeenCalledWith(
+      { debateId: 'debate-1', request: { kind: 'social_video' } },
+      expect.any(Object)
+    );
+    expect(mocks.mediaMutate.mock.calls.every(([variables]) => variables.request.kind !== 'social_preview_image')).toBe(
+      true
+    );
+    expect(mocks.mediaMutate).not.toHaveBeenCalledWith(
+      { debateId: 'debate-2', request: expect.anything() },
+      expect.anything()
+    );
+  });
+
+  it('cancels a fast-scroll dwell and starts a fresh five-second dwell for the new active debate', async () => {
+    mocks.debates.push(completedDebate('debate-2', 'Adjacent debate', '2026-07-01T00:01:10.000Z'));
+    render(<DebatesBrowseFeed spaceId="space-1" />);
+
+    await advance(3_000);
+    activateDebate('Adjacent debate');
+    await advance(4_999);
+    expect(mocks.mediaMutate).not.toHaveBeenCalled();
+
+    await advance(1);
+    expect(mocks.mediaMutate).toHaveBeenCalledTimes(1);
+    expect(mocks.mediaMutate).toHaveBeenCalledWith(
+      { debateId: 'debate-2', request: { kind: 'social_video' } },
+      expect.any(Object)
+    );
+  });
+
+  it('aborts an in-flight preparation and revokes a ready blob when scrolling away', async () => {
+    mocks.debates.push(completedDebate('debate-2', 'Adjacent debate', '2026-07-01T00:01:10.000Z'));
+    let downloadSignal: AbortSignal | undefined;
+    mocks.fetch.mockImplementationOnce((_url, init) => {
+      downloadSignal = init.signal;
+      return new Promise(() => undefined);
+    });
+    render(<DebatesBrowseFeed spaceId="space-1" />);
+
+    await advance(5_000);
+    expect(downloadSignal).toBeDefined();
+    activateDebate('Adjacent debate');
+    expect(downloadSignal?.aborted).toBe(true);
+
+    cleanup();
+    mocks.fetch.mockResolvedValue(videoResponse());
+    render(<DebatesBrowseFeed spaceId="space-1" />);
+    await advance(5_000);
+    await flushPromises();
+    expect(mocks.createObjectURL).toHaveBeenCalled();
+
+    activateDebate('Adjacent debate');
+    expect(mocks.revokeObjectURL).toHaveBeenCalledWith('blob:https://geo.test/social-video');
+  });
+
+  it('does not start an MP4 download when the artifact URL arrives after deactivation', async () => {
+    mocks.debates.push(completedDebate('debate-2', 'Adjacent debate', '2026-07-01T00:01:10.000Z'));
+    let videoRequestOptions: { onSuccess: (response: { upload: { url: string } }) => void } | undefined;
+    mocks.mediaMutate.mockImplementation((variables, options) => {
+      if (variables.request.kind === 'social_video') videoRequestOptions = options;
+    });
+    render(<DebatesBrowseFeed spaceId="space-1" />);
+
+    await advance(5_000);
+    expect(videoRequestOptions).toBeDefined();
+    activateDebate('Adjacent debate');
+    videoRequestOptions?.onSuccess({ upload: { url: 'https://video.test/debate-1.mp4' } });
+    await flushPromises();
+
+    expect(mocks.fetch).not.toHaveBeenCalled();
+  });
+
+  it('keeps both preparing controls focusable, unavailable, and explained by a tooltip', async () => {
+    render(<DebatesBrowseFeed spaceId="space-1" />);
+
+    const shareButtons = screen.getAllByRole('button', { name: 'Share debate video (preparing)' });
+    expect(shareButtons).toHaveLength(2);
+    for (const button of shareButtons) {
+      expect(button).toHaveAttribute('aria-disabled', 'true');
+      expect(button).not.toBeDisabled();
+    }
+
+    fireEvent.focus(shareButtons[0]);
+    await advance(300);
+    expect(screen.getAllByText('Preparing video for sharing… You can share soon.').length).toBeGreaterThan(0);
+  });
+
+  it('turns preparation failure into an enabled retry that starts immediately while active', async () => {
+    let requestCount = 0;
+    mocks.mediaMutate.mockImplementation((variables, options) => {
+      if (variables.request.kind !== 'social_video') return;
+      requestCount += 1;
+      if (requestCount === 1) options.onError(new Error('Video unavailable'));
+    });
+    render(<DebatesBrowseFeed spaceId="space-1" />);
+
+    await advance(5_000);
+    const retryButtons = screen.getAllByRole('button', { name: 'Retry debate video preparation' });
+    expect(retryButtons).toHaveLength(2);
+    expect(retryButtons[0]).toHaveAttribute('aria-disabled', 'false');
+
+    fireEvent.click(retryButtons[0]);
+    expect(requestCount).toBe(2);
+  });
+
+  it('shares only the claim title and prepared MP4 from either ready control', async () => {
+    mocks.canShare.mockReturnValue(true);
+    mocks.share.mockResolvedValue(undefined);
+    render(<DebatesBrowseFeed spaceId="space-1" />);
+
+    await advance(5_000);
+    await flushPromises();
+    const shareButtons = screen.getAllByRole('button', { name: 'Share debate video' });
+    expect(shareButtons).toHaveLength(2);
+    expect(shareButtons.every(button => button.getAttribute('aria-disabled') === 'false')).toBe(true);
+
+    fireEvent.click(shareButtons[1]);
+    const file = mocks.share.mock.calls[0]?.[0].files[0] as File;
+    expect(file).toBeInstanceOf(File);
+    expect(file.name).toBe('debate-debate-1-social.mp4');
+    expect(mocks.share).toHaveBeenCalledWith({ title: 'Debates are useful', files: [file] });
+    expect(mocks.share.mock.calls[0]?.[0]).not.toHaveProperty('url');
+    expect(mocks.share.mock.calls[0]?.[0]).not.toHaveProperty('text');
+  });
+
+  it('downloads the prepared MP4 when native file sharing is unsupported', async () => {
+    render(<DebatesBrowseFeed spaceId="space-1" />);
+
+    await advance(5_000);
+    await flushPromises();
+    fireEvent.click(screen.getAllByRole('button', { name: 'Download debate video' })[0]);
+
+    expect(mocks.downloadClick).toHaveBeenCalledTimes(1);
+    const downloadLink = mocks.downloadClick.mock.instances[0] as HTMLAnchorElement;
+    expect(downloadLink.href).toBe('blob:https://geo.test/social-video');
+    expect(downloadLink.download).toBe('debate-debate-1-social.mp4');
+    expect(mocks.share).not.toHaveBeenCalled();
+  });
+
+  it('keeps cancellation silent and a real handoff failure retryable without redownloading', async () => {
+    mocks.canShare.mockReturnValue(true);
+    mocks.share
+      .mockRejectedValueOnce(new DOMException('Cancelled', 'AbortError'))
+      .mockRejectedValueOnce(new Error('Share service unavailable'))
+      .mockResolvedValueOnce(undefined);
+    render(<DebatesBrowseFeed spaceId="space-1" />);
+
+    await advance(5_000);
+    await flushPromises();
+    fireEvent.click(screen.getAllByRole('button', { name: 'Share debate video' })[0]);
+    await flushPromises();
+    expect(screen.queryByRole('button', { name: /try sharing/i })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Share debate video' })[0]);
+    await flushPromises();
+    const retryButtons = screen.getAllByRole('button', { name: 'Try sharing debate video again' });
+    expect(retryButtons).toHaveLength(2);
+    expect(mocks.mediaMutate).toHaveBeenCalledTimes(1);
+    expect(mocks.fetch).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(retryButtons[1]);
+    await flushPromises();
+    expect(mocks.share).toHaveBeenCalledTimes(3);
+    expect(mocks.mediaMutate).toHaveBeenCalledTimes(1);
+    expect(mocks.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('prevents duplicate handoffs across the horizontal and vertical controls', async () => {
+    mocks.canShare.mockReturnValue(true);
+    let resolveShare: (() => void) | undefined;
+    mocks.share.mockReturnValue(new Promise<void>(resolve => (resolveShare = resolve)));
+    render(<DebatesBrowseFeed spaceId="space-1" />);
+
+    await advance(5_000);
+    await flushPromises();
+    const shareButtons = screen.getAllByRole('button', { name: 'Share debate video' });
+    fireEvent.click(shareButtons[0]);
+    fireEvent.click(shareButtons[1]);
+
+    expect(mocks.share).toHaveBeenCalledTimes(1);
+    const sharingButtons = screen.getAllByRole('button', { name: 'Sharing debate video' });
+    expect(sharingButtons).toHaveLength(2);
+    expect(sharingButtons.every(button => button.getAttribute('aria-disabled') === 'true')).toBe(true);
+
+    resolveShare?.();
+    await flushPromises();
+  });
+});
+
+async function advance(milliseconds: number) {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(milliseconds);
+  });
+}
+
+async function flushPromises() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+function activateDebate(claim: string) {
+  const section = screen.getByRole('heading', { name: claim }).closest('section');
+  if (!section) throw new Error(`Could not find debate section for ${claim}`);
+  const observer = observers.find(record => record.elements.has(section));
+  if (!observer) throw new Error(`Could not find observer for ${claim}`);
+  act(() => {
+    observer.callback(
+      [
+        {
+          target: section,
+          isIntersecting: true,
+          intersectionRatio: 0.6,
+        } as unknown as IntersectionObserverEntry,
+      ],
+      observer.instance
+    );
+  });
+}
+
+function videoResponse() {
+  return new Response(new Uint8Array([1, 2, 3]), {
+    status: 200,
+    headers: { 'content-length': '3', 'content-type': 'video/mp4' },
+  });
+}
+
+function completedDebate(id: string, claim: string, completedAt: string): Debate {
+  return {
+    id,
+    claim: {
+      id: `claim-${id}`,
+      space_id: 'space-1',
+      claim_entity_id: `claim-entity-${id}`,
+      claim,
+      description: null,
+    },
+    status: 'complete',
+    room_name: id,
+    first_participant_slot: 1,
+    current_turn_index: 1,
+    current_speaker_slot: null,
+    connecting_started_at: null,
+    connecting_deadline_at: null,
+    turn_started_at: null,
+    turn_ends_at: null,
+    preflight_ends_at: null,
+    turn_format_id: 'standard',
+    turn_durations_ms: [30_000, 30_000],
+    created_at: completedAt,
+    started_at: completedAt,
+    completed_at: completedAt,
+    participants: [],
+    recordings: [1, 2].map(slot => ({
+      id: `${id}-recording-${slot}`,
+      participant_slot: slot as 1 | 2,
+      position: slot === 1,
+      position_label: slot === 1 ? 'Yes' : 'No',
+      user_id: `${id}-user-${slot}`,
+      object_key: `${id}-recording-${slot}.webm`,
+      filename: `${id}-recording-${slot}.webm`,
+      source: 'local' as const,
+      content_type: 'video/webm',
+      started_at_ms: 0,
+      ended_at_ms: 60_000,
+      duration_seconds: 60,
+      byte_size: 1,
+      width: 640,
+      height: 480,
+      framerate: 30,
+      video_bits_per_second: 500_000,
+    })),
+    recording_error: null,
+    cancellation_reason: null,
+    recording_cancelled_at: null,
+    recording_cancelled_by: null,
+  };
+}

--- a/apps/web/core/debates/browse/debate-feed.tsx
+++ b/apps/web/core/debates/browse/debate-feed.tsx
@@ -8,6 +8,12 @@ import { CLAIM_TYPE_ID, TOPICS_PROPERTY_ID } from '~/core/claims/ontology';
 import type { Debate } from '~/core/debates/api';
 import { useProcessedVideoDebateIds, useSpaceDebates } from '~/core/debates/hooks';
 import { isWatchableDebate } from '~/core/debates/playback-utils';
+import {
+  getPreparedSocialVideoHandoffMethod,
+  handoffPreparedSocialVideo,
+  isAbortError,
+  usePreparedSocialVideo,
+} from '~/core/debates/social-video-share';
 import { useDebateVotes } from '~/core/debates/use-debate-votes';
 import { useSpace } from '~/core/hooks/use-space';
 import { ID } from '~/core/id';
@@ -20,10 +26,11 @@ import { Text } from '~/design-system/text';
 
 import { DebateClaimsPanel } from './debate-claims-panel';
 import { DebateFeedPlayer } from './debate-feed-player';
-import { DebateInteractionBar, type DebateVote } from './debate-interaction-bar';
+import { DebateInteractionBar, type DebateShareAction, type DebateVote } from './debate-interaction-bar';
 import { JoinDebatePanel } from './join-debate-panel';
 
 const PAGE_SIZE = 5;
+const SHARE_PREPARATION_DWELL_MS = 5_000;
 
 export function DebatesBrowseFeed({
   spaceId,
@@ -205,7 +212,28 @@ function DebateFeedItem({
 }) {
   const itemRef = React.useRef<HTMLElement | null>(null);
   const [vote, setVote] = React.useState<DebateVote>(null);
+  const [preparationEnabled, setPreparationEnabled] = React.useState(false);
+  const [isSharing, setIsSharing] = React.useState(false);
+  const [shareError, setShareError] = React.useState<string | null>(null);
+  const sharingRef = React.useRef(false);
+  const activationGenerationRef = React.useRef(0);
   const winnerVotes = useDebateVotes(debate);
+  const preparedVideo = usePreparedSocialVideo(debate.id, {
+    enabled: active && preparationEnabled,
+    includePreview: false,
+  });
+
+  React.useEffect(() => {
+    setShareError(null);
+    if (!active) {
+      activationGenerationRef.current += 1;
+      setPreparationEnabled(false);
+      return;
+    }
+
+    const dwellTimer = window.setTimeout(() => setPreparationEnabled(true), SHARE_PREPARATION_DWELL_MS);
+    return () => window.clearTimeout(dwellTimer);
+  }, [active]);
 
   React.useEffect(() => {
     const element = itemRef.current;
@@ -222,6 +250,52 @@ function DebateFeedItem({
     return () => observer.disconnect();
   }, [onActivate, root]);
 
+  const handoffMethod = React.useMemo(
+    () => (preparedVideo.file ? getPreparedSocialVideoHandoffMethod(preparedVideo.file) : null),
+    [preparedVideo.file]
+  );
+  let shareState: DebateShareAction['state'] = 'preparing';
+  if (isSharing) shareState = 'sharing';
+  else if (active && (shareError || preparedVideo.status === 'error')) shareState = 'error';
+  else if (active && preparedVideo.status === 'ready') shareState = 'ready';
+  const shareTooltipMessage = getShareTooltipMessage({
+    state: shareState,
+    method: handoffMethod,
+    error: shareError ?? preparedVideo.error,
+  });
+  const activateShare = () => {
+    if (!active || sharingRef.current) return;
+    if (preparedVideo.status === 'error') {
+      setShareError(null);
+      preparedVideo.retry();
+      return;
+    }
+    if (!preparedVideo.file || !preparedVideo.downloadUrl) return;
+
+    const file = preparedVideo.file;
+    const downloadUrl = preparedVideo.downloadUrl;
+    const activationGeneration = activationGenerationRef.current;
+    sharingRef.current = true;
+    setIsSharing(true);
+    setShareError(null);
+    const handoff = handoffPreparedSocialVideo({
+      debateId: debate.id,
+      title: debate.claim.claim,
+      file,
+      downloadUrl,
+    });
+    void handoff
+      .catch(error => {
+        if (activationGenerationRef.current === activationGeneration && !isAbortError(error)) {
+          setShareError(error instanceof Error ? error.message : 'Could not share the video.');
+        }
+      })
+      .finally(() => {
+        sharingRef.current = false;
+        setIsSharing(false);
+      });
+  };
+
   const interactionProps = {
     score: vote === 'up' ? 1 : vote === 'down' ? -1 : 0,
     vote,
@@ -230,7 +304,12 @@ function DebateFeedItem({
     claimsCount: 0,
     onComment: () => undefined,
     onClaims: onOpenClaims,
-    onShare: () => undefined,
+    shareAction: {
+      state: shareState,
+      method: handoffMethod,
+      tooltipMessage: shareTooltipMessage,
+      onActivate: activateShare,
+    } satisfies DebateShareAction,
   };
 
   return (
@@ -348,4 +427,18 @@ function FeedMessage({ children }: { children: React.ReactNode }) {
 function completedTime(debate: Debate) {
   const value = debate.completed_at ?? debate.started_at ?? debate.created_at;
   return value ? new Date(value).getTime() : 0;
+}
+
+function getShareTooltipMessage({
+  state,
+  method,
+  error,
+}: Pick<DebateShareAction, 'state' | 'method'> & { error: string | null }) {
+  if (state === 'preparing') return 'Preparing video for sharing… You can share soon.';
+  if (state === 'sharing') return 'Opening sharing options…';
+  if (state === 'error') {
+    const fallback = method ? 'Could not share the video.' : 'Could not prepare the video.';
+    return `${error ?? fallback} Select to try again.`;
+  }
+  return method === 'download' ? 'Download the debate video.' : 'Share the debate video.';
 }

--- a/apps/web/core/debates/browse/debate-feed.tsx
+++ b/apps/web/core/debates/browse/debate-feed.tsx
@@ -435,10 +435,10 @@ function getShareTooltipMessage({
   error,
 }: Pick<DebateShareAction, 'state' | 'method'> & { error: string | null }) {
   if (state === 'preparing') return 'Preparing video for sharing… You can share soon.';
-  if (state === 'sharing') return 'Opening sharing options…';
+  if (state === 'sharing') return undefined;
   if (state === 'error') {
     const fallback = method ? 'Could not share the video.' : 'Could not prepare the video.';
     return `${error ?? fallback} Select to try again.`;
   }
-  return method === 'download' ? 'Download the debate video.' : 'Share the debate video.';
+  return method === 'download' ? 'Download the debate video.' : undefined;
 }

--- a/apps/web/core/debates/browse/debate-interaction-bar.tsx
+++ b/apps/web/core/debates/browse/debate-interaction-bar.tsx
@@ -7,10 +7,19 @@ import cx from 'classnames';
 import { InfoSmall } from '~/design-system/icons/info-small';
 import { VoteArrow } from '~/design-system/icons/vote-arrow';
 import { Text } from '~/design-system/text';
+import { Tooltip } from '~/design-system/tooltip';
 
+import type { SocialVideoHandoffMethod } from '../social-video-share';
 import { Comment, Share } from './icons';
 
 export type DebateVote = 'up' | 'down' | null;
+
+export type DebateShareAction = {
+  state: 'preparing' | 'ready' | 'sharing' | 'error';
+  method: SocialVideoHandoffMethod | null;
+  tooltipMessage: string;
+  onActivate: () => void;
+};
 
 type InteractionBarProps = {
   orientation: 'vertical' | 'horizontal';
@@ -21,13 +30,13 @@ type InteractionBarProps = {
   claimsCount: number;
   onComment: () => void;
   onClaims: () => void;
-  onShare: () => void;
+  shareAction: DebateShareAction;
   className?: string;
 };
 
 /**
  * The upvote/downvote/comment/claims/share bar beside each debate. Renders the
- * controls and counts; voting is local-only and comment/share are stubs so far.
+ * controls and counts; voting is local-only and comments are a stub so far.
  */
 export function DebateInteractionBar({
   orientation,
@@ -38,16 +47,29 @@ export function DebateInteractionBar({
   claimsCount,
   onComment,
   onClaims,
-  onShare,
+  shareAction,
   className,
 }: InteractionBarProps) {
+  const shareUnavailable = shareAction.state === 'preparing' || shareAction.state === 'sharing';
+  const shareAriaLabel = getShareAriaLabel(shareAction);
+  const activateShare = () => {
+    if (!shareUnavailable) shareAction.onActivate();
+  };
+
   if (orientation === 'vertical') {
     return (
       <div className={cx('flex w-9 flex-col items-center gap-3', className)}>
         <VotePill orientation="vertical" score={score} vote={vote} onVote={onVote} />
         <CircleAction label={String(commentCount)} onClick={onComment} icon={<Comment />} ariaLabel="Comments" />
         <CircleAction label={String(claimsCount)} onClick={onClaims} icon={<InfoSmall />} ariaLabel="Claims" />
-        <CircleAction label="Share" onClick={onShare} icon={<Share />} ariaLabel="Share debate" />
+        <CircleAction
+          label="Share"
+          onClick={activateShare}
+          icon={<Share />}
+          ariaLabel={shareAriaLabel}
+          ariaDisabled={shareUnavailable}
+          tooltipMessage={shareAction.tooltipMessage}
+        />
       </div>
     );
   }
@@ -57,7 +79,15 @@ export function DebateInteractionBar({
       <VotePill orientation="horizontal" score={score} vote={vote} onVote={onVote} />
       <PillAction onClick={onComment} icon={<Comment />} label={String(commentCount)} ariaLabel="Comments" />
       <PillAction onClick={onClaims} icon={<InfoSmall />} label={String(claimsCount)} ariaLabel="Claims" />
-      <PillAction onClick={onShare} icon={<Share />} label="Share" ariaLabel="Share debate" className="ml-auto" />
+      <PillAction
+        onClick={activateShare}
+        icon={<Share />}
+        label="Share"
+        ariaLabel={shareAriaLabel}
+        ariaDisabled={shareUnavailable}
+        tooltipMessage={shareAction.tooltipMessage}
+        className="ml-auto"
+      />
     </div>
   );
 }
@@ -110,22 +140,31 @@ function CircleAction({
   icon,
   onClick,
   ariaLabel,
+  ariaDisabled,
+  tooltipMessage,
 }: {
   label: string;
   icon: React.ReactNode;
   onClick: () => void;
   ariaLabel: string;
+  ariaDisabled?: boolean;
+  tooltipMessage?: string;
 }) {
+  const button = (
+    <button
+      type="button"
+      aria-label={ariaLabel}
+      aria-disabled={ariaDisabled}
+      onClick={onClick}
+      className="grid size-9 place-items-center rounded-full border border-grey-02 bg-white text-grey-04 shadow-light transition-colors hover:text-text aria-disabled:cursor-not-allowed aria-disabled:opacity-50"
+    >
+      {icon}
+    </button>
+  );
+
   return (
     <div className="flex flex-col items-center gap-1">
-      <button
-        type="button"
-        aria-label={ariaLabel}
-        onClick={onClick}
-        className="grid size-9 place-items-center rounded-full border border-grey-02 bg-white text-grey-04 shadow-light transition-colors hover:text-text"
-      >
-        {icon}
-      </button>
+      {tooltipMessage ? <Tooltip trigger={button} label={tooltipMessage} position="left" /> : button}
       <Text as="span" variant="tag" color="grey-04" className="tabular-nums">
         {label}
       </Text>
@@ -138,21 +177,26 @@ function PillAction({
   icon,
   onClick,
   ariaLabel,
+  ariaDisabled,
+  tooltipMessage,
   className,
 }: {
   label: string;
   icon: React.ReactNode;
   onClick: () => void;
   ariaLabel: string;
+  ariaDisabled?: boolean;
+  tooltipMessage?: string;
   className?: string;
 }) {
-  return (
+  const button = (
     <button
       type="button"
       aria-label={ariaLabel}
+      aria-disabled={ariaDisabled}
       onClick={onClick}
       className={cx(
-        'flex h-7 items-center gap-1.5 rounded-full border border-grey-02 bg-white px-2.5 text-grey-04 shadow-light transition-colors hover:text-text',
+        'flex h-7 items-center gap-1.5 rounded-full border border-grey-02 bg-white px-2.5 text-grey-04 shadow-light transition-colors hover:text-text aria-disabled:cursor-not-allowed aria-disabled:opacity-50',
         className
       )}
     >
@@ -162,4 +206,15 @@ function PillAction({
       </Text>
     </button>
   );
+
+  return tooltipMessage ? <Tooltip trigger={button} label={tooltipMessage} position="top" /> : button;
+}
+
+function getShareAriaLabel(shareAction: DebateShareAction) {
+  if (shareAction.state === 'preparing') return 'Share debate video (preparing)';
+  if (shareAction.state === 'sharing') return 'Sharing debate video';
+  if (shareAction.state === 'error') {
+    return shareAction.method ? 'Try sharing debate video again' : 'Retry debate video preparation';
+  }
+  return shareAction.method === 'download' ? 'Download debate video' : 'Share debate video';
 }

--- a/apps/web/core/debates/browse/debate-interaction-bar.tsx
+++ b/apps/web/core/debates/browse/debate-interaction-bar.tsx
@@ -17,7 +17,7 @@ export type DebateVote = 'up' | 'down' | null;
 export type DebateShareAction = {
   state: 'preparing' | 'ready' | 'sharing' | 'error';
   method: SocialVideoHandoffMethod | null;
-  tooltipMessage: string;
+  tooltipMessage?: string;
   onActivate: () => void;
 };
 

--- a/apps/web/core/debates/debate-coordinator.test.tsx
+++ b/apps/web/core/debates/debate-coordinator.test.tsx
@@ -468,7 +468,9 @@ describe('DebateCoordinator', () => {
       debate_id: 'debate-1',
       method: 'download',
     });
-    expect(mocks.handleMutate).toHaveBeenCalledWith({ promptId: 'prompt-1', action: 'shared' }, expect.any(Object));
+    await waitFor(() =>
+      expect(mocks.handleMutate).toHaveBeenCalledWith({ promptId: 'prompt-1', action: 'shared' }, expect.any(Object))
+    );
 
     mocks.prompts = [];
     view.rerender(<DebateCoordinator />);

--- a/apps/web/core/debates/debate-coordinator.tsx
+++ b/apps/web/core/debates/debate-coordinator.tsx
@@ -29,7 +29,12 @@ import {
   useRejectDebateChallenge,
 } from './hooks';
 import { DebateMatchPrompt } from './match-prompt';
-import { captureSocialVideoEvent, isAbortError, usePreparedSocialVideo } from './social-video-share';
+import {
+  getPreparedSocialVideoHandoffMethod,
+  handoffPreparedSocialVideo,
+  isAbortError,
+  usePreparedSocialVideo,
+} from './social-video-share';
 
 export function DebateCoordinator() {
   const router = useRouter();
@@ -213,7 +218,7 @@ function DebateSharePromptDialog({
   const [promptHandled, setPromptHandled] = React.useState(false);
   const sharingRef = React.useRef(false);
   const promptActionRef = React.useRef(false);
-  const preparedVideo = usePreparedSocialVideo(prompt.debate_id, true);
+  const preparedVideo = usePreparedSocialVideo(prompt.debate_id, { enabled: true, includePreview: true });
 
   React.useEffect(() => {
     const previousBodyOverflow = document.body.style.overflow;
@@ -262,7 +267,10 @@ function DebateSharePromptDialog({
     }
     finishPrompt(handoffCompleted ? 'shared' : 'dismissed');
   };
-  const canShareFile = preparedVideo.file ? canNativeShareFile(preparedVideo.file) : false;
+  const handoffMethod = React.useMemo(
+    () => (preparedVideo.file ? getPreparedSocialVideoHandoffMethod(preparedVideo.file) : null),
+    [preparedVideo.file]
+  );
   const share = async () => {
     if (handoffCompleted) {
       if (promptHandled) closeDialog();
@@ -275,24 +283,16 @@ function DebateSharePromptDialog({
     setIsSharing(true);
     setShareError(null);
     try {
-      if (canShareFile) {
-        await navigator.share({ title: prompt.claim, files: [preparedVideo.file] });
-      } else {
-        downloadPreparedVideo(preparedVideo.downloadUrl, preparedVideo.file.name);
-      }
-      captureSocialVideoEvent('debate_social_video_handoff_resolved', {
-        debate_id: prompt.debate_id,
-        method: canShareFile ? 'native_share' : 'download',
+      await handoffPreparedSocialVideo({
+        debateId: prompt.debate_id,
+        title: prompt.claim,
+        file: preparedVideo.file,
+        downloadUrl: preparedVideo.downloadUrl,
       });
       setHandoffCompleted(true);
       finishPrompt('shared', true);
     } catch (error) {
       if (isAbortError(error)) return;
-      captureSocialVideoEvent('debate_social_video_handoff_failed', {
-        debate_id: prompt.debate_id,
-        method: canShareFile ? 'native_share' : 'download',
-        error_name: error instanceof Error ? error.name : 'UnknownError',
-      });
       setShareError(error instanceof Error ? error.message : 'Could not share the video.');
     } finally {
       sharingRef.current = false;
@@ -309,7 +309,7 @@ function DebateSharePromptDialog({
           : 'Finish sharing'
         : preparedVideo.status !== 'ready'
           ? 'Preparing video…'
-          : canShareFile
+          : handoffMethod === 'native_share'
             ? 'Share video'
             : 'Download video';
 
@@ -422,26 +422,4 @@ function DebateSharePromptDialog({
       </section>
     </div>
   );
-}
-
-function downloadPreparedVideo(url: string, filename: string) {
-  const link = document.createElement('a');
-  link.href = url;
-  link.download = filename;
-  link.style.display = 'none';
-  document.body.append(link);
-  link.click();
-  link.remove();
-}
-
-function canNativeShareFile(file: File) {
-  if (typeof navigator === 'undefined') return false;
-  const share = navigator.share as typeof navigator.share | undefined;
-  const canShare = navigator.canShare as typeof navigator.canShare | undefined;
-  if (typeof share !== 'function' || typeof canShare !== 'function') return false;
-  try {
-    return canShare.call(navigator, { files: [file] });
-  } catch {
-    return false;
-  }
 }

--- a/apps/web/core/debates/social-video-share.test.ts
+++ b/apps/web/core/debates/social-video-share.test.ts
@@ -1,10 +1,161 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { downloadSocialVideo } from './social-video-share';
+import { downloadSocialVideo, handoffPreparedSocialVideo } from './social-video-share';
+
+const mocks = vi.hoisted(() => ({
+  capture: vi.fn(),
+  share: vi.fn(),
+  canShare: vi.fn(),
+  downloadClick: vi.fn(),
+}));
+
+vi.mock('~/core/analytics', () => ({ capture: mocks.capture }));
+
+const preparedFile = new File([new Uint8Array([1, 2, 3])], 'debate-debate-1-social.mp4', {
+  type: 'video/mp4',
+});
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
 
 afterEach(() => {
   vi.useRealTimers();
   vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('handoffPreparedSocialVideo', () => {
+  it('probes only the file payload and shares only the claim title and MP4', async () => {
+    mocks.canShare.mockReturnValue(true);
+    mocks.share.mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'canShare', { configurable: true, value: mocks.canShare });
+    Object.defineProperty(navigator, 'share', { configurable: true, value: mocks.share });
+
+    const handoff = handoffPreparedSocialVideo({
+      debateId: 'debate-1',
+      title: 'Debates are useful',
+      file: preparedFile,
+      downloadUrl: 'blob:https://geo.test/social-video',
+    });
+
+    expect(mocks.canShare).toHaveBeenCalledWith({ files: [preparedFile] });
+    expect(mocks.share).toHaveBeenCalledWith({ title: 'Debates are useful', files: [preparedFile] });
+    await expect(handoff).resolves.toBe('native_share');
+    expect(mocks.capture).toHaveBeenCalledWith('debate_social_video_handoff_resolved', {
+      debate_id: 'debate-1',
+      method: 'native_share',
+    });
+  });
+
+  it.each([
+    ['unsupported', () => false],
+    [
+      'throwing',
+      () => {
+        throw new TypeError('Unsupported share payload');
+      },
+    ],
+  ])('downloads when file sharing is %s', async (_label, capabilityProbe) => {
+    mocks.canShare.mockImplementation(capabilityProbe);
+    Object.defineProperty(navigator, 'canShare', { configurable: true, value: mocks.canShare });
+    Object.defineProperty(navigator, 'share', { configurable: true, value: mocks.share });
+    Object.defineProperty(HTMLAnchorElement.prototype, 'click', {
+      configurable: true,
+      value: mocks.downloadClick,
+    });
+
+    await expect(
+      handoffPreparedSocialVideo({
+        debateId: 'debate-1',
+        title: 'Debates are useful',
+        file: preparedFile,
+        downloadUrl: 'blob:https://geo.test/social-video',
+      })
+    ).resolves.toBe('download');
+
+    expect(mocks.share).not.toHaveBeenCalled();
+    expect(mocks.downloadClick).toHaveBeenCalledTimes(1);
+    const downloadLink = mocks.downloadClick.mock.instances[0] as HTMLAnchorElement;
+    expect(downloadLink.href).toBe('blob:https://geo.test/social-video');
+    expect(downloadLink.download).toBe('debate-debate-1-social.mp4');
+    expect(mocks.capture).toHaveBeenCalledWith('debate_social_video_handoff_resolved', {
+      debate_id: 'debate-1',
+      method: 'download',
+    });
+  });
+
+  it('rethrows native share cancellation without failure analytics', async () => {
+    const cancellation = new DOMException('Cancelled', 'AbortError');
+    mocks.canShare.mockReturnValue(true);
+    mocks.share.mockRejectedValue(cancellation);
+    Object.defineProperty(navigator, 'canShare', { configurable: true, value: mocks.canShare });
+    Object.defineProperty(navigator, 'share', { configurable: true, value: mocks.share });
+
+    await expect(
+      handoffPreparedSocialVideo({
+        debateId: 'debate-1',
+        title: 'Debates are useful',
+        file: preparedFile,
+        downloadUrl: 'blob:https://geo.test/social-video',
+      })
+    ).rejects.toBe(cancellation);
+
+    expect(mocks.capture).not.toHaveBeenCalledWith('debate_social_video_handoff_failed', expect.anything());
+  });
+
+  it('reports non-cancellation native share failures and leaves retry to the caller', async () => {
+    const failure = new Error('Share service unavailable');
+    mocks.canShare.mockReturnValue(true);
+    mocks.share.mockRejectedValue(failure);
+    Object.defineProperty(navigator, 'canShare', { configurable: true, value: mocks.canShare });
+    Object.defineProperty(navigator, 'share', { configurable: true, value: mocks.share });
+
+    await expect(
+      handoffPreparedSocialVideo({
+        debateId: 'debate-1',
+        title: 'Debates are useful',
+        file: preparedFile,
+        downloadUrl: 'blob:https://geo.test/social-video',
+      })
+    ).rejects.toBe(failure);
+
+    expect(mocks.capture).toHaveBeenCalledWith('debate_social_video_handoff_failed', {
+      debate_id: 'debate-1',
+      method: 'native_share',
+      error_name: 'Error',
+    });
+  });
+
+  it('removes the temporary download link and reports a failed fallback download', async () => {
+    const failure = new Error('Download blocked');
+    mocks.canShare.mockReturnValue(false);
+    mocks.downloadClick.mockImplementation(() => {
+      throw failure;
+    });
+    Object.defineProperty(navigator, 'canShare', { configurable: true, value: mocks.canShare });
+    Object.defineProperty(navigator, 'share', { configurable: true, value: mocks.share });
+    Object.defineProperty(HTMLAnchorElement.prototype, 'click', {
+      configurable: true,
+      value: mocks.downloadClick,
+    });
+
+    await expect(
+      handoffPreparedSocialVideo({
+        debateId: 'debate-1',
+        title: 'Debates are useful',
+        file: preparedFile,
+        downloadUrl: 'blob:https://geo.test/social-video',
+      })
+    ).rejects.toBe(failure);
+
+    expect(document.querySelector('a[download="debate-debate-1-social.mp4"]')).toBeNull();
+    expect(mocks.capture).toHaveBeenCalledWith('debate_social_video_handoff_failed', {
+      debate_id: 'debate-1',
+      method: 'download',
+      error_name: 'Error',
+    });
+  });
 });
 
 describe('downloadSocialVideo', () => {

--- a/apps/web/core/debates/social-video-share.ts
+++ b/apps/web/core/debates/social-video-share.ts
@@ -8,6 +8,8 @@ import { useDebateMediaArtifactUrl } from './hooks';
 
 type PreparationStatus = 'preparing' | 'ready' | 'error';
 
+export type SocialVideoHandoffMethod = 'native_share' | 'download';
+
 export type PreparedSocialVideo = {
   status: PreparationStatus;
   previewUrl: string | null;
@@ -38,7 +40,10 @@ const EMPTY_PREPARED_SOCIAL_VIDEO: Omit<PreparedSocialVideo, 'retry'> = {
   error: null,
 };
 
-export function usePreparedSocialVideo(debateId: string, enabled = true): PreparedSocialVideo {
+export function usePreparedSocialVideo(
+  debateId: string,
+  { enabled, includePreview }: { enabled: boolean; includePreview: boolean }
+): PreparedSocialVideo {
   const previewArtifact = useDebateMediaArtifactUrl();
   const videoArtifact = useDebateMediaArtifactUrl();
   const previewMutateRef = React.useRef(previewArtifact.mutate);
@@ -78,30 +83,31 @@ export function usePreparedSocialVideo(debateId: string, enabled = true): Prepar
       error: null,
     }));
 
-    previewMutateRef.current(
-      { debateId, request: { kind: 'social_preview_image' } },
-      {
-        onSuccess: response => {
-          if (active) setState(current => ({ ...current, previewUrl: response.upload.url }));
-        },
-        onError: () => {
-          if (!active) return;
-          captureSocialVideoEvent('debate_social_video_preparation_failed', {
-            debate_id: debateId,
-            stage: 'preview_url',
-          });
-          setState(current => ({ ...current, previewFailed: true }));
-        },
-      }
-    );
+    if (includePreview) {
+      previewMutateRef.current(
+        { debateId, request: { kind: 'social_preview_image' } },
+        {
+          onSuccess: response => {
+            if (active) setState(current => ({ ...current, previewUrl: response.upload.url }));
+          },
+          onError: () => {
+            if (!active) return;
+            captureSocialVideoEvent('debate_social_video_preparation_failed', {
+              debate_id: debateId,
+              stage: 'preview_url',
+            });
+            setState(current => ({ ...current, previewFailed: true }));
+          },
+        }
+      );
+    }
 
     videoMutateRef.current(
       { debateId, request: { kind: 'social_video' } },
       {
         onSuccess: response => {
-          if (active) {
-            setState(current => (current.playbackUrl ? current : { ...current, playbackUrl: response.upload.url }));
-          }
+          if (!active) return;
+          setState(current => (current.playbackUrl ? current : { ...current, playbackUrl: response.upload.url }));
           void downloadSocialVideo(response.upload.url, controller.signal, progress => {
             if (!active) return;
             const progressPercent = progress.totalBytes
@@ -162,12 +168,60 @@ export function usePreparedSocialVideo(debateId: string, enabled = true): Prepar
       controller.abort();
       if (downloadUrl) URL.revokeObjectURL(downloadUrl);
     };
-  }, [debateId, enabled, retryCount]);
+  }, [debateId, enabled, includePreview, retryCount]);
 
   return {
     ...state,
     retry: () => setRetryCount(count => count + 1),
   };
+}
+
+export async function handoffPreparedSocialVideo({
+  debateId,
+  title,
+  file,
+  downloadUrl,
+}: {
+  debateId: string;
+  title: string;
+  file: File;
+  downloadUrl: string;
+}): Promise<SocialVideoHandoffMethod> {
+  const method = getPreparedSocialVideoHandoffMethod(file);
+
+  try {
+    if (method === 'native_share') {
+      const sharePromise = navigator.share({ title, files: [file] });
+      await sharePromise;
+    } else {
+      downloadPreparedVideo(downloadUrl, file.name);
+    }
+
+    captureSocialVideoEvent('debate_social_video_handoff_resolved', {
+      debate_id: debateId,
+      method,
+    });
+    return method;
+  } catch (error) {
+    if (!isAbortError(error)) {
+      captureSocialVideoEvent('debate_social_video_handoff_failed', {
+        debate_id: debateId,
+        method,
+        error_name: error instanceof Error ? error.name : 'UnknownError',
+      });
+    }
+    throw error;
+  }
+}
+
+export function getPreparedSocialVideoHandoffMethod(file: File): SocialVideoHandoffMethod {
+  if (typeof navigator === 'undefined') return 'download';
+  if (typeof navigator.share !== 'function' || typeof navigator.canShare !== 'function') return 'download';
+  try {
+    return navigator.canShare({ files: [file] }) ? 'native_share' : 'download';
+  } catch {
+    return 'download';
+  }
 }
 
 export async function downloadSocialVideo(
@@ -254,6 +308,19 @@ export function captureSocialVideoEvent(eventName: string, properties: Record<st
     capture(eventName, properties);
   } catch {
     // Analytics is best-effort and must not change preparation or sharing semantics.
+  }
+}
+
+function downloadPreparedVideo(url: string, filename: string) {
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  link.style.display = 'none';
+  document.body.append(link);
+  try {
+    link.click();
+  } finally {
+    link.remove();
   }
 }
 

--- a/apps/web/design-system/tooltip.tsx
+++ b/apps/web/design-system/tooltip.tsx
@@ -84,7 +84,7 @@ const positionClassName: Record<Position, string> = {
 
 const variantClassName: Record<Variant, string> = {
   light: 'bg-white text-text max-w-[250px] rounded p-3 shadow-lg text-metadata',
-  dark: 'bg-text text-white max-w-[192px] rounded p-2 shadow-button text-center text-breadcrumb',
+  dark: 'bg-text text-white max-w-[192px] rounded p-2 text-center text-breadcrumb',
   propertyDescription:
     'w-[350px] max-w-[min(700px,calc(100vw-32px))] overflow-hidden rounded-lg border border-grey-02 bg-white p-3 text-metadata text-text shadow-[0px_8px_25px_0px_rgba(0,0,0,0.09)]',
 };


### PR DESCRIPTION
## Summary

Debate feed share controls prepare the active debate's MP4 after a five-second dwell, then open native file sharing when supported or download the video as a fallback. Scrolling away cancels preparation and releases prepared blobs so inactive debates do not consume download work.

Preparation keeps the share controls keyboard-focusable and explains when the video will be ready. Once ready, native sharing opens without the redundant “Share the debate video” tooltip, the sharing-in-progress state no longer shows “Opening sharing options,” and remaining dark tooltips render without the previous white shadow. Preparation failures retry immediately, native-share cancellation stays silent, other handoff failures remain retryable without redownloading, and the existing share-prompt modal keeps the same UI.

## Validation

- Focused debate sharing suites: 57 tests passed before the follow-ups; focused feed suite: 10 tests passed after tooltip removal
- TypeScript, ESLint, Prettier, and `git diff --check` passed after the styling follow-up
- Desktop and mobile smoke previously confirmed the share controls; the latest local browser check redirected `/debates` to the Crypto overview before the tooltip could be inspected

## Post-Deploy Monitoring & Validation

No additional operational monitoring is required. This is a client-side presentation change covered by focused UI tests and static validation; after deployment, verify that preparation guidance remains visible without a white tooltip shadow and roll back the latest follow-up commit if the shadow reappears or tooltip readability regresses.
