### PR TITLE
fix(debates): stop pinning matched claims to the top of the All tab

### DIFF
--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
@@ -8,10 +8,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { TOPICS_PROPERTY_ID } from '~/core/claims/ontology';
 import type { DebateRematchClaim, DebateRematchSession, MatchmakingClaim } from '~/core/debates/api';
-import {
-  clearDebateReturnDestination,
-  rememberDebateReturnDestination,
-} from '~/core/debates/debate-return-navigation';
+import { clearDebateReturnDestination, rememberDebateReturnDestination } from '~/core/debates/debate-return-navigation';
 import type { ParticipantPosition } from '~/core/debates/participant-positions';
 
 import { DebateRematchPageClient } from './rematch-page-client';
@@ -267,7 +264,10 @@ vi.mock('~/core/debates/recommended-claims', () => ({
 // isn't about this gate behaves as before.
 vi.mock('~/core/debates/use-debate-publishable-spaces', async importOriginal => {
   const actual = await importOriginal<typeof import('~/core/debates/use-debate-publishable-spaces')>();
-  return { ...actual, useDebatePublishableSpaces: () => ({ publishableSpaceIds: mocks.publishableSpaceIds, isLoading: false }) };
+  return {
+    ...actual,
+    useDebatePublishableSpaces: () => ({ publishableSpaceIds: mocks.publishableSpaceIds, isLoading: false }),
+  };
 });
 
 // Null is "the allowlist hasn't resolved", which every case that isn't about it runs under.
@@ -475,13 +475,14 @@ describe('DebateRematchPageClient', () => {
     expect(mocks.back).not.toHaveBeenCalled();
   });
 
-  it('pins shared preferences above additional published claims and enables opposing requests', () => {
+  // The pin this used to assert is gone (GEO-2647); what matters is that both claims are listed
+  // and a shared preference is still the one you can act on.
+  it("lists the session's own claims alongside published ones and enables opposing requests", () => {
     render(<DebateRematchPageClient sessionId="rematch-1" />);
     showAllClaims();
 
-    const shared = screen.getByText('A claim both participants chose');
-    const additional = screen.getByText('A newly published claim');
-    expect(shared.compareDocumentPosition(additional) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(screen.getByText('A claim both participants chose')).toBeInTheDocument();
+    expect(screen.getByText('A newly published claim')).toBeInTheDocument();
     expect(screen.getAllByRole('button', { name: 'Request debate' })[0]).toBeEnabled();
   });
 
@@ -1111,9 +1112,7 @@ describe('DebateRematchPageClient', () => {
     // only when every claim in it was unpublishable.
     it('keeps the publishable claims in a mixed section and drops only the rest', async () => {
       const PERSONAL_CLAIM = '019fedb8-6ca7-7f94-a077-8cd3be5a0a64';
-      mocks.recommendedSections = [
-        { id: 'block-1', name: 'Politics', claimIds: [PERSONAL_CLAIM, CLAIM_MORE] },
-      ];
+      mocks.recommendedSections = [{ id: 'block-1', name: 'Politics', claimIds: [PERSONAL_CLAIM, CLAIM_MORE] }];
       mocks.recommendedEntities = [
         { ...publishedEntity(PERSONAL_CLAIM, 'A claim in someone’s own space'), spaces: [SPACE_1] },
         publishedEntity(),
@@ -1400,6 +1399,30 @@ describe('DebateRematchPageClient', () => {
       { ...sharedClaim(), shared_preference: false, claim: claimSummary(THIRD, 'Ordered claim three') },
       { ...sharedClaim(), shared_preference: false, claim: claimSummary(FIRST, 'Ordered claim one') },
     ];
+
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+    showAllClaims();
+
+    const names = screen.getAllByText(/^Ordered claim/).map(element => element.textContent);
+    expect(names).toEqual(['Ordered claim one', 'Ordered claim two', 'Ordered claim three']);
+  });
+
+  // GEO-2647. A shared preference used to be pinned to the top of the All tab, which put it ahead
+  // of what the viewer had typed and pushed their search results down. Matched claims stay
+  // legible without the pin — they are the ones offering "Request debate", and the Matches tab
+  // lists them on their own.
+  it('leaves a matched claim where the page returned it rather than pinning it first', () => {
+    const FIRST = '019fedb4-3f74-7c61-8d44-5fa08b1e7a01';
+    const SECOND = '019fedb4-3f74-7c61-8d44-5fa08b1e7a02';
+    const MATCHED = '019fedb4-3f74-7c61-8d44-5fa08b1e7a03';
+    mocks.matchmakingClaims = [
+      matchmakingClaim(FIRST, 'Ordered claim one'),
+      matchmakingClaim(SECOND, 'Ordered claim two'),
+      matchmakingClaim(MATCHED, 'Ordered claim three'),
+    ];
+    mocks.savedClaims = [];
+    // The last of the three is the one both participants have answered.
+    mocks.claims = [{ ...sharedClaim(), shared_preference: true, claim: claimSummary(MATCHED, 'Ordered claim three') }];
 
     render(<DebateRematchPageClient sessionId="rematch-1" />);
     showAllClaims();

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -290,10 +290,7 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   // differently, and when this list is unknown — no acceptor configured, a failed lookup — the
   // type test still rules out the case that actually bit us, claims living in a personal space.
   const { publishableSpaceIds } = useDebatePublishableSpaces();
-  const spaceTypePublishable = React.useMemo(
-    () => debatePublishableSpacePredicate(candidateSpaces),
-    [candidateSpaces]
-  );
+  const spaceTypePublishable = React.useMemo(() => debatePublishableSpacePredicate(candidateSpaces), [candidateSpaces]);
   const canPublishDebateIn = React.useCallback(
     (spaceId: string | null | undefined) =>
       isSpaceDebatePublishable(spaceId, publishableSpaceIds) && spaceTypePublishable(spaceId),
@@ -407,7 +404,12 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   // The All tab: geo-chat's rows, the graph's sides. Held while the allowlist resolves (see above).
   // It is still every claim the picker knows: the session's own rows — what both have answered,
   // the opponent's and the curated lists — join the pages, so a shared preference the index has
-  // not paged to yet is on the All tab, pinned first as it always was.
+  // not paged to yet is on the All tab too.
+  //
+  // Deliberately unsorted (GEO-2647). Shared preferences used to be pinned to the top, which put
+  // them ahead of what the viewer had actually typed and pushed their search results down the
+  // list. They stay legible without it: a matched claim is the one offering "Request debate", and
+  // the Matches tab exists to list them on their own.
   const browsedRows = React.useMemo(() => {
     if (allowlistPending) return [];
     const rows = new Map<string, DebateRematchClaim>();
@@ -441,7 +443,7 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
     for (const row of [...savedRows, ...opponentClaims, ...curatedClaims]) {
       if (!rows.has(row.claim.claim_entity_id)) rows.set(row.claim.claim_entity_id, row);
     }
-    return [...rows.values()].sort((a, b) => Number(b.shared_preference) - Number(a.shared_preference));
+    return [...rows.values()];
   }, [
     allowlistPending,
     browsedPages,


### PR DESCRIPTION
Closes [GEO-2647](https://linear.app/geobrowser/issue/GEO-2647/debates-stop-pinning-matched-claims-to-the-top-of-the-all-tab).

The All tab sorted shared preferences first, so a search returned its results *underneath* a block of claims that had nothing to do with the query. The pin was one line in the rematch picker, and the comment above it said as much — *"pinned first as it always was."*

## What changed

The sort is gone, so rows read in the order the page returned them, with the session's own claims (saved, the opponent's, curated) following. `useStableListOrder` still holds that order until the search or space filter changes, so it doesn't reshuffle mid-scroll.

**Removed entirely rather than only while searching.** Your call on the ticket's open question — the list holds one order whether or not there's a query, and never reorders as one is typed or cleared.

**No marker replaces it**, also per your call: a matched claim is already the one offering "Request debate", and the Matches tab lists them on their own.

**The opponent tab keeps its own ordering.** It sorts by the same field, but it isn't a search surface — it's the opponent's claims — and the ticket scopes this to All. Easy to change if you want it consistent.

## The side panel

The ticket asked to check whether the same behaviour exists there. **It doesn't.** The hub's Claims tab renders the server's order through `useStableListOrder` and never re-sorts by match state — its only `sort` alphabetises the topic filter's options. Nothing to fix.

## Testing

One test added: a matched claim returned third stays third. Verified non-vacuous by restoring the sort — it fails.

One existing test updated. `pins shared preferences above additional published claims and enables opposing requests` asserted the behaviour being removed; the half that still matters (both claims listed, a shared preference actionable) is kept, and the ordering assertion dropped.

Full suite green at 282 files / 2874 tests; lint and build pass. Two pre-existing `tsc` errors in `core/governance/sort-open-proposals.test.ts` are on master already.

Not verified in a browser — it needs a live rematch session, so the ordering is asserted through the rendered list.