### PR TITLE
feat(debates): label the debates button in the nav bar

### DIFF
--- a/apps/web/core/debates/matchmaking/debates-hub-button.test.tsx
+++ b/apps/web/core/debates/matchmaking/debates-hub-button.test.tsx
@@ -13,7 +13,6 @@ const mocks = vi.hoisted(() => ({
   incomingRequestCount: 0,
 }));
 
-
 vi.mock('../hooks', () => ({
   useGeoChatAuth: () => ({ ready: mocks.ready, authenticated: mocks.authenticated, accountKey: 'user-a' }),
   useDebateActivity: () => ({ data: { incoming_request_count: mocks.incomingRequestCount } }),
@@ -68,6 +67,48 @@ describe('DebatesHubButton', () => {
 
     expect(screen.getByRole('button', { name: 'Debates, 3 pending requests' })).toBeInTheDocument();
     expect(screen.getByText('3')).toBeInTheDocument();
+  });
+
+  /**
+   * GEO-2689. A megaphone on its own does not say "debates", and the button had nothing else to go
+   * on. The word has to agree with what the button already answers to — the panel it opens is
+   * headed "Debates" and so is its own accessible name, and a control that shows one name while
+   * answering to another is worse than one showing none.
+   */
+  describe('label', () => {
+    it('says what the button is for', () => {
+      renderButton();
+
+      expect(screen.getByText('Debates')).toBeInTheDocument();
+    });
+
+    it('shows the same word the button answers to', () => {
+      renderButton();
+
+      const button = screen.getByRole('button', { name: 'Debates' });
+
+      expect(button).toHaveTextContent('Debates');
+    });
+
+    // The count is the reason the accessible name is written by hand, and it has to keep winning
+    // over the visible text now that there is some.
+    it('still announces the pending count rather than reading out the label and a bare number', () => {
+      mocks.incomingRequestCount = 2;
+      renderButton();
+
+      expect(screen.getByRole('button', { name: 'Debates, 2 pending requests' })).toBeInTheDocument();
+      expect(screen.getByText('Debates')).toBeInTheDocument();
+      expect(screen.getByText('2')).toBeInTheDocument();
+    });
+
+    // Phones have the least room in the navbar, so the label is dropped there — but only the
+    // visible one. `aria-label` still names the button for anyone reading it that way.
+    it('drops the visible label on phones without dropping the name', () => {
+      renderButton();
+
+      expect(screen.getByText('Debates')).toHaveClass('sm:hidden');
+      expect(screen.getByRole('button', { name: 'Debates' })).toBeInTheDocument();
+    });
   });
 
   it('leaves the hub closed when there is no button to open it', () => {

--- a/apps/web/core/debates/matchmaking/debates-hub-button.test.tsx
+++ b/apps/web/core/debates/matchmaking/debates-hub-button.test.tsx
@@ -41,14 +41,14 @@ afterEach(cleanup);
 describe('DebatesHubButton', () => {
   it('shows for a signed-in user', () => {
     renderButton();
-    expect(screen.getByRole('button', { name: 'Debates' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Debate' })).toBeInTheDocument();
   });
 
   it('stays hidden for a signed-out visitor', () => {
     mocks.authenticated = false;
     renderButton();
     // The hub is the only opener for the panel, and every tab behind it needs an identity.
-    expect(screen.queryByRole('button', { name: /Debates/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Debate/ })).not.toBeInTheDocument();
   });
 
   it('stays hidden until Privy has restored the session', () => {
@@ -58,36 +58,40 @@ describe('DebatesHubButton', () => {
     mocks.authenticated = false;
     renderButton();
 
-    expect(screen.queryByRole('button', { name: /Debates/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Debate/ })).not.toBeInTheDocument();
   });
 
   it('keeps announcing the pending request count while signed in', () => {
     mocks.incomingRequestCount = 3;
     renderButton();
 
-    expect(screen.getByRole('button', { name: 'Debates, 3 pending requests' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Debate, 3 pending requests' })).toBeInTheDocument();
     expect(screen.getByText('3')).toBeInTheDocument();
   });
 
   /**
-   * GEO-2689. A megaphone on its own does not say "debates", and the button had nothing else to go
-   * on. The word has to agree with what the button already answers to — the panel it opens is
-   * headed "Debates" and so is its own accessible name, and a control that shows one name while
-   * answering to another is worse than one showing none.
+   * GEO-2689. A megaphone on its own does not say "debate", and the button had nothing else to go
+   * on. Whatever the word is, the button has to answer to it: a control that shows one name while
+   * answering to another is worse than one showing none, so these pin the visible label and the
+   * accessible name to each other rather than to a particular spelling.
    */
   describe('label', () => {
     it('says what the button is for', () => {
       renderButton();
 
-      expect(screen.getByText('Debates')).toBeInTheDocument();
+      expect(screen.getByText('Debate')).toBeInTheDocument();
     });
 
     it('shows the same word the button answers to', () => {
       renderButton();
 
-      const button = screen.getByRole('button', { name: 'Debates' });
+      const button = screen.getByRole('button');
+      const visible = button.querySelector('span')?.textContent ?? '';
 
-      expect(button).toHaveTextContent('Debates');
+      // Read back rather than asserted twice over: the point is that the two agree, whichever word
+      // is chosen, so this fails if either is edited without the other.
+      expect(visible).not.toBe('');
+      expect(button).toHaveAccessibleName(visible);
     });
 
     // The count is the reason the accessible name is written by hand, and it has to keep winning
@@ -96,9 +100,17 @@ describe('DebatesHubButton', () => {
       mocks.incomingRequestCount = 2;
       renderButton();
 
-      expect(screen.getByRole('button', { name: 'Debates, 2 pending requests' })).toBeInTheDocument();
-      expect(screen.getByText('Debates')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Debate, 2 pending requests' })).toBeInTheDocument();
+      expect(screen.getByText('Debate')).toBeInTheDocument();
       expect(screen.getByText('2')).toBeInTheDocument();
+    });
+
+    // Set in the browse sidebar's menu type so the two read as the same kind of navigation text,
+    // rather than the navbar's heavier metadata weight.
+    it('is set in the browse menu type', () => {
+      renderButton();
+
+      expect(screen.getByText('Debate')).toHaveClass('text-browseMenu');
     });
 
     // Phones have the least room in the navbar, so the label is dropped there — but only the
@@ -106,8 +118,8 @@ describe('DebatesHubButton', () => {
     it('drops the visible label on phones without dropping the name', () => {
       renderButton();
 
-      expect(screen.getByText('Debates')).toHaveClass('sm:hidden');
-      expect(screen.getByRole('button', { name: 'Debates' })).toBeInTheDocument();
+      expect(screen.getByText('Debate')).toHaveClass('sm:hidden');
+      expect(screen.getByRole('button', { name: 'Debate' })).toBeInTheDocument();
     });
   });
 

--- a/apps/web/core/debates/matchmaking/debates-hub-button.test.tsx
+++ b/apps/web/core/debates/matchmaking/debates-hub-button.test.tsx
@@ -71,9 +71,13 @@ describe('DebatesHubButton', () => {
 
   /**
    * GEO-2689. A megaphone on its own does not say "debate", and the button had nothing else to go
-   * on. Whatever the word is, the button has to answer to it: a control that shows one name while
-   * answering to another is worse than one showing none, so these pin the visible label and the
-   * accessible name to each other rather than to a particular spelling.
+   * on.
+   *
+   * Most of these do pin the word: "Debate" is the product's choice, and a test that shrugged at it
+   * would not notice the button quietly renaming itself. The one exception is the agreement case
+   * below, which reads whatever is shown and requires the accessible name to match — that one holds
+   * whichever word is chosen, because a control showing one name while answering to another is
+   * worse than one showing none.
    */
   describe('label', () => {
     it('says what the button is for', () => {
@@ -107,6 +111,14 @@ describe('DebatesHubButton', () => {
       expect(screen.getByRole('button', { name: 'Debate, 2 pending requests' })).toBeInTheDocument();
       expect(screen.getByText('Debate')).toBeInTheDocument();
       expect(screen.getByText('2')).toBeInTheDocument();
+    });
+
+    // Read aloud, so it has to be a sentence. One request is not "1 pending requests".
+    it('counts a single pending request', () => {
+      mocks.incomingRequestCount = 1;
+      renderButton();
+
+      expect(screen.getByRole('button', { name: 'Debate, 1 pending request' })).toBeInTheDocument();
     });
 
     // Set in the browse sidebar's menu type so the two read as the same kind of navigation text,

--- a/apps/web/core/debates/matchmaking/debates-hub-button.test.tsx
+++ b/apps/web/core/debates/matchmaking/debates-hub-button.test.tsx
@@ -83,10 +83,14 @@ describe('DebatesHubButton', () => {
     });
 
     it('shows the same word the button answers to', () => {
+      // No pending count, so everything the button shows is the label — the icon carries no text.
+      // Reading all of it beats picking a span: the first span is the label only until someone adds
+      // a wrapper or moves the count, and then the assertion quietly changes subject. Not selected
+      // by its class either, which would tie this to styling and to the test below that pins it.
       renderButton();
 
       const button = screen.getByRole('button');
-      const visible = button.querySelector('span')?.textContent ?? '';
+      const visible = button.textContent?.trim() ?? '';
 
       // Read back rather than asserted twice over: the point is that the two agree, whichever word
       // is chosen, so this fails if either is edited without the other.

--- a/apps/web/core/debates/matchmaking/debates-hub-button.tsx
+++ b/apps/web/core/debates/matchmaking/debates-hub-button.tsx
@@ -39,7 +39,11 @@ export function DebatesHubButton() {
       // The pending count is the whole point of the button, and an aria-label would otherwise
       // override the visible number. It says "Debate" to match the label below: a control should
       // answer to the word it shows, so the two move together.
-      aria-label={requestCount > 0 ? `Debate, ${requestCount} pending requests` : 'Debate'}
+      //
+      // Counted, because this is read aloud and "1 pending requests" is not a sentence.
+      aria-label={
+        requestCount > 0 ? `Debate, ${requestCount} pending ${requestCount === 1 ? 'request' : 'requests'}` : 'Debate'
+      }
       aria-expanded={isOpen}
       onClick={() => toggle()}
       className={cx(

--- a/apps/web/core/debates/matchmaking/debates-hub-button.tsx
+++ b/apps/web/core/debates/matchmaking/debates-hub-button.tsx
@@ -47,6 +47,15 @@ export function DebatesHubButton() {
       )}
     >
       <Megaphone />
+      {/* A megaphone says nothing about debates on its own (GEO-2689). "Debates" rather than
+          "Debate" because that is what the panel it opens is headed, and what this button already
+          calls itself to a screen reader — a control that answers to one name and shows another is
+          worse than an unlabelled icon.
+
+          Dropped on phones, where the navbar has the least room to give and the label is the only
+          thing here that can be spared. The `aria-label` carries the name through regardless, so
+          nothing is lost for anyone reading it that way. */}
+      <span className="text-metadataMedium leading-none sm:hidden">Debates</span>
       {requestCount > 0 ? <span className="text-metadataMedium leading-none">{requestCount}</span> : null}
     </button>
   );

--- a/apps/web/core/debates/matchmaking/debates-hub-button.tsx
+++ b/apps/web/core/debates/matchmaking/debates-hub-button.tsx
@@ -37,8 +37,9 @@ export function DebatesHubButton() {
       type="button"
       data-debates-hub-opener
       // The pending count is the whole point of the button, and an aria-label would otherwise
-      // override the visible number.
-      aria-label={requestCount > 0 ? `Debates, ${requestCount} pending requests` : 'Debates'}
+      // override the visible number. It says "Debate" to match the label below: a control should
+      // answer to the word it shows, so the two move together.
+      aria-label={requestCount > 0 ? `Debate, ${requestCount} pending requests` : 'Debate'}
       aria-expanded={isOpen}
       onClick={() => toggle()}
       className={cx(
@@ -47,15 +48,17 @@ export function DebatesHubButton() {
       )}
     >
       <Megaphone />
-      {/* A megaphone says nothing about debates on its own (GEO-2689). "Debates" rather than
-          "Debate" because that is what the panel it opens is headed, and what this button already
-          calls itself to a screen reader — a control that answers to one name and shows another is
-          worse than an unlabelled icon.
+      {/* A megaphone says nothing about debates on its own (GEO-2689). "Debate" reads as the
+          invitation the button is, where the panel behind it stays headed "Debates" for the things
+          it lists — the `aria-label` above follows this word rather than the panel's, so the button
+          answers to what it shows.
+
+          Set in the browse sidebar's menu type, which is the nearest navigation text on screen.
 
           Dropped on phones, where the navbar has the least room to give and the label is the only
           thing here that can be spared. The `aria-label` carries the name through regardless, so
           nothing is lost for anyone reading it that way. */}
-      <span className="text-metadataMedium leading-none sm:hidden">Debates</span>
+      <span className="text-browseMenu font-normal not-italic sm:hidden">Debate</span>
       {requestCount > 0 ? <span className="text-metadataMedium leading-none">{requestCount}</span> : null}
     </button>
   );


### PR DESCRIPTION
Closes GEO-2689.

Adds a visible label beside the megaphone in the top bar.

## "Debates", not "Debate"

The ticket flagged this as a decision. Going with **Debates**, because it is already the word on both sides of this button:

- the panel it opens is headed `Debates` (`debates-hub-panel.tsx:224`)
- the button's own `aria-label` is `Debates`, and has been since it was written

Showing `Debate` would have left a control displaying one name while answering to another, which is worse for someone using both eyes and a screen reader than showing no name at all. `Debate` does exist in the product — the per-claim toggle on a row — but that is a verb about one claim, where this is a place holding all of them.

## Fit

The ticket asked whether the row still fits at narrower widths, so I measured instead of guessing. The button only renders for a signed-in user, and rather than change the component to see it, I built the same markup with the same classes and dropped it into the live top bar:

| viewport | label | button | top bar |
|---|---|---|---|
| 1500px | shown (50px) | 106px | fits |
| 1280px | shown (50px) | 106px | fits |
| 1024px | shown (50px) | 106px | fits |
| 900px | shown (50px) | 106px | fits |
| 768px | shown (50px) | 106px | fits |
| 640px | shown (50px) | 106px | fits |
| 560px | hidden | 49px | fits |
| 390px | hidden | 49px | fits |

No overflow and no spill past the bar's right edge at any width. Measured with a pending count of 3, the widest the button gets.

The label is dropped below 640px via `sm:hidden` — the breakpoints here are desktop-first max-width (`styles.css:245`), so `sm:` is phones. Only the visible word goes; `aria-label` still names the button, so nothing is lost for anyone reading it that way.

## On the other icon-only controls

The ticket wondered whether labelling this one leaves the others looking bare. Search and create sit next to it unlabelled. I have left them: they are conventional icons that people already recognise, which is exactly what a megaphone is not — and widening the row further is the thing the measurements above say to be careful about. Worth a look in review, since it is a judgement about the row as a whole rather than about this control.

## Tests

Four cases added to `debates-hub-button.test.tsx`: the label is there, it matches what the button answers to, the pending count still wins the accessible name over the visible text, and the phone rule drops the word without dropping the name.

Verified non-vacuous by two sabotages, each failing all four: removing the label, and setting it to `Debate` so it disagrees with the accessible name.

## Not verified

Not seen with the real component signed in — the browser here is signed out, so the fit table comes from a stand-in with identical classes. The label, the sizing and the classes are the real ones; what is untested is whether a signed-in top bar carries anything else that changes the arithmetic.

Unrelated to this change: `core/debates/api.test.ts` and a few neighbours fail locally with `window.localStorage.removeItem is not a function`, a known jsdom problem that reproduces on clean master.

---

## Updated after review

**The word is "Debate".** Preston's call. I had argued for "Debates" on the grounds that it is what the panel and the accessible name already said; the reading that settles it is that the button is an invitation — *debate* — while the panel behind it lists the things, and stays headed "Debates".

The `aria-label` moved with it, to `Debate` / `Debate, N pending requests`. That part is not cosmetic: leaving it on "Debates" would have kept the button answering to a word it no longer shows, which is the exact failure the label exists to fix. Nothing outside this component and its own tests referenced that name.

**Type now matches the browse sidebar.** `text-browseMenu font-normal not-italic`, the same class its menu links use, replacing the navbar's `text-metadataMedium`. The two tokens are both 16px but differ in weight and tracking, which is the difference that was showing.

Confirmed against a real sidebar link in the browser rather than by reading the token:

```
nav label    {family: calibre, size: 16px, weight: 400, spacing: -0.35px, style: normal}
sidebar link {family: calibre, size: 16px, weight: 400, spacing: -0.35px, style: normal}   ("Explore")
identical
```

**The agreement test got better as a result.** It used to assert the spelling twice, once for the label and once for the name — which would have passed happily if both were wrong together, and needed editing for this change. It now reads the visible word off the button and asserts the accessible name equals it, so it fails if either moves without the other, whatever the word becomes next.

The pending-count badge keeps `text-metadataMedium` — it is a number rather than navigation text, and a slightly heavier weight suits it. Easy to bring in line if you would rather the whole pill were one type.
