### PR TITLE
perf(explore): walk the featured-space tree once, not once per request

### DIFF
--- a/apps/web/app/explore/page.tsx
+++ b/apps/web/app/explore/page.tsx
@@ -6,7 +6,7 @@ import { resolveMemberSpaceFromWalletSafe } from '~/core/browse/resolve-member-s
 import { type ExploreCall, fetchCommunityCallsForExplore } from '~/core/community-calls/fetch-community-calls';
 import { WALLET_ADDRESS } from '~/core/cookie';
 import { type FeaturedRanking, fetchFeaturedRankings } from '~/core/io/subgraph/fetch-featured-rankings';
-import { type FeaturedSpace, fetchFeaturedSpaces } from '~/core/io/subgraph/fetch-featured-spaces';
+import { type FeaturedSpace, fetchFeaturedSpacesShared } from '~/core/io/subgraph/fetch-featured-spaces';
 import { fetchActiveMemberRequest } from '~/core/io/subgraph/fetch-proposed-members';
 import { mapWithConcurrency } from '~/core/utils/map-with-concurrency';
 import { normId } from '~/core/utils/norm-id';
@@ -27,7 +27,7 @@ export default async function ExploreRoutePage() {
 
   // Fire every fetch in parallel. Each branch handles its own failure so one
   // degraded indexer call doesn't drop the whole page.
-  const featuredSpacesPromise = fetchFeaturedSpaces().catch(() => [] as FeaturedSpace[]);
+  const featuredSpacesPromise = fetchFeaturedSpacesShared().catch(() => [] as FeaturedSpace[]);
   // Reuse the same in-flight Root-topic traversal for the Browse Featured-spaces
   // section and the Explore Join-spaces panel.
   const browsePromise = fetchBrowseSidebarData(memberSpaceId, featuredSpacesPromise).catch(() =>

--- a/apps/web/core/browse/fetch-browse-sidebar-data.test.ts
+++ b/apps/web/core/browse/fetch-browse-sidebar-data.test.ts
@@ -25,8 +25,12 @@ vi.mock('~/core/io/subgraph/fetch-editor-space-ids', () => ({
   fetchEditorSpaceIds: (...args: unknown[]) => mocks.fetchEditorSpaceIds(...args),
 }));
 
+// The sidebar reads the traversal through its shared wrapper, so that is what has to be
+// stubbed. The mock keeps the `fetchFeaturedSpaces` name for the spy because these suites
+// assert on what the sidebar does with the traversal's answer, not on how it is shared —
+// `fetch-featured-spaces.test.ts` owns the sharing.
 vi.mock('~/core/io/subgraph/fetch-featured-spaces', () => ({
-  fetchFeaturedSpaces: (...args: unknown[]) => mocks.fetchFeaturedSpaces(...args),
+  fetchFeaturedSpacesShared: (...args: unknown[]) => mocks.fetchFeaturedSpaces(...args),
 }));
 
 vi.mock('~/core/io/subgraph/fetch-pending-membership-space-ids', () => ({

--- a/apps/web/core/browse/fetch-browse-sidebar-data.ts
+++ b/apps/web/core/browse/fetch-browse-sidebar-data.ts
@@ -6,7 +6,7 @@ import type { Space } from '~/core/io/dto/spaces';
 import { getSpaces, getSpacesWhereMember } from '~/core/io/queries';
 import { AbortError } from '~/core/io/subgraph/errors';
 import { fetchEditorSpaceIds } from '~/core/io/subgraph/fetch-editor-space-ids';
-import { type FeaturedSpace, fetchFeaturedSpaces } from '~/core/io/subgraph/fetch-featured-spaces';
+import { type FeaturedSpace, fetchFeaturedSpacesShared } from '~/core/io/subgraph/fetch-featured-spaces';
 import {
   fetchPendingEditorshipSpaceIds,
   fetchPendingMembershipSpaceIds,
@@ -172,7 +172,7 @@ type BrowseSidebarSources = {
 type FeaturedSpacesSource = FeaturedSpace[] | PromiseLike<FeaturedSpace[]>;
 
 function resolveFeaturedSpaces(source?: FeaturedSpacesSource): Promise<FeaturedSpace[]> {
-  const promise = source ? Promise.resolve(source) : fetchFeaturedSpaces();
+  const promise = source ? Promise.resolve(source) : fetchFeaturedSpacesShared();
   return promise.catch(error => {
     // Cancellation must keep propagating so query consumers do not replace a
     // cancelled request with a successful-but-empty sidebar response.

--- a/apps/web/core/io/subgraph/fetch-featured-spaces.test.ts
+++ b/apps/web/core/io/subgraph/fetch-featured-spaces.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { FEATURED_TAG_ID, ROOT_SPACE, TAG_PROPERTY_ID } from '~/core/constants';
 
-import { fetchFeaturedSpaces } from './fetch-featured-spaces';
+import { clearFeaturedSpacesCache, fetchFeaturedSpaces, fetchFeaturedSpacesShared } from './fetch-featured-spaces';
 
 const graphqlMock = vi.fn();
 
@@ -233,5 +233,98 @@ describe('fetchFeaturedSpaces', () => {
   it('returns [] when the root space has no topic', async () => {
     graphqlMock.mockImplementation(() => Effect.succeed({ space: { topicId: null } }));
     expect(await fetchFeaturedSpaces()).toEqual([]);
+  });
+});
+
+/**
+ * The traversal is the most expensive thing on the Explore path — five sequential round
+ * trips over ~2,900 topic nodes in production — and `/api/explore/feed` ran it per
+ * request. These cover the sharing, not the traversal, which the suite above owns.
+ */
+describe('fetchFeaturedSpacesShared', () => {
+  const AI_ONLY = () => {
+    graphqlMock.mockImplementation((arg: unknown) => {
+      const q = query(arg);
+      if (q.includes('space(id:')) return Effect.succeed({ space: { topicId: 't0' } });
+      return Effect.succeed({
+        entities: [
+          {
+            id: 't0',
+            name: 'Root',
+            spacesByTopicIdConnection: { totalCount: 0, nodes: [] },
+            featuredTags: featuredTags(false),
+            subtopics: [{ toEntity: { id: 't1' } }],
+          },
+          {
+            id: 't1',
+            name: 'AI',
+            spacesByTopicIdConnection: { totalCount: 1, nodes: [spaceNode(AI_SPACE, 'AI')] },
+            featuredTags: featuredTags(),
+            subtopics: [],
+          },
+        ],
+      });
+    });
+  };
+
+  beforeEach(() => {
+    graphqlMock.mockReset();
+    clearFeaturedSpacesCache();
+    vi.useRealTimers();
+  });
+
+  it('walks the tree once and reuses the answer', async () => {
+    AI_ONLY();
+
+    const first = await fetchFeaturedSpacesShared();
+    const callsAfterFirst = graphqlMock.mock.calls.length;
+    const second = await fetchFeaturedSpacesShared();
+
+    expect(first.map(f => f.spaceId)).toEqual([AI_SPACE]);
+    expect(second).toEqual(first);
+    expect(graphqlMock.mock.calls.length).toBe(callsAfterFirst);
+  });
+
+  // The one that matters in production: `/api/explore/feed` cannot hand its promise to the
+  // next request the way `app/explore/page.tsx` hands one to the sidebar, so simultaneous
+  // Explore loads were each walking the whole topic tree. Callers arriving *before* the
+  // first traversal resolves must join it, not start their own.
+  it('makes concurrent callers join the traversal already running', async () => {
+    AI_ONLY();
+
+    const [a, b, c] = await Promise.all([
+      fetchFeaturedSpacesShared(),
+      fetchFeaturedSpacesShared(),
+      fetchFeaturedSpacesShared(),
+    ]);
+    const rootQueries = graphqlMock.mock.calls.filter(call => query(call[0]).includes('space(id:')).length;
+
+    expect(rootQueries).toBe(1);
+    expect(a).toEqual(b);
+    expect(b).toEqual(c);
+  });
+
+  it('walks again once the list has gone stale', async () => {
+    AI_ONLY();
+
+    await fetchFeaturedSpacesShared();
+    const callsAfterFirst = graphqlMock.mock.calls.length;
+    vi.useFakeTimers();
+    vi.advanceTimersByTime(5 * 60 * 1000);
+    await fetchFeaturedSpacesShared();
+
+    expect(graphqlMock.mock.calls.length).toBeGreaterThan(callsAfterFirst);
+  });
+
+  // A transient GraphQL failure must cost one traversal, not five minutes of an empty
+  // Featured panel. `runQuery` re-throws cancellation on purpose, so the same applies to an
+  // aborted caller: it must not leave its rejection behind for everyone else.
+  it('does not keep a rejection', async () => {
+    graphqlMock.mockImplementation(() => Effect.fail({ _tag: 'AbortError' }));
+
+    await expect(fetchFeaturedSpacesShared()).rejects.toBeDefined();
+
+    AI_ONLY();
+    await expect(fetchFeaturedSpacesShared()).resolves.toEqual([expect.objectContaining({ spaceId: AI_SPACE })]);
   });
 });

--- a/apps/web/core/io/subgraph/fetch-featured-spaces.ts
+++ b/apps/web/core/io/subgraph/fetch-featured-spaces.ts
@@ -147,6 +147,66 @@ async function runQuery<T>(query: string): Promise<T | null> {
 }
 
 /**
+ * How long a resolved Featured list is reused. The set is curated — an editor tags a
+ * topic Featured in the Root space — so it changes on human timescales, while the
+ * traversal that discovers it is the most expensive thing on the Explore path.
+ *
+ * The cost is a real measurement, not a guess: against production the traversal is five
+ * *sequential* round trips that visit 2,941 topic nodes and transfer 274 KB to discover
+ * four featured spaces, and `/api/explore/feed` — which runs it on every request — takes
+ * 4.2-4.5 s end to end while the ranked feed query it exists to serve is ~300 ms of that.
+ */
+const FEATURED_SPACES_TTL_MS = 5 * 60 * 1000;
+
+let shared: Promise<FeaturedSpace[]> | null = null;
+// `null` means "still in flight". Kept distinct from a timestamp of 0 on purpose: while the
+// traversal is unresolved there is nothing to expire, and treating it as infinitely stale
+// sends every concurrent caller off to start a traversal of its own — which is the exact
+// pile-up this function exists to stop.
+let resolvedAt: number | null = null;
+
+/** Exported for tests; no caller should need to reach for this. */
+export function clearFeaturedSpacesCache(): void {
+  shared = null;
+  resolvedAt = null;
+}
+
+/**
+ * {@link fetchFeaturedSpaces} with the traversal shared rather than repeated.
+ *
+ * Two distinct wins, and the second is the one that showed up in production. Within the
+ * TTL a resolved list is reused outright; *before* it resolves, concurrent callers join
+ * the one in-flight traversal instead of each starting their own. `/api/explore/feed`
+ * runs per request with no way to share a promise the way `app/explore/page.tsx` does
+ * with the sidebar, so every simultaneous Explore load was walking the whole topic tree
+ * on its own.
+ *
+ * A rejection is never cached, so a transient GraphQL failure costs one traversal rather
+ * than five minutes of empty Featured panels. That includes the cancellation
+ * `resolveFeaturedSpaces` deliberately re-throws: an aborted caller must not leave an
+ * aborted promise behind for everyone else. Nothing here is per-request, so no signal is
+ * threaded through and one caller going away cannot cancel the traversal for the rest.
+ */
+export function fetchFeaturedSpacesShared(): Promise<FeaturedSpace[]> {
+  if (shared && (resolvedAt === null || Date.now() - resolvedAt < FEATURED_SPACES_TTL_MS)) return shared;
+
+  const started = fetchFeaturedSpaces();
+  shared = started;
+  resolvedAt = null;
+  // Only start the clock once the answer exists. Timing from the *call* would let a slow
+  // traversal burn its own TTL and expire the moment it landed.
+  started.then(
+    () => {
+      if (shared === started) resolvedAt = Date.now();
+    },
+    () => {
+      if (shared === started) clearFeaturedSpacesCache();
+    }
+  );
+  return started;
+}
+
+/**
  * Builds the explore panel's "Join spaces" list by walking the Root space's
  * subtopic tree top-down and emitting one entry per topic tagged Featured in
  * the Root space that has a claiming space. The Root topic itself is used only


### PR DESCRIPTION
Preston: *"the explore page feed loads really slow."* He's right, and it isn't the feed.

## Measurement

`/api/explore/feed` against production, warm, repeated:

```
explore feed endpoint: total=4.472s
explore feed endpoint: total=4.236s
explore feed endpoint: total=4.234s
```

Split into its pieces (each timed against the prod API, interleaved and repeated so cold-cache effects don't masquerade as structural cost):

| piece | round trips | cost |
|---|---|---|
| `fetchFeaturedSpaces` topic-tree traversal | **5, sequential** | 2,941 nodes visited, **274 KB**, to find **4 featured spaces** |
| the ranked feed query (`first=30`, full card selection) | 1 | median 567 ms wall, ~**290 ms** server work |

The query the endpoint exists to serve is the cheap part. The traversal runs first, on every request, and blocks it.

Two things I initially got wrong and only caught by repeating the measurement:

- I suspected `backlinks { totalCount }` per card was the problem — a single sample read 2,038 ms. Interleaved repeats put it at ~140 ms; the 2 s was a cold cache. Not a problem.
- The traversal's *first* run reads 5.5 s; warm it's 1.6–2.2 s. Still the dominant term, but I'd have overstated it 3×.

## The fix

`fetchFeaturedSpacesShared` — reuse a resolved list for 5 minutes, and make callers arriving *before* it resolves join the traversal already running.

That second half is the one that bites in production. `app/explore/page.tsx` can hand its in-flight promise to the sidebar (there's an existing `featuredSpacesSource` parameter for exactly that), but the API route has no equivalent, so every simultaneous Explore load walked the whole topic tree on its own.

A rejection is never cached: a transient GraphQL failure costs one traversal, not five minutes of an empty Featured panel. That includes the cancellation `resolveFeaturedSpaces` deliberately re-throws — an aborted caller must not leave its rejection behind for everyone else. Nothing here is per-request, so no signal is threaded through and one caller going away can't cancel the traversal for the rest.

## Verification

- `core/io/subgraph` + `core/browse` + `core/explore`: 73 tests pass. Full `apps/web` suite has 1 unrelated pre-existing failure family and `tsc` reports 1 pre-existing error (`use-entity-vote.ts`), both on clean `master` too.
- **Mutation-tested, four ways:**
  | mutation | killed by |
  |---|---|
  | `resolvedAt` starts at 0 with no in-flight state | `makes concurrent callers join the traversal already running` |
  | never expires | `walks again once the list has gone stale` |
  | caches a rejection | `does not keep a rejection` |
  | no sharing at all | `walks the tree once and reuses the answer` |

  The first mutation is not hypothetical — it's the bug I actually wrote, spotted before testing, and then confirmed the concurrency test catches. Without distinguishing "in flight" from "resolved", concurrent callers each start their own traversal and the main win evaporates silently.

- The browse-sidebar suite mocked `fetchFeaturedSpaces`; updated to mock the wrapper the sidebar now calls. Those suites assert what the sidebar does with the answer, not how it's shared, so the spy keeps its name.

## Scope, and what this deliberately does not do

**Per-instance.** The cache is module state, so it fixes the warm path, not a cold start. A cross-instance cache would remove the first traversal too.

**The traversal is untouched.** A single direct query on the Featured tag relation returns the same four spaces in **1 round trip and 3.7 KB** — verified against production. I didn't make that change here, for two reasons:

1. It drops the tree-reachability requirement, and three tests encode that on purpose, including *"skips untagged topics but still traverses them to find featured descendants"*. Which spaces are featured is a curated product surface.
2. `MAX_NODES = 2500` is **already binding** at 2,941 visited nodes — so today's featured set is whatever the truncated walk happened to reach, and a deep featured topic can be silently dropped. The direct query is arguably a correctness fix as well as a 5×-fewer-round-trips one.

Worth a decision from whoever owns curation rather than a drive-by.

**Logged-in users have it worse.** From the route source, not measured: a signed-in request adds three more serial round trips before the feed (`resolveMemberSpaceFromWalletSafe` → `getGovernanceHomeSpaceContext` → the member variant of the sidebar), plus `fetchProfile` and one membership check per space after it. My 4.2 s was logged out. Separate PR.