### PR TITLE
feat(debates): report foreground tab attention

### DIFF
--- a/apps/web/core/debates/debate-attention.test.ts
+++ b/apps/web/core/debates/debate-attention.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createDebateAttentionStore } from './debate-attention';
+
+describe('debate attention', () => {
+  let focused: boolean;
+  let visibilityState: DocumentVisibilityState;
+  let store: ReturnType<typeof createDebateAttentionStore>;
+  let unsubscribe: (() => void) | undefined;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    focused = true;
+    visibilityState = 'visible';
+    vi.spyOn(document, 'hasFocus').mockImplementation(() => focused);
+    vi.spyOn(document, 'visibilityState', 'get').mockImplementation(() => visibilityState);
+  });
+
+  afterEach(() => {
+    unsubscribe?.();
+    unsubscribe = undefined;
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  function subscribe() {
+    store = createDebateAttentionStore(window, document);
+    unsubscribe = store.subscribe(vi.fn());
+  }
+
+  it.each([
+    ['visible and focused', 'visible', true, true],
+    ['hidden', 'hidden', true, false],
+    ['visible but unfocused', 'visible', false, false],
+  ] as const)('initializes %s as %s', (_label, visibility, hasFocus, expected) => {
+    visibilityState = visibility;
+    focused = hasFocus;
+    subscribe();
+
+    expect(store.getSnapshot()).toBe(expected);
+  });
+
+  it('deactivates immediately when hidden or pagehide fires', () => {
+    subscribe();
+    expect(store.getSnapshot()).toBe(true);
+
+    visibilityState = 'hidden';
+    document.dispatchEvent(new Event('visibilitychange'));
+    expect(store.getSnapshot()).toBe(false);
+
+    visibilityState = 'visible';
+    focused = true;
+    window.dispatchEvent(new Event('focus'));
+    expect(store.getSnapshot()).toBe(true);
+
+    window.dispatchEvent(new Event('pagehide'));
+    expect(store.getSnapshot()).toBe(false);
+  });
+
+  it('keeps visible blur active for three seconds, then deactivates', () => {
+    subscribe();
+    focused = false;
+    window.dispatchEvent(new Event('blur'));
+
+    vi.advanceTimersByTime(2_999);
+    expect(store.getSnapshot()).toBe(true);
+    vi.advanceTimersByTime(1);
+    expect(store.getSnapshot()).toBe(false);
+  });
+
+  it('cancels blur deactivation when focus returns during the grace period', () => {
+    subscribe();
+    focused = false;
+    window.dispatchEvent(new Event('blur'));
+    vi.advanceTimersByTime(2_000);
+
+    focused = true;
+    window.dispatchEvent(new Event('focus'));
+    vi.advanceTimersByTime(2_000);
+
+    expect(store.getSnapshot()).toBe(true);
+  });
+
+  it('reactivates immediately when visible focus returns after deactivation', () => {
+    subscribe();
+    focused = false;
+    window.dispatchEvent(new Event('blur'));
+    vi.advanceTimersByTime(3_000);
+    expect(store.getSnapshot()).toBe(false);
+
+    focused = true;
+    window.dispatchEvent(new Event('focus'));
+    expect(store.getSnapshot()).toBe(true);
+  });
+
+  it('reconciles focus when a page returns from the back-forward cache', () => {
+    subscribe();
+    window.dispatchEvent(new Event('pagehide'));
+    expect(store.getSnapshot()).toBe(false);
+
+    focused = true;
+    visibilityState = 'visible';
+    window.dispatchEvent(new Event('pageshow'));
+
+    expect(store.getSnapshot()).toBe(true);
+  });
+
+  it('reconciles attention when listeners return after a gap', () => {
+    subscribe();
+    expect(store.getSnapshot()).toBe(true);
+    unsubscribe?.();
+    unsubscribe = undefined;
+
+    focused = false;
+    unsubscribe = store.subscribe(vi.fn());
+
+    expect(store.getSnapshot()).toBe(false);
+  });
+});

