### PR TITLE
fix(debates): move the claim card's debate toggle into the card header

### DIFF
--- a/apps/web/core/debates/matchmaking/claim-readiness-toggle.tsx
+++ b/apps/web/core/debates/matchmaking/claim-readiness-toggle.tsx
@@ -75,7 +75,8 @@ export function ClaimReadinessToggle({ claim, readiness, activeDebate, hasRespon
         }
         className={cx(
           // `min-h-4` matches the space chip's avatar so the two sit on one line in the card header.
-          // The label stays grey per the design; the switch itself carries the on/off signal.
+          // Per the design the label is grey whether or not readiness is on — the switch alone
+          // carries that signal. Hover still darkens it, as the affordance that it's clickable.
           'flex min-h-4 shrink-0 items-center gap-2 text-footnoteMedium text-grey-04 transition-colors disabled:opacity-50',
           !disabled && 'hover:text-text'
         )}

--- a/apps/web/core/debates/matchmaking/claim-readiness-toggle.tsx
+++ b/apps/web/core/debates/matchmaking/claim-readiness-toggle.tsx
@@ -74,8 +74,9 @@ export function ClaimReadinessToggle({ claim, readiness, activeDebate, hasRespon
           })
         }
         className={cx(
-          'flex h-6 shrink-0 items-center gap-1.5 text-footnote transition-colors disabled:opacity-50',
-          ready ? 'text-text' : 'text-grey-04',
+          // `min-h-4` matches the space chip's avatar so the two sit on one line in the card header.
+          // The label stays grey per the design; the switch itself carries the on/off signal.
+          'flex min-h-4 shrink-0 items-center gap-2 text-footnoteMedium text-grey-04 transition-colors disabled:opacity-50',
           !disabled && 'hover:text-text'
         )}
       >

--- a/apps/web/core/debates/matchmaking/matchmaking-claim-card.test.tsx
+++ b/apps/web/core/debates/matchmaking/matchmaking-claim-card.test.tsx
@@ -6,10 +6,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { DebateClaimPositionSummary, DebateClaimSummary, MatchmakingReadiness } from '../api';
 import { MatchmakingClaimCard } from './matchmaking-claim-card';
 
