### PR TITLE
fix(debates): never route into a debate that is over, not just one with a cancelled recording

### DIFF
--- a/apps/web/core/debates/activity-state.test.ts
+++ b/apps/web/core/debates/activity-state.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { activeDebate, hasActiveDebateFlow, recordingCancelledDebateId } from './activity-state';
+import { activeDebate, hasActiveDebateFlow, unenterableDebateId } from './activity-state';
 import type { Debate, DebateActivity, DebateMatch } from './api';
 
 const debate = (status: Debate['status']) => ({ id: 'debate-1', status }) as Debate;
@@ -32,11 +32,17 @@ describe('activity state', () => {
     expect(hasActiveDebateFlow(activityWithCancelledRecording)).toBe(false);
   });
 
-  it('names the debate whose recording was cancelled so callers refuse to route into it', () => {
-    expect(recordingCancelledDebateId(activity({ debate: cancelledRecording('thanking') }))).toBe('debate-1');
-    expect(recordingCancelledDebateId(activity({ debate: debate('thanking') }))).toBeNull();
-    expect(recordingCancelledDebateId(activity({ debate: null }))).toBeNull();
-    expect(recordingCancelledDebateId(null)).toBeNull();
+  it('names a debate there is nothing left to enter so callers refuse to route into it', () => {
+    expect(unenterableDebateId(activity({ debate: cancelledRecording('thanking') }))).toBe('debate-1');
+    expect(unenterableDebateId(activity({ debate: debate('thanking') }))).toBeNull();
+    expect(unenterableDebateId(activity({ debate: null }))).toBeNull();
+    expect(unenterableDebateId(null)).toBeNull();
+  });
+
+  // GEO-2600: naming only the cancelled recording left a `complete` debate looking enterable, and
+  // the room returns whoever opens one just the same. Tied to `activeDebate` so they cannot drift.
+  it.each(['complete', 'cancelled'] as const)('names a %s debate as unenterable too', status => {
+    expect(unenterableDebateId(activity({ debate: debate(status) }))).toBe('debate-1');
   });
 
   it('treats a rematch session as an active flow', () => {

--- a/apps/web/core/debates/activity-state.ts
+++ b/apps/web/core/debates/activity-state.ts
@@ -23,12 +23,18 @@ export function activeDebate(activity: ActivityLike | null | undefined): Debate 
 }
 
 /**
- * The reported debate's id if its recording was cancelled. Callers use it to refuse to navigate
- * into a room that has nothing left to show — see `activeDebate` for why it is not "active".
+ * The reported debate's id when there is nothing left to enter: it finished, or its recording was
+ * cancelled. Callers use it to refuse to navigate into a room that hides itself and returns whoever
+ * opens it — see `activeDebate` for why such a debate is not "active".
+ *
+ * Deliberately the exact inverse of `activeDebate` rather than its own list of conditions. GEO-2600
+ * was a caller that checked only the cancelled recording and so still routed into a `complete`
+ * room, which bounced the viewer straight back out and re-armed the push that sent them.
  */
-export function recordingCancelledDebateId(activity: ActivityLike | null | undefined): string | null {
+export function unenterableDebateId(activity: ActivityLike | null | undefined): string | null {
   const debate = activity?.debate ?? null;
-  return debate?.recording_cancelled_at ? debate.id : null;
+  if (!debate) return null;
+  return activeDebate(activity) ? null : debate.id;
 }
 
 /**

--- a/apps/web/core/debates/debate-coordinator.test.tsx
+++ b/apps/web/core/debates/debate-coordinator.test.tsx
@@ -460,6 +460,26 @@ describe('DebateCoordinator', () => {
     expect(screen.queryByRole('button', { name: /Your debate is/ })).not.toBeInTheDocument();
   });
 
+  // GEO-2600. Same loop, wider cause: the room returns whoever opens *any* finished debate, not
+  // only one whose recording was cancelled. `activeDebate` has always known that; this effect only
+  // checked the recording. So a `deciding` rematch over a complete debate pushed into a room that
+  // bounced straight back out, and the push repeated on every activity change — the rematch page
+  // blanking and redrawing on a URL that never moved, which is what Preston recorded.
+  it.each(['complete', 'cancelled'] as const)(
+    'does not route into a deciding rematch whose debate is %s',
+    async status => {
+      mocks.pathname = '/space/space-1/debates/rematches/rematch-1';
+      mocks.activity = {
+        ...activityWithRematch('deciding'),
+        debate: { ...activityWithDebate().debate!, status, participants: bothParticipants() },
+      };
+
+      render(<DebateCoordinator />);
+
+      await waitFor(() => expect(mocks.push).not.toHaveBeenCalled());
+    }
+  );
+
   it('still routes into a deciding rematch while the debate is intact', async () => {
     mocks.pathname = '/space/space-1/claims';
     mocks.activity = activityWithRematch('deciding');

--- a/apps/web/core/debates/debate-coordinator.tsx
+++ b/apps/web/core/debates/debate-coordinator.tsx
@@ -9,7 +9,7 @@ import { Upload } from '~/design-system/icons/upload';
 import { Spinner } from '~/design-system/spinner';
 import { Text } from '~/design-system/text';
 
-import { activeDebate, recordingCancelledDebateId } from './activity-state';
+import { activeDebate, unenterableDebateId } from './activity-state';
 import { type DebateSharePrompt } from './api';
 import { useClaimResponseIndexedNotifier } from './claim-response-indexed-notifier';
 import { useDebatePresence } from './debate-attention';
@@ -173,10 +173,12 @@ export function DebateCoordinator() {
     if (!activity) return;
     const rematch = activity.rematch;
     if (!rematch) return;
-    // A debate whose recording was cancelled cannot be re-entered: the room hides itself and
-    // returns whoever opens it. Pushing into it here turned that into a navigation loop — the
-    // screen flickered, and the opponent's "your debate was removed" dialog came back after Okay.
-    if (rematch.source_debate_id && rematch.source_debate_id === recordingCancelledDebateId(activity)) return;
+    // A debate that is over cannot be re-entered: the room hides itself and returns whoever opens
+    // it. Pushing into it here turned that into a navigation loop — the screen flickered, and the
+    // opponent's "your debate was removed" dialog came back after Okay. That first showed up as a
+    // cancelled recording, but GEO-2600 was the same loop over a `complete` debate: the push landed
+    // and bounced on every activity change, blanking the rematch page on a URL that never moved.
+    if (rematch.source_debate_id && rematch.source_debate_id === unenterableDebateId(activity)) return;
     const sourceDebatePath = rematch.source_debate_id ? `/debates/${rematch.source_debate_id}` : null;
     if (rematch.status === 'deciding') {
       if (sourceDebatePath && !pathname.includes(sourceDebatePath)) {


### PR DESCRIPTION
Closes GEO-2600.

## What the recording actually shows

I pulled Preston's `.mov` off the ticket and stepped through it:

- The page is the rematch claim picker, `/space/f3dab…/debates/rematches/b55561…`.
- The content **blanks to white and comes back** roughly 2–3× a second.
- **The URL is byte-identical in all 31 samples** over 5 seconds (6 fps).
- On a blank frame the browser's reload button is a reload arrow, not a stop ✕ — no page load is in flight.

So it isn't a slow query and it isn't a visible route transition. The rematch page mounts, leaves, and mounts again faster than the address bar ever paints the intermediate URL.

## The loop

`DebateCoordinator` routes a `deciding` rematch into its source debate's room:

```js
if (rematch.source_debate_id && rematch.source_debate_id === recordingCancelledDebateId(activity)) return;
…
if (rematch.status === 'deciding') {
  if (sourceDebatePath && !pathname.includes(sourceDebatePath)) {
    router.push(`/space/${rematch.source_space_id}${sourceDebatePath}`);
  }
}
```

That guard was added for exactly this class of loop, but it only asks about the **recording**. The room hides itself and returns whoever opens *any* finished debate — `activeDebate` has always known that, and there is already a room test named *"returns through browser history without rendering an already-completed room"*.

So with a `complete` source debate:

1. coordinator pushes into the room,
2. the room mounts, sees a finished debate, and returns,
3. `pathname` changes back, the effect re-runs, and the guard still says the debate is fine,
4. goto 1.

## The fix

`recordingCancelledDebateId` becomes `unenterableDebateId`, defined as the **exact inverse of `activeDebate`** instead of keeping its own list of conditions:

```ts
export function unenterableDebateId(activity) {
  const debate = activity?.debate ?? null;
  if (!debate) return null;
  return activeDebate(activity) ? null : debate.id;
}
```

The drift between those two lists *is* the bug, so the fix is to remove the possibility of drift rather than add `complete` to a second list.

## Verification

The test was written before the fix and observed to fail:

```
× does not route into a deciding rematch whose debate is complete
× does not route into a deciding rematch whose debate is cancelled
```

The existing coverage had the shape of this hole visible in it: there was a test for *recording-cancelled + deciding → no push*, and a test for *complete/cancelled → no push* that carried **no rematch**, so the `deciding` push path was never exercised for a finished debate.

- 54 debate suites / 629 tests pass.
- `tsc --noEmit`: 8 errors, identical to the `master` baseline (all pre-existing, unrelated files).
- eslint and prettier clean.
- **Mutation-tested both directions:**
  | mutation | killed by |
  |---|---|
  | back to the recording-only rule | 2 activity-state cases + both new coordinator cases |
  | treat every reported debate as unenterable | `names a debate there is nothing left to enter…` |

## Related

Preston filed a second flicker in the same ticket — the one on *exit*. #2186 (GEO-2605) replaces the room's `router.back()` exit with a forward navigation to the recorded flow origin, which removes the room re-mount the room's own comment identifies as that flicker. The two are independent; this one is the loop that needs no user action at all.