### PR TITLE
fix(claims): show claim controls for claims listed from another space

### DIFF
--- a/apps/web/partials/blocks/table/table-block-bulleted-list-item.tsx
+++ b/apps/web/partials/blocks/table/table-block-bulleted-list-item.tsx
@@ -149,7 +149,8 @@ export function TableBlockBulletedListItem({
             </Link>
           </CollectionMetadata>
         )}
-        <EntityRowActions entityId={rowEntityId} spaceId={currentSpaceId} className="mt-1" />
+        {/* The entity's own space, not the block's — see the note in table-block-list-item. */}
+        <EntityRowActions entityId={rowEntityId} spaceId={nameCell?.space ?? currentSpaceId} className="mt-1" />
       </div>
       <div className="flex h-[1.8125rem] shrink-0 items-center gap-1 md:hidden">
         {!isPlaceholder && source.type !== 'COLLECTION' && (

--- a/apps/web/partials/blocks/table/table-block-list-item-space.test.tsx
+++ b/apps/web/partials/blocks/table/table-block-list-item-space.test.tsx
@@ -1,0 +1,110 @@
+import { SystemIds } from '@geoprotocol/geo-sdk/lite';
+import '@testing-library/jest-dom/vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+
+import type React from 'react';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { Cell } from '~/core/types';
+
+import { TableBlockBulletedListItem } from './table-block-bulleted-list-item';
+import { TableBlockListItem } from './table-block-list-item';
+
+/**
+ * The list and bulleted-list halves of GEO-2581, which fixed the table and gallery views only.
+ *
+ * A data block lists rows drawn from many spaces, so a row's entity does not necessarily live in
+ * the block's space. `EntityRowActions` forwards its `spaceId` to two things that care: the Debate
+ * button, which sends it to geo-chat (rejected as `claim_not_in_space`, surfaced as "Connection
+ * failed"), and the claim response controls, which read the claim's response kind out of it.
+ *
+ * Every other space-scoped prop in both components already resolves `nameCell?.space` first — the
+ * href, the side-panel button, the collection metadata. The actions row was the lone exception.
+ */
+vi.mock('~/partials/entity-page/entity-row-actions', () => ({
+  EntityRowActions: ({ entityId, spaceId }: { entityId: string; spaceId: string }) => (
+    <div data-testid="row-actions" data-entity-id={entityId} data-space-id={spaceId} />
+  ),
+}));
+
+vi.mock('~/core/sync/use-mutate', () => ({ useMutate: () => ({ storage: {} }) }));
+vi.mock('~/core/hooks/use-block-main-media-url', () => ({
+  useBlockMainMediaUrl: () => ({ url: null, isResolving: false }),
+}));
+vi.mock('~/core/sync/use-store', () => ({ useSpaceAwareValue: () => null, useQueryEntity: () => ({ entity: null }) }));
+
+vi.mock('~/design-system/prefetch-link', () => ({
+  PrefetchLink: ({ children, href }: { children: React.ReactNode; href: string }) => <a href={href}>{children}</a>,
+}));
+vi.mock('~/design-system/select-entity', () => ({ SelectEntity: () => null }));
+vi.mock('~/design-system/editable-fields/editable-fields', () => ({
+  PageStringField: () => null,
+  BlockImageField: () => null,
+}));
+vi.mock('~/design-system/geo-image', () => ({ GeoImage: () => null, DEFAULT_IMAGE_SIZES: '' }));
+vi.mock('next/image', () => ({ default: () => null }));
+
+vi.mock('~/partials/blocks/table/data-block-open-side-panel-button', () => ({
+  DataBlockOpenSidePanelButton: () => null,
+}));
+vi.mock('~/partials/blocks/table/collection-row-actions', () => ({ CollectionRowActions: () => null }));
+vi.mock('~/partials/blocks/table/collection-metadata', () => ({
+  CollectionMetadata: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+}));
+vi.mock('~/partials/blocks/table/edit-mode-name-field', () => ({ EditModeNameField: () => null }));
+vi.mock('./table-block-property-field', () => ({ TableBlockPropertyField: () => null }));
+
+afterEach(cleanup);
+
+const BLOCK_SPACE = 'cc31e40f74231d530f1b5d0fc1cd94d8'; // The space whose page shows the block
+const CLAIM_SPACE = '41e851610e13a19441c4d980f2f2ce6b'; // Where the claim was actually published
+
+function nameColumn(nameCell: Partial<Cell>) {
+  return { [SystemIds.NAME_PROPERTY]: { propertyId: SystemIds.NAME_PROPERTY, ...nameCell } } as Record<string, Cell>;
+}
+
+const renderListItem = (nameCell: Partial<Cell>) =>
+  render(
+    <TableBlockListItem
+      columns={nameColumn(nameCell)}
+      currentSpaceId={BLOCK_SPACE}
+      isEditing={false}
+      rowEntityId="entity-1"
+      onChangeEntry={() => {}}
+      onLinkEntry={() => {}}
+      isPlaceholder={false}
+      source={{ type: 'GEO' }}
+    />
+  );
+
+const renderBulletedItem = (nameCell: Partial<Cell>) =>
+  render(
+    <TableBlockBulletedListItem
+      columns={nameColumn(nameCell)}
+      currentSpaceId={BLOCK_SPACE}
+      isEditing={false}
+      rowEntityId="entity-1"
+      onChangeEntry={() => {}}
+      onLinkEntry={() => {}}
+      isPlaceholder={false}
+      source={{ type: 'GEO' }}
+    />
+  );
+
+describe.each([
+  ['TableBlockListItem', renderListItem],
+  ['TableBlockBulletedListItem', renderBulletedItem],
+])('%s row actions space', (_name, renderItem) => {
+  it("passes the entity's own space, not the block's", () => {
+    renderItem({ space: CLAIM_SPACE, name: 'AGI development should be paused.' } as Partial<Cell>);
+
+    expect(screen.getByTestId('row-actions')).toHaveAttribute('data-space-id', CLAIM_SPACE);
+  });
+
+  it("falls back to the block's space when the row's cell carries none", () => {
+    renderItem({ name: 'AGI development should be paused.' } as Partial<Cell>);
+
+    expect(screen.getByTestId('row-actions')).toHaveAttribute('data-space-id', BLOCK_SPACE);
+  });
+});

--- a/apps/web/partials/blocks/table/table-block-list-item.tsx
+++ b/apps/web/partials/blocks/table/table-block-list-item.tsx
@@ -344,7 +344,11 @@ export function TableBlockListItem({
             );
           })}
           <div className="mt-1 flex items-center justify-between gap-2">
