### PR TITLE
fix(community-calls): refuse to write a call with an empty schedule

### DIFF
--- a/apps/web/core/community-calls/call-ops.test.ts
+++ b/apps/web/core/community-calls/call-ops.test.ts
@@ -11,7 +11,7 @@ import {
   buildPublishRecordingsOps,
   buildUpdateCallOps,
 } from './call-ops';
-import { EVENT_SCHEMA } from './constants';
+import { CALL_SCHEMA, EVENT_SCHEMA } from './constants';
 
 function fakeBlockRelation(id: string): Relation {
   return {
@@ -55,6 +55,52 @@ describe('buildCreateCallOps', () => {
     });
 
     expect(relations.filter(r => r.type.id === SystemIds.BLOCKS)).toHaveLength(0);
+  });
+});
+
+/**
+ * The bug this closes: a Meeting Time value stored as the empty string
+ * (`65587cf0adea4ea8b5c2c8b3c39cc87f`). Both readers expand a call into occurrences and
+ * drop anything yielding none, so an empty schedule does not degrade the call — it deletes
+ * it from every view while leaving the entity in the graph, with no feedback to the author.
+ */
+describe('empty schedules are refused rather than written', () => {
+  const fields = {
+    spaceId: 'space-1',
+    name: 'Test community call',
+    description: 'Test description',
+    autoPublishAhead: 0,
+  };
+
+  it.each(['', '   ', '\n'])('create refuses schedule %j', schedule => {
+    expect(() => buildCreateCallOps({ ...fields, schedule })).toThrow(/empty schedule/i);
+  });
+
+  // The path that actually produced the bad row: create only writes autoPublishAhead when
+  // it is > 0, and the broken call had one at 0 — so it had been through an edit.
+  it.each(['', '   '])('update refuses schedule %j', schedule => {
+    expect(() => buildUpdateCallOps({ ...fields, schedule, entityId: 'call-1' })).toThrow(/empty schedule/i);
+  });
+
+  // Refused, not unset. Every other optional field here unsets when empty, and for the
+  // schedule that would be equally invisible — so neither is acceptable.
+  it('does not fall back to unsetting the meeting time', () => {
+    let captured: unknown = null;
+    try {
+      buildUpdateCallOps({ ...fields, schedule: '', entityId: 'call-1' });
+    } catch (error) {
+      captured = error;
+    }
+    expect(captured).toBeInstanceOf(Error);
+  });
+
+  it('still accepts a real schedule', () => {
+    const { values } = buildCreateCallOps({
+      ...fields,
+      schedule: 'DTSTART;TZID=Europe/Vilnius:20260821T220000\nDTEND;TZID=Europe/Vilnius:20260821T230000',
+    });
+    const meeting = values.find(v => v.property.id === CALL_SCHEMA.MEETING_TIME_PROPERTY);
+    expect(meeting?.value).toContain('DTSTART');
   });
 });
 

--- a/apps/web/core/community-calls/call-ops.ts
+++ b/apps/web/core/community-calls/call-ops.ts
@@ -51,6 +51,32 @@ function buildValue({
   };
 }
 
