### PR TITLE
fix: give the Comments overlay the entity side panel's width

### DIFF
--- a/apps/web/partials/comments/entity-comments-panel.test.tsx
+++ b/apps/web/partials/comments/entity-comments-panel.test.tsx
@@ -4,6 +4,7 @@ import { cleanup, fireEvent, render } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { EntityCommentsPanel } from './entity-comments-panel';
+import { SIDE_PANEL_WIDTH_CLASS } from '~/partials/side-panel-layout';
 
 vi.mock('~/core/hooks/use-comments', () => ({
   useComments: () => ({ comments: [], totalCount: 3, isLoading: false, error: null, refetch: vi.fn() }),
@@ -48,5 +49,35 @@ describe('EntityCommentsPanel', () => {
     fireEvent.keyDown(window, { key: 'Escape', isComposing: true });
 
     expect(onClose).not.toHaveBeenCalled();
+  });
+});
+
+const DOCKED_WIDTH_CLASS = 'w-[360px]';
+
+function renderPanelForWidth(presentation: 'docked' | 'overlay') {
+  const { container } = render(
+    <EntityCommentsPanel entityId="entity-1" spaceId="space-1" onClose={vi.fn()} presentation={presentation} />
+  );
+  return container.querySelector('aside') as HTMLElement;
+}
+
+describe('EntityCommentsPanel width', () => {
+  it('matches the entity side panel when it is an overlay', () => {
+    // Both are right-edge panels reachable from the same places, so a width difference
+    // reads as a bug. Asserted against the shared constant rather than a pasted value,
+    // so this stays true if that width is ever retuned.
+    const panel = renderPanelForWidth('overlay');
+
+    expect([...panel.classList]).toContain(SIDE_PANEL_WIDTH_CLASS);
+    expect([...panel.classList]).not.toContain(DOCKED_WIDTH_CLASS);
+  });
+
+  it('keeps the narrower column width when docked in the debates feed', () => {
+    // Docked it sits beside JoinDebatePanel and DebateClaimsPanel, which are 360px.
+    // Widening it to the overlay width here would squeeze the debate players.
+    const panel = renderPanelForWidth('docked');
+
+    expect([...panel.classList]).toContain(DOCKED_WIDTH_CLASS);
+    expect([...panel.classList]).not.toContain(SIDE_PANEL_WIDTH_CLASS);
   });
 });

--- a/apps/web/partials/comments/entity-comments-panel.tsx
+++ b/apps/web/partials/comments/entity-comments-panel.tsx
@@ -10,6 +10,7 @@ import { Close } from '~/design-system/icons/close';
 import { Text } from '~/design-system/text';
 
 import { CommentSection } from '~/partials/comments/comments-section';
+import { SIDE_PANEL_WIDTH_CLASS } from '~/partials/side-panel-layout';
 
 /**
  * "Comments" side panel for any entity. It hosts the same CommentSection entity
@@ -53,11 +54,17 @@ export function EntityCommentsPanel({
     <aside
       data-entity-comments-panel
       className={cx(
-        'flex w-[360px] shrink-0 flex-col border-l border-divider bg-white',
+        'flex shrink-0 flex-col border-l border-divider bg-white',
         'md:fixed md:inset-x-0 md:top-auto md:bottom-0 md:z-[80] md:h-[85dvh] md:w-full md:rounded-t-[16px] md:border-t md:border-l-0',
-        // Above the page but below the entity side panel (z-200), which can be
-        // opened on top of it from a comment author's name.
-        presentation === 'overlay' && 'shadow-2xl fixed inset-y-0 right-0 z-[150] md:inset-y-auto'
+        // Docked, it's one column in the debates feed's row, so it matches its
+        // siblings there (JoinDebatePanel, DebateClaimsPanel) at 360px.
+        presentation === 'docked' && 'w-[360px]',
+        // As an overlay it's the same kind of right-edge panel as the entity side
+        // panel and opens in the same places, so it shares that panel's width.
+        // Above the page but below it at z-200, since that one can open on top of
+        // this from a comment author's name.
+        presentation === 'overlay' &&
+          cx(SIDE_PANEL_WIDTH_CLASS, 'shadow-2xl fixed inset-y-0 right-0 z-[150] md:inset-y-auto')
       )}
     >
       <header className="flex items-center justify-between px-5 py-4">

--- a/apps/web/partials/entity-page/entity-side-panel.tsx
+++ b/apps/web/partials/entity-page/entity-side-panel.tsx
@@ -43,6 +43,7 @@ import { Text } from '~/design-system/text';
 import { EntityPageBody } from '~/partials/entity-page/entity-page-body';
 import { useEntityPageSurfaceData } from '~/partials/entity-page/hooks/use-entity-page-surface-data';
 import { NavbarBreadcrumb } from '~/partials/navbar/navbar-breadcrumb';
+import { SIDE_PANEL_WIDTH_CLASS } from '~/partials/side-panel-layout';
 
 import {
   createPostFlowAtom,
@@ -544,7 +545,8 @@ export function EntitySidePanel() {
       ref={panelHostRef}
       data-entity-side-panel
       className={cx(
-        'rounded-l-2xl shadow-2xl fixed inset-y-0 right-0 flex w-[min(600px,100vw)] shrink-0 flex-col overflow-hidden border-l border-grey-02 bg-white',
+        SIDE_PANEL_WIDTH_CLASS,
+        'rounded-l-2xl shadow-2xl fixed inset-y-0 right-0 flex shrink-0 flex-col overflow-hidden border-l border-grey-02 bg-white',
         isReviewOpen ? 'z-[10001]' : 'z-[200]'
       )}
     >

--- a/apps/web/partials/side-panel-layout.ts
+++ b/apps/web/partials/side-panel-layout.ts
@@ -1,0 +1,12 @@
+/**
+ * Width of a right-edge side panel — the entity side panel and the Comments panel
+ * in its overlay presentation. They open in the same places (a comment button on an
+ * entity row, then an author's name from inside that panel), so a viewer sees them
+ * as the same surface and any difference in width reads as a bug.
+ *
+ * Shared as a constant rather than repeated so the two can't drift apart again.
+ * Note this is the overlay width only: docked in the debates feed, the Comments
+ * panel is a column beside JoinDebatePanel and DebateClaimsPanel and matches those
+ * at 360px instead.
+ */
+export const SIDE_PANEL_WIDTH_CLASS = 'w-[min(600px,100vw)]';


### PR DESCRIPTION
The Comments panel was `w-[360px]` while the entity side panel is `w-[min(600px,100vw)]`. They're both right-edge panels and they open in the same places — a comment button on an entity row, and then a comment author's name opens the entity side panel *on top of* the Comments panel — so the size jump between them read as a layout glitch.

## Scoped to the overlay presentation

`EntityCommentsPanel` has two presentations, and only one of them is comparable to the entity side panel:

- **`overlay`** (`EntityCommentsPanelHost`, for comment buttons anywhere in the app) — pinned to the right edge above the page. **This is the one that now matches, at 600px.**
- **`docked`** (the debates feed) — a flex sibling taking its own column, beside `JoinDebatePanel` and `DebateClaimsPanel`, both of which are `w-[360px]`. **Left at 360px**, since widening it there would break alignment with its actual neighbours and squeeze the debate players.

The width had to move into the per-presentation branch rather than being overridden — two `w-*` utilities of equal specificity resolve by stylesheet order, not by `cx()` argument order, so an override would have been unreliable.

## Shared rather than duplicated

The value lives in `partials/side-panel-layout.ts` as `SIDE_PANEL_WIDTH_CLASS`, imported by both panels, so "these two match" is enforced rather than a coincidence that a future edit can quietly undo. There's existing precedent for `*_CLASS` Tailwind constants in the codebase (`ranking-list-view.tsx`, `ranking-period-metadata.tsx`), and Tailwind v4's auto source detection picks up `.ts` files — verified below, since a missed scan would have silently dropped the width from both panels.

## Testing

- Measured in the running app: the Comments overlay renders at exactly **600px**, flush to the right edge. This also confirms the class is generated from the constant rather than only from the literals still in the two ranking-compose panels.
- Two new tests in `entity-comments-panel.test.tsx` pin both presentations — overlay carries the shared constant and not the docked width, docked the reverse. Asserted against the imported constant, so they stay correct if the width is ever retuned. Verified they fail if the overlay is put back to 360px.
- `vitest run partials/comments` — 10 passing, including the three existing Escape-handling tests, untouched.
- `bun run build` clean.

`partials/entity-page/personal-profile-create-post-side-panel-sync.test.tsx` fails locally with `TypeError: _a2.getItem is not a function` — the known jotai `atomWithStorage`/jsdom issue. It's unrelated to this diff and fails the same way on branches that don't touch it.

## Not changed

Two other right-edge panels use the same literal and could adopt the constant: `ranking-compose-create-entity-panel.tsx` and `ranking-compose-entity-sheet.tsx`. I left them out to keep this diff to the two panels you asked about — happy to fold them in if you'd like the constant to cover every case.

The two panels also still differ in trim: the entity side panel has `rounded-l-2xl` and `border-grey-02`, the Comments overlay is square-edged with `border-divider`. That's beyond "match the width", so I didn't touch it, but say the word if you want them fully aligned.