### PR TITLE
fix(home): stop querying governance spaces with a wallet address as the space id

### DIFF
--- a/apps/web/app/home/governance-home-space-ids.test.ts
+++ b/apps/web/app/home/governance-home-space-ids.test.ts
@@ -1,0 +1,68 @@
+import { Effect } from 'effect';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { getSpacesWhereMember } from '~/core/io/queries';
+import { fetchEditorSpaceIds } from '~/core/io/subgraph/fetch-editor-space-ids';
+
+import { getGovernanceHomeSpaceContext } from './governance-home-space-ids';
+
+vi.mock('~/core/io/queries', () => ({ getSpacesWhereMember: vi.fn() }));
+vi.mock('~/core/io/subgraph/fetch-editor-space-ids', () => ({ fetchEditorSpaceIds: vi.fn() }));
+
+// `cache()` from react memoizes per-argument, so every case needs a distinct id or the second
+// call would return the first's result and the assertion would pass for the wrong reason.
+const VALID_SPACE_ID = '89bd89bf28ff8a0963faf92a8c905e20';
+const OTHER_VALID_SPACE_ID = 'c9f267dcb0d270718c2a3c45a64afd32';
+const WALLET_ADDRESS = '0x77b3b79b551d90bfcd7fa12f372ca31626d79dc0';
+
+afterEach(() => {
+  vi.mocked(getSpacesWhereMember).mockReset();
+  vi.mocked(fetchEditorSpaceIds).mockReset();
+});
+
+describe('getGovernanceHomeSpaceContext', () => {
+  /**
+   * The bug this exists for (GEOGENESIS-48, 274 occurrences): `fetchProfile` puts the wallet
+   * address in `Profile.spaceId` on every failure path, callers checked it for truthiness, and both
+   * queries here take a GraphQL `UUID!` — so the address reached the API and 400'd.
+   */
+  it('does not query with a wallet address masquerading as a space id', async () => {
+    const result = await getGovernanceHomeSpaceContext(WALLET_ADDRESS);
+
+    expect(result).toEqual({ editorIds: [], myProposalSpaceIds: [] });
+    expect(fetchEditorSpaceIds).not.toHaveBeenCalled();
+    expect(getSpacesWhereMember).not.toHaveBeenCalled();
+  });
+
+  it('does not query with an empty id', async () => {
+    const result = await getGovernanceHomeSpaceContext('');
+
+    expect(result).toEqual({ editorIds: [], myProposalSpaceIds: [] });
+    expect(getSpacesWhereMember).not.toHaveBeenCalled();
+  });
+
+  it('still queries and merges for a real space id', async () => {
+    vi.mocked(fetchEditorSpaceIds).mockResolvedValue(['editor-space']);
+    // The real function returns an Effect and the module runs it through `Effect.runPromise`, so
+    // the mock has to be an Effect too — a bare Promise fails with "Not a valid effect".
+    vi.mocked(getSpacesWhereMember).mockReturnValue(
+      Effect.succeed([{ id: 'member-space' }, { id: VALID_SPACE_ID }]) as never
+    );
+
+    const result = await getGovernanceHomeSpaceContext(VALID_SPACE_ID);
+
+    expect(fetchEditorSpaceIds).toHaveBeenCalledWith(VALID_SPACE_ID);
+    expect(result.editorIds).toEqual(['editor-space']);
+    // Own space filtered out, editor and member ids merged and deduped.
+    expect(result.myProposalSpaceIds).toEqual(['editor-space', 'member-space']);
+  });
+
+  it('dedupes a space the user is both editor and member of', async () => {
+    vi.mocked(fetchEditorSpaceIds).mockResolvedValue(['shared-space']);
+    vi.mocked(getSpacesWhereMember).mockReturnValue(Effect.succeed([{ id: 'shared-space' }]) as never);
+
+    const result = await getGovernanceHomeSpaceContext(OTHER_VALID_SPACE_ID);
+
+    expect(result.myProposalSpaceIds).toEqual(['shared-space']);
+  });
+});

--- a/apps/web/app/home/governance-home-space-ids.ts
+++ b/apps/web/app/home/governance-home-space-ids.ts
@@ -1,3 +1,5 @@
+import { IdUtils } from '@geoprotocol/geo-sdk/lite';
+
 import { cache } from 'react';
 
 import * as Effect from 'effect/Effect';
@@ -5,7 +7,27 @@ import * as Effect from 'effect/Effect';
 import { getSpacesWhereMember } from '~/core/io/queries';
 import { fetchEditorSpaceIds } from '~/core/io/subgraph/fetch-editor-space-ids';
 
