### PR TITLE
fix(debates): resolve a claim's home space to one the debate could be published in

### DIFF
--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
@@ -1097,6 +1097,55 @@ describe('DebateRematchPageClient', () => {
       await waitFor(() => expect(screen.queryByText('A newly published claim')).toBeNull());
     });
 
+    // A curated page holding some claims in a personal space and some in a public one keeps the
+    // public ones. The filter is per claim, on that claim's own home space — a section drops out
+    // only when every claim in it was unpublishable.
+    it('keeps the publishable claims in a mixed section and drops only the rest', async () => {
+      const PERSONAL_CLAIM = '019fedb8-6ca7-7f94-a077-8cd3be5a0a64';
+      mocks.recommendedSections = [
+        { id: 'block-1', name: 'Politics', claimIds: [PERSONAL_CLAIM, CLAIM_MORE] },
+      ];
+      mocks.recommendedEntities = [
+        { ...publishedEntity(PERSONAL_CLAIM, 'A claim in someone’s own space'), spaces: [SPACE_1] },
+        publishedEntity(),
+      ];
+      mocks.curatedIds = [PERSONAL_CLAIM, CLAIM_MORE];
+      mocks.spaceTypes = { [SPACE_1]: 'PERSONAL' };
+      render(<DebateRematchPageClient sessionId="rematch-1" />);
+
+      expect(await screen.findByText('A newly published claim')).toBeInTheDocument();
+      expect(screen.getByText('Politics')).toBeInTheDocument();
+      expect(screen.queryByText('A claim in someone’s own space')).toBeNull();
+    });
+
+    // A debater publishes a claim into their own space; a curator later adds it to a shared one, so
+    // it is named in both. The space ranking has no opinion between them — neither is in its table,
+    // so the tie falls to array order — and picking the personal one would lose a claim that is
+    // perfectly debatable in the public space, since the home space is what decides where the
+    // debate is published.
+    it('resolves a claim named in both a personal and a public space to the public one', async () => {
+      const BOTH = '019fedb9-7db8-70a5-b188-9de4cf6b1b75';
+      mocks.recommendedSections = [{ id: 'block-1', name: 'Politics', claimIds: [BOTH] }];
+      mocks.recommendedEntities = [
+        {
+          ...publishedEntity(BOTH, 'A claim in two spaces'),
+          // Personal space first, so array order alone would have picked it: neither id is in the
+          // ranking table, so the tie falls through to order.
+          spaces: [SPACE_1, SPACE_2],
+          values: [
+            { property: { id: NAME_PROPERTY }, spaceId: SPACE_1, value: 'A claim in two spaces' },
+            { property: { id: NAME_PROPERTY }, spaceId: SPACE_2, value: 'A claim in two spaces' },
+          ],
+        },
+      ];
+      mocks.curatedIds = [BOTH];
+      mocks.spaceTypes = { [SPACE_1]: 'PERSONAL' };
+      render(<DebateRematchPageClient sessionId="rematch-1" />);
+
+      // Resolving to the personal space would have filtered it out entirely.
+      expect(await screen.findByText('A claim in two spaces')).toBeInTheDocument();
+    });
+
     it('keeps a claim in a DAO space, which the acceptor can publish into', () => {
       mocks.claims = [sharedClaim()];
       mocks.spaceTypes = { [SPACE_1]: 'DAO' };

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -266,10 +266,30 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
     [curatedClaimsQuery.data, opponentClaimsQuery.data, savedClaimsQuery.data]
   );
 
+  // A debate is published into the claim's home space by the acceptor, and a personal space grants
+  // editor rights to its owner alone — so a claim living in one can never carry a published debate
+  // (see `isDebatePublishableSpace`). Every list is narrowed by this, unlike the viewer-specific
+  // allowlist above: it is a property of the claim, so both debaters see the same answer, and
+  // offering such a claim spends a debate on a result that quietly evaporates.
+  //
+  // Every space a claim is named in is looked up, not just the one that currently wins the ranking,
+  // because which one wins is the next decision and it needs the types to make it.
+  const candidateSpaceIds = React.useMemo(() => {
+    const ids = new Set<string>();
+    for (const entity of [...opponentEntitiesQuery.entities, ...recommendedEntities]) {
+      for (const spaceId of claimCandidateSpaceIds(entity)) ids.add(spaceId);
+    }
+    for (const page of browsedPages) for (const entry of page.claims) ids.add(entry.claim.space_id);
+    for (const row of savedClaimsQuery.data?.claims ?? []) ids.add(row.claim.space_id);
+    return [...ids];
+  }, [browsedPages, opponentEntitiesQuery.entities, recommendedEntities, savedClaimsQuery.data]);
+  const { spacesById: candidateSpaces } = useSpacesByIds(candidateSpaceIds);
+  const canPublishDebateIn = React.useMemo(() => debatePublishableSpacePredicate(candidateSpaces), [candidateSpaces]);
+
   /** A picker row from a graph entity, with geo-chat's session row layered on when it has one. */
   const rowFromEntity = React.useCallback(
     (entity: ClaimPickerEntity): DebateRematchClaim | null => {
-      const homeSpaceId = claimHomeSpaceId(entity);
+      const homeSpaceId = claimHomeSpaceId(entity, canPublishDebateIn);
       if (!entity.name || !homeSpaceId) return null;
       const sessionRow = sessionRowsByClaimId.get(entity.id);
       const responseKind = sessionRow?.response_kind ?? claimResponseKind(entity, homeSpaceId);
@@ -291,7 +311,7 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
         readiness_disabled_reason: sessionRow ? sessionRow.readiness_disabled_reason : null,
       };
     },
-    [recentlyRejectedClaimIds, sessionCarriesReadiness, sessionRowsByClaimId, sidesOf]
+    [canPublishDebateIn, recentlyRejectedClaimIds, sessionCarriesReadiness, sessionRowsByClaimId, sidesOf]
   );
 
   // Topics live on the KG claim entity, so resolve them here to label each card and drive the
