### PR TITLE
Return profile debate exits to the origin page

### DIFF
--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
@@ -14,7 +14,9 @@ const mocks = vi.hoisted(() => ({
   session: null as DebateRematchSession | null,
   claims: [] as DebateRematchClaim[],
   replace: vi.fn(),
+  back: vi.fn(),
   mutate: vi.fn(),
+  leaveMutate: vi.fn(),
   acceptMutate: vi.fn(),
   rejectMutate: vi.fn(),
   submitResponse: vi.fn(),
@@ -22,7 +24,7 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock('next/navigation', () => ({
-  useRouter: () => ({ replace: mocks.replace }),
+  useRouter: () => ({ replace: mocks.replace, back: mocks.back }),
 }));
 
 vi.mock('~/core/debates/api', async importOriginal => {
@@ -39,7 +41,7 @@ vi.mock('~/core/debates/hooks', () => ({
   }),
   useDebate: () => ({ data: { claim: { claim_entity_id: 'claim-source' } } }),
   useCreateDebateRematchRequest: () => mutation(),
-  useLeaveDebateRematch: () => mutation(),
+  useLeaveDebateRematch: () => mutation(mocks.leaveMutate),
   useAcceptDebateRematchRequest: () => mutation(mocks.acceptMutate),
   useRejectDebateRematchRequest: () => mutation(mocks.rejectMutate),
 }));
@@ -79,7 +81,9 @@ function mutation(mutate = mocks.mutate) {
 
 beforeEach(() => {
   mocks.replace.mockReset();
+  mocks.back.mockReset();
   mocks.mutate.mockReset();
+  mocks.leaveMutate.mockReset();
   mocks.acceptMutate.mockReset();
   mocks.rejectMutate.mockReset();
   mocks.submitResponse.mockReset();
@@ -102,7 +106,7 @@ describe('DebateRematchPageClient', () => {
 
     expect(await screen.findByRole('heading', { name: 'A claim both participants chose' })).toBeInTheDocument();
     await new Promise(resolve => window.setTimeout(resolve, 0));
-    expect(mocks.mutate).not.toHaveBeenCalled();
+    expect(mocks.leaveMutate).not.toHaveBeenCalled();
   });
 
   it('does not end a browsing rematch when the page unmounts', async () => {
@@ -111,7 +115,7 @@ describe('DebateRematchPageClient', () => {
     unmount();
     await new Promise(resolve => window.setTimeout(resolve, 0));
 
-    expect(mocks.mutate).not.toHaveBeenCalled();
+    expect(mocks.leaveMutate).not.toHaveBeenCalled();
   });
 
   it('ends a browsing rematch only through the explicit leave action', () => {
@@ -119,7 +123,39 @@ describe('DebateRematchPageClient', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Leave debate' }));
 
-    expect(mocks.mutate).toHaveBeenCalledOnce();
+    expect(mocks.leaveMutate).toHaveBeenCalledOnce();
+  });
+
+  it('returns a profile challenge to the page before the debate flow after leaving', () => {
+    window.history.pushState({}, '', '/space/profile-remote?tabId=about');
+    const endedSession = session({ source_debate_id: null, status: 'ended' });
+    mocks.session = session({ source_debate_id: null });
+    mocks.leaveMutate.mockImplementation(
+      (_input: undefined, options: { onSuccess?: (ended: DebateRematchSession) => void }) => {
+        options.onSuccess?.(endedSession);
+      }
+    );
+
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+    fireEvent.click(screen.getByRole('button', { name: 'Leave debate' }));
+
+    expect(mocks.back).toHaveBeenCalledOnce();
+    expect(mocks.replace).not.toHaveBeenCalledWith('/space/space-1/debates');
+  });
+
+  it('preserves the debates-page exit for rematches started from a prior debate', () => {
+    const endedSession = session({ status: 'ended' });
+    mocks.leaveMutate.mockImplementation(
+      (_input: undefined, options: { onSuccess?: (ended: DebateRematchSession) => void }) => {
+        options.onSuccess?.(endedSession);
+      }
+    );
+
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+    fireEvent.click(screen.getByRole('button', { name: 'Leave debate' }));
+
+    expect(mocks.replace).toHaveBeenCalledWith('/space/space-1/debates');
+    expect(mocks.back).not.toHaveBeenCalled();
   });
 
   it('pins shared preferences above additional published claims and enables opposing requests', () => {

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
@@ -94,7 +94,10 @@ beforeEach(() => {
   document.documentElement.style.overflow = '';
 });
 
-afterEach(cleanup);
+afterEach(() => {
+  vi.restoreAllMocks();
+  cleanup();
+});
 
 describe('DebateRematchPageClient', () => {
   it('does not leave a browsing rematch during the Strict Mode effect rehearsal', async () => {
@@ -127,7 +130,7 @@ describe('DebateRematchPageClient', () => {
   });
 
   it('returns a profile challenge to the page before the debate flow after leaving', () => {
-    window.history.pushState({}, '', '/space/profile-remote?tabId=about');
+    vi.spyOn(window.history, 'length', 'get').mockReturnValue(2);
     const endedSession = session({ source_debate_id: null, status: 'ended' });
     mocks.session = session({ source_debate_id: null });
     mocks.leaveMutate.mockImplementation(

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -39,6 +39,7 @@ import { Text } from '~/design-system/text';
 export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   const router = useRouter();
   const currentUserId = getCurrentGeoChatUserId();
+  const exitStartedRef = React.useRef(false);
   const sessionQuery = useDebateRematch(sessionId);
   const [publishedClaimsCursor, setPublishedClaimsCursor] = React.useState<string | undefined>();
   const {
@@ -153,6 +154,29 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   const [tab, setTab] = React.useState<'all' | 'debate-now'>('all');
   const [topicFilter, setTopicFilter] = React.useState<string>('');
 
+  const returnFromSession = React.useCallback(
+    (endedSession: DebateRematchSession) => {
+      if (exitStartedRef.current) return;
+      exitStartedRef.current = true;
+
+      if (endedSession.source_debate_id === null) {
+        if (window.history.length > 1) {
+          router.back();
+          return;
+        }
+
+        const opponentProfileSpaceId = endedSession.participants.find(
+          participant => participant.user_id !== currentUserId
+        )?.profile_space_id;
+        router.replace(`/space/${opponentProfileSpaceId ?? endedSession.source_space_id}`);
+        return;
+      }
+
+      router.replace(`/space/${endedSession.source_space_id}/debates`);
+    },
+    [currentUserId, router]
+  );
+
   // "Debate now" = claims the opponent has responded to; the tab badge counts them.
   const opponentPositionCount = React.useMemo(
     () => claims.filter(claim => opponentPositionOf(claim) !== null).length,
@@ -183,13 +207,13 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
     if (session.status === 'converted' && session.converted_debate_id) {
       router.replace(`/space/${session.source_space_id}/debates/${session.converted_debate_id}`);
     } else if (session.status === 'ended' || session.status === 'expired') {
-      router.replace(`/space/${session.source_space_id}/debates`);
+      returnFromSession(session);
     }
-  }, [router, session]);
+  }, [returnFromSession, router, session]);
 
   const leave = () => {
     leaveSession.mutate(undefined, {
-      onSuccess: ended => router.replace(`/space/${ended.source_space_id}/debates`),
+      onSuccess: returnFromSession,
     });
   };
 


### PR DESCRIPTION
## Summary

- return profile-challenge claim pickers to the browser page that launched the debate flow
- use the opponent’s profile as a safe fallback when no prior browser-history entry exists
- keep the existing space Debates destination for rematches that originated from a completed debate
- guard terminal-session and explicit-leave redirects so only one exit navigation runs

## Root cause

The profile flow enters the claim picker with `router.push`, which correctly preserves the origin page in browser history. The picker discarded that information on exit by always replacing the route with `/space/<space-id>/debates`.

## Impact

Leaving a profile-started debate flow now returns each participant to the page they were viewing before the flow began. Existing debate-room exits already use browser history and continue to behave consistently after the picker is replaced by the room route.

## Validation

- `NODE_OPTIONS=--no-experimental-webstorage bun run test 'app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx'` (17 tests passed)
- ESLint on the implementation and test files
- `bunx tsc --noEmit`
- `git diff --check`
