### PR TITLE
fix(debates): stop the ready prompt flashing over an accept in flight

### DIFF
--- a/apps/web/core/debates/debate-coordinator.test.tsx
+++ b/apps/web/core/debates/debate-coordinator.test.tsx
@@ -5,7 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { DebateActivity, DebateRequestsResponse, DebateSharePrompt } from './api';
 import { DebateCoordinator } from './debate-coordinator';
-import { clearEnteringDebate, markEnteringDebate } from './debate-entry-intent';
+import { clearEnteringDebate, markEnteringDebate, markEnteringPendingDebate } from './debate-entry-intent';
 
 const mocks = vi.hoisted(() => ({
   push: vi.fn(),
@@ -515,6 +515,71 @@ describe('DebateCoordinator', () => {
     expect(screen.queryByText('Your debate is ready')).not.toBeInTheDocument();
     // Nor the fallback bar: it would flash in exactly the same window.
     expect(screen.queryByRole('button', { name: /Your debate is/ })).not.toBeInTheDocument();
+  });
+
+  // GEO-2604, the other window: accepting is a round trip, the server creates the debate inside it
+  // and emits `debate.state_changed` to the accepting tab, so that tab's own socket event can hand
+  // the coordinator a `ready` debate on some other path while the response it is waiting on is still
+  // in flight. The id-keyed intent cannot help — there is no id until the response arrives.
+  it('does not prompt while this tab is waiting on an accept', async () => {
+    mocks.pathname = '/space/space-1/claims';
+    mocks.activity = {
+      ...activityWithDebate(),
+      rematch: null,
+      debate: { ...activityWithDebate().debate!, status: 'ready', participants: bothParticipants() },
+    };
+    const release = markEnteringPendingDebate();
+
+    try {
+      render(<DebateCoordinator />);
+
+      await waitFor(() => expect(mocks.push).not.toHaveBeenCalled());
+      expect(screen.queryByText('Your debate is ready')).not.toBeInTheDocument();
+      // Nor the rejoin bar, which would flash in the same window for the same reason.
+      expect(screen.queryByRole('button', { name: /Your debate is/ })).not.toBeInTheDocument();
+    } finally {
+      release();
+    }
+  });
+
+  // Released when the mutation settles, so a failed accept cannot leave the viewer with no way in.
+  it('prompts again once the accept has settled', async () => {
+    mocks.pathname = '/space/space-1/claims';
+    mocks.activity = {
+      ...activityWithDebate(),
+      rematch: null,
+      debate: { ...activityWithDebate().debate!, status: 'ready', participants: bothParticipants() },
+    };
+    const release = markEnteringPendingDebate();
+    const { rerender } = render(<DebateCoordinator />);
+    expect(screen.queryByText('Your debate is ready')).not.toBeInTheDocument();
+
+    release();
+    rerender(<DebateCoordinator />);
+
+    await waitFor(() => expect(screen.getByText('Your debate is ready')).toBeInTheDocument());
+  });
+
+  // Counted, not boolean: two accepts can overlap, and the first to settle must not drop the
+  // second's claim and let the prompt through underneath it.
+  it('keeps suppressing while a second overlapping accept is still in flight', async () => {
+    mocks.pathname = '/space/space-1/claims';
+    mocks.activity = {
+      ...activityWithDebate(),
+      rematch: null,
+      debate: { ...activityWithDebate().debate!, status: 'ready', participants: bothParticipants() },
+    };
+    const releaseFirst = markEnteringPendingDebate();
+    const releaseSecond = markEnteringPendingDebate();
+    const { rerender } = render(<DebateCoordinator />);
+
+    releaseFirst();
+    rerender(<DebateCoordinator />);
+    expect(screen.queryByText('Your debate is ready')).not.toBeInTheDocument();
+
+    releaseSecond();
+    rerender(<DebateCoordinator />);
+    await waitFor(() => expect(screen.getByText('Your debate is ready')).toBeInTheDocument());
   });
 
   // Still prompted anywhere else, so suppressing it above cannot swallow a real one.

--- a/apps/web/core/debates/debate-coordinator.tsx
+++ b/apps/web/core/debates/debate-coordinator.tsx
@@ -14,7 +14,7 @@ import { type DebateSharePrompt } from './api';
 import { useClaimResponseIndexedNotifier } from './claim-response-indexed-notifier';
 import { useDebateAttention, useDebatePresence } from './debate-attention';
 import { DebateChallengeDialog } from './debate-challenge-dialog';
-import { clearEnteringDebate, useEnteringDebateId } from './debate-entry-intent';
+import { clearEnteringDebate, useEnteringDebateId, useEnteringDebatePending } from './debate-entry-intent';
 import { useDebateGateway } from './debate-gateway';
 import { DebateReadyPrompt, DebateRejoinBar } from './debate-ready-prompt';
 import { rememberDebateReturnDestination } from './debate-return-navigation';
@@ -76,7 +76,13 @@ export function DebateCoordinator() {
   // pathname — for the seconds the route takes, while the activity it invalidated on the way out
   // comes straight back reporting the debate.
   const enteringDebateId = useEnteringDebateId();
-  const atDebate = Boolean(debate && (pathname.includes(`/debates/${debate.id}`) || debate.id === enteringDebateId));
+  // And the same, one step earlier: an accept in flight has no debate id to key on yet, but this tab
+  // is just as much on its way in, and its own `debate.state_changed` can arrive before the response
+  // does (GEO-2604). Not keyed on `debate` — the point is to cover the window where the id is not
+  // known, so it cannot be matched against one.
+  const enteringPending = useEnteringDebatePending();
+  const atDebate =
+    enteringPending || Boolean(debate && (pathname.includes(`/debates/${debate.id}`) || debate.id === enteringDebateId));
   // The rematch page walks the viewer into its own converted debate, and accepting fires a single
   // `debate.rematch_changed` that the gateway turns into *two* refetches — the account's activity
   // and the rematch session — either of which can land first. When activity wins, this coordinator

--- a/apps/web/core/debates/debate-entry-intent.ts
+++ b/apps/web/core/debates/debate-entry-intent.ts
@@ -31,6 +31,7 @@ const ENTRY_INTENT_TIMEOUT_MS = 30_000;
 
 let enteringDebateId: string | null = null;
 let expiry: ReturnType<typeof setTimeout> | null = null;
+let pendingEntries = 0;
 const listeners = new Set<() => void>();
 
 function emit() {
@@ -63,6 +64,36 @@ export function clearEnteringDebate(debateId?: string) {
   set(null);
 }
 
+/**
+ * The same intent, for the window where the debate has no id yet (GEO-2604).
+ *
+ * `markEnteringDebate` can only be called once the accept response names the debate, and the accept
+ * is a round trip. The server creates the debate inside it and emits `debate.state_changed` to both
+ * parties, so the accepting tab's *own* gateway event can land, invalidate activity, and hand the
+ * coordinator a `ready` debate on some other path — the exact shape it reads as "this person has not
+ * been told" — while the response it is waiting on is still in flight. The prompt appears for as
+ * long as the round trip has left to run, then the push takes it away. That is the popup Preston saw
+ * flash and then redirect without him touching it.
+ *
+ * Held from the moment the mutation is sent, so there is no window left to lose. Counted rather than
+ * boolean: two accepts can overlap, and the first to settle must not release the second's claim.
+ *
+ * No timeout here, unlike the id-keyed intent above. This is released by the mutation settling,
+ * which React Query guarantees on both success and failure — where the id-keyed intent is released
+ * by a navigation that may never commit and so needs its own backstop.
+ */
+export function markEnteringPendingDebate(): () => void {
+  pendingEntries += 1;
+  emit();
+  let released = false;
+  return () => {
+    if (released) return;
+    released = true;
+    pendingEntries -= 1;
+    emit();
+  };
+}
+
 const subscribe = (listener: () => void) => {
   listeners.add(listener);
   return () => {
@@ -75,4 +106,12 @@ const getServerSnapshot = () => null;
 
 export function useEnteringDebateId() {
   return React.useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}
+
+const getPendingSnapshot = () => pendingEntries > 0;
+const getPendingServerSnapshot = () => false;
+
+/** Whether this tab is waiting on an accept that will walk it into a debate room. */
+export function useEnteringDebatePending() {
+  return React.useSyncExternalStore(subscribe, getPendingSnapshot, getPendingServerSnapshot);
 }

--- a/apps/web/core/debates/hooks.ts
+++ b/apps/web/core/debates/hooks.ts
@@ -64,7 +64,7 @@ import {
 } from './api';
 import { claimResponseIndexedEvent } from './claim-response-indexed-notifier';
 import { useDebateAttention, useDebatePresence } from './debate-attention';
-import { markEnteringDebate } from './debate-entry-intent';
+import { markEnteringDebate, markEnteringPendingDebate } from './debate-entry-intent';
 import { useDebateGatewayScope, useDebateGatewaySnapshot, useDebateGatewaySpaceScopes } from './debate-gateway';
 import { hasProcessedVideo } from './playback-utils';
 import {
@@ -724,6 +724,11 @@ export function useAcceptDebateRematchRequest() {
 
   return useMutation({
     mutationFn: (requestId: string) => acceptDebateRematchRequest(requestId, getPrivyIdentityToken, accountKey),
+    // Same window as the hub's accept: the debate is created inside this round trip and announced to
+    // this tab over its own socket, so the id-keyed intent below is taken too late to stop the
+    // coordinator prompting us to join it (GEO-2604).
+    onMutate: () => ({ releaseEntry: markEnteringPendingDebate() }),
+    onSettled: (_result, _error, _variables, context) => context?.releaseEntry(),
     onSuccess: result => {
       queryClient.setQueryData(debateQueryKeys.rematch(accountKey, result.session.id), result.session);
       void queryClient.invalidateQueries({ queryKey: debateQueryKeys.rematch(accountKey, result.session.id) });

--- a/apps/web/core/debates/matchmaking/hooks.ts
+++ b/apps/web/core/debates/matchmaking/hooks.ts
@@ -22,7 +22,7 @@ import {
   unblockDebateUser,
   withdrawDebateRequest,
 } from '../api';
-import { markEnteringDebate } from '../debate-entry-intent';
+import { markEnteringDebate, markEnteringPendingDebate } from '../debate-entry-intent';
 import { useDebateGatewayScope } from '../debate-gateway';
 import { debatePath } from '../debate-routes';
 import {
@@ -287,6 +287,12 @@ export function useAcceptDebateRequest() {
   return useMutation({
     mutationFn: ({ requestId, formatId }: { requestId: string; formatId?: string }) =>
       acceptDebateRequest(requestId, getPrivyIdentityToken, accountKey, formatId),
+    // Claimed before the request leaves, released when it settles. The id-keyed intent below cannot
+    // be taken until the response names the debate, and the server emits `debate.state_changed` to
+    // this very tab on the way — so without this the coordinator gets a `ready` debate off our own
+    // socket event, mid-round-trip, and prompts us to join what we are already accepting (GEO-2604).
+    onMutate: () => ({ releaseEntry: markEnteringPendingDebate() }),
+    onSettled: (_result, _error, _variables, context) => context?.releaseEntry(),
     onSuccess: result => {
       if (result.debate) {
         queryClient.setQueryData(debateQueryKeys.debate(result.debate.id), result.debate);


### PR DESCRIPTION
Part of GEO-2604 — the popup half.

> I sent someone else a request. They accepted. Then this popup came up for a second, required no interaction from me, and then without me clicking redirected me to the I'm ready screen.

## Why the existing guard couldn't catch it

`markEnteringDebate` exists for exactly this flicker, and its docstring says so. It landed **2026-08-13** — a week *before* this report — so it was already in place and didn't hold.

It can't. It needs the debate id, and the id doesn't exist until the accept response arrives. The suppression it provides begins at `onSuccess`, which is where the window **ends**, not where it starts.

## The window

Accepting creates the debate inside the round trip, and the server announces it with `debate.state_changed` to **both** parties — including the tab doing the accepting. So that tab's own socket event can land, invalidate activity, and hand the coordinator a `ready` debate on some other path — the exact shape it reads as "this person has not been told" — while the response it's waiting on is still in flight. The prompt opens for whatever's left of the round trip; the push then takes it away, untouched.

## The fix

Claim the intent when the mutation is *sent*, via a counted `markEnteringPendingDebate()` released in `onSettled`.

- **Counted, not boolean** — two accepts can overlap, and the first to settle mustn't drop the second's claim and let the prompt through underneath it.
- **Released on settle**, which React Query guarantees for failures too, so a rejected accept can't leave the viewer with no way in.
- **No timeout**, unlike the id-keyed intent — that one is released by a navigation which may never commit and so needs its own backstop; this one is released by the mutation, which always settles.

Applied to both accept paths that can produce a debate. The challenge accept creates a rematch *session* and routes through the coordinator's rematch effect, which doesn't prompt, so it needs nothing.

## Verification

Three tests, each checked by reverting the fix and confirming it fails. There was already a GEO-2604 test for a *different* window (the rematch page's own conversion race), so these are complementary rather than duplicate. 916 tests / 63 files green across `core/debates` and the debates routes.

## Two things worth flagging

**This got more reachable, not less, after #2222.** A socket that previously sat dead delivered no event at all, so there was nothing to race the round trip with. Fixing the socket is what exposes this.

**I have not reproduced Preston's exact sequence.** He describes himself as the request *sender*, but this mechanism only fires on the *accepting* side — there is no auto-navigation for a sender anywhere in the code, so either he was the accepter or he had both sides open. The mechanism is real and the description matches it precisely; which seat he was in, I can't confirm.

## Not in this PR

The ticket's first half — *"various loading indicators that don't need to be there"* when entering a debate — is a screen recording I can't watch. I'd need either a list of which indicators, or I can audit the entry path and propose removals to check against the video.