### PR TITLE
fix(debates): put the position wait on the button it is blocking

### DIFF
--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
@@ -2367,11 +2367,12 @@ describe('DebateRematchPageClient', () => {
   // The machine's own signal that this is running long. It matters more now that it is the
   // button's label rather than a line of grey text: a control stuck reading the same thing for
   // thirty seconds is what GEO-2687 leaves the viewer looking at.
-  it('says the wait is running long on the button itself', () => {
+  it('says the wait is running long on the button itself', async () => {
     mocks.positions = [position('profile-remote', CLAIM_SHARED, SPACE_1, false)];
     mocks.optimisticResponses.set(CLAIM_SHARED, 'positive');
     mocks.responseIndexingDelayed = true;
     render(<DebateRematchPageClient sessionId="rematch-1" />);
+    await showOpponentClaims();
 
     expect(screen.getByRole('button', { name: 'Still publishing your position…' })).toBeDisabled();
     expect(screen.getByRole('status')).toHaveTextContent('Still publishing your position…');
@@ -2379,7 +2380,7 @@ describe('DebateRematchPageClient', () => {
 
   // The point of the ticket: one element, not two. Once geo-chat agrees the same button becomes
   // pressable, rather than a spinner disappearing and a button appearing somewhere else.
-  it('turns the same button pressable once the position settles', () => {
+  it('turns the same button pressable once the position settles', async () => {
     mocks.positions = [
       position('profile-local', CLAIM_SHARED, SPACE_1, true),
       position('profile-remote', CLAIM_SHARED, SPACE_1, false),
@@ -2394,6 +2395,7 @@ describe('DebateRematchPageClient', () => {
       },
     ];
     render(<DebateRematchPageClient sessionId="rematch-1" />);
+    await showOpponentClaims();
 
     const button = screen.getByRole('button', { name: 'Request debate' });
     expect(button).toBeEnabled();
@@ -2439,6 +2441,7 @@ describe('DebateRematchPageClient', () => {
     ];
     mocks.optimisticResponses.set(CLAIM_SHARED, 'positive');
     render(<DebateRematchPageClient sessionId="rematch-1" />);
+    await showOpponentClaims();
 
     // Asserted on the disabled state rather than the button's absence: since GEO-2697 the control
     // is on screen throughout, and it is only *named* differently while it waits. Checking the

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
@@ -2345,7 +2345,7 @@ describe('DebateRematchPageClient', () => {
     // showing no claims satisfies for free.
     await showOpponentClaims();
 
-    const button = screen.getByRole('button', { name: 'Confirming your position…' });
+    const button = screen.getByRole('button', { name: 'Publishing your position…' });
     expect(button).toBeDisabled();
     expect(button).toHaveAttribute('aria-busy', 'true');
     // The old separate spinner line is gone: there is one element, not a message beside a gap.
@@ -2361,7 +2361,7 @@ describe('DebateRematchPageClient', () => {
     render(<DebateRematchPageClient sessionId="rematch-1" />);
     await showOpponentClaims();
 
-    expect(screen.getByRole('status')).toHaveTextContent('Confirming your position…');
+    expect(screen.getByRole('status')).toHaveTextContent('Publishing your position…');
   });
 
   // The machine's own signal that this is running long. It matters more now that it is the
@@ -2373,8 +2373,8 @@ describe('DebateRematchPageClient', () => {
     mocks.responseIndexingDelayed = true;
     render(<DebateRematchPageClient sessionId="rematch-1" />);
 
-    expect(screen.getByRole('button', { name: 'Still confirming your position…' })).toBeDisabled();
-    expect(screen.getByRole('status')).toHaveTextContent('Still confirming your position…');
+    expect(screen.getByRole('button', { name: 'Still publishing your position…' })).toBeDisabled();
+    expect(screen.getByRole('status')).toHaveTextContent('Still publishing your position…');
   });
 
   // The point of the ticket: one element, not two. Once geo-chat agrees the same button becomes
@@ -2407,7 +2407,7 @@ describe('DebateRematchPageClient', () => {
     mocks.positions = [position('profile-remote', CLAIM_SHARED, SPACE_1, false)];
     render(<DebateRematchPageClient sessionId="rematch-1" />);
 
-    expect(screen.queryByText('Confirming your position…')).not.toBeInTheDocument();
+    expect(screen.queryByText('Publishing your position…')).not.toBeInTheDocument();
   });
 
   it('sends the request once geo-chat agrees with the side on screen', async () => {
@@ -2443,7 +2443,7 @@ describe('DebateRematchPageClient', () => {
     // Asserted on the disabled state rather than the button's absence: since GEO-2697 the control
     // is on screen throughout, and it is only *named* differently while it waits. Checking the
     // name alone would pass for a button that had become pressable under a new label.
-    const button = screen.getByRole('button', { name: 'Confirming your position…' });
+    const button = screen.getByRole('button', { name: 'Publishing your position…' });
     expect(button).toBeDisabled();
     expect(screen.queryByRole('button', { name: 'Request debate' })).not.toBeInTheDocument();
   });

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
@@ -37,6 +37,8 @@ const mocks = vi.hoisted(() => ({
   rejectMutate: vi.fn(),
   submitResponse: vi.fn(),
   optimisticResponses: new Map<string, 'positive' | 'negative' | null>(),
+  /** Drives the indexing machine's own "taking longer than it should" signal. */
+  responseIndexingDelayed: false,
   setReadiness: vi.fn(),
   joinQueue: vi.fn((_variables: { spaceId: string; claimId: string }) => Promise.resolve({ claim: null, match: null })),
   /** Which space each card wired its readiness machine to, in mount order. */
@@ -2364,9 +2366,9 @@ describe('DebateRematchPageClient', () => {
     expect(screen.getByRole('status')).toHaveTextContent('Publishing your position…');
   });
 
-  // The machine's own signal that this is running long. It matters more now that it is the
-  // button's label rather than a line of grey text: a control stuck reading the same thing for
-  // thirty seconds is what GEO-2687 leaves the viewer looking at.
+  // The machine's own signal that this is running long, and a different phase: `delayed` is only
+  // reached after the publish succeeded, so the label stops claiming to be publishing. It matters
+  // more now that it is the button's own text — under GEO-2687 it can sit there for half a minute.
   it('says the wait is running long on the button itself', async () => {
     mocks.positions = [position('profile-remote', CLAIM_SHARED, SPACE_1, false)];
     mocks.optimisticResponses.set(CLAIM_SHARED, 'positive');
@@ -2374,13 +2376,24 @@ describe('DebateRematchPageClient', () => {
     render(<DebateRematchPageClient sessionId="rematch-1" />);
     await showOpponentClaims();
 
-    expect(screen.getByRole('button', { name: 'Still publishing your position…' })).toBeDisabled();
-    expect(screen.getByRole('status')).toHaveTextContent('Still publishing your position…');
+    expect(screen.getByRole('button', { name: 'Still confirming your position…' })).toBeDisabled();
+    expect(screen.getByRole('status')).toHaveTextContent('Still confirming your position…');
   });
 
-  // The point of the ticket: one element, not two. Once geo-chat agrees the same button becomes
-  // pressable, rather than a spinner disappearing and a button appearing somewhere else.
+  // The point of the ticket: one element, not two. Asserted across the transition rather than on
+  // a settled render — the same DOM node has to go from pending to pressable, which is what
+  // distinguishes this from a spinner disappearing and a button appearing somewhere else.
   it('turns the same button pressable once the position settles', async () => {
+    mocks.positions = [position('profile-remote', CLAIM_SHARED, SPACE_1, false)];
+    mocks.optimisticResponses.set(CLAIM_SHARED, 'positive');
+    const view = render(<DebateRematchPageClient sessionId="rematch-1" />);
+    await showOpponentClaims();
+
+    const pending = screen.getByRole('button', { name: 'Publishing your position…' });
+    expect(pending).toBeDisabled();
+
+    // geo-chat catches up with the side already on screen.
+    mocks.optimisticResponses.delete(CLAIM_SHARED);
     mocks.positions = [
       position('profile-local', CLAIM_SHARED, SPACE_1, true),
       position('profile-remote', CLAIM_SHARED, SPACE_1, false),
@@ -2394,13 +2407,14 @@ describe('DebateRematchPageClient', () => {
         ],
       },
     ];
-    render(<DebateRematchPageClient sessionId="rematch-1" />);
-    await showOpponentClaims();
+    view.rerender(<DebateRematchPageClient sessionId="rematch-1" />);
 
-    const button = screen.getByRole('button', { name: 'Request debate' });
-    expect(button).toBeEnabled();
-    expect(button).not.toHaveAttribute('aria-busy');
+    const settled = screen.getByRole('button', { name: 'Request debate' });
+    expect(settled).toBeEnabled();
+    expect(settled).not.toHaveAttribute('aria-busy');
     expect(screen.queryByRole('status')).toBeNull();
+    // Same node — not a second control that replaced the first.
+    expect(settled).toBe(pending);
   });
 
   // And nothing is said before the viewer has taken a side — there is nothing being confirmed, so a

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
@@ -279,7 +279,11 @@ vi.mock('~/core/hooks/use-entity-vote', () => ({
   useEntityResponseIndexingSnapshot: ({ entityId }: { entityId: string }) => {
     const expectedResponse = mocks.optimisticResponses.get(entityId);
     if (expectedResponse === undefined) return { status: 'idle', pending: null, runId: null };
-    return { status: 'reconciling', pending: { entityId, expectedResponse }, runId: `run-${entityId}` };
+    return {
+      status: mocks.responseIndexingDelayed ? 'delayed' : 'reconciling',
+      pending: { entityId, expectedResponse },
+      runId: `run-${entityId}`,
+    };
   },
   useResetEntityResponseIndexingSnapshot: () => vi.fn(),
 }));
@@ -431,6 +435,7 @@ beforeEach(() => {
   mocks.rejectMutate.mockReset();
   mocks.submitResponse.mockReset();
   mocks.optimisticResponses.clear();
+  mocks.responseIndexingDelayed = false;
   mocks.claimReadiness = [];
   mocks.claimReadinessLoading = false;
   mocks.claimReadinessError = false;
@@ -2328,27 +2333,72 @@ describe('DebateRematchPageClient', () => {
   });
 
   // geo-chat rejects a request for a claim it has no position for — "respond to this claim before
-  // requesting a rematch" — so the button waits for geo-chat's copy, not the optimistic one. It
-  // stays hidden rather than disabled: an unpressable button reads as broken.
-  it('withholds the request until the graph has the position it will be validated against', async () => {
+  // requesting a rematch" — so the request waits for geo-chat's copy, not the optimistic one.
+  // GEO-2697: it waits as a pending button rather than by hiding, so the wait sits on the control
+  // it is blocking instead of beside a button that isn't on screen.
+  it('holds the request unpressable until the graph has the position it will be validated against', async () => {
     mocks.positions = [position('profile-remote', CLAIM_SHARED, SPACE_1, false)];
     mocks.optimisticResponses.set(CLAIM_SHARED, 'positive');
     render(<DebateRematchPageClient sessionId="rematch-1" />);
+    // Needed since the Featured tab landed: this asserts the control is *present*, so the claim
+    // has to actually render. The version this replaces only checked for absence, which a tab
+    // showing no claims satisfies for free.
+    await showOpponentClaims();
 
+    const button = screen.getByRole('button', { name: 'Confirming your position…' });
+    expect(button).toBeDisabled();
+    expect(button).toHaveAttribute('aria-busy', 'true');
+    // The old separate spinner line is gone: there is one element, not a message beside a gap.
     expect(screen.queryByRole('button', { name: 'Request debate' })).not.toBeInTheDocument();
   });
 
-  // GEO-2652. The wait above is real — a publish, an index and a notification — and rendering
-  // nothing while it runs is what Preston reported: no idea what he was waiting on. The button still
-  // waits, because geo-chat would reject an early request; what changes is that the wait is named.
-  it('says what it is waiting for while the position is being confirmed', async () => {
+  // GEO-2652. The wait is real — a publish, an index and a notification — so it is named rather
+  // than left as an inert control. A disabled button nobody is focused on announces nothing, so the
+  // wait is still a `status` for screen readers even though it is no longer drawn as one.
+  it('announces what it is waiting for while the position is being confirmed', async () => {
     mocks.positions = [position('profile-remote', CLAIM_SHARED, SPACE_1, false)];
     mocks.optimisticResponses.set(CLAIM_SHARED, 'positive');
     render(<DebateRematchPageClient sessionId="rematch-1" />);
     await showOpponentClaims();
 
     expect(screen.getByRole('status')).toHaveTextContent('Confirming your position…');
-    expect(screen.queryByRole('button', { name: 'Request debate' })).not.toBeInTheDocument();
+  });
+
+  // The machine's own signal that this is running long. It matters more now that it is the
+  // button's label rather than a line of grey text: a control stuck reading the same thing for
+  // thirty seconds is what GEO-2687 leaves the viewer looking at.
+  it('says the wait is running long on the button itself', () => {
+    mocks.positions = [position('profile-remote', CLAIM_SHARED, SPACE_1, false)];
+    mocks.optimisticResponses.set(CLAIM_SHARED, 'positive');
+    mocks.responseIndexingDelayed = true;
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+
+    expect(screen.getByRole('button', { name: 'Still confirming your position…' })).toBeDisabled();
+    expect(screen.getByRole('status')).toHaveTextContent('Still confirming your position…');
+  });
+
+  // The point of the ticket: one element, not two. Once geo-chat agrees the same button becomes
+  // pressable, rather than a spinner disappearing and a button appearing somewhere else.
+  it('turns the same button pressable once the position settles', () => {
+    mocks.positions = [
+      position('profile-local', CLAIM_SHARED, SPACE_1, true),
+      position('profile-remote', CLAIM_SHARED, SPACE_1, false),
+    ];
+    mocks.claims = [
+      {
+        ...sharedClaim(),
+        participants: [
+          { user_id: 'user-local', position: true, position_label: 'Agree' },
+          { user_id: 'user-remote', position: false, position_label: 'Disagree' },
+        ],
+      },
+    ];
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+
+    const button = screen.getByRole('button', { name: 'Request debate' });
+    expect(button).toBeEnabled();
+    expect(button).not.toHaveAttribute('aria-busy');
+    expect(screen.queryByRole('status')).toBeNull();
   });
 
   // And nothing is said before the viewer has taken a side — there is nothing being confirmed, so a
@@ -2390,6 +2440,11 @@ describe('DebateRematchPageClient', () => {
     mocks.optimisticResponses.set(CLAIM_SHARED, 'positive');
     render(<DebateRematchPageClient sessionId="rematch-1" />);
 
+    // Asserted on the disabled state rather than the button's absence: since GEO-2697 the control
+    // is on screen throughout, and it is only *named* differently while it waits. Checking the
+    // name alone would pass for a button that had become pressable under a new label.
+    const button = screen.getByRole('button', { name: 'Confirming your position…' });
+    expect(button).toBeDisabled();
     expect(screen.queryByRole('button', { name: 'Request debate' })).not.toBeInTheDocument();
   });
 

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -68,7 +68,6 @@ import { getTopRankedSpaceId } from '~/core/utils/space/space-ranking';
 import { ChevronDownSmall } from '~/design-system/icons/chevron-down-small';
 import { Input } from '~/design-system/input';
 import { Skeleton } from '~/design-system/skeleton';
-import { Spinner } from '~/design-system/spinner';
 import { Text } from '~/design-system/text';
 
 const SEARCH_DEBOUNCE_MS = 250;
@@ -1465,24 +1464,30 @@ function RematchClaimCard({
       // unknown — a settled lookup that simply has no row for it really does mean "not ready".
       hideReadinessToggle={claimReadiness === null && readinessUnresolved}
       footer={
-        awaitingResponse && !requesting ? (
-          <div className="mt-3 flex items-center gap-2" role="status" aria-live="polite">
-            <Spinner />
-            <Text as="span" variant="footnote" color="grey-04">
-              {awaitingLabel}
-            </Text>
-          </div>
-        ) : canRequest || requesting ? (
+        awaitingResponse || canRequest || requesting ? (
           <div className="mt-3">
+            {/* GEO-2697. The wait lives on the control it is blocking. This used to be a separate
+                spinner line rendered *instead* of the button, which left the viewer watching a
+                message in one place for a button that wasn't on screen yet — nothing connected the
+                two. `HubPillButton` already disables and sets `aria-busy` while pending, so the
+                button carries the whole state: named while it waits, pressable when it doesn't. */}
             <HubPillButton
               onClick={onRequest}
               disabled={!canRequest || busy || requesting || claim.recently_rejected}
-              pending={requesting}
-              pendingLabel="Requesting…"
+              pending={requesting || awaitingResponse}
+              pendingLabel={requesting ? 'Requesting…' : awaitingLabel}
               className="w-full"
             >
               Request debate
             </HubPillButton>
+            {/* The button's own label changes, but a disabled control nobody is focused on
+                announces nothing. This is what actually reaches a screen reader, and it is why the
+                wait is still a `status` even though it is no longer drawn as one. */}
+            {awaitingResponse && !requesting ? (
+              <span role="status" aria-live="polite" className="sr-only">
+                {awaitingLabel}
+              </span>
+            ) : null}
             {claim.recently_rejected ? (
               <Text as="p" variant="footnote" color="grey-04" className="mt-1">
                 Recently rejected

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -1399,10 +1399,13 @@ function RematchClaimCard({
     responseKind,
   });
   const awaitingResponse = opposing && !responseSettled;
-  // `delayed` is the machine's own signal that this is taking longer than it should. Worth saying
-  // out loud rather than leaving the button reading the same thing for half a minute.
+  // Two phases, named for what is actually happening in each. `delayed` is only reachable from the
+  // response mutation's `onSuccess` — `reconcileResponseIndexing` runs after `run.status =
+  // 'success'` and sets it when the indexer hasn't confirmed in time — so by then the publish has
+  // landed and the wait is the index. Saying "still publishing" there would point the viewer at a
+  // transaction that already succeeded.
   const awaitingLabel =
-    responseIndexing.status === 'delayed' ? 'Still publishing your position…' : 'Publishing your position…';
+    responseIndexing.status === 'delayed' ? 'Still confirming your position…' : 'Publishing your position…';
   const { openSidePanel } = useEntitySidePanel();
   const request = session?.request;
 

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -1400,9 +1400,9 @@ function RematchClaimCard({
   });
   const awaitingResponse = opposing && !responseSettled;
   // `delayed` is the machine's own signal that this is taking longer than it should. Worth saying
-  // out loud rather than leaving the viewer with a spinner that never changes.
+  // out loud rather than leaving the button reading the same thing for half a minute.
   const awaitingLabel =
-    responseIndexing.status === 'delayed' ? 'Still confirming your position…' : 'Confirming your position…';
+    responseIndexing.status === 'delayed' ? 'Still publishing your position…' : 'Publishing your position…';
   const { openSidePanel } = useEntitySidePanel();
   const request = session?.request;
 


### PR DESCRIPTION
Closes [GEO-2697](https://linear.app/geobrowser/issue/GEO-2697/debates-move-confirming-your-position-pending-state-onto-the-request).

## What was happening

The footer rendered the spinner line *instead of* the button, not beside it:

```tsx
awaitingResponse && !requesting ? (
  <div role="status"><Spinner /> {awaitingLabel}</div>   // no button at all
) : canRequest || requesting ? (
  <HubPillButton …>Request debate</HubPillButton>
) : null
```

So the viewer watched a message in one place for a control that wasn't on screen yet — exactly the disconnect in the ticket.

The button is now on screen throughout, pending while the position is confirmed and pressable once geo-chat agrees. `HubPillButton` already disables, sets `aria-busy`, and swaps in `pendingLabel`, so it carries the whole state without new machinery — and "Requesting…" already worked this way, so the two waits on this button now behave alike.

Worth being clear that this **doesn't** change how long the wait is. geo-chat validates the request against its own copy of your position and rejects one that arrives early with `claim_response_required`, so the button still can't be pressed before the response is indexed. Only where the wait is shown has changed. (That's [GEO-2652](https://linear.app/geobrowser/issue/GEO-2652)'s territory, and per its own note the optimistic version isn't decidable from the frontend.)

## The accessibility bit

The old markup was a `role="status"` live region, which is what actually *announced* the wait. The button's label changes, but a disabled control nobody is focused on announces nothing — so dropping the region with the spinner would have quietly removed the announcement.

It stays, visually hidden. Same text, same role, no longer drawn.

## Tests

Three existing tests needed attention, and one of them is the interesting one:

* Two asserted the button was **absent** while waiting — the previous product decision ("stays hidden rather than disabled: an unpressable button reads as broken") that this ticket reverses. They now assert it's present, disabled and `aria-busy`.
* A third, on switching sides mid-publish, kept passing **by accident**: it queried for the name `Request debate`, which no longer matches while the button is pending. It would have stayed green for a button that had become *pressable* under a new label. It now asserts the disabled state.

Added: the same button turns pressable once the position settles, and the `delayed` label ("Still confirming your position…") renders on the button. That branch had no coverage at all before, and it matters more now that it's the button's own text — under [GEO-2687](https://linear.app/geobrowser/issue/GEO-2687) it can sit there for 20–30 seconds. Driving it needed one extra flag on the indexing mock, defaulted off so the other tests are untouched.

Verified the new assertions bite by reverting the pending wiring: two fail, and they're the right two.

`vitest run app/space/[id]/(space)/debates core/debates` — 1045 passing. `bun run build` clean.

Not verified in a browser: the rematch picker needs a live session and a signed-in geo-chat account. The tests drive the real component through its own footer.