### PR TITLE
feat(community-calls): report why participants drop out of calls

### DIFF
--- a/apps/web/core/community-calls/disconnect-telemetry.test.ts
+++ b/apps/web/core/community-calls/disconnect-telemetry.test.ts
@@ -1,0 +1,138 @@
+import { DisconnectReason } from 'livekit-client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { reportEvent } from '~/core/telemetry/logger';
+
+import { disconnectCause, disconnectReasonName, reportCallDisconnect } from './disconnect-telemetry';
+
+vi.mock('~/core/telemetry/logger', () => ({ reportEvent: vi.fn() }));
+
+const CONTEXT = {
+  spaceId: 'space-1',
+  callId: 'call-1',
+  roomName: 'space-1::call-1::1772130000000',
+  occurrenceStart: 1772130000000,
+  role: 'participant' as const,
+};
+
+afterEach(() => {
+  vi.mocked(reportEvent).mockClear();
+});
+
+/** The tags of the single reported event, or null if nothing was reported. */
+function reportedTags(): Record<string, unknown> | null {
+  const calls = vi.mocked(reportEvent).mock.calls;
+  if (calls.length === 0) return null;
+  expect(calls).toHaveLength(1);
+  return calls[0][0].tags ?? {};
+}
+
+describe('disconnectReasonName', () => {
+  it('names each reason', () => {
+    expect(disconnectReasonName(DisconnectReason.MIGRATION)).toBe('MIGRATION');
+    expect(disconnectReasonName(DisconnectReason.SERVER_SHUTDOWN)).toBe('SERVER_SHUTDOWN');
+  });
+
+  /**
+   * "LiveKit gave us no reason" and "LiveKit said UNKNOWN_REASON" point at different places,
+   * so collapsing them into one label would lose the distinction.
+   */
+  it('distinguishes an absent reason from an explicitly unknown one', () => {
+    expect(disconnectReasonName(undefined)).toBe('NOT_REPORTED');
+    expect(disconnectReasonName(DisconnectReason.UNKNOWN_REASON)).toBe('UNKNOWN_REASON');
+  });
+
+  it('labels a reason added by a future livekit version rather than dropping it', () => {
+    expect(disconnectReasonName(99 as DisconnectReason)).toBe('UNMAPPED_99');
+  });
+});
+
+describe('disconnectCause', () => {
+  it('attributes server-side lifecycle reasons to the server', () => {
+    expect(disconnectCause(DisconnectReason.SERVER_SHUTDOWN)).toBe('server');
+    expect(disconnectCause(DisconnectReason.MIGRATION)).toBe('server');
+    expect(disconnectCause(DisconnectReason.STATE_MISMATCH)).toBe('server');
+    expect(disconnectCause(DisconnectReason.JOIN_FAILURE)).toBe('server');
+  });
+
+  it('separates moderation from faults', () => {
+    expect(disconnectCause(DisconnectReason.PARTICIPANT_REMOVED)).toBe('moderation');
+    expect(disconnectCause(DisconnectReason.ROOM_DELETED)).toBe('moderation');
+  });
+
+  it('treats a voluntary leave as intentional', () => {
+    expect(disconnectCause(DisconnectReason.CLIENT_INITIATED)).toBe('intentional');
+  });
+
+  /**
+   * SIGNAL_CLOSE happens both when a participant's network drops and when something
+   * upstream severs the socket. Guessing `client` would blame users for our own outages.
+   */
+  it('leaves the ambiguous signal-close unattributed', () => {
+    expect(disconnectCause(DisconnectReason.SIGNAL_CLOSE)).toBe('unknown');
+  });
+
+  it('falls back to unknown for an unmapped reason', () => {
+    expect(disconnectCause(undefined)).toBe('unknown');
+    expect(disconnectCause(99 as DisconnectReason)).toBe('unknown');
+  });
+});
+
+describe('reportCallDisconnect', () => {
+  /**
+   * The overwhelmingly common disconnect is someone pressing Leave. Counting those as drops
+   * would bury the handful that matter.
+   */
+  it('does not report a voluntary leave', () => {
+    reportCallDisconnect(CONTEXT, { outcome: 'left', reason: DisconnectReason.CLIENT_INITIATED });
+    expect(reportedTags()).toBeNull();
+  });
+
+  it('reports the scheduled cutoff even though it also arrives as a leave', () => {
+    reportCallDisconnect(CONTEXT, {
+      outcome: 'left',
+      reason: DisconnectReason.CLIENT_INITIATED,
+      endedByCutoff: true,
+    });
+
+    const tags = reportedTags();
+    expect(tags).toMatchObject({ cause: 'scheduled', reason: 'SCHEDULED_CUTOFF', outcome: 'left' });
+  });
+
+  it('reports a drop that recovered on its own, with how long it took', () => {
+    reportCallDisconnect(CONTEXT, {
+      outcome: 'recovered',
+      reason: DisconnectReason.SIGNAL_CLOSE,
+      reconnectingMs: 4200,
+      msSinceJoin: 90_000,
+    });
+
+    const call = vi.mocked(reportEvent).mock.calls[0][0];
+    expect(call.tags).toMatchObject({ outcome: 'recovered', cause: 'unknown', reason: 'SIGNAL_CLOSE' });
+    expect(call.extra).toMatchObject({ reconnectingMs: 4200, msSinceJoin: 90_000 });
+  });
+
+  /** The room is what lets several participants' episodes be correlated to one outage. */
+  it('carries the room so simultaneous drops can be correlated', () => {
+    reportCallDisconnect(CONTEXT, { outcome: 'gave_up', reason: DisconnectReason.MIGRATION });
+
+    const call = vi.mocked(reportEvent).mock.calls[0][0];
+    expect(call.extra).toMatchObject({ roomName: CONTEXT.roomName, occurrenceStart: CONTEXT.occurrenceStart });
+    expect(call.tags).toMatchObject({ cause: 'server', outcome: 'gave_up' });
+  });
+
+  /** Grouping in Sentry is by message text, so the name must not vary per call. */
+  it('uses one stable event name so events aggregate', () => {
+    reportCallDisconnect(CONTEXT, { outcome: 'gave_up', reason: DisconnectReason.MIGRATION });
+    reportCallDisconnect({ ...CONTEXT, callId: 'call-2' }, { outcome: 'recovered', reason: undefined });
+
+    const names = vi.mocked(reportEvent).mock.calls.map(([event]) => event.name);
+    expect(new Set(names).size).toBe(1);
+    expect(names[0]).not.toContain('call-1');
+  });
+
+  it('distinguishes viewers from participants', () => {
+    reportCallDisconnect({ ...CONTEXT, role: 'viewer' }, { outcome: 'gave_up', reason: undefined });
+    expect(reportedTags()).toMatchObject({ role: 'viewer', reason: 'NOT_REPORTED' });
+  });
+});

