### PR TITLE
fix(debates): stop one upstream 503 from dropping the claim-space filter

### DIFF
--- a/apps/web/app/api/debates/publishable-spaces/route.ts
+++ b/apps/web/app/api/debates/publishable-spaces/route.ts
@@ -2,6 +2,12 @@ import { NextResponse } from 'next/server';
 
 import { getDebateAcceptorConfig } from '~/core/debates/server/acceptor-config';
 import { listEditorSpaceIds } from '~/core/debates/server/editor-spaces';
+import {
+  type PublishableSpacesCacheEntry,
+  PUBLISHABLE_SPACES_TTL_MS,
+  isFresh,
+  resolvePublishableSpaces,
+} from '~/core/debates/server/publishable-spaces-cache';
 
 /**
  * The spaces a finished debate could actually be published into.
@@ -19,8 +25,21 @@ import { listEditorSpaceIds } from '~/core/debates/server/editor-spaces';
  * debatable — which is already observable by trying. No auth, so it can be cached and shared.
  */
 
-/** Editor sets change when someone is added to a space, which is rare. */
-export const revalidate = 300;
+/**
+ * Dynamic on purpose. This used to carry `export const revalidate = 300`, which cached whatever the
+ * handler returned — including the `{ spaceIds: null }` it returns on failure. `null` means
+ * "unknown", and the client gates read unknown as "do not filter", so one upstream 503 was cached
+ * as an answer and every viewer served it saw claims from spaces the acceptor cannot publish into.
+ * Observed in production: a logged 503 at 15:54 and the endpoint still answering `null` when
+ * sampled hours later, against an acceptor that edits six spaces perfectly well.
+ *
+ * Segment revalidation caches the *response*, so it cannot express "cache successes, never cache
+ * failures". The TTL therefore lives in `publishable-spaces-cache`, where a failure can be handled
+ * on its own terms.
+ */
+export const dynamic = 'force-dynamic';
+
+let cached: PublishableSpacesCacheEntry | null = null;
 
 export async function GET() {
   const config = getDebateAcceptorConfig();
@@ -30,15 +49,39 @@ export async function GET() {
   // other filters rather than emptying every list. Local and preview environments run without an
   // acceptor configured, and they should still show a usable picker.
   if (!config) {
-    return NextResponse.json({ spaceIds: null });
+    return NextResponse.json({ spaceIds: null }, { headers: { 'Cache-Control': 'no-store' } });
   }
 
-  try {
-    const spaceIds = await listEditorSpaceIds(config.spaceId);
-    return NextResponse.json({ spaceIds });
-  } catch (error) {
-    // Same reasoning as above: a failed lookup is "unknown", not "nothing is publishable".
-    console.error('[debates] could not resolve publishable spaces', error);
-    return NextResponse.json({ spaceIds: null });
+  const nowMs = Date.now();
+  if (isFresh(cached, nowMs)) {
+    return NextResponse.json(
+      { spaceIds: cached!.spaceIds },
+      { headers: { 'Cache-Control': `public, max-age=${Math.floor(PUBLISHABLE_SPACES_TTL_MS / 1000)}` } }
+    );
   }
+
+  let refreshed: string[] | null = null;
+  try {
+    refreshed = await listEditorSpaceIds(config.spaceId);
+    cached = { spaceIds: refreshed, storedAtMs: nowMs };
+  } catch (error) {
+    // Retries are exhausted by this point (see `listEditorSpaceIds`), so this is either a real
+    // outage or a rejected query. Either way it is "unknown", never "nothing is publishable".
+    console.error('[debates] could not resolve publishable spaces', error);
+  }
+
+  const { spaceIds, cacheable } = resolvePublishableSpaces({ entry: cached, refreshed, nowMs });
+
+  return NextResponse.json(
+    { spaceIds },
+    {
+      headers: {
+        // A failure is never cached, whether it produced a stale list or a null. Only a fresh
+        // successful lookup earns a max-age.
+        'Cache-Control': cacheable
+          ? `public, max-age=${Math.floor(PUBLISHABLE_SPACES_TTL_MS / 1000)}`
+          : 'no-store',
+      },
+    }
+  );
 }

--- a/apps/web/core/debates/server/editor-spaces.ts
+++ b/apps/web/core/debates/server/editor-spaces.ts
@@ -14,14 +14,66 @@ const EDITOR_SPACES_QUERY = `
 `;
 
 /**
+ * Retries for this query, and why it needs its own.
+ *
+ * Every other GraphQL read in the app goes through `core/io/graphql-client`, which already retries
+ * 408/429/5xx on an exponential jittered schedule. This one does not: it is a hand-written query on
+ * a raw `GraphQLClient`, so it inherited none of that and a single upstream blip became a hard
+ * failure. Observed in production — the API returned
+ *
+ *   GraphQL Error (Code: 503): upstream connect error or disconnect/reset before headers.
+ *   reset reason: connection termination
+ *
+ * from envoy, on one request. The caller treats a failure as "unknown", which deliberately means
+ * "do not filter" — so that one 503 silently widened the claims corpus to every space the viewer
+ * can see, instead of the six the acceptor edits.
+ *
+ * Three attempts over ~450ms is sized for that failure mode: a connection reset is either gone on
+ * the next attempt or it is a real outage, and this sits in a request path so it cannot wait long.
+ */
+const MAX_ATTEMPTS = 3;
+const BASE_RETRY_DELAY_MS = 150;
+
+/** A 503 from a load balancer is transient; a 400 from a malformed query is not worth retrying. */
+export function isTransientEditorSpacesError(error: unknown): boolean {
+  const status = (error as { response?: { status?: number } } | null)?.response?.status;
+  // No status at all is a transport failure (DNS, reset, timeout) rather than a rejected query.
+  if (status === undefined) return true;
+  return status === 408 || status === 429 || status >= 500;
+}
+
+export function editorSpacesRetryDelayMs(attempt: number): number {
+  return BASE_RETRY_DELAY_MS * 2 ** Math.max(0, attempt);
+}
+
+const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+/**
  * Every space the given member space is an editor of, straight from the knowledge graph. This is
  * how the publish sweep finds its work: the acceptor publishes only into spaces it can edit, so
  * enumerating its editor spaces is the whole candidate set — no manual allowlist to maintain.
+ *
+ * Throws once retries are exhausted. Callers decide what an unanswerable question means; see the
+ * route for why it must not mean "nothing is publishable".
  */
 export async function listEditorSpaceIds(memberSpaceId: string): Promise<string[]> {
   const client = new GraphQLClient(getConfig().api);
-  const data = await client.request<{ editors: Array<{ spaceId: string }> }>(EDITOR_SPACES_QUERY, {
-    memberSpaceId: normalizeSpaceId(memberSpaceId),
-  });
-  return [...new Set(data.editors.map(editor => editor.spaceId))];
+  const variables = { memberSpaceId: normalizeSpaceId(memberSpaceId) };
+
+  let lastError: unknown;
+  for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+    try {
+      const data = await client.request<{ editors: Array<{ spaceId: string }> }>(
+        EDITOR_SPACES_QUERY,
+        variables
+      );
+      return [...new Set(data.editors.map(editor => editor.spaceId))];
+    } catch (error) {
+      lastError = error;
+      if (!isTransientEditorSpacesError(error) || attempt === MAX_ATTEMPTS - 1) throw error;
+      await sleep(editorSpacesRetryDelayMs(attempt));
+    }
+  }
+
+  throw lastError;
 }

--- a/apps/web/core/debates/server/publishable-spaces-cache.test.ts
+++ b/apps/web/core/debates/server/publishable-spaces-cache.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  PUBLISHABLE_SPACES_STALE_LIMIT_MS,
+  PUBLISHABLE_SPACES_TTL_MS,
+  isFresh,
+  isServableWhenStale,
+  resolvePublishableSpaces,
+} from './publishable-spaces-cache';
+import { editorSpacesRetryDelayMs, isTransientEditorSpacesError } from './editor-spaces';
+
+const NOW = 1_800_000_000_000;
+const entry = (ageMs: number, spaceIds = ['space-a', 'space-b']) => ({
+  spaceIds,
+  storedAtMs: NOW - ageMs,
+});
+
+describe('publishable spaces cache', () => {
+  it('serves a fresh entry without refetching', () => {
+    expect(isFresh(entry(PUBLISHABLE_SPACES_TTL_MS - 1), NOW)).toBe(true);
+    expect(isFresh(entry(PUBLISHABLE_SPACES_TTL_MS + 1), NOW)).toBe(false);
+    expect(isFresh(null, NOW)).toBe(false);
+  });
+
+  it('caches a successful lookup and marks it cacheable', () => {
+    expect(
+      resolvePublishableSpaces({ entry: null, refreshed: ['space-a'], nowMs: NOW })
+    ).toEqual({ spaceIds: ['space-a'], cacheable: true });
+  });
+
+  it('treats an empty list as a real answer, not a failure', () => {
+    // `[]` means "the acceptor edits nothing", which is a filter that hides everything. `null`
+    // means "unknown", which is a filter that hides nothing. Collapsing the two inverts the gate.
+    expect(resolvePublishableSpaces({ entry: null, refreshed: [], nowMs: NOW })).toEqual({
+      spaceIds: [],
+      cacheable: true,
+    });
+  });
+
+  it('serves the last known good list when the refresh fails', () => {
+    // The bug this exists for: a failed refresh used to answer `null`, and both client gates read
+    // null as "do not filter" — so an upstream blip widened the corpus instead of narrowing it.
+    expect(
+      resolvePublishableSpaces({ entry: entry(PUBLISHABLE_SPACES_TTL_MS + 60_000), refreshed: null, nowMs: NOW })
+    ).toEqual({ spaceIds: ['space-a', 'space-b'], cacheable: false });
+  });
+
+  it('never caches a response derived from a failure', () => {
+    // Cacheability is the half that turned one 503 into hours of a dropped filter.
+    for (const stored of [PUBLISHABLE_SPACES_TTL_MS + 1, PUBLISHABLE_SPACES_STALE_LIMIT_MS + 1]) {
+      expect(resolvePublishableSpaces({ entry: entry(stored), refreshed: null, nowMs: NOW }).cacheable).toBe(
+        false
+      );
+    }
+  });
+
+  it('stops serving a stale list once it is too old to trust', () => {
+    // Bounded so a permanently broken upstream eventually reads as unknown rather than pinning an
+    // editor set from hours ago forever.
+    expect(isServableWhenStale(entry(PUBLISHABLE_SPACES_STALE_LIMIT_MS - 1), NOW)).toBe(true);
+    expect(isServableWhenStale(entry(PUBLISHABLE_SPACES_STALE_LIMIT_MS + 1), NOW)).toBe(false);
+    expect(
+      resolvePublishableSpaces({
+        entry: entry(PUBLISHABLE_SPACES_STALE_LIMIT_MS + 1),
+        refreshed: null,
+        nowMs: NOW,
+      })
+    ).toEqual({ spaceIds: null, cacheable: false });
+  });
+
+  it('answers unknown when there is nothing cached and the refresh failed', () => {
+    // A cold serverless instance. Correct, and a much smaller window than a cached null.
+    expect(resolvePublishableSpaces({ entry: null, refreshed: null, nowMs: NOW })).toEqual({
+      spaceIds: null,
+      cacheable: false,
+    });
+  });
+
+  it('prefers a successful refresh over a stale entry', () => {
+    expect(
+      resolvePublishableSpaces({ entry: entry(60_000, ['old']), refreshed: ['new'], nowMs: NOW })
+    ).toEqual({ spaceIds: ['new'], cacheable: true });
+  });
+
+  it('keeps the stale window much longer than the retry interval', () => {
+    // If these crossed, a failed refresh would drop straight to null instead of serving the list
+    // it already had — which is the whole point of keeping it.
+    expect(PUBLISHABLE_SPACES_STALE_LIMIT_MS).toBeGreaterThan(PUBLISHABLE_SPACES_TTL_MS);
+  });
+});
+
+describe('editor spaces retries', () => {
+  it('retries the failure that was actually observed in production', () => {
+    // GraphQL Error (Code: 503): upstream connect error or disconnect/reset before headers.
+    expect(isTransientEditorSpacesError({ response: { status: 503 } })).toBe(true);
+  });
+
+  it('retries transport failures that carry no status at all', () => {
+    // DNS, connection reset, timeout — a rejected query always has a status.
+    expect(isTransientEditorSpacesError(new Error('socket hang up'))).toBe(true);
+    expect(isTransientEditorSpacesError(null)).toBe(true);
+  });
+
+  it('does not retry a rejected query', () => {
+    // A malformed query or a bad UUID fails identically on every attempt; retrying spends request
+    // latency to reach the same answer.
+    expect(isTransientEditorSpacesError({ response: { status: 400 } })).toBe(false);
+    expect(isTransientEditorSpacesError({ response: { status: 404 } })).toBe(false);
+  });
+
+  it('retries the throttling and timeout statuses too', () => {
+    expect(isTransientEditorSpacesError({ response: { status: 408 } })).toBe(true);
+    expect(isTransientEditorSpacesError({ response: { status: 429 } })).toBe(true);
+  });
+
+  it('backs off without stalling the request it sits in', () => {
+    expect(editorSpacesRetryDelayMs(0)).toBe(150);
+    expect(editorSpacesRetryDelayMs(1)).toBe(300);
+    // Two waits across three attempts, so the worst case adds well under half a second.
+    expect(editorSpacesRetryDelayMs(0) + editorSpacesRetryDelayMs(1)).toBeLessThan(500);
+  });
+});

