### PR TITLE
feat(debates): read pre-extracted claims from geo-chat when publishing (rebased)

### DIFF
--- a/apps/web/core/debates/debate-publish-draft.test.ts
+++ b/apps/web/core/debates/debate-publish-draft.test.ts
@@ -9,13 +9,19 @@ import {
   buildDebatePublishDraft,
   mergeTranscriptSegmentsIntoTurns,
 } from './debate-publish-draft';
+import { CLAIM_IS_FACTUAL_PROPERTY_ID, CLAIM_TYPE_ID } from '~/core/claims/ontology';
+
 import {
+  AUTHORS_PROPERTY_ID,
+  DEBATE_CLAIMS_PROPERTY_ID,
   DEBATE_OPPOSED_BY_PROPERTY_ID,
   DEBATE_SUPPORTED_BY_PROPERTY_ID,
   DEBATE_TYPE_ID,
   IMAGE_TYPE_ID,
   IMAGE_URL_PROPERTY_ID,
   KEY_FRAME_IMAGE_PROPERTY_ID,
+  NAME_PROPERTY_ID,
+  SOURCES_PROPERTY_ID,
   TRANSCRIPT_TYPE_ID,
   TYPES_PROPERTY_ID,
   VIDEO_TYPE_ID,
@@ -45,8 +51,8 @@ function baseInput(overrides: Partial<DebatePublishInput> = {}): DebatePublishIn
     videoUrl: 'ipfs://bafyfinalvideo',
     keyframeUrl: 'ipfs://bafykeyframe',
     transcriptTurns: [
-      { speakerSpaceEntityId: YES_SPACE, speakerName: 'Arturas', text: 'Iran was building a nuke.' },
-      { speakerSpaceEntityId: NO_SPACE, speakerName: 'Preston', text: 'There was no congressional approval.' },
+      { turnIndex: 0, speakerSpaceEntityId: YES_SPACE, speakerName: 'Arturas', text: 'Iran was building a nuke.' },
+      { turnIndex: 1, speakerSpaceEntityId: NO_SPACE, speakerName: 'Preston', text: 'There was no congressional approval.' },
     ],
     ...overrides,
   };
