### PR TITLE
fix: restore the space Community tab's sidebar geometry

### DIFF
--- a/apps/web/app/space/[id]/(space)/community/page.tsx
+++ b/apps/web/app/space/[id]/(space)/community/page.tsx
@@ -6,6 +6,7 @@ import { fetchCommunityCalls } from '~/core/community-calls/fetch-community-call
 
 import { SpaceCommunityCallsSection } from '~/partials/community-calls/space-community-calls-section';
 import { CommunityTabPage } from '~/partials/community-tab/community-tab-page';
+import { EntityPageSideRail } from '~/partials/entity-page/entity-page-side-rail';
 import { EntityPageSidebarLayout } from '~/partials/entity-page/entity-page-sidebar-layout';
 
 type Props = {
@@ -25,7 +26,11 @@ export default async function CommunityPage(props: Props) {
   return (
     <EntityPageSidebarLayout
       sidebar={
-        communityCalls.length > 0 ? <SpaceCommunityCallsSection spaceId={spaceId} series={communityCalls} /> : null
+        communityCalls.length > 0 ? (
+          <EntityPageSideRail>
+            <SpaceCommunityCallsSection spaceId={spaceId} series={communityCalls} />
+          </EntityPageSideRail>
+        ) : null
       }
     >
       <CommunityTabPage spaceId={spaceId} />

--- a/apps/web/partials/entity-page/entity-page-content-container.test.tsx
+++ b/apps/web/partials/entity-page/entity-page-content-container.test.tsx
@@ -70,8 +70,13 @@ describe('EntityPageSideRail', () => {
 
     // A rail that isn't `w-[...] shrink-0` sizes to its own content and squeezes the
     // content column — the community-tab regression this guards against.
-    expect(rail.className).toContain('w-[300px]');
-    expect(rail.className).toContain('shrink-0');
+    //
+    // Asserted against the token list rather than the className string: a substring
+    // match on `w-[300px]` also passes for `max-w-[300px]`, which would not constrain
+    // the rail at all. jest-dom's `toHaveClass` would say this more directly, but
+    // vite.config.js registers no setupFiles so setupTests.ts never loads its matchers.
+    expect([...rail.classList]).toContain('w-[300px]');
+    expect([...rail.classList]).toContain('shrink-0');
     expect(rail.textContent).toBe('Panel');
   });
 

--- a/apps/web/partials/entity-page/entity-page-content-container.test.tsx
+++ b/apps/web/partials/entity-page/entity-page-content-container.test.tsx
@@ -3,6 +3,7 @@ import { cleanup, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { EntityPageContentContainer } from './entity-page-content-container';
+import { EntityPageSideRail } from './entity-page-side-rail';
 import { EntityPageSidebarLayout } from './entity-page-sidebar-layout';
 
 afterEach(cleanup);
@@ -48,5 +49,39 @@ describe('EntityPageSidebarLayout', () => {
 
     expect(container?.getAttribute('data-entity-page-content-variant')).toBe('auto-sidebar');
     expect(screen.getByRole('complementary').textContent).toBe('Sidebar');
+  });
+});
+
+describe('EntityPageSideRail', () => {
+  it('renders an aside at the fixed rail width so the content column keeps its size', () => {
+    render(
+      <EntityPageSidebarLayout
+        sidebar={
+          <EntityPageSideRail>
+            <div>Panel</div>
+          </EntityPageSideRail>
+        }
+      >
+        Content
+      </EntityPageSidebarLayout>
+    );
+
+    const rail = screen.getByRole('complementary');
+
+    // A rail that isn't `w-[...] shrink-0` sizes to its own content and squeezes the
+    // content column — the community-tab regression this guards against.
+    expect(rail.className).toContain('w-[300px]');
+    expect(rail.className).toContain('shrink-0');
+    expect(rail.textContent).toBe('Panel');
+  });
+
+  it('widens the page container, because the auto-sidebar variant keys off the aside', () => {
+    render(
+      <EntityPageSidebarLayout sidebar={<EntityPageSideRail>Panel</EntityPageSideRail>}>Content</EntityPageSidebarLayout>
+    );
+
+    const container = screen.getByText('Content').closest('[data-entity-page-content-variant]');
+
+    expect(container?.className).toContain('has-[aside]:max-w-[var(--entity-page-with-sidebar-max-width)]');
   });
 });

--- a/apps/web/partials/entity-page/entity-page-side-rail.tsx
+++ b/apps/web/partials/entity-page/entity-page-side-rail.tsx
@@ -7,8 +7,12 @@ import * as React from 'react';
  * lays the rail out as a flex sibling of the main column, so without `w-[300px] shrink-0`
  * the rail sizes to its own content and squeezes the content column. The `<aside>` tag is
  * what `EntityPageContentContainer`'s `auto-sidebar` variant matches on (`has-[aside]`) to
- * widen the page to the with-sidebar max width. Panels that render conditionally should
- * return `null` above this shell so the page falls back to the readable content width.
+ * widen the page from ENTITY_PAGE_CONTENT_MAX_WIDTH to ENTITY_PAGE_WITH_SIDEBAR_MAX_WIDTH.
+ * Panels that render conditionally should return `null` above this shell so the page falls
+ * back to the readable content width.
+ *
+ * Note this repo's breakpoints are desktop-first — `lg` is `max-width: 1023px` (see
+ * styles.css), so `lg:hidden` drops the rail on narrow viewports and keeps it on desktop.
  */
 export function EntityPageSideRail({ children }: { children: React.ReactNode }) {
   return (

--- a/apps/web/partials/entity-page/entity-page-side-rail.tsx
+++ b/apps/web/partials/entity-page/entity-page-side-rail.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+
+/**
+ * The right-hand rail shared by every space tab that renders a side panel.
+ *
+ * The width and the `<aside>` element are both load-bearing: `EntityPageSidebarLayout`
+ * lays the rail out as a flex sibling of the main column, so without `w-[300px] shrink-0`
+ * the rail sizes to its own content and squeezes the content column. The `<aside>` tag is
+ * what `EntityPageContentContainer`'s `auto-sidebar` variant matches on (`has-[aside]`) to
+ * widen the page to the with-sidebar max width. Panels that render conditionally should
+ * return `null` above this shell so the page falls back to the readable content width.
+ */
+export function EntityPageSideRail({ children }: { children: React.ReactNode }) {
+  return (
+    <aside className="ml-8 w-[300px] shrink-0 border-l border-divider pl-8 lg:hidden">
+      <div className="flex flex-col gap-6 pb-4">{children}</div>
+    </aside>
+  );
+}

--- a/apps/web/partials/space-page/space-overview-side-panel.tsx
+++ b/apps/web/partials/space-page/space-overview-side-panel.tsx
@@ -6,6 +6,7 @@ import type { CallSeries } from '~/core/community-calls/types';
 import { useSpaceDailyActivityTasks } from '~/core/space/use-space-daily-activities';
 
 import { SpaceCommunityCallsSection } from '~/partials/community-calls/space-community-calls-section';
+import { EntityPageSideRail } from '~/partials/entity-page/entity-page-side-rail';
 
 import { SpaceDailyActivitiesSection } from './space-daily-activities-section';
 
@@ -27,11 +28,9 @@ export function SpaceOverviewSidePanel({ spaceId, communityCalls }: Props) {
   if (!showDaily && !showCalls) return null;
 
   return (
-    <aside className="ml-8 w-[300px] shrink-0 border-l border-divider pl-8 lg:hidden">
-      <div className="flex flex-col gap-6 pb-4">
-        {showDaily ? <SpaceDailyActivitiesSection spaceId={spaceId} tasks={tasks} /> : null}
-        {showCalls ? <SpaceCommunityCallsSection spaceId={spaceId} series={communityCalls} /> : null}
-      </div>
-    </aside>
+    <EntityPageSideRail>
+      {showDaily ? <SpaceDailyActivitiesSection spaceId={spaceId} tasks={tasks} /> : null}
+      {showCalls ? <SpaceCommunityCallsSection spaceId={spaceId} series={communityCalls} /> : null}
+    </EntityPageSideRail>
   );
 }


### PR DESCRIPTION
The Community tab added in #2098 renders its community-calls panel through `EntityPageSidebarLayout`, but passes it as a bare `<div>` rather than the `<aside>` shell the Overview tab uses. Two things depend on that shell:

- The layout lays the panel out as a flex sibling of the content column, so without `w-[300px] shrink-0` the rail sizes to its own content and squeezes the main column.
- `EntityPageContentContainer`'s `auto-sidebar` variant selects the wider with-sidebar max-width via `has-[aside]`, so with no `<aside>` the page also stayed at the narrow 900px content width.

Together those left the rail taking roughly half the row inside a too-narrow page, clipping the curator leaderboard's Votes and Submissions columns.

## Fix

Extract the rail shell out of `SpaceOverviewSidePanel` into a shared `EntityPageSideRail` and use it on both tabs, so the geometry can't drift again the next time a tab grows a side panel.

Measured on `/space/<id>/community` at a 1600px viewport — Community now matches Overview exactly:

| | before | after | Overview tab |
|---|---|---|---|
| page container | 900 | 1142 | 1142 |
| content column | ~490 | 810 | 810 |
| side rail | ~370 (content-sized) | 300 | 300 |

Spaces with no community calls still return `null` above the shell, so they keep the readable 900px content width.

## Testing

- Two new cases in `entity-page-content-container.test.tsx` pin the rail to a fixed-width `<aside>` and assert the container widens off it (6 passing in that file).
- `vitest run partials/community-tab core/community` — 61 passing.
- `bun run build` clean.
- Verified visually against the Health space, Community vs Overview.

## Noted, not fixed

The rail's "View all" link points at `/space/[id]/community` — the tab you are already on — since #2098 replaced the standalone community-calls page with this tab. `CommunityCallsPage` is now unreferenced. Happy to fix in a follow-up; it seemed out of scope for a layout fix.