### PR TITLE
fix(community-calls): stop admitting joiners into a call about to cut them off

### DIFF
--- a/apps/web/core/community-calls/constants.test.ts
+++ b/apps/web/core/community-calls/constants.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  CALL_END_TIMER_DELAY_MINUTES,
+  LIVE_MEETING_GRACE_MINUTES,
+  LIVE_WINDOW_AFTER_MS,
+  LIVE_WINDOW_BEFORE_MS,
+  isOccurrenceLive,
+} from './constants';
+
+const START = Date.UTC(2026, 2, 5, 17, 0);
+const END = Date.UTC(2026, 2, 5, 18, 0);
+const MINUTE = 60 * 1000;
+
+/** The instant every connected client force-disconnects itself — see CallEndTimer. */
+const hardCutoff = END + LIVE_MEETING_GRACE_MINUTES * MINUTE;
+/** The instant the countdown banner appears. */
+const countdownStart = END + CALL_END_TIMER_DELAY_MINUTES * MINUTE;
+
+describe('join window vs. the forced cutoff', () => {
+  /**
+   * GEO-2584. These two used to be written as independent literals that happened to be
+   * equal, so the join screen admitted people at the very instant the cutoff ejected them,
+   * and rejoining was permitted so it looped. Anyone admitted must get the full countdown.
+   */
+  it('stops admitting joiners before the hard cutoff', () => {
+    expect(END + LIVE_WINDOW_AFTER_MS).toBeLessThan(hardCutoff);
+  });
+
+  it('stops admitting joiners no later than the countdown banner', () => {
+    expect(END + LIVE_WINDOW_AFTER_MS).toBeLessThanOrEqual(countdownStart);
+  });
+
+  it('refuses to join once the countdown is under way', () => {
+    expect(isOccurrenceLive(START, END, countdownStart + 1)).toBe(false);
+    expect(isOccurrenceLive(START, END, hardCutoff - MINUTE)).toBe(false);
+    expect(isOccurrenceLive(START, END, hardCutoff)).toBe(false);
+    expect(isOccurrenceLive(START, END, hardCutoff + MINUTE)).toBe(false);
+  });
+
+  /**
+   * The property that actually protects the user, stated directly: whatever the last
+   * admissible instant is, the cutoff must still be a full countdown away from it. The old
+   * window failed this with a margin of zero — the last joiner had no time at all.
+   */
+  it('leaves an admitted joiner the whole countdown before the cutoff', () => {
+    const lastAdmissibleInstant = END + LIVE_WINDOW_AFTER_MS;
+    const countdownLengthMs = (LIVE_MEETING_GRACE_MINUTES - CALL_END_TIMER_DELAY_MINUTES) * MINUTE;
+    expect(hardCutoff - lastAdmissibleInstant).toBeGreaterThanOrEqual(countdownLengthMs);
+  });
+
+  it('still admits joiners through the grace window up to that point', () => {
+    expect(isOccurrenceLive(START, END, END + LIVE_WINDOW_AFTER_MS)).toBe(true);
+    expect(isOccurrenceLive(START, END, END + LIVE_WINDOW_AFTER_MS - 1)).toBe(true);
+    expect(isOccurrenceLive(START, END, END + MINUTE)).toBe(true);
+  });
+});
+
+describe('isOccurrenceLive', () => {
+  it('admits early joiners within the pre-start window and refuses them before it', () => {
+    expect(isOccurrenceLive(START, END, START - LIVE_WINDOW_BEFORE_MS)).toBe(true);
+    expect(isOccurrenceLive(START, END, START - LIVE_WINDOW_BEFORE_MS - 1)).toBe(false);
+  });
+
+  it('is live throughout the scheduled window', () => {
+    expect(isOccurrenceLive(START, END, START)).toBe(true);
+    expect(isOccurrenceLive(START, END, (START + END) / 2)).toBe(true);
+    expect(isOccurrenceLive(START, END, END)).toBe(true);
+  });
+});

