### PR TITLE
fix(debates): scroll the rematch tabs instead of the whole session

### DIFF
--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
@@ -746,6 +746,55 @@ describe('DebateRematchPageClient', () => {
     expect(screen.queryByText('A claim both participants chose')).toBeNull();
   });
 
+  // On a phone the three tabs are wider than the screen. They were laid out in a row that could
+  // neither shrink them nor scroll, inside a layer that could scroll sideways — so a swipe at the
+  // tabs panned the whole session instead of moving the tabs.
+  describe('tab strip overflow', () => {
+    /** The row holding the tab buttons. */
+    function tabStrip() {
+      const tab = screen.getByRole('button', { name: /All/ });
+      const strip = tab.parentElement;
+      expect(strip).not.toBeNull();
+      return strip!;
+    }
+
+    it('scrolls the tabs on their own rather than the page', () => {
+      render(<DebateRematchPageClient sessionId="rematch-1" />);
+
+      expect(tabStrip().className).toContain('overflow-x-auto');
+      // Without this the row is only as wide as its content allows, and there is nothing to scroll.
+      expect(tabStrip().className).toContain('min-w-0');
+    });
+
+    // A swipe that reaches the end of the strip would otherwise chain outward, which on iOS is the
+    // browser's back gesture — leaving the debate.
+    it('keeps an overscrolling swipe inside the strip', () => {
+      render(<DebateRematchPageClient sessionId="rematch-1" />);
+
+      expect(tabStrip().className).toContain('overscroll-x-contain');
+    });
+
+    // The tabs have to keep their own width for the strip to have anything to scroll; squeezed
+    // flex children just get narrower and stay on screen.
+    it('lets each tab keep its natural width', () => {
+      render(<DebateRematchPageClient sessionId="rematch-1" />);
+
+      for (const name of [/All/, /positions/]) {
+        expect(screen.getByRole('button', { name }).className).toContain('shrink-0');
+      }
+    });
+
+    // `overflow-y-auto` alone leaves the other axis computing to `auto`, which is what let the
+    // whole fixed layer pan sideways.
+    it('does not let the page itself scroll sideways', () => {
+      const { container } = render(<DebateRematchPageClient sessionId="rematch-1" />);
+
+      const shell = container.querySelector('.fixed.inset-0');
+      expect(shell).not.toBeNull();
+      expect(shell!.className).toContain('overflow-x-hidden');
+    });
+  });
+
   it('shortens the opponent tab to their first name', () => {
     const base = session();
     mocks.session = session({
@@ -1015,7 +1064,9 @@ describe('DebateRematchPageClient', () => {
 
     expect(mocks.markEnteringDebate).toHaveBeenCalledWith('debate-9');
     expect(mocks.replace).toHaveBeenCalledWith(`/space/${SPACE_1}/debates/debate-9`);
-    expect(mocks.markEnteringDebate.mock.invocationCallOrder[0]).toBeLessThan(mocks.replace.mock.invocationCallOrder[0]!);
+    expect(mocks.markEnteringDebate.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.replace.mock.invocationCallOrder[0]!
+    );
   });
 
   // A backend that predates the fields answers `undefined`, and the picker must keep working

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { SystemIds } from '@geoprotocol/geo-sdk/lite';
+
 import * as React from 'react';
 
 import cx from 'classnames';
@@ -17,9 +18,9 @@ import {
   type MatchmakingTopic,
 } from '~/core/debates/api';
 import { type ClaimPickerEntity, useClaimPickerPage } from '~/core/debates/claim-picker-page';
+import { isClaimSpaceAllowed } from '~/core/debates/claim-space-allowlist';
 import { markEnteringDebate } from '~/core/debates/debate-entry-intent';
 import { useDebateGatewaySpaceScopes } from '~/core/debates/debate-gateway';
-import { isClaimSpaceAllowed } from '~/core/debates/claim-space-allowlist';
 import { DebateRequestDialog } from '~/core/debates/debate-request-dialog';
 import { defaultDebateFormatId } from '~/core/debates/formats';
 import {
@@ -477,18 +478,25 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
     // Below the entity side panel (z-200) on purpose: a claim opens there rather than navigating,
     // and the panel has to land on top. Still above the navbar (z-60) and the app's z-100 band, so
     // the session keeps the screen to itself.
-    <div className="fixed inset-0 z-[150] overflow-y-auto bg-white text-text">
+    // `overflow-x-hidden` is load-bearing, not tidying: CSS computes the other axis to `auto` as
+    // soon as one of them isn't `visible`, so `overflow-y-auto` alone left this layer horizontally
+    // scrollable. Anything wider than the viewport — the tab strip, on a phone — panned the whole
+    // screen sideways instead of scrolling itself.
+    <div className="fixed inset-0 z-[150] overflow-x-hidden overflow-y-auto bg-white text-text">
       <main className="mx-auto min-h-dvh w-full max-w-[720px] px-5 py-8 sm:px-8">
         <header className="mb-4 flex items-center justify-between gap-4">
           <h1 className="sr-only">Rematch {remoteName}</h1>
-          <div className="flex min-w-0 items-center gap-5">
+          {/* Scrolls on its own: `min-w-0` lets it be narrower than its tabs, `overflow-x-auto`
+              gives those tabs somewhere to go, and `overscroll-x-contain` stops a swipe that
+              reaches the end from chaining into the browser's back gesture. */}
+          <div className="no-scrollbar flex min-w-0 flex-1 items-center gap-5 overflow-x-auto overscroll-x-contain">
             {hasRecommended || recommendedLoading ? (
               <TabButton active={tab === 'recommended'} onClick={() => setTab('recommended')}>
                 Recommended
               </TabButton>
             ) : null}
             <TabButton active={tab === 'opponent'} onClick={() => setTab('opponent')}>
-              <span className="truncate">{firstNamePossessive(remoteName)} positions</span>
+              <span className="max-w-[10rem] truncate">{firstNamePossessive(remoteName)} positions</span>
               <span
                 className={cx(
                   'inline-flex min-h-6 min-w-6 items-center justify-center rounded-full px-1.5 text-metadataMedium tabular-nums',
@@ -1038,7 +1046,9 @@ function TabButton({ active, onClick, children }: { active: boolean; onClick: ()
       onClick={onClick}
       aria-selected={active}
       className={cx(
-        'flex items-center gap-2 text-[1.4rem] leading-tight font-medium transition-colors',
+        // `shrink-0` so a narrow screen scrolls the strip rather than squeezing three tabs into
+        // the width of one; `whitespace-nowrap` so a two-word tab can't wrap into two lines.
+        'flex shrink-0 items-center gap-2 text-[1.4rem] leading-tight font-medium whitespace-nowrap transition-colors',
         active ? 'text-text' : 'text-grey-03 hover:text-grey-04'
       )}
     >


### PR DESCRIPTION
## The bug

On a phone the debate-again picker's three tabs are wider than the screen. Swiping at them dragged the **entire session** sideways instead of moving the tabs — with the Leave button sitting on top of the opponent tab and "All" off the edge entirely.

## Why

Two causes, one on each side of the overflow.

**The session layer could scroll sideways.** It set `overflow-y-auto` and nothing else, and CSS computes the *other* axis to `auto` as soon as one of them isn't `visible`. So the layer was already a horizontal scroll container — the tabs were just the first thing wide enough to reveal it. That's the "whole page moves left/right".

**The tab row had nowhere to put its tabs.** It carried `min-w-0` but no `overflow-x`, so the tabs overflowed their container rather than scrolling inside it. And because they were ordinary flex children with no `shrink-0`, the row's first instinct was to squeeze them — which is why the opponent tab ended up under the Leave button rather than scrolling past it.

## The fix

- The session layer takes `overflow-x-hidden`, so nothing pans the screen.
- The tab row becomes its own scroll container: `overflow-x-auto` with `no-scrollbar`, plus `overscroll-x-contain` so a swipe that runs off the end doesn't chain into the browser's back gesture and drop the viewer out of the debate — worth having on a surface people reach mid-session.
- `TabButton` takes `shrink-0` and `whitespace-nowrap`: squeezed flex children just get narrower and never scroll, and a two-word tab shouldn't wrap to two lines instead.
- The opponent tab keeps its truncation, now bounded at `10rem`, so one unusually long first name can't stretch the strip by itself.

## Notes for review

- `overflow-x-hidden` on the shell doesn't clip the request dialog. That dialog is `position: fixed`, and the shell has no transform/filter/will-change, so it isn't in the dialog's containing-block chain — the dialog is positioned against the viewport and unaffected. It also renders inside the same shell today, which already had a computed `overflow-x: auto`, so nothing changes for it.
- Radix menus (the space/topic filters) portal to `body`, so they're outside this subtree either way.

## Testing

- Four new cases in `rematch-page-client.test.tsx`: the strip scrolls itself (`overflow-x-auto` + `min-w-0`), a swipe stays inside it (`overscroll-x-contain`), each tab keeps its natural width (`shrink-0`), and the page can't scroll sideways (`overflow-x-hidden`).
- Verified non-vacuous: reverting all three source changes fails exactly those four and nothing else.
- `bun run vitest run core partials app` → 265 files / 2671 tests pass.
- `NEXT_PUBLIC_CHAIN_ID=55516 bun run build` → clean.

These assert class names, which is a weaker contract than real layout — jsdom has no layout engine, so a scroll behaviour test isn't available here. They pin the specific combination that was wrong rather than proving the result; worth a real phone to confirm the strip scrolls and the page no longer does.