### PR TITLE
Tighten vote action spacing

### DIFF
--- a/apps/web/partials/blocks/table/ranking-entry-row.test.tsx
+++ b/apps/web/partials/blocks/table/ranking-entry-row.test.tsx
@@ -39,11 +39,11 @@ describe('RankingEntryRow', () => {
     expect(markup).not.toContain('data-vote-actions');
   });
 
-  it('keeps actions exactly 8px below the final text row', () => {
+  it('keeps actions exactly 6px below the final text row', () => {
     render(<RankingEntryRow entry={entry} spaceId="space-1" actions={<div data-testid="row-actions" />} />);
 
     const actions = screen.getByTestId('row-actions').parentElement;
-    expect(actions?.className).toContain('mt-1');
+    expect(actions?.className).toContain('mt-0.5');
     expect(actions?.parentElement?.className).toContain('gap-1');
   });
 

--- a/apps/web/partials/blocks/table/ranking-entry-row.test.tsx
+++ b/apps/web/partials/blocks/table/ranking-entry-row.test.tsx
@@ -39,11 +39,11 @@ describe('RankingEntryRow', () => {
     expect(markup).not.toContain('data-vote-actions');
   });
 
-  it('keeps actions exactly 6px below the final text row', () => {
+  it('keeps actions exactly 4px below the final text row', () => {
     render(<RankingEntryRow entry={entry} spaceId="space-1" actions={<div data-testid="row-actions" />} />);
 
     const actions = screen.getByTestId('row-actions').parentElement;
-    expect(actions?.className).toContain('mt-0.5');
+    expect(actions?.className).toContain('mt-0');
     expect(actions?.parentElement?.className).toContain('gap-1');
   });
 

--- a/apps/web/partials/blocks/table/ranking-entry-row.tsx
+++ b/apps/web/partials/blocks/table/ranking-entry-row.tsx
@@ -37,7 +37,7 @@ export function RankingEntryRowSkeleton({
       <div className="flex min-h-16 min-w-0 flex-1 flex-col justify-center gap-2">
         <Skeleton className="h-4 w-1/3" />
         <Skeleton className="h-3 w-3/5" />
-        {reserveVoteControls ? <Skeleton className="-mt-0.5 h-5 w-16 shrink-0 rounded" /> : null}
+        {reserveVoteControls ? <Skeleton className="-mt-1 h-5 w-16 shrink-0 rounded" /> : null}
       </div>
     </div>
   );
@@ -56,7 +56,7 @@ type Props = {
   linkToEntity?: boolean;
   /** `leading` = rank column left of avatar; `avatar-badge` = overlapping corner badge (default). */
   rankStyle?: 'leading' | 'avatar-badge';
-  /** Actions rendered exactly 6px below the final text row. */
+  /** Actions rendered exactly 4px below the final text row. */
   actions?: ReactNode;
   /** Show entity vote controls (including claim variants) below the item content. */
   showVotes?: boolean;
@@ -128,7 +128,7 @@ export function RankingEntryRow({
         ) : null}
         {pending ? <p className="text-[12px] leading-[16px] font-medium text-grey-04">Pending approval</p> : null}
         {rowActions ? (
-          <div className="mt-0.5" onClick={event => event.stopPropagation()}>
+          <div className="mt-0" onClick={event => event.stopPropagation()}>
             {rowActions}
           </div>
         ) : null}

--- a/apps/web/partials/blocks/table/ranking-entry-row.tsx
+++ b/apps/web/partials/blocks/table/ranking-entry-row.tsx
@@ -37,7 +37,7 @@ export function RankingEntryRowSkeleton({
       <div className="flex min-h-16 min-w-0 flex-1 flex-col justify-center gap-2">
         <Skeleton className="h-4 w-1/3" />
         <Skeleton className="h-3 w-3/5" />
-        {reserveVoteControls ? <Skeleton className="h-5 w-16 shrink-0 rounded" /> : null}
+        {reserveVoteControls ? <Skeleton className="-mt-0.5 h-5 w-16 shrink-0 rounded" /> : null}
       </div>
     </div>
   );
@@ -56,7 +56,7 @@ type Props = {
   linkToEntity?: boolean;
   /** `leading` = rank column left of avatar; `avatar-badge` = overlapping corner badge (default). */
   rankStyle?: 'leading' | 'avatar-badge';
-  /** Actions rendered exactly 8px below the final text row. */
+  /** Actions rendered exactly 6px below the final text row. */
   actions?: ReactNode;
   /** Show entity vote controls (including claim variants) below the item content. */
   showVotes?: boolean;
@@ -128,7 +128,7 @@ export function RankingEntryRow({
         ) : null}
         {pending ? <p className="text-[12px] leading-[16px] font-medium text-grey-04">Pending approval</p> : null}
         {rowActions ? (
-          <div className="mt-1" onClick={event => event.stopPropagation()}>
+          <div className="mt-0.5" onClick={event => event.stopPropagation()}>
             {rowActions}
           </div>
         ) : null}

--- a/apps/web/partials/blocks/table/ranking-gallery-view.tsx
+++ b/apps/web/partials/blocks/table/ranking-gallery-view.tsx
@@ -75,7 +75,7 @@ function RankingGalleryCard({
         <p className="line-clamp-2 text-[19px] leading-[1.3] font-medium text-text">{name}</p>
       </Link>
       <div
-        className="mt-2 flex h-5 items-center"
+        className="mt-[6px] flex h-5 items-center"
         onPointerDown={event => event.stopPropagation()}
         onClick={event => event.stopPropagation()}
       >
@@ -90,7 +90,7 @@ function RankingGalleryCardSkeleton({ keyId }: { keyId: string }) {
     <div key={keyId} className="w-[240px] shrink-0">
       <Skeleton className="h-[120px] w-[240px] rounded-xl" />
       <Skeleton className="mt-2 h-6 w-[180px]" />
-      <Skeleton className="mt-2 h-5 w-16" />
+      <Skeleton className="mt-[6px] h-5 w-16" />
     </div>
   );
 }

--- a/apps/web/partials/blocks/table/ranking-gallery-view.tsx
+++ b/apps/web/partials/blocks/table/ranking-gallery-view.tsx
@@ -75,7 +75,7 @@ function RankingGalleryCard({
         <p className="line-clamp-2 text-[19px] leading-[1.3] font-medium text-text">{name}</p>
       </Link>
       <div
-        className="mt-[6px] flex h-5 items-center"
+        className="mt-1 flex h-5 items-center"
         onPointerDown={event => event.stopPropagation()}
         onClick={event => event.stopPropagation()}
       >
@@ -90,7 +90,7 @@ function RankingGalleryCardSkeleton({ keyId }: { keyId: string }) {
     <div key={keyId} className="w-[240px] shrink-0">
       <Skeleton className="h-[120px] w-[240px] rounded-xl" />
       <Skeleton className="mt-2 h-6 w-[180px]" />
-      <Skeleton className="mt-[6px] h-5 w-16" />
+      <Skeleton className="mt-1 h-5 w-16" />
     </div>
   );
 }

--- a/apps/web/partials/blocks/table/ranking-list-view.tsx
+++ b/apps/web/partials/blocks/table/ranking-list-view.tsx
@@ -23,7 +23,7 @@ const ROW_RANK_CLASS =
 
 function RankingListRowSkeleton({ rank }: { rank: number }) {
   return (
-    <div className="flex w-full min-w-0 flex-col gap-2">
+    <div className="flex w-full min-w-0 flex-col gap-[6px]">
       <div className={ROW_CLASS}>
         <span className={ROW_RANK_CLASS}>{rank}</span>
         <div className="min-w-0 flex-1">
@@ -47,7 +47,7 @@ function RankingListRow({ rank, entityId, spaceId, voteSpaceId, name }: ListRowP
   const href = NavUtils.toEntity(spaceId, entityId);
 
   return (
-    <div className="flex w-full min-w-0 flex-col gap-2">
+    <div className="flex w-full min-w-0 flex-col gap-[6px]">
       <div className={ROW_CLASS}>
         <span className={ROW_RANK_CLASS}>{rank}</span>
         <Link href={href} className={cx(ROW_NAME_CLASS, 'min-w-0 flex-1 hover:underline')} title={name}>

--- a/apps/web/partials/blocks/table/ranking-list-view.tsx
+++ b/apps/web/partials/blocks/table/ranking-list-view.tsx
@@ -23,7 +23,7 @@ const ROW_RANK_CLASS =
 
 function RankingListRowSkeleton({ rank }: { rank: number }) {
   return (
-    <div className="flex w-full min-w-0 flex-col gap-[6px]">
+    <div className="flex w-full min-w-0 flex-col gap-1">
       <div className={ROW_CLASS}>
         <span className={ROW_RANK_CLASS}>{rank}</span>
         <div className="min-w-0 flex-1">
@@ -47,7 +47,7 @@ function RankingListRow({ rank, entityId, spaceId, voteSpaceId, name }: ListRowP
   const href = NavUtils.toEntity(spaceId, entityId);
 
   return (
-    <div className="flex w-full min-w-0 flex-col gap-[6px]">
+    <div className="flex w-full min-w-0 flex-col gap-1">
       <div className={ROW_CLASS}>
         <span className={ROW_RANK_CLASS}>{rank}</span>
         <Link href={href} className={cx(ROW_NAME_CLASS, 'min-w-0 flex-1 hover:underline')} title={name}>

--- a/apps/web/partials/blocks/table/ranking-list-view.tsx
+++ b/apps/web/partials/blocks/table/ranking-list-view.tsx
@@ -20,10 +20,13 @@ const ROW_NAME_CLASS = 'block text-[16px] leading-[20px] font-normal tracking-[-
 const ROW_CLASS = 'flex w-full min-w-0 items-start gap-3';
 const ROW_RANK_CLASS =
   'w-5 shrink-0 text-center text-[16px] leading-[20px] font-normal tracking-[-0.35px] text-grey-04 tabular-nums';
+// The compact 20px ranking line box needs 2px of optical compensation to match
+// the visible 4px content-to-actions spacing of the 29px data-block body text.
+const ROW_ACTIONS_GAP_CLASS = 'gap-[6px]';
 
 function RankingListRowSkeleton({ rank }: { rank: number }) {
   return (
-    <div className="flex w-full min-w-0 flex-col gap-1">
+    <div className={cx('flex w-full min-w-0 flex-col', ROW_ACTIONS_GAP_CLASS)}>
       <div className={ROW_CLASS}>
         <span className={ROW_RANK_CLASS}>{rank}</span>
         <div className="min-w-0 flex-1">
@@ -47,7 +50,7 @@ function RankingListRow({ rank, entityId, spaceId, voteSpaceId, name }: ListRowP
   const href = NavUtils.toEntity(spaceId, entityId);
 
   return (
-    <div className="flex w-full min-w-0 flex-col gap-1">
+    <div className={cx('flex w-full min-w-0 flex-col', ROW_ACTIONS_GAP_CLASS)}>
       <div className={ROW_CLASS}>
         <span className={ROW_RANK_CLASS}>{rank}</span>
         <Link href={href} className={cx(ROW_NAME_CLASS, 'min-w-0 flex-1 hover:underline')} title={name}>

--- a/apps/web/partials/blocks/table/table-block-bulleted-list-item.tsx
+++ b/apps/web/partials/blocks/table/table-block-bulleted-list-item.tsx
@@ -149,7 +149,7 @@ export function TableBlockBulletedListItem({
             </Link>
           </CollectionMetadata>
         )}
-        <EntityRowActions entityId={rowEntityId} spaceId={currentSpaceId} className="mt-2" />
+        <EntityRowActions entityId={rowEntityId} spaceId={currentSpaceId} className="mt-[6px]" />
       </div>
       <div className="flex h-[1.8125rem] shrink-0 items-center gap-1 md:hidden">
         {!isPlaceholder && source.type !== 'COLLECTION' && (

--- a/apps/web/partials/blocks/table/table-block-bulleted-list-item.tsx
+++ b/apps/web/partials/blocks/table/table-block-bulleted-list-item.tsx
@@ -149,7 +149,7 @@ export function TableBlockBulletedListItem({
             </Link>
           </CollectionMetadata>
         )}
-        <EntityRowActions entityId={rowEntityId} spaceId={currentSpaceId} className="mt-[6px]" />
+        <EntityRowActions entityId={rowEntityId} spaceId={currentSpaceId} className="mt-1" />
       </div>
       <div className="flex h-[1.8125rem] shrink-0 items-center gap-1 md:hidden">
         {!isPlaceholder && source.type !== 'COLLECTION' && (

--- a/apps/web/partials/blocks/table/table-block-gallery-item.tsx
+++ b/apps/web/partials/blocks/table/table-block-gallery-item.tsx
@@ -352,7 +352,7 @@ export function TableBlockGalleryItem({
             </div>
           );
         })}
-        <div className="mt-2 flex items-center justify-between gap-2">
+        <div className="mt-[6px] flex items-center justify-between gap-2">
           <EntityRowActions entityId={rowEntityId} spaceId={currentSpaceId} />
           {!isPlaceholder && (
             <div className="invisible flex items-center opacity-0 transition duration-200 group-focus-within:visible group-focus-within:opacity-100 group-hover:visible group-hover:opacity-100 md:hidden [&_button]:h-5 [&_button]:w-5">

--- a/apps/web/partials/blocks/table/table-block-gallery-item.tsx
+++ b/apps/web/partials/blocks/table/table-block-gallery-item.tsx
@@ -352,7 +352,7 @@ export function TableBlockGalleryItem({
             </div>
           );
         })}
-        <div className="mt-[6px] flex items-center justify-between gap-2">
+        <div className="mt-1 flex items-center justify-between gap-2">
           <EntityRowActions entityId={rowEntityId} spaceId={currentSpaceId} />
           {!isPlaceholder && (
             <div className="invisible flex items-center opacity-0 transition duration-200 group-focus-within:visible group-focus-within:opacity-100 group-hover:visible group-hover:opacity-100 md:hidden [&_button]:h-5 [&_button]:w-5">

--- a/apps/web/partials/blocks/table/table-block-list-item.tsx
+++ b/apps/web/partials/blocks/table/table-block-list-item.tsx
@@ -343,7 +343,7 @@ export function TableBlockListItem({
               </div>
             );
           })}
-          <div className="mt-2 flex items-center justify-between gap-2">
+          <div className="mt-[6px] flex items-center justify-between gap-2">
             <EntityRowActions entityId={rowEntityId} spaceId={currentSpaceId} />
             {!isPlaceholder && (
               <div className="invisible flex items-center opacity-0 transition duration-200 group-focus-within:visible group-focus-within:opacity-100 group-hover:visible group-hover:opacity-100 md:hidden [&_button]:h-5 [&_button]:w-5">

--- a/apps/web/partials/blocks/table/table-block-list-item.tsx
+++ b/apps/web/partials/blocks/table/table-block-list-item.tsx
@@ -343,7 +343,7 @@ export function TableBlockListItem({
               </div>
             );
           })}
-          <div className="mt-[6px] flex items-center justify-between gap-2">
+          <div className="mt-1 flex items-center justify-between gap-2">
             <EntityRowActions entityId={rowEntityId} spaceId={currentSpaceId} />
             {!isPlaceholder && (
               <div className="invisible flex items-center opacity-0 transition duration-200 group-focus-within:visible group-focus-within:opacity-100 group-hover:visible group-hover:opacity-100 md:hidden [&_button]:h-5 [&_button]:w-5">

--- a/apps/web/partials/explore/explore-feed-card.test.tsx
+++ b/apps/web/partials/explore/explore-feed-card.test.tsx
@@ -44,11 +44,11 @@ const item: ExploreFeedItem = {
 };
 
 describe('ExploreFeedCard', () => {
-  it('keeps actions 6px below text even when the card has an image', () => {
+  it('keeps actions 4px below text even when the card has an image', () => {
     render(<ExploreFeedCard item={item} />);
 
     const actions = screen.getByTestId('row-actions');
-    expect(actions.className).toContain('mt-[6px]');
+    expect(actions.className).toContain('mt-1');
     expect(actions.parentElement?.contains(screen.getByText('A claim'))).toBe(true);
     expect(actions.parentElement?.parentElement?.contains(screen.getByTestId('image'))).toBe(true);
   });

--- a/apps/web/partials/explore/explore-feed-card.test.tsx
+++ b/apps/web/partials/explore/explore-feed-card.test.tsx
@@ -44,11 +44,11 @@ const item: ExploreFeedItem = {
 };
 
 describe('ExploreFeedCard', () => {
-  it('keeps actions 8px below text even when the card has an image', () => {
+  it('keeps actions 6px below text even when the card has an image', () => {
     render(<ExploreFeedCard item={item} />);
 
     const actions = screen.getByTestId('row-actions');
-    expect(actions.className).toContain('mt-2');
+    expect(actions.className).toContain('mt-[6px]');
     expect(actions.parentElement?.contains(screen.getByText('A claim'))).toBe(true);
     expect(actions.parentElement?.parentElement?.contains(screen.getByTestId('image'))).toBe(true);
   });

--- a/apps/web/partials/explore/explore-feed-card.tsx
+++ b/apps/web/partials/explore/explore-feed-card.tsx
@@ -104,7 +104,7 @@ export function ExploreFeedCard({ item, hideSpaceLink = false, hideJoinButton = 
               {item.description}
             </p>
           ) : null}
-          <EntityRowActions entityId={item.entityId} spaceId={item.spaceId} className="mt-2">
+          <EntityRowActions entityId={item.entityId} spaceId={item.spaceId} className="mt-[6px]">
             <Link
               href={entityHref}
               className="inline-flex items-center gap-1.5 text-grey-04 transition-colors hover:text-text"

--- a/apps/web/partials/explore/explore-feed-card.tsx
+++ b/apps/web/partials/explore/explore-feed-card.tsx
@@ -104,7 +104,7 @@ export function ExploreFeedCard({ item, hideSpaceLink = false, hideJoinButton = 
               {item.description}
             </p>
           ) : null}
-          <EntityRowActions entityId={item.entityId} spaceId={item.spaceId} className="mt-[6px]">
+          <EntityRowActions entityId={item.entityId} spaceId={item.spaceId} className="mt-1">
             <Link
               href={entityHref}
               className="inline-flex items-center gap-1.5 text-grey-04 transition-colors hover:text-text"

--- a/apps/web/partials/space-page/subtopic-gallery.tsx
+++ b/apps/web/partials/space-page/subtopic-gallery.tsx
@@ -60,7 +60,7 @@ export function SubtopicGallery({ spaceId, subtopics }: SubtopicGalleryProps) {
                     <div className="text-smallTitle font-medium text-text">{subtopic.name}</div>
                   </Link>
                 </div>
-                <div className="mt-2 flex items-center justify-between gap-2">
+                <div className="mt-1 flex items-center justify-between gap-2">
                   <EntityVoteButtons entityId={subtopic.id} spaceId={spaceId} />
                 </div>
               </div>


### PR DESCRIPTION
## Summary

- reduce the visible vertical gap between entity content and vote actions
- apply 4px spacing across Explore, data-block bulleted/list/gallery views, ranking entry/gallery views, and Subspaces cards
- optically compensate the compact ranking bulleted-list typography so it visually matches the data-block bulleted list
- keep loading placeholders aligned with their corresponding rows

## Impact

Vote controls sit closer to the content they belong to and remain visually consistent across the supported block and feed layouts.

## Validation

- `bun run test partials/blocks/table/ranking-entry-row.test.tsx partials/blocks/table/ranking-list-view.test.tsx partials/blocks/table/ranking-gallery-pill-votes.test.tsx partials/explore/explore-feed-card.test.tsx partials/entity-page/entity-row-actions.test.tsx`
- ESLint on all affected files
- `bunx tsc --noEmit`
- `git diff --check`