### PR TITLE
fix(design-system): fall back to the generated avatar when an image fails

### DIFF
--- a/apps/web/design-system/avatar.tsx
+++ b/apps/web/design-system/avatar.tsx
@@ -13,16 +13,13 @@ interface Props {
 }
 
 export const Avatar = ({ value, avatarUrl, priority = false, alt = '', size = 12, square = false }: Props) => {
-  return avatarUrl ? (
-    <NativeGeoImage
-      value={avatarUrl}
-      alt={alt}
-      className="h-full w-full object-cover"
-      loading={priority ? 'eager' : 'lazy'}
-      fetchPriority={priority ? 'high' : undefined}
-      decoding="async"
-    />
-  ) : (
+  // GEO-2642. The generated avatar is the fallback for an image that cannot load, not only for the
+  // absence of one. A present-but-unresolvable `avatarUrl` used to render an `<img>` that 404'd
+  // through every gateway and settled on the browser's broken-image icon, because this branch keys
+  // on the URL being *set* rather than on it working. In a call the avatar comes from a cid minted
+  // by curator-backend, so a participant with a stale or malformed one showed as broken while
+  // everyone around them looked fine.
+  const generated = (
     <BoringAvatar
       size={size}
       variant="beam"
@@ -36,5 +33,19 @@ export const Avatar = ({ value, avatarUrl, priority = false, alt = '', size = 12
       ]}
       square={square}
     />
+  );
+
+  return avatarUrl ? (
+    <NativeGeoImage
+      value={avatarUrl}
+      alt={alt}
+      className="h-full w-full object-cover"
+      loading={priority ? 'eager' : 'lazy'}
+      fetchPriority={priority ? 'high' : undefined}
+      decoding="async"
+      fallback={generated}
+    />
+  ) : (
+    generated
   );
 };

--- a/apps/web/design-system/geo-image.test.tsx
+++ b/apps/web/design-system/geo-image.test.tsx
@@ -1,0 +1,81 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { IPFS_GATEWAY_COUNT } from '~/core/utils/utils';
+
+import { NativeGeoImage } from './geo-image';
+
+afterEach(cleanup);
+
+/**
+ * GEO-2642. An avatar whose image cannot load used to leave the browser's broken-image icon on
+ * screen: a bad CID still resolves to a perfectly valid gateway URL, so the `<img>` renders, 404s
+ * at every gateway in turn, and there was nothing to fall back to.
+ */
+describe('NativeGeoImage', () => {
+  const exhaustGateways = (image: HTMLElement) => {
+    for (let attempt = 0; attempt < IPFS_GATEWAY_COUNT; attempt += 1) {
+      fireEvent.error(image);
+    }
+  };
+
+  it('walks the gateway chain before giving up', () => {
+    render(<NativeGeoImage value="ipfs://bafyBroken" alt="avatar" fallback={<span>fallback</span>} />);
+
+    const image = screen.getByAltText('avatar');
+    const first = image.getAttribute('src');
+    fireEvent.error(image);
+
+    expect(screen.getByAltText('avatar').getAttribute('src')).not.toBe(first);
+    expect(screen.queryByText('fallback')).toBeNull();
+  });
+
+  it('shows the fallback once every gateway has failed', () => {
+    render(<NativeGeoImage value="ipfs://bafyBroken" alt="avatar" fallback={<span>fallback</span>} />);
+
+    exhaustGateways(screen.getByAltText('avatar'));
+
+    expect(screen.getByText('fallback')).toBeInTheDocument();
+    expect(screen.queryByAltText('avatar')).toBeNull();
+  });
+
+  // A non-IPFS URL has nowhere else to look, so retrying the same src would loop forever.
+  it('gives up immediately on a non-ipfs value', () => {
+    render(<NativeGeoImage value="https://example.com/missing.png" alt="avatar" fallback={<span>fallback</span>} />);
+
+    fireEvent.error(screen.getByAltText('avatar'));
+
+    expect(screen.getByText('fallback')).toBeInTheDocument();
+  });
+
+  // A bare CID resolves to nothing a browser can fetch, so it never gets as far as an error.
+  it('shows the fallback for a value that cannot be rendered at all', () => {
+    render(<NativeGeoImage value="bafyBareCidWithNoScheme" alt="avatar" fallback={<span>fallback</span>} />);
+
+    expect(screen.getByText('fallback')).toBeInTheDocument();
+    expect(screen.queryByAltText('avatar')).toBeNull();
+  });
+
+  // These render in recycled lists — a call's participant strip reorders constantly — so a
+  // previous participant's exhausted state must not follow the component to the next one.
+  it('starts over when the value changes', () => {
+    const { rerender } = render(
+      <NativeGeoImage value="ipfs://bafyBroken" alt="avatar" fallback={<span>fallback</span>} />
+    );
+    exhaustGateways(screen.getByAltText('avatar'));
+    expect(screen.getByText('fallback')).toBeInTheDocument();
+
+    rerender(<NativeGeoImage value="ipfs://bafyWorking" alt="avatar" fallback={<span>fallback</span>} />);
+
+    expect(screen.getByAltText('avatar')).toBeInTheDocument();
+    expect(screen.queryByText('fallback')).toBeNull();
+  });
+
+  it('renders nothing rather than crashing when no fallback is given', () => {
+    const { container } = render(<NativeGeoImage value="bafyBareCidWithNoScheme" alt="avatar" />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/apps/web/design-system/geo-image.tsx
+++ b/apps/web/design-system/geo-image.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useState } from 'react';
+import { type ReactNode, useCallback, useState } from 'react';
 import type { ImgHTMLAttributes } from 'react';
 
 import cn from 'classnames';
@@ -44,20 +44,39 @@ export function GeoImage({ value, alt = '', unoptimized = false, ...props }: Geo
 
 type NativeGeoImageProps = Omit<ImgHTMLAttributes<HTMLImageElement>, 'src' | 'onError'> & {
   value: string;
+  /**
+   * Rendered instead of the image once it cannot be shown — an unrenderable value, or every
+   * gateway exhausted. Without one the caller gets the browser's broken-image icon, which is what
+   * a participant with an unresolvable avatar looked like in a call (GEO-2642).
+   */
+  fallback?: ReactNode;
 };
 
 /** Native img element resolving IPFS values through the gateway fallback chain (Filebase → Pinata → Lighthouse). */
-export function NativeGeoImage({ value, alt = '', ...props }: NativeGeoImageProps) {
-  const [level, setLevel] = useState(0);
+export function NativeGeoImage({ value, alt = '', fallback, ...props }: NativeGeoImageProps) {
+  const [attempt, setAttempt] = useState({ value, level: 0, failed: false });
+
+  // Reset when the value changes rather than in an effect: these render in recycled lists — a
+  // LiveKit participant strip reorders constantly — and carrying a previous participant's
+  // exhausted-gateway state across would show their fallback for someone whose avatar is fine.
+  const level = attempt.value === value ? attempt.level : 0;
+  const failed = attempt.value === value ? attempt.failed : false;
 
   const handleError = useCallback(() => {
-    if (value.startsWith('ipfs://')) {
-      setLevel(prev => Math.min(prev + 1, IPFS_GATEWAY_COUNT - 1));
-    }
+    setAttempt(previous => {
+      const current = previous.value === value ? previous : { value, level: 0, failed: false };
+      // Only IPFS values have anywhere else to look. Anything else has failed on its first and
+      // only attempt, and retrying the same URL would loop.
+      if (value.startsWith('ipfs://') && current.level < IPFS_GATEWAY_COUNT - 1) {
+        return { value, level: current.level + 1, failed: false };
+      }
+      return { value, level: current.level, failed: true };
+    });
   }, [value]);
 
   const src = getImagePathAtLevel(value, level);
-  if (!isRenderableSrc(src)) return null;
+  // A bare CID or an entity id that slipped through resolves to something no browser can fetch.
+  if (failed || !isRenderableSrc(src)) return <>{fallback ?? null}</>;
 
   return <img {...props} src={src} alt={alt} onError={handleError} />;
 }


### PR DESCRIPTION
Fixes GEO-2642 — *"when showing a user's avatar in a call the avatar image looks broke"*.

## What produces a broken avatar

`Avatar` chose between the image and the generated avatar on whether `avatarUrl` was **set**, not on whether it **worked**:

```jsx
return avatarUrl ? <NativeGeoImage value={avatarUrl} … /> : <BoringAvatar … />;
```

And nothing upstream catches the failure. A bad CID still resolves to a perfectly valid gateway URL — `getImagePathAtLevel` just concatenates gateway + hash — so `isRenderableSrc` passes, the `<img>` renders, and it 404s at each gateway in turn. When the chain ran out, `NativeGeoImage` stopped advancing and left the browser's broken-image icon on screen with nothing behind it.

In a call the avatar comes from a cid curator-backend mints into the LiveKit participant metadata, which is why it shows up there: one participant with a stale or malformed cid looks broken while everyone around them is fine.

## The fix

The generated avatar becomes the fallback for an image that *can't load*, not only for the absence of one. `NativeGeoImage` takes the `fallback` because it's already the client component that owns the gateway chain; `Avatar` stays server-renderable and passes it down.

Two details that matter more than they look:

- **A non-IPFS value gives up on its first error.** It has nowhere else to resolve to, so the old code's "advance the gateway" did nothing and the broken icon stayed forever.
- **Attempt state is keyed on the value and reset during render, not in an effect.** These render in recycled lists — a call's participant strip reorders constantly — so carrying one participant's exhausted-gateway state to the next would show a fallback for someone whose avatar is perfectly good. There's a test for exactly that.

## Verification

Six tests, four of which fail with the fallback path removed. The two that pass either way cover the gateway walk itself, which already worked — flagging that rather than implying all six are load-bearing.

`design-system` + `core/utils`: **433 passed, 32 files**. eslint exit 0. `tsc` reports the same 3 pre-existing errors as master (`sort-open-proposals.test.ts`, `use-entity-vote.ts`), none in files this touches.

## What I could not confirm

The ticket is one line with no repro or screenshot, so **I've inferred the mechanism rather than reproduced the report**. What I can say is that this path definitely produces a broken-image icon for a present-but-unresolvable avatar, and that the calls surface is where unresolvable cids are most likely, since they come from a separate service.

If what Preston actually saw was a *squashed* or mis-sized avatar rather than a broken one, that's a different bug and this won't fix it — worth a screenshot before closing the ticket. Either way this is a strict improvement: a failed avatar image should never render as a broken icon.