### PR TITLE
fix(search): drop hits the graph can no longer resolve

### DIFF
--- a/apps/web/core/sync/orm.search.test.ts
+++ b/apps/web/core/sync/orm.search.test.ts
@@ -8,6 +8,7 @@ import {
   isIncludedSearchResult,
   mergeResolvableSpaces,
   resolveSearchSpaces,
+  selectUnresolvableRemoteIds,
 } from './orm';
 
 function makeSpaceEntity(spaceId: string, overrides: Partial<SpaceEntity> = {}): SpaceEntity {
@@ -41,6 +42,28 @@ describe('resolveSearchSpaces', () => {
 
   it('drops string-only spaces when hydration data is unavailable', () => {
     expect(resolveSearchSpaces(['space-1'], {})).toEqual([]);
+  });
+});
+
+describe('selectUnresolvableRemoteIds', () => {
+  // The reported case: /search ranked an entity the graph had already dropped, so choosing it
+  // added a collection item pointing at nothing.
+  it('reports a hit the graph did not return', () => {
+    expect(selectUnresolvableRemoteIds(['ghost', 'real'], ['real'])).toEqual(new Set(['ghost']));
+  });
+
+  it('reports nothing when every hit resolved', () => {
+    expect(selectUnresolvableRemoteIds(['a', 'b'], ['b', 'a'])).toEqual(new Set());
+  });
+
+  // Blanking the results is the worse failure: an empty answer reads as the graph struggling far
+  // more often than it reads as every hit being a ghost.
+  it('trusts nothing from an empty answer, rather than discarding every hit', () => {
+    expect(selectUnresolvableRemoteIds(['a', 'b'], [])).toEqual(new Set());
+  });
+
+  it('has nothing to say when there were no hits to check', () => {
+    expect(selectUnresolvableRemoteIds([], [])).toEqual(new Set());
   });
 });
 

--- a/apps/web/core/sync/orm.ts
+++ b/apps/web/core/sync/orm.ts
@@ -56,6 +56,26 @@ export function getSearchResultNameForTopSpace(
   return hasName(result.name) ? result.name : null;
 }
 
+/**
+ * Search hits the graph can no longer resolve.
+ *
+ * The search index outlives the entities it points at: `/search` still ranks an entity that has
+ * been deleted, and choosing one adds a collection item that resolves to nothing — a row with no
+ * name, no page to open, and no way to tell it apart from a real one. Search already asks the graph
+ * about every remote hit to widen their space lists, so an id missing from that answer is one the
+ * graph doesn't have.
+ *
+ * Only trusted when the answer carried something. An empty response to a non-empty ask is far more
+ * likely to be the graph having a bad moment than every hit being a ghost, and blanking the search
+ * results on that reading is the worse failure of the two.
+ */
+export function selectUnresolvableRemoteIds(requestedIds: string[], resolvedIds: string[]): Set<string> {
+  if (resolvedIds.length === 0) return new Set();
+
+  const resolved = new Set(resolvedIds);
+  return new Set(requestedIds.filter(id => !resolved.has(id)));
+}
+
 export function applyKnownEntitySpaces(
   result: SearchResult,
   knownEntity: Pick<Entity, 'spaces'> | null | undefined
@@ -489,9 +509,17 @@ export class E {
       remoteEntities.map(e => [e.id as string, applyKnownEntitySpaces(e, remoteEntityDetailsById.get(e.id))])
     );
 
-    const maybeEntities = mergedIds.map(entityId => {
-      return mergeSearchResult({ id: entityId, store, mergeWith: remoteById.get(entityId) });
-    });
+    const unresolvableRemoteIds = selectUnresolvableRemoteIds(
+      dedupedRemoteIds,
+      remoteEntityDetails.map(entity => entity.id)
+    );
+
+    const maybeEntities = mergedIds
+      // A local-only id was never in the remote answer to begin with, so it is never a ghost.
+      .filter(entityId => !unresolvableRemoteIds.has(entityId))
+      .map(entityId => {
+        return mergeSearchResult({ id: entityId, store, mergeWith: remoteById.get(entityId) });
+      });
 
     const entities = maybeEntities
       .filter(e => e !== null)


### PR DESCRIPTION
## Answer: it's a backend issue — but the frontend can stop it reaching a collection, so this PR does that.

## Evidence

For the reported entity `13711444bd8d405f99852b523d112166`, against `api-testnet.geobrowser.io`:

| Ask | Answer |
|---|---|
| `GET /search?query=Lebanese President Joseph Aoun visited the White House` | returns it as the **top hit**, with name and space `c9f26…` (Crypto) |
| `{ entity(id: "13711444…") { id name } }` | **`null`** |
| `entities(filter:{id:{in:[…]}})` — the batch lookup search already runs | omits it entirely |

A sibling hit from the same search (`72a20422…`) resolves normally through both, so this isn't a bad query shape — it's specific to this id.

**So the search index is serving entities the entity store no longer has.** Pruning that index is the backend's job, and worth reporting: nothing in the client can put the entity back, and every surface that trusts `/search` will keep offering it.

One aside worth checking separately: the raw-id row in your screenshot, `660ef494c6d346a0a630b7cf449bfc9e`, is a *different* problem — that entity **does** exist but has an empty `name`, which is why it renders as a bare id rather than a title.

## What this PR changes

The frontend was never going to notice, but it turns out it already had the answer. `E.findFuzzyPage` calls `getBatchEntitySpaces(remoteIds)` for every remote hit to widen their space lists — and the ghost is simply absent from that response. The result was kept anyway.

Now an id the graph didn't return is dropped from the results. No extra request; it reads the answer already on the wire.

Guarded so it can't misfire: an **empty** response to a non-empty ask is ignored rather than treated as "every hit is a ghost". The graph returned `SERVICE_UNAVAILABLE` (database pressure) several times while I was investigating, and blanking the search dropdown during a wobble is a worse failure than showing an occasional stale row. Local-only results are untouched, since they were never in the remote answer to begin with.

This is defense-in-depth, not the fix. It stops a deleted entity being added to a collection; it doesn't stop it being indexed.

## Test plan

- `selectUnresolvableRemoteIds` extracted as a pure helper and unit-tested alongside the other search helpers in `orm.search.test.ts` (4 cases). **Verified as a real guard** — removing the empty-answer check fails the test that covers it.
- `core/sync` + `core/io` + `core/hooks`: **40 files / 320 tests pass.**
- `bun run build` passes (type check included).
- Not exercised against the live dropdown — worth searching that claim name once on a preview build to confirm the row is gone.