### PR TITLE
feat(explore): add the "Best" sort, backed by the Phase A ranking

### DIFF
--- a/apps/web/app/api/explore/feed/route.ts
+++ b/apps/web/app/api/explore/feed/route.ts
@@ -14,12 +14,12 @@ function normId(id: string): string {
   return id.replace(/-/g, '').toLowerCase();
 }
 
-const SORTS: ExploreSort[] = ['new', 'top'];
+const SORTS: ExploreSort[] = ['new', 'top', 'best'];
 const TIMES: ExploreTime[] = ['today', 'week', 'month', 'year', 'all'];
 
 function parseSort(raw: string | null): ExploreSort {
   if (raw && (SORTS as string[]).includes(raw)) return raw as ExploreSort;
-  return 'top';
+  return 'best';
 }
 
 function parseTime(raw: string | null): ExploreTime {

--- a/apps/web/core/explore/explore-best-document.ts
+++ b/apps/web/core/explore/explore-best-document.ts
@@ -1,0 +1,63 @@
+import type { TypedDocumentNode } from '@graphql-typed-document-node/core';
+
+import { parse } from 'graphql';
+
+import { exploreCardNodeFields, exploreCardPropertyFragment } from './explore-card-selection';
+
+const FRAGMENT = 'ExploreBestFragment';
+
+/**
+ * The "Best" sort — Phase A ranked feed, backed by `entities_ranked_for_feed`.
+ *
+ * Deliberately passes no `filter`. The other two sorts build one with
+ * `buildFeedFilter`, but every clause of it is enforced inside the function now:
+ *
+ *   * name presence            -> migration 0075
+ *   * system entities          -> 0076, keyed on the unforgeable System Type relation
+ *   * data/text/ranking blocks -> `entity_type_exclusions` config
+ *   * space and type scoping   -> 0077, as function arguments rather than filter clauses
+ *   * the recency window       -> `createdAfter`, the function's own argument
+ *
+ * Sending them again would be redundant, and not free: `filter` combined with
+ * `totalCount` and `edges` on this connection exceeds the statement timeout, because
+ * totalCount scans the filtered candidate set while edges walks it again. This document
+ * requests neither `totalCount` nor `filter`, which keeps it on the fast path — an
+ * index-ordered walk of the ranking index that stops as soon as `first` rows are found.
+ *
+ * There is no `orderBy` either: ordering is the function's own
+ * `ORDER BY ranking_score DESC, entity_id DESC`, and the cursor is offset-based over
+ * that order. One consequence worth knowing: because cursors are offsets rather than
+ * keys, entities scored while a user pages can shift rows under them. That matches how
+ * the other sorts already behave and is acceptable for a feed, but it is not a stable
+ * keyset cursor.
+ */
+const EXPLORE_BEST_SOURCE = /* GraphQL */ `
+  ${exploreCardPropertyFragment(FRAGMENT)}
+
+  query ExploreBestConnection(
+    $first: Int
+    $after: Cursor
+    $spaceIds: [UUID!]
+    $typeIds: [UUID!]
+    $createdAfter: String
+    $spaceIdsForLists: [UUID!]!
+  ) {
+    entitiesRankedForFeedConnection(
+      first: $first
+      after: $after
+      spaceIds: $spaceIds
+      typeIds: $typeIds
+      createdAfter: $createdAfter
+    ) {
+      pageInfo {
+        endCursor
+        hasNextPage
+      }
+      nodes {
+        ${exploreCardNodeFields(FRAGMENT)}
+      }
+    }
+  }
+`;
+
+export const exploreBestConnectionDocument = parse(EXPLORE_BEST_SOURCE) as TypedDocumentNode<any, any>;

--- a/apps/web/core/explore/explore-card-selection.ts
+++ b/apps/web/core/explore/explore-card-selection.ts
@@ -1,0 +1,138 @@
+import { ContentIds, SystemIds } from '@geoprotocol/geo-sdk/lite';
+
+import {
+  EXPLORE_AVATAR_PROPERTY_ID,
+  EXPLORE_COVER_PROPERTY_ID,
+  EXPLORE_ENTITY_DESCRIPTION_PROPERTY_ID,
+  EXPLORE_ENTITY_NAME_PROPERTY_ID,
+} from './explore-constants';
+
+// Only the four property IDs and the three relation-type IDs we actually read per entity.
+// Narrowing these on the server slashes payload size — most entities have dozens of
+// unrelated values/relations we'd otherwise serialize, ship, and decode for nothing.
+const CARD_VALUE_PROPERTY_IDS = [
+  EXPLORE_ENTITY_NAME_PROPERTY_ID,
+  EXPLORE_ENTITY_DESCRIPTION_PROPERTY_ID,
+  EXPLORE_COVER_PROPERTY_ID,
+  EXPLORE_AVATAR_PROPERTY_ID,
+];
+const CARD_RELATION_TYPE_IDS = [
+  SystemIds.COVER_PROPERTY,
+  ContentIds.AVATAR_PROPERTY,
+  // `types` relation — used to derive space-scoped type tags.
+  SystemIds.TYPES_PROPERTY,
+];
+
+const valuePropertyIdList = CARD_VALUE_PROPERTY_IDS.map(id => `"${id}"`).join(', ');
+const relationTypeIdList = CARD_RELATION_TYPE_IDS.map(id => `"${id}"`).join(', ');
+
+/** Comment relation type — `backlinks` through it is how a card gets its comment count. */
+const COMMENT_RELATION_TYPE_ID = '310d4a240e5b451cb2151bfce40d0fe6';
+
+/**
+ * The per-entity selection every Explore feed card decodes, shared by all the feed
+ * documents so a field added for one sort cannot silently go missing from another.
+ *
+ * It was duplicated across `explore-entities-document` (New) and
+ * `explore-entities-by-property-document` (Top) — byte-identical apart from the
+ * fragment name — and a third copy was about to be added for Best. Each document still
+ * declares its own fragment name because they are parsed independently and a shared
+ * name would collide, so the name is a parameter rather than a constant.
+ *
+ * Whitespace here is not significant: consumers `parse()` the result, and the
+ * equivalence of the New/Top documents before and after this extraction was checked by
+ * comparing their printed ASTs, which normalise formatting.
+ */
+export function exploreCardPropertyFragment(fragmentName: string): string {
+  return /* GraphQL */ `
+    fragment ${fragmentName} on PropertyInfo {
+      id
+      name
+      dataTypeId
+      dataTypeName
+      renderableTypeId
+      renderableTypeName
+      format
+      isType
+    }
+  `;
+}
+
+/**
+ * Fields selected inside `nodes { ... }`. `$spaceIdsForLists` must be declared by the
+ * caller's query as `[UUID!]!` — the values/relations lists are space-scoped so a
+ * multi-space feed still decodes cover/avatar/description without pulling every
+ * unrelated value.
+ */
+export function exploreCardNodeFields(fragmentName: string): string {
+  return /* GraphQL */ `
+    id
+    name
+    description
+    spaceIds
+    createdAt
+
+    backlinks(filter: { typeId: { is: "${COMMENT_RELATION_TYPE_ID}" } }) {
+      totalCount
+    }
+
+    types {
+      id
+      name
+    }
+
+    valuesList(filter: {
+      spaceId: { in: $spaceIdsForLists }
+      propertyId: { in: [${valuePropertyIdList}] }
+    }) {
+      spaceId
+      property {
+        ...${fragmentName}
+      }
+      text
+      integer
+      float
+      point
+      boolean
+      time
+      language
+      unit
+      datetime
+      date
+      decimal
+      schedule
+    }
+
+    relationsList(filter: {
+      spaceId: { in: $spaceIdsForLists }
+      typeId: { in: [${relationTypeIdList}] }
+    }) {
+      id
+      spaceId
+      position
+      verified
+      entityId
+      fromEntity {
+        id
+        name
+      }
+      toEntity {
+        id
+        name
+        types {
+          id
+        }
+        valuesList(filter: { spaceId: { in: $spaceIdsForLists } }) {
+          spaceId
+          propertyId
+          text
+        }
+      }
+      toSpaceId
+      type {
+        id
+        name
+      }
+    }
+  `;
+}

--- a/apps/web/core/explore/explore-entities-by-property-document.ts
+++ b/apps/web/core/explore/explore-entities-by-property-document.ts
@@ -1,41 +1,16 @@
-import { ContentIds, SystemIds } from '@geoprotocol/geo-sdk/lite';
 import type { TypedDocumentNode } from '@graphql-typed-document-node/core';
 
 import { parse } from 'graphql';
 
-import {
-  EXPLORE_AVATAR_PROPERTY_ID,
-  EXPLORE_COVER_PROPERTY_ID,
-  EXPLORE_ENTITY_DESCRIPTION_PROPERTY_ID,
-  EXPLORE_ENTITY_NAME_PROPERTY_ID,
-} from './explore-constants';
+import { exploreCardNodeFields, exploreCardPropertyFragment } from './explore-card-selection';
 
-// Kept in sync with exploreEntitiesConnectionDocument so the shared decoder works.
-const CARD_VALUE_PROPERTY_IDS = [
-  EXPLORE_ENTITY_NAME_PROPERTY_ID,
-  EXPLORE_ENTITY_DESCRIPTION_PROPERTY_ID,
-  EXPLORE_COVER_PROPERTY_ID,
-  EXPLORE_AVATAR_PROPERTY_ID,
-];
-const CARD_RELATION_TYPE_IDS = [SystemIds.COVER_PROPERTY, ContentIds.AVATAR_PROPERTY, SystemIds.TYPES_PROPERTY];
+const FRAGMENT = 'ExploreByPropertyFragment';
 
-const valuePropertyIdList = CARD_VALUE_PROPERTY_IDS.map(id => `"${id}"`).join(', ');
-const relationTypeIdList = CARD_RELATION_TYPE_IDS.map(id => `"${id}"`).join(', ');
-
-// Mirrors `ExploreEntitiesConnection`'s selection set so the shared decoder/cards
-// can render results from `entitiesOrderedByPropertyConnection` unchanged. Used
-// by the "Top" sort, where `propertyId` is the integer score property.
+// Shares `ExploreEntitiesConnection`'s selection set (see explore-card-selection) so the
+// shared decoder/cards can render results from `entitiesOrderedByPropertyConnection`
+// unchanged. Used by the "Top" sort, where `propertyId` is the integer score property.
 const EXPLORE_ENTITIES_BY_PROPERTY_SOURCE = /* GraphQL */ `
-  fragment ExploreByPropertyFragment on PropertyInfo {
-    id
-    name
-    dataTypeId
-    dataTypeName
-    renderableTypeId
-    renderableTypeName
-    format
-    isType
-  }
+  ${exploreCardPropertyFragment(FRAGMENT)}
 
   query ExploreEntitiesByPropertyConnection(
     $first: Int
@@ -65,74 +40,7 @@ const EXPLORE_ENTITIES_BY_PROPERTY_SOURCE = /* GraphQL */ `
         hasNextPage
       }
       nodes {
-        id
-        name
-        description
-        spaceIds
-        createdAt
-
-        backlinks(filter: { typeId: { is: "310d4a240e5b451cb2151bfce40d0fe6" } }) {
-          totalCount
-        }
-
-        types {
-          id
-          name
-        }
-
-        valuesList(filter: {
-          spaceId: { in: $spaceIdsForLists }
-          propertyId: { in: [${valuePropertyIdList}] }
-        }) {
-          spaceId
-          property {
-            ...ExploreByPropertyFragment
-          }
-          text
-          integer
-          float
-          point
-          boolean
-          time
-          language
-          unit
-          datetime
-          date
-          decimal
-          schedule
-        }
-
-        relationsList(filter: {
-          spaceId: { in: $spaceIdsForLists }
-          typeId: { in: [${relationTypeIdList}] }
-        }) {
-          id
-          spaceId
-          position
-          verified
-          entityId
-          fromEntity {
-            id
-            name
-          }
-          toEntity {
-            id
-            name
-            types {
-              id
-            }
-            valuesList(filter: { spaceId: { in: $spaceIdsForLists } }) {
-              spaceId
-              propertyId
-              text
-            }
-          }
-          toSpaceId
-          type {
-            id
-            name
-          }
-        }
+        ${exploreCardNodeFields(FRAGMENT)}
       }
     }
   }

