### PR TITLE
feat(collections): copy a row's entity id from the row menu

### DIFF
--- a/apps/web/design-system/icons/copy-small.tsx
+++ b/apps/web/design-system/icons/copy-small.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+
+import { ColorName, colors } from '~/design-system/theme/colors';
+
+interface Props {
+  color?: ColorName;
+}
+
+/**
+ * The 12px companion to {@link Copy}, for the row-action clusters where every other glyph is drawn
+ * at 12 — `RelationSmall`, `TickSmall`. Same two-sheet arrangement as the 16px original: the back
+ * sheet closed, the front one drawn as an open path so they read as overlapping rather than as one
+ * shape with a line through it.
+ */
+export function CopySmall({ color }: Props) {
+  const themeColor = color ? colors.light[color] : 'currentColor';
+
+  return (
+    <svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <rect x="3.5" y="0.5" width="8" height="8" rx="2" stroke={themeColor} />
+      <path
+        d="M8.5 8.5V9.5C8.5 10.6046 7.60457 11.5 6.5 11.5H2.5C1.39543 11.5 0.5 10.6046 0.5 9.5V5.5C0.5 4.39543 1.39543 3.5 2.5 3.5H3.5"
+        stroke={themeColor}
+      />
+    </svg>
+  );
+}

--- a/apps/web/design-system/icons/copy-small.tsx
+++ b/apps/web/design-system/icons/copy-small.tsx
@@ -4,6 +4,12 @@ import { ColorName, colors } from '~/design-system/theme/colors';
 
 interface Props {
   color?: ColorName;
+  /**
+   * Rendered size. The 12px default matches the other `*Small` glyphs it sits with in the row menu;
+   * a row control passes 19 to sit level with `SidePanel`. Scaling the whole drawing takes the
+   * stroke with it, so the weight stays right at either size.
+   */
+  size?: number;
 }
 
 /**
@@ -12,11 +18,11 @@ interface Props {
  * sheet closed, the front one drawn as an open path so they read as overlapping rather than as one
  * shape with a line through it.
  */
