### PR TITLE
fix(debates): stop the rematch picker racing and mis-scoping claim responses

### DIFF
--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
@@ -10,13 +10,18 @@ import type { DebateRematchClaim, DebateRematchSession } from '~/core/debates/ap
 
 import { DebateRematchPageClient } from './rematch-page-client';
 
-const { SPACE_1, SPACE_2, CLAIM_SHARED, CLAIM_MORE, CLAIM_SOURCE } = vi.hoisted(() => ({
-  SPACE_1: '019fedae-72b6-7ab2-927a-df044d57c566',
-  SPACE_2: '019fedae-72b6-7ab2-927a-df044d57c567',
-  CLAIM_SHARED: '019fedb1-0c41-7f3e-9a11-2c7d5e8b4419',
-  CLAIM_MORE: '019fedb2-1d52-7a4f-8b22-3d8e6f9c5520',
-  CLAIM_SOURCE: '019fedb3-2e63-7b50-9c33-4e9f7a0d6621',
-}));
+const { SPACE_1, SPACE_2, CLAIM_SHARED, CLAIM_MORE, CLAIM_SOURCE, CRYPTO_SPACE, PODCASTS_SPACE, NAME_PROPERTY } =
+  vi.hoisted(() => ({
+    SPACE_1: '019fedae-72b6-7ab2-927a-df044d57c566',
+    SPACE_2: '019fedae-72b6-7ab2-927a-df044d57c567',
+    // Real ids from the hard-coded ranking table, so the ordering under test is the real one.
+    CRYPTO_SPACE: 'c9f267dcb0d270718c2a3c45a64afd32',
+    PODCASTS_SPACE: 'b5a31f8182b042437ede0f84ee02f104',
+    NAME_PROPERTY: 'a126ca530c8e48d5b88882c734c38935',
+    CLAIM_SHARED: '019fedb1-0c41-7f3e-9a11-2c7d5e8b4419',
+    CLAIM_MORE: '019fedb2-1d52-7a4f-8b22-3d8e6f9c5520',
+    CLAIM_SOURCE: '019fedb3-2e63-7b50-9c33-4e9f7a0d6621',
+  }));
 
 const mocks = vi.hoisted(() => ({
   session: null as DebateRematchSession | null,
@@ -729,6 +734,36 @@ describe('DebateRematchPageClient', () => {
     expect(mocks.setReadiness).toHaveBeenCalledWith({
       spaceId: SPACE_1,
       claimId: CLAIM_SHARED,
+      ready: true,
+    });
+  });
+
+  // `entity.spaces` is rank-ordered and counts any space that merely references the claim, so
+  // `spaces[0]` is a citing space whenever it outranks the claim's own. Responding in one space and
+  // asking to debate in another is what the server answers with "respond to this claim in this
+  // space before enabling debate readiness".
+  it('scopes a browsed claim to the space it is named in, not the highest-ranked one citing it', () => {
+    mocks.entities = [
+      {
+        ...publishedEntity(CLAIM_MORE, 'A claim that lives in Podcasts'),
+        // Crypto (rank 2) outranks Podcasts (rank 8), but only Podcasts names the claim.
+        spaces: [CRYPTO_SPACE, PODCASTS_SPACE],
+        values: [
+          { isDeleted: false, property: { id: NAME_PROPERTY }, spaceId: PODCASTS_SPACE, value: 'A claim that lives in Podcasts' },
+        ],
+      },
+    ];
+    // The toggle only offers itself once the viewer holds a position.
+    mocks.optimisticResponses.set(CLAIM_MORE, 'positive');
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+    showAllClaims();
+
+    const card = screen.getByText('A claim that lives in Podcasts').closest('article');
+    fireEvent.click(within(card!).getByRole('switch', { name: 'Ready to debate this claim' }));
+
+    expect(mocks.setReadiness).toHaveBeenCalledWith({
+      spaceId: PODCASTS_SPACE,
+      claimId: CLAIM_MORE,
       ready: true,
     });
   });

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
@@ -48,6 +48,7 @@ const mocks = vi.hoisted(() => ({
   curatedIds: [] as string[],
   savedClaims: null as DebateRematchClaim[] | null,
   browsedLookupLoading: false,
+  currentUserId: 'user-local' as string | null,
   claimReadinessLoading: false,
   claimReadinessError: false,
   claimReadiness: [] as Array<{
@@ -65,8 +66,8 @@ vi.mock('~/core/debates/api', async importOriginal => {
   const actual = await importOriginal<typeof import('~/core/debates/api')>();
   return {
     ...actual,
-    getCurrentGeoChatUserId: () => 'user-local',
-    resolveCurrentGeoChatUserId: () => Promise.resolve('user-local'),
+    getCurrentGeoChatUserId: () => mocks.currentUserId,
+    resolveCurrentGeoChatUserId: () => Promise.resolve(mocks.currentUserId),
   };
 });
 
@@ -190,6 +191,7 @@ beforeEach(() => {
   mocks.curatedIds = [];
   mocks.savedClaims = null;
   mocks.browsedLookupLoading = false;
+  mocks.currentUserId = 'user-local';
   // The hub's filter menus measure their dropdown.
   window.ResizeObserver ??= class {
     observe() {}
@@ -741,6 +743,35 @@ describe('DebateRematchPageClient', () => {
   });
 
   // Taking a side here means you want to debate it, so readiness shouldn't be a second step.
+  // A position can appear without anyone picking one — here because geo-chat's copy of a claim the
+  // viewer had already answered lands after the card is on screen. That looks identical to a fresh
+  // pick, and standing them ready for it reverses a stand-down they made elsewhere.
+  it('does not stand the viewer ready when geo-chat reports a position they already held', () => {
+    mocks.claims = [
+      {
+        ...sharedClaim(),
+        participants: [
+          { user_id: 'user-local', position: null, position_label: null },
+          { user_id: 'user-remote', position: false, position_label: 'Disagree' },
+        ],
+      },
+    ];
+    const view = render(<DebateRematchPageClient sessionId="rematch-1" />);
+
+    mocks.claims = [
+      {
+        ...sharedClaim(),
+        participants: [
+          { user_id: 'user-local', position: true, position_label: 'Agree' },
+          { user_id: 'user-remote', position: false, position_label: 'Disagree' },
+        ],
+      },
+    ];
+    view.rerender(<DebateRematchPageClient sessionId="rematch-1" />);
+
+    expect(mocks.setReadiness).not.toHaveBeenCalled();
+  });
+
   // Standing down elsewhere is deliberate; arriving here mustn't quietly reverse it.
   it('leaves readiness alone for positions already held on arrival', () => {
     render(<DebateRematchPageClient sessionId="rematch-1" />);

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
@@ -571,25 +571,6 @@ describe('DebateRematchPageClient', () => {
   });
 
   // Taking a side here means you want to debate it, so readiness shouldn't be a second step.
-  it('turns the Debate toggle on when a position is first established here', () => {
-    mocks.claims = [
-      {
-        ...sharedClaim(),
-        participants: [
-          { user_id: 'user-local', position: null, position_label: null },
-          { user_id: 'user-remote', position: false, position_label: 'Disagree' },
-        ],
-      },
-    ];
-    const { rerender } = render(<DebateRematchPageClient sessionId="rematch-1" />);
-    expect(mocks.setReadiness).not.toHaveBeenCalled();
-
-    mocks.optimisticResponses.set(CLAIM_SHARED, 'positive');
-    rerender(<DebateRematchPageClient sessionId="rematch-1" />);
-
-    expect(mocks.setReadiness).toHaveBeenCalledWith({ spaceId: SPACE_1, claimId: CLAIM_SHARED, ready: true });
-  });
-
   // Standing down elsewhere is deliberate; arriving here mustn't quietly reverse it.
   it('leaves readiness alone for positions already held on arrival', () => {
     render(<DebateRematchPageClient sessionId="rematch-1" />);
@@ -655,13 +636,12 @@ describe('DebateRematchPageClient', () => {
 
     const card = screen.getByText('A claim both participants chose').closest('article');
     expect(within(card!).getByRole('button', { name: /^Agree/ })).toHaveAttribute('aria-pressed', 'true');
-    // Offered, but not yet sendable — see below.
-    expect(within(card!).getByRole('button', { name: 'Publishing…' })).toBeInTheDocument();
   });
 
   // geo-chat rejects a request for a claim it has no position for — "respond to this claim before
-  // requesting a rematch" — so the button has to wait for geo-chat's copy, not the optimistic one.
-  it('holds the request until geo-chat has the position it will be validated against', () => {
+  // requesting a rematch" — so the button waits for geo-chat's copy, not the optimistic one. It
+  // stays hidden rather than disabled: an unpressable button reads as broken.
+  it('withholds the request until geo-chat has the position it will be validated against', () => {
     mocks.claims = [
       {
         ...sharedClaim(),
@@ -674,10 +654,7 @@ describe('DebateRematchPageClient', () => {
     mocks.optimisticResponses.set(CLAIM_SHARED, 'positive');
     render(<DebateRematchPageClient sessionId="rematch-1" />);
 
-    const publishing = screen.getByRole('button', { name: 'Publishing…' });
-    expect(publishing).toBeDisabled();
-    fireEvent.click(publishing);
-    expect(mocks.mutate).not.toHaveBeenCalled();
+    expect(screen.queryByRole('button', { name: 'Request debate' })).not.toBeInTheDocument();
   });
 
   it('sends the request once geo-chat agrees with the side on screen', () => {
@@ -701,7 +678,7 @@ describe('DebateRematchPageClient', () => {
 
   // Switching sides leaves geo-chat holding the side you just moved off, which is no more valid to
   // request against than holding none.
-  it('holds the request while a side switch is still publishing', () => {
+  it('withholds the request while a side switch is still publishing', () => {
     mocks.claims = [
       {
         ...sharedClaim(),
@@ -714,7 +691,76 @@ describe('DebateRematchPageClient', () => {
     mocks.optimisticResponses.set(CLAIM_SHARED, 'positive');
     render(<DebateRematchPageClient sessionId="rematch-1" />);
 
-    expect(screen.getByRole('button', { name: 'Publishing…' })).toBeDisabled();
+    expect(screen.queryByRole('button', { name: 'Request debate' })).not.toBeInTheDocument();
+  });
+
+  // Readiness is rejected for a claim geo-chat has no response for, and `useClaimReadiness` rolls
+  // the switch back when that happens — so opting in off the optimistic position made the toggle
+  // visibly flip on and straight back off.
+  it('waits for the response to settle before standing the viewer ready', () => {
+    const unresponded = {
+      ...sharedClaim(),
+      participants: [
+        { user_id: 'user-local', position: null, position_label: null },
+        { user_id: 'user-remote', position: false, position_label: 'Disagree' },
+      ],
+    };
+    mocks.claims = [unresponded];
+    const view = render(<DebateRematchPageClient sessionId="rematch-1" />);
+    expect(mocks.setReadiness).not.toHaveBeenCalled();
+
+    // The side is picked: optimistic only, geo-chat still has nothing.
+    mocks.optimisticResponses.set(CLAIM_SHARED, 'positive');
+    view.rerender(<DebateRematchPageClient sessionId="rematch-1" />);
+    expect(mocks.setReadiness).not.toHaveBeenCalled();
+
+    // geo-chat catches up, and only now is readiness sent.
+    mocks.claims = [
+      {
+        ...sharedClaim(),
+        participants: [
+          { user_id: 'user-local', position: true, position_label: 'Agree' },
+          { user_id: 'user-remote', position: false, position_label: 'Disagree' },
+        ],
+      },
+    ];
+    view.rerender(<DebateRematchPageClient sessionId="rematch-1" />);
+
+    expect(mocks.setReadiness).toHaveBeenCalledWith({
+      spaceId: SPACE_1,
+      claimId: CLAIM_SHARED,
+      ready: true,
+    });
+  });
+
+  it('stands the viewer ready only once, even as the claim keeps refetching', () => {
+    mocks.claims = [
+      {
+        ...sharedClaim(),
+        participants: [
+          { user_id: 'user-local', position: null, position_label: null },
+          { user_id: 'user-remote', position: false, position_label: 'Disagree' },
+        ],
+      },
+    ];
+    const view = render(<DebateRematchPageClient sessionId="rematch-1" />);
+
+    mocks.optimisticResponses.set(CLAIM_SHARED, 'positive');
+    view.rerender(<DebateRematchPageClient sessionId="rematch-1" />);
+
+    mocks.claims = [
+      {
+        ...sharedClaim(),
+        participants: [
+          { user_id: 'user-local', position: true, position_label: 'Agree' },
+          { user_id: 'user-remote', position: false, position_label: 'Disagree' },
+        ],
+      },
+    ];
+    view.rerender(<DebateRematchPageClient sessionId="rematch-1" />);
+    view.rerender(<DebateRematchPageClient sessionId="rematch-1" />);
+
+    expect(mocks.setReadiness).toHaveBeenCalledOnce();
   });
 });
 

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
@@ -49,7 +49,11 @@ vi.mock('next/navigation', () => ({
 
 vi.mock('~/core/debates/api', async importOriginal => {
   const actual = await importOriginal<typeof import('~/core/debates/api')>();
-  return { ...actual, getCurrentGeoChatUserId: () => 'user-local' };
+  return {
+    ...actual,
+    getCurrentGeoChatUserId: () => 'user-local',
+    resolveCurrentGeoChatUserId: () => Promise.resolve('user-local'),
+  };
 });
 
 vi.mock('~/core/debates/hooks', () => ({
@@ -69,6 +73,7 @@ vi.mock('~/core/debates/hooks', () => ({
   useLeaveDebateRematch: () => mutation(mocks.leaveMutate),
   useAcceptDebateRematchRequest: () => mutation(mocks.acceptMutate),
   useRejectDebateRematchRequest: () => mutation(mocks.rejectMutate),
+  useGeoChatAuth: () => ({ ready: true, authenticated: true, accountKey: 'account-a', getPrivyIdentityToken: vi.fn() }),
 }));
 
 vi.mock('~/core/sync/use-store', () => ({
@@ -650,7 +655,66 @@ describe('DebateRematchPageClient', () => {
 
     const card = screen.getByText('A claim both participants chose').closest('article');
     expect(within(card!).getByRole('button', { name: /^Agree/ })).toHaveAttribute('aria-pressed', 'true');
-    expect(screen.getByRole('button', { name: 'Request debate' })).toBeEnabled();
+    // Offered, but not yet sendable — see below.
+    expect(within(card!).getByRole('button', { name: 'Publishing…' })).toBeInTheDocument();
+  });
+
+  // geo-chat rejects a request for a claim it has no position for — "respond to this claim before
+  // requesting a rematch" — so the button has to wait for geo-chat's copy, not the optimistic one.
+  it('holds the request until geo-chat has the position it will be validated against', () => {
+    mocks.claims = [
+      {
+        ...sharedClaim(),
+        participants: [
+          { user_id: 'user-local', position: null, position_label: null },
+          { user_id: 'user-remote', position: false, position_label: 'Disagree' },
+        ],
+      },
+    ];
+    mocks.optimisticResponses.set(CLAIM_SHARED, 'positive');
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+
+    const publishing = screen.getByRole('button', { name: 'Publishing…' });
+    expect(publishing).toBeDisabled();
+    fireEvent.click(publishing);
+    expect(mocks.mutate).not.toHaveBeenCalled();
+  });
+
+  it('sends the request once geo-chat agrees with the side on screen', () => {
+    mocks.claims = [
+      {
+        ...sharedClaim(),
+        participants: [
+          { user_id: 'user-local', position: true, position_label: 'Agree' },
+          { user_id: 'user-remote', position: false, position_label: 'Disagree' },
+        ],
+      },
+    ];
+    mocks.optimisticResponses.set(CLAIM_SHARED, 'positive');
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+
+    const request = screen.getByRole('button', { name: 'Request debate' });
+    expect(request).toBeEnabled();
+    fireEvent.click(request);
+    expect(mocks.mutate).toHaveBeenCalled();
+  });
+
+  // Switching sides leaves geo-chat holding the side you just moved off, which is no more valid to
+  // request against than holding none.
+  it('holds the request while a side switch is still publishing', () => {
+    mocks.claims = [
+      {
+        ...sharedClaim(),
+        participants: [
+          { user_id: 'user-local', position: false, position_label: 'Disagree' },
+          { user_id: 'user-remote', position: false, position_label: 'Disagree' },
+        ],
+      },
+    ];
+    mocks.optimisticResponses.set(CLAIM_SHARED, 'positive');
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+
+    expect(screen.getByRole('button', { name: 'Publishing…' })).toBeDisabled();
   });
 });
 

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -681,6 +681,10 @@ function RematchClaimCard({
   useReadinessOnFirstPosition({
     claim: claim.claim,
     localPosition,
+    // The optimistic copy exists only while this client's own submission is in flight, so it is
+    // what separates "the viewer just picked this side" from "we just learned the side they already
+    // held" — which is what a position looks like when their identity or geo-chat's copy lands late.
+    pickedHere: optimisticResponse !== undefined,
     responseSettled,
     alreadyReady: claimReadiness?.viewer_debate_ready ?? false,
   });
@@ -749,11 +753,14 @@ function RematchClaimCard({
 function useReadinessOnFirstPosition({
   claim,
   localPosition,
+  pickedHere,
   responseSettled,
   alreadyReady,
 }: {
   claim: DebateClaimSummary;
   localPosition: boolean | null;
+  /** Whether {@link localPosition} is this client's own in-flight submission. */
+  pickedHere: boolean;
   /** Whether geo-chat's copy of the response has caught up with {@link localPosition}. */
   responseSettled: boolean;
   alreadyReady: boolean;
@@ -770,10 +777,14 @@ function useReadinessOnFirstPosition({
     previousPosition.current = localPosition;
 
     const justEstablished = previous === null && localPosition !== null;
-    if (!justEstablished || alreadyReady || optedIn.current) return;
+    // A position can appear without anyone picking anything: the viewer's id resolves a beat after
+    // mount, or geo-chat's copy of a claim they had already answered lands late. Both look exactly
+    // like a fresh pick from here, and standing them ready for either silently undoes a stand-down
+    // they made elsewhere — the thing this hook is careful not to do.
+    if (!justEstablished || !pickedHere || alreadyReady || optedIn.current) return;
 
     setWantsReadiness(true);
-  }, [alreadyReady, localPosition]);
+  }, [alreadyReady, localPosition, pickedHere]);
 
   // ...but it is only sent once geo-chat can see the response readiness depends on. Firing on the
   // optimistic position instead had the server reject it for a claim it had no response for, and

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { SystemIds } from '@geoprotocol/geo-sdk/lite';
 import { keepPreviousData } from '@tanstack/react-query';
 
 import * as React from 'react';
@@ -41,6 +42,7 @@ import { useEntityResponse } from '~/core/hooks/use-entity-vote';
 import { uuidToHex } from '~/core/id/normalize';
 import { responsePositionLabel } from '~/core/responses/entity-response';
 import { useQueryEntities } from '~/core/sync/use-store';
+import { getTopRankedSpaceId } from '~/core/utils/space/space-ranking';
 
 import { Button } from '~/design-system/button';
 import { getChecked } from '~/design-system/checkbox';
@@ -145,9 +147,10 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
       ...(publishedClaimsQuery.data?.excluded_claim_ids ?? []),
     ]);
     for (const claim of publishedClaims.entities) {
+      const homeSpaceId = claimHomeSpaceId(claim);
       if (
         claim.name &&
-        claim.spaces[0] &&
+        homeSpaceId &&
         !excludedClaimIds.has(claim.id) &&
         claim.id !== sourceDebateQuery.data?.claim.claim_entity_id &&
         !synchronizedClaims.has(claim.id)
@@ -155,12 +158,12 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
         synchronizedClaims.set(claim.id, {
           claim: {
             id: claim.id,
-            space_id: claim.spaces[0]!,
+            space_id: homeSpaceId,
             claim_entity_id: claim.id,
             claim: claim.name!,
             description: claim.description,
           },
-          response_kind: claimResponseKind(claim, claim.spaces[0]!),
+          response_kind: claimResponseKind(claim, homeSpaceId),
           participants: (session?.participants ?? []).map(participant => ({
             user_id: participant.user_id,
             position: null,
@@ -711,6 +714,40 @@ function rematchPositionSummaries(
       participants,
     };
   });
+}
+
+/**
+ * The space a claim actually lives in.
+ *
+ * Everything the picker does with a claim is scoped to one space — the response is published
+ * against it, geo-chat keys its claim row and readiness on it, and the "Is factual" value that
+ * decides the response kind is read from it. Getting it wrong means responding in one space and
+ * asking to debate in another, which the server answers with "respond to this claim in this space
+ * before enabling debate readiness".
+ *
+ * `entity.spaces` can't answer it: it is ordered by a fixed space ranking and counts every space
+ * holding *any* value or even an inbound relation, so `spaces[0]` is a space that merely mentions
+ * the claim whenever that space outranks the claim's own — a Podcasts claim cited from Root or
+ * Crypto resolves to those. Prefer the spaces where the claim is actually named, which is how the
+ * entity side panel scopes the same entity.
+ */
+function claimHomeSpaceId(entity: {
+  spaces: string[];
+  values?: Array<{ isDeleted?: boolean; property: { id: string }; spaceId: string; value: string }>;
+}): string | null {
+  const namedSpaceIds = new Set<string>();
+  for (const value of entity.values ?? []) {
+    if (
+      value.isDeleted !== true &&
+      uuidToHex(value.property.id) === uuidToHex(SystemIds.NAME_PROPERTY) &&
+      typeof value.value === 'string' &&
+      value.value.trim().length > 0
+    ) {
+      namedSpaceIds.add(value.spaceId);
+    }
+  }
+
+  return getTopRankedSpaceId([...namedSpaceIds]) ?? getTopRankedSpaceId(entity.spaces) ?? null;
 }
 
 function claimResponseKind(

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -567,18 +567,22 @@ function RematchClaimCard({
         : optimisticResponse === 'positive';
 
   const opposing = localPosition !== null && remotePosition !== null && localPosition !== remotePosition;
-  // geo-chat validates the request against its own copy of your position, which trails the
-  // optimistic one by a publish, an index, and a notification. Showing the button on the optimistic
-  // answer is what keeps the card responsive; *sending* it before geo-chat agrees is what earns
-  // "respond to this claim before requesting a rematch". Comparing rather than null-checking also
-  // covers switching sides, where geo-chat still holds the side you just moved off.
+  // geo-chat validates against its own copy of your position, which trails the optimistic one by a
+  // publish, an index, and a notification. Acting before it agrees earns "respond to this claim
+  // before requesting a rematch". Comparing rather than null-checking also covers switching sides,
+  // where geo-chat still holds the side you just moved off — equally invalid to act on.
   const responseSettled = serverLocalPosition === localPosition;
+  // The side you picked still highlights immediately off the optimistic answer; only the request
+  // waits. It stays hidden rather than sitting there disabled — a button you cannot press yet reads
+  // as broken, and the wait is short.
+  const canRequest = opposing && responseSettled;
   const { openSidePanel } = useEntitySidePanel();
   const request = session?.request;
 
   useReadinessOnFirstPosition({
     claim: claim.claim,
     localPosition,
+    responseSettled,
     alreadyReady: claimReadiness?.viewer_debate_ready ?? false,
   });
   const requesting =
@@ -611,13 +615,13 @@ function RematchClaimCard({
       // unknown — a settled lookup that simply has no row for it really does mean "not ready".
       hideReadinessToggle={claimReadiness === null && readinessUnresolved}
       footer={
-        opposing || requesting ? (
+        canRequest || requesting ? (
           <div className="mt-3">
             <HubPillButton
               onClick={onRequest}
-              disabled={!opposing || busy || requesting || claim.recently_rejected || !responseSettled}
-              pending={requesting || (opposing && !responseSettled)}
-              pendingLabel={requesting ? 'Requesting…' : 'Publishing…'}
+              disabled={!canRequest || busy || requesting || claim.recently_rejected}
+              pending={requesting}
+              pendingLabel="Requesting…"
               className="w-full"
             >
               Request debate
@@ -646,17 +650,22 @@ function RematchClaimCard({
 function useReadinessOnFirstPosition({
   claim,
   localPosition,
+  responseSettled,
   alreadyReady,
 }: {
   claim: DebateClaimSummary;
   localPosition: boolean | null;
+  /** Whether geo-chat's copy of the response has caught up with {@link localPosition}. */
+  responseSettled: boolean;
   alreadyReady: boolean;
 }) {
   const setReadiness = useClaimReadiness();
   // Seeded with the position held on mount, so arriving with one is not a transition.
   const previousPosition = React.useRef(localPosition);
   const optedIn = React.useRef(false);
+  const [wantsReadiness, setWantsReadiness] = React.useState(false);
 
+  // The intent is recorded off the optimistic position, so it survives the wait below.
   React.useEffect(() => {
     const previous = previousPosition.current;
     previousPosition.current = localPosition;
@@ -664,9 +673,19 @@ function useReadinessOnFirstPosition({
     const justEstablished = previous === null && localPosition !== null;
     if (!justEstablished || alreadyReady || optedIn.current) return;
 
+    setWantsReadiness(true);
+  }, [alreadyReady, localPosition]);
+
+  // ...but it is only sent once geo-chat can see the response readiness depends on. Firing on the
+  // optimistic position instead had the server reject it for a claim it had no response for, and
+  // the rollback in `useClaimReadiness` flipped the switch straight back off.
+  React.useEffect(() => {
+    if (!wantsReadiness || !responseSettled || optedIn.current) return;
+
     optedIn.current = true;
+    setWantsReadiness(false);
     setReadiness.mutate({ spaceId: claim.space_id, claimId: claim.claim_entity_id, ready: true });
-  }, [alreadyReady, claim.claim_entity_id, claim.space_id, localPosition, setReadiness]);
+  }, [claim.claim_entity_id, claim.space_id, responseSettled, setReadiness, wantsReadiness]);
 }
 
 /** Both sides of a rematch claim, in the shape the shared card draws avatars from. */

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -16,7 +16,6 @@ import {
   type DebateRematchSession,
   type MatchmakingReadiness,
   type MatchmakingTopic,
-  getCurrentGeoChatUserId,
 } from '~/core/debates/api';
 import { DebateRequestDialog } from '~/core/debates/debate-request-dialog';
 import { defaultDebateFormatId } from '~/core/debates/formats';
@@ -36,6 +35,7 @@ import { HubCardList } from '~/core/debates/matchmaking/hub-motion';
 import { HubPillButton } from '~/core/debates/matchmaking/hub-pill-button';
 import { HubQueryState } from '~/core/debates/matchmaking/hub-states';
 import { MatchmakingClaimCard } from '~/core/debates/matchmaking/matchmaking-claim-card';
+import { useCurrentGeoChatUserId } from '~/core/debates/use-current-geo-chat-user-id';
 import { useEntitySidePanel } from '~/core/hooks/use-entity-side-panel';
 import { useEntityResponse } from '~/core/hooks/use-entity-vote';
 import { uuidToHex } from '~/core/id/normalize';
@@ -62,7 +62,7 @@ function firstNamePossessive(name: string) {
 
 export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   const router = useRouter();
-  const currentUserId = getCurrentGeoChatUserId();
+  const currentUserId = useCurrentGeoChatUserId();
   const exitStartedRef = React.useRef(false);
   const sessionQuery = useDebateRematch(sessionId);
   const [search, setSearch] = React.useState('');
@@ -567,6 +567,12 @@ function RematchClaimCard({
         : optimisticResponse === 'positive';
 
   const opposing = localPosition !== null && remotePosition !== null && localPosition !== remotePosition;
+  // geo-chat validates the request against its own copy of your position, which trails the
+  // optimistic one by a publish, an index, and a notification. Showing the button on the optimistic
+  // answer is what keeps the card responsive; *sending* it before geo-chat agrees is what earns
+  // "respond to this claim before requesting a rematch". Comparing rather than null-checking also
+  // covers switching sides, where geo-chat still holds the side you just moved off.
+  const responseSettled = serverLocalPosition === localPosition;
   const { openSidePanel } = useEntitySidePanel();
   const request = session?.request;
 
@@ -609,9 +615,9 @@ function RematchClaimCard({
           <div className="mt-3">
             <HubPillButton
               onClick={onRequest}
-              disabled={!opposing || busy || requesting || claim.recently_rejected}
-              pending={requesting}
-              pendingLabel="Requesting…"
+              disabled={!opposing || busy || requesting || claim.recently_rejected || !responseSettled}
+              pending={requesting || (opposing && !responseSettled)}
+              pendingLabel={requesting ? 'Requesting…' : 'Publishing…'}
               className="w-full"
             >
               Request debate


### PR DESCRIPTION
Three fixes in the rematch ("debate again") claim picker. The first two share a root cause; the third is separate but lands in the same file.

## 1 & 2 — acting before the response has landed

The card reads the **optimistic** response so your chosen side highlights instantly. But geo-chat validates against **its own** copy, which trails by a publish, an index, and a notification. Two things fired into that gap:

- **Request debate** appeared immediately and returned `respond to this claim before requesting a rematch` when pressed. It now isn't drawn until geo-chat's copy agrees with the side on screen — hidden rather than disabled, since a button you can't press reads as broken.
- **Readiness auto-opt-in** fired the moment you took a side. The server rejected it for a claim it had no response for, and the rollback in `useClaimReadiness` flipped the switch visibly back off. The intent is now recorded when you pick the side and *sent* once the response settles.

Both gate on the same signal:

```ts
const responseSettled = serverLocalPosition === localPosition;
```

Comparing rather than null-checking also covers **switching sides**, where geo-chat still holds the side you just moved off — no more valid to act on than holding none.

## 3 — the wrong space entirely

Responding to a claim from certain spaces (Podcasts was the report) and then toggling Debate gave `respond to this claim in this space before enabling debate readiness`, even after publishing had finished. The claims side panel never had this.

The All tab browses **every** published claim and had to pick a space for each, taking `entity.spaces[0]`. That list is ordered by a hard-coded ranking table and counts every space holding any value *or merely an inbound relation* — so a Podcasts claim (rank 8) cited from Root (0) or Crypto (2) resolved to the citing space.

That single guess scoped everything downstream: the response was published against the wrong space, readiness was requested for it, and the `Is factual` lookup that picks the response kind read from it too — so even a response made in the same card could be recorded under the wrong vote kind and be invisible to the check. geo-chat keys claims and readiness on `(space, claim)`, hence the error.

It now resolves the space the way the entity side panel does — the top-ranked space where the claim is actually **named** — which is precisely why the side panel never hit this.

These compose: fix 3 makes the response and the notification land in the space geo-chat has a claim row for, which is what lets geo-chat echo the position back, which is what fixes 1 and 2 wait for.

## Test plan

- Rematch picker: **37 tests pass**. New/amended cases, each verified to fail against the code it guards:
  - the request stays hidden while publishing, and while a side switch is publishing
  - it appears and sends once geo-chat agrees
  - readiness waits for the response to settle, and fires only once across refetches
  - a browsed claim named only in Podcasts but cited from Crypto is scoped to **Podcasts**
  - one pre-existing test asserted the old immediate-fire behaviour and was replaced rather than left contradicting the fix
- `core/debates` + all `debates` routes + `partials/entity-page`: **56 files / 701 tests pass**.
- `bun run build` passes (type check included).
- Not exercised against a live geo-chat. Fix 3 in particular changes which space responses are published to, so it deserves a real run — respond to a Podcasts claim from the All tab and confirm both the toggle and the request work.

## Worth knowing

For a claim geo-chat hasn't seen yet, the fabricated participants carry `position: null`, so `responseSettled` stays false and the auto-opt-in doesn't fire on that first pass. It self-heals: once the response is indexed and geo-chat is notified — in the right space, per fix 3 — the claim comes back as a real geo-chat claim carrying your position, and readiness goes out then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)