### PR TITLE
feat(debates): order the browse feed by the explore "Best" ranking

### DIFF
--- a/apps/web/app/space/[id]/(space)/debates/debates-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/debates-page-client.test.tsx
@@ -54,6 +54,13 @@ vi.mock('~/core/debates/hooks', () => ({
   useJoinDebateQueue: () => ({ mutateAsync: vi.fn(), isPending: false }),
 }));
 
+// The feed orders itself by the explore "Best" ranking. These tests are about readiness and
+// error states, so the ranking is settled and empty — which leaves the feed on recency, the order
+// they were written against.
+vi.mock('~/core/debates/browse/use-debates-best-order', () => ({
+  useDebatesBestOrder: () => ({ rankByDebateId: new Map(), isLoading: false, isError: false }),
+}));
+
 vi.mock('~/core/hooks/use-space', () => ({
   useSpace: () => ({ space: { entity: { name: 'Fashion', image: null } }, isLoading: false }),
 }));

--- a/apps/web/core/debates/browse/debate-feed.test.tsx
+++ b/apps/web/core/debates/browse/debate-feed.test.tsx
@@ -23,6 +23,9 @@ const mocks = vi.hoisted(() => ({
   revokeObjectURL: vi.fn(),
   downloadClick: vi.fn(),
   entityVoteProps: [] as Array<Record<string, unknown>>,
+  /** Debate entity ids in "Best" order. Empty = the ranking covers nothing, so recency stands. */
+  bestOrderIds: [] as string[],
+  bestOrderLoading: false,
 }));
 
 type ObserverRecord = {
@@ -42,6 +45,18 @@ vi.mock('~/core/debates/hooks', () => ({
   }),
   useDebateMediaArtifactUrl: () => ({ mutate: mocks.mediaMutate }),
 }));
