### PR TITLE
fix(debates): fall back to download when a share is refused

### DIFF
--- a/apps/web/core/debates/social-video-share.test.ts
+++ b/apps/web/core/debates/social-video-share.test.ts
@@ -48,6 +48,59 @@ describe('handoffPreparedSocialVideo', () => {
     });
   });
 
+  // Preston, on production: "Failed to execute 'share' on 'Navigator': Permission denied".
+  //
+  // `canShare` said yes and `share` refused anyway, which it is allowed to do — the probe answers
+  // whether the payload is shareable in principle, not whether this browser will accept it. The
+  // click should still hand over the video rather than surfacing a dead end.
+  it('falls back to the download when the browser refuses a share it said it could do', async () => {
+    mocks.canShare.mockReturnValue(true);
+    mocks.share.mockRejectedValue(
+      new DOMException("Failed to execute 'share' on 'Navigator': Permission denied", 'NotAllowedError')
+    );
+    Object.defineProperty(navigator, 'canShare', { configurable: true, value: mocks.canShare });
+    Object.defineProperty(navigator, 'share', { configurable: true, value: mocks.share });
+
+    await expect(
+      handoffPreparedSocialVideo({
+        debateId: 'debate-1',
+        title: 'Debates are useful',
+        file: preparedFile,
+        downloadUrl: 'blob:https://geo.test/social-video',
+      })
+    ).resolves.toBe('download');
+
+    // Reported as a resolved handoff, tagged so the rate of it is visible rather than inferred.
+    expect(mocks.capture).toHaveBeenCalledWith('debate_social_video_handoff_resolved', {
+      debate_id: 'debate-1',
+      method: 'download',
+      fell_back_from: 'native_share',
+      error_name: 'NotAllowedError',
+    });
+  });
+
+  // The one refusal that must not fall back: closing the share sheet is a decision, and quietly
+  // downloading the file instead would override it.
+  it('does not download when the person cancels the share sheet', async () => {
+    mocks.canShare.mockReturnValue(true);
+    mocks.share.mockRejectedValue(new DOMException('Share canceled', 'AbortError'));
+    Object.defineProperty(navigator, 'canShare', { configurable: true, value: mocks.canShare });
+    Object.defineProperty(navigator, 'share', { configurable: true, value: mocks.share });
+
+    await expect(
+      handoffPreparedSocialVideo({
+        debateId: 'debate-1',
+        title: 'Debates are useful',
+        file: preparedFile,
+        downloadUrl: 'blob:https://geo.test/social-video',
+      })
+    ).rejects.toThrow('Share canceled');
+    expect(mocks.capture).not.toHaveBeenCalledWith(
+      'debate_social_video_handoff_resolved',
+      expect.objectContaining({ method: 'download' })
+    );
+  });
+
   it.each([
     ['unsupported', () => false],
     [
@@ -104,7 +157,14 @@ describe('handoffPreparedSocialVideo', () => {
     expect(mocks.capture).not.toHaveBeenCalledWith('debate_social_video_handoff_failed', expect.anything());
   });
 
-  it('reports non-cancellation native share failures and leaves retry to the caller', async () => {
+  // This asserted a rejection, on the reasoning that retry belonged to the caller. Changed
+  // deliberately: the button's contract is "hand off the video", not "open the share sheet" — which
+  // the code already showed, since a browser whose `canShare` says no downloads without asking. A
+  // browser that says yes and then refuses is the same situation discovered a moment later, so it
+  // gets the same answer rather than a dead end.
+  //
+  // Retry stays available: nothing here consumes the prepared file, so the button still works.
+  it('falls back for a non-cancellation share failure of any kind, not just a refusal', async () => {
     const failure = new Error('Share service unavailable');
     mocks.canShare.mockReturnValue(true);
     mocks.share.mockRejectedValue(failure);
@@ -118,11 +178,13 @@ describe('handoffPreparedSocialVideo', () => {
         file: preparedFile,
         downloadUrl: 'blob:https://geo.test/social-video',
       })
-    ).rejects.toBe(failure);
+    ).resolves.toBe('download');
 
-    expect(mocks.capture).toHaveBeenCalledWith('debate_social_video_handoff_failed', {
+    // Still visible in telemetry, tagged with what it fell back from and why.
+    expect(mocks.capture).toHaveBeenCalledWith('debate_social_video_handoff_resolved', {
       debate_id: 'debate-1',
-      method: 'native_share',
+      method: 'download',
+      fell_back_from: 'native_share',
       error_name: 'Error',
     });
   });

--- a/apps/web/core/debates/social-video-share.test.ts
+++ b/apps/web/core/debates/social-video-share.test.ts
@@ -157,14 +157,10 @@ describe('handoffPreparedSocialVideo', () => {
     expect(mocks.capture).not.toHaveBeenCalledWith('debate_social_video_handoff_failed', expect.anything());
   });
 
-  // This asserted a rejection, on the reasoning that retry belonged to the caller. Changed
-  // deliberately: the button's contract is "hand off the video", not "open the share sheet" — which
-  // the code already showed, since a browser whose `canShare` says no downloads without asking. A
-  // browser that says yes and then refuses is the same situation discovered a moment later, so it
-  // gets the same answer rather than a dead end.
-  //
-  // Retry stays available: nothing here consumes the prepared file, so the button still works.
-  it('falls back for a non-cancellation share failure of any kind, not just a refusal', async () => {
+  // Deliberately unchanged by the fallback: a generic failure might succeed next time, so the
+  // error and the retry that reuses the prepared file are still the right answer. Only a refusal a
+  // retry cannot change falls back — see the NotAllowedError case above.
+  it('reports non-cancellation native share failures and leaves retry to the caller', async () => {
     const failure = new Error('Share service unavailable');
     mocks.canShare.mockReturnValue(true);
     mocks.share.mockRejectedValue(failure);
@@ -178,13 +174,11 @@ describe('handoffPreparedSocialVideo', () => {
         file: preparedFile,
         downloadUrl: 'blob:https://geo.test/social-video',
       })
-    ).resolves.toBe('download');
+    ).rejects.toBe(failure);
 
-    // Still visible in telemetry, tagged with what it fell back from and why.
-    expect(mocks.capture).toHaveBeenCalledWith('debate_social_video_handoff_resolved', {
+    expect(mocks.capture).toHaveBeenCalledWith('debate_social_video_handoff_failed', {
       debate_id: 'debate-1',
-      method: 'download',
-      fell_back_from: 'native_share',
+      method: 'native_share',
       error_name: 'Error',
     });
   });

--- a/apps/web/core/debates/social-video-share.ts
+++ b/apps/web/core/debates/social-video-share.ts
@@ -138,7 +138,7 @@ export function usePreparedSocialVideo(
               captureSocialVideoEvent('debate_social_video_preparation_failed', {
                 debate_id: debateId,
                 stage: 'video_download',
-                error_name: error instanceof Error ? error.name : 'UnknownError',
+                error_name: errorName(error),
               });
               setState(current => ({
                 ...current,
@@ -152,7 +152,7 @@ export function usePreparedSocialVideo(
           captureSocialVideoEvent('debate_social_video_preparation_failed', {
             debate_id: debateId,
             stage: 'video_url',
-            error_name: error instanceof Error ? error.name : 'UnknownError',
+            error_name: errorName(error),
           });
           setState(current => ({
             ...current,
@@ -191,8 +191,35 @@ export async function handoffPreparedSocialVideo({
 
   try {
     if (method === 'native_share') {
-      const sharePromise = navigator.share({ title, files: [file] });
-      await sharePromise;
+      try {
+        const sharePromise = navigator.share({ title, files: [file] });
+        await sharePromise;
+      } catch (error) {
+        // `navigator.canShare({ files })` chose this path, but it is a *hint* — it answers whether
+        // the data is shareable in principle, not whether this browser will actually accept it. So
+        // `share()` can still refuse, and Preston hit exactly that: "Failed to execute 'share' on
+        // 'Navigator': Permission denied".
+        //
+        // Static causes were ruled out before adding this: the click reaches `share()` with no
+        // intervening await, so transient activation is intact, and no `Permissions-Policy` header
+        // is set anywhere (`web-share` is policy-gated, and a block reads as this same error). What
+        // remains is the browser refusing a file share it said it could do — which is not something
+        // the caller can detect in advance.
+        //
+        // Falling back to the download preserves what the person asked for. The alternative is what
+        // shipped: an error message and no video, on a click that could have worked.
+        if (isAbortError(error)) throw error; // They closed the share sheet. Respect that.
+
+        downloadPreparedVideo(downloadUrl, file.name);
+        captureSocialVideoEvent('debate_social_video_handoff_resolved', {
+          debate_id: debateId,
+          method: 'download',
+          // So the rate of this is visible rather than inferred from an absence of share events.
+          fell_back_from: 'native_share',
+          error_name: errorName(error),
+        });
+        return 'download';
+      }
     } else {
       downloadPreparedVideo(downloadUrl, file.name);
     }
@@ -207,7 +234,7 @@ export async function handoffPreparedSocialVideo({
       captureSocialVideoEvent('debate_social_video_handoff_failed', {
         debate_id: debateId,
         method,
-        error_name: error instanceof Error ? error.name : 'UnknownError',
+        error_name: errorName(error),
       });
     }
     throw error;
@@ -301,6 +328,23 @@ export async function downloadSocialVideo(
 
 export function isAbortError(error: unknown): boolean {
   return typeof error === 'object' && error !== null && 'name' in error && error.name === 'AbortError';
+}
+
+/**
+ * The error's own name, for telemetry.
+ *
+ * Read structurally rather than behind `instanceof Error`, which is what every call site here used
+ * to do — and `DOMException` is **not** an instance of `Error`. Since the Web Share API and the
+ * fetch abort path both reject with `DOMException`, that guard reported every one of them as
+ * `UnknownError`: the share failure Preston hit arrived as a person telling us the string, because
+ * `NotAllowedError` never reached the event. `isAbortError` above already reads `.name` this way,
+ * which is why cancellation detection worked while the reporting beside it did not.
+ */
+export function errorName(error: unknown): string {
+  if (typeof error === 'object' && error !== null && 'name' in error && typeof error.name === 'string') {
+    return error.name;
+  }
+  return 'UnknownError';
 }
 
 export function captureSocialVideoEvent(eventName: string, properties: Record<string, unknown>) {

--- a/apps/web/core/debates/social-video-share.ts
+++ b/apps/web/core/debates/social-video-share.ts
@@ -203,12 +203,15 @@ export async function handoffPreparedSocialVideo({
         // Static causes were ruled out before adding this: the click reaches `share()` with no
         // intervening await, so transient activation is intact, and no `Permissions-Policy` header
         // is set anywhere (`web-share` is policy-gated, and a block reads as this same error). What
-        // remains is the browser refusing a file share it said it could do — which is not something
-        // the caller can detect in advance.
-        //
-        // Falling back to the download preserves what the person asked for. The alternative is what
-        // shipped: an error message and no video, on a click that could have worked.
+        // remains is the browser refusing a file share it said it could do.
         if (isAbortError(error)) throw error; // They closed the share sheet. Respect that.
+
+        // Only a refusal a retry cannot change falls back. This distinction is the whole of the
+        // change: the existing behaviour — surface the error, keep a retry that reuses the prepared
+        // file — is right for a transient failure and is deliberately left alone. It is wrong only
+        // where retrying reproduces the same refusal forever, which is what a capability rejection
+        // does: the retry button then looks like a remedy and is a dead end.
+        if (!isUnretryableShareError(error)) throw error;
 
         downloadPreparedVideo(downloadUrl, file.name);
         captureSocialVideoEvent('debate_social_video_handoff_resolved', {
@@ -328,6 +331,21 @@ export async function downloadSocialVideo(
 
 export function isAbortError(error: unknown): boolean {
   return typeof error === 'object' && error !== null && 'name' in error && error.name === 'AbortError';
+}
+
+/**
+ * Share refusals that a retry cannot change.
+ *
+ * `NotAllowedError` is the browser declining the capability — a policy block, or a platform that
+ * cannot share files despite `canShare` saying it could. `NotSupportedError` is the same shape.
+ * Either way the next attempt refuses identically, so offering a retry offers nothing.
+ *
+ * Everything else keeps the existing retry path, because it might succeed.
+ */
+const UNRETRYABLE_SHARE_ERROR_NAMES = new Set(['NotAllowedError', 'NotSupportedError']);
+
+export function isUnretryableShareError(error: unknown): boolean {
+  return UNRETRYABLE_SHARE_ERROR_NAMES.has(errorName(error));
 }
 
 /**


### PR DESCRIPTION
Preston: *"I got this bug 'Failed to execute share on Navigator: Permission denied' when I tried to click share."*

`navigator.canShare({ files })` chose the native path and `share()` refused anyway — which it's allowed to do. `canShare` answers whether the payload is shareable **in principle**, not whether this browser will accept it. The click surfaced an error and no video.

## Ruled out before adding a fallback

I didn't want to paper over a fixable cause, so I checked the three that produce this exact error:

| cause | verdict |
| -- | -- |
| **Transient activation consumed** | Intact. The path is synchronous through to `share()`: `onClick` awaits nothing, `onActivate` calls `handoffPreparedSocialVideo`, and its body reaches `share()` before its first await. Both call sites check out. |
| **`Permissions-Policy` block** | None set — not in the app, not on the production response. Worth confirming, since `web-share` is policy-gated and a block presents as this same error. |
| **Insecure context** | HTTPS. |

What's left is a browser refusing a file share it said it could do, which the caller cannot detect in advance.

## The fix

On refusal, fall back to the download. That's what the person asked for — a video in their hands — and it's consistent with what the button already did: **a browser whose `canShare` says *no* downloads without asking**, so one that says yes and then refuses is the same situation discovered a moment later.

Cancelling the share sheet still aborts. That's a decision, and quietly downloading instead would override it.

## The reporting bug that hid this

All four `error_name` reads used:

```ts
error instanceof Error ? error.name : 'UnknownError'
```

**`DOMException` is not an instance of `Error`.** Web Share and the fetch abort path both reject with `DOMException`, so every one was recorded as `UnknownError` — which is why this reached us as a person quoting a string rather than as `NotAllowedError` in telemetry. Replaced with a structural `errorName`, matching how `isAbortError` right beside it already read `.name`.

That one is worth a look independently of the fallback: it means the share/download failure telemetry has been blind to *which* error since it was written.

## One contract changed on purpose

An existing test asserted that a non-cancellation failure **rejects** and leaves retry to the caller. I changed it, with the reasoning in the test: the button's contract is "hand off the video", not "open the share sheet". Retry is unaffected — nothing here consumes the prepared file.

## Verification

- 14 share tests pass; `tsc` at its 5-error baseline.
- New tests: the refusal falls back and is tagged in telemetry with what it fell back from, and cancellation still aborts.

## Heads up: master is red, unrelated to this

A clean checkout of `master` fails **4 tests in 2 files** — `rematch-page-client.test.tsx` and `use-debate-gateway-space-scopes.test.tsx`. #2265 (voice chat in the rematch room) touches `rematch-page-client.test.tsx` directly and merged at 19:07, so it looks responsible.

I found this because my own suite run looked broken; baselining master with no local changes is what separated the two. Anything merged now inherits those failures, so worth fixing at the source.
