### PR TITLE
feat(debates): page claims by scrolling instead of a Load more button

### DIFF
--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
@@ -180,6 +180,15 @@ beforeEach(() => {
   mocks.curatedIds = [];
   mocks.savedClaims = null;
   mocks.browsedLookupLoading = false;
+  // jsdom has no IntersectionObserver, which the infinite-scroll sentinel builds.
+  window.IntersectionObserver ??= class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+    takeRecords() {
+      return [];
+    }
+  } as unknown as typeof IntersectionObserver;
   // The hub's filter menus measure their dropdown.
   window.ResizeObserver ??= class {
     observe() {}
@@ -524,15 +533,31 @@ describe('DebateRematchPageClient', () => {
 
   // Recommended comes from the curator's page whole, so paging the browsed corpus means nothing
   // there — offering it implies there are more recommendations waiting.
-  it('keeps Load more off the Recommended tab while offering it on the others', () => {
+  it('keeps the paging sentinel off the Recommended tab while placing it on the others', () => {
     mocks.entityQueryHasNextPage = true;
     mocks.recommendedSections = [{ id: 'block-1', name: 'Geopolitics & chips', claimIds: [CLAIM_SHARED] }];
     render(<DebateRematchPageClient sessionId="rematch-1" />);
 
-    expect(screen.queryByRole('button', { name: 'Load more' })).toBeNull();
+    expect(screen.queryByTestId('claims-scroll-sentinel')).toBeNull();
 
     showAllClaims();
-    expect(screen.getByRole('button', { name: 'Load more' })).toBeInTheDocument();
+    expect(screen.getByTestId('claims-scroll-sentinel')).toBeInTheDocument();
+  });
+
+  // No button to press any more; reaching the end of the list is what asks for the next page.
+  it('does not offer a Load more button', () => {
+    mocks.entityQueryHasNextPage = true;
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+    showAllClaims();
+
+    expect(screen.queryByRole('button', { name: 'Load more' })).toBeNull();
+  });
+
+  it('leaves the sentinel out once there is no page left to fetch', () => {
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+    showAllClaims();
+
+    expect(screen.queryByTestId('claims-scroll-sentinel')).toBeNull();
   });
 
   // Curated claims are picked by hand, so they can be ones the browsed pages never reach. They

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom/vitest';
-import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 
 import { StrictMode } from 'react';
 
@@ -31,7 +31,7 @@ const mocks = vi.hoisted(() => ({
   optimisticResponses: new Map<string, 'positive' | 'negative' | null>(),
   setReadiness: vi.fn(),
   openSidePanel: vi.fn(),
-  entityQueries: [] as unknown[],
+  entityQueries: [] as Array<{ where?: unknown; after?: string }>,
   entityQueryPlaceholder: false,
   entityQueryHasNextPage: false,
   entityQueryLoading: false,
@@ -43,6 +43,7 @@ const mocks = vi.hoisted(() => ({
   curatedIds: [] as string[],
   savedClaims: null as DebateRematchClaim[] | null,
   browsedLookupLoading: false,
+  scrollSentinelIntoView: null as null | (() => void),
   claimReadinessLoading: false,
   claimReadinessError: false,
   claimReadiness: [] as Array<{
@@ -98,8 +99,8 @@ vi.mock('~/core/debates/hooks', () => ({
 }));
 
 vi.mock('~/core/sync/use-store', () => ({
-  useQueryEntities: (options: { where?: unknown }) => {
-    mocks.entityQueries.push(options.where);
+  useQueryEntities: (options: { where?: unknown; after?: string }) => {
+    mocks.entityQueries.push(options);
     return {
       entities: mocks.entities,
       isLoading: mocks.entityQueryLoading,
@@ -180,15 +181,24 @@ beforeEach(() => {
   mocks.curatedIds = [];
   mocks.savedClaims = null;
   mocks.browsedLookupLoading = false;
-  // jsdom has no IntersectionObserver, which the infinite-scroll sentinel builds.
-  window.IntersectionObserver ??= class {
-    observe() {}
-    unobserve() {}
-    disconnect() {}
-    takeRecords() {
-      return [];
+  // jsdom has no IntersectionObserver, which the infinite-scroll sentinel builds. This one records
+  // the callback so a test can say the sentinel scrolled into view.
+  mocks.scrollSentinelIntoView = null;
+  vi.stubGlobal(
+    'IntersectionObserver',
+    class {
+      constructor(private readonly callback: IntersectionObserverCallback) {}
+      observe(element: Element) {
+        mocks.scrollSentinelIntoView = () =>
+          this.callback([{ isIntersecting: true, target: element } as IntersectionObserverEntry], this as never);
+      }
+      unobserve() {}
+      disconnect() {}
+      takeRecords() {
+        return [];
+      }
     }
-  } as unknown as typeof IntersectionObserver;
+  );
   // The hub's filter menus measure their dropdown.
   window.ResizeObserver ??= class {
     observe() {}
@@ -553,6 +563,21 @@ describe('DebateRematchPageClient', () => {
     expect(screen.queryByRole('button', { name: 'Load more' })).toBeNull();
   });
 
+  // The picker pages by cursor rather than through an infinite query, so the sentinel firing has
+  // to be shown to advance that cursor — a sentinel that renders but is wired to nothing would
+  // satisfy every other test here.
+  it('advances the cursor when the end of the list scrolls into view', () => {
+    mocks.entityQueryHasNextPage = true;
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+    showAllClaims();
+
+    expect(browsedClaimsQueryOptions()?.after).toBeUndefined();
+
+    act(() => mocks.scrollSentinelIntoView?.());
+
+    expect(browsedClaimsQueryOptions()?.after).toBe('cursor-1');
+  });
+
   it('leaves the sentinel out once there is no page left to fetch', () => {
     render(<DebateRematchPageClient sessionId="rematch-1" />);
     showAllClaims();
@@ -845,14 +870,17 @@ describe('DebateRematchPageClient', () => {
 });
 
 /** The where clause of the query that browses published claims, not the curated lookups beside it. */
-function browsedClaimsWhere() {
+function browsedClaimsQueryOptions() {
   return mocks.entityQueries
-    .filter(
-      (where): where is { types?: Array<{ id?: { equals?: string } }> } =>
-        typeof where === 'object' && where !== null && 'types' in where
-    )
-    .filter(where => where.types?.[0]?.id?.equals === CLAIM_TYPE_ID)
+    .filter(options => {
+      const where = options.where as { types?: Array<{ id?: { equals?: string } }> } | undefined;
+      return where?.types?.[0]?.id?.equals === CLAIM_TYPE_ID;
+    })
     .at(-1);
+}
+
+function browsedClaimsWhere() {
+  return browsedClaimsQueryOptions()?.where;
 }
 
 /** The picker opens on the opponent's positions; most assertions want the unfiltered list. */

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -40,11 +40,11 @@ import { MatchmakingClaimCard } from '~/core/debates/matchmaking/matchmaking-cla
 import { useRecommendedClaimSections } from '~/core/debates/recommended-claims';
 import { useEntitySidePanel } from '~/core/hooks/use-entity-side-panel';
 import { useEntityResponse } from '~/core/hooks/use-entity-vote';
+import { useInfiniteScrollSentinel } from '~/core/hooks/use-infinite-scroll-sentinel';
 import { uuidToHex } from '~/core/id/normalize';
 import { responsePositionLabel } from '~/core/responses/entity-response';
 import { useQueryEntities } from '~/core/sync/use-store';
 
-import { Button } from '~/design-system/button';
 import { getChecked } from '~/design-system/checkbox';
 import { ChevronDownSmall } from '~/design-system/icons/chevron-down-small';
 import { Input } from '~/design-system/input';
@@ -329,6 +329,16 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
 
   const hasFilters = Boolean(debouncedSearch || spaceId || topicId);
 
+  const sentinelRef = useInfiniteScrollSentinel({
+    hasNextPage: publishedClaimsHasNextPage && Boolean(publishedClaimsEndCursor),
+    // The cursor query keeps the previous page on screen while the next one loads, which is this
+    // list's "a fetch is already in flight".
+    isFetchingNextPage: publishedClaimsPlaceholder,
+    fetchNextPage: () => {
+      if (publishedClaimsEndCursor) setPublishedClaimsCursor(publishedClaimsEndCursor);
+    },
+  });
+
   // Each tab draws from a different set of queries, so each waits on its own. The browsed scan is
   // the slow one and only the All tab reads it.
   const tabIsLoading =
@@ -541,22 +551,12 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
           )}
         </HubQueryState>
 
-        {/* Outside the empty state deliberately: when a filter empties the list, fetching another
-            page is the way out, so the control has to stay reachable. Not on the curated tab
-            though — its sections come from the page whole, so there is no next page to fetch. */}
+        {/* Outside the empty state deliberately: when a filter empties the list, the next page is
+            the way out, so the sentinel has to stay reachable — with nothing rendered it sits in
+            view and keeps paging until a match turns up or the corpus runs out. Not on the curated
+            tab, whose sections come from the page whole and have no next page to fetch. */}
         {tab !== 'recommended' && publishedClaimsHasNextPage && (
-          <div className="mt-5 flex justify-center">
-            <Button
-              type="button"
-              variant="secondary"
-              onClick={() => {
-                if (publishedClaimsEndCursor) setPublishedClaimsCursor(publishedClaimsEndCursor);
-              }}
-              disabled={publishedClaimsPlaceholder || !publishedClaimsEndCursor}
-            >
-              Load more
-            </Button>
-          </div>
+          <div ref={sentinelRef} data-testid="claims-scroll-sentinel" className="h-px" />
         )}
       </main>
 

--- a/apps/web/core/debates/matchmaking/claims-tab.test.tsx
+++ b/apps/web/core/debates/matchmaking/claims-tab.test.tsx
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom/vitest';
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -9,6 +9,10 @@ import { ClaimsTab } from './claims-tab';
 const mocks = vi.hoisted(() => ({
   claims: [] as MatchmakingClaim[],
   lastQuery: null as unknown,
+  hasNextPage: false,
+  fetchNextPage: vi.fn(),
+  observed: [] as Element[],
+  trigger: null as null | (() => void),
 }));
 
 vi.mock('./hooks', () => ({
@@ -18,9 +22,9 @@ vi.mock('./hooks', () => ({
       data: { pages: [{ claims: mocks.claims, next_cursor: null, facets: { space_ids: [] } }] },
       isLoading: false,
       error: null,
-      hasNextPage: false,
+      hasNextPage: mocks.hasNextPage,
       isFetchingNextPage: false,
-      fetchNextPage: vi.fn(),
+      fetchNextPage: mocks.fetchNextPage,
       refetch: vi.fn(),
     };
   },
@@ -62,6 +66,27 @@ const MINE = '019fedb1-0c41-7f3e-9a11-2c7d5e8b4419';
 const THEIRS = '019fedb2-1d52-7a4f-8b22-3d8e6f9c5520';
 
 beforeEach(() => {
+  mocks.hasNextPage = false;
+  mocks.fetchNextPage.mockReset();
+  mocks.observed = [];
+  // Records the sentinel and hands back a way to say it scrolled into view.
+  vi.stubGlobal(
+    'IntersectionObserver',
+    class {
+      constructor(private readonly callback: IntersectionObserverCallback) {}
+      observe(element: Element) {
+        mocks.observed.push(element);
+        mocks.trigger = () =>
+          this.callback([{ isIntersecting: true, target: element } as IntersectionObserverEntry], this as never);
+      }
+      unobserve() {}
+      disconnect() {}
+      takeRecords() {
+        return [];
+      }
+    }
+  );
+
   mocks.claims = [
     claim(MINE, 'Chips are better than fries', true),
     claim(THEIRS, 'Bitcoin will never top $250K', false),
@@ -77,6 +102,25 @@ beforeEach(() => {
 afterEach(cleanup);
 
 describe('ClaimsTab', () => {
+  // Pages arrive by reaching the end of the list, not by pressing anything.
+  it('fetches the next page when the end of the list scrolls into view', () => {
+    mocks.hasNextPage = true;
+    render(<ClaimsTab />);
+
+    expect(screen.queryByRole('button', { name: 'Load more' })).toBeNull();
+    expect(mocks.fetchNextPage).not.toHaveBeenCalled();
+
+    act(() => mocks.trigger?.());
+
+    expect(mocks.fetchNextPage).toHaveBeenCalled();
+  });
+
+  it('places no sentinel once the last page has arrived', () => {
+    render(<ClaimsTab />);
+
+    expect(screen.queryByTestId('claims-scroll-sentinel')).toBeNull();
+  });
+
   // The claims you've taken a side on are the ones that can turn into debates, so they lead.
   it('leads with the claims the viewer has a position on', () => {
     render(<ClaimsTab />);

--- a/apps/web/core/debates/matchmaking/claims-tab.tsx
+++ b/apps/web/core/debates/matchmaking/claims-tab.tsx
@@ -7,6 +7,7 @@ import * as React from 'react';
 import cx from 'classnames';
 
 import { TOPICS_PROPERTY_ID } from '~/core/claims/ontology';
+import { useInfiniteScrollSentinel } from '~/core/hooks/use-infinite-scroll-sentinel';
 import { useSpacesByIds } from '~/core/hooks/use-spaces-by-ids';
 import { useQueryEntities } from '~/core/sync/use-store';
 import { validateEntityId } from '~/core/utils/utils';
@@ -18,7 +19,6 @@ import type { MatchmakingClaim, MatchmakingClaimsFilter, MatchmakingClaimsQuery,
 import { useMatchmakingClaims } from './hooks';
 import { HubFilterMenu, type HubFilterOption } from './hub-filter-menu';
 import { HubCardList } from './hub-motion';
-import { HubPillButton } from './hub-pill-button';
 import { HubQueryState } from './hub-states';
 import { MatchmakingClaimCard } from './matchmaking-claim-card';
 import { useStableListOrder } from './use-stable-list-order';
@@ -102,6 +102,12 @@ export function ClaimsTab() {
 
   const hasFilters = Boolean(debouncedSearch || spaceId || topicId || filter !== 'all');
 
+  const sentinelRef = useInfiniteScrollSentinel({
+    hasNextPage: claimsQuery.hasNextPage,
+    isFetchingNextPage: claimsQuery.isFetchingNextPage,
+    fetchNextPage: claimsQuery.fetchNextPage,
+  });
+
   const visibleClaims = React.useMemo(
     () =>
       topicId
@@ -175,15 +181,11 @@ export function ClaimsTab() {
           {otherClaims.length > 0 ? (
             <ClaimSection label={showSections && myClaims.length > 0 ? 'All claims' : null} claims={otherClaims} />
           ) : null}
+          {/* Pages arrive as the viewer reaches the end of the list rather than on a button. The
+              sentinel only exists while there is a page left, so it can't sit in view asking for
+              one that isn't there. */}
           {claimsQuery.hasNextPage ? (
-            <HubPillButton
-              onClick={() => void claimsQuery.fetchNextPage()}
-              pending={claimsQuery.isFetchingNextPage}
-              pendingLabel="Loading…"
-              className="mt-2 w-full"
-            >
-              Load more
-            </HubPillButton>
+            <div ref={sentinelRef} data-testid="claims-scroll-sentinel" className="h-px" />
           ) : null}
         </>
       </HubQueryState>


### PR DESCRIPTION
Both claim lists now fetch the next page when the end of the list comes into view: the debates side panel's **Claims tab** and the **debate again** picker.

Uses the app's existing `useInfiniteScrollSentinel` rather than a new mechanism — it's already how the space members/editors lists and the ranking block page, including inside nested scroll containers, which both of these are.

### Notes for review

- **The sentinel only exists while a page is left to fetch** (`hasNextPage`), so it can't sit in view asking for one that isn't there.
- **The picker keeps it outside the empty state**, for the same reason the button was there: when a client-side space or topic filter empties the list, the next page is the way out. Worth being explicit about the consequence — with nothing rendered the sentinel is immediately in view, so it will page continuously until a match turns up or the corpus runs out. That's the intended behaviour (it's what the viewer would have done by pressing the button repeatedly), just automatic now.
- **Still off the curated tab**, whose sections arrive whole from the curator's page and have no next page.
- **The two lists page differently.** The hub uses a React Query infinite query, so `isFetchingNextPage` comes free. The picker accumulates pages by cursor, so its "already fetching" signal is the placeholder page the cursor query keeps on screen while the next one loads.

### Verification

- `claims-tab.test.tsx`: a stubbed observer records the sentinel and fires it, asserting the next page is fetched and that no Load more button remains; plus no sentinel once the last page has arrived.
- `rematch-page-client.test.tsx`: sentinel present on the browsing tabs and absent on the curated one, absent when there's no next page, and no Load more button.
- Sabotage-checked: removing the sentinel fails the fetch test.
- Both suites needed an `IntersectionObserver` stub, which jsdom doesn't implement.
- All debates suites: 595 pass. Two files fail to load (`media-session`, `debate-room-page-client`) — both fail identically on master.
- Typecheck and prettier clean.

**Running these locally needs the pinned Node 23** from `.tool-versions`; under Node 25 or Bun, `atomWithStorage` throws at import and any suite reaching `matchmaking-claim-card` fails to load.

### Not verified

Not exercised in the running app — worth a scroll through both lists on the preview, particularly that paging keeps up on the picker's All tab, which browses the whole published corpus.