### PR TITLE
feat(debates): rebuild the rematch claim picker to match the design

### DIFF
--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
@@ -517,6 +517,54 @@ describe('DebateRematchPageClient', () => {
     expect(mocks.openSidePanel).toHaveBeenCalledWith(CLAIM_SHARED, SPACE_1, false);
   });
 
+  // Taking a side here means you want to debate it, so readiness shouldn't be a second step.
+  it('turns the Debate toggle on when a position is first established here', () => {
+    mocks.claims = [
+      {
+        ...sharedClaim(),
+        participants: [
+          { user_id: 'user-local', position: null, position_label: null },
+          { user_id: 'user-remote', position: false, position_label: 'Disagree' },
+        ],
+      },
+    ];
+    const { rerender } = render(<DebateRematchPageClient sessionId="rematch-1" />);
+    expect(mocks.setReadiness).not.toHaveBeenCalled();
+
+    mocks.optimisticResponses.set(CLAIM_SHARED, 'positive');
+    rerender(<DebateRematchPageClient sessionId="rematch-1" />);
+
+    expect(mocks.setReadiness).toHaveBeenCalledWith({ spaceId: SPACE_1, claimId: CLAIM_SHARED, ready: true });
+  });
+
+  // Standing down elsewhere is deliberate; arriving here mustn't quietly reverse it.
+  it('leaves readiness alone for positions already held on arrival', () => {
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+
+    expect(mocks.setReadiness).not.toHaveBeenCalled();
+  });
+
+  it('does not re-publish readiness that is already on', () => {
+    mocks.claims = [
+      {
+        ...sharedClaim(),
+        participants: [
+          { user_id: 'user-local', position: null, position_label: null },
+          { user_id: 'user-remote', position: false, position_label: 'Disagree' },
+        ],
+      },
+    ];
+    mocks.claimReadiness = [
+      { claim_entity_id: CLAIM_SHARED, viewer_debate_ready: true, readiness_disabled_reason: null },
+    ];
+    const { rerender } = render(<DebateRematchPageClient sessionId="rematch-1" />);
+
+    mocks.optimisticResponses.set(CLAIM_SHARED, 'positive');
+    rerender(<DebateRematchPageClient sessionId="rematch-1" />);
+
+    expect(mocks.setReadiness).not.toHaveBeenCalled();
+  });
+
   // The All tab browses every published claim a page at a time, so filtering the loaded pages
   // only ever searched what had been paged in. The hub's Claims tab searches server-side.
   it('searches the whole claim corpus rather than the loaded pages', async () => {

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
@@ -31,6 +31,7 @@ const mocks = vi.hoisted(() => ({
   optimisticResponses: new Map<string, 'positive' | 'negative' | null>(),
   setReadiness: vi.fn(),
   openSidePanel: vi.fn(),
+  entityQueries: [] as unknown[],
   claimReadiness: [] as Array<{
     claim_entity_id: string;
     viewer_debate_ready: boolean;
@@ -63,24 +64,27 @@ vi.mock('~/core/debates/hooks', () => ({
 }));
 
 vi.mock('~/core/sync/use-store', () => ({
-  useQueryEntities: () => ({
-    entities: [
-      {
-        id: CLAIM_MORE,
-        name: 'A newly published claim',
-        description: null,
-        spaces: [SPACE_2],
-        relations: [
-          { type: { id: TOPICS_PROPERTY_ID }, toEntity: { id: 'topic-gov', name: 'Governance' }, isDeleted: false },
-          { type: { id: TOPICS_PROPERTY_ID }, toEntity: { id: 'topic-eth', name: 'Ethics' }, isDeleted: false },
-        ],
-      },
-    ],
-    isLoading: false,
-    isPlaceholderData: false,
-    endCursor: null,
-    hasNextPage: false,
-  }),
+  useQueryEntities: (options: { where?: unknown }) => {
+    mocks.entityQueries.push(options.where);
+    return {
+      entities: [
+        {
+          id: CLAIM_MORE,
+          name: 'A newly published claim',
+          description: null,
+          spaces: [SPACE_2],
+          relations: [
+            { type: { id: TOPICS_PROPERTY_ID }, toEntity: { id: 'topic-gov', name: 'Governance' }, isDeleted: false },
+            { type: { id: TOPICS_PROPERTY_ID }, toEntity: { id: 'topic-eth', name: 'Ethics' }, isDeleted: false },
+          ],
+        },
+      ],
+      isLoading: false,
+      isPlaceholderData: false,
+      endCursor: null,
+      hasNextPage: false,
+    };
+  },
 }));
 
 vi.mock('~/core/hooks/use-entity-vote', () => ({
@@ -130,6 +134,7 @@ beforeEach(() => {
   mocks.claimReadiness = [];
   mocks.setReadiness.mockReset();
   mocks.openSidePanel.mockReset();
+  mocks.entityQueries.length = 0;
   // The hub's filter menus measure their dropdown.
   window.ResizeObserver ??= class {
     observe() {}
@@ -510,6 +515,17 @@ describe('DebateRematchPageClient', () => {
     fireEvent.click(claim);
 
     expect(mocks.openSidePanel).toHaveBeenCalledWith(CLAIM_SHARED, SPACE_1, false);
+  });
+
+  // The All tab browses every published claim a page at a time, so filtering the loaded pages
+  // only ever searched what had been paged in. The hub's Claims tab searches server-side.
+  it('searches the whole claim corpus rather than the loaded pages', async () => {
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+    showAllClaims();
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Search claims' }), { target: { value: 'Fast fashion' } });
+
+    await waitFor(() => expect(mocks.entityQueries.at(-1)).toMatchObject({ name: { contains: 'Fast fashion' } }));
   });
 
   it('renders the card’s Debate toggle against real readiness', () => {

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
@@ -30,6 +30,7 @@ const mocks = vi.hoisted(() => ({
   submitResponse: vi.fn(),
   optimisticResponses: new Map<string, 'positive' | 'negative' | null>(),
   setReadiness: vi.fn(),
+  openSidePanel: vi.fn(),
   claimReadiness: [] as Array<{
     claim_entity_id: string;
     viewer_debate_ready: boolean;
@@ -98,6 +99,10 @@ vi.mock('~/core/debates/matchmaking/hooks', () => ({
   useClaimReadiness: () => ({ mutate: mocks.setReadiness, isPending: false, error: null }),
 }));
 
+vi.mock('~/core/hooks/use-entity-side-panel', () => ({
+  useEntitySidePanel: () => ({ openSidePanel: mocks.openSidePanel, sidePanelTarget: null, closeSidePanel: vi.fn() }),
+}));
+
 vi.mock('~/core/hooks/use-spaces-by-ids', () => ({
   useSpacesByIds: () => ({
     spaces: [],
@@ -124,6 +129,7 @@ beforeEach(() => {
   mocks.optimisticResponses.clear();
   mocks.claimReadiness = [];
   mocks.setReadiness.mockReset();
+  mocks.openSidePanel.mockReset();
   // The hub's filter menus measure their dropdown.
   window.ResizeObserver ??= class {
     observe() {}
@@ -491,6 +497,19 @@ describe('DebateRematchPageClient', () => {
     fireEvent.click(screen.getByRole('button', { name: /Salina’s positions/ }));
     await waitFor(() => expect(screen.queryByText('A newly published claim')).toBeNull());
     expect(screen.getByText('No claims match these filters.')).toBeInTheDocument();
+  });
+
+  // Following a link to the entity page would navigate out of the app shell and abandon the live
+  // session, so the claim opens beside the picker instead.
+  it('opens a claim in the side panel rather than navigating to it', () => {
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+
+    const claim = screen.getByText('A claim both participants chose');
+    expect(claim.closest('a')).toBeNull();
+
+    fireEvent.click(claim);
+
+    expect(mocks.openSidePanel).toHaveBeenCalledWith(CLAIM_SHARED, SPACE_1, false);
   });
 
   it('renders the card’s Debate toggle against real readiness', () => {

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
@@ -32,6 +32,10 @@ const mocks = vi.hoisted(() => ({
   setReadiness: vi.fn(),
   openSidePanel: vi.fn(),
   entityQueries: [] as unknown[],
+  entityQueryPlaceholder: false,
+  entities: [] as Array<Record<string, unknown>>,
+  claimReadinessLoading: false,
+  claimReadinessError: false,
   claimReadiness: [] as Array<{
     claim_entity_id: string;
     viewer_debate_ready: boolean;
@@ -56,7 +60,11 @@ vi.mock('~/core/debates/hooks', () => ({
     error: null,
   }),
   useDebate: () => ({ data: { claim: { claim_entity_id: CLAIM_SOURCE } } }),
-  useDebateClaimsBySpaces: () => mocks.claimReadiness,
+  useDebateClaimsBySpaces: () => ({
+    claims: mocks.claimReadiness,
+    isLoading: mocks.claimReadinessLoading,
+    isError: mocks.claimReadinessError,
+  }),
   useCreateDebateRematchRequest: () => mutation(),
   useLeaveDebateRematch: () => mutation(mocks.leaveMutate),
   useAcceptDebateRematchRequest: () => mutation(mocks.acceptMutate),
@@ -67,20 +75,9 @@ vi.mock('~/core/sync/use-store', () => ({
   useQueryEntities: (options: { where?: unknown }) => {
     mocks.entityQueries.push(options.where);
     return {
-      entities: [
-        {
-          id: CLAIM_MORE,
-          name: 'A newly published claim',
-          description: null,
-          spaces: [SPACE_2],
-          relations: [
-            { type: { id: TOPICS_PROPERTY_ID }, toEntity: { id: 'topic-gov', name: 'Governance' }, isDeleted: false },
-            { type: { id: TOPICS_PROPERTY_ID }, toEntity: { id: 'topic-eth', name: 'Ethics' }, isDeleted: false },
-          ],
-        },
-      ],
+      entities: mocks.entities,
       isLoading: false,
-      isPlaceholderData: false,
+      isPlaceholderData: mocks.entityQueryPlaceholder,
       endCursor: null,
       hasNextPage: false,
     };
@@ -132,9 +129,13 @@ beforeEach(() => {
   mocks.submitResponse.mockReset();
   mocks.optimisticResponses.clear();
   mocks.claimReadiness = [];
+  mocks.claimReadinessLoading = false;
+  mocks.claimReadinessError = false;
   mocks.setReadiness.mockReset();
   mocks.openSidePanel.mockReset();
   mocks.entityQueries.length = 0;
+  mocks.entityQueryPlaceholder = false;
+  mocks.entities = [publishedEntity()];
   // The hub's filter menus measure their dropdown.
   window.ResizeObserver ??= class {
     observe() {}
@@ -517,6 +518,53 @@ describe('DebateRematchPageClient', () => {
     expect(mocks.openSidePanel).toHaveBeenCalledWith(CLAIM_SHARED, SPACE_1, false);
   });
 
+  // A switch drawn from a guess is worse than one that waits: reading an unresolved lookup as
+  // "not ready" would report the opposite of the truth on a claim the viewer is standing ready on.
+  it('leaves the Debate toggle out until readiness is known', () => {
+    mocks.claimReadinessLoading = true;
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+
+    expect(screen.queryByRole('switch', { name: 'Ready to debate this claim' })).toBeNull();
+  });
+
+  it('leaves it out when the readiness lookup failed', () => {
+    mocks.claimReadinessError = true;
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+
+    expect(screen.queryByRole('switch', { name: 'Ready to debate this claim' })).toBeNull();
+  });
+
+  // A settled lookup with no row for the claim genuinely means not ready, so the switch belongs.
+  it('shows the toggle off once a settled lookup reports nothing for the claim', () => {
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+
+    expect(screen.getByRole('switch', { name: 'Ready to debate this claim' })).not.toBeChecked();
+  });
+
+  // `keepPreviousData` keeps the previous term's page on screen while the new one fetches. Filing
+  // it under the new term would let a prior search's claims survive into this one — and into the
+  // unfiltered list once the term is cleared.
+  it('does not bank the previous search’s page against a new term', async () => {
+    const STALE = '019fedb4-3f74-7c61-8d44-5fa08b1e7732';
+    const { rerender } = render(<DebateRematchPageClient sessionId="rematch-1" />);
+    showAllClaims();
+
+    // The new term is in flight, so the page still on hand belongs to the previous one. Its name
+    // contains the term, so nothing downstream would filter it out if it were banked.
+    mocks.entities = [publishedEntity(STALE, 'A stale claim from the previous search')];
+    mocks.entityQueryPlaceholder = true;
+    fireEvent.change(screen.getByRole('textbox', { name: 'Search claims' }), { target: { value: 'claim' } });
+    await waitFor(() => expect(mocks.entityQueries.at(-1)).toMatchObject({ name: { contains: 'claim' } }));
+
+    // The real page for this term lands.
+    mocks.entities = [publishedEntity()];
+    mocks.entityQueryPlaceholder = false;
+    rerender(<DebateRematchPageClient sessionId="rematch-1" />);
+
+    expect(screen.getByText('A newly published claim')).toBeInTheDocument();
+    await waitFor(() => expect(screen.queryByText('A stale claim from the previous search')).toBeNull());
+  });
+
   // Taking a side here means you want to debate it, so readiness shouldn't be a second step.
   it('turns the Debate toggle on when a position is first established here', () => {
     mocks.claims = [
@@ -666,6 +714,19 @@ function sharedClaim(): DebateRematchClaim {
     shared_preference: true,
     recently_rejected: false,
     previously_debated: false,
+  };
+}
+
+function publishedEntity(id = CLAIM_MORE, name = 'A newly published claim') {
+  return {
+    id,
+    name,
+    description: null,
+    spaces: [SPACE_2],
+    relations: [
+      { type: { id: TOPICS_PROPERTY_ID }, toEntity: { id: 'topic-gov', name: 'Governance' }, isDeleted: false },
+      { type: { id: TOPICS_PROPERTY_ID }, toEntity: { id: 'topic-eth', name: 'Ethics' }, isDeleted: false },
+    ],
   };
 }
 

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom/vitest';
-import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 
 import { StrictMode } from 'react';
 
@@ -9,6 +9,14 @@ import { TOPICS_PROPERTY_ID } from '~/core/claims/ontology';
 import type { DebateRematchClaim, DebateRematchSession } from '~/core/debates/api';
 
 import { DebateRematchPageClient } from './rematch-page-client';
+
+const { SPACE_1, SPACE_2, CLAIM_SHARED, CLAIM_MORE, CLAIM_SOURCE } = vi.hoisted(() => ({
+  SPACE_1: '019fedae-72b6-7ab2-927a-df044d57c566',
+  SPACE_2: '019fedae-72b6-7ab2-927a-df044d57c567',
+  CLAIM_SHARED: '019fedb1-0c41-7f3e-9a11-2c7d5e8b4419',
+  CLAIM_MORE: '019fedb2-1d52-7a4f-8b22-3d8e6f9c5520',
+  CLAIM_SOURCE: '019fedb3-2e63-7b50-9c33-4e9f7a0d6621',
+}));
 
 const mocks = vi.hoisted(() => ({
   session: null as DebateRematchSession | null,
@@ -21,6 +29,12 @@ const mocks = vi.hoisted(() => ({
   rejectMutate: vi.fn(),
   submitResponse: vi.fn(),
   optimisticResponses: new Map<string, 'positive' | 'negative' | null>(),
+  setReadiness: vi.fn(),
+  claimReadiness: [] as Array<{
+    claim_entity_id: string;
+    viewer_debate_ready: boolean;
+    readiness_disabled_reason: string | null;
+  }>,
 }));
 
 vi.mock('next/navigation', () => ({
@@ -35,11 +49,12 @@ vi.mock('~/core/debates/api', async importOriginal => {
 vi.mock('~/core/debates/hooks', () => ({
   useDebateRematch: () => ({ data: mocks.session, isLoading: false, error: null }),
   useDebateRematchClaims: () => ({
-    data: { claims: mocks.claims, excluded_claim_ids: ['claim-source'] },
+    data: { claims: mocks.claims, excluded_claim_ids: [CLAIM_SOURCE] },
     isLoading: false,
     error: null,
   }),
-  useDebate: () => ({ data: { claim: { claim_entity_id: 'claim-source' } } }),
+  useDebate: () => ({ data: { claim: { claim_entity_id: CLAIM_SOURCE } } }),
+  useDebateClaimsBySpaces: () => mocks.claimReadiness,
   useCreateDebateRematchRequest: () => mutation(),
   useLeaveDebateRematch: () => mutation(mocks.leaveMutate),
   useAcceptDebateRematchRequest: () => mutation(mocks.acceptMutate),
@@ -50,10 +65,10 @@ vi.mock('~/core/sync/use-store', () => ({
   useQueryEntities: () => ({
     entities: [
       {
-        id: 'claim-more',
+        id: CLAIM_MORE,
         name: 'A newly published claim',
         description: null,
-        spaces: ['space-2'],
+        spaces: [SPACE_2],
         relations: [
           { type: { id: TOPICS_PROPERTY_ID }, toEntity: { id: 'topic-gov', name: 'Governance' }, isDeleted: false },
           { type: { id: TOPICS_PROPERTY_ID }, toEntity: { id: 'topic-eth', name: 'Ethics' }, isDeleted: false },
@@ -72,6 +87,25 @@ vi.mock('~/core/hooks/use-entity-vote', () => ({
     submitResponse: (direction: 'positive' | 'negative' | 'clear') => mocks.submitResponse(entityId, direction),
     optimisticResponse: mocks.optimisticResponses.get(entityId),
     isConnected: true,
+    personalSpaceId: 'personal-space',
+  }),
+  useEntityResponseIndexingSnapshot: () => ({ status: 'idle', pending: null, runId: null }),
+  useResetEntityResponseIndexingSnapshot: () => vi.fn(),
+}));
+
+// The card's Debate toggle publishes readiness through this.
+vi.mock('~/core/debates/matchmaking/hooks', () => ({
+  useClaimReadiness: () => ({ mutate: mocks.setReadiness, isPending: false, error: null }),
+}));
+
+vi.mock('~/core/hooks/use-spaces-by-ids', () => ({
+  useSpacesByIds: () => ({
+    spaces: [],
+    spacesById: new Map([
+      [SPACE_1, { entity: { name: 'Crypto', image: null } }],
+      [SPACE_2, { entity: { name: 'Governance space', image: null } }],
+    ]),
+    isLoading: false,
   }),
 }));
 
@@ -88,6 +122,14 @@ beforeEach(() => {
   mocks.rejectMutate.mockReset();
   mocks.submitResponse.mockReset();
   mocks.optimisticResponses.clear();
+  mocks.claimReadiness = [];
+  mocks.setReadiness.mockReset();
+  // The hub's filter menus measure their dropdown.
+  window.ResizeObserver ??= class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver;
   mocks.session = session();
   mocks.claims = [sharedClaim()];
   document.body.style.overflow = '';
@@ -107,7 +149,7 @@ describe('DebateRematchPageClient', () => {
       </StrictMode>
     );
 
-    expect(await screen.findByRole('heading', { name: 'A claim both participants chose' })).toBeInTheDocument();
+    expect(await screen.findByText('A claim both participants chose')).toBeInTheDocument();
     await new Promise(resolve => window.setTimeout(resolve, 0));
     expect(mocks.leaveMutate).not.toHaveBeenCalled();
   });
@@ -143,7 +185,7 @@ describe('DebateRematchPageClient', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Leave debate' }));
 
     expect(mocks.back).toHaveBeenCalledOnce();
-    expect(mocks.replace).not.toHaveBeenCalledWith('/space/space-1/debates');
+    expect(mocks.replace).not.toHaveBeenCalledWith(`/space/${SPACE_1}/debates`);
   });
 
   it('preserves the debates-page exit for rematches started from a prior debate', () => {
@@ -157,15 +199,16 @@ describe('DebateRematchPageClient', () => {
     render(<DebateRematchPageClient sessionId="rematch-1" />);
     fireEvent.click(screen.getByRole('button', { name: 'Leave debate' }));
 
-    expect(mocks.replace).toHaveBeenCalledWith('/space/space-1/debates');
+    expect(mocks.replace).toHaveBeenCalledWith(`/space/${SPACE_1}/debates`);
     expect(mocks.back).not.toHaveBeenCalled();
   });
 
   it('pins shared preferences above additional published claims and enables opposing requests', () => {
     render(<DebateRematchPageClient sessionId="rematch-1" />);
+    showAllClaims();
 
-    const shared = screen.getByRole('heading', { name: 'A claim both participants chose' });
-    const additional = screen.getByRole('heading', { name: 'A newly published claim' });
+    const shared = screen.getByText('A claim both participants chose');
+    const additional = screen.getByText('A newly published claim');
     expect(shared.compareDocumentPosition(additional) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     expect(screen.getAllByRole('button', { name: 'Request debate' })[0]).toBeEnabled();
   });
@@ -173,12 +216,20 @@ describe('DebateRematchPageClient', () => {
   it('renders active semantic response buttons with holder avatars', () => {
     render(<DebateRematchPageClient sessionId="rematch-1" />);
 
-    const sharedClaimCard = screen.getByRole('heading', { name: 'A claim both participants chose' }).closest('article');
+    const sharedClaimCard = screen.getByText('A claim both participants chose').closest('article');
     expect(sharedClaimCard).not.toBeNull();
-    expect(within(sharedClaimCard!).getByRole('button', { name: 'Agree' })).toBeEnabled();
-    expect(within(sharedClaimCard!).getByRole('button', { name: 'Disagree' })).toBeEnabled();
-    expect(within(sharedClaimCard!).getByRole('button', { name: 'Agree' }).querySelector('img, svg')).not.toBeNull();
-    expect(within(sharedClaimCard!).getByRole('button', { name: 'Disagree' }).querySelector('img, svg')).not.toBeNull();
+    expect(within(sharedClaimCard!).getByRole('button', { name: /^Agree/ })).toBeEnabled();
+    expect(within(sharedClaimCard!).getByRole('button', { name: /^Disagree/ })).toBeEnabled();
+    expect(
+      within(sharedClaimCard!)
+        .getByRole('button', { name: /^Agree/ })
+        .querySelector('img, svg')
+    ).not.toBeNull();
+    expect(
+      within(sharedClaimCard!)
+        .getByRole('button', { name: /^Disagree/ })
+        .querySelector('img, svg')
+    ).not.toBeNull();
   });
 
   it('changes responses through the semantic buttons without rendering a second response area', () => {
@@ -193,17 +244,18 @@ describe('DebateRematchPageClient', () => {
     ];
 
     render(<DebateRematchPageClient sessionId="rematch-1" />);
+    showAllClaims();
 
-    const sharedClaimCard = screen.getByRole('heading', { name: 'A claim both participants chose' }).closest('article');
+    const sharedClaimCard = screen.getByText('A claim both participants chose').closest('article');
     expect(sharedClaimCard).not.toBeNull();
-    fireEvent.click(within(sharedClaimCard!).getByRole('button', { name: 'Disagree' }));
-    expect(mocks.submitResponse).toHaveBeenCalledWith('claim-shared', 'negative');
+    fireEvent.click(within(sharedClaimCard!).getByRole('button', { name: /^Disagree/ }));
+    expect(mocks.submitResponse).toHaveBeenCalledWith(CLAIM_SHARED, 'negative');
     expect(screen.queryByText('You both have the same response. Change yours to request this debate.')).toBeNull();
-    const syntheticClaimCard = screen.getByRole('heading', { name: 'A newly published claim' }).closest('article');
+    const syntheticClaimCard = screen.getByText('A newly published claim').closest('article');
     expect(syntheticClaimCard).not.toBeNull();
     expect(within(syntheticClaimCard!).queryByText('Respond before requesting')).toBeNull();
-    expect(within(syntheticClaimCard!).getByRole('button', { name: 'Agree' })).toBeEnabled();
-    expect(within(syntheticClaimCard!).getByRole('button', { name: 'Disagree' })).toBeEnabled();
+    expect(within(syntheticClaimCard!).getByRole('button', { name: /^Agree/ })).toBeEnabled();
+    expect(within(syntheticClaimCard!).getByRole('button', { name: /^Disagree/ })).toBeEnabled();
   });
 
   it('uses Verify and Dispute for factual claims', () => {
@@ -220,10 +272,10 @@ describe('DebateRematchPageClient', () => {
 
     render(<DebateRematchPageClient sessionId="rematch-1" />);
 
-    const claimCard = screen.getByRole('heading', { name: 'A claim both participants chose' }).closest('article');
+    const claimCard = screen.getByText('A claim both participants chose').closest('article');
     expect(claimCard).not.toBeNull();
-    expect(within(claimCard!).getByRole('button', { name: 'Verify' })).toBeEnabled();
-    expect(within(claimCard!).getByRole('button', { name: 'Dispute' })).toBeEnabled();
+    expect(within(claimCard!).getByRole('button', { name: /^Verify/ })).toBeEnabled();
+    expect(within(claimCard!).getByRole('button', { name: /^Dispute/ })).toBeEnabled();
   });
 
   it('shows authoritative stance labels in the incoming request dialog and preserves rematch actions', () => {
@@ -232,7 +284,7 @@ describe('DebateRematchPageClient', () => {
       request: {
         id: 'request-1',
         status: 'pending',
-        claim: claimSummary('claim-shared', 'A claim both participants chose'),
+        claim: claimSummary(CLAIM_SHARED, 'A claim both participants chose'),
         requester_user_id: 'user-remote',
         recipient_user_id: 'user-local',
         requester_position: false,
@@ -278,7 +330,7 @@ describe('DebateRematchPageClient', () => {
       request: {
         id: 'request-legacy',
         status: 'pending',
-        claim: claimSummary('claim-shared', 'A claim both participants chose'),
+        claim: claimSummary(CLAIM_SHARED, 'A claim both participants chose'),
         requester_user_id: 'user-remote',
         recipient_user_id: 'user-local',
         requester_position: false,
@@ -302,7 +354,7 @@ describe('DebateRematchPageClient', () => {
       request: {
         id: 'request-1',
         status: 'pending',
-        claim: claimSummary('claim-shared', 'A claim both participants chose'),
+        claim: claimSummary(CLAIM_SHARED, 'A claim both participants chose'),
         requester_user_id: 'user-local',
         recipient_user_id: 'user-remote',
         requester_position: true,
@@ -317,9 +369,10 @@ describe('DebateRematchPageClient', () => {
     });
 
     render(<DebateRematchPageClient sessionId="rematch-1" />);
+    showAllClaims();
 
-    expect(screen.getByRole('button', { name: 'Requesting...' })).toBeDisabled();
-    expect(screen.getAllByRole('button', { name: /^(Agree|Disagree)$/ })).toHaveLength(4);
+    expect(screen.getByRole('button', { name: 'Requesting…' })).toBeDisabled();
+    expect(screen.getAllByRole('button', { name: /^(Agree|Disagree)/ })).toHaveLength(4);
   });
 
   it('explains when response changes cancel a rematch request', () => {
@@ -327,7 +380,7 @@ describe('DebateRematchPageClient', () => {
       request: {
         id: 'request-1',
         status: 'expired',
-        claim: claimSummary('claim-shared', 'A claim both participants chose'),
+        claim: claimSummary(CLAIM_SHARED, 'A claim both participants chose'),
         requester_user_id: 'user-local',
         recipient_user_id: 'user-remote',
         requester_position: true,
@@ -349,53 +402,146 @@ describe('DebateRematchPageClient', () => {
     ).toBeInTheDocument();
   });
 
-  it('filters to opponent-committed claims on the Debate now tab', () => {
+  it('opens on the opponent’s positions, named after them and counted', () => {
     render(<DebateRematchPageClient sessionId="rematch-1" />);
 
-    // The opponent has taken a side on the shared claim but not the newly published one.
-    expect(screen.getByRole('heading', { name: 'A claim both participants chose' })).toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: 'A newly published claim' })).toBeInTheDocument();
+    const tab = screen.getByRole('button', { name: /Salina’s positions/ });
+    // Only the shared claim carries a side from Salina.
+    expect(within(tab).getByText('1')).toBeInTheDocument();
+    expect(screen.getByText('A claim both participants chose')).toBeInTheDocument();
+    expect(screen.queryByText('A newly published claim')).toBeNull();
+  });
 
-    fireEvent.click(screen.getByRole('button', { name: /Debate now/ }));
+  it('shortens the opponent tab to their first name', () => {
+    const base = session();
+    mocks.session = session({
+      participants: [base.participants[0], { ...base.participants[1], display_name: 'Salina Okonkwo' }],
+    });
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
 
-    expect(screen.getByRole('heading', { name: 'A claim both participants chose' })).toBeInTheDocument();
-    expect(screen.queryByRole('heading', { name: 'A newly published claim' })).toBeNull();
+    expect(screen.getByRole('button', { name: /Salina’s positions/ })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Okonkwo/ })).toBeNull();
+  });
+
+  it('lists every eligible claim on the All tab', async () => {
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+    showAllClaims();
+
+    expect(screen.getByText('A claim both participants chose')).toBeInTheDocument();
+    expect(screen.getByText('A newly published claim')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /Salina’s positions/ }));
+
+    expect(screen.getByText('A claim both participants chose')).toBeInTheDocument();
+    await waitFor(() => expect(screen.queryByText('A newly published claim')).toBeNull());
   });
 
   it('shows the opponent-specific empty state when no claim is debate-ready', () => {
     mocks.claims = [];
     render(<DebateRematchPageClient sessionId="rematch-1" />);
 
-    fireEvent.click(screen.getByRole('button', { name: /Debate now/ }));
-
-    expect(screen.getByText(/Salina hasn't responded yet/)).toBeInTheDocument();
+    expect(screen.getByText(/Salina hasn’t responded yet/)).toBeInTheDocument();
   });
 
-  it('narrows the list to the selected topic', () => {
+  it('narrows the list to the selected topic', async () => {
     render(<DebateRematchPageClient sessionId="rematch-1" />);
+    showAllClaims();
 
-    fireEvent.change(screen.getByRole('combobox', { name: 'Filter by topic' }), { target: { value: 'Governance' } });
+    selectFilter('Any topic', 'Governance');
 
     // Only the Governance-tagged published claim survives; the untagged shared claim drops out.
-    expect(screen.getByRole('heading', { name: 'A newly published claim' })).toBeInTheDocument();
-    expect(screen.queryByRole('heading', { name: 'A claim both participants chose' })).toBeNull();
+    expect(screen.getByText('A newly published claim')).toBeInTheDocument();
+    await waitFor(() => expect(screen.queryByText('A claim both participants chose')).toBeNull());
   });
 
   it('matches the topic filter on any of a claim topics, not just the first', () => {
     render(<DebateRematchPageClient sessionId="rematch-1" />);
+    showAllClaims();
 
     // The published claim is tagged Governance and Ethics; filtering on the second still matches.
-    fireEvent.change(screen.getByRole('combobox', { name: 'Filter by topic' }), { target: { value: 'Ethics' } });
+    selectFilter('Any topic', 'Ethics');
 
-    expect(screen.getByRole('heading', { name: 'A newly published claim' })).toBeInTheDocument();
+    expect(screen.getByText('A newly published claim')).toBeInTheDocument();
+  });
+
+  it('narrows the list to the selected space', async () => {
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+    showAllClaims();
+
+    // The shared claim sits in Crypto; the published one is in Governance space.
+    selectFilter('Any space', 'Crypto');
+
+    expect(screen.getByText('A claim both participants chose')).toBeInTheDocument();
+    await waitFor(() => expect(screen.queryByText('A newly published claim')).toBeNull());
+  });
+
+  it('searches claim text, and keeps searching across a tab switch', async () => {
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+    showAllClaims();
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Search claims' }), {
+      target: { value: 'newly published' },
+    });
+
+    // Debounced, so the shared claim leaves a beat later.
+    expect(screen.getByText('A newly published claim')).toBeInTheDocument();
+    await waitFor(() => expect(screen.queryByText('A claim both participants chose')).toBeNull());
+
+    // The search still applies on the opponent tab, where it leaves nothing.
+    fireEvent.click(screen.getByRole('button', { name: /Salina’s positions/ }));
+    await waitFor(() => expect(screen.queryByText('A newly published claim')).toBeNull());
+    expect(screen.getByText('No claims match these filters.')).toBeInTheDocument();
+  });
+
+  it('renders the card’s Debate toggle against real readiness', () => {
+    mocks.claimReadiness = [
+      { claim_entity_id: CLAIM_SHARED, viewer_debate_ready: true, readiness_disabled_reason: null },
+    ];
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+
+    expect(screen.getByRole('switch', { name: 'Ready to debate this claim' })).toBeChecked();
+  });
+
+  // Waiting for geo-chat to echo the response back would leave the side you just picked
+  // unhighlighted and Request debate missing for seconds.
+  it('reflects a just-picked side and offers the debate straight away', () => {
+    mocks.claims = [
+      {
+        ...sharedClaim(),
+        participants: [
+          { user_id: 'user-local', position: null, position_label: null },
+          { user_id: 'user-remote', position: false, position_label: 'Disagree' },
+        ],
+      },
+    ];
+    mocks.optimisticResponses.set(CLAIM_SHARED, 'positive');
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+
+    const card = screen.getByText('A claim both participants chose').closest('article');
+    expect(within(card!).getByRole('button', { name: /^Agree/ })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: 'Request debate' })).toBeEnabled();
   });
 });
+
+/** The picker opens on the opponent's positions; most assertions want the unfiltered list. */
+function showAllClaims() {
+  fireEvent.click(screen.getByRole('button', { name: 'All' }));
+}
+
+/**
+ * Opens one of the hub filter menus and picks an option. Names are matched loosely: a space
+ * option's accessible name picks up its avatar initial ("CCrypto").
+ */
+function selectFilter(trigger: string, option: string) {
+  fireEvent.click(screen.getByRole('button', { name: new RegExp(trigger) }));
+  fireEvent.click(screen.getByRole('button', { name: new RegExp(option) }));
+}
 
 function session(overrides: Partial<DebateRematchSession> = {}): DebateRematchSession {
   return {
     id: 'rematch-1',
     source_debate_id: 'debate-1',
-    source_space_id: 'space-1',
+    source_space_id: SPACE_1,
     status: 'browsing',
     participants: [
       {
@@ -428,7 +574,7 @@ function session(overrides: Partial<DebateRematchSession> = {}): DebateRematchSe
 
 function sharedClaim(): DebateRematchClaim {
   return {
-    claim: claimSummary('claim-shared', 'A claim both participants chose'),
+    claim: claimSummary(CLAIM_SHARED, 'A claim both participants chose'),
     response_kind: 'stance',
     participants: [
       { user_id: 'user-local', position: true, position_label: 'Agree' },
@@ -441,5 +587,5 @@ function sharedClaim(): DebateRematchClaim {
 }
 
 function claimSummary(id: string, claim: string) {
-  return { id, space_id: 'space-1', claim_entity_id: id, claim, description: null };
+  return { id, space_id: SPACE_1, claim_entity_id: id, claim, description: null };
 }

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -34,6 +34,7 @@ import { HubCardList } from '~/core/debates/matchmaking/hub-motion';
 import { HubPillButton } from '~/core/debates/matchmaking/hub-pill-button';
 import { HubQueryState } from '~/core/debates/matchmaking/hub-states';
 import { MatchmakingClaimCard } from '~/core/debates/matchmaking/matchmaking-claim-card';
+import { useEntitySidePanel } from '~/core/hooks/use-entity-side-panel';
 import { useEntityResponse } from '~/core/hooks/use-entity-vote';
 import { uuidToHex } from '~/core/id/normalize';
 import { responsePositionLabel } from '~/core/responses/entity-response';
@@ -291,7 +292,10 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
       : [];
 
   return (
-    <div className="fixed inset-0 z-[1000] overflow-y-auto bg-white text-text">
+    // Below the entity side panel (z-200) on purpose: a claim opens there rather than navigating,
+    // and the panel has to land on top. Still above the navbar (z-60) and the app's z-100 band, so
+    // the session keeps the screen to itself.
+    <div className="fixed inset-0 z-[150] overflow-y-auto bg-white text-text">
       <main className="mx-auto min-h-dvh w-full max-w-[720px] px-5 py-8 sm:px-8">
         <header className="mb-4 flex items-center justify-between gap-4">
           <h1 className="sr-only">Rematch {remoteName}</h1>
@@ -520,6 +524,7 @@ function RematchClaimCard({
         : optimisticResponse === 'positive';
 
   const opposing = localPosition !== null && remotePosition !== null && localPosition !== remotePosition;
+  const { openSidePanel } = useEntitySidePanel();
   const request = session?.request;
   const requesting =
     session?.status === 'request_pending' && request?.claim.claim_entity_id === claim.claim.claim_entity_id;
@@ -544,6 +549,9 @@ function RematchClaimCard({
       claim={claim.claim}
       positions={positions}
       readiness={readiness}
+      // Reading a claim shouldn't cost the session: navigating to its entity page would leave the
+      // rematch behind, so open it beside the picker instead.
+      onOpenClaim={() => openSidePanel(claim.claim.claim_entity_id, claim.claim.space_id, false)}
       footer={
         opposing || requesting ? (
           <div className="mt-3">

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -63,7 +63,21 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   const currentUserId = getCurrentGeoChatUserId();
   const exitStartedRef = React.useRef(false);
   const sessionQuery = useDebateRematch(sessionId);
+  const [search, setSearch] = React.useState('');
+  const [debouncedSearch, setDebouncedSearch] = React.useState('');
+
+  React.useEffect(() => {
+    const timeout = setTimeout(() => setDebouncedSearch(search.trim()), SEARCH_DEBOUNCE_MS);
+    return () => clearTimeout(timeout);
+  }, [search]);
+
   const [publishedClaimsCursor, setPublishedClaimsCursor] = React.useState<string | undefined>();
+
+  // A new term is a new corpus, so paging starts over.
+  React.useEffect(() => {
+    setPublishedClaimsCursor(undefined);
+  }, [debouncedSearch]);
+
   const {
     entities: publishedClaimsPage,
     isLoading: publishedClaimsLoading,
@@ -71,22 +85,38 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
     endCursor: publishedClaimsEndCursor,
     hasNextPage: publishedClaimsHasNextPage,
   } = useQueryEntities({
-    where: { types: [{ id: { equals: CLAIM_TYPE_ID } }] },
+    // Search runs in the query rather than over the loaded pages. The All tab browses every
+    // published claim 50 at a time, so filtering locally only ever searched what had been paged
+    // in — the hub's Claims tab searches server-side, and this now matches it. `contains` maps to
+    // the same case-insensitive substring its `?search=` does.
+    where: {
+      types: [{ id: { equals: CLAIM_TYPE_ID } }],
+      ...(debouncedSearch ? { name: { contains: debouncedSearch } } : {}),
+    },
     first: 50,
     after: publishedClaimsCursor,
     placeholderData: keepPreviousData,
   });
-  const [publishedClaims, setPublishedClaims] = React.useState<typeof publishedClaimsPage>([]);
+
+  // Pages accumulate as the viewer loads more, but a change of term replaces them rather than
+  // piling the new matches on top of the previous corpus.
+  const [publishedClaims, setPublishedClaims] = React.useState<{
+    search: string;
+    entities: typeof publishedClaimsPage;
+  }>({ search: '', entities: [] });
   React.useEffect(() => {
     setPublishedClaims(current => {
-      const next = new Map(current.map(claim => [claim.id, claim]));
+      const sameSearch = current.search === debouncedSearch;
+      const base = sameSearch ? current.entities : [];
+      const next = new Map(base.map(claim => [claim.id, claim]));
       for (const claim of publishedClaimsPage) {
         if (!next.has(claim.id)) next.set(claim.id, claim);
       }
-      return next.size === current.length ? current : [...next.values()];
+      if (sameSearch && next.size === base.length) return current;
+      return { search: debouncedSearch, entities: [...next.values()] };
     });
-  }, [publishedClaimsPage]);
-  const publishedClaimIds = React.useMemo(() => publishedClaims.map(claim => claim.id), [publishedClaims]);
+  }, [debouncedSearch, publishedClaimsPage]);
+  const publishedClaimIds = React.useMemo(() => publishedClaims.entities.map(claim => claim.id), [publishedClaims]);
   const savedClaimsQuery = useDebateRematchClaims(sessionId);
   const publishedClaimsQuery = useDebateRematchClaims(sessionId, publishedClaimIds);
   const createRequest = useCreateDebateRematchRequest(sessionId);
@@ -107,7 +137,7 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
       ...(savedClaimsQuery.data?.excluded_claim_ids ?? []),
       ...(publishedClaimsQuery.data?.excluded_claim_ids ?? []),
     ]);
-    for (const claim of publishedClaims) {
+    for (const claim of publishedClaims.entities) {
       if (
         claim.name &&
         claim.spaces[0] &&
@@ -139,7 +169,7 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
       .filter(claim => !excludedClaimIds.has(claim.claim.claim_entity_id))
       .sort((a, b) => Number(b.shared_preference) - Number(a.shared_preference));
   }, [
-    publishedClaims,
+    publishedClaims.entities,
     publishedClaimsQuery.data,
     savedClaimsQuery.data,
     session?.participants,
@@ -164,26 +194,19 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   // label each card and drive the "Any topic" filter. A claim can carry several topics.
   const topicsByClaimId = React.useMemo(() => {
     const map = new Map<string, MatchmakingTopic[]>();
-    for (const entity of publishedClaims) {
+    for (const entity of publishedClaims.entities) {
       const topics = entity.relations
         .filter(relation => relation.type.id === TOPICS_PROPERTY_ID && relation.isDeleted !== true)
         .map(relation => ({ id: relation.toEntity.id, name: relation.toEntity.name ?? null }));
       if (topics.length > 0) map.set(entity.id, topics);
     }
     return map;
-  }, [publishedClaims]);
+  }, [publishedClaims.entities]);
 
   // Opens on the opponent's positions: those are the claims that can turn into a debate now.
   const [tab, setTab] = React.useState<PickerTab>('opponent');
   const [spaceId, setSpaceId] = React.useState<string | null>(null);
   const [topicId, setTopicId] = React.useState<string | null>(null);
-  const [search, setSearch] = React.useState('');
-  const [debouncedSearch, setDebouncedSearch] = React.useState('');
-
-  React.useEffect(() => {
-    const timeout = setTimeout(() => setDebouncedSearch(search.trim().toLowerCase()), SEARCH_DEBOUNCE_MS);
-    return () => clearTimeout(timeout);
-  }, [search]);
 
   const returnFromSession = React.useCallback(
     (endedSession: DebateRematchSession) => {
@@ -236,7 +259,10 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
         if (spaceId && claim.claim.space_id !== spaceId) return false;
         if (topicId && !(topicsByClaimId.get(claim.claim.claim_entity_id) ?? []).some(t => t.id === topicId))
           return false;
-        if (debouncedSearch && !claim.claim.claim.toLowerCase().includes(debouncedSearch)) return false;
+        // Still applied locally: the session's own claims come from geo-chat, not the query above,
+        // so they'd otherwise ignore the term. Case-insensitive substring, matching what the
+        // query does to the published half.
+        if (debouncedSearch && !claim.claim.claim.toLowerCase().includes(debouncedSearch.toLowerCase())) return false;
         return true;
       }),
     [claims, debouncedSearch, opponentPositionOf, spaceId, tab, topicId, topicsByClaimId]

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -9,9 +9,12 @@ import { useRouter } from 'next/navigation';
 
 import { CLAIM_IS_FACTUAL_PROPERTY_ID, CLAIM_TYPE_ID, TOPICS_PROPERTY_ID } from '~/core/claims/ontology';
 import {
+  type DebateClaimPositionSummary,
   type DebateRematchClaim,
   type DebateRematchParticipant,
   type DebateRematchSession,
+  type MatchmakingReadiness,
+  type MatchmakingTopic,
   getCurrentGeoChatUserId,
 } from '~/core/debates/api';
 import { DebateRequestDialog } from '~/core/debates/debate-request-dialog';
@@ -20,21 +23,39 @@ import {
   useAcceptDebateRematchRequest,
   useCreateDebateRematchRequest,
   useDebate,
+  useDebateClaimsBySpaces,
   useDebateRematch,
   useDebateRematchClaims,
   useLeaveDebateRematch,
   useRejectDebateRematchRequest,
 } from '~/core/debates/hooks';
+import { SpaceTopicFilters } from '~/core/debates/matchmaking/claims-tab';
+import { HubCardList } from '~/core/debates/matchmaking/hub-motion';
+import { HubPillButton } from '~/core/debates/matchmaking/hub-pill-button';
+import { HubQueryState } from '~/core/debates/matchmaking/hub-states';
+import { MatchmakingClaimCard } from '~/core/debates/matchmaking/matchmaking-claim-card';
 import { useEntityResponse } from '~/core/hooks/use-entity-vote';
 import { uuidToHex } from '~/core/id/normalize';
 import { responsePositionLabel } from '~/core/responses/entity-response';
 import { useQueryEntities } from '~/core/sync/use-store';
 
-import { Avatar } from '~/design-system/avatar';
 import { Button } from '~/design-system/button';
 import { getChecked } from '~/design-system/checkbox';
-import { ChevronDownSmall } from '~/design-system/icons/chevron-down-small';
+import { Input } from '~/design-system/input';
 import { Text } from '~/design-system/text';
+
+const SEARCH_DEBOUNCE_MS = 250;
+
+type PickerTab = 'opponent' | 'all';
+
+/**
+ * The tab is narrow, so it carries the opponent's first name only: "Jenna Ruiz" -> "Jenna’s".
+ * A name already ending in s takes the bare apostrophe: "Chris" -> "Chris’".
+ */
+function firstNamePossessive(name: string) {
+  const firstName = name.trim().split(/\s+/)[0] || name;
+  return firstName.endsWith('s') ? `${firstName}’` : `${firstName}’s`;
+}
 
 export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   const router = useRouter();
@@ -141,18 +162,27 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   // Topics live on the KG claim entity (not the rematch API), so resolve them here to
   // label each card and drive the "Any topic" filter. A claim can carry several topics.
   const topicsByClaimId = React.useMemo(() => {
-    const map = new Map<string, string[]>();
+    const map = new Map<string, MatchmakingTopic[]>();
     for (const entity of publishedClaims) {
       const topics = entity.relations
         .filter(relation => relation.type.id === TOPICS_PROPERTY_ID && relation.isDeleted !== true)
-        .map(relation => relation.toEntity.name ?? relation.toEntity.id);
+        .map(relation => ({ id: relation.toEntity.id, name: relation.toEntity.name ?? null }));
       if (topics.length > 0) map.set(entity.id, topics);
     }
     return map;
   }, [publishedClaims]);
 
-  const [tab, setTab] = React.useState<'all' | 'debate-now'>('all');
-  const [topicFilter, setTopicFilter] = React.useState<string>('');
+  // Opens on the opponent's positions: those are the claims that can turn into a debate now.
+  const [tab, setTab] = React.useState<PickerTab>('opponent');
+  const [spaceId, setSpaceId] = React.useState<string | null>(null);
+  const [topicId, setTopicId] = React.useState<string | null>(null);
+  const [search, setSearch] = React.useState('');
+  const [debouncedSearch, setDebouncedSearch] = React.useState('');
+
+  React.useEffect(() => {
+    const timeout = setTimeout(() => setDebouncedSearch(search.trim().toLowerCase()), SEARCH_DEBOUNCE_MS);
+    return () => clearTimeout(timeout);
+  }, [search]);
 
   const returnFromSession = React.useCallback(
     (endedSession: DebateRematchSession) => {
@@ -183,24 +213,48 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
     [claims, opponentPositionOf]
   );
 
-  const availableTopics = React.useMemo(() => {
-    const topics = new Set<string>();
+  const facetSpaceIds = React.useMemo(() => [...new Set(claims.map(claim => claim.claim.space_id))], [claims]);
+
+  const facetTopics = React.useMemo(() => {
+    const seen = new Map<string, MatchmakingTopic>();
     for (const claim of claims) {
-      for (const topic of topicsByClaimId.get(claim.claim.claim_entity_id) ?? []) topics.add(topic);
+      for (const topic of topicsByClaimId.get(claim.claim.claim_entity_id) ?? []) {
+        if (!seen.has(topic.id)) seen.set(topic.id, topic);
+      }
     }
-    return [...topics].sort((a, b) => a.localeCompare(b));
+    return [...seen.values()].sort((a, b) => (a.name ?? '').localeCompare(b.name ?? ''));
   }, [claims, topicsByClaimId]);
 
+  // The rematch claim list is session-scoped — it already drops the source debate's claim and
+  // anything recently rejected — so there's no server query to push these into, the way the hub's
+  // Claims tab can.
   const visibleClaims = React.useMemo(
     () =>
       claims.filter(claim => {
-        if (tab === 'debate-now' && opponentPositionOf(claim) === null) return false;
-        if (topicFilter && !(topicsByClaimId.get(claim.claim.claim_entity_id) ?? []).includes(topicFilter))
+        if (tab === 'opponent' && opponentPositionOf(claim) === null) return false;
+        if (spaceId && claim.claim.space_id !== spaceId) return false;
+        if (topicId && !(topicsByClaimId.get(claim.claim.claim_entity_id) ?? []).some(t => t.id === topicId))
           return false;
+        if (debouncedSearch && !claim.claim.claim.toLowerCase().includes(debouncedSearch)) return false;
         return true;
       }),
-    [claims, opponentPositionOf, tab, topicFilter, topicsByClaimId]
+    [claims, debouncedSearch, opponentPositionOf, spaceId, tab, topicId, topicsByClaimId]
   );
+
+  const hasFilters = Boolean(debouncedSearch || spaceId || topicId);
+
+  // Readiness drives the card's Debate toggle and the rematch claims response doesn't carry it, so
+  // read it from the per-space debate-claims endpoint instead — one query per space on screen.
+  const claimIdsBySpace = React.useMemo(() => {
+    const bySpace = new Map<string, string[]>();
+    for (const claim of claims) {
+      const existing = bySpace.get(claim.claim.space_id);
+      if (existing) existing.push(claim.claim.claim_entity_id);
+      else bySpace.set(claim.claim.space_id, [claim.claim.claim_entity_id]);
+    }
+    return bySpace;
+  }, [claims]);
+  const readinessByClaimId = useClaimReadinessByClaimId(claimIdsBySpace);
 
   React.useEffect(() => {
     if (!session) return;
@@ -242,19 +296,19 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
         <header className="mb-4 flex items-center justify-between gap-4">
           <h1 className="sr-only">Rematch {remoteName}</h1>
           <div className="flex min-w-0 items-center gap-5">
-            <TabButton active={tab === 'all'} onClick={() => setTab('all')}>
-              All
-            </TabButton>
-            <TabButton active={tab === 'debate-now'} onClick={() => setTab('debate-now')}>
-              <span>Debate now</span>
+            <TabButton active={tab === 'opponent'} onClick={() => setTab('opponent')}>
+              <span className="truncate">{firstNamePossessive(remoteName)} positions</span>
               <span
                 className={cx(
                   'inline-flex min-h-6 min-w-6 items-center justify-center rounded-full px-1.5 text-metadataMedium tabular-nums',
-                  tab === 'debate-now' ? 'bg-text text-white' : 'bg-grey-01 text-grey-04'
+                  tab === 'opponent' ? 'bg-text text-white' : 'bg-grey-01 text-grey-04'
                 )}
               >
                 {opponentPositionCount}
               </span>
+            </TabButton>
+            <TabButton active={tab === 'all'} onClick={() => setTab('all')}>
+              All
             </TabButton>
           </div>
           <button
@@ -269,25 +323,25 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
           </button>
         </header>
 
-        <div className="mb-5">
-          <TopicFilter value={topicFilter} topics={availableTopics} onChange={setTopicFilter} />
+        <div className="mb-3 flex flex-col gap-3">
+          <SpaceTopicFilters
+            spaceId={spaceId}
+            onSpaceChange={setSpaceId}
+            topicId={topicId}
+            onTopicChange={setTopicId}
+            facetSpaceIds={facetSpaceIds}
+            facetTopics={facetTopics}
+            className="justify-between"
+          />
+          <Input
+            withSearchIcon
+            value={search}
+            onChange={event => setSearch(event.currentTarget.value)}
+            placeholder="Search claims"
+            aria-label="Search claims"
+          />
         </div>
 
-        {(sessionQuery.isLoading ||
-          savedClaimsQuery.isLoading ||
-          publishedClaimsQuery.isLoading ||
-          publishedClaimsLoading) && <Text color="grey-04">Loading claims...</Text>}
-        {(sessionQuery.error instanceof Error ||
-          savedClaimsQuery.error instanceof Error ||
-          publishedClaimsQuery.error instanceof Error) && (
-          <Text color="red-01">
-            {sessionQuery.error instanceof Error
-              ? sessionQuery.error.message
-              : savedClaimsQuery.error instanceof Error
-                ? savedClaimsQuery.error.message
-                : publishedClaimsQuery.error?.message}
-          </Text>
-        )}
         {(createRequest.error instanceof Error || leaveSession.error instanceof Error) && (
           <Text color="red-01" className="mb-4">
             {createRequest.error instanceof Error
@@ -303,37 +357,58 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
           </Text>
         )}
 
-        <div className="grid gap-4">
-          {visibleClaims.map(claim => (
-            <RematchClaimCard
-              key={claim.claim.claim_entity_id}
-              claim={claim}
-              topic={topicsByClaimId.get(claim.claim.claim_entity_id)?.[0] ?? null}
-              session={session}
-              currentUserId={currentUserId}
-              onRequest={() =>
-                createRequest.mutate({
-                  source_space_id: claim.claim.space_id,
-                  claim_id: claim.claim.claim_entity_id,
-                  format_id: defaultDebateFormatId,
-                })
-              }
-              busy={createRequest.isPending || session?.status === 'request_pending'}
-            />
-          ))}
-        </div>
+        <HubQueryState
+          isLoading={
+            sessionQuery.isLoading ||
+            savedClaimsQuery.isLoading ||
+            publishedClaimsQuery.isLoading ||
+            publishedClaimsLoading
+          }
+          error={sessionQuery.error ?? savedClaimsQuery.error ?? publishedClaimsQuery.error}
+          isEmpty={visibleClaims.length === 0}
+          emptyMessage={
+            hasFilters
+              ? 'No claims match these filters.'
+              : tab === 'opponent'
+                ? `${remoteName} hasn’t responded yet. When they do, those claims show up here.`
+                : 'No other eligible claims are available yet.'
+          }
+          emptyAction={
+            hasFilters
+              ? {
+                  label: 'Clear filters',
+                  onClick: () => {
+                    setSearch('');
+                    setSpaceId(null);
+                    setTopicId(null);
+                  },
+                }
+              : undefined
+          }
+        >
+          <HubCardList>
+            {visibleClaims.map(claim => (
+              <RematchClaimCard
+                key={claim.claim.claim_entity_id}
+                claim={claim}
+                session={session}
+                currentUserId={currentUserId}
+                readiness={readinessByClaimId.get(claim.claim.claim_entity_id) ?? null}
+                onRequest={() =>
+                  createRequest.mutate({
+                    source_space_id: claim.claim.space_id,
+                    claim_id: claim.claim.claim_entity_id,
+                    format_id: defaultDebateFormatId,
+                  })
+                }
+                busy={createRequest.isPending || session?.status === 'request_pending'}
+              />
+            ))}
+          </HubCardList>
+        </HubQueryState>
 
-        {!savedClaimsQuery.isLoading && !publishedClaimsQuery.isLoading && visibleClaims.length === 0 && (
-          <div className="rounded-lg border border-grey-02 bg-white p-6 text-center">
-            <Text color="grey-04">
-              {tab === 'debate-now'
-                ? `${remoteName} hasn't responded yet. When they do, those claims show up here.`
-                : topicFilter
-                  ? 'No claims match this topic.'
-                  : 'No other eligible claims are available yet.'}
-            </Text>
-          </div>
-        )}
+        {/* Outside the empty state deliberately: when a filter empties the list, fetching another
+            page is the way out, so the control has to stay reachable. */}
         {publishedClaimsHasNextPage && (
           <div className="mt-5 flex justify-center">
             <Button
@@ -372,98 +447,150 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   );
 }
 
+/** What the per-space debate-claims endpoint knows about a claim's readiness. */
+type ClaimReadinessState = { viewer_debate_ready: boolean; readiness_disabled_reason: string | null };
+
+/**
+ * Readiness for every claim on screen, keyed by claim entity id. The rematch claims response
+ * doesn't carry it, so this reads the per-space debate-claims endpoint — one query per space —
+ * letting the shared card render its Debate toggle against real state.
+ */
+function useClaimReadinessByClaimId(claimIdsBySpace: Map<string, string[]>) {
+  const groups = React.useMemo(
+    () =>
+      [...claimIdsBySpace.entries()]
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([spaceId, claimIds]) => ({ spaceId, claimIds })),
+    [claimIdsBySpace]
+  );
+  const claims = useDebateClaimsBySpaces(groups);
+
+  return React.useMemo(() => {
+    const byClaimId = new Map<string, ClaimReadinessState>();
+    for (const claim of claims) {
+      byClaimId.set(claim.claim_entity_id, {
+        viewer_debate_ready: claim.viewer_debate_ready,
+        readiness_disabled_reason: claim.readiness_disabled_reason,
+      });
+    }
+    return byClaimId;
+  }, [claims]);
+}
+
+/**
+ * A rematch claim in the hub's card, so the picker and the debates side panel read as one surface.
+ * The rematch API models sides per session participant, so the shared `DebateClaimPositionSummary`
+ * shape is assembled here.
+ */
 function RematchClaimCard({
   claim,
-  topic,
   session,
   currentUserId,
+  readiness: claimReadiness,
   onRequest,
   busy,
 }: {
   claim: DebateRematchClaim;
-  topic: string | null;
   session: DebateRematchSession | null;
   currentUserId: string | null;
+  readiness: ClaimReadinessState | null;
   onRequest: () => void;
   busy: boolean;
 }) {
-  const localResponse = claim.participants.find(position => position.user_id === currentUserId) ?? null;
-  const remoteResponse = claim.participants.find(position => position.user_id !== currentUserId) ?? null;
-  const localPosition = localResponse?.position ?? null;
-  const remotePosition = remoteResponse?.position ?? null;
-  const opposing = localPosition !== null && remotePosition !== null && localPosition !== remotePosition;
-  const { submitResponse, optimisticResponse, isConnected } = useEntityResponse({
+  const serverLocalPosition = claim.participants.find(side => side.user_id === currentUserId)?.position ?? null;
+  const remotePosition = claim.participants.find(side => side.user_id !== currentUserId)?.position ?? null;
+
+  // A claim whose stored kind didn't parse still has to render; 'stance' is the fallback
+  // `responsePositionLabel` already applies, so the labels agree either way.
+  const responseKind = claim.response_kind ?? 'stance';
+
+  // The client knows its own answer long before geo-chat echoes it back. Reading the optimistic
+  // copy is what keeps the side you just picked highlighted, and Request debate appearing with it,
+  // instead of both waiting on a refetch.
+  const { optimisticResponse } = useEntityResponse({
     entityId: claim.claim.claim_entity_id,
     spaceId: claim.claim.space_id,
-    responseKind: claim.response_kind,
+    responseKind,
   });
-  let displayedLocalPosition = localPosition;
-  if (optimisticResponse !== undefined) {
-    displayedLocalPosition = optimisticResponse === null ? null : optimisticResponse === 'positive';
-  }
+  const localPosition =
+    optimisticResponse === undefined
+      ? serverLocalPosition
+      : optimisticResponse === null
+        ? null
+        : optimisticResponse === 'positive';
+
+  const opposing = localPosition !== null && remotePosition !== null && localPosition !== remotePosition;
   const request = session?.request;
   const requesting =
     session?.status === 'request_pending' && request?.claim.claim_entity_id === claim.claim.claim_entity_id;
 
-  return (
-    <article className="rounded-lg border border-grey-02 bg-white p-5">
-      <div className="flex items-start justify-between gap-3">
-        <Text as="div" variant="footnote" color="grey-04">
-          {topic ?? (claim.shared_preference ? 'You both responded' : 'More claims')}
-        </Text>
-        {claim.recently_rejected && (
-          <Text as="div" variant="footnote" color="grey-04">
-            Recently rejected
-          </Text>
-        )}
-      </div>
-      <Text as="h2" variant="smallTitle" className="mt-3">
-        {claim.claim.claim}
-      </Text>
-
-      <div className="mt-5 grid grid-cols-2 gap-2">
-        {[true, false].map(position => {
-          const positionLabel = responsePositionLabel(claim.response_kind, position);
-          const holderIds = new Set(
-            claim.participants
-              .filter(participant => participant.user_id !== currentUserId && participant.position === position)
-              .map(participant => participant.user_id)
-          );
-          if (currentUserId && displayedLocalPosition === position) holderIds.add(currentUserId);
-          const holders = session?.participants.filter(participant => holderIds.has(participant.user_id)) ?? [];
-          const selected = displayedLocalPosition === position;
-          return (
-            <button
-              type="button"
-              key={String(position)}
-              aria-pressed={selected}
-              disabled={!claim.response_kind || !isConnected}
-              onClick={() => submitResponse(selected ? 'clear' : position ? 'positive' : 'negative')}
-              className={cx(
-                'flex min-h-9 items-center justify-between gap-2 rounded-full px-3 text-button transition-colors',
-                selected ? 'bg-text text-white' : 'bg-bg text-text hover:bg-grey-01',
-                (!claim.response_kind || !isConnected) && 'cursor-default opacity-50'
-              )}
-            >
-              <span>{positionLabel}</span>
-              {holders.length > 0 && <PositionAvatars participants={holders} />}
-            </button>
-          );
-        })}
-      </div>
-
-      {(opposing || requesting) && (
-        <button
-          type="button"
-          onClick={onRequest}
-          disabled={!opposing || busy || requesting || claim.recently_rejected}
-          className="mt-2 flex min-h-10 w-full items-center justify-center rounded-full bg-text px-4 text-button text-white transition-colors hover:bg-text/90 disabled:bg-grey-01 disabled:text-grey-04"
-        >
-          {requesting ? 'Requesting...' : 'Request debate'}
-        </button>
-      )}
-    </article>
+  const positions = React.useMemo(
+    () => rematchPositionSummaries(claim, session, responseKind),
+    [claim, responseKind, session]
   );
+
+  const readiness: MatchmakingReadiness = {
+    response_kind: responseKind,
+    viewer_response:
+      localPosition === null
+        ? null
+        : { position: localPosition, position_label: responsePositionLabel(responseKind, localPosition) },
+    viewer_debate_ready: claimReadiness?.viewer_debate_ready ?? false,
+    readiness_disabled_reason: claimReadiness?.readiness_disabled_reason ?? null,
+  };
+
+  return (
+    <MatchmakingClaimCard
+      claim={claim.claim}
+      positions={positions}
+      readiness={readiness}
+      footer={
+        opposing || requesting ? (
+          <div className="mt-3">
+            <HubPillButton
+              onClick={onRequest}
+              disabled={!opposing || busy || requesting || claim.recently_rejected}
+              pending={requesting}
+              pendingLabel="Requesting…"
+              className="w-full"
+            >
+              Request debate
+            </HubPillButton>
+            {claim.recently_rejected ? (
+              <Text as="p" variant="footnote" color="grey-04" className="mt-1">
+                Recently rejected
+              </Text>
+            ) : null}
+          </div>
+        ) : null
+      }
+    />
+  );
+}
+
+/** Both sides of a rematch claim, in the shape the shared card draws avatars from. */
+function rematchPositionSummaries(
+  claim: DebateRematchClaim,
+  session: DebateRematchSession | null,
+  responseKind: 'stance' | 'veracity'
+): DebateClaimPositionSummary[] {
+  return [true, false].map(position => {
+    const holders = claim.participants.filter(side => side.position === position);
+    const participants = holders
+      .map(holder => session?.participants.find(participant => participant.user_id === holder.user_id))
+      .filter((participant): participant is DebateRematchParticipant => participant !== undefined);
+
+    return {
+      position,
+      // A server-supplied label wins, so an authoritative Verify/Dispute survives.
+      position_label:
+        holders.find(holder => holder.position_label)?.position_label ?? responsePositionLabel(responseKind, position),
+      total_count: holders.length,
+      // Only meaningful for the hub's "available now" counts; a rematch is already a fixed pair.
+      available_now_count: 0,
+      participants,
+    };
+  });
 }
 
 function claimResponseKind(
@@ -497,21 +624,6 @@ function rematchCancellationMessage(reason: string) {
   }
 }
 
-function PositionAvatars({ participants }: { participants: DebateRematchParticipant[] }) {
-  return (
-    <span className="flex -space-x-1.5">
-      {participants.map(participant => (
-        <span
-          key={participant.user_id}
-          className="relative box-content block size-5 overflow-hidden rounded-full border-2 border-white"
-        >
-          <Avatar avatarUrl={participant.avatar_cid} value={participant.profile_space_id} size={20} />
-        </span>
-      ))}
-    </span>
-  );
-}
-
 function TabButton({ active, onClick, children }: { active: boolean; onClick: () => void; children: React.ReactNode }) {
   return (
     <button
@@ -525,37 +637,6 @@ function TabButton({ active, onClick, children }: { active: boolean; onClick: ()
     >
       {children}
     </button>
-  );
-}
-
-function TopicFilter({
-  value,
-  topics,
-  onChange,
-}: {
-  value: string;
-  topics: string[];
-  onChange: (topic: string) => void;
-}) {
-  return (
-    <div className="relative inline-flex">
-      <select
-        aria-label="Filter by topic"
-        value={value}
-        onChange={event => onChange(event.target.value)}
-        className="min-h-9 appearance-none rounded-full border border-grey-02 bg-white py-2 pr-9 pl-4 text-button text-text outline-hidden hover:border-grey-04 focus:border-text"
-      >
-        <option value="">Any topic</option>
-        {topics.map(topic => (
-          <option key={topic} value={topic}>
-            {topic}
-          </option>
-        ))}
-      </select>
-      <span className="pointer-events-none absolute top-1/2 right-3 -translate-y-1/2">
-        <ChevronDownSmall color="grey-04" />
-      </span>
-    </div>
   );
 }
 

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -10,6 +10,7 @@ import { useRouter } from 'next/navigation';
 import { CLAIM_IS_FACTUAL_PROPERTY_ID, CLAIM_TYPE_ID, TOPICS_PROPERTY_ID } from '~/core/claims/ontology';
 import {
   type DebateClaimPositionSummary,
+  type DebateClaimSummary,
   type DebateRematchClaim,
   type DebateRematchParticipant,
   type DebateRematchSession,
@@ -30,6 +31,7 @@ import {
   useRejectDebateRematchRequest,
 } from '~/core/debates/hooks';
 import { SpaceTopicFilters } from '~/core/debates/matchmaking/claims-tab';
+import { useClaimReadiness } from '~/core/debates/matchmaking/hooks';
 import { HubCardList } from '~/core/debates/matchmaking/hub-motion';
 import { HubPillButton } from '~/core/debates/matchmaking/hub-pill-button';
 import { HubQueryState } from '~/core/debates/matchmaking/hub-states';
@@ -552,6 +554,12 @@ function RematchClaimCard({
   const opposing = localPosition !== null && remotePosition !== null && localPosition !== remotePosition;
   const { openSidePanel } = useEntitySidePanel();
   const request = session?.request;
+
+  useReadinessOnFirstPosition({
+    claim: claim.claim,
+    localPosition,
+    alreadyReady: claimReadiness?.viewer_debate_ready ?? false,
+  });
   const requesting =
     session?.status === 'request_pending' && request?.claim.claim_entity_id === claim.claim.claim_entity_id;
 
@@ -600,6 +608,41 @@ function RematchClaimCard({
       }
     />
   );
+}
+
+/**
+ * Taking a side here means you want to debate this claim, so readiness follows rather than being a
+ * second step the viewer has to find. Deliberately local to the picker: the hub's Claims tab keeps
+ * the two separate, where browsing and standing ready really are different intents.
+ *
+ * Only a side picked while the picker is open counts. Opting in for positions already held on
+ * arrival would fire a write per claim on load, and would silently undo a stand-down the viewer
+ * made somewhere else. Switching sides doesn't re-fire either, for the same reason.
+ */
+function useReadinessOnFirstPosition({
+  claim,
+  localPosition,
+  alreadyReady,
+}: {
+  claim: DebateClaimSummary;
+  localPosition: boolean | null;
+  alreadyReady: boolean;
+}) {
+  const setReadiness = useClaimReadiness();
+  // Seeded with the position held on mount, so arriving with one is not a transition.
+  const previousPosition = React.useRef(localPosition);
+  const optedIn = React.useRef(false);
+
+  React.useEffect(() => {
+    const previous = previousPosition.current;
+    previousPosition.current = localPosition;
+
+    const justEstablished = previous === null && localPosition !== null;
+    if (!justEstablished || alreadyReady || optedIn.current) return;
+
+    optedIn.current = true;
+    setReadiness.mutate({ spaceId: claim.space_id, claimId: claim.claim_entity_id, ready: true });
+  }, [alreadyReady, claim.claim_entity_id, claim.space_id, localPosition, setReadiness]);
 }
 
 /** Both sides of a rematch claim, in the shape the shared card draws avatars from. */

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -107,6 +107,11 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
     entities: typeof publishedClaimsPage;
   }>({ search: '', entities: [] });
   React.useEffect(() => {
+    // `keepPreviousData` keeps the old term's page on screen while the new one fetches. Recording
+    // that under the new term would file the previous search's claims as matches for this one, and
+    // the real page would then merge on top of them rather than replace them.
+    if (publishedClaimsPlaceholder) return;
+
     setPublishedClaims(current => {
       const sameSearch = current.search === debouncedSearch;
       const base = sameSearch ? current.entities : [];
@@ -117,7 +122,7 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
       if (sameSearch && next.size === base.length) return current;
       return { search: debouncedSearch, entities: [...next.values()] };
     });
-  }, [debouncedSearch, publishedClaimsPage]);
+  }, [debouncedSearch, publishedClaimsPage, publishedClaimsPlaceholder]);
   const publishedClaimIds = React.useMemo(() => publishedClaims.entities.map(claim => claim.id), [publishedClaims]);
   const savedClaimsQuery = useDebateRematchClaims(sessionId);
   const publishedClaimsQuery = useDebateRematchClaims(sessionId, publishedClaimIds);
@@ -283,7 +288,8 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
     }
     return bySpace;
   }, [claims]);
-  const readinessByClaimId = useClaimReadinessByClaimId(claimIdsBySpace);
+  const { byClaimId: readinessByClaimId, unresolved: readinessUnresolved } =
+    useClaimReadinessByClaimId(claimIdsBySpace);
 
   React.useEffect(() => {
     if (!session) return;
@@ -426,6 +432,7 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
                 session={session}
                 currentUserId={currentUserId}
                 readiness={readinessByClaimId.get(claim.claim.claim_entity_id) ?? null}
+                readinessUnresolved={readinessUnresolved}
                 onRequest={() =>
                   createRequest.mutate({
                     source_space_id: claim.claim.space_id,
@@ -495,18 +502,23 @@ function useClaimReadinessByClaimId(claimIdsBySpace: Map<string, string[]>) {
         .map(([spaceId, claimIds]) => ({ spaceId, claimIds })),
     [claimIdsBySpace]
   );
-  const claims = useDebateClaimsBySpaces(groups);
+  const { claims, isLoading, isError } = useDebateClaimsBySpaces(groups);
 
-  return React.useMemo(() => {
-    const byClaimId = new Map<string, ClaimReadinessState>();
+  const byClaimId = React.useMemo(() => {
+    const map = new Map<string, ClaimReadinessState>();
     for (const claim of claims) {
-      byClaimId.set(claim.claim_entity_id, {
+      map.set(claim.claim_entity_id, {
         viewer_debate_ready: claim.viewer_debate_ready,
         readiness_disabled_reason: claim.readiness_disabled_reason,
       });
     }
-    return byClaimId;
+    return map;
   }, [claims]);
+
+  // A claim missing from a settled lookup genuinely has no readiness row, so `false` is the truth.
+  // Missing while a lookup is still running or has failed means we don't know, and a switch drawn
+  // from a guess is worse than one that waits.
+  return { byClaimId, unresolved: isLoading || isError };
 }
 
 /**
@@ -519,6 +531,7 @@ function RematchClaimCard({
   session,
   currentUserId,
   readiness: claimReadiness,
+  readinessUnresolved,
   onRequest,
   busy,
 }: {
@@ -526,6 +539,8 @@ function RematchClaimCard({
   session: DebateRematchSession | null;
   currentUserId: string | null;
   readiness: ClaimReadinessState | null;
+  /** True while any readiness lookup is still running or has failed. */
+  readinessUnresolved: boolean;
   onRequest: () => void;
   busy: boolean;
 }) {
@@ -586,6 +601,9 @@ function RematchClaimCard({
       // Reading a claim shouldn't cost the session: navigating to its entity page would leave the
       // rematch behind, so open it beside the picker instead.
       onOpenClaim={() => openSidePanel(claim.claim.claim_entity_id, claim.claim.space_id, false)}
+      // Rather than draw the switch off on a guess. Only while this claim's readiness is genuinely
+      // unknown — a settled lookup that simply has no row for it really does mean "not ready".
+      hideReadinessToggle={claimReadiness === null && readinessUnresolved}
       footer={
         opposing || requesting ? (
           <div className="mt-3">

--- a/apps/web/core/debates/debate-gateway.test.ts
+++ b/apps/web/core/debates/debate-gateway.test.ts
@@ -315,6 +315,7 @@ describe('DebateGatewayClient', () => {
     queryClient.setQueryData(['claim-response-summaries', 'profile-1', 'space-1', ['claim-2:veracity']], new Map());
     queryClient.setQueryData(['claim-response-summary-data', 'profile-1', 'space-1', ['claim-2:veracity']], new Map());
     queryClient.setQueryData(['claim-response-summaries', 'profile-1', 'space-2', ['claim-2:veracity']], new Map());
+    queryClient.setQueryData(['debates', 'account', 'user-a', 'rematch', 'session-1', 'claims', ['claim-9']], {});
     const refetchQueries = vi.spyOn(queryClient, 'refetchQueries').mockResolvedValue();
 
     client.start(
@@ -362,6 +363,15 @@ describe('DebateGatewayClient', () => {
         queryClient
           .getQueryCache()
           .find({ queryKey: ['claim-response-summary-data', 'profile-1', 'space-1', ['claim-2:veracity']] })!
+      )
+    ).toBe(true);
+    // The rematch picker draws both participants' sides, so any claim change has to reach it —
+    // even one it isn't holding an id for, since the opponent's response is what it's waiting on.
+    expect(
+      predicate!(
+        queryClient
+          .getQueryCache()
+          .find({ queryKey: ['debates', 'account', 'user-a', 'rematch', 'session-1', 'claims', ['claim-9']] })!
       )
     ).toBe(true);
     expect(

--- a/apps/web/core/debates/debate-gateway.ts
+++ b/apps/web/core/debates/debate-gateway.ts
@@ -466,6 +466,14 @@ export class DebateGatewayClient {
               queryClaimIds.some(claimId => typeof claimId === 'string' && changedClaims.has(claimId))));
         if (isDebateClaimQuery) return true;
 
+        // The rematch picker lists claims from many spaces and draws both participants' sides, so
+        // it has to refresh whenever *anyone's* response lands — its own subscription only covers
+        // the viewer's. Without this the opponent's choices appeared only after rejoining.
+        const [, accountSegment, , rematchSegment, , claimsSegment] = query.queryKey;
+        if (accountSegment === 'account' && rematchSegment === 'rematch' && claimsSegment === 'claims') {
+          return true;
+        }
+
         return isClaimResponseSummaryQueryKey(query.queryKey, {
           spaceId,
           targetKeys: changedResponseTargets,
@@ -685,6 +693,24 @@ export function useDebateGatewayScope(scope: DebateGatewayScope, enabled: boolea
       scopeType === 'space' ? { scope: 'space', space_id: scopeId } : { scope: 'debate', debate_id: scopeId }
     );
   }, [enabled, scopeId, scopeType]);
+}
+
+/**
+ * Retains a space scope for every id in the list. `debate.claims_changed` is space-scoped, so a
+ * surface showing claims from several spaces at once — the rematch picker — has to hold them all
+ * or it only hears about some of its own rows.
+ */
+export function useDebateGatewaySpaceScopes(spaceIds: string[], enabled: boolean) {
+  // Joined so the effect keys off the ids themselves rather than a fresh array each render.
+  const key = spaceIds.join(',');
+
+  React.useEffect(() => {
+    if (!enabled || !key) return;
+    const releases = key.split(',').map(spaceId => debateGateway.retainScope({ scope: 'space', space_id: spaceId }));
+    return () => {
+      for (const release of releases) release();
+    };
+  }, [enabled, key]);
 }
 
 /** Read-only view of the gateway snapshot. Unlike `useDebateGateway` this never starts a socket. */

--- a/apps/web/core/debates/hooks.ts
+++ b/apps/web/core/debates/hooks.ts
@@ -56,7 +56,7 @@ import {
 } from './api';
 import { claimResponseIndexedEvent } from './claim-response-indexed-notifier';
 import { useDebateAttention } from './debate-attention';
-import { useDebateGatewayScope } from './debate-gateway';
+import { useDebateGatewayScope, useDebateGatewaySpaceScopes } from './debate-gateway';
 import { hasProcessedVideo } from './playback-utils';
 
 export const debateQueryNetworkOptions = {
@@ -132,6 +132,11 @@ export function useDebateClaims(spaceId: string, claimIds: string[] | null, enab
  */
 export function useDebateClaimsBySpaces(groups: Array<{ spaceId: string; claimIds: string[] }>) {
   const { accountKey, authenticated, getPrivyIdentityToken } = useGeoChatAuth();
+
+  // Same subscription `useDebateClaims` makes for its one space: without it the gateway never
+  // delivers this space's claim changes, so nothing here would refresh when someone responds.
+  const spaceIds = React.useMemo(() => groups.map(group => group.spaceId), [groups]);
+  useDebateGatewaySpaceScopes(spaceIds, authenticated && spaceIds.length > 0);
 
   // Stable by contract: react-query re-runs `combine` whenever its identity changes and diffs the
   // result with `replaceEqualDeep`, so a fresh closure each render would defeat callers' memos.

--- a/apps/web/core/debates/hooks.ts
+++ b/apps/web/core/debates/hooks.ts
@@ -10,6 +10,7 @@ import { getCachedIdentityToken, useIdentityTokenSync } from '~/core/auth/identi
 import {
   type Debate,
   type DebateActivity,
+  type DebateClaimsResponse,
   type DebateMediaArtifactUrlRequest,
   type DebateMediaProcessRequest,
   type DebateMediaResponse,
@@ -121,6 +122,39 @@ export function useDebateClaims(spaceId: string, claimIds: string[] | null, enab
         signal
       ),
     enabled: shouldFetch,
+  });
+}
+
+/**
+ * The same per-space payload as {@link useDebateClaims}, for callers holding claims spread across
+ * several spaces — the rematch picker mixes geo-chat's session claims with published ones from
+ * anywhere. A hook per space is impossible when the list changes length, so this fans out.
+ */
+export function useDebateClaimsBySpaces(groups: Array<{ spaceId: string; claimIds: string[] }>) {
+  const { accountKey, authenticated, getPrivyIdentityToken } = useGeoChatAuth();
+
+  // Stable by contract: react-query re-runs `combine` whenever its identity changes and diffs the
+  // result with `replaceEqualDeep`, so a fresh closure each render would defeat callers' memos.
+  const combine = React.useCallback(
+    (results: UseQueryResult<DebateClaimsResponse>[]) => results.flatMap(result => result.data?.claims ?? []),
+    []
+  );
+
+  return useQueries({
+    queries: groups.map(group => ({
+      ...debateQueryNetworkOptions,
+      queryKey: debateQueryKeys.claims(group.spaceId, group.claimIds),
+      queryFn: ({ signal }: { signal?: AbortSignal }) =>
+        listDebateClaims(
+          group.spaceId,
+          group.claimIds,
+          authenticated ? getPrivyIdentityToken : undefined,
+          authenticated ? accountKey : null,
+          signal
+        ),
+      enabled: authenticated && group.claimIds.length > 0,
+    })),
+    combine,
   });
 }
 

--- a/apps/web/core/debates/hooks.ts
+++ b/apps/web/core/debates/hooks.ts
@@ -140,8 +140,17 @@ export function useDebateClaimsBySpaces(groups: Array<{ spaceId: string; claimId
 
   // Stable by contract: react-query re-runs `combine` whenever its identity changes and diffs the
   // result with `replaceEqualDeep`, so a fresh closure each render would defeat callers' memos.
+  //
+  // Status rides along with the claims deliberately. Flattening to a bare list makes a pending or
+  // failed lookup indistinguishable from "no readiness on this claim", and callers rendering a
+  // readiness switch would then draw it off — misreporting a claim the viewer is standing ready on
+  // for as long as the failure lasts.
   const combine = React.useCallback(
-    (results: UseQueryResult<DebateClaimsResponse>[]) => results.flatMap(result => result.data?.claims ?? []),
+    (results: UseQueryResult<DebateClaimsResponse>[]) => ({
+      claims: results.flatMap(result => result.data?.claims ?? []),
+      isLoading: results.some(result => result.isLoading),
+      isError: results.some(result => result.isError),
+    }),
     []
   );
 

--- a/apps/web/core/debates/matchmaking/claims-tab.tsx
+++ b/apps/web/core/debates/matchmaking/claims-tab.tsx
@@ -4,6 +4,8 @@ import { keepPreviousData } from '@tanstack/react-query';
 
 import * as React from 'react';
 
+import cx from 'classnames';
+
 import { TOPICS_PROPERTY_ID } from '~/core/claims/ontology';
 import { useSpacesByIds } from '~/core/hooks/use-spaces-by-ids';
 import { useQueryEntities } from '~/core/sync/use-store';
@@ -222,6 +224,8 @@ type SpaceTopicFiltersProps = {
   facetTopics?: { id: string; name: string | null }[];
   /** Rendered before the space filter — the Claims tab puts its position filter here. */
   leading?: React.ReactNode;
+  /** Overrides the row layout — the rematch picker spreads the two menus across its width. */
+  className?: string;
 };
 
 /**
@@ -236,6 +240,7 @@ export function SpaceTopicFilters({
   facetSpaceIds,
   facetTopics,
   leading,
+  className,
 }: SpaceTopicFiltersProps) {
   const { spacesById } = useSpacesByIds(facetSpaceIds);
 
@@ -263,7 +268,7 @@ export function SpaceTopicFilters({
   const topicLabel = topicId ? (facetTopics?.find(topic => topic.id === topicId)?.name ?? 'Topic') : 'Any topic';
 
   return (
-    <div className="flex flex-wrap items-center gap-2">
+    <div className={cx('flex flex-wrap items-center gap-2', className)}>
       {leading}
       <HubFilterMenu
         label={spaceLabel}

--- a/apps/web/core/debates/matchmaking/hooks.test.tsx
+++ b/apps/web/core/debates/matchmaking/hooks.test.tsx
@@ -106,4 +106,32 @@ describe('useClaimReadiness', () => {
       expect(claims[1]!.viewer_debate_ready).toBe(false);
     });
   });
+
+  // The rematch picker reads readiness from the per-space claims family, which keys the ids on the
+  // entry rather than nesting them under `claim`. Missing it left that toggle unmoved on click.
+  it('moves the switch in the per-space claims family too', async () => {
+    mocks.joinDebateQueue.mockResolvedValue({ claim: { id: 'claim-row-1' }, match: null });
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const key = ['debates', 'claims', 'space-1', ['claim-1']];
+    queryClient.setQueryData(key, {
+      claims: [
+        { space_id: 'space-1', claim_entity_id: 'claim-1', viewer_debate_ready: false },
+        { space_id: 'space-2', claim_entity_id: 'claim-1', viewer_debate_ready: false },
+      ],
+    });
+
+    const { result } = renderHook(() => useClaimReadiness(), {
+      wrapper: ({ children }: { children: ReactNode }) => (
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      ),
+    });
+    result.current.mutate({ spaceId: 'space-1', claimId: 'claim-1', ready: true });
+
+    await waitFor(() => {
+      const claims = (queryClient.getQueryData(key) as { claims: { viewer_debate_ready: boolean }[] }).claims;
+      expect(claims[0]!.viewer_debate_ready).toBe(true);
+      // Same claim entity in another space keeps its own switch.
+      expect(claims[1]!.viewer_debate_ready).toBe(false);
+    });
+  });
 });

--- a/apps/web/core/debates/matchmaking/hooks.ts
+++ b/apps/web/core/debates/matchmaking/hooks.ts
@@ -126,6 +126,18 @@ export function useDebateBlocks(enabled: boolean) {
  * readiness on (the server requires an indexed active response) or off — it never sends a side.
  * Both directions are the plain queue endpoints, keyed per claim so cards can pass their own space.
  */
+/**
+ * Every cached family that carries `viewer_debate_ready`, so the switch moves in whichever surface
+ * the viewer is looking at. `['debates', 'claims']` is the per-space family the rematch picker
+ * reads; leaving it out left that toggle unmoved until the settle refetch landed.
+ */
+const READINESS_FAMILIES = (accountKey: string | null) =>
+  [
+    debateQueryKeys.matchmakingClaimsRoot(accountKey),
+    debateQueryKeys.matches(accountKey),
+    ['debates', 'claims'],
+  ] as const;
+
 export function useClaimReadiness() {
   const queryClient = useQueryClient();
   const { accountKey, getPrivyIdentityToken } = useGeoChatAuth();
@@ -138,7 +150,7 @@ export function useClaimReadiness() {
     // The switch moves now rather than a round trip and a refetch later, mirroring the
     // availability switch in the panel header.
     onMutate: async ({ spaceId, claimId, ready }) => {
-      const families = [debateQueryKeys.matchmakingClaimsRoot(accountKey), debateQueryKeys.matches(accountKey)];
+      const families = READINESS_FAMILIES(accountKey);
       await Promise.all(families.map(queryKey => queryClient.cancelQueries({ queryKey })));
       for (const queryKey of families) {
         queryClient.setQueriesData({ queryKey }, (current: unknown) =>
@@ -150,7 +162,7 @@ export function useClaimReadiness() {
     // own copy of this mutation, so a snapshot rollback would also revert a toggle on another claim
     // and any gateway refetch that landed in between.
     onError: (_error, { spaceId, claimId, ready }) => {
-      for (const queryKey of [debateQueryKeys.matchmakingClaimsRoot(accountKey), debateQueryKeys.matches(accountKey)]) {
+      for (const queryKey of READINESS_FAMILIES(accountKey)) {
         queryClient.setQueriesData({ queryKey }, (current: unknown) =>
           patchClaimReadiness(current, spaceId, claimId, !ready)
         );
@@ -189,8 +201,24 @@ function patchClaimReadiness(data: unknown, spaceId: string, claimId: string, re
 
   if (!data || typeof data !== 'object') return data;
 
+  // The per-space family (`DebateClaimsResponse`) keys the ids on the entry itself rather than
+  // nesting them under `claim`, so it needs its own matcher.
+  const patchFlat = <T extends { space_id: string; claim_entity_id: string; viewer_debate_ready: boolean }>(
+    entry: T
+  ) =>
+    entry.claim_entity_id === claimId && entry.space_id === spaceId ? { ...entry, viewer_debate_ready: ready } : entry;
+
   if ('matches' in data && Array.isArray(data.matches)) {
     return { ...data, matches: data.matches.map(patchOne) };
+  }
+
+  if ('claims' in data && Array.isArray(data.claims)) {
+    return {
+      ...data,
+      claims: data.claims.map((entry: unknown) =>
+        entry && typeof entry === 'object' && 'claim_entity_id' in entry ? patchFlat(entry as never) : entry
+      ),
+    };
   }
 
   if ('pages' in data && Array.isArray(data.pages)) {

--- a/apps/web/core/debates/matchmaking/matchmaking-claim-card.tsx
+++ b/apps/web/core/debates/matchmaking/matchmaking-claim-card.tsx
@@ -39,6 +39,12 @@ type Props = {
    * following a link there would navigate out of the app shell and abandon the live session.
    */
   onOpenClaim?: () => void;
+  /**
+   * Leaves the readiness switch out. For hosts that can't yet say whether the viewer is standing
+   * ready — the switch reads `viewer_debate_ready`, so drawing it from an unresolved lookup would
+   * report "not ready" on a claim they are in fact ready on.
+   */
+  hideReadinessToggle?: boolean;
   /** `AnimatePresence mode="popLayout"` measures the exiting row through this; without it the row
    * never pops out of flow and the rows above close the gap only after the fade finishes. */
   ref?: React.Ref<HTMLElement>;
@@ -58,7 +64,16 @@ export function isResolvableClaim(claim: Pick<DebateClaimSummary, 'space_id' | '
  * there are deliberately no separate vote arrows here. Readiness, the geo-chat half, rides
  * alongside them.
  */
-export function MatchmakingClaimCard({ claim, positions, readiness, activeDebate, footer, onOpenClaim, ref }: Props) {
+export function MatchmakingClaimCard({
+  claim,
+  positions,
+  readiness,
+  activeDebate,
+  footer,
+  onOpenClaim,
+  hideReadinessToggle,
+  ref,
+}: Props) {
   // geo-chat can hand back a claim the graph has never seen. Responding to one is impossible, and
   // asking the graph about it fails the request, so don't offer or ask.
   const isOnGraph = isResolvableClaim(claim);
@@ -74,6 +89,7 @@ export function MatchmakingClaimCard({ claim, positions, readiness, activeDebate
           readiness={readiness}
           activeDebate={activeDebate}
           onOpenClaim={onOpenClaim}
+          hideReadinessToggle={hideReadinessToggle}
         />
       ) : (
         <UnresolvableControls
@@ -82,6 +98,7 @@ export function MatchmakingClaimCard({ claim, positions, readiness, activeDebate
           claim={claim}
           activeDebate={activeDebate}
           onOpenClaim={onOpenClaim}
+          hideReadinessToggle={hideReadinessToggle}
         />
       )}
 
@@ -144,12 +161,14 @@ function RespondableControls({
   readiness,
   activeDebate,
   onOpenClaim,
+  hideReadinessToggle,
 }: {
   claim: DebateClaimSummary;
   positions: DebateClaimPositionSummary[];
   readiness: MatchmakingReadiness;
   activeDebate?: boolean;
   onOpenClaim?: () => void;
+  hideReadinessToggle?: boolean;
 }) {
   const target = {
     entityId: claim.claim_entity_id,
@@ -213,13 +232,15 @@ function RespondableControls({
         isOnGraph
         onOpenClaim={onOpenClaim}
         toggle={
-          <ClaimReadinessToggle
-            claim={claim}
-            readiness={readiness}
-            activeDebate={activeDebate}
-            hasResponse={viewerPosition !== null}
-            responseIndexing={isPublishing}
-          />
+          hideReadinessToggle ? null : (
+            <ClaimReadinessToggle
+              claim={claim}
+              readiness={readiness}
+              activeDebate={activeDebate}
+              hasResponse={viewerPosition !== null}
+              responseIndexing={isPublishing}
+            />
+          )
         }
       />
       <PositionRow
@@ -248,12 +269,14 @@ function UnresolvableControls({
   readiness,
   activeDebate,
   onOpenClaim,
+  hideReadinessToggle,
 }: {
   claim: DebateClaimSummary;
   positions: DebateClaimPositionSummary[];
   readiness: MatchmakingReadiness;
   activeDebate?: boolean;
   onOpenClaim?: () => void;
+  hideReadinessToggle?: boolean;
 }) {
   return (
     <>
@@ -263,12 +286,14 @@ function UnresolvableControls({
         onOpenClaim={onOpenClaim}
         toggle={
           /* Readiness is geo-chat state, so it still works without a graph id. */
-          <ClaimReadinessToggle
-            claim={claim}
-            readiness={readiness}
-            activeDebate={activeDebate}
-            hasResponse={readiness.viewer_response !== null}
-          />
+          hideReadinessToggle ? null : (
+            <ClaimReadinessToggle
+              claim={claim}
+              readiness={readiness}
+              activeDebate={activeDebate}
+              hasResponse={readiness.viewer_response !== null}
+            />
+          )
         }
       />
       <PositionRow

--- a/apps/web/core/debates/matchmaking/matchmaking-claim-card.tsx
+++ b/apps/web/core/debates/matchmaking/matchmaking-claim-card.tsx
@@ -34,6 +34,11 @@ type Props = {
   activeDebate?: boolean;
   /** Rendered under the controls — e.g. the Matches tab's "Request debate" button. */
   footer?: React.ReactNode;
+  /**
+   * Replaces the claim's link to its entity page. The rematch picker opens the side panel instead:
+   * following a link there would navigate out of the app shell and abandon the live session.
+   */
+  onOpenClaim?: () => void;
   /** `AnimatePresence mode="popLayout"` measures the exiting row through this; without it the row
    * never pops out of flow and the rows above close the gap only after the fade finishes. */
   ref?: React.Ref<HTMLElement>;
@@ -53,7 +58,7 @@ export function isResolvableClaim(claim: Pick<DebateClaimSummary, 'space_id' | '
  * there are deliberately no separate vote arrows here. Readiness, the geo-chat half, rides
  * alongside them.
  */
-export function MatchmakingClaimCard({ claim, positions, readiness, activeDebate, footer, ref }: Props) {
+export function MatchmakingClaimCard({ claim, positions, readiness, activeDebate, footer, onOpenClaim, ref }: Props) {
   // geo-chat can hand back a claim the graph has never seen. Responding to one is impossible, and
   // asking the graph about it fails the request, so don't offer or ask.
   const isOnGraph = isResolvableClaim(claim);
@@ -63,9 +68,21 @@ export function MatchmakingClaimCard({ claim, positions, readiness, activeDebate
     // collapse to its content width as it fades.
     <motion.article ref={ref} {...hubCardMotion} className="w-full rounded-lg border border-grey-02 bg-white p-3">
       {isOnGraph ? (
-        <RespondableControls claim={claim} positions={positions} readiness={readiness} activeDebate={activeDebate} />
+        <RespondableControls
+          claim={claim}
+          positions={positions}
+          readiness={readiness}
+          activeDebate={activeDebate}
+          onOpenClaim={onOpenClaim}
+        />
       ) : (
-        <UnresolvableControls positions={positions} readiness={readiness} claim={claim} activeDebate={activeDebate} />
+        <UnresolvableControls
+          positions={positions}
+          readiness={readiness}
+          claim={claim}
+          activeDebate={activeDebate}
+          onOpenClaim={onOpenClaim}
+        />
       )}
 
       {footer}
@@ -82,11 +99,32 @@ function ClaimHeader({
   claim,
   isOnGraph,
   toggle,
+  onOpenClaim,
 }: {
   claim: DebateClaimSummary;
   isOnGraph: boolean;
   toggle: React.ReactNode;
+  onOpenClaim?: () => void;
 }) {
+  const openable = isOnGraph ? (
+    onOpenClaim ? (
+      <button type="button" onClick={onOpenClaim} className="mb-3 block text-left text-metadataMedium hover:underline">
+        {claim.claim}
+      </button>
+    ) : (
+      <Link
+        href={NavUtils.toEntity(claim.space_id, claim.claim_entity_id)}
+        className="mb-3 block text-metadataMedium hover:underline"
+      >
+        {claim.claim}
+      </Link>
+    )
+  ) : (
+    <Text as="p" variant="metadataMedium" className="mb-3">
+      {claim.claim}
+    </Text>
+  );
+
   return (
     <>
       {/* `items-start` so the chip stays put when the toggle stacks an explanation beneath it. */}
@@ -94,18 +132,7 @@ function ClaimHeader({
         <SpaceChip spaceId={claim.space_id} />
         {toggle}
       </div>
-      {isOnGraph ? (
-        <Link
-          href={NavUtils.toEntity(claim.space_id, claim.claim_entity_id)}
-          className="mb-3 block text-metadataMedium hover:underline"
-        >
-          {claim.claim}
-        </Link>
-      ) : (
-        <Text as="p" variant="metadataMedium" className="mb-3">
-          {claim.claim}
-        </Text>
-      )}
+      {openable}
     </>
   );
 }
@@ -116,11 +143,13 @@ function RespondableControls({
   positions,
   readiness,
   activeDebate,
+  onOpenClaim,
 }: {
   claim: DebateClaimSummary;
   positions: DebateClaimPositionSummary[];
   readiness: MatchmakingReadiness;
   activeDebate?: boolean;
+  onOpenClaim?: () => void;
 }) {
   const target = {
     entityId: claim.claim_entity_id,
@@ -182,6 +211,7 @@ function RespondableControls({
       <ClaimHeader
         claim={claim}
         isOnGraph
+        onOpenClaim={onOpenClaim}
         toggle={
           <ClaimReadinessToggle
             claim={claim}
@@ -217,17 +247,20 @@ function UnresolvableControls({
   positions,
   readiness,
   activeDebate,
+  onOpenClaim,
 }: {
   claim: DebateClaimSummary;
   positions: DebateClaimPositionSummary[];
   readiness: MatchmakingReadiness;
   activeDebate?: boolean;
+  onOpenClaim?: () => void;
 }) {
   return (
     <>
       <ClaimHeader
         claim={claim}
         isOnGraph={false}
+        onOpenClaim={onOpenClaim}
         toggle={
           /* Readiness is geo-chat state, so it still works without a graph id. */
           <ClaimReadinessToggle


### PR DESCRIPTION
Rebuilds the claim picker behind **debate again** and **debate this person** on the debates side panel's own components, per the [Figma design](https://www.figma.com/design/iWKsYButqqKWd1bqeBrUUj/Geo---Web?node-id=75123-430445&m=dev).

The two flows already share one surface — a profile challenge opens a rematch session with no source debate, and `DebateRematchPageClient` renders both — so this is one component, not two.

### What changed

| | before | after |
|---|---|---|
| Tabs | `All` · `Debate now` | `<first name>’s positions` (count) · `All`, opening on the opponent's |
| Filters | topic only, a bare `<select>` | space + topic, the hub's filter menus, spread to the design's width |
| Search | none | debounced |
| Rows | a local card | `MatchmakingClaimCard`, including its Debate toggle |
| Empty / loading / error | three ad-hoc blocks | `HubQueryState` |

Both tabs narrow by space, topic and search, and both keep Request debate wherever the two sides oppose.

#2134 landing first helped: the shared card's Debate toggle now sits in the header, exactly where the design puts it.

### Two things worth a look

**Readiness needed a new query.** The card's Debate toggle reads `viewer_debate_ready`, and the rematch claims response doesn't carry it — drawing the toggle off by default would misreport claims the viewer is actually standing ready on. It *is* on the per-space debate-claims endpoint, so `useDebateClaimsBySpaces` fans out one query per space on screen and the toggle renders against real state.

**The response stays optimistic.** The card being replaced read `optimisticResponse`; the hub card waits on the indexing snapshot. Feeding the optimistic copy in keeps the picked side highlighted and Request debate appearing immediately, rather than both lagging a refetch by seconds — this preserves today's behaviour rather than adding anything.

### Notes

- **Filtering is client-side.** The rematch claim list is session-scoped — it already drops the source debate's claim and anything recently rejected, and merges geo-chat's list with published claims from the graph — so there's no server query to push search/space/topic into the way the hub's Claims tab has.
- **Load more sits outside the empty state**, since fetching another page is exactly the way out when a filter empties the list.
- The hub card renders the claim as a link to its entity page rather than as a heading, so the picker loses the `<h2>` it had. That's what matching the hub costs.

### Verification

- 23 tests in `rematch-page-client.test.tsx` — the renamed tab and its count, first-name shortening, the default tab, space/topic/search narrowing, search surviving a tab switch, the Debate toggle against real readiness, and the optimistic side + Request debate.
- Sabotage-checked the two behavioural ones: reverting the optimistic read fails `reflects a just-picked side`, and hard-coding `viewer_debate_ready: false` fails the toggle test.
- Fixtures moved from readable slugs to well-formed ids — `isResolvableClaim` gates the card's response buttons on ids the graph would accept, so the old `'claim-shared'` fixtures would have rendered the read-only variant and quietly stopped testing responses.
- All debates suites: 514 tests pass. Two files fail to load (`media-session`, `debate-room-page-client`) — both fail identically on master with these changes stashed.
- Typecheck and prettier clean.

**Running these locally needs the pinned Node 23** from `.tool-versions`. Under Node 25 or Bun, `atomWithStorage` throws at import on a partial `localStorage` global and every suite reaching `matchmaking-claim-card` fails to load — unrelated to this change, but it now catches this file too.

### Not verified

Not exercised in the running app — reaching this screen needs a live rematch session or an accepted profile challenge.