### PR TITLE
fix(debates): gate the side panel's claims tab on publishable spaces too

### DIFF
--- a/apps/web/core/debates/matchmaking/claims-tab.test.tsx
+++ b/apps/web/core/debates/matchmaking/claims-tab.test.tsx
@@ -14,6 +14,8 @@ const mocks = vi.hoisted(() => ({
   facetSpaceIds: [] as string[],
   spaceAllowlist: null as Set<string> | null,
   allowlistLoading: false,
+  publishableSpaceIds: null as Set<string> | null,
+  publishableLoading: false,
   sidebarData: null as unknown,
   fetchedSpaceIds: [] as string[][],
   spacesLoading: false,
@@ -26,6 +28,15 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock('~/core/debates/use-claim-space-allowlist', () => ({
   useClaimSpaceAllowlist: () => ({ allowlist: mocks.spaceAllowlist, isLoading: mocks.allowlistLoading }),
+}));
+
+vi.mock('~/core/debates/use-debate-publishable-spaces', async importOriginal => ({
+  // The real predicate: normalization and the null-means-unknown rule are the parts under test.
+  ...(await importOriginal<typeof import('../use-debate-publishable-spaces')>()),
+  useDebatePublishableSpaces: () => ({
+    publishableSpaceIds: mocks.publishableSpaceIds,
+    isLoading: mocks.publishableLoading,
+  }),
 }));
 
 vi.mock('./hooks', () => ({
@@ -140,6 +151,10 @@ beforeEach(() => {
   // unfiltered list — what every pre-existing case here runs under.
   mocks.spaceAllowlist = null;
   mocks.allowlistLoading = false;
+  // Same shape, same reason: settled-with-no-answer does not filter, which is what every
+  // pre-existing case here runs under.
+  mocks.publishableSpaceIds = null;
+  mocks.publishableLoading = false;
   mocks.sidebarData = null;
   mocks.fetchedSpaceIds = [];
   mocks.spacesLoading = false;
@@ -260,6 +275,66 @@ describe('ClaimsTab', () => {
 
     expect(screen.getByText('Chips are better than fries')).toBeInTheDocument();
     expect(screen.queryByText('Bitcoin will never top $250K')).not.toBeInTheDocument();
+  });
+
+  // GEO-2649. A separate question from the allowlist: the viewer may be perfectly entitled to see
+  // the space, but if the acceptor isn't an editor of it the debate fails on-chain at the very end,
+  // so offering the claim is offering a dead end.
+  it('shows only claims from spaces a debate could be published in', () => {
+    mocks.claims = [
+      claim(MINE, 'Chips are better than fries', true),
+      claim(THEIRS, 'Bitcoin will never top $250K', false, false, OTHER_SPACE_ID),
+    ];
+    mocks.publishableSpaceIds = new Set([SPACE_ID.replace(/-/g, '')]);
+    render(<ClaimsTab />);
+
+    expect(screen.getByText('Chips are better than fries')).toBeInTheDocument();
+    expect(screen.queryByText('Bitcoin will never top $250K')).not.toBeInTheDocument();
+  });
+
+  // Both gates apply, and a claim has to clear both. Allowed to see it, but nothing can be
+  // published there.
+  it('hides an allowed space that no debate can be published in', () => {
+    mocks.claims = [claim(MINE, 'Chips are better than fries', true)];
+    mocks.spaceAllowlist = new Set([SPACE_ID.replace(/-/g, '')]);
+    mocks.publishableSpaceIds = new Set([OTHER_SPACE_ID.replace(/-/g, '')]);
+    render(<ClaimsTab />);
+
+    expect(screen.queryByText('Chips are better than fries')).toBeNull();
+  });
+
+  it('keeps the space filter to spaces a debate could be published in', () => {
+    mocks.claims = [claim(MINE, 'Chips are better than fries', true)];
+    mocks.facetSpaceIds = [SPACE_ID, OTHER_SPACE_ID];
+    mocks.publishableSpaceIds = new Set([SPACE_ID.replace(/-/g, '')]);
+    render(<ClaimsTab />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Any space/ }));
+
+    // Names resolve through useSpacesByIds, mocked empty here, so each offered space reads "Space".
+    expect(screen.getAllByRole('button', { name: /Space$/ })).toHaveLength(1);
+  });
+
+  // Same trimming-under-the-viewer problem the allowlist has, and the same answer: `null` does not
+  // filter, so without waiting the tab lists everything and then pulls claims back out.
+  it('shows nothing until the publishable lookup settles', () => {
+    mocks.claims = [claim(THEIRS, 'Bitcoin will never top $250K', false, false, OTHER_SPACE_ID)];
+    mocks.publishableSpaceIds = null;
+    mocks.publishableLoading = true;
+    render(<ClaimsTab />);
+
+    expect(screen.queryByText('Bitcoin will never top $250K')).toBeNull();
+  });
+
+  // And the other half of that rule: a lookup that settled without an answer must not empty the
+  // tab. No acceptor is configured locally at all, so this is the everyday path.
+  it('falls through to the unfiltered list when the publishable lookup comes back empty', () => {
+    mocks.claims = [claim(MINE, 'Chips are better than fries', true)];
+    mocks.publishableSpaceIds = null;
+    mocks.publishableLoading = false;
+    render(<ClaimsTab />);
+
+    expect(screen.getByText('Chips are better than fries')).toBeInTheDocument();
   });
 
   // The allowlist is keyed on normalized ids; a claim row carries the hyphen-less form.

--- a/apps/web/core/debates/matchmaking/claims-tab.tsx
+++ b/apps/web/core/debates/matchmaking/claims-tab.tsx
@@ -17,6 +17,7 @@ import { Input } from '~/design-system/input';
 import type { MatchmakingClaimsFilter, MatchmakingClaimsQuery, MatchmakingTopic } from '../api';
 import { isClaimSpaceAllowed } from '../claim-space-allowlist';
 import { useClaimSpaceAllowlist } from '../use-claim-space-allowlist';
+import { isSpaceDebatePublishable, useDebatePublishableSpaces } from '../use-debate-publishable-spaces';
 import { useMatchmakingClaims } from './hooks';
 import { HubFilterMenu, type HubFilterOption } from './hub-filter-menu';
 import { HubCardList } from './hub-motion';
@@ -76,19 +77,35 @@ export function ClaimsTab() {
   // that never fills.
   const allowlistPending = spaceAllowlist === null && allowlistLoading;
 
+  // GEO-2649. Two independent questions, and a claim has to pass both: the allowlist above asks
+  // whether this *viewer* may see the space, and this asks whether a debate there could ever be
+  // published — the acceptor has to be an editor of it, or the debate fails on-chain at the end.
+  // Offering a claim that cannot carry a debate is offering a dead end.
+  //
+  // Same "wait rather than trim under the viewer" rule, for the same reason: `null` means unknown
+  // and deliberately does not filter, so without this the tab would list the unfiltered set and
+  // pull claims out of it a moment later.
+  const { publishableSpaceIds, isLoading: publishableLoading } = useDebatePublishableSpaces();
+  const publishablePending = publishableSpaceIds === null && publishableLoading;
+  const spacesPending = allowlistPending || publishablePending;
+
+  const spaceShowsClaims = React.useCallback(
+    (candidateSpaceId: string) =>
+      isClaimSpaceAllowed(candidateSpaceId, spaceAllowlist) &&
+      isSpaceDebatePublishable(candidateSpaceId, publishableSpaceIds),
+    [publishableSpaceIds, spaceAllowlist]
+  );
+
   const serverClaims = React.useMemo(
-    () =>
-      allowlistPending
-        ? []
-        : pages.flatMap(page => page.claims).filter(entry => isClaimSpaceAllowed(entry.claim.space_id, spaceAllowlist)),
-    [allowlistPending, pages, spaceAllowlist]
+    () => (spacesPending ? [] : pages.flatMap(page => page.claims).filter(entry => spaceShowsClaims(entry.claim.space_id))),
+    [pages, spaceShowsClaims, spacesPending]
   );
 
   // The space menu offers only what the list can actually show, so picking an option never lands
   // the viewer on an empty list they can't explain.
   const facetSpaceIds = React.useMemo(
-    () => (allowlistPending ? [] : (facets?.space_ids ?? []).filter(id => isClaimSpaceAllowed(id, spaceAllowlist))),
-    [allowlistPending, facets?.space_ids, spaceAllowlist]
+    () => (spacesPending ? [] : (facets?.space_ids ?? []).filter(spaceShowsClaims)),
+    [facets?.space_ids, spaceShowsClaims, spacesPending]
   );
 
   // The server re-sorts on every readiness change, so hold the order the user is looking at until
@@ -176,7 +193,7 @@ export function ClaimsTab() {
       />
 
       <HubQueryState
-        isLoading={claimsQuery.isLoading || allowlistPending}
+        isLoading={claimsQuery.isLoading || spacesPending}
         error={claimsQuery.error}
         onRetry={() => void claimsQuery.refetch()}
         isEmpty={visibleClaims.length === 0}
@@ -221,7 +238,7 @@ export function ClaimsTab() {
           Not while the allowlist is pending, though: the tab is showing a four-row skeleton then,
           so the sentinel sits in view under it and pages the corpus on the strength of a loading
           state being visible — reading "the viewer reached the end" off a list that isn't there. */}
-      {claimsQuery.hasNextPage && !allowlistPending ? (
+      {claimsQuery.hasNextPage && !spacesPending ? (
         <div ref={sentinelRef} data-testid="claims-scroll-sentinel" className="h-px" />
       ) : null}
     </div>


### PR DESCRIPTION
Part of GEO-2649.

**#2215 only did half of this ticket.** It asks for the gate in the debates side panel as well as the debate-again flow, and #2215 wired it into the picker only — I marked the ticket Done, then checked the call sites and found `useDebatePublishableSpaces` had exactly one consumer. The side panel's Claims tab was still filtering on the viewer's space allowlist alone.

## The two gates are different questions

The allowlist asks whether **this viewer** may see the space. Publishability asks whether **a debate there could ever be published** — the acceptor has to be an editor of it, or the debate fails on-chain at the very end. A claim has to clear both, and offering one that can't carry a debate is offering a dead end.

## Following what's already there

Both edges of the existing allowlist behaviour matter and both are kept:

- **It waits rather than trimming.** `null` means unknown and deliberately doesn't filter, so listing first would show claims and pull them back out a moment later — the flicker GEO-2600 and GEO-2604 are about.
- **A settled-but-empty answer still doesn't filter.** No acceptor configured returns `null`, and local environments run with none at all. Reading that as "nothing is publishable" would empty the tab.

The space filter is narrowed alongside the list, so picking an option never lands the viewer on an empty list they can't explain.

## Verification

Five tests. Four were checked by reverting the fix and confirming they fail: the filter, the two-gate composition, the space menu, and the wait-don't-trim case. The fifth — falls through when the lookup comes back empty — passes either way by design; it's a guard against over-filtering, not a test of the filter, and I'd rather say that than imply it's load-bearing.

`claims-tab` suite green at 25/25, typecheck clean. Leaving the full suite to CI: my local run was invalidated when I split this onto its own branch.

## Still open on the ticket

Preston's note about the **empty state not explaining why** claims disappeared. Filtering silently means fewer results with no reason given. Better done once we can see how much actually gets filtered in practice.