### PR TITLE
feat: surface the slash command in the empty block placeholder

### DIFF
--- a/apps/web/partials/editor/extensions.tsx
+++ b/apps/web/partials/editor/extensions.tsx
@@ -64,8 +64,11 @@ export function resolveBlockPlaceholder({
 
   // Nothing is being edited, so an otherwise empty document would render with no
   // affordance at all. Keep the short resting copy for that one case; it is too
-  // short to wrap, so it cannot overlap the way the hint would.
-  if (isEmpty) return EMPTY_BLOCK_RESTING_TEXT;
+  // short to wrap, so it cannot overlap the way the hint would. Still scoped to
+  // the block holding the selection: `isEmpty` is true of a document made of
+  // several empty paragraphs, so without `hasAnchor` this would label every
+  // blank line.
+  if (isEmpty && hasAnchor) return EMPTY_BLOCK_RESTING_TEXT;
 
   return '';
 }

--- a/apps/web/partials/editor/extensions.tsx
+++ b/apps/web/partials/editor/extensions.tsx
@@ -66,7 +66,7 @@ export const tiptapExtensions = [
       if (node.type.name === 'paragraph' && node.attrs?.tailPlaceholder) {
         return PROFILE_OVERVIEW_TAIL_PLACEHOLDER_TEXT;
       }
-      return 'Add content or type "/" for other block types...';
+      return 'Write some content or use / to select block type...';
     },
   }),
   UndoRedo,

--- a/apps/web/partials/editor/extensions.tsx
+++ b/apps/web/partials/editor/extensions.tsx
@@ -23,6 +23,53 @@ import { TrailingNode } from './trailing-node';
 import { VideoNode } from './video-node';
 import { Web2URLExtension } from './web2-url-extension';
 
