### PR TITLE
fix(debates): tell a dead media job apart from one still working

### DIFF
--- a/apps/web/app/api/debates/publish-sweep/route.test.ts
+++ b/apps/web/app/api/debates/publish-sweep/route.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { DebateNotPublishableError } from '~/core/debates/server/debate-source';
+
+const mocks = vi.hoisted(() => ({
+  candidates: {} as Record<string, string[]>,
+  editorSpaceIds: [] as string[],
+  publish: vi.fn(),
+}));
+
+vi.mock('~/core/debates/server/acceptor-config', () => ({
+  getDebateAcceptorConfig: () => ({ privateKey: '0xkey', spaceId: 'acceptor-space' }),
+}));
+
+vi.mock('~/core/debates/server/editor-spaces', () => ({
+  listEditorSpaceIds: async () => mocks.editorSpaceIds,
+}));
+
+// `DebateNotPublishableError` stays real: the route branches on `instanceof`, so a stubbed class
+// would send every outcome down the generic-failure path and the test would prove nothing.
+vi.mock('~/core/debates/server/debate-source', async importOriginal => ({
+  ...(await importOriginal<typeof import('~/core/debates/server/debate-source')>()),
+  listSweepCandidateDebateIds: async (spaceId: string) => mocks.candidates[spaceId] ?? [],
+}));
+
+vi.mock('~/core/debates/server/publish-debate', () => ({
+  publishDebateAsAcceptor: (debateId: string) => mocks.publish(debateId),
+}));
+
+async function sweep() {
+  const { GET } = await import('./route');
+  const response = await GET(new Request('https://geo.test/api/debates/publish-sweep', { headers: { authorization: 'Bearer test-secret' } }));
+  return response.json();
+}
+
+beforeEach(() => {
+  vi.stubEnv('CRON_SECRET', 'test-secret');
+  mocks.editorSpaceIds = ['space-1'];
+  mocks.candidates = {};
+  mocks.publish.mockReset();
+});
+
+describe('publish sweep', () => {
+  it('refuses a request without the cron secret', async () => {
+    const { GET } = await import('./route');
+    const response = await GET(new Request('https://geo.test/api/debates/publish-sweep'));
+
+    expect(response.status).toBe(401);
+  });
+
+  it('publishes an eligible debate', async () => {
+    mocks.candidates = { 'space-1': ['debate-1'] };
+    mocks.publish.mockResolvedValue({ status: 'published', debateEntityId: 'e1', spaceId: 'space-1', userOpHash: '0x1' });
+
+    await expect(sweep()).resolves.toMatchObject({ ok: true, published: ['debate-1'] });
+  });
+
+  // The distinction this whole change exists for. A dead media job and a still-rendering one used to
+  // share `media_not_ready`, so a debate that could never publish was counted as a healthy backlog
+  // on every tick, forever — indistinguishable from one that would finish in a minute.
+  it('reports a permanently failed media job apart from a pending one', async () => {
+    mocks.candidates = { 'space-1': ['dead', 'rendering'] };
+    mocks.publish.mockImplementation(async (debateId: string) => {
+      throw debateId === 'dead'
+        ? new DebateNotPublishableError('media_failed', 'media job failed permanently')
+        : new DebateNotPublishableError('media_not_ready', 'media is not ready');
+    });
+
+    await expect(sweep()).resolves.toMatchObject({ mediaFailed: ['dead'], pending: 1 });
+  });
+
+  // Two stuck debates must not cost the sweep its budget, or a permanent failure would stall
+  // publishing for everyone else.
+  it('does not spend the attempt budget on unpublishable debates', async () => {
+    mocks.candidates = { 'space-1': ['dead-1', 'dead-2', 'dead-3', 'publishable'] };
+    mocks.publish.mockImplementation(async (debateId: string) => {
+      if (debateId === 'publishable') {
+        return { status: 'published', debateEntityId: 'e', spaceId: 'space-1', userOpHash: '0x1' };
+      }
+      throw new DebateNotPublishableError('media_failed', 'media job failed permanently');
+    });
+
+    const result = await sweep();
+
+    expect(result.mediaFailed).toEqual(['dead-1', 'dead-2', 'dead-3']);
+    expect(result.published).toEqual(['publishable']);
+  });
+
+  it('reports an empty list when nothing is stuck', async () => {
+    mocks.candidates = { 'space-1': [] };
+
+    await expect(sweep()).resolves.toMatchObject({ mediaFailed: [], pending: 0 });
+  });
+});

