### PR TITLE
fix(debates): stop the opponent tab re-sorting under the viewer

### DIFF
--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
@@ -1286,92 +1286,33 @@ describe('DebateRematchPageClient', () => {
         position('profile-remote', CLAIM_MORE, SPACE_1, false),
       ];
       mocks.entities = [sharedEntity(), opponentEntity(CLAIM_MORE, SECOND_CLAIM)];
-      mocks.claims = [sessionRow(CLAIM_SHARED, 'A claim both participants chose', false)];
+      mocks.claims = [sessionRow(CLAIM_SHARED, FIRST_CLAIM, false)];
     }
 
-    /** The claims on the opponent's tab, top to bottom, read off the rendered document. */
-    function listedClaims() {
-      return [FIRST_CLAIM, SECOND_CLAIM, THIRD_CLAIM]
-        .map(text => ({ text, node: screen.queryByText(text) }))
-        .filter((entry): entry is { text: string; node: HTMLElement } => entry.node !== null)
-        .sort((a, b) =>
-          // eslint-disable-next-line no-bitwise
-          a.node.compareDocumentPosition(b.node) & Node.DOCUMENT_POSITION_FOLLOWING ? -1 : 1
-        )
-        .map(entry => entry.text);
-    }
+    const positionsTab = () => screen.getByRole('button', { name: /positions/ });
 
