### PR TITLE
feat(debates): gate claims on the spaces the debates bot can actually publish into

### DIFF
--- a/apps/web/app/api/debates/publishable-spaces/route.ts
+++ b/apps/web/app/api/debates/publishable-spaces/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from 'next/server';
+
+import { getDebateAcceptorConfig } from '~/core/debates/server/acceptor-config';
+import { listEditorSpaceIds } from '~/core/debates/server/editor-spaces';
+
+/**
+ * The spaces a finished debate could actually be published into.
+ *
+ * A debate is published by the acceptor service account into the *claim's home space*, and that
+ * needs editor rights there — a member can propose but not vote and execute, so anything else
+ * reverts on-chain. So the set of spaces that can host a debate is exactly the set the acceptor
+ * edits, which is the same set the publish sweep uses to discover its work (`listEditorSpaceIds`).
+ * One source of truth for "can this claim carry a debate", read by both ends.
+ *
+ * This exists because `DEBATE_ACCEPTOR_SPACE_ID` is server-only and should stay that way. The
+ * client needs the *answer*, not the acceptor's identity, so the resolution happens here.
+ *
+ * Nothing here is sensitive: it is a list of public space ids, and it says only which spaces are
+ * debatable — which is already observable by trying. No auth, so it can be cached and shared.
+ */
+
+/** Editor sets change when someone is added to a space, which is rare. */
+export const revalidate = 300;
+
+export async function GET() {
+  const config = getDebateAcceptorConfig();
+
+  // `null`, not `[]`. An empty array is a real answer meaning "nothing is debatable"; a missing
+  // acceptor means the question cannot be answered here, and callers must fall through to their
+  // other filters rather than emptying every list. Local and preview environments run without an
+  // acceptor configured, and they should still show a usable picker.
+  if (!config) {
+    return NextResponse.json({ spaceIds: null });
+  }
+
+  try {
+    const spaceIds = await listEditorSpaceIds(config.spaceId);
+    return NextResponse.json({ spaceIds });
+  } catch (error) {
+    // Same reasoning as above: a failed lookup is "unknown", not "nothing is publishable".
+    console.error('[debates] could not resolve publishable spaces', error);
+    return NextResponse.json({ spaceIds: null });
+  }
+}

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
@@ -77,6 +77,7 @@ const mocks = vi.hoisted(() => ({
   spaceAllowlist: null as Set<string> | null,
   allowlistLoading: false,
   spaceTypes: {} as Record<string, 'DAO' | 'PERSONAL'>,
+  publishableSpaceIds: null as Set<string> | null,
   scrollSentinelIntoView: null as null | (() => void),
   claimReadinessLoading: false,
   claimReadinessError: false,
@@ -262,6 +263,13 @@ vi.mock('~/core/debates/recommended-claims', () => ({
   }),
 }));
 
+// The acceptor's editor spaces. Null is "unknown", which does not filter — so every case that
+// isn't about this gate behaves as before.
+vi.mock('~/core/debates/use-debate-publishable-spaces', async importOriginal => {
+  const actual = await importOriginal<typeof import('~/core/debates/use-debate-publishable-spaces')>();
+  return { ...actual, useDebatePublishableSpaces: () => ({ publishableSpaceIds: mocks.publishableSpaceIds, isLoading: false }) };
+});
+
 // Null is "the allowlist hasn't resolved", which every case that isn't about it runs under.
 vi.mock('~/core/debates/use-claim-space-allowlist', () => ({
   useClaimSpaceAllowlist: () => ({ allowlist: mocks.spaceAllowlist, isLoading: mocks.allowlistLoading }),
@@ -349,6 +357,7 @@ beforeEach(() => {
   mocks.spaceAllowlist = null;
   mocks.allowlistLoading = false;
   mocks.spaceTypes = {};
+  mocks.publishableSpaceIds = null;
   // jsdom has no IntersectionObserver, which the infinite-scroll sentinel builds. This one records
   // the callback so a test can say the sentinel scrolled into view.
   mocks.scrollSentinelIntoView = null;
@@ -1144,6 +1153,39 @@ describe('DebateRematchPageClient', () => {
 
       // Resolving to the personal space would have filtered it out entirely.
       expect(await screen.findByText('A claim in two spaces')).toBeInTheDocument();
+    });
+
+    // Preston's refinement, on top of the space-type test: the authoritative constraint is the
+    // set of spaces the acceptor is an *editor* of, which is the same set the publish sweep works
+    // from. This catches an ordinary public space the acceptor simply does not edit — invisible to
+    // the type test, and a debate there fails on-chain exactly as a personal space does.
+    it('drops a claim from a public space the acceptor does not edit', async () => {
+      mocks.claims = [sharedClaim()];
+      mocks.spaceTypes = { [SPACE_1]: 'DAO' };
+      mocks.publishableSpaceIds = new Set([SPACE_2.replace(/-/g, '')]);
+      render(<DebateRematchPageClient sessionId="rematch-1" />);
+
+      await waitFor(() => expect(screen.queryByText('A claim both participants chose')).toBeNull());
+    });
+
+    it('keeps a claim from a space the acceptor does edit', () => {
+      mocks.claims = [sharedClaim()];
+      mocks.spaceTypes = { [SPACE_1]: 'DAO' };
+      mocks.publishableSpaceIds = new Set([SPACE_1.replace(/-/g, '')]);
+      render(<DebateRematchPageClient sessionId="rematch-1" />);
+
+      expect(screen.getByText('A claim both participants chose')).toBeInTheDocument();
+    });
+
+    // The two gates fail differently, which is why both are kept. With the editor list unknown,
+    // the type test still rules out the case that actually caused the incident.
+    it('still drops a personal-space claim when the editor list is unknown', async () => {
+      mocks.claims = [sharedClaim()];
+      mocks.spaceTypes = { [SPACE_1]: 'PERSONAL' };
+      mocks.publishableSpaceIds = null;
+      render(<DebateRematchPageClient sessionId="rematch-1" />);
+
+      await waitFor(() => expect(screen.queryByText('A claim both participants chose')).toBeNull());
     });
 
     it('keeps a claim in a DAO space, which the acceptor can publish into', () => {

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -24,6 +24,7 @@ import { type ClaimPickerEntity, useClaimEntitiesByIds } from '~/core/debates/cl
 import { isClaimSpaceAllowed } from '~/core/debates/claim-space-allowlist';
 import { markEnteringDebate } from '~/core/debates/debate-entry-intent';
 import { useDebateGatewaySpaceScopes } from '~/core/debates/debate-gateway';
+import { debatePublishableSpacePredicate } from '~/core/debates/debate-publish-target';
 import { DebateRequestDialog } from '~/core/debates/debate-request-dialog';
 import { consumeDebateReturnDestination } from '~/core/debates/debate-return-navigation';
 import { defaultDebateFormatId } from '~/core/debates/formats';
@@ -39,7 +40,6 @@ import {
   useLeaveDebateRematch,
   useRejectDebateRematchRequest,
 } from '~/core/debates/hooks';
-import { debatePublishableSpacePredicate } from '~/core/debates/debate-publish-target';
 import { SpaceTopicFilters } from '~/core/debates/matchmaking/claims-tab';
 import { useMatchmakingClaims } from '~/core/debates/matchmaking/hooks';
 import { HubCardList } from '~/core/debates/matchmaking/hub-motion';
@@ -52,6 +52,7 @@ import { useRecommendedClaimSections } from '~/core/debates/recommended-claims';
 import { useClaimDebateReadiness } from '~/core/debates/use-claim-debate-readiness';
 import { useClaimSpaceAllowlist } from '~/core/debates/use-claim-space-allowlist';
 import { useCurrentGeoChatUserId } from '~/core/debates/use-current-geo-chat-user-id';
+import { isSpaceDebatePublishable, useDebatePublishableSpaces } from '~/core/debates/use-debate-publishable-spaces';
 import { useEntitySidePanel } from '~/core/hooks/use-entity-side-panel';
 import { useEntityResponse } from '~/core/hooks/use-entity-vote';
 import { useInfiniteScrollSentinel } from '~/core/hooks/use-infinite-scroll-sentinel';
@@ -284,7 +285,20 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
     return [...ids];
   }, [browsedPages, opponentEntitiesQuery.entities, recommendedEntities, savedClaimsQuery.data]);
   const { spacesById: candidateSpaces } = useSpacesByIds(candidateSpaceIds);
-  const canPublishDebateIn = React.useMemo(() => debatePublishableSpacePredicate(candidateSpaces), [candidateSpaces]);
+  // The acceptor's editor spaces are the authoritative answer, and the same set the publish sweep
+  // works from. The space-type test below it is kept rather than replaced: the two fail
+  // differently, and when this list is unknown — no acceptor configured, a failed lookup — the
+  // type test still rules out the case that actually bit us, claims living in a personal space.
+  const { publishableSpaceIds } = useDebatePublishableSpaces();
+  const spaceTypePublishable = React.useMemo(
+    () => debatePublishableSpacePredicate(candidateSpaces),
+    [candidateSpaces]
+  );
+  const canPublishDebateIn = React.useCallback(
+    (spaceId: string | null | undefined) =>
+      isSpaceDebatePublishable(spaceId, publishableSpaceIds) && spaceTypePublishable(spaceId),
+    [publishableSpaceIds, spaceTypePublishable]
+  );
 
   /** A picker row from a graph entity, with geo-chat's session row layered on when it has one. */
   const rowFromEntity = React.useCallback(

--- a/apps/web/core/debates/use-debate-publishable-spaces.test.ts
+++ b/apps/web/core/debates/use-debate-publishable-spaces.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+
+import { isSpaceDebatePublishable } from './use-debate-publishable-spaces';
+
+const EDITED = '41e851610e13a19441c4d980f2f2ce6b';
+const NOT_EDITED = '8a4955bcd9d0fc0d8613f17f01de3b9f';
+
+describe('isSpaceDebatePublishable', () => {
+  it('accepts a space the acceptor edits', () => {
+    expect(isSpaceDebatePublishable(EDITED, new Set([EDITED]))).toBe(true);
+  });
+
+  // The case the space-type test cannot see: a perfectly ordinary public space that the acceptor
+  // simply is not an editor of. A debate there fails on-chain exactly as a personal space does.
+  it('rejects a space the acceptor does not edit', () => {
+    expect(isSpaceDebatePublishable(NOT_EDITED, new Set([EDITED]))).toBe(false);
+  });
+
+  // A claim row carries the spelling the graph was queried with; the editor list carries the one
+  // the API answered with. Matching them literally would reject every dashed id.
+  it('matches ids across dash spellings', () => {
+    const dashed = '41e85161-0e13-a194-41c4-d980f2f2ce6b';
+    expect(isSpaceDebatePublishable(dashed, new Set([EDITED]))).toBe(true);
+  });
+
+  // `null` is "the lookup has no answer" — no acceptor configured, or it failed. Reading that as
+  // "nothing is publishable" would empty every list in the picker on a transient error, and local
+  // environments run with no acceptor at all.
+  it('does not filter while the answer is unknown', () => {
+    expect(isSpaceDebatePublishable(NOT_EDITED, null)).toBe(true);
+  });
+
+  // An empty set is a real answer, unlike null: the acceptor edits nothing, so nothing is debatable.
+  it('rejects everything when the acceptor genuinely edits no spaces', () => {
+    expect(isSpaceDebatePublishable(EDITED, new Set())).toBe(false);
+  });
+
+  it('rejects a claim with no home space at all', () => {
+    expect(isSpaceDebatePublishable(null, new Set([EDITED]))).toBe(false);
+    expect(isSpaceDebatePublishable('', new Set([EDITED]))).toBe(false);
+  });
+});

--- a/apps/web/core/debates/use-debate-publishable-spaces.ts
+++ b/apps/web/core/debates/use-debate-publishable-spaces.ts
@@ -1,0 +1,58 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+
+import * as React from 'react';
+
+import { normId } from '~/core/utils/norm-id';
+
+/**
+ * The spaces a finished debate could actually be published into — the ones the acceptor edits.
+ *
+ * This is the authoritative answer to "can this claim carry a debate", and it is the one the
+ * publish sweep acts on. `isDebatePublishableSpace` only ever approximated it: it can rule out a
+ * personal space from the space type alone, but a *public* space the acceptor happens not to edit
+ * fails in exactly the same way and is indistinguishable without this list.
+ *
+ * `null` means unknown — no acceptor configured, or the lookup failed. Callers must read that as
+ * "don't filter on this", never as "nothing is publishable"; the alternative empties every list in
+ * the picker on a transient error, and local environments run with no acceptor at all.
+ */
+export function useDebatePublishableSpaces(): {
+  /** Normalized space ids, or null while unknown. */
+  publishableSpaceIds: Set<string> | null;
+  isLoading: boolean;
+} {
+  const { data, isLoading } = useQuery({
+    queryKey: ['debates', 'publishable-spaces'],
+    queryFn: async (): Promise<string[] | null> => {
+      const response = await fetch('/api/debates/publishable-spaces');
+      if (!response.ok) return null;
+      const body = (await response.json()) as { spaceIds?: string[] | null };
+      return body.spaceIds ?? null;
+    },
+    // Editor sets change when someone is added to a space. Refetching this per mount would spend a
+    // request on an answer that is the same all session.
+    staleTime: 5 * 60_000,
+    retry: false,
+  });
+
+  const publishableSpaceIds = React.useMemo(
+    () => (data ? new Set(data.map(normId)) : null),
+    [data]
+  );
+
+  return { publishableSpaceIds, isLoading };
+}
+
+/**
+ * Whether a debate on a claim in this space could be published, given whatever the lookup knows.
+ *
+ * Ids are normalized on both sides: a claim row carries the spelling the graph was queried with,
+ * while the editor list carries the spelling the API answered with, and the two differ by dashes.
+ */
+export function isSpaceDebatePublishable(spaceId: string | null | undefined, publishable: Set<string> | null): boolean {
+  if (publishable === null) return true;
+  if (!spaceId) return false;
+  return publishable.has(normId(spaceId));
+}


### PR DESCRIPTION
Preston's suggestion from GEO-2637, and it closes the gap #2205 shipped with.

## Why #2205 was incomplete

That PR gated the picker on `isDebatePublishableSpace`, which can only rule out a **personal** space from its type. Its own comment admitted the limit:

> It is a *sufficient* test, not a complete one: a DAO space the acceptor does not edit fails the same way, and this cannot tell — `DEBATE_ACCEPTOR_SPACE_ID` is server-only.

So an ordinary public space the acceptor simply isn't an editor of stayed a dead-end click: the request succeeds, the debate records, and the publish fails on-chain.

## The authoritative answer already existed

`listEditorSpaceIds` is how the publish sweep discovers its work — the acceptor publishes only where it holds editor rights, so **its editor spaces are exactly the set of spaces that can host a debate.** This exposes that set so both ends read one source of truth instead of the picker approximating it.

`GET /api/debates/publishable-spaces` resolves it server-side, so the acceptor's identity stays there — the client needs the *answer*, not the identity. The response is a list of public space ids saying only which spaces are debatable, which is already observable by trying, so it needs no auth and can be cached. Revalidates every 5 minutes; editor sets change when someone is added to a space.

## `null` vs `[]`, deliberately

An empty array is a **real answer**: the acceptor edits nothing, so nothing is debatable. `null` means the question couldn't be answered — no acceptor configured, or the lookup failed — and callers must fall through to their other filters rather than emptying every list on a transient error. Local and preview environments run with no acceptor at all and should still show a usable picker. Both cases are pinned by tests.

## Kept *on top of* the type test, not replacing it

As Preston framed it. The editor set subsumes the type test logically — a personal space grants editor rights to its owner alone, and the acceptor is never that owner — but **the two fail differently.** When the editor list is unknown, the type test still rules out the case that actually caused the incident (136 claims in a personal space). Defence in depth with independent failure modes, pinned by a test.

## Verification

**903 tests / 64 files** green across `core/debates`, the debates pages and `app/api/debates`. `tsc` and lint clean (the two warnings in the picker test are pre-existing, on untouched lines).

Six new cases on the predicate, three on the picker. I checked the picker ones by removing the gate and watching them fail — worth doing here specifically because the default is *permissive*, so a test against this gate can easily pass whether or not the gate exists.

## Knock-on worth knowing

This may also help GEO-2599. The picker currently waits on the viewer's claim-space allowlist, which walks the Root topic tree over ~13 sequential round trips. This list is **one cheap query** with a 5-minute revalidate. If it turns out to subsume enough of what the allowlist was doing on the All tab, that tab could stop waiting on the traversal — but that's a separate change and wants Preston's re-test first.
