### PR TITLE
fix(debates): count the avatar overflow from available people, not every holder

### DIFF
--- a/apps/web/core/debates/api.ts
+++ b/apps/web/core/debates/api.ts
@@ -391,11 +391,19 @@ export type DebatePeopleResponse = {
 export type DebateClaimPositionSummary = {
   position: boolean;
   position_label: string;
-  /** Everyone who set this position, online or not. */
+  /**
+   * Everyone geo-chat counts as holding this position — which is narrower than it sounds: the
+   * query only counts rows surviving `readiness.is_ready`, so someone who took the position
+   * without standing ready to debate it is excluded. Not shown on the claim card.
+   */
   total_count: number;
   /** Online, available, not in a debate, not blocked either way. */
   available_now_count: number;
-  /** Capped list used for avatar stacks. */
+  /**
+   * Capped list for the avatar stack, drawn only from available people (GEO-2691). Any count
+   * rendered beside it has to come from `available_now_count`, not `total_count`, or the overflow
+   * describes a different population than the faces.
+   */
   participants: DebateParticipantSummary[];
 };
 

--- a/apps/web/core/debates/matchmaking/matchmaking-claim-card.test.tsx
+++ b/apps/web/core/debates/matchmaking/matchmaking-claim-card.test.tsx
@@ -121,6 +121,15 @@ function readiness(overrides: Partial<MatchmakingReadiness> = {}): MatchmakingRe
   };
 }
 
