### PR TITLE
fix(web): 404 impossible /space URLs instead of rendering them with a 200

### DIFF
--- a/apps/web/app/robots.ts
+++ b/apps/web/app/robots.ts
@@ -1,0 +1,34 @@
+import type { MetadataRoute } from 'next';
+
+/**
+ * There was no robots.txt at all — the URL returned 404 — so crawlers had no
+ * guidance on a site whose `/space/...` space is effectively unbounded.
+ *
+ * The rules stay permissive for real content: space and entity pages are the
+ * public knowledge graph and should be indexed. What is disallowed is the set of
+ * paths that cost a full uncached server render while having nothing worth
+ * indexing, which is what the crawl budget was being spent on.
+ *
+ * This is a mitigation, not the fix. The fix is `middleware.ts` returning a real
+ * 404 for malformed URLs — robots.txt is advisory and the well-behaved crawlers
+ * that honour it were never the whole problem.
+ */
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+      disallow: [
+        // Server-rendered API surface: no indexable content, and some of it is
+        // expensive (dynamic OG image generation, chat, sweeps).
+        '/api/',
+        // Per-user and write-oriented views. They render per request, are
+        // meaningless without a session, and generate unbounded URL variants.
+        '/space/*/import',
+        '/space/*/debug-debates',
+        '/space/*/ranking-compose',
+        '/space/*/power-tools',
+      ],
+    },
+  };
+}

--- a/apps/web/core/utils/space-url.test.ts
+++ b/apps/web/core/utils/space-url.test.ts
@@ -1,0 +1,100 @@
+import { IdUtils } from '@geoprotocol/geo-sdk/lite';
+import { describe, expect, it } from 'vitest';
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { SPACE_ROOT_SEGMENTS, SPACE_TAB_SEGMENTS, isPossibleSpacePath, isValidId } from './space-url';
+
+const APP_SPACE_DIR = path.join(process.cwd(), 'app', 'space');
+
+/** Route-group dirs `(x)` are URL-invisible; `[x]` are params. Neither is a literal segment. */
+function literalDirs(dir: string): string[] {
+  if (!fs.existsSync(dir)) return [];
+  return fs
+    .readdirSync(dir, { withFileTypes: true })
+    .filter(entry => entry.isDirectory() && !entry.name.startsWith('(') && !entry.name.startsWith('['))
+    .map(entry => entry.name)
+    .sort();
+}
+
+/** Literal dirs directly beneath the `[id]` param, looking through route groups. */
+function spaceTabDirs(): string[] {
+  const idDir = path.join(APP_SPACE_DIR, '[id]');
+  const groups = fs.existsSync(idDir)
+    ? fs
+        .readdirSync(idDir, { withFileTypes: true })
+        .filter(e => e.isDirectory() && e.name.startsWith('('))
+        .map(e => path.join(idDir, e.name))
+    : [];
+  return [...new Set([...literalDirs(idDir), ...groups.flatMap(literalDirs)])].sort();
+}
+
+describe('isValidId', () => {
+  // The middleware cannot import the SDK (it is bundled for the edge), so the
+  // local regex is a copy. This is the guard that stops the copy drifting: if
+  // the SDK's notion of a valid id ever changes, this fails rather than the
+  // middleware silently 404ing real pages.
+  it.each([
+    'c9f267dcb0d270718c2a3c45a64afd32',
+    'C9F267DCB0D270718C2A3C45A64AFD32',
+    '12a21058-4706-4d9c-b8c8-813732ef63b2',
+    'BDuZwkjCg3nPWMDshoYtpS',
+    '0xc46618C200f02EF1EEA28923FC3828301e63C4Bd',
+    'totally-made-up-nonsense-id',
+    'governance',
+    'pending',
+    '',
+    'c9f267dcb0d270718c2a3c45a64afd3',
+    'c9f267dcb0d270718c2a3c45a64afd322',
+    'zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz',
+  ])('agrees with IdUtils.isValid for %j', segment => {
+    expect(isValidId(segment)).toBe(IdUtils.isValid(segment));
+  });
+});
+
+describe('route literals stay in sync with the filesystem', () => {
+  // Without these, adding a route would 404 it in production. Failing here
+  // instead is the whole point.
+  it('SPACE_ROOT_SEGMENTS matches the literal dirs under app/space', () => {
+    expect([...SPACE_ROOT_SEGMENTS].sort()).toEqual(literalDirs(APP_SPACE_DIR));
+  });
+
+  it('SPACE_TAB_SEGMENTS matches the literal dirs under app/space/[id]', () => {
+    expect([...SPACE_TAB_SEGMENTS].sort()).toEqual(spaceTabDirs());
+  });
+});
+
+describe('isPossibleSpacePath', () => {
+  it.each([
+    '/space/c9f267dcb0d270718c2a3c45a64afd32',
+    '/space/c9f267dcb0d270718c2a3c45a64afd32/governance',
+    '/space/c9f267dcb0d270718c2a3c45a64afd32/community',
+    '/space/c9f267dcb0d270718c2a3c45a64afd32/3970e24854164ed5a4792d3e418088ef',
+    '/space/c9f267dcb0d270718c2a3c45a64afd32/3970e24854164ed5a4792d3e418088ef/activity',
+    '/space/1310f810454cd482e35ce81cb86ca383/de318eede32a47b2a34a442afe86cef1/opengraph-image-7wh9xe',
+    '/space/12a21058-4706-4d9c-b8c8-813732ef63b2',
+    '/space/pending/some-topic-id',
+    '/space',
+    '/home',
+    '/root',
+  ])('allows %s', pathname => {
+    expect(isPossibleSpacePath(pathname)).toBe(true);
+  });
+
+  // Every one of these was observed in production returning 200 with a full
+  // server-rendered body. They are pre-migration id formats and pure garbage.
+  it.each([
+    '/space/BDuZwkjCg3nPWMDshoYtpS/BZCkGYotMmRsNBW7xu6uFD',
+    '/space/0xc46618C200f02EF1EEA28923FC3828301e63C4Bd/12a21058-4706-4d9c-b8c8-813732ef63b2',
+    '/space/totally-made-up-nonsense-id/also-fake-entity',
+    '/space/zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz',
+    '/space/c9f267dcb0d270718c2a3c45a64afd32/not-a-tab-or-an-id',
+  ])('rejects %s', pathname => {
+    expect(isPossibleSpacePath(pathname)).toBe(false);
+  });
+
+  it('rejects a malformed space id even when the tab is real', () => {
+    expect(isPossibleSpacePath('/space/BDuZwkjCg3nPWMDshoYtpS/governance')).toBe(false);
+  });
+});

