### PR TITLE
fix(debates): say what the picker is waiting for before Request debate

### DIFF
--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
@@ -1605,6 +1605,27 @@ describe('DebateRematchPageClient', () => {
     expect(screen.queryByRole('button', { name: 'Request debate' })).not.toBeInTheDocument();
   });
 
+  // GEO-2652. The wait above is real — a publish, an index and a notification — and rendering
+  // nothing while it runs is what Preston reported: no idea what he was waiting on. The button still
+  // waits, because geo-chat would reject an early request; what changes is that the wait is named.
+  it('says what it is waiting for while the position is being confirmed', () => {
+    mocks.positions = [position('profile-remote', CLAIM_SHARED, SPACE_1, false)];
+    mocks.optimisticResponses.set(CLAIM_SHARED, 'positive');
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+
+    expect(screen.getByRole('status')).toHaveTextContent('Confirming your position…');
+    expect(screen.queryByRole('button', { name: 'Request debate' })).not.toBeInTheDocument();
+  });
+
+  // And nothing is said before the viewer has taken a side — there is nothing being confirmed, so a
+  // spinner would be claiming work that is not happening.
+  it('says nothing while the viewer has taken no side', () => {
+    mocks.positions = [position('profile-remote', CLAIM_SHARED, SPACE_1, false)];
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+
+    expect(screen.queryByText('Confirming your position…')).not.toBeInTheDocument();
+  });
+
   it('sends the request once geo-chat agrees with the side on screen', () => {
     mocks.claims = [
       {

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -54,7 +54,7 @@ import { useClaimSpaceAllowlist } from '~/core/debates/use-claim-space-allowlist
 import { useCurrentGeoChatUserId } from '~/core/debates/use-current-geo-chat-user-id';
 import { isSpaceDebatePublishable, useDebatePublishableSpaces } from '~/core/debates/use-debate-publishable-spaces';
 import { useEntitySidePanel } from '~/core/hooks/use-entity-side-panel';
-import { useEntityResponse } from '~/core/hooks/use-entity-vote';
+import { useEntityResponse, useEntityResponseIndexingSnapshot } from '~/core/hooks/use-entity-vote';
 import { useInfiniteScrollSentinel } from '~/core/hooks/use-infinite-scroll-sentinel';
 import { useSpacesByIds } from '~/core/hooks/use-spaces-by-ids';
 import { uuidToHex } from '~/core/id/normalize';
@@ -64,6 +64,7 @@ import { getTopRankedSpaceId } from '~/core/utils/space/space-ranking';
 import { getChecked } from '~/design-system/checkbox';
 import { ChevronDownSmall } from '~/design-system/icons/chevron-down-small';
 import { Input } from '~/design-system/input';
+import { Spinner } from '~/design-system/spinner';
 import { Skeleton } from '~/design-system/skeleton';
 import { Text } from '~/design-system/text';
 
@@ -1007,10 +1008,33 @@ function RematchClaimCard({
   // before requesting a rematch". Comparing rather than null-checking also covers switching sides,
   // where geo-chat still holds the side you just moved off — equally invalid to act on.
   const responseSettled = serverLocalPosition === localPosition;
-  // The side you picked still highlights immediately off the optimistic answer; only the request
-  // waits. It stays hidden rather than sitting there disabled — a button you cannot press yet reads
-  // as broken, and the wait is short.
   const canRequest = opposing && responseSettled;
+  /**
+   * GEO-2652. The side you picked highlights immediately off the optimistic answer, but the request
+   * has to wait for geo-chat's copy, which trails by a publish, an index and a notification. That
+   * is not a moment — it is an on-chain write and an indexer.
+   *
+   * This used to render nothing at all, on the reasoning that a button you cannot press yet reads
+   * as broken and the wait is short. The first half holds; the second does not. So say what is
+   * happening instead of showing an empty space where the button will be: Preston's report is
+   * precisely that the viewer has no idea what they are waiting on.
+   *
+   * Not made optimistic, which the ticket would prefer, because it cannot be done from here.
+   * geo-chat validates the request against its *own* copy of the position and rejects it with
+   * `claim_response_required` — so a request sent early does not race ahead, it fails. Accepting one
+   * before the response is indexed is a backend decision about whether a debate may be created on a
+   * position that does not exist on-chain yet.
+   */
+  const responseIndexing = useEntityResponseIndexingSnapshot({
+    entityId: claim.claim.claim_entity_id,
+    spaceId: claim.claim.space_id,
+    responseKind,
+  });
+  const awaitingResponse = opposing && !responseSettled;
+  // `delayed` is the machine's own signal that this is taking longer than it should. Worth saying
+  // out loud rather than leaving the viewer with a spinner that never changes.
+  const awaitingLabel =
+    responseIndexing.status === 'delayed' ? 'Still confirming your position…' : 'Confirming your position…';
   const { openSidePanel } = useEntitySidePanel();
   const request = session?.request;
 
@@ -1072,7 +1096,14 @@ function RematchClaimCard({
       // unknown — a settled lookup that simply has no row for it really does mean "not ready".
       hideReadinessToggle={claimReadiness === null && readinessUnresolved}
       footer={
-        canRequest || requesting ? (
+        awaitingResponse && !requesting ? (
+          <div className="mt-3 flex items-center gap-2" role="status" aria-live="polite">
+            <Spinner />
+            <Text as="span" variant="footnote" color="grey-04">
+              {awaitingLabel}
+            </Text>
+          </div>
+        ) : canRequest || requesting ? (
           <div className="mt-3">
             <HubPillButton
               onClick={onRequest}


### PR DESCRIPTION
Fixes GEO-2652 — with the ticket's fallback rather than its preferred option, and the reason matters.

## What was happening

Picking a side opposite your opponent highlights **immediately** off the optimistic answer. But `Request debate` waits on `responseSettled`, which compares geo-chat's copy of your position against the local one — and that copy trails by **a publish, an index, and a notification**. That's an on-chain write and an indexer, not a moment.

While it ran, the card rendered *nothing*. The existing comment justified that: a button you cannot press yet reads as broken, and the wait is short. The first half holds. The second doesn't — which is exactly Preston's report: *"at minimum, the user has no idea what they're waiting on."*

## What changed

The wait is named instead of being an empty space where the button will appear.

The machinery already existed — `useEntityResponseIndexingSnapshot` models `idle | reconciling | delayed | indexed`, and `delayed` is the machine's own signal that this is taking longer than it should. So that state gets its own copy ("Still confirming your position…") rather than leaving a spinner that never changes.

Nothing is shown before a side is taken: nothing is being confirmed then, and a spinner would be claiming work that isn't happening.

## Why not optimistic

The ticket prefers optimistic, and I want to be clear this isn't me taking the easier road: **it cannot be done from the client.** geo-chat validates the request against its own copy of the position and rejects it with `claim_response_required`. A request sent early doesn't race ahead — it fails.

Making it genuinely optimistic is a backend decision about whether a debate may be created on a position that doesn't exist on-chain yet, and it carries exactly the rollback problem the ticket raises: withdrawing a request the opponent may already have seen is worse than the wait. Worth doing deliberately, in geo-chat, if you want it.

## On "measure the actual wait first"

I couldn't put a number on it — it spans an on-chain publish and the indexer, so measuring needs the full stack, not a local run. What I could establish is the *shape*: it's bounded by indexing, not by a request geo-chat is slow to answer, which is what decides between the two options. If it turns out to be a second in practice, this is the right fix anyway; if it's ten, this is the right fix and the backend change becomes worth its cost.

## Verification

88/88 in the rematch suite. The new label test fails without the fix (verified by disabling the condition). The companion test — nothing shown before a side is taken — passes either way by design; it guards against over-eager rendering rather than testing the feature, and I'd rather say so than imply both are load-bearing.

Typecheck clean, eslint exit 0.