--- a/apps/web/app/api/debates/publish-sweep/route.ts
+++ b/apps/web/app/api/debates/publish-sweep/route.ts
@@ -44,6 +44,9 @@ export async function GET(request: Request) {
   let notEditor = 0;
   let pending = 0;
   let skipped = 0;
+  // Debates whose media will never be publishable. Counted apart from `pending` because the two
+  // want opposite reactions: a backlog drains itself, this does not.
+  const mediaFailed: string[] = [];
 
   for (const spaceId of spaceIds) {
     let debateIds: string[];
@@ -67,7 +70,13 @@ export async function GET(request: Request) {
         else if (result.status === 'not_editor') notEditor += 1;
       } catch (error) {
         if (error instanceof DebateNotPublishableError) {
-          if (error.code === 'media_not_ready' || error.code === 'not_complete') {
+          if (error.code === 'media_failed') {
+            // Terminal: the worker has spent its retries, so no later tick will publish this.
+            // Collected rather than logged here — the sweep runs every five minutes and these
+            // debates never leave the list, so a line each would be a few hundred a day per stuck
+            // debate. One aggregate line below carries the same information without the noise.
+            mediaFailed.push(debateId);
+          } else if (error.code === 'media_not_ready' || error.code === 'not_complete') {
             // Media still processing or lifecycle state changed — retry next tick.
             pending += 1;
           } else {
@@ -84,5 +93,23 @@ export async function GET(request: Request) {
     }
   }
 
-  return NextResponse.json({ ok: true, published, alreadyPublished, notEditor, pending, skipped, failed });
+  if (mediaFailed.length > 0) {
+    console.error('[debate-acceptor] debates permanently unpublishable this sweep', {
+      count: mediaFailed.length,
+      debateIds: mediaFailed,
+    });
+  }
+
+  return NextResponse.json({
+    ok: true,
+    published,
+    alreadyPublished,
+    notEditor,
+    pending,
+    // Every unpublishable debate the sweep saw, by id, on every tick — so the answer to "how many
+    // debates are stuck?" is a number someone can read rather than an archaeology exercise.
+    mediaFailed,
+    skipped,
+    failed,
+  });
 }

--- a/apps/web/core/debates/server/debate-source.test.ts
+++ b/apps/web/core/debates/server/debate-source.test.ts
@@ -121,11 +121,12 @@ describe('loadDebatePublishSource media gating', () => {
   });
 
   // Without this gate, a succeeded job missing final_video publishes a videoless Debate entity.
-  it('treats a succeeded job with no final_video as not yet publishable', async () => {
+  // Terminal rather than a wait: the job that would have produced the video has already finished.
+  it('treats a succeeded job with no final_video as permanently unpublishable', async () => {
     mockGeoChat({ job: { status: 'succeeded' }, artifacts: [{ kind: 'preview_image' }] });
 
     await expect(loadDebatePublishSource(DEBATE_ID)).rejects.toThrow(DebateNotPublishableError);
-    await expect(loadDebatePublishSource(DEBATE_ID)).rejects.toThrow(/no processed final_video/);
+    await expect(loadDebatePublishSource(DEBATE_ID)).rejects.toMatchObject({ code: 'media_failed' });
   });
 
   // The hevc rendition is a companion to final_video, never a substitute for it.
@@ -138,10 +139,27 @@ describe('loadDebatePublishSource media gating', () => {
     await expect(loadDebatePublishSource(DEBATE_ID)).rejects.toThrow(DebateNotPublishableError);
   });
 
-  it.each([['failed'], ['pending'], ['running']])('leaves a %s media job for a later tick', async status => {
+  it.each([['queued'], ['pending'], ['running']])('leaves a %s media job for a later tick', async status => {
     mockGeoChat({ job: { status }, artifacts: [] });
 
-    await expect(loadDebatePublishSource(DEBATE_ID)).rejects.toThrow(/media is not ready/);
+    await expect(loadDebatePublishSource(DEBATE_ID)).rejects.toMatchObject({ code: 'media_not_ready' });
+  });
+
+  // A failed job has already spent its retries in the worker, so no later tick will publish this
+  // debate. Sharing `media_not_ready` with the statuses above is what let a dead debate count as a
+  // healthy backlog on every sweep, forever.
+  it('reports a failed media job as permanent rather than pending', async () => {
+    mockGeoChat({ job: { status: 'failed' }, artifacts: [] });
+
+    await expect(loadDebatePublishSource(DEBATE_ID)).rejects.toMatchObject({ code: 'media_failed' });
+  });
+
+  // A debate with no job row at all is the ambiguous case: a lost enqueue looks exactly like one
+  // about to happen, so it stays a wait rather than being reported as permanently dead.
+  it('treats a missing media job as a wait, not a permanent failure', async () => {
+    mockGeoChat({ job: null, artifacts: [] });
+
+    await expect(loadDebatePublishSource(DEBATE_ID)).rejects.toMatchObject({ code: 'media_not_ready' });
   });
 
   it('permanently rejects a cancelled debate even when media previously succeeded', async () => {

--- a/apps/web/core/debates/server/debate-source.ts
+++ b/apps/web/core/debates/server/debate-source.ts
@@ -59,12 +59,25 @@ export type DebateSource = {
   input: DebatePublishInput;
 };
 
+/**
+ * Why a debate can't be published yet — or, for `media_failed`, ever.
+ *
+ * The distinction between `media_not_ready` and `media_failed` is the whole point of having two
+ * codes: one is a debate the next sweep will pick up, the other is a debate no sweep will ever
+ * publish. Collapsing them is how twelve debates died unnoticed over a month — a permanently dead
+ * job counted as "still processing" on every tick, forever, and looked exactly like a healthy
+ * backlog.
+ */
+export type DebateNotPublishableCode =
+  | 'not_complete'
+  | 'recording_cancelled'
+  | 'cancellation_window_open'
+  | 'media_not_ready'
+  | 'media_failed';
+
 export class DebateNotPublishableError extends Error {
-  code: 'not_complete' | 'recording_cancelled' | 'cancellation_window_open' | 'media_not_ready';
-  constructor(
-    code: 'not_complete' | 'recording_cancelled' | 'cancellation_window_open' | 'media_not_ready',
-    message: string
-  ) {
+  code: DebateNotPublishableCode;
+  constructor(code: DebateNotPublishableCode, message: string) {
     super(message);
     this.name = 'DebateNotPublishableError';
     this.code = code;
@@ -100,7 +113,18 @@ export async function loadDebatePublishSource(debateId: string): Promise<DebateS
   assertDebateRecordingPublishable(debate, Date.now());
 
   const media = await geoChatGet<DebateMediaResponse>(`/debates/${debateId}/media`);
+  // A failed job has already spent its retries in the worker; it is not coming back on its own.
+  if (media.job?.status === 'failed') {
+    throw new DebateNotPublishableError(
+      'media_failed',
+      `Debate ${debateId} media job failed permanently and will not be retried.`
+    );
+  }
   if (media.job?.status !== 'succeeded') {
+    // Queued, running, or no job row yet — all of which the next tick may resolve. A missing job is
+    // the weakest of the three: if the enqueue itself was lost there is nothing to wait for, but
+    // that is indistinguishable from "about to be enqueued", so it stays a wait rather than risking
+    // a false report of permanent death.
     throw new DebateNotPublishableError(
       'media_not_ready',
       `Debate ${debateId} media is not ready (job ${media.job?.status ?? 'missing'}).`
@@ -108,8 +132,12 @@ export async function loadDebatePublishSource(debateId: string): Promise<DebateS
   }
 
   // A job can succeed without composing a `final_video`; publishing then yields a videoless Debate.
+  // Terminal, not a wait: the job that would have produced it has already finished.
   if (!hasProcessedVideo(media)) {
-    throw new DebateNotPublishableError('media_not_ready', `Debate ${debateId} has no processed final_video artifact.`);
+    throw new DebateNotPublishableError(
+      'media_failed',
+      `Debate ${debateId} media job succeeded without a processed final_video artifact.`
+    );
   }
 
   const videoUrl = await pinArtifactToIpfs(debateId, 'final_video');


### PR DESCRIPTION
Makes a permanently dead media job visible instead of counting it as a healthy backlog. Pairs with `geo-chat#…` (`ohohoreilly/media-terminal-failure-log`), which gives the terminal failure its own log line on the worker side.

## The gap

The publish gate treated every non-succeeded media job identically:

```ts
if (media.job?.status !== 'succeeded') {
  throw new DebateNotPublishableError('media_not_ready', …);
}
```

`queued`, `running` and `failed` all came out as `media_not_ready`, and the sweep counts that as `pending`. So a debate whose media job had **exhausted its retries in the worker** was reported — every five minutes, forever — as indistinguishable from one that would finish in a minute.

This is the exact shape of the incident already written up in `crates/media/src/worker.rs`: twelve debates permanently unpublishable between 2026-07-20 and 2026-08-20, *"and nobody noticed for a month"*. That fix addressed the cause of those twelve (a hard bail that now pads up to 10s). It did not make the next class of permanent failure any easier to see.

## Two codes

`media_not_ready` keeps what a later tick may resolve. `media_failed` marks what no tick ever will:

- **a `failed` job** — `MEDIA_JOB_MAX_ATTEMPTS` is spent; the worker is not coming back to it
- **a `succeeded` job with no `final_video`** — the job that would have produced one has finished

**A missing job row deliberately stays a wait.** A lost enqueue and an imminent one look identical from here, and reporting a debate as permanently dead when it is about to render would be worse than the silence this replaces. Pinned by a test so the next reader doesn't "tidy" it into the terminal branch.

## Where the number surfaces

The sweep collects those ids and returns them, so *"how many debates are stuck?"* is a field in a response that already runs every five minutes:

```json
{ "ok": true, "published": [], "pending": 3, "mediaFailed": ["debate-abc"], … }
```

Logged **once per sweep as an aggregate**, not per debate. These never leave the list, so a line each would be a few hundred a day per stuck debate — which trades a silent failure for an ignored one.

## Tests

This adds the sweep route's first tests, because the counting *is* the change:

- a failed job is reported apart from a pending one
- stuck debates don't spend the two-attempt budget and stall publishing for everyone else
- the auth gate, a normal publish, and the empty case

`DebateNotPublishableError` is left real in those tests rather than stubbed — the route branches on `instanceof`, so a stubbed class would send every outcome down the generic-failure path and the tests would prove nothing.

880 tests / 62 files green across `core/debates`, the debates pages and `app/api/debates`. `tsc` and lint clean on the touched files.

## Not in this PR

The worker comment names a root cause that is still open: *"the debate clock starts from the server's `preflight_ends_at` with nothing gating on the participants' recorders actually producing data."* The 10s pad recovers the warmup cases; the observed 27s, 50s and 58s misses stay hard failures by design. Closing that properly means gating the debate clock on recorders actually producing data — a cross-repo protocol change to the live debate path, and a design decision rather than a patch. This PR makes those failures visible in the meantime.
