### PR TITLE
Rename ungrouped properties to Other properties

### DIFF
--- a/apps/web/partials/entity-page/editable-entity-page.tsx
+++ b/apps/web/partials/entity-page/editable-entity-page.tsx
@@ -1373,7 +1373,7 @@ function useVisiblePropertySections(
         id: 'ungrouped',
         isGroup: true,
         groupId: 'ungrouped',
-        label: 'Ungrouped properties',
+        label: 'Other properties',
         defaultCollapsed: false,
         collapsible: false,
         entries: ungroupedEntries,

--- a/apps/web/partials/entity-page/readable-entity-page.tsx
+++ b/apps/web/partials/entity-page/readable-entity-page.tsx
@@ -243,7 +243,7 @@ export function ReadableEntityProperties({ id: entityId, spaceId }: Props) {
         <div className="flex flex-col gap-2">
           {groupedSections.hasGroups && (
             <Text as="p" variant="metadata" className="leading-[13px] tracking-[-0.35px] text-grey-04">
-              Ungrouped properties
+              Other properties
             </Text>
           )}
           <div className="flex flex-col gap-6">

--- a/apps/web/partials/entity-page/type-property-groups-editor.tsx
+++ b/apps/web/partials/entity-page/type-property-groups-editor.tsx
@@ -917,7 +917,7 @@ function UngroupedDropContainer({
     <div className={cx(hasGroupsAbove && 'border-t border-grey-02', 'px-4 py-3')}>
       {hasGroupsAbove && (
         <Text as="p" variant="metadata" className="leading-[13px] tracking-[-0.35px] text-grey-04">
-          Ungrouped properties
+          Other properties
         </Text>
       )}
       <div

--- a/apps/web/partials/entity-page/type-schema-inline.tsx
+++ b/apps/web/partials/entity-page/type-schema-inline.tsx
@@ -172,7 +172,7 @@ function TypeSchemaReadView({ entityId, spaceId }: Props) {
           <div className="flex flex-col gap-2">
             {sections.groups.length > 0 && (
               <Text as="p" variant="metadata" className="leading-[13px] tracking-[-0.35px] text-grey-04">
-                Ungrouped properties
+                Other properties
               </Text>
             )}
             <div className="flex flex-wrap gap-2">


### PR DESCRIPTION
## Summary

- rename the user-facing **Ungrouped properties** label to **Other properties**
- apply the copy consistently across editable entity properties, readable entity properties, inline type schemas, and the property-group editor
- retain internal `ungrouped` identifiers and data-model terminology

## User impact

Properties without an assigned group now appear under the friendlier **Other properties** heading everywhere property groups are displayed or edited.

## Validation

- `bun x tsc --noEmit --pretty false`
- targeted ESLint across the four changed files (no errors; three pre-existing warnings in `editable-entity-page.tsx`)
- verified no rendered `Ungrouped properties` labels remain under `apps/web`
- `git diff --check`
