### PR TITLE
fix(community-calls): tie the forced call cutoff to the occurrence actually joined

### DIFF
--- a/apps/web/core/community-calls/constants.ts
+++ b/apps/web/core/community-calls/constants.ts
@@ -120,3 +120,13 @@ export const LIVE_WINDOW_AFTER_MS = 30 * 60 * 1000;
 export function isOccurrenceLive(startMs: number, endMs: number, now = Date.now()): boolean {
   return now >= startMs - LIVE_WINDOW_BEFORE_MS && now <= endMs + LIVE_WINDOW_AFTER_MS;
 }
+
+/**
+ * How often "which occurrence is live" is re-evaluated while a call page is open.
+ *
+ * Answering it once on load leaves a tab that has been open across a boundary reporting
+ * the wrong occurrence — or none at all, which silently blocks the viewer auto-join. Half
+ * a minute is well inside the 15-minute join window on either side, so a tick can't land
+ * a user outside a window they are genuinely in.
+ */
+export const LIVE_OCCURRENCE_TICK_MS = 30 * 1000;

--- a/apps/web/core/community-calls/occurrences.test.ts
+++ b/apps/web/core/community-calls/occurrences.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { bucketOccurrences, getOccurrences } from './occurrences';
+import { bucketOccurrences, findOccurrenceByStart, getOccurrences } from './occurrences';
 
 // Fixed "now" so the windowed expansion is deterministic.
 const NOW = Date.UTC(2026, 2, 5, 17, 30); // 2026-03-05 17:30 UTC
@@ -69,5 +69,42 @@ describe('bucketOccurrences', () => {
     expect(live!.startMs).toBe(Date.UTC(2026, 2, 5, 17, 0));
     expect(upcoming.every(o => o.startMs > NOW)).toBe(true);
     expect(past.every(o => o.endMs < NOW)).toBe(true);
+  });
+});
+
+// Anything acting on the occurrence a user actually joined must resolve it from the
+// server's `occurrenceStart`, not from "what is live now". A page open across a boundary
+// disagrees, and acting on the wrong occurrence put the forced end-of-call cutoff in the
+// past — which disconnects the moment it is evaluated (GEO-2584).
+describe('findOccurrenceByStart', () => {
+  const WEEKLY = 'DTSTART:20260305T170000Z\nDTEND:20260305T180000Z\nRRULE:FREQ=WEEKLY;BYDAY=TH';
+
+  it('resolves the occurrence for an exact start', () => {
+    const start = Date.UTC(2026, 2, 12, 17, 0); // the following Thursday
+    expect(findOccurrenceByStart(WEEKLY, start)?.endMs).toBe(Date.UTC(2026, 2, 12, 18, 0));
+  });
+
+  it('resolves a start that is near-miss rather than identical', () => {
+    // The server's instant need not match the locally expanded one to the millisecond.
+    const start = Date.UTC(2026, 2, 12, 17, 0) + 60_000;
+    expect(findOccurrenceByStart(WEEKLY, start)?.startMs).toBe(Date.UTC(2026, 2, 12, 17, 0));
+  });
+
+  // The point of the helper: expansion is centred on the target, not on `now`. This start
+  // is deliberately outside the +180-day expansion window measured from NOW, so a version
+  // that expanded around `now` would miss it — as the assertion below asserts directly.
+  it('resolves an occurrence outside the window that `now` would expand', () => {
+    const farStart = Date.UTC(2027, 2, 4, 17, 0); // ~1 year on, still a Thursday
+    expect(getOccurrences(WEEKLY, NOW).some(o => o.startMs === farStart)).toBe(false);
+    expect(findOccurrenceByStart(WEEKLY, farStart)?.endMs).toBe(Date.UTC(2027, 2, 4, 18, 0));
+  });
+
+  it('returns null when nothing lands within tolerance', () => {
+    const notAnOccurrence = Date.UTC(2026, 2, 10, 3, 0); // a Tuesday at 03:00
+    expect(findOccurrenceByStart(WEEKLY, notAnOccurrence)).toBeNull();
+  });
+
+  it('returns null for an empty schedule rather than throwing', () => {
+    expect(findOccurrenceByStart('', Date.UTC(2026, 2, 12, 17, 0))).toBeNull();
   });
 });

--- a/apps/web/core/community-calls/occurrences.ts
+++ b/apps/web/core/community-calls/occurrences.ts
@@ -5,6 +5,7 @@
  */
 import { localToUtcMs, parseSchedule } from '~/core/utils/schedule';
 