-            <EntityRowActions entityId={rowEntityId} spaceId={currentSpaceId} />
+            {/* The entity's own space, not the block's — a data block lists rows from many
+                spaces, and both the claim controls and the Debate button are scoped by it
+                (GEO-2581). Every other space-bearing prop in this file already resolves it the
+                same way. */}
+            <EntityRowActions entityId={rowEntityId} spaceId={nameCell?.space ?? currentSpaceId} />
             {!isPlaceholder && (
               <div className="invisible flex items-center opacity-0 transition duration-200 group-focus-within:visible group-focus-within:opacity-100 group-hover:visible group-hover:opacity-100 md:hidden [&_button]:h-5 [&_button]:w-5">
                 {source.type === 'COLLECTION' ? (

--- a/apps/web/partials/entity-page/entity-vote-buttons.claim-space.test.tsx
+++ b/apps/web/partials/entity-page/entity-vote-buttons.claim-space.test.tsx
@@ -1,0 +1,188 @@
+import { SystemIds } from '@geoprotocol/geo-sdk/lite';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import '@testing-library/jest-dom/vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+
+import type { ReactNode } from 'react';
+
+import { Effect } from 'effect';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { CLAIM_IS_FACTUAL_PROPERTY_ID, CLAIM_TYPE_ID } from '~/core/claims/ontology';
+
+import { EntityVoteButtons } from './entity-vote-buttons';
+
+/**
+ * A claim shown outside the space it was published to — a data block row, a ranking entry — used to
+ * draw curation arrows while the Debate button sat next to it, because the two read claim-ness from
+ * different places. `store.getEntity` filters `relations` to the space asked for but derives `types`
+ * from all of them, so scoping the lookup to the collecting space hid the Types relation entirely.
+ */
+const BLOCK_SPACE = 'cc31e40f74231d530f1b5d0fc1cd94d8';
+const CLAIM_SPACE = '41e851610e13a19441c4d980f2f2ce6b';
+
+const mocks = vi.hoisted(() => ({
+  entity: null as unknown,
+  queryEntityOptions: [] as Record<string, unknown>[],
+}));
+
+vi.mock('@geogenesis/auth', () => ({ useGeoLogin: () => ({ login: vi.fn() }) }));
+
+vi.mock('~/core/analytics', () => ({
+  downvoted: vi.fn(),
+  trackPrivyAuth: vi.fn(),
+  upvoted: vi.fn(),
+  voteCast: vi.fn(),
+}));
+
+vi.mock('~/core/hooks/use-entity-vote', () => ({
+  useEntityResponse: () => ({
+    submitResponse: vi.fn(),
+    optimisticResponse: undefined,
+    isResponseIndexingDelayed: false,
+    isConnected: true,
+    personalSpaceId: 'profile-1',
+  }),
+}));
+
+vi.mock('~/core/hooks/use-personal-space-id', () => ({
+  usePersonalSpaceId: () => ({ personalSpaceId: 'profile-1', isRegistered: true, isLoading: false }),
+}));
+
+vi.mock('~/core/hooks/use-smart-account', () => ({ useSmartAccount: () => ({ smartAccount: null }) }));
+
+vi.mock('~/core/io/queries', () => ({
+  getClaimResponseSummaryPage: () => Effect.succeed([]),
+  // Two up, one down: a curation score reads "1", a claim percentage reads "67%".
+  getEntityResponseCounts: () => Effect.succeed({ positive: 2, negative: 1 }),
+  getEntityResponders: () => Effect.succeed([]),
+  getSpaces: () => Effect.succeed([]),
+  getUserEntityResponse: () => Effect.succeed(null),
+}));
+
+vi.mock('~/core/io/subgraph/fetch-profile', () => ({ fetchProfilesBySpaceIds: () => Effect.succeed([]) }));
+
+vi.mock('~/core/state/pending-personal-space', () => ({
+  usePendingPersonalSpace: () => ({ isPending: false }),
+}));
+
+/**
+ * Stands in for `store.getEntity`, including the filtering that caused the bug: `relations` and
+ * `values` are narrowed to the space asked for, while the entity itself carries every space's. A
+ * mock that ignored `spaceId` would pass whether or not the component scopes its lookup.
+ */
+vi.mock('~/core/sync/use-store', () => ({
+  useQueryEntity: (options: Record<string, unknown>) => {
+    mocks.queryEntityOptions.push(options);
+
+    const entity = mocks.entity as {
+      relations: { spaceId: string }[];
+      values: { spaceId: string }[];
+    } | null;
+
+    if (!entity) return { entity: null, isLoading: false };
+
+    const spaceId = options.spaceId as string | undefined;
+    if (!spaceId) return { entity, isLoading: false };
+
+    return {
+      entity: {
+        ...entity,
+        relations: entity.relations.filter(relation => relation.spaceId === spaceId),
+        values: entity.values.filter(value => value.spaceId === spaceId),
+      },
+      isLoading: false,
+    };
+  },
+}));
+
+vi.mock('~/partials/entity-page/claim-voter-avatars', () => ({ ClaimResponderAvatars: () => null }));
+
+/**
+ * As `store.getEntity` returns it when no space is given: relations from every space the entity
+ * lives in, so the Types relation is present whichever space the caller happens to be rendering.
+ */
+function claimEntity({ isFactualIn }: { isFactualIn?: string } = {}) {
+  return {
+    id: 'claim-1',
+    name: 'AGI development should be paused.',
+    relations: [
+      {
+        type: { id: SystemIds.TYPES_PROPERTY },
+        toEntity: { id: CLAIM_TYPE_ID },
+        spaceId: CLAIM_SPACE,
+        isDeleted: false,
+      },
+    ],
+    values: isFactualIn
+      ? [{ property: { id: CLAIM_IS_FACTUAL_PROPERTY_ID }, spaceId: isFactualIn, value: '1', isDeleted: false }]
+      : [],
+  };
+}
+
+function renderButtons() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(<EntityVoteButtons entityId="claim-1" spaceId={BLOCK_SPACE} />, {
+    wrapper: ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    ),
+  });
+}
+
+beforeEach(() => {
+  mocks.entity = null;
+  mocks.queryEntityOptions.length = 0;
+});
+
+afterEach(cleanup);
+
+describe('EntityVoteButtons claim detection across spaces', () => {
+  // The reported bug: claims collected into another space rendered the curation arrows.
+  it('treats an entity as a claim when its Types relation lives in another space', async () => {
+    mocks.entity = claimEntity();
+    renderButtons();
+
+    // The claim controls show agreement as a percentage; curation shows a net score.
+    expect(await screen.findByText('67%')).toBeInTheDocument();
+    expect(screen.queryByText('1')).not.toBeInTheDocument();
+  });
+
+  // Scoping the lookup is what hid the relation, so the absence of a space is the fix itself.
+  it('does not scope the entity lookup to the space it was asked to respond in', () => {
+    mocks.entity = claimEntity();
+    renderButtons();
+
+    expect(mocks.queryEntityOptions.at(-1)).not.toHaveProperty('spaceId');
+  });
+
+  // An ordinary entity is still an ordinary entity — the widened lookup must not turn everything
+  // into a claim.
+  it('leaves a non-claim entity on the curation controls', async () => {
+    mocks.entity = { id: 'entity-1', name: 'Something else', relations: [], values: [] };
+    renderButtons();
+
+    expect(await screen.findByText('1')).toBeInTheDocument();
+    expect(screen.queryByText('67%')).not.toBeInTheDocument();
+  });
+
+  // Which *kind* of claim response is asked for stays a per-space question: the space passed in is
+  // the one being responded in, and "Is factual" is a per-space value.
+  it('reads the factual flag from the space it was asked to respond in', async () => {
+    mocks.entity = claimEntity({ isFactualIn: BLOCK_SPACE });
+    const view = renderButtons();
+
+    await screen.findByText('67%');
+    // Veracity draws chevrons, which are the only 16x16 icons among the response controls.
+    const icons = [...view.container.querySelectorAll('svg')];
+    expect(icons.some(icon => icon.getAttribute('viewBox') === '0 0 16 16')).toBe(true);
+  });
+
+  it('ignores a factual flag set in a space other than the one being responded in', async () => {
+    mocks.entity = claimEntity({ isFactualIn: CLAIM_SPACE });
+    const view = renderButtons();
+
+    await screen.findByText('67%');
+    const icons = [...view.container.querySelectorAll('svg')];
+    expect(icons.some(icon => icon.getAttribute('viewBox') === '0 0 16 16')).toBe(false);
+  });
+});

--- a/apps/web/partials/entity-page/entity-vote-buttons.tsx
+++ b/apps/web/partials/entity-page/entity-vote-buttons.tsx
@@ -76,9 +76,18 @@ export function EntityVoteButtons({
   presentation = 'inline',
 }: EntityVoteButtonsProps) {
   const responseBatch = useClaimResponseBatchState();
+  // Deliberately unscoped by space. `store.getEntity` filters `relations` to the space asked for
+  // but derives `types` from all of them, so a claim collected into another space — a data block
+  // row, a ranking entry — has its Types relation only in the space it was published to. Asking
+  // for that other space returned an entity with no Types relation at all, so this read it as a
+  // plain entity and drew curation arrows, while `ClaimDebateButton` reads `types` and drew the
+  // Debate toggle beside it. One claim, two controls disagreeing about what it was.
+  //
+  // Space still decides the *kind* of response, just not whether there is one: the checks below
+  // and `hasUnpublishedClaimResponseKindEdit` each re-filter to `spaceId` themselves, so widening
+  // the query leaves them reading exactly what they read before.
   const { entity, isLoading: isLoadingEntity } = useQueryEntity({
     id: entityId,
-    spaceId,
     includeDeleted: true,
     enabled: responseKindOverride === undefined,
   });
@@ -442,11 +451,11 @@ function DebateVotePill({
         disabled={disabled}
         title={positiveTitle}
         onClick={onPositive}
-        className="group/vote flex items-center justify-center text-grey-04 transition-colors hover:text-text aria-pressed:text-ctaPrimary disabled:cursor-default disabled:opacity-50"
+        className="group/vote flex items-center justify-center text-grey-04 transition-colors hover:text-text disabled:cursor-default disabled:opacity-50 aria-pressed:text-ctaPrimary"
       >
         <VoteArrow direction="up" filled={positiveActive} color={positiveActive ? 'ctaPrimary' : undefined} />
       </button>
-      <span className="text-metadataMedium tabular-nums text-text">{score}</span>
+      <span className="text-metadataMedium text-text tabular-nums">{score}</span>
       <button
         type="button"
         aria-label={negativeTitle}
@@ -454,7 +463,7 @@ function DebateVotePill({
         disabled={disabled}
         title={negativeTitle}
         onClick={onNegative}
-        className="group/vote flex items-center justify-center text-grey-04 transition-colors hover:text-text aria-pressed:text-red-01 disabled:cursor-default disabled:opacity-50"
+        className="group/vote flex items-center justify-center text-grey-04 transition-colors hover:text-text disabled:cursor-default disabled:opacity-50 aria-pressed:text-red-01"
       >
         <VoteArrow direction="down" filled={negativeActive} color={negativeActive ? 'red-01' : undefined} />
       </button>


### PR DESCRIPTION
## The bug

Claims listed in a data block drew the old curation arrows — with the **Debate toggle sitting right beside them**. One claim, two controls disagreeing about what it was.

Reported on [Arturas's Positions tab](https://www.geobrowser.io/space/cc31e40f74231d530f1b5d0fc1cd94d8?tabId=5d7fa1e5876942d0864d41ed4a3baf47).

## Why

`store.getEntity` treats the two halves of an entity differently:

```ts
const types = readTypes(relations);                      // every space
...
relations: relations.filter(r => options.spaceId ? r.spaceId === options.spaceId : true),  // one space
```

`ClaimDebateButton` reads `entity.types`, so it saw a claim. `EntityVoteButtons` re-derives claim-ness from `entity.relations` **and** scoped its lookup to the space being responded in, so it saw a plain entity and fell back to `curation`.

Those two agree only while a claim is read in the space it was published to. Confirmed against the API for the claim in the screenshot:

| | space |
|---|---|
| `Types → Claim` relation | `41e85161…` only |
| Name value | `41e85161…` |
| Arturas's space `cc31e40f…` holds | a `Score` value |

Enough to list the row, not enough to recognise it as a claim.

## The fix

**1. The response lookup is no longer scoped by space.** Which *kind* of response is offered stays per-space, since "Is factual" is a per-space value — that check and `hasUnpublishedClaimResponseKindEdit` each re-filter to `spaceId` themselves, so widening the query leaves them reading exactly what they read before. Only claim-*ness* becomes space-agnostic, which is what `types` already was.

**2. The list and bulleted-list rows forwarded the block's space to their row actions.** GEO-2581 (#2163) fixed exactly this in the table and gallery views and missed these two; every other space-bearing prop in both files already resolves `nameCell?.space ?? currentSpaceId`. Besides the response kind, this is what the Debate button sends to geo-chat, which rejects a claim not in the space given (`claim_not_in_space`, surfaced as "Connection failed") — so these two views were still hitting the bug #2163 was written to fix.

## Testing

- `entity-vote-buttons.claim-space.test.tsx` — new: a claim whose Types relation lives in another space renders claim controls (agreement %) rather than curation (net score); the lookup carries no `spaceId`; a non-claim still renders curation; and the factual flag is read from the space being responded in, not from any space.
- `table-block-list-item-space.test.tsx` — new, both views: the row's own space is forwarded, with the block's space as fallback when the cell carries none. Mirrors `table-block-gallery-item-space.test.tsx` from #2163.
- Both suites verified non-vacuous by reverting each half: 4 of 5 claim-space cases fail without the widened lookup, and both "own space" cases fail without the call-site fix.
  - Worth noting: my first version of the entity mock ignored `spaceId` and so passed under sabotage. It now emulates `store.getEntity`'s filtering, which is the contract that caused the bug.
- `bun run vitest run core partials app` → 265 files / 2667 tests pass.
- `NEXT_PUBLIC_CHAIN_ID=55516 bun run build` → clean.

Not verified in a running browser. The claim in the screenshot has no "Is factual" value in either space, so it should land on Agree/Disagree; worth confirming a Verify/Dispute claim renders chevrons when listed from elsewhere too.