### PR TITLE
feat(debates): add a Recommended tab of curated claims to the rematch picker

### DIFF
--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
@@ -33,6 +33,7 @@ const mocks = vi.hoisted(() => ({
   openSidePanel: vi.fn(),
   entityQueries: [] as unknown[],
   entityQueryPlaceholder: false,
+  entityQueryHasNextPage: false,
   entities: [] as Array<Record<string, unknown>>,
   recommendedSections: [] as Array<{ id: string; name: string; claimIds: string[] }>,
   claimReadinessLoading: false,
@@ -84,8 +85,8 @@ vi.mock('~/core/sync/use-store', () => ({
       entities: mocks.entities,
       isLoading: false,
       isPlaceholderData: mocks.entityQueryPlaceholder,
-      endCursor: null,
-      hasNextPage: false,
+      endCursor: mocks.entityQueryHasNextPage ? 'cursor-1' : null,
+      hasNextPage: mocks.entityQueryHasNextPage,
     };
   },
 }));
@@ -108,7 +109,7 @@ vi.mock('~/core/debates/matchmaking/hooks', () => ({
 
 // The curated lookup has its own tests; these cover the picker around it.
 vi.mock('~/core/debates/recommended-claims', () => ({
-  useRecommendedClaimSections: () => mocks.recommendedSections,
+  useRecommendedClaimSections: () => ({ sections: mocks.recommendedSections, claimEntities: [] }),
 }));
 
 vi.mock('~/core/hooks/use-entity-side-panel', () => ({
@@ -146,6 +147,7 @@ beforeEach(() => {
   mocks.openSidePanel.mockReset();
   mocks.entityQueries.length = 0;
   mocks.entityQueryPlaceholder = false;
+  mocks.entityQueryHasNextPage = false;
   mocks.entities = [publishedEntity()];
   mocks.recommendedSections = [];
   // The hub's filter menus measure their dropdown.
@@ -488,6 +490,19 @@ describe('DebateRematchPageClient', () => {
 
     await waitFor(() => expect(screen.queryByRole('heading', { name: 'Geopolitics & chips' })).toBeNull());
     expect(screen.getByRole('heading', { name: 'Open weight AI' })).toBeInTheDocument();
+  });
+
+  // Recommended comes from the curator's page whole, so paging the browsed corpus means nothing
+  // there — offering it implies there are more recommendations waiting.
+  it('keeps Load more off the Recommended tab while offering it on the others', () => {
+    mocks.entityQueryHasNextPage = true;
+    mocks.recommendedSections = [{ id: 'block-1', name: 'Geopolitics & chips', claimIds: [CLAIM_SHARED] }];
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+
+    expect(screen.queryByRole('button', { name: 'Load more' })).toBeNull();
+
+    showAllClaims();
+    expect(screen.getByRole('button', { name: 'Load more' })).toBeInTheDocument();
   });
 
   it('shortens the opponent tab to their first name', () => {

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
@@ -5,7 +5,7 @@ import { StrictMode } from 'react';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { TOPICS_PROPERTY_ID } from '~/core/claims/ontology';
+import { CLAIM_TYPE_ID, TOPICS_PROPERTY_ID } from '~/core/claims/ontology';
 import type { DebateRematchClaim, DebateRematchSession } from '~/core/debates/api';
 
 import { DebateRematchPageClient } from './rematch-page-client';
@@ -34,6 +34,7 @@ const mocks = vi.hoisted(() => ({
   entityQueries: [] as unknown[],
   entityQueryPlaceholder: false,
   entities: [] as Array<Record<string, unknown>>,
+  recommendedSections: [] as Array<{ id: string; name: string; claimIds: string[] }>,
   claimReadinessLoading: false,
   claimReadinessError: false,
   claimReadiness: [] as Array<{
@@ -100,6 +101,11 @@ vi.mock('~/core/debates/matchmaking/hooks', () => ({
   useClaimReadiness: () => ({ mutate: mocks.setReadiness, isPending: false, error: null }),
 }));
 
+// The curated lookup has its own tests; these cover the picker around it.
+vi.mock('~/core/debates/recommended-claims', () => ({
+  useRecommendedClaimSections: () => mocks.recommendedSections,
+}));
+
 vi.mock('~/core/hooks/use-entity-side-panel', () => ({
   useEntitySidePanel: () => ({ openSidePanel: mocks.openSidePanel, sidePanelTarget: null, closeSidePanel: vi.fn() }),
 }));
@@ -136,6 +142,7 @@ beforeEach(() => {
   mocks.entityQueries.length = 0;
   mocks.entityQueryPlaceholder = false;
   mocks.entities = [publishedEntity()];
+  mocks.recommendedSections = [];
   // The hub's filter menus measure their dropdown.
   window.ResizeObserver ??= class {
     observe() {}
@@ -424,6 +431,60 @@ describe('DebateRematchPageClient', () => {
     expect(screen.queryByText('A newly published claim')).toBeNull();
   });
 
+  // A curator's page for this pairing is the best thing to land on; without one the tab has no
+  // reason to exist.
+  it('hides the Recommended tab when nothing is curated for this pairing', () => {
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+
+    expect(screen.queryByRole('button', { name: 'Recommended' })).toBeNull();
+    expect(screen.getByRole('button', { name: /Salina’s positions/ })).toBeInTheDocument();
+  });
+
+  it('opens on Recommended when a curator has, grouping each block into its own section', () => {
+    mocks.recommendedSections = [
+      { id: 'block-1', name: 'Geopolitics & chips', claimIds: [CLAIM_SHARED] },
+      { id: 'block-2', name: 'Open weight AI', claimIds: [CLAIM_MORE] },
+    ];
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+
+    expect(screen.getByRole('button', { name: 'Recommended' })).toBeInTheDocument();
+    const geopolitics = screen.getByRole('heading', { name: 'Geopolitics & chips' });
+    const openWeight = screen.getByRole('heading', { name: 'Open weight AI' });
+    expect(geopolitics.compareDocumentPosition(openWeight) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+
+    // Each block lists its own claims.
+    expect(screen.getByText('A claim both participants chose')).toBeInTheDocument();
+    expect(screen.getByText('A newly published claim')).toBeInTheDocument();
+  });
+
+  it('collapses a section without touching the others', () => {
+    mocks.recommendedSections = [
+      { id: 'block-1', name: 'Geopolitics & chips', claimIds: [CLAIM_SHARED] },
+      { id: 'block-2', name: 'Open weight AI', claimIds: [CLAIM_MORE] },
+    ];
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Geopolitics & chips/ }));
+
+    expect(screen.queryByText('A claim both participants chose')).toBeNull();
+    expect(screen.getByText('A newly published claim')).toBeInTheDocument();
+  });
+
+  // A curated claim the session hasn't heard of still has to render, so it joins the same pool the
+  // browsed pages feed rather than being listed separately.
+  it('drops a section whose claims all fall out of the filters', async () => {
+    mocks.recommendedSections = [
+      { id: 'block-1', name: 'Geopolitics & chips', claimIds: [CLAIM_SHARED] },
+      { id: 'block-2', name: 'Open weight AI', claimIds: [CLAIM_MORE] },
+    ];
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Search claims' }), { target: { value: 'newly' } });
+
+    await waitFor(() => expect(screen.queryByRole('heading', { name: 'Geopolitics & chips' })).toBeNull());
+    expect(screen.getByRole('heading', { name: 'Open weight AI' })).toBeInTheDocument();
+  });
+
   it('shortens the opponent tab to their first name', () => {
     const base = session();
     mocks.session = session({
@@ -554,7 +615,7 @@ describe('DebateRematchPageClient', () => {
     mocks.entities = [publishedEntity(STALE, 'A stale claim from the previous search')];
     mocks.entityQueryPlaceholder = true;
     fireEvent.change(screen.getByRole('textbox', { name: 'Search claims' }), { target: { value: 'claim' } });
-    await waitFor(() => expect(mocks.entityQueries.at(-1)).toMatchObject({ name: { contains: 'claim' } }));
+    await waitFor(() => expect(browsedClaimsWhere()).toMatchObject({ name: { contains: 'claim' } }));
 
     // The real page for this term lands.
     mocks.entities = [publishedEntity()];
@@ -621,7 +682,7 @@ describe('DebateRematchPageClient', () => {
 
     fireEvent.change(screen.getByRole('textbox', { name: 'Search claims' }), { target: { value: 'Fast fashion' } });
 
-    await waitFor(() => expect(mocks.entityQueries.at(-1)).toMatchObject({ name: { contains: 'Fast fashion' } }));
+    await waitFor(() => expect(browsedClaimsWhere()).toMatchObject({ name: { contains: 'Fast fashion' } }));
   });
 
   it('renders the card’s Debate toggle against real readiness', () => {
@@ -653,6 +714,17 @@ describe('DebateRematchPageClient', () => {
     expect(screen.getByRole('button', { name: 'Request debate' })).toBeEnabled();
   });
 });
+
+/** The where clause of the query that browses published claims, not the curated lookups beside it. */
+function browsedClaimsWhere() {
+  return mocks.entityQueries
+    .filter(
+      (where): where is { types?: Array<{ id?: { equals?: string } }> } =>
+        typeof where === 'object' && where !== null && 'types' in where
+    )
+    .filter(where => where.types?.[0]?.id?.equals === CLAIM_TYPE_ID)
+    .at(-1);
+}
 
 /** The picker opens on the opponent's positions; most assertions want the unfiltered list. */
 function showAllClaims() {

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
@@ -34,11 +34,15 @@ const mocks = vi.hoisted(() => ({
   entityQueries: [] as unknown[],
   entityQueryPlaceholder: false,
   entityQueryHasNextPage: false,
+  entityQueryLoading: false,
   entities: [] as Array<Record<string, unknown>>,
   recommendedSections: [] as Array<{ id: string; name: string; claimIds: string[] }>,
   recommendedEntities: [] as Array<Record<string, unknown>>,
   recommendedLoading: false,
   rematchClaimIds: [] as string[][],
+  curatedIds: [] as string[],
+  savedClaims: null as DebateRematchClaim[] | null,
+  browsedLookupLoading: false,
   claimReadinessLoading: false,
   claimReadinessError: false,
   claimReadiness: [] as Array<{
@@ -59,13 +63,22 @@ vi.mock('~/core/debates/api', async importOriginal => {
 
 vi.mock('~/core/debates/hooks', () => ({
   useDebateRematch: () => ({ data: mocks.session, isLoading: false, error: null }),
+  // The session's own saved claims. `savedClaims` lets a test empty this so a claim can only
+  // arrive through the id lookup.
   useDebateRematchClaims: () => ({
-    data: { claims: mocks.claims, excluded_claim_ids: [CLAIM_SOURCE] },
+    data: { claims: mocks.savedClaims ?? mocks.claims, excluded_claim_ids: [CLAIM_SOURCE] },
     isLoading: false,
     error: null,
   }),
+  // Two lookups run: one for the curated ids, one for the browsed ones. `curatedIds` lets a test
+  // stall the browsed lookup on its own, which is the whole point of their being separate.
   useDebateRematchClaimsForIds: (_sessionId: string, claimIds: string[]) => {
     mocks.rematchClaimIds.push(claimIds);
+    const isCuratedLookup =
+      mocks.curatedIds.length > 0 && claimIds.every(claimId => mocks.curatedIds.includes(claimId));
+    if (mocks.browsedLookupLoading && !isCuratedLookup) {
+      return { data: { claims: [], excluded_claim_ids: [] }, isLoading: true, error: null };
+    }
     return {
       data: { claims: mocks.claims, excluded_claim_ids: [CLAIM_SOURCE] },
       isLoading: false,
@@ -89,7 +102,7 @@ vi.mock('~/core/sync/use-store', () => ({
     mocks.entityQueries.push(options.where);
     return {
       entities: mocks.entities,
-      isLoading: false,
+      isLoading: mocks.entityQueryLoading,
       isPlaceholderData: mocks.entityQueryPlaceholder,
       endCursor: mocks.entityQueryHasNextPage ? 'cursor-1' : null,
       hasNextPage: mocks.entityQueryHasNextPage,
@@ -158,11 +171,15 @@ beforeEach(() => {
   mocks.entityQueries.length = 0;
   mocks.entityQueryPlaceholder = false;
   mocks.entityQueryHasNextPage = false;
+  mocks.entityQueryLoading = false;
   mocks.entities = [publishedEntity()];
   mocks.recommendedSections = [];
   mocks.recommendedEntities = [];
   mocks.recommendedLoading = false;
   mocks.rematchClaimIds.length = 0;
+  mocks.curatedIds = [];
+  mocks.savedClaims = null;
+  mocks.browsedLookupLoading = false;
   // The hub's filter menus measure their dropdown.
   window.ResizeObserver ??= class {
     observe() {}
@@ -528,7 +545,36 @@ describe('DebateRematchPageClient', () => {
 
     expect(screen.getByText('A curated claim from elsewhere')).toBeInTheDocument();
     // And it goes into the id lookup, so the session can report positions on it.
-    expect(mocks.rematchClaimIds.at(-1)).toContain(CURATED);
+    expect(mocks.rematchClaimIds.flat()).toContain(CURATED);
+  });
+
+  // The browsed scan reads every Claim in the graph and is the slowest thing here. The curated tab
+  // draws nothing from it, so waiting on it was pure delay.
+  it('shows curated sections without waiting on the browsed claim scan', () => {
+    mocks.entityQueryLoading = true;
+    // The browsed half of the session lookup is still in flight too — the curated half is not,
+    // and only stays independent while the two are asked for separately.
+    mocks.browsedLookupLoading = true;
+    mocks.curatedIds = [CLAIM_SHARED];
+    // Not among the session's saved claims, so the curated lookup is its only source of positions.
+    mocks.savedClaims = [];
+    mocks.recommendedSections = [{ id: 'block-1', name: 'Geopolitics & chips', claimIds: [CLAIM_SHARED] }];
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+
+    expect(screen.getByRole('heading', { name: 'Geopolitics & chips' })).toBeInTheDocument();
+    // Not just the card: its sides come from the session lookup, so a curated claim sharing the
+    // browsed lookup would render with no positions and no debate to request until the scan lands.
+    expect(screen.getByRole('button', { name: 'Request debate' })).toBeInTheDocument();
+  });
+
+  // The session's own claims arrive in one round trip; they shouldn't sit behind the scan either.
+  it('shows the opponent’s claims without waiting on the browsed claim scan', () => {
+    mocks.entityQueryLoading = true;
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Salina’s positions/ }));
+
+    expect(screen.getByText('A claim both participants chose')).toBeInTheDocument();
   });
 
   // An empty result mid-flight is not "nothing recommended"; landing on the opponent tab and then

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
@@ -60,6 +60,11 @@ vi.mock('~/core/debates/hooks', () => ({
     isLoading: false,
     error: null,
   }),
+  useDebateRematchClaimsForIds: () => ({
+    data: { claims: mocks.claims, excluded_claim_ids: [CLAIM_SOURCE] },
+    isLoading: false,
+    error: null,
+  }),
   useDebate: () => ({ data: { claim: { claim_entity_id: CLAIM_SOURCE } } }),
   useDebateClaimsBySpaces: () => ({
     claims: mocks.claimReadiness,

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
@@ -36,6 +36,9 @@ const mocks = vi.hoisted(() => ({
   entityQueryHasNextPage: false,
   entities: [] as Array<Record<string, unknown>>,
   recommendedSections: [] as Array<{ id: string; name: string; claimIds: string[] }>,
+  recommendedEntities: [] as Array<Record<string, unknown>>,
+  recommendedLoading: false,
+  rematchClaimIds: [] as string[][],
   claimReadinessLoading: false,
   claimReadinessError: false,
   claimReadiness: [] as Array<{
@@ -61,11 +64,14 @@ vi.mock('~/core/debates/hooks', () => ({
     isLoading: false,
     error: null,
   }),
-  useDebateRematchClaimsForIds: () => ({
-    data: { claims: mocks.claims, excluded_claim_ids: [CLAIM_SOURCE] },
-    isLoading: false,
-    error: null,
-  }),
+  useDebateRematchClaimsForIds: (_sessionId: string, claimIds: string[]) => {
+    mocks.rematchClaimIds.push(claimIds);
+    return {
+      data: { claims: mocks.claims, excluded_claim_ids: [CLAIM_SOURCE] },
+      isLoading: false,
+      error: null,
+    };
+  },
   useDebate: () => ({ data: { claim: { claim_entity_id: CLAIM_SOURCE } } }),
   useDebateClaimsBySpaces: () => ({
     claims: mocks.claimReadiness,
@@ -109,7 +115,11 @@ vi.mock('~/core/debates/matchmaking/hooks', () => ({
 
 // The curated lookup has its own tests; these cover the picker around it.
 vi.mock('~/core/debates/recommended-claims', () => ({
-  useRecommendedClaimSections: () => ({ sections: mocks.recommendedSections, claimEntities: [] }),
+  useRecommendedClaimSections: () => ({
+    sections: mocks.recommendedSections,
+    claimEntities: mocks.recommendedEntities,
+    isLoading: mocks.recommendedLoading,
+  }),
 }));
 
 vi.mock('~/core/hooks/use-entity-side-panel', () => ({
@@ -150,6 +160,9 @@ beforeEach(() => {
   mocks.entityQueryHasNextPage = false;
   mocks.entities = [publishedEntity()];
   mocks.recommendedSections = [];
+  mocks.recommendedEntities = [];
+  mocks.recommendedLoading = false;
+  mocks.rematchClaimIds.length = 0;
   // The hub's filter menus measure their dropdown.
   window.ResizeObserver ??= class {
     observe() {}
@@ -503,6 +516,31 @@ describe('DebateRematchPageClient', () => {
 
     showAllClaims();
     expect(screen.getByRole('button', { name: 'Load more' })).toBeInTheDocument();
+  });
+
+  // Curated claims are picked by hand, so they can be ones the browsed pages never reach. They
+  // have to land in the same pool, or a recommendation would head a section with nothing under it.
+  it('renders a curated claim the browsed pages never returned', () => {
+    const CURATED = '019fedb59a8f7d728e556ab19c3e8841';
+    mocks.recommendedSections = [{ id: 'block-1', name: 'Geopolitics & chips', claimIds: [CURATED] }];
+    mocks.recommendedEntities = [publishedEntity(CURATED, 'A curated claim from elsewhere')];
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+
+    expect(screen.getByText('A curated claim from elsewhere')).toBeInTheDocument();
+    // And it goes into the id lookup, so the session can report positions on it.
+    expect(mocks.rematchClaimIds.at(-1)).toContain(CURATED);
+  });
+
+  // An empty result mid-flight is not "nothing recommended"; landing on the opponent tab and then
+  // moving the viewer once the lookup settles is worse than waiting.
+  it('waits on the Recommended tab while the curated lookup is still running', () => {
+    mocks.recommendedLoading = true;
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+
+    expect(screen.getByRole('button', { name: 'Recommended' })).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByRole('button', { name: /Salina’s positions/ })).toHaveAttribute('aria-selected', 'false');
+    // And the claims stay behind the loading state rather than the opponent tab's list appearing.
+    expect(screen.queryByText('A claim both participants chose')).toBeNull();
   });
 
   it('shortens the opponent tab to their first name', () => {

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -144,8 +144,11 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   // hook hands back their entities along with the sections, and they join the same pool the browsed
   // claims feed — so the session lookup, response kinds and the cards treat them like any other
   // published claim.
-  const { sections: recommendedSections, claimEntities: recommendedEntities } =
-    useRecommendedClaimSections(participantSpaceIds);
+  const {
+    sections: recommendedSections,
+    claimEntities: recommendedEntities,
+    isLoading: recommendedLoading,
+  } = useRecommendedClaimSections(participantSpaceIds);
 
   const claimEntities = React.useMemo(() => {
     const byId = new Map(publishedClaims.entities.map(claim => [claim.id, claim]));
@@ -266,7 +269,9 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   );
 
   const hasRecommended = recommendedSections.length > 0;
-  const tab: PickerTab = chosenTab ?? (hasRecommended ? 'recommended' : 'opponent');
+  // Held on the curated tab while the lookup runs, so an empty result mid-flight can't land the
+  // viewer on the opponent tab and then move them once it settles.
+  const tab: PickerTab = chosenTab ?? (hasRecommended || recommendedLoading ? 'recommended' : 'opponent');
   const setTab = setChosenTab;
 
   const facetSpaceIds = React.useMemo(() => [...new Set(claims.map(claim => claim.claim.space_id))], [claims]);
@@ -393,7 +398,7 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
         <header className="mb-4 flex items-center justify-between gap-4">
           <h1 className="sr-only">Rematch {remoteName}</h1>
           <div className="flex min-w-0 items-center gap-5">
-            {hasRecommended ? (
+            {hasRecommended || recommendedLoading ? (
               <TabButton active={tab === 'recommended'} onClick={() => setTab('recommended')}>
                 Recommended
               </TabButton>
@@ -464,7 +469,8 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
             sessionQuery.isLoading ||
             savedClaimsQuery.isLoading ||
             publishedClaimsQuery.isLoading ||
-            publishedClaimsLoading
+            publishedClaimsLoading ||
+            (tab === 'recommended' && recommendedLoading)
           }
           error={sessionQuery.error ?? savedClaimsQuery.error ?? publishedClaimsQuery.error}
           isEmpty={tab === 'recommended' ? visibleSections.length === 0 : visibleClaims.length === 0}

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -140,21 +140,12 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
     () => (session?.participants ?? []).map(participant => participant.profile_space_id),
     [session?.participants]
   );
-  const recommendedSections = useRecommendedClaimSections(participantSpaceIds);
-  const recommendedClaimIds = React.useMemo(
-    () => [...new Set(recommendedSections.flatMap(section => section.claimIds))],
-    [recommendedSections]
-  );
-
-  // Curated claims are picked by hand, so they can be ones the browsed pages haven't reached.
-  // Fetching their entities puts them in the same pool, and everything downstream — the session
-  // lookup, response kinds, the cards — treats them like any other published claim.
-  const { entities: recommendedEntities } = useQueryEntities({
-    where: { id: { in: recommendedClaimIds } },
-    first: 100,
-    enabled: recommendedClaimIds.length > 0,
-    placeholderData: keepPreviousData,
-  });
+  // Curated claims are picked by hand, so they can be ones the browsed pages haven't reached. The
+  // hook hands back their entities along with the sections, and they join the same pool the browsed
+  // claims feed — so the session lookup, response kinds and the cards treat them like any other
+  // published claim.
+  const { sections: recommendedSections, claimEntities: recommendedEntities } =
+    useRecommendedClaimSections(participantSpaceIds);
 
   const claimEntities = React.useMemo(() => {
     const byId = new Map(publishedClaims.entities.map(claim => [claim.id, claim]));
@@ -514,8 +505,9 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
         </HubQueryState>
 
         {/* Outside the empty state deliberately: when a filter empties the list, fetching another
-            page is the way out, so the control has to stay reachable. */}
-        {publishedClaimsHasNextPage && (
+            page is the way out, so the control has to stay reachable. Not on the curated tab
+            though — its sections come from the page whole, so there is no next page to fetch. */}
+        {tab !== 'recommended' && publishedClaimsHasNextPage && (
           <div className="mt-5 flex justify-center">
             <Button
               type="button"

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -150,27 +150,42 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
     isLoading: recommendedLoading,
   } = useRecommendedClaimSections(participantSpaceIds);
 
+  const recommendedClaimIds = React.useMemo(
+    () => [...new Set(recommendedSections.flatMap(section => section.claimIds))],
+    [recommendedSections]
+  );
+
   const claimEntities = React.useMemo(() => {
     const byId = new Map(publishedClaims.entities.map(claim => [claim.id, claim]));
     for (const claim of recommendedEntities) if (!byId.has(claim.id)) byId.set(claim.id, claim);
     return [...byId.values()];
   }, [publishedClaims.entities, recommendedEntities]);
 
-  const publishedClaimIds = React.useMemo(() => claimEntities.map(claim => claim.id), [claimEntities]);
-  // Batched: geo-chat caps the ids per request, and the browsed list plus the curated claims runs
-  // past that cap after a page or two of Load more.
-  const publishedClaimsQuery = useDebateRematchClaimsForIds(sessionId, publishedClaimIds);
+  // Looked up separately from the browsed ids rather than as one list. Sharing a list would make
+  // the curated tab wait on the graph-wide claim scan below, which it draws nothing from — and
+  // that scan is the slowest thing on the page.
+  //
+  // Both batched: geo-chat caps the ids per request, and the browsed list alone runs past that cap
+  // after a page or two of Load more.
+  const curatedClaimsQuery = useDebateRematchClaimsForIds(sessionId, recommendedClaimIds);
+  const browsedClaimIds = React.useMemo(
+    () => publishedClaims.entities.map(claim => claim.id),
+    [publishedClaims.entities]
+  );
+  const browsedClaimsQuery = useDebateRematchClaimsForIds(sessionId, browsedClaimIds);
 
   const claims = React.useMemo(() => {
     const synchronizedClaims = new Map(
-      [...(savedClaimsQuery.data?.claims ?? []), ...(publishedClaimsQuery.data?.claims ?? [])].map(claim => [
-        claim.claim.claim_entity_id,
-        claim,
-      ])
+      [
+        ...(savedClaimsQuery.data?.claims ?? []),
+        ...(curatedClaimsQuery.data?.claims ?? []),
+        ...(browsedClaimsQuery.data?.claims ?? []),
+      ].map(claim => [claim.claim.claim_entity_id, claim])
     );
     const excludedClaimIds = new Set([
       ...(savedClaimsQuery.data?.excluded_claim_ids ?? []),
-      ...(publishedClaimsQuery.data?.excluded_claim_ids ?? []),
+      ...(curatedClaimsQuery.data?.excluded_claim_ids ?? []),
+      ...(browsedClaimsQuery.data?.excluded_claim_ids ?? []),
     ]);
     for (const claim of claimEntities) {
       if (
@@ -203,7 +218,14 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
     return [...synchronizedClaims.values()]
       .filter(claim => !excludedClaimIds.has(claim.claim.claim_entity_id))
       .sort((a, b) => Number(b.shared_preference) - Number(a.shared_preference));
-  }, [claimEntities, publishedClaimsQuery.data, savedClaimsQuery.data, session?.participants, sourceDebateQuery.data]);
+  }, [
+    browsedClaimsQuery.data,
+    claimEntities,
+    curatedClaimsQuery.data,
+    savedClaimsQuery.data,
+    session?.participants,
+    sourceDebateQuery.data,
+  ]);
   const remoteParticipant =
     currentUserId === null
       ? null
@@ -306,6 +328,16 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   );
 
   const hasFilters = Boolean(debouncedSearch || spaceId || topicId);
+
+  // Each tab draws from a different set of queries, so each waits on its own. The browsed scan is
+  // the slow one and only the All tab reads it.
+  const tabIsLoading =
+    sessionQuery.isLoading ||
+    (tab === 'recommended'
+      ? recommendedLoading || curatedClaimsQuery.isLoading
+      : tab === 'opponent'
+        ? savedClaimsQuery.isLoading
+        : savedClaimsQuery.isLoading || publishedClaimsLoading || browsedClaimsQuery.isLoading);
 
   // The curated tab groups by block rather than listing flat, but narrows on the same filters.
   const visibleSections = React.useMemo(() => {
@@ -465,14 +497,13 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
         )}
 
         <HubQueryState
+          // Only what the visible tab actually draws from, and only while it has nothing to show.
+          // Holding every tab on the slowest query meant the session's own claims — which arrive in
+          // one round trip — sat behind a graph-wide scan they don't come from.
           isLoading={
-            sessionQuery.isLoading ||
-            savedClaimsQuery.isLoading ||
-            publishedClaimsQuery.isLoading ||
-            publishedClaimsLoading ||
-            (tab === 'recommended' && recommendedLoading)
+            tabIsLoading && (tab === 'recommended' ? visibleSections.length === 0 : visibleClaims.length === 0)
           }
-          error={sessionQuery.error ?? savedClaimsQuery.error ?? publishedClaimsQuery.error}
+          error={sessionQuery.error ?? savedClaimsQuery.error ?? browsedClaimsQuery.error}
           isEmpty={tab === 'recommended' ? visibleSections.length === 0 : visibleClaims.length === 0}
           emptyMessage={
             hasFilters

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -27,6 +27,7 @@ import {
   useDebateClaimsBySpaces,
   useDebateRematch,
   useDebateRematchClaims,
+  useDebateRematchClaimsForIds,
   useLeaveDebateRematch,
   useRejectDebateRematchRequest,
 } from '~/core/debates/hooks';
@@ -162,7 +163,9 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   }, [publishedClaims.entities, recommendedEntities]);
 
   const publishedClaimIds = React.useMemo(() => claimEntities.map(claim => claim.id), [claimEntities]);
-  const publishedClaimsQuery = useDebateRematchClaims(sessionId, publishedClaimIds);
+  // Batched: geo-chat caps the ids per request, and the browsed list plus the curated claims runs
+  // past that cap after a page or two of Load more.
+  const publishedClaimsQuery = useDebateRematchClaimsForIds(sessionId, publishedClaimIds);
 
   const claims = React.useMemo(() => {
     const synchronizedClaims = new Map(

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -36,6 +36,7 @@ import { HubCardList } from '~/core/debates/matchmaking/hub-motion';
 import { HubPillButton } from '~/core/debates/matchmaking/hub-pill-button';
 import { HubQueryState } from '~/core/debates/matchmaking/hub-states';
 import { MatchmakingClaimCard } from '~/core/debates/matchmaking/matchmaking-claim-card';
+import { useRecommendedClaimSections } from '~/core/debates/recommended-claims';
 import { useEntitySidePanel } from '~/core/hooks/use-entity-side-panel';
 import { useEntityResponse } from '~/core/hooks/use-entity-vote';
 import { uuidToHex } from '~/core/id/normalize';
@@ -44,12 +45,13 @@ import { useQueryEntities } from '~/core/sync/use-store';
 
 import { Button } from '~/design-system/button';
 import { getChecked } from '~/design-system/checkbox';
+import { ChevronDownSmall } from '~/design-system/icons/chevron-down-small';
 import { Input } from '~/design-system/input';
 import { Text } from '~/design-system/text';
 
 const SEARCH_DEBOUNCE_MS = 250;
 
-type PickerTab = 'opponent' | 'all';
+type PickerTab = 'recommended' | 'opponent' | 'all';
 
 /**
  * The tab is narrow, so it carries the opponent's first name only: "Jenna Ruiz" -> "Jenna’s".
@@ -123,9 +125,7 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
       return { search: debouncedSearch, entities: [...next.values()] };
     });
   }, [debouncedSearch, publishedClaimsPage, publishedClaimsPlaceholder]);
-  const publishedClaimIds = React.useMemo(() => publishedClaims.entities.map(claim => claim.id), [publishedClaims]);
   const savedClaimsQuery = useDebateRematchClaims(sessionId);
-  const publishedClaimsQuery = useDebateRematchClaims(sessionId, publishedClaimIds);
   const createRequest = useCreateDebateRematchRequest(sessionId);
   const leaveSession = useLeaveDebateRematch(sessionId);
   const acceptRequest = useAcceptDebateRematchRequest();
@@ -133,6 +133,37 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   const session = sessionQuery.data ?? null;
   // A session opened from a profile challenge has no source debate, so nothing to exclude.
   const sourceDebateQuery = useDebate(session?.source_debate_id ?? '', Boolean(session?.source_debate_id));
+
+  // The opponent is whichever participant isn't the local user; both drive the curated lookup.
+  const participantSpaceIds = React.useMemo(
+    () => (session?.participants ?? []).map(participant => participant.profile_space_id),
+    [session?.participants]
+  );
+  const recommendedSections = useRecommendedClaimSections(participantSpaceIds);
+  const recommendedClaimIds = React.useMemo(
+    () => [...new Set(recommendedSections.flatMap(section => section.claimIds))],
+    [recommendedSections]
+  );
+
+  // Curated claims are picked by hand, so they can be ones the browsed pages haven't reached.
+  // Fetching their entities puts them in the same pool, and everything downstream — the session
+  // lookup, response kinds, the cards — treats them like any other published claim.
+  const { entities: recommendedEntities } = useQueryEntities({
+    where: { id: { in: recommendedClaimIds } },
+    first: 100,
+    enabled: recommendedClaimIds.length > 0,
+    placeholderData: keepPreviousData,
+  });
+
+  const claimEntities = React.useMemo(() => {
+    const byId = new Map(publishedClaims.entities.map(claim => [claim.id, claim]));
+    for (const claim of recommendedEntities) if (!byId.has(claim.id)) byId.set(claim.id, claim);
+    return [...byId.values()];
+  }, [publishedClaims.entities, recommendedEntities]);
+
+  const publishedClaimIds = React.useMemo(() => claimEntities.map(claim => claim.id), [claimEntities]);
+  const publishedClaimsQuery = useDebateRematchClaims(sessionId, publishedClaimIds);
+
   const claims = React.useMemo(() => {
     const synchronizedClaims = new Map(
       [...(savedClaimsQuery.data?.claims ?? []), ...(publishedClaimsQuery.data?.claims ?? [])].map(claim => [
@@ -144,7 +175,7 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
       ...(savedClaimsQuery.data?.excluded_claim_ids ?? []),
       ...(publishedClaimsQuery.data?.excluded_claim_ids ?? []),
     ]);
-    for (const claim of publishedClaims.entities) {
+    for (const claim of claimEntities) {
       if (
         claim.name &&
         claim.spaces[0] &&
@@ -175,13 +206,7 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
     return [...synchronizedClaims.values()]
       .filter(claim => !excludedClaimIds.has(claim.claim.claim_entity_id))
       .sort((a, b) => Number(b.shared_preference) - Number(a.shared_preference));
-  }, [
-    publishedClaims.entities,
-    publishedClaimsQuery.data,
-    savedClaimsQuery.data,
-    session?.participants,
-    sourceDebateQuery.data,
-  ]);
+  }, [claimEntities, publishedClaimsQuery.data, savedClaimsQuery.data, session?.participants, sourceDebateQuery.data]);
   const remoteParticipant =
     currentUserId === null
       ? null
@@ -201,17 +226,19 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   // label each card and drive the "Any topic" filter. A claim can carry several topics.
   const topicsByClaimId = React.useMemo(() => {
     const map = new Map<string, MatchmakingTopic[]>();
-    for (const entity of publishedClaims.entities) {
+    for (const entity of claimEntities) {
       const topics = entity.relations
         .filter(relation => relation.type.id === TOPICS_PROPERTY_ID && relation.isDeleted !== true)
         .map(relation => ({ id: relation.toEntity.id, name: relation.toEntity.name ?? null }));
       if (topics.length > 0) map.set(entity.id, topics);
     }
     return map;
-  }, [publishedClaims.entities]);
+  }, [claimEntities]);
 
-  // Opens on the opponent's positions: those are the claims that can turn into a debate now.
-  const [tab, setTab] = React.useState<PickerTab>('opponent');
+  // Left unset until the viewer picks one: Recommended is the best landing tab when a curator has
+  // put something together for this pairing, and it doesn't exist otherwise. Deciding in state
+  // would fix the default before that lookup settles.
+  const [chosenTab, setChosenTab] = React.useState<PickerTab | null>(null);
   const [spaceId, setSpaceId] = React.useState<string | null>(null);
   const [topicId, setTopicId] = React.useState<string | null>(null);
 
@@ -243,6 +270,10 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
     () => claims.filter(claim => opponentPositionOf(claim) !== null).length,
     [claims, opponentPositionOf]
   );
+
+  const hasRecommended = recommendedSections.length > 0;
+  const tab: PickerTab = chosenTab ?? (hasRecommended ? 'recommended' : 'opponent');
+  const setTab = setChosenTab;
 
   const facetSpaceIds = React.useMemo(() => [...new Set(claims.map(claim => claim.claim.space_id))], [claims]);
 
@@ -277,6 +308,21 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
 
   const hasFilters = Boolean(debouncedSearch || spaceId || topicId);
 
+  // The curated tab groups by block rather than listing flat, but narrows on the same filters.
+  const visibleSections = React.useMemo(() => {
+    if (tab !== 'recommended') return [];
+    const visibleById = new Map(visibleClaims.map(claim => [claim.claim.claim_entity_id, claim]));
+
+    return recommendedSections
+      .map(section => ({
+        ...section,
+        claims: section.claimIds
+          .map(claimId => visibleById.get(claimId))
+          .filter((claim): claim is DebateRematchClaim => claim !== undefined),
+      }))
+      .filter(section => section.claims.length > 0);
+  }, [recommendedSections, tab, visibleClaims]);
+
   // Readiness drives the card's Debate toggle and the rematch claims response doesn't carry it, so
   // read it from the per-space debate-claims endpoint instead — one query per space on screen.
   const claimIdsBySpace = React.useMemo(() => {
@@ -306,6 +352,25 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
     });
   };
 
+  const renderClaimCard = (claim: DebateRematchClaim) => (
+    <RematchClaimCard
+      key={claim.claim.claim_entity_id}
+      claim={claim}
+      session={session}
+      currentUserId={currentUserId}
+      readiness={readinessByClaimId.get(claim.claim.claim_entity_id) ?? null}
+      readinessUnresolved={readinessUnresolved}
+      onRequest={() =>
+        createRequest.mutate({
+          source_space_id: claim.claim.space_id,
+          claim_id: claim.claim.claim_entity_id,
+          format_id: defaultDebateFormatId,
+        })
+      }
+      busy={createRequest.isPending || session?.status === 'request_pending'}
+    />
+  );
+
   const pendingRequest = session?.status === 'request_pending' ? session.request : null;
   const incomingRequest = pendingRequest?.recipient_user_id === currentUserId ? pendingRequest : null;
   const incomingRequestParticipants =
@@ -334,6 +399,11 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
         <header className="mb-4 flex items-center justify-between gap-4">
           <h1 className="sr-only">Rematch {remoteName}</h1>
           <div className="flex min-w-0 items-center gap-5">
+            {hasRecommended ? (
+              <TabButton active={tab === 'recommended'} onClick={() => setTab('recommended')}>
+                Recommended
+              </TabButton>
+            ) : null}
             <TabButton active={tab === 'opponent'} onClick={() => setTab('opponent')}>
               <span className="truncate">{firstNamePossessive(remoteName)} positions</span>
               <span
@@ -403,13 +473,15 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
             publishedClaimsLoading
           }
           error={sessionQuery.error ?? savedClaimsQuery.error ?? publishedClaimsQuery.error}
-          isEmpty={visibleClaims.length === 0}
+          isEmpty={tab === 'recommended' ? visibleSections.length === 0 : visibleClaims.length === 0}
           emptyMessage={
             hasFilters
               ? 'No claims match these filters.'
-              : tab === 'opponent'
-                ? `${remoteName} hasn’t responded yet. When they do, those claims show up here.`
-                : 'No other eligible claims are available yet.'
+              : tab === 'recommended'
+                ? `Nothing recommended for you and ${remoteName} yet.`
+                : tab === 'opponent'
+                  ? `${remoteName} hasn’t responded yet. When they do, those claims show up here.`
+                  : 'No other eligible claims are available yet.'
           }
           emptyAction={
             hasFilters
@@ -424,26 +496,18 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
               : undefined
           }
         >
-          <HubCardList>
-            {visibleClaims.map(claim => (
-              <RematchClaimCard
-                key={claim.claim.claim_entity_id}
-                claim={claim}
-                session={session}
-                currentUserId={currentUserId}
-                readiness={readinessByClaimId.get(claim.claim.claim_entity_id) ?? null}
-                readinessUnresolved={readinessUnresolved}
-                onRequest={() =>
-                  createRequest.mutate({
-                    source_space_id: claim.claim.space_id,
-                    claim_id: claim.claim.claim_entity_id,
-                    format_id: defaultDebateFormatId,
-                  })
-                }
-                busy={createRequest.isPending || session?.status === 'request_pending'}
-              />
-            ))}
-          </HubCardList>
+          {tab === 'recommended' ? (
+            // Each data block on the curator's page is its own section, in page order.
+            <div className="flex flex-col gap-4">
+              {visibleSections.map(section => (
+                <RecommendedSection key={section.id} name={section.name} count={section.claims.length}>
+                  <HubCardList>{section.claims.map(renderClaimCard)}</HubCardList>
+                </RecommendedSection>
+              ))}
+            </div>
+          ) : (
+            <HubCardList>{visibleClaims.map(renderClaimCard)}</HubCardList>
+          )}
         </HubQueryState>
 
         {/* Outside the empty state deliberately: when a filter empties the list, fetching another
@@ -661,6 +725,33 @@ function useReadinessOnFirstPosition({
     optedIn.current = true;
     setReadiness.mutate({ spaceId: claim.space_id, claimId: claim.claim_entity_id, ready: true });
   }, [alreadyReady, claim.claim_entity_id, claim.space_id, localPosition, setReadiness]);
+}
+
+/** One curated block, collapsible so a long page of recommendations stays scannable. */
+function RecommendedSection({ name, count, children }: { name: string; count: number; children: React.ReactNode }) {
+  const [open, setOpen] = React.useState(true);
+  const contentId = React.useId();
+
+  return (
+    <section>
+      <button
+        type="button"
+        aria-expanded={open}
+        aria-controls={contentId}
+        onClick={() => setOpen(current => !current)}
+        className="mb-2 flex w-full items-center gap-2 text-left"
+      >
+        <Text as="h2" variant="smallTitle" color="text">
+          {name}
+        </Text>
+        <span className={cx('text-grey-04 transition-transform', open ? 'rotate-180' : undefined)}>
+          <ChevronDownSmall />
+        </span>
+        <span className="sr-only">{`${count} ${count === 1 ? 'claim' : 'claims'}`}</span>
+      </button>
+      {open ? <div id={contentId}>{children}</div> : null}
+    </section>
+  );
 }
 
 /** Both sides of a rematch claim, in the shape the shared card draws avatars from. */

--- a/apps/web/core/debates/hooks.test.tsx
+++ b/apps/web/core/debates/hooks.test.tsx
@@ -19,6 +19,7 @@ import {
   useDebateActivity,
   useDebateClaims,
   useDebateRematchClaims,
+  useDebateRematchClaimsForIds,
   useEndDebateTurn,
   useGeoChatAuth,
   useLeaveDebateRematch,
@@ -76,6 +77,55 @@ vi.mock('./api', async importOriginal => {
     markDebateReady: mocks.markDebateReady,
     updateDebateAvailability: mocks.updateDebateAvailability,
   };
+});
+
+describe('useDebateRematchClaimsForIds', () => {
+  beforeEach(() => {
+    mocks.authenticated = true;
+    mocks.identityToken.mockReturnValue(null);
+    mocks.getIdentityToken.mockResolvedValue(null);
+    mocks.listDebateRematchClaims.mockReset();
+    setCachedIdentityToken(null);
+  });
+
+  // geo-chat rejects a request naming more than 100 claims outright, and losing that response
+  // takes every claim's positions with it — not only the ones past the limit.
+  it('splits an over-long id list across requests and merges the responses', async () => {
+    const ids = Array.from({ length: 150 }, (_, index) => `claim-${index}`);
+    mocks.listDebateRematchClaims.mockImplementation((_sessionId: string, claimIds: string[]) =>
+      Promise.resolve({
+        claims: claimIds.map(claimId => ({ claim: { claim_entity_id: claimId } })),
+        excluded_claim_ids: [`excluded-${claimIds.length}`],
+      })
+    );
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+    const { result } = renderHook(() => useDebateRematchClaimsForIds('session-1', ids), {
+      wrapper: ({ children }: { children: ReactNode }) => (
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      ),
+    });
+
+    await waitFor(() => expect(result.current.data.claims).toHaveLength(150));
+    const batchSizes = mocks.listDebateRematchClaims.mock.calls.map(([, claimIds]) => claimIds.length);
+    expect(batchSizes).toEqual([100, 50]);
+    // Exclusions from every batch count, deduped.
+    expect(result.current.data.excluded_claim_ids.sort()).toEqual(['excluded-100', 'excluded-50']);
+  });
+
+  it('asks once for a list that fits', async () => {
+    mocks.listDebateRematchClaims.mockResolvedValue({ claims: [], excluded_claim_ids: [] });
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+    renderHook(() => useDebateRematchClaimsForIds('session-1', ['claim-a', 'claim-b']), {
+      wrapper: ({ children }: { children: ReactNode }) => (
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      ),
+    });
+
+    await waitFor(() => expect(mocks.listDebateRematchClaims).toHaveBeenCalledTimes(1));
+    expect(mocks.listDebateRematchClaims.mock.calls[0]![1]).toEqual(['claim-a', 'claim-b']);
+  });
 });
 
 function jwtExpiringIn(seconds: number) {

--- a/apps/web/core/debates/hooks.ts
+++ b/apps/web/core/debates/hooks.ts
@@ -14,6 +14,7 @@ import {
   type DebateMediaArtifactUrlRequest,
   type DebateMediaProcessRequest,
   type DebateMediaResponse,
+  type DebateRematchClaimsResponse,
   GeoChatRequestError,
   type LocalRecordingCompleteRequest,
   type LocalRecordingUploadRequest,
@@ -444,6 +445,55 @@ export function useLeaveDebateRematch(sessionId: string) {
       void queryClient.invalidateQueries({ queryKey: debateQueryKeys.rematch(accountKey, session.id) });
       void queryClient.invalidateQueries({ queryKey: activityKey });
     },
+  });
+}
+
+/**
+ * geo-chat rejects a request naming more than this many claims outright, so a caller browsing more
+ * claims than this has to ask in batches rather than in one request that 400s.
+ */
+export const REMATCH_CLAIM_ID_BATCH_SIZE = 100;
+
+/**
+ * {@link useDebateRematchClaims} for a list of ids of any length, split across as many requests as
+ * the server's per-request cap needs. The rematch picker accumulates claims a page at a time and
+ * adds curated ones on top, so it passes the cap in ordinary use — and losing the whole response
+ * to a 400 takes every claim's positions with it, not just the ones past the limit.
+ */
+export function useDebateRematchClaimsForIds(sessionId: string, claimIds: string[], enabled = true) {
+  const { accountKey, getPrivyIdentityToken } = useGeoChatAuth();
+
+  const batches = React.useMemo(() => {
+    const unique = [...new Set(claimIds)];
+    const chunks: string[][] = [];
+    for (let index = 0; index < unique.length; index += REMATCH_CLAIM_ID_BATCH_SIZE) {
+      chunks.push(unique.slice(index, index + REMATCH_CLAIM_ID_BATCH_SIZE));
+    }
+    return chunks;
+  }, [claimIds]);
+
+  // Stable by contract, as in `useDebateClaimsBySpaces`.
+  const combine = React.useCallback(
+    (results: UseQueryResult<DebateRematchClaimsResponse>[]) => ({
+      data: {
+        claims: results.flatMap(result => result.data?.claims ?? []),
+        excluded_claim_ids: [...new Set(results.flatMap(result => result.data?.excluded_claim_ids ?? []))],
+      },
+      isLoading: results.some(result => result.isLoading),
+      error: results.find(result => result.error)?.error ?? null,
+    }),
+    []
+  );
+
+  return useQueries({
+    queries: batches.map(batch => ({
+      ...debateQueryNetworkOptions,
+      queryKey: debateQueryKeys.rematchClaims(accountKey, sessionId, batch),
+      queryFn: ({ signal }: { signal?: AbortSignal }) =>
+        listDebateRematchClaims(sessionId, batch, getPrivyIdentityToken, accountKey, signal),
+      enabled: enabled && Boolean(sessionId),
+    })),
+    combine,
   });
 }
 

--- a/apps/web/core/debates/recommended-claims.test.tsx
+++ b/apps/web/core/debates/recommended-claims.test.tsx
@@ -4,6 +4,8 @@ import { renderHook } from '@testing-library/react';
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { CLAIM_TYPE_ID } from '~/core/claims/ontology';
+
 import {
   RECOMMENDED_CLAIMS_PARTICIPANTS_PROPERTY_ID,
   RECOMMENDED_CLAIMS_TYPE_ID,
@@ -16,13 +18,24 @@ const ME = '70a0a4ddda1057868ae4feebceaaacef';
 const OPPONENT = 'f3dab79cb5a3d9d1759656dd5361d1c6';
 const STRANGER = '019fedb11c417f3e9a112c7d5e8b4419';
 
-const mocks = vi.hoisted(() => ({ pages: [] as unknown[], blocks: [] as unknown[] }));
+const mocks = vi.hoisted(() => ({
+  pages: [] as unknown[],
+  blocks: [] as unknown[],
+  items: [] as unknown[],
+}));
 
-// One query per stage: pages by type, then the blocks they point at.
+// Three stages: pages by type, the blocks they point at, then the blocks' collection items. The
+// two id lookups are told apart by which ids they ask for.
 vi.mock('~/core/sync/use-store', () => ({
-  useQueryEntities: ({ where }: { where: Record<string, unknown> }) => ({
-    entities: 'types' in where ? mocks.pages : mocks.blocks,
-  }),
+  useQueryEntities: ({ where }: { where: Record<string, unknown> }) => {
+    if ('types' in where) return { entities: mocks.pages };
+    const ids = (where.id as { in?: string[] } | undefined)?.in ?? [];
+    const blocks = (mocks.blocks as Array<{ id: string }>).filter(block => ids.includes(block.id));
+    return {
+      entities:
+        blocks.length > 0 ? blocks : (mocks.items as Array<{ id: string }>).filter(item => ids.includes(item.id)),
+    };
+  },
 }));
 
 function page({
@@ -50,6 +63,14 @@ function page({
   };
 }
 
+function claimEntity(id: string) {
+  return { id, name: id, spaces: [CURATOR_SPACE], types: [{ id: CLAIM_TYPE_ID }], relations: [] };
+}
+
+function otherEntity(id: string) {
+  return { id, name: id, spaces: [CURATOR_SPACE], types: [{ id: 'some-other-type' }], relations: [] };
+}
+
 function block(id: string, name: string, claimIds: string[], positions?: string[]) {
   return {
     id,
@@ -66,13 +87,16 @@ function block(id: string, name: string, claimIds: string[], positions?: string[
 beforeEach(() => {
   mocks.pages = [page()];
   mocks.blocks = [block('block-1', 'Geopolitics & chips', ['claim-a', 'claim-b'])];
+  mocks.items = [claimEntity('claim-a'), claimEntity('claim-b')];
 });
 
 describe('useRecommendedClaimSections', () => {
   it('returns each block as a section of its collection items', () => {
     const { result } = renderHook(() => useRecommendedClaimSections([ME, OPPONENT]));
 
-    expect(result.current).toEqual([{ id: 'block-1', name: 'Geopolitics & chips', claimIds: ['claim-a', 'claim-b'] }]);
+    expect(result.current.sections).toEqual([
+      { id: 'block-1', name: 'Geopolitics & chips', claimIds: ['claim-a', 'claim-b'] },
+    ]);
   });
 
   // A page curated for a different pairing that happens to include one debater is not a
@@ -82,7 +106,7 @@ describe('useRecommendedClaimSections', () => {
 
     const { result } = renderHook(() => useRecommendedClaimSections([ME, OPPONENT]));
 
-    expect(result.current).toEqual([]);
+    expect(result.current.sections).toEqual([]);
   });
 
   // The type is not a permission — anyone could publish an entity of it.
@@ -91,28 +115,55 @@ describe('useRecommendedClaimSections', () => {
 
     const { result } = renderHook(() => useRecommendedClaimSections([ME, OPPONENT]));
 
-    expect(result.current).toEqual([]);
+    expect(result.current.sections).toEqual([]);
+  });
+
+  // A collection holds whatever the curator dropped in it, but this tab feeds a claim picker.
+  it('leaves out collection items that are not claims', () => {
+    mocks.blocks = [block('block-1', 'Geopolitics & chips', ['claim-a', 'not-a-claim'])];
+    mocks.items = [claimEntity('claim-a'), otherEntity('not-a-claim')];
+
+    const { result } = renderHook(() => useRecommendedClaimSections([ME, OPPONENT]));
+
+    expect(result.current.sections[0]!.claimIds).toEqual(['claim-a']);
+  });
+
+  it('drops a block whose items are all non-claims rather than heading an empty section', () => {
+    mocks.blocks = [block('block-1', 'Nothing debatable', ['not-a-claim'])];
+    mocks.items = [otherEntity('not-a-claim')];
+
+    const { result } = renderHook(() => useRecommendedClaimSections([ME, OPPONENT]));
+
+    expect(result.current.sections).toEqual([]);
+  });
+
+  it('hands back the claim entities so callers need not refetch them', () => {
+    const { result } = renderHook(() => useRecommendedClaimSections([ME, OPPONENT]));
+
+    expect(result.current.claimEntities.map(claim => claim.id)).toEqual(['claim-a', 'claim-b']);
   });
 
   it('orders claims within a block by their position', () => {
     mocks.blocks = [block('block-1', 'Geopolitics & chips', ['claim-late', 'claim-early'], ['b0', 'a0'])];
+    mocks.items = [claimEntity('claim-late'), claimEntity('claim-early')];
 
     const { result } = renderHook(() => useRecommendedClaimSections([ME, OPPONENT]));
 
-    expect(result.current[0]!.claimIds).toEqual(['claim-early', 'claim-late']);
+    expect(result.current.sections[0]!.claimIds).toEqual(['claim-early', 'claim-late']);
   });
 
   it('drops a block with nothing in it rather than heading an empty section', () => {
     mocks.blocks = [block('block-1', 'Empty', [])];
+    mocks.items = [];
 
     const { result } = renderHook(() => useRecommendedClaimSections([ME, OPPONENT]));
 
-    expect(result.current).toEqual([]);
+    expect(result.current.sections).toEqual([]);
   });
 
   it('returns nothing before the session has participants', () => {
     const { result } = renderHook(() => useRecommendedClaimSections([]));
 
-    expect(result.current).toEqual([]);
+    expect(result.current.sections).toEqual([]);
   });
 });

--- a/apps/web/core/debates/recommended-claims.test.tsx
+++ b/apps/web/core/debates/recommended-claims.test.tsx
@@ -22,13 +22,16 @@ const mocks = vi.hoisted(() => ({
   pages: [] as unknown[],
   blocks: [] as unknown[],
   items: [] as unknown[],
+  loading: false,
+  wheres: [] as Array<Record<string, unknown>>,
 }));
 
 // Three stages: pages by type, the blocks they point at, then the blocks' collection items. The
 // two id lookups are told apart by which ids they ask for.
 vi.mock('~/core/sync/use-store', () => ({
   useQueryEntities: ({ where }: { where: Record<string, unknown> }) => {
-    if ('types' in where) return { entities: mocks.pages };
+    mocks.wheres.push(where);
+    if ('types' in where) return { entities: mocks.pages, isLoading: mocks.loading };
     const ids = (where.id as { in?: string[] } | undefined)?.in ?? [];
     const blocks = (mocks.blocks as Array<{ id: string }>).filter(block => ids.includes(block.id));
     return {
@@ -88,6 +91,8 @@ beforeEach(() => {
   mocks.pages = [page()];
   mocks.blocks = [block('block-1', 'Geopolitics & chips', ['claim-a', 'claim-b'])];
   mocks.items = [claimEntity('claim-a'), claimEntity('claim-b')];
+  mocks.loading = false;
+  mocks.wheres.length = 0;
 });
 
 describe('useRecommendedClaimSections', () => {
@@ -159,6 +164,39 @@ describe('useRecommendedClaimSections', () => {
     const { result } = renderHook(() => useRecommendedClaimSections([ME, OPPONENT]));
 
     expect(result.current.sections).toEqual([]);
+  });
+
+  // An absent index has to fall to the end, not to the front where an empty-string default puts it.
+  it('sorts items without a position after the ones that have one', () => {
+    mocks.blocks = [block('block-1', 'Geopolitics & chips', ['claim-unplaced', 'claim-placed'])];
+    (mocks.blocks[0] as { relations: Array<{ position?: string }> }).relations[0]!.position = undefined;
+    mocks.items = [claimEntity('claim-unplaced'), claimEntity('claim-placed')];
+
+    const { result } = renderHook(() => useRecommendedClaimSections([ME, OPPONENT]));
+
+    expect(result.current.sections[0]!.claimIds).toEqual(['claim-placed', 'claim-unplaced']);
+  });
+
+  // Anyone can publish this type, so a hundred unrelated entities could crowd a real page out of a
+  // result capped before the source is checked.
+  it('asks only for pages in the curated spaces', () => {
+    renderHook(() => useRecommendedClaimSections([ME, OPPONENT]));
+
+    const pagesWhere = mocks.wheres.find(where => 'types' in where) as {
+      OR?: Array<{ spaces?: Array<{ equals?: string }> }>;
+    };
+    expect(pagesWhere.OR?.map(branch => branch.spaces?.[0]?.equals)).toEqual([
+      '8a4955bcd9d0fc0d8613f17f01de3b9f',
+      CURATOR_SPACE,
+    ]);
+  });
+
+  it('reports that it is still looking rather than that nothing is recommended', () => {
+    mocks.loading = true;
+
+    const { result } = renderHook(() => useRecommendedClaimSections([ME, OPPONENT]));
+
+    expect(result.current.isLoading).toBe(true);
   });
 
   it('returns nothing before the session has participants', () => {

--- a/apps/web/core/debates/recommended-claims.test.tsx
+++ b/apps/web/core/debates/recommended-claims.test.tsx
@@ -1,0 +1,118 @@
+import { SystemIds } from '@geoprotocol/geo-sdk';
+import '@testing-library/jest-dom/vitest';
+import { renderHook } from '@testing-library/react';
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  RECOMMENDED_CLAIMS_PARTICIPANTS_PROPERTY_ID,
+  RECOMMENDED_CLAIMS_TYPE_ID,
+  useRecommendedClaimSections,
+} from './recommended-claims';
+
+const CURATOR_SPACE = 'f3dab79cb5a3d9d1759656dd5361d1c6';
+const OTHER_SPACE = '019fedae72b67ab2927adf044d57c566';
+const ME = '70a0a4ddda1057868ae4feebceaaacef';
+const OPPONENT = 'f3dab79cb5a3d9d1759656dd5361d1c6';
+const STRANGER = '019fedb11c417f3e9a112c7d5e8b4419';
+
+const mocks = vi.hoisted(() => ({ pages: [] as unknown[], blocks: [] as unknown[] }));
+
+// One query per stage: pages by type, then the blocks they point at.
+vi.mock('~/core/sync/use-store', () => ({
+  useQueryEntities: ({ where }: { where: Record<string, unknown> }) => ({
+    entities: 'types' in where ? mocks.pages : mocks.blocks,
+  }),
+}));
+
+function page({
+  spaces = [CURATOR_SPACE],
+  participants = [ME, OPPONENT],
+  blockIds = ['block-1'],
+}: { spaces?: string[]; participants?: string[]; blockIds?: string[] } = {}) {
+  return {
+    id: 'page-1',
+    name: 'Recommended claims',
+    spaces,
+    types: [{ id: RECOMMENDED_CLAIMS_TYPE_ID }],
+    relations: [
+      ...participants.map((spaceId, index) => ({
+        type: { id: RECOMMENDED_CLAIMS_PARTICIPANTS_PROPERTY_ID },
+        toEntity: { id: spaceId },
+        position: `a${index}`,
+      })),
+      ...blockIds.map((id, index) => ({
+        type: { id: SystemIds.BLOCKS },
+        toEntity: { id },
+        position: `a${index}`,
+      })),
+    ],
+  };
+}
+
+function block(id: string, name: string, claimIds: string[], positions?: string[]) {
+  return {
+    id,
+    name,
+    spaces: [CURATOR_SPACE],
+    relations: claimIds.map((claimId, index) => ({
+      type: { id: SystemIds.COLLECTION_ITEM_RELATION_TYPE },
+      toEntity: { id: claimId },
+      position: positions?.[index] ?? `a${index}`,
+    })),
+  };
+}
+
+beforeEach(() => {
+  mocks.pages = [page()];
+  mocks.blocks = [block('block-1', 'Geopolitics & chips', ['claim-a', 'claim-b'])];
+});
+
+describe('useRecommendedClaimSections', () => {
+  it('returns each block as a section of its collection items', () => {
+    const { result } = renderHook(() => useRecommendedClaimSections([ME, OPPONENT]));
+
+    expect(result.current).toEqual([{ id: 'block-1', name: 'Geopolitics & chips', claimIds: ['claim-a', 'claim-b'] }]);
+  });
+
+  // A page curated for a different pairing that happens to include one debater is not a
+  // recommendation for this debate.
+  it('ignores a page that does not cover every debater', () => {
+    mocks.pages = [page({ participants: [ME, STRANGER] })];
+
+    const { result } = renderHook(() => useRecommendedClaimSections([ME, OPPONENT]));
+
+    expect(result.current).toEqual([]);
+  });
+
+  // The type is not a permission — anyone could publish an entity of it.
+  it('ignores a page published outside the curated spaces', () => {
+    mocks.pages = [page({ spaces: [OTHER_SPACE] })];
+
+    const { result } = renderHook(() => useRecommendedClaimSections([ME, OPPONENT]));
+
+    expect(result.current).toEqual([]);
+  });
+
+  it('orders claims within a block by their position', () => {
+    mocks.blocks = [block('block-1', 'Geopolitics & chips', ['claim-late', 'claim-early'], ['b0', 'a0'])];
+
+    const { result } = renderHook(() => useRecommendedClaimSections([ME, OPPONENT]));
+
+    expect(result.current[0]!.claimIds).toEqual(['claim-early', 'claim-late']);
+  });
+
+  it('drops a block with nothing in it rather than heading an empty section', () => {
+    mocks.blocks = [block('block-1', 'Empty', [])];
+
+    const { result } = renderHook(() => useRecommendedClaimSections([ME, OPPONENT]));
+
+    expect(result.current).toEqual([]);
+  });
+
+  it('returns nothing before the session has participants', () => {
+    const { result } = renderHook(() => useRecommendedClaimSections([]));
+
+    expect(result.current).toEqual([]);
+  });
+});

--- a/apps/web/core/debates/recommended-claims.ts
+++ b/apps/web/core/debates/recommended-claims.ts
@@ -47,11 +47,24 @@ export function useRecommendedClaimSections(participantSpaceIds: string[]): {
   sections: RecommendedClaimSection[];
   /** The claims themselves, so callers don't fetch what this already resolved. */
   claimEntities: Entity[];
+  /**
+   * True until every stage has settled. Empty sections mean "nothing recommended" only once this
+   * is false — before then they only mean "still looking", and a caller that can't tell the two
+   * apart will show the wrong tab and then move it under the viewer.
+   */
+  isLoading: boolean;
 } {
   const enabled = participantSpaceIds.length > 0;
 
-  const { entities: pages } = useQueryEntities({
-    where: { types: [{ id: { equals: RECOMMENDED_CLAIMS_TYPE_ID } }] },
+  const { entities: pages, isLoading: pagesLoading } = useQueryEntities({
+    // Scoped to the curated spaces in the query, not after it: anyone can publish this type, and a
+    // hundred unrelated entities would otherwise fill the page and crowd a real one out.
+    // One branch per space rather than one `spaces` array — a multi-id space filter matches
+    // nothing, where a single-id one matches as expected.
+    where: {
+      types: [{ id: { equals: RECOMMENDED_CLAIMS_TYPE_ID } }],
+      OR: RECOMMENDED_CLAIMS_SPACE_IDS.map(spaceId => ({ spaces: [{ equals: spaceId }] })),
+    },
     first: 100,
     enabled,
   });
@@ -80,7 +93,7 @@ export function useRecommendedClaimSections(participantSpaceIds: string[]): {
       );
   }, [enabled, pages, participantSpaceIds]);
 
-  const { entities: blocks } = useQueryEntities({
+  const { entities: blocks, isLoading: blocksLoading } = useQueryEntities({
     where: { id: { in: blockIds } },
     first: 100,
     enabled: blockIds.length > 0,
@@ -107,7 +120,7 @@ export function useRecommendedClaimSections(participantSpaceIds: string[]): {
 
   const itemIds = React.useMemo(() => [...new Set(itemIdsByBlock.flatMap(block => block.itemIds))], [itemIdsByBlock]);
 
-  const { entities: items } = useQueryEntities({
+  const { entities: items, isLoading: itemsLoading } = useQueryEntities({
     where: { id: { in: itemIds } },
     first: 100,
     enabled: itemIds.length > 0,
@@ -131,10 +144,19 @@ export function useRecommendedClaimSections(participantSpaceIds: string[]): {
     );
   }, [claimEntities, itemIdsByBlock]);
 
-  return React.useMemo(() => ({ sections, claimEntities }), [claimEntities, sections]);
+  // Each stage feeds the next, so any of them still running means the answer isn't in yet.
+  const isLoading =
+    enabled && (pagesLoading || (blockIds.length > 0 && blocksLoading) || (itemIds.length > 0 && itemsLoading));
+
+  return React.useMemo(() => ({ sections, claimEntities, isLoading }), [claimEntities, isLoading, sections]);
 }
 
 /** Blocks and collection items both carry a fractional index; absent, they fall to the end. */
 function byPosition(a: { position?: string }, z: { position?: string }) {
-  return (a.position ?? '').localeCompare(z.position ?? '');
+  // An empty string sorts before every real position, so absent has to be handled on its own
+  // rather than defaulted — otherwise "falls to the end" would put it first.
+  if (a.position === undefined || z.position === undefined) {
+    return Number(a.position === undefined) - Number(z.position === undefined);
+  }
+  return a.position.localeCompare(z.position);
 }

--- a/apps/web/core/debates/recommended-claims.ts
+++ b/apps/web/core/debates/recommended-claims.ts
@@ -4,8 +4,10 @@ import { SystemIds } from '@geoprotocol/geo-sdk';
 
 import * as React from 'react';
 
+import { CLAIM_TYPE_ID } from '~/core/claims/ontology';
 import { ID } from '~/core/id';
 import { useQueryEntities } from '~/core/sync/use-store';
+import type { Entity } from '~/core/types';
 
 /** A curated "Recommended claims" page: claims a curator has picked out for a specific pairing. */
 export const RECOMMENDED_CLAIMS_TYPE_ID = '2f8a7be40c5242368bac78511bf0b47f';
@@ -41,7 +43,11 @@ export type RecommendedClaimSection = {
  * Two round trips by necessity: the page carries its blocks as relations, but a block's claims
  * live on the block entity, which has to be fetched in turn.
  */
-export function useRecommendedClaimSections(participantSpaceIds: string[]): RecommendedClaimSection[] {
+export function useRecommendedClaimSections(participantSpaceIds: string[]): {
+  sections: RecommendedClaimSection[];
+  /** The claims themselves, so callers don't fetch what this already resolved. */
+  claimEntities: Entity[];
+} {
   const enabled = participantSpaceIds.length > 0;
 
   const { entities: pages } = useQueryEntities({
@@ -80,29 +86,52 @@ export function useRecommendedClaimSections(participantSpaceIds: string[]): Reco
     enabled: blockIds.length > 0,
   });
 
-  return React.useMemo(() => {
+  // Item ids per block, in block order. These are whatever the curator collected — a collection
+  // can hold anything, so what they *are* isn't known until they're fetched.
+  const itemIdsByBlock = React.useMemo(() => {
     const byId = new Map(blocks.map(block => [block.id, block]));
 
-    return blockIds
-      .map(blockId => {
-        const block = byId.get(blockId);
-        if (!block) return null;
+    return blockIds.flatMap(blockId => {
+      const block = byId.get(blockId);
+      if (!block) return [];
 
-        const claimIds = block.relations
-          .filter(
-            relation => relation.type.id === SystemIds.COLLECTION_ITEM_RELATION_TYPE && relation.isDeleted !== true
-          )
-          .slice()
-          .sort(byPosition)
-          .map(relation => relation.toEntity.id);
+      const itemIds = block.relations
+        .filter(relation => relation.type.id === SystemIds.COLLECTION_ITEM_RELATION_TYPE && relation.isDeleted !== true)
+        .slice()
+        .sort(byPosition)
+        .map(relation => relation.toEntity.id);
 
-        // A block with nothing in it would render as an empty heading.
-        if (claimIds.length === 0) return null;
-
-        return { id: block.id, name: block.name ?? 'Recommended', claimIds };
-      })
-      .filter((section): section is RecommendedClaimSection => section !== null);
+      return [{ id: block.id, name: block.name ?? 'Recommended', itemIds }];
+    });
   }, [blockIds, blocks]);
+
+  const itemIds = React.useMemo(() => [...new Set(itemIdsByBlock.flatMap(block => block.itemIds))], [itemIdsByBlock]);
+
+  const { entities: items } = useQueryEntities({
+    where: { id: { in: itemIds } },
+    first: 100,
+    enabled: itemIds.length > 0,
+  });
+
+  const claimEntities = React.useMemo(
+    () => items.filter(item => item.types.some(type => ID.equals(type.id, CLAIM_TYPE_ID))),
+    [items]
+  );
+
+  const sections = React.useMemo(() => {
+    // A collection can hold anything the curator dropped in it, but this tab feeds a claim picker:
+    // anything that isn't a claim has no side to take and no debate to request.
+    const claimIds = new Set(claimEntities.map(claim => claim.id));
+
+    return (
+      itemIdsByBlock
+        .map(block => ({ id: block.id, name: block.name, claimIds: block.itemIds.filter(id => claimIds.has(id)) }))
+        // A block holding no claims would render as a heading over nothing.
+        .filter(section => section.claimIds.length > 0)
+    );
+  }, [claimEntities, itemIdsByBlock]);
+
+  return React.useMemo(() => ({ sections, claimEntities }), [claimEntities, sections]);
 }
 
 /** Blocks and collection items both carry a fractional index; absent, they fall to the end. */

--- a/apps/web/core/debates/recommended-claims.ts
+++ b/apps/web/core/debates/recommended-claims.ts
@@ -1,0 +1,111 @@
+'use client';
+
+import { SystemIds } from '@geoprotocol/geo-sdk';
+
+import * as React from 'react';
+
+import { ID } from '~/core/id';
+import { useQueryEntities } from '~/core/sync/use-store';
+
+/** A curated "Recommended claims" page: claims a curator has picked out for a specific pairing. */
+export const RECOMMENDED_CLAIMS_TYPE_ID = '2f8a7be40c5242368bac78511bf0b47f';
+
+/** Points at the personal space entity of each debater the page is curated for. */
+export const RECOMMENDED_CLAIMS_PARTICIPANTS_PROPERTY_ID = '7169d65aa8b94addb6cc23c19c9fc0dd';
+
+/**
+ * Only pages curated in one of these spaces count. The type alone isn't a permission: anyone could
+ * publish an entity of it, and a recommendation is only worth surfacing if we trust its source.
+ */
+export const RECOMMENDED_CLAIMS_SPACE_IDS = [
+  // Adam
+  '8a4955bcd9d0fc0d8613f17f01de3b9f',
+  // Preston
+  'f3dab79cb5a3d9d1759656dd5361d1c6',
+];
+
+/** One data block from a recommended page — a named group of claims. */
+export type RecommendedClaimSection = {
+  id: string;
+  name: string;
+  claimIds: string[];
+};
+
+/**
+ * The curated claim groups for a pair of debaters, in page order.
+ *
+ * A page qualifies when it is one of the curated spaces' `Recommended claims` entities and its
+ * `Participants` cover *every* debater in the session — a page curated for a different pairing
+ * that happens to include one of them isn't a recommendation for this debate.
+ *
+ * Two round trips by necessity: the page carries its blocks as relations, but a block's claims
+ * live on the block entity, which has to be fetched in turn.
+ */
+export function useRecommendedClaimSections(participantSpaceIds: string[]): RecommendedClaimSection[] {
+  const enabled = participantSpaceIds.length > 0;
+
+  const { entities: pages } = useQueryEntities({
+    where: { types: [{ id: { equals: RECOMMENDED_CLAIMS_TYPE_ID } }] },
+    first: 100,
+    enabled,
+  });
+
+  // Block ids in page order, from every page curated for this exact set of debaters.
+  const blockIds = React.useMemo(() => {
+    if (!enabled) return [];
+
+    return pages
+      .filter(page => page.spaces.some(spaceId => RECOMMENDED_CLAIMS_SPACE_IDS.some(id => ID.equals(id, spaceId))))
+      .filter(page => {
+        const participants = page.relations
+          .filter(
+            relation => relation.type.id === RECOMMENDED_CLAIMS_PARTICIPANTS_PROPERTY_ID && relation.isDeleted !== true
+          )
+          .map(relation => relation.toEntity.id);
+
+        return participantSpaceIds.every(spaceId => participants.some(participant => ID.equals(participant, spaceId)));
+      })
+      .flatMap(page =>
+        page.relations
+          .filter(relation => relation.type.id === SystemIds.BLOCKS && relation.isDeleted !== true)
+          .slice()
+          .sort(byPosition)
+          .map(relation => relation.toEntity.id)
+      );
+  }, [enabled, pages, participantSpaceIds]);
+
+  const { entities: blocks } = useQueryEntities({
+    where: { id: { in: blockIds } },
+    first: 100,
+    enabled: blockIds.length > 0,
+  });
+
+  return React.useMemo(() => {
+    const byId = new Map(blocks.map(block => [block.id, block]));
+
+    return blockIds
+      .map(blockId => {
+        const block = byId.get(blockId);
+        if (!block) return null;
+
+        const claimIds = block.relations
+          .filter(
+            relation => relation.type.id === SystemIds.COLLECTION_ITEM_RELATION_TYPE && relation.isDeleted !== true
+          )
+          .slice()
+          .sort(byPosition)
+          .map(relation => relation.toEntity.id);
+
+        // A block with nothing in it would render as an empty heading.
+        if (claimIds.length === 0) return null;
+
+        return { id: block.id, name: block.name ?? 'Recommended', claimIds };
+      })
+      .filter((section): section is RecommendedClaimSection => section !== null);
+  }, [blockIds, blocks]);
+}
+
+/** Blocks and collection items both carry a fractional index; absent, they fall to the end. */
+function byPosition(a: { position?: string }, z: { position?: string }) {
+  return (a.position ?? '').localeCompare(z.position ?? '');
+}


### PR DESCRIPTION
Adds the **Recommended** tab to the picker shared by *debate again* and *debate this person*.

A curator publishes a `Recommended claims` page naming two or more debaters in its **Participants**, and fills it with data blocks of claims. When both people in a rematch session are named on such a page, its blocks become the picker's first tab — one collapsible section per block, in page order.

I read the shape off the [example page](https://www.geobrowser.io/space/f3dab79cb5a3d9d1759656dd5361d1c6/e02b9be75f6e454cb4de83236fbc3ee3) rather than assuming it:

- **Participants** point at the debaters' personal **space** entities, so they match `participant.profile_space_id` directly.
- **Blocks** are `Data block` entities using a **Collection data source**; their claims are `Collection item` relations.
- Both blocks and collection items carry a fractional `position`, so both are ordered by it.

Only Preston's space has a page today; Adam's is empty. Both are checked.

### Two guards worth reviewing

- **Curated spaces only.** The type isn't a permission — anyone could publish an entity of it — so a page only counts from Adam's or Preston's space.
- **Every debater, not any.** The Participants must cover *both* people in the session. A page curated for a different pairing that happens to include one of them isn't a recommendation for this debate.

Both are sabotage-checked: relaxing `every` to `some`, or dropping the space filter, each fails its test.

### How curated claims reach the cards

They're picked by hand, so they can be claims the browsed pages haven't paged in yet. Rather than list them through a separate path, their entities join the same pool the browsed claims feed — so the session lookup, response kinds, positions and the cards treat them like any other published claim, and the space/topic/search filters narrow the sections exactly as they narrow the flat lists. A section whose claims all fall out of the filters disappears rather than heading an empty group.

### The landing tab

The tab doesn't exist when nothing is curated for the pairing, so the default can't be fixed at mount — it's a null-until-chosen tab resolved once the lookup settles, landing on Recommended when there is something and the opponent's positions otherwise. An explicit choice always sticks.

### Verification

- `recommended-claims.test.tsx` (new, 6): sections from blocks, the two guards, ordering by position, empty blocks dropped, and nothing before the session has participants.
- `rematch-page-client.test.tsx` (+4): the tab hidden when nothing is curated, opening on Recommended with a section per block in order, collapsing one section without touching others, and a section disappearing when the filters empty it.
- All debates suites: 549 pass. Two files fail to load (`media-session`, `debate-room-page-client`) — both fail identically on master.
- Typecheck and prettier clean.

### Worth flagging

- The screenshot shows the middle tab as **Debate now**; it currently reads **`<first name>'s positions`** from #2137, which you asked for explicitly. I've left that alone — say the word if the screenshot is the newer intent.
- The screenshot puts **Any topic** left and **Any space** right; the shared `SpaceTopicFilters` renders space first. Left as-is rather than adding a prop to reverse a shared component.

### Not verified

Not exercised in the running app — needs a live rematch session between two people who are both named on a curated page.