### PR TITLE
fix(debates): stop the space-scope churn that trips the gateway rate limit

### DIFF
--- a/apps/web/core/debates/debate-gateway.ts
+++ b/apps/web/core/debates/debate-gateway.ts
@@ -852,7 +852,15 @@ function isGraphqlRequestError(error: unknown): boolean {
   );
 }
 
-const debateGateway = new DebateGatewayClient({
+/**
+ * The one client every debate surface shares. `useDebateGateway` owns its lifecycle; everything
+ * else retains scopes on it.
+ *
+ * Exported so the scope hooks can be tested against the instance they actually use. Their bug was
+ * command *volume* (GEO-2670), which is only observable by counting what reaches this object — a
+ * separately constructed client would have tested the test's own wiring instead.
+ */
+export const debateGateway = new DebateGatewayClient({
   queryClient,
   getSession: getGeoChatSession,
   getApiBaseUrl: getGeoChatApiBaseUrl,
@@ -899,17 +907,54 @@ export function useDebateGatewayScope(scope: DebateGatewayScope, enabled: boolea
  * surface showing claims from several spaces at once — the rematch picker — has to hold them all
  * or it only hears about some of its own rows.
  */
+/**
+ * Hold a space scope for each id, reconciling rather than rebuilding when the set changes.
+ *
+ * The set arrives in stages — the rematch picker adds spaces as the opponent's claims land, then
+ * the curated ones, then each browsed page — and it used to key one retain/release block on the
+ * whole joined list. Because retention is refcounted and React runs cleanup before the next
+ * effect, adding a single space released all N and re-retained all N: roughly `2N + 1` gateway
+ * commands where one was needed, every time the set grew.
+ *
+ * `gateway_commands_by_session` allows 120 per minute. A picker spanning fifteen spaces across a
+ * few arrival stages passes that on its own, and the server answers `rate_limited`, which the
+ * client turns into a reconnect — and on READY it re-subscribes every scope in one burst, spending
+ * the budget again. That is the reconnecting banner that would not go away in the debate-again
+ * flow (GEO-2670), and it is self-inflicted: the churn was almost entirely
+ * unsubscribe-then-resubscribe for spaces that never left the set.
+ *
+ * Reconciling makes a growing set cost one command per genuinely new space.
+ */
 export function useDebateGatewaySpaceScopes(spaceIds: string[], enabled: boolean) {
   // Joined so the effect keys off the ids themselves rather than a fresh array each render.
   const key = spaceIds.join(',');
+  const heldRef = React.useRef<Map<string, () => void>>(new Map());
 
   React.useEffect(() => {
-    if (!enabled || !key) return;
-    const releases = key.split(',').map(spaceId => debateGateway.retainScope({ scope: 'space', space_id: spaceId }));
-    return () => {
-      for (const release of releases) release();
-    };
+    const held = heldRef.current;
+    const wanted = new Set(enabled && key ? key.split(',') : []);
+
+    // Copied before iterating: releasing mutates the map being walked.
+    for (const [spaceId, release] of [...held]) {
+      if (wanted.has(spaceId)) continue;
+      release();
+      held.delete(spaceId);
+    }
+    for (const spaceId of wanted) {
+      if (held.has(spaceId)) continue;
+      held.set(spaceId, debateGateway.retainScope({ scope: 'space', space_id: spaceId }));
+    }
   }, [enabled, key]);
+
+  // Unmount only, deliberately. Putting this on the effect above is what caused the churn: its
+  // cleanup runs on every key change, not just when the caller goes away.
+  React.useEffect(
+    () => () => {
+      for (const release of heldRef.current.values()) release();
+      heldRef.current.clear();
+    },
+    []
+  );
 }
 
 /** Read-only view of the gateway snapshot. Unlike `useDebateGateway` this never starts a socket. */

--- a/apps/web/core/debates/use-debate-gateway-space-scopes.test.tsx
+++ b/apps/web/core/debates/use-debate-gateway-space-scopes.test.tsx
@@ -1,0 +1,99 @@
+import { renderHook } from '@testing-library/react';
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  retain: vi.fn(),
+  release: vi.fn(),
+}));
+
+// No module mock: the hook and the gateway singleton are the pair under test, and the singleton
+// opens no socket until `start()`. Spying on `retainScope` is enough to count commands.
+
+describe('useDebateGatewaySpaceScopes', () => {
+  let useDebateGatewaySpaceScopes: typeof import('./debate-gateway').useDebateGatewaySpaceScopes;
+
+  beforeEach(async () => {
+    mocks.retain.mockReset();
+    mocks.release.mockReset();
+    const mod = await import('./debate-gateway');
+    useDebateGatewaySpaceScopes = mod.useDebateGatewaySpaceScopes;
+    vi.spyOn(mod.debateGateway, 'retainScope').mockImplementation(scope => {
+      mocks.retain(scope);
+      return () => mocks.release(scope);
+    });
+  });
+
+  const spaceIdsOf = (calls: unknown[][]) =>
+    calls.map(([scope]) => (scope as { space_id: string }).space_id).sort();
+
+  it('retains one scope per space', () => {
+    renderHook(() => useDebateGatewaySpaceScopes(['a', 'b'], true));
+
+    expect(spaceIdsOf(mocks.retain.mock.calls)).toEqual(['a', 'b']);
+    expect(mocks.release).not.toHaveBeenCalled();
+  });
+
+  // GEO-2670. The bug: keying one retain/release block on the whole joined set meant adding a
+  // space released all N and re-retained all N. With `gateway_commands_by_session` at 120/minute,
+  // a picker spanning a dozen spaces across a few arrival stages trips the limit on its own, and
+  // the client turns `rate_limited` into a reconnect.
+  it('costs one retain and no releases when a space is added', () => {
+    const { rerender } = renderHook(({ ids }) => useDebateGatewaySpaceScopes(ids, true), {
+      initialProps: { ids: ['a', 'b', 'c'] },
+    });
+    mocks.retain.mockClear();
+
+    rerender({ ids: ['a', 'b', 'c', 'd'] });
+
+    expect(spaceIdsOf(mocks.retain.mock.calls)).toEqual(['d']);
+    expect(mocks.release).not.toHaveBeenCalled();
+  });
+
+  it('releases only the space that left', () => {
+    const { rerender } = renderHook(({ ids }) => useDebateGatewaySpaceScopes(ids, true), {
+      initialProps: { ids: ['a', 'b', 'c'] },
+    });
+    mocks.retain.mockClear();
+
+    rerender({ ids: ['a', 'c'] });
+
+    expect(spaceIdsOf(mocks.release.mock.calls)).toEqual(['b']);
+    expect(mocks.retain).not.toHaveBeenCalled();
+  });
+
+  // Reordering is not a change. The picker sorts its ids, but a caller that does not would
+  // otherwise rebuild every scope for nothing.
+  it('does nothing when the same spaces arrive in a different order', () => {
+    const { rerender } = renderHook(({ ids }) => useDebateGatewaySpaceScopes(ids, true), {
+      initialProps: { ids: ['a', 'b'] },
+    });
+    mocks.retain.mockClear();
+
+    rerender({ ids: ['b', 'a'] });
+
+    expect(mocks.retain).not.toHaveBeenCalled();
+    expect(mocks.release).not.toHaveBeenCalled();
+  });
+
+  it('releases everything on unmount', () => {
+    const { unmount } = renderHook(() => useDebateGatewaySpaceScopes(['a', 'b'], true));
+
+    unmount();
+
+    expect(spaceIdsOf(mocks.release.mock.calls)).toEqual(['a', 'b']);
+  });
+
+  it('releases everything when it is disabled, and retains again when re-enabled', () => {
+    const { rerender } = renderHook(({ on }) => useDebateGatewaySpaceScopes(['a', 'b'], on), {
+      initialProps: { on: true },
+    });
+
+    rerender({ on: false });
+    expect(spaceIdsOf(mocks.release.mock.calls)).toEqual(['a', 'b']);
+
+    mocks.retain.mockClear();
+    rerender({ on: true });
+    expect(spaceIdsOf(mocks.retain.mock.calls)).toEqual(['a', 'b']);
+  });
+});


### PR DESCRIPTION
Addresses GEO-2670 — the reconnecting banner that keeps appearing in the debate-again flow.

## The mechanism

`useDebateGatewaySpaceScopes` keyed **one** retain/release block on the whole joined set:

```ts
const key = spaceIds.join(',');
React.useEffect(() => {
  const releases = key.split(',').map(id => debateGateway.retainScope(…));
  return () => { for (const release of releases) release(); };
}, [enabled, key]);
```

Retention is refcounted, and React runs an effect's cleanup **before** its next setup — so the counts genuinely reach zero. Adding one space to a set of N therefore released all N and re-retained all N: roughly **2N + 1** gateway commands where one was needed.

The rematch picker is what feels it, because its set arrives in *stages* — the opponent's claims, then curated, then each browsed page, plus both participants' profile spaces. Every stage rewrote the whole set.

`gateway_commands_by_session` allows **120 per minute** (`crates/gateway/src/rate_limit.rs`). A picker spanning a dozen spaces across a few arrival stages passes that on its own. The server answers `rate_limited`; the client turns that into `forceReconnect`; and on `READY` it re-subscribes **every** scope in one burst, spending the budget again. Hence a banner that keeps coming back rather than clearing.

Almost all of that traffic was unsubscribe-then-resubscribe for spaces that never left the set.

## The fix

Reconcile: release what left, retain what's new, leave the rest alone. A growing set costs one command per genuinely new space.

The full release moves to an **unmount-only** effect. Leaving it on the reconciling effect is exactly what caused this — its cleanup runs on every key change, not only when the caller goes away.

## This is partly self-inflicted

Widening the picker's scope set in #2204 and #2205 — to cover every space across opponent, curated and browsed claims plus participants — is what turned this from waste into a breach. The churn predates me; I made the set big enough for it to matter.

## Verification

Six tests. **Three fail against the old implementation** — one retain and no releases when a space is added, only the departed space released, and reordering being a no-op. The other three (one scope per space, release on unmount, disable/re-enable) pass either way: they guard behaviour this doesn't change, and I'd rather say so than imply all six are load-bearing.

`core/debates`: **717 tests / 61 files green.** eslint exit 0. Typecheck adds **zero** errors — 5 on this branch, and the same 5 in the same three files on master, compared file-by-file after excluding my own untracked test file, which had polluted my first baseline run.

The gateway singleton is now exported so the scope hooks can be tested against the instance they actually use. The bug is command *volume*, observable only by counting what reaches that object; a separately constructed client would have tested the test's own wiring.

## What I have not established

**I have not reproduced Preston's screenshot**, and I can't see it. What I can say is that only two reconnecting UIs exist in the app, the LiveKit overlay is community-calls only, and the rematch picker isn't a LiveKit room — so the coordinator's gateway pill is the one he's seeing. The arithmetic above is plausible rather than measured: I don't know his actual space count.

So this may reduce the banner without eliminating it. Two things would settle it, and I'd suggest at least the first:

- **Distinguish `rate_limited` in the client.** It currently collapses into the same generic pill as any other pause, so a budget breach is indistinguishable from a dropped socket — which is why this took code reading rather than logs to find.
- Confirm with Preston whether the banner now clears, and whether it was permanent or recurring. Recurring fits this; permanent would point at the `subscription_limit_reached` park instead, which #2222 deliberately does not reconnect from.