### PR TITLE
fix: land comment thread connectors on the parent avatar in the panel

### DIFF
--- a/apps/web/partials/comments/comment-density.ts
+++ b/apps/web/partials/comments/comment-density.ts
@@ -9,6 +9,8 @@ const COMMENT_AVATAR_COL_PX = 32;
 const COMMENT_HEADER_GAP_PX = 12;
 const COMMENT_BODY_INSET_PX = COMMENT_AVATAR_COL_PX + COMMENT_HEADER_GAP_PX;
 const COMMENT_AVATAR_COLUMN_CENTER_PX = COMMENT_AVATAR_COL_PX / 2;
+/** Tailwind `min-h-8`. Sized for the page's 32px avatar, and shared by both densities. */
+const COMMENT_HEADER_MIN_HEIGHT_PX = 32;
 
 /**
  * Row density. Entity pages use the roomy 32px-avatar layout; side panels (the
@@ -18,6 +20,13 @@ const COMMENT_AVATAR_COLUMN_CENTER_PX = COMMENT_AVATAR_COL_PX / 2;
  */
 export type CommentDensity = {
   avatarPx: number;
+  /**
+   * Minimum height of a comment's header row. This is what `min-h-8` used to assert
+   * inline; it is a field because the connectors have to know it — at the panel's 20px
+   * avatar the row is taller than the avatar, so the avatar is centred inside it rather
+   * than sitting flush at the top.
+   */
+  headerMinHeightPx: number;
   bodyInsetPx: number;
   avatarCenterPx: number;
   /** Author name. */
@@ -30,6 +39,7 @@ export type CommentDensity = {
 
 export const PAGE_DENSITY: CommentDensity = {
   avatarPx: COMMENT_AVATAR_COL_PX,
+  headerMinHeightPx: COMMENT_HEADER_MIN_HEIGHT_PX,
   bodyInsetPx: COMMENT_BODY_INSET_PX,
   avatarCenterPx: COMMENT_AVATAR_COLUMN_CENTER_PX,
   nameClass: 'text-bodySemibold',
@@ -43,6 +53,7 @@ export const PAGE_DENSITY: CommentDensity = {
 // column wrap early and look narrow in the panel.
 export const PANEL_DENSITY: CommentDensity = {
   avatarPx: 20,
+  headerMinHeightPx: COMMENT_HEADER_MIN_HEIGHT_PX,
   bodyInsetPx: COMMENT_BODY_INSET_PX,
   avatarCenterPx: 10,
   nameClass: 'text-[16px] leading-[13px] font-medium tracking-[-0.35px]',
@@ -61,4 +72,27 @@ export const PANEL_DENSITY: CommentDensity = {
  */
 export function threadSpineOffsetPx(density: CommentDensity): number {
   return density.bodyInsetPx - density.avatarCenterPx;
+}
+
+/** Height of the header row the avatar is centred in. */
+function headerRowHeightPx(density: CommentDensity): number {
+  return Math.max(density.avatarPx, density.headerMinHeightPx);
+}
+
+/**
+ * Vertical centre of the avatar within its row — where a connector arriving from the
+ * side has to land.
+ *
+ * Not `avatarCenterPx`: that is half the avatar, which only doubles as the avatar's
+ * centre in the row when the avatar is as tall as the row. It is on the page (32px
+ * avatar, 32px row), but in the panel a 20px avatar is centred in the same 32px row, so
+ * its centre is at 16px rather than 10px — and the connectors were drawn 6px high.
+ */
+export function threadArmCenterPx(density: CommentDensity): number {
+  return headerRowHeightPx(density) / 2;
+}
+
+/** Bottom edge of the avatar within its row, where a spine descending from it starts. */
+export function avatarBottomInRowPx(density: CommentDensity): number {
+  return threadArmCenterPx(density) + density.avatarPx / 2;
 }

--- a/apps/web/partials/comments/comment-density.ts
+++ b/apps/web/partials/comments/comment-density.ts
@@ -1,0 +1,64 @@
+/**
+ * Comment row metrics, and the nested-thread connector geometry derived from them.
+ *
+ * Kept out of comments-section.tsx so the geometry can be unit-tested on its own —
+ * that module pulls in jotai storage atoms and a sync-engine provider, which a test
+ * of pure arithmetic has no business booting.
+ */
+const COMMENT_AVATAR_COL_PX = 32;
+const COMMENT_HEADER_GAP_PX = 12;
+const COMMENT_BODY_INSET_PX = COMMENT_AVATAR_COL_PX + COMMENT_HEADER_GAP_PX;
+const COMMENT_AVATAR_COLUMN_CENTER_PX = COMMENT_AVATAR_COL_PX / 2;
+
+/**
+ * Row density. Entity pages use the roomy 32px-avatar layout; side panels (the
+ * debates feed's Comments panel) use the design's compact 20px avatar, which
+ * pulls the body up under the name instead of leaving it below a tall avatar
+ * row. The body inset stays 44px in both so nested threading geometry holds.
+ */
+export type CommentDensity = {
+  avatarPx: number;
+  bodyInsetPx: number;
+  avatarCenterPx: number;
+  /** Author name. */
+  nameClass: string;
+  /** Timestamp, Reply/Edit actions — anything secondary in grey. */
+  metaClass: string;
+  /** Comment body copy and the composer prompt. */
+  bodyClass: string;
+};
+
+export const PAGE_DENSITY: CommentDensity = {
+  avatarPx: COMMENT_AVATAR_COL_PX,
+  bodyInsetPx: COMMENT_BODY_INSET_PX,
+  avatarCenterPx: COMMENT_AVATAR_COLUMN_CENTER_PX,
+  nameClass: 'text-bodySemibold',
+  metaClass: 'text-smallButton',
+  bodyClass: 'text-body',
+};
+
+// Figma's comment type ramp (Geo "Comment name" / "Comment text" / "Comment
+// button" tokens): everything is 16px — the page's 20px body and 11px footnote
+// are much larger/smaller respectively, and the oversized body is what made the
+// column wrap early and look narrow in the panel.
+export const PANEL_DENSITY: CommentDensity = {
+  avatarPx: 20,
+  bodyInsetPx: COMMENT_BODY_INSET_PX,
+  avatarCenterPx: 10,
+  nameClass: 'text-[16px] leading-[13px] font-medium tracking-[-0.35px]',
+  metaClass: 'text-[16px] leading-[13px] tracking-[-0.35px]',
+  bodyClass: 'text-[16px] leading-[20px] tracking-[-0.35px]',
+};
+
+/**
+ * Distance from a nested reply list's left edge back to its parent avatar's centre.
+ *
+ * The list sits inside the parent's body area, inset by `bodyInsetPx`, while the
+ * parent's avatar centre is `avatarCenterPx` from that row's left edge — so the
+ * connectors have to reach back by the difference. That is 28px at the page's 32px
+ * avatar and 34px at the panel's 20px one; hardcoding 28 left every panel connector
+ * 6px right of the avatar it was meant to meet.
+ */
+export function threadSpineOffsetPx(density: CommentDensity): number {
+  return density.bodyInsetPx - density.avatarCenterPx;
+}

--- a/apps/web/partials/comments/comment-thread-geometry.test.ts
+++ b/apps/web/partials/comments/comment-thread-geometry.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+
+import { PAGE_DENSITY, PANEL_DENSITY, threadSpineOffsetPx } from './comment-density';
+
+describe('threadSpineOffsetPx', () => {
+  // The invariant, stated the way the layout actually works: a nested reply list is
+  // inset from its parent row by `bodyInsetPx`, so reaching back by the spine offset
+  // has to land exactly on the parent avatar's centre. Asserted per density because
+  // the bug was one hardcoded offset used for both.
+  it.each([
+    ['page', PAGE_DENSITY],
+    ['panel', PANEL_DENSITY],
+  ])('lands the connector on the parent avatar centre at %s density', (_label, density) => {
+    expect(density.bodyInsetPx - threadSpineOffsetPx(density)).toBe(density.avatarCenterPx);
+  });
+
+  it('differs between densities, since the avatar sizes differ', () => {
+    // 44 − 16 and 44 − 10. The panel value is the one that used to be wrong: it was
+    // hardcoded to the page's 28, leaving every panel connector 6px off.
+    expect(threadSpineOffsetPx(PAGE_DENSITY)).toBe(28);
+    expect(threadSpineOffsetPx(PANEL_DENSITY)).toBe(34);
+    expect(threadSpineOffsetPx(PANEL_DENSITY)).not.toBe(threadSpineOffsetPx(PAGE_DENSITY));
+  });
+});

--- a/apps/web/partials/comments/comment-thread-geometry.test.ts
+++ b/apps/web/partials/comments/comment-thread-geometry.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { PAGE_DENSITY, PANEL_DENSITY, threadSpineOffsetPx } from './comment-density';
+import { avatarBottomInRowPx, PAGE_DENSITY, PANEL_DENSITY, threadArmCenterPx, threadSpineOffsetPx } from './comment-density';
 
 describe('threadSpineOffsetPx', () => {
   // The invariant, stated the way the layout actually works: a nested reply list is
@@ -20,5 +20,30 @@ describe('threadSpineOffsetPx', () => {
     expect(threadSpineOffsetPx(PAGE_DENSITY)).toBe(28);
     expect(threadSpineOffsetPx(PANEL_DENSITY)).toBe(34);
     expect(threadSpineOffsetPx(PANEL_DENSITY)).not.toBe(threadSpineOffsetPx(PAGE_DENSITY));
+  });
+});
+
+describe('threadArmCenterPx', () => {
+  // A connector arriving from the side has to land on the avatar's centre *within its
+  // row*. On the page those are the same number, which is why the old code could use
+  // half-the-avatar for both and still look right there.
+  it('coincides with half the avatar on the page, where the avatar fills the row', () => {
+    expect(PAGE_DENSITY.avatarPx).toBe(PAGE_DENSITY.headerMinHeightPx);
+    expect(threadArmCenterPx(PAGE_DENSITY)).toBe(PAGE_DENSITY.avatarCenterPx);
+  });
+
+  it('is not half the avatar in the panel, where a 20px avatar is centred in a 32px row', () => {
+    expect(PANEL_DENSITY.avatarPx).toBeLessThan(PANEL_DENSITY.headerMinHeightPx);
+    // 16, not the 10 the connectors used to be drawn at — the 6px the arms sat high by.
+    expect(threadArmCenterPx(PANEL_DENSITY)).toBe(16);
+    expect(threadArmCenterPx(PANEL_DENSITY)).not.toBe(PANEL_DENSITY.avatarCenterPx);
+  });
+
+  it('puts the descending spine at the avatar bottom, half an avatar below the arm', () => {
+    for (const density of [PAGE_DENSITY, PANEL_DENSITY]) {
+      expect(avatarBottomInRowPx(density) - threadArmCenterPx(density)).toBe(density.avatarPx / 2);
+    }
+    expect(avatarBottomInRowPx(PAGE_DENSITY)).toBe(32);
+    expect(avatarBottomInRowPx(PANEL_DENSITY)).toBe(26);
   });
 });

--- a/apps/web/partials/comments/comments-section.tsx
+++ b/apps/web/partials/comments/comments-section.tsx
@@ -34,52 +34,8 @@ import { Text } from '~/design-system/text';
 
 import { EntityVoteButtons } from '~/partials/entity-page/entity-vote-buttons';
 
+import { type CommentDensity, PAGE_DENSITY, PANEL_DENSITY, threadSpineOffsetPx } from './comment-density';
 import type { CommentFilter, CommentSortOrder, CommentWithReplies } from './types';
-
-const COMMENT_AVATAR_COL_PX = 32;
-const COMMENT_HEADER_GAP_PX = 12;
-const COMMENT_BODY_INSET_PX = COMMENT_AVATAR_COL_PX + COMMENT_HEADER_GAP_PX;
-const COMMENT_AVATAR_COLUMN_CENTER_PX = COMMENT_AVATAR_COL_PX / 2;
-
-/**
- * Row density. Entity pages use the roomy 32px-avatar layout; side panels (the
- * debates feed's Comments panel) use the design's compact 20px avatar, which
- * pulls the body up under the name instead of leaving it below a tall avatar
- * row. The body inset stays 44px in both so nested threading geometry holds.
- */
-type CommentDensity = {
-  avatarPx: number;
-  bodyInsetPx: number;
-  avatarCenterPx: number;
-  /** Author name. */
-  nameClass: string;
-  /** Timestamp, Reply/Edit actions — anything secondary in grey. */
-  metaClass: string;
-  /** Comment body copy and the composer prompt. */
-  bodyClass: string;
-};
-
-const PAGE_DENSITY: CommentDensity = {
-  avatarPx: COMMENT_AVATAR_COL_PX,
-  bodyInsetPx: COMMENT_BODY_INSET_PX,
-  avatarCenterPx: COMMENT_AVATAR_COLUMN_CENTER_PX,
-  nameClass: 'text-bodySemibold',
-  metaClass: 'text-smallButton',
-  bodyClass: 'text-body',
-};
-
-// Figma's comment type ramp (Geo "Comment name" / "Comment text" / "Comment
-// button" tokens): everything is 16px — the page's 20px body and 11px footnote
-// are much larger/smaller respectively, and the oversized body is what made the
-// column wrap early and look narrow in the panel.
-const PANEL_DENSITY: CommentDensity = {
-  avatarPx: 20,
-  bodyInsetPx: COMMENT_BODY_INSET_PX,
-  avatarCenterPx: 10,
-  nameClass: 'text-[16px] leading-[13px] font-medium tracking-[-0.35px]',
-  metaClass: 'text-[16px] leading-[13px] tracking-[-0.35px]',
-  bodyClass: 'text-[16px] leading-[20px] tracking-[-0.35px]',
-};
 
 const CommentDensityContext = React.createContext<CommentDensity>(PAGE_DENSITY);
 
@@ -795,17 +751,17 @@ function CommentList({
   }
 
   // Nested replies with connector lines.
-  // This container lives inside the parent comment's ml-[44px] body area.
-  // The parent's avatar center is at -28px from this container's left edge.
+  // Connectors reach back to the parent avatar's centre — see threadSpineOffsetPx.
   // We render a single continuous vertical line spanning from top to the last reply's
   // avatar center, then each reply gets a horizontal arm (or curve for the last one).
   // The elbow lands on the reply avatar's vertical centre, so its geometry
   // follows the density's avatar size rather than the 32px avatar these paths
   // were originally drawn against.
   const density = useCommentDensity();
+  const spineOffsetPx = threadSpineOffsetPx(density);
   const armY = density.avatarCenterPx - 0.5;
   const elbowRadius = Math.min(9.5, Math.max(0, armY));
-  const elbowPath = `M 0.5 0 L 0.5 ${armY - elbowRadius} Q 0.5 ${armY}, ${0.5 + elbowRadius} ${armY} L 28 ${armY}`;
+  const elbowPath = `M 0.5 0 L 0.5 ${armY - elbowRadius} Q 0.5 ${armY}, ${0.5 + elbowRadius} ${armY} L ${spineOffsetPx} ${armY}`;
 
   const parentBundle =
     parentCommentId != null && hi.focus?.kind === 'parent-thread' && hi.focus.threadCommentId === parentCommentId;
@@ -827,7 +783,7 @@ function CommentList({
           {...branchLeave}
           className="comment-branch-hit comment-branch-parent-hit comment-branch-spine-hit absolute z-[1] flex -translate-x-1/2 cursor-pointer justify-center border-0 bg-transparent p-0"
           style={{
-            left: 'calc(-28px + 0.5px)',
+            left: `calc(${-spineOffsetPx}px + 0.5px)`,
             top: 0,
             height: `${lastReplyTop}px`,
             width: `${COMMENT_THREAD_LINE_HIT_PX}px`,
@@ -865,12 +821,17 @@ function CommentList({
                     onPointerDown={() => hi.pressSpineForListParent(parentCommentId!)}
                     {...branchLeave}
                     className="comment-branch-hit comment-branch-parent-hit pointer-events-auto absolute cursor-pointer border-0 bg-transparent p-0"
-                    style={{ left: '-28px', top: '-2px', width: '28px', height: `${density.avatarCenterPx + 6}px` }}
+                    style={{
+                      left: `${-spineOffsetPx}px`,
+                      top: '-2px',
+                      width: `${spineOffsetPx}px`,
+                      height: `${density.avatarCenterPx + 6}px`,
+                    }}
                   >
                     <svg
                       className="pointer-events-none overflow-visible"
-                      style={{ width: '28px', height: `${density.avatarCenterPx}px` }}
-                      viewBox={`0 0 28 ${density.avatarCenterPx}`}
+                      style={{ width: `${spineOffsetPx}px`, height: `${density.avatarCenterPx}px` }}
+                      viewBox={`0 0 ${spineOffsetPx} ${density.avatarCenterPx}`}
                       fill="none"
                     >
                       <path
@@ -884,8 +845,13 @@ function CommentList({
                 ) : (
                   <svg
                     className="pointer-events-none absolute overflow-visible"
-                    style={{ left: '-28px', top: 0, width: '28px', height: `${density.avatarCenterPx}px` }}
-                    viewBox={`0 0 28 ${density.avatarCenterPx}`}
+                    style={{
+                      left: `${-spineOffsetPx}px`,
+                      top: 0,
+                      width: `${spineOffsetPx}px`,
+                      height: `${density.avatarCenterPx}px`,
+                    }}
+                    viewBox={`0 0 ${spineOffsetPx} ${density.avatarCenterPx}`}
                     fill="none"
                   >
                     <path
@@ -907,12 +873,17 @@ function CommentList({
                   onPointerDown={() => hi.pressSpineForListParent(parentCommentId!)}
                   {...branchLeave}
                   className="comment-branch-hit comment-branch-parent-hit pointer-events-auto absolute -translate-y-1/2 cursor-pointer border-0 bg-transparent p-0"
-                  style={{ left: '-28px', top: `${density.avatarCenterPx}px`, width: '28px', height: '12px' }}
+                  style={{
+                    left: `${-spineOffsetPx}px`,
+                    top: `${density.avatarCenterPx}px`,
+                    width: `${spineOffsetPx}px`,
+                    height: '12px',
+                  }}
                 >
                   <span
                     className={cx(
                       THREAD_LEVEL_BRANCH_SEGMENT,
-                      'absolute top-1/2 left-0 h-px w-[28px] -translate-y-1/2 transition-colors',
+                      'absolute top-1/2 left-0 h-px w-full -translate-y-1/2 transition-colors',
                       spanFill
                     )}
                   />
@@ -924,7 +895,11 @@ function CommentList({
                     'pointer-events-none absolute h-px transition-colors',
                     spanFill
                   )}
-                  style={{ left: '-28px', top: `${density.avatarCenterPx}px`, width: '28px' }}
+                  style={{
+                    left: `${-spineOffsetPx}px`,
+                    top: `${density.avatarCenterPx}px`,
+                    width: `${spineOffsetPx}px`,
+                  }}
                 />
               )}
             </div>
@@ -1027,7 +1002,7 @@ function CommentItem({
   const replies = Array.isArray(comment.replies) ? comment.replies : [];
   const sortedReplies = React.useMemo(() => sortReplies(replies), [replies, sortReplies]);
   const hasReplies = replies.length > 0;
-  const nestedSpineLeftPx = -28;
+  const nestedSpineLeftPx = -threadSpineOffsetPx(density);
   /** Horizontal center of the branch line for the toggle (`commentRef` coordinates): */
   const threadLineCenterXFromRootPx = depth === 0 || hasReplies ? density.avatarCenterPx : nestedSpineLeftPx;
   const threadLineStrokeCenterNudgePx = 0.5;

--- a/apps/web/partials/comments/comments-section.tsx
+++ b/apps/web/partials/comments/comments-section.tsx
@@ -1098,6 +1098,10 @@ function CommentItem({
                   ...parentThreadLeave,
                 }
               : {})}
+            // Empty, padding-less, and in an `items-center` parent that won't stretch it,
+            // so without an explicit minimum this collapses to zero height and the
+            // blank-space collapse target stops being clickable.
+            style={{ minHeight: density.headerMinHeightPx }}
             className={
               hasReplies
                 ? 'comment-branch-parent-hit min-w-12 flex-1 basis-0 cursor-pointer border-0 bg-transparent p-0'

--- a/apps/web/partials/comments/comments-section.tsx
+++ b/apps/web/partials/comments/comments-section.tsx
@@ -34,7 +34,14 @@ import { Text } from '~/design-system/text';
 
 import { EntityVoteButtons } from '~/partials/entity-page/entity-vote-buttons';
 
-import { type CommentDensity, PAGE_DENSITY, PANEL_DENSITY, threadSpineOffsetPx } from './comment-density';
+import {
+  avatarBottomInRowPx,
+  type CommentDensity,
+  PAGE_DENSITY,
+  PANEL_DENSITY,
+  threadArmCenterPx,
+  threadSpineOffsetPx,
+} from './comment-density';
 import type { CommentFilter, CommentSortOrder, CommentWithReplies } from './types';
 
 const CommentDensityContext = React.createContext<CommentDensity>(PAGE_DENSITY);
@@ -759,7 +766,8 @@ function CommentList({
   // were originally drawn against.
   const density = useCommentDensity();
   const spineOffsetPx = threadSpineOffsetPx(density);
-  const armY = density.avatarCenterPx - 0.5;
+  const armCenterPx = threadArmCenterPx(density);
+  const armY = armCenterPx - 0.5;
   const elbowRadius = Math.min(9.5, Math.max(0, armY));
   const elbowPath = `M 0.5 0 L 0.5 ${armY - elbowRadius} Q 0.5 ${armY}, ${0.5 + elbowRadius} ${armY} L ${spineOffsetPx} ${armY}`;
 
@@ -825,13 +833,13 @@ function CommentList({
                       left: `${-spineOffsetPx}px`,
                       top: '-2px',
                       width: `${spineOffsetPx}px`,
-                      height: `${density.avatarCenterPx + 6}px`,
+                      height: `${armCenterPx + 6}px`,
                     }}
                   >
                     <svg
                       className="pointer-events-none overflow-visible"
-                      style={{ width: `${spineOffsetPx}px`, height: `${density.avatarCenterPx}px` }}
-                      viewBox={`0 0 ${spineOffsetPx} ${density.avatarCenterPx}`}
+                      style={{ width: `${spineOffsetPx}px`, height: `${armCenterPx}px` }}
+                      viewBox={`0 0 ${spineOffsetPx} ${armCenterPx}`}
                       fill="none"
                     >
                       <path
@@ -849,9 +857,9 @@ function CommentList({
                       left: `${-spineOffsetPx}px`,
                       top: 0,
                       width: `${spineOffsetPx}px`,
-                      height: `${density.avatarCenterPx}px`,
+                      height: `${armCenterPx}px`,
                     }}
-                    viewBox={`0 0 ${spineOffsetPx} ${density.avatarCenterPx}`}
+                    viewBox={`0 0 ${spineOffsetPx} ${armCenterPx}`}
                     fill="none"
                   >
                     <path
@@ -875,7 +883,7 @@ function CommentList({
                   className="comment-branch-hit comment-branch-parent-hit pointer-events-auto absolute -translate-y-1/2 cursor-pointer border-0 bg-transparent p-0"
                   style={{
                     left: `${-spineOffsetPx}px`,
-                    top: `${density.avatarCenterPx}px`,
+                    top: `${armCenterPx}px`,
                     width: `${spineOffsetPx}px`,
                     height: '12px',
                   }}
@@ -897,7 +905,7 @@ function CommentList({
                   )}
                   style={{
                     left: `${-spineOffsetPx}px`,
-                    top: `${density.avatarCenterPx}px`,
+                    top: `${armCenterPx}px`,
                     width: `${spineOffsetPx}px`,
                   }}
                 />
@@ -1031,12 +1039,12 @@ function CommentItem({
       const commentRect = commentRef.current.getBoundingClientRect();
       const repliesRect = repliesRef.current.getBoundingClientRect();
       // The spine starts below the avatar, so drop that much off its length.
-      setParentLineHeight(repliesRect.top - commentRect.top - density.avatarPx);
+      setParentLineHeight(repliesRect.top - commentRect.top - avatarBottomInRowPx(density));
     }
   }, [hasReplies, threadCollapsed, replies.length, isEditing, isReplying, density.avatarPx]);
 
   const expandedHeaderRow = (
-    <div className="flex items-center gap-3">
+    <div className="flex items-center gap-3" style={{ minHeight: density.headerMinHeightPx }}>
       <div
         className="flex shrink-0 items-center justify-center"
         style={{ width: density.avatarPx, height: density.avatarPx }}
@@ -1092,8 +1100,8 @@ function CommentItem({
               : {})}
             className={
               hasReplies
-                ? 'comment-branch-parent-hit min-h-8 min-w-12 flex-1 basis-0 cursor-pointer border-0 bg-transparent p-0'
-                : 'min-h-8 min-w-12 flex-1 basis-0 cursor-pointer border-0 bg-transparent p-0'
+                ? 'comment-branch-parent-hit min-w-12 flex-1 basis-0 cursor-pointer border-0 bg-transparent p-0'
+                : 'min-w-12 flex-1 basis-0 cursor-pointer border-0 bg-transparent p-0'
             }
           />
         )}
@@ -1216,7 +1224,7 @@ function CommentItem({
   return (
     <div ref={commentRef} className={cx('relative', !isLast && 'mb-6')}>
       {threadCollapsed ? (
-        <div className="flex min-h-8 items-center gap-3">
+        <div className="flex items-center gap-3" style={{ minHeight: density.headerMinHeightPx }}>
           <div className="flex shrink-0 items-center justify-center" style={{ width: density.avatarPx }}>
             {showThreadToggle && (
               <button
@@ -1232,7 +1240,10 @@ function CommentItem({
               </button>
             )}
           </div>
-          <div className="flex min-h-8 min-w-0 flex-1 flex-nowrap items-center gap-2 overflow-hidden">
+          <div
+            className="flex min-w-0 flex-1 flex-nowrap items-center gap-2 overflow-hidden"
+            style={{ minHeight: density.headerMinHeightPx }}
+          >
             <a href={NavUtils.toSpace(comment.author.spaceId)} className="min-w-0 truncate hover:underline">
               <span className={cx(density.nameClass, 'text-text')}>{comment.author.name ?? 'Anonymous'}</span>
             </a>
@@ -1246,7 +1257,8 @@ function CommentItem({
                 aria-expanded={false}
                 aria-label={hasReplies ? 'Expand comment thread' : 'Expand comment'}
                 onClick={() => toggleThreadCollapsed(comment.id)}
-                className="min-h-8 min-w-12 flex-1 basis-0 cursor-pointer border-0 bg-transparent p-0"
+                style={{ minHeight: density.headerMinHeightPx }}
+                className="min-w-12 flex-1 basis-0 cursor-pointer border-0 bg-transparent p-0"
               />
             )}
           </div>
@@ -1266,7 +1278,7 @@ function CommentItem({
               style={{
                 left: `${density.avatarCenterPx}px`,
                 // Starts just below the avatar it descends from.
-                top: `${density.avatarPx}px`,
+                top: `${avatarBottomInRowPx(density)}px`,
                 height: `${parentLineHeight}px`,
                 width: `${COMMENT_THREAD_LINE_HIT_PX}px`,
               }}


### PR DESCRIPTION
The nested reply connectors in the Comments panel don't meet the avatars they point at. Two independent bugs, one on each axis, from the same root cause: geometry written against the entity page's 32px avatar and reused for the panel's 20px one.

## Horizontal — the reach was hardcoded

Every connector was drawn at a hardcoded `-28px` reach, in nine places:

| | avatar | body inset | parent avatar centre, from the nested list's left edge | drawn at |
|---|---|---|---|---|
| Entity page | 32px | 44px | 16 − 44 = **−28** ✓ | −28 |
| Side panel | 20px | 44px | 10 − 44 = **−34** ✗ | −28 |

So panel connectors sat 6px right of their avatar. The vertical geometry in that block was already density-aware, so the file was half-converted; `nestedSpineLeftPx = -28` had the same problem.

Now derived: `threadSpineOffsetPx(density)` → `bodyInsetPx - avatarCenterPx`. 28 on the page (unchanged), 34 in the panel.

## Vertical — half the avatar isn't the avatar's centre

The header row carries a hardcoded `min-h-8` (32px). On the page the 32px avatar fills that row, so half-the-avatar (`avatarCenterPx` = 16) doubles as the avatar's centre *in the row*. In the panel a 20px avatar is centred in the same 32px row, so its middle is at 16px while `avatarCenterPx` is 10 — and every arm arriving from the side was drawn 6px high.

Row height is now a density field (`headerMinHeightPx`) instead of an inline class, and arms are drawn at `threadArmCenterPx` — the avatar's centre within that row. The spine descending from a parent starts at `avatarBottomInRowPx` for the same reason.

## Testing

Measured in the live panel, on the same thread as the report:

| | connector offset from avatar centre |
|---|---|
| before | **−5.5 / −6.5px** |
| after | **±0.5px** (stroke centring) |

- 14 tests in `partials/comments`, six of them new in `comment-thread-geometry.test.ts`. They assert the invariants rather than magic numbers — reaching back by the spine offset from a `bodyInsetPx`-inset list must land on `avatarCenterPx`; the arm centre coincides with half the avatar on the page but must not in the panel. Verified the horizontal ones fail against the old behaviour (`expected 16 to be 10`, `expected 28 to be 34`).
- `bun run build` clean.
- Page density is arithmetically unchanged on both axes (28 and 16), so entity-page comments are untouched.

The row metrics moved to `comment-density.ts`. That isn't tidying for its own sake: `comments-section.tsx` pulls in jotai storage atoms and a sync-engine provider, so importing it from a test of pure arithmetic fails at module load.

## Related, not fixed

The collapsed-row header puts a 24px toggle button inside a 20px-wide avatar column in panel density, so it overflows horizontally. That predates this change and is a separate layout question — say the word if you want it in scope.