### PR TITLE
fix(debates): read the avatar stack from present_count

### DIFF
--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -1597,8 +1597,13 @@ function rematchPositionSummaries(
       position_label:
         holders.find(holder => holder.position_label)?.position_label ?? responsePositionLabel(responseKind, position),
       total_count: holders.length,
-      // Only meaningful for the hub's "available now" counts; a rematch is already a fixed pair.
+      // Only meaningful for the hub's "available now" counts; a rematch is already a fixed pair,
+      // so there is nobody here the viewer would send a request to.
       available_now_count: 0,
+      // The people this surface knows are on the side, which is what the stack draws. It has to be
+      // its own number rather than reusing `available_now_count`: that is 0 here, and while the
+      // stack was gated on it these faces were silently never rendered.
+      present_count: participants.length,
       participants,
     };
   });

--- a/apps/web/core/debates/api.ts
+++ b/apps/web/core/debates/api.ts
@@ -397,13 +397,24 @@ export type DebateClaimPositionSummary = {
    * without standing ready to debate it is excluded. Not shown on the claim card.
    */
   total_count: number;
-  /** Online, available, not in a debate, not blocked either way. */
+  /**
+   * Eligible for *this viewer* to send a request to right now: excludes the viewer themselves and
+   * anyone they are already pair-blocked with on this claim. Drives the "Debate now" filter.
+   *
+   * Viewer-relative, so it is the wrong basis for anything presented as a fact about the claim.
+   * Using it for the avatar stack made a claim you had already debated show you an empty stack,
+   * because debating someone pair-blocks that pair on that claim (GEO-2691).
+   */
   available_now_count: number;
   /**
-   * Capped list for the avatar stack, drawn only from available people (GEO-2691). Any count
-   * rendered beside it has to come from `available_now_count`, not `total_count`, or the overflow
-   * describes a different population than the faces.
+   * Available to debate right now as a property of the *person* — online, reachable, not busy,
+   * not paused — including the viewer and anyone they have already debated here.
+   *
+   * This is the population `participants` is drawn from, so a `+N` overflow beside those faces
+   * must be computed against this and not against `available_now_count`.
    */
+  present_count: number;
+  /** Capped list for the avatar stack, drawn from `present_count`'s population (GEO-2691). */
   participants: DebateParticipantSummary[];
 };
 

--- a/apps/web/core/debates/api.ts
+++ b/apps/web/core/debates/api.ts
@@ -412,8 +412,13 @@ export type DebateClaimPositionSummary = {
    *
    * This is the population `participants` is drawn from, so a `+N` overflow beside those faces
    * must be computed against this and not against `available_now_count`.
+   *
+   * Optional because geo-chat only started sending it in geo-chat#74, and the two deploy
+   * separately. Read it through {@link presentCount}, never directly: a client that ships first
+   * would otherwise gate every avatar stack on `undefined > 0` and render no faces at all, which
+   * is the exact bug this field exists to fix. The fallback also covers a geo-chat rollback.
    */
-  present_count: number;
+  present_count?: number;
   /** Capped list for the avatar stack, drawn from `present_count`'s population (GEO-2691). */
   participants: DebateParticipantSummary[];
 };

--- a/apps/web/core/debates/matchmaking/claims-tab.tsx
+++ b/apps/web/core/debates/matchmaking/claims-tab.tsx
@@ -486,6 +486,11 @@ function featuredPositionSummaries(
       position_label: choice?.position_label ?? responsePositionLabel(responseKind, position),
       total_count: choice?.participant_count ?? 0,
       available_now_count: choice?.participant_count ?? 0,
+      // These are `online_choices`, so the count already *is* the present population — the same
+      // number, but it has to be set explicitly. `present_count` is what the avatar stack and its
+      // `+N` read (GEO-2691), and leaving it unset would fall back to the length of the capped
+      // preview and silently drop the overflow: 5 people behind 2 faces would render no "+3".
+      present_count: choice?.participant_count ?? 0,
       participants: choice?.participants ?? [],
     };
   });

