### PR TITLE
fix(governance): say "Can't be completed" for proposals the DAO has no record of

### DIFF
--- a/apps/web/core/hooks/use-execute-proposal.ts
+++ b/apps/web/core/hooks/use-execute-proposal.ts
@@ -11,13 +11,18 @@ import { usePersonalSpaceId } from '~/core/hooks/use-personal-space-id';
 import { useSmartAccount } from '~/core/hooks/use-smart-account';
 import { useSmartAccountTransaction } from '~/core/hooks/use-smart-account-transaction';
 import { geo } from '~/core/sdk/geo-client';
-import { SPACE_REGISTRY_ADDRESS, assertSpaceRegistryDeployed, contractHasCode } from '~/core/sdk/geo-network';
-import { runEffectEither } from '~/core/telemetry/effect-runtime';
 import {
-  ACTION_REVERTED_SELECTOR,
-  type GovernanceRevert,
-  decodeGovernanceRevert,
-} from '~/core/utils/contracts/governance-errors';
+  SPACE_REGISTRY_ADDRESS,
+  assertSpaceRegistryDeployed,
+  contractHasCode,
+  proposalExistsOnChain,
+} from '~/core/sdk/geo-network';
+import { runEffectEither } from '~/core/telemetry/effect-runtime';
+import { type GovernanceRevert, decodeGovernanceRevert } from '~/core/utils/contracts/governance-errors';
+import {
+  type ProposalExecutability,
+  classifyProposalExecutability,
+} from '~/core/utils/contracts/proposal-executability';
 import { validateSpaceId } from '~/core/utils/utils';
 import { GEOGENESIS } from '~/core/wallet/geo-chain';
 
@@ -113,26 +118,27 @@ export function useExecuteProposal({ spaceId, proposalId }: UseExecuteProposalAr
   };
 }
 
