### PR TITLE
GEO-2685: Add hover control to insert text blocks

### DIFF
--- a/apps/web/partials/editor/block-reorder.test.ts
+++ b/apps/web/partials/editor/block-reorder.test.ts
@@ -1,6 +1,6 @@
 import { DndContext } from '@dnd-kit/core';
 import '@testing-library/jest-dom/vitest';
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import Document from '@tiptap/extension-document';
 import Paragraph from '@tiptap/extension-paragraph';
 import Text from '@tiptap/extension-text';
@@ -16,6 +16,7 @@ import {
   getGutterHoveredChildIndex,
   getNextKeyboardDropBoundary,
   getTopLevelBlockElements,
+  insertTextBlockBelow,
   isBlockDropNoOp,
   makeDropZones,
   moveTopLevelBlock,
@@ -26,12 +27,16 @@ const editors: Editor[] = [];
 
 afterEach(() => {
   cleanup();
-  for (const editor of editors.splice(0)) editor.destroy();
+  for (const editor of editors.splice(0)) {
+    editor.view.dom.remove();
+    editor.destroy();
+  }
   vi.unstubAllGlobals();
 });
 
 describe('BlockDragHandle', () => {
-  it('bridges the gap between the visible handle and the hovered block', () => {
+  it('renders the plus button to the left of the drag handle', () => {
+    const onInsertBelow = vi.fn();
     render(
       React.createElement(
         DndContext,
@@ -42,16 +47,21 @@ describe('BlockDragHandle', () => {
           left: -32,
           isDragging: false,
           visible: true,
+          onInsertBelow,
         })
       )
     );
 
-    const button = screen.getByRole('button', { name: 'Drag block 1 to reorder' });
-    const hoverBridge = button.parentElement;
+    const addButton = screen.getByRole('button', { name: 'Add block below block 1' });
+    const dragButton = screen.getByRole('button', { name: 'Drag block 1 to reorder' });
+    const hoverCluster = dragButton.parentElement;
 
-    expect(button).toHaveClass('size-6');
-    expect(hoverBridge).toHaveAttribute('data-block-drag-handle');
-    expect(hoverBridge).toHaveClass('w-8');
+    expect(addButton.compareDocumentPosition(dragButton)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+    expect(hoverCluster).toHaveAttribute('data-block-drag-handle');
+    expect(hoverCluster).toHaveClass('w-[60px]');
+
+    fireEvent.click(addButton);
+    expect(onInsertBelow).toHaveBeenCalledOnce();
   });
 
   it('reveals a hidden handle when it receives keyboard focus', () => {
@@ -153,10 +163,37 @@ describe('BlockGutterHoverArea', () => {
 
     expect(container.querySelector('[data-block-drag-gutter]')).toHaveStyle({
       top: '10px',
-      left: '52px',
-      width: '48px',
+      left: '40px',
+      width: '60px',
       height: '60px',
     });
+  });
+});
+
+describe('insertTextBlockBelow', () => {
+  it('inserts an empty paragraph directly below the selected block and focuses it', async () => {
+    const editor = makeEditor(['A', 'B']);
+    document.body.appendChild(editor.view.dom);
+
+    expect(insertTextBlockBelow(editor, 0)).toBe(true);
+
+    expect(blockText(editor)).toEqual(['A', '', 'B']);
+    expect(editor.state.selection.from).toBe(editor.state.doc.child(0).nodeSize + 1);
+    await waitFor(() => expect(editor.isFocused).toBe(true));
+  });
+
+  it('inserts below the final block', () => {
+    const editor = makeEditor(['A', 'B']);
+
+    expect(insertTextBlockBelow(editor, 1)).toBe(true);
+    expect(blockText(editor)).toEqual(['A', 'B', '']);
+  });
+
+  it('does not change the document for an invalid block index', () => {
+    const editor = makeEditor(['A']);
+
+    expect(insertTextBlockBelow(editor, 1)).toBe(false);
+    expect(blockText(editor)).toEqual(['A']);
   });
 });
 
@@ -203,7 +240,7 @@ describe('getGutterHoveredChildIndex', () => {
   });
 
   it('ignores pointers outside the left gutter', () => {
-    expect(getGutterHoveredChildIndex(blocks, 51, 20, 100)).toBeNull();
+    expect(getGutterHoveredChildIndex(blocks, 39, 20, 100)).toBeNull();
     expect(getGutterHoveredChildIndex(blocks, 101, 20, 100)).toBeNull();
   });
 });

--- a/apps/web/partials/editor/block-reorder.tsx
+++ b/apps/web/partials/editor/block-reorder.tsx
@@ -22,6 +22,7 @@ import type { Editor } from '@tiptap/react';
 import * as React from 'react';
 
 import { OrderDots } from '~/design-system/icons/order-dots';
+import { Plus } from '~/design-system/icons/plus';
 
 import { ensureUniqueNodeIds } from './id-extension';
 
@@ -40,7 +41,7 @@ type DropZoneLayout = {
   indicatorTop: number;
 };
 
-const GUTTER_HOVER_WIDTH = 48;
+const GUTTER_HOVER_WIDTH = 60;
 
 type Props = {
   children: React.ReactNode;
@@ -233,6 +234,12 @@ export function BlockReorder({ children, editor, editorWrapperRef, enabled, onRe
     resetDragState();
   };
 
+  const handleInsertBelow = (childIndex: number) => {
+    if (!enabled) return;
+
+    insertTextBlockBelow(editor, childIndex);
+  };
+
   return (
     <DndContext
       sensors={sensors}
@@ -255,9 +262,10 @@ export function BlockReorder({ children, editor, editorWrapperRef, enabled, onRe
               key={getBlockDragHandleKey(editor, layout.childIndex)}
               childIndex={layout.childIndex}
               top={layout.top + Math.min(16, (layout.bottom - layout.top) / 2) - 12}
-              left={editorLeft - 32}
+              left={editorLeft - GUTTER_HOVER_WIDTH}
               isDragging={activeChildIndex !== null}
               visible={layout === handleLayout && visibleHandleIndex !== null}
+              onInsertBelow={() => handleInsertBelow(layout.childIndex)}
             />
           ))
         : null}
@@ -337,12 +345,14 @@ export function BlockDragHandle({
   left,
   isDragging,
   visible,
+  onInsertBelow,
 }: {
   childIndex: number;
   top: number;
   left: number;
   isDragging: boolean;
   visible: boolean;
+  onInsertBelow?: () => void;
 }) {
   const [isFocused, setIsFocused] = React.useState(false);
   const [isCoarseOrHoverlessPointer, setIsCoarseOrHoverlessPointer] = React.useState(false);
@@ -366,7 +376,7 @@ export function BlockDragHandle({
   return (
     <div
       data-block-drag-handle
-      className="absolute z-30 flex h-6 w-8 items-center"
+      className="absolute z-30 flex h-6 w-[60px] items-center gap-1 pr-2"
       style={{
         top,
         left,
@@ -374,6 +384,20 @@ export function BlockDragHandle({
         pointerEvents: isAvailable ? 'auto' : 'none',
       }}
     >
+      {onInsertBelow ? (
+        <button
+          type="button"
+          aria-label={`Add block below block ${childIndex + 1}`}
+          title="Add block below"
+          className="flex size-6 shrink-0 items-center justify-center rounded text-grey-04 transition-colors hover:bg-grey-01 hover:text-text focus-visible:bg-grey-01"
+          onMouseDown={event => event.preventDefault()}
+          onClick={onInsertBelow}
+          onFocus={() => setIsFocused(true)}
+          onBlur={() => setIsFocused(false)}
+        >
+          <Plus />
+        </button>
+      ) : null}
       <button
         ref={setNodeRef}
         type="button"
@@ -560,6 +584,20 @@ export function moveTopLevelBlock(editor: Editor, sourceIndex: number, dropBound
 
   editor.view.dispatch(transaction);
   return true;
+}
+
+/** Inserts a standard text block below a top-level node and moves the cursor into it. */
+export function insertTextBlockBelow(editor: Editor, childIndex: number): boolean {
+  const { doc } = editor.state;
+  if (childIndex < 0 || childIndex >= doc.childCount) return false;
+
+  const insertPosition = positionBeforeChild(doc, childIndex + 1);
+  return editor
+    .chain()
+    .insertContentAt(insertPosition, { type: 'paragraph' })
+    .focus(insertPosition + 1)
+    .scrollIntoView()
+    .run();
 }
 
 function positionBeforeChild(doc: Editor['state']['doc'], childIndex: number) {


### PR DESCRIPTION
## Summary
- add a plus button to the left of each hovered content-block drag handle
- insert a standard empty text block directly below the selected block
- move focus and the cursor into the new block immediately
- extend the left hover gutter across the full control cluster

## Testing
- bun run test partials/editor/block-reorder.test.ts partials/editor/id-extension.test.ts core/state/editor/get-block-position-changes.test.ts core/state/editor/make-block-position.test.ts
- bun run lint (passes with existing warnings)

Linear: [GEO-2685](https://linear.app/geobrowser/issue/GEO-2685/blocks-add-a-plus-button-on-hover-to-insert-a-block-below-and-focus-it)