### PR TITLE
fix(debates): read rematch picker positions from the graph and browse through the hub's claims query

### DIFF
--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
@@ -7,7 +7,8 @@ import { type ReactElement, StrictMode } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { TOPICS_PROPERTY_ID } from '~/core/claims/ontology';
-import type { DebateRematchClaim, DebateRematchSession } from '~/core/debates/api';
+import type { DebateRematchClaim, DebateRematchSession, MatchmakingClaim } from '~/core/debates/api';
+import type { ParticipantPosition } from '~/core/debates/participant-positions';
 
 import { DebateRematchPageClient } from './rematch-page-client';
 
@@ -43,11 +44,24 @@ const mocks = vi.hoisted(() => ({
     Promise.resolve({ claim: null, match: null })
   ),
   openSidePanel: vi.fn(),
-  entityQueries: [] as Array<{ search: string; after: string | undefined }>,
-  entityQueryPlaceholder: false,
+  /** Every query the All tab handed the hub's claims lookup, in render order. */
+  entityQueries: [] as Array<{ search: string | null; spaceId: string | null }>,
+  /** Every id list the opponent's claims were hydrated with, in render order. */
+  entityIdLookups: [] as string[][],
   entityQueryHasNextPage: false,
+  /** The hub's claims query (the All tab) is still in flight. */
   entityQueryLoading: false,
+  /** The by-id hydration of the opponent's claims is still in flight. */
+  entityHydrationLoading: false,
+  fetchNextPage: vi.fn(),
+  /** Graph entities available to hydrate by id. */
   entities: [] as Array<Record<string, unknown>>,
+  /** The hub's claims rows the All tab lists. */
+  matchmakingClaims: [] as MatchmakingClaim[],
+  /** Both participants' graph positions. */
+  positions: [] as ParticipantPosition[],
+  positionsLoading: false,
+  positionParticipants: [] as string[][],
   recommendedSections: [] as Array<{ id: string; name: string; claimIds: string[] }>,
   recommendedEntities: [] as Array<Record<string, unknown>>,
   recommendedLoading: false,
@@ -97,19 +111,7 @@ vi.mock('~/core/debates/hooks', () => ({
   }),
   // Two lookups run: one for the curated ids, one for the browsed ones. `curatedIds` lets a test
   // stall the browsed lookup on its own, which is the whole point of their being separate.
-  useDebateRematchClaimsForIds: (_sessionId: string, claimIds: string[]) => {
-    mocks.rematchClaimIds.push(claimIds);
-    const isCuratedLookup =
-      mocks.curatedIds.length > 0 && claimIds.every(claimId => mocks.curatedIds.includes(claimId));
-    if (mocks.browsedLookupLoading && !isCuratedLookup) {
-      return { data: { claims: [], excluded_claim_ids: [] }, isLoading: true, error: null };
-    }
-    return {
-      data: { claims: mocks.claims, excluded_claim_ids: [CLAIM_SOURCE] },
-      isLoading: false,
-      error: null,
-    };
-  },
+  useDebateRematchClaimsForIds: (_sessionId: string, claimIds: string[]) => rematchClaimsLookup(claimIds),
   useDebate: () => ({ data: { claim: { claim_entity_id: CLAIM_SOURCE } } }),
   useDebateClaimsBySpaces: (groups: Array<{ spaceId: string; claimIds: string[] }>) => {
     mocks.perSpaceReadinessGroups.push(groups);
@@ -149,6 +151,19 @@ vi.mock('~/core/debates/hooks', () => ({
   }),
 }));
 
+function rematchClaimsLookup(claimIds: string[]) {
+  mocks.rematchClaimIds.push(claimIds);
+  const isCuratedLookup = mocks.curatedIds.length > 0 && claimIds.every(claimId => mocks.curatedIds.includes(claimId));
+  if (mocks.browsedLookupLoading && !isCuratedLookup) {
+    return { data: { claims: [], excluded_claim_ids: [] }, isLoading: true, error: null };
+  }
+  return {
+    data: { claims: mocks.claims, excluded_claim_ids: [CLAIM_SOURCE] },
+    isLoading: false,
+    error: null,
+  };
+}
+
 function render(ui: ReactElement) {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   const view = rtlRender(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>);
@@ -171,20 +186,33 @@ vi.mock('~/core/debates/debate-entry-intent', () => ({
   markEnteringDebate: (debateId: string) => mocks.markEnteringDebate(debateId),
 }));
 
-// The picker's browsed page comes from its own narrow query now, not the entity store. Its
-// `{ search, after }` arguments are what the tests below inspect.
+// The opponent's claims are hydrated from the graph by id, through the picker's narrow projection.
 vi.mock('~/core/debates/claim-picker-page', () => ({
-  useClaimPickerPage: (options: { search: string; after: string | undefined }) => {
-    mocks.entityQueries.push(options);
+  useClaimEntitiesByIds: (ids: string[]) => {
+    mocks.entityIdLookups.push(ids);
     return {
-      entities: mocks.entities,
-      isLoading: mocks.entityQueryLoading,
-      isPlaceholderData: mocks.entityQueryPlaceholder,
-      endCursor: mocks.entityQueryHasNextPage ? 'cursor-1' : null,
-      hasNextPage: mocks.entityQueryHasNextPage,
+      entities: mocks.entities.filter(entity => ids.includes(entity.id as string)),
+      isLoading: mocks.entityHydrationLoading,
+      error: null,
     };
   },
 }));
+
+// Both participants' sides, straight from the graph. `positions` is the rows the query returns.
+vi.mock('~/core/debates/participant-positions', async importOriginal => {
+  const actual = await importOriginal<typeof import('~/core/debates/participant-positions')>();
+  return {
+    ...actual,
+    useParticipantPositions: (participants: Array<{ profile_space_id: string }>) => {
+      mocks.positionParticipants.push(participants.map(participant => participant.profile_space_id));
+      return {
+        byClaim: actual.groupParticipantPositions(mocks.positions),
+        isLoading: mocks.positionsLoading,
+        error: null,
+      };
+    },
+  };
+});
 
 vi.mock('~/core/hooks/use-entity-vote', () => ({
   useEntityResponse: ({ entityId }: { entityId: string }) => ({
@@ -206,6 +234,18 @@ vi.mock('~/core/hooks/use-entity-vote', () => ({
 // The card's Debate toggle publishes readiness through this.
 vi.mock('~/core/debates/matchmaking/hooks', () => ({
   useClaimReadiness: () => ({ mutate: mocks.setReadiness, isPending: false, error: null }),
+  // The All tab is the hub's Claims query. Its arguments are what the tests below inspect.
+  useMatchmakingClaims: (query: { search: string | null; spaceId: string | null }) => {
+    mocks.entityQueries.push(query);
+    return {
+      data: { pages: [{ claims: mocks.matchmakingClaims, next_cursor: null, facets: undefined }] },
+      isLoading: mocks.entityQueryLoading,
+      error: null,
+      hasNextPage: mocks.entityQueryHasNextPage,
+      isFetchingNextPage: false,
+      fetchNextPage: mocks.fetchNextPage,
+    };
+  },
 }));
 
 // The curated lookup has its own tests; these cover the picker around it.
@@ -271,10 +311,19 @@ beforeEach(() => {
   mocks.joinQueueSpaceIds.length = 0;
   mocks.openSidePanel.mockReset();
   mocks.entityQueries.length = 0;
-  mocks.entityQueryPlaceholder = false;
+  mocks.entityIdLookups.length = 0;
   mocks.entityQueryHasNextPage = false;
   mocks.entityQueryLoading = false;
-  mocks.entities = [publishedEntity()];
+  mocks.entityHydrationLoading = false;
+  mocks.fetchNextPage.mockReset();
+  mocks.entities = [sharedEntity(), publishedEntity()];
+  mocks.matchmakingClaims = [matchmakingClaim()];
+  mocks.positions = [
+    position('profile-local', CLAIM_SHARED, SPACE_1, true),
+    position('profile-remote', CLAIM_SHARED, SPACE_1, false),
+  ];
+  mocks.positionsLoading = false;
+  mocks.positionParticipants.length = 0;
   mocks.recommendedSections = [];
   mocks.recommendedEntities = [];
   mocks.recommendedLoading = false;
@@ -441,15 +490,10 @@ describe('DebateRematchPageClient', () => {
   });
 
   it('uses Verify and Dispute for factual claims', () => {
-    mocks.claims = [
-      {
-        ...sharedClaim(),
-        response_kind: 'veracity',
-        participants: [
-          { user_id: 'user-local', position: true, position_label: 'Verify' },
-          { user_id: 'user-remote', position: false, position_label: 'Dispute' },
-        ],
-      },
+    mocks.claims = [{ ...sharedClaim(), response_kind: 'veracity' }];
+    mocks.positions = [
+      { ...position('profile-local', CLAIM_SHARED, SPACE_1, true), responseKind: 'veracity' },
+      { ...position('profile-remote', CLAIM_SHARED, SPACE_1, false), responseKind: 'veracity' },
     ];
 
     render(<DebateRematchPageClient sessionId="rematch-1" />);
@@ -608,6 +652,7 @@ describe('DebateRematchPageClient', () => {
       { id: 'block-1', name: 'Geopolitics & chips', claimIds: [CLAIM_SHARED] },
       { id: 'block-2', name: 'Open weight AI', claimIds: [CLAIM_MORE] },
     ];
+    mocks.recommendedEntities = [sharedEntity(), publishedEntity()];
     render(<DebateRematchPageClient sessionId="rematch-1" />);
 
     expect(screen.getByRole('button', { name: 'Recommended' })).toBeInTheDocument();
@@ -625,12 +670,37 @@ describe('DebateRematchPageClient', () => {
       { id: 'block-1', name: 'Geopolitics & chips', claimIds: [CLAIM_SHARED] },
       { id: 'block-2', name: 'Open weight AI', claimIds: [CLAIM_MORE] },
     ];
+    mocks.recommendedEntities = [sharedEntity(), publishedEntity()];
     render(<DebateRematchPageClient sessionId="rematch-1" />);
 
     fireEvent.click(screen.getByRole('button', { name: /Geopolitics & chips/ }));
 
     expect(screen.queryByText('A claim both participants chose')).toBeNull();
     expect(screen.getByText('A newly published claim')).toBeInTheDocument();
+  });
+
+  // The opponent's tab is what the graph says they have responded to, not what geo-chat has a
+  // session row for. A side they took that geo-chat hasn't heard about yet still lists — and the
+  // graph's list is one query, so it doesn't wait on the allowlist or any geo-chat lookup.
+  it('lists a claim the opponent answered that geo-chat has no row for', () => {
+    const FRESH = '019fedb7-5b96-7e83-9f66-7bc2ad4f9953';
+    mocks.savedClaims = [];
+    mocks.claims = [];
+    mocks.entities = [sharedEntity(), { ...sharedEntity(), id: FRESH, name: 'A claim Salina just answered' }];
+    mocks.positions = [
+      position('profile-remote', CLAIM_SHARED, SPACE_1, false),
+      position('profile-remote', FRESH, SPACE_1, true),
+    ];
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+
+    expect(screen.getByText('A claim Salina just answered')).toBeInTheDocument();
+    expect(screen.getByText('A claim both participants chose')).toBeInTheDocument();
+    const tab = screen.getByRole('button', { name: /Salina’s positions/ });
+    expect(within(tab).getByText('2')).toBeInTheDocument();
+    // Hydrated by id — exactly the claims the graph named, nothing paged.
+    expect(mocks.entityIdLookups.at(-1)).toEqual([CLAIM_SHARED, FRESH]);
+    // And the graph was asked about exactly these two people.
+    expect(mocks.positionParticipants.at(-1)).toEqual(['profile-local', 'profile-remote']);
   });
 
   // A curated claim the session hasn't heard of still has to render, so it joins the same pool the
@@ -640,6 +710,7 @@ describe('DebateRematchPageClient', () => {
       { id: 'block-1', name: 'Geopolitics & chips', claimIds: [CLAIM_SHARED] },
       { id: 'block-2', name: 'Open weight AI', claimIds: [CLAIM_MORE] },
     ];
+    mocks.recommendedEntities = [sharedEntity(), publishedEntity()];
     render(<DebateRematchPageClient sessionId="rematch-1" />);
 
     fireEvent.change(screen.getByRole('textbox', { name: 'Search claims' }), { target: { value: 'newly' } });
@@ -650,11 +721,15 @@ describe('DebateRematchPageClient', () => {
 
   // Recommended comes from the curator's page whole, so paging the browsed corpus means nothing
   // there — offering it implies there are more recommendations waiting.
-  it('keeps the paging sentinel off the Recommended tab while placing it on the others', () => {
+  // Nor on the opponent's tab: that list is the session's own from geo-chat, and paging the graph-wide
+  // scan from it walked the corpus hoping a browsed claim happened to carry their side.
+  it('keeps the paging sentinel off the Recommended and opponent tabs, placing it on All', () => {
     mocks.entityQueryHasNextPage = true;
     mocks.recommendedSections = [{ id: 'block-1', name: 'Geopolitics & chips', claimIds: [CLAIM_SHARED] }];
     render(<DebateRematchPageClient sessionId="rematch-1" />);
 
+    expect(screen.queryByTestId('claims-scroll-sentinel')).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: /Salina’s positions/ }));
     expect(screen.queryByTestId('claims-scroll-sentinel')).toBeNull();
 
     showAllClaims();
@@ -662,27 +737,27 @@ describe('DebateRematchPageClient', () => {
   });
 
   // No button to press any more; reaching the end of the list is what asks for the next page.
-  it('does not offer a Load more button', () => {
+  it('does not offer a Keep looking button while the sentinel is still paging', () => {
     mocks.entityQueryHasNextPage = true;
     render(<DebateRematchPageClient sessionId="rematch-1" />);
     showAllClaims();
 
-    expect(screen.queryByRole('button', { name: 'Load more' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Keep looking' })).toBeNull();
   });
 
   // The picker pages by cursor rather than through an infinite query, so the sentinel firing has
   // to be shown to advance that cursor — a sentinel that renders but is wired to nothing would
   // satisfy every other test here.
-  it('advances the cursor when the end of the list scrolls into view', () => {
+  it('asks the hub query for its next page when the end of the list scrolls into view', () => {
     mocks.entityQueryHasNextPage = true;
     render(<DebateRematchPageClient sessionId="rematch-1" />);
     showAllClaims();
 
-    expect(browsedClaimsQueryOptions()?.after).toBeUndefined();
+    expect(mocks.fetchNextPage).not.toHaveBeenCalled();
 
     act(() => mocks.scrollSentinelIntoView?.());
 
-    expect(browsedClaimsQueryOptions()?.after).toBe('cursor-1');
+    expect(mocks.fetchNextPage).toHaveBeenCalledOnce();
   });
 
   it('leaves the sentinel out once there is no page left to fetch', () => {
@@ -716,11 +791,11 @@ describe('DebateRematchPageClient', () => {
     // Not among the session's saved claims, so the curated lookup is its only source of positions.
     mocks.savedClaims = [];
     mocks.recommendedSections = [{ id: 'block-1', name: 'Geopolitics & chips', claimIds: [CLAIM_SHARED] }];
+    mocks.recommendedEntities = [sharedEntity()];
     render(<DebateRematchPageClient sessionId="rematch-1" />);
 
     expect(screen.getByRole('heading', { name: 'Geopolitics & chips' })).toBeInTheDocument();
-    // Not just the card: its sides come from the session lookup, so a curated claim sharing the
-    // browsed lookup would render with no positions and no debate to request until the scan lands.
+    // Not just the card: its sides come from the graph, so nothing here waits on the browsed list.
     expect(screen.getByRole('button', { name: 'Request debate' })).toBeInTheDocument();
   });
 
@@ -734,16 +809,34 @@ describe('DebateRematchPageClient', () => {
     expect(screen.getByText('A claim both participants chose')).toBeInTheDocument();
   });
 
-  // An empty result mid-flight is not "nothing recommended"; landing on the opponent tab and then
-  // moving the viewer once the lookup settles is worse than waiting.
-  it('waits on the Recommended tab while the curated lookup is still running', () => {
+  // The opponent's claims arrive in one round trip; the curated lookup is three in sequence. The
+  // viewer lands on what is ready, and a curated page arriving afterwards adds its tab rather than
+  // moving them onto it — being moved once the lookup settles is worse than a tab appearing.
+  it('lands on the opponent’s positions while the curated lookup is still running, and stays put', () => {
     mocks.recommendedLoading = true;
-    render(<DebateRematchPageClient sessionId="rematch-1" />);
+    const { rerender } = render(<DebateRematchPageClient sessionId="rematch-1" />);
 
-    expect(screen.getByRole('button', { name: 'Recommended' })).toHaveAttribute('aria-selected', 'true');
-    expect(screen.getByRole('button', { name: /Salina’s positions/ })).toHaveAttribute('aria-selected', 'false');
-    // And the claims stay behind the loading state rather than the opponent tab's list appearing.
-    expect(screen.queryByText('A claim both participants chose')).toBeNull();
+    expect(screen.getByRole('button', { name: /Salina’s positions/ })).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByRole('button', { name: 'Recommended' })).toHaveAttribute('aria-selected', 'false');
+    expect(screen.getByText('A claim both participants chose')).toBeInTheDocument();
+
+    mocks.recommendedLoading = false;
+    mocks.recommendedSections = [{ id: 'block-1', name: 'Geopolitics & chips', claimIds: [CLAIM_MORE] }];
+    rerender(<DebateRematchPageClient sessionId="rematch-1" />);
+
+    expect(screen.getByRole('button', { name: /Salina’s positions/ })).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByRole('button', { name: 'Recommended' })).toHaveAttribute('aria-selected', 'false');
+    expect(screen.queryByRole('heading', { name: 'Geopolitics & chips' })).toBeNull();
+  });
+
+  // The hub's query takes a space, so the space filter runs server-side on the All tab; topics are
+  // knowledge-graph data geo-chat doesn't model, so that one stays a cut over the loaded rows.
+  it('sends the selected space to the hub query', async () => {
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+    showAllClaims();
+
+    selectFilter('Any space', 'Crypto');
+    await waitFor(() => expect(browsedClaimsQueryOptions()?.spaceId).toBe(SPACE_1));
   });
 
   // On a phone the three tabs are wider than the screen. They were laid out in a row that could
@@ -821,6 +914,7 @@ describe('DebateRematchPageClient', () => {
 
   it('shows the opponent-specific empty state when no claim is debate-ready', () => {
     mocks.claims = [];
+    mocks.positions = [];
     render(<DebateRematchPageClient sessionId="rematch-1" />);
 
     expect(screen.getByText(/Salina hasn’t responded yet/)).toBeInTheDocument();
@@ -892,15 +986,53 @@ describe('DebateRematchPageClient', () => {
     expect(mocks.rematchClaimIds.flat()).not.toContain(CLAIM_MORE);
   });
 
-  // Listing the unfiltered pool and trimming it once the allowlist lands means claims and spaces
-  // appear and then vanish under the viewer. Waiting is the honest state.
-  it('shows nothing while the allowlist is still resolving', async () => {
+  // Listing a pool and trimming it once the allowlist lands means claims appear and then vanish
+  // under the viewer. Every list waits; the count waits with it, so the tab can't advertise a
+  // position it is about to drop.
+  it('holds every list, and the count, while the allowlist is still resolving', async () => {
     mocks.spaceAllowlist = null;
     mocks.allowlistLoading = true;
     render(<DebateRematchPageClient sessionId="rematch-1" />);
-    showAllClaims();
 
+    expect(screen.queryByText('A claim both participants chose')).toBeNull();
+    expect(within(screen.getByRole('button', { name: /Salina’s positions/ })).getByText('0')).toBeInTheDocument();
+
+    showAllClaims();
     await waitFor(() => expect(screen.queryByText('A newly published claim')).toBeNull());
+  });
+
+  // A new response from the opponent adds an id to the list, and the lookups keyed on that list
+  // start over. Dropping the tab to nothing — and its count to zero — while they catch up read as
+  // the opponent's positions vanishing every time they took another one.
+  it('keeps the opponent’s list and count up while a new response is being looked up', () => {
+    const FRESH = '019fedb7-5b96-7e83-9f66-7bc2ad4f9953';
+    const view = render(<DebateRematchPageClient sessionId="rematch-1" />);
+    expect(screen.getByText('A claim both participants chose')).toBeInTheDocument();
+
+    // The graph reports another side; the id-keyed lookups are back in flight.
+    mocks.positions = [...mocks.positions, position('profile-remote', FRESH, SPACE_1, true)];
+    mocks.browsedLookupLoading = true;
+    view.rerender(<DebateRematchPageClient sessionId="rematch-1" />);
+
+    expect(screen.getByText('A claim both participants chose')).toBeInTheDocument();
+    const tab = screen.getByRole('button', { name: /Salina’s positions/ });
+    expect(within(tab).getByText('1')).toBeInTheDocument();
+
+    // They land, and the new claim joins the list.
+    mocks.browsedLookupLoading = false;
+    mocks.entities = [...mocks.entities, { ...sharedEntity(), id: FRESH, name: 'A claim Salina just answered' }];
+    view.rerender(<DebateRematchPageClient sessionId="rematch-1" />);
+
+    expect(screen.getByText('A claim Salina just answered')).toBeInTheDocument();
+    expect(within(tab).getByText('2')).toBeInTheDocument();
+  });
+
+  // Same for the session's exclusions: the source debate's claim and a recently rejected one are
+  // known only once geo-chat answers for the opponent's ids, and listing them first would flash.
+  it('holds the opponent’s list until the session’s exclusions are known', () => {
+    mocks.browsedLookupLoading = true;
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+
     expect(screen.queryByText('A claim both participants chose')).toBeNull();
   });
 
@@ -931,11 +1063,11 @@ describe('DebateRematchPageClient', () => {
       target: { value: 'newly published' },
     });
 
-    // Debounced, so the shared claim leaves a beat later.
+    // The All tab searches server-side, through the hub's query — debounced.
     expect(screen.getByText('A newly published claim')).toBeInTheDocument();
-    await waitFor(() => expect(screen.queryByText('A claim both participants chose')).toBeNull());
+    await waitFor(() => expect(browsedClaimsQueryOptions()?.search).toBe('newly published'));
 
-    // The search still applies on the opponent tab, where it leaves nothing.
+    // The opponent's tab is the graph's list, so the term is applied here — where it leaves nothing.
     fireEvent.click(screen.getByRole('button', { name: /Salina’s positions/ }));
     await waitFor(() => expect(screen.queryByText('A newly published claim')).toBeNull());
     expect(screen.getByText('No claims match these filters.')).toBeInTheDocument();
@@ -1000,10 +1132,10 @@ describe('DebateRematchPageClient', () => {
       mocks.claimReadiness = [];
 
       render(<DebateRematchPageClient sessionId="rematch-1" />);
-      showAllClaims();
+      expect(mocks.gatewaySpaceScopes.filter(scope => scope.enabled).at(-1)?.spaceIds).toEqual([SPACE_1]);
 
-      const retained = mocks.gatewaySpaceScopes.filter(scope => scope.enabled).at(-1);
-      expect(retained?.spaceIds).toEqual([SPACE_1, SPACE_2].sort());
+      showAllClaims();
+      expect(mocks.gatewaySpaceScopes.filter(scope => scope.enabled).at(-1)?.spaceIds).toEqual([SPACE_2]);
     });
 
     it('shows the toggle off for a claim it reports as not ready', () => {
@@ -1039,10 +1171,10 @@ describe('DebateRematchPageClient', () => {
     const FIRST = '019fedb4-3f74-7c61-8d44-5fa08b1e7a01';
     const SECOND = '019fedb4-3f74-7c61-8d44-5fa08b1e7a02';
     const THIRD = '019fedb4-3f74-7c61-8d44-5fa08b1e7a03';
-    mocks.entities = [
-      publishedEntity(FIRST, 'Ordered claim one'),
-      publishedEntity(SECOND, 'Ordered claim two'),
-      publishedEntity(THIRD, 'Ordered claim three'),
+    mocks.matchmakingClaims = [
+      matchmakingClaim(FIRST, 'Ordered claim one'),
+      matchmakingClaim(SECOND, 'Ordered claim two'),
+      matchmakingClaim(THIRD, 'Ordered claim three'),
     ];
     mocks.savedClaims = [];
     mocks.claims = [
@@ -1080,30 +1212,6 @@ describe('DebateRematchPageClient', () => {
 
     expect(screen.getByRole('switch', { name: 'Ready to debate this claim' })).toBeChecked();
     expect(mocks.perSpaceReadinessGroups.some(groups => groups.length > 0)).toBe(true);
-  });
-
-  // `keepPreviousData` keeps the previous term's page on screen while the new one fetches. Filing
-  // it under the new term would let a prior search's claims survive into this one — and into the
-  // unfiltered list once the term is cleared.
-  it('does not bank the previous search’s page against a new term', async () => {
-    const STALE = '019fedb4-3f74-7c61-8d44-5fa08b1e7732';
-    const { rerender } = render(<DebateRematchPageClient sessionId="rematch-1" />);
-    showAllClaims();
-
-    // The new term is in flight, so the page still on hand belongs to the previous one. Its name
-    // contains the term, so nothing downstream would filter it out if it were banked.
-    mocks.entities = [publishedEntity(STALE, 'A stale claim from the previous search')];
-    mocks.entityQueryPlaceholder = true;
-    fireEvent.change(screen.getByRole('textbox', { name: 'Search claims' }), { target: { value: 'claim' } });
-    await waitFor(() => expect(browsedClaimsQueryOptions()?.search).toBe('claim'));
-
-    // The real page for this term lands.
-    mocks.entities = [publishedEntity()];
-    mocks.entityQueryPlaceholder = false;
-    rerender(<DebateRematchPageClient sessionId="rematch-1" />);
-
-    expect(screen.getByText('A newly published claim')).toBeInTheDocument();
-    await waitFor(() => expect(screen.queryByText('A stale claim from the previous search')).toBeNull());
   });
 
   // Taking a side here means you want to debate it, so readiness shouldn't be a second step.
@@ -1206,16 +1314,8 @@ describe('DebateRematchPageClient', () => {
   // geo-chat rejects a request for a claim it has no position for — "respond to this claim before
   // requesting a rematch" — so the button waits for geo-chat's copy, not the optimistic one. It
   // stays hidden rather than disabled: an unpressable button reads as broken.
-  it('withholds the request until geo-chat has the position it will be validated against', () => {
-    mocks.claims = [
-      {
-        ...sharedClaim(),
-        participants: [
-          { user_id: 'user-local', position: null, position_label: null },
-          { user_id: 'user-remote', position: false, position_label: 'Disagree' },
-        ],
-      },
-    ];
+  it('withholds the request until the graph has the position it will be validated against', () => {
+    mocks.positions = [position('profile-remote', CLAIM_SHARED, SPACE_1, false)];
     mocks.optimisticResponses.set(CLAIM_SHARED, 'positive');
     render(<DebateRematchPageClient sessionId="rematch-1" />);
 
@@ -1244,14 +1344,9 @@ describe('DebateRematchPageClient', () => {
   // Switching sides leaves geo-chat holding the side you just moved off, which is no more valid to
   // request against than holding none.
   it('withholds the request while a side switch is still publishing', () => {
-    mocks.claims = [
-      {
-        ...sharedClaim(),
-        participants: [
-          { user_id: 'user-local', position: false, position_label: 'Disagree' },
-          { user_id: 'user-remote', position: false, position_label: 'Disagree' },
-        ],
-      },
+    mocks.positions = [
+      position('profile-local', CLAIM_SHARED, SPACE_1, false),
+      position('profile-remote', CLAIM_SHARED, SPACE_1, false),
     ];
     mocks.optimisticResponses.set(CLAIM_SHARED, 'positive');
     render(<DebateRematchPageClient sessionId="rematch-1" />);
@@ -1263,31 +1358,19 @@ describe('DebateRematchPageClient', () => {
   // the switch back when that happens — so opting in off the optimistic position made the toggle
   // visibly flip on and straight back off.
   it('waits for the response to settle before standing the viewer ready', async () => {
-    const unresponded = {
-      ...sharedClaim(),
-      participants: [
-        { user_id: 'user-local', position: null, position_label: null },
-        { user_id: 'user-remote', position: false, position_label: 'Disagree' },
-      ],
-    };
-    mocks.claims = [unresponded];
+    mocks.positions = [position('profile-remote', CLAIM_SHARED, SPACE_1, false)];
     const view = render(<DebateRematchPageClient sessionId="rematch-1" />);
     expect(mocks.joinQueue).not.toHaveBeenCalled();
 
-    // The side is picked: optimistic only, geo-chat still has nothing.
+    // The side is picked: optimistic only, the graph still has nothing.
     mocks.optimisticResponses.set(CLAIM_SHARED, 'positive');
     view.rerender(<DebateRematchPageClient sessionId="rematch-1" />);
     expect(mocks.joinQueue).not.toHaveBeenCalled();
 
-    // geo-chat catches up, and only now is readiness sent.
-    mocks.claims = [
-      {
-        ...sharedClaim(),
-        participants: [
-          { user_id: 'user-local', position: true, position_label: 'Agree' },
-          { user_id: 'user-remote', position: false, position_label: 'Disagree' },
-        ],
-      },
+    // The graph indexes it, and only now is readiness sent.
+    mocks.positions = [
+      position('profile-local', CLAIM_SHARED, SPACE_1, true),
+      position('profile-remote', CLAIM_SHARED, SPACE_1, false),
     ];
     view.rerender(<DebateRematchPageClient sessionId="rematch-1" />);
 
@@ -1298,7 +1381,7 @@ describe('DebateRematchPageClient', () => {
   // `spaces[0]` is a citing space whenever it outranks the claim's own. Responding in one space and
   // asking to debate in another is what the server answers with "respond to this claim in this
   // space before enabling debate readiness".
-  it('scopes a browsed claim to the space it is named in, not the highest-ranked one citing it', () => {
+  it('scopes a claim to the space it is named in, not the highest-ranked one citing it', () => {
     mocks.entities = [
       {
         ...publishedEntity(CLAIM_MORE, 'A claim that lives in Podcasts'),
@@ -1314,42 +1397,30 @@ describe('DebateRematchPageClient', () => {
         ],
       },
     ];
+    // The opponent answered it in Podcasts, which is where the graph has the claim.
+    mocks.positions = [position('profile-remote', CLAIM_MORE, PODCASTS_SPACE, false)];
     // The toggle only offers itself once the viewer holds a position.
     mocks.optimisticResponses.set(CLAIM_MORE, 'positive');
     render(<DebateRematchPageClient sessionId="rematch-1" />);
-    showAllClaims();
 
     // The space is fixed when the card wires its readiness machine, not when the request goes out —
-    // a browsed claim has no indexed response yet, so the machine holds the request until geo-chat
-    // has one. What matters here is which space it is bound to.
+    // the viewer has no indexed response yet, so the machine holds the request until geo-chat has
+    // one. What matters here is which space it is bound to.
     expect(screen.getByText('A claim that lives in Podcasts')).toBeInTheDocument();
     expect(mocks.joinQueueSpaceIds).toContain(PODCASTS_SPACE);
     expect(mocks.joinQueueSpaceIds).not.toContain(CRYPTO_SPACE);
   });
 
   it('stands the viewer ready only once, even as the claim keeps refetching', async () => {
-    mocks.claims = [
-      {
-        ...sharedClaim(),
-        participants: [
-          { user_id: 'user-local', position: null, position_label: null },
-          { user_id: 'user-remote', position: false, position_label: 'Disagree' },
-        ],
-      },
-    ];
+    mocks.positions = [position('profile-remote', CLAIM_SHARED, SPACE_1, false)];
     const view = render(<DebateRematchPageClient sessionId="rematch-1" />);
 
     mocks.optimisticResponses.set(CLAIM_SHARED, 'positive');
     view.rerender(<DebateRematchPageClient sessionId="rematch-1" />);
 
-    mocks.claims = [
-      {
-        ...sharedClaim(),
-        participants: [
-          { user_id: 'user-local', position: true, position_label: 'Agree' },
-          { user_id: 'user-remote', position: false, position_label: 'Disagree' },
-        ],
-      },
+    mocks.positions = [
+      position('profile-local', CLAIM_SHARED, SPACE_1, true),
+      position('profile-remote', CLAIM_SHARED, SPACE_1, false),
     ];
     view.rerender(<DebateRematchPageClient sessionId="rematch-1" />);
     view.rerender(<DebateRematchPageClient sessionId="rematch-1" />);
@@ -1423,6 +1494,41 @@ function sharedClaim(): DebateRematchClaim {
     shared_preference: true,
     recently_rejected: false,
     previously_debated: false,
+  };
+}
+
+/** The shared claim as the graph holds it: named in Crypto, where both sides responded. */
+function sharedEntity() {
+  return {
+    id: CLAIM_SHARED,
+    name: 'A claim both participants chose',
+    description: null,
+    spaces: [SPACE_1],
+    values: [{ property: { id: NAME_PROPERTY }, spaceId: SPACE_1, value: 'A claim both participants chose' }],
+    relations: [],
+  };
+}
+
+function position(profileSpaceId: string, claimId: string, spaceId: string, side: boolean): ParticipantPosition {
+  return { profileSpaceId, claimId, spaceId, responseKind: 'stance', position: side };
+}
+
+/** The published claim as the hub's claims query lists it: in Governance space, tagged twice. */
+function matchmakingClaim(id = CLAIM_MORE, claim = 'A newly published claim'): MatchmakingClaim {
+  return {
+    claim: { id, space_id: SPACE_2, claim_entity_id: id, claim, description: null },
+    response_kind: 'stance',
+    viewer_response: null,
+    viewer_debate_ready: false,
+    readiness_disabled_reason: null,
+    viewer_position: null,
+    topics: [
+      { id: 'topic-gov', name: 'Governance' },
+      { id: 'topic-eth', name: 'Ethics' },
+    ],
+    positions: [],
+    score: 0,
+    active_debate: false,
   };
 }
 

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
@@ -697,6 +697,10 @@ describe('DebateRematchPageClient', () => {
     expect(screen.getByText('A claim both participants chose')).toBeInTheDocument();
     const tab = screen.getByRole('button', { name: /Salina’s positions/ });
     expect(within(tab).getByText('2')).toBeInTheDocument();
+    // geo-chat's settled batch has no row for it, so it has no readiness row: not ready, drawn
+    // without spending a per-space request to find that out.
+    expect(screen.getAllByRole('switch', { name: 'Ready to debate this claim' })).toHaveLength(2);
+    expect(mocks.perSpaceReadinessGroups.every(groups => groups.length === 0)).toBe(true);
     // Hydrated by id — exactly the claims the graph named, nothing paged.
     expect(mocks.entityIdLookups.at(-1)).toEqual([CLAIM_SHARED, FRESH]);
     // And the graph was asked about exactly these two people.
@@ -827,6 +831,39 @@ describe('DebateRematchPageClient', () => {
     expect(screen.getByRole('button', { name: /Salina’s positions/ })).toHaveAttribute('aria-selected', 'true');
     expect(screen.getByRole('button', { name: 'Recommended' })).toHaveAttribute('aria-selected', 'false');
     expect(screen.queryByRole('heading', { name: 'Geopolitics & chips' })).toBeNull();
+  });
+
+  // An opponent's tab with nothing on it is no place to land while a curator's page may still be
+  // on its way; it waits, and Recommended takes the landing once it is known to exist.
+  it('waits on the curated lookup while the opponent has nothing to show, then lands on Recommended', async () => {
+    mocks.savedClaims = [];
+    mocks.claims = [];
+    mocks.positions = [];
+    mocks.recommendedLoading = true;
+    const { rerender } = render(<DebateRematchPageClient sessionId="rematch-1" />);
+
+    expect(screen.queryByText(/hasn’t responded/)).toBeNull();
+    expect(screen.getByRole('button', { name: 'Recommended' })).toBeInTheDocument();
+
+    mocks.recommendedLoading = false;
+    mocks.recommendedSections = [{ id: 'block-1', name: 'Geopolitics & chips', claimIds: [CLAIM_MORE] }];
+    mocks.recommendedEntities = [publishedEntity()];
+    rerender(<DebateRematchPageClient sessionId="rematch-1" />);
+
+    expect(screen.getByRole('button', { name: 'Recommended' })).toHaveAttribute('aria-selected', 'true');
+    expect(await screen.findByRole('heading', { name: 'Geopolitics & chips' })).toBeInTheDocument();
+  });
+
+  // A claim either side turned down recently still lists — with its request disabled and saying
+  // why — whether the row came from geo-chat or from the hub's index, which knows nothing of it.
+  it('keeps a recently rejected claim listed with its request disabled', () => {
+    mocks.claims = [];
+    mocks.session = session({ recently_rejected_claim_ids: [CLAIM_SHARED] });
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+
+    expect(screen.getByText('A claim both participants chose')).toBeInTheDocument();
+    expect(screen.getByText('Recently rejected')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Request debate' })).toBeDisabled();
   });
 
   // The hub's query takes a space, so the space filter runs server-side on the All tab; topics are
@@ -977,15 +1014,6 @@ describe('DebateRematchPageClient', () => {
     expect(within(tab).getByText('0')).toBeInTheDocument();
   });
 
-  // The browsed scan is graph-wide; asking geo-chat about claims the picker will drop spends a
-  // batch of round trips on rows nobody sees.
-  it('keeps disallowed claims out of the geo-chat lookup entirely', () => {
-    mocks.spaceAllowlist = new Set([SPACE_1.replace(/-/g, '')]);
-    render(<DebateRematchPageClient sessionId="rematch-1" />);
-
-    expect(mocks.rematchClaimIds.flat()).not.toContain(CLAIM_MORE);
-  });
-
   // Listing a pool and trimming it once the allowlist lands means claims appear and then vanish
   // under the viewer. Every list waits; the count waits with it, so the tab can't advertise a
   // position it is about to drop.
@@ -1034,15 +1062,6 @@ describe('DebateRematchPageClient', () => {
     render(<DebateRematchPageClient sessionId="rematch-1" />);
 
     expect(screen.queryByText('A claim both participants chose')).toBeNull();
-  });
-
-  // Nor does it spend a batch of geo-chat round trips on a pool it is about to throw away.
-  it('holds the geo-chat lookup while the allowlist is still resolving', () => {
-    mocks.spaceAllowlist = null;
-    mocks.allowlistLoading = true;
-    render(<DebateRematchPageClient sessionId="rematch-1" />);
-
-    expect(mocks.rematchClaimIds.flat()).not.toContain(CLAIM_MORE);
   });
 
   // A lookup that settles without an answer must not leave the picker permanently empty.
@@ -1135,7 +1154,7 @@ describe('DebateRematchPageClient', () => {
       expect(mocks.gatewaySpaceScopes.filter(scope => scope.enabled).at(-1)?.spaceIds).toEqual([SPACE_1]);
 
       showAllClaims();
-      expect(mocks.gatewaySpaceScopes.filter(scope => scope.enabled).at(-1)?.spaceIds).toEqual([SPACE_2]);
+      expect(mocks.gatewaySpaceScopes.filter(scope => scope.enabled).at(-1)?.spaceIds).toEqual([SPACE_1, SPACE_2]);
     });
 
     it('shows the toggle off for a claim it reports as not ready', () => {

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -211,7 +211,6 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
       ...(savedClaimsQuery.data?.excluded_claim_ids ?? []),
       ...(opponentClaimsQuery.data?.excluded_claim_ids ?? []),
       ...(curatedClaimsQuery.data?.excluded_claim_ids ?? []),
-      ...(session?.recently_rejected_claim_ids ?? []),
     ]);
     const sourceClaimId = sourceDebateQuery.data?.claim.claim_entity_id;
     if (sourceClaimId) excluded.add(sourceClaimId);
@@ -223,6 +222,25 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
     session?.recently_rejected_claim_ids,
     sourceDebateQuery.data,
   ]);
+
+  // A claim either side recently rejected stays listed with its request disabled, as geo-chat's
+  // own rows flag it; the hub's index knows nothing of this session, so its rows read the list.
+  const recentlyRejectedClaimIds = React.useMemo(
+    () => new Set(session?.recently_rejected_claim_ids ?? []),
+    [session?.recently_rejected_claim_ids]
+  );
+
+  // Whether geo-chat's rows carry readiness at all. When they do, a claim its settled batch has no
+  // row for has no readiness row either: not ready is the truth, not a guess to send per space.
+  // A backend that predates readiness on these rows leaves every claim to the per-space lookup.
+  const sessionCarriesReadiness = React.useMemo(() => {
+    const rows = [
+      ...(savedClaimsQuery.data?.claims ?? []),
+      ...(opponentClaimsQuery.data?.claims ?? []),
+      ...(curatedClaimsQuery.data?.claims ?? []),
+    ];
+    return rows.length === 0 || rows[0]!.viewer_debate_ready !== undefined;
+  }, [curatedClaimsQuery.data, opponentClaimsQuery.data, savedClaimsQuery.data]);
 
   // geo-chat's row for a claim, where it has one. It carries the session flags and readiness; the
   // sides on it are replaced by the graph's below, which are fresher by a notification round trip.
@@ -256,13 +274,14 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
         response_kind: responseKind,
         participants: sidesOf(entity.id, sessionRow?.claim.space_id ?? homeSpaceId, responseKind),
         shared_preference: sessionRow?.shared_preference ?? false,
-        recently_rejected: sessionRow?.recently_rejected ?? false,
+        recently_rejected: sessionRow?.recently_rejected ?? recentlyRejectedClaimIds.has(entity.id),
         previously_debated: sessionRow?.previously_debated ?? false,
-        viewer_debate_ready: sessionRow?.viewer_debate_ready,
-        readiness_disabled_reason: sessionRow?.readiness_disabled_reason,
+        // These rows only list once their geo-chat batch has settled (see `sessionCarriesReadiness`).
+        viewer_debate_ready: sessionRow ? sessionRow.viewer_debate_ready : sessionCarriesReadiness ? false : undefined,
+        readiness_disabled_reason: sessionRow ? sessionRow.readiness_disabled_reason : null,
       };
     },
-    [sessionRowsByClaimId, sidesOf]
+    [recentlyRejectedClaimIds, sessionCarriesReadiness, sessionRowsByClaimId, sidesOf]
   );
 
   // Topics live on the KG claim entity, so resolve them here to label each card and drive the
@@ -333,32 +352,52 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   const curatedClaims = useLastSettled(curatedClaimsNow, curatedClaimsSettling);
 
   // The All tab: geo-chat's rows, the graph's sides. Held while the allowlist resolves (see above).
-  const browsedRows = React.useMemo(
-    () =>
-      allowlistPending
-        ? []
-        : browsedPages
-            .flatMap(page => page.claims)
-            .filter(
-              entry =>
-                !excludedClaimIds.has(entry.claim.claim_entity_id) &&
-                isClaimSpaceAllowed(entry.claim.space_id, spaceAllowlist)
-            )
-            .map((entry): DebateRematchClaim => {
-              const sessionRow = sessionRowsByClaimId.get(entry.claim.claim_entity_id);
-              return {
-                claim: entry.claim,
-                response_kind: entry.response_kind,
-                participants: sidesOf(entry.claim.claim_entity_id, entry.claim.space_id, entry.response_kind),
-                shared_preference: sessionRow?.shared_preference ?? false,
-                recently_rejected: sessionRow?.recently_rejected ?? false,
-                previously_debated: sessionRow?.previously_debated ?? false,
-                viewer_debate_ready: entry.viewer_debate_ready,
-                readiness_disabled_reason: entry.readiness_disabled_reason,
-              };
-            }),
-    [allowlistPending, browsedPages, excludedClaimIds, sessionRowsByClaimId, sidesOf, spaceAllowlist]
-  );
+  // It is still every claim the picker knows: the session's own rows — what both have answered,
+  // the opponent's and the curated lists — join the pages, so a shared preference the index has
+  // not paged to yet is on the All tab, pinned first as it always was.
+  const browsedRows = React.useMemo(() => {
+    if (allowlistPending) return [];
+    const rows = new Map<string, DebateRematchClaim>();
+    for (const entry of browsedPages.flatMap(page => page.claims)) {
+      const claimId = entry.claim.claim_entity_id;
+      if (excludedClaimIds.has(claimId) || !isClaimSpaceAllowed(entry.claim.space_id, spaceAllowlist)) continue;
+      const sessionRow = sessionRowsByClaimId.get(claimId);
+      rows.set(claimId, {
+        claim: entry.claim,
+        response_kind: entry.response_kind,
+        participants: sidesOf(claimId, entry.claim.space_id, entry.response_kind),
+        shared_preference: sessionRow?.shared_preference ?? false,
+        recently_rejected: sessionRow?.recently_rejected ?? recentlyRejectedClaimIds.has(claimId),
+        previously_debated: sessionRow?.previously_debated ?? false,
+        viewer_debate_ready: entry.viewer_debate_ready,
+        readiness_disabled_reason: entry.readiness_disabled_reason,
+      });
+    }
+    const savedRows = (savedClaimsQuery.data?.claims ?? [])
+      .filter(
+        row =>
+          !excludedClaimIds.has(row.claim.claim_entity_id) && isClaimSpaceAllowed(row.claim.space_id, spaceAllowlist)
+      )
+      .map(row => ({
+        ...row,
+        participants: sidesOf(row.claim.claim_entity_id, row.claim.space_id, row.response_kind),
+      }));
+    for (const row of [...savedRows, ...opponentClaims, ...curatedClaims]) {
+      if (!rows.has(row.claim.claim_entity_id)) rows.set(row.claim.claim_entity_id, row);
+    }
+    return [...rows.values()].sort((a, b) => Number(b.shared_preference) - Number(a.shared_preference));
+  }, [
+    allowlistPending,
+    browsedPages,
+    curatedClaims,
+    excludedClaimIds,
+    opponentClaims,
+    recentlyRejectedClaimIds,
+    savedClaimsQuery.data,
+    sessionRowsByClaimId,
+    sidesOf,
+    spaceAllowlist,
+  ]);
   // The server re-sorts on every readiness change, so hold the order the viewer is looking at
   // until they ask for a different list.
   const browsedClaims = useStableListOrder(
@@ -410,7 +449,8 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   // picker lands on whichever has something to show first and stays there: once a tab has drawn
   // its list the landing is settled, so a curated page arriving afterwards adds its tab to the
   // strip rather than moving the viewer onto it. Before then Recommended wins as soon as it is
-  // known to exist, since a curator's page for this pairing is the best thing to land on.
+  // known to exist, since a curator's page for this pairing is the best thing to land on — and an
+  // opponent's tab with nothing on it waits for that lookup rather than settling on an empty state.
   const landedTabRef = React.useRef<PickerTab | null>(null);
   const tab: PickerTab = chosenTab ?? landedTabRef.current ?? (hasRecommended ? 'recommended' : 'opponent');
   const setTab = setChosenTab;
@@ -477,7 +517,10 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
     (tab === 'recommended'
       ? recommendedLoading || curatedClaimsQuery.isLoading
       : tab === 'opponent'
-        ? positions.isLoading || opponentEntitiesQuery.isLoading || opponentClaimsQuery.isLoading
+        ? positions.isLoading ||
+          opponentEntitiesQuery.isLoading ||
+          opponentClaimsQuery.isLoading ||
+          (landedTabRef.current === null && claims.length === 0 && recommendedLoading)
         : browsedClaimsQuery.isLoading);
 
   const tabError =
@@ -488,11 +531,13 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
         ? browsedClaimsQuery.error
         : curatedClaimsQuery.error);
 
-  // Settle the landing tab once it has drawn its list (see `landedTabRef`).
+  // Settle the landing tab once it has drawn its list (see `landedTabRef`). An empty tab settles
+  // nothing: it is still the default, and Recommended may yet take over.
+  const tabHasRows = claims.length > 0;
   React.useEffect(() => {
-    if (chosenTab !== null || landedTabRef.current !== null || tabIsLoading) return;
+    if (chosenTab !== null || landedTabRef.current !== null || tabIsLoading || !tabHasRows) return;
     landedTabRef.current = tab;
-  }, [chosenTab, tab, tabIsLoading]);
+  }, [chosenTab, tab, tabHasRows, tabIsLoading]);
 
   // The curated tab groups by block rather than listing flat, but narrows on the same filters.
   const visibleSections = React.useMemo(() => {

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -12,12 +12,15 @@ import {
   type DebateClaimPositionSummary,
   type DebateClaimSummary,
   type DebateRematchClaim,
+  type DebateRematchClaimPosition,
   type DebateRematchParticipant,
   type DebateRematchSession,
+  type DebateResponseKind,
+  type MatchmakingClaimsQuery,
   type MatchmakingReadiness,
   type MatchmakingTopic,
 } from '~/core/debates/api';
-import { type ClaimPickerEntity, useClaimPickerPage } from '~/core/debates/claim-picker-page';
+import { type ClaimPickerEntity, useClaimEntitiesByIds } from '~/core/debates/claim-picker-page';
 import { isClaimSpaceAllowed } from '~/core/debates/claim-space-allowlist';
 import { markEnteringDebate } from '~/core/debates/debate-entry-intent';
 import { useDebateGatewaySpaceScopes } from '~/core/debates/debate-gateway';
@@ -36,10 +39,13 @@ import {
   useRejectDebateRematchRequest,
 } from '~/core/debates/hooks';
 import { SpaceTopicFilters } from '~/core/debates/matchmaking/claims-tab';
+import { useMatchmakingClaims } from '~/core/debates/matchmaking/hooks';
 import { HubCardList } from '~/core/debates/matchmaking/hub-motion';
 import { HubPillButton } from '~/core/debates/matchmaking/hub-pill-button';
 import { HubQueryState } from '~/core/debates/matchmaking/hub-states';
 import { MatchmakingClaimCard } from '~/core/debates/matchmaking/matchmaking-claim-card';
+import { useStableListOrder } from '~/core/debates/matchmaking/use-stable-list-order';
+import { participantSidesOn, useParticipantPositions } from '~/core/debates/participant-positions';
 import { useRecommendedClaimSections } from '~/core/debates/recommended-claims';
 import { useClaimDebateReadiness } from '~/core/debates/use-claim-debate-readiness';
 import { useClaimSpaceAllowlist } from '~/core/debates/use-claim-space-allowlist';
@@ -57,6 +63,23 @@ import { Input } from '~/design-system/input';
 import { Text } from '~/design-system/text';
 
 const SEARCH_DEBOUNCE_MS = 250;
+
+const NO_PARTICIPANTS: DebateRematchParticipant[] = [];
+
+function sameId(left: string, right: string) {
+  return uuidToHex(left) === uuidToHex(right);
+}
+
+/**
+ * `value` once it has settled, and the last settled value while it is settling again. Before the
+ * first settle there is nothing to hold, and the (empty) unsettled value comes through — which is
+ * what lets the first load show a loading state instead of an empty list.
+ */
+function useLastSettled<T>(value: T, settling: boolean): T {
+  const lastSettledRef = React.useRef<{ value: T } | null>(null);
+  if (!settling) lastSettledRef.current = { value };
+  return settling && lastSettledRef.current ? lastSettledRef.current.value : value;
+}
 
 type PickerTab = 'recommended' | 'opponent' | 'all';
 
@@ -82,69 +105,55 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
     return () => clearTimeout(timeout);
   }, [search]);
 
-  const [publishedClaimsCursor, setPublishedClaimsCursor] = React.useState<string | undefined>();
+  const [spaceId, setSpaceId] = React.useState<string | null>(null);
+  const [topicId, setTopicId] = React.useState<string | null>(null);
+  // Left unset until the viewer picks one: Recommended is the best landing tab when a curator has
+  // put something together for this pairing, and it doesn't exist otherwise. Deciding in state
+  // would fix the default before that lookup settles.
+  const [chosenTab, setChosenTab] = React.useState<PickerTab | null>(null);
 
-  // A new term is a new corpus, so paging starts over.
-  React.useEffect(() => {
-    setPublishedClaimsCursor(undefined);
-  }, [debouncedSearch]);
-
-  const {
-    entities: publishedClaimsPage,
-    isLoading: publishedClaimsLoading,
-    isPlaceholderData: publishedClaimsPlaceholder,
-    endCursor: publishedClaimsEndCursor,
-    hasNextPage: publishedClaimsHasNextPage,
-    // Search runs in the query rather than over the loaded pages. The All tab browses every
-    // published claim 50 at a time, so filtering locally only ever searched what had been paged
-    // in — the hub's Claims tab searches server-side, and this matches it.
-    //
-    // A purpose-built page rather than `useQueryEntities`: that fetches whole entities — every
-    // value, every relation, every related entity's values — and this scan is graph-wide, so a
-    // page ran to a quarter of a megabyte and several seconds. The picker reads six fields.
-  } = useClaimPickerPage({ search: debouncedSearch, after: publishedClaimsCursor });
-
-  // Pages accumulate as the viewer loads more, but a change of term replaces them rather than
-  // piling the new matches on top of the previous corpus.
-  const [publishedClaims, setPublishedClaims] = React.useState<{
-    search: string;
-    entities: ClaimPickerEntity[];
-  }>({ search: '', entities: [] });
-  React.useEffect(() => {
-    // `keepPreviousData` keeps the old term's page on screen while the new one fetches. Recording
-    // that under the new term would file the previous search's claims as matches for this one, and
-    // the real page would then merge on top of them rather than replace them.
-    if (publishedClaimsPlaceholder) return;
-
-    setPublishedClaims(current => {
-      const sameSearch = current.search === debouncedSearch;
-      const base = sameSearch ? current.entities : [];
-      const next = new Map(base.map(claim => [claim.id, claim]));
-      for (const claim of publishedClaimsPage) {
-        if (!next.has(claim.id)) next.set(claim.id, claim);
-      }
-      if (sameSearch && next.size === base.length) return current;
-      return { search: debouncedSearch, entities: [...next.values()] };
-    });
-  }, [debouncedSearch, publishedClaimsPage, publishedClaimsPlaceholder]);
   const savedClaimsQuery = useDebateRematchClaims(sessionId);
   const createRequest = useCreateDebateRematchRequest(sessionId);
   const leaveSession = useLeaveDebateRematch(sessionId);
   const acceptRequest = useAcceptDebateRematchRequest();
   const rejectRequest = useRejectDebateRematchRequest();
   const session = sessionQuery.data ?? null;
+  const participants = React.useMemo(() => session?.participants ?? NO_PARTICIPANTS, [session?.participants]);
   // A session opened from a profile challenge has no source debate, so nothing to exclude.
   const sourceDebateQuery = useDebate(session?.source_debate_id ?? '', Boolean(session?.source_debate_id));
 
+  // Both participants' sides on every claim, straight from the knowledge graph. A position is an
+  // on-chain claim response; geo-chat only mirrors them, a hundred claim ids per request. This is
+  // one query for both people, and it is what the opponent's tab is a list of.
+  const positions = useParticipantPositions(participants);
+
+  const remoteParticipant =
+    currentUserId === null ? null : (participants.find(participant => participant.user_id !== currentUserId) ?? null);
+  const remoteName = remoteParticipant?.display_name || remoteParticipant?.profile_space_id || 'debater';
+
+  // The claims the opponent has taken a side on, newest response first — the graph returns them in
+  // that order, and the grouping keeps it.
+  const opponentClaimIds = React.useMemo(() => {
+    if (!remoteParticipant) return [];
+    const ids: string[] = [];
+    for (const [claimId, rows] of positions.byClaim) {
+      if (rows.some(row => sameId(row.profileSpaceId, remoteParticipant.profile_space_id))) ids.push(claimId);
+    }
+    return ids;
+  }, [positions.byClaim, remoteParticipant]);
+
+  // Those ids are all the graph hands back; the claim itself — name, description, home space,
+  // whether it is factual, topics — is a second, narrow lookup.
+  const opponentEntitiesQuery = useClaimEntitiesByIds(opponentClaimIds);
+
   // The opponent is whichever participant isn't the local user; both drive the curated lookup.
   const participantSpaceIds = React.useMemo(
-    () => (session?.participants ?? []).map(participant => participant.profile_space_id),
-    [session?.participants]
+    () => participants.map(participant => participant.profile_space_id),
+    [participants]
   );
-  // Curated claims are picked by hand, so they can be ones the browsed pages haven't reached. The
-  // hook hands back their entities along with the sections, and they join the same pool the browsed
-  // claims feed — so the session lookup, response kinds and the cards treat them like any other
-  // published claim.
+  // Curated claims are picked by hand, so they can be ones the opponent has never answered. The
+  // hook hands back their entities along with the sections, and they join the same pool — so the
+  // session lookup, response kinds and the cards treat them like any other claim.
   const {
     sections: recommendedSections,
     claimEntities: recommendedEntities,
@@ -162,119 +171,201 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   const { allowlist: spaceAllowlist, isLoading: allowlistLoading } = useClaimSpaceAllowlist();
 
   // While it is still resolving there is no telling an allowed space from one the viewer has
-  // nothing to do with, so the picker waits rather than listing the unfiltered set and trimming it
-  // under them. A lookup that settled without an answer leaves this false and falls through to the
-  // unfiltered list — too wide beats never filling.
+  // nothing to do with. Every list waits for it rather than showing the unfiltered set and
+  // trimming it under the viewer — a lookup that settled without an answer leaves this false and
+  // falls through to the unfiltered list, since too wide beats never filling. The wait is the
+  // allowlist alone: the lists' own lookups run alongside it, so they are ready when it lands.
   const allowlistPending = spaceAllowlist === null && allowlistLoading;
 
-  const claimEntities = React.useMemo(() => {
-    // The browsed pages carry the narrow projection; curated claims arrive as full entities, which
-    // satisfy the same shape. Both go through the same helpers below.
-    const byId = new Map<string, ClaimPickerEntity>(publishedClaims.entities.map(claim => [claim.id, claim]));
-    for (const claim of recommendedEntities) if (!byId.has(claim.id)) byId.set(claim.id, claim);
-    return [...byId.values()];
-  }, [publishedClaims.entities, recommendedEntities]);
+  // The All tab is the hub's Claims tab: geo-chat's own index of debatable claims, paged and
+  // searched server-side, each row carrying the viewer's side and readiness. It takes a single
+  // `space_id`, so the viewer's allowlist is a page-local cut, the same as the hub's.
+  const matchmakingQuery = React.useMemo<MatchmakingClaimsQuery>(
+    () => ({ search: debouncedSearch || null, spaceId, filter: 'all' }),
+    [debouncedSearch, spaceId]
+  );
+  const browsedClaimsQuery = useMatchmakingClaims(matchmakingQuery, true);
+  const browsedPages = React.useMemo(() => browsedClaimsQuery.data?.pages ?? [], [browsedClaimsQuery.data]);
+  const browsedFacets = browsedPages[0]?.facets;
 
-  // Looked up separately from the browsed ids rather than as one list. Sharing a list would make
-  // the curated tab wait on the graph-wide claim scan below, which it draws nothing from — and
-  // that scan is the slowest thing on the page.
-  //
-  // Both batched: geo-chat caps the ids per request, and the browsed list alone runs past that cap
-  // after a page or two of Load more.
+  // What geo-chat knows about this session's claims — readiness, the shared-preference and
+  // rejection flags, and which ids the session excludes. One batch for the opponent's claims, one
+  // for the curated ones; the session's own id-less list covers anything both have answered.
+  const opponentClaimsQuery = useDebateRematchClaimsForIds(sessionId, opponentClaimIds);
   const curatedClaimsQuery = useDebateRematchClaimsForIds(sessionId, recommendedClaimIds);
-  // Narrowed to the allowed spaces before the lookup, not after: the browsed scan is graph-wide,
-  // and asking geo-chat about claims the picker is going to drop is a batch of round trips spent
-  // on rows nobody sees. Held entirely while the allowlist is still resolving, when every id would
-  // be such a row.
-  const browsedClaimIds = React.useMemo(
+
+  // A claim's sides, from the graph. The shape the rest of the page was already drawing.
+  const sidesOf = React.useCallback(
+    (claimId: string, claimSpaceId: string, responseKind: DebateResponseKind | null): DebateRematchClaimPosition[] =>
+      participantSidesOn(positions.byClaim, claimId, claimSpaceId, participants).map(side => ({
+        user_id: side.participant.user_id,
+        position: side.position,
+        position_label:
+          side.position === null ? null : responsePositionLabel(side.responseKind ?? responseKind, side.position),
+      })),
+    [participants, positions.byClaim]
+  );
+
+  const excludedClaimIds = React.useMemo(() => {
+    const excluded = new Set([
+      ...(savedClaimsQuery.data?.excluded_claim_ids ?? []),
+      ...(opponentClaimsQuery.data?.excluded_claim_ids ?? []),
+      ...(curatedClaimsQuery.data?.excluded_claim_ids ?? []),
+      ...(session?.recently_rejected_claim_ids ?? []),
+    ]);
+    const sourceClaimId = sourceDebateQuery.data?.claim.claim_entity_id;
+    if (sourceClaimId) excluded.add(sourceClaimId);
+    return excluded;
+  }, [
+    curatedClaimsQuery.data,
+    opponentClaimsQuery.data,
+    savedClaimsQuery.data,
+    session?.recently_rejected_claim_ids,
+    sourceDebateQuery.data,
+  ]);
+
+  // geo-chat's row for a claim, where it has one. It carries the session flags and readiness; the
+  // sides on it are replaced by the graph's below, which are fresher by a notification round trip.
+  const sessionRowsByClaimId = React.useMemo(
+    () =>
+      new Map(
+        [
+          ...(savedClaimsQuery.data?.claims ?? []),
+          ...(opponentClaimsQuery.data?.claims ?? []),
+          ...(curatedClaimsQuery.data?.claims ?? []),
+        ].map(claim => [claim.claim.claim_entity_id, claim])
+      ),
+    [curatedClaimsQuery.data, opponentClaimsQuery.data, savedClaimsQuery.data]
+  );
+
+  /** A picker row from a graph entity, with geo-chat's session row layered on when it has one. */
+  const rowFromEntity = React.useCallback(
+    (entity: ClaimPickerEntity): DebateRematchClaim | null => {
+      const homeSpaceId = claimHomeSpaceId(entity);
+      if (!entity.name || !homeSpaceId) return null;
+      const sessionRow = sessionRowsByClaimId.get(entity.id);
+      const responseKind = sessionRow?.response_kind ?? claimResponseKind(entity, homeSpaceId);
+      return {
+        claim: sessionRow?.claim ?? {
+          id: entity.id,
+          space_id: homeSpaceId,
+          claim_entity_id: entity.id,
+          claim: entity.name,
+          description: entity.description,
+        },
+        response_kind: responseKind,
+        participants: sidesOf(entity.id, sessionRow?.claim.space_id ?? homeSpaceId, responseKind),
+        shared_preference: sessionRow?.shared_preference ?? false,
+        recently_rejected: sessionRow?.recently_rejected ?? false,
+        previously_debated: sessionRow?.previously_debated ?? false,
+        viewer_debate_ready: sessionRow?.viewer_debate_ready,
+        readiness_disabled_reason: sessionRow?.readiness_disabled_reason,
+      };
+    },
+    [sessionRowsByClaimId, sidesOf]
+  );
+
+  // Topics live on the KG claim entity, so resolve them here to label each card and drive the
+  // "Any topic" filter. A claim can carry several topics. The browsed rows bring their own.
+  const topicsByClaimId = React.useMemo(() => {
+    const map = new Map<string, MatchmakingTopic[]>();
+    for (const entity of [...opponentEntitiesQuery.entities, ...recommendedEntities]) {
+      const topics = entity.relations
+        .filter(relation => relation.type.id === TOPICS_PROPERTY_ID && relation.isDeleted !== true)
+        .map(relation => ({ id: relation.toEntity.id, name: relation.toEntity.name ?? null }));
+      if (topics.length > 0) map.set(entity.id, topics);
+    }
+    for (const page of browsedPages) {
+      for (const entry of page.claims) {
+        if (entry.topics.length > 0 && !map.has(entry.claim.claim_entity_id)) {
+          map.set(entry.claim.claim_entity_id, entry.topics);
+        }
+      }
+    }
+    return map;
+  }, [browsedPages, opponentEntitiesQuery.entities, recommendedEntities]);
+
+  // The opponent's tab: every claim they hold a side on, newest first. Held until the allowlist
+  // and the session's exclusions are in, so nothing lists and then vanishes.
+  const opponentClaimsSettling = allowlistPending || opponentClaimsQuery.isLoading || opponentEntitiesQuery.isLoading;
+  const opponentClaimsNow = React.useMemo(() => {
+    if (opponentClaimsSettling) return [];
+    const entitiesById = new Map(opponentEntitiesQuery.entities.map(entity => [entity.id, entity]));
+    const rows: DebateRematchClaim[] = [];
+    for (const claimId of opponentClaimIds) {
+      if (excludedClaimIds.has(claimId)) continue;
+      const entity = entitiesById.get(claimId);
+      const row = entity ? rowFromEntity(entity) : null;
+      if (row && row.participants.some(side => side.user_id !== currentUserId && side.position !== null))
+        rows.push(row);
+    }
+    return rows
+      .filter(row => isClaimSpaceAllowed(row.claim.space_id, spaceAllowlist))
+      .sort((a, b) => Number(b.shared_preference) - Number(a.shared_preference));
+  }, [
+    currentUserId,
+    excludedClaimIds,
+    opponentClaimIds,
+    opponentClaimsSettling,
+    opponentEntitiesQuery.entities,
+    rowFromEntity,
+    spaceAllowlist,
+  ]);
+  // A new response from the opponent adds an id, and the lookups keyed on the id list start over.
+  // The list they were drawn from is still right for every claim already on it, so it stays up
+  // until the new one lands rather than dropping to nothing in between.
+  const opponentClaims = useLastSettled(opponentClaimsNow, opponentClaimsSettling);
+
+  // The curated tab, in the curator's order. Held the same way.
+  const curatedClaimsSettling = allowlistPending || curatedClaimsQuery.isLoading;
+  const curatedClaimsNow = React.useMemo(
+    () =>
+      curatedClaimsSettling
+        ? []
+        : recommendedClaimIds.flatMap(claimId => {
+            if (excludedClaimIds.has(claimId)) return [];
+            const entity = recommendedEntities.find(candidate => candidate.id === claimId);
+            const row = entity ? rowFromEntity(entity) : null;
+            return row && isClaimSpaceAllowed(row.claim.space_id, spaceAllowlist) ? [row] : [];
+          }),
+    [curatedClaimsSettling, excludedClaimIds, recommendedClaimIds, recommendedEntities, rowFromEntity, spaceAllowlist]
+  );
+  const curatedClaims = useLastSettled(curatedClaimsNow, curatedClaimsSettling);
+
+  // The All tab: geo-chat's rows, the graph's sides. Held while the allowlist resolves (see above).
+  const browsedRows = React.useMemo(
     () =>
       allowlistPending
         ? []
-        : publishedClaims.entities
-            .filter(claim => isClaimSpaceAllowed(claimHomeSpaceId(claim), spaceAllowlist))
-            .map(claim => claim.id),
-    [allowlistPending, publishedClaims.entities, spaceAllowlist]
+        : browsedPages
+            .flatMap(page => page.claims)
+            .filter(
+              entry =>
+                !excludedClaimIds.has(entry.claim.claim_entity_id) &&
+                isClaimSpaceAllowed(entry.claim.space_id, spaceAllowlist)
+            )
+            .map((entry): DebateRematchClaim => {
+              const sessionRow = sessionRowsByClaimId.get(entry.claim.claim_entity_id);
+              return {
+                claim: entry.claim,
+                response_kind: entry.response_kind,
+                participants: sidesOf(entry.claim.claim_entity_id, entry.claim.space_id, entry.response_kind),
+                shared_preference: sessionRow?.shared_preference ?? false,
+                recently_rejected: sessionRow?.recently_rejected ?? false,
+                previously_debated: sessionRow?.previously_debated ?? false,
+                viewer_debate_ready: entry.viewer_debate_ready,
+                readiness_disabled_reason: entry.readiness_disabled_reason,
+              };
+            }),
+    [allowlistPending, browsedPages, excludedClaimIds, sessionRowsByClaimId, sidesOf, spaceAllowlist]
   );
-  const browsedClaimsQuery = useDebateRematchClaimsForIds(sessionId, browsedClaimIds);
-
-  const claims = React.useMemo(() => {
-    const synchronizedClaims = new Map(
-      [
-        ...(savedClaimsQuery.data?.claims ?? []),
-        ...(curatedClaimsQuery.data?.claims ?? []),
-        ...(browsedClaimsQuery.data?.claims ?? []),
-      ].map(claim => [claim.claim.claim_entity_id, claim])
-    );
-    const excludedClaimIds = new Set([
-      ...(savedClaimsQuery.data?.excluded_claim_ids ?? []),
-      ...(curatedClaimsQuery.data?.excluded_claim_ids ?? []),
-      ...(browsedClaimsQuery.data?.excluded_claim_ids ?? []),
-    ]);
-    for (const claim of claimEntities) {
-      const homeSpaceId = claimHomeSpaceId(claim);
-      if (
-        claim.name &&
-        homeSpaceId &&
-        !excludedClaimIds.has(claim.id) &&
-        claim.id !== sourceDebateQuery.data?.claim.claim_entity_id &&
-        !synchronizedClaims.has(claim.id)
-      ) {
-        synchronizedClaims.set(claim.id, {
-          claim: {
-            id: claim.id,
-            space_id: homeSpaceId,
-            claim_entity_id: claim.id,
-            claim: claim.name!,
-            description: claim.description,
-          },
-          response_kind: claimResponseKind(claim, homeSpaceId),
-          participants: (session?.participants ?? []).map(participant => ({
-            user_id: participant.user_id,
-            position: null,
-            position_label: null,
-          })),
-          shared_preference: false,
-          recently_rejected: false,
-          previously_debated: false,
-        });
-      }
-    }
-    if (allowlistPending) return [];
-
-    // The batches geo-chat answers come back in id-sorted chunks, so a Map fed from them would
-    // reorder the list every time a new page joins. Lay the rows out in the order the picker
-    // asked for them: saved, then curated, then the browsed page as the knowledge graph paged it.
-    const orderByClaimId = new Map<string, number>();
-    for (const claimId of [
-      ...(savedClaimsQuery.data?.claims ?? []).map(claim => claim.claim.claim_entity_id),
-      ...recommendedClaimIds,
-      ...claimEntities.map(claim => claim.id),
-    ]) {
-      if (!orderByClaimId.has(claimId)) orderByClaimId.set(claimId, orderByClaimId.size);
-    }
-    const orderOf = (claim: DebateRematchClaim) =>
-      orderByClaimId.get(claim.claim.claim_entity_id) ?? Number.MAX_SAFE_INTEGER;
-
-    return [...synchronizedClaims.values()]
-      .filter(claim => !excludedClaimIds.has(claim.claim.claim_entity_id))
-      .filter(claim => isClaimSpaceAllowed(claim.claim.space_id, spaceAllowlist))
-      .sort((a, b) => Number(b.shared_preference) - Number(a.shared_preference) || orderOf(a) - orderOf(b));
-  }, [
-    allowlistPending,
-    browsedClaimsQuery.data,
-    claimEntities,
-    curatedClaimsQuery.data,
-    recommendedClaimIds,
-    savedClaimsQuery.data,
-    session?.participants,
-    sourceDebateQuery.data,
-    spaceAllowlist,
-  ]);
-  const remoteParticipant =
-    currentUserId === null
-      ? null
-      : (session?.participants.find(participant => participant.user_id !== currentUserId) ?? null);
-  const remoteName = remoteParticipant?.display_name || remoteParticipant?.profile_space_id || 'debater';
+  // The server re-sorts on every readiness change, so hold the order the viewer is looking at
+  // until they ask for a different list.
+  const browsedClaims = useStableListOrder(
+    browsedRows,
+    row => `${row.claim.space_id}:${row.claim.claim_entity_id}`,
+    `${debouncedSearch}|${spaceId ?? ''}`
+  );
 
   // The opponent is whichever participant isn't the local user; with no local user there is none.
   const opponentPositionOf = React.useCallback(
@@ -284,26 +375,6 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
         : (claim.participants.find(position => position.user_id !== currentUserId)?.position ?? null),
     [currentUserId]
   );
-
-  // Topics live on the KG claim entity (not the rematch API), so resolve them here to
-  // label each card and drive the "Any topic" filter. A claim can carry several topics.
-  const topicsByClaimId = React.useMemo(() => {
-    const map = new Map<string, MatchmakingTopic[]>();
-    for (const entity of claimEntities) {
-      const topics = entity.relations
-        .filter(relation => relation.type.id === TOPICS_PROPERTY_ID && relation.isDeleted !== true)
-        .map(relation => ({ id: relation.toEntity.id, name: relation.toEntity.name ?? null }));
-      if (topics.length > 0) map.set(entity.id, topics);
-    }
-    return map;
-  }, [claimEntities]);
-
-  // Left unset until the viewer picks one: Recommended is the best landing tab when a curator has
-  // put something together for this pairing, and it doesn't exist otherwise. Deciding in state
-  // would fix the default before that lookup settles.
-  const [chosenTab, setChosenTab] = React.useState<PickerTab | null>(null);
-  const [spaceId, setSpaceId] = React.useState<string | null>(null);
-  const [topicId, setTopicId] = React.useState<string | null>(null);
 
   const returnFromSession = React.useCallback(
     (endedSession: DebateRematchSession) => {
@@ -330,70 +401,98 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
 
   // "Debate now" = claims the opponent has responded to; the tab badge counts them.
   const opponentPositionCount = React.useMemo(
-    () => claims.filter(claim => opponentPositionOf(claim) !== null).length,
-    [claims, opponentPositionOf]
+    () => opponentClaims.filter(claim => opponentPositionOf(claim) !== null).length,
+    [opponentClaims, opponentPositionOf]
   );
 
   const hasRecommended = recommendedSections.length > 0;
-  // Held on the curated tab while the lookup runs, so an empty result mid-flight can't land the
-  // viewer on the opponent tab and then move them once it settles.
-  const tab: PickerTab = chosenTab ?? (hasRecommended || recommendedLoading ? 'recommended' : 'opponent');
+  // The opponent's claims arrive in one round trip; the curated lookup is three, in sequence. The
+  // picker lands on whichever has something to show first and stays there: once a tab has drawn
+  // its list the landing is settled, so a curated page arriving afterwards adds its tab to the
+  // strip rather than moving the viewer onto it. Before then Recommended wins as soon as it is
+  // known to exist, since a curator's page for this pairing is the best thing to land on.
+  const landedTabRef = React.useRef<PickerTab | null>(null);
+  const tab: PickerTab = chosenTab ?? landedTabRef.current ?? (hasRecommended ? 'recommended' : 'opponent');
   const setTab = setChosenTab;
 
-  const facetSpaceIds = React.useMemo(() => [...new Set(claims.map(claim => claim.claim.space_id))], [claims]);
+  const claims = tab === 'opponent' ? opponentClaims : tab === 'recommended' ? curatedClaims : browsedClaims;
+
+  // Every space and topic the lists have shown, not only the current tab's. Space runs in the
+  // browsed query, so the loaded corpus is whatever the current filter allows — a menu listing only
+  // the space you picked would have no way back to another.
+  const seenFacetsRef = React.useRef<{ spaceIds: Set<string>; topics: Map<string, MatchmakingTopic> }>({
+    spaceIds: new Set(),
+    topics: new Map(),
+  });
+
+  const facetSpaceIds = React.useMemo(() => {
+    const seen = seenFacetsRef.current.spaceIds;
+    for (const claim of [...opponentClaims, ...curatedClaims, ...browsedClaims]) seen.add(claim.claim.space_id);
+    for (const id of browsedFacets?.space_ids ?? []) if (isClaimSpaceAllowed(id, spaceAllowlist)) seen.add(id);
+    return [...seen];
+  }, [browsedClaims, browsedFacets?.space_ids, curatedClaims, opponentClaims, spaceAllowlist]);
 
   const facetTopics = React.useMemo(() => {
-    const seen = new Map<string, MatchmakingTopic>();
-    for (const claim of claims) {
+    const seen = seenFacetsRef.current.topics;
+    for (const claim of [...opponentClaims, ...curatedClaims, ...browsedClaims]) {
       for (const topic of topicsByClaimId.get(claim.claim.claim_entity_id) ?? []) {
         if (!seen.has(topic.id)) seen.set(topic.id, topic);
       }
     }
     return [...seen.values()].sort((a, b) => (a.name ?? '').localeCompare(b.name ?? ''));
-  }, [claims, topicsByClaimId]);
+  }, [browsedClaims, curatedClaims, opponentClaims, topicsByClaimId]);
 
-  // The rematch claim list is session-scoped — it already drops the source debate's claim and
-  // anything recently rejected — so there's no server query to push these into, the way the hub's
-  // Claims tab can.
+  // Search and space reach the browsed query; on the other tabs, and for the topic everywhere
+  // (geo-chat doesn't model topics), they are applied here.
   const visibleClaims = React.useMemo(
     () =>
       claims.filter(claim => {
-        if (tab === 'opponent' && opponentPositionOf(claim) === null) return false;
         if (spaceId && claim.claim.space_id !== spaceId) return false;
         if (topicId && !(topicsByClaimId.get(claim.claim.claim_entity_id) ?? []).some(t => t.id === topicId))
           return false;
-        // Still applied locally: the session's own claims come from geo-chat, not the query above,
-        // so they'd otherwise ignore the term. Case-insensitive substring, matching what the
-        // query does to the published half.
-        if (debouncedSearch && !claim.claim.claim.toLowerCase().includes(debouncedSearch.toLowerCase())) return false;
+        if (
+          tab !== 'all' &&
+          debouncedSearch &&
+          !claim.claim.claim.toLowerCase().includes(debouncedSearch.toLowerCase())
+        )
+          return false;
         return true;
       }),
-    [claims, debouncedSearch, opponentPositionOf, spaceId, tab, topicId, topicsByClaimId]
+    [claims, debouncedSearch, spaceId, tab, topicId, topicsByClaimId]
   );
 
   const hasFilters = Boolean(debouncedSearch || spaceId || topicId);
 
   const sentinelRef = useInfiniteScrollSentinel({
-    hasNextPage: publishedClaimsHasNextPage && Boolean(publishedClaimsEndCursor),
-    // The cursor query keeps the previous page on screen while the next one loads, which is this
-    // list's "a fetch is already in flight".
-    isFetchingNextPage: publishedClaimsPlaceholder,
-    fetchNextPage: () => {
-      if (publishedClaimsEndCursor) setPublishedClaimsCursor(publishedClaimsEndCursor);
-    },
+    hasNextPage: Boolean(browsedClaimsQuery.hasNextPage),
+    isFetchingNextPage: browsedClaimsQuery.isFetchingNextPage,
+    fetchNextPage: browsedClaimsQuery.fetchNextPage,
   });
 
-  // Each tab draws from a different set of queries, so each waits on its own. The browsed scan is
-  // the slow one and only the All tab reads it. The allowlist is the exception — it narrows the
-  // pool every tab reads, so all of them wait on it.
+  // Each tab draws from a different set of queries, so each waits on its own — and on the
+  // allowlist, which narrows all of them.
   const tabIsLoading =
     sessionQuery.isLoading ||
     allowlistPending ||
     (tab === 'recommended'
       ? recommendedLoading || curatedClaimsQuery.isLoading
       : tab === 'opponent'
-        ? savedClaimsQuery.isLoading
-        : savedClaimsQuery.isLoading || publishedClaimsLoading || browsedClaimsQuery.isLoading);
+        ? positions.isLoading || opponentEntitiesQuery.isLoading || opponentClaimsQuery.isLoading
+        : browsedClaimsQuery.isLoading);
+
+  const tabError =
+    sessionQuery.error ??
+    (tab === 'opponent'
+      ? (positions.error ?? opponentEntitiesQuery.error)
+      : tab === 'all'
+        ? browsedClaimsQuery.error
+        : curatedClaimsQuery.error);
+
+  // Settle the landing tab once it has drawn its list (see `landedTabRef`).
+  React.useEffect(() => {
+    if (chosenTab !== null || landedTabRef.current !== null || tabIsLoading) return;
+    landedTabRef.current = tab;
+  }, [chosenTab, tab, tabIsLoading]);
 
   // The curated tab groups by block rather than listing flat, but narrows on the same filters.
   const visibleSections = React.useMemo(() => {
@@ -415,7 +514,12 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   // predates that, and it costs one query per space on screen.
   const { byClaimId: readinessByClaimId, unresolved: readinessUnresolved } = useClaimReadinessByClaimId({
     claims,
-    rematchResponses: [savedClaimsQuery, curatedClaimsQuery, browsedClaimsQuery],
+    unresolved:
+      tab === 'all'
+        ? browsedClaimsQuery.isLoading || Boolean(browsedClaimsQuery.error)
+        : tab === 'opponent'
+          ? opponentClaimsQuery.isLoading || Boolean(opponentClaimsQuery.error)
+          : curatedClaimsQuery.isLoading || Boolean(curatedClaimsQuery.error),
   });
 
   React.useEffect(() => {
@@ -563,7 +667,7 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
           isLoading={
             tabIsLoading && (tab === 'recommended' ? visibleSections.length === 0 : visibleClaims.length === 0)
           }
-          error={sessionQuery.error ?? savedClaimsQuery.error ?? browsedClaimsQuery.error}
+          error={tabError}
           isEmpty={tab === 'recommended' ? visibleSections.length === 0 : visibleClaims.length === 0}
           emptyMessage={
             hasFilters
@@ -602,14 +706,13 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
         </HubQueryState>
 
         {/* Outside the empty state deliberately: when a filter empties the list, the next page is
-            the way out, so the sentinel has to stay reachable — with nothing rendered it sits in
-            view and keeps paging until a match turns up or the corpus runs out. Not on the curated
-            tab, whose sections come from the page whole and have no next page to fetch, and not
-            while the allowlist is pending — the picker is showing a loading state then, and paging
-            the graph-wide scan against it would burn round trips on a pool held back on purpose. */}
-        {tab !== 'recommended' && publishedClaimsHasNextPage && !allowlistPending && (
+            the way out, so the sentinel has to stay reachable. Only on the All tab: the curated
+            tab's sections come from the page whole, and the opponent's tab is the whole of what
+            the graph knows about them, in one query. Not while the allowlist is pending either —
+            the picker is showing a loading state then. */}
+        {tab === 'all' && browsedClaimsQuery.hasNextPage && !allowlistPending ? (
           <div ref={sentinelRef} data-testid="claims-scroll-sentinel" className="h-px" />
-        )}
+        ) : null}
       </main>
 
       {incomingRequest && session && currentUserId && (
@@ -637,44 +740,25 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
 /** What the per-space debate-claims endpoint knows about a claim's readiness. */
 type ClaimReadinessState = { viewer_debate_ready: boolean; readiness_disabled_reason: string | null };
 
-type RematchClaimsQueryState = {
-  data?: { claims: DebateRematchClaim[] } | null;
-  isLoading: boolean;
-  error: unknown;
-};
-
 /**
  * Readiness for every claim on screen, keyed by claim entity id, so the shared card can render its
  * Debate toggle against real state.
  *
- * Read from the rematch claims responses when they carry it — the same rows the picker already
- * asked for, so nothing extra goes over the wire. A claim those responses omit has no debate-claim
- * row in geo-chat at all, and readiness hangs off that row, so its settled truth is "not ready".
- * A backend that predates the fields answers `undefined`; then the per-space debate-claims
- * endpoint is asked instead, one query per space on screen, exactly as before.
+ * Read off the rows themselves when they carry it — geo-chat's matchmaking and rematch responses
+ * both do, so nothing extra goes over the wire. A row with the field absent comes from a backend
+ * that predates it (or from the graph alone); then the per-space debate-claims endpoint is asked
+ * about those claims, one query per space.
  */
 function useClaimReadinessByClaimId({
   claims,
-  rematchResponses,
+  unresolved: sourceUnresolved,
 }: {
   claims: DebateRematchClaim[];
-  rematchResponses: RematchClaimsQueryState[];
+  /** True while the lookup these rows' readiness comes from is still running or has failed. */
+  unresolved: boolean;
 }) {
-  // Keyed on the payloads, not the array literal the caller builds each render — otherwise this
-  // map and every card below it would rebuild on every render of the page.
-  const [savedPayload, curatedPayload, browsedPayload] = rematchResponses.map(response => response.data);
-  const rematchClaims = React.useMemo(
-    () => [savedPayload, curatedPayload, browsedPayload].flatMap(payload => payload?.claims ?? []),
-    [savedPayload, curatedPayload, browsedPayload]
-  );
-  // Every response comes from the same backend, so one claim speaks for all of them. With none
-  // loaded yet the answer is unknown, and asking the per-space endpoint on a guess would spend the
-  // very requests this exists to save — so treat that as "carried" and let `unresolved` hold.
-  const rematchCarriesReadiness = rematchClaims.length === 0 || rematchClaims[0]!.viewer_debate_ready !== undefined;
-
   // `debate.claims_changed` is delivered per space, so the picker has to hold a scope on every
-  // space it shows or the opponent's responses only appear after a reconnect. That used to ride on
-  // the per-space readiness query below; it must not depend on where readiness comes from.
+  // space it shows or the opponent's responses only appear after a reconnect.
   const { authenticated } = useGeoChatAuth();
   const spaceIds = React.useMemo(
     () => [...new Set(claims.map(claim => claim.claim.space_id))].sort((a, b) => a.localeCompare(b)),
@@ -682,10 +766,13 @@ function useClaimReadinessByClaimId({
   );
   useDebateGatewaySpaceScopes(spaceIds, authenticated && spaceIds.length > 0);
 
+  // Only the rows that don't carry readiness go to the per-space endpoint. While a source is still
+  // loading its rows haven't arrived, so there is nothing to ask about yet — which is what stops a
+  // guess from spending the very requests this exists to save.
   const claimIdsBySpace = React.useMemo(() => {
-    if (rematchCarriesReadiness) return [];
     const bySpace = new Map<string, string[]>();
     for (const claim of claims) {
+      if (claim.viewer_debate_ready !== undefined) continue;
       const existing = bySpace.get(claim.claim.space_id);
       if (existing) existing.push(claim.claim.claim_entity_id);
       else bySpace.set(claim.claim.space_id, [claim.claim.claim_entity_id]);
@@ -693,36 +780,31 @@ function useClaimReadinessByClaimId({
     return [...bySpace.entries()]
       .sort(([a], [b]) => a.localeCompare(b))
       .map(([spaceId, claimIds]) => ({ spaceId, claimIds }));
-  }, [claims, rematchCarriesReadiness]);
+  }, [claims]);
   const perSpace = useDebateClaimsBySpaces(claimIdsBySpace);
 
   const byClaimId = React.useMemo(() => {
     const map = new Map<string, ClaimReadinessState>();
-    if (rematchCarriesReadiness) {
-      for (const claim of rematchClaims) {
-        if (claim.viewer_debate_ready === undefined) continue;
-        map.set(claim.claim.claim_entity_id, {
-          viewer_debate_ready: claim.viewer_debate_ready,
-          readiness_disabled_reason: claim.readiness_disabled_reason ?? null,
-        });
-      }
-      return map;
-    }
     for (const claim of perSpace.claims) {
       map.set(claim.claim_entity_id, {
         viewer_debate_ready: claim.viewer_debate_ready,
         readiness_disabled_reason: claim.readiness_disabled_reason,
       });
     }
+    for (const claim of claims) {
+      if (claim.viewer_debate_ready === undefined) continue;
+      map.set(claim.claim.claim_entity_id, {
+        viewer_debate_ready: claim.viewer_debate_ready,
+        readiness_disabled_reason: claim.readiness_disabled_reason ?? null,
+      });
+    }
     return map;
-  }, [perSpace.claims, rematchCarriesReadiness, rematchClaims]);
+  }, [claims, perSpace.claims]);
 
   // A claim missing from a settled lookup genuinely has no readiness row, so `false` is the truth.
   // Missing while a lookup is still running or has failed means we don't know, and a switch drawn
   // from a guess is worse than one that waits.
-  const unresolved = rematchCarriesReadiness
-    ? rematchResponses.some(response => response.isLoading || response.error)
-    : perSpace.isLoading || perSpace.isError;
+  const unresolved = sourceUnresolved || perSpace.isLoading || perSpace.isError;
   return { byClaimId, unresolved };
 }
 

--- a/apps/web/core/debates/claim-picker-page.test.ts
+++ b/apps/web/core/debates/claim-picker-page.test.ts
@@ -1,12 +1,12 @@
+import { SystemIds } from '@geoprotocol/geo-sdk/lite';
+
 import * as Effect from 'effect/Effect';
 import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
-
-import { SystemIds } from '@geoprotocol/geo-sdk/lite';
 
 import { CLAIM_IS_FACTUAL_PROPERTY_ID, CLAIM_TYPE_ID, TOPICS_PROPERTY_ID } from '~/core/claims/ontology';
 import { graphql } from '~/core/io/graphql-client';
 
-import { claimPickerPageQueryKey, fetchClaimPickerPage } from './claim-picker-page';
+import { claimPickerEntitiesQueryKey, fetchClaimPickerEntities } from './claim-picker-page';
 
 vi.mock('~/core/io/graphql-client', () => ({
   graphql: vi.fn(),
@@ -14,7 +14,7 @@ vi.mock('~/core/io/graphql-client', () => ({
 
 const graphqlMock = graphql as unknown as Mock;
 
-describe('fetchClaimPickerPage', () => {
+describe('fetchClaimPickerEntities', () => {
   beforeEach(() => {
     graphqlMock.mockReset();
   });
@@ -23,40 +23,28 @@ describe('fetchClaimPickerPage', () => {
     graphqlMock.mockImplementation(({ decoder }) => Effect.succeed(decoder({ entitiesConnection })));
   }
 
-  it('asks the server for only the fields the picker reads, scoped to the claim type', async () => {
-    respondWith({ pageInfo: { endCursor: null, hasNextPage: false }, nodes: [] });
+  it('asks the server for only the fields the picker reads, for exactly the ids given', async () => {
+    respondWith({ nodes: [] });
 
-    await fetchClaimPickerPage({ search: '' });
+    await fetchClaimPickerEntities(['claim-1', 'claim-2']);
 
-    const variables = graphqlMock.mock.calls.at(-1)?.[0]?.variables;
-    expect(variables).toMatchObject({
+    expect(graphqlMock.mock.calls.at(-1)?.[0]?.variables).toEqual({
       claimTypeId: CLAIM_TYPE_ID,
       propertyIds: [SystemIds.NAME_PROPERTY, CLAIM_IS_FACTUAL_PROPERTY_ID],
       topicsPropertyId: TOPICS_PROPERTY_ID,
-      first: 50,
+      ids: ['claim-1', 'claim-2'],
     });
-    // The ORM path excluded nameless claims server-side; the picker cannot render them either.
-    expect(variables.filter).toEqual({ name: { isNull: false, isNot: '' } });
   });
 
-  it('maps the search term to the same case-insensitive substring the ORM used', async () => {
-    respondWith({ pageInfo: { endCursor: 'c-2', hasNextPage: true }, nodes: [] });
-
-    const page = await fetchClaimPickerPage({ search: 'fast fashion', after: 'c-1' });
-
-    expect(graphqlMock.mock.calls.at(-1)?.[0]?.variables).toMatchObject({
-      after: 'c-1',
-      filter: { name: { isNull: false, isNot: '', includesInsensitive: 'fast fashion' } },
-    });
-    expect(page.endCursor).toBe('c-2');
-    expect(page.hasNextPage).toBe(true);
+  it('does not ask at all for an empty list', async () => {
+    await expect(fetchClaimPickerEntities([])).resolves.toEqual([]);
+    expect(graphqlMock).not.toHaveBeenCalled();
   });
 
-  // The picker's helpers were written against `Entity`; the narrow page has to land in the same
-  // shape or the home-space, response-kind and topic lookups silently see nothing.
+  // The picker's helpers were written against `Entity`; the narrow projection has to land in the
+  // same shape or the home-space, response-kind and topic lookups silently see nothing.
   it('decodes nodes into the Entity subset the picker reads', async () => {
     respondWith({
-      pageInfo: { endCursor: null, hasNextPage: false },
       nodes: [
         {
           id: 'claim-1',
@@ -71,19 +59,15 @@ describe('fetchClaimPickerPage', () => {
             { spaceId: 'space-b', propertyId: SystemIds.NAME_PROPERTY, text: null, boolean: null },
             null,
           ],
-          relationsList: [
-            { toEntity: { id: 'topic-1', name: 'Fashion' } },
-            { toEntity: null },
-            null,
-          ],
+          relationsList: [{ toEntity: { id: 'topic-1', name: 'Fashion' } }, { toEntity: null }, null],
         },
         null,
       ],
     });
 
-    const page = await fetchClaimPickerPage({ search: '' });
+    const entities = await fetchClaimPickerEntities(['claim-1']);
 
-    expect(page.entities).toEqual([
+    expect(entities).toEqual([
       {
         id: 'claim-1',
         name: 'Fast fashion is bad',
@@ -100,18 +84,16 @@ describe('fetchClaimPickerPage', () => {
     ]);
   });
 
-  it('returns an empty page when the connection is missing', async () => {
+  it('returns nothing when the connection is missing', async () => {
     respondWith(null);
 
-    const page = await fetchClaimPickerPage({ search: '' });
-
-    expect(page).toEqual({ entities: [], endCursor: null, hasNextPage: false });
+    await expect(fetchClaimPickerEntities(['claim-1'])).resolves.toEqual([]);
   });
 });
 
 // The gateway reconciles and the debates mutations invalidate everything under `'debates'`; a
-// knowledge-graph page under that root would refetch on every reconnect and, when the graph
+// knowledge-graph lookup under that root would refetch on every reconnect and, when the graph
 // failed, be read as a broken socket.
-it('keys the picker page outside the debates family', () => {
-  expect(claimPickerPageQueryKey('', undefined)[0]).not.toBe('debates');
+it('keys the picker lookup outside the debates family', () => {
+  expect(claimPickerEntitiesQueryKey(['claim-1'])[0]).not.toBe('debates');
 });

--- a/apps/web/core/debates/claim-picker-page.ts
+++ b/apps/web/core/debates/claim-picker-page.ts
@@ -1,41 +1,32 @@
+import { SystemIds } from '@geoprotocol/geo-sdk/lite';
 import type { TypedDocumentNode } from '@graphql-typed-document-node/core';
-import { keepPreviousData, useQuery } from '@tanstack/react-query';
+import { type UseQueryResult, useQueries } from '@tanstack/react-query';
+
+import * as React from 'react';
+
 import { Effect } from 'effect';
 import { parse } from 'graphql';
-
-import { SystemIds } from '@geoprotocol/geo-sdk/lite';
 
 import { CLAIM_IS_FACTUAL_PROPERTY_ID, CLAIM_TYPE_ID, TOPICS_PROPERTY_ID } from '~/core/claims/ontology';
 import { graphql } from '~/core/io/graphql-client';
 
 /**
- * A page of published claims for the rematch picker, carrying only what the picker reads.
+ * The rematch picker's projection of a claim, carrying only what the picker reads.
  *
- * The picker used to page through `useQueryEntities`, whose fragment pulls every value, every
- * relation and every related entity's values for each row — a quarter of a megabyte and several
- * seconds per fifty claims, of which the picker read six fields: the name, the description, the
- * spaces its name is set in (to work out its home space), whether it is factual, and its topics.
- * Filtering those lists on the server brings a page down to a few kilobytes.
+ * `useQueryEntities` pulls every value, every relation and every related entity's values for each
+ * row — a quarter of a megabyte and several seconds per fifty claims, of which the picker reads six
+ * fields: the name, the description, the spaces its name is set in (to work out its home space),
+ * whether it is factual, and its topics. Filtering those lists on the server brings a batch down to
+ * a few kilobytes.
  *
  * Shaped as the same structural subset of `Entity` the picker was already reading, so the helpers
  * that resolve a claim's home space, response kind and topics work unchanged on both sources.
  *
  * Hand-written rather than generated so it doesn't require regenerating `gql.ts`.
  */
-const CLAIM_PICKER_PAGE_SOURCE = /* GraphQL */ `
-  query ClaimPickerPage(
-    $claimTypeId: UUID!
-    $propertyIds: [UUID!]!
-    $topicsPropertyId: UUID!
-    $first: Int!
-    $after: Cursor
-    $filter: EntityFilter
-  ) {
-    entitiesConnection(first: $first, after: $after, typeId: $claimTypeId, filter: $filter) {
-      pageInfo {
-        endCursor
-        hasNextPage
-      }
+const CLAIM_PICKER_ENTITIES_SOURCE = /* GraphQL */ `
+  query ClaimPickerEntities($claimTypeId: UUID!, $propertyIds: [UUID!]!, $topicsPropertyId: UUID!, $ids: [UUID!]!) {
+    entitiesConnection(first: 100, typeId: $claimTypeId, filter: { id: { in: $ids } }) {
       nodes {
         id
         name
@@ -58,9 +49,8 @@ const CLAIM_PICKER_PAGE_SOURCE = /* GraphQL */ `
   }
 `;
 
-type ClaimPickerPageQuery = {
+type ClaimPickerEntitiesQuery = {
   entitiesConnection: {
-    pageInfo: { endCursor: string | null; hasNextPage: boolean } | null;
     nodes: Array<{
       id: string;
       name: string | null;
@@ -77,18 +67,16 @@ type ClaimPickerPageQuery = {
   } | null;
 };
 
-type ClaimPickerPageVariables = {
+type ClaimPickerEntitiesVariables = {
   claimTypeId: string;
   propertyIds: string[];
   topicsPropertyId: string;
-  first: number;
-  after?: string;
-  filter: { name: { isNull: false; isNot: ''; includesInsensitive?: string } };
+  ids: string[];
 };
 
-const claimPickerPageDocument = parse(CLAIM_PICKER_PAGE_SOURCE) as TypedDocumentNode<
-  ClaimPickerPageQuery,
-  ClaimPickerPageVariables
+const claimPickerEntitiesDocument = parse(CLAIM_PICKER_ENTITIES_SOURCE) as TypedDocumentNode<
+  ClaimPickerEntitiesQuery,
+  ClaimPickerEntitiesVariables
 >;
 
 /** The subset of `Entity` the rematch picker reads. A full `Entity` satisfies it structurally. */
@@ -101,15 +89,10 @@ export type ClaimPickerEntity = {
   relations: Array<{ isDeleted?: boolean; type: { id: string }; toEntity: { id: string; name: string | null } }>;
 };
 
-export type ClaimPickerPage = {
-  entities: ClaimPickerEntity[];
-  endCursor: string | null;
-  hasNextPage: boolean;
-};
+/** The graph caps `first` on `entitiesConnection`; ids are asked for in lists this long. */
+export const CLAIM_PICKER_IDS_BATCH_SIZE = 100;
 
-export const CLAIM_PICKER_PAGE_SIZE = 50;
-
-function decodeClaimPickerPage(data: ClaimPickerPageQuery): ClaimPickerPage {
+function decodeClaimPickerEntities(data: ClaimPickerEntitiesQuery): ClaimPickerEntity[] {
   const connection = data.entitiesConnection;
   const entities: ClaimPickerEntity[] = [];
   for (const node of connection?.nodes ?? []) {
@@ -133,30 +116,20 @@ function decodeClaimPickerPage(data: ClaimPickerPageQuery): ClaimPickerPage {
       ),
     });
   }
-  return {
-    entities,
-    endCursor: connection?.pageInfo?.endCursor ?? null,
-    hasNextPage: connection?.pageInfo?.hasNextPage ?? false,
-  };
+  return entities;
 }
 
-export function fetchClaimPickerPage(
-  { search, after }: { search: string; after?: string },
-  signal?: AbortSignal
-): Promise<ClaimPickerPage> {
+export function fetchClaimPickerEntities(ids: string[], signal?: AbortSignal): Promise<ClaimPickerEntity[]> {
+  if (ids.length === 0) return Promise.resolve([]);
   return Effect.runPromise(
     graphql({
-      query: claimPickerPageDocument,
-      decoder: decodeClaimPickerPage,
+      query: claimPickerEntitiesDocument,
+      decoder: decodeClaimPickerEntities,
       variables: {
         claimTypeId: CLAIM_TYPE_ID,
         propertyIds: [SystemIds.NAME_PROPERTY, CLAIM_IS_FACTUAL_PROPERTY_ID],
         topicsPropertyId: TOPICS_PROPERTY_ID,
-        first: CLAIM_PICKER_PAGE_SIZE,
-        after,
-        // Same filter the ORM built: nameless claims are excluded (the picker cannot show them) and
-        // the search term is the case-insensitive substring `contains` maps to.
-        filter: { name: { isNull: false, isNot: '', ...(search ? { includesInsensitive: search } : null) } },
+        ids,
       },
       signal,
     })
@@ -165,32 +138,42 @@ export function fetchClaimPickerPage(
 
 /**
  * Deliberately not under `'debates'`: that root is what the gateway reconciles and refetches on
- * every (re)connect and what the debates mutations invalidate. This page comes from the knowledge
- * graph, not geo-chat, so a socket event says nothing about it — and a failing graph refetch under
- * that root would be read as a broken socket and recycle the connection over it.
+ * every (re)connect and what the debates mutations invalidate. These rows come from the knowledge
+ * graph, not geo-chat, so a socket event says nothing about them — and a failing graph refetch
+ * under that root would be read as a broken socket and recycle the connection over it.
  */
-export const claimPickerPageQueryKey = (search: string, after: string | undefined) =>
-  ['claim-picker', 'page', search, after ?? null] as const;
+export const claimPickerEntitiesQueryKey = (ids: string[]) => ['claim-picker', 'entities', ids] as const;
 
 /**
- * One page of the picker's browsed claims. `keepPreviousData` holds the prior page on screen while
- * the next loads, which is what the caller reads as "a fetch is in flight" for its scroll sentinel.
+ * The picker's projection of a known set of claims — the ones the opponent has responded to. Asked
+ * for in id-sorted batches so a claim joining the list re-fetches its batch and nothing else, and
+ * the claim entity itself rarely changes, so a batch stays fresh for a while.
  */
-export function useClaimPickerPage({ search, after }: { search: string; after: string | undefined }) {
-  const query = useQuery({
-    queryKey: claimPickerPageQueryKey(search, after),
-    queryFn: ({ signal }) => fetchClaimPickerPage({ search, after }, signal),
-    placeholderData: keepPreviousData,
-    staleTime: 60_000,
+export function useClaimEntitiesByIds(ids: string[]) {
+  const batches = React.useMemo(() => {
+    const sorted = [...new Set(ids)].sort();
+    const chunks: string[][] = [];
+    for (let index = 0; index < sorted.length; index += CLAIM_PICKER_IDS_BATCH_SIZE) {
+      chunks.push(sorted.slice(index, index + CLAIM_PICKER_IDS_BATCH_SIZE));
+    }
+    return chunks;
+  }, [ids]);
+
+  const combine = React.useCallback(
+    (results: UseQueryResult<ClaimPickerEntity[]>[]) => ({
+      entities: results.flatMap(result => result.data ?? []),
+      isLoading: results.some(result => result.isLoading),
+      error: results.find(result => result.error)?.error ?? null,
+    }),
+    []
+  );
+
+  return useQueries({
+    queries: batches.map(batch => ({
+      queryKey: claimPickerEntitiesQueryKey(batch),
+      queryFn: ({ signal }: { signal?: AbortSignal }) => fetchClaimPickerEntities(batch, signal),
+      staleTime: 5 * 60_000,
+    })),
+    combine,
   });
-
-  return {
-    entities: query.data?.entities ?? EMPTY_ENTITIES,
-    isLoading: query.isLoading,
-    isPlaceholderData: query.isPlaceholderData,
-    endCursor: query.data?.endCursor ?? null,
-    hasNextPage: query.data?.hasNextPage ?? false,
-  };
 }
-
-const EMPTY_ENTITIES: ClaimPickerEntity[] = [];

--- a/apps/web/core/debates/debate-gateway.test.ts
+++ b/apps/web/core/debates/debate-gateway.test.ts
@@ -699,6 +699,27 @@ describe('DebateGatewayClient', () => {
     expect(sockets).toHaveLength(2);
   });
 
+  // The participants' positions come from the knowledge graph; its failing says nothing about the
+  // geo-chat socket, and the query polls on its own.
+  it('keeps a healthy socket open when the graph-side positions refetch fails', async () => {
+    invalidateQueries.mockRejectedValueOnce(
+      Object.assign(new Error('graphql request failed'), { _tag: 'GraphqlRequestError' })
+    );
+    client.start(
+      vi.fn(async () => 'privy-token'),
+      'user-a'
+    );
+    await vi.runAllTicks();
+    sockets[0]!.open();
+    sockets[0]!.receive('READY', readyPayload([]));
+    await flushInvalidations();
+
+    expect(sockets[0]!.readyState).toBe(FakeWebSocket.OPEN);
+    expect(client.getSnapshot()).toMatchObject({ status: 'ready', paused: false });
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(sockets).toHaveLength(1);
+  });
+
   it('keeps a healthy socket open when an invalidated query fails with a deterministic 4xx', async () => {
     invalidateQueries.mockRejectedValueOnce(
       new GeoChatRequestError('at most 50 claim IDs may be requested', 'too_many_claim_ids', 400)
@@ -979,6 +1000,50 @@ describe('DebateGatewayClient', () => {
     const reask = refetchQueries.mock.calls.find(([filters]) => filters?.predicate?.(batch));
     expect(reask).toBeDefined();
     expect(reask![1]).toEqual({ throwOnError: true, cancelRefetch: false });
+
+    settle();
+    unsubscribe();
+  });
+
+  // A hook-side refresh can cancel one joined batch mid-flush. That batch's cancellation must not
+  // cost the others in the same flush the re-ask that brings them past the event.
+  it('still asks an in-flight rematch batch again when the joined invalidation was cancelled', async () => {
+    const batchKey = ['debates', 'account', 'user-a', 'rematch', 'rematch-1', 'claims', ['claim-2']];
+    queryClient.setQueryData(batchKey, { claims: [], excluded_claim_ids: [] });
+    let settle!: () => void;
+    const inFlight = new QueryObserver(queryClient, {
+      queryKey: batchKey,
+      queryFn: () =>
+        new Promise<unknown>(resolve => {
+          settle = () => resolve({ claims: [], excluded_claim_ids: [] });
+        }),
+      retry: false,
+    });
+    const unsubscribe = inFlight.subscribe(() => undefined);
+    void inFlight.refetch();
+    await vi.runAllTicks();
+    const refetchQueries = vi.spyOn(queryClient, 'refetchQueries').mockResolvedValue();
+
+    client.start(
+      vi.fn(async () => 'privy-token'),
+      'user-a'
+    );
+    await vi.runAllTicks();
+    sockets[0]!.open();
+    sockets[0]!.receive('READY', readyPayload([]));
+    await flushInvalidations();
+    refetchQueries.mockClear();
+    invalidateQueries.mockRejectedValueOnce(new CancelledError());
+    sockets[0]!.receive('EVENT', {
+      event_id: 'event-claims',
+      event_type: 'debate.claims_changed',
+      payload: { space_id: 'space-1', claim_entity_ids: ['claim-2'] },
+    });
+    await flushInvalidations();
+
+    const batch = queryClient.getQueryCache().find({ queryKey: batchKey })!;
+    expect(refetchQueries.mock.calls.some(([filters]) => filters?.predicate?.(batch))).toBe(true);
+    expect(sockets[0]!.readyState).toBe(FakeWebSocket.OPEN);
 
     settle();
     unsubscribe();

--- a/apps/web/core/debates/debate-gateway.test.ts
+++ b/apps/web/core/debates/debate-gateway.test.ts
@@ -172,10 +172,22 @@ describe('DebateGatewayClient', () => {
 
     expect(invalidateQueries.mock.calls).toEqual(
       expect.arrayContaining([
-        [{ queryKey: ['debates', 'media', 'debate-1'], refetchType: 'active' }, { throwOnError: true }],
-        [{ queryKey: ['debates', 'detail', 'debate-1'], refetchType: 'active' }, { throwOnError: true }],
-        [{ queryKey: ['debates', 'transcript', 'debate-1'], refetchType: 'active' }, { throwOnError: true }],
-        [{ queryKey: ['debates', 'space', 'space-1'], refetchType: 'active' }, { throwOnError: true }],
+        [
+          { queryKey: ['debates', 'media', 'debate-1'], refetchType: 'active' },
+          { throwOnError: true, cancelRefetch: false },
+        ],
+        [
+          { queryKey: ['debates', 'detail', 'debate-1'], refetchType: 'active' },
+          { throwOnError: true, cancelRefetch: false },
+        ],
+        [
+          { queryKey: ['debates', 'transcript', 'debate-1'], refetchType: 'active' },
+          { throwOnError: true, cancelRefetch: false },
+        ],
+        [
+          { queryKey: ['debates', 'space', 'space-1'], refetchType: 'active' },
+          { throwOnError: true, cancelRefetch: false },
+        ],
       ])
     );
     expect(invalidateQueries).toHaveBeenCalledTimes(4);
@@ -324,6 +336,7 @@ describe('DebateGatewayClient', () => {
     queryClient.setQueryData(['debates', 'account', 'user-a', 'rematch', 'session-1', 'claims', ['claim-9']], {});
     queryClient.setQueryData(['debates', 'account', 'user-a', 'rematch', 'session-1', 'claims', ['claim-2']], {});
     queryClient.setQueryData(['debates', 'account', 'user-a', 'rematch', 'session-1', 'claims', []], {});
+    queryClient.setQueryData(['participant-positions', ['profile-1', 'profile-2']], []);
     const refetchQueries = vi.spyOn(queryClient, 'refetchQueries').mockResolvedValue();
 
     client.start(
@@ -406,6 +419,11 @@ describe('DebateGatewayClient', () => {
           .find({ queryKey: ['claim-response-summaries', 'profile-1', 'space-2', ['claim-2:veracity']] })!
       )
     ).toBe(false);
+    // The rematch picker reads both participants' sides straight from the graph in one query;
+    // any response in a watched space may be one of theirs, so it re-asks.
+    expect(
+      predicate!(queryClient.getQueryCache().find({ queryKey: ['participant-positions', ['profile-1', 'profile-2']] })!)
+    ).toBe(true);
     expect(refetchQueries).not.toHaveBeenCalled();
   });
 
@@ -908,6 +926,64 @@ describe('DebateGatewayClient', () => {
     unsubscribe();
   });
 
+  // The rematch picker holds a positions batch per page of claims on screen, and the other side's
+  // responses arrive faster than those round trips complete. Restarting every batch on every
+  // event meant none of them landed while the responses kept coming. A batch in flight is left to
+  // land, then asked again so the screen never shows an answer older than the event.
+  it('lets an in-flight rematch batch land instead of cancelling it, then asks it again', async () => {
+    const batchKey = ['debates', 'account', 'user-a', 'rematch', 'rematch-1', 'claims', ['claim-2']];
+    queryClient.setQueryData(batchKey, { claims: [], excluded_claim_ids: [] });
+    let settle!: () => void;
+    const inFlight = new QueryObserver(queryClient, {
+      queryKey: batchKey,
+      queryFn: () =>
+        new Promise<unknown>(resolve => {
+          settle = () => resolve({ claims: [{ claim: { claim_entity_id: 'claim-2' } }], excluded_claim_ids: [] });
+        }),
+      retry: false,
+    });
+    const unsubscribe = inFlight.subscribe(() => undefined);
+    void inFlight.refetch();
+    await vi.runAllTicks();
+    const cancelQueries = vi.spyOn(queryClient, 'cancelQueries');
+    const refetchQueries = vi.spyOn(queryClient, 'refetchQueries').mockResolvedValue();
+
+    client.start(
+      vi.fn(async () => 'privy-token'),
+      'user-a'
+    );
+    await vi.runAllTicks();
+    sockets[0]!.open();
+    sockets[0]!.receive('READY', readyPayload([]));
+    await flushInvalidations();
+    refetchQueries.mockClear();
+    sockets[0]!.receive('EVENT', {
+      event_id: 'event-claims',
+      event_type: 'debate.claims_changed',
+      payload: { space_id: 'space-1', claim_entity_ids: ['claim-2'] },
+    });
+    await flushInvalidations();
+
+    const cache = queryClient.getQueryCache();
+    const batch = cache.find({ queryKey: batchKey })!;
+    // Not cancelled, even though it holds data.
+    const cancelFilters = cancelQueries.mock.calls.map(([filters]) => filters).find(filters => filters?.predicate);
+    expect(cancelFilters!.predicate!(batch)).toBe(false);
+    expect(batch.state.fetchStatus).toBe('fetching');
+    // The invalidation joins the request in flight rather than restarting it...
+    expect(invalidateQueries).toHaveBeenCalledWith(
+      { predicate: expect.any(Function), refetchType: 'active' },
+      { throwOnError: true, cancelRefetch: false }
+    );
+    // ...and once that has landed the batch is asked again, so the answer postdates the event.
+    const reask = refetchQueries.mock.calls.find(([filters]) => filters?.predicate?.(batch));
+    expect(reask).toBeDefined();
+    expect(reask![1]).toEqual({ throwOnError: true, cancelRefetch: false });
+
+    settle();
+    unsubscribe();
+  });
+
   it('rotates the socket thirty seconds before token expiry', async () => {
     session = { ...session, expires_at: '2026-07-20T12:01:00.000Z' };
     client.start(
@@ -1097,12 +1173,12 @@ async function flushInvalidations() {
 }
 
 function expectInvalidated(invalidateQueries: ReturnType<typeof vi.spyOn>, filters: unknown) {
-  expect(invalidateQueries.mock.calls).toContainEqual([filters, { throwOnError: true }]);
+  expect(invalidateQueries.mock.calls).toContainEqual([filters, { throwOnError: true, cancelRefetch: false }]);
 }
 
 function expectBroadInvalidated(invalidateQueries: ReturnType<typeof vi.spyOn>) {
   expect(invalidateQueries).toHaveBeenCalledWith(
     { predicate: expect.any(Function), refetchType: 'active' },
-    { throwOnError: true }
+    { throwOnError: true, cancelRefetch: false }
   );
 }

--- a/apps/web/core/debates/debate-gateway.ts
+++ b/apps/web/core/debates/debate-gateway.ts
@@ -562,15 +562,22 @@ export class DebateGatewayClient {
         });
         // `cancelRefetch: false`: a refetch of a query still fetching joins that request instead
         // of aborting it. Everything this flush meant to cancel has been cancelled above.
-        await this.queryClient.invalidateQueries(queryFilters, { throwOnError: true, cancelRefetch: false });
-        if (inFlightRematchBatches.length > 0) {
-          await this.queryClient.refetchQueries(
-            {
-              type: 'active',
-              predicate: query => inFlightRematchBatches.some(batch => batch.queryHash === query.queryHash),
-            },
-            { throwOnError: true, cancelRefetch: false }
-          );
+        //
+        // The re-ask runs whether or not the invalidation settled cleanly: a hook-side refresh can
+        // cancel one joined batch, and that one batch's `CancelledError` must not cost every other
+        // batch in this flush the refetch that brings it past the event.
+        try {
+          await this.queryClient.invalidateQueries(queryFilters, { throwOnError: true, cancelRefetch: false });
+        } finally {
+          if (inFlightRematchBatches.length > 0) {
+            await this.queryClient.refetchQueries(
+              {
+                type: 'active',
+                predicate: query => inFlightRematchBatches.some(batch => batch.queryHash === query.queryHash),
+              },
+              { throwOnError: true, cancelRefetch: false }
+            );
+          }
         }
       })
     );
@@ -794,6 +801,9 @@ function invalidationFailureRecovery(error: unknown): InvalidationRecovery {
   // spurious "live updates paused".
   if (error instanceof CancelledError) return 'ignore';
   if (error instanceof DOMException && error.name === 'AbortError') return 'ignore';
+  // The participants' positions are read from the knowledge graph, which this socket has nothing
+  // to do with. Its client has already retried; the query polls, so the next tick picks it up.
+  if (isGraphqlRequestError(error)) return 'ignore';
   if (!(error instanceof GeoChatRequestError)) return 'reconnect';
   if (error.code && deterministicInvalidationErrorCodes.has(error.code)) return 'ignore';
   if (error.status === 401 || error.status === 403) return 'reauthenticate';
@@ -802,6 +812,15 @@ function invalidationFailureRecovery(error: unknown): InvalidationRecovery {
   if (error.status === 408 || error.status === 429 || error.status >= 500) return 'retry';
   if (error.status >= 400 && error.status < 500) return 'ignore';
   return 'reconnect';
+}
+
+function isGraphqlRequestError(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    '_tag' in error &&
+    (error as { _tag?: unknown })._tag === 'GraphqlRequestError'
+  );
 }
 
 const debateGateway = new DebateGatewayClient({

--- a/apps/web/core/debates/debate-gateway.ts
+++ b/apps/web/core/debates/debate-gateway.ts
@@ -1,9 +1,11 @@
 'use client';
 
-import { CancelledError, type QueryClient, type QueryKey } from '@tanstack/react-query';
+import { CancelledError, type Query, type QueryClient, type QueryKey } from '@tanstack/react-query';
 
 import * as React from 'react';
 
+import { isParticipantPositionsQueryKey } from '~/core/debates/participant-positions';
+import { isRematchClaimsQueryKey } from '~/core/debates/rematch-claims-query-key';
 import { queryClient } from '~/core/query-client';
 import {
   claimResponseTargetKey,
@@ -424,7 +426,11 @@ export class DebateGatewayClient {
     this.queueInvalidation(BROAD_INVALIDATION_KEY, {
       predicate: query => {
         const root = query.queryKey[0];
-        return root === 'debates' || isClaimResponseSummaryQueryKey(query.queryKey);
+        return (
+          root === 'debates' ||
+          isClaimResponseSummaryQueryKey(query.queryKey) ||
+          isParticipantPositionsQueryKey(query.queryKey)
+        );
       },
       refetchType: 'active',
     });
@@ -495,6 +501,10 @@ export class DebateGatewayClient {
           );
         }
 
+        // The rematch picker reads both participants' sides straight from the graph; any response
+        // landing in a space it watches may be one of theirs. One query, so no need to narrow.
+        if (isParticipantPositionsQueryKey(query.queryKey)) return true;
+
         return isClaimResponseSummaryQueryKey(query.queryKey, {
           spaceId,
           targetKeys: changedResponseTargets,
@@ -529,16 +539,39 @@ export class DebateGatewayClient {
   private async flushInvalidations(invalidations: InvalidationFilters[], attempt = 0) {
     const results = await Promise.allSettled(
       invalidations.map(async queryFilters => {
+        const matches = (query: Query) => queryFilters.predicate === undefined || queryFilters.predicate(query);
         // Cancelling stops a stale in-flight response from overwriting the fresh refetch — which
         // only matters once there is data to overwrite. A query still on its first load has none;
         // aborting it restarts a request that was about to land, and on a screen with slow round
         // trips and frequent events that restart repeated until nothing ever landed.
+        //
+        // The rematch picker's positions batches are never cancelled, loaded or not. They are one
+        // request per page of claims on screen, and responses land on them faster than the round
+        // trips complete; restarting every batch on every event starved the list of updates for as
+        // long as the other side kept responding. A batch in flight is left to land and is then
+        // asked again, so the answer on screen is never older than the event that prompted it.
+        const inFlightRematchBatches = this.queryClient.getQueryCache().findAll({
+          ...queryFilters,
+          fetchStatus: 'fetching',
+          predicate: query => isRematchClaimsQueryKey(query.queryKey) && matches(query),
+        });
         await this.queryClient.cancelQueries({
           ...queryFilters,
           predicate: query =>
-            query.state.data !== undefined && (queryFilters.predicate === undefined || queryFilters.predicate(query)),
+            query.state.data !== undefined && !isRematchClaimsQueryKey(query.queryKey) && matches(query),
         });
-        await this.queryClient.invalidateQueries(queryFilters, { throwOnError: true });
+        // `cancelRefetch: false`: a refetch of a query still fetching joins that request instead
+        // of aborting it. Everything this flush meant to cancel has been cancelled above.
+        await this.queryClient.invalidateQueries(queryFilters, { throwOnError: true, cancelRefetch: false });
+        if (inFlightRematchBatches.length > 0) {
+          await this.queryClient.refetchQueries(
+            {
+              type: 'active',
+              predicate: query => inFlightRematchBatches.some(batch => batch.queryHash === query.queryHash),
+            },
+            { throwOnError: true, cancelRefetch: false }
+          );
+        }
       })
     );
 

--- a/apps/web/core/debates/hooks.test.tsx
+++ b/apps/web/core/debates/hooks.test.tsx
@@ -376,7 +376,9 @@ describe('useGeoChatAuth', () => {
       });
     });
 
-    await waitFor(() => expect(invalidateQueries).toHaveBeenCalledWith({ predicate: expect.any(Function) }));
+    await waitFor(() =>
+      expect(invalidateQueries).toHaveBeenCalledWith({ predicate: expect.any(Function) }, { cancelRefetch: false })
+    );
 
     // Only the batches naming the claim, plus the id-less session list any response can add a
     // row to. The picker holds a batch per page on screen; refetching all of them for one
@@ -391,6 +393,55 @@ describe('useGeoChatAuth', () => {
     expect(
       predicate({ queryKey: ['debates', 'account', 'user-a', 'rematch', 'rematch-2', 'claims', ['claim-1']] } as never)
     ).toBe(false);
+  });
+
+  // Cancelling a batch that is about to answer throws the request away, and when responses keep
+  // arriving it means none of them ever land — the starvation this family is invalidated around.
+  // The request in flight is left to land, then asked again so the answer postdates the response.
+  it('lets a rematch batch in flight land and asks it again once an indexed response arrives', async () => {
+    mocks.identityToken.mockReturnValue(null);
+    mocks.getIdentityToken.mockResolvedValue(null);
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+
+    let landFirst!: () => void;
+    mocks.listDebateRematchClaims.mockImplementationOnce(
+      () =>
+        new Promise(resolve => {
+          landFirst = () => resolve({ claims: [], excluded_claim_ids: [] });
+        })
+    );
+
+    renderHook(() => useDebateRematchClaims('rematch-1', ['claim-1']), { wrapper });
+    await waitFor(() => expect(mocks.listDebateRematchClaims).toHaveBeenCalledTimes(1));
+
+    act(() => {
+      queryClient.setQueryData(entityResponseIndexingQueryKey('profile-1', 'claim-1', 'space-1', 'veracity'), {
+        status: 'indexed',
+        pending: {
+          entityId: 'claim-1',
+          expectedResponse: 'negative',
+          personalSpaceId: 'profile-1',
+          responseKind: 'veracity',
+          spaceId: 'space-1',
+        },
+        runId: 'run-1',
+      });
+    });
+
+    // The request that was already on its way is not restarted out from under itself.
+    const batch = queryClient
+      .getQueryCache()
+      .find({ queryKey: debateQueryKeys.rematchClaims('user-a', 'rematch-1', ['claim-1']) })!;
+    expect(batch.state.fetchStatus).toBe('fetching');
+    expect(mocks.listDebateRematchClaims).toHaveBeenCalledTimes(1);
+
+    act(() => landFirst());
+
+    // ...and once it has landed, it is asked again, so what ends up on screen knows the response.
+    await waitFor(() => expect(mocks.listDebateRematchClaims).toHaveBeenCalledTimes(2));
   });
 
   // A `users/me` sent before logout can resolve after it. Writing that result back would

--- a/apps/web/core/debates/hooks.test.tsx
+++ b/apps/web/core/debates/hooks.test.tsx
@@ -10,6 +10,7 @@ import { entityResponseIndexingQueryKey } from '~/core/responses/entity-response
 
 import { type Debate, type DebateActivity, type DebateRematchSession, GeoChatRequestError } from './api';
 import { DebateCoordinator } from './debate-coordinator';
+import { clearEnteringDebate, useEnteringDebateId } from './debate-entry-intent';
 import {
   debateQueryKeys,
   useAcceptDebateRematchRequest,
@@ -28,7 +29,6 @@ import {
   useMarkDebateReady,
   useUpdateDebateAvailability,
 } from './hooks';
-import { clearEnteringDebate, useEnteringDebateId } from './debate-entry-intent';
 
 const mocks = vi.hoisted(() => ({
   authenticated: true,
@@ -53,8 +53,7 @@ vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: mocks.push, back: mocks.back }),
 }));
 
-vi.mock('~/core/state/feature-flags', () => ({
-}));
+vi.mock('~/core/state/feature-flags', () => ({}));
 
 vi.mock('@geogenesis/auth', () => ({
   getIdentityToken: mocks.getIdentityToken,
@@ -377,11 +376,21 @@ describe('useGeoChatAuth', () => {
       });
     });
 
-    await waitFor(() =>
-      expect(invalidateQueries).toHaveBeenCalledWith({
-        queryKey: ['debates', 'account', 'user-a', 'rematch', 'rematch-1', 'claims'],
-      })
-    );
+    await waitFor(() => expect(invalidateQueries).toHaveBeenCalledWith({ predicate: expect.any(Function) }));
+
+    // Only the batches naming the claim, plus the id-less session list any response can add a
+    // row to. The picker holds a batch per page on screen; refetching all of them for one
+    // response is what left its positions trailing.
+    const predicate = invalidateQueries.mock.calls.at(-1)![0]!.predicate!;
+    const batch = (claimIds: string[]) =>
+      ({ queryKey: ['debates', 'account', 'user-a', 'rematch', 'rematch-1', 'claims', claimIds] }) as never;
+    expect(predicate(batch(['claim-1']))).toBe(true);
+    expect(predicate(batch(['claim-0', 'claim-1', 'claim-2']))).toBe(true);
+    expect(predicate(batch([]))).toBe(true);
+    expect(predicate(batch(['claim-2']))).toBe(false);
+    expect(
+      predicate({ queryKey: ['debates', 'account', 'user-a', 'rematch', 'rematch-2', 'claims', ['claim-1']] } as never)
+    ).toBe(false);
   });
 
   // A `users/me` sent before logout can resolve after it. Writing that result back would
@@ -465,7 +474,16 @@ describe('useUpdateDebateAvailability', () => {
 
     expect(mocks.updateDebateAvailability).toHaveBeenCalledWith(false, expect.any(Function), 'user-a');
     expect(queryClient.getQueryData(debateQueryKeys.activity('user-a'))).toEqual(authoritative);
-    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['debates'] });
+    // Everything under `'debates'` bar the rematch picker's positions batches, which availability
+    // says nothing about and which cost a request per page of claims on screen.
+    expect(invalidateQueries).toHaveBeenCalledWith({ predicate: expect.any(Function) });
+    const predicate = invalidateQueries.mock.calls.at(-1)![0]!.predicate!;
+    expect(predicate({ queryKey: ['debates', 'account', 'user-a', 'activity'] } as never)).toBe(true);
+    expect(predicate({ queryKey: ['debates', 'claims', 'space-1', 'all'] } as never)).toBe(true);
+    expect(
+      predicate({ queryKey: ['debates', 'account', 'user-a', 'rematch', 'rematch-1', 'claims', ['claim-1']] } as never)
+    ).toBe(false);
+    expect(predicate({ queryKey: ['claim-picker', 'page'] } as never)).toBe(false);
   });
 
   it('rolls the optimistic activity back when the request fails', async () => {

--- a/apps/web/core/debates/hooks.ts
+++ b/apps/web/core/debates/hooks.ts
@@ -3,6 +3,7 @@
 import { usePrivy } from '@geogenesis/auth';
 import {
   type QueryClient,
+  type QueryFilters,
   type UseQueryResult,
   useMutation,
   useQueries,
@@ -267,6 +268,28 @@ export function rematchClaimBatchesWithClaim(accountKey: string | null, claimId:
 }
 
 /**
+ * Refresh rematch claim batches without restarting a request that is about to land.
+ *
+ * Invalidating cancels an in-flight fetch by default, which throws away a request that was about
+ * to answer — and when changes arrive faster than the round trips complete, means none of them
+ * ever land. A batch in flight is left to land, since its answer is still worth putting on screen,
+ * and is then asked again so what the viewer ends up looking at postdates the change that prompted
+ * this. The gateway does the same on its own flushes; these are the same batches.
+ */
+function refreshRematchClaimBatches(queryClient: QueryClient, filters: QueryFilters) {
+  const inFlight = queryClient.getQueryCache().findAll({ ...filters, fetchStatus: 'fetching' });
+  const refreshed = queryClient.invalidateQueries(filters, { cancelRefetch: false });
+  if (inFlight.length === 0) return refreshed;
+
+  return refreshed.finally(() =>
+    queryClient.refetchQueries(
+      { type: 'active', predicate: query => inFlight.some(batch => batch.queryHash === query.queryHash) },
+      { cancelRefetch: false }
+    )
+  );
+}
+
+/**
  * Everything under `'debates'` except the rematch claim batches. The root-wide invalidation a
  * mutation used to fire refetched every batch the picker had loaded — a request per page on
  * screen — for a change that touched none of them.
@@ -290,7 +313,7 @@ function invalidateAfterReadinessChange(queryClient: QueryClient, accountKey: st
   ]) {
     void queryClient.invalidateQueries({ queryKey });
   }
-  void queryClient.invalidateQueries(rematchClaimBatchesWithClaim(accountKey, claimId));
+  void refreshRematchClaimBatches(queryClient, rematchClaimBatchesWithClaim(accountKey, claimId));
 }
 
 export function useJoinDebateQueue(spaceId: string) {
@@ -642,7 +665,10 @@ export function useDebateRematchClaims(sessionId: string, claimIds: string[] = N
         // Only the batches that name the claim, plus the session's own list. Refetching every
         // batch the picker holds — one per page on screen — for a single response is what left
         // the positions trailing on a long list.
-        void queryClient.invalidateQueries(rematchClaimBatchesWithClaim(accountKey, response.entityId, sessionId));
+        void refreshRematchClaimBatches(
+          queryClient,
+          rematchClaimBatchesWithClaim(accountKey, response.entityId, sessionId)
+        );
       });
     },
     [accountKey, claimIds, enabled, queryClient, sessionId]
@@ -704,7 +730,8 @@ export function useRejectDebateRematchRequest() {
       void queryClient.invalidateQueries({ queryKey: debateQueryKeys.rematch(accountKey, result.session.id) });
       // A rejection marks one claim `recently_rejected`; only the batches carrying it need to hear.
       const rejectedClaimId = result.request?.claim.claim_entity_id;
-      void queryClient.invalidateQueries(
+      void refreshRematchClaimBatches(
+        queryClient,
         rejectedClaimId
           ? rematchClaimBatchesWithClaim(accountKey, rejectedClaimId, result.session.id)
           : { queryKey: ['debates', 'account', accountKey, 'rematch', result.session.id, 'claims'] }

--- a/apps/web/core/debates/hooks.ts
+++ b/apps/web/core/debates/hooks.ts
@@ -1,7 +1,14 @@
 'use client';
 
 import { usePrivy } from '@geogenesis/auth';
-import { type UseQueryResult, useMutation, useQueries, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  type QueryClient,
+  type UseQueryResult,
+  useMutation,
+  useQueries,
+  useQuery,
+  useQueryClient,
+} from '@tanstack/react-query';
 
 import * as React from 'react';
 
@@ -60,6 +67,7 @@ import { useDebateAttention } from './debate-attention';
 import { markEnteringDebate } from './debate-entry-intent';
 import { useDebateGatewayScope, useDebateGatewaySpaceScopes } from './debate-gateway';
 import { hasProcessedVideo } from './playback-utils';
+import { isRematchClaimsQueryKey } from './rematch-claims-query-key';
 
 export const debateQueryNetworkOptions = {
   retry: false,
@@ -242,6 +250,49 @@ function claimIdHash(claimId: string) {
   return hash;
 }
 
+/**
+ * Filters for the rematch claim batches that carry `claimId` — plus the id-less session list,
+ * which any response can add a row to. The batches that don't name the claim learned nothing.
+ */
+export function rematchClaimBatchesWithClaim(accountKey: string | null, claimId: string, sessionId?: string) {
+  return {
+    predicate: (query: { queryKey: readonly unknown[] }) => {
+      const { queryKey } = query;
+      if (!isRematchClaimsQueryKey(queryKey) || queryKey[2] !== accountKey) return false;
+      if (sessionId !== undefined && queryKey[4] !== sessionId) return false;
+      const ids = queryKey[6];
+      return !Array.isArray(ids) || ids.length === 0 || ids.includes(claimId);
+    },
+  };
+}
+
+/**
+ * Everything under `'debates'` except the rematch claim batches. The root-wide invalidation a
+ * mutation used to fire refetched every batch the picker had loaded — a request per page on
+ * screen — for a change that touched none of them.
+ */
+export function invalidateDebatesOutsideRematchClaims(queryClient: QueryClient) {
+  return queryClient.invalidateQueries({
+    predicate: query => query.queryKey[0] === 'debates' && !isRematchClaimsQueryKey(query.queryKey),
+  });
+}
+
+/**
+ * Standing ready (or down) on one claim moves that claim's readiness wherever it is listed and
+ * re-sorts who is matchable. Nothing else under `'debates'` changes, so only those families go.
+ */
+function invalidateAfterReadinessChange(queryClient: QueryClient, accountKey: string | null, claimId: string) {
+  for (const queryKey of [
+    ['debates', 'claims'] as const,
+    debateQueryKeys.matchmakingClaimsRoot(accountKey),
+    debateQueryKeys.matches(accountKey),
+    debateQueryKeys.activity(accountKey),
+  ]) {
+    void queryClient.invalidateQueries({ queryKey });
+  }
+  void queryClient.invalidateQueries(rematchClaimBatchesWithClaim(accountKey, claimId));
+}
+
 export function useJoinDebateQueue(spaceId: string) {
   const queryClient = useQueryClient();
   const { accountKey, getPrivyIdentityToken } = useGeoChatAuth();
@@ -249,9 +300,7 @@ export function useJoinDebateQueue(spaceId: string) {
   return useMutation({
     mutationFn: ({ claimId }: { claimId: string }) =>
       joinDebateQueue(spaceId, claimId, getPrivyIdentityToken, accountKey),
-    onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ['debates'] });
-    },
+    onSuccess: (_result, { claimId }) => invalidateAfterReadinessChange(queryClient, accountKey, claimId),
   });
 }
 
@@ -262,9 +311,7 @@ export function useLeaveDebateQueue(spaceId: string) {
   return useMutation({
     mutationFn: ({ claimId }: { claimId: string }) =>
       leaveDebateQueue(spaceId, claimId, getPrivyIdentityToken, accountKey),
-    onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ['debates'] });
-    },
+    onSuccess: (_result, { claimId }) => invalidateAfterReadinessChange(queryClient, accountKey, claimId),
   });
 }
 
@@ -312,7 +359,7 @@ export function useUpdateDebateAvailability() {
       queryClient.setQueryData(activityKey, activity);
     },
     onSettled: () => {
-      void queryClient.invalidateQueries({ queryKey: ['debates'] });
+      void invalidateDebatesOutsideRematchClaims(queryClient);
     },
   });
 }
@@ -541,11 +588,14 @@ export const REMATCH_CLAIM_ID_BATCH_SIZE = 100;
  * to a 400 takes every claim's positions with it, not just the ones past the limit.
  */
 export function useDebateRematchClaimsForIds(sessionId: string, claimIds: string[], enabled = true) {
-  const { accountKey, getPrivyIdentityToken } = useGeoChatAuth();
-
-  // Content-defined chunks for the same reason as `useDebateClaimsBySpaces`: the picker prepends
-  // as it pages and filters, and index-sliced batches would all change key on every insertion.
+  // Content-defined chunks for the same reason as `useDebateClaimsBySpaces`: callers rebuild this
+  // list as they filter, and index-sliced batches would all change key on every insertion.
   const batches = React.useMemo(() => stableClaimIdChunks(claimIds, REMATCH_CLAIM_ID_BATCH_SIZE), [claimIds]);
+  return useDebateRematchClaimBatches(sessionId, batches, enabled);
+}
+
+function useDebateRematchClaimBatches(sessionId: string, batches: string[][], enabled: boolean) {
+  const { accountKey, getPrivyIdentityToken } = useGeoChatAuth();
 
   // Stable by contract, as in `useDebateClaimsBySpaces`.
   const combine = React.useCallback(
@@ -572,7 +622,9 @@ export function useDebateRematchClaimsForIds(sessionId: string, claimIds: string
   });
 }
 
-export function useDebateRematchClaims(sessionId: string, claimIds: string[] = [], enabled = true) {
+const NO_CLAIM_IDS: string[] = [];
+
+export function useDebateRematchClaims(sessionId: string, claimIds: string[] = NO_CLAIM_IDS, enabled = true) {
   const queryClient = useQueryClient();
   const { accountKey, getPrivyIdentityToken } = useGeoChatAuth();
 
@@ -587,9 +639,10 @@ export function useDebateRematchClaims(sessionId: string, claimIds: string[] = [
           return;
         }
 
-        void queryClient.invalidateQueries({
-          queryKey: ['debates', 'account', accountKey, 'rematch', sessionId, 'claims'],
-        });
+        // Only the batches that name the claim, plus the session's own list. Refetching every
+        // batch the picker holds — one per page on screen — for a single response is what left
+        // the positions trailing on a long list.
+        void queryClient.invalidateQueries(rematchClaimBatchesWithClaim(accountKey, response.entityId, sessionId));
       });
     },
     [accountKey, claimIds, enabled, queryClient, sessionId]
@@ -649,9 +702,13 @@ export function useRejectDebateRematchRequest() {
     onSuccess: result => {
       queryClient.setQueryData(debateQueryKeys.rematch(accountKey, result.session.id), result.session);
       void queryClient.invalidateQueries({ queryKey: debateQueryKeys.rematch(accountKey, result.session.id) });
-      void queryClient.invalidateQueries({
-        queryKey: ['debates', 'account', accountKey, 'rematch', result.session.id, 'claims'],
-      });
+      // A rejection marks one claim `recently_rejected`; only the batches carrying it need to hear.
+      const rejectedClaimId = result.request?.claim.claim_entity_id;
+      void queryClient.invalidateQueries(
+        rejectedClaimId
+          ? rematchClaimBatchesWithClaim(accountKey, rejectedClaimId, result.session.id)
+          : { queryKey: ['debates', 'account', accountKey, 'rematch', result.session.id, 'claims'] }
+      );
     },
   });
 }

--- a/apps/web/core/debates/matchmaking/hooks.ts
+++ b/apps/web/core/debates/matchmaking/hooks.ts
@@ -25,7 +25,12 @@ import {
 import { markEnteringDebate } from '../debate-entry-intent';
 import { useDebateGatewayScope } from '../debate-gateway';
 import { debatePath } from '../debate-routes';
-import { debateQueryKeys, debateQueryNetworkOptions, useGeoChatAuth } from '../hooks';
+import {
+  debateQueryKeys,
+  debateQueryNetworkOptions,
+  invalidateDebatesOutsideRematchClaims,
+  useGeoChatAuth,
+} from '../hooks';
 
 const MATCHMAKING_CLAIMS_PAGE_SIZE = 20;
 
@@ -242,7 +247,7 @@ export function useCreateDebateRequest() {
 
   return useMutation({
     mutationFn: (request: CreateDebateRequestBody) => createDebateRequest(request, getPrivyIdentityToken, accountKey),
-    onSuccess: () => void queryClient.invalidateQueries({ queryKey: ['debates'] }),
+    onSuccess: () => void invalidateDebatesOutsideRematchClaims(queryClient),
   });
 }
 
@@ -252,7 +257,7 @@ export function useWithdrawDebateRequest() {
 
   return useMutation({
     mutationFn: (requestId: string) => withdrawDebateRequest(requestId, getPrivyIdentityToken, accountKey),
-    onSuccess: () => void queryClient.invalidateQueries({ queryKey: ['debates'] }),
+    onSuccess: () => void invalidateDebatesOutsideRematchClaims(queryClient),
   });
 }
 
@@ -265,7 +270,7 @@ export function useDismissDebateRequest() {
       const body: DismissDebateRequestBody = removeIntent ? { remove_intent: true } : {};
       return dismissDebateRequest(requestId, body, getPrivyIdentityToken, accountKey);
     },
-    onSuccess: () => void queryClient.invalidateQueries({ queryKey: ['debates'] }),
+    onSuccess: () => void invalidateDebatesOutsideRematchClaims(queryClient),
   });
 }
 
@@ -292,7 +297,7 @@ export function useAcceptDebateRequest() {
         markEnteringDebate(result.debate.id);
         router.push(debatePath(result.debate));
       }
-      void queryClient.invalidateQueries({ queryKey: ['debates'] });
+      void invalidateDebatesOutsideRematchClaims(queryClient);
     },
   });
 }
@@ -303,7 +308,7 @@ export function useBlockDebateUser() {
 
   return useMutation({
     mutationFn: (userId: string) => blockDebateUser(userId, getPrivyIdentityToken, accountKey),
-    onSuccess: () => void queryClient.invalidateQueries({ queryKey: ['debates'] }),
+    onSuccess: () => void invalidateDebatesOutsideRematchClaims(queryClient),
   });
 }
 
@@ -313,6 +318,6 @@ export function useUnblockDebateUser() {
 
   return useMutation({
     mutationFn: (userId: string) => unblockDebateUser(userId, getPrivyIdentityToken, accountKey),
-    onSuccess: () => void queryClient.invalidateQueries({ queryKey: ['debates'] }),
+    onSuccess: () => void invalidateDebatesOutsideRematchClaims(queryClient),
   });
 }

--- a/apps/web/core/debates/participant-positions.test.ts
+++ b/apps/web/core/debates/participant-positions.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { DebateRematchParticipant } from './api';
+import {
+  fetchParticipantPositions,
+  groupParticipantPositions,
+  isParticipantPositionsQueryKey,
+  participantPositionsQueryKey,
+  participantSidesOn,
+} from './participant-positions';
+
+const LOCAL: DebateRematchParticipant = {
+  user_id: 'user-local',
+  profile_space_id: '019fedae72b67ab2927adf044d57c566',
+  display_name: 'You',
+  avatar_cid: null,
+  participant_slot: 1,
+  consented_at: '2026-07-10T10:00:00.000Z',
+};
+const REMOTE: DebateRematchParticipant = {
+  ...LOCAL,
+  user_id: 'user-remote',
+  profile_space_id: '019fedae72b67ab2927adf044d57c567',
+  display_name: 'Salina',
+  participant_slot: 2,
+};
+
+describe('fetchParticipantPositions', () => {
+  // Positions are on-chain claim responses, which the graph indexes as `userVotes` keyed on the
+  // responder's personal space. One filter for both people, active responses only, both kinds.
+  it('asks for both participants’ active stance and veracity responses in one filter', async () => {
+    const fetchPage = vi.fn().mockResolvedValue([]);
+
+    await fetchParticipantPositions([LOCAL.profile_space_id, REMOTE.profile_space_id], undefined, fetchPage);
+
+    expect(fetchPage).toHaveBeenCalledOnce();
+    expect(fetchPage.mock.calls[0]![0]).toEqual({
+      userId: { in: [LOCAL.profile_space_id, REMOTE.profile_space_id] },
+      objectType: { is: 0 },
+      voteType: { in: [0, 1] },
+      voteKind: { in: [1, 2] },
+    });
+  });
+
+  it('asks nothing for no participants', async () => {
+    const fetchPage = vi.fn();
+    await expect(fetchParticipantPositions([], undefined, fetchPage)).resolves.toEqual([]);
+    expect(fetchPage).not.toHaveBeenCalled();
+  });
+
+  it('decodes rows into sides, dropping anything that is not an active stance or veracity response', async () => {
+    const fetchPage = vi.fn().mockResolvedValue([
+      { userId: LOCAL.profile_space_id, objectId: 'claim-1', spaceId: 'space-1', voteType: 0, voteKind: 1 },
+      { userId: REMOTE.profile_space_id, objectId: 'claim-1', spaceId: 'space-1', voteType: 1, voteKind: 2 },
+      // A curation vote is not a position.
+      { userId: REMOTE.profile_space_id, objectId: 'claim-2', spaceId: 'space-1', voteType: 0, voteKind: 0 },
+      // Nor is a withdrawn response.
+      { userId: REMOTE.profile_space_id, objectId: 'claim-3', spaceId: 'space-1', voteType: 2, voteKind: 1 },
+    ]);
+
+    await expect(
+      fetchParticipantPositions([LOCAL.profile_space_id, REMOTE.profile_space_id], undefined, fetchPage)
+    ).resolves.toEqual([
+      {
+        profileSpaceId: LOCAL.profile_space_id,
+        claimId: 'claim-1',
+        spaceId: 'space-1',
+        responseKind: 'stance',
+        position: true,
+      },
+      {
+        profileSpaceId: REMOTE.profile_space_id,
+        claimId: 'claim-1',
+        spaceId: 'space-1',
+        responseKind: 'veracity',
+        position: false,
+      },
+    ]);
+  });
+
+  it('pages until a short page comes back', async () => {
+    const full = Array.from({ length: 500 }, (_, index) => ({
+      userId: LOCAL.profile_space_id,
+      objectId: `claim-${index}`,
+      spaceId: 'space-1',
+      voteType: 0,
+      voteKind: 1,
+    }));
+    const fetchPage = vi.fn().mockResolvedValueOnce(full).mockResolvedValueOnce(full.slice(0, 3));
+
+    const positions = await fetchParticipantPositions([LOCAL.profile_space_id], undefined, fetchPage);
+
+    expect(positions).toHaveLength(503);
+    expect(fetchPage.mock.calls.map(call => call[2])).toEqual([0, 500]);
+  });
+});
+
+describe('participantSidesOn', () => {
+  // geo-chat validates a request against the claim's home space, and the card publishes there; a
+  // response in some other space that merely cites the claim is not a side on this claim.
+  it('reads each participant’s side in the claim’s space only, matching ids in either form', () => {
+    const byClaim = groupParticipantPositions([
+      {
+        profileSpaceId: LOCAL.profile_space_id,
+        claimId: 'claim-1',
+        spaceId: 'space-1',
+        responseKind: 'stance',
+        position: true,
+      },
+      {
+        profileSpaceId: '019fedae-72b6-7ab2-927a-df044d57c567',
+        claimId: 'claim-1',
+        spaceId: 'SPACE-1',
+        responseKind: 'stance',
+        position: false,
+      },
+      {
+        profileSpaceId: REMOTE.profile_space_id,
+        claimId: 'claim-2',
+        spaceId: 'space-9',
+        responseKind: 'stance',
+        position: true,
+      },
+    ]);
+
+    expect(participantSidesOn(byClaim, 'claim-1', 'space-1', [LOCAL, REMOTE])).toEqual([
+      { participant: LOCAL, position: true, responseKind: 'stance' },
+      { participant: REMOTE, position: false, responseKind: 'stance' },
+    ]);
+    // Answered in a different space: no side here.
+    expect(participantSidesOn(byClaim, 'claim-2', 'space-1', [LOCAL, REMOTE])).toEqual([
+      { participant: LOCAL, position: null, responseKind: null },
+      { participant: REMOTE, position: null, responseKind: null },
+    ]);
+  });
+});
+
+// Outside `'debates'`, so the mutations that invalidate that root leave it alone; the gateway
+// reaches it by its own predicate.
+it('keys the query outside the debates family, in participant order', () => {
+  const key = participantPositionsQueryKey(['b', 'a']);
+  expect(key[0]).not.toBe('debates');
+  expect(key).toEqual(participantPositionsQueryKey(['a', 'b']));
+  expect(isParticipantPositionsQueryKey(key)).toBe(true);
+  expect(isParticipantPositionsQueryKey(['debates', 'claims'])).toBe(false);
+});

--- a/apps/web/core/debates/participant-positions.ts
+++ b/apps/web/core/debates/participant-positions.ts
@@ -1,0 +1,218 @@
+'use client';
+
+import type { TypedDocumentNode } from '@graphql-typed-document-node/core';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+
+import * as React from 'react';
+
+import { Effect } from 'effect';
+import { parse } from 'graphql';
+
+import { graphql } from '~/core/io/graphql-client';
+import { decodeActiveResponseDirection, responseKindToVoteKind } from '~/core/responses/entity-response';
+
+import type { DebateRematchParticipant, DebateResponseKind } from './api';
+import { claimResponseIndexedEvent } from './claim-response-indexed-notifier';
+import { useDebateAttention } from './debate-attention';
+
+/**
+ * Both participants' positions on every claim, read straight from the knowledge graph.
+ *
+ * A position is an on-chain claim response; geo-chat only mirrors them (and learns about half of
+ * them from this very client, via `notifyClaimResponseIndexed`). Asking the graph directly skips
+ * that round trip, and the `userVotes` table answers "everything these two people have responded
+ * to" in one query — a couple of hundred rows at most — where the rematch endpoint had to be asked
+ * about claims a hundred ids at a time.
+ */
+export const PARTICIPANT_POSITIONS_QUERY_ROOT = 'participant-positions';
+
+/** How often the list re-asks while the picker is in the foreground. */
+const PARTICIPANT_POSITIONS_POLL_MS = 20_000;
+
+const PAGE_SIZE = 500;
+
+export type ParticipantPosition = {
+  /** The responder's personal space id — what the graph keys responses on. */
+  profileSpaceId: string;
+  claimId: string;
+  /** The space the response was published against. */
+  spaceId: string;
+  responseKind: DebateResponseKind;
+  position: boolean;
+};
+
+export type ParticipantPositionsByClaim = Map<string, ParticipantPosition[]>;
+
+export function participantPositionsQueryKey(profileSpaceIds: string[]) {
+  return [PARTICIPANT_POSITIONS_QUERY_ROOT, [...profileSpaceIds].sort()] as const;
+}
+
+export function isParticipantPositionsQueryKey(queryKey: readonly unknown[]) {
+  return queryKey[0] === PARTICIPANT_POSITIONS_QUERY_ROOT;
+}
+
+const VOTE_KIND_TO_RESPONSE_KIND = new Map<number, DebateResponseKind>([
+  [responseKindToVoteKind('stance'), 'stance'],
+  [responseKindToVoteKind('veracity'), 'veracity'],
+]);
+
+/**
+ * Hand-written rather than generated so it doesn't require regenerating `gql.ts`. The generated
+ * `ClaimResponseSummaries` document is the same table without `spaceId`, and the space matters
+ * here: a response counts only in the space the claim lives in.
+ */
+const PARTICIPANT_POSITIONS_SOURCE = /* GraphQL */ `
+  query ParticipantPositions($filter: UserVoteFilter!, $first: Int!, $offset: Int!) {
+    userVotes(filter: $filter, first: $first, offset: $offset, orderBy: [VOTED_AT_DESC, OBJECT_ID_ASC]) {
+      userId
+      objectId
+      spaceId
+      voteType
+      voteKind
+    }
+  }
+`;
+
+type ParticipantPositionRow = { userId: string; objectId: string; spaceId: string; voteType: number; voteKind: number };
+type ParticipantPositionsFilter = {
+  userId: { in: string[] };
+  objectType: { is: number };
+  voteType: { in: number[] };
+  voteKind: { in: number[] };
+};
+const participantPositionsDocument = parse(PARTICIPANT_POSITIONS_SOURCE) as TypedDocumentNode<
+  { userVotes: Array<ParticipantPositionRow | null> | null },
+  { filter: ParticipantPositionsFilter; first: number; offset: number }
+>;
+
+type FetchPage = (
+  filter: ParticipantPositionsFilter,
+  first: number,
+  offset: number,
+  signal?: AbortSignal
+) => Promise<ParticipantPositionRow[]>;
+
+function defaultFetchPage(filter: ParticipantPositionsFilter, first: number, offset: number, signal?: AbortSignal) {
+  return Effect.runPromise(
+    graphql({
+      query: participantPositionsDocument,
+      decoder: data =>
+        (data.userVotes ?? []).flatMap(row =>
+          row
+            ? [{ ...row, userId: String(row.userId), objectId: String(row.objectId), spaceId: String(row.spaceId) }]
+            : []
+        ),
+      variables: { filter, first, offset },
+      signal,
+    })
+  );
+}
+
+export async function fetchParticipantPositions(
+  profileSpaceIds: string[],
+  signal?: AbortSignal,
+  fetchPage: FetchPage = defaultFetchPage
+): Promise<ParticipantPosition[]> {
+  if (profileSpaceIds.length === 0) return [];
+  const filter = {
+    userId: { in: profileSpaceIds },
+    objectType: { is: 0 },
+    // Active responses only: a withdrawn one is a different vote type and means "no side".
+    voteType: { in: [0, 1] },
+    voteKind: { in: [...VOTE_KIND_TO_RESPONSE_KIND.keys()] },
+  };
+
+  const rows: ParticipantPositionRow[] = [];
+  let offset = 0;
+  while (true) {
+    const page = await fetchPage(filter, PAGE_SIZE, offset, signal);
+    rows.push(...page);
+    if (page.length < PAGE_SIZE) break;
+    offset += PAGE_SIZE;
+  }
+
+  return rows.flatMap(row => {
+    const direction = decodeActiveResponseDirection(row.voteType);
+    const responseKind = VOTE_KIND_TO_RESPONSE_KIND.get(row.voteKind);
+    if (!direction || !responseKind) return [];
+    return [
+      {
+        profileSpaceId: row.userId,
+        claimId: row.objectId,
+        spaceId: row.spaceId,
+        responseKind,
+        position: direction === 'positive',
+      },
+    ];
+  });
+}
+
+export function groupParticipantPositions(positions: ParticipantPosition[]): ParticipantPositionsByClaim {
+  const byClaim: ParticipantPositionsByClaim = new Map();
+  for (const position of positions) {
+    const existing = byClaim.get(position.claimId);
+    if (existing) existing.push(position);
+    else byClaim.set(position.claimId, [position]);
+  }
+  return byClaim;
+}
+
+/**
+ * The side each session participant holds on a claim, in the space the claim lives in. A response
+ * in some other space that merely cites the claim doesn't count — geo-chat validates a request
+ * against the home space, and the card publishes there.
+ */
+export function participantSidesOn(
+  positionsByClaim: ParticipantPositionsByClaim,
+  claimId: string,
+  spaceId: string,
+  participants: DebateRematchParticipant[]
+) {
+  const rows = positionsByClaim.get(claimId) ?? [];
+  return participants.map(participant => {
+    const row = rows.find(
+      position => sameId(position.profileSpaceId, participant.profile_space_id) && sameId(position.spaceId, spaceId)
+    );
+    return { participant, position: row?.position ?? null, responseKind: row?.responseKind ?? null };
+  });
+}
+
+function sameId(left: string, right: string) {
+  return left.replace(/-/g, '').toLowerCase() === right.replace(/-/g, '').toLowerCase();
+}
+
+export function useParticipantPositions(participants: DebateRematchParticipant[]) {
+  const queryClient = useQueryClient();
+  const foreground = useDebateAttention();
+  const profileSpaceIds = React.useMemo(
+    () => [...new Set(participants.map(participant => participant.profile_space_id))].sort(),
+    [participants]
+  );
+  const queryKey = React.useMemo(() => participantPositionsQueryKey(profileSpaceIds), [profileSpaceIds]);
+
+  // The viewer's own response lands in the graph a beat before anyone tells geo-chat about it;
+  // the indexing snapshot turning `indexed` is that beat, so re-ask then rather than wait on the
+  // socket to echo it back.
+  React.useEffect(() => {
+    if (profileSpaceIds.length === 0) return;
+    return queryClient.getQueryCache().subscribe(event => {
+      if (event.type !== 'updated' || event.action.type !== 'success') return;
+      if (!claimResponseIndexedEvent(event.query.queryKey, event.query.state.data)) return;
+      void queryClient.invalidateQueries({ queryKey });
+    });
+  }, [profileSpaceIds.length, queryClient, queryKey]);
+
+  const query = useQuery({
+    queryKey,
+    queryFn: ({ signal }) => fetchParticipantPositions(profileSpaceIds, signal),
+    enabled: profileSpaceIds.length > 0,
+    // `debate.claims_changed` only reaches this tab for spaces it holds a scope on; the opponent
+    // can respond somewhere it doesn't, and that claim should still turn up. A slow poll covers it.
+    refetchInterval: foreground ? PARTICIPANT_POSITIONS_POLL_MS : false,
+    staleTime: 5_000,
+  });
+
+  const byClaim = React.useMemo(() => groupParticipantPositions(query.data ?? []), [query.data]);
+
+  return { byClaim, isLoading: query.isLoading, error: query.error };
+}

--- a/apps/web/core/debates/rematch-claims-query-key.ts
+++ b/apps/web/core/debates/rematch-claims-query-key.ts
@@ -1,0 +1,13 @@
+/**
+ * Whether a query key is one of the rematch picker's positions lookups —
+ * `['debates','account',accountKey,'rematch',sessionId,'claims',ids]`.
+ *
+ * These are the most expensive family under `'debates'`: a request per page of claims on screen,
+ * and almost nothing that invalidates the root actually changes them. Kept in its own module so
+ * the gateway and the hooks can both read it without importing each other.
+ */
+export function isRematchClaimsQueryKey(queryKey: readonly unknown[]) {
+  return (
+    queryKey[0] === 'debates' && queryKey[1] === 'account' && queryKey[3] === 'rematch' && queryKey[5] === 'claims'
+  );
+}

--- a/apps/web/core/debates/rematch-claims-query-key.ts
+++ b/apps/web/core/debates/rematch-claims-query-key.ts
@@ -1,10 +1,13 @@
 /**
- * Whether a query key is one of the rematch picker's positions lookups —
- * `['debates','account',accountKey,'rematch',sessionId,'claims',ids]`.
+ * Whether a query key names a session's rematch claims — the batches the picker asks geo-chat for,
+ * `['debates','account',accountKey,'rematch',sessionId,'claims',ids]`, and the id-less prefix
+ * `[...,'claims']` that covers every batch of a session. Both forms are matched: the predicate
+ * stops at the `'claims'` segment, so a filter written as the prefix is recognised as well.
  *
- * These are the most expensive family under `'debates'`: a request per page of claims on screen,
- * and almost nothing that invalidates the root actually changes them. Kept in its own module so
- * the gateway and the hooks can both read it without importing each other.
+ * These carry the session's flags and the viewer's readiness for each claim. They are the most
+ * expensive family under `'debates'` — a request per page of claims on screen — and almost nothing
+ * that invalidates the root actually changes them. Kept in its own module so the gateway and the
+ * hooks can both read it without importing each other.
  */
 export function isRematchClaimsQueryKey(queryKey: readonly unknown[]) {
   return (


### PR DESCRIPTION
The rematch picker joined three backends in the browser: a graph-wide scan of every Claim entity (255k rows, 50 a page, no space filter), geo-chat positions batches re-chunked over the union of every loaded id, and a space allowlist that sat in front of all three tabs. Filtering locally kept the All tab paging until something visible turned up, every event or mutation refetched (and cancelled) every batch, and the opponent's tab — one geo-chat call — waited on the viewer's wallet chain.

Positions are on-chain claim responses; geo-chat only mirrors them. Read them straight from the graph's userVotes table for both participants in one query (participant-positions.ts), hydrate exactly those ids with the picker's narrow projection, and keep geo-chat for what only it knows: readiness and the session flags, one batch per tab. The All tab is now the hub's /matchmaking/claims query — geo-chat's own index of debatable claims, paged and searched server-side — with the graph's sides laid over it.

Along the way: readiness toggles, indexed responses and the hub mutations no longer invalidate the whole debates root; the gateway lets an in-flight rematch batch land and re-asks it rather than cancelling it; claims_changed and reconnects refresh the positions query; useDebateRematchClaims stopped resubscribing to the cache on every render.

Lists hold until the allowlist and the session's exclusions are known, so nothing is listed and then trimmed, and hold their last settled rows while an id-keyed re-lookup is in flight, so a new response from the opponent doesn't drop the tab to zero on its way in.

Measured on api-testnet: both participants' positions 136 ms; an unscoped claim page 240–320 ms; spaceIds list filters 2–18 s or an error, which is why the allowlist stays a client-side cut.