### PR TITLE
fix: make search results and bounty links real links

### DIFF
--- a/apps/web/core/utils/is-modified-click.ts
+++ b/apps/web/core/utils/is-modified-click.ts
@@ -8,8 +8,10 @@
  * nothing at all. Fanning research out across tabs is a core way to read a knowledge graph, so this
  * is a question of function rather than polish (GEO-2701).
  *
- * `button === 1` is the middle button. It arrives as `auxclick` rather than `click` in modern
- * browsers, but React's `onClick` still sees it in some paths, and checking costs nothing.
+ * `button === 1` is the middle button, which browsers deliver as `auxclick` rather than `click` —
+ * so an `onClick` handler never sees one. It is checked here for handlers wired to `onAuxClick` or
+ * to a raw listener, which do. An anchor needs none of this for middle click: nothing runs, nothing
+ * prevents the default, and the browser opens its background tab.
  */
 export function isModifiedClick(event: {
   metaKey?: boolean;

--- a/apps/web/core/utils/is-modified-click.ts
+++ b/apps/web/core/utils/is-modified-click.ts
@@ -1,0 +1,22 @@
+/**
+ * Whether a click asked the browser to do something other than follow the link here and now —
+ * cmd/ctrl for a new tab, shift for a new window, alt to download, middle click for a background
+ * tab.
+ *
+ * A handler that navigates on click has to check this. Without it, cmd-clicking an entity opens it
+ * in a new tab *and* moves the current one, or the handler swallows the event and the modifier does
+ * nothing at all. Fanning research out across tabs is a core way to read a knowledge graph, so this
+ * is a question of function rather than polish (GEO-2701).
+ *
+ * `button === 1` is the middle button. It arrives as `auxclick` rather than `click` in modern
+ * browsers, but React's `onClick` still sees it in some paths, and checking costs nothing.
+ */
+export function isModifiedClick(event: {
+  metaKey?: boolean;
+  ctrlKey?: boolean;
+  shiftKey?: boolean;
+  altKey?: boolean;
+  button?: number;
+}): boolean {
+  return Boolean(event.metaKey || event.ctrlKey || event.shiftKey || event.altKey || event.button === 1);
+}

--- a/apps/web/design-system/autocomplete/results-list.test.tsx
+++ b/apps/web/design-system/autocomplete/results-list.test.tsx
@@ -52,13 +52,30 @@ describe('ResultContent', () => {
       ['cmd', { metaKey: true }],
       ['ctrl', { ctrlKey: true }],
       ['shift', { shiftKey: true }],
-      ['middle click', { button: 1 }],
     ])('leaves a %s click to the browser', (_name, modifier) => {
       const { onClick } = renderRow({ href: HREF });
 
       const event = fireEvent.click(screen.getByRole('link', { name: /Ethereum/ }), modifier);
 
       // Not prevented: the browser still gets to open its new tab.
+      expect(event).toBe(true);
+      expect(onClick).not.toHaveBeenCalled();
+    });
+
+    /**
+     * Middle click arrives as `auxclick`, which no `onClick` handler sees — so what carries it is
+     * the anchor itself: nothing runs, nothing prevents the default, the browser opens its
+     * background tab. Dispatched as the real event rather than a `click` with `button: 1`, which
+     * would pass against a plain button and prove nothing.
+     */
+    it('leaves a middle click to the browser', () => {
+      const { onClick } = renderRow({ href: HREF });
+
+      const event = fireEvent(
+        screen.getByRole('link', { name: /Ethereum/ }),
+        new MouseEvent('auxclick', { bubbles: true, cancelable: true, button: 1 })
+      );
+
       expect(event).toBe(true);
       expect(onClick).not.toHaveBeenCalled();
     });
@@ -72,6 +89,21 @@ describe('ResultContent', () => {
 
       expect(event).toBe(false);
       expect(onClick).toHaveBeenCalledTimes(1);
+    });
+    /**
+     * A row standing in for something already taken does not travel, by any means of asking. The
+     * modifier branch returns without preventing the default, so without a check ahead of it a
+     * cmd-click would open a row the surface is showing as unavailable.
+     */
+    it('goes nowhere when the row is already taken', () => {
+      const { onClick } = renderRow({ href: HREF, alreadySelected: true });
+
+      const plain = fireEvent.click(screen.getByRole('link', { name: /Ethereum/ }));
+      const modified = fireEvent.click(screen.getByRole('link', { name: /Ethereum/ }), { metaKey: true });
+
+      expect(plain).toBe(false);
+      expect(modified).toBe(false);
+      expect(onClick).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/web/design-system/autocomplete/results-list.test.tsx
+++ b/apps/web/design-system/autocomplete/results-list.test.tsx
@@ -1,0 +1,95 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+
+import type React from 'react';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { ResultContent } from './results-list';
+
+/**
+ * GEO-2701. A search result goes somewhere, so it has to be something the browser can act on.
+ * Rendered as a button it had no destination: cmd-click opened nothing, middle click did nothing,
+ * and right click offered no "Open in new tab" — the interactions people use to fan a knowledge
+ * graph out across tabs.
+ *
+ * The same component is the picker's row, where clicking chooses a value rather than travelling to
+ * one. That row has nowhere to go, so it stays a button; the difference is whether a caller passes
+ * an `href`.
+ */
+vi.mock('~/design-system/geo-image', () => ({ GeoImage: () => null }));
+vi.mock('~/design-system/native-geo-image', () => ({ NativeGeoImage: () => null }));
+
+afterEach(cleanup);
+
+const RESULT = {
+  id: 'entity-1',
+  name: 'Ethereum',
+  description: null,
+  types: [],
+  spaces: [{ spaceId: 'space-1', name: 'Crypto', image: null }],
+} as never;
+
+const HREF = '/space/space-1/entity-1';
+
+function renderRow(props: Partial<React.ComponentProps<typeof ResultContent>> = {}) {
+  const onClick = vi.fn();
+  render(<ResultContent onClick={onClick} result={RESULT} {...props} />);
+  return { onClick };
+}
+
+describe('ResultContent', () => {
+  describe('as a link', () => {
+    it('is an anchor carrying where it goes', () => {
+      renderRow({ href: HREF });
+
+      expect(screen.getByRole('link', { name: /Ethereum/ })).toHaveAttribute('href', HREF);
+    });
+
+    // The browser was asked for a new tab. Following the href *and* running the row's own handler
+    // would open the result twice: once beside the current page and once in place of it.
+    it.each([
+      ['cmd', { metaKey: true }],
+      ['ctrl', { ctrlKey: true }],
+      ['shift', { shiftKey: true }],
+      ['middle click', { button: 1 }],
+    ])('leaves a %s click to the browser', (_name, modifier) => {
+      const { onClick } = renderRow({ href: HREF });
+
+      const event = fireEvent.click(screen.getByRole('link', { name: /Ethereum/ }), modifier);
+
+      // Not prevented: the browser still gets to open its new tab.
+      expect(event).toBe(true);
+      expect(onClick).not.toHaveBeenCalled();
+    });
+
+    // An ordinary click belongs to whoever already handled selection — cmdk, in the search dialog.
+    // Letting the href go too would navigate twice.
+    it('hands an ordinary click to the row’s own handler', () => {
+      const { onClick } = renderRow({ href: HREF });
+
+      const event = fireEvent.click(screen.getByRole('link', { name: /Ethereum/ }));
+
+      expect(event).toBe(false);
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('as a picker row', () => {
+    // Nothing to navigate to, so nothing to make a link of.
+    it('stays a button when it has nowhere to go', () => {
+      renderRow();
+
+      expect(screen.queryByRole('link')).not.toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /Ethereum/ })).toBeInTheDocument();
+    });
+
+    it('still selects on click', () => {
+      const { onClick } = renderRow();
+
+      fireEvent.click(screen.getByRole('button', { name: /Ethereum/ }));
+
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/apps/web/design-system/autocomplete/results-list.tsx
+++ b/apps/web/design-system/autocomplete/results-list.tsx
@@ -99,8 +99,6 @@ function ResultRow({
       onClick={event => {
         // A row standing in for something already taken does not travel, by any means of asking.
         // Checked before the modifier branch, which returns without preventing the default.
-        // A row standing in for something already taken does not travel, by any means of asking.
-        // Checked before the modifier branch, which returns without preventing the default.
         if (disabled) {
           event.preventDefault();
           return;

--- a/apps/web/design-system/autocomplete/results-list.tsx
+++ b/apps/web/design-system/autocomplete/results-list.tsx
@@ -68,6 +68,7 @@ export const ResultItem = ({ existsOnEntity = false, className = '', ...rest }: 
 function ResultRow({
   href,
   onActivate,
+  disabled = false,
   className,
   children,
   ...rest
@@ -75,9 +76,14 @@ function ResultRow({
   href?: string;
   /** Named away from `onSelect`, which is a DOM prop and collides with the spread row props. */
   onActivate: () => void;
+  /** The row is showing something the caller has already taken; it renders but does not act. */
+  disabled?: boolean;
   className: string;
   children: React.ReactNode;
-} & Record<string, unknown>) {
+  // Attributes both elements understand. Deliberately not the button's own props: `disabled`,
+  // `type` and `form` mean nothing on an anchor, and a wider type here would let a caller pass one
+  // and have it quietly do nothing on whichever branch it landed in.
+} & React.HTMLAttributes<HTMLElement>) {
   if (!href) {
     return (
       <button onClick={onActivate} className={className} {...rest}>
@@ -91,6 +97,14 @@ function ResultRow({
       href={href}
       className={className}
       onClick={event => {
+        // A row standing in for something already taken does not travel, by any means of asking.
+        // Checked before the modifier branch, which returns without preventing the default.
+        // A row standing in for something already taken does not travel, by any means of asking.
+        // Checked before the modifier branch, which returns without preventing the default.
+        if (disabled) {
+          event.preventDefault();
+          return;
+        }
         // The browser has been asked for a new tab or window. Let it, and stop the event here so
         // the list around this row does not navigate the current one as well.
         if (isModifiedClick(event)) {
@@ -123,7 +137,9 @@ type ResultContentProps = {
    * pickers, which select a value instead.
    */
   href?: string;
-} & React.ComponentPropsWithoutRef<'button'>;
+  // Attributes shared by the button and the anchor this row can be. It used to promise the
+  // button's own props, which no caller used and the anchor branch could not honour.
+} & React.HTMLAttributes<HTMLElement>;
 
 export const ResultContent = ({
   onClick,
@@ -160,6 +176,7 @@ export const ResultContent = ({
       <ResultRow
         href={href}
         onActivate={onSelect}
+        disabled={alreadySelected}
         className={cx(
           active && 'bg-grey-01',
           alreadySelected ? 'cursor-not-allowed bg-grey-01' : 'cursor-pointer',
@@ -274,6 +291,7 @@ export const SpaceContent = ({
       <ResultRow
         href={href}
         onActivate={onSelect}
+        disabled={alreadySelected}
         className={cx(
           alreadySelected ? 'cursor-not-allowed bg-grey-01' : 'cursor-pointer',
           'flex w-full flex-col p-2 transition-colors duration-150 hover:bg-grey-01 focus:bg-grey-01 focus:outline-hidden'

--- a/apps/web/design-system/autocomplete/results-list.tsx
+++ b/apps/web/design-system/autocomplete/results-list.tsx
@@ -6,6 +6,7 @@ import cx from 'classnames';
 
 import { useEntity } from '~/core/database/entities';
 import { SearchResult, SpaceEntity } from '~/core/types';
+import { isModifiedClick } from '~/core/utils/is-modified-click';
 
 import { Breadcrumb } from '~/design-system/breadcrumb';
 import { CheckboxVisual } from '~/design-system/checkbox';
@@ -57,6 +58,57 @@ export const ResultItem = ({ existsOnEntity = false, className = '', ...rest }: 
   />
 );
 
+/**
+ * A result row: a link where the row goes somewhere, a button where it picks something.
+ *
+ * Search results are links, and a link the browser cannot act on is a link with most of its
+ * behaviour missing — no cmd-click, no middle click, nothing under right click (GEO-2701). Pickers
+ * choose a value rather than navigate, so they pass no `href` and keep the button they had.
+ */
+function ResultRow({
+  href,
+  onActivate,
+  className,
+  children,
+  ...rest
+}: {
+  href?: string;
+  /** Named away from `onSelect`, which is a DOM prop and collides with the spread row props. */
+  onActivate: () => void;
+  className: string;
+  children: React.ReactNode;
+} & Record<string, unknown>) {
+  if (!href) {
+    return (
+      <button onClick={onActivate} className={className} {...rest}>
+        {children}
+      </button>
+    );
+  }
+
+  return (
+    <a
+      href={href}
+      className={className}
+      onClick={event => {
+        // The browser has been asked for a new tab or window. Let it, and stop the event here so
+        // the list around this row does not navigate the current one as well.
+        if (isModifiedClick(event)) {
+          event.stopPropagation();
+          return;
+        }
+        // An ordinary click belongs to whatever already handled selection — cmdk's `onSelect` in
+        // the search dialog. Following the href too would navigate twice.
+        event.preventDefault();
+        onActivate();
+      }}
+      {...rest}
+    >
+      {children}
+    </a>
+  );
+}
+
 type ResultContentProps = {
   onClick: () => void;
   result: SearchResult;
@@ -66,6 +118,11 @@ type ResultContentProps = {
   active?: boolean;
   /** When set, renders a multi-select checkbox (empty/checked) on the row instead of the single-select indicator. */
   multiSelectChecked?: boolean;
+  /**
+   * Where this row goes, when it goes somewhere. Set by surfaces that navigate; left unset by the
+   * pickers, which select a value instead.
+   */
+  href?: string;
 } & React.ComponentPropsWithoutRef<'button'>;
 
 export const ResultContent = ({
@@ -76,6 +133,7 @@ export const ResultContent = ({
   withDescription = true,
   onChooseSpace,
   multiSelectChecked,
+  href,
   ...rest
 }: ResultContentProps) => {
   const [space, ...otherSpaces] = result.spaces;
@@ -99,8 +157,9 @@ export const ResultContent = ({
 
   return (
     <div>
-      <button
-        onClick={onSelect}
+      <ResultRow
+        href={href}
+        onActivate={onSelect}
         className={cx(
           active && 'bg-grey-01',
           alreadySelected ? 'cursor-not-allowed bg-grey-01' : 'cursor-pointer',
@@ -148,7 +207,7 @@ export const ResultContent = ({
             </Truncate>
           </>
         )}
-      </button>
+      </ResultRow>
       {hasOtherSpaces && !!onChooseSpace && (
         <button
           onClick={e => {
@@ -185,6 +244,8 @@ type SpaceContentProps = {
   space: SpaceEntity;
   alreadySelected?: boolean;
   withDescription?: boolean;
+  /** Where this row goes. Same reasoning as `ResultContentProps['href']`. */
+  href?: string;
 };
 
 export const SpaceContent = ({
@@ -193,6 +254,7 @@ export const SpaceContent = ({
   space,
   alreadySelected,
   withDescription = true,
+  href,
 }: SpaceContentProps) => {
   const entity = useEntity({ id: entityId, spaceId: space.spaceId });
 
@@ -209,8 +271,9 @@ export const SpaceContent = ({
 
   return (
     <div>
-      <button
-        onClick={onSelect}
+      <ResultRow
+        href={href}
+        onActivate={onSelect}
         className={cx(
           alreadySelected ? 'cursor-not-allowed bg-grey-01' : 'cursor-pointer',
           'flex w-full flex-col p-2 transition-colors duration-150 hover:bg-grey-01 focus:bg-grey-01 focus:outline-hidden'
@@ -252,7 +315,7 @@ export const SpaceContent = ({
             </Truncate>
           </>
         )}
-      </button>
+      </ResultRow>
     </div>
   );
 };

--- a/apps/web/design-system/chip.tsx
+++ b/apps/web/design-system/chip.tsx
@@ -14,6 +14,7 @@ import { useEntitySidePanel } from '~/core/hooks/use-entity-side-panel';
 import { useSpace } from '~/core/hooks/use-space';
 import { useVideoWithFallback } from '~/core/hooks/use-video-with-fallback';
 import { EntityId } from '~/core/io/substream-schema';
+import { isModifiedClick } from '~/core/utils/is-modified-click';
 import { NavUtils } from '~/core/utils/utils';
 
 import { Dots } from '~/design-system/dots';
@@ -241,9 +242,7 @@ export function LinkableRelationChip({
   const handleEntityLinkClick = React.useCallback(
     (event: React.MouseEvent<HTMLAnchorElement>) => {
       if (!isSidePanelOpen) return;
-      if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey || event.button === 1) {
-        return;
-      }
+      if (isModifiedClick(event)) return;
       event.preventDefault();
       event.stopPropagation();
       openInSidePanel(entityId, targetSpaceId);
@@ -254,9 +253,7 @@ export function LinkableRelationChip({
   const handleRelationEntityLinkClick = React.useCallback(
     (event: React.MouseEvent<HTMLAnchorElement>) => {
       if (!isSidePanelOpen || !relationEntityId) return;
-      if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey || event.button === 1) {
-        return;
-      }
+      if (isModifiedClick(event)) return;
       event.preventDefault();
       event.stopPropagation();
       openInSidePanel(relationEntityId, currentSpaceId);

--- a/apps/web/partials/active-proposal/proposal-bounty-links.tsx
+++ b/apps/web/partials/active-proposal/proposal-bounty-links.tsx
@@ -807,15 +807,18 @@ function BountyReadOnly({ bounty }: { bounty: Bounty }) {
           <span className="min-w-0 truncate">{bounty.spaceLabel}</span>
         </div>
       )}
-      <button
-        type="button"
-        onClick={() =>
-          bounty.spaceId && window.open(NavUtils.toEntity(bounty.spaceId, bounty.id), '_blank', 'noopener,noreferrer')
-        }
+      {/* An anchor rather than a button that calls `window.open`: the destination is a real one, so
+          the browser can offer its own ways of opening it — new tab, new window, the context menu —
+          instead of one hard-coded choice (GEO-2701). `target` keeps the previous behaviour of
+          opening away from the proposal being reviewed. */}
+      <a
+        href={bounty.spaceId ? NavUtils.toEntity(bounty.spaceId, bounty.id) : undefined}
+        target="_blank"
+        rel="noopener noreferrer"
         className="text-left text-[15px] font-semibold text-text hover:underline"
       >
         {bounty.name}
-      </button>
+      </a>
     </div>
   );
 }

--- a/apps/web/partials/active-proposal/proposal-bounty-links.tsx
+++ b/apps/web/partials/active-proposal/proposal-bounty-links.tsx
@@ -810,15 +810,23 @@ function BountyReadOnly({ bounty }: { bounty: Bounty }) {
       {/* An anchor rather than a button that calls `window.open`: the destination is a real one, so
           the browser can offer its own ways of opening it — new tab, new window, the context menu —
           instead of one hard-coded choice (GEO-2701). `target` keeps the previous behaviour of
-          opening away from the proposal being reviewed. */}
-      <a
-        href={bounty.spaceId ? NavUtils.toEntity(bounty.spaceId, bounty.id) : undefined}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="text-left text-[15px] font-semibold text-text hover:underline"
-      >
-        {bounty.name}
-      </a>
+          opening away from the proposal being reviewed.
+
+          A bounty with no space has nowhere to go, and an `<a>` without an href is not a link: it
+          takes no focus and carries no role, so it would read as text to a keyboard while still
+          underlining on hover. The name renders as what it is instead. */}
+      {bounty.spaceId ? (
+        <a
+          href={NavUtils.toEntity(bounty.spaceId, bounty.id)}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-left text-[15px] font-semibold text-text hover:underline"
+        >
+          {bounty.name}
+        </a>
+      ) : (
+        <span className="text-left text-[15px] font-semibold text-text">{bounty.name}</span>
+      )}
     </div>
   );
 }

--- a/apps/web/partials/search/dialog.tsx
+++ b/apps/web/partials/search/dialog.tsx
@@ -257,6 +257,10 @@ const SearchDialogComponent = ({ open, onDone }: Props) => {
                               id={`search-result-${i}`}
                               // The onClick behavior is handled by cmdk.
                               onClick={() => {}}
+                              // A real destination, so the row can be opened in a new tab, middle
+                              // clicked, or right clicked like any other link (GEO-2701). The same
+                              // one cmdk pushes on a plain click.
+                              href={NavUtils.toEntity(result.spaces[0].spaceId, result.id)}
                               result={result}
                               active={i === selectedIndex}
                               onChooseSpace={() => setOpenSpacesIndex(i)}
@@ -312,6 +316,7 @@ const SearchDialogComponent = ({ open, onDone }: Props) => {
                             <SpaceContent
                               // The onClick behavior is handled by cmdk.
                               onClick={() => {}}
+                              href={NavUtils.toEntity(space.spaceId, selectedEntity.id)}
                               entityId={selectedEntity.id}
                               space={space}
                             />


### PR DESCRIPTION
Part of GEO-2701. **This does not close the ticket** — see "What is left" below.

## The audit

The ticket asked for a survey rather than a single fix, so I scanned every click handler that navigates and checked whether the thing being clicked is something the browser can act on.

**Already correct — no change needed:**

| Surface | Why it was fine |
|---|---|
| `PrefetchLink` (used almost everywhere) | a real `next/link` with an `href`; Next leaves modified clicks to the browser |
| Entity links in tables | `EntityTableCell` renders `PrefetchLink` |
| Relation chips | anchor *and* an existing modifier guard — this was the reference implementation |
| Breadcrumbs, nav items | `PrefetchLink` throughout |

**Navigates on click but is not a link — fixed here:**

- `partials/search/dialog.tsx` — entity results and the "open in this space" rows
- `partials/active-proposal/proposal-bounty-links.tsx` — a `<button>` calling `window.open`

**Navigates on click, deliberately left alone:** eleven handlers that run *after* an action rather than linking to something — go to the entity you just created, the space you just made, the version you just moved. There is no destination to right-click before the action happens, so an anchor would be wrong. Full list in the audit script output; happy to paste it if useful.

## What changed

Search results were cmdk items calling `router.push`, with no anchor and no href — so cmd-click did nothing, middle click did nothing, right click offered no "Open in new tab". They now carry a destination:

- an ordinary click still belongs to cmdk, which closes the dialog and navigates as before
- a modified click is left to the browser, and stopped from reaching cmdk — otherwise the result opens beside the current page *and* in place of it

The same component is the entity picker's row, where clicking chooses a value rather than travelling to one. Those rows have nowhere to go, so they stay buttons. The difference is whether a caller passes an `href`.

`isModifiedClick` is shared rather than restated: the relation chip already had the check inline and correct, and now reads from the same place.

## Verified in a browser

Not just asserted in jsdom — the point of the ticket is real browser behaviour:

```
search result anchors: 9, first href /space/5908c73a…/bee5326a…
cmd+click → pages before/after: 1 / 2
             this tab moved:    false
ok: opened a new tab, current tab stayed put
```

## Tests

Eight cases in `results-list.test.tsx`: the row is an anchor carrying its href, cmd/ctrl/shift/middle clicks are left to the browser, an ordinary click goes to the existing handler, and a row with no href stays a button that still selects.

Verified non-vacuous by two sabotages — ignoring modifiers fails four; never rendering an anchor fails six.

## What is left

I fixed the surfaces that are links pretending to be buttons. Two judgement calls I did not make alone:

- **`explore/featured-rankings-section.tsx`** renders ranked entities as `<button onClick={openSidePanel}>`. That is a side panel opener, not a navigation — making it a link would change what clicking does, not just how. Worth deciding whether those rows should navigate at all.
- **`design-system/find-entity.tsx`** has an explicit "open in new tab" button using `window.open`. It works, but as a button it cannot be middle-clicked or copied. Cosmetic next to the rest.

Also unaddressed: the ticket's note about reconciling with GEO-2681, which overrides the native right-click menu for content blocks. Nothing here touches that, but the two will collide if that ticket lands as described.
