### PR TITLE
fix(community-calls): stop participant avatars rendering as broken images

### DIFF
--- a/apps/web/core/community-calls/participant-avatar.test.ts
+++ b/apps/web/core/community-calls/participant-avatar.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import { participantAvatarUrl } from './participant-avatar';
+
+describe('participantAvatarUrl', () => {
+  it('qualifies a bare CID so the gateway chain can resolve it', () => {
+    expect(participantAvatarUrl('QmT78zSuBmuS4z925WZfrqQ1qHaJ56DQaTfyMUF7F8ff5o')).toBe(
+      'ipfs://QmT78zSuBmuS4z925WZfrqQ1qHaJ56DQaTfyMUF7F8ff5o'
+    );
+  });
+
+  // The bug this exists for: prefixing an already-qualified value yields `ipfs://ipfs://…`, whose
+  // hash parses out empty and resolves to the bare gateway root — a valid URL that 404s.
+  it('leaves an already-qualified ipfs value alone', () => {
+    expect(participantAvatarUrl('ipfs://QmT78z')).toBe('ipfs://QmT78z');
+  });
+
+  it('leaves values the browser can already fetch alone', () => {
+    expect(participantAvatarUrl('https://cdn.example/a.png')).toBe('https://cdn.example/a.png');
+    expect(participantAvatarUrl('http://cdn.example/a.png')).toBe('http://cdn.example/a.png');
+    expect(participantAvatarUrl('data:image/png;base64,AAAA')).toBe('data:image/png;base64,AAAA');
+    expect(participantAvatarUrl('/local/a.png')).toBe('/local/a.png');
+  });
+
+  it('reports nothing for an absent or blank value, so callers draw the generated avatar', () => {
+    expect(participantAvatarUrl(null)).toBeUndefined();
+    expect(participantAvatarUrl(undefined)).toBeUndefined();
+    expect(participantAvatarUrl('')).toBeUndefined();
+    expect(participantAvatarUrl('   ')).toBeUndefined();
+  });
+
+  it('trims surrounding whitespace before qualifying', () => {
+    expect(participantAvatarUrl('  QmT78z  ')).toBe('ipfs://QmT78z');
+  });
+});

--- a/apps/web/core/community-calls/participant-avatar.ts
+++ b/apps/web/core/community-calls/participant-avatar.ts
@@ -1,0 +1,21 @@
+/**
+ * Resolve a call participant's avatar into a value the image components understand.
+ *
+ * curator-backend names the field a CID, but what it carries is whatever the profile held — a bare
+ * CID for some participants, an already-qualified `ipfs://` or https URL for others. Prefixing
+ * blindly is what breaks the qualified ones: `ipfs://ipfs://Qm…` parses to an *empty* hash (the
+ * split takes the segment between the two prefixes), which resolves to the bare gateway root. That
+ * is a perfectly valid URL, so it passes the renderable check, reaches the browser, and 404s —
+ * leaving a broken-image glyph rather than degrading to the generated avatar.
+ *
+ * Returns `undefined` for an absent value so callers land on the generated avatar instead.
+ */
+export function participantAvatarUrl(avatarCid?: string | null): string | undefined {
+  const value = avatarCid?.trim();
+  if (!value) return undefined;
+
+  // Already addressable — either an IPFS URI or something the browser can fetch directly.
+  if (/^(ipfs:\/\/|https?:\/\/|data:|\/)/.test(value)) return value;
+
+  return `ipfs://${value}`;
+}

--- a/apps/web/design-system/avatar.test.tsx
+++ b/apps/web/design-system/avatar.test.tsx
@@ -3,7 +3,7 @@ import { cleanup, fireEvent, render } from '@testing-library/react';
 
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { IPFS_GATEWAY_COUNT } from '~/core/utils/utils';
+import { IPFS_GATEWAY_COUNT, getImagePathAtLevel } from '~/core/utils/utils';
 
 import { Avatar } from './avatar';
 
