### PR TITLE
fix(debates): hide the navbar Debates button from signed-out visitors

### DIFF
--- a/apps/web/core/debates/matchmaking/debates-hub-button.test.tsx
+++ b/apps/web/core/debates/matchmaking/debates-hub-button.test.tsx
@@ -1,0 +1,93 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+
+import { Provider, createStore } from 'jotai';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { DebatesHubButton } from './debates-hub-button';
+import { debatesHubAtom } from '~/atoms';
+
+const mocks = vi.hoisted(() => ({
+  debatesEnabled: true,
+  ready: true,
+  authenticated: true,
+  incomingRequestCount: 0,
+}));
+
+vi.mock('~/core/state/feature-flags', () => ({ useDebatesEnabled: () => mocks.debatesEnabled }));
+
+vi.mock('../hooks', () => ({
+  useGeoChatAuth: () => ({ ready: mocks.ready, authenticated: mocks.authenticated, accountKey: 'user-a' }),
+  useDebateActivity: () => ({ data: { incoming_request_count: mocks.incomingRequestCount } }),
+}));
+
+vi.mock('./hooks', () => ({
+  useDebateRequests: () => ({ data: undefined, isLoading: false, error: null }),
+}));
+
+function renderButton() {
+  return render(
+    <Provider store={createStore()}>
+      <DebatesHubButton />
+    </Provider>
+  );
+}
+
+beforeEach(() => {
+  mocks.debatesEnabled = true;
+  mocks.ready = true;
+  mocks.authenticated = true;
+  mocks.incomingRequestCount = 0;
+});
+
+afterEach(cleanup);
+
+describe('DebatesHubButton', () => {
+  it('shows for a signed-in user', () => {
+    renderButton();
+    expect(screen.getByRole('button', { name: 'Debates' })).toBeInTheDocument();
+  });
+
+  it('stays hidden for a signed-out visitor', () => {
+    mocks.authenticated = false;
+    renderButton();
+    // The hub is the only opener for the panel, and every tab behind it needs an identity.
+    expect(screen.queryByRole('button', { name: /Debates/ })).not.toBeInTheDocument();
+  });
+
+  it('stays hidden until Privy has restored the session', () => {
+    // `authenticated` is false while Privy is still resolving, so a returning user sees the button
+    // appear late rather than watching it flash in and out.
+    mocks.ready = false;
+    mocks.authenticated = false;
+    renderButton();
+
+    expect(screen.queryByRole('button', { name: /Debates/ })).not.toBeInTheDocument();
+  });
+
+  it('stays hidden when debates are switched off, even signed in', () => {
+    mocks.debatesEnabled = false;
+    renderButton();
+    expect(screen.queryByRole('button', { name: /Debates/ })).not.toBeInTheDocument();
+  });
+
+  it('keeps announcing the pending request count while signed in', () => {
+    mocks.incomingRequestCount = 3;
+    renderButton();
+
+    expect(screen.getByRole('button', { name: 'Debates, 3 pending requests' })).toBeInTheDocument();
+    expect(screen.getByText('3')).toBeInTheDocument();
+  });
+
+  it('leaves the hub closed when there is no button to open it', () => {
+    mocks.authenticated = false;
+    const store = createStore();
+    render(
+      <Provider store={store}>
+        <DebatesHubButton />
+      </Provider>
+    );
+
+    expect(store.get(debatesHubAtom)).toBeNull();
+  });
+});

--- a/apps/web/core/debates/matchmaking/debates-hub-button.tsx
+++ b/apps/web/core/debates/matchmaking/debates-hub-button.tsx
@@ -8,17 +8,22 @@ import { useDebatesEnabled } from '~/core/state/feature-flags';
 
 import { Megaphone } from '~/design-system/icons/megaphone';
 