+
+vi.mock('./use-debates-best-order', async () => {
+  // Keyed exactly as the real hook keys it, so the feed's own lookup is what's under test.
+  const { ID } = await import('~/core/id');
+  return {
+    useDebatesBestOrder: () => ({
+      rankByDebateId: new Map(mocks.bestOrderIds.map((id, index) => [ID.uuidToHex(id), index])),
+      isLoading: mocks.bestOrderLoading,
+      isError: false,
+    }),
+  };
+});
 
 vi.mock('~/core/debates/use-debate-votes', () => ({
   useDebateVotes: () => ({
@@ -101,6 +116,8 @@ beforeEach(() => {
   mocks.entityVoteProps.length = 0;
   mocks.debates = [completedDebate('debate-1', 'Debates are useful', '2026-07-02T00:01:10.000Z')];
   mocks.processedIds = null;
+  mocks.bestOrderIds = [];
+  mocks.bestOrderLoading = false;
   mocks.mediaLoading = false;
   mocks.mediaError = false;
   mocks.createObjectURL.mockReturnValue('blob:https://geo.test/social-video');
@@ -768,3 +785,75 @@ function completedDebate(id: string, claim: string, completedAt: string): Debate
     recording_cancelled_by: null,
   };
 }
+
+describe('DebatesBrowseFeed ordering', () => {
+  const older = '2026-07-01T00:00:00.000Z';
+  const newer = '2026-07-05T00:00:00.000Z';
+
+  function headings() {
+    return screen.getAllByRole('heading', { level: 2 }).map(h => h.textContent);
+  }
+
+  // What plays after the debate you opened is what the explore page's "Best" sort would have
+  // shown you, rather than simply the most recent thing in the space.
+  it('follows the Best ranking rather than recency', () => {
+    mocks.debates = [
+      completedDebate('debate-old', 'Ranked first', older),
+      completedDebate('debate-new', 'Ranked second', newer),
+    ];
+    mocks.bestOrderIds = ['debate-old', 'debate-new'];
+
+    render(<DebatesBrowseFeed spaceId="space-1" />);
+
+    expect(headings()).toEqual(['Ranked first', 'Ranked second']);
+  });
+
+  it('falls back to recency when the ranking covers nothing', () => {
+    mocks.debates = [completedDebate('debate-old', 'Older', older), completedDebate('debate-new', 'Newer', newer)];
+    mocks.bestOrderIds = [];
+
+    render(<DebatesBrowseFeed spaceId="space-1" />);
+
+    expect(headings()).toEqual(['Newer', 'Older']);
+  });
+
+  // The ranking only covers published, named debates. Anything it misses still plays — after the
+  // ranked ones, in the order the feed used before.
+  it('plays unranked debates after the ranked ones, newest first', () => {
+    mocks.debates = [
+      completedDebate('debate-unranked-old', 'Unranked older', older),
+      completedDebate('debate-ranked', 'Ranked', older),
+      completedDebate('debate-unranked-new', 'Unranked newer', newer),
+    ];
+    mocks.bestOrderIds = ['debate-ranked'];
+
+    render(<DebatesBrowseFeed spaceId="space-1" />);
+
+    expect(headings()).toEqual(['Ranked', 'Unranked newer', 'Unranked older']);
+  });
+
+  // Opening a debate still lands you on it; the ranking decides what follows, not what leads.
+  it('keeps the debate you opened first and ranks the rest behind it', () => {
+    mocks.debates = [
+      completedDebate('debate-top', 'Ranked first', older),
+      completedDebate('debate-mid', 'Ranked second', newer),
+      completedDebate('debate-anchor', 'Opened', older),
+    ];
+    mocks.bestOrderIds = ['debate-top', 'debate-mid', 'debate-anchor'];
+
+    render(<DebatesBrowseFeed spaceId="space-1" initialDebateId="debate-anchor" />);
+
+    expect(headings()).toEqual(['Opened', 'Ranked first', 'Ranked second']);
+  });
+
+  // Painting in recency order and then resequencing would move the next debate out from under
+  // someone who had already started scrolling.
+  it('waits for the ranking before drawing the feed', () => {
+    mocks.debates = [completedDebate('debate-1', 'Debates are useful', older)];
+    mocks.bestOrderLoading = true;
+
+    render(<DebatesBrowseFeed spaceId="space-1" />);
+
+    expect(screen.queryByRole('heading', { name: 'Debates are useful' })).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/core/debates/browse/debate-feed.tsx
+++ b/apps/web/core/debates/browse/debate-feed.tsx
@@ -30,6 +30,7 @@ import { DebateInteractionBar } from './debate-interaction-bar';
 import { DebateScrollHint, scrollHintBounceProps, useDebateScrollHint } from './debate-scroll-hint';
 import { JoinDebatePanel } from './join-debate-panel';
 import { useDebateShareAction } from './use-debate-share-action';
+import { useDebatesBestOrder } from './use-debates-best-order';
 import { debateFullscreenActiveAtom } from '~/atoms';
 
 const PAGE_SIZE = 5;
@@ -65,11 +66,25 @@ export function DebatesBrowseFeed({
     hasError: mediaError,
   } = useProcessedVideoDebateIds(candidateIds, candidateIds.length > 0);
 
+  // The same ranking the explore page's "Best" sort uses, so what plays after the debate you
+  // opened is what that sort would have put in front of you.
+  const { rankByDebateId, isLoading: bestOrderLoading } = useDebatesBestOrder(spaceId, candidateIds.length > 0);
+
   const debates = React.useMemo(() => {
+    // Held back the way the media lookups hold it back — by having nothing to show yet rather than
+    // by a flag, since the flag below only drives the empty and anchor states. Painting in recency
+    // order first would move the next debate out from under someone already scrolling. A ranking
+    // that fails rather than loads leaves this empty, so the feed falls through to recency.
+    if (bestOrderLoading) return [];
+
     const processed = new Set(processedIds);
+    // Recency is the tiebreak, not the rule: the ranking covers published, named debates, so
+    // anything it hasn't scored still plays — after the ranked ones, newest first, exactly as the
+    // whole feed used to be ordered.
+    const rankOf = (debate: Debate) => rankByDebateId.get(ID.uuidToHex(debate.id)) ?? Number.MAX_SAFE_INTEGER;
     const sorted = candidates
       .filter(debate => processed.has(debate.id))
-      .sort((a, b) => completedTime(b) - completedTime(a));
+      .sort((a, b) => rankOf(a) - rankOf(b) || completedTime(b) - completedTime(a));
     if (!initialDebateId) return sorted;
     // Navigating to a Debate entity lands you on that debate: hoist it to the top so it's the
     // first full-screen video, then let the rest of the space's debates scroll in below it.
@@ -77,7 +92,7 @@ export function DebatesBrowseFeed({
     if (anchorIndex <= 0) return sorted;
     const [anchor] = sorted.splice(anchorIndex, 1);
     return [anchor, ...sorted];
-  }, [candidates, processedIds, initialDebateId]);
+  }, [candidates, processedIds, initialDebateId, rankByDebateId, bestOrderLoading]);
 
   // Topics live on the claim entity (not the debates API), so resolve them once
   // for the space and map claim entity id -> topic names.
@@ -116,7 +131,9 @@ export function DebatesBrowseFeed({
 
   // The media lookups gate rendering, so the feed is still loading until they settle — otherwise it
   // flashes "no debates" and strands a valid anchor.
-  const isLoading = debatesQuery.isLoading || mediaLoading;
+  // Waiting on the ranking too, so the feed doesn't paint in recency order and then resequence
+  // itself underneath someone who has already started scrolling.
+  const isLoading = debatesQuery.isLoading || mediaLoading || bestOrderLoading;
 
   const anchorPresent = React.useMemo(
     () => initialDebateId == null || debates.some(debate => ID.equals(debate.id, initialDebateId)),

--- a/apps/web/core/debates/browse/debates-best-order-document.test.ts
+++ b/apps/web/core/debates/browse/debates-best-order-document.test.ts
@@ -1,0 +1,65 @@
+import { type DocumentNode, type FieldNode, Kind, type OperationDefinitionNode } from 'graphql';
+import { describe, expect, it } from 'vitest';
+
+import { exploreBestConnectionDocument } from '~/core/explore/explore-best-document';
+
+import { debatesBestOrderDocument } from './debates-best-order-document';
+
+function operation(doc: DocumentNode): OperationDefinitionNode {
+  const op = doc.definitions.find(d => d.kind === Kind.OPERATION_DEFINITION);
+  if (!op) throw new Error('no operation in document');
+  return op as OperationDefinitionNode;
+}
+
+function rootField(doc: DocumentNode): FieldNode {
+  const selections = operation(doc).selectionSet.selections.filter(s => s.kind === Kind.FIELD);
+  expect(selections).toHaveLength(1);
+  return selections[0] as FieldNode;
+}
+
+function argNames(field: FieldNode): string[] {
+  return (field.arguments ?? []).map(a => a.name.value).sort();
+}
+
+function nodeFieldNames(doc: DocumentNode): string[] {
+  const nodes = (rootField(doc).selectionSet?.selections ?? []).find(
+    s => s.kind === Kind.FIELD && s.name.value === 'nodes'
+  ) as FieldNode | undefined;
+  if (!nodes) throw new Error('no nodes selection');
+  return (nodes.selectionSet?.selections ?? [])
+    .filter(s => s.kind === Kind.FIELD)
+    .map(s => (s as FieldNode).name.value)
+    .sort();
+}
+
+describe('debatesBestOrderDocument', () => {
+  // The whole point is that this is the same ranking the explore page sorts by, not a lookalike.
+  it('reads the same ranked connection the explore Best sort does', () => {
+    expect(rootField(debatesBestOrderDocument).name.value).toBe(rootField(exploreBestConnectionDocument).name.value);
+    expect(rootField(debatesBestOrderDocument).name.value).toBe('entitiesRankedForFeedConnection');
+  });
+
+  it('asks for ids alone — the feed already has the debates', () => {
+    expect(nodeFieldNames(debatesBestOrderDocument)).toEqual(['id']);
+  });
+
+  it('scopes to one space and to debates', () => {
+    expect(argNames(rootField(debatesBestOrderDocument))).toEqual(expect.arrayContaining(['spaceIds', 'typeIds']));
+  });
+
+  // Same fast-path constraints the explore document documents: `filter` or `totalCount` alongside
+  // `edges` can exceed the statement timeout, and ordering is the ranking function's own.
+  it.each(['filter', 'totalCount', 'orderBy'])('does not send %s', arg => {
+    expect(argNames(rootField(debatesBestOrderDocument))).not.toContain(arg);
+    expect(nodeFieldNames(debatesBestOrderDocument)).not.toContain(arg);
+  });
+
+  // A debate feed has no time control, and windowing would strand older debates at the end.
+  it('does not window by recency', () => {
+    expect(argNames(rootField(debatesBestOrderDocument))).not.toContain('createdAfter');
+  });
+
+  it('pages, so a space larger than one page still ranks in full', () => {
+    expect(argNames(rootField(debatesBestOrderDocument))).toEqual(expect.arrayContaining(['first', 'after']));
+  });
+});

--- a/apps/web/core/debates/browse/debates-best-order-document.test.ts
+++ b/apps/web/core/debates/browse/debates-best-order-document.test.ts
@@ -21,6 +21,14 @@ function argNames(field: FieldNode): string[] {
   return (field.arguments ?? []).map(a => a.name.value).sort();
 }
 
+/** Fields selected directly on the connection — where `totalCount` would sit, beside `nodes`. */
+function connectionFieldNames(doc: DocumentNode): string[] {
+  return (rootField(doc).selectionSet?.selections ?? [])
+    .filter(s => s.kind === Kind.FIELD)
+    .map(s => (s as FieldNode).name.value)
+    .sort();
+}
+
 function nodeFieldNames(doc: DocumentNode): string[] {
   const nodes = (rootField(doc).selectionSet?.selections ?? []).find(
     s => s.kind === Kind.FIELD && s.name.value === 'nodes'
@@ -47,11 +55,18 @@ describe('debatesBestOrderDocument', () => {
     expect(argNames(rootField(debatesBestOrderDocument))).toEqual(expect.arrayContaining(['spaceIds', 'typeIds']));
   });
 
-  // Same fast-path constraints the explore document documents: `filter` or `totalCount` alongside
-  // `edges` can exceed the statement timeout, and ordering is the ranking function's own.
-  it.each(['filter', 'totalCount', 'orderBy'])('does not send %s', arg => {
+  // Same fast-path constraints the explore document spells out: ordering is the ranking function's
+  // own, and a `filter` argument is redundant with what the function already enforces.
+  it.each(['filter', 'orderBy'])('does not send %s as an argument', arg => {
     expect(argNames(rootField(debatesBestOrderDocument))).not.toContain(arg);
-    expect(nodeFieldNames(debatesBestOrderDocument)).not.toContain(arg);
+  });
+
+  // `totalCount` sits on the connection beside `nodes`, not inside a node — so it has to be
+  // checked there. Alongside `edges` it scans the candidate set twice and can exceed the
+  // statement timeout.
+  it('does not select totalCount on the connection', () => {
+    expect(connectionFieldNames(debatesBestOrderDocument)).toEqual(['nodes', 'pageInfo']);
+    expect(connectionFieldNames(debatesBestOrderDocument)).not.toContain('totalCount');
   });
 
   // A debate feed has no time control, and windowing would strand older debates at the end.

--- a/apps/web/core/debates/browse/debates-best-order-document.ts
+++ b/apps/web/core/debates/browse/debates-best-order-document.ts
@@ -1,0 +1,35 @@
+import type { TypedDocumentNode } from '@graphql-typed-document-node/core';
+
+import { parse } from 'graphql';
+
+/**
+ * The order the explore page's "Best" sort would put a space's debates in.
+ *
+ * Same source as that sort — `entities_ranked_for_feed`, ordered by the function's own
+ * `ranking_score DESC, entity_id DESC` — narrowed to Debate-typed entities in one space. It asks
+ * for ids alone: the feed already has every debate it needs from geo-chat and is only missing the
+ * order to show them in.
+ *
+ * Deliberately no `filter`, no `totalCount` and no `orderBy`, for the reasons spelled out on
+ * `exploreBestConnectionDocument` — the combination is what keeps this on the ranking index's fast
+ * path rather than a scan that can exceed the statement timeout.
+ *
+ * No `createdAfter` either. The explore feed uses it for its time filter; a debate feed has no such
+ * control, and windowing here would quietly drop older debates out of the ranking and strand them
+ * at the end of the scroll.
+ */
+const DEBATES_BEST_ORDER_SOURCE = /* GraphQL */ `
+  query DebatesBestOrder($first: Int, $after: Cursor, $spaceIds: [UUID!], $typeIds: [UUID!]) {
+    entitiesRankedForFeedConnection(first: $first, after: $after, spaceIds: $spaceIds, typeIds: $typeIds) {
+      pageInfo {
+        endCursor
+        hasNextPage
+      }
+      nodes {
+        id
+      }
+    }
+  }
+`;
+
+export const debatesBestOrderDocument = parse(DEBATES_BEST_ORDER_SOURCE) as TypedDocumentNode<any, any>;

--- a/apps/web/core/debates/browse/use-debates-best-order.test.ts
+++ b/apps/web/core/debates/browse/use-debates-best-order.test.ts
@@ -1,0 +1,89 @@
+import { Effect } from 'effect';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+type Page = { ids: string[]; endCursor: string | null; hasNextPage: boolean };
+
+const mocks = vi.hoisted(() => ({
+  pages: [] as Page[],
+  calls: [] as { after: string | null }[],
+}));
+
+vi.mock('~/core/io/graphql-client', () => ({
+  graphql: ({ decoder, variables }: { decoder: (data: unknown) => unknown; variables: { after: string | null } }) => {
+    mocks.calls.push({ after: variables.after });
+    const page = mocks.pages[mocks.calls.length - 1] ?? { ids: [], endCursor: null, hasNextPage: false };
+    return Effect.succeed(
+      decoder({
+        entitiesRankedForFeedConnection: {
+          pageInfo: { endCursor: page.endCursor, hasNextPage: page.hasNextPage },
+          nodes: page.ids.map(id => ({ id })),
+        },
+      })
+    );
+  },
+}));
+
+const { fetchDebatesBestOrder } = await import('./use-debates-best-order');
+
+beforeEach(() => {
+  mocks.pages = [];
+  mocks.calls = [];
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('fetchDebatesBestOrder', () => {
+  it('returns one page in ranked order', async () => {
+    mocks.pages = [{ ids: ['a', 'b', 'c'], endCursor: null, hasNextPage: false }];
+
+    expect(await fetchDebatesBestOrder('space-1')).toEqual(['a', 'b', 'c']);
+    expect(mocks.calls).toHaveLength(1);
+  });
+
+  // A space larger than one page ranks in full rather than ranking the first page and dropping the
+  // rest to the bottom of the scroll.
+  it('drains the connection until there is no next page', async () => {
+    mocks.pages = [
+      { ids: ['a'], endCursor: 'cursor-1', hasNextPage: true },
+      { ids: ['b'], endCursor: 'cursor-2', hasNextPage: true },
+      { ids: ['c'], endCursor: null, hasNextPage: false },
+    ];
+
+    expect(await fetchDebatesBestOrder('space-1')).toEqual(['a', 'b', 'c']);
+    expect(mocks.calls.map(call => call.after)).toEqual([null, 'cursor-1', 'cursor-2']);
+  });
+
+  // The loop is driven entirely by what the server returns, so it must not rely on the server
+  // behaving. A repeated cursor would otherwise page until the cap.
+  it('stops when the connection repeats a cursor, and says so', async () => {
+    mocks.pages = [
+      { ids: ['a'], endCursor: 'same', hasNextPage: true },
+      { ids: ['b'], endCursor: 'same', hasNextPage: true },
+      { ids: ['c'], endCursor: 'same', hasNextPage: true },
+    ];
+
+    expect(await fetchDebatesBestOrder('space-1')).toEqual(['a', 'b']);
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('repeated a cursor'), expect.anything());
+  });
+
+  it('reports reaching the page cap rather than passing off a partial ranking as whole', async () => {
+    mocks.pages = Array.from({ length: 60 }, (_, index) => ({
+      ids: [`entity-${index}`],
+      endCursor: `cursor-${index}`,
+      hasNextPage: true,
+    }));
+
+    const ids = await fetchDebatesBestOrder('space-1');
+
+    expect(ids).toHaveLength(50);
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('page cap'), expect.anything());
+  });
+
+  it('treats an empty ranking as no ranking rather than an error', async () => {
+    mocks.pages = [{ ids: [], endCursor: null, hasNextPage: false }];
+
+    expect(await fetchDebatesBestOrder('space-1')).toEqual([]);
+    expect(console.error).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/core/debates/browse/use-debates-best-order.ts
+++ b/apps/web/core/debates/browse/use-debates-best-order.ts
@@ -1,0 +1,91 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+
+import * as React from 'react';
+
+import { Effect } from 'effect';
+
+import { DEBATE_TYPE_ID } from '~/core/debates/ontology';
+import { ID } from '~/core/id';
+import { graphql } from '~/core/io/graphql-client';
+
+import { debatesBestOrderDocument } from './debates-best-order-document';
+
+/**
+ * One page is plenty for a space's debates — the busiest space on testnet has single digits — but
+ * paging exists so a space that outgrows it ranks all of its debates rather than silently ranking
+ * the first page and dropping the rest to the bottom of the scroll.
+ */
+const PAGE_SIZE = 100;
+const MAX_PAGES = 5;
+
+/** Debate entity ids in "Best" order, most deserving of attention first. */
+export async function fetchDebatesBestOrder(spaceId: string, signal?: AbortSignal): Promise<string[]> {
+  const ids: string[] = [];
+  let after: string | null = null;
+
+  for (let page = 0; page < MAX_PAGES; page++) {
+    const result: { ids: string[]; endCursor: string | null; hasNextPage: boolean } = await Effect.runPromise(
+      graphql({
+        query: debatesBestOrderDocument,
+        decoder: (data: {
+          entitiesRankedForFeedConnection?: {
+            pageInfo?: { endCursor?: string | null; hasNextPage?: boolean | null } | null;
+            nodes?: ({ id?: string | null } | null)[] | null;
+          } | null;
+        }) => {
+          const connection = data.entitiesRankedForFeedConnection;
+          return {
+            ids: (connection?.nodes ?? []).flatMap(node => (node?.id ? [node.id] : [])),
+            endCursor: connection?.pageInfo?.endCursor ?? null,
+            hasNextPage: connection?.pageInfo?.hasNextPage ?? false,
+          };
+        },
+        variables: { first: PAGE_SIZE, after, spaceIds: [spaceId], typeIds: [DEBATE_TYPE_ID] },
+        signal,
+      })
+    );
+
+    ids.push(...result.ids);
+    if (!result.hasNextPage || !result.endCursor) break;
+    after = result.endCursor;
+  }
+
+  return ids;
+}
+
+export type DebatesBestOrder = {
+  /** Entity id (normalized) -> position in the ranking. Absent means the ranking didn't cover it. */
+  rankByDebateId: Map<string, number>;
+  isLoading: boolean;
+  isError: boolean;
+};
+
+/**
+ * Ranks a space's debates the way the explore page's "Best" sort ranks everything else.
+ *
+ * Returns positions rather than a sorted list of debates: the feed already knows which debates it
+ * can play — geo-chat says which exist, and the media checks say which have finished processing —
+ * and a ranking that returned debates would be able to reintroduce ones the feed had ruled out.
+ */
+export function useDebatesBestOrder(spaceId: string, enabled: boolean): DebatesBestOrder {
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ['debates', 'best-order', spaceId],
+    queryFn: ({ signal }) => fetchDebatesBestOrder(spaceId, signal),
+    enabled: enabled && Boolean(spaceId),
+    staleTime: 60_000,
+  });
+
+  const rankByDebateId = React.useMemo(() => {
+    const map = new Map<string, number>();
+    (data ?? []).forEach((entityId, index) => {
+      // geo-chat hands the feed dashed uuids while the graph stores bare hex, so both sides are
+      // normalized before they ever meet.
+      map.set(ID.uuidToHex(entityId), index);
+    });
+    return map;
+  }, [data]);
+
+  return { rankByDebateId, isLoading, isError };
+}

--- a/apps/web/core/debates/browse/use-debates-best-order.ts
+++ b/apps/web/core/debates/browse/use-debates-best-order.ts
@@ -13,19 +13,27 @@ import { graphql } from '~/core/io/graphql-client';
 import { debatesBestOrderDocument } from './debates-best-order-document';
 
 /**
- * One page is plenty for a space's debates — the busiest space on testnet has single digits — but
- * paging exists so a space that outgrows it ranks all of its debates rather than silently ranking
- * the first page and dropping the rest to the bottom of the scroll.
+ * One page covers a space's debates today — the busiest space on testnet has single digits — but
+ * paging exists so a space that outgrows it ranks all of its debates rather than ranking the first
+ * page and dropping the rest to the bottom of the scroll.
  */
 const PAGE_SIZE = 100;
-const MAX_PAGES = 5;
+
+/**
+ * A runaway guard, not a paging policy. Reaching it means either a space with more ranked debates
+ * than anyone has built, or a connection that keeps claiming another page — so it says so rather
+ * than returning a truncated ranking as if it were the whole thing.
+ */
+const MAX_PAGES = 50;
 
 /** Debate entity ids in "Best" order, most deserving of attention first. */
 export async function fetchDebatesBestOrder(spaceId: string, signal?: AbortSignal): Promise<string[]> {
   const ids: string[] = [];
+  const seenCursors = new Set<string>();
   let after: string | null = null;
+  let page = 0;
 
-  for (let page = 0; page < MAX_PAGES; page++) {
+  for (; page < MAX_PAGES; page++) {
     const result: { ids: string[]; endCursor: string | null; hasNextPage: boolean } = await Effect.runPromise(
       graphql({
         query: debatesBestOrderDocument,
@@ -49,7 +57,24 @@ export async function fetchDebatesBestOrder(spaceId: string, signal?: AbortSigna
 
     ids.push(...result.ids);
     if (!result.hasNextPage || !result.endCursor) break;
+    // A cursor that repeats would page forever. Offset cursors make that unlikely, but the loop is
+    // driven entirely by what the server hands back, so it must not depend on the server behaving.
+    if (seenCursors.has(result.endCursor)) {
+      console.error('[useDebatesBestOrder] Ranking connection repeated a cursor; ranking may be partial', {
+        spaceId,
+        ranked: ids.length,
+      });
+      break;
+    }
+    seenCursors.add(result.endCursor);
     after = result.endCursor;
+  }
+
+  if (page === MAX_PAGES) {
+    console.error('[useDebatesBestOrder] Ranking hit the page cap; debates past it fall back to recency', {
+      spaceId,
+      ranked: ids.length,
+    });
   }
 
   return ids;
@@ -74,7 +99,17 @@ export function useDebatesBestOrder(spaceId: string, enabled: boolean): DebatesB
     queryKey: ['debates', 'best-order', spaceId],
     queryFn: ({ signal }) => fetchDebatesBestOrder(spaceId, signal),
     enabled: enabled && Boolean(spaceId),
-    staleTime: 60_000,
+    // A snapshot for as long as the feed is open, deliberately. A refetch would hand back a
+    // different order and resequence a feed someone is already scrolling — the exact movement the
+    // loading gate exists to prevent, arriving later and with no gate in front of it.
+    staleTime: Infinity,
+    refetchOnWindowFocus: false,
+    refetchOnMount: false,
+    refetchOnReconnect: false,
+    // `graphql` already retries transport failures with backoff. Retrying around it multiplies that
+    // budget and holds the feed on its loading gate, when the promise on failure is that it drops
+    // straight through to recency.
+    retry: false,
   });
 
   const rankByDebateId = React.useMemo(() => {


### PR DESCRIPTION
## How the feed was populated before

Clicking a debate in browse mode opens `DebatesBrowseFeed`, which builds its scroll from the **current space's** debates:

1. `useSpaceDebates(spaceId)` — every debate geo-chat has for the space.
2. Filtered by `isWatchableDebate` (both raw recordings exist).
3. Filtered again by `useProcessedVideoDebateIds` (the media worker actually composed a final video).
4. **Sorted `completedTime` descending** — newest-completed first.
5. If you arrived via a specific debate, that one is hoisted to the top and the rest follow.

So "what plays next" was just "whatever finished most recently", which answers a different question from "what is worth watching".

## What this changes

Step 4 now uses the same ranking the explore page's **Best** sort uses — `entities_ranked_for_feed`, ordered by its own `ranking_score DESC, entity_id DESC` — narrowed to Debate-typed entities in the space.

Verified against the API that this works for debates before building it. Debate entities are in the ranked feed with real names, and space scoping returns a complete set:

```
entitiesRankedForFeedConnection(spaceIds: [Crypto], typeIds: [Debate])
  → 7 nodes, hasNextPage: false
  → "Nate vs. Preston Mantel on Crypto's lack of regulation…"
```

Three deliberate choices:

**It asks for ids only, not debates.** The feed already knows which debates exist and which have finished processing; a ranking that returned debates could reintroduce ones the readiness checks had ruled out. `useDebatesBestOrder` returns positions and the feed applies them.

**Recency becomes the tiebreak, not the rule.** The ranking covers published, named entities. Anything it hasn't scored still plays — after the ranked ones, newest first, exactly as the whole feed was ordered before. A ranking that *fails* leaves everything unscored, which degrades to the old behaviour precisely.

**The list waits for the ranking.** Painting in recency order and resequencing a moment later would move the next debate out from under someone already scrolling. It's held back the same way the media lookups already hold it back — by having nothing to show yet. Worth a second opinion: it couples first paint to one more request, though it runs in parallel with the media checks and is an index walk. Ranking *failure* falls through immediately; only a slow-but-alive endpoint would delay things.

`createdAfter` is deliberately not sent — the explore feed uses it for its time filter, but a debate feed has no such control and windowing would strand older debates at the end of the scroll.

## Testing

13 new tests:
- `debates-best-order-document.test.ts` — asserts it reads the *same* connection the explore Best document does, requests ids alone, scopes by space and type, pages, and omits `filter` / `totalCount` / `orderBy` (the combination that blows the statement timeout, per the explore document's own notes).
- `debate-feed.test.tsx` — ranking beats recency, unranked debates fall in behind newest-first, the opened debate stays first, and the feed waits for the ranking.

Verified non-vacuous by reverting the sort. Full suite green at 269 files / 2751 tests; typecheck, lint and build pass.

Not verified in a browser — the ordering is asserted through the feed's rendered headings rather than by scrolling a real space.