+import { OCCURRENCE_MATCH_TOLERANCE_MS } from './constants';
 import { Occurrence } from './types';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -146,4 +147,25 @@ export function bucketOccurrences(occurrences: Occurrence[], now = Date.now()): 
   const upcoming = occurrences.filter(o => o.startMs > now && o !== live).sort((a, b) => a.startMs - b.startMs);
   const past = occurrences.filter(o => o.endMs < now && o !== live).sort((a, b) => b.startMs - a.startMs);
   return { live, upcoming, past };
+}
+
+/**
+ * The occurrence a given `occurrenceStart` refers to, or null.
+ *
+ * Anything acting on the occurrence a user actually joined has to resolve it from the
+ * `occurrenceStart` the server minted their token for, rather than recomputing "what is
+ * live now" — the two disagree for a page that has been open across a boundary, and
+ * acting on the wrong occurrence is how a forced end-of-call cutoff lands in the past.
+ *
+ * Matched within {@link OCCURRENCE_MATCH_TOLERANCE_MS}: the server's instant need not be
+ * byte-identical to the locally expanded one. Expansion is centred on the target rather
+ * than on `now`, so a start far outside the current window still resolves.
+ */
+export function findOccurrenceByStart(schedule: string, occurrenceStart: number): Occurrence | null {
+  if (!schedule) return null;
+  return (
+    getOccurrences(schedule, occurrenceStart).find(
+      occurrence => Math.abs(occurrence.startMs - occurrenceStart) <= OCCURRENCE_MATCH_TOLERANCE_MS
+    ) ?? null
+  );
 }

--- a/apps/web/partials/community-calls/community-call-flow.tsx
+++ b/apps/web/partials/community-calls/community-call-flow.tsx
@@ -8,8 +8,8 @@ import * as React from 'react';
 import { Effect } from 'effect';
 
 import { getCommunityCallToken, getViewerToken } from '~/core/community-calls/api';
-import { CALL_SCHEMA, buildRoomName, isOccurrenceLive } from '~/core/community-calls/constants';
-import { getOccurrences } from '~/core/community-calls/occurrences';
+import { CALL_SCHEMA, LIVE_OCCURRENCE_TICK_MS, buildRoomName, isOccurrenceLive } from '~/core/community-calls/constants';
+import { findOccurrenceByStart, getOccurrences } from '~/core/community-calls/occurrences';
 import { CommunityCallToken, ViewerToken } from '~/core/community-calls/types';
 import { useCommunityCallIdentityToken } from '~/core/community-calls/use-identity-token';
 import { useAccessControl } from '~/core/hooks/use-access-control';
@@ -65,11 +65,40 @@ export function CommunityCallFlow({ spaceId, callId }: { spaceId: string; callId
   const [joining, setJoining] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
 
+  // Re-read on a tick rather than once. `Date.now()` inside a memo keyed only on the
+  // schedule freezes "what is live" at the moment the schedule loaded, so a page left
+  // open across a boundary keeps answering with the wrong occurrence — or with none,
+  // which is what stops the viewer auto-join below from ever firing once a call goes
+  // live under an already-open tab.
+  const [nowTick, setNowTick] = React.useState(() => Date.now());
+  React.useEffect(() => {
+    const interval = window.setInterval(() => setNowTick(Date.now()), LIVE_OCCURRENCE_TICK_MS);
+    return () => window.clearInterval(interval);
+  }, []);
+
   const liveOccurrence = React.useMemo(() => {
     if (!data?.schedule) return null;
-    const now = Date.now();
-    return getOccurrences(data.schedule, now).find(o => isOccurrenceLive(o.startMs, o.endMs, now)) ?? null;
-  }, [data?.schedule]);
+    return getOccurrences(data.schedule, nowTick).find(o => isOccurrenceLive(o.startMs, o.endMs, nowTick)) ?? null;
+  }, [data?.schedule, nowTick]);
+
+  /**
+   * The end of the occurrence the viewer actually joined, taken from the `occurrenceStart`
+   * the server minted the token for.
+   *
+   * Deliberately not `liveOccurrence.endMs`. That is a client-side answer to "what is live
+   * right now", and the forced cutoff has to be tied to the occurrence the participant is
+   * *in*. When the two disagreed the cutoff was computed from the wrong occurrence, and a
+   * past one puts `hardCutoffMs` behind us — so `CallEndTimer` reaches `remaining <= 0` on
+   * its first tick and disconnects immediately, which reads as being kicked out mid-call.
+   *
+   * Matched with the same tolerance the other occurrence lookups use, since the server's
+   * `occurrenceStart` need not be identical to the locally computed instant.
+   */
+  const joinedOccurrenceEnd = React.useMemo(() => {
+    const occurrenceStart = joined?.token.occurrenceStart;
+    if (!data?.schedule || occurrenceStart === undefined) return undefined;
+    return findOccurrenceByStart(data.schedule, occurrenceStart)?.endMs;
+  }, [data?.schedule, joined]);
 
   const backHref = `/space/${spaceId}/community`;
   const spaceName = data?.spaceName ?? 'this space';
