### PR TITLE
fix(debates): stop the rematch picker emptying its curated and opponent tabs

### DIFF
--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
@@ -1023,29 +1023,46 @@ describe('DebateRematchPageClient', () => {
     await waitFor(() => expect(screen.queryByText('A newly published claim')).toBeNull());
   });
 
-  // Applied to the pool, not to the All tab alone, so the tab a viewer lands on describes the same
-  // set of claims as every other one.
-  it('drops disallowed claims from the opponent tab too', async () => {
+  // Applied to the All tab alone. The opponent's tab is bounded by one person's own responses, and
+  // a debater's claims live in their personal space, which nobody else is a member of — narrowing
+  // it by the viewer's own memberships emptied the tab, and zeroed its count, for everyone but the
+  // debater who published the claims.
+  it('keeps the opponent’s claims from spaces outside the viewer’s allowed set', () => {
     mocks.claims = [sharedClaim()];
     mocks.spaceAllowlist = new Set([SPACE_2.replace(/-/g, '')]);
     render(<DebateRematchPageClient sessionId="rematch-1" />);
 
-    await waitFor(() => expect(screen.queryByText('A claim both participants chose')).toBeNull());
-    // The count follows the same pool, so it can't advertise a position the tab no longer lists.
+    expect(screen.getByText('A claim both participants chose')).toBeInTheDocument();
     const tab = screen.getByRole('button', { name: /Salina’s positions/ });
-    expect(within(tab).getByText('0')).toBeInTheDocument();
+    expect(within(tab).getByText('1')).toBeInTheDocument();
+  });
+
+  // Same reasoning, and the case that made it visible: a curator's page is trusted by the space it
+  // was published in, so the claims on it are vouched for wherever they live. The other debater
+  // saw the tab with nothing under it.
+  it('keeps curated claims from spaces outside the viewer’s allowed set', async () => {
+    mocks.recommendedSections = [{ id: 'block-1', name: 'Politics', claimIds: [CLAIM_MORE] }];
+    mocks.recommendedEntities = [publishedEntity()];
+    mocks.curatedIds = [CLAIM_MORE];
+    mocks.spaceAllowlist = new Set([SPACE_1.replace(/-/g, '')]);
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+
+    // The published claim sits in Governance space, which the allowlist leaves out.
+    expect(await screen.findByText('A newly published claim')).toBeInTheDocument();
+    expect(screen.getByText('Politics')).toBeInTheDocument();
   });
 
   // Listing a pool and trimming it once the allowlist lands means claims appear and then vanish
-  // under the viewer. Every list waits; the count waits with it, so the tab can't advertise a
-  // position it is about to drop.
-  it('holds every list, and the count, while the allowlist is still resolving', async () => {
+  // under the viewer. The All tab, which the allowlist narrows, waits for it. The other two don't
+  // narrow on it any more, so they have nothing to wait for — and the opponent's list arriving in
+  // one round trip is the whole point of not holding it behind a lookup it doesn't use.
+  it('holds the browsed list, but not the opponent’s, while the allowlist is still resolving', async () => {
     mocks.spaceAllowlist = null;
     mocks.allowlistLoading = true;
     render(<DebateRematchPageClient sessionId="rematch-1" />);
 
-    expect(screen.queryByText('A claim both participants chose')).toBeNull();
-    expect(within(screen.getByRole('button', { name: /Salina’s positions/ })).getByText('0')).toBeInTheDocument();
+    expect(screen.getByText('A claim both participants chose')).toBeInTheDocument();
+    expect(within(screen.getByRole('button', { name: /Salina’s positions/ })).getByText('1')).toBeInTheDocument();
 
     showAllClaims();
     await waitFor(() => expect(screen.queryByText('A newly published claim')).toBeNull());
@@ -1168,15 +1185,21 @@ describe('DebateRematchPageClient', () => {
     // The per-space lookup used to be what retained the gateway's space scopes, and
     // `debate.claims_changed` is delivered per space: skip the lookup without keeping the scopes
     // and the opponent's responses only ever show up after a reconnect.
-    it('still holds a gateway scope on every space it shows', () => {
+    //
+    // Every list's spaces, not the visible tab's — keyed on the tab, switching tabs dropped the
+    // scopes the other lists depend on — plus both participants' personal spaces, which is where a
+    // debater's own claims live and the only way to hear about their *first* position: the tab is
+    // empty then, so there is no claim to derive a scope from.
+    it('holds a gateway scope on every list’s spaces and both debaters’ own', () => {
       mocks.claims = [{ ...sharedClaim(), viewer_debate_ready: true, readiness_disabled_reason: null }];
       mocks.claimReadiness = [];
 
       render(<DebateRematchPageClient sessionId="rematch-1" />);
-      expect(mocks.gatewaySpaceScopes.filter(scope => scope.enabled).at(-1)?.spaceIds).toEqual([SPACE_1]);
+      const scoped = () => mocks.gatewaySpaceScopes.filter(scope => scope.enabled).at(-1)?.spaceIds;
+      expect(scoped()).toEqual([SPACE_1, SPACE_2, 'profile-local', 'profile-remote']);
 
       showAllClaims();
-      expect(mocks.gatewaySpaceScopes.filter(scope => scope.enabled).at(-1)?.spaceIds).toEqual([SPACE_1, SPACE_2]);
+      expect(scoped()).toEqual([SPACE_1, SPACE_2, 'profile-local', 'profile-remote']);
     });
 
     it('shows the toggle off for a claim it reports as not ready', () => {

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -166,9 +166,16 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
     [recommendedSections]
   );
 
-  // Featured spaces plus the ones the viewer belongs to. Applied to the whole pool rather than to
-  // the All tab alone, so every tab, the space menu and the opponent-position count all describe
-  // the same set of claims.
+  // Featured spaces plus the ones the viewer belongs to. It narrows the All tab, which browses the
+  // whole published corpus and would otherwise offer claims from spaces the viewer has nothing to do
+  // with.
+  //
+  // The other two tabs are deliberately outside it. Each is bounded by an explicit source — one
+  // person's own responses, or one page from a curator space this build trusts by id — so neither
+  // can fan out the way browsing can, and the viewer's *own* space membership says nothing about
+  // whether the source is worth showing. Applying it there emptied both tabs in the ordinary case:
+  // a debater's claims live in their personal space, which nobody else is a member of, so the
+  // opponent's positions and a curator's page were dropped wholesale on the other side.
   const { allowlist: spaceAllowlist, isLoading: allowlistLoading } = useClaimSpaceAllowlist();
 
   // While it is still resolving there is no telling an allowed space from one the viewer has
@@ -305,9 +312,10 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
     return map;
   }, [browsedPages, opponentEntitiesQuery.entities, recommendedEntities]);
 
-  // The opponent's tab: every claim they hold a side on, newest first. Held until the allowlist
-  // and the session's exclusions are in, so nothing lists and then vanishes.
-  const opponentClaimsSettling = allowlistPending || opponentClaimsQuery.isLoading || opponentEntitiesQuery.isLoading;
+  // The opponent's tab: every claim they hold a side on, newest first. Held until the session's
+  // exclusions are in, so nothing lists and then vanishes. Not narrowed by the space allowlist —
+  // see it above.
+  const opponentClaimsSettling = opponentClaimsQuery.isLoading || opponentEntitiesQuery.isLoading;
   const opponentClaimsNow = React.useMemo(() => {
     if (opponentClaimsSettling) return [];
     const entitiesById = new Map(opponentEntitiesQuery.entities.map(entity => [entity.id, entity]));
@@ -319,9 +327,7 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
       if (row && row.participants.some(side => side.user_id !== currentUserId && side.position !== null))
         rows.push(row);
     }
-    return rows
-      .filter(row => isClaimSpaceAllowed(row.claim.space_id, spaceAllowlist))
-      .sort((a, b) => Number(b.shared_preference) - Number(a.shared_preference));
+    return rows.sort((a, b) => Number(b.shared_preference) - Number(a.shared_preference));
   }, [
     currentUserId,
     excludedClaimIds,
@@ -329,15 +335,15 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
     opponentClaimsSettling,
     opponentEntitiesQuery.entities,
     rowFromEntity,
-    spaceAllowlist,
   ]);
   // A new response from the opponent adds an id, and the lookups keyed on the id list start over.
   // The list they were drawn from is still right for every claim already on it, so it stays up
   // until the new one lands rather than dropping to nothing in between.
   const opponentClaims = useLastSettled(opponentClaimsNow, opponentClaimsSettling);
 
-  // The curated tab, in the curator's order. Held the same way.
-  const curatedClaimsSettling = allowlistPending || curatedClaimsQuery.isLoading;
+  // The curated tab, in the curator's order. Held the same way, and likewise not narrowed by the
+  // space allowlist.
+  const curatedClaimsSettling = curatedClaimsQuery.isLoading;
   const curatedClaimsNow = React.useMemo(
     () =>
       curatedClaimsSettling
@@ -346,9 +352,9 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
             if (excludedClaimIds.has(claimId)) return [];
             const entity = recommendedEntities.find(candidate => candidate.id === claimId);
             const row = entity ? rowFromEntity(entity) : null;
-            return row && isClaimSpaceAllowed(row.claim.space_id, spaceAllowlist) ? [row] : [];
+            return row ? [row] : [];
           }),
-    [curatedClaimsSettling, excludedClaimIds, recommendedClaimIds, recommendedEntities, rowFromEntity, spaceAllowlist]
+    [curatedClaimsSettling, excludedClaimIds, recommendedClaimIds, recommendedEntities, rowFromEntity]
   );
   const curatedClaims = useLastSettled(curatedClaimsNow, curatedClaimsSettling);
 
@@ -516,11 +522,10 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
     fetchNextPage: browsedClaimsQuery.fetchNextPage,
   });
 
-  // Each tab draws from a different set of queries, so each waits on its own — and on the
-  // allowlist, which narrows all of them.
+  // Each tab draws from a different set of queries, so each waits on its own. The allowlist narrows
+  // the All tab alone now, so only that one waits for it.
   const tabIsLoading =
     sessionQuery.isLoading ||
-    allowlistPending ||
     (tab === 'recommended'
       ? recommendedLoading || curatedClaimsQuery.isLoading
       : tab === 'opponent'
@@ -528,7 +533,7 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
           opponentEntitiesQuery.isLoading ||
           opponentClaimsQuery.isLoading ||
           (landedTabRef.current === null && claims.length === 0 && recommendedLoading)
-        : browsedClaimsQuery.isLoading);
+        : allowlistPending || browsedClaimsQuery.isLoading);
 
   const tabError =
     sessionQuery.error ??
@@ -560,6 +565,25 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
       }))
       .filter(section => section.claims.length > 0);
   }, [recommendedSections, tab, visibleClaims]);