@@ -313,27 +333,6 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
     }
     return map;
   }, [browsedPages, opponentEntitiesQuery.entities, recommendedEntities]);
-
-  // A debate is published into the claim's home space by the acceptor, and a personal space grants
-  // editor rights to its owner alone — so a claim living in one can never carry a published debate
-  // (see `isDebatePublishableSpace`). Every list is narrowed by this, unlike the viewer-specific
-  // allowlist above: it is a property of the claim, so both debaters see the same answer, and
-  // offering such a claim spends a debate on a result that quietly evaporates.
-  const candidateSpaceIds = React.useMemo(() => {
-    const ids = new Set<string>();
-    for (const entity of [...opponentEntitiesQuery.entities, ...recommendedEntities]) {
-      const homeSpaceId = claimHomeSpaceId(entity);
-      if (homeSpaceId) ids.add(homeSpaceId);
-    }
-    for (const page of browsedPages) for (const entry of page.claims) ids.add(entry.claim.space_id);
-    for (const row of savedClaimsQuery.data?.claims ?? []) ids.add(row.claim.space_id);
-    return [...ids];
-  }, [browsedPages, opponentEntitiesQuery.entities, recommendedEntities, savedClaimsQuery.data]);
-  const { spacesById: candidateSpaces } = useSpacesByIds(candidateSpaceIds);
-  const canPublishDebateIn = React.useMemo(
-    () => debatePublishableSpacePredicate(candidateSpaces),
-    [candidateSpaces]
-  );
 
   // The opponent's tab: every claim they hold a side on, newest first. Held until the session's
   // exclusions are in, so nothing lists and then vanishes. Not narrowed by the space allowlist —
