### PR TITLE
feat: say "Proposal submitted" when publishing to a DAO space

### DIFF
--- a/apps/web/core/hooks/use-publish.ts
+++ b/apps/web/core/hooks/use-publish.ts
@@ -129,6 +129,7 @@ export function usePublish() {
             dispatch({
               type: 'SET_REVIEW_STATE',
               payload: newState,
+              spaceGovernanceType: space.type,
             }),
           ops,
           smartAccount,
@@ -144,6 +145,8 @@ export function usePublish() {
           valuesToPublish.map(v => v.id),
           relations.map(r => r.id)
         );
+
+        return space.type;
       });
 
       const result = await runEffectEither(publish);
@@ -161,7 +164,7 @@ export function usePublish() {
         return;
       }
 
-      dispatch({ type: 'SET_REVIEW_STATE', payload: 'publish-complete' });
+      dispatch({ type: 'SET_REVIEW_STATE', payload: 'publish-complete', spaceGovernanceType: result.right });
 
       // want to show the "complete" state for 3s if it succeeds
       await sleepWithCallback(() => {
@@ -236,6 +239,7 @@ export function useBulkPublish() {
             dispatch({
               type: 'SET_REVIEW_STATE',
               payload: newState,
+              spaceGovernanceType: space.type,
             }),
           ops,
           smartAccount,
@@ -246,6 +250,8 @@ export function useBulkPublish() {
             isEditor: spaceAccess.isEditor,
           },
         });
+
+        return space.type;
       });
 
       const result = await runEffectEither(publish);
@@ -267,7 +273,7 @@ export function useBulkPublish() {
         triples.map(v => v.id),
         relations.map(r => r.id)
       );
-      dispatch({ type: 'SET_REVIEW_STATE', payload: 'publish-complete' });
+      dispatch({ type: 'SET_REVIEW_STATE', payload: 'publish-complete', spaceGovernanceType: result.right });
       onSuccess?.();
 
       // want to show the "complete" state for 3s if it succeeds

--- a/apps/web/core/hooks/use-publish.ts
+++ b/apps/web/core/hooks/use-publish.ts
@@ -146,7 +146,7 @@ export function usePublish() {
           relations.map(r => r.id)
         );
 
-        return space.type;
+        return { spaceGovernanceType: space.type };
       });
 
       const result = await runEffectEither(publish);
@@ -164,7 +164,11 @@ export function usePublish() {
         return;
       }
 
-      dispatch({ type: 'SET_REVIEW_STATE', payload: 'publish-complete', spaceGovernanceType: result.right });
+      dispatch({
+        type: 'SET_REVIEW_STATE',
+        payload: 'publish-complete',
+        spaceGovernanceType: result.right.spaceGovernanceType,
+      });
 
       // want to show the "complete" state for 3s if it succeeds
       await sleepWithCallback(() => {
@@ -251,7 +255,7 @@ export function useBulkPublish() {
           },
         });
 
-        return space.type;
+        return { spaceGovernanceType: space.type };
       });
 
       const result = await runEffectEither(publish);
@@ -273,7 +277,11 @@ export function useBulkPublish() {
         triples.map(v => v.id),
         relations.map(r => r.id)
       );
-      dispatch({ type: 'SET_REVIEW_STATE', payload: 'publish-complete', spaceGovernanceType: result.right });
+      dispatch({
+        type: 'SET_REVIEW_STATE',
+        payload: 'publish-complete',
+        spaceGovernanceType: result.right.spaceGovernanceType,
+      });
       onSuccess?.();
 
       // want to show the "complete" state for 3s if it succeeds

--- a/apps/web/core/state/status-bar-store.test.ts
+++ b/apps/web/core/state/status-bar-store.test.ts
@@ -1,6 +1,5 @@
-import { describe, expect, it, vi } from 'vitest';
-
 import { createStore } from 'jotai';
