### PR TITLE
feat: show claims on Explore by default

### DIFF
--- a/apps/web/core/explore/explore-constants.ts
+++ b/apps/web/core/explore/explore-constants.ts
@@ -1,3 +1,5 @@
+import { CLAIM_TYPE_ID } from '~/core/claims/ontology';
+
 export const NEWS_STORY_TYPE_ID = 'e550fe517e904b2c8fffdf13408f5634';
 export const EPISODE_TYPE_ID = '972d201ad78045689e01543f67b26bee';
 export const TWEET_TYPE_ID = 'd6f0506def324d8e9de4976b986e78ec';
@@ -16,6 +18,7 @@ export const EXPLORE_ENTITY_TYPES = [
   { id: '150db6defe2344f0805afa57502e2c32', label: 'Ranking block' },
   { id: '0419ca20118b4cdb84dfdb9ed73b50c2', label: 'Community call event' },
   { id: 'fd51f93520634617be397b672b23364c', label: 'Debate' },
+  { id: CLAIM_TYPE_ID, label: 'Claim' },
 ] as const;
 
 export const EXPLORE_ENTITY_TYPE_IDS = EXPLORE_ENTITY_TYPES.map(type => type.id);

--- a/apps/web/core/explore/explore-type-filter.test.ts
+++ b/apps/web/core/explore/explore-type-filter.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import { CLAIM_TYPE_ID } from '~/core/claims/ontology';
 
-import { EXPLORE_ENTITY_TYPES, EXPLORE_ENTITY_TYPE_IDS } from './explore-constants';
+import { EXPLORE_ENTITY_TYPE_IDS } from './explore-constants';
 import {
   exploreTypeFilterLabel,
   parseExploreTypeIdsParam,
@@ -16,8 +16,10 @@ describe('Explore default types', () => {
   // list wherever it goes and would stay green if a type were dropped. Claim is pinned
   // explicitly: Explore is where claims get discovered, so it defaulting off is a
   // regression rather than a preference.
+  //
+  // Asserted by ID only. The menu label is display copy, and the entry's shape is already
+  // a compile-time guarantee, so pinning the string here would only fail on a rename.
   it('includes Claim, selected by default', () => {
-    expect(EXPLORE_ENTITY_TYPES.map(type => type.label)).toContain('Claim');
     expect(EXPLORE_ENTITY_TYPE_IDS).toContain(CLAIM_TYPE_ID);
     expect(parseStoredExploreTypeIds(null)).toContain(CLAIM_TYPE_ID);
     expect(parseExploreTypeIdsParam(null)).toContain(CLAIM_TYPE_ID);

--- a/apps/web/core/explore/explore-type-filter.test.ts
+++ b/apps/web/core/explore/explore-type-filter.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
-import { EXPLORE_ENTITY_TYPE_IDS } from './explore-constants';
+import { CLAIM_TYPE_ID } from '~/core/claims/ontology';
+
+import { EXPLORE_ENTITY_TYPES, EXPLORE_ENTITY_TYPE_IDS } from './explore-constants';
 import {
   exploreTypeFilterLabel,
   parseExploreTypeIdsParam,
@@ -8,6 +10,19 @@ import {
   sanitizeExploreTypeIds,
   toggleExploreTypeId,
 } from './explore-type-filter';
+
+describe('Explore default types', () => {
+  // The rest of this suite is written against EXPLORE_ENTITY_TYPE_IDS, so it follows the
+  // list wherever it goes and would stay green if a type were dropped. Claim is pinned
+  // explicitly: Explore is where claims get discovered, so it defaulting off is a
+  // regression rather than a preference.
+  it('includes Claim, selected by default', () => {
+    expect(EXPLORE_ENTITY_TYPES.map(type => type.label)).toContain('Claim');
+    expect(EXPLORE_ENTITY_TYPE_IDS).toContain(CLAIM_TYPE_ID);
+    expect(parseStoredExploreTypeIds(null)).toContain(CLAIM_TYPE_ID);
+    expect(parseExploreTypeIdsParam(null)).toContain(CLAIM_TYPE_ID);
+  });
+});
 
 describe('parseStoredExploreTypeIds', () => {
   it('defaults to every Explore type when cache is missing or corrupt', () => {


### PR DESCRIPTION
Claims were the one debate primitive Explore couldn't surface. The type filter offered eleven types and Claim wasn't among them, so there was no way to reach claims from the feed — even though the welcome banner invites people to "organize topics, questions, **claims**, and relevant sources."

## Change

One entry added to `EXPLORE_ENTITY_TYPES` in `core/explore/explore-constants.ts`. That array is both the filter menu's contents and the default selection (`defaultExploreTypeIds()` returns all of it), so Claim ships **on** rather than as an opt-in.

The ID is imported from `core/claims/ontology` rather than pasted as a fresh literal — that file is already its canonical home, and this list has been burned once already by a duplicated ranking-block ID.

Appended after `Debate` rather than inserted: `entity-feed.test.tsx` clicks types by list position (`Episode`/`Post` as entries 2 and 3), so appending keeps those assertions meaningful.

## No card work needed

Claims store their text as the entity `name` and carry no description or cover, so `BaseExploreFeedCard` renders them as-is. `EntityRowActions` already switches `EntityVoteButtons` into its claim-aware agree/disagree mode off the entity's type, so claims arrive with the right controls automatically.

## Testing

- New test pins Claim into the default set. Everything else in that suite is written against `EXPLORE_ENTITY_TYPE_IDS` and so follows the list wherever it goes — it would stay green if Claim were dropped. Verified the new test actually fails without the entry.
- `vitest run core/explore partials/feed/entity-feed.test.tsx` — 15 passing.
- `bun run build` clean.
- Verified in the running app: filter chip reads "12 types", no `typeIds=` param is sent on the default selection (unchanged behavior), and claims render with the Claim chip, claim text as title, and vote controls.

`exploreTypeFilterLabel(11)` in `explore-type-filter.test.ts` passes 11 as a literal to a pure formatter, so it needed no update.

## Two things worth a look before this merges

**Claims dominate the New feed.** `/api/explore/feed?sort=new&time=month` now returns 21 claims out of 22 items. Explore's default sort is Top/Last month, where they're mixed in normally, but anyone switching to New effectively gets a claims feed. If that's not wanted, the fix is a ranking/interleaving change rather than a filter change — happy to take it as a follow-up.

**Returning users with a saved filter won't see claims.** The selection persists to `localStorage` on any toggle, and `sanitizeExploreTypeIds` drops unknown IDs — so a stored eleven-type array stays eleven types with Claim off. Users who never touched the filter (nothing stored) get Claim on by default, which is the common case.

I left that alone deliberately: an explicit saved selection is a stated preference, and silently resetting it seemed the worse error. If you'd rather claims turn on for everyone, bumping `EXPLORE_TYPE_FILTER_STORAGE_KEY` to a v2 key does it in one line, at the cost of discarding existing custom selections. Your call.