### PR TITLE
feat(governance): show which path a proposal is being reviewed under

### DIFF
--- a/apps/web/core/io/dto/proposals.ts
+++ b/apps/web/core/io/dto/proposals.ts
@@ -1,4 +1,5 @@
 import { PLACEHOLDER_SPACE_IMAGE } from '~/core/constants';
+import type { ProposalVotingMode } from '~/core/hooks/use-publish';
 import { OmitStrict, Profile } from '~/core/types';
 import { Entities } from '~/core/utils/entity';
 
@@ -60,6 +61,10 @@ export type Proposal = {
   endTime: number;
   status: ProposalStatus;
   canExecute: boolean;
+  /** Which governance path the author chose when they submitted. Optional because only
+   *  the REST proposal endpoint reports it — the GraphQL sources behind the list views
+   *  have it on `ProposalVersion` rather than `Proposal`, and don't select it. */
+  votingMode?: ProposalVotingMode;
   proposalVotes: {
     totalCount: number;
     nodes: VoteWithProfile[];

--- a/apps/web/core/io/subgraph/fetch-completed-proposals.ts
+++ b/apps/web/core/io/subgraph/fetch-completed-proposals.ts
@@ -40,6 +40,7 @@ function apiProposalToDto(proposal: ApiProposalListItem, profile?: Profile): Pro
     endTime: proposal.timing.endTime,
     status: mapProposalStatus(proposal.status),
     canExecute: getApiProposalCanExecute(proposal),
+    votingMode: proposal.votingMode,
     space: {
       id: proposal.spaceId,
       name: null,

--- a/apps/web/core/io/subgraph/fetch-proposal-voting-mode.test.ts
+++ b/apps/web/core/io/subgraph/fetch-proposal-voting-mode.test.ts
@@ -1,0 +1,59 @@
+import { Effect } from 'effect';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { fetchProposal } from './fetch-proposal';
+
+const restFetchMock = vi.fn();
+
+vi.mock('~/core/environment', () => ({
+  Environment: {
+    getConfig: () => ({ api: 'https://example.com/graphql', bundler: '', chainId: '19411', rpc: '' }),
+  },
+}));
+
+vi.mock('../rest', async () => {
+  const actual = await vi.importActual<typeof import('../rest')>('../rest');
+  return { ...actual, restFetch: (...args: unknown[]) => restFetchMock(...args) };
+});
+
+vi.mock('./fetch-profile', () => ({
+  defaultProfile: (id: string) => ({ id, address: id, name: null, avatarUrl: null, profileLink: null }),
+  fetchProfileBySpaceId: () => Effect.succeed(null),
+  fetchProfilesBySpaceIds: () => Effect.succeed([]),
+}));
+
+/** A proposal payload with only the fields the mapping under test reads. */
+function apiProposal(votingMode: 'FAST' | 'SLOW') {
+  return {
+    proposalId: 'proposal-1',
+    proposalVersion: 2,
+    spaceId: 'space-1',
+    name: 'Add a claim',
+    proposedBy: 'author-space-1',
+    status: 'PROPOSED',
+    votingMode,
+    actions: [],
+    userVote: null,
+    canExecute: false,
+    quorum: { required: 2, current: 0, progress: 0, reached: false },
+    threshold: { required: '51', current: 0, progress: 0, reached: false },
+    timing: { startTime: 1, endTime: 2, timeRemaining: null, isVotingEnded: false },
+    votes: { yes: 0, no: 0, abstain: 0, total: 0, voters: [] },
+  };
+}
+
+beforeEach(() => {
+  restFetchMock.mockReset();
+});
+
+describe('fetchProposal voting mode', () => {
+  // A reviewer is shown this to decide how much weight their vote carries, so it has to be
+  // the path the author actually submitted under rather than a default.
+  it.each(['FAST', 'SLOW'] as const)('carries the %s path through to the proposal', async votingMode => {
+    restFetchMock.mockReturnValue(Effect.succeed(apiProposal(votingMode)));
+
+    const proposal = await fetchProposal({ id: 'proposal-1' });
+
+    expect(proposal?.votingMode).toBe(votingMode);
+  });
+});

--- a/apps/web/core/io/subgraph/fetch-proposal.ts
+++ b/apps/web/core/io/subgraph/fetch-proposal.ts
@@ -119,6 +119,7 @@ export async function fetchProposal(options: FetchProposalOptions): Promise<Prop
     endTime: apiProposal.timing.endTime,
     status: mapProposalStatus(apiProposal.status),
     canExecute: getApiProposalCanExecute(apiProposal),
+    votingMode: apiProposal.votingMode,
     space: {
       id: apiProposal.spaceId,
       name: null,

--- a/apps/web/core/io/subgraph/fetch-proposals.ts
+++ b/apps/web/core/io/subgraph/fetch-proposals.ts
@@ -44,6 +44,7 @@ function apiProposalToDto(proposal: ApiProposalListItem, profile?: Profile): Pro
     endTime: proposal.timing.endTime,
     status: mapProposalStatus(proposal.status),
     canExecute: getApiProposalCanExecute(proposal),
+    votingMode: proposal.votingMode,
     space: {
       id: proposal.spaceId,
       name: null,

--- a/apps/web/partials/active-proposal/active-proposal.tsx
+++ b/apps/web/partials/active-proposal/active-proposal.tsx
@@ -16,6 +16,7 @@ import { Avatar } from '~/design-system/avatar';
 import { PrefetchLink as Link } from '~/design-system/prefetch-link';
 
 import { GovernanceOutcomeDate, GovernanceOutcomeTime } from '~/partials/governance/governance-outcome-timestamp';
+import { ProposalPathLabel } from '~/partials/governance/proposal-path-label';
 
 import { AcceptOrReject } from './accept-or-reject';
 import { MetadataMotionContainer } from './active-proposal-metadata-motion-container';
@@ -156,12 +157,20 @@ async function ReviewProposal({ proposalId, spaceId }: Props) {
                             />
                           </>
                         )}
+                        {proposal.votingMode && (
+                          <>
+                            <span aria-hidden className="shrink-0 text-grey-04 select-none">
+                              ·
+                            </span>
+                            <span className="inline-flex shrink-0 items-center gap-1.5 text-grey-04">
+                              <ProposalPathLabel votingMode={proposal.votingMode} />
+                            </span>
+                          </>
+                        )}
                         <span aria-hidden className="shrink-0 text-grey-04 select-none">
                           ·
                         </span>
-                        <span className="text-text">
-                          {proposalStatusLabel}
-                        </span>
+                        <span className="text-text">{proposalStatusLabel}</span>
                       </div>
                     </div>
                   </div>

--- a/apps/web/partials/governance/proposal-path-label.tsx
+++ b/apps/web/partials/governance/proposal-path-label.tsx
@@ -1,0 +1,24 @@
+import type { ProposalVotingMode } from '~/core/hooks/use-publish';
+
+import { FastPath } from '~/design-system/icons/fast-path';
+import { Time } from '~/design-system/icons/time';
+
+/**
+ * How a governance path is named and iconed, in one place.
+ *
+ * The author picks the path in `ProposalPathSelector` and a reviewer reads it back on the
+ * proposal, so the two have to agree: a proposal submitted under "Fast path" that reviews
+ * as something else is worse than not showing it at all. Both render this.
+ */
+export function proposalPathName(votingMode: ProposalVotingMode): string {
+  return votingMode === 'FAST' ? 'Fast path' : 'Review path';
+}
+
+export function ProposalPathLabel({ votingMode }: { votingMode: ProposalVotingMode }) {
+  return (
+    <>
+      {votingMode === 'FAST' ? <FastPath /> : <Time />}
+      {proposalPathName(votingMode)}
+    </>
+  );
+}

--- a/apps/web/partials/governance/proposal-path-selector.tsx
+++ b/apps/web/partials/governance/proposal-path-selector.tsx
@@ -8,6 +8,7 @@ import { Dropdown } from '~/design-system/dropdown';
 import { FastPath } from '~/design-system/icons/fast-path';
 import { Time } from '~/design-system/icons/time';
 
+import { ProposalPathLabel, proposalPathName } from './proposal-path-label';
 import type { VotingSettingsSnapshot } from './voting-settings';
 
 type Props = {
@@ -45,7 +46,7 @@ export function ProposalPathSelector({ votingMode, onChange, votingSettings, isF
       label: (
         <OptionLabel
           icon={<FastPath />}
-          title="Fast path"
+          title={proposalPathName('FAST')}
           description={
             isFastPathRestricted
               ? 'Not available to you yet — this space restricts the fast path for new members'
@@ -61,7 +62,7 @@ export function ProposalPathSelector({ votingMode, onChange, votingSettings, isF
       label: (
         <OptionLabel
           icon={<Time />}
-          title="Review path"
+          title={proposalPathName('SLOW')}
           description={`Goes to a review over ${durationHours} hour${durationHours === 1 ? '' : 's'} and requires a ${passPercent}% pass rate`}
         />
       ),
@@ -73,8 +74,7 @@ export function ProposalPathSelector({ votingMode, onChange, votingSettings, isF
       align="end"
       trigger={
         <span className="flex items-center gap-1.5">
-          {votingMode === 'FAST' ? <FastPath /> : <Time />}
-          {votingMode === 'FAST' ? 'Fast path' : 'Review path'}
+          <ProposalPathLabel votingMode={votingMode} />
         </span>
       }
       options={options}


### PR DESCRIPTION
On the review screen where an editor votes to accept or reject, the proposal now shows whether it is on the **Fast path** or the **Review path**.

## Why it matters

The path is not decoration — it decides what the reviewer's vote *does*. On the fast path, one editor approving executes the proposal outright. On the review path it is one vote in a timed count with a pass threshold. The reviewer was being asked to make that call without being told which one they were in.

## What it took

Almost nothing, as it turns out. The REST proposal endpoint already reports `votingMode`, and this screen already decodes it — `getApiProposalCanExecute` reads it to decide whether to offer the execute button. It simply wasn't carried past the mapper.

So: one line in `fetchProposal`, one optional field on the DTO, and the label in the byline beside the status it explains.

## Decisions worth a look

**Optional on the DTO, and why it has to be.** `votingMode` lives on `ProposalVersion` in GraphQL, not `Proposal` — I introspected the live schema to check. The GraphQL-backed list views select `Proposal`, so they genuinely cannot supply it. The screen renders nothing when it's absent rather than defaulting: showing the *wrong* path is worse than showing none.

**Carried in the list and completed-proposal mappers too**, though nothing renders it there yet. They decode the same payload into the same `Proposal` type, and a field that's populated from one of three sources is a trap for whoever reads that type next. Happy to drop those two lines if you'd rather keep the diff to the review screen.

**The name and icon now live in one place** (`ProposalPathLabel`), shared with the selector the author submits through. These two have to agree — a proposal submitted under "Fast path" that reviews as something else would be a worse bug than the missing label was.

**Placement**: in the byline metadata row (`author · [date · time] · Fast path · status`), using the same icon and wording as the submit dropdown so it reads as the same concept. Easy to move if you'd rather it sat with the vote controls in the header.

## Testing

New `fetch-proposal-voting-mode.test.ts` covers both paths surviving the mapping. I checked it fails without the change rather than trusting it passes with it.

Worth noting: my first version of that test passed a fixture that didn't satisfy the response schema, so decoding failed and `fetchProposal` returned `null` — which surfaced as the same `undefined` a missing mapping would. Fixing the fixture is what made the test actually exercise the path.

- `bun run build` passes.
- Full `vitest run`: 22 failed files / 39 failed tests, identical to the `origin/master` baseline (pre-existing jsdom `localStorage` collection errors), plus the 2 new passes.

## Not covered

I haven't seen this rendered in a running app — it needs an editor account with a live proposal in a DAO space. The data path is tested and the markup mirrors the existing byline items, but the visual placement is worth a glance before this leaves draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)