### PR TITLE
fix(debates): send the entity's own space from data-block row actions (GEO-2581)

### DIFF
--- a/apps/web/partials/blocks/table/table-block-gallery-item-space.test.tsx
+++ b/apps/web/partials/blocks/table/table-block-gallery-item-space.test.tsx
@@ -1,0 +1,92 @@
+import '@testing-library/jest-dom/vitest';
+import { SystemIds } from '@geoprotocol/geo-sdk/lite';
+import { cleanup, render, screen } from '@testing-library/react';
+
+import type React from 'react';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { Cell } from '~/core/types';
+
+import { TableBlockGalleryItem } from './table-block-gallery-item';
+
+/**
+ * GEO-2581. A data block lists rows from many spaces, so a row's entity does not
+ * necessarily live in the block's space. `EntityRowActions` forwards its `spaceId` to
+ * `ClaimDebateButton` -> `useDebateClaims` -> geo-chat, which rejects the claim with
+ * `claim_not_in_space` when that space does not contain it — surfaced to users as
+ * "Connection failed". Passing the block's space sent ROOT_SPACE for claims living
+ * elsewhere; 3,357 failures in a single 5-hour window traced to exactly that.
+ *
+ * Every other space-scoped prop in this component already resolves `nameCell?.space`
+ * first. This asserts the actions row does too, so it cannot quietly regress.
+ */
+vi.mock('~/partials/entity-page/entity-row-actions', () => ({
+  EntityRowActions: ({ entityId, spaceId }: { entityId: string; spaceId: string }) => (
+    <div data-testid="row-actions" data-entity-id={entityId} data-space-id={spaceId} />
+  ),
+}));
+
+vi.mock('~/core/sync/use-mutate', () => ({ useMutate: () => ({ storage: {} }) }));
+vi.mock('~/core/sync/use-store', () => ({ useSpaceAwareValue: () => null }));
+vi.mock('~/core/hooks/use-block-main-media-url', () => ({
+  useBlockMainMediaUrl: () => ({ url: null, isResolving: false }),
+}));
+
+vi.mock('~/design-system/prefetch-link', () => ({
+  PrefetchLink: ({ children, href }: { children: React.ReactNode; href: string }) => <a href={href}>{children}</a>,
+}));
+vi.mock('~/design-system/geo-image', () => ({ GeoImage: () => null, DEFAULT_IMAGE_SIZES: '' }));
+vi.mock('~/design-system/select-entity', () => ({ SelectEntity: () => null }));
+vi.mock('~/design-system/editable-fields/editable-fields', () => ({
+  BlockImageField: () => null,
+  PageStringField: () => null,
+}));
+vi.mock('next/image', () => ({ default: () => null }));
+
+vi.mock('~/partials/blocks/table/data-block-open-side-panel-button', () => ({
+  DataBlockOpenSidePanelButton: () => null,
+}));
+vi.mock('~/partials/blocks/table/collection-row-actions', () => ({ CollectionRowActions: () => null }));
+vi.mock('~/partials/blocks/table/collection-metadata', () => ({ CollectionMetadata: () => null }));
+vi.mock('~/partials/blocks/table/edit-mode-name-field', () => ({ EditModeNameField: () => null }));
+vi.mock('./table-block-property-field', () => ({ TableBlockPropertyField: () => null }));
+
+afterEach(cleanup);
+
+const BLOCK_SPACE = 'a19c345ab9866679b001d7d2138d88a1'; // ROOT_SPACE — the wrong answer
+const CLAIM_SPACE = 'b5a31f8182b042437ede0f84ee02f104'; // Podcasts — where the claim lives
+
+// The component destructures `nameCell` unguarded (`const { propertyId, verified } = nameCell`),
+// so a row always carries a name cell — the `?? currentSpaceId` fallback is reachable only when
+// the cell itself has no `space`, which is the case exercised below.
+const renderItem = (nameCell: Partial<Cell>) =>
+  render(
+    <TableBlockGalleryItem
+      columns={{ [SystemIds.NAME_PROPERTY]: { propertyId: SystemIds.NAME_PROPERTY, ...nameCell } } as Record<
+        string,
+        Cell
+      >}
+      currentSpaceId={BLOCK_SPACE}
+      isEditing={false}
+      rowEntityId="entity-1"
+      onChangeEntry={() => {}}
+      onLinkEntry={() => {}}
+      isPlaceholder={false}
+      source={{ type: 'GEO' }}
+    />
+  );
+
+describe('TableBlockGalleryItem row actions space', () => {
+  it("passes the entity's own space, not the block's", () => {
+    renderItem({ space: CLAIM_SPACE, name: 'A claim' } as Partial<Cell>);
+
+    expect(screen.getByTestId('row-actions')).toHaveAttribute('data-space-id', CLAIM_SPACE);
+  });
+
+  it("falls back to the block's space when the row's cell carries none", () => {
+    renderItem({ name: 'A claim' } as Partial<Cell>);
+
+    expect(screen.getByTestId('row-actions')).toHaveAttribute('data-space-id', BLOCK_SPACE);
+  });
+});

