### PR TITLE
feat(debates): stop interrupting the sender of a debate request

### DIFF
--- a/apps/web/core/debates/debate-challenge-dialog.tsx
+++ b/apps/web/core/debates/debate-challenge-dialog.tsx
@@ -10,27 +10,27 @@ import { useScrollLock } from './use-scroll-lock';
 
 type DebateChallengeDialogProps = {
   challenge: DebateChallenge;
-  /** The sender sees a waiting state; only the recipient can accept. */
-  role: 'requester' | 'recipient';
   busy: boolean;
   error: string | null;
   onAccept: () => void;
-  /** Answers the challenge for good — rejecting it as the recipient, cancelling it as the sender. */
+  /** Rejects the challenge for good. */
   onReject: () => void;
   /** Closes this popup and nothing else. The challenge stays live in the hub's Requests tab. */
   onNotNow: () => void;
 };
 
 /**
- * The claimless debate request sent from someone's profile. Accepting drops both
- * people into the claim picker to choose one.
+ * The claimless debate request sent from someone's profile, shown to the person it was sent to.
+ * Accepting drops both people into the claim picker to choose one.
+ *
+ * Only the recipient is interrupted: the sender has nothing to decide, so their challenge waits
+ * in the hub's Requests tab under Sent rather than behind a modal.
  *
  * Turning it down and putting it off are deliberately separate: a challenge lives until it
  * expires, so "Not now" only closes this popup, and rejecting is the text action underneath.
  */
 export function DebateChallengeDialog({
   challenge,
-  role,
   busy,
   error,
   onAccept,
@@ -38,9 +38,8 @@ export function DebateChallengeDialog({
   onNotNow,
 }: DebateChallengeDialogProps) {
   const titleId = React.useId();
-  const isRecipient = role === 'recipient';
-  const you = isRecipient ? challenge.recipient : challenge.requester;
-  const other = isRecipient ? challenge.requester : challenge.recipient;
+  const you = challenge.recipient;
+  const other = challenge.requester;
 
   useScrollLock();
 
@@ -81,47 +80,31 @@ export function DebateChallengeDialog({
         )}
 
         <footer className="grid gap-5">
-          {isRecipient ? (
-            <div className="grid grid-cols-2 gap-2">
-              <button
-                type="button"
-                onClick={onNotNow}
-                disabled={busy}
-                className="flex h-7 w-full items-center justify-center rounded-full border border-grey-02 bg-white px-4 text-metadata text-text transition-colors hover:bg-grey-01 disabled:opacity-50"
-              >
-                Not now
-              </button>
-              <button
-                type="button"
-                onClick={onAccept}
-                disabled={busy}
-                className="flex h-7 w-full items-center justify-center rounded-full bg-text px-4 text-metadata text-white transition-colors hover:bg-text/90 disabled:opacity-50"
-              >
-                Explore claims
-              </button>
-            </div>
-          ) : (
-            <>
-              <Text as="p" variant="body" color="grey-04" className="text-center">
-                Waiting for {participantName(other)} to accept...
-              </Text>
-              <button
-                type="button"
-                onClick={onNotNow}
-                disabled={busy}
-                className="flex h-7 w-full items-center justify-center rounded-full border border-grey-02 bg-white px-4 text-metadata text-text transition-colors hover:bg-grey-01 disabled:opacity-50"
-              >
-                Not now
-              </button>
-            </>
-          )}
+          <div className="grid grid-cols-2 gap-2">
+            <button
+              type="button"
+              onClick={onNotNow}
+              disabled={busy}
+              className="flex h-7 w-full items-center justify-center rounded-full border border-grey-02 bg-white px-4 text-metadata text-text transition-colors hover:bg-grey-01 disabled:opacity-50"
+            >
+              Not now
+            </button>
+            <button
+              type="button"
+              onClick={onAccept}
+              disabled={busy}
+              className="flex h-7 w-full items-center justify-center rounded-full bg-text px-4 text-metadata text-white transition-colors hover:bg-text/90 disabled:opacity-50"
+            >
+              Explore claims
+            </button>
+          </div>
           <button
             type="button"
             onClick={onReject}
             disabled={busy}
             className="mx-auto -mt-3 px-4 py-1 text-metadata text-grey-04 underline hover:text-text disabled:opacity-50"
           >
-            {isRecipient ? 'Reject request' : 'Cancel request'}
+            Reject request
           </button>
         </footer>
       </section>

--- a/apps/web/core/debates/debate-coordinator.test.tsx
+++ b/apps/web/core/debates/debate-coordinator.test.tsx
@@ -222,6 +222,40 @@ describe('DebateCoordinator', () => {
     expect(mocks.acceptRequestMutate).not.toHaveBeenCalled();
   });
 
+  // A claimless challenge interrupts the person who has to answer it, and nobody else. The sender
+  // has no decision to make, so their copy lives under Sent in the hub's Requests tab.
+  it('prompts the recipient of a claimless challenge', async () => {
+    mocks.currentUserId = 'user-recipient';
+    mocks.activity = { ...idleActivity(), challenge: pendingChallenge() };
+
+    render(<DebateCoordinator />);
+
+    expect(await screen.findByText('Debate request')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Explore claims' })).toBeInTheDocument();
+  });
+
+  it('does not interrupt the sender of a challenge while it waits to be answered', async () => {
+    mocks.currentUserId = 'user-requester';
+    mocks.activity = { ...idleActivity(), challenge: pendingChallenge() };
+
+    render(<DebateCoordinator />);
+
+    await waitFor(() => expect(screen.queryByText('Debate request')).not.toBeInTheDocument());
+    expect(screen.queryByText(/Waiting for .* to accept/)).not.toBeInTheDocument();
+  });
+
+  // The sender learns it was accepted the same way every other flow does: activity gains a rematch
+  // and the routing effect walks them into the claim picker. No popup is involved either way.
+  it('routes the sender into the claim picker once the challenge is accepted', async () => {
+    mocks.currentUserId = 'user-requester';
+    mocks.pathname = '/space/space-1/claims';
+    mocks.activity = { ...activityWithRematch('browsing'), challenge: null };
+
+    render(<DebateCoordinator />);
+
+    await waitFor(() => expect(mocks.push).toHaveBeenCalledWith('/space/space-1/debates/rematches/rematch-1'));
+  });
+
   it('does not prompt for a request while a debate is under way', async () => {
     mocks.pathname = '/space/space-1/claims';
     mocks.activity = { ...activityWithDebate(), incoming_request_count: 1 };
@@ -723,6 +757,27 @@ function idleActivity(): DebateActivity {
     rematch: null,
     challenge: null,
   };
+}
+
+function pendingChallenge() {
+  const party = (userId: string, name: string) => ({
+    user_id: userId,
+    profile_space_id: `space-${userId}`,
+    display_name: name,
+    avatar_cid: null,
+  });
+
+  return {
+    id: 'challenge-1',
+    status: 'pending',
+    source_space_id: 'space-1',
+    requester: party('user-requester', 'Ada'),
+    recipient: party('user-recipient', 'Grace'),
+    rematch_session_id: null,
+    created_at: '2026-08-12T11:00:00.000Z',
+    // Comfortably ahead of the countdown filter, which drops expired challenges before they prompt.
+    expires_at: '2099-01-01T00:00:00.000Z',
+  } as DebateActivity['challenge'];
 }
 
 function incomingRequest() {

--- a/apps/web/core/debates/debate-coordinator.tsx
+++ b/apps/web/core/debates/debate-coordinator.tsx
@@ -103,6 +103,9 @@ export function DebateCoordinator() {
   // challenge keeps its place in the hub's Requests tab until it is answered or expires.
   const [snoozedChallengeId, setSnoozedChallengeId] = React.useState<string | null>(null);
   const promptedChallenge = challenge && challenge.id !== snoozedChallengeId ? challenge : null;
+  // Only the recipient is prompted. `challenge` itself stays live for everyone, since `activeFlow`
+  // above reads it to keep other popups from stacking on top of an outstanding challenge.
+  const isChallengeRecipient = promptedChallenge?.recipient.user_id === currentUserId;
 
   React.useEffect(() => {
     if (snoozedChallengeId && challenge?.id !== snoozedChallengeId) setSnoozedChallengeId(null);
@@ -174,10 +177,12 @@ export function DebateCoordinator() {
         />
       )}
       {debate && !viewingDebate && !promptedDebate && !activity?.rematch && <DebateRejoinBar debate={debate} />}
-      {promptedChallenge && !debate && !activity?.rematch && (
+      {/* Recipient only: they have a decision to make. The sender's copy waits under Sent in the
+          hub's Requests tab, and the rematch routing effect above walks them into the claim picker
+          the moment it is accepted. */}
+      {promptedChallenge && isChallengeRecipient && !debate && !activity?.rematch && (
         <DebateChallengeDialog
           challenge={promptedChallenge}
-          role={promptedChallenge.recipient.user_id === getCurrentGeoChatUserId() ? 'recipient' : 'requester'}
           busy={acceptChallenge.isPending || rejectChallenge.isPending}
           error={challengeError instanceof Error ? challengeError.message : null}
           onAccept={() => acceptChallenge.mutate(promptedChallenge.id)}

--- a/apps/web/core/debates/matchmaking/requests-tab.tsx
+++ b/apps/web/core/debates/matchmaking/requests-tab.tsx
@@ -168,8 +168,10 @@ function ChallengeCard({ challenge, role }: { challenge: DebateChallenge; role: 
   const isRecipient = role === 'recipient';
   const other = isRecipient ? challenge.requester : challenge.recipient;
   const busy = acceptChallenge.isPending || rejectChallenge.isPending;
-  // This card is the sender's only view of an outgoing challenge, so a failed cancel has to report
-  // itself here — there is no popup left to carry the message.
+  // Both roles act from this card and neither could report a failure before: the sender has no
+  // popup left to carry one, and the recipient's Dismiss/Explore claims live here as well as in
+  // theirs. Each `useMutation` call owns its own state, so only the action this card actually
+  // offers can ever set this.
   const actionError = acceptChallenge.error ?? rejectChallenge.error;
 
   return (
@@ -226,7 +228,7 @@ function ChallengeCard({ challenge, role }: { challenge: DebateChallenge; role: 
       )}
 
       {actionError instanceof Error ? (
-        // role="alert" so a failed cancel is announced, not just drawn under the button.
+        // role="alert" so a failed action is announced, not just drawn under the button.
         <div role="alert">
           <Text as="p" variant="footnote" color="red-01">
             {actionError.message}

--- a/apps/web/core/debates/matchmaking/requests-tab.tsx
+++ b/apps/web/core/debates/matchmaking/requests-tab.tsx
@@ -168,6 +168,9 @@ function ChallengeCard({ challenge, role }: { challenge: DebateChallenge; role: 
   const isRecipient = role === 'recipient';
   const other = isRecipient ? challenge.requester : challenge.recipient;
   const busy = acceptChallenge.isPending || rejectChallenge.isPending;
+  // This card is the sender's only view of an outgoing challenge, so a failed cancel has to report
+  // itself here — there is no popup left to carry the message.
+  const actionError = acceptChallenge.error ?? rejectChallenge.error;
 
   return (
     <article className="flex flex-col gap-3 rounded-lg border border-grey-02 bg-white p-3">
@@ -221,6 +224,15 @@ function ChallengeCard({ challenge, role }: { challenge: DebateChallenge; role: 
           Cancel request
         </HubPillButton>
       )}
+
+      {actionError instanceof Error ? (
+        // role="alert" so a failed cancel is announced, not just drawn under the button.
+        <div role="alert">
+          <Text as="p" variant="footnote" color="red-01">
+            {actionError.message}
+          </Text>
+        </div>
+      ) : null}
     </article>
   );
 }


### PR DESCRIPTION
## What

Sending a claimless debate request put a blocking modal on the **sender's** screen reading "Waiting for `<Name>` to accept…", with "Not now" and "Cancel request". It offered no decision, and the hub's Requests tab already files the same challenge under **Sent** with the same countdown, the same other-party row, and the same cancel action.

The dialog is now recipient-only — they're the one with something to answer. The sender just sees their request sitting under Sent, and when it's accepted they're pulled into the claim picker exactly as before.

## How

`DebateChallengeDialog` loses its `role` prop and the requester branch; `debate-coordinator.tsx` gates the render on the viewer actually being the recipient.

Nothing else had to move, because **the popup never owned the rest of the flow**:

- **Detecting acceptance** is the gateway (`debate.rematch_changed` / `debate.activity_changed`) → `useDebateActivity`. There's no polling and the dialog wasn't part of it.
- **Entering the claim exploration flow** is the coordinator's rematch routing effect, which pushes the sender to `/space/{id}/debates/rematches/{sessionId}` when activity gains a `browsing` rematch.
- **Cancelling** is the same `useRejectDebateChallenge` mutation the Sent card already calls.
- `activeFlow` reads `challenge`, not `promptedChallenge`, so gating the dialog doesn't change how other popups stack.

One thing did need handling: the dialog was the sender's **only error surface**, so a failed cancel would now fail silently. `ChallengeCard` picks up a `role="alert"` error line, matching the pattern in `matches-tab.tsx`.

## Test plan

- Three new `DebateCoordinator` tests (the challenge dialog previously had **no coverage at all** — every fixture set `challenge: null`): the recipient is still prompted with "Explore claims", the sender is not interrupted, and the sender is still routed into the claim picker once a rematch appears. Verified the sender test is a real guard — it fails if the recipient gate is removed.
- The existing `requests-tab` test that pins the replacement behaviour (`files a challenge you sent under Sent, where you can cancel it`) still passes untouched.
- `core/debates`: **47 files / 501 tests pass.** I got the previously-unrunnable suites working locally — Node's webstorage stub was shadowing jsdom's `localStorage`, killing any suite that imports jotai's `atomWithStorage` at module load. Repaired it with a throwaway setup file (not committed) so this change is verified against the whole debates suite rather than just the parts that happened to load.
- `bun run build` passes (type check included).
- Not checked in a browser — worth sending a request end to end before this goes in.

## Worth a look

- **Discoverability.** The popup was the sender's confirmation that anything happened. Now `ProfileDebateButton` / the People tab's row just flip to "Requesting…" and back, and nothing points at the Sent section. If you want, the send action could open the hub on the Requests tab (`useDebatesHub().open('requests')`) — I left it out as it wasn't part of the ask.
- **A space filter hides sent challenges** (`requests-tab.tsx`: a challenge belongs to no space, so `challengeRole` goes null when a space is selected). Pre-existing, but the popup used to paper over it; now a sender with a space filter set sees nothing at all.
- **The navbar badge counts only incoming**, so nothing signals that your own request is still live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)