### PR TITLE
feat(data-blocks): put remove in the collection row instead of behind the "..." menu

### DIFF
--- a/apps/web/partials/blocks/table/collection-metadata.tsx
+++ b/apps/web/partials/blocks/table/collection-metadata.tsx
@@ -56,11 +56,11 @@ export const CollectionMetadata = ({
   const hasHoverActions = !hideHoverActions && Boolean(relationId || showSidePanel || isEditing);
   const showHoverActions = isRowHovered;
   const reserveActionSpace = verified || hasHoverActions;
-  // Remove sits in the row now rather than inside the popover, so the actions are one control
-  // wider while editing and the name needs the room to match. Without it a long name runs under
-  // the button it is about to be deleted by.
+  // Remove took the arrow's place in the row and is the wider control of the two, so the name
+  // needs a little more room than the 56px the row used to reserve. Without it a long name runs
+  // under the button it is about to be deleted by.
   const hasRemoveAction = hasHoverActions && isEditing && Boolean(relationId);
-  const hoverActionPadding = hasRemoveAction ? 'pr-20' : 'pr-14';
+  const hoverActionPadding = hasRemoveAction ? 'pr-16' : 'pr-14';
   const paddingClass = hasHoverActions
     ? verified
       ? `${hoverActionPadding} md:pr-6`

--- a/apps/web/partials/blocks/table/collection-metadata.tsx
+++ b/apps/web/partials/blocks/table/collection-metadata.tsx
@@ -56,7 +56,18 @@ export const CollectionMetadata = ({
   const hasHoverActions = !hideHoverActions && Boolean(relationId || showSidePanel || isEditing);
   const showHoverActions = isRowHovered;
   const reserveActionSpace = verified || hasHoverActions;
-  const paddingClass = hasHoverActions ? (verified ? 'pr-14 md:pr-6' : 'pr-14 md:pr-0') : verified ? 'pr-6' : '';
+  // Remove sits in the row now rather than inside the popover, so the actions are one control
+  // wider while editing and the name needs the room to match. Without it a long name runs under
+  // the button it is about to be deleted by.
+  const hasRemoveAction = hasHoverActions && isEditing && Boolean(relationId);
+  const hoverActionPadding = hasRemoveAction ? 'pr-20' : 'pr-14';
+  const paddingClass = hasHoverActions
+    ? verified
+      ? `${hoverActionPadding} md:pr-6`
+      : `${hoverActionPadding} md:pr-0`
+    : verified
+      ? 'pr-6'
+      : '';
 
   return (
     <div

--- a/apps/web/partials/blocks/table/collection-row-actions.test.tsx
+++ b/apps/web/partials/blocks/table/collection-row-actions.test.tsx
@@ -1,0 +1,124 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+
+import type React from 'react';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { CollectionRowActions } from './collection-row-actions';
+
+/**
+ * GEO-2643. Removing a row from a collection used to live inside the "..." popover: hover the row,
+ * find the control, open it, then click through. This covers the promoted button — that it is
+ * there without opening anything, that it drops the row's own relation, and that it stays out of
+ * the way when there is nothing to remove.
+ */
+const ENTITY = '019fedae72b67ab2927adf044d57c566';
+const OTHER_ENTITY = '019fedae72b67ab2927adf044d57c567';
+const RELATION = '019fedae72b67ab2927adf044d57c600';
+const SPACE = '019fedae72b67ab2927adf044d57c500';
+
+type FakeRelation = { id: string; entityId: string; toEntity: { id: string } };
+
+const mocks = vi.hoisted(() => ({
+  relations: [] as FakeRelation[],
+  deleteRelation: vi.fn(),
+}));
+
+vi.mock('~/core/blocks/data/use-data-block', () => ({
+  useDataBlock: () => ({ blockEntity: { relations: mocks.relations } }),
+}));
+
+vi.mock('~/core/sync/use-mutate', () => ({
+  useMutate: () => ({ storage: { relations: { delete: mocks.deleteRelation } } }),
+}));
+
+vi.mock('~/core/hooks/use-space', () => ({ useSpace: () => ({ space: null }) }));
+
+vi.mock('~/design-system/geo-image', () => ({ GeoImage: () => null }));
+vi.mock('~/design-system/prefetch-link', () => ({
+  PrefetchLink: ({ children }: { children: React.ReactNode }) => <a href="#">{children}</a>,
+}));
+vi.mock('~/design-system/select-space-dialog', () => ({
+  SelectSpaceAsPopover: ({ trigger }: { trigger: React.ReactNode }) => <>{trigger}</>,
+}));
+vi.mock('~/partials/blocks/table/data-block-open-side-panel-button', () => ({
+  DataBlockOpenSidePanelButton: () => null,
+}));
+
+function renderActions(overrides: Partial<React.ComponentProps<typeof CollectionRowActions>> = {}) {
+  return render(
+    <CollectionRowActions
+      isEditing
+      currentSpaceId={SPACE}
+      entityId={ENTITY}
+      relationId={RELATION}
+      onLinkEntry={() => {}}
+      {...overrides}
+    />
+  );
+}
+
+const removeButton = () => screen.queryByRole('button', { name: 'Remove from collection' });
+
+beforeEach(() => {
+  mocks.relations = [{ id: RELATION, entityId: 'relation-entity', toEntity: { id: ENTITY } }];
+  mocks.deleteRelation.mockReset();
+});
+
+afterEach(cleanup);
+
+describe('CollectionRowActions remove', () => {
+  // The whole point of the ticket: no popover in the way.
+  it('offers remove without opening the row menu', () => {
+    renderActions();
+
+    expect(removeButton()).toBeInTheDocument();
+  });
+
+  it('removes the row on a single click', () => {
+    renderActions();
+
+    fireEvent.click(removeButton()!);
+
+    expect(mocks.deleteRelation).toHaveBeenCalledTimes(1);
+    expect(mocks.deleteRelation).toHaveBeenCalledWith(mocks.relations[0]);
+  });
+
+  // `blockEntity.relations` carries everything hanging off the block, not just its rows. Matching
+  // on what a relation points at would delete whichever reached this entity first.
+  it('drops the row relation, not another relation reaching the same entity', () => {
+    const blockType: FakeRelation = { id: 'types-relation', entityId: 'types-entity', toEntity: { id: ENTITY } };
+    const rowRelation: FakeRelation = { id: RELATION, entityId: 'relation-entity', toEntity: { id: ENTITY } };
+    mocks.relations = [blockType, rowRelation];
+
+    renderActions();
+    fireEvent.click(removeButton()!);
+
+    expect(mocks.deleteRelation).toHaveBeenCalledWith(rowRelation);
+  });
+
+  it('does nothing when the row relation is no longer on the block', () => {
+    mocks.relations = [{ id: 'someone-elses-relation', entityId: 'x', toEntity: { id: OTHER_ENTITY } }];
+
+    renderActions();
+    fireEvent.click(removeButton()!);
+
+    expect(mocks.deleteRelation).not.toHaveBeenCalled();
+  });
+
+  // Reading a block is not editing one.
+  it('leaves remove out when the block is not being edited', () => {
+    renderActions({ isEditing: false });
+
+    expect(removeButton()).not.toBeInTheDocument();
+  });
+
+  // A row with no collection-item relation has nothing to remove — query blocks derive their rows
+  // from the query, which is why the ticket scopes this to collections.
+  it('leaves remove out for a row with no relation of its own', () => {
+    renderActions({ relationId: undefined });
+
+    expect(removeButton()).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/partials/blocks/table/collection-row-actions.test.tsx
+++ b/apps/web/partials/blocks/table/collection-row-actions.test.tsx
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom/vitest';
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
 
 import type React from 'react';
 
@@ -37,7 +37,22 @@ vi.mock('~/core/hooks/use-space', () => ({ useSpace: () => ({ space: null }) }))
 
 vi.mock('~/design-system/geo-image', () => ({ GeoImage: () => null }));
 vi.mock('~/design-system/prefetch-link', () => ({
-  PrefetchLink: ({ children }: { children: React.ReactNode }) => <a href="#">{children}</a>,
+  PrefetchLink: ({
+    children,
+    href,
+    entityId: _entityId,
+    spaceId: _spaceId,
+    ...rest
+  }: {
+    children: React.ReactNode;
+    href?: string;
+    entityId?: string;
+    spaceId?: string;
+  }) => (
+    <a href={href ?? '#'} {...rest}>
+      {children}
+    </a>
+  ),
 }));
 vi.mock('~/design-system/select-space-dialog', () => ({
   SelectSpaceAsPopover: ({ trigger }: { trigger: React.ReactNode }) => <>{trigger}</>,
@@ -60,6 +75,18 @@ function renderActions(overrides: Partial<React.ComponentProps<typeof Collection
 }
 
 const removeButton = () => screen.queryByRole('button', { name: 'Remove from collection' });
+const navigateLink = () => screen.queryByRole('link', { name: 'Navigate to entity' });
+const rowMenuTrigger = () => screen.queryByRole('button', { name: 'Show row actions' });
+
+/**
+ * Radix mounts the popover's contents only while it is open, which hovering the trigger does, and
+ * gives that content `role="dialog"`. Returning it lets a test say an action is *in the menu*
+ * rather than merely somewhere on screen — which a link still sitting in the row would satisfy.
+ */
+function openRowMenu() {
+  fireEvent.mouseEnter(rowMenuTrigger()!);
+  return within(screen.getByRole('dialog'));
+}
 
 beforeEach(() => {
   mocks.relations = [{ id: RELATION, entityId: 'relation-entity', toEntity: { id: ENTITY } }];
@@ -105,6 +132,32 @@ describe('CollectionRowActions remove', () => {
     fireEvent.click(removeButton()!);
 
     expect(mocks.deleteRelation).not.toHaveBeenCalled();
+  });
+
+  // Navigate is a rarely-used action that was taking a permanent slot in the row next to the one
+  // people actually came for.
+  it('keeps navigate out of the row', () => {
+    renderActions();
+
+    expect(navigateLink()).not.toBeInTheDocument();
+  });
+
+  it('offers navigate inside the row menu instead', () => {
+    renderActions();
+
+    const menu = openRowMenu();
+
+    expect(menu.getByRole('link', { name: 'Navigate to entity' })).toBeInTheDocument();
+  });
+
+  // A placeholder row is editable before it has a collection-item relation. Navigate was reachable
+  // there before it moved, so the menu has to open without one.
+  it('still reaches navigate on a row with no relation yet', () => {
+    renderActions({ relationId: undefined });
+
+    const menu = openRowMenu();
+
+    expect(menu.getByRole('link', { name: 'Navigate to entity' })).toBeInTheDocument();
   });
 
   // Reading a block is not editing one.

--- a/apps/web/partials/blocks/table/collection-row-actions.tsx
+++ b/apps/web/partials/blocks/table/collection-row-actions.tsx
@@ -13,7 +13,7 @@ import { NavUtils } from '~/core/utils/utils';
 import { GeoImage } from '~/design-system/geo-image';
 import { Menu } from '~/design-system/icons/menu';
 import { RelationSmall } from '~/design-system/icons/relation-small';
-import { RightArrowLongChip } from '~/design-system/icons/right-arrow-long-chip';
+import { RightArrowLongSmall } from '~/design-system/icons/right-arrow-long-small';
 import { TopRanked } from '~/design-system/icons/top-ranked';
 import { Trash } from '~/design-system/icons/trash';
 import { PrefetchLink } from '~/design-system/prefetch-link';
@@ -95,7 +95,7 @@ export function CollectionRowActions({
 
   return (
     <div className="flex shrink-0 flex-nowrap items-center gap-0.5">
-      {relationId && (
+      {(relationId || isEditing) && (
         <Popover.Root open={isPopoverOpen} onOpenChange={setIsPopoverOpen}>
           <Popover.Trigger asChild>
             <button
@@ -148,7 +148,7 @@ export function CollectionRowActions({
                 setIsPopoverOpen(false);
               }}
             >
-              {isEditing && (
+              {isEditing && relationId && (
                 <SelectSpaceAsPopover
                   entityId={EntityId(entityId)}
                   spaceId={spaceId}
@@ -176,12 +176,25 @@ export function CollectionRowActions({
                   }
                 />
               )}
-              <PrefetchLink
-                href={`/space/${currentSpaceId}/${relationEntityId}`}
-                className="p-1 group-hover:text-grey-03 hover:text-text!"
-              >
-                <RelationSmall />
-              </PrefetchLink>
+              {relationId && (
+                <PrefetchLink
+                  href={`/space/${currentSpaceId}/${relationEntityId}`}
+                  className="p-1 group-hover:text-grey-03 hover:text-text!"
+                >
+                  <RelationSmall />
+                </PrefetchLink>
+              )}
+              {isEditing && (
+                <PrefetchLink
+                  href={NavUtils.toEntity(spaceId ?? currentSpaceId, entityId, true)}
+                  entityId={entityId}
+                  spaceId={spaceId ?? currentSpaceId}
+                  aria-label="Navigate to entity"
+                  className="p-1 group-hover:text-grey-03 hover:text-text!"
+                >
+                  <RightArrowLongSmall />
+                </PrefetchLink>
+              )}
             </Popover.Content>
           </Popover.Portal>
         </Popover.Root>
@@ -193,19 +206,8 @@ export function CollectionRowActions({
           openedWithMainViewEditing={openedWithMainViewEditing}
         />
       )}
-      {isEditing && (
-        <PrefetchLink
-          href={NavUtils.toEntity(spaceId ?? currentSpaceId, entityId, true)}
-          entityId={entityId}
-          spaceId={spaceId ?? currentSpaceId}
-          aria-label="Navigate to entity"
-          className="inline-flex shrink-0 items-center text-grey-03 transition duration-300 ease-in-out hover:text-text"
-        >
-          <RightArrowLongChip />
-        </PrefetchLink>
-      )}
-      {/* Last in the row on purpose: the only destructive action here, kept furthest from the two
-          people reach for by habit. Grey until hovered, then red — the row shouldn't shout at
+      {/* Last in the row on purpose: the only destructive action here, kept furthest from the side
+          panel people open by habit. Grey until hovered, then red — the row shouldn't shout at
           someone who is only reading it. No confirmation: this is an edit like any other, and the
           review bar is where it gets taken back. */}
       {isEditing && relationId && (

--- a/apps/web/partials/blocks/table/collection-row-actions.tsx
+++ b/apps/web/partials/blocks/table/collection-row-actions.tsx
@@ -11,11 +11,11 @@ import { useMutate } from '~/core/sync/use-mutate';
 import { NavUtils } from '~/core/utils/utils';
 
 import { GeoImage } from '~/design-system/geo-image';
-import { CheckCloseSmall } from '~/design-system/icons/check-close-small';
 import { Menu } from '~/design-system/icons/menu';
 import { RelationSmall } from '~/design-system/icons/relation-small';
 import { RightArrowLongChip } from '~/design-system/icons/right-arrow-long-chip';
 import { TopRanked } from '~/design-system/icons/top-ranked';
+import { Trash } from '~/design-system/icons/trash';
 import { PrefetchLink } from '~/design-system/prefetch-link';
 import { SelectSpaceAsPopover } from '~/design-system/select-space-dialog';
 
@@ -65,12 +65,18 @@ export function CollectionRowActions({
     };
   }, []);
 
+  // By the relation's own id, not by what it points at. `blockEntity.relations` holds everything
+  // hanging off the block — its types, its blocks, its filters — so matching on `toEntity.id` would
+  // delete whichever of those happened to reach this entity first. That was survivable while
+  // removal took two deliberate interactions to reach; as a one-click control on every row it is
+  // not. `relationId` is the collection-item relation for this row (use-mapping.ts:127), which is
+  // exactly the one to drop.
   const onDeleteEntry = async () => {
-    if (blockEntity) {
-      const blockRelation = blockEntity.relations.find(r => r.toEntity.id === entityId);
-      if (blockRelation) {
-        storage.relations.delete(blockRelation);
-      }
+    if (!blockEntity || !relationId) return;
+
+    const blockRelation = blockEntity.relations.find(r => r.id === relationId);
+    if (blockRelation) {
+      storage.relations.delete(blockRelation);
     }
   };
 
@@ -176,16 +182,6 @@ export function CollectionRowActions({
               >
                 <RelationSmall />
               </PrefetchLink>
-              {isEditing && (
-                <button
-                  type="button"
-                  onClick={onDeleteEntry}
-                  onMouseDown={e => e.preventDefault()}
-                  className="p-1 group-hover:text-grey-03 hover:text-text!"
-                >
-                  <CheckCloseSmall />
-                </button>
-              )}
             </Popover.Content>
           </Popover.Portal>
         </Popover.Root>
@@ -207,6 +203,22 @@ export function CollectionRowActions({
         >
           <RightArrowLongChip />
         </PrefetchLink>
+      )}
+      {/* Last in the row on purpose: the only destructive action here, kept furthest from the two
+          people reach for by habit. Grey until hovered, then red — the row shouldn't shout at
+          someone who is only reading it. No confirmation: this is an edit like any other, and the
+          review bar is where it gets taken back. */}
+      {isEditing && relationId && (
+        <button
+          type="button"
+          aria-label="Remove from collection"
+          title="Remove from collection"
+          onClick={onDeleteEntry}
+          onMouseDown={e => e.preventDefault()}
+          className="inline-flex h-5 w-5 shrink-0 items-center justify-center text-grey-03 transition duration-300 ease-in-out hover:text-red-01"
+        >
+          <Trash />
+        </button>
       )}
     </div>
   );


### PR DESCRIPTION
Closes GEO-2643.

## What

Reshuffles the collection row's hover actions so the common one is one click and the rare ones are behind the menu.

| | Before | After |
|---|---|---|
| **In the row** | `...` menu, side panel, navigate | `...` menu, side panel, **remove** |
| **In the `...` menu** | space selector, relation link, remove | space selector, relation link, **navigate** |

Removing a row took two deliberate interactions and gave no sign it was possible: hover the row, find the small `...`, open it, then pick the circled x from three unlabelled icons. Navigate, meanwhile, held a permanent slot in the row despite being the rarest of these actions.

## Design calls

- **Remove is last in the row.** It's the only destructive action here, and the side panel beside it is what people open by habit. Putting remove at the end keeps a mis-click from being the expensive one.
- **Grey until hovered, then red.** A row someone is only reading shouldn't shout at them; the intent shows up at the moment they aim for it.
- **Trash, not the circled x.** `ranking-compose-swipeable-row` already uses the trash for exactly this job. The circled x read as "dismiss" more than "delete".
- **No confirmation.** This is an edit like any other — it lands in the review bar, which is where it gets taken back.
- **The bare arrow inside the menu.** `RightArrowLongChip` carries its own outline, drawn for the row, and sat a size above its neighbours in the popover. `RightArrowLongSmall` (14×12) matches the 12px icons beside it.

## One fix that came with it

`onDeleteEntry` looked the relation up by what it points at:

```ts
const blockRelation = blockEntity.relations.find(r => r.toEntity.id === entityId);
```

`blockEntity.relations` holds everything hanging off the block — its types, its blocks, its filters — so this deleted whichever of those reached the row's entity first, not necessarily the row. Survivable while removal was two interactions deep. As a one-click control on every row it isn't, so it now matches on `relationId`, which `use-mapping.ts:127` sets to the row's own collection-item relation.

Still ambiguous for a collection holding the same entity twice — both rows get the same `relationId` upstream in `use-mapping`. Out of scope here, and unchanged by this PR either way.

## Two smaller consequences

**The menu is no longer gated on the row having a relation.** Navigate doesn't need one, and a placeholder row is editable before it has a collection-item relation — navigate was reachable there before it moved, so gating the whole popover on `relationId` would have lost it. Each item carries its own condition now.

**Reserved name-column width.** It went up when remove joined the row and back down once navigate left; the row is three controls wide again, just 4px wider than before since remove (20px) replaces the arrow (16px). `pr-14` → `pr-16`.

## Scope

Collections only, as the ticket asks. These actions come from `CollectionMetadata`, which the name cell renders only when `source.type === 'COLLECTION'` (`editable-entity-table-cell.tsx:116`). Query blocks derive their rows and have nothing to remove.

## Testing

- `collection-row-actions.test.tsx` — new, 9 cases: remove is present without opening anything, one click removes, it drops the row's relation rather than another relation reaching the same entity, it no-ops when the relation is gone, it stays out for a non-editing viewer and for a row with no relation of its own; navigate is out of the row, inside the menu, and still reachable on a row with no relation yet.
- Verified non-vacuous by reverting each change separately: removing the promoted button fails 4 cases, restoring the old `toEntity.id` lookup fails the targeting case alone, and putting navigate back in the row fails all 3 navigate cases.
  - The navigate assertions initially passed under that last revert — they only checked the link existed *somewhere*. They now assert it is within the popover's `role="dialog"`, which is what actually distinguishes the two placements.
- `bun run vitest run core partials app` → 278 files / 2829 tests pass.
- `NEXT_PUBLIC_CHAIN_ID=55516 bun run build` → clean.

Not verified in a running browser. Worth checking the hover row in all three views that render these actions — table, list, and gallery — since they reserve space differently.