### PR TITLE
feat(debates): update upload and publishing banner

### DIFF
--- a/apps/web/core/debates/recording-upload-coordinator.integration.test.tsx
+++ b/apps/web/core/debates/recording-upload-coordinator.integration.test.tsx
@@ -271,9 +271,11 @@ describe('DebateRecordingUploadCoordinator', () => {
     );
     // debate-1's bytes are out and debate-2 hasn't started, so half the queued bytes have shipped.
     expect(screen.getByText('Uploading & publishing 2 debates')).toBeInTheDocument();
-    expect(screen.getByRole('progressbar', { name: 'Uploading and publishing 2 debates' })).toHaveAttribute(
-      'aria-valuenow',
-      '50'
+    await waitFor(() =>
+      expect(screen.getByRole('progressbar', { name: 'Uploading and publishing 2 debates' })).toHaveAttribute(
+        'aria-valuenow',
+        '50'
+      )
     );
     expect(mocks.createUpload).not.toHaveBeenCalledWith('debate-2', expect.anything(), expect.anything(), 'user-a');
 
@@ -446,9 +448,11 @@ describe('DebateRecordingUploadCoordinator', () => {
     render(<DebateRecordingUploadCoordinator />);
 
     expect(await screen.findByText('Uploading & publishing 2 debates')).toBeInTheDocument();
-    expect(screen.getByRole('progressbar', { name: 'Uploading and publishing 2 debates' })).toHaveAttribute(
-      'aria-valuenow',
-      '50'
+    await waitFor(() =>
+      expect(screen.getByRole('progressbar', { name: 'Uploading and publishing 2 debates' })).toHaveAttribute(
+        'aria-valuenow',
+        '50'
+      )
     );
     fireEvent.click(await screen.findByRole('button', { name: 'Cancel' }));
     fireEvent.click(await screen.findByRole('button', { name: 'Delete debate forever' }));
@@ -651,9 +655,11 @@ describe('DebateRecordingUploadCoordinator', () => {
     mocks.reportProgress!(3);
 
     expect(await screen.findByText('Uploading & publishing 1 debate')).toBeInTheDocument();
-    expect(screen.getByRole('progressbar', { name: 'Uploading and publishing 1 debate' })).toHaveAttribute(
-      'aria-valuenow',
-      '33'
+    await waitFor(() =>
+      expect(screen.getByRole('progressbar', { name: 'Uploading and publishing 1 debate' })).toHaveAttribute(
+        'aria-valuenow',
+        '33'
+      )
     );
 
     held.resolve();

--- a/apps/web/core/debates/recording-upload-coordinator.integration.test.tsx
+++ b/apps/web/core/debates/recording-upload-coordinator.integration.test.tsx
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom/vitest';
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -188,7 +188,7 @@ afterEach(() => {
 });
 
 describe('DebateRecordingUploadCoordinator', () => {
-  it('shows the publish choice while the recording is still being prepared and ignores stale activity for that debate', async () => {
+  it('shows progress and cancellation while the recording is still being prepared and ignores stale activity', async () => {
     mocks.queue = [];
     mocks.thankingHasPendingLocalRecording = true;
     mocks.activityDebate = { id: 'debate-1', status: 'in_progress' };
@@ -196,7 +196,8 @@ describe('DebateRecordingUploadCoordinator', () => {
     render(<DebateRecordingUploadCoordinator />);
 
     expect(await screen.findByText('Preparing debate upload')).toBeInTheDocument();
-    expect(screen.getByRole('checkbox', { name: 'Publish debate' })).toHaveAttribute('aria-checked', 'true');
+    expect(screen.getByRole('progressbar', { name: 'Preparing debate upload' })).not.toHaveAttribute('aria-valuenow');
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
   });
 
   it('still hides the pending thank-you banner during an unrelated live debate', async () => {
@@ -269,7 +270,11 @@ describe('DebateRecordingUploadCoordinator', () => {
       expect(mocks.completeUpload).toHaveBeenCalledWith('debate-1', expect.anything(), expect.anything(), 'user-a')
     );
     // debate-1's bytes are out and debate-2 hasn't started, so half the queued bytes have shipped.
-    expect(screen.getByText('Uploading 2 debates · 50%')).toBeInTheDocument();
+    expect(screen.getByText('Uploading & publishing 2 debates')).toBeInTheDocument();
+    expect(screen.getByRole('progressbar', { name: 'Uploading and publishing 2 debates' })).toHaveAttribute(
+      'aria-valuenow',
+      '50'
+    );
     expect(mocks.createUpload).not.toHaveBeenCalledWith('debate-2', expect.anything(), expect.anything(), 'user-a');
 
     firstCompletion.resolve();
@@ -397,14 +402,15 @@ describe('DebateRecordingUploadCoordinator', () => {
     expect(mocks.deleteUpload).not.toHaveBeenCalled();
   });
 
-  it('cancels the upload and drops the local blob when publish is unchecked', async () => {
+  it('cancels the upload and drops the local blob from the banner action', async () => {
     // Keep the upload in flight so the banner stays on screen while we interact with it.
     mocks.completeUpload.mockImplementation(() => new Promise<void>(() => undefined));
     mocks.queue = [queuedRecording('debate-1')];
 
     render(<DebateRecordingUploadCoordinator />);
 
-    fireEvent.click(await screen.findByRole('checkbox', { name: 'Publish debate' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Cancel' }));
+    expect(within(screen.getByRole('status')).queryByRole('button', { name: 'Cancel' })).not.toBeInTheDocument();
     fireEvent.click(await screen.findByRole('button', { name: 'Delete debate forever' }));
 
     await waitFor(() => expect(mocks.cancelRecording).toHaveBeenCalledWith('debate-1', expect.anything(), 'user-a'));
@@ -417,7 +423,7 @@ describe('DebateRecordingUploadCoordinator', () => {
 
     render(<DebateRecordingUploadCoordinator />);
 
-    fireEvent.click(await screen.findByRole('checkbox', { name: 'Publish debate' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Cancel' }));
     fireEvent.click(await screen.findByRole('button', { name: 'Delete debate forever' }));
 
     await waitFor(() => expect(mocks.cancelRecording).toHaveBeenCalledOnce());
@@ -439,8 +445,12 @@ describe('DebateRecordingUploadCoordinator', () => {
 
     render(<DebateRecordingUploadCoordinator />);
 
-    expect(await screen.findByText('Uploading 2 debates · 50%')).toBeInTheDocument();
-    fireEvent.click(await screen.findByRole('checkbox', { name: 'Publish debate' }));
+    expect(await screen.findByText('Uploading & publishing 2 debates')).toBeInTheDocument();
+    expect(screen.getByRole('progressbar', { name: 'Uploading and publishing 2 debates' })).toHaveAttribute(
+      'aria-valuenow',
+      '50'
+    );
+    fireEvent.click(await screen.findByRole('button', { name: 'Cancel' }));
     fireEvent.click(await screen.findByRole('button', { name: 'Delete debate forever' }));
 
     await waitFor(() => expect(mocks.deleteUpload).toHaveBeenCalledWith('user-a:debate-2'));
@@ -448,8 +458,8 @@ describe('DebateRecordingUploadCoordinator', () => {
     expect(mocks.cancelRecording).toHaveBeenCalledWith('debate-2', expect.anything(), 'user-a');
     expect(mocks.deleteUpload).not.toHaveBeenCalledWith('user-a:debate-1');
     // The untouched recording keeps uploading, now without an opt-out.
-    expect(await screen.findByText('Uploading 1 debate...')).toBeInTheDocument();
-    expect(screen.queryByRole('checkbox', { name: 'Publish debate' })).not.toBeInTheDocument();
+    expect(await screen.findByText('Uploading & publishing 1 debate')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Cancel' })).not.toBeInTheDocument();
   });
 
   it('matches the thank-you debate even though the queue stores ids dashless', async () => {
@@ -460,7 +470,7 @@ describe('DebateRecordingUploadCoordinator', () => {
 
     render(<DebateRecordingUploadCoordinator />);
 
-    fireEvent.click(await screen.findByRole('checkbox', { name: 'Publish debate' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Cancel' }));
     fireEvent.click(await screen.findByRole('button', { name: 'Delete debate forever' }));
 
     // The cancel request uses the dashless id the queue and backend already agree on.
@@ -473,26 +483,26 @@ describe('DebateRecordingUploadCoordinator', () => {
     );
   });
 
-  it('offers no publish opt-out once the thank-you period is over', async () => {
+  it('offers no cancellation action once the thank-you period is over', async () => {
     mocks.completeUpload.mockImplementation(() => new Promise<void>(() => undefined));
     mocks.thankingDebateId = null;
     mocks.queue = [queuedRecording('debate-1')];
 
     render(<DebateRecordingUploadCoordinator />);
 
-    expect(await screen.findByText('Uploading 1 debate...')).toBeInTheDocument();
-    expect(screen.queryByRole('checkbox', { name: 'Publish debate' })).not.toBeInTheDocument();
+    expect(await screen.findByText('Uploading & publishing 1 debate')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Cancel' })).not.toBeInTheDocument();
   });
 
-  it('keeps the banner and publish opt-out through the thank-you screen after the upload finishes', async () => {
-    // The fast-connection race: the upload finishes before the user can reach the checkbox.
+  it('keeps the banner and cancellation action through the thank-you screen after the upload finishes', async () => {
+    // The fast-connection race: the upload finishes before the user can reach the Cancel action.
     mocks.queue = [queuedRecording('debate-1')];
 
     render(<DebateRecordingUploadCoordinator />);
 
     await waitFor(() => expect(mocks.deleteUpload).toHaveBeenCalledWith('user-a:debate-1'));
     expect(await screen.findByText('Debate uploaded')).toBeInTheDocument();
-    expect(screen.getByRole('checkbox', { name: 'Publish debate' })).toHaveAttribute('aria-checked', 'true');
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
   });
 
   it('restores the uploaded banner from the debate snapshot after a remount', async () => {
@@ -502,7 +512,7 @@ describe('DebateRecordingUploadCoordinator', () => {
     render(<DebateRecordingUploadCoordinator />);
 
     expect(await screen.findByText('Debate uploaded')).toBeInTheDocument();
-    expect(screen.getByRole('checkbox', { name: 'Publish debate' })).toHaveAttribute('aria-checked', 'true');
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
     expect(mocks.createUpload).not.toHaveBeenCalled();
   });
 
@@ -514,7 +524,7 @@ describe('DebateRecordingUploadCoordinator', () => {
     render(<DebateRecordingUploadCoordinator />);
 
     expect(await screen.findByText('Debate uploaded')).toBeInTheDocument();
-    expect(screen.getByRole('checkbox', { name: 'Publish debate' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
     await waitFor(() =>
       expect(mocks.createUpload).toHaveBeenCalledWith(
         'debate-2',
@@ -531,7 +541,7 @@ describe('DebateRecordingUploadCoordinator', () => {
 
     render(<DebateRecordingUploadCoordinator />);
 
-    fireEvent.click(await screen.findByRole('checkbox', { name: 'Publish debate' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Cancel' }));
     fireEvent.click(await screen.findByRole('button', { name: 'Delete debate forever' }));
 
     await waitFor(() => expect(mocks.cancelRecording).toHaveBeenCalledWith('debate-1', expect.anything(), 'user-a'));
@@ -548,7 +558,7 @@ describe('DebateRecordingUploadCoordinator', () => {
     await waitFor(() => expect(mocks.deleteUpload).toHaveBeenCalledWith('user-a:debate-1'));
     expect(mocks.completeUpload).not.toHaveBeenCalled();
     expect(screen.queryByRole('status')).not.toBeInTheDocument();
-    expect(screen.queryByRole('checkbox', { name: 'Publish debate' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Cancel' })).not.toBeInTheDocument();
   });
 
   it('keeps the confirmation and local upload when cancellation fails', async () => {
@@ -558,7 +568,7 @@ describe('DebateRecordingUploadCoordinator', () => {
 
     render(<DebateRecordingUploadCoordinator />);
 
-    fireEvent.click(await screen.findByRole('checkbox', { name: 'Publish debate' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Cancel' }));
     fireEvent.click(await screen.findByRole('button', { name: 'Delete debate forever' }));
 
     expect(await screen.findByText('Cancellation failed')).toBeInTheDocument();
@@ -575,7 +585,7 @@ describe('DebateRecordingUploadCoordinator', () => {
 
     render(<DebateRecordingUploadCoordinator />);
 
-    fireEvent.click(await screen.findByRole('checkbox', { name: 'Publish debate' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Cancel' }));
     fireEvent.click(await screen.findByRole('button', { name: 'Delete debate forever' }));
 
     expect(
@@ -584,19 +594,19 @@ describe('DebateRecordingUploadCoordinator', () => {
       )
     ).toBeInTheDocument();
     expect(mocks.cancelRecording).toHaveBeenCalledOnce();
-    expect(screen.queryByRole('checkbox', { name: 'Publish debate' })).not.toBeInTheDocument();
+    expect(screen.getAllByRole('button', { name: 'Cancel' })).toHaveLength(1);
 
     fireEvent.click(screen.getByRole('button', { name: 'Close' }));
-    await waitFor(() => expect(screen.queryByRole('checkbox', { name: 'Publish debate' })).not.toBeInTheDocument());
+    await waitFor(() => expect(screen.queryByRole('button', { name: 'Cancel' })).not.toBeInTheDocument());
   });
 
-  it('still cancels an already uploaded recording when publish is unchecked during thanking', async () => {
+  it('still cancels an already uploaded recording from the banner during thanking', async () => {
     mocks.queue = [queuedRecording('debate-1')];
 
     render(<DebateRecordingUploadCoordinator />);
 
     expect(await screen.findByText('Debate uploaded')).toBeInTheDocument();
-    fireEvent.click(screen.getByRole('checkbox', { name: 'Publish debate' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
     fireEvent.click(await screen.findByRole('button', { name: 'Delete debate forever' }));
 
     await waitFor(() => expect(mocks.cancelRecording).toHaveBeenCalledWith('debate-1', expect.anything(), 'user-a'));
@@ -640,7 +650,11 @@ describe('DebateRecordingUploadCoordinator', () => {
     // byteSize is 9, so 3 bytes out is a third of the recording.
     mocks.reportProgress!(3);
 
-    expect(await screen.findByText('Uploading 1 debate · 33%')).toBeInTheDocument();
+    expect(await screen.findByText('Uploading & publishing 1 debate')).toBeInTheDocument();
+    expect(screen.getByRole('progressbar', { name: 'Uploading and publishing 1 debate' })).toHaveAttribute(
+      'aria-valuenow',
+      '33'
+    );
 
     held.resolve();
     await waitFor(() => expect(mocks.completeUpload).toHaveBeenCalledOnce());

--- a/apps/web/core/debates/recording-upload-coordinator.test.tsx
+++ b/apps/web/core/debates/recording-upload-coordinator.test.tsx
@@ -146,6 +146,11 @@ describe('DebateRecordingUploadBanner', () => {
     );
 
     expect(screen.getByText('Uploading & publishing 1 debate')).toBeInTheDocument();
+    const banner = screen.getByRole('status');
+    const content = screen.getByText('Uploading & publishing 1 debate').parentElement;
+    expect(banner).toHaveClass('h-7', 'items-center', 'justify-center');
+    expect(content).toHaveClass('w-auto', 'items-center', 'gap-2', 'md:w-full');
+    expect(screen.getByText('Uploading & publishing 1 debate')).toHaveClass('flex-initial', 'md:flex-1');
     const progress = screen.getByRole('progressbar', { name: 'Uploading and publishing 1 debate' });
     expect(progress).toHaveAttribute('aria-valuemin', '0');
     expect(progress).toHaveAttribute('aria-valuemax', '100');

--- a/apps/web/core/debates/recording-upload-coordinator.test.tsx
+++ b/apps/web/core/debates/recording-upload-coordinator.test.tsx
@@ -132,51 +132,61 @@ describe('debate recording uploader', () => {
 });
 
 describe('DebateRecordingUploadBanner', () => {
-  it('shows the upload count with the publish checkbox checked', () => {
+  it('shows the upload and publishing state with determinate progress and a cancel action', () => {
+    const cancel = vi.fn();
     render(
       <DebateRecordingUploadBanner
         count={1}
+        percent={57}
         waitingReason={null}
         errorMessage={null}
-        canPublishOptOut
-        publishChecked
-        onUncheckPublish={() => undefined}
+        canCancel
+        onCancel={cancel}
       />
     );
 
-    expect(screen.getByText('Uploading 1 debate')).toBeInTheDocument();
-    expect(screen.getByRole('checkbox', { name: 'Publish debate' })).toHaveAttribute('aria-checked', 'true');
+    expect(screen.getByText('Uploading & publishing 1 debate')).toBeInTheDocument();
+    const progress = screen.getByRole('progressbar', { name: 'Uploading and publishing 1 debate' });
+    expect(progress).toHaveAttribute('aria-valuemin', '0');
+    expect(progress).toHaveAttribute('aria-valuemax', '100');
+    expect(progress).toHaveAttribute('aria-valuenow', '57');
+    expect(progress.firstElementChild).toHaveStyle({ width: '57%' });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(cancel).toHaveBeenCalledOnce();
+    expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
   });
 
-  it('iterates the count while several debates upload at once', () => {
+  it('pluralizes the count and shows indeterminate progress while the percentage is unavailable', () => {
     render(
       <DebateRecordingUploadBanner
         count={2}
         waitingReason={null}
         errorMessage={null}
-        canPublishOptOut
-        publishChecked
-        onUncheckPublish={() => undefined}
+        canCancel
+        onCancel={() => undefined}
       />
     );
 
-    expect(screen.getByText('Uploading 2 debates')).toBeInTheDocument();
+    expect(screen.getByText('Uploading & publishing 2 debates')).toBeInTheDocument();
+    expect(screen.getByRole('progressbar', { name: 'Uploading and publishing 2 debates' })).not.toHaveAttribute(
+      'aria-valuenow'
+    );
   });
 
-  it('drops the publish checkbox once the thank-you period is over', () => {
+  it('drops the cancel action once the thank-you period is over', () => {
     render(
       <DebateRecordingUploadBanner
         count={1}
         waitingReason={null}
         errorMessage={null}
-        canPublishOptOut={false}
-        publishChecked
-        onUncheckPublish={() => undefined}
+        canCancel={false}
+        onCancel={() => undefined}
       />
     );
 
-    expect(screen.getByText('Uploading 1 debate...')).toBeInTheDocument();
-    expect(screen.queryByRole('checkbox', { name: 'Publish debate' })).not.toBeInTheDocument();
+    expect(screen.getByText('Uploading & publishing 1 debate')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Cancel' })).not.toBeInTheDocument();
   });
 
   it('shows generic plural waiting copy when no reason is available', () => {
@@ -185,13 +195,14 @@ describe('DebateRecordingUploadBanner', () => {
         count={2}
         waitingReason="waiting"
         errorMessage={null}
-        canPublishOptOut
-        publishChecked
-        onUncheckPublish={() => undefined}
+        canCancel
+        onCancel={() => undefined}
       />
     );
 
     expect(screen.getByText('Waiting to upload 2 debates')).toBeInTheDocument();
+    expect(screen.getByRole('status')).toHaveAttribute('aria-live', 'polite');
+    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
   });
 
   it('explains that offline uploads are waiting for a connection', () => {
@@ -200,14 +211,14 @@ describe('DebateRecordingUploadBanner', () => {
         count={1}
         waitingReason="offline"
         errorMessage="stale upload failure"
-        canPublishOptOut
-        publishChecked
-        onUncheckPublish={() => undefined}
+        canCancel
+        onCancel={() => undefined}
       />
     );
 
     expect(screen.getByText('Waiting to upload 1 debate — waiting for a connection')).toBeInTheDocument();
     expect(screen.queryByText(/stale upload failure/)).not.toBeInTheDocument();
+    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
   });
 
   it('shows the latest failure and says retries are automatic', () => {
@@ -216,15 +227,16 @@ describe('DebateRecordingUploadBanner', () => {
         count={2}
         waitingReason="retry"
         errorMessage="Finalization unavailable"
-        canPublishOptOut
-        publishChecked
-        onUncheckPublish={() => undefined}
+        canCancel
+        onCancel={() => undefined}
       />
     );
 
     expect(
       screen.getByText('Waiting to upload 2 debates — Finalization unavailable. Retrying automatically.')
     ).toBeInTheDocument();
+    expect(screen.getByRole('status')).toHaveAttribute('aria-live', 'polite');
+    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
   });
 
   it('keeps long failure text in the live region while visually truncating it', () => {
@@ -234,9 +246,8 @@ describe('DebateRecordingUploadBanner', () => {
         count={1}
         waitingReason="retry"
         errorMessage={longError}
-        canPublishOptOut
-        publishChecked
-        onUncheckPublish={() => undefined}
+        canCancel
+        onCancel={() => undefined}
       />
     );
 
@@ -245,34 +256,22 @@ describe('DebateRecordingUploadBanner', () => {
     expect(screen.getByText(message)).toHaveClass('truncate');
   });
 
-  it('asks to cancel only when unchecking a checked publish box', () => {
-    const uncheck = vi.fn();
-    const { rerender } = render(
+  it('keeps uploaded copy and hides progress after the upload finishes', () => {
+    render(
       <DebateRecordingUploadBanner
         count={1}
+        thankingUploadFinished
         waitingReason={null}
         errorMessage={null}
-        canPublishOptOut
-        publishChecked
-        onUncheckPublish={uncheck}
+        canCancel
+        onCancel={() => undefined}
       />
     );
 
-    fireEvent.click(screen.getByRole('checkbox', { name: 'Publish debate' }));
-    expect(uncheck).toHaveBeenCalledOnce();
-
-    rerender(
-      <DebateRecordingUploadBanner
-        count={1}
-        waitingReason={null}
-        errorMessage={null}
-        canPublishOptOut
-        publishChecked={false}
-        onUncheckPublish={uncheck}
-      />
-    );
-    fireEvent.click(screen.getByRole('checkbox', { name: 'Publish debate' }));
-    expect(uncheck).toHaveBeenCalledOnce();
+    expect(screen.getByText('Debate uploaded')).toBeInTheDocument();
+    expect(screen.getByRole('status')).toHaveAttribute('aria-live', 'polite');
+    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
   });
 });
 

--- a/apps/web/core/debates/recording-upload-coordinator.tsx
+++ b/apps/web/core/debates/recording-upload-coordinator.tsx
@@ -4,11 +4,9 @@ import { useQueryClient } from '@tanstack/react-query';
 
 import * as React from 'react';
 
-import cx from 'classnames';
-
 import { Z_LAYER_CLASS } from '~/core/z-layers';
 
-import { Check } from '~/design-system/icons/check';
+import { SmallButton } from '~/design-system/button';
 import { CloseSmall } from '~/design-system/icons/close-small';
 import { Text } from '~/design-system/text';
 
@@ -123,8 +121,8 @@ export function DebateRecordingUploadCoordinator() {
   const [cancelError, setCancelError] = React.useState<string | null>(null);
   const [uploadProgress, setUploadProgress] = React.useState<{ id: string; loaded: number } | null>(null);
   // Debates whose recording finished uploading in this session and is still publishable. The queue
-  // row is deleted as soon as an upload completes, so nothing else can keep the banner, and its
-  // publish opt-out, on screen for the rest of the thank-you period.
+  // row is deleted as soon as an upload completes, so nothing else can keep the banner and its
+  // cancellation action on screen for the rest of the thank-you period.
   const [uploadedDebateIds, setUploadedDebateIds] = React.useState<ReadonlySet<string>>(() => new Set());
   const [cancelledDebateIds, setCancelledDebateIds] = React.useState<ReadonlySet<string>>(() => new Set());
   const thankingDebate = useThankingDebate();
@@ -206,7 +204,7 @@ export function DebateRecordingUploadCoordinator() {
     return () => subscription.unsubscribe();
   }, [userId]);
 
-  // Recording persistence and the publish opt-out can finish in either order at the phase
+  // Recording persistence and cancellation can finish in either order at the phase
   // boundary. If a cancelled debate appears in IndexedDB afterward, keep it hidden, never start
   // its upload, and remove the late row as soon as the observer reports it.
   React.useEffect(() => {
@@ -346,9 +344,9 @@ export function DebateRecordingUploadCoordinator() {
     !cancelledDebateIds.has(normalizedThankingDebateId)
       ? (publishableUploads.find(upload => normalizeDebateId(upload.debateId) === normalizedThankingDebateId) ?? null)
       : null;
-  // A fast connection finishes the upload before the user can reach the checkbox, so an already
-  // uploaded debate keeps the banner open until thanking ends. The backend still accepts a cancel
-  // for it. Debates dropped as unpublishable never enter `uploadedDebateIds`, so they get no opt-out.
+  // A fast connection can finish the upload before the user reaches the Cancel action. Keep the
+  // uploaded debate banner open until thanking ends, since the backend still accepts a cancel.
+  // Debates dropped as unpublishable never enter `uploadedDebateIds`, so they get no opt-out.
   const thankingUploadFinished =
     normalizedThankingDebateId !== null &&
     !thankingUpload &&
@@ -414,7 +412,7 @@ export function DebateRecordingUploadCoordinator() {
       }
       if (mountedRef.current) {
         // The server opt-out is authoritative even if this device cannot clean IndexedDB. Mark it
-        // before local cleanup so a storage failure can never make Publish appear enabled again.
+        // before local cleanup so a storage failure can never make Cancel available again.
         setCancelledDebateIds(current => new Set(current).add(normalizedTargetDebateId));
         setUploadedDebateIds(current => {
           const next = new Set(current);
@@ -471,9 +469,8 @@ export function DebateRecordingUploadCoordinator() {
           percent={uploadPercent}
           waitingReason={waitingReason}
           errorMessage={latestFailedUpload?.lastError ?? null}
-          canPublishOptOut={cancellableDebateId !== null || cancelPromptOpen}
-          publishChecked={!cancelPromptOpen}
-          onUncheckPublish={() => setCancelTargetDebateId(cancellableDebateId)}
+          canCancel={cancellableDebateId !== null && !cancelPromptOpen}
+          onCancel={() => setCancelTargetDebateId(cancellableDebateId)}
         />
       )}
       {cancelPromptOpen && (
@@ -495,9 +492,8 @@ export function DebateRecordingUploadBanner({
   percent = null,
   waitingReason,
   errorMessage,
-  canPublishOptOut,
-  publishChecked,
-  onUncheckPublish,
+  canCancel,
+  onCancel,
 }: {
   count: number;
   thankingRecordingPending?: boolean;
@@ -505,9 +501,8 @@ export function DebateRecordingUploadBanner({
   percent?: number | null;
   waitingReason: DebateRecordingUploadWaitingReason;
   errorMessage: string | null;
-  canPublishOptOut: boolean;
-  publishChecked: boolean;
-  onUncheckPublish: () => void;
+  canCancel: boolean;
+  onCancel: () => void;
 }) {
   const label = `${count} debate${count === 1 ? '' : 's'}`;
   let message: string;
@@ -524,47 +519,40 @@ export function DebateRecordingUploadBanner({
     message = `Waiting to upload ${label} — ${failure}${punctuation} Retrying automatically.`;
   } else if (waitingReason) {
     message = `Waiting to upload ${label}`;
-  } else if (percent !== null) {
-    message = `Uploading ${label} · ${percent}%`;
   } else {
-    // With no checkbox or percent after it the message is the whole line, so the ellipsis is what
-    // keeps it reading as in progress.
-    message = canPublishOptOut ? `Uploading ${label}` : `Uploading ${label}...`;
+    message = `Uploading & publishing ${label}`;
   }
+
+  const showProgress = thankingRecordingPending || (!thankingUploadFinished && waitingReason === null);
+  const progressPercent = thankingRecordingPending ? null : percent;
+  const progressLabel = thankingRecordingPending ? message : `Uploading and publishing ${label}`;
 
   return (
     <div
       role="status"
       aria-live="polite"
-      className={`fixed inset-x-0 bottom-0 flex min-w-0 items-center justify-center gap-2 bg-divider px-4 py-2 text-metadata text-grey-04 ${Z_LAYER_CLASS.toast}`}
+      className={`fixed inset-x-0 bottom-0 flex h-7 min-w-0 items-center gap-2 bg-divider px-4 text-metadata text-text ${Z_LAYER_CLASS.toast}`}
     >
-      <span className="min-w-0 truncate">{message}</span>
-      {canPublishOptOut && (
-        <>
-          <span aria-hidden="true" className="shrink-0">
-            ·
-          </span>
-          <button
-            type="button"
-            role="checkbox"
-            aria-checked={publishChecked}
-            aria-label="Publish debate"
-            onClick={() => {
-              if (publishChecked) onUncheckPublish();
-            }}
-            className="inline-flex shrink-0 items-center gap-1.5 text-text"
-          >
-            Publish
-            <span
-              className={cx(
-                'grid size-3 place-items-center rounded-sm border transition-colors *:size-2.5',
-                publishChecked ? 'border-text bg-text text-white' : 'border-grey-03 bg-white text-transparent'
-              )}
-            >
-              <Check />
-            </span>
-          </button>
-        </>
+      <span className="min-w-0 flex-1 truncate">{message}</span>
+      {showProgress && (
+        <div
+          role="progressbar"
+          aria-label={progressLabel}
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-valuenow={progressPercent ?? undefined}
+          className="h-1 w-14 shrink-0 overflow-hidden rounded-full bg-grey-03"
+        >
+          <div
+            className={`h-full rounded-full bg-text transition-[width] ${progressPercent === null ? 'w-1/3 animate-pulse' : ''}`}
+            style={progressPercent === null ? undefined : { width: `${progressPercent}%` }}
+          />
+        </div>
+      )}
+      {canCancel && (
+        <SmallButton type="button" variant="ghost" onClick={onCancel} className="shrink-0 bg-transparent! hover:bg-bg!">
+          Cancel
+        </SmallButton>
       )}
     </div>
   );

--- a/apps/web/core/debates/recording-upload-coordinator.tsx
+++ b/apps/web/core/debates/recording-upload-coordinator.tsx
@@ -531,29 +531,36 @@ export function DebateRecordingUploadBanner({
     <div
       role="status"
       aria-live="polite"
-      className={`fixed inset-x-0 bottom-0 flex h-7 min-w-0 items-center gap-2 bg-divider px-4 text-metadata text-text ${Z_LAYER_CLASS.toast}`}
+      className={`fixed inset-x-0 bottom-0 flex h-7 min-w-0 items-center justify-center bg-divider px-4 text-metadata text-text ${Z_LAYER_CLASS.toast}`}
     >
-      <span className="min-w-0 flex-1 truncate">{message}</span>
-      {showProgress && (
-        <div
-          role="progressbar"
-          aria-label={progressLabel}
-          aria-valuemin={0}
-          aria-valuemax={100}
-          aria-valuenow={progressPercent ?? undefined}
-          className="h-1 w-14 shrink-0 overflow-hidden rounded-full bg-grey-03"
-        >
+      <div className="flex w-auto max-w-full min-w-0 items-center gap-2 md:w-full">
+        <span className="min-w-0 flex-initial truncate md:flex-1">{message}</span>
+        {showProgress && (
           <div
-            className={`h-full rounded-full bg-text transition-[width] ${progressPercent === null ? 'w-1/3 animate-pulse' : ''}`}
-            style={progressPercent === null ? undefined : { width: `${progressPercent}%` }}
-          />
-        </div>
-      )}
-      {canCancel && (
-        <SmallButton type="button" variant="ghost" onClick={onCancel} className="shrink-0 bg-transparent! hover:bg-bg!">
-          Cancel
-        </SmallButton>
-      )}
+            role="progressbar"
+            aria-label={progressLabel}
+            aria-valuemin={0}
+            aria-valuemax={100}
+            aria-valuenow={progressPercent ?? undefined}
+            className="h-1 w-14 shrink-0 overflow-hidden rounded-full bg-grey-03"
+          >
+            <div
+              className={`h-full rounded-full bg-text transition-[width] ${progressPercent === null ? 'w-1/3 animate-pulse' : ''}`}
+              style={progressPercent === null ? undefined : { width: `${progressPercent}%` }}
+            />
+          </div>
+        )}
+        {canCancel && (
+          <SmallButton
+            type="button"
+            variant="ghost"
+            onClick={onCancel}
+            className="shrink-0 bg-transparent! hover:bg-bg!"
+          >
+            Cancel
+          </SmallButton>
+        )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

The upload banner now uses the same compact treatment on mobile and desktop, with clearer “Uploading & publishing” copy and accessible visual progress. A ghost Cancel action replaces the ambiguous Publish checkbox while preserving the existing destructive confirmation, upload targeting, and failure behavior.

Preparing and finalization states use indeterminate progress. Waiting, error, and uploaded states keep their existing messages without showing misleading progress.

## Validation

- Focused unit and integration suite: 45 tests passed
- ESLint, Prettier, and `git diff --check` passed
