### PR TITLE
feat(community): keep listed personal spaces off the curator leaderboard

### DIFF
--- a/apps/web/core/community/curator-leaderboard-exclusions.test.ts
+++ b/apps/web/core/community/curator-leaderboard-exclusions.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+
+import { EXCLUDED_CURATOR_SPACE_IDS, isExcludedCurator } from './curator-leaderboard-exclusions';
+
+const EXCLUDED = EXCLUDED_CURATOR_SPACE_IDS[0];
+const SOMEONE_ELSE = '019fedae72b67ab2927adf044d57c566';
+
+describe('isExcludedCurator', () => {
+  it('excludes a listed personal space', () => {
+    expect(isExcludedCurator(EXCLUDED)).toBe(true);
+  });
+
+  it('leaves everyone else alone', () => {
+    expect(isExcludedCurator(SOMEONE_ELSE)).toBe(false);
+  });
+
+  // Curator ids reach this from several sources — relation `spaceId`s, proposal authors, the
+  // viewer's own id off a query string — and they don't agree on a format.
+  it('matches the same space written as a hyphenated uuid', () => {
+    const uuid = [
+      EXCLUDED.slice(0, 8),
+      EXCLUDED.slice(8, 12),
+      EXCLUDED.slice(12, 16),
+      EXCLUDED.slice(16, 20),
+      EXCLUDED.slice(20),
+    ].join('-');
+
+    expect(isExcludedCurator(uuid)).toBe(true);
+  });
+
+  it('matches regardless of case', () => {
+    expect(isExcludedCurator(EXCLUDED.toUpperCase())).toBe(true);
+  });
+
+  // "No curator" is not an excluded curator — callers pass a nullable viewer id straight in.
+  it('treats a missing id as not excluded', () => {
+    expect(isExcludedCurator(null)).toBe(false);
+    expect(isExcludedCurator(undefined)).toBe(false);
+    expect(isExcludedCurator('')).toBe(false);
+  });
+});
+
+describe('EXCLUDED_CURATOR_SPACE_IDS', () => {
+  // The list is hand-maintained, so a typo is the likeliest way it breaks: an id that isn't a
+  // 32-character hex space id silently matches nobody.
+  it('holds only well-formed space ids', () => {
+    for (const id of EXCLUDED_CURATOR_SPACE_IDS) {
+      expect(id.replace(/-/g, '').toLowerCase()).toMatch(/^[0-9a-f]{32}$/);
+    }
+  });
+});

--- a/apps/web/core/community/curator-leaderboard-exclusions.ts
+++ b/apps/web/core/community/curator-leaderboard-exclusions.ts
@@ -1,0 +1,25 @@
+import { ID } from '~/core/id';
+
+/**
+ * Personal spaces kept off the curator leaderboard.
+ *
+ * A hard-coded list by design: these are accounts whose activity is real but isn't the community
+ * contribution the board is meant to celebrate — team, bot and test accounts that would otherwise
+ * sit at the top of a public ranking. There is no on-graph flag for "don't rank me", so until
+ * there is, the list lives here.
+ *
+ * Entries are personal space ids, in any format — they are normalized on the way into the set
+ * below, so a UUID with hyphens and the bare hex form of the same space both match.
+ *
+ * To add someone: put their personal space id in this array with a comment saying who it is and
+ * why, so the next person reading it doesn't have to guess.
+ */
+export const EXCLUDED_CURATOR_SPACE_IDS: string[] = ['cc0bf85a27c217d75993bc785a15b198'];
+
+const excludedSpaceIds = new Set(EXCLUDED_CURATOR_SPACE_IDS.map(id => ID.uuidToHex(id)));
+
+/** Whether this personal space is one the leaderboard leaves out. */
+export function isExcludedCurator(spaceId: string | null | undefined): boolean {
+  if (!spaceId) return false;
+  return excludedSpaceIds.has(ID.uuidToHex(spaceId));
+}

