### PR TITLE
fix(explore): cap consecutive same-type items in the Best feed

### DIFF
--- a/apps/web/core/explore/explore-diversity.test.ts
+++ b/apps/web/core/explore/explore-diversity.test.ts
@@ -1,0 +1,291 @@
+import { describe, expect, it } from 'vitest';
+
+import { CLAIM_TYPE_ID } from '~/core/claims/ontology';
+
+import {
+  EPISODE_TYPE_ID,
+  EXPLORE_PAGE_SIZE,
+  NEWS_STORY_TYPE_ID,
+  TWEET_TYPE_ID,
+} from './explore-constants';
+import {
+  EXPLORE_DIVERSITY_MAX_RUN,
+  EXPLORE_DIVERSITY_WINDOW_SIZE,
+  applyDiversityCap,
+  exploreItemTypeKey,
+  longestTypeRun,
+} from './explore-diversity';
+import {
+  decodeExploreWindowCursor,
+  encodeExploreWindowCursor,
+  nextExploreWindowCursor,
+} from './explore-window-cursor';
+
+type Item = { id: string; types: { id: string }[] };
+
+const item = (id: string, ...typeIds: string[]): Item => ({ id, types: typeIds.map(t => ({ id: t })) });
+
+const key = exploreItemTypeKey;
+const ids = (items: readonly Item[]) => items.map(i => i.id);
+
+/**
+ * The measured production mix, Best sort (GEO-2690): claims own ranks 1-30 outright, then
+ * news stories run about 30% of the way down. Reproduced positionally rather than as a
+ * ratio, because the whole problem is *where* the off-type items sit, not how many exist.
+ */
+function measuredProductionWindow(size: number): Item[] {
+  const items: Item[] = [];
+  for (let rank = 0; rank < size; rank++) {
+    const isNews = rank >= 30 && rank % 3 === 0;
+    items.push(item(`${isNews ? 'news' : 'claim'}-${rank}`, isNews ? NEWS_STORY_TYPE_ID : CLAIM_TYPE_ID));
+  }
+  return items;
+}
+
+describe('exploreItemTypeKey', () => {
+  it('is stable across relation order', () => {
+    // `types` comes from relations, whose order is not meaningful. Two identical entities
+    // must not land in different diversity buckets because the rows came back swapped.
+    expect(key(item('a', CLAIM_TYPE_ID, NEWS_STORY_TYPE_ID))).toBe(
+      key(item('b', NEWS_STORY_TYPE_ID, CLAIM_TYPE_ID))
+    );
+  });
+
+  it('classifies a multi-typed claim as its more specific type', () => {
+    // Claim is declared last in EXPLORE_ENTITY_TYPES, so it loses every tie. That is the
+    // useful direction: such an item can break a claim run instead of extending one.
+    expect(key(item('a', CLAIM_TYPE_ID, EPISODE_TYPE_ID))).not.toBe(key(item('b', CLAIM_TYPE_ID)));
+    expect(key(item('a', CLAIM_TYPE_ID, EPISODE_TYPE_ID))).toBe(key(item('c', EPISODE_TYPE_ID)));
+  });
+
+  it('is case- and hyphen-insensitive, matching the ids the feed actually returns', () => {
+    const hyphenated = CLAIM_TYPE_ID.replace(/^(.{8})(.{4})/, '$1-$2').toUpperCase();
+    expect(key(item('a', hyphenated))).toBe(key(item('b', CLAIM_TYPE_ID)));
+  });
+
+  it('buckets untyped entities together rather than treating each as unique', () => {
+    // The activity feed sends no type whitelist. If untyped items each got their own key
+    // the cap would consider a wall of them perfectly diverse.
+    expect(key(item('a'))).toBe(key(item('b')));
+  });
+
+  it('keeps a stable key for types outside the explore whitelist', () => {
+    const offList = 'ffffffffffffffffffffffffffffffff';
+    expect(key(item('a', offList))).toBe(offList);
+  });
+});
+
+describe('applyDiversityCap', () => {
+  it('breaks up the measured production window on the first screen', () => {
+    const window = measuredProductionWindow(EXPLORE_DIVERSITY_WINDOW_SIZE);
+
+    // Before: the first screen is 100% claims and nothing else appears at all.
+    const firstScreenBefore = window.slice(0, EXPLORE_PAGE_SIZE);
+    expect(firstScreenBefore.every(i => i.id.startsWith('claim'))).toBe(true);
+
+    const firstScreenAfter = applyDiversityCap(window, key).slice(0, EXPLORE_PAGE_SIZE);
+    const news = firstScreenAfter.filter(i => i.id.startsWith('news'));
+
+    expect(longestTypeRun(firstScreenAfter, key)).toBeLessThanOrEqual(EXPLORE_DIVERSITY_MAX_RUN);
+    // A full screen holds floor(22 / (3 + 1)) = 5 breaks: five runs of three claims each
+    // separated by one off-type item, then a short trailing run with nothing to separate
+    // it from. So 5 news / 17 claims is the cap working exactly, not falling short.
+    const expectedBreaks = Math.floor(EXPLORE_PAGE_SIZE / (EXPLORE_DIVERSITY_MAX_RUN + 1));
+    expect(expectedBreaks).toBe(5);
+    expect(news.length).toBeGreaterThanOrEqual(expectedBreaks);
+    // The measured 100% is now at most 77%, which is the floor a run cap alone can reach.
+    expect(firstScreenAfter.length - news.length).toBeLessThanOrEqual(
+      EXPLORE_PAGE_SIZE - expectedBreaks
+    );
+  });
+
+  it('caps runs across the whole window, not just the first page', () => {
+    const ordered = applyDiversityCap(measuredProductionWindow(EXPLORE_DIVERSITY_WINDOW_SIZE), key);
+    // The window's own tail is all claims once the news is spent, so the run cap can only
+    // hold while off-type items remain — assert it holds for as long as they do.
+    let lastNews = -1;
+    ordered.forEach((entry, index) => {
+      if (entry.id.startsWith('news')) lastNews = index;
+    });
+    expect(lastNews).toBeGreaterThan(EXPLORE_PAGE_SIZE);
+    expect(longestTypeRun(ordered.slice(0, lastNews + 1), key)).toBeLessThanOrEqual(EXPLORE_DIVERSITY_MAX_RUN);
+  });
+
+  it('never drops or duplicates an item', () => {
+    const window = measuredProductionWindow(EXPLORE_DIVERSITY_WINDOW_SIZE);
+    const ordered = applyDiversityCap(window, key);
+    expect(ordered).toHaveLength(window.length);
+    expect(new Set(ids(ordered)).size).toBe(window.length);
+    expect(ids(ordered).sort()).toEqual(ids(window).sort());
+  });
+
+  it('extends a run rather than truncating when nothing else is left', () => {
+    // A single-type feed (type filter narrowed to one) must come back whole and in order.
+    const claims = Array.from({ length: 10 }, (_, i) => item(`claim-${i}`, CLAIM_TYPE_ID));
+    expect(ids(applyDiversityCap(claims, key))).toEqual(ids(claims));
+  });
+
+  it('promotes the highest-ranked off-type item, so demotions are minimal', () => {
+    const window = [
+      item('c1', CLAIM_TYPE_ID),
+      item('c2', CLAIM_TYPE_ID),
+      item('c3', CLAIM_TYPE_ID),
+      item('c4', CLAIM_TYPE_ID),
+      item('n1', NEWS_STORY_TYPE_ID),
+      item('t1', TWEET_TYPE_ID),
+    ];
+    // n1 is the next non-claim by rank, so it — not t1 — fills the gap after c3.
+    expect(ids(applyDiversityCap(window, key))).toEqual(['c1', 'c2', 'c3', 'n1', 'c4', 't1']);
+  });
+
+  it('leaves an already-diverse list untouched', () => {
+    const window = [
+      item('n1', NEWS_STORY_TYPE_ID),
+      item('c1', CLAIM_TYPE_ID),
+      item('t1', TWEET_TYPE_ID),
+      item('c2', CLAIM_TYPE_ID),
+    ];
+    expect(ids(applyDiversityCap(window, key))).toEqual(ids(window));
+  });
+
+  it('is a pure function of its input, which is what makes the window pageable', () => {
+    // The window is re-derived on each request and sliced deeper; if the reorder were not
+    // deterministic, items would repeat or vanish between pages.
+    const window = measuredProductionWindow(EXPLORE_DIVERSITY_WINDOW_SIZE);
+    expect(ids(applyDiversityCap(window, key))).toEqual(ids(applyDiversityCap(window, key)));
+    expect(ids(window)).toEqual(ids(measuredProductionWindow(EXPLORE_DIVERSITY_WINDOW_SIZE)));
+  });
+
+  it('treats a non-positive cap as off', () => {
+    const window = measuredProductionWindow(12);
+    expect(ids(applyDiversityCap(window, key, 0))).toEqual(ids(window));
+  });
+});
+
+describe('longestTypeRun', () => {
+  it('counts consecutive same-type items, not totals', () => {
+    const window = [
+      item('c1', CLAIM_TYPE_ID),
+      item('c2', CLAIM_TYPE_ID),
+      item('n1', NEWS_STORY_TYPE_ID),
+      item('c3', CLAIM_TYPE_ID),
+    ];
+    expect(longestTypeRun(window, key)).toBe(2);
+    expect(longestTypeRun([], key)).toBe(0);
+  });
+});
+
+describe('explore window cursor', () => {
+  it('round-trips', () => {
+    for (const cursor of [
+      { after: null, offset: 0 },
+      { after: 'WyJuYXR1cmFsIiwgNjZd', offset: 22 },
+      { after: 'a+b/c=', offset: 44 },
+    ]) {
+      expect(decodeExploreWindowCursor(encodeExploreWindowCursor(cursor))).toEqual(cursor);
+    }
+  });
+
+  it('reads a bare server cursor as the start of a window', () => {
+    // Clients mid-scroll when this ships still hold plain cursors.
+    expect(decodeExploreWindowCursor('WyJuYXR1cmFsIiwgMzBd')).toEqual({
+      after: 'WyJuYXR1cmFsIiwgMzBd',
+      offset: 0,
+    });
+    expect(decodeExploreWindowCursor(null)).toEqual({ after: null, offset: 0 });
+  });
+
+  it('falls back to the first window on anything malformed', () => {
+    expect(decodeExploreWindowCursor('w1:')).toEqual({ after: null, offset: 0 });
+    expect(decodeExploreWindowCursor('w1:abc:xyz')).toEqual({ after: 'xyz', offset: 0 });
+    expect(decodeExploreWindowCursor('w1:-4:xyz')).toEqual({ after: 'xyz', offset: 0 });
+  });
+
+  it('walks the window before stepping to the next one', () => {
+    const window = { windowLength: 66, hasNextPage: true, endCursor: 'END' };
+    expect(nextExploreWindowCursor({ ...window, after: null, offset: 0, served: 22 })).toBe('w1:22:');
+    expect(nextExploreWindowCursor({ ...window, after: null, offset: 22, served: 22 })).toBe('w1:44:');
+    expect(nextExploreWindowCursor({ ...window, after: null, offset: 44, served: 22 })).toBe('w1:0:END');
+  });
+
+  it('keeps the window start while paging within it', () => {
+    expect(
+      nextExploreWindowCursor({
+        after: 'START',
+        offset: 22,
+        served: 22,
+        windowLength: 66,
+        hasNextPage: true,
+        endCursor: 'END',
+      })
+    ).toBe('w1:44:START');
+  });
+
+  it('ends the feed when the last window is exhausted', () => {
+    expect(
+      nextExploreWindowCursor({
+        after: 'START',
+        offset: 44,
+        served: 10,
+        windowLength: 54,
+        hasNextPage: false,
+        endCursor: 'END',
+      })
+    ).toBeNull();
+  });
+
+  it('ends the feed rather than restarting it when the server offers no cursor', () => {
+    // hasNextPage with a null endCursor would re-encode `after: null`, i.e. window one —
+    // an infinite scroll that never leaves the first screen.
+    expect(
+      nextExploreWindowCursor({
+        after: 'START',
+        offset: 44,
+        served: 22,
+        windowLength: 66,
+        hasNextPage: true,
+        endCursor: null,
+      })
+    ).toBeNull();
+  });
+
+  it('advances past a window that came back shorter than the offset', () => {
+    // Rows shift under a reader mid-scroll; this must move on, not serve nothing forever.
+    expect(
+      nextExploreWindowCursor({
+        after: 'START',
+        offset: 44,
+        served: 0,
+        windowLength: 12,
+        hasNextPage: true,
+        endCursor: 'END',
+      })
+    ).toBe('w1:0:END');
+  });
+});
+
+describe('paging the reordered window end to end', () => {
+  it('serves every item exactly once, in the reordered order', () => {
+    const window = applyDiversityCap(measuredProductionWindow(EXPLORE_DIVERSITY_WINDOW_SIZE), key);
+
+    const served: Item[] = [];
+    let cursor: string | null = null;
+    for (let request = 0; request < 10; request++) {
+      const { offset } = decodeExploreWindowCursor(cursor);
+      const slice = window.slice(offset, offset + EXPLORE_PAGE_SIZE);
+      served.push(...slice);
+      cursor = nextExploreWindowCursor({
+        after: null,
+        offset,
+        served: slice.length,
+        windowLength: window.length,
+        hasNextPage: false,
+        endCursor: null,
+      });
+      if (cursor === null) break;
+    }
+
+    expect(cursor).toBeNull();
+    expect(ids(served)).toEqual(ids(window));
+  });
+});