+function participant(id: string) {
+  return {
+    user_id: id,
+    profile_space_id: `${id}-space`,
+    display_name: id,
+    avatar_cid: null,
+  } as DebateClaimPositionSummary['participants'][number];
+}
+
 const toggleName = 'Ready to debate this claim';
 
 function renderCard(card: ReactElement) {
@@ -140,6 +149,79 @@ beforeEach(() => {
 });
 
 afterEach(cleanup);
+
+/**
+ * GEO-2691. The avatar stack means "who could I debate about this, right now". geo-chat narrowed
+ * the preview to available people; the overflow was still `total_count - shown`, which counts
+ * every holder including offline ones. So a side with nobody available rendered a bare "+2" and no
+ * faces, and a side with one available person out of three said "+2" when only one was reachable.
+ */
+describe('position avatar stack', () => {
+  const withCounts = (overrides: Array<Partial<DebateClaimPositionSummary>>): DebateClaimPositionSummary[] => [
+    { ...positions[0], ...overrides[0] },
+    { ...positions[1], ...overrides[1] },
+  ];
+
+  it('draws no stack at all for a side with nobody available', () => {
+    renderCard(
+      <MatchmakingClaimCard
+        claim={claim}
+        positions={withCounts([
+          { total_count: 1, available_now_count: 1, participants: [participant('available-one')] },
+          { total_count: 2, available_now_count: 0, participants: [] },
+        ])}
+        readiness={readiness()}
+      />
+    );
+
+    const disagree = screen.getByRole('button', { name: /^Disagree/ });
+    // No faces and no count: two offline holders are not "+2" people you could debate.
+    expect(within(disagree).queryByText('+2')).toBeNull();
+    expect(within(disagree).queryByText(/^\+/)).toBeNull();
+  });
+
+  it('counts the overflow from available people, not from every holder', () => {
+    renderCard(
+      <MatchmakingClaimCard
+        claim={claim}
+        positions={withCounts([
+          {
+            total_count: 9,
+            available_now_count: 4,
+            participants: [participant('one'), participant('two')],
+          },
+          { total_count: 3, available_now_count: 0, participants: [] },
+        ])}
+        readiness={readiness()}
+      />
+    );
+
+    const agree = screen.getByRole('button', { name: /^Agree/ });
+    // 4 available, 2 shown -> +2. Not 9 - 2 = +7, which counted five people who are offline.
+    expect(within(agree).getByText('+2')).toBeInTheDocument();
+    expect(within(agree).queryByText('+7')).toBeNull();
+  });
+
+  it('shows no overflow when every available person is already on screen', () => {
+    renderCard(
+      <MatchmakingClaimCard
+        claim={claim}
+        positions={withCounts([
+          {
+            total_count: 6,
+            available_now_count: 2,
+            participants: [participant('one'), participant('two')],
+          },
+          { total_count: 0, available_now_count: 0, participants: [] },
+        ])}
+        readiness={readiness()}
+      />
+    );
+
+    const agree = screen.getByRole('button', { name: /^Agree/ });
+    expect(within(agree).queryByText(/^\+/)).toBeNull();
+  });
+});
 
 describe('MatchmakingClaimCard', () => {
   it('puts the debate toggle in the card header beside the space name', () => {
@@ -191,15 +273,17 @@ describe('MatchmakingClaimCard', () => {
       />
     );
 
-    // Three on the server plus the viewer: their face is shown, the other three counted over.
+    // Disagree has 3 holders but only 2 available. The viewer's face is shown and the count is of
+    // the *available* others behind it, so +2 — not +3, which used to include the offline holder
+    // (GEO-2691).
     const disagree = screen.getByRole('button', { name: /^Disagree/ });
     expect(within(disagree).getByTestId('avatar')).toHaveTextContent('https://example.com/you.png');
-    expect(within(disagree).getByText('+3')).toBeInTheDocument();
+    expect(within(disagree).getByText('+2')).toBeInTheDocument();
 
-    // The side they didn't take is left exactly as the server reported it.
+    // The side they didn't take is left as the server reported it: 2 holders, 1 available.
     const agree = screen.getByRole('button', { name: /^Agree/ });
     expect(within(agree).queryByTestId('avatar')).not.toBeInTheDocument();
-    expect(within(agree).getByText('+2')).toBeInTheDocument();
+    expect(within(agree).getByText('+1')).toBeInTheDocument();
   });
 
   // The switch of sides, which the test above doesn't reach: it starts from no server position, so

--- a/apps/web/core/debates/matchmaking/matchmaking-claim-card.tsx
+++ b/apps/web/core/debates/matchmaking/matchmaking-claim-card.tsx
@@ -361,11 +361,19 @@ export function withViewerPosition({
   const withViewer = (side: DebateClaimPositionSummary): DebateClaimPositionSummary => ({
     ...side,
     total_count: side.total_count + (serverPosition === side.position ? 0 : 1),
+    // Unconditionally +1, unlike `total_count`. geo-chat computes availability as
+    // `readiness.user_id <> $viewer`, so the viewer is *never* in `available_now_count` even once
+    // the server knows their position — there is nothing to avoid double-counting. Their face is
+    // shown, so for the stack's purposes they are one of the people it is drawn from; without this
+    // the viewer occupies a slot the overflow does not know about and it undercounts by one.
+    available_now_count: side.available_now_count + 1,
     participants: [viewer, ...side.participants.filter(participant => !heldByViewer(participant))],
   });
   const withoutViewer = (side: DebateClaimPositionSummary): DebateClaimPositionSummary => ({
     ...side,
     total_count: Math.max(0, side.total_count - (serverPosition === side.position ? 1 : 0)),
+    // `available_now_count` needs no adjustment here, for the same reason: the viewer was never
+    // counted in it, so there is nothing to take out.
     participants: side.participants.filter(participant => !heldByViewer(participant)),
   });
 
@@ -537,7 +545,7 @@ function PositionButton({
           {selected ? <span className="sr-only"> — your response</span> : null}
         </span>
       </span>
-      {summary && summary.total_count > 0 ? <PositionAvatars summary={summary} /> : null}
+      {summary && summary.available_now_count > 0 ? <PositionAvatars summary={summary} /> : null}
     </>
   );
 
@@ -557,9 +565,21 @@ function PositionButton({
   );
 }
 
+/**
+ * The stack answers one question: who could I debate about this, right now.
+ *
+ * GEO-2691. The overflow was `total_count - shown`, which counted every holder of the position
+ * including people who are offline — under a control whose whole meaning is availability. Once
+ * geo-chat narrowed the preview to available people the mismatch became visible rather than merely
+ * wrong: a side with nobody available returned no faces while `total_count` still said two, so the
+ * card rendered a bare "+2" and no avatars.
+ *
+ * Both halves now come from the same population. `total_count` is left alone — it answers "who
+ * holds this position", which the card does not show here.
+ */
 function PositionAvatars({ summary }: { summary: DebateClaimPositionSummary }) {
   const participants = summary.participants.slice(0, 2);
-  const overflow = Math.max(0, summary.total_count - participants.length);
+  const overflow = Math.max(0, summary.available_now_count - participants.length);
 
   return (
     <span aria-hidden="true" className="flex shrink-0 items-center -space-x-2">


### PR DESCRIPTION
The client half of GEO-2691, on Preston's answer:

> Why would the count include people who can't debate? It seems like this avatar count used on those buttons is users who are available to debate right now

It didn't. `overflow` was `total_count - shown`, and `total_count` counts **every** holder including offline ones — under a control whose entire meaning is availability.

Now that geo-chat narrows the preview to available people, that mismatch became visible rather than merely wrong: a side with nobody available returns no faces while `total_count` still says two, so the card drew a bare **"+2" with no avatars**. Both halves now come from `available_now_count`, render gate included, so such a side draws nothing at all.

## The viewer needed different handling from `total_count`, and a test caught it

geo-chat computes availability as `readiness.user_id <> $viewer`, so **the viewer is never in `available_now_count`** — not even once the server knows their position. So `withViewer` adds 1 *unconditionally*, where `total_count` only adds 1 when the server hasn't caught up:

```ts
total_count: side.total_count + (serverPosition === side.position ? 0 : 1),
available_now_count: side.available_now_count + 1,
```

Without that, the viewer's own face occupies a preview slot the overflow knows nothing about and every count is one short. **An existing test caught this** — `puts the viewer on the side they just took` — which is the only reason I found it, and worth saying because I'd have shipped it otherwise.

## An existing expectation changed, deliberately

That test's fixture is 3 holders with 2 available. It expected "+3"; correct is **"+2"** — the viewer's face plus the two available others. "+3" was counting the offline holder. The other side moves "+2" → "+1" for the same reason. I changed the expectations because the old numbers were wrong, not to get to green.

## Also

`total_count`'s doc comment claimed *"Everyone who set this position, online or not"*. The query only counts rows surviving `readiness.is_ready`, so someone who took the position without standing ready to debate it is excluded. Comment and count disagreed; the comment now says what the number is, and notes it isn't shown on the card.

## Verification

- `vitest core/debates partials/community-calls` — **750 passed, 63 files**
- `tsc --noEmit` — 5 errors, all pre-existing in unrelated files
- **Mutation-checked**: overflow back to `total_count` fails 3 tests; dropping the viewer bump fails 1

Three new tests cover the cases that were broken — a side with nobody available drawing nothing, overflow counted from availability (4 available of 9 holders → "+2", not "+7"), and no overflow when every available person is already on screen.

## Pairs with

`ohohoreilly/geo-2691-available-only-count` in geo-chat, which makes the preview unconditionally available-only rather than only under "Debate now". **That branch is pushed but I've deliberately not opened a PR for it yet** — there's a testnet deploy that has now failed four times because a merge superseded its build mid-flight, and I'd rather not add a fifth. This PR is safe to merge independently: it only makes the count agree with a preview that is already narrowed under the filter.
