### PR TITLE
fix(responses): keep positions on screen while a changed claim set reloads

### DIFF
--- a/apps/web/core/responses/use-claim-response-summaries.test.tsx
+++ b/apps/web/core/responses/use-claim-response-summaries.test.tsx
@@ -63,6 +63,45 @@ describe('useClaimResponseSummaryBatch', () => {
     );
   });
 
+  it('keeps already-loaded positions on screen while a changed claim set reloads', async () => {
+    // GEO-2599. The query key contains the whole target list, so adding a claim —
+    // or any local-store update while typing, since the claims page passes
+    // includeUnpublishedLocal — mints a NEW key. Without placeholderData the hook
+    // reports no data for it and ClaimResponseBatchBoundary, which gates on
+    // isSuccess, blanks every position until the refetch lands.
+    const { wrapper } = createHarness();
+    const loaded = new Map([['claim-1:stance', { responders: [] }]]) as never;
+    mocks.loadCaches.mockResolvedValue(loaded);
+
+    const { result, rerender } = renderHook(
+      ({ targets }: { targets: { entityId: string; responseKind: 'stance' | 'veracity' }[] }) =>
+        useClaimResponseSummaryBatch({ spaceId: 'space-1', targets, enabled: true }),
+      { wrapper, initialProps: { targets: [{ entityId: 'claim-1', responseKind: 'stance' as const }] } }
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toBe(loaded);
+
+    let resolveSecond: (value: unknown) => void = () => {};
+    mocks.loadCaches.mockReturnValue(
+      new Promise(resolve => {
+        resolveSecond = resolve;
+      })
+    );
+    rerender({
+      targets: [
+        { entityId: 'claim-1', responseKind: 'stance' as const },
+        { entityId: 'claim-2', responseKind: 'stance' as const },
+      ],
+    });
+
+    await waitFor(() => expect(mocks.loadCaches).toHaveBeenCalledTimes(2));
+    expect(result.current.data).toBe(loaded);
+
+    resolveSecond(new Map());
+    await waitFor(() => expect(result.current.data).not.toBe(loaded));
+  });
+
   it('isolates the batch cache by viewer account and exact space', async () => {
     const { queryClient, wrapper } = createHarness();
     const targets = [{ entityId: 'claim-1', responseKind: 'stance' as const }];

--- a/apps/web/core/responses/use-claim-response-summaries.ts
+++ b/apps/web/core/responses/use-claim-response-summaries.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { keepPreviousData, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import * as React from 'react';
 
@@ -56,6 +56,22 @@ export function useClaimResponseSummaryBatch({
     enabled: enabled && !isPersonalSpaceLoading && normalizedTargets.length > 0,
     staleTime: 30_000,
     retry: 2,
+    // GEO-2599: the query key contains the whole target list, so adding a claim —
+    // or any local-store update while typing, since the claims page passes
+    // `includeUnpublishedLocal` — mints a NEW key. React Query then has no data for
+    // it, `isSuccess` drops to false, and `ClaimResponseBatchBoundary` (which gates
+    // on exactly that) hides every position until the refetch lands. `staleTime`
+    // cannot help: it only applies within one key.
+    //
+    // That is what "I just lost all of Dovile's positions without doing anything
+    // whilst I was typing" was. Invisible on a fast connection, where the gap is
+    // milliseconds; most of a minute on a slow one.
+    //
+    // Serving the previous key's data through the transition keeps known positions
+    // on screen while the new set loads. Safe because positions are additive and
+    // `spaceId` + `personalSpaceId` are in the key prefix, so it can never show a
+    // different space's data.
+    placeholderData: keepPreviousData,
   });
   const responderSpaceIds = responseBatch.data ? claimResponseSummaryResponderSpaceIds(responseBatch.data) : [];
 


### PR DESCRIPTION
GEO-2599 — *"I just lost all of Dovile's positions without doing anything whilst I was typing."*

## Root cause

`useClaimResponseSummaryBatch` puts the **entire target list inside its query key**:

```ts
queryKey: [...claimResponseSummariesQueryKeyPrefix(personalSpaceId, spaceId),
           normalizedTargets.map(claimResponseTargetKey)]
staleTime: 30_000,
```

Any change to the claim set mints a **new key**. React Query has no data for a new key → `isSuccess` drops to false → `ClaimResponseBatchBoundary`, which gates on exactly that, **hides every position** until the refetch lands. `staleTime` can't help — it only applies within one key.

And the claims page passes `includeUnpublishedLocal: true`, so **typing** updates the local store → new claims array → new `publishedClaimIds` → new targets → new key. That's the whole bug.

`placeholderData: keepPreviousData` serves the previous key's data through the transition. Safe here: positions are additive, and `spaceId` + `personalSpaceId` are in the key prefix so it can never show another space's data — there's an existing test asserting that isolation and it still passes.

## Why one defect became several tickets

It's invisible on a fast connection, where the gap is milliseconds. Preston's line made it most of a minute. **His slow connection wasn't a confound — it was the stress test.**

I'd expect the same mechanism to explain part of GEO-2600 (flickering), GEO-2603 (lag before the request-debate button appears) and GEO-2604 (spurious loading indicators) — all three are "the UI briefly has no data" symptoms. Worth re-testing those after this lands rather than fixing them blind.

## Not fixed here

Positions load through **three serial round trips** — `useQueryEntities` → `useDebateClaims` → `useClaimResponseSummaryBatch`, each waiting on the previous one's result. That serialisation is most of the reported ~1 minute and no caching hides it on a slow line; it needs parallelisation or a server-side batch, and deserves its own issue.

It probably also explains *"Dovile has chosen 6 positions and I only see 4"* — a partially populated chain rather than a wrong query.

## Verification

- 54 tests pass, up from 53
- eslint clean on `core/responses/`
- The new test is **mutation-checked**: removing `placeholderData` fails it and nothing else, so it pins this behaviour rather than passing incidentally

One process note: I first built this on top of `ohohoreilly/explore-best-sort` by mistake — this repo's default is `master`, and my local copy was 129 commits behind. Rebuilt on current `master` and re-verified from scratch; I checked first that `master` still had the bug (it does — no `placeholderData`, `staleTime: 30_000` unchanged) rather than assuming.