--- a/apps/web/core/explore/explore-diversity.ts
+++ b/apps/web/core/explore/explore-diversity.ts
@@ -1,0 +1,141 @@
+import { EXPLORE_ENTITY_TYPES, EXPLORE_PAGE_SIZE } from './explore-constants';
+
+/**
+ * Read-time diversity cap for the "Best" feed (GEO-2690).
+ *
+ * Measured on production, Best sort: the first screen was 100% Claim, 110 items were
+ * 78% Claim, and only 2 of the 12 explore types appeared at all. The intended lever —
+ * `entity_type_weights` in gaia — cannot fix it: claims lead news by >4 score units on
+ * the participation/comment terms, while the schema floors a weight at 0.1
+ * (`ln(0.1) ≈ -2.30`, about 29 hours of freshness equivalent). That floor is a
+ * deliberate PRD guardrail, so the scores cannot be made to produce a mix.
+ *
+ * This reorders at read time instead, which is independent of the scoring model: cap how
+ * many items of one type may appear consecutively, and pull the next highest-ranked item
+ * of another type up into the gap. Ranking still decides *what* is in the feed and
+ * broadly in what order — it just stops deciding that one type owns the whole screen.
+ *
+ * Nothing is dropped and nothing is reordered across pages: see
+ * `explore-window-cursor` for how the over-fetched window is paged.
+ */
+
+function normId(id: string): string {
+  return id.replace(/-/g, '').toLowerCase();
+}
+
+/**
+ * At most this many consecutive items may share a type. 3 yields a 3:1 worst-case ratio
+ * (75% of a screen), which is the most one type can hold when off-type items are
+ * available — a large move from the measured 100%, without shuffling the ranking so hard
+ * that "Best" stops meaning anything.
+ */
+export const EXPLORE_DIVERSITY_MAX_RUN = 3;
+
+/**
+ * How many ranked items to fetch per window, as a multiple of the page size.
+ *
+ * This is sized from the measurement, not picked round. News stories only start
+ * appearing around rank 31 (the longest unbroken claim run was 30), and run ~30% of
+ * ranks 30-110. Filling 22 slots under a run cap of 3 needs
+ * `floor(22 / (3 + 1)) = 5` off-type items — floor, not ceil, because the last run on a
+ * screen has nothing after it to separate from:
+ *
+ *   * 2x (44 items) supplies roughly 4 — just short, so the cap would keep bottoming out.
+ *   * 3x (66 items) supplies roughly 11 — comfortably enough.
+ *
+ * So 3 is the smallest multiplier that actually delivers a mix on the first screen.
+ * Raising it buys deeper variety at a proportional payload cost.
+ */
+export const EXPLORE_DIVERSITY_SCAN_MULTIPLIER = 3;
+
+export const EXPLORE_DIVERSITY_WINDOW_SIZE = EXPLORE_PAGE_SIZE * EXPLORE_DIVERSITY_SCAN_MULTIPLIER;
+
+/**
+ * Explore's declared type order, used as a classification priority.
+ *
+ * Entities carry several `types` relations and the relation order is not meaningful, so
+ * the run cap needs one deterministic type per item. Walking `EXPLORE_ENTITY_TYPES` in
+ * its declared order gives that, and gives it a useful bias for free: Claim is declared
+ * last, so an entity that is both a Claim and something more specific is classified as
+ * the something more specific. That is both the more informative label and the safer
+ * default here — it lets such an item break a claim run rather than extend one.
+ */
+const TYPE_PRIORITY = EXPLORE_ENTITY_TYPES.map(type => normId(type.id));
+
+/** Types the feed shows but that carry no useful signal for diversity. */
+export const UNTYPED_DIVERSITY_KEY = '';
+
+export function exploreItemTypeKey(item: { types: readonly { id: string }[] }): string {
+  if (item.types.length === 0) return UNTYPED_DIVERSITY_KEY;
+  const present = new Set(item.types.map(type => normId(type.id)));
+  for (const id of TYPE_PRIORITY) {
+    if (present.has(id)) return id;
+  }
+  // Not on the explore whitelist (the activity feed sends no type filter at all). Any
+  // stable key will do; the first relation is as good as another and keeps like with like.
+  return normId(item.types[0].id);
+}
+
+/**
+ * Reorder a ranked list so no more than `maxRun` consecutive items share a type.
+ *
+ * Greedy and order-preserving within a type: once a run is full, the highest-ranked item
+ * of any other type is promoted, so demotions are always the minimum needed to break the
+ * run. Two properties matter more than the exact heuristic:
+ *
+ *   * **Nothing is dropped.** When no off-type item remains the run is allowed to
+ *     continue, rather than truncating the page or leaving a hole. A single-type feed
+ *     (the type filter narrowed to one) therefore comes back in its original order.
+ *   * **It is a pure function of the input list.** The window can be re-derived on a
+ *     later request and sliced deeper without items repeating or going missing.
+ */
+export function applyDiversityCap<T>(
+  items: readonly T[],
+  keyOf: (item: T) => string,
+  maxRun: number = EXPLORE_DIVERSITY_MAX_RUN
+): T[] {
+  if (maxRun <= 0 || items.length <= maxRun) return [...items];
+
+  const remaining = items.slice();
+  const ordered: T[] = [];
+  let runKey: string | null = null;
+  let runLength = 0;
+
+  while (remaining.length > 0) {
+    let index = 0;
+    if (runKey !== null && runLength >= maxRun) {
+      const promoted = remaining.findIndex(item => keyOf(item) !== runKey);
+      // -1 means every remaining item is the same type: extend the run rather than drop.
+      if (promoted >= 0) index = promoted;
+    }
+
+    const [picked] = remaining.splice(index, 1);
+    const key = keyOf(picked);
+    if (key === runKey) {
+      runLength += 1;
+    } else {
+      runKey = key;
+      runLength = 1;
+    }
+    ordered.push(picked);
+  }
+
+  return ordered;
+}
+
+/** Longest run of one type in a list — the property the cap exists to bound. */
+export function longestTypeRun<T>(items: readonly T[], keyOf: (item: T) => string): number {
+  let longest = 0;
+  let runKey: string | null = null;
+  let runLength = 0;
+  for (const item of items) {
+    const key = keyOf(item);
+    if (key === runKey) runLength += 1;
+    else {
+      runKey = key;
+      runLength = 1;
+    }
+    if (runLength > longest) longest = runLength;
+  }
+  return longest;
+}