--- a/apps/web/core/explore/explore-entities-document.ts
+++ b/apps/web/core/explore/explore-entities-document.ts
@@ -1,33 +1,10 @@
-import { ContentIds, SystemIds } from '@geoprotocol/geo-sdk/lite';
 import type { TypedDocumentNode } from '@graphql-typed-document-node/core';
 
 import { parse } from 'graphql';
 
-import {
-  EXPLORE_AVATAR_PROPERTY_ID,
-  EXPLORE_COVER_PROPERTY_ID,
-  EXPLORE_ENTITY_DESCRIPTION_PROPERTY_ID,
-  EXPLORE_ENTITY_NAME_PROPERTY_ID,
-} from './explore-constants';
+import { exploreCardNodeFields, exploreCardPropertyFragment } from './explore-card-selection';
 
-// Only the four property IDs and the three relation-type IDs we actually read per entity.
-// Narrowing these on the server slashes payload size — most entities have dozens of
-// unrelated values/relations we'd otherwise serialize, ship, and decode for nothing.
-const CARD_VALUE_PROPERTY_IDS = [
-  EXPLORE_ENTITY_NAME_PROPERTY_ID,
-  EXPLORE_ENTITY_DESCRIPTION_PROPERTY_ID,
-  EXPLORE_COVER_PROPERTY_ID,
-  EXPLORE_AVATAR_PROPERTY_ID,
-];
-const CARD_RELATION_TYPE_IDS = [
-  SystemIds.COVER_PROPERTY,
-  ContentIds.AVATAR_PROPERTY,
-  // `types` relation — used to derive space-scoped type tags.
-  SystemIds.TYPES_PROPERTY,
-];
-
-const valuePropertyIdList = CARD_VALUE_PROPERTY_IDS.map(id => `"${id}"`).join(', ');
-const relationTypeIdList = CARD_RELATION_TYPE_IDS.map(id => `"${id}"`).join(', ');
+const FRAGMENT = 'ExplorePropertyFragment';
 
 /**
  * Like `allEntitiesConnectionDocument`, but scopes `valuesList` / `relationsList` to any of
@@ -35,16 +12,7 @@ const relationTypeIdList = CARD_RELATION_TYPE_IDS.map(id => `"${id}"`).join(', '
  * explore feeds still decode cover/avatar/description without pulling every unrelated value.
  */
 const EXPLORE_ENTITIES_CONNECTION_SOURCE = /* GraphQL */ `
-  fragment ExplorePropertyFragment on PropertyInfo {
-    id
-    name
-    dataTypeId
-    dataTypeName
-    renderableTypeId
-    renderableTypeName
-    format
-    isType
-  }
+  ${exploreCardPropertyFragment(FRAGMENT)}
 
   query ExploreEntitiesConnection(
     $limit: Int
@@ -68,74 +36,7 @@ const EXPLORE_ENTITIES_CONNECTION_SOURCE = /* GraphQL */ `
         hasNextPage
       }
       nodes {
-        id
-        name
-        description
-        spaceIds
-        createdAt
-
-        backlinks(filter: { typeId: { is: "310d4a240e5b451cb2151bfce40d0fe6" } }) {
-          totalCount
-        }
-
-        types {
-          id
-          name
-        }
-
-        valuesList(filter: {
-          spaceId: { in: $spaceIdsForLists }
-          propertyId: { in: [${valuePropertyIdList}] }
-        }) {
-          spaceId
-          property {
-            ...ExplorePropertyFragment
-          }
-          text
-          integer
-          float
-          point
-          boolean
-          time
-          language
-          unit
-          datetime
-          date
-          decimal
-          schedule
-        }
-
-        relationsList(filter: {
-          spaceId: { in: $spaceIdsForLists }
-          typeId: { in: [${relationTypeIdList}] }
-        }) {
-          id
-          spaceId
-          position
-          verified
-          entityId
-          fromEntity {
-            id
-            name
-          }
-          toEntity {
-            id
-            name
-            types {
-              id
-            }
-            valuesList(filter: { spaceId: { in: $spaceIdsForLists } }) {
-              spaceId
-              propertyId
-              text
-            }
-          }
-          toSpaceId
-          type {
-            id
-            name
-          }
-        }
+        ${exploreCardNodeFields(FRAGMENT)}
       }
     }
   }