--- a/apps/web/core/utils/space-url.ts
+++ b/apps/web/core/utils/space-url.ts
@@ -1,0 +1,91 @@
+/**
+ * Structural validation for `/space/...` URLs, used by the middleware to reject
+ * nonexistent pages with a real 404 before anything renders.
+ *
+ * Why this exists: `notFound()` inside the entity route does not produce a 404.
+ * The layout streams (it has Suspense boundaries), so the 200 is committed
+ * before the call is reached, and the not-found UI ships with a success status.
+ * The observable result was that EVERY nonexistent space/entity URL — including
+ * invented ones — returned `200` with a 44KB server-rendered body:
+ *
+ *     /space/totally-made-up-nonsense-id/also-fake-entity  ->  200
+ *
+ * A 404 tells a crawler to drop a URL; a 200 tells it to keep coming back. With
+ * no robots.txt and `cache-control: no-store` on these routes, that made the
+ * crawlable URL space unbounded and every hit a fresh serverless render — which
+ * is what produced the edge-request anomaly (~76k requests/24h against ~2k real
+ * pageviews, across 6,005 distinct paths, still serving pre-migration base58 and
+ * 0x-address URLs long after those ID formats were retired).
+ *
+ * Doing this in middleware rather than in the page is deliberate: it is the only
+ * place that runs before the response starts streaming, and it also skips the
+ * render entirely, so an invalid URL costs a cheap check instead of a full page.
+ */
+
+/**
+ * Mirrors `IdUtils.isValid` from `@geoprotocol/geo-sdk/lite`: a 32-char hex id
+ * (either case) or a dashed UUID.
+ *
+ * Deliberately a local regex rather than an SDK import — middleware is bundled
+ * for the edge and should not pull the SDK in. `space-url.test.ts` asserts this
+ * stays equivalent to `IdUtils.isValid`, so the two cannot drift silently.
+ */
+const ID_PATTERN =
+  /^(?:[0-9a-fA-F]{32}|[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$/;
+
+export function isValidId(segment: string): boolean {
+  return ID_PATTERN.test(segment);
+}
+
+/**
+ * Literal first segments under `/space/` that are routes rather than space ids.
+ * `space-url.test.ts` asserts this matches the filesystem, so adding a route
+ * without listing it here fails CI rather than 404ing in production.
+ */
+export const SPACE_ROOT_SEGMENTS = ['pending'] as const;
+
+/**
+ * Literal second segments under `/space/<id>/` — the space's own tabs. Anything
+ * else in that position is treated as an entity id and must be a valid id.
+ * Also filesystem-checked by the test.
+ */
+export const SPACE_TAB_SEGMENTS = [
+  'activity',
+  'claims',
+  'community',
+  'debates',
+  'debug-debates',
+  'governance',
+  'import',
+  'questions',
+] as const;
+
+/**
+ * Whether a `/space/...` pathname is structurally capable of existing.
+ *
+ * Structural only — it says nothing about whether the space or entity is real.
+ * A well-formed id for something that was deleted still renders and still
+ * returns 200; fixing that needs a data lookup, which does not belong in
+ * middleware. The unbounded case this closes is the malformed one, which is what
+ * the crawl traffic is made of.
+ *
+ * @param pathname a URL path beginning `/space/`
+ * @returns false when the URL can be rejected outright with a 404
+ */
+export function isPossibleSpacePath(pathname: string): boolean {
+  const segments = pathname.split('/').filter(Boolean);
+
+  // ['space'] alone, or anything not under /space, is not ours to judge.
+  if (segments[0] !== 'space' || segments.length < 2) return true;
+
+  const [, first, second] = segments;
+
+  if (first === undefined) return true;
+  if ((SPACE_ROOT_SEGMENTS as readonly string[]).includes(first)) return true;
+  if (!isValidId(first)) return false;
+
+  if (second === undefined) return true;
+  // Either a space tab, or an entity id. Deeper segments are tabs beneath a
+  // valid entity (…/activity, …/opengraph-image-*) and are left alone.
+  return (SPACE_TAB_SEGMENTS as readonly string[]).includes(second) || isValidId(second);
+}

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+import { isPossibleSpacePath } from '~/core/utils/space-url';
+
+/**
+ * Rejects structurally impossible `/space/...` URLs with a real 404.
+ *
+ * Named `proxy` per Next 16 — the `middleware` file convention is deprecated.
+ *
+ * See `core/utils/space-url.ts` for why this cannot live in the page: the entity
+ * route streams, so `notFound()` there arrives after the 200 is already
+ * committed and the not-found UI is served with a success status. Crawlers only
+ * drop a URL on a genuine 404, so every malformed URL stayed alive and was
+ * re-crawled indefinitely, each time paying a full uncached serverless render.
+ *
+ * Rewriting to `/_not-found` rather than returning a bare 404 body keeps the
+ * normal styled 404 page, so a human who mistypes a URL sees the same thing they
+ * always did — only the status line changes.
+ */
+export default function proxy(request: NextRequest) {
+  if (isPossibleSpacePath(request.nextUrl.pathname)) {
+    return NextResponse.next();
+  }
+
+  return NextResponse.rewrite(new URL('/_not-found', request.url), { status: 404 });
+}
+
+export const config = {
+  // Scoped to /space so no other route pays for this check. Excludes Next's own
+  // asset paths, which never look like space URLs but would otherwise be matched
+  // on every request.
+  matcher: ['/space/:path*'],
+};


### PR DESCRIPTION
Vercel flagged an edge-request anomaly on geogenesis (**4.28×**). This is the cause.

## Every nonexistent /space URL returns 200

```
/space/totally-made-up-nonsense-id/also-fake-entity   →  200, 44 KB   ← I invented this URL
/space/BDuZwkjCg3nPWMDshoYtpS/BZCkGYotMmRsNBW7xu6uFD  →  200, 44 KB   ← pre-migration base58
/space/0xc46618C2…/12a21058-4706-4d9c-b8c8-813732…    →  200, 44 KB   ← 0x-address era
```

**A 404 tells a crawler to drop a URL. A 200 tells it to keep coming back**, and to treat the page as real content worth recrawling. So the crawlable URL space under `/space` is unbounded — and because these routes send `cache-control: private, no-cache, no-store`, every hit is a fresh uncached serverless render.

What production is actually doing (Vercel runtime logs, 24h):

| | |
|---|---|
| SSR requests | ~76,000 (99.6% `200`) |
| Tracked pageviews / visitors | ~2,075 / 298 |
| Distinct request paths | **6,005** |
| Top routes | `/space/[id]` 24.7k · `/space/[id]/[entityId]` 18k |

Web Analytics only counts real browsers running its script, so that ~35× gap is essentially all non-browser traffic — and it's still walking ID formats that were retired at the migration.

## Why `notFound()` didn't already do this

The route **already calls `notFound()`** — in the page (line 28) and the layout (line 63). It doesn't work: the layout streams (it has Suspense boundaries), so the `200` is committed before the call is reached, and the not-found UI ships with a success status.

That's why this stayed invisible. In a browser the page looks completely correct; only the status line is wrong.

## The fix

`proxy.ts` — the only place that runs *before* the response starts streaming. It also skips the render entirely, so a malformed URL now costs a regex instead of a full page.

Scope is deliberately **structural**. A well-formed id for something deleted still renders and still returns 200, because deciding that needs a data lookup which doesn't belong in a proxy. The unbounded case is the malformed one, and that's what the crawl traffic is made of.

Two things kept honest by tests rather than vigilance:

- The id regex is a **copy** of `IdUtils.isValid` (the proxy is edge-bundled and shouldn't pull in the SDK), so a test asserts the two agree case by case.
- The literal route segments (`pending`, and the space tabs) are asserted **against the filesystem**, so adding a tab without listing it fails CI instead of 404ing in production.

Named `proxy` rather than `middleware` because Next 16 deprecates that convention — the dev server warns about it.

## Also: robots.txt

There was none at all — `/robots.txt` returned **404**, so crawlers had zero guidance. `app/robots.ts` stays permissive for the public knowledge graph and disallows only paths that cost a render while having nothing to index (`/api/`, import, debug-debates, ranking-compose, power-tools).

It's a mitigation, not the fix — robots.txt is advisory, and the crawlers that honour it were never the whole problem.

## Verification

Against a local dev server (`tsc --noEmit` clean, eslint clean, 31 tests passing):

| Status | Path |
|---|---|
| 200 | `/robots.txt`, `/home`, `/root` |
| 200 | `/space/<valid>`, `/space/<valid>/governance`, `/space/<valid>/<entity>` |
| 200 | `/space/pending/abc` |
| **404** | `/space/totally-made-up-nonsense-id/also-fake-entity` |
| **404** | `/space/BDuZwkjCg3nPWMDshoYtpS/BZCkGYotMmRsNBW7xu6uFD` |
| **404** | `/space/0xc46618C2…/12a21058-…` |

A control run with the file disabled confirms nothing else changed: valid paths behave identically with and without it.

## What I deliberately did *not* change

Making these pages **cacheable** would cut cost far more than anything here — but `private, no-cache, no-store` is presumably deliberate because pages render per-user with auth cookies. Flipping that to `public` risks serving one user's view to another through the CDN. It needs public content split from per-user chrome, which is a design change and a separate PR.

Related, unflagged, and worth a look separately: the **`news`** project serves **~166k req/24h** with the same no-cache posture, driven by the 2,508-URL sitemap added in `ae6940b` last week.
