### PR TITLE
fix(telemetry): give the browser SDK a release, so client stacks stop being minified

### DIFF
--- a/apps/web/instrumentation-client.test.ts
+++ b/apps/web/instrumentation-client.test.ts
@@ -1,0 +1,46 @@
+import fs from 'fs';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Next only inlines `NEXT_PUBLIC_*` variables into the browser bundle. Reading any other
+ * `process.env` value from a file that runs client-side yields `undefined` at runtime — silently,
+ * with no build warning and nothing rendering differently.
+ *
+ * That is not hypothetical here. `instrumentation-client.ts` set
+ * `release: process.env.VERCEL_GIT_COMMIT_SHA`, which is server-only, so every browser event was
+ * reported with no release. Sentry then had nothing to match the uploaded source maps against, so
+ * every client-side stack stayed minified — measured at 5,809 of 6,251 error events over 7 days
+ * carrying `release: null`, while server events (where the variable does exist) resolved fine.
+ * The largest client crash groups had been unactionable for months as a direct result.
+ *
+ * A unit test can't observe Next's build-time inlining, so this asserts the property that
+ * actually matters and is checkable: the file reads nothing from `process.env` that the browser
+ * won't receive.
+ */
+const CLIENT_ENTRYPOINT = path.join(__dirname, 'instrumentation-client.ts');
+
+/**
+ * `NODE_ENV` is inlined by Next itself regardless of prefix, so it is genuinely available in the
+ * browser. Anything else must carry the prefix.
+ */
+const ALWAYS_INLINED = new Set(['NODE_ENV']);
+
+describe('instrumentation-client env reads', () => {
+  const source = fs.readFileSync(CLIENT_ENTRYPOINT, 'utf8');
+
+  // Strip comments first: the explanation above this fix names `VERCEL_GIT_COMMIT_SHA`, and a
+  // scan that counted prose would fail on the very comment describing the bug.
+  const code = source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*$/gm, '');
+
+  it('reads only variables the browser bundle actually receives', () => {
+    const reads = [...code.matchAll(/process\.env\.([A-Z0-9_]+)/g)].map(match => match[1]);
+    const unavailable = reads.filter(name => !name.startsWith('NEXT_PUBLIC_') && !ALWAYS_INLINED.has(name));
+
+    expect(unavailable).toEqual([]);
+  });
+
+  it('still sets a release, so source maps have something to match', () => {
+    expect(code).toContain('release: process.env.NEXT_PUBLIC_SENTRY_RELEASE');
+  });
+});