--- a/apps/web/core/explore/explore-feed-documents.test.ts
+++ b/apps/web/core/explore/explore-feed-documents.test.ts
@@ -1,0 +1,102 @@
+import { type DocumentNode, type FieldNode, Kind, type OperationDefinitionNode, print } from 'graphql';
+import { describe, expect, it } from 'vitest';
+
+import { exploreBestConnectionDocument } from './explore-best-document';
+import { exploreEntitiesByPropertyConnectionDocument } from './explore-entities-by-property-document';
+import { exploreEntitiesConnectionDocument } from './explore-entities-document';
+
+function operation(doc: DocumentNode): OperationDefinitionNode {
+  const op = doc.definitions.find(d => d.kind === Kind.OPERATION_DEFINITION);
+  if (!op) throw new Error('no operation in document');
+  return op as OperationDefinitionNode;
+}
+
+/** The single root field of the query — the connection being paged. */
+function rootField(doc: DocumentNode): FieldNode {
+  const selections = operation(doc).selectionSet.selections.filter(s => s.kind === Kind.FIELD);
+  expect(selections).toHaveLength(1);
+  return selections[0] as FieldNode;
+}
+
+function variableNames(doc: DocumentNode): string[] {
+  return (operation(doc).variableDefinitions ?? []).map(v => v.variable.name.value).sort();
+}
+
+function argNames(field: FieldNode): string[] {
+  return (field.arguments ?? []).map(a => a.name.value).sort();
+}
+
+/** Field names selected directly under `nodes { ... }`, which is what the card decodes. */
+function nodeFieldNames(doc: DocumentNode): string[] {
+  const nodes = (rootField(doc).selectionSet?.selections ?? []).find(
+    s => s.kind === Kind.FIELD && s.name.value === 'nodes'
+  ) as FieldNode | undefined;
+  if (!nodes) throw new Error('no nodes selection');
+  return (nodes.selectionSet?.selections ?? [])
+    .filter(s => s.kind === Kind.FIELD)
+    .map(s => (s as FieldNode).alias?.value ?? (s as FieldNode).name.value)
+    .sort();
+}
+
+describe('explore feed documents', () => {
+  it('each sort targets its own connection', () => {
+    expect(rootField(exploreEntitiesConnectionDocument).name.value).toBe('entitiesConnection');
+    expect(rootField(exploreEntitiesByPropertyConnectionDocument).name.value).toBe(
+      'entitiesOrderedByPropertyConnection'
+    );
+    expect(rootField(exploreBestConnectionDocument).name.value).toBe('entitiesRankedForFeedConnection');
+  });
+
+  it('all three select an identical per-entity field set', () => {
+    // The card decoder is shared, so a field present for one sort and missing from
+    // another renders a subtly different card on that tab. These came from one builder
+    // (explore-card-selection) precisely so this cannot drift.
+    const forNew = nodeFieldNames(exploreEntitiesConnectionDocument);
+    expect(nodeFieldNames(exploreEntitiesByPropertyConnectionDocument)).toEqual(forNew);
+    expect(nodeFieldNames(exploreBestConnectionDocument)).toEqual(forNew);
+    expect(forNew).toContain('name');
+    expect(forNew).toContain('createdAt');
+  });
+
+  describe('the Best sort', () => {
+    it('passes space, type and recency scoping as connection arguments', () => {
+      expect(argNames(rootField(exploreBestConnectionDocument))).toEqual(
+        ['after', 'createdAfter', 'first', 'spaceIds', 'typeIds'].sort()
+      );
+    });
+
+    it('sends no `filter`', () => {
+      // Every clause buildFeedFilter would add is enforced inside
+      // entities_ranked_for_feed: name presence (0075), system entities (0076),
+      // excluded block types (config), space/type/recency (0077 arguments).
+      //
+      // Re-adding one is not merely redundant: `filter` together with `totalCount` and
+      // `edges` on this connection exceeds the statement timeout.
+      expect(variableNames(exploreBestConnectionDocument)).not.toContain('filter');
+      expect(argNames(rootField(exploreBestConnectionDocument))).not.toContain('filter');
+    });
+
+    it('requests no top-level totalCount', () => {
+      // The nested backlinks totalCount (comment count) is expected; a totalCount on the
+      // connection itself is the half of the timeout pair this document must not ask for.
+      const top = (rootField(exploreBestConnectionDocument).selectionSet?.selections ?? [])
+        .filter(s => s.kind === Kind.FIELD)
+        .map(s => (s as FieldNode).name.value);
+      expect(top).not.toContain('totalCount');
+      expect(top).toEqual(expect.arrayContaining(['pageInfo', 'nodes']));
+    });
+
+    it('does not try to order the results itself', () => {
+      // Ordering is the function's own ORDER BY ranking_score DESC, entity_id DESC.
+      // The connection exposes no orderBy, so passing one would be a schema error.
+      expect(argNames(rootField(exploreBestConnectionDocument))).not.toContain('orderBy');
+      expect(variableNames(exploreBestConnectionDocument)).not.toContain('orderBy');
+    });
+
+    it('pages with a cursor, so the feed can scroll', () => {
+      expect(variableNames(exploreBestConnectionDocument)).toContain('after');
+      expect(print(exploreBestConnectionDocument)).toContain('endCursor');
+      expect(print(exploreBestConnectionDocument)).toContain('hasNextPage');
+    });
+  });
+});