--- a/apps/web/core/debates/server/publishable-spaces-cache.ts
+++ b/apps/web/core/debates/server/publishable-spaces-cache.ts
@@ -1,0 +1,72 @@
+/**
+ * Last-known-good cache for the acceptor's editor spaces.
+ *
+ * This exists because of how the previous caching failed, which is worth stating precisely. The
+ * route carried `export const revalidate = 300`, so whatever it returned was cached — *including*
+ * the `{ spaceIds: null }` it returns when the lookup fails. `null` means "unknown", and both
+ * client-side gates read unknown as "do not filter". So a single upstream 503 was baked into the
+ * response cache, and every viewer served that entry saw claims from every space they could see
+ * rather than the six the acceptor edits. Observed in production: one logged 503 at 15:54, and the
+ * endpoint still answering `null` when sampled hours later.
+ *
+ * Segment-level revalidation cannot express "cache successes, never cache failures" — it caches the
+ * response, not the outcome. So the route is dynamic now and the TTL lives here, where a failure can
+ * be handled on its own terms: serve the last good answer instead.
+ *
+ * Serving a stale-but-real list beats serving `null`. A space the acceptor stopped editing lingers
+ * for at most one TTL, which offers one dead-end claim; `null` drops the filter entirely. Wrong in
+ * the narrow direction beats wrong in the wide one.
+ *
+ * Per-instance and best-effort by nature — serverless instances are ephemeral and there are many, so
+ * a cold instance has no last-good value and correctly falls through to `null`. That is a smaller
+ * window than the one this replaces, not a guarantee.
+ */
+
+export type PublishableSpacesCacheEntry = {
+  spaceIds: string[];
+  storedAtMs: number;
+};
+
+/** Editor sets change when someone is added to a space, which is rare. */
+export const PUBLISHABLE_SPACES_TTL_MS = 5 * 60_000;
+
+/**
+ * How long a last-known-good list may be served *after* a failed refresh.
+ *
+ * Deliberately much longer than the TTL. The TTL decides when to try again; this decides how long
+ * a real answer stays better than no answer, and an editor set that changed an hour ago is still a
+ * far better filter than none. Bounded rather than unbounded so a permanently broken upstream
+ * eventually surfaces as unknown instead of pinning a stale list forever.
+ */
+export const PUBLISHABLE_SPACES_STALE_LIMIT_MS = 6 * 60 * 60_000;
+
+export function isFresh(entry: PublishableSpacesCacheEntry | null, nowMs: number): boolean {
+  if (!entry) return false;
+  return nowMs - entry.storedAtMs < PUBLISHABLE_SPACES_TTL_MS;
+}
+
+export function isServableWhenStale(entry: PublishableSpacesCacheEntry | null, nowMs: number): boolean {
+  if (!entry) return false;
+  return nowMs - entry.storedAtMs < PUBLISHABLE_SPACES_STALE_LIMIT_MS;
+}
+
+/**
+ * What to return, given the cache and whether the refresh succeeded.
+ *
+ * Split out as a pure function because the interesting behaviour is the failure path, and that is
+ * the one hardest to exercise through a route handler.
+ */
+export function resolvePublishableSpaces(args: {
+  entry: PublishableSpacesCacheEntry | null;
+  refreshed: string[] | null;
+  nowMs: number;
+}): { spaceIds: string[] | null; cacheable: boolean } {
+  if (args.refreshed) {
+    return { spaceIds: args.refreshed, cacheable: true };
+  }
+  // Refresh failed. A real list from a moment ago is a better filter than no filter at all.
+  if (isServableWhenStale(args.entry, args.nowMs)) {
+    return { spaceIds: args.entry!.spaceIds, cacheable: false };
+  }
+  return { spaceIds: null, cacheable: false };
+}