+
+  // `debate.claims_changed` is delivered per space, and it is what turns the opponent's new
+  // response into a refresh of this page rather than something the poll finds up to twenty seconds
+  // later. So hold a scope on every space the picker could see one land in:
+  //
+  // - every space any of the three lists shows, not just the tab in front of the viewer. Keyed on
+  //   the visible tab alone, switching tabs dropped the scopes the other lists depend on.
+  // - both participants' personal spaces, whether or not a claim from them is listed yet. A
+  //   debater's own claims live there, and the tab starts empty precisely in the case this is
+  //   about — the opponent taking their *first* position — so there would be no claim to derive the
+  //   scope from at the moment it matters.
+  const { authenticated: geoChatAuthenticated } = useGeoChatAuth();
+  const scopedSpaceIds = React.useMemo(() => {
+    const ids = new Set<string>();
+    for (const claim of [...opponentClaims, ...curatedClaims, ...browsedClaims]) ids.add(claim.claim.space_id);
+    for (const participant of participants) ids.add(participant.profile_space_id);
+    return [...ids].sort((a, b) => a.localeCompare(b));
+  }, [browsedClaims, curatedClaims, opponentClaims, participants]);
+  useDebateGatewaySpaceScopes(scopedSpaceIds, geoChatAuthenticated && scopedSpaceIds.length > 0);
 
   // Readiness drives the card's Debate toggle. geo-chat now carries it on the rematch claims
   // response itself; the per-space debate-claims endpoint is the fallback for a backend that
