### PR TITLE
fix(debates): route the debate room to the tab the user is looking at

### DIFF
--- a/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
@@ -6,6 +6,7 @@ import { type ComponentPropsWithoutRef, StrictMode } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { Debate, DebateRematchSession } from '~/core/debates/api';
+import type { DebateRoomTakeoverContext } from '~/core/debates/debate-room-ownership';
 import { ExtendedReconnectPolicy } from '~/core/livekit/extended-reconnect-policy';
 
 import { DebateRoomPageClient, isDebateInThankYouPeriod } from './debate-room-page-client';
@@ -52,7 +53,7 @@ const mocks = vi.hoisted(() => ({
   ownershipRequestTakeover: vi.fn(),
   ownershipRelease: vi.fn(),
   ownershipClose: vi.fn(),
-  ownershipTakeoverHandler: null as null | (() => boolean | Promise<boolean>),
+  ownershipTakeoverHandler: null as null | ((context: DebateRoomTakeoverContext) => boolean | Promise<boolean>),
   ownershipCoordinationMode: 'lock-and-broadcast' as 'lock-and-broadcast' | 'lock-only' | 'livekit-fallback',
   useRealRoomOwnership: false,
   deviceChangeHandler: null as null | (() => void),
@@ -303,6 +304,9 @@ beforeEach(() => {
   mocks.clearTimedOutDebateActivity.mockReset();
   mocks.roomOn.mockReset();
   mocks.capture.mockReset();
+  // Tests run as an unfocused tab by default so the auto-takeover-on-focus effect stays quiet;
+  // focused-tab scenarios opt in per test.
+  vi.spyOn(document, 'hasFocus').mockReturnValue(false);
   mocks.ownershipAcquire.mockReset().mockResolvedValue({ acquired: true, waitedForLocalRelease: false });
   mocks.ownershipRequestTakeover.mockReset().mockResolvedValue(true);
   mocks.ownershipRelease.mockReset();
@@ -1332,6 +1336,69 @@ describe('DebateRoomPageClient', () => {
     );
   });
 
+  it('automatically reclaims the debate when the blocked tab is the focused one', async () => {
+    vi.spyOn(document, 'hasFocus').mockReturnValue(true);
+    mocks.ownershipAcquire.mockResolvedValue({ acquired: false, waitedForLocalRelease: false });
+    mocks.debate = {
+      ...readyDebate({ localReady: true, remoteReady: true }),
+      status: 'connecting',
+      connecting_started_at: '2099-07-02T00:00:00.000Z',
+      connecting_deadline_at: '2099-07-02T00:00:10.000Z',
+    };
+
+    render(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
+
+    // No "Continue here" click: the lock race landed the room in another tab while the user is
+    // looking at this one, so the focused tab issues the takeover itself.
+    await waitFor(() => expect(mocks.ownershipRequestTakeover).toHaveBeenCalledOnce());
+    await waitFor(() => expect(mocks.liveKitJoinMutateAsync).toHaveBeenCalledOnce());
+  });
+
+  it('does not auto-reclaim across devices after a duplicate-identity disconnect', async () => {
+    vi.spyOn(document, 'hasFocus').mockReturnValue(true);
+    mocks.debate = {
+      ...readyDebate({ localReady: true, remoteReady: true }),
+      status: 'connecting',
+      connecting_started_at: '2099-07-02T00:00:00.000Z',
+      connecting_deadline_at: '2099-07-02T00:00:10.000Z',
+    };
+
+    render(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
+    await waitFor(() => expect(mocks.markJoinedMutateAsync).toHaveBeenCalled());
+
+    act(() => emitRoomEvent('disconnected', 2));
+
+    // The other participant identity may be the user's phone; evicting it must stay behind the
+    // explicit "Continue here" click even though this tab is focused.
+    expect(await screen.findByText('This debate is active in another tab or device.')).toBeInTheDocument();
+    expect(mocks.ownershipRequestTakeover).not.toHaveBeenCalled();
+  });
+
+  it('does not retry a refused auto-takeover until the tab is refocused', async () => {
+    vi.spyOn(document, 'hasFocus').mockReturnValue(true);
+    mocks.ownershipAcquire.mockResolvedValue({ acquired: false, waitedForLocalRelease: false });
+    mocks.ownershipRequestTakeover.mockResolvedValue(false);
+    mocks.debate = {
+      ...readyDebate({ localReady: true, remoteReady: true }),
+      status: 'connecting',
+      connecting_started_at: '2099-07-02T00:00:00.000Z',
+      connecting_deadline_at: '2099-07-02T00:00:10.000Z',
+    };
+
+    render(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
+    await waitFor(() => expect(mocks.ownershipRequestTakeover).toHaveBeenCalledOnce());
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    // A refusal must not spin: the next attempt waits for a real focus transition.
+    expect(mocks.ownershipRequestTakeover).toHaveBeenCalledOnce();
+    expect(mocks.liveKitJoinMutateAsync).not.toHaveBeenCalled();
+
+    act(() => {
+      window.dispatchEvent(new Event('focus'));
+    });
+    await waitFor(() => expect(mocks.ownershipRequestTakeover).toHaveBeenCalledTimes(2));
+  });
+
   it('keeps takeover available during a preflight ownership conflict', async () => {
     const now = Date.parse('2026-07-02T00:00:05.000Z');
     vi.spyOn(Date, 'now').mockReturnValue(now);
@@ -1369,7 +1436,9 @@ describe('DebateRoomPageClient', () => {
     render(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
     await waitFor(() => expect(mocks.roomConnect).toHaveBeenCalledOnce());
 
-    await expect(Promise.resolve(mocks.ownershipTakeoverHandler?.())).resolves.toBe(true);
+    await expect(
+      Promise.resolve(mocks.ownershipTakeoverHandler?.({ requesterPriority: 2, ownerPriority: 2 }))
+    ).resolves.toBe(true);
     expect(mocks.roomDisconnect).toHaveBeenCalledOnce();
     expect(mocks.capture).toHaveBeenCalledOnce();
     expect(mocks.capture).toHaveBeenCalledWith(
@@ -1422,7 +1491,9 @@ describe('DebateRoomPageClient', () => {
     // must compare against the clock directly instead of trusting the last rendered status.
     now.mockReturnValue(Date.parse('2026-07-02T00:00:11.000Z'));
     monotonicNow.mockReturnValue(3_000);
-    await expect(Promise.resolve(mocks.ownershipTakeoverHandler?.())).resolves.toBe(false);
+    await expect(
+      Promise.resolve(mocks.ownershipTakeoverHandler?.({ requesterPriority: 2, ownerPriority: 2 }))
+    ).resolves.toBe(false);
     expect(mocks.roomDisconnect).not.toHaveBeenCalled();
   });
 
@@ -1561,7 +1632,7 @@ describe('DebateRoomPageClient', () => {
     // emit Disconnected, so the CLIENT_INITIATED from our own room.disconnect() never reaches the
     // handler body — no "Lost connection" error, no drop metric.
     await act(async () => {
-      await mocks.ownershipTakeoverHandler?.();
+      await mocks.ownershipTakeoverHandler?.({ requesterPriority: 2, ownerPriority: 2 });
     });
     mocks.capture.mockClear();
     act(() => emitRoomEvent('disconnected', 1));

--- a/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
@@ -1374,8 +1374,8 @@ describe('DebateRoomPageClient', () => {
     expect(mocks.ownershipRequestTakeover).not.toHaveBeenCalled();
   });
 
-  it('does not retry a refused auto-takeover until the tab is refocused', async () => {
-    vi.spyOn(document, 'hasFocus').mockReturnValue(true);
+  it('does not retry a refused auto-takeover until the tab genuinely loses and regains focus', async () => {
+    const hasFocus = vi.spyOn(document, 'hasFocus').mockReturnValue(true);
     mocks.ownershipAcquire.mockResolvedValue({ acquired: false, waitedForLocalRelease: false });
     mocks.ownershipRequestTakeover.mockResolvedValue(false);
     mocks.debate = {
@@ -1393,10 +1393,49 @@ describe('DebateRoomPageClient', () => {
     expect(mocks.ownershipRequestTakeover).toHaveBeenCalledOnce();
     expect(mocks.liveKitJoinMutateAsync).not.toHaveBeenCalled();
 
+    // Redundant focus/visibilitychange events while the tab never lost focus must not retry —
+    // browsers fire both for a single activation, and a double connect() supersedes itself.
     act(() => {
+      window.dispatchEvent(new Event('focus'));
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+    await new Promise(resolve => setTimeout(resolve, 50));
+    expect(mocks.ownershipRequestTakeover).toHaveBeenCalledOnce();
+
+    // A genuine blur re-arms the attempt; regaining focus retries exactly once even though the
+    // activation fires both events.
+    hasFocus.mockReturnValue(false);
+    act(() => {
+      window.dispatchEvent(new Event('blur'));
+    });
+    hasFocus.mockReturnValue(true);
+    act(() => {
+      document.dispatchEvent(new Event('visibilitychange'));
       window.dispatchEvent(new Event('focus'));
     });
     await waitFor(() => expect(mocks.ownershipRequestTakeover).toHaveBeenCalledTimes(2));
+    await new Promise(resolve => setTimeout(resolve, 50));
+    expect(mocks.ownershipRequestTakeover).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not auto-takeover once the debate is in progress', async () => {
+    vi.spyOn(document, 'hasFocus').mockReturnValue(true);
+    mocks.ownershipAcquire.mockResolvedValue({ acquired: false, waitedForLocalRelease: false });
+    mocks.debate = {
+      ...completedDebate(),
+      status: 'in_progress',
+      completed_at: null,
+    };
+
+    render(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
+
+    // Past preflight the room is (or should be) recording, so the focused duplicate stays on the
+    // dead-end screen rather than pulling a live debate out from under the owner.
+    expect(
+      await screen.findByRole('heading', { name: 'This debate is already open in another tab.' })
+    ).toBeInTheDocument();
+    await new Promise(resolve => setTimeout(resolve, 50));
+    expect(mocks.ownershipRequestTakeover).not.toHaveBeenCalled();
   });
 
   it('keeps takeover available during a preflight ownership conflict', async () => {

--- a/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.tsx
@@ -30,6 +30,7 @@ import {
   type DebateRoomOwnershipCoordinationMode,
   type DebateRoomOwnershipCoordinator,
   createDebateRoomOwnershipCoordinator,
+  debateRoomTabPriority,
 } from '~/core/debates/debate-room-ownership';
 import {
   useAbortDebate,
@@ -259,6 +260,9 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
   // ended by our own teardown (leave, takeover, unmount) close no analytics event, so
   // debate_room_reconnecting counts can exceed the sum of the two closing events.
   const reconnectingStartedAtRef = React.useRef<number | null>(null);
+  // The connection generation whose conflict this tab last tried to auto-resolve, so a refused
+  // takeover doesn't retry on every focus event within the same conflict.
+  const autoTakeoverGenerationRef = React.useRef<number | null>(null);
   const ownershipRef = React.useRef<DebateRoomOwnershipCoordinator | null>(null);
   const connectionInstanceIdRef = React.useRef('uncoordinated');
   const recorderRef = React.useRef<MediaRecorder | null>(null);
@@ -508,13 +512,18 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
     const coordinator = createDebateRoomOwnershipCoordinator({
       debateId,
       userId: currentUserId,
-      onTakeoverRequested: () => {
+      onTakeoverRequested: ({ requesterPriority, ownerPriority }) => {
         const status = debateStatusRef.current;
         const preflightStillPending =
           status === 'preflight' &&
           recordingStartedAtRef.current === null &&
           (preflightEndsAtMsRef.current === null || serverNowRef.current() < preflightEndsAtMsRef.current);
-        const canReleaseOwnership = status === 'connecting' || preflightStillPending;
+        // A focused tab may pull the connection from an unfocused one while nothing has been
+        // recorded yet. Once recording starts the owner keeps the room: releasing would tear down
+        // an in-flight MediaRecorder, which cannot finish persisting inside the takeover budget.
+        const focusHandoff =
+          requesterPriority === 2 && ownerPriority < 2 && recordingStartedAtRef.current === null;
+        const canReleaseOwnership = status === 'connecting' || preflightStillPending || focusHandoff;
         if (!canReleaseOwnership) return false;
 
         const generation = connectionGenerationRef.current + 1;
@@ -1178,6 +1187,34 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
   const takeOverConnection = React.useCallback(() => {
     void connect({ takeover: true });
   }, [connect]);
+
+  // A blocked tab the user focuses reclaims the debate by itself instead of dead-ending on
+  // "already open in another tab" until they find the Continue button. Limited to same-browser
+  // conflict sources: reclaiming across devices (livekit_duplicate_identity) would evict a call
+  // the user may be actively holding on their phone, so that stays behind the explicit click.
+  React.useEffect(() => {
+    if (roomState !== 'idle') return;
+    if (connectionConflictSource !== 'web_lock_blocked' && connectionConflictSource !== 'ownership_released') return;
+    const attemptTakeover = () => {
+      const status = debateStatusRef.current;
+      if (status === null || ['complete', 'cancelled', 'thanking'].includes(status)) return;
+      if (debateRoomTabPriority() !== 2) return;
+      const generation = connectionGenerationRef.current;
+      if (autoTakeoverGenerationRef.current === generation) return;
+      autoTakeoverGenerationRef.current = generation;
+      void connectRef.current({ takeover: true });
+    };
+    window.addEventListener('focus', attemptTakeover);
+    document.addEventListener('visibilitychange', attemptTakeover);
+    // The conflict can land while this tab is already focused (it lost the connect race to a
+    // background tab that navigated earlier); reclaim immediately rather than waiting for a
+    // focus transition that will never come.
+    attemptTakeover();
+    return () => {
+      window.removeEventListener('focus', attemptTakeover);
+      document.removeEventListener('visibilitychange', attemptTakeover);
+    };
+  }, [connectionConflictSource, roomState]);
 
   const toggleAudioMuted = React.useCallback(() => {
     setAudioMuted(current => !current);

--- a/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.tsx
@@ -260,9 +260,13 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
   // ended by our own teardown (leave, takeover, unmount) close no analytics event, so
   // debate_room_reconnecting counts can exceed the sum of the two closing events.
   const reconnectingStartedAtRef = React.useRef<number | null>(null);
-  // The connection generation whose conflict this tab last tried to auto-resolve, so a refused
-  // takeover doesn't retry on every focus event within the same conflict.
-  const autoTakeoverGenerationRef = React.useRef<number | null>(null);
+  // One auto-takeover per focus episode: spent when an attempt fires, re-armed only when the tab
+  // genuinely loses attention (or the conflict resolves). Generation numbers can't dedupe here —
+  // connect() bumps the generation as its first statement, so any recorded value is stale
+  // immediately. The in-flight flag additionally keeps overlapping attempts from superseding each
+  // other's connection generation mid-handshake.
+  const autoTakeoverSpentRef = React.useRef(false);
+  const autoTakeoverInFlightRef = React.useRef(false);
   const ownershipRef = React.useRef<DebateRoomOwnershipCoordinator | null>(null);
   const connectionInstanceIdRef = React.useRef('uncoordinated');
   const recorderRef = React.useRef<MediaRecorder | null>(null);
@@ -521,8 +525,13 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
         // A focused tab may pull the connection from an unfocused one while nothing has been
         // recorded yet. Once recording starts the owner keeps the room: releasing would tear down
         // an in-flight MediaRecorder, which cannot finish persisting inside the takeover budget.
+        // The status gate also protects live debates whose recording never managed to start
+        // (recordingStartedAtRef stays null when MediaRecorder is unavailable).
         const focusHandoff =
-          requesterPriority === 2 && ownerPriority < 2 && recordingStartedAtRef.current === null;
+          requesterPriority === 2 &&
+          ownerPriority < 2 &&
+          recordingStartedAtRef.current === null &&
+          (status === 'connecting' || status === 'preflight');
         const canReleaseOwnership = status === 'connecting' || preflightStillPending || focusHandoff;
         if (!canReleaseOwnership) return false;
 
@@ -1193,26 +1202,47 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
   // conflict sources: reclaiming across devices (livekit_duplicate_identity) would evict a call
   // the user may be actively holding on their phone, so that stays behind the explicit click.
   React.useEffect(() => {
-    if (roomState !== 'idle') return;
-    if (connectionConflictSource !== 'web_lock_blocked' && connectionConflictSource !== 'ownership_released') return;
+    if (
+      roomState !== 'idle' ||
+      (connectionConflictSource !== 'web_lock_blocked' && connectionConflictSource !== 'ownership_released')
+    ) {
+      // The conflict resolved or changed shape; the next episode gets a fresh attempt.
+      autoTakeoverSpentRef.current = false;
+      return;
+    }
     const attemptTakeover = () => {
+      if (autoTakeoverSpentRef.current || autoTakeoverInFlightRef.current) return;
+      // Mirror the "Continue here" button's status gate: past preflight the owner refuses anyway
+      // — or worse, hands over a live debate whose recording never managed to start.
       const status = debateStatusRef.current;
-      if (status === null || ['complete', 'cancelled', 'thanking'].includes(status)) return;
-      if (debateRoomTabPriority() !== 2) return;
-      const generation = connectionGenerationRef.current;
-      if (autoTakeoverGenerationRef.current === generation) return;
-      autoTakeoverGenerationRef.current = generation;
-      void connectRef.current({ takeover: true });
+      if (status !== 'connecting' && status !== 'preflight') return;
+      autoTakeoverSpentRef.current = true;
+      autoTakeoverInFlightRef.current = true;
+      void connectRef.current({ takeover: true }).finally(() => {
+        autoTakeoverInFlightRef.current = false;
+      });
     };
-    window.addEventListener('focus', attemptTakeover);
-    document.addEventListener('visibilitychange', attemptTakeover);
+    const handleAttentionChange = () => {
+      if (debateRoomTabPriority() !== 2) {
+        // Leaving focus re-arms the next attempt; browsers that fire redundant focus or
+        // visibilitychange events while the tab stays focused therefore cannot double-connect.
+        autoTakeoverSpentRef.current = false;
+        return;
+      }
+      attemptTakeover();
+    };
+    window.addEventListener('focus', handleAttentionChange);
+    // A window losing focus to another application fires blur without any visibilitychange.
+    window.addEventListener('blur', handleAttentionChange);
+    document.addEventListener('visibilitychange', handleAttentionChange);
     // The conflict can land while this tab is already focused (it lost the connect race to a
     // background tab that navigated earlier); reclaim immediately rather than waiting for a
     // focus transition that will never come.
-    attemptTakeover();
+    if (debateRoomTabPriority() === 2) attemptTakeover();
     return () => {
-      window.removeEventListener('focus', attemptTakeover);
-      document.removeEventListener('visibilitychange', attemptTakeover);
+      window.removeEventListener('focus', handleAttentionChange);
+      window.removeEventListener('blur', handleAttentionChange);
+      document.removeEventListener('visibilitychange', handleAttentionChange);
     };
   }, [connectionConflictSource, roomState]);
 

--- a/apps/web/core/debates/debate-room-ownership.test.ts
+++ b/apps/web/core/debates/debate-room-ownership.test.ts
@@ -5,6 +5,7 @@ import {
   type DebateRoomTabPriority,
   type DebateRoomTakeoverContext,
   createDebateRoomOwnershipCoordinator,
+  debateRoomTabPriority,
 } from './debate-room-ownership';
 
 type QueuedLock = {
@@ -392,13 +393,54 @@ describe('debate room ownership', () => {
   });
 });
 
+describe('debateRoomTabPriority', () => {
+  function stubVisibility(visibilityState: DocumentVisibilityState, hasFocus: boolean | undefined) {
+    Object.defineProperty(document, 'visibilityState', { configurable: true, value: visibilityState });
+    Object.defineProperty(document, 'hasFocus', {
+      configurable: true,
+      value: hasFocus === undefined ? undefined : () => hasFocus,
+    });
+  }
+
+  afterEach(() => {
+    // Restore the jsdom prototype getters shadowed by the instance properties above.
+    Reflect.deleteProperty(document, 'visibilityState');
+    Reflect.deleteProperty(document, 'hasFocus');
+  });
+
+  it('ranks hidden below visible below focused, and fails open without hasFocus', () => {
+    stubVisibility('hidden', true);
+    expect(debateRoomTabPriority()).toBe(0);
+
+    stubVisibility('visible', false);
+    expect(debateRoomTabPriority()).toBe(1);
+
+    stubVisibility('visible', true);
+    expect(debateRoomTabPriority()).toBe(2);
+
+    // Browsers without hasFocus must claim focus: the worst case is the pre-stagger race, never
+    // a tab that voluntarily delays itself behind everyone else.
+    stubVisibility('visible', undefined);
+    expect(debateRoomTabPriority()).toBe(2);
+  });
+});
+
 describe('focus-weighted acquisition', () => {
+  // Unique per test: the local-release barrier map is module-global and keyed by debateId/userId,
+  // so a mid-stagger close leaking a barrier must not be able to hang the next test.
+  let staggerDebateId = 'debate-stagger-0';
+  let staggerDebateNumber = 0;
+
+  beforeEach(() => {
+    staggerDebateId = `debate-stagger-${++staggerDebateNumber}`;
+  });
+
   function createTab(
     getTabPriority: () => DebateRoomTabPriority,
     onTakeoverRequested: (context: DebateRoomTakeoverContext) => boolean | Promise<boolean> = () => true
   ) {
     return createDebateRoomOwnershipCoordinator({
-      debateId: 'debate-1',
+      debateId: staggerDebateId,
       userId: 'user-a',
       onTakeoverRequested,
       getTabPriority,
@@ -440,7 +482,14 @@ describe('focus-weighted acquisition', () => {
     let priority: DebateRoomTabPriority = 0;
     const tab = createTab(() => priority);
 
+    let settled = false;
     const acquisition = tab.acquire();
+    void acquisition.then(() => {
+      settled = true;
+    });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(settled).toBe(false);
+
     priority = 2;
     window.dispatchEvent(new Event('focus'));
 
@@ -448,6 +497,34 @@ describe('focus-weighted acquisition', () => {
     await expect(acquisition).resolves.toEqual({ acquired: true, waitedForLocalRelease: false });
 
     await closeCoordinators(tab);
+  });
+
+  it('settles a mid-stagger acquire immediately when a takeover arrives', async () => {
+    vi.useFakeTimers();
+    const tab = createTab(() => 0);
+
+    const acquisition = tab.acquire();
+    // No timer advance: the takeover hits the acquisition dedup slot while its 700ms stagger is
+    // pending and must force-settle it rather than inherit the residual delay.
+    await expect(tab.requestTakeover()).resolves.toBe(true);
+    await expect(acquisition).resolves.toEqual({ acquired: true, waitedForLocalRelease: false });
+
+    await closeCoordinators(tab);
+  });
+
+  it('does not make a same-tab successor wait out a predecessor stagger after close', async () => {
+    vi.useFakeTimers();
+    const hidden = createTab(() => 0);
+
+    void hidden.acquire();
+    hidden.close();
+
+    // No timer advance: close() must settle the cancelled stagger so the local-release barrier
+    // resolves now, not 700ms later — a StrictMode remount would otherwise pay the delay twice.
+    const successor = createTab(() => 2);
+    await expect(successor.acquire()).resolves.toEqual({ acquired: true, waitedForLocalRelease: true });
+
+    await closeCoordinators(hidden, successor);
   });
 
   it('does not acquire when closed during the stagger', async () => {
@@ -468,12 +545,7 @@ describe('focus-weighted acquisition', () => {
     vi.useFakeTimers();
     const onTakeoverRequested = vi.fn().mockResolvedValue(true);
     const owner = createTab(() => 0, onTakeoverRequested);
-    const requester = createDebateRoomOwnershipCoordinator({
-      debateId: 'debate-1',
-      userId: 'user-a',
-      onTakeoverRequested: () => true,
-      getTabPriority: () => 2,
-    });
+    const requester = createTab(() => 2);
 
     const ownerAcquisition = owner.acquire();
     await vi.advanceTimersByTimeAsync(700);
@@ -492,7 +564,7 @@ describe('focus-weighted acquisition', () => {
     await owner.acquire();
 
     // An old tab running a build that predates requesterPriority omits the field entirely.
-    const legacyChannel = new FakeBroadcastChannel('geo:debate-room:debate-1:user-a');
+    const legacyChannel = new FakeBroadcastChannel(`geo:debate-room:${staggerDebateId}:user-a`);
     legacyChannel.postMessage({ type: 'takeover-request', requestId: 'legacy-1', requesterId: 'legacy-instance' });
     await new Promise(resolve => queueMicrotask(() => resolve(undefined)));
 

--- a/apps/web/core/debates/debate-room-ownership.test.ts
+++ b/apps/web/core/debates/debate-room-ownership.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { type DebateRoomOwnershipCoordinator, createDebateRoomOwnershipCoordinator } from './debate-room-ownership';
+import {
+  type DebateRoomOwnershipCoordinator,
+  type DebateRoomTabPriority,
+  type DebateRoomTakeoverContext,
+  createDebateRoomOwnershipCoordinator,
+} from './debate-room-ownership';
 
 type QueuedLock = {
   callback: (lock: Lock | null) => Promise<void> | void;
@@ -103,10 +108,15 @@ beforeEach(() => {
   vi.stubGlobal('BroadcastChannel', FakeBroadcastChannel);
   let instanceNumber = 0;
   vi.stubGlobal('crypto', { randomUUID: vi.fn(() => `instance-${++instanceNumber}`) });
+  // Tests that don't inject getTabPriority run as a focused tab, so the acquisition stagger stays
+  // out of every pre-existing timing expectation.
+  vi.spyOn(document, 'hasFocus').mockReturnValue(true);
 });
 
 afterEach(() => {
   vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  vi.useRealTimers();
   Object.defineProperty(navigator, 'locks', { configurable: true, value: undefined });
 });
 
@@ -379,5 +389,127 @@ describe('debate room ownership', () => {
     await expect(second.acquire()).resolves.toEqual({ acquired: true, waitedForLocalRelease: false });
 
     await closeCoordinators(first, second);
+  });
+});
+
+describe('focus-weighted acquisition', () => {
+  function createTab(
+    getTabPriority: () => DebateRoomTabPriority,
+    onTakeoverRequested: (context: DebateRoomTakeoverContext) => boolean | Promise<boolean> = () => true
+  ) {
+    return createDebateRoomOwnershipCoordinator({
+      debateId: 'debate-1',
+      userId: 'user-a',
+      onTakeoverRequested,
+      getTabPriority,
+    });
+  }
+
+  it('lets a focused tab win the lock over a hidden tab that asked first', async () => {
+    vi.useFakeTimers();
+    const hidden = createTab(() => 0);
+    const focused = createTab(() => 2);
+
+    const hiddenAcquisition = hidden.acquire();
+    const focusedAcquisition = focused.acquire();
+
+    await expect(focusedAcquisition).resolves.toEqual({ acquired: true, waitedForLocalRelease: false });
+    await vi.advanceTimersByTimeAsync(700);
+    await expect(hiddenAcquisition).resolves.toEqual({ acquired: false, waitedForLocalRelease: false });
+
+    await closeCoordinators(hidden, focused);
+  });
+
+  it('keeps first-come ordering between two hidden tabs', async () => {
+    vi.useFakeTimers();
+    const first = createTab(() => 0);
+    const second = createTab(() => 0);
+
+    const firstAcquisition = first.acquire();
+    const secondAcquisition = second.acquire();
+    await vi.advanceTimersByTimeAsync(700);
+
+    await expect(firstAcquisition).resolves.toEqual({ acquired: true, waitedForLocalRelease: false });
+    await expect(secondAcquisition).resolves.toEqual({ acquired: false, waitedForLocalRelease: false });
+
+    await closeCoordinators(first, second);
+  });
+
+  it('acquires early when the tab gains focus mid-stagger', async () => {
+    vi.useFakeTimers();
+    let priority: DebateRoomTabPriority = 0;
+    const tab = createTab(() => priority);
+
+    const acquisition = tab.acquire();
+    priority = 2;
+    window.dispatchEvent(new Event('focus'));
+
+    // Resolves without the 700ms hidden-tab stagger elapsing.
+    await expect(acquisition).resolves.toEqual({ acquired: true, waitedForLocalRelease: false });
+
+    await closeCoordinators(tab);
+  });
+
+  it('does not acquire when closed during the stagger', async () => {
+    vi.useFakeTimers();
+    const tab = createTab(() => 0);
+
+    const acquisition = tab.acquire();
+    tab.close();
+    await vi.advanceTimersByTimeAsync(700);
+
+    await expect(acquisition).resolves.toEqual({ acquired: false, waitedForLocalRelease: false });
+    expect(tab.ownsConnection()).toBe(false);
+
+    await closeCoordinators(tab);
+  });
+
+  it('skips the stagger for explicit takeovers and hands both priorities to the owner', async () => {
+    vi.useFakeTimers();
+    const onTakeoverRequested = vi.fn().mockResolvedValue(true);
+    const owner = createTab(() => 0, onTakeoverRequested);
+    const requester = createDebateRoomOwnershipCoordinator({
+      debateId: 'debate-1',
+      userId: 'user-a',
+      onTakeoverRequested: () => true,
+      getTabPriority: () => 2,
+    });
+
+    const ownerAcquisition = owner.acquire();
+    await vi.advanceTimersByTimeAsync(700);
+    await expect(ownerAcquisition).resolves.toEqual({ acquired: true, waitedForLocalRelease: false });
+
+    // No timer advance: a hidden owner's release must not delay the takeover by another stagger.
+    await expect(requester.requestTakeover()).resolves.toBe(true);
+    expect(onTakeoverRequested).toHaveBeenCalledWith({ requesterPriority: 2, ownerPriority: 0 });
+
+    await closeCoordinators(owner, requester);
+  });
+
+  it('treats a takeover request without a priority as coming from a focused tab', async () => {
+    const onTakeoverRequested = vi.fn().mockResolvedValue(false);
+    const owner = createTab(() => 1, onTakeoverRequested);
+    await owner.acquire();
+
+    // An old tab running a build that predates requesterPriority omits the field entirely.
+    const legacyChannel = new FakeBroadcastChannel('geo:debate-room:debate-1:user-a');
+    legacyChannel.postMessage({ type: 'takeover-request', requestId: 'legacy-1', requesterId: 'legacy-instance' });
+    await new Promise(resolve => queueMicrotask(() => resolve(undefined)));
+
+    expect(onTakeoverRequested).toHaveBeenCalledWith({ requesterPriority: 2, ownerPriority: 1 });
+
+    legacyChannel.close();
+    await closeCoordinators(owner);
+  });
+
+  it('does not stagger the LiveKit fallback, where last connect wins', async () => {
+    Object.defineProperty(navigator, 'locks', { configurable: true, value: undefined });
+    const hidden = createTab(() => 0);
+
+    // Resolves immediately under real timers: a delay here would hand the room to the hidden tab,
+    // because DUPLICATE_IDENTITY arbitration favors the LAST tab to connect.
+    await expect(hidden.acquire()).resolves.toEqual({ acquired: true, waitedForLocalRelease: false });
+
+    await closeCoordinators(hidden);
   });
 });

--- a/apps/web/core/debates/debate-room-ownership.ts
+++ b/apps/web/core/debates/debate-room-ownership.ts
@@ -121,16 +121,22 @@ export function createDebateRoomOwnershipCoordinator({
     }
   };
 
+  // Resolves the in-flight acquisition stagger immediately: a takeover arriving mid-stagger and
+  // release()/close() must not sit out the residual delay (nothing else re-checks cancellation
+  // until the timer or a focus event fires).
+  let finishActiveStagger: (() => void) | null = null;
+
   // Holds off the lock request in proportion to how far the tab is from the user's attention, so
   // the focused tab reaches navigator.locks first even when a background tab's connect() started
   // earlier. Resolves early if the tab gains focus mid-wait.
-  const awaitAcquisitionStagger = async (delay: number, cancelled: () => boolean) => {
-    await new Promise<void>(resolve => {
+  const awaitAcquisitionStagger = (delay: number, cancelled: () => boolean) =>
+    new Promise<void>(resolve => {
       let settled = false;
       let timer: number | null = null;
       const finish = () => {
         if (settled) return;
         settled = true;
+        if (finishActiveStagger === finish) finishActiveStagger = null;
         if (timer !== null) window.clearTimeout(timer);
         window.removeEventListener('focus', onPriorityChange);
         document.removeEventListener('visibilitychange', onPriorityChange);
@@ -142,8 +148,8 @@ export function createDebateRoomOwnershipCoordinator({
       timer = window.setTimeout(finish, delay);
       window.addEventListener('focus', onPriorityChange);
       document.addEventListener('visibilitychange', onPriorityChange);
+      finishActiveStagger = finish;
     });
-  };
 
   const acquireLock = (skipStagger = false): Promise<DebateRoomOwnershipAcquireResult> => {
     if (ownsConnection) return Promise.resolve({ acquired: true, waitedForLocalRelease: false });
@@ -155,7 +161,12 @@ export function createDebateRoomOwnershipCoordinator({
       ownsConnection = true;
       return Promise.resolve({ acquired: true, waitedForLocalRelease: false });
     }
-    if (acquisition) return acquisition;
+    if (acquisition) {
+      // The dedup slot may hold a mid-stagger acquisition; a takeover must not inherit the
+      // residual delay, so settle the stagger now and share the (correct) result.
+      if (skipStagger) finishActiveStagger?.();
+      return acquisition;
+    }
 
     const attempt = { cancelled: false };
     activeAcquisitionAttempt = attempt;
@@ -235,6 +246,9 @@ export function createDebateRoomOwnershipCoordinator({
     const activeRequest = lockRequest ?? acquisition?.then(() => undefined);
     if (!activeRequest) return;
     if (activeAcquisitionAttempt) activeAcquisitionAttempt.cancelled = true;
+    // A cancelled stagger would otherwise run out its timer, holding the local-release barrier —
+    // and any same-tab successor waiting on it — for the residual delay.
+    finishActiveStagger?.();
     ownsConnection = false;
     releaseLock?.();
     const barrier = registerLocalReleaseBarrier(coordinationName, activeRequest);

--- a/apps/web/core/debates/debate-room-ownership.ts
+++ b/apps/web/core/debates/debate-room-ownership.ts
@@ -2,6 +2,9 @@ type TakeoverRequest = {
   type: 'takeover-request';
   requestId: string;
   requesterId: string;
+  // Optional on the wire: tabs running a build that predates the field omit it, and the owner
+  // assumes a focused requester so an old tab is never permanently unbeatable mid-deploy.
+  requesterPriority?: DebateRoomTabPriority;
 };
 
 type TakeoverResponse = {
@@ -13,10 +16,17 @@ type TakeoverResponse = {
 
 type OwnershipMessage = TakeoverRequest | TakeoverResponse;
 
+export type DebateRoomTakeoverContext = {
+  requesterPriority: DebateRoomTabPriority;
+  ownerPriority: DebateRoomTabPriority;
+};
+
 type CreateDebateRoomOwnershipCoordinatorOptions = {
   debateId: string;
   userId: string;
-  onTakeoverRequested: () => boolean | Promise<boolean>;
+  onTakeoverRequested: (context: DebateRoomTakeoverContext) => boolean | Promise<boolean>;
+  // Test seam; production uses debateRoomTabPriority.
+  getTabPriority?: () => DebateRoomTabPriority;
 };
 
 export type DebateRoomOwnershipCoordinator = {
@@ -36,6 +46,23 @@ export type DebateRoomOwnershipAcquireResult = {
 
 export type DebateRoomOwnershipCoordinationMode = 'lock-and-broadcast' | 'lock-only' | 'livekit-fallback';
 
+// 0 = hidden, 1 = visible but unfocused, 2 = focused. Biases the ownership race toward the tab
+// the user is looking at: without it, whichever tab's connect() ran microseconds earlier owns the
+// debate — and after a rematch the background tab structurally wins, because the foreground tab
+// is still persisting its recording when the navigation fan-out lands.
+export type DebateRoomTabPriority = 0 | 1 | 2;
+
+export function debateRoomTabPriority(): DebateRoomTabPriority {
+  // Without a document we cannot tell, so claim focus rather than add an artificial delay.
+  if (typeof document === 'undefined') return 2;
+  if (document.visibilityState !== 'visible') return 0;
+  return typeof document.hasFocus === 'function' && !document.hasFocus() ? 1 : 2;
+}
+
+// A hidden tab waits long enough for a focused tab to reach its own lock request first, but far
+// less than the ~10s connecting window, so a genuinely solo hidden tab still connects comfortably.
+const acquisitionStaggerMs: Record<DebateRoomTabPriority, number> = { 0: 700, 1: 250, 2: 0 };
+
 const takeoverResponseTimeoutMs = 1_500;
 const localReleaseBarriers = new Map<string, Promise<void>>();
 
@@ -43,6 +70,7 @@ export function createDebateRoomOwnershipCoordinator({
   debateId,
   userId,
   onTakeoverRequested,
+  getTabPriority = debateRoomTabPriority,
 }: CreateDebateRoomOwnershipCoordinatorOptions): DebateRoomOwnershipCoordinator {
   const instanceId = createInstanceId();
   const coordinationName = `geo:debate-room:${debateId}:${userId}`;
@@ -93,10 +121,37 @@ export function createDebateRoomOwnershipCoordinator({
     }
   };
 
-  const acquireLock = (): Promise<DebateRoomOwnershipAcquireResult> => {
+  // Holds off the lock request in proportion to how far the tab is from the user's attention, so
+  // the focused tab reaches navigator.locks first even when a background tab's connect() started
+  // earlier. Resolves early if the tab gains focus mid-wait.
+  const awaitAcquisitionStagger = async (delay: number, cancelled: () => boolean) => {
+    await new Promise<void>(resolve => {
+      let settled = false;
+      let timer: number | null = null;
+      const finish = () => {
+        if (settled) return;
+        settled = true;
+        if (timer !== null) window.clearTimeout(timer);
+        window.removeEventListener('focus', onPriorityChange);
+        document.removeEventListener('visibilitychange', onPriorityChange);
+        resolve();
+      };
+      const onPriorityChange = () => {
+        if (getTabPriority() === 2 || cancelled()) finish();
+      };
+      timer = window.setTimeout(finish, delay);
+      window.addEventListener('focus', onPriorityChange);
+      document.addEventListener('visibilitychange', onPriorityChange);
+    });
+  };
+
+  const acquireLock = (skipStagger = false): Promise<DebateRoomOwnershipAcquireResult> => {
     if (ownsConnection) return Promise.resolve({ acquired: true, waitedForLocalRelease: false });
     if (closed) return Promise.resolve({ acquired: false, waitedForLocalRelease: false });
     if (!lockManager || !lockRequestsAvailable) {
+      // No stagger here: with LiveKit DUPLICATE_IDENTITY as the arbiter the LAST connect wins, so
+      // delaying a hidden tab would hand it the room instead of the focused one. The focused tab
+      // recovers through the auto-takeover-on-focus path instead.
       ownsConnection = true;
       return Promise.resolve({ acquired: true, waitedForLocalRelease: false });
     }
@@ -111,6 +166,15 @@ export function createDebateRoomOwnershipCoordinator({
       }
       if (closed || attempt.cancelled) return { acquired: false, waitedForLocalRelease };
       if (ownsConnection) return { acquired: true, waitedForLocalRelease };
+      // Takeovers skip the stagger: they are an explicit user action, already focus-driven. A
+      // zero delay must not even await — callers rely on an unstaggered acquire registering its
+      // lock request synchronously (the close/release drain machinery depends on it).
+      const staggerDelay = skipStagger ? 0 : acquisitionStaggerMs[getTabPriority()];
+      if (staggerDelay > 0 && typeof window !== 'undefined') {
+        await awaitAcquisitionStagger(staggerDelay, () => closed || attempt.cancelled);
+        if (closed || attempt.cancelled) return { acquired: false, waitedForLocalRelease };
+        if (ownsConnection) return { acquired: true, waitedForLocalRelease };
+      }
 
       const lockResult = await new Promise<'acquired' | 'blocked' | 'unavailable'>(resolve => {
         let request: Promise<void>;
@@ -192,7 +256,11 @@ export function createDebateRoomOwnershipCoordinator({
       }
 
       if (message.type !== 'takeover-request' || message.requesterId === instanceId || !ownsConnection) return;
-      void Promise.resolve(onTakeoverRequested())
+      const takeoverContext: DebateRoomTakeoverContext = {
+        requesterPriority: message.requesterPriority ?? 2,
+        ownerPriority: getTabPriority(),
+      };
+      void Promise.resolve(onTakeoverRequested(takeoverContext))
         .then(async released => {
           if (released) await release();
           postTakeoverResponse(message, released);
@@ -208,12 +276,12 @@ export function createDebateRoomOwnershipCoordinator({
     get coordinationMode() {
       return coordinationMode;
     },
-    acquire: acquireLock,
+    acquire: () => acquireLock(),
     requestTakeover: async () => {
       if (ownsConnection) return true;
-      if (!lockManager || !lockRequestsAvailable) return (await acquireLock()).acquired;
+      if (!lockManager || !lockRequestsAvailable) return (await acquireLock(true)).acquired;
       if (closed) return false;
-      if ((await acquireLock()).acquired) return true;
+      if ((await acquireLock(true)).acquired) return true;
       if (!channel) return false;
       const takeoverChannel = channel;
 
@@ -233,6 +301,7 @@ export function createDebateRoomOwnershipCoordinator({
             type: 'takeover-request',
             requestId,
             requesterId: instanceId,
+            requesterPriority: getTabPriority(),
           } satisfies TakeoverRequest);
         } catch {
           window.clearTimeout(timeout);
@@ -241,7 +310,7 @@ export function createDebateRoomOwnershipCoordinator({
         }
       });
       if (!released) return false;
-      return (await acquireLock()).acquired;
+      return (await acquireLock(true)).acquired;
     },
     release,
     close: () => {


### PR DESCRIPTION
With multiple Geo tabs open, a launching debate could land in a background tab: gateway events fan out to every tab, each tab's connect() races for the navigator.locks ownership lock with { ifAvailable: true }, and whichever tab asked microseconds first won permanently — with the foreground tab structurally slower after a rematch because it persists its recording before navigating. The focused user then dead-ended on "This debate is already open in another tab." (GEO-2577)

- Stagger lock acquisition by tab attention: focused tabs request immediately, visible-unfocused tabs wait 250ms, hidden tabs 700ms — small against the ~10s connecting window, decisive against a microsecond race. The wait resolves early if the tab gains focus, and explicit takeovers skip it entirely.
- Carry the requester's tab priority on the takeover BroadcastChannel wire (older builds omit the field and are assumed focused), and let a focused tab pull the connection from an unfocused one while nothing has been recorded yet. Once recording starts the owner keeps the room.
- Auto-reclaim on focus: a tab blocked by a same-browser conflict (web_lock_blocked / ownership_released) issues the takeover itself when it is or becomes focused, instead of dead-ending until the user finds the Continue button. Cross-device conflicts (livekit_duplicate_identity) stay behind the explicit click, since the other identity may be a phone the user is actively holding. A refused attempt retries only on a real focus transition.
- The no-Web-Locks fallback stays unstaggered on purpose: LiveKit DUPLICATE_IDENTITY arbitration is last-connect-wins, so a delay there would hand the room to the hidden tab.