### PR TITLE
feat(debates): pin search and filters above the claim lists, and add search to People

### DIFF
--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
@@ -1459,6 +1459,27 @@ describe('DebateRematchPageClient', () => {
     expect(names).toEqual(['Ordered claim one', 'Ordered claim two', 'Ordered claim three']);
   });
 
+  // GEO-2684. This page's sticky block is its own implementation rather than the hub's shared
+  // helper, so nothing else covers it. Its tabs scroll with the page, unlike the panel's, which is
+  // why they are pinned alongside the filters — pinning the filters alone would float them over a
+  // tab strip sliding past behind them.
+  it('pins the tabs, filters and search together, leaving the list to scroll', () => {
+    mocks.entityQueryHasNextPage = true;
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+    showAllClaims();
+
+    const pinned = screen.getByRole('textbox', { name: 'Search claims' }).closest('.sticky');
+    expect(pinned).not.toBeNull();
+    expect(pinned?.className).toContain('top-0');
+
+    // The tab strip rides in the same block rather than scrolling out from under the controls.
+    expect(screen.getByRole('button', { name: 'All' }).closest('.sticky')).toBe(pinned);
+    expect(screen.getByRole('button', { name: /Any space/ }).closest('.sticky')).toBe(pinned);
+
+    // And the list is outside it, or it would be pinned too and never scroll.
+    expect(screen.getByTestId('claims-scroll-sentinel').closest('.sticky')).toBeNull();
+  });
+
   // GEO-2671. Rows the index hasn't paged to — a claim the opponent answered, a saved or curated
   // one — used to be appended after every paged row, so each new batch inserted rows above them
   // and slid them further down. A claim the viewer already held a position on was still sinking

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -752,69 +752,76 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
     // scrollable. Anything wider than the viewport — the tab strip, on a phone — panned the whole
     // screen sideways instead of scrolling itself.
     <div className="fixed inset-0 z-[150] overflow-x-hidden overflow-y-auto bg-white text-text">
