### PR TITLE
feat(debates): match the rematch claim picker to the hub's Claims tab

### DIFF
--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
@@ -31,6 +31,16 @@ const mocks = vi.hoisted(() => ({
   rejectMutate: vi.fn(),
   submitResponse: vi.fn(),
   optimisticResponses: new Map<string, 'positive' | 'negative' | null>(),
+  claimReadiness: [] as Array<{
+    claim_entity_id: string;
+    viewer_debate_ready: boolean;
+    readiness_disabled_reason: string | null;
+  }>,
+  setReadiness: vi.fn(),
+}));
+
+vi.mock('~/core/debates/matchmaking/hooks', () => ({
+  useClaimReadiness: () => ({ mutate: mocks.setReadiness, isPending: false, error: null }),
 }));
 
 vi.mock('next/navigation', () => ({
@@ -50,6 +60,8 @@ vi.mock('~/core/debates/hooks', () => ({
     error: null,
   }),
   useDebate: () => ({ data: { claim: { claim_entity_id: CLAIM_SOURCE } } }),
+  // Readiness comes from the per-space debate-claims endpoint, keyed by claim entity id.
+  useDebateClaimsBySpaces: () => mocks.claimReadiness,
   useCreateDebateRematchRequest: () => mutation(),
   useLeaveDebateRematch: () => mutation(mocks.leaveMutate),
   useAcceptDebateRematchRequest: () => mutation(mocks.acceptMutate),
@@ -113,6 +125,8 @@ beforeEach(() => {
   mocks.rejectMutate.mockReset();
   mocks.submitResponse.mockReset();
   mocks.optimisticResponses.clear();
+  mocks.claimReadiness = [];
+  mocks.setReadiness.mockReset();
   mocks.session = session();
   mocks.claims = [sharedClaim()];
   // The hub's filter menus measure their dropdown.
@@ -194,6 +208,7 @@ describe('DebateRematchPageClient', () => {
 
   it('pins shared preferences above additional published claims and enables opposing requests', () => {
     render(<DebateRematchPageClient sessionId="rematch-1" />);
+    showAllClaims();
 
     const shared = screen.getByText('A claim both participants chose');
     const additional = screen.getByText('A newly published claim');
@@ -232,6 +247,8 @@ describe('DebateRematchPageClient', () => {
     ];
 
     render(<DebateRematchPageClient sessionId="rematch-1" />);
+    // This one also inspects the published claim, which only the All tab lists.
+    showAllClaims();
 
     const sharedClaimCard = screen.getByText('A claim both participants chose').closest('article');
     expect(sharedClaimCard).not.toBeNull();
@@ -356,6 +373,7 @@ describe('DebateRematchPageClient', () => {
     });
 
     render(<DebateRematchPageClient sessionId="rematch-1" />);
+    showAllClaims();
 
     expect(screen.getByRole('button', { name: 'Requesting…' })).toBeDisabled();
     // Two sides on each of the two claims; the held side's name carries a "your response" suffix.
@@ -389,6 +407,87 @@ describe('DebateRematchPageClient', () => {
     ).toBeInTheDocument();
   });
 
+  it('opens on the opponent’s positions rather than the whole list', () => {
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+
+    // The published claim carries no position from Salina, so it waits on the All tab.
+    expect(screen.getByText('A claim both participants chose')).toBeInTheDocument();
+    expect(screen.queryByText('A newly published claim')).toBeNull();
+  });
+
+  it('shortens the opponent tab to their first name', () => {
+    mocks.session = session({
+      participants: [session().participants[0], { ...session().participants[1], display_name: 'Salina Okonkwo' }],
+    });
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+
+    expect(screen.getByRole('button', { name: /Salina’s positions/ })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Okonkwo/ })).toBeNull();
+  });
+
+  // Waiting for geo-chat to echo the response back left the side you just picked unhighlighted
+  // and "Request debate" missing for seconds after the click.
+  it('reflects a just-picked side and offers the debate straight away', () => {
+    mocks.claims = [
+      {
+        ...sharedClaim(),
+        participants: [
+          { user_id: 'user-local', position: null, position_label: null },
+          { user_id: 'user-remote', position: false, position_label: 'Disagree' },
+        ],
+      },
+    ];
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+
+    // Nothing to request yet: the viewer holds no side.
+    expect(screen.queryByRole('button', { name: 'Request debate' })).toBeNull();
+
+    // The client knows its own answer before the server does.
+    mocks.optimisticResponses.set(CLAIM_SHARED, 'positive');
+    cleanup();
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+
+    const card = screen.getByText('A claim both participants chose').closest('article');
+    expect(within(card!).getByRole('button', { name: /^Agree/ })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: 'Request debate' })).toBeEnabled();
+  });
+
+  it('shows the Debate toggle against real readiness', () => {
+    mocks.claimReadiness = [
+      { claim_entity_id: CLAIM_SHARED, viewer_debate_ready: true, readiness_disabled_reason: null },
+    ];
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+
+    expect(screen.getByRole('switch', { name: 'Ready to debate this claim' })).toBeChecked();
+  });
+
+  // Picking a side here means you want to debate it, so readiness shouldn't be a second step.
+  it('opts into readiness when a side is picked in this flow', () => {
+    mocks.claims = [
+      {
+        ...sharedClaim(),
+        participants: [
+          { user_id: 'user-local', position: null, position_label: null },
+          { user_id: 'user-remote', position: false, position_label: 'Disagree' },
+        ],
+      },
+    ];
+    const { rerender } = render(<DebateRematchPageClient sessionId="rematch-1" />);
+    expect(mocks.setReadiness).not.toHaveBeenCalled();
+
+    mocks.optimisticResponses.set(CLAIM_SHARED, 'positive');
+    rerender(<DebateRematchPageClient sessionId="rematch-1" />);
+
+    expect(mocks.setReadiness).toHaveBeenCalledWith({ spaceId: SPACE_1, claimId: CLAIM_SHARED, ready: true });
+  });
+
+  // Standing down from elsewhere is deliberate; arriving here mustn't silently undo it.
+  it('does not opt in for positions that were already held on arrival', () => {
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+
+    expect(mocks.setReadiness).not.toHaveBeenCalled();
+  });
+
   // The opponent tab is the old "Debate now": claims they've already taken a side on.
   it('names the opponent tab after them and counts their positions', () => {
     render(<DebateRematchPageClient sessionId="rematch-1" />);
@@ -400,6 +499,7 @@ describe('DebateRematchPageClient', () => {
 
   it('filters to opponent-committed claims on their positions tab', async () => {
     render(<DebateRematchPageClient sessionId="rematch-1" />);
+    showAllClaims();
 
     // The opponent has taken a side on the shared claim but not the newly published one.
     expect(screen.getByText('A claim both participants chose')).toBeInTheDocument();
@@ -422,6 +522,7 @@ describe('DebateRematchPageClient', () => {
 
   it('narrows the list to the selected topic', async () => {
     render(<DebateRematchPageClient sessionId="rematch-1" />);
+    showAllClaims();
 
     selectFilter('Any topic', 'Governance');
 
@@ -432,6 +533,7 @@ describe('DebateRematchPageClient', () => {
 
   it('matches the topic filter on any of a claim topics, not just the first', () => {
     render(<DebateRematchPageClient sessionId="rematch-1" />);
+    showAllClaims();
 
     // The published claim is tagged Governance and Ethics; filtering on the second still matches.
     selectFilter('Any topic', 'Ethics');
@@ -442,6 +544,7 @@ describe('DebateRematchPageClient', () => {
   // The hub's Claims tab narrows by space too, so the picker does the same.
   it('narrows the list to the selected space', async () => {
     render(<DebateRematchPageClient sessionId="rematch-1" />);
+    showAllClaims();
 
     // The shared claim sits in Crypto; the newly published one is in Governance space.
     selectFilter('Any space', 'Crypto');
@@ -452,6 +555,7 @@ describe('DebateRematchPageClient', () => {
 
   it('searches the claim text, and both filters and search survive a tab switch', async () => {
     render(<DebateRematchPageClient sessionId="rematch-1" />);
+    showAllClaims();
 
     fireEvent.change(screen.getByRole('textbox', { name: 'Search claims' }), {
       target: { value: 'newly published' },
@@ -467,6 +571,11 @@ describe('DebateRematchPageClient', () => {
     expect(screen.getByText('No claims match these filters.')).toBeInTheDocument();
   });
 });
+
+/** The picker opens on the opponent's positions; most assertions want the unfiltered list. */
+function showAllClaims() {
+  fireEvent.click(screen.getByRole('button', { name: 'All' }));
+}
 
 /**
  * Opens one of the hub filter menus and picks an option. Names are matched loosely: a space

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom/vitest';
-import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 
 import { StrictMode } from 'react';
 
@@ -9,6 +9,16 @@ import { TOPICS_PROPERTY_ID } from '~/core/claims/ontology';
 import type { DebateRematchClaim, DebateRematchSession } from '~/core/debates/api';
 
 import { DebateRematchPageClient } from './rematch-page-client';
+
+// `isResolvableClaim` gates the hub card's response buttons on ids the graph would accept, so
+// these have to be well-formed rather than readable slugs.
+const { SPACE_1, SPACE_2, CLAIM_SHARED, CLAIM_MORE, CLAIM_SOURCE } = vi.hoisted(() => ({
+  SPACE_1: '019fedae-72b6-7ab2-927a-df044d57c566',
+  SPACE_2: '019fedae-72b6-7ab2-927a-df044d57c567',
+  CLAIM_SHARED: '019fedb1-0c41-7f3e-9a11-2c7d5e8b4419',
+  CLAIM_MORE: '019fedb2-1d52-7a4f-8b22-3d8e6f9c5520',
+  CLAIM_SOURCE: '019fedb3-2e63-7b50-9c33-4e9f7a0d6621',
+}));
 
 const mocks = vi.hoisted(() => ({
   session: null as DebateRematchSession | null,
@@ -35,11 +45,11 @@ vi.mock('~/core/debates/api', async importOriginal => {
 vi.mock('~/core/debates/hooks', () => ({
   useDebateRematch: () => ({ data: mocks.session, isLoading: false, error: null }),
   useDebateRematchClaims: () => ({
-    data: { claims: mocks.claims, excluded_claim_ids: ['claim-source'] },
+    data: { claims: mocks.claims, excluded_claim_ids: [CLAIM_SOURCE] },
     isLoading: false,
     error: null,
   }),
-  useDebate: () => ({ data: { claim: { claim_entity_id: 'claim-source' } } }),
+  useDebate: () => ({ data: { claim: { claim_entity_id: CLAIM_SOURCE } } }),
   useCreateDebateRematchRequest: () => mutation(),
   useLeaveDebateRematch: () => mutation(mocks.leaveMutate),
   useAcceptDebateRematchRequest: () => mutation(mocks.acceptMutate),
@@ -50,10 +60,10 @@ vi.mock('~/core/sync/use-store', () => ({
   useQueryEntities: () => ({
     entities: [
       {
-        id: 'claim-more',
+        id: CLAIM_MORE,
         name: 'A newly published claim',
         description: null,
-        spaces: ['space-2'],
+        spaces: [SPACE_2],
         relations: [
           { type: { id: TOPICS_PROPERTY_ID }, toEntity: { id: 'topic-gov', name: 'Governance' }, isDeleted: false },
           { type: { id: TOPICS_PROPERTY_ID }, toEntity: { id: 'topic-eth', name: 'Ethics' }, isDeleted: false },
@@ -72,6 +82,21 @@ vi.mock('~/core/hooks/use-entity-vote', () => ({
     submitResponse: (direction: 'positive' | 'negative' | 'clear') => mocks.submitResponse(entityId, direction),
     optimisticResponse: mocks.optimisticResponses.get(entityId),
     isConnected: true,
+    personalSpaceId: 'personal-space',
+  }),
+  useEntityResponseIndexingSnapshot: () => ({ status: 'idle', pending: null, runId: null }),
+  useResetEntityResponseIndexingSnapshot: () => vi.fn(),
+}));
+
+// The picker now renders the hub's claim card and filter menus, which resolve space names.
+vi.mock('~/core/hooks/use-spaces-by-ids', () => ({
+  useSpacesByIds: () => ({
+    spaces: [],
+    spacesById: new Map([
+      [SPACE_1, { entity: { name: 'Crypto', image: null } }],
+      [SPACE_2, { entity: { name: 'Governance space', image: null } }],
+    ]),
+    isLoading: false,
   }),
 }));
 
@@ -90,6 +115,12 @@ beforeEach(() => {
   mocks.optimisticResponses.clear();
   mocks.session = session();
   mocks.claims = [sharedClaim()];
+  // The hub's filter menus measure their dropdown.
+  window.ResizeObserver ??= class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver;
   document.body.style.overflow = '';
   document.documentElement.style.overflow = '';
 });
@@ -107,7 +138,7 @@ describe('DebateRematchPageClient', () => {
       </StrictMode>
     );
 
-    expect(await screen.findByRole('heading', { name: 'A claim both participants chose' })).toBeInTheDocument();
+    expect(await screen.findByText('A claim both participants chose')).toBeInTheDocument();
     await new Promise(resolve => window.setTimeout(resolve, 0));
     expect(mocks.leaveMutate).not.toHaveBeenCalled();
   });
@@ -143,7 +174,7 @@ describe('DebateRematchPageClient', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Leave debate' }));
 
     expect(mocks.back).toHaveBeenCalledOnce();
-    expect(mocks.replace).not.toHaveBeenCalledWith('/space/space-1/debates');
+    expect(mocks.replace).not.toHaveBeenCalledWith(`/space/${SPACE_1}/debates`);
   });
 
   it('preserves the debates-page exit for rematches started from a prior debate', () => {
@@ -157,15 +188,15 @@ describe('DebateRematchPageClient', () => {
     render(<DebateRematchPageClient sessionId="rematch-1" />);
     fireEvent.click(screen.getByRole('button', { name: 'Leave debate' }));
 
-    expect(mocks.replace).toHaveBeenCalledWith('/space/space-1/debates');
+    expect(mocks.replace).toHaveBeenCalledWith(`/space/${SPACE_1}/debates`);
     expect(mocks.back).not.toHaveBeenCalled();
   });
 
   it('pins shared preferences above additional published claims and enables opposing requests', () => {
     render(<DebateRematchPageClient sessionId="rematch-1" />);
 
-    const shared = screen.getByRole('heading', { name: 'A claim both participants chose' });
-    const additional = screen.getByRole('heading', { name: 'A newly published claim' });
+    const shared = screen.getByText('A claim both participants chose');
+    const additional = screen.getByText('A newly published claim');
     expect(shared.compareDocumentPosition(additional) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     expect(screen.getAllByRole('button', { name: 'Request debate' })[0]).toBeEnabled();
   });
@@ -173,12 +204,20 @@ describe('DebateRematchPageClient', () => {
   it('renders active semantic response buttons with holder avatars', () => {
     render(<DebateRematchPageClient sessionId="rematch-1" />);
 
-    const sharedClaimCard = screen.getByRole('heading', { name: 'A claim both participants chose' }).closest('article');
+    const sharedClaimCard = screen.getByText('A claim both participants chose').closest('article');
     expect(sharedClaimCard).not.toBeNull();
-    expect(within(sharedClaimCard!).getByRole('button', { name: 'Agree' })).toBeEnabled();
-    expect(within(sharedClaimCard!).getByRole('button', { name: 'Disagree' })).toBeEnabled();
-    expect(within(sharedClaimCard!).getByRole('button', { name: 'Agree' }).querySelector('img, svg')).not.toBeNull();
-    expect(within(sharedClaimCard!).getByRole('button', { name: 'Disagree' }).querySelector('img, svg')).not.toBeNull();
+    expect(within(sharedClaimCard!).getByRole('button', { name: /^Agree/ })).toBeEnabled();
+    expect(within(sharedClaimCard!).getByRole('button', { name: /^Disagree/ })).toBeEnabled();
+    expect(
+      within(sharedClaimCard!)
+        .getByRole('button', { name: /^Agree/ })
+        .querySelector('img, svg')
+    ).not.toBeNull();
+    expect(
+      within(sharedClaimCard!)
+        .getByRole('button', { name: /^Disagree/ })
+        .querySelector('img, svg')
+    ).not.toBeNull();
   });
 
   it('changes responses through the semantic buttons without rendering a second response area', () => {
@@ -194,16 +233,16 @@ describe('DebateRematchPageClient', () => {
 
     render(<DebateRematchPageClient sessionId="rematch-1" />);
 
-    const sharedClaimCard = screen.getByRole('heading', { name: 'A claim both participants chose' }).closest('article');
+    const sharedClaimCard = screen.getByText('A claim both participants chose').closest('article');
     expect(sharedClaimCard).not.toBeNull();
-    fireEvent.click(within(sharedClaimCard!).getByRole('button', { name: 'Disagree' }));
-    expect(mocks.submitResponse).toHaveBeenCalledWith('claim-shared', 'negative');
+    fireEvent.click(within(sharedClaimCard!).getByRole('button', { name: /^Disagree/ }));
+    expect(mocks.submitResponse).toHaveBeenCalledWith(CLAIM_SHARED, 'negative');
     expect(screen.queryByText('You both have the same response. Change yours to request this debate.')).toBeNull();
-    const syntheticClaimCard = screen.getByRole('heading', { name: 'A newly published claim' }).closest('article');
+    const syntheticClaimCard = screen.getByText('A newly published claim').closest('article');
     expect(syntheticClaimCard).not.toBeNull();
     expect(within(syntheticClaimCard!).queryByText('Respond before requesting')).toBeNull();
-    expect(within(syntheticClaimCard!).getByRole('button', { name: 'Agree' })).toBeEnabled();
-    expect(within(syntheticClaimCard!).getByRole('button', { name: 'Disagree' })).toBeEnabled();
+    expect(within(syntheticClaimCard!).getByRole('button', { name: /^Agree/ })).toBeEnabled();
+    expect(within(syntheticClaimCard!).getByRole('button', { name: /^Disagree/ })).toBeEnabled();
   });
 
   it('uses Verify and Dispute for factual claims', () => {
@@ -220,10 +259,10 @@ describe('DebateRematchPageClient', () => {
 
     render(<DebateRematchPageClient sessionId="rematch-1" />);
 
-    const claimCard = screen.getByRole('heading', { name: 'A claim both participants chose' }).closest('article');
+    const claimCard = screen.getByText('A claim both participants chose').closest('article');
     expect(claimCard).not.toBeNull();
-    expect(within(claimCard!).getByRole('button', { name: 'Verify' })).toBeEnabled();
-    expect(within(claimCard!).getByRole('button', { name: 'Dispute' })).toBeEnabled();
+    expect(within(claimCard!).getByRole('button', { name: /^Verify/ })).toBeEnabled();
+    expect(within(claimCard!).getByRole('button', { name: /^Dispute/ })).toBeEnabled();
   });
 
   it('shows authoritative stance labels in the incoming request dialog and preserves rematch actions', () => {
@@ -232,7 +271,7 @@ describe('DebateRematchPageClient', () => {
       request: {
         id: 'request-1',
         status: 'pending',
-        claim: claimSummary('claim-shared', 'A claim both participants chose'),
+        claim: claimSummary(CLAIM_SHARED, 'A claim both participants chose'),
         requester_user_id: 'user-remote',
         recipient_user_id: 'user-local',
         requester_position: false,
@@ -278,7 +317,7 @@ describe('DebateRematchPageClient', () => {
       request: {
         id: 'request-legacy',
         status: 'pending',
-        claim: claimSummary('claim-shared', 'A claim both participants chose'),
+        claim: claimSummary(CLAIM_SHARED, 'A claim both participants chose'),
         requester_user_id: 'user-remote',
         recipient_user_id: 'user-local',
         requester_position: false,
@@ -302,7 +341,7 @@ describe('DebateRematchPageClient', () => {
       request: {
         id: 'request-1',
         status: 'pending',
-        claim: claimSummary('claim-shared', 'A claim both participants chose'),
+        claim: claimSummary(CLAIM_SHARED, 'A claim both participants chose'),
         requester_user_id: 'user-local',
         recipient_user_id: 'user-remote',
         requester_position: true,
@@ -318,8 +357,9 @@ describe('DebateRematchPageClient', () => {
 
     render(<DebateRematchPageClient sessionId="rematch-1" />);
 
-    expect(screen.getByRole('button', { name: 'Requesting...' })).toBeDisabled();
-    expect(screen.getAllByRole('button', { name: /^(Agree|Disagree)$/ })).toHaveLength(4);
+    expect(screen.getByRole('button', { name: 'Requesting…' })).toBeDisabled();
+    // Two sides on each of the two claims; the held side's name carries a "your response" suffix.
+    expect(screen.getAllByRole('button', { name: /^(Agree|Disagree)/ })).toHaveLength(4);
   });
 
   it('explains when response changes cancel a rematch request', () => {
@@ -327,7 +367,7 @@ describe('DebateRematchPageClient', () => {
       request: {
         id: 'request-1',
         status: 'expired',
-        claim: claimSummary('claim-shared', 'A claim both participants chose'),
+        claim: claimSummary(CLAIM_SHARED, 'A claim both participants chose'),
         requester_user_id: 'user-local',
         recipient_user_id: 'user-remote',
         requester_position: true,
@@ -349,53 +389,99 @@ describe('DebateRematchPageClient', () => {
     ).toBeInTheDocument();
   });
 
-  it('filters to opponent-committed claims on the Debate now tab', () => {
+  // The opponent tab is the old "Debate now": claims they've already taken a side on.
+  it('names the opponent tab after them and counts their positions', () => {
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+
+    const tab = screen.getByRole('button', { name: /Salina’s positions/ });
+    // Only the shared claim has a position from Salina; the published one doesn't.
+    expect(within(tab).getByText('1')).toBeInTheDocument();
+  });
+
+  it('filters to opponent-committed claims on their positions tab', async () => {
     render(<DebateRematchPageClient sessionId="rematch-1" />);
 
     // The opponent has taken a side on the shared claim but not the newly published one.
-    expect(screen.getByRole('heading', { name: 'A claim both participants chose' })).toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: 'A newly published claim' })).toBeInTheDocument();
+    expect(screen.getByText('A claim both participants chose')).toBeInTheDocument();
+    expect(screen.getByText('A newly published claim')).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('button', { name: /Debate now/ }));
+    fireEvent.click(screen.getByRole('button', { name: /Salina’s positions/ }));
 
-    expect(screen.getByRole('heading', { name: 'A claim both participants chose' })).toBeInTheDocument();
-    expect(screen.queryByRole('heading', { name: 'A newly published claim' })).toBeNull();
+    expect(screen.getByText('A claim both participants chose')).toBeInTheDocument();
+    await waitFor(() => expect(screen.queryByText('A newly published claim')).toBeNull());
   });
 
   it('shows the opponent-specific empty state when no claim is debate-ready', () => {
     mocks.claims = [];
     render(<DebateRematchPageClient sessionId="rematch-1" />);
 
-    fireEvent.click(screen.getByRole('button', { name: /Debate now/ }));
+    fireEvent.click(screen.getByRole('button', { name: /Salina’s positions/ }));
 
-    expect(screen.getByText(/Salina hasn't responded yet/)).toBeInTheDocument();
+    expect(screen.getByText(/Salina hasn’t responded yet/)).toBeInTheDocument();
   });
 
-  it('narrows the list to the selected topic', () => {
+  it('narrows the list to the selected topic', async () => {
     render(<DebateRematchPageClient sessionId="rematch-1" />);
 
-    fireEvent.change(screen.getByRole('combobox', { name: 'Filter by topic' }), { target: { value: 'Governance' } });
+    selectFilter('Any topic', 'Governance');
 
     // Only the Governance-tagged published claim survives; the untagged shared claim drops out.
-    expect(screen.getByRole('heading', { name: 'A newly published claim' })).toBeInTheDocument();
-    expect(screen.queryByRole('heading', { name: 'A claim both participants chose' })).toBeNull();
+    expect(screen.getByText('A newly published claim')).toBeInTheDocument();
+    await waitFor(() => expect(screen.queryByText('A claim both participants chose')).toBeNull());
   });
 
   it('matches the topic filter on any of a claim topics, not just the first', () => {
     render(<DebateRematchPageClient sessionId="rematch-1" />);
 
     // The published claim is tagged Governance and Ethics; filtering on the second still matches.
-    fireEvent.change(screen.getByRole('combobox', { name: 'Filter by topic' }), { target: { value: 'Ethics' } });
+    selectFilter('Any topic', 'Ethics');
 
-    expect(screen.getByRole('heading', { name: 'A newly published claim' })).toBeInTheDocument();
+    expect(screen.getByText('A newly published claim')).toBeInTheDocument();
+  });
+
+  // The hub's Claims tab narrows by space too, so the picker does the same.
+  it('narrows the list to the selected space', async () => {
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+
+    // The shared claim sits in Crypto; the newly published one is in Governance space.
+    selectFilter('Any space', 'Crypto');
+
+    expect(screen.getByText('A claim both participants chose')).toBeInTheDocument();
+    await waitFor(() => expect(screen.queryByText('A newly published claim')).toBeNull());
+  });
+
+  it('searches the claim text, and both filters and search survive a tab switch', async () => {
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Search claims' }), {
+      target: { value: 'newly published' },
+    });
+
+    // Search is debounced, so the narrowing lands a beat later.
+    expect(screen.getByText('A newly published claim')).toBeInTheDocument();
+    await waitFor(() => expect(screen.queryByText('A claim both participants chose')).toBeNull());
+
+    // Search applies on the opponent tab too, where it leaves nothing.
+    fireEvent.click(screen.getByRole('button', { name: /Salina’s positions/ }));
+    await waitFor(() => expect(screen.queryByText('A newly published claim')).toBeNull());
+    expect(screen.getByText('No claims match these filters.')).toBeInTheDocument();
   });
 });
+
+/**
+ * Opens one of the hub filter menus and picks an option. Names are matched loosely: a space
+ * option's accessible name picks up its avatar initial ("CCrypto").
+ */
+function selectFilter(trigger: string, option: string) {
+  fireEvent.click(screen.getByRole('button', { name: new RegExp(trigger) }));
+  fireEvent.click(screen.getByRole('button', { name: new RegExp(option) }));
+}
 
 function session(overrides: Partial<DebateRematchSession> = {}): DebateRematchSession {
   return {
     id: 'rematch-1',
     source_debate_id: 'debate-1',
-    source_space_id: 'space-1',
+    source_space_id: SPACE_1,
     status: 'browsing',
     participants: [
       {
@@ -428,7 +514,7 @@ function session(overrides: Partial<DebateRematchSession> = {}): DebateRematchSe
 
 function sharedClaim(): DebateRematchClaim {
   return {
-    claim: claimSummary('claim-shared', 'A claim both participants chose'),
+    claim: claimSummary(CLAIM_SHARED, 'A claim both participants chose'),
     response_kind: 'stance',
     participants: [
       { user_id: 'user-local', position: true, position_label: 'Agree' },
@@ -441,5 +527,5 @@ function sharedClaim(): DebateRematchClaim {
 }
 
 function claimSummary(id: string, claim: string) {
-  return { id, space_id: 'space-1', claim_entity_id: id, claim, description: null };
+  return { id, space_id: SPACE_1, claim_entity_id: id, claim, description: null };
 }

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -10,6 +10,7 @@ import { useRouter } from 'next/navigation';
 import { CLAIM_IS_FACTUAL_PROPERTY_ID, CLAIM_TYPE_ID, TOPICS_PROPERTY_ID } from '~/core/claims/ontology';
 import {
   type DebateClaimPositionSummary,
+  type DebateClaimSummary,
   type DebateRematchClaim,
   type DebateRematchParticipant,
   type DebateRematchSession,
@@ -23,16 +24,19 @@ import {
   useAcceptDebateRematchRequest,
   useCreateDebateRematchRequest,
   useDebate,
+  useDebateClaimsBySpaces,
   useDebateRematch,
   useDebateRematchClaims,
   useLeaveDebateRematch,
   useRejectDebateRematchRequest,
 } from '~/core/debates/hooks';
 import { SpaceTopicFilters } from '~/core/debates/matchmaking/claims-tab';
+import { useClaimReadiness } from '~/core/debates/matchmaking/hooks';
 import { HubCardList } from '~/core/debates/matchmaking/hub-motion';
 import { HubPillButton } from '~/core/debates/matchmaking/hub-pill-button';
 import { HubQueryState } from '~/core/debates/matchmaking/hub-states';
 import { MatchmakingClaimCard } from '~/core/debates/matchmaking/matchmaking-claim-card';
+import { useEntityResponse } from '~/core/hooks/use-entity-vote';
 import { uuidToHex } from '~/core/id/normalize';
 import { responsePositionLabel } from '~/core/responses/entity-response';
 import { useQueryEntities } from '~/core/sync/use-store';
@@ -46,9 +50,13 @@ const SEARCH_DEBOUNCE_MS = 250;
 
 type PickerTab = 'opponent' | 'all';
 
-/** "Jenna" -> "Jenna’s", "Chris" -> "Chris’". */
-function possessive(name: string) {
-  return name.endsWith('s') ? `${name}\u2019` : `${name}\u2019s`;
+/**
+ * The tab is tight, so it uses the opponent's first name only: "Jenna Ruiz" -> "Jenna’s".
+ * A name already ending in s takes the bare apostrophe: "Chris" -> "Chris’".
+ */
+function firstNamePossessive(name: string) {
+  const firstName = name.trim().split(/\s+/)[0] || name;
+  return firstName.endsWith('s') ? `${firstName}\u2019` : `${firstName}\u2019s`;
 }
 
 export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
@@ -166,7 +174,7 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
     return map;
   }, [publishedClaims]);
 
-  const [tab, setTab] = React.useState<PickerTab>('all');
+  const [tab, setTab] = React.useState<PickerTab>('opponent');
   const [spaceId, setSpaceId] = React.useState<string | null>(null);
   const [topicId, setTopicId] = React.useState<string | null>(null);
   const [search, setSearch] = React.useState('');
@@ -207,6 +215,19 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   );
 
   const facetSpaceIds = React.useMemo(() => [...new Set(claims.map(claim => claim.claim.space_id))], [claims]);
+
+  // The rematch claims response carries no readiness, so pull it from the per-space debate-claims
+  // endpoint — one query per space the picker is showing — and key it by claim entity id.
+  const claimIdsBySpace = React.useMemo(() => {
+    const bySpace = new Map<string, string[]>();
+    for (const claim of claims) {
+      const existing = bySpace.get(claim.claim.space_id);
+      if (existing) existing.push(claim.claim.claim_entity_id);
+      else bySpace.set(claim.claim.space_id, [claim.claim.claim_entity_id]);
+    }
+    return bySpace;
+  }, [claims]);
+  const readinessByClaimId = useRematchClaimReadiness(claimIdsBySpace);
 
   const facetTopics = React.useMemo(() => {
     const seen = new Map<string, MatchmakingTopic>();
@@ -277,7 +298,7 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
           <h1 className="sr-only">Rematch {remoteName}</h1>
           <div className="flex min-w-0 items-center gap-5">
             <TabButton active={tab === 'opponent'} onClick={() => setTab('opponent')}>
-              <span className="truncate">{possessive(remoteName)} positions</span>
+              <span className="truncate">{firstNamePossessive(remoteName)} positions</span>
               <span
                 className={cx(
                   'inline-flex min-h-6 min-w-6 items-center justify-center rounded-full px-1.5 text-metadataMedium tabular-nums',
@@ -373,6 +394,7 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
                 claim={claim}
                 session={session}
                 currentUserId={currentUserId}
+                readiness={readinessByClaimId.get(claim.claim.claim_entity_id) ?? null}
                 onRequest={() =>
                   createRequest.mutate({
                     source_space_id: claim.claim.space_id,
@@ -426,6 +448,36 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   );
 }
 
+/** What the per-space debate-claims endpoint knows about a claim's readiness. */
+type ClaimReadinessState = { viewer_debate_ready: boolean; readiness_disabled_reason: string | null };
+
+/**
+ * Readiness for every claim on screen, from the per-space debate-claims endpoint — the rematch
+ * claims response doesn't carry it. One query per space, so the picker can render the hub's Debate
+ * toggle against real state rather than drawing it permanently off.
+ */
+function useRematchClaimReadiness(claimIdsBySpace: Map<string, string[]>) {
+  const spaceIds = React.useMemo(() => [...claimIdsBySpace.keys()].sort(), [claimIdsBySpace]);
+
+  const results = useDebateClaimsBySpaces(
+    React.useMemo(
+      () => spaceIds.map(spaceId => ({ spaceId, claimIds: claimIdsBySpace.get(spaceId) ?? [] })),
+      [claimIdsBySpace, spaceIds]
+    )
+  );
+
+  return React.useMemo(() => {
+    const byClaimId = new Map<string, ClaimReadinessState>();
+    for (const claim of results) {
+      byClaimId.set(claim.claim_entity_id, {
+        viewer_debate_ready: claim.viewer_debate_ready,
+        readiness_disabled_reason: claim.readiness_disabled_reason,
+      });
+    }
+    return byClaimId;
+  }, [results]);
+}
+
 /**
  * A rematch claim in the hub's card, so this picker and the debates side panel read as one
  * surface. The rematch API models positions per session participant, so the shared
@@ -435,25 +487,51 @@ function RematchClaimCard({
   claim,
   session,
   currentUserId,
+  readiness: claimReadiness,
   onRequest,
   busy,
 }: {
   claim: DebateRematchClaim;
   session: DebateRematchSession | null;
   currentUserId: string | null;
+  readiness: ClaimReadinessState | null;
   onRequest: () => void;
   busy: boolean;
 }) {
-  const localPosition = claim.participants.find(position => position.user_id === currentUserId)?.position ?? null;
+  const serverLocalPosition = claim.participants.find(position => position.user_id === currentUserId)?.position ?? null;
   const remotePosition = claim.participants.find(position => position.user_id !== currentUserId)?.position ?? null;
+
+  // A claim whose stored kind didn't parse still has to render; 'stance' is the same fallback
+  // `responsePositionLabel` applies, so the labels agree either way.
+  const responseKind = claim.response_kind ?? 'stance';
+  const target = {
+    entityId: claim.claim.claim_entity_id,
+    spaceId: claim.claim.space_id,
+    responseKind,
+  };
+
+  // Read the client's own optimistic copy rather than waiting for geo-chat to catch up. Without
+  // this the side you just picked stays unhighlighted, and "Request debate" only appears once the
+  // rematch claims query refetches — seconds after the click.
+  const { optimisticResponse } = useEntityResponse(target);
+  const localPosition =
+    optimisticResponse === undefined
+      ? serverLocalPosition
+      : optimisticResponse === null
+        ? null
+        : optimisticResponse === 'positive';
+
   const opposing = localPosition !== null && remotePosition !== null && localPosition !== remotePosition;
   const request = session?.request;
   const requesting =
     session?.status === 'request_pending' && request?.claim.claim_entity_id === claim.claim.claim_entity_id;
 
-  // A claim whose stored kind didn't parse still has to render; 'stance' is the same fallback
-  // `responsePositionLabel` applies, so the labels agree either way.
-  const responseKind = claim.response_kind ?? 'stance';
+  useAutoReadinessOptIn({
+    claim: claim.claim,
+    localPosition,
+    alreadyReady: claimReadiness?.viewer_debate_ready ?? false,
+  });
+
   const positions = React.useMemo(
     () => rematchPositionSummaries(claim, session, responseKind),
     [claim, responseKind, session]
@@ -464,10 +542,8 @@ function RematchClaimCard({
       localPosition === null
         ? null
         : { position: localPosition, position_label: responsePositionLabel(responseKind, localPosition) },
-    // Unread: the readiness toggle is hidden below, because a rematch session carries no readiness
-    // state to drive it from.
-    viewer_debate_ready: false,
-    readiness_disabled_reason: null,
+    viewer_debate_ready: claimReadiness?.viewer_debate_ready ?? false,
+    readiness_disabled_reason: claimReadiness?.readiness_disabled_reason ?? null,
   };
 
   return (
@@ -475,7 +551,6 @@ function RematchClaimCard({
       claim={claim.claim}
       positions={positions}
       readiness={readiness}
-      hideReadinessToggle
       footer={
         opposing || requesting ? (
           <div className="mt-3">
@@ -498,6 +573,37 @@ function RematchClaimCard({
       }
     />
   );
+}
+
+/**
+ * Taking a side in this flow means you want to debate it, so standing ready is implied — the
+ * viewer shouldn't have to flip the toggle as a second step. Only fires on a side picked while the
+ * picker is open: opting in for positions that were already held would silently undo a deliberate
+ * stand-down from elsewhere.
+ */
+function useAutoReadinessOptIn({
+  claim,
+  localPosition,
+  alreadyReady,
+}: {
+  claim: DebateClaimSummary;
+  localPosition: boolean | null;
+  alreadyReady: boolean;
+}) {
+  const setReadiness = useClaimReadiness();
+  const previousPosition = React.useRef<boolean | null>(localPosition);
+  const optedInFor = React.useRef<boolean | null>(null);
+
+  React.useEffect(() => {
+    const previous = previousPosition.current;
+    previousPosition.current = localPosition;
+
+    if (localPosition === null || previous === localPosition) return;
+    if (alreadyReady || optedInFor.current === localPosition) return;
+
+    optedInFor.current = localPosition;
+    setReadiness.mutate({ spaceId: claim.space_id, claimId: claim.claim_entity_id, ready: true });
+  }, [alreadyReady, claim.claim_entity_id, claim.space_id, localPosition, setReadiness]);
 }
 
 /** Both sides of a rematch claim in the shape the shared card renders avatars from. */

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -9,9 +9,12 @@ import { useRouter } from 'next/navigation';
 
 import { CLAIM_IS_FACTUAL_PROPERTY_ID, CLAIM_TYPE_ID, TOPICS_PROPERTY_ID } from '~/core/claims/ontology';
 import {
+  type DebateClaimPositionSummary,
   type DebateRematchClaim,
   type DebateRematchParticipant,
   type DebateRematchSession,
+  type MatchmakingReadiness,
+  type MatchmakingTopic,
   getCurrentGeoChatUserId,
 } from '~/core/debates/api';
 import { DebateRequestDialog } from '~/core/debates/debate-request-dialog';
@@ -25,16 +28,28 @@ import {
   useLeaveDebateRematch,
   useRejectDebateRematchRequest,
 } from '~/core/debates/hooks';
-import { useEntityResponse } from '~/core/hooks/use-entity-vote';
+import { SpaceTopicFilters } from '~/core/debates/matchmaking/claims-tab';
+import { HubCardList } from '~/core/debates/matchmaking/hub-motion';
+import { HubPillButton } from '~/core/debates/matchmaking/hub-pill-button';
+import { HubQueryState } from '~/core/debates/matchmaking/hub-states';
+import { MatchmakingClaimCard } from '~/core/debates/matchmaking/matchmaking-claim-card';
 import { uuidToHex } from '~/core/id/normalize';
 import { responsePositionLabel } from '~/core/responses/entity-response';
 import { useQueryEntities } from '~/core/sync/use-store';
 
-import { Avatar } from '~/design-system/avatar';
 import { Button } from '~/design-system/button';
 import { getChecked } from '~/design-system/checkbox';
-import { ChevronDownSmall } from '~/design-system/icons/chevron-down-small';
+import { Input } from '~/design-system/input';
 import { Text } from '~/design-system/text';
+
+const SEARCH_DEBOUNCE_MS = 250;
+
+type PickerTab = 'opponent' | 'all';
+
+/** "Jenna" -> "Jenna’s", "Chris" -> "Chris’". */
+function possessive(name: string) {
+  return name.endsWith('s') ? `${name}\u2019` : `${name}\u2019s`;
+}
 
 export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   const router = useRouter();
@@ -141,18 +156,26 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   // Topics live on the KG claim entity (not the rematch API), so resolve them here to
   // label each card and drive the "Any topic" filter. A claim can carry several topics.
   const topicsByClaimId = React.useMemo(() => {
-    const map = new Map<string, string[]>();
+    const map = new Map<string, MatchmakingTopic[]>();
     for (const entity of publishedClaims) {
       const topics = entity.relations
         .filter(relation => relation.type.id === TOPICS_PROPERTY_ID && relation.isDeleted !== true)
-        .map(relation => relation.toEntity.name ?? relation.toEntity.id);
+        .map(relation => ({ id: relation.toEntity.id, name: relation.toEntity.name ?? null }));
       if (topics.length > 0) map.set(entity.id, topics);
     }
     return map;
   }, [publishedClaims]);
 
-  const [tab, setTab] = React.useState<'all' | 'debate-now'>('all');
-  const [topicFilter, setTopicFilter] = React.useState<string>('');
+  const [tab, setTab] = React.useState<PickerTab>('all');
+  const [spaceId, setSpaceId] = React.useState<string | null>(null);
+  const [topicId, setTopicId] = React.useState<string | null>(null);
+  const [search, setSearch] = React.useState('');
+  const [debouncedSearch, setDebouncedSearch] = React.useState('');
+
+  React.useEffect(() => {
+    const timeout = setTimeout(() => setDebouncedSearch(search.trim().toLowerCase()), SEARCH_DEBOUNCE_MS);
+    return () => clearTimeout(timeout);
+  }, [search]);
 
   const returnFromSession = React.useCallback(
     (endedSession: DebateRematchSession) => {
@@ -177,30 +200,41 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
     [currentUserId, router]
   );
 
-  // "Debate now" = claims the opponent has responded to; the tab badge counts them.
+  // The opponent tab shows claims they have already taken a side on; the badge counts them.
   const opponentPositionCount = React.useMemo(
     () => claims.filter(claim => opponentPositionOf(claim) !== null).length,
     [claims, opponentPositionOf]
   );
 
-  const availableTopics = React.useMemo(() => {
-    const topics = new Set<string>();
+  const facetSpaceIds = React.useMemo(() => [...new Set(claims.map(claim => claim.claim.space_id))], [claims]);
+
+  const facetTopics = React.useMemo(() => {
+    const seen = new Map<string, MatchmakingTopic>();
     for (const claim of claims) {
-      for (const topic of topicsByClaimId.get(claim.claim.claim_entity_id) ?? []) topics.add(topic);
+      for (const topic of topicsByClaimId.get(claim.claim.claim_entity_id) ?? []) {
+        if (!seen.has(topic.id)) seen.set(topic.id, topic);
+      }
     }
-    return [...topics].sort((a, b) => a.localeCompare(b));
+    return [...seen.values()].sort((a, b) => (a.name ?? '').localeCompare(b.name ?? ''));
   }, [claims, topicsByClaimId]);
 
+  // Everything narrows client-side: the rematch claim list is session-scoped (it already excludes
+  // the source debate's claim and anything rejected), so there's no server query to push this into
+  // the way the hub's Claims tab can.
   const visibleClaims = React.useMemo(
     () =>
       claims.filter(claim => {
-        if (tab === 'debate-now' && opponentPositionOf(claim) === null) return false;
-        if (topicFilter && !(topicsByClaimId.get(claim.claim.claim_entity_id) ?? []).includes(topicFilter))
+        if (tab === 'opponent' && opponentPositionOf(claim) === null) return false;
+        if (spaceId && claim.claim.space_id !== spaceId) return false;
+        if (topicId && !(topicsByClaimId.get(claim.claim.claim_entity_id) ?? []).some(t => t.id === topicId))
           return false;
+        if (debouncedSearch && !claim.claim.claim.toLowerCase().includes(debouncedSearch)) return false;
         return true;
       }),
-    [claims, opponentPositionOf, tab, topicFilter, topicsByClaimId]
+    [claims, debouncedSearch, opponentPositionOf, spaceId, tab, topicId, topicsByClaimId]
   );
+
+  const hasFilters = Boolean(debouncedSearch || spaceId || topicId);
 
   React.useEffect(() => {
     if (!session) return;
@@ -242,19 +276,19 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
         <header className="mb-4 flex items-center justify-between gap-4">
           <h1 className="sr-only">Rematch {remoteName}</h1>
           <div className="flex min-w-0 items-center gap-5">
-            <TabButton active={tab === 'all'} onClick={() => setTab('all')}>
-              All
-            </TabButton>
-            <TabButton active={tab === 'debate-now'} onClick={() => setTab('debate-now')}>
-              <span>Debate now</span>
+            <TabButton active={tab === 'opponent'} onClick={() => setTab('opponent')}>
+              <span className="truncate">{possessive(remoteName)} positions</span>
               <span
                 className={cx(
                   'inline-flex min-h-6 min-w-6 items-center justify-center rounded-full px-1.5 text-metadataMedium tabular-nums',
-                  tab === 'debate-now' ? 'bg-text text-white' : 'bg-grey-01 text-grey-04'
+                  tab === 'opponent' ? 'bg-text text-white' : 'bg-grey-01 text-grey-04'
                 )}
               >
                 {opponentPositionCount}
               </span>
+            </TabButton>
+            <TabButton active={tab === 'all'} onClick={() => setTab('all')}>
+              All
             </TabButton>
           </div>
           <button
@@ -269,25 +303,25 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
           </button>
         </header>
 
-        <div className="mb-5">
-          <TopicFilter value={topicFilter} topics={availableTopics} onChange={setTopicFilter} />
+        <div className="mb-3 flex flex-col gap-3">
+          <SpaceTopicFilters
+            spaceId={spaceId}
+            onSpaceChange={setSpaceId}
+            topicId={topicId}
+            onTopicChange={setTopicId}
+            facetSpaceIds={facetSpaceIds}
+            facetTopics={facetTopics}
+            className="justify-between"
+          />
+          <Input
+            withSearchIcon
+            value={search}
+            onChange={event => setSearch(event.currentTarget.value)}
+            placeholder="Search claims"
+            aria-label="Search claims"
+          />
         </div>
 
-        {(sessionQuery.isLoading ||
-          savedClaimsQuery.isLoading ||
-          publishedClaimsQuery.isLoading ||
-          publishedClaimsLoading) && <Text color="grey-04">Loading claims...</Text>}
-        {(sessionQuery.error instanceof Error ||
-          savedClaimsQuery.error instanceof Error ||
-          publishedClaimsQuery.error instanceof Error) && (
-          <Text color="red-01">
-            {sessionQuery.error instanceof Error
-              ? sessionQuery.error.message
-              : savedClaimsQuery.error instanceof Error
-                ? savedClaimsQuery.error.message
-                : publishedClaimsQuery.error?.message}
-          </Text>
-        )}
         {(createRequest.error instanceof Error || leaveSession.error instanceof Error) && (
           <Text color="red-01" className="mb-4">
             {createRequest.error instanceof Error
@@ -303,37 +337,57 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
           </Text>
         )}
 
-        <div className="grid gap-4">
-          {visibleClaims.map(claim => (
-            <RematchClaimCard
-              key={claim.claim.claim_entity_id}
-              claim={claim}
-              topic={topicsByClaimId.get(claim.claim.claim_entity_id)?.[0] ?? null}
-              session={session}
-              currentUserId={currentUserId}
-              onRequest={() =>
-                createRequest.mutate({
-                  source_space_id: claim.claim.space_id,
-                  claim_id: claim.claim.claim_entity_id,
-                  format_id: defaultDebateFormatId,
-                })
-              }
-              busy={createRequest.isPending || session?.status === 'request_pending'}
-            />
-          ))}
-        </div>
+        <HubQueryState
+          isLoading={
+            sessionQuery.isLoading ||
+            savedClaimsQuery.isLoading ||
+            publishedClaimsQuery.isLoading ||
+            publishedClaimsLoading
+          }
+          error={sessionQuery.error ?? savedClaimsQuery.error ?? publishedClaimsQuery.error}
+          isEmpty={visibleClaims.length === 0}
+          emptyMessage={
+            hasFilters
+              ? 'No claims match these filters.'
+              : tab === 'opponent'
+                ? `${remoteName} hasn’t responded yet. When they do, those claims show up here.`
+                : 'No other eligible claims are available yet.'
+          }
+          emptyAction={
+            hasFilters
+              ? {
+                  label: 'Clear filters',
+                  onClick: () => {
+                    setSearch('');
+                    setSpaceId(null);
+                    setTopicId(null);
+                  },
+                }
+              : undefined
+          }
+        >
+          <HubCardList>
+            {visibleClaims.map(claim => (
+              <RematchClaimCard
+                key={claim.claim.claim_entity_id}
+                claim={claim}
+                session={session}
+                currentUserId={currentUserId}
+                onRequest={() =>
+                  createRequest.mutate({
+                    source_space_id: claim.claim.space_id,
+                    claim_id: claim.claim.claim_entity_id,
+                    format_id: defaultDebateFormatId,
+                  })
+                }
+                busy={createRequest.isPending || session?.status === 'request_pending'}
+              />
+            ))}
+          </HubCardList>
+        </HubQueryState>
 
-        {!savedClaimsQuery.isLoading && !publishedClaimsQuery.isLoading && visibleClaims.length === 0 && (
-          <div className="rounded-lg border border-grey-02 bg-white p-6 text-center">
-            <Text color="grey-04">
-              {tab === 'debate-now'
-                ? `${remoteName} hasn't responded yet. When they do, those claims show up here.`
-                : topicFilter
-                  ? 'No claims match this topic.'
-                  : 'No other eligible claims are available yet.'}
-            </Text>
-          </div>
-        )}
+        {/* Outside the empty state on purpose: when a filter empties the list, fetching the next
+            page is exactly the way out, so the control has to stay reachable. */}
         {publishedClaimsHasNextPage && (
           <div className="mt-5 flex justify-center">
             <Button
@@ -372,98 +426,103 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   );
 }
 
+/**
+ * A rematch claim in the hub's card, so this picker and the debates side panel read as one
+ * surface. The rematch API models positions per session participant, so the shared
+ * `DebateClaimPositionSummary` shape is built here.
+ */
 function RematchClaimCard({
   claim,
-  topic,
   session,
   currentUserId,
   onRequest,
   busy,
 }: {
   claim: DebateRematchClaim;
-  topic: string | null;
   session: DebateRematchSession | null;
   currentUserId: string | null;
   onRequest: () => void;
   busy: boolean;
 }) {
-  const localResponse = claim.participants.find(position => position.user_id === currentUserId) ?? null;
-  const remoteResponse = claim.participants.find(position => position.user_id !== currentUserId) ?? null;
-  const localPosition = localResponse?.position ?? null;
-  const remotePosition = remoteResponse?.position ?? null;
+  const localPosition = claim.participants.find(position => position.user_id === currentUserId)?.position ?? null;
+  const remotePosition = claim.participants.find(position => position.user_id !== currentUserId)?.position ?? null;
   const opposing = localPosition !== null && remotePosition !== null && localPosition !== remotePosition;
-  const { submitResponse, optimisticResponse, isConnected } = useEntityResponse({
-    entityId: claim.claim.claim_entity_id,
-    spaceId: claim.claim.space_id,
-    responseKind: claim.response_kind,
-  });
-  let displayedLocalPosition = localPosition;
-  if (optimisticResponse !== undefined) {
-    displayedLocalPosition = optimisticResponse === null ? null : optimisticResponse === 'positive';
-  }
   const request = session?.request;
   const requesting =
     session?.status === 'request_pending' && request?.claim.claim_entity_id === claim.claim.claim_entity_id;
 
-  return (
-    <article className="rounded-lg border border-grey-02 bg-white p-5">
-      <div className="flex items-start justify-between gap-3">
-        <Text as="div" variant="footnote" color="grey-04">
-          {topic ?? (claim.shared_preference ? 'You both responded' : 'More claims')}
-        </Text>
-        {claim.recently_rejected && (
-          <Text as="div" variant="footnote" color="grey-04">
-            Recently rejected
-          </Text>
-        )}
-      </div>
-      <Text as="h2" variant="smallTitle" className="mt-3">
-        {claim.claim.claim}
-      </Text>
-
-      <div className="mt-5 grid grid-cols-2 gap-2">
-        {[true, false].map(position => {
-          const positionLabel = responsePositionLabel(claim.response_kind, position);
-          const holderIds = new Set(
-            claim.participants
-              .filter(participant => participant.user_id !== currentUserId && participant.position === position)
-              .map(participant => participant.user_id)
-          );
-          if (currentUserId && displayedLocalPosition === position) holderIds.add(currentUserId);
-          const holders = session?.participants.filter(participant => holderIds.has(participant.user_id)) ?? [];
-          const selected = displayedLocalPosition === position;
-          return (
-            <button
-              type="button"
-              key={String(position)}
-              aria-pressed={selected}
-              disabled={!claim.response_kind || !isConnected}
-              onClick={() => submitResponse(selected ? 'clear' : position ? 'positive' : 'negative')}
-              className={cx(
-                'flex min-h-9 items-center justify-between gap-2 rounded-full px-3 text-button transition-colors',
-                selected ? 'bg-text text-white' : 'bg-bg text-text hover:bg-grey-01',
-                (!claim.response_kind || !isConnected) && 'cursor-default opacity-50'
-              )}
-            >
-              <span>{positionLabel}</span>
-              {holders.length > 0 && <PositionAvatars participants={holders} />}
-            </button>
-          );
-        })}
-      </div>
-
-      {(opposing || requesting) && (
-        <button
-          type="button"
-          onClick={onRequest}
-          disabled={!opposing || busy || requesting || claim.recently_rejected}
-          className="mt-2 flex min-h-10 w-full items-center justify-center rounded-full bg-text px-4 text-button text-white transition-colors hover:bg-text/90 disabled:bg-grey-01 disabled:text-grey-04"
-        >
-          {requesting ? 'Requesting...' : 'Request debate'}
-        </button>
-      )}
-    </article>
+  // A claim whose stored kind didn't parse still has to render; 'stance' is the same fallback
+  // `responsePositionLabel` applies, so the labels agree either way.
+  const responseKind = claim.response_kind ?? 'stance';
+  const positions = React.useMemo(
+    () => rematchPositionSummaries(claim, session, responseKind),
+    [claim, responseKind, session]
   );
+  const readiness: MatchmakingReadiness = {
+    response_kind: responseKind,
+    viewer_response:
+      localPosition === null
+        ? null
+        : { position: localPosition, position_label: responsePositionLabel(responseKind, localPosition) },
+    // Unread: the readiness toggle is hidden below, because a rematch session carries no readiness
+    // state to drive it from.
+    viewer_debate_ready: false,
+    readiness_disabled_reason: null,
+  };
+
+  return (
+    <MatchmakingClaimCard
+      claim={claim.claim}
+      positions={positions}
+      readiness={readiness}
+      hideReadinessToggle
+      footer={
+        opposing || requesting ? (
+          <div className="mt-3">
+            <HubPillButton
+              onClick={onRequest}
+              disabled={!opposing || busy || requesting || claim.recently_rejected}
+              pending={requesting}
+              pendingLabel="Requesting…"
+              className="w-full"
+            >
+              Request debate
+            </HubPillButton>
+            {claim.recently_rejected ? (
+              <Text as="p" variant="footnote" color="grey-04" className="mt-1">
+                Recently rejected
+              </Text>
+            ) : null}
+          </div>
+        ) : null
+      }
+    />
+  );
+}
+
+/** Both sides of a rematch claim in the shape the shared card renders avatars from. */
+function rematchPositionSummaries(
+  claim: DebateRematchClaim,
+  session: DebateRematchSession | null,
+  responseKind: 'stance' | 'veracity'
+): DebateClaimPositionSummary[] {
+  return [true, false].map(position => {
+    const holders = claim.participants.filter(participant => participant.position === position);
+    const participants = holders
+      .map(holder => session?.participants.find(participant => participant.user_id === holder.user_id))
+      .filter((participant): participant is DebateRematchParticipant => participant !== undefined);
+
+    return {
+      position,
+      // Server labels win where a holder carries one, so an authoritative Verify/Dispute survives.
+      position_label:
+        holders.find(holder => holder.position_label)?.position_label ?? responsePositionLabel(responseKind, position),
+      total_count: holders.length,
+      // Only meaningful for the hub's "available now" counts; a rematch is already a fixed pair.
+      available_now_count: 0,
+      participants,
+    };
+  });
 }
 
 function claimResponseKind(
@@ -497,21 +556,6 @@ function rematchCancellationMessage(reason: string) {
   }
 }
 
-function PositionAvatars({ participants }: { participants: DebateRematchParticipant[] }) {
-  return (
-    <span className="flex -space-x-1.5">
-      {participants.map(participant => (
-        <span
-          key={participant.user_id}
-          className="relative box-content block size-5 overflow-hidden rounded-full border-2 border-white"
-        >
-          <Avatar avatarUrl={participant.avatar_cid} value={participant.profile_space_id} size={20} />
-        </span>
-      ))}
-    </span>
-  );
-}
-
 function TabButton({ active, onClick, children }: { active: boolean; onClick: () => void; children: React.ReactNode }) {
   return (
     <button
@@ -525,37 +569,6 @@ function TabButton({ active, onClick, children }: { active: boolean; onClick: ()
     >
       {children}
     </button>
-  );
-}
-
-function TopicFilter({
-  value,
-  topics,
-  onChange,
-}: {
-  value: string;
-  topics: string[];
-  onChange: (topic: string) => void;
-}) {
-  return (
-    <div className="relative inline-flex">
-      <select
-        aria-label="Filter by topic"
-        value={value}
-        onChange={event => onChange(event.target.value)}
-        className="min-h-9 appearance-none rounded-full border border-grey-02 bg-white py-2 pr-9 pl-4 text-button text-text outline-hidden hover:border-grey-04 focus:border-text"
-      >
-        <option value="">Any topic</option>
-        {topics.map(topic => (
-          <option key={topic} value={topic}>
-            {topic}
-          </option>
-        ))}
-      </select>
-      <span className="pointer-events-none absolute top-1/2 right-3 -translate-y-1/2">
-        <ChevronDownSmall color="grey-04" />
-      </span>
-    </div>
   );
 }
 

--- a/apps/web/core/debates/debate-gateway.ts
+++ b/apps/web/core/debates/debate-gateway.ts
@@ -466,6 +466,15 @@ export class DebateGatewayClient {
               queryClaimIds.some(claimId => typeof claimId === 'string' && changedClaims.has(claimId))));
         if (isDebateClaimQuery) return true;
 
+        // A rematch picker lists claims from many spaces and renders both participants' sides, so
+        // it has to refresh when *anyone's* response lands — not just the viewer's, which is all
+        // the picker's own indexed-response subscription covers. Without this the opponent's
+        // choices only appeared after leaving and rejoining the session.
+        const [, accountSegment, , rematchSegment, , claimsSegment] = query.queryKey;
+        if (accountSegment === 'account' && rematchSegment === 'rematch' && claimsSegment === 'claims') {
+          return true;
+        }
+
         return isClaimResponseSummaryQueryKey(query.queryKey, {
           spaceId,
           targetKeys: changedResponseTargets,

--- a/apps/web/core/debates/hooks.ts
+++ b/apps/web/core/debates/hooks.ts
@@ -10,6 +10,7 @@ import { getCachedIdentityToken, useIdentityTokenSync } from '~/core/auth/identi
 import {
   type Debate,
   type DebateActivity,
+  type DebateClaimsResponse,
   type DebateMediaArtifactUrlRequest,
   type DebateMediaProcessRequest,
   type DebateMediaResponse,
@@ -121,6 +122,39 @@ export function useDebateClaims(spaceId: string, claimIds: string[] | null, enab
         signal
       ),
     enabled: shouldFetch,
+  });
+}
+
+/**
+ * The same per-space claim payload as {@link useDebateClaims}, for callers holding claims spread
+ * across several spaces — the rematch picker mixes geo-chat's session claims with published ones
+ * from anywhere. A hook per space is impossible when the list changes length, so this fans out.
+ */
+export function useDebateClaimsBySpaces(groups: Array<{ spaceId: string; claimIds: string[] }>) {
+  const { accountKey, authenticated, getPrivyIdentityToken } = useGeoChatAuth();
+
+  // Stable by contract: react-query re-runs `combine` whenever its identity changes, and diffs the
+  // result with `replaceEqualDeep`, so a fresh closure each render would defeat callers' memos.
+  const combine = React.useCallback(
+    (results: UseQueryResult<DebateClaimsResponse>[]) => results.flatMap(result => result.data?.claims ?? []),
+    []
+  );
+
+  return useQueries({
+    queries: groups.map(group => ({
+      ...debateQueryNetworkOptions,
+      queryKey: debateQueryKeys.claims(group.spaceId, group.claimIds),
+      queryFn: ({ signal }: { signal?: AbortSignal }) =>
+        listDebateClaims(
+          group.spaceId,
+          group.claimIds,
+          authenticated ? getPrivyIdentityToken : undefined,
+          authenticated ? accountKey : null,
+          signal
+        ),
+      enabled: authenticated && group.claimIds.length > 0,
+    })),
+    combine,
   });
 }
 

--- a/apps/web/core/debates/matchmaking/claims-tab.tsx
+++ b/apps/web/core/debates/matchmaking/claims-tab.tsx
@@ -4,6 +4,8 @@ import { keepPreviousData } from '@tanstack/react-query';
 
 import * as React from 'react';
 
+import cx from 'classnames';
+
 import { TOPICS_PROPERTY_ID } from '~/core/claims/ontology';
 import { useSpacesByIds } from '~/core/hooks/use-spaces-by-ids';
 import { useQueryEntities } from '~/core/sync/use-store';
@@ -222,6 +224,8 @@ type SpaceTopicFiltersProps = {
   facetTopics?: { id: string; name: string | null }[];
   /** Rendered before the space filter — the Claims tab puts its position filter here. */
   leading?: React.ReactNode;
+  /** Overrides the row layout — the rematch picker spreads the two menus to its full width. */
+  className?: string;
 };
 
 /**
@@ -236,6 +240,7 @@ export function SpaceTopicFilters({
   facetSpaceIds,
   facetTopics,
   leading,
+  className,
 }: SpaceTopicFiltersProps) {
   const { spacesById } = useSpacesByIds(facetSpaceIds);
 
@@ -263,7 +268,7 @@ export function SpaceTopicFilters({
   const topicLabel = topicId ? (facetTopics?.find(topic => topic.id === topicId)?.name ?? 'Topic') : 'Any topic';
 
   return (
-    <div className="flex flex-wrap items-center gap-2">
+    <div className={cx('flex flex-wrap items-center gap-2', className)}>
       {leading}
       <HubFilterMenu
         label={spaceLabel}

--- a/apps/web/core/debates/matchmaking/matchmaking-claim-card.tsx
+++ b/apps/web/core/debates/matchmaking/matchmaking-claim-card.tsx
@@ -34,6 +34,12 @@ type Props = {
   activeDebate?: boolean;
   /** Rendered under the controls — e.g. the Matches tab's "Request debate" button. */
   footer?: React.ReactNode;
+  /**
+   * Hides the readiness toggle. For hosts with no readiness data to render it from: the toggle
+   * reads `viewer_debate_ready`, so a host that can't supply it would draw the switch permanently
+   * off and misreport a claim the viewer is in fact standing ready on.
+   */
+  hideReadinessToggle?: boolean;
   /** `AnimatePresence mode="popLayout"` measures the exiting row through this; without it the row
    * never pops out of flow and the rows above close the gap only after the fade finishes. */
   ref?: React.Ref<HTMLElement>;
@@ -53,7 +59,15 @@ export function isResolvableClaim(claim: Pick<DebateClaimSummary, 'space_id' | '
  * there are deliberately no separate vote arrows here. Readiness, the geo-chat half, rides
  * alongside them.
  */
-export function MatchmakingClaimCard({ claim, positions, readiness, activeDebate, footer, ref }: Props) {
+export function MatchmakingClaimCard({
+  claim,
+  positions,
+  readiness,
+  activeDebate,
+  footer,
+  hideReadinessToggle,
+  ref,
+}: Props) {
   // geo-chat can hand back a claim the graph has never seen. Responding to one is impossible, and
   // asking the graph about it fails the request, so don't offer or ask.
   const isOnGraph = isResolvableClaim(claim);
@@ -79,9 +93,21 @@ export function MatchmakingClaimCard({ claim, positions, readiness, activeDebate
       )}
 
       {isOnGraph ? (
-        <RespondableControls claim={claim} positions={positions} readiness={readiness} activeDebate={activeDebate} />
+        <RespondableControls
+          claim={claim}
+          positions={positions}
+          readiness={readiness}
+          activeDebate={activeDebate}
+          hideReadinessToggle={hideReadinessToggle}
+        />
       ) : (
-        <UnresolvableControls positions={positions} readiness={readiness} claim={claim} activeDebate={activeDebate} />
+        <UnresolvableControls
+          positions={positions}
+          readiness={readiness}
+          claim={claim}
+          activeDebate={activeDebate}
+          hideReadinessToggle={hideReadinessToggle}
+        />
       )}
 
       {footer}
@@ -95,11 +121,13 @@ function RespondableControls({
   positions,
   readiness,
   activeDebate,
+  hideReadinessToggle,
 }: {
   claim: DebateClaimSummary;
   positions: DebateClaimPositionSummary[];
   readiness: MatchmakingReadiness;
   activeDebate?: boolean;
+  hideReadinessToggle?: boolean;
 }) {
   const target = {
     entityId: claim.claim_entity_id,
@@ -173,15 +201,17 @@ function RespondableControls({
           </Text>
         </div>
       ) : null}
-      <div className="mt-3 flex justify-end">
-        <ClaimReadinessToggle
-          claim={claim}
-          readiness={readiness}
-          activeDebate={activeDebate}
-          hasResponse={viewerPosition !== null}
-          responseIndexing={isPublishing}
-        />
-      </div>
+      {hideReadinessToggle ? null : (
+        <div className="mt-3 flex justify-end">
+          <ClaimReadinessToggle
+            claim={claim}
+            readiness={readiness}
+            activeDebate={activeDebate}
+            hasResponse={viewerPosition !== null}
+            responseIndexing={isPublishing}
+          />
+        </div>
+      )}
     </>
   );
 }
@@ -192,11 +222,13 @@ function UnresolvableControls({
   positions,
   readiness,
   activeDebate,
+  hideReadinessToggle,
 }: {
   claim: DebateClaimSummary;
   positions: DebateClaimPositionSummary[];
   readiness: MatchmakingReadiness;
   activeDebate?: boolean;
+  hideReadinessToggle?: boolean;
 }) {
   return (
     <>
@@ -210,12 +242,14 @@ function UnresolvableControls({
           Claim unavailable
         </Text>
         {/* Readiness is geo-chat state, so it still works without a graph id. */}
-        <ClaimReadinessToggle
-          claim={claim}
-          readiness={readiness}
-          activeDebate={activeDebate}
-          hasResponse={readiness.viewer_response !== null}
-        />
+        {hideReadinessToggle ? null : (
+          <ClaimReadinessToggle
+            claim={claim}
+            readiness={readiness}
+            activeDebate={activeDebate}
+            hasResponse={readiness.viewer_response !== null}
+          />
+        )}
       </div>
     </>
   );


### PR DESCRIPTION
Rebuilds the claim picker behind "debate again" and "debate this person" on the debates side panel's own components, per the [Figma design](https://www.figma.com/design/iWKsYButqqKWd1bqeBrUUj/Geo---Web?node-id=75123-430445&m=dev).

The two flows already share one surface — a profile challenge opens a rematch session with no source debate, and `DebateRematchPageClient` renders both — so this is one component, not two.

### What changed

| | before | after |
|---|---|---|
| Tabs | `All` · `Debate now` (count) | `<opponent>’s positions` (count) · `All` |
| Filters | topic only, a bare `<select>` | space + topic, the hub's `HubFilterMenu` |
| Search | none | debounced, the hub's search input |
| Rows | a local card | `MatchmakingClaimCard` |
| Empty / loading / error | three ad-hoc blocks | `HubQueryState` |

Both tabs narrow by space, topic and search, and both keep the Request debate action wherever the two sides oppose — so requesting works from either, as on the Matches tab.

### Notes for review

- **Filtering is client-side.** The rematch claim list is session-scoped: it already excludes the source debate's claim and anything recently rejected, and it merges geo-chat's list with published claims from the graph. There's no server query to push search/space/topic into the way the hub's Claims tab has.
- **Load more sits outside the empty state.** When a filter empties the list, fetching another page is exactly the way out, so the control has to stay reachable.
- **The default tab is still `All`**, as today. The design lists the opponent's positions first and this now matches, but I didn't change which one opens — landing on a tab that's empty until the opponent responds seemed worse than leaving it. Easy to flip if you'd rather.

### One deliberate gap from the design

The design draws the **Debate toggle** on each card. A rematch session carries no readiness state — `viewer_debate_ready` comes from the matchmaking claims endpoint, and the rematch claims endpoint doesn't return it. Rendering the toggle anyway would draw it permanently off and misreport a claim the viewer is in fact standing ready on, so `MatchmakingClaimCard` gained `hideReadinessToggle` and the picker sets it. Closing this properly needs the field on the rematch claims response.

Worth a sanity check on intent too: readiness means "open to debating this with anyone", which is a different question from "let's debate *this*, now" — the toggle may not belong in this flow even once the data exists.

### Also worth flagging

The hub card renders the claim as a link to its entity page rather than as a heading, so the picker loses the `<h2>` it used to have. That's what matching the hub costs; say the word if you'd rather keep heading semantics here.

### Verification

- 20 tests in `rematch-page-client.test.tsx`, extended to cover the renamed tab and its count, the space filter, the topic filter, search, and search surviving a tab switch.
- Test fixtures moved from readable slugs to well-formed ids: `isResolvableClaim` gates the hub card's response buttons on ids the graph would accept, so the old `'claim-shared'` fixtures would have rendered the read-only variant and quietly stopped testing responses.
- All debates suites: 507 tests pass. Two files fail to load (`media-session`, `debate-room-page-client`) — both fail identically on master with these changes stashed.
- Typecheck and prettier clean on the touched files.

**Heads up on running these locally:** the suite needs the pinned Node 23 from `.tool-versions`. Under Node 25 or Bun, `atomWithStorage` blows up at import time on a partial `localStorage` global and every suite that reaches `matchmaking-claim-card` fails to load — which is unrelated to this change, but now catches this file too since it imports that card.

### Not verified

Not exercised in the running app — reaching this screen needs a live rematch session or an accepted profile challenge.