@@ -76,5 +76,28 @@ describe('Avatar', () => {
     rerender(<Avatar value="Arturas Vil" avatarUrl="ipfs://QmFresh" size={44} />);
 
     expect(storedImage(container)).not.toBeNull();
+  });
+
+  // Gateway progress belongs to the source that earned it. A live participant row keeps its
+  // identity while its avatar url changes underneath, so inheriting the previous url's level would
+  // skip the new image straight past gateways that would have served it.
+  it('restarts a replacement image at the first gateway', () => {
+    const { container, rerender } = render(<Avatar value="Arturas Vil" avatarUrl="ipfs://QmFirst" size={44} />);
+    fireEvent.error(storedImage(container)!);
+    expect(storedImage(container)?.getAttribute('src')).not.toBe(getImagePathAtLevel('ipfs://QmFirst', 0));
+
+    rerender(<Avatar value="Arturas Vil" avatarUrl="ipfs://QmSecond" size={44} />);
+
+    expect(storedImage(container)?.getAttribute('src')).toBe(getImagePathAtLevel('ipfs://QmSecond', 0));
+  });
+
+  // A bare CID mounts no image at all — there is no error event coming — so without an explicit
+  // report the avatar would sit blank. Debate surfaces pass `avatar_cid` through raw, so this is
+  // reachable outside community calls.
+  it('falls back to the generated avatar for a source that can never be requested', () => {
+    const { container } = render(<Avatar value="Arturas Vil" avatarUrl="QmBareCidNoScheme" size={44} />);
+
+    expect(storedImage(container)).toBeNull();
+    expect(generatedAvatar(container)).not.toBeNull();
   });
 });

--- a/apps/web/design-system/avatar.test.tsx
+++ b/apps/web/design-system/avatar.test.tsx
@@ -1,0 +1,80 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup, fireEvent, render } from '@testing-library/react';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { IPFS_GATEWAY_COUNT } from '~/core/utils/utils';
+
+import { Avatar } from './avatar';
+
+afterEach(cleanup);
+
+// The stored image is an `<img alt="">` (presentation role) and the generated one is an
+// `<svg role="img">`, so both would answer to the same query — go by tag instead.
+const storedImage = (container: HTMLElement) => container.querySelector('img');
+const generatedAvatar = (container: HTMLElement) => container.querySelector('svg');
+
+/** Walk the whole gateway fallback chain by failing every attempt. */
+function failEveryGateway(container: HTMLElement) {
+  for (let attempt = 0; attempt < IPFS_GATEWAY_COUNT; attempt += 1) {
+    const img = storedImage(container);
+    if (!img) return;
+    fireEvent.error(img);
+  }
+}
+
+describe('Avatar', () => {
+  it('draws the generated avatar when there is no image', () => {
+    const { container } = render(<Avatar value="Arturas Vil" size={44} />);
+
+    expect(storedImage(container)).toBeNull();
+    expect(generatedAvatar(container)).not.toBeNull();
+  });
+
+  it('draws the stored image while it still resolves', () => {
+    const { container } = render(<Avatar value="Arturas Vil" avatarUrl="ipfs://QmT78z" size={44} />);
+
+    expect(storedImage(container)).not.toBeNull();
+    expect(generatedAvatar(container)).toBeNull();
+  });
+
+  it('tries the next gateway before giving up on an ipfs image', () => {
+    const { container } = render(<Avatar value="Arturas Vil" avatarUrl="ipfs://QmT78z" size={44} />);
+
+    const first = storedImage(container)?.getAttribute('src');
+    fireEvent.error(storedImage(container)!);
+
+    expect(storedImage(container)).not.toBeNull();
+    expect(storedImage(container)?.getAttribute('src')).not.toBe(first);
+  });
+
+  // A stored avatar that no longer resolves anywhere used to leave the browser's broken-image
+  // glyph on screen, which is what the community-call cards were showing.
+  it('falls back to the generated avatar once no gateway can serve the image', () => {
+    const { container } = render(<Avatar value="Arturas Vil" avatarUrl="ipfs://QmT78z" size={44} />);
+
+    failEveryGateway(container);
+
+    expect(storedImage(container)).toBeNull();
+    expect(generatedAvatar(container)).not.toBeNull();
+  });
+
+  it('gives up immediately on a non-ipfs image, which has no chain to walk', () => {
+    const { container } = render(<Avatar value="Arturas Vil" avatarUrl="https://cdn.example/a.png" size={44} />);
+
+    fireEvent.error(storedImage(container)!);
+
+    expect(storedImage(container)).toBeNull();
+    expect(generatedAvatar(container)).not.toBeNull();
+  });
+
+  it('gives a newly supplied image its own attempt after an earlier one failed', () => {
+    const { container, rerender } = render(<Avatar value="Arturas Vil" avatarUrl="ipfs://QmBroken" size={44} />);
+    failEveryGateway(container);
+    expect(storedImage(container)).toBeNull();
+
+    rerender(<Avatar value="Arturas Vil" avatarUrl="ipfs://QmFresh" size={44} />);
+
+    expect(storedImage(container)).not.toBeNull();
+  });
+});

