### PR TITLE
Hide Other properties when no groups are visible

### DIFF
--- a/apps/web/partials/entity-page/readable-entity-page.tsx
+++ b/apps/web/partials/entity-page/readable-entity-page.tsx
@@ -176,7 +176,7 @@ export function ReadableEntityProperties({ id: entityId, spaceId }: Props) {
     }
 
     return {
-      hasGroups: true,
+      hasGroups: groups.length > 0,
       groups,
       ungrouped: orderedUngrouped,
     };


### PR DESCRIPTION
## Summary

- hide the **Other properties** heading when an entity has no visible named property groups
- keep the heading when it distinguishes ungrouped properties from at least one rendered group

## Root cause

The readable entity view filtered empty or non-renderable property groups out of its `groups` list, but retained a separate schema-level `hasGroups: true` flag. As a result, the **Other properties** heading could render even when no named group was actually displayed.

## User impact

Entities such as the referenced claim no longer show a redundant **Other properties** heading when all rendered fields are ungrouped.

## Validation

- `bun x tsc --noEmit --pretty false`
- `bun x eslint partials/entity-page/readable-entity-page.tsx`
- `git diff --check`
