### PR TITLE
fix: EIP-7702 yParity padding + AA25 nonce retry for new account/membership flows

### DIFF
--- a/apps/web/core/hooks/smart-account-send-queue.test.ts
+++ b/apps/web/core/hooks/smart-account-send-queue.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { QueuedSendTimeoutError, enqueueFor } from './smart-account-send-queue';
+import { QueuedSendTimeoutError, enqueueFor, withNonceRetry } from './smart-account-send-queue';
 
 const deferred = <T,>() => {
   let resolve!: (value: T) => void;
@@ -114,5 +114,54 @@ describe('smart-account send queue', () => {
 
     await expect(holding).resolves.toBe('done');
     await expect(queued).resolves.toBe('ran');
+  });
+
+  describe('withNonceRetry', () => {
+    // Mirrors the real shape: viem throws UserOperationExecutionError with an
+    // InvalidAccountNonceError cause, exposed via BaseError's .walk(predicate).
+    const nonceError = () => {
+      const err = new Error('Invalid Smart Account nonce used for User Operation.');
+      (err as unknown as { walk: (fn: (e: unknown) => boolean) => unknown }).walk = fn => {
+        const cause = new Error('Invalid Smart Account nonce used for User Operation.');
+        cause.name = 'InvalidAccountNonceError';
+        return fn(cause) ? cause : undefined;
+      };
+      return err;
+    };
+
+    it('retries a nonce-rejected send and succeeds once the nonce is fresh', async () => {
+      let attempts = 0;
+      const task = vi.fn(async () => {
+        attempts++;
+        if (attempts < 2) throw nonceError();
+        return 'ok';
+      });
+
+      const result = withNonceRetry(task);
+      await vi.advanceTimersByTimeAsync(500);
+      await expect(result).resolves.toBe('ok');
+      expect(task).toHaveBeenCalledTimes(2);
+    });
+
+    it('gives up after the retry budget and surfaces the nonce error', async () => {
+      const task = vi.fn(async () => {
+        throw nonceError();
+      });
+
+      const result = withNonceRetry(task);
+      const assertion = expect(result).rejects.toThrow('Invalid Smart Account nonce');
+      await vi.advanceTimersByTimeAsync(2_000);
+      await assertion;
+      expect(task).toHaveBeenCalledTimes(3);
+    });
+
+    it('does not retry errors unrelated to the nonce', async () => {
+      const task = vi.fn(async () => {
+        throw new Error('boom');
+      });
+
+      await expect(withNonceRetry(task)).rejects.toThrow('boom');
+      expect(task).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/apps/web/core/hooks/smart-account-send-queue.ts
+++ b/apps/web/core/hooks/smart-account-send-queue.ts
@@ -38,6 +38,43 @@ export class QueuedSendTimeoutError extends Error {
  */
 export const MAX_QUEUE_WAIT_MS = 120_000;
 
+const NONCE_RETRY_ATTEMPTS = 3;
+const NONCE_RETRY_DELAY_MS = 500;
+
+const isInvalidAccountNonceError = (error: unknown): boolean => {
+  if (!(error instanceof Error)) return false;
+  const walk = (error as { walk?: (fn: (e: unknown) => boolean) => unknown }).walk;
+  if (typeof walk === 'function') {
+    return Boolean(walk.call(error, e => (e as Error)?.name === 'InvalidAccountNonceError'));
+  }
+  return error.name === 'InvalidAccountNonceError';
+};
+
+/**
+ * AA25 ("Invalid Smart Account nonce used for User Operation") is a bundler
+ * validation-phase rejection thrown from eth_sendUserOperation before any hash is
+ * returned — by the ERC-4337 spec, nothing was accepted into the mempool. Retrying is
+ * safe for the same reason QueuedSendTimeoutError is safe to retry: never submitted.
+ * A short retry absorbs the case where the account's on-chain nonce read (via a
+ * separate RPC client from the bundler) lags just behind a just-confirmed prior send
+ * on the same key — the next read picks up the advanced nonce.
+ */
+export const withNonceRetry = async <T>(task: () => Promise<T>): Promise<T> => {
+  let lastError: unknown;
+  for (let attempt = 0; attempt < NONCE_RETRY_ATTEMPTS; attempt++) {
+    try {
+      return await task();
+    } catch (error) {
+      lastError = error;
+      if (!isInvalidAccountNonceError(error)) throw error;
+      if (attempt < NONCE_RETRY_ATTEMPTS - 1) {
+        await new Promise(resolve => setTimeout(resolve, NONCE_RETRY_DELAY_MS));
+      }
+    }
+  }
+  throw lastError;
+};
+
 export const enqueueFor = <T>(
   address: string,
   task: () => Promise<T>,

--- a/apps/web/core/hooks/use-smart-account.ts
+++ b/apps/web/core/hooks/use-smart-account.ts
@@ -9,7 +9,7 @@ import { useCookies } from 'react-cookie';
 
 import { Cookie, WALLET_ADDRESS } from '../cookie';
 import { GEO_NETWORK } from '../sdk/geo-network';
-import { MAX_QUEUE_WAIT_MS, enqueueFor } from './smart-account-send-queue';
+import { MAX_QUEUE_WAIT_MS, enqueueFor, withNonceRetry } from './smart-account-send-queue';
 
 export function useSmartAccount() {
   const { data: walletClient, isLoading: isLoadingWallet } = useWalletClient();
@@ -57,7 +57,7 @@ export function useSmartAccount() {
         signer: signer as Parameters<typeof generateZeroDevAccount>[0]['signer'],
       });
 
-      // Two failure modes to defend against here (the shared per-EOA queue in
+      // Three failure modes to defend against here (the shared per-EOA queue in
       // ./smart-account-send-queue is the mechanism):
       //
       // 1. AA25 nonce races: the kernel client computes the nonce at submit time,
@@ -68,6 +68,15 @@ export function useSmartAccount() {
       //    sendUserOperation alike — through the per-EOA queue, and hold
       //    each sendUserOperation slot until its receipt confirms inclusion.
       //    (kernel sendTransaction already waits for its receipt internally.)
+      //
+      // 1b. AA25 even with serialization: the account's nonce is read fresh via a
+      //    plain RPC `client` (Conduit) that is a separate backend from the
+      //    bundler (ZeroDev) confirming inclusion. If that RPC lags the bundler's
+      //    view by even one block, the very next send after a confirmed one can
+      //    read a stale nonce and get rejected as InvalidAccountNonceError. This
+      //    rejection happens at eth_sendUserOperation, before any hash exists, so
+      //    by the ERC-4337 spec nothing was submitted — a short retry (see
+      //    withNonceRetry) is safe and re-reads the nonce fresh.
       //
       // 2. Duplicate submissions on retry: callers wrap sends in Effect.retry
       //    (~10s windows). Once the bundler has accepted a UserOp, a failure
@@ -141,7 +150,7 @@ export function useSmartAccount() {
         // useSmartAccountTransaction's timeout, and the bound is what guarantees a
         // timed-out call never submits later (see QueuedSendTimeoutError).
         sendTransaction: (...args: Parameters<typeof zeroDevAccount.sendTransaction>) =>
-          enqueueFor(eoaAddress, () => zeroDevAccount.sendTransaction(...args), {
+          enqueueFor(eoaAddress, () => withNonceRetry(() => zeroDevAccount.sendTransaction(...args)), {
             maxQueueWaitMs: MAX_QUEUE_WAIT_MS,
           }),
         // Deliberately NOT queue-wait bounded: publish/comment/deploy callers have no
@@ -150,11 +159,13 @@ export function useSmartAccount() {
         sendUserOperation: (args: {
           calls: ReadonlyArray<{ to: `0x${string}`; data: `0x${string}`; value?: bigint }>;
         }) =>
-          enqueueFor(eoaAddress, async () => {
-            const hash = await zeroDevAccount.sendUserOperation(args);
-            await confirmInclusion(hash);
-            return hash;
-          }),
+          enqueueFor(eoaAddress, () =>
+            withNonceRetry(async () => {
+              const hash = await zeroDevAccount.sendUserOperation(args);
+              await confirmInclusion(hash);
+              return hash;
+            })
+          ),
       };
 
       if (!cookies.walletAddress || cookies.walletAddress !== wrapped.account.address) {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -112,7 +112,7 @@
     "react-textarea-autosize": "^8.5.9",
     "react-use-measure": "^2.1.7",
     "sharp": "^0.35.2",
-    "viem": "^2.54.2",
+    "viem": "^2.55.16",
     "wagmi": "^3.6.21"
   },
   "devDependencies": {

--- a/bun.lock
+++ b/bun.lock
@@ -118,7 +118,7 @@
         "react-textarea-autosize": "^8.5.9",
         "react-use-measure": "^2.1.7",
         "sharp": "^0.35.2",
-        "viem": "^2.54.2",
+        "viem": "^2.55.16",
         "wagmi": "^3.6.21",
       },
       "devDependencies": {
@@ -182,7 +182,7 @@
     "@tanstack/react-query": "^5.101.1",
     "permissionless": "^0.3.4",
     "prosemirror-model": "^1.25.9",
-    "viem": "2.54.6",
+    "viem": "2.55.16",
   },
   "packages": {
     "@aarkue/tiptap-math-extension": ["@aarkue/tiptap-math-extension@1.4.0", "", { "dependencies": { "evaluatex": "^2.2.0", "katex": "^0.16.7" }, "peerDependencies": { "@tiptap/core": "^3.0.0", "@tiptap/pm": "^3.0.0" } }, "sha512-vCu/6WgO2yJ2cFnvsOL6kQCcWRWDm7OJ5I64KLyXIGGzIA2HuVhSyfuWeoNg51YVkEqlxZNTUgy0MXw6OTvrQg=="],
@@ -3031,7 +3031,7 @@
 
     "valtio": ["valtio@2.1.7", "", { "dependencies": { "proxy-compare": "^3.0.1" }, "peerDependencies": { "@types/react": ">=18.0.0", "react": ">=18.0.0" }, "optionalPeers": ["@types/react", "react"] }, "sha512-DwJhCDpujuQuKdJ2H84VbTjEJJteaSmqsuUltsfbfdbotVfNeTE4K/qc/Wi57I9x8/2ed4JNdjEna7O6PfavRg=="],
 
-    "viem": ["viem@2.54.6", "", { "dependencies": { "@noble/curves": "1.9.1", "@noble/hashes": "1.8.0", "@scure/bip32": "1.7.0", "@scure/bip39": "1.6.0", "abitype": "1.2.3", "isows": "1.0.7", "ox": "0.14.30", "ws": "8.21.0" }, "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-OfybECKJYVmhiNqz+SHhed+O2h6niQ+0Wjg9J0b4bV+/QrvLgjxhfKO7hZqsuK1YtZ/0BErBKy708Zp+cU5T0Q=="],
+    "viem": ["viem@2.55.16", "", { "dependencies": { "@noble/curves": "1.9.1", "@noble/hashes": "1.8.0", "@scure/bip32": "1.7.0", "@scure/bip39": "1.6.0", "abitype": "1.2.3", "isows": "1.0.7", "ox": "0.14.33", "ws": "8.21.0" }, "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-bKs/0PNIkiaG45ZM0ERddHSVtku7hvyebK2i3bMLuyJQevh15tpDh3MiE3PhLjx5kxGrvizaXQw67gWc9Jl7fQ=="],
 
     "vite": ["vite@8.1.0", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.15", "rolldown": "~1.1.2", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.3.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-BuJcQK/56NQTWDGn4ABea3q4SSBdNPWwNZKTkkUpcMPnLoquSYH8llRtSUIgoL1KSCpHt5eghLShn50mH36y7Q=="],
 
@@ -3499,6 +3499,8 @@
 
     "tsconfig-paths/json5": ["json5@1.0.2", "", { "dependencies": { "minimist": "^1.2.0" }, "bin": { "json5": "lib/cli.js" } }, "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA=="],
 
+    "viem/ox": ["ox@0.14.33", "", { "dependencies": { "@adraffy/ens-normalize": "^1.11.0", "@noble/ciphers": "^1.3.0", "@noble/curves": "1.9.1", "@noble/hashes": "^1.8.0", "@scure/bip32": "^1.7.0", "@scure/bip39": "^1.6.0", "abitype": "^1.2.3", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-rooA/4o7bBof4Ge2VH/eovfNPb/AEEYyrNj03wggc55g5HZD8Pjs/OeWhttgjic3dDcqn0r29bDuvQEdTiUemQ=="],
+
     "vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "vite/postcss": ["postcss@8.5.16", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg=="],
@@ -3738,6 +3740,8 @@
     "qrcode/yargs/yargs-parser": ["yargs-parser@18.1.3", "", { "dependencies": { "camelcase": "^5.0.0", "decamelize": "^1.2.0" } }, "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ=="],
 
     "schema-utils/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "viem/ox/eventemitter3": ["eventemitter3@5.0.1", "", {}, "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="],
 
     "webpack/eslint-scope/estraverse": ["estraverse@4.3.0", "", {}, "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="],
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "permissionless": "^0.3.4",
     "@tanstack/react-query": "^5.101.1",
     "prosemirror-model": "^1.25.9",
-    "viem": "2.54.6",
+    "viem": "2.55.16",
     "@radix-ui/react-dialog": "1.1.19"
   },
   "private": true,


### PR DESCRIPTION
## Summary
Fixes two production bugs in the smart-account (ZeroDev EIP-7702 Kernel) stack:

- **GEO-2550** — New account creation fails: `Failed to register personal space`
- **GEO-2549** — Membership request fails: `Invalid Smart Account nonce used for User Operation`

### GEO-2550: viem `yParity` padding bug
`viem@2.54.6`'s `formatUserOperationRequest` encoded an EIP-7702 authorization `yParity` of `0` as a 32-byte zero value instead of `0x00`, which ZeroDev's bundler rejects (`Invalid fields set on User Operation`). Fixed upstream in `viem@2.55.10` ([wevm/viem#4900](https://github.com/wevm/viem/pull/4900)). Bumped the root `viem` override and `apps/web`'s declared range to `2.55.16` (latest patch on that line — changelog reviewed, no breaking changes for this stack). Reproduced the fix directly against the installed package: `yParity` now serializes as `0x00`.

Note: this repo also carries a documented, separate ZeroDev-side `selfFunded`-endpoint bug (`MAINNET_CUTOVER_PLAN.md`), mitigated via `ULTRA_RELAY`. Per Patrick, ZeroDev has since fixed that on their end, so that escalation note is stale.

### GEO-2549: AA25 invalid-nonce rejection
`InvalidAccountNonceError` ("Invalid Smart Account nonce used for User Operation") is a bundler validation-phase rejection at `eth_sendUserOperation` — thrown before any hash is returned, so per the ERC-4337 spec nothing was ever accepted into the mempool. A likely trigger: the account's nonce is read fresh via a plain RPC client (Conduit) that is a separate backend from the bundler (ZeroDev) confirming inclusion, so a lagging read can momentarily see a stale nonce right after a prior send confirms.

Added `withNonceRetry` in `smart-account-send-queue.ts`, wrapping `sendTransaction`/`sendUserOperation` with a bounded (3 attempt, 500ms) retry keyed off viem's `InvalidAccountNonceError` (detected via `BaseError.walk`, verified against a real thrown error). Retrying is safe by the same "never submitted" invariant this file already relies on for `QueuedSendTimeoutError`.

## Test plan
- [x] `packages/auth` (`tsc`) builds clean against viem 2.55.16
- [x] `apps/web` (`tsc --noEmit`) type-checks clean
- [x] Reproduced the `yParity` fix directly: constructed the exact `eip7702Auth` payload from the GEO-2550 ticket through the installed viem and confirmed `yParity` now serializes as `0x00`
- [x] Confirmed `formatUserOperationRequest`'s input key is `authorization` (not `eip7702Auth`) at this viem version, and traced that `sendTransaction`/`sendUserOperation` both flow through it
- [x] Verified `InvalidAccountNonceError` detection (`BaseError.walk`) against a real error constructed via viem's own `getUserOperationError`
- [x] Added unit tests for `withNonceRetry` (retries and succeeds, exhausts budget and surfaces the error, ignores unrelated errors) — all passing
- [x] Full `apps/web` vitest suite: same 47 pre-existing failures (unrelated `jsdom`/`localStorage` setup issue) before and after this change, zero new failures
- [ ] Manual end-to-end verification of new account creation + membership request against a live testnet wallet (not done in this session — no live wallet/browser access)
