### PR TITLE
fix(debates): stop the opponent tab claiming zero positions before it knows

### DIFF
--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
@@ -855,6 +855,47 @@ describe('DebateRematchPageClient', () => {
     expect(screen.getByText('A claim both participants chose')).toBeInTheDocument();
   });
 
+  // GEO-2656. The badge counted a list that is empty until three dependent round trips land, so it
+  // opened on `0` — which is not a placeholder but a claim, and a wrong one, on the one tab that is
+  // about the opponent's positions.
+  it('counts nothing until the opponent’s positions are actually known', () => {
+    // First load: in flight with nothing back yet. Both halves matter — the count is only unknown
+    // while the query is running *and* has produced no rows.
+    mocks.positions = [];
+    mocks.positionsLoading = true;
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+
+    expect(screen.getByLabelText('Counting positions')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Salina’s positions/ })).not.toHaveTextContent('0');
+  });
+
+  // The count is derived from ids that come *from* positions, so while that query is in flight the
+  // id list is empty and the two claim lookups are disabled rather than loading. Nothing downstream
+  // reports as pending, which is why the badge has to consult the positions query itself.
+  it('shows the count once it is known', () => {
+    mocks.positionsLoading = false;
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+
+    expect(screen.queryByLabelText('Counting positions')).toBeNull();
+    expect(screen.getByRole('button', { name: /Salina’s positions/ })).toHaveTextContent('1');
+  });
+
+  // A new response from the opponent restarts the lookups while `useLastSettled` still holds a list
+  // that is right for every claim already on it. Dropping back to a skeleton would flicker the badge
+  // on precisely the event that should be invisible.
+  it('keeps showing a known count while a refetch is in flight', () => {
+    const { rerender } = render(<DebateRematchPageClient sessionId="rematch-1" />);
+    expect(screen.getByRole('button', { name: /Salina’s positions/ })).toHaveTextContent('1');
+
+    // Same instance, so `useLastSettled` is holding the list it already drew. A fresh render would
+    // have no settled value to hold and would legitimately show the skeleton.
+    mocks.entityHydrationLoading = true;
+    rerender(<DebateRematchPageClient sessionId="rematch-1" />);
+
+    expect(screen.queryByLabelText('Counting positions')).toBeNull();
+    expect(screen.getByRole('button', { name: /Salina’s positions/ })).toHaveTextContent('1');
+  });
+
   // The opponent's claims arrive in one round trip; the curated lookup is three in sequence. The
   // viewer lands on what is ready, and a curated page arriving afterwards adds its tab rather than
   // moving them onto it — being moved once the lookup settles is worse than a tab appearing.

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -64,6 +64,7 @@ import { getTopRankedSpaceId } from '~/core/utils/space/space-ranking';
 import { getChecked } from '~/design-system/checkbox';
 import { ChevronDownSmall } from '~/design-system/icons/chevron-down-small';
 import { Input } from '~/design-system/input';
+import { Skeleton } from '~/design-system/skeleton';
 import { Text } from '~/design-system/text';
 
 const SEARCH_DEBOUNCE_MS = 250;
@@ -509,6 +510,27 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
     [opponentClaims, opponentPositionOf]
   );
 
+  /**
+   * GEO-2656. The badge drew `0` from the very first paint, because the count is derived from a
+   * list that is empty until three dependent round trips land — positions, then the claim
+   * entities, then the session's rematch rows.
+   *
+   * Zero is not a neutral placeholder here. It is a specific, confident claim — "this person holds
+   * no positions" — and it is usually wrong, on the one tab whose whole purpose is their
+   * positions. A viewer who reads it and switches away has been told something false.
+   *
+   * `positions.isLoading` has to be part of this. The two claim lookups are keyed on ids that come
+   * *from* positions, so while positions is still in flight the id list is empty, those queries
+   * are disabled rather than loading, and nothing downstream reports as pending.
+   *
+   * Once a settled list exists the number is shown even while a refetch is in flight: a new
+   * response from the opponent restarts the lookups, and `useLastSettled` is still holding a list
+   * that is correct for every claim already on it. Going back to a skeleton there would flicker
+   * the badge on exactly the event that ought to be invisible.
+   */
+  const opponentCountPending =
+    opponentClaims.length === 0 && (positions.isLoading || opponentClaimsSettling);
+
   const hasRecommended = recommendedSections.length > 0;
   // The opponent's claims arrive in one round trip; the curated lookup is three, in sequence. The
   // picker lands on whichever has something to show first and stays there: once a tab has drawn
@@ -735,7 +757,14 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
                   tab === 'opponent' ? 'bg-text text-white' : 'bg-grey-01 text-grey-04'
                 )}
               >
-                {opponentPositionCount}
+                {/* The badge keeps its size either way, so the strip doesn't reflow when the
+                    number lands. See `opponentCountPending`: a skeleton says "still counting",
+                    where `0` said "none" and was usually wrong. */}
+                {opponentCountPending ? (
+                  <Skeleton radius="rounded-full" className="h-3 w-3" aria-label="Counting positions" />
+                ) : (
+                  opponentPositionCount
+                )}
               </span>
             </TabButton>
             <TabButton active={tab === 'all'} onClick={() => setTab('all')}>


### PR DESCRIPTION
Items 1 and 3 of GEO-2656.

The badge on the opponent's tab is derived from a list that stays empty until **three dependent round trips** land — `useParticipantPositions`, then `useClaimEntitiesByIds` keyed on ids from that, then the session's rematch rows. So it drew `0` from the first paint.

Zero isn't a neutral placeholder here. It's a specific, confident claim — *this person holds no positions* — it's usually wrong, and it's on the one tab whose entire purpose is their positions. A viewer who reads it and switches away has been told something false.

## What changed

A skeleton until the count is actually known. The badge keeps its size either way, so the tab strip doesn't reflow when the number lands.

Two details that took some working out:

- **`positions.isLoading` has to be in the condition.** The two claim lookups are keyed on ids that come *from* positions, so while that query is in flight the id list is empty, those queries are **disabled rather than loading**, and nothing downstream reports as pending. I verified this is load-bearing by dropping just that term — the test fails.
- **A known count stays up during a refetch.** A new response from the opponent restarts the lookups while `useLastSettled` is still holding a list that's correct for every claim already on it. Going back to a skeleton there would flicker the badge on exactly the event that ought to be invisible.

## Verification

86/86 in the rematch suite. One of the three new tests fails without the fix; the other two — *shows the count once known*, *keeps a known count during a refetch* — pass either way. They're guards against the obvious ways to get this wrong rather than tests of the new behaviour, and I'd rather say so than imply all three are load-bearing.

My first attempt at these tests was wrong in a way worth recording: I set `positionsLoading = true` and expected an empty list, but the harness supplies position rows regardless of the loading flag, so the list was never empty and the skeleton never rendered. The real first-load state needs `positions = []` **and** loading — which is also the state the fix is actually about.

## Not in scope

**Item 3** (a loading indicator while claims load) already exists — `HubQueryState` has it. I'm not claiming credit for it.

**Item 2** (a cheap count endpoint) and **item 4** (load speed) are untouched. Both need an API-side answer: geo-chat would have to return the opponent's claim count without the three-hop hydration, and that's a backend change rather than anything this file can do. Worth splitting item 4 out once profiling says where the time goes.