### PR TITLE
fix(debates): route only the focused tab into the debate-again picker

### DIFF
--- a/apps/web/core/debates/debate-coordinator.test.tsx
+++ b/apps/web/core/debates/debate-coordinator.test.tsx
@@ -15,6 +15,9 @@ const mocks = vi.hoisted(() => ({
   dismissRequestMutate: vi.fn(),
   blockUserMutate: vi.fn(),
   pathname: '/space/space-1/debates',
+  // Whether this tab is the focused one. jsdom reports no focus, so the real store would make
+  // every routing case here look like a background tab.
+  hasAttention: true,
   prompts: [] as DebateSharePrompt[],
   promptsFetching: false,
   mediaMutate: vi.fn(),
@@ -65,6 +68,11 @@ vi.mock('./hooks', () => ({
   useRejectDebateChallenge: () => ({ mutate: mocks.rejectChallengeMutate, isPending: false, error: null }),
   useAbortDebate: () => ({ mutateAsync: mocks.abortMutateAsync, isPending: false }),
   useClearDebateActivity: () => mocks.clearDebateActivity,
+}));
+
+vi.mock('./debate-attention', () => ({
+  useDebatePresence: () => true,
+  useDebateAttention: () => mocks.hasAttention,
 }));
 
 vi.mock('./debate-gateway', () => ({
@@ -129,6 +137,7 @@ beforeEach(() => {
   mocks.dismissRequestMutate.mockReset();
   mocks.blockUserMutate.mockReset();
   mocks.pathname = '/space/space-1/debates';
+  mocks.hasAttention = true;
   mocks.prompts = [];
   mocks.promptsFetching = false;
   mocks.authenticated = true;
@@ -402,6 +411,44 @@ describe('DebateCoordinator', () => {
     render(<DebateCoordinator />);
 
     await waitFor(() => expect(screen.queryByText('Debate request')).not.toBeInTheDocument());
+  });
+
+  // GEO-2648. This coordinator runs in every open tab, and the source-debate guard only covers
+  // rematches that have one — a session with `source_debate_id: null` fell through and pushed
+  // *every* tab into the picker at once, which is what Dovile saw: all her tabs jumped to the
+  // claim being debated. The majority of sessions take this branch, so it fired routinely.
+  it('does not route a tab the viewer is not looking at', async () => {
+    mocks.currentUserId = 'user-requester';
+    mocks.pathname = '/space/space-1/claims';
+    mocks.hasAttention = false;
+    const activity = activityWithRematch('browsing');
+    mocks.activity = { ...activity, rematch: { ...activity.rematch!, source_debate_id: null }, challenge: null };
+
+    render(<DebateCoordinator />);
+
+    // Give the effect the same room to fire that the focused-tab case below needs.
+    await new Promise(resolve => setTimeout(resolve, 50));
+    expect(mocks.push).not.toHaveBeenCalled();
+  });
+
+  // Focus is what decides, not presence: several windows can be visible at once, so an unfocused
+  // tab must stay put and the focused one must still route in.
+  it('routes the focused tab once it gains attention', async () => {
+    mocks.currentUserId = 'user-requester';
+    mocks.pathname = '/space/space-1/claims';
+    mocks.hasAttention = false;
+    const activity = activityWithRematch('browsing');
+    mocks.activity = { ...activity, rematch: { ...activity.rematch!, source_debate_id: null }, challenge: null };
+
+    const view = render(<DebateCoordinator />);
+    await new Promise(resolve => setTimeout(resolve, 50));
+    expect(mocks.push).not.toHaveBeenCalled();
+
+    // The viewer turns to this tab. Attention is a subscription, so the effect re-runs.
+    mocks.hasAttention = true;
+    view.rerender(<DebateCoordinator />);
+
+    await waitFor(() => expect(mocks.push).toHaveBeenCalledWith('/space/space-1/debates/rematches/rematch-1'));
   });
 
   // The sender learns it was accepted the same way every other flow does: activity gains a rematch

--- a/apps/web/core/debates/debate-coordinator.tsx
+++ b/apps/web/core/debates/debate-coordinator.tsx
@@ -12,7 +12,7 @@ import { Text } from '~/design-system/text';
 import { activeDebate } from './activity-state';
 import { type DebateSharePrompt } from './api';
 import { useClaimResponseIndexedNotifier } from './claim-response-indexed-notifier';
-import { useDebatePresence } from './debate-attention';
+import { useDebateAttention, useDebatePresence } from './debate-attention';
 import { DebateChallengeDialog } from './debate-challenge-dialog';
 import { clearEnteringDebate, useEnteringDebateId } from './debate-entry-intent';
 import { useDebateGateway } from './debate-gateway';
@@ -44,6 +44,8 @@ export function DebateCoordinator() {
   const geoChatAuth = useGeoChatAuth();
   // Presence, not attention: being available to debate has to survive looking at another window.
   const debatePresence = useDebatePresence();
+  // Exactly one tab: visible *and* focused. See the rematch routing effect below.
+  const hasAttention = useDebateAttention();
   const gateway = useDebateGateway(
     geoChatAuth.ready && geoChatAuth.authenticated,
     geoChatAuth.getPrivyIdentityToken,
@@ -192,6 +194,19 @@ export function DebateCoordinator() {
     // coordinator sent every other open tab into that room, where ownership correctly rejected it.
     // The room handles deciding, recording finalization, browsing, and conversion itself.
     if (sourceDebatePath) return;
+    // Past that guard there is no room to hand off from — a session with no source debate comes
+    // from the matchmaking hub or a profile challenge, so this coordinator is the only thing that
+    // can route the viewer in, and it must. But it runs in *every* tab, and the guard above only
+    // covers the source-debate branch: a null `source_debate_id` fell through and pushed every
+    // open tab into the picker at once (GEO-2648, and the majority of sessions take this branch).
+    //
+    // Attention rather than presence is what makes it one tab. Presence is per-document
+    // visibility, so several windows report it together; attention additionally requires
+    // `document.hasFocus()`, which is true of at most one tab in the browser — the one the viewer
+    // is actually looking at, which is the only one that should move under them. Unfocused tabs
+    // stay put, and because attention is a subscription this re-runs when one is focused, so
+    // whichever tab they turn to still routes in rather than stranding them.
+    if (!hasAttention) return;
     if (rematch.status === 'browsing' || rematch.status === 'request_pending') {
       const path = `/space/${rematch.source_space_id}/debates/rematches/${rematch.id}`;
       if (pathname !== path) {
@@ -199,7 +214,9 @@ export function DebateCoordinator() {
         router.push(path);
       }
     }
-  }, [activity, pathname, router]);
+    // `hasAttention` is in here on purpose: an unfocused tab returns early above, and this is what
+    // re-runs the effect when the viewer turns to a tab, so it routes in then rather than never.
+  }, [activity, hasAttention, pathname, router]);
 
   const visibleSharePrompt =
     retainedSharePrompt ?? (queriedSharePrompt?.id === closedSharePromptId ? null : queriedSharePrompt);


### PR DESCRIPTION
Fixes [GEO-2648](https://linear.app/geobrowser/issue/GEO-2648/every-open-tab-navigates-into-the-debate-again-flow-when-a-rematch-has). Dovile reported that finishing a debate sent **all** her Geo tabs to "Bitcoin is a better store of value than gold".

## Cause

`DebateCoordinator` is mounted app-wide, so its rematch routing effect runs in **every open tab**. It already guards against precisely this — but only for rematches that have a source debate:

```ts
// A debate-again session is shared across every tab, but only the tab already in the source
// room owns its recording and transition into the rematch browser. Routing from this app-wide
// coordinator sent every other open tab into that room...
if (sourceDebatePath) return;
```

A session with `source_debate_id: null` falls straight through, and every tab pushes into the picker at once. The claim is that page's heading, which is what she saw.

## Confirmed against the live database

Her session:

```
Bitcoin is a better store of value than gold | converted | source_debate_id IS NULL | 2026-08-25 16:23:20
```

And it's the **common** path, not an edge case:

| `source_debate_id` | Sessions |
|---|---|
| NULL (unguarded) | **106** |
| set (guarded) | 77 |

Several from today. It's been firing routinely — it just needs a second tab open to be visible.

## Why the fix isn't "suppress it"

Past that guard the navigation is **not optional**. A session with no source debate comes from the matchmaking hub or a profile challenge, so there's no room to hand off from and this coordinator is the only thing that can walk the viewer in. The bug is that it walked *every* tab in. So: pick one.

**Attention picks one.** The coordinator already reads `useDebatePresence`, but presence is per-document visibility and several windows report it simultaneously. `useDebateAttention` additionally requires `document.hasFocus()`, which is true of at most one tab browser-wide — the tab the viewer is looking at, and the only one that should move under them.

It's a subscription, so it's in the effect's deps deliberately: turning to a background tab re-runs the effect and routes *that* tab in, rather than stranding someone whose tabs were all unfocused when the session appeared.

## Tests

The coordinator tests now mock `debate-attention` — jsdom reports no focus, so the real store would make every existing routing case look like a background tab (this is how I found that the existing challenge-accept test needed it).

Two new cases: an unfocused tab doesn't route, and a tab that gains attention does. **Both verified by removing the guard and watching them fail — run twice each way**, since a single sample has misled me three separate times today.

## Verification

63 files / 900 tests green across `core/debates` and the debates pages; `tsc` and lint clean.

One run of that subset showed 3 intermittent teardown errors (GEO-2645's race) with all 900 passing; three further runs on identical code were completely clean. That's the known intermittency rather than anything here — #2216 removes the unmocked-fetch trigger but any pending console log can still race a worker close.