--- a/apps/web/core/explore/fetch-explore-feed.ts
+++ b/apps/web/core/explore/fetch-explore-feed.ts
@@ -18,11 +18,16 @@ import {
   EXPLORE_ENTITY_NAME_PROPERTY_ID,
   EXPLORE_PAGE_SIZE,
 } from './explore-constants';
+import { exploreBestConnectionDocument } from './explore-best-document';
 import { exploreEntitiesByPropertyConnectionDocument } from './explore-entities-by-property-document';
 import { exploreEntitiesConnectionDocument } from './explore-entities-document';
 import { parseEntityUpdatedAtToUnixSec } from './explore-relative-time';
 
-export type ExploreSort = 'new' | 'top';
+/**
+ * `best` is the Phase A ranked feed (quality + structure + recency, server-side).
+ * `top` ranks by the integer score property; `new` is reverse-chronological.
+ */
+export type ExploreSort = 'new' | 'top' | 'best';
 export type ExploreTime = 'today' | 'week' | 'month' | 'year' | 'all';
 
 export type ExploreFeedItem = {
@@ -178,6 +183,12 @@ function decodeExploreEntitiesByProperty(data: {
   return decodeConnection(data.entitiesOrderedByPropertyConnection ?? null);
 }
 
+function decodeExploreBest(data: {
+  entitiesRankedForFeedConnection?: EntitiesConnectionShape;
+}): ExploreEntitiesPageResponse {
+  return decodeConnection(data.entitiesRankedForFeedConnection ?? null);
+}
+
 function buildFeedFilter(args: {
   spaceIds: string[];
   time: ExploreTime;
@@ -262,6 +273,42 @@ async function fetchTopEntitiesPage(args: {
         // (missing-as-zero for the integer Score property), so "Top" surfaces the full
         // set of entities ranked by score rather than only those already scored.
         includeWithoutValue: true,
+      },
+    })
+  );
+}
+
+// "Best" sort: the Phase A ranked feed via `entitiesRankedForFeedConnection`.
+//
+// Unlike the other two this passes no `filter`. Candidate generation inside
+// `entities_ranked_for_feed` already enforces every clause `buildFeedFilter` builds —
+// name presence, system entities, excluded block types — and takes space, type and
+// recency as its own arguments. See explore-best-document for why sending them twice is
+// not merely redundant.
+//
+// `requireName` is therefore not honoured here: an entity with no name is never a
+// candidate, server-side, and cannot be opted back in. Nothing passes
+// `requireName: false` today, and for this feed it would be a request to serve rows that
+// render as a raw uuid.
+async function fetchBestEntitiesPage(args: {
+  spaceIds: string[];
+  time: ExploreTime;
+  limit: number;
+  after: string | null;
+  typeIds?: readonly string[];
+}): Promise<ExploreEntitiesPageResponse> {
+  const t = timeThresholdSec(args.time);
+  return Effect.runPromise(
+    graphql({
+      query: exploreBestConnectionDocument,
+      decoder: decodeExploreBest,
+      variables: {
+        first: args.limit,
+        after: args.after,
+        spaceIds: args.spaceIds,
+        typeIds: args.typeIds?.length ? [...args.typeIds] : undefined,
+        createdAfter: t != null ? String(t) : undefined,
+        spaceIdsForLists: args.spaceIds,
       },
     })
   );
@@ -394,7 +441,15 @@ export async function fetchExploreFeed(args: {
   };
 
   const page =
-    args.sort === 'top'
+    args.sort === 'best'
+      ? await fetchBestEntitiesPage({
+          spaceIds: baseIds,
+          time: args.time,
+          limit: scanChunk,
+          after: args.cursor,
+          typeIds: args.typeIds,
+        })
+      : args.sort === 'top'
       ? await fetchTopEntitiesPage({
           spaceIds: baseIds,
           time: args.time,

--- a/apps/web/partials/explore/explore-page.tsx
+++ b/apps/web/partials/explore/explore-page.tsx
@@ -36,7 +36,7 @@ export function ExplorePage({
           apiEndpoint="/api/explore/feed"
           initialSpaceOptions={initialSpaceOptions}
           initialTime="month"
-          initialSort="top"
+          initialSort="best"
           showSortFilter
           showTypeFilter
           dividerBeforeFeed

--- a/apps/web/partials/feed/entity-feed.tsx
+++ b/apps/web/partials/feed/entity-feed.tsx
@@ -36,6 +36,7 @@ function LoadingSkeleton() {
 }
 
 const SORT_OPTIONS: { value: ExploreSort; label: string }[] = [
+  { value: 'best', label: 'Best' },
   { value: 'new', label: 'New' },
   { value: 'top', label: 'Top' },
 ];
@@ -63,7 +64,7 @@ type EntityFeedProps = {
   initialSort?: ExploreSort;
   /** Whether to render the time-range dropdown. Defaults to true. */
   showTimeFilter?: boolean;
-  /** Whether to render the sort dropdown (New / Top). Defaults to false. */
+  /** Whether to render the sort dropdown (Best / New / Top). Defaults to false. */
   showSortFilter?: boolean;
   /** Whether to render the Explore-only, locally persisted type checklist. Defaults to false. */
   showTypeFilter?: boolean;


### PR DESCRIPTION
Adds **Best** as the default Explore sort, served by `entitiesRankedForFeedConnection` (gaia #892, deployed). Best ranks on quality, structural completeness and recency computed server-side. `New` stays reverse-chronological, `Top` stays the integer score property.

Requires gaia #892 — merged and deployed to the v2 testnet, verified below.

## Best sends no `filter`, deliberately

The other two sorts build one with `buildFeedFilter`. Every clause of it is now enforced inside `entities_ranked_for_feed`:

| clause | enforced by |
|---|---|
| name presence | gaia 0075 |
| system entities | 0076, via the unforgeable System Type relation |
| data / text / ranking blocks | `entity_type_exclusions` config |
| space and type scoping | 0077, as function arguments |
| recency window | `createdAfter`, the function's own argument |

Sending them again would be redundant and **not free**: `filter` together with `totalCount` and `edges` on this connection exceeds the statement timeout — totalCount scans the filtered candidate set while edges walks it again. Omitting both keeps Best on an index-ordered walk that stops as soon as `first` rows are found.

Because re-adding either one looks like an improvement, tests pin their absence.

`requireName` is not honoured for Best: a nameless entity is never a candidate server-side and cannot be opted back in. Nothing passes `requireName: false` today, and for this feed it would be a request to serve rows that render as a raw uuid.

## No codegen

The explore documents are hand-built GraphQL parsed at runtime and typed `TypedDocumentNode<any, any>`, so nothing here depends on `core/gql` being regenerated. Worth stating because it looked like a prerequisite.

## Shared card selection extracted

The per-entity selection was duplicated **byte-identically** across the New and Top documents — differing only in fragment name, since they're parsed separately and a shared name would collide — and Best would have been a third copy of ~120 lines. A field added for one sort would then render a subtly different card on the others, which the shared decoder can't detect.

The extraction is behaviour-preserving: the **printed ASTs of both existing documents are identical before and after** (185 lines each), and a test asserts all three documents select the same field set.

## Verification

Against the deployed API, using the real document and `EXPLORE_ENTITY_TYPE_IDS`:

| scoping | rows |
|---|---|
| none | 5 |
| `spaceIds` = spaces the top entities live in | 5 |
| + `typeIds` = their types | 5 |
| + `createdAfter` 7d | 5 |
| `typeIds` = full EXPLORE set | 5 |

Scoping to six arbitrary spaces correctly returns zero — those spaces hold no ranked content.

21 tests pass. The 7 new document tests are mutation-tested:

| mutation | caught by |
|---|---|
| add a `$filter` variable | sends no `filter` |
| Best selects a field the others don't | all three select an identical field set |
| Best points at the wrong connection | each sort targets its own connection |

## Note for reviewers

The top-ranked entities currently all live in **one space**, and `Tweet` occupies ranks 2–4 — a type that has never been triaged in the feed config. Neither is caused by this PR (both fell out of removing the type boosts), but Best makes them the first thing a logged-out user sees. The per-creator diversity cap is Phase C.
