### PR TITLE
fix(explore): show the time range only for Top, and drop it from the other feeds

### DIFF
--- a/apps/web/app/api/activity/feed/route.ts
+++ b/apps/web/app/api/activity/feed/route.ts
@@ -10,9 +10,16 @@ import { getGovernanceHomeSpaceContext } from '~/app/home/governance-home-space-
 
 const TIMES: ExploreTime[] = ['today', 'week', 'month', 'year', 'all'];
 
+/**
+ * No `time` parameter means no time filter, which is what `'all'` is — `timeThresholdSec` maps it
+ * to null and nothing reaches the query. Feeds whose sort carries no range (Best, New) send
+ * nothing rather than a window the viewer can neither see nor change; defaulting to a week here
+ * would reinstate exactly the filter they omitted. An unrecognised value takes the same route: a
+ * range nobody can name is not one to guess at.
+ */
 function parseTime(raw: string | null): ExploreTime {
   if (raw && (TIMES as string[]).includes(raw)) return raw as ExploreTime;
-  return 'week';
+  return 'all';
 }
 
 /**

--- a/apps/web/app/api/explore/feed/route.ts
+++ b/apps/web/app/api/explore/feed/route.ts
@@ -22,9 +22,16 @@ function parseSort(raw: string | null): ExploreSort {
   return 'best';
 }
 
+/**
+ * No `time` parameter means no time filter, which is what `'all'` is — `timeThresholdSec` maps it
+ * to null and nothing reaches the query. Feeds whose sort carries no range (Best, New) send
+ * nothing rather than a window the viewer can neither see nor change; defaulting to a week here
+ * would reinstate exactly the filter they omitted. An unrecognised value takes the same route: a
+ * range nobody can name is not one to guess at.
+ */
 function parseTime(raw: string | null): ExploreTime {
   if (raw && (TIMES as string[]).includes(raw)) return raw as ExploreTime;
-  return 'week';
+  return 'all';
 }
 
 export async function GET(request: Request) {

--- a/apps/web/partials/feed/entity-feed.test.tsx
+++ b/apps/web/partials/feed/entity-feed.test.tsx
@@ -87,9 +87,10 @@ async function requestedUrl() {
 
 /**
  * The mocked Menu renders its trigger and its items together, so a word can appear twice. The
- * triggers carry an aria-label, which is what tells them apart from the item holding the same word.
+ * trigger's accessible name is "Time range: <value>", which both tells it apart from the item
+ * holding the same word and keeps the value it is showing.
  */
-const timeTrigger = () => screen.queryByRole('button', { name: 'Time range' });
+const timeTrigger = () => screen.queryByRole('button', { name: /^Time range:/ });
 const pickOption = (label: string) => fireEvent.click(screen.getByRole('button', { name: label }));
 
 // GEO-2610. The range answers "top of when?", so it belongs to Top alone. Best is ranked
@@ -138,6 +139,20 @@ describe('EntityFeed time range visibility', () => {
     pickOption('New');
 
     await waitFor(() => expect(timeTrigger()).toBeNull());
+  });
+
+  // `aria-label` replaces the visible text as the accessible name, so naming the control without
+  // its value would leave a screen reader unable to tell which sort or range is selected —
+  // `MenuItem` marks the active option with a background colour and nothing else.
+  it('announces the value each dropdown is showing, not just what it selects', () => {
+    renderExploreFeed();
+
+    expect(screen.queryByRole('button', { name: 'Sort: Best' })).not.toBeNull();
+
+    pickOption('Top');
+
+    expect(screen.queryByRole('button', { name: 'Sort: Top' })).not.toBeNull();
+    expect(screen.queryByRole('button', { name: 'Time range: Last month' })).not.toBeNull();
   });
 
   // The point of the ticket: a hidden range must not quietly filter the feed.

--- a/apps/web/partials/feed/entity-feed.test.tsx
+++ b/apps/web/partials/feed/entity-feed.test.tsx
@@ -78,6 +78,127 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
+/** The request the feed would make right now, as a URL. */
+async function requestedUrl() {
+  const queryFn = mocks.queryOptions?.queryFn as (args: { pageParam?: string }) => Promise<unknown>;
+  await queryFn({ pageParam: undefined });
+  return mocks.fetch.mock.calls.at(-1)?.[0] as string;
+}
+
+/**
+ * The mocked Menu renders its trigger and its items together, so a word can appear twice. The
+ * triggers carry an aria-label, which is what tells them apart from the item holding the same word.
+ */
+const timeTrigger = () => screen.queryByRole('button', { name: 'Time range' });
+const pickOption = (label: string) => fireEvent.click(screen.getByRole('button', { name: label }));
+
+// GEO-2610. The range answers "top of when?", so it belongs to Top alone. Best is ranked
+// server-side and New is ordered by recency already; a window over either is a filter the viewer
+// never asked for and — with the dropdown hidden — cannot see they have.
+describe('EntityFeed time range visibility', () => {
+  function renderExploreFeed() {
+    return render(
+      <EntityFeed
+        apiEndpoint="/api/explore/feed"
+        initialSpaceOptions={[]}
+        initialTime="month"
+        initialSort="best"
+        showSortFilter
+      />
+    );
+  }
+
+  it('hides the time dropdown for Best', () => {
+    renderExploreFeed();
+
+    expect(timeTrigger()).toBeNull();
+  });
+
+  it('hides it for New too', () => {
+    renderExploreFeed();
+
+    pickOption('New');
+
+    expect(timeTrigger()).toBeNull();
+  });
+
+  it('shows it once Top is picked', () => {
+    renderExploreFeed();
+
+    pickOption('Top');
+
+    expect(timeTrigger()).not.toBeNull();
+  });
+
+  it('hides it again when leaving Top', async () => {
+    renderExploreFeed();
+
+    pickOption('Top');
+    expect(timeTrigger()).not.toBeNull();
+    pickOption('New');
+
+    await waitFor(() => expect(timeTrigger()).toBeNull());
+  });
+
+  // The point of the ticket: a hidden range must not quietly filter the feed.
+  it('leaves the range out of the request when it is hidden', async () => {
+    renderExploreFeed();
+    await waitFor(() => expect(mocks.queryOptions?.enabled).toBe(true));
+
+    expect(await requestedUrl()).not.toContain('time=');
+  });
+
+  it('sends the range when Top is showing it', async () => {
+    renderExploreFeed();
+    pickOption('Top');
+
+    expect(await requestedUrl()).toContain('time=month');
+  });
+
+  // Resetting to a default would lose a choice the viewer made; the state is simply not consulted
+  // while there is nowhere to show it.
+  it('restores the range the viewer last picked when they return to Top', async () => {
+    renderExploreFeed();
+
+    pickOption('Top');
+    pickOption('Last year');
+    pickOption('New');
+    await waitFor(() => expect(timeTrigger()).toBeNull());
+
+    pickOption('Top');
+
+    expect(timeTrigger()).not.toBeNull();
+    expect(await requestedUrl()).toContain('time=year');
+  });
+
+  // Two Best feeds differing only in a hidden range are the same request; caching them apart would
+  // refetch on a change the viewer never made.
+  it('keys the query on what it actually sends', async () => {
+    renderExploreFeed();
+    await waitFor(() => expect(mocks.queryOptions?.enabled).toBe(true));
+    const bestKey = mocks.queryOptions?.queryKey as unknown[];
+
+    pickOption('Top');
+    pickOption('Last year');
+    pickOption('Best');
+    await waitFor(() => expect(timeTrigger()).toBeNull());
+
+    expect(mocks.queryOptions?.queryKey).toEqual(bestKey);
+  });
+
+  // The activity feed opts out of the range entirely, and its request is unchanged by this: it sent
+  // `time=all` before and sends nothing now, which the route reads the same way.
+  it('sends no range for a feed that opts out of the filter', async () => {
+    render(
+      <EntityFeed apiEndpoint="/api/activity/feed" lockedSpaceId="space-1" initialTime="all" showTimeFilter={false} />
+    );
+    await waitFor(() => expect(mocks.queryOptions?.enabled).toBe(true));
+
+    expect(timeTrigger()).toBeNull();
+    expect(await requestedUrl()).not.toContain('time=');
+  });
+});
+
 describe('EntityFeed Explore type filter', () => {
   it('omits the type parameter and does not persist before the user changes the default selection', async () => {
     render(<EntityFeed apiEndpoint="/api/explore/feed" initialSpaceOptions={[]} showSortFilter showTypeFilter />);
@@ -149,6 +270,8 @@ describe('EntityFeed Explore type filter', () => {
   it('preserves the historical query key for feeds without the Explore type filter', () => {
     render(<EntityFeed apiEndpoint="/api/activity/feed" lockedSpaceId="space-id" />);
 
-    expect(mocks.queryOptions?.queryKey).toEqual(['/api/activity/feed', 'new', 'week', 'space-id', null]);
+    // The time slot is empty rather than 'week': this feed sorts by New, which carries no range,
+    // so there is nothing to send and nothing to key on. Same positions otherwise.
+    expect(mocks.queryOptions?.queryKey).toEqual(['/api/activity/feed', 'new', undefined, 'space-id', null]);
   });
 });

--- a/apps/web/partials/feed/entity-feed.tsx
+++ b/apps/web/partials/feed/entity-feed.tsx
@@ -244,7 +244,7 @@ export function EntityFeed({
               trigger={
                 <button
                   type="button"
-                  aria-label="Sort"
+                  aria-label={`Sort: ${sortLabel}`}
                   className="flex h-6 items-center gap-1.5 rounded border border-grey-02 pr-2 pl-1.5 text-metadata text-grey-04 shadow-button transition-colors duration-150 focus-within:border-text"
                 >
                   <span>{sortLabel}</span>
@@ -278,7 +278,7 @@ export function EntityFeed({
               trigger={
                 <button
                   type="button"
-                  aria-label="Time range"
+                  aria-label={`Time range: ${timeLabel}`}
                   className="flex h-6 items-center gap-1.5 rounded border border-grey-02 pr-2 pl-1.5 text-metadata text-grey-04 shadow-button transition-colors duration-150 focus-within:border-text"
                 >
                   <span>{timeLabel}</span>

--- a/apps/web/partials/feed/entity-feed.tsx
+++ b/apps/web/partials/feed/entity-feed.tsx
@@ -41,6 +41,16 @@ const SORT_OPTIONS: { value: ExploreSort; label: string }[] = [
   { value: 'top', label: 'Top' },
 ];
 
+/**
+ * The sorts a time range applies to.
+ *
+ * "Top" is the only one that asks "of when?" — it ranks by score, so the window is what makes the
+ * answer mean anything. "Best" is ranked server-side and "New" is ordered by recency already, so a
+ * window over either is a filter the viewer never asked for and can't see they have. The dropdown
+ * is hidden for those, and the range leaves the request with it.
+ */
+const SORTS_WITH_TIME_RANGE: readonly ExploreSort[] = ['top'];
+
 const TIME_OPTIONS: { value: ExploreTime; label: string }[] = [
   { value: 'today', label: 'Today' },
   { value: 'week', label: 'This week' },
@@ -78,7 +88,8 @@ async function fetchFeedPage(
   apiEndpoint: string,
   params: {
     sort: ExploreSort;
-    time: ExploreTime;
+    /** Omitted when the feed's sort has no time range. */
+    time: ExploreTime | undefined;
     spaceId: string;
     typeIds: readonly string[] | undefined;
     cursor: string | undefined;
@@ -86,7 +97,9 @@ async function fetchFeedPage(
 ): Promise<ExploreFeedResult> {
   const sp = new URLSearchParams();
   sp.set('sort', params.sort);
-  sp.set('time', params.time);
+  // Absent means "no time filter" — see the route's parseTime. Sending nothing is what keeps a
+  // hidden range out of the feed it isn't shown for.
+  if (params.time !== undefined) sp.set('time', params.time);
   sp.set('spaceId', params.spaceId);
   if (params.typeIds !== undefined) sp.set('typeIds', params.typeIds.join(','));
   if (params.cursor) sp.set('cursor', params.cursor);
@@ -126,7 +139,12 @@ export function EntityFeed({
   const typeIds =
     showTypeFilter && selectedTypeIds.length !== EXPLORE_ENTITY_TYPE_IDS.length ? selectedTypeIds : undefined;
   const typeIdsKey = typeIds?.join(',') ?? null;
-  const showFilterRow = showSortFilter || showTimeFilter || lockedSpaceId == null || showTypeFilter;
+  // One condition behind both the dropdown and the request, so what the viewer can see and what
+  // the feed is filtered by cannot drift apart. `time` state is left alone while hidden, so
+  // returning to Top restores the range the viewer last picked rather than resetting it.
+  const timeRangeApplies = showTimeFilter && SORTS_WITH_TIME_RANGE.includes(sort);
+  const requestedTime = timeRangeApplies ? time : undefined;
+  const showFilterRow = showSortFilter || timeRangeApplies || lockedSpaceId == null || showTypeFilter;
 
   React.useEffect(() => {
     if (!showTypeFilter) return;
@@ -158,14 +176,22 @@ export function EntityFeed({
   // sign-in and leave "Join space" buttons stuck for a few seconds.
   const { smartAccount } = useSmartAccount();
   const smartAccountAddress = smartAccount?.account.address ?? null;
+  // Keyed on what is actually sent: two Best feeds differing only in a hidden range are the same
+  // request, and caching them apart would refetch on a change the viewer never made.
   const queryKey = showTypeFilter
-    ? [apiEndpoint, sort, time, spaceId, typeIdsKey, smartAccountAddress]
-    : [apiEndpoint, sort, time, spaceId, smartAccountAddress];
+    ? [apiEndpoint, sort, requestedTime, spaceId, typeIdsKey, smartAccountAddress]
+    : [apiEndpoint, sort, requestedTime, spaceId, smartAccountAddress];
 
   const { data, isLoading, isFetchingNextPage, fetchNextPage, hasNextPage, error } = useInfiniteQuery({
     queryKey,
     queryFn: ({ pageParam }) =>
-      fetchFeedPage(apiEndpoint, { sort, time, spaceId, typeIds, cursor: pageParam as string | undefined }),
+      fetchFeedPage(apiEndpoint, {
+        sort,
+        time: requestedTime,
+        spaceId,
+        typeIds,
+        cursor: pageParam as string | undefined,
+      }),
     initialPageParam: undefined as string | undefined,
     getNextPageParam: last => last.nextCursor ?? undefined,
     retry: 2,
@@ -218,6 +244,7 @@ export function EntityFeed({
               trigger={
                 <button
                   type="button"
+                  aria-label="Sort"
                   className="flex h-6 items-center gap-1.5 rounded border border-grey-02 pr-2 pl-1.5 text-metadata text-grey-04 shadow-button transition-colors duration-150 focus-within:border-text"
                 >
                   <span>{sortLabel}</span>
@@ -241,7 +268,7 @@ export function EntityFeed({
               ))}
             </Menu>
           ) : null}
-          {showTimeFilter ? (
+          {timeRangeApplies ? (
             <Menu
               asChild
               open={timeMenuOpen}
@@ -251,6 +278,7 @@ export function EntityFeed({
               trigger={
                 <button
                   type="button"
+                  aria-label="Time range"
                   className="flex h-6 items-center gap-1.5 rounded border border-grey-02 pr-2 pl-1.5 text-metadata text-grey-04 shadow-button transition-colors duration-150 focus-within:border-text"
                 >
                   <span>{timeLabel}</span>


### PR DESCRIPTION
Closes GEO-2610.

## What

The Explore time range (Today / This week / Last month / …) now renders only when **Top** is selected, and when it isn't shown it doesn't reach the query either — the `time` parameter leaves the request entirely, per the ticket's Answer.

| Sort | Dropdown | `time` sent |
|---|---|---|
| Top | shown | yes |
| Best | hidden | no |
| New | hidden | no |

## Why it mattered more than a stray control

Explore opens on **Best** with `initialTime="month"`. So the first feed anyone saw had been quietly cut to the last thirty days — a filter that was being applied through a control with no bearing on the sort sitting next to it. Hiding the dropdown without dropping the parameter would have left that cut in place invisibly, which is why the ticket calls out the query specifically.

## How

One condition drives both the dropdown and the request, so what the viewer can see and what the feed is filtered by can't drift apart:

```ts
const timeRangeApplies = showTimeFilter && SORTS_WITH_TIME_RANGE.includes(sort);
const requestedTime = timeRangeApplies ? time : undefined;
```

The query key uses `requestedTime` too — two Best feeds differing only in a hidden range are the same request, and keying them apart would refetch on a change the viewer never made.

**On the ticket's open question:** the `time` state is left alone while hidden, so returning to Top restores the range last picked rather than resetting it. Only whether it's *consulted* changes.

## The one change beyond the ticket

An absent `time` now means "no filter" in **both** feed routes (`parseTime` returns `'all'` instead of `'week'`). Without it the server would reinstate exactly the window the client just omitted. Worth a look since it's a server-side default flip:

- Nothing sends a request without `time` today, so no current caller changes.
- The activity feed is unchanged in effect — it sent `time=all` before and sends nothing now, which reads identically.
- An unrecognised value takes the same path, which I'd argue is also better: a range nobody can name isn't one to guess at.

One consequence to be aware of: a feed rendered with bare defaults (`showTimeFilter` true, sort `new`) no longer sends `week`. That case had a test pinning the old key; it's updated with a comment rather than worked around, since it's the rule change doing exactly what it says.

Also gave the sort and time triggers accessible names. They announced only their current value — "Best", "Last month" — which says what is selected but never what it selects.

## Testing

- 8 new cases in `entity-feed.test.tsx`: hidden for Best and New, shown for Top, hidden again on leaving Top, absent from the request when hidden, present when Top shows it, the range restored on return to Top, the query key keyed on what's actually sent, and the opted-out activity feed unaffected.
- Verified non-vacuous: with the gate reverted, 8 cases fail — including the pre-existing query-key test.
- `bun run vitest run core partials app` → 267 files / 2741 tests pass.
- `NEXT_PUBLIC_CHAIN_ID=55516 bun run build` → clean.

Not verified in a running browser — worth confirming Best now returns results older than a month, which is the user-visible half of this.