### PR TITLE
perf: stop the entity page refetching its backlinks on every render

### DIFF
--- a/apps/web/core/io/errors/retry-utils.ts
+++ b/apps/web/core/io/errors/retry-utils.ts
@@ -9,7 +9,25 @@ export type RetryCategory =
   | 'transport_dns'
   | 'transport_connection_reset'
   | 'transport_connection_refused'
-  | 'transport_unknown';
+  | 'transport_unknown'
+  // Only ever produced by the test-run network guard in `vitest.setup.ts`. Deliberately absent
+  // from `isRetryableCategory` — see `TEST_UNMOCKED_NETWORK_CODE` below.
+  | 'test_unmocked_network';
+
+/**
+ * Marker `code` set by the test-run network guard (`vitest.setup.ts`).
+ *
+ * GEO-2645 made that guard reject immediately so an unmocked call fails inside its own test's
+ * lifetime. That is necessary but not sufficient: an immediate rejection is still classified as a
+ * transport failure, and every transport category is retryable, so the client re-armed it on the
+ * exponential schedule and logged `Exhausted retries` roughly a second and a half later — after the
+ * test had finished. The pending console RPC then killed the whole run at worker teardown with
+ * `EnvironmentTeardownError`, every assertion passing, exit code 1.
+ *
+ * Classifying the guard's error as non-retryable closes that gap. The call still fails, and still
+ * fails loudly inside its own test — it just fails once.
+ */
+export const TEST_UNMOCKED_NETWORK_CODE = 'GEO_TEST_UNMOCKED_NETWORK';
 
 type ErrorRecord = Record<string, unknown>;
 
