### PR TITLE
fix(debates): keep app-wide debate prompts off the rematch page

### DIFF
--- a/apps/web/core/debates/debate-coordinator.test.tsx
+++ b/apps/web/core/debates/debate-coordinator.test.tsx
@@ -436,6 +436,42 @@ describe('DebateCoordinator', () => {
     expect(screen.queryByRole('button', { name: /Your debate is/ })).not.toBeInTheDocument();
   });
 
+  // GEO-2604. The window this closes: the rematch session has converted, so activity reports the
+  // new `ready` debate and no longer reports a rematch, but the page's own session query has not
+  // caught up and so has not navigated yet. That is exactly the shape the ready prompt exists for —
+  // a ready debate the viewer has not been told about — so it opened over a page that was already
+  // on its way into the room, then vanished when the navigation landed. Preston reported a popup
+  // that "required no interaction" and redirected him anyway.
+  it('does not prompt over the rematch page for a debate that page is about to open', async () => {
+    mocks.pathname = '/space/space-1/debates/rematches/rematch-1';
+    mocks.activity = {
+      ...activityWithDebate(),
+      rematch: null,
+      debate: { ...activityWithDebate().debate!, status: 'ready', participants: bothParticipants() },
+    };
+
+    render(<DebateCoordinator />);
+
+    await waitFor(() => expect(mocks.push).not.toHaveBeenCalled());
+    expect(screen.queryByText('Your debate is ready')).not.toBeInTheDocument();
+    // Nor the fallback bar: it would flash in exactly the same window.
+    expect(screen.queryByRole('button', { name: /Your debate is/ })).not.toBeInTheDocument();
+  });
+
+  // Still prompted anywhere else, so suppressing it above cannot swallow a real one.
+  it('still prompts for a ready debate away from the rematch page', async () => {
+    mocks.pathname = '/space/space-1/claims';
+    mocks.activity = {
+      ...activityWithDebate(),
+      rematch: null,
+      debate: { ...activityWithDebate().debate!, status: 'ready', participants: bothParticipants() },
+    };
+
+    render(<DebateCoordinator />);
+
+    await waitFor(() => expect(screen.getByText('Your debate is ready')).toBeInTheDocument());
+  });
+
   // The loop this stops: the room hides itself and returns whoever opens a debate whose recording
   // was cancelled, so routing into it from here bounced the viewer back and forth — the screen
   // flickered, and the opponent's "your debate was removed" dialog reappeared after Okay.

