### PR TITLE
fix(ranking): keep a rolled-off ballot instead of blanking the compose view

### DIFF
--- a/apps/web/core/blocks/ranking/ranking-rolling.test.ts
+++ b/apps/web/core/blocks/ranking/ranking-rolling.test.ts
@@ -6,6 +6,7 @@ import {
   getRollingExpiryMs,
   isRollingSubmissionLive,
   parseTimestampMs,
+  shouldMintNewRankEntity,
 } from './ranking-rolling';
 
 const HOUR = 60 * 60 * 1000;
@@ -65,6 +66,28 @@ describe('isRollingSubmissionLive', () => {
 describe('getRollingExpiryMs', () => {
   it('adds the frequency window to the submission time', () => {
     expect(getRollingExpiryMs(now, 24)).toBe(now + 24 * HOUR);
+  });
+});
+
+describe('shouldMintNewRankEntity', () => {
+  it('mints when the author has no ballot yet', () => {
+    expect(shouldMintNewRankEntity({ isRolling: false, hasExistingBallot: false, isSubmissionLive: true })).toBe(true);
+    expect(shouldMintNewRankEntity({ isRolling: true, hasExistingBallot: false, isSubmissionLive: false })).toBe(true);
+  });
+
+  it('updates in place while a ballot is still live', () => {
+    expect(shouldMintNewRankEntity({ isRolling: true, hasExistingBallot: true, isSubmissionLive: true })).toBe(false);
+  });
+
+  // A rolled-off ballot needs a fresh `submitted_at`, and the indexer only derives
+  // one from the edit that creates the rank entity — updating in place would leave
+  // the ballot expired forever.
+  it('mints again once a rolling ballot has rolled off', () => {
+    expect(shouldMintNewRankEntity({ isRolling: true, hasExistingBallot: true, isSubmissionLive: false })).toBe(true);
+  });
+
+  it('never mints for a non-rolling block with an existing ballot', () => {
+    expect(shouldMintNewRankEntity({ isRolling: false, hasExistingBallot: true, isSubmissionLive: false })).toBe(false);
   });
 });
 

--- a/apps/web/core/blocks/ranking/ranking-rolling.ts
+++ b/apps/web/core/blocks/ranking/ranking-rolling.ts
@@ -41,6 +41,35 @@ export function getRollingExpiryMs(submittedAtMs: number, frequencyHours: number
   return submittedAtMs + frequencyHours * MS_PER_HOUR;
 }
 
+/**
+ * Whether publishing a ballot has to create a new rank entity rather than update
+ * the author's existing one.
+ *
+ * True with no existing ballot, and true again once a Rolling block has rolled
+ * one off. The roll-off case is the subtle one: the indexer derives
+ * `submitted_at` from the block timestamp of the edit that *creates* the rank
+ * entity, and an `updateRank` edit re-emits only the vote relations, never the
+ * rank entity itself. Updating in place would leave `submitted_at` frozen at the
+ * original submission, so a rolled-off ballot could never climb back inside its
+ * window — re-submission has to mint a fresh entity to get a fresh timestamp.
+ *
+ * Note this is orthogonal to *retaining* the rolled-off ordering: an expired
+ * ballot is still shown in the compose view (see `useRankingSubmissions`), so
+ * re-submission confirms the previous ranking instead of rebuilding it.
+ */
+export function shouldMintNewRankEntity({
+  isRolling,
+  hasExistingBallot,
+  isSubmissionLive,
+}: {
+  isRolling: boolean;
+  hasExistingBallot: boolean;
+  isSubmissionLive: boolean;
+}): boolean {
+  if (!hasExistingBallot) return true;
+  return isRolling && !isSubmissionLive;
+}
+
 export function formatRollingSubmissionLabel({
   hasSubmission,
   isLive,

--- a/apps/web/core/blocks/ranking/use-ranking-submissions.ts
+++ b/apps/web/core/blocks/ranking/use-ranking-submissions.ts
@@ -21,7 +21,7 @@ import { validateEntityId, validateSpaceId } from '~/core/utils/utils';
 
 import { clearLocalMyRankingDraft } from './local-ranking-my-draft';
 import { getMyRankingOrderedEntityIds } from './my-ranking-entity';
-import { isRollingSubmissionLive, parseTimestampMs } from './ranking-rolling';
+import { isRollingSubmissionLive, parseTimestampMs, shouldMintNewRankEntity } from './ranking-rolling';
 import type { RankingSubmissionRecord } from './ranking-submission-types';
 import type { RankingSubmissionSlot } from './ranking-submission-types';
 import { rankingVoteWeightFromIndex } from './ranking-vote-weights';
@@ -137,7 +137,14 @@ export function useRankingSubmissions(blockId: string, spaceId: string, blockNam
 
   const hasRolledOff = isRolling && Boolean(myRankEntity) && !isSubmissionLive;
 
-  const mySubmission = hasRolledOff ? null : apiMySubmission;
+  // A rolled-off ballot is expired, not deleted, so it stays in the compose view.
+  // Blanking it here opened compose empty, authors rebuilt from scratch and
+  // published a single-entry ballot, and because the indexer keeps only the newest
+  // rank per (block, author space) that one entry permanently superseded the fuller
+  // ballot behind it — each roll-off ratcheting every participant's ballot down
+  // towards one entry. `hasRolledOff` still drives the "Submit new ranking" call to
+  // action and still forces a fresh rank entity below.
+  const mySubmission = apiMySubmission;
   const hasMySubmission = (mySubmission?.orderedEntityIds.length ?? 0) > 0;
 
   const saveMySubmission = React.useCallback(
@@ -174,7 +181,11 @@ export function useRankingSubmissions(blockId: string, spaceId: string, blockNam
       try {
         const rankName = blockName.trim() || 'My ranking';
 
-        const reuseExistingRank = Boolean(myRankEntity) && !hasRolledOff;
+        const reuseExistingRank = !shouldMintNewRankEntity({
+          isRolling,
+          hasExistingBallot: Boolean(myRankEntity),
+          isSubmissionLive,
+        });
 
         let ops;
         let rankId: string;
@@ -301,7 +312,8 @@ export function useRankingSubmissions(blockId: string, spaceId: string, blockNam
     [
       blockId,
       blockName,
-      hasRolledOff,
+      isRolling,
+      isSubmissionLive,
       myRankEntity,
       personalSpaceId,
       profile?.avatarUrl,

--- a/apps/web/partials/blocks/table/ranking-block-body.tsx
+++ b/apps/web/partials/blocks/table/ranking-block-body.tsx
@@ -53,7 +53,10 @@ function buildMyRankingActionButton(state: RankingBlockState) {
 
   const addLabel = isRollingRolledOff ? 'Submit new ranking' : 'Add my ranking';
 
-  return showEditRankingButton ? (
+  // A rolled-off ballot is retained, so `showEditRankingButton` is set even though
+  // the ranking no longer counts. Re-submitting is the action that matters then, so
+  // the roll-off call to action wins over "Edit my ranking".
+  return showEditRankingButton && !isRollingRolledOff ? (
     <Button
       variant="secondary"
       className="h-8 shrink-0 !rounded-full !border-text !bg-white !px-3 text-[16px] whitespace-nowrap !text-text"


### PR DESCRIPTION
## Problem

Arturas published a 5-claim ranking into AI space and reported it never appeared in the global rankings, with the front-page table empty. Tracing it back, this hook is half the cause.

When a Rolling block rolled an author's ballot off, `useRankingSubmissions` set `mySubmission` to `null`. The compose view then opened **empty**, so authors rebuilt from scratch — and because the indexer keeps only the newest rank per (block, author space), the one or two entries they re-added **permanently superseded** the fuller ballot behind them. Every roll-off ratcheted every participant's ballot down towards a single entry.

Observed on AI-space "Trending claims": four authors resubmitted inside a 45-minute window on 08-10, each publishing a 1-entry ballot that replaced their own previous 3–5 entry one. The block had 26 submissions and published a single row.

## Change

A rolled-off ballot is expired, not deleted, so it now stays in the compose view — re-submission confirms the previous ordering instead of rebuilding it. `hasRolledOff` still drives the "Submit new ranking" call to action, which now takes precedence over "Edit my ranking" since `showEditRankingButton` is set in this state too.

Re-submission **must** still mint a new rank entity, which is easy to get wrong in the other direction, so that decision moves into a pure `shouldMintNewRankEntity` with the reasoning recorded beside it:

> The indexer derives `submitted_at` from the block timestamp of the edit that *creates* the rank entity, and an `updateRank` edit re-emits only the vote relations, never the rank entity itself. Updating in place would leave `submitted_at` frozen at the original submission, so the ballot could never climb back inside its window.

I very nearly made exactly that mistake, hence the comment and the test.

## Verification

- 218 tests pass (3 new); eslint, prettier and `tsc` clean on the changed files.
- Mutation-tested the new helper: inverting the roll-off branch fails `mints again once a rolling ballot has rolled off`, so it isn't a check that cannot fail.

## Notes

- **Already-truncated ballots cannot be recovered here.** The four affected authors need to re-add their entries once; this only stops it recurring.
- Pairs with geobrowser/gaia#882, which fixes the other half — the indexer expiring rolling ballots at one `submission_frequency`, so the table published nothing at all between submissions. Either fix alone is a partial improvement; the two together close the loop.
- Not addressed here: a rolled-off author currently gets **no** "your ranking expired" message, because `formatRollingSubmissionLabel` deliberately returns `null` when not live (there is a test asserting it). With the ballot now retained and the button reading "Submit new ranking" the state is legible, but an explicit notice would be better — left alone rather than silently flipping a tested product decision.