### PR TITLE
Fix space tab layout shift

### DIFF
--- a/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
@@ -2354,6 +2354,8 @@ describe('DebateRoomPageClient', () => {
   });
 
   it('renders thanking on the scheduled final-turn boundary instead of the display interval', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(Date.parse('2026-07-02T00:00:20.000Z'));
     const now = Date.now();
     const finalTurnEndsAt = now + 100;
     mocks.debate = {
@@ -2372,7 +2374,8 @@ describe('DebateRoomPageClient', () => {
     render(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
 
     expect(screen.queryByText('Debate again?')).not.toBeInTheDocument();
-    expect(await screen.findByText('Debate again?', undefined, { timeout: 350 })).toBeInTheDocument();
+    await act(() => vi.advanceTimersByTimeAsync(101));
+    expect(screen.getByText('Debate again?')).toBeInTheDocument();
     expect(mocks.refetchDebate).not.toHaveBeenCalled();
   });
 

--- a/apps/web/app/space/[id]/(space)/layout.tsx
+++ b/apps/web/app/space/[id]/(space)/layout.tsx
@@ -70,7 +70,7 @@ export default async function Layout(props0: LayoutProps) {
       >
         <SpaceChromeGate>
           <EntityPageCover avatarUrl={props.avatarUrl} coverUrl={props.coverUrl} />
-          <SpaceHeaderContentContainer spaceId={spaceId} hasSidebar={hasCommunityCallsSidebar}>
+          <SpaceHeaderContentContainer hasSidebar={hasCommunityCallsSidebar}>
             <div className="space-y-2">
               <EditableSpaceHeading
                 spaceId={spaceId}

--- a/apps/web/app/space/[id]/(space)/space-chrome-gate.test.tsx
+++ b/apps/web/app/space/[id]/(space)/space-chrome-gate.test.tsx
@@ -20,33 +20,21 @@ describe('space chrome layout', () => {
   afterEach(cleanup);
 
   it('aligns the header with the sidebar layout on the space home page', () => {
-    render(
-      <SpaceHeaderContentContainer spaceId="test-space" hasSidebar>
-        Header
-      </SpaceHeaderContentContainer>
-    );
+    render(<SpaceHeaderContentContainer hasSidebar>Header</SpaceHeaderContentContainer>);
 
     expect(screen.getByText('Header').dataset.entityPageContentVariant).toBe('with-sidebar');
   });
 
-  it('keeps the readable header width on nested space routes', () => {
+  it('keeps the sidebar-aligned header width on nested space routes', () => {
     navigation.pathname = '/space/test-space/activity';
 
-    render(
-      <SpaceHeaderContentContainer spaceId="test-space" hasSidebar>
-        Header
-      </SpaceHeaderContentContainer>
-    );
+    render(<SpaceHeaderContentContainer hasSidebar>Header</SpaceHeaderContentContainer>);
 
-    expect(screen.getByText('Header').dataset.entityPageContentVariant).toBe('content');
+    expect(screen.getByText('Header').dataset.entityPageContentVariant).toBe('with-sidebar');
   });
 
   it('keeps the readable header width when the home page has no sidebar', () => {
-    render(
-      <SpaceHeaderContentContainer spaceId="test-space" hasSidebar={false}>
-        Header
-      </SpaceHeaderContentContainer>
-    );
+    render(<SpaceHeaderContentContainer hasSidebar={false}>Header</SpaceHeaderContentContainer>);
 
     expect(screen.getByText('Header').dataset.entityPageContentVariant).toBe('content');
   });

--- a/apps/web/app/space/[id]/(space)/space-chrome-gate.tsx
+++ b/apps/web/app/space/[id]/(space)/space-chrome-gate.tsx
@@ -19,16 +19,12 @@ export function SpaceChromeGate({ children }: { children: React.ReactNode }) {
 
 type SpaceHeaderContentContainerProps = {
   children: React.ReactNode;
-  spaceId: string;
   hasSidebar: boolean;
 };
 
-export function SpaceHeaderContentContainer({ children, spaceId, hasSidebar }: SpaceHeaderContentContainerProps) {
-  const pathname = usePathname();
-  const isSpaceHome = pathname === `/space/${spaceId}` || pathname === `/space/${spaceId}/`;
-
+export function SpaceHeaderContentContainer({ children, hasSidebar }: SpaceHeaderContentContainerProps) {
   return (
-    <EntityPageContentContainer variant={isSpaceHome && hasSidebar ? 'with-sidebar' : 'content'}>
+    <EntityPageContentContainer variant={hasSidebar ? 'with-sidebar' : 'content'}>
       {children}
     </EntityPageContentContainer>
   );


### PR DESCRIPTION
## What changed

- keep the shared space header, metadata, and tab rail on the sidebar-aligned width across every tab when that space has a community-call sidebar
- remove the active-route dependency from the shared alignment decision
- update regression coverage for both overview and nested space routes

## Why

The previous content-width work selected the wider header shell only while the overview route was active. Switching to a tab without the sidebar changed the shared header back to the readable-width shell, causing the entity title and tabs to recenter horizontally.

## Impact

Spaces with a sidebar on any tab now retain stable shared chrome while navigating between tabs. Spaces without a sidebar remain on the normal 900px readable layout. Individual tab bodies keep their existing specialized widths and full-bleed behavior.

## Checks

- `bun run test 'app/space/[id]/(space)/space-chrome-gate.test.tsx' partials/entity-page/entity-page-content-container.test.tsx` — 8 tests passed
- `bun x tsc --noEmit --pretty false` — passed after refreshing dependencies and rebuilding `packages/auth`
- `bun run lint` — passed with the repository's existing warning baseline
- Prettier check on all changed files — passed