-      <main className="mx-auto min-h-dvh w-full max-w-[720px] px-5 py-8 sm:px-8">
-        <header className="mb-4 flex items-center justify-between gap-4">
-          <h1 className="sr-only">Rematch {remoteName}</h1>
-          {/* Scrolls on its own: `min-w-0` lets it be narrower than its tabs, `overflow-x-auto`
-              gives those tabs somewhere to go, and `overscroll-x-contain` stops a swipe that
-              reaches the end from chaining into the browser's back gesture. */}
-          <div className="no-scrollbar flex min-w-0 flex-1 items-center gap-5 overflow-x-auto overscroll-x-contain">
-            {hasRecommended || recommendedLoading ? (
-              <TabButton active={tab === 'recommended'} onClick={() => setTab('recommended')}>
-                Recommended
+      <main className="mx-auto min-h-dvh w-full max-w-[720px] px-5 pt-8 pb-8 sm:px-8">
+        {/* Pinned together, tabs included. The list pages forever, so both the tab strip and the
+            controls under it were a full scroll away by the time the viewer wanted either — and
+            pinning the filters alone would have left them floating over a tab strip scrolling
+            past behind them. Bleeds to the layer's edges so the page passes under it rather than
+            beside it, and `-mt-8` lets it sit flush at the top once stuck. */}
+        <div className="sticky top-0 z-20 -mx-5 -mt-8 bg-white px-5 pt-8 pb-3 sm:-mx-8 sm:px-8">
+          <header className="mb-4 flex items-center justify-between gap-4">
+            <h1 className="sr-only">Rematch {remoteName}</h1>
+            {/* Scrolls on its own: `min-w-0` lets it be narrower than its tabs, `overflow-x-auto`
+                gives those tabs somewhere to go, and `overscroll-x-contain` stops a swipe that
+                reaches the end from chaining into the browser's back gesture. */}
+            <div className="no-scrollbar flex min-w-0 flex-1 items-center gap-5 overflow-x-auto overscroll-x-contain">
+              {hasRecommended || recommendedLoading ? (
+                <TabButton active={tab === 'recommended'} onClick={() => setTab('recommended')}>
+                  Recommended
+                </TabButton>
+              ) : null}
+              <TabButton active={tab === 'opponent'} onClick={() => setTab('opponent')}>
+                <span className="max-w-[10rem] truncate">{firstNamePossessive(remoteName)} positions</span>
+                <span
+                  className={cx(
+                    'inline-flex min-h-6 min-w-6 items-center justify-center rounded-full px-1.5 text-metadataMedium tabular-nums',
+                    tab === 'opponent' ? 'bg-text text-white' : 'bg-grey-01 text-grey-04'
+                  )}
+                >
+                  {/* The badge keeps its size either way, so the strip doesn't reflow when the
+                      number lands. See `opponentCountPending`: a skeleton says "still counting",
+                      where `0` said "none" and was usually wrong. */}
+                  {opponentCountPending ? (
+                    <Skeleton radius="rounded-full" className="h-3 w-3" aria-label="Counting positions" />
+                  ) : (
+                    opponentPositionCount
+                  )}
+                </span>
               </TabButton>
-            ) : null}
-            <TabButton active={tab === 'opponent'} onClick={() => setTab('opponent')}>
-              <span className="max-w-[10rem] truncate">{firstNamePossessive(remoteName)} positions</span>
-              <span
-                className={cx(
-                  'inline-flex min-h-6 min-w-6 items-center justify-center rounded-full px-1.5 text-metadataMedium tabular-nums',
-                  tab === 'opponent' ? 'bg-text text-white' : 'bg-grey-01 text-grey-04'
-                )}
-              >
-                {/* The badge keeps its size either way, so the strip doesn't reflow when the
-                    number lands. See `opponentCountPending`: a skeleton says "still counting",
-                    where `0` said "none" and was usually wrong. */}
-                {opponentCountPending ? (
-                  <Skeleton radius="rounded-full" className="h-3 w-3" aria-label="Counting positions" />
-                ) : (
-                  opponentPositionCount
-                )}
-              </span>
-            </TabButton>
-            <TabButton active={tab === 'all'} onClick={() => setTab('all')}>
-              All
-            </TabButton>
-          </div>
-          <button
-            type="button"
-            aria-label="Leave debate"
-            title="Leave debate"
-            onClick={leave}
-            disabled={leaveSession.isPending}
-            className="grid size-9 shrink-0 place-items-center rounded-full border border-grey-02 text-grey-04 transition-colors hover:text-text disabled:opacity-50"
-          >
-            <LeaveIcon />
-          </button>
-        </header>
+              <TabButton active={tab === 'all'} onClick={() => setTab('all')}>
+                All
+              </TabButton>
+            </div>
+            <button
+              type="button"
+              aria-label="Leave debate"
+              title="Leave debate"
+              onClick={leave}
+              disabled={leaveSession.isPending}
+              className="grid size-9 shrink-0 place-items-center rounded-full border border-grey-02 text-grey-04 transition-colors hover:text-text disabled:opacity-50"
+            >
+              <LeaveIcon />
+            </button>
+          </header>
 
