### PR TITLE
fix(debates): stop the full-screen debate from sliding under the navbar

### DIFF
--- a/apps/web/atoms/index.ts
+++ b/apps/web/atoms/index.ts
@@ -35,6 +35,12 @@ export const navbarSpaceOverrideAtom = atom<{ spaceId: string } | null>(null);
 
 export const rankingFullscreenActiveAtom = atom<boolean>(false);
 
+// Set while the full-screen debates feed is on screen. A Debate entity page renders the feed
+// from a route `Main` otherwise treats as an ordinary entity page, so without this it wraps a
+// viewport-filling takeover in `max-w-[1200px] pt-8 pb-16` — which makes the document taller
+// than the viewport and lets the feed scroll up under the sticky navbar.
+export const debateFullscreenActiveAtom = atom<boolean>(false);
+
 export const entitySidePanelWantsEditAtom = atom(false);
 
 export const entitySidePanelPersistEditorAtom = atom<(() => void) | null>(null);

--- a/apps/web/core/debates/browse/debate-feed.test.tsx
+++ b/apps/web/core/debates/browse/debate-feed.test.tsx
@@ -1,9 +1,12 @@
 import '@testing-library/jest-dom/vitest';
 import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
 
+import { Provider, createStore } from 'jotai';
 import { afterEach, assert, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { Debate } from '~/core/debates/api';
+
+import { debateFullscreenActiveAtom } from '~/atoms';
 
 import { DebatesBrowseFeed } from './debate-feed';
 
@@ -209,6 +212,33 @@ describe('DebatesBrowseFeed video sharing', () => {
       scrollHeight.mockRestore();
       clientHeight.mockRestore();
     }
+  });
+
+  // The takeover fills the viewport, but a Debate entity page reaches it through a route the app
+  // shell reads as an ordinary entity page. Left wrapped in that page's chrome, the document
+  // grows taller than the viewport and the feed scrolls up under the sticky navbar.
+  it('tells the app shell to drop its page chrome while the feed is on screen', () => {
+    const store = createStore();
+    render(
+      <Provider store={store}>
+        <DebatesBrowseFeed spaceId="space-1" />
+      </Provider>
+    );
+
+    expect(store.get(debateFullscreenActiveAtom)).toBe(true);
+  });
+
+  it('leaves the chrome alone when it falls back to the entity page', () => {
+    const store = createStore();
+    render(
+      <Provider store={store}>
+        <DebatesBrowseFeed spaceId="space-1" initialDebateId="not-in-this-space" fallback={<div>Entity page</div>} />
+      </Provider>
+    );
+
+    expect(screen.getByText('Entity page')).toBeInTheDocument();
+    // An ordinary entity page renders here and does want the chrome.
+    expect(store.get(debateFullscreenActiveAtom)).toBe(false);
   });
 
   it('nudges only when there is something below to scroll to', () => {

--- a/apps/web/core/debates/browse/debate-feed.test.tsx
+++ b/apps/web/core/debates/browse/debate-feed.test.tsx
@@ -157,8 +157,8 @@ describe('DebatesBrowseFeed video sharing', () => {
     expect(screen.getByRole('button', { name: 'Back' })).toHaveClass('size-8', 'justify-center', '-mb-3');
     const feedItem = heading.closest('section');
     assert(feedItem, 'Expected the debate heading to be rendered inside a feed item');
-    // `pt-5` is the design's 20px gap under the navbar; `md:pt-3` keeps mobile's own spacing.
-    expect(feedItem).toHaveClass('items-start', 'pt-5', 'md:h-auto', 'md:min-h-full', 'md:py-3', 'md:pt-3');
+    // `pt-5` is the design's 20px gap under the navbar; `md:py-3` overrides it on mobile.
+    expect(feedItem).toHaveClass('items-start', 'pt-5', 'md:h-auto', 'md:min-h-full', 'md:py-3');
     // One class per assertion: `not.toHaveClass(a, b)` only fails when *every* class is present,
     // so grouping them lets a regression on any single class slip through.
     expect(feedItem).not.toHaveClass('items-center');

--- a/apps/web/core/debates/browse/debate-feed.test.tsx
+++ b/apps/web/core/debates/browse/debate-feed.test.tsx
@@ -157,8 +157,12 @@ describe('DebatesBrowseFeed video sharing', () => {
     expect(screen.getByRole('button', { name: 'Back' })).toHaveClass('size-8', 'justify-center', '-mb-3');
     const feedItem = heading.closest('section');
     assert(feedItem, 'Expected the debate heading to be rendered inside a feed item');
-    expect(feedItem).toHaveClass('items-start', 'md:h-auto', 'md:min-h-full', 'md:py-3');
-    expect(feedItem).not.toHaveClass('items-center', 'pt-5', 'pb-[2.75rem]');
+    // `pt-5` is the design's 20px gap under the navbar; `md:pt-3` keeps mobile's own spacing.
+    expect(feedItem).toHaveClass('items-start', 'pt-5', 'md:h-auto', 'md:min-h-full', 'md:py-3', 'md:pt-3');
+    // One class per assertion: `not.toHaveClass(a, b)` only fails when *every* class is present,
+    // so grouping them lets a regression on any single class slip through.
+    expect(feedItem).not.toHaveClass('items-center');
+    expect(feedItem).not.toHaveClass('pb-[2.75rem]');
     const mediaColumn = screen.getByTestId('player-debate-1').parentElement?.parentElement;
     assert(mediaColumn, 'Expected the debate player to be rendered inside the media column');
     expect(mediaColumn).toHaveClass('min-w-0', 'w-[var(--debate-feed-column-width)]', 'md:w-[calc(100vw-1rem)]');

--- a/apps/web/core/debates/browse/debate-feed.tsx
+++ b/apps/web/core/debates/browse/debate-feed.tsx
@@ -5,6 +5,7 @@ import { keepPreviousData } from '@tanstack/react-query';
 import * as React from 'react';
 
 import cx from 'classnames';
+import { useSetAtom } from 'jotai';
 
 import { CLAIM_TYPE_ID, TOPICS_PROPERTY_ID } from '~/core/claims/ontology';
 import type { Debate } from '~/core/debates/api';
@@ -26,6 +27,8 @@ import { DebateInteractionBar } from './debate-interaction-bar';
 import { DebateScrollHint, scrollHintBounceProps, useDebateScrollHint } from './debate-scroll-hint';
 import { JoinDebatePanel } from './join-debate-panel';
 import { useDebateShareAction } from './use-debate-share-action';
+
+import { debateFullscreenActiveAtom } from '~/atoms';
 
 const PAGE_SIZE = 5;
 const DEBATE_COLUMN_STYLE = {
@@ -148,6 +151,18 @@ export function DebatesBrowseFeed({
   // Debates tab passes none and keeps its own empty/error states. Requires a clean read — an
   // errored lookup holds the feed's error state above rather than falling back.
   const anchorMissing = anchorUnresolved && !isLoading && !anchorErrored;
+
+  // Tell the app shell it's hosting a viewport-filling takeover, so a Debate entity page —
+  // whose route `Main` can't recognise as full-width — drops its page chrome. Not set on the
+  // fallback path, where an ordinary entity page renders and does want that chrome. A layout
+  // effect so the padded layout is never painted, only to snap away a frame later.
+  const rendersFeed = !(anchorMissing && fallback != null);
+  const setDebateFullscreenActive = useSetAtom(debateFullscreenActiveAtom);
+  React.useLayoutEffect(() => {
+    if (!rendersFeed) return;
+    setDebateFullscreenActive(true);
+    return () => setDebateFullscreenActive(false);
+  }, [rendersFeed, setDebateFullscreenActive]);
 
   const visibleDebates = anchorPending ? [] : debates.slice(0, visibleCount);
 

--- a/apps/web/core/debates/browse/debate-feed.tsx
+++ b/apps/web/core/debates/browse/debate-feed.tsx
@@ -296,7 +296,9 @@ function DebateFeedItem({
   return (
     <section
       ref={itemRef}
-      className="flex h-full snap-start items-start justify-center px-4 md:h-auto md:min-h-full md:px-2 md:py-3"
+      // 20px below the navbar, per the design — the media sizing has slack to absorb it, so
+      // the claim header doesn't need to sit flush against the chrome.
+      className="flex h-full snap-start items-start justify-center px-4 pt-5 md:h-auto md:min-h-full md:px-2 md:py-3 md:pt-3"
     >
       {/* The whole debate lifts with the nudge — title, media and controls together — so the
           gesture reads as the feed scrolling rather than as one element twitching. Shared

--- a/apps/web/core/debates/browse/debate-feed.tsx
+++ b/apps/web/core/debates/browse/debate-feed.tsx
@@ -297,8 +297,9 @@ function DebateFeedItem({
     <section
       ref={itemRef}
       // 20px below the navbar, per the design — the media sizing has slack to absorb it, so
-      // the claim header doesn't need to sit flush against the chrome.
-      className="flex h-full snap-start items-start justify-center px-4 pt-5 md:h-auto md:min-h-full md:px-2 md:py-3 md:pt-3"
+      // the claim header doesn't need to sit flush against the chrome. `md:py-3` still wins on
+      // mobile: Tailwind emits variant utilities after unprefixed ones, so no `md:pt-3` needed.
+      className="flex h-full snap-start items-start justify-center px-4 pt-5 md:h-auto md:min-h-full md:px-2 md:py-3"
     >
       {/* The whole debate lifts with the nudge — title, media and controls together — so the
           gesture reads as the feed scrolling rather than as one element twitching. Shared

--- a/apps/web/partials/main.test.tsx
+++ b/apps/web/partials/main.test.tsx
@@ -55,6 +55,10 @@ describe('Main', () => {
 
   it('keeps the chrome off routes that are already full-width', () => {
     mocks.pathname = '/space/space-1/debates';
-    expect(renderMain()).not.toHaveClass(...CHROME);
+    const main = renderMain();
+
+    // Individually: `not.toHaveClass(a, b)` only fails when *every* class is present, so the
+    // spread form would still pass if one chrome class crept back.
+    for (const className of CHROME) expect(main).not.toHaveClass(className);
   });
 });

--- a/apps/web/partials/main.test.tsx
+++ b/apps/web/partials/main.test.tsx
@@ -1,0 +1,60 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+
+import { Provider, createStore } from 'jotai';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { Main } from './main';
+import { debateFullscreenActiveAtom } from '~/atoms';
+
+const mocks = vi.hoisted(() => ({ pathname: '/space/space-1/entity-1' }));
+
+vi.mock('next/navigation', () => ({ usePathname: () => mocks.pathname }));
+vi.mock('~/core/state/diff-store', () => ({ useDiff: () => ({ isReviewOpen: false }) }));
+
+let store: ReturnType<typeof createStore>;
+
+beforeEach(() => {
+  mocks.pathname = '/space/space-1/entity-1';
+  store = createStore();
+});
+
+afterEach(cleanup);
+
+function renderMain() {
+  render(
+    <Provider store={store}>
+      <Main>
+        <div data-testid="page" />
+      </Main>
+    </Provider>
+  );
+  const main = screen.getByTestId('page').parentElement;
+  if (!main) throw new Error('Expected Main to wrap its children');
+  return main;
+}
+
+// The page chrome makes the document taller than the viewport. Around a viewport-filling
+// takeover that lets the whole thing scroll up under the sticky navbar, clipping the debate.
+const CHROME = ['mx-auto', 'max-w-[1200px]', 'pt-8', 'pb-16'];
+
+describe('Main', () => {
+  it('wraps an ordinary entity page in the page chrome', () => {
+    expect(renderMain()).toHaveClass(...CHROME);
+  });
+
+  // A Debate entity page renders the feed from a route that looks like any other entity page,
+  // so the pathname can't distinguish it — the view raises this flag instead.
+  it('drops the chrome while a full-screen debate is on that same route', () => {
+    store.set(debateFullscreenActiveAtom, true);
+    const main = renderMain();
+
+    expect(main).toHaveClass('min-w-0', 'flex-1');
+    for (const className of CHROME) expect(main).not.toHaveClass(className);
+  });
+
+  it('keeps the chrome off routes that are already full-width', () => {
+    mocks.pathname = '/space/space-1/debates';
+    expect(renderMain()).not.toHaveClass(...CHROME);
+  });
+});

--- a/apps/web/partials/main.tsx
+++ b/apps/web/partials/main.tsx
@@ -3,9 +3,12 @@
 import * as React from 'react';
 
 import { motion } from 'framer-motion';
+import { useAtomValue } from 'jotai';
 import { usePathname } from 'next/navigation';
 
 import { useDiff } from '~/core/state/diff-store';
+
+import { debateFullscreenActiveAtom } from '~/atoms';
 
 type MainProps = {
   children: React.ReactNode;
@@ -15,7 +18,13 @@ export const Main = ({ children }: MainProps) => {
   const { isReviewOpen } = useDiff();
   const isHidden = isReviewOpen;
   const pathname = usePathname();
+  // A Debate entity page renders the full-screen debates feed from an ordinary
+  // `/space/{id}/{entityId}` route, which no pathname test can pick out — only the view itself
+  // knows. Wrapping that takeover in the page chrome below makes the document taller than the
+  // viewport, so the feed scrolls up under the sticky navbar.
+  const debateFullscreenActive = useAtomValue(debateFullscreenActiveAtom);
   const isFullWidth =
+    debateFullscreenActive ||
     pathname === '/explore' ||
     /^\/space\/[^/]+\/community\/call\/[^/]+$/.test(pathname) ||
     /^\/space\/[^/]+\/debates(\/|$)/.test(pathname);


### PR DESCRIPTION
Opening a debate from the explore feed lands it offset, with the claim title clipped behind the navbar.

### Cause

The explore card links to the Debate **entity** page, so the URL is an ordinary `/space/{id}/{entityId}`. `Main` decides page chrome from the pathname, and its full-width list only covers `/explore`, community calls, and `/space/{id}/debates` — an entity page can't be matched by path, since nothing in the URL says the entity is a Debate. So the viewport-filling feed gets wrapped in `mx-auto max-w-[1200px] pt-8 pb-16`.

That padding makes the document taller than the viewport, so the page scrolls even though the feed is meant to fill it. Any scroll — including a position carried over from the explore feed — slides the whole takeover up behind the `sticky` navbar.

Measured in a reproduction of the app shell (navbar + `Main` + the real `--debate-feed-column-width` formula) at 1512×860:

| route | page scroll | title at full scroll |
|---|---|---|
| `/space/{id}/debates` | 0px | flush under navbar |
| `/space/{id}/{entityId}` | **96px** | **64px behind the navbar** |

96px is exactly `pt-8` + `pb-16`.

### Fix

Only the view knows it's rendering the takeover, so it raises a flag the shell reads — mirroring the existing `rankingFullscreenActiveAtom`. `DebatesBrowseFeed` sets `debateFullscreenActiveAtom` while it renders the feed and `Main` treats that as full-width.

Two details worth reviewing:

- **Set in a `useLayoutEffect`**, so the padded layout is never painted and then snapped away a frame later. A plain `useEffect` would flash a 32px shift on every debate entity page load.
- **Not set on the fallback path.** When the anchor can't be resolved, `DebatesBrowseFeed` renders the caller's entity page instead — that's an ordinary page and does want the chrome. Gating on `rendersFeed` rather than on mounting keeps the two cases apart.

### Verification

- `partials/main.test.tsx` (new): chrome on an ordinary entity route, dropped when the flag is up, and still absent on routes that were already full-width.
- `debate-feed.test.tsx`: the feed raises the flag, and leaves it down on the fallback path.
- Both halves confirmed to fail without the fix — reverting the `Main` condition fails the chrome test, and neutering the effect fails the feed test.
- 41 tests green across `core/debates/browse/` and `partials/main.test.tsx`; typecheck clean.

`debate-feed.tsx` and `debate-feed.test.tsx` are flagged by my local prettier, but so are master's own untouched copies — version skew, so I left their formatting alone rather than adding unrelated churn.

### Not verified

Not exercised in the running app — reproducing needs the debates flag plus a space with processed recordings. The measurements above come from a static reproduction of the shell, so a preview check on the real explore → debate path is worth doing before merge.