### PR TITLE
feat(debates): drop the respond-first caption from claim cards

### DIFF
--- a/apps/web/core/debates/matchmaking/claim-readiness-toggle.test.tsx
+++ b/apps/web/core/debates/matchmaking/claim-readiness-toggle.test.tsx
@@ -126,12 +126,14 @@ describe('ClaimReadinessToggle', () => {
   });
 
   // The position is an on-chain response, so readiness cannot be turned on before there is one.
-  // The reason is shown rather than left in a `title`, which never appears on touch.
-  it('cannot be turned on before the viewer has responded, and says why', () => {
-    renderToggle(readiness({ viewer_response: null }));
+  // That is now left to the disabled switch and the response pills beside it, rather than spelled
+  // out in a caption — but it must still not leak the backend's raw disabled reason into the gap.
+  it('cannot be turned on before the viewer has responded, and stays silent about it', () => {
+    renderToggle(readiness({ viewer_response: null, readiness_disabled_reason: 'awaiting_response' }));
 
     expect(toggle()).toBeDisabled();
-    expect(screen.getByText('Respond to this claim to debate it.')).toBeInTheDocument();
+    expect(screen.queryByText('Respond to this claim to debate it.')).not.toBeInTheDocument();
+    expect(screen.queryByText('awaiting_response')).not.toBeInTheDocument();
     fireEvent.click(toggle());
     expect(mocks.joinMutateAsync).not.toHaveBeenCalled();
   });

--- a/apps/web/core/debates/matchmaking/claim-readiness-toggle.tsx
+++ b/apps/web/core/debates/matchmaking/claim-readiness-toggle.tsx
@@ -45,12 +45,18 @@ export function ClaimReadinessToggle({ claim, readiness, activeDebate }: Props) 
   // `readiness_disabled_reason` explains why readiness is currently off; it never blocks turning
   // it back on. Standing yourself down reports `user_disabled`, which the mapper drops entirely —
   // treating it as a blocker would make standing down a one-way door.
+  //
+  // Having no position of your own is deliberately silent. The switch is disabled until you take
+  // a side, and this used to spell that out, but the response pills sit directly under this in the
+  // card — the card already shows what to do. The branch stays rather than falling through to the
+  // reason mapper, whose default returns the backend's raw reason string: dropping it would swap
+  // one sentence for whatever token geo-chat happens to send for "hasn't responded".
   const explanation = ready
     ? undefined
     : activeDebate
       ? 'This claim is being debated right now.'
       : viewerPosition === null
-        ? 'Respond to this claim to debate it.'
+        ? undefined
         : (readinessReasonMessage(readiness.readiness_disabled_reason) ?? undefined);
 
   const explanationId = React.useId();

--- a/apps/web/core/debates/matchmaking/matchmaking-claim-card.test.tsx
+++ b/apps/web/core/debates/matchmaking/matchmaking-claim-card.test.tsx
@@ -282,7 +282,9 @@ describe('MatchmakingClaimCard', () => {
     expect(mocks.submitResponse).toHaveBeenCalled();
   });
 
-  it('explains why the toggle is unavailable without a response', () => {
+  it('leaves the toggle disabled and uncaptioned without a response', () => {
+    // The card still shows what to do: the response pills render directly beneath this header,
+    // so the disabled switch no longer carries a caption of its own.
     renderCard(
       <MatchmakingClaimCard
         claim={claim}
@@ -292,6 +294,6 @@ describe('MatchmakingClaimCard', () => {
     );
 
     expect(screen.getByRole('switch', { name: toggleName })).toBeDisabled();
-    expect(screen.getByText('Respond to this claim to debate it.')).toBeInTheDocument();
+    expect(screen.queryByText('Respond to this claim to debate it.')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Closes [GEO-2657](https://linear.app/geobrowser/issue/GEO-2657/debates-remove-respond-to-this-claim-to-debate-it-text-from-claim).

Removes "Respond to this claim to debate it." from the top right of claim cards.

## Every surface, from one edit

The ticket asks whether this should go everywhere claim cards render rather than only where it was noticed. It should, and it does — all three surfaces render the same `MatchmakingClaimCard`, which owns the one `ClaimReadinessToggle` that produced the line:

| surface | render site |
|---|---|
| debates panel, Matches tab | `matches-tab.tsx:119` |
| debates panel, Claims tab | `claims-tab.tsx:203` |
| debate-again / rematch flow | `rematch-page-client.tsx:1030` |

Nothing outside that component ever showed this string. The sibling control on a claim's entity page (`claim-debate-readiness.tsx`) renders only the mapped `readiness_disabled_reason`, and is unchanged.

## The branch stays, emptied

The caption came from a `viewerPosition === null` branch. Deleting it outright would fall through to `readinessReasonMessage(readiness.readiness_disabled_reason)`, whose `default` case returns the backend's reason **verbatim** — and that field is an open `string | null`. So a plain deletion risks swapping one sentence for whatever raw token geo-chat sends for "hasn't responded".

The branch now returns `undefined` instead, which keeps that gap deliberately empty. There's a comment saying so, and a test pinning it, since the shape now looks redundant enough to invite a later "simplification".

## On the onboarding note

The ticket asks whether the text was doing onboarding work. It was explaining why the Debate switch is greyed out — `disabled = !checked && !canEnableToggle`, and `canEnableToggle` requires a position — and the original author deliberately rendered it as visible text rather than a `title`, because tooltips don't fire on touch or on disabled buttons.

What replaces it is proximity rather than nothing: `MatchmakingClaimCard` renders `PositionRow` — the Agree/Disagree pills — directly beneath the header holding the switch. The two sit on the same card, so the thing you must do to enable the switch is already on screen next to it. That reads as discoverable to me, but it is a judgment call and you're better placed to make it. If you'd rather keep a hint, a `title` on the disabled switch is the cheap middle ground, with the caveat above about touch.

## Testing

- The two tests asserting the string is present now assert it is absent, with the switch still disabled and the click still refused.
- The toggle test also feeds an unmapped `readiness_disabled_reason: 'awaiting_response'` and asserts it does **not** surface — the leak the emptied branch exists to prevent.
- `vitest run core/debates` — 685 passing across 60 files.
- `bun run build` clean.

Not verified in a browser: claim cards live behind geo-chat auth, which this environment doesn't have. The tests render the card directly and assert the header contents.