--- a/apps/web/core/debates/debate-attention.ts
+++ b/apps/web/core/debates/debate-attention.ts
@@ -1,0 +1,117 @@
+'use client';
+
+import * as React from 'react';
+
+const DEFAULT_BLUR_GRACE_MS = 3_000;
+
+type DebateAttentionStore = {
+  getSnapshot(): boolean;
+  subscribe(listener: () => void): () => void;
+};
+
+export function createDebateAttentionStore(
+  windowRef: Window,
+  documentRef: Document,
+  blurGraceMs = DEFAULT_BLUR_GRACE_MS
+): DebateAttentionStore {
+  let active = documentRef.visibilityState === 'visible' && documentRef.hasFocus();
+  let blurTimer: ReturnType<typeof setTimeout> | null = null;
+  const listeners = new Set<() => void>();
+
+  const setActive = (nextActive: boolean) => {
+    if (active === nextActive) return;
+    active = nextActive;
+    for (const listener of listeners) listener();
+  };
+
+  const clearBlurTimer = () => {
+    if (!blurTimer) return;
+    clearTimeout(blurTimer);
+    blurTimer = null;
+  };
+
+  const deactivate = () => {
+    clearBlurTimer();
+    setActive(false);
+  };
+
+  const handleVisibilityChange = () => {
+    if (documentRef.visibilityState !== 'visible') {
+      deactivate();
+      return;
+    }
+    if (documentRef.hasFocus()) {
+      clearBlurTimer();
+      setActive(true);
+    }
+  };
+
+  const handleFocus = () => {
+    clearBlurTimer();
+    if (documentRef.visibilityState === 'visible' && documentRef.hasFocus()) setActive(true);
+  };
+
+  const handleBlur = () => {
+    if (documentRef.visibilityState !== 'visible') {
+      deactivate();
+      return;
+    }
+    clearBlurTimer();
+    blurTimer = setTimeout(() => {
+      blurTimer = null;
+      if (documentRef.visibilityState === 'visible' && !documentRef.hasFocus()) setActive(false);
+    }, blurGraceMs);
+  };
+
+  const attach = () => {
+    documentRef.addEventListener('visibilitychange', handleVisibilityChange);
+    windowRef.addEventListener('focus', handleFocus);
+    windowRef.addEventListener('blur', handleBlur);
+    windowRef.addEventListener('pagehide', deactivate);
+    windowRef.addEventListener('pageshow', handleFocus);
+  };
+
+  const detach = () => {
+    clearBlurTimer();
+    documentRef.removeEventListener('visibilitychange', handleVisibilityChange);
+    windowRef.removeEventListener('focus', handleFocus);
+    windowRef.removeEventListener('blur', handleBlur);
+    windowRef.removeEventListener('pagehide', deactivate);
+    windowRef.removeEventListener('pageshow', handleFocus);
+  };
+
+  return {
+    getSnapshot: () => active,
+    subscribe(listener) {
+      listeners.add(listener);
+      if (listeners.size === 1) {
+        attach();
+        clearBlurTimer();
+        setActive(documentRef.visibilityState === 'visible' && documentRef.hasFocus());
+      }
+      return () => {
+        listeners.delete(listener);
+        if (listeners.size === 0) detach();
+      };
+    },
+  };
+}
+
+let browserAttentionStore: DebateAttentionStore | null = null;
+const serverAttentionStore: DebateAttentionStore = {
+  getSnapshot: () => false,
+  subscribe: () => () => undefined,
+};
+
+function getBrowserAttentionStore() {
+  if (typeof window === 'undefined' || typeof document === 'undefined') return serverAttentionStore;
+  if (!browserAttentionStore) browserAttentionStore = createDebateAttentionStore(window, document);
+  return browserAttentionStore;
+}
+
+const getServerSnapshot = () => false;
+
+export function useDebateAttention() {
+  const store = getBrowserAttentionStore();
+  return React.useSyncExternalStore(store.subscribe, store.getSnapshot, getServerSnapshot);
+}

--- a/apps/web/core/debates/debate-coordinator.tsx
+++ b/apps/web/core/debates/debate-coordinator.tsx
@@ -13,6 +13,7 @@ import { Text } from '~/design-system/text';
 
 import { type DebateMatch, type DebateSharePrompt, getCurrentGeoChatUserId } from './api';
 import { DebateChallengeDialog } from './debate-challenge-dialog';