--- a/apps/web/core/explore/explore-window-cursor.ts
+++ b/apps/web/core/explore/explore-window-cursor.ts
@@ -1,0 +1,89 @@
+/**
+ * Cursor for the over-fetched, reordered "Best" window (GEO-2690).
+ *
+ * The diversity cap has to see more items than a page holds, which creates a pagination
+ * problem: reorder 66 ranked items, serve 22, and the other 44 have nowhere to live. The
+ * server cursor is offset-based over `ranking_score DESC, entity_id DESC` and opaque to
+ * us, so it cannot be advanced by a partial amount.
+ *
+ * Two options were rejected before this one:
+ *
+ *   * **Advance the server cursor past the whole window.** That is what the pre-existing
+ *     code did in miniature — it scanned 30, served 22, and advanced 30, silently losing
+ *     8 items per page. At a 66-item window it would lose 44.
+ *   * **Query each type separately and merge.** Preston flagged the failure himself:
+ *     independent cursors per type make a thin type loop, so on reload "users may see the
+ *     same entity over and over".
+ *
+ * So the window start stays put and we carry an offset into it. Because `applyDiversityCap`
+ * is a pure function of the ranked list, re-fetching the same window on the next request
+ * reproduces the same ordering, and slicing deeper into it neither repeats nor skips.
+ * The cost is that a window is fetched once per page it serves.
+ *
+ * The ranked list is not perfectly stable — the score has a recency term, and entities
+ * scored mid-scroll shift rows underneath the reader. That is already true of every
+ * explore sort (the connection's cursors are offsets, not keys) and is documented on
+ * `exploreBestConnectionDocument`; the window inherits it rather than adding to it.
+ */
+
+const WINDOW_CURSOR_PREFIX = 'w1:';
+
+export type ExploreWindowCursor = {
+  /** Server cursor for the item *before* this window, or null for the first window. */
+  after: string | null;
+  /** How many items of the reordered window have already been served. */
+  offset: number;
+};
+
+export function encodeExploreWindowCursor(cursor: ExploreWindowCursor): string {
+  return `${WINDOW_CURSOR_PREFIX}${cursor.offset}:${cursor.after ?? ''}`;
+}
+
+/**
+ * Tolerant by design. A bare (non-prefixed) value is a plain server cursor — either from
+ * a client that loaded before this shipped and is still scrolling, or from one of the
+ * sorts that does not window — and reads as offset 0 of a window starting there. Anything
+ * malformed restarts at the first window, which shows a duplicate screen at worst.
+ */
+export function decodeExploreWindowCursor(raw: string | null): ExploreWindowCursor {
+  if (!raw) return { after: null, offset: 0 };
+  if (!raw.startsWith(WINDOW_CURSOR_PREFIX)) return { after: raw, offset: 0 };
+
+  const body = raw.slice(WINDOW_CURSOR_PREFIX.length);
+  const separator = body.indexOf(':');
+  if (separator < 0) return { after: null, offset: 0 };
+
+  // Base64 server cursors contain no ':', but split on the first one regardless so a
+  // cursor that someday does still round-trips whole.
+  const after = body.slice(separator + 1) || null;
+  const offset = Number(body.slice(0, separator));
+  if (!Number.isSafeInteger(offset) || offset < 0) return { after, offset: 0 };
+
+  return { after, offset };
+}
+
+/**
+ * The cursor to hand back after serving `served` items from a window of `windowLength`.
+ *
+ * Stays in the current window while it has items left, then steps to the next one. Null
+ * when the feed is exhausted — including when the server claims another page but gives no
+ * cursor to reach it, since re-encoding `after: null` there would restart the feed and
+ * scroll forever.
+ */
+export function nextExploreWindowCursor(args: {
+  after: string | null;
+  offset: number;
+  served: number;
+  windowLength: number;
+  hasNextPage: boolean;
+  endCursor: string | null;
+}): string | null {
+  const consumed = args.offset + args.served;
+  if (consumed < args.windowLength) {
+    return encodeExploreWindowCursor({ after: args.after, offset: consumed });
+  }
+  if (args.hasNextPage && args.endCursor) {
+    return encodeExploreWindowCursor({ after: args.endCursor, offset: 0 });
+  }
+  return null;
+}

