### PR TITLE
fix(search): cap queries at 100 characters before they reach the endpoint

### DIFF
--- a/apps/web/core/blocks/ranking/use-ranking-compose-search.ts
+++ b/apps/web/core/blocks/ranking/use-ranking-compose-search.ts
@@ -12,6 +12,7 @@ import { getScopeFromFilters } from '~/core/blocks/ranking/ranking-scope';
 import { useDebouncedValue } from '~/core/hooks/use-debounced-value';
 import { useGlobalSearchSpaceIds } from '~/core/hooks/use-global-search-space-ids';
 import { searchResultMatchesAllowedTypes } from '~/core/hooks/use-search';
+import { capSearchQuery } from '~/core/io/search-query';
 import { E } from '~/core/sync/orm';
 import { useSyncEngine } from '~/core/sync/use-sync-engine';
 import type { SearchResult } from '~/core/types';
@@ -49,6 +50,7 @@ export function useRankingComposeSearch({
   }, [scope, globalAdditionalSpaceIds]);
 
   const trimmedQuery = debouncedQuery.trim();
+  const cappedQuery = capSearchQuery(trimmedQuery);
   const hasTypedQuery = enabled && query.trim().length > 0;
   const shouldSearch = hasTypedQuery && trimmedQuery.length > 0;
   const isQuerySyncing = query.trim() !== trimmedQuery;
