### PR TITLE
perf(debates): warm the claim-space allowlist while the debate runs

### DIFF
--- a/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
@@ -13,6 +13,7 @@ import { ExtendedReconnectPolicy } from '~/core/livekit/extended-reconnect-polic
 import { DebateRoomPageClient, isDebateInThankYouPeriod } from './debate-room-page-client';
 
 const mocks = vi.hoisted(() => ({
+  prefetchAllowlist: vi.fn(),
   back: vi.fn(),
   push: vi.fn(),
   replace: vi.fn(),
@@ -251,7 +252,14 @@ class FakeBroadcastChannel {
   }
 }
 
+// The warm-up reaches for a QueryClient and this suite renders without a provider. Mocked to the
+// question the room is responsible for: does entering a debate ask for the allowlist to be warmed?
+vi.mock('~/core/debates/use-prefetch-claim-space-allowlist', () => ({
+  usePrefetchClaimSpaceAllowlist: (enabled: boolean) => mocks.prefetchAllowlist(enabled),
+}));
+
 beforeEach(() => {
+  mocks.prefetchAllowlist.mockReset();
   clearDebateReturnDestination();
   setHistoryLength(1);
   mocks.back.mockReset();
@@ -431,6 +439,16 @@ describe('isDebateInThankYouPeriod', () => {
 });
 
 describe('DebateRoomPageClient', () => {
+  // GEO-2599. The debate-again picker's All tab waits on the claim-space allowlist, which walks the
+  // Root space's topic tree — about thirteen sequential round trips cold, and the tab stays empty
+  // until it lands. Entering the room says the picker is minutes away, so the traversal is started
+  // against a viewer who is watching a debate rather than one waiting on a list.
+  it('warms the claim-space allowlist on entering a debate', () => {
+    render(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
+
+    expect(mocks.prefetchAllowlist).toHaveBeenCalledWith(true);
+  });
+
   it('returns through browser history without rendering an already-completed room', async () => {
     setHistoryLength(2);
 

--- a/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.tsx
@@ -18,6 +18,7 @@ import {
   getServerTime,
 } from '~/core/debates/api';
 import { DebatePreScreen } from '~/core/debates/debate-pre-join-screen';
+import { usePrefetchClaimSpaceAllowlist } from '~/core/debates/use-prefetch-claim-space-allowlist';
 import { consumeDebateReturnDestination } from '~/core/debates/debate-return-navigation';
 import {
   CameraIcon,
@@ -177,6 +178,15 @@ const connectionFailureRedirectDelayMs = 750;
 const maximumBrowserTimeoutMs = 2_147_483_647;
 
 export function DebateRoomPageClient({ spaceId, debateId }: DebateRoomPageClientProps) {
+  // GEO-2599. The debate-again picker's All tab waits on the claim-space allowlist, which walks the
+  // Root space's topic tree — about thirteen sequential round trips on a cold cache, and the tab is
+  // empty until it lands. Being in the room says the picker is minutes away, so the traversal runs
+  // now, against a viewer who is watching a debate rather than waiting on a list.
+  //
+  // Here rather than in `DebateCoordinator`: that is mounted on every page in the app, and the query
+  // source this needs pulls a smart-account resolver into all of them.
+  usePrefetchClaimSpaceAllowlist(true);
+
   return (
     <DebateMediaSessionBoundary>
       <DebateRoomSurface spaceId={spaceId} debateId={debateId} />

--- a/apps/web/core/debates/use-prefetch-claim-space-allowlist.ts
+++ b/apps/web/core/debates/use-prefetch-claim-space-allowlist.ts
@@ -1,0 +1,56 @@
+'use client';
+
+import { useQueryClient } from '@tanstack/react-query';
+
+import * as React from 'react';
+
+import { browseSidebarDataQueryKey } from '~/core/browse/browse-sidebar-query';
+import { useBrowseSidebarQuerySource } from '~/core/browse/use-browse-sidebar-cache';
+
+/**
+ * Start the claim-space allowlist's traversal before the rematch picker needs it (GEO-2599).
+ *
+ * The picker does not *repeat* the browse sidebar's work — it shares its cache. It mounts alongside
+ * it and then waits: the All tab gates on `allowlistPending`, and assembling the allowlist walks the
+ * Root space's topic tree, up to about thirteen sequential round trips on a cold cache. The tab is
+ * empty for as long as that takes, which is what "took like 1 min to load" was.
+ *
+ * Warming it during the debate turns that into time nobody was waiting on, because a debate runs for
+ * minutes before its thank-you screen offers another one. Same key, same fetchers and the same
+ * `staleTime` as {@link useClaimSpaceAllowlist}, so on a page that already renders the sidebar this
+ * is a no-op rather than a second request.
+ *
+ * Called from the debate room rather than from `DebateCoordinator`, which was the obvious home and
+ * the wrong one: the coordinator is mounted on *every page in the app*, and reading the sidebar's
+ * query source there pulls a smart-account resolver — and with it a `CookiesProvider` requirement —
+ * into the graph of every page, for a warm-up most viewers never trigger. The room is already inside
+ * those providers, and being in a debate is the signal that matters anyway.
+ *
+ * The fetchers are still imported dynamically so the sidebar's loaders stay off the path until a
+ * warm-up actually runs.
+ *
+ * Gated on the same `personalSpaceLoading` as the hook, for the same reason: fetching earlier would
+ * cache a featured-only, signed-out answer under a partial identity key and drop the viewer's own
+ * spaces out of their own panel for as long as that entry stayed fresh. Warming the wrong answer
+ * sooner is worse than warming the right one late.
+ */
+export function usePrefetchClaimSpaceAllowlist(enabled: boolean) {
+  const queryClient = useQueryClient();
+  const { personalSpaceId, walletAddress, keyInput, isLoading: personalSpaceLoading } = useBrowseSidebarQuerySource();
+
+  React.useEffect(() => {
+    if (!enabled || personalSpaceLoading) return;
+    void queryClient.prefetchQuery({
+      queryKey: browseSidebarDataQueryKey(keyInput),
+      queryFn: async () => {
+        if (personalSpaceId) {
+          const { fetchBrowseSidebarData } = await import('~/core/browse/fetch-browse-sidebar-data');
+          return fetchBrowseSidebarData(personalSpaceId);
+        }
+        const { loadBrowseSidebarData } = await import('~/partials/browse-sidebar/load-browse-sidebar-data');
+        return loadBrowseSidebarData(walletAddress);
+      },
+      staleTime: 60_000,
+    });
+  }, [enabled, keyInput, personalSpaceId, personalSpaceLoading, queryClient, walletAddress]);
+}


### PR DESCRIPTION
GEO-2599's remaining item — the last one unique to that ticket, now that the rest has been split into GEO-2650/2652/2656.

## What was slow

The rematch picker's All tab gates on `allowlistPending`, and assembling that allowlist walks the Root space's topic tree: **up to about thirteen sequential round trips** on a cold cache. The tab is empty until it lands. That's the *"took like 1 min to load"*.

The picker does **not** repeat the browse sidebar's work — it shares its cache. It mounts alongside the sidebar and then waits.

So the fix isn't to drop the gate. That reintroduces exactly the flicker GEO-2600 and GEO-2604 are about: claims listing and then vanishing under the viewer. The fix is to start the traversal when nobody is waiting on it.

A debate runs for minutes before its thank-you screen offers another one, so entering the room is both early enough and a reliable signal the picker is coming.

Same key, same fetchers and the same `staleTime` as `useClaimSpaceAllowlist`, so on a page already rendering the sidebar this is a no-op rather than a second request. Gated on the same `personalSpaceLoading`, for the same reason the hook is: fetching earlier caches a featured-only, signed-out answer under a partial identity key and drops the viewer's own spaces out of their own panel for as long as that entry stays fresh. **Warming the wrong answer sooner is worse than warming the right one late.**

## I put this in the wrong place first

The obvious home was `DebateCoordinator` — mounted everywhere, and it would also have covered a viewer reloading straight onto the picker.

Then an unrelated file, `hooks.test.tsx`, started failing. I checked it against master rather than assuming: green there, red on my branch. Mine. The cause was that reading the sidebar's query source pulls `useSmartAccount`, and the missing mocks cascaded — `useWalletClient`, then `useWallets`, then **`Missing <CookiesProvider>`**.

I'd already told myself the production cost was nil, since every page renders the sidebar anyway. That was wrong: **requiring a provider is a real constraint on where an app-wide component can be mounted**, not a test artifact. Three cascading mocks was the codebase saying the dependency didn't belong there.

So it moved to the room, which is already inside those providers.

**What that costs:** a viewer who reloads straight onto the picker still gets the cold traversal. That's today's behaviour so nothing regresses, but the warm-up doesn't cover them, and I'd rather say so than let the title imply otherwise. If it matters, the fix is a prefetch on the picker's own route segment — separate change.

The fetchers are imported dynamically so the sidebar's loaders stay off the path until a warm-up actually runs.

## Verification

- Room suite **130/130**; coordinator + hooks suites **87/87** (both restored to green after the revert).
- The new test verified failing with the call removed.
- `eslint` exit 0. `tsc` reports 3 errors, all pre-existing in `sort-open-proposals.test.ts` and `use-entity-vote.ts` — the same ones present on master, none in files this PR touches.