### PR TITLE
feat(debates): add Featured to the claims tab and stand it in for Recommended

### DIFF
--- a/apps/web/app/space/[id]/(space)/claims/claims-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/claims/claims-page-client.tsx
@@ -5,13 +5,13 @@ import * as React from 'react';
 import cx from 'classnames';
 
 import { buildClaimDraft } from '~/core/claims/claim-draft';
-import { CLAIM_IS_FACTUAL_PROPERTY_ID, CLAIM_TYPE_ID, TOPICS_PROPERTY_ID, TOPIC_TYPE_ID } from '~/core/claims/ontology';
+import { CLAIM_TYPE_ID, TOPICS_PROPERTY_ID, TOPIC_TYPE_ID } from '~/core/claims/ontology';
 import { isClaimPublishedInSpace } from '~/core/claims/publish';
+import { claimResponseKind } from '~/core/claims/response-kind';
 import type { DebateClaim } from '~/core/debates/api';
 import { ClaimDebateReadiness } from '~/core/debates/claim-debate-readiness';
 import { DebateEntityResponseControls } from '~/core/debates/debate-entity-response-controls';
 import { useDebateClaims } from '~/core/debates/hooks';
-import { uuidToHex } from '~/core/id/normalize';
 import {
   ClaimResponseBatchBoundary,
   useClaimResponseSummaryBatch,
@@ -22,7 +22,6 @@ import { useQueryEntities } from '~/core/sync/use-store';
 import type { Entity, Relation } from '~/core/types';
 
 import { Button } from '~/design-system/button';
-import { getChecked } from '~/design-system/checkbox';
 import { Plus } from '~/design-system/icons/plus';
 import { SelectEntityCompact, type SelectEntityCompactResult } from '~/design-system/select-entity-compact';
 import { Text } from '~/design-system/text';
@@ -407,14 +406,4 @@ function RelationChipGroup({
 
 function relationsForProperty(relations: Relation[], propertyId: string): Relation[] {
   return relations.filter(relation => relation.type.id === propertyId && relation.isDeleted !== true);
-}
-
-function claimResponseKind(claim: Entity, spaceId: string): 'stance' | 'veracity' {
-  const isFactual = claim.values.find(
-    value =>
-      value.isDeleted !== true &&
-      uuidToHex(value.spaceId) === uuidToHex(spaceId) &&
-      uuidToHex(value.property.id) === uuidToHex(CLAIM_IS_FACTUAL_PROPERTY_ID)
-  )?.value;
-  return getChecked(isFactual) === true ? 'veracity' : 'stance';
 }

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
@@ -49,6 +49,8 @@ const mocks = vi.hoisted(() => ({
   entityQueries: [] as Array<{ search: string | null; spaceId: string | null }>,
   /** Every id list the opponent's claims were hydrated with, in render order. */
   entityIdLookups: [] as string[][],
+  featuredClaims: [] as Array<{ claimEntityId: string; spaceId: string; name: string; description: string | null }>,
+  featuredCatalogLoading: false,
   entityQueryHasNextPage: false,
   /** The hub's claims query (the All tab) is still in flight. */
   entityQueryLoading: false,
@@ -190,6 +192,22 @@ vi.mock('~/core/debates/debate-gateway', () => ({
 
 vi.mock('~/core/debates/debate-entry-intent', () => ({
   markEnteringDebate: (debateId: string) => mocks.markEnteringDebate(debateId),
+}));
+
+// GEO-2683. Featured stands in for Recommended when no curator page exists, which is what most of
+// these suites run under — so without this every case here would reach the graph for the tag.
+vi.mock('~/core/debates/featured-claims', async importOriginal => ({
+  ...(await importOriginal<typeof import('~/core/debates/featured-claims')>()),
+  useFeaturedClaims: (enabled: boolean) => {
+    const claims = enabled ? mocks.featuredClaims : [];
+    return {
+      claims,
+      claimIds: claims.map(claim => claim.claimEntityId),
+      isLoading: enabled && mocks.featuredCatalogLoading,
+      error: null,
+      refetch: vi.fn(),
+    };
+  },
 }));
 
 // The opponent's claims are hydrated from the graph by id, through the picker's narrow projection.
@@ -343,6 +361,8 @@ beforeEach(() => {
   mocks.openSidePanel.mockReset();
   mocks.entityQueries.length = 0;
   mocks.entityIdLookups.length = 0;
+  mocks.featuredClaims = [];
+  mocks.featuredCatalogLoading = false;
   mocks.entityQueryHasNextPage = false;
   mocks.entityQueryLoading = false;
   mocks.entityHydrationLoading = false;
@@ -700,6 +720,86 @@ describe('DebateRematchPageClient', () => {
     expect(screen.getByRole('button', { name: /Salina’s positions/ })).toBeInTheDocument();
   });
 
+  // GEO-2683. Featured stands in for Recommended, so it takes that slot rather than adding a fourth
+  // tab: it exists precisely when a curated page for this pairing does not.
+  describe('Featured, in place of Recommended', () => {
+    const FEATURED = '019fedb8-6ca7-7f94-8a77-8cd3be5faa64';
+
+    function featuredEntity(id = FEATURED, name = 'A featured claim') {
+      return { ...publishedEntity(id, name), spaces: [SPACE_2] };
+    }
+
+    function featuredTag(id = FEATURED, name = 'A featured claim', spaceId = SPACE_2) {
+      return { claimEntityId: id, spaceId, name, description: null };
+    }
+
+    it('takes Recommended’s slot when nothing is curated for this pairing', () => {
+      mocks.featuredClaims = [featuredTag()];
+      mocks.entities = [sharedEntity(), featuredEntity()];
+      render(<DebateRematchPageClient sessionId="rematch-1" />);
+
+      expect(screen.getByRole('button', { name: 'Featured' })).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Recommended' })).toBeNull();
+
+      fireEvent.click(screen.getByRole('button', { name: 'Featured' }));
+      expect(screen.getByText('A featured claim')).toBeInTheDocument();
+    });
+
+    // A curator's page for this exact pairing beats a tag anyone's space can carry, and the two
+    // share one slot — so Featured is not offered as a second-best alongside it.
+    it('stays out of the way when a curator has a page for this pairing', () => {
+      mocks.recommendedSections = [{ id: 'block-1', name: 'Geopolitics & chips', claimIds: [CLAIM_SHARED] }];
+      mocks.recommendedEntities = [sharedEntity()];
+      mocks.featuredClaims = [featuredTag()];
+      mocks.entities = [sharedEntity(), featuredEntity()];
+      render(<DebateRematchPageClient sessionId="rematch-1" />);
+
+      expect(screen.getByRole('button', { name: 'Recommended' })).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Featured' })).toBeNull();
+    });
+
+    // Unlike Recommended, Featured is a tag any space can carry, so it fans out across the corpus
+    // the way the All tab does — and is bounded the same way.
+    it('drops tagged claims from spaces outside the viewer’s allowed set', async () => {
+      mocks.spaceAllowlist = new Set([SPACE_1.replace(/-/g, '')]);
+      mocks.featuredClaims = [featuredTag()];
+      mocks.entities = [sharedEntity(), featuredEntity()];
+      render(<DebateRematchPageClient sessionId="rematch-1" />);
+
+      fireEvent.click(screen.getByRole('button', { name: 'Featured' }));
+
+      // Awaited because the tab's content swaps with a transition rather than on the same tick.
+      await waitFor(() =>
+        expect(screen.getByText('No featured claims are available to debate yet.')).toBeInTheDocument()
+      );
+      expect(screen.queryByText('A featured claim')).toBeNull();
+    });
+
+    // The viewer is not put on the tab until it has something, on the rule Recommended already
+    // follows. Landing on a tab that then settles empty is worse than never starting there.
+    it('keeps the viewer off the slot while the tag lookup runs', () => {
+      mocks.featuredCatalogLoading = true;
+      render(<DebateRematchPageClient sessionId="rematch-1" />);
+
+      expect(screen.getByRole('button', { name: 'Featured' })).toBeInTheDocument();
+      // Still the opponent's tab, which is where a picker with no curated page opens.
+      expect(screen.getByText('A claim both participants chose')).toBeInTheDocument();
+    });
+
+    it('says nothing is featured rather than nothing is debatable', async () => {
+      mocks.featuredClaims = [featuredTag()];
+      // Tagged, but the graph has no entity for it — so the tab exists with nothing on it.
+      mocks.entities = [sharedEntity()];
+      render(<DebateRematchPageClient sessionId="rematch-1" />);
+
+      fireEvent.click(screen.getByRole('button', { name: 'Featured' }));
+
+      await waitFor(() =>
+        expect(screen.getByText('No featured claims are available to debate yet.')).toBeInTheDocument()
+      );
+    });
+  });
+
   it('opens on Recommended when a curator has, grouping each block into its own section', () => {
     mocks.recommendedSections = [
       { id: 'block-1', name: 'Geopolitics & chips', claimIds: [CLAIM_SHARED] },
@@ -755,7 +855,9 @@ describe('DebateRematchPageClient', () => {
     expect(screen.getAllByRole('switch', { name: 'Ready to debate this claim' })).toHaveLength(2);
     expect(mocks.perSpaceReadinessGroups.every(groups => groups.length === 0)).toBe(true);
     // Hydrated by id — exactly the claims the graph named, nothing paged.
-    expect(mocks.entityIdLookups.at(-1)).toEqual([CLAIM_SHARED, FRESH]);
+    // Empty lookups skipped: the Featured slot hydrates through the same hook and asks for nothing
+    // when no claim is tagged, which would otherwise be the last call recorded.
+    expect(mocks.entityIdLookups.filter(ids => ids.length > 0).at(-1)).toEqual([CLAIM_SHARED, FRESH]);
     // And the graph was asked about exactly these two people.
     expect(mocks.positionParticipants.at(-1)).toEqual(['profile-local', 'profile-remote']);
   });

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
@@ -435,6 +435,7 @@ describe('DebateRematchPageClient', () => {
         <DebateRematchPageClient sessionId="rematch-1" />
       </StrictMode>
     );
+    await showOpponentClaims();
 
     expect(await screen.findByText('A claim both participants chose')).toBeInTheDocument();
     await new Promise(resolve => window.setTimeout(resolve, 0));
@@ -443,6 +444,7 @@ describe('DebateRematchPageClient', () => {
 
   it('does not end a browsing rematch when the page unmounts', async () => {
     const { unmount } = render(<DebateRematchPageClient sessionId="rematch-1" />);
+    await showOpponentClaims();
 
     unmount();
     await new Promise(resolve => window.setTimeout(resolve, 0));
@@ -450,7 +452,7 @@ describe('DebateRematchPageClient', () => {
     expect(mocks.leaveMutate).not.toHaveBeenCalled();
   });
 
-  it('ends a browsing rematch only through the explicit leave action', () => {
+  it('ends a browsing rematch only through the explicit leave action', async () => {
     render(<DebateRematchPageClient sessionId="rematch-1" />);
 
     fireEvent.click(screen.getByRole('button', { name: 'Leave debate' }));
@@ -458,7 +460,7 @@ describe('DebateRematchPageClient', () => {
     expect(mocks.leaveMutate).toHaveBeenCalledOnce();
   });
 
-  it('returns a profile challenge to the page before the debate flow after leaving', () => {
+  it('returns a profile challenge to the page before the debate flow after leaving', async () => {
     vi.spyOn(window.history, 'length', 'get').mockReturnValue(2);
     const endedSession = session({ source_debate_id: null, status: 'ended' });
     mocks.session = session({ source_debate_id: null });
@@ -475,7 +477,7 @@ describe('DebateRematchPageClient', () => {
     expect(mocks.replace).not.toHaveBeenCalledWith(`/space/${SPACE_1}/debates`);
   });
 
-  it('preserves the debates-page exit for rematches started from a prior debate', () => {
+  it('preserves the debates-page exit for rematches started from a prior debate', async () => {
     const endedSession = session({ status: 'ended' });
     mocks.leaveMutate.mockImplementation(
       (_input: undefined, options: { onSuccess?: (ended: DebateRematchSession) => void }) => {
@@ -490,7 +492,7 @@ describe('DebateRematchPageClient', () => {
     expect(mocks.back).not.toHaveBeenCalled();
   });
 
-  it('returns a debate-again session to the page that opened the flow', () => {
+  it('returns a debate-again session to the page that opened the flow', async () => {
     rememberDebateReturnDestination('/space/my-space?tab=activity#latest');
     const endedSession = session({ status: 'ended' });
     mocks.leaveMutate.mockImplementation(
@@ -508,17 +510,18 @@ describe('DebateRematchPageClient', () => {
 
   // The pin this used to assert is gone (GEO-2647); what matters is that both claims are listed
   // and a shared preference is still the one you can act on.
-  it("lists the session's own claims alongside published ones and enables opposing requests", () => {
+  it("lists the session's own claims alongside published ones and enables opposing requests", async () => {
     render(<DebateRematchPageClient sessionId="rematch-1" />);
-    showAllClaims();
+    await showAllClaims();
 
     expect(screen.getByText('A claim both participants chose')).toBeInTheDocument();
     expect(screen.getByText('A newly published claim')).toBeInTheDocument();
     expect(screen.getAllByRole('button', { name: 'Request debate' })[0]).toBeEnabled();
   });
 
-  it('renders active semantic response buttons with holder avatars', () => {
+  it('renders active semantic response buttons with holder avatars', async () => {
     render(<DebateRematchPageClient sessionId="rematch-1" />);
+    await showOpponentClaims();
 
     const sharedClaimCard = screen.getByText('A claim both participants chose').closest('article');
     expect(sharedClaimCard).not.toBeNull();
@@ -536,7 +539,7 @@ describe('DebateRematchPageClient', () => {
     ).not.toBeNull();
   });
 
-  it('changes responses through the semantic buttons without rendering a second response area', () => {
+  it('changes responses through the semantic buttons without rendering a second response area', async () => {
     mocks.claims = [
       {
         ...sharedClaim(),
@@ -548,7 +551,7 @@ describe('DebateRematchPageClient', () => {
     ];
 
     render(<DebateRematchPageClient sessionId="rematch-1" />);
-    showAllClaims();
+    await showAllClaims();
 
     const sharedClaimCard = screen.getByText('A claim both participants chose').closest('article');
     expect(sharedClaimCard).not.toBeNull();
@@ -562,7 +565,7 @@ describe('DebateRematchPageClient', () => {
     expect(within(syntheticClaimCard!).getByRole('button', { name: /^Disagree/ })).toBeEnabled();
   });
 
-  it('uses Verify and Dispute for factual claims', () => {
+  it('uses Verify and Dispute for factual claims', async () => {
     mocks.claims = [{ ...sharedClaim(), response_kind: 'veracity' }];
     mocks.positions = [
       { ...position('profile-local', CLAIM_SHARED, SPACE_1, true), responseKind: 'veracity' },
@@ -570,6 +573,7 @@ describe('DebateRematchPageClient', () => {
     ];
 
     render(<DebateRematchPageClient sessionId="rematch-1" />);
+    await showOpponentClaims();
 
     const claimCard = screen.getByText('A claim both participants chose').closest('article');
     expect(claimCard).not.toBeNull();
@@ -577,7 +581,7 @@ describe('DebateRematchPageClient', () => {
     expect(within(claimCard!).getByRole('button', { name: /^Dispute/ })).toBeEnabled();
   });
 
-  it('shows authoritative stance labels in the incoming request dialog and preserves rematch actions', () => {
+  it('shows authoritative stance labels in the incoming request dialog and preserves rematch actions', async () => {
     mocks.session = session({
       status: 'request_pending',
       request: {
@@ -623,7 +627,7 @@ describe('DebateRematchPageClient', () => {
     expect(document.documentElement.style.overflow).toBe('');
   });
 
-  it('falls back to Agree and Disagree for incoming requests without response metadata', () => {
+  it('falls back to Agree and Disagree for incoming requests without response metadata', async () => {
     mocks.session = session({
       status: 'request_pending',
       request: {
@@ -647,7 +651,7 @@ describe('DebateRematchPageClient', () => {
     expect(within(within(dialog).getByText('Salina').parentElement!).getByText('Disagree')).toBeInTheDocument();
   });
 
-  it('disables debate requests while a rematch request is pending', () => {
+  it('disables debate requests while a rematch request is pending', async () => {
     mocks.session = session({
       status: 'request_pending',
       request: {
@@ -668,13 +672,13 @@ describe('DebateRematchPageClient', () => {
     });
 
     render(<DebateRematchPageClient sessionId="rematch-1" />);
-    showAllClaims();
+    await showAllClaims();
 
     expect(screen.getByRole('button', { name: 'Requesting…' })).toBeDisabled();
     expect(screen.getAllByRole('button', { name: /^(Agree|Disagree)/ })).toHaveLength(4);
   });
 
-  it('explains when response changes cancel a rematch request', () => {
+  it('explains when response changes cancel a rematch request', async () => {
     mocks.session = session({
       request: {
         id: 'request-1',
@@ -701,28 +705,35 @@ describe('DebateRematchPageClient', () => {
     ).toBeInTheDocument();
   });
 
-  it('opens on the opponent’s positions, named after them and counted', () => {
+  // GEO-2683. Claims is the landing tab now, whatever its source turns out to be — the strip no
+  // longer reshuffles as the curated lookup lands, because which claims Claims shows is the source
+  // menu's business.
+  it('opens on Claims, with the opponent’s positions counted alongside', async () => {
     render(<DebateRematchPageClient sessionId="rematch-1" />);
 
+    expect(screen.getByRole('button', { name: 'Claims' })).toHaveAttribute('aria-selected', 'true');
     const tab = screen.getByRole('button', { name: /Salina’s positions/ });
-    // Only the shared claim carries a side from Salina.
+    // Only the shared claim carries a side from Salina, and the badge says so from the other tab.
     expect(within(tab).getByText('1')).toBeInTheDocument();
+
+    await showOpponentClaims();
+
     expect(screen.getByText('A claim both participants chose')).toBeInTheDocument();
     expect(screen.queryByText('A newly published claim')).toBeNull();
   });
 
   // A curator's page for this pairing is the best thing to land on; without one the tab has no
   // reason to exist.
-  it('hides the Recommended tab when nothing is curated for this pairing', () => {
+  it('hides the Recommended tab when nothing is curated for this pairing', async () => {
     render(<DebateRematchPageClient sessionId="rematch-1" />);
 
     expect(screen.queryByRole('button', { name: 'Recommended' })).toBeNull();
     expect(screen.getByRole('button', { name: /Salina’s positions/ })).toBeInTheDocument();
   });
 
-  // GEO-2683. Featured stands in for Recommended, so it takes that slot rather than adding a fourth
-  // tab: it exists precisely when a curated page for this pairing does not.
-  describe('Featured, in place of Recommended', () => {
+  // GEO-2683. Recommended, Featured and the whole corpus are three answers to one question --
+  // "which claims?" -- so they are a menu on the Claims tab rather than tabs of their own.
+  describe('the Claims source menu', () => {
     const FEATURED = '019fedb8-6ca7-7f94-8a77-8cd3be5faa64';
 
     function featuredEntity(id = FEATURED, name = 'A featured claim') {
@@ -733,74 +744,85 @@ describe('DebateRematchPageClient', () => {
       return { claimEntityId: id, spaceId, name, description: null };
     }
 
-    it('takes Recommended’s slot when nothing is curated for this pairing', () => {
+    function curatedPage() {
+      mocks.recommendedSections = [{ id: 'block-1', name: 'Geopolitics & chips', claimIds: [CLAIM_SHARED] }];
+      mocks.recommendedEntities = [sharedEntity()];
+    }
+
+    it('opens on Featured when no curator has a page for this pairing', async () => {
       mocks.featuredClaims = [featuredTag()];
       mocks.entities = [sharedEntity(), featuredEntity()];
       render(<DebateRematchPageClient sessionId="rematch-1" />);
 
+      expect(screen.getByRole('button', { name: 'Claims' })).toHaveAttribute('aria-selected', 'true');
       expect(screen.getByRole('button', { name: 'Featured' })).toBeInTheDocument();
-      expect(screen.queryByRole('button', { name: 'Recommended' })).toBeNull();
-
-      fireEvent.click(screen.getByRole('button', { name: 'Featured' }));
       expect(screen.getByText('A featured claim')).toBeInTheDocument();
     });
 
-    // A curator's page for this exact pairing beats a tag anyone's space can carry, and the two
-    // share one slot — so Featured is not offered as a second-best alongside it.
-    it('stays out of the way when a curator has a page for this pairing', () => {
-      mocks.recommendedSections = [{ id: 'block-1', name: 'Geopolitics & chips', claimIds: [CLAIM_SHARED] }];
-      mocks.recommendedEntities = [sharedEntity()];
+    // A curator's page for this exact pairing beats a tag anyone's space can carry.
+    it('opens on Recommended when a curator has a page, keeping Featured a pick away', async () => {
+      curatedPage();
       mocks.featuredClaims = [featuredTag()];
       mocks.entities = [sharedEntity(), featuredEntity()];
       render(<DebateRematchPageClient sessionId="rematch-1" />);
 
-      expect(screen.getByRole('button', { name: 'Recommended' })).toBeInTheDocument();
-      expect(screen.queryByRole('button', { name: 'Featured' })).toBeNull();
+      expect(screen.getByRole('heading', { name: 'Geopolitics & chips' })).toBeInTheDocument();
+
+      await chooseSource('Featured');
+
+      expect(screen.getByText('A featured claim')).toBeInTheDocument();
+      expect(screen.queryByRole('heading', { name: 'Geopolitics & chips' })).toBeNull();
+    });
+
+    // A fixed order, so a source that appears doesn't reshuffle the ones already in the menu.
+    it('offers the sources in a fixed order, Recommended first', async () => {
+      curatedPage();
+      render(<DebateRematchPageClient sessionId="rematch-1" />);
+
+      openSourceMenu();
+
+      const labels = ['Recommended', 'Featured', 'All claims'];
+      const options = screen.getAllByRole('button').filter(button => labels.includes(button.textContent?.trim() ?? ''));
+      // The trigger carries the current label too, and it is rendered ahead of the options.
+      expect(options.slice(-3).map(button => button.textContent?.trim())).toEqual(labels);
+    });
+
+    it('leaves Recommended out of the menu when there is no curated page', async () => {
+      render(<DebateRematchPageClient sessionId="rematch-1" />);
+
+      openSourceMenu();
+
+      expect(screen.queryByRole('button', { name: 'Recommended' })).toBeNull();
+      expect(screen.getByRole('button', { name: 'All claims' })).toBeInTheDocument();
     });
 
     // Unlike Recommended, Featured is a tag any space can carry, so it fans out across the corpus
-    // the way the All tab does — and is bounded the same way.
+    // the way All claims does -- and is bounded the same way.
     it('drops tagged claims from spaces outside the viewer’s allowed set', async () => {
       mocks.spaceAllowlist = new Set([SPACE_1.replace(/-/g, '')]);
       mocks.featuredClaims = [featuredTag()];
       mocks.entities = [sharedEntity(), featuredEntity()];
       render(<DebateRematchPageClient sessionId="rematch-1" />);
 
-      fireEvent.click(screen.getByRole('button', { name: 'Featured' }));
+      await settleTabSwap();
 
-      // Awaited because the tab's content swaps with a transition rather than on the same tick.
-      await waitFor(() =>
-        expect(screen.getByText('No featured claims are available to debate yet.')).toBeInTheDocument()
-      );
       expect(screen.queryByText('A featured claim')).toBeNull();
-    });
-
-    // The viewer is not put on the tab until it has something, on the rule Recommended already
-    // follows. Landing on a tab that then settles empty is worse than never starting there.
-    it('keeps the viewer off the slot while the tag lookup runs', () => {
-      mocks.featuredCatalogLoading = true;
-      render(<DebateRematchPageClient sessionId="rematch-1" />);
-
-      expect(screen.getByRole('button', { name: 'Featured' })).toBeInTheDocument();
-      // Still the opponent's tab, which is where a picker with no curated page opens.
-      expect(screen.getByText('A claim both participants chose')).toBeInTheDocument();
+      expect(screen.getByText('No featured claims are available to debate yet.')).toBeInTheDocument();
     });
 
     it('says nothing is featured rather than nothing is debatable', async () => {
       mocks.featuredClaims = [featuredTag()];
-      // Tagged, but the graph has no entity for it — so the tab exists with nothing on it.
+      // Tagged, but the graph has no entity for it -- so the source has nothing to show.
       mocks.entities = [sharedEntity()];
       render(<DebateRematchPageClient sessionId="rematch-1" />);
 
-      fireEvent.click(screen.getByRole('button', { name: 'Featured' }));
+      await settleTabSwap();
 
-      await waitFor(() =>
-        expect(screen.getByText('No featured claims are available to debate yet.')).toBeInTheDocument()
-      );
+      expect(screen.getByText('No featured claims are available to debate yet.')).toBeInTheDocument();
     });
   });
 
-  it('opens on Recommended when a curator has, grouping each block into its own section', () => {
+  it('opens on Recommended when a curator has, grouping each block into its own section', async () => {
     mocks.recommendedSections = [
       { id: 'block-1', name: 'Geopolitics & chips', claimIds: [CLAIM_SHARED] },
       { id: 'block-2', name: 'Open weight AI', claimIds: [CLAIM_MORE] },
@@ -818,7 +840,7 @@ describe('DebateRematchPageClient', () => {
     expect(screen.getByText('A newly published claim')).toBeInTheDocument();
   });
 
-  it('collapses a section without touching the others', () => {
+  it('collapses a section without touching the others', async () => {
     mocks.recommendedSections = [
       { id: 'block-1', name: 'Geopolitics & chips', claimIds: [CLAIM_SHARED] },
       { id: 'block-2', name: 'Open weight AI', claimIds: [CLAIM_MORE] },
@@ -835,7 +857,7 @@ describe('DebateRematchPageClient', () => {
   // The opponent's tab is what the graph says they have responded to, not what geo-chat has a
   // session row for. A side they took that geo-chat hasn't heard about yet still lists — and the
   // graph's list is one query, so it doesn't wait on the allowlist or any geo-chat lookup.
-  it('lists a claim the opponent answered that geo-chat has no row for', () => {
+  it('lists a claim the opponent answered that geo-chat has no row for', async () => {
     const FRESH = '019fedb7-5b96-7e83-9f66-7bc2ad4f9953';
     mocks.savedClaims = [];
     mocks.claims = [];
@@ -845,6 +867,7 @@ describe('DebateRematchPageClient', () => {
       position('profile-remote', FRESH, SPACE_1, true),
     ];
     render(<DebateRematchPageClient sessionId="rematch-1" />);
+    await showOpponentClaims();
 
     expect(screen.getByText('A claim Salina just answered')).toBeInTheDocument();
     expect(screen.getByText('A claim both participants chose')).toBeInTheDocument();
@@ -882,7 +905,7 @@ describe('DebateRematchPageClient', () => {
   // there — offering it implies there are more recommendations waiting.
   // Nor on the opponent's tab: that list is the session's own from geo-chat, and paging the graph-wide
   // scan from it walked the corpus hoping a browsed claim happened to carry their side.
-  it('keeps the paging sentinel off the Recommended and opponent tabs, placing it on All', () => {
+  it('keeps the paging sentinel off the Recommended and opponent tabs, placing it on All', async () => {
     mocks.entityQueryHasNextPage = true;
     mocks.recommendedSections = [{ id: 'block-1', name: 'Geopolitics & chips', claimIds: [CLAIM_SHARED] }];
     render(<DebateRematchPageClient sessionId="rematch-1" />);
@@ -891,15 +914,15 @@ describe('DebateRematchPageClient', () => {
     fireEvent.click(screen.getByRole('button', { name: /Salina’s positions/ }));
     expect(screen.queryByTestId('claims-scroll-sentinel')).toBeNull();
 
-    showAllClaims();
+    await showAllClaims();
     expect(screen.getByTestId('claims-scroll-sentinel')).toBeInTheDocument();
   });
 
   // No button to press any more; reaching the end of the list is what asks for the next page.
-  it('does not offer a Keep looking button while the sentinel is still paging', () => {
+  it('does not offer a Keep looking button while the sentinel is still paging', async () => {
     mocks.entityQueryHasNextPage = true;
     render(<DebateRematchPageClient sessionId="rematch-1" />);
-    showAllClaims();
+    await showAllClaims();
 
     expect(screen.queryByRole('button', { name: 'Keep looking' })).toBeNull();
   });
@@ -907,10 +930,10 @@ describe('DebateRematchPageClient', () => {
   // The picker pages by cursor rather than through an infinite query, so the sentinel firing has
   // to be shown to advance that cursor — a sentinel that renders but is wired to nothing would
   // satisfy every other test here.
-  it('asks the hub query for its next page when the end of the list scrolls into view', () => {
+  it('asks the hub query for its next page when the end of the list scrolls into view', async () => {
     mocks.entityQueryHasNextPage = true;
     render(<DebateRematchPageClient sessionId="rematch-1" />);
-    showAllClaims();
+    await showAllClaims();
 
     expect(mocks.fetchNextPage).not.toHaveBeenCalled();
 
@@ -919,16 +942,16 @@ describe('DebateRematchPageClient', () => {
     expect(mocks.fetchNextPage).toHaveBeenCalledOnce();
   });
 
-  it('leaves the sentinel out once there is no page left to fetch', () => {
+  it('leaves the sentinel out once there is no page left to fetch', async () => {
     render(<DebateRematchPageClient sessionId="rematch-1" />);
-    showAllClaims();
+    await showAllClaims();
 
     expect(screen.queryByTestId('claims-scroll-sentinel')).toBeNull();
   });
 
   // Curated claims are picked by hand, so they can be ones the browsed pages never reach. They
   // have to land in the same pool, or a recommendation would head a section with nothing under it.
-  it('renders a curated claim the browsed pages never returned', () => {
+  it('renders a curated claim the browsed pages never returned', async () => {
     const CURATED = '019fedb59a8f7d728e556ab19c3e8841';
     mocks.recommendedSections = [{ id: 'block-1', name: 'Geopolitics & chips', claimIds: [CURATED] }];
     mocks.recommendedEntities = [publishedEntity(CURATED, 'A curated claim from elsewhere')];
@@ -941,7 +964,7 @@ describe('DebateRematchPageClient', () => {
 
   // The browsed scan reads every Claim in the graph and is the slowest thing here. The curated tab
   // draws nothing from it, so waiting on it was pure delay.
-  it('shows curated sections without waiting on the browsed claim scan', () => {
+  it('shows curated sections without waiting on the browsed claim scan', async () => {
     mocks.entityQueryLoading = true;
     // The browsed half of the session lookup is still in flight too — the curated half is not,
     // and only stays independent while the two are asked for separately.
@@ -959,9 +982,10 @@ describe('DebateRematchPageClient', () => {
   });
 
   // The session's own claims arrive in one round trip; they shouldn't sit behind the scan either.
-  it('shows the opponent’s claims without waiting on the browsed claim scan', () => {
+  it('shows the opponent’s claims without waiting on the browsed claim scan', async () => {
     mocks.entityQueryLoading = true;
     render(<DebateRematchPageClient sessionId="rematch-1" />);
+    await showOpponentClaims();
 
     fireEvent.click(screen.getByRole('button', { name: /Salina’s positions/ }));
 
@@ -971,7 +995,7 @@ describe('DebateRematchPageClient', () => {
   // GEO-2656. The badge counted a list that is empty until three dependent round trips land, so it
   // opened on `0` — which is not a placeholder but a claim, and a wrong one, on the one tab that is
   // about the opponent's positions.
-  it('counts nothing until the opponent’s positions are actually known', () => {
+  it('counts nothing until the opponent’s positions are actually known', async () => {
     // First load: in flight with nothing back yet. Both halves matter — the count is only unknown
     // while the query is running *and* has produced no rows.
     mocks.positions = [];
@@ -985,7 +1009,7 @@ describe('DebateRematchPageClient', () => {
   // The count is derived from ids that come *from* positions, so while that query is in flight the
   // id list is empty and the two claim lookups are disabled rather than loading. Nothing downstream
   // reports as pending, which is why the badge has to consult the positions query itself.
-  it('shows the count once it is known', () => {
+  it('shows the count once it is known', async () => {
     mocks.positionsLoading = false;
     render(<DebateRematchPageClient sessionId="rematch-1" />);
 
@@ -996,7 +1020,7 @@ describe('DebateRematchPageClient', () => {
   // A new response from the opponent restarts the lookups while `useLastSettled` still holds a list
   // that is right for every claim already on it. Dropping back to a skeleton would flicker the badge
   // on precisely the event that should be invisible.
-  it('keeps showing a known count while a refetch is in flight', () => {
+  it('keeps showing a known count while a refetch is in flight', async () => {
     const { rerender } = render(<DebateRematchPageClient sessionId="rematch-1" />);
     expect(screen.getByRole('button', { name: /Salina’s positions/ })).toHaveTextContent('1');
 
@@ -1009,53 +1033,49 @@ describe('DebateRematchPageClient', () => {
     expect(screen.getByRole('button', { name: /Salina’s positions/ })).toHaveTextContent('1');
   });
 
-  // The opponent's claims arrive in one round trip; the curated lookup is three in sequence. The
-  // viewer lands on what is ready, and a curated page arriving afterwards adds its tab rather than
-  // moving them onto it — being moved once the lookup settles is worse than a tab appearing.
-  it('lands on the opponent’s positions while the curated lookup is still running, and stays put', () => {
+  // Until the curated lookup settles there is no telling "no curator page" from "not yet", and the
+  // default source turns on exactly that. So the list waits rather than showing Featured and
+  // swapping it for Recommended a moment later.
+  it('waits on the curated lookup rather than defaulting to Featured and swapping', async () => {
     mocks.recommendedLoading = true;
     const { rerender } = render(<DebateRematchPageClient sessionId="rematch-1" />);
 
-    expect(screen.getByRole('button', { name: /Salina’s positions/ })).toHaveAttribute('aria-selected', 'true');
-    expect(screen.getByRole('button', { name: 'Recommended' })).toHaveAttribute('aria-selected', 'false');
-    expect(screen.getByText('A claim both participants chose')).toBeInTheDocument();
-
-    mocks.recommendedLoading = false;
-    mocks.recommendedSections = [{ id: 'block-1', name: 'Geopolitics & chips', claimIds: [CLAIM_MORE] }];
-    rerender(<DebateRematchPageClient sessionId="rematch-1" />);
-
-    expect(screen.getByRole('button', { name: /Salina’s positions/ })).toHaveAttribute('aria-selected', 'true');
-    expect(screen.getByRole('button', { name: 'Recommended' })).toHaveAttribute('aria-selected', 'false');
-    expect(screen.queryByRole('heading', { name: 'Geopolitics & chips' })).toBeNull();
-  });
-
-  // An opponent's tab with nothing on it is no place to land while a curator's page may still be
-  // on its way; it waits, and Recommended takes the landing once it is known to exist.
-  it('waits on the curated lookup while the opponent has nothing to show, then lands on Recommended', async () => {
-    mocks.savedClaims = [];
-    mocks.claims = [];
-    mocks.positions = [];
-    mocks.recommendedLoading = true;
-    const { rerender } = render(<DebateRematchPageClient sessionId="rematch-1" />);
-
-    expect(screen.queryByText(/hasn’t responded/)).toBeNull();
-    expect(screen.getByRole('button', { name: 'Recommended' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Claims' })).toHaveAttribute('aria-selected', 'true');
+    expect(screen.queryByText('No featured claims are available to debate yet.')).toBeNull();
 
     mocks.recommendedLoading = false;
     mocks.recommendedSections = [{ id: 'block-1', name: 'Geopolitics & chips', claimIds: [CLAIM_MORE] }];
     mocks.recommendedEntities = [publishedEntity()];
     rerender(<DebateRematchPageClient sessionId="rematch-1" />);
 
-    expect(screen.getByRole('button', { name: 'Recommended' })).toHaveAttribute('aria-selected', 'true');
     expect(await screen.findByRole('heading', { name: 'Geopolitics & chips' })).toBeInTheDocument();
+  });
+
+  // A viewer who has picked a source keeps it: the curated lookup settling afterwards is not a
+  // reason to move the list under them.
+  it('keeps the source the viewer picked when the curated lookup settles later', async () => {
+    mocks.recommendedLoading = true;
+    const { rerender } = render(<DebateRematchPageClient sessionId="rematch-1" />);
+
+    await chooseSource('All claims');
+    expect(screen.getByText('A newly published claim')).toBeInTheDocument();
+
+    mocks.recommendedLoading = false;
+    mocks.recommendedSections = [{ id: 'block-1', name: 'Geopolitics & chips', claimIds: [CLAIM_MORE] }];
+    mocks.recommendedEntities = [publishedEntity()];
+    rerender(<DebateRematchPageClient sessionId="rematch-1" />);
+
+    expect(screen.queryByRole('heading', { name: 'Geopolitics & chips' })).toBeNull();
+    expect(screen.getByText('A newly published claim')).toBeInTheDocument();
   });
 
   // A claim either side turned down recently still lists — with its request disabled and saying
   // why — whether the row came from geo-chat or from the hub's index, which knows nothing of it.
-  it('keeps a recently rejected claim listed with its request disabled', () => {
+  it('keeps a recently rejected claim listed with its request disabled', async () => {
     mocks.claims = [];
     mocks.session = session({ recently_rejected_claim_ids: [CLAIM_SHARED] });
     render(<DebateRematchPageClient sessionId="rematch-1" />);
+    await showOpponentClaims();
 
     expect(screen.getByText('A claim both participants chose')).toBeInTheDocument();
     expect(screen.getByText('Recently rejected')).toBeInTheDocument();
@@ -1066,7 +1086,7 @@ describe('DebateRematchPageClient', () => {
   // knowledge-graph data geo-chat doesn't model, so that one stays a cut over the loaded rows.
   it('sends the selected space to the hub query', async () => {
     render(<DebateRematchPageClient sessionId="rematch-1" />);
-    showAllClaims();
+    await showAllClaims();
 
     selectFilter('Any space', 'Crypto');
     await waitFor(() => expect(browsedClaimsQueryOptions()?.spaceId).toBe(SPACE_1));
@@ -1078,13 +1098,13 @@ describe('DebateRematchPageClient', () => {
   describe('tab strip overflow', () => {
     /** The row holding the tab buttons. */
     function tabStrip() {
-      const tab = screen.getByRole('button', { name: /All/ });
+      const tab = screen.getByRole('button', { name: 'Claims' });
       const strip = tab.parentElement;
       expect(strip).not.toBeNull();
       return strip!;
     }
 
-    it('scrolls the tabs on their own rather than the page', () => {
+    it('scrolls the tabs on their own rather than the page', async () => {
       render(<DebateRematchPageClient sessionId="rematch-1" />);
 
       expect(tabStrip().className).toContain('overflow-x-auto');
@@ -1094,7 +1114,7 @@ describe('DebateRematchPageClient', () => {
 
     // A swipe that reaches the end of the strip would otherwise chain outward, which on iOS is the
     // browser's back gesture — leaving the debate.
-    it('keeps an overscrolling swipe inside the strip', () => {
+    it('keeps an overscrolling swipe inside the strip', async () => {
       render(<DebateRematchPageClient sessionId="rematch-1" />);
 
       expect(tabStrip().className).toContain('overscroll-x-contain');
@@ -1102,17 +1122,17 @@ describe('DebateRematchPageClient', () => {
 
     // The tabs have to keep their own width for the strip to have anything to scroll; squeezed
     // flex children just get narrower and stay on screen.
-    it('lets each tab keep its natural width', () => {
+    it('lets each tab keep its natural width', async () => {
       render(<DebateRematchPageClient sessionId="rematch-1" />);
 
-      for (const name of [/All/, /positions/]) {
+      for (const name of ['Claims', /positions/]) {
         expect(screen.getByRole('button', { name }).className).toContain('shrink-0');
       }
     });
 
     // `overflow-y-auto` alone leaves the other axis computing to `auto`, which is what let the
     // whole fixed layer pan sideways.
-    it('does not let the page itself scroll sideways', () => {
+    it('does not let the page itself scroll sideways', async () => {
       const { container } = render(<DebateRematchPageClient sessionId="rematch-1" />);
 
       const shell = container.querySelector('.fixed.inset-0');
@@ -1121,7 +1141,7 @@ describe('DebateRematchPageClient', () => {
     });
   });
 
-  it('shortens the opponent tab to their first name', () => {
+  it('shortens the opponent tab to their first name', async () => {
     const base = session();
     mocks.session = session({
       participants: [base.participants[0], { ...base.participants[1], display_name: 'Salina Okonkwo' }],
@@ -1134,7 +1154,7 @@ describe('DebateRematchPageClient', () => {
 
   it('lists every eligible claim on the All tab', async () => {
     render(<DebateRematchPageClient sessionId="rematch-1" />);
-    showAllClaims();
+    await showAllClaims();
 
     expect(screen.getByText('A claim both participants chose')).toBeInTheDocument();
     expect(screen.getByText('A newly published claim')).toBeInTheDocument();
@@ -1145,17 +1165,18 @@ describe('DebateRematchPageClient', () => {
     await waitFor(() => expect(screen.queryByText('A newly published claim')).toBeNull());
   });
 
-  it('shows the opponent-specific empty state when no claim is debate-ready', () => {
+  it('shows the opponent-specific empty state when no claim is debate-ready', async () => {
     mocks.claims = [];
     mocks.positions = [];
     render(<DebateRematchPageClient sessionId="rematch-1" />);
+    await showOpponentClaims();
 
     expect(screen.getByText(/Salina hasn’t responded yet/)).toBeInTheDocument();
   });
 
   it('narrows the list to the selected topic', async () => {
     render(<DebateRematchPageClient sessionId="rematch-1" />);
-    showAllClaims();
+    await showAllClaims();
 
     selectFilter('Any topic', 'Governance');
 
@@ -1164,9 +1185,9 @@ describe('DebateRematchPageClient', () => {
     await waitFor(() => expect(screen.queryByText('A claim both participants chose')).toBeNull());
   });
 
-  it('matches the topic filter on any of a claim topics, not just the first', () => {
+  it('matches the topic filter on any of a claim topics, not just the first', async () => {
     render(<DebateRematchPageClient sessionId="rematch-1" />);
-    showAllClaims();
+    await showAllClaims();
 
     // The published claim is tagged Governance and Ethics; filtering on the second still matches.
     selectFilter('Any topic', 'Ethics');
@@ -1176,7 +1197,7 @@ describe('DebateRematchPageClient', () => {
 
   it('narrows the list to the selected space', async () => {
     render(<DebateRematchPageClient sessionId="rematch-1" />);
-    showAllClaims();
+    await showAllClaims();
 
     // The shared claim sits in Crypto; the published one is in Governance space.
     selectFilter('Any space', 'Crypto');
@@ -1190,7 +1211,7 @@ describe('DebateRematchPageClient', () => {
   it('drops claims from spaces outside the viewer’s allowed set', async () => {
     mocks.spaceAllowlist = new Set([SPACE_1.replace(/-/g, '')]);
     render(<DebateRematchPageClient sessionId="rematch-1" />);
-    showAllClaims();
+    await showAllClaims();
 
     // The shared claim sits in Crypto (allowed); the published one is in Governance space.
     expect(screen.getByText('A claim both participants chose')).toBeInTheDocument();
@@ -1201,10 +1222,11 @@ describe('DebateRematchPageClient', () => {
   // a debater's claims live in their personal space, which nobody else is a member of — narrowing
   // it by the viewer's own memberships emptied the tab, and zeroed its count, for everyone but the
   // debater who published the claims.
-  it('keeps the opponent’s claims from spaces outside the viewer’s allowed set', () => {
+  it('keeps the opponent’s claims from spaces outside the viewer’s allowed set', async () => {
     mocks.claims = [sharedClaim()];
     mocks.spaceAllowlist = new Set([SPACE_2.replace(/-/g, '')]);
     render(<DebateRematchPageClient sessionId="rematch-1" />);
+    await showOpponentClaims();
 
     expect(screen.getByText('A claim both participants chose')).toBeInTheDocument();
     const tab = screen.getByRole('button', { name: /Salina’s positions/ });
@@ -1256,7 +1278,7 @@ describe('DebateRematchPageClient', () => {
     it('leaves it out of the All tab', async () => {
       mocks.spaceTypes = { [SPACE_2]: 'PERSONAL' };
       render(<DebateRematchPageClient sessionId="rematch-1" />);
-      showAllClaims();
+      await showAllClaims();
 
       await waitFor(() => expect(screen.queryByText('A newly published claim')).toBeNull());
     });
@@ -1321,11 +1343,12 @@ describe('DebateRematchPageClient', () => {
       await waitFor(() => expect(screen.queryByText('A claim both participants chose')).toBeNull());
     });
 
-    it('keeps a claim from a space the acceptor does edit', () => {
+    it('keeps a claim from a space the acceptor does edit', async () => {
       mocks.claims = [sharedClaim()];
       mocks.spaceTypes = { [SPACE_1]: 'DAO' };
       mocks.publishableSpaceIds = new Set([SPACE_1.replace(/-/g, '')]);
       render(<DebateRematchPageClient sessionId="rematch-1" />);
+      await showOpponentClaims();
 
       expect(screen.getByText('A claim both participants chose')).toBeInTheDocument();
     });
@@ -1341,20 +1364,22 @@ describe('DebateRematchPageClient', () => {
       await waitFor(() => expect(screen.queryByText('A claim both participants chose')).toBeNull());
     });
 
-    it('keeps a claim in a DAO space, which the acceptor can publish into', () => {
+    it('keeps a claim in a DAO space, which the acceptor can publish into', async () => {
       mocks.claims = [sharedClaim()];
       mocks.spaceTypes = { [SPACE_1]: 'DAO' };
       render(<DebateRematchPageClient sessionId="rematch-1" />);
+      await showOpponentClaims();
 
       expect(screen.getByText('A claim both participants chose')).toBeInTheDocument();
     });
 
     // Same convention as the allowlist: filtering on a half-resolved lookup would list the claim
     // and then pull it back out from under the viewer.
-    it('keeps a claim whose space type has not resolved yet', () => {
+    it('keeps a claim whose space type has not resolved yet', async () => {
       mocks.claims = [sharedClaim()];
       mocks.spaceTypes = {};
       render(<DebateRematchPageClient sessionId="rematch-1" />);
+      await showOpponentClaims();
 
       expect(screen.getByText('A claim both participants chose')).toBeInTheDocument();
     });
@@ -1368,20 +1393,22 @@ describe('DebateRematchPageClient', () => {
     mocks.spaceAllowlist = null;
     mocks.allowlistLoading = true;
     render(<DebateRematchPageClient sessionId="rematch-1" />);
+    await showOpponentClaims();
 
     expect(screen.getByText('A claim both participants chose')).toBeInTheDocument();
     expect(within(screen.getByRole('button', { name: /Salina’s positions/ })).getByText('1')).toBeInTheDocument();
 
-    showAllClaims();
+    await showAllClaims();
     await waitFor(() => expect(screen.queryByText('A newly published claim')).toBeNull());
   });
 
   // A new response from the opponent adds an id to the list, and the lookups keyed on that list
   // start over. Dropping the tab to nothing — and its count to zero — while they catch up read as
   // the opponent's positions vanishing every time they took another one.
-  it('keeps the opponent’s list and count up while a new response is being looked up', () => {
+  it('keeps the opponent’s list and count up while a new response is being looked up', async () => {
     const FRESH = '019fedb7-5b96-7e83-9f66-7bc2ad4f9953';
     const view = render(<DebateRematchPageClient sessionId="rematch-1" />);
+    await showOpponentClaims();
     expect(screen.getByText('A claim both participants chose')).toBeInTheDocument();
 
     // The graph reports another side; the id-keyed lookups are back in flight.
@@ -1404,7 +1431,7 @@ describe('DebateRematchPageClient', () => {
 
   // Same for the session's exclusions: the source debate's claim and a recently rejected one are
   // known only once geo-chat answers for the opponent's ids, and listing them first would flash.
-  it('holds the opponent’s list until the session’s exclusions are known', () => {
+  it('holds the opponent’s list until the session’s exclusions are known', async () => {
     mocks.browsedLookupLoading = true;
     render(<DebateRematchPageClient sessionId="rematch-1" />);
 
@@ -1416,14 +1443,14 @@ describe('DebateRematchPageClient', () => {
     mocks.spaceAllowlist = null;
     mocks.allowlistLoading = false;
     render(<DebateRematchPageClient sessionId="rematch-1" />);
-    showAllClaims();
+    await showAllClaims();
 
     expect(await screen.findByText('A newly published claim')).toBeInTheDocument();
   });
 
   it('searches claim text, and keeps searching across a tab switch', async () => {
     render(<DebateRematchPageClient sessionId="rematch-1" />);
-    showAllClaims();
+    await showAllClaims();
 
     fireEvent.change(screen.getByRole('textbox', { name: 'Search claims' }), {
       target: { value: 'newly published' },
@@ -1441,8 +1468,9 @@ describe('DebateRematchPageClient', () => {
 
   // Following a link to the entity page would navigate out of the app shell and abandon the live
   // session, so the claim opens beside the picker instead.
-  it('opens a claim in the side panel rather than navigating to it', () => {
+  it('opens a claim in the side panel rather than navigating to it', async () => {
     render(<DebateRematchPageClient sessionId="rematch-1" />);
+    await showOpponentClaims();
 
     const claim = screen.getByText('A claim both participants chose');
     expect(claim.closest('a')).toBeNull();
@@ -1454,14 +1482,14 @@ describe('DebateRematchPageClient', () => {
 
   // A switch drawn from a guess is worse than one that waits: reading an unresolved lookup as
   // "not ready" would report the opposite of the truth on a claim the viewer is standing ready on.
-  it('leaves the Debate toggle out until readiness is known', () => {
+  it('leaves the Debate toggle out until readiness is known', async () => {
     mocks.claimReadinessLoading = true;
     render(<DebateRematchPageClient sessionId="rematch-1" />);
 
     expect(screen.queryByRole('switch', { name: 'Ready to debate this claim' })).toBeNull();
   });
 
-  it('leaves it out when the readiness lookup failed', () => {
+  it('leaves it out when the readiness lookup failed', async () => {
     mocks.claimReadinessError = true;
     render(<DebateRematchPageClient sessionId="rematch-1" />);
 
@@ -1469,8 +1497,9 @@ describe('DebateRematchPageClient', () => {
   });
 
   // A settled lookup with no row for the claim genuinely means not ready, so the switch belongs.
-  it('shows the toggle off once a settled lookup reports nothing for the claim', () => {
+  it('shows the toggle off once a settled lookup reports nothing for the claim', async () => {
     render(<DebateRematchPageClient sessionId="rematch-1" />);
+    await showOpponentClaims();
 
     expect(screen.getByRole('switch', { name: 'Ready to debate this claim' })).not.toBeChecked();
   });
@@ -1479,12 +1508,13 @@ describe('DebateRematchPageClient', () => {
   // asked for. The per-space lookup used to cost one request per space on screen; when the rematch
   // response has the answer, that fan-out must not run at all.
   describe('when the rematch response carries readiness', () => {
-    it('draws the toggle from it and skips the per-space lookup', () => {
+    it('draws the toggle from it and skips the per-space lookup', async () => {
       mocks.claims = [{ ...sharedClaim(), viewer_debate_ready: true, readiness_disabled_reason: null }];
       // Left empty on purpose: if the card read this the switch would be off.
       mocks.claimReadiness = [];
 
       render(<DebateRematchPageClient sessionId="rematch-1" />);
+      await showOpponentClaims();
 
       expect(screen.getByRole('switch', { name: 'Ready to debate this claim' })).toBeChecked();
       expect(mocks.perSpaceReadinessGroups.every(groups => groups.length === 0)).toBe(true);
@@ -1498,7 +1528,7 @@ describe('DebateRematchPageClient', () => {
     // scopes the other lists depend on — plus both participants' personal spaces, which is where a
     // debater's own claims live and the only way to hear about their *first* position: the tab is
     // empty then, so there is no claim to derive a scope from.
-    it('holds a gateway scope on every list’s spaces and both debaters’ own', () => {
+    it('holds a gateway scope on every list’s spaces and both debaters’ own', async () => {
       mocks.claims = [{ ...sharedClaim(), viewer_debate_ready: true, readiness_disabled_reason: null }];
       mocks.claimReadiness = [];
 
@@ -1506,20 +1536,21 @@ describe('DebateRematchPageClient', () => {
       const scoped = () => mocks.gatewaySpaceScopes.filter(scope => scope.enabled).at(-1)?.spaceIds;
       expect(scoped()).toEqual([SPACE_1, SPACE_2, 'profile-local', 'profile-remote']);
 
-      showAllClaims();
+      await showAllClaims();
       expect(scoped()).toEqual([SPACE_1, SPACE_2, 'profile-local', 'profile-remote']);
     });
 
-    it('shows the toggle off for a claim it reports as not ready', () => {
+    it('shows the toggle off for a claim it reports as not ready', async () => {
       mocks.claims = [{ ...sharedClaim(), viewer_debate_ready: false, readiness_disabled_reason: null }];
       mocks.claimReadiness = [];
 
       render(<DebateRematchPageClient sessionId="rematch-1" />);
+      await showOpponentClaims();
 
       expect(screen.getByRole('switch', { name: 'Ready to debate this claim' })).not.toBeChecked();
     });
 
-    it('treats a claim the response omits as settled not-ready', () => {
+    it('treats a claim the response omits as settled not-ready', async () => {
       // A published claim the graph knows about but geo-chat has no row for: it can hold no
       // readiness, so `false` is the truth and the switch belongs on screen, off. The saved claim
       // carries the field so the response counts as one that has readiness at all.
@@ -1527,7 +1558,7 @@ describe('DebateRematchPageClient', () => {
       mocks.claimReadiness = [];
 
       render(<DebateRematchPageClient sessionId="rematch-1" />);
-      showAllClaims();
+      await showAllClaims();
 
       const switches = screen.getAllByRole('switch', { name: 'Ready to debate this claim' });
       expect(switches).toHaveLength(2);
@@ -1539,7 +1570,7 @@ describe('DebateRematchPageClient', () => {
 
   // geo-chat answers the browsed lookup in id-sorted batches, so a list laid out in response order
   // would reshuffle every time a new page's ids landed in the middle of the sorted range.
-  it('keeps the All tab in the order the page returned the claims', () => {
+  it('keeps the All tab in the order the page returned the claims', async () => {
     const FIRST = '019fedb4-3f74-7c61-8d44-5fa08b1e7a01';
     const SECOND = '019fedb4-3f74-7c61-8d44-5fa08b1e7a02';
     const THIRD = '019fedb4-3f74-7c61-8d44-5fa08b1e7a03';
@@ -1555,7 +1586,7 @@ describe('DebateRematchPageClient', () => {
     ];
 
     render(<DebateRematchPageClient sessionId="rematch-1" />);
-    showAllClaims();
+    await showAllClaims();
 
     const names = screen.getAllByText(/^Ordered claim/).map(element => element.textContent);
     expect(names).toEqual(['Ordered claim one', 'Ordered claim two', 'Ordered claim three']);
@@ -1565,7 +1596,7 @@ describe('DebateRematchPageClient', () => {
   // one — used to be appended after every paged row, so each new batch inserted rows above them
   // and slid them further down. A claim the viewer already held a position on was still sinking
   // after ten pages. Their slot is fixed after the first page now.
-  it('holds a claim the pages have not reached in place when the next page lands', () => {
+  it('holds a claim the pages have not reached in place when the next page lands', async () => {
     const PAGE_ONE = '019fedb4-3f74-7c61-8d44-5fa08b1e7b01';
     const PAGE_TWO = '019fedb4-3f74-7c61-8d44-5fa08b1e7b02';
     const ANSWERED = '019fedb7-5b96-7e83-9f66-7bc2ad4f9953';
@@ -1580,7 +1611,7 @@ describe('DebateRematchPageClient', () => {
     mocks.positions = [position('profile-remote', ANSWERED, SPACE_1, true)];
 
     render(<DebateRematchPageClient sessionId="rematch-1" />);
-    showAllClaims();
+    await showAllClaims();
 
     // Its slot is after the first page and before the second — not swept to the end behind
     // every row paging has since produced.
@@ -1590,22 +1621,22 @@ describe('DebateRematchPageClient', () => {
 
   // Reaching the end of the list is what asks for the next page, so without this the sentinel
   // fires silently and the list sits there looking finished.
-  it('shows a loading skeleton while the next page is on its way', () => {
+  it('shows a loading skeleton while the next page is on its way', async () => {
     mocks.entityQueryHasNextPage = true;
     mocks.entityQueryFetchingNextPage = true;
     render(<DebateRematchPageClient sessionId="rematch-1" />);
 
     // Not on the tabs that don't page — they load whole.
     expect(screen.queryByTestId('claims-next-page-skeleton')).toBeNull();
-    showAllClaims();
+    await showAllClaims();
     expect(screen.getByTestId('claims-next-page-skeleton')).toBeInTheDocument();
   });
 
-  it('shows no skeleton once the page has landed', () => {
+  it('shows no skeleton once the page has landed', async () => {
     mocks.entityQueryHasNextPage = true;
     mocks.entityQueryFetchingNextPage = false;
     render(<DebateRematchPageClient sessionId="rematch-1" />);
-    showAllClaims();
+    await showAllClaims();
 
     expect(screen.getByTestId('claims-scroll-sentinel')).toBeInTheDocument();
     expect(screen.queryByTestId('claims-next-page-skeleton')).toBeNull();
@@ -1615,7 +1646,7 @@ describe('DebateRematchPageClient', () => {
   // of what the viewer had typed and pushed their search results down. Matched claims stay
   // legible without the pin — they are the ones offering "Request debate", and the Matches tab
   // lists them on their own.
-  it('leaves a matched claim where the page returned it rather than pinning it first', () => {
+  it('leaves a matched claim where the page returned it rather than pinning it first', async () => {
     const FIRST = '019fedb4-3f74-7c61-8d44-5fa08b1e7a01';
     const SECOND = '019fedb4-3f74-7c61-8d44-5fa08b1e7a02';
     const MATCHED = '019fedb4-3f74-7c61-8d44-5fa08b1e7a03';
@@ -1629,13 +1660,13 @@ describe('DebateRematchPageClient', () => {
     mocks.claims = [{ ...sharedClaim(), shared_preference: true, claim: claimSummary(MATCHED, 'Ordered claim three') }];
 
     render(<DebateRematchPageClient sessionId="rematch-1" />);
-    showAllClaims();
+    await showAllClaims();
 
     const names = screen.getAllByText(/^Ordered claim/).map(element => element.textContent);
     expect(names).toEqual(['Ordered claim one', 'Ordered claim two', 'Ordered claim three']);
   });
 
-  it('marks the requester as entering the debate before routing into the room', () => {
+  it('marks the requester as entering the debate before routing into the room', async () => {
     mocks.session = session({ status: 'converted', converted_debate_id: 'debate-9' });
 
     render(<DebateRematchPageClient sessionId="rematch-1" />);
@@ -1649,12 +1680,13 @@ describe('DebateRematchPageClient', () => {
 
   // A backend that predates the fields answers `undefined`, and the picker must keep working
   // exactly as before against it.
-  it('falls back to the per-space lookup when the rematch response has no readiness', () => {
+  it('falls back to the per-space lookup when the rematch response has no readiness', async () => {
     mocks.claimReadiness = [
       { claim_entity_id: CLAIM_SHARED, viewer_debate_ready: true, readiness_disabled_reason: null },
     ];
 
     render(<DebateRematchPageClient sessionId="rematch-1" />);
+    await showOpponentClaims();
 
     expect(screen.getByRole('switch', { name: 'Ready to debate this claim' })).toBeChecked();
     expect(mocks.perSpaceReadinessGroups.some(groups => groups.length > 0)).toBe(true);
@@ -1664,7 +1696,7 @@ describe('DebateRematchPageClient', () => {
   // A position can appear without anyone picking one — here because geo-chat's copy of a claim the
   // viewer had already answered lands after the card is on screen. That looks identical to a fresh
   // pick, and standing them ready for it reverses a stand-down they made elsewhere.
-  it('does not stand the viewer ready when geo-chat reports a position they already held', () => {
+  it('does not stand the viewer ready when geo-chat reports a position they already held', async () => {
     mocks.claims = [
       {
         ...sharedClaim(),
@@ -1691,13 +1723,13 @@ describe('DebateRematchPageClient', () => {
   });
 
   // Standing down elsewhere is deliberate; arriving here mustn't quietly reverse it.
-  it('leaves readiness alone for positions already held on arrival', () => {
+  it('leaves readiness alone for positions already held on arrival', async () => {
     render(<DebateRematchPageClient sessionId="rematch-1" />);
 
     expect(mocks.setReadiness).not.toHaveBeenCalled();
   });
 
-  it('does not re-publish readiness that is already on', () => {
+  it('does not re-publish readiness that is already on', async () => {
     mocks.claims = [
       {
         ...sharedClaim(),
@@ -1722,25 +1754,26 @@ describe('DebateRematchPageClient', () => {
   // only ever searched what had been paged in. The hub's Claims tab searches server-side.
   it('searches the whole claim corpus rather than the loaded pages', async () => {
     render(<DebateRematchPageClient sessionId="rematch-1" />);
-    showAllClaims();
+    await showAllClaims();
 
     fireEvent.change(screen.getByRole('textbox', { name: 'Search claims' }), { target: { value: 'Fast fashion' } });
 
     await waitFor(() => expect(browsedClaimsQueryOptions()?.search).toBe('Fast fashion'));
   });
 
-  it('renders the card’s Debate toggle against real readiness', () => {
+  it('renders the card’s Debate toggle against real readiness', async () => {
     mocks.claimReadiness = [
       { claim_entity_id: CLAIM_SHARED, viewer_debate_ready: true, readiness_disabled_reason: null },
     ];
     render(<DebateRematchPageClient sessionId="rematch-1" />);
+    await showOpponentClaims();
 
     expect(screen.getByRole('switch', { name: 'Ready to debate this claim' })).toBeChecked();
   });
 
   // Waiting for geo-chat to echo the response back would leave the side you just picked
   // unhighlighted and Request debate missing for seconds.
-  it('reflects a just-picked side and offers the debate straight away', () => {
+  it('reflects a just-picked side and offers the debate straight away', async () => {
     mocks.claims = [
       {
         ...sharedClaim(),
@@ -1752,6 +1785,7 @@ describe('DebateRematchPageClient', () => {
     ];
     mocks.optimisticResponses.set(CLAIM_SHARED, 'positive');
     render(<DebateRematchPageClient sessionId="rematch-1" />);
+    await showOpponentClaims();
 
     const card = screen.getByText('A claim both participants chose').closest('article');
     expect(within(card!).getByRole('button', { name: /^Agree/ })).toHaveAttribute('aria-pressed', 'true');
@@ -1760,7 +1794,7 @@ describe('DebateRematchPageClient', () => {
   // geo-chat rejects a request for a claim it has no position for — "respond to this claim before
   // requesting a rematch" — so the button waits for geo-chat's copy, not the optimistic one. It
   // stays hidden rather than disabled: an unpressable button reads as broken.
-  it('withholds the request until the graph has the position it will be validated against', () => {
+  it('withholds the request until the graph has the position it will be validated against', async () => {
     mocks.positions = [position('profile-remote', CLAIM_SHARED, SPACE_1, false)];
     mocks.optimisticResponses.set(CLAIM_SHARED, 'positive');
     render(<DebateRematchPageClient sessionId="rematch-1" />);
@@ -1771,10 +1805,11 @@ describe('DebateRematchPageClient', () => {
   // GEO-2652. The wait above is real — a publish, an index and a notification — and rendering
   // nothing while it runs is what Preston reported: no idea what he was waiting on. The button still
   // waits, because geo-chat would reject an early request; what changes is that the wait is named.
-  it('says what it is waiting for while the position is being confirmed', () => {
+  it('says what it is waiting for while the position is being confirmed', async () => {
     mocks.positions = [position('profile-remote', CLAIM_SHARED, SPACE_1, false)];
     mocks.optimisticResponses.set(CLAIM_SHARED, 'positive');
     render(<DebateRematchPageClient sessionId="rematch-1" />);
+    await showOpponentClaims();
 
     expect(screen.getByRole('status')).toHaveTextContent('Confirming your position…');
     expect(screen.queryByRole('button', { name: 'Request debate' })).not.toBeInTheDocument();
@@ -1782,14 +1817,14 @@ describe('DebateRematchPageClient', () => {
 
   // And nothing is said before the viewer has taken a side — there is nothing being confirmed, so a
   // spinner would be claiming work that is not happening.
-  it('says nothing while the viewer has taken no side', () => {
+  it('says nothing while the viewer has taken no side', async () => {
     mocks.positions = [position('profile-remote', CLAIM_SHARED, SPACE_1, false)];
     render(<DebateRematchPageClient sessionId="rematch-1" />);
 
     expect(screen.queryByText('Confirming your position…')).not.toBeInTheDocument();
   });
 
-  it('sends the request once geo-chat agrees with the side on screen', () => {
+  it('sends the request once geo-chat agrees with the side on screen', async () => {
     mocks.claims = [
       {
         ...sharedClaim(),
@@ -1801,6 +1836,7 @@ describe('DebateRematchPageClient', () => {
     ];
     mocks.optimisticResponses.set(CLAIM_SHARED, 'positive');
     render(<DebateRematchPageClient sessionId="rematch-1" />);
+    await showOpponentClaims();
 
     const request = screen.getByRole('button', { name: 'Request debate' });
     expect(request).toBeEnabled();
@@ -1810,7 +1846,7 @@ describe('DebateRematchPageClient', () => {
 
   // Switching sides leaves geo-chat holding the side you just moved off, which is no more valid to
   // request against than holding none.
-  it('withholds the request while a side switch is still publishing', () => {
+  it('withholds the request while a side switch is still publishing', async () => {
     mocks.positions = [
       position('profile-local', CLAIM_SHARED, SPACE_1, false),
       position('profile-remote', CLAIM_SHARED, SPACE_1, false),
@@ -1827,6 +1863,7 @@ describe('DebateRematchPageClient', () => {
   it('waits for the response to settle before standing the viewer ready', async () => {
     mocks.positions = [position('profile-remote', CLAIM_SHARED, SPACE_1, false)];
     const view = render(<DebateRematchPageClient sessionId="rematch-1" />);
+    await showOpponentClaims();
     expect(mocks.joinQueue).not.toHaveBeenCalled();
 
     // The side is picked: optimistic only, the graph still has nothing.
@@ -1848,7 +1885,7 @@ describe('DebateRematchPageClient', () => {
   // `spaces[0]` is a citing space whenever it outranks the claim's own. Responding in one space and
   // asking to debate in another is what the server answers with "respond to this claim in this
   // space before enabling debate readiness".
-  it('scopes a claim to the space it is named in, not the highest-ranked one citing it', () => {
+  it('scopes a claim to the space it is named in, not the highest-ranked one citing it', async () => {
     mocks.entities = [
       {
         ...publishedEntity(CLAIM_MORE, 'A claim that lives in Podcasts'),
@@ -1869,6 +1906,7 @@ describe('DebateRematchPageClient', () => {
     // The toggle only offers itself once the viewer holds a position.
     mocks.optimisticResponses.set(CLAIM_MORE, 'positive');
     render(<DebateRematchPageClient sessionId="rematch-1" />);
+    await showOpponentClaims();
 
     // The space is fixed when the card wires its readiness machine, not when the request goes out —
     // the viewer has no indexed response yet, so the machine holds the request until geo-chat has
@@ -1881,6 +1919,7 @@ describe('DebateRematchPageClient', () => {
   it('stands the viewer ready only once, even as the claim keeps refetching', async () => {
     mocks.positions = [position('profile-remote', CLAIM_SHARED, SPACE_1, false)];
     const view = render(<DebateRematchPageClient sessionId="rematch-1" />);
+    await showOpponentClaims();
 
     mocks.optimisticResponses.set(CLAIM_SHARED, 'positive');
     view.rerender(<DebateRematchPageClient sessionId="rematch-1" />);
@@ -1901,9 +1940,43 @@ function browsedClaimsQueryOptions() {
   return mocks.entityQueries.at(-1);
 }
 
-/** The picker opens on the opponent's positions; most assertions want the unfiltered list. */
-function showAllClaims() {
-  fireEvent.click(screen.getByRole('button', { name: 'All' }));
+/**
+ * The tab region cross-fades with `mode="wait"`, so the incoming list is not in the DOM until the
+ * outgoing one has finished leaving. Comfortably longer than the 100ms swap.
+ */
+async function settleTabSwap() {
+  await act(async () => {
+    await new Promise(resolve => setTimeout(resolve, 200));
+  });
+}
+
+/** Opens the source menu on whichever option it is currently showing. */
+function openSourceMenu() {
+  const label = (['Recommended', 'Featured', 'All claims'] as const).find(
+    name => screen.queryAllByRole('button', { name }).length > 0
+  );
+  fireEvent.click(screen.getAllByRole('button', { name: label! })[0]!);
+}
+
+/** The picker opens on Claims, sourced from Recommended or Featured; most assertions want the index. */
+async function showAllClaims() {
+  fireEvent.click(screen.getByRole('button', { name: 'Claims' }));
+  openSourceMenu();
+  fireEvent.click(screen.getByRole('button', { name: 'All claims' }));
+  await settleTabSwap();
+}
+
+/** The opponent's own responses, which are a tab of their own rather than a source of Claims. */
+async function showOpponentClaims() {
+  fireEvent.click(screen.getByRole('button', { name: /positions/ }));
+  await settleTabSwap();
+}
+
+/** Picks a source out of the Claims menu. */
+async function chooseSource(next: string) {
+  openSourceMenu();
+  fireEvent.click(screen.getByRole('button', { name: next }));
+  await settleTabSwap();
 }
 
 /** Whether `first` is rendered ahead of `second` in the document. */

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
@@ -51,6 +51,8 @@ const mocks = vi.hoisted(() => ({
   entityIdLookups: [] as string[][],
   featuredClaims: [] as Array<{ claimEntityId: string; spaceId: string; name: string; description: string | null }>,
   featuredCatalogLoading: false,
+  featuredCatalogError: null as Error | null,
+  featuredEnabledWith: [] as boolean[],
   entityQueryHasNextPage: false,
   /** The hub's claims query (the All tab) is still in flight. */
   entityQueryLoading: false,
@@ -199,12 +201,13 @@ vi.mock('~/core/debates/debate-entry-intent', () => ({
 vi.mock('~/core/debates/featured-claims', async importOriginal => ({
   ...(await importOriginal<typeof import('~/core/debates/featured-claims')>()),
   useFeaturedClaims: (enabled: boolean) => {
+    mocks.featuredEnabledWith.push(enabled);
     const claims = enabled ? mocks.featuredClaims : [];
     return {
       claims,
       claimIds: claims.map(claim => claim.claimEntityId),
       isLoading: enabled && mocks.featuredCatalogLoading,
-      error: null,
+      error: enabled ? mocks.featuredCatalogError : null,
       refetch: vi.fn(),
     };
   },
@@ -363,6 +366,8 @@ beforeEach(() => {
   mocks.entityIdLookups.length = 0;
   mocks.featuredClaims = [];
   mocks.featuredCatalogLoading = false;
+  mocks.featuredCatalogError = null;
+  mocks.featuredEnabledWith = [];
   mocks.entityQueryHasNextPage = false;
   mocks.entityQueryLoading = false;
   mocks.entityHydrationLoading = false;
@@ -808,6 +813,46 @@ describe('DebateRematchPageClient', () => {
 
       expect(screen.queryByText('A featured claim')).toBeNull();
       expect(screen.getByText('No featured claims are available to debate yet.')).toBeInTheDocument();
+    });
+
+    // A failed tag query is not an empty tag query. Reporting "nothing is featured" for one hides a
+    // fault behind a sentence that reads like a fact about the graph.
+    it('reports a failed tag lookup as an error rather than an empty list', async () => {
+      mocks.featuredCatalogError = new Error('tag lookup exploded');
+      render(<DebateRematchPageClient sessionId="rematch-1" />);
+
+      await settleTabSwap();
+
+      expect(screen.getByText('Something went wrong.')).toBeInTheDocument();
+      expect(screen.queryByText('No featured claims are available to debate yet.')).toBeNull();
+    });
+
+    // Featured ids are empty while the allowlist is resolving, so without counting that as part of
+    // the source's loading state the empty message painted and was then replaced by the list.
+    it('waits on the allowlist rather than flashing its empty state', async () => {
+      mocks.spaceAllowlist = null;
+      mocks.allowlistLoading = true;
+      mocks.featuredClaims = [featuredTag()];
+      mocks.entities = [sharedEntity(), featuredEntity()];
+      render(<DebateRematchPageClient sessionId="rematch-1" />);
+
+      await settleTabSwap();
+
+      expect(screen.queryByText('No featured claims are available to debate yet.')).toBeNull();
+    });
+
+    // A remembered Featured source shouldn't keep a graph query alive behind the opponent's tab,
+    // which draws from somewhere else entirely.
+    it('stops asking for the tag once the viewer leaves Claims', async () => {
+      mocks.featuredClaims = [featuredTag()];
+      mocks.entities = [sharedEntity(), featuredEntity()];
+      render(<DebateRematchPageClient sessionId="rematch-1" />);
+
+      expect(mocks.featuredEnabledWith.at(-1)).toBe(true);
+
+      await showOpponentClaims();
+
+      expect(mocks.featuredEnabledWith.at(-1)).toBe(false);
     });
 
     it('says nothing is featured rather than nothing is debatable', async () => {

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
@@ -202,7 +202,10 @@ vi.mock('~/core/debates/featured-claims', async importOriginal => ({
   ...(await importOriginal<typeof import('~/core/debates/featured-claims')>()),
   useFeaturedClaims: (enabled: boolean) => {
     mocks.featuredEnabledWith.push(enabled);
-    const claims = enabled ? mocks.featuredClaims : [];
+    // Rows are returned whether or not the query is enabled, as react-query does: `enabled: false`
+    // stops the fetch, it does not clear the cache — and the hub shares this key, so a catalog it
+    // fetched arrives here already warm.
+    const claims = mocks.featuredClaims;
     return {
       claims,
       claimIds: claims.map(claim => claim.claimEntityId),
@@ -853,6 +856,51 @@ describe('DebateRematchPageClient', () => {
       await showOpponentClaims();
 
       expect(mocks.featuredEnabledWith.at(-1)).toBe(false);
+    });
+
+    // The space ranking picks the highest-ranked space a claim is *named* in and knows nothing of
+    // the allowlist, so left to it a claim featured in an allowed space could be drawn — and its
+    // debate requested — in a disallowed one that happens to outrank it.
+    it('draws a tagged claim in the space it was featured in, not the highest-ranked one', async () => {
+      // SPACE_1 (Crypto, rank 2) outranks SPACE_2, and the claim is named in both.
+      mocks.spaceAllowlist = new Set([SPACE_2.replace(/-/g, '')]);
+      mocks.featuredClaims = [featuredTag(FEATURED, 'A featured claim', SPACE_2)];
+      mocks.entities = [
+        sharedEntity(),
+        {
+          ...featuredEntity(),
+          spaces: [SPACE_1, SPACE_2],
+          values: [
+            { property: { id: NAME_PROPERTY }, spaceId: SPACE_1, value: 'A featured claim' },
+            { property: { id: NAME_PROPERTY }, spaceId: SPACE_2, value: 'A featured claim' },
+          ],
+        },
+      ];
+      render(<DebateRematchPageClient sessionId="rematch-1" />);
+
+      await settleTabSwap();
+
+      expect(screen.getByText('A featured claim')).toBeInTheDocument();
+      // Named in both, so geo-chat is asked about it in the space the tag was written in.
+      expect(mocks.rematchClaimIds.flat()).toContain(FEATURED);
+      expect(screen.queryByText('No featured claims are available to debate yet.')).toBeNull();
+    });
+
+    // `enabled: false` leaves react-query's cached rows in place, and the hub shares this query key
+    // — so a catalog fetched there arrives pre-populated and would keep the hydration mounted.
+    it('hydrates nothing while Featured is off screen, even with a cached catalog', async () => {
+      curatedPage();
+      mocks.featuredClaims = [featuredTag()];
+      mocks.entities = [sharedEntity(), featuredEntity()];
+      render(<DebateRematchPageClient sessionId="rematch-1" />);
+
+      // Recommended is the default here, so Featured's claim is never asked about.
+      expect(mocks.entityIdLookups.flat()).not.toContain(FEATURED);
+      expect(mocks.rematchClaimIds.flat()).not.toContain(FEATURED);
+
+      await chooseSource('Featured');
+
+      expect(mocks.entityIdLookups.flat()).toContain(FEATURED);
     });
 
     it('says nothing is featured rather than nothing is debatable', async () => {

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -7,7 +7,8 @@ import * as React from 'react';
 import cx from 'classnames';
 import { useRouter } from 'next/navigation';
 
-import { CLAIM_IS_FACTUAL_PROPERTY_ID, TOPICS_PROPERTY_ID } from '~/core/claims/ontology';
+import { TOPICS_PROPERTY_ID } from '~/core/claims/ontology';
+import { claimResponseKind } from '~/core/claims/response-kind';
 import {
   type DebateClaimPositionSummary,
   type DebateClaimSummary,
@@ -27,6 +28,7 @@ import { useDebateGatewaySpaceScopes } from '~/core/debates/debate-gateway';
 import { debatePublishableSpacePredicate } from '~/core/debates/debate-publish-target';
 import { DebateRequestDialog } from '~/core/debates/debate-request-dialog';
 import { consumeDebateReturnDestination } from '~/core/debates/debate-return-navigation';
+import { useFeaturedClaims } from '~/core/debates/featured-claims';
 import { defaultDebateFormatId } from '~/core/debates/formats';
 import {
   useAcceptDebateRematchRequest,
@@ -61,11 +63,10 @@ import { uuidToHex } from '~/core/id/normalize';
 import { responsePositionLabel } from '~/core/responses/entity-response';
 import { getTopRankedSpaceId } from '~/core/utils/space/space-ranking';
 
-import { getChecked } from '~/design-system/checkbox';
 import { ChevronDownSmall } from '~/design-system/icons/chevron-down-small';
 import { Input } from '~/design-system/input';
-import { Spinner } from '~/design-system/spinner';
 import { Skeleton } from '~/design-system/skeleton';
+import { Spinner } from '~/design-system/spinner';
 import { Text } from '~/design-system/text';
 
 const SEARCH_DEBOUNCE_MS = 250;
@@ -87,7 +88,12 @@ function useLastSettled<T>(value: T, settling: boolean): T {
   return settling && lastSettledRef.current ? lastSettledRef.current.value : value;
 }
 
-type PickerTab = 'recommended' | 'opponent' | 'all';
+/**
+ * GEO-2683. `featured` takes Recommended's slot rather than sitting beside it: it is the stand-in
+ * for when no curator has put a page together for this pairing, so the two are never both on the
+ * strip.
+ */
+type PickerTab = 'recommended' | 'featured' | 'opponent' | 'all';
 
 /**
  * The tab is narrow, so it carries the opponent's first name only: "Jenna Ruiz" -> "Jenna’s".
@@ -190,6 +196,30 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   // allowlist alone: the lists' own lookups run alongside it, so they are ready when it lands.
   const allowlistPending = spaceAllowlist === null && allowlistLoading;
 
+  // GEO-2683. Featured stands in for Recommended when no curator has put a page together for this
+  // pairing, so it is asked for only once that lookup has settled with nothing — there is no point
+  // fetching a list that a curated page would take the slot of.
+  //
+  // Narrowed by the viewer's allowlist, unlike Recommended. The reasoning above turns on Recommended
+  // being one page from a space this build trusts by id; Featured is a tag anyone's space can carry,
+  // so it fans out across the corpus the way the All tab does and is bounded the same way.
+  const featuredEnabled = !recommendedLoading && recommendedSections.length === 0;
+  const { claims: featuredCatalog, isLoading: featuredCatalogLoading } = useFeaturedClaims(featuredEnabled);
+
+  const featuredClaimIds = React.useMemo(
+    () =>
+      allowlistPending
+        ? []
+        : featuredCatalog
+            .filter(claim => isClaimSpaceAllowed(claim.spaceId, spaceAllowlist))
+            .map(claim => claim.claimEntityId),
+    [allowlistPending, featuredCatalog, spaceAllowlist]
+  );
+
+  // The same two lookups the curated tab makes: the claim entities the picker's rows are built
+  // from, and geo-chat's session rows for readiness and this session's exclusions.
+  const featuredEntitiesQuery = useClaimEntitiesByIds(featuredClaimIds);
+
   // The All tab is the hub's Claims tab: geo-chat's own index of debatable claims, paged and
   // searched server-side, each row carrying the viewer's side and readiness. It takes a single
   // `space_id`, so the viewer's allowlist is a page-local cut, the same as the hub's.
@@ -206,6 +236,7 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   // for the curated ones; the session's own id-less list covers anything both have answered.
   const opponentClaimsQuery = useDebateRematchClaimsForIds(sessionId, opponentClaimIds);
   const curatedClaimsQuery = useDebateRematchClaimsForIds(sessionId, recommendedClaimIds);
+  const featuredClaimsQuery = useDebateRematchClaimsForIds(sessionId, featuredClaimIds);
 
   // A claim's sides, from the graph. The shape the rest of the page was already drawing.
   const sidesOf = React.useCallback(
@@ -224,12 +255,14 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
       ...(savedClaimsQuery.data?.excluded_claim_ids ?? []),
       ...(opponentClaimsQuery.data?.excluded_claim_ids ?? []),
       ...(curatedClaimsQuery.data?.excluded_claim_ids ?? []),
+      ...(featuredClaimsQuery.data?.excluded_claim_ids ?? []),
     ]);
     const sourceClaimId = sourceDebateQuery.data?.claim.claim_entity_id;
     if (sourceClaimId) excluded.add(sourceClaimId);
     return excluded;
   }, [
     curatedClaimsQuery.data,
+    featuredClaimsQuery.data,
     opponentClaimsQuery.data,
     savedClaimsQuery.data,
     session?.recently_rejected_claim_ids,
@@ -251,9 +284,10 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
       ...(savedClaimsQuery.data?.claims ?? []),
       ...(opponentClaimsQuery.data?.claims ?? []),
       ...(curatedClaimsQuery.data?.claims ?? []),
+      ...(featuredClaimsQuery.data?.claims ?? []),
     ];
     return rows.length === 0 || rows[0]!.viewer_debate_ready !== undefined;
-  }, [curatedClaimsQuery.data, opponentClaimsQuery.data, savedClaimsQuery.data]);
+  }, [curatedClaimsQuery.data, featuredClaimsQuery.data, opponentClaimsQuery.data, savedClaimsQuery.data]);
 
   // geo-chat's row for a claim, where it has one. It carries the session flags and readiness; the
   // sides on it are replaced by the graph's below, which are fresher by a notification round trip.
@@ -264,9 +298,10 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
           ...(savedClaimsQuery.data?.claims ?? []),
           ...(opponentClaimsQuery.data?.claims ?? []),
           ...(curatedClaimsQuery.data?.claims ?? []),
+          ...(featuredClaimsQuery.data?.claims ?? []),
         ].map(claim => [claim.claim.claim_entity_id, claim])
       ),
-    [curatedClaimsQuery.data, opponentClaimsQuery.data, savedClaimsQuery.data]
+    [curatedClaimsQuery.data, featuredClaimsQuery.data, opponentClaimsQuery.data, savedClaimsQuery.data]
   );
 
   // A debate is published into the claim's home space by the acceptor, and a personal space grants
@@ -279,13 +314,23 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   // because which one wins is the next decision and it needs the types to make it.
   const candidateSpaceIds = React.useMemo(() => {
     const ids = new Set<string>();
-    for (const entity of [...opponentEntitiesQuery.entities, ...recommendedEntities]) {
+    for (const entity of [
+      ...opponentEntitiesQuery.entities,
+      ...recommendedEntities,
+      ...featuredEntitiesQuery.entities,
+    ]) {
       for (const spaceId of claimCandidateSpaceIds(entity)) ids.add(spaceId);
     }
     for (const page of browsedPages) for (const entry of page.claims) ids.add(entry.claim.space_id);
     for (const row of savedClaimsQuery.data?.claims ?? []) ids.add(row.claim.space_id);
     return [...ids];
-  }, [browsedPages, opponentEntitiesQuery.entities, recommendedEntities, savedClaimsQuery.data]);
+  }, [
+    browsedPages,
+    featuredEntitiesQuery.entities,
+    opponentEntitiesQuery.entities,
+    recommendedEntities,
+    savedClaimsQuery.data,
+  ]);
   const { spacesById: candidateSpaces } = useSpacesByIds(candidateSpaceIds);
   // The acceptor's editor spaces are the authoritative answer, and the same set the publish sweep
   // works from. The space-type test below it is kept rather than replaced: the two fail
@@ -331,7 +376,11 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   // "Any topic" filter. A claim can carry several topics. The browsed rows bring their own.
   const topicsByClaimId = React.useMemo(() => {
     const map = new Map<string, MatchmakingTopic[]>();
-    for (const entity of [...opponentEntitiesQuery.entities, ...recommendedEntities]) {
+    for (const entity of [
+      ...opponentEntitiesQuery.entities,
+      ...recommendedEntities,
+      ...featuredEntitiesQuery.entities,
+    ]) {
       const topics = entity.relations
         .filter(relation => relation.type.id === TOPICS_PROPERTY_ID && relation.isDeleted !== true)
         .map(relation => ({ id: relation.toEntity.id, name: relation.toEntity.name ?? null }));
@@ -345,7 +394,7 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
       }
     }
     return map;
-  }, [browsedPages, opponentEntitiesQuery.entities, recommendedEntities]);
+  }, [browsedPages, featuredEntitiesQuery.entities, opponentEntitiesQuery.entities, recommendedEntities]);
 
   // The opponent's tab: every claim they hold a side on, newest first. Held until the session's
   // exclusions are in, so nothing lists and then vanishes. Not narrowed by the space allowlist —
@@ -402,6 +451,36 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
     ]
   );
   const curatedClaims = useLastSettled(curatedClaimsNow, curatedClaimsSettling);
+
+  // The Featured tab, in the order the graph returned the tags. Built exactly as the curated list
+  // is — the entities are the same projection and the rows carry the same session flags — and held
+  // the same way while its lookups settle.
+  //
+  // Not merged into the All tab the way the curated and opponent lists are. Those are rows the
+  // index has not paged to yet and belong in a list of everything; Featured is a few hundred claims
+  // the index already knows, so folding them in would pin them above what the viewer searched for.
+  const featuredClaimsSettling =
+    featuredCatalogLoading || featuredEntitiesQuery.isLoading || featuredClaimsQuery.isLoading;
+  const featuredClaimsNow = React.useMemo(
+    () =>
+      featuredClaimsSettling
+        ? []
+        : featuredClaimIds.flatMap(claimId => {
+            if (excludedClaimIds.has(claimId)) return [];
+            const entity = featuredEntitiesQuery.entities.find(candidate => candidate.id === claimId);
+            const row = entity ? rowFromEntity(entity) : null;
+            return row && canPublishDebateIn(row.claim.space_id) ? [row] : [];
+          }),
+    [
+      canPublishDebateIn,
+      excludedClaimIds,
+      featuredClaimIds,
+      featuredClaimsSettling,
+      featuredEntitiesQuery.entities,
+      rowFromEntity,
+    ]
+  );
+  const featuredClaims = useLastSettled(featuredClaimsNow, featuredClaimsSettling);
 
   // The All tab: geo-chat's rows, the graph's sides. Held while the allowlist resolves (see above).
   // It is still every claim the picker knows: the session's own rows — what both have answered,
@@ -543,10 +622,20 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
    * that is correct for every claim already on it. Going back to a skeleton there would flicker
    * the badge on exactly the event that ought to be invisible.
    */
-  const opponentCountPending =
-    opponentClaims.length === 0 && (positions.isLoading || opponentClaimsSettling);
+  const opponentCountPending = opponentClaims.length === 0 && (positions.isLoading || opponentClaimsSettling);
 
   const hasRecommended = recommendedSections.length > 0;
+  // Featured takes Recommended's slot when there is no curated page for this pairing.
+  const showsFeatured = !hasRecommended && !recommendedLoading;
+  const hasFeatured = showsFeatured && featuredClaims.length > 0;
+  // The slot is filled whenever Recommended isn't, empty or not — unlike Recommended, which hides
+  // when a curator has nothing for this pairing. Recommended's absence is information ("no one
+  // curated this"); Featured's would just be a tab that comes and goes, and a viewer who has seen
+  // it once should be able to go back and find it. It carries its own empty state instead.
+  //
+  // Landing is the separate question, and it waits for `hasFeatured`: putting the viewer on a tab
+  // that then settles empty is worse than never starting them there.
+  const featuredSlotVisible = showsFeatured;
   // The opponent's claims arrive in one round trip; the curated lookup is three, in sequence. The
   // picker lands on whichever has something to show first and stays there: once a tab has drawn
   // its list the landing is settled, so a curated page arriving afterwards adds its tab to the
@@ -554,10 +643,18 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   // known to exist, since a curator's page for this pairing is the best thing to land on — and an
   // opponent's tab with nothing on it waits for that lookup rather than settling on an empty state.
   const landedTabRef = React.useRef<PickerTab | null>(null);
-  const tab: PickerTab = chosenTab ?? landedTabRef.current ?? (hasRecommended ? 'recommended' : 'opponent');
+  const tab: PickerTab =
+    chosenTab ?? landedTabRef.current ?? (hasRecommended ? 'recommended' : hasFeatured ? 'featured' : 'opponent');
   const setTab = setChosenTab;
 
-  const claims = tab === 'opponent' ? opponentClaims : tab === 'recommended' ? curatedClaims : browsedClaims;
+  const claims =
+    tab === 'opponent'
+      ? opponentClaims
+      : tab === 'recommended'
+        ? curatedClaims
+        : tab === 'featured'
+          ? featuredClaims
+          : browsedClaims;
 
   // Every space and topic the lists have shown, not only the current tab's. Space runs in the
   // browsed query, so the loaded corpus is whatever the current filter allows — a menu listing only
@@ -569,20 +666,21 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
 
   const facetSpaceIds = React.useMemo(() => {
     const seen = seenFacetsRef.current.spaceIds;
-    for (const claim of [...opponentClaims, ...curatedClaims, ...browsedClaims]) seen.add(claim.claim.space_id);
+    for (const claim of [...opponentClaims, ...curatedClaims, ...featuredClaims, ...browsedClaims])
+      seen.add(claim.claim.space_id);
     for (const id of browsedFacets?.space_ids ?? []) if (isClaimSpaceAllowed(id, spaceAllowlist)) seen.add(id);
     return [...seen];
-  }, [browsedClaims, browsedFacets?.space_ids, curatedClaims, opponentClaims, spaceAllowlist]);
+  }, [browsedClaims, browsedFacets?.space_ids, curatedClaims, featuredClaims, opponentClaims, spaceAllowlist]);
 
   const facetTopics = React.useMemo(() => {
     const seen = seenFacetsRef.current.topics;
-    for (const claim of [...opponentClaims, ...curatedClaims, ...browsedClaims]) {
+    for (const claim of [...opponentClaims, ...curatedClaims, ...featuredClaims, ...browsedClaims]) {
       for (const topic of topicsByClaimId.get(claim.claim.claim_entity_id) ?? []) {
         if (!seen.has(topic.id)) seen.set(topic.id, topic);
       }
     }
     return [...seen.values()].sort((a, b) => (a.name ?? '').localeCompare(b.name ?? ''));
-  }, [browsedClaims, curatedClaims, opponentClaims, topicsByClaimId]);
+  }, [browsedClaims, curatedClaims, featuredClaims, opponentClaims, topicsByClaimId]);
 
   // Search and space reach the browsed query; on the other tabs, and for the topic everywhere
   // (geo-chat doesn't model topics), they are applied here.
@@ -617,12 +715,14 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
     sessionQuery.isLoading ||
     (tab === 'recommended'
       ? recommendedLoading || curatedClaimsQuery.isLoading
-      : tab === 'opponent'
-        ? positions.isLoading ||
-          opponentEntitiesQuery.isLoading ||
-          opponentClaimsQuery.isLoading ||
-          (landedTabRef.current === null && claims.length === 0 && recommendedLoading)
-        : allowlistPending || browsedClaimsQuery.isLoading);
+      : tab === 'featured'
+        ? featuredClaimsSettling
+        : tab === 'opponent'
+          ? positions.isLoading ||
+            opponentEntitiesQuery.isLoading ||
+            opponentClaimsQuery.isLoading ||
+            (landedTabRef.current === null && claims.length === 0 && recommendedLoading)
+          : allowlistPending || browsedClaimsQuery.isLoading);
 
   const tabError =
     sessionQuery.error ??
@@ -630,7 +730,9 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
       ? (positions.error ?? opponentEntitiesQuery.error)
       : tab === 'all'
         ? browsedClaimsQuery.error
-        : curatedClaimsQuery.error);
+        : tab === 'featured'
+          ? (featuredEntitiesQuery.error ?? featuredClaimsQuery.error)
+          : curatedClaimsQuery.error);
 
   // Settle the landing tab once it has drawn its list (see `landedTabRef`). An empty tab settles
   // nothing: it is still the default, and Recommended may yet take over.
@@ -668,10 +770,11 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   const { authenticated: geoChatAuthenticated } = useGeoChatAuth();
   const scopedSpaceIds = React.useMemo(() => {
     const ids = new Set<string>();
-    for (const claim of [...opponentClaims, ...curatedClaims, ...browsedClaims]) ids.add(claim.claim.space_id);
+    for (const claim of [...opponentClaims, ...curatedClaims, ...featuredClaims, ...browsedClaims])
+      ids.add(claim.claim.space_id);
     for (const participant of participants) ids.add(participant.profile_space_id);
     return [...ids].sort((a, b) => a.localeCompare(b));
-  }, [browsedClaims, curatedClaims, opponentClaims, participants]);
+  }, [browsedClaims, curatedClaims, featuredClaims, opponentClaims, participants]);
   useDebateGatewaySpaceScopes(scopedSpaceIds, geoChatAuthenticated && scopedSpaceIds.length > 0);
 
   // Readiness drives the card's Debate toggle. geo-chat now carries it on the rematch claims
@@ -763,6 +866,10 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
               <TabButton active={tab === 'recommended'} onClick={() => setTab('recommended')}>
                 Recommended
               </TabButton>
+            ) : featuredSlotVisible ? (
+              <TabButton active={tab === 'featured'} onClick={() => setTab('featured')}>
+                Featured
+              </TabButton>
             ) : null}
             <TabButton active={tab === 'opponent'} onClick={() => setTab('opponent')}>
               <span className="max-w-[10rem] truncate">{firstNamePossessive(remoteName)} positions</span>
@@ -846,9 +953,11 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
               ? 'No claims match these filters.'
               : tab === 'recommended'
                 ? `Nothing recommended for you and ${remoteName} yet.`
-                : tab === 'opponent'
-                  ? `${remoteName} hasn’t responded yet. When they do, those claims show up here.`
-                  : 'No other eligible claims are available yet.'
+                : tab === 'featured'
+                  ? 'No featured claims are available to debate yet.'
+                  : tab === 'opponent'
+                    ? `${remoteName} hasn’t responded yet. When they do, those claims show up here.`
+                    : 'No other eligible claims are available yet.'
           }
           emptyAction={
             hasFilters
@@ -1328,22 +1437,6 @@ function claimCandidateSpaceIds(entity: {
   values?: Array<{ isDeleted?: boolean; property: { id: string }; spaceId: string; value: string }>;
 }): string[] {
   return [...new Set([...claimNamedSpaceIds(entity), ...entity.spaces])];
-}
-
-function claimResponseKind(
-  entity: { values?: Array<{ isDeleted?: boolean; property: { id: string }; spaceId: string; value: string }> },
-  spaceId: string
-): 'stance' | 'veracity' {
-  const isFactual =
-    getChecked(
-      entity.values?.find(
-        value =>
-          value.isDeleted !== true &&
-          uuidToHex(value.spaceId) === uuidToHex(spaceId) &&
-          uuidToHex(value.property.id) === uuidToHex(CLAIM_IS_FACTUAL_PROPERTY_ID)
-      )?.value
-    ) === true;
-  return isFactual ? 'veracity' : 'stance';
 }
 
 function rematchCancellationMessage(reason: string) {

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -44,6 +44,7 @@ import {
 } from '~/core/debates/hooks';
 import { SpaceTopicFilters } from '~/core/debates/matchmaking/claims-tab';
 import { useMatchmakingClaims } from '~/core/debates/matchmaking/hooks';
+import { HubFilterMenu, type HubFilterOption } from '~/core/debates/matchmaking/hub-filter-menu';
 import { HubCardList } from '~/core/debates/matchmaking/hub-motion';
 import { HubPillButton } from '~/core/debates/matchmaking/hub-pill-button';
 import { HubQueryState, HubSkeleton } from '~/core/debates/matchmaking/hub-states';
@@ -88,12 +89,20 @@ function useLastSettled<T>(value: T, settling: boolean): T {
   return settling && lastSettledRef.current ? lastSettledRef.current.value : value;
 }
 
+type PickerTab = 'claims' | 'opponent';
+
 /**
- * GEO-2683. `featured` takes Recommended's slot rather than sitting beside it: it is the stand-in
- * for when no curator has put a page together for this pairing, so the two are never both on the
- * strip.
+ * GEO-2683. Where the Claims tab draws its list from. Recommended, Featured and the whole corpus
+ * are three answers to one question — "which claims?" — so they belong in a menu rather than in
+ * three tabs the viewer has to notice appearing and disappearing.
  */
-type PickerTab = 'recommended' | 'featured' | 'opponent' | 'all';
+type ClaimsSource = 'recommended' | 'featured' | 'all';
+
+const CLAIMS_SOURCE_LABELS: Record<ClaimsSource, string> = {
+  recommended: 'Recommended',
+  featured: 'Featured',
+  all: 'All claims',
+};
 
 /**
  * The tab is narrow, so it carries the opponent's first name only: "Jenna Ruiz" -> "Jenna’s".
@@ -119,10 +128,11 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
 
   const [spaceId, setSpaceId] = React.useState<string | null>(null);
   const [topicId, setTopicId] = React.useState<string | null>(null);
-  // Left unset until the viewer picks one: Recommended is the best landing tab when a curator has
-  // put something together for this pairing, and it doesn't exist otherwise. Deciding in state
-  // would fix the default before that lookup settles.
   const [chosenTab, setChosenTab] = React.useState<PickerTab | null>(null);
+  // Left unset until the viewer picks one: Recommended is the best default when a curator has put
+  // something together for this pairing, and it doesn't exist otherwise. Deciding in state would
+  // fix the default before that lookup settles.
+  const [chosenSource, setChosenSource] = React.useState<ClaimsSource | null>(null);
 
   const savedClaimsQuery = useDebateRematchClaims(sessionId);
   const createRequest = useCreateDebateRematchRequest(sessionId);
@@ -196,14 +206,19 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   // allowlist alone: the lists' own lookups run alongside it, so they are ready when it lands.
   const allowlistPending = spaceAllowlist === null && allowlistLoading;
 
-  // GEO-2683. Featured stands in for Recommended when no curator has put a page together for this
-  // pairing, so it is asked for only once that lookup has settled with nothing — there is no point
-  // fetching a list that a curated page would take the slot of.
+  // GEO-2683. Fetched only when Featured is the source on screen — it is one option in a menu, and
+  // the other two answer for themselves.
   //
-  // Narrowed by the viewer's allowlist, unlike Recommended. The reasoning above turns on Recommended
-  // being one page from a space this build trusts by id; Featured is a tag anyone's space can carry,
-  // so it fans out across the corpus the way the All tab does and is bounded the same way.
-  const featuredEnabled = !recommendedLoading && recommendedSections.length === 0;
+  // Narrowed by the viewer's allowlist, unlike Recommended. Recommended is one page from a space
+  // this build trusts by id; Featured is a tag anyone's space can carry, so it fans out across the
+  // corpus the way All claims does and is bounded the same way.
+  const hasRecommended = recommendedSections.length > 0;
+  // Until the curated lookup settles there is no telling "no curator page" from "not yet", and the
+  // default turns on exactly that. The list waits rather than showing Featured and swapping it for
+  // Recommended a moment later.
+  const sourceUndecided = chosenSource === null && recommendedLoading;
+  const source: ClaimsSource = chosenSource ?? (hasRecommended ? 'recommended' : 'featured');
+  const featuredEnabled = source === 'featured' && !sourceUndecided;
   const { claims: featuredCatalog, isLoading: featuredCatalogLoading } = useFeaturedClaims(featuredEnabled);
 
   const featuredClaimIds = React.useMemo(
@@ -624,35 +639,29 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
    */
   const opponentCountPending = opponentClaims.length === 0 && (positions.isLoading || opponentClaimsSettling);
 
-  const hasRecommended = recommendedSections.length > 0;
-  // Featured takes Recommended's slot when there is no curated page for this pairing.
-  const showsFeatured = !hasRecommended && !recommendedLoading;
-  const hasFeatured = showsFeatured && featuredClaims.length > 0;
-  // The slot is filled whenever Recommended isn't, empty or not — unlike Recommended, which hides
-  // when a curator has nothing for this pairing. Recommended's absence is information ("no one
-  // curated this"); Featured's would just be a tab that comes and goes, and a viewer who has seen
-  // it once should be able to go back and find it. It carries its own empty state instead.
-  //
-  // Landing is the separate question, and it waits for `hasFeatured`: putting the viewer on a tab
-  // that then settles empty is worse than never starting them there.
-  const featuredSlotVisible = showsFeatured;
-  // The opponent's claims arrive in one round trip; the curated lookup is three, in sequence. The
-  // picker lands on whichever has something to show first and stays there: once a tab has drawn
-  // its list the landing is settled, so a curated page arriving afterwards adds its tab to the
-  // strip rather than moving the viewer onto it. Before then Recommended wins as soon as it is
-  // known to exist, since a curator's page for this pairing is the best thing to land on — and an
-  // opponent's tab with nothing on it waits for that lookup rather than settling on an empty state.
-  const landedTabRef = React.useRef<PickerTab | null>(null);
-  const tab: PickerTab =
-    chosenTab ?? landedTabRef.current ?? (hasRecommended ? 'recommended' : hasFeatured ? 'featured' : 'opponent');
+  // Claims is where the picker opens, whatever its source turns out to be. The strip no longer
+  // shifts under the viewer as lookups land: which claims Claims shows is the menu's business now,
+  // and the menu says so in words rather than by growing a tab.
+  const tab: PickerTab = chosenTab ?? 'claims';
   const setTab = setChosenTab;
+
+  // Recommended is offered only when a curator has a page for this pairing; the order is fixed, so
+  // a source that appears doesn't reshuffle the ones already in the menu.
+  const sourceOptions = React.useMemo<HubFilterOption<ClaimsSource>[]>(
+    () =>
+      (hasRecommended ? (['recommended', 'featured', 'all'] as const) : (['featured', 'all'] as const)).map(value => ({
+        value,
+        label: CLAIMS_SOURCE_LABELS[value],
+      })),
+    [hasRecommended]
+  );
 
   const claims =
     tab === 'opponent'
       ? opponentClaims
-      : tab === 'recommended'
+      : source === 'recommended'
         ? curatedClaims
-        : tab === 'featured'
+        : source === 'featured'
           ? featuredClaims
           : browsedClaims;
 
@@ -690,61 +699,54 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
         if (spaceId && claim.claim.space_id !== spaceId) return false;
         if (topicId && !(topicsByClaimId.get(claim.claim.claim_entity_id) ?? []).some(t => t.id === topicId))
           return false;
-        if (
-          tab !== 'all' &&
-          debouncedSearch &&
-          !claim.claim.claim.toLowerCase().includes(debouncedSearch.toLowerCase())
-        )
+        // All claims searches server-side, in the browsed query. Every other list is in memory.
+        const searchesHere = !(tab === 'claims' && source === 'all');
+        if (searchesHere && debouncedSearch && !claim.claim.claim.toLowerCase().includes(debouncedSearch.toLowerCase()))
           return false;
         return true;
       }),
-    [claims, debouncedSearch, spaceId, tab, topicId, topicsByClaimId]
+    [claims, debouncedSearch, source, spaceId, tab, topicId, topicsByClaimId]
   );
 
   const hasFilters = Boolean(debouncedSearch || spaceId || topicId);
 
+  // Only All claims is paged; the other two sources come whole.
+  const browsesPages = tab === 'claims' && source === 'all';
+  const hasNextPage = browsesPages && Boolean(browsedClaimsQuery.hasNextPage);
+
   const sentinelRef = useInfiniteScrollSentinel({
-    hasNextPage: Boolean(browsedClaimsQuery.hasNextPage),
+    hasNextPage,
     isFetchingNextPage: browsedClaimsQuery.isFetchingNextPage,
     fetchNextPage: browsedClaimsQuery.fetchNextPage,
   });
 
-  // Each tab draws from a different set of queries, so each waits on its own. The allowlist narrows
-  // the All tab alone now, so only that one waits for it.
+  // Each list draws from a different set of queries, so each waits on its own. The allowlist narrows
+  // All claims alone now, so only that one waits for it.
   const tabIsLoading =
     sessionQuery.isLoading ||
-    (tab === 'recommended'
-      ? recommendedLoading || curatedClaimsQuery.isLoading
-      : tab === 'featured'
-        ? featuredClaimsSettling
-        : tab === 'opponent'
-          ? positions.isLoading ||
-            opponentEntitiesQuery.isLoading ||
-            opponentClaimsQuery.isLoading ||
-            (landedTabRef.current === null && claims.length === 0 && recommendedLoading)
-          : allowlistPending || browsedClaimsQuery.isLoading);
+    (tab === 'opponent'
+      ? positions.isLoading || opponentEntitiesQuery.isLoading || opponentClaimsQuery.isLoading
+      : sourceUndecided ||
+        (source === 'recommended'
+          ? recommendedLoading || curatedClaimsQuery.isLoading
+          : source === 'featured'
+            ? featuredClaimsSettling
+            : allowlistPending || browsedClaimsQuery.isLoading));
 
   const tabError =
     sessionQuery.error ??
     (tab === 'opponent'
       ? (positions.error ?? opponentEntitiesQuery.error)
-      : tab === 'all'
+      : source === 'all'
         ? browsedClaimsQuery.error
-        : tab === 'featured'
+        : source === 'featured'
           ? (featuredEntitiesQuery.error ?? featuredClaimsQuery.error)
           : curatedClaimsQuery.error);
 
-  // Settle the landing tab once it has drawn its list (see `landedTabRef`). An empty tab settles
-  // nothing: it is still the default, and Recommended may yet take over.
-  const tabHasRows = claims.length > 0;
-  React.useEffect(() => {
-    if (chosenTab !== null || landedTabRef.current !== null || tabIsLoading || !tabHasRows) return;
-    landedTabRef.current = tab;
-  }, [chosenTab, tab, tabHasRows, tabIsLoading]);
-
-  // The curated tab groups by block rather than listing flat, but narrows on the same filters.
+  // Recommended groups by block rather than listing flat, but narrows on the same filters.
+  const showsSections = tab === 'claims' && source === 'recommended';
   const visibleSections = React.useMemo(() => {
-    if (tab !== 'recommended') return [];
+    if (!showsSections) return [];
     const visibleById = new Map(visibleClaims.map(claim => [claim.claim.claim_entity_id, claim]));
 
     return recommendedSections
@@ -755,7 +757,7 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
           .filter((claim): claim is DebateRematchClaim => claim !== undefined),
       }))
       .filter(section => section.claims.length > 0);
-  }, [recommendedSections, tab, visibleClaims]);
+  }, [recommendedSections, showsSections, visibleClaims]);
 
   // `debate.claims_changed` is delivered per space, and it is what turns the opponent's new
   // response into a refresh of this page rather than something the poll finds up to twenty seconds
@@ -783,11 +785,13 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   const { byClaimId: readinessByClaimId, unresolved: readinessUnresolved } = useClaimReadinessByClaimId({
     claims,
     unresolved:
-      tab === 'all'
-        ? browsedClaimsQuery.isLoading || Boolean(browsedClaimsQuery.error)
-        : tab === 'opponent'
-          ? opponentClaimsQuery.isLoading || Boolean(opponentClaimsQuery.error)
-          : curatedClaimsQuery.isLoading || Boolean(curatedClaimsQuery.error),
+      tab === 'opponent'
+        ? opponentClaimsQuery.isLoading || Boolean(opponentClaimsQuery.error)
+        : source === 'all'
+          ? browsedClaimsQuery.isLoading || Boolean(browsedClaimsQuery.error)
+          : source === 'featured'
+            ? featuredClaimsQuery.isLoading || Boolean(featuredClaimsQuery.error)
+            : curatedClaimsQuery.isLoading || Boolean(curatedClaimsQuery.error),
   });
 
   React.useEffect(() => {
@@ -862,15 +866,9 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
               gives those tabs somewhere to go, and `overscroll-x-contain` stops a swipe that
               reaches the end from chaining into the browser's back gesture. */}
           <div className="no-scrollbar flex min-w-0 flex-1 items-center gap-5 overflow-x-auto overscroll-x-contain">
-            {hasRecommended || recommendedLoading ? (
-              <TabButton active={tab === 'recommended'} onClick={() => setTab('recommended')}>
-                Recommended
-              </TabButton>
-            ) : featuredSlotVisible ? (
-              <TabButton active={tab === 'featured'} onClick={() => setTab('featured')}>
-                Featured
-              </TabButton>
-            ) : null}
+            <TabButton active={tab === 'claims'} onClick={() => setTab('claims')}>
+              Claims
+            </TabButton>
             <TabButton active={tab === 'opponent'} onClick={() => setTab('opponent')}>
               <span className="max-w-[10rem] truncate">{firstNamePossessive(remoteName)} positions</span>
               <span
@@ -888,9 +886,6 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
                   opponentPositionCount
                 )}
               </span>
-            </TabButton>
-            <TabButton active={tab === 'all'} onClick={() => setTab('all')}>
-              All
             </TabButton>
           </div>
           <button
@@ -914,6 +909,18 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
             facetSpaceIds={facetSpaceIds}
             facetTopics={facetTopics}
             className="justify-between"
+            // Only on Claims: the opponent's tab is one fixed source — their own responses — and a
+            // menu offering three others there would read as filtering a list it can't reach.
+            leading={
+              tab === 'claims' ? (
+                <HubFilterMenu
+                  label={CLAIMS_SOURCE_LABELS[source]}
+                  options={sourceOptions}
+                  value={source}
+                  onChange={setChosenSource}
+                />
+              ) : null
+            }
           />
           <Input
             withSearchIcon
@@ -943,20 +950,18 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
           // Only what the visible tab actually draws from, and only while it has nothing to show.
           // Holding every tab on the slowest query meant the session's own claims — which arrive in
           // one round trip — sat behind a graph-wide scan they don't come from.
-          isLoading={
-            tabIsLoading && (tab === 'recommended' ? visibleSections.length === 0 : visibleClaims.length === 0)
-          }
+          isLoading={tabIsLoading && (showsSections ? visibleSections.length === 0 : visibleClaims.length === 0)}
           error={tabError}
-          isEmpty={tab === 'recommended' ? visibleSections.length === 0 : visibleClaims.length === 0}
+          isEmpty={showsSections ? visibleSections.length === 0 : visibleClaims.length === 0}
           emptyMessage={
             hasFilters
               ? 'No claims match these filters.'
-              : tab === 'recommended'
-                ? `Nothing recommended for you and ${remoteName} yet.`
-                : tab === 'featured'
-                  ? 'No featured claims are available to debate yet.'
-                  : tab === 'opponent'
-                    ? `${remoteName} hasn’t responded yet. When they do, those claims show up here.`
+              : tab === 'opponent'
+                ? `${remoteName} hasn’t responded yet. When they do, those claims show up here.`
+                : source === 'recommended'
+                  ? `Nothing recommended for you and ${remoteName} yet.`
+                  : source === 'featured'
+                    ? 'No featured claims are available to debate yet.'
                     : 'No other eligible claims are available yet.'
           }
           emptyAction={
@@ -972,7 +977,7 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
               : undefined
           }
         >
-          {tab === 'recommended' ? (
+          {showsSections ? (
             // Each data block on the curator's page is its own section, in page order.
             <div className="flex flex-col gap-4">
               {visibleSections.map(section => (
@@ -987,17 +992,17 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
         </HubQueryState>
 
         {/* Outside the empty state deliberately: when a filter empties the list, the next page is
-            the way out, so the sentinel has to stay reachable. Only on the All tab: the curated
-            tab's sections come from the page whole, and the opponent's tab is the whole of what
-            the graph knows about them, in one query. Not while the allowlist is pending either —
-            the picker is showing a loading state then. */}
-        {tab === 'all' && browsedClaimsQuery.hasNextPage && !allowlistPending ? (
+            the way out, so the sentinel has to stay reachable. Only under All claims: Recommended's
+            sections come from the curator's page whole, Featured is one graph query, and the
+            opponent's tab is the whole of what the graph knows about them. Not while the allowlist
+            is pending either — the picker is showing a loading state then. */}
+        {hasNextPage && !allowlistPending ? (
           <div ref={sentinelRef} data-testid="claims-scroll-sentinel" className="h-px" />
         ) : null}
         {/* The same skeleton the list shows on first load, so the next batch reads as more of
             the same list arriving rather than a different component. Without it the sentinel
             fires silently and the list just sits there until the page lands. */}
-        {tab === 'all' && browsedClaimsQuery.isFetchingNextPage ? (
+        {browsesPages && browsedClaimsQuery.isFetchingNextPage ? (
           <div className="mt-2" data-testid="claims-next-page-skeleton">
             <HubSkeleton rows={2} />
           </div>

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -28,7 +28,7 @@ import { useDebateGatewaySpaceScopes } from '~/core/debates/debate-gateway';
 import { debatePublishableSpacePredicate } from '~/core/debates/debate-publish-target';
 import { DebateRequestDialog } from '~/core/debates/debate-request-dialog';
 import { consumeDebateReturnDestination } from '~/core/debates/debate-return-navigation';
-import { useFeaturedClaims } from '~/core/debates/featured-claims';
+import { dedupeFeaturedClaims, useFeaturedClaims } from '~/core/debates/featured-claims';
 import { defaultDebateFormatId } from '~/core/debates/formats';
 import {
   useAcceptDebateRematchRequest,
@@ -134,6 +134,12 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   // fix the default before that lookup settles.
   const [chosenSource, setChosenSource] = React.useState<ClaimsSource | null>(null);
 
+  // Claims is where the picker opens, whatever its source turns out to be. The strip no longer
+  // shifts under the viewer as lookups land: which claims Claims shows is the menu's business now,
+  // and the menu says so in words rather than by growing a tab.
+  const tab: PickerTab = chosenTab ?? 'claims';
+  const setTab = setChosenTab;
+
   const savedClaimsQuery = useDebateRematchClaims(sessionId);
   const createRequest = useCreateDebateRematchRequest(sessionId);
   const leaveSession = useLeaveDebateRematch(sessionId);
@@ -218,16 +224,25 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   // Recommended a moment later.
   const sourceUndecided = chosenSource === null && recommendedLoading;
   const source: ClaimsSource = chosenSource ?? (hasRecommended ? 'recommended' : 'featured');
-  const featuredEnabled = source === 'featured' && !sourceUndecided;
-  const { claims: featuredCatalog, isLoading: featuredCatalogLoading } = useFeaturedClaims(featuredEnabled);
+  // Gated on the tab too: a remembered Featured source shouldn't keep a graph query alive behind the
+  // opponent's positions, which draw from somewhere else entirely.
+  const featuredEnabled = tab === 'claims' && source === 'featured' && !sourceUndecided;
+  const {
+    claims: featuredCatalog,
+    isLoading: featuredCatalogLoading,
+    error: featuredCatalogError,
+  } = useFeaturedClaims(featuredEnabled);
 
+  // Collapsed to one row per claim *after* the allowlist, not before. A claim can be tagged in
+  // several spaces, and deduplicating first would let a space outside the allowlist stand for a
+  // claim featured in one inside it — dropping it from the list entirely.
   const featuredClaimIds = React.useMemo(
     () =>
       allowlistPending
         ? []
-        : featuredCatalog
-            .filter(claim => isClaimSpaceAllowed(claim.spaceId, spaceAllowlist))
-            .map(claim => claim.claimEntityId),
+        : dedupeFeaturedClaims(featuredCatalog.filter(claim => isClaimSpaceAllowed(claim.spaceId, spaceAllowlist))).map(
+            claim => claim.claimEntityId
+          ),
     [allowlistPending, featuredCatalog, spaceAllowlist]
   );
 
@@ -475,7 +490,7 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   // index has not paged to yet and belong in a list of everything; Featured is a few hundred claims
   // the index already knows, so folding them in would pin them above what the viewer searched for.
   const featuredClaimsSettling =
-    featuredCatalogLoading || featuredEntitiesQuery.isLoading || featuredClaimsQuery.isLoading;
+    allowlistPending || featuredCatalogLoading || featuredEntitiesQuery.isLoading || featuredClaimsQuery.isLoading;
   const featuredClaimsNow = React.useMemo(
     () =>
       featuredClaimsSettling
@@ -639,12 +654,6 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
    */
   const opponentCountPending = opponentClaims.length === 0 && (positions.isLoading || opponentClaimsSettling);
 
-  // Claims is where the picker opens, whatever its source turns out to be. The strip no longer
-  // shifts under the viewer as lookups land: which claims Claims shows is the menu's business now,
-  // and the menu says so in words rather than by growing a tab.
-  const tab: PickerTab = chosenTab ?? 'claims';
-  const setTab = setChosenTab;
-
   // Recommended is offered only when a curator has a page for this pairing; the order is fixed, so
   // a source that appears doesn't reshuffle the ones already in the menu.
   const sourceOptions = React.useMemo<HubFilterOption<ClaimsSource>[]>(
@@ -740,7 +749,7 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
       : source === 'all'
         ? browsedClaimsQuery.error
         : source === 'featured'
-          ? (featuredEntitiesQuery.error ?? featuredClaimsQuery.error)
+          ? (featuredCatalogError ?? featuredEntitiesQuery.error ?? featuredClaimsQuery.error)
           : curatedClaimsQuery.error);
 
   // Recommended groups by block rather than listing flat, but narrows on the same filters.

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -28,7 +28,7 @@ import { useDebateGatewaySpaceScopes } from '~/core/debates/debate-gateway';
 import { debatePublishableSpacePredicate } from '~/core/debates/debate-publish-target';
 import { DebateRequestDialog } from '~/core/debates/debate-request-dialog';
 import { consumeDebateReturnDestination } from '~/core/debates/debate-return-navigation';
-import { dedupeFeaturedClaims, useFeaturedClaims } from '~/core/debates/featured-claims';
+import { type FeaturedClaim, dedupeFeaturedClaims, useFeaturedClaims } from '~/core/debates/featured-claims';
 import { defaultDebateFormatId } from '~/core/debates/formats';
 import {
   useAcceptDebateRematchRequest,
@@ -71,6 +71,9 @@ import { Spinner } from '~/design-system/spinner';
 import { Text } from '~/design-system/text';
 
 const SEARCH_DEBOUNCE_MS = 250;
+
+/** Stable identity so the hydration below doesn't restart whenever Featured isn't the source. */
+const NO_FEATURED_CLAIMS: FeaturedClaim[] = [];
 
 const NO_PARTICIPANTS: DebateRematchParticipant[] = [];
 
@@ -236,14 +239,24 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   // Collapsed to one row per claim *after* the allowlist, not before. A claim can be tagged in
   // several spaces, and deduplicating first would let a space outside the allowlist stand for a
   // claim featured in one inside it — dropping it from the list entirely.
-  const featuredClaimIds = React.useMemo(
+  //
+  // The tag survives rather than just its id. Its space is the space the claim is featured in, and
+  // the only one here known to have passed the allowlist — the rows below are built against it.
+  //
+  // Gated on `featuredEnabled` too, not only on the fetch: `enabled: false` leaves react-query's
+  // cached rows in place, and the hub shares this key, so a catalog fetched there would otherwise
+  // keep the hydration below mounted and refetching behind Recommended or the opponent's tab.
+  const featuredSelection = React.useMemo(
     () =>
-      allowlistPending
-        ? []
-        : dedupeFeaturedClaims(featuredCatalog.filter(claim => isClaimSpaceAllowed(claim.spaceId, spaceAllowlist))).map(
-            claim => claim.claimEntityId
-          ),
-    [allowlistPending, featuredCatalog, spaceAllowlist]
+      !featuredEnabled || allowlistPending
+        ? NO_FEATURED_CLAIMS
+        : dedupeFeaturedClaims(featuredCatalog.filter(claim => isClaimSpaceAllowed(claim.spaceId, spaceAllowlist))),
+    [allowlistPending, featuredCatalog, featuredEnabled, spaceAllowlist]
+  );
+
+  const featuredClaimIds = React.useMemo(
+    () => featuredSelection.map(claim => claim.claimEntityId),
+    [featuredSelection]
   );
 
   // The same two lookups the curated tab makes: the claim entities the picker's rows are built
@@ -374,10 +387,20 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
     [publishableSpaceIds, spaceTypePublishable]
   );
 
-  /** A picker row from a graph entity, with geo-chat's session row layered on when it has one. */
+  /**
+   * A picker row from a graph entity, with geo-chat's session row layered on when it has one.
+   *
+   * `preferredSpaceId` overrides the space ranking where the caller already knows which space the
+   * claim belongs to it in. Featured passes the space its tag was written in: the ranking picks the
+   * highest-ranked space the claim is *named* in, which knows nothing of the viewer's allowlist, so
+   * without this a claim featured in an allowed space could be drawn — and its debate requested — in
+   * a disallowed one that happens to outrank it. Ignored when a debate could never be published
+   * there, since that is the one thing the ranking does already screen for.
+   */
   const rowFromEntity = React.useCallback(
-    (entity: ClaimPickerEntity): DebateRematchClaim | null => {
-      const homeSpaceId = claimHomeSpaceId(entity, canPublishDebateIn);
+    (entity: ClaimPickerEntity, preferredSpaceId?: string): DebateRematchClaim | null => {
+      const preferred = preferredSpaceId && canPublishDebateIn(preferredSpaceId) ? preferredSpaceId : null;
+      const homeSpaceId = preferred ?? claimHomeSpaceId(entity, canPublishDebateIn);
       if (!entity.name || !homeSpaceId) return null;
       const sessionRow = sessionRowsByClaimId.get(entity.id);
       const responseKind = sessionRow?.response_kind ?? claimResponseKind(entity, homeSpaceId);
@@ -495,19 +518,24 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
     () =>
       featuredClaimsSettling
         ? []
-        : featuredClaimIds.flatMap(claimId => {
-            if (excludedClaimIds.has(claimId)) return [];
-            const entity = featuredEntitiesQuery.entities.find(candidate => candidate.id === claimId);
-            const row = entity ? rowFromEntity(entity) : null;
-            return row && canPublishDebateIn(row.claim.space_id) ? [row] : [];
+        : featuredSelection.flatMap(featured => {
+            if (excludedClaimIds.has(featured.claimEntityId)) return [];
+            const entity = featuredEntitiesQuery.entities.find(candidate => candidate.id === featured.claimEntityId);
+            const row = entity ? rowFromEntity(entity, featured.spaceId) : null;
+            // Both gates, against the space the row actually carries. `rowFromEntity` takes geo-chat's
+            // session row whole where it has one, and that row names its own space — so checking the
+            // tag's space alone would let a claim through in one the viewer may not be shown.
+            if (!row || !canPublishDebateIn(row.claim.space_id)) return [];
+            return isClaimSpaceAllowed(row.claim.space_id, spaceAllowlist) ? [row] : [];
           }),
     [
       canPublishDebateIn,
       excludedClaimIds,
-      featuredClaimIds,
       featuredClaimsSettling,
       featuredEntitiesQuery.entities,
+      featuredSelection,
       rowFromEntity,
+      spaceAllowlist,
     ]
   );
   const featuredClaims = useLastSettled(featuredClaimsNow, featuredClaimsSettling);

--- a/apps/web/core/claims/response-kind.ts
+++ b/apps/web/core/claims/response-kind.ts
@@ -1,0 +1,29 @@
+import { uuidToHex } from '~/core/id/normalize';
+
+import { getChecked } from '~/design-system/checkbox';
+
+import { CLAIM_IS_FACTUAL_PROPERTY_ID } from './ontology';
+
+/** The subset of an entity this reads. A full `Entity` satisfies it structurally. */
+type ClaimValues = {
+  values?: Array<{ isDeleted?: boolean; property: { id: string }; spaceId: string; value: string }>;
+};
+
+/**
+ * Which vocabulary labels a claim's two sides: Verify/Dispute for a factual claim, Agree/Disagree
+ * otherwise.
+ *
+ * Read per space on purpose. "Is factual" is a value like any other, so two spaces can disagree
+ * about the same claim, and the side labels have to match the space the response is published
+ * against.
+ */
+export function claimResponseKind(claim: ClaimValues, spaceId: string): 'stance' | 'veracity' {
+  const isFactual = claim.values?.find(
+    value =>
+      value.isDeleted !== true &&
+      uuidToHex(value.spaceId) === uuidToHex(spaceId) &&
+      uuidToHex(value.property.id) === uuidToHex(CLAIM_IS_FACTUAL_PROPERTY_ID)
+  )?.value;
+
+  return getChecked(isFactual) === true ? 'veracity' : 'stance';
+}

--- a/apps/web/core/debates/featured-claims.test.ts
+++ b/apps/web/core/debates/featured-claims.test.ts
@@ -3,7 +3,7 @@ import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { graphql } from '~/core/io/graphql-client';
 
-import { fetchFeaturedClaims } from './featured-claims';
+import { FEATURED_CLAIMS_LIMIT, dedupeFeaturedClaims, fetchFeaturedClaims } from './featured-claims';
 
 vi.mock('~/core/io/graphql-client', () => ({
   graphql: vi.fn(),
@@ -17,9 +17,22 @@ function node(id: string, name: string, rankingScore: string | null, spaceId = S
   return { spaceId, fromEntity: { id, name, description: null, rankingScore } };
 }
 
-/** Runs the module's own decoder over `nodes`, which is what the ordering lives in. */
+/** Runs the module's own decoder over one page of `nodes`, which is where the ordering lives. */
 function respondWith(nodes: unknown[]) {
-  graphqlMock.mockImplementation(({ decoder }) => Effect.succeed(decoder({ relationsConnection: { nodes } })));
+  respondWithPages([nodes]);
+}
+
+/** Answers each successive request with the next page, the last one closing the connection. */
+function respondWithPages(pages: unknown[][]) {
+  let index = 0;
+  graphqlMock.mockImplementation(({ decoder }) => {
+    const nodes = pages[index] ?? [];
+    const hasNextPage = index < pages.length - 1;
+    index += 1;
+    return Effect.succeed(
+      decoder({ relationsConnection: { pageInfo: { hasNextPage, endCursor: `cursor-${index}` }, nodes } })
+    );
+  });
 }
 
 function namesOf(claims: Array<{ name: string }>) {
@@ -55,13 +68,54 @@ describe('fetchFeaturedClaims', () => {
     expect(namesOf(await fetchFeaturedClaims())).toEqual(['Scored', 'Unscored']);
   });
 
-  it('keeps the first tag when a claim is featured in more than one space', async () => {
+  // Every tag survives the fetch. Which space a viewer may be shown is a question only the callers
+  // can answer, so collapsing here would make an arbitrary one authoritative — and drop the claim
+  // outright when that one falls outside their allowlist and another tag would have passed.
+  it('keeps every tag when a claim is featured in more than one space', async () => {
     const OTHER_SPACE = '019fedae72b67ab2927adf044d57c599';
     respondWith([node('a1', 'Tagged twice', '10'), node('a1', 'Tagged twice', '10', OTHER_SPACE)]);
 
+    expect((await fetchFeaturedClaims()).map(claim => claim.spaceId)).toEqual([SPACE, OTHER_SPACE]);
+  });
+
+  // A page-worth of tags is a sample, not the set: the connection orders by relation id, which is a
+  // random v4, so a capped single request would drop rows at random from a list that is then ranked.
+  it('pages to exhaustion and ranks the whole set, not the first page', async () => {
+    respondWithPages([
+      [node('a1', 'Page one, low', '10')],
+      [node('a2', 'Page two, high', '900')],
+      [node('a3', 'Page three, middling', '100')],
+    ]);
+
+    expect(namesOf(await fetchFeaturedClaims())).toEqual(['Page two, high', 'Page three, middling', 'Page one, low']);
+    expect(graphqlMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('passes the previous page cursor along', async () => {
+    respondWithPages([[node('a1', 'One', '1')], [node('a2', 'Two', '2')]]);
+
+    await fetchFeaturedClaims();
+
+    expect(graphqlMock.mock.calls.map(call => call[0].variables.after)).toEqual([null, 'cursor-1']);
+  });
+
+  // A guard against a mis-tagging pointing the whole corpus at Featured, not a product limit.
+  it('stops at the runaway guard rather than paging forever', async () => {
+    graphqlMock.mockImplementation(({ decoder }) =>
+      Effect.succeed(
+        decoder({
+          relationsConnection: {
+            pageInfo: { hasNextPage: true, endCursor: 'cursor' },
+            nodes: Array.from({ length: 500 }, (_, index) => node(`a${index}`, `Claim ${index}`, '1')),
+          },
+        })
+      )
+    );
+
     const claims = await fetchFeaturedClaims();
-    expect(claims).toHaveLength(1);
-    expect(claims[0]!.spaceId).toBe(SPACE);
+
+    expect(claims.length).toBeGreaterThanOrEqual(FEATURED_CLAIMS_LIMIT);
+    expect(graphqlMock.mock.calls.length).toBeLessThanOrEqual(Math.ceil(FEATURED_CLAIMS_LIMIT / 500));
   });
 
   // A claim with no name has nothing to render, and one whose tag carries no space can't be grouped
@@ -76,5 +130,28 @@ describe('fetchFeaturedClaims', () => {
     ]);
 
     expect(namesOf(await fetchFeaturedClaims())).toEqual(['Fine']);
+  });
+});
+
+describe('dedupeFeaturedClaims', () => {
+  function claim(claimEntityId: string, spaceId: string) {
+    return { claimEntityId, spaceId, name: claimEntityId, description: null, rankingScore: 1 };
+  }
+
+  it('keeps the first entry for each claim', () => {
+    const first = claim('a1', 'space-1');
+    const second = claim('a1', 'space-2');
+
+    expect(dedupeFeaturedClaims([first, second, claim('a2', 'space-1')])).toEqual([first, claim('a2', 'space-1')]);
+  });
+
+  // The point of deduplicating late: run after a space filter, the tag that survives is one the
+  // viewer may actually be shown.
+  it('collapses onto whichever tag survived a space filter', () => {
+    const allowed = claim('a1', 'space-2');
+
+    expect(dedupeFeaturedClaims([claim('a1', 'space-1'), allowed].filter(c => c.spaceId === 'space-2'))).toEqual([
+      allowed,
+    ]);
   });
 });

--- a/apps/web/core/debates/featured-claims.test.ts
+++ b/apps/web/core/debates/featured-claims.test.ts
@@ -1,0 +1,80 @@
+import * as Effect from 'effect/Effect';
+import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { graphql } from '~/core/io/graphql-client';
+
+import { fetchFeaturedClaims } from './featured-claims';
+
+vi.mock('~/core/io/graphql-client', () => ({
+  graphql: vi.fn(),
+}));
+
+const graphqlMock = graphql as unknown as Mock;
+
+const SPACE = '019fedae72b67ab2927adf044d57c566';
+
+function node(id: string, name: string, rankingScore: string | null, spaceId = SPACE) {
+  return { spaceId, fromEntity: { id, name, description: null, rankingScore } };
+}
+
+/** Runs the module's own decoder over `nodes`, which is what the ordering lives in. */
+function respondWith(nodes: unknown[]) {
+  graphqlMock.mockImplementation(({ decoder }) => Effect.succeed(decoder({ relationsConnection: { nodes } })));
+}
+
+function namesOf(claims: Array<{ name: string }>) {
+  return claims.map(claim => claim.name);
+}
+
+describe('fetchFeaturedClaims', () => {
+  beforeEach(() => {
+    graphqlMock.mockReset();
+  });
+
+  // Unordered, the relations connection comes back by relation id — random v4s, so a fixed shuffle
+  // with no relationship to anything a reader would recognise. This is Explore's "Best" order.
+  it('orders by ranking score, highest first', async () => {
+    respondWith([node('a1', 'Middling', '120.5'), node('a2', 'Best', '900.25'), node('a3', 'Worst', '3')]);
+
+    expect(namesOf(await fetchFeaturedClaims())).toEqual(['Best', 'Middling', 'Worst']);
+  });
+
+  // `entities_ranked_for_feed` breaks ties on `entity_id DESC`, so two claims on the same score land
+  // here exactly where Explore puts them.
+  it('breaks a tie on entity id, descending, as the ranked feed does', async () => {
+    respondWith([node('a1', 'Lower id', '500'), node('a3', 'Higher id', '500'), node('a2', 'Middle id', '500')]);
+
+    expect(namesOf(await fetchFeaturedClaims())).toEqual(['Higher id', 'Middle id', 'Lower id']);
+  });
+
+  // A claim the feed has never scored isn't in that table, so there is no place in the order for
+  // it. Last rather than dropped: a curator tagged it deliberately.
+  it('puts an unscored claim last rather than dropping it', async () => {
+    respondWith([node('a1', 'Unscored', null), node('a2', 'Scored', '1')]);
+
+    expect(namesOf(await fetchFeaturedClaims())).toEqual(['Scored', 'Unscored']);
+  });
+
+  it('keeps the first tag when a claim is featured in more than one space', async () => {
+    const OTHER_SPACE = '019fedae72b67ab2927adf044d57c599';
+    respondWith([node('a1', 'Tagged twice', '10'), node('a1', 'Tagged twice', '10', OTHER_SPACE)]);
+
+    const claims = await fetchFeaturedClaims();
+    expect(claims).toHaveLength(1);
+    expect(claims[0]!.spaceId).toBe(SPACE);
+  });
+
+  // A claim with no name has nothing to render, and one whose tag carries no space can't be grouped
+  // for the geo-chat lookups or tested against the viewer's spaces.
+  it('drops rows it could not render or scope', async () => {
+    respondWith([
+      node('a1', 'Fine', '10'),
+      { spaceId: SPACE, fromEntity: { id: 'a2', name: null, description: null, rankingScore: '99' } },
+      { spaceId: null, fromEntity: { id: 'a3', name: 'No space', description: null, rankingScore: '99' } },
+      { spaceId: SPACE, fromEntity: null },
+      null,
+    ]);
+
+    expect(namesOf(await fetchFeaturedClaims())).toEqual(['Fine']);
+  });
+});

--- a/apps/web/core/debates/featured-claims.ts
+++ b/apps/web/core/debates/featured-claims.ts
@@ -20,6 +20,10 @@ import { graphql } from '~/core/io/graphql-client';
  * The relation carries the space it was written in, which is the space the claim was featured
  * *in* — a better answer than ranking the claim's spaces after the fact, and the one both callers
  * use to group their geo-chat lookups.
+ *
+ * `rankingScore` rides along so the list can be ordered the way Explore's "Best" sort and geo-chat
+ * both order theirs. Unordered, this connection comes back by relation id, and those are random
+ * v4s — a fixed shuffle with no relationship to anything a reader would recognise.
  */
 const FEATURED_CLAIMS_SOURCE = /* GraphQL */ `
   query FeaturedClaims(
@@ -43,6 +47,7 @@ const FEATURED_CLAIMS_SOURCE = /* GraphQL */ `
           id
           name
           description
+          rankingScore
         }
       }
     }
@@ -53,7 +58,13 @@ type FeaturedClaimsQuery = {
   relationsConnection: {
     nodes: Array<{
       spaceId: string | null;
-      fromEntity: { id: string; name: string | null; description: string | null } | null;
+      fromEntity: {
+        id: string;
+        name: string | null;
+        description: string | null;
+        // `BigFloat`, so it arrives as a string.
+        rankingScore: string | null;
+      } | null;
     } | null> | null;
   } | null;
 };
@@ -84,7 +95,27 @@ export type FeaturedClaim = {
   spaceId: string;
   name: string;
   description: string | null;
+  /** `null` for a claim the ranking feed has never scored. */
+  rankingScore: number | null;
 };
+
+/**
+ * Explore's "Best" order, which is `entities_ranked_for_feed`'s own
+ * `ORDER BY ranking_score DESC, entity_id DESC` — the tiebreak included, so two claims on the same
+ * score land the same way here as they do there.
+ *
+ * A claim the feed has never scored isn't in that table at all, so there is no place in the order
+ * for it. It goes last rather than being dropped: a curator tagged it deliberately, and leaving it
+ * out would quietly overrule them.
+ */
+export function compareFeaturedClaims(a: FeaturedClaim, z: FeaturedClaim): number {
+  if (a.rankingScore !== z.rankingScore) {
+    if (a.rankingScore === null) return 1;
+    if (z.rankingScore === null) return -1;
+    return z.rankingScore - a.rankingScore;
+  }
+  return z.claimEntityId.localeCompare(a.claimEntityId);
+}
 
 function decodeFeaturedClaims(data: FeaturedClaimsQuery): FeaturedClaim[] {
   const claims: FeaturedClaim[] = [];
@@ -103,10 +134,13 @@ function decodeFeaturedClaims(data: FeaturedClaimsQuery): FeaturedClaim[] {
       spaceId: node.spaceId,
       name: node.fromEntity.name,
       description: node.fromEntity.description,
+      rankingScore: node.fromEntity.rankingScore === null ? null : Number(node.fromEntity.rankingScore),
     });
   }
 
-  return claims;
+  // Sorted here rather than in the query: the connection can only order by its own columns, and the
+  // score belongs to the claim on the other end of the relation.
+  return claims.sort(compareFeaturedClaims);
 }
 
 export function fetchFeaturedClaims(signal?: AbortSignal): Promise<FeaturedClaim[]> {
@@ -136,9 +170,10 @@ export const featuredClaimsQueryKey = ['featured-claims', 'claims'] as const;
 const NO_FEATURED_CLAIMS: FeaturedClaim[] = [];
 
 /**
- * Every claim tagged Featured, unfiltered. Callers narrow it to the spaces they may show — the
- * viewer's allowlist and the acceptor's editor spaces — because which spaces those are is a
- * different question in the hub than it is in the rematch picker.
+ * Every claim tagged Featured, in Explore's "Best" order and unfiltered. Callers narrow it to the
+ * spaces they may show — the viewer's allowlist and the acceptor's editor spaces — because which
+ * spaces those are is a different question in the hub than it is in the rematch picker. Narrowing
+ * preserves the order, so what survives is still ranked.
  *
  * Curation moves at human speed, so this stays fresh for a good while; both callers ask for the
  * same key and share the one request.

--- a/apps/web/core/debates/featured-claims.ts
+++ b/apps/web/core/debates/featured-claims.ts
@@ -10,6 +10,7 @@ import { parse } from 'graphql';
 import { CLAIM_TYPE_ID } from '~/core/claims/ontology';
 import { FEATURED_TAG_ID, TAG_PROPERTY_ID } from '~/core/constants';
 import { graphql } from '~/core/io/graphql-client';
+import { devLog } from '~/core/utils/dev-log';
 
 /**
  * GEO-2683. A claim is featured when a curator tags it — a `Tags` relation pointing at the
@@ -32,15 +33,21 @@ const FEATURED_CLAIMS_SOURCE = /* GraphQL */ `
     $typesPropertyId: UUID!
     $claimTypeId: UUID!
     $first: Int!
+    $after: Cursor
   ) {
     relationsConnection(
       first: $first
+      after: $after
       filter: {
         typeId: { is: $tagPropertyId }
         toEntityId: { is: $featuredTagId }
         fromEntity: { relations: { some: { typeId: { is: $typesPropertyId }, toEntityId: { is: $claimTypeId } } } }
       }
     ) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
       nodes {
         spaceId
         fromEntity {
@@ -56,6 +63,7 @@ const FEATURED_CLAIMS_SOURCE = /* GraphQL */ `
 
 type FeaturedClaimsQuery = {
   relationsConnection: {
+    pageInfo: { hasNextPage: boolean; endCursor: string | null } | null;
     nodes: Array<{
       spaceId: string | null;
       fromEntity: {
@@ -75,6 +83,7 @@ type FeaturedClaimsVariables = {
   typesPropertyId: string;
   claimTypeId: string;
   first: number;
+  after: string | null;
 };
 
 const featuredClaimsDocument = parse(FEATURED_CLAIMS_SOURCE) as TypedDocumentNode<
@@ -82,12 +91,18 @@ const featuredClaimsDocument = parse(FEATURED_CLAIMS_SOURCE) as TypedDocumentNod
   FeaturedClaimsVariables
 >;
 
+/** Rows per request. The whole tagged set is what both callers filter and show, so it is paged
+ * through to exhaustion rather than sampled — a single capped request would decide what to keep by
+ * relation id, which is a random v4 and so has no relationship to the order this list is shown in. */
+const FEATURED_CLAIMS_PAGE_SIZE = 500;
+
 /**
- * A ceiling rather than a page size: the whole featured set is what both callers filter and show,
- * so it is fetched in one request. Set well above the current few hundred so growth doesn't
- * silently truncate the list, and low enough that a tagging mistake can't fetch the corpus.
+ * A runaway guard, not a product limit: a few hundred claims are tagged today, so this is an order
+ * of magnitude of headroom, and reaching it means a mis-tagging has pointed the whole corpus at
+ * Featured. If curation ever legitimately grows past it, the answer is a ranked server-side
+ * endpoint rather than a bigger number here — the client is already sorting the entire set.
  */
-export const FEATURED_CLAIMS_LIMIT = 500;
+export const FEATURED_CLAIMS_LIMIT = 5_000;
 
 /** A claim a curator has tagged Featured, and the space they tagged it in. */
 export type FeaturedClaim = {
@@ -117,18 +132,33 @@ export function compareFeaturedClaims(a: FeaturedClaim, z: FeaturedClaim): numbe
   return z.claimEntityId.localeCompare(a.claimEntityId);
 }
 
-function decodeFeaturedClaims(data: FeaturedClaimsQuery): FeaturedClaim[] {
-  const claims: FeaturedClaim[] = [];
+/**
+ * One claim per id, keeping the first entry.
+ *
+ * Deliberately not done while decoding. A claim can be tagged in several spaces, and which of those
+ * a viewer may be shown is a question only the callers can answer — deduplicating first would make
+ * an arbitrary space authoritative and drop the claim entirely when that one happens to be outside
+ * the viewer's allowlist, even though it is featured in a space they can see. So every tag survives
+ * the fetch and the callers collapse them *after* filtering.
+ */
+export function dedupeFeaturedClaims(claims: FeaturedClaim[]): FeaturedClaim[] {
   const seen = new Set<string>();
+  return claims.filter(claim => {
+    if (seen.has(claim.claimEntityId)) return false;
+    seen.add(claim.claimEntityId);
+    return true;
+  });
+}
+
+type FeaturedClaimsPage = { claims: FeaturedClaim[]; endCursor: string | null; hasNextPage: boolean };
+
+function decodeFeaturedClaimsPage(data: FeaturedClaimsQuery): FeaturedClaimsPage {
+  const claims: FeaturedClaim[] = [];
 
   for (const node of data.relationsConnection?.nodes ?? []) {
     // A claim with no name has nothing to render, and one whose tag carries no space can't be
     // grouped for the geo-chat lookups or tested against the viewer's spaces.
     if (!node?.fromEntity?.name || !node.spaceId) continue;
-    // The same claim can be tagged in more than one space. First tag wins: the alternative is
-    // listing the claim twice, and the card is keyed on the claim, not the tag.
-    if (seen.has(node.fromEntity.id)) continue;
-    seen.add(node.fromEntity.id);
     claims.push({
       claimEntityId: node.fromEntity.id,
       spaceId: node.spaceId,
@@ -138,26 +168,47 @@ function decodeFeaturedClaims(data: FeaturedClaimsQuery): FeaturedClaim[] {
     });
   }
 
-  // Sorted here rather than in the query: the connection can only order by its own columns, and the
-  // score belongs to the claim on the other end of the relation.
-  return claims.sort(compareFeaturedClaims);
+  return {
+    claims,
+    endCursor: data.relationsConnection?.pageInfo?.endCursor ?? null,
+    hasNextPage: data.relationsConnection?.pageInfo?.hasNextPage ?? false,
+  };
 }
 
-export function fetchFeaturedClaims(signal?: AbortSignal): Promise<FeaturedClaim[]> {
-  return Effect.runPromise(
-    graphql({
-      query: featuredClaimsDocument,
-      decoder: decodeFeaturedClaims,
-      variables: {
-        tagPropertyId: TAG_PROPERTY_ID,
-        featuredTagId: FEATURED_TAG_ID,
-        typesPropertyId: SystemIds.TYPES_PROPERTY,
-        claimTypeId: CLAIM_TYPE_ID,
-        first: FEATURED_CLAIMS_LIMIT,
-      },
-      signal,
-    })
-  );
+export async function fetchFeaturedClaims(signal?: AbortSignal): Promise<FeaturedClaim[]> {
+  const claims: FeaturedClaim[] = [];
+  let after: string | null = null;
+
+  // Paged to exhaustion. Sorting can only happen once every page is in — the score belongs to the
+  // claim on the other end of the relation, so the connection can't order by it, and a partial set
+  // would be ranked against itself rather than against the whole tagged corpus.
+  while (claims.length < FEATURED_CLAIMS_LIMIT) {
+    const page: FeaturedClaimsPage = await Effect.runPromise(
+      graphql({
+        query: featuredClaimsDocument,
+        decoder: decodeFeaturedClaimsPage,
+        variables: {
+          tagPropertyId: TAG_PROPERTY_ID,
+          featuredTagId: FEATURED_TAG_ID,
+          typesPropertyId: SystemIds.TYPES_PROPERTY,
+          claimTypeId: CLAIM_TYPE_ID,
+          first: FEATURED_CLAIMS_PAGE_SIZE,
+          after,
+        },
+        signal,
+      })
+    );
+
+    claims.push(...page.claims);
+    if (!page.hasNextPage || !page.endCursor) break;
+    after = page.endCursor;
+  }
+
+  if (claims.length >= FEATURED_CLAIMS_LIMIT) {
+    devLog(`[featured-claims] stopped at the ${FEATURED_CLAIMS_LIMIT}-row guard; the list is truncated.`);
+  }
+
+  return claims.sort(compareFeaturedClaims);
 }
 
 /**

--- a/apps/web/core/debates/featured-claims.ts
+++ b/apps/web/core/debates/featured-claims.ts
@@ -1,0 +1,180 @@
+import { SystemIds } from '@geoprotocol/geo-sdk/lite';
+import type { TypedDocumentNode } from '@graphql-typed-document-node/core';
+import { useQuery } from '@tanstack/react-query';
+
+import * as React from 'react';
+
+import { Effect } from 'effect';
+import { parse } from 'graphql';
+
+import { CLAIM_TYPE_ID } from '~/core/claims/ontology';
+import { FEATURED_TAG_ID, TAG_PROPERTY_ID } from '~/core/constants';
+import { graphql } from '~/core/io/graphql-client';
+
+/**
+ * GEO-2683. A claim is featured when a curator tags it — a `Tags` relation pointing at the
+ * `Featured` entity — and the tag is what this asks for, rather than the claims and then their
+ * tags: featured claims are a few hundred out of three hundred thousand, so a filter applied to
+ * pages of claims would page for a very long time before it found one.
+ *
+ * The relation carries the space it was written in, which is the space the claim was featured
+ * *in* — a better answer than ranking the claim's spaces after the fact, and the one both callers
+ * use to group their geo-chat lookups.
+ */
+const FEATURED_CLAIMS_SOURCE = /* GraphQL */ `
+  query FeaturedClaims(
+    $tagPropertyId: UUID!
+    $featuredTagId: UUID!
+    $typesPropertyId: UUID!
+    $claimTypeId: UUID!
+    $first: Int!
+  ) {
+    relationsConnection(
+      first: $first
+      filter: {
+        typeId: { is: $tagPropertyId }
+        toEntityId: { is: $featuredTagId }
+        fromEntity: { relations: { some: { typeId: { is: $typesPropertyId }, toEntityId: { is: $claimTypeId } } } }
+      }
+    ) {
+      nodes {
+        spaceId
+        fromEntity {
+          id
+          name
+          description
+        }
+      }
+    }
+  }
+`;
+
+type FeaturedClaimsQuery = {
+  relationsConnection: {
+    nodes: Array<{
+      spaceId: string | null;
+      fromEntity: { id: string; name: string | null; description: string | null } | null;
+    } | null> | null;
+  } | null;
+};
+
+type FeaturedClaimsVariables = {
+  tagPropertyId: string;
+  featuredTagId: string;
+  typesPropertyId: string;
+  claimTypeId: string;
+  first: number;
+};
+
+const featuredClaimsDocument = parse(FEATURED_CLAIMS_SOURCE) as TypedDocumentNode<
+  FeaturedClaimsQuery,
+  FeaturedClaimsVariables
+>;
+
+/**
+ * A ceiling rather than a page size: the whole featured set is what both callers filter and show,
+ * so it is fetched in one request. Set well above the current few hundred so growth doesn't
+ * silently truncate the list, and low enough that a tagging mistake can't fetch the corpus.
+ */
+export const FEATURED_CLAIMS_LIMIT = 500;
+
+/** A claim a curator has tagged Featured, and the space they tagged it in. */
+export type FeaturedClaim = {
+  claimEntityId: string;
+  spaceId: string;
+  name: string;
+  description: string | null;
+};
+
+function decodeFeaturedClaims(data: FeaturedClaimsQuery): FeaturedClaim[] {
+  const claims: FeaturedClaim[] = [];
+  const seen = new Set<string>();
+
+  for (const node of data.relationsConnection?.nodes ?? []) {
+    // A claim with no name has nothing to render, and one whose tag carries no space can't be
+    // grouped for the geo-chat lookups or tested against the viewer's spaces.
+    if (!node?.fromEntity?.name || !node.spaceId) continue;
+    // The same claim can be tagged in more than one space. First tag wins: the alternative is
+    // listing the claim twice, and the card is keyed on the claim, not the tag.
+    if (seen.has(node.fromEntity.id)) continue;
+    seen.add(node.fromEntity.id);
+    claims.push({
+      claimEntityId: node.fromEntity.id,
+      spaceId: node.spaceId,
+      name: node.fromEntity.name,
+      description: node.fromEntity.description,
+    });
+  }
+
+  return claims;
+}
+
+export function fetchFeaturedClaims(signal?: AbortSignal): Promise<FeaturedClaim[]> {
+  return Effect.runPromise(
+    graphql({
+      query: featuredClaimsDocument,
+      decoder: decodeFeaturedClaims,
+      variables: {
+        tagPropertyId: TAG_PROPERTY_ID,
+        featuredTagId: FEATURED_TAG_ID,
+        typesPropertyId: SystemIds.TYPES_PROPERTY,
+        claimTypeId: CLAIM_TYPE_ID,
+        first: FEATURED_CLAIMS_LIMIT,
+      },
+      signal,
+    })
+  );
+}
+
+/**
+ * Deliberately not under `'debates'`, for the same reason as the claim picker's key: that root is
+ * what the gateway reconciles and refetches on every (re)connect, and these rows come from the
+ * knowledge graph rather than geo-chat, so a socket event says nothing about them.
+ */
+export const featuredClaimsQueryKey = ['featured-claims', 'claims'] as const;
+
+const NO_FEATURED_CLAIMS: FeaturedClaim[] = [];
+
+/**
+ * Every claim tagged Featured, unfiltered. Callers narrow it to the spaces they may show — the
+ * viewer's allowlist and the acceptor's editor spaces — because which spaces those are is a
+ * different question in the hub than it is in the rematch picker.
+ *
+ * Curation moves at human speed, so this stays fresh for a good while; both callers ask for the
+ * same key and share the one request.
+ */
+export function useFeaturedClaims(enabled: boolean) {
+  const query = useQuery({
+    queryKey: featuredClaimsQueryKey,
+    queryFn: ({ signal }) => fetchFeaturedClaims(signal),
+    staleTime: 5 * 60_000,
+    enabled,
+  });
+
+  const claims = query.data ?? NO_FEATURED_CLAIMS;
+  const claimIds = React.useMemo(() => claims.map(claim => claim.claimEntityId), [claims]);
+
+  return {
+    claims,
+    claimIds,
+    // `enabled: false` leaves react-query pending forever, which a caller waiting on this would
+    // read as "still looking" and never show its empty state.
+    isLoading: enabled && query.isLoading,
+    error: query.error,
+    refetch: query.refetch,
+  };
+}
+
+/** The featured claims grouped for geo-chat's per-space `debate-claims` lookup, in a stable order. */
+export function featuredClaimIdsBySpace(claims: FeaturedClaim[]): Array<{ spaceId: string; claimIds: string[] }> {
+  const bySpace = new Map<string, string[]>();
+  for (const claim of claims) {
+    const existing = bySpace.get(claim.spaceId);
+    if (existing) existing.push(claim.claimEntityId);
+    else bySpace.set(claim.spaceId, [claim.claimEntityId]);
+  }
+
+  return [...bySpace.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([spaceId, claimIds]) => ({ spaceId, claimIds }));
+}

--- a/apps/web/core/debates/matchmaking/claims-tab.test.tsx
+++ b/apps/web/core/debates/matchmaking/claims-tab.test.tsx
@@ -642,6 +642,19 @@ describe('ClaimsTab -- Featured', () => {
     expect(screen.queryByText('Chips are better than fries')).toBeNull();
   });
 
+  // Featured leads the menu because it is what the tab opens on; an option you land on shouldn't
+  // sit below the one you didn't.
+  it('leads the position menu, ahead of All claims', () => {
+    render(<ClaimsTab />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Featured' }));
+
+    const labels = ['Featured', 'All claims', 'My positions', 'Debate now'];
+    const options = screen.getAllByRole('button').filter(button => labels.includes(button.textContent?.trim() ?? ''));
+    // The trigger carries the current label too, and it is rendered ahead of the options.
+    expect(options.slice(-4).map(button => button.textContent?.trim())).toEqual(labels);
+  });
+
   // Featured claims are a few hundred in a corpus of hundreds of thousands, so the index is no help
   // here and asking it for a page while Featured is showing is a request for nothing.
   it('leaves the index alone until the viewer asks for All claims', async () => {

--- a/apps/web/core/debates/matchmaking/claims-tab.test.tsx
+++ b/apps/web/core/debates/matchmaking/claims-tab.test.tsx
@@ -6,6 +6,8 @@ import type { ReactElement } from 'react';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { CLAIM_IS_FACTUAL_PROPERTY_ID } from '~/core/claims/ontology';
+
 import type { MatchmakingClaim } from '../api';
 import { ClaimsTab } from './claims-tab';
 
@@ -15,6 +17,15 @@ const mocks = vi.hoisted(() => ({
   featuredLoading: false,
   featuredEnabledWith: [] as boolean[],
   debateClaimGroups: [] as Array<Array<{ spaceId: string; claimIds: string[] }>>,
+  claimEntityLookups: [] as string[][],
+  claimEntities: [] as Array<{
+    id: string;
+    name: string | null;
+    description: string | null;
+    spaces: string[];
+    values: Array<{ property: { id: string }; spaceId: string; value: string }>;
+    relations: Array<{ type: { id: string }; toEntity: { id: string; name: string | null } }>;
+  }>,
   facetSpaceIds: [] as string[],
   spaceAllowlist: null as Set<string> | null,
   allowlistLoading: false,
@@ -127,6 +138,15 @@ vi.mock('~/core/sync/use-store', () => ({
   useQueryEntities: () => ({ entities: [] }),
 }));
 
+// The tab reads topics and the "Is factual" value through the picker's narrow projection. Recorded
+// so a case can say which ids it asked for; `entities` lets one supply the values back.
+vi.mock('../claim-picker-page', () => ({
+  useClaimEntitiesByIds: (ids: string[]) => {
+    mocks.claimEntityLookups.push(ids);
+    return { entities: mocks.claimEntities.filter(entity => ids.includes(entity.id)), isLoading: false, error: null };
+  },
+}));
+
 function render(ui: ReactElement) {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return rtlRender(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>);
@@ -195,6 +215,8 @@ beforeEach(() => {
   mocks.featuredLoading = false;
   mocks.featuredEnabledWith = [];
   mocks.debateClaimGroups = [];
+  mocks.claimEntityLookups = [];
+  mocks.claimEntities = [];
   // Null + settled is "the allowlist lookup came back with nothing", which falls through to an
   // unfiltered list — what every pre-existing case here runs under.
   mocks.spaceAllowlist = null;
@@ -597,7 +619,7 @@ describe('ClaimsTab', () => {
     render(<ClaimsTab />);
     await showAllClaims();
 
-    expect(mocks.fetchedSpaceIds.flat()).toEqual([OTHER_SPACE_ID]);
+    expect([...new Set(mocks.fetchedSpaceIds.flat())]).toEqual([OTHER_SPACE_ID]);
   });
 });
 
@@ -669,6 +691,35 @@ describe('ClaimsTab -- Featured', () => {
     expect(mocks.lastEnabled).toBe(true);
   });
 
+  // The lookup this replaced was `useQueryEntities`, which defaults to nine rows and slices to them
+  // — so every claim after the ninth drew as a stance claim with no topics, whatever its own "Is
+  // factual" value said. The slicing was inside that hook, so a mocked hook can't reproduce it;
+  // what this pins is the half that lives here: the whole id set is asked for, and the response
+  // kind is read off the answer rather than defaulted.
+  it('asks for every claim it lists and reads each one’s response kind', () => {
+    const ids = Array.from(
+      { length: 12 },
+      (_, index) => `019fedb6-0000-7000-8000-00000000${String(index).padStart(4, '0')}`
+    );
+    mocks.featuredClaims = ids.map((id, index) => featuredClaim(id, `Claim number ${index}`));
+    // The last one is factual, so its sides are Verify/Dispute rather than Agree/Disagree.
+    mocks.claimEntities = [
+      {
+        id: ids.at(-1)!,
+        name: 'Claim number 11',
+        description: null,
+        spaces: [SPACE_ID],
+        values: [{ property: { id: CLAIM_IS_FACTUAL_PROPERTY_ID }, spaceId: SPACE_ID, value: '1' }],
+        relations: [],
+      },
+    ];
+    render(<ClaimsTab />);
+
+    // Asked for all twelve, not a nine-row slice.
+    expect(mocks.claimEntityLookups.at(-1)).toHaveLength(12);
+    expect(screen.getByRole('button', { name: /Verify/ })).toBeInTheDocument();
+  });
+
   // The same two gates the paged list runs under: the viewer's allowlist, and whether a debate in
   // that space could ever be published.
   it('drops tagged claims from spaces the viewer may not be shown', () => {
@@ -693,6 +744,22 @@ describe('ClaimsTab -- Featured', () => {
 
     expect(screen.getByText('Nuclear power is the cheapest clean energy')).toBeInTheDocument();
     expect(screen.queryByText('Cities should ban cars downtown')).toBeNull();
+  });
+
+  // A claim can be tagged in several spaces. Collapsing to one row before the gates would let a
+  // space the viewer can't be shown stand for the claim and drop it, though it is featured in one
+  // they can.
+  it('keeps a claim tagged in both a shown and a hidden space', () => {
+    mocks.spaceAllowlist = new Set([SPACE_ID.replace(/-/g, '')]);
+    mocks.featuredClaims = [
+      featuredClaim(FEATURED_A, 'Nuclear power is the cheapest clean energy', OTHER_SPACE_ID),
+      featuredClaim(FEATURED_A, 'Nuclear power is the cheapest clean energy'),
+    ];
+    render(<ClaimsTab />);
+
+    expect(screen.getByText('Nuclear power is the cheapest clean energy')).toBeInTheDocument();
+    // And on the tag the viewer may actually be shown, so geo-chat is asked in that space.
+    expect(mocks.debateClaimGroups.at(-1)).toEqual([{ spaceId: SPACE_ID, claimIds: [FEATURED_A] }]);
   });
 
   // The sides and readiness on the cards are geo-chat's, asked for by id per space. A claim the tab

--- a/apps/web/core/debates/matchmaking/claims-tab.test.tsx
+++ b/apps/web/core/debates/matchmaking/claims-tab.test.tsx
@@ -1,6 +1,6 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import '@testing-library/jest-dom/vitest';
-import { act, cleanup, fireEvent, render as rtlRender, screen } from '@testing-library/react';
+import { act, cleanup, fireEvent, render as rtlRender, screen, waitFor } from '@testing-library/react';
 
 import type { ReactElement } from 'react';
 
@@ -11,6 +11,10 @@ import { ClaimsTab } from './claims-tab';
 
 const mocks = vi.hoisted(() => ({
   claims: [] as MatchmakingClaim[],
+  featuredClaims: [] as Array<{ claimEntityId: string; spaceId: string; name: string; description: string | null }>,
+  featuredLoading: false,
+  featuredEnabledWith: [] as boolean[],
+  debateClaimGroups: [] as Array<Array<{ spaceId: string; claimIds: string[] }>>,
   facetSpaceIds: [] as string[],
   spaceAllowlist: null as Set<string> | null,
   allowlistLoading: false,
@@ -20,6 +24,7 @@ const mocks = vi.hoisted(() => ({
   fetchedSpaceIds: [] as string[][],
   spacesLoading: false,
   lastQuery: null as unknown,
+  lastEnabled: true,
   hasNextPage: false,
   fetchNextPage: vi.fn(),
   observed: [] as Element[],
@@ -40,8 +45,9 @@ vi.mock('~/core/debates/use-debate-publishable-spaces', async importOriginal => 
 }));
 
 vi.mock('./hooks', () => ({
-  useMatchmakingClaims: (query: unknown) => {
+  useMatchmakingClaims: (query: unknown, enabled: boolean) => {
     mocks.lastQuery = query;
+    mocks.lastEnabled = enabled;
     return {
       data: { pages: [{ claims: mocks.claims, next_cursor: null, facets: { space_ids: mocks.facetSpaceIds } }] },
       isLoading: false,
@@ -68,6 +74,26 @@ vi.mock('../hooks', () => ({
   useGeoChatAuth: () => ({ ready: true, authenticated: true, accountKey: 'account-1' }),
   useJoinDebateQueue: () => ({ mutateAsync: vi.fn(), reset: vi.fn(), isPending: false, error: null }),
   useLeaveDebateQueue: () => ({ mutateAsync: vi.fn(), isPending: false, error: null }),
+  // Featured rows are hydrated by the per-space debate-claims lookup. Records what it was asked
+  // for so the suites can assert the tab only asks about spaces it may show.
+  useDebateClaimsBySpaces: (groups: Array<{ spaceId: string; claimIds: string[] }>) => {
+    mocks.debateClaimGroups.push(groups);
+    return { claims: [], isLoading: false, isError: false };
+  },
+}));
+
+vi.mock('../featured-claims', async importOriginal => ({
+  ...(await importOriginal<typeof import('../featured-claims')>()),
+  useFeaturedClaims: (enabled: boolean) => {
+    mocks.featuredEnabledWith.push(enabled);
+    return {
+      claims: enabled ? mocks.featuredClaims : [],
+      claimIds: enabled ? mocks.featuredClaims.map(claim => claim.claimEntityId) : [],
+      isLoading: enabled && mocks.featuredLoading,
+      error: null,
+      refetch: vi.fn(),
+    };
+  },
 }));
 
 vi.mock('~/core/hooks/use-entity-vote', () => ({
@@ -147,6 +173,10 @@ const THEIRS = '019fedb2-1d52-7a4f-8b22-3d8e6f9c5520';
 beforeEach(() => {
   mocks.hasNextPage = false;
   mocks.facetSpaceIds = [];
+  mocks.featuredClaims = [];
+  mocks.featuredLoading = false;
+  mocks.featuredEnabledWith = [];
+  mocks.debateClaimGroups = [];
   // Null + settled is "the allowlist lookup came back with nothing", which falls through to an
   // unfiltered list — what every pre-existing case here runs under.
   mocks.spaceAllowlist = null;
@@ -518,4 +548,154 @@ it('asks the server for the filter the viewer picked', () => {
   fireEvent.click(screen.getByRole('button', { name: 'Debate now' }));
 
   expect(mocks.lastQuery).toMatchObject({ filter: 'debate_now' });
+});
+
+const FEATURED_A = '019fedb4-3f74-7c61-8d44-5fa0810e7742';
+const FEATURED_B = '019fedb5-4085-7d72-9e55-60b1921f8853';
+
+function featuredClaim(entityId: string, name: string, spaceId = SPACE_ID) {
+  return { claimEntityId: entityId, spaceId, name, description: null };
+}
+
+/** Picks an option out of the position dropdown, which opens on its current label. */
+function chooseFilter(current: string, next: string) {
+  fireEvent.click(screen.getByRole('button', { name: current }));
+  fireEvent.click(screen.getByRole('button', { name: next }));
+}
+
+// GEO-2683. Featured is the one option in this menu geo-chat knows nothing about: the tag lives in
+// the knowledge graph, so picking it swaps the list's source rather than changing a query param.
+describe('ClaimsTab -- Featured', () => {
+  it('lists the tagged claims instead of the index page', async () => {
+    mocks.featuredClaims = [featuredClaim(FEATURED_A, 'Nuclear power is the cheapest clean energy')];
+    render(<ClaimsTab />);
+
+    chooseFilter('All claims', 'Featured');
+
+    expect(screen.getByText('Nuclear power is the cheapest clean energy')).toBeInTheDocument();
+    // The paged list is what Featured replaces, not something it filters. Awaited because the
+    // replaced cards animate out rather than leaving the DOM on the same tick.
+    await waitFor(() => expect(screen.queryByText('Chips are better than fries')).toBeNull());
+  });
+
+  // Featured claims are a few hundred in a corpus of hundreds of thousands, so the index is no help
+  // here and asking it for a page while Featured is showing is a request for nothing.
+  it('stops asking the index for pages while Featured is showing', () => {
+    render(<ClaimsTab />);
+    expect(mocks.lastEnabled).toBe(true);
+
+    chooseFilter('All claims', 'Featured');
+
+    expect(mocks.lastEnabled).toBe(false);
+    // Still 'all', so switching back lands on the pages already cached rather than paging again.
+    expect(mocks.lastQuery).toMatchObject({ filter: 'all' });
+  });
+
+  // The same two gates the paged list runs under: the viewer's allowlist, and whether a debate in
+  // that space could ever be published.
+  it('drops tagged claims from spaces the viewer may not be shown', () => {
+    mocks.spaceAllowlist = new Set([SPACE_ID.replace(/-/g, '')]);
+    mocks.featuredClaims = [
+      featuredClaim(FEATURED_A, 'Nuclear power is the cheapest clean energy'),
+      featuredClaim(FEATURED_B, 'Cities should ban cars downtown', OTHER_SPACE_ID),
+    ];
+    render(<ClaimsTab />);
+
+    chooseFilter('All claims', 'Featured');
+
+    expect(screen.getByText('Nuclear power is the cheapest clean energy')).toBeInTheDocument();
+    expect(screen.queryByText('Cities should ban cars downtown')).toBeNull();
+  });
+
+  it('drops tagged claims from spaces a debate could never be published in', () => {
+    mocks.publishableSpaceIds = new Set([SPACE_ID.replace(/-/g, '')]);
+    mocks.featuredClaims = [
+      featuredClaim(FEATURED_A, 'Nuclear power is the cheapest clean energy'),
+      featuredClaim(FEATURED_B, 'Cities should ban cars downtown', OTHER_SPACE_ID),
+    ];
+    render(<ClaimsTab />);
+
+    chooseFilter('All claims', 'Featured');
+
+    expect(screen.getByText('Nuclear power is the cheapest clean energy')).toBeInTheDocument();
+    expect(screen.queryByText('Cities should ban cars downtown')).toBeNull();
+  });
+
+  // The sides and readiness on the cards are geo-chat's, asked for by id per space. A claim the tab
+  // has already ruled out shouldn't cost a request -- or a gateway scope on that space.
+  it('asks geo-chat only about the tagged claims it may show', () => {
+    mocks.spaceAllowlist = new Set([SPACE_ID.replace(/-/g, '')]);
+    mocks.featuredClaims = [
+      featuredClaim(FEATURED_A, 'Nuclear power is the cheapest clean energy'),
+      featuredClaim(FEATURED_B, 'Cities should ban cars downtown', OTHER_SPACE_ID),
+    ];
+    render(<ClaimsTab />);
+
+    chooseFilter('All claims', 'Featured');
+
+    expect(mocks.debateClaimGroups.at(-1)).toEqual([{ spaceId: SPACE_ID, claimIds: [FEATURED_A] }]);
+  });
+
+  // Search runs over the loaded list here -- there is no server query for it to go into -- and the
+  // set geo-chat is asked about deliberately doesn't narrow with it, so typing filters a list that
+  // is already loaded instead of restarting a fan-out on every keystroke.
+  it('searches the loaded list without re-asking geo-chat', async () => {
+    mocks.featuredClaims = [
+      featuredClaim(FEATURED_A, 'Nuclear power is the cheapest clean energy'),
+      featuredClaim(FEATURED_B, 'Cities should ban cars downtown'),
+    ];
+    render(<ClaimsTab />);
+
+    chooseFilter('All claims', 'Featured');
+    const askedBefore = mocks.debateClaimGroups.at(-1);
+
+    fireEvent.change(screen.getByLabelText('Search claims'), { target: { value: 'nuclear' } });
+
+    await waitFor(() => expect(screen.queryByText('Cities should ban cars downtown')).toBeNull());
+    expect(screen.getByText('Nuclear power is the cheapest clean energy')).toBeInTheDocument();
+    expect(mocks.debateClaimGroups.at(-1)).toEqual(askedBefore);
+  });
+
+  // Featured is one graph query, not a paged list. `keepPreviousData` leaves the paged query's
+  // pages in place while Featured is showing, so a sentinel gated on those would page the corpus
+  // underneath a list that never grows.
+  it('places no scroll sentinel on Featured', () => {
+    mocks.hasNextPage = true;
+    mocks.featuredClaims = [featuredClaim(FEATURED_A, 'Nuclear power is the cheapest clean energy')];
+    render(<ClaimsTab />);
+
+    expect(screen.getByTestId('claims-scroll-sentinel')).toBeInTheDocument();
+
+    chooseFilter('All claims', 'Featured');
+
+    expect(screen.queryByTestId('claims-scroll-sentinel')).toBeNull();
+  });
+
+  // Featured chooses which list is on screen rather than narrowing one, so an empty tab reads as
+  // "nothing is featured" — not as filters hiding claims that are there.
+  it('says nothing is featured rather than nothing is debatable', async () => {
+    render(<ClaimsTab />);
+
+    chooseFilter('All claims', 'Featured');
+
+    await waitFor(() => expect(screen.getByText('No claims have been featured yet.')).toBeInTheDocument());
+    expect(screen.queryByRole('button', { name: 'Clear filters' })).toBeNull();
+  });
+
+  // And once one is applied, clearing it leaves the viewer on Featured rather than dropping them
+  // back onto the paged list they didn't ask for.
+  it('keeps the viewer on Featured when they clear a filter', async () => {
+    mocks.featuredClaims = [featuredClaim(FEATURED_A, 'Nuclear power is the cheapest clean energy')];
+    render(<ClaimsTab />);
+
+    chooseFilter('All claims', 'Featured');
+    fireEvent.change(screen.getByLabelText('Search claims'), { target: { value: 'nothing matches this' } });
+
+    await waitFor(() => expect(screen.getByText('No featured claims match these filters.')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole('button', { name: 'Clear filters' }));
+
+    await waitFor(() => expect(screen.getByText('Nuclear power is the cheapest clean energy')).toBeInTheDocument());
+    expect(mocks.lastEnabled).toBe(false);
+  });
 });

--- a/apps/web/core/debates/matchmaking/claims-tab.test.tsx
+++ b/apps/web/core/debates/matchmaking/claims-tab.test.tsx
@@ -167,6 +167,24 @@ function claim(
   };
 }
 
+/** Picks an option out of the position dropdown, which opens on its current label. */
+function chooseFilter(current: string, next: string) {
+  fireEvent.click(screen.getByRole('button', { name: current }));
+  fireEvent.click(screen.getByRole('button', { name: next }));
+}
+
+/**
+ * The tab opens on Featured, so every case about geo-chat's paged list has to ask for it. Kept as a
+ * helper rather than folded into `render` so the default stays visible in the cases that assert it.
+ *
+ * Awaits the swap: the region cross-fades with `mode="wait"`, so the list is not in the DOM until
+ * the state it replaced has finished leaving.
+ */
+async function showAllClaims() {
+  chooseFilter('Featured', 'All claims');
+  await waitFor(() => expect(screen.queryByText('No claims have been featured yet.')).toBeNull());
+}
+
 const MINE = '019fedb1-0c41-7f3e-9a11-2c7d5e8b4419';
 const THEIRS = '019fedb2-1d52-7a4f-8b22-3d8e6f9c5520';
 
@@ -227,9 +245,10 @@ afterEach(cleanup);
 
 describe('ClaimsTab', () => {
   // Pages arrive by reaching the end of the list, not by pressing anything.
-  it('fetches the next page when the end of the list scrolls into view', () => {
+  it('fetches the next page when the end of the list scrolls into view', async () => {
     mocks.hasNextPage = true;
     render(<ClaimsTab />);
+    await showAllClaims();
 
     expect(screen.queryByRole('button', { name: 'Load more' })).toBeNull();
     expect(mocks.fetchNextPage).not.toHaveBeenCalled();
@@ -239,8 +258,9 @@ describe('ClaimsTab', () => {
     expect(mocks.fetchNextPage).toHaveBeenCalled();
   });
 
-  it('places no sentinel once the last page has arrived', () => {
+  it('places no sentinel once the last page has arrived', async () => {
     render(<ClaimsTab />);
+    await showAllClaims();
 
     expect(screen.queryByTestId('claims-scroll-sentinel')).toBeNull();
   });
@@ -248,8 +268,9 @@ describe('ClaimsTab', () => {
   // The tab is one list in the server's order. Leading with the claims you'd already answered
   // re-ranked it by something the Position filter in the dropdown already covers, and it moved a
   // card between two sections the moment you took a side.
-  it('renders one unsectioned list in the order the server returned', () => {
+  it('renders one unsectioned list in the order the server returned', async () => {
     render(<ClaimsTab />);
+    await showAllClaims();
 
     expect(screen.queryByRole('heading', { name: 'My positions' })).not.toBeInTheDocument();
     expect(screen.queryByRole('heading', { name: 'All claims' })).not.toBeInTheDocument();
@@ -261,12 +282,13 @@ describe('ClaimsTab', () => {
     expect(first.compareDocumentPosition(second) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 
-  it('leaves an answered claim where the server put it rather than promoting it', () => {
+  it('leaves an answered claim where the server put it rather than promoting it', async () => {
     mocks.claims = [
       claim(THEIRS, 'Bitcoin will never top $250K', false),
       claim(MINE, 'Chips are better than fries', true),
     ];
     render(<ClaimsTab />);
+    await showAllClaims();
 
     const unanswered = screen.getByText('Bitcoin will never top $250K');
     const answered = screen.getByText('Chips are better than fries');
@@ -277,13 +299,14 @@ describe('ClaimsTab', () => {
   // currently open to debating it — the toggle is a separate answer to a separate question. The
   // reported bug drops the toggled-off ones, and it is geo-chat's join to fix; this pins the client
   // half, so nobody closes the gap here by filtering the list a second time on the way in.
-  it('keeps positions the viewer is not currently open to debating', () => {
+  it('keeps positions the viewer is not currently open to debating', async () => {
     const OFF = '019fedb3-2e63-7b50-9c33-4e9f7a0d6631';
     mocks.claims = [
       claim(MINE, 'Chips are better than fries', true, true),
       claim(OFF, 'Rust belongs in the kernel', true, false),
     ];
     render(<ClaimsTab />);
+    await showAllClaims();
 
     fireEvent.click(screen.getByRole('button', { name: /All claims/ }));
     fireEvent.click(screen.getByRole('button', { name: 'My positions' }));
@@ -295,13 +318,14 @@ describe('ClaimsTab', () => {
 
   // Featured spaces plus the viewer's own; `/matchmaking/claims` takes a single space_id, so the
   // list has to be narrowed here.
-  it('shows only claims from spaces the viewer is allowed to see', () => {
+  it('shows only claims from spaces the viewer is allowed to see', async () => {
     mocks.claims = [
       claim(MINE, 'Chips are better than fries', true),
       claim(THEIRS, 'Bitcoin will never top $250K', false, false, OTHER_SPACE_ID),
     ];
     mocks.spaceAllowlist = new Set([SPACE_ID.replace(/-/g, '')]);
     render(<ClaimsTab />);
+    await showAllClaims();
 
     expect(screen.getByText('Chips are better than fries')).toBeInTheDocument();
     expect(screen.queryByText('Bitcoin will never top $250K')).not.toBeInTheDocument();
@@ -310,13 +334,14 @@ describe('ClaimsTab', () => {
   // GEO-2649. A separate question from the allowlist: the viewer may be perfectly entitled to see
   // the space, but if the acceptor isn't an editor of it the debate fails on-chain at the very end,
   // so offering the claim is offering a dead end.
-  it('shows only claims from spaces a debate could be published in', () => {
+  it('shows only claims from spaces a debate could be published in', async () => {
     mocks.claims = [
       claim(MINE, 'Chips are better than fries', true),
       claim(THEIRS, 'Bitcoin will never top $250K', false, false, OTHER_SPACE_ID),
     ];
     mocks.publishableSpaceIds = new Set([SPACE_ID.replace(/-/g, '')]);
     render(<ClaimsTab />);
+    await showAllClaims();
 
     expect(screen.getByText('Chips are better than fries')).toBeInTheDocument();
     expect(screen.queryByText('Bitcoin will never top $250K')).not.toBeInTheDocument();
@@ -324,20 +349,22 @@ describe('ClaimsTab', () => {
 
   // Both gates apply, and a claim has to clear both. Allowed to see it, but nothing can be
   // published there.
-  it('hides an allowed space that no debate can be published in', () => {
+  it('hides an allowed space that no debate can be published in', async () => {
     mocks.claims = [claim(MINE, 'Chips are better than fries', true)];
     mocks.spaceAllowlist = new Set([SPACE_ID.replace(/-/g, '')]);
     mocks.publishableSpaceIds = new Set([OTHER_SPACE_ID.replace(/-/g, '')]);
     render(<ClaimsTab />);
+    await showAllClaims();
 
     expect(screen.queryByText('Chips are better than fries')).toBeNull();
   });
 
-  it('keeps the space filter to spaces a debate could be published in', () => {
+  it('keeps the space filter to spaces a debate could be published in', async () => {
     mocks.claims = [claim(MINE, 'Chips are better than fries', true)];
     mocks.facetSpaceIds = [SPACE_ID, OTHER_SPACE_ID];
     mocks.publishableSpaceIds = new Set([SPACE_ID.replace(/-/g, '')]);
     render(<ClaimsTab />);
+    await showAllClaims();
 
     fireEvent.click(screen.getByRole('button', { name: /Any space/ }));
 
@@ -347,31 +374,34 @@ describe('ClaimsTab', () => {
 
   // Same trimming-under-the-viewer problem the allowlist has, and the same answer: `null` does not
   // filter, so without waiting the tab lists everything and then pulls claims back out.
-  it('shows nothing until the publishable lookup settles', () => {
+  it('shows nothing until the publishable lookup settles', async () => {
     mocks.claims = [claim(THEIRS, 'Bitcoin will never top $250K', false, false, OTHER_SPACE_ID)];
     mocks.publishableSpaceIds = null;
     mocks.publishableLoading = true;
     render(<ClaimsTab />);
+    await showAllClaims();
 
     expect(screen.queryByText('Bitcoin will never top $250K')).toBeNull();
   });
 
   // And the other half of that rule: a lookup that settled without an answer must not empty the
   // tab. No acceptor is configured locally at all, so this is the everyday path.
-  it('falls through to the unfiltered list when the publishable lookup comes back empty', () => {
+  it('falls through to the unfiltered list when the publishable lookup comes back empty', async () => {
     mocks.claims = [claim(MINE, 'Chips are better than fries', true)];
     mocks.publishableSpaceIds = null;
     mocks.publishableLoading = false;
     render(<ClaimsTab />);
+    await showAllClaims();
 
     expect(screen.getByText('Chips are better than fries')).toBeInTheDocument();
   });
 
   // The allowlist is keyed on normalized ids; a claim row carries the hyphen-less form.
-  it('matches allowed spaces across id formats', () => {
+  it('matches allowed spaces across id formats', async () => {
     mocks.claims = [claim(MINE, 'Chips are better than fries', true)];
     mocks.spaceAllowlist = new Set([SPACE_ID.replace(/-/g, '').toLowerCase()]);
     render(<ClaimsTab />);
+    await showAllClaims();
 
     expect(screen.getByText('Chips are better than fries')).toBeInTheDocument();
   });
@@ -379,12 +409,13 @@ describe('ClaimsTab', () => {
   // The reported bug: the menu opened on every space the server faceted, then trimmed itself to
   // the viewer's own a moment later — spaces appearing and vanishing, and offering picks that were
   // never theirs to make.
-  it('shows nothing until the allowlist settles, rather than trimming under the viewer', () => {
+  it('shows nothing until the allowlist settles, rather than trimming under the viewer', async () => {
     mocks.claims = [claim(THEIRS, 'Bitcoin will never top $250K', false, false, OTHER_SPACE_ID)];
     mocks.facetSpaceIds = [SPACE_ID, OTHER_SPACE_ID];
     mocks.spaceAllowlist = null;
     mocks.allowlistLoading = true;
     render(<ClaimsTab />);
+    await showAllClaims();
 
     expect(screen.queryByText('Bitcoin will never top $250K')).toBeNull();
 
@@ -395,11 +426,12 @@ describe('ClaimsTab', () => {
 
   // The tab shows a four-row skeleton while the allowlist resolves, so a sentinel below it sits in
   // view and reads "the viewer reached the end" off a list that isn't rendered.
-  it('does not page the corpus while the allowlist is still resolving', () => {
+  it('does not page the corpus while the allowlist is still resolving', async () => {
     mocks.spaceAllowlist = null;
     mocks.allowlistLoading = true;
     mocks.hasNextPage = true;
     render(<ClaimsTab />);
+    await showAllClaims();
 
     expect(screen.queryByTestId('claims-scroll-sentinel')).toBeNull();
 
@@ -410,20 +442,22 @@ describe('ClaimsTab', () => {
 
   // A lookup that settles without an answer must not leave the panel permanently empty — too wide
   // a list beats one that never fills.
-  it('falls through to the unfiltered list when the allowlist lookup comes back empty', () => {
+  it('falls through to the unfiltered list when the allowlist lookup comes back empty', async () => {
     mocks.claims = [claim(THEIRS, 'Bitcoin will never top $250K', false, false, OTHER_SPACE_ID)];
     mocks.spaceAllowlist = null;
     mocks.allowlistLoading = false;
     render(<ClaimsTab />);
+    await showAllClaims();
 
     expect(screen.getByText('Bitcoin will never top $250K')).toBeInTheDocument();
   });
 
   // The space menu comes from the server's facets, which span every space the query touched.
-  it('offers only allowed spaces in the space filter', () => {
+  it('offers only allowed spaces in the space filter', async () => {
     mocks.facetSpaceIds = [SPACE_ID, OTHER_SPACE_ID];
     mocks.spaceAllowlist = new Set([SPACE_ID.replace(/-/g, '')]);
     render(<ClaimsTab />);
+    await showAllClaims();
 
     fireEvent.click(screen.getByRole('button', { name: /Any space/ }));
 
@@ -434,11 +468,12 @@ describe('ClaimsTab', () => {
   // The allowlist runs over the loaded page, so a page can arrive with nothing left in it. With
   // the sentinel rendered only alongside results the list would stop there and report "no claims"
   // while the corpus still held matches.
-  it('keeps asking for pages when the allowlist empties the one it has', () => {
+  it('keeps asking for pages when the allowlist empties the one it has', async () => {
     mocks.claims = [claim(THEIRS, 'Bitcoin will never top $250K', false, false, OTHER_SPACE_ID)];
     mocks.spaceAllowlist = new Set([SPACE_ID.replace(/-/g, '')]);
     mocks.hasNextPage = true;
     render(<ClaimsTab />);
+    await showAllClaims();
 
     expect(screen.getByText('No debatable claims yet.')).toBeInTheDocument();
     expect(screen.getByTestId('claims-scroll-sentinel')).toBeInTheDocument();
@@ -450,10 +485,11 @@ describe('ClaimsTab', () => {
 
   // The reported bug: the space menu opened as a column of "Space" placeholders while it re-fetched
   // names the browse sidebar had been showing since first paint.
-  it('names the space options from the sidebar rows without fetching them again', () => {
+  it('names the space options from the sidebar rows without fetching them again', async () => {
     mocks.facetSpaceIds = [SPACE_ID];
     mocks.sidebarData = sidebarData();
     render(<ClaimsTab />);
+    await showAllClaims();
 
     fireEvent.click(screen.getByRole('button', { name: /Any space/ }));
 
@@ -464,21 +500,23 @@ describe('ClaimsTab', () => {
   });
 
   // The same placeholder showed on every card in the list, from the same missing names.
-  it('names each card space from the sidebar rows too', () => {
+  it('names each card space from the sidebar rows too', async () => {
     mocks.claims = [claim(MINE, 'Chips are better than fries', true)];
     mocks.sidebarData = sidebarData();
     render(<ClaimsTab />);
+    await showAllClaims();
 
     expect(screen.getByText('Crypto')).toBeInTheDocument();
   });
 
   // On a cold load the sidebar hasn't cached anything yet either. A column of identical "Space"
   // rows reads as a list of real, indistinguishable choices; skeletons read as names on their way.
-  it('draws unresolved space options as skeletons rather than a column of "Space"', () => {
+  it('draws unresolved space options as skeletons rather than a column of "Space"', async () => {
     mocks.claims = [];
     mocks.facetSpaceIds = [SPACE_ID, OTHER_SPACE_ID];
     mocks.spacesLoading = true;
     render(<ClaimsTab />);
+    await showAllClaims();
 
     fireEvent.click(screen.getByRole('button', { name: /Any space/ }));
 
@@ -487,11 +525,12 @@ describe('ClaimsTab', () => {
   });
 
   // Picking a space nobody can name yet filters the list to something the viewer can't read back.
-  it('does not let an unresolved space be picked', () => {
+  it('does not let an unresolved space be picked', async () => {
     mocks.claims = [];
     mocks.facetSpaceIds = [SPACE_ID];
     mocks.spacesLoading = true;
     render(<ClaimsTab />);
+    await showAllClaims();
 
     fireEvent.click(screen.getByRole('button', { name: /Any space/ }));
     const option = screen.getByLabelText('Loading space name').closest('button');
@@ -504,11 +543,12 @@ describe('ClaimsTab', () => {
 
   // A settled lookup that still can't name the space really does leave "Space" as the best label
   // there is — the skeleton must not become the permanent state.
-  it('falls back to the plain label once the lookup settles with no name', () => {
+  it('falls back to the plain label once the lookup settles with no name', async () => {
     mocks.claims = [];
     mocks.facetSpaceIds = [SPACE_ID];
     mocks.spacesLoading = false;
     render(<ClaimsTab />);
+    await showAllClaims();
 
     fireEvent.click(screen.getByRole('button', { name: /Any space/ }));
 
@@ -518,20 +558,22 @@ describe('ClaimsTab', () => {
   });
 
   // The same placeholder ran down every card in the list.
-  it('draws an unresolved card space as a skeleton', () => {
+  it('draws an unresolved card space as a skeleton', async () => {
     mocks.claims = [claim(MINE, 'Chips are better than fries', true)];
     mocks.spacesLoading = true;
     render(<ClaimsTab />);
+    await showAllClaims();
 
     expect(screen.getAllByLabelText('Loading space name').length).toBeGreaterThan(0);
     expect(screen.queryByText('Space')).toBeNull();
   });
 
   // A space the sidebar has no row for still has to resolve the old way.
-  it('still fetches a space the sidebar has never heard of', () => {
+  it('still fetches a space the sidebar has never heard of', async () => {
     mocks.facetSpaceIds = [SPACE_ID, OTHER_SPACE_ID];
     mocks.sidebarData = sidebarData();
     render(<ClaimsTab />);
+    await showAllClaims();
 
     expect(mocks.fetchedSpaceIds.flat()).toEqual([OTHER_SPACE_ID]);
   });
@@ -539,13 +581,13 @@ describe('ClaimsTab', () => {
 
 // Search, the space filter and the position filter all run server-side, so what this tab puts in
 // the query is the whole feature — a mock that ignores it cannot catch a dropped filter.
-it('asks the server for the filter the viewer picked', () => {
+it('asks the server for the filter the viewer picked', async () => {
   render(<ClaimsTab />);
+  await showAllClaims();
 
   expect(mocks.lastQuery).toMatchObject({ filter: 'all', spaceId: null });
 
-  fireEvent.click(screen.getByRole('button', { name: 'All claims' }));
-  fireEvent.click(screen.getByRole('button', { name: 'Debate now' }));
+  chooseFilter('All claims', 'Debate now');
 
   expect(mocks.lastQuery).toMatchObject({ filter: 'debate_now' });
 });
@@ -557,38 +599,39 @@ function featuredClaim(entityId: string, name: string, spaceId = SPACE_ID) {
   return { claimEntityId: entityId, spaceId, name, description: null };
 }
 
-/** Picks an option out of the position dropdown, which opens on its current label. */
-function chooseFilter(current: string, next: string) {
-  fireEvent.click(screen.getByRole('button', { name: current }));
-  fireEvent.click(screen.getByRole('button', { name: next }));
-}
-
 // GEO-2683. Featured is the one option in this menu geo-chat knows nothing about: the tag lives in
 // the knowledge graph, so picking it swaps the list's source rather than changing a query param.
 describe('ClaimsTab -- Featured', () => {
-  it('lists the tagged claims instead of the index page', async () => {
+  const FEATURED_A = '019fedb4-3f74-7c61-8d44-5fa0810e7742';
+  const FEATURED_B = '019fedb5-4085-7d72-9e55-60b1921f8853';
+
+  function featuredClaim(entityId: string, name: string, spaceId = SPACE_ID) {
+    return { claimEntityId: entityId, spaceId, name, description: null };
+  }
+
+  // Where the tab opens: a curator's pick beats whatever the index ranked highest as the first
+  // thing to put in front of someone, and the whole corpus is one menu away.
+  it('opens on Featured, listing the tagged claims rather than the index page', () => {
     mocks.featuredClaims = [featuredClaim(FEATURED_A, 'Nuclear power is the cheapest clean energy')];
     render(<ClaimsTab />);
 
-    chooseFilter('All claims', 'Featured');
-
+    expect(screen.getByRole('button', { name: 'Featured' })).toBeInTheDocument();
     expect(screen.getByText('Nuclear power is the cheapest clean energy')).toBeInTheDocument();
-    // The paged list is what Featured replaces, not something it filters. Awaited because the
-    // replaced cards animate out rather than leaving the DOM on the same tick.
-    await waitFor(() => expect(screen.queryByText('Chips are better than fries')).toBeNull());
+    expect(screen.queryByText('Chips are better than fries')).toBeNull();
   });
 
   // Featured claims are a few hundred in a corpus of hundreds of thousands, so the index is no help
   // here and asking it for a page while Featured is showing is a request for nothing.
-  it('stops asking the index for pages while Featured is showing', () => {
+  it('leaves the index alone until the viewer asks for All claims', async () => {
     render(<ClaimsTab />);
-    expect(mocks.lastEnabled).toBe(true);
-
-    chooseFilter('All claims', 'Featured');
 
     expect(mocks.lastEnabled).toBe(false);
-    // Still 'all', so switching back lands on the pages already cached rather than paging again.
+    // Still 'all', so asking for it lands on whatever pages are already cached.
     expect(mocks.lastQuery).toMatchObject({ filter: 'all' });
+
+    await showAllClaims();
+
+    expect(mocks.lastEnabled).toBe(true);
   });
 
   // The same two gates the paged list runs under: the viewer's allowlist, and whether a debate in
@@ -601,8 +644,6 @@ describe('ClaimsTab -- Featured', () => {
     ];
     render(<ClaimsTab />);
 
-    chooseFilter('All claims', 'Featured');
-
     expect(screen.getByText('Nuclear power is the cheapest clean energy')).toBeInTheDocument();
     expect(screen.queryByText('Cities should ban cars downtown')).toBeNull();
   });
@@ -614,8 +655,6 @@ describe('ClaimsTab -- Featured', () => {
       featuredClaim(FEATURED_B, 'Cities should ban cars downtown', OTHER_SPACE_ID),
     ];
     render(<ClaimsTab />);
-
-    chooseFilter('All claims', 'Featured');
 
     expect(screen.getByText('Nuclear power is the cheapest clean energy')).toBeInTheDocument();
     expect(screen.queryByText('Cities should ban cars downtown')).toBeNull();
@@ -631,8 +670,6 @@ describe('ClaimsTab -- Featured', () => {
     ];
     render(<ClaimsTab />);
 
-    chooseFilter('All claims', 'Featured');
-
     expect(mocks.debateClaimGroups.at(-1)).toEqual([{ spaceId: SPACE_ID, claimIds: [FEATURED_A] }]);
   });
 
@@ -646,7 +683,6 @@ describe('ClaimsTab -- Featured', () => {
     ];
     render(<ClaimsTab />);
 
-    chooseFilter('All claims', 'Featured');
     const askedBefore = mocks.debateClaimGroups.at(-1);
 
     fireEvent.change(screen.getByLabelText('Search claims'), { target: { value: 'nuclear' } });
@@ -659,38 +695,34 @@ describe('ClaimsTab -- Featured', () => {
   // Featured is one graph query, not a paged list. `keepPreviousData` leaves the paged query's
   // pages in place while Featured is showing, so a sentinel gated on those would page the corpus
   // underneath a list that never grows.
-  it('places no scroll sentinel on Featured', () => {
+  it('places no scroll sentinel on Featured', async () => {
     mocks.hasNextPage = true;
     mocks.featuredClaims = [featuredClaim(FEATURED_A, 'Nuclear power is the cheapest clean energy')];
     render(<ClaimsTab />);
 
-    expect(screen.getByTestId('claims-scroll-sentinel')).toBeInTheDocument();
-
-    chooseFilter('All claims', 'Featured');
-
     expect(screen.queryByTestId('claims-scroll-sentinel')).toBeNull();
+
+    await showAllClaims();
+
+    expect(screen.getByTestId('claims-scroll-sentinel')).toBeInTheDocument();
   });
 
   // Featured chooses which list is on screen rather than narrowing one, so an empty tab reads as
-  // "nothing is featured" — not as filters hiding claims that are there.
-  it('says nothing is featured rather than nothing is debatable', async () => {
+  // "nothing is featured" -- not as filters hiding claims that are there.
+  it('says nothing is featured rather than nothing is debatable', () => {
     render(<ClaimsTab />);
 
-    chooseFilter('All claims', 'Featured');
-
-    await waitFor(() => expect(screen.getByText('No claims have been featured yet.')).toBeInTheDocument());
+    expect(screen.getByText('No claims have been featured yet.')).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Clear filters' })).toBeNull();
   });
 
   // And once one is applied, clearing it leaves the viewer on Featured rather than dropping them
-  // back onto the paged list they didn't ask for.
+  // onto the paged list they didn't ask for.
   it('keeps the viewer on Featured when they clear a filter', async () => {
     mocks.featuredClaims = [featuredClaim(FEATURED_A, 'Nuclear power is the cheapest clean energy')];
     render(<ClaimsTab />);
 
-    chooseFilter('All claims', 'Featured');
     fireEvent.change(screen.getByLabelText('Search claims'), { target: { value: 'nothing matches this' } });
-
     await waitFor(() => expect(screen.getByText('No featured claims match these filters.')).toBeInTheDocument());
 
     fireEvent.click(screen.getByRole('button', { name: 'Clear filters' }));

--- a/apps/web/core/debates/matchmaking/claims-tab.tsx
+++ b/apps/web/core/debates/matchmaking/claims-tab.tsx
@@ -45,9 +45,11 @@ const SEARCH_DEBOUNCE_MS = 250;
  */
 type ClaimsTabFilter = MatchmakingClaimsFilter | 'featured';
 
+// Featured leads: it is where the tab opens, and an option the menu opens on should be the one at
+// the top of it.
 const FILTER_OPTIONS: HubFilterOption<ClaimsTabFilter>[] = [
-  { value: 'all', label: 'All claims' },
   { value: 'featured', label: 'Featured' },
+  { value: 'all', label: 'All claims' },
   { value: 'mine', label: 'My positions' },
   { value: 'debate_now', label: 'Debate now' },
 ];

--- a/apps/web/core/debates/matchmaking/claims-tab.tsx
+++ b/apps/web/core/debates/matchmaking/claims-tab.tsx
@@ -1,7 +1,5 @@
 'use client';
 
-import { keepPreviousData } from '@tanstack/react-query';
-
 import * as React from 'react';
 
 import cx from 'classnames';
@@ -12,7 +10,6 @@ import { useInfiniteScrollSentinel } from '~/core/hooks/use-infinite-scroll-sent
 import { spaceLabel, useSpaceLabels } from '~/core/hooks/use-space-labels';
 import { ID } from '~/core/id';
 import { responsePositionLabel } from '~/core/responses/entity-response';
-import { useQueryEntities } from '~/core/sync/use-store';
 import { validateEntityId } from '~/core/utils/utils';
 
 import { Input } from '~/design-system/input';
@@ -25,8 +22,14 @@ import type {
   MatchmakingClaimsQuery,
   MatchmakingTopic,
 } from '../api';
+import { useClaimEntitiesByIds } from '../claim-picker-page';
 import { isClaimSpaceAllowed } from '../claim-space-allowlist';
-import { type FeaturedClaim, featuredClaimIdsBySpace, useFeaturedClaims } from '../featured-claims';
+import {
+  type FeaturedClaim,
+  dedupeFeaturedClaims,
+  featuredClaimIdsBySpace,
+  useFeaturedClaims,
+} from '../featured-claims';
 import { useDebateClaimsBySpaces } from '../hooks';
 import { useClaimSpaceAllowlist } from '../use-claim-space-allowlist';
 import { isSpaceDebatePublishable, useDebatePublishableSpaces } from '../use-debate-publishable-spaces';
@@ -146,11 +149,14 @@ export function ClaimsTab() {
     refetch: refetchFeatured,
   } = useFeaturedClaims(featured);
 
+  // Collapsed to one row per claim *after* the space gates, not before. A claim can be tagged in
+  // several spaces, and deduplicating first would let a space the viewer can't be shown stand for a
+  // claim that is featured in one they can — dropping it from the list entirely.
   const featuredAllowed = React.useMemo(
     () =>
       !featured || spacesPending
         ? NO_FEATURED_CLAIMS
-        : featuredCatalog.filter(claim => spaceShowsClaims(claim.spaceId)),
+        : dedupeFeaturedClaims(featuredCatalog.filter(claim => spaceShowsClaims(claim.spaceId))),
     [featured, featuredCatalog, spaceShowsClaims, spacesPending]
   );
 
@@ -195,11 +201,12 @@ export function ClaimsTab() {
         : [...new Set(serverClaims.map(entry => entry.claim.claim_entity_id).filter(validateEntityId))],
     [featured, featuredMatching, serverClaims]
   );
-  const { entities: claimEntities } = useQueryEntities({
-    where: { id: { in: claimEntityIds } },
-    enabled: claimEntityIds.length > 0,
-    placeholderData: keepPreviousData,
-  });
+  // The picker's narrow projection rather than `useQueryEntities`: that one defaults to nine rows
+  // and slices to it, so a list of any length came back with topics for the first nine claims only
+  // — and Featured leans on the same lookup for the "Is factual" value that decides a card's side
+  // labels. This asks in batches of a hundred and pulls six fields instead of every value and
+  // relation on the entity.
+  const { entities: claimEntities } = useClaimEntitiesByIds(claimEntityIds);
 
   // Featured claims in the shape the rest of the tab already speaks. geo-chat has a row for a claim
   // only once someone has taken a side on it, so everything it would carry has a graph-derived

--- a/apps/web/core/debates/matchmaking/claims-tab.tsx
+++ b/apps/web/core/debates/matchmaking/claims-tab.tsx
@@ -7,15 +7,27 @@ import * as React from 'react';
 import cx from 'classnames';
 
 import { TOPICS_PROPERTY_ID } from '~/core/claims/ontology';
+import { claimResponseKind } from '~/core/claims/response-kind';
 import { useInfiniteScrollSentinel } from '~/core/hooks/use-infinite-scroll-sentinel';
 import { spaceLabel, useSpaceLabels } from '~/core/hooks/use-space-labels';
+import { ID } from '~/core/id';
+import { responsePositionLabel } from '~/core/responses/entity-response';
 import { useQueryEntities } from '~/core/sync/use-store';
 import { validateEntityId } from '~/core/utils/utils';
 
 import { Input } from '~/design-system/input';
 
-import type { MatchmakingClaimsFilter, MatchmakingClaimsQuery, MatchmakingTopic } from '../api';
+import type {
+  DebateClaim,
+  DebateClaimPositionSummary,
+  MatchmakingClaim,
+  MatchmakingClaimsFilter,
+  MatchmakingClaimsQuery,
+  MatchmakingTopic,
+} from '../api';
 import { isClaimSpaceAllowed } from '../claim-space-allowlist';
+import { type FeaturedClaim, featuredClaimIdsBySpace, useFeaturedClaims } from '../featured-claims';
+import { useDebateClaimsBySpaces } from '../hooks';
 import { useClaimSpaceAllowlist } from '../use-claim-space-allowlist';
 import { isSpaceDebatePublishable, useDebatePublishableSpaces } from '../use-debate-publishable-spaces';
 import { useMatchmakingClaims } from './hooks';
@@ -27,11 +39,21 @@ import { useStableListOrder } from './use-stable-list-order';
 
 const SEARCH_DEBOUNCE_MS = 250;
 
-const FILTER_OPTIONS: HubFilterOption<MatchmakingClaimsFilter>[] = [
+/**
+ * GEO-2683. `featured` is the tab's own, not one of geo-chat's: the index has no notion of the tag,
+ * so picking it swaps the list's source for the knowledge graph rather than changing a query param.
+ */
+type ClaimsTabFilter = MatchmakingClaimsFilter | 'featured';
+
+const FILTER_OPTIONS: HubFilterOption<ClaimsTabFilter>[] = [
   { value: 'all', label: 'All claims' },
+  { value: 'featured', label: 'Featured' },
   { value: 'mine', label: 'My positions' },
   { value: 'debate_now', label: 'Debate now' },
 ];
+
+/** Stable identity so the geo-chat lookups don't restart on every render of a non-featured list. */
+const NO_FEATURED_CLAIMS: FeaturedClaim[] = [];
 
 /**
  * Cross-space claim discovery. Search, the space and position filters, and the sort (people
@@ -47,7 +69,7 @@ const FILTER_OPTIONS: HubFilterOption<MatchmakingClaimsFilter>[] = [
 export function ClaimsTab() {
   const [search, setSearch] = React.useState('');
   const [debouncedSearch, setDebouncedSearch] = React.useState('');
-  const [filter, setFilter] = React.useState<MatchmakingClaimsFilter>('all');
+  const [filter, setFilter] = React.useState<ClaimsTabFilter>('all');
   const [spaceId, setSpaceId] = React.useState<string | null>(null);
   const [topicId, setTopicId] = React.useState<string | null>(null);
 
@@ -56,12 +78,17 @@ export function ClaimsTab() {
     return () => clearTimeout(timeout);
   }, [search]);
 
+  const featured = filter === 'featured';
+
+  // Featured draws its own list, so the index isn't asked for one. The query keeps saying `all`
+  // rather than going undefined: switching to Featured and back then lands on the pages already
+  // cached instead of paging the corpus again from the top.
   const query = React.useMemo<MatchmakingClaimsQuery>(
-    () => ({ search: debouncedSearch || null, spaceId, filter }),
-    [debouncedSearch, spaceId, filter]
+    () => ({ search: debouncedSearch || null, spaceId, filter: featured ? 'all' : filter }),
+    [debouncedSearch, featured, filter, spaceId]
   );
 
-  const claimsQuery = useMatchmakingClaims(query, true);
+  const claimsQuery = useMatchmakingClaims(query, !featured);
   const pages = React.useMemo(() => claimsQuery.data?.pages ?? [], [claimsQuery.data]);
   const facets = pages[0]?.facets;
 
@@ -97,36 +124,121 @@ export function ClaimsTab() {
   );
 
   const serverClaims = React.useMemo(
-    () => (spacesPending ? [] : pages.flatMap(page => page.claims).filter(entry => spaceShowsClaims(entry.claim.space_id))),
+    () =>
+      spacesPending ? [] : pages.flatMap(page => page.claims).filter(entry => spaceShowsClaims(entry.claim.space_id)),
     [pages, spaceShowsClaims, spacesPending]
   );
 
-  // The space menu offers only what the list can actually show, so picking an option never lands
-  // the viewer on an empty list they can't explain.
-  const facetSpaceIds = React.useMemo(
-    () => (spacesPending ? [] : (facets?.space_ids ?? []).filter(spaceShowsClaims)),
-    [facets?.space_ids, spaceShowsClaims, spacesPending]
+  // GEO-2683. Featured is a curator's tag in the knowledge graph, and geo-chat doesn't index it —
+  // so unlike the position filter this can't be a query param, and unlike topics it can't be a cut
+  // over the loaded pages either: tagged claims are a few hundred out of a corpus of hundreds of
+  // thousands, so a page-local filter would page for a very long time before it found one. The
+  // list comes from the graph, narrowed by the same two space gates as the paged one.
+  const {
+    claims: featuredCatalog,
+    isLoading: featuredLoading,
+    error: featuredError,
+    refetch: refetchFeatured,
+  } = useFeaturedClaims(featured);
+
+  const featuredAllowed = React.useMemo(
+    () =>
+      !featured || spacesPending
+        ? NO_FEATURED_CLAIMS
+        : featuredCatalog.filter(claim => spaceShowsClaims(claim.spaceId)),
+    [featured, featuredCatalog, spaceShowsClaims, spacesPending]
   );
 
-  // The server re-sorts on every readiness change, so hold the order the user is looking at until
-  // they ask for a different list.
-  const claims = useStableListOrder(
-    serverClaims,
-    entry => `${entry.claim.space_id}:${entry.claim.claim_entity_id}`,
-    `${debouncedSearch}|${spaceId ?? ''}|${filter}`
-  );
+  // Search and the space menu run over the loaded list, for the reason topics already do: there is
+  // no server query for them to go into.
+  const featuredMatching = React.useMemo(() => {
+    const needle = debouncedSearch.toLowerCase();
+    return featuredAllowed.filter(
+      claim =>
+        (spaceId === null || ID.equals(claim.spaceId, spaceId)) &&
+        (needle === '' || claim.name.toLowerCase().includes(needle))
+    );
+  }, [debouncedSearch, featuredAllowed, spaceId]);
+
+  // The sides and readiness the cards draw are geo-chat's, and its only lookup for claims it hasn't
+  // ranked is the per-space one — so the tagged claims are asked for by id, grouped by the space
+  // they were tagged in.
+  //
+  // Deliberately the whole allowed set rather than what search currently matches: typing then
+  // filters a list that is already loaded instead of restarting a fan-out of per-space requests on
+  // every keystroke, and the gateway scopes those lookups hold stay put while it happens.
+  const featuredGroups = React.useMemo(() => featuredClaimIdsBySpace(featuredAllowed), [featuredAllowed]);
+  const featuredRows = useDebateClaimsBySpaces(featuredGroups);
+  const featuredReadinessUnresolved = featured && (featuredRows.isLoading || featuredRows.isError);
+
+  // The space menu offers only what the list can actually show, so picking an option never lands
+  // the viewer on an empty list they can't explain. Featured has no server facets — its spaces are
+  // wherever the tagged claims live — and they are read before its own space selection is applied,
+  // or picking one would leave that one option in the menu.
+  const facetSpaceIds = React.useMemo(() => {
+    if (spacesPending) return [];
+    if (featured) return [...new Set(featuredAllowed.map(claim => claim.spaceId))];
+    return (facets?.space_ids ?? []).filter(spaceShowsClaims);
+  }, [facets?.space_ids, featured, featuredAllowed, spaceShowsClaims, spacesPending]);
 
   // Only real entity ids can be looked up in the KG; the graph 400s the whole batch on a single
   // malformed id, so drop any that aren't valid.
   const claimEntityIds = React.useMemo(
-    () => [...new Set(claims.map(entry => entry.claim.claim_entity_id).filter(validateEntityId))],
-    [claims]
+    () =>
+      featured
+        ? [...new Set(featuredMatching.map(claim => claim.claimEntityId).filter(validateEntityId))]
+        : [...new Set(serverClaims.map(entry => entry.claim.claim_entity_id).filter(validateEntityId))],
+    [featured, featuredMatching, serverClaims]
   );
   const { entities: claimEntities } = useQueryEntities({
     where: { id: { in: claimEntityIds } },
     enabled: claimEntityIds.length > 0,
     placeholderData: keepPreviousData,
   });
+
+  // Featured claims in the shape the rest of the tab already speaks. geo-chat has a row for a claim
+  // only once someone has taken a side on it, so everything it would carry has a graph-derived
+  // fallback: a claim nobody has answered still lists, with no sides and the response kind its own
+  // "Is factual" value implies.
+  const featuredEntries = React.useMemo<MatchmakingClaim[]>(() => {
+    if (!featured) return [];
+    const rowsByClaimId = new Map(featuredRows.claims.map(row => [row.claim_entity_id, row]));
+    const entitiesById = new Map(claimEntities.map(entity => [entity.id, entity]));
+
+    return featuredMatching.map(claim => {
+      const row = rowsByClaimId.get(claim.claimEntityId);
+      const entity = entitiesById.get(claim.claimEntityId);
+      const responseKind = row?.response_kind ?? (entity ? claimResponseKind(entity, claim.spaceId) : 'stance');
+
+      return {
+        claim: {
+          id: row?.id ?? claim.claimEntityId,
+          space_id: claim.spaceId,
+          claim_entity_id: claim.claimEntityId,
+          claim: claim.name,
+          description: claim.description,
+        },
+        topics: [],
+        response_kind: responseKind,
+        viewer_response: row?.viewer_response ?? null,
+        viewer_position: row?.viewer_response?.position ?? null,
+        viewer_debate_ready: row?.viewer_debate_ready ?? false,
+        readiness_disabled_reason: row?.readiness_disabled_reason ?? null,
+        positions: featuredPositionSummaries(row, responseKind),
+        // The index's ranking score, which this list has no equivalent of and doesn't sort by.
+        score: 0,
+        active_debate: Boolean(row?.active_debate),
+      };
+    });
+  }, [claimEntities, featured, featuredMatching, featuredRows.claims]);
+
+  // The server re-sorts on every readiness change, so hold the order the user is looking at until
+  // they ask for a different list.
+  const claims = useStableListOrder(
+    featured ? featuredEntries : serverClaims,
+    entry => `${entry.claim.space_id}:${entry.claim.claim_entity_id}`,
+    `${debouncedSearch}|${spaceId ?? ''}|${filter}`
+  );
 
   const topicsByClaimId = React.useMemo(() => {
     const map = new Map<string, MatchmakingTopic[]>();
@@ -149,10 +261,18 @@ export function ClaimsTab() {
     return [...seen.values()].sort((a, b) => (a.name ?? '').localeCompare(b.name ?? ''));
   }, [topicsByClaimId]);
 
-  const hasFilters = Boolean(debouncedSearch || spaceId || topicId || filter !== 'all');
+  // Featured is not counted: it chooses which list is on screen rather than narrowing one, so an
+  // empty Featured tab should say nothing is featured — not that filters are hiding things — and
+  // "Clear filters" should leave the viewer on the tab they picked.
+  const hasFilters = Boolean(debouncedSearch || spaceId || topicId || (!featured && filter !== 'all'));
+
+  // Featured is one graph query, not a paged list, so it never asks for more. `keepPreviousData`
+  // leaves the paged query's pages in place while Featured is showing, so this has to be gated on
+  // the filter rather than on whether a next page happens to exist.
+  const hasNextPage = !featured && claimsQuery.hasNextPage;
 
   const sentinelRef = useInfiniteScrollSentinel({
-    hasNextPage: claimsQuery.hasNextPage,
+    hasNextPage,
     isFetchingNextPage: claimsQuery.isFetchingNextPage,
     fetchNextPage: claimsQuery.fetchNextPage,
   });
@@ -193,18 +313,26 @@ export function ClaimsTab() {
       />
 
       <HubQueryState
-        isLoading={claimsQuery.isLoading || spacesPending}
-        error={claimsQuery.error}
-        onRetry={() => void claimsQuery.refetch()}
+        isLoading={spacesPending || (featured ? featuredLoading : claimsQuery.isLoading)}
+        error={featured ? featuredError : claimsQuery.error}
+        onRetry={() => void (featured ? refetchFeatured() : claimsQuery.refetch())}
         isEmpty={visibleClaims.length === 0}
-        emptyMessage={hasFilters ? 'No claims match these filters.' : 'No debatable claims yet.'}
+        emptyMessage={
+          featured
+            ? hasFilters
+              ? 'No featured claims match these filters.'
+              : 'No claims have been featured yet.'
+            : hasFilters
+              ? 'No claims match these filters.'
+              : 'No debatable claims yet.'
+        }
         emptyAction={
           hasFilters
             ? {
                 label: 'Clear filters',
                 onClick: () => {
                   setSearch('');
-                  setFilter('all');
+                  if (!featured) setFilter('all');
                   setSpaceId(null);
                   setTopicId(null);
                 },
@@ -223,6 +351,11 @@ export function ClaimsTab() {
               positions={entry.positions}
               readiness={entry}
               activeDebate={entry.active_debate}
+              // Featured rows carry `viewer_debate_ready: false` until geo-chat's per-space lookup
+              // lands, and a switch drawn from that would report "not ready" on a claim the viewer
+              // is in fact standing ready on. The paged rows come with readiness on them, so this
+              // only ever applies to Featured.
+              hideReadinessToggle={featuredReadinessUnresolved}
             />
           ))}
         </HubCardList>
@@ -238,11 +371,37 @@ export function ClaimsTab() {
           Not while the allowlist is pending, though: the tab is showing a four-row skeleton then,
           so the sentinel sits in view under it and pages the corpus on the strength of a loading
           state being visible — reading "the viewer reached the end" off a list that isn't there. */}
-      {claimsQuery.hasNextPage && !spacesPending ? (
+      {hasNextPage && !spacesPending ? (
         <div ref={sentinelRef} data-testid="claims-scroll-sentinel" className="h-px" />
       ) : null}
     </div>
   );
+}
+
+/**
+ * The two sides of a featured claim, from geo-chat's per-space row.
+ *
+ * That row reports the sides as `online_choices` — who is online and available on each — where the
+ * hub's index reports a total alongside them. The card draws the avatars and their overflow count
+ * off `total_count`, so the online count stands in for it: it is the only count this endpoint
+ * gives, and undercounting a side is better than claiming a total it never told us.
+ */
+function featuredPositionSummaries(
+  row: DebateClaim | undefined,
+  responseKind: 'stance' | 'veracity'
+): DebateClaimPositionSummary[] {
+  return [true, false].map(position => {
+    const choice = row?.online_choices.find(candidate => candidate.position === position);
+
+    return {
+      position,
+      // A server-supplied label wins, so an authoritative Verify/Dispute survives.
+      position_label: choice?.position_label ?? responsePositionLabel(responseKind, position),
+      total_count: choice?.participant_count ?? 0,
+      available_now_count: choice?.participant_count ?? 0,
+      participants: choice?.participants ?? [],
+    };
+  });
 }
 
 type SpaceTopicFiltersProps = {

--- a/apps/web/core/debates/matchmaking/claims-tab.tsx
+++ b/apps/web/core/debates/matchmaking/claims-tab.tsx
@@ -69,7 +69,10 @@ const NO_FEATURED_CLAIMS: FeaturedClaim[] = [];
 export function ClaimsTab() {
   const [search, setSearch] = React.useState('');
   const [debouncedSearch, setDebouncedSearch] = React.useState('');
-  const [filter, setFilter] = React.useState<ClaimsTabFilter>('all');
+  // Featured is where the tab opens. The whole corpus is the wider net but the shallower one — a
+  // curator's pick is a better first thing to put in front of someone than whatever the index
+  // ranked highest, and All claims is one menu away.
+  const [filter, setFilter] = React.useState<ClaimsTabFilter>('featured');
   const [spaceId, setSpaceId] = React.useState<string | null>(null);
   const [topicId, setTopicId] = React.useState<string | null>(null);
 


### PR DESCRIPTION
Closes [GEO-2683](https://linear.app/geobrowser/issue/GEO-2683/debates-add-featured-option-to-claims-tab-and-use-it-in-place-of).

## What

Claims a curator has tagged **Featured** — a `Tags` relation (`257090341ba5406f94e4d4af90042fba`) pointing at `Featured` (`ec3086a54ddf43d8aaefd6cc6e1b0556`) — surfaced in two places.

**Debates hub, Claims tab.** `Featured` leads the position menu and is what the tab opens on. A curator's pick is a better first thing to put in front of someone than whatever the index ranked highest, and All claims is one option below.

**Debate-again (rematch) picker.** The tab strip is `Claims` and `{Name}'s positions`. Claims is where the picker opens, and a source menu to the left of the space filter chooses what it lists: `Recommended` (only when a curator has a page for this pairing), `Featured`, `All claims` — in that fixed order. It starts on Recommended when there is one, Featured otherwise.

The old model had a slot that changed identity as lookups landed — Recommended, or Featured standing in for it, or neither, with the landing tab moving under the viewer. Recommended, Featured and the whole corpus are three answers to one question, "which claims?", so they belong in a menu that says so in words rather than in tabs the viewer has to notice appearing.

## Ordering

The list is ordered the way Explore's **Best** sort orders its feed: `ranking_score DESC, entity_id DESC`, the tiebreak included, so two claims on the same score land here exactly where Explore puts them. `Entity.rankingScore` is selectable on the query that was already being made, so this costs no extra round trip.

A claim the ranking feed has never scored isn't in `entities_ranked_for_feed` at all, so there's no place in the order for it. It goes last rather than being dropped — a curator tagged it deliberately, and leaving it out would quietly overrule them.

The tag query pages to exhaustion, because the connection orders by relation id — random v4s — so a single capped request would decide what to keep at random from a set that is then ranked. `FEATURED_CLAIMS_LIMIT` remains as a runaway guard well above the real corpus (205 tags today), and says so through `devLog` if it's ever reached.

## Why Featured isn't a filter

geo-chat's matchmaking index has no notion of the tag, so Featured can't be a query param the way the position filter is. It can't be a cut over the loaded pages the way topics are either: on testnet there are 205 tagged claims against 302,390 claims total — 0.07% — so a page-local filter would page for a very long time before it found one.

So Featured swaps the list's *source*: one `relationsConnection` query for the tag (which carries the space it was written in, i.e. the space the claim was featured in), then geo-chat asked about those claims by id, per space, for the sides and readiness the cards draw. A claim nobody has answered yet still lists — everything geo-chat's row would carry has a graph-derived fallback, including the response kind, read off the claim's own "Is factual" value.

## Space scoping

Per the ticket's note, "relevant spaces" means the same set the rest of the panel is scoped to:

- **Hub Claims tab** — both gates: the viewer's allowlist and `isSpaceDebatePublishable` (GEO-2649). Featured can't offer a claim the paged list wouldn't.
- **Rematch picker** — the viewer's allowlist. Recommended is deliberately outside it (one page from a space this build trusts by id), but Featured is a tag any space can carry, so it fans out across the corpus the way All claims does and is bounded the same way. `canPublishDebateIn` applies as it does to every list there.

A claim can be tagged in several spaces, so the tags are collapsed to one row per claim **after** those gates, not before — otherwise a space the viewer can't be shown would stand for a claim that is featured in one they can, and drop it. The surviving tag's space is then the space the row is built against: the picker's usual space ranking picks the highest-ranked space a claim is *named* in, which knows nothing of the allowlist, so left to it a claim featured in an allowed space could be drawn and requested in a disallowed one. Narrowing preserves the order, so what survives is still ranked.

## Decisions worth a look

- **Waiting on the curated lookup.** Until it settles there's no telling "no curator page" from "not yet", and the picker's default source turns on exactly that — so the Claims list waits rather than showing Featured and swapping it for Recommended a moment later. A source the viewer picked is then theirs to keep.
- **Empty states.** Featured chooses *which* list is on screen rather than narrowing one, so an empty result says "No claims have been featured yet" rather than blaming filters, and "Clear filters" leaves the viewer on Featured. The picker has its own message for the same case, and a failed tag lookup reports as an error rather than as an empty list.
- **The source menu is Claims-only.** The opponent's tab is one fixed source — their own responses — and a menu offering three others there would read as filtering a list it can't reach. The tag query is gated on the tab too, so a remembered Featured source doesn't hold a graph query open behind it.
- **Featured claims aren't merged into All claims** in the picker, the way the curated and opponent lists are. Those are rows the index hasn't paged to yet; Featured is a few hundred claims the index already knows, so folding them in would pin them above what the viewer searched for.

## Drive-by fix

The hub's Claims tab resolved topics through `useQueryEntities`, which defaults to nine rows and slices to them — so the topic facet has only ever seen the first nine claims of each page. Featured made that worse by leaning on the same lookup for the "Is factual" value that decides a card's side labels. Both paths now use the picker's batched `useClaimEntitiesByIds` projection, which asks in hundreds and pulls six fields rather than every value and relation on the entity.

Also lifts the third copy of `claimResponseKind` out of the two page files it was duplicated in.

## Testing

- New `featured-claims.test.ts` covering the Best ordering, the entity-id tiebreak, unscored claims landing last, pagination and the runaway guard, multi-space tags surviving the fetch, and `dedupeFeaturedClaims`.
- New cases in `claims-tab.test.tsx` (the default, menu order, both space gates, multi-space tags, the source swap, the paging sentinel, empty states) and `rematch-page-client.test.tsx` (the source menu's default, order, allowlist narrowing and loading, error reporting, tab-gated fetching, and that a picked source survives a late curated lookup). Existing suites updated for the new landing tab.
- Full web suite: 302 files passing. `bun run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

