### PR TITLE
test: refuse network by default, and stop a marginal test reading as a regression

### DIFF
--- a/apps/web/core/sdk/geo-network-envcheck.test.ts
+++ b/apps/web/core/sdk/geo-network-envcheck.test.ts
@@ -37,5 +37,9 @@ describe('geo-network env resolution (SDK defaults)', () => {
 
     expect(SPACE_REGISTRY_ADDRESS).toBe('0xCF13491802747e759e1BB8E364bc43045398d1DD');
     expect(DAO_SPACE_FACTORY_ADDRESS).toBe('0x323aF429B85c954D4a161b2A6281c26DF45b7128');
-  });
+    // Two dynamic imports of the environment and SDK modules, which is most of the app's
+    // config graph. Measured at ~5.3s against the 5s default, so this was already tipping
+    // over on a loaded machine and reporting a timeout rather than a real regression — the
+    // failure mode looks identical to an SDK bump, which is exactly what it must not do.
+  }, 30_000);
 });

--- a/apps/web/vite.config.js
+++ b/apps/web/vite.config.js
@@ -7,6 +7,9 @@ export default defineConfig({
       '~': path.resolve(__dirname, './'),
     },
     environment: 'jsdom',
+    // Refuses network by default. See vitest.setup.ts — the endpoints below are unreachable on
+    // purpose, and a *slow* failure is what made unmocked calls log after their test had finished.
+    setupFiles: ['./vitest.setup.ts'],
     env: {
       NEXT_PUBLIC_APP_ENV: 'production',
       NEXT_PUBLIC_PRIVY_APP_ID: 'clpsvsqpt005fl70fe775owo5',

--- a/apps/web/vitest.setup.ts
+++ b/apps/web/vitest.setup.ts
@@ -1,0 +1,41 @@
+/**
+ * Test-run setup: refuse network by default.
+ *
+ * GEO-2645. `vite.config.js` points every endpoint at `https://test.example.com`, so a test that
+ * reaches the network doesn't get an error — it gets a *slow* DNS failure. Whatever catch handler
+ * sits on that call then logs seconds later, by which time the test has finished. If that log is
+ * still in flight when its worker closes its RPC, the whole run dies with
+ * `EnvironmentTeardownError: Closing rpc while "onUserConsoleLog" was pending` — every assertion
+ * passing, exit code 1.
+ *
+ * It is a coin flip per run, it hit twice in one day, and it blames whichever file happened to be
+ * running rather than the file that made the call — so it reliably sends whoever is debugging into
+ * the wrong place, and it points at the file with the most tests because that file runs longest.
+ *
+ * Rejecting immediately is what fixes it. The failure lands inside the test's own lifetime, so any
+ * resulting log flushes while the worker is still up. Tests that want network still stub `fetch`
+ * themselves and are unaffected.
+ *
+ * Deliberately *not* silencing those logs: they are how a genuinely unmocked call gets noticed. The
+ * error names the URL so the fix is obvious.
+ *
+ * Assigned directly rather than through `vi.stubGlobal`, so a test that stubs `fetch` and then
+ * calls `vi.unstubAllGlobals()` is restored to this guard rather than to real network access.
+ *
+ * Note `setupTests.ts` in this directory is currently referenced by nothing — it is not wired into
+ * the vitest config and none of it runs. Left alone here on purpose: adopting it would switch on
+ * global cleanup, a `next/router` mock and two DOM polyfills all at once, which is a separate
+ * change with its own blast radius.
+ */
+const refuseNetwork: typeof fetch = async input => {
+  const url =
+    typeof input === 'string' ? input : input instanceof URL ? input.toString() : (input as Request).url ?? '<unknown>';
+
+  throw new Error(
+    `Unmocked network request in a test: ${url}\n` +
+      'Tests must not reach the network. Stub it for this test, e.g.\n' +
+      "  vi.stubGlobal('fetch', vi.fn(async () => new Response('{}', { status: 200 })));"
+  );
+};
+
+globalThis.fetch = refuseNetwork;


### PR DESCRIPTION
Fixes [GEO-2645](https://linear.app/geobrowser/issue/GEO-2645/ci-goes-red-at-random-on-a-vitest-teardown-race-with-every-test). CI has gone red twice today with **every assertion passing**:

```
Test Files  282 passed (282)
      Tests  2873 passed (2873)
     Errors  3 errors

EnvironmentTeardownError: [vitest-worker]:
  Closing rpc while "onUserConsoleLog" was pending
```

Both times a re-run on the identical commit passed.

## The mechanism

`vite.config.js` points every endpoint at `https://test.example.com`, so a test that reaches the network doesn't get an *error* — it gets a **slow DNS failure**. Whatever catch handler sits on that call then logs seconds later, by which point the test has finished. If that log is still in flight when its worker closes its RPC, the run dies.

Two things make it nastier than a normal flake:

- It reports **success for every test** and then exits 1, so the signal doesn't correlate with the results.
- It blames **whichever file happened to be running**, not the one that made the call. Today that was `rematch-page-client.test.tsx` — which emits no console output at all and passes 82/82 in isolation. It got blamed because it's now the suite's longest-running file. That systematically points the finger at the file with the most tests and sends whoever's debugging into the wrong place.

## The fix

A default `fetch` that rejects **immediately**. That addresses the mechanism rather than the symptom: the failure lands inside the test's own lifetime, so any log it produces flushes while the worker is still up.

- The 7 tests that stub `fetch` themselves are unaffected.
- The error **names the URL**, so an unmocked call is easy to fix rather than mysterious.
- Deliberately **not** silencing those logs — they're how a genuinely unmocked call gets noticed. Only the *timing* changes.
- Assigned directly rather than via `vi.stubGlobal`, so a test that stubs `fetch` and then calls `vi.unstubAllGlobals()` is restored to the guard rather than to real network access.

## Also: a marginal test that was lying about its failure

`geo-network-envcheck` does two dynamic imports covering most of the app's config graph, and measured **~5.3s against the 5s default timeout**. It's been tipping over on loaded machines already.

Worse, it fails as a **timeout** — which is indistinguishable from the SDK-bump regression the test exists to catch. Someone reviewing a dependency bump would read that failure as "the SDK moved" and go looking in entirely the wrong place. Given an explicit 30s timeout with the reasoning recorded inline.

Worth being straight about how I found it: my first full-suite run failed on this test, I ran a single A/B against the setup file, and concluded my change had caused it. Repeating the comparison, my setup file passes **3/3** — it was the marginal timeout tipping under load, not the stub. One run is not a reproduction.

## Verification

Full suite run locally (282 files, 2,873 tests) — the only failure was the marginal test above, now fixed. A second full run is in flight; CI runs the same suite independently.

## Not in this PR

**`apps/web/setupTests.ts` is referenced by nothing.** It contains jest-dom registration, an `afterEach(cleanup)`, a `next/router` mock, and `PointerEvent`/`ResizeObserver` polyfills — and none of it executes, which is why individual test files import `@testing-library/jest-dom/vitest` themselves. Adopting it would switch on global cleanup plus a router mock plus two DOM polyfills in one go; that deserves its own change and its own review. I've noted the relationship in `vitest.setup.ts` so the next reader doesn't assume it's live.

**A stricter policy is available later:** the guard could *fail* a test on any unmocked call rather than merely rejecting. That's the right end state, but it would fail a number of existing tests immediately, so it wants doing deliberately rather than folded in here.
