### PR TITLE
Align full-screen debate views with designs

### DIFF
--- a/apps/web/app/space/[id]/(space)/debates/debates-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/debates-page-client.test.tsx
@@ -90,7 +90,7 @@ describe('DebatesPageClient browse feed', () => {
 
     expect(screen.getByRole('heading', { name: 'Debates are useful' })).toBeInTheDocument();
     expect(screen.getAllByText('Fashion').length).toBeGreaterThan(0);
-    expect(screen.getAllByRole('button', { name: 'Join debate' }).length).toBeGreaterThan(0);
+    expect(screen.getAllByRole('button', { name: 'Join a debate' }).length).toBeGreaterThan(0);
     expect(screen.getAllByText('Winner?').length).toBeGreaterThan(0);
 
     await waitFor(() => expect(container.querySelectorAll('video')).toHaveLength(2));

--- a/apps/web/core/debates/browse/debate-feed.test.tsx
+++ b/apps/web/core/debates/browse/debate-feed.test.tsx
@@ -122,6 +122,18 @@ afterEach(() => {
 });
 
 describe('DebatesBrowseFeed video sharing', () => {
+  it('uses the full-screen responsive layout and design copy', () => {
+    render(<DebatesBrowseFeed spaceId="space-1" />);
+
+    const heading = screen.getByRole('heading', { name: 'Debates are useful' });
+    expect(screen.getByRole('button', { name: 'Join a debate' })).toBeInTheDocument();
+    expect(heading.closest('section')).toHaveClass('items-start', 'pt-5', 'md:pt-3');
+    expect(screen.getByTestId('player-debate-1').parentElement?.parentElement).toHaveClass(
+      'w-[480px]',
+      'md:w-[calc(100vw-1rem)]'
+    );
+  });
+
   it('waits for five seconds of active dwell and never prepares an adjacent debate', async () => {
     mocks.debates.push(completedDebate('debate-2', 'Adjacent debate', '2026-07-01T00:01:10.000Z'));
     render(<DebatesBrowseFeed spaceId="space-1" />);

--- a/apps/web/core/debates/browse/debate-feed.test.tsx
+++ b/apps/web/core/debates/browse/debate-feed.test.tsx
@@ -131,11 +131,7 @@ describe('DebatesBrowseFeed video sharing', () => {
     expect(heading.closest('section')).toHaveClass('items-start', 'pt-5', 'md:pt-3');
     const mediaColumn = screen.getByTestId('player-debate-1').parentElement?.parentElement;
     assert(mediaColumn, 'Expected the debate player to be rendered inside the media column');
-    expect(mediaColumn).toHaveClass(
-      'min-w-0',
-      'w-[480px]',
-      'md:w-[calc(100vw-1rem)]'
-    );
+    expect(mediaColumn).toHaveClass('min-w-0', 'w-[480px]', 'md:w-[calc(100vw-1rem)]');
   });
 
   it('waits for five seconds of active dwell and never prepares an adjacent debate', async () => {

--- a/apps/web/core/debates/browse/debate-feed.test.tsx
+++ b/apps/web/core/debates/browse/debate-feed.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom/vitest';
 import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
 
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, assert, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { Debate } from '~/core/debates/api';
 
@@ -127,8 +127,12 @@ describe('DebatesBrowseFeed video sharing', () => {
 
     const heading = screen.getByRole('heading', { name: 'Debates are useful' });
     expect(screen.getByRole('button', { name: 'Join a debate' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Back' })).toHaveClass('size-8', 'justify-center', '-mb-3');
     expect(heading.closest('section')).toHaveClass('items-start', 'pt-5', 'md:pt-3');
-    expect(screen.getByTestId('player-debate-1').parentElement?.parentElement).toHaveClass(
+    const mediaColumn = screen.getByTestId('player-debate-1').parentElement?.parentElement;
+    assert(mediaColumn, 'Expected the debate player to be rendered inside the media column');
+    expect(mediaColumn).toHaveClass(
+      'min-w-0',
       'w-[480px]',
       'md:w-[calc(100vw-1rem)]'
     );

--- a/apps/web/core/debates/browse/debate-feed.tsx
+++ b/apps/web/core/debates/browse/debate-feed.tsx
@@ -144,7 +144,7 @@ export function DebatesBrowseFeed({
   const feed = (
     <div
       ref={setScrollEl}
-      className="no-scrollbar h-[calc(100dvh-2.75rem)] snap-y snap-mandatory overflow-y-auto overscroll-contain scroll-smooth"
+      className="no-scrollbar h-[calc(100dvh-2.75rem)] snap-y snap-mandatory overflow-y-auto overscroll-contain scroll-smooth md:h-dvh"
     >
       {debates.length === 0 && <FeedMessage>{emptyMessage}</FeedMessage>}
       {visibleDebates.map(debate => (
@@ -182,7 +182,7 @@ export function DebatesBrowseFeed({
   // Keep the feed in the same tree position whether or not a side panel is open, so
   // toggling the claims/join panel doesn't remount the players and restart playback.
   return (
-    <div className="flex h-[calc(100dvh-2.75rem)] items-stretch">
+    <div className="flex h-[calc(100dvh-2.75rem)] items-stretch md:fixed md:inset-0 md:z-[70] md:h-dvh md:bg-white">
       <div className="min-w-0 flex-1">{feed}</div>
       {sidePanel}
     </div>
@@ -313,35 +313,34 @@ function DebateFeedItem({
   };
 
   return (
-    <section ref={itemRef} className="flex h-full snap-start items-center justify-center px-4">
+    <section ref={itemRef} className="flex h-full snap-start items-start justify-center px-4 pt-5 md:px-2 md:pt-3">
       <div className="flex items-stretch gap-3">
-        {/* Column width is driven by height so both 480×289 videos + header fit
-            the viewport at once (fills the screen, TikTok-style). */}
-        <div
-          className="flex max-w-[90vw] flex-col gap-4"
-          style={{ width: 'min(480px, calc((100dvh - 10rem) * 0.83))' }}
-        >
+        <div className="flex w-[480px] flex-col md:w-[calc(100vw-1rem)]">
           {/* Mobile-only back arrow; desktop keeps the app nav. NB: breakpoints
               here are desktop-first (md = max-width:767px), so md: targets mobile. */}
           <button
             type="button"
             aria-label="Back"
             onClick={() => window.history.back()}
-            className="-mb-1 hidden size-8 items-center text-text md:flex"
+            className="hidden h-5 w-8 items-center text-text md:flex"
           >
             <ArrowLeft />
           </button>
-          <DebateTitleHeader
-            claim={debate.claim.claim}
-            spaceName={spaceName}
-            spaceImage={spaceImage}
-            topics={topics}
-            onOpenJoin={onOpenJoin}
-          />
-          <DebateFeedPlayer debate={debate} active={active} votes={winnerVotes} />
+          <div className="md:mt-4">
+            <DebateTitleHeader
+              claim={debate.claim.claim}
+              spaceName={spaceName}
+              spaceImage={spaceImage}
+              topics={topics}
+              onOpenJoin={onOpenJoin}
+            />
+          </div>
+          <div className="mt-6 md:mt-7">
+            <DebateFeedPlayer debate={debate} active={active} votes={winnerVotes} />
+          </div>
           {/* Mobile: horizontal bar below the videos. Wrapper controls display so
               it doesn't collide with the bar's own `flex`. */}
-          <div className="hidden md:block">
+          <div className="mt-3 hidden md:block">
             <DebateInteractionBar orientation="horizontal" {...interactionProps} />
           </div>
         </div>
@@ -374,25 +373,41 @@ function DebateTitleHeader({
           <span className="block size-4 shrink-0 overflow-hidden rounded-full bg-grey-02">
             <Avatar avatarUrl={spaceImage} value={spaceName} size={16} />
           </span>
-          <Text as="span" variant="metadata" color="text" className="truncate">
+          <Text as="span" variant="metadata" color="text" className="truncate !leading-[13px] !tracking-[-0.35px]">
             {spaceName}
           </Text>
           {topics.map(topic => (
             <React.Fragment key={topic}>
-              <Text as="span" variant="metadata" color="grey-04">
+              <Text as="span" variant="metadata" color="grey-04" className="!leading-[13px] !tracking-[-0.35px]">
                 ·
               </Text>
-              <Text as="span" variant="metadata" color="grey-04" className="truncate">
+              <Text
+                as="span"
+                variant="metadata"
+                color="grey-04"
+                className="truncate !leading-[13px] !tracking-[-0.35px]"
+              >
                 {topic}
               </Text>
             </React.Fragment>
           ))}
         </div>
-        <Button type="button" variant="secondary" small onClick={onOpenJoin} className="shrink-0">
-          Join debate
+        <Button
+          type="button"
+          variant="secondary"
+          small
+          onClick={onOpenJoin}
+          className="!h-7 shrink-0 !rounded-full !px-[11px] !py-0 !text-[16px] !leading-[13px] !font-normal !tracking-[-0.35px] !shadow-none md:!px-3 md:!text-[18px] md:!leading-[22px] md:!tracking-[-0.36px]"
+        >
+          Join a debate
         </Button>
       </div>
-      <Text as="h2" variant="cardEntityTitle" color="text">
+      <Text
+        as="h2"
+        variant="cardEntityTitle"
+        color="text"
+        className="!text-[22.4px] !leading-[21px] !tracking-[-0.672px] md:!text-[24px] md:!leading-6 md:!tracking-[-0.75px]"
+      >
         {claim}
       </Text>
     </div>

--- a/apps/web/core/debates/browse/debate-feed.tsx
+++ b/apps/web/core/debates/browse/debate-feed.tsx
@@ -315,14 +315,14 @@ function DebateFeedItem({
   return (
     <section ref={itemRef} className="flex h-full snap-start items-start justify-center px-4 pt-5 md:px-2 md:pt-3">
       <div className="flex items-stretch gap-3">
-        <div className="flex w-[480px] flex-col md:w-[calc(100vw-1rem)]">
+        <div className="flex min-w-0 w-[480px] flex-col md:w-[calc(100vw-1rem)]">
           {/* Mobile-only back arrow; desktop keeps the app nav. NB: breakpoints
               here are desktop-first (md = max-width:767px), so md: targets mobile. */}
           <button
             type="button"
             aria-label="Back"
             onClick={() => window.history.back()}
-            className="hidden h-5 w-8 items-center text-text md:flex"
+            className="-mb-3 hidden size-8 items-center justify-center text-text md:flex"
           >
             <ArrowLeft />
           </button>

--- a/apps/web/core/debates/browse/debate-feed.tsx
+++ b/apps/web/core/debates/browse/debate-feed.tsx
@@ -315,7 +315,7 @@ function DebateFeedItem({
   return (
     <section ref={itemRef} className="flex h-full snap-start items-start justify-center px-4 pt-5 md:px-2 md:pt-3">
       <div className="flex items-stretch gap-3">
-        <div className="flex min-w-0 w-[480px] flex-col md:w-[calc(100vw-1rem)]">
+        <div className="flex w-[480px] min-w-0 flex-col md:w-[calc(100vw-1rem)]">
           {/* Mobile-only back arrow; desktop keeps the app nav. NB: breakpoints
               here are desktop-first (md = max-width:767px), so md: targets mobile. */}
           <button


### PR DESCRIPTION
## Summary

- top-align the full-screen debate content using the desktop and mobile Figma spacing
- use the designed 480px desktop media width and near-edge-to-edge mobile media width instead of height-derived scaling
- make the mobile debate feed cover the app navbar as a true full-screen view
- match the responsive title, metadata, and action-button typography
- change the action copy to **Join a debate**

## Root cause

The debate card was vertically centered and its width was derived from viewport height, which made the content undersized and pushed it toward the bottom on larger screens. Mobile also continued to reserve the global navbar height even though the design is a full-screen view.

## Validation

- `env NODE_OPTIONS=--no-experimental-webstorage mise exec -- bun run test core/debates/browse/debate-feed.test.tsx 'app/space/[id]/(space)/debates/debates-page-client.test.tsx'`
- `mise exec -- bunx eslint core/debates/browse/debate-feed.tsx core/debates/browse/debate-feed.test.tsx 'app/space/[id]/(space)/debates/debates-page-client.test.tsx'`
- `mise exec -- bunx tsc --noEmit`
- `git diff --check`