--- a/apps/web/core/community-calls/disconnect-telemetry.ts
+++ b/apps/web/core/community-calls/disconnect-telemetry.ts
@@ -1,0 +1,156 @@
+import { DisconnectReason } from 'livekit-client';
+
+import { reportEvent } from '~/core/telemetry/logger';
+
+/**
+ * Telemetry for community-call connection drops.
+ *
+ * Written because GEO-2584 ("users getting kicked out of community calls mid call") could
+ * not be diagnosed from the app at all: the overlay tells the participant what happened and
+ * nothing tells us. There was no drop count, no reason breakdown, and no reconnect success
+ * rate, so answering "was that the server or their wifi" meant asking the person who
+ * experienced it what the dialog said.
+ *
+ * Reported per *episode*, not per event. LiveKit emits `reconnecting` and
+ * `signalReconnecting` repeatedly through one outage, so raw transitions would need
+ * reassembling before they meant anything. One record per episode, carrying its outcome and
+ * duration, is the shape the questions are actually asked in.
+ */
+
+/** The name of the Sentry issue every drop episode groups into. Must stay constant. */
+const CALL_DISCONNECT_EVENT = 'community-call connection episode';
+
+/**
+ * Rough attribution, for triage rather than certainty.
+ *
+ * The distinction that matters operationally: a `server` cause drops every participant in a
+ * room at nearly the same instant, so it correlates across users and is ours to fix, while a
+ * `client` cause is one person alone. That is why `roomName` is reported — correlating
+ * several participants' episodes within the same room and second is the strongest available
+ * evidence of a server-side cause, and it is exactly what we could not do before.
+ */
+export type DisconnectCause = 'intentional' | 'scheduled' | 'server' | 'client' | 'moderation' | 'unknown';
+
+/**
+ * Ambiguous on purpose: SIGNAL_CLOSE means the signalling websocket closed, which happens
+ * both when a participant's network drops and when something upstream (proxy, load
+ * balancer, ingress) severs it. Calling it `client` would quietly blame users for our
+ * outages, so it stays `unknown` and is resolved by correlation instead.
+ */
+const CAUSE_BY_REASON: Partial<Record<DisconnectReason, DisconnectCause>> = {
+  [DisconnectReason.UNKNOWN_REASON]: 'unknown',
+  [DisconnectReason.CLIENT_INITIATED]: 'intentional',
+  // The user opened the same call in a second tab or device — their action, not a fault.
+  [DisconnectReason.DUPLICATE_IDENTITY]: 'client',
+  [DisconnectReason.SERVER_SHUTDOWN]: 'server',
+  [DisconnectReason.PARTICIPANT_REMOVED]: 'moderation',
+  [DisconnectReason.ROOM_DELETED]: 'moderation',
+  [DisconnectReason.STATE_MISMATCH]: 'server',
+  [DisconnectReason.JOIN_FAILURE]: 'server',
+  // A node being drained or rebalanced. Expected during deploys, and a leading suspect
+  // whenever several participants drop together.
+  [DisconnectReason.MIGRATION]: 'server',
+  [DisconnectReason.SIGNAL_CLOSE]: 'unknown',
+  [DisconnectReason.ROOM_CLOSED]: 'server',
+  // Agent/SIP dispatch reasons; not reachable from a browser participant, mapped for
+  // completeness so an unexpected one is still labelled rather than silently 'unknown'.
+  [DisconnectReason.USER_UNAVAILABLE]: 'unknown',
+  [DisconnectReason.USER_REJECTED]: 'unknown',
+};
+
+const REASON_NAME: Partial<Record<DisconnectReason, string>> = {
+  [DisconnectReason.UNKNOWN_REASON]: 'UNKNOWN_REASON',
+  [DisconnectReason.CLIENT_INITIATED]: 'CLIENT_INITIATED',
+  [DisconnectReason.DUPLICATE_IDENTITY]: 'DUPLICATE_IDENTITY',
+  [DisconnectReason.SERVER_SHUTDOWN]: 'SERVER_SHUTDOWN',
+  [DisconnectReason.PARTICIPANT_REMOVED]: 'PARTICIPANT_REMOVED',
+  [DisconnectReason.ROOM_DELETED]: 'ROOM_DELETED',
+  [DisconnectReason.STATE_MISMATCH]: 'STATE_MISMATCH',
+  [DisconnectReason.JOIN_FAILURE]: 'JOIN_FAILURE',
+  [DisconnectReason.MIGRATION]: 'MIGRATION',
+  [DisconnectReason.SIGNAL_CLOSE]: 'SIGNAL_CLOSE',
+  [DisconnectReason.ROOM_CLOSED]: 'ROOM_CLOSED',
+  [DisconnectReason.USER_UNAVAILABLE]: 'USER_UNAVAILABLE',
+  [DisconnectReason.USER_REJECTED]: 'USER_REJECTED',
+};
+
+/**
+ * A reason LiveKit didn't give us is not the same as `UNKNOWN_REASON`, which it did give
+ * us — keep them distinct, since "the event carried no reason" and "the server said it
+ * didn't know" point at different places.
+ */
+export function disconnectReasonName(reason: DisconnectReason | undefined): string {
+  if (reason === undefined) return 'NOT_REPORTED';
+  return REASON_NAME[reason] ?? `UNMAPPED_${reason}`;
+}
+
+export function disconnectCause(reason: DisconnectReason | undefined): DisconnectCause {
+  if (reason === undefined) return 'unknown';
+  return CAUSE_BY_REASON[reason] ?? 'unknown';
+}
+
+/**
+ * How an episode finished.
+ *
+ * - `recovered` — LiveKit's retry got the participant back in; they saw the overlay flash.
+ * - `gave_up` — the retry budget was exhausted, leaving the manual rejoin screen. Ours is
+ *   extended to ~3 minutes, so reaching this means the transport was gone for minutes.
+ * - `left` — a clean, immediate disconnect with no reconnection attempted (Leave pressed,
+ *   an editor closing the room, or the scheduled cutoff).
+ */
+export type EpisodeOutcome = 'recovered' | 'gave_up' | 'left';
+
+export type CallTelemetryContext = {
+  spaceId: string;
+  callId: string;
+  roomName: string;
+  occurrenceStart: number;
+  role: 'participant' | 'viewer';
+};
+
+export type DisconnectEpisode = {
+  outcome: EpisodeOutcome;
+  reason: DisconnectReason | undefined;
+  /** True when the scheduled end-of-call cutoff disconnected this client (GEO-2584). */
+  endedByCutoff?: boolean;
+  /** Wall-clock time the participant spent in the reconnecting state, if they entered it. */
+  reconnectingMs?: number;
+  /** How far into the call the episode began — "did this happen at the start or the end". */
+  msSinceJoin?: number;
+};
+
+/**
+ * Record one connection episode.
+ *
+ * `roomName` is deliberately `extra` rather than a tag: it embeds the occurrence timestamp,
+ * so as a tag it would be unbounded cardinality. `callId` is a tag because the set of calls
+ * is small and "which call is dropping people" is the first question anyone asks.
+ */
+export function reportCallDisconnect(context: CallTelemetryContext, episode: DisconnectEpisode): void {
+  // A voluntary leave is not a drop, and counting it as one would bury the real signal
+  // under the overwhelmingly common case. The scheduled cutoff is still worth recording:
+  // it also arrives as CLIENT_INITIATED, and how often it fires is a live product question.
+  if (episode.outcome === 'left' && !episode.endedByCutoff) {
+    return;
+  }
+
+  const cause = episode.endedByCutoff ? 'scheduled' : disconnectCause(episode.reason);
+
+  reportEvent({
+    name: CALL_DISCONNECT_EVENT,
+    tags: {
+      outcome: episode.outcome,
+      cause,
+      reason: episode.endedByCutoff ? 'SCHEDULED_CUTOFF' : disconnectReasonName(episode.reason),
+      role: context.role,
+      callId: context.callId,
+      spaceId: context.spaceId,
+    },
+    extra: {
+      roomName: context.roomName,
+      occurrenceStart: context.occurrenceStart,
+      reconnectingMs: episode.reconnectingMs,
+      msSinceJoin: episode.msSinceJoin,
+    },
+  });
+}

