### PR TITLE
fix(debates): give the challenge recipient their popup back

### DIFF
--- a/apps/web/core/debates/debate-coordinator.test.tsx
+++ b/apps/web/core/debates/debate-coordinator.test.tsx
@@ -30,6 +30,8 @@ const mocks = vi.hoisted(() => ({
   authenticated: true,
   gatewayPaused: false,
   currentUserId: 'user-for' as string | null,
+  // What the token exchange answers with when the stored session hasn't been written yet.
+  resolvedUserId: null as string | null,
   refetch: vi.fn(),
 }));
 
@@ -42,7 +44,11 @@ vi.mock('~/core/analytics', () => ({ capture: mocks.capture }));
 
 vi.mock('./api', async importOriginal => {
   const actual = await importOriginal<typeof import('./api')>();
-  return { ...actual, getCurrentGeoChatUserId: () => mocks.currentUserId };
+  return {
+    ...actual,
+    getCurrentGeoChatUserId: () => mocks.currentUserId,
+    resolveCurrentGeoChatUserId: () => Promise.resolve(mocks.resolvedUserId),
+  };
 });
 
 vi.mock('./hooks', () => ({
@@ -108,6 +114,7 @@ beforeEach(() => {
   mocks.authenticated = true;
   mocks.gatewayPaused = false;
   mocks.currentUserId = 'user-for';
+  mocks.resolvedUserId = null;
   mocks.refetch.mockReset();
   Object.defineProperty(navigator, 'share', { configurable: true, value: mocks.share });
   Object.defineProperty(navigator, 'canShare', { configurable: true, value: mocks.canShare });
@@ -242,6 +249,30 @@ describe('DebateCoordinator', () => {
 
     await waitFor(() => expect(screen.queryByText('Debate request')).not.toBeInTheDocument());
     expect(screen.queryByText(/Waiting for .* to accept/)).not.toBeInTheDocument();
+  });
+
+  // The stored geo-chat session is what names the viewer, and it isn't always written yet. An
+  // absent id used to read as "not the recipient", which left the person the challenge was *for*
+  // with no popup at all — the bug this hook exists to close.
+  it('still prompts the recipient when the viewer id has to be resolved', async () => {
+    mocks.currentUserId = null;
+    mocks.resolvedUserId = 'user-recipient';
+    mocks.activity = { ...idleActivity(), challenge: pendingChallenge() };
+
+    render(<DebateCoordinator />);
+
+    expect(await screen.findByText('Debate request')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Explore claims' })).toBeInTheDocument();
+  });
+
+  it('keeps the sender uninterrupted once their id resolves', async () => {
+    mocks.currentUserId = null;
+    mocks.resolvedUserId = 'user-requester';
+    mocks.activity = { ...idleActivity(), challenge: pendingChallenge() };
+
+    render(<DebateCoordinator />);
+
+    await waitFor(() => expect(screen.queryByText('Debate request')).not.toBeInTheDocument());
   });
 
   // The sender learns it was accepted the same way every other flow does: activity gains a rematch

--- a/apps/web/core/debates/debate-coordinator.tsx
+++ b/apps/web/core/debates/debate-coordinator.tsx
@@ -12,7 +12,7 @@ import { Spinner } from '~/design-system/spinner';
 import { Text } from '~/design-system/text';
 
 import { activeDebate } from './activity-state';
-import { type DebateSharePrompt, getCurrentGeoChatUserId } from './api';
+import { type DebateSharePrompt } from './api';
 import { useClaimResponseIndexedNotifier } from './claim-response-indexed-notifier';
 import { useDebatePresence } from './debate-attention';
 import { DebateChallengeDialog } from './debate-challenge-dialog';
@@ -35,6 +35,7 @@ import {
   isAbortError,
   usePreparedSocialVideo,
 } from './social-video-share';
+import { useCurrentGeoChatUserId } from './use-current-geo-chat-user-id';
 import { useScrollLock } from './use-scroll-lock';
 
 export function DebateCoordinator() {
@@ -56,7 +57,7 @@ export function DebateCoordinator() {
     geoChatAuth.accountKey
   );
   const activityQuery = useDebateActivity(isDebatesEnabled);
-  const currentUserId = getCurrentGeoChatUserId();
+  const currentUserId = useCurrentGeoChatUserId();
   const activity = activityQuery.data ?? null;
   const debate = activeDebate(activity);
   const reportedChallenge = activity?.challenge?.status === 'pending' ? activity.challenge : null;

--- a/apps/web/core/debates/matchmaking/requests-tab.test.tsx
+++ b/apps/web/core/debates/matchmaking/requests-tab.test.tsx
@@ -16,12 +16,14 @@ const mocks = vi.hoisted(() => ({
   block: vi.fn(),
   acceptChallenge: vi.fn(),
   rejectChallenge: vi.fn(),
+  currentUserId: 'user-me' as string | null,
 }));
 
 vi.mock('../hooks', () => ({
   useDebateActivity: () => ({ data: { challenge: mocks.challenge, outbound_request: null } }),
   useAcceptDebateChallenge: () => ({ mutate: mocks.acceptChallenge, isPending: false, error: null }),
   useRejectDebateChallenge: () => ({ mutate: mocks.rejectChallenge, isPending: false, error: null }),
+  useGeoChatAuth: () => ({ ready: true, authenticated: true, accountKey: 'account-a', getPrivyIdentityToken: vi.fn() }),
 }));
 
 vi.mock('./hooks', () => ({
@@ -43,7 +45,8 @@ vi.mock('~/core/hooks/use-spaces-by-ids', () => ({
 
 vi.mock('../api', async importOriginal => ({
   ...(await importOriginal<typeof import('../api')>()),
-  getCurrentGeoChatUserId: () => 'user-me',
+  getCurrentGeoChatUserId: () => mocks.currentUserId,
+  resolveCurrentGeoChatUserId: () => Promise.resolve(mocks.currentUserId),
 }));
 
 const SPACE_A = '019fedae-72b6-7ab2-927a-df044d57c566';
@@ -98,6 +101,7 @@ beforeEach(() => {
   mocks.incoming = [request('request-1', SPACE_A, 'Bitcoin will never go above $250K')];
   mocks.outbound = null;
   mocks.challenge = null;
+  mocks.currentUserId = 'user-me';
   mocks.accept.mockReset();
   mocks.dismiss.mockReset();
   mocks.withdraw.mockReset();
@@ -217,6 +221,26 @@ describe('RequestsTab', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Cancel request' }));
     expect(mocks.rejectChallenge).toHaveBeenCalledWith('challenge-1');
+  });
+
+  // Guessing the role from an absent id filed the challenge under Sent, which told the person it
+  // was sent *to* that they had sent it, and offered them "Cancel request" instead of accepting.
+  it('waits for the viewer id before deciding which side of a challenge they are on', async () => {
+    mocks.incoming = [];
+    mocks.currentUserId = null;
+    mocks.challenge = challenge('recipient');
+    render(<RequestsTab />);
+
+    expect(screen.queryByRole('heading', { name: 'Sent' })).not.toBeInTheDocument();
+    expect(screen.queryByText('Waiting for a reply')).not.toBeInTheDocument();
+
+    // …and once it resolves, it lands under Received with the accept action.
+    mocks.currentUserId = 'user-me';
+    cleanup();
+    render(<RequestsTab />);
+
+    expect(await screen.findByRole('heading', { name: 'Received' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Explore claims' })).toBeInTheDocument();
   });
 
   it('shows both sides of a request and keeps blocking behind the overflow menu', () => {

--- a/apps/web/core/debates/matchmaking/requests-tab.tsx
+++ b/apps/web/core/debates/matchmaking/requests-tab.tsx
@@ -6,9 +6,10 @@ import { Avatar } from '~/design-system/avatar';
 import { Time } from '~/design-system/icons/time';
 import { Text } from '~/design-system/text';
 
-import { type DebateChallenge, getCurrentGeoChatUserId } from '../api';
+import type { DebateChallenge } from '../api';
 import { useAcceptDebateChallenge, useDebateActivity, useRejectDebateChallenge } from '../hooks';
 import { speakerLabel } from '../playback-utils';
+import { useCurrentGeoChatUserId } from '../use-current-geo-chat-user-id';
 import { SpaceTopicFilters } from './claims-tab';
 import { useDebateRequests } from './hooks';
 import { HubFilterMenu, type HubFilterOption } from './hub-filter-menu';
@@ -67,10 +68,16 @@ export function RequestsTab() {
     React.useMemo(() => (reportedChallenge ? [reportedChallenge] : []), [reportedChallenge])
   );
   const challenge = liveChallenges[0] ?? null;
-  const currentUserId = getCurrentGeoChatUserId();
-  // A claimless challenge belongs to no space, so a space filter can only hide it.
+  const currentUserId = useCurrentGeoChatUserId();
+  // A claimless challenge belongs to no space, so a space filter can only hide it. Role is left
+  // undecided until the viewer's id is known — guessing files an incoming challenge under Sent,
+  // where it reads as something the viewer sent and offers them "Cancel request" for it.
   const challengeRole =
-    !challenge || spaceId ? null : challenge.recipient.user_id === currentUserId ? 'recipient' : 'requester';
+    !challenge || spaceId || !currentUserId
+      ? null
+      : challenge.recipient.user_id === currentUserId
+        ? 'recipient'
+        : 'requester';
   const incomingChallenge = challengeRole === 'recipient' && status !== 'sent' ? challenge : null;
   const outgoingChallenge = challengeRole === 'requester' && status !== 'received' ? challenge : null;
 

--- a/apps/web/core/debates/use-current-geo-chat-user-id.test.tsx
+++ b/apps/web/core/debates/use-current-geo-chat-user-id.test.tsx
@@ -1,0 +1,97 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useCurrentGeoChatUserId } from './use-current-geo-chat-user-id';
+
+const mocks = vi.hoisted(() => ({
+  stored: null as string | null,
+  authenticated: true,
+  accountKey: 'account-a' as string | null,
+  resolve: vi.fn(),
+}));
+
+vi.mock('./api', async importOriginal => ({
+  ...(await importOriginal<typeof import('./api')>()),
+  getCurrentGeoChatUserId: () => mocks.stored,
+  resolveCurrentGeoChatUserId: (...args: unknown[]) => mocks.resolve(...args),
+}));
+
+vi.mock('./hooks', () => ({
+  useGeoChatAuth: () => ({
+    ready: true,
+    authenticated: mocks.authenticated,
+    accountKey: mocks.accountKey,
+    getPrivyIdentityToken: vi.fn(),
+  }),
+}));
+
+function Probe() {
+  const userId = useCurrentGeoChatUserId();
+  return <span data-testid="id">{userId ?? 'unknown'}</span>;
+}
+
+const readId = () => screen.getByTestId('id').textContent;
+
+beforeEach(() => {
+  mocks.stored = null;
+  mocks.authenticated = true;
+  mocks.accountKey = 'account-a';
+  mocks.resolve.mockReset();
+  mocks.resolve.mockResolvedValue('user-a');
+});
+
+afterEach(cleanup);
+
+describe('useCurrentGeoChatUserId', () => {
+  it('uses the stored session without a round trip', () => {
+    mocks.stored = 'user-a';
+    render(<Probe />);
+
+    expect(readId()).toBe('user-a');
+    expect(mocks.resolve).not.toHaveBeenCalled();
+  });
+
+  it('resolves the id when the session has not been written yet', async () => {
+    render(<Probe />);
+
+    expect(readId()).toBe('unknown');
+    await waitFor(() => expect(readId()).toBe('user-a'));
+  });
+
+  // Switching accounts clears the stored session, so a resolved id that isn't tied to the account
+  // it came from would keep answering for the account the viewer just left — and the popup gating
+  // that reads this would then be deciding against the wrong person.
+  it('does not answer with the previous account id after a switch', async () => {
+    const view = render(<Probe />);
+    await waitFor(() => expect(readId()).toBe('user-a'));
+
+    // The new account has no stored session yet and its exchange has not settled.
+    mocks.accountKey = 'account-b';
+    mocks.resolve.mockReturnValue(new Promise(() => {}));
+    view.rerender(<Probe />);
+
+    expect(readId()).toBe('unknown');
+  });
+
+  it('forgets a resolved id once the viewer signs out', async () => {
+    const view = render(<Probe />);
+    await waitFor(() => expect(readId()).toBe('user-a'));
+
+    mocks.authenticated = false;
+    view.rerender(<Probe />);
+
+    await waitFor(() => expect(readId()).toBe('unknown'));
+  });
+
+  it('lets the stored session take over from a resolved id', async () => {
+    const view = render(<Probe />);
+    await waitFor(() => expect(readId()).toBe('user-a'));
+
+    mocks.stored = 'user-stored';
+    view.rerender(<Probe />);
+
+    expect(readId()).toBe('user-stored');
+  });
+});

--- a/apps/web/core/debates/use-current-geo-chat-user-id.ts
+++ b/apps/web/core/debates/use-current-geo-chat-user-id.ts
@@ -20,7 +20,9 @@ import { useGeoChatAuth } from './hooks';
 export function useCurrentGeoChatUserId(): string | null {
   const { accountKey, authenticated, getPrivyIdentityToken } = useGeoChatAuth();
   const stored = getCurrentGeoChatUserId();
-  const [resolved, setResolved] = React.useState<string | null>(null);
+  // Kept with the account it was resolved for. Switching accounts clears the stored session, so a
+  // bare id would go on answering for the account the viewer just left.
+  const [resolved, setResolved] = React.useState<{ accountKey: string | null; id: string } | null>(null);
 
   React.useEffect(() => {
     // The stored session already answers it, and it stays authoritative — a resolved id from an
@@ -37,7 +39,7 @@ export function useCurrentGeoChatUserId(): string | null {
     let cancelled = false;
     void resolveCurrentGeoChatUserId(getPrivyIdentityToken, accountKey)
       .then(id => {
-        if (!cancelled && id) setResolved(id);
+        if (!cancelled && id) setResolved({ accountKey, id });
       })
       // Nothing to recover here: the session write that follows any authenticated request puts the
       // id back within reach of the synchronous read above.
@@ -48,5 +50,6 @@ export function useCurrentGeoChatUserId(): string | null {
     };
   }, [accountKey, authenticated, getPrivyIdentityToken, stored]);
 
-  return stored ?? resolved;
+  if (stored) return stored;
+  return resolved && resolved.accountKey === accountKey ? resolved.id : null;
 }

--- a/apps/web/core/debates/use-current-geo-chat-user-id.ts
+++ b/apps/web/core/debates/use-current-geo-chat-user-id.ts
@@ -1,0 +1,52 @@
+'use client';
+
+import * as React from 'react';
+
+import { getCurrentGeoChatUserId, resolveCurrentGeoChatUserId } from './api';
+import { useGeoChatAuth } from './hooks';
+
+/**
+ * The viewer's geo-chat user id, for the decisions that need to know *who* the viewer is.
+ *
+ * {@link getCurrentGeoChatUserId} reads the stored session synchronously and returns null until
+ * that session has been written — and being a plain read, nothing re-renders when it lands. That
+ * null is fine for code that only styles itself differently, but it is not fine for code that
+ * decides whether to show someone their own request: an absent id reads as "not you", so the
+ * person the request is *for* gets treated like a bystander and shown nothing.
+ *
+ * So: prefer the stored session on every render, and when it isn't there yet, run the token
+ * exchange once and hold the answer until it is.
+ */
+export function useCurrentGeoChatUserId(): string | null {
+  const { accountKey, authenticated, getPrivyIdentityToken } = useGeoChatAuth();
+  const stored = getCurrentGeoChatUserId();
+  const [resolved, setResolved] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    // The stored session already answers it, and it stays authoritative — a resolved id from an
+    // earlier account must never outlive it.
+    if (stored) {
+      setResolved(current => (current === null ? current : null));
+      return;
+    }
+    if (!authenticated) {
+      setResolved(null);
+      return;
+    }
+
+    let cancelled = false;
+    void resolveCurrentGeoChatUserId(getPrivyIdentityToken, accountKey)
+      .then(id => {
+        if (!cancelled && id) setResolved(id);
+      })
+      // Nothing to recover here: the session write that follows any authenticated request puts the
+      // id back within reach of the synchronous read above.
+      .catch(() => undefined);
+
+    return () => {
+      cancelled = true;
+    };
+  }, [accountKey, authenticated, getPrivyIdentityToken, stored]);
+
+  return stored ?? resolved;
+}


### PR DESCRIPTION
## What

Follow-up to #2140, which muted the "Debate request" popup for the person who *sent* it. The intent was sender-only, but the recipient stopped seeing it too.

## Why it happened

#2140 gated the popup on "is the viewer the recipient", comparing `challenge.recipient.user_id` against `getCurrentGeoChatUserId()`. That function reads the stored geo-chat session from `localStorage` synchronously and returns `null` until the session has been written — and being a plain read rather than a hook, nothing re-renders when it lands.

An absent id therefore reads as **"not the recipient"**, so the popup was withheld from exactly the person it was for. Before #2140 the same gap existed but was invisible: the dialog always rendered and the comparison only chose which branch, so a null id merely showed the recipient the wrong copy.

## The fix

A `useCurrentGeoChatUserId` hook that prefers the stored session on every render and, when it isn't there yet, runs the token exchange (`resolveCurrentGeoChatUserId`, the same call `recording-upload-coordinator` already uses) and holds the answer. The recipient-only gate is unchanged — it just gets an id it can trust.

**The Requests tab had the same fragility with worse manners.** Its role check fell through to `'requester'` whenever the id was unknown, so an *incoming* challenge was filed under **Sent**, captioned "Waiting for a reply", and offered the recipient a "Cancel request" button for a request they never sent. It now leaves the role undecided until the id is known rather than guessing.

## Test plan

- `core/debates`: **47 files / 509 tests pass** (up from 501; the `--localstorage-file` workaround from #2140's notes was used again locally so the whole suite actually runs).
- Four new tests, all verified to fail against the code they guard:
  - coordinator: recipient is still prompted when the id has to be resolved (**fails** on the old synchronous read)
  - coordinator: sender stays uninterrupted once their id resolves
  - requests-tab: an unknown id no longer files an incoming challenge under Sent
  - requests-tab: it lands under Received with "Explore claims" once the id is known
- `bun run build` passes (type check included).

## One caveat worth your judgement

I could not reproduce this against a live geo-chat, so the null-id path is a diagnosis from reading, not an observed stack trace. It is the only way the merged gate can withhold the popup from a recipient — the gate itself is intact on master, nothing since has touched it, and it demonstrably works whenever the id is present. But if you saw the recipient miss the popup while their id was clearly available (e.g. the Requests tab was correctly showing the challenge under **Received** at the time), then something else is also going on and I'd want to know that before this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)