--- a/apps/web/core/community/curator-leaderboard-exclusions.ts
+++ b/apps/web/core/community/curator-leaderboard-exclusions.ts
@@ -14,7 +14,7 @@ import { ID } from '~/core/id';
  * To add someone: put their personal space id in this array with a comment saying who it is and
  * why, so the next person reading it doesn't have to guess.
  */
-export const EXCLUDED_CURATOR_SPACE_IDS: string[] = ['cc0bf85a27c217d75993bc785a15b198'];
+export const EXCLUDED_CURATOR_SPACE_IDS: readonly string[] = ['cc0bf85a27c217d75993bc785a15b198'];
 
 const excludedSpaceIds = new Set(EXCLUDED_CURATOR_SPACE_IDS.map(id => ID.uuidToHex(id)));
 

--- a/apps/web/core/community/fetch-curator-leaderboard.test.ts
+++ b/apps/web/core/community/fetch-curator-leaderboard.test.ts
@@ -24,20 +24,34 @@ vi.mock('./community-graphql', async importOriginal => {
 
   return {
     ...actual,
+    // Every label is answered explicitly, and an unrecognised one throws rather than falling back
+    // to an empty result. A new query added to the fetcher would otherwise be answered with
+    // "nothing", quietly narrowing what these tests cover while they carried on passing.
     runQuery: async (label: string) => {
-      if (label === 'space ranking blocks') {
-        return { entitiesConnection: { nodes: [{ id: RANKING_BLOCK }] } };
+      switch (label) {
+        case 'space ranking blocks':
+          return { entitiesConnection: { nodes: [{ id: RANKING_BLOCK }] } };
+        // Reached only when the fixtures above give them something to look up, which they don't.
+        case 'bounty-linked proposals':
+        case 'news story edit versions':
+          return null;
+        default:
+          throw new Error(`unstubbed community query: "${label}"`);
       }
-      return null;
     },
     collectConnection: async (label: string) => {
-      if (label === 'submitted to ranking block relations') {
-        return { nodes: mocks.rankingRelations, truncated: false, totalCount: mocks.rankingRelations.length };
+      switch (label) {
+        case 'submitted to ranking block relations':
+          return { nodes: mocks.rankingRelations, truncated: false, totalCount: mocks.rankingRelations.length };
+        case 'user votes':
+          return { nodes: mocks.votes, truncated: false };
+        case 'bounty links':
+        case 'news story entities':
+        case 'news story type relation versions':
+          return { nodes: [], truncated: false, totalCount: 0 };
+        default:
+          throw new Error(`unstubbed community connection: "${label}"`);
       }
-      if (label === 'user votes') {
-        return { nodes: mocks.votes, truncated: false };
-      }
-      return { nodes: [], truncated: false, totalCount: 0 };
     },
   };
 });

--- a/apps/web/core/community/fetch-curator-leaderboard.test.ts
+++ b/apps/web/core/community/fetch-curator-leaderboard.test.ts
@@ -1,0 +1,147 @@
+import { Effect } from 'effect';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { EXCLUDED_CURATOR_SPACE_IDS } from './curator-leaderboard-exclusions';
+import { fetchCuratorLeaderboard } from './fetch-curator-leaderboard';
+
+const SPACE = '019fedae72b67ab2927adf044d57c500';
+const RANKING_BLOCK = '019fedae72b67ab2927adf044d57c501';
+const EXCLUDED = EXCLUDED_CURATOR_SPACE_IDS[0];
+const KEEPER = '019fedae72b67ab2927adf044d57c566';
+const OTHER = '019fedae72b67ab2927adf044d57c567';
+
+const mocks = vi.hoisted(() => ({
+  /** Rows the "submitted to ranking block" connection returns, one per ranking published. */
+  rankingRelations: [] as { fromEntityId: string; spaceId: string }[],
+  votes: [] as { userId: string }[],
+  profileSpaceIds: [] as string[][],
+}));
+
+// The real query plumbing is covered by community-graphql.test.ts; these stubs stand in for the
+// indexer so the aggregation above them can be driven directly. Everything else stays real.
+vi.mock('./community-graphql', async importOriginal => {
+  const actual = await importOriginal<typeof import('./community-graphql')>();
+
+  return {
+    ...actual,
+    runQuery: async (label: string) => {
+      if (label === 'space ranking blocks') {
+        return { entitiesConnection: { nodes: [{ id: RANKING_BLOCK }] } };
+      }
+      return null;
+    },
+    collectConnection: async (label: string) => {
+      if (label === 'submitted to ranking block relations') {
+        return { nodes: mocks.rankingRelations, truncated: false, totalCount: mocks.rankingRelations.length };
+      }
+      if (label === 'user votes') {
+        return { nodes: mocks.votes, truncated: false };
+      }
+      return { nodes: [], truncated: false, totalCount: 0 };
+    },
+  };
+});
+
+vi.mock('~/core/io/subgraph/fetch-profile', () => ({
+  fetchProfilesBySpaceIds: (spaceIds: string[]) => {
+    mocks.profileSpaceIds.push(spaceIds);
+    return Effect.succeed(
+      spaceIds.map(spaceId => ({ spaceId, name: `Curator ${spaceId.slice(-4)}`, avatarUrl: null }))
+    );
+  },
+}));
+
+function ranking(curatorSpaceId: string, index: number) {
+  return { fromEntityId: `${curatorSpaceId}-${index}`, spaceId: curatorSpaceId };
+}
+
+beforeEach(() => {
+  mocks.rankingRelations = [];
+  mocks.votes = [];
+  mocks.profileSpaceIds = [];
+});
+
+describe('fetchCuratorLeaderboard exclusions', () => {
+  // The excluded curator out-publishes everyone, so if the filter misses they lead the board.
+  it('leaves an excluded curator off the rows entirely', async () => {
+    mocks.rankingRelations = [ranking(EXCLUDED, 1), ranking(EXCLUDED, 2), ranking(EXCLUDED, 3), ranking(KEEPER, 1)];
+
+    const result = await fetchCuratorLeaderboard({ spaceId: SPACE, period: 'all' });
+
+    expect(result.rows.map(row => row.curatorSpaceId)).toEqual([KEEPER]);
+  });
+
+  it('does not count them among the active curators', async () => {
+    mocks.rankingRelations = [ranking(EXCLUDED, 1), ranking(KEEPER, 1), ranking(OTHER, 1)];
+
+    const result = await fetchCuratorLeaderboard({ spaceId: SPACE, period: 'all' });
+
+    expect(result.metrics.activeCurators).toBe(2);
+  });
+
+  // The space really does hold those rankings, whoever published them — the metric counts content,
+  // not who is on the board.
+  it('leaves the space-wide totals alone', async () => {
+    mocks.rankingRelations = [ranking(EXCLUDED, 1), ranking(EXCLUDED, 2), ranking(KEEPER, 1)];
+
+    const result = await fetchCuratorLeaderboard({ spaceId: SPACE, period: 'all' });
+
+    expect(result.metrics.rankings).toBe(3);
+  });
+
+  // Votes reach the board through a different source than rankings, so the filter has to sit
+  // downstream of all of them rather than in any one.
+  it('excludes them however their activity reached the board', async () => {
+    mocks.votes = [{ userId: EXCLUDED }, { userId: KEEPER }];
+
+    const result = await fetchCuratorLeaderboard({ spaceId: SPACE, period: 'all' });
+
+    expect(result.rows.map(row => row.curatorSpaceId)).toEqual([KEEPER]);
+  });
+
+  // Nothing on screen needs their name, so nothing should go and fetch it.
+  it('does not look up a profile for them', async () => {
+    mocks.rankingRelations = [ranking(EXCLUDED, 1), ranking(KEEPER, 1)];
+
+    await fetchCuratorLeaderboard({ spaceId: SPACE, period: 'all' });
+
+    expect(mocks.profileSpaceIds.flat()).not.toContain(EXCLUDED);
+  });
+
+  // Otherwise the board appends the viewer their own row when they miss the cut — which would show
+  // an excluded curator the thing they are excluded from, and with zeroed counts at that.
+  it('shows an excluded curator no row of their own', async () => {
+    mocks.rankingRelations = [ranking(KEEPER, 1)];
+
+    const result = await fetchCuratorLeaderboard({
+      spaceId: SPACE,
+      period: 'all',
+      currentUserSpaceId: EXCLUDED,
+    });
+
+    expect(result.currentUserRow).toBeNull();
+    expect(result.rows.some(row => row.isCurrentUser)).toBe(false);
+  });
+
+  // The other half of that: an ordinary viewer who missed the cut still gets their row.
+  it('still appends a row for a viewer who is not excluded', async () => {
+    mocks.rankingRelations = [ranking(KEEPER, 1)];
+
+    const result = await fetchCuratorLeaderboard({
+      spaceId: SPACE,
+      period: 'all',
+      currentUserSpaceId: OTHER,
+    });
+
+    expect(result.currentUserRow?.curatorSpaceId).toBe(OTHER);
+  });
+
+  it('leaves a board with nobody excluded untouched', async () => {
+    mocks.rankingRelations = [ranking(KEEPER, 1), ranking(OTHER, 1)];
+
+    const result = await fetchCuratorLeaderboard({ spaceId: SPACE, period: 'all' });
+
+    expect(result.rows.map(row => row.curatorSpaceId).sort()).toEqual([KEEPER, OTHER].sort());
+    expect(result.metrics.activeCurators).toBe(2);
+  });
+});

--- a/apps/web/core/community/fetch-curator-leaderboard.ts
+++ b/apps/web/core/community/fetch-curator-leaderboard.ts
@@ -468,7 +468,9 @@ export async function fetchCuratorLeaderboard({
   // curator count, and the profiles fetched below all read this one map. The space-wide totals
   // beside them (rankings, news stories) are deliberately left alone — they count what the space
   // holds, not who is on the board, and an excluded curator's rankings are still the space's.
-  for (const curatorSpaceId of countsByCurator.keys()) {
+  // Over a snapshot of the keys rather than the live iterator: deleting the current key mid-loop is
+  // well defined, but it reads like a bug and invites one the next time this moves.
+  for (const curatorSpaceId of [...countsByCurator.keys()]) {
     if (isExcludedCurator(curatorSpaceId)) countsByCurator.delete(curatorSpaceId);
   }
 

--- a/apps/web/core/community/fetch-curator-leaderboard.ts
+++ b/apps/web/core/community/fetch-curator-leaderboard.ts
@@ -9,6 +9,7 @@ import { RANKING_BLOCK_TYPE_ID, SUBMITTED_TO_PROPERTY_ID } from '~/core/ranking-
 import { mapWithConcurrency } from '~/core/utils/map-with-concurrency';
 
 import { ID_CHUNK_SIZE, afterArg, chunk, collectConnection, gqlId, gqlIdList, runQuery } from './community-graphql';
+import { isExcludedCurator } from './curator-leaderboard-exclusions';
 import { type CuratorLeaderboardWindow, curatorLeaderboardWindow } from './curator-leaderboard-period';
 import type {
   CuratorLeaderboardPeriod,
@@ -463,7 +464,19 @@ export async function fetchCuratorLeaderboard({
     accumulate(curatorSpaceId, counts => (counts.newsStories += count));
   }
 
-  const normalizedCurrentUserSpaceId = currentUserSpaceId ? gqlId(currentUserSpaceId) : null;
+  // Dropped here rather than per source, so everything downstream agrees: the rows, the active
+  // curator count, and the profiles fetched below all read this one map. The space-wide totals
+  // beside them (rankings, news stories) are deliberately left alone — they count what the space
+  // holds, not who is on the board, and an excluded curator's rankings are still the space's.
+  for (const curatorSpaceId of countsByCurator.keys()) {
+    if (isExcludedCurator(curatorSpaceId)) countsByCurator.delete(curatorSpaceId);
+  }
+
+  // An excluded curator is excluded from their own view too. Left as-is, `buildRows` would append
+  // them their own row — with zeroed counts, since the real ones were just dropped — which is both
+  // a leak of the thing being hidden and wrong about their activity.
+  const viewerSpaceId = isExcludedCurator(currentUserSpaceId) ? null : currentUserSpaceId;
+  const normalizedCurrentUserSpaceId = viewerSpaceId ? gqlId(viewerSpaceId) : null;
 
   const profileSpaceIds = [...countsByCurator.keys()];
   if (normalizedCurrentUserSpaceId && !profileSpaceIds.includes(normalizedCurrentUserSpaceId)) {


### PR DESCRIPTION
## What

Adds a hard-coded exclusion list to the Community tab's curator leaderboard, so listed personal spaces don't appear on it.

- `core/community/curator-leaderboard-exclusions.ts` — the list plus an `isExcludedCurator()` helper.
- `core/community/fetch-curator-leaderboard.ts` — applies it.

Seeded with the one id you gave me: `cc0bf85a27c217d75993bc785a15b198`. Adding more is a one-line append.

## Where the filter sits

Once, against the accumulated per-curator map — not in each of the four sources that feed it (rankings, votes, submissions, news stories).

Everything downstream reads that one map, so the rows, `metrics.activeCurators`, and the profile lookup all agree by construction rather than by four separate filters staying in step. A test covers a curator reaching the board via votes rather than rankings, which is the case a per-source filter would be most likely to miss.

Ids are normalized (`ID.uuidToHex`) on both sides of the comparison. They reach this code from relation `spaceId`s, proposal authors, and the viewer's own id off a query string, and those don't agree on hyphens or case.

## Two judgement calls worth a look

Both are one-line changes if you'd rather they went the other way:

1. **The space-wide totals are left alone.** `metrics.rankings` and `metrics.newsStories` come from connection `totalCount`s and still include an excluded curator's contributions. They count what the space holds, not who is on the board — an excluded curator's rankings are still the space's rankings. `activeCurators` *does* drop them, since that one is a count of the people the board is about.

2. **An excluded curator is excluded from their own view.** Without this, `buildRows` appends the viewer a personal row when they miss the top five — so an excluded curator would be shown the thing they're excluded from, and with zeroed counts, since their real ones were just dropped. Now they get no row at all. A viewer who *isn't* excluded still gets theirs, which is a separate test.

## Testing

- `curator-leaderboard-exclusions.test.ts` — the helper: listed vs not, hyphenated UUID and uppercase forms of the same id, null/undefined/empty, and a guard that every entry in the list is a well-formed 32-character hex space id (a typo would otherwise silently match nobody).
- `fetch-curator-leaderboard.test.ts` — new, driving the fetcher end to end with the query layer stubbed by label: excluded curator absent from rows even when they out-publish everyone, not counted in `activeCurators`, excluded whether they arrived via rankings or votes, no profile fetched for them, no self-row, plus two controls (space-wide totals unchanged, ordinary viewer still gets their row).
- Confirmed the tests aren't vacuous: with the filter disabled, the five exclusion cases fail and the three controls still pass.
- `bun run vitest run core partials app` → 261 files / 2616 tests pass.
- `NEXT_PUBLIC_CHAIN_ID=55516 bun run build` → clean.

Not verified in a running browser — the space id is one I can't check the identity of, so worth confirming the right account disappears from the board.