### PR TITLE
perf(debates): back off the response-indexing re-check instead of a flat 10s

### DIFF
--- a/apps/web/core/hooks/use-entity-vote.test.tsx
+++ b/apps/web/core/hooks/use-entity-vote.test.tsx
@@ -9,6 +9,7 @@ import { userEntityVotesQueryKey, votedEntityIdsPendingQueryKey } from '~/core/h
 import { entityResponseIndexingQueryKey } from '~/core/responses/entity-response';
 
 import {
+  responseIndexingRetryDelayMs,
   useEntityResponse,
   useEntityResponseIndexingSnapshot,
   useEntityResponseIndexingState,
@@ -697,3 +698,42 @@ function createHarness() {
     ),
   };
 }
+
+/**
+ * GEO-2687. This re-check is on the critical path of a two-person interaction: in the rematch
+ * picker the opponent only learns about a position once this client notices it is indexed and
+ * tells geo-chat, which then emits `debate.claims_changed`. It used to be a flat 10s, which
+ * quantised the opponent's view to 10s steps on top of a write measuring p50 9.9s / p95 48.6s.
+ */
+describe('responseIndexingRetryDelayMs', () => {
+  it('starts fast, so indexing that lands a second later is not charged a full interval', () => {
+    expect(responseIndexingRetryDelayMs(0)).toBe(1_000);
+  });
+
+  it('backs off, so a genuinely slow index does not become a tight poll', () => {
+    expect(responseIndexingRetryDelayMs(1)).toBe(2_000);
+    expect(responseIndexingRetryDelayMs(2)).toBe(4_000);
+    expect(responseIndexingRetryDelayMs(3)).toBe(8_000);
+  });
+
+  it('caps at the old flat interval, so it is never slower than what it replaced', () => {
+    expect(responseIndexingRetryDelayMs(4)).toBe(10_000);
+    expect(responseIndexingRetryDelayMs(50)).toBe(10_000);
+    // 2 ** 50 * 1000 overflows into a number far above the cap; the clamp has to hold there too.
+    expect(Number.isFinite(responseIndexingRetryDelayMs(2000))).toBe(true);
+    expect(responseIndexingRetryDelayMs(2000)).toBe(10_000);
+  });
+
+  it('is monotonic and never below the base', () => {
+    let previous = 0;
+    for (let attempt = 0; attempt <= 12; attempt += 1) {
+      const delay = responseIndexingRetryDelayMs(attempt);
+      expect(delay).toBeGreaterThanOrEqual(Math.max(previous, 1_000));
+      previous = delay;
+    }
+  });
+
+  it('treats a negative attempt as the first one rather than returning a sub-base delay', () => {
+    expect(responseIndexingRetryDelayMs(-1)).toBe(1_000);
+  });
+});

--- a/apps/web/core/hooks/use-entity-vote.ts
+++ b/apps/web/core/hooks/use-entity-vote.ts
@@ -2,7 +2,7 @@
 
 import { hashKey, useMutation, useQueryClient } from '@tanstack/react-query';
 
-import { useCallback, useEffect, useMemo, useSyncExternalStore } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useSyncExternalStore } from 'react';
 
 import { Effect, Either } from 'effect';
 
@@ -21,6 +21,7 @@ import {
   userEntityVotesQueryKey,
   votedEntityIdsPendingQueryKey,
 } from '~/core/hooks/use-user-voted-entity-ids';
