### PR TITLE
feat(debates): drop the second availability toggle from the avatar menu

### DIFF
--- a/apps/web/partials/navbar/navbar-actions.test.tsx
+++ b/apps/web/partials/navbar/navbar-actions.test.tsx
@@ -10,19 +10,6 @@ const address = '0x1234567890abcdef1234567890abcdef12345678';
 
 const mocks = vi.hoisted(() => ({
   logout: vi.fn(),
-  setToast: vi.fn(),
-  debateActivityHook: vi.fn(),
-  mutateAvailability: vi.fn(),
-  mutationPending: false,
-  activityPending: false,
-  activity: {
-    online: true,
-    available_to_debate: true,
-    cooldown_until: null,
-    match: null,
-    debate: null,
-    rematch: null,
-  },
   profile: {
     name: 'Max',
     avatarUrl: 'ipfs://avatar',
@@ -56,19 +43,6 @@ vi.mock('~/core/state/pending-personal-space', () => ({
   usePendingPersonalSpace: () => mocks.pendingPersonalSpace,
 }));
 vi.mock('~/core/state/feature-flags', () => ({
-}));
-vi.mock('~/core/debates/hooks', () => ({
-  useDebateActivity: (enabled: boolean) => {
-    mocks.debateActivityHook(enabled);
-    return { data: mocks.activity, isPending: mocks.activityPending };
-  },
-  useUpdateDebateAvailability: () => ({
-    mutate: mocks.mutateAvailability,
-    isPending: mocks.mutationPending,
-  }),
-}));
-vi.mock('~/core/hooks/use-toast', () => ({
-  useToast: () => [null, mocks.setToast],
 }));
 vi.mock('~/core/hooks/use-space-id', () => ({ useSpaceId: () => null }));
 vi.mock('~/core/hooks/use-access-control', () => ({
@@ -124,24 +98,11 @@ vi.mock('~/design-system/menu', () => ({
   ),
 }));
 
-describe('NavbarActions debate availability menu', () => {
+describe('NavbarActions profile menu', () => {
   afterEach(cleanup);
 
   beforeEach(() => {
     mocks.logout.mockReset();
-    mocks.setToast.mockReset();
-    mocks.debateActivityHook.mockReset();
-    mocks.mutateAvailability.mockReset();
-    mocks.mutationPending = false;
-    mocks.activityPending = false;
-    mocks.activity = {
-      online: true,
-      available_to_debate: true,
-      cooldown_until: null,
-      match: null,
-      debate: null,
-      rematch: null,
-    };
     mocks.profile = { name: 'Max', avatarUrl: 'ipfs://avatar' };
     mocks.personalSpaceId = 'personal-space';
     mocks.pendingPersonalSpace = { isPending: false, topicId: null };
@@ -179,18 +140,6 @@ describe('NavbarActions debate availability menu', () => {
       'tracking-[-0.03125rem]',
       'not-italic'
     );
-    expect(screen.getByRole('switch', { name: 'Available to debate' })).toHaveAttribute('aria-checked', 'true');
-    expect(screen.getByRole('switch', { name: 'Available to debate' })).toHaveClass(
-      'px-3',
-      'py-2.5',
-      'gap-1',
-      'font-[family-name:var(--font-calibre)]',
-      'text-[1rem]',
-      'leading-[0.9375rem]',
-      'font-medium',
-      'tracking-[-0.03125rem]',
-      'not-italic'
-    );
     expect(screen.getByRole('button', { name: 'Sign out' })).toHaveClass(
       'px-3',
       'py-2.5',
@@ -220,41 +169,14 @@ describe('NavbarActions debate availability menu', () => {
     expect(within(identityLink).getByText(address, { selector: 'p' })).toBeInTheDocument();
   });
 
-  it('toggles with the keyboard and disables the switch while pending', async () => {
-    const user = userEvent.setup();
-    const { rerender } = render(<NavbarActions />);
-    await user.click(screen.getByRole('button', { name: 'Open profile menu' }));
-    const availabilitySwitch = screen.getByRole('switch', { name: 'Available to debate' });
-
-    availabilitySwitch.focus();
-    await user.keyboard('[Space]');
-    expect(mocks.mutateAvailability).toHaveBeenCalledWith(false, expect.any(Object));
-
-    mocks.activity.available_to_debate = false;
-    rerender(<NavbarActions />);
-    expect(screen.getByRole('switch', { name: 'Available to debate' })).toHaveAttribute('aria-checked', 'false');
-
-    mocks.mutationPending = true;
-    rerender(<NavbarActions />);
-    expect(screen.getByRole('switch', { name: 'Available to debate' })).toBeDisabled();
-
-    mocks.mutationPending = false;
-    mocks.activityPending = true;
-    rerender(<NavbarActions />);
-    expect(screen.getByRole('switch', { name: 'Available to debate' })).toBeDisabled();
-  });
-
-  it('keeps sign out usable on load failure and shows the existing toast treatment on mutation failure', async () => {
-    mocks.activity = undefined as never;
-    mocks.mutateAvailability.mockImplementation((_value, options) => options.onError());
+  it('leaves sign out working, and no longer offers a second availability switch', async () => {
+    // The toggle moved to the debates hub panel, which the navbar's own hub button opens
+    // from anywhere — a copy here was a second control for one setting.
     const user = userEvent.setup();
     render(<NavbarActions />);
     await user.click(screen.getByRole('button', { name: 'Open profile menu' }));
 
-    await user.click(screen.getByRole('switch', { name: 'Available to debate' }));
-    expect(mocks.setToast).toHaveBeenCalledWith(
-      expect.objectContaining({ props: expect.objectContaining({ children: 'Couldn’t update debate availability.' }) })
-    );
+    expect(screen.queryByRole('switch', { name: 'Available to debate' })).not.toBeInTheDocument();
 
     await user.click(screen.getByRole('button', { name: 'Sign out' }));
     expect(mocks.logout).toHaveBeenCalledOnce();

--- a/apps/web/partials/navbar/navbar-actions.tsx
+++ b/apps/web/partials/navbar/navbar-actions.tsx
@@ -10,14 +10,12 @@ import { AnimatePresence, motion, useAnimation } from 'framer-motion';
 import { useAtomValue } from 'jotai';
 
 import { browseModeToggled, editModeToggled } from '~/core/analytics';
-import { useDebateActivity, useUpdateDebateAvailability } from '~/core/debates/hooks';
 import { useAccessControl } from '~/core/hooks/use-access-control';
 import { useGeoProfile } from '~/core/hooks/use-geo-profile';
 import { useKeyboardShortcuts } from '~/core/hooks/use-keyboard-shortcuts';
 import { usePersonalSpaceId } from '~/core/hooks/use-personal-space-id';
 import { useSmartAccount } from '~/core/hooks/use-smart-account';
 import { useSpaceId } from '~/core/hooks/use-space-id';
-import { useToast } from '~/core/hooks/use-toast';
 import { useEditable } from '~/core/state/editable-store';
 import { usePendingPersonalSpace } from '~/core/state/pending-personal-space';
 import { NavUtils } from '~/core/utils/utils';
@@ -50,10 +48,7 @@ export function NavbarActions() {
   const { personalSpaceId } = usePersonalSpaceId();
   const { isPending, topicId } = usePendingPersonalSpace();
   const pendingAvatar = useAtomValue(avatarAtom);
-  const activityQuery = useDebateActivity();
-  const availabilityMutation = useUpdateDebateAvailability();
   const { user } = usePrivy();
-  const [, setToast] = useToast();
   // Cleanup is registered once at the app root (useGeoLogoutCleanup); here we
   // only trigger the logout.
   const { logout } = useLogout();
@@ -83,15 +78,6 @@ export function NavbarActions() {
   const displayName = profile?.name?.trim() || shortAddress(address);
   const email = userEmail(user);
   const identityDetail = email ?? address;
-  const availableToDebate = activityQuery.data?.available_to_debate ?? true;
-  const availabilityPending = activityQuery.isPending || availabilityMutation.isPending;
-
-  const toggleDebateAvailability = () => {
-    availabilityMutation.mutate(!availableToDebate, {
-      onError: () => setToast(<span>Couldn’t update debate availability.</span>),
-    });
-  };
-
   return (
     <div className="flex items-center gap-4">
       <ModeToggle />
@@ -120,30 +106,6 @@ export function NavbarActions() {
           onNavigate={() => onOpenChange(false)}
         />
         <div className="border-t border-grey-02">
-          <button
-            type="button"
-            role="switch"
-            aria-checked={availableToDebate}
-            disabled={availabilityPending}
-            onClick={toggleDebateAvailability}
-            className="flex w-full items-center justify-between gap-1 px-3 py-2.5 text-left font-[family-name:var(--font-calibre)] text-[1rem] leading-[0.9375rem] font-medium tracking-[-0.03125rem] text-text not-italic transition-colors hover:bg-bg focus-visible:bg-bg focus-visible:outline-none disabled:cursor-wait disabled:text-grey-03"
-          >
-            <span className="min-w-0 truncate">Available to debate</span>
-            <span
-              aria-hidden="true"
-              className={cx(
-                'relative h-4 w-6 shrink-0 rounded-full transition-colors',
-                availableToDebate ? 'bg-text' : 'bg-grey-03'
-              )}
-            >
-              <span
-                className={cx(
-                  'absolute top-0.5 left-0.5 h-3 w-3 rounded-full bg-white transition-transform',
-                  availableToDebate && 'translate-x-2'
-                )}
-              />
-            </span>
-          </button>
           <button
             type="button"
             onClick={logout}


### PR DESCRIPTION
Closes [GEO-2655](https://linear.app/geobrowser/issue/GEO-2655/debates-remove-duplicate-available-to-debate-toggle-from-the-profile).

"Available to debate" lives in the debates hub panel now, so the copy in the profile avatar dropdown was a second control for one piece of state. This removes it.

## On the reachability question in the ticket

The ticket flags that the avatar dropdown is visible everywhere while the debates side panel isn't, and asks whether the toggle stays reachable — particularly to turn availability **off** once someone is done. It holds up:

- `DebatesHubPanel` is mounted in `app/entry.tsx` at the app root, not on the debates route, so it's available from any page.
- It opens from `DebatesHubButton`, which renders in the navbar itself (`navbar-client-actions.tsx`) — a few pixels from the avatar this toggle used to sit behind.
- That button is deliberately shown to people who are *not* currently available. Its own comment says so: "Shown to signed-in users once debates are enabled — including those who are not available to debate, since the hub is where they turn it on."

So turning availability off is as reachable as before, and one navbar click away rather than behind a dropdown. The second note — that someone who learned the dropdown location may read this as the setting vanishing — is a judgment call I've left alone: the replacement is adjacent and visible rather than hidden, so a pointer seemed like more noise than help. Easy to add if you disagree.

## Also removed

The navbar's own `useDebateActivity` / `useUpdateDebateAvailability` calls and the toast wiring, which existed only for this control. The hub button already runs that query, so nothing stops being fetched and the panel's toggle is unaffected.

## Testing

- The two navbar tests that existed only for this toggle are gone; one is replaced by a check that the switch is **not** in the menu, so the duplicate can't quietly return. Sign-out coverage is kept.
- The identity-layout test no longer asserts the switch's classes.
- Mocks that existed only for the toggle (`useDebateActivity`, `useUpdateDebateAvailability`, `useToast`, and the activity fixture) are removed rather than left dangling.
- `vitest run partials/navbar core/debates/matchmaking` — 128 passing, including the hub panel's own toggle tests.
- `bun run build` clean.

Not verified in a browser: the dropdown only renders for a signed-in account, which this environment doesn't have. The navbar tests render the menu with mocked auth and assert its contents directly, which covers the same ground.