### PR TITLE
fix(debates): stop the ready prompt flickering over the rematch handoff

### DIFF
--- a/apps/web/core/debates/debate-coordinator.test.tsx
+++ b/apps/web/core/debates/debate-coordinator.test.tsx
@@ -105,6 +105,19 @@ vi.mock('./claim-response-indexed-notifier', () => ({
 
 vi.mock('~/core/state/feature-flags', () => ({}));
 
+// `pending-personal-space` reads localStorage at module scope (`atomWithStorage` with
+// `getOnInit`), and the storage jsdom hands back here has no `getItem`. That throws while the
+// module graph is still being built, which took the whole suite down at collection — every test
+// in this file, on master and in CI alike. The coordinator reaches it through `SpaceChip`.
+vi.mock('~/core/state/pending-personal-space', () => ({
+  PENDING_PERSONAL_SPACE_PREFIX: 'pending:',
+  pendingPersonalSpaceAtom: { toString: () => 'pendingPersonalSpaceAtom' },
+  pendingPersonalSpaceId: (topicId: string) => `pending:${topicId}`,
+  isPendingPersonalSpaceId: (spaceId: string | null | undefined) =>
+    typeof spaceId === 'string' && spaceId.startsWith('pending:'),
+  usePendingPersonalSpace: () => ({ isPending: false }),
+}));
+
 beforeEach(() => {
   sessionStorage.clear();
   mocks.push.mockReset();
@@ -248,6 +261,35 @@ describe('DebateCoordinator', () => {
     mocks.activity = activityWithDebate();
     mocks.activity.debate = { ...mocks.activity.debate!, status: 'ready', participants: bothParticipants() };
     markEnteringDebate('debate-2');
+
+    render(<DebateCoordinator />);
+
+    expect(await screen.findByText('Your debate is ready')).toBeInTheDocument();
+  });
+
+  // The reported flicker, requester side. They sent the rematch claim request and are sitting in
+  // the picker; the moment the opponent accepts, `debate.rematch_changed` invalidates activity and
+  // the rematch session as two separate refetches. Activity landing first reports the new debate
+  // with the session already gone, and the picker has not yet seen `converted` to redirect — so
+  // "Your debate is ready" appeared for a beat and was then navigated out from under them.
+  it('does not prompt the requester while the rematch picker is handing them off', async () => {
+    mocks.pathname = '/space/space-1/debates/rematches/rematch-1';
+    mocks.activity = activityWithDebate();
+    mocks.activity.debate = { ...mocks.activity.debate!, status: 'ready', participants: bothParticipants() };
+
+    render(<DebateCoordinator />);
+
+    await waitFor(() => expect(screen.queryByText('Your debate is ready')).not.toBeInTheDocument());
+    // Nor the fallback in its place, which would be the same flicker wearing a smaller hat.
+    expect(screen.queryByRole('button', { name: /Your debate is/ })).not.toBeInTheDocument();
+  });
+
+  // Scoped to the handoff, not to having ever been in a rematch: someone who walked away from the
+  // picker still has no other way of being told, which is the whole point of the prompt.
+  it('still prompts once the requester has left the rematch picker', async () => {
+    mocks.pathname = '/space/space-1/claims';
+    mocks.activity = activityWithDebate();
+    mocks.activity.debate = { ...mocks.activity.debate!, status: 'ready', participants: bothParticipants() };
 
     render(<DebateCoordinator />);
 

--- a/apps/web/core/debates/debate-coordinator.tsx
+++ b/apps/web/core/debates/debate-coordinator.tsx
@@ -74,6 +74,13 @@ export function DebateCoordinator() {
   // comes straight back reporting the debate.
   const enteringDebateId = useEnteringDebateId();
   const atDebate = Boolean(debate && (pathname.includes(`/debates/${debate.id}`) || debate.id === enteringDebateId));
+  // The rematch picker owns the handoff into the debate it just produced: it holds the session
+  // query and replaces into the room the moment that query reports `converted`. Activity is a
+  // separate refetch off the same `debate.rematch_changed` event, so it can land first — and once
+  // the session has cleared from activity, that window put "Your debate is ready" on the
+  // requester's screen for a moment before the picker redirected out from under it. Neither the
+  // prompt nor the rejoin bar has anything to offer on a page that is already on its way there.
+  const atRematchHandoff = pathname.includes('/debates/rematches/');
   const activeFlow = Boolean(debate || activity?.rematch || challenge);
   const sharePromptsQuery = useDebateSharePrompts(Boolean(activity) && !activeFlow);
   const queriedSharePrompt =
@@ -136,7 +143,8 @@ export function DebateCoordinator() {
   // out. Everything past `ready` falls through to the rejoin bar, which offers the way in without
   // offering a way to destroy it.
   const describable = (debate?.participants?.length ?? 0) >= 2;
-  const promptedDebate = debate && debate.status === 'ready' && describable && !atDebate ? debate : null;
+  const promptedDebate =
+    debate && debate.status === 'ready' && describable && !atDebate && !atRematchHandoff ? debate : null;
 
   // Held until a navigation commits, then released. Arriving at the room is the expected end, and
   // `atDebate` carries on from the pathname there. Going anywhere else abandons the walk — holding
@@ -209,7 +217,9 @@ export function DebateCoordinator() {
       {promptedDebate && currentUserId && !activity?.rematch && (
         <DebateReadyPrompt key={promptedDebate.id} debate={promptedDebate} currentUserId={currentUserId} />
       )}
-      {debate && !atDebate && !promptedDebate && !activity?.rematch && <DebateRejoinBar debate={debate} />}
+      {debate && !atDebate && !promptedDebate && !atRematchHandoff && !activity?.rematch && (
+        <DebateRejoinBar debate={debate} />
+      )}
       {/* Recipient only: they have a decision to make. The sender's copy waits under Sent in the
           hub's Requests tab, and the rematch routing effect above walks them into the claim picker
           the moment it is accepted. */}


### PR DESCRIPTION
## The bug

Requester side of the rematch flow: send a claim request from the picker, the opponent accepts, and "Your debate is ready" flashes on screen for a beat before the app redirects to the get-ready screen. No interaction, nothing to decide — it just appears and leaves.

## Why

Accepting fires one `debate.rematch_changed`. The gateway turns that into **two separate refetches** — the account's activity and the rematch session — and either can land first.

The picker only redirects once *its* session query reports `converted`. So when activity landed first, there was a window where the requester had a new `ready` debate in activity, the rematch session already cleared from it, and a picker that had not yet learned to redirect. `DebateCoordinator` reads exactly that shape as "this person has not been told their debate is ready" and opens the dialog — which the picker then navigates out from under them.

The accepting tab was already covered. Its mutation has the debate in hand, so it calls `markEnteringDebate` before pushing ([hooks.ts:634](apps/web/core/debates/hooks.ts)). The requester has no mutation to hang that on. All they have is the page they are already sitting on.

## The fix

The coordinator now treats the rematch picker the way it already treats the debate room: a place that owns its own way in and must not be interrupted.

The rejoin bar is suppressed there too. Letting it through instead would be the same flicker in a smaller hat — and the existing accepting-tab test already guards that pairing, so it seemed worth matching.

Scoped to being *on* the picker, not to having been in a rematch at all: someone who walked away still has nothing else to tell them, which is the entire point of the prompt (GEO-2514).

## Testing

`debate-coordinator.test.tsx` has the right harness for this, but **none of it was running**. `pending-personal-space` reads localStorage at module scope (`atomWithStorage` with `getOnInit`), and the storage jsdom hands back here has no `getItem` — the throw took the file down during collection, so all 40 tests were dead on master and in CI alike. The coordinator reaches that module through `SpaceChip`.

Mocked locally so the suite runs. That is 40 pre-existing tests brought back, all green, plus two new ones:

- the requester is not prompted (nor offered the rejoin bar) while the picker is handing them off
- they *are* prompted once they have left the picker, so the guard hasn't swallowed the case the prompt exists for

I checked the new test fails without the fix rather than trusting it passes with it.

- `bun run build` passes.
- Full `vitest run`: 21 failed files / 39 failed tests vs. a baseline of 22 / 39 — one fewer broken file, same failures, 42 more tests passing.

## Not covered, and one thing worth a look

I traced this from the code and the gateway's invalidation path, not from a live repro — it needs two signed-in accounts running a rematch to completion. The reasoning rests on activity dropping `rematch` at conversion, which is what the reported symptom implies (the existing `!activity?.rematch` guard would otherwise have suppressed the dialog already). Worth a confirm on a real run before this leaves draft.

The root localStorage problem is worth its own PR: the same throw is why ~20 other test files never collect, and fixing `pending-personal-space` to tolerate a storage without `getItem` would bring all of them back at once. Out of scope here, but happy to pick it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)