--- a/apps/web/core/community-calls/use-reconnection-state.test.tsx
+++ b/apps/web/core/community-calls/use-reconnection-state.test.tsx
@@ -1,0 +1,191 @@
+import { act, renderHook } from '@testing-library/react';
+
+import { ConnectionState, DisconnectReason, Room } from 'livekit-client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { reportCallDisconnect } from './disconnect-telemetry';
+import { useReconnectionState } from './use-reconnection-state';
+
+vi.mock('./disconnect-telemetry', () => ({ reportCallDisconnect: vi.fn() }));
+
+const TELEMETRY = {
+  spaceId: 'space-1',
+  callId: 'call-1',
+  roomName: 'space-1::call-1::1772130000000',
+  occurrenceStart: 1772130000000,
+  role: 'participant' as const,
+};
+
+/**
+ * Minimal stand-in for LiveKit's Room. Only the event emitter matters here, and using the
+ * real Room would require a signalling connection.
+ */
+function createFakeRoom() {
+  const listeners = new Map<string, Set<(...args: unknown[]) => void>>();
+  const room = {
+    on(event: string, handler: (...args: unknown[]) => void) {
+      if (!listeners.has(event)) listeners.set(event, new Set());
+      listeners.get(event)!.add(handler);
+      return room;
+    },
+    off(event: string, handler: (...args: unknown[]) => void) {
+      listeners.get(event)?.delete(handler);
+      return room;
+    },
+  };
+  const emit = (event: string, ...args: unknown[]) => {
+    for (const handler of [...(listeners.get(event) ?? [])]) handler(...args);
+  };
+  return { room: room as unknown as Room, emit };
+}
+
+const episodes = () => vi.mocked(reportCallDisconnect).mock.calls.map(([, episode]) => episode);
+
+afterEach(() => {
+  vi.mocked(reportCallDisconnect).mockClear();
+});
+
+describe('useReconnectionState episode reporting', () => {
+  it('reports one recovered episode for a drop that reconnects', () => {
+    const { room, emit } = createFakeRoom();
+    const { result } = renderHook(() => useReconnectionState(room, vi.fn(), TELEMETRY));
+
+    act(() => emit('reconnecting'));
+    expect(result.current.status).toBe('reconnecting');
+    act(() => emit('reconnected'));
+
+    expect(result.current.status).toBe('connected');
+    expect(episodes()).toHaveLength(1);
+    expect(episodes()[0]).toMatchObject({ outcome: 'recovered' });
+  });
+
+  /**
+   * The bug this guards: LiveKit emits `reconnecting`, `signalReconnecting` and a
+   * `connectionStateChanged` through a single outage. Treating each as its own episode would
+   * multiply every count, and restarting the clock on each would shrink the measured
+   * duration to the last retry rather than the whole outage.
+   */
+  it('collapses a burst of reconnecting events into a single episode', () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date('2026-08-26T12:00:00Z'));
+      const { room, emit } = createFakeRoom();
+      renderHook(() => useReconnectionState(room, vi.fn(), TELEMETRY));
+
+      // One outage, reported on three channels over 30 seconds.
+      act(() => emit('reconnecting'));
+      vi.advanceTimersByTime(10_000);
+      act(() => emit('signalReconnecting'));
+      vi.advanceTimersByTime(10_000);
+      act(() => emit('connectionStateChanged', ConnectionState.Reconnecting));
+      vi.advanceTimersByTime(10_000);
+      act(() => emit('reconnected'));
+
+      expect(episodes()).toHaveLength(1);
+      // The whole outage, not just the stretch after the last retry event — that is the
+      // difference between a 30s outage and an apparent 10s one.
+      expect(episodes()[0].reconnectingMs).toBe(30_000);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  /**
+   * The bug this guards: one disconnect reaches the hook twice, via the `disconnected`
+   * event and via `connectionStateChanged`. Reporting both would double every drop count.
+   */
+  it('reports a terminal disconnect once despite arriving on two channels', () => {
+    const { room, emit } = createFakeRoom();
+    renderHook(() => useReconnectionState(room, vi.fn(), TELEMETRY));
+
+    act(() => {
+      emit('disconnected', DisconnectReason.SIGNAL_CLOSE);
+      emit('connectionStateChanged', ConnectionState.Disconnected);
+    });
+
+    expect(episodes()).toHaveLength(1);
+    expect(episodes()[0]).toMatchObject({ outcome: 'left', reason: DisconnectReason.SIGNAL_CLOSE });
+  });
+
+  it('marks a drop that exhausted its retries as gave_up, not left', () => {
+    const { room, emit } = createFakeRoom();
+    renderHook(() => useReconnectionState(room, vi.fn(), TELEMETRY));
+
+    act(() => emit('reconnecting'));
+    act(() => emit('disconnected', DisconnectReason.SIGNAL_CLOSE));
+
+    expect(episodes()).toHaveLength(1);
+    expect(episodes()[0]).toMatchObject({ outcome: 'gave_up' });
+  });
+
+  /** Connecting for the first time is not a recovery from anything. */
+  it('does not report the initial connect as a recovery', () => {
+    const { room, emit } = createFakeRoom();
+    renderHook(() => useReconnectionState(room, vi.fn(), TELEMETRY));
+
+    act(() => emit('connectionStateChanged', ConnectionState.Connected));
+
+    expect(episodes()).toHaveLength(0);
+  });
+
+  it('reports a second drop after a manual rejoin lifts the latch', () => {
+    const { room, emit } = createFakeRoom();
+    const { result } = renderHook(() => useReconnectionState(room, vi.fn(), TELEMETRY));
+
+    act(() => emit('disconnected', DisconnectReason.SIGNAL_CLOSE));
+    act(() => result.current.reset());
+    act(() => emit('disconnected', DisconnectReason.SIGNAL_CLOSE));
+
+    expect(episodes()).toHaveLength(2);
+  });
+
+  it('reports nothing at all when no telemetry context is supplied', () => {
+    const { room, emit } = createFakeRoom();
+    renderHook(() => useReconnectionState(room, vi.fn()));
+
+    act(() => emit('reconnecting'));
+    act(() => emit('reconnected'));
+    act(() => emit('disconnected', DisconnectReason.SIGNAL_CLOSE));
+
+    expect(episodes()).toHaveLength(0);
+  });
+});
+
+describe('useReconnectionState cutoff handling', () => {
+  it('shows the ended status instead of navigating away when the cutoff fires', () => {
+    const { room, emit } = createFakeRoom();
+    const onPermanentDisconnect = vi.fn();
+    const { result } = renderHook(() => useReconnectionState(room, onPermanentDisconnect, TELEMETRY));
+
+    act(() => result.current.markEndedByCutoff());
+    act(() => emit('disconnected', DisconnectReason.CLIENT_INITIATED));
+
+    expect(result.current.status).toBe('ended');
+    expect(onPermanentDisconnect).not.toHaveBeenCalled();
+    expect(episodes()[0]).toMatchObject({ endedByCutoff: true });
+  });
+
+  /** Without the cutoff marker, CLIENT_INITIATED must still navigate away as before. */
+  it('navigates away on an unmarked voluntary leave', () => {
+    const { room, emit } = createFakeRoom();
+    const onPermanentDisconnect = vi.fn();
+    const { result } = renderHook(() => useReconnectionState(room, onPermanentDisconnect, TELEMETRY));
+
+    act(() => emit('disconnected', DisconnectReason.CLIENT_INITIATED));
+
+    expect(onPermanentDisconnect).toHaveBeenCalledTimes(1);
+    expect(result.current.status).toBe('connected');
+  });
+
+  it('still shows the overlay for a drop that is not the cutoff', () => {
+    const { room, emit } = createFakeRoom();
+    const onPermanentDisconnect = vi.fn();
+    const { result } = renderHook(() => useReconnectionState(room, onPermanentDisconnect, TELEMETRY));
+
+    act(() => emit('disconnected', DisconnectReason.DUPLICATE_IDENTITY));
+
+    expect(result.current.status).toBe('disconnected');
+    expect(result.current.disconnectReason).toBe(DisconnectReason.DUPLICATE_IDENTITY);
+    expect(onPermanentDisconnect).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/core/community-calls/use-reconnection-state.ts
+++ b/apps/web/core/community-calls/use-reconnection-state.ts
@@ -2,11 +2,13 @@ import * as React from 'react';
 
 import { ConnectionState, DisconnectReason, Room } from 'livekit-client';
 
+import { CallTelemetryContext, EpisodeOutcome, reportCallDisconnect } from './disconnect-telemetry';
+
 /**
- * `ended` is never produced by this hook. A forced end-of-call cutoff and a voluntary Leave
- * both go through `room.disconnect()` and arrive as CLIENT_INITIATED, so the room's own
- * events cannot tell them apart — whoever triggers the cutoff has to say so. See
- * live-room's `endedByCutoff` (GEO-2584).
+ * `ended` is the scheduled end-of-call cutoff. It can't be derived from the room's events:
+ * the cutoff and a voluntary Leave both go through `room.disconnect()` and arrive as
+ * CLIENT_INITIATED, so the caller that triggers it has to declare it via
+ * `markEndedByCutoff()` beforehand (GEO-2584).
  */
 export type ReconnectionStatus = 'connected' | 'reconnecting' | 'disconnected' | 'ended';
 
@@ -17,6 +19,11 @@ export type ReconnectionState = {
   disconnectReason: DisconnectReason | undefined;
   /** Reset state after a successful manual rejoin. */
   reset: () => void;
+  /**
+   * Declare that the disconnect about to happen is the scheduled cutoff, not a leave.
+   * Call it immediately before `room.disconnect()`.
+   */
+  markEndedByCutoff: () => void;
 };
 
 /** CLIENT_INITIATED is a user-chosen leave, not a drop — handled as immediate navigation. */
@@ -34,14 +41,62 @@ const NAVIGATE_AWAY_REASONS = new Set([DisconnectReason.CLIENT_INITIATED]);
  * so the parent component can navigate away instead of showing the overlay. Admin
  * kicks, duplicate-tab drops, and network failures all show the overlay instead of
  * silently navigating away, so the user understands what happened.
+ *
+ * Also the reporting point for drop telemetry, since it is the one place that observes
+ * every connection transition — see disconnect-telemetry.ts.
  */
-export function useReconnectionState(room: Room, onPermanentDisconnect: () => void): ReconnectionState {
+export function useReconnectionState(
+  room: Room,
+  onPermanentDisconnect: () => void,
+  /**
+   * Identifies the call for drop telemetry. Optional so the hook stays usable and
+   * testable standalone; when omitted, nothing is reported.
+   */
+  telemetry?: CallTelemetryContext
+): ReconnectionState {
   const [status, setStatus] = React.useState<ReconnectionStatus>('connected');
   const [disconnectReason, setDisconnectReason] = React.useState<DisconnectReason | undefined>(undefined);
   const onPermanentDisconnectRef = React.useRef(onPermanentDisconnect);
   onPermanentDisconnectRef.current = onPermanentDisconnect;
   const lastDisconnectReasonRef = React.useRef<DisconnectReason | undefined>(undefined);
   const isMountedRef = React.useRef(true);
+
+  // Read through a ref so a fresh context object each render can't restart the room's
+  // event subscriptions, which would discard the episode currently being measured.
+  const telemetryRef = React.useRef(telemetry);
+  telemetryRef.current = telemetry;
+
+  // Episode bookkeeping. `episodeStartedAt` doubles as "an outage is in progress": LiveKit
+  // emits `reconnecting` and `signalReconnecting` repeatedly through one outage, so this is
+  // what collapses that burst into a single episode with one outcome.
+  const episodeStartedAtRef = React.useRef<number | null>(null);
+  const joinedAtRef = React.useRef(Date.now());
+  const endedByCutoffRef = React.useRef(false);
+  // A single disconnect reaches us twice — once via the `disconnected` event and once via
+  // `connectionStateChanged`. Setting state twice was harmless, but reporting twice would
+  // double every count, so the terminal report is latched until the next reconnect.
+  const reportedTerminalRef = React.useRef(false);
+
+  const reportEpisode = React.useCallback((outcome: EpisodeOutcome, reason: DisconnectReason | undefined) => {
+    const context = telemetryRef.current;
+    const startedAt = episodeStartedAtRef.current;
+    episodeStartedAtRef.current = null;
+    if (!context) return;
+
+    reportCallDisconnect(context, {
+      outcome,
+      reason,
+      endedByCutoff: endedByCutoffRef.current,
+      reconnectingMs: startedAt === null ? undefined : Date.now() - startedAt,
+      // Measured from when the trouble started, not when it resolved, so "how far into the
+      // call did this happen" isn't skewed by however long the retry ran.
+      msSinceJoin: (startedAt ?? Date.now()) - joinedAtRef.current,
+    });
+  }, []);
+
+  const markEndedByCutoff = React.useCallback(() => {
+    endedByCutoffRef.current = true;
+  }, []);
 
   React.useEffect(() => {
     return () => {
@@ -51,10 +106,23 @@ export function useReconnectionState(room: Room, onPermanentDisconnect: () => vo
 
   React.useEffect(() => {
     const handleReconnecting = () => {
+      // Only the first transition of an outage opens the episode — a later
+      // `signalReconnecting` in the same outage must not reset its start time, or the
+      // measured duration collapses to the last retry rather than the whole outage.
+      if (episodeStartedAtRef.current === null) {
+        episodeStartedAtRef.current = Date.now();
+      }
       setStatus('reconnecting');
     };
 
     const handleReconnected = () => {
+      // Fires on every Connected transition, including the initial connect and a manual
+      // rejoin. Report only when an episode is actually open, so those aren't counted as
+      // recoveries from a drop that never happened.
+      if (episodeStartedAtRef.current !== null) {
+        reportEpisode('recovered', lastDisconnectReasonRef.current);
+      }
+      reportedTerminalRef.current = false;
       lastDisconnectReasonRef.current = undefined;
       setDisconnectReason(undefined);
       setStatus('connected');
@@ -63,6 +131,21 @@ export function useReconnectionState(room: Room, onPermanentDisconnect: () => vo
     const handleDisconnected = (reason?: DisconnectReason) => {
       lastDisconnectReasonRef.current = reason;
       if (!isMountedRef.current) return;
+
+      if (!reportedTerminalRef.current) {
+        reportedTerminalRef.current = true;
+        // An open episode means LiveKit had been retrying and has now exhausted its budget;
+        // no episode means the disconnect was immediate, with nothing attempted.
+        reportEpisode(episodeStartedAtRef.current === null ? 'left' : 'gave_up', reason);
+      }
+
+      // Checked before NAVIGATE_AWAY_REASONS: the cutoff arrives as CLIENT_INITIATED, and
+      // navigating away on it is precisely the silent eject GEO-2584 is about.
+      if (endedByCutoffRef.current) {
+        setDisconnectReason(reason);
+        setStatus('ended');
+        return;
+      }
 
       if (reason !== undefined && NAVIGATE_AWAY_REASONS.has(reason)) {
         onPermanentDisconnectRef.current();
@@ -96,13 +179,16 @@ export function useReconnectionState(room: Room, onPermanentDisconnect: () => vo
       room.off('disconnected', handleDisconnected);
       room.off('connectionStateChanged', handleConnectionStateChanged);
     };
-  }, [room]);
+  }, [room, reportEpisode]);
 
   const reset = React.useCallback(() => {
+    // A manual rejoin starts a fresh connection, so the terminal latch has to lift or the
+    // next drop in this session would go unreported.
+    reportedTerminalRef.current = false;
     lastDisconnectReasonRef.current = undefined;
     setDisconnectReason(undefined);
     setStatus('connected');
   }, []);
 
-  return { status, disconnectReason, reset };
+  return { status, disconnectReason, reset, markEndedByCutoff };
 }

--- a/apps/web/core/telemetry/logger.ts
+++ b/apps/web/core/telemetry/logger.ts
@@ -22,6 +22,39 @@ export function reportBoundaryError(error: unknown): void {
   reportError(error);
 }
 
+type TelemetryEvent = {
+  /**
+   * Stable, low-cardinality name. Sentry groups messages by their text, so a *constant*
+   * name with varying tags collapses into one issue whose tag breakdown is the aggregate —
+   * which is how these are meant to be read. Interpolating an id into the name instead
+   * produces thousands of one-event issues and no aggregate at all.
+   */
+  name: string;
+  /** Indexed and filterable/groupable in Sentry. Low-cardinality values only. */
+  tags?: Record<string, string | number | boolean>;
+  /** Not indexed — the place for ids, durations and anything high-cardinality. */
+  extra?: Record<string, unknown>;
+};
+
+/**
+ * Report a structured operational event: something worth *counting*, not a failure.
+ *
+ * Distinct from `reportError` on purpose. An event that isn't an exception has no stack
+ * and no error semantics, and routing it through `captureException` would both pollute
+ * error rates and get filtered by the client's `allowUrls` stack-frame policy.
+ */
+export function reportEvent({ name, tags, extra }: TelemetryEvent): void {
+  if (!isTelemetryEnabled) {
+    return;
+  }
+
+  try {
+    Sentry.captureMessage(name, { level: 'info', tags, extra });
+  } catch (reportingError) {
+    console.error('[Telemetry] Failed to capture event', reportingError);
+  }
+}
+
 export function setTelemetryUser(user: TelemetryUser | null): void {
   if (!isTelemetryEnabled) {
     return;

--- a/apps/web/partials/community-calls/live-room.tsx
+++ b/apps/web/partials/community-calls/live-room.tsx
@@ -220,22 +220,23 @@ function RoomBody({
   const [leaveDialogOpen, setLeaveDialogOpen] = React.useState(false);
   const [endCallBusy, setEndCallBusy] = React.useState(false);
 
-  // The forced end-of-call cutoff disconnects the room itself, so it reaches
-  // `useReconnectionState` as CLIENT_INITIATED — identical to pressing Leave, and therefore
-  // silently navigating away. Record that it was the cutoff before disconnecting, so the
-  // user is told the call ended rather than just finding themselves back on the calls page
-  // (GEO-2584). The ref is what the disconnect handler reads: `room.disconnect()` can emit
-  // before React has re-rendered with the new state.
-  const [endedByCutoff, setEndedByCutoff] = React.useState(false);
-  const endedByCutoffRef = React.useRef(false);
+  // Identifies this call on every drop episode reported to telemetry. Memoized so a new
+  // object each render can't churn the hook's room subscriptions.
+  const callTelemetry = React.useMemo(
+    () => ({
+      spaceId,
+      callId,
+      roomName,
+      occurrenceStart,
+      role: isViewer ? ('viewer' as const) : ('participant' as const),
+    }),
+    [spaceId, callId, roomName, occurrenceStart, isViewer]
+  );
 
   // Distinguishes an intentional Leave (CLIENT_INITIATED) — navigate away directly —
   // from a drop that should show the reconnection overlay instead of silently
   // kicking the user out. See use-reconnection-state.ts.
-  const reconnection = useReconnectionState(room, () => {
-    if (endedByCutoffRef.current) return;
-    router.push(backHref);
-  });
+  const reconnection = useReconnectionState(room, () => router.push(backHref), callTelemetry);
   const [rejoinBusy, setRejoinBusy] = React.useState(false);
   const [rejoinError, setRejoinError] = React.useState<string | null>(null);
 
@@ -321,8 +322,7 @@ function RoomBody({
   // itself first so the overlay can say why. No recording-stop confirmation on this
   // path — the call ends regardless of whether a recording is still running.
   const handleTimeUp = useCallTimeUp(() => {
-    endedByCutoffRef.current = true;
-    setEndedByCutoff(true);
+    reconnection.markEndedByCutoff();
     onLeave();
   });
 
@@ -527,7 +527,7 @@ function RoomBody({
       />
 
       <ReconnectionOverlay
-        status={endedByCutoff ? 'ended' : reconnection.status}
+        status={reconnection.status}
         disconnectReason={reconnection.disconnectReason}
         onRejoin={handleRejoin}
         onLeave={() => router.push(backHref)}


### PR DESCRIPTION
Part of GEO-2584. Follow-up to #2242, which fixed one real cutoff bug found while investigating that ticket but turned out **not** to be the reported one.

## Why

GEO-2584 could not be diagnosed from the app at all. The overlay tells the participant what happened and **nothing tells us** — no drop count, no reason breakdown, no reconnect success rate. So answering "was that the server or their wifi" meant asking the person it happened to what the dialog said. That answer arrived hours later, and when it did (*"it did show Reconnecting"*) it refuted the diagnosis I had built in its absence. This is the instrument that should have answered it in a minute.

## What is reported

Per **episode**, not per event. LiveKit emits `reconnecting` and `signalReconnecting` repeatedly through a single outage, so raw transitions would need reassembling before they meant anything. One record per episode, carrying its outcome and duration, is the shape the questions actually get asked in.

| field | why it's there |
|---|---|
| `outcome` | `recovered` (retry got them back) / `gave_up` (budget exhausted, left on the rejoin screen) / `left`. **This is the discriminator I had to ask a human for.** |
| `cause` | `server` / `client` / `moderation` / `intentional` / `scheduled`, derived from the DisconnectReason |
| `reason` | the raw DisconnectReason name, so a cause mapping I got wrong is still recoverable from the data |
| `reconnectingMs` | how long the outage ran — ours retries ~3min, so a long one implicates the server, not a wifi blip |
| `msSinceJoin` | how far into the call it began |
| `roomName` | so several participants' episodes in one room and second can be **correlated** |

That last one matters most. Correlating simultaneous drops across participants is the strongest available evidence of a server-side cause, and it is exactly what we could not do before. `SERVER_SHUTDOWN` and `MIGRATION` are the leading suspects for the original report and both would show up this way.

## Judgement calls worth reviewing

**`SIGNAL_CLOSE` stays `unknown`, not `client`.** The signalling socket closes both when a participant's network drops and when something upstream (proxy, LB, ingress) severs it. Guessing `client` would quietly blame users for our own outages, so it's resolved by correlation instead.

**A voluntary leave is not reported.** It's the overwhelmingly common disconnect and would bury the handful that matter. The scheduled cutoff *is* reported, since it also arrives as `CLIENT_INITIATED` and how often it fires is an open product question from #2242.

**`reportEvent` is new alongside `reportError`.** An event that isn't an exception has no stack; routing it through `captureException` would pollute error rates and get dropped by the client's `allowUrls` stack-frame policy. The event name is deliberately constant so Sentry's message grouping yields one issue whose tag breakdown *is* the aggregate — interpolating an id into the name would produce thousands of one-event issues and no aggregate at all.

**The cutoff flag moved into the hook** as `markEndedByCutoff()`. That's where it belonged: the hook owns every other connection transition, and #2242 had left `live-room` duplicating it as both state and a ref in order to override the hook's own status. `live-room` gets smaller as a result.

## Two bugs found while wiring it up

Both would have corrupted the counts rather than failing loudly, which is the worst way for an instrument to be wrong:

1. **A single disconnect reaches the hook twice** — once via the `disconnected` event, once via `connectionStateChanged`. Setting state twice was harmless, so this was invisible before; reporting twice would have doubled every drop count. Latched, and the latch lifts on rejoin so a second genuine drop still reports.
2. **A later `signalReconnecting` reset the episode start**, collapsing a measured 30s outage to the 10s after the last retry event.

## Verification

- `vitest run core/community-calls partials/community-calls` — **83 passed, 8 files**
- `tsc --noEmit` — 5 errors, all pre-existing in unrelated files (`sort-open-proposals.test.ts`, `use-entity-vote.ts`, `entity-response.test.ts`); none in the touched files
- **Mutation-checked rather than assumed.** Breaking each guard turns exactly one test red: resetting the episode start on every event, removing the double-report latch, and regressing the cutoff check back behind `NAVIGATE_AWAY_REASONS`. The hook is tested against a fake Room emitter, since the real one needs a signalling connection.

## Note

This is instrumentation, so it proves itself only by being read. Once it has been live through a few calls the next step on GEO-2584 is querying it — in particular whether Arturas's two drops correlate with anyone else's.