+// Claim and space ids are knowledge-graph ids, so the fixtures have to be real ones — the card
+// refuses to touch the graph for anything else. The space id is hoisted because `vi.mock` factories
+// are lifted above every module-level declaration, so a mock that reads it can't use a plain const.
 const mocks = vi.hoisted(() => ({
   readinessMutate: vi.fn(),
   submitResponse: vi.fn(),
   spaceName: 'Crypto',
+  spaceId: '019fedae-72b6-7ab2-927a-df044d57c566',
 }));
 
 vi.mock('./hooks', () => ({
@@ -32,7 +36,7 @@ vi.mock('~/core/hooks/use-entity-vote', () => ({
 vi.mock('~/core/hooks/use-spaces-by-ids', () => ({
   useSpacesByIds: () => ({
     spaces: [],
-    spacesById: new Map([[SPACE_ID, { entity: { name: mocks.spaceName, image: null } }]]),
+    spacesById: new Map([[mocks.spaceId, { entity: { name: mocks.spaceName, image: null } }]]),
     isLoading: false,
   }),
 }));
@@ -41,9 +45,7 @@ vi.mock('~/core/state/pending-personal-space', () => ({
   usePendingPersonalSpace: () => ({ isPending: false }),
 }));
 
-// Claim and space ids are knowledge-graph ids, so the fixtures have to be real ones — the card
-// refuses to touch the graph for anything else.
-const SPACE_ID = '019fedae-72b6-7ab2-927a-df044d57c566';
+const SPACE_ID = mocks.spaceId;
 const CLAIM_ENTITY_ID = '019fedb1-0c41-7f3e-9a11-2c7d5e8b4419';
 const CLAIM_TEXT = 'Chips are better than fries';
 

--- a/apps/web/core/debates/matchmaking/matchmaking-claim-card.test.tsx
+++ b/apps/web/core/debates/matchmaking/matchmaking-claim-card.test.tsx
@@ -1,0 +1,132 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { DebateClaimPositionSummary, DebateClaimSummary, MatchmakingReadiness } from '../api';
+import { MatchmakingClaimCard } from './matchmaking-claim-card';
+
+const mocks = vi.hoisted(() => ({
+  readinessMutate: vi.fn(),
+  submitResponse: vi.fn(),
+  spaceName: 'Crypto',
+}));
+
+vi.mock('./hooks', () => ({
+  useClaimReadiness: () => ({ mutate: mocks.readinessMutate, isPending: false, error: null }),
+}));
+
+vi.mock('~/core/hooks/use-entity-vote', () => ({
+  useEntityResponse: () => ({
+    submitResponse: mocks.submitResponse,
+    optimisticResponse: undefined,
+    isProcessingResponse: false,
+    isResponseIndexingDelayed: false,
+    isConnected: true,
+    personalSpaceId: 'personal-space',
+  }),
+  useEntityResponseIndexingSnapshot: () => ({ status: 'idle', pending: null, runId: null }),
+  useResetEntityResponseIndexingSnapshot: () => vi.fn(),
+}));
+
+vi.mock('~/core/hooks/use-spaces-by-ids', () => ({
+  useSpacesByIds: () => ({
+    spaces: [],
+    spacesById: new Map([[SPACE_ID, { entity: { name: mocks.spaceName, image: null } }]]),
+    isLoading: false,
+  }),
+}));
+
+vi.mock('~/core/state/pending-personal-space', () => ({
+  usePendingPersonalSpace: () => ({ isPending: false }),
+}));
+
+// Claim and space ids are knowledge-graph ids, so the fixtures have to be real ones — the card
+// refuses to touch the graph for anything else.
+const SPACE_ID = '019fedae-72b6-7ab2-927a-df044d57c566';
+const CLAIM_ENTITY_ID = '019fedb1-0c41-7f3e-9a11-2c7d5e8b4419';
+const CLAIM_TEXT = 'Chips are better than fries';
+
+const claim: DebateClaimSummary = {
+  id: 'debate-claim-1',
+  space_id: SPACE_ID,
+  claim_entity_id: CLAIM_ENTITY_ID,
+  claim: CLAIM_TEXT,
+  description: null,
+};
+
+const positions: DebateClaimPositionSummary[] = [
+  { position: true, position_label: 'Agree', total_count: 2, available_now_count: 1, participants: [] },
+  { position: false, position_label: 'Disagree', total_count: 3, available_now_count: 2, participants: [] },
+];
+
+function readiness(overrides: Partial<MatchmakingReadiness> = {}): MatchmakingReadiness {
+  return {
+    response_kind: 'stance',
+    viewer_response: { position: true, position_label: 'Agree' } as MatchmakingReadiness['viewer_response'],
+    viewer_debate_ready: true,
+    readiness_disabled_reason: null,
+    ...overrides,
+  };
+}
+
+const toggleName = 'Ready to debate this claim';
+
+beforeEach(() => {
+  mocks.readinessMutate.mockReset();
+  mocks.submitResponse.mockReset();
+  mocks.spaceName = 'Crypto';
+});
+
+afterEach(cleanup);
+
+describe('MatchmakingClaimCard', () => {
+  it('puts the debate toggle in the card header beside the space name', () => {
+    render(<MatchmakingClaimCard claim={claim} positions={positions} readiness={readiness()} />);
+
+    const toggle = screen.getByRole('switch', { name: toggleName });
+    const spaceName = screen.getByText('Crypto');
+
+    // The header row is the toggle's own row: the space chip and the toggle share it, which is
+    // what puts the toggle top-right rather than below the response buttons.
+    const headerRow = toggle.parentElement?.parentElement;
+    expect(headerRow).not.toBeNull();
+    expect(headerRow?.contains(spaceName)).toBe(true);
+
+    // ...and the header sits above the claim, so the toggle precedes it in the document.
+    const claimText = screen.getByText(CLAIM_TEXT);
+    expect(toggle.compareDocumentPosition(claimText) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it('keeps the toggle above the response buttons', () => {
+    render(<MatchmakingClaimCard claim={claim} positions={positions} readiness={readiness()} />);
+
+    const toggle = screen.getByRole('switch', { name: toggleName });
+    const agree = screen.getByRole('button', { name: /^Agree/ });
+
+    expect(toggle.compareDocumentPosition(agree) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it('still heads the card with the toggle when the claim is not on the graph', () => {
+    const offGraph = { ...claim, claim_entity_id: 'not-a-graph-id' };
+    render(<MatchmakingClaimCard claim={offGraph} positions={positions} readiness={readiness()} />);
+
+    const toggle = screen.getByRole('switch', { name: toggleName });
+    expect(toggle.parentElement?.parentElement?.contains(screen.getByText('Crypto'))).toBe(true);
+    // The unavailable notice loses the toggle it used to sit beside, but must still be shown.
+    expect(screen.getByText('Claim unavailable')).toBeInTheDocument();
+  });
+
+  it('explains why the toggle is unavailable without a response', () => {
+    render(
+      <MatchmakingClaimCard
+        claim={claim}
+        positions={positions}
+        readiness={readiness({ viewer_response: null, viewer_debate_ready: false })}
+      />
+    );
+
+    expect(screen.getByRole('switch', { name: toggleName })).toBeDisabled();
+    expect(screen.getByText('Respond to this claim to debate it.')).toBeInTheDocument();
+  });
+});

--- a/apps/web/core/debates/matchmaking/matchmaking-claim-card.tsx
+++ b/apps/web/core/debates/matchmaking/matchmaking-claim-card.tsx
@@ -62,8 +62,37 @@ export function MatchmakingClaimCard({ claim, positions, readiness, activeDebate
     // `w-full` matters: popLayout absolutely positions an exiting card, which would otherwise
     // collapse to its content width as it fades.
     <motion.article ref={ref} {...hubCardMotion} className="w-full rounded-lg border border-grey-02 bg-white p-3">
-      <div className="mb-2">
+      {isOnGraph ? (
+        <RespondableControls claim={claim} positions={positions} readiness={readiness} activeDebate={activeDebate} />
+      ) : (
+        <UnresolvableControls positions={positions} readiness={readiness} claim={claim} activeDebate={activeDebate} />
+      )}
+
+      {footer}
+    </motion.article>
+  );
+}
+
+/**
+ * Space chip, readiness toggle, and the claim itself — the chrome both control variants share.
+ * The toggle rides in the header's top right per the design, but whether it can be turned on
+ * depends on response state only the respondable variant tracks, so each passes its own.
+ */
+function ClaimHeader({
+  claim,
+  isOnGraph,
+  toggle,
+}: {
+  claim: DebateClaimSummary;
+  isOnGraph: boolean;
+  toggle: React.ReactNode;
+}) {
+  return (
+    <>
+      {/* `items-start` so the chip stays put when the toggle stacks an explanation beneath it. */}
+      <div className="mb-2 flex items-start justify-between gap-3">
         <SpaceChip spaceId={claim.space_id} />
+        {toggle}
       </div>
       {isOnGraph ? (
         <Link
@@ -77,15 +106,7 @@ export function MatchmakingClaimCard({ claim, positions, readiness, activeDebate
           {claim.claim}
         </Text>
       )}
-
-      {isOnGraph ? (
-        <RespondableControls claim={claim} positions={positions} readiness={readiness} activeDebate={activeDebate} />
-      ) : (
-        <UnresolvableControls positions={positions} readiness={readiness} claim={claim} activeDebate={activeDebate} />
-      )}
-
-      {footer}
-    </motion.article>
+    </>
   );
 }
 
@@ -158,6 +179,19 @@ function RespondableControls({
 
   return (
     <>
+      <ClaimHeader
+        claim={claim}
+        isOnGraph
+        toggle={
+          <ClaimReadinessToggle
+            claim={claim}
+            readiness={readiness}
+            activeDebate={activeDebate}
+            hasResponse={viewerPosition !== null}
+            responseIndexing={isPublishing}
+          />
+        }
+      />
       <PositionRow
         positions={positions}
         responseKind={readiness.response_kind}
@@ -173,15 +207,6 @@ function RespondableControls({
           </Text>
         </div>
       ) : null}
-      <div className="mt-3 flex justify-end">
-        <ClaimReadinessToggle
-          claim={claim}
-          readiness={readiness}
-          activeDebate={activeDebate}
-          hasResponse={viewerPosition !== null}
-          responseIndexing={isPublishing}
-        />
-      </div>
     </>
   );
 }
@@ -200,22 +225,28 @@ function UnresolvableControls({
 }) {
   return (
     <>
+      <ClaimHeader
+        claim={claim}
+        isOnGraph={false}
+        toggle={
+          /* Readiness is geo-chat state, so it still works without a graph id. */
+          <ClaimReadinessToggle
+            claim={claim}
+            readiness={readiness}
+            activeDebate={activeDebate}
+            hasResponse={readiness.viewer_response !== null}
+          />
+        }
+      />
       <PositionRow
         positions={positions}
         responseKind={readiness.response_kind}
         viewerPosition={readiness.viewer_response?.position ?? null}
       />
-      <div className="mt-3 flex items-center justify-between gap-3">
+      <div className="mt-3">
         <Text as="span" variant="footnote" color="grey-04">
           Claim unavailable
         </Text>
-        {/* Readiness is geo-chat state, so it still works without a graph id. */}
-        <ClaimReadinessToggle
-          claim={claim}
-          readiness={readiness}
-          activeDebate={activeDebate}
-          hasResponse={readiness.viewer_response !== null}
-        />
       </div>
     </>
   );


### PR DESCRIPTION
## What

In the Debates side panel (Claims and Matches tabs), the readiness toggle was rendering at the **bottom** of each claim card, under the response buttons. The [design](https://www.figma.com/design/iWKsYButqqKWd1bqeBrUUj/Geo---Web?node-id=74928-116114&m=dev) puts it **top right**, sharing the header row with the space chip.

Before / after:

```
before                              after
┌──────────────────────────┐        ┌──────────────────────────┐
│ ⬤ Crypto                 │        │ ⬤ Crypto      ▭ Debate   │
│ Ronald Mannak largely…   │        │ Ronald Mannak largely…   │
│ [ Yes  ⬤⬤ ] [ No   ⬤⬤ ] │        │ [ Yes  ⬤⬤ ] [ No   ⬤⬤ ] │
│              ▭ Debate    │        │                          │
└──────────────────────────┘        └──────────────────────────┘
```

## How

The toggle's enabled state depends on response state (`hasResponse`, `responseIndexing`) that only `RespondableControls` tracks, so it couldn't simply be lifted into `MatchmakingClaimCard` — the card renders either the respondable or the unresolvable variant, and calling the graph response hooks unconditionally would query the graph for claims it can't resolve (which the card deliberately avoids).

Instead both variants now render through a shared `ClaimHeader` (space chip + toggle slot + claim text), each passing the toggle it can describe. The unresolvable variant keeps its "Claim unavailable" notice, now standing alone where the toggle used to sit beside it.

Toggle styling follows the design: 8px gap between switch and label, `footnoteMedium` label, `min-h-4` so it lines up with the space chip's avatar, and a label that stays grey in both states (the switch itself carries the on/off signal — the design shows the ON state with a grey label). The explanation/error text stays attached below the switch, so `aria-describedby` and the "Respond to this claim to debate it." guidance are unchanged; the header row uses `items-start` so the space chip doesn't drift when that text appears.

## Test plan

- New `matchmaking-claim-card.test.tsx` (the card had no direct coverage before): asserts the toggle shares the header row with the space chip and precedes both the claim text and the response buttons, in the on-graph and off-graph variants, plus the unavailable-explanation behavior. **Verified it's a real guard** — 3 of its 4 tests fail against the previous layout.
- `bun run build` passes (type check included).
- Note: the rest of `core/debates/matchmaking` currently fails to load locally on a `--localstorage-file` / jsdom `localStorage` issue — identical on pristine master, unrelated to this change. Those suites still need CI to confirm.
- Not visually verified in a browser; worth a look in the side panel before marking ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)