### PR TITLE
Debates: claim counts, count ordering, and multi-select filters

### DIFF
--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
@@ -46,7 +46,7 @@ const mocks = vi.hoisted(() => ({
   ),
   openSidePanel: vi.fn(),
   /** Every query the All tab handed the hub's claims lookup, in render order. */
-  entityQueries: [] as Array<{ search: string | null; spaceId: string | null }>,
+  entityQueries: [] as Array<{ search: string | null; spaceIds?: string[] | null; topicIds?: string[] | null }>,
   /** Every id list the opponent's claims were hydrated with, in render order. */
   entityIdLookups: [] as string[][],
   entityQueryHasNextPage: false,
@@ -259,7 +259,7 @@ vi.mock('~/core/debates/matchmaking/hooks', () => ({
   useClaimReadiness: () => ({ mutate: mocks.setReadiness, isPending: false, error: null }),
   // The All tab is the hub's Claims query. Its arguments are what the tests below inspect.
   useMatchmakingClaims: (
-    query: { search: string | null; spaceId: string | null; topicId?: string | null },
+    query: { search: string | null; spaceIds?: string[] | null; topicIds?: string[] | null },
     enabled: boolean
   ) => {
     // A disabled query is not a silent one: `placeholderData: keepPreviousData` outlives
@@ -293,7 +293,14 @@ vi.mock('~/core/debates/matchmaking/hooks', () => ({
     // `space_id` and `topic_id` both filter server-side as of GEO-2659, and every page carries
     // facets computed over the whole candidate set rather than the page being returned.
     const corpus = mocks.entityQueryPages ?? [mocks.matchmakingClaims];
-    const inSpace = corpus.flat().filter(entry => !query.spaceId || entry.claim.space_id === query.spaceId);
+    // Both sides normalized, as geo-chat does: the scope carries dash-less ids while the fixtures
+    // carry the dashed spelling, so comparing them raw would filter everything out.
+    const norm = (id: string) => id.replace(/-/g, '').toLowerCase();
+    const inSpaceFilter = (spaceId: string) =>
+      !query.spaceIds?.length || query.spaceIds.some(id => norm(id) === norm(spaceId));
+    const inTopicFilter = (topics: { id: string }[]) =>
+      !query.topicIds?.length || topics.some(topic => (query.topicIds ?? []).includes(topic.id));
+    const inSpace = corpus.flat().filter(entry => inSpaceFilter(entry.claim.space_id));
     const topicFacets = [...new Map(inSpace.flatMap(entry => entry.topics).map(topic => [topic.id, topic])).values()];
     const spaceIds = [...new Set(corpus.flat().map(entry => entry.claim.space_id))];
     // Narrowed by space, never by topic: picking a topic must not collapse its own menu.
@@ -305,9 +312,7 @@ vi.mock('~/core/debates/matchmaking/hooks', () => ({
     };
     const data = {
       pages: corpus.map(page => ({
-        claims: page
-          .filter(entry => !query.spaceId || entry.claim.space_id === query.spaceId)
-          .filter(entry => !query.topicId || entry.topics.some(topic => topic.id === query.topicId)),
+        claims: page.filter(entry => inSpaceFilter(entry.claim.space_id)).filter(entry => inTopicFilter(entry.topics)),
         next_cursor: null,
         facets,
       })),
@@ -1040,7 +1045,7 @@ describe('DebateRematchPageClient', () => {
     showAllClaims();
 
     selectFilter('Any space', 'Crypto');
-    await waitFor(() => expect(browsedClaimsQueryOptions()?.spaceId).toBe(SPACE_1));
+    await waitFor(() => expect(browsedClaimsQueryOptions()?.spaceIds).toEqual([SPACE_1]));
   });
 
   // On a phone the three tabs are wider than the screen. They were laid out in a row that could
@@ -1316,7 +1321,7 @@ describe('DebateRematchPageClient', () => {
     selectFilter('Any topic', 'Governance');
 
     // Filtering only here would narrow the pages already loaded and nothing beyond them.
-    await waitFor(() => expect(mocks.entityQueries.at(-1)).toMatchObject({ topicId: 'topic-gov' }));
+    await waitFor(() => expect(mocks.entityQueries.at(-1)).toMatchObject({ topicIds: ['topic-gov'] }));
   });
 
   // Reported after the facet landed: pick a space, pick a topic it lists, get nothing. The space
@@ -1474,6 +1479,7 @@ describe('DebateRematchPageClient', () => {
     fireEvent.click(screen.getByRole('button', { name: /Crypto/ }));
 
     expect(screen.getByRole('button', { name: /Governance/ })).toBeInTheDocument();
+    fireEvent.keyDown(document, { key: 'Escape' });
   });
 
   it('lets go of a selected topic once the space no longer has claims for it', async () => {
@@ -2257,6 +2263,9 @@ function appearsBefore(first: string, second: string) {
 function selectFilter(trigger: string, option: string) {
   fireEvent.click(screen.getByRole('button', { name: new RegExp(trigger) }));
   fireEvent.click(screen.getByRole('button', { name: new RegExp(option) }));
+  // Multi-select menus stay open across a tick, so the trigger and the row would both answer to
+  // the same name until this closes it.
+  fireEvent.keyDown(document, { key: 'Escape' });
 }
 
 function session(overrides: Partial<DebateRematchSession> = {}): DebateRematchSession {

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
@@ -1701,18 +1701,43 @@ describe('DebateRematchPageClient', () => {
     fireEvent.keyDown(document, { key: 'Escape' });
   });
 
-  it('lets go of a selected topic once the space no longer has claims for it', async () => {
+  // A space can be on the menu without being in the allowlist — the graph-backed sources aren't
+  // narrowed by it, so their rows put their spaces there. Picking one alongside an allowed space
+  // used to send both: `browsedRows` dropped the disallowed rows, but the facets riding with them
+  // still named their topics and counted their claims.
+  it('sends geo-chat only the picked spaces it can answer for', async () => {
+    mocks.spaceAllowlist = new Set([SPACE_2.replace(/-/g, '')]);
     render(<DebateRematchPageClient sessionId="rematch-1" />);
     await showAllClaims();
 
-    selectFilter('Any topic', 'Governance');
-    await waitFor(() => expect(screen.queryByText('A claim both participants chose')).toBeNull());
+    selectFilter('Any space', 'Governance space');
+    await waitFor(() => expect(mocks.entityQueries.at(-1)).toMatchObject({ spaceIds: [SPACE_2] }));
 
-    selectFilter('Any space', 'Crypto');
+    // Crypto reaches the menu through a pinned row, not through the allowlist. The trigger now
+    // reads the picked space's own name, so that is what opens the menu again.
+    selectFilter('Governance space', 'Crypto');
+
+    await waitFor(() => expect(mocks.entityQueries.at(-1)).toMatchObject({ spaceIds: [SPACE_2] }));
+  });
+
+  // Not reachable by picking a topic and then a space it has nothing in: each menu is narrowed by
+  // the other, so such a space is never on offer. It is reachable by the corpus moving under a
+  // selection that was valid when it was made.
+  it('lets go of a selected topic once the space no longer has claims for it', async () => {
+    const view = render(<DebateRematchPageClient sessionId="rematch-1" />);
+    await showAllClaims();
+
+    selectFilter('Any space', 'Governance space');
+    selectFilter('Any topic', 'Ethics');
+    await waitFor(() => expect(mocks.entityQueries.at(-1)).toMatchObject({ topicIds: ['topic-eth'] }));
+
+    // The one Ethics claim in that space is answered, published elsewhere, or otherwise leaves the
+    // candidate set, so the facet stops naming the topic.
+    mocks.matchmakingClaims = [{ ...matchmakingClaim(), topics: [{ id: 'topic-gov', name: 'Governance' }] }];
+    view.rerender(<DebateRematchPageClient sessionId="rematch-1" />);
 
     // Held, it would filter the list by a chip that is no longer in the menu to unpick.
     await waitFor(() => expect(screen.getByRole('button', { name: /Any topic/ })).toBeInTheDocument());
-    expect(screen.getByText('A claim both participants chose')).toBeInTheDocument();
   });
 
   it('narrows the list to the selected space', async () => {

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -51,6 +51,7 @@ import { MatchmakingClaimCard } from '~/core/debates/matchmaking/matchmaking-cla
 import {
   countBy,
   keepSelectableTopics,
+  keepSelectedVisible,
   mergeFacetCounts,
   orderFacetOptions,
   toggleId,
@@ -897,10 +898,10 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
     );
     const fromServer = (browsedFacets?.space_facets ?? []).filter(facet => offered.has(facet.id));
     const merged = mergeFacetCounts(browsesPages ? fromServer : [], fromRows);
-    // No zero-count backfill. A space the other filters leave empty is an option that can only ever
-    // produce an empty list, which is the thing this menu exists not to do — and the way back is
-    // already safe without it, since the space facet is never narrowed by the space selection.
-    return orderFacetOptions(merged, spaceIds);
+    // Absent options stay absent — one the other filters leave empty could only ever produce an
+    // empty list. An absent *selection* comes back at zero, or its checkbox disappears while the
+    // trigger goes on counting it, and it can't be unticked without clearing every space.
+    return orderFacetOptions(keepSelectedVisible(merged, spaceIds), spaceIds);
   }, [browsedFacets?.space_facets, claims, debouncedSearch, facetSpaceIds, spaceIds, tab, topicIds, topicsByClaimId]);
 
   // A space picked while the gates were still passing everything has to be let go once they

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -21,7 +21,7 @@ import {
   type MatchmakingTopic,
 } from '~/core/debates/api';
 import { type ClaimPickerEntity, useClaimEntitiesByIds } from '~/core/debates/claim-picker-page';
-import { eligibleClaimSpaceIds, isClaimSpaceAllowed, keepSelectableSpace } from '~/core/debates/claim-space-allowlist';
+import { eligibleClaimSpaceIds, isClaimSpaceAllowed } from '~/core/debates/claim-space-allowlist';
 import { markEnteringDebate } from '~/core/debates/debate-entry-intent';
 import { useDebateGatewaySpaceScopes } from '~/core/debates/debate-gateway';
 import { debatePublishableSpacePredicate } from '~/core/debates/debate-publish-target';
@@ -46,7 +46,6 @@ import { HubPillButton } from '~/core/debates/matchmaking/hub-pill-button';
 import { HubQueryState, HubSkeleton } from '~/core/debates/matchmaking/hub-states';
 import { MatchmakingClaimCard } from '~/core/debates/matchmaking/matchmaking-claim-card';
 import {
-  availableTopics,
   countBy,
   keepSelectableTopics,
   mergeFacetCounts,

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -45,7 +45,14 @@ import { HubCardList } from '~/core/debates/matchmaking/hub-motion';
 import { HubPillButton } from '~/core/debates/matchmaking/hub-pill-button';
 import { HubQueryState, HubSkeleton } from '~/core/debates/matchmaking/hub-states';
 import { MatchmakingClaimCard } from '~/core/debates/matchmaking/matchmaking-claim-card';
-import { availableTopics, keepSelectableTopic } from '~/core/debates/matchmaking/topic-facets';
+import {
+  availableTopics,
+  countBy,
+  keepSelectableTopics,
+  mergeFacetCounts,
+  orderFacetOptions,
+  toggleId,
+} from '~/core/debates/matchmaking/topic-facets';
 import { useScopedMatchmakingClaims } from '~/core/debates/matchmaking/use-scoped-claims';
 import { useStableListOrder } from '~/core/debates/matchmaking/use-stable-list-order';
 import { participantSidesOn, useParticipantPositions } from '~/core/debates/participant-positions';
@@ -112,8 +119,8 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
     return () => clearTimeout(timeout);
   }, [search]);
 
-  const [spaceId, setSpaceId] = React.useState<string | null>(null);
-  const [topicId, setTopicId] = React.useState<string | null>(null);
+  const [spaceIds, setSpaceIds] = React.useState<string[]>([]);
+  const [topicIds, setTopicIds] = React.useState<string[]>([]);
   // Left unset until the viewer picks one: Recommended is the best landing tab when a curator has
   // put something together for this pairing, and it doesn't exist otherwise. Deciding in state
   // would fix the default before that lookup settles.
@@ -245,7 +252,10 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   // aren't narrowed by it, so their rows put their spaces there — but `browsedRows` still drops
   // every *browsed* row from a disallowed space. Selecting one leaves the server answering with
   // rows that cannot be shown, and a facet describing them, while only the pinned rows survive.
-  const selectedSpaceShowsNothing = spaceId !== null && !isClaimSpaceAllowed(spaceId, spaceAllowlist);
+  // Every picked space, not any: with one allowed space picked alongside a disallowed one, the
+  // browsed corpus still has rows to give.
+  const selectedSpaceShowsNothing =
+    spaceIds.length > 0 && spaceIds.every(id => !isClaimSpaceAllowed(id, spaceAllowlist));
 
   // Every lookup the scope is built from. Until they have all landed the scope is `null`, which
   // geo-chat reads as "no filter" — so asking now buys an answer about the whole corpus, whose
@@ -264,26 +274,25 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
     [allowlistPending, allowlistSpacesHeldOver, allowlistSpacesPending, eligibleSpaceIds, publishablePending]
   );
 
-  const matchmakingQuery = React.useMemo<Omit<MatchmakingClaimsQuery, 'spaceIds'>>(
+  const matchmakingQuery = React.useMemo<Omit<MatchmakingClaimsQuery, 'spaceIds' | 'spaceId'>>(
     // `topicId` is sent whichever tab is showing. It only filters *these* rows, which back the
     // All tab, and the server's topic facet is narrowed by spaces rather than by topics — so a
     // topic selection can never collapse the menu it came from. The other two tabs are built
     // from graph entities geo-chat has never seen, so their topic filter stays client-side.
     () => ({
       search: debouncedSearch || null,
-      spaceId,
-      topicId,
+      topicIds,
       // What `excludedClaimIds` removes below, removed by the endpoint instead — so the facets
       // describe the same corpus the rows do. Without it a topic whose every claim in the space
       // was one this session had dropped stayed on the menu over an empty list.
       rematchSessionId: sessionId,
       filter: 'all',
     }),
-    [debouncedSearch, sessionId, spaceId, topicId]
+    [debouncedSearch, sessionId, topicIds]
   );
   // Every way the pages can outlive the scope that fetched them is handled in there, once, for
   // both pickers — see `useScopedMatchmakingClaims`.
-  const browsedClaimsQuery = useScopedMatchmakingClaims(matchmakingQuery, scope, selectedSpaceShowsNothing);
+  const browsedClaimsQuery = useScopedMatchmakingClaims(matchmakingQuery, scope, spaceIds, selectedSpaceShowsNothing);
   const { pages: browsedPages, facets: browsedFacets } = browsedClaimsQuery;
 
   // What geo-chat knows about this session's claims — readiness, the shared-preference and
@@ -561,7 +570,7 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
     // Topic belongs in the key for the same reason space does: it goes out as `topic_id`, so the
     // server ranks a different list under it, and holding the previous order would arrange the
     // new one by a ranking the viewer has already moved on from.
-    `${debouncedSearch}|${spaceId ?? ''}|${topicId ?? ''}`
+    `${debouncedSearch}|${spaceIds.join(',')}|${topicIds.join(',')}`
   );
 
   // The opponent is whichever participant isn't the local user; with no local user there is none.
@@ -678,10 +687,51 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
     return [...menu];
   }, [browsedClaims, browsedFacets?.space_ids, canPublishDebateIn, curatedClaims, opponentClaims, spaceAllowlist]);
 
+  // The menu's ids with counts against them. The server counts the browsed corpus; anything only
+  // the rows know about is counted from the rows, which is all there is to count — see
+  // `mergeFacetCounts` for why the two are not summed.
+  const facetSpaces = React.useMemo(() => {
+    const offered = new Set(facetSpaceIds);
+    // Narrowed by the topic and the search, never by the space selection — the mirror of
+    // `topicFacetClaims`, and the rule the server counts by: a dimension is never narrowed by
+    // itself, or picking one space would empty the menu it was picked from.
+    const fromRows = countBy(
+      claims
+        .filter(claim => {
+          if (!offered.has(claim.claim.space_id)) return false;
+          if (
+            topicIds.length > 0 &&
+            !(topicsByClaimId.get(claim.claim.claim_entity_id) ?? []).some(topic => topicIds.includes(topic.id))
+          )
+            return false;
+          if (
+            tab !== 'all' &&
+            debouncedSearch &&
+            !claim.claim.claim.toLowerCase().includes(debouncedSearch.toLowerCase())
+          )
+            return false;
+          return true;
+        })
+        .map(claim => ({ id: claim.claim.space_id, name: null }))
+    );
+    const fromServer = (browsedFacets?.space_facets ?? []).filter(facet => offered.has(facet.id));
+    const merged = mergeFacetCounts(tab === 'all' ? fromServer : [], fromRows);
+    // Every id the menu offers, including any the counts can't reach — a space whose only rows are
+    // filtered out right now is still somewhere the viewer can go back to.
+    for (const id of facetSpaceIds)
+      if (!merged.some(entry => entry.id === id)) merged.push({ id, name: null, count: 0 });
+    return orderFacetOptions(merged, spaceIds);
+  }, [browsedFacets?.space_facets, claims, debouncedSearch, facetSpaceIds, spaceIds, tab, topicIds, topicsByClaimId]);
+
   // A space picked while the gates were still passing everything has to be let go once they
   // reject it, or it keeps going out as `space_id` on every request while its rows are dropped.
   React.useEffect(() => {
-    setSpaceId(current => keepSelectableSpace(current, facetSpaceIds, !allowlistPending));
+    if (allowlistPending) return;
+    setSpaceIds(current => {
+      const offered = new Set(facetSpaceIds);
+      const kept = current.filter(id => offered.has(id));
+      return kept.length === current.length ? current : kept;
+    });
   }, [allowlistPending, facetSpaceIds]);
 
   // The claims the topic menu describes on the graph-backed tabs: everything the other filters
@@ -691,7 +741,7 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   const topicFacetClaims = React.useMemo(
     () =>
       claims.filter(claim => {
-        if (spaceId && claim.claim.space_id !== spaceId) return false;
+        if (spaceIds.length > 0 && !spaceIds.includes(claim.claim.space_id)) return false;
         // Cut on the same terms `visibleClaims` is, or the menu stops describing the list. On the
         // All tab the search runs server-side over the browsed rows, and the pinned ones are
         // merged in whether they match it or not — so cutting them here left a row on screen with
@@ -704,21 +754,29 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
           return false;
         return true;
       }),
-    [claims, debouncedSearch, spaceId, tab]
+    [claims, debouncedSearch, spaceIds, tab]
   );
 
   // The All tab takes its menu from the server, which knows the whole filtered corpus rather
   // than the pages this client has walked — the difference GEO-2653 was about. The other two
   // tabs are built from graph entities geo-chat has never heard of, so they still derive theirs.
   //
-  // The server orders by count; kept in name order to match the other tabs and to leave the
-  // count ordering, with the counts themselves, to GEO-2654.
+  // Ordered by count with the picked ones pinned, the same as the Claims tab.
+  // Counted from the rows the tab would show, which is the only count available for a claim
+  // geo-chat has never seen.
+  const rowTopicCounts = React.useMemo(
+    () =>
+      countBy(
+        topicFacetClaims.flatMap(claim =>
+          (topicsByClaimId.get(claim.claim.claim_entity_id) ?? []).map(topic => ({ id: topic.id, name: topic.name }))
+        )
+      ),
+    [topicFacetClaims, topicsByClaimId]
+  );
+
   const facetTopics = React.useMemo(() => {
-    const fromRows = availableTopics(
-      topicFacetClaims.map(claim => claim.claim.claim_entity_id),
-      topicsByClaimId
-    );
-    if (tab !== 'all') return fromRows;
+    const rowCounts = rowTopicCounts;
+    if (tab !== 'all') return orderFacetOptions(rowCounts, topicIds);
 
     // Both, because neither is the whole answer. The facet covers claims no page has reached,
     // which the rows cannot; the rows cover this session's saved, opponent and curated claims,
@@ -727,23 +785,23 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
     //
     // Adding rows can't reintroduce an empty option: every topic here comes from a claim the
     // other filters already allow, so picking it leaves at least that one behind.
-    const merged = new Map<string, MatchmakingTopic>();
-    for (const facet of browsedFacets?.topic_facets ?? []) merged.set(facet.id, { id: facet.id, name: facet.name });
-    for (const topic of fromRows) if (!merged.has(topic.id)) merged.set(topic.id, topic);
-    return [...merged.values()].sort((a, b) => (a.name ?? '').localeCompare(b.name ?? ''));
-  }, [browsedFacets?.topic_facets, tab, topicFacetClaims, topicsByClaimId]);
+    return orderFacetOptions(mergeFacetCounts(browsedFacets?.topic_facets ?? [], rowCounts), topicIds);
+  }, [browsedFacets?.topic_facets, rowTopicCounts, tab, topicIds]);
 
   // Search and space reach the browsed query; on the other tabs, and for the topic everywhere
   // (geo-chat doesn't model topics), they are applied here.
   const visibleClaims = React.useMemo(
     () =>
       claims.filter(claim => {
-        if (spaceId && claim.claim.space_id !== spaceId) return false;
+        if (spaceIds.length > 0 && !spaceIds.includes(claim.claim.space_id)) return false;
         // Kept even on the All tab, where the query has already applied it. That tab is the
         // browsed rows *plus* this session's claims pinned in front of them, and the pinned ones
         // never went through the query — without this they survive a topic filter they don't
         // match. A no-op for the rows the server did filter, which match by construction.
-        if (topicId && !(topicsByClaimId.get(claim.claim.claim_entity_id) ?? []).some(t => t.id === topicId))
+        if (
+          topicIds.length > 0 &&
+          !(topicsByClaimId.get(claim.claim.claim_entity_id) ?? []).some(t => topicIds.includes(t.id))
+        )
           return false;
         if (
           tab !== 'all' &&
@@ -753,10 +811,10 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
           return false;
         return true;
       }),
-    [claims, debouncedSearch, spaceId, tab, topicId, topicsByClaimId]
+    [claims, debouncedSearch, spaceIds, tab, topicIds, topicsByClaimId]
   );
 
-  const hasFilters = Boolean(debouncedSearch || spaceId || topicId);
+  const hasFilters = Boolean(debouncedSearch || spaceIds.length || topicIds.length);
 
   const sentinelRef = useInfiniteScrollSentinel({
     // Masked for the same reason the pages are: the retained `hasNextPage` outlives the scope it
@@ -788,7 +846,7 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
     // The All tab's menu is only as settled as the facets behind it; the other two have no facet
     // to wait on, so their own loading state is the whole answer.
     const resolved = tab === 'all' ? browsedClaimsQuery.facetsSettled && !tabIsLoading : !tabIsLoading;
-    setTopicId(current => keepSelectableTopic(current, facetTopics, resolved));
+    setTopicIds(current => keepSelectableTopics(current, facetTopics, resolved));
   }, [browsedClaimsQuery.facetsSettled, facetTopics, tab, tabIsLoading]);
 
   const tabError =
@@ -973,11 +1031,13 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
 
           <div className="flex flex-col gap-3">
             <SpaceTopicFilters
-              spaceId={spaceId}
-              onSpaceChange={setSpaceId}
-              topicId={topicId}
-              onTopicChange={setTopicId}
-              facetSpaceIds={facetSpaceIds}
+              spaceIds={spaceIds}
+              onSpaceToggle={id => setSpaceIds(current => toggleId(current, id))}
+              onSpacesClear={() => setSpaceIds([])}
+              topicIds={topicIds}
+              onTopicToggle={id => setTopicIds(current => toggleId(current, id))}
+              onTopicsClear={() => setTopicIds([])}
+              facetSpaces={facetSpaces}
               facetTopics={facetTopics}
               className="justify-between"
             />
@@ -1030,8 +1090,8 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
                   label: 'Clear filters',
                   onClick: () => {
                     setSearch('');
-                    setSpaceId(null);
-                    setTopicId(null);
+                    setSpaceIds([]);
+                    setTopicIds([]);
                   },
                 }
               : undefined

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -281,8 +281,18 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   // rows that cannot be shown, and a facet describing them, while only the pinned rows survive.
   // Every picked space, not any: with one allowed space picked alongside a disallowed one, the
   // browsed corpus still has rows to give.
-  const selectedSpaceShowsNothing =
-    spaceIds.length > 0 && spaceIds.every(id => !isClaimSpaceAllowed(id, spaceAllowlist));
+  // The graph-backed sources deliberately offer spaces outside the viewer's allowlist, so a
+  // selection can hold both kinds at once. Only the allowed ones may reach geo-chat: `browsedRows`
+  // drops the rest anyway, but the facets riding with them would still name their topics and count
+  // their claims. The full selection stays in `spaceIds` for the pinned rows, which come from the
+  // graph and are not narrowed by the allowlist.
+  const browsableSpaceIds = React.useMemo(
+    () => spaceIds.filter(id => isClaimSpaceAllowed(id, spaceAllowlist)),
+    [spaceAllowlist, spaceIds]
+  );
+
+  // Nothing left to ask about once every pick is one geo-chat cannot answer for.
+  const selectedSpaceShowsNothing = spaceIds.length > 0 && browsableSpaceIds.length === 0;
 
   // Every lookup the scope is built from. Until they have all landed the scope is `null`, which
   // geo-chat reads as "no filter" — so asking now buys an answer about the whole corpus, whose
@@ -375,7 +385,12 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   // also feed the space menu and their spaces the gateway scopes this page holds — both of which
   // have to describe every list, not the one in front of the viewer. Only the sentinel is gated,
   // below: paging a corpus that isn't on screen is the part that would be waste.
-  const browsedClaimsQuery = useScopedMatchmakingClaims(matchmakingQuery, scope, spaceIds, selectedSpaceShowsNothing);
+  const browsedClaimsQuery = useScopedMatchmakingClaims(
+    matchmakingQuery,
+    scope,
+    browsableSpaceIds,
+    selectedSpaceShowsNothing
+  );
   const { pages: browsedPages, facets: browsedFacets } = browsedClaimsQuery;
 
   // What geo-chat knows about this session's claims — readiness, the shared-preference and
@@ -882,10 +897,9 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
     );
     const fromServer = (browsedFacets?.space_facets ?? []).filter(facet => offered.has(facet.id));
     const merged = mergeFacetCounts(browsesPages ? fromServer : [], fromRows);
-    // Every id the menu offers, including any the counts can't reach — a space whose only rows are
-    // filtered out right now is still somewhere the viewer can go back to.
-    for (const id of facetSpaceIds)
-      if (!merged.some(entry => entry.id === id)) merged.push({ id, name: null, count: 0 });
+    // No zero-count backfill. A space the other filters leave empty is an option that can only ever
+    // produce an empty list, which is the thing this menu exists not to do — and the way back is
+    // already safe without it, since the space facet is never narrowed by the space selection.
     return orderFacetOptions(merged, spaceIds);
   }, [browsedFacets?.space_facets, claims, debouncedSearch, facetSpaceIds, spaceIds, tab, topicIds, topicsByClaimId]);
 

--- a/apps/web/core/debates/api.test.ts
+++ b/apps/web/core/debates/api.test.ts
@@ -242,6 +242,34 @@ describe('matchmaking', () => {
     expect(url.searchParams.get('rematch_session_id')).toBe('rematch-1');
   });
 
+  // Same shape as the space pair, and the same reason to send only one.
+  it('sends multiple topics as a joined list', async () => {
+    const fetch = stubJson({ claims: [], next_cursor: null });
+
+    await listMatchmakingClaims({ topicIds: ['topic-ai', 'topic-health'] }, vi.fn(), 'user-a');
+
+    const url = new URL((fetch.mock.calls[0]?.[0] as string) ?? '');
+    expect(url.searchParams.get('topic_ids')).toBe('topic-ai,topic-health');
+  });
+
+  it('sends the single topic instead of the list, never both', async () => {
+    const fetch = stubJson({ claims: [], next_cursor: null });
+
+    await listMatchmakingClaims({ topicId: 'topic-ai', topicIds: ['topic-ai', 'topic-health'] }, vi.fn(), 'user-a');
+
+    const url = new URL((fetch.mock.calls[0]?.[0] as string) ?? '');
+    expect(url.searchParams.get('topic_id')).toBe('topic-ai');
+    expect(url.searchParams.has('topic_ids')).toBe(false);
+  });
+
+  it('omits an empty topic list rather than sending it as no filter', async () => {
+    const fetch = stubJson({ claims: [], next_cursor: null });
+
+    await listMatchmakingClaims({ topicIds: [] }, vi.fn(), 'user-a');
+
+    expect(fetch).toHaveBeenCalledWith('http://localhost:8080/matchmaking/claims', expect.anything());
+  });
+
   // The two space parameters are OR-merged server-side, so sending both would widen the corpus to
   // the whole eligible set the moment the viewer picked one space out of it.
   it('sends the picked space instead of the scope, never both', async () => {

--- a/apps/web/core/debates/api.ts
+++ b/apps/web/core/debates/api.ts
@@ -461,6 +461,11 @@ export type MatchmakingClaimsQuery = {
   spaceIds?: string[] | null;
   topicId?: string | null;
   /**
+   * Topics to narrow by, OR-ed together. Merged with `topicId` the same way `spaceIds` is with
+   * `spaceId`, so send one or the other rather than both.
+   */
+  topicIds?: string[] | null;
+  /**
    * Narrows rows *and* facets to what a debate-again session can still offer: geo-chat drops the
    * claim the source debate was about, and any this pairing has blocked (GEO-2674).
    *
@@ -1097,6 +1102,7 @@ export async function listMatchmakingClaims(
   // eligible set means.
   else if (query.spaceIds?.length) params.set('space_ids', query.spaceIds.join(','));
   if (query.topicId) params.set('topic_id', query.topicId);
+  else if (query.topicIds?.length) params.set('topic_ids', query.topicIds.join(','));
   if (query.rematchSessionId) params.set('rematch_session_id', query.rematchSessionId);
   if (query.filter && query.filter !== 'all') params.set('filter', query.filter);
   if (query.cursor) params.set('cursor', query.cursor);

--- a/apps/web/core/debates/matchmaking/claims-tab.test.tsx
+++ b/apps/web/core/debates/matchmaking/claims-tab.test.tsx
@@ -981,6 +981,49 @@ describe('ClaimsTab -- Featured', () => {
     expect(screen.queryByText('Chips are better than fries')).toBeNull();
   });
 
+  // Featured has no server facet, so its counts are computed here — and a count still has to say
+  // what picking the option would leave. Reported: pick a topic that only exists in one space, and
+  // the other space kept its full count over a list that would come back empty.
+  it('narrows its space counts by the picked topic', async () => {
+    mocks.featuredClaims = [
+      featuredClaim(FEATURED_A, 'Nuclear power is the cheapest clean energy', SPACE_ID),
+      featuredClaim(FEATURED_B, 'Cities should ban cars downtown', OTHER_SPACE_ID),
+    ];
+    mocks.claimEntities = [
+      {
+        id: FEATURED_A,
+        name: 'Nuclear power is the cheapest clean energy',
+        description: null,
+        spaces: [SPACE_ID],
+        values: [],
+        relations: [{ type: { id: TOPICS_PROPERTY_ID }, toEntity: { id: 'topic-energy', name: 'Energy' } }],
+      },
+      {
+        id: FEATURED_B,
+        name: 'Cities should ban cars downtown',
+        description: null,
+        spaces: [OTHER_SPACE_ID],
+        values: [],
+        relations: [],
+      },
+    ];
+    render(<ClaimsTab />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Any space/ }));
+    // Both spaces carry a featured claim, so both are offered before any topic narrows them.
+    expect(screen.getAllByRole('button', { name: /Space/ })).toHaveLength(2);
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    fireEvent.click(screen.getByRole('button', { name: /Any topic/ }));
+    fireEvent.click(screen.getByRole('button', { name: /^Energy/ }));
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    // Only the Energy claim's space is left to pick, and the other is gone rather than offered
+    // over a list it could not fill.
+    fireEvent.click(screen.getByRole('button', { name: /Any space/ }));
+    await waitFor(() => expect(screen.getAllByRole('button', { name: /Space/ })).toHaveLength(1));
+  });
+
   // The panel is narrow enough that three menus fill the row on their own. Pushing the topic one to
   // the far end there — as the rematch picker does, where there is width to spare — would only
   // separate it from the two it sits with.

--- a/apps/web/core/debates/matchmaking/claims-tab.test.tsx
+++ b/apps/web/core/debates/matchmaking/claims-tab.test.tsx
@@ -87,12 +87,19 @@ vi.mock('./hooks', () => ({
         refetch: vi.fn(),
       };
     }
-    const { spaceId, topicId } = query as { spaceId?: string | null; topicId?: string | null };
+    const { spaceIds, topicIds } = query as { spaceIds?: string[] | null; topicIds?: string[] | null };
+    // geo-chat normalizes both sides before comparing; the fixtures carry the dashed spelling while
+    // the allowlist carries the dash-less one, so a mock that compared them raw would filter
+    // everything out and look like a broken query.
+    const norm = (id: string) => id.replace(/-/g, '').toLowerCase();
+    const inSpaceFilter = (spaceId: string) => !spaceIds?.length || spaceIds.some(id => norm(id) === norm(spaceId));
+    const inTopicFilter = (topics: { id: string }[]) =>
+      !topicIds?.length || topics.some(topic => topicIds.includes(topic.id));
     // `space_id` and `topic_id` are both query parameters as of GEO-2659, so the endpoint
     // returns only the rows that match. Mirrored here, because what the tab renders and what
     // its menus describe both hang off that.
-    const inSpace = mocks.claims.filter(entry => !spaceId || entry.claim.space_id === spaceId);
-    const claims = inSpace.filter(entry => !topicId || entry.topics.some(topic => topic.id === topicId));
+    const inSpace = mocks.claims.filter(entry => inSpaceFilter(entry.claim.space_id));
+    const claims = inSpace.filter(entry => inTopicFilter(entry.topics));
     // Each dimension is counted without narrowing itself, and *is* narrowed by the other — what
     // `MATCHMAKING_CLAIMS_FACETS_QUERY` does, and what a facet count is for. So the topic facet is
     // cut by the space filter and the space facet by the topic filter; neither is cut by its own.
@@ -100,11 +107,11 @@ vi.mock('./hooks', () => ({
     // server-side facet.
     const topicFacets = [...new Map(inSpace.flatMap(entry => entry.topics).map(topic => [topic.id, topic])).values()];
     const spacesCarryingTopic = new Set(
-      mocks.claims
-        .filter(entry => !topicId || entry.topics.some(topic => topic.id === topicId))
-        .map(entry => entry.claim.space_id)
+      mocks.claims.filter(entry => inTopicFilter(entry.topics)).map(entry => norm(entry.claim.space_id))
     );
-    const spaceFacetIds = topicId ? mocks.facetSpaceIds.filter(id => spacesCarryingTopic.has(id)) : mocks.facetSpaceIds;
+    const spaceFacetIds = topicIds?.length
+      ? mocks.facetSpaceIds.filter(id => spacesCarryingTopic.has(norm(id)))
+      : mocks.facetSpaceIds;
     // Facets are computed over the whole filtered set while the page is a slice of it — the
     // shape that matters here, since the menu must not depend on how far the viewer has scrolled.
     const page = mocks.pageSize === null ? claims : claims.slice(0, mocks.pageSize);
@@ -424,7 +431,7 @@ describe('ClaimsTab', () => {
     fireEvent.click(screen.getByRole('button', { name: /Any space/ }));
 
     // Names resolve through useSpacesByIds, mocked empty here, so each offered space reads "Space".
-    expect(screen.getAllByRole('button', { name: /^Space/ })).toHaveLength(1);
+    expect(screen.getAllByRole('button', { name: /Space/ })).toHaveLength(1);
   });
 
   // Same trimming-under-the-viewer problem the allowlist has, and the same answer: `null` does not
@@ -510,7 +517,7 @@ describe('ClaimsTab', () => {
     fireEvent.click(screen.getByRole('button', { name: /Any space/ }));
 
     // Names resolve through useSpacesByIds, mocked empty here, so every allowed space reads "Space".
-    expect(screen.getAllByRole('button', { name: /^Space/ })).toHaveLength(1);
+    expect(screen.getAllByRole('button', { name: /Space/ })).toHaveLength(1);
   });
 
   // The allowlist runs over the loaded page, so a page can arrive with nothing left in it. With
@@ -596,7 +603,7 @@ describe('ClaimsTab', () => {
 
     expect(screen.queryByLabelText('Loading space name')).toBeNull();
     // The option's accessible name picks up its avatar initial, so it reads "SSpace".
-    expect(screen.getByRole('button', { name: /^Space/ })).toBeEnabled();
+    expect(screen.getByRole('button', { name: /Space/ })).toBeEnabled();
   });
 
   // The same placeholder ran down every card in the list.
@@ -763,8 +770,10 @@ describe('topic menu', () => {
     fireEvent.click(screen.getByRole('button', { name: /Any space/ }));
     fireEvent.click(screen.getByRole('button', { name: /Crypto/ }));
 
-    // geo-chat ORs the two together, so sending both would widen the query straight back out.
-    expect((mocks.lastQuery as { spaceId?: string | null }).spaceId).toBeTruthy();
+    // geo-chat ORs the space parameters together, so sending the scope alongside the pick would
+    // widen the query straight back out to every eligible space.
+    // The menu's option values are the facet's own ids, which is what goes back out.
+    expect(mocks.lastQuery).toMatchObject({ spaceIds: [SPACE_ID] });
   });
 
   it('asks the server to do the topic filtering', () => {
@@ -805,6 +814,8 @@ describe('topic menu', () => {
     fireEvent.click(screen.getByRole('button', { name: /Crypto/ }));
     fireEvent.click(screen.getByRole('button', { name: /Any topic/ }));
     fireEvent.click(screen.getByRole('button', { name: /^AI/ }));
+    // The menu stays open across a tick, so the trigger and the row both read "AI" until it closes.
+    fireEvent.keyDown(document, { key: 'Escape' });
     expect(screen.getByRole('button', { name: /AI/ })).toBeInTheDocument();
 
     // The one AI claim in Crypto is answered, published elsewhere, or otherwise leaves the

--- a/apps/web/core/debates/matchmaking/claims-tab.test.tsx
+++ b/apps/web/core/debates/matchmaking/claims-tab.test.tsx
@@ -424,7 +424,7 @@ describe('ClaimsTab', () => {
     fireEvent.click(screen.getByRole('button', { name: /Any space/ }));
 
     // Names resolve through useSpacesByIds, mocked empty here, so each offered space reads "Space".
-    expect(screen.getAllByRole('button', { name: /Space$/ })).toHaveLength(1);
+    expect(screen.getAllByRole('button', { name: /^Space/ })).toHaveLength(1);
   });
 
   // Same trimming-under-the-viewer problem the allowlist has, and the same answer: `null` does not
@@ -510,7 +510,7 @@ describe('ClaimsTab', () => {
     fireEvent.click(screen.getByRole('button', { name: /Any space/ }));
 
     // Names resolve through useSpacesByIds, mocked empty here, so every allowed space reads "Space".
-    expect(screen.getAllByRole('button', { name: /Space$/ })).toHaveLength(1);
+    expect(screen.getAllByRole('button', { name: /^Space/ })).toHaveLength(1);
   });
 
   // The allowlist runs over the loaded page, so a page can arrive with nothing left in it. With
@@ -581,7 +581,7 @@ describe('ClaimsTab', () => {
 
     fireEvent.click(option!);
 
-    expect(mocks.lastQuery).toMatchObject({ spaceId: null });
+    expect(mocks.lastQuery).toMatchObject({ spaceIds: null });
   });
 
   // A settled lookup that still can't name the space really does leave "Space" as the best label
@@ -596,7 +596,7 @@ describe('ClaimsTab', () => {
 
     expect(screen.queryByLabelText('Loading space name')).toBeNull();
     // The option's accessible name picks up its avatar initial, so it reads "SSpace".
-    expect(screen.getByRole('button', { name: /Space$/ })).toBeEnabled();
+    expect(screen.getByRole('button', { name: /^Space/ })).toBeEnabled();
   });
 
   // The same placeholder ran down every card in the list.
@@ -624,7 +624,7 @@ describe('ClaimsTab', () => {
 it('asks the server for the filter the viewer picked', () => {
   render(<ClaimsTab />);
 
-  expect(mocks.lastQuery).toMatchObject({ filter: 'all', spaceId: null });
+  expect(mocks.lastQuery).toMatchObject({ filter: 'all', spaceIds: null });
 
   fireEvent.click(screen.getByRole('button', { name: 'All claims' }));
   fireEvent.click(screen.getByRole('button', { name: 'Debate now' }));
@@ -654,8 +654,8 @@ describe('topic menu', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /Any topic/ }));
 
-    expect(screen.getByRole('button', { name: 'AI' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Health' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^AI/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^Health/ })).toBeInTheDocument();
   });
 
   it('drops the topics that have no claims in the picked space', () => {
@@ -666,9 +666,9 @@ describe('topic menu', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /Any topic/ }));
 
-    expect(screen.getByRole('button', { name: 'AI' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^AI/ })).toBeInTheDocument();
     // The reported bug: Health stayed on the menu, and picking it showed nothing at all.
-    expect(screen.queryByRole('button', { name: 'Health' })).toBeNull();
+    expect(screen.queryByRole('button', { name: /^Health/ })).toBeNull();
   });
 
   // The report that reopened this: filter to a space, and topics appeared only as you scrolled,
@@ -686,7 +686,7 @@ describe('topic menu', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /Any topic/ }));
 
-    expect(screen.getByRole('button', { name: 'AI' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^AI/ })).toBeInTheDocument();
   });
 
   // Without this the facet describes every space geo-chat knows, so a topic living only in a
@@ -732,7 +732,7 @@ describe('topic menu', () => {
 
     expect(screen.queryByText('Models are getting cheaper')).toBeNull();
     fireEvent.click(screen.getByRole('button', { name: /Any topic/ }));
-    expect(screen.queryByRole('button', { name: 'AI' })).toBeNull();
+    expect(screen.queryByRole('button', { name: /^AI/ })).toBeNull();
   });
 
   // Disabling the query is not the same as having no data: it keeps the previous key's pages,
@@ -744,7 +744,7 @@ describe('topic menu', () => {
     const view = render(<ClaimsTab />);
 
     fireEvent.click(screen.getByRole('button', { name: /Any topic/ }));
-    expect(screen.getByRole('button', { name: 'AI' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^AI/ })).toBeInTheDocument();
     fireEvent.keyDown(document, { key: 'Escape' });
 
     mocks.spaceAllowlist = new Set();
@@ -753,7 +753,7 @@ describe('topic menu', () => {
     // The list animates its rows out, so the card outlives the render that dropped it.
     await waitFor(() => expect(screen.queryByText('Models are getting cheaper')).toBeNull());
     fireEvent.click(screen.getByRole('button', { name: /Any topic/ }));
-    expect(screen.queryByRole('button', { name: 'AI' })).toBeNull();
+    expect(screen.queryByRole('button', { name: /^AI/ })).toBeNull();
   });
 
   it('sends the picked space alone, never alongside the eligible list', () => {
@@ -771,11 +771,11 @@ describe('topic menu', () => {
     render(<ClaimsTab />);
 
     fireEvent.click(screen.getByRole('button', { name: /Any topic/ }));
-    fireEvent.click(screen.getByRole('button', { name: 'AI' }));
+    fireEvent.click(screen.getByRole('button', { name: /^AI/ }));
 
     // Filtering here would only ever narrow the pages already loaded, which is the same bug in
     // the list that the menu had.
-    expect(mocks.lastQuery).toMatchObject({ topicId: AI.id });
+    expect(mocks.lastQuery).toMatchObject({ topicIds: [AI.id] });
   });
 
   // The scope goes out as `spaceIds`, and it isn't known until the allowlist and the publishable
@@ -791,8 +791,8 @@ describe('topic menu', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /Any topic/ }));
 
-    expect(screen.queryByRole('button', { name: 'AI' })).toBeNull();
-    expect(screen.queryByRole('button', { name: 'Health' })).toBeNull();
+    expect(screen.queryByRole('button', { name: /^AI/ })).toBeNull();
+    expect(screen.queryByRole('button', { name: /^Health/ })).toBeNull();
   });
 
   // Not reachable by picking one and then the other — each menu is narrowed by the other, so a
@@ -804,7 +804,7 @@ describe('topic menu', () => {
     fireEvent.click(screen.getByRole('button', { name: /Any space/ }));
     fireEvent.click(screen.getByRole('button', { name: /Crypto/ }));
     fireEvent.click(screen.getByRole('button', { name: /Any topic/ }));
-    fireEvent.click(screen.getByRole('button', { name: 'AI' }));
+    fireEvent.click(screen.getByRole('button', { name: /^AI/ }));
     expect(screen.getByRole('button', { name: /AI/ })).toBeInTheDocument();
 
     // The one AI claim in Crypto is answered, published elsewhere, or otherwise leaves the
@@ -827,7 +827,7 @@ describe('topic menu', () => {
     fireEvent.click(screen.getByRole('button', { name: /Any space/ }));
     fireEvent.click(screen.getByRole('button', { name: /Crypto/ }));
     fireEvent.click(screen.getByRole('button', { name: /Any topic/ }));
-    fireEvent.click(screen.getByRole('button', { name: 'AI' }));
+    fireEvent.click(screen.getByRole('button', { name: /^AI/ }));
 
     // The AI claim moves out of Crypto, so the AI-narrowed space facet no longer names it.
     mocks.claims = [claim('claim-ai', 'Models are getting cheaper', false, false, OTHER_SPACE_ID, [AI])];

--- a/apps/web/core/debates/matchmaking/claims-tab.tsx
+++ b/apps/web/core/debates/matchmaking/claims-tab.tsx
@@ -13,11 +13,11 @@ import type { MatchmakingClaimsFilter, MatchmakingClaimsQuery } from '../api';
 import { eligibleClaimSpaceIds, isClaimSpaceAllowed } from '../claim-space-allowlist';
 import { useClaimSpaceAllowlist } from '../use-claim-space-allowlist';
 import { isSpaceDebatePublishable, useDebatePublishableSpaces } from '../use-debate-publishable-spaces';
-import { HubFilterMenu, type HubFilterOption } from './hub-filter-menu';
+import { HubFilterMenu, type HubFilterOption, HubMultiFilterMenu } from './hub-filter-menu';
 import { HubCardList } from './hub-motion';
 import { HubQueryState } from './hub-states';
 import { MatchmakingClaimCard } from './matchmaking-claim-card';
-import { keepSelectableTopic } from './topic-facets';
+import { keepSelectableTopics, orderFacetOptions, toggleId } from './topic-facets';
 import { useScopedMatchmakingClaims } from './use-scoped-claims';
 import { useStableListOrder } from './use-stable-list-order';
 
@@ -44,8 +44,8 @@ export function ClaimsTab() {
   const [search, setSearch] = React.useState('');
   const [debouncedSearch, setDebouncedSearch] = React.useState('');
   const [filter, setFilter] = React.useState<MatchmakingClaimsFilter>('all');
-  const [spaceId, setSpaceId] = React.useState<string | null>(null);
-  const [topicId, setTopicId] = React.useState<string | null>(null);
+  const [spaceIds, setSpaceIds] = React.useState<string[]>([]);
+  const [topicIds, setTopicIds] = React.useState<string[]>([]);
 
   React.useEffect(() => {
     const timeout = setTimeout(() => setDebouncedSearch(search.trim()), SEARCH_DEBOUNCE_MS);
@@ -98,9 +98,9 @@ export function ClaimsTab() {
     [candidateSpaceIds, spaceShowsClaims]
   );
 
-  const query = React.useMemo<Omit<MatchmakingClaimsQuery, 'spaceIds'>>(
-    () => ({ search: debouncedSearch || null, spaceId, topicId, filter }),
-    [debouncedSearch, spaceId, topicId, filter]
+  const query = React.useMemo<Omit<MatchmakingClaimsQuery, 'spaceIds' | 'spaceId'>>(
+    () => ({ search: debouncedSearch || null, topicIds, filter }),
+    [debouncedSearch, topicIds, filter]
   );
 
   const scope = React.useMemo(
@@ -110,7 +110,7 @@ export function ClaimsTab() {
 
   // Every way the pages can describe a wider corpus than this tab will show is handled in there,
   // once, for both pickers — see `useScopedMatchmakingClaims`.
-  const claimsQuery = useScopedMatchmakingClaims(query, scope);
+  const claimsQuery = useScopedMatchmakingClaims(query, scope, spaceIds);
   const { pages, facets } = claimsQuery;
 
   const serverClaims = React.useMemo(
@@ -120,9 +120,16 @@ export function ClaimsTab() {
 
   // The space menu offers only what the list can actually show, so picking an option never lands
   // the viewer on an empty list they can't explain.
-  const facetSpaceIds = React.useMemo(
-    () => (facets?.space_ids ?? []).filter(spaceShowsClaims),
-    [facets?.space_ids, spaceShowsClaims]
+  // Ordered by count with the picked ones held at the top, so ticking one doesn't re-sort the
+  // list under the cursor. Zero-count options need no decision: both facets are a `GROUP BY` over
+  // the candidate set, so an option with nothing behind it is absent rather than present at zero.
+  const facetSpaces = React.useMemo(
+    () =>
+      orderFacetOptions(
+        (facets?.space_facets ?? []).filter(facet => spaceShowsClaims(facet.id)),
+        spaceIds
+      ),
+    [facets?.space_facets, spaceIds, spaceShowsClaims]
   );
 
   // The server re-sorts on every readiness change, so hold the order the user is looking at until
@@ -130,7 +137,7 @@ export function ClaimsTab() {
   const claims = useStableListOrder(
     serverClaims,
     entry => `${entry.claim.space_id}:${entry.claim.claim_entity_id}`,
-    `${debouncedSearch}|${spaceId ?? ''}|${topicId ?? ''}|${filter}`
+    `${debouncedSearch}|${spaceIds.join(',')}|${topicIds.join(',')}|${filter}`
   );
 
   // The topic menu, straight from the server. It describes every claim the current filters
@@ -142,11 +149,8 @@ export function ClaimsTab() {
   // name order here so this change is about which options exist rather than how they are
   // arranged; the count order and the counts themselves belong to GEO-2654.
   const facetTopics = React.useMemo(
-    () =>
-      [...(facets?.topic_facets ?? [])]
-        .map(facet => ({ id: facet.id, name: facet.name }))
-        .sort((a, b) => (a.name ?? '').localeCompare(b.name ?? '')),
-    [facets?.topic_facets]
+    () => orderFacetOptions(facets?.topic_facets ?? [], topicIds),
+    [facets?.topic_facets, topicIds]
   );
 
   const { facetsSettled } = claimsQuery;
@@ -168,16 +172,19 @@ export function ClaimsTab() {
   // cleared against them would be cleared on nothing.
   React.useEffect(() => {
     if (spacesPending) return;
-    setSpaceId(current => (current !== null && !spaceShowsClaims(current) ? null : current));
+    setSpaceIds(current => {
+      const kept = current.filter(spaceShowsClaims);
+      return kept.length === current.length ? current : kept;
+    });
   }, [spaceShowsClaims, spacesPending]);
 
   // Changing space with a topic held would otherwise leave the viewer filtered by a chip that is
   // no longer in the menu to unpick.
   React.useEffect(() => {
-    setTopicId(current => keepSelectableTopic(current, facetTopics, facetsSettled));
+    setTopicIds(current => keepSelectableTopics(current, facetTopics, facetsSettled));
   }, [facetTopics, facetsSettled]);
 
-  const hasFilters = Boolean(debouncedSearch || spaceId || topicId || filter !== 'all');
+  const hasFilters = Boolean(debouncedSearch || spaceIds.length || topicIds.length || filter !== 'all');
 
   const sentinelRef = useInfiniteScrollSentinel({
     hasNextPage: claimsQuery.hasNextPage,
@@ -197,11 +204,13 @@ export function ClaimsTab() {
         />
 
         <SpaceTopicFilters
-          spaceId={spaceId}
-          onSpaceChange={setSpaceId}
-          topicId={topicId}
-          onTopicChange={setTopicId}
-          facetSpaceIds={facetSpaceIds}
+          spaceIds={spaceIds}
+          onSpaceToggle={id => setSpaceIds(current => toggleId(current, id))}
+          onSpacesClear={() => setSpaceIds([])}
+          topicIds={topicIds}
+          onTopicToggle={id => setTopicIds(current => toggleId(current, id))}
+          onTopicsClear={() => setTopicIds([])}
+          facetSpaces={facetSpaces}
           facetTopics={facetTopics}
           leading={
             <HubFilterMenu
@@ -228,8 +237,8 @@ export function ClaimsTab() {
                   onClick: () => {
                     setSearch('');
                     setFilter('all');
-                    setSpaceId(null);
-                    setTopicId(null);
+                    setSpaceIds([]);
+                    setTopicIds([]);
                   },
                 }
               : undefined
@@ -284,13 +293,16 @@ export function HubStickyControls({ children }: { children: React.ReactNode }) {
 }
 
 type SpaceTopicFiltersProps = {
-  spaceId: string | null;
-  onSpaceChange: (spaceId: string | null) => void;
+  spaceIds: string[];
+  onSpaceToggle: (spaceId: string) => void;
+  onSpacesClear: () => void;
   /** Omit the topic props to hide the topic menu — requests carry no topics to facet on. */
-  topicId?: string | null;
-  onTopicChange?: (topicId: string | null) => void;
-  facetSpaceIds: string[];
-  facetTopics?: { id: string; name: string | null }[];
+  topicIds?: string[];
+  onTopicToggle?: (topicId: string) => void;
+  onTopicsClear?: () => void;
+  /** Ordered as they should be shown, and carrying the counts the rows display. */
+  facetSpaces: { id: string; count: number }[];
+  facetTopics?: { id: string; name: string | null; count: number }[];
   /** Rendered before the space filter — the Claims tab puts its position filter here. */
   leading?: React.ReactNode;
   /** Overrides the row layout — the rematch picker spreads the two menus across its width. */
@@ -304,66 +316,89 @@ type SpaceTopicFiltersProps = {
  * narrowed to the viewer's own spaces, which is exactly what the sidebar is holding.
  */
 export function SpaceTopicFilters({
-  spaceId,
-  onSpaceChange,
-  topicId,
-  onTopicChange,
-  facetSpaceIds,
+  spaceIds,
+  onSpaceToggle,
+  onSpacesClear,
+  topicIds,
+  onTopicToggle,
+  onTopicsClear,
+  facetSpaces,
   facetTopics,
   leading,
   className,
 }: SpaceTopicFiltersProps) {
+  const facetSpaceIds = React.useMemo(() => facetSpaces.map(space => space.id), [facetSpaces]);
   const { labelsById, isLoading: labelsLoading } = useSpaceLabels(facetSpaceIds);
 
   const spaceOptions = React.useMemo<HubFilterOption<string>[]>(
-    () => [
-      { value: '', label: 'Any space', showImage: false },
-      ...facetSpaceIds.map(id => {
-        const label = spaceLabel(labelsById, id);
+    () =>
+      facetSpaces.map(space => {
+        const label = spaceLabel(labelsById, space.id);
         return {
-          value: id,
+          value: space.id,
           // A settled lookup that still can't name the space really does leave "Space" as the best
           // label there is; only a name still on its way draws as a skeleton.
           label: label?.name ?? 'Space',
           image: label?.image ?? null,
           pending: !label && labelsLoading,
+          count: space.count,
         };
       }),
-    ],
-    [facetSpaceIds, labelsById, labelsLoading]
+    [facetSpaces, labelsById, labelsLoading]
   );
 
   const topicOptions = React.useMemo<HubFilterOption<string>[]>(
-    () => [
-      { value: '', label: 'Any topic' },
-      ...(facetTopics ?? []).map(topic => ({ value: topic.id, label: topic.name ?? 'Topic' })),
-    ],
+    () => (facetTopics ?? []).map(topic => ({ value: topic.id, label: topic.name ?? 'Topic', count: topic.count })),
     [facetTopics]
   );
 
-  const selectedSpace = spaceId ? spaceLabel(labelsById, spaceId) : undefined;
-  const selectedSpaceLabel = spaceId ? (selectedSpace?.name ?? 'Space') : 'Any space';
-  const topicLabel = topicId ? (facetTopics?.find(topic => topic.id === topicId)?.name ?? 'Topic') : 'Any topic';
+  const onlySpace = spaceIds.length === 1 ? spaceLabel(labelsById, spaceIds[0]) : undefined;
+  const spaceMenuLabel = pickerLabel(
+    spaceIds.length,
+    'Any space',
+    () => onlySpace?.name ?? 'Space',
+    count => `${count} spaces`
+  );
+  const topicMenuLabel = pickerLabel(
+    topicIds?.length ?? 0,
+    'Any topic',
+    () => facetTopics?.find(topic => topic.id === topicIds?.[0])?.name ?? 'Topic',
+    count => `${count} topics`
+  );
 
   return (
     <div className={cx('flex flex-wrap items-center gap-2', className)}>
       {leading}
-      <HubFilterMenu
-        label={selectedSpaceLabel}
-        labelPending={Boolean(spaceId) && !selectedSpace && labelsLoading}
+      <HubMultiFilterMenu
+        label={spaceMenuLabel}
+        labelPending={spaceIds.length === 1 && !onlySpace && labelsLoading}
         options={spaceOptions}
-        value={spaceId ?? ''}
-        onChange={value => onSpaceChange(value || null)}
+        values={spaceIds}
+        onToggle={onSpaceToggle}
+        onClear={onSpacesClear}
+        clearLabel="Any space"
         showImages
       />
-      {facetTopics && onTopicChange ? (
-        <HubFilterMenu
-          label={topicLabel}
+      {facetTopics && topicIds && onTopicToggle && onTopicsClear ? (
+        <HubMultiFilterMenu
+          label={topicMenuLabel}
           options={topicOptions}
-          value={topicId ?? ''}
-          onChange={value => onTopicChange(value || null)}
+          values={topicIds}
+          onToggle={onTopicToggle}
+          onClear={onTopicsClear}
+          clearLabel="Any topic"
         />
       ) : null}
     </div>
   );
+}
+
+/**
+ * What the trigger pill says. One selection reads as its own name — the useful case, and the one
+ * the viewer is most often in — while several collapse to a count, because two names rarely fit
+ * and a truncated pair reads as one bad name.
+ */
+function pickerLabel(count: number, empty: string, single: () => string, many: (count: number) => string) {
+  if (count === 0) return empty;
+  return count === 1 ? single() : many(count);
 }

--- a/apps/web/core/debates/matchmaking/claims-tab.tsx
+++ b/apps/web/core/debates/matchmaking/claims-tab.tsx
@@ -37,7 +37,7 @@ import { HubFilterMenu, type HubFilterOption, HubMultiFilterMenu } from './hub-f
 import { HubCardList } from './hub-motion';
 import { HubQueryState } from './hub-states';
 import { MatchmakingClaimCard } from './matchmaking-claim-card';
-import { countBy, keepSelectableTopics, orderFacetOptions, toggleId } from './topic-facets';
+import { countBy, keepSelectableTopics, keepSelectedVisible, orderFacetOptions, toggleId } from './topic-facets';
 import { useScopedMatchmakingClaims } from './use-scoped-claims';
 import { useStableListOrder } from './use-stable-list-order';
 
@@ -281,7 +281,7 @@ export function ClaimsTab() {
     const source = featured
       ? countBy(featuredAllowed.map(claim => ({ id: claim.spaceId, name: null })))
       : (facets?.space_facets ?? []).filter(facet => spaceShowsClaims(facet.id));
-    return orderFacetOptions(source, spaceIds);
+    return orderFacetOptions(keepSelectedVisible(source, spaceIds), spaceIds);
   }, [facets?.space_facets, featured, featuredAllowed, spaceIds, spaceShowsClaims]);
 
   // The server re-sorts on every readiness change, so hold the order the user is looking at until

--- a/apps/web/core/debates/matchmaking/claims-tab.tsx
+++ b/apps/web/core/debates/matchmaking/claims-tab.tsx
@@ -185,14 +185,24 @@ export function ClaimsTab() {
 
   // Search and the space menu run over the loaded list. The server-side versions belong to
   // geo-chat's index, which knows nothing about this list.
-  const featuredMatching = React.useMemo(() => {
+  // Search only, deliberately. The space facet counts claims *outside* the picked spaces — no facet
+  // is narrowed by its own dimension — and to narrow it by topic instead, those claims' topics have
+  // to be resolvable. So the entity lookup below runs over this set rather than the space-filtered
+  // one, and picking a space no longer decides which topics the client can see.
+  const featuredSearched = React.useMemo(() => {
     const needle = debouncedSearch.toLowerCase();
-    return featuredAllowed.filter(
-      claim =>
-        (spaceIds.length === 0 || spaceIds.some(id => ID.equals(claim.spaceId, id))) &&
-        (needle === '' || claim.name.toLowerCase().includes(needle))
-    );
-  }, [debouncedSearch, featuredAllowed, spaceIds]);
+    return needle === '' ? featuredAllowed : featuredAllowed.filter(claim => claim.name.toLowerCase().includes(needle));
+  }, [debouncedSearch, featuredAllowed]);
+
+  const inPickedSpace = React.useCallback(
+    (spaceId: string) => spaceIds.length === 0 || spaceIds.some(id => ID.equals(spaceId, id)),
+    [spaceIds]
+  );
+
+  const featuredMatching = React.useMemo(
+    () => featuredSearched.filter(claim => inPickedSpace(claim.spaceId)),
+    [featuredSearched, inPickedSpace]
+  );
 
   // The sides and readiness the cards draw are geo-chat's, and its only lookup for claims it hasn't
   // ranked is the per-space one — so the tagged claims are asked for by id, grouped by the space
@@ -212,8 +222,8 @@ export function ClaimsTab() {
   // and slices to them. It asks in batches of a hundred and pulls six fields instead of every value
   // and relation on the entity.
   const featuredEntityIds = React.useMemo(
-    () => [...new Set(featuredMatching.map(claim => claim.claimEntityId).filter(validateEntityId))],
-    [featuredMatching]
+    () => [...new Set(featuredSearched.map(claim => claim.claimEntityId).filter(validateEntityId))],
+    [featuredSearched]
   );
   const { entities: featuredEntities, isLoading: featuredEntitiesLoading } = useClaimEntitiesByIds(featuredEntityIds);
 
@@ -269,6 +279,15 @@ export function ClaimsTab() {
     return map;
   }, [featured, featuredEntities]);
 
+  // Whether a claim survives the topic filter, by the same rule the rows use. Defined here because
+  // the space facet needs it over claims the rows have already dropped.
+  const carriesPickedTopic = React.useCallback(
+    (claimEntityId: string) =>
+      topicIds.length === 0 ||
+      (featuredTopicsByClaimId.get(claimEntityId) ?? []).some(topic => topicIds.includes(topic.id)),
+    [featuredTopicsByClaimId, topicIds]
+  );
+
   // The space menu offers only what the list can actually show, so picking an option never lands
   // the viewer on an empty list they can't explain.
   // Ordered by count with the picked ones held at the top, so ticking one doesn't re-sort the list
@@ -279,10 +298,14 @@ export function ClaimsTab() {
   // would leave that one option in the menu.
   const facetSpaces = React.useMemo(() => {
     const source = featured
-      ? countBy(featuredAllowed.map(claim => ({ id: claim.spaceId, name: null })))
+      ? countBy(
+          featuredSearched
+            .filter(claim => carriesPickedTopic(claim.claimEntityId))
+            .map(claim => ({ id: claim.spaceId, name: null }))
+        )
       : (facets?.space_facets ?? []).filter(facet => spaceShowsClaims(facet.id));
     return orderFacetOptions(keepSelectedVisible(source, spaceIds), spaceIds);
-  }, [facets?.space_facets, featured, featuredAllowed, spaceIds, spaceShowsClaims]);
+  }, [carriesPickedTopic, facets?.space_facets, featured, featuredSearched, spaceIds, spaceShowsClaims]);
 
   // The server re-sorts on every readiness change, so hold the order the user is looking at until
   // they ask for a different list.
@@ -315,10 +338,17 @@ export function ClaimsTab() {
     // Counting the featured claims per topic rather than deduping them: a count is the point of
     // the menu now, and the claims in hand are the whole featured list.
     const source = featured
-      ? countBy([...featuredTopicsByClaimId.values()].flat().map(topic => ({ id: topic.id, name: topic.name })))
+      ? countBy(
+          featuredMatching.flatMap(claim =>
+            (featuredTopicsByClaimId.get(claim.claimEntityId) ?? []).map(topic => ({
+              id: topic.id,
+              name: topic.name,
+            }))
+          )
+        )
       : (facets?.topic_facets ?? []);
     return orderFacetOptions(source, topicIds);
-  }, [facets?.topic_facets, featured, featuredTopicsByClaimId, topicIds]);
+  }, [facets?.topic_facets, featured, featuredMatching, featuredTopicsByClaimId, topicIds]);
 
   // Featured's menu settles with its entity lookup, which is where its topics come from — the
   // server facets it would otherwise read never arrive, since the query is never made.

--- a/apps/web/core/debates/matchmaking/hub-filter-menu.tsx
+++ b/apps/web/core/debates/matchmaking/hub-filter-menu.tsx
@@ -3,12 +3,15 @@
 import * as React from 'react';
 
 import { SmallButton } from '~/design-system/button';
+import { CheckboxVisual } from '~/design-system/checkbox';
 import { ThumbGeoImage } from '~/design-system/geo-image';
 import { ChevronDownSmall } from '~/design-system/icons/chevron-down-small';
 import { TickSmall } from '~/design-system/icons/tick-small';
 import { Menu } from '~/design-system/menu';
 import { Skeleton } from '~/design-system/skeleton';
 import { Text } from '~/design-system/text';
+
+import { formatFacetCount } from './topic-facets';
 
 export type HubFilterOption<T extends string> = {
   value: T;
@@ -17,6 +20,8 @@ export type HubFilterOption<T extends string> = {
   showImage?: boolean;
   /** This option's label hasn't arrived yet — draw it as a skeleton and don't let it be picked. */
   pending?: boolean;
+  /** How many claims this option would leave, given every other filter currently applied. */
+  count?: number;
 };
 
 type Props<T extends string> = {
@@ -109,6 +114,124 @@ export function HubFilterMenu<T extends string>({
                 <TickSmall />
               </span>
             ) : null}
+          </button>
+        ))}
+      </>
+    </Menu>
+  );
+}
+
+type MultiProps<T extends string> = {
+  /** Shown in the trigger pill: the one selected name, a count of them, or the "any" wording. */
+  label: string;
+  options: HubFilterOption<T>[];
+  values: T[];
+  onToggle: (value: T) => void;
+  /** Clears every selection — the row that reads "Any space" / "Any topic". */
+  onClear: () => void;
+  clearLabel: string;
+  showImages?: boolean;
+  labelPending?: boolean;
+};
+
+/**
+ * The multi-select twin of {@link HubFilterMenu}: checkboxes, and the menu stays open so several
+ * can be picked in one visit.
+ *
+ * Counts sit at the end of each row and describe what that option would leave given every *other*
+ * filter — geo-chat counts each dimension without narrowing itself, so a topic's count answers
+ * "how many of the claims I'm already looking at carry this", and ticking one never changes the
+ * numbers in its own menu.
+ */
+export function HubMultiFilterMenu<T extends string>({
+  label,
+  options,
+  values,
+  onToggle,
+  onClear,
+  clearLabel,
+  showImages,
+  labelPending,
+}: MultiProps<T>) {
+  const [open, setOpen] = React.useState(false);
+  const selected = new Set<string>(values);
+
+  return (
+    <Menu
+      open={open}
+      onOpenChange={setOpen}
+      asChild
+      className="max-w-[280px]"
+      trigger={
+        <SmallButton icon={<ChevronDownSmall />} className="max-w-[160px]">
+          {labelPending ? (
+            <Skeleton className="h-[1em] w-16" aria-label="Loading space name" />
+          ) : (
+            <span className="truncate">{label}</span>
+          )}
+        </SmallButton>
+      }
+    >
+      <>
+        <button
+          type="button"
+          onClick={() => {
+            onClear();
+            setOpen(false);
+          }}
+          className="flex w-full cursor-pointer items-center gap-2 bg-white px-3 py-2.5 text-left hover:bg-bg"
+        >
+          <Text variant="button" className="truncate hover:text-text!">
+            {clearLabel}
+          </Text>
+          {values.length === 0 ? (
+            <span className="ml-auto shrink-0">
+              <TickSmall />
+            </span>
+          ) : null}
+        </button>
+        {options.map(option => (
+          <button
+            key={option.value}
+            type="button"
+            disabled={option.pending}
+            // No `setOpen(false)`: the point of multi-select is picking more than one, and closing
+            // on the first tick would make the second a whole new trip through the trigger.
+            onClick={() => onToggle(option.value)}
+            className="flex w-full cursor-pointer items-center gap-2 bg-white px-3 py-2.5 text-left hover:bg-bg disabled:cursor-default disabled:hover:bg-white"
+          >
+            <span className="shrink-0">
+              <CheckboxVisual checked={selected.has(option.value)} />
+            </span>
+            {showImages && option.showImage !== false ? (
+              option.pending ? (
+                <Skeleton className="h-5 w-5 shrink-0 rounded-md" />
+              ) : option.image ? (
+                <span className="relative h-5 w-5 shrink-0 overflow-hidden rounded-md">
+                  <ThumbGeoImage value={option.image} alt="" />
+                </span>
+              ) : (
+                <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-md bg-grey-01 text-[10px] font-medium text-grey-04">
+                  {(option.label.trim().slice(0, 1).toUpperCase() || '?').replace(/[^A-Z0-9?]/g, '?')}
+                </span>
+              )
+            ) : null}
+            {option.pending ? (
+              <Skeleton
+                className="h-[1em] flex-1"
+                style={{ maxWidth: pendingLabelWidth(option.value) }}
+                aria-label="Loading space name"
+              />
+            ) : (
+              <Text variant="button" className="truncate hover:text-text!">
+                {option.label}
+              </Text>
+            )}
+            {option.count === undefined ? null : (
+              <Text variant="footnote" className="ml-auto shrink-0 text-grey-04!">
+                {formatFacetCount(option.count)}
+              </Text>
+            )}
           </button>
         ))}
       </>

--- a/apps/web/core/debates/matchmaking/hub-filter-menu.tsx
+++ b/apps/web/core/debates/matchmaking/hub-filter-menu.tsx
@@ -195,6 +195,9 @@ export function HubMultiFilterMenu<T extends string>({
             key={option.value}
             type="button"
             disabled={option.pending}
+            // The checkbox is a graphic, and `aria-hidden` at that, so without this the row reads as
+            // an ordinary button and nothing says whether it is picked.
+            aria-pressed={selected.has(option.value)}
             // No `setOpen(false)`: the point of multi-select is picking more than one, and closing
             // on the first tick would make the second a whole new trip through the trigger.
             onClick={() => onToggle(option.value)}

--- a/apps/web/core/debates/matchmaking/matches-tab.tsx
+++ b/apps/web/core/debates/matchmaking/matches-tab.tsx
@@ -13,6 +13,7 @@ import { HubPillButton } from './hub-pill-button';
 import { HubQueryState } from './hub-states';
 import { MatchmakingClaimCard } from './matchmaking-claim-card';
 import { OutboundRequestCard } from './outbound-request-card';
+import { countBy, orderFacetOptions, toggleId } from './topic-facets';
 import { useStableListOrder } from './use-stable-list-order';
 import type { DebatesHubTab } from '~/atoms';
 
@@ -25,7 +26,7 @@ import type { DebatesHubTab } from '~/atoms';
  * tab filters by space only.
  */
 export function MatchesTab({ onTabChange }: { onTabChange: (tab: DebatesHubTab) => void }) {
-  const [spaceId, setSpaceId] = React.useState<string | null>(null);
+  const [spaceIds, setSpaceIds] = React.useState<string[]>([]);
 
   const matchesQuery = useMatchmakingMatches(true);
   const requestsQuery = useDebateRequests(true);
@@ -38,17 +39,19 @@ export function MatchesTab({ onTabChange }: { onTabChange: (tab: DebatesHubTab) 
   const matches = useStableListOrder(
     serverMatches,
     match => `${match.claim.space_id}:${match.claim.claim_entity_id}`,
-    spaceId ?? ''
+    spaceIds.join(',')
   );
 
-  const facetSpaceIds = React.useMemo(
-    () => [...new Set(serverMatches.map(match => match.claim.space_id))],
-    [serverMatches]
+  // Counted from the matches themselves — this tab has no server facet, and the whole list is in
+  // hand, so the rows are the complete answer.
+  const facetSpaces = React.useMemo(
+    () => orderFacetOptions(countBy(serverMatches.map(match => ({ id: match.claim.space_id, name: null }))), spaceIds),
+    [serverMatches, spaceIds]
   );
 
   const filtered = React.useMemo(
-    () => matches.filter(match => !spaceId || match.claim.space_id === spaceId),
-    [matches, spaceId]
+    () => matches.filter(match => spaceIds.length === 0 || spaceIds.includes(match.claim.space_id)),
+    [matches, spaceIds]
   );
 
   return (
@@ -58,7 +61,12 @@ export function MatchesTab({ onTabChange }: { onTabChange: (tab: DebatesHubTab) 
           couldn't be offset by a known height. */}
       <HubStickyControls>
         {outbound ? <OutboundRequestCard request={outbound} /> : null}
-        <SpaceTopicFilters spaceId={spaceId} onSpaceChange={setSpaceId} facetSpaceIds={facetSpaceIds} />
+        <SpaceTopicFilters
+          spaceIds={spaceIds}
+          onSpaceToggle={id => setSpaceIds(current => toggleId(current, id))}
+          onSpacesClear={() => setSpaceIds([])}
+          facetSpaces={facetSpaces}
+        />
       </HubStickyControls>
 
       <div className="flex flex-col gap-3 px-4 py-3">

--- a/apps/web/core/debates/matchmaking/requests-tab.tsx
+++ b/apps/web/core/debates/matchmaking/requests-tab.tsx
@@ -57,19 +57,18 @@ export function RequestsTab() {
   const sent = status === 'received' || !outbound || !inSpace(outbound.claim.space_id) ? null : outbound;
 
   // No server facet here either: the requests in hand are the whole list.
-  const facetSpaces = React.useMemo(
-    () =>
-      orderFacetOptions(
-        countBy(
-          [...(outbound ? [outbound.claim.space_id] : []), ...incoming.map(r => r.claim.space_id)].map(id => ({
-            id,
-            name: null,
-          }))
-        ),
-        spaceIds
-      ),
-    [incoming, outbound, spaceIds]
-  );
+  //
+  // Counted under the status filter, not across both directions. A count has to describe what
+  // picking the option would leave, and status is one of the filters that decides that — so with
+  // "Awaiting response" showing, a space that only appears in received requests would otherwise
+  // carry a number over a list it cannot fill.
+  const facetSpaces = React.useMemo(() => {
+    const spaces = [
+      ...(outbound && status !== 'received' ? [outbound.claim.space_id] : []),
+      ...(status === 'sent' ? [] : incoming.map(request => request.claim.space_id)),
+    ];
+    return orderFacetOptions(countBy(spaces.map(id => ({ id, name: null }))), spaceIds);
+  }, [incoming, outbound, spaceIds, status]);
 
   // The claimless challenge sits alongside claim requests: it expires the same way, and "Not now"
   // in its popup leaves it here rather than answering it.

--- a/apps/web/core/debates/matchmaking/requests-tab.tsx
+++ b/apps/web/core/debates/matchmaking/requests-tab.tsx
@@ -14,6 +14,7 @@ import { HubCardList } from './hub-motion';
 import { HubQueryState } from './hub-states';
 import { IncomingRequestCard } from './incoming-request-card';
 import { OutboundRequestCard } from './outbound-request-card';
+import { countBy, orderFacetOptions, toggleId } from './topic-facets';
 import { useUnexpiredRequests } from './use-request-countdown';
 
 type RequestStatusFilter = 'all' | 'sent' | 'received';
@@ -35,7 +36,7 @@ const STATUS_OPTIONS: HubFilterOption<RequestStatusFilter>[] = [
  * concern, so the design's third menu has nothing to offer here.)
  */
 export function RequestsTab() {
-  const [spaceId, setSpaceId] = React.useState<string | null>(null);
+  const [spaceIds, setSpaceIds] = React.useState<string[]>([]);
   const [status, setStatus] = React.useState<RequestStatusFilter>('all');
 
   const requestsQuery = useDebateRequests(true);
@@ -44,7 +45,10 @@ export function RequestsTab() {
   const incoming = useUnexpiredRequests(requestsQuery.data?.incoming ?? []);
   const outbound = requestsQuery.data?.outbound ?? activity?.outbound_request ?? null;
 
-  const inSpace = React.useCallback((requestSpaceId: string) => !spaceId || requestSpaceId === spaceId, [spaceId]);
+  const inSpace = React.useCallback(
+    (requestSpaceId: string) => spaceIds.length === 0 || spaceIds.includes(requestSpaceId),
+    [spaceIds]
+  );
 
   const received = React.useMemo(
     () => (status === 'sent' ? [] : incoming.filter(request => inSpace(request.claim.space_id))),
@@ -52,9 +56,19 @@ export function RequestsTab() {
   );
   const sent = status === 'received' || !outbound || !inSpace(outbound.claim.space_id) ? null : outbound;
 
-  const facetSpaceIds = React.useMemo(
-    () => [...new Set([...(outbound ? [outbound.claim.space_id] : []), ...incoming.map(r => r.claim.space_id)])],
-    [incoming, outbound]
+  // No server facet here either: the requests in hand are the whole list.
+  const facetSpaces = React.useMemo(
+    () =>
+      orderFacetOptions(
+        countBy(
+          [...(outbound ? [outbound.claim.space_id] : []), ...incoming.map(r => r.claim.space_id)].map(id => ({
+            id,
+            name: null,
+          }))
+        ),
+        spaceIds
+      ),
+    [incoming, outbound, spaceIds]
   );
 
   // The claimless challenge sits alongside claim requests: it expires the same way, and "Not now"
@@ -69,7 +83,7 @@ export function RequestsTab() {
   // undecided until the viewer's id is known — guessing files an incoming challenge under Sent,
   // where it reads as something the viewer sent and offers them "Cancel request" for it.
   const challengeRole =
-    !challenge || spaceId || !currentUserId
+    !challenge || spaceIds.length > 0 || !currentUserId
       ? null
       : challenge.recipient.user_id === currentUserId
         ? 'recipient'
@@ -77,16 +91,17 @@ export function RequestsTab() {
   const incomingChallenge = challengeRole === 'recipient' && status !== 'sent' ? challenge : null;
   const outgoingChallenge = challengeRole === 'requester' && status !== 'received' ? challenge : null;
 
-  const hasFilters = Boolean(spaceId) || status !== 'all';
+  const hasFilters = spaceIds.length > 0 || status !== 'all';
   const isEmpty = !sent && !outgoingChallenge && received.length === 0 && !incomingChallenge;
 
   return (
     <div className="flex flex-col">
       <HubStickyControls>
         <SpaceTopicFilters
-          spaceId={spaceId}
-          onSpaceChange={setSpaceId}
-          facetSpaceIds={facetSpaceIds}
+          spaceIds={spaceIds}
+          onSpaceToggle={id => setSpaceIds(current => toggleId(current, id))}
+          onSpacesClear={() => setSpaceIds([])}
+          facetSpaces={facetSpaces}
           leading={
             <HubFilterMenu
               label={STATUS_OPTIONS.find(option => option.value === status)?.label ?? 'Any status'}
@@ -100,48 +115,48 @@ export function RequestsTab() {
 
       <div className="flex flex-col gap-3 px-4 py-3">
         <HubQueryState
-        isLoading={requestsQuery.isLoading}
-        error={requestsQuery.error}
-        onRetry={() => void requestsQuery.refetch()}
-        isEmpty={isEmpty}
-        emptyMessage={
-          hasFilters ? 'No requests match these filters.' : 'Any debate requests you’ll receive will appear here.'
-        }
-        emptyAction={
-          hasFilters
-            ? {
-                label: 'Clear filters',
-                onClick: () => {
-                  setSpaceId(null);
-                  setStatus('all');
-                },
-              }
-            : undefined
-        }
-      >
-        <div className="flex flex-col gap-4">
-          {sent || outgoingChallenge ? (
-            <RequestSection label="Sent">
-              <div className="flex flex-col gap-2">
-                {outgoingChallenge ? <DebateChallengeCard challenge={outgoingChallenge} role="requester" /> : null}
-                <HubCardList>{sent ? <OutboundRequestCard key={sent.id} request={sent} /> : null}</HubCardList>
-              </div>
-            </RequestSection>
-          ) : null}
+          isLoading={requestsQuery.isLoading}
+          error={requestsQuery.error}
+          onRetry={() => void requestsQuery.refetch()}
+          isEmpty={isEmpty}
+          emptyMessage={
+            hasFilters ? 'No requests match these filters.' : 'Any debate requests you’ll receive will appear here.'
+          }
+          emptyAction={
+            hasFilters
+              ? {
+                  label: 'Clear filters',
+                  onClick: () => {
+                    setSpaceIds([]);
+                    setStatus('all');
+                  },
+                }
+              : undefined
+          }
+        >
+          <div className="flex flex-col gap-4">
+            {sent || outgoingChallenge ? (
+              <RequestSection label="Sent">
+                <div className="flex flex-col gap-2">
+                  {outgoingChallenge ? <DebateChallengeCard challenge={outgoingChallenge} role="requester" /> : null}
+                  <HubCardList>{sent ? <OutboundRequestCard key={sent.id} request={sent} /> : null}</HubCardList>
+                </div>
+              </RequestSection>
+            ) : null}
 
-          {incomingChallenge || received.length > 0 ? (
-            <RequestSection label="Received">
-              <div className="flex flex-col gap-2">
-                {incomingChallenge ? <DebateChallengeCard challenge={incomingChallenge} role="recipient" /> : null}
-                <HubCardList>
-                  {received.map(request => (
-                    <IncomingRequestCard key={request.id} request={request} />
-                  ))}
-                </HubCardList>
-              </div>
-            </RequestSection>
-          ) : null}
-        </div>
+            {incomingChallenge || received.length > 0 ? (
+              <RequestSection label="Received">
+                <div className="flex flex-col gap-2">
+                  {incomingChallenge ? <DebateChallengeCard challenge={incomingChallenge} role="recipient" /> : null}
+                  <HubCardList>
+                    {received.map(request => (
+                      <IncomingRequestCard key={request.id} request={request} />
+                    ))}
+                  </HubCardList>
+                </div>
+              </RequestSection>
+            ) : null}
+          </div>
         </HubQueryState>
       </div>
     </div>

--- a/apps/web/core/debates/matchmaking/topic-facets.test.ts
+++ b/apps/web/core/debates/matchmaking/topic-facets.test.ts
@@ -2,7 +2,13 @@ import { describe, expect, it } from 'vitest';
 
 import type { MatchmakingTopic } from '~/core/debates/api';
 
-import { availableTopics, keepSelectableTopic } from './topic-facets';
+import {
+  availableTopics,
+  formatFacetCount,
+  keepSelectableTopic,
+  keepSelectableTopics,
+  orderFacetOptions,
+} from './topic-facets';
 
 const ai: MatchmakingTopic = { id: 'topic-ai', name: 'AI' };
 const health: MatchmakingTopic = { id: 'topic-health', name: 'Health' };
@@ -69,5 +75,64 @@ describe('keepSelectableTopic', () => {
 
   it('leaves an empty selection alone', () => {
     expect(keepSelectableTopic(null, [ai], true)).toBeNull();
+  });
+});
+
+describe('keepSelectableTopics', () => {
+  const AI = { id: 'ai', name: 'AI' };
+  const HEALTH = { id: 'health', name: 'Health' };
+
+  it('drops only the selections the menu no longer offers', () => {
+    expect(keepSelectableTopics(['ai', 'health'], [AI], true)).toEqual(['ai']);
+  });
+
+  it('holds every selection while the menu is unresolved', () => {
+    expect(keepSelectableTopics(['ai', 'health'], [], false)).toEqual(['ai', 'health']);
+  });
+
+  // Returned by identity when nothing is dropped, so feeding the result back into state can't
+  // loop on a fresh array every render.
+  it('returns the same array when everything is still offered', () => {
+    const selected = ['ai', 'health'];
+    expect(keepSelectableTopics(selected, [AI, HEALTH], true)).toBe(selected);
+  });
+});
+
+describe('orderFacetOptions', () => {
+  const options = [
+    { id: 'a', count: 1 },
+    { id: 'b', count: 9 },
+    { id: 'c', count: 5 },
+  ];
+
+  it('orders by count, descending', () => {
+    expect(orderFacetOptions(options, []).map(o => o.id)).toEqual(['b', 'c', 'a']);
+  });
+
+  // Otherwise ticking one re-sorts the list under the cursor, and the row just clicked moves
+  // before the next click lands.
+  it('holds selected options at the top, whatever their count', () => {
+    expect(orderFacetOptions(options, ['a']).map(o => o.id)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('keeps equal counts in a stable order rather than whatever order they arrived in', () => {
+    const tied = [
+      { id: 'z', count: 3 },
+      { id: 'y', count: 3 },
+    ];
+    expect(orderFacetOptions(tied, []).map(o => o.id)).toEqual(['y', 'z']);
+  });
+});
+
+describe('formatFacetCount', () => {
+  it('shows small counts exactly', () => {
+    expect(formatFacetCount(7)).toBe('7');
+    expect(formatFacetCount(99)).toBe('99');
+  });
+
+  // A narrow panel sizes every row to the widest number in it.
+  it('caps anything past two digits', () => {
+    expect(formatFacetCount(100)).toBe('99+');
+    expect(formatFacetCount(4210)).toBe('99+');
   });
 });

--- a/apps/web/core/debates/matchmaking/topic-facets.test.ts
+++ b/apps/web/core/debates/matchmaking/topic-facets.test.ts
@@ -7,6 +7,7 @@ import {
   formatFacetCount,
   keepSelectableTopic,
   keepSelectableTopics,
+  keepSelectedVisible,
   orderFacetOptions,
 } from './topic-facets';
 
@@ -134,5 +135,25 @@ describe('formatFacetCount', () => {
   it('caps anything past two digits', () => {
     expect(formatFacetCount(100)).toBe('99+');
     expect(formatFacetCount(4210)).toBe('99+');
+  });
+});
+
+describe('keepSelectedVisible', () => {
+  const options = [{ id: 'a', name: 'A', count: 2 }];
+
+  it('leaves options that were never selected absent', () => {
+    expect(keepSelectedVisible(options, []).map(o => o.id)).toEqual(['a']);
+  });
+
+  // Without this the checkbox vanishes while the trigger goes on counting the selection, and the
+  // only way to remove it is to clear every space.
+  it('brings a selection that fell out of the facet back at zero', () => {
+    const kept = keepSelectedVisible(options, ['a', 'b']);
+    expect(kept.map(o => o.id)).toEqual(['a', 'b']);
+    expect(kept.find(o => o.id === 'b')?.count).toBe(0);
+  });
+
+  it('returns the same array when nothing is missing', () => {
+    expect(keepSelectedVisible(options, ['a'])).toBe(options);
   });
 });

--- a/apps/web/core/debates/matchmaking/topic-facets.ts
+++ b/apps/web/core/debates/matchmaking/topic-facets.ts
@@ -55,3 +55,99 @@ export function keepSelectableTopic(
   if (topicId === null || !isResolved) return topicId;
   return available.some(topic => topic.id === topicId) ? topicId : null;
 }
+
+/**
+ * The topics that should stay selected once `available` has changed under them.
+ *
+ * The multi-select form of {@link keepSelectableTopic}, and the same rule: a selection the menu no
+ * longer offers is a chip the viewer cannot unpick from the menu it came from. Returns the input
+ * unchanged while unresolved, and the same array when nothing is dropped, so it is safe to feed
+ * straight back into state without looping.
+ */
+export function keepSelectableTopics(topicIds: string[], available: MatchmakingTopic[], isResolved: boolean): string[] {
+  if (topicIds.length === 0 || !isResolved) return topicIds;
+  const offered = new Set(available.map(topic => topic.id));
+  const kept = topicIds.filter(id => offered.has(id));
+  return kept.length === topicIds.length ? topicIds : kept;
+}
+
+/**
+ * How a count reads in a menu row. Anything past two digits is noise in a narrow panel — the
+ * viewer is choosing between "lots" and "a few", not counting — and an unbounded number widens
+ * every row to fit the largest.
+ */
+export function formatFacetCount(count: number): string {
+  return count > 99 ? '99+' : String(count);
+}
+
+/**
+ * Menu options in the order they should be shown: by count, descending, with anything currently
+ * selected held at the top.
+ *
+ * Count order is what the ticket asks for, and pinning is what makes it usable. Without it, ticking
+ * an option re-sorts the list under the cursor — every count changes when the filter does, so the
+ * row just clicked can jump elsewhere before the next click lands. Pinned, the things being worked
+ * with stay put and the ordering applies to what's left.
+ */
+export function orderFacetOptions<T extends { id: string; count: number }>(options: T[], selected: string[]): T[] {
+  const picked = new Set(selected);
+  return [...options].sort((a, b) => {
+    const aPicked = picked.has(a.id);
+    const bPicked = picked.has(b.id);
+    if (aPicked !== bPicked) return aPicked ? -1 : 1;
+    if (a.count !== b.count) return b.count - a.count;
+    return a.id.localeCompare(b.id);
+  });
+}
+
+/**
+ * A selection with `id` added or removed.
+ *
+ * Appends rather than inserting in menu order: the menu is ordered by count and re-orders as the
+ * filter changes, so there is no position here worth preserving — while the order things were
+ * picked in is at least the viewer's own.
+ */
+export function toggleId(selected: string[], id: string): string[] {
+  return selected.includes(id) ? selected.filter(entry => entry !== id) : [...selected, id];
+}
+
+/**
+ * Merges a server facet with options derived from rows the server has never seen.
+ *
+ * The debate-again picker's All tab is geo-chat's browsed corpus *plus* this session's saved,
+ * opponent and curated claims pinned in front of it. Those come from the graph, so the facet can
+ * neither name nor count them.
+ *
+ * Where both know an option, the server's count wins: it covers the whole browsed corpus rather
+ * than the page walked so far, which is the larger and more useful number. That does mean a count
+ * can understate what the tab renders, by however many pinned rows carry the option — the facet
+ * cannot see them. Understating only ever hides rows the viewer then finds anyway; the alternative
+ * is summing two sets that overlap, which would overstate, and a count promising claims that
+ * aren't there is the failure this whole surface is built to avoid.
+ */
+export function mergeFacetCounts(
+  fromServer: { id: string; name: string | null; count: number }[],
+  fromRows: { id: string; name: string | null; count: number }[]
+): { id: string; name: string | null; count: number }[] {
+  const merged = new Map<string, { id: string; name: string | null; count: number }>();
+  for (const option of fromServer) merged.set(option.id, option);
+  for (const option of fromRows) {
+    const existing = merged.get(option.id);
+    if (!existing) merged.set(option.id, option);
+    else if (existing.name === null && option.name !== null) merged.set(option.id, { ...existing, name: option.name });
+  }
+  return [...merged.values()];
+}
+
+/** Counts how many of `values` fall into each bucket, as facet options. */
+export function countBy(
+  entries: { id: string; name: string | null }[]
+): { id: string; name: string | null; count: number }[] {
+  const counts = new Map<string, { id: string; name: string | null; count: number }>();
+  for (const entry of entries) {
+    const existing = counts.get(entry.id);
+    if (existing) existing.count += 1;
+    else counts.set(entry.id, { id: entry.id, name: entry.name, count: 1 });
+  }
+  return [...counts.values()];
+}

--- a/apps/web/core/debates/matchmaking/topic-facets.ts
+++ b/apps/web/core/debates/matchmaking/topic-facets.ts
@@ -151,3 +151,27 @@ export function countBy(
   }
   return [...counts.values()];
 }
+
+/**
+ * Facet options with any *selected* id that has fallen out of them added back at zero.
+ *
+ * The two halves of this look contradictory and aren't. An unselected option with nothing behind it
+ * has no business in the menu — picking it could only ever produce an empty list. A *selected* one
+ * has the opposite problem: a space facet is narrowed by the topic and the search, so a space the
+ * viewer picked can drop out of it the moment those leave the combination empty. Gone from the
+ * menu, its checkbox goes with it — and the trigger still counts it, so the viewer is told they
+ * have two spaces picked while only one row is checked, with no way to remove the other short of
+ * clearing them all.
+ *
+ * So: absent options stay absent, and absent *selections* come back at zero, where they can be
+ * unticked. A count of zero is honest here — it says what the list would hold, which is why the
+ * viewer wants it gone.
+ */
+export function keepSelectedVisible<T extends { id: string; name: string | null; count: number }>(
+  options: T[],
+  selected: string[]
+): (T | { id: string; name: string | null; count: number })[] {
+  const present = new Set(options.map(option => option.id));
+  const missing = selected.filter(id => !present.has(id)).map(id => ({ id, name: null, count: 0 }));
+  return missing.length === 0 ? options : [...options, ...missing];
+}

--- a/apps/web/core/debates/matchmaking/use-scoped-claims.test.ts
+++ b/apps/web/core/debates/matchmaking/use-scoped-claims.test.ts
@@ -37,8 +37,8 @@ vi.mock('./hooks', () => ({
 
 const QUERY = { search: null, spaceId: null, topicId: null } as const;
 
-function scoped(scope: { spaceIds: string[] | null; pending: boolean }, alsoUnusable = false) {
-  return renderHook(() => useScopedMatchmakingClaims(QUERY, scope, alsoUnusable));
+function scoped(scope: { spaceIds: string[] | null; pending: boolean }, alsoUnusable = false, selected: string[] = []) {
+  return renderHook(() => useScopedMatchmakingClaims(QUERY, scope, selected, alsoUnusable));
 }
 
 beforeEach(() => {
@@ -84,7 +84,7 @@ describe('useScopedMatchmakingClaims', () => {
     const { result, rerender } = renderHook(
       ({ spaceIds, placeholder }) => {
         mocks.isPlaceholderData = placeholder;
-        return useScopedMatchmakingClaims(QUERY, { spaceIds, pending: false });
+        return useScopedMatchmakingClaims(QUERY, { spaceIds, pending: false }, []);
       },
       { initialProps: { spaceIds: ['space-1'] as string[] | null, placeholder: false } }
     );
@@ -101,6 +101,20 @@ describe('useScopedMatchmakingClaims', () => {
     scoped({ spaceIds: [], pending: false });
 
     expect(mocks.enabled).toBe(false);
+  });
+
+  // The picked spaces replace the scope rather than joining it: geo-chat ORs the space parameters,
+  // so sending both would ask about every space in the scope alongside the one that was picked.
+  it('asks about the picked spaces rather than the whole scope', () => {
+    scoped({ spaceIds: ['space-1', 'space-2', 'space-3'], pending: false }, false, ['space-2']);
+
+    expect(mocks.query).toMatchObject({ spaceIds: ['space-2'] });
+  });
+
+  it('falls back to the scope when nothing is picked', () => {
+    scoped({ spaceIds: ['space-1', 'space-2'], pending: false }, false, []);
+
+    expect(mocks.query).toMatchObject({ spaceIds: ['space-1', 'space-2'] });
   });
 
   // A scope that can show nothing is a finished answer about the menu: empty. Read as "not known

--- a/apps/web/core/debates/matchmaking/use-scoped-claims.ts
+++ b/apps/web/core/debates/matchmaking/use-scoped-claims.ts
@@ -59,8 +59,9 @@ export type ScopedClaims = {
  * there is nothing worth asking for.
  */
 export function useScopedMatchmakingClaims(
-  query: Omit<MatchmakingClaimsQuery, 'spaceIds'>,
+  query: Omit<MatchmakingClaimsQuery, 'spaceIds' | 'spaceId'>,
   scope: ClaimSpaceScope,
+  selectedSpaceIds: string[],
   alsoUnusable = false
 ): ScopedClaims {
   // A known-empty scope is not the same as no scope: omitting the ids would fetch the unfiltered
@@ -69,10 +70,14 @@ export function useScopedMatchmakingClaims(
 
   // `query` is expected memoized by the caller — it is the react-query key, so a fresh object every
   // render would refetch on every render.
-  const scopedQuery = React.useMemo<MatchmakingClaimsQuery>(
-    () => ({ ...query, spaceIds: scope.spaceIds }),
-    [query, scope.spaceIds]
-  );
+  // The viewer's picked spaces stand in for the scope rather than joining it. They are always a
+  // subset of it — the menu offers nothing the scope doesn't admit — so sending them alone is both
+  // correct and narrower. Sending both would *widen*: geo-chat ORs the space parameters together
+  // rather than intersecting them, so a scope of ten spaces alongside a pick of one asks about all
+  // ten. With nothing picked the scope is the filter, which is what bounds the facets.
+  const spaceIds = selectedSpaceIds.length > 0 ? selectedSpaceIds : scope.spaceIds;
+
+  const scopedQuery = React.useMemo<MatchmakingClaimsQuery>(() => ({ ...query, spaceIds }), [query, spaceIds]);
 
   const claimsQuery = useMatchmakingClaims(scopedQuery, !unusable && !scope.pending);
 


### PR DESCRIPTION
## GEO-2654

Counts next to every space and topic in the debates filter menus, both menus ordered by that count, and both multi-select.

**No backend work was needed.** geo-chat already accepts `space_ids` and `topic_ids` as comma-joined lists (merged with the singular forms and deduped), already returns `space_facets`/`topic_facets` with counts, and already orders them `ORDER BY entries DESC, id ASC`. The whole ticket is client-side.

## Semantics

Each dimension is narrowed by the other and never by itself — the rule the server counts by. So a topic's count answers "how many of the claims I'm already looking at carry this", ticking a topic never changes the numbers in its own menu, and picking one space never collapses the space menu.

Within a menu, selections are OR; across menus, AND.

The picked spaces **replace** the eligible scope on the wire rather than joining it, because geo-chat ORs the space parameters together — sending both would ask about every space in the scope alongside the one that was picked. The selection is always a subset of the scope, so sending it alone is correct and strictly narrower.

## Decisions the ticket left open

- **Zero-count options** need no decision: both facets are a `GROUP BY` over the candidate set, so an option with nothing behind it is absent from the response rather than present at zero. Hiding is what already happens.
- **Selected options pin to the top**, then count descending. Without pinning, ticking an option re-sorts the list under the cursor — every count changes when the filter does — so the row just clicked can move before the next click lands.
- **Counts cap at `99+`.** A narrow panel sizes every row to the widest number in it.
- **Trigger label**: one selection reads as its own name, several collapse to "3 spaces". Two names rarely fit, and a truncated pair reads as one bad name.

## The debate-again picker

Its All tab is the browsed corpus plus this session's pinned rows, which geo-chat has never seen and cannot count. Where both know an option the server's count wins, since it covers the whole corpus rather than the page walked so far. That means a count can understate by however many pinned rows carry the option — but understating only hides rows the viewer finds anyway, whereas summing two overlapping sets would overstate, and a count promising claims that aren't there is the failure this surface exists to avoid.

## Status

Production code is complete and typechecks clean. The existing tests are mid-update for the new menus — the option rows now carry counts in their accessible names and the menu stays open across a tick, so a number of queries need adjusting. Not ready for review yet; I'll push again when the suite is green.