### PR TITLE
feat(debates): keep the side panels on the debate you scroll to

### DIFF
--- a/apps/web/core/debates/browse/debate-feed.test.tsx
+++ b/apps/web/core/debates/browse/debate-feed.test.tsx
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom/vitest';
-import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen, within } from '@testing-library/react';
 
 import { Provider, createStore } from 'jotai';
 import { afterEach, assert, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -582,6 +582,21 @@ describe('DebatesBrowseFeed panels follow the scrolled-to debate', () => {
     activateDebate('Adjacent debate');
 
     expect(screen.getByText('Claims panel for debate-2')).toBeInTheDocument();
+  });
+
+  // A debate's bar is clickable from the moment any of it is on screen, but the
+  // scroll observer only activates it at 60% — so mid-scroll a press would
+  // otherwise open the panel on the debate being scrolled away from.
+  it('opens the panel for the pressed debate even before the scroll observer activates it', () => {
+    render(<DebatesBrowseFeed spaceId="space-1" />);
+    // debate-1 is active; debate-2 has not crossed the activation threshold.
+    const adjacent = screen.getByRole('heading', { name: 'Adjacent debate' }).closest('section');
+    assert(adjacent, 'Expected a section for the adjacent debate');
+
+    fireEvent.click(within(adjacent).getAllByRole('button', { name: 'Comments' })[0]);
+
+    expect(screen.getByText('Comments panel for debate-2')).toBeInTheDocument();
+    expect(screen.queryByText('Comments panel for debate-1')).not.toBeInTheDocument();
   });
 
   it('leaves a closed panel closed while scrolling', () => {

--- a/apps/web/core/debates/browse/debate-feed.test.tsx
+++ b/apps/web/core/debates/browse/debate-feed.test.tsx
@@ -82,7 +82,9 @@ vi.mock('./debate-scroll-hint', () => ({
   DebateScrollHint: ({ className }: { className?: string }) => <div data-testid="scroll-hint" className={className} />,
 }));
 
-vi.mock('./debate-claims-panel', () => ({ DebateClaimsPanel: () => <div>Claims panel</div> }));
+vi.mock('./debate-claims-panel', () => ({
+  DebateClaimsPanel: ({ debate }: { debate: Debate }) => <div>Claims panel for {debate.id}</div>,
+}));
 vi.mock('./join-debate-panel', () => ({ JoinDebatePanel: () => <div>Join panel</div> }));
 vi.mock('~/partials/comments/entity-comments-panel', () => ({
   EntityCommentsPanel: ({ entityId }: { entityId: string }) => <div>Comments panel for {entityId}</div>,
@@ -544,12 +546,51 @@ describe('DebatesBrowseFeed comments', () => {
     expect(screen.getByText('Comments panel for debate-1')).toBeInTheDocument();
 
     fireEvent.click(screen.getAllByRole('button', { name: 'Claims' })[0]);
-    expect(screen.getByText('Claims panel')).toBeInTheDocument();
+    expect(screen.getByText('Claims panel for debate-1')).toBeInTheDocument();
     expect(screen.queryByText('Comments panel for debate-1')).not.toBeInTheDocument();
 
     fireEvent.click(screen.getAllByRole('button', { name: 'Comments' })[0]);
     expect(screen.getByText('Comments panel for debate-1')).toBeInTheDocument();
-    expect(screen.queryByText('Claims panel')).not.toBeInTheDocument();
+    expect(screen.queryByText(/^Claims panel for/)).not.toBeInTheDocument();
+  });
+});
+
+// The panels describe the debate on screen, so scrolling the feed under an open
+// panel has to bring the panel along — otherwise you're reading one debate's
+// video beside another's comments.
+describe('DebatesBrowseFeed panels follow the scrolled-to debate', () => {
+  beforeEach(() => {
+    mocks.debates.push(completedDebate('debate-2', 'Adjacent debate', '2026-07-01T00:01:10.000Z'));
+  });
+
+  it('moves the comments panel to the next debate on scroll', () => {
+    render(<DebatesBrowseFeed spaceId="space-1" />);
+    fireEvent.click(screen.getAllByRole('button', { name: 'Comments' })[0]);
+    expect(screen.getByText('Comments panel for debate-1')).toBeInTheDocument();
+
+    activateDebate('Adjacent debate');
+
+    expect(screen.getByText('Comments panel for debate-2')).toBeInTheDocument();
+    expect(screen.queryByText('Comments panel for debate-1')).not.toBeInTheDocument();
+  });
+
+  it('moves the claims panel to the next debate on scroll', () => {
+    render(<DebatesBrowseFeed spaceId="space-1" />);
+    fireEvent.click(screen.getAllByRole('button', { name: 'Claims' })[0]);
+    expect(screen.getByText('Claims panel for debate-1')).toBeInTheDocument();
+
+    activateDebate('Adjacent debate');
+
+    expect(screen.getByText('Claims panel for debate-2')).toBeInTheDocument();
+  });
+
+  it('leaves a closed panel closed while scrolling', () => {
+    render(<DebatesBrowseFeed spaceId="space-1" />);
+
+    activateDebate('Adjacent debate');
+
+    expect(screen.queryByText(/^Comments panel for/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/^Claims panel for/)).not.toBeInTheDocument();
   });
 });
 

--- a/apps/web/core/debates/browse/debate-feed.tsx
+++ b/apps/web/core/debates/browse/debate-feed.tsx
@@ -211,9 +211,22 @@ export function DebatesBrowseFeed({
           // Only the debate the viewer is looking at carries the nudge and lifts with it.
           scrollHint={index === 0 ? scrollHint : null}
           onActivate={() => setActiveId(debate.id)}
-          onOpenJoin={() => setOpenPanel('join')}
-          onOpenClaims={() => setOpenPanel('claims')}
-          onOpenComments={() => setOpenPanel('comments')}
+          // Pressing a debate's own control makes it the active one rather than
+          // waiting for the scroll observer: its bar is reachable from 0%
+          // visibility but activation needs 60%, so mid-scroll the panel would
+          // otherwise open on the debate being scrolled away from.
+          onOpenJoin={() => {
+            setActiveId(debate.id);
+            setOpenPanel('join');
+          }}
+          onOpenClaims={() => {
+            setActiveId(debate.id);
+            setOpenPanel('claims');
+          }}
+          onOpenComments={() => {
+            setActiveId(debate.id);
+            setOpenPanel('comments');
+          }}
         />
       ))}
       {!anchorPending && visibleCount < debates.length && (

--- a/apps/web/core/debates/browse/debate-feed.tsx
+++ b/apps/web/core/debates/browse/debate-feed.tsx
@@ -109,9 +109,10 @@ export function DebatesBrowseFeed({
   // An anchored feed starts active on the anchor so the linked debate is the one
   // that autoplays, before any IntersectionObserver has fired.
   const [activeId, setActiveId] = React.useState<string | null>(initialDebateId ?? null);
-  const [joinOpen, setJoinOpen] = React.useState(false);
-  const [claimsDebate, setClaimsDebate] = React.useState<Debate | null>(null);
-  const [commentsDebate, setCommentsDebate] = React.useState<Debate | null>(null);
+  // Which panel is open, not which debate it was opened from: the claims and
+  // comments panels describe the debate you're watching, so they follow the feed
+  // as you scroll rather than staying pinned to the one whose button you pressed.
+  const [openPanel, setOpenPanel] = React.useState<'join' | 'claims' | 'comments' | null>(null);
 
   // The media lookups gate rendering, so the feed is still loading until they settle — otherwise it
   // flashes "no debates" and strands a valid anchor.
@@ -210,21 +211,9 @@ export function DebatesBrowseFeed({
           // Only the debate the viewer is looking at carries the nudge and lifts with it.
           scrollHint={index === 0 ? scrollHint : null}
           onActivate={() => setActiveId(debate.id)}
-          onOpenJoin={() => {
-            setClaimsDebate(null);
-            setCommentsDebate(null);
-            setJoinOpen(true);
-          }}
-          onOpenClaims={() => {
-            setJoinOpen(false);
-            setCommentsDebate(null);
-            setClaimsDebate(debate);
-          }}
-          onOpenComments={() => {
-            setJoinOpen(false);
-            setClaimsDebate(null);
-            setCommentsDebate(debate);
-          }}
+          onOpenJoin={() => setOpenPanel('join')}
+          onOpenClaims={() => setOpenPanel('claims')}
+          onOpenComments={() => setOpenPanel('comments')}
         />
       ))}
       {!anchorPending && visibleCount < debates.length && (
@@ -233,13 +222,19 @@ export function DebatesBrowseFeed({
     </div>
   );
 
-  const sidePanel = joinOpen ? (
-    <JoinDebatePanel spaceId={spaceId} onClose={() => setJoinOpen(false)} />
-  ) : claimsDebate ? (
-    <DebateClaimsPanel debate={claimsDebate} count={0} onClose={() => setClaimsDebate(null)} />
-  ) : commentsDebate ? (
-    <EntityCommentsPanel entityId={commentsDebate.id} spaceId={spaceId} onClose={() => setCommentsDebate(null)} />
-  ) : null;
+  const activeDebate = visibleDebates.find(debate => debate.id === activeId) ?? null;
+  const closePanel = () => setOpenPanel(null);
+
+  const sidePanel =
+    openPanel === 'join' ? (
+      <JoinDebatePanel spaceId={spaceId} onClose={closePanel} />
+    ) : openPanel === 'claims' && activeDebate ? (
+      <DebateClaimsPanel debate={activeDebate} count={0} onClose={closePanel} />
+    ) : openPanel === 'comments' && activeDebate ? (
+      // Keyed so scrolling to the next debate resets the panel rather than
+      // carrying a half-typed reply across to a different debate's thread.
+      <EntityCommentsPanel key={activeDebate.id} entityId={activeDebate.id} spaceId={spaceId} onClose={closePanel} />
+    ) : null;
 
   // Keep the feed in the same tree position whether or not a side panel is open, so
   // toggling the claims/join panel doesn't remount the players and restart playback.


### PR DESCRIPTION
## What

In the fullscreen debates feed, scrolling to the next debate with the comments or claims panel open left the panel on the debate you came from — one debate's video beside another's comments. Both panels now follow the feed.

## How

The feed stored *which debate each panel was opened from* (`claimsDebate` / `commentsDebate`, each pinning a `Debate`). But both panels describe the debate you're **watching**, so that state modelled the wrong thing.

- Two pinned-debate states collapse into one `openPanel: 'join' | 'claims' | 'comments' | null`.
- The open panel renders against `activeDebate` — the debate the feed's existing IntersectionObserver already tracks to decide which video autoplays. Scrolling updates the panel for free, off the same signal that drives playback, so the panel can't disagree with the video.
- The three mutual-exclusion handlers (each clearing the other two states) become a single setter, so the panels can't get out of sync.

Net: 28 lines removed, 64 added — most of the additions are tests.

## Two deliberate choices

- **The comments panel is keyed on the debate id**, so scrolling remounts it. Without that, a half-typed reply would carry across and post into a different debate's thread. The cost is losing an in-progress draft when you scroll away; that seemed clearly the better trade, but it's easy to reverse if you disagree.
- **The Join panel doesn't follow scroll** — it's about joining the space, not the debate on screen.

## Testing

- New: comments panel follows scroll; claims panel follows scroll; a closed panel stays closed while scrolling. Feed suite: 29 passing.
- `next build` (with type check) and eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)