--- a/apps/web/core/community-calls/constants.ts
+++ b/apps/web/core/community-calls/constants.ts
@@ -113,9 +113,24 @@ export function parseRoomName(roomName: string): { spaceId: string; callId: stri
 // reschedule.
 export const OCCURRENCE_MATCH_TOLERANCE_MS = 15 * 60 * 1000;
 
-/** A call is joinable from 15min before start until 30min after end. */
+/** A call is joinable from 15min before start until the call-end countdown begins. */
 export const LIVE_WINDOW_BEFORE_MS = 15 * 60 * 1000;
-export const LIVE_WINDOW_AFTER_MS = 30 * 60 * 1000;
+
+/**
+ * Derived from {@link CALL_END_TIMER_DELAY_MINUTES}, deliberately, rather than written as
+ * its own literal.
+ *
+ * It used to be an independent `30 * 60 * 1000`, which happened to equal
+ * {@link LIVE_MEETING_GRACE_MINUTES} — so the join window closed at the *exact instant* of
+ * the hard cutoff. Two consequences, both GEO-2584: joining in the last five minutes bought
+ * a session that `CallEndTimer` ended almost immediately (at the boundary, on its very first
+ * tick, since `update()` runs on mount), and because admission was still permitted right up
+ * to that instant, rejoining looped — reported as "got kicked out twice".
+ *
+ * Closing admission when the countdown *starts* keeps the two ordered by construction:
+ * anyone let in always sees the banner count down before being disconnected.
+ */
+export const LIVE_WINDOW_AFTER_MS = CALL_END_TIMER_DELAY_MINUTES * 60 * 1000;
 
 export function isOccurrenceLive(startMs: number, endMs: number, now = Date.now()): boolean {
   return now >= startMs - LIVE_WINDOW_BEFORE_MS && now <= endMs + LIVE_WINDOW_AFTER_MS;

--- a/apps/web/core/community-calls/use-reconnection-state.ts
+++ b/apps/web/core/community-calls/use-reconnection-state.ts
@@ -2,7 +2,13 @@ import * as React from 'react';
 
 import { ConnectionState, DisconnectReason, Room } from 'livekit-client';
 
-export type ReconnectionStatus = 'connected' | 'reconnecting' | 'disconnected';
+/**
+ * `ended` is never produced by this hook. A forced end-of-call cutoff and a voluntary Leave
+ * both go through `room.disconnect()` and arrive as CLIENT_INITIATED, so the room's own
+ * events cannot tell them apart — whoever triggers the cutoff has to say so. See
+ * live-room's `endedByCutoff` (GEO-2584).
+ */
+export type ReconnectionStatus = 'connected' | 'reconnecting' | 'disconnected' | 'ended';
 
 export type ReconnectionState = {
   /** Current connection status. */

--- a/apps/web/partials/community-calls/call-end-timer.tsx
+++ b/apps/web/partials/community-calls/call-end-timer.tsx
@@ -27,6 +27,13 @@ export function CallEndTimer({ endTime, onTimeUp }: Props) {
   const [secondsLeft, setSecondsLeft] = React.useState<number | null>(null);
   const firedRef = React.useRef(false);
 
+  // Callers pass a fresh closure every render (it has to close over the room), so keeping
+  // `onTimeUp` in the effect's deps tore down and rebuilt the interval on every render —
+  // which on a busy call is more often than once a second, so the tick could go long
+  // stretches without ever firing. Read it through a ref instead.
+  const onTimeUpRef = React.useRef(onTimeUp);
+  onTimeUpRef.current = onTimeUp;
+
   const hardCutoffMs = endTime.getTime() + LIVE_MEETING_GRACE_MINUTES * 60 * 1000;
   const timerVisibleMs = endTime.getTime() + CALL_END_TIMER_DELAY_MINUTES * 60 * 1000;
 
@@ -43,14 +50,14 @@ export function CallEndTimer({ endTime, onTimeUp }: Props) {
 
       if (remaining <= 0 && !firedRef.current) {
         firedRef.current = true;
-        onTimeUp?.();
+        onTimeUpRef.current?.();
       }
     };
 
     update();
     const interval = window.setInterval(update, 1000);
     return () => window.clearInterval(interval);
-  }, [hardCutoffMs, timerVisibleMs, onTimeUp]);
+  }, [hardCutoffMs, timerVisibleMs]);
 
   if (secondsLeft === null) return null;
 

