### PR TITLE
feat: read and write votes in the space an entity lives in, not the one listing it

### DIFF
--- a/apps/web/partials/entity-page/entity-vote-buttons.claim-space.test.tsx
+++ b/apps/web/partials/entity-page/entity-vote-buttons.claim-space.test.tsx
@@ -141,6 +141,19 @@ function claimEntity({ isFactualIn, alsoIn }: { isFactualIn?: string; alsoIn?: s
   };
 }
 
+/** A non-claim entity — no Types relation — holding its name in exactly one space. */
+function plainEntity({ livesIn }: { livesIn: string }) {
+  return {
+    id: 'claim-1',
+    name: 'Something else',
+    spaces: [livesIn],
+    relations: [],
+    values: [
+      { property: { id: SystemIds.NAME_PROPERTY }, spaceId: livesIn, value: 'Something else', isDeleted: false },
+    ],
+  };
+}
+
 function renderButtons() {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return render(<EntityVoteButtons entityId="claim-1" spaceId={BLOCK_SPACE} />, {
@@ -246,24 +259,30 @@ describe('EntityVoteButtons response space resolution', () => {
   });
 
   /**
-   * Curation is per-space by design: the same entity is upvoted separately in each space that lists
-   * it, and this component draws those arrows too. Re-homing them would hide a reader's existing
-   * vote behind a tally from a space they never visited, then write the next one somewhere else
-   * again — and `ensureSpaceMembership` would propose membership there on their behalf.
+   * Curation re-homes on the same rule as a claim's stance (GEO-2660): a table listing the
+   * top-ranked version of an entity shows that version's votes, so the arrows belong to the space
+   * the row is actually showing rather than the one doing the listing.
    */
-  it('leaves a non-claim entity voting in the space listing it', async () => {
-    mocks.entity = {
-      id: 'entity-1',
-      name: 'Something else',
-      spaces: [CLAIM_SPACE],
-      relations: [],
-      values: [
-        { property: { id: SystemIds.NAME_PROPERTY }, spaceId: CLAIM_SPACE, value: 'Something else', isDeleted: false },
-      ],
-    };
+  it('tallies a non-claim entity in the space it lives in, not the one listing it', async () => {
+    mocks.entity = plainEntity({ livesIn: CLAIM_SPACE });
     renderButtons();
 
-    // The curation controls: a net score, not a percentage.
+    // The curation controls: a net score, not a percentage. Still curation — only the space moved.
+    await screen.findByText('1');
+    expect(mocks.countsSpaceIds).toContain(CLAIM_SPACE);
+    expect(mocks.countsSpaceIds).not.toContain(BLOCK_SPACE);
+    expect(mocks.responseSpaceIds.at(-1)).toBe(CLAIM_SPACE);
+  });
+
+  /**
+   * The other half of that rule, and the reason broadening it is narrow in practice: an entity the
+   * listing space actually holds content in does not move. Every ordinary row and every entity page
+   * is this case, so a reader's existing curation vote stays where they cast it.
+   */
+  it('leaves an ordinary non-claim row voting in the space listing it', async () => {
+    mocks.entity = plainEntity({ livesIn: BLOCK_SPACE });
+    renderButtons();
+
     await screen.findByText('1');
     expect(mocks.countsSpaceIds).toContain(BLOCK_SPACE);
     expect(mocks.countsSpaceIds).not.toContain(CLAIM_SPACE);

--- a/apps/web/partials/entity-page/entity-vote-buttons.tsx
+++ b/apps/web/partials/entity-page/entity-vote-buttons.tsx
@@ -101,17 +101,23 @@ export function EntityVoteButtons({
     activeRelations.some(
       relation => uuidToHex(relation.type.id) === TYPES_PROPERTY && uuidToHex(relation.toEntity.id) === CLAIM_TYPE
     ) ?? false;
-  // Which space the response belongs to, which is not always the one the caller renders from. A
-  // claim collected into a curated page without a pinned target space arrives here as the page's
-  // own space, where the claim holds nothing: the counts came back empty and the percentage read
-  // 0%. Resolving it to the space the claim actually lives in is what puts the tally back.
+  // Which space the response belongs to, which is not always the one the caller renders from. An
+  // entity collected into a curated page without a pinned target space arrives here as the page's
+  // own space, where it holds nothing: the counts came back empty and the percentage read 0%.
+  // Resolving it to the space the entity actually lives in is what puts the tally back.
   //
-  // Claims only. A claim is one debate wherever it is listed, so its responses belong to the space
-  // it was published to; curation is per-space by design — the same entity is upvoted separately in
-  // each space that lists it, and this component draws those arrows too. Re-homing them would hide
-  // a reader's existing vote behind a tally from a space they never visited, then write the next
-  // one somewhere else again.
-  const spaceId = isClaim ? resolveEntitySpaceId(entity, requestedSpaceId) : requestedSpaceId;
+  // Every response kind, not only claims (GEO-2660). A table that lists the top-ranked version of
+  // an entity should show that version's votes, so curation follows the same rule as a claim's
+  // stance: the arrows belong to whichever space the row is actually showing. This does not re-home
+  // curation wholesale — `resolveEntitySpaceId` keeps the requested space whenever the entity holds
+  // live content there, so every ordinary row and every entity page are untouched, and only a row
+  // listing an entity that lives somewhere else diverts.
+  //
+  // What it costs: a curation vote cast against a listing space before this reads as the entity
+  // holding nothing there — nothing but the Score that vote itself wrote, which residency ignores
+  // by design — so that vote is no longer the one displayed. It is still recorded in that space.
+  // Auto-join doesn't widen with it: `useEntityVote` excludes curation from `ensureSpaceMembership`.
+  const spaceId = resolveEntitySpaceId(entity, requestedSpaceId);
   const isFactualClaim =
     isClaim &&
     getChecked(


### PR DESCRIPTION
Closes GEO-2660.

## What changed

One line, in `EntityVoteButtons`:

```diff
-const spaceId = isClaim ? resolveEntitySpaceId(entity, requestedSpaceId) : requestedSpaceId;
+const spaceId = resolveEntitySpaceId(entity, requestedSpaceId);
```

This branch previously carried a parallel implementation of the same resolution. #2184 landed first and did it better — `resolveEntitySpaceId`, the Score exclusion, the deterministic tie-break, the id normalization. That work is all gone from here; the branch is reset onto master and reduced to broadening the rule #2184 established.

## Why broaden it

#2184 restricted re-homing to claims, reasoning that curation is per-space by design — the same entity is upvoted separately in each space that lists it, so moving the arrows would hide a reader's vote behind a tally from a space they never visited.

That holds for an entity a space genuinely curates. It does not hold for a row that is showing **another space's** entity, which is what GEO-2660 is about: if a table lists the top-ranked version of an entity, the votes on screen should be that version's. Today the arrows tally a space the reader isn't looking at, and their vote is written there.

Worth being explicit that this reverses a documented decision — @b-d055, flagging for you directly rather than quietly undoing it.

## Why it is narrower than it sounds

`resolveEntitySpaceId` returns the requested space whenever the entity holds live content there. So:

| Case | Before | After |
|---|---|---|
| Entity page, entity lives in that space | requested | unchanged |
| Ordinary row, block and entity share a space | requested | unchanged |
| Row listing an entity that lives elsewhere | requested | **entity's space** |
| Claim collected without a pinned target space | entity's space | unchanged |

Only the third row moves.

## The cost

A curation vote cast against a listing space before this change is no longer the one displayed. Residency deliberately ignores the Score property (`placesEntity`), and in a listing space that Score is typically the only value the entity has — written by the vote itself. So such a space stops reading as home. The vote is still recorded there; it is a display change, not a data change.

Auto-join does not widen with it: `useEntityVote` already excludes `curation` from `ensureSpaceMembership` ([use-entity-vote.ts:371](https://github.com/geobrowser/geogenesis/blob/master/apps/web/core/hooks/use-entity-vote.ts#L371)), so no membership proposals follow from this.

## Tests

`entity-vote-buttons.claim-space.test.tsx` — the test pinning claims-only is replaced by two:

- a non-claim listed from a space it holds nothing in tallies and responds in the space it lives in
- an ordinary non-claim row, whose entity lives in the listing space, stays put

Verified non-vacuous: restoring the `isClaim` gate fails the first and only the first. 79 tests pass across the vote, home-space, row-actions, side-panel-scope and ranking suites.

## Not verified

Not exercised in a running browser — no check against a real table of another space's entities.