-/**
- * Whether a passed proposal can actually be executed on-chain, and if not, why.
- *
- * - `checking`   — still simulating (or no registered account to simulate from)
- * - `executable` — the execute call would succeed
- * - `dead`       — the proposal's own action reverts (ActionReverted); it can
- *                  never execute and must be recreated (legacy malformed proposal)
- * - `blocked`    — some other governance revert (already executed, not enough
- *                  votes, voting period not elapsed) — transient or resolved
- */
-export type ProposalExecutability = 'checking' | 'executable' | 'dead' | 'blocked';
+export type { ProposalExecutability };
 
 /**
- * Simulate the real execute calldata against the live chain so the UI can tell a
- * genuinely-executable proposal apart from a stale or permanently-dead one.
+ * Probe the live chain so the UI can tell a genuinely-executable proposal apart
+ * from a stale or permanently-dead one.
  *
  * `canExecute`, status, and the membership roster all come from the indexer,
  * which lags the chain — it happily shows "Pending execution" for a proposal
- * that was already executed OR for a legacy proposal whose action reverts every
- * time. The simulation is the only ground truth that separates those.
+ * that was already executed, for a legacy proposal whose action reverts every
+ * time, or for a migrated proposal the DAO has no record of. The chain is the
+ * only ground truth that separates those.
+ *
+ * Two signals, in order of strength:
+ *
+ *  1. Does the DAO know the proposal at all (`proposalExistsOnChain`)? Absence is
+ *     permanent and needs no wallet, so this runs for signed-out viewers too —
+ *     without it, a proposal that can never execute reads as "Pending execution"
+ *     to anyone who has not connected, which is most people looking at a
+ *     governance list.
+ *  2. Otherwise simulate the real execute calldata, which needs a registered
+ *     personal space to simulate from.
  *
  * A non-revert failure (slow/unreachable RPC, unknown revert) resolves to
  * `executable` so a flaky RPC never permanently hides a legitimate action.
@@ -144,15 +150,25 @@ export function useProposalExecutability({ spaceId, proposalId }: UseExecuteProp
   const { personalSpaceId, isRegistered } = usePersonalSpaceId();
   const { smartAccount } = useSmartAccount();
   const account = smartAccount?.account.address;
+  const canSimulate = Boolean(account && personalSpaceId && isRegistered);
 
   const { data } = useQuery({
+    // `account` stays in the key so connecting a wallet re-runs this and upgrades
+    // a wallet-free `checking` into a real simulation.
     queryKey: ['proposal-executability', spaceId, proposalId, account],
-    enabled: Boolean(
-      account && personalSpaceId && isRegistered && validateSpaceId(spaceId) && validateSpaceId(proposalId)
-    ),
+    enabled: validateSpaceId(spaceId) && validateSpaceId(proposalId),
     // A passing result is cached briefly; a stale pass self-heals via the post-click recovery net.
     staleTime: 30_000,
     queryFn: async (): Promise<{ state: ProposalExecutability; revert: GovernanceRevert | null }> => {
+      const existsOnChain = await proposalExistsOnChain(spaceId, proposalId);
+      if (existsOnChain === false) {
+        return { state: classifyProposalExecutability({ existsOnChain, simulationRevert: undefined }), revert: null };
+      }
+
+      if (!canSimulate) {
+        return { state: 'checking', revert: null };
+      }
+
       const { calldata } = geo.daoSpaces.executeProposal({
         authorSpaceId: personalSpaceId!,
         spaceId,
@@ -170,13 +186,10 @@ export function useProposalExecutability({ spaceId, proposalId }: UseExecuteProp
 
       try {
         await publicClient.call({ account: account as Hex, to: SPACE_REGISTRY_ADDRESS as Hex, data: calldata });
-        return { state: 'executable', revert: null };
+        return { state: classifyProposalExecutability({ existsOnChain, simulationRevert: null }), revert: null };
       } catch (error) {
         const revert = decodeGovernanceRevert(error);
-        // Unknown / RPC error: fail open so we never hide a valid action.
-        if (revert === null) return { state: 'executable', revert: null };
-        const state = revert.selector === ACTION_REVERTED_SELECTOR ? 'dead' : 'blocked';
-        return { state, revert };
+        return { state: classifyProposalExecutability({ existsOnChain, simulationRevert: revert }), revert };
       }
     },
   });

--- a/apps/web/core/sdk/geo-network.ts
+++ b/apps/web/core/sdk/geo-network.ts
@@ -155,6 +155,82 @@ export function isSpaceActiveOnChain(spaceId: string): Promise<boolean> {
   return probe.catch(() => false);
 }
 
+const SPACE_ID_TO_ADDRESS_ABI = [
+  {
+    type: 'function',
+    name: 'spaceIdToAddress',
+    stateMutability: 'view',
+    inputs: [{ name: 'spaceId', type: 'bytes16' }],
+    outputs: [{ name: '', type: 'address' }],
+  },
+] as const;
+
+const LATEST_PROPOSAL_VERSION_ABI = [
+  {
+    type: 'function',
+    name: 'latestProposalVersion',
+    stateMutability: 'view',
+    inputs: [{ name: '_proposalId', type: 'bytes16' }],
+    outputs: [{ name: '_version', type: 'uint8' }],
+  },
+] as const;
+
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
+
+/**
+ * Whether `proposalId` exists on its space's DAO contract.
+ *
+ * `null` means "could not determine" — callers must treat that as "assume it
+ * exists" rather than as absence, since a wrong "absent" permanently labels a
+ * healthy proposal as unexecutable.
+ *
+ * This is the only reliable way to tell a proposal that can never execute from
+ * one that merely cannot execute yet. The migration copied proposal history into
+ * the database without recreating those proposals on chain, so the DAO has no
+ * record of them and `executeProposal` reverts forever. Both of the obvious
+ * checks are useless for detecting that: `canExecuteProposal` and
+ * `isSupportThresholdReached` each return `false` for an unknown proposal id,
+ * exactly as they do for one that simply has not passed yet. A zero version is
+ * unambiguous — the DAO assigns version 1 on creation.
+ *
+ * Needs no wallet, so signed-out viewers get the honest answer too.
+ */
+export async function proposalExistsOnChain(spaceId: string, proposalId: string): Promise<boolean | null> {
+  const spaceIdHex = (spaceId.startsWith('0x') ? spaceId : `0x${spaceId}`) as Hex;
+  const proposalIdHex = (proposalId.startsWith('0x') ? proposalId : `0x${proposalId}`) as Hex;
+
+  try {
+    // An eth_call against an address with no code returns empty data, which
+    // decodes as a zero version — indistinguishable from a real absence. Bail to
+    // `null` instead of reporting every proposal in the space as dead.
+    if (!(await contractHasCode(SPACE_REGISTRY_ADDRESS_HEX))) return null;
+
+    const client = createPublicClient({ chain: GEOGENESIS, transport: http() });
+
+    const daoAddress = (await client.readContract({
+      address: SPACE_REGISTRY_ADDRESS_HEX,
+      abi: SPACE_ID_TO_ADDRESS_ABI,
+      functionName: 'spaceIdToAddress',
+      args: [spaceIdHex],
+    })) as Hex;
+
+    if (!daoAddress || daoAddress.toLowerCase() === ZERO_ADDRESS) return null;
+    if (!(await contractHasCode(daoAddress))) return null;
+
+    const version = await client.readContract({
+      address: daoAddress,
+      abi: LATEST_PROPOSAL_VERSION_ABI,
+      functionName: 'latestProposalVersion',
+      args: [proposalIdHex],
+    });
+
+    return Number(version) > 0;
+  } catch {
+    // Fail open: an RPC blip must never brand a live proposal unexecutable.
+    return null;
+  }
+}
+
 /** Throws before a write can be sent to a SpaceRegistry address with no code. */
 export async function assertSpaceRegistryDeployed(): Promise<void> {
   if (!(await contractHasCode(SPACE_REGISTRY_ADDRESS_HEX))) {

--- a/apps/web/core/utils/contracts/proposal-executability.test.ts
+++ b/apps/web/core/utils/contracts/proposal-executability.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+
+import { ACTION_REVERTED_SELECTOR, type GovernanceRevert } from './governance-errors';
+import { classifyProposalExecutability } from './proposal-executability';
+
+const CAN_NOT_EXECUTE_SELECTOR = '0xdf322356';
+
+function revert(selector: string): GovernanceRevert {
+  return { selector } as GovernanceRevert;
+}
+
+describe('classifyProposalExecutability', () => {
+  it('is checking until a simulation has run', () => {
+    expect(classifyProposalExecutability({ existsOnChain: true, simulationRevert: undefined })).toBe('checking');
+    expect(classifyProposalExecutability({ existsOnChain: null, simulationRevert: undefined })).toBe('checking');
+  });
+
+  it('is executable when the simulation does not revert', () => {
+    expect(classifyProposalExecutability({ existsOnChain: true, simulationRevert: null })).toBe('executable');
+  });
+
+  it('fails open when the failure is unrecognisable, so a flaky RPC never hides a live action', () => {
+    expect(classifyProposalExecutability({ existsOnChain: null, simulationRevert: null })).toBe('executable');
+  });
+
+  it('is dead when the proposal action itself reverts', () => {
+    expect(
+      classifyProposalExecutability({ existsOnChain: true, simulationRevert: revert(ACTION_REVERTED_SELECTOR) })
+    ).toBe('dead');
+  });
+
+  it('is blocked for a transient governance revert', () => {
+    expect(
+      classifyProposalExecutability({ existsOnChain: true, simulationRevert: revert(CAN_NOT_EXECUTE_SELECTOR) })
+    ).toBe('blocked');
+  });
+
+  // The regression this module exists for: a migrated proposal the DAO has no
+  // record of reverts CanNotExecute(), which is otherwise classified `blocked` —
+  // i.e. transient — so the UI showed "Pending execution" forever. Absence has to
+  // win over the revert selector.
+  it('is dead when the DAO has no record of the proposal, even though it reverts CanNotExecute', () => {
+    expect(
+      classifyProposalExecutability({ existsOnChain: false, simulationRevert: revert(CAN_NOT_EXECUTE_SELECTOR) })
+    ).toBe('dead');
+  });
+
+  it('is dead when absent from the DAO before any simulation runs, so signed-out viewers see the truth', () => {
+    expect(classifyProposalExecutability({ existsOnChain: false, simulationRevert: undefined })).toBe('dead');
+  });
+
+  it('does not treat an undeterminable existence probe as absence', () => {
+    // `null` means "could not tell" — branding a healthy proposal dead off a
+    // failed probe is worse than briefly showing the optimistic state.
+    expect(
+      classifyProposalExecutability({ existsOnChain: null, simulationRevert: revert(CAN_NOT_EXECUTE_SELECTOR) })
+    ).toBe('blocked');
+  });
+});

--- a/apps/web/core/utils/contracts/proposal-executability.ts
+++ b/apps/web/core/utils/contracts/proposal-executability.ts
@@ -1,0 +1,59 @@
+import { ACTION_REVERTED_SELECTOR, type GovernanceRevert } from './governance-errors';
+
+/**
+ * Whether a passed proposal can actually be executed on-chain, and if not, why.
+ *
+ * - `checking`   — still probing (or no registered account to simulate from)
+ * - `executable` — the execute call would succeed
+ * - `dead`       — it can never execute and must be recreated: either the DAO has
+ *                  no such proposal, or the proposal's own action reverts
+ * - `blocked`    — some other governance revert (already executed, not enough
+ *                  votes, voting period not elapsed) — transient or resolved
+ */
+export type ProposalExecutability = 'checking' | 'executable' | 'dead' | 'blocked';
+
+/**
+ * Decide a proposal's executability from the two independent signals we can
+ * gather: whether the DAO knows the proposal at all, and what simulating its
+ * execute call reverts with.
+ *
+ * Pure so the classification is testable without a chain. The reason it exists
+ * separately from the probing is that the previous single-signal version quietly
+ * mislabelled a whole class of proposals: it keyed only on the revert selector and
+ * treated everything that was not `ActionReverted` as `blocked` — i.e. transient.
+ * A proposal that the DAO has never heard of reverts `CanNotExecute()`, so it
+ * landed in `blocked`, the UI kept showing the "Pending execution" fallback, and
+ * it did so forever. Migration-only proposals (present in the indexer database,
+ * never created on chain) sat like that indefinitely.
+ *
+ * `existsOnChain === false` therefore wins over any simulation result: it is the
+ * one signal that distinguishes "cannot execute yet" from "can never execute".
+ * Note the two false-negative traps that make the weaker signals unusable here —
+ * `canExecuteProposal` and `isSupportThresholdReached` both return `false` for a
+ * proposal id that does not exist, so neither can tell absence from "hasn't
+ * passed yet"; only the version lookup discriminates.
+ */
+export function classifyProposalExecutability({
+  existsOnChain,
+  simulationRevert,
+}: {
+  /** `false` = the DAO has no such proposal. `null` = could not determine. */
+  existsOnChain: boolean | null;
+  /**
+   * Decoded revert from simulating execute: `null` when it would not revert (or
+   * the failure was unrecognisable), `undefined` when no simulation was run.
+   */
+  simulationRevert: GovernanceRevert | null | undefined;
+}): ProposalExecutability {
+  // Absent from the DAO is permanent and knowable without a wallet, so it is
+  // checked before anything that needs one.
+  if (existsOnChain === false) return 'dead';
+
+  if (simulationRevert === undefined) return 'checking';
+
+  // Includes the unrecognisable-failure case: fail open so a flaky RPC or an
+  // unknown revert never hides a legitimate action behind a dead-end label.
+  if (simulationRevert === null) return 'executable';
+
+  return simulationRevert.selector === ACTION_REVERTED_SELECTOR ? 'dead' : 'blocked';
+}

--- a/apps/web/partials/active-proposal/execute.tsx
+++ b/apps/web/partials/active-proposal/execute.tsx
@@ -74,14 +74,15 @@ export function Execute({ proposalId, spaceId, variant = 'default', fallback = n
     );
   }
 
-  // The proposal's own action reverts on-chain — it can never be executed and
-  // "Pending execution" would be a lie. Say so honestly. (Editors can recreate
-  // the request one click away from the Editors menu.)
+  // The proposal can never be executed — either the DAO has no record of it, or
+  // its own action reverts on-chain. "Pending execution" would be a lie. Say so
+  // honestly. (Editors can recreate the request one click away from the Editors
+  // menu; a proposal missing from the DAO has to be published again.)
   if (executability === 'dead' && status === 'idle') {
     return (
       <div
         className="inline-flex h-6 items-center rounded bg-errorTertiary px-1.5 text-metadata leading-none text-red-01"
-        title="One of this proposal's on-chain actions reverts when executed. Older editor and member requests can hit this permanently and need to be recreated."
+        title="This proposal can never be executed: either the space's DAO has no record of it, or one of its on-chain actions reverts. Older editor and member requests, and proposals that predate this space's migration, hit this permanently and need to be recreated."
       >
         Can&apos;t be completed
       </div>

--- a/apps/web/partials/governance/governance-status-chip.tsx
+++ b/apps/web/partials/governance/governance-status-chip.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { useSmartAccount } from '~/core/hooks/use-smart-account';
 import { ProposalStatus } from '~/core/io/substream-schema';
 import { getProposalTimeRemaining } from '~/core/utils/utils';
 
@@ -22,7 +21,6 @@ interface Props {
 }
 
 export function GovernanceStatusChip({ status, endTime, canExecute, viewerVote, spaceId, proposalId }: Props) {
-  const { smartAccount } = useSmartAccount();
   switch (status) {
     case 'ACCEPTED': {
       return (
@@ -62,7 +60,13 @@ export function GovernanceStatusChip({ status, endTime, canExecute, viewerVote, 
         // self-gates on a registered personal space + an on-chain simulation,
         // falling back to the label while it checks or when the user can't
         // execute — so the status is never blank.
-        if (smartAccount && spaceId && proposalId) {
+        //
+        // Rendered without requiring a connected wallet: Execute's chain probe
+        // detects a proposal the DAO has no record of (permanently unexecutable)
+        // without one, and that is the case this label was lying about. Gating on
+        // `smartAccount` meant every signed-out viewer saw "Pending execution"
+        // forever on proposals nobody could ever execute.
+        if (spaceId && proposalId) {
           return (
             <div className="relative z-10">
               <Execute spaceId={spaceId} proposalId={proposalId} variant="small" fallback={pendingExecutionLabel} />
@@ -83,9 +87,7 @@ export function GovernanceStatusChip({ status, endTime, canExecute, viewerVote, 
 
       if (endTime <= 0) {
         return (
-          <div className="flex items-center gap-2 rounded-sm px-2 py-1.5 text-metadataMedium">
-            Voting period open
-          </div>
+          <div className="flex items-center gap-2 rounded-sm px-2 py-1.5 text-metadataMedium">Voting period open</div>
         );
       }
 


### PR DESCRIPTION
## Problem

Preston: *"is there any way we can remove these proposals that are just hanging in 'Pending execution' but are unable to be executed?"*

The migration left proposals in the indexer database that were never created on the v2 chain, so `executeProposal` reverts `CanNotExecute()` forever. **5 in AI space, 51 across 27 spaces.** Two things conspired to advertise them as executable anyway:

1. `useProposalExecutability` mapped **only** `ActionReverted` (`0x24c05f9a`) to `dead`. `CanNotExecute()` is `0xdf322356`, so it landed in `blocked` — i.e. *transient* — and `Execute` rendered the "Pending execution" fallback indefinitely.
2. `GovernanceStatusChip` only rendered `Execute` when a wallet was connected, so **every signed-out viewer saw the stale label regardless** — which is most people looking at a governance list.

So the machinery to say "Can't be completed" already existed; it just never recognised this case.

## Change

Detect absence directly with **`latestProposalVersion == 0`** (the DAO assigns version 1 on creation).

This is the only probe that works. `canExecuteProposal` and `isSupportThresholdReached` both return `false` for an unknown proposal id exactly as they do for one that merely hasn't passed yet — I tried both. Confirmed against chain 55516: **0** for all five stuck AI-space proposals, **1** for recently executed ones in the same space.

The probe needs no wallet, so it runs for signed-out viewers and the chip no longer gates on `smartAccount`. It **fails open** — a codeless address, a zero registry entry, or any RPC error resolves to "could not tell" rather than absence, because branding a healthy proposal dead is worse than briefly showing the optimistic state.

Classification moves into a pure `classifyProposalExecutability` so the ordering that actually matters — absence outranks the revert selector — is pinned by tests rather than implied by the control flow of a query function.

## Verification

- 8 new tests; 74 pass across the touched areas; eslint, prettier and `tsc` clean on the changed files.
- Mutation-tested: removing the absence branch fails exactly the two tests that assert it, so the coverage isn't decorative.
- Pre-existing local failures in `reverted-user-operation.test.ts` are **not** from this change — they fail identically with my changes stashed (stale `@geogenesis/auth` dist locally; CI builds workspaces first).

## Notes

- Pairs with geobrowser/gaia#884, which adds a verified `unexecutable_at` marker so the API reports these as terminally rejected instead of executable. This PR is the safety net that also covers anything not yet flagged, and any future orphan.
- **This does not restore the lost edits.** The affected proposals carry real `PUBLISH` actions; 4 of the 5 in AI space still have recoverable IPFS content and need republishing.
- The `dead` tooltip now names both causes (absent from the DAO, or a reverting action) rather than only the latter.
