### PR TITLE
fix(debates): cap the claim search the way the other search box does

### DIFF
--- a/apps/web/core/debates/api.test.ts
+++ b/apps/web/core/debates/api.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { MAX_SEARCH_QUERY_LENGTH } from '~/core/io/search-query';
+
 import {
   GeoChatRequestError,
   blockDebateUser,
@@ -187,6 +189,31 @@ describe('matchmaking', () => {
       'http://localhost:8080/matchmaking/claims?search=chips&filter=debate_now&limit=20',
       expect.objectContaining({ method: 'GET' })
     );
+  });
+
+  // GEO-2658. `/matchmaking/claims` has no ceiling on `search` — it trims, escapes the LIKE
+  // wildcards and binds — so this is about the same typed string behaving the same way whichever
+  // search box it went into, not about staying inside a limit.
+  it('caps an over-long claim search the way the other search box does', async () => {
+    const fetch = stubJson({ claims: [], next_cursor: null });
+
+    await listMatchmakingClaims({ search: 'a'.repeat(250) }, vi.fn(), 'user-a');
+
+    const url = new URL((fetch.mock.calls[0]?.[0] as string) ?? '');
+    expect(url.searchParams.get('search')).toHaveLength(MAX_SEARCH_QUERY_LENGTH);
+  });
+
+  // The part that is a correctness fix rather than a consistency one: slicing by code unit would
+  // cut a surrogate pair in half, and `URLSearchParams` turns a lone surrogate into a replacement
+  // character — a query the server can never match.
+  it('never cuts an emoji in half on the way out', async () => {
+    const fetch = stubJson({ claims: [], next_cursor: null });
+
+    await listMatchmakingClaims({ search: '🎉'.repeat(120) }, vi.fn(), 'user-a');
+
+    const sent = new URL((fetch.mock.calls[0]?.[0] as string) ?? '').searchParams.get('search') ?? '';
+    expect(sent).not.toContain('\uFFFD');
+    expect([...sent]).toHaveLength(MAX_SEARCH_QUERY_LENGTH);
   });
 
   it('omits the default "all" filter and unset facets', async () => {

--- a/apps/web/core/debates/api.ts
+++ b/apps/web/core/debates/api.ts
@@ -1,5 +1,7 @@
 'use client';
 
+import { capSearchQuery } from '~/core/io/search-query';
+
 export type ParticipantSlot = 1 | 2;
 export type DebateMatchStatus = 'pending' | 'accepted' | 'declined' | 'expired';
 export type DebateStatus = 'ready' | 'connecting' | 'preflight' | 'in_progress' | 'thanking' | 'complete' | 'cancelled';
@@ -1027,7 +1029,14 @@ export async function listMatchmakingClaims(
   signal?: AbortSignal
 ) {
   const params = new URLSearchParams();
-  if (query.search) params.set('search', query.search);
+  // GEO-2658. Capped for consistency, not to stay inside a limit: `/matchmaking/claims` has no
+  // ceiling on `search` — it trims, escapes the LIKE wildcards and binds, so an over-long query is
+  // answered rather than rejected. This is the only search box in debates, and the same typed
+  // string shouldn't behave differently depending on which box it went into.
+  //
+  // `capSearchQuery` also does the work that matters more than the length: it slices by code point,
+  // so a cut never lands inside a surrogate pair and hands `URLSearchParams` a lone surrogate.
+  if (query.search) params.set('search', capSearchQuery(query.search));
   if (query.spaceId) params.set('space_id', query.spaceId);
   if (query.filter && query.filter !== 'all') params.set('filter', query.filter);
   if (query.cursor) params.set('cursor', query.cursor);


### PR DESCRIPTION
Fixes GEO-2658 — and answers the question the ticket opens with.

## It's case 2, not case 1

The ticket lists three possibilities for geo-chat's behaviour on a long `search`. It's the second: **there is no limit, and nothing was broken.**

`/matchmaking/claims` trims, drops-if-empty, escapes `\ % _` so a typed wildcard stays literal, and binds. No length check anywhere — the only length guards in that file are on id-list sizes. A 250-character query returns *no matches*, which is correct, because no claim text contains that substring.

So this is a **consistency fix**, not a bug fix. Debates was the only search box not going through `capSearchQuery`, and the same typed string shouldn't behave differently depending on which box it went into.

## The part that is a correctness fix

`capSearchQuery` slices by **code point**. Cutting by code unit would halve a surrogate pair, and `URLSearchParams` turns a lone surrogate into a replacement character — a query the server can never match. That's pinned by its own test.

## Verification

Both tests verified failing with the cap removed. 28/28 in the api suite.

## Not in this PR — worth its own ticket

The real performance story, which the ticket's case 3 gestures at but gets the mechanism wrong. The predicate is:

```sql
claim.claim_text ILIKE '%' || $3 || '%' OR claim.description ILIKE '%' || $3 || '%'
```

A leading-wildcard `ILIKE` can't use a b-tree, and I checked the alternative rather than assuming: **`pg_trgm` is not installed** — `migrations/0001_initial_schema.sql` creates only `pgcrypto` — and there's no GIN or GIST index on either column. So every debates search is a scan over the candidate set.

That cost is **independent of query length**, which is why it isn't this ticket. But it's real, and it belongs with GEO-2613 / GEO-2656 item 4. `pg_trgm` plus a GIN index is the obvious candidate.

Given nothing is actually broken here, this ticket is probably not a Bug — worth downgrading.