### PR TITLE
Adopt #2178's return-navigation over my narrower #2186/#2187

### DIFF
--- a/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
@@ -1398,7 +1398,8 @@ describe('DebateRoomPageClient', () => {
       await screen.findByRole('heading', { name: 'This debate is already open in another tab.' })
     ).toBeInTheDocument();
     expect(screen.getByText('Close this tab and continue your debate in the original tab.')).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Go to debates' })).toHaveAttribute('href', '/space/space-1/debates');
+    fireEvent.click(screen.getByRole('button', { name: 'Go back' }));
+    expect(mocks.replace).toHaveBeenCalledWith('/space/space-1/debates');
     expect(screen.queryByRole('button', { name: 'Continue here' })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Back to debates' })).not.toBeInTheDocument();
     expect(screen.queryByText('Debate room')).not.toBeInTheDocument();
@@ -1406,6 +1407,23 @@ describe('DebateRoomPageClient', () => {
     expect(screen.queryByText('Waiting for both speakers to join.')).not.toBeInTheDocument();
     expect(mocks.liveKitJoinMutateAsync).not.toHaveBeenCalled();
     expect(mocks.roomConnect).not.toHaveBeenCalled();
+  });
+
+  it('returns a secondary tab ownership conflict to the page that opened the room', async () => {
+    rememberDebateReturnDestination('/space/root-space?tab=activity');
+    mocks.ownershipAcquire.mockResolvedValue({ acquired: false, waitedForLocalRelease: false });
+    mocks.debate = {
+      ...completedDebate(),
+      status: 'in_progress',
+      completed_at: null,
+    };
+
+    render(<DebateRoomPageClient spaceId="opponent-space" debateId="debate-1" />);
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Go back' }));
+
+    expect(mocks.replace).toHaveBeenCalledWith('/space/root-space?tab=activity');
+    expect(mocks.back).not.toHaveBeenCalled();
   });
 
   it('does not hand off a stale preflight after the first turn has started locally', async () => {

--- a/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
@@ -6,7 +6,6 @@ import { type ComponentPropsWithoutRef, StrictMode } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { Debate, DebateRematchSession } from '~/core/debates/api';
-import { recordDebateFlowOrigin } from '~/core/debates/debate-entry-intent';
 import type { DebateRoomTakeoverContext } from '~/core/debates/debate-room-ownership';
 import { ExtendedReconnectPolicy } from '~/core/livekit/extended-reconnect-policy';
 
@@ -253,7 +252,6 @@ class FakeBroadcastChannel {
 
 beforeEach(() => {
   setHistoryLength(1);
-  window.sessionStorage.clear();
   mocks.back.mockReset();
   mocks.push.mockReset();
   mocks.replace.mockReset();
@@ -440,19 +438,6 @@ describe('DebateRoomPageClient', () => {
     expect(mocks.back).toHaveBeenCalledOnce();
     expect(mocks.replace).not.toHaveBeenCalled();
     expect(mocks.enqueueRecording).not.toHaveBeenCalled();
-  });
-
-  // GEO-2605. history.length says only how deep we are, not where the flow began: hub -> room ->
-  // rematch -> room leaves another room one entry back, so back() returns into the flow. The path
-  // recorded on entry is the only thing that knows where the viewer actually came from.
-  it('returns to the path the flow started from rather than one history entry back', async () => {
-    setHistoryLength(4);
-    recordDebateFlowOrigin('/space/space-1/entity-7');
-
-    render(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
-
-    await waitFor(() => expect(mocks.replace).toHaveBeenCalledWith('/space/space-1/entity-7'));
-    expect(mocks.back).not.toHaveBeenCalled();
   });
 
   it('falls back to the debates page when a cancelled room has no prior history', async () => {

--- a/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
@@ -6,6 +6,7 @@ import { type ComponentPropsWithoutRef, StrictMode } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { Debate, DebateRematchSession } from '~/core/debates/api';
+import { clearDebateReturnDestination, rememberDebateReturnDestination } from '~/core/debates/debate-return-navigation';
 import { ExtendedReconnectPolicy } from '~/core/livekit/extended-reconnect-policy';
 
 import { DebateRoomPageClient, isDebateInThankYouPeriod } from './debate-room-page-client';
@@ -250,6 +251,7 @@ class FakeBroadcastChannel {
 }
 
 beforeEach(() => {
+  clearDebateReturnDestination();
   setHistoryLength(1);
   mocks.back.mockReset();
   mocks.push.mockReset();
@@ -385,6 +387,7 @@ beforeEach(() => {
 
 afterEach(async () => {
   cleanup();
+  clearDebateReturnDestination();
   await Promise.resolve();
   await Promise.resolve();
   vi.useRealTimers();
@@ -451,8 +454,9 @@ describe('DebateRoomPageClient', () => {
   // Forward, never back: the entry behind this room is often this same room (hub → room → rematch
   // → room), and stepping back into a debate that ended under us re-runs the exit from a fresh
   // mount. That was the flicker, and on the opponent's side it took a second Okay to escape.
-  it('sends a recording canceller forward to the debates page instead of back into the room', async () => {
+  it('returns a recording canceller to the page that opened the flow', async () => {
     setHistoryLength(2);
+    rememberDebateReturnDestination('/space/my-space?tab=activity');
     mocks.debate = {
       ...completedDebate(),
       recording_cancelled_at: '2026-07-02T00:01:20.000Z',
@@ -463,7 +467,7 @@ describe('DebateRoomPageClient', () => {
     render(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
 
     expect(screen.queryByText('Debate complete.')).not.toBeInTheDocument();
-    await waitFor(() => expect(mocks.replace).toHaveBeenCalledWith('/space/space-1/debates'));
+    await waitFor(() => expect(mocks.replace).toHaveBeenCalledWith('/space/my-space?tab=activity'));
     expect(mocks.back).not.toHaveBeenCalled();
     expect(mocks.clearDebateActivity).toHaveBeenCalledWith('debate-1');
   });
@@ -2286,6 +2290,7 @@ describe('DebateRoomPageClient', () => {
 
   it('stops media at the deadline and returns to matching after backend cancellation', async () => {
     vi.useFakeTimers();
+    rememberDebateReturnDestination('/space/my-space/claims#recent');
     const connectingDebate: Debate = {
       ...completedDebate(),
       status: 'connecting',
@@ -2311,7 +2316,7 @@ describe('DebateRoomPageClient', () => {
     expect(mocks.clearTimedOutDebateActivity).toHaveBeenCalledWith('debate-1');
     expect(mocks.replace).not.toHaveBeenCalled();
     act(() => vi.advanceTimersByTime(750));
-    expect(mocks.replace).toHaveBeenCalledWith('/space/space-1/questions');
+    expect(mocks.replace).toHaveBeenCalledWith('/space/my-space/claims#recent');
   });
 
   it('keeps the room connected when preflight won the deadline race', async () => {

--- a/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.tsx
@@ -1,11 +1,11 @@
 'use client';
 
 import type { KrispNoiseFilterProcessor } from '@livekit/krisp-noise-filter';
-import type { RoomConnectOptions, RoomOptions } from 'livekit-client';
 
 import * as React from 'react';
 
 import cx from 'classnames';
+import type { RoomConnectOptions, RoomOptions } from 'livekit-client';
 import { useRouter } from 'next/navigation';
 
 import { capture } from '~/core/analytics';
@@ -18,6 +18,7 @@ import {
   getServerTime,
 } from '~/core/debates/api';
 import { DebatePreScreen } from '~/core/debates/debate-pre-join-screen';
+import { consumeDebateReturnDestination } from '~/core/debates/debate-return-navigation';
 import {
   CameraIcon,
   LeaveIcon,
@@ -426,6 +427,11 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
       if (debateExitStartedRef.current) return;
       debateExitStartedRef.current = true;
       clearDebateActivity(debateId);
+      const returnDestination = consumeDebateReturnDestination();
+      if (returnDestination) {
+        router.replace(returnDestination);
+        return;
+      }
       // Going back restores whatever opened the room, which is where an ordinary exit belongs.
       // A debate that ended under us is different: the entry behind us is often this same room
       // (hub → room → rematch → room), and stepping back into it re-runs the exit from a fresh
@@ -965,7 +971,9 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
         room.on(livekit.RoomEvent.Disconnected, payload => {
           if (!isCurrent() || roomRef.current !== room) return;
           const reconnectElapsedMs =
-            reconnectingStartedAtRef.current !== null ? performance.now() - reconnectingStartedAtRef.current : undefined;
+            reconnectingStartedAtRef.current !== null
+              ? performance.now() - reconnectingStartedAtRef.current
+              : undefined;
           reconnectingStartedAtRef.current = null;
           const conflictGeneration = connectionGenerationRef.current + 1;
           connectionGenerationRef.current = conflictGeneration;
@@ -1405,7 +1413,7 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
   const redirectAfterConnectionFailure = React.useCallback(() => {
     if (connectionFailureRedirectTimerRef.current !== null) return;
     connectionFailureRedirectTimerRef.current = window.setTimeout(() => {
-      router.replace(`/space/${spaceId}/questions`);
+      router.replace(consumeDebateReturnDestination() ?? `/space/${spaceId}/questions`);
     }, connectionFailureRedirectDelayMs);
   }, [router, spaceId]);
 

--- a/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.tsx
@@ -68,7 +68,6 @@ import { useFeatureFlag } from '~/core/state/feature-flags';
 
 import { Button } from '~/design-system/button';
 import { Check } from '~/design-system/icons/check';
-import { PrefetchLink as Link } from '~/design-system/prefetch-link';
 import { Text } from '~/design-system/text';
 
 type DebateRoomPageClientProps = {
@@ -447,6 +446,19 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
 
   /** The exit for a debate whose recording was cancelled — it can never be re-entered. */
   const leaveCancelledDebate = React.useCallback(() => returnFromDebate({ forwardOnly: true }), [returnFromDebate]);
+
+  const leaveConflictingRoom = React.useCallback(() => {
+    const returnDestination = consumeDebateReturnDestination();
+    if (returnDestination) {
+      router.replace(returnDestination);
+      return;
+    }
+    if (window.history.length > 1) {
+      router.back();
+      return;
+    }
+    router.replace(`/space/${spaceId}/debates`);
+  }, [router, spaceId]);
 
   React.useEffect(() => {
     serverNowRef.current = serverClock.now;
@@ -1639,14 +1651,15 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
           <Text as="p" variant="metadata" color="grey-04" className="mt-3">
             Close this tab and continue your debate in the original tab.
           </Text>
-          <Link
-            href={`/space/${spaceId}/debates`}
+          <button
+            type="button"
+            onClick={leaveConflictingRoom}
             className="mt-6 text-ctaPrimary transition-colors hover:text-ctaHover focus-visible:text-ctaHover"
           >
             <Text as="span" variant="textLinkSemibold" color="current">
-              Go to debates
+              Go back
             </Text>
-          </Link>
+          </button>
         </div>
       </div>
     );

--- a/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.tsx
@@ -17,7 +17,6 @@ import {
   getCurrentGeoChatUserId,
   getServerTime,
 } from '~/core/debates/api';
-import { takeDebateFlowOrigin } from '~/core/debates/debate-entry-intent';
 import { DebatePreScreen } from '~/core/debates/debate-pre-join-screen';
 import {
   CameraIcon,
@@ -435,17 +434,10 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
       if (debateExitStartedRef.current) return;
       debateExitStartedRef.current = true;
       clearDebateActivity(debateId);
-      // Prefer the path recorded when the viewer entered the flow. `router.back()`
-      // only steps one entry, so in hub → room → rematch → room it lands inside the
-      // flow rather than where they came from — and re-mounting a room re-runs its
-      // exit, which is the flicker. Going forward to a known origin avoids both.
-      const origin = takeDebateFlowOrigin();
-      if (origin) {
-        router.replace(origin);
-        return;
-      }
-      // No origin recorded (storage unavailable, or entry predates it): fall back to
-      // the previous behaviour rather than stranding the viewer.
+      // Going back restores whatever opened the room, which is where an ordinary exit belongs.
+      // A debate that ended under us is different: the entry behind us is often this same room
+      // (hub → room → rematch → room), and stepping back into it re-runs the exit from a fresh
+      // mount. That is the flicker, and it is why the removal dialog needed a second Okay.
       if (!forwardOnly && window.history.length > 1) {
         router.back();
         return;

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
@@ -8,6 +8,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { TOPICS_PROPERTY_ID } from '~/core/claims/ontology';
 import type { DebateRematchClaim, DebateRematchSession } from '~/core/debates/api';
+import { clearDebateReturnDestination, rememberDebateReturnDestination } from '~/core/debates/debate-return-navigation';
 
 import { DebateRematchPageClient } from './rematch-page-client';
 
@@ -254,6 +255,7 @@ function mutation(mutate = mocks.mutate) {
 }
 
 beforeEach(() => {
+  clearDebateReturnDestination();
   mocks.replace.mockReset();
   mocks.back.mockReset();
   mocks.mutate.mockReset();
@@ -319,6 +321,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  clearDebateReturnDestination();
   vi.restoreAllMocks();
   cleanup();
 });
@@ -382,6 +385,22 @@ describe('DebateRematchPageClient', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Leave debate' }));
 
     expect(mocks.replace).toHaveBeenCalledWith(`/space/${SPACE_1}/debates`);
+    expect(mocks.back).not.toHaveBeenCalled();
+  });
+
+  it('returns a debate-again session to the page that opened the flow', () => {
+    rememberDebateReturnDestination('/space/my-space?tab=activity#latest');
+    const endedSession = session({ status: 'ended' });
+    mocks.leaveMutate.mockImplementation(
+      (_input: undefined, options: { onSuccess?: (ended: DebateRematchSession) => void }) => {
+        options.onSuccess?.(endedSession);
+      }
+    );
+
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+    fireEvent.click(screen.getByRole('button', { name: 'Leave debate' }));
+
+    expect(mocks.replace).toHaveBeenCalledWith('/space/my-space?tab=activity#latest');
     expect(mocks.back).not.toHaveBeenCalled();
   });
 
@@ -1015,7 +1034,9 @@ describe('DebateRematchPageClient', () => {
 
     expect(mocks.markEnteringDebate).toHaveBeenCalledWith('debate-9');
     expect(mocks.replace).toHaveBeenCalledWith(`/space/${SPACE_1}/debates/debate-9`);
-    expect(mocks.markEnteringDebate.mock.invocationCallOrder[0]).toBeLessThan(mocks.replace.mock.invocationCallOrder[0]!);
+    expect(mocks.markEnteringDebate.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.replace.mock.invocationCallOrder[0]!
+    );
   });
 
   // A backend that predates the fields answers `undefined`, and the picker must keep working

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { SystemIds } from '@geoprotocol/geo-sdk/lite';
+
 import * as React from 'react';
 
 import cx from 'classnames';
@@ -17,10 +18,11 @@ import {
   type MatchmakingTopic,
 } from '~/core/debates/api';
 import { type ClaimPickerEntity, useClaimPickerPage } from '~/core/debates/claim-picker-page';
+import { isClaimSpaceAllowed } from '~/core/debates/claim-space-allowlist';
 import { markEnteringDebate } from '~/core/debates/debate-entry-intent';
 import { useDebateGatewaySpaceScopes } from '~/core/debates/debate-gateway';
-import { isClaimSpaceAllowed } from '~/core/debates/claim-space-allowlist';
 import { DebateRequestDialog } from '~/core/debates/debate-request-dialog';
+import { consumeDebateReturnDestination } from '~/core/debates/debate-return-navigation';
 import { defaultDebateFormatId } from '~/core/debates/formats';
 import {
   useAcceptDebateRematchRequest,
@@ -308,6 +310,12 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
     (endedSession: DebateRematchSession) => {
       if (exitStartedRef.current) return;
       exitStartedRef.current = true;
+
+      const returnDestination = consumeDebateReturnDestination();
+      if (returnDestination) {
+        router.replace(returnDestination);
+        return;
+      }
 
       if (endedSession.source_debate_id === null) {
         if (window.history.length > 1) {

--- a/apps/web/core/debates/activity-state.test.ts
+++ b/apps/web/core/debates/activity-state.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { activeDebate, hasActiveDebateFlow, unenterableDebateId } from './activity-state';
+import { activeDebate, hasActiveDebateFlow, recordingCancelledDebateId } from './activity-state';
 import type { Debate, DebateActivity, DebateMatch } from './api';
 
 const debate = (status: Debate['status']) => ({ id: 'debate-1', status }) as Debate;
@@ -32,17 +32,11 @@ describe('activity state', () => {
     expect(hasActiveDebateFlow(activityWithCancelledRecording)).toBe(false);
   });
 
-  it('names a debate there is nothing left to enter so callers refuse to route into it', () => {
-    expect(unenterableDebateId(activity({ debate: cancelledRecording('thanking') }))).toBe('debate-1');
-    expect(unenterableDebateId(activity({ debate: debate('thanking') }))).toBeNull();
-    expect(unenterableDebateId(activity({ debate: null }))).toBeNull();
-    expect(unenterableDebateId(null)).toBeNull();
-  });
-
-  // GEO-2600: naming only the cancelled recording left a `complete` debate looking enterable, and
-  // the room returns whoever opens one just the same. Tied to `activeDebate` so they cannot drift.
-  it.each(['complete', 'cancelled'] as const)('names a %s debate as unenterable too', status => {
-    expect(unenterableDebateId(activity({ debate: debate(status) }))).toBe('debate-1');
+  it('names the debate whose recording was cancelled so callers refuse to route into it', () => {
+    expect(recordingCancelledDebateId(activity({ debate: cancelledRecording('thanking') }))).toBe('debate-1');
+    expect(recordingCancelledDebateId(activity({ debate: debate('thanking') }))).toBeNull();
+    expect(recordingCancelledDebateId(activity({ debate: null }))).toBeNull();
+    expect(recordingCancelledDebateId(null)).toBeNull();
   });
 
   it('treats a rematch session as an active flow', () => {

--- a/apps/web/core/debates/activity-state.ts
+++ b/apps/web/core/debates/activity-state.ts
@@ -23,18 +23,12 @@ export function activeDebate(activity: ActivityLike | null | undefined): Debate 
 }
 
 /**
- * The reported debate's id when there is nothing left to enter: it finished, or its recording was
- * cancelled. Callers use it to refuse to navigate into a room that hides itself and returns whoever
- * opens it — see `activeDebate` for why such a debate is not "active".
- *
- * Deliberately the exact inverse of `activeDebate` rather than its own list of conditions. GEO-2600
- * was a caller that checked only the cancelled recording and so still routed into a `complete`
- * room, which bounced the viewer straight back out and re-armed the push that sent them.
+ * The reported debate's id if its recording was cancelled. Callers use it to refuse to navigate
+ * into a room that has nothing left to show — see `activeDebate` for why it is not "active".
  */
-export function unenterableDebateId(activity: ActivityLike | null | undefined): string | null {
+export function recordingCancelledDebateId(activity: ActivityLike | null | undefined): string | null {
   const debate = activity?.debate ?? null;
-  if (!debate) return null;
-  return activeDebate(activity) ? null : debate.id;
+  return debate?.recording_cancelled_at ? debate.id : null;
 }
 
 /**

--- a/apps/web/core/debates/debate-coordinator.test.tsx
+++ b/apps/web/core/debates/debate-coordinator.test.tsx
@@ -178,13 +178,13 @@ describe('DebateCoordinator', () => {
     expect(screen.queryByText('Live debate updates are paused while reconnecting.')).not.toBeInTheDocument();
   });
 
-  it('routes an available participant into a shared rematch browser', async () => {
+  it('does not route another tab into a shared debate-again browser', async () => {
     mocks.activity = activityWithRematch('browsing');
 
     render(<DebateCoordinator />);
 
-    await waitFor(() => expect(mocks.push).toHaveBeenCalledWith('/space/space-1/debates/rematches/rematch-1'));
-    expect(mocks.rememberDebateReturnDestination).toHaveBeenCalled();
+    await waitFor(() => expect(mocks.push).not.toHaveBeenCalled());
+    expect(mocks.rememberDebateReturnDestination).not.toHaveBeenCalled();
   });
 
   it('leaves a secondary tab on its current page when shared activity contains a debate', async () => {
@@ -409,7 +409,12 @@ describe('DebateCoordinator', () => {
   it('routes the sender into the claim picker once the challenge is accepted', async () => {
     mocks.currentUserId = 'user-requester';
     mocks.pathname = '/space/space-1/claims';
-    mocks.activity = { ...activityWithRematch('browsing'), challenge: null };
+    const activity = activityWithRematch('browsing');
+    mocks.activity = {
+      ...activity,
+      rematch: { ...activity.rematch!, source_debate_id: null },
+      challenge: null,
+    };
 
     render(<DebateCoordinator />);
 
@@ -467,13 +472,13 @@ describe('DebateCoordinator', () => {
     expect(screen.queryByRole('button', { name: /Your debate is/ })).not.toBeInTheDocument();
   });
 
-  it('still routes into a deciding rematch while the debate is intact', async () => {
+  it('leaves an unrelated tab alone while an intact debate-again session is deciding', async () => {
     mocks.pathname = '/space/space-1/claims';
     mocks.activity = activityWithRematch('deciding');
 
     render(<DebateCoordinator />);
 
-    await waitFor(() => expect(mocks.push).toHaveBeenCalledWith('/space/space-1/debates/debate-1'));
+    await waitFor(() => expect(mocks.push).not.toHaveBeenCalled());
   });
 
   it.each(['complete', 'cancelled'] as const)('does not reopen a %s debate from stale activity', async status => {

--- a/apps/web/core/debates/debate-coordinator.test.tsx
+++ b/apps/web/core/debates/debate-coordinator.test.tsx
@@ -496,26 +496,6 @@ describe('DebateCoordinator', () => {
     expect(screen.queryByRole('button', { name: /Your debate is/ })).not.toBeInTheDocument();
   });
 
-  // GEO-2600. Same loop, wider cause: the room returns whoever opens *any* finished debate, not
-  // only one whose recording was cancelled. `activeDebate` has always known that; this effect only
-  // checked the recording. So a `deciding` rematch over a complete debate pushed into a room that
-  // bounced straight back out, and the push repeated on every activity change — the rematch page
-  // blanking and redrawing on a URL that never moved, which is what Preston recorded.
-  it.each(['complete', 'cancelled'] as const)(
-    'does not route into a deciding rematch whose debate is %s',
-    async status => {
-      mocks.pathname = '/space/space-1/debates/rematches/rematch-1';
-      mocks.activity = {
-        ...activityWithRematch('deciding'),
-        debate: { ...activityWithDebate().debate!, status, participants: bothParticipants() },
-      };
-
-      render(<DebateCoordinator />);
-
-      await waitFor(() => expect(mocks.push).not.toHaveBeenCalled());
-    }
-  );
-
   it('still routes into a deciding rematch while the debate is intact', async () => {
     mocks.pathname = '/space/space-1/claims';
     mocks.activity = activityWithRematch('deciding');

--- a/apps/web/core/debates/debate-coordinator.test.tsx
+++ b/apps/web/core/debates/debate-coordinator.test.tsx
@@ -36,6 +36,7 @@ const mocks = vi.hoisted(() => ({
   refetch: vi.fn(),
   abortMutateAsync: vi.fn(),
   clearDebateActivity: vi.fn(),
+  rememberDebateReturnDestination: vi.fn(),
 }));
 
 vi.mock('next/navigation', () => ({
@@ -103,6 +104,10 @@ vi.mock('./claim-response-indexed-notifier', () => ({
   useClaimResponseIndexedNotifier: vi.fn(),
 }));
 
+vi.mock('./debate-return-navigation', () => ({
+  rememberDebateReturnDestination: mocks.rememberDebateReturnDestination,
+}));
+
 vi.mock('~/core/state/feature-flags', () => ({}));
 
 beforeEach(() => {
@@ -134,6 +139,7 @@ beforeEach(() => {
   mocks.abortMutateAsync.mockReset();
   mocks.abortMutateAsync.mockResolvedValue(undefined);
   mocks.clearDebateActivity.mockReset();
+  mocks.rememberDebateReturnDestination.mockReset();
   Object.defineProperty(navigator, 'share', { configurable: true, value: mocks.share });
   Object.defineProperty(navigator, 'canShare', { configurable: true, value: mocks.canShare });
   Object.defineProperty(URL, 'createObjectURL', {
@@ -178,6 +184,7 @@ describe('DebateCoordinator', () => {
     render(<DebateCoordinator />);
 
     await waitFor(() => expect(mocks.push).toHaveBeenCalledWith('/space/space-1/debates/rematches/rematch-1'));
+    expect(mocks.rememberDebateReturnDestination).toHaveBeenCalled();
   });
 
   it('leaves a secondary tab on its current page when shared activity contains a debate', async () => {

--- a/apps/web/core/debates/debate-coordinator.tsx
+++ b/apps/web/core/debates/debate-coordinator.tsx
@@ -9,7 +9,7 @@ import { Upload } from '~/design-system/icons/upload';
 import { Spinner } from '~/design-system/spinner';
 import { Text } from '~/design-system/text';
 
-import { activeDebate, unenterableDebateId } from './activity-state';
+import { activeDebate, recordingCancelledDebateId } from './activity-state';
 import { type DebateSharePrompt } from './api';
 import { useClaimResponseIndexedNotifier } from './claim-response-indexed-notifier';
 import { useDebatePresence } from './debate-attention';
@@ -181,12 +181,10 @@ export function DebateCoordinator() {
     if (!activity) return;
     const rematch = activity.rematch;
     if (!rematch) return;
-    // A debate that is over cannot be re-entered: the room hides itself and returns whoever opens
-    // it. Pushing into it here turned that into a navigation loop — the screen flickered, and the
-    // opponent's "your debate was removed" dialog came back after Okay. That first showed up as a
-    // cancelled recording, but GEO-2600 was the same loop over a `complete` debate: the push landed
-    // and bounced on every activity change, blanking the rematch page on a URL that never moved.
-    if (rematch.source_debate_id && rematch.source_debate_id === unenterableDebateId(activity)) return;
+    // A debate whose recording was cancelled cannot be re-entered: the room hides itself and
+    // returns whoever opens it. Pushing into it here turned that into a navigation loop — the
+    // screen flickered, and the opponent's "your debate was removed" dialog came back after Okay.
+    if (rematch.source_debate_id && rematch.source_debate_id === recordingCancelledDebateId(activity)) return;
     const sourceDebatePath = rematch.source_debate_id ? `/debates/${rematch.source_debate_id}` : null;
     if (rematch.status === 'deciding') {
       if (sourceDebatePath && !pathname.includes(sourceDebatePath)) {

--- a/apps/web/core/debates/debate-coordinator.tsx
+++ b/apps/web/core/debates/debate-coordinator.tsx
@@ -9,7 +9,7 @@ import { Upload } from '~/design-system/icons/upload';
 import { Spinner } from '~/design-system/spinner';
 import { Text } from '~/design-system/text';
 
-import { activeDebate, recordingCancelledDebateId } from './activity-state';
+import { activeDebate } from './activity-state';
 import { type DebateSharePrompt } from './api';
 import { useClaimResponseIndexedNotifier } from './claim-response-indexed-notifier';
 import { useDebatePresence } from './debate-attention';
@@ -174,21 +174,13 @@ export function DebateCoordinator() {
     if (!activity) return;
     const rematch = activity.rematch;
     if (!rematch) return;
-    // A debate whose recording was cancelled cannot be re-entered: the room hides itself and
-    // returns whoever opens it. Pushing into it here turned that into a navigation loop — the
-    // screen flickered, and the opponent's "your debate was removed" dialog came back after Okay.
-    if (rematch.source_debate_id && rematch.source_debate_id === recordingCancelledDebateId(activity)) return;
     const sourceDebatePath = rematch.source_debate_id ? `/debates/${rematch.source_debate_id}` : null;
-    if (rematch.status === 'deciding') {
-      if (sourceDebatePath && !pathname.includes(sourceDebatePath)) {
-        rememberDebateReturnDestination();
-        router.push(`/space/${rematch.source_space_id}${sourceDebatePath}`);
-      }
-      return;
-    }
+    // A debate-again session is shared across every tab, but only the tab already in the source
+    // room owns its recording and transition into the rematch browser. Routing from this app-wide
+    // coordinator sent every other open tab into that room, where ownership correctly rejected it.
+    // The room handles deciding, recording finalization, browsing, and conversion itself.
+    if (sourceDebatePath) return;
     if (rematch.status === 'browsing' || rematch.status === 'request_pending') {
-      // The debate room owns recording finalization before entering the browser.
-      if (sourceDebatePath && pathname.includes(sourceDebatePath)) return;
       const path = `/space/${rematch.source_space_id}/debates/rematches/${rematch.id}`;
       if (pathname !== path) {
         rememberDebateReturnDestination();

--- a/apps/web/core/debates/debate-coordinator.tsx
+++ b/apps/web/core/debates/debate-coordinator.tsx
@@ -17,6 +17,7 @@ import { DebateChallengeDialog } from './debate-challenge-dialog';
 import { clearEnteringDebate, useEnteringDebateId } from './debate-entry-intent';
 import { useDebateGateway } from './debate-gateway';
 import { DebateReadyPrompt, DebateRejoinBar } from './debate-ready-prompt';
+import { rememberDebateReturnDestination } from './debate-return-navigation';
 import {
   useAcceptDebateChallenge,
   useDebateActivity,
@@ -180,6 +181,7 @@ export function DebateCoordinator() {
     const sourceDebatePath = rematch.source_debate_id ? `/debates/${rematch.source_debate_id}` : null;
     if (rematch.status === 'deciding') {
       if (sourceDebatePath && !pathname.includes(sourceDebatePath)) {
+        rememberDebateReturnDestination();
         router.push(`/space/${rematch.source_space_id}${sourceDebatePath}`);
       }
       return;
@@ -188,7 +190,10 @@ export function DebateCoordinator() {
       // The debate room owns recording finalization before entering the browser.
       if (sourceDebatePath && pathname.includes(sourceDebatePath)) return;
       const path = `/space/${rematch.source_space_id}/debates/rematches/${rematch.id}`;
-      if (pathname !== path) router.push(path);
+      if (pathname !== path) {
+        rememberDebateReturnDestination();
+        router.push(path);
+      }
     }
   }, [activity, pathname, router]);
 

--- a/apps/web/core/debates/debate-entry-intent.test.ts
+++ b/apps/web/core/debates/debate-entry-intent.test.ts
@@ -2,18 +2,11 @@ import { act, cleanup, renderHook } from '@testing-library/react';
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import {
-  clearEnteringDebate,
-  markEnteringDebate,
-  recordDebateFlowOrigin,
-  takeDebateFlowOrigin,
-  useEnteringDebateId,
-} from './debate-entry-intent';
+import { clearEnteringDebate, markEnteringDebate, useEnteringDebateId } from './debate-entry-intent';
 
 afterEach(() => {
   cleanup();
   clearEnteringDebate();
-  window.sessionStorage.clear();
   vi.useRealTimers();
 });
 
@@ -72,81 +65,5 @@ describe('debate entry intent', () => {
     act(() => vi.advanceTimersByTime(25_000));
 
     expect(result.current).toBe('debate-2');
-  });
-});
-
-// GEO-2605. `router.back()` steps one history entry, which is the origin only when the flow was a
-// single hop — so the origin is recorded on the way in rather than inferred on the way out.
-describe('debate flow origin', () => {
-  it('returns the path the flow started from', () => {
-    recordDebateFlowOrigin('/space/space-1/entity-7');
-
-    expect(takeDebateFlowOrigin()).toBe('/space/space-1/entity-7');
-  });
-
-  // The whole point: hub -> room -> rematch -> room must still return to the hub, not to the room
-  // one entry back. Every entry calls markEnteringDebate, so the second one must not overwrite.
-  it('keeps the first origin when the flow enters a second room', () => {
-    recordDebateFlowOrigin('/space/space-1/entity-7');
-    recordDebateFlowOrigin('/space/space-1/debates/debate-1');
-    markEnteringDebate('debate-2');
-
-    expect(takeDebateFlowOrigin()).toBe('/space/space-1/entity-7');
-  });
-
-  // A refresh mid-flow re-enters from a debate path. Recording it would make the room its own
-  // origin, which sends the viewer straight back into the flow they were leaving.
-  it('never records a path inside the flow', () => {
-    recordDebateFlowOrigin('/space/space-1/debates');
-
-    expect(takeDebateFlowOrigin()).toBeNull();
-  });
-
-  // Distinguishes the record-side guard from the read-side one: if an in-flow path were stored,
-  // the already-held guard would then block the real origin and the exit would fall back.
-  it('does not let a refresh inside the flow consume the origin slot', () => {
-    recordDebateFlowOrigin('/space/space-1/debates/debate-1');
-    recordDebateFlowOrigin('/space/space-1/entity-7');
-
-    expect(takeDebateFlowOrigin()).toBe('/space/space-1/entity-7');
-  });
-
-  it('does not treat a path merely containing the word as the flow', () => {
-    recordDebateFlowOrigin('/space/space-1/debatesomething');
-
-    expect(takeDebateFlowOrigin()).toBe('/space/space-1/debatesomething');
-  });
-
-  it('forgets the origin once it has been used, so a later exit falls back', () => {
-    recordDebateFlowOrigin('/space/space-1/entity-7');
-
-    expect(takeDebateFlowOrigin()).toBe('/space/space-1/entity-7');
-    expect(takeDebateFlowOrigin()).toBeNull();
-  });
-
-  it('has nothing to return to when the flow was never entered', () => {
-    expect(takeDebateFlowOrigin()).toBeNull();
-  });
-
-  // Private-mode browsers throw on sessionStorage. Losing the origin is acceptable; taking the
-  // room down on the way out is not.
-  it('survives storage that throws', () => {
-    // jsdom's Storage is a proxy whose methods live on the prototype, so spying on the instance
-    // silently writes a storage entry instead of replacing the method. Swap the whole object.
-    const real = window.sessionStorage;
-    const denied = () => {
-      throw new Error('denied');
-    };
-    Object.defineProperty(window, 'sessionStorage', {
-      configurable: true,
-      value: { getItem: denied, setItem: denied, removeItem: denied },
-    });
-
-    try {
-      expect(() => recordDebateFlowOrigin('/space/space-1/entity-7')).not.toThrow();
-      expect(takeDebateFlowOrigin()).toBeNull();
-    } finally {
-      Object.defineProperty(window, 'sessionStorage', { configurable: true, value: real });
-    }
   });
 });

--- a/apps/web/core/debates/debate-entry-intent.test.ts
+++ b/apps/web/core/debates/debate-entry-intent.test.ts
@@ -3,10 +3,12 @@ import { act, cleanup, renderHook } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { clearEnteringDebate, markEnteringDebate, useEnteringDebateId } from './debate-entry-intent';
+import { clearDebateReturnDestination } from './debate-return-navigation';
 
 afterEach(() => {
   cleanup();
   clearEnteringDebate();
+  clearDebateReturnDestination();
   vi.useRealTimers();
 });
 

--- a/apps/web/core/debates/debate-entry-intent.ts
+++ b/apps/web/core/debates/debate-entry-intent.ts
@@ -45,75 +45,8 @@ function set(debateId: string | null) {
   emit();
 }
 
-/**
- * Where the viewer was before they entered the debate flow.
- *
- * GEO-2605: exiting a debate used `router.back()`, which steps back exactly one
- * history entry. In a single-hop entry that is the origin, but the flow is rarely
- * single-hop — hub -> room -> rematch -> room means the entry behind you is
- * another room, so back() lands inside the flow and the fallback drops you on
- * `/space/{id}/debates`, which is the "weird screen" in the report. The room's own
- * comment already noted the other half of it: stepping back into a room re-runs
- * its exit from a fresh mount, which is the flicker.
- *
- * So record the origin on the way in instead of inferring it on the way out.
- *
- * Captured on `markEnteringDebate`, which every entry into a room already calls,
- * and deliberately *only if nothing is held yet* — a rematch entering a second
- * room must not overwrite the hub the viewer actually came from. Paths already
- * inside the flow are never recorded, so a refresh mid-flow cannot make the room
- * its own origin.
- *
- * `sessionStorage` rather than module state because "errored out of the flow" can
- * mean a reload, and module state does not survive one. Scoped to the tab, so two
- * debates in two tabs keep separate origins.
- *
- * Every exit through the room consumes the origin, so it only goes stale if the
- * viewer leaves the flow some other way (a nav click) and later re-enters from a
- * different page. They then land on the earlier origin instead of the newer one —
- * still a page they were on in this tab, so not worth a route observer to fix.
- */
-const DEBATE_FLOW_ORIGIN_KEY = 'geo.debate-flow-origin';
-
-/** True for any path that is itself part of the debate flow. */
-function isDebateFlowPath(path: string): boolean {
-  return /\/debates(\/|$|\?)/.test(path);
-}
-
-function currentPath(): string | null {
-  if (typeof window === 'undefined') return null;
-  return `${window.location.pathname}${window.location.search}`;
-}
-
-/**
- * Remember where the flow started. No-op if an origin is already held, if the
- * current path is inside the flow, or off the browser.
- */
-export function recordDebateFlowOrigin(path: string | null = currentPath()): void {
-  if (typeof window === 'undefined' || !path || isDebateFlowPath(path)) return;
-  try {
-    if (window.sessionStorage.getItem(DEBATE_FLOW_ORIGIN_KEY)) return;
-    window.sessionStorage.setItem(DEBATE_FLOW_ORIGIN_KEY, path);
-  } catch {
-    // Private-mode or storage-disabled browsers fall back to the old behaviour.
-  }
-}
-
-/** Read and forget the origin. Returns null when there is nothing to return to. */
-export function takeDebateFlowOrigin(): string | null {
-  if (typeof window === 'undefined') return null;
-  try {
-    const origin = window.sessionStorage.getItem(DEBATE_FLOW_ORIGIN_KEY);
-    window.sessionStorage.removeItem(DEBATE_FLOW_ORIGIN_KEY);
-    return origin || null;
-  } catch {
-    return null;
-  }
-}
-
 /** Call immediately before pushing into a debate room. */
 export function markEnteringDebate(debateId: string) {
-  recordDebateFlowOrigin();
   set(debateId);
   expiry = setTimeout(() => {
     expiry = null;

--- a/apps/web/core/debates/debate-entry-intent.ts
+++ b/apps/web/core/debates/debate-entry-intent.ts
@@ -2,6 +2,8 @@
 
 import * as React from 'react';
 
+import { rememberDebateReturnDestination } from './debate-return-navigation';
+
 /**
  * The debate this tab is on its way into.
  *
@@ -47,6 +49,7 @@ function set(debateId: string | null) {
 
 /** Call immediately before pushing into a debate room. */
 export function markEnteringDebate(debateId: string) {
+  rememberDebateReturnDestination();
   set(debateId);
   expiry = setTimeout(() => {
     expiry = null;

--- a/apps/web/core/debates/debate-ready-prompt.test.tsx
+++ b/apps/web/core/debates/debate-ready-prompt.test.tsx
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => ({
   abortMutateAsync: vi.fn(),
   abortPending: false,
   clearDebateActivity: vi.fn(),
+  markEnteringDebate: vi.fn(),
 }));
 
 vi.mock('next/navigation', () => ({
@@ -20,6 +21,10 @@ vi.mock('next/navigation', () => ({
 vi.mock('./hooks', () => ({
   useAbortDebate: () => ({ mutateAsync: mocks.abortMutateAsync, isPending: mocks.abortPending }),
   useClearDebateActivity: () => mocks.clearDebateActivity,
+}));
+
+vi.mock('./debate-entry-intent', () => ({
+  markEnteringDebate: mocks.markEnteringDebate,
 }));
 
 // useSpaceLabels reads the browse sidebar's cache before falling back to the mock below. These
@@ -77,6 +82,7 @@ beforeEach(() => {
   mocks.abortMutateAsync.mockResolvedValue(debate({ status: 'cancelled' }));
   mocks.abortPending = false;
   mocks.clearDebateActivity.mockReset();
+  mocks.markEnteringDebate.mockReset();
 });
 afterEach(cleanup);
 
@@ -89,6 +95,7 @@ describe('DebateReadyPrompt', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Join debate' }));
 
+    expect(mocks.markEnteringDebate).toHaveBeenCalledWith('debate-1');
     expect(mocks.push).toHaveBeenCalledWith('/space/space-1/debates/debate-1');
   });
 
@@ -173,6 +180,7 @@ describe('DebateRejoinBar', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /Your debate is ready/ }));
 
+    expect(mocks.markEnteringDebate).toHaveBeenCalledWith('debate-1');
     expect(mocks.push).toHaveBeenCalledWith('/space/space-1/debates/debate-1');
   });
 });

--- a/apps/web/core/debates/debate-ready-prompt.test.tsx
+++ b/apps/web/core/debates/debate-ready-prompt.test.tsx
@@ -4,7 +4,6 @@ import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/re
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { Debate, DebateParticipant } from './api';
-import { takeDebateFlowOrigin } from './debate-entry-intent';
 import { DebateReadyPrompt, DebateRejoinBar } from './debate-ready-prompt';
 
 const mocks = vi.hoisted(() => ({
@@ -78,8 +77,6 @@ beforeEach(() => {
   mocks.abortMutateAsync.mockResolvedValue(debate({ status: 'cancelled' }));
   mocks.abortPending = false;
   mocks.clearDebateActivity.mockReset();
-  window.sessionStorage.clear();
-  window.history.replaceState({}, '', '/space/space-1/entity-7');
 });
 afterEach(cleanup);
 
@@ -93,16 +90,6 @@ describe('DebateReadyPrompt', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Join debate' }));
 
     expect(mocks.push).toHaveBeenCalledWith('/space/space-1/debates/debate-1');
-  });
-
-  // GEO-2605. This dialog is app-wide, so joining from it can start anywhere — and that anywhere is
-  // where exiting the debate has to return them. Nothing else records it on this path.
-  it('records where the viewer was so the exit can return them there', () => {
-    render(<DebateReadyPrompt debate={debate()} currentUserId="user-me" />);
-
-    fireEvent.click(screen.getByRole('button', { name: 'Join debate' }));
-
-    expect(takeDebateFlowOrigin()).toBe('/space/space-1/entity-7');
   });
 
   // The room is a server segment with no loading boundary: the router keeps this page on screen
@@ -187,13 +174,5 @@ describe('DebateRejoinBar', () => {
     fireEvent.click(screen.getByRole('button', { name: /Your debate is ready/ }));
 
     expect(mocks.push).toHaveBeenCalledWith('/space/space-1/debates/debate-1');
-  });
-
-  it('records the origin too, since it floats over whatever page the viewer is on', () => {
-    render(<DebateRejoinBar debate={debate()} />);
-
-    fireEvent.click(screen.getByRole('button', { name: /Your debate is ready/ }));
-
-    expect(takeDebateFlowOrigin()).toBe('/space/space-1/entity-7');
   });
 });

--- a/apps/web/core/debates/debate-ready-prompt.tsx
+++ b/apps/web/core/debates/debate-ready-prompt.tsx
@@ -7,6 +7,7 @@ import { useRouter } from 'next/navigation';
 import { Text } from '~/design-system/text';
 
 import type { Debate } from './api';
+import { markEnteringDebate } from './debate-entry-intent';
 import { DebateRequestDialog } from './debate-request-dialog';
 import { debatePath } from './debate-routes';
 import { useAbortDebate, useClearDebateActivity } from './hooks';
@@ -35,6 +36,7 @@ export function DebateReadyPrompt({ debate, currentUserId }: { debate: Debate; c
   const join = () => {
     if (joining) return;
     setJoining(true);
+    markEnteringDebate(debate.id);
     startJoining(() => router.push(debatePath(debate)));
   };
 
@@ -108,6 +110,7 @@ export function DebateRejoinBar({ debate }: { debate: Debate }) {
         disabled={joining}
         onClick={() => {
           setJoining(true);
+          markEnteringDebate(debate.id);
           startJoining(() => router.push(debatePath(debate)));
         }}
         className="pointer-events-auto flex max-w-full items-center gap-2 rounded-full bg-text py-2 pr-2 pl-4 text-white shadow-card transition-opacity hover:opacity-90 disabled:opacity-70"

--- a/apps/web/core/debates/debate-ready-prompt.tsx
+++ b/apps/web/core/debates/debate-ready-prompt.tsx
@@ -7,7 +7,6 @@ import { useRouter } from 'next/navigation';
 import { Text } from '~/design-system/text';
 
 import type { Debate } from './api';
-import { recordDebateFlowOrigin } from './debate-entry-intent';
 import { DebateRequestDialog } from './debate-request-dialog';
 import { debatePath } from './debate-routes';
 import { useAbortDebate, useClearDebateActivity } from './hooks';
@@ -36,10 +35,6 @@ export function DebateReadyPrompt({ debate, currentUserId }: { debate: Debate; c
   const join = () => {
     if (joining) return;
     setJoining(true);
-    // GEO-2605. This dialog is app-wide, so the viewer could be anywhere when it opens; where they
-    // are now is where exiting the debate should return them. Not `markEnteringDebate` — that would
-    // count them as already there and unmount this dialog mid-join, losing the pending state.
-    recordDebateFlowOrigin();
     startJoining(() => router.push(debatePath(debate)));
   };
 
@@ -113,9 +108,6 @@ export function DebateRejoinBar({ debate }: { debate: Debate }) {
         disabled={joining}
         onClick={() => {
           setJoining(true);
-          // Same as the prompt above: this bar floats over whatever page the viewer is on, and that
-          // page is where exiting the debate belongs.
-          recordDebateFlowOrigin();
           startJoining(() => router.push(debatePath(debate)));
         }}
         className="pointer-events-auto flex max-w-full items-center gap-2 rounded-full bg-text py-2 pr-2 pl-4 text-white shadow-card transition-opacity hover:opacity-90 disabled:opacity-70"

--- a/apps/web/core/debates/debate-return-navigation.test.ts
+++ b/apps/web/core/debates/debate-return-navigation.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  clearDebateReturnDestination,
+  consumeDebateReturnDestination,
+  rememberDebateReturnDestination,
+} from './debate-return-navigation';
+
+beforeEach(() => {
+  clearDebateReturnDestination();
+});
+
+afterEach(() => {
+  clearDebateReturnDestination();
+  vi.useRealTimers();
+});
+
+describe('debate return navigation', () => {
+  it('returns to the captured internal page once', () => {
+    rememberDebateReturnDestination('/space/my-space?tab=posts#latest');
+
+    expect(consumeDebateReturnDestination()).toBe('/space/my-space?tab=posts#latest');
+    expect(consumeDebateReturnDestination()).toBeNull();
+  });
+
+  it('preserves the original page across debate room and rematch routes', () => {
+    rememberDebateReturnDestination('/space/my-space');
+    rememberDebateReturnDestination('/space/claim-space/debates/debate-1');
+    rememberDebateReturnDestination('/space/claim-space/debates/rematches/rematch-1');
+
+    expect(consumeDebateReturnDestination()).toBe('/space/my-space');
+  });
+
+  it('allows the debates index to be the return page', () => {
+    rememberDebateReturnDestination('/space/my-space/debates?tab=requests');
+
+    expect(consumeDebateReturnDestination()).toBe('/space/my-space/debates?tab=requests');
+  });
+
+  it('replaces a stale destination when a new flow starts from another page', () => {
+    rememberDebateReturnDestination('/space/first');
+    rememberDebateReturnDestination('/space/second');
+
+    expect(consumeDebateReturnDestination()).toBe('/space/second');
+  });
+
+  it('rejects external and expired destinations', () => {
+    rememberDebateReturnDestination('https://example.com/steal-me');
+    expect(consumeDebateReturnDestination()).toBeNull();
+
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-19T00:00:00Z'));
+    rememberDebateReturnDestination('/space/my-space');
+    vi.advanceTimersByTime(6 * 60 * 60 * 1_000 + 1);
+
+    expect(consumeDebateReturnDestination()).toBeNull();
+  });
+});

--- a/apps/web/core/debates/debate-return-navigation.ts
+++ b/apps/web/core/debates/debate-return-navigation.ts
@@ -1,0 +1,80 @@
+'use client';
+
+const debateReturnDestinationKey = 'geo.debates.return-destination';
+const debateReturnDestinationMaxAgeMs = 6 * 60 * 60 * 1_000;
+
+type StoredDebateReturnDestination = {
+  href: string;
+  capturedAt: number;
+};
+
+/**
+ * Remember the page that opened a live debate flow. Debate room and rematch
+ * transitions intentionally do not overwrite it, so one destination survives
+ * recording -> debate again -> recording until the flow actually exits.
+ */
+export function rememberDebateReturnDestination(href = currentBrowserHref()) {
+  const destination = safeInternalHref(href);
+  if (!destination || isDebateFlowHref(destination)) return;
+
+  try {
+    window.sessionStorage.setItem(
+      debateReturnDestinationKey,
+      JSON.stringify({ href: destination, capturedAt: Date.now() } satisfies StoredDebateReturnDestination)
+    );
+  } catch {
+    // Browser storage can be unavailable in privacy modes. Existing history
+    // and route fallbacks still handle the exit in that case.
+  }
+}
+
+/** Read and clear the destination so a later, unrelated debate cannot reuse it. */
+export function consumeDebateReturnDestination(): string | null {
+  let raw: string | null = null;
+  try {
+    raw = window.sessionStorage.getItem(debateReturnDestinationKey);
+    window.sessionStorage.removeItem(debateReturnDestinationKey);
+  } catch {
+    return null;
+  }
+  if (!raw) return null;
+
+  try {
+    const stored = JSON.parse(raw) as Partial<StoredDebateReturnDestination>;
+    if (typeof stored.href !== 'string' || typeof stored.capturedAt !== 'number') return null;
+    if (Date.now() - stored.capturedAt > debateReturnDestinationMaxAgeMs) return null;
+    const destination = safeInternalHref(stored.href);
+    return destination && !isDebateFlowHref(destination) ? destination : null;
+  } catch {
+    return null;
+  }
+}
+
+export function clearDebateReturnDestination() {
+  try {
+    window.sessionStorage.removeItem(debateReturnDestinationKey);
+  } catch {
+    // Nothing to clear when storage is unavailable.
+  }
+}
+
+function currentBrowserHref() {
+  if (typeof window === 'undefined') return '';
+  return `${window.location.pathname}${window.location.search}${window.location.hash}`;
+}
+
+function safeInternalHref(href: string): string | null {
+  if (!href.startsWith('/') || href.startsWith('//')) return null;
+  try {
+    const url = new URL(href, 'https://geo.local');
+    return `${url.pathname}${url.search}${url.hash}`;
+  } catch {
+    return null;
+  }
+}
+
+function isDebateFlowHref(href: string) {
+  const pathname = href.split(/[?#]/, 1)[0];
+  const segments = pathname.split('/').filter(Boolean);
+  return segments[0] === 'space' && segments[2] === 'debates' && segments.length > 3;
+}


### PR DESCRIPTION
Supersedes #2178 (adopting its work) and reverts my #2186 and #2187.

**I duplicated work.** Preston opened #2178 on 08-20 00:41 and #2182 at 01:30. I then picked GEO-2605 and GEO-2604 off the list he handed me, about a day later, without checking for open PRs — built my own, and merged them — which broke both of his (10 and 2 conflicts). Preston's #2178 is better than what I shipped, so this backs mine out and lands his.

## Where his is better

| | mine (#2186) | his (#2178) |
|---|---|---|
| `/space/{id}/debates` as an origin | **treated as in-flow → not recorded** | recorded |
| URL hash | dropped | preserved |
| destination validation | none | `safeInternalHref`, rejects `//host` |
| stale origin | documented as won't-fix | 6-hour max age |
| room-ownership conflict exit | not handled | `leaveConflictingRoom` |
| rematch/recording transitions | not handled | destination survives them |

The first row is a real bug in what I merged. My predicate was `/\/debates(\/|$|\?)/`, which matches the debates **hub** — so entering a debate from the hub recorded no origin at all and fell straight back to `router.back()`. The hub is the most common entry point and precisely where Preston's "weird screen" report lives, so **#2186 did not fix the main case.** Verified both predicates side by side against real paths.

His coordinator change also supersedes my #2187. I narrowed the guard so the coordinator wouldn't push into a *finished* debate; he removes the source-room push entirely, on the grounds that only the tab already in the room owns that transition. That kills the whole loop class *and* a multi-tab bug — routing from an app-wide coordinator sent every other open tab into a room that ownership then rejected.

I checked that claim rather than taking it: `finishLiveDebate` in the room does compute `rematchDestination(session)` and `router.replace`es there itself, so the coordinator's push was redundant. ✅

## What I changed in his work

- **Rebased onto current master.** His branch predates #2183, so its `useClaimPickerPage` import had to become `useClaimEntitiesByIds`; two other conflicts were import-block unions.
- **Added a test for the `//host` guard**, which mutation-testing showed was unverified. Worth being precise about severity: this is *not* a live open redirect — `new URL('//evil.com/x', base)` reconstructs to the bare path `/x`, so without the guard you'd be sent to the wrong **local** page, not off-origin. The test pins reject-over-rewrite.

## One claim of his that doesn't reproduce

#2182 says `debate-coordinator.test.tsx` doesn't collect — "all 40 tests were dead on master and in CI alike" — because `pending-personal-space` reads localStorage at module scope, and offers a follow-up to bring ~20 files back.

It collects fine on master: **44 tests pass** (40 original, +2 from #2187, +2 from #2189). His full-suite baseline of "22 failed files" is almost certainly an **unbuilt `@geogenesis/auth` workspace package** — I hit the same thing tonight, saw 8 phantom `tsc` errors and 7 phantom test failures from it, and `bun turbo run build --filter=@geogenesis/auth` cleared all of them. CI builds before testing, so those tests were never dead there. The offered follow-up would chase the wrong cause.

## Kept

#2189 stays — it's the same fix as his #2182 (suppress the coordinator's prompt and rejoin bar on the picker path). His description of the mechanism is better than mine, though: one `debate.rematch_changed` becomes two refetches and either can land first. Same race, more precise account.

## Known gap, not introduced here but widened

With the coordinator no longer routing for a rematch that has a source debate, nothing surfaces an active rematch outside the room tab — `hasActiveDebateFlow()` greys out every Debate control, the rejoin bar is suppressed while `activity.rematch` is set, and no push happens. Lose the room tab mid-rematch and you're stranded until it expires. Previously the coordinator would at least push you *somewhere* (into the loop). Worth its own fix; flagging rather than folding in.

## Verification

- 58 debate suites / **836 tests** pass.
- `tsc --noEmit`: 1 pre-existing error (`use-entity-vote.ts`), same on master.
- eslint and prettier clean.
- **Mutation-tested his three guards:** treating the hub as in-flow, accepting `//host`, and never expiring each fail a test.