--- a/apps/web/partials/community-calls/community-call-flow.tsx
+++ b/apps/web/partials/community-calls/community-call-flow.tsx
@@ -8,7 +8,14 @@ import * as React from 'react';
 import { Effect } from 'effect';
 
 import { getCommunityCallToken, getViewerToken } from '~/core/community-calls/api';
-import { CALL_SCHEMA, LIVE_OCCURRENCE_TICK_MS, buildRoomName, isOccurrenceLive } from '~/core/community-calls/constants';
+import {
+  CALL_SCHEMA,
+  LIVE_OCCURRENCE_TICK_MS,
+  LIVE_WINDOW_AFTER_MS,
+  LIVE_WINDOW_BEFORE_MS,
+  buildRoomName,
+  isOccurrenceLive,
+} from '~/core/community-calls/constants';
 import { findOccurrenceByStart, getOccurrences } from '~/core/community-calls/occurrences';
 import { CommunityCallToken, ViewerToken } from '~/core/community-calls/types';
 import { useCommunityCallIdentityToken } from '~/core/community-calls/use-identity-token';
@@ -183,7 +190,12 @@ export function CommunityCallFlow({ spaceId, callId }: { spaceId: string; callId
     return (
       <Notice>
         <p className="text-smallTitle text-text">This call isn’t active right now.</p>
-        <p>You can join from 15 minutes before it starts until 30 minutes after it ends.</p>
+        {/* Read off the constants rather than written out — the window moved once already
+            (GEO-2584) and hardcoded copy silently kept quoting the old one. */}
+        <p>
+          You can join from {LIVE_WINDOW_BEFORE_MS / 60_000} minutes before it starts until{' '}
+          {LIVE_WINDOW_AFTER_MS / 60_000} minutes after it ends.
+        </p>
       </Notice>
     );
   }

--- a/apps/web/partials/community-calls/live-room.tsx
+++ b/apps/web/partials/community-calls/live-room.tsx
@@ -31,7 +31,6 @@ import {
   stopRecording,
 } from '~/core/community-calls/api';
 import { LAST_EDITOR_CONFIRM_DELAY_MS } from '~/core/community-calls/constants';
-import { ExtendedReconnectPolicy } from '~/core/livekit/extended-reconnect-policy';
 import { formatDuration } from '~/core/community-calls/format';
 import { Recording, parseParticipantMetadata } from '~/core/community-calls/types';
 import { useCallTimeUp } from '~/core/community-calls/use-call-time-up';
@@ -40,6 +39,7 @@ import { useIsMobileCallLayout } from '~/core/community-calls/use-is-mobile-call
 import { ChatEntry, usePersistentChat } from '~/core/community-calls/use-persistent-chat';
 import { useReconnectionState } from '~/core/community-calls/use-reconnection-state';
 import { useRecordingMetadataSync } from '~/core/community-calls/use-recording-metadata-sync';
+import { ExtendedReconnectPolicy } from '~/core/livekit/extended-reconnect-policy';
 import { TrackedErrorBoundary } from '~/core/telemetry/tracked-error-boundary';
 
 import { Avatar } from '~/design-system/avatar';
@@ -220,10 +220,22 @@ function RoomBody({
   const [leaveDialogOpen, setLeaveDialogOpen] = React.useState(false);
   const [endCallBusy, setEndCallBusy] = React.useState(false);
 
+  // The forced end-of-call cutoff disconnects the room itself, so it reaches
+  // `useReconnectionState` as CLIENT_INITIATED — identical to pressing Leave, and therefore
+  // silently navigating away. Record that it was the cutoff before disconnecting, so the
+  // user is told the call ended rather than just finding themselves back on the calls page
+  // (GEO-2584). The ref is what the disconnect handler reads: `room.disconnect()` can emit
+  // before React has re-rendered with the new state.
+  const [endedByCutoff, setEndedByCutoff] = React.useState(false);
+  const endedByCutoffRef = React.useRef(false);
+
   // Distinguishes an intentional Leave (CLIENT_INITIATED) — navigate away directly —
   // from a drop that should show the reconnection overlay instead of silently
   // kicking the user out. See use-reconnection-state.ts.
-  const reconnection = useReconnectionState(room, () => router.push(backHref));
+  const reconnection = useReconnectionState(room, () => {
+    if (endedByCutoffRef.current) return;
+    router.push(backHref);
+  });
   const [rejoinBusy, setRejoinBusy] = React.useState(false);
   const [rejoinError, setRejoinError] = React.useState<string | null>(null);
 
@@ -305,10 +317,14 @@ function RoomBody({
   };
 
   // Forced-timeout path: fires once when the CallEndTimer banner counts down to
-  // zero, converging on the same disconnect + navigate-away cleanup as the manual
-  // leave dialog. No recording-stop confirmation on this path — the call ends
-  // regardless of whether a recording is still running.
-  const handleTimeUp = useCallTimeUp(onLeave);
+  // zero, converging on the same disconnect as the manual leave dialog but flagging
+  // itself first so the overlay can say why. No recording-stop confirmation on this
+  // path — the call ends regardless of whether a recording is still running.
+  const handleTimeUp = useCallTimeUp(() => {
+    endedByCutoffRef.current = true;
+    setEndedByCutoff(true);
+    onLeave();
+  });
 
   const onStopRecordingAndLeave = async () => {
     if (endCallBusy) return;
@@ -511,7 +527,7 @@ function RoomBody({
       />
 
       <ReconnectionOverlay
-        status={reconnection.status}
+        status={endedByCutoff ? 'ended' : reconnection.status}
         disconnectReason={reconnection.disconnectReason}
         onRejoin={handleRejoin}
         onLeave={() => router.push(backHref)}

--- a/apps/web/partials/community-calls/reconnection-overlay.tsx
+++ b/apps/web/partials/community-calls/reconnection-overlay.tsx
@@ -37,6 +37,17 @@ const DEFAULT_DISCONNECT_INFO = {
   message: "We weren't able to reconnect automatically. You can try rejoining the call below.",
 };
 
+/**
+ * The scheduled cutoff. Not keyed on a DisconnectReason because it doesn't have one — the
+ * cutoff disconnects the client itself, so LiveKit reports CLIENT_INITIATED, exactly as if
+ * the user had pressed Leave. Saying so explicitly is the point: without it the cutoff
+ * dropped people back on the calls page with no explanation (GEO-2584).
+ */
+const ENDED_INFO = {
+  heading: 'Call ended',
+  message: 'This call reached the end of its scheduled time, so everyone was disconnected.',
+};
+
 function getDisconnectInfo(reason: DisconnectReason | undefined): { heading: string; message: string } {
   return (reason !== undefined && DISCONNECT_INFO[reason]) || DEFAULT_DISCONNECT_INFO;
 }
@@ -51,9 +62,12 @@ export function ReconnectionOverlay({ status, disconnectReason, onRejoin, onLeav
   if (status === 'connected') return null;
 
   const isReconnecting = status === 'reconnecting';
-  const disconnectInfo = getDisconnectInfo(disconnectReason);
+  const isEnded = status === 'ended';
+  const disconnectInfo = isEnded ? ENDED_INFO : getDisconnectInfo(disconnectReason);
   const title = isReconnecting ? 'Reconnecting' : disconnectInfo.heading;
-  const isRoomDeleted = disconnectReason === DisconnectReason.ROOM_DELETED;
+  // Nothing to rejoin in either case: the room is gone, or the schedule window is over and
+  // the join screen would refuse a fresh token anyway. Offer acknowledgement, not a retry.
+  const isTerminal = isEnded || disconnectReason === DisconnectReason.ROOM_DELETED;
 
   return (
     <div role="dialog" aria-modal="true" className="fixed inset-0 z-100 flex items-center justify-center bg-text/20">
@@ -73,9 +87,9 @@ export function ReconnectionOverlay({ status, disconnectReason, onRejoin, onLeav
 
         {rejoinError && <p className="text-metadata text-red-01">{rejoinError}</p>}
 
-        {status === 'disconnected' && (
+        {(status === 'disconnected' || isEnded) && (
           <div className="flex w-full flex-col gap-2">
-            {isRoomDeleted ? (
+            {isTerminal ? (
               <Button variant="primary" onClick={onLeave}>
                 OK
               </Button>


### PR DESCRIPTION
Found while investigating GEO-2584. **Does not close it** — see the correction on that ticket. The reporter saw a "Reconnecting" overlay, which this code path cannot produce (the cutoff navigates away silently), so his incident was a transport-level drop rather than the cutoff described below. The bug fixed here is real and independently reproducible, but it is a different bug.

## The join window and the hard cutoff ended at the same instant

Two independent literals that happened to be equal, with no relationship expressed between them:

| | when |
|---|---|
| Joinable until | `endMs + 30min` (`LIVE_WINDOW_AFTER_MS`) |
| Countdown banner appears | `endMs + 25min` (`CALL_END_TIMER_DELAY_MINUTES`) |
| **Hard cutoff — every client force-disconnects** | `endMs + 30min` (`LIVE_MEETING_GRACE_MINUTES`) |

So the system admitted people at the exact moment it was about to throw them out. `CallEndTimer` runs `update()` on mount, so a joiner in the last stretch reached `remaining <= 0` on the first tick and was disconnected almost immediately — instantly, at the boundary. And because admission stayed open to that same instant, rejoining was permitted and did it again.

`LIVE_WINDOW_AFTER_MS` is now derived from `CALL_END_TIMER_DELAY_MINUTES`, so admission closes when the countdown starts and the ordering holds by construction: anyone let in always sees the banner count down before being disconnected. The "isn't active right now" copy reads the constants instead of quoting them — it had been left stating the old window.

## The eject couldn't explain itself

`onTimeUp` -> `onLeave()` -> `room.disconnect()`, which LiveKit reports as `CLIENT_INITIATED`. That is the *one* reason `useReconnectionState` treats as a voluntary leave, navigating away silently. Every other cause (admin kick, duplicate identity, network) shows the overlay. So a schedule-forced eject was indistinguishable from pressing Leave.

The room's own events can't recover that intent, so the cutoff now carries it: a new terminal `ended` status on `ReconnectionStatus`, set before disconnecting, rendering **Call ended** with the reason. Acknowledgement only, no rejoin button — the narrowed window would refuse a fresh token anyway, the same treatment `ROOM_DELETED` already gets.

## Also, incidentally

`onTimeUp` is a fresh closure every render, and it was in the countdown effect's dependency list — so the 1s interval was torn down and rebuilt on every render. On a busy call that is more often than once a second, leaving the tick liable to never fire; only `update()` running on each rebuild masked it. Held in a ref now.

## Verification

New `core/community-calls/constants.test.ts` pins the invariant that regressed — the last admissible instant must still be a full countdown away from the cutoff. Restoring the old `30 * 60 * 1000` literal fails 4 of the 7 tests; I checked that rather than assuming.

- `vitest run core/community-calls partials/community-calls` — 59 passed, 6 files
- `tsc --noEmit` — 17 errors, all pre-existing and in unrelated files (governance, hooks, responses); none in the touched files

## Note for review

This narrows admission but deliberately does **not** touch the cutoff itself: a call that runs long still gets cut off 30 minutes after its scheduled end, now with a warning and an explanation instead of silently. Whether an *actively in-progress* call should be cut off at all is a separate product question.
