### PR TITLE
feat(explore): redesign Featured rankings side-panel cards

### DIFF
--- a/apps/web/app/explore/page.tsx
+++ b/apps/web/app/explore/page.tsx
@@ -87,6 +87,17 @@ export default async function ExploreRoutePage() {
     pendingMembershipSpaceIds = checks.filter((id): id is string => id !== null);
   }
 
+  // Featured rankings surface only from spaces the viewer can already see in the
+  // panel: the featured (Join spaces) set or spaces they're a member/editor of. A
+  // ranking tagged Featured in some unrelated space shouldn't reach the panel.
+  const rankingSpaceAllowlist = new Set([
+    ...featuredSpaces.map(space => normId(space.spaceId)),
+    ...memberOrEditorSpaceIds.map(normId),
+  ]);
+  const visibleFeaturedRankings = featuredRankings.filter(ranking =>
+    rankingSpaceAllowlist.has(normId(ranking.spaceId))
+  );
+
   const seen = new Set<string>();
   const initialSpaceOptions: { value: string; label: string }[] = [];
   for (const row of [...browse.featured, ...browse.editorOf, ...browse.memberOf]) {
@@ -100,7 +111,7 @@ export default async function ExploreRoutePage() {
     <ExplorePage
       initialSpaceOptions={initialSpaceOptions}
       featuredSpaces={featuredSpaces}
-      featuredRankings={featuredRankings}
+      featuredRankings={visibleFeaturedRankings}
       pendingMembershipSpaceIds={pendingMembershipSpaceIds}
       memberOrEditorSpaceIds={memberOrEditorSpaceIds}
       communityCalls={communityCalls}

--- a/apps/web/core/io/subgraph/fetch-featured-rankings.test.ts
+++ b/apps/web/core/io/subgraph/fetch-featured-rankings.test.ts
@@ -13,18 +13,22 @@ import { fetchFeaturedRankings } from './fetch-featured-rankings';
 const getAllEntitiesMock = vi.fn();
 const getEntityPageMock = vi.fn();
 const getRelationsByToEntityIdsMock = vi.fn();
+const getSpacesMock = vi.fn();
 const getSubmitterRefsMock = vi.fn();
 const getSubmissionCountMock = vi.fn();
+const getOrderedRelationTargetIdsMock = vi.fn();
 
 vi.mock('~/core/io/queries', () => ({
   getAllEntities: (...args: unknown[]) => getAllEntitiesMock(...args),
   getEntityPage: (...args: unknown[]) => getEntityPageMock(...args),
   getRelationsByToEntityIds: (...args: unknown[]) => getRelationsByToEntityIdsMock(...args),
+  getSpaces: (...args: unknown[]) => getSpacesMock(...args),
 }));
 
 vi.mock('~/core/blocks/ranking/ranking-block-relations', () => ({
   getAggregatedRankingSubmitterRefs: (...args: unknown[]) => getSubmitterRefsMock(...args),
   getAggregatedRankingSubmissionCount: (...args: unknown[]) => getSubmissionCountMock(...args),
+  getOrderedRelationTargetIds: (...args: unknown[]) => getOrderedRelationTargetIdsMock(...args),
 }));
 
 const BLOCK = 'cb5afff8d4f04436ab8110c238008926';
@@ -72,14 +76,18 @@ describe('fetchFeaturedRankings', () => {
     getAllEntitiesMock.mockReset();
     getEntityPageMock.mockReset();
     getRelationsByToEntityIdsMock.mockReset();
+    getSpacesMock.mockReset();
     getSubmitterRefsMock.mockReset();
     getSubmissionCountMock.mockReset();
+    getOrderedRelationTargetIdsMock.mockReset();
 
     // Sensible happy-path defaults; individual tests override as needed.
     getAllEntitiesMock.mockReturnValue(Effect.succeed({ entities: [{ id: BLOCK, spaces: [SPACE] }] }));
     getRelationsByToEntityIdsMock.mockReturnValue(Effect.succeed(blocksRelation()));
+    getSpacesMock.mockReturnValue(Effect.succeed([]));
     getSubmitterRefsMock.mockReturnValue([{ rankEntityId: RANK_ENTITY, spaceId: SUBMITTER_SPACE }]);
     getSubmissionCountMock.mockReturnValue(3);
+    getOrderedRelationTargetIdsMock.mockReturnValue([]);
   });
 
   it('keeps a live ranking and resolves its space/block/parent coordinates and submitters', async () => {
@@ -98,8 +106,55 @@ describe('fetchFeaturedRankings', () => {
         rankingEndDate: FUTURE,
         submitterSpaceIds: [SUBMITTER_SPACE],
         submissionCount: 3,
+        spaceName: null,
+        spaceImage: null,
+        topEntries: [],
       },
     ]);
+  });
+
+  it('resolves leaderboard top entries in standings order and attaches space metadata', async () => {
+    const FIRST = 'e1c9f267dcb0d270718c2a3c45a64afd';
+    const SECOND = 'e2c9f267dcb0d270718c2a3c45a64afd';
+
+    getEntityPageMock.mockReturnValue(Effect.succeed(entityPage({ startDate: PAST, endDate: FUTURE })));
+    getOrderedRelationTargetIdsMock.mockReturnValue([FIRST, SECOND]);
+    getAllEntitiesMock.mockImplementation((opts: { filter?: { id?: { in?: string[] } } }) => {
+      if (opts.filter?.id?.in) {
+        // Returned out of order — the fetcher must re-order to the standings.
+        return Effect.succeed({
+          entities: [
+            { id: SECOND, name: 'Rome', relations: [] },
+            { id: FIRST, name: 'Paris', relations: [] },
+          ],
+        });
+      }
+      return Effect.succeed({ entities: [{ id: BLOCK, spaces: [SPACE] }] });
+    });
+    getSpacesMock.mockReturnValue(
+      Effect.succeed([{ id: SPACE, entity: { name: 'Travel', image: 'ipfs://space-image' } }])
+    );
+
+    const result = await fetchFeaturedRankings();
+
+    expect(result).toHaveLength(1);
+    expect(result[0].topEntries).toEqual([
+      { entityId: FIRST, name: 'Paris', image: null },
+      { entityId: SECOND, name: 'Rome', image: null },
+    ]);
+    expect(result[0].spaceName).toBe('Travel');
+    expect(result[0].spaceImage).toBe('ipfs://space-image');
+  });
+
+  it('still returns rankings when the space metadata lookup fails', async () => {
+    getEntityPageMock.mockReturnValue(Effect.succeed(entityPage({ startDate: PAST, endDate: FUTURE })));
+    getSpacesMock.mockImplementation(() => Effect.die(new Error('boom')));
+
+    const result = await fetchFeaturedRankings();
+
+    expect(result).toHaveLength(1);
+    expect(result[0].spaceName).toBeNull();
+    expect(result[0].spaceImage).toBeNull();
   });
 
   it('resolves the window from the legacy date properties when the current ones are absent', async () => {

--- a/apps/web/core/io/subgraph/fetch-featured-rankings.test.ts
+++ b/apps/web/core/io/subgraph/fetch-featured-rankings.test.ts
@@ -146,6 +146,22 @@ describe('fetchFeaturedRankings', () => {
     expect(result[0].spaceImage).toBe('ipfs://space-image');
   });
 
+  it('still returns the ranking (without a leaderboard) when the top-entries lookup fails', async () => {
+    getEntityPageMock.mockReturnValue(Effect.succeed(entityPage({ startDate: PAST, endDate: FUTURE })));
+    getOrderedRelationTargetIdsMock.mockReturnValue(['e1c9f267dcb0d270718c2a3c45a64afd']);
+    getAllEntitiesMock.mockImplementation((opts: { filter?: { id?: { in?: string[] } } }) => {
+      if (opts.filter?.id?.in) {
+        return Effect.die(new Error('entities lookup down'));
+      }
+      return Effect.succeed({ entities: [{ id: BLOCK, spaces: [SPACE] }] });
+    });
+
+    const result = await fetchFeaturedRankings();
+
+    expect(result).toHaveLength(1);
+    expect(result[0].topEntries).toEqual([]);
+  });
+
   it('still returns rankings when the space metadata lookup fails', async () => {
     getEntityPageMock.mockReturnValue(Effect.succeed(entityPage({ startDate: PAST, endDate: FUTURE })));
     getSpacesMock.mockImplementation(() => Effect.die(new Error('boom')));

--- a/apps/web/core/io/subgraph/fetch-featured-rankings.ts
+++ b/apps/web/core/io/subgraph/fetch-featured-rankings.ts
@@ -125,23 +125,31 @@ async function resolveSubmitterSpaceIds(refs: AggregatedRankingSubmitterRef[]): 
 
 /**
  * Resolve the aggregated leaderboard's top entries (name + thumbnail), in
- * standings order. Best-effort: an entity that fails to resolve still renders,
- * as "Untitled" with no image, so the list keeps its positions.
+ * standings order. Best-effort twice over: an entity missing from the response
+ * still renders (as "Untitled" with no image) so the list keeps its positions,
+ * and a failed lookup yields an empty list so the ranking card still renders
+ * without its leaderboard instead of being dropped by the per-ranking catch.
  */
 async function resolveTopEntries(entityIds: string[], spaceId: string): Promise<FeaturedRankingEntry[]> {
   if (entityIds.length === 0) return [];
-  const { entities } = await Effect.runPromise(
-    getAllEntities({ filter: { id: { in: entityIds } }, spaceId, limit: entityIds.length })
-  );
-  const entitiesById = new Map(entities.map(entity => [entity.id, entity]));
-  return entityIds.map(entityId => {
-    const entity = entitiesById.get(entityId);
-    return {
-      entityId,
-      name: entity?.name?.trim() || 'Untitled',
-      image: entity ? (Entities.avatar(entity.relations) ?? Entities.cover(entity.relations) ?? null) : null,
-    };
-  });
+
+  try {
+    const { entities } = await Effect.runPromise(
+      getAllEntities({ filter: { id: { in: entityIds } }, spaceId, limit: entityIds.length })
+    );
+    const entitiesById = new Map(entities.map(entity => [entity.id, entity]));
+    return entityIds.map(entityId => {
+      const entity = entitiesById.get(entityId);
+      return {
+        entityId,
+        name: entity?.name?.trim() || 'Untitled',
+        image: entity ? (Entities.avatar(entity.relations) ?? Entities.cover(entity.relations) ?? null) : null,
+      };
+    });
+  } catch (error) {
+    console.error(`Unable to resolve featured ranking top entries (space ${spaceId})`, error);
+    return [];
+  }
 }
 
 /**

--- a/apps/web/core/io/subgraph/fetch-featured-rankings.ts
+++ b/apps/web/core/io/subgraph/fetch-featured-rankings.ts
@@ -11,19 +11,28 @@ import {
   type AggregatedRankingSubmitterRef,
   getAggregatedRankingSubmissionCount,
   getAggregatedRankingSubmitterRefs,
+  getOrderedRelationTargetIds,
 } from '~/core/blocks/ranking/ranking-block-relations';
 import { getRankingPeriodState, rankingSubmissionsOpen } from '~/core/blocks/ranking/ranking-period';
 import { FEATURED_TAG_ID, TAG_PROPERTY_ID } from '~/core/constants';
 import type { EntityFilter } from '~/core/gql/graphql';
-import { getAllEntities, getEntityPage, getRelationsByToEntityIds } from '~/core/io/queries';
-import { RANKING_BLOCK_TYPE_ID } from '~/core/ranking-block-ids';
+import { getAllEntities, getEntityPage, getRelationsByToEntityIds, getSpaces } from '~/core/io/queries';
+import { RANKING_BLOCK_TYPE_ID, RANK_POSITION_PROPERTY_ID } from '~/core/ranking-block-ids';
 import type { Entity } from '~/core/types';
+import { Entities } from '~/core/utils/entity';
 import { mapWithConcurrency } from '~/core/utils/map-with-concurrency';
+import { normId } from '~/core/utils/norm-id';
 
 // A featured ranking is a Ranking Block entity carrying a TAG_PROPERTY relation
 // to the Featured tag entity. We surface only the ones whose voting window is
 // currently open ("live"), each resolved down to the coordinates the fullscreen
 // vote view needs (space + block + parent placement).
+export interface FeaturedRankingEntry {
+  entityId: string;
+  name: string;
+  image: string | null;
+}
+
 export interface FeaturedRanking {
   blockEntityId: string;
   spaceId: string;
@@ -37,6 +46,11 @@ export interface FeaturedRanking {
   /** Personal spaces that submitted a ranking — feeds the "Ranked by" avatars. */
   submitterSpaceIds: string[];
   submissionCount: number;
+  /** Name/image of the space the block lives in — feeds the card's space badge. */
+  spaceName: string | null;
+  spaceImage: string | null;
+  /** Current aggregated leaderboard, best first — the card pages through it in threes. */
+  topEntries: FeaturedRankingEntry[];
 }
 
 // Pull a small window of candidates, then keep only the live ones. A handful of
@@ -45,6 +59,10 @@ export interface FeaturedRanking {
 const MAX_CANDIDATES = 25;
 const MAX_FEATURED_RANKINGS = 10;
 const RESOLVE_CONCURRENCY = 6;
+
+// The card shows three leaderboard entries per page; nine covers three pages
+// without fetching the whole standings.
+const MAX_TOP_ENTRIES = 9;
 
 // Entities that are Ranking Blocks AND tagged Featured.
 const FEATURED_RANKINGS_FILTER: EntityFilter = {
@@ -106,6 +124,54 @@ async function resolveSubmitterSpaceIds(refs: AggregatedRankingSubmitterRef[]): 
 }
 
 /**
+ * Resolve the aggregated leaderboard's top entries (name + thumbnail), in
+ * standings order. Best-effort: an entity that fails to resolve still renders,
+ * as "Untitled" with no image, so the list keeps its positions.
+ */
+async function resolveTopEntries(entityIds: string[], spaceId: string): Promise<FeaturedRankingEntry[]> {
+  if (entityIds.length === 0) return [];
+  const { entities } = await Effect.runPromise(
+    getAllEntities({ filter: { id: { in: entityIds } }, spaceId, limit: entityIds.length })
+  );
+  const entitiesById = new Map(entities.map(entity => [entity.id, entity]));
+  return entityIds.map(entityId => {
+    const entity = entitiesById.get(entityId);
+    return {
+      entityId,
+      name: entity?.name?.trim() || 'Untitled',
+      image: entity ? (Entities.avatar(entity.relations) ?? Entities.cover(entity.relations) ?? null) : null,
+    };
+  });
+}
+
+/**
+ * Attach each ranking's space name/image via one batched spaces lookup.
+ * Best-effort: on failure the cards render without the space badge rather than
+ * dropping the section.
+ */
+async function attachSpaceMetadata(rankings: FeaturedRanking[]): Promise<FeaturedRanking[]> {
+  const spaceIds = dedupePreserveOrder(rankings.map(ranking => ranking.spaceId));
+  if (spaceIds.length === 0) return rankings;
+
+  try {
+    const spaces = await Effect.runPromise(getSpaces({ spaceIds }));
+    const spacesById = new Map(spaces.map(space => [normId(space.id), space]));
+    return rankings.map(ranking => {
+      const space = spacesById.get(normId(ranking.spaceId));
+      if (!space) return ranking;
+      return {
+        ...ranking,
+        spaceName: space.entity.name?.trim() || null,
+        spaceImage: space.entity.image ?? null,
+      };
+    });
+  } catch (error) {
+    console.error('Unable to resolve featured ranking space metadata', error);
+    return rankings;
+  }
+}
+
+/**
  * Find where a block is embedded: its parent entity id and the id of the BLOCKS
  * relation binding them. The block is the target of a BLOCKS relation from its
  * parent, so we read the block's backlinks. Returns null when the placement
@@ -149,47 +215,67 @@ export async function fetchFeaturedRankings(): Promise<FeaturedRanking[]> {
 
   // 2. Resolve each candidate scoped to its space: date window (for the live
   //    check), aggregated submitters, and parent placement.
-  const resolved = await mapWithConcurrency(candidates, RESOLVE_CONCURRENCY, async ({ blockEntityId, spaceId }) => {
-    try {
-      const page = await Effect.runPromise(getEntityPage(blockEntityId, spaceId));
-      if (!page?.entity) return null;
+  const resolved = await mapWithConcurrency(
+    candidates,
+    RESOLVE_CONCURRENCY,
+    async ({ blockEntityId, spaceId }): Promise<FeaturedRanking | null> => {
+      try {
+        const page = await Effect.runPromise(getEntityPage(blockEntityId, spaceId));
+        if (!page?.entity) return null;
 
-      const entity = page.entity;
-      const relations = page.relations.length > 0 ? page.relations : entity.relations;
+        const entity = page.entity;
+        const relations = page.relations.length > 0 ? page.relations : entity.relations;
 
-      const readBlockDate = (propertyId: string) => readDateValue(entity, propertyId, spaceId);
-      const rankingStartDate = resolveRankingDateValue(RANKING_START_PROPERTY_IDS, readBlockDate);
-      const rankingEndDate = resolveRankingDateValue(RANKING_END_PROPERTY_IDS, readBlockDate);
+        const readBlockDate = (propertyId: string) => readDateValue(entity, propertyId, spaceId);
+        const rankingStartDate = resolveRankingDateValue(RANKING_START_PROPERTY_IDS, readBlockDate);
+        const rankingEndDate = resolveRankingDateValue(RANKING_END_PROPERTY_IDS, readBlockDate);
 
-      // "Live" == voting is currently open (in-progress, or no bounded window).
-      const periodState = getRankingPeriodState(rankingStartDate, rankingEndDate);
-      if (!rankingSubmissionsOpen(periodState)) return null;
+        // "Live" == voting is currently open (in-progress, or no bounded window).
+        const periodState = getRankingPeriodState(rankingStartDate, rankingEndDate);
+        if (!rankingSubmissionsOpen(periodState)) return null;
 
-      const placement = await resolveBlockPlacement(blockEntityId, spaceId);
-      if (!placement) return null;
+        const placement = await resolveBlockPlacement(blockEntityId, spaceId);
+        if (!placement) return null;
 
-      const submitterRefs = getAggregatedRankingSubmitterRefs(relations, blockEntityId, spaceId);
-      const submitterSpaceIds = await resolveSubmitterSpaceIds(submitterRefs);
+        const submitterRefs = getAggregatedRankingSubmitterRefs(relations, blockEntityId, spaceId);
+        const submitterSpaceIds = await resolveSubmitterSpaceIds(submitterRefs);
 
-      return {
-        blockEntityId,
-        spaceId,
-        parentEntityId: placement.parentEntityId,
-        relationId: placement.relationId,
-        name: entity.name?.trim() || 'Untitled ranking',
-        rankingStartDate: rankingStartDate.value,
-        rankingEndDate: rankingEndDate.value,
-        submitterSpaceIds,
-        submissionCount: getAggregatedRankingSubmissionCount(relations, blockEntityId, spaceId),
-      } satisfies FeaturedRanking;
-    } catch (error) {
-      // Best-effort per ranking: a single block that fails to resolve is skipped
-      // rather than failing the whole section, but log it so silently-missing
-      // featured rankings stay debuggable in production.
-      console.error(`Unable to resolve featured ranking (block ${blockEntityId}, space ${spaceId})`, error);
-      return null;
+        const orderedEntityIds = getOrderedRelationTargetIds(
+          relations,
+          blockEntityId,
+          RANK_POSITION_PROPERTY_ID,
+          spaceId
+        ).slice(0, MAX_TOP_ENTRIES);
+        const topEntries = await resolveTopEntries(orderedEntityIds, spaceId);
+
+        return {
+          blockEntityId,
+          spaceId,
+          parentEntityId: placement.parentEntityId,
+          relationId: placement.relationId,
+          name: entity.name?.trim() || 'Untitled ranking',
+          rankingStartDate: rankingStartDate.value,
+          rankingEndDate: rankingEndDate.value,
+          submitterSpaceIds,
+          submissionCount: getAggregatedRankingSubmissionCount(relations, blockEntityId, spaceId),
+          // Space metadata is attached in one batched lookup after the per-block resolve.
+          spaceName: null,
+          spaceImage: null,
+          topEntries,
+        } satisfies FeaturedRanking;
+      } catch (error) {
+        // Best-effort per ranking: a single block that fails to resolve is skipped
+        // rather than failing the whole section, but log it so silently-missing
+        // featured rankings stay debuggable in production.
+        console.error(`Unable to resolve featured ranking (block ${blockEntityId}, space ${spaceId})`, error);
+        return null;
+      }
     }
-  });
+  );
 
-  return resolved.filter((ranking): ranking is FeaturedRanking => ranking !== null).slice(0, MAX_FEATURED_RANKINGS);
+  const rankings = resolved
+    .filter((ranking): ranking is FeaturedRanking => ranking !== null)
+    .slice(0, MAX_FEATURED_RANKINGS);
+
+  return attachSpaceMetadata(rankings);
 }

--- a/apps/web/partials/explore/explore-join-space-button.tsx
+++ b/apps/web/partials/explore/explore-join-space-button.tsx
@@ -10,8 +10,9 @@ import { Pending } from '~/design-system/pending';
 type ExploreJoinSpaceButtonProps = {
   spaceId: string;
   hasRequestedSpaceMembership: boolean;
-  /** Render style. 'text' (default) for inline article-card use; 'button' for the chip-styled button. */
-  variant?: 'text' | 'button';
+  /** Render style. 'text' (default) for inline article-card use; 'button' for the
+   *  chip-styled button; 'pill' for the compact rounded pill next to a space badge. */
+  variant?: 'text' | 'button' | 'pill';
   /** CTA label for the idle state. Defaults to 'Join space'; pill use passes 'Join'. */
   label?: string;
 };
@@ -36,6 +37,21 @@ export function ExploreJoinSpaceButton({
     <Pending isPending={status === 'pending'} position="end">
       {showPendingLabel ? (
         <span className="text-smallButton text-grey-04">Membership pending</span>
+      ) : variant === 'pill' ? (
+        <button
+          type="button"
+          className="flex h-[18px] items-center rounded-full border border-grey-02 px-1.5 text-[14px] leading-[13px] text-text transition-colors duration-150 hover:border-text"
+          disabled={status !== 'idle'}
+          onClick={() => {
+            if (!smartAccount) {
+              openSignInPrompt('join');
+              return;
+            }
+            requestToBeMember();
+          }}
+        >
+          {label}
+        </button>
       ) : variant === 'button' ? (
         <button
           type="button"

--- a/apps/web/partials/explore/explore-side-panel.tsx
+++ b/apps/web/partials/explore/explore-side-panel.tsx
@@ -60,7 +60,16 @@ export function ExploreSidePanel({
     sections.push({ key: 'join-spaces', node: <JoinSpacesSection spaces={joinableSpaces} /> });
   }
   if (featuredRankings.length > 0) {
-    sections.push({ key: 'featured-rankings', node: <FeaturedRankingsSection rankings={featuredRankings} /> });
+    sections.push({
+      key: 'featured-rankings',
+      node: (
+        <FeaturedRankingsSection
+          rankings={featuredRankings}
+          memberOrEditorSpaceIds={memberOrEditorSet}
+          pendingMembershipSpaceIds={pendingSet}
+        />
+      ),
+    });
   }
   if (communityCalls.length > 0) {
     sections.push({

--- a/apps/web/partials/explore/featured-rankings-section.tsx
+++ b/apps/web/partials/explore/featured-rankings-section.tsx
@@ -4,20 +4,33 @@ import * as React from 'react';
 
 import { rankingComposeHref } from '~/core/blocks/ranking/ranking-compose-url';
 import type { FeaturedRanking } from '~/core/io/subgraph/fetch-featured-rankings';
+import { normId } from '~/core/utils/norm-id';
 
+import { FallbackImage } from '~/design-system/fallback-image';
+import { LeftArrowLong } from '~/design-system/icons/left-arrow-long';
+import { RightArrowLong } from '~/design-system/icons/right-arrow-long';
 import { PrefetchLink as Link } from '~/design-system/prefetch-link';
 
 import { RankingAggregatedSubmitterAvatars } from '~/partials/blocks/table/ranking-period-metadata';
 
+import { ExploreJoinSpaceButton } from './explore-join-space-button';
+
 type Props = {
   rankings: FeaturedRanking[];
+  /** Spaces the viewer already belongs to — no Join pill for these. */
+  memberOrEditorSpaceIds: Set<string>;
+  /** Spaces with an in-flight membership request — render "Membership pending". */
+  pendingMembershipSpaceIds: Set<string>;
 };
 
-// Show five rankings, with a "Show more" toggle revealing the rest — mirrors the
-// "Join spaces" featured-spaces section.
-const INITIAL_VISIBLE_COUNT = 5;
+// The redesigned cards are tall (leaderboard + footer), so cap the initial list
+// lower than the old compact rows and reveal the rest behind "Show more".
+const INITIAL_VISIBLE_COUNT = 3;
 
-export function FeaturedRankingsSection({ rankings }: Props) {
+// Leaderboard page size — matches the design's three visible entries.
+const ENTRIES_PER_PAGE = 3;
+
+export function FeaturedRankingsSection({ rankings, memberOrEditorSpaceIds, pendingMembershipSpaceIds }: Props) {
   const [showAll, setShowAll] = React.useState(false);
 
   if (rankings.length === 0) return null;
@@ -27,14 +40,19 @@ export function FeaturedRankingsSection({ rankings }: Props) {
 
   return (
     <section className="flex flex-col">
-      <h2 className="sticky top-0 z-20 bg-white pt-1 pb-4 text-[19px] leading-[23px] font-semibold tracking-[-0.02em] text-text">
-        Featured rankings
-      </h2>
+      <div className="flex flex-col gap-1 pb-4">
+        <h2 className="text-[19px] leading-[23px] font-semibold tracking-[-0.02em] text-text">Featured rankings</h2>
+        <p className="text-[16px] leading-[20px] text-grey-04">Rank top content every day to impact what people see</p>
+      </div>
 
       <ul className="flex flex-col gap-3">
         {visible.map(ranking => (
           <li key={ranking.blockEntityId}>
-            <FeaturedRankingCard ranking={ranking} />
+            <FeaturedRankingCard
+              ranking={ranking}
+              isMember={memberOrEditorSpaceIds.has(normId(ranking.spaceId))}
+              pending={pendingMembershipSpaceIds.has(normId(ranking.spaceId))}
+            />
           </li>
         ))}
       </ul>
@@ -52,8 +70,16 @@ export function FeaturedRankingsSection({ rankings }: Props) {
   );
 }
 
-function FeaturedRankingCard({ ranking }: { ranking: FeaturedRanking }) {
-  // The Vote button opens the ranking's fullscreen view (mode: 'view'), from
+function FeaturedRankingCard({
+  ranking,
+  isMember,
+  pending,
+}: {
+  ranking: FeaturedRanking;
+  isMember: boolean;
+  pending: boolean;
+}) {
+  // The Rank button opens the ranking's fullscreen view (mode: 'view'), from
   // which the user can build and submit their ranking — the same target the
   // in-page fullscreen trigger uses (table-block-ranking.tsx).
   const href = rankingComposeHref({
@@ -66,33 +92,103 @@ function FeaturedRankingCard({ ranking }: { ranking: FeaturedRanking }) {
     mode: 'view',
   });
 
+  const [page, setPage] = React.useState(0);
+  const pageCount = Math.max(1, Math.ceil(ranking.topEntries.length / ENTRIES_PER_PAGE));
+  const currentPage = Math.min(page, pageCount - 1);
+  const pageStart = currentPage * ENTRIES_PER_PAGE;
+  const pageEntries = ranking.topEntries.slice(pageStart, pageStart + ENTRIES_PER_PAGE);
+  const showPager = ranking.topEntries.length > ENTRIES_PER_PAGE;
+
   // Gate on resolved submitter spaces, not the raw count: when submitters exist
-  // but none resolve to a space, the avatar group renders nothing, and keying off
-  // the count alone would leave a dangling "Ranked by" label with no avatars.
+  // but none resolve to a space, the avatar group renders nothing.
   const hasRankedBy = ranking.submitterSpaceIds.length > 0;
+  const hasSpaceBadge = Boolean(ranking.spaceName);
 
   return (
-    <div className="flex items-center justify-between gap-3 rounded-lg border border-grey-02 px-4 py-3">
-      <div className="flex min-w-0 flex-col gap-0.5">
-        <span className="truncate text-[16px] leading-[20px] font-medium text-text">{ranking.name}</span>
-        {hasRankedBy ? (
-          <span className="flex min-w-0 flex-nowrap items-center gap-2 text-metadata text-grey-04">
-            <span className="shrink-0">Ranked by</span>
-            <RankingAggregatedSubmitterAvatars
-              submitterSpaceIds={ranking.submitterSpaceIds}
-              totalCount={ranking.submissionCount || ranking.submitterSpaceIds.length}
-            />
-          </span>
-        ) : null}
+    <div className="flex flex-col rounded-xl border border-grey-02 p-5">
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex min-w-0 items-center gap-1.5">
+          {hasSpaceBadge ? (
+            <>
+              <span className="relative size-3 shrink-0 overflow-hidden rounded bg-grey-01">
+                <FallbackImage value={ranking.spaceImage ?? ''} sizes="12px" className="object-cover" />
+              </span>
+              <span className="truncate text-[14px] leading-[16px] text-text">{ranking.spaceName}</span>
+            </>
+          ) : null}
+          {!isMember ? (
+            <span className="shrink-0">
+              <ExploreJoinSpaceButton
+                spaceId={ranking.spaceId}
+                hasRequestedSpaceMembership={pending}
+                variant="pill"
+                label="Join"
+              />
+            </span>
+          ) : null}
+        </div>
+        <Link
+          href={href}
+          aria-label={`Rank ${ranking.name}`}
+          className="flex h-7 shrink-0 items-center rounded-full bg-text px-2.5 text-[16px] leading-[13px] text-white transition-colors hover:bg-text/90"
+        >
+          Rank
+        </Link>
       </div>
 
-      <Link
-        href={href}
-        aria-label={`Vote on ${ranking.name}`}
-        className="flex h-8 shrink-0 items-center rounded-lg border border-grey-02 px-3 text-[16px] leading-[18px] text-text shadow-button transition-colors hover:border-text"
-      >
-        Vote
-      </Link>
+      <span className="mt-1 truncate text-[16px] leading-[20px] font-medium text-text">{ranking.name}</span>
+
+      {pageEntries.length > 0 ? (
+        <ol className="mt-5 flex flex-col gap-1.5">
+          {pageEntries.map((entry, index) => (
+            <li key={entry.entityId} className="flex items-center gap-3">
+              <span className="w-3 shrink-0 text-[16px] leading-[18px] font-medium text-text tabular-nums">
+                {pageStart + index + 1}
+              </span>
+              <span className="flex min-w-0 flex-1 items-center gap-2">
+                <span className="relative size-6 shrink-0 overflow-hidden rounded bg-grey-01">
+                  {entry.image ? <FallbackImage value={entry.image} sizes="24px" className="object-cover" /> : null}
+                </span>
+                <span className="min-w-0 flex-1 truncate text-[16px] leading-[20px] text-text">{entry.name}</span>
+              </span>
+            </li>
+          ))}
+        </ol>
+      ) : null}
+
+      {hasRankedBy || showPager ? (
+        <div className="mt-5 flex min-h-4 items-center justify-between gap-3">
+          <span className="flex min-w-0 items-center">
+            {hasRankedBy ? (
+              <RankingAggregatedSubmitterAvatars
+                submitterSpaceIds={ranking.submitterSpaceIds}
+                totalCount={ranking.submissionCount || ranking.submitterSpaceIds.length}
+                size={12}
+              />
+            ) : null}
+          </span>
+          {showPager ? (
+            <span className="flex shrink-0 items-center gap-3">
+              <button
+                type="button"
+                aria-label="Previous entries"
+                disabled={currentPage === 0}
+                onClick={() => setPage(prev => Math.max(0, prev - 1))}
+              >
+                <LeftArrowLong color={currentPage === 0 ? 'grey-03' : 'text'} />
+              </button>
+              <button
+                type="button"
+                aria-label="Next entries"
+                disabled={currentPage >= pageCount - 1}
+                onClick={() => setPage(prev => Math.min(pageCount - 1, prev + 1))}
+              >
+                <RightArrowLong color={currentPage >= pageCount - 1 ? 'grey-03' : 'text'} />
+              </button>
+            </span>
+          ) : null}
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/apps/web/partials/explore/featured-rankings-section.tsx
+++ b/apps/web/partials/explore/featured-rankings-section.tsx
@@ -141,14 +141,16 @@ function FeaturedRankingCard({
       {pageEntries.length > 0 ? (
         <ol className="mt-5 flex flex-col gap-1.5">
           {pageEntries.map((entry, index) => (
-            <li key={entry.entityId} className="flex items-center gap-3">
+            <li key={entry.entityId} className="flex min-h-6 items-center gap-3">
               <span className="w-3 shrink-0 text-[16px] leading-[18px] font-medium text-text tabular-nums">
                 {pageStart + index + 1}
               </span>
               <span className="flex min-w-0 flex-1 items-center gap-2">
-                <span className="relative size-6 shrink-0 overflow-hidden rounded bg-grey-01">
-                  {entry.image ? <FallbackImage value={entry.image} sizes="24px" className="object-cover" /> : null}
-                </span>
+                {entry.image ? (
+                  <span className="relative size-6 shrink-0 overflow-hidden rounded bg-grey-01">
+                    <FallbackImage value={entry.image} sizes="24px" className="object-cover" />
+                  </span>
+                ) : null}
                 <span className="min-w-0 flex-1 truncate text-[16px] leading-[20px] text-text">{entry.name}</span>
               </span>
             </li>

--- a/apps/web/partials/explore/featured-rankings-section.tsx
+++ b/apps/web/partials/explore/featured-rankings-section.tsx
@@ -3,6 +3,7 @@
 import * as React from 'react';
 
 import { rankingComposeHref } from '~/core/blocks/ranking/ranking-compose-url';
+import { useEntitySidePanel } from '~/core/hooks/use-entity-side-panel';
 import type { FeaturedRanking } from '~/core/io/subgraph/fetch-featured-rankings';
 import { normId } from '~/core/utils/norm-id';
 
@@ -92,6 +93,8 @@ function FeaturedRankingCard({
     mode: 'view',
   });
 
+  const { openSidePanel } = useEntitySidePanel();
+
   const [page, setPage] = React.useState(0);
   const pageCount = Math.max(1, Math.ceil(ranking.topEntries.length / ENTRIES_PER_PAGE));
   const currentPage = Math.min(page, pageCount - 1);
@@ -151,7 +154,13 @@ function FeaturedRankingCard({
                     <FallbackImage value={entry.image} sizes="24px" className="object-cover" />
                   </span>
                 ) : null}
-                <span className="min-w-0 flex-1 truncate text-[16px] leading-[20px] text-text">{entry.name}</span>
+                <button
+                  type="button"
+                  onClick={() => openSidePanel(entry.entityId, ranking.spaceId, false)}
+                  className="min-w-0 flex-1 truncate text-left text-[16px] leading-[20px] text-text hover:underline"
+                >
+                  {entry.name}
+                </button>
               </span>
             </li>
           ))}


### PR DESCRIPTION
## What

Updates the explore page's **Featured rankings** side-panel section to match the new Figma design ([node 73790-76229](https://www.figma.com/design/iWKsYButqqKWd1bqeBrUUj/Geo---Web?node-id=73790-76229&m=dev), right side panel).

Each card now shows:
- **Space badge** (space image + name) with a compact **Join** pill when the viewer isn't a member (reuses `ExploreJoinSpaceButton` via a new `pill` variant; hidden for members, flips to "Membership pending" after a request)
- A black **Rank** pill button opening the ranking's fullscreen compose view (same target as the old Vote button)
- The ranking title
- The current **top-3 leaderboard entries** (rank number, entity thumbnail, name), pageable in threes via prev/next arrows (up to 9 entries fetched)
- The **submitter avatar group** (+count) in the footer

The section header gains the design's subtitle ("Rank top content every day to impact what people see").

## How

- `fetchFeaturedRankings` now resolves each block's aggregated leaderboard order (`getOrderedRelationTargetIds` on `RANK_POSITION_PROPERTY`, mirroring the global OG-card path) and the top entries' names/thumbnails, plus the owning space's name/image via one batched `getSpaces` lookup. Both are best-effort so a degraded call can't drop the section.
- `ExploreSidePanel` passes its existing member/pending sets down so the Join pill renders only when joinable.

## Testing

- `fetch-featured-rankings` unit tests updated + new cases for standings order, space metadata, and metadata-lookup failure (9 passing)
- `next build` (type check included) passes; eslint clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)