+import { describe, expect, it, vi } from 'vitest';
 
 import { statusBarDispatchAtom, statusBarStateAtom } from './status-bar-store';
 
@@ -59,5 +58,61 @@ describe('status bar retry handling', () => {
     store.set(statusBarDispatchAtom, { type: 'ERROR', payload: 'No retry available' });
 
     expect(store.get(statusBarStateAtom).retry).toBeUndefined();
+  });
+});
+
+/**
+ * The destination decides the wording of the completion toast, and only some of a publish's
+ * dispatches know it — so it has to survive the ones that don't, and not outlive the publish.
+ */
+describe('status bar publish destination', () => {
+  it('has no destination before a publish starts', () => {
+    const store = createStore();
+
+    expect(store.get(statusBarStateAtom).spaceGovernanceType).toBeNull();
+  });
+
+  it('holds the destination across dispatches that do not carry one', () => {
+    const store = createStore();
+
+    store.set(statusBarDispatchAtom, {
+      type: 'SET_REVIEW_STATE',
+      payload: 'publishing-ipfs',
+      spaceGovernanceType: 'DAO',
+    });
+    store.set(statusBarDispatchAtom, { type: 'SET_REVIEW_STATE', payload: 'signing-wallet' });
+
+    expect(store.get(statusBarStateAtom).spaceGovernanceType).toBe('DAO');
+  });
+
+  it('forgets the destination once the publish returns to idle', () => {
+    const store = createStore();
+
+    store.set(statusBarDispatchAtom, {
+      type: 'SET_REVIEW_STATE',
+      payload: 'publish-complete',
+      spaceGovernanceType: 'DAO',
+    });
+    store.set(statusBarDispatchAtom, { type: 'SET_REVIEW_STATE', payload: 'idle' });
+
+    expect(store.get(statusBarStateAtom).spaceGovernanceType).toBeNull();
+  });
+
+  // Otherwise a personal publish following a DAO one would report a proposal it never filed.
+  it('replaces the destination rather than keeping the previous one', () => {
+    const store = createStore();
+
+    store.set(statusBarDispatchAtom, {
+      type: 'SET_REVIEW_STATE',
+      payload: 'publish-complete',
+      spaceGovernanceType: 'DAO',
+    });
+    store.set(statusBarDispatchAtom, {
+      type: 'SET_REVIEW_STATE',
+      payload: 'publishing-ipfs',
+      spaceGovernanceType: 'PERSONAL',
+    });
+
+    expect(store.get(statusBarStateAtom).spaceGovernanceType).toBe('PERSONAL');
   });
 });

--- a/apps/web/core/state/status-bar-store.tsx
+++ b/apps/web/core/state/status-bar-store.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 
 import { atom, useAtomValue, useSetAtom } from 'jotai';
 
-import { ReviewState } from '~/core/types';
+import { ReviewState, SpaceGovernanceType } from '~/core/types';
 
 type Retry = (() => Promise<unknown>) | (() => unknown);
 
@@ -12,12 +12,19 @@ export interface StatusBarState {
   reviewState: ReviewState;
   error: string | null;
   retry?: Retry;
+  /**
+   * Where the publish is going, so the toast can name what actually happened: writing to your own
+   * space publishes, while writing to a DAO space files a proposal for the space to decide on.
+   */
+  spaceGovernanceType: SpaceGovernanceType | null;
 }
 
 export type StatusBarActions =
   | {
       type: 'SET_REVIEW_STATE';
       payload: ReviewState;
+      /** Carried through the publish so the completion message can match the destination. */
+      spaceGovernanceType?: SpaceGovernanceType;
     }
   | { type: 'ERROR'; payload: string | null; retry?: Retry };
 
@@ -27,11 +34,13 @@ export type StatusBarActions =
 const reviewStateAtom = atom<ReviewState>('idle');
 const errorAtom = atom<string | null>(null);
 const retryAtom = atom<Retry | undefined>(undefined);