+/**
+ * A community call without a schedule cannot be shown anywhere.
+ *
+ * Both readers expand a call into occurrences and drop anything that yields none —
+ * `fetchCommunityCalls` bails on a falsy schedule outright, and the curator app filters on
+ * `occurrence.end`. So writing an empty Meeting Time does not produce a call with a missing
+ * time; it produces a call that has silently vanished, with the entity still in the graph
+ * and no feedback to whoever saved it. That is what happened to
+ * `65587cf0adea4ea8b5c2c8b3c39cc87f`: a Meeting Time value stored as the empty string.
+ *
+ * Every other optional field here unsets when empty rather than writing blank (see
+ * `buildUpdateCallOps`'s doc). The schedule cannot take that route either — an unset is
+ * equally invisible — so it is neither written nor unset: it is refused.
+ *
+ * A throw rather than a silent skip because the form already validates this
+ * (`validateSchedule` rejects an empty schedule), so reaching here means a caller bypassed
+ * validation. That is a bug worth surfacing, not one worth absorbing.
+ */
+function assertScheduleWritable(schedule: string): void {
+  if (!schedule.trim()) {
+    throw new Error(
+      'Refusing to write a community call with an empty schedule: the call would exist in the graph but be invisible in every view.'
+    );
+  }
+}
+
 /** An `isDeleted` Value becomes an `unset: [{property, language: 'all'}]` op on publish. */
 function buildUnsetValue(args: {
   entityRef: { id: string; name: string | null };
@@ -223,6 +249,8 @@ export function buildCreateCallOps({ spaceId, name, description, schedule, autoP
   values: Value[];
   relations: Relation[];
 } {
+  assertScheduleWritable(schedule);
+
   const entityId = createEntityId();
   const entityRef = { id: entityId, name };
 
@@ -314,6 +342,8 @@ export function buildUpdateCallOps({
   autoPublishAhead,
   existingBlockRelations = [],
 }: CallFields & { entityId: string; existingBlockRelations?: Relation[] }): { values: Value[]; relations: Relation[] } {
+  assertScheduleWritable(schedule);
+
   const entityRef = { id: entityId, name };
 
   const values: Value[] = [

--- a/apps/web/core/community-calls/fetch-community-calls.ts
+++ b/apps/web/core/community-calls/fetch-community-calls.ts
@@ -29,7 +29,14 @@ export const fetchCommunityCalls = cache(async (spaceId: string): Promise<CallSe
 
   return page.entities.flatMap(entity => {
     const schedule = entity.values.find(v => v.property.id === CALL_SCHEMA.MEETING_TIME_PROPERTY)?.value;
-    if (!schedule) return [];
+    if (!schedule) {
+      // A call with no usable schedule cannot be placed on a timeline, so it has to come out
+      // of the list — but dropping it silently is how one stayed invisible with nobody able
+      // to say why. `call-ops` now refuses to write this state; the log is for the rows that
+      // already carry it.
+      console.warn('[community-calls] skipping call with no meeting time', { entityId: entity.id });
+      return [];
+    }
 
     return [
       {


### PR DESCRIPTION
Dovile reported a community call created in the browser that's invisible on the space page and in the app.

## Root cause, confirmed against live data

Its Meeting Time value is stored as the **empty string** — not null, empty:

```
Name                schedule=NULL          text="Test community call"
Auto publish ahead  schedule=NULL          integer=0
Meeting Time        schedule=EMPTY STRING  text=NULL
Description         schedule=NULL          text="Test description"
```

And both readers drop a call with no usable schedule:

- `fetch-community-calls.ts:32` — `if (!schedule) return []`
- the curator app expands occurrences and filters on `occurrence.end`, so no schedule means no occurrences

So an empty schedule doesn't degrade the call, it **deletes it from every view** while leaving the entity in the graph, with no feedback to the author. That's the whole of her report.

## The fix

`call-ops` already has the right principle — its own doc says *"An empty `description` or a zero `autoPublishAhead` unsets that property rather than writing an empty value."* The schedule was the one field exempt from it, and the one where blank is fatal.

It can't take the unset route either (an unset is equally invisible), so it's **refused**: `assertScheduleWritable` throws on both the create and update paths. A throw rather than a silent skip because `validateSchedule` already rejects empty in the form, so reaching the builder means validation was bypassed — worth surfacing, not absorbing.

Reader side now logs what it drops. Dropping is still correct — nothing can place these on a timeline — but doing it silently is how this one stayed invisible with nobody able to say why.

## What I could not determine

**How an empty schedule got past the form.** The evidence says it came through the *update* path — create only writes `autoPublishAhead` when `> 0`, and the broken call carries one at `0`, so it had been edited. But `validateSchedule` rejects empty unconditionally and has since March (#1574), and there's only one create/edit form. So either the form has a second bug or something bypassed it.

This PR is therefore the guard at the write boundary, not a fix for whatever produced the value. If the form is also at fault that's a second bug, and this doesn't substitute for it — but it does mean the next occurrence fails loudly instead of silently eating a call.

## Verification

- 41 tests pass across `core/community-calls` and `partials/community-calls`.
- `tsc --noEmit`: 7 errors, identical to the `master` baseline (all pre-existing, `sort-open-proposals.test.ts` and the auth-account family).
- eslint and prettier clean.
- **Mutation-tested:** removing the create guard, removing the update guard, and narrowing the check to `length === 0` (so whitespace-only slips through) each fail. Whitespace matters — `serializeSchedule` returning `"\n"` would otherwise pass.

## Her other four reports — not in this PR

| report | finding |
|---|---|
| "asked for time in UTC, call is local (GMT+3)" | **Can't reproduce from code.** Both the browser form and the curator app read `Intl.DateTimeFormat().resolvedOptions().timeZone`, and her other call stored `TZID=Europe/Vilnius` correctly. So the stored data is right and this is likely a UI label — needs a screenshot of the field to place it. |
| Neither call visible in the app | Call 1 is explained above. **Call 2 is not.** I thought it might be excluded as in-progress (it started 19:00Z and ends 20:00Z today), but the active branch keeps anything with `occurrence.end > now`, so it should appear. Still open. |
| Call recording unavailable | not investigated |
| Text unreadable / no avatar / agent bubble over chat button | not investigated; needs a screenshot |