### PR TITLE
fix(debates): clarify active debate tab conflicts

### DIFF
--- a/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom/vitest';
 import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 
-import { StrictMode } from 'react';
+import { type ComponentPropsWithoutRef, StrictMode } from 'react';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -62,6 +62,14 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ back: mocks.back, push: mocks.push, replace: mocks.replace }),
+}));
+
+vi.mock('~/design-system/prefetch-link', () => ({
+  PrefetchLink: ({ children, href, ...props }: ComponentPropsWithoutRef<'a'>) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
 }));
 
 vi.mock('~/core/state/feature-flags', () => ({
@@ -924,6 +932,30 @@ describe('DebateRoomPageClient', () => {
     );
   });
 
+  it('keeps takeover available during a preflight ownership conflict', async () => {
+    const now = Date.parse('2026-07-02T00:00:05.000Z');
+    vi.spyOn(Date, 'now').mockReturnValue(now);
+    mocks.ownershipAcquire.mockResolvedValue(false);
+    mocks.debate = {
+      ...completedDebate(),
+      status: 'preflight',
+      current_turn_index: 0,
+      current_speaker_slot: null,
+      preflight_ends_at: new Date(now + 5_000).toISOString(),
+      completed_at: null,
+    };
+
+    render(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Continue here' }));
+
+    await waitFor(() => expect(mocks.ownershipRequestTakeover).toHaveBeenCalledOnce());
+    await waitFor(() => expect(mocks.liveKitJoinMutateAsync).toHaveBeenCalledOnce());
+    expect(mocks.ownershipRequestTakeover.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.liveKitJoinMutateAsync.mock.invocationCallOrder[0]
+    );
+  });
+
   it('disconnects an in-flight LiveKit room before handing ownership to another tab', async () => {
     const pendingConnection = deferred<void>();
     mocks.roomConnect.mockReturnValue(pendingConnection.promise);
@@ -953,12 +985,18 @@ describe('DebateRoomPageClient', () => {
 
     render(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
 
-    expect(await screen.findByText('This debate is already open in another tab.')).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: 'Continue here' })).not.toBeInTheDocument();
     expect(
-      screen.getByText('Continue the debate in the original tab or device to preserve its recording.')
+      await screen.findByRole('heading', { name: 'This debate is already open in another tab.' })
     ).toBeInTheDocument();
+    expect(screen.getByText('Close this tab and continue your debate in the original tab.')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Go to debates' })).toHaveAttribute('href', '/space/space-1/debates');
+    expect(screen.queryByRole('button', { name: 'Continue here' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Back to debates' })).not.toBeInTheDocument();
+    expect(screen.queryByText('Debate room')).not.toBeInTheDocument();
+    expect(screen.queryByText('in progress')).not.toBeInTheDocument();
+    expect(screen.queryByText('Waiting for both speakers to join.')).not.toBeInTheDocument();
     expect(mocks.liveKitJoinMutateAsync).not.toHaveBeenCalled();
+    expect(mocks.roomConnect).not.toHaveBeenCalled();
   });
 
   it('does not hand off a stale preflight after the first turn has started locally', async () => {

--- a/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.tsx
@@ -63,6 +63,7 @@ import { useDebatesEnabled, useFeatureFlag } from '~/core/state/feature-flags';
 
 import { Button } from '~/design-system/button';
 import { Check } from '~/design-system/icons/check';
+import { PrefetchLink as Link } from '~/design-system/prefetch-link';
 import { Text } from '~/design-system/text';
 
 type DebateRoomPageClientProps = {
@@ -1380,6 +1381,29 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
 
   if (shouldHideTerminalDebate) return null;
 
+  if (connectionConflictWithoutTakeover) {
+    return (
+      <div className="flex min-h-[calc(100dvh-2.75rem)] items-center justify-center px-5 py-8 text-center">
+        <div className="flex w-full max-w-[451px] flex-col items-center">
+          <Text as="h1" variant="smallTitle" color="text">
+            This debate is already open in another tab.
+          </Text>
+          <Text as="p" variant="metadata" color="grey-04" className="mt-3">
+            Close this tab and continue your debate in the original tab.
+          </Text>
+          <Link
+            href={`/space/${spaceId}/debates`}
+            className="mt-6 text-ctaPrimary transition-colors hover:text-ctaHover focus-visible:text-ctaHover"
+          >
+            <Text as="span" variant="textLinkSemibold" color="current">
+              Go to debates
+            </Text>
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="py-8">
       {debate?.status !== 'ready' && (
@@ -1488,11 +1512,6 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
               {roomError && roomState === 'idle' && (
                 <div className="mt-4 rounded-lg border border-red-01 bg-white px-5 py-4">
                   <Text color="red-01">{roomError}</Text>
-                  {connectionConflictWithoutTakeover && (
-                    <Text as="p" color="grey-04" className="mt-2">
-                      Continue the debate in the original tab or device to preserve its recording.
-                    </Text>
-                  )}
                 </div>
               )}
             </section>


### PR DESCRIPTION
## Summary

When an in-progress recorded debate is already owned by another tab, the secondary tab now shows a dedicated centered handoff state instead of the room card and error treatment. It directs the user back to the space's debates while keeping LiveKit disconnected and preserving recording ownership in the original tab.

Connecting and preflight conflicts still offer **Continue here**, so takeover remains available before recording begins.

## Validation

- `bun vitest run 'app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx'` - 108 tests passed
- ESLint passed for the component and focused test
- Prettier passed for the component and focused test
- `bunx tsc --noEmit --pretty false` passed
- `git diff --check` passed
- Live visual browser QA was not completed because the existing local development server was unreachable from the test environment
