### PR TITLE
Fix fullscreen debate vote persistence

### DIFF
--- a/apps/web/app/space/[id]/(space)/debates/debates-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/debates-page-client.test.tsx
@@ -32,6 +32,10 @@ vi.mock('~/core/debates/use-debate-votes', () => ({
   useDebateVotesByVoter: () => new Map(),
 }));
 
+vi.mock('~/partials/entity-page/entity-vote-buttons', () => ({
+  EntityVoteButtons: () => <div data-testid="entity-vote-buttons" />,
+}));
+
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ replace: mocks.replace }),
 }));
@@ -92,6 +96,7 @@ describe('DebatesPageClient browse feed', () => {
     expect(screen.getAllByText('Fashion').length).toBeGreaterThan(0);
     expect(screen.getAllByRole('button', { name: 'Join a debate' }).length).toBeGreaterThan(0);
     expect(screen.getAllByText('Winner?').length).toBeGreaterThan(0);
+    expect(screen.getAllByTestId('entity-vote-buttons')).toHaveLength(2);
 
     await waitFor(() => expect(container.querySelectorAll('video')).toHaveLength(2));
   });

--- a/apps/web/core/debates/browse/debate-feed.test.tsx
+++ b/apps/web/core/debates/browse/debate-feed.test.tsx
@@ -16,6 +16,7 @@ const mocks = vi.hoisted(() => ({
   createObjectURL: vi.fn(() => 'blob:https://geo.test/social-video'),
   revokeObjectURL: vi.fn(),
   downloadClick: vi.fn(),
+  entityVoteProps: [] as Array<Record<string, unknown>>,
 }));
 
 type ObserverRecord = {
@@ -54,6 +55,13 @@ vi.mock('~/core/sync/use-store', () => ({
   useQueryEntities: () => ({ entities: [], isLoading: false }),
 }));
 
+vi.mock('~/partials/entity-page/entity-vote-buttons', () => ({
+  EntityVoteButtons: (props: Record<string, unknown>) => {
+    mocks.entityVoteProps.push(props);
+    return <div data-testid={`entity-votes-${String(props.presentation)}`} />;
+  },
+}));
+
 vi.mock('./debate-feed-player', () => ({
   DebateFeedPlayer: ({ debate, active }: { debate: Debate; active: boolean }) => (
     <div data-testid={`player-${debate.id}`} data-active={active} />
@@ -67,6 +75,7 @@ beforeEach(() => {
   vi.useFakeTimers();
   vi.resetAllMocks();
   observers = [];
+  mocks.entityVoteProps.length = 0;
   mocks.debates = [completedDebate('debate-1', 'Debates are useful', '2026-07-02T00:01:10.000Z')];
   mocks.createObjectURL.mockReturnValue('blob:https://geo.test/social-video');
   mocks.fetch.mockResolvedValue(videoResponse());
@@ -138,6 +147,13 @@ describe('DebatesBrowseFeed video sharing', () => {
     expect(mediaColumn).toHaveStyle({
       '--debate-feed-column-width': 'clamp(280px, min(calc(100cqw - 4rem), calc(82.9dvh - 10.88rem)), 640px)',
     });
+    expect(screen.getByTestId('entity-votes-debate-horizontal')).toBeInTheDocument();
+    expect(screen.getByTestId('entity-votes-debate-vertical')).toBeInTheDocument();
+    expect(mocks.entityVoteProps).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ entityId: 'debate-1', spaceId: 'space-1', responseKind: 'curation' }),
+      ])
+    );
   });
 
   it('renders when ResizeObserver is unavailable', () => {

--- a/apps/web/core/debates/browse/debate-feed.tsx
+++ b/apps/web/core/debates/browse/debate-feed.tsx
@@ -20,7 +20,7 @@ import { Text } from '~/design-system/text';
 
 import { DebateClaimsPanel } from './debate-claims-panel';
 import { DebateFeedPlayer } from './debate-feed-player';
-import { DebateInteractionBar, type DebateVote } from './debate-interaction-bar';
+import { DebateInteractionBar } from './debate-interaction-bar';
 import { JoinDebatePanel } from './join-debate-panel';
 import { useDebateShareAction } from './use-debate-share-action';
 
@@ -150,6 +150,7 @@ export function DebatesBrowseFeed({
         <DebateFeedItem
           key={debate.id}
           debate={debate}
+          spaceId={spaceId}
           spaceName={space?.entity.name ?? 'Space'}
           spaceImage={space?.entity.image}
           topics={topicsByClaimId.get(debate.claim.claim_entity_id) ?? []}
@@ -190,6 +191,7 @@ export function DebatesBrowseFeed({
 
 function DebateFeedItem({
   debate,
+  spaceId,
   spaceName,
   spaceImage,
   topics,
@@ -200,6 +202,7 @@ function DebateFeedItem({
   onOpenClaims,
 }: {
   debate: Debate;
+  spaceId: string;
   spaceName: string;
   spaceImage?: string | null;
   topics: string[];
@@ -210,7 +213,6 @@ function DebateFeedItem({
   onOpenClaims: () => void;
 }) {
   const itemRef = React.useRef<HTMLElement | null>(null);
-  const [vote, setVote] = React.useState<DebateVote>(null);
   const winnerVotes = useDebateVotes(debate);
   const shareAction = useDebateShareAction(debate, active);
 
@@ -230,9 +232,8 @@ function DebateFeedItem({
   }, [onActivate, root]);
 
   const interactionProps = {
-    score: vote === 'up' ? 1 : vote === 'down' ? -1 : 0,
-    vote,
-    onVote: setVote,
+    entityId: debate.id,
+    spaceId,
     commentCount: 0,
     claimsCount: 0,
     onComment: () => undefined,
@@ -409,4 +410,3 @@ function completedTime(debate: Debate) {
   const value = debate.completed_at ?? debate.started_at ?? debate.created_at;
   return value ? new Date(value).getTime() : 0;
 }
-

--- a/apps/web/core/debates/browse/debate-interaction-bar.tsx
+++ b/apps/web/core/debates/browse/debate-interaction-bar.tsx
@@ -5,14 +5,13 @@ import * as React from 'react';
 import cx from 'classnames';
 
 import { InfoSmall } from '~/design-system/icons/info-small';
-import { VoteArrow } from '~/design-system/icons/vote-arrow';
 import { Text } from '~/design-system/text';
 import { Tooltip } from '~/design-system/tooltip';
 
+import { EntityVoteButtons } from '~/partials/entity-page/entity-vote-buttons';
+
 import type { SocialVideoHandoffMethod } from '../social-video-share';
 import { Comment, Share } from './icons';
-
-export type DebateVote = 'up' | 'down' | null;
 
 export type DebateShareAction = {
   state: 'preparing' | 'ready' | 'sharing' | 'error';
@@ -23,9 +22,8 @@ export type DebateShareAction = {
 
 type InteractionBarProps = {
   orientation: 'vertical' | 'horizontal';
-  score: number;
-  vote: DebateVote;
-  onVote: (vote: DebateVote) => void;
+  entityId: string;
+  spaceId: string;
   commentCount: number;
   claimsCount: number;
   onComment: () => void;
@@ -35,14 +33,13 @@ type InteractionBarProps = {
 };
 
 /**
- * The upvote/downvote/comment/claims/share bar beside each debate. Renders the
- * controls and counts; voting is local-only and comments are a stub so far.
+ * The upvote/downvote/comment/claims/share bar beside each debate. Entity votes
+ * use the same persisted response path as gallery and entity-page vote controls.
  */
 export function DebateInteractionBar({
   orientation,
-  score,
-  vote,
-  onVote,
+  entityId,
+  spaceId,
   commentCount,
   claimsCount,
   onComment,
@@ -59,7 +56,12 @@ export function DebateInteractionBar({
   if (orientation === 'vertical') {
     return (
       <div className={cx('flex w-9 flex-col items-center gap-3', className)}>
-        <VotePill orientation="vertical" score={score} vote={vote} onVote={onVote} />
+        <EntityVoteButtons
+          entityId={entityId}
+          spaceId={spaceId}
+          responseKind="curation"
+          presentation="debate-vertical"
+        />
         <CircleAction label={String(commentCount)} onClick={onComment} icon={<Comment />} ariaLabel="Comments" />
         <CircleAction label={String(claimsCount)} onClick={onClaims} icon={<InfoSmall />} ariaLabel="Claims" />
         <CircleAction
@@ -76,7 +78,12 @@ export function DebateInteractionBar({
 
   return (
     <div className={cx('flex w-full items-center gap-2', className)}>
-      <VotePill orientation="horizontal" score={score} vote={vote} onVote={onVote} />
+      <EntityVoteButtons
+        entityId={entityId}
+        spaceId={spaceId}
+        responseKind="curation"
+        presentation="debate-horizontal"
+      />
       <PillAction onClick={onComment} icon={<Comment />} label={String(commentCount)} ariaLabel="Comments" />
       <PillAction onClick={onClaims} icon={<InfoSmall />} label={String(claimsCount)} ariaLabel="Claims" />
       <PillAction
@@ -88,49 +95,6 @@ export function DebateInteractionBar({
         tooltipMessage={shareAction.tooltipMessage}
         className="ml-auto"
       />
-    </div>
-  );
-}
-
-function VotePill({
-  orientation,
-  score,
-  vote,
-  onVote,
-}: {
-  orientation: 'vertical' | 'horizontal';
-  score: number;
-  vote: DebateVote;
-  onVote: (vote: DebateVote) => void;
-}) {
-  return (
-    <div
-      className={cx(
-        'flex items-center justify-center gap-1.5 rounded-full border border-grey-02 bg-white text-text shadow-light',
-        orientation === 'vertical' ? 'w-9 flex-col py-2' : 'h-7 px-2.5'
-      )}
-    >
-      <button
-        type="button"
-        aria-label="Upvote"
-        aria-pressed={vote === 'up'}
-        onClick={() => onVote(vote === 'up' ? null : 'up')}
-        className="group/vote flex items-center justify-center text-grey-04 transition-colors hover:text-text aria-pressed:text-ctaPrimary"
-      >
-        <VoteArrow direction="up" filled={vote === 'up'} color={vote === 'up' ? 'ctaPrimary' : undefined} />
-      </button>
-      <Text as="span" variant="metadataMedium" color="text" className="tabular-nums">
-        {score}
-      </Text>
-      <button
-        type="button"
-        aria-label="Downvote"
-        aria-pressed={vote === 'down'}
-        onClick={() => onVote(vote === 'down' ? null : 'down')}
-        className="group/vote flex items-center justify-center text-grey-04 transition-colors hover:text-text aria-pressed:text-red-01"
-      >
-        <VoteArrow direction="down" filled={vote === 'down'} color={vote === 'down' ? 'red-01' : undefined} />
-      </button>
     </div>
   );
 }

--- a/apps/web/partials/entity-page/entity-vote-buttons.batch.test.tsx
+++ b/apps/web/partials/entity-page/entity-vote-buttons.batch.test.tsx
@@ -134,6 +134,40 @@ describe('EntityVoteButtons claims-page batching', () => {
     expect(responseIcons.every(icon => icon.getAttribute('viewBox') === '0 0 16 16')).toBe(true);
   });
 
+  it('renders persisted curation state in the fullscreen debate pill', () => {
+    mocks.smartAccount = {};
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    queryClient.setQueryData(entityResponseCountsQueryKey('debate-1', 'space-1', 0, 'curation'), {
+      positive: 8,
+      negative: 1,
+    });
+    queryClient.setQueryData(
+      userEntityResponseQueryKey('profile-1', 'debate-1', 'space-1', 0, 'curation'),
+      'positive'
+    );
+
+    const view = render(
+      <ClaimResponseBatchBoundary ready>
+        <EntityVoteButtons
+          entityId="debate-1"
+          spaceId="space-1"
+          responseKind="curation"
+          presentation="debate-vertical"
+        />
+      </ClaimResponseBatchBoundary>,
+      {
+        wrapper: ({ children }: { children: ReactNode }) => (
+          <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+        ),
+      }
+    );
+
+    expect(view.getByText('7')).toBeInTheDocument();
+    expect(view.getByRole('button', { name: 'Upvote' })).toHaveAttribute('aria-pressed', 'true');
+    fireEvent.click(view.getByRole('button', { name: 'Downvote' }));
+    expect(mocks.submitResponse).toHaveBeenLastCalledWith('negative', expect.any(Object));
+  });
+
   it('passes the optimistic viewer response to responder avatars immediately', () => {
     mocks.optimisticResponse = 'negative';
 

--- a/apps/web/partials/entity-page/entity-vote-buttons.batch.test.tsx
+++ b/apps/web/partials/entity-page/entity-vote-buttons.batch.test.tsx
@@ -163,7 +163,7 @@ describe('EntityVoteButtons claims-page batching', () => {
     );
 
     expect(view.getByText('7')).toBeInTheDocument();
-    expect(view.getByRole('button', { name: 'Upvote' })).toHaveAttribute('aria-pressed', 'true');
+    expect(view.getByRole('button', { name: 'Remove upvote' })).toHaveAttribute('aria-pressed', 'true');
     fireEvent.click(view.getByRole('button', { name: 'Downvote' }));
     expect(mocks.submitResponse).toHaveBeenLastCalledWith('negative', expect.any(Object));
   });

--- a/apps/web/partials/entity-page/entity-vote-buttons.tsx
+++ b/apps/web/partials/entity-page/entity-vote-buttons.tsx
@@ -437,7 +437,7 @@ function DebateVotePill({
     >
       <button
         type="button"
-        aria-label="Upvote"
+        aria-label={positiveTitle}
         aria-pressed={positiveActive}
         disabled={disabled}
         title={positiveTitle}
@@ -449,7 +449,7 @@ function DebateVotePill({
       <span className="text-metadataMedium tabular-nums text-text">{score}</span>
       <button
         type="button"
-        aria-label="Downvote"
+        aria-label={negativeTitle}
         aria-pressed={negativeActive}
         disabled={disabled}
         title={negativeTitle}

--- a/apps/web/partials/entity-page/entity-vote-buttons.tsx
+++ b/apps/web/partials/entity-page/entity-vote-buttons.tsx
@@ -65,6 +65,7 @@ type EntityVoteButtonsProps = {
   spaceId: string;
   responseKind?: ResponseKind | null;
   claimResponderAvatarsPosition?: 'leading' | 'trailing';
+  presentation?: 'inline' | 'debate-vertical' | 'debate-horizontal';
 };
 
 export function EntityVoteButtons({
@@ -72,6 +73,7 @@ export function EntityVoteButtons({
   spaceId,
   responseKind: responseKindOverride,
   claimResponderAvatarsPosition = 'leading',
+  presentation = 'inline',
 }: EntityVoteButtonsProps) {
   const responseBatch = useClaimResponseBatchState();
   const { entity, isLoading: isLoadingEntity } = useQueryEntity({
@@ -232,6 +234,25 @@ export function EntityVoteButtons({
 
   const positiveActive = activeResponse === 'positive';
   const negativeActive = activeResponse === 'negative';
+  const responseDisabled = !!smartAccount && (!isConnected || isAccountSetupPending);
+  const positiveTitle = !smartAccount
+    ? responseCopy.signIn
+    : isAccountSetupPending
+      ? 'Finishing account setup…'
+      : isConnected
+        ? positiveActive
+          ? responseCopy.removePositive
+          : responseCopy.positiveAction
+        : responseCopy.connect;
+  const negativeTitle = !smartAccount
+    ? responseCopy.signIn
+    : isAccountSetupPending
+      ? 'Finishing account setup…'
+      : isConnected
+        ? negativeActive
+          ? responseCopy.removeNegative
+          : responseCopy.negativeAction
+        : responseCopy.connect;
 
   const totalResponders = (responseCounts?.positive ?? 0) + (responseCounts?.negative ?? 0);
 
@@ -300,6 +321,22 @@ export function EntityVoteButtons({
     );
   }
 
+  if (presentation !== 'inline') {
+    return (
+      <DebateVotePill
+        orientation={presentation === 'debate-vertical' ? 'vertical' : 'horizontal'}
+        score={scoreLabel}
+        positiveActive={positiveActive}
+        negativeActive={negativeActive}
+        disabled={responseDisabled}
+        positiveTitle={positiveTitle}
+        negativeTitle={negativeTitle}
+        onPositive={handlePositiveResponse}
+        onNegative={handleNegativeResponse}
+      />
+    );
+  }
+
   return (
     <div className="flex items-center gap-1 text-metadataMedium text-text">
       {claimResponderAvatarsPosition === 'leading' && claimResponderAvatars ? (
@@ -307,23 +344,13 @@ export function EntityVoteButtons({
       ) : null}
       <button
         onClick={handlePositiveResponse}
-        disabled={!!smartAccount && (!isConnected || isAccountSetupPending)}
-        title={
-          !smartAccount
-            ? responseCopy.signIn
-            : isAccountSetupPending
-              ? 'Finishing account setup…'
-              : isConnected
-                ? positiveActive
-                  ? responseCopy.removePositive
-                  : responseCopy.positiveAction
-                : responseCopy.connect
-        }
+        disabled={responseDisabled}
+        title={positiveTitle}
         className={cx(
           'group/vote flex h-5 w-5 items-center justify-center rounded transition-colors',
           !isClaimVariant && 'translate-y-px',
           claimResponseButtonColor(positiveActive),
-          !!smartAccount && (!isConnected || isAccountSetupPending) && 'cursor-default opacity-50'
+          responseDisabled && 'cursor-default opacity-50'
         )}
       >
         {renderResponseIcon('up', positiveActive)}
@@ -356,23 +383,13 @@ export function EntityVoteButtons({
       </Popover.Root>
       <button
         onClick={handleNegativeResponse}
-        disabled={!!smartAccount && (!isConnected || isAccountSetupPending)}
-        title={
-          !smartAccount
-            ? responseCopy.signIn
-            : isAccountSetupPending
-              ? 'Finishing account setup…'
-              : isConnected
-                ? negativeActive
-                  ? responseCopy.removeNegative
-                  : responseCopy.negativeAction
-                : responseCopy.connect
-        }
+        disabled={responseDisabled}
+        title={negativeTitle}
         className={cx(
           'group/vote flex h-5 w-5 items-center justify-center rounded transition-colors',
           !isClaimVariant && 'translate-y-px',
           claimResponseButtonColor(negativeActive),
-          !!smartAccount && (!isConnected || isAccountSetupPending) && 'cursor-default opacity-50'
+          responseDisabled && 'cursor-default opacity-50'
         )}
       >
         {renderResponseIcon('down', negativeActive)}
@@ -385,6 +402,62 @@ export function EntityVoteButtons({
           Response submitted. Waiting for confirmation.
         </span>
       ) : null}
+    </div>
+  );
+}
+
+function DebateVotePill({
+  orientation,
+  score,
+  positiveActive,
+  negativeActive,
+  disabled,
+  positiveTitle,
+  negativeTitle,
+  onPositive,
+  onNegative,
+}: {
+  orientation: 'vertical' | 'horizontal';
+  score: string;
+  positiveActive: boolean;
+  negativeActive: boolean;
+  disabled: boolean;
+  positiveTitle: string;
+  negativeTitle: string;
+  onPositive: () => void;
+  onNegative: () => void;
+}) {
+  return (
+    <div
+      data-entity-vote-presentation={`debate-${orientation}`}
+      className={cx(
+        'flex items-center justify-center gap-1.5 rounded-full border border-grey-02 bg-white text-text shadow-light',
+        orientation === 'vertical' ? 'w-9 flex-col py-2' : 'h-7 px-2.5'
+      )}
+    >
+      <button
+        type="button"
+        aria-label="Upvote"
+        aria-pressed={positiveActive}
+        disabled={disabled}
+        title={positiveTitle}
+        onClick={onPositive}
+        className="group/vote flex items-center justify-center text-grey-04 transition-colors hover:text-text aria-pressed:text-ctaPrimary disabled:cursor-default disabled:opacity-50"
+      >
+        <VoteArrow direction="up" filled={positiveActive} color={positiveActive ? 'ctaPrimary' : undefined} />
+      </button>
+      <span className="text-metadataMedium tabular-nums text-text">{score}</span>
+      <button
+        type="button"
+        aria-label="Downvote"
+        aria-pressed={negativeActive}
+        disabled={disabled}
+        title={negativeTitle}
+        onClick={onNegative}
+        className="group/vote flex items-center justify-center text-grey-04 transition-colors hover:text-text aria-pressed:text-red-01 disabled:cursor-default disabled:opacity-50"
+      >
+        <VoteArrow direction="down" filled={negativeActive} color={negativeActive ? 'red-01' : undefined} />
+      </button>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- replace the fullscreen debate player's local-only vote state with the persisted entity-response flow used by gallery cards
- hydrate the existing vote total and the viewer's prior vote
- submit upvotes, downvotes, and vote removal through the existing optimistic mutation/indexing path
- preserve the compact vertical and horizontal fullscreen vote-pill layouts
- add coverage for feed wiring and persisted vote state/mutations

## Root cause

The fullscreen player maintained its own React state and never queried or submitted Geo entity responses. Every debate therefore started at zero in that UI, and any click disappeared after refresh.

## Validation

- `bun run test core/debates/browse/debate-feed.test.tsx partials/entity-page/entity-vote-buttons.batch.test.tsx` — 20 tests passed
- ESLint passed for all five changed files
- `git diff --check` passed

## Existing master issue

The full web TypeScript check is currently blocked by an unrelated error already on latest `master`: `partials/explore/debate-explore-feed-card.test.tsx:183` uses status `"aborted"`, which is not part of `DebateStatus`. This PR does not modify that file.