@@ -1174,11 +1173,39 @@ function rematchPositionSummaries(
  * the claim whenever that space outranks the claim's own — a Podcasts claim cited from Root or
  * Crypto resolves to those. Prefer the spaces where the claim is actually named, which is how the
  * entity side panel scopes the same entity.
+ *
+ * `canPublishIn`, where given, is consulted before the ranking. A claim named in both a personal
+ * space and a public one is a real case — a debater publishes into their own space and a curator
+ * later adds the claim to a shared one — and the space ranking has no opinion on which to pick:
+ * neither is in its table, so the tie falls to array order. Picking the personal space there loses a
+ * claim that is perfectly debatable in the public one, since the home space is exactly what decides
+ * where the debate is published. So: rank among the spaces that could receive it, and fall back to
+ * the plain ranking when none can, which leaves the claim to be filtered out on its merits rather
+ * than resolving to no space at all.
  */
-function claimHomeSpaceId(entity: {
-  spaces: string[];
+function claimHomeSpaceId(
+  entity: {
+    spaces: string[];
+    values?: Array<{ isDeleted?: boolean; property: { id: string }; spaceId: string; value: string }>;
+  },
+  canPublishIn?: (spaceId: string) => boolean
+): string | null {
+  const named = [...claimNamedSpaceIds(entity)];
+  const publishable = canPublishIn ? (ids: string[]) => ids.filter(canPublishIn) : (ids: string[]) => ids;
+
+  return (
+    getTopRankedSpaceId(publishable(named)) ??
+    getTopRankedSpaceId(named) ??
+    getTopRankedSpaceId(publishable(entity.spaces)) ??
+    getTopRankedSpaceId(entity.spaces) ??
+    null
+  );
+}
+
+/** The spaces a claim is actually named in — where it lives, as opposed to where it is mentioned. */
+function claimNamedSpaceIds(entity: {
   values?: Array<{ isDeleted?: boolean; property: { id: string }; spaceId: string; value: string }>;
-}): string | null {
+}): Set<string> {
   const namedSpaceIds = new Set<string>();
   for (const value of entity.values ?? []) {
     if (
@@ -1190,8 +1217,19 @@ function claimHomeSpaceId(entity: {
       namedSpaceIds.add(value.spaceId);
     }
   }
+  return namedSpaceIds;
+}
 
-  return getTopRankedSpaceId([...namedSpaceIds]) ?? getTopRankedSpaceId(entity.spaces) ?? null;
+/**
+ * Every space a claim could resolve its home to. The publishability lookup covers all of them, so
+ * {@link claimHomeSpaceId} has the types it needs to choose between them rather than choosing first
+ * and discovering afterwards that the space it picked can never receive the debate.
+ */
+function claimCandidateSpaceIds(entity: {
+  spaces: string[];
+  values?: Array<{ isDeleted?: boolean; property: { id: string }; spaceId: string; value: string }>;
+}): string[] {
+  return [...new Set([...claimNamedSpaceIds(entity), ...entity.spaces])];
 }
 
 function claimResponseKind(


### PR DESCRIPTION
Follow-up to #2205 (already merged), answering Preston's question about it: *if some claims live in a personal space but others live in a public space, would I still see the public ones and just have the personal ones filtered out?*

**Yes** — the filter is per claim, on that claim's own home space. A mixed curated section keeps its publishable claims and drops only the rest; a section disappears only when *every* claim in it was unpublishable. That was already the behaviour; there's now a test pinning it instead of leaving it to be inferred.

## One case that did not behave that way

A claim can be **named in several spaces** — a debater publishes it into their own space, and a curator later adds it to a shared one. `claimHomeSpaceId` picked among those by the space ranking, and neither a personal space nor most DAO spaces are in that ranking's table, so `getTopRankedSpaceId` ties and falls through to **array order**:

```ts
let best = spaceIds[0];
// ...
if (rank < bestRank) { best = spaceIds[i]; }   // strict <, so a tie keeps the first
```

So a claim that *is* available in a perfectly debatable public space could resolve its home to the personal one and then be filtered out on that basis — losing a claim that should have been offered.

Not hypothetical: **3 of the 136 claims** on the curated page behind GEO-2637 are named in two spaces (`8a4955bc…` personal and `41e85161…` DAO).

## Fix

The home space is exactly what decides where the debate gets published, so publishability now comes *before* the ranking: rank among the spaces that could receive the debate, and fall back to the plain ranking when none can — which leaves the claim to be filtered on its merits rather than resolving to no space at all.

```ts
getTopRankedSpaceId(publishable(named)) ??
  getTopRankedSpaceId(named) ??
  getTopRankedSpaceId(publishable(entity.spaces)) ??
  getTopRankedSpaceId(entity.spaces)
```

This inverts a dependency: the publishability lookup now has to cover every space a claim *could* resolve to, not just the one that currently wins, so `claimCandidateSpaceIds` feeds it the named spaces and `entity.spaces` both, and the lookup is hoisted above `rowFromEntity`. `claimNamedSpaceIds` is split out so both helpers share one definition of "named in".

## Verification

- **872 tests / 61 files** green across `core/debates` and `app/space/[id]/(space)/debates`, rebased onto master with #2205 merged.
- `tsc` and lint clean on the touched files (same three pre-existing errors as before, in files not touched here).
- Two new tests: the mixed-section case Preston asked about, and the named-in-both case above.
- I verified the second test genuinely fails without the fix — dropped the `canPublishDebateIn` argument, watched it fail, restored it, watched it pass. Without that check it would have been a test that passes for the wrong reason, since the tie-break makes the outcome depend on fixture ordering.
