### PR TITLE
fix(debates): group the picker's source and space filters, keeping topic at the end

### DIFF
--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
@@ -858,20 +858,25 @@ describe('DebateRematchPageClient', () => {
       expect(screen.queryByRole('heading', { name: 'Geopolitics & chips' })).toBeNull();
     });
 
-    // The row spread its two menus across the full width, which was fine while there were two of
-    // them. With the source menu leading it, that pushed the space menu into the middle of the row
-    // instead of leaving it beside the source it belongs next to.
-    it('keeps the filter row left-aligned rather than spreading it', async () => {
+    // The row spread all of its menus across the full width, which was fine while there were two of
+    // them. With the source menu leading it, that stranded the space menu in the middle rather than
+    // leaving it beside the source it narrows. Only the topic menu goes to the far end now.
+    it('groups the source and space menus, leaving the topic menu at the end', async () => {
       render(<DebateRematchPageClient sessionId="rematch-1" />);
 
       const sourceMenu = screen.getByRole('button', { name: 'Featured' });
       const spaceMenu = screen.getByRole('button', { name: /Any space/ });
+      const topicMenu = screen.getByRole('button', { name: /Any topic/ });
       const row = sourceMenu.parentElement;
 
+      // The two that belong together share the row directly, in order, with nothing spreading them.
       expect(row).toBe(spaceMenu.parentElement);
       expect(row?.className).not.toContain('justify-between');
-      // And the source leads the row, so the space menu sits directly after it.
       expect(sourceMenu.compareDocumentPosition(spaceMenu) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+
+      // And the topic menu alone is pushed to the far end.
+      expect(topicMenu.parentElement?.className).toContain('ml-auto');
+      expect(topicMenu.parentElement?.parentElement).toBe(row);
     });
 
     // A fixed order, so a source that appears doesn't reshuffle the ones already in the menu.

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
@@ -858,6 +858,22 @@ describe('DebateRematchPageClient', () => {
       expect(screen.queryByRole('heading', { name: 'Geopolitics & chips' })).toBeNull();
     });
 
+    // The row spread its two menus across the full width, which was fine while there were two of
+    // them. With the source menu leading it, that pushed the space menu into the middle of the row
+    // instead of leaving it beside the source it belongs next to.
+    it('keeps the filter row left-aligned rather than spreading it', async () => {
+      render(<DebateRematchPageClient sessionId="rematch-1" />);
+
+      const sourceMenu = screen.getByRole('button', { name: 'Featured' });
+      const spaceMenu = screen.getByRole('button', { name: /Any space/ });
+      const row = sourceMenu.parentElement;
+
+      expect(row).toBe(spaceMenu.parentElement);
+      expect(row?.className).not.toContain('justify-between');
+      // And the source leads the row, so the space menu sits directly after it.
+      expect(sourceMenu.compareDocumentPosition(spaceMenu) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    });
+
     // A fixed order, so a source that appears doesn't reshuffle the ones already in the menu.
     it('offers the sources in a fixed order, Recommended first', async () => {
       curatedPage();

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -1142,7 +1142,6 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
               onTopicChange={setTopicId}
               facetSpaceIds={facetSpaceIds}
               facetTopics={facetTopics}
-              className="justify-between"
               // Only on Claims: the opponent's tab is one fixed source — their own responses — and
               // a menu offering three others there would read as filtering a list it can't reach.
               leading={

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -1142,6 +1142,7 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
               onTopicChange={setTopicId}
               facetSpaceIds={facetSpaceIds}
               facetTopics={facetTopics}
+              topicAtEnd
               // Only on Claims: the opponent's tab is one fixed source — their own responses — and
               // a menu offering three others there would read as filtering a list it can't reach.
               leading={

--- a/apps/web/core/debates/matchmaking/claims-tab.test.tsx
+++ b/apps/web/core/debates/matchmaking/claims-tab.test.tsx
@@ -970,6 +970,16 @@ describe('ClaimsTab -- Featured', () => {
     expect(screen.queryByText('Chips are better than fries')).toBeNull();
   });
 
+  // The panel is narrow enough that three menus fill the row on their own. Pushing the topic one to
+  // the far end there — as the rematch picker does, where there is width to spare — would only
+  // separate it from the two it sits with.
+  it('leaves the topic menu beside the others rather than at the far end', () => {
+    render(<ClaimsTab />);
+
+    const topicMenu = screen.getByRole('button', { name: /Any topic/ });
+    expect(topicMenu.parentElement?.className ?? '').not.toContain('ml-auto');
+  });
+
   // Featured leads the menu because it is what the tab opens on; an option you land on shouldn't
   // sit below the one you didn't.
   it('leads the position menu, ahead of All claims', () => {

--- a/apps/web/core/debates/matchmaking/claims-tab.tsx
+++ b/apps/web/core/debates/matchmaking/claims-tab.tsx
@@ -2,8 +2,6 @@
 
 import * as React from 'react';
 
-import cx from 'classnames';
-
 import { TOPICS_PROPERTY_ID } from '~/core/claims/ontology';
 import { claimResponseKind } from '~/core/claims/response-kind';
 import { useInfiniteScrollSentinel } from '~/core/hooks/use-infinite-scroll-sentinel';
@@ -501,8 +499,6 @@ type SpaceTopicFiltersProps = {
   facetTopics?: { id: string; name: string | null }[];
   /** Rendered before the space filter — the Claims tab puts its position filter here. */
   leading?: React.ReactNode;
-  /** Overrides the row layout — the rematch picker spreads the two menus across its width. */
-  className?: string;
 };
 
 /**
@@ -519,7 +515,6 @@ export function SpaceTopicFilters({
   facetSpaceIds,
   facetTopics,
   leading,
-  className,
 }: SpaceTopicFiltersProps) {
   const { labelsById, isLoading: labelsLoading } = useSpaceLabels(facetSpaceIds);
 
@@ -554,7 +549,7 @@ export function SpaceTopicFilters({
   const topicLabel = topicId ? (facetTopics?.find(topic => topic.id === topicId)?.name ?? 'Topic') : 'Any topic';
 
   return (
-    <div className={cx('flex flex-wrap items-center gap-2', className)}>
+    <div className="flex flex-wrap items-center gap-2">
       {leading}
       <HubFilterMenu
         label={selectedSpaceLabel}

--- a/apps/web/core/debates/matchmaking/claims-tab.tsx
+++ b/apps/web/core/debates/matchmaking/claims-tab.tsx
@@ -2,6 +2,8 @@
 
 import * as React from 'react';
 
+import cx from 'classnames';
+
 import { TOPICS_PROPERTY_ID } from '~/core/claims/ontology';
 import { claimResponseKind } from '~/core/claims/response-kind';
 import { useInfiniteScrollSentinel } from '~/core/hooks/use-infinite-scroll-sentinel';
@@ -499,6 +501,13 @@ type SpaceTopicFiltersProps = {
   facetTopics?: { id: string; name: string | null }[];
   /** Rendered before the space filter — the Claims tab puts its position filter here. */
   leading?: React.ReactNode;
+  /**
+   * Pushes the topic menu to the far end of the row, leaving the source and space menus together on
+   * the left. For a surface with width to spare: the rematch picker is a full page, where a row of
+   * menus huddled at one edge leaves an obvious gap. The side panel is narrow enough that they fill
+   * the row anyway, and pushing one out there would only separate it from the others.
+   */
+  topicAtEnd?: boolean;
 };
 
 /**
@@ -515,6 +524,7 @@ export function SpaceTopicFilters({
   facetSpaceIds,
   facetTopics,
   leading,
+  topicAtEnd,
 }: SpaceTopicFiltersProps) {
   const { labelsById, isLoading: labelsLoading } = useSpaceLabels(facetSpaceIds);
 
@@ -560,12 +570,17 @@ export function SpaceTopicFilters({
         showImages
       />
       {facetTopics && onTopicChange ? (
-        <HubFilterMenu
-          label={topicLabel}
-          options={topicOptions}
-          value={topicId ?? ''}
-          onChange={value => onTopicChange(value || null)}
-        />
+        // `ml-auto` on the menu itself rather than `justify-between` on the row: with three items
+        // that spread all of them, which stranded the space menu in the middle instead of leaving
+        // it beside the source it narrows.
+        <div className={cx(topicAtEnd && 'ml-auto')}>
+          <HubFilterMenu
+            label={topicLabel}
+            options={topicOptions}
+            value={topicId ?? ''}
+            onChange={value => onTopicChange(value || null)}
+          />
+        </div>
       ) : null}
     </div>
   );


### PR DESCRIPTION
Follow-up to [GEO-2683](https://linear.app/geobrowser/issue/GEO-2683/debates-add-featured-option-to-claims-tab-and-use-it-in-place-of) (#2251).

## What

The debate-again picker's filter row carried `justify-between`, which spread its menus across the picker's full width. With two menus that read fine — **Any space** on the left, **Any topic** on the right. #2251 added the source menu in front of them, and `justify-between` spread three instead, stranding **Any space** in the middle of the row rather than beside the source menu it narrows.

`justify-between` was the wrong tool once there were three: it justifies the whole row, where what the picker wants is two menus grouped left and one held at the end. So the topic menu gets `ml-auto` instead, and the row keeps the plain left-aligned layout every other hub surface uses:

```
[ Featured ] [ Any space ]                              [ Any topic ]
```

## Why a prop rather than `className`

The picker was the only caller passing `className`, and its doc comment ("spreads the two menus across its width") no longer describes anything real. It's replaced by `topicAtEnd`, which says what the caller actually wants — one menu's placement, not the row's justification.

Only the picker sets it. The side panel is narrow enough that three menus fill the row on their own, so pushing one to the far end there would just separate it from the two it sits with.

## Testing

- `groups the source and space menus, leaving the topic menu at the end` (picker) — the source and space menus share the row in order with nothing spreading them, and the topic menu alone is pushed to the end.
- `leaves the topic menu beside the others rather than at the far end` (side panel) — pins the difference between the two surfaces, so the default can't quietly flip.
- Full web suite: 313 files passing. `bun run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
