### PR TITLE
fix(debates): return to where the flow started, not one history entry back

### DIFF
--- a/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
@@ -6,6 +6,7 @@ import { type ComponentPropsWithoutRef, StrictMode } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { Debate, DebateRematchSession } from '~/core/debates/api';
+import { recordDebateFlowOrigin } from '~/core/debates/debate-entry-intent';
 import type { DebateRoomTakeoverContext } from '~/core/debates/debate-room-ownership';
 import { ExtendedReconnectPolicy } from '~/core/livekit/extended-reconnect-policy';
 
@@ -252,6 +253,7 @@ class FakeBroadcastChannel {
 
 beforeEach(() => {
   setHistoryLength(1);
+  window.sessionStorage.clear();
   mocks.back.mockReset();
   mocks.push.mockReset();
   mocks.replace.mockReset();
@@ -438,6 +440,19 @@ describe('DebateRoomPageClient', () => {
     expect(mocks.back).toHaveBeenCalledOnce();
     expect(mocks.replace).not.toHaveBeenCalled();
     expect(mocks.enqueueRecording).not.toHaveBeenCalled();
+  });
+
+  // GEO-2605. history.length says only how deep we are, not where the flow began: hub -> room ->
+  // rematch -> room leaves another room one entry back, so back() returns into the flow. The path
+  // recorded on entry is the only thing that knows where the viewer actually came from.
+  it('returns to the path the flow started from rather than one history entry back', async () => {
+    setHistoryLength(4);
+    recordDebateFlowOrigin('/space/space-1/entity-7');
+
+    render(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
+
+    await waitFor(() => expect(mocks.replace).toHaveBeenCalledWith('/space/space-1/entity-7'));
+    expect(mocks.back).not.toHaveBeenCalled();
   });
 
   it('falls back to the debates page when a cancelled room has no prior history', async () => {

--- a/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.tsx
@@ -17,6 +17,7 @@ import {
   getCurrentGeoChatUserId,
   getServerTime,
 } from '~/core/debates/api';
+import { takeDebateFlowOrigin } from '~/core/debates/debate-entry-intent';
 import { DebatePreScreen } from '~/core/debates/debate-pre-join-screen';
 import {
   CameraIcon,
@@ -434,10 +435,17 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
       if (debateExitStartedRef.current) return;
       debateExitStartedRef.current = true;
       clearDebateActivity(debateId);
-      // Going back restores whatever opened the room, which is where an ordinary exit belongs.
-      // A debate that ended under us is different: the entry behind us is often this same room
-      // (hub → room → rematch → room), and stepping back into it re-runs the exit from a fresh
-      // mount. That is the flicker, and it is why the removal dialog needed a second Okay.
+      // Prefer the path recorded when the viewer entered the flow. `router.back()`
+      // only steps one entry, so in hub → room → rematch → room it lands inside the
+      // flow rather than where they came from — and re-mounting a room re-runs its
+      // exit, which is the flicker. Going forward to a known origin avoids both.
+      const origin = takeDebateFlowOrigin();
+      if (origin) {
+        router.replace(origin);
+        return;
+      }
+      // No origin recorded (storage unavailable, or entry predates it): fall back to
+      // the previous behaviour rather than stranding the viewer.
       if (!forwardOnly && window.history.length > 1) {
         router.back();
         return;

--- a/apps/web/core/debates/debate-entry-intent.test.ts
+++ b/apps/web/core/debates/debate-entry-intent.test.ts
@@ -2,11 +2,18 @@ import { act, cleanup, renderHook } from '@testing-library/react';
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { clearEnteringDebate, markEnteringDebate, useEnteringDebateId } from './debate-entry-intent';
+import {
+  clearEnteringDebate,
+  markEnteringDebate,
+  recordDebateFlowOrigin,
+  takeDebateFlowOrigin,
+  useEnteringDebateId,
+} from './debate-entry-intent';
 
 afterEach(() => {
   cleanup();
   clearEnteringDebate();
+  window.sessionStorage.clear();
   vi.useRealTimers();
 });
 
@@ -65,5 +72,81 @@ describe('debate entry intent', () => {
     act(() => vi.advanceTimersByTime(25_000));
 
     expect(result.current).toBe('debate-2');
+  });
+});
+
+// GEO-2605. `router.back()` steps one history entry, which is the origin only when the flow was a
+// single hop — so the origin is recorded on the way in rather than inferred on the way out.
+describe('debate flow origin', () => {
+  it('returns the path the flow started from', () => {
+    recordDebateFlowOrigin('/space/space-1/entity-7');
+
+    expect(takeDebateFlowOrigin()).toBe('/space/space-1/entity-7');
+  });
+
+  // The whole point: hub -> room -> rematch -> room must still return to the hub, not to the room
+  // one entry back. Every entry calls markEnteringDebate, so the second one must not overwrite.
+  it('keeps the first origin when the flow enters a second room', () => {
+    recordDebateFlowOrigin('/space/space-1/entity-7');
+    recordDebateFlowOrigin('/space/space-1/debates/debate-1');
+    markEnteringDebate('debate-2');
+
+    expect(takeDebateFlowOrigin()).toBe('/space/space-1/entity-7');
+  });
+
+  // A refresh mid-flow re-enters from a debate path. Recording it would make the room its own
+  // origin, which sends the viewer straight back into the flow they were leaving.
+  it('never records a path inside the flow', () => {
+    recordDebateFlowOrigin('/space/space-1/debates');
+
+    expect(takeDebateFlowOrigin()).toBeNull();
+  });
+
+  // Distinguishes the record-side guard from the read-side one: if an in-flow path were stored,
+  // the already-held guard would then block the real origin and the exit would fall back.
+  it('does not let a refresh inside the flow consume the origin slot', () => {
+    recordDebateFlowOrigin('/space/space-1/debates/debate-1');
+    recordDebateFlowOrigin('/space/space-1/entity-7');
+
+    expect(takeDebateFlowOrigin()).toBe('/space/space-1/entity-7');
+  });
+
+  it('does not treat a path merely containing the word as the flow', () => {
+    recordDebateFlowOrigin('/space/space-1/debatesomething');
+
+    expect(takeDebateFlowOrigin()).toBe('/space/space-1/debatesomething');
+  });
+
+  it('forgets the origin once it has been used, so a later exit falls back', () => {
+    recordDebateFlowOrigin('/space/space-1/entity-7');
+
+    expect(takeDebateFlowOrigin()).toBe('/space/space-1/entity-7');
+    expect(takeDebateFlowOrigin()).toBeNull();
+  });
+
+  it('has nothing to return to when the flow was never entered', () => {
+    expect(takeDebateFlowOrigin()).toBeNull();
+  });
+
+  // Private-mode browsers throw on sessionStorage. Losing the origin is acceptable; taking the
+  // room down on the way out is not.
+  it('survives storage that throws', () => {
+    // jsdom's Storage is a proxy whose methods live on the prototype, so spying on the instance
+    // silently writes a storage entry instead of replacing the method. Swap the whole object.
+    const real = window.sessionStorage;
+    const denied = () => {
+      throw new Error('denied');
+    };
+    Object.defineProperty(window, 'sessionStorage', {
+      configurable: true,
+      value: { getItem: denied, setItem: denied, removeItem: denied },
+    });
+
+    try {
+      expect(() => recordDebateFlowOrigin('/space/space-1/entity-7')).not.toThrow();
+      expect(takeDebateFlowOrigin()).toBeNull();
+    } finally {
+      Object.defineProperty(window, 'sessionStorage', { configurable: true, value: real });
+    }
   });
 });

--- a/apps/web/core/debates/debate-entry-intent.ts
+++ b/apps/web/core/debates/debate-entry-intent.ts
@@ -45,8 +45,75 @@ function set(debateId: string | null) {
   emit();
 }
 
+/**
+ * Where the viewer was before they entered the debate flow.
+ *
+ * GEO-2605: exiting a debate used `router.back()`, which steps back exactly one
+ * history entry. In a single-hop entry that is the origin, but the flow is rarely
+ * single-hop — hub -> room -> rematch -> room means the entry behind you is
+ * another room, so back() lands inside the flow and the fallback drops you on
+ * `/space/{id}/debates`, which is the "weird screen" in the report. The room's own
+ * comment already noted the other half of it: stepping back into a room re-runs
+ * its exit from a fresh mount, which is the flicker.
+ *
+ * So record the origin on the way in instead of inferring it on the way out.
+ *
+ * Captured on `markEnteringDebate`, which every entry into a room already calls,
+ * and deliberately *only if nothing is held yet* — a rematch entering a second
+ * room must not overwrite the hub the viewer actually came from. Paths already
+ * inside the flow are never recorded, so a refresh mid-flow cannot make the room
+ * its own origin.
+ *
+ * `sessionStorage` rather than module state because "errored out of the flow" can
+ * mean a reload, and module state does not survive one. Scoped to the tab, so two
+ * debates in two tabs keep separate origins.
+ *
+ * Every exit through the room consumes the origin, so it only goes stale if the
+ * viewer leaves the flow some other way (a nav click) and later re-enters from a
+ * different page. They then land on the earlier origin instead of the newer one —
+ * still a page they were on in this tab, so not worth a route observer to fix.
+ */
+const DEBATE_FLOW_ORIGIN_KEY = 'geo.debate-flow-origin';
+
+/** True for any path that is itself part of the debate flow. */
+function isDebateFlowPath(path: string): boolean {
+  return /\/debates(\/|$|\?)/.test(path);
+}
+
+function currentPath(): string | null {
+  if (typeof window === 'undefined') return null;
+  return `${window.location.pathname}${window.location.search}`;
+}
+
+/**
+ * Remember where the flow started. No-op if an origin is already held, if the
+ * current path is inside the flow, or off the browser.
+ */
+export function recordDebateFlowOrigin(path: string | null = currentPath()): void {
+  if (typeof window === 'undefined' || !path || isDebateFlowPath(path)) return;
+  try {
+    if (window.sessionStorage.getItem(DEBATE_FLOW_ORIGIN_KEY)) return;
+    window.sessionStorage.setItem(DEBATE_FLOW_ORIGIN_KEY, path);
+  } catch {
+    // Private-mode or storage-disabled browsers fall back to the old behaviour.
+  }
+}
+
+/** Read and forget the origin. Returns null when there is nothing to return to. */
+export function takeDebateFlowOrigin(): string | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const origin = window.sessionStorage.getItem(DEBATE_FLOW_ORIGIN_KEY);
+    window.sessionStorage.removeItem(DEBATE_FLOW_ORIGIN_KEY);
+    return origin || null;
+  } catch {
+    return null;
+  }
+}
+
 /** Call immediately before pushing into a debate room. */
 export function markEnteringDebate(debateId: string) {
+  recordDebateFlowOrigin();
   set(debateId);
   expiry = setTimeout(() => {
     expiry = null;

--- a/apps/web/core/debates/debate-ready-prompt.test.tsx
+++ b/apps/web/core/debates/debate-ready-prompt.test.tsx
@@ -4,6 +4,7 @@ import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/re
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { Debate, DebateParticipant } from './api';
+import { takeDebateFlowOrigin } from './debate-entry-intent';
 import { DebateReadyPrompt, DebateRejoinBar } from './debate-ready-prompt';
 
 const mocks = vi.hoisted(() => ({
@@ -77,6 +78,8 @@ beforeEach(() => {
   mocks.abortMutateAsync.mockResolvedValue(debate({ status: 'cancelled' }));
   mocks.abortPending = false;
   mocks.clearDebateActivity.mockReset();
+  window.sessionStorage.clear();
+  window.history.replaceState({}, '', '/space/space-1/entity-7');
 });
 afterEach(cleanup);
 
@@ -90,6 +93,16 @@ describe('DebateReadyPrompt', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Join debate' }));
 
     expect(mocks.push).toHaveBeenCalledWith('/space/space-1/debates/debate-1');
+  });
+
+  // GEO-2605. This dialog is app-wide, so joining from it can start anywhere — and that anywhere is
+  // where exiting the debate has to return them. Nothing else records it on this path.
+  it('records where the viewer was so the exit can return them there', () => {
+    render(<DebateReadyPrompt debate={debate()} currentUserId="user-me" />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Join debate' }));
+
+    expect(takeDebateFlowOrigin()).toBe('/space/space-1/entity-7');
   });
 
   // The room is a server segment with no loading boundary: the router keeps this page on screen
@@ -174,5 +187,13 @@ describe('DebateRejoinBar', () => {
     fireEvent.click(screen.getByRole('button', { name: /Your debate is ready/ }));
 
     expect(mocks.push).toHaveBeenCalledWith('/space/space-1/debates/debate-1');
+  });
+
+  it('records the origin too, since it floats over whatever page the viewer is on', () => {
+    render(<DebateRejoinBar debate={debate()} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Your debate is ready/ }));
+
+    expect(takeDebateFlowOrigin()).toBe('/space/space-1/entity-7');
   });
 });

--- a/apps/web/core/debates/debate-ready-prompt.tsx
+++ b/apps/web/core/debates/debate-ready-prompt.tsx
@@ -7,6 +7,7 @@ import { useRouter } from 'next/navigation';
 import { Text } from '~/design-system/text';
 
 import type { Debate } from './api';
+import { recordDebateFlowOrigin } from './debate-entry-intent';
 import { DebateRequestDialog } from './debate-request-dialog';
 import { debatePath } from './debate-routes';
 import { useAbortDebate, useClearDebateActivity } from './hooks';
@@ -35,6 +36,10 @@ export function DebateReadyPrompt({ debate, currentUserId }: { debate: Debate; c
   const join = () => {
     if (joining) return;
     setJoining(true);
+    // GEO-2605. This dialog is app-wide, so the viewer could be anywhere when it opens; where they
+    // are now is where exiting the debate should return them. Not `markEnteringDebate` — that would
+    // count them as already there and unmount this dialog mid-join, losing the pending state.
+    recordDebateFlowOrigin();
     startJoining(() => router.push(debatePath(debate)));
   };
 
@@ -108,6 +113,9 @@ export function DebateRejoinBar({ debate }: { debate: Debate }) {
         disabled={joining}
         onClick={() => {
           setJoining(true);
+          // Same as the prompt above: this bar floats over whatever page the viewer is on, and that
+          // page is where exiting the debate belongs.
+          recordDebateFlowOrigin();
           startJoining(() => router.push(debatePath(debate)));
         }}
         className="pointer-events-auto flex max-w-full items-center gap-2 rounded-full bg-text py-2 pr-2 pl-4 text-white shadow-card transition-opacity hover:opacity-90 disabled:opacity-70"


### PR DESCRIPTION
Closes GEO-2605. Possibly closes GEO-2600.

## The bug

Exiting a debate used `router.back()`. That steps **exactly one** history entry, which is the origin only if the flow was a single hop — and it usually isn't:

```
hub → room → rematch → room
```

The entry behind you there is *another room*, so `back()` returns into the flow. And when there's no prior history the fallback is literally `/space/{id}/debates` — which is precisely the "weird screen" Preston reports.

This has been attempted three times (#2061, #2093, #2120), each refining the *inference*. The inference is the problem: `window.history.length` tells you how deep you are and never tells you where you came from.

## The fix

Record the origin on the way **in** instead of inferring it on the way out.

`markEnteringDebate()` already runs on every entry into a room (rematch, accept, matchmaking), so it captures the current path there:

- **only if nothing is held yet** — a rematch entering a second room must not overwrite the hub the viewer actually came from;
- **never a path already inside `/debates`** — otherwise a refresh mid-flow makes the room its own origin and the exit loops back into the flow.

Exit consumes the origin and `router.replace`s forward. With no origin recorded, the previous behaviour stands unchanged.

`sessionStorage` rather than module state, because "errored out of the flow" can mean a reload, and module state doesn't survive one. It's tab-scoped, so two debates in two tabs keep separate origins. Storage that throws (private mode) degrades to the old fallback rather than taking the exit down.

## Why this may also close GEO-2600

The code being replaced carried this comment:

> *stepping back into it re-runs the exit from a fresh mount. That is the flicker, and it is why the removal dialog needed a second Okay.*

Going forward to a known origin never re-mounts a room, so that re-entry path is gone. Worth re-testing 2600 against this.

## Verification

- 57 debate suites / 834 tests pass (`core/debates` + the room).
- 8 new unit tests + 1 room integration test.
- `tsc --noEmit`: 8 errors, identical to the `master` baseline (all pre-existing, unrelated files).
- eslint clean on all four changed files.
- **Mutation-tested** — each guard was removed in turn and the suite re-run:
  | mutation | killed by |
  |---|---|
  | room ignores the recorded origin | `returns to the path the flow started from…` |
  | drop the already-held guard | `keeps the first origin when the flow enters a second room` |
  | drop the in-flow guard on record | `does not let a refresh inside the flow consume the origin slot` |
  | never forget the origin | `forgets the origin once it has been used…` |

  A fifth mutation (dropping a redundant in-flow check on *read*) **survived** — it was unreachable behind the record-side guard, so it's untested code pretending to be a safeguard. Removed rather than left in.

## Known limitation

The origin is consumed by every exit through the room, so it only goes stale if the viewer leaves the flow some other way (a nav click) and later re-enters from a different page. They'd land on the earlier origin instead of the newer one — still a page they were on in this tab. Documented in the source; not worth a route observer to fix.