### PR TITLE
fix(telemetry): make error-boundary failures diagnosable, and stop analytics noise burying them

### DIFF
--- a/apps/web/core/telemetry/auto-retry-error.tsx
+++ b/apps/web/core/telemetry/auto-retry-error.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 
 import { motion } from 'framer-motion';
 
-import { reportError } from '~/core/telemetry/logger';
+import { reportCaughtError } from '~/core/telemetry/logger';
 
 import { Notice } from '~/design-system/notice';
 import { Text } from '~/design-system/text';
@@ -72,7 +72,7 @@ export function AutoRetryError({ error, reset, preview }: Props) {
   React.useEffect(() => {
     if (preview) return;
     setOffline(looksOffline());
-    setEventId(reportError(error));
+    setEventId(reportCaughtError(error, 'app-root'));
   }, [error, preview]);
 
   React.useEffect(() => {
@@ -113,7 +113,12 @@ export function AutoRetryError({ error, reset, preview }: Props) {
   // "Reconnecting" was shown for *every* error this boundary caught, so a plain bug read to
   // users — and to whoever they reported it to — as a connection problem, and got chased as
   // one (GEO-2670). Claim a connection cause only when the browser says there is no network.
-  const reference = eventId ?? (digest === 'preview' ? undefined : digest);
+  // The digest wins over the Sentry event id when present. React strips a Server Components
+  // error's message in production and gives the client only this digest, while the real error
+  // is logged server-side under the same one — so it is the join key between what the user saw
+  // and what actually broke. Searching `digest:<value>` in Sentry finds both sides; a client
+  // event id finds only the stripped half.
+  const reference = error.digest ?? eventId ?? (digest === 'preview' ? undefined : digest);
 
   return (
     <Notice

--- a/apps/web/core/telemetry/auto-retry-error.tsx
+++ b/apps/web/core/telemetry/auto-retry-error.tsx
@@ -7,6 +7,7 @@ import { motion } from 'framer-motion';
 import { reportError } from '~/core/telemetry/logger';
 
 import { Notice } from '~/design-system/notice';
+import { Text } from '~/design-system/text';
 
 type Props = {
   error: Error & { digest?: string };
@@ -50,12 +51,28 @@ function writeState(state: StoredState) {
   } catch {}
 }
 
+/**
+ * Whether this looks like a connection problem rather than a fault.
+ *
+ * `navigator.onLine === false` is the one signal here that means something: the browser is
+ * certain there is no network. `true` only means an interface is up, so it is never taken as
+ * evidence of connectivity — it just leaves the generic wording in place.
+ */
+function looksOffline(): boolean {
+  return typeof navigator !== 'undefined' && navigator.onLine === false;
+}
+
 export function AutoRetryError({ error, reset, preview }: Props) {
   const digest = errorDigest(error);
+  const [eventId, setEventId] = React.useState<string | undefined>(undefined);
+  // Read once per error rather than during render: the value can change under us, and a
+  // render that reads it would disagree with the copy already on screen.
+  const [offline, setOffline] = React.useState(false);
 
   React.useEffect(() => {
     if (preview) return;
-    reportError(error);
+    setOffline(looksOffline());
+    setEventId(reportError(error));
   }, [error, preview]);
 
   React.useEffect(() => {
@@ -93,16 +110,30 @@ export function AutoRetryError({ error, reset, preview }: Props) {
     };
   }, [digest, preview, reset]);
 
+  // "Reconnecting" was shown for *every* error this boundary caught, so a plain bug read to
+  // users — and to whoever they reported it to — as a connection problem, and got chased as
+  // one (GEO-2670). Claim a connection cause only when the browser says there is no network.
+  const reference = eventId ?? (digest === 'preview' ? undefined : digest);
+
   return (
     <Notice
       visual={<LargeSpinner />}
-      title="Reconnecting"
+      title={offline ? 'Reconnecting' : 'Something went wrong'}
       description={
         <>
-          Something interrupted loading this page.
+          {offline ? 'Your device appears to be offline.' : 'This page didn’t load properly.'}
           <br />
           Retrying automatically...
         </>
+      }
+      // The one thing that makes a screenshot of this actionable. Without it a report is
+      // "I saw the reconnecting screen", and the matching Sentry event can't be found.
+      footer={
+        reference ? (
+          <Text as="p" variant="footnote" color="grey-04">
+            Reference: <span className="font-mono">{reference.slice(0, 12)}</span>
+          </Text>
+        ) : null
       }
     />
   );

--- a/apps/web/core/telemetry/logger.ts
+++ b/apps/web/core/telemetry/logger.ts
@@ -11,21 +11,57 @@ type TelemetryUser = {
  * reference that leads straight back to it. Undefined when telemetry is off or reporting
  * itself failed — callers must treat it as best-effort.
  */
-export function reportError(error: unknown): string | undefined {
+export function reportError(
+  error: unknown,
+  options?: { tags?: Record<string, string>; contexts?: Record<string, Record<string, unknown>> }
+): string | undefined {
   if (!isTelemetryEnabled) {
     return undefined;
   }
 
   try {
-    return Sentry.captureException(error);
+    return Sentry.captureException(error, options);
   } catch (reportingError) {
     console.error('[Telemetry] Failed to capture exception', reportingError);
     return undefined;
   }
 }
 
-export function reportBoundaryError(error: unknown): void {
-  reportError(error);
+/**
+ * Report an error that an error boundary caught — i.e. one the user is being shown a failure
+ * screen for, rather than one swallowed in the background.
+ *
+ * The `digest` is the load-bearing part. React strips a Server Components error's message in
+ * production and hands the client only a digest, so the biggest user-visible error group in
+ * this project (GEOGENESIS-9: 1100+ events, 47 users, open since February) reads only
+ * "the specific message is omitted" with a single minified frame. The real error is logged
+ * server-side under the *same digest* — so without recording it there is no join key between
+ * what the user saw and what actually failed, and the group is undiagnosable by construction.
+ *
+ * `boundary` marks these as user-visible, which separates them from background noise that
+ * never reached a screen.
+ */
+export function reportCaughtError(error: unknown, boundary: string): string | undefined {
+  const digest = typeof error === 'object' && error !== null ? (error as { digest?: unknown }).digest : undefined;
+
+  return reportError(error, {
+    tags: {
+      boundary,
+      // Tagged, not just context: the whole point is to filter and group by it, and to paste
+      // one the user read off their screen straight into Sentry's search.
+      ...(typeof digest === 'string' ? { digest } : {}),
+    },
+  });
+}
+
+/**
+ * Adapter for `react-error-boundary`'s `onError`, which is called as `(error, info)`. The second
+ * parameter is deliberately `unknown` and ignored: this is passed by reference as
+ * `onError={reportBoundaryError}` from several boundaries, so narrowing it to anything else
+ * breaks assignability at every one of those call sites.
+ */
+export function reportBoundaryError(error: unknown, _info?: unknown): string | undefined {
+  return reportCaughtError(error, 'component');
 }
 
 type TelemetryEvent = {

--- a/apps/web/core/telemetry/logger.ts
+++ b/apps/web/core/telemetry/logger.ts
@@ -6,15 +6,21 @@ type TelemetryUser = {
   id: string;
 };
 
-export function reportError(error: unknown): void {
+/**
+ * Returns the Sentry event id, so a surface that shows the user an error can quote a
+ * reference that leads straight back to it. Undefined when telemetry is off or reporting
+ * itself failed — callers must treat it as best-effort.
+ */
+export function reportError(error: unknown): string | undefined {
   if (!isTelemetryEnabled) {
-    return;
+    return undefined;
   }
 
   try {
-    Sentry.captureException(error);
+    return Sentry.captureException(error);
   } catch (reportingError) {
     console.error('[Telemetry] Failed to capture exception', reportingError);
+    return undefined;
   }
 }
 

--- a/apps/web/instrumentation-client.ts
+++ b/apps/web/instrumentation-client.ts
@@ -14,6 +14,48 @@ const tracePropagationTargets: (string | RegExp)[] = [
   Environment.getConfig().api,
 ];
 
+/**
+ * Analytics beacons that an ad-blocker or privacy extension refused.
+ *
+ * These are unactionable by construction — the request never leaves the browser, no user-facing
+ * behaviour changes, and the "fix" would be asking users to disable their blocker. They are
+ * also overwhelming: measured over 7 days, 5,742 of 6,251 error events (92%) were these, which
+ * buried the ~500 real ones and made the issue stream unreadable. Dropping them client-side
+ * also stops them consuming event quota.
+ *
+ * Matched on the host rather than on "Failed to fetch", because that message is the generic
+ * one every genuine network failure produces — filtering by it would silently discard real
+ * API failures, which is exactly the mistake worth avoiding here.
+ */
+const BLOCKED_ANALYTICS_HOSTS = ['api2.amplitude.com', 'api.amplitude.com', 'cdn.amplitude.com'];
+
+/** Frames from the analytics bundle, which is served from the root as `ga-<contenthash>.js`. */
+const ANALYTICS_BUNDLE_FRAME = /(^|\/)ga-[a-z0-9]+\.js$/i;
+
+/** Amplitude's own transport functions, as they appear in the analytics bundle's frames. */
+const ANALYTICS_TRANSPORT_FUNCTIONS = ['sendAmplitudeHttp', 'flushAmplitudeEvents', 'queueAmplitude'];
+
+type SentryExceptionValue = {
+  value?: string;
+  stacktrace?: { frames?: { filename?: string; function?: string }[] };
+};
+
+function isBlockedAnalyticsTransport(value: SentryExceptionValue): boolean {
+  // Two independent signals, because either alone is brittle. The message currently carries the
+  // host ("Failed to fetch (api2.amplitude.com)"), but that formatting is the SDK's and could
+  // change; the stack frames are the analytics bundle's own and are stable.
+  if (value.value && BLOCKED_ANALYTICS_HOSTS.some(host => value.value!.includes(host))) {
+    return true;
+  }
+
+  const frames = value.stacktrace?.frames ?? [];
+  return frames.some(
+    frame =>
+      (frame.filename !== undefined && ANALYTICS_BUNDLE_FRAME.test(frame.filename)) ||
+      (frame.function !== undefined && ANALYTICS_TRANSPORT_FUNCTIONS.includes(frame.function))
+  );
+}
+
 if (isTelemetryEnabled) {
   Sentry.init({
     dsn: telemetryDsn,
@@ -30,6 +72,9 @@ if (isTelemetryEnabled) {
 
       for (const value of values) {
         if (value.value?.includes('User rejected the request') || value.type === 'UserRejectedRequestError') {
+          return null;
+        }
+        if (isBlockedAnalyticsTransport(value)) {
           return null;
         }
       }


### PR DESCRIPTION
Part of GEO-2670. **This does not fix what throws in the debate-again flow** — read on for why that is still open. It fixes the reason we couldn't find out.

Everything below is read from Sentry (`geo-7y/geogenesis`) rather than inferred from code.

## 1. The biggest user-visible error group in the app is undiagnosable by construction

**GEOGENESIS-9 — 1,137 occurrences, 47 users, open since 24 February.**

> An error occurred in the Server Components render. The specific message is omitted in production builds to avoid leaking sensitive details. A digest property is included on this error instance...

with a stacktrace of exactly one minified frame. React strips the message in production and hands the client only a `digest`; the real error is logged **server-side under that same digest**. We never recorded it — so there was no join key between what the user saw and what actually failed, and no amount of staring at this group could ever resolve it.

The digest is now a Sentry **tag**, so `digest:<value>` finds both halves. Also tagged: which boundary caught it, separating user-visible failures from background noise that never reached a screen.

## 2. 92% of error volume is unactionable analytics noise

Measured over 7 days: **5,742 of 6,251 error events** were ad-blocked Amplitude beacons. One group (GEOGENESIS-6M) has **183,606 lifetime occurrences**.

They cannot cause a user-visible fault — the analytics bundle loads via its own `<script>` tag and these arrive as `onunhandledrejection` inside it, so they never reach a React boundary — but they buried the ~500 real events and consume event quota.

Dropped in `beforeSend`, on **two independent signals**: the analytics host, and the bundle's own frames (`sendAmplitudeHttp`, `flushAmplitudeEvents`, `ga-<contenthash>.js`). Deliberately **not** matched on "Failed to fetch" — that is the generic message every genuine network failure produces, and filtering on it would silently discard real API failures, which is the exact mistake worth avoiding in a noise filter.

## 3. The boundary called every error "Reconnecting"

`app/error.tsx` is the **only** error boundary in the app, so any uncaught throw anywhere blanks the page with this notice — and it said "Reconnecting" regardless of cause. So a plain bug read to users, and to whoever they reported it to, as a connection problem and got chased as one. That is GEO-2670's framing, and it is why my first read of this ticket went looking at network code.

It now claims a connection cause only when `navigator.onLine` is actually `false`, and shows a short **reference** (digest first, Sentry event id otherwise) so a screenshot of the screen pins the underlying event instead of being unlinkable.

## Two hypotheses I killed rather than leaving open

- **Deployment skew** (stale build id → failed RSC fetch → boundary). Refuted: there are **no** chunk-load or dynamic-import failures in the project at all.
- **Amplitude as the cause.** Refuted on mechanism, not just correlation: script-tag loader, unhandled rejection, cannot reach a React boundary.

## What is still open, and why I'm not guessing

Over 14 days, `/space/:id/debates/rematches/:sessionId` shows only the analytics noise plus **one** "Maximum update depth exceeded". One event does not match Preston's "I keep getting this". So the root cause is genuinely not in the data yet, and the honest move is to make the next occurrence traceable rather than to pick a plausible mechanism and ship a fix for it. I already made that mistake once on GEO-2584 this week.

## Verification

- `vitest run core/telemetry core/community-calls core/analytics.test.ts` — **84 passed, 8 files**
- `tsc --noEmit` — 5 errors, all pre-existing in unrelated files (`sort-open-proposals.test.ts`, `use-entity-vote.ts`, `entity-response.test.ts`)

One note for review: `reportBoundaryError` keeps a signature compatible with `react-error-boundary`'s `onError(error, info)`, because it is passed by reference from four boundaries — narrowing the second parameter broke assignability at all four (I did exactly that, and the typecheck caught it). The digest/boundary tagging therefore lives in `reportCaughtError`, which the app-root boundary calls directly.