+export const EMPTY_BLOCK_SLASH_HINT = 'Write some content or use / to select block type...';
+export const EMPTY_BLOCK_RESTING_TEXT = 'Add content...';
+
+type BlockPlaceholderInput = {
+  nodeName: string;
+  isTailPlaceholder: boolean;
+  /** The caret sits in this block. Survives blur, so it is not enough on its own. */
+  hasAnchor: boolean;
+  /** The editor holds DOM focus. */
+  isFocused: boolean;
+  /** The whole document is empty, not just this block. */
+  isEmpty: boolean;
+};
+
+/**
+ * Picks the placeholder for one empty block.
+ *
+ * Only the block actually being edited advertises the slash menu. Showing it on
+ * every empty block repeats a long line down the document, and because the
+ * placeholder `::before` is `height: 0`, a hint that wraps at narrow widths
+ * overlaps the block below it.
+ */
+export function resolveBlockPlaceholder({
+  nodeName,
+  isTailPlaceholder,
+  hasAnchor,
+  isFocused,
+  isEmpty,
+}: BlockPlaceholderInput): string {
+  if (nodeName === 'heading') return 'Heading...';
+  if (nodeName === 'bulletList') return '';
+  if (nodeName === 'codeBlock') return '';
+
+  // The profile bio tail is a standing invite — it has to render while the caret
+  // is elsewhere, which is also why `showOnlyCurrent` stays false below.
+  if (nodeName === 'paragraph' && isTailPlaceholder) return PROFILE_OVERVIEW_TAIL_PLACEHOLDER_TEXT;
+
+  if (isFocused && hasAnchor) return EMPTY_BLOCK_SLASH_HINT;
+
+  // Nothing is being edited, so an otherwise empty document would render with no
+  // affordance at all. Keep the short resting copy for that one case; it is too
+  // short to wrap, so it cannot overlap the way the hint would.
+  if (isEmpty) return EMPTY_BLOCK_RESTING_TEXT;
+
+  return '';
+}
+
 export const tiptapExtensions = [
   Document,
   Text,
@@ -57,24 +104,19 @@ export const tiptapExtensions = [
   RankingNode,
   ImageNode,
   VideoNode,
-  // showOnlyCurrent stays false because the profile bio tail is a standing
-  // invite — it has to render while the caret is elsewhere. The slash hint is
-  // gated on `hasAnchor` instead, so only the block the caret sits in shows it.
-  // Every empty block showing it would repeat a long line down the document and,
-  // since the placeholder `::before` is `height: 0`, overlap the block below
-  // once it wraps at narrow widths.
+  // showOnlyCurrent stays false so the profile bio tail keeps rendering while the
+  // caret is elsewhere; TipTap applies that option to every node, so the slash
+  // hint is scoped inside resolveBlockPlaceholder instead.
   Placeholder.configure({
     showOnlyCurrent: false,
-    placeholder: ({ node, hasAnchor }) => {
-      if (node.type.name === 'heading') return 'Heading...';
-      if (node.type.name === 'bulletList') return '';
-      if (node.type.name === 'codeBlock') return '';
-      if (node.type.name === 'paragraph' && node.attrs?.tailPlaceholder) {
-        return PROFILE_OVERVIEW_TAIL_PLACEHOLDER_TEXT;
-      }
-      if (!hasAnchor) return '';
-      return 'Write some content or use / to select block type...';
-    },
+    placeholder: ({ editor, node, hasAnchor }) =>
+      resolveBlockPlaceholder({
+        nodeName: node.type.name,
+        isTailPlaceholder: Boolean(node.attrs?.tailPlaceholder),
+        hasAnchor,
+        isFocused: editor.isFocused,
+        isEmpty: editor.isEmpty,
+      }),
   }),
   UndoRedo,
   FloatingToolbarExtension,

--- a/apps/web/partials/editor/extensions.tsx
+++ b/apps/web/partials/editor/extensions.tsx
@@ -5,7 +5,7 @@ import Italic from '@tiptap/extension-italic';
 import { BulletList, ListItem } from '@tiptap/extension-list';
 import Text from '@tiptap/extension-text';
 import Underline from '@tiptap/extension-underline';
-import { Focus, Gapcursor, Placeholder, UndoRedo } from '@tiptap/extensions';
+import { Gapcursor, Placeholder, UndoRedo } from '@tiptap/extensions';
 
 import { PROFILE_OVERVIEW_TAIL_PLACEHOLDER_TEXT } from '~/core/state/editor/profile-overview-tail-placeholder';
 
@@ -57,11 +57,6 @@ export const tiptapExtensions = [
   RankingNode,
   ImageNode,
   VideoNode,
-  // mode: 'deepest' tags only the leaf node, not the wrapper chain. With
-  // 'all', the `has-focus` class lands on every NodeView wrapper on the
-  // selection path — including `data-node` etc. — and the slash-hint CSS
-  // (`.is-empty.has-focus::before`) leaks onto empty NodeView wrappers.
-  Focus.configure({ className: 'has-focus', mode: 'deepest' }),
   Placeholder.configure({
     showOnlyCurrent: false,
     placeholder: ({ node }) => {
@@ -71,7 +66,7 @@ export const tiptapExtensions = [
       if (node.type.name === 'paragraph' && node.attrs?.tailPlaceholder) {
         return PROFILE_OVERVIEW_TAIL_PLACEHOLDER_TEXT;
       }
-      return 'Add content...';
+      return 'Add content or type "/" for other block types...';
     },
   }),
   UndoRedo,

--- a/apps/web/partials/editor/extensions.tsx
+++ b/apps/web/partials/editor/extensions.tsx
@@ -57,15 +57,22 @@ export const tiptapExtensions = [
   RankingNode,
   ImageNode,
   VideoNode,
+  // showOnlyCurrent stays false because the profile bio tail is a standing
+  // invite — it has to render while the caret is elsewhere. The slash hint is
+  // gated on `hasAnchor` instead, so only the block the caret sits in shows it.
+  // Every empty block showing it would repeat a long line down the document and,
+  // since the placeholder `::before` is `height: 0`, overlap the block below
+  // once it wraps at narrow widths.
   Placeholder.configure({
     showOnlyCurrent: false,
-    placeholder: ({ node }) => {
+    placeholder: ({ node, hasAnchor }) => {
       if (node.type.name === 'heading') return 'Heading...';
       if (node.type.name === 'bulletList') return '';
       if (node.type.name === 'codeBlock') return '';
       if (node.type.name === 'paragraph' && node.attrs?.tailPlaceholder) {
         return PROFILE_OVERVIEW_TAIL_PLACEHOLDER_TEXT;
       }
+      if (!hasAnchor) return '';
       return 'Write some content or use / to select block type...';
     },
   }),

--- a/apps/web/partials/editor/placeholder-hint.test.ts
+++ b/apps/web/partials/editor/placeholder-hint.test.ts
@@ -1,0 +1,74 @@
+import { Editor } from '@tiptap/core';
+import type { DecorationSet } from '@tiptap/pm/view';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { PROFILE_OVERVIEW_TAIL_PLACEHOLDER_TEXT } from '~/core/state/editor/profile-overview-tail-placeholder';
+
+import { tiptapExtensions } from './extensions';
+
+const SLASH_HINT = 'Write some content or use / to select block type...';
+
+let editor: Editor | null = null;
+
+afterEach(() => {
+  editor?.destroy();
+  editor = null;
+});
+
+/**
+ * Reads the placeholder text TipTap decorates each empty block with, in document
+ * order. `null` marks a block that got no placeholder decoration at all.
+ */
+function placeholdersFor(content: Record<string, unknown>[], caretAt: number) {
+  editor = new Editor({
+    element: document.createElement('div'),
+    extensions: tiptapExtensions,
+    content: { type: 'doc', content },
+  });
+
+  editor.commands.setTextSelection(caretAt);
+
+  const { state } = editor;
+  const byPos = new Map<number, string>();
+
+  for (const plugin of state.plugins) {
+    const set = plugin.props.decorations?.call(plugin, state) as DecorationSet | null | undefined;
+    for (const decoration of set?.find() ?? []) {
+      const placeholder = (decoration as unknown as { type: { attrs?: Record<string, string> } }).type.attrs?.[
+        'data-placeholder'
+      ];
+      if (placeholder !== undefined) byPos.set(decoration.from, placeholder);
+    }
+  }
+
+  const result: (string | null)[] = [];
+  state.doc.forEach((_node, offset) => result.push(byPos.get(offset) ?? null));
+  return result;
+}
+
+const emptyParagraph = { type: 'paragraph' };
+
+describe('empty block placeholder', () => {
+  it('shows the slash hint only on the block holding the caret', () => {
+    // Three empty paragraphs; caret inside the second one.
+    const placeholders = placeholdersFor([emptyParagraph, emptyParagraph, emptyParagraph], 3);
+
+    expect(placeholders).toEqual(['', SLASH_HINT, '']);
+  });
+
+  it('moves the hint with the caret', () => {
+    const placeholders = placeholdersFor([emptyParagraph, emptyParagraph, emptyParagraph], 1);
+
+    expect(placeholders).toEqual([SLASH_HINT, '', '']);
+  });
+
+  it('keeps the profile bio tail invite visible while the caret is elsewhere', () => {
+    const placeholders = placeholdersFor(
+      [emptyParagraph, { type: 'paragraph', attrs: { tailPlaceholder: true } }],
+      1
+    );
+
+    expect(placeholders).toEqual([SLASH_HINT, PROFILE_OVERVIEW_TAIL_PLACEHOLDER_TEXT]);
+  });
+});

--- a/apps/web/partials/editor/placeholder-hint.test.ts
+++ b/apps/web/partials/editor/placeholder-hint.test.ts
@@ -1,74 +1,95 @@
 import { Editor } from '@tiptap/core';
-import type { DecorationSet } from '@tiptap/pm/view';
 
-import { afterEach, describe, expect, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import { PROFILE_OVERVIEW_TAIL_PLACEHOLDER_TEXT } from '~/core/state/editor/profile-overview-tail-placeholder';
 
-import { tiptapExtensions } from './extensions';
+import {
+  EMPTY_BLOCK_RESTING_TEXT,
+  EMPTY_BLOCK_SLASH_HINT,
+  resolveBlockPlaceholder,
+  tiptapExtensions,
+} from './extensions';
 
-const SLASH_HINT = 'Write some content or use / to select block type...';
+const paragraph = {
+  nodeName: 'paragraph',
+  isTailPlaceholder: false,
+  hasAnchor: false,
+  isFocused: false,
+  isEmpty: false,
+};
 
-let editor: Editor | null = null;
+describe('resolveBlockPlaceholder', () => {
+  it('advertises the slash menu on the block being edited', () => {
+    expect(resolveBlockPlaceholder({ ...paragraph, hasAnchor: true, isFocused: true })).toBe(EMPTY_BLOCK_SLASH_HINT);
+  });
 
-afterEach(() => {
-  editor?.destroy();
-  editor = null;
+  it('says nothing on empty blocks the caret is not in', () => {
+    expect(resolveBlockPlaceholder({ ...paragraph, hasAnchor: false, isFocused: true })).toBe('');
+  });
+
+  // The ProseMirror selection survives blur, so gating on the caret alone would
+  // strand the hint on whichever block the user left — and keep it overlapping
+  // the block below at widths where the long copy wraps.
+  it('drops the hint once the editor loses focus, even on the block that kept the caret', () => {
+    expect(resolveBlockPlaceholder({ ...paragraph, hasAnchor: true, isFocused: false })).toBe('');
+  });
+
+  // Otherwise an untouched, empty entity page renders with nothing to click.
+  it('falls back to the short resting copy on a blurred empty document', () => {
+    expect(resolveBlockPlaceholder({ ...paragraph, hasAnchor: true, isFocused: false, isEmpty: true })).toBe(
+      EMPTY_BLOCK_RESTING_TEXT
+    );
+  });
+
+  it('prefers the hint over the resting copy once that empty document is focused', () => {
+    expect(resolveBlockPlaceholder({ ...paragraph, hasAnchor: true, isFocused: true, isEmpty: true })).toBe(
+      EMPTY_BLOCK_SLASH_HINT
+    );
+  });
+
+  it('keeps the profile bio tail invite regardless of focus or caret', () => {
+    expect(resolveBlockPlaceholder({ ...paragraph, isTailPlaceholder: true })).toBe(
+      PROFILE_OVERVIEW_TAIL_PLACEHOLDER_TEXT
+    );
+  });
+
+  it('leaves the heading placeholder alone', () => {
+    expect(resolveBlockPlaceholder({ ...paragraph, nodeName: 'heading' })).toBe('Heading...');
+  });
 });
 
 /**
- * Reads the placeholder text TipTap decorates each empty block with, in document
- * order. `null` marks a block that got no placeholder decoration at all.
+ * jsdom cannot give a contenteditable real DOM focus, so `editor.isFocused` is
+ * always false here. That happens to be exactly the state this test needs: it
+ * pins the blurred behaviour end-to-end, through TipTap's own decoration pass.
  */
-function placeholdersFor(content: Record<string, unknown>[], caretAt: number) {
-  editor = new Editor({
-    element: document.createElement('div'),
-    extensions: tiptapExtensions,
-    content: { type: 'doc', content },
-  });
+describe('placeholder decorations on a blurred editor', () => {
+  function renderPlaceholders(content: Record<string, unknown>[], caretAt: number) {
+    const element = document.createElement('div');
+    const editor = new Editor({ element, extensions: tiptapExtensions, content: { type: 'doc', content } });
 
-  editor.commands.setTextSelection(caretAt);
+    try {
+      editor.commands.setTextSelection(caretAt);
+      expect(editor.isFocused).toBe(false);
 
-  const { state } = editor;
-  const byPos = new Map<number, string>();
-
-  for (const plugin of state.plugins) {
-    const set = plugin.props.decorations?.call(plugin, state) as DecorationSet | null | undefined;
-    for (const decoration of set?.find() ?? []) {
-      const placeholder = (decoration as unknown as { type: { attrs?: Record<string, string> } }).type.attrs?.[
-        'data-placeholder'
-      ];
-      if (placeholder !== undefined) byPos.set(decoration.from, placeholder);
+      return Array.from(element.querySelectorAll('[data-placeholder]')).map(node =>
+        node.getAttribute('data-placeholder')
+      );
+    } finally {
+      editor.destroy();
     }
   }
 
-  const result: (string | null)[] = [];
-  state.doc.forEach((_node, offset) => result.push(byPos.get(offset) ?? null));
-  return result;
-}
+  const emptyParagraph = { type: 'paragraph' };
+  const writtenParagraph = { type: 'paragraph', content: [{ type: 'text', text: 'written' }] };
 
-const emptyParagraph = { type: 'paragraph' };
-
-describe('empty block placeholder', () => {
-  it('shows the slash hint only on the block holding the caret', () => {
-    // Three empty paragraphs; caret inside the second one.
-    const placeholders = placeholdersFor([emptyParagraph, emptyParagraph, emptyParagraph], 3);
-
-    expect(placeholders).toEqual(['', SLASH_HINT, '']);
+  it('strands no hint on the block that kept the caret', () => {
+    // Caret in the first empty block, editor blurred.
+    expect(renderPlaceholders([writtenParagraph, emptyParagraph, emptyParagraph], 10)).toEqual(['', '']);
   });
 
-  it('moves the hint with the caret', () => {
-    const placeholders = placeholdersFor([emptyParagraph, emptyParagraph, emptyParagraph], 1);
-
-    expect(placeholders).toEqual([SLASH_HINT, '', '']);
-  });
-
-  it('keeps the profile bio tail invite visible while the caret is elsewhere', () => {
-    const placeholders = placeholdersFor(
-      [emptyParagraph, { type: 'paragraph', attrs: { tailPlaceholder: true } }],
-      1
-    );
-
-    expect(placeholders).toEqual([SLASH_HINT, PROFILE_OVERVIEW_TAIL_PLACEHOLDER_TEXT]);
+  it('still invites input on an empty document', () => {
+    expect(renderPlaceholders([emptyParagraph], 1)).toEqual([EMPTY_BLOCK_RESTING_TEXT]);
   });
 });

--- a/apps/web/partials/editor/placeholder-hint.test.ts
+++ b/apps/web/partials/editor/placeholder-hint.test.ts
@@ -42,6 +42,12 @@ describe('resolveBlockPlaceholder', () => {
     );
   });
 
+  // `editor.isEmpty` is true of a document made only of blank paragraphs, so the
+  // resting copy has to be scoped to the selection too or every blank line gets it.
+  it('keeps the resting copy off the other blank lines of an all-empty document', () => {
+    expect(resolveBlockPlaceholder({ ...paragraph, hasAnchor: false, isFocused: false, isEmpty: true })).toBe('');
+  });
+
   it('prefers the hint over the resting copy once that empty document is focused', () => {
     expect(resolveBlockPlaceholder({ ...paragraph, hasAnchor: true, isFocused: true, isEmpty: true })).toBe(
       EMPTY_BLOCK_SLASH_HINT
@@ -91,5 +97,14 @@ describe('placeholder decorations on a blurred editor', () => {
 
   it('still invites input on an empty document', () => {
     expect(renderPlaceholders([emptyParagraph], 1)).toEqual([EMPTY_BLOCK_RESTING_TEXT]);
+  });
+
+  it('invites input once, not on every blank line of an all-empty document', () => {
+    // The whole document is blank, so `editor.isEmpty` is true for all three.
+    expect(renderPlaceholders([emptyParagraph, emptyParagraph, emptyParagraph], 1)).toEqual([
+      EMPTY_BLOCK_RESTING_TEXT,
+      '',
+      '',
+    ]);
   });
 });

--- a/apps/web/styles/tiptap.css
+++ b/apps/web/styles/tiptap.css
@@ -75,13 +75,6 @@
   @apply text-grey-03;
 }
 
-/* Focused empty paragraph: switch from "Add content..." to the slash hint.
-   Exclude `.paragraph-tail-placeholder` so the profile bio tail keeps TipTap’s placeholder
-   (grey “Type / for commands…”) like `placeholder:text-grey-03` on inputs — not this slash line. */
-.ProseMirror .is-empty.has-focus:not(.paragraph-tail-placeholder):has(> .paragraph-node)::before {
-  content: '/ to select content block or write some content...';
-}
-
 /* Profile bio tail: same grey as table title placeholders; ::before is non-interactive — clicks focus <p> / caret; typing removes `is-empty` so grey disappears. */
 .ProseMirror .paragraph-tail-placeholder.is-empty::before {
   content: attr(data-placeholder);


### PR DESCRIPTION
Closes [GEO-2703](https://linear.app/geobrowser/issue/GEO-2703/blocks-update-new-block-placeholder-to-mention-the-command).

## What

Empty blocks now read **`Write some content or use / to select block type...`** instead of `Add content...`.

## The part that wasn't obvious

There were **two** competing placeholders on an empty block, and the ticket's string only fixes one of them:

| State | Source | Text |
|---|---|---|
| Unfocused | `extensions.tsx` → `data-placeholder` | `Add content...` |
| **Focused** | `tiptap.css` → `content:` override | `/ to select content block or write some content...` |

A newly inserted block **is** focused, so changing only the extension string would have left the exact case in the ticket screenshot unchanged. This PR collapses both states onto the one string, which also removes the CSS/JS split that made the copy easy to change in one place and miss in the other.

Dropping that CSS rule orphans the `Focus` extension — its in-code comment says it exists specifically for the slash-hint rule, and `has-focus` is not referenced anywhere else in the repo — so it's removed too. That's the one piece here that's a judgement call rather than the literal ask; happy to put it back if you'd rather keep it.

## Wording

The ticket left the punctuation open. The final string leads with the common case (writing) and writes the slash **unquoted**, matching the other slash hint in the editor (`Type / for commands or start writing...`, the profile bio tail). Trailing ellipsis is three ASCII dots, consistent with `Add content...` / `Heading...`.

## Width check

Measured the rendered string in Calibre at `--text-body` (20px):

| String | Width |
|---|---|
| `Add content...` | 123px |
| `/ to select content block or write some content...` (ships today, focused) | 419px |
| **`Write some content or use / to select block type...`** (this PR) | **433px** |

Fits on one line everywhere the editor actually renders wide: the 900px entity page and the 520px power-tools panel both hold it comfortably. It is 14px wider than the hint that ships today on a focused block, which matters only below ~440px.

At mobile width (~343px) it wraps to two lines, and because the placeholder is `float: left; height: 0` the second line overlaps the block below. **This is pre-existing, not introduced here** — the current 419px focused string overlaps there too, and as of the fix below only one block can ever be in that state at a time. Fixing the overlap properly means reworking the shared `::before` (it also backs the heading and profile-bio placeholders), so I left it alone; say the word and I'll open a follow-up.

## Only the active block shows the hint

Caught by Copilot in review: the placeholder runs with `showOnlyCurrent: false`, so the first pass rendered the new hint on **every** empty block, not just the active one. That repeats a long line down the document, and an unfocused wrapped hint overlaps the block below at narrow widths. The old copy was short enough to hide this.

`showOnlyCurrent` can't simply flip to `true` — TipTap applies it to every node, and the profile bio tail is a standing invite that has to render while the caret is elsewhere (it's even defensively stripped from persisted markdown in `profile-overview-tail-placeholder.ts`). So the gate is on the `hasAnchor` flag the placeholder callback already receives, which scopes it to the slash hint and leaves the tail invite alone.

Empty blocks that aren't holding the caret now show no placeholder at all, rather than reverting to a shorter string.

The gate is `isFocused && hasAnchor`, not `hasAnchor` alone — the ProseMirror selection is retained across blur, so the caret check on its own strands the hint on whichever block the user left. TipTap dispatches a transaction on blur, so `isFocused` clears and the decoration goes with it, matching what the removed `Focus` decoration did.

One wrinkle: `isFocused && hasAnchor` on its own blanks an untouched empty page. Nothing autofocuses the editor, every other branch returns `''`, and the `is-editor-empty` rule reads the same attribute — so an empty entity page would render with no affordance at all. The short resting copy is kept for that one case; at 123px it can't wrap, so it can't overlap. That fallback is scoped to the selected block as well: `editor.isEmpty` recurses, so a document of several blank paragraphs counts as empty and an unscoped fallback would label every blank line.

Net behaviour:

| | Placeholder |
|---|---|
| Block being edited | the slash hint |
| Other empty blocks | nothing |
| Blurred, document has content | nothing |
| Blurred, document empty | `Add content...`, on the selected block only |
| Profile bio tail | its own standing invite, unchanged |

The branching lives in `resolveBlockPlaceholder` so it can be tested directly. `partials/editor/placeholder-hint.test.ts` covers every branch, plus an end-to-end pass through TipTap's own decorations for the blurred case — jsdom can't give a contenteditable real DOM focus, which makes `isFocused` unreachable through a live editor but pins the blurred behaviour for free. Verified the blur assertions fail if the gate is weakened back to `hasAnchor`, and the all-empty-document assertions fail if the resting copy loses its `hasAnchor` scope.

## Testing

- `vitest run core/state/editor partials/editor` — 13 files, 110 tests, all passing (11 new)
- `tsc --noEmit` — no new errors (4 pre-existing failures, all in unrelated test files)
- Rendered the real `::before` rule with the app's Calibre face at 900 / 520 / 343px to confirm the wrap behaviour above


