### PR TITLE
fix(debates): keep account activity fresh when the gateway stops listening

### DIFF
--- a/apps/web/core/debates/hooks-query-network.test.tsx
+++ b/apps/web/core/debates/hooks-query-network.test.tsx
@@ -20,6 +20,7 @@ import {
 const mocks = vi.hoisted(() => ({
   authenticated: true,
   attention: true,
+  gatewayPaused: false,
   queryCache: { subscribe: vi.fn(() => vi.fn()) },
   queryClient: {
     getQueryCache: vi.fn(() => mocks.queryCache),
@@ -50,6 +51,7 @@ vi.mock('~/core/auth/identity-token', () => ({
 
 vi.mock('./debate-gateway', () => ({
   useDebateGatewayScope: mocks.useScope,
+  useDebateGatewaySnapshot: () => ({ status: mocks.gatewayPaused ? 'degraded' : 'ready', paused: mocks.gatewayPaused }),
 }));
 
 vi.mock('./debate-attention', () => ({
@@ -59,6 +61,7 @@ vi.mock('./debate-attention', () => ({
 beforeEach(() => {
   mocks.authenticated = true;
   mocks.attention = true;
+  mocks.gatewayPaused = false;
   mocks.queryClient.invalidateQueries.mockClear();
   mocks.queryClient.getQueryCache.mockClear();
   mocks.queryCache.subscribe.mockClear();
@@ -70,10 +73,11 @@ beforeEach(() => {
 });
 
 describe('debate query network ownership', () => {
+  // The gateway owns freshness; a poll is an exception each query has to earn. Profile eligibility
+  // and account activity are the two that have, and each is pinned by its own case below.
   it('disables polling and generic browser refetches for every debate query', () => {
     renderHook(() => {
       useDebateClaims('space-1', ['claim-1'], true);
-      useDebateActivity();
       useSpaceDebates('space-1', true);
       useDebate('debate-1', true);
       useDebateRematch('rematch-1');
@@ -83,11 +87,35 @@ describe('debate query network ownership', () => {
       useDebateTranscript('debate-1');
     });
 
-    expect(mocks.useQuery).toHaveBeenCalledTimes(9);
+    expect(mocks.useQuery).toHaveBeenCalledTimes(8);
     for (const [options] of mocks.useQuery.mock.calls) {
       expect(options).toMatchObject({ retry: false, refetchOnReconnect: false, refetchOnWindowFocus: false });
       expect(options).not.toHaveProperty('refetchInterval');
     }
+  });
+
+  // Activity gates the incoming-request popup, and the socket has two ways to be deaf: reconnect
+  // backoff, and an ERROR frame that pauses live updates without scheduling a reconnect. Neither
+  // recovers on its own, and the shared options switch off React Query's focus and reconnect
+  // refetches — so without this a request waited on a remount to appear (GEO-2638).
+  it('polls activity while foregrounded, faster while the gateway is paused, and refetches on return', () => {
+    const { rerender } = renderHook(() => useDebateActivity());
+    expect(mocks.useQuery.mock.calls.at(-1)?.[0]).toMatchObject({ refetchInterval: 30_000 });
+    expect(mocks.queryRefetch).not.toHaveBeenCalled();
+
+    // A paused gateway means this is the only thing still asking, so it asks more often.
+    mocks.gatewayPaused = true;
+    rerender();
+    expect(mocks.useQuery.mock.calls.at(-1)?.[0]).toMatchObject({ refetchInterval: 10_000 });
+
+    // A tab nobody is looking at has no popup to draw, paused or not.
+    mocks.attention = false;
+    rerender();
+    expect(mocks.useQuery.mock.calls.at(-1)?.[0]).toMatchObject({ refetchInterval: false });
+
+    mocks.attention = true;
+    rerender();
+    expect(mocks.queryRefetch).toHaveBeenCalledTimes(1);
   });
 
   it('polls profile eligibility every thirty seconds only while foregrounded and refetches on return', () => {

--- a/apps/web/core/debates/hooks.test.tsx
+++ b/apps/web/core/debates/hooks.test.tsx
@@ -64,6 +64,7 @@ vi.mock('@geogenesis/auth', () => ({
 vi.mock('./debate-gateway', () => ({
   useDebateGateway: () => ({ status: 'ready', paused: false }),
   useDebateGatewayScope: vi.fn(),
+  useDebateGatewaySnapshot: () => ({ status: 'ready', paused: false }),
   useDebateGatewaySpaceScopes: vi.fn(),
 }));
 
@@ -1060,6 +1061,10 @@ describe('debate query refresh behavior', () => {
     window.localStorage.clear();
   });
 
+  // The gateway owns freshness for these, so time passing must not cost a request. Account activity
+  // is deliberately not among them any more — it gates the incoming-request popup and polls to
+  // survive a deaf socket (GEO-2638); its cadence is pinned in `hooks-query-network.test.tsx`,
+  // where the two focus gates a real interval depends on can be stated directly.
   it('does not issue periodic debate reads while time advances', async () => {
     vi.useFakeTimers();
     window.localStorage.setItem(
@@ -1074,20 +1079,10 @@ describe('debate query refresh behavior', () => {
       })
     );
     const fetch = vi.fn().mockResolvedValue(
-      new Response(
-        JSON.stringify({
-          online: true,
-          available_to_debate: true,
-          cooldown_until: null,
-          match: null,
-          debate: null,
-          rematch: null,
-        }),
-        {
-          status: 200,
-          headers: { 'Content-Type': 'application/json' },
-        }
-      )
+      new Response(JSON.stringify({ id: 'debate-1' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
     );
     vi.stubGlobal('fetch', fetch);
     const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
@@ -1095,7 +1090,7 @@ describe('debate query refresh behavior', () => {
       <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
     );
 
-    renderHook(() => useDebateActivity(), { wrapper });
+    renderHook(() => useDebate('debate-1', true), { wrapper });
     await vi.waitFor(() => expect(fetch).toHaveBeenCalledTimes(1));
 
     await act(async () => vi.advanceTimersByTimeAsync(60_000));

--- a/apps/web/core/debates/hooks.ts
+++ b/apps/web/core/debates/hooks.ts
@@ -65,7 +65,7 @@ import {
 import { claimResponseIndexedEvent } from './claim-response-indexed-notifier';
 import { useDebateAttention } from './debate-attention';
 import { markEnteringDebate } from './debate-entry-intent';
-import { useDebateGatewayScope, useDebateGatewaySpaceScopes } from './debate-gateway';
+import { useDebateGatewayScope, useDebateGatewaySnapshot, useDebateGatewaySpaceScopes } from './debate-gateway';
 import { hasProcessedVideo } from './playback-utils';
 import {
   isRematchClaimsQueryKey,
@@ -303,11 +303,41 @@ export function useLeaveDebateQueue(spaceId: string) {
   });
 }
 
+/** How often activity re-asks while the viewer is looking, with a live gateway behind it. */
+const ACTIVITY_POLL_MS = 30_000;
+/** And while the gateway is paused, when this is the only thing still asking. */
+const ACTIVITY_DEGRADED_POLL_MS = 10_000;
+
+/**
+ * The viewer's own debate state: the debate or rematch they are in, and the counts that gate the
+ * incoming-request popup.
+ *
+ * This is the entry point for anything that arrives unannounced. `DebateCoordinator` only fetches
+ * the request list once `incoming_request_count` says one exists, so a stale answer here is a
+ * request the recipient is never shown — and every other route to freshness is switched off:
+ * `debateQueryNetworkOptions` turns off `refetchOnWindowFocus` and `refetchOnReconnect`, which
+ * leaves the gateway's `debate.requests_changed` as the only thing that ever re-asked.
+ *
+ * That is fine until the socket is not listening, and it has two ways not to be. A dropped
+ * connection backs off for up to thirty seconds before `READY` triggers its reconcile. And an
+ * `ERROR` frame the gateway can't act on pauses live updates deliberately, without scheduling a
+ * reconnect — a scope-level rejection, but it takes the account-level stream down with it, and
+ * nothing recovers it. Either way the popup waited on a remount, which is how a request took
+ * "30-60 seconds" to appear (GEO-2638).
+ *
+ * So: poll while the viewer is looking, faster while the gateway is paused and this is the only
+ * thing still asking, and re-ask on return to the tab. The socket still does the fast path — a
+ * couple of seconds, of which the outbox relay is two — and this only bounds the bad case.
+ */
 export function useDebateActivity(enabled = true) {
   const queryClient = useQueryClient();
   const { accountKey, authenticated, getPrivyIdentityToken } = useGeoChatAuth();
+  const foreground = useDebateAttention();
+  const { paused } = useDebateGatewaySnapshot();
+  const queryEnabled = enabled && authenticated;
+  const wasForeground = React.useRef(foreground);
 
-  return useQuery({
+  const query = useQuery({
     ...debateQueryNetworkOptions,
     queryKey: debateQueryKeys.activity(accountKey),
     queryFn: async ({ signal }) => {
@@ -320,8 +350,22 @@ export function useDebateActivity(enabled = true) {
       }
       return activity;
     },
-    enabled: enabled && authenticated,
+    enabled: queryEnabled,
+    // Background tabs don't poll: presence keeps the socket's own view current, and a tab nobody is
+    // looking at has no popup to draw.
+    refetchInterval: foreground ? (paused ? ACTIVITY_DEGRADED_POLL_MS : ACTIVITY_POLL_MS) : false,
   });
+
+  // Coming back to the tab is the one moment a viewer expects to be shown what they missed, and the
+  // shared options switch off React Query's own focus refetch for every debate query. Same shape as
+  // `useDebateProfile`, which needs it for the same reason.
+  React.useEffect(() => {
+    const returnedToForeground = foreground && !wasForeground.current;
+    wasForeground.current = foreground;
+    if (returnedToForeground && queryEnabled) void query.refetch();
+  }, [foreground, query.refetch, queryEnabled]);
+
+  return query;
 }
 
 export function useUpdateDebateAvailability() {


### PR DESCRIPTION
Fixes [GEO-2638](https://linear.app/geobrowser/issue/GEO-2638/lag-between-sending-and-receiving-debate-request) — a debate request taking 30-60s to reach the recipient's popup.

## Ruled out first

Both ends of the delivery path are fast, so this isn't a missing interval somewhere:

- **Outbox relay:** fixed at 2s (`runtime.rs:123`), and not env-tunable — the k8s configmap overrides `SPACE_SYNC`/`CLAIM_RANKING_SYNC`/`MEDIA_WORKER` intervals but never this one.
- **Fan-out:** `publish_debate_event` resolves an **implicit user audience** (`routing.users.get(user_id)`), so the recipient's socket receives `debate.requests_changed` without holding any subscription for it. `emit_requests_changed` targets both requester and recipient.
- **Presence / `is_online`:** the freshness window is 90s (`recompute_debate_presence_aggregate`) against a 30s client heartbeat, and the client sends presence on `HELLO`, on transition, and flushes a deferred one on `HEARTBEAT_ACK`. Not the bottleneck.

## What actually stalls

That single event was the **only** thing that ever re-asked on the recipient's side.

`DebateCoordinator` fetches the request list only once activity says one exists:

```ts
const hasIncomingRequests = (activity?.incoming_request_count ?? 0) > 0;
const requestsQuery = useDebateRequests(hasIncomingRequests && !activeFlow);
```

So a stale activity answer *is* a request the recipient never sees. And every other route to freshness was off — `debateQueryNetworkOptions` disables `refetchOnWindowFocus` and `refetchOnReconnect` for all debate queries, and `useDebateActivity` carried no `refetchInterval`.

The socket has two ways not to be listening:

1. **Reconnect backoff.** `scheduleReconnect` is exponential, capped at **30 seconds**, before `READY` triggers `queueBroadReconcile`. A blip, a sleep, or a deploy costs one or two silent cycles — which is the reported window, near enough exactly.
2. **A paused gateway.** An `ERROR` frame the client can't act on sets `paused: true` **without** scheduling a reconnect — unlike every other pause site. That's deliberate (two tests assert it), but a *scope-level* rejection takes the *account-level* stream down with it, and nothing recovers it.

Either way the popup waited on a remount.

## Fix

Poll activity while the viewer is looking: 30s normally, 10s while the gateway reports itself `paused` and this is the only thing still asking. Plus a refetch on return to the tab, since that's the one moment a viewer expects to be shown what they missed and the shared options switch React Query's own focus refetch off.

The socket keeps the fast path (~2s). This only bounds the bad case. Background tabs stay quiet — presence keeps the socket's view current, and a tab nobody is looking at has no popup to draw.

**Deliberately not touching the pause itself.** Reconnecting on a subscription rejection re-asks for the scope that was just refused, and the existing tests pin that behaviour on purpose. Making a deaf gateway degrade to polling fixes the harm without churning the socket. If you'd rather close that hole properly, the cleaner shape is for a rejected scope to be dropped and the connection kept — worth its own change.

## Test structure

`useDebateActivity` joins `useDebateProfile` as an explicit exception to gateway-owns-freshness, so it moves out of the blanket no-polling assertion (9 → 8 queries) and into its own case stating the cadence, the paused cadence, the background case, and the return-to-foreground refetch.

The integration test that watched a minute pass without a request keeps doing exactly that, over `useDebate` — a query the rule still covers. I first tried to assert the real interval there and it wouldn't fire: a live `refetchInterval` needs **two** focus gates that jsdom leaves off (our `document.hasFocus()` and React Query's own `focusManager`, since `refetchIntervalInBackground` is off). Stating that in the unit test is clearer than reproducing it, so the integration test went back to guarding the rule rather than the exception.

## Verification

- **871 tests / 61 files** green across `core/debates` and `app/space/[id]/(space)/debates`.
- `tsc` and lint clean on the touched files (the three usual pre-existing errors are in files not touched here).

## Scope note

I kept this to activity, the query that gates the popup. `useDebateRequests` already sets `refetchOnWindowFocus: true` and expired requests are dropped client-side by `useUnexpiredRequests`, so once activity unlocks it the chain completes. A separately stuck requests list would be a different fix.
