### PR TITLE
Hide the default space Claims and Debates tabs

### DIFF
--- a/apps/web/core/state/feature-flags.ts
+++ b/apps/web/core/state/feature-flags.ts
@@ -9,7 +9,7 @@ export const featureFlagDefinitions = [
   {
     id: 'questionsTab',
     label: 'Claims and debates',
-    description: 'Show the Claims and Debates tabs on spaces.',
+    description: 'Show the Claims tab and enable debate features on spaces.',
   },
   {
     id: 'debateDebugging',
@@ -65,7 +65,7 @@ export function useFeatureFlag(id: FeatureFlagId) {
 }
 
 /**
- * The Debates feature — the space Claims/Debates tabs, the debate room, the
+ * The Debates feature — the space Claims tab, the debate room, the
  * claim debate button, and the match coordinator — all gate on the single
  * `questionsTab` flag. Use this hook everywhere that renders claim/debate UI
  * instead of inlining the flag id, so every surface flips together.

--- a/apps/web/core/state/feature-flags.ts
+++ b/apps/web/core/state/feature-flags.ts
@@ -9,7 +9,7 @@ export const featureFlagDefinitions = [
   {
     id: 'questionsTab',
     label: 'Claims and debates',
-    description: 'Show the Claims tab and enable debate features on spaces.',
+    description: 'Enable claim and debate features on spaces.',
   },
   {
     id: 'debateDebugging',
@@ -65,8 +65,8 @@ export function useFeatureFlag(id: FeatureFlagId) {
 }
 
 /**
- * The Debates feature — the space Claims tab, the debate room, the
- * claim debate button, and the match coordinator — all gate on the single
+ * The Debates feature — the claims page, the debate room, the claim debate
+ * button, and the match coordinator — all gate on the single
  * `questionsTab` flag. Use this hook everywhere that renders claim/debate UI
  * instead of inlining the flag id, so every surface flips together.
  */

--- a/apps/web/partials/space-page/space-tabs.test.ts
+++ b/apps/web/partials/space-page/space-tabs.test.ts
@@ -12,59 +12,43 @@ const dynamicTabs = [
 ];
 
 describe('buildSpaceTabs', () => {
-  it('omits Claims when the feature flag is disabled', () => {
+  it('omits system Claims and Debates tabs', () => {
     const tabs = buildSpaceTabs({
       spaceId,
       overviewHref,
       dynamicTabs,
       typeIds: [SystemIds.SPACE_TYPE],
-      isDebatesEnabled: false,
       isDebugDebatesPageEnabled: false,
     });
 
     expect(tabs.map(tab => tab.label)).toEqual(['Overview', 'Facts', 'Sources', 'Governance', 'Activity']);
-  });
-
-  it('inserts Claims after content tabs and before Governance when enabled', () => {
-    const tabs = buildSpaceTabs({
-      spaceId,
-      overviewHref,
-      dynamicTabs,
-      typeIds: [SystemIds.SPACE_TYPE],
-      isDebatesEnabled: true,
-      isDebugDebatesPageEnabled: false,
-    });
-
-    expect(tabs.map(tab => tab.label)).toEqual(['Overview', 'Facts', 'Sources', 'Claims', 'Governance', 'Activity']);
-    expect(tabs.find(tab => tab.label === 'Claims')?.href).toBe(`/space/${spaceId}/claims`);
+    expect(tabs.find(tab => tab.label === 'Claims')).toBeUndefined();
     expect(tabs.find(tab => tab.label === 'Debates')).toBeUndefined();
   });
 
-  it('keeps personal spaces from showing Governance while still showing Claims', () => {
+  it('keeps personal spaces from showing Governance', () => {
     const tabs = buildSpaceTabs({
       spaceId,
       overviewHref,
       dynamicTabs,
       typeIds: [SystemIds.SPACE_TYPE, SystemIds.PERSON_TYPE],
-      isDebatesEnabled: true,
       isDebugDebatesPageEnabled: false,
     });
 
-    expect(tabs.map(tab => tab.label)).toEqual(['Overview', 'Facts', 'Sources', 'Claims', 'Activity']);
+    expect(tabs.map(tab => tab.label)).toEqual(['Overview', 'Facts', 'Sources', 'Activity']);
   });
 
-  it('keeps the system Claims route when a dynamic tab has the same label', () => {
+  it('keeps an authored Claims tab because the system tab is no longer shown', () => {
     const tabs = buildSpaceTabs({
       spaceId,
       overviewHref,
       dynamicTabs: [...dynamicTabs, { label: 'Claims', href: `${overviewHref}?tabId=dynamic-claims` }],
       typeIds: [SystemIds.SPACE_TYPE],
-      isDebatesEnabled: true,
       isDebugDebatesPageEnabled: false,
     });
 
     expect(tabs.map(tab => tab.label)).toEqual(['Overview', 'Facts', 'Sources', 'Claims', 'Governance', 'Activity']);
-    expect(tabs.find(tab => tab.label === 'Claims')?.href).toBe(`/space/${spaceId}/claims`);
+    expect(tabs.find(tab => tab.label === 'Claims')?.href).toBe(`${overviewHref}?tabId=dynamic-claims`);
   });
 
   it('keeps an authored Debates tab because the system tab is no longer shown', () => {
@@ -73,7 +57,6 @@ describe('buildSpaceTabs', () => {
       overviewHref,
       dynamicTabs: [...dynamicTabs, { label: 'Debates', href: `${overviewHref}?tabId=dynamic-debates` }],
       typeIds: [SystemIds.SPACE_TYPE],
-      isDebatesEnabled: true,
       isDebugDebatesPageEnabled: false,
     });
 
@@ -82,7 +65,6 @@ describe('buildSpaceTabs', () => {
       'Facts',
       'Sources',
       'Debates',
-      'Claims',
       'Governance',
       'Activity',
     ]);
@@ -95,7 +77,6 @@ describe('buildSpaceTabs', () => {
       overviewHref,
       dynamicTabs,
       typeIds: [SystemIds.SPACE_TYPE],
-      isDebatesEnabled: false,
       isDebugDebatesPageEnabled: true,
     });
 
@@ -110,34 +91,12 @@ describe('buildSpaceTabs', () => {
     expect(tabs.find(tab => tab.label === 'Debug debates')?.href).toBe(`/space/${spaceId}/debug-debates`);
   });
 
-  it('inserts Claims and Debug debates when both flags are enabled', () => {
-    const tabs = buildSpaceTabs({
-      spaceId,
-      overviewHref,
-      dynamicTabs,
-      typeIds: [SystemIds.SPACE_TYPE],
-      isDebatesEnabled: true,
-      isDebugDebatesPageEnabled: true,
-    });
-
-    expect(tabs.map(tab => tab.label)).toEqual([
-      'Overview',
-      'Facts',
-      'Sources',
-      'Claims',
-      'Debug debates',
-      'Governance',
-      'Activity',
-    ]);
-  });
-
   it('shows Debug debates in personal spaces without Governance', () => {
     const tabs = buildSpaceTabs({
       spaceId,
       overviewHref,
       dynamicTabs,
       typeIds: [SystemIds.SPACE_TYPE, SystemIds.PERSON_TYPE],
-      isDebatesEnabled: false,
       isDebugDebatesPageEnabled: true,
     });
 
@@ -150,7 +109,6 @@ describe('buildSpaceTabs', () => {
       overviewHref,
       dynamicTabs: [...dynamicTabs, { label: 'Debug debates', href: `${overviewHref}?tabId=debug-debates` }],
       typeIds: [SystemIds.SPACE_TYPE],
-      isDebatesEnabled: false,
       isDebugDebatesPageEnabled: true,
     });
 

--- a/apps/web/partials/space-page/space-tabs.test.ts
+++ b/apps/web/partials/space-page/space-tabs.test.ts
@@ -12,7 +12,7 @@ const dynamicTabs = [
 ];
 
 describe('buildSpaceTabs', () => {
-  it('omits Claims and Debates when the feature flag is disabled', () => {
+  it('omits Claims when the feature flag is disabled', () => {
     const tabs = buildSpaceTabs({
       spaceId,
       overviewHref,
@@ -25,7 +25,7 @@ describe('buildSpaceTabs', () => {
     expect(tabs.map(tab => tab.label)).toEqual(['Overview', 'Facts', 'Sources', 'Governance', 'Activity']);
   });
 
-  it('inserts Claims and Debates after content tabs and before Governance when enabled', () => {
+  it('inserts Claims after content tabs and before Governance when enabled', () => {
     const tabs = buildSpaceTabs({
       spaceId,
       overviewHref,
@@ -35,20 +35,12 @@ describe('buildSpaceTabs', () => {
       isDebugDebatesPageEnabled: false,
     });
 
-    expect(tabs.map(tab => tab.label)).toEqual([
-      'Overview',
-      'Facts',
-      'Sources',
-      'Claims',
-      'Debates',
-      'Governance',
-      'Activity',
-    ]);
+    expect(tabs.map(tab => tab.label)).toEqual(['Overview', 'Facts', 'Sources', 'Claims', 'Governance', 'Activity']);
     expect(tabs.find(tab => tab.label === 'Claims')?.href).toBe(`/space/${spaceId}/claims`);
-    expect(tabs.find(tab => tab.label === 'Debates')?.href).toBe(`/space/${spaceId}/debates`);
+    expect(tabs.find(tab => tab.label === 'Debates')).toBeUndefined();
   });
 
-  it('keeps personal spaces from showing Governance while still showing Claims and Debates', () => {
+  it('keeps personal spaces from showing Governance while still showing Claims', () => {
     const tabs = buildSpaceTabs({
       spaceId,
       overviewHref,
@@ -58,7 +50,7 @@ describe('buildSpaceTabs', () => {
       isDebugDebatesPageEnabled: false,
     });
 
-    expect(tabs.map(tab => tab.label)).toEqual(['Overview', 'Facts', 'Sources', 'Claims', 'Debates', 'Activity']);
+    expect(tabs.map(tab => tab.label)).toEqual(['Overview', 'Facts', 'Sources', 'Claims', 'Activity']);
   });
 
   it('keeps the system Claims route when a dynamic tab has the same label', () => {
@@ -71,19 +63,11 @@ describe('buildSpaceTabs', () => {
       isDebugDebatesPageEnabled: false,
     });
 
-    expect(tabs.map(tab => tab.label)).toEqual([
-      'Overview',
-      'Facts',
-      'Sources',
-      'Claims',
-      'Debates',
-      'Governance',
-      'Activity',
-    ]);
+    expect(tabs.map(tab => tab.label)).toEqual(['Overview', 'Facts', 'Sources', 'Claims', 'Governance', 'Activity']);
     expect(tabs.find(tab => tab.label === 'Claims')?.href).toBe(`/space/${spaceId}/claims`);
   });
 
-  it('keeps the system Debates route when a dynamic tab has the same label', () => {
+  it('keeps an authored Debates tab because the system tab is no longer shown', () => {
     const tabs = buildSpaceTabs({
       spaceId,
       overviewHref,
@@ -97,12 +81,12 @@ describe('buildSpaceTabs', () => {
       'Overview',
       'Facts',
       'Sources',
-      'Claims',
       'Debates',
+      'Claims',
       'Governance',
       'Activity',
     ]);
-    expect(tabs.find(tab => tab.label === 'Debates')?.href).toBe(`/space/${spaceId}/debates`);
+    expect(tabs.find(tab => tab.label === 'Debates')?.href).toBe(`${overviewHref}?tabId=dynamic-debates`);
   });
 
   it('inserts Debug debates after authored tabs when only its flag is enabled', () => {
@@ -126,7 +110,7 @@ describe('buildSpaceTabs', () => {
     expect(tabs.find(tab => tab.label === 'Debug debates')?.href).toBe(`/space/${spaceId}/debug-debates`);
   });
 
-  it('inserts Debug debates after Debates when both flags are enabled', () => {
+  it('inserts Claims and Debug debates when both flags are enabled', () => {
     const tabs = buildSpaceTabs({
       spaceId,
       overviewHref,
@@ -141,7 +125,6 @@ describe('buildSpaceTabs', () => {
       'Facts',
       'Sources',
       'Claims',
-      'Debates',
       'Debug debates',
       'Governance',
       'Activity',

--- a/apps/web/partials/space-page/space-tabs.tsx
+++ b/apps/web/partials/space-page/space-tabs.tsx
@@ -62,12 +62,6 @@ export function buildSpaceTabs({
     priority: 2,
   };
 
-  const DEBATE_TAB: BuiltSpaceTab = {
-    label: 'Debates',
-    href: `/space/${spaceId}/debates`,
-    priority: 3,
-  };
-
   const DEBUG_DEBATES_TAB: BuiltSpaceTab = {
     label: 'Debug debates',
     href: `/space/${spaceId}/debug-debates`,
@@ -93,7 +87,7 @@ export function buildSpaceTabs({
   if (typeIds.includes(SystemIds.SPACE_TYPE)) {
     if (dynamicTabs.length > 0) {
       const reservedLabels = new Set([
-        ...(isDebatesEnabled ? [QUESTION_TAB.label, DEBATE_TAB.label] : []),
+        ...(isDebatesEnabled ? [QUESTION_TAB.label] : []),
         ...(isDebugDebatesPageEnabled ? [DEBUG_DEBATES_TAB.label] : []),
       ]);
       const visibleDynamicTabs =
@@ -105,7 +99,6 @@ export function buildSpaceTabs({
 
   if (isDebatesEnabled) {
     tabs.push(QUESTION_TAB);
-    tabs.push(DEBATE_TAB);
   }
 
   if (isDebugDebatesPageEnabled) tabs.push(DEBUG_DEBATES_TAB);
@@ -178,7 +171,6 @@ export function SpaceTabs({ spaceId, entityId, initialTabRelations, tabEntities,
 
   if (isDebatesEnabled) {
     systemTabsAfter.push({ label: 'Claims', href: `/space/${spaceId}/claims` });
-    systemTabsAfter.push({ label: 'Debates', href: `/space/${spaceId}/debates` });
   }
 
   if (isDebugDebatesPageEnabled) {

--- a/apps/web/partials/space-page/space-tabs.tsx
+++ b/apps/web/partials/space-page/space-tabs.tsx
@@ -5,7 +5,7 @@ import { SystemIds } from '@geoprotocol/geo-sdk/lite';
 import * as React from 'react';
 
 import { useEditable } from '~/core/state/editable-store';
-import { useDebatesEnabled, useDebugDebatesPageEnabled } from '~/core/state/feature-flags';
+import { useDebugDebatesPageEnabled } from '~/core/state/feature-flags';
 import { useRelations, useValues } from '~/core/sync/use-store';
 import { TabEntity } from '~/core/types';
 import { Relation } from '~/core/types';
@@ -34,7 +34,6 @@ type BuildSpaceTabsParams = {
   overviewHref: string;
   dynamicTabs: Array<{ label: string; href: string }>;
   typeIds: string[];
-  isDebatesEnabled: boolean;
   isDebugDebatesPageEnabled: boolean;
 };
 
@@ -43,7 +42,6 @@ export function buildSpaceTabs({
   overviewHref,
   dynamicTabs,
   typeIds,
-  isDebatesEnabled,
   isDebugDebatesPageEnabled,
 }: BuildSpaceTabsParams): BuiltSpaceTab[] {
   const tabs: BuiltSpaceTab[] = [];
@@ -55,12 +53,6 @@ export function buildSpaceTabs({
       priority: 1,
     },
   ];
-
-  const QUESTION_TAB: BuiltSpaceTab = {
-    label: 'Claims',
-    href: `/space/${spaceId}/claims`,
-    priority: 2,
-  };
 
   const DEBUG_DEBATES_TAB: BuiltSpaceTab = {
     label: 'Debug debates',
@@ -86,19 +78,12 @@ export function buildSpaceTabs({
 
   if (typeIds.includes(SystemIds.SPACE_TYPE)) {
     if (dynamicTabs.length > 0) {
-      const reservedLabels = new Set([
-        ...(isDebatesEnabled ? [QUESTION_TAB.label] : []),
-        ...(isDebugDebatesPageEnabled ? [DEBUG_DEBATES_TAB.label] : []),
-      ]);
+      const reservedLabels = new Set(isDebugDebatesPageEnabled ? [DEBUG_DEBATES_TAB.label] : []);
       const visibleDynamicTabs =
         reservedLabels.size > 0 ? dynamicTabs.filter(tab => !reservedLabels.has(tab.label)) : dynamicTabs;
 
       tabs.push(...visibleDynamicTabs.map(tab => ({ ...tab, priority: 1 as const })));
     }
-  }
-
-  if (isDebatesEnabled) {
-    tabs.push(QUESTION_TAB);
   }
 
   if (isDebugDebatesPageEnabled) tabs.push(DEBUG_DEBATES_TAB);
@@ -122,7 +107,6 @@ export function buildSpaceTabs({
 
 export function SpaceTabs({ spaceId, entityId, initialTabRelations, tabEntities, typeIds }: SpaceTabsProps) {
   const { editable } = useEditable();
-  const isDebatesEnabled = useDebatesEnabled();
   const isDebugDebatesPageEnabled = useDebugDebatesPageEnabled();
 
   // Merge local tab relation changes with server data
@@ -169,10 +153,6 @@ export function SpaceTabs({ spaceId, entityId, initialTabRelations, tabEntities,
 
   const systemTabsAfter: Array<{ label: string; href: string }> = [];
 
-  if (isDebatesEnabled) {
-    systemTabsAfter.push({ label: 'Claims', href: `/space/${spaceId}/claims` });
-  }
-
   if (isDebugDebatesPageEnabled) {
     systemTabsAfter.push({ label: 'Debug debates', href: `/space/${spaceId}/debug-debates` });
   }
@@ -212,7 +192,6 @@ export function SpaceTabs({ spaceId, entityId, initialTabRelations, tabEntities,
     overviewHref,
     dynamicTabs,
     typeIds,
-    isDebatesEnabled,
     isDebugDebatesPageEnabled,
   });
 


### PR DESCRIPTION
## Summary

- remove the system-provided Claims and Debates tabs from space navigation in browse and edit modes
- keep the claims/debates routes, feature-flagged functionality, debate controls, and Debug debates tab unchanged
- allow space-authored custom tabs named “Claims” or “Debates” to remain visible
- update the feature-flag description to reflect the navigation change

## Why

Spaces no longer need default navigation links to the Claims and Debates pages, but the underlying features must remain available for ongoing debate work.

## Validation

- `NODE_OPTIONS=--no-experimental-webstorage bun run test partials/space-page/space-tabs.test.ts core/state/feature-flags.test.ts` (10 tests passed)
- ESLint on affected files
- `bunx tsc --noEmit`
- `git diff --check`