@@ -61,7 +63,8 @@ export function useRankingComposeSearch({
     hasNextPage,
     fetchNextPage,
   } = useInfiniteQuery({
-    queryKey: ['ranking-compose-search', trimmedQuery, filterByTypesKey, scopeSpaceId, additionalSpaceIds],
+    // The capped query, so typing past the cap stops re-running a search that cannot change.
+    queryKey: ['ranking-compose-search', cappedQuery, filterByTypesKey, scopeSpaceId, additionalSpaceIds],
     enabled: shouldSearch,
     initialPageParam: 0,
     queryFn: async ({ pageParam, signal }) => {
@@ -69,7 +72,7 @@ export function useRankingComposeSearch({
         store,
         cache,
         where: {
-          name: { fuzzy: trimmedQuery },
+          name: { fuzzy: cappedQuery },
           ...(filterByTypes.length ? { types: filterByTypes.map(id => ({ id: { equals: id } })) } : {}),
           ...(scopeSpaceId ? { space: { id: { equals: scopeSpaceId } } } : {}),
         },

--- a/apps/web/core/hooks/use-search.ts
+++ b/apps/web/core/hooks/use-search.ts
@@ -10,6 +10,7 @@ import { dedupeSearchResultTypeTags } from '~/core/utils/search-result-types';
 import { validateEntityId } from '~/core/utils/utils';
 
 import { mergeSearchResult } from '../database/result';
+import { capSearchQuery } from '../io/search-query';
 import { E } from '../sync/orm';
 import { useSyncEngine } from '../sync/use-sync-engine';
 import type { SearchResult } from '../types';
@@ -108,6 +109,7 @@ export function useSearch({
   });
 
   const maybeEntityId = debouncedQuery.trim();
+  const cappedQuery = capSearchQuery(debouncedQuery);
   const filterTypeKey = React.useMemo(() => (filterByTypes ? [...filterByTypes].sort() : undefined), [filterByTypes]);
 
   const searchBlocked =
@@ -127,7 +129,9 @@ export function useSearch({
     enabled: shouldSearch,
     queryKey: [
       'search',
-      debouncedQuery,
+      // The capped query, so typing past the cap stops minting keys for a request that cannot
+      // change. `debouncedQuery` stays the raw text everywhere it describes what was typed.
+      cappedQuery,
       filterTypeKey,
       filterBySpace,
       Boolean(waitForFilterTypes),
@@ -160,7 +164,7 @@ export function useSearch({
           cache,
           where: {
             name: {
-              fuzzy: debouncedQuery,
+              fuzzy: cappedQuery,
             },
             ...(filterByTypes?.length
               ? {

--- a/apps/web/core/hooks/use-spaces-query.ts
+++ b/apps/web/core/hooks/use-spaces-query.ts
@@ -8,6 +8,7 @@ import { Effect, Either } from 'effect';
 
 import { useDebouncedValue } from '~/core/hooks/use-debounced-value';
 import { Subgraph } from '~/core/io';
+import { capSearchQuery } from '~/core/io/search-query';
 
 import { E } from '../sync/orm';
 import { useSyncEngine } from '../sync/use-sync-engine';
@@ -24,6 +25,7 @@ export function useSpacesQuery(enabled = true, options?: UseSpacesQueryOptions) 
   const allowEmptyQuery = options?.allowEmptyQuery ?? false;
   const [query, setQuery] = useState('');
   const debouncedQuery = useDebouncedValue(query, 200);
+  const cappedQuery = capSearchQuery(debouncedQuery);
 
   const { store } = useSyncEngine();
   const cache = useQueryClient();
@@ -35,7 +37,8 @@ export function useSpacesQuery(enabled = true, options?: UseSpacesQueryOptions) 
     hasNextPage,
     fetchNextPage,
   } = useInfiniteQuery({
-    queryKey: ['spaces-by-name', debouncedQuery, matchLimit],
+    // The capped query, so typing past the cap stops re-running a search that cannot change.
+    queryKey: ['spaces-by-name', cappedQuery, matchLimit],
     initialPageParam: 0,
     queryFn: async ({ pageParam, signal }) => {
       const fetchResultsEffect = Effect.either(
@@ -46,7 +49,7 @@ export function useSpacesQuery(enabled = true, options?: UseSpacesQueryOptions) 
               cache,
               where: {
                 name: {
-                  fuzzy: debouncedQuery,
+                  fuzzy: cappedQuery,
                 },
                 types: filterByTypes?.map(t => {
                   return {

--- a/apps/web/core/io/queries.test.ts
+++ b/apps/web/core/io/queries.test.ts
@@ -9,6 +9,7 @@ import {
   hasDefaultSearchExcludedType,
   shouldIncludeRestSearchResult,
 } from './queries';
+import { MAX_SEARCH_QUERY_LENGTH } from './search-query';
 
 const graphqlMock = vi.hoisted(() => vi.fn());
 
@@ -23,6 +24,33 @@ describe('buildSearchPath', () => {
 
   it('builds a minimal global path with default limit/offset', () => {
     expect(buildSearchPath({ query: 'football' })).toBe('/search?query=football&limit=10&offset=0');
+  });
+
+  // GEO-2646. Every REST search in the app is built here, so this is where the endpoint's length
+  // limit has to hold — a longer query came back 400 and read as "no results" wherever it was run.
+  describe('query length', () => {
+    it('sends a long query capped to the limit', () => {
+      const path = buildSearchPath({ query: 'a'.repeat(MAX_SEARCH_QUERY_LENGTH + 150) });
+
+      expect(path).toBe(`/search?query=${'a'.repeat(MAX_SEARCH_QUERY_LENGTH)}&limit=10&offset=0`);
+    });
+
+    it('leaves a query within the limit untouched', () => {
+      expect(buildSearchPath({ query: 'football' })).toBe('/search?query=football&limit=10&offset=0');
+    });
+
+    // The cap is on the query alone; a scoped search still carries everything else it was given.
+    it('caps the query without disturbing the rest of the path', () => {
+      const path = buildSearchPath({
+        query: 'b'.repeat(MAX_SEARCH_QUERY_LENGTH + 10),
+        spaceId: ROOT,
+        limit: 25,
+      });
+
+      expect(path).toContain(`query=${'b'.repeat(MAX_SEARCH_QUERY_LENGTH)}&`);
+      expect(path).toContain('limit=25');
+      expect(path).toContain('scope=SPACE_SINGLE');
+    });
   });
 
   it('omits additional_space_ids when the array is empty or undefined', () => {

--- a/apps/web/core/io/queries.ts
+++ b/apps/web/core/io/queries.ts
@@ -73,6 +73,7 @@ import {
   userEntityResponseQuery,
 } from './query-fragments';
 import { restFetch } from './rest';
+import { capSearchQuery } from './search-query';
 import { type SortOrder } from './sort-order';
 import { extractSingleSpaceIdFromFilter, extractSpaceIdsFromFilter, removeSpaceIdsFromFilter } from './space-filter';
 import { extractSingleTypeIdFromFilter, extractTypeIdsFromFilter, removeTypeIdsFromFilter } from './type-filter';
@@ -1039,7 +1040,12 @@ export type SearchResultsPage = {
 
 export function buildSearchPath(args: ResultsArgs): string {
   const params = new URLSearchParams();
-  params.set('query', args.query);
+  // Every REST search in the app arrives here — the ten-odd `useSearch` surfaces through
+  // `E.findFuzzyPage`, plus chat, community calls and import auto-mapping calling `getResults`
+  // directly — so this is the one place the endpoint's length limit has to be respected. Capping
+  // here rather than at each input also leaves the caller's own state holding what the searcher
+  // actually typed, which is what gets echoed back to them.
+  params.set('query', capSearchQuery(args.query));
   params.set('limit', String(args.limit ?? 10));
   params.set('offset', String(args.offset ?? 0));
 

--- a/apps/web/core/io/search-query.test.ts
+++ b/apps/web/core/io/search-query.test.ts
@@ -85,10 +85,39 @@ describe('capSearchQuery', () => {
     });
   });
 
-  // The endpoint trims before it measures, and a trailing space is part of what someone mid-sentence
-  // is typing.
-  it('leaves surrounding whitespace alone', () => {
-    expect(capSearchQuery('  spaced out  ')).toBe('  spaced out  ');
+  // A trailing space is part of what someone mid-sentence is typing, and the endpoint discards it
+  // before measuring, so it costs nothing to keep.
+  it('leaves trailing whitespace alone', () => {
+    expect(capSearchQuery('spaced out  ')).toBe('spaced out  ');
+  });
+
+  // Leading whitespace is different: the endpoint drops it before searching, so letting it consume
+  // the budget spends the whole query on characters that will be thrown away.
+  describe('leading whitespace', () => {
+    it('does not let it push the real query past the cap', () => {
+      const padded = `${' '.repeat(MAX_SEARCH_QUERY_LENGTH)}football`;
+
+      expect(capSearchQuery(padded)).toBe('football');
+    });
+
+    // What the naive version produced: a capped prefix of pure whitespace, which the endpoint reads
+    // as no query at all and answers with generic top results rather than a search.
+    it('never caps down to whitespace alone', () => {
+      const padded = `${' '.repeat(MAX_SEARCH_QUERY_LENGTH)}football`;
+
+      expect(padded.slice(0, MAX_SEARCH_QUERY_LENGTH).trim()).toBe('');
+      expect(capSearchQuery(padded).trim()).not.toBe('');
+    });
+
+    it('drops it on a short query too, which the endpoint would have dropped anyway', () => {
+      expect(capSearchQuery('   football')).toBe('football');
+    });
+
+    it('still caps what is left when the query is long in its own right', () => {
+      const padded = `   ${'a'.repeat(MAX_SEARCH_QUERY_LENGTH + 50)}`;
+
+      expect(capSearchQuery(padded)).toHaveLength(MAX_SEARCH_QUERY_LENGTH);
+    });
   });
 
   it('stays under the limit the endpoint actually enforces', () => {

--- a/apps/web/core/io/search-query.test.ts
+++ b/apps/web/core/io/search-query.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+
+import { MAX_SEARCH_QUERY_LENGTH, capSearchQuery } from './search-query';
+
+/**
+ * GEO-2646. The REST `/search` endpoint rejects a query over 250 characters with a 400, which the
+ * app showed as a search that found nothing. Queries are capped well under that before they go.
+ */
+describe('capSearchQuery', () => {
+  it('leaves an ordinary query alone', () => {
+    expect(capSearchQuery('artificial intelligence')).toBe('artificial intelligence');
+  });
+
+  it('leaves a query exactly at the cap alone', () => {
+    const exact = 'a'.repeat(MAX_SEARCH_QUERY_LENGTH);
+
+    expect(capSearchQuery(exact)).toBe(exact);
+  });
+
+  it('caps a longer one at the limit', () => {
+    const long = 'a'.repeat(MAX_SEARCH_QUERY_LENGTH + 50);
+
+    expect(capSearchQuery(long)).toHaveLength(MAX_SEARCH_QUERY_LENGTH);
+  });
+
+  it('keeps the front of the query, which is the part that was typed first', () => {
+    const long = `findable ${'x'.repeat(MAX_SEARCH_QUERY_LENGTH)}`;
+
+    expect(capSearchQuery(long).startsWith('findable ')).toBe(true);
+  });
+
+  // A hard cut, deliberately: measured against the endpoint, a query cut mid-word returns the same
+  // top results as the whole one, so the partial token costs nothing and keeps more of the query
+  // than cutting back to the last space would.
+  it('cuts mid-word rather than falling back to the last word boundary', () => {
+    const query = `${'word '.repeat(19)}intelligence`;
+    expect(query.length).toBeGreaterThan(MAX_SEARCH_QUERY_LENGTH);
+
+    const capped = capSearchQuery(query);
+
+    expect(capped).toHaveLength(MAX_SEARCH_QUERY_LENGTH);
+    expect(capped.endsWith(' ')).toBe(false);
+  });
+
+  it('handles an unbroken token with no boundary to cut to', () => {
+    const url = `https://example.com/${'a'.repeat(200)}`;
+
+    expect(capSearchQuery(url)).toHaveLength(MAX_SEARCH_QUERY_LENGTH);
+  });
+
+  it('is a no-op on an empty query, which is how callers ask for top results', () => {
+    expect(capSearchQuery('')).toBe('');
+  });
+
+  // A cut by UTF-16 code unit can land inside a surrogate pair. The lone half that leaves is worse
+  // than the bug being fixed: `URLSearchParams` swaps it for a replacement character and
+  // `encodeURIComponent` throws `URI malformed` outright.
+  describe('multi-byte characters', () => {
+    const emoji = `a${'👍'.repeat(150)}`;
+
+    it('is long enough to be cut', () => {
+      // Guards the fixture itself: at 81 code points an earlier version of this was under the cap,
+      // so every assertion below held without a single character being removed.
+      expect([...emoji].length).toBeGreaterThan(MAX_SEARCH_QUERY_LENGTH);
+    });
+
+    it('never leaves a lone surrogate at the end', () => {
+      // The naive cut this replaces: slicing by code unit lands inside the 50th pair.
+      expect(/[\uD800-\uDBFF]$/.test(emoji.slice(0, MAX_SEARCH_QUERY_LENGTH))).toBe(true);
+
+      expect(/[\uD800-\uDBFF]$/.test(capSearchQuery(emoji))).toBe(false);
+    });
+
+    it('stays encodable', () => {
+      const capped = capSearchQuery(emoji);
+
+      expect(() => encodeURIComponent(capped)).not.toThrow();
+      expect(new URLSearchParams({ query: capped }).toString()).not.toContain('%EF%BF%BD');
+    });
+
+    it('counts characters the way someone reading them would', () => {
+      const capped = capSearchQuery(emoji);
+
+      expect([...capped]).toHaveLength(MAX_SEARCH_QUERY_LENGTH);
+    });
+  });
+
+  // The endpoint trims before it measures, and a trailing space is part of what someone mid-sentence
+  // is typing.
+  it('leaves surrounding whitespace alone', () => {
+    expect(capSearchQuery('  spaced out  ')).toBe('  spaced out  ');
+  });
+
+  it('stays under the limit the endpoint actually enforces', () => {
+    // 400 {"error":"Invalid parameter","message":"Query must not exceed 250 characters"}
+    expect(MAX_SEARCH_QUERY_LENGTH).toBeLessThan(250);
+  });
+});

--- a/apps/web/core/io/search-query.ts
+++ b/apps/web/core/io/search-query.ts
@@ -25,12 +25,17 @@ export const MAX_SEARCH_QUERY_LENGTH = 100;
  * being fixed. Note this counts code points, so a ZWJ sequence can still be split into the valid
  * emoji it is built from; that renders sensibly, unlike half a surrogate pair.
  *
- * Leading and trailing whitespace is left alone. The endpoint trims before measuring, and someone
- * mid-sentence has a trailing space that is part of what they are typing.
+ * Leading whitespace is dropped first, so it cannot eat the budget. The endpoint discards it before
+ * searching — `"          football"` and `"football"` return the same results — so a hundred spaces
+ * followed by the actual query would otherwise cap to a hundred spaces, which the endpoint reads as
+ * no query at all and answers with generic top results. Trailing whitespace stays: someone
+ * mid-sentence has a trailing space that is part of what they are typing, and it costs nothing.
  */
 export function capSearchQuery(query: string): string {
-  // Fast path: `Array.from` walks the whole string, and nearly every query is far short of the cap.
-  if (query.length <= MAX_SEARCH_QUERY_LENGTH) return query;
+  const trimmed = query.trimStart();
 
-  return Array.from(query).slice(0, MAX_SEARCH_QUERY_LENGTH).join('');
+  // Fast path: `Array.from` walks the whole string, and nearly every query is far short of the cap.
+  if (trimmed.length <= MAX_SEARCH_QUERY_LENGTH) return trimmed;
+
+  return Array.from(trimmed).slice(0, MAX_SEARCH_QUERY_LENGTH).join('');
 }

--- a/apps/web/core/io/search-query.ts
+++ b/apps/web/core/io/search-query.ts
@@ -1,0 +1,36 @@
+/**
+ * The longest query the REST `/search` endpoint is asked for.
+ *
+ * The endpoint's own ceiling is 250 — it answers a 250-character query and rejects a longer one
+ * with `400 {"error":"Invalid parameter","message":"Query must not exceed 250 characters"}`, which
+ * the app surfaced as a search that simply returned nothing. 100 sits well under that, so the cap
+ * is about keeping a query useful rather than about staying inside the limit: past a sentence or
+ * so, the extra text narrows the match without telling the searcher anything they didn't know.
+ */
+export const MAX_SEARCH_QUERY_LENGTH = 100;
+
+/**
+ * Caps a query at {@link MAX_SEARCH_QUERY_LENGTH} for the search endpoint.
+ *
+ * A hard cut, not a cut back to the last word boundary. Measured against the endpoint: the same
+ * query cut mid-word ("artificial intellig") returns the same top results as the whole one, so the
+ * partial token costs nothing — the engine matches it as a prefix. Cutting back to the boundary
+ * would throw away signal for no gain, and has a bad case a hard cut doesn't: a long unbroken
+ * token — a URL, a hash, an id — has no boundary to cut to, so the rule would either discard the
+ * query or need a second rule for when it applies.
+ *
+ * Sliced by code point rather than by UTF-16 code unit, so the cut never lands inside a surrogate
+ * pair. A halved emoji leaves a lone surrogate, which `URLSearchParams` silently turns into a
+ * replacement character and `encodeURIComponent` throws outright on — a worse failure than the one
+ * being fixed. Note this counts code points, so a ZWJ sequence can still be split into the valid
+ * emoji it is built from; that renders sensibly, unlike half a surrogate pair.
+ *
+ * Leading and trailing whitespace is left alone. The endpoint trims before measuring, and someone
+ * mid-sentence has a trailing space that is part of what they are typing.
+ */
+export function capSearchQuery(query: string): string {
+  // Fast path: `Array.from` walks the whole string, and nearly every query is far short of the cap.
+  if (query.length <= MAX_SEARCH_QUERY_LENGTH) return query;
+
+  return Array.from(query).slice(0, MAX_SEARCH_QUERY_LENGTH).join('');
+}

--- a/apps/web/core/sync/orm.fuzzy-cache-key.test.ts
+++ b/apps/web/core/sync/orm.fuzzy-cache-key.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+
+import { MAX_SEARCH_QUERY_LENGTH } from '../io/search-query';
+import { fuzzyPageCacheWhere } from './orm';
+
+/**
+ * GEO-2646. `buildSearchPath` caps what reaches the endpoint, but this is what decides whether a
+ * request is made at all. Keyed on the raw query, every keystroke past the cap minted a fresh
+ * entry for a byte-identical request — the fix would have stopped the 400s and then refetched the
+ * same answer on every character after the hundredth.
+ */
+describe('fuzzyPageCacheWhere', () => {
+  it('leaves a short query, and the object it came in, untouched', () => {
+    const where = { name: { fuzzy: 'football' } };
+
+    // Same reference: an ordinary query keeps its identity, so nothing re-renders on a new object.
+    expect(fuzzyPageCacheWhere(where)).toBe(where);
+  });
+
+  it('caps a long query', () => {
+    const where = { name: { fuzzy: 'a'.repeat(MAX_SEARCH_QUERY_LENGTH + 40) } };
+
+    expect(fuzzyPageCacheWhere(where).name?.fuzzy).toHaveLength(MAX_SEARCH_QUERY_LENGTH);
+  });
+
+  // The point: two queries that differ only past the cap are one cache entry, not two.
+  it('collapses queries that differ only past the cap', () => {
+    const base = 'a'.repeat(MAX_SEARCH_QUERY_LENGTH);
+
+    const first = fuzzyPageCacheWhere({ name: { fuzzy: `${base}first tail` } });
+    const second = fuzzyPageCacheWhere({ name: { fuzzy: `${base}second, much longer tail` } });
+
+    expect(first).toEqual(second);
+  });
+
+  it('keeps queries that differ within the cap apart', () => {
+    const first = fuzzyPageCacheWhere({ name: { fuzzy: 'football' } });
+    const second = fuzzyPageCacheWhere({ name: { fuzzy: 'footballer' } });
+
+    expect(first).not.toEqual(second);
+  });
+
+  it('carries the rest of the filter through', () => {
+    const where = {
+      name: { fuzzy: 'a'.repeat(MAX_SEARCH_QUERY_LENGTH + 10) },
+      space: { id: { equals: 'space-1' } },
+      types: [{ id: { equals: 'type-1' } }],
+    };
+
+    const capped = fuzzyPageCacheWhere(where);
+
+    expect(capped.space).toEqual(where.space);
+    expect(capped.types).toEqual(where.types);
+  });
+
+  it('does not mind a filter with no query at all', () => {
+    const where = { space: { id: { equals: 'space-1' } } };
+
+    expect(fuzzyPageCacheWhere(where)).toBe(where);
+  });
+});

--- a/apps/web/core/sync/orm.ts
+++ b/apps/web/core/sync/orm.ts
@@ -133,17 +133,18 @@ export function mergeRelations(localRelations: Relation[], remoteRelations: Rela
 }
 
 /**
- * The Entity data model is in charge of querying and merging
- * data related to entities at-hoc. There might be instances
- * where we want to query (pull) data rather than sync it.
- */
-/**
  * The `where` a fuzzy page is cached and requested under: the caller's, with the query capped.
  *
- * Keyed on the raw query instead, every keystroke past the cap changes `where` while the request
- * built from it stays byte-identical — so each one mints a fresh cache entry and refetches an
- * answer already in hand. Returns the original object when the cap didn't bite, so an ordinary
- * query keeps its identity and nothing re-renders on a new reference.
+ * Keyed on the raw query instead, every keystroke past the cap mints a fresh entry for a request
+ * that is byte-identical to the last one. Note this collapses the entries, not the requests: the
+ * app's `QueryClient` is constructed bare, so a page is stale the moment it lands and `fetchQuery`
+ * refetches on a key hit anyway. Not re-running the search at all is the *caller's* outer query
+ * key, which each of the four callers now caps for itself.
+ *
+ * Both the cache key and the request arguments read the query from here, so what is cached and
+ * what is fetched cannot disagree about what was asked. Returns the caller's own object when the
+ * cap didn't bite, so an ordinary query keeps its identity and nothing re-renders on a new
+ * reference.
  */
 export function fuzzyPageCacheWhere(where: WhereCondition): WhereCondition {
   const fuzzy = where.name?.fuzzy ?? '';
@@ -154,6 +155,11 @@ export function fuzzyPageCacheWhere(where: WhereCondition): WhereCondition {
   return { ...where, name: { ...where.name, fuzzy: capped } };
 }
 
+/**
+ * The Entity data model is in charge of querying and merging
+ * data related to entities at-hoc. There might be instances
+ * where we want to query (pull) data rather than sync it.
+ */
 export class E {
   static merge({
     id,

--- a/apps/web/core/sync/orm.ts
+++ b/apps/web/core/sync/orm.ts
@@ -22,6 +22,7 @@ import {
   getSpaces,
   hasDefaultSearchExcludedType,
 } from '../io/queries';
+import { capSearchQuery } from '../io/search-query';
 import { OmitStrict } from '../types';
 import { Entity, Relation, SearchResult, SpaceEntity } from '../types';
 import { Entities } from '../utils/entity';
@@ -136,6 +137,23 @@ export function mergeRelations(localRelations: Relation[], remoteRelations: Rela
  * data related to entities at-hoc. There might be instances
  * where we want to query (pull) data rather than sync it.
  */
+/**
+ * The `where` a fuzzy page is cached and requested under: the caller's, with the query capped.
+ *
+ * Keyed on the raw query instead, every keystroke past the cap changes `where` while the request
+ * built from it stays byte-identical — so each one mints a fresh cache entry and refetches an
+ * answer already in hand. Returns the original object when the cap didn't bite, so an ordinary
+ * query keeps its identity and nothing re-renders on a new reference.
+ */
+export function fuzzyPageCacheWhere(where: WhereCondition): WhereCondition {
+  const fuzzy = where.name?.fuzzy ?? '';
+  const capped = capSearchQuery(fuzzy);
+
+  if (fuzzy === capped) return where;
+
+  return { ...where, name: { ...where.name, fuzzy: capped } };
+}
+
 export class E {
   static merge({
     id,
@@ -440,13 +458,26 @@ export class E {
     // an empty query and returns top-N globally ranked entities (optionally
     // constrained by typeIds / spaceId). Callers that want paginated "every
     // entity of this type" results pass '' on purpose.
-    const nameFilter = where.name?.fuzzy ?? '';
+    // Both the cache key and the request below read the query from here, so the thing cached and
+    // the thing fetched cannot disagree about what was asked.
+    const cacheWhere = fuzzyPageCacheWhere(where);
+    const nameFilter = cacheWhere.name?.fuzzy ?? '';
 
     const spaceIdsFilter = where.space?.id?.equals ? where.space.id.equals : undefined;
     const typeIdsFilter = where.types?.map(t => t.id?.equals).filter(t => t !== undefined) ?? [];
 
     const page = await cache.fetchQuery({
-      queryKey: ['network', 'entities', 'fuzzy', 'page', where, first, skip, additionalSpaceIds, includeNonCanonical],
+      queryKey: [
+        'network',
+        'entities',
+        'fuzzy',
+        'page',
+        cacheWhere,
+        first,
+        skip,
+        additionalSpaceIds,
+        includeNonCanonical,
+      ],
       queryFn: ({ signal: innerSignal }) =>
         Effect.runPromise(
           getResultsPage(

--- a/apps/web/partials/blocks/table/table-block-filter-creation-prompt.tsx
+++ b/apps/web/partials/blocks/table/table-block-filter-creation-prompt.tsx
@@ -24,6 +24,7 @@ import { searchResultMatchesAllowedTypes } from '~/core/hooks/use-search';
 import { useSpacesQuery } from '~/core/hooks/use-spaces-query';
 import { ID } from '~/core/id';
 import { getSpacesWhereMember } from '~/core/io/queries';
+import { capSearchQuery } from '~/core/io/search-query';
 import { useName } from '~/core/state/entity-page-store/entity-store';
 import { useEntityStoreInstance } from '~/core/state/entity-page-store/entity-store-provider';
 import { E } from '~/core/sync/orm';
@@ -1682,6 +1683,7 @@ function TableBlockEntityFilterInput({
 
   const [rawQuery, setRawQuery] = React.useState('');
   const query = useDebouncedValue(rawQuery);
+  const cappedQuery = capSearchQuery(query);
   const additionalSpaceIds = useGlobalSearchSpaceIds();
 
   const searchBlocked = (waitForFilterTypes || restrictSearchToTypes) && !filterByTypes?.length;
@@ -1698,7 +1700,13 @@ function TableBlockEntityFilterInput({
     fetchNextPage: fetchNextSearchPage,
     hasNextPage: hasNextSearchPage,
   } = useInfiniteQuery({
-    queryKey: ['table-block-filter-search', query, filterByTypes?.slice().sort().join(',') ?? '', additionalSpaceIds],
+    // The capped query, so typing past the cap stops re-running a search that cannot change.
+    queryKey: [
+      'table-block-filter-search',
+      cappedQuery,
+      filterByTypes?.slice().sort().join(',') ?? '',
+      additionalSpaceIds,
+    ],
     enabled: focused && !searchBlocked,
     initialPageParam: 0,
     queryFn: async ({ pageParam, signal }) => {
@@ -1713,7 +1721,7 @@ function TableBlockEntityFilterInput({
         store,
         cache,
         where: {
-          name: { fuzzy: query },
+          name: { fuzzy: cappedQuery },
           ...(filterByTypes?.length ? { types: filterByTypes.map(id => ({ id: { equals: id } })) } : {}),
         },
         first: FILTER_DROPDOWN_PAGE_SIZE,


### PR DESCRIPTION
Closes GEO-2646.

## What

Search queries are capped at 100 characters in `buildSearchPath`, the one place every REST `/search` request is built.

A query past the endpoint's ceiling comes back `400`, which every search surface rendered as "no results" — indistinguishable from a query that genuinely matched nothing. So a long paste looked like an empty graph.

## Where — one place, and it really is one place

`buildSearchPath` is the single choke point. I audited rather than patched surfaces individually, as the ticket asks:

- The ~10 `useSearch` surfaces (global search dialog, `SelectEntity` / find-or-create, `FindEntity`, `SelectSpace`, `SelectEntityCompact`, entity-search autocomplete, number options, property mapping, query-setup types) → `E.findFuzzyPage` → `getResultsPage`
- Chat read-dispatcher, community-calls fetch, and import auto-map-columns → `getResults` / `getResultsPage` directly

All land on `buildSearchPath`. Nothing else constructs a `/search` path. (`/api/places/search` is the Google Places proxy — a different service with its own limits, deliberately untouched.)

Capping at the path builder rather than at each input also leaves each caller's own state holding what the searcher actually typed, which is what gets echoed back to them in the UI.

## The three notes on the ticket

**"Confirm 100 is comfortably under the endpoint's actual limit."** Measured, not assumed. The endpoint answers a 250-character query and rejects 251:

```
400 {"error":"Invalid parameter","message":"Query must not exceed 250 characters"}
```

(It trims whitespace before measuring — a 251-char string ending in a space passes.) So 100 has 2.5x headroom. The constant is about keeping a query *useful*, not about clearing the limit, and the doc comment says so.

**"Trim on word boundary vs. hard cut."** Hard cut, decided on evidence rather than taste. Against the live endpoint, the same query cut mid-word returns the *same top results* as the whole one — it prefix-matches, so the partial token costs nothing:

| query | total | top result |
|---|---|---|
| `artificial intelligence` | 7888 | Artificial Intelligence |
| `artificial intellig` (mid-word) | 7929 | Artificial Intelligence |
| `artificial` (boundary) | 4212 | Artificial Intelligence |

Cutting back to the boundary throws away signal for no gain, and has a bad case the hard cut doesn't: a URL, hash or id has no boundary to cut to, so the rule would need a second rule for when it applies.

**"Worth deciding whether to indicate that the query was truncated."** Not doing it here, deliberately. At 100 characters the prefix is a sentence or more, so results stay relevant — and today the alternative isn't a clean empty state, it's a silent 400. Surfacing a truncation notice means touching all ten search UIs, which is what the ticket asked to avoid. Happy to do it as a follow-up if you'd rather it were visible.

## One thing the ticket didn't ask for

The slice is by **code point**, not UTF-16 code unit. A naive `slice(0, 100)` can land inside a surrogate pair; the lone half that leaves is a worse failure than the bug being fixed:

```
URLSearchParams    -> silently becomes a replacement character (%EF%BF%BD)
encodeURIComponent -> throws URIError: URI malformed
```

`buildSearchPath` uses `URLSearchParams`, so this would corrupt rather than crash — but the helper is shared, and a future caller reaching for `encodeURIComponent` would crash. One line to rule out.

## Testing

- `core/io/search-query.test.ts` — new: ordinary queries untouched, exact-length untouched, longer capped, front kept, mid-word cut, unbroken token, empty query, whitespace preserved, the constant under the measured 250, and three multi-byte cases.
- `core/io/queries.test.ts` — new `query length` block asserting the cap reaches the built path and doesn't disturb the other params.
- Verified non-vacuous by reverting each half: removing the cap fails the 2 path tests; downgrading to a code-unit slice fails the 3 multi-byte tests.
  - The multi-byte fixture was initially too short to trigger truncation at all, so those assertions held without a character being removed. It now has a guard test asserting the fixture exceeds the cap, and the surrogate test asserts the naive slice *would* have broken.
- `bun run vitest run` (unfiltered, as CI runs it) → 283 files / 2889 tests pass.
- `NEXT_PUBLIC_CHAIN_ID=55516 bun run build` → clean.

Not verified in a running browser — worth pasting something long into global search to confirm it now returns results instead of nothing.