@@ -142,6 +148,104 @@ describe('buildDebatePublishDraft', () => {
 
   it('produces a valid non-empty edit through the real publish op pipeline', async () => {
     const draft = buildDebatePublishDraft(baseInput(), { createEntityId: ID.createEntityId });
+    const ops = await Effect.runPromise(Publish.prepareLocalDataForPublishing(draft.values, draft.relations, SPACE));
+    expect(ops.length).toBeGreaterThan(0);
+  });
+
+  const claimIdByName = (draft: ReturnType<typeof buildDebatePublishDraft>, name: string) =>
+    draft.values.find(v => v.property.id === NAME_PROPERTY_ID && v.value === name)?.entity.id;
+
+  const blockAuthoringClaim = (draft: ReturnType<typeof buildDebatePublishDraft>, claimId: string | undefined) => {
+    const blockClaimRel = draft.relations.find(r => r.type.id === DEBATE_CLAIMS_PROPERTY_ID && r.toEntity.id === claimId);
+    const blockId = blockClaimRel?.fromEntity.id;
+    return draft.relations.find(r => r.type.id === AUTHORS_PROPERTY_ID && r.fromEntity.id === blockId)?.toEntity.id;
+  };
+
+  it('mints a Claim per extracted claim, attributed to its turn block, with Is factual set', () => {
+    const draft = buildDebatePublishDraft(
+      baseInput({
+        claims: [
+          { text: 'Iran was developing a nuclear weapon', isFactual: true, turnIndex: 0 },
+          { text: 'Attacking Iran was wrong', isFactual: false, turnIndex: 1 },
+        ],
+      }),
+      { createEntityId: idFactory(), createPosition: () => 'a0' }
+    );
+
+    // One Claim entity (Types -> Claim) per extracted claim.
+    const claimTypeRels = draft.relations.filter(r => r.type.id === TYPES_PROPERTY_ID && r.toEntity.id === CLAIM_TYPE_ID);
+    expect(claimTypeRels).toHaveLength(2);
+
+    // Fact claim: Is factual = true (BOOLEAN), attributed to the YES speaker's block, Sources -> Debate.
+    const factClaimId = claimIdByName(draft, 'Iran was developing a nuclear weapon');
+    const factBool = draft.values.find(v => v.entity.id === factClaimId && v.property.id === CLAIM_IS_FACTUAL_PROPERTY_ID);
+    expect(factBool?.value).toBe('true');
+    expect(factBool?.property.dataType).toBe('BOOLEAN');
+    expect(blockAuthoringClaim(draft, factClaimId)).toBe(YES_SPACE);
+    expect(
+      draft.relations.some(
+        r => r.type.id === SOURCES_PROPERTY_ID && r.fromEntity.id === factClaimId && r.toEntity.id === draft.debateEntityId
+      )
+    ).toBe(true);
+
+    // Opinion claim: Is factual = false, attributed to the NO speaker's block.
+    const opinionClaimId = claimIdByName(draft, 'Attacking Iran was wrong');
+    expect(
+      draft.values.find(v => v.entity.id === opinionClaimId && v.property.id === CLAIM_IS_FACTUAL_PROPERTY_ID)?.value
+    ).toBe('false');
+    expect(blockAuthoringClaim(draft, opinionClaimId)).toBe(NO_SPACE);
+  });
+
+  it('attributes claims by turn_index, not array position, when the two diverge', () => {
+    // geo-chat's turn_index need not equal the JS array position: a turn Rust kept but a JS-side
+    // whitespace filter would drop (e.g. a lone U+FEFF) leaves a gap. Keying claims by turnIndex —
+    // not forEach position — keeps each claim on its own speaker's block regardless.
+    const draft = buildDebatePublishDraft(
+      baseInput({
+        transcriptTurns: [
+          { turnIndex: 3, speakerSpaceEntityId: YES_SPACE, speakerName: 'Arturas', text: 'Yes-side turn.' },
+          { turnIndex: 7, speakerSpaceEntityId: NO_SPACE, speakerName: 'Preston', text: 'No-side turn.' },
+        ],
+        claims: [
+          { text: 'Belongs to the no-side turn', isFactual: true, turnIndex: 7 },
+          { text: 'Belongs to the yes-side turn', isFactual: false, turnIndex: 3 },
+        ],
+      }),
+      { createEntityId: idFactory(), createPosition: () => 'a0' }
+    );
+    // Positional keying would drop turnIndex 7 (only two turns) and misplace turnIndex 3.
+    expect(blockAuthoringClaim(draft, claimIdByName(draft, 'Belongs to the no-side turn'))).toBe(NO_SPACE);
+    expect(blockAuthoringClaim(draft, claimIdByName(draft, 'Belongs to the yes-side turn'))).toBe(YES_SPACE);
+  });
+
+  it('omits the Is factual value when factuality is null', () => {
+    const draft = buildDebatePublishDraft(baseInput({ claims: [{ text: 'Unclassified claim', isFactual: null, turnIndex: 0 }] }), {
+      createEntityId: idFactory(),
+      createPosition: () => 'a0',
+    });
+    const claimId = claimIdByName(draft, 'Unclassified claim');
+    expect(claimId).toBeTruthy();
+    expect(draft.values.some(v => v.entity.id === claimId && v.property.id === CLAIM_IS_FACTUAL_PROPERTY_ID)).toBe(false);
+  });
+
+  it('mints no Claim entities when no claims are provided (backwards compatible)', () => {
+    const draft = buildDebatePublishDraft(baseInput(), { createEntityId: idFactory(), createPosition: () => 'a0' });
+    expect(draft.relations.some(r => r.type.id === TYPES_PROPERTY_ID && r.toEntity.id === CLAIM_TYPE_ID)).toBe(false);
+  });
+
+  it('drops a claim whose turnIndex has no matching turn', () => {
+    const draft = buildDebatePublishDraft(baseInput({ claims: [{ text: 'Ghost claim', isFactual: true, turnIndex: 5 }] }), {
+      createEntityId: idFactory(),
+      createPosition: () => 'a0',
+    });
+    expect(draft.values.some(v => v.value === 'Ghost claim')).toBe(false);
+  });
+
+  it('claim ops (incl. the boolean) survive the real publish pipeline', async () => {
+    const draft = buildDebatePublishDraft(
+      baseInput({ claims: [{ text: 'Verifiable thing', isFactual: true, turnIndex: 0 }] }),
+      { createEntityId: ID.createEntityId }
+    );
     const ops = await Effect.runPromise(Publish.prepareLocalDataForPublishing(draft.values, draft.relations, SPACE));
     expect(ops.length).toBeGreaterThan(0);
   });

--- a/apps/web/core/debates/debate-publish-draft.ts
+++ b/apps/web/core/debates/debate-publish-draft.ts
@@ -1,5 +1,6 @@
 import { Position } from '@geoprotocol/geo-sdk/lite';
 
+import { CLAIM_IS_FACTUAL_PROPERTY_ID, CLAIM_TYPE_ID } from '~/core/claims/ontology';
 import { ID } from '~/core/id';
 import type { DataType, Relation, Value } from '~/core/types';
 
@@ -35,10 +36,30 @@ export type DebatePublishParticipant = {
 };
 
 export type DebatePublishTurn = {
+  /**
+   * The turn's index in geo-chat's canonical `{ turns }` payload. Claims attach to their turn's block
+   * by this value — carried explicitly rather than re-derived from array position after a JS-side
+   * filter, so attribution stays correct even when Rust and JS disagree on what counts as whitespace
+   * (e.g. U+FEFF) and their turn arrays would otherwise drift out of alignment.
+   */
+  turnIndex: number;
   /** Space system entity id of whoever spoke this turn. */
   speakerSpaceEntityId: string;
   speakerName: string | null;
   text: string;
+};
+
+export type DebateClaimInput = {
+  /** The claim text (becomes the Claim entity name). */
+  text: string;
+  /** True = verifiable fact, False = opinion, null = unclassified. */
+  isFactual: boolean | null;
+  /**
+   * geo-chat's `turn_index` for the turn this claim was extracted from — matched against each turn's
+   * own `turnIndex` (not array position), so the claim attaches to the correct turn's text block and
+   * rides its Authors relation for speaker attribution.
+   */
+  turnIndex: number;
 };
 
 export type DebatePublishInput = {
@@ -59,6 +80,11 @@ export type DebatePublishInput = {
   keyframeUrl: string | null;
   /** Merged per-turn transcript. Empty skips the Transcript entity. */
   transcriptTurns: DebatePublishTurn[];
+  /**
+   * Claims extracted from the transcript, each attributed to a turn by its post-filter index in
+   * `transcriptTurns`. Optional — omitted/empty publishes the debate with no extracted claims.
+   */
+  claims?: DebateClaimInput[];
 };
 
 export type DebatePublishDraft = {
@@ -101,6 +127,21 @@ export function buildDebatePublishDraft(input: DebatePublishInput, options: Buil
   const setText = (entityId: string, entityName: string | null, propertyId: string, value: string) => {
     values.push(makeTextValue({ entityId, entityName, propertyId, value, spaceId: input.spaceId }));
   };
+
+  const setBoolean = (entityId: string, entityName: string | null, propertyId: string, value: boolean) => {
+    values.push(
+      makeBooleanValue({ entityId, entityName, propertyId, value: value ? 'true' : 'false', spaceId: input.spaceId })
+    );
+  };
+
+  // Group extracted claims by their turn's `turnIndex`, so the transcript loop can attach each to its
+  // source block by matching `turn.turnIndex` — independent of array position after the filter below.
+  const claimsByTurnIndex = new Map<number, DebateClaimInput[]>();
+  for (const claim of input.claims ?? []) {
+    const list = claimsByTurnIndex.get(claim.turnIndex);
+    if (list) list.push(claim);
+    else claimsByTurnIndex.set(claim.turnIndex, [claim]);
+  }
 
   const relate = ({
     fromEntity,
@@ -217,7 +258,7 @@ export function buildDebatePublishDraft(input: DebatePublishInput, options: Buil
       toEntityName: transcriptName,
     });
 
-    for (const turn of turns) {
+    turns.forEach(turn => {
       const speakerName = turn.speakerName?.trim() ? turn.speakerName.trim() : 'Anonymous';
       const blockId = createEntityId();
       const blockName = `${speakerName} — ${claimText}`;
@@ -248,7 +289,35 @@ export function buildDebatePublishDraft(input: DebatePublishInput, options: Buil
         toEntityId: blockId,
         toEntityName: blockName,
       });
-    }
+
+      // Claims extracted from this turn. Each becomes a Claim entity linked FROM this text block via
+      // the Claims relation — so attribution rides the block's Authors relation (the speaker), with no
+      // separate claim→speaker property. Side (for/against) is recoverable from the participant's
+      // Supported/Opposed-by membership on the Debate.
+      for (const claim of claimsByTurnIndex.get(turn.turnIndex) ?? []) {
+        const claimEntityText = claim.text.trim();
+        if (claimEntityText.length === 0) continue;
+        const claimId = createEntityId();
+        const claimRef = { id: claimId, name: claimEntityText };
+        setText(claimId, claimEntityText, NAME_PROPERTY_ID, claimEntityText);
+        relate({ fromEntity: claimRef, propertyId: TYPES_PROPERTY_ID, toEntityId: CLAIM_TYPE_ID, toEntityName: 'Claim' });
+        if (claim.isFactual !== null) {
+          setBoolean(claimId, claimEntityText, CLAIM_IS_FACTUAL_PROPERTY_ID, claim.isFactual);
+        }
+        relate({
+          fromEntity: blockRef,
+          propertyId: DEBATE_CLAIMS_PROPERTY_ID,
+          toEntityId: claimId,
+          toEntityName: claimEntityText,
+        });
+        relate({
+          fromEntity: claimRef,
+          propertyId: SOURCES_PROPERTY_ID,
+          toEntityId: debateEntityId,
+          toEntityName: debateName,
+        });
+      }
+    });
   }
 
   return { debateEntityId, debateName, values, relations };
@@ -272,7 +341,12 @@ export function mergeTranscriptSegmentsIntoTurns(
     if (last && last.speakerSpaceEntityId === speaker.spaceEntityId) {
       last.text = `${last.text} ${text}`.trim();
     } else {
-      turns.push({ speakerSpaceEntityId: speaker.spaceEntityId, speakerName: speaker.displayName, text });
+      turns.push({
+        turnIndex: turns.length,
+        speakerSpaceEntityId: speaker.spaceEntityId,
+        speakerName: speaker.displayName,
+        text,
+      });
     }
   }
   return turns;
@@ -297,6 +371,32 @@ function makeTextValue({
     id: ID.createValueId({ entityId, propertyId, spaceId }),
     entity: { id: entityId, name: entityName },
     property: { id: propertyId, name: null, dataType: TEXT_DATA_TYPE },
+    value,
+    spaceId,
+    isLocal: true,
+    hasBeenPublished: false,
+  };
+}
+
+const BOOLEAN_DATA_TYPE: DataType = 'BOOLEAN';
+
+function makeBooleanValue({
+  entityId,
+  entityName,
+  propertyId,
+  value,
+  spaceId,
+}: {
+  entityId: string;
+  entityName: string | null;
+  propertyId: string;
+  value: string;
+  spaceId: string;
+}): Value {
+  return {
+    id: ID.createValueId({ entityId, propertyId, spaceId }),
+    entity: { id: entityId, name: entityName },
+    property: { id: propertyId, name: null, dataType: BOOLEAN_DATA_TYPE },
     value,
     spaceId,
     isLocal: true,

--- a/apps/web/core/debates/server/debate-source.test.ts
+++ b/apps/web/core/debates/server/debate-source.test.ts
@@ -32,7 +32,7 @@ function debateBody(overrides: Record<string, unknown> = {}) {
 }
 
 /** Routes each geo-chat path the loader touches — plus the object store it redirects to — to a canned response. */
-function mockGeoChat(media: unknown, debate = debateBody(), artifactStatus = 200) {
+function mockGeoChat(media: unknown, debate = debateBody(), artifactStatus = 200, claims: unknown = null) {
   vi.stubGlobal(
     'fetch',
     vi.fn(async (input: string | URL, init?: RequestInit) => {
@@ -42,11 +42,13 @@ function mockGeoChat(media: unknown, debate = debateBody(), artifactStatus = 200
       }
       const body = url.endsWith('/media')
         ? media
-        : url.includes('/transcript')
-          ? { segments: [] }
-          : url.includes('/media/artifacts/url')
-            ? { upload: { url: presignedUrlFor(String(init?.body)) } }
-            : debate;
+        : url.endsWith('/claims')
+          ? claims
+          : url.includes('/transcript')
+            ? { segments: [] }
+            : url.includes('/media/artifacts/url')
+              ? { upload: { url: presignedUrlFor(String(init?.body)) } }
+              : debate;
       return new Response(JSON.stringify(body), { status: 200 });
     })
   );
@@ -90,6 +92,37 @@ describe('loadDebatePublishSource media gating', () => {
 
     const { input } = await loadDebatePublishSource(DEBATE_ID);
     expect(input.keyframeUrl).toBe('ipfs://cid-for-preview_image');
+  });
+
+  it('uses geo-chat canonical turns + pre-attributed claims when available', async () => {
+    mockGeoChat({ job: { status: 'succeeded' }, artifacts: [{ kind: 'final_video' }] }, debateBody(), 200, {
+      turns: [
+        { turn_index: 0, participant_slot: 1, attributed_space_id: 'space-1', speaker_name: 'Specter', text: 'Nuclear program was advancing.' },
+        { turn_index: 1, participant_slot: 2, attributed_space_id: 'space-2', speaker_name: 'Antispecter', text: 'There was no congressional approval.' },
+      ],
+      claims: [
+        { text: 'The nuclear program was advancing.', is_factual: true, turn_index: 0 },
+        { text: 'The action was unjustified.', is_factual: false, turn_index: 1 },
+      ],
+    });
+
+    const { input } = await loadDebatePublishSource(DEBATE_ID);
+    // Transcript blocks come from geo-chat's canonical turns, attributed to each speaker's space entity.
+    expect(input.transcriptTurns.map(t => t.speakerSpaceEntityId)).toEqual(['space-1', 'space-2']);
+    expect(input.transcriptTurns[0].text).toBe('Nuclear program was advancing.');
+    // Claims arrive pre-attributed, keyed to the same turn indices.
+    expect(input.claims).toEqual([
+      { text: 'The nuclear program was advancing.', isFactual: true, turnIndex: 0 },
+      { text: 'The action was unjustified.', isFactual: false, turnIndex: 1 },
+    ]);
+  });
+
+  it('falls back to the raw transcript with no claims when geo-chat reports none', async () => {
+    mockGeoChat({ job: { status: 'succeeded' }, artifacts: [{ kind: 'final_video' }] });
+
+    const { input } = await loadDebatePublishSource(DEBATE_ID);
+    expect(input.claims).toEqual([]);
+    expect(input.transcriptTurns).toEqual([]); // /transcript mock returns no segments
   });
 
   it('publishes without a keyframe when the worker composed no preview_image', async () => {

--- a/apps/web/core/debates/server/debate-source.ts
+++ b/apps/web/core/debates/server/debate-source.ts
@@ -8,8 +8,10 @@ import type {
   SpaceDebatesResponse,
 } from '../api';
 import {
+  type DebateClaimInput,
   type DebatePublishInput,
   type DebatePublishParticipant,
+  type DebatePublishTurn,
   mergeTranscriptSegmentsIntoTurns,
 } from '../debate-publish-draft';
 import { hasProcessedVideo } from '../playback-utils';
@@ -144,7 +146,13 @@ export async function loadDebatePublishSource(debateId: string): Promise<DebateS
   const keyframeUrl = media.artifacts.some(artifact => artifact.kind === 'preview_image')
     ? await pinKeyframeToIpfs(debateId)
     : null;
-  const transcriptTurns = await loadTranscriptTurns(debateId, debate);
+  // Prefer geo-chat's canonical turns + pre-attributed claims (extracted in its media job, next to
+  // transcription). geo-chat is the single authority on turn boundaries, so its `turn_index` lines
+  // the published transcript blocks up with the claims exactly. Falls back to merging the raw
+  // transcript ourselves (and publishing no claims) when claims aren't available yet.
+  const extracted = await loadDebateClaims(debateId);
+  const transcriptTurns = extracted?.transcriptTurns ?? (await loadTranscriptTurns(debateId, debate));
+  const claims = extracted?.claims ?? [];
 
   const participants: DebatePublishParticipant[] = debate.participants.map(p => ({
     spaceEntityId: p.profile_space_id,
@@ -162,6 +170,7 @@ export async function loadDebatePublishSource(debateId: string): Promise<DebateS
     videoUrl,
     keyframeUrl,
     transcriptTurns,
+    claims,
   };
 
   return { debate, media, input };
@@ -226,6 +235,55 @@ async function pinKeyframeToIpfs(debateId: string): Promise<string | null> {
     console.warn(`[debate-acceptor] could not pin keyframe for ${debateId}; publishing without one.`, error);
     return null;
   }
+}
+
+type DebateExtractedClaimsTurn = {
+  turn_index: number;
+  participant_slot: number;
+  /** The turn speaker's Geo personal-space entity id (the Authors relation target). */
+  attributed_space_id: string;
+  speaker_name: string | null;
+  text: string;
+};
+type DebateExtractedClaimsClaim = { text: string; is_factual: boolean | null; turn_index: number };
+type DebateExtractedClaimsResponse = { turns: DebateExtractedClaimsTurn[]; claims: DebateExtractedClaimsClaim[] };
+
+/**
+ * Load geo-chat's pre-computed, pre-attributed debate claims. geo-chat extracts them in its media
+ * job (beside Whisper) and returns the canonical per-turn structure PLUS the claims keyed to it by
+ * `turn_index`, so the transcript blocks we publish and the claims attach to the same turns.
+ *
+ * Returns null when claims are unavailable (older debate, extraction failed, or geo-chat does not
+ * report claims for this debate) — the caller then falls back to the raw /transcript merge and
+ * publishes with no claims. `turn_index` is expected 0-based and contiguous over non-empty turns.
+ */
+async function loadDebateClaims(
+  debateId: string
+): Promise<{ transcriptTurns: DebatePublishTurn[]; claims: DebateClaimInput[] } | null> {
+  let response: DebateExtractedClaimsResponse;
+  try {
+    response = await geoChatGet<DebateExtractedClaimsResponse>(`/debates/${debateId}/claims`);
+  } catch (error) {
+    // A missing/failed claims read shouldn't block publishing the Debate + Transcript.
+    console.warn(`[debate-acceptor] could not load extracted claims for ${debateId}; using raw transcript.`, error);
+    return null;
+  }
+  if (!response || !Array.isArray(response.turns) || response.turns.length === 0) return null;
+
+  const transcriptTurns: DebatePublishTurn[] = [...response.turns]
+    .sort((a, b) => a.turn_index - b.turn_index)
+    .map(turn => ({
+      turnIndex: turn.turn_index,
+      speakerSpaceEntityId: turn.attributed_space_id,
+      speakerName: turn.speaker_name,
+      text: turn.text,
+    }));
+  const claims: DebateClaimInput[] = (response.claims ?? []).map(claim => ({
+    text: claim.text,
+    isFactual: claim.is_factual ?? null,
+    turnIndex: claim.turn_index,
+  }));
+  return { transcriptTurns, claims };
 }
 
 async function loadTranscriptTurns(debateId: string, debate: Debate) {


### PR DESCRIPTION
Rebases and unblocks **#2108** (@TheHoneySeller / Faruk Balci's work — authorship preserved). Part of GEO-2544. Companion to **geo-chat#66**, which does the extraction and serves the endpoint this reads. Supersedes #2108; close that one in favour of this.

Nik approved #2108 on 6 Aug. It then sat for 15 days while `master` moved **119 commits**.

## Squashed rather than replayed, deliberately

The branch's first two commits implement the **inline** extraction design Nik's review rejected, which commit 3 replaced. Replaying them would mean resolving conflicts against code the branch itself deletes two commits later. It also contains a merge commit, which a rebase flattens anyway.

The net diff is what carries the intent, and it applied to current `master` **cleanly across all five files** — no conflict resolution, so nothing was re-interpreted by me.

Dropped one thing from the original: a stray trailing blank line in `apps/web/.env.example`. It was the last residue of extraction config living in geogenesis, which the ticket explicitly moves to geo-chat, and it carried a whitespace error.

## What it does

`loadDebatePublishSource` now prefers geo-chat's `GET /debates/{id}/claims`, taking **both** the canonical turns and the claims keyed to them by `turn_index` — so the transcript blocks published to the graph and the claims attach to exactly the same turns. geo-chat is the single authority on turn boundaries, which is what makes the attribution trustworthy.

On any failure — older debate, extraction not run, geo-chat unreachable — it returns `null` and falls back to the raw `/transcript` merge, publishing with no claims. **Extraction can therefore never block a Debate + Transcript publish**, which was the substance of Nik's concern:

> Claims extraction is a blocking interaction. In case it fails publishing fails. Not sure this is intentional or not.

His two specific defects are handled on the geo-chat side (required API key, and an abort/deadline on both the enqueue and the poll) — detailed in geo-chat#66, since the extraction client moved there.

## The detail worth reviewing

Claims are attributed by **explicit `turn_index`, not array position**, and there's a test for the case where those diverge. That case is reachable rather than theoretical: geo-chat's Rust side keeps a turn that a JS-side whitespace filter would drop (a lone U+FEFF, say), leaving a gap. Positional keying silently puts a claim on the wrong speaker's block there — the kind of bug that would be noticed weeks later as "it attributed my opponent's claim to me."

## Verification

- `vitest run core/debates` — **741 passed, 62 files**
- `tsc --noEmit` — 5 errors, all pre-existing in unrelated files (`sort-open-proposals.test.ts`, `use-entity-vote.ts`, `entity-response.test.ts`)

## Merge order, and a caveat

Merge **geo-chat#66 first**. This PR's fallback makes it harmless to land in either order, but until the endpoint exists it does nothing.

And once both are merged the feature is still inert: there are **no `EXTRACTION_*` keys in the geo-chat namespace** (28 secret keys, 33 config keys, none of them). `EXTRACTION_API_URL` and `EXTRACTION_API_KEY` need provisioning before anything is extracted. I verified the target service is live and the contract matches — see geo-chat#66 — so this is a config step, not a code one. **"Merged" will not mean "working."**
