### PR TITLE
fix: read entity names from the highest-ranked space

### DIFF
--- a/apps/web/core/io/dto/entities.test.ts
+++ b/apps/web/core/io/dto/entities.test.ts
@@ -1,3 +1,5 @@
+import { SystemIds } from '@geoprotocol/geo-sdk/lite';
+
 import { describe, expect, it, vi } from 'vitest';
 
 import { SCORE_SYSTEM_PROPERTY } from '~/core/constants';
@@ -63,5 +65,95 @@ describe('EntityDtoLive', () => {
     });
 
     expect(EntityDtoLive(remoteEntity).spaces).toEqual([]);
+  });
+});
+
+/**
+ * The Root space names entity `e4e366e9…` "Role"; a downstream space names the same entity
+ * "Person role". The API's own `name` handed back the downstream one, which is what a proposal
+ * diff in the Root space ended up showing for the type being added.
+ */
+describe('EntityDtoLive names', () => {
+  const ROOT_SPACE = 'a19c345ab9866679b001d7d2138d88a1';
+  const BASEBALL_SPACE = '7570a0ba7552e6806e0751c2ad105754';
+  const NAME_PROPERTY = SystemIds.NAME_PROPERTY;
+
+  function nameValue(spaceId: string, text: string) {
+    return {
+      spaceId,
+      property: {
+        id: NAME_PROPERTY,
+        name: 'Name',
+        dataTypeId: null,
+        dataTypeName: null,
+        renderableTypeId: null,
+        renderableTypeName: null,
+        format: null,
+        isType: null,
+      },
+      text,
+      integer: null,
+      float: null,
+      boolean: null,
+      point: null,
+      time: null,
+      language: null,
+      unit: null,
+      datetime: null,
+      date: null,
+      decimal: null,
+      schedule: null,
+      embedding: null,
+    };
+  }
+
+  it('reads the name from the highest-ranked space rather than the API default', () => {
+    const decoded = EntityDtoLive(
+      entity({
+        name: 'Person role',
+        spaceIds: [ROOT_SPACE, BASEBALL_SPACE],
+        valuesList: [nameValue(BASEBALL_SPACE, 'Person role'), nameValue(ROOT_SPACE, 'Role')],
+      })
+    );
+
+    expect(decoded.name).toBe('Role');
+  });
+
+  it('does not depend on the order the API returns the names in', () => {
+    const decoded = EntityDtoLive(
+      entity({
+        name: 'Person role',
+        spaceIds: [ROOT_SPACE, BASEBALL_SPACE],
+        valuesList: [nameValue(ROOT_SPACE, 'Role'), nameValue(BASEBALL_SPACE, 'Person role')],
+      })
+    );
+
+    expect(decoded.name).toBe('Role');
+  });
+
+  // A space-scoped query returns only that space's values, so scoped reads are unchanged.
+  it('keeps a space-scoped name when that is all the query asked for', () => {
+    const decoded = EntityDtoLive(
+      entity({
+        name: 'Person role',
+        spaceIds: [BASEBALL_SPACE],
+        valuesList: [nameValue(BASEBALL_SPACE, 'Person role')],
+      })
+    );
+
+    expect(decoded.name).toBe('Person role');
+  });
+
+  // Plenty of queries don't ask for values at all; those keep the only answer available.
+  it('falls back to the API name when no values were fetched', () => {
+    const decoded = EntityDtoLive(entity({ name: 'Person role', valuesList: [] }));
+
+    expect(decoded.name).toBe('Person role');
+  });
+
+  it('leaves an unnamed entity unnamed', () => {
+    const decoded = EntityDtoLive(entity({ name: null, valuesList: [] }));
+
+    expect(decoded.name).toBeNull();
   });
 });

--- a/apps/web/core/io/dto/entities.ts
+++ b/apps/web/core/io/dto/entities.ts
@@ -1,6 +1,6 @@
-import { hasRelationTarget, RelationDtoLive } from '~/core/io/dto/relations';
+import { RelationDtoLive, hasRelationTarget } from '~/core/io/dto/relations';
 import { Entity } from '~/core/types';
-import { spacesFromRoutingProjections } from '~/core/utils/entity/entities';
+import { name as nameFromValues, spacesFromRoutingProjections } from '~/core/utils/entity/entities';
 import { sortSpaceIdsByRank } from '~/core/utils/space/space-ranking';
 
 import { RemoteEntity } from '../schema';
@@ -27,9 +27,17 @@ export function EntityDtoLive(remoteEntity: RemoteEntity): Entity {
     });
   }
 
+  // An entity can be named differently in every space that touches it, and the API's own `name`
+  // picks one of them for us — for `Role` in the Root space that came back as `Person role`, the
+  // name a downstream space gave it. `nameFromValues` applies the rule the rest of the app uses:
+  // the highest-ranked space wins, with Root at the top. Where the query scoped values to a single
+  // space that resolves to the same name it always did, and where it asked for no values at all
+  // there is nothing to rank, so the API's answer still stands.
+  const rankedName = nameFromValues(values);
+
   return {
     id: remoteEntity.id,
-    name: remoteEntity.name,
+    name: rankedName ?? remoteEntity.name,
     description: remoteEntity.description,
     spaces: sortSpaceIdsByRank(spaceIdsForRouting),
     types: [...remoteEntity.types],


### PR DESCRIPTION
The type being added in [this proposal](https://www.geobrowser.io/space/a19c345ab9866679b001d7d2138d88a1/governance?proposalId=6060b9ef27434f76a989ded81d4ddde7) rendered as **Person role**. That is what a downstream space calls entity `e4e366e9d5554b6892bf7358e824afd2`; Root — and the rest of the app — calls it **Role**.

## What was happening

Confirmed against the API. The entity carries a name per space:

```
name (API's own field): "Person role"
  a19c345a… (Root, rank 0)  → "Role"
  cf0e1133… (unranked)      → "Role"
  7570a0ba… (unranked)      → "Person role"
```

`mapRelationDiff` drops the `toEntityName` the diff endpoint sends, so `postProcessDiffs` collects the id and re-resolves it through `getBatchEntities` → `EntityDtoLive`, which took `remoteEntity.name` — the API's pick, above.

## The fix

`Entities.name` already implements the rule the app uses everywhere else: sort the NAME values by space rank and take the winner, Root first. `EntityDtoLive` now uses it, falling back to the API's `name` when the query fetched no values to rank.

Verified the decoder's own query with `spaceId` unset returns all three names, so the ranking has something to work with on this path.

## Two calls worth reviewing

**I did not restore `toEntityName` from the diff payload**, even though it is right there and would save a round trip. The API scopes that name to the proposal's space — it returns `"Role"` for this Root-space proposal, but the same relation in the downstream space would come back `"Person role"`. Dropping it is what lets the ranking decide, so what looks like an omission in `mapRelationDiff` is load-bearing.

**This is the shared decoder, not a diff-only change.** It is the single place entity names are produced from the API, so the rule now applies consistently. Concretely it only moves names for entities that are named in more than one space *and* fetched without a space scope — a space-scoped query returns just that space's values, so those reads resolve exactly as before. Blast radius is the ambiguous case by construction, but it is worth knowing it is not confined to the diff view. Happy to narrow it to the diff path if you would rather land it small.

## Testing

5 new cases in `entities.test.ts` — ranked over API default, order-independence, scoped queries unchanged, no-values fallback, and an unnamed entity staying unnamed. The first two fail against master.

Full suite green at 265 files / 2679 tests; typecheck, lint and build pass.

Not verified in a browser — I confirmed the data and the resolution path against the API rather than by loading the proposal.