### PR TITLE
chore(debates): ship claims and debates to everyone

### DIFF
--- a/apps/web/app/space/[id]/(space)/claims/claims-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/claims/claims-page-client.test.tsx
@@ -27,7 +27,6 @@ const mocks = vi.hoisted(() => ({
 
 let claims: Entity[] = [];
 let claimsLoading = false;
-let featureEnabled = true;
 let joinPending = false;
 let lastQueryEntitiesOptions: unknown = null;
 let debateClaimsResponse: { claims: unknown[] } = { claims: [] };
@@ -39,7 +38,6 @@ vi.mock('next/navigation', () => ({
 }));
 
 vi.mock('~/core/state/feature-flags', () => ({
-  useDebatesEnabled: () => featureEnabled,
 }));
 
 vi.mock('~/core/hooks/use-entity-vote', () => ({
@@ -117,7 +115,6 @@ vi.mock('~/design-system/select-entity-compact', () => ({
 beforeEach(() => {
   claims = [];
   claimsLoading = false;
-  featureEnabled = true;
   joinPending = false;
   lastQueryEntitiesOptions = null;
   debateClaimsResponse = { claims: [] };

--- a/apps/web/app/space/[id]/(space)/claims/claims-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/claims/claims-page-client.tsx
@@ -3,7 +3,6 @@
 import * as React from 'react';
 
 import cx from 'classnames';
-import { useRouter } from 'next/navigation';
 
 import { buildClaimDraft } from '~/core/claims/claim-draft';
 import { CLAIM_IS_FACTUAL_PROPERTY_ID, CLAIM_TYPE_ID, TOPICS_PROPERTY_ID, TOPIC_TYPE_ID } from '~/core/claims/ontology';
@@ -18,7 +17,6 @@ import {
   useClaimResponseSummaryBatch,
 } from '~/core/responses/use-claim-response-summaries';
 import { useDiff } from '~/core/state/diff-store';
-import { useDebatesEnabled } from '~/core/state/feature-flags';
 import { useMutate } from '~/core/sync/use-mutate';
 import { useQueryEntities } from '~/core/sync/use-store';
 import type { Entity, Relation } from '~/core/types';
@@ -52,21 +50,6 @@ const relatedFields: RelatedField[] = [
 ];
 
 export function ClaimsPageClient({ spaceId }: ClaimsPageClientProps) {
-  const isDebatesEnabled = useDebatesEnabled();
-  const router = useRouter();
-
-  React.useEffect(() => {
-    if (!isDebatesEnabled) {
-      router.replace(`/space/${spaceId}`);
-    }
-  }, [isDebatesEnabled, router, spaceId]);
-
-  if (!isDebatesEnabled) return null;
-
-  return <ClaimsTabSurface spaceId={spaceId} debatesEnabled={isDebatesEnabled} />;
-}
-
-function ClaimsTabSurface({ spaceId, debatesEnabled }: ClaimsPageClientProps & { debatesEnabled: boolean }) {
   const [formOpen, setFormOpen] = React.useState(false);
   const { entities: claims, isLoading } = useQueryEntities({
     where: {
@@ -78,7 +61,7 @@ function ClaimsTabSurface({ spaceId, debatesEnabled }: ClaimsPageClientProps & {
     includeUnpublishedLocal: true,
   });
   const publishedClaimIds = React.useMemo(() => claims.filter(isClaimPublished).map(claim => claim.id), [claims]);
-  const debateClaimsQuery = useDebateClaims(spaceId, publishedClaimIds, debatesEnabled);
+  const debateClaimsQuery = useDebateClaims(spaceId, publishedClaimIds, true);
   const debateClaimsByEntityId = React.useMemo(() => {
     const map = new Map<string, DebateClaim>();
     for (const claim of debateClaimsQuery.data?.claims ?? []) {
@@ -109,7 +92,7 @@ function ClaimsTabSurface({ spaceId, debatesEnabled }: ClaimsPageClientProps & {
   const responseBatch = useClaimResponseSummaryBatch({
     spaceId,
     targets: responseTargets,
-    enabled: debatesEnabled,
+    enabled: true,
   });
   const responseBatchReady = responseTargets.length === 0 || responseBatch.isSuccess;
   return (
@@ -141,7 +124,6 @@ function ClaimsTabSurface({ spaceId, debatesEnabled }: ClaimsPageClientProps & {
             claims={claims}
             isLoading={isLoading}
             spaceId={spaceId}
-            debatesEnabled={debatesEnabled}
             debateJoinBlocked={activeDebates.length > 0}
             debateClaimsByEntityId={debateClaimsByEntityId}
             responseKindsByEntityId={responseKindsByEntityId}
@@ -262,7 +244,6 @@ function ClaimsList({
   claims,
   isLoading,
   spaceId,
-  debatesEnabled,
   debateJoinBlocked,
   debateClaimsByEntityId,
   responseKindsByEntityId,
@@ -271,7 +252,6 @@ function ClaimsList({
   claims: Entity[];
   isLoading: boolean;
   spaceId: string;
-  debatesEnabled: boolean;
   debateJoinBlocked: boolean;
   debateClaimsByEntityId: Map<string, DebateClaim>;
   responseKindsByEntityId: Map<string, 'stance' | 'veracity'>;
@@ -300,7 +280,7 @@ function ClaimsList({
 
   return (
     <div className="space-y-3">
-      {debateStatus && debatesEnabled && (
+      {debateStatus && (
         <div className="rounded-lg border border-red-01 bg-white px-5 py-3">
           <Text color="red-01">{debateStatus}</Text>
         </div>
@@ -310,7 +290,6 @@ function ClaimsList({
           key={claim.id}
           claim={claim}
           spaceId={spaceId}
-          debatesEnabled={debatesEnabled}
           debateJoinBlocked={debateJoinBlocked}
           debateClaim={debateClaimsByEntityId.get(claim.id) ?? null}
           responseKind={responseKindsByEntityId.get(claim.id) ?? claimResponseKind(claim, spaceId)}
@@ -323,14 +302,12 @@ function ClaimsList({
 function ClaimListItem({
   claim,
   spaceId,
-  debatesEnabled,
   debateJoinBlocked,
   debateClaim,
   responseKind,
 }: {
   claim: Entity;
   spaceId: string;
-  debatesEnabled: boolean;
   debateJoinBlocked: boolean;
   debateClaim: DebateClaim | null;
   responseKind: 'stance' | 'veracity';
@@ -346,14 +323,14 @@ function ClaimListItem({
           {claim.name ?? claim.id}
         </Text>
 
-        {!published && debatesEnabled && (
+        {!published && (
           <Text as="p" variant="body" color="grey-04" className="mt-2">
             Publish this claim before starting a debate.
           </Text>
         )}
       </div>
 
-      {debatesEnabled && published && (
+      {published && (
         <div className="mt-3 flex items-center gap-4">
           <DebateEntityResponseControls entityId={claim.id} spaceId={spaceId} responseKind={responseKind} />
           <ClaimDebateReadiness
@@ -366,7 +343,7 @@ function ClaimListItem({
         </div>
       )}
 
-      {debatesEnabled && <ClaimDebateStatus debateClaim={debateClaim} published={published} />}
+      <ClaimDebateStatus debateClaim={debateClaim} published={published} />
 
       {topics.length > 0 && (
         <div className="mt-3 grid gap-2 md:grid-cols-3">

--- a/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
@@ -58,7 +58,6 @@ const mocks = vi.hoisted(() => ({
   debate: null as Debate | null,
   rematch: null as DebateRematchSession | null,
   featureFlags: {
-    questionsTab: true,
     debateDebugging: false,
   } as Record<string, boolean>,
 }));
@@ -77,7 +76,6 @@ vi.mock('~/design-system/prefetch-link', () => ({
 
 vi.mock('~/core/state/feature-flags', () => ({
   useFeatureFlag: (id: string) => mocks.featureFlags[id] ?? false,
-  useDebatesEnabled: () => mocks.featureFlags['questionsTab'] ?? false,
 }));
 
 vi.mock('~/core/analytics', () => ({
@@ -309,7 +307,6 @@ beforeEach(() => {
   mocks.debate = completedDebate();
   mocks.rematch = null;
   mocks.featureFlags = {
-    questionsTab: true,
     debateDebugging: false,
   };
   mocks.readyMutateAsync.mockResolvedValue(readyDebate({ localReady: true, remoteReady: false }));

--- a/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.tsx
@@ -61,7 +61,7 @@ import {
 } from '~/core/debates/recording-upload-queue';
 import { createLocalServerClock, synchronizeServerClock } from '~/core/debates/server-clock';
 import { useSetThankingDebate } from '~/core/debates/thanking-debate-store';
-import { useDebatesEnabled, useFeatureFlag } from '~/core/state/feature-flags';
+import { useFeatureFlag } from '~/core/state/feature-flags';
 
 import { Button } from '~/design-system/button';
 import { Check } from '~/design-system/icons/check';
@@ -142,17 +142,6 @@ const connectionFailureRedirectDelayMs = 750;
 const maximumBrowserTimeoutMs = 2_147_483_647;
 
 export function DebateRoomPageClient({ spaceId, debateId }: DebateRoomPageClientProps) {
-  const isDebatesEnabled = useDebatesEnabled();
-  const router = useRouter();
-
-  React.useEffect(() => {
-    if (!isDebatesEnabled) {
-      router.replace(`/space/${spaceId}`);
-    }
-  }, [isDebatesEnabled, router, spaceId]);
-
-  if (!isDebatesEnabled) return null;
-
   return (
     <DebateMediaSessionBoundary>
       <DebateRoomSurface spaceId={spaceId} debateId={debateId} />

--- a/apps/web/app/space/[id]/(space)/debates/debates-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/debates-page-client.test.tsx
@@ -42,7 +42,6 @@ vi.mock('next/navigation', () => ({
 
 vi.mock('~/core/state/feature-flags', () => ({
   useFeatureFlag: () => true,
-  useDebatesEnabled: () => true,
 }));
 
 vi.mock('~/core/debates/hooks', () => ({

--- a/apps/web/app/space/[id]/(space)/debates/debates-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/debates-page-client.tsx
@@ -1,27 +1,11 @@
 'use client';
 
-import * as React from 'react';
-
-import { useRouter } from 'next/navigation';
-
 import { DebatesBrowseFeed } from '~/core/debates/browse/debate-feed';
-import { useDebatesEnabled } from '~/core/state/feature-flags';
 
 type DebatesPageClientProps = {
   spaceId: string;
 };
 
 export function DebatesPageClient({ spaceId }: DebatesPageClientProps) {
-  const isDebatesEnabled = useDebatesEnabled();
-  const router = useRouter();
-
-  React.useEffect(() => {
-    if (!isDebatesEnabled) {
-      router.replace(`/space/${spaceId}`);
-    }
-  }, [isDebatesEnabled, router, spaceId]);
-
-  if (!isDebatesEnabled) return null;
-
   return <DebatesBrowseFeed spaceId={spaceId} />;
 }

--- a/apps/web/core/debates/browse/debate-entity-view.tsx
+++ b/apps/web/core/debates/browse/debate-entity-view.tsx
@@ -3,7 +3,6 @@
 import * as React from 'react';
 
 import { useUserIsEditing } from '~/core/hooks/use-user-is-editing';
-import { useDebatesEnabled } from '~/core/state/feature-flags';
 
 import { DebatesBrowseFeed } from './debate-feed';
 
@@ -23,9 +22,8 @@ type DebateEntityViewProps = {
  */
 export function DebateEntityView({ spaceId, debateId, editView }: DebateEntityViewProps) {
   const isEditing = useUserIsEditing(spaceId);
-  const debatesEnabled = useDebatesEnabled();
 
-  if (isEditing || !debatesEnabled) {
+  if (isEditing) {
     return <>{editView}</>;
   }
 

--- a/apps/web/core/debates/claim-debate-button.test.tsx
+++ b/apps/web/core/debates/claim-debate-button.test.tsx
@@ -13,14 +13,12 @@ import type { DebateClaim } from './api';
 import { ClaimDebateButton } from './claim-debate-button';
 
 const mocks = vi.hoisted(() => ({
-  debatesEnabled: vi.fn(),
   debateClaims: vi.fn(),
   joinMutate: vi.fn(),
   leaveMutate: vi.fn(),
 }));
 
 vi.mock('~/core/state/feature-flags', () => ({
-  useDebatesEnabled: () => mocks.debatesEnabled(),
 }));
 
 vi.mock('~/core/hooks/use-entity-vote', () => ({
@@ -46,7 +44,6 @@ vi.mock('~/partials/entity-page/entity-vote-buttons', () => ({
 }));
 
 beforeEach(() => {
-  mocks.debatesEnabled.mockReturnValue(true);
   mocks.debateClaims.mockReturnValue({ data: { claims: [] } });
   mocks.joinMutate.mockReset();
   mocks.joinMutate.mockReturnValue(new Promise(() => undefined));

--- a/apps/web/core/debates/claim-debate-button.tsx
+++ b/apps/web/core/debates/claim-debate-button.tsx
@@ -2,7 +2,6 @@
 
 import { CLAIM_TYPE_ID } from '~/core/claims/ontology';
 import { isClaimPublished } from '~/core/claims/publish';
-import { useDebatesEnabled } from '~/core/state/feature-flags';
 import { useQueryEntity } from '~/core/sync/use-store';
 import type { Entity } from '~/core/types';
 
@@ -18,22 +17,21 @@ type ClaimDebateButtonProps = {
 };
 
 export function ClaimDebateButton({ entityId, spaceId, entity: providedEntity }: ClaimDebateButtonProps) {
-  const isDebatesEnabled = useDebatesEnabled();
   const { entity: fetchedEntity } = useQueryEntity({
     id: entityId,
     spaceId,
-    enabled: isDebatesEnabled && providedEntity == null,
+    enabled: providedEntity == null,
   });
   const entity = providedEntity ?? fetchedEntity;
   const isClaim = entity?.types.some(type => type.id === CLAIM_TYPE_ID) ?? false;
   const published = entity ? isClaimPublished(entity) : false;
 
-  const debateClaimsQuery = useDebateClaims(spaceId, published ? [entityId] : [], isDebatesEnabled && isClaim);
+  const debateClaimsQuery = useDebateClaims(spaceId, published ? [entityId] : [], isClaim);
   const debateClaim = debateClaimsQuery.data?.claims.find(claim => claim.claim_entity_id === entityId) ?? null;
-  const activity = useDebateActivity(isDebatesEnabled && isClaim).data ?? null;
+  const activity = useDebateActivity(isClaim).data ?? null;
   const hasActiveFlowElsewhere = hasActiveDebateFlow(activity);
 
-  if (!isDebatesEnabled || !isClaim) return null;
+  if (!isClaim) return null;
 
   const canEnable = published && !debateClaim?.active_debate && !hasActiveFlowElsewhere;
 

--- a/apps/web/core/debates/debate-coordinator.test.tsx
+++ b/apps/web/core/debates/debate-coordinator.test.tsx
@@ -92,7 +92,6 @@ vi.mock('./claim-response-indexed-notifier', () => ({
 }));
 
 vi.mock('~/core/state/feature-flags', () => ({
-  useDebatesEnabled: () => true,
 }));
 
 beforeEach(() => {

--- a/apps/web/core/debates/debate-coordinator.tsx
+++ b/apps/web/core/debates/debate-coordinator.tsx
@@ -4,8 +4,6 @@ import * as React from 'react';
 
 import { usePathname, useRouter } from 'next/navigation';
 
-import { useDebatesEnabled } from '~/core/state/feature-flags';
-
 import { Button } from '~/design-system/button';
 import { Upload } from '~/design-system/icons/upload';
 import { Spinner } from '~/design-system/spinner';
@@ -42,22 +40,21 @@ import { useScrollLock } from './use-scroll-lock';
 export function DebateCoordinator() {
   const router = useRouter();
   const pathname = usePathname();
-  const isDebatesEnabled = useDebatesEnabled();
   const geoChatAuth = useGeoChatAuth();
   // Presence, not attention: being available to debate has to survive looking at another window.
   const debatePresence = useDebatePresence();
   const gateway = useDebateGateway(
-    isDebatesEnabled && geoChatAuth.ready && geoChatAuth.authenticated,
+    geoChatAuth.ready && geoChatAuth.authenticated,
     geoChatAuth.getPrivyIdentityToken,
     geoChatAuth.accountKey,
     debatePresence
   );
   useClaimResponseIndexedNotifier(
-    isDebatesEnabled && geoChatAuth.ready && geoChatAuth.authenticated,
+    geoChatAuth.ready && geoChatAuth.authenticated,
     geoChatAuth.getPrivyIdentityToken,
     geoChatAuth.accountKey
   );
-  const activityQuery = useDebateActivity(isDebatesEnabled);
+  const activityQuery = useDebateActivity();
   const currentUserId = useCurrentGeoChatUserId();
   const activity = activityQuery.data ?? null;
   const debate = activeDebate(activity);
@@ -87,7 +84,7 @@ export function DebateCoordinator() {
   // Only fetch the request list once activity says one exists, so idle sessions stay quiet. "Not
   // now" snoozes a request for this session; it stays in the hub's Requests tab either way.
   const hasIncomingRequests = (activity?.incoming_request_count ?? 0) > 0;
-  const requestsQuery = useDebateRequests(isDebatesEnabled && hasIncomingRequests && !activeFlow);
+  const requestsQuery = useDebateRequests(hasIncomingRequests && !activeFlow);
   const [snoozedRequestIds, setSnoozedRequestIds] = React.useState<string[]>([]);
   // Expired requests are dropped here too, so the popup can never prompt for a dead request while
   // waiting on the server's `debate.requests_changed` event.
@@ -195,7 +192,6 @@ export function DebateCoordinator() {
     }
   }, [activity, pathname, router]);
 
-  if (!isDebatesEnabled) return null;
   const visibleSharePrompt =
     retainedSharePrompt ?? (queriedSharePrompt?.id === closedSharePromptId ? null : queriedSharePrompt);
 

--- a/apps/web/core/debates/hooks.test.tsx
+++ b/apps/web/core/debates/hooks.test.tsx
@@ -50,7 +50,6 @@ vi.mock('next/navigation', () => ({
 }));
 
 vi.mock('~/core/state/feature-flags', () => ({
-  useDebatesEnabled: () => true,
 }));
 
 vi.mock('@geogenesis/auth', () => ({

--- a/apps/web/core/debates/matchmaking/debates-hub-button.test.tsx
+++ b/apps/web/core/debates/matchmaking/debates-hub-button.test.tsx
@@ -8,13 +8,11 @@ import { DebatesHubButton } from './debates-hub-button';
 import { debatesHubAtom } from '~/atoms';
 
 const mocks = vi.hoisted(() => ({
-  debatesEnabled: true,
   ready: true,
   authenticated: true,
   incomingRequestCount: 0,
 }));
 
-vi.mock('~/core/state/feature-flags', () => ({ useDebatesEnabled: () => mocks.debatesEnabled }));
 
 vi.mock('../hooks', () => ({
   useGeoChatAuth: () => ({ ready: mocks.ready, authenticated: mocks.authenticated, accountKey: 'user-a' }),
@@ -34,7 +32,6 @@ function renderButton() {
 }
 
 beforeEach(() => {
-  mocks.debatesEnabled = true;
   mocks.ready = true;
   mocks.authenticated = true;
   mocks.incomingRequestCount = 0;
@@ -62,12 +59,6 @@ describe('DebatesHubButton', () => {
     mocks.authenticated = false;
     renderButton();
 
-    expect(screen.queryByRole('button', { name: /Debates/ })).not.toBeInTheDocument();
-  });
-
-  it('stays hidden when debates are switched off, even signed in', () => {
-    mocks.debatesEnabled = false;
-    renderButton();
     expect(screen.queryByRole('button', { name: /Debates/ })).not.toBeInTheDocument();
   });
 

--- a/apps/web/core/debates/matchmaking/debates-hub-button.tsx
+++ b/apps/web/core/debates/matchmaking/debates-hub-button.tsx
@@ -4,8 +4,6 @@ import * as React from 'react';
 
 import cx from 'classnames';
 
-import { useDebatesEnabled } from '~/core/state/feature-flags';
-
 import { Megaphone } from '~/design-system/icons/megaphone';
 
 import { useDebateActivity, useGeoChatAuth } from '../hooks';
@@ -20,18 +18,17 @@ import { useUnexpiredRequests } from './use-request-countdown';
  * open it for.
  */
 export function DebatesHubButton() {
-  const isDebatesEnabled = useDebatesEnabled();
   // False until Privy has restored the session, so the button stays hidden until we actually know
   // — appearing late beats flashing in and out for someone who was never signed in.
   const { authenticated } = useGeoChatAuth();
   const { isOpen, toggle } = useDebatesHub();
-  const { data: activity } = useDebateActivity(isDebatesEnabled);
+  const { data: activity } = useDebateActivity();
   // Read-only: the coordinator already fetches this list whenever there is anything in it, and the
   // badge must agree with the one in the panel rather than counting requests that have expired.
   const { data: requests } = useDebateRequests(false);
   const incoming = useUnexpiredRequests(requests?.incoming ?? []);
 
-  if (!isDebatesEnabled || !authenticated) return null;
+  if (!authenticated) return null;
 
   const requestCount = requests ? incoming.length : (activity?.incoming_request_count ?? 0);
 

--- a/apps/web/core/debates/matchmaking/debates-hub-panel.test.tsx
+++ b/apps/web/core/debates/matchmaking/debates-hub-panel.test.tsx
@@ -20,7 +20,6 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock('next/navigation', () => ({ usePathname: () => mocks.pathname }));
 
-vi.mock('~/core/state/feature-flags', () => ({ useDebatesEnabled: () => true }));
 
 vi.mock('~/core/hooks/use-is-mobile-layout', () => ({ useIsMobileLayout: () => mocks.isMobile }));
 

--- a/apps/web/core/debates/matchmaking/debates-hub-panel.tsx
+++ b/apps/web/core/debates/matchmaking/debates-hub-panel.tsx
@@ -8,7 +8,6 @@ import { usePathname } from 'next/navigation';
 import { createPortal } from 'react-dom';
 
 import { useIsMobileLayout } from '~/core/hooks/use-is-mobile-layout';
-import { useDebatesEnabled } from '~/core/state/feature-flags';
 
 import { CloseSmall } from '~/design-system/icons/close-small';
 import { Badge, tabGroupTabLinkStyles } from '~/design-system/tab-group';
@@ -56,7 +55,6 @@ function shouldStartSheetDrag(event: React.PointerEvent, root: HTMLElement): boo
 }
 
 export function DebatesHubPanel() {
-  const isDebatesEnabled = useDebatesEnabled();
   const isMobile = useIsMobileLayout();
   const dragControls = useDragControls();
   const { isOpen, activeTab, close, setTab } = useDebatesHub();
@@ -115,7 +113,7 @@ export function DebatesHubPanel() {
     return () => document.removeEventListener('pointerdown', handlePointerDown, true);
   }, [isOpen, isMobile, close]);
 
-  if (!isDebatesEnabled || !isOpen) return null;
+  if (!isOpen) return null;
   if (typeof document === 'undefined' || !document.body) return null;
 
   // Only the sheet gets a close button. `aria-modal` hides the rest of the page from assistive

--- a/apps/web/core/debates/profile-debate-button.tsx
+++ b/apps/web/core/debates/profile-debate-button.tsx
@@ -2,8 +2,6 @@
 
 import * as React from 'react';
 
-import { useDebatesEnabled } from '~/core/state/feature-flags';
-
 import { Text } from '~/design-system/text';
 
 import { useCreateDebateChallenge, useDebateProfile } from './hooks';
@@ -14,11 +12,10 @@ import { useCreateDebateChallenge, useDebateProfile } from './hooks';
  * available and neither side is mid-flow. `DebateCoordinator` owns the request dialog.
  */
 export function ProfileDebateButton({ spaceId }: { spaceId: string }) {
-  const isDebatesEnabled = useDebatesEnabled();
-  const profileQuery = useDebateProfile(spaceId, isDebatesEnabled);
+  const profileQuery = useDebateProfile(spaceId);
   const createChallenge = useCreateDebateChallenge();
 
-  if (!isDebatesEnabled || !profileQuery.data?.can_challenge) return null;
+  if (!profileQuery.data?.can_challenge) return null;
 
   const error = createChallenge.error instanceof Error ? createChallenge.error.message : null;
 

--- a/apps/web/core/state/feature-flags.test.ts
+++ b/apps/web/core/state/feature-flags.test.ts
@@ -15,29 +15,23 @@ describe('feature flags', () => {
   });
 
   it('defaults local feature flags to disabled', () => {
-    expect(defaultFeatureFlags.questionsTab).toBe(false);
     expect(defaultFeatureFlags.debugDebatesPage).toBe(false);
     expect(defaultFeatureFlags.debateDebugging).toBe(false);
     expect(defaultFeatureFlags.debateFormatSelector).toBe(false);
     expect(normalizeFeatureFlags(null)).toEqual({
-      questionsTab: false,
       debugDebatesPage: false,
       debateDebugging: false,
       debateFormatSelector: false,
     });
   });
 
-  it('maps the legacy Debates flag into the combined flag', () => {
-    expect(normalizeFeatureFlags({ debatesTab: true })).toEqual({
-      questionsTab: true,
+  // Claims and debates shipped to everyone. Every browser that ever opened the flags dialog still
+  // has the retired ids in storage, and they must not survive normalization — a stray `questionsTab`
+  // reaching the dialog would render a checkbox for a flag nothing reads.
+  it('drops the retired claims-and-debates flags that are still in storage', () => {
+    expect(normalizeFeatureFlags({ questionsTab: true, debatesTab: true, debateDebugging: true })).toEqual({
       debugDebatesPage: false,
-      debateDebugging: false,
-      debateFormatSelector: false,
-    });
-    expect(normalizeFeatureFlags({ questionsTab: true, debatesTab: false })).toEqual({
-      questionsTab: true,
-      debugDebatesPage: false,
-      debateDebugging: false,
+      debateDebugging: true,
       debateFormatSelector: false,
     });
   });
@@ -46,19 +40,16 @@ describe('feature flags', () => {
     const store = createStore();
 
     store.set(featureFlagsAtom, currentFlags => {
-      const flags = setFeatureFlagValue(normalizeFeatureFlags(currentFlags), 'questionsTab', true);
-      const debugPageFlags = setFeatureFlagValue(flags, 'debugDebatesPage', true);
+      const debugPageFlags = setFeatureFlagValue(normalizeFeatureFlags(currentFlags), 'debugDebatesPage', true);
       const debuggingFlags = setFeatureFlagValue(debugPageFlags, 'debateDebugging', true);
       return setFeatureFlagValue(debuggingFlags, 'debateFormatSelector', true);
     });
 
-    expect(store.get(featureFlagsAtom).questionsTab).toBe(true);
     expect(store.get(featureFlagsAtom).debugDebatesPage).toBe(true);
     expect(store.get(featureFlagsAtom).debateDebugging).toBe(true);
     expect(store.get(featureFlagsAtom).debateFormatSelector).toBe(true);
     expect(window.localStorage.getItem(featureFlagsStorageKey)).toBe(
       JSON.stringify({
-        questionsTab: true,
         debugDebatesPage: true,
         debateDebugging: true,
         debateFormatSelector: true,

--- a/apps/web/core/state/feature-flags.ts
+++ b/apps/web/core/state/feature-flags.ts
@@ -7,11 +7,6 @@ export const featureFlagsStorageKey = 'geo:feature-flags';
 
 export const featureFlagDefinitions = [
   {
-    id: 'questionsTab',
-    label: 'Claims and debates',
-    description: 'Enable claim and debate features on spaces.',
-  },
-  {
     id: 'debateDebugging',
     label: 'Debate debugging',
     description: 'Show manual debugging controls during debate recording.',
@@ -30,10 +25,12 @@ export const featureFlagDefinitions = [
 
 export type FeatureFlagId = (typeof featureFlagDefinitions)[number]['id'];
 export type FeatureFlags = Record<FeatureFlagId, boolean>;
-type StoredFeatureFlags = Partial<Record<FeatureFlagId | 'debatesTab', boolean>>;
+// Claims and debates shipped to everyone, so `questionsTab` (and `debatesTab`, the id it was
+// renamed from) are no longer flags. Both are still sitting in browsers' stored flag objects;
+// normalizing drops them on the next write rather than reading them back.
+type StoredFeatureFlags = Partial<Record<FeatureFlagId | 'questionsTab' | 'debatesTab', boolean>>;
 
 export const defaultFeatureFlags: FeatureFlags = {
-  questionsTab: false,
   debugDebatesPage: false,
   debateDebugging: false,
   debateFormatSelector: false,
@@ -41,7 +38,6 @@ export const defaultFeatureFlags: FeatureFlags = {
 
 export function normalizeFeatureFlags(flags: StoredFeatureFlags | null | undefined): FeatureFlags {
   return {
-    questionsTab: flags?.questionsTab ?? flags?.debatesTab ?? defaultFeatureFlags.questionsTab,
     debugDebatesPage: flags?.debugDebatesPage ?? defaultFeatureFlags.debugDebatesPage,
     debateDebugging: flags?.debateDebugging ?? defaultFeatureFlags.debateDebugging,
     debateFormatSelector: flags?.debateFormatSelector ?? defaultFeatureFlags.debateFormatSelector,
@@ -62,16 +58,6 @@ export const featureFlagsAtom = atomWithStorage<FeatureFlags>(featureFlagsStorag
 export function useFeatureFlag(id: FeatureFlagId) {
   const flags = useAtomValue(featureFlagsAtom);
   return normalizeFeatureFlags(flags)[id];
-}
-
-/**
- * The Debates feature — the claims page, the debate room, the claim debate
- * button, and the match coordinator — all gate on the single
- * `questionsTab` flag. Use this hook everywhere that renders claim/debate UI
- * instead of inlining the flag id, so every surface flips together.
- */
-export function useDebatesEnabled() {
-  return useFeatureFlag('questionsTab');
 }
 
 export function useDebugDebatesPageEnabled() {

--- a/apps/web/partials/explore/debate-explore-feed-card.test.tsx
+++ b/apps/web/partials/explore/debate-explore-feed-card.test.tsx
@@ -10,7 +10,6 @@ import type { ExploreFeedItem } from '~/core/explore/fetch-explore-feed';
 import { DebateExploreFeedCard } from './debate-explore-feed-card';
 
 const mocks = vi.hoisted(() => ({
-  debatesEnabled: true,
   debateQuery: { data: undefined as Debate | undefined, isError: false },
   mediaQuery: { data: undefined as { artifacts: { kind: string }[] } | undefined, isError: false },
 }));
@@ -24,7 +23,6 @@ type ObserverRecord = {
 let observers: ObserverRecord[] = [];
 
 vi.mock('~/core/state/feature-flags', () => ({
-  useDebatesEnabled: () => mocks.debatesEnabled,
 }));
 
 vi.mock('~/core/debates/hooks', () => ({
@@ -105,7 +103,6 @@ function watchableDebate(): Debate {
 beforeEach(() => {
   vi.clearAllMocks();
   observers = [];
-  mocks.debatesEnabled = true;
   mocks.debateQuery = { data: undefined, isError: false };
   mocks.mediaQuery = { data: undefined, isError: false };
 
@@ -164,13 +161,6 @@ function renderCard() {
 }
 
 describe('DebateExploreFeedCard', () => {
-  it('renders the fallback when the debates feature is off', () => {
-    mocks.debatesEnabled = false;
-    renderCard();
-    expect(screen.getByTestId('fallback')).toBeDefined();
-    expect(screen.queryByTestId('player')).toBeNull();
-  });
-
   it('shows the card chrome with video placeholders while the debate loads', () => {
     renderCard();
     expect(screen.getByText('Fast fashion should be discouraged with higher taxation')).toBeDefined();

--- a/apps/web/partials/explore/debate-explore-feed-card.tsx
+++ b/apps/web/partials/explore/debate-explore-feed-card.tsx
@@ -13,7 +13,6 @@ import { useDebateVotes } from '~/core/debates/use-debate-votes';
 import { formatExploreRelativeTime } from '~/core/explore/explore-relative-time';
 import type { ExploreFeedItem } from '~/core/explore/fetch-explore-feed';
 import { ID } from '~/core/id';
-import { useDebatesEnabled } from '~/core/state/feature-flags';
 import { NavUtils } from '~/core/utils/utils';
 
 import { PrefetchLink as Link } from '~/design-system/prefetch-link';
@@ -52,7 +51,6 @@ export function DebateExploreFeedCard({
   hideJoinButton = false,
   fallback,
 }: DebateExploreFeedCardProps) {
-  const debatesEnabled = useDebatesEnabled();
   // A Debate entity's id is its geo-chat debate id (see useDebateVotes), modulo hyphenation.
   const debateId = ID.hexToUuid(item.entityId);
 
@@ -91,14 +89,13 @@ export function DebateExploreFeedCard({
     return () => observer.disconnect();
   }, [container]);
 
-  const enabled = debatesEnabled && nearViewport;
-  const debateQuery = useDebate(debateId, enabled);
+  const debateQuery = useDebate(debateId, nearViewport);
   const debate = debateQuery.data;
   const watchable = debate != null && isWatchableDebate(debate);
 
   // Same two-stage gate as the full-screen feed (GEO-2412): both recordings existing doesn't
   // prove the media job produced a playable final video.
-  const mediaQuery = useDebateMedia(debateId, enabled && watchable);
+  const mediaQuery = useDebateMedia(debateId, nearViewport && watchable);
   const processed = hasProcessedVideo(mediaQuery.data);
 
   const notWatchable =
@@ -107,7 +104,7 @@ export function DebateExploreFeedCard({
     mediaQuery.isError ||
     (mediaQuery.data != null && !processed);
 
-  if (!debatesEnabled || notWatchable) {
+  if (notWatchable) {
     return <>{fallback}</>;
   }
 

--- a/apps/web/partials/feature-flags/feature-flags-dialog.test.tsx
+++ b/apps/web/partials/feature-flags/feature-flags-dialog.test.tsx
@@ -44,13 +44,11 @@ describe('FeatureFlagsDialog', () => {
       .getAllByRole('button')
       .filter(button => button.getAttribute('aria-label') !== 'Close feature flags');
     expect(featureFlagButtons.map(button => button.getAttribute('aria-label'))).toEqual([
-      'Claims and debates',
       'Debate debugging',
       'Debate format selector',
       'Debates debug tab per space',
     ]);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Claims and debates' }));
     fireEvent.click(screen.getByRole('button', { name: 'Debate debugging' }));
     fireEvent.click(screen.getByRole('button', { name: 'Debate format selector' }));
     fireEvent.click(screen.getByRole('button', { name: 'Debates debug tab per space' }));
@@ -58,7 +56,6 @@ describe('FeatureFlagsDialog', () => {
     await waitFor(() => {
       expect(window.localStorage.getItem(featureFlagsStorageKey)).toBe(
         JSON.stringify({
-          questionsTab: true,
           debugDebatesPage: true,
           debateDebugging: true,
           debateFormatSelector: true,

--- a/apps/web/partials/navbar/navbar-actions.test.tsx
+++ b/apps/web/partials/navbar/navbar-actions.test.tsx
@@ -9,7 +9,6 @@ import { NavbarActions } from './navbar-actions';
 const address = '0x1234567890abcdef1234567890abcdef12345678';
 
 const mocks = vi.hoisted(() => ({
-  debatesEnabled: true,
   logout: vi.fn(),
   setToast: vi.fn(),
   debateActivityHook: vi.fn(),
@@ -57,7 +56,6 @@ vi.mock('~/core/state/pending-personal-space', () => ({
   usePendingPersonalSpace: () => mocks.pendingPersonalSpace,
 }));
 vi.mock('~/core/state/feature-flags', () => ({
-  useDebatesEnabled: () => mocks.debatesEnabled,
 }));
 vi.mock('~/core/debates/hooks', () => ({
   useDebateActivity: (enabled: boolean) => {
@@ -130,7 +128,6 @@ describe('NavbarActions debate availability menu', () => {
   afterEach(cleanup);
 
   beforeEach(() => {
-    mocks.debatesEnabled = true;
     mocks.logout.mockReset();
     mocks.setToast.mockReset();
     mocks.debateActivityHook.mockReset();
@@ -155,22 +152,7 @@ describe('NavbarActions debate availability menu', () => {
     };
   });
 
-  it('keeps the legacy menu when the debate flag is off', async () => {
-    mocks.debatesEnabled = false;
-    const user = userEvent.setup();
-    render(<NavbarActions />);
-
-    await user.click(screen.getByRole('button', { name: 'Open profile menu' }));
-
-    expect(screen.getByText('Personal space')).toBeInTheDocument();
-    expect(screen.getByText('Sign out')).toBeInTheDocument();
-    expect(screen.queryByRole('switch')).not.toBeInTheDocument();
-    expect(screen.queryByText('max@example.com')).not.toBeInTheDocument();
-    expect(mocks.debateActivityHook).toHaveBeenCalledWith(false);
-    expect(mocks.mutateAvailability).not.toHaveBeenCalled();
-  });
-
-  it('renders the wider flagged identity layout and personal-space link', async () => {
+  it('renders the wider identity layout and personal-space link', async () => {
     const user = userEvent.setup();
     render(<NavbarActions />);
 

--- a/apps/web/partials/navbar/navbar-actions.tsx
+++ b/apps/web/partials/navbar/navbar-actions.tsx
@@ -5,7 +5,6 @@ import * as Popover from '@radix-ui/react-popover';
 
 import * as React from 'react';
 
-import { cva } from 'class-variance-authority';
 import cx from 'classnames';
 import { AnimatePresence, motion, useAnimation } from 'framer-motion';
 import { useAtomValue } from 'jotai';
@@ -20,7 +19,6 @@ import { useSmartAccount } from '~/core/hooks/use-smart-account';
 import { useSpaceId } from '~/core/hooks/use-space-id';
 import { useToast } from '~/core/hooks/use-toast';
 import { useEditable } from '~/core/state/editable-store';
-import { useDebatesEnabled } from '~/core/state/feature-flags';
 import { usePendingPersonalSpace } from '~/core/state/pending-personal-space';
 import { NavUtils } from '~/core/utils/utils';
 import { GeoConnectButton } from '~/core/wallet';
@@ -28,7 +26,6 @@ import { GeoConnectButton } from '~/core/wallet';
 import { Avatar } from '~/design-system/avatar';
 import { FallbackImage } from '~/design-system/fallback-image';
 import { BulkEdit } from '~/design-system/icons/bulk-edit';
-import { DisconnectWallet } from '~/design-system/icons/disconnect-wallet';
 import { EyeSmall } from '~/design-system/icons/eye-small';
 import { Menu } from '~/design-system/menu';
 import { PrefetchLink as Link } from '~/design-system/prefetch-link';
@@ -53,8 +50,7 @@ export function NavbarActions() {
   const { personalSpaceId } = usePersonalSpaceId();
   const { isPending, topicId } = usePendingPersonalSpace();
   const pendingAvatar = useAtomValue(avatarAtom);
-  const isDebatesEnabled = useDebatesEnabled();
-  const activityQuery = useDebateActivity(isDebatesEnabled);
+  const activityQuery = useDebateActivity();
   const availabilityMutation = useUpdateDebateAvailability();
   const { user } = usePrivy();
   const [, setToast] = useToast();
@@ -113,67 +109,49 @@ export function NavbarActions() {
         open={open}
         onOpenChange={onOpenChange}
         sideOffset={12}
-        className={
-          isDebatesEnabled ? 'w-[calc(100vw-16px)] max-w-[322px] rounded-[20px] sm:w-[322px]' : 'max-w-[165px]'
-        }
+        className="w-[calc(100vw-16px)] max-w-[322px] rounded-[20px] sm:w-[322px]"
       >
-        {isDebatesEnabled ? (
-          <>
-            <IdentityHeader
-              address={address}
-              avatarValue={avatarValue}
-              displayName={displayName}
-              detail={identityDetail}
-              href={personalHref}
-              onNavigate={() => onOpenChange(false)}
-            />
-            <div className="border-t border-grey-02">
-              <button
-                type="button"
-                role="switch"
-                aria-checked={availableToDebate}
-                disabled={availabilityPending}
-                onClick={toggleDebateAvailability}
-                className="flex w-full items-center justify-between gap-1 px-3 py-2.5 text-left font-[family-name:var(--font-calibre)] text-[1rem] leading-[0.9375rem] font-medium tracking-[-0.03125rem] text-text not-italic transition-colors hover:bg-bg focus-visible:bg-bg focus-visible:outline-none disabled:cursor-wait disabled:text-grey-03"
-              >
-                <span className="min-w-0 truncate">Available to debate</span>
-                <span
-                  aria-hidden="true"
-                  className={cx(
-                    'relative h-4 w-6 shrink-0 rounded-full transition-colors',
-                    availableToDebate ? 'bg-text' : 'bg-grey-03'
-                  )}
-                >
-                  <span
-                    className={cx(
-                      'absolute top-0.5 left-0.5 h-3 w-3 rounded-full bg-white transition-transform',
-                      availableToDebate && 'translate-x-2'
-                    )}
-                  />
-                </span>
-              </button>
-              <button
-                type="button"
-                onClick={logout}
-                className="flex w-full items-center px-3 py-2.5 text-left font-[family-name:var(--font-calibre)] text-[1rem] leading-[0.9375rem] font-medium tracking-[-0.03125rem] text-text not-italic transition-colors hover:bg-bg focus-visible:bg-bg focus-visible:outline-none"
-              >
-                Sign out
-              </button>
-            </div>
-          </>
-        ) : (
-          <>
-            {personalHref && (
-              <AvatarMenuItem href={personalHref}>
-                <p className="text-button">Personal space</p>
-              </AvatarMenuItem>
-            )}
-            <AvatarMenuItem onClick={logout}>
-              <p className="text-button">Sign out</p>
-              <DisconnectWallet />
-            </AvatarMenuItem>
-          </>
-        )}
+        <IdentityHeader
+          address={address}
+          avatarValue={avatarValue}
+          displayName={displayName}
+          detail={identityDetail}
+          href={personalHref}
+          onNavigate={() => onOpenChange(false)}
+        />
+        <div className="border-t border-grey-02">
+          <button
+            type="button"
+            role="switch"
+            aria-checked={availableToDebate}
+            disabled={availabilityPending}
+            onClick={toggleDebateAvailability}
+            className="flex w-full items-center justify-between gap-1 px-3 py-2.5 text-left font-[family-name:var(--font-calibre)] text-[1rem] leading-[0.9375rem] font-medium tracking-[-0.03125rem] text-text not-italic transition-colors hover:bg-bg focus-visible:bg-bg focus-visible:outline-none disabled:cursor-wait disabled:text-grey-03"
+          >
+            <span className="min-w-0 truncate">Available to debate</span>
+            <span
+              aria-hidden="true"
+              className={cx(
+                'relative h-4 w-6 shrink-0 rounded-full transition-colors',
+                availableToDebate ? 'bg-text' : 'bg-grey-03'
+              )}
+            >
+              <span
+                className={cx(
+                  'absolute top-0.5 left-0.5 h-3 w-3 rounded-full bg-white transition-transform',
+                  availableToDebate && 'translate-x-2'
+                )}
+              />
+            </span>
+          </button>
+          <button
+            type="button"
+            onClick={logout}
+            className="flex w-full items-center px-3 py-2.5 text-left font-[family-name:var(--font-calibre)] text-[1rem] leading-[0.9375rem] font-medium tracking-[-0.03125rem] text-text not-italic transition-colors hover:bg-bg focus-visible:bg-bg focus-visible:outline-none"
+          >
+            Sign out
+          </button>
+        </div>
       </Menu>
     </div>
   );
@@ -267,47 +245,6 @@ function normalizeEmail(value: unknown) {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
-}
-
-const avatarMenuItemStyles = cva(
-  'flex w-full items-center justify-between bg-white px-3 py-2 text-button select-none hover:outline-hidden aria-disabled:cursor-not-allowed aria-disabled:text-grey-03',
-  {
-    variants: {
-      disabled: {
-        true: 'cursor-not-allowed text-grey-03',
-        false: 'cursor-pointer text-grey-04 hover:bg-bg hover:text-text',
-      },
-    },
-    defaultVariants: {
-      disabled: false,
-    },
-  }
-);
-
-function AvatarMenuItem({
-  children,
-  onClick,
-  href,
-  disabled = false,
-}: {
-  children: React.ReactNode;
-  onClick?: () => void;
-  href?: string;
-  disabled?: boolean;
-}) {
-  if (href) {
-    return (
-      <Link href={href} className={avatarMenuItemStyles({ disabled })}>
-        {children}
-      </Link>
-    );
-  }
-
-  return (
-    <button onClick={onClick} disabled={disabled} className={avatarMenuItemStyles({ disabled })}>
-      {children}
-    </button>
-  );
 }
 
 const shake = [7, -8.4, 6.3, -10, 8.4, -4.4, 0];


### PR DESCRIPTION
Removes the **Claims and debates** feature flag (`questionsTab`) and the gate behind it, per [GEO-2504](https://linear.app/geobrowser/issue/GEO-2504/remove-debates-feature-flag). The three debug flags stay.

## What is now unconditional

Ten surfaces gated on `useDebatesEnabled()` and now render for everyone: the claims tab, the debates browse feed, the debate room, the debate entity view, the claim and profile debate buttons, the debates hub button and panel, the explore debate card, and the match coordinator.

The hook is gone rather than hardcoded to `true`, so there is no dead switch left to flip back.

## Two surfaces existed only to hold the gate

The claims and debates route clients each wrapped their real surface in a redirect effect plus a `return null`, so both collapse into the surface itself. The claims page also threaded `debatesEnabled` down through four components; that prop is gone.

The navbar's avatar menu kept a **pre-debates layout** on the other side of the flag — a narrower menu with a plain Personal space / Sign out list. That branch goes with the flag, along with the `AvatarMenuItem` helper only it used, which is most of the line count here.

## Stored flags

`questionsTab` and `debatesTab` (the id it was renamed from) are still sitting in the stored flag object in every browser that has opened the flags dialog. `normalizeFeatureFlags` rebuilds from known ids, so they drop out on the next write rather than coming back as a checkbox for a flag nothing reads. A test pins that, since it is the one behavior a reader would not guess from the type.

## Testing

- Three tests asserting flag-off behavior are deleted (hidden hub button, explore fallback, legacy navbar menu); the rest lose their mocks.
- `feature-flags.test.ts` swaps the legacy-id mapping test for the retired-id-dropping one above.
- 66 test files / 822 tests pass across the touched areas; typecheck, lint, and build clean.

## Not included

The **Debate claims** tab visible in the space nav is space-configured data, not code-gated, so nothing here changes which spaces show it.