+const spaceGovernanceTypeAtom = atom<SpaceGovernanceType | null>(null);
 
 export const statusBarStateAtom = atom<StatusBarState>(get => ({
   reviewState: get(reviewStateAtom),
   error: get(errorAtom),
   retry: get(retryAtom),
+  spaceGovernanceType: get(spaceGovernanceTypeAtom),
 }));
 
 export const statusBarDispatchAtom = atom(null, (_get, set, action: StatusBarActions) => {
@@ -40,6 +49,14 @@ export const statusBarDispatchAtom = atom(null, (_get, set, action: StatusBarAct
       set(reviewStateAtom, action.payload);
       set(errorAtom, null);
       set(retryAtom, undefined);
+      // Only the dispatches that know the destination carry it, and the rest of a publish's states
+      // must not wipe what an earlier one established. Returning to idle does clear it, so the next
+      // publish can't inherit the last one's wording.
+      if (action.spaceGovernanceType !== undefined) {
+        set(spaceGovernanceTypeAtom, action.spaceGovernanceType);
+      } else if (action.payload === 'idle') {
+        set(spaceGovernanceTypeAtom, null);
+      }
       return;
     case 'ERROR':
       set(reviewStateAtom, 'publish-error');

--- a/apps/web/partials/review/status-bar-message.test.ts
+++ b/apps/web/partials/review/status-bar-message.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { statusBarMessage } from './status-bar';
+import { statusBarMessage } from './status-bar-message';
 
 describe('statusBarMessage', () => {
   // Writing to your own space publishes outright, so the original wording still holds.

--- a/apps/web/partials/review/status-bar-message.test.ts
+++ b/apps/web/partials/review/status-bar-message.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+
+import { statusBarMessage } from './status-bar';
+
+describe('statusBarMessage', () => {
+  // Writing to your own space publishes outright, so the original wording still holds.
+  it('says changes were published for a personal space', () => {
+    expect(statusBarMessage({ reviewState: 'publish-complete', spaceGovernanceType: 'PERSONAL' })).toBe(
+      'Changes published!'
+    );
+  });
+
+  // A DAO edit is filed for the space to decide on. Calling that "published" claims the change is
+  // live when it is still waiting on a vote.
+  it('says a proposal was submitted for a DAO space', () => {
+    expect(statusBarMessage({ reviewState: 'publish-complete', spaceGovernanceType: 'DAO' })).toBe(
+      'Proposal submitted'
+    );
+  });
+
+  // Nothing before the final state names a destination, so an unknown one keeps the old wording
+  // rather than inventing a proposal.
+  it('falls back to the published wording when the destination is unknown', () => {
+    expect(statusBarMessage({ reviewState: 'publish-complete', spaceGovernanceType: null })).toBe('Changes published!');
+  });
+
+  it.each(['publishing-ipfs', 'signing-wallet', 'publishing-contract', 'publish-error'] as const)(
+    'leaves the %s message alone whatever the destination',
+    reviewState => {
+      expect(statusBarMessage({ reviewState, spaceGovernanceType: 'DAO' })).toBe(
+        statusBarMessage({ reviewState, spaceGovernanceType: 'PERSONAL' })
+      );
+    }
+  );
+
+  it('still reports progress states while publishing to a DAO space', () => {
+    expect(statusBarMessage({ reviewState: 'signing-wallet', spaceGovernanceType: 'DAO' })).toBe(
+      'Sign your transaction'
+    );
+  });
+});

--- a/apps/web/partials/review/status-bar-message.ts
+++ b/apps/web/partials/review/status-bar-message.ts
@@ -1,0 +1,29 @@
+import type { ReviewState, SpaceGovernanceType } from '~/core/types';
+
+const message: Record<ReviewState, string> = {
+  idle: '',
+  reviewing: '',
+  'publishing-ipfs': 'Uploading changes to IPFS',
+  'signing-wallet': 'Sign your transaction',
+  'publishing-contract': 'Adding your changes to The Graph',
+  'publish-complete': 'Changes published!',
+  'publish-error': 'An error has occurred',
+};
+
+/**
+ * Writing to your own space publishes the changes outright. Writing to a DAO space files a
+ * proposal for the space to decide on, so saying "published" there claims something that hasn't
+ * happened yet — the edit is submitted, not live.
+ *
+ * An unknown destination keeps the original wording rather than inventing a proposal.
+ */
+export function statusBarMessage(state: {
+  reviewState: ReviewState;
+  spaceGovernanceType: SpaceGovernanceType | null;
+}): string {
+  if (state.reviewState === 'publish-complete' && state.spaceGovernanceType === 'DAO') {
+    return 'Proposal submitted';
+  }
+
+  return message[state.reviewState];
+}

--- a/apps/web/partials/review/status-bar.tsx
+++ b/apps/web/partials/review/status-bar.tsx
@@ -10,7 +10,7 @@ import { usePersonalSpaceId } from '~/core/hooks/use-personal-space-id';
 import { useSmartAccount } from '~/core/hooks/use-smart-account';
 import { useEditable } from '~/core/state/editable-store';
 import { useStatusBar } from '~/core/state/status-bar-store';
-import { ReviewState, SpaceGovernanceType } from '~/core/types';
+import { ReviewState } from '~/core/types';
 import { collectClientDiagnostics, formatErrorReport } from '~/core/utils/error-diagnostics';
 import { Z_LAYERS, Z_LAYER_CLASS } from '~/core/z-layers';
 
@@ -21,6 +21,8 @@ import { RetrySmall } from '~/design-system/icons/retry-small';
 import { TickSmall } from '~/design-system/icons/tick-small';
 import { Warning } from '~/design-system/icons/warning';
 import { Spinner } from '~/design-system/spinner';
+
+import { statusBarMessage } from './status-bar-message';
 
 /**
  * Surfaces publish progress and errors.
@@ -210,31 +212,6 @@ export const StatusBar = () => {
     </div>
   );
 };
-
-const message: Record<ReviewState, string> = {
-  idle: '',
-  reviewing: '',
-  'publishing-ipfs': 'Uploading changes to IPFS',
-  'signing-wallet': 'Sign your transaction',
-  'publishing-contract': 'Adding your changes to The Graph',
-  'publish-complete': 'Changes published!',
-  'publish-error': 'An error has occurred',
-};
-
-/**
- * Writing to your own space publishes the changes outright. Writing to a DAO space files a
- * proposal for the space to decide on, so saying "published" there claims something that hasn't
- * happened yet — the edit is submitted, not live.
- */
-function completionMessage(spaceGovernanceType: SpaceGovernanceType | null): string {
-  return spaceGovernanceType === 'DAO' ? 'Proposal submitted' : message['publish-complete'];
-}
-
-export function statusBarMessage(state: { reviewState: ReviewState; spaceGovernanceType: SpaceGovernanceType | null }) {
-  return state.reviewState === 'publish-complete'
-    ? completionMessage(state.spaceGovernanceType)
-    : message[state.reviewState];
-}
 
 const publishingStates: Array<ReviewState> = [
   'publishing-ipfs',

--- a/apps/web/partials/review/status-bar.tsx
+++ b/apps/web/partials/review/status-bar.tsx
@@ -10,7 +10,7 @@ import { usePersonalSpaceId } from '~/core/hooks/use-personal-space-id';
 import { useSmartAccount } from '~/core/hooks/use-smart-account';
 import { useEditable } from '~/core/state/editable-store';
 import { useStatusBar } from '~/core/state/status-bar-store';
-import { ReviewState } from '~/core/types';
+import { ReviewState, SpaceGovernanceType } from '~/core/types';
 import { collectClientDiagnostics, formatErrorReport } from '~/core/utils/error-diagnostics';
 import { Z_LAYERS, Z_LAYER_CLASS } from '~/core/z-layers';
 
@@ -195,13 +195,13 @@ export const StatusBar = () => {
               )}
               {state.reviewState !== 'publish-complete' && publishingStates.includes(state.reviewState) && <Spinner />}
               <motion.span
-                key={message[state.reviewState]}
+                key={statusBarMessage(state)}
                 initial={{ opacity: 0, filter: 'blur(2px)' }}
                 animate={{ opacity: 1, filter: 'blur(0px)' }}
                 exit={{ opacity: 0, filter: 'blur(2px)' }}
                 transition={{ type: 'spring', duration: 0.5, delay: 0.15 }}
               >
-                {message[state.reviewState]}
+                {statusBarMessage(state)}
               </motion.span>
             </div>
           </AnimatePresence>
@@ -220,6 +220,21 @@ const message: Record<ReviewState, string> = {
   'publish-complete': 'Changes published!',
   'publish-error': 'An error has occurred',
 };
+
+/**
+ * Writing to your own space publishes the changes outright. Writing to a DAO space files a
+ * proposal for the space to decide on, so saying "published" there claims something that hasn't
+ * happened yet — the edit is submitted, not live.
+ */
+function completionMessage(spaceGovernanceType: SpaceGovernanceType | null): string {
+  return spaceGovernanceType === 'DAO' ? 'Proposal submitted' : message['publish-complete'];
+}
+
+export function statusBarMessage(state: { reviewState: ReviewState; spaceGovernanceType: SpaceGovernanceType | null }) {
+  return state.reviewState === 'publish-complete'
+    ? completionMessage(state.spaceGovernanceType)
+    : message[state.reviewState];
+}
 
 const publishingStates: Array<ReviewState> = [
   'publishing-ipfs',


### PR DESCRIPTION
Publishing to a DAO space now finishes with **Proposal submitted** instead of **Changes published!**. Personal spaces keep the toast they had.

## Why the plumbing

Writing to your own space publishes the changes outright; writing to a DAO space files a proposal for the space to decide on. The shared toast claimed the change was live when it was still waiting on a vote.

[`StatusBar`](apps/web/partials/review/status-bar.tsx) is mounted globally in `entry.tsx` and only knew the `ReviewState` — nothing about where the publish was going. So the destination now rides along with it. `usePublish` and `useBulkPublish` already resolve the space before proposing, so both pass `space.type` on every dispatch, and both hand it back out of the Effect so the completion dispatch states it explicitly rather than relying on what an earlier dispatch happened to leave behind.

Two details in the store worth a look:
- Only some of a publish's dispatches know the destination, so the rest must not wipe what an earlier one established.
- Returning to `idle` clears it, so a personal publish following a DAO one can't inherit the previous wording.

The message lookup is extracted as `statusBarMessage` so the branch is testable without rendering the toast.

## Two things for you to decide

**Punctuation.** I used `Proposal submitted` exactly as you wrote it. The string it replaces is `Changes published!` and the toast still shows the 🎉, so `Proposal submitted!` would match the house tone better. One-character change either way — say which you prefer.

**Fast-path proposals.** An editor publishing with FAST voting creates a proposal that auto-executes moments later, so their change effectively does go live. They'll still see "Proposal submitted", which is accurate at the moment it shows. If you'd rather that case read differently, that's a follow-up — it needs the toast to know the voting mode and the execution result, not just the space type.

## Testing

10 new tests:
- `status-bar-message.test.ts` — DAO vs personal wording, unknown destination falls back to the published wording, and the in-progress states are unchanged whatever the destination.
- `status-bar-store.test.ts` — the destination survives dispatches that don't carry one, clears on idle, and is replaced rather than retained across publishes.

Confirmed both key tests fail with their change reverted. Full suite green at 260 files / 2598 tests; typecheck and build pass. The one eslint warning in `status-bar.tsx` (`Z_LAYERS` unused) is pre-existing on master — verified by stashing.

Not verified in a browser: it needs a real DAO publish to see the toast.