@@ -119,7 +148,7 @@ export function CommunityCallFlow({ spaceId, callId }: { spaceId: string; callId
         spaceId={spaceId}
         callId={callId}
         occurrenceStart={joined.token.occurrenceStart}
-        occurrenceEnd={liveOccurrence?.endMs}
+        occurrenceEnd={joinedOccurrenceEnd}
         audio={joined.settings.audioEnabled}
         video={joined.settings.videoEnabled}
         backHref={backHref}
@@ -139,7 +168,7 @@ export function CommunityCallFlow({ spaceId, callId }: { spaceId: string; callId
         spaceId={spaceId}
         callId={callId}
         occurrenceStart={joined.token.occurrenceStart}
-        occurrenceEnd={liveOccurrence?.endMs}
+        occurrenceEnd={joinedOccurrenceEnd}
         audio={false}
         video={false}
         backHref={backHref}


### PR DESCRIPTION
Addresses [GEO-2584](https://linear.app/geobrowser/issue/GEO-2584/bug-users-getting-kicked-out-of-community-calls-mid-call). The ticket has no description, so this is one mechanism found by reading the code — not a confirmed reproduction of what Preston saw. See *Scope* below.

## The mechanism

The forced end-of-call cutoff was fed `liveOccurrence?.endMs` — a **client-side** answer to "which occurrence is live right now" — while the participant is in whichever occurrence **the server** minted their token for. When those disagree, the cutoff is computed from the wrong occurrence.

That alone disconnects someone. `CallEndTimer` fires `onTimeUp` the instant `hardCutoffMs` is in the past, and `onTimeUp` leaves the room:

```ts
const remaining = Math.max(Math.ceil((hardCutoffMs - now) / 1000), 0);
if (remaining <= 0 && !firedRef.current) { firedRef.current = true; onTimeUp?.(); }
```

So a cutoff derived from an *earlier* occurrence fires on the timer's first tick, with no countdown banner and nothing the user could anticipate.

## Why it was easy to hit

```ts
const liveOccurrence = React.useMemo(() => {
  const now = Date.now();          // ← captured inside the memo
  return getOccurrences(data.schedule, now).find(o => isOccurrenceLive(o.startMs, o.endMs, now));
}, [data?.schedule]);              // ← only re-runs when the schedule changes
```

It answered **once**, when the schedule loaded, and never again. A tab left open across an occurrence boundary — an obvious thing to do with a recurring call — kept reporting the previous occurrence, or none at all.

## The fix

**Cutoff resolves from the token's `occurrenceStart`** via a new `findOccurrenceByStart`, so it describes the occurrence the participant is actually in and cannot drift from it. Matching uses the existing `OCCURRENCE_MATCH_TOLERANCE_MS`, since the server's instant needn't equal the locally expanded one.

**`liveOccurrence` re-evaluates on a 30s tick.** That also unblocks a second bug: with a frozen `null`, the viewer auto-join effect (`!liveOccurrence` → return) could never fire for a tab that was already open when the call went live. 30s is well inside the 15-minute join window on either side, so a tick can't land a user outside a window they're genuinely in.

`findOccurrenceByStart` centres its expansion on the target instant rather than on `now`, which is the whole point — expanding around `now` is what returned the wrong occurrence.

## Tests

Five new cases on the helper (exact match, near-miss within tolerance, empty schedule, no match, and out-of-window). The out-of-window one asserts **both halves**:

```ts
expect(getOccurrences(WEEKLY, NOW).some(o => o.startMs === farStart)).toBe(false);
expect(findOccurrenceByStart(WEEKLY, farStart)?.endMs).toBe(...);
```

My first version used a start two months out, which sits inside the −60/+180-day expansion window — so it passed whether or not the helper centred correctly. Worth flagging because a test that can't fail is worse than no test.

46 tests / 4 files green across `core/community-calls` and `partials/community-calls`. `tsc` and lint clean.

## Scope — what this does not fix

**Participant identity is the user's space id** (`getStableProfileIdentity = profile.spaceId`), which is permanently stable. LiveKit evicts the existing participant when the same identity joins again, so a second tab or any rejoin still disconnects the live session. `useReconnectionState` already surfaces that as an overlay rather than a silent boot, but the eviction itself is inherent to a stable identity and is a design question — noted on the ticket rather than changed here.

Also unchanged, and worth knowing it's deliberate: a call is force-ended 30 minutes after its scheduled end (`LIVE_MEETING_GRACE_MINUTES`), with a countdown banner from 25 minutes. If the reports are of calls ending at a *predictable* time rather than at random, that's the behaviour to revisit — not this.