+import { withRetryAfterJitter } from '~/core/io/errors/retry-utils';
 import { getUserEntityResponse } from '~/core/io/queries';
 import {
   claimResponseSummariesQueryKeyPrefix,
@@ -65,6 +66,34 @@ export type EntityResponseIndexingState =
   | { status: 'indexed'; pending: PendingEntityResponseIndex; runId: string };
 
 const IDLE_INDEXING_STATE: EntityResponseIndexingState = { status: 'idle', pending: null, runId: null };
+
+/**
+ * How long to wait before re-checking whether a submitted response has been indexed.
+ *
+ * This sits on the critical path of a *two-person* interaction, which is why it is a backoff and
+ * not a flat interval. In the rematch picker, the opponent only learns about a position once this
+ * client notices it is indexed and tells geo-chat (`useClaimResponseIndexedNotifier`), which then
+ * emits `debate.claims_changed`. A flat 10s re-check therefore quantised the opponent's view to
+ * 10s steps *on top of* the write, which measures p50 9.9s / p95 48.6s (`web.write.entity_response`
+ * in Sentry, 200 samples over 7 days) — together landing on the 20-30s in GEO-2687.
+ *
+ * Starting at 1s catches the common case where indexing completes a second or two after the first
+ * check, which the flat interval charged a full 10s for. The cap keeps a genuinely slow index from
+ * turning into a tight poll, and the jitter stops two participants' clients — which submit at
+ * nearly the same moment — from lining their retries up on the same instants.
+ */
+const RESPONSE_INDEXING_RETRY_BASE_MS = 1_000;
+const RESPONSE_INDEXING_RETRY_MAX_MS = 10_000;
+
+/**
+ * The un-jittered delay before re-check number `attempt` (0-based). Exported and kept pure so the
+ * shape of the backoff can be asserted directly, rather than inferred from fake-timer choreography.
+ */
+export function responseIndexingRetryDelayMs(attempt: number): number {
+  const exponential = RESPONSE_INDEXING_RETRY_BASE_MS * 2 ** Math.max(0, attempt);
+  return Math.min(exponential, RESPONSE_INDEXING_RETRY_MAX_MS);
+}
+
 let responseIndexingRunSequence = 0;
 type ResponseSubmissionRun = {
   pending: PendingEntityResponseIndex | null;
@@ -518,11 +547,30 @@ export function useEntityResponse({ entityId, spaceId, responseKind }: UseEntity
     void reconcileResponseIndexing(current.pending, runId);
   }, [indexingQueryKey, queryClient, reconcileResponseIndexing]);
 
+  // Counted per run so a new response starts its backoff from the beginning rather than inheriting
+  // the tail of the previous one. A ref rather than state: this must survive the
+  // delayed -> reconciling -> delayed cycling that re-runs the effect below, without itself
+  // causing a render.
+  const retryAttemptRef = useRef<{ runId: string | null; attempts: number }>({ runId: null, attempts: 0 });
+
   useEffect(() => {
     if (indexingState.status !== 'delayed') return;
-    const retryTimer = window.setTimeout(retryResponseIndexing, 10_000);
+
+    const { runId } = indexingState;
+    if (retryAttemptRef.current.runId !== runId) {
+      retryAttemptRef.current = { runId, attempts: 0 };
+    }
+    const attempt = retryAttemptRef.current.attempts;
+    retryAttemptRef.current.attempts = attempt + 1;
+
+    const retryTimer = window.setTimeout(
+      retryResponseIndexing,
+      withRetryAfterJitter(responseIndexingRetryDelayMs(attempt))
+    );
     return () => window.clearTimeout(retryTimer);
-  }, [indexingState.status, retryResponseIndexing]);
+    // `runId` is a dependency so a second response submitted while the first is still delayed
+    // reschedules against its own attempt count instead of the previous run's.
+  }, [indexingState.status, indexingState.runId, retryResponseIndexing]);
 
   const optimisticResponse =
     (indexingState.status !== 'reconciling' && indexingState.status !== 'delayed') || !indexingState.pending


### PR DESCRIPTION
Part of GEO-2687. **Not the whole fix** — the dominant cost needs a product decision, which is on the ticket. This removes the part stacked on top of it.

## Measured first, in Sentry

`web.write.entity_response`, 200 samples over 7 days:

| p50 | avg | p95 | max |
|---|---|---|---|
| **9.9s** | 16.2s | **48.6s** | 67.1s |

A trace of the worst case confirms it is *entirely* `sendTransaction`:

```
web.write.entity_response [67139ms]
   └─ web.write.sendTransaction [67137ms]
```

So the delay is on the **write side**. A position is an on-chain claim response — it doesn't exist to be pushed until the transaction lands.

## What this PR changes

The opponent learns about a position only once *this* client notices it has been indexed and calls `notifyClaimResponseIndexed`, which makes geo-chat emit `debate.claims_changed`. That notice was gated on a **flat 10s re-check**, so the opponent's view was quantised into 10s steps *on top of* the ~10s write. Indexing that completed one second after a failed check still cost the full interval.

Now `1s → 2s → 4s → 8s`, capped at 10s, through the existing `withRetryAfterJitter`. Two properties worth noting:

- **The cap means this is never slower than what it replaced.** Worst case is identical; the win is entirely in the fast start.
- **The jitter matters here specifically** because both participants submit at nearly the same moment, so without it their re-checks line up on the same instants.

Attempts are counted per `runId` in a ref, so a second response submitted while the first is still delayed backs off on its own schedule rather than inheriting the previous run's tail. A ref rather than state because the effect re-runs on the `delayed → reconciling → delayed` cycling and must not trigger a render for it.

## What I deliberately did *not* change

I set out to shorten `PARTICIPANT_POSITIONS_POLL_MS` (20s) and **checked first, which turned out to matter**: the rematch picker already holds gateway scopes on every space in all three lists *plus* both participants' personal spaces — there's a comment there explaining it was written for exactly this scenario, the opponent taking their first position. So `debate.claims_changed` reaches the picker for essentially any position the opponent adds, and the 20s poll is a fallback that rarely binds.

Tightening it would have added request volume against the wrong constraint and looked like progress.

## Tests

The backoff shape is a pure exported function, so it's asserted directly rather than through fake-timer choreography — five cases covering the fast start, the growth, the cap (including integer-overflow attempts), monotonicity, and a negative attempt.

**Verified they catch a regression** rather than assuming: restoring the flat 10s base fails 4 of them; removing the cap fails 1.

- `vitest core/hooks core/debates core/responses` — **921 passed, 83 files** (19 pre-existing entity-vote tests unaffected)
- `tsc --noEmit` — 5 errors, all pre-existing in unrelated files; the `use-entity-vote` one is the known `geo.responses` typing issue, line number shifted only

## Still open

The write dominates, so this makes the interaction better but not synchronous. The only way to make it feel immediate is to stop waiting for the chain before telling the opponent — push a *pending* position at submit time and firm it up when it lands. That's a product call, described on the ticket.

Also flagged there: `sendTransaction` has no internal instrumentation, so in the slow cases we can't separate submission from confirmation-waiting. `submitUserOperation` p95 is 11.5s while its parents reach 42–49s, which points at confirmation waiting — but that's inference from aggregates and worth instrumenting rather than assuming.