+import { useDebateAttention } from './debate-attention';
 import { useDebateGateway } from './debate-gateway';
 import {
   clearDebateMatchTabOwnership,
@@ -41,10 +42,12 @@ export function DebateCoordinator() {
   const pathname = usePathname();
   const isDebatesEnabled = useDebatesEnabled();
   const geoChatAuth = useGeoChatAuth();
+  const debateAttention = useDebateAttention();
   const gateway = useDebateGateway(
     isDebatesEnabled && geoChatAuth.ready && geoChatAuth.authenticated,
     geoChatAuth.getPrivyIdentityToken,
-    geoChatAuth.accountKey
+    geoChatAuth.accountKey,
+    debateAttention
   );
   const activityQuery = useDebateActivity(isDebatesEnabled);
   const currentUserId = getCurrentGeoChatUserId();

--- a/apps/web/core/debates/debate-gateway.test.ts
+++ b/apps/web/core/debates/debate-gateway.test.ts
@@ -284,6 +284,57 @@ describe('DebateGatewayClient', () => {
     expect(sockets).toHaveLength(2);
   });
 
+  it('sends the current inactive presence without disconnecting the gateway', async () => {
+    client.start(
+      vi.fn(async () => 'privy-token'),
+      'user-a',
+      false
+    );
+    await vi.runAllTicks();
+    sockets[0]!.open();
+    sockets[0]!.receive('HELLO', { heartbeat_interval_ms: 1_000 });
+
+    expect(sockets[0]!.sent).toContainEqual(
+      expect.objectContaining({ op: 'HEARTBEAT', payload: { debate_presence: false } })
+    );
+
+    sockets[0]!.receive('HEARTBEAT_ACK', {});
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(sockets[0]!.sent.at(-1)).toEqual(
+      expect.objectContaining({ op: 'HEARTBEAT', payload: { debate_presence: false } })
+    );
+    expect(sockets[0]!.readyState).toBe(FakeWebSocket.OPEN);
+  });
+
+  it('coalesces rapid attention changes behind an outstanding heartbeat and preserves the final state', async () => {
+    client.start(
+      vi.fn(async () => 'privy-token'),
+      'user-a',
+      true
+    );
+    await vi.runAllTicks();
+    sockets[0]!.open();
+    sockets[0]!.receive('HELLO', { heartbeat_interval_ms: 1_000 });
+    const initialHeartbeatCount = sockets[0]!.sent.filter(message => message.op === 'HEARTBEAT').length;
+
+    client.setDebatePresence(false);
+    client.setDebatePresence(true);
+    client.setDebatePresence(false);
+    expect(sockets[0]!.sent.filter(message => message.op === 'HEARTBEAT')).toHaveLength(initialHeartbeatCount);
+
+    sockets[0]!.receive('HEARTBEAT_ACK', {});
+    expect(sockets[0]!.sent.at(-1)).toEqual(
+      expect.objectContaining({ op: 'HEARTBEAT', payload: { debate_presence: false } })
+    );
+    expect(sockets[0]!.readyState).toBe(FakeWebSocket.OPEN);
+
+    sockets[0]!.receive('HEARTBEAT_ACK', {});
+    client.setDebatePresence(true);
+    expect(sockets[0]!.sent.at(-1)).toEqual(
+      expect.objectContaining({ op: 'HEARTBEAT', payload: { debate_presence: true } })
+    );
+  });
+
   it('resets missed acknowledgements and keeps the live socket connected', async () => {
     client.start(
       vi.fn(async () => 'privy-token'),

--- a/apps/web/core/debates/debate-gateway.ts
+++ b/apps/web/core/debates/debate-gateway.ts
@@ -95,6 +95,8 @@ export class DebateGatewayClient {
   private reconnectAttempt = 0;
   private heartbeatIntervalMs = DEFAULT_HEARTBEAT_INTERVAL_MS;
   private heartbeatsAwaitingAck = 0;
+  private debatePresence = true;
+  private presenceTransitionPending = false;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private heartbeatTimer: ReturnType<typeof setTimeout> | null = null;
   private handshakeTimer: ReturnType<typeof setTimeout> | null = null;
@@ -117,14 +119,26 @@ export class DebateGatewayClient {
     return () => this.listeners.delete(listener);
   };
 
-  start(getPrivyIdentityToken: GetPrivyIdentityToken, accountKey: string) {
+  start(getPrivyIdentityToken: GetPrivyIdentityToken, accountKey: string, debatePresence?: boolean) {
     if (this.enabled && this.accountKey !== accountKey) this.stop();
+    if (debatePresence !== undefined) this.setDebatePresence(debatePresence);
     this.getPrivyIdentityToken = getPrivyIdentityToken;
     this.accountKey = accountKey;
     if (this.enabled) return;
     this.enabled = true;
     this.setSnapshot({ status: 'connecting', paused: false });
     void this.connect();
+  }
+
+  setDebatePresence(debatePresence: boolean) {
+    if (this.debatePresence === debatePresence) return;
+    this.debatePresence = debatePresence;
+    if (!this.socket || this.socket.readyState !== OPEN) return;
+    if (this.heartbeatsAwaitingAck > 0) {
+      this.presenceTransitionPending = true;
+      return;
+    }
+    this.sendHeartbeat();
   }
 
   stop() {
@@ -223,6 +237,7 @@ export class DebateGatewayClient {
         break;
       case 'HEARTBEAT_ACK':
         this.heartbeatsAwaitingAck = 0;
+        if (this.presenceTransitionPending) this.sendHeartbeat();
         break;
       case 'RESUME':
         this.queueBroadReconcile();
@@ -246,6 +261,7 @@ export class DebateGatewayClient {
       this.heartbeatIntervalMs = Math.max(1_000, payload.heartbeat_interval_ms);
     }
     this.heartbeatsAwaitingAck = 0;
+    this.presenceTransitionPending = false;
     this.sendHeartbeat();
   }
 
@@ -442,7 +458,8 @@ export class DebateGatewayClient {
       return;
     }
     this.heartbeatsAwaitingAck += 1;
-    this.sendEnvelope('HEARTBEAT', { debate_presence: true }, this.lastSequence);
+    this.presenceTransitionPending = false;
+    this.sendEnvelope('HEARTBEAT', { debate_presence: this.debatePresence }, this.lastSequence);
     this.heartbeatTimer = setTimeout(() => this.sendHeartbeat(), this.heartbeatIntervalMs);
   }
 
@@ -517,6 +534,7 @@ export class DebateGatewayClient {
     this.clearTimer('handshake');
     this.clearTimer('token');
     this.heartbeatsAwaitingAck = 0;
+    this.presenceTransitionPending = false;
   }
 
   private clearAllTimers() {
@@ -556,8 +574,13 @@ const debateGateway = new DebateGatewayClient({
 export function useDebateGateway(
   enabled: boolean,
   getPrivyIdentityToken: GetPrivyIdentityToken,
-  accountKey: string | null
+  accountKey: string | null,
+  debatePresence: boolean
 ) {
+  React.useEffect(() => {
+    debateGateway.setDebatePresence(debatePresence);
+  }, [debatePresence]);
+
   React.useEffect(() => {
     if (!enabled || !accountKey) {
       debateGateway.stop();

--- a/apps/web/core/debates/hooks-query-network.test.tsx
+++ b/apps/web/core/debates/hooks-query-network.test.tsx
@@ -3,21 +3,27 @@ import { renderHook } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
+  useCreateDebateChallenge,
   useDebate,
   useDebateActivity,
   useDebateClaims,
   useDebateMedia,
   useDebateRematch,
   useDebateRematchClaims,
+  useDebateProfile,
   useDebateSharePrompts,
   useDebateTranscript,
   useSpaceDebates,
 } from './hooks';
+import { GeoChatRequestError } from './api';
 
 const mocks = vi.hoisted(() => ({
   authenticated: true,
-  queryClient: { setQueryData: vi.fn() },
-  useQuery: vi.fn((options: unknown) => options),
+  attention: true,
+  queryClient: { invalidateQueries: vi.fn(), setQueryData: vi.fn() },
+  queryRefetch: vi.fn(),
+  useMutation: vi.fn((options: unknown) => options),
+  useQuery: vi.fn((options: unknown) => ({ options, refetch: mocks.queryRefetch })),
   useScope: vi.fn(),
 }));
 
@@ -28,6 +34,7 @@ vi.mock('@geogenesis/auth', () => ({
 vi.mock('@tanstack/react-query', async importOriginal => ({
   ...(await importOriginal<typeof import('@tanstack/react-query')>()),
   useQuery: mocks.useQuery,
+  useMutation: mocks.useMutation,
   useQueryClient: () => mocks.queryClient,
 }));
 
@@ -40,9 +47,17 @@ vi.mock('./debate-gateway', () => ({
   useDebateGatewayScope: mocks.useScope,
 }));
 
+vi.mock('./debate-attention', () => ({
+  useDebateAttention: () => mocks.attention,
+}));
+
 beforeEach(() => {
   mocks.authenticated = true;
+  mocks.attention = true;
+  mocks.queryClient.invalidateQueries.mockClear();
   mocks.queryClient.setQueryData.mockClear();
+  mocks.queryRefetch.mockClear();
+  mocks.useMutation.mockClear();
   mocks.useQuery.mockClear();
   mocks.useScope.mockClear();
 });
@@ -66,6 +81,36 @@ describe('debate query network ownership', () => {
       expect(options).toMatchObject({ retry: false, refetchOnReconnect: false, refetchOnWindowFocus: false });
       expect(options).not.toHaveProperty('refetchInterval');
     }
+  });
+
+  it('polls profile eligibility every thirty seconds only while foregrounded and refetches on return', () => {
+    const { rerender } = renderHook(() => useDebateProfile('profile-b'));
+    expect(mocks.useQuery.mock.calls.at(-1)?.[0]).toMatchObject({ refetchInterval: 30_000 });
+    expect(mocks.queryRefetch).not.toHaveBeenCalled();
+
+    mocks.attention = false;
+    rerender();
+    expect(mocks.useQuery.mock.calls.at(-1)?.[0]).toMatchObject({ refetchInterval: false });
+
+    mocks.attention = true;
+    rerender();
+    expect(mocks.queryRefetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('invalidates the challenged profile after an availability rejection', () => {
+    const { result } = renderHook(() => useCreateDebateChallenge());
+    const mutation = result.current as unknown as {
+      onError(error: Error, request: { recipient_profile_space_id: string }): void;
+    };
+
+    mutation.onError(
+      new GeoChatRequestError('Unavailable', 'challenge_unavailable', 400),
+      { recipient_profile_space_id: 'profile-b' }
+    );
+
+    expect(mocks.queryClient.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ['debates', 'account', 'user-a', 'profile', 'profile-b'],
+    });
   });
 
   it('registers only authenticated space and debate scopes', () => {

--- a/apps/web/core/debates/hooks.ts
+++ b/apps/web/core/debates/hooks.ts
@@ -7,6 +7,8 @@ import * as React from 'react';
 
 import { getCachedIdentityToken, useIdentityTokenSync } from '~/core/auth/identity-token';
 
+import { useDebateAttention } from './debate-attention';
+
 import {
   type Debate,
   type DebateActivity,
@@ -505,13 +507,25 @@ export function useRejectDebateRematchRequest() {
 
 export function useDebateProfile(profileSpaceId: string, enabled = true) {
   const { accountKey, authenticated, getPrivyIdentityToken } = useGeoChatAuth();
+  const foreground = useDebateAttention();
+  const queryEnabled = enabled && authenticated && Boolean(profileSpaceId);
+  const wasForeground = React.useRef(foreground);
 
-  return useQuery({
+  const query = useQuery({
     ...debateQueryNetworkOptions,
     queryKey: debateQueryKeys.profile(accountKey, profileSpaceId),
     queryFn: ({ signal }) => getDebateProfile(profileSpaceId, getPrivyIdentityToken, accountKey, signal),
-    enabled: enabled && authenticated && Boolean(profileSpaceId),
+    enabled: queryEnabled,
+    refetchInterval: foreground ? 30_000 : false,
   });
+
+  React.useEffect(() => {
+    const returnedToForeground = foreground && !wasForeground.current;
+    wasForeground.current = foreground;
+    if (returnedToForeground && queryEnabled) void query.refetch();
+  }, [foreground, query.refetch, queryEnabled]);
+
+  return query;
 }
 
 export function useCreateDebateChallenge() {
@@ -526,6 +540,12 @@ export function useCreateDebateChallenge() {
         current ? { ...current, challenge } : current
       );
       void queryClient.invalidateQueries({ queryKey: debateQueryKeys.activity(accountKey) });
+    },
+    onError: (error, request) => {
+      if (!(error instanceof GeoChatRequestError) || error.code !== 'challenge_unavailable') return;
+      void queryClient.invalidateQueries({
+        queryKey: debateQueryKeys.profile(accountKey, request.recipient_profile_space_id),
+      });
     },
   });
 }


### PR DESCRIPTION
## Summary

“Available to debate” remains a persistent preference, while effective online presence now follows whether at least one Geo tab is actively visible and focused.

- Hidden tabs and page exits deactivate immediately; visible window blur uses a three-second grace period and focus restores presence immediately.
- The debate WebSocket stays connected while inactive so existing prompts and state updates continue, and heartbeat transitions are coalesced without triggering false missed-ACK reconnects.
- Debate profile eligibility refreshes every 30 seconds only in the foreground, refetches on focus return, and invalidates stale eligibility after an availability rejection.
- Existing matches and challenges retain their normal deadlines when a tab becomes inactive.

## Rollout

Depends on https://github.com/geobrowser/geo-chat/pull/33. Deploy the backend migration and API before this frontend change.

## Validation

- `bun run test -- core/debates/debate-attention.test.ts core/debates/debate-gateway.test.ts core/debates/hooks-query-network.test.tsx` (38 passed)
- `bun run test` (191 files, 1,974 tests passed)
- `bun run lint` (0 errors; 93 pre-existing warnings)
