### PR TITLE
chore(deps): bump @geoprotocol/geo-sdk 0.20.1 -> 0.20.3

### DIFF
--- a/apps/web/core/utils/contracts/governance.test.ts
+++ b/apps/web/core/utils/contracts/governance.test.ts
@@ -28,7 +28,7 @@ const DAO_ADDRESS = '0x1111111111111111111111111111111111111111';
 
 describe('encodeProposalCreatedData', () => {
   // Subspace and DAO-topic proposals are the only two write paths with no SDK helper
-  // (geo-sdk 0.20.1 exposes daoSpaces.create/proposeEdit/propose*/voteProposal/
+  // (geo-sdk 0.20.3 exposes daoSpaces.create/proposeEdit/propose*/voteProposal/
   // executeProposal and nothing for subspaces or topics), so we hand-roll their
   // calldata. This test is what keeps the hand-rolled copy aligned with the SDK.
   it('agrees with the action tuple the SDK itself encodes', () => {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -25,7 +25,7 @@
     "@effect/opentelemetry": "^0.63.0",
     "@floating-ui/dom": "^1.7.5",
     "@geogenesis/auth": "workspace:*",
-    "@geoprotocol/geo-sdk": "0.20.1",
+    "@geoprotocol/geo-sdk": "0.20.3",
     "@geoprotocol/grc-20": "^0.4.1",
     "@graphql-typed-document-node/core": "^3.2.0",
     "@livekit/components-react": "^2.9.21",

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "geogenesis",
       "dependencies": {
-        "@geoprotocol/geo-sdk": "0.20.1",
+        "@geoprotocol/geo-sdk": "0.20.3",
       },
       "devDependencies": {
         "@graphql-codegen/client-preset": "^6.0.1",
@@ -31,7 +31,7 @@
         "@effect/opentelemetry": "^0.63.0",
         "@floating-ui/dom": "^1.7.5",
         "@geogenesis/auth": "workspace:*",
-        "@geoprotocol/geo-sdk": "0.20.1",
+        "@geoprotocol/geo-sdk": "0.20.3",
         "@geoprotocol/grc-20": "^0.4.1",
         "@graphql-typed-document-node/core": "^3.2.0",
         "@livekit/components-react": "^2.9.21",
@@ -163,7 +163,7 @@
       "name": "@geogenesis/auth",
       "version": "1.0.0",
       "dependencies": {
-        "@geoprotocol/geo-sdk": "0.20.1",
+        "@geoprotocol/geo-sdk": "0.20.3",
         "@privy-io/react-auth": "^3.21.0",
         "@privy-io/wagmi": "^4.0.4",
         "@rhinestone/module-sdk": "^0.4.0",
@@ -419,7 +419,7 @@
 
     "@geogenesis/auth": ["@geogenesis/auth@workspace:packages/auth"],
 
-    "@geoprotocol/geo-sdk": ["@geoprotocol/geo-sdk@0.20.1", "", { "dependencies": { "@geoprotocol/grc-20": "^0.4.1", "@zerodev/sdk": "^5.5.10", "effect": "^3.17.13", "fflate": "^0.8.2", "fractional-indexing-jittered": "^1.0.0", "image-size": "^2.0.2", "uuid": "^13.0.0", "viem": "^2.37.6" } }, "sha512-n6L+i7XVELDqo5eQ+Ne3vWBi4mBaXYwUHl10vR4OYSCCMO/K811k17Qxf6D0qCYPeb3cvkkxegxEyGI9jpIZ6g=="],
+    "@geoprotocol/geo-sdk": ["@geoprotocol/geo-sdk@0.20.3", "", { "dependencies": { "@geoprotocol/grc-20": "^0.4.1", "@zerodev/sdk": "^5.5.10", "effect": "^3.17.13", "fflate": "^0.8.2", "fractional-indexing-jittered": "^1.0.0", "image-size": "^2.0.2", "uuid": "^13.0.0", "viem": "^2.37.6" } }, "sha512-vkMmVPZBp+LiHtOoeiC35WsAzu6arLvcU0a4UG1yEZ+sWaoBWS8HPxWZceRZRNsUzzIaDOy4Ae09i/z5qvdv1A=="],
 
     "@geoprotocol/grc-20": ["@geoprotocol/grc-20@0.4.1", "", { "dependencies": { "@bokuweb/zstd-wasm": "^0.0.27" } }, "sha512-J5trJZBydDOO5GsEMzy9ukX9GetblBMLnn4ugpTFOcwS4akA54Lxg/uYJbXUDh5EVPir3PAzC6UN6EiBz0K/Ww=="],
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "clean-node-modules": "rimraf --glob \"**/node_modules\""
   },
   "dependencies": {
-    "@geoprotocol/geo-sdk": "0.20.1"
+    "@geoprotocol/geo-sdk": "0.20.3"
   },
   "devDependencies": {
     "@graphql-codegen/client-preset": "^6.0.1",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -22,7 +22,7 @@
     "test": "vitest"
   },
   "dependencies": {
-    "@geoprotocol/geo-sdk": "0.20.1",
+    "@geoprotocol/geo-sdk": "0.20.3",
     "@privy-io/react-auth": "^3.21.0",
     "@privy-io/wagmi": "^4.0.4",
     "@rhinestone/module-sdk": "^0.4.0",


### PR DESCRIPTION
Bumps `@geoprotocol/geo-sdk` from 0.20.1 to 0.20.3 to pick up the `responses` client namespace — the client half of the new vote kinds.

## What 0.20.3 adds

`geo.responses` exposes all nine permissionless response actions:

| kind | actions |
|---|---|
| curation | `upvote` `downvote` `unvote` |
| stance | `agree` `disagree` `unagree` |
| veracity | `verify` `dispute` `unverify` |

The storage layer for these landed in gaia #872, and the six new action hashes are registered on chain 55516.

## Scope

**Bump only — no call sites change.** `geo.entityVotes` is deprecated in 0.20.3 but still exported, so the shipped vote controls in `core/hooks/use-entity-vote.ts` keep working untouched.

The SDK is declared in **three** manifests (root, `apps/web`, `packages/auth`). Bumping one alone leaves the others resolving 0.20.1 via hoisting — two copies of the SDK in one build. All three move together here and now share a single physical copy in the bun store.

## Verification

Checked against the registry rather than the changelog, because **an unregistered action does not revert — it silently does nothing.** A spelling drift between the SDK and the on-chain registry would not surface at call time.

- The nine `PERMISSIONLESS.*` strings the SDK hardcodes hash to exactly the action IDs registered on chain (`UNAGREED` and `UNVERIFIED` spot-checked against their on-chain values) and match `ActionsConstants.sol`.
- Embedded config still targets chain **55516** and space registry **`0xCF13491802747e759e1BB8E364bc43045398d1DD`**. The old 19411 registry appears nowhere in the package — worth stating explicitly, since a frontend on the old registry is what produced the "create a new account" login bug.

Gates, run locally under the CI environment: build ✓, test ✓ (1996 passed / 193 files), lint ✓ (0 errors; 93 pre-existing warnings).

## Follow-ups (not in this PR)

1. **Migrate `use-entity-vote.ts` to `geo.responses`.** Params shape is identical (`{authorSpaceId, spaceId, entityId}`), so it is a per-call rename.
2. **`entityVoteCountQuery` needs a `voteKind` filter before anyone casts a non-curation response** — without it, reads sum across kinds and inflate scores.
3. **`mainnet-migration-v020` is still on `0.20.0-beta.10`** and will need the same bump when it rebases, or it reintroduces the older SDK.