@@ -809,15 +833,6 @@ function useClaimReadinessByClaimId({
   /** True while the lookup these rows' readiness comes from is still running or has failed. */
   unresolved: boolean;
 }) {
-  // `debate.claims_changed` is delivered per space, so the picker has to hold a scope on every
-  // space it shows or the opponent's responses only appear after a reconnect.
-  const { authenticated } = useGeoChatAuth();
-  const spaceIds = React.useMemo(
-    () => [...new Set(claims.map(claim => claim.claim.space_id))].sort((a, b) => a.localeCompare(b)),
-    [claims]
-  );
-  useDebateGatewaySpaceScopes(spaceIds, authenticated && spaceIds.length > 0);
-
   // Only the rows that don't carry readiness go to the per-space endpoint. While a source is still
   // loading its rows haven't arrived, so there is nothing to ask about yet — which is what stops a
   // guess from spending the very requests this exists to save.

--- a/apps/web/core/debates/recommended-claims.test.tsx
+++ b/apps/web/core/debates/recommended-claims.test.tsx
@@ -23,20 +23,33 @@ const mocks = vi.hoisted(() => ({
   blocks: [] as unknown[],
   items: [] as unknown[],
   loading: false,
+  itemsLoading: false,
   wheres: [] as Array<Record<string, unknown>>,
+  itemIdLookups: [] as string[][],
 }));
 
-// Three stages: pages by type, the blocks they point at, then the blocks' collection items. The
-// two id lookups are told apart by which ids they ask for.
+// The first two stages: pages by type, then the blocks they point at.
 vi.mock('~/core/sync/use-store', () => ({
   useQueryEntities: ({ where }: { where: Record<string, unknown> }) => {
     mocks.wheres.push(where);
     if ('types' in where) return { entities: mocks.pages, isLoading: mocks.loading };
     const ids = (where.id as { in?: string[] } | undefined)?.in ?? [];
-    const blocks = (mocks.blocks as Array<{ id: string }>).filter(block => ids.includes(block.id));
+    return { entities: (mocks.blocks as Array<{ id: string }>).filter(block => ids.includes(block.id)) };
+  },
+}));
+
+// The third: the blocks' collection items, through the picker's batched claim lookup. That lookup
+// asks the graph for claims specifically and batches the ids, so it answers with the claims among
+// the ids it was given and nothing else — which is what the mock reproduces.
+vi.mock('./claim-picker-page', () => ({
+  useClaimEntitiesByIds: (ids: string[]) => {
+    mocks.itemIdLookups.push(ids);
     return {
-      entities:
-        blocks.length > 0 ? blocks : (mocks.items as Array<{ id: string }>).filter(item => ids.includes(item.id)),
+      entities: (mocks.items as Array<{ id: string; types: Array<{ id: string }> }>).filter(
+        item => ids.includes(item.id) && item.types.some(type => type.id === CLAIM_TYPE_ID)
+      ),
+      isLoading: mocks.itemsLoading,
+      error: null,
     };
   },
 }));
@@ -92,7 +105,9 @@ beforeEach(() => {
   mocks.blocks = [block('block-1', 'Geopolitics & chips', ['claim-a', 'claim-b'])];
   mocks.items = [claimEntity('claim-a'), claimEntity('claim-b')];
   mocks.loading = false;
+  mocks.itemsLoading = false;
   mocks.wheres.length = 0;
+  mocks.itemIdLookups.length = 0;
 });
 
 describe('useRecommendedClaimSections', () => {
@@ -189,6 +204,30 @@ describe('useRecommendedClaimSections', () => {
       '8a4955bcd9d0fc0d8613f17f01de3b9f',
       CURATOR_SPACE,
     ]);
+  });
+
+  // The items used to be asked for as one page capped at a hundred ids, and the cap fell across
+  // every block at once: a page of six collections holding a hundred and forty claims resolved the
+  // first hundred in block order, so the last block's claims were all missing and its section was
+  // dropped as empty. Every collected id has to reach the lookup, which batches them itself.
+  it('asks for every collected item id, however many blocks there are', () => {
+    const claimIds = Array.from({ length: 140 }, (_, index) => `claim-${index}`);
+    // Positions sort as strings, so pad them — otherwise `a10` lands between `a1` and `a2` and the
+    // fixture, not the hook, decides the order.
+    const positions = claimIds.map((_, index) => `a${String(index).padStart(3, '0')}`);
+    mocks.blocks = [
+      block('block-1', 'Politics', claimIds.slice(0, 120), positions.slice(0, 120)),
+      block('block-2', 'Current affairs', claimIds.slice(120), positions.slice(120)),
+    ];
+    mocks.pages = [page({ blockIds: ['block-1', 'block-2'] })];
+    mocks.items = claimIds.map(claimEntity);
+
+    const { result } = renderHook(() => useRecommendedClaimSections([ME, OPPONENT]));
+
+    expect(mocks.itemIdLookups.at(-1)).toEqual(claimIds);
+    // The last block is the one a shared cap reaches first, so assert it by name and in full.
+    expect(result.current.sections.map(section => section.name)).toEqual(['Politics', 'Current affairs']);
+    expect(result.current.sections[1]!.claimIds).toEqual(claimIds.slice(120));
   });
 
   it('reports that it is still looking rather than that nothing is recommended', () => {

--- a/apps/web/core/debates/recommended-claims.ts
+++ b/apps/web/core/debates/recommended-claims.ts
@@ -4,10 +4,10 @@ import { SystemIds } from '@geoprotocol/geo-sdk';
 
 import * as React from 'react';
 
-import { CLAIM_TYPE_ID } from '~/core/claims/ontology';
 import { ID } from '~/core/id';
 import { useQueryEntities } from '~/core/sync/use-store';
-import type { Entity } from '~/core/types';
+
+import { type ClaimPickerEntity, useClaimEntitiesByIds } from './claim-picker-page';
 
 /** A curated "Recommended claims" page: claims a curator has picked out for a specific pairing. */
 export const RECOMMENDED_CLAIMS_TYPE_ID = '2f8a7be40c5242368bac78511bf0b47f';
@@ -46,7 +46,7 @@ export type RecommendedClaimSection = {
 export function useRecommendedClaimSections(participantSpaceIds: string[]): {
   sections: RecommendedClaimSection[];
   /** The claims themselves, so callers don't fetch what this already resolved. */
-  claimEntities: Entity[];
+  claimEntities: ClaimPickerEntity[];
   /**
    * True until every stage has settled. Empty sections mean "nothing recommended" only once this
    * is false — before then they only mean "still looking", and a caller that can't tell the two
@@ -120,20 +120,17 @@ export function useRecommendedClaimSections(participantSpaceIds: string[]): {
 
   const itemIds = React.useMemo(() => [...new Set(itemIdsByBlock.flatMap(block => block.itemIds))], [itemIdsByBlock]);
 
-  const { entities: items, isLoading: itemsLoading } = useQueryEntities({
-    where: { id: { in: itemIds } },
-    first: 100,
-    enabled: itemIds.length > 0,
-  });
-
-  const claimEntities = React.useMemo(
-    () => items.filter(item => item.types.some(type => ID.equals(type.id, CLAIM_TYPE_ID))),
-    [items]
-  );
+  // Batched by the picker's own lookup rather than asked for in one `first`-bounded page. A page is
+  // capped at a hundred ids, and the cap fell across the *whole* set rather than per block: a page
+  // of six collections holding a hundred and forty claims resolved the first hundred in block order
+  // and silently dropped the rest, so the last block came back with no claims at all and its
+  // section was filtered out as empty — a curated group that simply never appeared.
+  const { entities: claimEntities, isLoading: itemsLoading } = useClaimEntitiesByIds(itemIds);
 
   const sections = React.useMemo(() => {
     // A collection can hold anything the curator dropped in it, but this tab feeds a claim picker:
-    // anything that isn't a claim has no side to take and no debate to request.
+    // anything that isn't a claim has no side to take and no debate to request. The lookup asks for
+    // claims specifically, so whatever it doesn't return isn't one.
     const claimIds = new Set(claimEntities.map(claim => claim.id));
 
     return (


### PR DESCRIPTION
Fixes [GEO-2637](https://linear.app/geobrowser/issue/GEO-2637/debate-again-flow-bugs). Three reports off the rematch picker; two of them turned out to be the same bug.

## The allowlist was applied to every tab (reports 1 and 2)

`useClaimSpaceAllowlist` is *featured spaces + the spaces the viewer belongs to*. It exists for the **All** tab, which browses the whole published corpus and would otherwise offer claims from spaces the viewer has nothing to do with. It was applied to the whole pool instead — and a debater's claims live in their **personal space**, which nobody else is a member of.

Checked against the curator page in the report (`123ed70f…`):

- all **136** curated claims live in `8a4955bc…`, Adam's personal space — `type: PERSONAL`, zero members, zero editors
- so it enters the allowlist only via `if (personalSpaceId) allowed.add(...)`

That makes it Adam's space and no one else's. The Recommended tab drew for him and rendered empty for Dovile — precisely the asymmetry reported. The same filter dropped every position he took on his own claims out of Dovile's *"Adam's positions"* tab and zeroed its count, which is what read as **"the tab isn't updating."**

The allowlist now narrows the All tab only. The other two tabs are each bounded by an explicit source — one person's own responses, or one page published in a curator space this build trusts by id — so neither can fan out the way browsing can, and the viewer's own memberships say nothing about whether the source is worth showing. They also no longer wait on a lookup they don't use.

## The live path had a second hole (report 1)

`debate.claims_changed` is delivered per space, and the picker retained a gateway scope only on the spaces of the tab **in front of the viewer**. Two consequences: switching tabs dropped the scopes the other lists depend on, and the opponent's *first* position could never arrive live — the tab is empty at that point, so there is no claim to derive a scope from.

Now scoped on every list's spaces plus both participants' personal spaces, where a debater's own claims live. The 20-second poll goes back to being the backstop it was meant to be.

Scope retention moved out of `useClaimReadinessByClaimId` (it was incidental there) and up into the page, where the union is available. It only ever *invalidates* keys with `refetchType: 'active'`, so the two extra profile-space scopes cost no requests — the picker mounts neither `['debates','claims',…]` nor `['debates','space',…]` for them.

## The missing section was its own bug (report 3)

The blocks' collection items were fetched as one page capped at 100 ids, with the cap falling across **all** blocks at once rather than per block. Measured against the live entity, in block order:

| Block | Claims | Actually resolved |
|---|---|---|
| AI | 31 | 31 |
| Relationships | 32 | 32 |
| Health | 21 | 21 |
| Politics | 43 | **21** |
| Current Affairs | 14 | **0** |

A block holding no claims is dropped rather than headed as an empty section — hence a curated group that simply never appeared, and Politics silently showing half of what the curator picked.

Routed through the picker's own `useClaimEntitiesByIds`, which batches the ids and asks the graph for claims specifically. That also drops the client-side type filter it makes redundant, and swaps a full-entity fetch for the narrow projection built to avoid exactly this cost.

## Verification

- `tsc` clean on all four files. Three errors remain in `sort-open-proposals.test.ts` and `use-entity-vote.ts` — pre-existing on master, untouched here.
- Lint clean (two warnings in the test file are pre-existing, on untouched lines).
- **858 tests / 60 files** green across `core/debates` and `app/space/[id]/(space)/debates`, re-run after rebasing onto current master.
- Two tests that encoded the old allowlist behaviour are replaced by ones asserting the opposite, with the reasoning; new regression test covers the item-fetch cap.

## Two things for review

1. **Needs a gateway-side check.** I verified the client now holds a scope on the participants' personal spaces, but not whether geo-chat actually *broadcasts* `claims_changed` to a subscriber who isn't a member of that space. If the server gates on membership too, report 1's live path needs a geo-chat change as well and the poll stays the only route. Worth confirming with whoever owns the gateway.
2. **Report 2's symptom is "the tab renders but draws nothing"**, not "the tab is absent" — the tab button isn't allowlist-gated, so it appears either way. If Dovile saw *no tab at all*, there is a third thing going on that this doesn't cover.