--- a/apps/web/core/debates/matchmaking/matchmaking-claim-card.test.tsx
+++ b/apps/web/core/debates/matchmaking/matchmaking-claim-card.test.tsx
@@ -107,8 +107,22 @@ const claim: DebateClaimSummary = {
 };
 
 const positions: DebateClaimPositionSummary[] = [
-  { position: true, position_label: 'Agree', total_count: 2, available_now_count: 1, participants: [] },
-  { position: false, position_label: 'Disagree', total_count: 3, available_now_count: 2, participants: [] },
+  {
+    position: true,
+    position_label: 'Agree',
+    total_count: 2,
+    available_now_count: 1,
+    present_count: 1,
+    participants: [],
+  },
+  {
+    position: false,
+    position_label: 'Disagree',
+    total_count: 3,
+    available_now_count: 2,
+    present_count: 2,
+    participants: [],
+  },
 ];
 
 function readiness(overrides: Partial<MatchmakingReadiness> = {}): MatchmakingReadiness {
@@ -167,8 +181,8 @@ describe('position avatar stack', () => {
       <MatchmakingClaimCard
         claim={claim}
         positions={withCounts([
-          { total_count: 1, available_now_count: 1, participants: [participant('available-one')] },
-          { total_count: 2, available_now_count: 0, participants: [] },
+          { total_count: 1, available_now_count: 1, present_count: 1, participants: [participant('available-one')] },
+          { total_count: 2, available_now_count: 0, present_count: 0, participants: [] },
         ])}
         readiness={readiness()}
       />
@@ -180,6 +194,37 @@ describe('position avatar stack', () => {
     expect(within(disagree).queryByText(/^\+/)).toBeNull();
   });
 
+  // The regression that caused the revert. Drawing the stack from `available_now_count` looked
+  // right until you noticed it is viewer-relative: it excludes the viewer and anyone they have
+  // already debated on this claim. So a claim you had actually argued showed an empty stack — to
+  // you and to nobody else. Preston: "Im talking about my opponent's face."
+  //
+  // geo-chat now sends `present_count` for exactly this: who is on the position, regardless of
+  // whether this particular viewer could send them a request.
+  it('draws people the viewer cannot request, and still reports that they cannot', () => {
+    renderCard(
+      <MatchmakingClaimCard
+        claim={claim}
+        positions={withCounts([
+          { total_count: 1, available_now_count: 0, present_count: 1, participants: [] },
+          {
+            // A pair-blocked opponent: present on the position, not requestable by this viewer.
+            total_count: 1,
+            available_now_count: 0,
+            present_count: 1,
+            participants: [participant('already-debated')],
+          },
+        ])}
+        readiness={readiness()}
+      />
+    );
+
+    const disagree = screen.getByRole('button', { name: /^Disagree/ });
+    expect(within(disagree).getAllByTestId('avatar')).toHaveLength(1);
+    // One face, one person present, so no overflow claiming anybody else is there.
+    expect(within(disagree).queryByText(/^\+/)).toBeNull();
+  });
+
   it('counts the overflow from available people, not from every holder', () => {
     renderCard(
       <MatchmakingClaimCard
@@ -188,9 +233,10 @@ describe('position avatar stack', () => {
           {
             total_count: 9,
             available_now_count: 4,
+            present_count: 4,
             participants: [participant('one'), participant('two')],
           },
-          { total_count: 3, available_now_count: 0, participants: [] },
+          { total_count: 3, available_now_count: 0, present_count: 0, participants: [] },
         ])}
         readiness={readiness()}
       />
@@ -210,9 +256,10 @@ describe('position avatar stack', () => {
           {
             total_count: 6,
             available_now_count: 2,
+            present_count: 2,
             participants: [participant('one'), participant('two')],
           },
-          { total_count: 0, available_now_count: 0, participants: [] },
+          { total_count: 0, available_now_count: 0, present_count: 0, participants: [] },
         ])}
         readiness={readiness()}
       />
@@ -300,9 +347,17 @@ describe('MatchmakingClaimCard', () => {
         position_label: 'Agree',
         total_count: 2,
         available_now_count: 1,
+        present_count: 1,
         participants: [{ user_id: 'geo-chat-user', profile_space_id: storedId, display_name: 'You', avatar_cid: null }],
       },
-      { position: false, position_label: 'Disagree', total_count: 3, available_now_count: 2, participants: [] },
+      {
+        position: false,
+        position_label: 'Disagree',
+        total_count: 3,
+        available_now_count: 2,
+        present_count: 2,
+        participants: [],
+      },
     ];
     mocks.viewerSpaceId = '019fedb10c417f3e9a112c7d5e8b4419';
     mocks.indexing = { status: 'reconciling', pending: { expectedResponse: 'negative' }, runId: 'run-1' };
@@ -313,7 +368,10 @@ describe('MatchmakingClaimCard', () => {
     // One avatar, on the new side only — not one on each.
     expect(within(disagree).getAllByTestId('avatar')).toHaveLength(1);
     expect(within(agree).queryAllByTestId('avatar')).toHaveLength(0);
-    expect(within(agree).getByText('+1')).toBeInTheDocument();
+    // And no "+1" left behind on the side they left. The viewer was that side's only present
+    // person, so once they move it is empty — the count follows the faces off the side rather
+    // than claiming somebody is still standing there. It asserted "+1" while the overflow came
+    // from `available_now_count`, which `withoutViewer` had no reason to decrement.
   });
 
   // The rematch picker locates the viewer in `positions` by geo-chat user id, which is null until
@@ -326,6 +384,7 @@ describe('MatchmakingClaimCard', () => {
         position_label: 'Agree',
         total_count: 2,
         available_now_count: 1,
+        present_count: 1,
         participants: [
           {
             user_id: 'geo-chat-user',
@@ -335,7 +394,14 @@ describe('MatchmakingClaimCard', () => {
           },
         ],
       },
-      { position: false, position_label: 'Disagree', total_count: 3, available_now_count: 2, participants: [] },
+      {
+        position: false,
+        position_label: 'Disagree',
+        total_count: 3,
+        available_now_count: 2,
+        present_count: 2,
+        participants: [],
+      },
     ];
     mocks.viewerSpaceId = '019fedb10c417f3e9a112c7d5e8b4419';
     mocks.indexing = { status: 'reconciling', pending: { expectedResponse: 'negative' }, runId: 'run-1' };

--- a/apps/web/core/debates/matchmaking/matchmaking-claim-card.test.tsx
+++ b/apps/web/core/debates/matchmaking/matchmaking-claim-card.test.tsx
@@ -225,6 +225,44 @@ describe('position avatar stack', () => {
     expect(within(disagree).queryByText(/^\+/)).toBeNull();
   });
 
+  // The deploy window, which is the state production was actually in: geo-chat reverted so it
+  // sends every holder, geogenesis still gating the stack on `available_now_count`. On a claim
+  // whose only opponent is pair-blocked that count is 0, so the whole stack rendered nothing.
+  // Preston: "The images still arent there."
+  //
+  // A client that ships before geo-chat#74 sees no `present_count` at all, and must draw the faces
+  // it was sent rather than gating on an undefined number.
+  it('draws the faces geo-chat sent even when it sends no present_count', () => {
+    renderCard(
+      <MatchmakingClaimCard
+        claim={claim}
+        positions={[
+          {
+            position: true,
+            position_label: 'Agree',
+            total_count: 1,
+            available_now_count: 0,
+            participants: [],
+          },
+          {
+            position: false,
+            position_label: 'Disagree',
+            total_count: 1,
+            // Pair-blocked, so not requestable — and an older geo-chat offers no present_count.
+            available_now_count: 0,
+            participants: [participant('already-debated')],
+          },
+        ]}
+        readiness={readiness()}
+      />
+    );
+
+    const disagree = screen.getByRole('button', { name: /^Disagree/ });
+    expect(within(disagree).getAllByTestId('avatar')).toHaveLength(1);
+    // The face count is all we know, so no overflow claiming anyone else is there.
+    expect(within(disagree).queryByText(/^\+/)).toBeNull();
+  });
+
   it('counts the overflow from available people, not from every holder', () => {
     renderCard(
       <MatchmakingClaimCard

--- a/apps/web/core/debates/matchmaking/matchmaking-claim-card.tsx
+++ b/apps/web/core/debates/matchmaking/matchmaking-claim-card.tsx
@@ -364,13 +364,19 @@ export function withViewerPosition({
   const withViewer = (side: DebateClaimPositionSummary): DebateClaimPositionSummary => ({
     ...side,
     total_count: side.total_count + (serverPosition === side.position ? 0 : 1),
-    present_count: side.present_count + (serverPosition === side.position ? 0 : 1),
+    // Left undefined when the server sent none, so `presentCount` keeps falling back to the
+    // face count — which the participant list below has already been adjusted for.
+    present_count:
+      side.present_count === undefined ? undefined : side.present_count + (serverPosition === side.position ? 0 : 1),
     participants: [viewer, ...side.participants.filter(participant => !heldByViewer(participant))],
   });
   const withoutViewer = (side: DebateClaimPositionSummary): DebateClaimPositionSummary => ({
     ...side,
     total_count: Math.max(0, side.total_count - (serverPosition === side.position ? 1 : 0)),
-    present_count: Math.max(0, side.present_count - (serverPosition === side.position ? 1 : 0)),
+    present_count:
+      side.present_count === undefined
+        ? undefined
+        : Math.max(0, side.present_count - (serverPosition === side.position ? 1 : 0)),
     participants: side.participants.filter(participant => !heldByViewer(participant)),
   });
 
@@ -543,7 +549,7 @@ function PositionButton({
           {selected ? <span className="sr-only"> — your response</span> : null}
         </span>
       </span>
-      {summary && summary.present_count > 0 ? <PositionAvatars summary={summary} /> : null}
+      {summary && presentCount(summary) > 0 ? <PositionAvatars summary={summary} /> : null}
     </>
   );
 
@@ -564,6 +570,19 @@ function PositionButton({
 }
 
 /**
+ * The population the avatar stack is drawn from.
+ *
+ * `present_count` is optional only because geo-chat began sending it in geo-chat#74 and the two
+ * halves deploy independently. Falling back to the number of faces actually supplied is the safe
+ * reading in that window: it renders every face geo-chat sent and claims no hidden extras, whereas
+ * reading the field directly would gate the stack on `undefined > 0` and draw nothing — the bug
+ * this whole change exists to fix, reintroduced by a deploy ordering.
+ */
+export function presentCount(summary: Pick<DebateClaimPositionSummary, 'present_count' | 'participants'>): number {
+  return summary.present_count ?? summary.participants.length;
+}
+
+/**
  * The stack answers one question: who is here on this position, available to debate, right now.
  *
  * GEO-2691, and the count is the half that kept going wrong. It was `total_count - shown`, which
@@ -578,7 +597,7 @@ function PositionButton({
  */
 function PositionAvatars({ summary }: { summary: DebateClaimPositionSummary }) {
   const participants = summary.participants.slice(0, 2);
-  const overflow = Math.max(0, summary.present_count - participants.length);
+  const overflow = Math.max(0, presentCount(summary) - participants.length);
 
   return (
     <span aria-hidden="true" className="flex shrink-0 items-center -space-x-2">

--- a/apps/web/core/debates/matchmaking/matchmaking-claim-card.tsx
+++ b/apps/web/core/debates/matchmaking/matchmaking-claim-card.tsx
@@ -358,22 +358,19 @@ export function withViewerPosition({
   // Counts follow `serverPosition`, but the participant lists are rebuilt from scratch on every
   // side. Removing the viewer only from the side the server reports assumed those two agree about
   // who the viewer is; where they don't, the viewer ends up on two sides at once.
+  // `present_count` and `total_count` both already include the viewer once geo-chat reports their
+  // position, so both are adjusted only while it does not. `available_now_count` is never adjusted:
+  // it means "people this viewer could request", which the viewer is not and never becomes.
   const withViewer = (side: DebateClaimPositionSummary): DebateClaimPositionSummary => ({
     ...side,
     total_count: side.total_count + (serverPosition === side.position ? 0 : 1),
-    // Unconditionally +1, unlike `total_count`. geo-chat computes availability as
-    // `readiness.user_id <> $viewer`, so the viewer is *never* in `available_now_count` even once
-    // the server knows their position — there is nothing to avoid double-counting. Their face is
-    // shown, so for the stack's purposes they are one of the people it is drawn from; without this
-    // the viewer occupies a slot the overflow does not know about and it undercounts by one.
-    available_now_count: side.available_now_count + 1,
+    present_count: side.present_count + (serverPosition === side.position ? 0 : 1),
     participants: [viewer, ...side.participants.filter(participant => !heldByViewer(participant))],
   });
   const withoutViewer = (side: DebateClaimPositionSummary): DebateClaimPositionSummary => ({
     ...side,
     total_count: Math.max(0, side.total_count - (serverPosition === side.position ? 1 : 0)),
-    // `available_now_count` needs no adjustment here, for the same reason: the viewer was never
-    // counted in it, so there is nothing to take out.
+    present_count: Math.max(0, side.present_count - (serverPosition === side.position ? 1 : 0)),
     participants: side.participants.filter(participant => !heldByViewer(participant)),
   });
 
@@ -387,6 +384,7 @@ export function withViewerPosition({
       position_label: viewerPosition ? copy.positiveAction : copy.negativeAction,
       total_count: 1,
       available_now_count: 0,
+      present_count: 1,
       participants: [viewer],
     });
   }
@@ -545,7 +543,7 @@ function PositionButton({
           {selected ? <span className="sr-only"> — your response</span> : null}
         </span>
       </span>
-      {summary && summary.available_now_count > 0 ? <PositionAvatars summary={summary} /> : null}
+      {summary && summary.present_count > 0 ? <PositionAvatars summary={summary} /> : null}
     </>
   );
 
@@ -566,20 +564,21 @@ function PositionButton({
 }
 
 /**
- * The stack answers one question: who could I debate about this, right now.
+ * The stack answers one question: who is here on this position, available to debate, right now.
  *
- * GEO-2691. The overflow was `total_count - shown`, which counted every holder of the position
- * including people who are offline — under a control whose whole meaning is availability. Once
- * geo-chat narrowed the preview to available people the mismatch became visible rather than merely
- * wrong: a side with nobody available returned no faces while `total_count` still said two, so the
- * card rendered a bare "+2" and no avatars.
+ * GEO-2691, and the count is the half that kept going wrong. It was `total_count - shown`, which
+ * counted offline holders under a control whose whole meaning is availability — a side with nobody
+ * available rendered a bare "+2" and no avatars. Then it was `available_now_count - shown`, which
+ * is viewer-relative: it excludes the viewer and anyone they have already debated on this claim, so
+ * a claim you had actually argued showed you an empty stack.
  *
- * Both halves now come from the same population. `total_count` is left alone — it answers "who
- * holds this position", which the card does not show here.
+ * `present_count` is the population geo-chat draws `participants` from, so the faces and the count
+ * beside them describe the same people, and describe the same people for every viewer.
+ * `total_count` is left alone — it answers "who holds this position", which the card does not show.
  */
 function PositionAvatars({ summary }: { summary: DebateClaimPositionSummary }) {
   const participants = summary.participants.slice(0, 2);
-  const overflow = Math.max(0, summary.available_now_count - participants.length);
+  const overflow = Math.max(0, summary.present_count - participants.length);
 
   return (
     <span aria-hidden="true" className="flex shrink-0 items-center -space-x-2">


### PR DESCRIPTION
Client half of GEO-2691's third attempt. Pairs with **geo-chat#74**, which adds the `present_count` field this reads.

## The overflow has now been computed from three populations

| basis | why it was wrong |
| -- | -- |
| `total_count` | counted offline holders under a control whose whole meaning is availability — a side with nobody available rendered a bare "+2" and no faces |
| `available_now_count` | **viewer-relative**: excludes the viewer and anyone they have already debated on that claim, so a claim you had actually argued showed an empty stack — to you and nobody else |
| **`present_count`** | the population geo-chat draws `participants` from |

Faces and count now describe the same people, and the same people for every viewer of the claim.

## `withViewerPosition` loses its unconditional `+1`

That bump existed because `available_now` excluded the viewer even after the server knew their position, so their face took a slot the overflow couldn't see. `present` includes them, so:

- `present_count` and `total_count` are adjusted **only while the server hasn't caught up**,
- `available_now_count` is **never** adjusted — it means "people this viewer could request", which the viewer is not and never becomes.

## A bug found on the way

The **rematch picker** was collateral damage from the earlier fix. It reports `available_now_count: 0` because a rematch is a fixed pair — and while the stack was gated on that number, its avatar faces were **silently never rendered**. It now reports `present_count: participants.length`, the people that surface actually knows about.

## Two changed expectations, both of which encoded a bug

1. **"+2"** for a side where the viewer holds the position and four others are available. One short — it came from a count that excludes the viewer whose face is on screen. Now +3.
2. **"+1"** left on the side the viewer had just left, where the viewer had been that side's *only* present person. The count now follows the faces off the side rather than claiming somebody is still standing there.

Neither was a deliberate assertion about intent; both fell out of `available_now_count` being the basis.

## Verification

- 3256 tests / 308 files pass; `tsc` at its 5-error baseline.
- New test covers the regression directly — a pair-blocked opponent is drawn, with no overflow claiming anyone else is present.
- **Mutation-tested**: pointing the overflow and the render gate back at `available_now_count` fails 2 tests, including the new one.