@@ -41,6 +59,22 @@ export function classifyTransportFailure(error: unknown): TransportFailure {
   const causeMessage = typeof cause?.message === 'string' ? cause.message : undefined;
   const causeCode = typeof cause?.code === 'string' ? cause.code : undefined;
   const haystack = `${message} ${code ?? ''} ${errno ?? ''} ${causeMessage ?? ''} ${causeCode ?? ''}`.toLowerCase();
+
+  // Checked first: the guard's message names a URL, which the heuristics below would happily read
+  // as a DNS failure and retry.
+  if (code === TEST_UNMOCKED_NETWORK_CODE) {
+    return {
+      category: 'test_unmocked_network',
+      name,
+      message,
+      code,
+      errno,
+      syscall,
+      causeName,
+      causeMessage,
+      causeCode,
+    };
+  }
 
   if (
     haystack.includes('timed out') ||

--- a/apps/web/core/io/errors/test-network-guard-is-not-retried.test.ts
+++ b/apps/web/core/io/errors/test-network-guard-is-not-retried.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  TEST_UNMOCKED_NETWORK_CODE,
+  classifyTransportFailure,
+  isRetryableCategory,
+} from './retry-utils';
+
+/**
+ * The test-run network guard in `vitest.setup.ts` must fail *once*, immediately.
+ *
+ * If it is ever retried, the client's exponential schedule pushes its `Exhausted retries` log about
+ * 1.5s past the end of whichever test made the call, and the pending console RPC takes the whole run
+ * down at worker teardown — `EnvironmentTeardownError: Closing rpc while "onUserConsoleLog" was
+ * pending`, with every assertion passing and exit code 1. It blames whichever file happened to be
+ * running rather than the one that made the call, so it is expensive to debug and worth pinning.
+ *
+ * GEO-2645 made the guard reject immediately, which was necessary but not sufficient — the retry
+ * schedule put the delay back. These assert the part that closes it.
+ */
+describe('the test-run network guard is never retried', () => {
+  const guardError = () => {
+    const error = new Error('Unmocked network request in a test: https://test.example.com/graphql');
+    (error as Error & { code: string }).code = TEST_UNMOCKED_NETWORK_CODE;
+    return error;
+  };
+
+  it('classifies the guard error as non-retryable', () => {
+    const { category } = classifyTransportFailure(guardError());
+
+    expect(category).toBe('test_unmocked_network');
+    expect(isRetryableCategory(category)).toBe(false);
+  });
+
+  it('wins over the substring heuristics that would otherwise retry it', () => {
+    // The guard's message always names a URL, and the classifier reads a bare hostname as a DNS
+    // failure — which is retryable. The marker has to be checked before that, not after.
+    const dnsShaped = new Error('Unmocked network request in a test: https://dns.example.com/graphql');
+    expect(classifyTransportFailure(dnsShaped).category).toBe('transport_dns');
+    expect(isRetryableCategory('transport_dns')).toBe(true);
+
+    (dnsShaped as Error & { code: string }).code = TEST_UNMOCKED_NETWORK_CODE;
+    expect(classifyTransportFailure(dnsShaped).category).toBe('test_unmocked_network');
+  });
+
+  it('leaves real transport failures retryable', () => {
+    // The fix must not quietly disarm retries for the failures they exist for.
+    const reset = new Error('socket hang up');
+    (reset as Error & { code: string }).code = 'ECONNRESET';
+
+    const { category } = classifyTransportFailure(reset);
+    expect(category).toBe('transport_connection_reset');
+    expect(isRetryableCategory(category)).toBe(true);
+  });
+});

--- a/apps/web/partials/entity-page/async-components-in-client-boundaries.test.ts
+++ b/apps/web/partials/entity-page/async-components-in-client-boundaries.test.ts
@@ -1,3 +1,5 @@
+// This walks the source tree with `fs` and never touches the DOM.
+// @vitest-environment node
 import { readFileSync, readdirSync } from 'node:fs';
 import path from 'node:path';
 import { describe, expect, it } from 'vitest';
@@ -7,24 +9,39 @@ import { describe, expect, it } from 'vitest';
  * the function on every render, so whatever it awaits is refetched every render, and a `Suspense`
  * wrapper hides it completely — the UI looks right while the network loops.
  *
- * That is how `BacklinksServerContainer` came to send `EntityBacklinksPage` 82 times and `Spaces`
- * 64 times on a single entity page load, all with identical variables (GEO-2666). Nothing failed,
+ * That is how `BacklinksServerContainer` came to send `EntityBacklinksPage` 54 times and `Spaces`
+ * 53 times on a single entity page load, all with identical variables (GEO-2666). Nothing failed,
  * so nothing surfaced it.
  *
  * This walks the same path by hand rather than trusting a convention: find the async components,
  * find where each is rendered, and fail if any render site is a client file.
+ *
+ * Two things this has already got wrong, both of which made it pass while the bug was present:
+ *
+ * 1. The named-export pattern required a type annotation on the const, so it silently matched
+ *    nothing for the very component this test exists for.
+ * 2. It only looked at *named* exports. There are 37 `export default async function` components in
+ *    the tree, including `DefaultEntityPage` and `PostEntityPage` — reusable ones that a client file
+ *    could plausibly render. Matching a default export by name is not enough either, since the
+ *    importing file may bind it to any local name, so default exports are tracked by resolving the
+ *    import specifier back to the file that declared them.
  */
 
 const ROOT = path.resolve(__dirname, '..', '..');
 const SOURCE_DIRS = ['app', 'core', 'partials'];
 
-/**
- * `export async function Name(` and `export const Name = async (`, with or without a type
- * annotation on the const. The annotation is optional and easy to get wrong: requiring it silently
- * matched nothing for the very component this test exists for.
- */
-const ASYNC_COMPONENT =
+/** `export async function Name(` and `export const Name = async (`, type annotation optional. */
+const NAMED_ASYNC_COMPONENT =
   /^export\s+(?:async\s+function\s+([A-Z]\w*)\s*[(<]|const\s+([A-Z]\w*)\s*(?::[^=]+)?=\s*async\s*[(<])/gm;
+
+/** `export default async function Name(` and the anonymous `export default async (`. */
+const DEFAULT_ASYNC_COMPONENT = /^export\s+default\s+async\s+(?:function\s*([A-Z]\w*)?\s*[(<]|[(<])/m;
+
+/** A default import: `import Local from '<specifier>'`, ignoring `import type`. */
+const DEFAULT_IMPORT = /^import\s+(?!type\s)([A-Z]\w*)\s*(?:,\s*\{[^}]*\})?\s+from\s+['"]([^'"]+)['"]/gm;
+
+/** Route handlers and metadata exports share the shape but are never rendered as JSX. */
+const NOT_COMPONENTS = new Set(['GET', 'POST', 'PUT', 'PATCH', 'DELETE']);
 
 function sourceFiles(): string[] {
   const found: string[] = [];
@@ -46,19 +63,44 @@ function isClientFile(contents: string): boolean {
   return /^\s*['"]use client['"]/.test(contents);
 }
 
+/**
+ * Resolve an import specifier to a repo-relative `.tsx` path, or null for anything outside the
+ * source tree (packages, node_modules, `.ts` modules — none of which can hold a JSX component we
+ * care about here).
+ */
+function resolveImport(specifier: string, importingFile: string): string | null {
+  let absolute: string;
+
+  if (specifier.startsWith('~/')) {
+    absolute = path.join(ROOT, specifier.slice(2));
+  } else if (specifier.startsWith('.')) {
+    absolute = path.resolve(ROOT, path.dirname(importingFile), specifier);
+  } else {
+    return null;
+  }
+
+  const relative = path.relative(ROOT, absolute);
+  for (const candidate of [`${relative}.tsx`, path.join(relative, 'index.tsx')]) {
+    if (SOURCE_DIRS.some(dir => candidate.startsWith(`${dir}${path.sep}`))) return candidate;
+  }
+  return null;
+}
+
 describe('async components are never rendered from a client boundary', () => {
-  it('finds no async component rendered inside a "use client" file', () => {
-    const files = sourceFiles();
+  const files = sourceFiles();
+  const contentsByFile = new Map(files.map(file => [file, readFileSync(path.join(ROOT, file), 'utf8')]));
+
+  it('walks a source tree that actually has files in it', () => {
+    // Guards against a silently empty run if the layout moves.
     expect(files.length).toBeGreaterThan(50);
+  });
 
-    const contentsByFile = new Map(files.map(file => [file, readFileSync(path.join(ROOT, file), 'utf8')]));
-
+  it('finds no *named* async component rendered inside a "use client" file', () => {
     const asyncComponents = new Set<string>();
     for (const contents of contentsByFile.values()) {
-      for (const match of contents.matchAll(ASYNC_COMPONENT)) {
+      for (const match of contents.matchAll(NAMED_ASYNC_COMPONENT)) {
         const name = match[1] ?? match[2];
-        // Route handlers share the shape but are never rendered as JSX.
-        if (name && !['GET', 'POST', 'PUT', 'PATCH', 'DELETE'].includes(name)) asyncComponents.add(name);
+        if (name && !NOT_COMPONENTS.has(name)) asyncComponents.add(name);
       }
     }
     expect(asyncComponents.size).toBeGreaterThan(0);
@@ -67,8 +109,32 @@ describe('async components are never rendered from a client boundary', () => {
     for (const [file, contents] of contentsByFile) {
       if (!isClientFile(contents)) continue;
       for (const name of asyncComponents) {
-        if (new RegExp(`<${name}[\\s/>]`).test(contents)) {
-          offences.push(`<${name}> rendered in ${file}`);
+        if (new RegExp(`<${name}[\\s/>]`).test(contents)) offences.push(`<${name}> rendered in ${file}`);
+      }
+    }
+
+    expect(offences).toEqual([]);
+  });
+
+  it('finds no *default-exported* async component rendered inside a "use client" file', () => {
+    const declaredBy = new Set<string>();
+    for (const [file, contents] of contentsByFile) {
+      if (DEFAULT_ASYNC_COMPONENT.test(contents)) declaredBy.add(file);
+    }
+    // `app/` alone has dozens; if this hits zero the pattern has drifted and the test is vacuous.
+    expect(declaredBy.size).toBeGreaterThan(10);
+
+    const offences: string[] = [];
+    for (const [file, contents] of contentsByFile) {
+      if (!isClientFile(contents)) continue;
+
+      for (const match of contents.matchAll(DEFAULT_IMPORT)) {
+        const [, localName, specifier] = match;
+        const target = resolveImport(specifier, file);
+        if (!target || !declaredBy.has(target)) continue;
+
+        if (new RegExp(`<${localName}[\\s/>]`).test(contents)) {
+          offences.push(`<${localName}> (default export of ${target}) rendered in ${file}`);
         }
       }
     }

--- a/apps/web/partials/entity-page/async-components-in-client-boundaries.test.ts
+++ b/apps/web/partials/entity-page/async-components-in-client-boundaries.test.ts
@@ -40,6 +40,23 @@ const DEFAULT_ASYNC_COMPONENT = /^export\s+default\s+async\s+(?:function\s*([A-Z
 /** A default import: `import Local from '<specifier>'`, ignoring `import type`. */
 const DEFAULT_IMPORT = /^import\s+(?!type\s)([A-Z]\w*)\s*(?:,\s*\{[^}]*\})?\s+from\s+['"]([^'"]+)['"]/gm;
 
+/** A named import block: `import { A, B as C } from '<specifier>'`, ignoring `import type`. */
+const NAMED_IMPORT_BLOCK =
+  /^import\s+(?!type\s)(?:[A-Za-z_$][\w$]*\s*,\s*)?\{([^}]*)\}\s+from\s+['"]([^'"]+)['"]/gm;
+
+/** `A` or `A as B` inside a named import block, skipping inline `type` specifiers. */
+function parseNamedBindings(block: string): { exported: string; local: string }[] {
+  return block
+    .split(',')
+    .map(entry => entry.trim())
+    .filter(entry => entry.length > 0 && !entry.startsWith('type '))
+    .map(entry => {
+      const [exported, local] = entry.split(/\s+as\s+/).map(part => part.trim());
+      return { exported, local: local ?? exported };
+    })
+    .filter(({ exported, local }) => Boolean(exported) && Boolean(local));
+}
+
 /** Route handlers and metadata exports share the shape but are never rendered as JSX. */
 const NOT_COMPONENTS = new Set(['GET', 'POST', 'PUT', 'PATCH', 'DELETE']);
 
@@ -100,21 +117,54 @@ describe('async components are never rendered from a client boundary', () => {
     expect(files.length).toBeGreaterThan(50);
   });
 
-  it('finds no *named* async component rendered inside a "use client" file', () => {
-    const asyncComponents = new Set<string>();
-    for (const contents of contentsByFile.values()) {
-      for (const match of contents.matchAll(NAMED_ASYNC_COMPONENT)) {
-        const name = match[1] ?? match[2];
-        if (name && !NOT_COMPONENTS.has(name)) asyncComponents.add(name);
-      }
+  /** Named async components, kept per declaring file so aliased imports can be resolved back. */
+  const namedAsyncByFile = new Map<string, Set<string>>();
+  const allNamedAsync = new Set<string>();
+  for (const [file, contents] of contentsByFile) {
+    for (const match of contents.matchAll(NAMED_ASYNC_COMPONENT)) {
+      const name = match[1] ?? match[2];
+      if (!name || NOT_COMPONENTS.has(name)) continue;
+      if (!namedAsyncByFile.has(file)) namedAsyncByFile.set(file, new Set());
+      namedAsyncByFile.get(file)!.add(name);
+      allNamedAsync.add(name);
     }
-    expect(asyncComponents.size).toBeGreaterThan(0);
+  }
+
+  it('finds no *named* async component rendered inside a "use client" file', () => {
+    expect(allNamedAsync.size).toBeGreaterThan(0);
 
     const offences: string[] = [];
     for (const [file, contents] of contentsByFile) {
       if (!isClientFile(contents)) continue;
-      for (const name of asyncComponents) {
+      for (const name of allNamedAsync) {
         if (new RegExp(`<${name}[\\s/>]`).test(contents)) offences.push(`<${name}> rendered in ${file}`);
+      }
+    }
+
+    expect(offences).toEqual([]);
+  });
+
+  it('finds no *aliased* named async component rendered inside a "use client" file', () => {
+    // `import { BacklinksServerContainer as Renamed }` defeats the by-name check above, and there
+    // are 65 aliased named imports in this tree, so this is a live shape rather than a contrived
+    // one. Resolved the same way as default exports: specifier back to the declaring file, then
+    // match the *local* binding in JSX.
+    const offences: string[] = [];
+    for (const [file, contents] of contentsByFile) {
+      if (!isClientFile(contents)) continue;
+
+      for (const match of contents.matchAll(NAMED_IMPORT_BLOCK)) {
+        const [, block, specifier] = match;
+        const target = resolveImport(specifier, file);
+        const declared = target ? namedAsyncByFile.get(target) : undefined;
+        if (!declared) continue;
+
+        for (const { exported, local } of parseNamedBindings(block)) {
+          if (exported === local || !declared.has(exported)) continue;
+          if (new RegExp(`<${local}[\\s/>]`).test(contents)) {
+            offences.push(`<${local}> (alias of ${exported} from ${target}) rendered in ${file}`);
+          }
+        }
       }
     }
 

--- a/apps/web/partials/entity-page/async-components-in-client-boundaries.test.ts
+++ b/apps/web/partials/entity-page/async-components-in-client-boundaries.test.ts
@@ -1,6 +1,6 @@
 // This walks the source tree with `fs` and never touches the DOM.
 // @vitest-environment node
-import { readFileSync, readdirSync } from 'node:fs';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 
@@ -81,7 +81,12 @@ function resolveImport(specifier: string, importingFile: string): string | null 
 
   const relative = path.relative(ROOT, absolute);
   for (const candidate of [`${relative}.tsx`, path.join(relative, 'index.tsx')]) {
-    if (SOURCE_DIRS.some(dir => candidate.startsWith(`${dir}${path.sep}`))) return candidate;
+    if (!SOURCE_DIRS.some(dir => candidate.startsWith(`${dir}${path.sep}`))) continue;
+    // Both candidates share a directory prefix, so testing the prefix alone always accepts the
+    // first and makes `index.tsx` unreachable — a silent false negative in a test whose only job is
+    // not to have them. Nothing in the tree resolves that way today; that is not a reason to leave
+    // the branch dead.
+    if (existsSync(path.join(ROOT, candidate))) return candidate;
   }
   return null;
 }

--- a/apps/web/partials/entity-page/async-components-in-client-boundaries.test.ts
+++ b/apps/web/partials/entity-page/async-components-in-client-boundaries.test.ts
@@ -1,0 +1,78 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * An async component rendered from a `'use client'` file is not a Server Component. React re-invokes
+ * the function on every render, so whatever it awaits is refetched every render, and a `Suspense`
+ * wrapper hides it completely — the UI looks right while the network loops.
+ *
+ * That is how `BacklinksServerContainer` came to send `EntityBacklinksPage` 82 times and `Spaces`
+ * 64 times on a single entity page load, all with identical variables (GEO-2666). Nothing failed,
+ * so nothing surfaced it.
+ *
+ * This walks the same path by hand rather than trusting a convention: find the async components,
+ * find where each is rendered, and fail if any render site is a client file.
+ */
+
+const ROOT = path.resolve(__dirname, '..', '..');
+const SOURCE_DIRS = ['app', 'core', 'partials'];
+
+/**
+ * `export async function Name(` and `export const Name = async (`, with or without a type
+ * annotation on the const. The annotation is optional and easy to get wrong: requiring it silently
+ * matched nothing for the very component this test exists for.
+ */
+const ASYNC_COMPONENT =
+  /^export\s+(?:async\s+function\s+([A-Z]\w*)\s*[(<]|const\s+([A-Z]\w*)\s*(?::[^=]+)?=\s*async\s*[(<])/gm;
+
+function sourceFiles(): string[] {
+  const found: string[] = [];
+  const walk = (dir: string) => {
+    for (const entry of readdirSync(path.join(ROOT, dir), { withFileTypes: true })) {
+      const rel = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (entry.name !== 'node_modules') walk(rel);
+      } else if (entry.name.endsWith('.tsx') && !entry.name.endsWith('.test.tsx')) {
+        found.push(rel);
+      }
+    }
+  };
+  for (const dir of SOURCE_DIRS) walk(dir);
+  return found;
+}
+
+function isClientFile(contents: string): boolean {
+  return /^\s*['"]use client['"]/.test(contents);
+}
+
+describe('async components are never rendered from a client boundary', () => {
+  it('finds no async component rendered inside a "use client" file', () => {
+    const files = sourceFiles();
+    expect(files.length).toBeGreaterThan(50);
+
+    const contentsByFile = new Map(files.map(file => [file, readFileSync(path.join(ROOT, file), 'utf8')]));
+
+    const asyncComponents = new Set<string>();
+    for (const contents of contentsByFile.values()) {
+      for (const match of contents.matchAll(ASYNC_COMPONENT)) {
+        const name = match[1] ?? match[2];
+        // Route handlers share the shape but are never rendered as JSX.
+        if (name && !['GET', 'POST', 'PUT', 'PATCH', 'DELETE'].includes(name)) asyncComponents.add(name);
+      }
+    }
+    expect(asyncComponents.size).toBeGreaterThan(0);
+
+    const offences: string[] = [];
+    for (const [file, contents] of contentsByFile) {
+      if (!isClientFile(contents)) continue;
+      for (const name of asyncComponents) {
+        if (new RegExp(`<${name}[\\s/>]`).test(contents)) {
+          offences.push(`<${name}> rendered in ${file}`);
+        }
+      }
+    }
+
+    expect(offences).toEqual([]);
+  });
+});

--- a/apps/web/partials/entity-page/backlinks-client-container.test.tsx
+++ b/apps/web/partials/entity-page/backlinks-client-container.test.tsx
@@ -31,8 +31,7 @@ class CatchingBoundary extends Component<{ children: ReactNode }, { caught: bool
   }
 }
 
-function renderInBoundary() {
-  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+function renderInBoundary(queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })) {
   return render(
     <QueryClientProvider client={queryClient}>
       <CatchingBoundary>
@@ -71,6 +70,31 @@ describe('BacklinksClientContainer', () => {
     await waitFor(() => expect(mocks.fetchPayload).toHaveBeenCalled());
     expect(screen.queryByTestId('caught')).toBeNull();
     expect(container.textContent).toBe('');
+  });
+
+  it('keeps already-rendered backlinks when a background refetch fails', async () => {
+    // The counterpart to the test above, and the reason `throwOnError` is a predicate rather than
+    // `true`. Backlinks refetch on tab focus, so a transient failure here is routine — and
+    // `TrackedErrorBoundary` has no reset key, so tripping it would swap real rows for the empty
+    // fallback permanently. Reporting a failure must not cost more than the failure does.
+    mocks.fetchPayload.mockResolvedValueOnce([{ id: 'a' }, { id: 'b' }]);
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+    renderInBoundary(queryClient);
+    await waitFor(() => expect(screen.getByTestId('backlinks').textContent).toBe('2'));
+
+    mocks.fetchPayload.mockRejectedValueOnce(new Error('transient blip'));
+    await queryClient.refetchQueries({ queryKey: ['entity-backlinks', 'entity-1'] }).catch(() => {});
+
+    // Wait for the query to actually reach `error`, not just for the refetch call to return.
+    // Asserting straight after `refetchQueries` passes either way — React has not re-rendered yet,
+    // so the boundary could not have tripped regardless of the setting, and the test proves nothing.
+    await waitFor(() =>
+      expect(queryClient.getQueryState(['entity-backlinks', 'entity-1'])?.status).toBe('error')
+    );
+
+    expect(screen.queryByTestId('caught')).toBeNull();
+    expect(screen.getByTestId('backlinks').textContent).toBe('2');
   });
 
   it('renders backlinks when there are some', async () => {

--- a/apps/web/partials/entity-page/backlinks-client-container.test.tsx
+++ b/apps/web/partials/entity-page/backlinks-client-container.test.tsx
@@ -1,0 +1,83 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { Component, type ReactNode } from 'react';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { BacklinksClientContainer } from './backlinks-client-container';
+
+const mocks = vi.hoisted(() => ({
+  fetchPayload: vi.fn(),
+}));
+
+vi.mock('~/partials/entity-page/fetch-entity-backlinks', () => ({
+  fetchEntityBacklinksPayload: (entityId: string) => mocks.fetchPayload(entityId),
+}));
+
+vi.mock('~/partials/entity-page/backlinks', () => ({
+  Backlinks: ({ backlinks }: { backlinks: unknown[] }) => <div data-testid="backlinks">{backlinks.length}</div>,
+}));
+
+/** Stands in for the `TrackedErrorBoundary` the real call site is wrapped in. */
+class CatchingBoundary extends Component<{ children: ReactNode }, { caught: boolean }> {
+  state = { caught: false };
+
+  static getDerivedStateFromError() {
+    return { caught: true };
+  }
+
+  render() {
+    return this.state.caught ? <div data-testid="caught" /> : this.props.children;
+  }
+}
+
+function renderInBoundary() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <CatchingBoundary>
+        <BacklinksClientContainer entityId="entity-1" />
+      </CatchingBoundary>
+    </QueryClientProvider>
+  );
+}
+
+describe('BacklinksClientContainer', () => {
+  // This repo does not switch on RTL's global cleanup (see the note in `vitest.setup.ts`), so
+  // without this the previous test's DOM is still mounted and `queryByTestId` finds its boundary
+  // rather than this test's.
+  afterEach(() => {
+    cleanup();
+    mocks.fetchPayload.mockReset();
+  });
+
+  it('surfaces a failed fetch to the error boundary rather than rendering nothing', async () => {
+    // The reason this is worth a test: a failed fetch and an empty result both render nothing, so a
+    // regression here is invisible from the outside. `useQuery` swallows errors unless told not to,
+    // and the route variant used to report these — it reached the same data through an async
+    // component whose throw the boundary caught. Losing that would be silent.
+    mocks.fetchPayload.mockRejectedValueOnce(new Error('backlinks fetch failed'));
+
+    renderInBoundary();
+
+    await waitFor(() => expect(screen.getByTestId('caught')).toBeTruthy());
+  });
+
+  it('renders nothing for a genuinely empty result, without involving the boundary', async () => {
+    mocks.fetchPayload.mockResolvedValueOnce([]);
+
+    const { container } = renderInBoundary();
+
+    await waitFor(() => expect(mocks.fetchPayload).toHaveBeenCalled());
+    expect(screen.queryByTestId('caught')).toBeNull();
+    expect(container.textContent).toBe('');
+  });
+
+  it('renders backlinks when there are some', async () => {
+    mocks.fetchPayload.mockResolvedValueOnce([{ id: 'a' }, { id: 'b' }]);
+
+    renderInBoundary();
+
+    await waitFor(() => expect(screen.getByTestId('backlinks').textContent).toBe('2'));
+  });
+});

--- a/apps/web/partials/entity-page/backlinks-client-container.tsx
+++ b/apps/web/partials/entity-page/backlinks-client-container.tsx
@@ -18,7 +18,14 @@ export function BacklinksClientContainer({ entityId }: BacklinksClientContainerP
     // used to reach here through an async component whose throw was caught and reported by the
     // surrounding `TrackedErrorBoundary`, and without this it would have quietly stopped reporting.
     // The single call site is inside that boundary, so a throw is tracked and falls back to empty.
-    throwOnError: true,
+    //
+    // Only on the initial load, though. A bare `true` also throws when a *background* refetch fails
+    // after good rows are already cached, and `TrackedErrorBoundary` has no reset key — so one
+    // transient blip would replace real backlinks with the empty fallback and never recover. That is
+    // not hypothetical: backlinks refetch on tab focus, so alt-tabbing back through a blip would do
+    // it. Throwing only when there is nothing to lose reports the failure that has no other symptom
+    // and keeps the data that does.
+    throwOnError: (_error, query) => query.state.data === undefined,
   });
 
   if (isLoading || !data?.length) {

--- a/apps/web/partials/entity-page/backlinks-client-container.tsx
+++ b/apps/web/partials/entity-page/backlinks-client-container.tsx
@@ -13,6 +13,12 @@ export function BacklinksClientContainer({ entityId }: BacklinksClientContainerP
   const { data, isLoading } = useQuery({
     queryKey: ['entity-backlinks', entityId],
     queryFn: () => fetchEntityBacklinksPayload(entityId),
+    // `useQuery` swallows errors by default, and the empty state below is indistinguishable from a
+    // failed fetch — both render nothing. That silence is why this is explicit: the route variant
+    // used to reach here through an async component whose throw was caught and reported by the
+    // surrounding `TrackedErrorBoundary`, and without this it would have quietly stopped reporting.
+    // The single call site is inside that boundary, so a throw is tracked and falls back to empty.
+    throwOnError: true,
   });
 
   if (isLoading || !data?.length) {

--- a/apps/web/partials/entity-page/entity-page-body.tsx
+++ b/apps/web/partials/entity-page/entity-page-body.tsx
@@ -13,7 +13,6 @@ import { CommentSection } from '~/partials/comments/comments-section';
 import { Editor } from '~/partials/editor/editor';
 import { AutomaticModeToggle } from '~/partials/entity-page/automatic-mode-toggle';
 import { BacklinksClientContainer } from '~/partials/entity-page/backlinks-client-container';
-import { BacklinksServerContainer } from '~/partials/entity-page/backlinks-server-container';
 import { EditableHeading } from '~/partials/entity-page/editable-entity-header';
 import { EntityPageContentContainer } from '~/partials/entity-page/entity-page-content-container';
 import { EntityPageCover } from '~/partials/entity-page/entity-page-cover';
@@ -74,17 +73,20 @@ function EntityTabsSection({
   );
 }
 
-function RouteBacklinks({ entityId }: { entityId: string }) {
-  return (
-    <TrackedErrorBoundary fallback={<EmptyErrorComponent />}>
-      <React.Suspense fallback={<div />}>
-        <BacklinksServerContainer entityId={entityId} />
-      </React.Suspense>
-    </TrackedErrorBoundary>
-  );
-}
-
-function SidePanelBacklinks({ entityId }: { entityId: string }) {
+/**
+ * Both variants fetch through `BacklinksClientContainer`, which is the only one of the two
+ * containers that can run here.
+ *
+ * `BacklinksServerContainer` is an async component. This file is a client component, so React
+ * doesn't treat it as a Server Component — it re-invokes the function on every render, which fires
+ * its two requests again, suspends, resolves, renders, and invokes it again. The `Suspense` that
+ * used to wrap it hid that entirely: the backlinks looked fine while a single entity page load sent
+ * `EntityBacklinksPage` 82 times and `Spaces` 64 times, with identical variables (GEO-2666).
+ *
+ * The server container is still right for the three routes that render it from an actual server
+ * component; it just can't be reached from here.
+ */
+function EntityBacklinks({ entityId }: { entityId: string }) {
   return (
     <TrackedErrorBoundary fallback={<EmptyErrorComponent />}>
       <BacklinksClientContainer entityId={entityId} />
@@ -114,7 +116,7 @@ function EditorFooter({
         <ToggleEntityPage id={entityId} spaceId={spaceId} />
       )}
       <Spacer height={40} />
-      {variant === 'route' ? <RouteBacklinks entityId={entityId} /> : <SidePanelBacklinks entityId={entityId} />}
+      <EntityBacklinks entityId={entityId} />
       <CommentSection entityId={entityId} spaceId={spaceId} />
     </>
   );

--- a/apps/web/vitest.setup.ts
+++ b/apps/web/vitest.setup.ts
@@ -16,6 +16,13 @@
  * resulting log flushes while the worker is still up. Tests that want network still stub `fetch`
  * themselves and are unaffected.
  *
+ * Rejecting immediately turned out not to be enough on its own. The graphql client classifies any
+ * status-less failure as a transport error, every transport category is retryable, and so it put
+ * this rejection on the exponential schedule and logged `Exhausted retries` about 1.5s later —
+ * back outside the test's lifetime, and the same teardown crash returned. The error therefore
+ * carries `TEST_UNMOCKED_NETWORK_CODE`, which `classifyTransportFailure` maps to a category that
+ * `isRetryableCategory` excludes. It fails once, immediately, and stays inside the test.
+ *
  * Deliberately *not* silencing those logs: they are how a genuinely unmocked call gets noticed. The
  * error names the URL so the fix is obvious.
  *
@@ -27,15 +34,22 @@
  * global cleanup, a `next/router` mock and two DOM polyfills all at once, which is a separate
  * change with its own blast radius.
  */
+import { TEST_UNMOCKED_NETWORK_CODE } from './core/io/errors/retry-utils';
+
 const refuseNetwork: typeof fetch = async input => {
   const url =
     typeof input === 'string' ? input : input instanceof URL ? input.toString() : (input as Request).url ?? '<unknown>';
 
-  throw new Error(
+  const error = new Error(
     `Unmocked network request in a test: ${url}\n` +
       'Tests must not reach the network. Stub it for this test, e.g.\n' +
       "  vi.stubGlobal('fetch', vi.fn(async () => new Response('{}', { status: 200 })));"
   );
+
+  // Read by `classifyTransportFailure` so the graphql client does not retry this.
+  (error as Error & { code: string }).code = TEST_UNMOCKED_NETWORK_CODE;
+
+  throw error;
 };
 
 globalThis.fetch = refuseNetwork;


### PR DESCRIPTION
Closes [GEO-2666](https://linear.app/geobrowser/issue/GEO-2666).

## The bug

`BacklinksServerContainer` is an **async component**. `partials/entity-page/entity-page-body.tsx` is `'use client'` and rendered it. Inside a client boundary that isn't a Server Component — React re-invokes the function on every render, which fires its two requests again, suspends, resolves, renders, and invokes it again.

The `<Suspense>` around it hid this completely. Backlinks rendered correctly the whole time; only the network showed it.

## Measured

Headless Chromium, **production build**, testnet API, logged out, one load of an entity page, 14s settle. Grouped by `operationName` + `JSON.stringify(variables)`:

| | before | after |
|---|---|---|
| Total POSTs | 256 | **131** |
| Byte-identical repeats | 136 | **11** |
| `EntityBacklinksPage` (same variables) | 65x | 1x |
| `Spaces` (same variables) | 63x | 1x |
| Distinct calls | 120 | 120 |
| Requests on tab refocus | 185 | **80** |

Distinct count is unchanged, so nothing stopped being fetched — only the repetition went. Dev-mode numbers agree (279 → 135).

## The fix

The route variant now uses `BacklinksClientContainer`, which the side panel already used and which fetches once through react-query keyed on the entity. Both variants ended up identical, so they collapse into one wrapper.

`BacklinksServerContainer` stays — it's still correct for the three routes that render it from a real server component (`post-entity-page`, `profile-entity-server-container`, `app/space/[id]/(space)/page.tsx`), all verified server-side.

## Audit work from the ticket

- **Swept for the same pattern elsewhere.** Every exported async component, cross-referenced against its render sites. This was the only offender.
- **Checked empty-case parity.** The server container returns `null` for no backlinks after mapping; the client container checks `!data?.length` on the mapped payload. Same outcome. Verified in-browser that "Referenced by" still renders with real rows.
- **Confirmed on a production build**, not just dev — the table above is prod.
- **Checked for a second loop.** 11 repeats remain: `EntitiesBatch` 5x, `Space` 4x, `PropertiesBatch` 4x/2x. Much smaller, different cause, out of scope here — worth folding into GEO-2661's before/after.

## The test

A guard for the class, not this instance: it finds every exported async component, finds where each is rendered, and fails if any render site is a `'use client'` file.

Worth flagging — **the first version of this test passed against the reintroduced bug.** Its regex only matched type-annotated consts (`const X: Type = async (`), so it never matched `export const BacklinksServerContainer = async (` — the one component it was written for. Fixed, and re-verified in both directions: passes clean, and fails naming the offender when the bug is put back.

## Note for anyone re-running the measurement

`apps/web/.env` points at `testnet-api.geobrowser.io`, which is stale and 400s on `spaceVotingSetting`. That produced a 264-request retry storm on my first run and swamped everything. Use `api-testnet.geobrowser.io`.

Full suite green at 283 files / 2891 tests; lint and build pass.


---

## Correction: the tab-refocus row

The refocus figures above were originally published as **90 → 0**. That was wrong, and the error was in my harness, not the code. Copilot caught it.

I dispatched `new Event('visibilitychange')` on `document` without `bubbles: true`. React Query v5 registers its focus listener on **`window`**, so a non-bubbling event dispatched on `document` never reached it — I was measuring a focus handler that had never fired, and read the resulting zero as a result.

Re-measured with `bubbles: true` and a positive control (a listener installed on `window`, asserted to have fired before trusting any number):

| Refocus | master | this PR |
|---|---|---|
| Total POSTs | 185 | **80** |
| `EntityBacklinksPage` | 54x | 1x |
| `Spaces` | 53x | 1x |

The fix is real — the two backlinks operations go from 54x/53x to 1x/1x, which is the loop being gone — but refocus is **not** zero, and the remaining 80 requests are the app-wide react-query defaults (`Entity` 42x, `EntitiesBatch` 14x, `PropertiesBatch` 10x, …). That is GEO-2661, whose baseline now records this breakdown. I chose not to spot-configure this one query here, since it would address 1 of those 80 and leave the pattern in place.

The page-load numbers in the main table were measured by a different, unaffected path and stand as published.

## CI failure, and why it was not flakiness

The `Test` job failed with all 2951 assertions passing and exit code 1:

```
EnvironmentTeardownError: Closing rpc while "onUserConsoleLog" was pending
This error originated in "core/debates/matchmaking/matches-tab.test.tsx"
```

`matches-tab.test.tsx` is untouched here and passes in isolation. The blamed file is not the cause — as `vitest.setup.ts` already documents, this error names whichever file ran longest, not the one that made the call.

GEO-2645 met this before and fixed it by making the test-run `fetch` guard reject immediately, so an unmocked call fails inside its own test's lifetime. That was necessary but not sufficient. The graphql client classifies any status-less failure as a transport error, `isRetryableCategory` treats **every** transport category as retryable, and so it put the guard's immediate rejection back onto the exponential schedule and logged `Exhausted retries` about 1.5s later — outside the test again.

Measured through the real client, which makes this deterministic rather than a coin flip:

| | elapsed | late `Exhausted retries` logs |
|---|---|---|
| before | 1513ms | 1 |
| after | **5ms** | **0** |

The guard's error now carries a marker code that classifies as a category `isRetryableCategory` excludes, so it fails once, immediately, and stays inside the test. Real transport failures are untouched and still retry — pinned by a test alongside the marker, since the risk of this change is silently disarming the retries that matter.

Full suite locally: 284 files, 2896 tests, no unhandled errors.

*(Note for anyone building locally: `bun run build` needs `NEXT_PUBLIC_CHAIN_ID=55516` in the environment — it is absent from `apps/web/.env` and there is no default by design.)*