--- a/apps/web/core/debates/use-debate-publishable-spaces.ts
+++ b/apps/web/core/debates/use-debate-publishable-spaces.ts
@@ -27,14 +27,22 @@ export function useDebatePublishableSpaces(): {
     queryKey: ['debates', 'publishable-spaces'],
     queryFn: async (): Promise<string[] | null> => {
       const response = await fetch('/api/debates/publishable-spaces');
-      if (!response.ok) return null;
+      // Throw rather than return null, so an HTTP failure is a *retryable* error instead of a
+      // cached "unknown". Returning null here made a single blip a settled answer for the session.
+      if (!response.ok) throw new Error(`publishable spaces: ${response.status}`);
       const body = (await response.json()) as { spaceIds?: string[] | null };
       return body.spaceIds ?? null;
     },
     // Editor sets change when someone is added to a space. Refetching this per mount would spend a
-    // request on an answer that is the same all session.
-    staleTime: 5 * 60_000,
-    retry: false,
+    // request on an answer that is the same all session — but only once there *is* an answer:
+    // `null` means the lookup could not be made, and holding that for five minutes keeps the
+    // filter off long after the upstream recovered. So a null is stale immediately.
+    staleTime: query => (query.state.data == null ? 0 : 5 * 60_000),
+    // Was `false`, which meant one transient 503 dropped the space filter entirely and nothing
+    // tried again. Both gates fail open on `null`, so a failed lookup silently widens the claims
+    // corpus rather than narrowing it — the failure mode that hides a retry being absent.
+    retry: 2,
+    retryDelay: attempt => Math.min(1_000 * 2 ** attempt, 5_000),
   });
 
   const publishableSpaceIds = React.useMemo(


### PR DESCRIPTION
Answers Preston's question directly: *"How come I am still seeing claims from these spaces that dont have the debate bot as an editor? Like the 'datasets spaces'"*

Because the filter was off. Sampled production:

```
$ curl https://www.geobrowser.io/api/debates/publishable-spaces
{"spaceIds":null}
```

`null` means "unknown", and both client gates read unknown as **do not filter** — deliberately, so a transient failure can't empty every list in the picker. But the cost of that choice was never bounded: a failure silently *widens* the corpus, and it stayed widened.

## What actually failed

Not the config. The acceptor is set up correctly and edits six spaces; running its query by hand returns them fine. One request failed:

```
GraphQL Error (Code: 503): upstream connect error or disconnect/reset
before headers. reset reason: connection termination
```

Three things turned that blip into a lasting outage.

**1. No retries.** `listEditorSpaceIds` is a hand-written query on a raw `GraphQLClient`, so it never inherited the 408/429/5xx retry schedule `core/io/graphql-client` gives every other read in the app. Now three attempts over ~450ms, transient failures only — a rejected query fails identically on every attempt, so retrying it just spends latency.

**2. The failure was cached.** The route carried `revalidate = 300`, which caches the *response* — so it cached the `null` exactly as it would a real answer. Segment revalidation can't express "cache successes, never cache failures", so the route is `force-dynamic` and the TTL moved into `publishable-spaces-cache`, which only stores successes and marks anything derived from a failure `no-store`.

**3. A failed refresh answered `null` even with a good list in hand.** It now serves the last known good list, bounded at six hours so a permanently broken upstream still degrades to unknown rather than pinning a stale editor set forever.

That last trade is the one worth arguing with me about: **serving a slightly stale real list beats serving none.** A space the acceptor stopped editing offers one dead-end claim; `null` drops the filter entirely. Wrong narrowly beats wrong widely.

## Client side

`retry: false` plus a five-minute `staleTime` meant one null became the answer for the **whole session**. The query now throws on a bad response so it's retryable, retries twice, and treats a null result as immediately stale — there's no value in holding "I couldn't tell" for five minutes after the upstream recovered.

## Caveat

The module cache is per-instance and best-effort. Serverless instances are ephemeral, so a cold one has no last-good value and correctly falls through to `null`. That's a much smaller window than a cached null, not a guarantee. A shared cache would close it properly if this recurs.

## Verification

- 3255 tests / 308 files pass; `tsc` at its 5-error baseline.
- The cache and retry decisions are pure functions with their own tests, including that `[]` stays a real answer ("nothing is debatable") and is never collapsed into `null` ("unknown") — those two **invert** the gate, so conflating them is the dangerous bug in this file.
- Retry predicate is tested against the exact production failure shape (503 with a `response.status`), plus status-less transport errors.

Worth noting this is a *different* bug from the avatar-stack one Preston reported in the same stretch, despite both surfacing as "wrong claims/faces in the debates picker".