--- a/apps/web/core/explore/fetch-explore-feed.ts
+++ b/apps/web/core/explore/fetch-explore-feed.ts
@@ -22,9 +22,15 @@ import {
   EXPLORE_PAGE_SIZE,
 } from './explore-constants';
 import { exploreBestConnectionDocument } from './explore-best-document';
+import {
+  EXPLORE_DIVERSITY_WINDOW_SIZE,
+  applyDiversityCap,
+  exploreItemTypeKey,
+} from './explore-diversity';
 import { exploreEntitiesByPropertyConnectionDocument } from './explore-entities-by-property-document';
 import { exploreEntitiesConnectionDocument } from './explore-entities-document';
 import { parseEntityUpdatedAtToUnixSec } from './explore-relative-time';
+import { decodeExploreWindowCursor, nextExploreWindowCursor } from './explore-window-cursor';
 
 /**
  * `best` is the Phase A ranked feed (quality + structure + recency, server-side).
@@ -448,16 +454,46 @@ export async function fetchExploreFeed(args: {
     return out;
   };
 
+  // "Best" is the only sort that reorders (GEO-2690). "New" is reverse-chronological and
+  // an activity log that shuffles is simply wrong; "Top" is an explicit "rank by score"
+  // request, and the crowding-out was measured on Best, which is also the default tab.
+  if (args.sort === 'best') {
+    const { after, offset } = decodeExploreWindowCursor(args.cursor);
+
+    // A single type cannot be diversified against anything, so don't pay for a wide
+    // window: `applyDiversityCap` would return the list untouched. The offset paging
+    // below still applies, which is what stops the tail of the scan being dropped.
+    const windowSize = (args.typeIds?.length ?? 0) === 1 ? scanChunk : EXPLORE_DIVERSITY_WINDOW_SIZE;
+
+    const scanned = await fetchBestEntitiesPage({
+      spaceIds: baseIds,
+      time: args.time,
+      limit: windowSize,
+      after,
+      typeIds: args.typeIds,
+    });
+
+    const ordered = applyDiversityCap(
+      buildItems(scanned.entities, allowed, memberOrEditorSet),
+      exploreItemTypeKey
+    );
+    const slice = ordered.slice(offset, offset + pageSize);
+
+    return {
+      items: await attachMeta(slice),
+      nextCursor: nextExploreWindowCursor({
+        after,
+        offset,
+        served: slice.length,
+        windowLength: ordered.length,
+        hasNextPage: scanned.hasNextPage,
+        endCursor: scanned.endCursor,
+      }),
+    };
+  }
+
   const page =
-    args.sort === 'best'
-      ? await fetchBestEntitiesPage({
-          spaceIds: baseIds,
-          time: args.time,
-          limit: scanChunk,
-          after: args.cursor,
-          typeIds: args.typeIds,
-        })
-      : args.sort === 'top'
+    args.sort === 'top'
       ? await fetchTopEntitiesPage({
           spaceIds: baseIds,
           time: args.time,

--- a/apps/web/core/explore/fetch-explore-feed.ts
+++ b/apps/web/core/explore/fetch-explore-feed.ts
@@ -454,68 +454,63 @@ export async function fetchExploreFeed(args: {
     return out;
   };
 
-  // "Best" is the only sort that reorders (GEO-2690). "New" is reverse-chronological and
-  // an activity log that shuffles is simply wrong; "Top" is an explicit "rank by score"
-  // request, and the crowding-out was measured on Best, which is also the default tab.
-  if (args.sort === 'best') {
-    const { after, offset } = decodeExploreWindowCursor(args.cursor);
+  const { after, offset } = decodeExploreWindowCursor(args.cursor);
 
-    // A single type cannot be diversified against anything, so don't pay for a wide
-    // window: `applyDiversityCap` would return the list untouched. The offset paging
-    // below still applies, which is what stops the tail of the scan being dropped.
-    const windowSize = (args.typeIds?.length ?? 0) === 1 ? scanChunk : EXPLORE_DIVERSITY_WINDOW_SIZE;
-
-    const scanned = await fetchBestEntitiesPage({
-      spaceIds: baseIds,
-      time: args.time,
-      limit: windowSize,
-      after,
-      typeIds: args.typeIds,
-    });
-
-    const ordered = applyDiversityCap(
-      buildItems(scanned.entities, allowed, memberOrEditorSet),
-      exploreItemTypeKey
-    );
-    const slice = ordered.slice(offset, offset + pageSize);
-
-    return {
-      items: await attachMeta(slice),
-      nextCursor: nextExploreWindowCursor({
-        after,
-        offset,
-        served: slice.length,
-        windowLength: ordered.length,
-        hasNextPage: scanned.hasNextPage,
-        endCursor: scanned.endCursor,
-      }),
-    };
-  }
+  // Every sort scans wider than it serves — `buildItems` drops entities with no
+  // displayable space, so over-scanning absorbs that. Best scans wider still, because a
+  // diversity cap cannot break up a page it cannot see past. A single type is the
+  // exception: there is nothing to diversify against, so it keeps the narrow scan.
+  const windowSize =
+    args.sort === 'best' && (args.typeIds?.length ?? 0) !== 1 ? EXPLORE_DIVERSITY_WINDOW_SIZE : scanChunk;
 
   const page =
-    args.sort === 'top'
+    args.sort === 'best'
+      ? await fetchBestEntitiesPage({
+          spaceIds: baseIds,
+          time: args.time,
+          limit: windowSize,
+          after,
+          typeIds: args.typeIds,
+        })
+      : args.sort === 'top'
       ? await fetchTopEntitiesPage({
           spaceIds: baseIds,
           time: args.time,
-          limit: scanChunk,
-          after: args.cursor,
+          limit: windowSize,
+          after,
           typeIds: args.typeIds,
           requireName: args.requireName,
         })
       : await fetchExploreEntitiesPage({
           spaceIds: baseIds,
           time: args.time,
-          limit: scanChunk,
-          after: args.cursor,
+          limit: windowSize,
+          after,
           orderBy: [EntitiesOrderBy.CreatedAtDesc],
           typeIds: args.typeIds,
           requireName: args.requireName,
         });
 
-  const enriched = buildItems(page.entities, allowed, memberOrEditorSet);
-  const items = await attachMeta(enriched.slice(0, pageSize));
+  const rows = buildItems(page.entities, allowed, memberOrEditorSet);
 
-  const nextCursor = page.hasNextPage ? page.endCursor : null;
+  // "Best" is the only sort that reorders (GEO-2690). "New" is reverse-chronological and
+  // an activity log that shuffles is simply wrong; "Top" is an explicit "rank by score"
+  // request, and the crowding-out was measured on Best, which is also the default tab.
+  const ordered = args.sort === 'best' ? applyDiversityCap(rows, exploreItemTypeKey) : rows;
 
-  return { items, nextCursor };
+  // Serving a prefix and advancing the cursor past the whole scan is what dropped ranks
+  // 23-30 of every page before (GEO-2695). The offset keeps the rest reachable.
+  const slice = ordered.slice(offset, offset + pageSize);
+
+  return {
+    items: await attachMeta(slice),
+    nextCursor: nextExploreWindowCursor({
+      after,
+      offset,
+      served: slice.length,
+      windowLength: ordered.length,
+      hasNextPage: page.hasNextPage,
+      endCursor: page.endCursor,
+    }),
+  };
 }


### PR DESCRIPTION
Closes GEO-2690.

Preston asked to "lower their rank slightly so we get a better mix of content types". The measurement says that lever can't do it, so this does it at read time instead. He approved the approach: *"I'm cool with a diversity cap solution right now."*

## The measurement

Production, Best sort, paging via `nextCursor`:

|  | first screen (22) | 110 items / 5 pages |
| -- | -- | -- |
| **Claim** | **22 — 100%** | 86 — 78.2% |
| News story | 0 | 24 — 21.8% |
| everything else | 0 | **0** |

Longest unbroken claim run: **30**. Tweet and Episode each return 22 items when queried alone, so the content exists — it's outranked, not missing.

## Why the type weight can't fix it

`entity_type_weights` is the intended lever, applied as `ln(weight)`. Claims are **older** than news stories (median 168.6 h vs 118.1 h), so the recency term already favours news by 4.04 score units — and claims still win. The gap on the participation/comment terms is therefore >4 units, needing `weight ≈ 0.018`.

The schema forbids it:

```sql
CONSTRAINT "entity_type_weights_range" CHECK ("weight" > 0.1 AND "weight" <= 10.0)
```

and that floor is deliberate, per the migration's own comment: *"A weight can demote but never effectively exclude."* Maximum demotion is `ln(0.1) ≈ -2.30`, about 29 hours of freshness. The gap is over 50.

## What this does

At most 3 consecutive items share a type; the gap is filled by the highest-ranked item of another type. On the measured mix the first screen goes **22/22 claims → 17/22**. 77% is the floor a run cap alone reaches — the ticket's option 2 (normalising the participation terms, which claims accrue as a byproduct of every debate and news stories never do) is still the principled fix.

Only **Best** reorders. New is reverse-chronological and an activity log that shuffles is wrong; Top is an explicit "rank by score" request.

## Two things worth reviewing closely

**1. Paging, which is most of the diff.** Diversifying a page requires seeing past it, which leaves the over-fetched remainder homeless. Two options rejected:

- *Advance the server cursor past the whole window.* This is what the existing code already did in miniature — scan 30, serve 22, advance 30, **silently dropping 8 items per page**. At a 66-item window it drops 44. (That pre-existing bug is fixed here as a side effect.)
- *Query each type separately and merge.* Preston flagged the failure himself: independent cursors per type make a thin type loop, so *"users may see the same entity over and over"* on reload.

So the window start stays put and the cursor carries an offset into it (`w1:<offset>:<serverCursor>`). `applyDiversityCap` is a pure function of the ranked list, so re-fetching the window reproduces the same order and slicing deeper neither repeats nor skips. **The cost is that a window is fetched once per page it serves.** That's the tradeoff I'd most like a second opinion on — the alternative is returning 66-item pages, which is less total work but triples the first response.

**2. Type classification.** `types` comes from relations whose order isn't meaningful, so the key walks `EXPLORE_ENTITY_TYPES` in declared order. Claim is declared last and loses every tie, which is the useful direction: an entity that is also an Episode breaks a claim run instead of extending one.

## Sizing

3× the page size, from the measurement rather than picked round. A full screen needs `floor(22 / (3+1)) = 5` off-type items; news only starts around rank 31 and runs ~30% of ranks 30–110, so 2× supplies ~4 (short) and 3× supplies ~11. A type filter narrowed to one type keeps the old narrow scan — nothing to diversify against.

An earlier version of this used `ceil` and a test caught it: the last run on a screen has nothing after it to separate from, so it's `floor`.

## Verification

- 3182 tests / 304 files pass; `tsc` shows only the 5 pre-existing errors.
- Cap tested against the measured mix positionally, not as a ratio — the problem is *where* the off-type items sit.
- Both halves mutation-tested: disabling the cap fails 3 tests, dropping the window tail fails 3 others.
- Cursor covers the awkward cases: bare cursors from clients mid-scroll, `hasNextPage` with a null `endCursor` (would otherwise scroll the first screen forever), and a window that comes back shorter than the offset.
