### PR TITLE
fix(debates): say why live debate updates are paused

### DIFF
--- a/apps/web/core/debates/debate-gateway.test.ts
+++ b/apps/web/core/debates/debate-gateway.test.ts
@@ -1151,6 +1151,99 @@ describe('DebateGatewayClient', () => {
   // heartbeats kept being acked, the two-missed-ack path to `forceReconnect` was never reached, and
   // there was no route back to `ready` for the rest of the session — one scope-level rejection took
   // the account-level stream, and with it the incoming-request popup, down with it.
+  // GEO-2670. Every pause used to be the same `{ degraded, paused }`, so spending the command
+  // budget looked exactly like a dropped socket — and tracing it meant reading the subscription
+  // code rather than a log line. The reason is what makes a pause actionable.
+  it('says why live updates are paused', async () => {
+    client.start(
+      vi.fn(async () => 'privy-token'),
+      'user-a'
+    );
+    await vi.runAllTicks();
+    sockets[0]!.open();
+    sockets[0]!.receive('READY', readyPayload([]));
+    expect(client.getSnapshot()).toMatchObject({ paused: false, pauseReason: null });
+
+    // Our fault, not the network's: we sent more commands than the session allows.
+    sockets[0]!.receive('ERROR', { code: 'rate_limited', message: 'retry after 5 seconds' });
+    expect(client.getSnapshot()).toMatchObject({ paused: true, pauseReason: 'rate_limited' });
+
+    await vi.advanceTimersByTimeAsync(5_000);
+    sockets[1]!.open();
+    sockets[1]!.receive('READY', readyPayload([]));
+    expect(client.getSnapshot()).toMatchObject({ paused: false, pauseReason: null });
+
+    // A ceiling we are sitting against, which a reconnect would hit again.
+    sockets[1]!.receive('ERROR', {
+      code: 'subscription_limit_reached',
+      message: 'too many subscriptions',
+    });
+    expect(client.getSnapshot()).toMatchObject({ paused: true, pauseReason: 'subscription_limit' });
+  });
+
+  // A dropped socket is ordinary transport trouble, and has to stay distinguishable from the two
+  // above — that distinction is the whole point.
+  it('reports a dropped socket as disconnected rather than as a client fault', async () => {
+    client.start(
+      vi.fn(async () => 'privy-token'),
+      'user-a'
+    );
+    await vi.runAllTicks();
+    sockets[0]!.open();
+    sockets[0]!.receive('READY', readyPayload([]));
+
+    sockets[0]!.serverClose();
+
+    expect(client.getSnapshot()).toMatchObject({ paused: true, pauseReason: 'disconnected' });
+  });
+
+  // A server that never advertises the debate capability is not going to start: nothing recovers
+  // this without a deploy, so it must not read as a transient pause.
+  it('reports a missing debate capability as unsupported', async () => {
+    client.start(
+      vi.fn(async () => 'privy-token'),
+      'user-a'
+    );
+    await vi.runAllTicks();
+    sockets[0]!.open();
+    sockets[0]!.receive('READY', { capabilities: [], subscriptions: [] });
+
+    expect(client.getSnapshot()).toMatchObject({ paused: true, pauseReason: 'unsupported' });
+  });
+
+  // The trap in `setSnapshot`: it skips notifying when status and paused are unchanged. These two
+  // pauses are both `degraded/paused` with no ready in between, so the reason is the *only*
+  // difference — which is exactly the case that would be written and never delivered.
+  //
+  // An earlier version of this test put a reconnect between them. That reset `paused` to false, so
+  // the status comparison already differed and the guard was never exercised: the test passed with
+  // the guard deleted.
+  it('notifies listeners when only the pause reason changes', async () => {
+    client.start(
+      vi.fn(async () => 'privy-token'),
+      'user-a'
+    );
+    await vi.runAllTicks();
+    sockets[0]!.open();
+    sockets[0]!.receive('READY', readyPayload([]));
+
+    // Parks without reconnecting, so the socket stays open and `paused` stays true throughout.
+    sockets[0]!.receive('ERROR', {
+      code: 'subscription_limit_reached',
+      message: 'too many subscriptions',
+    });
+    expect(client.getSnapshot()).toMatchObject({ paused: true, pauseReason: 'subscription_limit' });
+
+    const seen: (string | null)[] = [];
+    const unsubscribe = client.subscribe(() => seen.push(client.getSnapshot().pauseReason));
+
+    // Same status, same `paused`, different reason.
+    sockets[0]!.receive('ERROR', { code: 'subscription_forbidden', message: 'not authorized' });
+
+    unsubscribe();
+    expect(seen).toEqual(['disconnected']);
+  });
+
   it('recycles the socket when a subscription is rejected, rather than parking on it', async () => {
     client.start(
       vi.fn(async () => 'privy-token'),

--- a/apps/web/core/debates/debate-gateway.ts
+++ b/apps/web/core/debates/debate-gateway.ts
@@ -31,9 +31,35 @@ export type DebateGatewayScope =
 
 export type MatchmakingSection = 'people' | 'claims' | 'matches';
 
+/**
+ * Why live updates are paused, when they are.
+ *
+ * Every pause used to collapse into the same `{ degraded, paused }`, so a client spending its
+ * command budget was indistinguishable from a dropped socket — and diagnosing GEO-2670 meant
+ * reading the subscription code rather than a log line. These are the distinctions that change what
+ * you would do about it:
+ *
+ * - `rate_limited` is a *client* fault. We sent more gateway commands than the session allows, so
+ *   the fix is to send fewer, not to wait.
+ * - `subscription_limit` is a ceiling we are sitting against; the account stream still works and
+ *   reconnecting would hit it again.
+ * - `disconnected` and `session` are ordinary transport trouble that a reconnect resolves.
+ * - `unsupported` means the server never advertised the debate capability, so nothing will recover
+ *   it without a deploy.
+ */
+export type DebateGatewayPauseReason =
+  | 'disconnected'
+  | 'session'
+  | 'rate_limited'
+  | 'subscription_limit'
+  | 'unsupported'
+  | 'error';
+
 export type DebateGatewaySnapshot = {
   status: 'idle' | 'connecting' | 'ready' | 'degraded';
   paused: boolean;
+  /** Set whenever `paused` is true, so a pause can be acted on rather than merely noticed. */
+  pauseReason: DebateGatewayPauseReason | null;
   /** Capabilities advertised by the last READY. Used to detect `debate_matchmaking_v1`. */
   capabilities: string[];
 };
@@ -119,7 +145,12 @@ export class DebateGatewayClient {
   private readonly pendingInvalidations = new Map<string, InvalidationFilters>();
   private readonly pendingChangedClaimsBySpace = new Map<string, Set<string>>();
 
-  private snapshot: DebateGatewaySnapshot = { status: 'idle', paused: false, capabilities: EMPTY_CAPABILITIES };
+  private snapshot: DebateGatewaySnapshot = {
+    status: 'idle',
+    paused: false,
+    pauseReason: null,
+    capabilities: EMPTY_CAPABILITIES,
+  };
   private capabilities: string[] = EMPTY_CAPABILITIES;
   private getPrivyIdentityToken: GetPrivyIdentityToken | null = null;
   private accountKey: string | null = null;
@@ -164,7 +195,7 @@ export class DebateGatewayClient {
     this.accountKey = accountKey;
     if (this.enabled) return;
     this.enabled = true;
-    this.setSnapshot({ status: 'connecting', paused: false });
+    this.setSnapshot({ status: 'connecting', paused: false, pauseReason: null });
     void this.connect();
   }
 
@@ -196,7 +227,7 @@ export class DebateGatewayClient {
     this.capabilities = EMPTY_CAPABILITIES;
     this.pendingChangedClaimsBySpace.clear();
     if (accountKey) this.queryClient.removeQueries({ queryKey: ['debates'] });
-    this.setSnapshot({ status: 'idle', paused: false });
+    this.setSnapshot({ status: 'idle', paused: false, pauseReason: null });
   }
 
   retainScope(scope: DebateGatewayScope) {
@@ -248,7 +279,7 @@ export class DebateGatewayClient {
       socket.onclose = () => this.handleClose(socket);
     } catch {
       if (!this.enabled || generation !== this.connectionGeneration) return;
-      this.setSnapshot({ status: 'degraded', paused: true });
+      this.setSnapshot({ status: 'degraded', paused: true, pauseReason: 'session' });
       this.scheduleReconnect();
     }
   }
@@ -287,11 +318,20 @@ export class DebateGatewayClient {
         if (isEventsLagged(envelope.payload)) {
           this.queueBroadReconcile();
         } else if (isRateLimited(envelope.payload)) {
-          this.forceReconnect(socket, rateLimitRetryDelayMs(envelope.payload));
+          const retryDelayMs = rateLimitRetryDelayMs(envelope.payload);
+          // Loud on purpose, and distinct from every other pause. This one is *our* fault: we sent
+          // more gateway commands than `gateway_commands_by_session` allows, so waiting does not fix
+          // it — sending fewer does. It reads as an ordinary reconnect to the viewer, which is how a
+          // subscription bug hid behind the generic banner until GEO-2670 was traced by hand.
+          console.error(
+            `Debate gateway rate limited; retrying in ${retryDelayMs}ms. This means the client sent ` +
+              'too many gateway commands, not that the connection is unhealthy.'
+          );
+          this.forceReconnect(socket, retryDelayMs, 'rate_limited');
         } else if (isSubscriptionLimitReached(envelope.payload)) {
           // A real ceiling, and reconnecting re-sends the same scopes and hits it again. The
           // account-routed stream keeps working; only the scopes past the limit are lost.
-          this.setSnapshot({ status: 'degraded', paused: true });
+          this.setSnapshot({ status: 'degraded', paused: true, pauseReason: 'subscription_limit' });
         } else if (this.canRecoverFromError()) {
           // Anything else is not known to be permanent, and parking here was a dead end: nothing in
           // this branch closes the socket, so heartbeats keep being acked, `heartbeatsAwaitingAck`
@@ -306,7 +346,7 @@ export class DebateGatewayClient {
           // another reconnect would spin: `reconnectAttempt` resets on a successful invalidation
           // flush, which a fresh connection performs before the error recurs, so the backoff would
           // never actually grow. Park, and let the degraded poll carry correctness.
-          this.setSnapshot({ status: 'degraded', paused: true });
+          this.setSnapshot({ status: 'degraded', paused: true, pauseReason: 'error' });
         }
         break;
     }
@@ -330,13 +370,13 @@ export class DebateGatewayClient {
     const supportsDebates = this.capabilities.includes(CAPABILITY);
     if (!supportsDebates) {
       this.readyForDebates = false;
-      this.setSnapshot({ status: 'degraded', paused: true });
+      this.setSnapshot({ status: 'degraded', paused: true, pauseReason: 'unsupported' });
       return;
     }
 
     const firstReadyForSocket = !this.readyForDebates;
     this.readyForDebates = true;
-    this.setSnapshot({ status: 'ready', paused: false });
+    this.setSnapshot({ status: 'ready', paused: false, pauseReason: null });
 
     if (firstReadyForSocket) {
       this.queueBroadReconcile();
@@ -715,11 +755,15 @@ export class DebateGatewayClient {
     this.readyForDebates = false;
     this.clearConnectionTimers();
     if (!this.enabled) return;
-    this.setSnapshot({ status: 'degraded', paused: true });
+    this.setSnapshot({ status: 'degraded', paused: true, pauseReason: 'disconnected' });
     this.scheduleReconnect();
   }
 
-  private forceReconnect(socket: WebSocketLike, minimumDelayMs = 0) {
+  private forceReconnect(
+    socket: WebSocketLike,
+    minimumDelayMs = 0,
+    reason: DebateGatewayPauseReason = 'disconnected'
+  ) {
     if (socket !== this.socket) return;
     this.socket = null;
     this.readyForDebates = false;
@@ -727,7 +771,7 @@ export class DebateGatewayClient {
     socket.onclose = null;
     socket.close();
     if (!this.enabled) return;
-    this.setSnapshot({ status: 'degraded', paused: true });
+    this.setSnapshot({ status: 'degraded', paused: true, pauseReason: reason });
     this.scheduleReconnect(minimumDelayMs);
   }
 
@@ -793,6 +837,9 @@ export class DebateGatewayClient {
     if (
       snapshot.status === this.snapshot.status &&
       snapshot.paused === this.snapshot.paused &&
+      // Included deliberately: a pause whose reason changed is a different pause, and without this
+      // the reason would be written but never delivered to a listener.
+      snapshot.pauseReason === this.snapshot.pauseReason &&
       capabilities === this.snapshot.capabilities
     ) {
       return;


### PR DESCRIPTION
Follow-up to #2237, and the part of GEO-2670 that would have made it a five-minute diagnosis.

## The problem

Every pause collapsed into the same `{ status: 'degraded', paused: true }`. Six call sites, one shape. So a client that had spent its gateway command budget looked exactly like one whose socket had dropped, and the viewer saw the same banner either way.

That's why tracing #2237 meant reading the subscription code and doing arithmetic about command counts, rather than reading a log line. The fix there is right, but its mechanism is *inferred* — and it needn't have been.

## What changes

`pauseReason` on the snapshot, because the distinctions change what you'd do about it:

| reason | what it means |
| --- | --- |
| `rate_limited` | **Our fault.** We sent more commands than the session allows — send fewer, don't wait. |
| `subscription_limit` | A ceiling we're against. Account stream still works; reconnecting hits it again. |
| `disconnected` / `session` | Ordinary transport trouble a reconnect resolves. |
| `unsupported` | Server never advertised the debate capability. Nothing recovers this without a deploy. |

`rate_limited` also logs, loudly and distinctly, saying explicitly that the client sent too many commands rather than the connection being unhealthy. Left silent it reads as an ordinary reconnect and hides behind the banner exactly as it did before.

## The subtle part

The reason is included in `setSnapshot`'s equality check. That comparison skips notifying listeners when `status` and `paused` are unchanged — so two pauses differing *only* in reason would be written and never delivered. Easy to miss, and it would have quietly defeated the whole change.

**That test needed a second attempt, and I'd rather say so.** My first version put a reconnect between the two pauses. The reconnect reset `paused` to `false`, so the status comparison already differed and the guard was never exercised — it passed with the guard deleted. The version here parks on `subscription_limit_reached` (which doesn't reconnect, so the socket stays open and `paused` stays true) and then triggers a different error on the same socket, making the reason the only difference. It fails with the guard removed.

## Verification

`core/debates`: **721 tests / 61 files green.** eslint exit 0. Typecheck clean on the changed files.

Four tests cover the reasons themselves — rate-limited, subscription-limit, a dropped socket staying `disconnected` rather than reading as a client fault, and a missing capability reading as `unsupported` rather than transient.

## Why it matters beyond tidiness

If Preston reports the banner still appearing after #2237, this is the difference between another round of code reading and a log line that names the cause. And the reasons aren't cosmetic labels — `rate_limited` says *stop sending*, `subscription_limit` says *you're at the ceiling*, `unsupported` says *this will never recover*. Those want different responses, and until now they were the same pixel.