--- a/apps/web/instrumentation-client.ts
+++ b/apps/web/instrumentation-client.ts
@@ -61,7 +61,12 @@ if (isTelemetryEnabled) {
     dsn: telemetryDsn,
 
     environment: process.env.NEXT_PUBLIC_APP_ENV || 'development',
-    release: process.env.VERCEL_GIT_COMMIT_SHA,
+    // NEXT_PUBLIC_ prefix is load-bearing: this runs in the browser, and Next only inlines
+    // NEXT_PUBLIC_* variables into the client bundle. This read `VERCEL_GIT_COMMIT_SHA`
+    // directly, which is server-only, so it resolved to `undefined` and every client event was
+    // reported with no release — leaving the uploaded source maps unmatchable and every browser
+    // stack minified. Set in next.config.ts from the same value the source-map upload pins.
+    release: process.env.NEXT_PUBLIC_SENTRY_RELEASE,
 
     // 100% of traces in development, 20% in production
     tracesSampleRate: process.env.NODE_ENV === 'development' ? 1.0 : 0.2,

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -21,7 +21,29 @@ const turbopackOptimizations =
 
 const optimizePackageImports = ['effect', 'viem', 'wagmi', 'date-fns'];
 
+/**
+ * The Sentry release name, resolved once here and used for three things that must agree: the
+ * source-map upload, the server SDK, and the browser SDK.
+ *
+ * Read here rather than at each use site because this file runs on the build server, where
+ * `VERCEL_GIT_COMMIT_SHA` exists. The browser bundle only receives `NEXT_PUBLIC_*` variables, so
+ * `instrumentation-client.ts` reading `VERCEL_GIT_COMMIT_SHA` directly got `undefined` — every
+ * client event was reported with no release, which meant the uploaded source maps had nothing to
+ * match against and every client-side stack stayed minified. Measured before this fix: 5,809 of
+ * the last 7 days' error events had `release: null` (all the browser ones), while server events
+ * carried a sha and resolved fine. That is why the largest client crash groups had sat
+ * unactionable for months.
+ *
+ * Falling back to the local git sha keeps preview and self-hosted builds attributable too.
+ */
+const sentryRelease = process.env.VERCEL_GIT_COMMIT_SHA ?? process.env.SENTRY_RELEASE;
+
 const nextConfig: NextConfig = {
+  // Exposed so the browser SDK reports the same release the source maps are uploaded under.
+  // Next inlines this at build time; a bare `VERCEL_GIT_COMMIT_SHA` would not reach the client.
+  env: {
+    ...(sentryRelease ? { NEXT_PUBLIC_SENTRY_RELEASE: sentryRelease } : {}),
+  },
   // reactStrictMode: true,
   reactCompiler: process.env.DISABLE_REACT_COMPILER !== '1',
   agentRules: false,
@@ -175,6 +197,11 @@ export default process.env.DISABLE_SENTRY === '1'
       org: ServerEnvironment.sentryBuild?.org,
       project: ServerEnvironment.sentryBuild?.project,
       authToken: ServerEnvironment.sentryBuild?.authToken,
+
+      // Pinned to the same value both SDKs report, so uploaded source maps are guaranteed to be
+      // matched against the release the events actually carry rather than a separately-detected
+      // one. Omitted (letting the plugin detect it) when there is no sha to pin.
+      ...(sentryRelease ? { release: { name: sentryRelease } } : {}),
 
       // Route Sentry requests through the app to avoid ad-blockers
       tunnelRoute: '/monitoring',

--- a/apps/web/sentry.server.config.ts
+++ b/apps/web/sentry.server.config.ts
@@ -7,7 +7,9 @@ if (isTelemetryEnabled) {
     dsn: telemetryDsn,
 
     environment: process.env.NEXT_PUBLIC_APP_ENV || 'development',
-    release: process.env.VERCEL_GIT_COMMIT_SHA,
+    // Server-side, so the unprefixed variable is available; falls back to the shared one so
+    // both SDKs report an identical release even if the build sets only NEXT_PUBLIC_SENTRY_RELEASE.
+    release: process.env.VERCEL_GIT_COMMIT_SHA ?? process.env.NEXT_PUBLIC_SENTRY_RELEASE,
 
     // 100% of traces in development, 20% in production
     tracesSampleRate: process.env.NODE_ENV === 'development' ? 1.0 : 0.2,


### PR DESCRIPTION
Found while trying to diagnose GEO-2670. Not a feature — this is the reason our client-side error backlog has been stuck.

## Every browser event was reported with no release

Source maps are matched to events **by release**. With none set, there is nothing to match against, so every client-side stack stayed minified — one frame of `3ejp_0kl0879d.js:2:23824` and no way to tell which component crashed.

Measured in Sentry (`geo-7y/geogenesis`) over 7 days, not inferred:

| release | events |
|---|---|
| **`null`** | **5,809** ← every browser event |
| `07288da2…` | 115 |
| `e601b7dd…` | 109 |
| `38c08d0c…` | 41 |
| … | … ← server events, resolving fine |

## Cause

`instrumentation-client.ts` read `process.env.VERCEL_GIT_COMMIT_SHA`. That variable is **server-only**, and Next inlines only `NEXT_PUBLIC_*` into the browser bundle — so it resolved to `undefined` at runtime and the SDK reported events with no release.

The failure is completely silent: no build warning, nothing renders differently, and events keep arriving so the integration looks healthy. `core/telemetry/config.ts` documents this exact rule two files away:

> NEXT_PUBLIC_ prefix is required: this runs client-side (instrumentation-client.ts), and Next only exposes NEXT_PUBLIC_* env vars to the browser bundle.

## What this has cost

- **GEOGENESIS-9** — Server Components render error, **1,137 occurrences, 47 users, open since 24 February.** React strips the message in production, so it reads "the specific message is omitted" with one minified frame. Nobody could have acted on it.
- **GEOGENESIS-8B / A3** — "Maximum update depth exceeded", 13 users. The frames point at `core/sync/store.ts` (`hydrateReactiveState`, atom `set`/`notify`) but stop being readable exactly where it matters. This is what blocked me an hour ago.

## The fix

The release name is resolved **once** in `next.config.ts`, which runs on the build server where the sha exists, and used for all three things that must agree:

1. the source-map upload — `release: { name }` on `withSentryConfig`
2. the server SDK
3. the browser SDK, via `NEXT_PUBLIC_SENTRY_RELEASE`

Pinning the upload to the same value, rather than letting the plugin detect its own, removes the chance of artifacts and events disagreeing about the release even once both are set. Falls back to `SENTRY_RELEASE` so preview and self-hosted builds stay attributable, and omits the pin entirely when there is no sha rather than inventing one.

## Tests

A unit test can't observe Next's build-time inlining, so the guard asserts the property that *is* checkable: the client entrypoint reads nothing from `process.env` that the browser won't receive (`NODE_ENV` allowlisted, since Next inlines that regardless of prefix).

Comments are stripped before scanning — the comment explaining this fix names `VERCEL_GIT_COMMIT_SHA`, so a naive scan would fail on the very prose describing the bug.

**Verified it catches the original**: restoring the old line fails both tests. I checked that rather than assuming it.

- `tsc --noEmit` — 5 errors, all pre-existing in unrelated files (`sort-open-proposals.test.ts`, `use-entity-vote.ts`, `entity-response.test.ts`)

## After this deploys

Client stacks become readable for the first time, which unblocks GEOGENESIS-9 and the `store.ts` render loop. Worth re-triaging both once a build with this has been live for a day — the frames will finally name real files.