--- a/apps/web/design-system/avatar.tsx
+++ b/apps/web/design-system/avatar.tsx
@@ -1,4 +1,8 @@
+'use client';
+
 import BoringAvatar from 'boring-avatars';
+
+import { useState } from 'react';
 
 import { NativeGeoImage } from './geo-image';
 import { colors } from './theme/colors';
@@ -13,7 +17,12 @@ interface Props {
 }
 
 export const Avatar = ({ value, avatarUrl, priority = false, alt = '', size = 12, square = false }: Props) => {
-  return avatarUrl ? (
+  // Keyed by the url that failed rather than a bare boolean, so a new avatar gets its own attempt
+  // without an effect to reset the flag.
+  const [failedUrl, setFailedUrl] = useState<string | null>(null);
+  const unreachable = avatarUrl != null && failedUrl === avatarUrl;
+
+  return avatarUrl && !unreachable ? (
     <NativeGeoImage
       value={avatarUrl}
       alt={alt}
@@ -21,6 +30,9 @@ export const Avatar = ({ value, avatarUrl, priority = false, alt = '', size = 12
       loading={priority ? 'eager' : 'lazy'}
       fetchPriority={priority ? 'high' : undefined}
       decoding="async"
+      // An avatar always has something to fall back to, so a stored image that no longer resolves
+      // should show the generated one rather than the browser's broken-image glyph.
+      onExhausted={() => setFailedUrl(avatarUrl)}
     />
   ) : (
     <BoringAvatar

--- a/apps/web/design-system/geo-image.tsx
+++ b/apps/web/design-system/geo-image.tsx
@@ -44,17 +44,25 @@ export function GeoImage({ value, alt = '', unoptimized = false, ...props }: Geo
 
 type NativeGeoImageProps = Omit<ImgHTMLAttributes<HTMLImageElement>, 'src' | 'onError'> & {
   value: string;
+  /**
+   * Called once the image cannot be loaded from anywhere — a non-IPFS source that failed, or the
+   * last gateway in the chain. Lets a caller draw something of its own rather than leave the
+   * browser's broken-image glyph on screen.
+   */
+  onExhausted?: () => void;
 };
 
 /** Native img element resolving IPFS values through the gateway fallback chain (Filebase → Pinata → Lighthouse). */
-export function NativeGeoImage({ value, alt = '', ...props }: NativeGeoImageProps) {
+export function NativeGeoImage({ value, alt = '', onExhausted, ...props }: NativeGeoImageProps) {
   const [level, setLevel] = useState(0);
 
   const handleError = useCallback(() => {
-    if (value.startsWith('ipfs://')) {
-      setLevel(prev => Math.min(prev + 1, IPFS_GATEWAY_COUNT - 1));
+    if (value.startsWith('ipfs://') && level < IPFS_GATEWAY_COUNT - 1) {
+      setLevel(level + 1);
+      return;
     }
-  }, [value]);
+    onExhausted?.();
+  }, [level, onExhausted, value]);
 
   const src = getImagePathAtLevel(value, level);
   if (!isRenderableSrc(src)) return null;

--- a/apps/web/design-system/geo-image.tsx
+++ b/apps/web/design-system/geo-image.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import type { ImgHTMLAttributes } from 'react';
 
 import cn from 'classnames';
@@ -25,15 +25,33 @@ function isRenderableSrc(src: string): boolean {
   return src.startsWith('https://') || src.startsWith('http://') || src.startsWith('/') || src.startsWith('data:');
 }
 
+/**
+ * How far through the gateway chain this source has been pushed, reset whenever the source itself
+ * changes. Without the reset a new value inherits the previous one's progress and skips straight
+ * past gateways that would have served it — these components are long-lived in polled lists, where
+ * a row keeps its identity while its image url changes underneath.
+ */
+function useGatewayLevel(value: string) {
+  const [level, setLevel] = useState(0);
+  const [attempted, setAttempted] = useState(value);
+
+  if (attempted !== value) {
+    setAttempted(value);
+    setLevel(0);
+  }
+
+  return [attempted === value ? level : 0, setLevel] as const;
+}
+
 /** Image component that resolves IPFS values through the gateway fallback chain (Filebase → Pinata → Lighthouse). */
 export function GeoImage({ value, alt = '', unoptimized = false, ...props }: GeoImageProps) {
-  const [level, setLevel] = useState(0);
+  const [level, setLevel] = useGatewayLevel(value);
 
   const handleError = useCallback(() => {
     if (value.startsWith('ipfs://')) {
       setLevel(prev => Math.min(prev + 1, IPFS_GATEWAY_COUNT - 1));
     }
-  }, [value]);
+  }, [setLevel, value]);
 
   const src = getImagePathAtLevel(value, level);
   if (!isRenderableSrc(src)) return null;
@@ -54,18 +72,30 @@ type NativeGeoImageProps = Omit<ImgHTMLAttributes<HTMLImageElement>, 'src' | 'on
 
 /** Native img element resolving IPFS values through the gateway fallback chain (Filebase → Pinata → Lighthouse). */
 export function NativeGeoImage({ value, alt = '', onExhausted, ...props }: NativeGeoImageProps) {
-  const [level, setLevel] = useState(0);
+  const [level, setLevel] = useGatewayLevel(value);
+  // Held in a ref so an inline callback doesn't re-fire the effect below on every render.
+  const onExhaustedRef = useRef(onExhausted);
+  onExhaustedRef.current = onExhausted;
+
+  const src = getImagePathAtLevel(value, level);
+  const renderable = isRenderableSrc(src);
+
+  // An unrenderable source — a bare CID, or an entity id that slipped through — mounts no image, so
+  // no error event is ever coming. Say so once per value, or a caller with a fallback of its own is
+  // left drawing a blank instead.
+  useEffect(() => {
+    if (!renderable) onExhaustedRef.current?.();
+  }, [renderable, value]);
 
   const handleError = useCallback(() => {
     if (value.startsWith('ipfs://') && level < IPFS_GATEWAY_COUNT - 1) {
       setLevel(level + 1);
       return;
     }
-    onExhausted?.();
-  }, [level, onExhausted, value]);
+    onExhaustedRef.current?.();
+  }, [level, setLevel, value]);
 
-  const src = getImagePathAtLevel(value, level);
-  if (!isRenderableSrc(src)) return null;
+  if (!renderable) return null;
 
   return <img {...props} src={src} alt={alt} onError={handleError} />;
 }

--- a/apps/web/partials/community-calls/call-details.tsx
+++ b/apps/web/partials/community-calls/call-details.tsx
@@ -13,6 +13,7 @@ import {
 } from '~/core/community-calls/api';
 import { OCCURRENCE_MATCH_TOLERANCE_MS, detailsHref, parseRoomName } from '~/core/community-calls/constants';
 import { formatDateTime, formatDuration, formatFullDate, formatTimeRange } from '~/core/community-calls/format';
+import { participantAvatarUrl } from '~/core/community-calls/participant-avatar';
 import {
   CallAttendee,
   CallChatLogMessage,
@@ -326,11 +327,7 @@ function AttendeesTab({ attendees }: { attendees: CallAttendee[] }) {
         <li key={a.identity} className="flex items-center justify-between rounded-lg border border-grey-02 p-3">
           <div className="flex items-center gap-2">
             <span className="size-6 shrink-0 overflow-hidden rounded-full">
-              <Avatar
-                value={a.name || a.identity}
-                avatarUrl={a.avatarCid ? `ipfs://${a.avatarCid}` : undefined}
-                size={24}
-              />
+              <Avatar value={a.name || a.identity} avatarUrl={participantAvatarUrl(a.avatarCid)} size={24} />
             </span>
             <div className="flex flex-col">
               <span className="text-metadata text-text">

--- a/apps/web/partials/community-calls/chat-panel.tsx
+++ b/apps/web/partials/community-calls/chat-panel.tsx
@@ -6,6 +6,7 @@ import Textarea from 'react-textarea-autosize';
 
 import { formatRelativeTime } from '~/core/community-calls/format';
 import { formatChatMessageLinks } from '~/core/community-calls/format-chat-links';
+import { participantAvatarUrl } from '~/core/community-calls/participant-avatar';
 import { ChatEntry } from '~/core/community-calls/use-persistent-chat';
 import { useToast } from '~/core/hooks/use-toast';
 
@@ -148,11 +149,7 @@ function ChatRow({ entry, showHeader }: { entry: ChatEntry; showHeader: boolean 
       <div className="w-6 shrink-0">
         {showHeader && (
           <span className="block size-6 overflow-hidden rounded-full">
-            <Avatar
-              value={entry.senderName}
-              avatarUrl={entry.senderAvatarCid ? `ipfs://${entry.senderAvatarCid}` : undefined}
-              size={24}
-            />
+            <Avatar value={entry.senderName} avatarUrl={participantAvatarUrl(entry.senderAvatarCid)} size={24} />
           </span>
         )}
       </div>

--- a/apps/web/partials/community-calls/participant-avatar-strip.tsx
+++ b/apps/web/partials/community-calls/participant-avatar-strip.tsx
@@ -5,6 +5,7 @@ import { useQuery } from '@tanstack/react-query';
 import * as React from 'react';
 
 import { getLiveParticipants } from '~/core/community-calls/api';
+import { participantAvatarUrl } from '~/core/community-calls/participant-avatar';
 
 import { Avatar } from '~/design-system/avatar';
 
@@ -49,11 +50,7 @@ export function ParticipantAvatarStrip({
           <div className="grid size-11 grid-cols-2 gap-1">
             {overflow.map(p => (
               <span key={p.identity} className="size-5 overflow-hidden rounded-full border border-white">
-                <Avatar
-                  value={p.name || p.identity}
-                  avatarUrl={p.avatarCid ? `ipfs://${p.avatarCid}` : undefined}
-                  size={20}
-                />
+                <Avatar value={p.name || p.identity} avatarUrl={participantAvatarUrl(p.avatarCid)} size={20} />
               </span>
             ))}
           </div>
@@ -68,7 +65,7 @@ function ParticipantAvatar({ name, avatarCid }: { name: string; avatarCid: strin
   return (
     <div className="flex w-[55px] flex-col items-center gap-1.5">
       <span className="size-11 shrink-0 overflow-hidden rounded-full">
-        <Avatar value={name} avatarUrl={avatarCid ? `ipfs://${avatarCid}` : undefined} size={44} />
+        <Avatar value={name} avatarUrl={participantAvatarUrl(avatarCid)} size={44} />
       </span>
       <span className="w-full truncate text-center text-[12px] leading-[16px] text-grey-04">{name}</span>
     </div>

--- a/apps/web/partials/community-calls/participants-panel.tsx
+++ b/apps/web/partials/community-calls/participants-panel.tsx
@@ -8,6 +8,7 @@ import { Track } from 'livekit-client';
 import type { Participant } from 'livekit-client';
 
 import { muteParticipant, removeParticipant } from '~/core/community-calls/api';
+import { participantAvatarUrl } from '~/core/community-calls/participant-avatar';
 import { parseParticipantMetadata } from '~/core/community-calls/types';
 import { useCommunityCallIdentityToken } from '~/core/community-calls/use-identity-token';
 
@@ -142,7 +143,7 @@ function ParticipantGroup({
                 <span className="size-6 shrink-0 overflow-hidden rounded-full">
                   <Avatar
                     value={participant.name || participant.identity}
-                    avatarUrl={meta.avatarCid ? `ipfs://${meta.avatarCid}` : undefined}
+                    avatarUrl={participantAvatarUrl(meta.avatarCid)}
                     size={24}
                   />
                 </span>


### PR DESCRIPTION
## What

Participant avatars on the live-call card render as broken-image glyphs (the strip under "AI community call" in the explore side panel). Two things are wrong, and I've fixed both — one is the likely root cause, the other guarantees the symptom can't come back looking like this.

## 1. The URL was being double-prefixed

Every community-call surface built its avatar src the same way:

```ts
avatarUrl={p.avatarCid ? `ipfs://${p.avatarCid}` : undefined}
```

curator-backend *names* the field a CID, but it carries whatever the profile held — for some participants a bare CID, for others an already-qualified `ipfs://` or https URL. Prefixing blind turns the qualified ones into `ipfs://ipfs://Qm…`, and that resolves to something worse than nothing:

```
"ipfs://QmABC"                    -> "https://…/ipfs/QmABC"     ✅
"ipfs://ipfs://QmABC"             -> "https://…/ipfs/"          ← bare gateway root
"ipfs://https://cdn.example/a.png" -> "https://…/ipfs/https://cdn.example/a.png"
```

`getImageHash` splits on `ipfs://` and takes the *second* element, which for a double prefix is the empty string between them. The result is a syntactically valid URL, so it passes `isRenderableSrc`, reaches the browser, and 404s — which is exactly a broken-image glyph rather than a blank or a fallback.

Worth noting the same values are passed **raw** everywhere in debates (`avatarUrl={participant.avatar_cid}`), and those avatars work — community calls is the only place adding a prefix.

Fixed with `participantAvatarUrl()`, which only qualifies a value that isn't already addressable, applied at all four call sites (live strip, participants panel, attendee list, chat).

## 2. A failed avatar had nowhere to land

`NativeGeoImage` walks Filebase → Pinata → Lighthouse and then stops, leaving a broken `<img>` on screen. For an avatar that's never the right outcome — there's always a generated one to fall back to.

`NativeGeoImage` now takes an `onExhausted` callback fired when the chain is spent (or immediately for a non-IPFS source, which has no chain), and `Avatar` uses it to draw its `BoringAvatar` instead. Failure is tracked by the URL that failed rather than a boolean, so a newly supplied avatar still gets its own attempt without an effect to reset the flag.

This is the part that holds regardless of what the stored value turns out to be — including a CID that's simply unpinned.

## Test plan

- New `participant-avatar.test.ts` (5 cases) and `avatar.test.tsx` (6 cases). **Both verified as real guards** — reverting the normalizer fails 2, reverting `onExhausted` fails 3.
- `design-system` + `core/community-calls` + `partials/community-calls` + `partials/explore` + `core/debates`: **60 files / 625 tests pass.**
- `bun run build` passes (type check included).

## What I could not verify

I could not confirm the actual `avatarCid` payload shape — curator-backend is an external service, `CURATOR_BACKEND_URL` isn't set in my env, and reaching the participants endpoint needs a live call. So part 1 is a diagnosis from the code, not from an observed response.

If curator does return bare CIDs, the normalizer is a no-op and part 2 is what fixes the glyph — but then the real cause is upstream (bad or unpinned CIDs) and worth chasing there. **The quickest confirmation: open a live call and check what `GET /community-call/participants/…` returns for `avatarCid`.** Happy to adjust if it's something else again.

Note `Avatar` gains `'use client'` since it now holds state. It's rendered inside client trees everywhere I can see, but it's used broadly enough to be worth a glance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)