### PR TITLE
fix(debates): prevent false room tab conflicts

### DIFF
--- a/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
@@ -46,11 +46,14 @@ const mocks = vi.hoisted(() => ({
   refetchDebate: vi.fn(),
   clearTimedOutDebateActivity: vi.fn(),
   roomOn: vi.fn(),
+  capture: vi.fn(),
   ownershipAcquire: vi.fn(),
   ownershipRequestTakeover: vi.fn(),
   ownershipRelease: vi.fn(),
   ownershipClose: vi.fn(),
   ownershipTakeoverHandler: null as null | (() => boolean | Promise<boolean>),
+  ownershipCoordinationMode: 'lock-and-broadcast' as 'lock-and-broadcast' | 'lock-only' | 'livekit-fallback',
+  useRealRoomOwnership: false,
   deviceChangeHandler: null as null | (() => void),
   debate: null as Debate | null,
   rematch: null as DebateRematchSession | null,
@@ -75,6 +78,10 @@ vi.mock('~/design-system/prefetch-link', () => ({
 vi.mock('~/core/state/feature-flags', () => ({
   useFeatureFlag: (id: string) => mocks.featureFlags[id] ?? false,
   useDebatesEnabled: () => mocks.featureFlags['questionsTab'] ?? false,
+}));
+
+vi.mock('~/core/analytics', () => ({
+  capture: mocks.capture,
 }));
 
 vi.mock('~/core/debates/api', async importOriginal => {
@@ -116,19 +123,28 @@ vi.mock('~/core/debates/thanking-debate-store', () => ({
   useSetThankingDebate: () => mocks.setThankingDebate,
 }));
 
-vi.mock('~/core/debates/debate-room-ownership', () => ({
-  createDebateRoomOwnershipCoordinator: (options: { onTakeoverRequested: () => boolean | Promise<boolean> }) => {
-    mocks.ownershipTakeoverHandler = options.onTakeoverRequested;
-    return {
-      instanceId: 'connection-instance-1',
-      acquire: mocks.ownershipAcquire,
-      requestTakeover: mocks.ownershipRequestTakeover,
-      release: mocks.ownershipRelease,
-      close: mocks.ownershipClose,
-      ownsConnection: () => true,
-    };
-  },
-}));
+vi.mock('~/core/debates/debate-room-ownership', async importOriginal => {
+  const actual = await importOriginal<typeof import('~/core/debates/debate-room-ownership')>();
+
+  return {
+    ...actual,
+    createDebateRoomOwnershipCoordinator: (
+      options: Parameters<typeof actual.createDebateRoomOwnershipCoordinator>[0]
+    ) => {
+      if (mocks.useRealRoomOwnership) return actual.createDebateRoomOwnershipCoordinator(options);
+      mocks.ownershipTakeoverHandler = options.onTakeoverRequested;
+      return {
+        instanceId: 'connection-instance-1',
+        coordinationMode: mocks.ownershipCoordinationMode,
+        acquire: mocks.ownershipAcquire,
+        requestTakeover: mocks.ownershipRequestTakeover,
+        release: mocks.ownershipRelease,
+        close: mocks.ownershipClose,
+        ownsConnection: () => true,
+      };
+    },
+  };
+});
 
 vi.mock('livekit-client', () => ({
   createLocalTracks: mocks.createLocalTracks,
@@ -168,6 +184,63 @@ vi.mock('@livekit/krisp-noise-filter', () => ({
 function emitRoomEvent(event: string, payload?: unknown) {
   for (const [registeredEvent, callback] of mocks.roomOn.mock.calls) {
     if (registeredEvent === event) callback(payload);
+  }
+}
+
+type QueuedLock = {
+  callback: (lock: Lock | null) => Promise<void> | void;
+  resolve: () => void;
+  reject: (error: unknown) => void;
+};
+
+class FakeLockManager {
+  private held = false;
+  private queue: QueuedLock[] = [];
+
+  request(_name: string, options: LockOptions, callback: QueuedLock['callback']): Promise<void> {
+    if (options.ifAvailable && this.held) return Promise.resolve(callback(null));
+
+    return new Promise<void>((resolve, reject) => {
+      const queued = { callback, resolve, reject };
+      if (this.held) this.queue.push(queued);
+      else void this.run(queued);
+    });
+  }
+
+  private async run(queued: QueuedLock) {
+    this.held = true;
+    try {
+      await queued.callback({ name: 'debate-room', mode: 'exclusive' });
+      queued.resolve();
+    } catch (error) {
+      queued.reject(error);
+    } finally {
+      this.held = false;
+      const next = this.queue.shift();
+      if (next) void this.run(next);
+    }
+  }
+}
+
+class FakeBroadcastChannel {
+  static channels = new Map<string, Set<FakeBroadcastChannel>>();
+
+  onmessage: ((event: MessageEvent) => void) | null = null;
+
+  constructor(private readonly name: string) {
+    const channels = FakeBroadcastChannel.channels.get(name) ?? new Set();
+    channels.add(this);
+    FakeBroadcastChannel.channels.set(name, channels);
+  }
+
+  postMessage(data: unknown) {
+    for (const channel of FakeBroadcastChannel.channels.get(this.name) ?? []) {
+      if (channel !== this) queueMicrotask(() => channel.onmessage?.(new MessageEvent('message', { data })));
+    }
+  }
+
+  close() {
+    FakeBroadcastChannel.channels.get(this.name)?.delete(this);
   }
 }
 
@@ -224,11 +297,14 @@ beforeEach(() => {
   mocks.refetchDebate.mockReset();
   mocks.clearTimedOutDebateActivity.mockReset();
   mocks.roomOn.mockReset();
-  mocks.ownershipAcquire.mockReset().mockResolvedValue(true);
+  mocks.capture.mockReset();
+  mocks.ownershipAcquire.mockReset().mockResolvedValue({ acquired: true, waitedForLocalRelease: false });
   mocks.ownershipRequestTakeover.mockReset().mockResolvedValue(true);
   mocks.ownershipRelease.mockReset();
   mocks.ownershipClose.mockReset();
   mocks.ownershipTakeoverHandler = null;
+  mocks.ownershipCoordinationMode = 'lock-and-broadcast';
+  mocks.useRealRoomOwnership = false;
   mocks.deviceChangeHandler = null;
   mocks.debate = completedDebate();
   mocks.rematch = null;
@@ -303,11 +379,14 @@ beforeEach(() => {
   });
 });
 
-afterEach(() => {
+afterEach(async () => {
   cleanup();
+  await Promise.resolve();
+  await Promise.resolve();
   vi.useRealTimers();
   vi.restoreAllMocks();
   vi.unstubAllGlobals();
+  Object.defineProperty(navigator, 'locks', { configurable: true, value: undefined });
 });
 
 describe('isDebateInThankYouPeriod', () => {
@@ -897,7 +976,7 @@ describe('DebateRoomPageClient', () => {
   });
 
   it('does not mint a token when another tab owns the participant connection', async () => {
-    mocks.ownershipAcquire.mockResolvedValue(false);
+    mocks.ownershipAcquire.mockResolvedValue({ acquired: false, waitedForLocalRelease: false });
     mocks.debate = {
       ...readyDebate({ localReady: true, remoteReady: true }),
       status: 'connecting',
@@ -911,10 +990,50 @@ describe('DebateRoomPageClient', () => {
     expect(screen.getByRole('button', { name: 'Continue here' })).toBeInTheDocument();
     expect(mocks.liveKitJoinMutateAsync).not.toHaveBeenCalled();
     expect(mocks.roomConnect).not.toHaveBeenCalled();
+    expect(mocks.capture).toHaveBeenCalledOnce();
+    expect(mocks.capture).toHaveBeenCalledWith(
+      'debate_room_connection_conflict',
+      expect.objectContaining({
+        debate_id: 'debate-1',
+        source: 'web_lock_blocked',
+        coordination_mode: 'lock-and-broadcast',
+        debate_status: 'connecting',
+        room_state: 'idle',
+        visibility_state: expect.any(String),
+        has_focus: expect.any(Boolean),
+        navigation_type: expect.any(String),
+      })
+    );
+  });
+
+  it('keeps lock-only pages exclusive before token creation', async () => {
+    mocks.useRealRoomOwnership = true;
+    Object.defineProperty(navigator, 'locks', { configurable: true, value: new FakeLockManager() });
+    vi.stubGlobal('BroadcastChannel', undefined);
+    mocks.debate = {
+      ...readyDebate({ localReady: true, remoteReady: true }),
+      status: 'connecting',
+      connecting_started_at: '2099-07-02T00:00:00.000Z',
+      connecting_deadline_at: '2099-07-02T00:00:10.000Z',
+    };
+
+    render(
+      <>
+        <DebateRoomPageClient spaceId="space-1" debateId="debate-1" />
+        <DebateRoomPageClient spaceId="space-1" debateId="debate-1" />
+      </>
+    );
+
+    await waitFor(() => expect(mocks.liveKitJoinMutateAsync).toHaveBeenCalledOnce());
+    expect(await screen.findByText('This debate is already open in another tab.')).toBeInTheDocument();
+    expect(mocks.capture).toHaveBeenCalledWith(
+      'debate_room_connection_conflict',
+      expect.objectContaining({ source: 'web_lock_blocked', coordination_mode: 'lock-only' })
+    );
   });
 
   it('takes over a connection-phase debate before minting a new token', async () => {
-    mocks.ownershipAcquire.mockResolvedValue(false);
+    mocks.ownershipAcquire.mockResolvedValue({ acquired: false, waitedForLocalRelease: false });
     mocks.debate = {
       ...readyDebate({ localReady: true, remoteReady: true }),
       status: 'connecting',
@@ -935,7 +1054,7 @@ describe('DebateRoomPageClient', () => {
   it('keeps takeover available during a preflight ownership conflict', async () => {
     const now = Date.parse('2026-07-02T00:00:05.000Z');
     vi.spyOn(Date, 'now').mockReturnValue(now);
-    mocks.ownershipAcquire.mockResolvedValue(false);
+    mocks.ownershipAcquire.mockResolvedValue({ acquired: false, waitedForLocalRelease: false });
     mocks.debate = {
       ...completedDebate(),
       status: 'preflight',
@@ -971,12 +1090,17 @@ describe('DebateRoomPageClient', () => {
 
     await expect(Promise.resolve(mocks.ownershipTakeoverHandler?.())).resolves.toBe(true);
     expect(mocks.roomDisconnect).toHaveBeenCalledOnce();
+    expect(mocks.capture).toHaveBeenCalledOnce();
+    expect(mocks.capture).toHaveBeenCalledWith(
+      'debate_room_connection_conflict',
+      expect.objectContaining({ source: 'ownership_released', coordination_mode: 'lock-and-broadcast' })
+    );
 
     pendingConnection.resolve();
   });
 
   it('does not allow a secondary tab to take over an active debate recording', async () => {
-    mocks.ownershipAcquire.mockResolvedValue(false);
+    mocks.ownershipAcquire.mockResolvedValue({ acquired: false, waitedForLocalRelease: false });
     mocks.debate = {
       ...completedDebate(),
       status: 'in_progress',
@@ -1104,6 +1228,7 @@ describe('DebateRoomPageClient', () => {
   });
 
   it('explains when LiveKit disconnects a duplicate participant identity', async () => {
+    mocks.ownershipCoordinationMode = 'livekit-fallback';
     mocks.debate = {
       ...readyDebate({ localReady: true, remoteReady: true }),
       status: 'connecting',
@@ -1120,6 +1245,11 @@ describe('DebateRoomPageClient', () => {
     expect(screen.getByRole('button', { name: 'Continue here' })).toBeInTheDocument();
     expect(screen.queryByText('Lost connection to the debate room.')).not.toBeInTheDocument();
     expect(mocks.ownershipRelease).toHaveBeenCalled();
+    expect(mocks.capture).toHaveBeenCalledOnce();
+    expect(mocks.capture).toHaveBeenCalledWith(
+      'debate_room_connection_conflict',
+      expect.objectContaining({ source: 'livekit_duplicate_identity', coordination_mode: 'livekit-fallback' })
+    );
   });
 
   it('does not resume an in-flight join after a duplicate-identity disconnect', async () => {
@@ -1145,6 +1275,10 @@ describe('DebateRoomPageClient', () => {
   });
 
   it('connects to LiveKit after the Strict Mode effect rehearsal', async () => {
+    mocks.useRealRoomOwnership = true;
+    FakeBroadcastChannel.channels.clear();
+    Object.defineProperty(navigator, 'locks', { configurable: true, value: new FakeLockManager() });
+    vi.stubGlobal('BroadcastChannel', FakeBroadcastChannel);
     mocks.debate = {
       ...readyDebate({ localReady: true, remoteReady: true }),
       status: 'connecting',
@@ -1158,8 +1292,19 @@ describe('DebateRoomPageClient', () => {
       </StrictMode>
     );
 
-    await waitFor(() => expect(mocks.roomConnect).toHaveBeenCalled());
-    await waitFor(() => expect(mocks.markJoinedMutateAsync).toHaveBeenCalled());
+    await waitFor(() => expect(mocks.roomConnect).toHaveBeenCalledOnce());
+    await waitFor(() => expect(mocks.markJoinedMutateAsync).toHaveBeenCalledOnce());
+    expect(screen.queryByText('This debate is already open in another tab.')).not.toBeInTheDocument();
+    expect(mocks.liveKitJoinMutateAsync).toHaveBeenCalledOnce();
+    expect(mocks.capture).toHaveBeenCalledOnce();
+    expect(mocks.capture).toHaveBeenCalledWith(
+      'debate_room_ownership_recovered',
+      expect.objectContaining({
+        debate_id: 'debate-1',
+        coordination_mode: 'lock-and-broadcast',
+        waited_for_local_release: true,
+      })
+    );
   });
 
   it('refetches the debate when LiveKit reports the remote participant connected', async () => {

--- a/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
@@ -1032,6 +1032,33 @@ describe('DebateRoomPageClient', () => {
     );
   });
 
+  it('uses the LiveKit fallback instead of showing a conflict when Web Lock requests fail', async () => {
+    mocks.useRealRoomOwnership = true;
+    Object.defineProperty(navigator, 'locks', {
+      configurable: true,
+      value: {
+        request: vi.fn().mockRejectedValue(new Error('Web Locks are unavailable')),
+      },
+    });
+    vi.stubGlobal('BroadcastChannel', FakeBroadcastChannel);
+    mocks.debate = {
+      ...readyDebate({ localReady: true, remoteReady: true }),
+      status: 'connecting',
+      connecting_started_at: '2099-07-02T00:00:00.000Z',
+      connecting_deadline_at: '2099-07-02T00:00:10.000Z',
+    };
+
+    render(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
+
+    await waitFor(() => expect(mocks.liveKitJoinMutateAsync).toHaveBeenCalledOnce());
+    await waitFor(() => expect(mocks.roomConnect).toHaveBeenCalledOnce());
+    expect(screen.queryByText('This debate is already open in another tab.')).not.toBeInTheDocument();
+    expect(mocks.capture).not.toHaveBeenCalledWith(
+      'debate_room_connection_conflict',
+      expect.objectContaining({ source: 'web_lock_blocked' })
+    );
+  });
+
   it('takes over a connection-phase debate before minting a new token', async () => {
     mocks.ownershipAcquire.mockResolvedValue({ acquired: false, waitedForLocalRelease: false });
     mocks.debate = {

--- a/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.tsx
@@ -7,6 +7,7 @@ import * as React from 'react';
 import cx from 'classnames';
 import { useRouter } from 'next/navigation';
 
+import { capture } from '~/core/analytics';
 import {
   type Debate,
   type DebateRematchSession,
@@ -25,6 +26,7 @@ import {
   SpeakerIcon,
 } from '~/core/debates/debate-room-controls';
 import {
+  type DebateRoomOwnershipCoordinationMode,
   type DebateRoomOwnershipCoordinator,
   createDebateRoomOwnershipCoordinator,
 } from '~/core/debates/debate-room-ownership';
@@ -72,6 +74,8 @@ type DebateRoomPageClientProps = {
 };
 
 type DebateNoiseFilterStatus = 'initializing' | 'enabled' | 'disabled' | 'unsupported' | 'failed';
+
+type DebateRoomConnectionConflictSource = 'web_lock_blocked' | 'ownership_released' | 'livekit_duplicate_identity';
 
 const debateNoiseFilterStatusLabel: Record<DebateNoiseFilterStatus, string> = {
   initializing: 'Loading…',
@@ -203,7 +207,8 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
     'idle'
   );
   const [roomError, setRoomError] = React.useState<string | null>(null);
-  const [connectionConflict, setConnectionConflict] = React.useState(false);
+  const [connectionConflictSource, setConnectionConflictSource] =
+    React.useState<DebateRoomConnectionConflictSource | null>(null);
   const [remoteVideoReady, setRemoteVideoReady] = React.useState(false);
   const [rematchConsentRequested, setRematchConsentRequested] = React.useState(false);
   const [audioMuted, setAudioMuted] = React.useState(false);
@@ -235,6 +240,8 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
   const recordingStopTimerRef = React.useRef<number | null>(null);
   const autoConnectAttemptedRef = React.useRef<string | null>(null);
   const connectionFailureHandledRef = React.useRef(false);
+  const reportedConflictGenerationRef = React.useRef<number | null>(null);
+  const reportedRecoveryGenerationRef = React.useRef<number | null>(null);
   const connectionFailureRedirectTimerRef = React.useRef<number | null>(null);
   const remoteParticipantRefetchTimerRef = React.useRef<number | null>(null);
   const serverNowRef = React.useRef(serverClock.now);
@@ -324,6 +331,7 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
     localSlot,
     audioMuted || pendingTurnYield !== null
   );
+  const connectionConflict = connectionConflictSource !== null;
   const canTakeOverConnection =
     connectionConflict && (countdown.effectiveStatus === 'connecting' || countdown.effectiveStatus === 'preflight');
   const connectionConflictWithoutTakeover = connectionConflict && !canTakeOverConnection;
@@ -392,6 +400,40 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
     setRemoteMediaAudioEnabled(remoteMediaRef, remoteAudioEnabled);
   }, [remoteAudioEnabled]);
 
+  const reportConnectionConflict = React.useCallback(
+    (
+      generation: number,
+      source: DebateRoomConnectionConflictSource,
+      coordinationMode: DebateRoomOwnershipCoordinationMode
+    ) => {
+      if (reportedConflictGenerationRef.current === generation) return;
+      reportedConflictGenerationRef.current = generation;
+      captureDebateRoomConnectionEvent('debate_room_connection_conflict', {
+        debateId,
+        source,
+        coordinationMode,
+        debateStatus: debateStatusRef.current,
+        roomState: roomStateRef.current,
+      });
+    },
+    [debateId]
+  );
+
+  const reportLocalReleaseRecovery = React.useCallback(
+    (generation: number, coordinationMode: DebateRoomOwnershipCoordinationMode) => {
+      if (reportedRecoveryGenerationRef.current === generation) return;
+      reportedRecoveryGenerationRef.current = generation;
+      captureDebateRoomConnectionEvent('debate_room_ownership_recovered', {
+        debateId,
+        coordinationMode,
+        debateStatus: debateStatusRef.current,
+        roomState: roomStateRef.current,
+        waitedForLocalRelease: true,
+      });
+    },
+    [debateId]
+  );
+
   React.useEffect(() => {
     if (!currentUserId) return;
     const coordinator = createDebateRoomOwnershipCoordinator({
@@ -406,12 +448,13 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
         const canReleaseOwnership = status === 'connecting' || preflightStillPending;
         if (!canReleaseOwnership) return false;
 
-        connectionGenerationRef.current += 1;
+        const generation = connectionGenerationRef.current + 1;
+        connectionGenerationRef.current = generation;
         disconnectConnectingRoom(connectingRoomRef);
         disconnectRoom(roomRef, localTracksRef, localVideoRef, remoteMediaRef);
         localMediaStreamRef.current = null;
         setRemoteVideoReady(false);
-        setConnectionConflict(true);
+        setConnectionConflictSource('ownership_released');
         setRoomError('This debate moved to another tab.');
         setRoomState('idle');
         logDebateConnectionDiagnostic('ownership-released', {
@@ -419,6 +462,11 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
           instanceId: connectionInstanceIdRef.current,
           roomState: roomStateRef.current,
         });
+        reportConnectionConflict(
+          generation,
+          'ownership_released',
+          ownershipRef.current?.coordinationMode ?? 'livekit-fallback'
+        );
         return true;
       },
     });
@@ -429,7 +477,7 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
       if (ownershipRef.current === coordinator) ownershipRef.current = null;
       coordinator.close();
     };
-  }, [currentUserId, debateId]);
+  }, [currentUserId, debateId, reportConnectionConflict]);
 
   const clearRecordingTimers = React.useCallback(() => {
     if (recordingStartTimerRef.current !== null) {
@@ -700,10 +748,21 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
       let connectingRoom: RoomLike | null = null;
       let newlyCreatedTracks: LocalTrackLike[] = [];
       const ownership = ownershipRef.current;
-      const ownsConnection = options.takeover ? await ownership?.requestTakeover() : await ownership?.acquire();
+      let ownsConnection: boolean | undefined;
+      let waitedForLocalRelease = false;
+      if (options.takeover) {
+        ownsConnection = await ownership?.requestTakeover();
+      } else {
+        const acquisition = await ownership?.acquire();
+        ownsConnection = acquisition?.acquired;
+        waitedForLocalRelease = acquisition?.waitedForLocalRelease ?? false;
+      }
       if (!isCurrent()) return;
+      if (ownsConnection && waitedForLocalRelease) {
+        reportLocalReleaseRecovery(generation, ownership?.coordinationMode ?? 'livekit-fallback');
+      }
       if (ownsConnection === false) {
-        setConnectionConflict(true);
+        setConnectionConflictSource('web_lock_blocked');
         setRoomError('This debate is already open in another tab.');
         setRoomState('idle');
         logDebateConnectionDiagnostic('ownership-blocked', {
@@ -711,10 +770,11 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
           instanceId: connectionInstanceIdRef.current,
           roomState: roomStateRef.current,
         });
+        reportConnectionConflict(generation, 'web_lock_blocked', ownership?.coordinationMode ?? 'livekit-fallback');
         return;
       }
 
-      setConnectionConflict(false);
+      setConnectionConflictSource(null);
       setRoomError(null);
       setRoomState('connecting');
       setServerClockSettled(false);
@@ -806,7 +866,8 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
         room.on(livekit.RoomEvent.Disconnected, payload => {
           if (!isCurrent() || roomRef.current !== room) return;
           if (payload === livekit.DisconnectReason.CLIENT_INITIATED) return;
-          connectionGenerationRef.current += 1;
+          const conflictGeneration = connectionGenerationRef.current + 1;
+          connectionGenerationRef.current = conflictGeneration;
           // The room is already gone, so null the ref before cleanup: disconnectRoom would otherwise
           // call room.disconnect() a second time and could re-enter this handler.
           roomRef.current = null;
@@ -816,7 +877,7 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
           localMediaStreamRef.current = null;
           setRemoteVideoReady(false);
           const duplicateIdentity = payload === livekit.DisconnectReason.DUPLICATE_IDENTITY;
-          setConnectionConflict(duplicateIdentity);
+          setConnectionConflictSource(duplicateIdentity ? 'livekit_duplicate_identity' : null);
           setRoomError(
             duplicateIdentity
               ? 'This debate is active in another tab or device.'
@@ -829,6 +890,13 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
             roomState: roomStateRef.current,
             disconnectReason: payload,
           });
+          if (duplicateIdentity) {
+            reportConnectionConflict(
+              conflictGeneration,
+              'livekit_duplicate_identity',
+              ownershipRef.current?.coordinationMode ?? 'livekit-fallback'
+            );
+          }
         });
 
         await room.connect(token.url, token.token);
@@ -918,7 +986,7 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
           if (roomRef.current === room) roomRef.current = null;
           return;
         }
-        setConnectionConflict(false);
+        setConnectionConflictSource(null);
         setRoomState('connected');
       } catch (error) {
         if (connectingRoom && connectingRoomRef.current === connectingRoom) connectingRoomRef.current = null;
@@ -930,7 +998,7 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
         localMediaStreamRef.current = null;
         if (isCurrent()) {
           ownershipRef.current?.release();
-          setConnectionConflict(false);
+          setConnectionConflictSource(null);
           setRoomError(error instanceof Error ? error.message : 'Could not join the debate room.');
           setRoomState(debate?.status === 'connecting' ? 'connecting' : 'idle');
         }
@@ -945,6 +1013,8 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
       initializeNoiseFilter,
       liveKitJoin,
       markJoined,
+      reportConnectionConflict,
+      reportLocalReleaseRecovery,
       refetchDebate,
       setPreviewStream,
       videoEnabled,
@@ -2404,6 +2474,40 @@ function logDebateConnectionDiagnostic(
   }
 ) {
   console.info('[DebateRoomConnection]', { event, ...details });
+}
+
+function captureDebateRoomConnectionEvent(
+  eventName: 'debate_room_connection_conflict' | 'debate_room_ownership_recovered',
+  details: {
+    debateId: string;
+    coordinationMode: DebateRoomOwnershipCoordinationMode;
+    debateStatus: Debate['status'] | null;
+    roomState: string;
+    source?: DebateRoomConnectionConflictSource;
+    waitedForLocalRelease?: boolean;
+  }
+) {
+  try {
+    capture(eventName, {
+      debate_id: details.debateId,
+      coordination_mode: details.coordinationMode,
+      debate_status: details.debateStatus ?? 'unknown',
+      room_state: details.roomState,
+      visibility_state: typeof document === 'undefined' ? 'unknown' : document.visibilityState,
+      has_focus: typeof document !== 'undefined' && typeof document.hasFocus === 'function' && document.hasFocus(),
+      navigation_type: currentNavigationType(),
+      ...(details.source ? { source: details.source } : {}),
+      ...(details.waitedForLocalRelease ? { waited_for_local_release: true } : {}),
+    });
+  } catch {
+    // Analytics is best-effort and must never affect room ownership or connection recovery.
+  }
+}
+
+function currentNavigationType() {
+  if (typeof performance === 'undefined' || typeof performance.getEntriesByType !== 'function') return 'unknown';
+  const navigation = performance.getEntriesByType('navigation')[0] as PerformanceNavigationTiming | undefined;
+  return navigation?.type ?? 'unknown';
 }
 
 // Mobile browsers behind cellular/symmetric NAT can take several seconds to establish the publisher

--- a/apps/web/core/debates/debate-room-ownership.test.ts
+++ b/apps/web/core/debates/debate-room-ownership.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { createDebateRoomOwnershipCoordinator } from './debate-room-ownership';
+import { type DebateRoomOwnershipCoordinator, createDebateRoomOwnershipCoordinator } from './debate-room-ownership';
 
 type QueuedLock = {
   callback: (lock: Lock | null) => Promise<void> | void;
@@ -12,6 +12,11 @@ type QueuedLock = {
 class FakeLockManager {
   private held = false;
   private queue: QueuedLock[] = [];
+  private pausedRequests = 0;
+
+  pauseNextRequest() {
+    this.pausedRequests += 1;
+  }
 
   request(_name: string, options: LockOptions, callback: (lock: Lock | null) => Promise<void> | void): Promise<void> {
     if (options.ifAvailable && this.held) {
@@ -32,12 +37,19 @@ class FakeLockManager {
         },
         { once: true }
       );
-      if (this.held) {
+      if (this.held || this.pausedRequests > 0) {
+        if (this.pausedRequests > 0) this.pausedRequests -= 1;
         this.queue.push(queued);
       } else {
         void this.run(queued);
       }
     });
+  }
+
+  grantNextRequest() {
+    if (this.held) return;
+    const next = this.queue.shift();
+    if (next) void this.run(next);
   }
 
   private async run(queued: QueuedLock) {
@@ -77,6 +89,11 @@ class FakeBroadcastChannel {
   }
 }
 
+async function closeCoordinators(...coordinators: DebateRoomOwnershipCoordinator[]) {
+  for (const coordinator of coordinators) coordinator.close();
+  await Promise.all(coordinators.map(coordinator => coordinator.release()));
+}
+
 beforeEach(() => {
   FakeBroadcastChannel.channels.clear();
   Object.defineProperty(navigator, 'locks', {
@@ -106,11 +123,11 @@ describe('debate room ownership', () => {
       onTakeoverRequested: () => true,
     });
 
-    await expect(first.acquire()).resolves.toBe(true);
-    await expect(second.acquire()).resolves.toBe(false);
+    expect(first.coordinationMode).toBe('lock-and-broadcast');
+    await expect(first.acquire()).resolves.toEqual({ acquired: true, waitedForLocalRelease: false });
+    await expect(second.acquire()).resolves.toEqual({ acquired: false, waitedForLocalRelease: false });
 
-    first.close();
-    second.close();
+    await closeCoordinators(first, second);
   });
 
   it('hands ownership to another tab only after the current owner releases it', async () => {
@@ -133,8 +150,7 @@ describe('debate room ownership', () => {
     expect(first.ownsConnection()).toBe(false);
     expect(second.ownsConnection()).toBe(true);
 
-    first.close();
-    second.close();
+    await closeCoordinators(first, second);
   });
 
   it('keeps the original owner when an active debate refuses takeover', async () => {
@@ -155,8 +171,7 @@ describe('debate room ownership', () => {
     expect(first.ownsConnection()).toBe(true);
     expect(second.ownsConnection()).toBe(false);
 
-    first.close();
-    second.close();
+    await closeCoordinators(first, second);
   });
 
   it('reclaims a free local lock after a duplicate connection displaced the tab', async () => {
@@ -175,11 +190,107 @@ describe('debate room ownership', () => {
 
     await expect(second.requestTakeover()).resolves.toBe(true);
 
-    first.close();
-    second.close();
+    await closeCoordinators(first, second);
   });
 
-  it('falls back to LiveKit identity handling when BroadcastChannel is unavailable', async () => {
+  it('waits for an immediate same-tab predecessor to close before acquiring', async () => {
+    const first = createDebateRoomOwnershipCoordinator({
+      debateId: 'debate-1',
+      userId: 'user-a',
+      onTakeoverRequested: () => true,
+    });
+    await first.acquire();
+
+    first.close();
+    const successor = createDebateRoomOwnershipCoordinator({
+      debateId: 'debate-1',
+      userId: 'user-a',
+      onTakeoverRequested: () => true,
+    });
+
+    await expect(successor.acquire()).resolves.toEqual({ acquired: true, waitedForLocalRelease: true });
+    expect(successor.ownsConnection()).toBe(true);
+
+    await closeCoordinators(first, successor);
+  });
+
+  it('drains a close during pending acquisition before a successor requests the lock', async () => {
+    const lockManager = new FakeLockManager();
+    lockManager.pauseNextRequest();
+    Object.defineProperty(navigator, 'locks', { configurable: true, value: lockManager });
+    const first = createDebateRoomOwnershipCoordinator({
+      debateId: 'debate-1',
+      userId: 'user-a',
+      onTakeoverRequested: () => true,
+    });
+
+    const firstAcquisition = first.acquire();
+    first.close();
+    const successor = createDebateRoomOwnershipCoordinator({
+      debateId: 'debate-1',
+      userId: 'user-a',
+      onTakeoverRequested: () => true,
+    });
+    const successorAcquisition = successor.acquire();
+    lockManager.grantNextRequest();
+
+    await expect(firstAcquisition).resolves.toEqual({ acquired: false, waitedForLocalRelease: false });
+    await expect(successorAcquisition).resolves.toEqual({ acquired: true, waitedForLocalRelease: true });
+
+    await closeCoordinators(first, successor);
+  });
+
+  it('drains chained local closes without making a successor wait on itself', async () => {
+    const first = createDebateRoomOwnershipCoordinator({
+      debateId: 'debate-1',
+      userId: 'user-a',
+      onTakeoverRequested: () => true,
+    });
+    await first.acquire();
+
+    first.close();
+    const closingSuccessor = createDebateRoomOwnershipCoordinator({
+      debateId: 'debate-1',
+      userId: 'user-a',
+      onTakeoverRequested: () => true,
+    });
+    const closingAcquisition = closingSuccessor.acquire();
+    closingSuccessor.close();
+    const finalSuccessor = createDebateRoomOwnershipCoordinator({
+      debateId: 'debate-1',
+      userId: 'user-a',
+      onTakeoverRequested: () => true,
+    });
+    const finalAcquisition = finalSuccessor.acquire();
+
+    await expect(closingAcquisition).resolves.toEqual({ acquired: false, waitedForLocalRelease: true });
+    await expect(finalAcquisition).resolves.toEqual({ acquired: true, waitedForLocalRelease: true });
+
+    await closeCoordinators(first, closingSuccessor, finalSuccessor);
+  });
+
+  it('keeps repeated release and close calls idempotent', async () => {
+    const first = createDebateRoomOwnershipCoordinator({
+      debateId: 'debate-1',
+      userId: 'user-a',
+      onTakeoverRequested: () => true,
+    });
+    await first.acquire();
+
+    first.close();
+    await Promise.all([first.release(), first.release()]);
+
+    const successor = createDebateRoomOwnershipCoordinator({
+      debateId: 'debate-1',
+      userId: 'user-a',
+      onTakeoverRequested: () => true,
+    });
+    await expect(successor.acquire()).resolves.toEqual({ acquired: true, waitedForLocalRelease: false });
+
+    await closeCoordinators(first, successor);
+  });
+
+  it('keeps Web Lock ownership enforcement when BroadcastChannel is unavailable', async () => {
     vi.stubGlobal('BroadcastChannel', undefined);
     const first = createDebateRoomOwnershipCoordinator({
       debateId: 'debate-1',
@@ -192,10 +303,60 @@ describe('debate room ownership', () => {
       onTakeoverRequested: () => true,
     });
 
-    await expect(first.acquire()).resolves.toBe(true);
-    await expect(second.acquire()).resolves.toBe(true);
+    expect(first.coordinationMode).toBe('lock-only');
+    expect(second.coordinationMode).toBe('lock-only');
+    await expect(first.acquire()).resolves.toEqual({ acquired: true, waitedForLocalRelease: false });
+    await expect(second.acquire()).resolves.toEqual({ acquired: false, waitedForLocalRelease: false });
+    await expect(second.requestTakeover()).resolves.toBe(false);
 
-    first.close();
-    second.close();
+    await closeCoordinators(first, second);
+  });
+
+  it('keeps Web Lock ownership enforcement when BroadcastChannel construction fails', async () => {
+    vi.stubGlobal(
+      'BroadcastChannel',
+      class {
+        constructor() {
+          throw new Error('BroadcastChannel is blocked');
+        }
+      }
+    );
+    const first = createDebateRoomOwnershipCoordinator({
+      debateId: 'debate-1',
+      userId: 'user-a',
+      onTakeoverRequested: () => true,
+    });
+    const second = createDebateRoomOwnershipCoordinator({
+      debateId: 'debate-1',
+      userId: 'user-a',
+      onTakeoverRequested: () => true,
+    });
+
+    expect(first.coordinationMode).toBe('lock-only');
+    await expect(first.acquire()).resolves.toEqual({ acquired: true, waitedForLocalRelease: false });
+    await expect(second.acquire()).resolves.toEqual({ acquired: false, waitedForLocalRelease: false });
+
+    await closeCoordinators(first, second);
+  });
+
+  it('falls back to LiveKit identity handling when Web Locks are unavailable', async () => {
+    Object.defineProperty(navigator, 'locks', { configurable: true, value: undefined });
+    const first = createDebateRoomOwnershipCoordinator({
+      debateId: 'debate-1',
+      userId: 'user-a',
+      onTakeoverRequested: () => true,
+    });
+    const second = createDebateRoomOwnershipCoordinator({
+      debateId: 'debate-1',
+      userId: 'user-a',
+      onTakeoverRequested: () => true,
+    });
+
+    expect(first.coordinationMode).toBe('livekit-fallback');
+    expect(second.coordinationMode).toBe('livekit-fallback');
+    await expect(first.acquire()).resolves.toEqual({ acquired: true, waitedForLocalRelease: false });
+    await expect(second.acquire()).resolves.toEqual({ acquired: true, waitedForLocalRelease: false });
+
+    await closeCoordinators(first, second);
   });
 });

--- a/apps/web/core/debates/debate-room-ownership.test.ts
+++ b/apps/web/core/debates/debate-room-ownership.test.ts
@@ -339,6 +339,27 @@ describe('debate room ownership', () => {
     await closeCoordinators(first, second);
   });
 
+  it('falls back to LiveKit identity handling when a Web Lock request fails', async () => {
+    Object.defineProperty(navigator, 'locks', {
+      configurable: true,
+      value: {
+        request: vi.fn().mockRejectedValue(new Error('Web Locks are unavailable')),
+      },
+    });
+    const coordinator = createDebateRoomOwnershipCoordinator({
+      debateId: 'debate-1',
+      userId: 'user-a',
+      onTakeoverRequested: () => true,
+    });
+
+    expect(coordinator.coordinationMode).toBe('lock-and-broadcast');
+    await expect(coordinator.acquire()).resolves.toEqual({ acquired: true, waitedForLocalRelease: false });
+    expect(coordinator.coordinationMode).toBe('livekit-fallback');
+    expect(coordinator.ownsConnection()).toBe(true);
+
+    await closeCoordinators(coordinator);
+  });
+
   it('falls back to LiveKit identity handling when Web Locks are unavailable', async () => {
     Object.defineProperty(navigator, 'locks', { configurable: true, value: undefined });
     const first = createDebateRoomOwnershipCoordinator({

--- a/apps/web/core/debates/debate-room-ownership.ts
+++ b/apps/web/core/debates/debate-room-ownership.ts
@@ -56,11 +56,12 @@ export function createDebateRoomOwnershipCoordinator({
       channel = null;
     }
   }
-  const coordinationMode: DebateRoomOwnershipCoordinationMode = lockManager
+  let coordinationMode: DebateRoomOwnershipCoordinationMode = lockManager
     ? channel
       ? 'lock-and-broadcast'
       : 'lock-only'
     : 'livekit-fallback';
+  let lockRequestsAvailable = lockManager !== null;
   let ownsConnection = false;
   let closed = false;
   let releaseLock: (() => void) | null = null;
@@ -69,6 +70,13 @@ export function createDebateRoomOwnershipCoordinator({
   let acquisition: Promise<DebateRoomOwnershipAcquireResult> | null = null;
   let activeAcquisitionAttempt: { cancelled: boolean } | null = null;
   const pendingTakeovers = new Map<string, (released: boolean) => void>();
+
+  const fallBackToLiveKitIdentity = () => {
+    lockRequestsAvailable = false;
+    coordinationMode = 'livekit-fallback';
+    channel?.close();
+    channel = null;
+  };
 
   const postTakeoverResponse = (message: TakeoverRequest, released: boolean) => {
     if (!channel || closed) return;
@@ -87,11 +95,11 @@ export function createDebateRoomOwnershipCoordinator({
 
   const acquireLock = (): Promise<DebateRoomOwnershipAcquireResult> => {
     if (ownsConnection) return Promise.resolve({ acquired: true, waitedForLocalRelease: false });
-    if (!lockManager) {
+    if (closed) return Promise.resolve({ acquired: false, waitedForLocalRelease: false });
+    if (!lockManager || !lockRequestsAvailable) {
       ownsConnection = true;
       return Promise.resolve({ acquired: true, waitedForLocalRelease: false });
     }
-    if (closed) return Promise.resolve({ acquired: false, waitedForLocalRelease: false });
     if (acquisition) return acquisition;
 
     const attempt = { cancelled: false };
@@ -104,21 +112,27 @@ export function createDebateRoomOwnershipCoordinator({
       if (closed || attempt.cancelled) return { acquired: false, waitedForLocalRelease };
       if (ownsConnection) return { acquired: true, waitedForLocalRelease };
 
-      const acquired = await new Promise<boolean>(resolve => {
-        const request = lockManager.request(coordinationName, { ifAvailable: true, mode: 'exclusive' }, async lock => {
-          const acquiredLock = Boolean(lock) && !closed && !attempt.cancelled;
-          resolve(acquiredLock);
-          if (!acquiredLock) return;
-          ownsConnection = true;
-          await new Promise<void>(release => {
-            releaseLock = release;
+      const lockResult = await new Promise<'acquired' | 'blocked' | 'unavailable'>(resolve => {
+        let request: Promise<void>;
+        try {
+          request = lockManager.request(coordinationName, { ifAvailable: true, mode: 'exclusive' }, async lock => {
+            const acquiredLock = Boolean(lock) && !closed && !attempt.cancelled;
+            resolve(acquiredLock ? 'acquired' : 'blocked');
+            if (!acquiredLock) return;
+            ownsConnection = true;
+            await new Promise<void>(release => {
+              releaseLock = release;
+            });
+            releaseLock = null;
+            ownsConnection = false;
           });
-          releaseLock = null;
-          ownsConnection = false;
-        });
+        } catch {
+          resolve('unavailable');
+          return;
+        }
         const activeRequest = request.then(
           () => undefined,
-          () => resolve(false)
+          () => resolve('unavailable')
         );
         lockRequest = activeRequest;
         void activeRequest.finally(() => {
@@ -126,7 +140,14 @@ export function createDebateRoomOwnershipCoordinator({
         });
       });
 
-      return { acquired, waitedForLocalRelease };
+      if (lockResult === 'unavailable') {
+        if (closed || attempt.cancelled) return { acquired: false, waitedForLocalRelease };
+        fallBackToLiveKitIdentity();
+        ownsConnection = true;
+        return { acquired: true, waitedForLocalRelease };
+      }
+
+      return { acquired: lockResult === 'acquired', waitedForLocalRelease };
     })()
       .catch(() => ({ acquired: false, waitedForLocalRelease }))
       .finally(() => {
@@ -143,7 +164,7 @@ export function createDebateRoomOwnershipCoordinator({
       await releaseRequest;
       return;
     }
-    if (!lockManager) {
+    if (!lockManager || !lockRequestsAvailable) {
       ownsConnection = false;
       return;
     }
@@ -184,14 +205,17 @@ export function createDebateRoomOwnershipCoordinator({
 
   return {
     instanceId,
-    coordinationMode,
+    get coordinationMode() {
+      return coordinationMode;
+    },
     acquire: acquireLock,
     requestTakeover: async () => {
       if (ownsConnection) return true;
-      if (!lockManager) return (await acquireLock()).acquired;
+      if (!lockManager || !lockRequestsAvailable) return (await acquireLock()).acquired;
       if (closed) return false;
       if ((await acquireLock()).acquired) return true;
       if (!channel) return false;
+      const takeoverChannel = channel;
 
       const requestId = createInstanceId();
       const released = await new Promise<boolean>(resolve => {
@@ -205,7 +229,7 @@ export function createDebateRoomOwnershipCoordinator({
           resolve(result);
         });
         try {
-          channel.postMessage({
+          takeoverChannel.postMessage({
             type: 'takeover-request',
             requestId,
             requesterId: instanceId,

--- a/apps/web/core/debates/debate-room-ownership.ts
+++ b/apps/web/core/debates/debate-room-ownership.ts
@@ -21,14 +21,23 @@ type CreateDebateRoomOwnershipCoordinatorOptions = {
 
 export type DebateRoomOwnershipCoordinator = {
   readonly instanceId: string;
-  acquire: () => Promise<boolean>;
+  readonly coordinationMode: DebateRoomOwnershipCoordinationMode;
+  acquire: () => Promise<DebateRoomOwnershipAcquireResult>;
   requestTakeover: () => Promise<boolean>;
   release: () => Promise<void>;
   close: () => void;
   ownsConnection: () => boolean;
 };
 
+export type DebateRoomOwnershipAcquireResult = {
+  acquired: boolean;
+  waitedForLocalRelease: boolean;
+};
+
+export type DebateRoomOwnershipCoordinationMode = 'lock-and-broadcast' | 'lock-only' | 'livekit-fallback';
+
 const takeoverResponseTimeoutMs = 1_500;
+const localReleaseBarriers = new Map<string, Promise<void>>();
 
 export function createDebateRoomOwnershipCoordinator({
   debateId,
@@ -37,23 +46,28 @@ export function createDebateRoomOwnershipCoordinator({
 }: CreateDebateRoomOwnershipCoordinatorOptions): DebateRoomOwnershipCoordinator {
   const instanceId = createInstanceId();
   const coordinationName = `geo:debate-room:${debateId}:${userId}`;
-  const canCoordinate =
-    typeof navigator !== 'undefined' && Boolean(navigator.locks?.request) && typeof BroadcastChannel !== 'undefined';
+  const lockManager =
+    typeof navigator !== 'undefined' && typeof navigator.locks?.request === 'function' ? navigator.locks : null;
   let channel: BroadcastChannel | null = null;
-  if (canCoordinate) {
+  if (lockManager && typeof BroadcastChannel !== 'undefined') {
     try {
       channel = new BroadcastChannel(coordinationName);
     } catch {
       channel = null;
     }
   }
-  const supportsCoordination = channel !== null;
+  const coordinationMode: DebateRoomOwnershipCoordinationMode = lockManager
+    ? channel
+      ? 'lock-and-broadcast'
+      : 'lock-only'
+    : 'livekit-fallback';
   let ownsConnection = false;
   let closed = false;
   let releaseLock: (() => void) | null = null;
   let lockRequest: Promise<void> | null = null;
   let releaseRequest: Promise<void> | null = null;
-  let acquisition: Promise<boolean> | null = null;
+  let acquisition: Promise<DebateRoomOwnershipAcquireResult> | null = null;
+  let activeAcquisitionAttempt: { cancelled: boolean } | null = null;
   const pendingTakeovers = new Map<string, (released: boolean) => void>();
 
   const postTakeoverResponse = (message: TakeoverRequest, released: boolean) => {
@@ -71,42 +85,57 @@ export function createDebateRoomOwnershipCoordinator({
     }
   };
 
-  const acquireLock = (): Promise<boolean> => {
-    if (releaseRequest) return releaseRequest.then(acquireLock);
-    if (ownsConnection) return Promise.resolve(true);
-    if (!supportsCoordination) {
+  const acquireLock = (): Promise<DebateRoomOwnershipAcquireResult> => {
+    if (ownsConnection) return Promise.resolve({ acquired: true, waitedForLocalRelease: false });
+    if (!lockManager) {
       ownsConnection = true;
-      return Promise.resolve(true);
+      return Promise.resolve({ acquired: true, waitedForLocalRelease: false });
     }
-    if (closed) return Promise.resolve(false);
+    if (closed) return Promise.resolve({ acquired: false, waitedForLocalRelease: false });
     if (acquisition) return acquisition;
 
-    acquisition = new Promise<boolean>(resolve => {
-      const request = navigator.locks.request(
-        coordinationName,
-        { ifAvailable: true, mode: 'exclusive' },
-        async lock => {
-          resolve(Boolean(lock));
-          if (!lock || closed) return;
+    const attempt = { cancelled: false };
+    activeAcquisitionAttempt = attempt;
+    let waitedForLocalRelease = false;
+    const currentAcquisition = (async () => {
+      if (localReleaseBarriers.has(coordinationName)) {
+        waitedForLocalRelease = await waitForLocalReleaseBarriers(coordinationName, () => closed || attempt.cancelled);
+      }
+      if (closed || attempt.cancelled) return { acquired: false, waitedForLocalRelease };
+      if (ownsConnection) return { acquired: true, waitedForLocalRelease };
+
+      const acquired = await new Promise<boolean>(resolve => {
+        const request = lockManager.request(coordinationName, { ifAvailable: true, mode: 'exclusive' }, async lock => {
+          const acquiredLock = Boolean(lock) && !closed && !attempt.cancelled;
+          resolve(acquiredLock);
+          if (!acquiredLock) return;
           ownsConnection = true;
           await new Promise<void>(release => {
             releaseLock = release;
           });
           releaseLock = null;
           ownsConnection = false;
-        }
-      );
-      lockRequest = request.then(
-        () => undefined,
-        () => resolve(false)
-      );
-    })
-      .catch(() => false)
-      .finally(() => {
-        acquisition = null;
+        });
+        const activeRequest = request.then(
+          () => undefined,
+          () => resolve(false)
+        );
+        lockRequest = activeRequest;
+        void activeRequest.finally(() => {
+          if (lockRequest === activeRequest) lockRequest = null;
+        });
       });
 
-    return acquisition;
+      return { acquired, waitedForLocalRelease };
+    })()
+      .catch(() => ({ acquired: false, waitedForLocalRelease }))
+      .finally(() => {
+        if (acquisition === currentAcquisition) acquisition = null;
+        if (activeAcquisitionAttempt === attempt) activeAcquisitionAttempt = null;
+      });
+
+    acquisition = currentAcquisition;
+    return currentAcquisition;
   };
 
   const release = async () => {
@@ -114,21 +143,21 @@ export function createDebateRoomOwnershipCoordinator({
       await releaseRequest;
       return;
     }
-    if (!supportsCoordination) {
+    if (!lockManager) {
       ownsConnection = false;
       return;
     }
-    if (!releaseLock) return;
-    const activeRequest = lockRequest;
-    const releaseCurrentLock = releaseLock;
+    const activeRequest = lockRequest ?? acquisition?.then(() => undefined);
+    if (!activeRequest) return;
+    if (activeAcquisitionAttempt) activeAcquisitionAttempt.cancelled = true;
     ownsConnection = false;
-    releaseCurrentLock();
-    const request = activeRequest ?? Promise.resolve();
-    const completion = request.finally(() => {
-      if (releaseRequest === completion) releaseRequest = null;
+    releaseLock?.();
+    const barrier = registerLocalReleaseBarrier(coordinationName, activeRequest);
+    releaseRequest = barrier;
+    void barrier.finally(() => {
+      if (releaseRequest === barrier) releaseRequest = null;
     });
-    releaseRequest = completion;
-    await releaseRequest;
+    await barrier;
   };
 
   if (channel) {
@@ -155,12 +184,14 @@ export function createDebateRoomOwnershipCoordinator({
 
   return {
     instanceId,
+    coordinationMode,
     acquire: acquireLock,
     requestTakeover: async () => {
       if (ownsConnection) return true;
-      if (!supportsCoordination) return acquireLock();
-      if (!channel || closed) return false;
-      if (await acquireLock()) return true;
+      if (!lockManager) return (await acquireLock()).acquired;
+      if (closed) return false;
+      if ((await acquireLock()).acquired) return true;
+      if (!channel) return false;
 
       const requestId = createInstanceId();
       const released = await new Promise<boolean>(resolve => {
@@ -186,7 +217,7 @@ export function createDebateRoomOwnershipCoordinator({
         }
       });
       if (!released) return false;
-      return acquireLock();
+      return (await acquireLock()).acquired;
     },
     release,
     close: () => {
@@ -198,6 +229,27 @@ export function createDebateRoomOwnershipCoordinator({
     },
     ownsConnection: () => ownsConnection,
   };
+}
+
+function registerLocalReleaseBarrier(coordinationName: string, activeRequest: Promise<void>) {
+  const barrier = activeRequest
+    .catch(() => undefined)
+    .finally(() => {
+      if (localReleaseBarriers.get(coordinationName) === barrier) localReleaseBarriers.delete(coordinationName);
+    });
+  localReleaseBarriers.set(coordinationName, barrier);
+  return barrier;
+}
+
+async function waitForLocalReleaseBarriers(coordinationName: string, cancelled: () => boolean) {
+  let waited = false;
+  let barrier = localReleaseBarriers.get(coordinationName);
+  while (barrier && !cancelled()) {
+    waited = true;
+    await barrier;
+    barrier = localReleaseBarriers.get(coordinationName);
+  }
+  return waited;
 }
 
 function createInstanceId() {


### PR DESCRIPTION
## Summary

Debate tabs no longer mistake a same-tab remount or a failed Web Lock request for another active tab. A same-realm release barrier now drains the predecessor's complete lock request before a successor probes ownership. Genuine competing tabs remain blocked before token creation.

Web Locks and BroadcastChannel are now independent capabilities. Browsers without BroadcastChannel retain single-owner enforcement, while browsers where locking is unavailable at runtime fall back to LiveKit duplicate-identity handling.

Conflict handling now records whether the source was a blocked Web Lock, released ownership, or a LiveKit duplicate identity. Successful recovery after waiting for a same-tab release emits a separate event without showing the conflict screen.

## Design decisions

- Keep the release barrier module-scoped and keyed by debate and user so only a successor in the same browser realm waits on it.
- Preserve the existing takeover flow before recording and the centered safety screen once recording may have started.
- Keep backend identity and recording policy unchanged.
- Treat a rejected Web Lock request as capability failure, not evidence of another owner, and degrade to the existing LiveKit safety net.

## Validation

- Reproduced the original race with a deterministic immediate-successor test that failed before the fix and passed afterward.
- Covered close-during-acquisition, chained remount cleanup, repeated release, lock-only browsers, runtime lock failure, LiveKit fallback, genuine conflicts, Strict Mode, and analytics provenance.
- `bun run test -- core/debates`: 29 files, 357 tests passed.
- Debate room page suite: 110 tests passed.
- TypeScript, ESLint, Prettier, and diff checks passed.
- The local app started successfully, but the authenticated two-tab LiveKit walkthrough was not run because no seeded debate was available.

## Related

Related: #2106