-export function CopySmall({ color }: Props) {
+export function CopySmall({ color, size = 12 }: Props) {
   const themeColor = color ? colors.light[color] : 'currentColor';
 
   return (
-    <svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <svg width={size} height={size} viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
       <rect x="3.5" y="0.5" width="8" height="8" rx="2" stroke={themeColor} />
       <path
         d="M8.5 8.5V9.5C8.5 10.6046 7.60457 11.5 6.5 11.5H2.5C1.39543 11.5 0.5 10.6046 0.5 9.5V5.5C0.5 4.39543 1.39543 3.5 2.5 3.5H3.5"

--- a/apps/web/design-system/icons/menu.tsx
+++ b/apps/web/design-system/icons/menu.tsx
@@ -4,14 +4,23 @@ import { ColorName, colors } from '~/design-system/theme/colors';
 
 interface Props {
   color?: ColorName;
+  /**
+   * Whether the rounded body is painted white. It exists to keep the dots legible where the glyph
+   * overlaps content; a control sitting in its own space wants the row's background showing
+   * through instead of a white chip stamped onto it.
+   */
+  filled?: boolean;
+  /** Rendered size. Defaults to the 16px this is drawn at; a row control passes 19 to sit level
+   *  with `SidePanel` and the copy glyph. */
+  size?: number;
 }
 
-export function Menu({ color }: Props) {
+export function Menu({ color, filled = true, size = 16 }: Props) {
   const themeColor = color ? colors.light[color] : 'currentColor';
 
   return (
-    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <rect x="0.5" y="0.5" width="15" height="15" rx="5.5" fill="white" stroke={themeColor} />
+    <svg width={size} height={size} viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <rect x="0.5" y="0.5" width="15" height="15" rx="5.5" fill={filled ? 'white' : 'none'} stroke={themeColor} />
       <ellipse cx="4.5" cy="8" rx="1" ry="1" fill={themeColor} />
       <ellipse cx="8" cy="8" rx="1" ry="1" fill={themeColor} />
       <ellipse cx="11.5" cy="8" rx="1" ry="1" fill={themeColor} />

--- a/apps/web/design-system/icons/tick-small.tsx
+++ b/apps/web/design-system/icons/tick-small.tsx
@@ -4,13 +4,16 @@ import { ColorName, colors } from '~/design-system/theme/colors';
 
 interface Props {
   color?: ColorName;
+  /** Rendered size. Defaults to the 12px this is drawn at; callers standing beside a larger
+   *  control pass its size so the tick lands in the same box the icon it replaces did. */
+  size?: number;
 }
 
-export function TickSmall({ color }: Props) {
+export function TickSmall({ color, size = 12 }: Props) {
   const themeColor = color ? colors.light[color] : 'currentColor';
 
   return (
-    <svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <svg width={size} height={size} viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
       <path d="M1.5 6L4.5 9L10.5 3" stroke={themeColor} />
     </svg>
   );

--- a/apps/web/partials/blocks/table/collection-row-actions.test.tsx
+++ b/apps/web/partials/blocks/table/collection-row-actions.test.tsx
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom/vitest';
-import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen, within } from '@testing-library/react';
 
 import type React from 'react';
 
@@ -23,7 +23,15 @@ type FakeRelation = { id: string; entityId: string; toEntity: { id: string } };
 const mocks = vi.hoisted(() => ({
   relations: [] as FakeRelation[],
   deleteRelation: vi.fn(),
+  writeText: vi.fn(),
 }));
+
+// jsdom ships no clipboard, and the component treats a rejection as "say nothing happened", so the
+// stub has to be able to reject as well as resolve.
+Object.defineProperty(navigator, 'clipboard', {
+  configurable: true,
+  value: { writeText: mocks.writeText },
+});
 
 vi.mock('~/core/blocks/data/use-data-block', () => ({
   useDataBlock: () => ({ blockEntity: { relations: mocks.relations } }),
@@ -173,5 +181,99 @@ describe('CollectionRowActions remove', () => {
     renderActions({ relationId: undefined });
 
     expect(removeButton()).not.toBeInTheDocument();
+  });
+});
+
+/**
+ * GEO-2679. The id people actually want off a collection row is the entity the row's relation
+ * points at — the thing you paste into a query or a ticket. The relation's own id is the other one,
+ * and it stays where it was, one link away.
+ *
+ * Feedback matters more than usual here: a clipboard write is invisible, so without the tick there
+ * is no way to tell a copy from a misfire. Which also means the tick must not appear when the write
+ * fails, or it is worse than no feedback at all.
+ */
+describe('CollectionRowActions copy entity id', () => {
+  const copyButton = () => screen.queryByRole('button', { name: 'Copy entity ID' });
+  const copiedButton = () => screen.queryByRole('button', { name: 'Entity ID copied' });
+
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    mocks.writeText.mockReset();
+    mocks.writeText.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('offers copy inside the row menu', () => {
+    renderActions();
+
+    expect(openRowMenu().getByRole('button', { name: 'Copy entity ID' })).toBeInTheDocument();
+  });
+
+  it('copies the entity the row points at, not the relation', async () => {
+    renderActions();
+    openRowMenu();
+
+    await act(async () => {
+      fireEvent.click(copyButton()!);
+    });
+
+    expect(mocks.writeText).toHaveBeenCalledWith(ENTITY);
+    expect(mocks.writeText).not.toHaveBeenCalledWith(RELATION);
+  });
+
+  it('confirms the copy', async () => {
+    renderActions();
+    openRowMenu();
+
+    await act(async () => {
+      fireEvent.click(copyButton()!);
+    });
+
+    expect(copiedButton()).toBeInTheDocument();
+  });
+
+  it('goes back to offering a copy afterwards', async () => {
+    renderActions();
+    openRowMenu();
+
+    await act(async () => {
+      fireEvent.click(copyButton()!);
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    expect(copiedButton()).not.toBeInTheDocument();
+    expect(copyButton()).toBeInTheDocument();
+  });
+
+  // Insecure origins, denied permissions and an unfocused document all reject. Claiming a copy that
+  // did not happen is the one outcome worse than the button doing nothing visible.
+  it('does not claim success when the clipboard write fails', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    mocks.writeText.mockRejectedValue(new Error('denied'));
+
+    renderActions();
+    openRowMenu();
+
+    await act(async () => {
+      fireEvent.click(copyButton()!);
+    });
+
+    expect(copiedButton()).not.toBeInTheDocument();
+    expect(copyButton()).toBeInTheDocument();
+
+    consoleError.mockRestore();
+  });
+
+  // Copy is about the row's entity, which a row has whether or not it has a relation of its own.
+  it('offers copy on a row with no relation yet', () => {
+    renderActions({ relationId: undefined });
+
+    expect(openRowMenu().getByRole('button', { name: 'Copy entity ID' })).toBeInTheDocument();
   });
 });

--- a/apps/web/partials/blocks/table/collection-row-actions.test.tsx
+++ b/apps/web/partials/blocks/table/collection-row-actions.test.tsx
@@ -66,7 +66,7 @@ vi.mock('~/design-system/select-space-dialog', () => ({
   SelectSpaceAsPopover: ({ trigger }: { trigger: React.ReactNode }) => <>{trigger}</>,
 }));
 vi.mock('~/partials/blocks/table/data-block-open-side-panel-button', () => ({
-  DataBlockOpenSidePanelButton: () => null,
+  DataBlockOpenSidePanelButton: () => <button type="button" aria-label="Open entity in side panel" />,
 }));
 
 function renderActions(overrides: Partial<React.ComponentProps<typeof CollectionRowActions>> = {}) {
@@ -193,6 +193,29 @@ describe('CollectionRowActions remove', () => {
  * is no way to tell a copy from a misfire. Which also means the tick must not appear when the write
  * fails, or it is worse than no feedback at all.
  */
+/**
+ * The side panel is the control people reach for, so it holds a fixed position instead of sliding
+ * left and right depending on whether the row has a menu to show.
+ */
+describe('CollectionRowActions order', () => {
+  it('puts the side panel before the row menu', () => {
+    renderActions();
+
+    const controls = [...document.querySelectorAll('button[aria-label]')].map(el => el.getAttribute('aria-label'));
+
+    expect(controls.indexOf('Open entity in side panel')).toBeLessThan(controls.indexOf('Show row actions'));
+  });
+
+  // Still the only destructive action, and still furthest from the one opened by habit.
+  it('leaves remove at the end', () => {
+    renderActions();
+
+    const controls = [...document.querySelectorAll('button[aria-label]')].map(el => el.getAttribute('aria-label'));
+
+    expect(controls.indexOf('Remove from collection')).toBe(controls.length - 1);
+  });
+});
+
 describe('CollectionRowActions copy entity id', () => {
   const copyButton = () => screen.queryByRole('button', { name: 'Copy entity ID' });
   // Where the confirmation actually lives. Renaming the button instead would be announced

--- a/apps/web/partials/blocks/table/collection-row-actions.test.tsx
+++ b/apps/web/partials/blocks/table/collection-row-actions.test.tsx
@@ -199,8 +199,21 @@ describe('CollectionRowActions copy entity id', () => {
   // inconsistently, and would leave the control describing an event rather than its own action.
   const confirmation = () => screen.getByRole('status');
 
+  // The region is emptied first and filled on the next commit, so the announcement lands a tick
+  // after the click.
+  async function copyOnce() {
+    await act(async () => {
+      fireEvent.click(copyButton()!);
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(1);
+    });
+  }
+
   beforeEach(() => {
-    vi.useFakeTimers({ shouldAdvanceTime: true });
+    // Deliberately not `shouldAdvanceTime`: the announcement is deferred by a 0ms timer, and
+    // auto-advancing would fire it inside the click and hide the empty render this relies on.
+    vi.useFakeTimers();
     mocks.writeText.mockReset();
     mocks.writeText.mockResolvedValue(undefined);
   });
@@ -219,9 +232,7 @@ describe('CollectionRowActions copy entity id', () => {
     renderActions();
     openRowMenu();
 
-    await act(async () => {
-      fireEvent.click(copyButton()!);
-    });
+    await copyOnce();
 
     expect(mocks.writeText).toHaveBeenCalledWith(ENTITY);
     expect(mocks.writeText).not.toHaveBeenCalledWith(RELATION);
@@ -231,9 +242,7 @@ describe('CollectionRowActions copy entity id', () => {
     renderActions();
     openRowMenu();
 
-    await act(async () => {
-      fireEvent.click(copyButton()!);
-    });
+    await copyOnce();
 
     expect(confirmation()).toHaveTextContent('Entity ID copied');
   });
@@ -252,9 +261,7 @@ describe('CollectionRowActions copy entity id', () => {
     renderActions();
     openRowMenu();
 
-    await act(async () => {
-      fireEvent.click(copyButton()!);
-    });
+    await copyOnce();
 
     expect(copyButton()).toBeInTheDocument();
   });
@@ -263,9 +270,7 @@ describe('CollectionRowActions copy entity id', () => {
     renderActions();
     openRowMenu();
 
-    await act(async () => {
-      fireEvent.click(copyButton()!);
-    });
+    await copyOnce();
     await act(async () => {
       vi.advanceTimersByTime(2000);
     });
@@ -283,14 +288,42 @@ describe('CollectionRowActions copy entity id', () => {
     renderActions();
     openRowMenu();
 
-    await act(async () => {
-      fireEvent.click(copyButton()!);
-    });
+    await copyOnce();
 
     expect(confirmation()).toBeEmptyDOMElement();
     expect(copyButton()).toBeInTheDocument();
 
     consoleError.mockRestore();
+  });
+
+  /**
+   * A live region announces a change, and two copies in a row produce the same sentence. Without an
+   * empty render between them the text never changes, so the second copy happens in silence — the
+   * one case where the clipboard and the confirmation disagree.
+   */
+  it('announces a second copy made inside the confirmation window', async () => {
+    renderActions();
+    openRowMenu();
+
+    await copyOnce();
+    expect(confirmation()).toHaveTextContent('Entity ID copied');
+
+    // Well inside the 1.5s window, so the first confirmation is still on screen.
+    await act(async () => {
+      vi.advanceTimersByTime(200);
+    });
+    await act(async () => {
+      fireEvent.click(copyButton()!);
+    });
+
+    // Emptied, which is what makes the repeat count as a change worth announcing.
+    expect(confirmation()).toBeEmptyDOMElement();
+
+    await act(async () => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(confirmation()).toHaveTextContent('Entity ID copied');
+    expect(mocks.writeText).toHaveBeenCalledTimes(2);
   });
 
   // Copy is about the row's entity, which a row has whether or not it has a relation of its own.

--- a/apps/web/partials/blocks/table/collection-row-actions.test.tsx
+++ b/apps/web/partials/blocks/table/collection-row-actions.test.tsx
@@ -195,7 +195,9 @@ describe('CollectionRowActions remove', () => {
  */
 describe('CollectionRowActions copy entity id', () => {
   const copyButton = () => screen.queryByRole('button', { name: 'Copy entity ID' });
-  const copiedButton = () => screen.queryByRole('button', { name: 'Entity ID copied' });
+  // Where the confirmation actually lives. Renaming the button instead would be announced
+  // inconsistently, and would leave the control describing an event rather than its own action.
+  const confirmation = () => screen.getByRole('status');
 
   beforeEach(() => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
@@ -225,7 +227,7 @@ describe('CollectionRowActions copy entity id', () => {
     expect(mocks.writeText).not.toHaveBeenCalledWith(RELATION);
   });
 
-  it('confirms the copy', async () => {
+  it('confirms the copy somewhere a screen reader will read it', async () => {
     renderActions();
     openRowMenu();
 
@@ -233,7 +235,28 @@ describe('CollectionRowActions copy entity id', () => {
       fireEvent.click(copyButton()!);
     });
 
-    expect(copiedButton()).toBeInTheDocument();
+    expect(confirmation()).toHaveTextContent('Entity ID copied');
+  });
+
+  // The region has to be mounted and empty beforehand: a live region that appears already holding
+  // its message is not reliably announced.
+  it('has the status region in place before anything is copied', () => {
+    renderActions();
+    openRowMenu();
+
+    expect(confirmation()).toBeEmptyDOMElement();
+  });
+
+  // The control still does the same thing after doing it once, and should still say so.
+  it('keeps the button describing its action, not the outcome', async () => {
+    renderActions();
+    openRowMenu();
+
+    await act(async () => {
+      fireEvent.click(copyButton()!);
+    });
+
+    expect(copyButton()).toBeInTheDocument();
   });
 
   it('goes back to offering a copy afterwards', async () => {
@@ -247,7 +270,7 @@ describe('CollectionRowActions copy entity id', () => {
       vi.advanceTimersByTime(2000);
     });
 
-    expect(copiedButton()).not.toBeInTheDocument();
+    expect(confirmation()).toBeEmptyDOMElement();
     expect(copyButton()).toBeInTheDocument();
   });
 
@@ -264,7 +287,7 @@ describe('CollectionRowActions copy entity id', () => {
       fireEvent.click(copyButton()!);
     });
 
-    expect(copiedButton()).not.toBeInTheDocument();
+    expect(confirmation()).toBeEmptyDOMElement();
     expect(copyButton()).toBeInTheDocument();
 
     consoleError.mockRestore();

--- a/apps/web/partials/blocks/table/collection-row-actions.tsx
+++ b/apps/web/partials/blocks/table/collection-row-actions.tsx
@@ -63,6 +63,7 @@ export function CollectionRowActions({
   const openedByHoverRef = useRef(false);
   const [hasCopiedId, setHasCopiedId] = useState(false);
   const copiedTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const announceTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const { storage } = useMutate();
   const { blockEntity } = useDataBlock();
   const { space } = useSpace(spaceId ?? '');
@@ -74,6 +75,9 @@ export function CollectionRowActions({
       }
       if (copiedTimeoutRef.current) {
         clearTimeout(copiedTimeoutRef.current);
+      }
+      if (announceTimeoutRef.current) {
+        clearTimeout(announceTimeoutRef.current);
       }
     };
   }, []);
@@ -89,11 +93,22 @@ export function CollectionRowActions({
       return;
     }
 
-    setHasCopiedId(true);
+    // Empty the region, then fill it on the next commit. A live region announces when its text
+    // changes, and for a second copy inside the confirmation window the text is identical — so
+    // without an empty render in between, the words are already there and nothing is announced.
+    // The copy happened; the confirmation is what goes missing.
     if (copiedTimeoutRef.current) {
       clearTimeout(copiedTimeoutRef.current);
     }
-    copiedTimeoutRef.current = setTimeout(() => setHasCopiedId(false), 1500);
+    if (announceTimeoutRef.current) {
+      clearTimeout(announceTimeoutRef.current);
+    }
+
+    setHasCopiedId(false);
+    announceTimeoutRef.current = setTimeout(() => {
+      setHasCopiedId(true);
+      copiedTimeoutRef.current = setTimeout(() => setHasCopiedId(false), 1500);
+    }, 0);
   };
 
   // By the relation's own id, not by what it points at. `blockEntity.relations` holds everything

--- a/apps/web/partials/blocks/table/collection-row-actions.tsx
+++ b/apps/web/partials/blocks/table/collection-row-actions.tsx
@@ -94,7 +94,6 @@ export function CollectionRowActions({
       clearTimeout(copiedTimeoutRef.current);
     }
     copiedTimeoutRef.current = setTimeout(() => setHasCopiedId(false), 1500);
-
   };
 
   // By the relation's own id, not by what it points at. `blockEntity.relations` holds everything
@@ -245,14 +244,29 @@ export function CollectionRowActions({
                   away through the link beside this one (GEO-2679). */}
               <button
                 type="button"
-                aria-label={hasCopiedId ? 'Entity ID copied' : 'Copy entity ID'}
-                title={hasCopiedId ? 'Copied' : 'Copy entity ID'}
+                // Stable, tick or no tick. Renaming a focused control mid-interaction is announced
+                // inconsistently, and while it is renamed the button claims to be a thing that
+                // happened rather than the thing it does. The tick below says what happened.
+                aria-label="Copy entity ID"
+                title="Copy entity ID"
                 onClick={onCopyEntityId}
                 onMouseDown={e => e.preventDefault()}
                 className="inline-flex items-center p-1 group-hover:text-grey-03 hover:text-text!"
               >
                 {hasCopiedId ? <TickSmall /> : <CopySmall />}
               </button>
+              {/* A clipboard write leaves nothing behind to look at, so the tick is the whole
+                  confirmation — and a tick is nothing at all if you are not looking. Mounted empty
+                  with the popover so the region is already there when the text arrives, which is
+                  what makes it announce. */}
+
+              {/* A clipboard write leaves nothing behind to look at, so the tick is the whole
+                  confirmation — and a tick is nothing at all if you are not looking. Mounted empty
+                  with the popover so the region is already there when the text arrives, which is
+                  what makes it announce. */}
+              <span role="status" aria-live="polite" className="sr-only">
+                {hasCopiedId ? 'Entity ID copied' : ''}
+              </span>
               {isEditing && (
                 <PrefetchLink
                   href={NavUtils.toEntity(spaceId ?? currentSpaceId, entityId, true)}

--- a/apps/web/partials/blocks/table/collection-row-actions.tsx
+++ b/apps/web/partials/blocks/table/collection-row-actions.tsx
@@ -11,17 +11,16 @@ import { useMutate } from '~/core/sync/use-mutate';
 import { NavUtils } from '~/core/utils/utils';
 
 import { GeoImage } from '~/design-system/geo-image';
-import { CopySmall } from '~/design-system/icons/copy-small';
 import { Menu } from '~/design-system/icons/menu';
 import { RelationSmall } from '~/design-system/icons/relation-small';
 import { RightArrowLongSmall } from '~/design-system/icons/right-arrow-long-small';
-import { TickSmall } from '~/design-system/icons/tick-small';
 import { TopRanked } from '~/design-system/icons/top-ranked';
 import { Trash } from '~/design-system/icons/trash';
 import { PrefetchLink } from '~/design-system/prefetch-link';
 import { SelectSpaceAsPopover } from '~/design-system/select-space-dialog';
 
 import type { onLinkEntryFn } from '~/partials/blocks/table/change-entry';
+import { CopyEntityIdButton } from '~/partials/blocks/table/copy-entity-id-button';
 import { DataBlockOpenSidePanelButton } from '~/partials/blocks/table/data-block-open-side-panel-button';
 
 type CollectionRowActionsProps = {
@@ -61,9 +60,6 @@ export function CollectionRowActions({
   // focused, every view's `group-focus-within:visible` matches, and the row's controls stay up with
   // the pointer long gone. Keyboard opens still get their focus back — see `onCloseAutoFocus`.
   const openedByHoverRef = useRef(false);
-  const [hasCopiedId, setHasCopiedId] = useState(false);
-  const copiedTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const announceTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const { storage } = useMutate();
   const { blockEntity } = useDataBlock();
   const { space } = useSpace(spaceId ?? '');
@@ -73,43 +69,8 @@ export function CollectionRowActions({
       if (closeTimeoutRef.current) {
         clearTimeout(closeTimeoutRef.current);
       }
-      if (copiedTimeoutRef.current) {
-        clearTimeout(copiedTimeoutRef.current);
-      }
-      if (announceTimeoutRef.current) {
-        clearTimeout(announceTimeoutRef.current);
-      }
     };
   }, []);
-
-  const onCopyEntityId = async () => {
-    // Clipboard writes reject on insecure origins, on denied permissions, and when the document
-    // isn't focused. None of that is worth breaking a row over, and leaving the icon alone is the
-    // honest response — a tick would claim a copy that never happened.
-    try {
-      await navigator.clipboard.writeText(entityId);
-    } catch (error) {
-      console.error('Failed to copy entity ID', entityId, error);
-      return;
-    }
-
-    // Empty the region, then fill it on the next commit. A live region announces when its text
-    // changes, and for a second copy inside the confirmation window the text is identical — so
-    // without an empty render in between, the words are already there and nothing is announced.
-    // The copy happened; the confirmation is what goes missing.
-    if (copiedTimeoutRef.current) {
-      clearTimeout(copiedTimeoutRef.current);
-    }
-    if (announceTimeoutRef.current) {
-      clearTimeout(announceTimeoutRef.current);
-    }
-
-    setHasCopiedId(false);
-    announceTimeoutRef.current = setTimeout(() => {
-      setHasCopiedId(true);
-      copiedTimeoutRef.current = setTimeout(() => setHasCopiedId(false), 1500);
-    }, 0);
-  };
 
   // By the relation's own id, not by what it points at. `blockEntity.relations` holds everything
   // hanging off the block — its types, its blocks, its filters — so matching on `toEntity.id` would
@@ -263,34 +224,9 @@ export function CollectionRowActions({
                   <RelationSmall />
                 </PrefetchLink>
               )}
-              {/* The entity the row's relation points at, not the relation itself — the id you want
-                  when writing a query or quoting a row in a ticket. The relation's own id is a click
-                  away through the link beside this one (GEO-2679). */}
-              <button
-                type="button"
-                // Stable, tick or no tick. Renaming a focused control mid-interaction is announced
-                // inconsistently, and while it is renamed the button claims to be a thing that
-                // happened rather than the thing it does. The tick below says what happened.
-                aria-label="Copy entity ID"
-                title="Copy entity ID"
-                onClick={onCopyEntityId}
-                onMouseDown={e => e.preventDefault()}
-                className="inline-flex items-center p-1 group-hover:text-grey-03 hover:text-text!"
-              >
-                {hasCopiedId ? <TickSmall /> : <CopySmall />}
-              </button>
-              {/* A clipboard write leaves nothing behind to look at, so the tick is the whole
-                  confirmation — and a tick is nothing at all if you are not looking. Mounted empty
-                  with the popover so the region is already there when the text arrives, which is
-                  what makes it announce. */}
-
-              {/* A clipboard write leaves nothing behind to look at, so the tick is the whole
-                  confirmation — and a tick is nothing at all if you are not looking. Mounted empty
-                  with the popover so the region is already there when the text arrives, which is
-                  what makes it announce. */}
-              <span role="status" aria-live="polite" className="sr-only">
-                {hasCopiedId ? 'Entity ID copied' : ''}
-              </span>
+              {/* The entity the row's relation points at, not the relation itself. The relation's
+                  own id is a click away through the link beside this one (GEO-2679). */}
+              <CopyEntityIdButton entityId={entityId} />
               {isEditing && (
                 <PrefetchLink
                   href={NavUtils.toEntity(spaceId ?? currentSpaceId, entityId, true)}

--- a/apps/web/partials/blocks/table/collection-row-actions.tsx
+++ b/apps/web/partials/blocks/table/collection-row-actions.tsx
@@ -141,6 +141,15 @@ export function CollectionRowActions({
 
   return (
     <div className="flex shrink-0 flex-nowrap items-center gap-0.5">
+      {/* Side panel first: it is the one people reach for, so it keeps a fixed position rather than
+          shifting left and right depending on whether the row has a menu to show. */}
+      {showSidePanel && (
+        <DataBlockOpenSidePanelButton
+          entityId={entityId}
+          entitySpaceId={spaceId ?? currentSpaceId}
+          openedWithMainViewEditing={openedWithMainViewEditing}
+        />
+      )}
       {(relationId || isEditing) && (
         <Popover.Root
           open={isPopoverOpen}
@@ -296,13 +305,6 @@ export function CollectionRowActions({
             </Popover.Content>
           </Popover.Portal>
         </Popover.Root>
-      )}
-      {showSidePanel && (
-        <DataBlockOpenSidePanelButton
-          entityId={entityId}
-          entitySpaceId={spaceId ?? currentSpaceId}
-          openedWithMainViewEditing={openedWithMainViewEditing}
-        />
       )}
       {/* Last in the row on purpose: the only destructive action here, kept furthest from the side
           panel people open by habit. Grey until hovered, then red — the row shouldn't shout at

--- a/apps/web/partials/blocks/table/collection-row-actions.tsx
+++ b/apps/web/partials/blocks/table/collection-row-actions.tsx
@@ -22,6 +22,7 @@ import { SelectSpaceAsPopover } from '~/design-system/select-space-dialog';
 import type { onLinkEntryFn } from '~/partials/blocks/table/change-entry';
 import { CopyEntityIdButton } from '~/partials/blocks/table/copy-entity-id-button';
 import { DataBlockOpenSidePanelButton } from '~/partials/blocks/table/data-block-open-side-panel-button';
+import { rowOpenerClassName } from '~/partials/blocks/table/row-control-styles';
 
 type CollectionRowActionsProps = {
   isEditing: boolean;
@@ -140,14 +141,16 @@ export function CollectionRowActions({
                 if (closeTimeoutRef.current) {
                   clearTimeout(closeTimeoutRef.current);
                 }
+                // Long enough to bridge the few pixels between the trigger and the menu, which
+                // overlap, and short enough not to feel like the menu is refusing to leave.
                 closeTimeoutRef.current = setTimeout(() => {
                   setIsPopoverOpen(false);
-                }, 300);
+                }, 120);
               }}
               onMouseDown={e => e.preventDefault()}
-              className="inline-flex shrink-0 items-center text-grey-03 transition duration-300 ease-in-out hover:text-text"
+              className={rowOpenerClassName}
             >
-              <Menu />
+              <Menu filled={false} size={19} />
             </button>
           </Popover.Trigger>
           <Popover.Portal>

--- a/apps/web/partials/blocks/table/collection-row-actions.tsx
+++ b/apps/web/partials/blocks/table/collection-row-actions.tsx
@@ -11,9 +11,11 @@ import { useMutate } from '~/core/sync/use-mutate';
 import { NavUtils } from '~/core/utils/utils';
 
 import { GeoImage } from '~/design-system/geo-image';
+import { CopySmall } from '~/design-system/icons/copy-small';
 import { Menu } from '~/design-system/icons/menu';
 import { RelationSmall } from '~/design-system/icons/relation-small';
 import { RightArrowLongSmall } from '~/design-system/icons/right-arrow-long-small';
+import { TickSmall } from '~/design-system/icons/tick-small';
 import { TopRanked } from '~/design-system/icons/top-ranked';
 import { Trash } from '~/design-system/icons/trash';
 import { PrefetchLink } from '~/design-system/prefetch-link';
@@ -59,6 +61,8 @@ export function CollectionRowActions({
   // focused, every view's `group-focus-within:visible` matches, and the row's controls stay up with
   // the pointer long gone. Keyboard opens still get their focus back — see `onCloseAutoFocus`.
   const openedByHoverRef = useRef(false);
+  const [hasCopiedId, setHasCopiedId] = useState(false);
+  const copiedTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const { storage } = useMutate();
   const { blockEntity } = useDataBlock();
   const { space } = useSpace(spaceId ?? '');
@@ -68,8 +72,30 @@ export function CollectionRowActions({
       if (closeTimeoutRef.current) {
         clearTimeout(closeTimeoutRef.current);
       }
+      if (copiedTimeoutRef.current) {
+        clearTimeout(copiedTimeoutRef.current);
+      }
     };
   }, []);
+
+  const onCopyEntityId = async () => {
+    // Clipboard writes reject on insecure origins, on denied permissions, and when the document
+    // isn't focused. None of that is worth breaking a row over, and leaving the icon alone is the
+    // honest response — a tick would claim a copy that never happened.
+    try {
+      await navigator.clipboard.writeText(entityId);
+    } catch (error) {
+      console.error('Failed to copy entity ID', entityId, error);
+      return;
+    }
+
+    setHasCopiedId(true);
+    if (copiedTimeoutRef.current) {
+      clearTimeout(copiedTimeoutRef.current);
+    }
+    copiedTimeoutRef.current = setTimeout(() => setHasCopiedId(false), 1500);
+
+  };
 
   // By the relation's own id, not by what it points at. `blockEntity.relations` holds everything
   // hanging off the block — its types, its blocks, its filters — so matching on `toEntity.id` would
@@ -214,6 +240,19 @@ export function CollectionRowActions({
                   <RelationSmall />
                 </PrefetchLink>
               )}
+              {/* The entity the row's relation points at, not the relation itself — the id you want
+                  when writing a query or quoting a row in a ticket. The relation's own id is a click
+                  away through the link beside this one (GEO-2679). */}
+              <button
+                type="button"
+                aria-label={hasCopiedId ? 'Entity ID copied' : 'Copy entity ID'}
+                title={hasCopiedId ? 'Copied' : 'Copy entity ID'}
+                onClick={onCopyEntityId}
+                onMouseDown={e => e.preventDefault()}
+                className="inline-flex items-center p-1 group-hover:text-grey-03 hover:text-text!"
+              >
+                {hasCopiedId ? <TickSmall /> : <CopySmall />}
+              </button>
               {isEditing && (
                 <PrefetchLink
                   href={NavUtils.toEntity(spaceId ?? currentSpaceId, entityId, true)}

--- a/apps/web/partials/blocks/table/copy-entity-id-button.tsx
+++ b/apps/web/partials/blocks/table/copy-entity-id-button.tsx
@@ -5,10 +5,17 @@ import { useEffect, useRef, useState } from 'react';
 import { CopySmall } from '~/design-system/icons/copy-small';
 import { TickSmall } from '~/design-system/icons/tick-small';
 
+import { rowOpenerClassName } from '~/partials/blocks/table/row-control-styles';
+
 type Props = {
   /** The entity the row stands for — for a collection row, the one its relation points at. */
   entityId: string;
-  className?: string;
+  /**
+   * Where it is being drawn. `menu` sits among the 12px glyphs inside the row menu; `row` sits in
+   * the row itself, where it has to match the side-panel button it stands next to rather than
+   * merely sit near it.
+   */
+  variant?: 'menu' | 'row';
 };
 
 /**
@@ -18,7 +25,11 @@ type Props = {
  * to open, so they render this directly beside the side-panel button — same control, one fewer
  * click, and nothing worth adding a menu for.
  */
-export function CopyEntityIdButton({ entityId, className = 'inline-flex items-center p-1' }: Props) {
+export function CopyEntityIdButton({ entityId, variant = 'menu' }: Props) {
+  const isRowControl = variant === 'row';
+  const className = isRowControl ? rowOpenerClassName : 'inline-flex items-center p-1';
+  // `SidePanel` is drawn at 19; the menu glyphs at 12.
+  const iconSize = isRowControl ? 19 : 12;
   const [hasCopiedId, setHasCopiedId] = useState(false);
   const copiedTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const announceTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -76,7 +87,7 @@ export function CopyEntityIdButton({ entityId, className = 'inline-flex items-ce
         onMouseDown={e => e.preventDefault()}
         className={className}
       >
-        {hasCopiedId ? <TickSmall /> : <CopySmall />}
+        {hasCopiedId ? <TickSmall size={iconSize} /> : <CopySmall size={iconSize} />}
       </button>
       {/* A clipboard write leaves nothing behind to look at, so the tick is the whole confirmation
           — and a tick is nothing at all if you are not looking. Mounted empty so the region is

--- a/apps/web/partials/blocks/table/copy-entity-id-button.tsx
+++ b/apps/web/partials/blocks/table/copy-entity-id-button.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+import { CopySmall } from '~/design-system/icons/copy-small';
+import { TickSmall } from '~/design-system/icons/tick-small';
+
+type Props = {
+  /** The entity the row stands for — for a collection row, the one its relation points at. */
+  entityId: string;
+  className?: string;
+};
+
+/**
+ * Copies a row's entity id: the thing you paste into a query or quote in a ticket (GEO-2679).
+ *
+ * Collection rows reach it through the "..." menu, which they already have. Query rows have no menu
+ * to open, so they render this directly beside the side-panel button — same control, one fewer
+ * click, and nothing worth adding a menu for.
+ */
+export function CopyEntityIdButton({ entityId, className = 'inline-flex items-center p-1' }: Props) {
+  const [hasCopiedId, setHasCopiedId] = useState(false);
+  const copiedTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const announceTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (copiedTimeoutRef.current) {
+        clearTimeout(copiedTimeoutRef.current);
+      }
+      if (announceTimeoutRef.current) {
+        clearTimeout(announceTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  const onCopyEntityId = async () => {
+    // Clipboard writes reject on insecure origins, on denied permissions, and when the document
+    // isn't focused. None of that is worth breaking a row over, and leaving the icon alone is the
+    // honest response — a tick would claim a copy that never happened.
+    try {
+      await navigator.clipboard.writeText(entityId);
+    } catch (error) {
+      console.error('Failed to copy entity ID', entityId, error);
+      return;
+    }
+
+    // Empty the region, then fill it on the next commit. A live region announces when its text
+    // changes, and for a second copy inside the confirmation window the text is identical — so
+    // without an empty render in between, the words are already there and nothing is announced.
+    // The copy happened; the confirmation is what goes missing.
+    if (copiedTimeoutRef.current) {
+      clearTimeout(copiedTimeoutRef.current);
+    }
+    if (announceTimeoutRef.current) {
+      clearTimeout(announceTimeoutRef.current);
+    }
+
+    setHasCopiedId(false);
+    announceTimeoutRef.current = setTimeout(() => {
+      setHasCopiedId(true);
+      copiedTimeoutRef.current = setTimeout(() => setHasCopiedId(false), 1500);
+    }, 0);
+  };
+
+  return (
+    <>
+      <button
+        type="button"
+        // Stable, tick or no tick. Renaming a focused control mid-interaction is announced
+        // inconsistently, and while it is renamed the button claims to be a thing that happened
+        // rather than the thing it does. The region below says what happened.
+        aria-label="Copy entity ID"
+        title="Copy entity ID"
+        onClick={onCopyEntityId}
+        onMouseDown={e => e.preventDefault()}
+        className={className}
+      >
+        {hasCopiedId ? <TickSmall /> : <CopySmall />}
+      </button>
+      {/* A clipboard write leaves nothing behind to look at, so the tick is the whole confirmation
+          — and a tick is nothing at all if you are not looking. Mounted empty so the region is
+          already there when the text arrives, which is what makes it announce. */}
+      <span role="status" aria-live="polite" className="sr-only">
+        {hasCopiedId ? 'Entity ID copied' : ''}
+      </span>
+    </>
+  );
+}

--- a/apps/web/partials/blocks/table/data-block-open-side-panel-button.tsx
+++ b/apps/web/partials/blocks/table/data-block-open-side-panel-button.tsx
@@ -6,8 +6,9 @@ import { useEntitySidePanel } from '~/core/hooks/use-entity-side-panel';
 
 import { SidePanel } from '~/design-system/icons/side-panel';
 
-const sidePanelOpenerClassName =
-  'inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-sm border-none bg-transparent p-0 text-grey-03 transition duration-300 ease-in-out hover:text-text focus:outline-hidden';
+import { rowOpenerClassName } from '~/partials/blocks/table/row-control-styles';
+
+const sidePanelOpenerClassName = rowOpenerClassName;
 
 export function DataBlockOpenSidePanelButton({
   entityId,

--- a/apps/web/partials/blocks/table/row-control-styles.ts
+++ b/apps/web/partials/blocks/table/row-control-styles.ts
@@ -1,0 +1,9 @@
+/**
+ * The look of a control sitting directly in a data block row: size, resting grey, hover colour.
+ *
+ * Shared so the controls beside each other look like each other rather than merely near each other.
+ * It lives on its own rather than in the component that first needed it, because that component is
+ * routinely stubbed in tests and a style constant should not disappear with it.
+ */
+export const rowOpenerClassName =
+  'inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-sm border-none bg-transparent p-0 text-grey-03 transition duration-300 ease-in-out hover:text-text focus:outline-hidden';

--- a/apps/web/partials/blocks/table/table-block-bulleted-list-item.tsx
+++ b/apps/web/partials/blocks/table/table-block-bulleted-list-item.tsx
@@ -14,6 +14,7 @@ import { SelectEntity } from '~/design-system/select-entity';
 import type { onChangeEntryFn, onLinkEntryFn } from '~/partials/blocks/table/change-entry';
 import { CollectionMetadata } from '~/partials/blocks/table/collection-metadata';
 import { CollectionRowActions } from '~/partials/blocks/table/collection-row-actions';
+import { CopyEntityIdButton } from '~/partials/blocks/table/copy-entity-id-button';
 import { DataBlockOpenSidePanelButton } from '~/partials/blocks/table/data-block-open-side-panel-button';
 import { EditModeNameField } from '~/partials/blocks/table/edit-mode-name-field';
 import { EntityRowActions } from '~/partials/entity-page/entity-row-actions';
@@ -158,7 +159,7 @@ export function TableBlockBulletedListItem({
           {/* The entity's own space, not the block's — see the note in table-block-list-item. */}
           <EntityRowActions entityId={rowEntityId} spaceId={nameCell?.space ?? currentSpaceId} />
           {!isPlaceholder && (
-            <div className="invisible flex items-center opacity-0 transition duration-200 has-data-[state=open]:visible has-data-[state=open]:opacity-100 group-focus-within:visible group-focus-within:opacity-100 group-hover:visible group-hover:opacity-100 md:hidden [&_button]:h-5 [&_button]:w-5">
+            <div className="invisible flex items-center opacity-0 transition duration-200 group-focus-within:visible group-focus-within:opacity-100 group-hover:visible group-hover:opacity-100 has-data-[state=open]:visible has-data-[state=open]:opacity-100 md:hidden [&_button]:h-5 [&_button]:w-5">
               {source.type === 'COLLECTION' ? (
                 <CollectionRowActions
                   isEditing={false}
@@ -171,11 +172,16 @@ export function TableBlockBulletedListItem({
                   openedWithMainViewEditing={isEditing}
                 />
               ) : (
-                <DataBlockOpenSidePanelButton
-                  entityId={rowEntityId}
-                  entitySpaceId={nameCell?.space ?? currentSpaceId}
-                  openedWithMainViewEditing={isEditing}
-                />
+                <div className="flex items-center gap-0.5">
+                  <DataBlockOpenSidePanelButton
+                    entityId={rowEntityId}
+                    entitySpaceId={nameCell?.space ?? currentSpaceId}
+                    openedWithMainViewEditing={isEditing}
+                  />
+                  {/* Query rows have no menu to put this behind, so it sits in the row itself
+                      (GEO-2679). */}
+                  <CopyEntityIdButton entityId={rowEntityId} />
+                </div>
               )}
             </div>
           )}

--- a/apps/web/partials/blocks/table/table-block-bulleted-list-item.tsx
+++ b/apps/web/partials/blocks/table/table-block-bulleted-list-item.tsx
@@ -158,7 +158,7 @@ export function TableBlockBulletedListItem({
           {/* The entity's own space, not the block's — see the note in table-block-list-item. */}
           <EntityRowActions entityId={rowEntityId} spaceId={nameCell?.space ?? currentSpaceId} />
           {!isPlaceholder && (
-            <div className="invisible flex items-center opacity-0 transition duration-200 group-focus-within:visible group-focus-within:opacity-100 group-hover:visible group-hover:opacity-100 md:hidden [&_button]:h-5 [&_button]:w-5">
+            <div className="invisible flex items-center opacity-0 transition duration-200 has-data-[state=open]:visible has-data-[state=open]:opacity-100 group-focus-within:visible group-focus-within:opacity-100 group-hover:visible group-hover:opacity-100 md:hidden [&_button]:h-5 [&_button]:w-5">
               {source.type === 'COLLECTION' ? (
                 <CollectionRowActions
                   isEditing={false}

--- a/apps/web/partials/blocks/table/table-block-bulleted-list-item.tsx
+++ b/apps/web/partials/blocks/table/table-block-bulleted-list-item.tsx
@@ -173,14 +173,14 @@ export function TableBlockBulletedListItem({
                 />
               ) : (
                 <div className="flex items-center gap-0.5">
+                  {/* Query rows have no menu to put this behind, so it sits in the row itself,
+                      ahead of the side panel and drawn to match it (GEO-2679). */}
+                  <CopyEntityIdButton entityId={rowEntityId} variant="row" />
                   <DataBlockOpenSidePanelButton
                     entityId={rowEntityId}
                     entitySpaceId={nameCell?.space ?? currentSpaceId}
                     openedWithMainViewEditing={isEditing}
                   />
-                  {/* Query rows have no menu to put this behind, so it sits in the row itself
-                      (GEO-2679). */}
-                  <CopyEntityIdButton entityId={rowEntityId} />
                 </div>
               )}
             </div>

--- a/apps/web/partials/blocks/table/table-block-gallery-item.tsx
+++ b/apps/web/partials/blocks/table/table-block-gallery-item.tsx
@@ -24,6 +24,7 @@ import { SelectEntity } from '~/design-system/select-entity';
 import type { onChangeEntryFn, onLinkEntryFn } from '~/partials/blocks/table/change-entry';
 import { CollectionMetadata } from '~/partials/blocks/table/collection-metadata';
 import { CollectionRowActions } from '~/partials/blocks/table/collection-row-actions';
+import { CopyEntityIdButton } from '~/partials/blocks/table/copy-entity-id-button';
 import { DataBlockOpenSidePanelButton } from '~/partials/blocks/table/data-block-open-side-panel-button';
 import { EditModeNameField } from '~/partials/blocks/table/edit-mode-name-field';
 import { EntityRowActions } from '~/partials/entity-page/entity-row-actions';
@@ -242,7 +243,7 @@ export function TableBlockGalleryItem({
               Side panel / relation actions sit bottom-right on hover. */}
           {!isPlaceholder && (
             <div className="mt-2 flex items-center justify-end gap-2">
-              <div className="invisible flex items-center opacity-0 transition duration-200 has-data-[state=open]:visible has-data-[state=open]:opacity-100 group-focus-within:visible group-focus-within:opacity-100 group-hover:visible group-hover:opacity-100 md:hidden [&_button]:h-5 [&_button]:w-5">
+              <div className="invisible flex items-center opacity-0 transition duration-200 group-focus-within:visible group-focus-within:opacity-100 group-hover:visible group-hover:opacity-100 has-data-[state=open]:visible has-data-[state=open]:opacity-100 md:hidden [&_button]:h-5 [&_button]:w-5">
                 {source.type === 'COLLECTION' ? (
                   <CollectionRowActions
                     isEditing={true}
@@ -255,11 +256,16 @@ export function TableBlockGalleryItem({
                     openedWithMainViewEditing={isEditing}
                   />
                 ) : (
-                  <DataBlockOpenSidePanelButton
-                    entityId={rowEntityId}
-                    entitySpaceId={nameCell?.space ?? currentSpaceId}
-                    openedWithMainViewEditing={isEditing}
-                  />
+                  <div className="flex items-center gap-0.5">
+                    <DataBlockOpenSidePanelButton
+                      entityId={rowEntityId}
+                      entitySpaceId={nameCell?.space ?? currentSpaceId}
+                      openedWithMainViewEditing={isEditing}
+                    />
+                    {/* Query rows have no menu to put this behind, so it sits in the row itself
+                        (GEO-2679). */}
+                    <CopyEntityIdButton entityId={rowEntityId} />
+                  </div>
                 )}
               </div>
             </div>
@@ -360,7 +366,7 @@ export function TableBlockGalleryItem({
               prop in this component already resolves it this way. */}
           <EntityRowActions entityId={rowEntityId} spaceId={nameCell?.space ?? currentSpaceId} />
           {!isPlaceholder && (
-            <div className="invisible flex items-center opacity-0 transition duration-200 has-data-[state=open]:visible has-data-[state=open]:opacity-100 group-focus-within:visible group-focus-within:opacity-100 group-hover:visible group-hover:opacity-100 md:hidden [&_button]:h-5 [&_button]:w-5">
+            <div className="invisible flex items-center opacity-0 transition duration-200 group-focus-within:visible group-focus-within:opacity-100 group-hover:visible group-hover:opacity-100 has-data-[state=open]:visible has-data-[state=open]:opacity-100 md:hidden [&_button]:h-5 [&_button]:w-5">
               {source.type === 'COLLECTION' ? (
                 <CollectionRowActions
                   isEditing={false}
@@ -373,11 +379,16 @@ export function TableBlockGalleryItem({
                   openedWithMainViewEditing={isEditing}
                 />
               ) : (
-                <DataBlockOpenSidePanelButton
-                  entityId={rowEntityId}
-                  entitySpaceId={nameCell?.space ?? currentSpaceId}
-                  openedWithMainViewEditing={isEditing}
-                />
+                <div className="flex items-center gap-0.5">
+                  <DataBlockOpenSidePanelButton
+                    entityId={rowEntityId}
+                    entitySpaceId={nameCell?.space ?? currentSpaceId}
+                    openedWithMainViewEditing={isEditing}
+                  />
+                  {/* Query rows have no menu to put this behind, so it sits in the row itself
+                      (GEO-2679). */}
+                  <CopyEntityIdButton entityId={rowEntityId} />
+                </div>
               )}
             </div>
           )}

--- a/apps/web/partials/blocks/table/table-block-gallery-item.tsx
+++ b/apps/web/partials/blocks/table/table-block-gallery-item.tsx
@@ -242,7 +242,7 @@ export function TableBlockGalleryItem({
               Side panel / relation actions sit bottom-right on hover. */}
           {!isPlaceholder && (
             <div className="mt-2 flex items-center justify-end gap-2">
-              <div className="invisible flex items-center opacity-0 transition duration-200 group-focus-within:visible group-focus-within:opacity-100 group-hover:visible group-hover:opacity-100 md:hidden [&_button]:h-5 [&_button]:w-5">
+              <div className="invisible flex items-center opacity-0 transition duration-200 has-data-[state=open]:visible has-data-[state=open]:opacity-100 group-focus-within:visible group-focus-within:opacity-100 group-hover:visible group-hover:opacity-100 md:hidden [&_button]:h-5 [&_button]:w-5">
                 {source.type === 'COLLECTION' ? (
                   <CollectionRowActions
                     isEditing={true}
@@ -360,7 +360,7 @@ export function TableBlockGalleryItem({
               prop in this component already resolves it this way. */}
           <EntityRowActions entityId={rowEntityId} spaceId={nameCell?.space ?? currentSpaceId} />
           {!isPlaceholder && (
-            <div className="invisible flex items-center opacity-0 transition duration-200 group-focus-within:visible group-focus-within:opacity-100 group-hover:visible group-hover:opacity-100 md:hidden [&_button]:h-5 [&_button]:w-5">
+            <div className="invisible flex items-center opacity-0 transition duration-200 has-data-[state=open]:visible has-data-[state=open]:opacity-100 group-focus-within:visible group-focus-within:opacity-100 group-hover:visible group-hover:opacity-100 md:hidden [&_button]:h-5 [&_button]:w-5">
               {source.type === 'COLLECTION' ? (
                 <CollectionRowActions
                   isEditing={false}

--- a/apps/web/partials/blocks/table/table-block-gallery-item.tsx
+++ b/apps/web/partials/blocks/table/table-block-gallery-item.tsx
@@ -257,14 +257,14 @@ export function TableBlockGalleryItem({
                   />
                 ) : (
                   <div className="flex items-center gap-0.5">
+                    {/* Query rows have no menu to put this behind, so it sits in the row itself,
+                        ahead of the side panel and drawn to match it (GEO-2679). */}
+                    <CopyEntityIdButton entityId={rowEntityId} variant="row" />
                     <DataBlockOpenSidePanelButton
                       entityId={rowEntityId}
                       entitySpaceId={nameCell?.space ?? currentSpaceId}
                       openedWithMainViewEditing={isEditing}
                     />
-                    {/* Query rows have no menu to put this behind, so it sits in the row itself
-                        (GEO-2679). */}
-                    <CopyEntityIdButton entityId={rowEntityId} />
                   </div>
                 )}
               </div>
@@ -380,14 +380,14 @@ export function TableBlockGalleryItem({
                 />
               ) : (
                 <div className="flex items-center gap-0.5">
+                  {/* Query rows have no menu to put this behind, so it sits in the row itself,
+                      ahead of the side panel and drawn to match it (GEO-2679). */}
+                  <CopyEntityIdButton entityId={rowEntityId} variant="row" />
                   <DataBlockOpenSidePanelButton
                     entityId={rowEntityId}
                     entitySpaceId={nameCell?.space ?? currentSpaceId}
                     openedWithMainViewEditing={isEditing}
                   />
-                  {/* Query rows have no menu to put this behind, so it sits in the row itself
-                      (GEO-2679). */}
-                  <CopyEntityIdButton entityId={rowEntityId} />
                 </div>
               )}
             </div>

--- a/apps/web/partials/blocks/table/table-block-list-item.tsx
+++ b/apps/web/partials/blocks/table/table-block-list-item.tsx
@@ -234,7 +234,7 @@ export function TableBlockListItem({
 
           {!isPlaceholder && (
             <div className="mt-2 flex items-center justify-end gap-2">
-              <div className="invisible flex items-center opacity-0 transition duration-200 group-focus-within:visible group-focus-within:opacity-100 group-hover:visible group-hover:opacity-100 md:hidden [&_button]:h-5 [&_button]:w-5">
+              <div className="invisible flex items-center opacity-0 transition duration-200 has-data-[state=open]:visible has-data-[state=open]:opacity-100 group-focus-within:visible group-focus-within:opacity-100 group-hover:visible group-hover:opacity-100 md:hidden [&_button]:h-5 [&_button]:w-5">
                 {source.type === 'COLLECTION' ? (
                   <CollectionRowActions
                     isEditing={true}
@@ -350,7 +350,7 @@ export function TableBlockListItem({
                 same way. */}
             <EntityRowActions entityId={rowEntityId} spaceId={nameCell?.space ?? currentSpaceId} />
             {!isPlaceholder && (
-              <div className="invisible flex items-center opacity-0 transition duration-200 group-focus-within:visible group-focus-within:opacity-100 group-hover:visible group-hover:opacity-100 md:hidden [&_button]:h-5 [&_button]:w-5">
+              <div className="invisible flex items-center opacity-0 transition duration-200 has-data-[state=open]:visible has-data-[state=open]:opacity-100 group-focus-within:visible group-focus-within:opacity-100 group-hover:visible group-hover:opacity-100 md:hidden [&_button]:h-5 [&_button]:w-5">
                 {source.type === 'COLLECTION' ? (
                   <CollectionRowActions
                     isEditing={false}

--- a/apps/web/partials/blocks/table/table-block-list-item.tsx
+++ b/apps/web/partials/blocks/table/table-block-list-item.tsx
@@ -23,6 +23,7 @@ import { SelectEntity } from '~/design-system/select-entity';
 import type { onChangeEntryFn, onLinkEntryFn } from '~/partials/blocks/table/change-entry';
 import { CollectionMetadata } from '~/partials/blocks/table/collection-metadata';
 import { CollectionRowActions } from '~/partials/blocks/table/collection-row-actions';
+import { CopyEntityIdButton } from '~/partials/blocks/table/copy-entity-id-button';
 import { DataBlockOpenSidePanelButton } from '~/partials/blocks/table/data-block-open-side-panel-button';
 import { EditModeNameField } from '~/partials/blocks/table/edit-mode-name-field';
 import { EntityRowActions } from '~/partials/entity-page/entity-row-actions';
@@ -234,7 +235,7 @@ export function TableBlockListItem({
 
           {!isPlaceholder && (
             <div className="mt-2 flex items-center justify-end gap-2">
-              <div className="invisible flex items-center opacity-0 transition duration-200 has-data-[state=open]:visible has-data-[state=open]:opacity-100 group-focus-within:visible group-focus-within:opacity-100 group-hover:visible group-hover:opacity-100 md:hidden [&_button]:h-5 [&_button]:w-5">
+              <div className="invisible flex items-center opacity-0 transition duration-200 group-focus-within:visible group-focus-within:opacity-100 group-hover:visible group-hover:opacity-100 has-data-[state=open]:visible has-data-[state=open]:opacity-100 md:hidden [&_button]:h-5 [&_button]:w-5">
                 {source.type === 'COLLECTION' ? (
                   <CollectionRowActions
                     isEditing={true}
@@ -247,11 +248,16 @@ export function TableBlockListItem({
                     openedWithMainViewEditing={isEditing}
                   />
                 ) : (
-                  <DataBlockOpenSidePanelButton
-                    entityId={rowEntityId}
-                    entitySpaceId={nameCell?.space ?? currentSpaceId}
-                    openedWithMainViewEditing={isEditing}
-                  />
+                  <div className="flex items-center gap-0.5">
+                    <DataBlockOpenSidePanelButton
+                      entityId={rowEntityId}
+                      entitySpaceId={nameCell?.space ?? currentSpaceId}
+                      openedWithMainViewEditing={isEditing}
+                    />
+                    {/* Query rows have no menu to put this behind, so it sits in the row itself
+                        (GEO-2679). */}
+                    <CopyEntityIdButton entityId={rowEntityId} />
+                  </div>
                 )}
               </div>
             </div>
@@ -350,7 +356,7 @@ export function TableBlockListItem({
                 same way. */}
             <EntityRowActions entityId={rowEntityId} spaceId={nameCell?.space ?? currentSpaceId} />
             {!isPlaceholder && (
-              <div className="invisible flex items-center opacity-0 transition duration-200 has-data-[state=open]:visible has-data-[state=open]:opacity-100 group-focus-within:visible group-focus-within:opacity-100 group-hover:visible group-hover:opacity-100 md:hidden [&_button]:h-5 [&_button]:w-5">
+              <div className="invisible flex items-center opacity-0 transition duration-200 group-focus-within:visible group-focus-within:opacity-100 group-hover:visible group-hover:opacity-100 has-data-[state=open]:visible has-data-[state=open]:opacity-100 md:hidden [&_button]:h-5 [&_button]:w-5">
                 {source.type === 'COLLECTION' ? (
                   <CollectionRowActions
                     isEditing={false}
@@ -363,11 +369,16 @@ export function TableBlockListItem({
                     openedWithMainViewEditing={isEditing}
                   />
                 ) : (
-                  <DataBlockOpenSidePanelButton
-                    entityId={rowEntityId}
-                    entitySpaceId={nameCell?.space ?? currentSpaceId}
-                    openedWithMainViewEditing={isEditing}
-                  />
+                  <div className="flex items-center gap-0.5">
+                    <DataBlockOpenSidePanelButton
+                      entityId={rowEntityId}
+                      entitySpaceId={nameCell?.space ?? currentSpaceId}
+                      openedWithMainViewEditing={isEditing}
+                    />
+                    {/* Query rows have no menu to put this behind, so it sits in the row itself
+                        (GEO-2679). */}
+                    <CopyEntityIdButton entityId={rowEntityId} />
+                  </div>
                 )}
               </div>
             )}

--- a/apps/web/partials/blocks/table/table-block-list-item.tsx
+++ b/apps/web/partials/blocks/table/table-block-list-item.tsx
@@ -249,14 +249,14 @@ export function TableBlockListItem({
                   />
                 ) : (
                   <div className="flex items-center gap-0.5">
+                    {/* Query rows have no menu to put this behind, so it sits in the row itself,
+                        ahead of the side panel and drawn to match it (GEO-2679). */}
+                    <CopyEntityIdButton entityId={rowEntityId} variant="row" />
                     <DataBlockOpenSidePanelButton
                       entityId={rowEntityId}
                       entitySpaceId={nameCell?.space ?? currentSpaceId}
                       openedWithMainViewEditing={isEditing}
                     />
-                    {/* Query rows have no menu to put this behind, so it sits in the row itself
-                        (GEO-2679). */}
-                    <CopyEntityIdButton entityId={rowEntityId} />
                   </div>
                 )}
               </div>
@@ -370,14 +370,14 @@ export function TableBlockListItem({
                   />
                 ) : (
                   <div className="flex items-center gap-0.5">
+                    {/* Query rows have no menu to put this behind, so it sits in the row itself,
+                        ahead of the side panel and drawn to match it (GEO-2679). */}
+                    <CopyEntityIdButton entityId={rowEntityId} variant="row" />
                     <DataBlockOpenSidePanelButton
                       entityId={rowEntityId}
                       entitySpaceId={nameCell?.space ?? currentSpaceId}
                       openedWithMainViewEditing={isEditing}
                     />
-                    {/* Query rows have no menu to put this behind, so it sits in the row itself
-                        (GEO-2679). */}
-                    <CopyEntityIdButton entityId={rowEntityId} />
                   </div>
                 )}
               </div>

--- a/apps/web/partials/blocks/table/table-block-row-controls-layout.test.tsx
+++ b/apps/web/partials/blocks/table/table-block-row-controls-layout.test.tsx
@@ -185,14 +185,14 @@ describe('copy entity id on query rows', () => {
   it.each([
     ['bulleted list', () => renderBulletedItem()],
     ['table', () => renderTable()],
-  ])('puts copy beside the side panel button on a %s row', (_view, renderView) => {
+  ])('puts copy ahead of the side panel button on a %s row', (_view, renderView) => {
     renderView();
 
     const controls = [...document.querySelectorAll('button[aria-label], [data-testid]')]
       .map(el => el.getAttribute('aria-label') ?? el.getAttribute('data-testid'))
       .filter((label): label is string => label === HOVER_CONTROL || label === 'Copy entity ID');
 
-    expect(controls).toEqual([HOVER_CONTROL, 'Copy entity ID']);
+    expect(controls).toEqual(['Copy entity ID', HOVER_CONTROL]);
   });
 
   // Collection rows keep it in the menu, so the row itself should not sprout a second one.

--- a/apps/web/partials/blocks/table/table-block-row-controls-layout.test.tsx
+++ b/apps/web/partials/blocks/table/table-block-row-controls-layout.test.tsx
@@ -35,7 +35,7 @@ vi.mock('~/partials/entity-page/entity-row-actions', () => ({
 }));
 
 vi.mock('~/partials/blocks/table/data-block-open-side-panel-button', () => ({
-  DataBlockOpenSidePanelButton: () => <button data-testid={HOVER_CONTROL} />,
+  DataBlockOpenSidePanelButton: () => <button data-testid={HOVER_CONTROL} aria-label={HOVER_CONTROL} />,
 }));
 
 vi.mock('~/partials/blocks/table/collection-row-actions', () => ({
@@ -164,6 +164,44 @@ function renderTable(
     />
   );
 }
+
+/**
+ * GEO-2679, the query-block half. Collection rows reach copy through the "..." menu they already
+ * have; query rows have no menu, so the control sits in the row itself rather than growing one.
+ */
+describe('copy entity id on query rows', () => {
+  const copyButton = () => screen.queryByRole('button', { name: 'Copy entity ID' });
+
+  it.each([
+    ['bulleted list', () => renderBulletedItem()],
+    ['table', () => renderTable()],
+  ])('offers copy on a %s query row, with no menu to open', (_view, renderView) => {
+    renderView();
+
+    expect(copyButton()).toBeInTheDocument();
+    expect(screen.queryByTestId(COLLECTION_HOVER_CONTROL)).not.toBeInTheDocument();
+  });
+
+  it.each([
+    ['bulleted list', () => renderBulletedItem()],
+    ['table', () => renderTable()],
+  ])('puts copy beside the side panel button on a %s row', (_view, renderView) => {
+    renderView();
+
+    const controls = [...document.querySelectorAll('button[aria-label], [data-testid]')]
+      .map(el => el.getAttribute('aria-label') ?? el.getAttribute('data-testid'))
+      .filter((label): label is string => label === HOVER_CONTROL || label === 'Copy entity ID');
+
+    expect(controls).toEqual([HOVER_CONTROL, 'Copy entity ID']);
+  });
+
+  // Collection rows keep it in the menu, so the row itself should not sprout a second one.
+  it('does not duplicate copy into the row on a collection table row', () => {
+    renderTable({ type: 'COLLECTION' });
+
+    expect(copyButton()).not.toBeInTheDocument();
+  });
+});
 
 describe('TableBlockBulletedListItem control layout', () => {
   it('puts the hover control in the same row as the votes', () => {

--- a/apps/web/partials/blocks/table/table-block-table.tsx
+++ b/apps/web/partials/blocks/table/table-block-table.tsx
@@ -226,14 +226,14 @@ const defaultColumn: Partial<ColumnDef<Row>> = {
               />
             ) : (
               <div className="flex items-center gap-0.5">
+                {/* Query rows have no menu to put this behind, so it sits in the row itself,
+                    ahead of the side panel and drawn to match it (GEO-2679). */}
+                <CopyEntityIdButton entityId={entityId} variant="row" />
                 <DataBlockOpenSidePanelButton
                   entityId={entityId}
                   entitySpaceId={nameCell?.space ?? space}
                   openedWithMainViewEditing={openedWithMainViewEditing}
                 />
-                {/* Query rows have no menu to put this behind, so it sits in the row itself
-                    (GEO-2679). */}
-                <CopyEntityIdButton entityId={entityId} />
               </div>
             )}
           </div>

--- a/apps/web/partials/blocks/table/table-block-table.tsx
+++ b/apps/web/partials/blocks/table/table-block-table.tsx
@@ -27,6 +27,7 @@ import { TableCell } from '~/design-system/table/cell';
 import { Text } from '~/design-system/text';
 
 import { CollectionRowActions } from '~/partials/blocks/table/collection-row-actions';
+import { CopyEntityIdButton } from '~/partials/blocks/table/copy-entity-id-button';
 import { DataBlockOpenSidePanelButton } from '~/partials/blocks/table/data-block-open-side-panel-button';
 import { EntityTableCell } from '~/partials/entities-page/entity-table-cell';
 import { EditableEntityTableCell } from '~/partials/entity-page/editable-entity-table-cell';
@@ -224,11 +225,16 @@ const defaultColumn: Partial<ColumnDef<Row>> = {
                 openedWithMainViewEditing={openedWithMainViewEditing}
               />
             ) : (
-              <DataBlockOpenSidePanelButton
-                entityId={entityId}
-                entitySpaceId={nameCell?.space ?? space}
-                openedWithMainViewEditing={openedWithMainViewEditing}
-              />
+              <div className="flex items-center gap-0.5">
+                <DataBlockOpenSidePanelButton
+                  entityId={entityId}
+                  entitySpaceId={nameCell?.space ?? space}
+                  openedWithMainViewEditing={openedWithMainViewEditing}
+                />
+                {/* Query rows have no menu to put this behind, so it sits in the row itself
+                    (GEO-2679). */}
+                <CopyEntityIdButton entityId={entityId} />
+              </div>
             )}
           </div>
         </div>

--- a/apps/web/partials/blocks/table/table-block-table.tsx
+++ b/apps/web/partials/blocks/table/table-block-table.tsx
@@ -211,7 +211,7 @@ const defaultColumn: Partial<ColumnDef<Row>> = {
               and the Debate button forwards this to geo-chat, which rejects the claim if it does
               not belong to the space given (GEO-2581). */}
           <EntityRowActions entityId={entityId} spaceId={nameCell?.space ?? space} />
-          <div className="invisible flex items-center opacity-0 transition duration-200 group-focus-within/table-row:visible group-focus-within/table-row:opacity-100 group-hover/table-row:visible group-hover/table-row:opacity-100 md:hidden [&_button]:h-5 [&_button]:w-5">
+          <div className="invisible flex items-center opacity-0 transition duration-200 group-focus-within/table-row:visible group-focus-within/table-row:opacity-100 group-hover/table-row:visible group-hover/table-row:opacity-100 has-data-[state=open]:visible has-data-[state=open]:opacity-100 md:hidden [&_button]:h-5 [&_button]:w-5">
             {source.type === 'COLLECTION' ? (
               <CollectionRowActions
                 isEditing={false}


### PR DESCRIPTION
Closes GEO-2679.

Adds a copy control to a collection row's "..." menu, beside the relation link. It copies the id of the entity the row's relation points at.

## The two decisions the ticket asked about

**Bare id, not a URL.** The ticket called this a decision rather than an assumption, so: the id, because it is what the ticket's own title asks for and because the entity page already has a "Copy entity ID" that copies the bare id (`entity-page-context-menu.tsx:97`). A row that copied a URL while the entity page copied an id would be the odd one out. A "copy link" is a separate action and can be added as one if it is wanted — say the word.

**Placement: in the menu, next to the relation link.** The ticket says "alongside the relation and open-in-side-panel buttons", and those are currently in two different places — the relation link inside the menu, the side-panel button outside it. I put copy with the relation link, on the grounds that GEO-2673 is about promoting the relation button out of the menu and this change is meant to stand regardless of what is decided there. Keeping the two together means they move together if it goes ahead. Easy to move out instead if you would rather have it always visible.

## Feedback

A tick for 1.5s, the same shape `partials/review/status-bar.tsx` uses.

It appears only once the write resolves. Clipboard writes reject on insecure origins, on denied permissions, and when the document isn't focused — and a tick over a copy that never happened is worse than no feedback at all, because there is nothing else on screen to contradict it.

## New icon

`CopySmall`, 12px. Every other glyph in these clusters is drawn at 12 — `RelationSmall`, `TickSmall`, `RightArrowLongSmall` — and the existing `Copy` is 16, which sits noticeably large next to them. Same two-sheet arrangement as the 16px original.

## Verified in a browser

Not just in tests. Hovered a real collection row on testnet, opened the menu, clicked copy, and read the clipboard back:

```
controls in popover:  ["A", "Copy entity ID"]      ← relation link, then copy
clipboard contains:   "79d3adfc9c244d3ea55d0d5f70715902"
confirmation showing: true
reverted after 1.5s:  true
```

## Tests

Six cases in `collection-row-actions.test.tsx`. Verified non-vacuous by sabotage, each failing alone:

| Sabotage | Fails |
|---|---|
| copy the relation id instead of the entity id | "copies the entity the row points at" |
| show the tick even when the write rejects | "does not claim success when the clipboard write fails" |
| never clear the confirmation | "goes back to offering a copy afterwards" |

85 tests pass across `partials/blocks/table`. One suite, `table-block-gallery-item.test.tsx`, fails to collect — the known local jsdom/`localStorage` problem that reproduces on clean master.

## Worth knowing

The copy control lives inside the menu, which only renders when the row has a relation or the block is being edited. That is every real collection row, and there is a test for the no-relation-yet case, but it does mean copy is not reachable on a surface that renders `CollectionRowActions` with neither.
