### PR TITLE
fix(debates): stop the rematch picker offering claims no debate can be published on

### DIFF
--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
@@ -76,6 +76,7 @@ const mocks = vi.hoisted(() => ({
   currentUserId: 'user-local' as string | null,
   spaceAllowlist: null as Set<string> | null,
   allowlistLoading: false,
+  spaceTypes: {} as Record<string, 'DAO' | 'PERSONAL'>,
   scrollSentinelIntoView: null as null | (() => void),
   claimReadinessLoading: false,
   claimReadinessError: false,
@@ -282,13 +283,21 @@ vi.mock('~/core/browse/use-browse-sidebar-cache', () => ({
   useCachedBrowseSidebarData: () => null,
 }));
 
+// `type` is load-bearing, not decoration: the picker refuses to offer a claim whose home space is
+// personal, because a debate there could never be published. `mocks.spaceTypes` overrides it per
+// space; anything unlisted is a DAO space, which is what the rest of these suites assume.
 vi.mock('~/core/hooks/use-spaces-by-ids', () => ({
-  useSpacesByIds: () => ({
+  useSpacesByIds: (spaceIds: string[] = []) => ({
     spaces: [],
-    spacesById: new Map([
-      [SPACE_1, { entity: { name: 'Crypto', image: null } }],
-      [SPACE_2, { entity: { name: 'Governance space', image: null } }],
-    ]),
+    spacesById: new Map(
+      [
+        // Anything the picker asked about resolves, so the type lookup can answer for it. The two
+        // named spaces come last so their real labels win over the generic fallback.
+        ...spaceIds.map(id => [id, `Space ${id.slice(0, 8)}`] as const),
+        [SPACE_1, 'Crypto'] as const,
+        [SPACE_2, 'Governance space'] as const,
+      ].map(([id, name]) => [id, { type: mocks.spaceTypes[id] ?? 'DAO', entity: { name, image: null } }])
+    ),
     isLoading: false,
   }),
 }));
@@ -339,6 +348,7 @@ beforeEach(() => {
   mocks.currentUserId = 'user-local';
   mocks.spaceAllowlist = null;
   mocks.allowlistLoading = false;
+  mocks.spaceTypes = {};
   // jsdom has no IntersectionObserver, which the infinite-scroll sentinel builds. This one records
   // the callback so a test can say the sentinel scrolled into view.
   mocks.scrollSentinelIntoView = null;
@@ -1050,6 +1060,60 @@ describe('DebateRematchPageClient', () => {
     // The published claim sits in Governance space, which the allowlist leaves out.
     expect(await screen.findByText('A newly published claim')).toBeInTheDocument();
     expect(screen.getByText('Politics')).toBeInTheDocument();
+  });
+
+  // A debate is published into the claim's home space by the acceptor, and editor rights on a
+  // personal space belong to its owner alone — so a claim living in one can never carry a published
+  // debate. Offering it spends a debate on a result that evaporates, which is worse than leaving it
+  // out. Unlike the allowlist this is a property of the claim, so both debaters see the same answer.
+  describe('when a claim’s home space could never receive the published debate', () => {
+    it('leaves it out of the opponent’s tab, and out of the count', async () => {
+      mocks.claims = [sharedClaim()];
+      mocks.spaceTypes = { [SPACE_1]: 'PERSONAL' };
+      render(<DebateRematchPageClient sessionId="rematch-1" />);
+
+      await waitFor(() => expect(screen.queryByText('A claim both participants chose')).toBeNull());
+      const tab = screen.getByRole('button', { name: /Salina’s positions/ });
+      expect(within(tab).getByText('0')).toBeInTheDocument();
+    });
+
+    it('leaves it out of the curated tab', async () => {
+      mocks.recommendedSections = [{ id: 'block-1', name: 'Politics', claimIds: [CLAIM_MORE] }];
+      mocks.recommendedEntities = [publishedEntity()];
+      mocks.curatedIds = [CLAIM_MORE];
+      mocks.spaceTypes = { [SPACE_2]: 'PERSONAL' };
+      render(<DebateRematchPageClient sessionId="rematch-1" />);
+
+      // The section would have been the only one, so the tab has nothing left to head.
+      await waitFor(() => expect(screen.queryByText('A newly published claim')).toBeNull());
+      expect(screen.queryByText('Politics')).toBeNull();
+    });
+
+    it('leaves it out of the All tab', async () => {
+      mocks.spaceTypes = { [SPACE_2]: 'PERSONAL' };
+      render(<DebateRematchPageClient sessionId="rematch-1" />);
+      showAllClaims();
+
+      await waitFor(() => expect(screen.queryByText('A newly published claim')).toBeNull());
+    });
+
+    it('keeps a claim in a DAO space, which the acceptor can publish into', () => {
+      mocks.claims = [sharedClaim()];
+      mocks.spaceTypes = { [SPACE_1]: 'DAO' };
+      render(<DebateRematchPageClient sessionId="rematch-1" />);
+
+      expect(screen.getByText('A claim both participants chose')).toBeInTheDocument();
+    });
+
+    // Same convention as the allowlist: filtering on a half-resolved lookup would list the claim
+    // and then pull it back out from under the viewer.
+    it('keeps a claim whose space type has not resolved yet', () => {
+      mocks.claims = [sharedClaim()];
+      mocks.spaceTypes = {};
+      render(<DebateRematchPageClient sessionId="rematch-1" />);
+
+      expect(screen.getByText('A claim both participants chose')).toBeInTheDocument();
+    });
   });
 
   // Listing a pool and trimming it once the allowlist lands means claims appear and then vanish

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -39,6 +39,7 @@ import {
   useLeaveDebateRematch,
   useRejectDebateRematchRequest,
 } from '~/core/debates/hooks';
+import { debatePublishableSpacePredicate } from '~/core/debates/debate-publish-target';
 import { SpaceTopicFilters } from '~/core/debates/matchmaking/claims-tab';
 import { useMatchmakingClaims } from '~/core/debates/matchmaking/hooks';
 import { HubCardList } from '~/core/debates/matchmaking/hub-motion';
@@ -54,6 +55,7 @@ import { useCurrentGeoChatUserId } from '~/core/debates/use-current-geo-chat-use
 import { useEntitySidePanel } from '~/core/hooks/use-entity-side-panel';
 import { useEntityResponse } from '~/core/hooks/use-entity-vote';
 import { useInfiniteScrollSentinel } from '~/core/hooks/use-infinite-scroll-sentinel';
+import { useSpacesByIds } from '~/core/hooks/use-spaces-by-ids';
 import { uuidToHex } from '~/core/id/normalize';
 import { responsePositionLabel } from '~/core/responses/entity-response';
 import { getTopRankedSpaceId } from '~/core/utils/space/space-ranking';
@@ -312,6 +314,27 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
     return map;
   }, [browsedPages, opponentEntitiesQuery.entities, recommendedEntities]);
 
+  // A debate is published into the claim's home space by the acceptor, and a personal space grants
+  // editor rights to its owner alone — so a claim living in one can never carry a published debate
+  // (see `isDebatePublishableSpace`). Every list is narrowed by this, unlike the viewer-specific
+  // allowlist above: it is a property of the claim, so both debaters see the same answer, and
+  // offering such a claim spends a debate on a result that quietly evaporates.
+  const candidateSpaceIds = React.useMemo(() => {
+    const ids = new Set<string>();
+    for (const entity of [...opponentEntitiesQuery.entities, ...recommendedEntities]) {
+      const homeSpaceId = claimHomeSpaceId(entity);
+      if (homeSpaceId) ids.add(homeSpaceId);
+    }
+    for (const page of browsedPages) for (const entry of page.claims) ids.add(entry.claim.space_id);
+    for (const row of savedClaimsQuery.data?.claims ?? []) ids.add(row.claim.space_id);
+    return [...ids];
+  }, [browsedPages, opponentEntitiesQuery.entities, recommendedEntities, savedClaimsQuery.data]);
+  const { spacesById: candidateSpaces } = useSpacesByIds(candidateSpaceIds);
+  const canPublishDebateIn = React.useMemo(
+    () => debatePublishableSpacePredicate(candidateSpaces),
+    [candidateSpaces]
+  );
+
   // The opponent's tab: every claim they hold a side on, newest first. Held until the session's
   // exclusions are in, so nothing lists and then vanishes. Not narrowed by the space allowlist —
   // see it above.
@@ -327,8 +350,11 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
       if (row && row.participants.some(side => side.user_id !== currentUserId && side.position !== null))
         rows.push(row);
     }
-    return rows.sort((a, b) => Number(b.shared_preference) - Number(a.shared_preference));
+    return rows
+      .filter(row => canPublishDebateIn(row.claim.space_id))
+      .sort((a, b) => Number(b.shared_preference) - Number(a.shared_preference));
   }, [
+    canPublishDebateIn,
     currentUserId,
     excludedClaimIds,
     opponentClaimIds,
@@ -352,9 +378,16 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
             if (excludedClaimIds.has(claimId)) return [];
             const entity = recommendedEntities.find(candidate => candidate.id === claimId);
             const row = entity ? rowFromEntity(entity) : null;
-            return row ? [row] : [];
+            return row && canPublishDebateIn(row.claim.space_id) ? [row] : [];
           }),
-    [curatedClaimsSettling, excludedClaimIds, recommendedClaimIds, recommendedEntities, rowFromEntity]
+    [
+      canPublishDebateIn,
+      curatedClaimsSettling,
+      excludedClaimIds,
+      recommendedClaimIds,
+      recommendedEntities,
+      rowFromEntity,
+    ]
   );
   const curatedClaims = useLastSettled(curatedClaimsNow, curatedClaimsSettling);
 
@@ -368,6 +401,7 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
     for (const entry of browsedPages.flatMap(page => page.claims)) {
       const claimId = entry.claim.claim_entity_id;
       if (excludedClaimIds.has(claimId) || !isClaimSpaceAllowed(entry.claim.space_id, spaceAllowlist)) continue;
+      if (!canPublishDebateIn(entry.claim.space_id)) continue;
       const sessionRow = sessionRowsByClaimId.get(claimId);
       rows.set(claimId, {
         claim: entry.claim,
@@ -383,7 +417,9 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
     const savedRows = (savedClaimsQuery.data?.claims ?? [])
       .filter(
         row =>
-          !excludedClaimIds.has(row.claim.claim_entity_id) && isClaimSpaceAllowed(row.claim.space_id, spaceAllowlist)
+          !excludedClaimIds.has(row.claim.claim_entity_id) &&
+          isClaimSpaceAllowed(row.claim.space_id, spaceAllowlist) &&
+          canPublishDebateIn(row.claim.space_id)
       )
       .map(row => ({
         ...row,
@@ -396,6 +432,7 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   }, [
     allowlistPending,
     browsedPages,
+    canPublishDebateIn,
     curatedClaims,
     excludedClaimIds,
     opponentClaims,

--- a/apps/web/core/debates/debate-publish-target.test.ts
+++ b/apps/web/core/debates/debate-publish-target.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+
+import { debatePublishableSpacePredicate, isDebatePublishableSpace } from './debate-publish-target';
+
+const DAO_SPACE = '41e851610e13a19441c4d980f2f2ce6b';
+const PERSONAL_SPACE = '8a4955bcd9d0fc0d8613f17f01de3b9f';
+
+describe('isDebatePublishableSpace', () => {
+  it('accepts a DAO space', () => {
+    expect(isDebatePublishableSpace({ type: 'DAO' })).toBe(true);
+  });
+
+  // Editor rights on a personal space belong to its owner alone, and the acceptor is never a
+  // debater's own space — so the sweep logs `not_editor` and the debate is never published.
+  it('rejects a personal space', () => {
+    expect(isDebatePublishableSpace({ type: 'PERSONAL' })).toBe(false);
+  });
+
+  // Same convention as the claim-space allowlist: filtering against a half-built answer hides
+  // claims the viewer is entitled to and then flashes them back in.
+  it('treats an unresolved space as publishable rather than filtering on a guess', () => {
+    expect(isDebatePublishableSpace(null)).toBe(true);
+    expect(isDebatePublishableSpace(undefined)).toBe(true);
+  });
+});
+
+describe('debatePublishableSpacePredicate', () => {
+  it('keeps claims in a DAO space and drops claims in a personal one', () => {
+    const canPublish = debatePublishableSpacePredicate(
+      new Map([
+        [DAO_SPACE, { type: 'DAO' as const }],
+        [PERSONAL_SPACE, { type: 'PERSONAL' as const }],
+      ])
+    );
+
+    expect(canPublish(DAO_SPACE)).toBe(true);
+    expect(canPublish(PERSONAL_SPACE)).toBe(false);
+  });
+
+  // A claim row carries the spelling the graph was queried with; the space lookup keys on the one
+  // the API answered with. Matching them literally let every dashed id read as unresolved.
+  it('matches ids across dash spellings', () => {
+    const dashed = '8a4955bc-d9d0-fc0d-8613-f17f01de3b9f';
+    const canPublish = debatePublishableSpacePredicate(new Map([[PERSONAL_SPACE, { type: 'PERSONAL' as const }]]));
+
+    expect(canPublish(dashed)).toBe(false);
+  });
+
+  it('holds a claim whose space has not resolved yet', () => {
+    const canPublish = debatePublishableSpacePredicate(new Map());
+
+    expect(canPublish(DAO_SPACE)).toBe(true);
+  });
+
+  // A row with no home space has nowhere to publish to at all, which is not the same as "not
+  // looked up yet" — it can never resolve.
+  it('drops a claim with no home space', () => {
+    const canPublish = debatePublishableSpacePredicate(new Map());
+
+    expect(canPublish(null)).toBe(false);
+    expect(canPublish('')).toBe(false);
+  });
+});

--- a/apps/web/core/debates/debate-publish-target.ts
+++ b/apps/web/core/debates/debate-publish-target.ts
@@ -1,0 +1,48 @@
+import type { SpaceGovernanceType } from '~/core/types';
+
+import { normId } from '~/core/utils/norm-id';
+
+/**
+ * Whether a finished debate on a claim in this space could ever reach the knowledge graph.
+ *
+ * A debate is published by the acceptor service account, into the *claim's home space*
+ * (`publishDebateAsAcceptor`), and publishing needs editor rights there — a member can propose but
+ * not vote and execute, so anything else reverts on-chain as `CanNotExecute`. `getSpaceAccess`
+ * grants a personal space's editor rights to its owner and to nobody else, and the acceptor is
+ * never a debater's own space. So a claim whose home space is personal cannot host a debate: the
+ * pair would record one, the sweep would log `not_editor`, and nothing would ever be published.
+ *
+ * Offering such a claim in the picker is worse than leaving it out. Both sides spend a debate on it
+ * and the result quietly evaporates.
+ *
+ * This is a *sufficient* test, not a complete one: a DAO space the acceptor does not edit fails the
+ * same way, and this cannot tell — `DEBATE_ACCEPTOR_SPACE_ID` is server-only, deliberately, and
+ * editorship is a per-space lookup against it. Closing that gap belongs in geo-chat, next to the
+ * `readiness_disabled_reason` it already computes per claim. The personal-space case is the one
+ * that is both decidable here and the one curators keep hitting, since a personal space is where a
+ * debater's own claims are published by default.
+ */
+export function isDebatePublishableSpace(space: { type: SpaceGovernanceType } | null | undefined): boolean {
+  // Unresolved reads as publishable, matching how the claim-space allowlist treats its own
+  // half-built state: too wide beats a list that never fills, and the lookup lands in a beat.
+  if (!space) return true;
+  return space.type !== 'PERSONAL';
+}
+
+/**
+ * A predicate over claim home-space ids, given whatever `useSpacesByIds` has resolved.
+ *
+ * Ids are normalized on the way in: a claim row carries the spelling the graph was queried with,
+ * while the space lookup keys on the spelling the API answered with, and the two differ by dashes.
+ */
+export function debatePublishableSpacePredicate(
+  spacesById: Map<string, { type: SpaceGovernanceType }>
+): (spaceId: string | null | undefined) => boolean {
+  const byNormalizedId = new Map<string, { type: SpaceGovernanceType }>();
+  for (const [id, space] of spacesById) byNormalizedId.set(normId(id), space);
+
+  return spaceId => {
+    if (!spaceId) return false;
+    return isDebatePublishableSpace(byNormalizedId.get(normId(spaceId)));
+  };
+}

--- a/apps/web/core/debates/server/publish-debate.ts
+++ b/apps/web/core/debates/server/publish-debate.ts
@@ -56,9 +56,16 @@ export async function publishDebateAsAcceptor(debateId: string): Promise<Publish
   // (CanNotExecute).
   const access = await Effect.runPromise(getSpaceAccess(space, config.spaceId));
   if (!access.isEditor) {
-    console.log('[debate-acceptor] skipping publish: acceptor is not an editor of the space', {
+    // `console.error`, not `log`: this is terminal, not a retry. The debate is recorded, its claim
+    // lives somewhere the acceptor can never publish, and every sweep from here on will reach this
+    // same line and spend one of its attempt slots doing it. A personal space is the usual cause —
+    // editor rights there belong to the owner alone — which is why the rematch picker refuses to
+    // offer such a claim in the first place (see `isDebatePublishableSpace`). Reaching here means a
+    // debate got past that, so it wants looking at rather than filing under routine.
+    console.error('[debate-acceptor] debate cannot be published: acceptor is not an editor of the space', {
       debateId,
       spaceId: input.spaceId,
+      spaceType: space.type,
       acceptorSpaceId: config.spaceId,
     });
     return { status: 'not_editor', debateEntityId: draft.debateEntityId, spaceId: input.spaceId };


### PR DESCRIPTION
Fixes [GEO-2639](https://linear.app/geobrowser/issue/GEO-2639/debates-on-claims-in-personal-spaces-can-never-be-published). Follow-up to #2204, and a **correction** to it.

Preston asked the right question about that PR: if the recommended claims live in a personal space, where would the debate be published?

## Nowhere

`publishDebateAsAcceptor` publishes into the **claim's home space**, and that needs editor rights (a member can propose but not vote+execute; anything else reverts on-chain as `CanNotExecute`). `getSpaceAccess` grants a personal space's editor rights to its owner and nobody else:

```ts
if (space.type === 'PERSONAL') {
  const isOwner = normalizedPersonalSpaceId === normalizedSpaceId;
  return Effect.succeed(toSpaceAccess({ isEditor: isOwner, isMember: isOwner }));
}
```

The acceptor is a service account, never a debater's own space. So it takes the `not_editor` branch, logs, and skips. Both sides spend a debate and the result never reaches the graph — no entity, no error shown to either participant.

Confirmed against the curated page from GEO-2637: `8a4955bc…` is `PERSONAL`, and 136 of its 136 claims are named there.

## Where #2204 went wrong

That PR correctly diagnosed why the tab was empty for the other debater. But *"so show them"* was the wrong remedy — it removed a filter that had been accidentally hiding an already-broken path, and widened exposure of a dead end.

Worth being precise about the old behaviour too: it wasn't a principled guard. The acceptor can't publish into that space for its **owner** either, so the claim-space allowlist hid those claims from everyone *except* the one person for whom they were equally dead. It was an accidental proxy for the real constraint, wrong in both directions — which is exactly why this read as an asymmetric display bug rather than a publishing one.

## The real gate

`isDebatePublishableSpace` asks whether a debate on a claim in this space could ever be published. Every list is narrowed by it — the opponent's positions, the curated sections, the browsed pages, and the session's own saved rows.

Unlike the allowlist it is a **property of the claim, not the viewer**, so both debaters see the same answer and there is no asymmetry to explain. An unresolved space reads as publishable, matching the allowlist's convention: too wide beats a list that never fills, and filtering on a half-built answer lists a claim and then pulls it out from under the viewer.

**It is a sufficient test, not a complete one.** A DAO space the acceptor does not edit fails identically, and the client cannot tell — `DEBATE_ACCEPTOR_SPACE_ID` is server-only (deliberately) and editorship is a per-space lookup against it. That gap belongs in geo-chat, beside the `readiness_disabled_reason` it already computes per claim; a code like `space_not_publishable` would let the picker disable a claim *and say why* rather than silently omitting it. Tracked on GEO-2639. The personal-space case is both decidable here and the one curators keep hitting, since a personal space is where a debater's own claims land by default.

## Acceptor logging

Promoted the skip from `console.log` to `console.error`, with the space type included. It is terminal, not a retry: the claim will never become publishable, and every sweep from here on reaches that line and spends one of its `MAX_PUBLISH_ATTEMPTS_PER_SWEEP` slots doing it. Reaching it now also means a debate got past the picker's gate, which wants looking at rather than filing under routine. (The sweep route already counts and returns `notEditor`, so the aggregate was never lost — only the per-debate line was quiet.)

## Verification

- **870 tests / 61 files** green across `core/debates` and `app/space/[id]/(space)/debates`.
- `tsc` clean on all touched files; the three remaining errors (`sort-open-proposals.test.ts`, `use-entity-vote.ts`) are pre-existing on master. Lint clean — the two warnings in the test file are pre-existing, on untouched lines.
- New `debate-publish-target.test.ts` covers the predicate, including id normalization across dash spellings (a claim row carries the graph's spelling; the space lookup keys on the API's) and the unresolved case.
- Five new picker tests cover each list. **Note:** the existing `useSpacesByIds` mock returned spaces with no `type`, so the gate silently passed everything and the suite went green without exercising it. The mock now carries a governance type — defaulting to `DAO`, overridable per space — which is what makes those five tests real.

## Heads-up for the demo

With this gate in place the Recommended tab will be **empty** until the curated claims move: all 136 live in a personal space. That is the honest state rather than a regression — those claims could never have produced a published debate. The unblock is re-curating the recommended-claims entity into a DAO/public space the acceptor edits, which needs no code and can happen today.