--- a/apps/web/partials/blocks/table/table-block-gallery-item.tsx
+++ b/apps/web/partials/blocks/table/table-block-gallery-item.tsx
@@ -356,7 +356,9 @@ export function TableBlockGalleryItem({
           );
         })}
         <div className="mt-1 flex items-center justify-between gap-2">
-          <EntityRowActions entityId={rowEntityId} spaceId={currentSpaceId} />
+          {/* The entity's own space, not the block's (GEO-2581) — every other space-scoped
+              prop in this component already resolves it this way. */}
+          <EntityRowActions entityId={rowEntityId} spaceId={nameCell?.space ?? currentSpaceId} />
           {!isPlaceholder && (
             <div className="invisible flex items-center opacity-0 transition duration-200 group-focus-within:visible group-focus-within:opacity-100 group-hover:visible group-hover:opacity-100 md:hidden [&_button]:h-5 [&_button]:w-5">
               {source.type === 'COLLECTION' ? (

--- a/apps/web/partials/blocks/table/table-block-table.tsx
+++ b/apps/web/partials/blocks/table/table-block-table.tsx
@@ -356,7 +356,15 @@ export const TableBlockTable = ({
                             />
                           </div>
                         )}
-                        <EntityRowActions entityId={row.original.entityId} spaceId={space} />
+                        {/* The entity's own space, not the block's — a data block lists rows
+                            from many spaces, and the Debate button forwards this to geo-chat,
+                            which rejects the claim if it does not belong to the space given
+                            (GEO-2581). Same resolution the side-panel button above and the name
+                            cell already use. */}
+                        <EntityRowActions
+                          entityId={row.original.entityId}
+                          spaceId={row.original.columns[SystemIds.NAME_PROPERTY]?.space ?? space}
+                        />
                       </div>
                     </TableCell>
                   )}


### PR DESCRIPTION
Fixes GEO-2581.

## Why

"Error: Connection failed" when entering a debate is not a connection fault.

geo-chat fetches the claim entity and rejects it unless `entity.space_ids` contains the space it was given, returning `400 claim_not_in_space` — which the handler surfaces as a **503**, and the UI renders any 503 as "Connection failed".

The space it was given was wrong. A data block lists rows drawn from many spaces, but both row-action call sites forwarded the **block's** space. On a root-space block that is `ROOT_SPACE` (`a19c345a…`), so every claim living elsewhere failed. **3,357 of ~4,459 failures** in one 5-hour window carried that single id, against claims verified in the database to live in five different spaces:

| claim | actually lives in | was requested with |
|---|---|---|
| `00010c84…` | `41e85161…` | ROOT_SPACE |
| `00021857…` | `89bd89bf…`, `cb4731c4…` | ROOT_SPACE |
| `0002373d…` | `5908c73a…`, `c9f267dc…` | ROOT_SPACE |

Preston's report is the clean case: his claim exists only in the podcasts space `b5a31f81…`, so nothing could legitimately pass another space. Nothing was — the block's space was passed instead of the claim's.

## The change

Both files already resolve the entity's own space everywhere else — the side-panel button on the adjacent line in `table-block-table.tsx`, and six other props in `table-block-gallery-item.tsx` (href, `EditModeNameField`, panels). The actions row was the lone exception in each.

## Test

`table-block-gallery-item-space.test.tsx` was verified to **fail without the fix** (expects `b5a31f81…`, gets `a19c345a…`), so it pins the actual regression rather than the current behaviour. `tsc --noEmit` is clean for both edited files.

## Deliberately not done

- **Preston asked that debates publish to the claim's TOP-RANKED space.** `getTopRankedSpaceId` needs the full `entity.spaces` list, and a row's `Cell` carries a single `space` (`core/types.ts:316`), so honouring that rule needs spaces plumbed through the row first. This change sends the space the row actually came from, which is what fixes the reported failures.
- **The `4xx -> 503` mapping in geo-chat `db_debates.rs` is untouched**, so a future mismatch will still read as "Connection failed" rather than something diagnosable. The exact line is the `claim_hydration_incomplete` return — fixing it properly needs the failure *reason* threaded through `failed_claim_ids`, which currently discards it.
- **Root is rank 0 in `SPACE_RANK`**, so once the top-ranked rule does land, a claim that also lives in Root would resolve *to* Root. Worth confirming that is intended before building on it.

## Noticed while testing

`table-block-gallery-item.tsx` destructures `nameCell` unguarded (line 74) while typing it `Cell | undefined` and using `nameCell?.image` on the next line. The optional handling is therefore already dead. Left alone as out of scope.