### PR TITLE
fix(debates): ask the rematch picker again after geo-chat is told, not alongside

### DIFF
--- a/apps/web/core/debates/claim-response-indexed-notifier.test.tsx
+++ b/apps/web/core/debates/claim-response-indexed-notifier.test.tsx
@@ -119,6 +119,47 @@ describe('useClaimResponseIndexedNotifier', () => {
     await waitFor(() => expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['debates', 'claims', 'space-1'] }));
   });
 
+  // GEO-2603. This notification is what puts the response in geo-chat's copy, and the rematch
+  // picker gates Request debate on geo-chat agreeing the viewer has taken a side. The picker's own
+  // refresh runs off the same `indexed` event that starts the notification, so it races it and
+  // usually loses; the ask that follows the notification is the only one guaranteed to postdate it.
+  it('asks the rematch picker again once geo-chat has been told', async () => {
+    const { queryClient, wrapper } = createHarness();
+    const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries');
+    renderHook(() => useClaimResponseIndexedNotifier(true, vi.fn(), 'account-1'), { wrapper });
+
+    act(() => {
+      queryClient.setQueryData(['entity-response-indexing', 'profile-1', 'claim-1', 'space-1', 'stance'], {
+        status: 'indexed',
+        pending: {
+          entityId: 'claim-1',
+          expectedResponse: 'positive',
+          personalSpaceId: 'profile-1',
+          responseKind: 'stance',
+          spaceId: 'space-1',
+        },
+        runId: 'run-refresh',
+      });
+    });
+
+    await waitFor(() => expect(mocks.notify).toHaveBeenCalledOnce());
+    const refresh = await waitFor(() => {
+      const call = invalidateQueries.mock.calls.find(([filters]) => typeof filters?.predicate === 'function');
+      const predicate = call?.[0]?.predicate;
+      expect(predicate).toBeTypeOf('function');
+      return predicate!;
+    });
+
+    const batch = (claimIds: string[]) => ({
+      queryKey: ['debates', 'account', 'account-1', 'rematch', 'rematch-1', 'claims', claimIds],
+    });
+    // The batches that name the claim, plus the session's own id-less list — and nothing else.
+    expect(refresh(batch(['claim-1']) as never)).toBe(true);
+    expect(refresh(batch([]) as never)).toBe(true);
+    expect(refresh(batch(['claim-2']) as never)).toBe(false);
+    expect(refresh({ queryKey: ['debates', 'claims', 'space-1'] } as never)).toBe(false);
+  });
+
   it('retries an interrupted notification when the same account is re-enabled', async () => {
     let notificationSignal: AbortSignal | undefined;
     mocks.notify.mockImplementation((...args: unknown[]) => {
@@ -159,12 +200,17 @@ describe('useClaimResponseIndexedNotifier', () => {
     await waitFor(() => expect(notificationSignal).toBeDefined());
     rerender({ enabled: false });
     await waitFor(() => expect(notificationSignal?.aborted).toBe(true));
+    // Neither the fallback nor the picker refresh belongs to a notification this hook cancelled
+    // itself: geo-chat was never told, so nothing it could answer with has changed, and the retry
+    // below is what will ask once it has been.
     expect(invalidateQueries).not.toHaveBeenCalled();
 
     mocks.notify.mockResolvedValue(undefined);
     rerender({ enabled: true });
     await waitFor(() => expect(mocks.notify).toHaveBeenCalledTimes(2));
-    expect(invalidateQueries).not.toHaveBeenCalled();
+    // The retry landed, so the picker is asked again — but the failure fallback still must not fire.
+    await waitFor(() => expect(invalidateQueries).toHaveBeenCalled());
+    expect(invalidateQueries).not.toHaveBeenCalledWith({ queryKey: ['debates', 'claims', 'space-1'] });
   });
 
   it('does not replay an interrupted notification for another account', async () => {

--- a/apps/web/core/debates/claim-response-indexed-notifier.ts
+++ b/apps/web/core/debates/claim-response-indexed-notifier.ts
@@ -7,6 +7,7 @@ import * as React from 'react';
 import type { EntityResponseIndexingState } from '~/core/hooks/use-entity-vote';
 
 import { type DebateResponseKind, type GetPrivyIdentityToken, notifyClaimResponseIndexed } from './api';
+import { refreshRematchClaimBatches, rematchClaimBatchesWithClaim } from './rematch-claims-query-key';
 
 const MAX_NOTIFIED_RUNS = 256;
 type IndexedClaimResponse = NonNullable<ReturnType<typeof claimResponseIndexedEvent>>;
@@ -82,7 +83,17 @@ export function useClaimResponseIndexedNotifier(
           if (isAbortError(error)) return;
           return queryClient.invalidateQueries({ queryKey: ['debates', 'claims', response.spaceId] });
         })
-        .finally(() => notificationControllers.delete(controller));
+        .finally(() => {
+          notificationControllers.delete(controller);
+          if (controller.signal.aborted) return;
+          // GEO-2603. This call is what puts the response in geo-chat's copy, and the rematch
+          // picker gates Request debate on geo-chat agreeing the viewer has taken a side. The
+          // picker refreshes its batches off the same `indexed` event that starts this notification,
+          // so that refetch races the notification and usually loses — leaving the button hidden
+          // until something unrelated happened to refetch. Asking again once the notification has
+          // settled is the only refresh guaranteed to postdate it.
+          void refreshRematchClaimBatches(queryClient, rematchClaimBatchesWithClaim(accountKey, response.entityId));
+        });
     };
 
     const unsubscribe = queryClient.getQueryCache().subscribe(event => {

--- a/apps/web/core/debates/hooks.ts
+++ b/apps/web/core/debates/hooks.ts
@@ -3,7 +3,6 @@
 import { usePrivy } from '@geogenesis/auth';
 import {
   type QueryClient,
-  type QueryFilters,
   type UseQueryResult,
   useMutation,
   useQueries,
@@ -68,7 +67,11 @@ import { useDebateAttention } from './debate-attention';
 import { markEnteringDebate } from './debate-entry-intent';
 import { useDebateGatewayScope, useDebateGatewaySpaceScopes } from './debate-gateway';
 import { hasProcessedVideo } from './playback-utils';
-import { isRematchClaimsQueryKey } from './rematch-claims-query-key';
+import {
+  isRematchClaimsQueryKey,
+  refreshRematchClaimBatches,
+  rematchClaimBatchesWithClaim,
+} from './rematch-claims-query-key';
 
 export const debateQueryNetworkOptions = {
   retry: false,
@@ -249,44 +252,6 @@ function claimIdHash(claimId: string) {
     hash = Math.imul(hash, 0x01000193) >>> 0;
   }
   return hash;
-}
-
-/**
- * Filters for the rematch claim batches that carry `claimId` — plus the id-less session list,
- * which any response can add a row to. The batches that don't name the claim learned nothing.
- */
-export function rematchClaimBatchesWithClaim(accountKey: string | null, claimId: string, sessionId?: string) {
-  return {
-    predicate: (query: { queryKey: readonly unknown[] }) => {
-      const { queryKey } = query;
-      if (!isRematchClaimsQueryKey(queryKey) || queryKey[2] !== accountKey) return false;
-      if (sessionId !== undefined && queryKey[4] !== sessionId) return false;
-      const ids = queryKey[6];
-      return !Array.isArray(ids) || ids.length === 0 || ids.includes(claimId);
-    },
-  };
-}
-
-/**
- * Refresh rematch claim batches without restarting a request that is about to land.
- *
- * Invalidating cancels an in-flight fetch by default, which throws away a request that was about
- * to answer — and when changes arrive faster than the round trips complete, means none of them
- * ever land. A batch in flight is left to land, since its answer is still worth putting on screen,
- * and is then asked again so what the viewer ends up looking at postdates the change that prompted
- * this. The gateway does the same on its own flushes; these are the same batches.
- */
-function refreshRematchClaimBatches(queryClient: QueryClient, filters: QueryFilters) {
-  const inFlight = queryClient.getQueryCache().findAll({ ...filters, fetchStatus: 'fetching' });
-  const refreshed = queryClient.invalidateQueries(filters, { cancelRefetch: false });
-  if (inFlight.length === 0) return refreshed;
-
-  return refreshed.finally(() =>
-    queryClient.refetchQueries(
-      { type: 'active', predicate: query => inFlight.some(batch => batch.queryHash === query.queryHash) },
-      { cancelRefetch: false }
-    )
-  );
 }
 
 /**

--- a/apps/web/core/debates/rematch-claims-query-key.ts
+++ b/apps/web/core/debates/rematch-claims-query-key.ts
@@ -1,3 +1,5 @@
+import type { QueryClient, QueryFilters } from '@tanstack/react-query';
+
 /**
  * Whether a query key names a session's rematch claims — the batches the picker asks geo-chat for,
  * `['debates','account',accountKey,'rematch',sessionId,'claims',ids]`, and the id-less prefix
@@ -12,5 +14,43 @@
 export function isRematchClaimsQueryKey(queryKey: readonly unknown[]) {
   return (
     queryKey[0] === 'debates' && queryKey[1] === 'account' && queryKey[3] === 'rematch' && queryKey[5] === 'claims'
+  );
+}
+
+/**
+ * Filters for the rematch claim batches that carry `claimId` — plus the id-less session list,
+ * which any response can add a row to. The batches that don't name the claim learned nothing.
+ */
+export function rematchClaimBatchesWithClaim(accountKey: string | null, claimId: string, sessionId?: string) {
+  return {
+    predicate: (query: { queryKey: readonly unknown[] }) => {
+      const { queryKey } = query;
+      if (!isRematchClaimsQueryKey(queryKey) || queryKey[2] !== accountKey) return false;
+      if (sessionId !== undefined && queryKey[4] !== sessionId) return false;
+      const ids = queryKey[6];
+      return !Array.isArray(ids) || ids.length === 0 || ids.includes(claimId);
+    },
+  };
+}
+
+/**
+ * Refresh rematch claim batches without restarting a request that is about to land.
+ *
+ * Invalidating cancels an in-flight fetch by default, which throws away a request that was about
+ * to answer — and when changes arrive faster than the round trips complete, means none of them
+ * ever land. A batch in flight is left to land, since its answer is still worth putting on screen,
+ * and is then asked again so what the viewer ends up looking at postdates the change that prompted
+ * this. The gateway does the same on its own flushes; these are the same batches.
+ */
+export function refreshRematchClaimBatches(queryClient: QueryClient, filters: QueryFilters) {
+  const inFlight = queryClient.getQueryCache().findAll({ ...filters, fetchStatus: 'fetching' });
+  const refreshed = queryClient.invalidateQueries(filters, { cancelRefetch: false });
+  if (inFlight.length === 0) return refreshed;
+
+  return refreshed.finally(() =>
+    queryClient.refetchQueries(
+      { type: 'active', predicate: query => inFlight.some(batch => batch.queryHash === query.queryHash) },
+      { cancelRefetch: false }
+    )
   );
 }


### PR DESCRIPTION
Closes GEO-2603 — *"too much lag between me clicking the position and the request debate button appearing"*.

## Why the button waits

The picker deliberately gates on geo-chat, not on the optimistic answer:

```ts
// geo-chat validates against its own copy of your position, which trails the optimistic one by a
// publish, an index, and a notification. Acting before it agrees earns "respond to this claim
// before requesting a rematch".
const responseSettled = serverLocalPosition === localPosition;
const canRequest = opposing && responseSettled;
```

That comment ends *"and the wait is short"*. It isn't, and this is why.

## The race

The thing that puts the response into geo-chat's copy is `notifyClaimResponseIndexed`, fired by `useClaimResponseIndexedNotifier` when the indexing run reaches `indexed`.

The thing that refreshes the picker's batches is an effect in `useDebateRematchClaims` — fired by **the same cache event**.

So they start together, and the refetch usually wins. It asks geo-chat for the viewer's position *before* geo-chat has been told about it, gets the stale answer, and `responseSettled` stays false. `Request debate` then stays hidden until something unrelated happens to refetch — a gateway event, a window focus, another response landing. Which is exactly the shape of the complaint: not a consistent delay, an indefinite one.

On success the notifier invalidated **nothing**. Its only invalidation was on the `.catch` path, and it targeted `['debates','claims',spaceId]` — a family that does not prefix-match the rematch batches (`['debates','account',…]`) at all.

## The fix

Ask again once the notification has settled. That is the only refresh guaranteed to postdate it. The picker's eager refresh stays — it is still the fast path when geo-chat already knew.

Not on a notification the hook cancelled itself (`enabled` flipped, account changed): geo-chat was never told, so it has nothing new to answer with, and the retry on re-enablement does the asking.

`rematchClaimBatchesWithClaim` and `refreshRematchClaimBatches` move from `hooks.ts` to `rematch-claims-query-key.ts` so the notifier can use them without an import cycle (`hooks` imports the notifier). That module's own header already says it exists "so the gateway and the hooks can both read it without importing each other".

The existing filter is reused rather than widened: only batches naming the claim, plus the session's id-less list. Refreshing every batch the picker holds is one request per page on screen.

## Verification

- 54 debate suites / 626 tests pass.
- `tsc --noEmit`: 8 errors, identical to the `master` baseline (all pre-existing, unrelated files).
- eslint and prettier clean.
- One existing test pinned the old contract (`expect(invalidateQueries).not.toHaveBeenCalled()` after a *successful* retry). Updated to assert what it was actually protecting — no silent local-claims fallback — rather than deleted.
- **Mutation-tested:**
  | mutation | killed by |
  |---|---|
  | no refresh after the notify (i.e. the bug) | `asks the rematch picker again once geo-chat has been told` |
  | refresh even on a cancelled notification | `retries an interrupted notification when the same account is re-enabled` |
  | drop the claim filter, refresh every batch | the new test + `refetches rematch snapshots when response reconciliation is fully indexed` |

  The second mutation initially **survived** — the test only checked the fallback wasn't called, not that the refresh wasn't. That assertion was tightened until it could fail.

## What this does not fix

The publish → index round trip itself. Once geo-chat is told, the button now appears on the next refetch instead of whenever one happens to occur; the on-chain part is unchanged.