### PR TITLE
Hide query data-block filters in browse mode

### DIFF
--- a/apps/web/partials/blocks/table/data-block-header-action-visibility.test.ts
+++ b/apps/web/partials/blocks/table/data-block-header-action-visibility.test.ts
@@ -4,33 +4,44 @@ import type { DataBlockView } from '~/core/blocks/data/use-view';
 
 import {
   filterPanelOpenStateForActions,
-  shouldShowFilterAndFullscreenActions,
+  shouldShowFilterAction,
+  shouldShowFullscreenAction,
 } from './data-block-header-action-visibility';
 
-describe('shouldShowFilterAndFullscreenActions', () => {
-  it('hides both actions for Explore view in browse mode', () => {
-    expect(shouldShowFilterAndFullscreenActions('EXPLORE', 'SPACES', false)).toBe(false);
+describe('shouldShowFilterAction', () => {
+  it('hides the filter action in browse mode', () => {
+    expect(shouldShowFilterAction(false)).toBe(false);
   });
 
-  it('keeps both actions for Explore view in edit mode', () => {
-    expect(shouldShowFilterAndFullscreenActions('EXPLORE', 'SPACES', true)).toBe(true);
+  it('keeps the filter action in edit mode', () => {
+    expect(shouldShowFilterAction(true)).toBe(true);
+  });
+});
+
+describe('shouldShowFullscreenAction', () => {
+  it('hides the fullscreen action for Explore view in browse mode', () => {
+    expect(shouldShowFullscreenAction('EXPLORE', 'SPACES', false)).toBe(false);
+  });
+
+  it('keeps the fullscreen action for Explore view in edit mode', () => {
+    expect(shouldShowFullscreenAction('EXPLORE', 'SPACES', true)).toBe(true);
   });
 
   it.each<DataBlockView>(['TABLE', 'LIST', 'GALLERY', 'BULLETED_LIST', 'PILL', 'EXPLORE'])(
-    'hides both actions for a Collection source using %s view in browse mode',
+    'hides the fullscreen action for a Collection source using %s view in browse mode',
     view => {
-      expect(shouldShowFilterAndFullscreenActions(view, 'COLLECTION', false)).toBe(false);
+      expect(shouldShowFullscreenAction(view, 'COLLECTION', false)).toBe(false);
     }
   );
 
-  it('keeps both actions for a Collection source in edit mode', () => {
-    expect(shouldShowFilterAndFullscreenActions('TABLE', 'COLLECTION', true)).toBe(true);
+  it('keeps the fullscreen action for a Collection source in edit mode', () => {
+    expect(shouldShowFullscreenAction('TABLE', 'COLLECTION', true)).toBe(true);
   });
 
   it.each<DataBlockView>(['TABLE', 'LIST', 'GALLERY', 'BULLETED_LIST', 'PILL'])(
-    'keeps both actions for a query source using %s view in browse mode',
+    'keeps the fullscreen action for a query source using %s view in browse mode',
     view => {
-      expect(shouldShowFilterAndFullscreenActions(view, 'SPACES', false)).toBe(true);
+      expect(shouldShowFullscreenAction(view, 'SPACES', false)).toBe(true);
     }
   );
 });

--- a/apps/web/partials/blocks/table/data-block-header-action-visibility.ts
+++ b/apps/web/partials/blocks/table/data-block-header-action-visibility.ts
@@ -1,8 +1,13 @@
 import type { Source } from '~/core/blocks/data/source';
 import type { DataBlockView } from '~/core/blocks/data/use-view';
 
-/** Explore and collection browse surfaces do not expose filter/fullscreen header actions. */
-export function shouldShowFilterAndFullscreenActions(
+/** Filters are an editing control and stay hidden on every browse surface. */
+export function shouldShowFilterAction(isEditing: boolean): boolean {
+  return isEditing;
+}
+
+/** Explore and collection browse surfaces do not expose the fullscreen header action. */
+export function shouldShowFullscreenAction(
   view: DataBlockView,
   sourceType: Source['type'],
   isEditing: boolean

--- a/apps/web/partials/blocks/table/table-block.tsx
+++ b/apps/web/partials/blocks/table/table-block.tsx
@@ -59,7 +59,8 @@ import { shouldShowCreateEntityAction } from './data-block-create-entity-visibil
 import { DataBlockExpandControl } from './data-block-expand-control';
 import {
   filterPanelOpenStateForActions,
-  shouldShowFilterAndFullscreenActions,
+  shouldShowFilterAction,
+  shouldShowFullscreenAction,
 } from './data-block-header-action-visibility';
 import { DataBlockScopeDropdown } from './data-block-scope-dropdown';
 import { DataBlockSortMenu } from './data-block-sort-menu';
@@ -975,11 +976,12 @@ const ConfiguredTableBlock = ({
 
   const showToolbarSort = isEditing || sortState !== null;
   const showToolbarDividerAfterScope = showToolbarSort || isEditing;
-  const showFilterAndFullscreenActions = shouldShowFilterAndFullscreenActions(view, source.type, isEditing);
+  const showFilterAction = shouldShowFilterAction(isEditing);
+  const showFullscreenAction = shouldShowFullscreenAction(view, source.type, isEditing);
 
   React.useEffect(() => {
-    setIsFilterOpen(current => filterPanelOpenStateForActions(current, showFilterAndFullscreenActions));
-  }, [showFilterAndFullscreenActions]);
+    setIsFilterOpen(current => filterPanelOpenStateForActions(current, showFilterAction));
+  }, [showFilterAction]);
 
   const toggleFilterHandler = () => setIsFilterOpen(current => !current);
 
@@ -1001,20 +1003,20 @@ const ConfiguredTableBlock = ({
               disabled={!canEdit}
             />
           )}
-          {showFilterAndFullscreenActions && (
-            <>
-              <IconButton
-                onClick={toggleFilterHandler}
-                icon={activeFilters.length > 0 ? <FilterTableWithFilters /> : <FilterTable />}
-                color="grey-04"
-              />
-              <DataBlockExpandControl
-                spaceId={spaceId}
-                blockEntityId={entityId}
-                isEditing={isEditing}
-                fullscreenHref={`/space/${spaceId}/${entityId}/power-tools?relationId=${relationId}`}
-              />
-            </>
+          {showFilterAction && (
+            <IconButton
+              onClick={toggleFilterHandler}
+              icon={activeFilters.length > 0 ? <FilterTableWithFilters /> : <FilterTable />}
+              color="grey-04"
+            />
+          )}
+          {showFullscreenAction && (
+            <DataBlockExpandControl
+              spaceId={spaceId}
+              blockEntityId={entityId}
+              isEditing={isEditing}
+              fullscreenHref={`/space/${spaceId}/${entityId}/power-tools?relationId=${relationId}`}
+            />
           )}
           <DataBlockViewMenu activeView={view} isLoading={isLoading} />
           <TableBlockContextMenu sourceType={source.type} />


### PR DESCRIPTION
## Summary

- hide the filter icon for query data blocks in browse mode
- keep the filter icon available in edit mode
- preserve the existing query “View all”/fullscreen action in non-Explore views
- preserve existing Explore and collection fullscreen visibility rules

## Root cause

Filter and fullscreen visibility shared one combined condition. Query blocks needed the filter hidden in browse mode while retaining their existing fullscreen action, so the controls now use independent visibility policies.

## Validation

- `bun run test partials/blocks/table/data-block-header-action-visibility.test.ts` (18 tests passed)
- `bun x tsc --noEmit --pretty false`
- targeted ESLint on the three changed files (no errors; three pre-existing warnings in `table-block.tsx`)