-        <div className="mb-3 flex flex-col gap-3">
-          <SpaceTopicFilters
-            spaceId={spaceId}
-            onSpaceChange={setSpaceId}
-            topicId={topicId}
-            onTopicChange={setTopicId}
-            facetSpaceIds={facetSpaceIds}
-            facetTopics={facetTopics}
-            className="justify-between"
-          />
-          <Input
-            withSearchIcon
-            value={search}
-            onChange={event => setSearch(event.currentTarget.value)}
-            placeholder="Search claims"
-            aria-label="Search claims"
-          />
+          <div className="flex flex-col gap-3">
+            <SpaceTopicFilters
+              spaceId={spaceId}
+              onSpaceChange={setSpaceId}
+              topicId={topicId}
+              onTopicChange={setTopicId}
+              facetSpaceIds={facetSpaceIds}
+              facetTopics={facetTopics}
+              className="justify-between"
+            />
+            <Input
+              withSearchIcon
+              value={search}
+              onChange={event => setSearch(event.currentTarget.value)}
+              placeholder="Search claims"
+              aria-label="Search claims"
+            />
+          </div>
         </div>
 
         {(createRequest.error instanceof Error || leaveSession.error instanceof Error) && (

--- a/apps/web/core/debates/matchmaking/claims-tab.test.tsx
+++ b/apps/web/core/debates/matchmaking/claims-tab.test.tsx
@@ -196,6 +196,27 @@ beforeEach(() => {
 afterEach(cleanup);
 
 describe('ClaimsTab', () => {
+  // GEO-2684. The list pages forever, so controls left in the scrolling body meant scrolling back
+  // to the start to change a filter. jsdom has no layout, so what's assertable is that they sit in
+  // a pinned container rather than in the body that scrolls.
+  it('pins search and the filters above the list', () => {
+    // The sentinel only exists while a page is outstanding, and it is the handle for "this part
+    // scrolls".
+    mocks.hasNextPage = true;
+    render(<ClaimsTab />);
+
+    const pinned = screen.getByLabelText('Search claims').closest('.sticky');
+    expect(pinned).not.toBeNull();
+    expect(pinned?.className).toContain('top-0');
+
+    // Both controls ride in the same pinned block. Two stickies would each claim `top-0` and
+    // overlap, which is why the filters aren't pinned separately.
+    expect(screen.getByRole('button', { name: /All claims/ }).closest('.sticky')).toBe(pinned);
+
+    // And the list itself is not inside it, or it would be pinned too and never scroll.
+    expect(screen.getByTestId('claims-scroll-sentinel').closest('.sticky')).toBeNull();
+  });
+
   // Pages arrive by reaching the end of the list, not by pressing anything.
   it('fetches the next page when the end of the list scrolls into view', () => {
     mocks.hasNextPage = true;

--- a/apps/web/core/debates/matchmaking/claims-tab.tsx
+++ b/apps/web/core/debates/matchmaking/claims-tab.tsx
@@ -166,33 +166,36 @@ export function ClaimsTab() {
   );
 
   return (
-    <div className="flex flex-col gap-3 px-4 py-3">
-      <Input
-        withSearchIcon
-        value={search}
-        onChange={event => setSearch(event.currentTarget.value)}
-        placeholder="Search claims"
-        aria-label="Search claims"
-      />
+    <div className="flex flex-col">
+      <HubStickyControls>
+        <Input
+          withSearchIcon
+          value={search}
+          onChange={event => setSearch(event.currentTarget.value)}
+          placeholder="Search claims"
+          aria-label="Search claims"
+        />
 
-      <SpaceTopicFilters
-        spaceId={spaceId}
-        onSpaceChange={setSpaceId}
-        topicId={topicId}
-        onTopicChange={setTopicId}
-        facetSpaceIds={facetSpaceIds}
-        facetTopics={facetTopics}
-        leading={
-          <HubFilterMenu
-            label={FILTER_OPTIONS.find(option => option.value === filter)?.label ?? 'All claims'}
-            options={FILTER_OPTIONS}
-            value={filter}
-            onChange={setFilter}
-          />
-        }
-      />
+        <SpaceTopicFilters
+          spaceId={spaceId}
+          onSpaceChange={setSpaceId}
+          topicId={topicId}
+          onTopicChange={setTopicId}
+          facetSpaceIds={facetSpaceIds}
+          facetTopics={facetTopics}
+          leading={
+            <HubFilterMenu
+              label={FILTER_OPTIONS.find(option => option.value === filter)?.label ?? 'All claims'}
+              options={FILTER_OPTIONS}
+              value={filter}
+              onChange={setFilter}
+            />
+          }
+        />
+      </HubStickyControls>
 
-      <HubQueryState
+      <div className="flex flex-col gap-3 px-4 py-3">
+        <HubQueryState
         isLoading={claimsQuery.isLoading || spacesPending}
         error={claimsQuery.error}
         onRetry={() => void claimsQuery.refetch()}
@@ -238,9 +241,10 @@ export function ClaimsTab() {
           Not while the allowlist is pending, though: the tab is showing a four-row skeleton then,
           so the sentinel sits in view under it and pages the corpus on the strength of a loading
           state being visible — reading "the viewer reached the end" off a list that isn't there. */}
-      {claimsQuery.hasNextPage && !spacesPending ? (
-        <div ref={sentinelRef} data-testid="claims-scroll-sentinel" className="h-px" />
-      ) : null}
+        {claimsQuery.hasNextPage && !spacesPending ? (
+          <div ref={sentinelRef} data-testid="claims-scroll-sentinel" className="h-px" />
+        ) : null}
+      </div>
     </div>
   );
 }
@@ -265,6 +269,22 @@ type SpaceTopicFiltersProps = {
  * sidebar's already-loaded rows before falling back to the knowledge graph — the facets are
  * narrowed to the viewer's own spaces, which is exactly what the sidebar is holding.
  */
+/**
+ * The controls a tab pins above its list. Both hub surfaces page forever, so leaving search and
+ * the filters at the top of the document meant scrolling back to the start to change either.
+ *
+ * Deliberately thin: the panel is narrow and short, so every pinned pixel is a claim the viewer
+ * can't see. The tab row above it is already fixed — it sits outside the panel's scroll container
+ * — so this is the only piece that needed pinning here.
+ */
+export function HubStickyControls({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="sticky top-0 z-10 flex flex-col gap-3 border-b border-grey-02 bg-white px-4 py-3">
+      {children}
+    </div>
+  );
+}
+
 export function SpaceTopicFilters({
   spaceId,
   onSpaceChange,

--- a/apps/web/core/debates/matchmaking/claims-tab.tsx
+++ b/apps/web/core/debates/matchmaking/claims-tab.tsx
@@ -249,6 +249,22 @@ export function ClaimsTab() {
   );
 }
 
+/**
+ * The controls a tab pins above its list. Both hub surfaces page forever, so leaving search and
+ * the filters at the top of the document meant scrolling back to the start to change either.
+ *
+ * Deliberately thin: the panel is narrow and short, so every pinned pixel is a claim the viewer
+ * can't see. The tab row above it is already fixed — it sits outside the panel's scroll container
+ * — so this is the only piece that needed pinning here.
+ */
+export function HubStickyControls({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="sticky top-0 z-10 flex flex-col gap-3 border-b border-grey-02 bg-white px-4 py-3">
+      {children}
+    </div>
+  );
+}
+
 type SpaceTopicFiltersProps = {
   spaceId: string | null;
   onSpaceChange: (spaceId: string | null) => void;
@@ -269,22 +285,6 @@ type SpaceTopicFiltersProps = {
  * sidebar's already-loaded rows before falling back to the knowledge graph — the facets are
  * narrowed to the viewer's own spaces, which is exactly what the sidebar is holding.
  */
-/**
- * The controls a tab pins above its list. Both hub surfaces page forever, so leaving search and
- * the filters at the top of the document meant scrolling back to the start to change either.
- *
- * Deliberately thin: the panel is narrow and short, so every pinned pixel is a claim the viewer
- * can't see. The tab row above it is already fixed — it sits outside the panel's scroll container
- * — so this is the only piece that needed pinning here.
- */
-export function HubStickyControls({ children }: { children: React.ReactNode }) {
-  return (
-    <div className="sticky top-0 z-10 flex flex-col gap-3 border-b border-grey-02 bg-white px-4 py-3">
-      {children}
-    </div>
-  );
-}
-
 export function SpaceTopicFilters({
   spaceId,
   onSpaceChange,

--- a/apps/web/core/debates/matchmaking/matches-tab.test.tsx
+++ b/apps/web/core/debates/matchmaking/matches-tab.test.tsx
@@ -297,4 +297,30 @@ describe('MatchesTab', () => {
 
     expect(screen.getByRole('button', { name: 'Request debate' })).toBeDisabled();
   });
+
+  // GEO-2684. The outbound card was already pinned; the filters joined it rather than becoming a
+  // second sticky, because two would both claim `top-0` and overlap — and the card is conditional,
+  // so the filters could not be offset by a known height either. The shared helper's own test only
+  // proves it has the sticky classes, so this is what would catch the card being lifted back out.
+  it('keeps a sent request and the filters in the same pinned block', () => {
+    mocks.outbound = {
+      id: 'request-1',
+      claim: match().claim,
+      expires_at: '2099-01-01T00:00:00.000Z',
+      requester: party('user-me', 'You', true, 'Agree'),
+      recipient: party('user-them', 'Arturas', false, 'Disagree'),
+    };
+    render(<MatchesTab onTabChange={vi.fn()} />);
+
+    const pinned = screen.getByText('Awaiting response').closest('.sticky');
+    expect(pinned).not.toBeNull();
+    expect(pinned?.className).toContain('top-0');
+    expect(screen.getByRole('button', { name: /Any space/ }).closest('.sticky')).toBe(pinned);
+  });
+
+  it('still pins the filters with no request outstanding', () => {
+    render(<MatchesTab onTabChange={vi.fn()} />);
+
+    expect(screen.getByRole('button', { name: /Any space/ }).closest('.sticky')).not.toBeNull();
+  });
 });

--- a/apps/web/core/debates/matchmaking/matches-tab.tsx
+++ b/apps/web/core/debates/matchmaking/matches-tab.tsx
@@ -6,7 +6,7 @@ import { Text } from '~/design-system/text';
 
 import type { MatchmakingMatch } from '../api';
 import { useDebateActivity } from '../hooks';
-import { SpaceTopicFilters } from './claims-tab';
+import { HubStickyControls, SpaceTopicFilters } from './claims-tab';
 import { useCreateDebateRequest, useDebateRequests, useMatchmakingMatches } from './hooks';
 import { HubCardList } from './hub-motion';
 import { HubPillButton } from './hub-pill-button';
@@ -53,15 +53,15 @@ export function MatchesTab({ onTabChange }: { onTabChange: (tab: DebatesHubTab) 
 
   return (
     <div className="flex flex-col">
-      {outbound ? (
-        <div className="sticky top-0 z-10 border-b border-grey-02 bg-white px-4 py-3">
-          <OutboundRequestCard request={outbound} />
-        </div>
-      ) : null}
+      {/* One pinned header rather than a pinned card above scrolling filters: two stickies would
+          both claim `top-0` and overlap, and the outbound card is conditional so the filters
+          couldn't be offset by a known height. */}
+      <HubStickyControls>
+        {outbound ? <OutboundRequestCard request={outbound} /> : null}
+        <SpaceTopicFilters spaceId={spaceId} onSpaceChange={setSpaceId} facetSpaceIds={facetSpaceIds} />
+      </HubStickyControls>
 
       <div className="flex flex-col gap-3 px-4 py-3">
-        <SpaceTopicFilters spaceId={spaceId} onSpaceChange={setSpaceId} facetSpaceIds={facetSpaceIds} />
-
         <HubQueryState
           isLoading={matchesQuery.isLoading}
           error={matchesQuery.error}

--- a/apps/web/core/debates/matchmaking/people-tab.test.tsx
+++ b/apps/web/core/debates/matchmaking/people-tab.test.tsx
@@ -89,6 +89,46 @@ beforeEach(() => {
 afterEach(cleanup);
 
 describe('PeopleTab', () => {
+  // Filtered client-side: the endpoint has no search parameter and returns everyone available in
+  // one unpaginated list, so there is nothing to page back for.
+  it('narrows the list to people matching the search', () => {
+    render(<PeopleTab />);
+
+    expect(screen.getByText('Arturas')).toBeInTheDocument();
+    expect(screen.getByText('Vytautas')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText('Search people'), { target: { value: 'artur' } });
+
+    expect(screen.getByText('Arturas')).toBeInTheDocument();
+    expect(screen.queryByText('Vytautas')).not.toBeInTheDocument();
+  });
+
+  it('says so when a search matches nobody, and offers a way back', async () => {
+    // Distinct from the "nobody is available" state: one is a filter the viewer can undo, the
+    // other is the room being empty.
+    render(<PeopleTab />);
+
+    fireEvent.change(screen.getByLabelText('Search people'), { target: { value: 'nobody-by-this-name' } });
+
+    // The empty state cross-fades in through HubSwap, so it arrives after the list leaves.
+    expect(await screen.findByText('Nobody available matches that search.')).toBeInTheDocument();
+    expect(screen.queryByText('Nobody is available to debate right now.')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Clear search' }));
+    expect(await screen.findByText('Arturas')).toBeInTheDocument();
+  });
+
+  it('pins search alongside a sent request rather than in a second sticky', () => {
+    // Two stickies would both claim top-0 and overlap; the card is conditional, so search could
+    // not be offset by a known height either.
+    mocks.challenge = challenge('requester');
+    render(<PeopleTab />);
+
+    const pinned = screen.getByLabelText('Search people').closest('.sticky');
+    expect(pinned).not.toBeNull();
+    expect(card()?.closest('.sticky')).toBe(pinned);
+  });
+
   it('shows no request card when nothing is outstanding', () => {
     render(<PeopleTab />);
 

--- a/apps/web/core/debates/matchmaking/people-tab.tsx
+++ b/apps/web/core/debates/matchmaking/people-tab.tsx
@@ -3,6 +3,7 @@
 import * as React from 'react';
 
 import { Avatar } from '~/design-system/avatar';
+import { Input } from '~/design-system/input';
 import { Text } from '~/design-system/text';
 
 import { activeDebate } from '../activity-state';
@@ -11,6 +12,7 @@ import { useCreateDebateChallenge, useDebateActivity } from '../hooks';
 import { speakerLabel } from '../playback-utils';
 import { useCurrentGeoChatUserId } from '../use-current-geo-chat-user-id';
 import { DebateChallengeCard } from './challenge-card';
+import { HubStickyControls } from './claims-tab';
 import { useDebatePeople, useDebateRequests } from './hooks';
 import { HubPillButton } from './hub-pill-button';
 import { HubQueryState } from './hub-states';
@@ -25,7 +27,17 @@ export function PeopleTab() {
   const { data: activity } = useDebateActivity(true);
   const { data: requests } = useDebateRequests(true);
   const currentUserId = useCurrentGeoChatUserId();
-  const people = peopleQuery.data?.people ?? [];
+  const allPeople = React.useMemo(() => peopleQuery.data?.people ?? [], [peopleQuery.data]);
+
+  // Filtered here rather than through the query: this endpoint has no search parameter and returns
+  // whoever is available right now in one unpaginated list, so there is nothing to page back for.
+  // Matching the same label the row renders keeps "search for what you can see" true.
+  const [search, setSearch] = React.useState('');
+  const people = React.useMemo(() => {
+    const term = search.trim().toLowerCase();
+    if (!term) return allPeople;
+    return allPeople.filter(person => speakerLabel(person).toLowerCase().includes(term));
+  }, [allPeople, search]);
 
   const reportedChallenge = activity?.challenge?.status === 'pending' ? activity.challenge : null;
   // A challenge stays `pending` in the activity payload until the server says otherwise, so its own
@@ -62,13 +74,20 @@ export function PeopleTab() {
 
   return (
     <div className="flex flex-col">
-      {/* Sticky above the list, the way Matches keeps a sent claim request in view — a request you
-          are waiting on shouldn't scroll away behind the people you can no longer ask. */}
-      {outboundChallenge ? (
-        <div className="sticky top-0 z-10 border-b border-grey-02 bg-white px-4 py-3">
-          <DebateChallengeCard challenge={outboundChallenge} role="requester" />
-        </div>
-      ) : null}
+      {/* One pinned block, like Matches: a request you are waiting on shouldn't scroll away behind
+          the people you can no longer ask, and search shouldn't either. Two stickies would both
+          claim `top-0` and overlap, and the card is conditional so search couldn't be offset by a
+          known height. */}
+      <HubStickyControls>
+        {outboundChallenge ? <DebateChallengeCard challenge={outboundChallenge} role="requester" /> : null}
+        <Input
+          withSearchIcon
+          value={search}
+          onChange={event => setSearch(event.currentTarget.value)}
+          placeholder="Search people"
+          aria-label="Search people"
+        />
+      </HubStickyControls>
 
       {/* Matches the other tabs' inset so content doesn't shift when switching between them. */}
       <div className="px-4 py-3">
@@ -76,7 +95,10 @@ export function PeopleTab() {
           isLoading={peopleQuery.isLoading}
           error={peopleQuery.error}
           isEmpty={people.length === 0}
-          emptyMessage="Nobody is available to debate right now."
+          emptyMessage={
+            search.trim() ? 'Nobody available matches that search.' : 'Nobody is available to debate right now.'
+          }
+          emptyAction={search.trim() ? { label: 'Clear search', onClick: () => setSearch('') } : undefined}
         >
           <>
             {blockedReason ? (

--- a/apps/web/core/debates/matchmaking/requests-tab.test.tsx
+++ b/apps/web/core/debates/matchmaking/requests-tab.test.tsx
@@ -134,6 +134,22 @@ afterEach(cleanup);
 const openFilter = (label: string) => fireEvent.click(screen.getByRole('button', { name: new RegExp(label) }));
 
 describe('RequestsTab', () => {
+  // GEO-2684. The shared helper's own test only proves it carries the sticky classes, so this is
+  // what would catch these filters being moved back into the scrolling body.
+  it('pins the status and space filters above the requests', () => {
+    render(<RequestsTab />);
+
+    const pinned = screen.getByRole('button', { name: /Any status/ }).closest('.sticky');
+    expect(pinned).not.toBeNull();
+    expect(pinned?.className).toContain('top-0');
+
+    // Both controls ride in the same pinned block rather than a second one that could overlap it.
+    expect(screen.getByRole('button', { name: /Any space/ }).closest('.sticky')).toBe(pinned);
+
+    // The requests themselves stay outside it, or they would be pinned too and never scroll.
+    expect(screen.getByRole('heading', { name: 'Received' }).closest('.sticky')).toBeNull();
+  });
+
   // The whole point of the popup's "Not now": the request is untouched, so it is still here with
   // its countdown for the rest of its 25-minute life.
   it('lists a request nobody has answered yet, with its countdown', () => {

--- a/apps/web/core/debates/matchmaking/requests-tab.tsx
+++ b/apps/web/core/debates/matchmaking/requests-tab.tsx
@@ -7,7 +7,7 @@ import { Text } from '~/design-system/text';
 import { useDebateActivity } from '../hooks';
 import { useCurrentGeoChatUserId } from '../use-current-geo-chat-user-id';
 import { DebateChallengeCard } from './challenge-card';
-import { SpaceTopicFilters } from './claims-tab';
+import { HubStickyControls, SpaceTopicFilters } from './claims-tab';
 import { useDebateRequests } from './hooks';
 import { HubFilterMenu, type HubFilterOption } from './hub-filter-menu';
 import { HubCardList } from './hub-motion';
@@ -81,22 +81,25 @@ export function RequestsTab() {
   const isEmpty = !sent && !outgoingChallenge && received.length === 0 && !incomingChallenge;
 
   return (
-    <div className="flex flex-col gap-3 px-4 py-3">
-      <SpaceTopicFilters
-        spaceId={spaceId}
-        onSpaceChange={setSpaceId}
-        facetSpaceIds={facetSpaceIds}
-        leading={
-          <HubFilterMenu
-            label={STATUS_OPTIONS.find(option => option.value === status)?.label ?? 'Any status'}
-            options={STATUS_OPTIONS}
-            value={status}
-            onChange={setStatus}
-          />
-        }
-      />
+    <div className="flex flex-col">
+      <HubStickyControls>
+        <SpaceTopicFilters
+          spaceId={spaceId}
+          onSpaceChange={setSpaceId}
+          facetSpaceIds={facetSpaceIds}
+          leading={
+            <HubFilterMenu
+              label={STATUS_OPTIONS.find(option => option.value === status)?.label ?? 'Any status'}
+              options={STATUS_OPTIONS}
+              value={status}
+              onChange={setStatus}
+            />
+          }
+        />
+      </HubStickyControls>
 
-      <HubQueryState
+      <div className="flex flex-col gap-3 px-4 py-3">
+        <HubQueryState
         isLoading={requestsQuery.isLoading}
         error={requestsQuery.error}
         onRetry={() => void requestsQuery.refetch()}
@@ -139,7 +142,8 @@ export function RequestsTab() {
             </RequestSection>
           ) : null}
         </div>
-      </HubQueryState>
+        </HubQueryState>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Closes [GEO-2684](https://linear.app/geobrowser/issue/GEO-2684/debates-pin-filters-and-search-on-scroll-in-side-panel-and-debate). Also adds search to the People tab, per review.

## The tab-row question

It turned out to have different answers per surface, because they were already different:

* **Side panel** — the tab row is *already* fixed. It sits outside the panel's `overflow-y-auto` container as a `shrink-0` sibling, so it never scrolled. Only the controls beneath it needed pinning, which is also the most compact answer to the note about vertical space: nothing new is pinned that wasn't already.
* **Rematch page** — its tabs *do* scroll, so they're pinned with the filters. Pinning the filters alone would float them over a tab strip sliding past behind them.

## Panel

`HubStickyControls` matches the `sticky top-0 z-10 … bg-white` treatment `matches-tab` already used for its outbound card — the existing idiom, already proven inside that scroll container.

Applied to every tab with controls. Matches and People both already pinned a conditional request card; in each the new controls join that block rather than becoming a second sticky, since two would both claim `top-0` and overlap and a conditional card can't offset the one below it by a known height.

## People search

The endpoint has no search parameter and returns whoever is available in one unpaginated list, so the filter runs client-side over the same label each row renders — there's no page to go back for, and "search for what you can see" stays true.

An empty result distinguishes *no match* from *nobody available*: one is a filter the viewer can undo, and it offers Clear search to undo it.

## Rematch page

Header and filters move into one sticky block that bleeds to the layer's edges (`-mx-5 sm:-mx-8`) so the list passes under it rather than beside it, with `-mt-8` so it sits flush once stuck.

## Testing

Structural coverage for each pinned block, since jsdom has no layout and the container is what guarantees the behaviour:

* Claims — search and filters share one pinned container; the list is outside it.
* Matches — a sent request and the filters share one container; filters still pinned with no request.
* People — search shares the container with an outstanding challenge card; search narrows the list; the no-match state is distinct and clearable.
* Rematch — tabs, filters and search share one container; the paging sentinel does not.

Each verified against the mutation it exists to catch: unpinning the helper, lifting the Matches card back out, unpinning the rematch block.

`vitest run core/debates app/space/[id]/(space)/debates` — 958 passing. `bun run build` clean.

**Not verified in a browser**, and this is a visual change, so it's the part most worth your eye: both surfaces need a signed-in geo-chat session this environment can't produce. I'd look at the sticky background covering the full width on the rematch page at both breakpoints, and how much claim list survives in the panel on a short viewport.

Some files show large diffs that are mostly re-indentation from the new wrapper — `git diff -w` is much smaller. Pre-existing prettier drift in `claims-tab.tsx` and the rematch client is left alone rather than swept into this diff.