### PR TITLE
fix(debates): narrow the topics menu to the selected space

### DIFF
--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
@@ -1186,6 +1186,23 @@ describe('DebateRematchPageClient', () => {
     await waitFor(() => expect(screen.queryByRole('button', { name: /Governance/ })).toBeNull());
   });
 
+  // The scope sent to geo-chat has to apply the space-type gate too. The allowlist holds the
+  // viewer's own personal space, and the editor-space lookup passes everything while unresolved —
+  // so without it a personal space joins the scope, contributes its topics to the facet, and has
+  // every one of its rows removed again by `canPublishDebateIn`.
+  it('keeps a personal space out of the scope even when the editor lookup is unresolved', async () => {
+    mocks.publishableSpaceIds = null;
+    mocks.spaceTypes = { [SPACE_2]: 'PERSONAL' };
+    mocks.spaceAllowlist = new Set([SPACE_1.replace(/-/g, ''), SPACE_2.replace(/-/g, '')]);
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+    showAllClaims();
+
+    await waitFor(() => expect(mocks.entityQueries.at(-1)).toBeTruthy());
+    const scope = (mocks.entityQueries.at(-1) as { spaceIds?: string[] | null }).spaceIds ?? [];
+    expect(scope).toContain(SPACE_1.replace(/-/g, ''));
+    expect(scope).not.toContain(SPACE_2.replace(/-/g, ''));
+  });
+
   it('keeps every space on offer after narrowing to one', async () => {
     render(<DebateRematchPageClient sessionId="rematch-1" />);
     showAllClaims();

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
@@ -61,6 +61,8 @@ const mocks = vi.hoisted(() => ({
   matchmakingClaims: [] as MatchmakingClaim[],
   /** Overrides the single-page default when a test needs paging to accumulate. */
   entityQueryPages: null as MatchmakingClaim[][] | null,
+  // What `keepPreviousData` would still be holding once the query goes disabled.
+  lastEnabledData: undefined as { pages: unknown[] } | undefined,
   entityQueryFetchingNextPage: false,
   /** Both participants' graph positions. */
   positions: [] as ParticipantPosition[],
@@ -254,7 +256,24 @@ vi.mock('~/core/hooks/use-entity-vote', () => ({
 vi.mock('~/core/debates/matchmaking/hooks', () => ({
   useClaimReadiness: () => ({ mutate: mocks.setReadiness, isPending: false, error: null }),
   // The All tab is the hub's Claims query. Its arguments are what the tests below inspect.
-  useMatchmakingClaims: (query: { search: string | null; spaceId: string | null; topicId?: string | null }) => {
+  useMatchmakingClaims: (
+    query: { search: string | null; spaceId: string | null; topicId?: string | null },
+    enabled: boolean
+  ) => {
+    // A disabled query is not a silent one: `placeholderData: keepPreviousData` outlives
+    // `enabled: false`, so it keeps handing back the last key's pages — facets included. Modelled,
+    // because a mock that returns nothing here makes the masking downstream look unnecessary.
+    if (!enabled) {
+      return {
+        data: mocks.lastEnabledData,
+        isLoading: false,
+        error: null,
+        hasNextPage: mocks.entityQueryHasNextPage,
+        isFetchingNextPage: false,
+        isPlaceholderData: mocks.lastEnabledData !== undefined,
+        fetchNextPage: mocks.fetchNextPage,
+      };
+    }
     mocks.entityQueries.push(query);
     // `space_id` and `topic_id` both filter server-side as of GEO-2659, and every page carries
     // facets computed over the whole candidate set rather than the page being returned.
@@ -269,16 +288,18 @@ vi.mock('~/core/debates/matchmaking/hooks', () => ({
       space_facets: spaceIds.map(id => ({ id, name: null, count: 1 })),
       topic_facets: topicFacets.map(topic => ({ ...topic, count: 1 })),
     };
+    const data = {
+      pages: corpus.map(page => ({
+        claims: page
+          .filter(entry => !query.spaceId || entry.claim.space_id === query.spaceId)
+          .filter(entry => !query.topicId || entry.topics.some(topic => topic.id === query.topicId)),
+        next_cursor: null,
+        facets,
+      })),
+    };
+    mocks.lastEnabledData = data;
     return {
-      data: {
-        pages: corpus.map(page => ({
-          claims: page
-            .filter(entry => !query.spaceId || entry.claim.space_id === query.spaceId)
-            .filter(entry => !query.topicId || entry.topics.some(topic => topic.id === query.topicId)),
-          next_cursor: null,
-          facets,
-        })),
-      },
+      data,
       isLoading: mocks.entityQueryLoading,
       error: null,
       hasNextPage: mocks.entityQueryHasNextPage,
@@ -372,6 +393,7 @@ beforeEach(() => {
   mocks.entityQueries.length = 0;
   mocks.entityIdLookups.length = 0;
   mocks.entityQueryHasNextPage = false;
+  mocks.lastEnabledData = undefined;
   mocks.entityQueryLoading = false;
   mocks.entityHydrationLoading = false;
   mocks.fetchNextPage.mockReset();
@@ -1141,6 +1163,51 @@ describe('DebateRematchPageClient', () => {
     fireEvent.click(screen.getByRole('button', { name: /Any topic/ }));
 
     expect(screen.getByRole('button', { name: /Later/ })).toBeInTheDocument();
+  });
+
+  // The same scope the rows are gated by has to reach the query, and it isn't known until the
+  // allowlist, the acceptor's editor spaces and the space types have all landed. Asked before
+  // then, geo-chat answers about every space it knows: `browsedRows` drops those rows, but a
+  // topic facet has no space on it to drop it by, so the menu kept offering them.
+  it('offers no topics until the scope it is about to apply is known', async () => {
+    mocks.matchmakingClaims = [
+      { ...matchmakingClaim(), topics: [] },
+      {
+        ...matchmakingClaim(CLAIM_SOURCE, 'A claim only the facet knows about'),
+        topics: [{ id: 'topic-later', name: 'Later' }],
+      },
+    ];
+    mocks.spaceAllowlist = null;
+    mocks.allowlistLoading = true;
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+    showAllClaims();
+
+    fireEvent.click(screen.getByRole('button', { name: /Any topic/ }));
+
+    expect(screen.queryByRole('button', { name: /Later/ })).toBeNull();
+  });
+
+  // The held order is released for a new search or space because those change what the server
+  // ranked. Topic does now too — it goes out as `topic_id` — so without it in the key the rows
+  // that survive the change keep the ranking of the query before it, and the newly ranked list
+  // arrives arranged by an order the viewer already left. The Claims tab resets on it already.
+  it('takes the new ranking when the topic changes, rather than holding the old one', async () => {
+    const FIRST = '019fedc1-1111-7000-8000-000000000001';
+    const SECOND = '019fedc1-2222-7000-8000-000000000002';
+    const gov = [{ id: 'topic-gov', name: 'Governance' }];
+    mocks.matchmakingClaims = [
+      { ...matchmakingClaim(FIRST, 'Ranked first when unfiltered'), topics: gov },
+      { ...matchmakingClaim(SECOND, 'Ranked first once filtered'), topics: gov },
+    ];
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+    showAllClaims();
+    await waitFor(() => expect(appearsBefore('Ranked first when unfiltered', 'Ranked first once filtered')).toBe(true));
+
+    // What the server does when the filter it ranks under changes.
+    mocks.matchmakingClaims = [...mocks.matchmakingClaims].reverse();
+    selectFilter('Any topic', 'Governance');
+
+    await waitFor(() => expect(appearsBefore('Ranked first once filtered', 'Ranked first when unfiltered')).toBe(true));
   });
 
   it('asks the server to do the topic filtering on the All tab', async () => {

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
@@ -1234,6 +1234,30 @@ describe('DebateRematchPageClient', () => {
     await waitFor(() => expect(screen.getByRole('button', { name: /Any space/ })).toBeInTheDocument());
   });
 
+  // The All tab is the browsed corpus plus this session's own rows pinned in front, and geo-chat
+  // has never seen those. A topic carried only by one of them was on screen with no way to
+  // filter to it, because the menu came from the facet alone.
+  it('offers a topic carried only by a pinned row geo-chat does not know', async () => {
+    mocks.matchmakingClaims = [];
+    mocks.entities = [
+      sharedEntity(),
+      {
+        ...sharedEntity(),
+        relations: [
+          { type: { id: TOPICS_PROPERTY_ID }, toEntity: { id: 'topic-pinned', name: 'Pinned only' }, isDeleted: false },
+        ],
+      },
+    ];
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+    showAllClaims();
+
+    await waitFor(() => expect(screen.getByText('A claim both participants chose')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole('button', { name: /Any topic/ }));
+
+    expect(screen.getByRole('button', { name: /Pinned only/ })).toBeInTheDocument();
+  });
+
   it('keeps every space on offer after narrowing to one', async () => {
     render(<DebateRematchPageClient sessionId="rematch-1" />);
     showAllClaims();

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
@@ -90,6 +90,19 @@ const mocks = vi.hoisted(() => ({
   }>,
 }));
 
+// `pending-personal-space` reads localStorage at module scope (`atomWithStorage` with
+// `getOnInit`), and the storage jsdom hands back here has no `getItem`. The throw happens while
+// the module graph is still being built, so it took this whole file down at collection — every
+// test in it, on master and in CI alike. The picker reaches it through the claim card.
+vi.mock('~/core/state/pending-personal-space', () => ({
+  PENDING_PERSONAL_SPACE_PREFIX: 'pending:',
+  pendingPersonalSpaceAtom: { toString: () => 'pendingPersonalSpaceAtom' },
+  pendingPersonalSpaceId: (topicId: string) => `pending:${topicId}`,
+  isPendingPersonalSpaceId: (spaceId: string | null | undefined) =>
+    typeof spaceId === 'string' && spaceId.startsWith('pending:'),
+  usePendingPersonalSpace: () => ({ isPending: false }),
+}));
+
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ replace: mocks.replace, back: mocks.back }),
 }));
@@ -1059,6 +1072,52 @@ describe('DebateRematchPageClient', () => {
     selectFilter('Any topic', 'Ethics');
 
     expect(screen.getByText('A newly published claim')).toBeInTheDocument();
+  });
+
+  // GEO-2653. The space and topic menus were both fed by a ref that only ever accumulated, so a
+  // topic stayed on offer after its claims had been filtered away — and picking it could only
+  // ever produce an empty list. Spaces still accumulate: the space filter runs in the browsed
+  // query, so a menu built from the loaded corpus would strand the viewer in whatever space they
+  // picked. The topic filter runs client-side and has no such problem to solve.
+  it('drops the topics that have no claims in the selected space', async () => {
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+    showAllClaims();
+
+    // Governance and Ethics belong to the published claim, which lives in the Governance space.
+    selectFilter('Any space', 'Crypto');
+    await waitFor(() => expect(screen.queryByText('A newly published claim')).toBeNull());
+
+    fireEvent.click(screen.getByRole('button', { name: /Any topic/ }));
+
+    expect(screen.queryByRole('button', { name: /Governance/ })).toBeNull();
+    expect(screen.queryByRole('button', { name: /Ethics/ })).toBeNull();
+  });
+
+  it('keeps every space on offer after narrowing to one', async () => {
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+    showAllClaims();
+
+    selectFilter('Any space', 'Crypto');
+    await waitFor(() => expect(screen.queryByText('A newly published claim')).toBeNull());
+
+    // The way back. Narrowing the space menu to the loaded corpus would leave only Crypto on it.
+    fireEvent.click(screen.getByRole('button', { name: /Crypto/ }));
+
+    expect(screen.getByRole('button', { name: /Governance/ })).toBeInTheDocument();
+  });
+
+  it('lets go of a selected topic once the space no longer has claims for it', async () => {
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+    showAllClaims();
+
+    selectFilter('Any topic', 'Governance');
+    await waitFor(() => expect(screen.queryByText('A claim both participants chose')).toBeNull());
+
+    selectFilter('Any space', 'Crypto');
+
+    // Held, it would filter the list by a chip that is no longer in the menu to unpick.
+    await waitFor(() => expect(screen.getByRole('button', { name: /Any topic/ })).toBeInTheDocument());
+    expect(screen.getByText('A claim both participants chose')).toBeInTheDocument();
   });
 
   it('narrows the list to the selected space', async () => {

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
@@ -63,6 +63,8 @@ const mocks = vi.hoisted(() => ({
   entityQueryPages: null as MatchmakingClaim[][] | null,
   // What `keepPreviousData` would still be holding once the query goes disabled.
   lastEnabledData: undefined as { pages: unknown[] } | undefined,
+  spacesHeldOver: false,
+  scopeHeldOver: false,
   entityQueryFetchingNextPage: false,
   /** Both participants' graph positions. */
   positions: [] as ParticipantPosition[],
@@ -274,6 +276,19 @@ vi.mock('~/core/debates/matchmaking/hooks', () => ({
         fetchNextPage: mocks.fetchNextPage,
       };
     }
+    // A scope change is a key change like any other, so `keepPreviousData` answers it with the
+    // previous scope's pages while the new request is in flight.
+    if (mocks.scopeHeldOver) {
+      return {
+        data: mocks.lastEnabledData,
+        isLoading: false,
+        error: null,
+        hasNextPage: mocks.entityQueryHasNextPage,
+        isFetchingNextPage: false,
+        isPlaceholderData: true,
+        fetchNextPage: mocks.fetchNextPage,
+      };
+    }
     mocks.entityQueries.push(query);
     // `space_id` and `topic_id` both filter server-side as of GEO-2659, and every page carries
     // facets computed over the whole candidate set rather than the page being returned.
@@ -365,6 +380,10 @@ vi.mock('~/core/hooks/use-spaces-by-ids', () => ({
       ].map(([id, name]) => [id, { type: mocks.spaceTypes[id] ?? 'DAO', entity: { name, image: null } }])
     ),
     isLoading: false,
+    // The real hook holds the previous id set's map rather than blanking it, and flags that it is
+    // doing so. A held map answers nothing about ids it was never asked for, which is the whole
+    // reason the picker has to wait it out.
+    isPlaceholderData: mocks.spacesHeldOver,
   }),
 }));
 
@@ -394,6 +413,8 @@ beforeEach(() => {
   mocks.entityIdLookups.length = 0;
   mocks.entityQueryHasNextPage = false;
   mocks.lastEnabledData = undefined;
+  mocks.spacesHeldOver = false;
+  mocks.scopeHeldOver = false;
   mocks.entityQueryLoading = false;
   mocks.entityHydrationLoading = false;
   mocks.fetchNextPage.mockReset();
@@ -1208,6 +1229,84 @@ describe('DebateRematchPageClient', () => {
     selectFilter('Any topic', 'Governance');
 
     await waitFor(() => expect(appearsBefore('Ranked first once filtered', 'Ranked first when unfiltered')).toBe(true));
+  });
+
+  // `useSpacesByIds` keeps the previous id set's map instead of blanking every space image on
+  // screen, and says so through `isPlaceholderData`. The picker reads it for ids that may not be
+  // in it — one just added to the allowlist — and a missing type reads as publishable, so the
+  // personal space this gate exists to exclude is exactly what the held map lets through.
+  it('waits out a held-over space map rather than trusting what it does not contain', async () => {
+    mocks.matchmakingClaims = [
+      { ...matchmakingClaim(), topics: [] },
+      {
+        ...matchmakingClaim(CLAIM_SOURCE, 'A claim only the facet knows about'),
+        topics: [{ id: 'topic-later', name: 'Later' }],
+      },
+    ];
+    mocks.spacesHeldOver = true;
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+    showAllClaims();
+
+    fireEvent.click(screen.getByRole('button', { name: /Any topic/ }));
+
+    expect(screen.queryByRole('button', { name: /Later/ })).toBeNull();
+  });
+
+  // The All tab's search runs server-side over the browsed rows; the pinned ones are merged in
+  // whether they match it or not. Cutting them out of the facet left them on screen with their
+  // topics missing from the menu — the pinned-row merge undone by the filter beside it.
+  it('keeps the topics of a pinned row the search does not match', async () => {
+    mocks.entities = [
+      sharedEntity(),
+      {
+        ...sharedEntity(),
+        relations: [
+          { type: { id: TOPICS_PROPERTY_ID }, toEntity: { id: 'topic-pinned', name: 'Pinned only' }, isDeleted: false },
+        ],
+      },
+    ];
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+    showAllClaims();
+
+    // Matches the browsed row's text, not the pinned claim both participants chose.
+    fireEvent.change(screen.getByRole('textbox', { name: 'Search claims' }), { target: { value: 'newly' } });
+    await waitFor(() => expect(mocks.entityQueries.at(-1)).toMatchObject({ search: 'newly' }));
+
+    // The pinned row is still on screen — the search never reached it — so it is still a row the
+    // viewer can be filtering to.
+    expect(screen.getByText('A claim both participants chose')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /Any topic/ }));
+
+    expect(screen.getByRole('button', { name: /Pinned only/ })).toBeInTheDocument();
+  });
+
+  // The scope can also change after it has settled — the viewer joins a space and the allowlist
+  // refetches — and no loading flag turns over when it does. The only sign is that the pages in
+  // hand were fetched under the scope before it, and their topic facet still names spaces that
+  // are now outside it.
+  it('drops the pages fetched under a scope the viewer has since left', async () => {
+    mocks.matchmakingClaims = [
+      { ...matchmakingClaim(), topics: [] },
+      {
+        ...matchmakingClaim(CLAIM_SOURCE, 'A claim only the facet knows about'),
+        topics: [{ id: 'topic-later', name: 'Later' }],
+      },
+    ];
+    const view = render(<DebateRematchPageClient sessionId="rematch-1" />);
+    showAllClaims();
+    await waitFor(() => expect(screen.getByText('A newly published claim')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole('button', { name: /Any topic/ }));
+    expect(screen.getByRole('button', { name: /Later/ })).toBeInTheDocument();
+
+    // The scope narrows from "no filter" to one space; the previous one's pages are what React
+    // Query has to answer with meanwhile. The menu is left open, so this is the option list
+    // changing under the viewer's cursor.
+    mocks.spaceAllowlist = new Set([SPACE_2.replace(/-/g, '')]);
+    mocks.scopeHeldOver = true;
+    view.rerender(<DebateRematchPageClient sessionId="rematch-1" />);
+
+    await waitFor(() => expect(screen.queryByRole('button', { name: /Later/ })).toBeNull());
   });
 
   it('asks the server to do the topic filtering on the All tab', async () => {

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
@@ -1283,6 +1283,17 @@ describe('DebateRematchPageClient', () => {
     expect(screen.queryByRole('button', { name: /Server only/ })).toBeNull();
   });
 
+  // The session's own exclusions — the source debate's claim, and anything this pairing has
+  // blocked — are geo-chat's to apply, so its facets describe the rows it actually returns. Left
+  // to the client they were applied after the facets were built, and a topic whose every claim in
+  // the space had been excluded stayed on the menu over an empty list (GEO-2674).
+  it('asks geo-chat to scope the corpus to this session', async () => {
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+    showAllClaims();
+
+    await waitFor(() => expect(mocks.entityQueries.at(-1)).toMatchObject({ rematchSessionId: 'rematch-1' }));
+  });
+
   it('keeps every space on offer after narrowing to one', async () => {
     render(<DebateRematchPageClient sessionId="rematch-1" />);
     showAllClaims();

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
@@ -1203,6 +1203,37 @@ describe('DebateRematchPageClient', () => {
     expect(scope).not.toContain(SPACE_2.replace(/-/g, ''));
   });
 
+  // The opponent and curated tabs are deliberately not narrowed by the viewer's allowlist, so a
+  // claim of theirs in a space the viewer has never joined stays on screen. Its space has to stay
+  // in the menu with it, or the row is visible and unfilterable.
+  it('keeps a graph-tab space in the menu even when the allowlist excludes it', async () => {
+    mocks.spaceAllowlist = new Set([SPACE_2.replace(/-/g, '')]);
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+
+    // The shared claim sits in Crypto, which the allowlist above leaves out.
+    expect(screen.getByText('A claim both participants chose')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /Any space/ }));
+
+    await waitFor(() => expect(screen.getByRole('button', { name: /Crypto/ })).toBeInTheDocument());
+  });
+
+  // A space can be picked while the gates are still passing everything. Once they reject it the
+  // menu drops it, and leaving it selected keeps it going out on every request.
+  it('lets go of a picked space the settled gates reject', async () => {
+    mocks.publishableSpaceIds = null;
+    const view = render(<DebateRematchPageClient sessionId="rematch-1" />);
+    showAllClaims();
+
+    selectFilter('Any space', 'Governance');
+    await waitFor(() => expect(screen.queryByText('A claim both participants chose')).toBeNull());
+
+    mocks.publishableSpaceIds = new Set([SPACE_1.replace(/-/g, '')]);
+    view.rerender(<DebateRematchPageClient sessionId="rematch-1" />);
+
+    await waitFor(() => expect(screen.getByRole('button', { name: /Any space/ })).toBeInTheDocument());
+  });
+
   it('keeps every space on offer after narrowing to one', async () => {
     render(<DebateRematchPageClient sessionId="rematch-1" />);
     showAllClaims();

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
@@ -1150,6 +1150,23 @@ describe('DebateRematchPageClient', () => {
     await waitFor(() => expect(mocks.entityQueries.at(-1)).toMatchObject({ topicId: 'topic-gov' }));
   });
 
+  // Reported after the facet landed: pick a space, pick a topic it lists, get nothing. The space
+  // menu was filtered by the viewer's allowlist but not by whether this pairing can publish a
+  // debate there — and `browsedRows` drops every claim in a space it cannot. The server's topic
+  // facet knows nothing about that, so it offered all of the space's topics over an empty list.
+  it('does not offer a space no debate can be published into', async () => {
+    mocks.publishableSpaceIds = new Set([SPACE_1.replace(/-/g, '')]);
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+    showAllClaims();
+
+    fireEvent.click(screen.getByRole('button', { name: /Any space/ }));
+
+    // SPACE_2 holds the published claim and is on the server's space facet; it is not somewhere
+    // this pairing can debate, so picking it could only ever empty the list.
+    await waitFor(() => expect(screen.getByRole('button', { name: /Crypto/ })).toBeInTheDocument());
+    expect(screen.queryByRole('button', { name: /Governance/ })).toBeNull();
+  });
+
   it('keeps every space on offer after narrowing to one', async () => {
     render(<DebateRematchPageClient sessionId="rematch-1" />);
     showAllClaims();

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
@@ -756,8 +756,10 @@ describe('DebateRematchPageClient', () => {
     // without spending a per-space request to find that out.
     expect(screen.getAllByRole('switch', { name: 'Ready to debate this claim' })).toHaveLength(2);
     expect(mocks.perSpaceReadinessGroups.every(groups => groups.length === 0)).toBe(true);
-    // Hydrated by id — exactly the claims the graph named, nothing paged.
-    expect(mocks.entityIdLookups.at(-1)).toEqual([CLAIM_SHARED, FRESH]);
+    // Hydrated by id — exactly the claims the graph named, nothing paged. Matched among the
+    // hydrations rather than as the last one: the All tab now hydrates its own rows too, for
+    // the topics geo-chat doesn't carry.
+    expect(mocks.entityIdLookups).toContainEqual([CLAIM_SHARED, FRESH]);
     // And the graph was asked about exactly these two people.
     expect(mocks.positionParticipants.at(-1)).toEqual(['profile-local', 'profile-remote']);
   });
@@ -1876,7 +1878,15 @@ function position(profileSpaceId: string, claimId: string, spaceId: string, side
   return { profileSpaceId, claimId, spaceId, responseKind: 'stance', position: side };
 }
 
-/** The published claim as the hub's claims query lists it: in Governance space, tagged twice. */
+/**
+ * The published claim as the hub's claims query lists it: in Governance space.
+ *
+ * `topics` is empty because that is what geo-chat sends — it hardcodes `topics: vec![]` on every
+ * row and ignores `topic_id`. This fixture used to supply them anyway, which is how the All tab
+ * could pass topic tests while showing no topics at all in the real app (GEO-2653): the picker
+ * has to hydrate these rows from the graph to learn their topics, and `publishedEntity` below
+ * is where they now come from.
+ */
 function matchmakingClaim(id = CLAIM_MORE, claim = 'A newly published claim'): MatchmakingClaim {
   return {
     claim: { id, space_id: SPACE_2, claim_entity_id: id, claim, description: null },
@@ -1885,10 +1895,7 @@ function matchmakingClaim(id = CLAIM_MORE, claim = 'A newly published claim'): M
     viewer_debate_ready: false,
     readiness_disabled_reason: null,
     viewer_position: null,
-    topics: [
-      { id: 'topic-gov', name: 'Governance' },
-      { id: 'topic-eth', name: 'Ethics' },
-    ],
+    topics: [],
     positions: [],
     score: 0,
     active_debate: false,

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
@@ -1167,6 +1167,25 @@ describe('DebateRematchPageClient', () => {
     expect(screen.queryByRole('button', { name: /Governance/ })).toBeNull();
   });
 
+  // The publishability lookup answers `true` while it is still resolving, so the first render
+  // admits every space the facet names. The menu accumulates, so gating only the writes would
+  // never take those back — it has to re-check what it already holds.
+  it('drops an unpublishable space from the menu once the lookup resolves', async () => {
+    mocks.publishableSpaceIds = null;
+    const view = render(<DebateRematchPageClient sessionId="rematch-1" />);
+    showAllClaims();
+
+    fireEvent.click(screen.getByRole('button', { name: /Any space/ }));
+    await waitFor(() => expect(screen.getByRole('button', { name: /Governance/ })).toBeInTheDocument());
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    mocks.publishableSpaceIds = new Set([SPACE_1.replace(/-/g, '')]);
+    view.rerender(<DebateRematchPageClient sessionId="rematch-1" />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Any space/ }));
+    await waitFor(() => expect(screen.queryByRole('button', { name: /Governance/ })).toBeNull());
+  });
+
   it('keeps every space on offer after narrowing to one', async () => {
     render(<DebateRematchPageClient sessionId="rematch-1" />);
     showAllClaims();

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
@@ -92,8 +92,8 @@ const mocks = vi.hoisted(() => ({
 
 // `pending-personal-space` reads localStorage at module scope (`atomWithStorage` with
 // `getOnInit`), and the storage jsdom hands back here has no `getItem`. The throw happens while
-// the module graph is still being built, so it took this whole file down at collection — every
-// test in it, on master and in CI alike. The picker reaches it through the claim card.
+// the module graph is still being built, so it takes this whole file down at collection — every
+// test in it, on master and in CI alike. Reached through the claim card.
 vi.mock('~/core/state/pending-personal-space', () => ({
   PENDING_PERSONAL_SPACE_PREFIX: 'pending:',
   pendingPersonalSpaceAtom: { toString: () => 'pendingPersonalSpaceAtom' },
@@ -251,10 +251,33 @@ vi.mock('~/core/hooks/use-entity-vote', () => ({
 vi.mock('~/core/debates/matchmaking/hooks', () => ({
   useClaimReadiness: () => ({ mutate: mocks.setReadiness, isPending: false, error: null }),
   // The All tab is the hub's Claims query. Its arguments are what the tests below inspect.
-  useMatchmakingClaims: (query: { search: string | null; spaceId: string | null }) => {
+  useMatchmakingClaims: (query: { search: string | null; spaceId: string | null; topicId?: string | null }) => {
     mocks.entityQueries.push(query);
+    // `space_id` and `topic_id` both filter server-side as of GEO-2659, and the response carries
+    // facets computed over the whole filtered set rather than the returned page.
+    const inSpace = mocks.matchmakingClaims.filter(entry => !query.spaceId || entry.claim.space_id === query.spaceId);
+    const claims = inSpace.filter(entry => !query.topicId || entry.topics.some(topic => topic.id === query.topicId));
+    const topicFacets = [...new Map(inSpace.flatMap(entry => entry.topics).map(topic => [topic.id, topic])).values()];
     return {
-      data: { pages: [{ claims: mocks.matchmakingClaims, next_cursor: null, facets: undefined }] },
+      data: {
+        pages: [
+          {
+            claims,
+            next_cursor: null,
+            // Narrowed by space, never by topic: picking a topic must not collapse its own menu.
+            facets: {
+              space_ids: [...new Set(mocks.matchmakingClaims.map(entry => entry.claim.space_id))],
+              topics: topicFacets,
+              space_facets: [...new Set(mocks.matchmakingClaims.map(entry => entry.claim.space_id))].map(id => ({
+                id,
+                name: null,
+                count: 1,
+              })),
+              topic_facets: topicFacets.map(topic => ({ ...topic, count: 1 })),
+            },
+          },
+        ],
+      },
       isLoading: mocks.entityQueryLoading,
       error: null,
       hasNextPage: mocks.entityQueryHasNextPage,
@@ -1095,6 +1118,38 @@ describe('DebateRematchPageClient', () => {
     expect(screen.queryByRole('button', { name: /Ethics/ })).toBeNull();
   });
 
+  // The report that reopened GEO-2653: the menu was built from the claims paged in so far, so a
+  // space whose first page carried no topics looked like a space with none. The facet describes
+  // the whole filtered set, so a topic shows up without the viewer scrolling to reach its claim.
+  it('offers a topic from a claim no page has returned yet', async () => {
+    mocks.matchmakingClaims = [
+      { ...matchmakingClaim(), topics: [] },
+      {
+        ...matchmakingClaim(CLAIM_SOURCE, 'A claim only the facet knows about'),
+        topics: [{ id: 'topic-later', name: 'Later' }],
+      },
+    ];
+    // The server returns the second row only once the topic is picked; the facet names it either
+    // way, which is the difference this is here to hold.
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+    showAllClaims();
+    await waitFor(() => expect(screen.getByText('A newly published claim')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole('button', { name: /Any topic/ }));
+
+    expect(screen.getByRole('button', { name: /Later/ })).toBeInTheDocument();
+  });
+
+  it('asks the server to do the topic filtering on the All tab', async () => {
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+    showAllClaims();
+
+    selectFilter('Any topic', 'Governance');
+
+    // Filtering only here would narrow the pages already loaded and nothing beyond them.
+    await waitFor(() => expect(mocks.entityQueries.at(-1)).toMatchObject({ topicId: 'topic-gov' }));
+  });
+
   it('keeps every space on offer after narrowing to one', async () => {
     render(<DebateRematchPageClient sessionId="rematch-1" />);
     showAllClaims();
@@ -1879,13 +1934,11 @@ function position(profileSpaceId: string, claimId: string, spaceId: string, side
 }
 
 /**
- * The published claim as the hub's claims query lists it: in Governance space.
+ * The published claim as the hub's claims query lists it: in Governance space, tagged twice.
  *
- * `topics` is empty because that is what geo-chat sends — it hardcodes `topics: vec![]` on every
- * row and ignores `topic_id`. This fixture used to supply them anyway, which is how the All tab
- * could pass topic tests while showing no topics at all in the real app (GEO-2653): the picker
- * has to hydrate these rows from the graph to learn their topics, and `publishedEntity` below
- * is where they now come from.
+ * geo-chat replicates topics from the Knowledge Graph as of GEO-2659, so its rows carry them
+ * again. They were briefly empty here to match a server that sent `topics: vec![]` on every row,
+ * which is what forced the picker to hydrate these rows from the graph itself.
  */
 function matchmakingClaim(id = CLAIM_MORE, claim = 'A newly published claim'): MatchmakingClaim {
   return {
@@ -1895,7 +1948,10 @@ function matchmakingClaim(id = CLAIM_MORE, claim = 'A newly published claim'): M
     viewer_debate_ready: false,
     readiness_disabled_reason: null,
     viewer_position: null,
-    topics: [],
+    topics: [
+      { id: 'topic-gov', name: 'Governance' },
+      { id: 'topic-eth', name: 'Ethics' },
+    ],
     positions: [],
     score: 0,
     active_debate: false,

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
@@ -1258,6 +1258,31 @@ describe('DebateRematchPageClient', () => {
     expect(screen.getByRole('button', { name: /Pinned only/ })).toBeInTheDocument();
   });
 
+  // The mirror of the allowlist exception: a space can be in the menu without being in the
+  // allowlist, but `browsedRows` still drops the browsed rows from it. Merging the server's facet
+  // for such a space would offer topics carried only by rows that never render.
+  it('does not offer server topics for a selected space outside the allowlist', async () => {
+    mocks.spaceAllowlist = new Set([SPACE_2.replace(/-/g, '')]);
+    mocks.matchmakingClaims = [
+      {
+        ...matchmakingClaim(CLAIM_SOURCE, 'A browsed claim in Crypto'),
+        claim: { ...matchmakingClaim().claim, id: CLAIM_SOURCE, claim_entity_id: CLAIM_SOURCE, space_id: SPACE_1 },
+        topics: [{ id: 'topic-server', name: 'Server only' }],
+      },
+    ];
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+    showAllClaims();
+
+    // Crypto is in the menu because the opponent's claim lives there, allowlist or not.
+    selectFilter('Any space', 'Crypto');
+    await waitFor(() => expect(screen.getByText('A claim both participants chose')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole('button', { name: /Any topic/ }));
+
+    // Its rows are dropped as disallowed, so its topics are not the menu's to offer.
+    expect(screen.queryByRole('button', { name: /Server only/ })).toBeNull();
+  });
+
   it('keeps every space on offer after narrowing to one', async () => {
     render(<DebateRematchPageClient sessionId="rematch-1" />);
     showAllClaims();

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -657,14 +657,23 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   // The server orders by count; kept in name order to match the other tabs and to leave the
   // count ordering, with the counts themselves, to GEO-2654.
   const facetTopics = React.useMemo(() => {
-    if (tab !== 'all')
-      return availableTopics(
-        topicFacetClaims.map(claim => claim.claim.claim_entity_id),
-        topicsByClaimId
-      );
-    return [...(browsedFacets?.topic_facets ?? [])]
-      .map(facet => ({ id: facet.id, name: facet.name }))
-      .sort((a, b) => (a.name ?? '').localeCompare(b.name ?? ''));
+    const fromRows = availableTopics(
+      topicFacetClaims.map(claim => claim.claim.claim_entity_id),
+      topicsByClaimId
+    );
+    if (tab !== 'all') return fromRows;
+
+    // Both, because neither is the whole answer. The facet covers claims no page has reached,
+    // which the rows cannot; the rows cover this session's saved, opponent and curated claims,
+    // pinned in front of the browsed ones and unknown to geo-chat, which the facet cannot. A
+    // topic carried only by one of those was on screen with no way to filter to it.
+    //
+    // Adding rows can't reintroduce an empty option: every topic here comes from a claim the
+    // other filters already allow, so picking it leaves at least that one behind.
+    const merged = new Map<string, MatchmakingTopic>();
+    for (const facet of browsedFacets?.topic_facets ?? []) merged.set(facet.id, { id: facet.id, name: facet.name });
+    for (const topic of fromRows) if (!merged.has(topic.id)) merged.set(topic.id, topic);
+    return [...merged.values()].sort((a, b) => (a.name ?? '').localeCompare(b.name ?? ''));
   }, [browsedFacets?.topic_facets, tab, topicFacetClaims, topicsByClaimId]);
 
   // Search and space reach the browsed query; on the other tabs, and for the topic everywhere
@@ -693,7 +702,10 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   const hasFilters = Boolean(debouncedSearch || spaceId || topicId);
 
   const sentinelRef = useInfiniteScrollSentinel({
-    hasNextPage: Boolean(browsedClaimsQuery.hasNextPage),
+    // Masked for the same reason the pages are: the retained `hasNextPage` outlives the scope it
+    // described, and `fetchNextPage` is a manual call that ignores `enabled` — so a sentinel left
+    // in view would page the unscoped corpus the moment it was scrolled to.
+    hasNextPage: !hasNoEligibleSpaces && Boolean(browsedClaimsQuery.hasNextPage),
     isFetchingNextPage: browsedClaimsQuery.isFetchingNextPage,
     fetchNextPage: browsedClaimsQuery.fetchNextPage,
   });
@@ -978,7 +990,7 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
             tab's sections come from the page whole, and the opponent's tab is the whole of what
             the graph knows about them, in one query. Not while the allowlist is pending either —
             the picker is showing a loading state then. */}
-        {tab === 'all' && browsedClaimsQuery.hasNextPage && !allowlistPending ? (
+        {tab === 'all' && !hasNoEligibleSpaces && browsedClaimsQuery.hasNextPage && !allowlistPending ? (
           <div ref={sentinelRef} data-testid="claims-scroll-sentinel" className="h-px" />
         ) : null}
       </main>

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -41,13 +41,12 @@ import {
   useRejectDebateRematchRequest,
 } from '~/core/debates/hooks';
 import { SpaceTopicFilters } from '~/core/debates/matchmaking/claims-tab';
-import { useMatchmakingClaims } from '~/core/debates/matchmaking/hooks';
 import { HubCardList } from '~/core/debates/matchmaking/hub-motion';
 import { HubPillButton } from '~/core/debates/matchmaking/hub-pill-button';
 import { HubQueryState, HubSkeleton } from '~/core/debates/matchmaking/hub-states';
 import { MatchmakingClaimCard } from '~/core/debates/matchmaking/matchmaking-claim-card';
 import { availableTopics, keepSelectableTopic } from '~/core/debates/matchmaking/topic-facets';
-import { useScopeHeldOver } from '~/core/debates/matchmaking/use-scope-holdover';
+import { useScopedMatchmakingClaims } from '~/core/debates/matchmaking/use-scoped-claims';
 import { useStableListOrder } from '~/core/debates/matchmaking/use-stable-list-order';
 import { participantSidesOn, useParticipantPositions } from '~/core/debates/participant-positions';
 import { useRecommendedClaimSections } from '~/core/debates/recommended-claims';
@@ -236,18 +235,12 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
     [allowlistTypePublishable, publishableSpaceIds, spaceAllowlist]
   );
 
-  // A known-empty scope is not the same as no scope. geo-chat reads "no ids" as "no filter", so
-  // omitting it would fetch the unfiltered corpus, and while the rows are all dropped below the
-  // facets are not — every topic on the menu would lead to an empty list.
-  const hasNoEligibleSpaces = eligibleSpaceIds !== null && eligibleSpaceIds.length === 0;
-
-  // The same problem reached the other way. A space can be in the menu without being in the
-  // allowlist — the graph-backed tabs aren't narrowed by it, so their rows put their spaces there
-  // — but `browsedRows` still drops every *browsed* row from a disallowed space. Selecting one
-  // therefore leaves the server answering with rows that cannot be shown, and a facet describing
-  // them, while only the pinned rows survive. Nothing it returns is usable, so it isn't asked.
-  const browsedCorpusUnusable =
-    hasNoEligibleSpaces || (spaceId !== null && !isClaimSpaceAllowed(spaceId, spaceAllowlist));
+  // The empty-scope case belongs to the shared hook below. This is the same problem reached the
+  // other way: a space can be in the menu without being in the allowlist — the graph-backed tabs
+  // aren't narrowed by it, so their rows put their spaces there — but `browsedRows` still drops
+  // every *browsed* row from a disallowed space. Selecting one leaves the server answering with
+  // rows that cannot be shown, and a facet describing them, while only the pinned rows survive.
+  const selectedSpaceShowsNothing = spaceId !== null && !isClaimSpaceAllowed(spaceId, spaceAllowlist);
 
   // Every lookup the scope is built from. Until they have all landed the scope is `null`, which
   // geo-chat reads as "no filter" — so asking now buys an answer about the whole corpus, whose
@@ -258,9 +251,15 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   // asking about a *missing* id has to check for it. This is such a caller: an id added to the
   // allowlist is absent from the held map, and an absent type reads as publishable — so the space
   // this gate exists to keep out is exactly the one that slips through the window.
-  const scopePending = allowlistPending || publishablePending || allowlistSpacesPending || allowlistSpacesHeldOver;
+  const scope = React.useMemo(
+    () => ({
+      spaceIds: eligibleSpaceIds,
+      pending: allowlistPending || publishablePending || allowlistSpacesPending || allowlistSpacesHeldOver,
+    }),
+    [allowlistPending, allowlistSpacesHeldOver, allowlistSpacesPending, eligibleSpaceIds, publishablePending]
+  );
 
-  const matchmakingQuery = React.useMemo<MatchmakingClaimsQuery>(
+  const matchmakingQuery = React.useMemo<Omit<MatchmakingClaimsQuery, 'spaceIds'>>(
     // `topicId` is sent whichever tab is showing. It only filters *these* rows, which back the
     // All tab, and the server's topic facet is narrowed by spaces rather than by topics — so a
     // topic selection can never collapse the menu it came from. The other two tabs are built
@@ -268,7 +267,6 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
     () => ({
       search: debouncedSearch || null,
       spaceId,
-      spaceIds: eligibleSpaceIds,
       topicId,
       // What `excludedClaimIds` removes below, removed by the endpoint instead — so the facets
       // describe the same corpus the rows do. Without it a topic whose every claim in the space
@@ -276,21 +274,12 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
       rematchSessionId: sessionId,
       filter: 'all',
     }),
-    [debouncedSearch, eligibleSpaceIds, sessionId, spaceId, topicId]
+    [debouncedSearch, sessionId, spaceId, topicId]
   );
-  const browsedClaimsQuery = useMatchmakingClaims(matchmakingQuery, !browsedCorpusUnusable && !scopePending);
-  // Masked rather than left to `enabled`: the hook keeps previous data across a key change, so a
-  // scope narrowing to nothing still hands back the last scope's pages — rows this drops anyway,
-  // but facets it would not.
-  // A settled scope can still change under the viewer — the allowlist refetches, a space is joined
-  // — and none of the flags in `scopePending` move when it does.
-  const scopeHeldOver = useScopeHeldOver(eligibleSpaceIds?.join(',') ?? null, browsedClaimsQuery.isPlaceholderData);
-
-  const browsedPages = React.useMemo(
-    () => (browsedCorpusUnusable || scopePending || scopeHeldOver ? [] : (browsedClaimsQuery.data?.pages ?? [])),
-    [browsedClaimsQuery.data, browsedCorpusUnusable, scopeHeldOver, scopePending]
-  );
-  const browsedFacets = browsedPages[0]?.facets;
+  // Every way the pages can outlive the scope that fetched them is handled in there, once, for
+  // both pickers — see `useScopedMatchmakingClaims`.
+  const browsedClaimsQuery = useScopedMatchmakingClaims(matchmakingQuery, scope, selectedSpaceShowsNothing);
+  const { pages: browsedPages, facets: browsedFacets } = browsedClaimsQuery;
 
   // What geo-chat knows about this session's claims — readiness, the shared-preference and
   // rejection flags, and which ids the session excludes. One batch for the opponent's claims, one
@@ -768,7 +757,7 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
     // Masked for the same reason the pages are: the retained `hasNextPage` outlives the scope it
     // described, and `fetchNextPage` is a manual call that ignores `enabled` — so a sentinel left
     // in view would page the unscoped corpus the moment it was scrolled to.
-    hasNextPage: !browsedCorpusUnusable && Boolean(browsedClaimsQuery.hasNextPage),
+    hasNextPage: browsedClaimsQuery.hasNextPage,
     isFetchingNextPage: browsedClaimsQuery.isFetchingNextPage,
     fetchNextPage: browsedClaimsQuery.fetchNextPage,
   });
@@ -784,19 +773,18 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
           opponentEntitiesQuery.isLoading ||
           opponentClaimsQuery.isLoading ||
           (landedTabRef.current === null && claims.length === 0 && recommendedLoading)
-        : scopePending || browsedClaimsQuery.isLoading);
+        : scope.pending || browsedClaimsQuery.isLoading);
 
   // A topic the menu no longer offers is unpickable as well as empty — the chip filtering the
   // list would not be in the menu to clear. Unlike the Claims tab, the topics here arrive with
   // the claim rows rather than in a lookup behind them, so once the tab has settled an empty
   // menu is a real answer.
   React.useEffect(() => {
-    // Placeholder facets belong to the previous filter, so they are "not known yet" here for the
-    // same reason an absent one is — see the Claims tab.
-    const browsedFacetsSettled = browsedFacets !== undefined && !tabIsLoading && !browsedClaimsQuery.isPlaceholderData;
-    const resolved = tab === 'all' ? browsedFacetsSettled : !tabIsLoading;
+    // The All tab's menu is only as settled as the facets behind it; the other two have no facet
+    // to wait on, so their own loading state is the whole answer.
+    const resolved = tab === 'all' ? browsedClaimsQuery.facetsSettled && !tabIsLoading : !tabIsLoading;
     setTopicId(current => keepSelectableTopic(current, facetTopics, resolved));
-  }, [browsedClaimsQuery.isPlaceholderData, browsedFacets, facetTopics, tab, tabIsLoading]);
+  }, [browsedClaimsQuery.facetsSettled, facetTopics, tab, tabIsLoading]);
 
   const tabError =
     sessionQuery.error ??
@@ -1063,7 +1051,7 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
             tab's sections come from the page whole, and the opponent's tab is the whole of what
             the graph knows about them, in one query. Not while the allowlist is pending either —
             the picker is showing a loading state then. */}
-        {tab === 'all' && !browsedCorpusUnusable && browsedClaimsQuery.hasNextPage && !allowlistPending ? (
+        {tab === 'all' && browsedClaimsQuery.hasNextPage ? (
           <div ref={sentinelRef} data-testid="claims-scroll-sentinel" className="h-px" />
         ) : null}
         {/* The same skeleton the list shows on first load, so the next batch reads as more of

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -21,7 +21,7 @@ import {
   type MatchmakingTopic,
 } from '~/core/debates/api';
 import { type ClaimPickerEntity, useClaimEntitiesByIds } from '~/core/debates/claim-picker-page';
-import { isClaimSpaceAllowed } from '~/core/debates/claim-space-allowlist';
+import { eligibleClaimSpaceIds, isClaimSpaceAllowed } from '~/core/debates/claim-space-allowlist';
 import { markEnteringDebate } from '~/core/debates/debate-entry-intent';
 import { useDebateGatewaySpaceScopes } from '~/core/debates/debate-gateway';
 import { debatePublishableSpacePredicate } from '~/core/debates/debate-publish-target';
@@ -194,13 +194,32 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   // The All tab is the hub's Claims tab: geo-chat's own index of debatable claims, paged and
   // searched server-side, each row carrying the viewer's side and readiness. It takes a single
   // `space_id`, so the viewer's allowlist is a page-local cut, the same as the hub's.
+  // The acceptor's editor spaces are the authoritative answer, and the same set the publish sweep
+  // works from. The space-type test below it is kept rather than replaced: the two fail
+  // differently, and when this list is unknown — no acceptor configured, a failed lookup — the
+  // type test still rules out the case that actually bit us, claims living in a personal space.
+  const { publishableSpaceIds } = useDebatePublishableSpaces();
+
+  // Same scoping as the hub's Claims tab: the facets have to describe the spaces this pairing
+  // can actually be shown claims from, or the topic menu offers topics from spaces `browsedRows`
+  // removes. `canPublishDebateIn` is defined below and closes over its own lookups, so this reads
+  // the two gates directly rather than through it.
+  const eligibleSpaceIds = React.useMemo(
+    () =>
+      eligibleClaimSpaceIds(
+        spaceAllowlist,
+        id => isClaimSpaceAllowed(id, spaceAllowlist) && isSpaceDebatePublishable(id, publishableSpaceIds)
+      ),
+    [publishableSpaceIds, spaceAllowlist]
+  );
+
   const matchmakingQuery = React.useMemo<MatchmakingClaimsQuery>(
     // `topicId` is sent whichever tab is showing. It only filters *these* rows, which back the
     // All tab, and the server's topic facet is narrowed by spaces rather than by topics — so a
     // topic selection can never collapse the menu it came from. The other two tabs are built
     // from graph entities geo-chat has never seen, so their topic filter stays client-side.
-    () => ({ search: debouncedSearch || null, spaceId, topicId, filter: 'all' }),
-    [debouncedSearch, spaceId, topicId]
+    () => ({ search: debouncedSearch || null, spaceId, spaceIds: eligibleSpaceIds, topicId, filter: 'all' }),
+    [debouncedSearch, eligibleSpaceIds, spaceId, topicId]
   );
   const browsedClaimsQuery = useMatchmakingClaims(matchmakingQuery, true);
   const browsedPages = React.useMemo(() => browsedClaimsQuery.data?.pages ?? [], [browsedClaimsQuery.data]);
@@ -292,11 +311,6 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
     return [...ids];
   }, [browsedPages, opponentEntitiesQuery.entities, recommendedEntities, savedClaimsQuery.data]);
   const { spacesById: candidateSpaces } = useSpacesByIds(candidateSpaceIds);
-  // The acceptor's editor spaces are the authoritative answer, and the same set the publish sweep
-  // works from. The space-type test below it is kept rather than replaced: the two fail
-  // differently, and when this list is unknown — no acceptor configured, a failed lookup — the
-  // type test still rules out the case that actually bit us, claims living in a personal space.
-  const { publishableSpaceIds } = useDebatePublishableSpaces();
   const spaceTypePublishable = React.useMemo(() => debatePublishableSpacePredicate(candidateSpaces), [candidateSpaces]);
   const canPublishDebateIn = React.useCallback(
     (spaceId: string | null | undefined) =>
@@ -562,14 +576,16 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   const facetSpaceIds = React.useMemo(() => {
     const seen = seenFacetsRef.current.spaceIds;
     for (const claim of [...opponentClaims, ...curatedClaims, ...browsedClaims]) seen.add(claim.claim.space_id);
-    // Publishability as well as the allowlist. `browsedRows` drops every claim in a space this
-    // pairing cannot publish a debate into, so offering that space listed a filter that could
-    // only ever empty the list — and, once the topic menu came from the server, offered all of
-    // that space's topics along with it while nothing rendered behind any of them.
-    for (const id of browsedFacets?.space_ids ?? []) {
-      if (isClaimSpaceAllowed(id, spaceAllowlist) && canPublishDebateIn(id)) seen.add(id);
-    }
-    return [...seen];
+    for (const id of browsedFacets?.space_ids ?? []) seen.add(id);
+    // Filtered on the way out, not on the way in. Both gates answer `true` while their lookup is
+    // still resolving — deliberately, so a slow answer doesn't empty the panel — and this set only
+    // ever grows, so gating the writes would admit every space on the first render and never take
+    // one back. `browsedRows` drops every claim in a space this pairing cannot publish into, so an
+    // ineligible space here is a filter that can only empty the list, and its topics come with it.
+    //
+    // Safe to apply to an accumulated set: neither gate narrows with the viewer's selection, which
+    // is the reason the accumulation exists.
+    return [...seen].filter(id => isClaimSpaceAllowed(id, spaceAllowlist) && canPublishDebateIn(id));
   }, [browsedClaims, browsedFacets?.space_ids, canPublishDebateIn, curatedClaims, opponentClaims, spaceAllowlist]);
 
   // The claims the topic menu describes on the graph-backed tabs: everything the other filters

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -21,7 +21,7 @@ import {
   type MatchmakingTopic,
 } from '~/core/debates/api';
 import { type ClaimPickerEntity, useClaimEntitiesByIds } from '~/core/debates/claim-picker-page';
-import { eligibleClaimSpaceIds, isClaimSpaceAllowed } from '~/core/debates/claim-space-allowlist';
+import { eligibleClaimSpaceIds, isClaimSpaceAllowed, keepSelectableSpace } from '~/core/debates/claim-space-allowlist';
 import { markEnteringDebate } from '~/core/debates/debate-entry-intent';
 import { useDebateGatewaySpaceScopes } from '~/core/debates/debate-gateway';
 import { debatePublishableSpacePredicate } from '~/core/debates/debate-publish-target';
@@ -245,7 +245,13 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
     [debouncedSearch, eligibleSpaceIds, spaceId, topicId]
   );
   const browsedClaimsQuery = useMatchmakingClaims(matchmakingQuery, !hasNoEligibleSpaces);
-  const browsedPages = React.useMemo(() => browsedClaimsQuery.data?.pages ?? [], [browsedClaimsQuery.data]);
+  // Masked rather than left to `enabled`: the hook keeps previous data across a key change, so a
+  // scope narrowing to nothing still hands back the last scope's pages — rows this drops anyway,
+  // but facets it would not.
+  const browsedPages = React.useMemo(
+    () => (hasNoEligibleSpaces ? [] : (browsedClaimsQuery.data?.pages ?? [])),
+    [browsedClaimsQuery.data, hasNoEligibleSpaces]
+  );
   const browsedFacets = browsedPages[0]?.facets;
 
   // What geo-chat knows about this session's claims — readiness, the shared-preference and
@@ -594,22 +600,41 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   // the topic filter runs here rather than in the query, so narrowing it never costs the viewer
   // their way back. Remembering them instead kept offering topics from spaces the viewer had
   // filtered away, and picking one of those could only ever produce an empty list (GEO-2653).
-  const seenFacetsRef = React.useRef<{ spaceIds: Set<string> }>({ spaceIds: new Set() });
+  // Kept apart because the two are gated differently on the way out. A space reaching the menu
+  // through a *row* has already passed whatever its own tab requires — and the opponent and
+  // curated tabs are deliberately not narrowed by the viewer's allowlist, so re-applying it here
+  // would drop the space of a claim those tabs are still showing.
+  const seenFacetsRef = React.useRef<{ rowSpaceIds: Set<string>; facetSpaceIds: Set<string> }>({
+    rowSpaceIds: new Set(),
+    facetSpaceIds: new Set(),
+  });
 
   const facetSpaceIds = React.useMemo(() => {
-    const seen = seenFacetsRef.current.spaceIds;
-    for (const claim of [...opponentClaims, ...curatedClaims, ...browsedClaims]) seen.add(claim.claim.space_id);
-    for (const id of browsedFacets?.space_ids ?? []) seen.add(id);
+    const { rowSpaceIds, facetSpaceIds: fromFacet } = seenFacetsRef.current;
+    for (const claim of [...opponentClaims, ...curatedClaims, ...browsedClaims]) rowSpaceIds.add(claim.claim.space_id);
+    for (const id of browsedFacets?.space_ids ?? []) fromFacet.add(id);
+
     // Filtered on the way out, not on the way in. Both gates answer `true` while their lookup is
-    // still resolving — deliberately, so a slow answer doesn't empty the panel — and this set only
-    // ever grows, so gating the writes would admit every space on the first render and never take
-    // one back. `browsedRows` drops every claim in a space this pairing cannot publish into, so an
-    // ineligible space here is a filter that can only empty the list, and its topics come with it.
+    // still resolving — deliberately, so a slow answer doesn't empty the panel — and these sets
+    // only ever grow, so gating the writes would admit every space on the first render and never
+    // take one back.
     //
-    // Safe to apply to an accumulated set: neither gate narrows with the viewer's selection, which
-    // is the reason the accumulation exists.
-    return [...seen].filter(id => isClaimSpaceAllowed(id, spaceAllowlist) && canPublishDebateIn(id));
+    // Safe against an accumulated set: neither gate narrows with the viewer's selection, which is
+    // the reason the accumulation exists.
+    const menu = new Set<string>();
+    // A row's space is already through its own tab's gates; publishability is re-checked because
+    // it can resolve after the row landed, and the allowlist is not because the graph-backed tabs
+    // are not narrowed by it.
+    for (const id of rowSpaceIds) if (canPublishDebateIn(id)) menu.add(id);
+    for (const id of fromFacet) if (isClaimSpaceAllowed(id, spaceAllowlist) && canPublishDebateIn(id)) menu.add(id);
+    return [...menu];
   }, [browsedClaims, browsedFacets?.space_ids, canPublishDebateIn, curatedClaims, opponentClaims, spaceAllowlist]);
+
+  // A space picked while the gates were still passing everything has to be let go once they
+  // reject it, or it keeps going out as `space_id` on every request while its rows are dropped.
+  React.useEffect(() => {
+    setSpaceId(current => keepSelectableSpace(current, facetSpaceIds, !allowlistPending));
+  }, [allowlistPending, facetSpaceIds]);
 
   // The claims the topic menu describes on the graph-backed tabs: everything the other filters
   // allow, topic aside. Narrowing by the current topic too would collapse the menu to the one

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -61,6 +61,7 @@ import { useSpacesByIds } from '~/core/hooks/use-spaces-by-ids';
 import { uuidToHex } from '~/core/id/normalize';
 import { responsePositionLabel } from '~/core/responses/entity-response';
 import { getTopRankedSpaceId } from '~/core/utils/space/space-ranking';
+import { validateEntityId } from '~/core/utils/utils';
 
 import { getChecked } from '~/design-system/checkbox';
 import { ChevronDownSmall } from '~/design-system/icons/chevron-down-small';
@@ -330,9 +331,31 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
 
   // Topics live on the KG claim entity, so resolve them here to label each card and drive the
   // "Any topic" filter. A claim can carry several topics. The browsed rows bring their own.
+  // geo-chat hardcodes `topics: []` on every row it returns, so the All tab's claims arrive
+  // without any. The other two tabs are built from graph entities and get theirs for free; this
+  // is the same lookup for the browsed ones, and without it the topic menu has nothing to
+  // describe them with — it listed the other tabs' topics instead, which is what GEO-2653 was.
+  //
+  // Kept separate from `opponentEntitiesQuery` rather than folded into it: those entities are
+  // what the opponent tab's rows are built from, so browsed ids joining that query would put
+  // browsed claims on the opponent's tab.
+  const browsedClaimEntityIds = React.useMemo(
+    () => [
+      ...new Set(
+        browsedPages.flatMap(page => page.claims.map(entry => entry.claim.claim_entity_id)).filter(validateEntityId)
+      ),
+    ],
+    [browsedPages]
+  );
+  const browsedEntitiesQuery = useClaimEntitiesByIds(browsedClaimEntityIds);
+
   const topicsByClaimId = React.useMemo(() => {
     const map = new Map<string, MatchmakingTopic[]>();
-    for (const entity of [...opponentEntitiesQuery.entities, ...recommendedEntities]) {
+    for (const entity of [
+      ...opponentEntitiesQuery.entities,
+      ...recommendedEntities,
+      ...browsedEntitiesQuery.entities,
+    ]) {
       const topics = entity.relations
         .filter(relation => relation.type.id === TOPICS_PROPERTY_ID && relation.isDeleted !== true)
         .map(relation => ({ id: relation.toEntity.id, name: relation.toEntity.name ?? null }));
@@ -346,7 +369,7 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
       }
     }
     return map;
-  }, [browsedPages, opponentEntitiesQuery.entities, recommendedEntities]);
+  }, [browsedEntitiesQuery.entities, browsedPages, opponentEntitiesQuery.entities, recommendedEntities]);
 
   // The opponent's tab: every claim they hold a side on, newest first. Held until the session's
   // exclusions are in, so nothing lists and then vanishes. Not narrowed by the space allowlist —
@@ -635,8 +658,8 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   // the claim rows rather than in a lookup behind them, so once the tab has settled an empty
   // menu is a real answer.
   React.useEffect(() => {
-    setTopicId(current => keepSelectableTopic(current, facetTopics, !tabIsLoading));
-  }, [facetTopics, tabIsLoading]);
+    setTopicId(current => keepSelectableTopic(current, facetTopics, !tabIsLoading && !browsedEntitiesQuery.isLoading));
+  }, [browsedEntitiesQuery.isLoading, facetTopics, tabIsLoading]);
 
   const tabError =
     sessionQuery.error ??

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -47,6 +47,7 @@ import { HubPillButton } from '~/core/debates/matchmaking/hub-pill-button';
 import { HubQueryState, HubSkeleton } from '~/core/debates/matchmaking/hub-states';
 import { MatchmakingClaimCard } from '~/core/debates/matchmaking/matchmaking-claim-card';
 import { availableTopics, keepSelectableTopic } from '~/core/debates/matchmaking/topic-facets';
+import { useScopeHeldOver } from '~/core/debates/matchmaking/use-scope-holdover';
 import { useStableListOrder } from '~/core/debates/matchmaking/use-stable-list-order';
 import { participantSidesOn, useParticipantPositions } from '~/core/debates/participant-positions';
 import { useRecommendedClaimSections } from '~/core/debates/recommended-claims';
@@ -214,7 +215,11 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   // on its own result. The allowlist depends on nothing here, so asking for those types directly
   // breaks the loop.
   const allowlistSpaceIds = React.useMemo(() => (spaceAllowlist ? [...spaceAllowlist] : []), [spaceAllowlist]);
-  const { spacesById: allowlistSpaces, isLoading: allowlistSpacesPending } = useSpacesByIds(allowlistSpaceIds);
+  const {
+    spacesById: allowlistSpaces,
+    isLoading: allowlistSpacesPending,
+    isPlaceholderData: allowlistSpacesHeldOver,
+  } = useSpacesByIds(allowlistSpaceIds);
   const allowlistTypePublishable = React.useMemo(
     () => debatePublishableSpacePredicate(allowlistSpaces),
     [allowlistSpaces]
@@ -247,7 +252,13 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   // Every lookup the scope is built from. Until they have all landed the scope is `null`, which
   // geo-chat reads as "no filter" — so asking now buys an answer about the whole corpus, whose
   // rows are dropped below and whose topic facet is not. See the Claims tab, same shape.
-  const scopePending = allowlistPending || publishablePending || allowlistSpacesPending;
+  //
+  // The held-over map counts as pending. `useSpacesByIds` keeps the previous id set's answers
+  // rather than blanking every space image on screen, and says in its own contract that a caller
+  // asking about a *missing* id has to check for it. This is such a caller: an id added to the
+  // allowlist is absent from the held map, and an absent type reads as publishable — so the space
+  // this gate exists to keep out is exactly the one that slips through the window.
+  const scopePending = allowlistPending || publishablePending || allowlistSpacesPending || allowlistSpacesHeldOver;
 
   const matchmakingQuery = React.useMemo<MatchmakingClaimsQuery>(
     // `topicId` is sent whichever tab is showing. It only filters *these* rows, which back the
@@ -271,9 +282,13 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   // Masked rather than left to `enabled`: the hook keeps previous data across a key change, so a
   // scope narrowing to nothing still hands back the last scope's pages — rows this drops anyway,
   // but facets it would not.
+  // A settled scope can still change under the viewer — the allowlist refetches, a space is joined
+  // — and none of the flags in `scopePending` move when it does.
+  const scopeHeldOver = useScopeHeldOver(eligibleSpaceIds?.join(',') ?? null, browsedClaimsQuery.isPlaceholderData);
+
   const browsedPages = React.useMemo(
-    () => (browsedCorpusUnusable || scopePending ? [] : (browsedClaimsQuery.data?.pages ?? [])),
-    [browsedClaimsQuery.data, browsedCorpusUnusable, scopePending]
+    () => (browsedCorpusUnusable || scopePending || scopeHeldOver ? [] : (browsedClaimsQuery.data?.pages ?? [])),
+    [browsedClaimsQuery.data, browsedCorpusUnusable, scopeHeldOver, scopePending]
   );
   const browsedFacets = browsedPages[0]?.facets;
 
@@ -683,10 +698,19 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
     () =>
       claims.filter(claim => {
         if (spaceId && claim.claim.space_id !== spaceId) return false;
-        if (debouncedSearch && !claim.claim.claim.toLowerCase().includes(debouncedSearch.toLowerCase())) return false;
+        // Cut on the same terms `visibleClaims` is, or the menu stops describing the list. On the
+        // All tab the search runs server-side over the browsed rows, and the pinned ones are
+        // merged in whether they match it or not — so cutting them here left a row on screen with
+        // its topics missing from the menu, which is the merge below undone.
+        if (
+          tab !== 'all' &&
+          debouncedSearch &&
+          !claim.claim.claim.toLowerCase().includes(debouncedSearch.toLowerCase())
+        )
+          return false;
         return true;
       }),
-    [claims, debouncedSearch, spaceId]
+    [claims, debouncedSearch, spaceId, tab]
   );
 
   // The All tab takes its menu from the server, which knows the whole filtered corpus rather

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -213,7 +213,12 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   // — built from the claims this very query returns. Going through it would make the query depend
   // on its own result. The allowlist depends on nothing here, so asking for those types directly
   // breaks the loop.
-  const allowlistSpaceIds = React.useMemo(() => (spaceAllowlist ? [...spaceAllowlist] : []), [spaceAllowlist]);
+  // Same fallback as the Claims tab: an allowlist that settled without an answer stops narrowing
+  // by *it*, not by everything. The publishable set answers a different question and still bounds
+  // which spaces can be shown, so the scope — and the type lookup that trims it further — run over
+  // whichever of the two is known.
+  const candidateScopeIds = spaceAllowlist ?? publishableSpaceIds;
+  const allowlistSpaceIds = React.useMemo(() => (candidateScopeIds ? [...candidateScopeIds] : []), [candidateScopeIds]);
   const {
     spacesById: allowlistSpaces,
     isLoading: allowlistSpacesPending,
@@ -226,13 +231,13 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   const eligibleSpaceIds = React.useMemo(
     () =>
       eligibleClaimSpaceIds(
-        spaceAllowlist,
+        candidateScopeIds,
         id =>
           isClaimSpaceAllowed(id, spaceAllowlist) &&
           isSpaceDebatePublishable(id, publishableSpaceIds) &&
           allowlistTypePublishable(id)
       ),
-    [allowlistTypePublishable, publishableSpaceIds, spaceAllowlist]
+    [allowlistTypePublishable, candidateScopeIds, publishableSpaceIds, spaceAllowlist]
   );
 
   // The empty-scope case belongs to the shared hook below. This is the same problem reached the

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -200,18 +200,41 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   // type test still rules out the case that actually bit us, claims living in a personal space.
   const { publishableSpaceIds } = useDebatePublishableSpaces();
 
-  // Same scoping as the hub's Claims tab: the facets have to describe the spaces this pairing
-  // can actually be shown claims from, or the topic menu offers topics from spaces `browsedRows`
-  // removes. `canPublishDebateIn` is defined below and closes over its own lookups, so this reads
-  // the two gates directly rather than through it.
+  // Same scoping as the hub's Claims tab: the facets have to describe the spaces this pairing can
+  // actually be shown claims from, or the topic menu offers topics from spaces `browsedRows`
+  // removes.
+  //
+  // It has to apply all three gates `canPublishDebateIn` does, including the space-type one that
+  // rules out personal spaces — the allowlist holds the viewer's own — or a personal space slips
+  // into the scope whenever the editor-space lookup is unresolved, since that gate passes
+  // everything until it lands.
+  //
+  // Typed off its own lookup rather than through `canPublishDebateIn`, which reads `candidateSpaces`
+  // — built from the claims this very query returns. Going through it would make the query depend
+  // on its own result. The allowlist depends on nothing here, so asking for those types directly
+  // breaks the loop.
+  const allowlistSpaceIds = React.useMemo(() => (spaceAllowlist ? [...spaceAllowlist] : []), [spaceAllowlist]);
+  const { spacesById: allowlistSpaces } = useSpacesByIds(allowlistSpaceIds);
+  const allowlistTypePublishable = React.useMemo(
+    () => debatePublishableSpacePredicate(allowlistSpaces),
+    [allowlistSpaces]
+  );
   const eligibleSpaceIds = React.useMemo(
     () =>
       eligibleClaimSpaceIds(
         spaceAllowlist,
-        id => isClaimSpaceAllowed(id, spaceAllowlist) && isSpaceDebatePublishable(id, publishableSpaceIds)
+        id =>
+          isClaimSpaceAllowed(id, spaceAllowlist) &&
+          isSpaceDebatePublishable(id, publishableSpaceIds) &&
+          allowlistTypePublishable(id)
       ),
-    [publishableSpaceIds, spaceAllowlist]
+    [allowlistTypePublishable, publishableSpaceIds, spaceAllowlist]
   );
+
+  // A known-empty scope is not the same as no scope. geo-chat reads "no ids" as "no filter", so
+  // omitting it would fetch the unfiltered corpus, and while the rows are all dropped below the
+  // facets are not — every topic on the menu would lead to an empty list.
+  const hasNoEligibleSpaces = eligibleSpaceIds !== null && eligibleSpaceIds.length === 0;
 
   const matchmakingQuery = React.useMemo<MatchmakingClaimsQuery>(
     // `topicId` is sent whichever tab is showing. It only filters *these* rows, which back the
@@ -221,7 +244,7 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
     () => ({ search: debouncedSearch || null, spaceId, spaceIds: eligibleSpaceIds, topicId, filter: 'all' }),
     [debouncedSearch, eligibleSpaceIds, spaceId, topicId]
   );
-  const browsedClaimsQuery = useMatchmakingClaims(matchmakingQuery, true);
+  const browsedClaimsQuery = useMatchmakingClaims(matchmakingQuery, !hasNoEligibleSpaces);
   const browsedPages = React.useMemo(() => browsedClaimsQuery.data?.pages ?? [], [browsedClaimsQuery.data]);
   const browsedFacets = browsedPages[0]?.facets;
 

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -249,8 +249,18 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
     // All tab, and the server's topic facet is narrowed by spaces rather than by topics — so a
     // topic selection can never collapse the menu it came from. The other two tabs are built
     // from graph entities geo-chat has never seen, so their topic filter stays client-side.
-    () => ({ search: debouncedSearch || null, spaceId, spaceIds: eligibleSpaceIds, topicId, filter: 'all' }),
-    [debouncedSearch, eligibleSpaceIds, spaceId, topicId]
+    () => ({
+      search: debouncedSearch || null,
+      spaceId,
+      spaceIds: eligibleSpaceIds,
+      topicId,
+      // What `excludedClaimIds` removes below, removed by the endpoint instead — so the facets
+      // describe the same corpus the rows do. Without it a topic whose every claim in the space
+      // was one this session had dropped stayed on the menu over an empty list.
+      rematchSessionId: sessionId,
+      filter: 'all',
+    }),
+    [debouncedSearch, eligibleSpaceIds, sessionId, spaceId, topicId]
   );
   const browsedClaimsQuery = useMatchmakingClaims(matchmakingQuery, !browsedCorpusUnusable);
   // Masked rather than left to `enabled`: the hook keeps previous data across a key change, so a

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -759,9 +759,12 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   // the claim rows rather than in a lookup behind them, so once the tab has settled an empty
   // menu is a real answer.
   React.useEffect(() => {
-    const resolved = tab === 'all' ? browsedFacets !== undefined && !tabIsLoading : !tabIsLoading;
+    // Placeholder facets belong to the previous filter, so they are "not known yet" here for the
+    // same reason an absent one is — see the Claims tab.
+    const browsedFacetsSettled = browsedFacets !== undefined && !tabIsLoading && !browsedClaimsQuery.isPlaceholderData;
+    const resolved = tab === 'all' ? browsedFacetsSettled : !tabIsLoading;
     setTopicId(current => keepSelectableTopic(current, facetTopics, resolved));
-  }, [browsedFacets, facetTopics, tab, tabIsLoading]);
+  }, [browsedClaimsQuery.isPlaceholderData, browsedFacets, facetTopics, tab, tabIsLoading]);
 
   const tabError =
     sessionQuery.error ??

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -562,9 +562,15 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   const facetSpaceIds = React.useMemo(() => {
     const seen = seenFacetsRef.current.spaceIds;
     for (const claim of [...opponentClaims, ...curatedClaims, ...browsedClaims]) seen.add(claim.claim.space_id);
-    for (const id of browsedFacets?.space_ids ?? []) if (isClaimSpaceAllowed(id, spaceAllowlist)) seen.add(id);
+    // Publishability as well as the allowlist. `browsedRows` drops every claim in a space this
+    // pairing cannot publish a debate into, so offering that space listed a filter that could
+    // only ever empty the list — and, once the topic menu came from the server, offered all of
+    // that space's topics along with it while nothing rendered behind any of them.
+    for (const id of browsedFacets?.space_ids ?? []) {
+      if (isClaimSpaceAllowed(id, spaceAllowlist) && canPublishDebateIn(id)) seen.add(id);
+    }
     return [...seen];
-  }, [browsedClaims, browsedFacets?.space_ids, curatedClaims, opponentClaims, spaceAllowlist]);
+  }, [browsedClaims, browsedFacets?.space_ids, canPublishDebateIn, curatedClaims, opponentClaims, spaceAllowlist]);
 
   // The claims the topic menu describes on the graph-backed tabs: everything the other filters
   // allow, topic aside. Narrowing by the current topic too would collapse the menu to the one

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -198,7 +198,7 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   //
   // Read here rather than beside `canPublishDebateIn` below, because the scope built underneath
   // it has to reach the query, which runs before either.
-  const { publishableSpaceIds } = useDebatePublishableSpaces();
+  const { publishableSpaceIds, isLoading: publishablePending } = useDebatePublishableSpaces();
 
   // Same scoping as the hub's Claims tab: the facets have to describe the spaces this pairing can
   // actually be shown claims from, or the topic menu offers topics from spaces `browsedRows`
@@ -214,7 +214,7 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   // on its own result. The allowlist depends on nothing here, so asking for those types directly
   // breaks the loop.
   const allowlistSpaceIds = React.useMemo(() => (spaceAllowlist ? [...spaceAllowlist] : []), [spaceAllowlist]);
-  const { spacesById: allowlistSpaces } = useSpacesByIds(allowlistSpaceIds);
+  const { spacesById: allowlistSpaces, isLoading: allowlistSpacesPending } = useSpacesByIds(allowlistSpaceIds);
   const allowlistTypePublishable = React.useMemo(
     () => debatePublishableSpacePredicate(allowlistSpaces),
     [allowlistSpaces]
@@ -244,6 +244,11 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   const browsedCorpusUnusable =
     hasNoEligibleSpaces || (spaceId !== null && !isClaimSpaceAllowed(spaceId, spaceAllowlist));
 
+  // Every lookup the scope is built from. Until they have all landed the scope is `null`, which
+  // geo-chat reads as "no filter" — so asking now buys an answer about the whole corpus, whose
+  // rows are dropped below and whose topic facet is not. See the Claims tab, same shape.
+  const scopePending = allowlistPending || publishablePending || allowlistSpacesPending;
+
   const matchmakingQuery = React.useMemo<MatchmakingClaimsQuery>(
     // `topicId` is sent whichever tab is showing. It only filters *these* rows, which back the
     // All tab, and the server's topic facet is narrowed by spaces rather than by topics — so a
@@ -262,13 +267,13 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
     }),
     [debouncedSearch, eligibleSpaceIds, sessionId, spaceId, topicId]
   );
-  const browsedClaimsQuery = useMatchmakingClaims(matchmakingQuery, !browsedCorpusUnusable);
+  const browsedClaimsQuery = useMatchmakingClaims(matchmakingQuery, !browsedCorpusUnusable && !scopePending);
   // Masked rather than left to `enabled`: the hook keeps previous data across a key change, so a
   // scope narrowing to nothing still hands back the last scope's pages — rows this drops anyway,
   // but facets it would not.
   const browsedPages = React.useMemo(
-    () => (browsedCorpusUnusable ? [] : (browsedClaimsQuery.data?.pages ?? [])),
-    [browsedClaimsQuery.data, browsedCorpusUnusable]
+    () => (browsedCorpusUnusable || scopePending ? [] : (browsedClaimsQuery.data?.pages ?? [])),
+    [browsedClaimsQuery.data, browsedCorpusUnusable, scopePending]
   );
   const browsedFacets = browsedPages[0]?.facets;
 
@@ -544,7 +549,10 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   const browsedClaims = useStableListOrder(
     browsedRows,
     row => `${row.claim.space_id}:${row.claim.claim_entity_id}`,
-    `${debouncedSearch}|${spaceId ?? ''}`
+    // Topic belongs in the key for the same reason space does: it goes out as `topic_id`, so the
+    // server ranks a different list under it, and holding the previous order would arrange the
+    // new one by a ranking the viewer has already moved on from.
+    `${debouncedSearch}|${spaceId ?? ''}|${topicId ?? ''}`
   );
 
   // The opponent is whichever participant isn't the local user; with no local user there is none.
@@ -752,7 +760,7 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
           opponentEntitiesQuery.isLoading ||
           opponentClaimsQuery.isLoading ||
           (landedTabRef.current === null && claims.length === 0 && recommendedLoading)
-        : allowlistPending || browsedClaimsQuery.isLoading);
+        : scopePending || browsedClaimsQuery.isLoading);
 
   // A topic the menu no longer offers is unpickable as well as empty — the chip filtering the
   // list would not be in the menu to clear. Unlike the Claims tab, the topics here arrive with

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -191,13 +191,13 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   // allowlist alone: the lists' own lookups run alongside it, so they are ready when it lands.
   const allowlistPending = spaceAllowlist === null && allowlistLoading;
 
-  // The All tab is the hub's Claims tab: geo-chat's own index of debatable claims, paged and
-  // searched server-side, each row carrying the viewer's side and readiness. It takes a single
-  // `space_id`, so the viewer's allowlist is a page-local cut, the same as the hub's.
   // The acceptor's editor spaces are the authoritative answer, and the same set the publish sweep
-  // works from. The space-type test below it is kept rather than replaced: the two fail
+  // works from. The space-type test is kept alongside rather than replaced by it: the two fail
   // differently, and when this list is unknown — no acceptor configured, a failed lookup — the
   // type test still rules out the case that actually bit us, claims living in a personal space.
+  //
+  // Read here rather than beside `canPublishDebateIn` below, because the scope built underneath
+  // it has to reach the query, which runs before either.
   const { publishableSpaceIds } = useDebatePublishableSpaces();
 
   // Same scoping as the hub's Claims tab: the facets have to describe the spaces this pairing can
@@ -610,18 +610,17 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
 
   const claims = tab === 'opponent' ? opponentClaims : tab === 'recommended' ? curatedClaims : browsedClaims;
 
-  // Every space the lists have shown, not only the current tab's. Space runs in the browsed
-  // query, so the loaded corpus is whatever the current filter allows — a menu listing only the
-  // space you picked would have no way back to another.
+  // Every space the lists have shown, not only the current tab's. Space runs in the browsed query,
+  // so the loaded corpus is whatever the current filter allows — a menu listing only the space you
+  // picked would have no way back to another. Topics need no equivalent: their filter is applied
+  // here rather than in the query, so narrowing them never costs the viewer their way back — and
+  // remembering them anyway kept offering topics from spaces the viewer had filtered away, where
+  // picking one could only ever produce an empty list (GEO-2653).
   //
-  // Topics are deliberately not accumulated the same way. They have no such problem to solve:
-  // the topic filter runs here rather than in the query, so narrowing it never costs the viewer
-  // their way back. Remembering them instead kept offering topics from spaces the viewer had
-  // filtered away, and picking one of those could only ever produce an empty list (GEO-2653).
-  // Kept apart because the two are gated differently on the way out. A space reaching the menu
-  // through a *row* has already passed whatever its own tab requires — and the opponent and
-  // curated tabs are deliberately not narrowed by the viewer's allowlist, so re-applying it here
-  // would drop the space of a claim those tabs are still showing.
+  // The two provenances are held apart because they are gated differently below. A space that
+  // reached the menu through a *row* has already passed whatever its own tab requires, and the
+  // opponent and curated tabs are deliberately not narrowed by the viewer's allowlist — so
+  // re-applying it would drop the space of a claim those tabs are still showing.
   const seenFacetsRef = React.useRef<{ rowSpaceIds: Set<string>; facetSpaceIds: Set<string> }>({
     rowSpaceIds: new Set(),
     facetSpaceIds: new Set(),

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -46,6 +46,7 @@ import { HubCardList } from '~/core/debates/matchmaking/hub-motion';
 import { HubPillButton } from '~/core/debates/matchmaking/hub-pill-button';
 import { HubQueryState } from '~/core/debates/matchmaking/hub-states';
 import { MatchmakingClaimCard } from '~/core/debates/matchmaking/matchmaking-claim-card';
+import { availableTopics, keepSelectableTopic } from '~/core/debates/matchmaking/topic-facets';
 import { useStableListOrder } from '~/core/debates/matchmaking/use-stable-list-order';
 import { participantSidesOn, useParticipantPositions } from '~/core/debates/participant-positions';
 import { useRecommendedClaimSections } from '~/core/debates/recommended-claims';
@@ -545,13 +546,15 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
 
   const claims = tab === 'opponent' ? opponentClaims : tab === 'recommended' ? curatedClaims : browsedClaims;
 
-  // Every space and topic the lists have shown, not only the current tab's. Space runs in the
-  // browsed query, so the loaded corpus is whatever the current filter allows — a menu listing only
-  // the space you picked would have no way back to another.
-  const seenFacetsRef = React.useRef<{ spaceIds: Set<string>; topics: Map<string, MatchmakingTopic> }>({
-    spaceIds: new Set(),
-    topics: new Map(),
-  });
+  // Every space the lists have shown, not only the current tab's. Space runs in the browsed
+  // query, so the loaded corpus is whatever the current filter allows — a menu listing only the
+  // space you picked would have no way back to another.
+  //
+  // Topics are deliberately not accumulated the same way. They have no such problem to solve:
+  // the topic filter runs here rather than in the query, so narrowing it never costs the viewer
+  // their way back. Remembering them instead kept offering topics from spaces the viewer had
+  // filtered away, and picking one of those could only ever produce an empty list (GEO-2653).
+  const seenFacetsRef = React.useRef<{ spaceIds: Set<string> }>({ spaceIds: new Set() });
 
   const facetSpaceIds = React.useMemo(() => {
     const seen = seenFacetsRef.current.spaceIds;
@@ -560,15 +563,32 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
     return [...seen];
   }, [browsedClaims, browsedFacets?.space_ids, curatedClaims, opponentClaims, spaceAllowlist]);
 
-  const facetTopics = React.useMemo(() => {
-    const seen = seenFacetsRef.current.topics;
-    for (const claim of [...opponentClaims, ...curatedClaims, ...browsedClaims]) {
-      for (const topic of topicsByClaimId.get(claim.claim.claim_entity_id) ?? []) {
-        if (!seen.has(topic.id)) seen.set(topic.id, topic);
-      }
-    }
-    return [...seen.values()].sort((a, b) => (a.name ?? '').localeCompare(b.name ?? ''));
-  }, [browsedClaims, curatedClaims, opponentClaims, topicsByClaimId]);
+  // The claims the topic menu describes: everything the other filters allow, topic aside. The
+  // tab is included — each one is a different corpus, and a topic only the opponent's tab holds
+  // is not an option while looking at the curated one.
+  const topicFacetClaims = React.useMemo(
+    () =>
+      claims.filter(claim => {
+        if (spaceId && claim.claim.space_id !== spaceId) return false;
+        if (
+          tab !== 'all' &&
+          debouncedSearch &&
+          !claim.claim.claim.toLowerCase().includes(debouncedSearch.toLowerCase())
+        )
+          return false;
+        return true;
+      }),
+    [claims, debouncedSearch, spaceId, tab]
+  );
+
+  const facetTopics = React.useMemo(
+    () =>
+      availableTopics(
+        topicFacetClaims.map(claim => claim.claim.claim_entity_id),
+        topicsByClaimId
+      ),
+    [topicFacetClaims, topicsByClaimId]
+  );
 
   // Search and space reach the browsed query; on the other tabs, and for the topic everywhere
   // (geo-chat doesn't model topics), they are applied here.
@@ -609,6 +629,14 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
           opponentClaimsQuery.isLoading ||
           (landedTabRef.current === null && claims.length === 0 && recommendedLoading)
         : allowlistPending || browsedClaimsQuery.isLoading);
+
+  // A topic the menu no longer offers is unpickable as well as empty — the chip filtering the
+  // list would not be in the menu to clear. Unlike the Claims tab, the topics here arrive with
+  // the claim rows rather than in a lookup behind them, so once the tab has settled an empty
+  // menu is a real answer.
+  React.useEffect(() => {
+    setTopicId(current => keepSelectableTopic(current, facetTopics, !tabIsLoading));
+  }, [facetTopics, tabIsLoading]);
 
   const tabError =
     sessionQuery.error ??

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -236,6 +236,14 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   // facets are not — every topic on the menu would lead to an empty list.
   const hasNoEligibleSpaces = eligibleSpaceIds !== null && eligibleSpaceIds.length === 0;
 
+  // The same problem reached the other way. A space can be in the menu without being in the
+  // allowlist — the graph-backed tabs aren't narrowed by it, so their rows put their spaces there
+  // — but `browsedRows` still drops every *browsed* row from a disallowed space. Selecting one
+  // therefore leaves the server answering with rows that cannot be shown, and a facet describing
+  // them, while only the pinned rows survive. Nothing it returns is usable, so it isn't asked.
+  const browsedCorpusUnusable =
+    hasNoEligibleSpaces || (spaceId !== null && !isClaimSpaceAllowed(spaceId, spaceAllowlist));
+
   const matchmakingQuery = React.useMemo<MatchmakingClaimsQuery>(
     // `topicId` is sent whichever tab is showing. It only filters *these* rows, which back the
     // All tab, and the server's topic facet is narrowed by spaces rather than by topics — so a
@@ -244,13 +252,13 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
     () => ({ search: debouncedSearch || null, spaceId, spaceIds: eligibleSpaceIds, topicId, filter: 'all' }),
     [debouncedSearch, eligibleSpaceIds, spaceId, topicId]
   );
-  const browsedClaimsQuery = useMatchmakingClaims(matchmakingQuery, !hasNoEligibleSpaces);
+  const browsedClaimsQuery = useMatchmakingClaims(matchmakingQuery, !browsedCorpusUnusable);
   // Masked rather than left to `enabled`: the hook keeps previous data across a key change, so a
   // scope narrowing to nothing still hands back the last scope's pages — rows this drops anyway,
   // but facets it would not.
   const browsedPages = React.useMemo(
-    () => (hasNoEligibleSpaces ? [] : (browsedClaimsQuery.data?.pages ?? [])),
-    [browsedClaimsQuery.data, hasNoEligibleSpaces]
+    () => (browsedCorpusUnusable ? [] : (browsedClaimsQuery.data?.pages ?? [])),
+    [browsedClaimsQuery.data, browsedCorpusUnusable]
   );
   const browsedFacets = browsedPages[0]?.facets;
 
@@ -705,7 +713,7 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
     // Masked for the same reason the pages are: the retained `hasNextPage` outlives the scope it
     // described, and `fetchNextPage` is a manual call that ignores `enabled` — so a sentinel left
     // in view would page the unscoped corpus the moment it was scrolled to.
-    hasNextPage: !hasNoEligibleSpaces && Boolean(browsedClaimsQuery.hasNextPage),
+    hasNextPage: !browsedCorpusUnusable && Boolean(browsedClaimsQuery.hasNextPage),
     isFetchingNextPage: browsedClaimsQuery.isFetchingNextPage,
     fetchNextPage: browsedClaimsQuery.fetchNextPage,
   });
@@ -990,7 +998,7 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
             tab's sections come from the page whole, and the opponent's tab is the whole of what
             the graph knows about them, in one query. Not while the allowlist is pending either —
             the picker is showing a loading state then. */}
-        {tab === 'all' && !hasNoEligibleSpaces && browsedClaimsQuery.hasNextPage && !allowlistPending ? (
+        {tab === 'all' && !browsedCorpusUnusable && browsedClaimsQuery.hasNextPage && !allowlistPending ? (
           <div ref={sentinelRef} data-testid="claims-scroll-sentinel" className="h-px" />
         ) : null}
       </main>

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -61,13 +61,12 @@ import { useSpacesByIds } from '~/core/hooks/use-spaces-by-ids';
 import { uuidToHex } from '~/core/id/normalize';
 import { responsePositionLabel } from '~/core/responses/entity-response';
 import { getTopRankedSpaceId } from '~/core/utils/space/space-ranking';
-import { validateEntityId } from '~/core/utils/utils';
 
 import { getChecked } from '~/design-system/checkbox';
 import { ChevronDownSmall } from '~/design-system/icons/chevron-down-small';
 import { Input } from '~/design-system/input';
-import { Spinner } from '~/design-system/spinner';
 import { Skeleton } from '~/design-system/skeleton';
+import { Spinner } from '~/design-system/spinner';
 import { Text } from '~/design-system/text';
 
 const SEARCH_DEBOUNCE_MS = 250;
@@ -196,8 +195,12 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   // searched server-side, each row carrying the viewer's side and readiness. It takes a single
   // `space_id`, so the viewer's allowlist is a page-local cut, the same as the hub's.
   const matchmakingQuery = React.useMemo<MatchmakingClaimsQuery>(
-    () => ({ search: debouncedSearch || null, spaceId, filter: 'all' }),
-    [debouncedSearch, spaceId]
+    // `topicId` is sent whichever tab is showing. It only filters *these* rows, which back the
+    // All tab, and the server's topic facet is narrowed by spaces rather than by topics — so a
+    // topic selection can never collapse the menu it came from. The other two tabs are built
+    // from graph entities geo-chat has never seen, so their topic filter stays client-side.
+    () => ({ search: debouncedSearch || null, spaceId, topicId, filter: 'all' }),
+    [debouncedSearch, spaceId, topicId]
   );
   const browsedClaimsQuery = useMatchmakingClaims(matchmakingQuery, true);
   const browsedPages = React.useMemo(() => browsedClaimsQuery.data?.pages ?? [], [browsedClaimsQuery.data]);
@@ -331,31 +334,9 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
 
   // Topics live on the KG claim entity, so resolve them here to label each card and drive the
   // "Any topic" filter. A claim can carry several topics. The browsed rows bring their own.
-  // geo-chat hardcodes `topics: []` on every row it returns, so the All tab's claims arrive
-  // without any. The other two tabs are built from graph entities and get theirs for free; this
-  // is the same lookup for the browsed ones, and without it the topic menu has nothing to
-  // describe them with — it listed the other tabs' topics instead, which is what GEO-2653 was.
-  //
-  // Kept separate from `opponentEntitiesQuery` rather than folded into it: those entities are
-  // what the opponent tab's rows are built from, so browsed ids joining that query would put
-  // browsed claims on the opponent's tab.
-  const browsedClaimEntityIds = React.useMemo(
-    () => [
-      ...new Set(
-        browsedPages.flatMap(page => page.claims.map(entry => entry.claim.claim_entity_id)).filter(validateEntityId)
-      ),
-    ],
-    [browsedPages]
-  );
-  const browsedEntitiesQuery = useClaimEntitiesByIds(browsedClaimEntityIds);
-
   const topicsByClaimId = React.useMemo(() => {
     const map = new Map<string, MatchmakingTopic[]>();
-    for (const entity of [
-      ...opponentEntitiesQuery.entities,
-      ...recommendedEntities,
-      ...browsedEntitiesQuery.entities,
-    ]) {
+    for (const entity of [...opponentEntitiesQuery.entities, ...recommendedEntities]) {
       const topics = entity.relations
         .filter(relation => relation.type.id === TOPICS_PROPERTY_ID && relation.isDeleted !== true)
         .map(relation => ({ id: relation.toEntity.id, name: relation.toEntity.name ?? null }));
@@ -369,7 +350,7 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
       }
     }
     return map;
-  }, [browsedEntitiesQuery.entities, browsedPages, opponentEntitiesQuery.entities, recommendedEntities]);
+  }, [browsedPages, opponentEntitiesQuery.entities, recommendedEntities]);
 
   // The opponent's tab: every claim they hold a side on, newest first. Held until the session's
   // exclusions are in, so nothing lists and then vanishes. Not narrowed by the space allowlist —
@@ -553,8 +534,7 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
    * that is correct for every claim already on it. Going back to a skeleton there would flicker
    * the badge on exactly the event that ought to be invisible.
    */
-  const opponentCountPending =
-    opponentClaims.length === 0 && (positions.isLoading || opponentClaimsSettling);
+  const opponentCountPending = opponentClaims.length === 0 && (positions.isLoading || opponentClaimsSettling);
 
   const hasRecommended = recommendedSections.length > 0;
   // The opponent's claims arrive in one round trip; the curated lookup is three, in sequence. The
@@ -586,32 +566,36 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
     return [...seen];
   }, [browsedClaims, browsedFacets?.space_ids, curatedClaims, opponentClaims, spaceAllowlist]);
 
-  // The claims the topic menu describes: everything the other filters allow, topic aside. The
-  // tab is included — each one is a different corpus, and a topic only the opponent's tab holds
-  // is not an option while looking at the curated one.
+  // The claims the topic menu describes on the graph-backed tabs: everything the other filters
+  // allow, topic aside. Narrowing by the current topic too would collapse the menu to the one
+  // option already chosen. The tab matters — each is a different corpus, and a topic only the
+  // opponent's tab holds is not an option while looking at the curated one.
   const topicFacetClaims = React.useMemo(
     () =>
       claims.filter(claim => {
         if (spaceId && claim.claim.space_id !== spaceId) return false;
-        if (
-          tab !== 'all' &&
-          debouncedSearch &&
-          !claim.claim.claim.toLowerCase().includes(debouncedSearch.toLowerCase())
-        )
-          return false;
+        if (debouncedSearch && !claim.claim.claim.toLowerCase().includes(debouncedSearch.toLowerCase())) return false;
         return true;
       }),
-    [claims, debouncedSearch, spaceId, tab]
+    [claims, debouncedSearch, spaceId]
   );
 
-  const facetTopics = React.useMemo(
-    () =>
-      availableTopics(
+  // The All tab takes its menu from the server, which knows the whole filtered corpus rather
+  // than the pages this client has walked — the difference GEO-2653 was about. The other two
+  // tabs are built from graph entities geo-chat has never heard of, so they still derive theirs.
+  //
+  // The server orders by count; kept in name order to match the other tabs and to leave the
+  // count ordering, with the counts themselves, to GEO-2654.
+  const facetTopics = React.useMemo(() => {
+    if (tab !== 'all')
+      return availableTopics(
         topicFacetClaims.map(claim => claim.claim.claim_entity_id),
         topicsByClaimId
-      ),
-    [topicFacetClaims, topicsByClaimId]
-  );
+      );
+    return [...(browsedFacets?.topic_facets ?? [])]
+      .map(facet => ({ id: facet.id, name: facet.name }))
+      .sort((a, b) => (a.name ?? '').localeCompare(b.name ?? ''));
+  }, [browsedFacets?.topic_facets, tab, topicFacetClaims, topicsByClaimId]);
 
   // Search and space reach the browsed query; on the other tabs, and for the topic everywhere
   // (geo-chat doesn't model topics), they are applied here.
@@ -619,6 +603,10 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
     () =>
       claims.filter(claim => {
         if (spaceId && claim.claim.space_id !== spaceId) return false;
+        // Kept even on the All tab, where the query has already applied it. That tab is the
+        // browsed rows *plus* this session's claims pinned in front of them, and the pinned ones
+        // never went through the query — without this they survive a topic filter they don't
+        // match. A no-op for the rows the server did filter, which match by construction.
         if (topicId && !(topicsByClaimId.get(claim.claim.claim_entity_id) ?? []).some(t => t.id === topicId))
           return false;
         if (
@@ -658,8 +646,9 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   // the claim rows rather than in a lookup behind them, so once the tab has settled an empty
   // menu is a real answer.
   React.useEffect(() => {
-    setTopicId(current => keepSelectableTopic(current, facetTopics, !tabIsLoading && !browsedEntitiesQuery.isLoading));
-  }, [browsedEntitiesQuery.isLoading, facetTopics, tabIsLoading]);
+    const resolved = tab === 'all' ? browsedFacets !== undefined && !tabIsLoading : !tabIsLoading;
+    setTopicId(current => keepSelectableTopic(current, facetTopics, resolved));
+  }, [browsedFacets, facetTopics, tab, tabIsLoading]);
 
   const tabError =
     sessionQuery.error ??

--- a/apps/web/core/debates/api.test.ts
+++ b/apps/web/core/debates/api.test.ts
@@ -224,6 +224,47 @@ describe('matchmaking', () => {
     expect(fetch).toHaveBeenCalledWith('http://localhost:8080/matchmaking/claims', expect.anything());
   });
 
+  // GEO-2659 and GEO-2674 moved the scope, the topic filter and this session's exclusions onto the
+  // wire. Nothing above reaches the URL for them — the UI suites mock the hook and assert the query
+  // object — so a renamed or wrongly joined parameter would be caught by neither.
+  it('sends the eligible scope, the topic and the session as query parameters', async () => {
+    const fetch = stubJson({ claims: [], next_cursor: null });
+
+    await listMatchmakingClaims(
+      { spaceIds: ['space-1', 'space-2'], topicId: 'topic-ai', rematchSessionId: 'rematch-1' },
+      vi.fn(),
+      'user-a'
+    );
+
+    const url = new URL((fetch.mock.calls[0]?.[0] as string) ?? '');
+    expect(url.searchParams.get('space_ids')).toBe('space-1,space-2');
+    expect(url.searchParams.get('topic_id')).toBe('topic-ai');
+    expect(url.searchParams.get('rematch_session_id')).toBe('rematch-1');
+  });
+
+  // The two space parameters are OR-merged server-side, so sending both would widen the corpus to
+  // the whole eligible set the moment the viewer picked one space out of it.
+  it('sends the picked space instead of the scope, never both', async () => {
+    const fetch = stubJson({ claims: [], next_cursor: null });
+
+    await listMatchmakingClaims({ spaceId: 'space-1', spaceIds: ['space-1', 'space-2'] }, vi.fn(), 'user-a');
+
+    const url = new URL((fetch.mock.calls[0]?.[0] as string) ?? '');
+    expect(url.searchParams.get('space_id')).toBe('space-1');
+    expect(url.searchParams.has('space_ids')).toBe(false);
+  });
+
+  // An empty scope means "no space this viewer may be shown claims from", and the server reads a
+  // missing `space_ids` as "no filter" — the exact opposite. The callers hold the query back in
+  // that case, and this is the half of the contract that makes their doing so necessary.
+  it('omits an empty scope rather than sending it as no filter', async () => {
+    const fetch = stubJson({ claims: [], next_cursor: null });
+
+    await listMatchmakingClaims({ spaceIds: [] }, vi.fn(), 'user-a');
+
+    expect(fetch).toHaveBeenCalledWith('http://localhost:8080/matchmaking/claims', expect.anything());
+  });
+
   it('creates a debate request for a claim', async () => {
     const fetch = stubJson({ id: 'request-1' });
 

--- a/apps/web/core/debates/api.ts
+++ b/apps/web/core/debates/api.ts
@@ -443,6 +443,14 @@ export type MatchmakingClaimsFilter = 'all' | 'mine' | 'debate_now';
 export type MatchmakingClaimsQuery = {
   search?: string | null;
   spaceId?: string | null;
+  /**
+   * The spaces this viewer may see claims from at all, sent when they haven't picked one.
+   *
+   * Both this and `spaceId` are OR-ed together server-side rather than one overriding the other,
+   * so only ever send one of them: sending both would widen the query back out to every space in
+   * either list.
+   */
+  spaceIds?: string[] | null;
   topicId?: string | null;
   filter?: MatchmakingClaimsFilter;
   cursor?: string | null;
@@ -1057,6 +1065,10 @@ export async function listMatchmakingClaims(
   // so a cut never lands inside a surrogate pair and hands `URLSearchParams` a lone surrogate.
   if (query.search) params.set('search', capSearchQuery(query.search));
   if (query.spaceId) params.set('space_id', query.spaceId);
+  // Only when no single space is picked — see the note on the type. An empty list is left off
+  // entirely: the server reads "no ids" as "no filter", which is the opposite of what an empty
+  // eligible set means.
+  else if (query.spaceIds?.length) params.set('space_ids', query.spaceIds.join(','));
   if (query.topicId) params.set('topic_id', query.topicId);
   if (query.filter && query.filter !== 'all') params.set('filter', query.filter);
   if (query.cursor) params.set('cursor', query.cursor);

--- a/apps/web/core/debates/api.ts
+++ b/apps/web/core/debates/api.ts
@@ -473,16 +473,27 @@ export type MatchmakingFacetCount = {
   count: number;
 };
 
+/**
+ * The two menus, counted over the whole candidate set rather than the page being returned.
+ *
+ * Each dimension is narrowed by *the other* and never by itself — standard faceted counting, and
+ * what makes a count answer "how many of the claims matching everything else I have chosen are in
+ * here". Picking a space therefore doesn't collapse the space menu, and picking a topic doesn't
+ * collapse the topic menu, but each does narrow its counterpart.
+ *
+ * The half that is easy to miss is that this cuts both ways: a space can disappear from
+ * `space_facets` because the selected *topic* has nothing in it. That is "this combination is
+ * empty", not "this space is no longer yours to pick", and the two must not be confused — see the
+ * space effect in `claims-tab.tsx`.
+ */
 export type MatchmakingFacets = {
-  /** Superseded by `space_facets`; geo-chat keeps both populated so clients can move at their own pace. */
+  /** Superseded by `space_facets`, and derived from it — so it inherits the topic narrowing too. */
   space_ids: string[];
   /** Superseded by `topic_facets`. Empty on every response until GEO-2659 made it real. */
   topics: MatchmakingTopic[];
-  /** Count descending. Deliberately *not* narrowed by the space filter: picking a space must not
-   *  collapse the menu it was picked from. */
+  /** Count descending. Narrowed by the topic filter, not by the space filter. */
   space_facets: MatchmakingFacetCount[];
-  /** Count descending, and narrowed by the space filter — "how many of the claims I'm looking at
-   *  carry this topic". This is what makes the topic menu complete regardless of paging. */
+  /** Count descending. Narrowed by the space filter, not by the topic filter. */
   topic_facets: MatchmakingFacetCount[];
 };
 

--- a/apps/web/core/debates/api.ts
+++ b/apps/web/core/debates/api.ts
@@ -452,6 +452,14 @@ export type MatchmakingClaimsQuery = {
    */
   spaceIds?: string[] | null;
   topicId?: string | null;
+  /**
+   * Narrows rows *and* facets to what a debate-again session can still offer: geo-chat drops the
+   * claim the source debate was about, and any this pairing has blocked (GEO-2674).
+   *
+   * The session id rather than the ids themselves — that set is geo-chat's own, and the client
+   * would be handing back a value it isn't the authority on.
+   */
+  rematchSessionId?: string | null;
   filter?: MatchmakingClaimsFilter;
   cursor?: string | null;
   limit?: number;
@@ -1070,6 +1078,7 @@ export async function listMatchmakingClaims(
   // eligible set means.
   else if (query.spaceIds?.length) params.set('space_ids', query.spaceIds.join(','));
   if (query.topicId) params.set('topic_id', query.topicId);
+  if (query.rematchSessionId) params.set('rematch_session_id', query.rematchSessionId);
   if (query.filter && query.filter !== 'all') params.set('filter', query.filter);
   if (query.cursor) params.set('cursor', query.cursor);
   if (query.limit) params.set('limit', String(query.limit));

--- a/apps/web/core/debates/api.ts
+++ b/apps/web/core/debates/api.ts
@@ -436,19 +436,38 @@ export type MatchmakingClaim = MatchmakingReadiness & {
 
 export type MatchmakingClaimsFilter = 'all' | 'mine' | 'debate_now';
 
-/** No topic facet: topics are Knowledge Graph data geo-chat doesn't model, so the Claims tab
- * resolves and filters them itself over the loaded pages. */
+/** Topics are Knowledge Graph data, which geo-chat replicates as of GEO-2659 — so `topicId`
+ * filters server-side and the response carries a topic facet. Before that the server returned
+ * `topics: []` and ignored the parameter, and both pickers resolved and filtered topics
+ * themselves over whatever pages they had loaded. */
 export type MatchmakingClaimsQuery = {
   search?: string | null;
   spaceId?: string | null;
+  topicId?: string | null;
   filter?: MatchmakingClaimsFilter;
   cursor?: string | null;
   limit?: number;
 };
 
+/** One dropdown option and how many claims the current filters leave behind it. */
+export type MatchmakingFacetCount = {
+  id: string;
+  /** Topics carry a replicated name; spaces don't — the client resolves those from the sidebar. */
+  name: string | null;
+  count: number;
+};
+
 export type MatchmakingFacets = {
+  /** Superseded by `space_facets`; geo-chat keeps both populated so clients can move at their own pace. */
   space_ids: string[];
+  /** Superseded by `topic_facets`. Empty on every response until GEO-2659 made it real. */
   topics: MatchmakingTopic[];
+  /** Count descending. Deliberately *not* narrowed by the space filter: picking a space must not
+   *  collapse the menu it was picked from. */
+  space_facets: MatchmakingFacetCount[];
+  /** Count descending, and narrowed by the space filter — "how many of the claims I'm looking at
+   *  carry this topic". This is what makes the topic menu complete regardless of paging. */
+  topic_facets: MatchmakingFacetCount[];
 };
 
 export type MatchmakingClaimsResponse = {
@@ -1038,6 +1057,7 @@ export async function listMatchmakingClaims(
   // so a cut never lands inside a surrogate pair and hands `URLSearchParams` a lone surrogate.
   if (query.search) params.set('search', capSearchQuery(query.search));
   if (query.spaceId) params.set('space_id', query.spaceId);
+  if (query.topicId) params.set('topic_id', query.topicId);
   if (query.filter && query.filter !== 'all') params.set('filter', query.filter);
   if (query.cursor) params.set('cursor', query.cursor);
   if (query.limit) params.set('limit', String(query.limit));

--- a/apps/web/core/debates/claim-space-allowlist.ts
+++ b/apps/web/core/debates/claim-space-allowlist.ts
@@ -88,3 +88,24 @@ export function eligibleClaimSpaceIds(
   if (allowlist === null) return null;
   return [...allowlist].filter(spaceShowsClaims);
 }
+
+/**
+ * The space that should stay selected once the menu has settled around it.
+ *
+ * Both eligibility gates pass everything while their lookups are unresolved, so a space can be
+ * picked out of the menu in that window and then rejected once the answers land. Left selected it
+ * keeps going out as `space_id` on every request — with its topic facet — while every row it
+ * returns is dropped again locally.
+ *
+ * `isResolved` is passed rather than inferred from an empty list, for the same reason
+ * `keepSelectableTopic` takes it: "the menu hasn't arrived" and "the menu excludes this" look
+ * identical from here, and clearing on the first would throw away a selection about to be valid.
+ */
+export function keepSelectableSpace(
+  spaceId: string | null,
+  availableSpaceIds: string[],
+  isResolved: boolean
+): string | null {
+  if (spaceId === null || !isResolved) return spaceId;
+  return availableSpaceIds.some(id => normId(id) === normId(spaceId)) ? spaceId : null;
+}

--- a/apps/web/core/debates/claim-space-allowlist.ts
+++ b/apps/web/core/debates/claim-space-allowlist.ts
@@ -69,3 +69,22 @@ export function isClaimSpaceAllowed(spaceId: string | null | undefined, allowlis
   if (!spaceId) return false;
   return allowlist.has(normId(spaceId));
 }
+
+/**
+ * The spaces a viewer may see claims from, as a list rather than a membership test.
+ *
+ * Sent to geo-chat so its rows *and* its facets are scoped to the same spaces the client would
+ * otherwise filter down to afterwards. Without it a topic living only in a space this viewer
+ * can't see is still offered, and picking it returns rows the client then removes — a menu
+ * option that can only ever produce an empty list (GEO-2653).
+ *
+ * `null` when the allowlist hasn't resolved: there is no list to send, and the gates deliberately
+ * pass everything until it does.
+ */
+export function eligibleClaimSpaceIds(
+  allowlist: Set<string> | null,
+  spaceShowsClaims: (spaceId: string) => boolean
+): string[] | null {
+  if (allowlist === null) return null;
+  return [...allowlist].filter(spaceShowsClaims);
+}

--- a/apps/web/core/debates/matchmaking/claims-tab.test.tsx
+++ b/apps/web/core/debates/matchmaking/claims-tab.test.tsx
@@ -619,6 +619,26 @@ describe('topic menu', () => {
     expect(screen.getByRole('button', { name: 'AI' })).toBeInTheDocument();
   });
 
+  // Without this the facet describes every space geo-chat knows, so a topic living only in a
+  // space this viewer can't be shown claims from is offered over a list the client then empties.
+  it('scopes the query to the spaces the viewer can be shown claims from', () => {
+    mocks.spaceAllowlist = new Set([SPACE_ID.replace(/-/g, '')]);
+    render(<ClaimsTab />);
+
+    expect(mocks.lastQuery).toMatchObject({ spaceIds: [SPACE_ID.replace(/-/g, '')] });
+  });
+
+  it('sends the picked space alone, never alongside the eligible list', () => {
+    mocks.spaceAllowlist = new Set([SPACE_ID.replace(/-/g, ''), OTHER_SPACE_ID.replace(/-/g, '')]);
+    render(<ClaimsTab />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Any space/ }));
+    fireEvent.click(screen.getByRole('button', { name: /Crypto/ }));
+
+    // geo-chat ORs the two together, so sending both would widen the query straight back out.
+    expect((mocks.lastQuery as { spaceId?: string | null }).spaceId).toBeTruthy();
+  });
+
   it('asks the server to do the topic filtering', () => {
     render(<ClaimsTab />);
 

--- a/apps/web/core/debates/matchmaking/claims-tab.test.tsx
+++ b/apps/web/core/debates/matchmaking/claims-tab.test.tsx
@@ -6,15 +6,13 @@ import type { ReactElement } from 'react';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { TOPICS_PROPERTY_ID } from '~/core/claims/ontology';
-
 import type { MatchmakingClaim } from '../api';
 import { ClaimsTab } from './claims-tab';
 
 const mocks = vi.hoisted(() => ({
   claims: [] as MatchmakingClaim[],
-  entities: [] as { id: string; relations: unknown[] }[],
   facetSpaceIds: [] as string[],
+  pageSize: null as number | null,
   spaceAllowlist: null as Set<string> | null,
   allowlistLoading: false,
   publishableSpaceIds: null as Set<string> | null,
@@ -30,9 +28,9 @@ const mocks = vi.hoisted(() => ({
 }));
 
 // `pending-personal-space` reads localStorage at module scope (`atomWithStorage` with
-// `getOnInit`), and the storage jsdom hands back here has no `getItem`. The throw happens
-// while the module graph is still being built, so it took this whole file down at collection
-// — every test in it, on master and in CI alike. The tab reaches it through the claim card.
+// `getOnInit`), and the storage jsdom hands back here has no `getItem`. The throw happens while
+// the module graph is still being built, so it takes this whole file down at collection — every
+// test in it, on master and in CI alike. Reached through the claim card.
 vi.mock('~/core/state/pending-personal-space', () => ({
   PENDING_PERSONAL_SPACE_PREFIX: 'pending:',
   pendingPersonalSpaceAtom: { toString: () => 'pendingPersonalSpaceAtom' },
@@ -58,25 +56,37 @@ vi.mock('~/core/debates/use-debate-publishable-spaces', async importOriginal => 
 vi.mock('./hooks', () => ({
   useMatchmakingClaims: (query: unknown) => {
     mocks.lastQuery = query;
+    const { spaceId, topicId } = query as { spaceId?: string | null; topicId?: string | null };
+    // `space_id` and `topic_id` are both query parameters as of GEO-2659, so the endpoint
+    // returns only the rows that match. Mirrored here, because what the tab renders and what
+    // its menus describe both hang off that.
+    const inSpace = mocks.claims.filter(entry => !spaceId || entry.claim.space_id === spaceId);
+    const claims = inSpace.filter(entry => !topicId || entry.topics.some(topic => topic.id === topicId));
+    // The topic facet is narrowed by the space filter but *not* by the topic filter — picking a
+    // topic must not collapse the menu it came from. Computed over the whole space-filtered set
+    // rather than the returned page: that is the point of a server-side facet.
+    const topicFacets = [...new Map(inSpace.flatMap(entry => entry.topics).map(topic => [topic.id, topic])).values()];
+    // Facets are computed over the whole filtered set while the page is a slice of it — the
+    // shape that matters here, since the menu must not depend on how far the viewer has scrolled.
+    const page = mocks.pageSize === null ? claims : claims.slice(0, mocks.pageSize);
     return {
       data: {
         pages: [
           {
-            // `space_id` is a query parameter, so the endpoint returns only that space's
-            // claims. Mirrored here: the topic menu is built from what came back.
-            claims: mocks.claims.filter(
-              entry =>
-                !(query as { spaceId?: string | null }).spaceId ||
-                entry.claim.space_id === (query as { spaceId?: string | null }).spaceId
-            ),
+            claims: page,
             next_cursor: null,
-            facets: { space_ids: mocks.facetSpaceIds },
+            facets: {
+              space_ids: mocks.facetSpaceIds,
+              topics: topicFacets,
+              space_facets: mocks.facetSpaceIds.map(id => ({ id, name: null, count: 1 })),
+              topic_facets: topicFacets.map(topic => ({ ...topic, count: 1 })),
+            },
           },
         ],
       },
       isLoading: false,
       error: null,
-      hasNextPage: mocks.hasNextPage,
+      hasNextPage: mocks.hasNextPage || page.length < claims.length,
       isFetchingNextPage: false,
       fetchNextPage: mocks.fetchNextPage,
       refetch: vi.fn(),
@@ -128,7 +138,7 @@ vi.mock('~/core/hooks/use-spaces-by-ids', () => ({
 }));
 
 vi.mock('~/core/sync/use-store', () => ({
-  useQueryEntities: () => ({ entities: mocks.entities }),
+  useQueryEntities: () => ({ entities: [] }),
 }));
 
 function render(ui: ReactElement) {
@@ -150,27 +160,17 @@ function sidebarData() {
   };
 }
 
-/** A resolved claim entity carrying topic relations, the shape the topic lookup reads. */
-function entityWithTopics(id: string, topics: { id: string; name: string }[]) {
-  return {
-    id,
-    relations: topics.map(topic => ({
-      type: { id: TOPICS_PROPERTY_ID },
-      toEntity: { id: topic.id, name: topic.name },
-    })),
-  };
-}
-
 function claim(
   entityId: string,
   text: string,
   viewerResponded: boolean,
   debateReady = false,
-  spaceId = SPACE_ID
+  spaceId = SPACE_ID,
+  topics: { id: string; name: string }[] = []
 ): MatchmakingClaim {
   return {
     claim: { id: `row-${entityId}`, space_id: spaceId, claim_entity_id: entityId, claim: text, description: null },
-    topics: [],
+    topics,
     response_kind: 'stance',
     viewer_position: viewerResponded ? true : null,
     viewer_response: viewerResponded ? { position: true, position_label: 'Agree' } : null,
@@ -187,8 +187,8 @@ const THEIRS = '019fedb2-1d52-7a4f-8b22-3d8e6f9c5520';
 
 beforeEach(() => {
   mocks.hasNextPage = false;
-  mocks.entities = [];
   mocks.facetSpaceIds = [];
+  mocks.pageSize = null;
   // Null + settled is "the allowlist lookup came back with nothing", which falls through to an
   // unfiltered list — what every pre-existing case here runs under.
   mocks.spaceAllowlist = null;
@@ -562,8 +562,10 @@ it('asks the server for the filter the viewer picked', () => {
   expect(mocks.lastQuery).toMatchObject({ filter: 'debate_now' });
 });
 
-// GEO-2653. The menu is built here rather than by geo-chat, which models no topics at all, and
-// it was built from every entity the lookup had resolved rather than from the claims on screen.
+// GEO-2653. The menu is the server's topic facet, which describes every claim the current
+// filters allow rather than the pages this client has walked — the client-side version grew as
+// the viewer scrolled, so a space whose first page carried no topics looked like a space with
+// none at all.
 describe('topic menu', () => {
   const AI = { id: 'topic-ai', name: 'AI' };
   const HEALTH = { id: 'topic-health', name: 'Health' };
@@ -572,10 +574,9 @@ describe('topic menu', () => {
     mocks.facetSpaceIds = [SPACE_ID, OTHER_SPACE_ID];
     mocks.sidebarData = sidebarData();
     mocks.claims = [
-      claim('claim-ai', 'Models are getting cheaper', false, false, SPACE_ID),
-      claim('claim-health', 'Sleep is underrated', false, false, OTHER_SPACE_ID),
+      claim('claim-ai', 'Models are getting cheaper', false, false, SPACE_ID, [AI]),
+      claim('claim-health', 'Sleep is underrated', false, false, OTHER_SPACE_ID, [HEALTH]),
     ];
-    mocks.entities = [entityWithTopics('claim-ai', [AI]), entityWithTopics('claim-health', [HEALTH])];
   });
 
   it('offers every topic while no space is picked', () => {
@@ -598,6 +599,35 @@ describe('topic menu', () => {
     expect(screen.getByRole('button', { name: 'AI' })).toBeInTheDocument();
     // The reported bug: Health stayed on the menu, and picking it showed nothing at all.
     expect(screen.queryByRole('button', { name: 'Health' })).toBeNull();
+  });
+
+  // The report that reopened this: filter to a space, and topics appeared only as you scrolled,
+  // because the menu was built from the claims paged in so far.
+  it('offers a topic no claim on the loaded page carries', () => {
+    mocks.claims = [
+      claim('claim-plain', 'A claim with no topics', false, false, SPACE_ID),
+      claim('claim-ai', 'Models are getting cheaper', false, false, SPACE_ID, [AI]),
+    ];
+    mocks.pageSize = 1;
+    render(<ClaimsTab />);
+
+    expect(screen.getByText('A claim with no topics')).toBeInTheDocument();
+    expect(screen.queryByText('Models are getting cheaper')).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: /Any topic/ }));
+
+    expect(screen.getByRole('button', { name: 'AI' })).toBeInTheDocument();
+  });
+
+  it('asks the server to do the topic filtering', () => {
+    render(<ClaimsTab />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Any topic/ }));
+    fireEvent.click(screen.getByRole('button', { name: 'AI' }));
+
+    // Filtering here would only ever narrow the pages already loaded, which is the same bug in
+    // the list that the menu had.
+    expect(mocks.lastQuery).toMatchObject({ topicId: AI.id });
   });
 
   it('lets go of a selected topic the picked space has no claims for', () => {

--- a/apps/web/core/debates/matchmaking/claims-tab.test.tsx
+++ b/apps/web/core/debates/matchmaking/claims-tab.test.tsx
@@ -685,6 +685,30 @@ describe('topic menu', () => {
     expect(mocks.lastQuery).toMatchObject({ spaceIds: [SPACE_ID.replace(/-/g, '')] });
   });
 
+  // The allowlist settling without an answer stops it narrowing, deliberately — a list that is too
+  // wide beats a panel that never fills. That is a reason to stop narrowing by the allowlist, not
+  // to stop narrowing: the publishable set is a different question, and the rows are still cut by
+  // it. Left unscoped, the facets would name every space geo-chat knows while the list showed only
+  // the publishable ones.
+  it('falls back to the publishable spaces when the allowlist settles with nothing', () => {
+    mocks.spaceAllowlist = null;
+    mocks.allowlistLoading = false;
+    mocks.publishableSpaceIds = new Set([SPACE_ID.replace(/-/g, '')]);
+    render(<ClaimsTab />);
+
+    expect(mocks.lastQuery).toMatchObject({ spaceIds: [SPACE_ID.replace(/-/g, '')] });
+  });
+
+  // Both unknown is the only case with nothing left to narrow by.
+  it('asks unscoped only when neither lookup has an answer', () => {
+    mocks.spaceAllowlist = null;
+    mocks.allowlistLoading = false;
+    mocks.publishableSpaceIds = null;
+    render(<ClaimsTab />);
+
+    expect(mocks.lastQuery).toMatchObject({ spaceIds: null });
+  });
+
   // "No eligible spaces" and "no space filter" are the same request on the wire, so the query
   // has to be skipped rather than sent unscoped: the rows would all be dropped here, but the
   // facets would not, leaving a menu whose every option leads to an empty list.

--- a/apps/web/core/debates/matchmaking/claims-tab.test.tsx
+++ b/apps/web/core/debates/matchmaking/claims-tab.test.tsx
@@ -701,6 +701,23 @@ describe('topic menu', () => {
     expect(mocks.lastQuery).toMatchObject({ topicId: AI.id });
   });
 
+  // The scope goes out as `spaceIds`, and it isn't known until the allowlist and the publishable
+  // lookup have both landed. Asked before then, the endpoint answers about the whole corpus — rows
+  // the gates then drop, and a topic facet spanning spaces this viewer is never shown. The rows
+  // being discarded is what made it look harmless: `keepPreviousData` hands the same facets back
+  // when the scope settles and the key changes, and nothing gates a topic by space, so the menu
+  // offers options over a list with nothing to put under them.
+  it('does not ask for a corpus wider than the scope it is about to apply', () => {
+    mocks.spaceAllowlist = null;
+    mocks.allowlistLoading = true;
+    render(<ClaimsTab />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Any topic/ }));
+
+    expect(screen.queryByRole('button', { name: 'AI' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Health' })).toBeNull();
+  });
+
   it('lets go of a selected topic the picked space has no claims for', () => {
     render(<ClaimsTab />);
 

--- a/apps/web/core/debates/matchmaking/claims-tab.test.tsx
+++ b/apps/web/core/debates/matchmaking/claims-tab.test.tsx
@@ -6,11 +6,14 @@ import type { ReactElement } from 'react';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { TOPICS_PROPERTY_ID } from '~/core/claims/ontology';
+
 import type { MatchmakingClaim } from '../api';
 import { ClaimsTab } from './claims-tab';
 
 const mocks = vi.hoisted(() => ({
   claims: [] as MatchmakingClaim[],
+  entities: [] as { id: string; relations: unknown[] }[],
   facetSpaceIds: [] as string[],
   spaceAllowlist: null as Set<string> | null,
   allowlistLoading: false,
@@ -24,6 +27,19 @@ const mocks = vi.hoisted(() => ({
   fetchNextPage: vi.fn(),
   observed: [] as Element[],
   trigger: null as null | (() => void),
+}));
+
+// `pending-personal-space` reads localStorage at module scope (`atomWithStorage` with
+// `getOnInit`), and the storage jsdom hands back here has no `getItem`. The throw happens
+// while the module graph is still being built, so it took this whole file down at collection
+// — every test in it, on master and in CI alike. The tab reaches it through the claim card.
+vi.mock('~/core/state/pending-personal-space', () => ({
+  PENDING_PERSONAL_SPACE_PREFIX: 'pending:',
+  pendingPersonalSpaceAtom: { toString: () => 'pendingPersonalSpaceAtom' },
+  pendingPersonalSpaceId: (topicId: string) => `pending:${topicId}`,
+  isPendingPersonalSpaceId: (spaceId: string | null | undefined) =>
+    typeof spaceId === 'string' && spaceId.startsWith('pending:'),
+  usePendingPersonalSpace: () => ({ isPending: false }),
 }));
 
 vi.mock('~/core/debates/use-claim-space-allowlist', () => ({
@@ -43,7 +59,21 @@ vi.mock('./hooks', () => ({
   useMatchmakingClaims: (query: unknown) => {
     mocks.lastQuery = query;
     return {
-      data: { pages: [{ claims: mocks.claims, next_cursor: null, facets: { space_ids: mocks.facetSpaceIds } }] },
+      data: {
+        pages: [
+          {
+            // `space_id` is a query parameter, so the endpoint returns only that space's
+            // claims. Mirrored here: the topic menu is built from what came back.
+            claims: mocks.claims.filter(
+              entry =>
+                !(query as { spaceId?: string | null }).spaceId ||
+                entry.claim.space_id === (query as { spaceId?: string | null }).spaceId
+            ),
+            next_cursor: null,
+            facets: { space_ids: mocks.facetSpaceIds },
+          },
+        ],
+      },
       isLoading: false,
       error: null,
       hasNextPage: mocks.hasNextPage,
@@ -98,7 +128,7 @@ vi.mock('~/core/hooks/use-spaces-by-ids', () => ({
 }));
 
 vi.mock('~/core/sync/use-store', () => ({
-  useQueryEntities: () => ({ entities: [] }),
+  useQueryEntities: () => ({ entities: mocks.entities }),
 }));
 
 function render(ui: ReactElement) {
@@ -117,6 +147,17 @@ function sidebarData() {
     memberOf: [],
     documentationImage: null,
     personalSpaceId: null,
+  };
+}
+
+/** A resolved claim entity carrying topic relations, the shape the topic lookup reads. */
+function entityWithTopics(id: string, topics: { id: string; name: string }[]) {
+  return {
+    id,
+    relations: topics.map(topic => ({
+      type: { id: TOPICS_PROPERTY_ID },
+      toEntity: { id: topic.id, name: topic.name },
+    })),
   };
 }
 
@@ -146,6 +187,7 @@ const THEIRS = '019fedb2-1d52-7a4f-8b22-3d8e6f9c5520';
 
 beforeEach(() => {
   mocks.hasNextPage = false;
+  mocks.entities = [];
   mocks.facetSpaceIds = [];
   // Null + settled is "the allowlist lookup came back with nothing", which falls through to an
   // unfiltered list — what every pre-existing case here runs under.
@@ -518,4 +560,58 @@ it('asks the server for the filter the viewer picked', () => {
   fireEvent.click(screen.getByRole('button', { name: 'Debate now' }));
 
   expect(mocks.lastQuery).toMatchObject({ filter: 'debate_now' });
+});
+
+// GEO-2653. The menu is built here rather than by geo-chat, which models no topics at all, and
+// it was built from every entity the lookup had resolved rather than from the claims on screen.
+describe('topic menu', () => {
+  const AI = { id: 'topic-ai', name: 'AI' };
+  const HEALTH = { id: 'topic-health', name: 'Health' };
+
+  beforeEach(() => {
+    mocks.facetSpaceIds = [SPACE_ID, OTHER_SPACE_ID];
+    mocks.sidebarData = sidebarData();
+    mocks.claims = [
+      claim('claim-ai', 'Models are getting cheaper', false, false, SPACE_ID),
+      claim('claim-health', 'Sleep is underrated', false, false, OTHER_SPACE_ID),
+    ];
+    mocks.entities = [entityWithTopics('claim-ai', [AI]), entityWithTopics('claim-health', [HEALTH])];
+  });
+
+  it('offers every topic while no space is picked', () => {
+    render(<ClaimsTab />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Any topic/ }));
+
+    expect(screen.getByRole('button', { name: 'AI' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Health' })).toBeInTheDocument();
+  });
+
+  it('drops the topics that have no claims in the picked space', () => {
+    render(<ClaimsTab />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Any space/ }));
+    fireEvent.click(screen.getByRole('button', { name: /Crypto/ }));
+
+    fireEvent.click(screen.getByRole('button', { name: /Any topic/ }));
+
+    expect(screen.getByRole('button', { name: 'AI' })).toBeInTheDocument();
+    // The reported bug: Health stayed on the menu, and picking it showed nothing at all.
+    expect(screen.queryByRole('button', { name: 'Health' })).toBeNull();
+  });
+
+  it('lets go of a selected topic the picked space has no claims for', () => {
+    render(<ClaimsTab />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Any topic/ }));
+    fireEvent.click(screen.getByRole('button', { name: 'Health' }));
+    expect(screen.getByRole('button', { name: /Health/ })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /Any space/ }));
+    fireEvent.click(screen.getByRole('button', { name: /Crypto/ }));
+
+    // Left held, it would filter the list from a chip that is no longer in the menu to unpick.
+    expect(screen.getByRole('button', { name: /Any topic/ })).toBeInTheDocument();
+    expect(screen.getByText('Models are getting cheaper')).toBeInTheDocument();
+  });
 });

--- a/apps/web/core/debates/matchmaking/claims-tab.test.tsx
+++ b/apps/web/core/debates/matchmaking/claims-tab.test.tsx
@@ -1,6 +1,6 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import '@testing-library/jest-dom/vitest';
-import { act, cleanup, fireEvent, render as rtlRender, screen } from '@testing-library/react';
+import { act, cleanup, fireEvent, render as rtlRender, screen, waitFor } from '@testing-library/react';
 
 import type { ReactElement } from 'react';
 
@@ -93,10 +93,18 @@ vi.mock('./hooks', () => ({
     // its menus describe both hang off that.
     const inSpace = mocks.claims.filter(entry => !spaceId || entry.claim.space_id === spaceId);
     const claims = inSpace.filter(entry => !topicId || entry.topics.some(topic => topic.id === topicId));
-    // The topic facet is narrowed by the space filter but *not* by the topic filter — picking a
-    // topic must not collapse the menu it came from. Computed over the whole space-filtered set
-    // rather than the returned page: that is the point of a server-side facet.
+    // Each dimension is counted without narrowing itself, and *is* narrowed by the other — what
+    // `MATCHMAKING_CLAIMS_FACETS_QUERY` does, and what a facet count is for. So the topic facet is
+    // cut by the space filter and the space facet by the topic filter; neither is cut by its own.
+    // Computed over the whole filtered set rather than the returned page, which is the point of a
+    // server-side facet.
     const topicFacets = [...new Map(inSpace.flatMap(entry => entry.topics).map(topic => [topic.id, topic])).values()];
+    const spacesCarryingTopic = new Set(
+      mocks.claims
+        .filter(entry => !topicId || entry.topics.some(topic => topic.id === topicId))
+        .map(entry => entry.claim.space_id)
+    );
+    const spaceFacetIds = topicId ? mocks.facetSpaceIds.filter(id => spacesCarryingTopic.has(id)) : mocks.facetSpaceIds;
     // Facets are computed over the whole filtered set while the page is a slice of it — the
     // shape that matters here, since the menu must not depend on how far the viewer has scrolled.
     const page = mocks.pageSize === null ? claims : claims.slice(0, mocks.pageSize);
@@ -106,9 +114,9 @@ vi.mock('./hooks', () => ({
           claims: page,
           next_cursor: null,
           facets: {
-            space_ids: mocks.facetSpaceIds,
+            space_ids: spaceFacetIds,
             topics: topicFacets,
-            space_facets: mocks.facetSpaceIds.map(id => ({ id, name: null, count: 1 })),
+            space_facets: spaceFacetIds.map(id => ({ id, name: null, count: 1 })),
             topic_facets: topicFacets.map(topic => ({ ...topic, count: 1 })),
           },
         },
@@ -177,7 +185,12 @@ vi.mock('~/core/sync/use-store', () => ({
 
 function render(ui: ReactElement) {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-  return rtlRender(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>);
+  const wrap = (node: ReactElement) => <QueryClientProvider client={queryClient}>{node}</QueryClientProvider>;
+  const view = rtlRender(wrap(ui));
+  // Testing Library's own `rerender` replaces the whole tree with what it is handed, which drops
+  // the provider — so a re-render of the same component crashes on a missing QueryClient rather
+  // than showing what changed. Re-wrapped here so a test can move the world and render again.
+  return { ...view, rerender: (next: ReactElement) => view.rerender(wrap(next)) };
 }
 
 const SPACE_ID = '019fedae-72b6-7ab2-927a-df044d57c566';
@@ -725,7 +738,7 @@ describe('topic menu', () => {
   // Disabling the query is not the same as having no data: it keeps the previous key's pages,
   // facets included. Narrowing from a populated scope to an empty one therefore left the last
   // scope's topic menu on screen over a list this tab had emptied.
-  it("drops the previous scope's menu when the eligible set narrows to nothing", () => {
+  it("drops the previous scope's menu when the eligible set narrows to nothing", async () => {
     mocks.spaceAllowlist = new Set([SPACE_ID.replace(/-/g, '')]);
     mocks.claims = [claim('claim-ai', 'Models are getting cheaper', false, false, SPACE_ID, [AI])];
     const view = render(<ClaimsTab />);
@@ -737,7 +750,8 @@ describe('topic menu', () => {
     mocks.spaceAllowlist = new Set();
     view.rerender(<ClaimsTab />);
 
-    expect(screen.queryByText('Models are getting cheaper')).toBeNull();
+    // The list animates its rows out, so the card outlives the render that dropped it.
+    await waitFor(() => expect(screen.queryByText('Models are getting cheaper')).toBeNull());
     fireEvent.click(screen.getByRole('button', { name: /Any topic/ }));
     expect(screen.queryByRole('button', { name: 'AI' })).toBeNull();
   });
@@ -781,18 +795,44 @@ describe('topic menu', () => {
     expect(screen.queryByRole('button', { name: 'Health' })).toBeNull();
   });
 
-  it('lets go of a selected topic the picked space has no claims for', () => {
-    render(<ClaimsTab />);
-
-    fireEvent.click(screen.getByRole('button', { name: /Any topic/ }));
-    fireEvent.click(screen.getByRole('button', { name: 'Health' }));
-    expect(screen.getByRole('button', { name: /Health/ })).toBeInTheDocument();
+  // Not reachable by picking one and then the other — each menu is narrowed by the other, so a
+  // topic with no claims in the picked space is never on offer to pick. It is reachable by the
+  // corpus moving underneath a selection that was valid when it was made.
+  it('lets go of a selected topic once the space stops having claims for it', () => {
+    const view = render(<ClaimsTab />);
 
     fireEvent.click(screen.getByRole('button', { name: /Any space/ }));
     fireEvent.click(screen.getByRole('button', { name: /Crypto/ }));
+    fireEvent.click(screen.getByRole('button', { name: /Any topic/ }));
+    fireEvent.click(screen.getByRole('button', { name: 'AI' }));
+    expect(screen.getByRole('button', { name: /AI/ })).toBeInTheDocument();
 
-    // Left held, it would filter the list from a chip that is no longer in the menu to unpick.
+    // The one AI claim in Crypto is answered, published elsewhere, or otherwise leaves the
+    // candidate set. Crypto now carries no AI claim, so the topic facet drops it.
+    mocks.claims = [claim('claim-health', 'Sleep is underrated', false, false, OTHER_SPACE_ID, [HEALTH])];
+    view.rerender(<ClaimsTab />);
+
+    // Left held, it would filter the list from a chip no longer in the menu to unpick.
     expect(screen.getByRole('button', { name: /Any topic/ })).toBeInTheDocument();
-    expect(screen.getByText('Models are getting cheaper')).toBeInTheDocument();
+  });
+
+  // The other dimension, which must behave differently. `space_facets` is narrowed by the topic
+  // selection — each dimension is counted without narrowing itself, so it is narrowed by the other
+  // — which means a space can drop out of the facet merely because *this combination* is empty.
+  // That is a reason to show an empty list, not to revise a choice the viewer made. Clearing it
+  // would silently discard the space the moment a topic, or a search, emptied the pair.
+  it('keeps a selected space when the current combination has nothing in it', () => {
+    const view = render(<ClaimsTab />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Any space/ }));
+    fireEvent.click(screen.getByRole('button', { name: /Crypto/ }));
+    fireEvent.click(screen.getByRole('button', { name: /Any topic/ }));
+    fireEvent.click(screen.getByRole('button', { name: 'AI' }));
+
+    // The AI claim moves out of Crypto, so the AI-narrowed space facet no longer names it.
+    mocks.claims = [claim('claim-ai', 'Models are getting cheaper', false, false, OTHER_SPACE_ID, [AI])];
+    view.rerender(<ClaimsTab />);
+
+    expect(screen.getByRole('button', { name: /Crypto/ })).toBeInTheDocument();
   });
 });

--- a/apps/web/core/debates/matchmaking/claims-tab.test.tsx
+++ b/apps/web/core/debates/matchmaking/claims-tab.test.tsx
@@ -54,8 +54,21 @@ vi.mock('~/core/debates/use-debate-publishable-spaces', async importOriginal => 
 }));
 
 vi.mock('./hooks', () => ({
-  useMatchmakingClaims: (query: unknown) => {
+  useMatchmakingClaims: (query: unknown, enabled: boolean) => {
     mocks.lastQuery = query;
+    // A disabled query fetches nothing and has no data — including no facets, which is what
+    // makes skipping it different from sending it unscoped.
+    if (!enabled) {
+      return {
+        data: undefined,
+        isLoading: false,
+        error: null,
+        hasNextPage: false,
+        isFetchingNextPage: false,
+        fetchNextPage: mocks.fetchNextPage,
+        refetch: vi.fn(),
+      };
+    }
     const { spaceId, topicId } = query as { spaceId?: string | null; topicId?: string | null };
     // `space_id` and `topic_id` are both query parameters as of GEO-2659, so the endpoint
     // returns only the rows that match. Mirrored here, because what the tab renders and what
@@ -626,6 +639,19 @@ describe('topic menu', () => {
     render(<ClaimsTab />);
 
     expect(mocks.lastQuery).toMatchObject({ spaceIds: [SPACE_ID.replace(/-/g, '')] });
+  });
+
+  // "No eligible spaces" and "no space filter" are the same request on the wire, so the query
+  // has to be skipped rather than sent unscoped: the rows would all be dropped here, but the
+  // facets would not, leaving a menu whose every option leads to an empty list.
+  it('asks for nothing at all when no space is eligible', () => {
+    mocks.spaceAllowlist = new Set();
+    mocks.claims = [claim('claim-ai', 'Models are getting cheaper', false, false, SPACE_ID, [AI])];
+    render(<ClaimsTab />);
+
+    expect(screen.queryByText('Models are getting cheaper')).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: /Any topic/ }));
+    expect(screen.queryByRole('button', { name: 'AI' })).toBeNull();
   });
 
   it('sends the picked space alone, never alongside the eligible list', () => {

--- a/apps/web/core/debates/matchmaking/claims-tab.test.tsx
+++ b/apps/web/core/debates/matchmaking/claims-tab.test.tsx
@@ -13,6 +13,7 @@ const mocks = vi.hoisted(() => ({
   claims: [] as MatchmakingClaim[],
   facetSpaceIds: [] as string[],
   pageSize: null as number | null,
+  lastEnabledData: undefined as unknown,
   spaceAllowlist: null as Set<string> | null,
   allowlistLoading: false,
   publishableSpaceIds: null as Set<string> | null,
@@ -56,14 +57,15 @@ vi.mock('~/core/debates/use-debate-publishable-spaces', async importOriginal => 
 vi.mock('./hooks', () => ({
   useMatchmakingClaims: (query: unknown, enabled: boolean) => {
     mocks.lastQuery = query;
-    // A disabled query fetches nothing and has no data — including no facets, which is what
-    // makes skipping it different from sending it unscoped.
+    // `placeholderData: keepPreviousData` outlives `enabled: false`, so a disabled query still
+    // hands back the last key's pages — facets included. Modelled, because a mock that returns
+    // nothing here makes masking look unnecessary.
     if (!enabled) {
       return {
-        data: undefined,
+        data: mocks.lastEnabledData,
         isLoading: false,
         error: null,
-        hasNextPage: false,
+        hasNextPage: true,
         isFetchingNextPage: false,
         fetchNextPage: mocks.fetchNextPage,
         refetch: vi.fn(),
@@ -82,21 +84,23 @@ vi.mock('./hooks', () => ({
     // Facets are computed over the whole filtered set while the page is a slice of it — the
     // shape that matters here, since the menu must not depend on how far the viewer has scrolled.
     const page = mocks.pageSize === null ? claims : claims.slice(0, mocks.pageSize);
-    return {
-      data: {
-        pages: [
-          {
-            claims: page,
-            next_cursor: null,
-            facets: {
-              space_ids: mocks.facetSpaceIds,
-              topics: topicFacets,
-              space_facets: mocks.facetSpaceIds.map(id => ({ id, name: null, count: 1 })),
-              topic_facets: topicFacets.map(topic => ({ ...topic, count: 1 })),
-            },
+    const data = {
+      pages: [
+        {
+          claims: page,
+          next_cursor: null,
+          facets: {
+            space_ids: mocks.facetSpaceIds,
+            topics: topicFacets,
+            space_facets: mocks.facetSpaceIds.map(id => ({ id, name: null, count: 1 })),
+            topic_facets: topicFacets.map(topic => ({ ...topic, count: 1 })),
           },
-        ],
-      },
+        },
+      ],
+    };
+    mocks.lastEnabledData = data;
+    return {
+      data,
       isLoading: false,
       error: null,
       hasNextPage: mocks.hasNextPage || page.length < claims.length,
@@ -202,6 +206,7 @@ beforeEach(() => {
   mocks.hasNextPage = false;
   mocks.facetSpaceIds = [];
   mocks.pageSize = null;
+  mocks.lastEnabledData = undefined;
   // Null + settled is "the allowlist lookup came back with nothing", which falls through to an
   // unfiltered list — what every pre-existing case here runs under.
   mocks.spaceAllowlist = null;
@@ -648,6 +653,26 @@ describe('topic menu', () => {
     mocks.spaceAllowlist = new Set();
     mocks.claims = [claim('claim-ai', 'Models are getting cheaper', false, false, SPACE_ID, [AI])];
     render(<ClaimsTab />);
+
+    expect(screen.queryByText('Models are getting cheaper')).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: /Any topic/ }));
+    expect(screen.queryByRole('button', { name: 'AI' })).toBeNull();
+  });
+
+  // Disabling the query is not the same as having no data: it keeps the previous key's pages,
+  // facets included. Narrowing from a populated scope to an empty one therefore left the last
+  // scope's topic menu on screen over a list this tab had emptied.
+  it("drops the previous scope's menu when the eligible set narrows to nothing", () => {
+    mocks.spaceAllowlist = new Set([SPACE_ID.replace(/-/g, '')]);
+    mocks.claims = [claim('claim-ai', 'Models are getting cheaper', false, false, SPACE_ID, [AI])];
+    const view = render(<ClaimsTab />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Any topic/ }));
+    expect(screen.getByRole('button', { name: 'AI' })).toBeInTheDocument();
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    mocks.spaceAllowlist = new Set();
+    view.rerender(<ClaimsTab />);
 
     expect(screen.queryByText('Models are getting cheaper')).toBeNull();
     fireEvent.click(screen.getByRole('button', { name: /Any topic/ }));

--- a/apps/web/core/debates/matchmaking/claims-tab.test.tsx
+++ b/apps/web/core/debates/matchmaking/claims-tab.test.tsx
@@ -18,6 +18,7 @@ const mocks = vi.hoisted(() => ({
   allowlistLoading: false,
   publishableSpaceIds: null as Set<string> | null,
   publishableLoading: false,
+  scopeHeldOver: false,
   sidebarData: null as unknown,
   fetchedSpaceIds: [] as string[][],
   spacesLoading: false,
@@ -71,6 +72,21 @@ vi.mock('./hooks', () => ({
         refetch: vi.fn(),
       };
     }
+    // A scope change is a key change like any other, so `keepPreviousData` answers it with the
+    // previous scope's pages while the new request is in flight. Modelled, because that hold is
+    // the whole of what the mask downstream is for.
+    if (mocks.scopeHeldOver) {
+      return {
+        data: mocks.lastEnabledData,
+        isLoading: false,
+        error: null,
+        hasNextPage: mocks.hasNextPage,
+        isFetchingNextPage: false,
+        isPlaceholderData: true,
+        fetchNextPage: mocks.fetchNextPage,
+        refetch: vi.fn(),
+      };
+    }
     const { spaceId, topicId } = query as { spaceId?: string | null; topicId?: string | null };
     // `space_id` and `topic_id` are both query parameters as of GEO-2659, so the endpoint
     // returns only the rows that match. Mirrored here, because what the tab renders and what
@@ -105,6 +121,7 @@ vi.mock('./hooks', () => ({
       error: null,
       hasNextPage: mocks.hasNextPage || page.length < claims.length,
       isFetchingNextPage: false,
+      isPlaceholderData: false,
       fetchNextPage: mocks.fetchNextPage,
       refetch: vi.fn(),
     };
@@ -207,6 +224,7 @@ beforeEach(() => {
   mocks.facetSpaceIds = [];
   mocks.pageSize = null;
   mocks.lastEnabledData = undefined;
+  mocks.scopeHeldOver = false;
   // Null + settled is "the allowlist lookup came back with nothing", which falls through to an
   // unfiltered list — what every pre-existing case here runs under.
   mocks.spaceAllowlist = null;

--- a/apps/web/core/debates/matchmaking/claims-tab.tsx
+++ b/apps/web/core/debates/matchmaking/claims-tab.tsx
@@ -151,13 +151,19 @@ export function ClaimsTab() {
 
   // Facets ride the first page, so they are absent until it lands and while a filter change is in
   // flight. That is "not known yet", not "no topics" — see `keepSelectableTopic`.
-  const topicsResolved = facets !== undefined && !claimsQuery.isLoading;
+  //
+  // Placeholder pages count as in flight. They are the previous filter's answer, held back so the
+  // list doesn't blink, and the rows on screen are theirs too — so the menu is not lying while
+  // they show. But they are not an answer to the filter now being asked about, and a selection
+  // cleared against them would be cleared on the wrong question.
+  const facetsSettled = facets !== undefined && !claimsQuery.isLoading && !claimsQuery.isPlaceholderData;
+  const topicsResolved = facetsSettled;
 
   // The same for the space itself: it can be picked while the gates are still passing everything,
   // and left selected it keeps going out on every request while its rows are dropped locally.
   React.useEffect(() => {
-    setSpaceId(current => keepSelectableSpace(current, facetSpaceIds, !spacesPending && facets !== undefined));
-  }, [facetSpaceIds, facets, spacesPending]);
+    setSpaceId(current => keepSelectableSpace(current, facetSpaceIds, !spacesPending && facetsSettled));
+  }, [facetSpaceIds, facetsSettled, spacesPending]);
 
   // Changing space with a topic held would otherwise leave the viewer filtered by a chip that is
   // no longer in the menu to unpick.

--- a/apps/web/core/debates/matchmaking/claims-tab.tsx
+++ b/apps/web/core/debates/matchmaking/claims-tab.tsx
@@ -10,7 +10,7 @@ import { spaceLabel, useSpaceLabels } from '~/core/hooks/use-space-labels';
 import { Input } from '~/design-system/input';
 
 import type { MatchmakingClaimsFilter, MatchmakingClaimsQuery } from '../api';
-import { isClaimSpaceAllowed } from '../claim-space-allowlist';
+import { eligibleClaimSpaceIds, isClaimSpaceAllowed } from '../claim-space-allowlist';
 import { useClaimSpaceAllowlist } from '../use-claim-space-allowlist';
 import { isSpaceDebatePublishable, useDebatePublishableSpaces } from '../use-debate-publishable-spaces';
 import { useMatchmakingClaims } from './hooks';
@@ -52,15 +52,6 @@ export function ClaimsTab() {
     return () => clearTimeout(timeout);
   }, [search]);
 
-  const query = React.useMemo<MatchmakingClaimsQuery>(
-    () => ({ search: debouncedSearch || null, spaceId, topicId, filter }),
-    [debouncedSearch, spaceId, topicId, filter]
-  );
-
-  const claimsQuery = useMatchmakingClaims(query, true);
-  const pages = React.useMemo(() => claimsQuery.data?.pages ?? [], [claimsQuery.data]);
-  const facets = pages[0]?.facets;
-
   const { allowlist: spaceAllowlist, isLoading: allowlistLoading } = useClaimSpaceAllowlist();
 
   // Until the allowlist settles there is no telling an allowed space from one the viewer has
@@ -91,6 +82,23 @@ export function ClaimsTab() {
       isSpaceDebatePublishable(candidateSpaceId, publishableSpaceIds),
     [publishableSpaceIds, spaceAllowlist]
   );
+
+  // Scopes the query — and so the facets it returns — to the spaces this viewer can actually be
+  // shown claims from. Without it the topic facet describes every space geo-chat knows, and a
+  // topic living only outside this set is offered over a list the gates below then empty.
+  const eligibleSpaceIds = React.useMemo(
+    () => eligibleClaimSpaceIds(spaceAllowlist, spaceShowsClaims),
+    [spaceAllowlist, spaceShowsClaims]
+  );
+
+  const query = React.useMemo<MatchmakingClaimsQuery>(
+    () => ({ search: debouncedSearch || null, spaceId, spaceIds: eligibleSpaceIds, topicId, filter }),
+    [debouncedSearch, spaceId, eligibleSpaceIds, topicId, filter]
+  );
+
+  const claimsQuery = useMatchmakingClaims(query, true);
+  const pages = React.useMemo(() => claimsQuery.data?.pages ?? [], [claimsQuery.data]);
+  const facets = pages[0]?.facets;
 
   const serverClaims = React.useMemo(
     () =>

--- a/apps/web/core/debates/matchmaking/claims-tab.tsx
+++ b/apps/web/core/debates/matchmaking/claims-tab.tsx
@@ -101,28 +101,35 @@ export function ClaimsTab() {
     [debouncedSearch, spaceId, eligibleSpaceIds, topicId, filter]
   );
 
-  const claimsQuery = useMatchmakingClaims(query, !hasNoEligibleSpaces);
+  // Not asked until the scope is known. Until then `spaceIds` is `null`, which geo-chat reads as
+  // "no filter", so the answer is about the whole corpus — and every row of it is dropped below by
+  // `spacesPending`, making the request pure waste on its own terms. What it leaves behind is not
+  // waste: `keepPreviousData` serves those pages back when the scope lands and the key changes,
+  // and while the rows are re-gated on the way out and the spaces are filtered on read, a topic
+  // facet carries no space to gate it by. The menu spent that window offering topics from spaces
+  // the list had already stopped showing.
+  const claimsQuery = useMatchmakingClaims(query, !hasNoEligibleSpaces && !spacesPending);
   // Masked rather than left to `enabled`. The hook keeps previous data across a key change, so a
-  // scope narrowing to nothing still hands back the last scope's pages — and while the rows are
-  // dropped below, the facets on them are not, which is the menu-over-an-empty-list this is meant
-  // to prevent.
+  // scope narrowing — to nothing, or from unknown to known — still hands back the last scope's
+  // pages, and while the rows are re-gated below the facets on them are not. That is the whole
+  // menu-over-an-empty-list this is meant to prevent, so it is the one place the scope is applied:
+  // everything downstream reads these pages and needs no guard of its own.
   const pages = React.useMemo(
-    () => (hasNoEligibleSpaces ? [] : (claimsQuery.data?.pages ?? [])),
-    [claimsQuery.data, hasNoEligibleSpaces]
+    () => (hasNoEligibleSpaces || spacesPending ? [] : (claimsQuery.data?.pages ?? [])),
+    [claimsQuery.data, hasNoEligibleSpaces, spacesPending]
   );
   const facets = pages[0]?.facets;
 
   const serverClaims = React.useMemo(
-    () =>
-      spacesPending ? [] : pages.flatMap(page => page.claims).filter(entry => spaceShowsClaims(entry.claim.space_id)),
-    [pages, spaceShowsClaims, spacesPending]
+    () => pages.flatMap(page => page.claims).filter(entry => spaceShowsClaims(entry.claim.space_id)),
+    [pages, spaceShowsClaims]
   );
 
   // The space menu offers only what the list can actually show, so picking an option never lands
   // the viewer on an empty list they can't explain.
   const facetSpaceIds = React.useMemo(
-    () => (spacesPending ? [] : (facets?.space_ids ?? []).filter(spaceShowsClaims)),
-    [facets?.space_ids, spaceShowsClaims, spacesPending]
+    () => (facets?.space_ids ?? []).filter(spaceShowsClaims),
+    [facets?.space_ids, spaceShowsClaims]
   );
 
   // The server re-sorts on every readiness change, so hold the order the user is looking at until
@@ -162,8 +169,8 @@ export function ClaimsTab() {
   // The same for the space itself: it can be picked while the gates are still passing everything,
   // and left selected it keeps going out on every request while its rows are dropped locally.
   React.useEffect(() => {
-    setSpaceId(current => keepSelectableSpace(current, facetSpaceIds, !spacesPending && facetsSettled));
-  }, [facetSpaceIds, facetsSettled, spacesPending]);
+    setSpaceId(current => keepSelectableSpace(current, facetSpaceIds, facetsSettled));
+  }, [facetSpaceIds, facetsSettled]);
 
   // Changing space with a topic held would otherwise leave the viewer filtered by a chip that is
   // no longer in the menu to unpick.

--- a/apps/web/core/debates/matchmaking/claims-tab.tsx
+++ b/apps/web/core/debates/matchmaking/claims-tab.tsx
@@ -13,13 +13,12 @@ import type { MatchmakingClaimsFilter, MatchmakingClaimsQuery } from '../api';
 import { eligibleClaimSpaceIds, isClaimSpaceAllowed, keepSelectableSpace } from '../claim-space-allowlist';
 import { useClaimSpaceAllowlist } from '../use-claim-space-allowlist';
 import { isSpaceDebatePublishable, useDebatePublishableSpaces } from '../use-debate-publishable-spaces';
-import { useMatchmakingClaims } from './hooks';
 import { HubFilterMenu, type HubFilterOption } from './hub-filter-menu';
 import { HubCardList } from './hub-motion';
 import { HubQueryState } from './hub-states';
 import { MatchmakingClaimCard } from './matchmaking-claim-card';
 import { keepSelectableTopic } from './topic-facets';
-import { useScopeHeldOver } from './use-scope-holdover';
+import { useScopedMatchmakingClaims } from './use-scoped-claims';
 import { useStableListOrder } from './use-stable-list-order';
 
 const SEARCH_DEBOUNCE_MS = 250;
@@ -92,38 +91,20 @@ export function ClaimsTab() {
     [spaceAllowlist, spaceShowsClaims]
   );
 
-  // A known-empty scope is not the same as no scope. geo-chat reads "no ids" as "no filter", so
-  // omitting it would fetch the unfiltered corpus — and while `serverClaims` drops every row of
-  // it, the facets are not filtered, leaving a menu whose every option leads to an empty list.
-  const hasNoEligibleSpaces = eligibleSpaceIds !== null && eligibleSpaceIds.length === 0;
-
-  const query = React.useMemo<MatchmakingClaimsQuery>(
-    () => ({ search: debouncedSearch || null, spaceId, spaceIds: eligibleSpaceIds, topicId, filter }),
-    [debouncedSearch, spaceId, eligibleSpaceIds, topicId, filter]
+  const query = React.useMemo<Omit<MatchmakingClaimsQuery, 'spaceIds'>>(
+    () => ({ search: debouncedSearch || null, spaceId, topicId, filter }),
+    [debouncedSearch, spaceId, topicId, filter]
   );
 
-  // Not asked until the scope is known. Until then `spaceIds` is `null`, which geo-chat reads as
-  // "no filter", so the answer is about the whole corpus — and every row of it is dropped below by
-  // `spacesPending`, making the request pure waste on its own terms. What it leaves behind is not
-  // waste: `keepPreviousData` serves those pages back when the scope lands and the key changes,
-  // and while the rows are re-gated on the way out and the spaces are filtered on read, a topic
-  // facet carries no space to gate it by. The menu spent that window offering topics from spaces
-  // the list had already stopped showing.
-  const claimsQuery = useMatchmakingClaims(query, !hasNoEligibleSpaces && !spacesPending);
-  // Masked rather than left to `enabled`. The hook keeps previous data across a key change, so a
-  // scope narrowing — to nothing, or from unknown to known — still hands back the last scope's
-  // pages, and while the rows are re-gated below the facets on them are not. That is the whole
-  // menu-over-an-empty-list this is meant to prevent, so it is the one place the scope is applied:
-  // everything downstream reads these pages and needs no guard of its own.
-  // A settled scope can still change — the allowlist refetches, someone joins a space — and that
-  // moves no loading flag, so `spacesPending` above says nothing about it.
-  const scopeHeldOver = useScopeHeldOver(eligibleSpaceIds?.join(',') ?? null, claimsQuery.isPlaceholderData);
-
-  const pages = React.useMemo(
-    () => (hasNoEligibleSpaces || spacesPending || scopeHeldOver ? [] : (claimsQuery.data?.pages ?? [])),
-    [claimsQuery.data, hasNoEligibleSpaces, scopeHeldOver, spacesPending]
+  const scope = React.useMemo(
+    () => ({ spaceIds: eligibleSpaceIds, pending: spacesPending }),
+    [eligibleSpaceIds, spacesPending]
   );
-  const facets = pages[0]?.facets;
+
+  // Every way the pages can describe a wider corpus than this tab will show is handled in there,
+  // once, for both pickers — see `useScopedMatchmakingClaims`.
+  const claimsQuery = useScopedMatchmakingClaims(query, scope);
+  const { pages, facets } = claimsQuery;
 
   const serverClaims = React.useMemo(
     () => pages.flatMap(page => page.claims).filter(entry => spaceShowsClaims(entry.claim.space_id)),
@@ -161,15 +142,7 @@ export function ClaimsTab() {
     [facets?.topic_facets]
   );
 
-  // Facets ride the first page, so they are absent until it lands and while a filter change is in
-  // flight. That is "not known yet", not "no topics" — see `keepSelectableTopic`.
-  //
-  // Placeholder pages count as in flight. They are the previous filter's answer, held back so the
-  // list doesn't blink, and the rows on screen are theirs too — so the menu is not lying while
-  // they show. But they are not an answer to the filter now being asked about, and a selection
-  // cleared against them would be cleared on the wrong question.
-  const facetsSettled = facets !== undefined && !claimsQuery.isLoading && !claimsQuery.isPlaceholderData;
-  const topicsResolved = facetsSettled;
+  const { facetsSettled } = claimsQuery;
 
   // The same for the space itself: it can be picked while the gates are still passing everything,
   // and left selected it keeps going out on every request while its rows are dropped locally.
@@ -180,13 +153,13 @@ export function ClaimsTab() {
   // Changing space with a topic held would otherwise leave the viewer filtered by a chip that is
   // no longer in the menu to unpick.
   React.useEffect(() => {
-    setTopicId(current => keepSelectableTopic(current, facetTopics, topicsResolved));
-  }, [facetTopics, topicsResolved]);
+    setTopicId(current => keepSelectableTopic(current, facetTopics, facetsSettled));
+  }, [facetTopics, facetsSettled]);
 
   const hasFilters = Boolean(debouncedSearch || spaceId || topicId || filter !== 'all');
 
   const sentinelRef = useInfiniteScrollSentinel({
-    hasNextPage: !hasNoEligibleSpaces && claimsQuery.hasNextPage,
+    hasNextPage: claimsQuery.hasNextPage,
     isFetchingNextPage: claimsQuery.isFetchingNextPage,
     fetchNextPage: claimsQuery.fetchNextPage,
   });
@@ -267,7 +240,7 @@ export function ClaimsTab() {
           Not while the allowlist is pending, though: the tab is showing a four-row skeleton then,
           so the sentinel sits in view under it and pages the corpus on the strength of a loading
           state being visible — reading "the viewer reached the end" off a list that isn't there. */}
-        {!hasNoEligibleSpaces && claimsQuery.hasNextPage && !spacesPending ? (
+        {claimsQuery.hasNextPage ? (
           <div ref={sentinelRef} data-testid="claims-scroll-sentinel" className="h-px" />
         ) : null}
       </div>

--- a/apps/web/core/debates/matchmaking/claims-tab.tsx
+++ b/apps/web/core/debates/matchmaking/claims-tab.tsx
@@ -23,6 +23,7 @@ import { HubFilterMenu, type HubFilterOption } from './hub-filter-menu';
 import { HubCardList } from './hub-motion';
 import { HubQueryState } from './hub-states';
 import { MatchmakingClaimCard } from './matchmaking-claim-card';
+import { availableTopics, keepSelectableTopic } from './topic-facets';
 import { useStableListOrder } from './use-stable-list-order';
 
 const SEARCH_DEBOUNCE_MS = 250;
@@ -122,11 +123,21 @@ export function ClaimsTab() {
     () => [...new Set(claims.map(entry => entry.claim.claim_entity_id).filter(validateEntityId))],
     [claims]
   );
-  const { entities: claimEntities } = useQueryEntities({
+  const {
+    entities: claimEntities,
+    isFetched: claimEntitiesFetched,
+    isPlaceholderData: claimEntitiesArePrevious,
+  } = useQueryEntities({
     where: { id: { in: claimEntityIds } },
     enabled: claimEntityIds.length > 0,
     placeholderData: keepPreviousData,
   });
+
+  // Whether `facetTopics` below is the finished answer for the filters currently applied. The
+  // lookup keeps its previous data while the next one is in flight, so "fetched" alone still
+  // describes the last set of claims — and no claims at all is a resolved answer of its own.
+  const topicsResolved =
+    !claimsQuery.isLoading && (claimEntityIds.length === 0 || (claimEntitiesFetched && !claimEntitiesArePrevious));
 
   const topicsByClaimId = React.useMemo(() => {
     const map = new Map<string, MatchmakingTopic[]>();
@@ -139,15 +150,27 @@ export function ClaimsTab() {
     return map;
   }, [claimEntities]);
 
-  const facetTopics = React.useMemo(() => {
-    const seen = new Map<string, MatchmakingTopic>();
-    for (const topics of topicsByClaimId.values()) {
-      for (const topic of topics) {
-        if (!seen.has(topic.id)) seen.set(topic.id, topic);
-      }
-    }
-    return [...seen.values()].sort((a, b) => (a.name ?? '').localeCompare(b.name ?? ''));
-  }, [topicsByClaimId]);
+  // Read off `claims` rather than off every entity the topic lookup has resolved. The two drift
+  // whenever a filter changes: the entity query holds its previous data while the next one is in
+  // flight, so a menu built from it keeps offering topics belonging to claims that are no longer
+  // in the list — and picking one of those lands the viewer on an empty result (GEO-2653).
+  //
+  // No space term is needed here, unlike the rematch picker: `spaceId` goes into the claims query
+  // itself, so `claims` is already only the selected space's.
+  const facetTopics = React.useMemo(
+    () =>
+      availableTopics(
+        claims.map(entry => entry.claim.claim_entity_id),
+        topicsByClaimId
+      ),
+    [claims, topicsByClaimId]
+  );
+
+  // Changing space with a topic held would otherwise leave the viewer filtered by a chip that is
+  // no longer in the menu to unpick.
+  React.useEffect(() => {
+    setTopicId(current => keepSelectableTopic(current, facetTopics, topicsResolved));
+  }, [facetTopics, topicsResolved]);
 
   const hasFilters = Boolean(debouncedSearch || spaceId || topicId || filter !== 'all');
 

--- a/apps/web/core/debates/matchmaking/claims-tab.tsx
+++ b/apps/web/core/debates/matchmaking/claims-tab.tsx
@@ -246,7 +246,7 @@ export function ClaimsTab() {
           Not while the allowlist is pending, though: the tab is showing a four-row skeleton then,
           so the sentinel sits in view under it and pages the corpus on the strength of a loading
           state being visible — reading "the viewer reached the end" off a list that isn't there. */}
-      {claimsQuery.hasNextPage && !spacesPending ? (
+      {!hasNoEligibleSpaces && claimsQuery.hasNextPage && !spacesPending ? (
         <div ref={sentinelRef} data-testid="claims-scroll-sentinel" className="h-px" />
       ) : null}
     </div>

--- a/apps/web/core/debates/matchmaking/claims-tab.tsx
+++ b/apps/web/core/debates/matchmaking/claims-tab.tsx
@@ -10,7 +10,7 @@ import { spaceLabel, useSpaceLabels } from '~/core/hooks/use-space-labels';
 import { Input } from '~/design-system/input';
 
 import type { MatchmakingClaimsFilter, MatchmakingClaimsQuery } from '../api';
-import { eligibleClaimSpaceIds, isClaimSpaceAllowed, keepSelectableSpace } from '../claim-space-allowlist';
+import { eligibleClaimSpaceIds, isClaimSpaceAllowed } from '../claim-space-allowlist';
 import { useClaimSpaceAllowlist } from '../use-claim-space-allowlist';
 import { isSpaceDebatePublishable, useDebatePublishableSpaces } from '../use-debate-publishable-spaces';
 import { HubFilterMenu, type HubFilterOption } from './hub-filter-menu';
@@ -151,11 +151,25 @@ export function ClaimsTab() {
 
   const { facetsSettled } = claimsQuery;
 
-  // The same for the space itself: it can be picked while the gates are still passing everything,
-  // and left selected it keeps going out on every request while its rows are dropped locally.
+  // The space is let go on the condition that actually means "not yours to pick" — the gates
+  // stopped admitting it — rather than on its absence from the facet.
+  //
+  // Absence means something else here. `space_facets` is narrowed by the *topic* selection, the
+  // mirror of the topic facet being narrowed by the space one: each dimension is counted without
+  // narrowing itself, which is what makes a facet count answer "how many of what I have chosen so
+  // far are in here". So a space drops out of it whenever the current combination is empty — a
+  // topic with nothing in that space, or a search that matches nothing there. That is a reason to
+  // show an empty list, not to revise an input the viewer chose. Clearing on it would discard the
+  // space the moment a topic or a search emptied the pair, silently and without their asking.
+  //
+  // The topic goes the other way for the same reason, not despite it: it is the narrower of the
+  // two, and a topic the space no longer carries is genuinely gone from the menu that offered it.
+  // Held while the lookups are still out: until they land the gates pass everything, so a space
+  // cleared against them would be cleared on nothing.
   React.useEffect(() => {
-    setSpaceId(current => keepSelectableSpace(current, facetSpaceIds, facetsSettled));
-  }, [facetSpaceIds, facetsSettled]);
+    if (spacesPending) return;
+    setSpaceId(current => (current !== null && !spaceShowsClaims(current) ? null : current));
+  }, [spaceShowsClaims, spacesPending]);
 
   // Changing space with a topic held would otherwise leave the viewer filtered by a chip that is
   // no longer in the menu to unpick.

--- a/apps/web/core/debates/matchmaking/claims-tab.tsx
+++ b/apps/web/core/debates/matchmaking/claims-tab.tsx
@@ -10,7 +10,7 @@ import { spaceLabel, useSpaceLabels } from '~/core/hooks/use-space-labels';
 import { Input } from '~/design-system/input';
 
 import type { MatchmakingClaimsFilter, MatchmakingClaimsQuery } from '../api';
-import { eligibleClaimSpaceIds, isClaimSpaceAllowed } from '../claim-space-allowlist';
+import { eligibleClaimSpaceIds, isClaimSpaceAllowed, keepSelectableSpace } from '../claim-space-allowlist';
 import { useClaimSpaceAllowlist } from '../use-claim-space-allowlist';
 import { isSpaceDebatePublishable, useDebatePublishableSpaces } from '../use-debate-publishable-spaces';
 import { useMatchmakingClaims } from './hooks';
@@ -102,7 +102,14 @@ export function ClaimsTab() {
   );
 
   const claimsQuery = useMatchmakingClaims(query, !hasNoEligibleSpaces);
-  const pages = React.useMemo(() => claimsQuery.data?.pages ?? [], [claimsQuery.data]);
+  // Masked rather than left to `enabled`. The hook keeps previous data across a key change, so a
+  // scope narrowing to nothing still hands back the last scope's pages — and while the rows are
+  // dropped below, the facets on them are not, which is the menu-over-an-empty-list this is meant
+  // to prevent.
+  const pages = React.useMemo(
+    () => (hasNoEligibleSpaces ? [] : (claimsQuery.data?.pages ?? [])),
+    [claimsQuery.data, hasNoEligibleSpaces]
+  );
   const facets = pages[0]?.facets;
 
   const serverClaims = React.useMemo(
@@ -146,6 +153,12 @@ export function ClaimsTab() {
   // flight. That is "not known yet", not "no topics" — see `keepSelectableTopic`.
   const topicsResolved = facets !== undefined && !claimsQuery.isLoading;
 
+  // The same for the space itself: it can be picked while the gates are still passing everything,
+  // and left selected it keeps going out on every request while its rows are dropped locally.
+  React.useEffect(() => {
+    setSpaceId(current => keepSelectableSpace(current, facetSpaceIds, !spacesPending && facets !== undefined));
+  }, [facetSpaceIds, facets, spacesPending]);
+
   // Changing space with a topic held would otherwise leave the viewer filtered by a chip that is
   // no longer in the menu to unpick.
   React.useEffect(() => {
@@ -155,7 +168,7 @@ export function ClaimsTab() {
   const hasFilters = Boolean(debouncedSearch || spaceId || topicId || filter !== 'all');
 
   const sentinelRef = useInfiniteScrollSentinel({
-    hasNextPage: claimsQuery.hasNextPage,
+    hasNextPage: !hasNoEligibleSpaces && claimsQuery.hasNextPage,
     isFetchingNextPage: claimsQuery.isFetchingNextPage,
     fetchNextPage: claimsQuery.fetchNextPage,
   });

--- a/apps/web/core/debates/matchmaking/claims-tab.tsx
+++ b/apps/web/core/debates/matchmaking/claims-tab.tsx
@@ -19,6 +19,7 @@ import { HubCardList } from './hub-motion';
 import { HubQueryState } from './hub-states';
 import { MatchmakingClaimCard } from './matchmaking-claim-card';
 import { keepSelectableTopic } from './topic-facets';
+import { useScopeHeldOver } from './use-scope-holdover';
 import { useStableListOrder } from './use-stable-list-order';
 
 const SEARCH_DEBOUNCE_MS = 250;
@@ -114,9 +115,13 @@ export function ClaimsTab() {
   // pages, and while the rows are re-gated below the facets on them are not. That is the whole
   // menu-over-an-empty-list this is meant to prevent, so it is the one place the scope is applied:
   // everything downstream reads these pages and needs no guard of its own.
+  // A settled scope can still change — the allowlist refetches, someone joins a space — and that
+  // moves no loading flag, so `spacesPending` above says nothing about it.
+  const scopeHeldOver = useScopeHeldOver(eligibleSpaceIds?.join(',') ?? null, claimsQuery.isPlaceholderData);
+
   const pages = React.useMemo(
-    () => (hasNoEligibleSpaces || spacesPending ? [] : (claimsQuery.data?.pages ?? [])),
-    [claimsQuery.data, hasNoEligibleSpaces, spacesPending]
+    () => (hasNoEligibleSpaces || spacesPending || scopeHeldOver ? [] : (claimsQuery.data?.pages ?? [])),
+    [claimsQuery.data, hasNoEligibleSpaces, scopeHeldOver, spacesPending]
   );
   const facets = pages[0]?.facets;
 

--- a/apps/web/core/debates/matchmaking/claims-tab.tsx
+++ b/apps/web/core/debates/matchmaking/claims-tab.tsx
@@ -86,9 +86,16 @@ export function ClaimsTab() {
   // Scopes the query — and so the facets it returns — to the spaces this viewer can actually be
   // shown claims from. Without it the topic facet describes every space geo-chat knows, and a
   // topic living only outside this set is offered over a list the gates below then empty.
+  //
+  // The allowlist can settle without an answer, which deliberately does not filter — a list that
+  // is too wide beats a panel that never fills. That is a reason to stop narrowing by *it*, not a
+  // reason to stop narrowing: the publishable set is a different question, and when it has an
+  // answer it still bounds which spaces can be shown. Falling through to it keeps the facets over
+  // the same spaces the rows are drawn from, rather than over everything geo-chat knows.
+  const candidateSpaceIds = spaceAllowlist ?? publishableSpaceIds;
   const eligibleSpaceIds = React.useMemo(
-    () => eligibleClaimSpaceIds(spaceAllowlist, spaceShowsClaims),
-    [spaceAllowlist, spaceShowsClaims]
+    () => eligibleClaimSpaceIds(candidateSpaceIds, spaceShowsClaims),
+    [candidateSpaceIds, spaceShowsClaims]
   );
 
   const query = React.useMemo<Omit<MatchmakingClaimsQuery, 'spaceIds'>>(

--- a/apps/web/core/debates/matchmaking/claims-tab.tsx
+++ b/apps/web/core/debates/matchmaking/claims-tab.tsx
@@ -91,12 +91,17 @@ export function ClaimsTab() {
     [spaceAllowlist, spaceShowsClaims]
   );
 
+  // A known-empty scope is not the same as no scope. geo-chat reads "no ids" as "no filter", so
+  // omitting it would fetch the unfiltered corpus — and while `serverClaims` drops every row of
+  // it, the facets are not filtered, leaving a menu whose every option leads to an empty list.
+  const hasNoEligibleSpaces = eligibleSpaceIds !== null && eligibleSpaceIds.length === 0;
+
   const query = React.useMemo<MatchmakingClaimsQuery>(
     () => ({ search: debouncedSearch || null, spaceId, spaceIds: eligibleSpaceIds, topicId, filter }),
     [debouncedSearch, spaceId, eligibleSpaceIds, topicId, filter]
   );
 
-  const claimsQuery = useMatchmakingClaims(query, true);
+  const claimsQuery = useMatchmakingClaims(query, !hasNoEligibleSpaces);
   const pages = React.useMemo(() => claimsQuery.data?.pages ?? [], [claimsQuery.data]);
   const facets = pages[0]?.facets;
 

--- a/apps/web/core/debates/matchmaking/claims-tab.tsx
+++ b/apps/web/core/debates/matchmaking/claims-tab.tsx
@@ -1,20 +1,15 @@
 'use client';
 
-import { keepPreviousData } from '@tanstack/react-query';
-
 import * as React from 'react';
 
 import cx from 'classnames';
 
-import { TOPICS_PROPERTY_ID } from '~/core/claims/ontology';
 import { useInfiniteScrollSentinel } from '~/core/hooks/use-infinite-scroll-sentinel';
 import { spaceLabel, useSpaceLabels } from '~/core/hooks/use-space-labels';
-import { useQueryEntities } from '~/core/sync/use-store';
-import { validateEntityId } from '~/core/utils/utils';
 
 import { Input } from '~/design-system/input';
 
-import type { MatchmakingClaimsFilter, MatchmakingClaimsQuery, MatchmakingTopic } from '../api';
+import type { MatchmakingClaimsFilter, MatchmakingClaimsQuery } from '../api';
 import { isClaimSpaceAllowed } from '../claim-space-allowlist';
 import { useClaimSpaceAllowlist } from '../use-claim-space-allowlist';
 import { isSpaceDebatePublishable, useDebatePublishableSpaces } from '../use-debate-publishable-spaces';
@@ -23,7 +18,7 @@ import { HubFilterMenu, type HubFilterOption } from './hub-filter-menu';
 import { HubCardList } from './hub-motion';
 import { HubQueryState } from './hub-states';
 import { MatchmakingClaimCard } from './matchmaking-claim-card';
-import { availableTopics, keepSelectableTopic } from './topic-facets';
+import { keepSelectableTopic } from './topic-facets';
 import { useStableListOrder } from './use-stable-list-order';
 
 const SEARCH_DEBOUNCE_MS = 250;
@@ -58,8 +53,8 @@ export function ClaimsTab() {
   }, [search]);
 
   const query = React.useMemo<MatchmakingClaimsQuery>(
-    () => ({ search: debouncedSearch || null, spaceId, filter }),
-    [debouncedSearch, spaceId, filter]
+    () => ({ search: debouncedSearch || null, spaceId, topicId, filter }),
+    [debouncedSearch, spaceId, topicId, filter]
   );
 
   const claimsQuery = useMatchmakingClaims(query, true);
@@ -98,7 +93,8 @@ export function ClaimsTab() {
   );
 
   const serverClaims = React.useMemo(
-    () => (spacesPending ? [] : pages.flatMap(page => page.claims).filter(entry => spaceShowsClaims(entry.claim.space_id))),
+    () =>
+      spacesPending ? [] : pages.flatMap(page => page.claims).filter(entry => spaceShowsClaims(entry.claim.space_id)),
     [pages, spaceShowsClaims, spacesPending]
   );
 
@@ -114,57 +110,28 @@ export function ClaimsTab() {
   const claims = useStableListOrder(
     serverClaims,
     entry => `${entry.claim.space_id}:${entry.claim.claim_entity_id}`,
-    `${debouncedSearch}|${spaceId ?? ''}|${filter}`
+    `${debouncedSearch}|${spaceId ?? ''}|${topicId ?? ''}|${filter}`
   );
 
-  // Only real entity ids can be looked up in the KG; the graph 400s the whole batch on a single
-  // malformed id, so drop any that aren't valid.
-  const claimEntityIds = React.useMemo(
-    () => [...new Set(claims.map(entry => entry.claim.claim_entity_id).filter(validateEntityId))],
-    [claims]
-  );
-  const {
-    entities: claimEntities,
-    isFetched: claimEntitiesFetched,
-    isPlaceholderData: claimEntitiesArePrevious,
-  } = useQueryEntities({
-    where: { id: { in: claimEntityIds } },
-    enabled: claimEntityIds.length > 0,
-    placeholderData: keepPreviousData,
-  });
-
-  // Whether `facetTopics` below is the finished answer for the filters currently applied. The
-  // lookup keeps its previous data while the next one is in flight, so "fetched" alone still
-  // describes the last set of claims — and no claims at all is a resolved answer of its own.
-  const topicsResolved =
-    !claimsQuery.isLoading && (claimEntityIds.length === 0 || (claimEntitiesFetched && !claimEntitiesArePrevious));
-
-  const topicsByClaimId = React.useMemo(() => {
-    const map = new Map<string, MatchmakingTopic[]>();
-    for (const entity of claimEntities) {
-      const topics = entity.relations
-        .filter(relation => relation.type.id === TOPICS_PROPERTY_ID && relation.isDeleted !== true)
-        .map(relation => ({ id: relation.toEntity.id, name: relation.toEntity.name ?? null }));
-      if (topics.length > 0) map.set(entity.id, topics);
-    }
-    return map;
-  }, [claimEntities]);
-
-  // Read off `claims` rather than off every entity the topic lookup has resolved. The two drift
-  // whenever a filter changes: the entity query holds its previous data while the next one is in
-  // flight, so a menu built from it keeps offering topics belonging to claims that are no longer
-  // in the list — and picking one of those lands the viewer on an empty result (GEO-2653).
+  // The topic menu, straight from the server. It describes every claim the current filters
+  // allow, not the pages loaded so far — which is what the client-side version could never do:
+  // it read topics off the loaded claims, so the menu grew as the viewer scrolled and a space
+  // whose first page happened to carry none looked like a space with no topics (GEO-2653).
   //
-  // No space term is needed here, unlike the rematch picker: `spaceId` goes into the claims query
-  // itself, so `claims` is already only the selected space's.
+  // Already narrowed by the space filter, and already ordered — by count, descending. Kept in
+  // name order here so this change is about which options exist rather than how they are
+  // arranged; the count order and the counts themselves belong to GEO-2654.
   const facetTopics = React.useMemo(
     () =>
-      availableTopics(
-        claims.map(entry => entry.claim.claim_entity_id),
-        topicsByClaimId
-      ),
-    [claims, topicsByClaimId]
+      [...(facets?.topic_facets ?? [])]
+        .map(facet => ({ id: facet.id, name: facet.name }))
+        .sort((a, b) => (a.name ?? '').localeCompare(b.name ?? '')),
+    [facets?.topic_facets]
   );
+
+  // Facets ride the first page, so they are absent until it lands and while a filter change is in
+  // flight. That is "not known yet", not "no topics" — see `keepSelectableTopic`.
+  const topicsResolved = facets !== undefined && !claimsQuery.isLoading;
 
   // Changing space with a topic held would otherwise leave the viewer filtered by a chip that is
   // no longer in the menu to unpick.
@@ -179,14 +146,6 @@ export function ClaimsTab() {
     isFetchingNextPage: claimsQuery.isFetchingNextPage,
     fetchNextPage: claimsQuery.fetchNextPage,
   });
-
-  const visibleClaims = React.useMemo(
-    () =>
-      topicId
-        ? claims.filter(entry => topicsByClaimId.get(entry.claim.claim_entity_id)?.some(topic => topic.id === topicId))
-        : claims,
-    [claims, topicsByClaimId, topicId]
-  );
 
   return (
     <div className="flex flex-col gap-3 px-4 py-3">
@@ -219,7 +178,7 @@ export function ClaimsTab() {
         isLoading={claimsQuery.isLoading || spacesPending}
         error={claimsQuery.error}
         onRetry={() => void claimsQuery.refetch()}
-        isEmpty={visibleClaims.length === 0}
+        isEmpty={claims.length === 0}
         emptyMessage={hasFilters ? 'No claims match these filters.' : 'No debatable claims yet.'}
         emptyAction={
           hasFilters
@@ -239,7 +198,7 @@ export function ClaimsTab() {
             re-ranked the tab by something the Position filter in the dropdown already covers, and
             it moved a card between two sections the moment you took a side. */}
         <HubCardList>
-          {visibleClaims.map(entry => (
+          {claims.map(entry => (
             <MatchmakingClaimCard
               key={`${entry.claim.space_id}:${entry.claim.claim_entity_id}`}
               claim={entry.claim}

--- a/apps/web/core/debates/matchmaking/topic-facets.test.ts
+++ b/apps/web/core/debates/matchmaking/topic-facets.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+
+import type { MatchmakingTopic } from '~/core/debates/api';
+
+import { availableTopics, keepSelectableTopic } from './topic-facets';
+
+const ai: MatchmakingTopic = { id: 'topic-ai', name: 'AI' };
+const health: MatchmakingTopic = { id: 'topic-health', name: 'Health' };
+const unnamed: MatchmakingTopic = { id: 'topic-unnamed', name: null };
+
+const topicsByClaimId = new Map<string, MatchmakingTopic[]>([
+  ['claim-in-crypto', [ai]],
+  ['claim-in-health', [health]],
+  ['claim-in-both', [ai, health]],
+  ['claim-unnamed-topic', [unnamed]],
+]);
+
+describe('availableTopics', () => {
+  it('offers only the topics carried by the claims it is given', () => {
+    expect(availableTopics(['claim-in-crypto'], topicsByClaimId)).toEqual([ai]);
+  });
+
+  it('drops a topic once its claims are filtered out', () => {
+    // The bug: filter to a space holding only the health claim and AI stayed on the menu,
+    // where picking it could only ever produce an empty list.
+    expect(availableTopics(['claim-in-health'], topicsByClaimId).map(topic => topic.id)).toEqual(['topic-health']);
+  });
+
+  it('deduplicates a topic carried by more than one claim', () => {
+    expect(availableTopics(['claim-in-crypto', 'claim-in-both'], topicsByClaimId)).toEqual([ai, health]);
+  });
+
+  it('sorts by name and tolerates a topic without one', () => {
+    expect(
+      availableTopics(['claim-in-health', 'claim-unnamed-topic', 'claim-in-crypto'], topicsByClaimId).map(
+        topic => topic.name
+      )
+    ).toEqual([null, 'AI', 'Health']);
+  });
+
+  it('is empty when the claims carry no topics', () => {
+    expect(availableTopics(['claim-with-no-topics'], topicsByClaimId)).toEqual([]);
+  });
+});
+
+describe('keepSelectableTopic', () => {
+  it('keeps a selection the menu still offers', () => {
+    expect(keepSelectableTopic('topic-ai', [ai, health], true)).toBe('topic-ai');
+  });
+
+  it('drops a selection the menu no longer offers', () => {
+    expect(keepSelectableTopic('topic-ai', [health], true)).toBeNull();
+  });
+
+  it('drops a selection when the picked space turns out to have no topics at all', () => {
+    // The case that "empty means still loading" got wrong: a space whose claims carry no
+    // topics is a resolved answer, and leaving the topic held stranded the viewer on an
+    // empty list with no chip in the menu to clear.
+    expect(keepSelectableTopic('topic-ai', [], true)).toBeNull();
+  });
+
+  it('holds the selection while the topics are still unresolved', () => {
+    // The Claims tab resolves topics a round trip behind its claims, so every filter change
+    // has a moment with nothing resolved. Clearing then would discard a selection that is
+    // about to be valid again.
+    expect(keepSelectableTopic('topic-ai', [], false)).toBe('topic-ai');
+    expect(keepSelectableTopic('topic-ai', [health], false)).toBe('topic-ai');
+  });
+
+  it('leaves an empty selection alone', () => {
+    expect(keepSelectableTopic(null, [ai], true)).toBeNull();
+  });
+});

--- a/apps/web/core/debates/matchmaking/topic-facets.ts
+++ b/apps/web/core/debates/matchmaking/topic-facets.ts
@@ -1,0 +1,56 @@
+import type { MatchmakingTopic } from '~/core/debates/api';
+
+/**
+ * Which topics the topic menu should offer, and what to do with a selection the menu no
+ * longer holds.
+ *
+ * geo-chat doesn't model topics — it returns `topics: []` and ignores `topic_id` — so both
+ * pickers resolve them from the Knowledge Graph over the claims they have loaded. That makes
+ * the menu's contents a client-side decision, and the one it was getting wrong: a topic with
+ * no claims behind it is an option that can only ever produce an empty list.
+ */
+
+/**
+ * The topics carried by `claimEntityIds`, deduplicated and sorted by name.
+ *
+ * Callers pass the claims every *other* filter allows — space, search, whichever tab — but
+ * not the topic filter itself. Narrowing by the current topic too would collapse the menu to
+ * the one option already chosen and strand the viewer there.
+ */
+export function availableTopics(
+  claimEntityIds: Iterable<string>,
+  topicsByClaimId: ReadonlyMap<string, MatchmakingTopic[]>
+): MatchmakingTopic[] {
+  const seen = new Map<string, MatchmakingTopic>();
+  for (const claimEntityId of claimEntityIds) {
+    for (const topic of topicsByClaimId.get(claimEntityId) ?? []) {
+      if (!seen.has(topic.id)) seen.set(topic.id, topic);
+    }
+  }
+  return [...seen.values()].sort((a, b) => (a.name ?? '').localeCompare(b.name ?? ''));
+}
+
+/**
+ * The topic that should stay selected once `available` has changed under it.
+ *
+ * Drops a selection the menu no longer offers: changing space with a topic held would
+ * otherwise leave the viewer on an empty list, filtered by a chip that is no longer in the
+ * menu to unpick.
+ *
+ * `isResolved` says whether `available` is the finished answer for the current filters. It is
+ * passed rather than inferred from emptiness because the two callers differ: the rematch
+ * picker builds its topics from the same entities its claim rows come from, so an empty menu
+ * genuinely means "these claims carry no topics", while the Claims tab resolves topics in a
+ * second Knowledge Graph lookup that lags the claims — and an empty menu there is usually just
+ * "not back yet". Treating unresolved as "nothing matches" would throw away a selection that is
+ * about to be valid again; treating "genuinely none" as unresolved would strand the viewer on
+ * an empty list, which is the bug this is here to fix.
+ */
+export function keepSelectableTopic(
+  topicId: string | null,
+  available: MatchmakingTopic[],
+  isResolved: boolean
+): string | null {
+  if (topicId === null || !isResolved) return topicId;
+  return available.some(topic => topic.id === topicId) ? topicId : null;
+}

--- a/apps/web/core/debates/matchmaking/topic-facets.ts
+++ b/apps/web/core/debates/matchmaking/topic-facets.ts
@@ -4,10 +4,11 @@ import type { MatchmakingTopic } from '~/core/debates/api';
  * Which topics the topic menu should offer, and what to do with a selection the menu no
  * longer holds.
  *
- * geo-chat doesn't model topics — it returns `topics: []` and ignores `topic_id` — so both
- * pickers resolve them from the Knowledge Graph over the claims they have loaded. That makes
- * the menu's contents a client-side decision, and the one it was getting wrong: a topic with
- * no claims behind it is an option that can only ever produce an empty list.
+ * Only the rematch picker's graph-backed tabs reach for this now. Its All tab and the hub's
+ * Claims tab both read geo-chat's `topic_facets`, which describes the whole filtered corpus
+ * rather than the pages a client happens to have walked (GEO-2659) — but the opponent and
+ * curated tabs are built from Knowledge Graph entities geo-chat has never seen, so their
+ * menus are still derived from the claims on screen.
  */
 
 /**

--- a/apps/web/core/debates/matchmaking/topic-facets.ts
+++ b/apps/web/core/debates/matchmaking/topic-facets.ts
@@ -38,14 +38,14 @@ export function availableTopics(
  * otherwise leave the viewer on an empty list, filtered by a chip that is no longer in the
  * menu to unpick.
  *
- * `isResolved` says whether `available` is the finished answer for the current filters. It is
- * passed rather than inferred from emptiness because the two callers differ: the rematch
- * picker builds its topics from the same entities its claim rows come from, so an empty menu
- * genuinely means "these claims carry no topics", while the Claims tab resolves topics in a
- * second Knowledge Graph lookup that lags the claims — and an empty menu there is usually just
- * "not back yet". Treating unresolved as "nothing matches" would throw away a selection that is
- * about to be valid again; treating "genuinely none" as unresolved would strand the viewer on
- * an empty list, which is the bug this is here to fix.
+ * `isResolved` says whether `available` is the finished answer for the current filters, and is
+ * passed rather than inferred from emptiness because an empty menu means two different things.
+ * Where the topics come from the same rows the list is drawn from, empty genuinely means "these
+ * claims carry no topics". Where they ride a server facet, empty is usually "the request for
+ * these filters hasn't come back", since the facets arrive with page one and are absent until it
+ * lands. Treating unresolved as "nothing matches" would throw away a selection that is about to
+ * be valid again; treating "genuinely none" as unresolved would strand the viewer on an empty
+ * list, filtered by a chip the menu no longer offers to unpick — the bug this is here to fix.
  */
 export function keepSelectableTopic(
   topicId: string | null,

--- a/apps/web/core/debates/matchmaking/use-scope-holdover.test.ts
+++ b/apps/web/core/debates/matchmaking/use-scope-holdover.test.ts
@@ -1,0 +1,62 @@
+import { renderHook } from '@testing-library/react';
+
+import { describe, expect, it } from 'vitest';
+
+import { useScopeHeldOver } from './use-scope-holdover';
+
+describe('useScopeHeldOver', () => {
+  it('holds nothing while the pages are the current scope’s', () => {
+    const { result } = renderHook(() => useScopeHeldOver('space-1', false));
+
+    expect(result.current).toBe(false);
+  });
+
+  // The case the mask is for: the scope moved, and what React Query has to answer with meanwhile
+  // was fetched under the one before it.
+  it('reports a holdover once the scope changes under placeholder data', () => {
+    const { result, rerender } = renderHook(({ scope, placeholder }) => useScopeHeldOver(scope, placeholder), {
+      initialProps: { scope: 'space-1', placeholder: false },
+    });
+
+    rerender({ scope: 'space-2', placeholder: true });
+
+    expect(result.current).toBe(true);
+  });
+
+  // And releases it, rather than leaving the list empty for good.
+  it('lets go once the new scope’s pages land', () => {
+    const { result, rerender } = renderHook(({ scope, placeholder }) => useScopeHeldOver(scope, placeholder), {
+      initialProps: { scope: 'space-1', placeholder: false },
+    });
+
+    rerender({ scope: 'space-2', placeholder: true });
+    rerender({ scope: 'space-2', placeholder: false });
+
+    expect(result.current).toBe(false);
+  });
+
+  // A search or topic change is a key change too, and holding the previous answer through it is
+  // the point of `keepPreviousData` — the rows on screen are that same page, so the menu over them
+  // is honest. Only a scope change makes the held facets describe spaces the rows no longer can.
+  it('holds nothing when a filter changes but the scope does not', () => {
+    const { result, rerender } = renderHook(({ scope, placeholder }) => useScopeHeldOver(scope, placeholder), {
+      initialProps: { scope: 'space-1', placeholder: false },
+    });
+
+    rerender({ scope: 'space-1', placeholder: true });
+
+    expect(result.current).toBe(false);
+  });
+
+  // `null` is "no scope in force", which is a different question from any particular scope — not
+  // an absence to be treated as equal to whatever came before.
+  it('treats an unscoped query and a scoped one as different scopes', () => {
+    const { result, rerender } = renderHook(({ scope, placeholder }) => useScopeHeldOver(scope, placeholder), {
+      initialProps: { scope: null as string | null, placeholder: false },
+    });
+
+    rerender({ scope: 'space-1', placeholder: true });
+
+    expect(result.current).toBe(true);
+  });
+});

--- a/apps/web/core/debates/matchmaking/use-scope-holdover.ts
+++ b/apps/web/core/debates/matchmaking/use-scope-holdover.ts
@@ -21,12 +21,15 @@ import * as React from 'react';
  * Pass a key that identifies the scope, and the query's own `isPlaceholderData`.
  */
 export function useScopeHeldOver(scopeKey: string | null, isPlaceholderData: boolean): boolean {
-  const fetchedUnder = React.useRef(scopeKey);
+  const [fetchedUnder, setFetchedUnder] = React.useState(scopeKey);
 
-  // Written during render, and safe for the same reason `useStableListOrder`'s is: the result is a
-  // fixed point. Settled data means the scope in force is the one it was fetched under, so a
-  // discarded or double-invoked render recomputes the same answer.
-  if (!isPlaceholderData) fetchedUnder.current = scopeKey;
+  // React's sanctioned "adjust state during render" escape hatch rather than a ref written in the
+  // same place. A ref would survive a render that never commits: a speculative pass for scope B
+  // could record B, be thrown away, and leave the committed tree for scope A masking its own
+  // pages. State set during render is discarded with the render that set it, so an abandoned pass
+  // leaves nothing behind. React re-runs this component immediately with the new value, before
+  // anything commits, so it costs no extra frame.
+  if (!isPlaceholderData && fetchedUnder !== scopeKey) setFetchedUnder(scopeKey);
 
-  return fetchedUnder.current !== scopeKey;
+  return fetchedUnder !== scopeKey;
 }

--- a/apps/web/core/debates/matchmaking/use-scope-holdover.ts
+++ b/apps/web/core/debates/matchmaking/use-scope-holdover.ts
@@ -1,0 +1,32 @@
+'use client';
+
+import * as React from 'react';
+
+/**
+ * Whether the pages in hand were fetched under a different scope than the one now in force.
+ *
+ * `placeholderData: keepPreviousData` holds the last query key's pages while the next request is in
+ * flight, which is what stops the list blinking on every keystroke. For a search, topic or space
+ * change that hold is exactly right: the data is the previous answer to a question the viewer is
+ * still asking, and the rows on screen are that same held page, so the menu describing them is
+ * honest.
+ *
+ * A change of *scope* — which spaces this viewer may be shown claims from at all — is the one case
+ * where the held data is not merely stale but wrong. The rows are re-gated on the way out, so they
+ * narrow the moment the scope does; the facets riding with them are not, because a topic facet
+ * carries no space to gate it by. For the length of that request the menu offers topics from spaces
+ * the list has already stopped showing, which is the whole of GEO-2653 arriving through a different
+ * door.
+ *
+ * Pass a key that identifies the scope, and the query's own `isPlaceholderData`.
+ */
+export function useScopeHeldOver(scopeKey: string | null, isPlaceholderData: boolean): boolean {
+  const fetchedUnder = React.useRef(scopeKey);
+
+  // Written during render, and safe for the same reason `useStableListOrder`'s is: the result is a
+  // fixed point. Settled data means the scope in force is the one it was fetched under, so a
+  // discarded or double-invoked render recomputes the same answer.
+  if (!isPlaceholderData) fetchedUnder.current = scopeKey;
+
+  return fetchedUnder.current !== scopeKey;
+}

--- a/apps/web/core/debates/matchmaking/use-scoped-claims.test.ts
+++ b/apps/web/core/debates/matchmaking/use-scoped-claims.test.ts
@@ -1,0 +1,114 @@
+import { renderHook } from '@testing-library/react';
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { MatchmakingClaimsQuery } from '../api';
+import { useScopedMatchmakingClaims } from './use-scoped-claims';
+
+const mocks = vi.hoisted(() => ({
+  enabled: undefined as boolean | undefined,
+  query: undefined as MatchmakingClaimsQuery | undefined,
+  isPlaceholderData: false,
+  hasNextPage: true,
+}));
+
+// The pages a settled request would have returned, so anything empty below is the masking rather
+// than an empty answer.
+const PAGES = [
+  { claims: [], next_cursor: null, facets: { space_ids: ['space-1'], topics: [], space_facets: [], topic_facets: [] } },
+];
+
+vi.mock('./hooks', () => ({
+  useMatchmakingClaims: (query: MatchmakingClaimsQuery, enabled: boolean) => {
+    mocks.query = query;
+    mocks.enabled = enabled;
+    return {
+      data: { pages: PAGES },
+      isLoading: false,
+      isPlaceholderData: mocks.isPlaceholderData,
+      hasNextPage: mocks.hasNextPage,
+      isFetchingNextPage: false,
+      fetchNextPage: vi.fn(),
+      refetch: vi.fn(),
+      error: null,
+    };
+  },
+}));
+
+const QUERY = { search: null, spaceId: null, topicId: null } as const;
+
+function scoped(scope: { spaceIds: string[] | null; pending: boolean }, alsoUnusable = false) {
+  return renderHook(() => useScopedMatchmakingClaims(QUERY, scope, alsoUnusable));
+}
+
+beforeEach(() => {
+  mocks.isPlaceholderData = false;
+  mocks.hasNextPage = true;
+  mocks.enabled = undefined;
+  mocks.query = undefined;
+});
+
+describe('useScopedMatchmakingClaims', () => {
+  it('answers with the pages when the scope is known and non-empty', () => {
+    const { result } = scoped({ spaceIds: ['space-1'], pending: false });
+
+    expect(result.current.pages).toEqual(PAGES);
+    expect(result.current.facets).toBeDefined();
+    expect(mocks.enabled).toBe(true);
+    expect(mocks.query).toMatchObject({ spaceIds: ['space-1'] });
+  });
+
+  // `null` is "not narrowed", which the server reads the same way — so it is a real question to ask.
+  it('asks unnarrowed when the scope is null', () => {
+    const { result } = scoped({ spaceIds: null, pending: false });
+
+    expect(mocks.enabled).toBe(true);
+    expect(result.current.pages).toEqual(PAGES);
+  });
+
+  // The four ways an answer can describe a wider corpus than the caller will show. Each was found
+  // separately in review; they are one condition now.
+  it.each([
+    ['the scope is empty', { spaceIds: [], pending: false }, false],
+    ['the scope is not known yet', { spaceIds: null, pending: true }, false],
+    ['the caller has its own reason', { spaceIds: ['space-1'], pending: false }, true],
+  ])('shows nothing while %s', (_why, scope, alsoUnusable) => {
+    const { result } = scoped(scope, alsoUnusable);
+
+    expect(result.current.pages).toEqual([]);
+    expect(result.current.facets).toBeUndefined();
+    expect(result.current.hasNextPage).toBe(false);
+  });
+
+  it('shows nothing while the pages belong to a scope the viewer has left', () => {
+    const { result, rerender } = renderHook(
+      ({ spaceIds, placeholder }) => {
+        mocks.isPlaceholderData = placeholder;
+        return useScopedMatchmakingClaims(QUERY, { spaceIds, pending: false });
+      },
+      { initialProps: { spaceIds: ['space-1'] as string[] | null, placeholder: false } }
+    );
+    expect(result.current.pages).toEqual(PAGES);
+
+    rerender({ spaceIds: ['space-2'], placeholder: true });
+
+    expect(result.current.pages).toEqual([]);
+    expect(result.current.facets).toBeUndefined();
+  });
+
+  // An empty scope is not no scope: the request is never made, rather than made unnarrowed.
+  it('never asks unnarrowed for a scope known to be empty', () => {
+    scoped({ spaceIds: [], pending: false });
+
+    expect(mocks.enabled).toBe(false);
+  });
+
+  // The difference between "no topics" and "not known yet", which is what stops a viewer's
+  // selection being cleared on a slow load.
+  it('calls the facets settled only once they answer the scope in force', () => {
+    expect(scoped({ spaceIds: ['space-1'], pending: false }).result.current.facetsSettled).toBe(true);
+
+    mocks.isPlaceholderData = true;
+    expect(scoped({ spaceIds: ['space-1'], pending: false }).result.current.facetsSettled).toBe(false);
+  });
+});

--- a/apps/web/core/debates/matchmaking/use-scoped-claims.test.ts
+++ b/apps/web/core/debates/matchmaking/use-scoped-claims.test.ts
@@ -103,6 +103,20 @@ describe('useScopedMatchmakingClaims', () => {
     expect(mocks.enabled).toBe(false);
   });
 
+  // A scope that can show nothing is a finished answer about the menu: empty. Read as "not known
+  // yet" instead, a selection made before the scope narrowed would be held forever, filtering an
+  // empty list from a chip the empty menu can't unpick.
+  it('calls an unusable scope settled, so a stranded selection can be let go', () => {
+    expect(scoped({ spaceIds: [], pending: false }).result.current.facetsSettled).toBe(true);
+    expect(scoped({ spaceIds: ['space-1'], pending: false }, true).result.current.facetsSettled).toBe(true);
+  });
+
+  // But only once it is known to be unusable — a scope still resolving says nothing either way.
+  it('calls nothing settled while the scope is still resolving', () => {
+    expect(scoped({ spaceIds: [], pending: true }).result.current.facetsSettled).toBe(false);
+    expect(scoped({ spaceIds: null, pending: true }).result.current.facetsSettled).toBe(false);
+  });
+
   // The difference between "no topics" and "not known yet", which is what stops a viewer's
   // selection being cleared on a slow load.
   it('calls the facets settled only once they answer the scope in force', () => {

--- a/apps/web/core/debates/matchmaking/use-scoped-claims.ts
+++ b/apps/web/core/debates/matchmaking/use-scoped-claims.ts
@@ -84,10 +84,17 @@ export function useScopedMatchmakingClaims(
   const pages = React.useMemo(() => (masked ? [] : (claimsQuery.data?.pages ?? [])), [claimsQuery.data, masked]);
   const facets = pages[0]?.facets;
 
+  // An unusable scope is an answer, not a silence. The query is deliberately never made, so the
+  // facets never arrive — and read as "not known yet" that would leave a selected space or topic
+  // held forever, filtering a list that has nothing in it and unpickable from a menu that is
+  // empty. Knowing there is nothing to show is knowing the menu.
+  const facetsSettled =
+    !scope.pending && (unusable || (facets !== undefined && !claimsQuery.isLoading && !claimsQuery.isPlaceholderData));
+
   return {
     pages,
     facets,
-    facetsSettled: facets !== undefined && !claimsQuery.isLoading && !claimsQuery.isPlaceholderData,
+    facetsSettled,
     unusable,
     hasNextPage: !masked && Boolean(claimsQuery.hasNextPage),
     isLoading: claimsQuery.isLoading,

--- a/apps/web/core/debates/matchmaking/use-scoped-claims.ts
+++ b/apps/web/core/debates/matchmaking/use-scoped-claims.ts
@@ -1,0 +1,99 @@
+'use client';
+
+import * as React from 'react';
+
+import type { MatchmakingClaimsQuery, MatchmakingClaimsResponse, MatchmakingFacets } from '../api';
+import { useMatchmakingClaims } from './hooks';
+import { useScopeHeldOver } from './use-scope-holdover';
+
+/**
+ * The spaces a viewer may be shown claims from, as the pickers know it.
+ *
+ * `spaceIds` is `null` for "not narrowed" and `[]` for "narrowed to nothing" — a distinction the
+ * wire does not make, since geo-chat reads a missing `space_ids` as no filter at all. `pending`
+ * covers every lookup the answer is built from, including one holding a previous answer over.
+ */
+export type ClaimSpaceScope = {
+  spaceIds: string[] | null;
+  pending: boolean;
+};
+
+export type ScopedClaims = {
+  /** Pages that answer the scope in force, or none. Never the previous scope's. */
+  pages: MatchmakingClaimsResponse[];
+  /** The facets riding page one, on the same terms. */
+  facets: MatchmakingFacets | undefined;
+  /**
+   * Whether `facets` is an answer rather than an absence. An empty menu is a real answer once this
+   * is true, and "not known yet" until then — the difference between clearing a viewer's selection
+   * and dropping it on a slow load.
+   */
+  facetsSettled: boolean;
+  /** Nothing this query could return is showable, so it was never asked. */
+  unusable: boolean;
+  /** Already masked: a sentinel rendered on this can't page a corpus the caller can't show. */
+  hasNextPage: boolean;
+  isLoading: boolean;
+  isFetchingNextPage: boolean;
+  fetchNextPage: () => void;
+  refetch: () => void;
+  error: unknown;
+};
+
+/**
+ * geo-chat's claims query, narrowed to a scope and held to it.
+ *
+ * Both pickers ask geo-chat the same question and face the same hazard: the rows come back with
+ * facets attached, the caller re-gates the rows on the way out, and nothing re-gates the facets —
+ * a topic facet carries no space to gate it by. Any moment the pages in hand describe a wider
+ * corpus than the caller will show is a menu offering topics that lead nowhere, which is GEO-2653.
+ *
+ * There are more such moments than is obvious: the scope isn't known yet; it is known and empty;
+ * it changed after settling and `keepPreviousData` is answering with the previous one's pages; a
+ * lookup underneath it is holding its own previous answer. Each was found separately, and each was
+ * fixed twice, once per picker, until they drifted. So the scope is applied here, once, where the
+ * pages are read — everything downstream inherits it and needs no guard of its own.
+ *
+ * `alsoUnusable` is for a caller whose own reasons make the answer unshowable: the debate-again
+ * picker drops every browsed row when the selected space is outside the viewer's allowlist, so
+ * there is nothing worth asking for.
+ */
+export function useScopedMatchmakingClaims(
+  query: Omit<MatchmakingClaimsQuery, 'spaceIds'>,
+  scope: ClaimSpaceScope,
+  alsoUnusable = false
+): ScopedClaims {
+  // A known-empty scope is not the same as no scope: omitting the ids would fetch the unfiltered
+  // corpus, which is the opposite of what an empty eligible set means.
+  const unusable = (scope.spaceIds !== null && scope.spaceIds.length === 0) || alsoUnusable;
+
+  // `query` is expected memoized by the caller — it is the react-query key, so a fresh object every
+  // render would refetch on every render.
+  const scopedQuery = React.useMemo<MatchmakingClaimsQuery>(
+    () => ({ ...query, spaceIds: scope.spaceIds }),
+    [query, scope.spaceIds]
+  );
+
+  const claimsQuery = useMatchmakingClaims(scopedQuery, !unusable && !scope.pending);
+
+  // A settled scope can still change — the allowlist refetches, a space is joined — and no loading
+  // flag turns over when it does. The only sign is the pages in hand naming the scope before it.
+  const heldOver = useScopeHeldOver(scope.spaceIds?.join(',') ?? null, claimsQuery.isPlaceholderData);
+
+  const masked = unusable || scope.pending || heldOver;
+  const pages = React.useMemo(() => (masked ? [] : (claimsQuery.data?.pages ?? [])), [claimsQuery.data, masked]);
+  const facets = pages[0]?.facets;
+
+  return {
+    pages,
+    facets,
+    facetsSettled: facets !== undefined && !claimsQuery.isLoading && !claimsQuery.isPlaceholderData,
+    unusable,
+    hasNextPage: !masked && Boolean(claimsQuery.hasNextPage),
+    isLoading: claimsQuery.isLoading,
+    isFetchingNextPage: claimsQuery.isFetchingNextPage,
+    fetchNextPage: claimsQuery.fetchNextPage,
+    refetch: claimsQuery.refetch,
+    error: claimsQuery.error,
+  };
+}


### PR DESCRIPTION
## GEO-2653 — the topics dropdown should reflect the selected space

Both claim pickers — the hub's **Claims tab** and the debate-again flow's **All tab** — showed a topics menu that didn't describe the list underneath it. Pick US Politics and the menu went empty; pick a topic the menu offered and the list came back with nothing.

The menu and the list were built from different corpora. The list came from geo-chat, paged and space-filtered server-side. The menu came from a Knowledge Graph lookup over *whatever page happened to be loaded* — so it narrowed as you scrolled, grew as you paged, and described spaces the list was no longer showing.

**A menu is only as honest as the corpus it describes.** That's the whole change: both surfaces now take their options from geo-chat's own facets over the same candidate set the list is drawn from.

### What changed

- **Server facets replace the client-side graph lookup.** `listMatchmakingClaims` returns `space_facets` and `topic_facets` over the full candidate set (geo-chat #58/#59/#60, GEO-2659). Each dimension is narrowed by the other and never by itself, so picking a space never collapses the space menu and picking a topic never collapses the topic menu.
- **Topic filtering moved server-side** for the browsed corpus (`topic_id`), so paging and counts agree with the filter.
- **Session scoping moved server-side** (`rematch_session_id`, geo-chat #63, GEO-2674) — the picker no longer excludes this session's claims client-side, which was the source of the "topic with no claims" case.
- **The scope is applied consistently.** A space reaches the menu only if the viewer's allowlist admits it, its type can hold claims, and a debate can actually be published into it. When no space qualifies, the query, the pagination sentinel, and the render are all masked together.
- **A selection the menu no longer offers is cleared** rather than left filtering against nothing — but only once the menu is known to be resolved, so a slow load never drops the viewer's choice.
- **Both pickers share one scoped query.** `useScopedMatchmakingClaims` owns query enablement, the mask, the facets, the settled flag and an already-masked `hasNextPage`, so the agreement between menu and list is kept in one place instead of re-established per surface. The copies had already drifted once.
- **Neither picker asks before it knows its scope.** While the allowlist and space lookups are unresolved the eligible set is `null`, and geo-chat reads that as "no filter" — so the query is not made at all until the scope is known, rather than made unnarrowed and filtered afterwards. The pages are also masked where they're read, so one gate covers the query, the facets and everything downstream.

The All tab renders a union of two corpora — geo-chat's browsed rows plus this session's pinned graph rows — with different rules. Its facets merge accordingly, and the client-side topic filter stays for the pinned rows only.

### Net effect on the Claims tab

A simplification: the KG hydration round trip, the per-claim topic map, and the client-side topic filter are all deleted.

### Testing

`+962` lines of tests, `+570` production. Every defect found in review has a test that was verified to fail against the code before the fix. The geo-chat contract is covered at the wire: `space_ids`, `topic_id`, `rematch_session_id` and the `space_id`-over-`space_ids` precedence are asserted against the request URL, each mutation-checked. Full `apps/web` debates + space suites: **72 files / 1054 tests passing**; lint, typecheck, and prettier clean.

### Not in scope

GEO-2654 (facet counts, ordering, multi-select) is unblocked by the same backend work but deliberately left out.


