### PR TITLE
feat(comments): open comments in a panel from any entity surface

### DIFF
--- a/apps/web/app/entry.tsx
+++ b/apps/web/app/entry.tsx
@@ -20,6 +20,7 @@ import { Persistence } from '~/core/state/persistence';
 import { ClientOnly } from '~/design-system/client-only';
 
 import { BrowseSidebar } from '~/partials/browse-sidebar/browse-sidebar';
+import { EntityCommentsPanelHost } from '~/partials/comments/entity-comments-panel-host';
 import { CreateSpaceDialog } from '~/partials/create-space/create-space-dialog';
 import { EntitySidePanel } from '~/partials/entity-page/entity-side-panel';
 import { FeatureFlagsDialog } from '~/partials/feature-flags/feature-flags-dialog';
@@ -127,6 +128,7 @@ export function App({ children }: { children: React.ReactNode }) {
           </div>
         </div>
         <EntitySidePanel />
+        <EntityCommentsPanelHost />
         {/* Client-side rendered due to `window.localStorage` usage */}
         <ClientOnly>
           <OnboardingDialog />

--- a/apps/web/atoms/index.ts
+++ b/apps/web/atoms/index.ts
@@ -16,6 +16,15 @@ export const entitySidePanelAtom = atom<EntitySidePanelTarget | null>(null);
 
 export const entitySidePanelHostElementAtom = atom<HTMLElement | null>(null);
 
+/**
+ * Entity whose comments are open in the global comments panel, or `null` when
+ * it's closed. Comment buttons appear on entities all over the app — explore
+ * cards, feed rows, data blocks — and everywhere except an entity's own full
+ * page they should open the comments beside what you're reading rather than
+ * navigate away from it.
+ */
+export const entityCommentsPanelAtom = atom<{ entityId: string; spaceId: string } | null>(null);
+
 export type DebatesHubTab = 'requests' | 'matches' | 'claims' | 'people';
 
 /** `null` while the debates matchmaking hub is closed. */

--- a/apps/web/core/hooks/use-entity-comments-panel.ts
+++ b/apps/web/core/hooks/use-entity-comments-panel.ts
@@ -1,5 +1,7 @@
 'use client';
 
+import * as React from 'react';
+
 import { useAtom } from 'jotai';
 
 import { entityCommentsPanelAtom } from '~/atoms';
@@ -12,9 +14,12 @@ import { entityCommentsPanelAtom } from '~/atoms';
 export function useEntityCommentsPanel() {
   const [target, setTarget] = useAtom(entityCommentsPanelAtom);
 
-  return {
-    commentsTarget: target,
-    openComments: (entityId: string, spaceId: string) => setTarget({ entityId, spaceId }),
-    closeComments: () => setTarget(null),
-  };
+  // Stable identities: the host keys a document-level listener off these.
+  const openComments = React.useCallback(
+    (entityId: string, spaceId: string) => setTarget({ entityId, spaceId }),
+    [setTarget]
+  );
+  const closeComments = React.useCallback(() => setTarget(null), [setTarget]);
+
+  return { commentsTarget: target, openComments, closeComments };
 }

--- a/apps/web/core/hooks/use-entity-comments-panel.ts
+++ b/apps/web/core/hooks/use-entity-comments-panel.ts
@@ -1,0 +1,20 @@
+'use client';
+
+import { useAtom } from 'jotai';
+
+import { entityCommentsPanelAtom } from '~/atoms';
+
+/**
+ * Opens the global comments panel for an entity. Use from any comment button
+ * that isn't on the entity's own full page — the panel keeps the reader where
+ * they are instead of navigating them to the entity.
+ */
+export function useEntityCommentsPanel() {
+  const [target, setTarget] = useAtom(entityCommentsPanelAtom);
+
+  return {
+    commentsTarget: target,
+    openComments: (entityId: string, spaceId: string) => setTarget({ entityId, spaceId }),
+    closeComments: () => setTarget(null),
+  };
+}

--- a/apps/web/partials/comments/entity-comments-button.tsx
+++ b/apps/web/partials/comments/entity-comments-button.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import * as React from 'react';
+
+import { useEntityCommentsPanel } from '~/core/hooks/use-entity-comments-panel';
+
+import { ExploreCommentsIcon } from '~/partials/explore/explore-comments-icon';
+
+/**
+ * Comment count + icon that opens the entity's comments in the global panel.
+ *
+ * For every surface that shows an entity it doesn't *own* — explore cards, feed
+ * rows, data-block rows — the reader should get the comments beside what
+ * they're reading. Only an entity's own full page renders comments inline
+ * instead. Rendered as a button rather than a link so nested row links (the
+ * card title, the row itself) don't swallow the click.
+ */
+export function EntityCommentsButton({
+  entityId,
+  spaceId,
+  count,
+  className,
+}: {
+  entityId: string;
+  spaceId: string;
+  count: number;
+  className?: string;
+}) {
+  const { openComments } = useEntityCommentsPanel();
+
+  return (
+    <button
+      type="button"
+      aria-label={`Comments (${count})`}
+      onClick={event => {
+        // These rows are commonly wrapped in a link to the entity.
+        event.preventDefault();
+        event.stopPropagation();
+        openComments(entityId, spaceId);
+      }}
+      className={className ?? 'inline-flex items-center gap-1.5 text-grey-04 transition-colors hover:text-text'}
+    >
+      <ExploreCommentsIcon className="text-grey-04" />
+      <span className="text-[14px] font-normal tabular-nums">{count}</span>
+    </button>
+  );
+}

--- a/apps/web/partials/comments/entity-comments-button.tsx
+++ b/apps/web/partials/comments/entity-comments-button.tsx
@@ -26,7 +26,8 @@ export function EntityCommentsButton({
   count: number;
   className?: string;
 }) {
-  const { openComments } = useEntityCommentsPanel();
+  const { commentsTarget, openComments } = useEntityCommentsPanel();
+  const isOpen = commentsTarget?.entityId === entityId;
 
   return (
     <button
@@ -35,6 +36,7 @@ export function EntityCommentsButton({
       // it to that entity rather than dismissing it as an outside click.
       data-entity-comments-opener
       aria-label={`Comments (${count})`}
+      aria-expanded={isOpen}
       onClick={event => {
         // These rows are commonly wrapped in a link to the entity.
         event.preventDefault();

--- a/apps/web/partials/comments/entity-comments-button.tsx
+++ b/apps/web/partials/comments/entity-comments-button.tsx
@@ -31,6 +31,9 @@ export function EntityCommentsButton({
   return (
     <button
       type="button"
+      // Marks this as an opener: clicking one while the panel is open switches
+      // it to that entity rather than dismissing it as an outside click.
+      data-entity-comments-opener
       aria-label={`Comments (${count})`}
       onClick={event => {
         // These rows are commonly wrapped in a link to the entity.

--- a/apps/web/partials/comments/entity-comments-panel-host.test.tsx
+++ b/apps/web/partials/comments/entity-comments-panel-host.test.tsx
@@ -1,0 +1,78 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+
+import { Provider, createStore } from 'jotai';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { EntityCommentsPanelHost } from './entity-comments-panel-host';
+import { entityCommentsPanelAtom } from '~/atoms';
+
+vi.mock('./entity-comments-panel', () => ({
+  EntityCommentsPanel: ({ entityId, onClose }: { entityId: string; onClose: () => void }) => (
+    <aside data-entity-comments-panel>
+      <span>Comments for {entityId}</span>
+      <button onClick={onClose}>Close</button>
+    </aside>
+  ),
+}));
+
+afterEach(cleanup);
+
+function renderHost() {
+  const store = createStore();
+  store.set(entityCommentsPanelAtom, { entityId: 'entity-1', spaceId: 'space-1' });
+  const view = render(
+    <Provider store={store}>
+      <div data-testid="page">Page behind the panel</div>
+      <EntityCommentsPanelHost />
+    </Provider>
+  );
+  return { store, view };
+}
+
+describe('EntityCommentsPanelHost', () => {
+  it('closes when the reader clicks the page behind it', () => {
+    const { store } = renderHost();
+    expect(screen.getByText('Comments for entity-1')).toBeInTheDocument();
+
+    fireEvent.pointerDown(screen.getByTestId('page'));
+
+    expect(store.get(entityCommentsPanelAtom)).toBeNull();
+  });
+
+  it('stays open for clicks inside the panel', () => {
+    const { store } = renderHost();
+
+    fireEvent.pointerDown(screen.getByText('Comments for entity-1'));
+
+    expect(store.get(entityCommentsPanelAtom)).not.toBeNull();
+  });
+
+  // Radix portals these out of the panel's DOM subtree, but to the reader they
+  // are part of it — dismissing on them would close the panel mid-interaction.
+  it('stays open for menus portalled out of the panel', () => {
+    const { store } = renderHost();
+    const menu = document.createElement('div');
+    menu.setAttribute('role', 'menu');
+    document.body.appendChild(menu);
+
+    fireEvent.pointerDown(menu);
+
+    expect(store.get(entityCommentsPanelAtom)).not.toBeNull();
+    menu.remove();
+  });
+
+  // Clicking another card's comment button should move the panel to that
+  // entity, not dismiss it and leave the reader with nothing.
+  it('stays open for another comment button, which switches it', () => {
+    const { store } = renderHost();
+    const opener = document.createElement('button');
+    opener.setAttribute('data-entity-comments-opener', '');
+    document.body.appendChild(opener);
+
+    fireEvent.pointerDown(opener);
+
+    expect(store.get(entityCommentsPanelAtom)).not.toBeNull();
+    opener.remove();
+  });
+});

--- a/apps/web/partials/comments/entity-comments-panel-host.test.tsx
+++ b/apps/web/partials/comments/entity-comments-panel-host.test.tsx
@@ -7,6 +7,11 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { EntityCommentsPanelHost } from './entity-comments-panel-host';
 import { entityCommentsPanelAtom } from '~/atoms';
 
+const pathname = { current: '/explore' };
+vi.mock('next/navigation', () => ({
+  usePathname: () => pathname.current,
+}));
+
 vi.mock('./entity-comments-panel', () => ({
   EntityCommentsPanel: ({ entityId, onClose }: { entityId: string; onClose: () => void }) => (
     <aside data-entity-comments-panel>
@@ -16,7 +21,10 @@ vi.mock('./entity-comments-panel', () => ({
   ),
 }));
 
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  pathname.current = '/explore';
+});
 
 function renderHost() {
   const store = createStore();
@@ -74,5 +82,21 @@ describe('EntityCommentsPanelHost', () => {
 
     expect(store.get(entityCommentsPanelAtom)).not.toBeNull();
     opener.remove();
+  });
+
+  // Browser back, a keyboard-activated link, or programmatic routing produce no
+  // outside pointerdown, so without this the panel rides along to the next page.
+  it('closes when the reader navigates', () => {
+    const { store, view } = renderHost();
+
+    pathname.current = '/space/space-1/entity-2';
+    view.rerender(
+      <Provider store={store}>
+        <div data-testid="page">Page behind the panel</div>
+        <EntityCommentsPanelHost />
+      </Provider>
+    );
+
+    expect(store.get(entityCommentsPanelAtom)).toBeNull();
   });
 });

--- a/apps/web/partials/comments/entity-comments-panel-host.tsx
+++ b/apps/web/partials/comments/entity-comments-panel-host.tsx
@@ -2,6 +2,7 @@
 
 import * as React from 'react';
 
+import { usePathname } from 'next/navigation';
 import { createPortal } from 'react-dom';
 
 import { useEntityCommentsPanel } from '~/core/hooks/use-entity-comments-panel';
@@ -21,6 +22,19 @@ export function EntityCommentsPanelHost() {
   const [mounted, setMounted] = React.useState(false);
 
   React.useEffect(() => setMounted(true), []);
+
+  // Navigating has taken the reader somewhere they asked to go — a card title,
+  // browser back, a keyboard link — and none of those routes produce the outside
+  // pointerdown below, so the overlay would sit over the destination (and could
+  // double up with the debates feed's own docked panel). Only on a change:
+  // closing on mount would shut the panel the moment it opened.
+  const pathname = usePathname();
+  const lastPathnameRef = React.useRef(pathname);
+  React.useEffect(() => {
+    if (lastPathnameRef.current === pathname) return;
+    lastPathnameRef.current = pathname;
+    closeComments();
+  }, [closeComments, pathname]);
 
   // Dismiss on a click outside the panel. Capture phase so it still fires when a
   // card's own handler stops propagation. Exempt: the panel itself; comment

--- a/apps/web/partials/comments/entity-comments-panel-host.tsx
+++ b/apps/web/partials/comments/entity-comments-panel-host.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import * as React from 'react';
+
+import { createPortal } from 'react-dom';
+
+import { useEntityCommentsPanel } from '~/core/hooks/use-entity-comments-panel';
+
+import { EntityCommentsPanel } from './entity-comments-panel';
+
+/**
+ * App-level host for the comments panel, mounted once beside EntitySidePanel so
+ * a comment button on any surface — explore cards, feed rows, data blocks — can
+ * open comments without that surface having to own panel state or layout.
+ *
+ * Portalled to the body so an overflow-hidden or transformed ancestor (feed
+ * cards sit inside plenty of both) can't clip or contain the fixed panel.
+ */
+export function EntityCommentsPanelHost() {
+  const { commentsTarget, closeComments } = useEntityCommentsPanel();
+  const [mounted, setMounted] = React.useState(false);
+
+  React.useEffect(() => setMounted(true), []);
+
+  if (!mounted || !commentsTarget) return null;
+
+  return createPortal(
+    <EntityCommentsPanel
+      entityId={commentsTarget.entityId}
+      spaceId={commentsTarget.spaceId}
+      onClose={closeComments}
+      presentation="overlay"
+    />,
+    document.body
+  );
+}

--- a/apps/web/partials/comments/entity-comments-panel-host.tsx
+++ b/apps/web/partials/comments/entity-comments-panel-host.tsx
@@ -22,6 +22,32 @@ export function EntityCommentsPanelHost() {
 
   React.useEffect(() => setMounted(true), []);
 
+  // Dismiss on a click outside the panel. Capture phase so it still fires when a
+  // card's own handler stops propagation. Exempt: the panel itself; comment
+  // buttons, which switch the panel to their entity instead of closing it; the
+  // entity side panel, which opens on top from a comment author's name; and
+  // anything Radix portals out of the panel (the sort/filter menus) or any
+  // dialog, which live outside the panel in the DOM but not to the reader.
+  React.useEffect(() => {
+    if (!commentsTarget) return;
+
+    const onPointerDown = (event: PointerEvent) => {
+      const target = event.target;
+      if (!(target instanceof Element)) return;
+      if (
+        target.closest(
+          '[data-entity-comments-panel], [data-entity-comments-opener], [data-entity-side-panel], [data-radix-popper-content-wrapper], [data-radix-portal], [role="dialog"], [role="menu"], [role="listbox"]'
+        )
+      ) {
+        return;
+      }
+      closeComments();
+    };
+
+    document.addEventListener('pointerdown', onPointerDown, true);
+    return () => document.removeEventListener('pointerdown', onPointerDown, true);
+  }, [commentsTarget, closeComments]);
+
   if (!mounted || !commentsTarget) return null;
 
   return createPortal(

--- a/apps/web/partials/comments/entity-comments-panel.test.tsx
+++ b/apps/web/partials/comments/entity-comments-panel.test.tsx
@@ -1,0 +1,52 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup, fireEvent, render } from '@testing-library/react';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { EntityCommentsPanel } from './entity-comments-panel';
+
+vi.mock('~/core/hooks/use-comments', () => ({
+  useComments: () => ({ comments: [], totalCount: 3, isLoading: false, error: null, refetch: vi.fn() }),
+}));
+
+vi.mock('./comments-section', () => ({
+  CommentSection: () => <div>Comment section</div>,
+}));
+
+afterEach(cleanup);
+
+describe('EntityCommentsPanel', () => {
+  it('closes on Escape', () => {
+    const onClose = vi.fn();
+    render(<EntityCommentsPanel entityId="entity-1" spaceId="space-1" onClose={onClose} />);
+
+    fireEvent.keyDown(window, { key: 'Escape' });
+
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  // Opening a comment author's profile stacks the entity side panel above this
+  // one. Both listen on the window, so without deferring, a single press would
+  // dismiss both layers at once instead of just the one on top.
+  it('leaves Escape to the entity side panel stacked above it', () => {
+    const onClose = vi.fn();
+    const sidePanel = document.createElement('aside');
+    sidePanel.setAttribute('data-entity-side-panel', '');
+    document.body.appendChild(sidePanel);
+
+    render(<EntityCommentsPanel entityId="entity-1" spaceId="space-1" onClose={onClose} />);
+    fireEvent.keyDown(window, { key: 'Escape' });
+
+    expect(onClose).not.toHaveBeenCalled();
+    sidePanel.remove();
+  });
+
+  it('ignores Escape while composing text', () => {
+    const onClose = vi.fn();
+    render(<EntityCommentsPanel entityId="entity-1" spaceId="space-1" onClose={onClose} />);
+
+    fireEvent.keyDown(window, { key: 'Escape', isComposing: true });
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/partials/comments/entity-comments-panel.tsx
+++ b/apps/web/partials/comments/entity-comments-panel.tsx
@@ -2,6 +2,8 @@
 
 import * as React from 'react';
 
+import cx from 'classnames';
+
 import { useComments } from '~/core/hooks/use-comments';
 
 import { Close } from '~/design-system/icons/close';
@@ -10,22 +12,25 @@ import { Text } from '~/design-system/text';
 import { CommentSection } from '~/partials/comments/comments-section';
 
 /**
- * "Comments" side panel for any entity — opened from the debates feed's comment
- * button today, and intended for other feeds (explore) next. It hosts the same
- * CommentSection entity pages use, so threads, replies, votes, editing and the
- * debater winner-pick chips behave identically wherever it's mounted.
+ * "Comments" side panel for any entity. It hosts the same CommentSection entity
+ * pages use, so threads, replies, votes, editing and the debater winner-pick
+ * chips behave identically wherever it's mounted.
  *
- * Desktop docks it beside the host surface; mobile presents it as a bottom sheet
- * per the design (NB: breakpoints here are desktop-first, so md: targets mobile).
+ * `docked` (the debates feed) lays it out as a flex sibling that takes its own
+ * column; `overlay` (EntityCommentsPanelHost, for comment buttons anywhere else)
+ * pins it to the right edge above the page. Mobile is a bottom sheet either way
+ * (NB: breakpoints here are desktop-first, so md: targets mobile).
  */
 export function EntityCommentsPanel({
   entityId,
   spaceId,
   onClose,
+  presentation = 'docked',
 }: {
   entityId: string;
   spaceId: string;
   onClose: () => void;
+  presentation?: 'docked' | 'overlay';
 }) {
   // Same arguments as the host's own count query, so posting here updates it.
   const { totalCount } = useComments({ entityId, spaceId });
@@ -39,7 +44,15 @@ export function EntityCommentsPanel({
   }, [onClose]);
 
   return (
-    <aside className="flex w-[360px] shrink-0 flex-col border-l border-divider bg-white md:fixed md:inset-x-0 md:top-auto md:bottom-0 md:z-[80] md:h-[85dvh] md:w-full md:rounded-t-[16px] md:border-t md:border-l-0">
+    <aside
+      className={cx(
+        'flex w-[360px] shrink-0 flex-col border-l border-divider bg-white',
+        'md:fixed md:inset-x-0 md:top-auto md:bottom-0 md:z-[80] md:h-[85dvh] md:w-full md:rounded-t-[16px] md:border-t md:border-l-0',
+        // Above the page but below the entity side panel (z-200), which can be
+        // opened on top of it from a comment author's name.
+        presentation === 'overlay' && 'shadow-2xl fixed inset-y-0 right-0 z-[150] md:inset-y-auto'
+      )}
+    >
       <header className="flex items-center justify-between px-5 py-4">
         <Text as="h2" variant="cardEntityTitle" color="text">
           Comments · {totalCount}

--- a/apps/web/partials/comments/entity-comments-panel.tsx
+++ b/apps/web/partials/comments/entity-comments-panel.tsx
@@ -45,6 +45,7 @@ export function EntityCommentsPanel({
 
   return (
     <aside
+      data-entity-comments-panel
       className={cx(
         'flex w-[360px] shrink-0 flex-col border-l border-divider bg-white',
         'md:fixed md:inset-x-0 md:top-auto md:bottom-0 md:z-[80] md:h-[85dvh] md:w-full md:rounded-t-[16px] md:border-t md:border-l-0',

--- a/apps/web/partials/comments/entity-comments-panel.tsx
+++ b/apps/web/partials/comments/entity-comments-panel.tsx
@@ -37,7 +37,13 @@ export function EntityCommentsPanel({
 
   React.useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') onClose();
+      if (event.key !== 'Escape' || event.isComposing || event.defaultPrevented) return;
+      // The entity side panel opens on top of this one (from a comment author's
+      // name) and has its own Escape handler. Both listen on the window, so
+      // without this one press would dismiss both layers at once — leave it to
+      // the top layer and close on the next press.
+      if (document.querySelector('[data-entity-side-panel]')) return;
+      onClose();
     };
     window.addEventListener('keydown', onKeyDown);
     return () => window.removeEventListener('keydown', onKeyDown);

--- a/apps/web/partials/explore/debate-explore-feed-card.tsx
+++ b/apps/web/partials/explore/debate-explore-feed-card.tsx
@@ -19,10 +19,10 @@ import { NavUtils } from '~/core/utils/utils';
 import { PrefetchLink as Link } from '~/design-system/prefetch-link';
 import { Tooltip } from '~/design-system/tooltip';
 
+import { EntityCommentsButton } from '~/partials/comments/entity-comments-button';
 import { EntityRowActions } from '~/partials/entity-page/entity-row-actions';
 
 import { ExploreClaimsIcon } from './explore-claims-icon';
-import { ExploreCommentsIcon } from './explore-comments-icon';
 import { ExploreJoinSpaceButton } from './explore-join-space-button';
 import { ExploreShareIcon } from './explore-share-icon';
 import { SpaceThumb } from './space-thumb';
@@ -102,7 +102,10 @@ export function DebateExploreFeedCard({
   const processed = hasProcessedVideo(mediaQuery.data);
 
   const notWatchable =
-    debateQuery.isError || (debate != null && !watchable) || mediaQuery.isError || (mediaQuery.data != null && !processed);
+    debateQuery.isError ||
+    (debate != null && !watchable) ||
+    mediaQuery.isError ||
+    (mediaQuery.data != null && !processed);
 
   if (!debatesEnabled || notWatchable) {
     return <>{fallback}</>;
@@ -110,7 +113,6 @@ export function DebateExploreFeedCard({
 
   const readyDebate = debate != null && watchable && processed ? debate : null;
   const timeAgo = formatExploreRelativeTime(item.createdAtSec);
-  const entityHref = `${NavUtils.toEntity(item.spaceId, item.entityId)}#entity-comments`;
 
   return (
     <article ref={setContainer} className="flex flex-col gap-2 border-b border-divider py-4 last:border-b-0">
@@ -161,10 +163,7 @@ export function DebateExploreFeedCard({
       </div>
 
       <EntityRowActions entityId={item.entityId} spaceId={item.spaceId} className="mt-1">
-        <Link href={entityHref} className="inline-flex items-center gap-1.5 text-grey-04 transition-colors hover:text-text">
-          <ExploreCommentsIcon className="text-grey-04" />
-          <span className="text-[14px] font-normal tabular-nums">{item.commentCount}</span>
-        </Link>
+        <EntityCommentsButton entityId={item.entityId} spaceId={item.spaceId} count={item.commentCount} />
         {readyDebate ? <DebateCardExtras debate={readyDebate} active={active} /> : null}
       </EntityRowActions>
     </article>

--- a/apps/web/partials/explore/explore-feed-card.test.tsx
+++ b/apps/web/partials/explore/explore-feed-card.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 
 import type React from 'react';
 
@@ -26,6 +26,11 @@ vi.mock('~/partials/entity-page/entity-row-actions', () => ({
 
 vi.mock('./explore-join-space-button', () => ({
   ExploreJoinSpaceButton: () => null,
+}));
+
+const openComments = vi.fn();
+vi.mock('~/core/hooks/use-entity-comments-panel', () => ({
+  useEntityCommentsPanel: () => ({ commentsTarget: null, openComments, closeComments: vi.fn() }),
 }));
 
 vi.mock('./debate-explore-feed-card', () => ({
@@ -78,5 +83,17 @@ describe('ExploreFeedCard', () => {
   it('does not route non-debate items to the debate card', () => {
     render(<ExploreFeedCard item={item} />);
     expect(screen.queryByTestId('debate-card')).toBeNull();
+  });
+
+  // Reading a card is not the same as wanting the entity's page: comments open
+  // beside the feed rather than navigating the reader away from it.
+  it('opens the comments panel for the card instead of linking to the entity page', () => {
+    render(<ExploreFeedCard item={item} />);
+
+    const commentsButton = screen.getByRole('button', { name: 'Comments (2)' });
+    expect(commentsButton.closest('a')).toBeNull();
+
+    fireEvent.click(commentsButton);
+    expect(openComments).toHaveBeenCalledWith('claim-1', 'space-1');
   });
 });

--- a/apps/web/partials/explore/explore-feed-card.tsx
+++ b/apps/web/partials/explore/explore-feed-card.tsx
@@ -13,10 +13,10 @@ import { NavUtils } from '~/core/utils/utils';
 import { FallbackImage } from '~/design-system/fallback-image';
 import { PrefetchLink as Link } from '~/design-system/prefetch-link';
 
+import { EntityCommentsButton } from '~/partials/comments/entity-comments-button';
 import { EntityRowActions } from '~/partials/entity-page/entity-row-actions';
 
 import { DebateExploreFeedCard } from './debate-explore-feed-card';
-import { ExploreCommentsIcon } from './explore-comments-icon';
 import { ExploreJoinSpaceButton } from './explore-join-space-button';
 import { SpaceThumb } from './space-thumb';
 
@@ -62,8 +62,6 @@ function BaseExploreFeedCard({ item, hideSpaceLink = false, hideJoinButton = fal
     return out;
   }, [item.types]);
   const timeAgo = formatExploreRelativeTime(item.createdAtSec);
-
-  const entityHref = `${NavUtils.toEntity(item.spaceId, item.entityId)}#entity-comments`;
 
   return (
     <article className="flex flex-col gap-2 border-b border-divider py-4 last:border-b-0">
@@ -113,13 +111,7 @@ function BaseExploreFeedCard({ item, hideSpaceLink = false, hideJoinButton = fal
             </p>
           ) : null}
           <EntityRowActions entityId={item.entityId} spaceId={item.spaceId} className="mt-1">
-            <Link
-              href={entityHref}
-              className="inline-flex items-center gap-1.5 text-grey-04 transition-colors hover:text-text"
-            >
-              <ExploreCommentsIcon className="text-grey-04" />
-              <span className="text-[14px] font-normal tabular-nums">{item.commentCount}</span>
-            </Link>
+            <EntityCommentsButton entityId={item.entityId} spaceId={item.spaceId} count={item.commentCount} />
           </EntityRowActions>
         </div>
         {item.imageUrl ? (


### PR DESCRIPTION
## What

A comment button on an explore card (and, in future, a feed row or data-block row) sits on an entity that surface doesn't own. Today those buttons link to `/entity#entity-comments`, so reading two replies costs the reader their place in the feed. Everywhere except an entity's own full page, comments now open in a panel beside what they're reading — the same panel and behaviour the fullscreen debates feed got in #2133.

## How

Mirrors the existing `EntitySidePanel` pattern, so no surface has to own panel state or layout:

- **`entityCommentsPanelAtom`** holds `{ entityId, spaceId } | null`.
- **`useEntityCommentsPanel()`** exposes `openComments` / `closeComments`.
- **`EntityCommentsPanelHost`** is mounted once in `entry.tsx` beside `EntitySidePanel`, portalled to `document.body` — feed cards sit inside plenty of `overflow-hidden` and transformed ancestors, either of which would clip or contain a fixed panel.
- **`EntityCommentsPanel`** gains a `presentation` prop. `docked` keeps the debates feed's flex-sibling column exactly as it was; `overlay` pins it to the right edge at `z-150` — above the page, below the entity side panel (`z-200`) that a comment author's name can open on top of it. Mobile stays a bottom sheet either way.
- **`EntityCommentsButton`** (icon + count) is the shared affordance, used by both explore cards in place of their links. It's a `button`, not a link, and stops propagation so the surrounding card link doesn't swallow the click.

Because the panel hosts the same `CommentSection` entity pages use, threads, replies, votes, editing, sign-in prompting and the debater winner-pick chips all behave identically to everywhere else.

## Scope note

The ask mentioned data blocks, but data blocks (`table-block-table`, ranking list/gallery views) render `EntityRowActions` with vote and debate actions only — **there's no comment button there today**, so nothing changed. Adding one is now `<EntityCommentsButton entityId spaceId count />` in that row's actions; the open question is where the per-row count comes from, since data blocks don't fetch one.

## Testing

- New test: the explore card renders a comments button (not a link) and opens the panel with the card's entity/space instead of navigating.
- Explore, comments and debates-browse suites pass; `next build` (with type check) and eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)