### PR TITLE
fix(debates): deliver a debate request without waiting on a 30s poll

### DIFF
--- a/apps/web/core/debates/debate-gateway.test.ts
+++ b/apps/web/core/debates/debate-gateway.test.ts
@@ -1147,7 +1147,11 @@ describe('DebateGatewayClient', () => {
     expect(client.getSnapshot()).toMatchObject({ status: 'degraded', paused: true });
   });
 
-  it('pauses live updates when a subscription is rejected', async () => {
+  // GEO-2650. This used to park in degraded forever. Nothing in that branch closed the socket, so
+  // heartbeats kept being acked, the two-missed-ack path to `forceReconnect` was never reached, and
+  // there was no route back to `ready` for the rest of the session — one scope-level rejection took
+  // the account-level stream, and with it the incoming-request popup, down with it.
+  it('recycles the socket when a subscription is rejected, rather than parking on it', async () => {
     client.start(
       vi.fn(async () => 'privy-token'),
       'user-a'
@@ -1158,7 +1162,65 @@ describe('DebateGatewayClient', () => {
 
     sockets[0]!.receive('ERROR', { code: 'subscription_forbidden', message: 'not authorized' });
 
+    expect(sockets[0]!.readyState).toBe(FakeWebSocket.CLOSED);
     expect(client.getSnapshot()).toMatchObject({ status: 'degraded', paused: true });
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(sockets).toHaveLength(2);
+    sockets[1]!.open();
+    sockets[1]!.receive('READY', readyPayload([]));
+    expect(client.getSnapshot()).toMatchObject({ status: 'ready', paused: false });
+  });
+
+  // The other half of that trade: `reconnectAttempt` resets on a successful invalidation flush, which
+  // a fresh connection performs before the error recurs, so the backoff never grows and a
+  // reproducing rejection would spin roughly once a second indefinitely.
+  it('stops recycling when the same rejection reproduces inside the cooldown', async () => {
+    client.start(
+      vi.fn(async () => 'privy-token'),
+      'user-a'
+    );
+    await vi.runAllTicks();
+    sockets[0]!.open();
+    sockets[0]!.receive('READY', readyPayload([]));
+    sockets[0]!.receive('ERROR', { code: 'subscription_forbidden', message: 'not authorized' });
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    sockets[1]!.open();
+    sockets[1]!.receive('READY', readyPayload([]));
+    await flushInvalidations();
+
+    sockets[1]!.receive('ERROR', { code: 'subscription_forbidden', message: 'not authorized' });
+
+    expect(sockets[1]!.readyState).toBe(FakeWebSocket.OPEN);
+    expect(client.getSnapshot()).toMatchObject({ status: 'degraded', paused: true });
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(sockets).toHaveLength(2);
+  });
+
+  // And once the socket has been healthy for the cooldown, a later rejection is a fresh incident
+  // rather than the same one reproducing, so it gets its own recovery attempt.
+  it('recycles again once the cooldown has passed', async () => {
+    client.start(
+      vi.fn(async () => 'privy-token'),
+      'user-a'
+    );
+    await vi.runAllTicks();
+    sockets[0]!.open();
+    sockets[0]!.receive('READY', readyPayload([]));
+    sockets[0]!.receive('ERROR', { code: 'subscription_forbidden', message: 'not authorized' });
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    sockets[1]!.open();
+    sockets[1]!.receive('READY', readyPayload([]));
+    await flushInvalidations();
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    sockets[1]!.receive('ERROR', { code: 'subscription_forbidden', message: 'not authorized' });
+
+    expect(sockets[1]!.readyState).toBe(FakeWebSocket.CLOSED);
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(sockets).toHaveLength(3);
   });
 
   it('reconnects with a new session when the authenticated account changes', async () => {

--- a/apps/web/core/debates/debate-gateway.ts
+++ b/apps/web/core/debates/debate-gateway.ts
@@ -94,6 +94,12 @@ const DEFAULT_HEARTBEAT_INTERVAL_MS = 30_000;
 const HANDSHAKE_TIMEOUT_MS = 10_000;
 const INVALIDATION_COALESCE_MS = 50;
 const INVALIDATION_RETRY_BASE_MS = 250;
+/**
+ * How long an unrecognised `ERROR` frame suppresses another reconnect. One recycle repairs a
+ * transient rejection; a second inside this window means it is reproducing, and spinning on it
+ * would be worse than running degraded.
+ */
+const ERROR_RECONNECT_COOLDOWN_MS = 60_000;
 /** Re-flushes after the first attempt fails transiently, so up to four attempts in all. */
 const MAX_INVALIDATION_RETRIES = 3;
 const BROAD_INVALIDATION_KEY = 'debates:all';
@@ -123,6 +129,7 @@ export class DebateGatewayClient {
   private readyForDebates = false;
   private lastSequence: number | null = null;
   private reconnectAttempt = 0;
+  private lastErrorReconnectAt: number | null = null;
   private heartbeatIntervalMs = DEFAULT_HEARTBEAT_INTERVAL_MS;
   private heartbeatsAwaitingAck = 0;
   private debatePresence = true;
@@ -180,6 +187,7 @@ export class DebateGatewayClient {
     this.hasReachedReady = false;
     this.lastSequence = null;
     this.reconnectAttempt = 0;
+    this.lastErrorReconnectAt = null;
     this.clearAllTimers();
     this.disposeSocket();
     this.sentScopes.clear();
@@ -281,8 +289,23 @@ export class DebateGatewayClient {
         } else if (isRateLimited(envelope.payload)) {
           this.forceReconnect(socket, rateLimitRetryDelayMs(envelope.payload));
         } else if (isSubscriptionLimitReached(envelope.payload)) {
+          // A real ceiling, and reconnecting re-sends the same scopes and hits it again. The
+          // account-routed stream keeps working; only the scopes past the limit are lost.
           this.setSnapshot({ status: 'degraded', paused: true });
+        } else if (this.canRecoverFromError()) {
+          // Anything else is not known to be permanent, and parking here was a dead end: nothing in
+          // this branch closes the socket, so heartbeats keep being acked, `heartbeatsAwaitingAck`
+          // never reaches two, and `forceReconnect` is never reached. The connection stayed up in a
+          // state the client had already declared dead, for the rest of the session, with no path
+          // back to `ready` — a scope-level rejection took the account-level stream down with it.
+          // Recycle the socket instead, on the usual backoff (GEO-2650).
+          this.lastErrorReconnectAt = Date.now();
+          this.forceReconnect(socket);
         } else {
+          // Already tried that recently, so the error is reproducing rather than transient and
+          // another reconnect would spin: `reconnectAttempt` resets on a successful invalidation
+          // flush, which a fresh connection performs before the error recurs, so the backoff would
+          // never actually grow. Park, and let the degraded poll carry correctness.
           this.setSnapshot({ status: 'degraded', paused: true });
         }
         break;
@@ -706,6 +729,12 @@ export class DebateGatewayClient {
     if (!this.enabled) return;
     this.setSnapshot({ status: 'degraded', paused: true });
     this.scheduleReconnect(minimumDelayMs);
+  }
+
+  private canRecoverFromError() {
+    return (
+      this.lastErrorReconnectAt === null || Date.now() - this.lastErrorReconnectAt >= ERROR_RECONNECT_COOLDOWN_MS
+    );
   }
 
   private scheduleReconnect(minimumDelayMs = 0) {

--- a/apps/web/core/debates/hooks-query-network.test.tsx
+++ b/apps/web/core/debates/hooks-query-network.test.tsx
@@ -20,6 +20,7 @@ import {
 const mocks = vi.hoisted(() => ({
   authenticated: true,
   attention: true,
+  presence: true,
   gatewayPaused: false,
   queryCache: { subscribe: vi.fn(() => vi.fn()) },
   queryClient: {
@@ -56,11 +57,13 @@ vi.mock('./debate-gateway', () => ({
 
 vi.mock('./debate-attention', () => ({
   useDebateAttention: () => mocks.attention,
+  useDebatePresence: () => mocks.presence,
 }));
 
 beforeEach(() => {
   mocks.authenticated = true;
   mocks.attention = true;
+  mocks.presence = true;
   mocks.gatewayPaused = false;
   mocks.queryClient.invalidateQueries.mockClear();
   mocks.queryClient.getQueryCache.mockClear();
@@ -98,7 +101,7 @@ describe('debate query network ownership', () => {
   // backoff, and an ERROR frame that pauses live updates without scheduling a reconnect. Neither
   // recovers on its own, and the shared options switch off React Query's focus and reconnect
   // refetches — so without this a request waited on a remount to appear (GEO-2638).
-  it('polls activity while foregrounded, faster while the gateway is paused, and refetches on return', () => {
+  it('polls activity while on screen, faster while the gateway is paused, and refetches on return', () => {
     const { rerender } = renderHook(() => useDebateActivity());
     expect(mocks.useQuery.mock.calls.at(-1)?.[0]).toMatchObject({ refetchInterval: 30_000 });
     expect(mocks.queryRefetch).not.toHaveBeenCalled();
@@ -108,13 +111,40 @@ describe('debate query network ownership', () => {
     rerender();
     expect(mocks.useQuery.mock.calls.at(-1)?.[0]).toMatchObject({ refetchInterval: 10_000 });
 
-    // A tab nobody is looking at has no popup to draw, paused or not.
-    mocks.attention = false;
+    // A hidden tab has no popup to draw, paused or not.
+    mocks.presence = false;
     rerender();
     expect(mocks.useQuery.mock.calls.at(-1)?.[0]).toMatchObject({ refetchInterval: false });
 
+    mocks.presence = true;
+    rerender();
+    expect(mocks.queryRefetch).toHaveBeenCalledTimes(1);
+  });
+
+  // GEO-2650. The gate used to be attention, which additionally requires `document.hasFocus()`, so
+  // a tab sitting open on screen behind whatever window the viewer was typing in did not poll at
+  // all — and the incoming-request popup is by definition the thing that arrives while you are
+  // looking somewhere else. That left the socket as the sole delivery path for the exact case this
+  // poll exists to cover, which is how a request still took ~36 seconds after GEO-2638.
+  it('keeps polling activity on a visible tab that is not the focused window', () => {
+    mocks.attention = false;
+    mocks.presence = true;
+
+    renderHook(() => useDebateActivity());
+
+    expect(mocks.useQuery.mock.calls.at(-1)?.[0]).toMatchObject({ refetchInterval: 30_000 });
+  });
+
+  // Regaining focus without a visibility change is its own return: the poll was already running, but
+  // someone who just clicked back in is the most likely person to be waiting on a popup.
+  it('refetches activity when focus returns to an already-visible tab', () => {
+    mocks.attention = false;
+    const { rerender } = renderHook(() => useDebateActivity());
+    expect(mocks.queryRefetch).not.toHaveBeenCalled();
+
     mocks.attention = true;
     rerender();
+
     expect(mocks.queryRefetch).toHaveBeenCalledTimes(1);
   });
 

--- a/apps/web/core/debates/hooks.ts
+++ b/apps/web/core/debates/hooks.ts
@@ -63,7 +63,7 @@ import {
   updateDebateAvailability,
 } from './api';
 import { claimResponseIndexedEvent } from './claim-response-indexed-notifier';
-import { useDebateAttention } from './debate-attention';
+import { useDebateAttention, useDebatePresence } from './debate-attention';
 import { markEnteringDebate } from './debate-entry-intent';
 import { useDebateGatewayScope, useDebateGatewaySnapshot, useDebateGatewaySpaceScopes } from './debate-gateway';
 import { hasProcessedVideo } from './playback-utils';
@@ -303,7 +303,7 @@ export function useLeaveDebateQueue(spaceId: string) {
   });
 }
 
-/** How often activity re-asks while the viewer is looking, with a live gateway behind it. */
+/** How often activity re-asks while this tab is on screen, with a live gateway behind it. */
 const ACTIVITY_POLL_MS = 30_000;
 /** And while the gateway is paused, when this is the only thing still asking. */
 const ACTIVITY_DEGRADED_POLL_MS = 10_000;
@@ -325,17 +325,27 @@ const ACTIVITY_DEGRADED_POLL_MS = 10_000;
  * nothing recovers it. Either way the popup waited on a remount, which is how a request took
  * "30-60 seconds" to appear (GEO-2638).
  *
- * So: poll while the viewer is looking, faster while the gateway is paused and this is the only
+ * So: poll while this tab is on screen, faster while the gateway is paused and this is the only
  * thing still asking, and re-ask on return to the tab. The socket still does the fast path — a
  * couple of seconds, of which the outbox relay is two — and this only bounds the bad case.
+ *
+ * The gate is *presence*, not attention. Attention additionally requires `document.hasFocus()`,
+ * and gating the poll on that meant a tab sitting open on screen — but behind the window the
+ * viewer happened to be typing in — did not poll at all, leaving the socket as the only delivery
+ * path for the exact case this poll exists to cover. An incoming request is by definition the
+ * thing that arrives while you are looking at something else, so focus is the wrong question to
+ * ask; that is why geo-chat keys reachability (`is_online`) on presence too. This is what was
+ * still reported as a ~36 second delivery after GEO-2638 (GEO-2650).
  */
 export function useDebateActivity(enabled = true) {
   const queryClient = useQueryClient();
   const { accountKey, authenticated, getPrivyIdentityToken } = useGeoChatAuth();
-  const foreground = useDebateAttention();
+  const attentive = useDebateAttention();
+  const present = useDebatePresence();
   const { paused } = useDebateGatewaySnapshot();
   const queryEnabled = enabled && authenticated;
-  const wasForeground = React.useRef(foreground);
+  const wasPresent = React.useRef(present);
+  const wasAttentive = React.useRef(attentive);
 
   const query = useQuery({
     ...debateQueryNetworkOptions,
@@ -351,19 +361,21 @@ export function useDebateActivity(enabled = true) {
       return activity;
     },
     enabled: queryEnabled,
-    // Background tabs don't poll: presence keeps the socket's own view current, and a tab nobody is
-    // looking at has no popup to draw.
-    refetchInterval: foreground ? (paused ? ACTIVITY_DEGRADED_POLL_MS : ACTIVITY_POLL_MS) : false,
+    // Hidden tabs still don't poll: they have no popup to draw, and browsers throttle their timers
+    // anyway. On-screen is the bar, whether or not this is the frontmost window.
+    refetchInterval: present ? (paused ? ACTIVITY_DEGRADED_POLL_MS : ACTIVITY_POLL_MS) : false,
   });
 
-  // Coming back to the tab is the one moment a viewer expects to be shown what they missed, and the
-  // shared options switch off React Query's own focus refetch for every debate query. Same shape as
-  // `useDebateProfile`, which needs it for the same reason.
+  // Coming back is the one moment a viewer expects to be shown what they missed, and the shared
+  // options switch off React Query's own focus refetch for every debate query. Both transitions
+  // count: becoming visible restarts the poll but not immediately, and regaining focus is when
+  // someone is most likely to be waiting on a popup.
   React.useEffect(() => {
-    const returnedToForeground = foreground && !wasForeground.current;
-    wasForeground.current = foreground;
-    if (returnedToForeground && queryEnabled) void query.refetch();
-  }, [foreground, query.refetch, queryEnabled]);
+    const returned = (present && !wasPresent.current) || (attentive && !wasAttentive.current);
+    wasPresent.current = present;
+    wasAttentive.current = attentive;
+    if (returned && queryEnabled) void query.refetch();
+  }, [attentive, present, query.refetch, queryEnabled]);
 
   return query;
 }


### PR DESCRIPTION
Fixes GEO-2650.

A debate request still took **~36 seconds** to reach the opponent after GEO-2638 shipped, and the number is the diagnosis. The poll #2208 added as a safety net is **30 seconds**. Delivery itself is a push — `emit_requests_changed` into `debate.requests_changed`, off an outbox relay that ticks every **2 seconds** (`crates/api/src/outbox.rs:37`), routed per user and independent of scope. So ~36s is not a slow server. It is the socket not delivering, and the poll rescuing it.

#2208 turned "sometimes never arrives" into "reliably arrives in 30s". Reliable, and still broken. Two things behind that.

## The poll didn't run at all

It was gated on `useDebateAttention`, which is visible **and** `document.hasFocus()`. A tab sitting open on screen — behind whatever window the viewer was actually typing in — therefore polled *never*, leaving the socket as the only delivery path for precisely the case the poll exists to cover.

An incoming request is by definition the thing that arrives while you are looking at something else, so focus is the wrong question to ask. geo-chat already draws this line the same way: `debate_presence` → `is_online` keys on presence, not focus, because keying reachability on focus made a request vanish the moment its requester clicked into another window.

Gated on `useDebatePresence` now. Hidden tabs still don't poll — they have no popup to draw, and browsers throttle their timers regardless. Both return transitions refetch: becoming visible restarts the poll but not instantly, and regaining focus is when someone is most likely to be waiting.

## The socket had a state it could never leave

An `ERROR` frame the client didn't recognise set `degraded/paused` and scheduled **no reconnect**. Nothing in that branch closes the socket, so heartbeats keep being acked, `heartbeatsAwaitingAck` never reaches two, and `forceReconnect` is never reached. The connection sat up in a state the client had already declared dead, with no route back to `ready` for the rest of the session — one scope-level rejection taking the account-level stream, and the request popup with it, down permanently.

It recycles the socket now. **Bounded on purpose:** `reconnectAttempt` resets on a successful invalidation flush, and a fresh connection performs one before the error recurs, so the backoff would never actually grow and a reproducing error would spin roughly once a second. A second unrecognised error inside 60s parks as before and lets the degraded poll carry correctness. `subscription_limit_reached` still parks immediately — it's a real ceiling, and reconnecting re-sends the same scopes into it.

## Verification

- Five tests, each checked by reverting its fix and confirming it fails: 2 on the poll gate, 3 on the socket recovery (recovers / stops inside the cooldown / recovers again after it).
- Full suite green: **282 files, 2879 tests**. Typecheck clean.

## What this does and doesn't settle

The mechanisms are certain. That they are what produced Preston's specific 36 seconds is inference from the timing — strong, but not a repro. If tens of seconds survive this deploy, the next step is instrumenting whether the event reaches the recipient's socket at all rather than guessing again.

Should also take most of GEO-2651 with it: a two-client handshake against a hard deadline was racing a 30s delivery floor.