-    it('holds the order it loaded with when a position becomes a match', () => {
+    it('holds the order it loaded with when a position becomes a match', async () => {
       twoUnmatchedPositions();
       const { rerender } = render(<DebateRematchPageClient sessionId="rematch-1" />);
+      await showOpponentClaims();
 
-      const loaded = listedClaims();
-      expect(loaded).toHaveLength(2);
-      expect(loaded[1]).toBe(SECOND_CLAIM);
+      expect(appearsBefore(FIRST_CLAIM, SECOND_CLAIM)).toBe(true);
 
       // The viewer takes a side on the second one: geo-chat's row comes back a match.
       mocks.claims = [sessionRow(CLAIM_SHARED, FIRST_CLAIM, false), sessionRow(CLAIM_MORE, SECOND_CLAIM, true)];
       rerender(<DebateRematchPageClient sessionId="rematch-1" />);
+      await settleTabSwap();
 
-      expect(listedClaims()).toEqual(loaded);
-    });
-
-    /**
-     * The route keeps this component when it moves from one rematch to another — nothing keys it on
-     * the session — so the hold that carries a list through a refetch would otherwise carry it
-     * across a session change too. That is the wrong list twice over: the previous rematch's claims
-     * on screen while the new one loads, and their order seeding the new session's.
-     */
-    it('does not carry the previous session’s claims into a new one', () => {
-      twoUnmatchedPositions();
-      const { rerender } = render(<DebateRematchPageClient sessionId="rematch-1" />);
-      expect(listedClaims()).toHaveLength(2);
-
-      const positionsTab = () => screen.getByRole('button', { name: /Salina’s positions/ });
-      expect(positionsTab()).toHaveTextContent('2');
-
-      // The new session's lookups are in flight: nothing of its own to show yet.
-      mocks.entityHydrationLoading = true;
-      rerender(<DebateRematchPageClient sessionId="rematch-2" />);
-
-      // Asserted on the tab's own count rather than on the claims: the same rows also reach the All
-      // tab, so searching the document would find them whichever list they came from. And on the
-      // skeleton specifically — "not 2" would be satisfied by a confident `0`, which is the wrong
-      // answer rather than an absent one.
-      expect(screen.getByLabelText('Counting positions')).toBeInTheDocument();
-      expect(positionsTab()).not.toHaveTextContent('2');
-    });
-
-    /**
-     * The window the session change opens: participants come from the session, positions from
-     * participants, the claim lookups from positions. While the session is in flight the whole
-     * chain is disabled rather than loading, so nothing downstream says "pending" — and the badge
-     * would answer `0` for a session it has not read yet. Zero is a claim about the opponent, not a
-     * placeholder.
-     */
-    it('does not answer zero positions for a session it has not read yet', () => {
-      twoUnmatchedPositions();
-      const { rerender } = render(<DebateRematchPageClient sessionId="rematch-1" />);
-      expect(screen.getByRole('button', { name: /Salina’s positions/ })).toHaveTextContent('2');
-
-      // Only the session is loading, and it has not returned yet — so everything keyed on what it
-      // returns is disabled, reporting `isLoading: false` while having nothing to say.
-      mocks.sessionLoading = true;
-      mocks.session = null;
-      rerender(<DebateRematchPageClient sessionId="rematch-2" />);
-
-      expect(screen.getByLabelText('Counting positions')).toBeInTheDocument();
-      // The tab is named from a fallback while the session is unknown, so the skeleton — not the
-      // tab's name — is what identifies the badge here.
-      expect(screen.queryByText('0')).not.toBeInTheDocument();
+      expect(appearsBefore(FIRST_CLAIM, SECOND_CLAIM)).toBe(true);
     });
 
     // The hold is on rows already shown, not on the arrangement itself: a claim the opponent
     // answers next has never been under the viewer's cursor, so the sort still places it.
-    it('still puts a newly arrived match at the top', () => {
+    it('still puts a newly arrived match at the top', async () => {
       twoUnmatchedPositions();
       const { rerender } = render(<DebateRematchPageClient sessionId="rematch-1" />);
-      expect(listedClaims()).toHaveLength(2);
+      await showOpponentClaims();
+      expect(appearsBefore(FIRST_CLAIM, SECOND_CLAIM)).toBe(true);
 
       mocks.positions = [
         position('profile-remote', CLAIM_FRESH, SPACE_1, false),
@@ -1385,8 +1326,56 @@ describe('DebateRematchPageClient', () => {
       ];
       mocks.claims = [sessionRow(CLAIM_SHARED, FIRST_CLAIM, false), sessionRow(CLAIM_FRESH, THIRD_CLAIM, true)];
       rerender(<DebateRematchPageClient sessionId="rematch-1" />);
+      await settleTabSwap();
 
-      expect(listedClaims()[0]).toBe(THIRD_CLAIM);
+      expect(appearsBefore(THIRD_CLAIM, FIRST_CLAIM)).toBe(true);
+    });
+
+    /**
+     * The route keeps this component when it moves from one rematch to another — nothing keys it on
+     * the session — so the hold that carries a list through a refetch would otherwise carry it
+     * across a session change too. That is the wrong list twice over: the previous rematch's claims
+     * on screen while the new one loads, and their order seeding the new session's.
+     */
+    it('does not carry the previous session’s claims into a new one', async () => {
+      twoUnmatchedPositions();
+      const { rerender } = render(<DebateRematchPageClient sessionId="rematch-1" />);
+      await showOpponentClaims();
+      expect(within(positionsTab()).getByText('2')).toBeInTheDocument();
+
+      // The new session's lookups are in flight: nothing of its own to show yet.
+      mocks.entityHydrationLoading = true;
+      rerender(<DebateRematchPageClient sessionId="rematch-2" />);
+
+      // Asserted on the tab's own count rather than on the claims: the same rows also reach the
+      // Claims tab, so searching the document would find them whichever list they came from. And on
+      // the skeleton specifically — "not 2" would be satisfied by a confident `0`, which is the
+      // wrong answer rather than an absent one.
+      expect(screen.getByLabelText('Counting positions')).toBeInTheDocument();
+      expect(within(positionsTab()).queryByText('2')).not.toBeInTheDocument();
+    });
+
+    /**
+     * The window the session change opens: participants come from the session, positions from
+     * participants, the claim lookups from positions. While the session is in flight the whole
+     * chain is disabled rather than loading, so nothing downstream says "pending" — and the badge
+     * would answer `0` for a session it has not read yet. Zero is a claim about the opponent, not a
+     * placeholder.
+     */
+    it('does not answer zero positions for a session it has not read yet', async () => {
+      twoUnmatchedPositions();
+      const { rerender } = render(<DebateRematchPageClient sessionId="rematch-1" />);
+      await showOpponentClaims();
+      expect(within(positionsTab()).getByText('2')).toBeInTheDocument();
+
+      // Only the session is loading, and it has not returned yet — so everything keyed on what it
+      // returns is disabled, reporting `isLoading: false` while having nothing to say.
+      mocks.sessionLoading = true;
+      mocks.session = null;
+      rerender(<DebateRematchPageClient sessionId="rematch-2" />);
+
+      expect(screen.getByLabelText('Counting positions')).toBeInTheDocument();
+      expect(screen.queryByText('0')).not.toBeInTheDocument();
     });
   });
 

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
@@ -40,6 +40,8 @@ const {
 
 const mocks = vi.hoisted(() => ({
   session: null as DebateRematchSession | null,
+  /** The session lookup itself is in flight — everything below it is keyed on what it returns. */
+  sessionLoading: false,
   claims: [] as DebateRematchClaim[],
   replace: vi.fn(),
   back: vi.fn(),
@@ -148,7 +150,7 @@ vi.mock('~/core/debates/api', async importOriginal => {
 });
 
 vi.mock('~/core/debates/hooks', () => ({
-  useDebateRematch: () => ({ data: mocks.session, isLoading: false, error: null }),
+  useDebateRematch: () => ({ data: mocks.session, isLoading: mocks.sessionLoading, error: null }),
   // The session's own saved claims. `savedClaims` lets a test empty this so a claim can only
   // arrive through the id lookup.
   useDebateRematchClaims: () => ({
@@ -518,6 +520,7 @@ beforeEach(() => {
     disconnect() {}
   } as unknown as typeof ResizeObserver;
   mocks.session = session();
+  mocks.sessionLoading = false;
   mocks.claims = [sharedClaim()];
   mocks.perSpaceReadinessGroups = [];
   mocks.gatewaySpaceScopes = [];
@@ -1332,8 +1335,35 @@ describe('DebateRematchPageClient', () => {
       rerender(<DebateRematchPageClient sessionId="rematch-2" />);
 
       // Asserted on the tab's own count rather than on the claims: the same rows also reach the All
-      // tab, so searching the document would find them whichever list they came from.
+      // tab, so searching the document would find them whichever list they came from. And on the
+      // skeleton specifically — "not 2" would be satisfied by a confident `0`, which is the wrong
+      // answer rather than an absent one.
+      expect(screen.getByLabelText('Counting positions')).toBeInTheDocument();
       expect(positionsTab()).not.toHaveTextContent('2');
+    });
+
+    /**
+     * The window the session change opens: participants come from the session, positions from
+     * participants, the claim lookups from positions. While the session is in flight the whole
+     * chain is disabled rather than loading, so nothing downstream says "pending" — and the badge
+     * would answer `0` for a session it has not read yet. Zero is a claim about the opponent, not a
+     * placeholder.
+     */
+    it('does not answer zero positions for a session it has not read yet', () => {
+      twoUnmatchedPositions();
+      const { rerender } = render(<DebateRematchPageClient sessionId="rematch-1" />);
+      expect(screen.getByRole('button', { name: /Salina’s positions/ })).toHaveTextContent('2');
+
+      // Only the session is loading, and it has not returned yet — so everything keyed on what it
+      // returns is disabled, reporting `isLoading: false` while having nothing to say.
+      mocks.sessionLoading = true;
+      mocks.session = null;
+      rerender(<DebateRematchPageClient sessionId="rematch-2" />);
+
+      expect(screen.getByLabelText('Counting positions')).toBeInTheDocument();
+      // The tab is named from a fallback while the session is unknown, so the skeleton — not the
+      // tab's name — is what identifies the badge here.
+      expect(screen.queryByText('0')).not.toBeInTheDocument();
     });
 
     // The hold is on rows already shown, not on the arrangement itself: a claim the opponent

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
@@ -13,18 +13,30 @@ import type { ParticipantPosition } from '~/core/debates/participant-positions';
 
 import { DebateRematchPageClient } from './rematch-page-client';
 
-const { SPACE_1, SPACE_2, CLAIM_SHARED, CLAIM_MORE, CLAIM_SOURCE, CRYPTO_SPACE, PODCASTS_SPACE, NAME_PROPERTY } =
-  vi.hoisted(() => ({
-    SPACE_1: '019fedae-72b6-7ab2-927a-df044d57c566',
-    SPACE_2: '019fedae-72b6-7ab2-927a-df044d57c567',
-    // Real ids from the hard-coded ranking table, so the ordering under test is the real one.
-    CRYPTO_SPACE: 'c9f267dcb0d270718c2a3c45a64afd32',
-    PODCASTS_SPACE: 'b5a31f8182b042437ede0f84ee02f104',
-    NAME_PROPERTY: 'a126ca530c8e48d5b88882c734c38935',
-    CLAIM_SHARED: '019fedb1-0c41-7f3e-9a11-2c7d5e8b4419',
-    CLAIM_MORE: '019fedb2-1d52-7a4f-8b22-3d8e6f9c5520',
-    CLAIM_SOURCE: '019fedb3-2e63-7b50-9c33-4e9f7a0d6621',
-  }));
+const {
+  SPACE_1,
+  SPACE_2,
+  CLAIM_SHARED,
+  CLAIM_MORE,
+  CLAIM_SOURCE,
+  CLAIM_FRESH,
+  CRYPTO_SPACE,
+  PODCASTS_SPACE,
+  NAME_PROPERTY,
+} = vi.hoisted(() => ({
+  SPACE_1: '019fedae-72b6-7ab2-927a-df044d57c566',
+  SPACE_2: '019fedae-72b6-7ab2-927a-df044d57c567',
+  // Real ids from the hard-coded ranking table, so the ordering under test is the real one.
+  CRYPTO_SPACE: 'c9f267dcb0d270718c2a3c45a64afd32',
+  PODCASTS_SPACE: 'b5a31f8182b042437ede0f84ee02f104',
+  NAME_PROPERTY: 'a126ca530c8e48d5b88882c734c38935',
+  CLAIM_SHARED: '019fedb1-0c41-7f3e-9a11-2c7d5e8b4419',
+  CLAIM_MORE: '019fedb2-1d52-7a4f-8b22-3d8e6f9c5520',
+  CLAIM_SOURCE: '019fedb3-2e63-7b50-9c33-4e9f7a0d6621',
+  // A claim the opponent answers mid-session. Not CLAIM_SOURCE: that is the session's own
+  // claim, which the picker excludes.
+  CLAIM_FRESH: '019fedb4-3f74-7c61-8d44-5fa08b1e7722',
+}));
 
 const mocks = vi.hoisted(() => ({
   session: null as DebateRematchSession | null,
@@ -1227,6 +1239,102 @@ describe('DebateRematchPageClient', () => {
 
     expect(screen.queryByLabelText('Counting positions')).toBeNull();
     expect(screen.getByRole('button', { name: /Salina’s positions/ })).toHaveTextContent('1');
+  });
+
+  /**
+   * GEO-2698. `shared_preference` is read off the session row, so taking a side on a claim the
+   * opponent has already answered flips it — and the tab sorted matches to the top on every
+   * recompute. The row the viewer had just acted on jumped out from under them, taking the rest of
+   * the list with it.
+   *
+   * The sort is a load-time arrangement. It still decides where things start, and where a claim the
+   * opponent answers next arrives; what it no longer does is rearrange rows the viewer is working.
+   */
+  describe('opponent tab ordering', () => {
+    const FIRST_CLAIM = 'A claim both participants chose';
+    const SECOND_CLAIM = 'A second claim they answered';
+    const THIRD_CLAIM = 'A claim they answered just now';
+
+    /**
+     * A second claim of the opponent's, named in the same space they answered it in — `sidesOf`
+     * keys on claim *and* space, so a row whose home space differs from its position's has no
+     * participants and never reaches the tab.
+     */
+    function opponentEntity(id: string, name: string) {
+      return {
+        id,
+        name,
+        description: null,
+        spaces: [SPACE_1],
+        values: [{ property: { id: NAME_PROPERTY }, spaceId: SPACE_1, value: name }],
+        relations: [],
+      };
+    }
+
+    /** A session row for a claim the opponent answered, matched or not. */
+    function sessionRow(id: string, claim: string, sharedPreference: boolean) {
+      return { ...sharedClaim(), claim: claimSummary(id, claim), shared_preference: sharedPreference };
+    }
+
+    /** The opponent's two positions, neither a match yet, in the order the graph returns them. */
+    function twoUnmatchedPositions() {
+      mocks.positions = [
+        position('profile-remote', CLAIM_SHARED, SPACE_1, false),
+        position('profile-remote', CLAIM_MORE, SPACE_1, false),
+      ];
+      mocks.entities = [sharedEntity(), opponentEntity(CLAIM_MORE, SECOND_CLAIM)];
+      mocks.claims = [sessionRow(CLAIM_SHARED, 'A claim both participants chose', false)];
+    }
+
+    /** The claims on the opponent's tab, top to bottom, read off the rendered document. */
+    function listedClaims() {
+      return [FIRST_CLAIM, SECOND_CLAIM, THIRD_CLAIM]
+        .map(text => ({ text, node: screen.queryByText(text) }))
+        .filter((entry): entry is { text: string; node: HTMLElement } => entry.node !== null)
+        .sort((a, b) =>
+          // eslint-disable-next-line no-bitwise
+          a.node.compareDocumentPosition(b.node) & Node.DOCUMENT_POSITION_FOLLOWING ? -1 : 1
+        )
+        .map(entry => entry.text);
+    }
+
+    it('holds the order it loaded with when a position becomes a match', () => {
+      twoUnmatchedPositions();
+      const { rerender } = render(<DebateRematchPageClient sessionId="rematch-1" />);
+
+      const loaded = listedClaims();
+      expect(loaded).toHaveLength(2);
+      expect(loaded[1]).toBe(SECOND_CLAIM);
+
+      // The viewer takes a side on the second one: geo-chat's row comes back a match.
+      mocks.claims = [sessionRow(CLAIM_SHARED, FIRST_CLAIM, false), sessionRow(CLAIM_MORE, SECOND_CLAIM, true)];
+      rerender(<DebateRematchPageClient sessionId="rematch-1" />);
+
+      expect(listedClaims()).toEqual(loaded);
+    });
+
+    // The hold is on rows already shown, not on the arrangement itself: a claim the opponent
+    // answers next has never been under the viewer's cursor, so the sort still places it.
+    it('still puts a newly arrived match at the top', () => {
+      twoUnmatchedPositions();
+      const { rerender } = render(<DebateRematchPageClient sessionId="rematch-1" />);
+      expect(listedClaims()).toHaveLength(2);
+
+      mocks.positions = [
+        position('profile-remote', CLAIM_FRESH, SPACE_1, false),
+        position('profile-remote', CLAIM_SHARED, SPACE_1, false),
+        position('profile-remote', CLAIM_MORE, SPACE_1, false),
+      ];
+      mocks.entities = [
+        opponentEntity(CLAIM_FRESH, THIRD_CLAIM),
+        sharedEntity(),
+        opponentEntity(CLAIM_MORE, SECOND_CLAIM),
+      ];
+      mocks.claims = [sessionRow(CLAIM_SHARED, FIRST_CLAIM, false), sessionRow(CLAIM_FRESH, THIRD_CLAIM, true)];
+      rerender(<DebateRematchPageClient sessionId="rematch-1" />);
+
+      expect(listedClaims()[0]).toBe(THIRD_CLAIM);
+    });
   });
 
   // Until the curated lookup settles there is no telling "no curator page" from "not yet", and the

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
@@ -1313,6 +1313,29 @@ describe('DebateRematchPageClient', () => {
       expect(listedClaims()).toEqual(loaded);
     });
 
+    /**
+     * The route keeps this component when it moves from one rematch to another — nothing keys it on
+     * the session — so the hold that carries a list through a refetch would otherwise carry it
+     * across a session change too. That is the wrong list twice over: the previous rematch's claims
+     * on screen while the new one loads, and their order seeding the new session's.
+     */
+    it('does not carry the previous session’s claims into a new one', () => {
+      twoUnmatchedPositions();
+      const { rerender } = render(<DebateRematchPageClient sessionId="rematch-1" />);
+      expect(listedClaims()).toHaveLength(2);
+
+      const positionsTab = () => screen.getByRole('button', { name: /Salina’s positions/ });
+      expect(positionsTab()).toHaveTextContent('2');
+
+      // The new session's lookups are in flight: nothing of its own to show yet.
+      mocks.entityHydrationLoading = true;
+      rerender(<DebateRematchPageClient sessionId="rematch-2" />);
+
+      // Asserted on the tab's own count rather than on the claims: the same rows also reach the All
+      // tab, so searching the document would find them whichever list they came from.
+      expect(positionsTab()).not.toHaveTextContent('2');
+    });
+
     // The hold is on rows already shown, not on the arrangement itself: a claim the opponent
     // answers next has never been under the viewer's cursor, so the sort still places it.
     it('still puts a newly arrived match at the top', () => {

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -657,7 +657,7 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
       spaceAllowlist,
     ]
   );
-  const featuredClaims = useLastSettled(featuredClaimsNow, featuredClaimsSettling);
+  const featuredClaims = useLastSettled(featuredClaimsNow, featuredClaimsSettling, sessionId);
 
   // The All tab: geo-chat's rows, the graph's sides. Held while the allowlist resolves (see above).
   // It is still every claim the picker knows: the session's own rows — what both have answered,

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -83,8 +83,19 @@ function sameId(left: string, right: string) {
  * first settle there is nothing to hold, and the (empty) unsettled value comes through — which is
  * what lets the first load show a loading state instead of an empty list.
  */
-function useLastSettled<T>(value: T, settling: boolean): T {
+function useLastSettled<T>(value: T, settling: boolean, resetKey: string): T {
   const lastSettledRef = React.useRef<{ value: T } | null>(null);
+  const resetRef = React.useRef(resetKey);
+
+  // Holding across a change of key would be holding the wrong thing. The page keeps its instance
+  // when the route moves from one rematch to another — nothing keys it on the session — so without
+  // this the previous session's claims stay on screen while the new one loads, and the order they
+  // were in seeds the new session's.
+  if (resetRef.current !== resetKey) {
+    resetRef.current = resetKey;
+    lastSettledRef.current = null;
+  }
+
   if (!settling) lastSettledRef.current = { value };
   return settling && lastSettledRef.current ? lastSettledRef.current.value : value;
 }
@@ -569,7 +580,7 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   // A new response from the opponent adds an id, and the lookups keyed on the id list start over.
   // The list they were drawn from is still right for every claim already on it, so it stays up
   // until the new one lands rather than dropping to nothing in between.
-  const opponentClaimsHeld = useLastSettled(opponentClaimsNow, opponentClaimsSettling);
+  const opponentClaimsHeld = useLastSettled(opponentClaimsNow, opponentClaimsSettling, sessionId);
   // The sort above is a load-time arrangement, not a live one (GEO-2698). `shared_preference` is
   // read off the session row, so taking a side on a claim the opponent has already answered flips
   // it — and re-sorting sent the row the viewer had just acted on to the top, carrying the rest of
@@ -608,7 +619,7 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
       rowFromEntity,
     ]
   );
-  const curatedClaims = useLastSettled(curatedClaimsNow, curatedClaimsSettling);
+  const curatedClaims = useLastSettled(curatedClaimsNow, curatedClaimsSettling, sessionId);
 
   // Featured, in the order the tag query ranked it. Built exactly as the curated list is — the
   // entities are the same projection and the rows carry the same session flags — and held the same

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -797,12 +797,20 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
    * *from* positions, so while positions is still in flight the id list is empty, those queries
    * are disabled rather than loading, and nothing downstream reports as pending.
    *
+   * `sessionQuery.isLoading` for the same reason, one step further up. Participants come from the
+   * session, positions are keyed on participants, and the claim lookups are keyed on positions — so
+   * while the session is in flight the whole chain below it is disabled rather than loading and
+   * reports nothing. That window is reachable: the route keeps this component when it moves between
+   * rematches, and the held list is dropped on the way (see `useLastSettled`), so without this the
+   * badge answers `0` for a session it has not read yet.
+   *
    * Once a settled list exists the number is shown even while a refetch is in flight: a new
    * response from the opponent restarts the lookups, and `useLastSettled` is still holding a list
    * that is correct for every claim already on it. Going back to a skeleton there would flicker
    * the badge on exactly the event that ought to be invisible.
    */
-  const opponentCountPending = opponentClaims.length === 0 && (positions.isLoading || opponentClaimsSettling);
+  const opponentCountPending =
+    opponentClaims.length === 0 && (sessionQuery.isLoading || positions.isLoading || opponentClaimsSettling);
 
   // Recommended is offered only when a curator has a page for this pairing; the order is fixed, so
   // a source that appears doesn't reshuffle the ones already in the menu.

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -569,7 +569,22 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   // A new response from the opponent adds an id, and the lookups keyed on the id list start over.
   // The list they were drawn from is still right for every claim already on it, so it stays up
   // until the new one lands rather than dropping to nothing in between.
-  const opponentClaims = useLastSettled(opponentClaimsNow, opponentClaimsSettling);
+  const opponentClaimsHeld = useLastSettled(opponentClaimsNow, opponentClaimsSettling);
+  // The sort above is a load-time arrangement, not a live one (GEO-2698). `shared_preference` is
+  // read off the session row, so taking a side on a claim the opponent has already answered flips
+  // it — and re-sorting sent the row the viewer had just acted on to the top, carrying the rest of
+  // the list with it. Held so that arrangement survives the viewer acting on it; a claim the
+  // opponent answers next is new rather than moved, and still lands at the top where the sort puts
+  // it. Keyed on the session, so reopening the flow arranges it afresh.
+  //
+  // Applied after `useLastSettled` rather than before it: the hold remembers the rows it has been
+  // shown, and `opponentClaimsNow` empties on every refetch. Stabilising that would hand it an
+  // empty list mid-flight and lose the order at the moment it is needed.
+  const opponentClaims = useStableListOrder(
+    opponentClaimsHeld,
+    row => `${row.claim.space_id}:${row.claim.claim_entity_id}`,
+    sessionId
+  );
 
   // The curated tab, in the curator's order. Held the same way, and likewise not narrowed by the
   // space allowlist.


### PR DESCRIPTION
Closes GEO-2698.

## The cause

`shared_preference` is read off geo-chat's session row, so taking a side on a claim the opponent has already answered flips it to `true`. The opponent tab sorted matches to the top on every recompute:

```ts
.sort((a, b) => Number(b.shared_preference) - Number(a.shared_preference));
```

So the row the viewer had just acted on jumped to the top, carrying the rest of the list with it. The sort was being treated as a live ranking when it is a load-time arrangement — which is exactly how the ticket described it.

## The fix

`useStableListOrder` already existed for this, written for the hub's lists and used by the All tab immediately below this one. The opponent tab was the last list in the picker still sorting live, so this is one call rather than new machinery:

```ts
const opponentClaims = useStableListOrder(
  opponentClaimsHeld,
  row => `${row.claim.space_id}:${row.claim.claim_entity_id}`,
  sessionId
);
```

Rows already shown keep their relative order. A claim the opponent answers next has never been under the viewer's cursor, so the sort still places it — matches still arrive at the top.

## The two ordering decisions the ticket asked for

**When it re-sorts:** on the session id. Reopening the flow is the boundary where a fresh arrangement is what the viewer is asking for.

**Not on filter change**, unlike the All tab, which keys on `search|space|topic`. Those go to the server there, so a filter change means the server ranked a different list and holding the old order would arrange it by a ranking the viewer has moved on from. On the opponent tab the filtering is client-side and downstream — it removes rows from this list rather than re-ranking it, so there is no new arrangement to adopt.

**Not on tab switch.** The complaint is a row moving unbidden; making it move when the viewer comes back is a quieter version of the same surprise.

## Placement

After `useLastSettled`, not before. The hold remembers rows it has been shown, and the raw list empties on every refetch — stabilising that would hand it an empty list mid-flight and forget the order at the moment it is needed. There is a comment on this in the code, because it looks like a free choice and is not.

## Tests

Two in `rematch-page-client.test.tsx`, driving the real component:

- a position becoming a match leaves the order untouched
- a claim the opponent answers next still arrives at the top

The first fails without the fix (`expected [ Array(2) ] to deeply equal [ …(2) ]`). The second passes either way — it is a guard on the behaviour the fix must not cost, not a regression test, and I would rather say so than imply two tests where there is one.

112 tests pass in the file; 121 across `core/debates/matchmaking`.

## Worth knowing

The ticket flags GEO-2671 and GEO-2647 as the same class of problem and asks whether there is one shared cause. There is, and it is already half-addressed: `useStableListOrder` is the fix that came out of that work, and the All tab's `// Deliberately unsorted (GEO-2647)` comment is the other half. This ticket is the third list catching up. **GEO-2671 — the claim pushed to the bottom on infinite scroll — I have not looked at**, so I cannot say whether it is now covered or still open.

Not verified in a browser: the flow needs a live rematch session with two participants. The evidence here is the component rendered under test with geo-chat's rows mocked.