-import { useDebateActivity } from '../hooks';
+import { useDebateActivity, useGeoChatAuth } from '../hooks';
 import { useDebateRequests } from './hooks';
 import { useDebatesHub } from './use-debates-hub';
 import { useUnexpiredRequests } from './use-request-countdown';
 
 /**
- * Navbar entry point for the matchmaking hub. Visible to every user once debates are enabled —
- * including those who are not available to debate, since the hub is where they turn it on.
+ * Navbar entry point for the matchmaking hub. Shown to signed-in users once debates are enabled —
+ * including those who are not available to debate, since the hub is where they turn it on. Every
+ * tab behind it is geo-chat data that needs an identity, so a signed-out visitor has nothing to
+ * open it for.
  */
 export function DebatesHubButton() {
   const isDebatesEnabled = useDebatesEnabled();
+  // False until Privy has restored the session, so the button stays hidden until we actually know
+  // — appearing late beats flashing in and out for someone who was never signed in.
+  const { authenticated } = useGeoChatAuth();
   const { isOpen, toggle } = useDebatesHub();
   const { data: activity } = useDebateActivity(isDebatesEnabled);
   // Read-only: the coordinator already fetches this list whenever there is anything in it, and the
@@ -26,7 +31,7 @@ export function DebatesHubButton() {
   const { data: requests } = useDebateRequests(false);
   const incoming = useUnexpiredRequests(requests?.incoming ?? []);
 
-  if (!isDebatesEnabled) return null;
+  if (!isDebatesEnabled || !authenticated) return null;
 
   const requestCount = requests ? incoming.length : (activity?.incoming_request_count ?? 0);
 


### PR DESCRIPTION
## What

The Debates (megaphone) button in the navbar showed for everyone once the feature flag was on, including signed-out visitors. It now renders only when the viewer is authenticated.

Every tab behind the hub is geo-chat data that requires an identity — the panel itself already recognises this and answers `Sign in to find people to debate.` — so the button was offering signed-out visitors a control with nothing behind it.

## How

One condition in `DebatesHubButton`, gated on `authenticated` from `useGeoChatAuth` (the same signal every debates query already gates on, and the one the hub panel uses).

Gating on `authenticated` rather than `ready` is deliberate: `authenticated` is false while Privy restores the session, so the button stays hidden until we actually know. A returning user sees it appear a beat late instead of everyone watching it flash in and straight back out. The button's tree already calls `useGeoChatAuth` via `useDebateActivity`, so this adds no new work.

## Notes for review

- **The button is the panel's only opener** (`useDebatesHub` has exactly two consumers: this button and the panel). So a visitor who was never signed in can no longer reach the panel at all, and its `Sign in to find people to debate.` branch is now only reachable by signing out with the hub already open. I left that branch and its test alone — it still covers that transition.
- **I considered auto-closing the hub on sign-out** and decided against it. It looked necessary because the desktop aside has no close button of its own, but it doesn't need one: the outside-pointerdown handler closes it on any click outside, and the mobile sheet has a close button, backdrop tap, and drag-to-dismiss. Auto-closing would also have made the signed-out message unreachable and broken the existing test asserting it. Happy to add it if you'd rather signing out dismissed the panel outright — say the word.

## Test plan

- New `debates-hub-button.test.tsx`: signed-in shows, signed-out hides, hidden through Privy's pre-`ready` window, still hidden when the flag is off, request-count badge/aria unaffected, and the hub atom stays closed with no button to open it. **Verified these are real guards** — the two visibility tests fail against the previous condition.
- `bun run vitest run core/debates/matchmaking`: 28 tests pass, 0 failures.
- `bun run build` passes (type check included).
- Caveat: 6 of the 11 matchmaking suites don't load on my machine — Node's built-in webstorage shadows jsdom's `localStorage` (`--localstorage-file` warning), which kills anything importing `pending-personal-space`. Identical on pristine master, unrelated to this change, but those suites need CI to confirm.
- Not checked in a browser; the signed-out navbar is worth a glance before this goes in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)