+const EMPTY_CONTEXT = { editorIds: [] as string[], myProposalSpaceIds: [] as string[] };
+
+/**
+ * Both queries below take `memberSpaceId` as a GraphQL `UUID!`, so a caller has to hand over a real
+ * space id — and `Profile.spaceId` is not guaranteed to be one.
+ *
+ * `fetchProfile` returns `defaultProfile(walletAddress, walletAddress)` on all three of its failure
+ * paths (address fails validation, the REST call fails, the response fails to decode), which puts a
+ * `0x…` wallet address in the space-id field. Callers checked it for truthiness, which a non-empty
+ * address passes, so the address reached the API and both queries came back 400: `Variable
+ * "$memberSpaceId" got invalid value "0x77b3…"; Invalid UUID`. 274 occurrences, and it renders the
+ * governance space pickers empty for exactly the users whose profile lookup already failed.
+ *
+ * Guarded here rather than at each call site: this is the one function that turns a profile's
+ * `spaceId` into UUID-typed queries, and there are four entry points into it (`/home`, `/explore`,
+ * and the activity and explore feed routes). `core/types.ts` gives this instruction for
+ * `Profile.id` for the same reason; `spaceId` carries the same hazard.
+ */
 export const getGovernanceHomeSpaceContext = cache(async (memberSpaceId: string) => {
+  if (!IdUtils.isValid(memberSpaceId)) return EMPTY_CONTEXT;
+
   const [editorIds, memberSpaces] = await Promise.all([
     fetchEditorSpaceIds(memberSpaceId),
     Effect.runPromise(getSpacesWhereMember(memberSpaceId)),

--- a/apps/web/core/types.ts
+++ b/apps/web/core/types.ts
@@ -18,7 +18,16 @@ export type Profile = {
    * the fallback values (wallet addresses) are not valid entity IDs.
    */
   id: string;
-  /** The user's personal space ID (bytes16 hex without 0x prefix) */
+  /**
+   * The user's personal space ID (bytes16 hex without 0x prefix).
+   *
+   * Carries the same hazard as `id` above, and the warning was previously only on `id`:
+   * `fetchProfile` falls back to `defaultProfile(walletAddress, walletAddress)` on every failure
+   * path, so this is a `0x…` wallet address whenever the profile lookup failed. Check
+   * `IdUtils.isValid()` rather than truthiness before passing it anywhere typed as a space or
+   * entity id — a non-empty address passes a truthiness check and then fails at the API as
+   * `Invalid UUID`.
+   */
   spaceId: string;
   name: string | null;
   avatarUrl: string | null;


### PR DESCRIPTION
Fixes GEOGENESIS-48. Found in Sentry, not reported by anyone — **274 occurrences, first seen 30 April, still firing today.**

## What was happening

Two queries on `/home` take `memberSpaceId` as a GraphQL `UUID!`. They were being handed a wallet address:

```
Variable "$memberSpaceId" got invalid value
"0x77b3b79b551d90bfcd7fa12f372ca31626d79dc0"; Invalid UUID
```

`Profile.spaceId` is not guaranteed to be a space id. `fetchProfile` returns `defaultProfile(walletAddress, walletAddress)` on **all three** of its failure paths — address fails validation, REST call fails, response fails to decode — putting a `0x…` address in the space-id field.

`getGovernanceHomeSpaceContext` then checked it for **truthiness**, which a non-empty address passes, and fired both queries.

## Why it matters beyond a log line

Users impacted reads 0 in Sentry because it's a server-side render error, but the user-visible effect is real: the governance space pickers on `/home` come back empty for exactly the users whose profile lookup already failed. The failure compounds instead of degrading — you lose your profile *and* your space list.

## The fix

`IdUtils.isValid` inside `getGovernanceHomeSpaceContext`, not at each call site. That function is the one place a profile's `spaceId` becomes UUID-typed queries, and **four** entry points reach it: `/home`, `/explore`, `/api/activity/feed`, `/api/explore/feed`. Returning an empty context is the same shape those callers already handle for a signed-out user, so nothing downstream needed to change.

## The part I'd flag to reviewers

`core/types.ts` already carried this exact warning:

> Use `IdUtils.isValid()` before passing this as an `author` to the geo-sdk, since the fallback values (wallet addresses) are not valid entity IDs.

…but only on `Profile.id`. `spaceId` inherited the identical fallback behaviour with no warning, which is precisely why a truthiness check looked reasonable to whoever wrote it. The warning is now on both fields — that's the part that stops this recurring somewhere else, more than the guard itself does.

## Tests

Four cases: the wallet address, the empty string, the happy path, and the editor/member dedupe. The last two matter because a guard that simply short-circuits everything would pass a test that only checked "doesn't query with a bad id".

**Verified by deleting the guard**: both new cases fail, both happy-path cases still pass. I checked that rather than assuming it.

- `tsc --noEmit` — 5 errors, all pre-existing in unrelated files (`sort-open-proposals.test.ts`, `use-entity-vote.ts`, `entity-response.test.ts`)

## Follow-up, deliberately not in scope

`core/io/subgraph/fetch-editor-space-ids.ts` interpolates `memberSpaceId` directly into the query string rather than parameterising it. Harmless now that the value is validated upstream, but it's the reason that sibling query produced a differently-shaped error, and it's worth tidying separately.