--- a/apps/web/core/debates/debate-coordinator.tsx
+++ b/apps/web/core/debates/debate-coordinator.tsx
@@ -74,6 +74,13 @@ export function DebateCoordinator() {
   // comes straight back reporting the debate.
   const enteringDebateId = useEnteringDebateId();
   const atDebate = Boolean(debate && (pathname.includes(`/debates/${debate.id}`) || debate.id === enteringDebateId));
+  // The rematch page walks the viewer into its own converted debate. Activity reports that debate
+  // before the session query reports `converted`, so for a beat this coordinator sees a `ready`
+  // debate, no rematch, and nobody at it — the exact shape it opens the ready prompt for. It opened
+  // it on top of a page that was already navigating, so it flashed up and vanished again without
+  // being touched (GEO-2604). Nothing app-wide belongs over that page: it owns its own routing, and
+  // whatever it is about to do is more current than activity is.
+  const atRematchPage = pathname.includes('/debates/rematches/');
   const activeFlow = Boolean(debate || activity?.rematch || challenge);
   const sharePromptsQuery = useDebateSharePrompts(Boolean(activity) && !activeFlow);
   const queriedSharePrompt =
@@ -136,7 +143,8 @@ export function DebateCoordinator() {
   // out. Everything past `ready` falls through to the rejoin bar, which offers the way in without
   // offering a way to destroy it.
   const describable = (debate?.participants?.length ?? 0) >= 2;
-  const promptedDebate = debate && debate.status === 'ready' && describable && !atDebate ? debate : null;
+  const promptedDebate =
+    debate && debate.status === 'ready' && describable && !atDebate && !atRematchPage ? debate : null;
 
   // Held until a navigation commits, then released. Arriving at the room is the expected end, and
   // `atDebate` carries on from the pathname there. Going anywhere else abandons the walk — holding
@@ -209,7 +217,9 @@ export function DebateCoordinator() {
       {promptedDebate && currentUserId && !activity?.rematch && (
         <DebateReadyPrompt key={promptedDebate.id} debate={promptedDebate} currentUserId={currentUserId} />
       )}
-      {debate && !atDebate && !promptedDebate && !activity?.rematch && <DebateRejoinBar debate={debate} />}
+      {debate && !atDebate && !atRematchPage && !promptedDebate && !activity?.rematch && (
+        <DebateRejoinBar debate={debate} />
+      )}
       {/* Recipient only: they have a decision to make. The sender's copy waits under Sent in the
           hub's Requests tab, and the rematch routing effect above walks them into the claim picker
           the moment it is accepted. */}


### PR DESCRIPTION
Addresses the **second half** of GEO-2604. The first half needs a product call — see the bottom.

## The reported bug

> I sent someone else a request. They accepted. Then this popup came up for a second, required no interaction from me, and then without me clicking redirected me to the I'm ready screen. This popup should not appear here.

The screenshot is `DebateReadyPrompt`.

## Why it appeared

The redirect itself is correct — `rematch-page-client.tsx` walks the requester into the converted debate:

```js
if (session.status === 'converted' && session.converted_debate_id) {
  markEnteringDebate(session.converted_debate_id);
  router.replace(`/space/${session.source_space_id}/debates/${session.converted_debate_id}`);
}
```

The popup is the gap in front of it. When the session converts, **activity** gains the new `ready` debate and drops the rematch — but the page's **session query** hasn't caught up, so `markEnteringDebate` hasn't run and the page hasn't navigated. For that beat the coordinator sees:

- a `ready` debate, ✅
- describable (both participants), ✅
- `!atDebate` — pathname is still the rematches page and no entry intent is held, ✅
- `!activity?.rematch` — already gone, ✅

which is precisely the "this person has not been told their debate is ready" shape. So it opened the dialog on top of a page that was already navigating, and unmounted it when the navigation landed.

## The fix

The rematch page owns routing for its own session, and what it is about to do is more current than activity is — so nothing app-wide belongs over it:

```js
const atRematchPage = pathname.includes('/debates/rematches/');
```

Applied to the ready prompt and to the rejoin bar, which would flash in the same window.

This is the same principle as the existing test *"does not route stale debate activity over an active rematch page"* — that guard covered the coordinator's navigation but not its dialogs.

## Verification

- 57 debate suites / 827 tests pass.
- `tsc --noEmit`: 8 errors, identical to the `master` baseline (all pre-existing, unrelated files).
- eslint and prettier clean.
- **Mutation-tested:**
  | mutation | killed by |
  |---|---|
  | drop the guard from the prompt | `does not prompt over the rematch page for a debate that page is about to open` |
  | drop the guard from the rejoin bar | same test's second assertion |
  | `atRematchPage = true` (suppress everywhere) | 8 tests, including the new `still prompts for a ready debate away from the rematch page` |

  The third mutation matters: a guard that suppresses too much would have looked like a pass without it.

## The first half of the ticket

> When I am entering a debate there are various loading indicators that dont need to be there.

I stepped through that `.mov` frame by frame. It is not a stray indicator — it is real waiting, in three stages:

| what is on screen | roughly |
|---|---|
| `Opening debate-again choices…` (the route's `loading.tsx`) | 2s |
| grey skeleton rows under `Recommended` | ~10s |
| `Connecting` / `Waiting for video` placeholders in the room | several seconds |

The 10-second skeleton is the picker's own comment describing itself: *"The opponent's claims arrive in one round trip; the curated lookup is three, in sequence."* Removing the indicators would just show an empty page for the same 10 seconds, so this needs either the serial round trips collapsed or a decision about what to show while they run — same underlying work as GEO-2599. Not folded in here.

The tail of that recording also shows *"This debate is already open in another tab"* repeatedly, which looks like a separate issue and may be related to GEO-2602.