### PR TITLE
feat(debates): backfill claim lists from the graph where geo-chat runs out (GEO-2704)

### DIFF
--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
@@ -76,6 +76,18 @@ const mocks = vi.hoisted(() => ({
   featuredCatalogError: null as Error | null,
   featuredEnabledWith: [] as boolean[],
   entityQueryHasNextPage: false,
+  tailSources: [] as Array<{
+    claimEntityId: string;
+    spaceId: string;
+    name: string;
+    description: string | null;
+    entity: Record<string, unknown>;
+  }>,
+  tailTopics: [] as Array<{ claimEntityId: string; topics: Array<{ id: string; name: string | null }> }>,
+  tailHasNextPage: false,
+  tailFetchNextPage: vi.fn(),
+  tailEnabledWith: [] as boolean[],
+  tailQueries: [] as unknown[],
   /** The hub's claims query (the All tab) is still in flight. */
   entityQueryLoading: false,
   /** The by-id hydration of the opponent's claims is still in flight. */
@@ -243,6 +255,23 @@ vi.mock('~/core/debates/debate-entry-intent', () => ({
 
 // GEO-2683. Featured stands in for Recommended when no curator page exists, which is what most of
 // these suites run under — so without this every case here would reach the graph for the tag.
+// GEO-2704. The graph tail that continues All claims once geo-chat runs out of pages.
+vi.mock('~/core/debates/use-graph-claim-tail', () => ({
+  useGraphClaimTailSources: ({ query, enabled }: { query: unknown; enabled: boolean }) => {
+    mocks.tailEnabledWith.push(enabled);
+    if (enabled) mocks.tailQueries.push(query);
+    return {
+      sources: enabled ? mocks.tailSources : [],
+      topicsByClaimId: new Map(enabled ? mocks.tailTopics.map(entry => [entry.claimEntityId, entry.topics]) : []),
+      isLoading: false,
+      isFetchingNextPage: false,
+      hasNextPage: enabled && mocks.tailHasNextPage,
+      fetchNextPage: mocks.tailFetchNextPage,
+      error: null,
+    };
+  },
+}));
+
 vi.mock('~/core/debates/featured-claims', async importOriginal => ({
   ...(await importOriginal<typeof import('~/core/debates/featured-claims')>()),
   useFeaturedClaims: (enabled: boolean) => {
@@ -478,6 +507,12 @@ beforeEach(() => {
   mocks.featuredCatalogError = null;
   mocks.featuredEnabledWith = [];
   mocks.entityQueryHasNextPage = false;
+  mocks.tailSources = [];
+  mocks.tailTopics = [];
+  mocks.tailHasNextPage = false;
+  mocks.tailFetchNextPage.mockReset();
+  mocks.tailEnabledWith = [];
+  mocks.tailQueries = [];
   mocks.lastEnabledData = undefined;
   mocks.spacesHeldOver = false;
   mocks.scopeHeldOver = false;
@@ -2921,3 +2956,92 @@ function publishedEntity(id = CLAIM_MORE, name = 'A newly published claim') {
 function claimSummary(id: string, claim: string) {
   return { id, space_id: SPACE_1, claim_entity_id: id, claim, description: null };
 }
+
+// GEO-2704. geo-chat can only list a claim it has a row for, and it has rows for far fewer claims
+// than exist — so its index running out of pages is not the corpus running out of claims.
+describe('DebateRematchPageClient — the graph tail', () => {
+  const TAILED = '019fedba-8ec9-7ab6-9c99-aef5d071cc86';
+
+  function tailSource(id = TAILED, name = 'A claim geo-chat never indexed') {
+    return {
+      claimEntityId: id,
+      spaceId: SPACE_2,
+      name,
+      description: null,
+      entity: { ...publishedEntity(id, name), spaces: [SPACE_2] },
+    };
+  }
+
+  it('appends the tail after geo-chat’s rows on All claims', async () => {
+    mocks.tailSources = [tailSource()];
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+    await showAllClaims();
+
+    expect(screen.getByText('A claim geo-chat never indexed')).toBeInTheDocument();
+    expect(appearsBefore('A newly published claim', 'A claim geo-chat never indexed')).toBe(true);
+  });
+
+  // While geo-chat still has pages, its list is the list.
+  it('waits for geo-chat to run out before asking the graph', async () => {
+    mocks.entityQueryHasNextPage = true;
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+    await showAllClaims();
+
+    expect(mocks.tailEnabledWith.at(-1)).toBe(false);
+  });
+
+  // A substring filter over the ranking walk measured at ten seconds.
+  it('stays off while the viewer is searching', async () => {
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+    await showAllClaims();
+
+    fireEvent.change(screen.getByLabelText('Search claims'), { target: { value: 'newly' } });
+
+    await waitFor(() => expect(mocks.tailEnabledWith.at(-1)).toBe(false));
+  });
+
+  // The other two sources are already graph-backed or a fixed curated set.
+  it('stays off under Recommended and Featured', async () => {
+    mocks.recommendedSections = [{ id: 'block-1', name: 'Geopolitics & chips', claimIds: [CLAIM_SHARED] }];
+    mocks.recommendedEntities = [sharedEntity()];
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+
+    expect(mocks.tailEnabledWith.at(-1)).toBe(false);
+
+    await chooseSource('Featured');
+
+    expect(mocks.tailEnabledWith.at(-1)).toBe(false);
+  });
+
+  it('excludes what is already on screen', async () => {
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+    await showAllClaims();
+
+    const asked = mocks.tailQueries.at(-1) as { excludeIds: string[] };
+    expect(asked.excludeIds).toContain(CLAIM_MORE);
+  });
+
+  // The reported bug: a topic carried only by claims geo-chat never indexed was missing from the
+  // menu, and unreachable, since you cannot filter to an option that isn't there.
+  it('offers a topic carried only by a tailed claim', async () => {
+    mocks.tailSources = [tailSource()];
+    mocks.tailTopics = [{ claimEntityId: TAILED, topics: [{ id: 'topic-morning', name: 'Morning routine' }] }];
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+    await showAllClaims();
+
+    fireEvent.click(screen.getByRole('button', { name: /Any topic/ }));
+
+    expect(screen.getByRole('button', { name: /Morning routine/ })).toBeInTheDocument();
+  });
+
+  // One sentinel, two sources, in order.
+  it('pages the tail once geo-chat has no pages left', async () => {
+    mocks.tailHasNextPage = true;
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+    await showAllClaims();
+
+    act(() => mocks.scrollSentinelIntoView?.());
+
+    expect(mocks.tailFetchNextPage).toHaveBeenCalled();
+  });
+});

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
@@ -257,9 +257,17 @@ vi.mock('~/core/debates/debate-entry-intent', () => ({
 // these suites run under — so without this every case here would reach the graph for the tag.
 // GEO-2704. The graph tail that continues All claims once geo-chat runs out of pages.
 vi.mock('~/core/debates/use-graph-claim-tail', () => ({
-  useGraphClaimTailSources: ({ query, enabled }: { query: unknown; enabled: boolean }) => {
+  useGraphClaimTailSources: ({
+    query,
+    search,
+    enabled,
+  }: {
+    query: unknown;
+    search?: string | null;
+    enabled: boolean;
+  }) => {
     mocks.tailEnabledWith.push(enabled);
-    if (enabled) mocks.tailQueries.push(query);
+    if (enabled) mocks.tailQueries.push({ ...(query as object), search: search ?? null });
     return {
       sources: enabled ? mocks.tailSources : [],
       topicsByClaimId: new Map(enabled ? mocks.tailTopics.map(entry => [entry.claimEntityId, entry.topics]) : []),
@@ -2990,14 +2998,16 @@ describe('DebateRematchPageClient — the graph tail', () => {
     expect(mocks.tailEnabledWith.at(-1)).toBe(false);
   });
 
-  // A substring filter over the ranking walk measured at ten seconds.
-  it('stays off while the viewer is searching', async () => {
+  // A search is answered too, through the indexed endpoint rather than the ranking walk — a
+  // substring filter over that measured at ten seconds.
+  it('hands a search term to the tail rather than switching it off', async () => {
     render(<DebateRematchPageClient sessionId="rematch-1" />);
     await showAllClaims();
 
     fireEvent.change(screen.getByLabelText('Search claims'), { target: { value: 'newly' } });
 
-    await waitFor(() => expect(mocks.tailEnabledWith.at(-1)).toBe(false));
+    await waitFor(() => expect((mocks.tailQueries.at(-1) as { search: string | null }).search).toBe('newly'));
+    expect(mocks.tailEnabledWith.at(-1)).toBe(true);
   });
 
   // The other two sources are already graph-backed or a fixed curated set.

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -410,12 +410,14 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
    *
    * geo-chat can only list a claim it has a row for, and it has rows for far fewer claims than
    * exist — so the index running out of pages is not the corpus running out of claims. Off while it
-   * still has pages, off while searching (a substring filter over the ranking walk measured at ten
-   * seconds), and off on the other two sources, which are already graph-backed or a fixed set.
+   * still has pages, and off on the other two sources, which are already graph-backed or a fixed
+   * curated set.
+   *
+   * A search is answered through the indexed endpoint rather than the ranking walk — see
+   * `useGraphClaimTailSources`, which picks the source.
    */
   const tailEnabled =
     browsesPages &&
-    !debouncedSearch &&
     !allowlistPending &&
     !browsedClaimsQuery.unusable &&
     !browsedClaimsQuery.isLoading &&
@@ -802,6 +804,7 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
 
   const tail = useGraphClaimTailSources({
     query: tailQuery,
+    search: debouncedSearch || null,
     enabled: tailEnabled,
     homeSpaceOf: tailHomeSpaceOf,
   });

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -63,6 +63,7 @@ import { useClaimDebateReadiness } from '~/core/debates/use-claim-debate-readine
 import { useClaimSpaceAllowlist } from '~/core/debates/use-claim-space-allowlist';
 import { useCurrentGeoChatUserId } from '~/core/debates/use-current-geo-chat-user-id';
 import { isSpaceDebatePublishable, useDebatePublishableSpaces } from '~/core/debates/use-debate-publishable-spaces';
+import { useGraphClaimTailSources } from '~/core/debates/use-graph-claim-tail';
 import { useEntitySidePanel } from '~/core/hooks/use-entity-side-panel';
 import { useEntityResponse, useEntityResponseIndexingSnapshot } from '~/core/hooks/use-entity-vote';
 import { useInfiniteScrollSentinel } from '~/core/hooks/use-infinite-scroll-sentinel';
@@ -404,6 +405,27 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   );
   const { pages: browsedPages, facets: browsedFacets } = browsedClaimsQuery;
 
+  /**
+   * GEO-2704. What geo-chat doesn't know about, continuing All claims once it runs out.
+   *
+   * geo-chat can only list a claim it has a row for, and it has rows for far fewer claims than
+   * exist — so the index running out of pages is not the corpus running out of claims. Off while it
+   * still has pages, off while searching (a substring filter over the ranking walk measured at ten
+   * seconds), and off on the other two sources, which are already graph-backed or a fixed set.
+   */
+  const tailEnabled =
+    browsesPages &&
+    !debouncedSearch &&
+    !allowlistPending &&
+    !browsedClaimsQuery.unusable &&
+    !browsedClaimsQuery.isLoading &&
+    !browsedClaimsQuery.hasNextPage;
+
+  const tailSpaceIds = React.useMemo(
+    () => (spaceIds.length > 0 ? spaceIds : eligibleSpaceIds),
+    [eligibleSpaceIds, spaceIds]
+  );
+
   // What geo-chat knows about this session's claims — readiness, the shared-preference and
   // rejection flags, and which ids the session excludes. One batch for the opponent's claims, one
   // for the curated ones; the session's own id-less list covers anything both have answered.
@@ -571,6 +593,7 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
         }
       }
     }
+    return map;
     return map;
   }, [browsedPages, featuredEntitiesQuery.entities, opponentEntitiesQuery.entities, recommendedEntities]);
 
@@ -753,10 +776,94 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
     sidesOf,
     spaceAllowlist,
   ]);
+  // Everything already on screen, so the tail never repeats a row. The session's own exclusions ride
+  // along for the same reason they go out as `rematch_session_id`: a claim this session has dealt
+  // with should not come back through another door.
+  const tailQuery = React.useMemo(
+    () => ({
+      spaceIds: tailSpaceIds,
+      topicIds,
+      excludeIds: [...new Set([...browsedRows.map(row => row.claim.claim_entity_id), ...excludedClaimIds])],
+    }),
+    [browsedRows, excludedClaimIds, tailSpaceIds, topicIds]
+  );
+
+  // Both gates, on the space the row will actually carry: the home space decides where the debate
+  // is published, so a claim whose home falls outside them is dropped rather than offered against a
+  // space this picker would not have listed.
+  const tailHomeSpaceOf = React.useCallback(
+    (entity: ClaimPickerEntity) => {
+      const homeSpaceId = claimHomeSpaceId(entity, canPublishDebateIn);
+      if (!homeSpaceId || !canPublishDebateIn(homeSpaceId)) return null;
+      return isClaimSpaceAllowed(homeSpaceId, spaceAllowlist) ? homeSpaceId : null;
+    },
+    [canPublishDebateIn, spaceAllowlist]
+  );
+
+  const tail = useGraphClaimTailSources({
+    query: tailQuery,
+    enabled: tailEnabled,
+    homeSpaceOf: tailHomeSpaceOf,
+  });
+
+  const tailClaimIds = React.useMemo(() => tail.sources.map(source => source.claimEntityId), [tail.sources]);
+  // The session's view of these claims — readiness and its flags — through the same lookup the other
+  // sources use, rather than the per-space one: these rows are the picker's shape, not the hub's.
+  const tailClaimsQuery = useDebateRematchClaimsForIds(sessionId, tailClaimIds);
+
+  // The tail's claims are ones geo-chat never indexed, so its facet says nothing about their topics
+  // — which is how a topic came to be offered under Featured and missing under All claims for the
+  // same space. Folded in here, the menu's existing merge of server facet and row topics picks them
+  // up without further change.
+  const topicsWithTail = React.useMemo(() => {
+    if (tail.topicsByClaimId.size === 0) return topicsByClaimId;
+    const map = new Map(topicsByClaimId);
+    for (const [claimId, topics] of tail.topicsByClaimId) if (!map.has(claimId)) map.set(claimId, topics);
+    return map;
+  }, [tail.topicsByClaimId, topicsByClaimId]);
+
+  /**
+   * Appended, not merged. geo-chat orders by presence and readiness, the tail by ranking score.
+   *
+   * The session's answer about these claims is layered here rather than folded into
+   * `sessionRowsByClaimId` and `excludedClaimIds` above. Those are built before the tail exists and
+   * the tail's own query is built from them, so feeding its response back into them is a cycle —
+   * the exclusions would depend on the lookup that depends on the exclusions.
+   */
+  const browsedWithTail = React.useMemo(() => {
+    if (tail.sources.length === 0) return browsedRows;
+
+    const sessionRows = new Map((tailClaimsQuery.data?.claims ?? []).map(row => [row.claim.claim_entity_id, row]));
+    const sessionExcluded = new Set(tailClaimsQuery.data?.excluded_claim_ids ?? []);
+    const shown = new Set(browsedRows.map(row => row.claim.claim_entity_id));
+
+    const rows = tail.sources.flatMap(source => {
+      const claimId = source.claimEntityId;
+      if (shown.has(claimId) || excludedClaimIds.has(claimId) || sessionExcluded.has(claimId)) return [];
+      const row = source.entity ? rowFromEntity(source.entity, source.spaceId) : null;
+      if (!row) return [];
+
+      const sessionRow = sessionRows.get(claimId);
+      if (!sessionRow) return [row];
+      return [
+        {
+          ...row,
+          shared_preference: sessionRow.shared_preference,
+          recently_rejected: sessionRow.recently_rejected,
+          previously_debated: sessionRow.previously_debated,
+          viewer_debate_ready: sessionRow.viewer_debate_ready,
+          readiness_disabled_reason: sessionRow.readiness_disabled_reason,
+        },
+      ];
+    });
+
+    return rows.length > 0 ? [...browsedRows, ...rows] : browsedRows;
+  }, [browsedRows, excludedClaimIds, rowFromEntity, tail.sources, tailClaimsQuery.data]);
+
   // The server re-sorts on every readiness change, so hold the order the viewer is looking at
   // until they ask for a different list.
   const browsedClaims = useStableListOrder(
-    browsedRows,
+    browsedWithTail,
     row => `${row.claim.space_id}:${row.claim.claim_entity_id}`,
     // Topic belongs in the key for the same reason space does: it goes out as `topic_id`, so the
     // server ranks a different list under it, and holding the previous order would arrange the
@@ -916,7 +1023,7 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
           if (!offered.has(claim.claim.space_id)) return false;
           if (
             topicIds.length > 0 &&
-            !(topicsByClaimId.get(claim.claim.claim_entity_id) ?? []).some(topic => topicIds.includes(topic.id))
+            !(topicsWithTail.get(claim.claim.claim_entity_id) ?? []).some(topic => topicIds.includes(topic.id))
           )
             return false;
           if (
@@ -935,7 +1042,7 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
     // empty list. An absent *selection* comes back at zero, or its checkbox disappears while the
     // trigger goes on counting it, and it can't be unticked without clearing every space.
     return orderFacetOptions(keepSelectedVisible(merged, spaceIds), spaceIds);
-  }, [browsedFacets?.space_facets, claims, debouncedSearch, facetSpaceIds, spaceIds, tab, topicIds, topicsByClaimId]);
+  }, [browsedFacets?.space_facets, claims, debouncedSearch, facetSpaceIds, spaceIds, tab, topicIds, topicsWithTail]);
 
   // A space picked while the gates were still passing everything has to be let go once they
   // reject it, or it keeps going out as `space_id` on every request while its rows are dropped.
@@ -982,10 +1089,10 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
     () =>
       countBy(
         topicFacetClaims.flatMap(claim =>
-          (topicsByClaimId.get(claim.claim.claim_entity_id) ?? []).map(topic => ({ id: topic.id, name: topic.name }))
+          (topicsWithTail.get(claim.claim.claim_entity_id) ?? []).map(topic => ({ id: topic.id, name: topic.name }))
         )
       ),
-    [topicFacetClaims, topicsByClaimId]
+    [topicFacetClaims, topicsWithTail]
   );
 
   const facetTopics = React.useMemo(() => {
@@ -1014,7 +1121,7 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
         // match. A no-op for the rows the server did filter, which match by construction.
         if (
           topicIds.length > 0 &&
-          !(topicsByClaimId.get(claim.claim.claim_entity_id) ?? []).some(t => topicIds.includes(t.id))
+          !(topicsWithTail.get(claim.claim.claim_entity_id) ?? []).some(t => topicIds.includes(t.id))
         )
           return false;
         if (
@@ -1025,21 +1132,26 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
           return false;
         return true;
       }),
-    [browsesPages, claims, debouncedSearch, spaceIds, topicIds, topicsByClaimId]
+    [browsesPages, claims, debouncedSearch, spaceIds, topicIds, topicsWithTail]
   );
 
   const hasFilters = Boolean(debouncedSearch || spaceIds.length || topicIds.length);
 
   // Only All claims pages, so the sentinel exists only under it.
-  const hasNextPage = browsesPages && browsedClaimsQuery.hasNextPage;
+  // geo-chat's pages first, then the tail's — one sentinel, two sources, in that order.
+  const hasNextPage = browsesPages && (browsedClaimsQuery.hasNextPage || tail.hasNextPage);
+  const fetchNextPage = React.useCallback(() => {
+    if (browsedClaimsQuery.hasNextPage) browsedClaimsQuery.fetchNextPage();
+    else tail.fetchNextPage();
+  }, [browsedClaimsQuery, tail]);
 
   const sentinelRef = useInfiniteScrollSentinel({
     // Masked for the same reason the pages are: the retained `hasNextPage` outlives the scope it
     // described, and `fetchNextPage` is a manual call that ignores `enabled` — so a sentinel left
     // in view would page the unscoped corpus the moment it was scrolled to.
     hasNextPage,
-    isFetchingNextPage: browsedClaimsQuery.isFetchingNextPage,
-    fetchNextPage: browsedClaimsQuery.fetchNextPage,
+    isFetchingNextPage: browsedClaimsQuery.isFetchingNextPage || tail.isFetchingNextPage,
+    fetchNextPage,
   });
 
   // Each tab draws from a different set of queries, so each waits on its own. The allowlist narrows

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -1,7 +1,5 @@
 'use client';
 
-import { SystemIds } from '@geoprotocol/geo-sdk/lite';
-
 import * as React from 'react';
 
 import cx from 'classnames';
@@ -21,6 +19,7 @@ import {
   type MatchmakingReadiness,
   type MatchmakingTopic,
 } from '~/core/debates/api';
+import { claimCandidateSpaceIds, claimHomeSpaceId } from '~/core/debates/claim-home-space';
 import { type ClaimPickerEntity, useClaimEntitiesByIds } from '~/core/debates/claim-picker-page';
 import { eligibleClaimSpaceIds, isClaimSpaceAllowed } from '~/core/debates/claim-space-allowlist';
 import { markEnteringDebate } from '~/core/debates/debate-entry-intent';
@@ -65,19 +64,18 @@ import { useClaimSpaceAllowlist } from '~/core/debates/use-claim-space-allowlist
 import { useCurrentGeoChatUserId } from '~/core/debates/use-current-geo-chat-user-id';
 import { isSpaceDebatePublishable, useDebatePublishableSpaces } from '~/core/debates/use-debate-publishable-spaces';
 import { useEntitySidePanel } from '~/core/hooks/use-entity-side-panel';
-
-import { RematchVoicePill } from './rematch-voice';
 import { useEntityResponse, useEntityResponseIndexingSnapshot } from '~/core/hooks/use-entity-vote';
 import { useInfiniteScrollSentinel } from '~/core/hooks/use-infinite-scroll-sentinel';
 import { useSpacesByIds } from '~/core/hooks/use-spaces-by-ids';
 import { uuidToHex } from '~/core/id/normalize';
 import { responsePositionLabel } from '~/core/responses/entity-response';
-import { getTopRankedSpaceId } from '~/core/utils/space/space-ranking';
 
 import { ChevronDownSmall } from '~/design-system/icons/chevron-down-small';
 import { Input } from '~/design-system/input';
 import { Skeleton } from '~/design-system/skeleton';
 import { Text } from '~/design-system/text';
+
+import { RematchVoicePill } from './rematch-voice';
 
 const SEARCH_DEBOUNCE_MS = 250;
 
@@ -1727,79 +1725,6 @@ function rematchPositionSummaries(
       participants,
     };
   });
-}
-
-/**
- * The space a claim actually lives in.
- *
- * Everything the picker does with a claim is scoped to one space — the response is published
- * against it, geo-chat keys its claim row and readiness on it, and the "Is factual" value that
- * decides the response kind is read from it. Getting it wrong means responding in one space and
- * asking to debate in another, which the server answers with "respond to this claim in this space
- * before enabling debate readiness".
- *
- * `entity.spaces` can't answer it: it is ordered by a fixed space ranking and counts every space
- * holding *any* value or even an inbound relation, so `spaces[0]` is a space that merely mentions
- * the claim whenever that space outranks the claim's own — a Podcasts claim cited from Root or
- * Crypto resolves to those. Prefer the spaces where the claim is actually named, which is how the
- * entity side panel scopes the same entity.
- *
- * `canPublishIn`, where given, is consulted before the ranking. A claim named in both a personal
- * space and a public one is a real case — a debater publishes into their own space and a curator
- * later adds the claim to a shared one — and the space ranking has no opinion on which to pick:
- * neither is in its table, so the tie falls to array order. Picking the personal space there loses a
- * claim that is perfectly debatable in the public one, since the home space is exactly what decides
- * where the debate is published. So: rank among the spaces that could receive it, and fall back to
- * the plain ranking when none can, which leaves the claim to be filtered out on its merits rather
- * than resolving to no space at all.
- */
-function claimHomeSpaceId(
-  entity: {
-    spaces: string[];
-    values?: Array<{ isDeleted?: boolean; property: { id: string }; spaceId: string; value: string }>;
-  },
-  canPublishIn?: (spaceId: string) => boolean
-): string | null {
-  const named = [...claimNamedSpaceIds(entity)];
-  const publishable = canPublishIn ? (ids: string[]) => ids.filter(canPublishIn) : (ids: string[]) => ids;
-
-  return (
-    getTopRankedSpaceId(publishable(named)) ??
-    getTopRankedSpaceId(named) ??
-    getTopRankedSpaceId(publishable(entity.spaces)) ??
-    getTopRankedSpaceId(entity.spaces) ??
-    null
-  );
-}
-
-/** The spaces a claim is actually named in — where it lives, as opposed to where it is mentioned. */
-function claimNamedSpaceIds(entity: {
-  values?: Array<{ isDeleted?: boolean; property: { id: string }; spaceId: string; value: string }>;
-}): Set<string> {
-  const namedSpaceIds = new Set<string>();
-  for (const value of entity.values ?? []) {
-    if (
-      value.isDeleted !== true &&
-      uuidToHex(value.property.id) === uuidToHex(SystemIds.NAME_PROPERTY) &&
-      typeof value.value === 'string' &&
-      value.value.trim().length > 0
-    ) {
-      namedSpaceIds.add(value.spaceId);
-    }
-  }
-  return namedSpaceIds;
-}
-
-/**
- * Every space a claim could resolve its home to. The publishability lookup covers all of them, so
- * {@link claimHomeSpaceId} has the types it needs to choose between them rather than choosing first
- * and discovering afterwards that the space it picked can never receive the debate.
- */
-function claimCandidateSpaceIds(entity: {
-  spaces: string[];
-  values?: Array<{ isDeleted?: boolean; property: { id: string }; spaceId: string; value: string }>;
-}): string[] {
-  return [...new Set([...claimNamedSpaceIds(entity), ...entity.spaces])];
 }
 
 function rematchCancellationMessage(reason: string) {

--- a/apps/web/core/debates/claim-home-space.ts
+++ b/apps/web/core/debates/claim-home-space.ts
@@ -1,0 +1,79 @@
+import { SystemIds } from '@geoprotocol/geo-sdk/lite';
+
+import { uuidToHex } from '~/core/id/normalize';
+import { getTopRankedSpaceId } from '~/core/utils/space/space-ranking';
+
+/**
+ * Which of a claim's spaces it belongs to, for debates.
+ *
+ * Lifted out of the rematch picker for GEO-2704: the graph-backed tail of the side panel's list
+ * has to answer the same question, and answering it twice is how the two surfaces would drift.
+ *
+ * The structural subset each takes is the picker's claim projection; a full `Entity` satisfies it.
+ */
+type ClaimSpaces = {
+  spaces: string[];
+  values?: Array<{ isDeleted?: boolean; property: { id: string }; spaceId: string; value: string }>;
+};
+
+/**
+ * The space a claim actually lives in.
+ *
+ * Everything the picker does with a claim is scoped to one space — the response is published
+ * against it, geo-chat keys its claim row and readiness on it, and the "Is factual" value that
+ * decides the response kind is read from it. Getting it wrong means responding in one space and
+ * asking to debate in another, which the server answers with "respond to this claim in this space
+ * before enabling debate readiness".
+ *
+ * `entity.spaces` can't answer it: it is ordered by a fixed space ranking and counts every space
+ * holding *any* value or even an inbound relation, so `spaces[0]` is a space that merely mentions
+ * the claim whenever that space outranks the claim's own — a Podcasts claim cited from Root or
+ * Crypto resolves to those. Prefer the spaces where the claim is actually named, which is how the
+ * entity side panel scopes the same entity.
+ *
+ * `canPublishIn`, where given, is consulted before the ranking. A claim named in both a personal
+ * space and a public one is a real case — a debater publishes into their own space and a curator
+ * later adds the claim to a shared one — and the space ranking has no opinion on which to pick:
+ * neither is in its table, so the tie falls to array order. Picking the personal space there loses a
+ * claim that is perfectly debatable in the public one, since the home space is exactly what decides
+ * where the debate is published. So: rank among the spaces that could receive it, and fall back to
+ * the plain ranking when none can, which leaves the claim to be filtered out on its merits rather
+ * than resolving to no space at all.
+ */
+export function claimHomeSpaceId(entity: ClaimSpaces, canPublishIn?: (spaceId: string) => boolean): string | null {
+  const named = [...claimNamedSpaceIds(entity)];
+  const publishable = canPublishIn ? (ids: string[]) => ids.filter(canPublishIn) : (ids: string[]) => ids;
+
+  return (
+    getTopRankedSpaceId(publishable(named)) ??
+    getTopRankedSpaceId(named) ??
+    getTopRankedSpaceId(publishable(entity.spaces)) ??
+    getTopRankedSpaceId(entity.spaces) ??
+    null
+  );
+}
+
+/** The spaces a claim is actually named in — where it lives, as opposed to where it is mentioned. */
+export function claimNamedSpaceIds(entity: Pick<ClaimSpaces, 'values'>): Set<string> {
+  const namedSpaceIds = new Set<string>();
+  for (const value of entity.values ?? []) {
+    if (
+      value.isDeleted !== true &&
+      uuidToHex(value.property.id) === uuidToHex(SystemIds.NAME_PROPERTY) &&
+      typeof value.value === 'string' &&
+      value.value.trim().length > 0
+    ) {
+      namedSpaceIds.add(value.spaceId);
+    }
+  }
+  return namedSpaceIds;
+}
+
+/**
+ * Every space a claim could resolve its home to. The publishability lookup covers all of them, so
+ * {@link claimHomeSpaceId} has the types it needs to choose between them rather than choosing first
+ * and discovering afterwards that the space it picked can never receive the debate.
+ */
+export function claimCandidateSpaceIds(entity: ClaimSpaces): string[] {
+  return [...new Set([...claimNamedSpaceIds(entity), ...entity.spaces])];
+}

--- a/apps/web/core/debates/graph-claim-rows.ts
+++ b/apps/web/core/debates/graph-claim-rows.ts
@@ -1,0 +1,116 @@
+import { TOPICS_PROPERTY_ID } from '~/core/claims/ontology';
+import { claimResponseKind } from '~/core/claims/response-kind';
+import { responsePositionLabel } from '~/core/responses/entity-response';
+
+import type { DebateClaim, DebateClaimPositionSummary, MatchmakingClaim, MatchmakingTopic } from './api';
+import type { ClaimPickerEntity } from './claim-picker-page';
+
+/**
+ * GEO-2704. Turning a knowledge-graph claim into the row the hub's cards already speak.
+ *
+ * Two lists need this now — Featured, which has always come from the graph, and the tail that
+ * continues geo-chat's list once it runs out — so the conversion lives here rather than being
+ * written twice with two sets of fallbacks.
+ *
+ * geo-chat has a row for a claim only once someone has taken a side on it, so everything its row
+ * would carry has a graph-derived fallback: a claim nobody has answered still lists, with no sides
+ * and the response kind its own "Is factual" value implies.
+ */
+
+/**
+ * The two sides of a claim, from geo-chat's per-space row.
+ *
+ * That row reports the sides as `online_choices` — who is online and available on each — where the
+ * hub's index reports a total alongside them. The card draws the avatars and their overflow count
+ * off `total_count`, so the online count stands in for it: it is the only count this endpoint
+ * gives, and undercounting a side is better than claiming a total it never told us.
+ */
+export function graphClaimPositionSummaries(
+  row: DebateClaim | undefined,
+  responseKind: 'stance' | 'veracity'
+): DebateClaimPositionSummary[] {
+  return [true, false].map(position => {
+    const choice = row?.online_choices.find(candidate => candidate.position === position);
+
+    return {
+      position,
+      // A server-supplied label wins, so an authoritative Verify/Dispute survives.
+      position_label: choice?.position_label ?? responsePositionLabel(responseKind, position),
+      total_count: choice?.participant_count ?? 0,
+      available_now_count: choice?.participant_count ?? 0,
+      participants: choice?.participants ?? [],
+    };
+  });
+}
+
+/** The graph-side facts a row is built from, once its home space has been decided. */
+export type GraphClaimSource = {
+  claimEntityId: string;
+  spaceId: string;
+  name: string;
+  description: string | null;
+  /** The claim's entity, where it was fetched — supplies the response kind when geo-chat has no row. */
+  entity?: ClaimPickerEntity;
+};
+
+export function graphClaimRow(source: GraphClaimSource, row: DebateClaim | undefined): MatchmakingClaim {
+  const responseKind =
+    row?.response_kind ?? (source.entity ? claimResponseKind(source.entity, source.spaceId) : 'stance');
+
+  return {
+    claim: {
+      id: row?.id ?? source.claimEntityId,
+      space_id: source.spaceId,
+      claim_entity_id: source.claimEntityId,
+      claim: source.name,
+      description: source.description,
+    },
+    // Topics ride alongside the row rather than on it — see `graphClaimTopics`, which the menus and
+    // the topic filter both read. geo-chat's own rows carry them here; these don't.
+    topics: [],
+    response_kind: responseKind,
+    viewer_response: row?.viewer_response ?? null,
+    viewer_position: row?.viewer_response?.position ?? null,
+    viewer_debate_ready: row?.viewer_debate_ready ?? false,
+    readiness_disabled_reason: row?.readiness_disabled_reason ?? null,
+    positions: graphClaimPositionSummaries(row, responseKind),
+    // The index's ranking score, which these lists have no equivalent of and don't sort by.
+    score: 0,
+    active_debate: Boolean(row?.active_debate),
+  };
+}
+
+/**
+ * Topics by claim id, off the entities already fetched for the response kind.
+ *
+ * geo-chat's topic facet describes the claims geo-chat knows about, so it says nothing about these
+ * — which is exactly how a topic came to be offered under Featured and missing under All claims for
+ * the same space. The menus union the two.
+ */
+export function graphClaimTopics(entities: ClaimPickerEntity[]): Map<string, MatchmakingTopic[]> {
+  const map = new Map<string, MatchmakingTopic[]>();
+
+  for (const entity of entities) {
+    const topics = entity.relations
+      .filter(relation => relation.type.id === TOPICS_PROPERTY_ID && relation.isDeleted !== true)
+      .map(relation => ({ id: relation.toEntity.id, name: relation.toEntity.name ?? null }));
+    if (topics.length > 0) map.set(entity.id, topics);
+  }
+
+  return map;
+}
+
+/** Claim ids grouped for geo-chat's per-space `debate-claims` lookup, in a stable order. */
+export function claimIdsBySpace(claims: Array<{ claimEntityId: string; spaceId: string }>) {
+  const bySpace = new Map<string, string[]>();
+
+  for (const claim of claims) {
+    const existing = bySpace.get(claim.spaceId);
+    if (existing) existing.push(claim.claimEntityId);
+    else bySpace.set(claim.spaceId, [claim.claimEntityId]);
+  }
+
+  return [...bySpace.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([spaceId, claimIds]) => ({ spaceId, claimIds }));
+}

--- a/apps/web/core/debates/graph-claim-search.test.ts
+++ b/apps/web/core/debates/graph-claim-search.test.ts
@@ -1,0 +1,133 @@
+import * as Effect from 'effect/Effect';
+import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { CLAIM_TYPE_ID, TOPICS_PROPERTY_ID } from '~/core/claims/ontology';
+import { getResultsPage } from '~/core/io/queries';
+
+import { fetchClaimPickerEntities } from './claim-picker-page';
+import { GRAPH_CLAIM_SEARCH_PAGE_SIZE, fetchGraphClaimSearch } from './graph-claim-search';
+
+vi.mock('~/core/io/queries', () => ({ getResultsPage: vi.fn() }));
+vi.mock('./claim-picker-page', () => ({ fetchClaimPickerEntities: vi.fn() }));
+
+const searchMock = getResultsPage as unknown as Mock;
+const hydrateMock = fetchClaimPickerEntities as unknown as Mock;
+
+const SPACE = '019fedae72b67ab2927adf044d57c566';
+
+function entity(id: string, topicIds: string[] = []) {
+  return {
+    id,
+    name: `Claim ${id}`,
+    description: null,
+    spaces: [SPACE],
+    values: [],
+    relations: topicIds.map(topicId => ({
+      type: { id: TOPICS_PROPERTY_ID },
+      toEntity: { id: topicId, name: topicId },
+    })),
+  };
+}
+
+function respondWith(ids: string[], total = ids.length) {
+  searchMock.mockImplementation(() =>
+    Effect.succeed({ results: ids.map(id => ({ id })), total, rawCount: ids.length, serverCount: ids.length })
+  );
+  hydrateMock.mockImplementation((requested: string[]) => Promise.resolve(requested.map(id => entity(id))));
+}
+
+describe('fetchGraphClaimSearch', () => {
+  beforeEach(() => {
+    searchMock.mockReset();
+    hydrateMock.mockReset();
+  });
+
+  // The ranking walk cannot answer a search — a substring filter over it measured at ten seconds —
+  // so this goes to the indexed endpoint, narrowed to claims.
+  it('searches the indexed endpoint for claims', async () => {
+    respondWith(['claim-1']);
+
+    await fetchGraphClaimSearch({ search: 'caffeine', spaceIds: null }, 0);
+
+    expect(searchMock.mock.calls.at(-1)?.[0]).toMatchObject({
+      query: 'caffeine',
+      typeIds: [CLAIM_TYPE_ID],
+      limit: GRAPH_CLAIM_SEARCH_PAGE_SIZE,
+      offset: 0,
+    });
+  });
+
+  // The endpoint takes one `space_id`, so a wider set is left to the caller's own gates.
+  it('scopes to a single space only when the viewer has narrowed to one', async () => {
+    respondWith([]);
+
+    await fetchGraphClaimSearch({ search: 'x', spaceIds: [SPACE] }, 0);
+    expect(searchMock.mock.calls.at(-1)?.[0]?.spaceId).toBe(SPACE);
+
+    await fetchGraphClaimSearch({ search: 'x', spaceIds: [SPACE, 'other'] }, 0);
+    expect(searchMock.mock.calls.at(-1)?.[0]?.spaceId).toBeUndefined();
+  });
+
+  // Matches, not claims — so the ids go through the picker's projection and come back
+  // indistinguishable from the ranking walk's rows.
+  it('hydrates the matches through the picker’s projection', async () => {
+    respondWith(['claim-1', 'claim-2']);
+
+    const page = await fetchGraphClaimSearch({ search: 'x', spaceIds: null }, 0);
+
+    expect(hydrateMock.mock.calls.at(-1)?.[0]).toEqual(['claim-1', 'claim-2']);
+    expect(page.claims.map(claim => claim.id)).toEqual(['claim-1', 'claim-2']);
+  });
+
+  it('never returns a claim the caller is already showing', async () => {
+    respondWith(['claim-1', 'claim-2']);
+
+    const page = await fetchGraphClaimSearch({ search: 'x', spaceIds: null, excludeIds: ['claim-1'] }, 0);
+
+    expect(hydrateMock.mock.calls.at(-1)?.[0]).toEqual(['claim-2']);
+    expect(page.claims.map(claim => claim.id)).toEqual(['claim-2']);
+  });
+
+  // `/search` has no topic parameter, and the topics are already on the hydrated entities.
+  it('applies the topic filter after hydrating, since the endpoint has no topic parameter', async () => {
+    searchMock.mockImplementation(() =>
+      Effect.succeed({ results: [{ id: 'claim-1' }, { id: 'claim-2' }], total: 2, rawCount: 2, serverCount: 2 })
+    );
+    hydrateMock.mockImplementation(() => Promise.resolve([entity('claim-1', ['topic-a']), entity('claim-2')]));
+
+    const page = await fetchGraphClaimSearch({ search: 'x', spaceIds: null, topicIds: ['topic-a'] }, 0);
+
+    expect(page.claims.map(claim => claim.id)).toEqual(['claim-1']);
+  });
+
+  // Exhaustion is judged against how many matches were asked for, not how many claims came back:
+  // grouping and the caller's gates both shrink a page, and reading either as "the end" would stop
+  // the list early.
+  it('pages on the match count rather than the rows that survived', async () => {
+    respondWith(['claim-1'], 90);
+
+    const page = await fetchGraphClaimSearch({ search: 'x', spaceIds: null, excludeIds: ['claim-1'] }, 0);
+
+    expect(page.claims).toHaveLength(0);
+    expect(page.hasNextPage).toBe(true);
+    expect(page.nextOffset).toBe(GRAPH_CLAIM_SEARCH_PAGE_SIZE);
+  });
+
+  it('stops once the offset has covered the matches', async () => {
+    respondWith(['claim-1'], GRAPH_CLAIM_SEARCH_PAGE_SIZE);
+
+    const page = await fetchGraphClaimSearch({ search: 'x', spaceIds: null }, 0);
+
+    expect(page.hasNextPage).toBe(false);
+    expect(page.nextOffset).toBeNull();
+  });
+
+  it('does not hydrate when nothing matched', async () => {
+    respondWith([]);
+
+    const page = await fetchGraphClaimSearch({ search: 'x', spaceIds: null }, 0);
+
+    expect(hydrateMock).not.toHaveBeenCalled();
+    expect(page.claims).toEqual([]);
+  });
+});

--- a/apps/web/core/debates/graph-claim-search.ts
+++ b/apps/web/core/debates/graph-claim-search.ts
@@ -1,0 +1,93 @@
+import { Effect } from 'effect';
+
+import { CLAIM_TYPE_ID, TOPICS_PROPERTY_ID } from '~/core/claims/ontology';
+import { getResultsPage } from '~/core/io/queries';
+
+import { type ClaimPickerEntity, fetchClaimPickerEntities } from './claim-picker-page';
+import type { GraphClaimsPage } from './graph-claims';
+
+/**
+ * GEO-2704. The searching half of the graph tail.
+ *
+ * The ranked walk cannot answer a search. A substring filter over it measured at ten seconds
+ * against testnet, because it has to walk a very long way to find few rows — the same reason a
+ * narrow scope is slower than a wide one there.
+ *
+ * The REST `/search` endpoint is indexed and answers the same question in about half a second
+ * (508ms unscoped, 361ms scoped to one space), which is what Explore already uses. It returns
+ * matches rather than claims, so the ids are hydrated through the picker's projection afterwards —
+ * two round trips, still a fraction of the one.
+ */
+
+/** Matches asked for per page. The endpoint caps a page at 100 however large a `limit` is sent. */
+export const GRAPH_CLAIM_SEARCH_PAGE_SIZE = 25;
+
+export type GraphClaimSearchQuery = {
+  search: string;
+  /**
+   * Passed as the endpoint's single-space scope only when the viewer has narrowed to exactly one.
+   * It takes one `space_id`, so a wider set is left to the caller's own gates — which drop a claim
+   * whose home space it may not show anyway, and would have dropped it however it arrived.
+   */
+  spaceIds: string[] | null;
+  topicIds?: string[];
+  excludeIds?: string[];
+};
+
+/**
+ * Offsets rather than cursors, which is what the endpoint offers. `total` is the pre-grouping count
+ * of matches, so exhaustion is judged against how many were asked for rather than how many claims
+ * came back — grouping and the gates below both shrink a page, and reading either as "the end"
+ * would stop the list early.
+ */
+export async function fetchGraphClaimSearch(
+  query: GraphClaimSearchQuery,
+  offset: number,
+  signal?: AbortSignal
+): Promise<GraphClaimsPage & { nextOffset: number | null }> {
+  const page = await Effect.runPromise(
+    getResultsPage(
+      {
+        query: query.search,
+        typeIds: [CLAIM_TYPE_ID],
+        spaceId: query.spaceIds?.length === 1 ? query.spaceIds[0] : undefined,
+        limit: GRAPH_CLAIM_SEARCH_PAGE_SIZE,
+        offset,
+      },
+      signal
+    )
+  );
+
+  const excluded = new Set(query.excludeIds ?? []);
+  const ids = page.results.map(result => result.id).filter(id => !excluded.has(id));
+
+  // Hydrated through the picker's projection so these rows are indistinguishable from the walk's:
+  // same fields, same home-space resolution, same response-kind fallback.
+  const entities = ids.length > 0 ? await fetchClaimPickerEntities(ids, signal) : [];
+  const claims = query.topicIds?.length ? entities.filter(entity => carriesTopic(entity, query.topicIds!)) : entities;
+
+  const consumed = offset + GRAPH_CLAIM_SEARCH_PAGE_SIZE;
+  const hasNextPage = consumed < page.total;
+
+  return { claims, endCursor: null, hasNextPage, nextOffset: hasNextPage ? consumed : null };
+}
+
+/**
+ * The topic filter, applied here rather than in the request: `/search` has no topic parameter, and
+ * the topics are already on the entities fetched above.
+ */
+function carriesTopic(entity: ClaimPickerEntity, topicIds: string[]) {
+  return entity.relations.some(
+    relation =>
+      relation.type.id === TOPICS_PROPERTY_ID && relation.isDeleted !== true && topicIds.includes(relation.toEntity.id)
+  );
+}
+
+export const graphClaimSearchQueryKey = (query: GraphClaimSearchQuery) =>
+  [
+    'graph-claims',
+    'search',
+    query.search,
+    query.spaceIds?.join(',') ?? null,
+    (query.topicIds ?? []).join(','),
+  ] as const;

--- a/apps/web/core/debates/graph-claims.test.ts
+++ b/apps/web/core/debates/graph-claims.test.ts
@@ -6,7 +6,7 @@ import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
 import { CLAIM_IS_FACTUAL_PROPERTY_ID, CLAIM_TYPE_ID, TOPICS_PROPERTY_ID } from '~/core/claims/ontology';
 import { graphql } from '~/core/io/graphql-client';
 
-import { buildGraphClaimsFilter, fetchGraphClaims } from './graph-claims';
+import { GRAPH_CLAIMS_MAX_EXCLUSIONS, buildGraphClaimsFilter, fetchGraphClaims } from './graph-claims';
 
 vi.mock('~/core/io/graphql-client', () => ({
   graphql: vi.fn(),
@@ -15,7 +15,6 @@ vi.mock('~/core/io/graphql-client', () => ({
 const graphqlMock = graphql as unknown as Mock;
 
 const SPACE = '019fedae72b67ab2927adf044d57c566';
-const TOPIC = '806d52bc27e94c9193c057978b093351';
 
 function node(id: string, name: string | null, overrides: Record<string, unknown> = {}) {
   return {
@@ -40,7 +39,7 @@ describe('buildGraphClaimsFilter', () => {
   // predicate per row, so nothing is sent when there is nothing to narrow by.
   it('sends no filter when nothing is being narrowed', () => {
     expect(buildGraphClaimsFilter({ spaceIds: [SPACE] })).toBeNull();
-    expect(buildGraphClaimsFilter({ spaceIds: [SPACE], topicId: null, search: '' })).toBeNull();
+    expect(buildGraphClaimsFilter({ spaceIds: [SPACE], topicId: null, excludeIds: [] })).toBeNull();
   });
 
   it('narrows to a topic through the claim’s Topics relation', () => {
@@ -49,21 +48,37 @@ describe('buildGraphClaimsFilter', () => {
     });
   });
 
-  it('searches claim names case-insensitively', () => {
-    expect(buildGraphClaimsFilter({ spaceIds: null, search: 'Caffeine' })).toEqual({
-      name: { includesInsensitive: 'Caffeine' },
+  // Server-side, not after the fetch: geo-chat orders by presence and this orders by ranking score,
+  // so the overlap is scattered through the graph's order rather than sitting at the front of it.
+  it('excludes the claims geo-chat already showed', () => {
+    expect(buildGraphClaimsFilter({ spaceIds: null, excludeIds: ['claim-1', 'claim-2'] })).toEqual({
+      id: { notIn: ['claim-1', 'claim-2'] },
     });
   });
 
-  // Both at once is the case the old server query handled and the reason this is a builder rather
-  // than a ternary: a topic and a search have to intersect, not replace each other.
-  it('intersects a topic and a search rather than dropping one', () => {
-    expect(buildGraphClaimsFilter({ spaceIds: null, topicId: 'topic-1', search: 'caffeine' })).toEqual({
+  it('intersects a topic with the exclusions rather than dropping one', () => {
+    expect(buildGraphClaimsFilter({ spaceIds: null, topicId: 'topic-1', excludeIds: ['claim-1'] })).toEqual({
       and: [
         { relations: { some: { typeId: { is: TOPICS_PROPERTY_ID }, toEntityId: { is: 'topic-1' } } } },
-        { name: { includesInsensitive: 'caffeine' } },
+        { id: { notIn: ['claim-1'] } },
       ],
     });
+  });
+
+  // The ids ride in the query string, so the list they can grow to is bounded.
+  it('caps how many exclusions it will send', () => {
+    const ids = Array.from({ length: GRAPH_CLAIMS_MAX_EXCLUSIONS + 50 }, (_, index) => `claim-${index}`);
+
+    const filter = buildGraphClaimsFilter({ spaceIds: null, excludeIds: ids }) as {
+      id: { notIn: string[] };
+    };
+
+    expect(filter.id.notIn).toHaveLength(GRAPH_CLAIMS_MAX_EXCLUSIONS);
+    expect(filter.id.notIn[0]).toBe('claim-0');
+  });
+
+  it('treats an empty exclusion list as nothing to narrow by', () => {
+    expect(buildGraphClaimsFilter({ spaceIds: [SPACE], excludeIds: [] })).toBeNull();
   });
 });
 

--- a/apps/web/core/debates/graph-claims.test.ts
+++ b/apps/web/core/debates/graph-claims.test.ts
@@ -39,12 +39,12 @@ describe('buildGraphClaimsFilter', () => {
   // predicate per row, so nothing is sent when there is nothing to narrow by.
   it('sends no filter when nothing is being narrowed', () => {
     expect(buildGraphClaimsFilter({ spaceIds: [SPACE] })).toBeNull();
-    expect(buildGraphClaimsFilter({ spaceIds: [SPACE], topicId: null, excludeIds: [] })).toBeNull();
+    expect(buildGraphClaimsFilter({ spaceIds: [SPACE], topicIds: [], excludeIds: [] })).toBeNull();
   });
 
-  it('narrows to a topic through the claim’s Topics relation', () => {
-    expect(buildGraphClaimsFilter({ spaceIds: null, topicId: 'topic-1' })).toEqual({
-      relations: { some: { typeId: { is: TOPICS_PROPERTY_ID }, toEntityId: { is: 'topic-1' } } },
+  it('narrows to any of the picked topics through the claim’s Topics relation', () => {
+    expect(buildGraphClaimsFilter({ spaceIds: null, topicIds: ['topic-1'] })).toEqual({
+      relations: { some: { typeId: { is: TOPICS_PROPERTY_ID }, toEntityId: { in: ['topic-1'] } } },
     });
   });
 
@@ -57,9 +57,9 @@ describe('buildGraphClaimsFilter', () => {
   });
 
   it('intersects a topic with the exclusions rather than dropping one', () => {
-    expect(buildGraphClaimsFilter({ spaceIds: null, topicId: 'topic-1', excludeIds: ['claim-1'] })).toEqual({
+    expect(buildGraphClaimsFilter({ spaceIds: null, topicIds: ['topic-1'], excludeIds: ['claim-1'] })).toEqual({
       and: [
-        { relations: { some: { typeId: { is: TOPICS_PROPERTY_ID }, toEntityId: { is: 'topic-1' } } } },
+        { relations: { some: { typeId: { is: TOPICS_PROPERTY_ID }, toEntityId: { in: ['topic-1'] } } } },
         { id: { notIn: ['claim-1'] } },
       ],
     });
@@ -90,7 +90,7 @@ describe('fetchGraphClaims', () => {
   it('asks for claims in the given spaces, with the fields the pickers read', async () => {
     respondWith([]);
 
-    await fetchGraphClaims({ spaceIds: [SPACE], topicId: 'topic-1' }, null);
+    await fetchGraphClaims({ spaceIds: [SPACE], topicIds: ['topic-1'] }, null);
 
     expect(graphqlMock.mock.calls.at(-1)?.[0]?.variables).toMatchObject({
       claimTypeId: CLAIM_TYPE_ID,
@@ -98,7 +98,7 @@ describe('fetchGraphClaims', () => {
       after: null,
       propertyIds: [SystemIds.NAME_PROPERTY, CLAIM_IS_FACTUAL_PROPERTY_ID],
       topicsPropertyId: TOPICS_PROPERTY_ID,
-      filter: { relations: { some: { typeId: { is: TOPICS_PROPERTY_ID }, toEntityId: { is: 'topic-1' } } } },
+      filter: { relations: { some: { typeId: { is: TOPICS_PROPERTY_ID }, toEntityId: { in: ['topic-1'] } } } },
     });
   });
 

--- a/apps/web/core/debates/graph-claims.test.ts
+++ b/apps/web/core/debates/graph-claims.test.ts
@@ -1,0 +1,151 @@
+import { SystemIds } from '@geoprotocol/geo-sdk/lite';
+
+import * as Effect from 'effect/Effect';
+import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { CLAIM_IS_FACTUAL_PROPERTY_ID, CLAIM_TYPE_ID, TOPICS_PROPERTY_ID } from '~/core/claims/ontology';
+import { graphql } from '~/core/io/graphql-client';
+
+import { buildGraphClaimsFilter, fetchGraphClaims } from './graph-claims';
+
+vi.mock('~/core/io/graphql-client', () => ({
+  graphql: vi.fn(),
+}));
+
+const graphqlMock = graphql as unknown as Mock;
+
+const SPACE = '019fedae72b67ab2927adf044d57c566';
+const TOPIC = '806d52bc27e94c9193c057978b093351';
+
+function node(id: string, name: string | null, overrides: Record<string, unknown> = {}) {
+  return {
+    id,
+    name,
+    description: null,
+    spaceIds: [SPACE],
+    valuesList: [],
+    relationsList: [],
+    ...overrides,
+  };
+}
+
+function respondWith(nodes: unknown[], pageInfo = { hasNextPage: false, endCursor: 'cursor-1' }) {
+  graphqlMock.mockImplementation(({ decoder }) =>
+    Effect.succeed(decoder({ entitiesRankedForFeedConnection: { pageInfo, nodes } }))
+  );
+}
+
+describe('buildGraphClaimsFilter', () => {
+  // The ranked feed's fast path is an index walk; a filter that matches everything still costs a
+  // predicate per row, so nothing is sent when there is nothing to narrow by.
+  it('sends no filter when nothing is being narrowed', () => {
+    expect(buildGraphClaimsFilter({ spaceIds: [SPACE] })).toBeNull();
+    expect(buildGraphClaimsFilter({ spaceIds: [SPACE], topicId: null, search: '' })).toBeNull();
+  });
+
+  it('narrows to a topic through the claim’s Topics relation', () => {
+    expect(buildGraphClaimsFilter({ spaceIds: null, topicId: 'topic-1' })).toEqual({
+      relations: { some: { typeId: { is: TOPICS_PROPERTY_ID }, toEntityId: { is: 'topic-1' } } },
+    });
+  });
+
+  it('searches claim names case-insensitively', () => {
+    expect(buildGraphClaimsFilter({ spaceIds: null, search: 'Caffeine' })).toEqual({
+      name: { includesInsensitive: 'Caffeine' },
+    });
+  });
+
+  // Both at once is the case the old server query handled and the reason this is a builder rather
+  // than a ternary: a topic and a search have to intersect, not replace each other.
+  it('intersects a topic and a search rather than dropping one', () => {
+    expect(buildGraphClaimsFilter({ spaceIds: null, topicId: 'topic-1', search: 'caffeine' })).toEqual({
+      and: [
+        { relations: { some: { typeId: { is: TOPICS_PROPERTY_ID }, toEntityId: { is: 'topic-1' } } } },
+        { name: { includesInsensitive: 'caffeine' } },
+      ],
+    });
+  });
+});
+
+describe('fetchGraphClaims', () => {
+  beforeEach(() => {
+    graphqlMock.mockReset();
+  });
+
+  it('asks for claims in the given spaces, with the fields the pickers read', async () => {
+    respondWith([]);
+
+    await fetchGraphClaims({ spaceIds: [SPACE], topicId: 'topic-1' }, null);
+
+    expect(graphqlMock.mock.calls.at(-1)?.[0]?.variables).toMatchObject({
+      claimTypeId: CLAIM_TYPE_ID,
+      spaceIds: [SPACE],
+      after: null,
+      propertyIds: [SystemIds.NAME_PROPERTY, CLAIM_IS_FACTUAL_PROPERTY_ID],
+      topicsPropertyId: TOPICS_PROPERTY_ID,
+      filter: { relations: { some: { typeId: { is: TOPICS_PROPERTY_ID }, toEntityId: { is: 'topic-1' } } } },
+    });
+  });
+
+  it('passes the cursor through so the list pages', async () => {
+    respondWith([], { hasNextPage: true, endCursor: 'cursor-2' });
+
+    const page = await fetchGraphClaims({ spaceIds: null }, 'cursor-1');
+
+    expect(graphqlMock.mock.calls.at(-1)?.[0]?.variables?.after).toBe('cursor-1');
+    expect(page).toMatchObject({ hasNextPage: true, endCursor: 'cursor-2' });
+  });
+
+  // The picker's own projection, so `claimHomeSpaceId` and `claimResponseKind` work on these rows
+  // unchanged — the whole point of matching that shape rather than inventing another.
+  it('decodes into the picker’s claim projection', async () => {
+    respondWith([
+      node('claim-1', 'Caffeine should be delayed after waking', {
+        description: 'A claim',
+        spaceIds: [SPACE, 'other-space'],
+        valuesList: [
+          { spaceId: SPACE, propertyId: SystemIds.NAME_PROPERTY, text: 'Caffeine should be delayed', boolean: null },
+          { spaceId: SPACE, propertyId: CLAIM_IS_FACTUAL_PROPERTY_ID, text: null, boolean: true },
+        ],
+        relationsList: [{ toEntity: { id: 'topic-1', name: 'Morning routine' } }],
+      }),
+    ]);
+
+    const page = await fetchGraphClaims({ spaceIds: [SPACE] }, null);
+
+    expect(page.claims).toEqual([
+      {
+        id: 'claim-1',
+        name: 'Caffeine should be delayed after waking',
+        description: 'A claim',
+        spaces: [SPACE, 'other-space'],
+        values: [
+          { property: { id: SystemIds.NAME_PROPERTY }, spaceId: SPACE, value: 'Caffeine should be delayed' },
+          // Booleans land as '1' / '0', matching how `Entity` decodes them — `claimResponseKind`
+          // reads this one through `getChecked`.
+          { property: { id: CLAIM_IS_FACTUAL_PROPERTY_ID }, spaceId: SPACE, value: '1' },
+        ],
+        relations: [{ type: { id: TOPICS_PROPERTY_ID }, toEntity: { id: 'topic-1', name: 'Morning routine' } }],
+      },
+    ]);
+  });
+
+  it('survives a page with nulls in it', async () => {
+    respondWith([null, node('claim-1', 'Fine', { valuesList: null, relationsList: [{ toEntity: null }, null] })]);
+
+    const page = await fetchGraphClaims({ spaceIds: null }, null);
+
+    expect(page.claims).toHaveLength(1);
+    expect(page.claims[0]).toMatchObject({ id: 'claim-1', values: [], relations: [] });
+  });
+
+  it('reads an absent connection as an empty last page', async () => {
+    graphqlMock.mockImplementation(({ decoder }) => Effect.succeed(decoder({ entitiesRankedForFeedConnection: null })));
+
+    expect(await fetchGraphClaims({ spaceIds: null }, null)).toEqual({
+      claims: [],
+      endCursor: null,
+      hasNextPage: false,
+    });
+  });
+});

--- a/apps/web/core/debates/graph-claims.ts
+++ b/apps/web/core/debates/graph-claims.ts
@@ -1,0 +1,224 @@
+import { SystemIds } from '@geoprotocol/geo-sdk/lite';
+import type { TypedDocumentNode } from '@graphql-typed-document-node/core';
+
+import { Effect } from 'effect';
+import { parse } from 'graphql';
+
+import { CLAIM_IS_FACTUAL_PROPERTY_ID, CLAIM_TYPE_ID, TOPICS_PROPERTY_ID } from '~/core/claims/ontology';
+import { graphql } from '~/core/io/graphql-client';
+
+import type { ClaimPickerEntity } from './claim-picker-page';
+
+/**
+ * GEO-2704. Claim discovery, straight from the knowledge graph.
+ *
+ * Both pickers used to get their lists from geo-chat's `/matchmaking/claims`, for a reason that was
+ * true when it was written: a KG scan over every Claim entity in a space 504s, and geo-chat had
+ * them indexed. What that traded away was coverage — a claim geo-chat has no row for cannot be
+ * listed, however plainly it exists on Geo — and it left the two surfaces disagreeing, since
+ * Featured reads the graph and everything else read geo-chat.
+ *
+ * `entities_ranked_for_feed` is what makes the graph answer this now. It is the same function
+ * behind Explore's "Best" sort: an index-ordered walk that stops once `first` rows are found,
+ * rather than the scan that timed out. Space and type scoping are its own arguments, and a topic or
+ * a name search rides along in `filter`.
+ *
+ * geo-chat is still asked about these claims — for sides, readiness and presence, which are its
+ * data and nobody else's. This module answers only *which claims exist*.
+ */
+const GRAPH_CLAIMS_SOURCE = /* GraphQL */ `
+  query DebateGraphClaims(
+    $first: Int!
+    $after: Cursor
+    $claimTypeId: UUID!
+    $spaceIds: [UUID!]
+    $filter: EntityFilter
+    $propertyIds: [UUID!]!
+    $topicsPropertyId: UUID!
+  ) {
+    entitiesRankedForFeedConnection(
+      first: $first
+      after: $after
+      spaceIds: $spaceIds
+      typeIds: [$claimTypeId]
+      filter: $filter
+    ) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      nodes {
+        id
+        name
+        description
+        spaceIds
+        valuesList(first: 100, filter: { propertyId: { in: $propertyIds } }) {
+          spaceId
+          propertyId
+          text
+          boolean
+        }
+        relationsList(first: 100, filter: { typeId: { is: $topicsPropertyId } }) {
+          toEntity {
+            id
+            name
+          }
+        }
+      }
+    }
+  }
+`;
+
+type GraphClaimsQueryResult = {
+  entitiesRankedForFeedConnection: {
+    pageInfo: { hasNextPage: boolean; endCursor: string | null } | null;
+    nodes: Array<{
+      id: string;
+      name: string | null;
+      description: string | null;
+      spaceIds: string[] | null;
+      valuesList: Array<{
+        spaceId: string;
+        propertyId: string;
+        text: string | null;
+        boolean: boolean | null;
+      } | null> | null;
+      relationsList: Array<{ toEntity: { id: string; name: string | null } | null } | null> | null;
+    } | null> | null;
+  } | null;
+};
+
+type EntityFilter = Record<string, unknown>;
+
+type GraphClaimsVariables = {
+  first: number;
+  after: string | null;
+  claimTypeId: string;
+  spaceIds: string[] | null;
+  filter: EntityFilter | null;
+  propertyIds: string[];
+  topicsPropertyId: string;
+};
+
+const graphClaimsDocument = parse(GRAPH_CLAIMS_SOURCE) as TypedDocumentNode<
+  GraphClaimsQueryResult,
+  GraphClaimsVariables
+>;
+
+/**
+ * What the pickers ask for at a time.
+ *
+ * Deliberately larger than geo-chat's page: a page here costs one indexed walk, and both surfaces
+ * then drop rows that fail their space gates — so a small page can arrive empty and spend a round
+ * trip saying nothing.
+ */
+export const GRAPH_CLAIMS_PAGE_SIZE = 50;
+
+export type GraphClaimsQuery = {
+  /**
+   * The spaces the viewer may be shown claims from. `null` means unnarrowed, which is not the same
+   * as `[]` — an empty list is a scope that admits nothing, and sending no ids would fetch the
+   * whole corpus instead. Callers with an empty eligible set should not ask at all.
+   */
+  spaceIds: string[] | null;
+  topicId?: string | null;
+  search?: string | null;
+};
+
+export type GraphClaimsPage = {
+  /** The picker's own projection, so `claimHomeSpaceId` and `claimResponseKind` work unchanged. */
+  claims: ClaimPickerEntity[];
+  endCursor: string | null;
+  hasNextPage: boolean;
+};
+
+/**
+ * `entities_ranked_for_feed` already excludes system entities, block types and unnamed rows, so
+ * this carries only what the *caller* is narrowing by. Left `null` when there is nothing to add:
+ * the function's fast path is an index walk, and a filter that matches everything still costs a
+ * predicate per row.
+ */
+export function buildGraphClaimsFilter(query: GraphClaimsQuery): EntityFilter | null {
+  const clauses: EntityFilter[] = [];
+
+  if (query.topicId) {
+    clauses.push({
+      relations: { some: { typeId: { is: TOPICS_PROPERTY_ID }, toEntityId: { is: query.topicId } } },
+    });
+  }
+
+  // Substring rather than the fuzzy `/search` endpoint: that one ranks by its own relevance and
+  // returns entities, which would fight the ranking this list is ordered by. A claim is a sentence,
+  // and the box above it is filtering a list rather than searching the graph.
+  if (query.search) {
+    clauses.push({ name: { includesInsensitive: query.search } });
+  }
+
+  if (clauses.length === 0) return null;
+  return clauses.length === 1 ? clauses[0]! : { and: clauses };
+}
+
+function decodeGraphClaimsPage(data: GraphClaimsQueryResult): GraphClaimsPage {
+  const connection = data.entitiesRankedForFeedConnection;
+  const claims: ClaimPickerEntity[] = [];
+
+  for (const node of connection?.nodes ?? []) {
+    if (!node) continue;
+    claims.push({
+      id: node.id,
+      name: node.name,
+      description: node.description,
+      spaces: node.spaceIds ?? [],
+      values: (node.valuesList ?? []).flatMap(value => {
+        if (!value) return [];
+        // Match `Entity`'s decoding: booleans land as '1' / '0', text as itself.
+        const decoded = value.boolean !== null ? (value.boolean ? '1' : '0') : value.text;
+        if (decoded === null) return [];
+        return [{ property: { id: value.propertyId }, spaceId: value.spaceId, value: decoded }];
+      }),
+      relations: (node.relationsList ?? []).flatMap(relation =>
+        relation?.toEntity
+          ? [{ type: { id: TOPICS_PROPERTY_ID }, toEntity: { id: relation.toEntity.id, name: relation.toEntity.name } }]
+          : []
+      ),
+    });
+  }
+
+  return {
+    claims,
+    endCursor: connection?.pageInfo?.endCursor ?? null,
+    hasNextPage: connection?.pageInfo?.hasNextPage ?? false,
+  };
+}
+
+export function fetchGraphClaims(
+  query: GraphClaimsQuery,
+  after: string | null,
+  signal?: AbortSignal
+): Promise<GraphClaimsPage> {
+  return Effect.runPromise(
+    graphql({
+      query: graphClaimsDocument,
+      decoder: decodeGraphClaimsPage,
+      variables: {
+        first: GRAPH_CLAIMS_PAGE_SIZE,
+        after,
+        claimTypeId: CLAIM_TYPE_ID,
+        spaceIds: query.spaceIds,
+        filter: buildGraphClaimsFilter(query),
+        propertyIds: [SystemIds.NAME_PROPERTY, CLAIM_IS_FACTUAL_PROPERTY_ID],
+        topicsPropertyId: TOPICS_PROPERTY_ID,
+      },
+      signal,
+    })
+  );
+}
+
+/**
+ * Deliberately not under `'debates'`, for the same reason as the claim picker's and the featured
+ * list's keys: that root is what the gateway reconciles and refetches on every (re)connect, and
+ * these rows come from the knowledge graph rather than geo-chat, so a socket event says nothing
+ * about them.
+ */
+export const graphClaimsQueryKey = (query: GraphClaimsQuery) =>
+  ['graph-claims', query.spaceIds?.join(',') ?? null, query.topicId ?? null, query.search ?? null] as const;

--- a/apps/web/core/debates/graph-claims.ts
+++ b/apps/web/core/debates/graph-claims.ts
@@ -10,21 +10,26 @@ import { graphql } from '~/core/io/graphql-client';
 import type { ClaimPickerEntity } from './claim-picker-page';
 
 /**
- * GEO-2704. Claim discovery, straight from the knowledge graph.
+ * GEO-2704. The tail of a claim list, from the knowledge graph.
  *
- * Both pickers used to get their lists from geo-chat's `/matchmaking/claims`, for a reason that was
- * true when it was written: a KG scan over every Claim entity in a space 504s, and geo-chat had
- * them indexed. What that traded away was coverage — a claim geo-chat has no row for cannot be
- * listed, however plainly it exists on Geo — and it left the two surfaces disagreeing, since
- * Featured reads the graph and everything else read geo-chat.
+ * Both pickers list claims from geo-chat's `/matchmaking/claims`, for a reason that was true when
+ * it was written: a KG scan over every Claim entity in a space 504s, and geo-chat had them indexed.
+ * What that traded away was coverage — a claim geo-chat has no row for cannot be listed, however
+ * plainly it exists on Geo.
  *
- * `entities_ranked_for_feed` is what makes the graph answer this now. It is the same function
- * behind Explore's "Best" sort: an index-ordered walk that stops once `first` rows are found,
- * rather than the scan that timed out. Space and type scoping are its own arguments, and a topic or
- * a name search rides along in `filter`.
+ * This does not replace that list. It continues it: once geo-chat has no next page, the graph is
+ * asked for claims matching the same filters, minus the ones already on screen. So the list is
+ * geo-chat's for as long as geo-chat has anything to say — its ordering, its readiness, its
+ * session exclusions all intact — and the graph only supplies what geo-chat never knew about.
  *
- * geo-chat is still asked about these claims — for sides, readiness and presence, which are its
- * data and nobody else's. This module answers only *which claims exist*.
+ * Appending rather than merging is deliberate. The two are ordered by different things (presence
+ * and positions there, ranking score here), and interleaving them would produce a sequence that
+ * answers to neither. A seam at the end of geo-chat's rows is easier to reason about than a
+ * shuffle throughout.
+ *
+ * `entities_ranked_for_feed` is what lets the graph answer at all: the function behind Explore's
+ * "Best" sort, an index-ordered walk that stops once the page is full rather than the scan that
+ * timed out.
  */
 const GRAPH_CLAIMS_SOURCE = /* GraphQL */ `
   query DebateGraphClaims(
@@ -106,13 +111,26 @@ const graphClaimsDocument = parse(GRAPH_CLAIMS_SOURCE) as TypedDocumentNode<
 >;
 
 /**
- * What the pickers ask for at a time.
+ * What the tail asks for at a time.
  *
- * Deliberately larger than geo-chat's page: a page here costs one indexed walk, and both surfaces
- * then drop rows that fail their space gates — so a small page can arrive empty and spend a round
- * trip saying nothing.
+ * Larger than geo-chat's page: a page here costs one indexed walk, and callers then drop rows that
+ * fail their space gates — so a small page can arrive empty and spend a round trip saying nothing.
  */
 export const GRAPH_CLAIMS_PAGE_SIZE = 50;
+
+/**
+ * How many already-shown claims are excluded server-side.
+ *
+ * Exclusion belongs in the query rather than after it: geo-chat orders by presence and this orders
+ * by ranking score, so the overlap is scattered through the graph's order rather than sitting at
+ * the front of it. Filtering a fetched page instead would leave pages that arrive mostly empty and
+ * no way to tell that from the end of the list.
+ *
+ * Bounded because the ids ride in the query string. Beyond this the caller filters what it gets,
+ * accepting the short pages — a list this long has already given the viewer far more than they
+ * are going to read.
+ */
+export const GRAPH_CLAIMS_MAX_EXCLUSIONS = 1_000;
 
 export type GraphClaimsQuery = {
   /**
@@ -122,7 +140,15 @@ export type GraphClaimsQuery = {
    */
   spaceIds: string[] | null;
   topicId?: string | null;
-  search?: string | null;
+  /**
+   * Claims already on screen from geo-chat, so the tail never repeats one.
+   *
+   * Note there is no `search` here. A substring filter over the ranking walk measured at ten
+   * seconds — it has to walk a very long way to find few rows — so a searching viewer gets
+   * geo-chat's answer alone for now. The indexed REST `/search` endpoint is the way in, and it is
+   * a separate fetch path rather than a parameter on this one.
+   */
+  excludeIds?: string[];
 };
 
 export type GraphClaimsPage = {
@@ -147,11 +173,9 @@ export function buildGraphClaimsFilter(query: GraphClaimsQuery): EntityFilter | 
     });
   }
 
-  // Substring rather than the fuzzy `/search` endpoint: that one ranks by its own relevance and
-  // returns entities, which would fight the ranking this list is ordered by. A claim is a sentence,
-  // and the box above it is filtering a list rather than searching the graph.
-  if (query.search) {
-    clauses.push({ name: { includesInsensitive: query.search } });
+  const excluded = (query.excludeIds ?? []).slice(0, GRAPH_CLAIMS_MAX_EXCLUSIONS);
+  if (excluded.length > 0) {
+    clauses.push({ id: { notIn: excluded } });
   }
 
   if (clauses.length === 0) return null;
@@ -219,6 +243,11 @@ export function fetchGraphClaims(
  * list's keys: that root is what the gateway reconciles and refetches on every (re)connect, and
  * these rows come from the knowledge graph rather than geo-chat, so a socket event says nothing
  * about them.
+ *
+ * The exclusions are deliberately *not* in the key. They grow as geo-chat's own list pages, and
+ * keying on them would throw the tail away and refetch it every time the head got longer — while
+ * the answer barely changes, since anything newly excluded was already filtered out of what the
+ * caller is showing.
  */
 export const graphClaimsQueryKey = (query: GraphClaimsQuery) =>
-  ['graph-claims', query.spaceIds?.join(',') ?? null, query.topicId ?? null, query.search ?? null] as const;
+  ['graph-claims', query.spaceIds?.join(',') ?? null, query.topicId ?? null] as const;

--- a/apps/web/core/debates/graph-claims.ts
+++ b/apps/web/core/debates/graph-claims.ts
@@ -139,7 +139,8 @@ export type GraphClaimsQuery = {
    * whole corpus instead. Callers with an empty eligible set should not ask at all.
    */
   spaceIds: string[] | null;
-  topicId?: string | null;
+  /** Any of them, matching how the menus narrow — a claim needs one of the picked topics, not all. */
+  topicIds?: string[];
   /**
    * Claims already on screen from geo-chat, so the tail never repeats one.
    *
@@ -167,9 +168,9 @@ export type GraphClaimsPage = {
 export function buildGraphClaimsFilter(query: GraphClaimsQuery): EntityFilter | null {
   const clauses: EntityFilter[] = [];
 
-  if (query.topicId) {
+  if (query.topicIds?.length) {
     clauses.push({
-      relations: { some: { typeId: { is: TOPICS_PROPERTY_ID }, toEntityId: { is: query.topicId } } },
+      relations: { some: { typeId: { is: TOPICS_PROPERTY_ID }, toEntityId: { in: query.topicIds } } },
     });
   }
 
@@ -250,4 +251,4 @@ export function fetchGraphClaims(
  * caller is showing.
  */
 export const graphClaimsQueryKey = (query: GraphClaimsQuery) =>
-  ['graph-claims', query.spaceIds?.join(',') ?? null, query.topicId ?? null] as const;
+  ['graph-claims', query.spaceIds?.join(',') ?? null, (query.topicIds ?? []).join(',')] as const;

--- a/apps/web/core/debates/matchmaking/claims-tab.test.tsx
+++ b/apps/web/core/debates/matchmaking/claims-tab.test.tsx
@@ -210,9 +210,9 @@ vi.mock('../featured-claims', async importOriginal => ({
 // GEO-2704. The graph tail that continues geo-chat's list once it runs out. Records what it was
 // enabled with and asked for, so the suites can pin when it fires and under which filters.
 vi.mock('../use-graph-claim-tail', () => ({
-  useGraphClaimTail: ({ query, enabled }: { query: unknown; enabled: boolean }) => {
+  useGraphClaimTail: ({ query, search, enabled }: { query: unknown; search?: string | null; enabled: boolean }) => {
     mocks.tailEnabledWith.push(enabled);
-    if (enabled) mocks.tailQueries.push(query);
+    if (enabled) mocks.tailQueries.push({ ...(query as object), search: search ?? null });
     return {
       claims: enabled ? mocks.tailClaims : [],
       topicsByClaimId: new Map(enabled ? mocks.tailTopics.map(entry => [entry.claimEntityId, entry.topics]) : []),
@@ -1314,15 +1314,16 @@ describe('ClaimsTab -- the graph tail', () => {
     expect(mocks.tailEnabledWith.at(-1)).toBe(false);
   });
 
-  // A substring filter over the ranking walk measured at ten seconds, so a searching viewer gets
-  // geo-chat's answer alone until the indexed endpoint is wired in.
-  it('stays off while the viewer is searching', async () => {
+  // A search is answered too, but not by the ranking walk — a substring filter over that measured
+  // at ten seconds. The hook takes the term and picks the indexed endpoint instead.
+  it('hands a search term to the tail rather than switching it off', async () => {
     render(<ClaimsTab />);
     await showAllClaims();
 
     fireEvent.change(screen.getByLabelText('Search claims'), { target: { value: 'chips' } });
 
-    await waitFor(() => expect(mocks.tailEnabledWith.at(-1)).toBe(false));
+    await waitFor(() => expect((mocks.tailQueries.at(-1) as { search: string | null }).search).toBe('chips'));
+    expect(mocks.tailEnabledWith.at(-1)).toBe(true);
   });
 
   // The same narrowing the index query gets, so the two halves answer the same question — and the

--- a/apps/web/core/debates/matchmaking/claims-tab.test.tsx
+++ b/apps/web/core/debates/matchmaking/claims-tab.test.tsx
@@ -21,6 +21,13 @@ const mocks = vi.hoisted(() => ({
   featuredLoading: false,
   debateClaimGroups: [] as Array<Array<{ spaceId: string; claimIds: string[] }>>,
   claimEntityLookups: [] as string[][],
+  tailClaims: [] as MatchmakingClaim[],
+  tailTopics: [] as Array<{ claimEntityId: string; topics: Array<{ id: string; name: string | null }> }>,
+  tailLoading: false,
+  tailHasNextPage: false,
+  tailFetchNextPage: vi.fn(),
+  tailEnabledWith: [] as boolean[],
+  tailQueries: [] as unknown[],
   claimEntities: [] as Array<{
     id: string;
     name: string | null;
@@ -200,6 +207,24 @@ vi.mock('../featured-claims', async importOriginal => ({
 }));
 
 // Featured reads topics and the "Is factual" value through the picker's narrow projection.
+// GEO-2704. The graph tail that continues geo-chat's list once it runs out. Records what it was
+// enabled with and asked for, so the suites can pin when it fires and under which filters.
+vi.mock('../use-graph-claim-tail', () => ({
+  useGraphClaimTail: ({ query, enabled }: { query: unknown; enabled: boolean }) => {
+    mocks.tailEnabledWith.push(enabled);
+    if (enabled) mocks.tailQueries.push(query);
+    return {
+      claims: enabled ? mocks.tailClaims : [],
+      topicsByClaimId: new Map(enabled ? mocks.tailTopics.map(entry => [entry.claimEntityId, entry.topics]) : []),
+      isLoading: enabled && mocks.tailLoading,
+      isFetchingNextPage: false,
+      hasNextPage: enabled && mocks.tailHasNextPage,
+      fetchNextPage: mocks.tailFetchNextPage,
+      error: null,
+    };
+  },
+}));
+
 vi.mock('../claim-picker-page', () => ({
   useClaimEntitiesByIds: (ids: string[]) => {
     mocks.claimEntityLookups.push(ids);
@@ -312,6 +337,13 @@ beforeEach(() => {
   mocks.featuredLoading = false;
   mocks.debateClaimGroups = [];
   mocks.claimEntityLookups = [];
+  mocks.tailClaims = [];
+  mocks.tailTopics = [];
+  mocks.tailLoading = false;
+  mocks.tailHasNextPage = false;
+  mocks.tailFetchNextPage.mockReset();
+  mocks.tailEnabledWith = [];
+  mocks.tailQueries = [];
   mocks.claimEntities = [];
   mocks.pageSize = null;
   mocks.lastEnabledData = undefined;
@@ -1227,5 +1259,123 @@ describe('ClaimsTab -- Featured', () => {
 
     await waitFor(() => expect(screen.getByText('Nuclear power is the cheapest clean energy')).toBeInTheDocument());
     expect(mocks.lastEnabled).toBe(false);
+  });
+});
+
+// GEO-2704. geo-chat can only list a claim it has a row for, and it has rows for far fewer claims
+// than exist — so the index running out of pages is not the corpus running out of claims. The graph
+// continues the list from there.
+describe('ClaimsTab -- the graph tail', () => {
+  const TAILED = '019fedb9-7db8-7fa5-8b88-9de4cf60bb75';
+
+  function tailClaim(entityId = TAILED, name = 'A claim geo-chat never indexed', spaceId = SPACE_ID) {
+    return {
+      claim: { id: entityId, space_id: spaceId, claim_entity_id: entityId, claim: name, description: null },
+      topics: [],
+      response_kind: 'stance' as const,
+      viewer_response: null,
+      viewer_position: null,
+      viewer_debate_ready: false,
+      readiness_disabled_reason: null,
+      positions: [],
+      score: 0,
+      active_debate: false,
+    };
+  }
+
+  it('appends the tail after geo-chat’s rows rather than merging into them', async () => {
+    mocks.tailClaims = [tailClaim()];
+    render(<ClaimsTab />);
+    await showAllClaims();
+
+    const tailed = screen.getByText('A claim geo-chat never indexed');
+    // geo-chat's ordering is untouched: its rows keep their places and the tail follows.
+    const indexed = screen.getByText('Chips are better than fries');
+    expect(indexed.compareDocumentPosition(tailed) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  // The whole point of the ordering: while geo-chat still has pages, its list is the list.
+  it('waits for geo-chat to run out before asking the graph', async () => {
+    mocks.hasNextPage = true;
+    render(<ClaimsTab />);
+    await showAllClaims();
+
+    expect(mocks.tailEnabledWith.at(-1)).toBe(false);
+  });
+
+  // `mine` and `debate_now` are questions about the viewer's own state, which the graph can't answer.
+  it('stays off the viewer-state filters', async () => {
+    render(<ClaimsTab />);
+    await showAllClaims();
+    expect(mocks.tailEnabledWith.at(-1)).toBe(true);
+
+    chooseFilter('All claims', 'My positions');
+
+    expect(mocks.tailEnabledWith.at(-1)).toBe(false);
+  });
+
+  // A substring filter over the ranking walk measured at ten seconds, so a searching viewer gets
+  // geo-chat's answer alone until the indexed endpoint is wired in.
+  it('stays off while the viewer is searching', async () => {
+    render(<ClaimsTab />);
+    await showAllClaims();
+
+    fireEvent.change(screen.getByLabelText('Search claims'), { target: { value: 'chips' } });
+
+    await waitFor(() => expect(mocks.tailEnabledWith.at(-1)).toBe(false));
+  });
+
+  // The same narrowing the index query gets, so the two halves answer the same question — and the
+  // rows already on screen are excluded, or the tail would repeat them.
+  it('asks under the same filters, excluding what is already shown', async () => {
+    render(<ClaimsTab />);
+    await showAllClaims();
+
+    const asked = mocks.tailQueries.at(-1) as { excludeIds: string[]; topicIds: string[] };
+    expect(asked.excludeIds).toContain(MINE);
+    expect(asked.excludeIds).toContain(THEIRS);
+    expect(asked.topicIds).toEqual([]);
+  });
+
+  // The reported bug. geo-chat's facet describes the claims it has rows for, so a topic carried only
+  // by claims it never indexed was missing from the menu — and unreachable, since you cannot filter
+  // to an option that isn't there.
+  it('offers a topic carried only by a tailed claim', async () => {
+    mocks.tailClaims = [tailClaim()];
+    mocks.tailTopics = [{ claimEntityId: TAILED, topics: [{ id: 'topic-morning', name: 'Morning routine' }] }];
+    render(<ClaimsTab />);
+    await showAllClaims();
+
+    fireEvent.click(screen.getByRole('button', { name: /Any topic/ }));
+
+    expect(screen.getByRole('button', { name: /Morning routine/ })).toBeInTheDocument();
+  });
+
+  // Both halves count towards one option rather than the tail's shadowing the server's.
+  it('adds the tail’s count to the server facet for a shared topic', async () => {
+    // One indexed claim carries the topic, so geo-chat's facet counts it once.
+    mocks.claims = [
+      claim(MINE, 'Chips are better than fries', true, false, SPACE_ID, [{ id: 'topic-shared', name: 'Sleep' }]),
+    ];
+    mocks.tailClaims = [tailClaim()];
+    mocks.tailTopics = [{ claimEntityId: TAILED, topics: [{ id: 'topic-shared', name: 'Sleep' }] }];
+    render(<ClaimsTab />);
+    await showAllClaims();
+
+    fireEvent.click(screen.getByRole('button', { name: /Any topic/ }));
+
+    expect(screen.getByRole('button', { name: /Sleep\s*2/ })).toBeInTheDocument();
+  });
+
+  // One sentinel, two sources, in order: geo-chat's pages first, then the tail's.
+  it('pages the tail once geo-chat has no pages left', async () => {
+    mocks.tailHasNextPage = true;
+    render(<ClaimsTab />);
+    await showAllClaims();
+
+    act(() => mocks.trigger?.());
+
+    expect(mocks.fetchNextPage).not.toHaveBeenCalled();
+    expect(mocks.tailFetchNextPage).toHaveBeenCalled();
   });
 });

--- a/apps/web/core/debates/matchmaking/claims-tab.tsx
+++ b/apps/web/core/debates/matchmaking/claims-tab.tsx
@@ -170,17 +170,15 @@ export function ClaimsTab() {
    * Once it does run out, the graph is asked for the rest under the same filters, and those rows
    * are appended.
    *
-   * Only under All claims, and only without a search term:
+   * Only under All claims: `mine` and `debate_now` are questions about the viewer's own state,
+   * which the graph cannot answer at all, and Featured is already graph-backed.
    *
-   * - `mine` and `debate_now` are questions about the viewer's own state, which the graph cannot
-   *   answer at all. Featured is already graph-backed.
-   * - a substring search over the ranking walk measured at ten seconds, so a searching viewer gets
-   *   geo-chat's answer alone until the indexed REST endpoint is wired in.
+   * A search is answered too, through the indexed endpoint rather than the ranking walk — see
+   * `useGraphClaimTailSources`, which picks the source.
    */
   const tailEnabled =
     !featured &&
     filter === 'all' &&
-    !debouncedSearch &&
     !spacesPending &&
     !claimsQuery.unusable &&
     !claimsQuery.isLoading &&
@@ -213,7 +211,12 @@ export function ClaimsTab() {
     [spaceShowsClaims]
   );
 
-  const tail = useGraphClaimTail({ query: tailQuery, enabled: tailEnabled, homeSpaceOf: tailHomeSpaceOf });
+  const tail = useGraphClaimTail({
+    query: tailQuery,
+    search: debouncedSearch || null,
+    enabled: tailEnabled,
+    homeSpaceOf: tailHomeSpaceOf,
+  });
 
   // GEO-2683. Featured is a curator's tag in the knowledge graph, and geo-chat doesn't index it —
   // so unlike the position filter this can't be a query param, and unlike the old client-side topic

--- a/apps/web/core/debates/matchmaking/claims-tab.tsx
+++ b/apps/web/core/debates/matchmaking/claims-tab.tsx
@@ -22,7 +22,8 @@ import type {
   MatchmakingClaimsQuery,
   MatchmakingTopic,
 } from '../api';
-import { useClaimEntitiesByIds } from '../claim-picker-page';
+import { claimHomeSpaceId } from '../claim-home-space';
+import { type ClaimPickerEntity, useClaimEntitiesByIds } from '../claim-picker-page';
 import { eligibleClaimSpaceIds, isClaimSpaceAllowed } from '../claim-space-allowlist';
 import {
   type FeaturedClaim,
@@ -33,6 +34,7 @@ import {
 import { useDebateClaimsBySpaces } from '../hooks';
 import { useClaimSpaceAllowlist } from '../use-claim-space-allowlist';
 import { isSpaceDebatePublishable, useDebatePublishableSpaces } from '../use-debate-publishable-spaces';
+import { useGraphClaimTail } from '../use-graph-claim-tail';
 import { HubFilterMenu, type HubFilterOption, HubMultiFilterMenu } from './hub-filter-menu';
 import { HubCardList } from './hub-motion';
 import { HubQueryState } from './hub-states';
@@ -159,6 +161,59 @@ export function ClaimsTab() {
     () => pages.flatMap(page => page.claims).filter(entry => spaceShowsClaims(entry.claim.space_id)),
     [pages, spaceShowsClaims]
   );
+
+  /**
+   * GEO-2704. What geo-chat doesn't know about.
+   *
+   * geo-chat can only list a claim it has a row for, and it has a row for far fewer claims than
+   * exist — so the index running out of pages is not the same as the corpus running out of claims.
+   * Once it does run out, the graph is asked for the rest under the same filters, and those rows
+   * are appended.
+   *
+   * Only under All claims, and only without a search term:
+   *
+   * - `mine` and `debate_now` are questions about the viewer's own state, which the graph cannot
+   *   answer at all. Featured is already graph-backed.
+   * - a substring search over the ranking walk measured at ten seconds, so a searching viewer gets
+   *   geo-chat's answer alone until the indexed REST endpoint is wired in.
+   */
+  const tailEnabled =
+    !featured &&
+    filter === 'all' &&
+    !debouncedSearch &&
+    !spacesPending &&
+    !claimsQuery.unusable &&
+    !claimsQuery.isLoading &&
+    !claimsQuery.hasNextPage;
+
+  // The viewer's picked spaces where they have picked any, the eligible set otherwise — the same
+  // narrowing the index query gets, so the two halves of the list answer the same question.
+  const tailSpaceIds = React.useMemo(
+    () => (spaceIds.length > 0 ? spaceIds : eligibleSpaceIds),
+    [eligibleSpaceIds, spaceIds]
+  );
+
+  const tailQuery = React.useMemo(
+    () => ({
+      spaceIds: tailSpaceIds,
+      topicIds,
+      excludeIds: serverClaims.map(entry => entry.claim.claim_entity_id),
+    }),
+    [serverClaims, tailSpaceIds, topicIds]
+  );
+
+  // The home space decides where a debate would be published and which space's "Is factual" value
+  // labels the sides, so a claim whose home lands outside the gates is dropped rather than shown
+  // against a space this tab would not have listed.
+  const tailHomeSpaceOf = React.useCallback(
+    (entity: ClaimPickerEntity) => {
+      const homeSpaceId = claimHomeSpaceId(entity, spaceShowsClaims);
+      return homeSpaceId && spaceShowsClaims(homeSpaceId) ? homeSpaceId : null;
+    },
+    [spaceShowsClaims]
+  );
+
+  const tail = useGraphClaimTail({ query: tailQuery, enabled: tailEnabled, homeSpaceOf: tailHomeSpaceOf });
 
   // GEO-2683. Featured is a curator's tag in the knowledge graph, and geo-chat doesn't index it —
   // so unlike the position filter this can't be a query param, and unlike the old client-side topic
@@ -303,14 +358,27 @@ export function ClaimsTab() {
             .filter(claim => carriesPickedTopic(claim.claimEntityId))
             .map(claim => ({ id: claim.spaceId, name: null }))
         )
-      : (facets?.space_facets ?? []).filter(facet => spaceShowsClaims(facet.id));
+      : // The tail's spaces join the facet's for the same reason its topics do: a space whose only
+        // claims are ones geo-chat never indexed would otherwise be missing from the menu.
+        [
+          ...(facets?.space_facets ?? []).filter(facet => spaceShowsClaims(facet.id)),
+          ...countBy(tail.claims.map(entry => ({ id: entry.claim.space_id, name: null }))),
+        ];
     return orderFacetOptions(keepSelectedVisible(source, spaceIds), spaceIds);
-  }, [carriesPickedTopic, facets?.space_facets, featured, featuredSearched, spaceIds, spaceShowsClaims]);
+  }, [carriesPickedTopic, facets?.space_facets, featured, featuredSearched, spaceIds, spaceShowsClaims, tail.claims]);
+
+  // Appended, not merged. geo-chat orders by presence and readiness; the tail by ranking score.
+  // Interleaving them would produce a sequence answering to neither, so the seam sits at the end of
+  // what geo-chat had to say.
+  const tailClaims = React.useMemo(
+    () => (tail.claims.length > 0 ? [...serverClaims, ...tail.claims] : serverClaims),
+    [serverClaims, tail.claims]
+  );
 
   // The server re-sorts on every readiness change, so hold the order the user is looking at until
   // they ask for a different list.
   const claims = useStableListOrder(
-    featured ? featuredEntries : serverClaims,
+    featured ? featuredEntries : tailClaims,
     entry => `${entry.claim.space_id}:${entry.claim.claim_entity_id}`,
     `${debouncedSearch}|${spaceIds.join(',')}|${topicIds.join(',')}|${filter}`
   );
@@ -337,22 +405,41 @@ export function ClaimsTab() {
   const facetTopics = React.useMemo(() => {
     // Counting the featured claims per topic rather than deduping them: a count is the point of
     // the menu now, and the claims in hand are the whole featured list.
-    const source = featured
-      ? countBy(
-          featuredMatching.flatMap(claim =>
-            (featuredTopicsByClaimId.get(claim.claimEntityId) ?? []).map(topic => ({
-              id: topic.id,
-              name: topic.name,
-            }))
-          )
+    if (featured) {
+      const source = countBy(
+        featuredMatching.flatMap(claim =>
+          (featuredTopicsByClaimId.get(claim.claimEntityId) ?? []).map(topic => ({
+            id: topic.id,
+            name: topic.name,
+          }))
         )
-      : (facets?.topic_facets ?? []);
-    return orderFacetOptions(source, topicIds);
-  }, [facets?.topic_facets, featured, featuredMatching, featuredTopicsByClaimId, topicIds]);
+      );
+      return orderFacetOptions(source, topicIds);
+    }
+
+    // GEO-2704. Both, because neither is the whole answer. The facet describes the claims geo-chat
+    // has rows for, which is what the server can count; the tail carries topics off claims geo-chat
+    // has never heard of, which is how a topic came to be offered under Featured and missing under
+    // All claims for the same space.
+    //
+    // The tail's half grows as the viewer pages it — the behaviour GEO-2653 moved away from — but it
+    // applies only to topics that are otherwise unreachable, which is the better of the two failures.
+    const merged = new Map((facets?.topic_facets ?? []).map(facet => [facet.id, { ...facet }]));
+    for (const topic of countBy([...tail.topicsByClaimId.values()].flat())) {
+      const existing = merged.get(topic.id);
+      if (existing) existing.count += topic.count;
+      else merged.set(topic.id, topic);
+    }
+    return orderFacetOptions([...merged.values()], topicIds);
+  }, [facets?.topic_facets, featured, featuredMatching, featuredTopicsByClaimId, tail.topicsByClaimId, topicIds]);
 
   // Featured's menu settles with its entity lookup, which is where its topics come from — the
   // server facets it would otherwise read never arrive, since the query is never made.
-  const facetsSettled = featured ? !featuredLoading && !featuredEntitiesLoading : claimsQuery.facetsSettled;
+  // The tail contributes to the menu, so a topic it is about to add is not yet absent — clearing a
+  // selection against a half-built menu would drop a chip the viewer had every right to.
+  const facetsSettled = featured
+    ? !featuredLoading && !featuredEntitiesLoading
+    : claimsQuery.facetsSettled && !tail.isLoading;
 
   // The space is let go on the condition that actually means "not yours to pick" — the gates
   // stopped admitting it — rather than on its absence from the facet.
@@ -388,10 +475,17 @@ export function ClaimsTab() {
   // "Clear filters" should leave the viewer on the tab they picked.
   const hasFilters = Boolean(debouncedSearch || spaceIds.length || topicIds.length || (!featured && filter !== 'all'));
 
+  // geo-chat's pages first, then the tail's — one sentinel, two sources, in that order.
+  const hasNextPage = claimsQuery.hasNextPage || tail.hasNextPage;
+  const fetchNextPage = React.useCallback(() => {
+    if (claimsQuery.hasNextPage) claimsQuery.fetchNextPage();
+    else tail.fetchNextPage();
+  }, [claimsQuery, tail]);
+
   const sentinelRef = useInfiniteScrollSentinel({
-    hasNextPage: claimsQuery.hasNextPage,
-    isFetchingNextPage: claimsQuery.isFetchingNextPage,
-    fetchNextPage: claimsQuery.fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage: claimsQuery.isFetchingNextPage || tail.isFetchingNextPage,
+    fetchNextPage,
   });
 
   return (
@@ -485,9 +579,7 @@ export function ClaimsTab() {
           Not while the allowlist is pending, though: the tab is showing a four-row skeleton then,
           so the sentinel sits in view under it and pages the corpus on the strength of a loading
           state being visible — reading "the viewer reached the end" off a list that isn't there. */}
-        {claimsQuery.hasNextPage ? (
-          <div ref={sentinelRef} data-testid="claims-scroll-sentinel" className="h-px" />
-        ) : null}
+        {hasNextPage ? <div ref={sentinelRef} data-testid="claims-scroll-sentinel" className="h-px" /> : null}
       </div>
     </div>
   );

--- a/apps/web/core/debates/use-graph-claim-tail.ts
+++ b/apps/web/core/debates/use-graph-claim-tail.ts
@@ -7,6 +7,7 @@ import * as React from 'react';
 import type { MatchmakingClaim, MatchmakingTopic } from './api';
 import { type ClaimPickerEntity } from './claim-picker-page';
 import { type GraphClaimSource, claimIdsBySpace, graphClaimRow, graphClaimTopics } from './graph-claim-rows';
+import { fetchGraphClaimSearch, graphClaimSearchQueryKey } from './graph-claim-search';
 import { type GraphClaimsQuery, fetchGraphClaims, graphClaimsQueryKey } from './graph-claims';
 import { useDebateClaimsBySpaces } from './hooks';
 
@@ -50,14 +51,26 @@ export type GraphClaimTail = TailPaging & {
  */
 export function useGraphClaimTailSources({
   query,
+  search,
   enabled,
   homeSpaceOf,
 }: {
   query: GraphClaimsQuery;
+  /** When set, the tail comes from the indexed search endpoint instead of the ranking walk. */
+  search?: string | null;
   enabled: boolean;
   homeSpaceOf: (entity: ClaimPickerEntity) => string | null;
 }): GraphClaimTailSources {
-  const pages = useInfiniteQuery({
+  const searching = Boolean(search);
+
+  // Two sources, one shape. The ranking walk cannot answer a search — a substring filter over it
+  // measured at ten seconds — so a search goes to the indexed REST endpoint instead, and the rows
+  // come back through the same projection either way.
+  //
+  // Two queries rather than one with a branch inside: their page params are different kinds
+  // (a cursor and an offset), and react-query keys them separately, so a viewer clearing a search
+  // returns to the walk's pages rather than refetching them.
+  const walk = useInfiniteQuery({
     queryKey: graphClaimsQueryKey(query),
     queryFn: ({ pageParam, signal }) => fetchGraphClaims(query, pageParam, signal),
     initialPageParam: null as string | null,
@@ -65,8 +78,24 @@ export function useGraphClaimTailSources({
     // Curation and publishing move at human speed, and this list is the tail of another one — a
     // refetch on every focus would re-walk the ranking for rows the viewer has already scrolled past.
     staleTime: 5 * 60_000,
-    enabled,
+    enabled: enabled && !searching,
   });
+
+  const searchQuery = React.useMemo(
+    () => ({ search: search ?? '', spaceIds: query.spaceIds, topicIds: query.topicIds, excludeIds: query.excludeIds }),
+    [query.excludeIds, query.spaceIds, query.topicIds, search]
+  );
+
+  const searched = useInfiniteQuery({
+    queryKey: graphClaimSearchQueryKey(searchQuery),
+    queryFn: ({ pageParam, signal }) => fetchGraphClaimSearch(searchQuery, pageParam, signal),
+    initialPageParam: 0,
+    getNextPageParam: page => page.nextOffset ?? undefined,
+    staleTime: 5 * 60_000,
+    enabled: enabled && searching,
+  });
+
+  const pages = searching ? searched : walk;
 
   const entities = React.useMemo(
     () => (enabled ? (pages.data?.pages.flatMap(page => page.claims) ?? NO_ENTITIES) : NO_ENTITIES),
@@ -112,6 +141,7 @@ export function useGraphClaimTailSources({
  */
 export function useGraphClaimTail(args: {
   query: GraphClaimsQuery;
+  search?: string | null;
   enabled: boolean;
   homeSpaceOf: (entity: ClaimPickerEntity) => string | null;
 }): GraphClaimTail {

--- a/apps/web/core/debates/use-graph-claim-tail.ts
+++ b/apps/web/core/debates/use-graph-claim-tail.ts
@@ -1,0 +1,106 @@
+'use client';
+
+import { useInfiniteQuery } from '@tanstack/react-query';
+
+import * as React from 'react';
+
+import type { MatchmakingClaim, MatchmakingTopic } from './api';
+import { type ClaimPickerEntity } from './claim-picker-page';
+import { claimIdsBySpace, graphClaimRow, graphClaimTopics } from './graph-claim-rows';
+import { type GraphClaimsQuery, fetchGraphClaims, graphClaimsQueryKey } from './graph-claims';
+import { useDebateClaimsBySpaces } from './hooks';
+
+const NO_CLAIMS: MatchmakingClaim[] = [];
+const NO_ENTITIES: ClaimPickerEntity[] = [];
+const NO_GROUPS: Array<{ spaceId: string; claimIds: string[] }> = [];
+const NO_TOPICS = new Map<string, MatchmakingTopic[]>();
+
+export type GraphClaimTail = {
+  /** Rows in the shape the hub's cards speak, ready to append after geo-chat's. */
+  claims: MatchmakingClaim[];
+  /** Topics of those claims, for the menus to union with geo-chat's facet. */
+  topicsByClaimId: Map<string, MatchmakingTopic[]>;
+  isLoading: boolean;
+  isFetchingNextPage: boolean;
+  hasNextPage: boolean;
+  fetchNextPage: () => void;
+  error: unknown;
+};
+
+/**
+ * GEO-2704. The part of a claim list geo-chat doesn't know about.
+ *
+ * Enabled by its caller only once geo-chat has no next page, so the list is geo-chat's — its
+ * ordering, its readiness, its session exclusions — for as long as geo-chat has anything to say.
+ * What comes back here is appended after that, never merged into it: the two are ordered by
+ * different things, and interleaving them would produce a sequence answering to neither.
+ *
+ * `homeSpaceOf` is the caller's, because the answer differs between surfaces. It decides which of a
+ * claim's spaces the row belongs to, and returning `null` drops the claim — which is how a caller
+ * refuses one whose only spaces it may not show.
+ */
+export function useGraphClaimTail({
+  query,
+  enabled,
+  homeSpaceOf,
+}: {
+  query: GraphClaimsQuery;
+  enabled: boolean;
+  homeSpaceOf: (entity: ClaimPickerEntity) => string | null;
+}): GraphClaimTail {
+  const pages = useInfiniteQuery({
+    queryKey: graphClaimsQueryKey(query),
+    queryFn: ({ pageParam, signal }) => fetchGraphClaims(query, pageParam, signal),
+    initialPageParam: null as string | null,
+    getNextPageParam: page => (page.hasNextPage ? page.endCursor : undefined),
+    // Curation and publishing move at human speed, and this list is the tail of another one — a
+    // refetch on every focus would re-walk the ranking for rows the viewer has already scrolled past.
+    staleTime: 5 * 60_000,
+    enabled,
+  });
+
+  const entities = React.useMemo(
+    () => (enabled ? (pages.data?.pages.flatMap(page => page.claims) ?? NO_ENTITIES) : NO_ENTITIES),
+    [enabled, pages.data]
+  );
+
+  // Home space first, because everything else keys on it: which space geo-chat is asked about, and
+  // which space's "Is factual" value decides the card's side labels.
+  const placed = React.useMemo(
+    () =>
+      entities.flatMap(entity => {
+        const spaceId = homeSpaceOf(entity);
+        if (!spaceId || !entity.name) return [];
+        return [{ claimEntityId: entity.id, spaceId, name: entity.name, description: entity.description, entity }];
+      }),
+    [entities, homeSpaceOf]
+  );
+
+  // Sides and readiness are geo-chat's and nobody else's, and its only lookup for claims it hasn't
+  // ranked is the per-space one — so these are asked for by id, grouped by the space they landed in.
+  const groups = React.useMemo(() => (placed.length > 0 ? claimIdsBySpace(placed) : NO_GROUPS), [placed]);
+  const rows = useDebateClaimsBySpaces(groups);
+
+  const claims = React.useMemo(() => {
+    if (!enabled || placed.length === 0) return NO_CLAIMS;
+    const rowsByClaimId = new Map(rows.claims.map(row => [row.claim_entity_id, row]));
+    return placed.map(source => graphClaimRow(source, rowsByClaimId.get(source.claimEntityId)));
+  }, [enabled, placed, rows.claims]);
+
+  const topicsByClaimId = React.useMemo(
+    () => (enabled && entities.length > 0 ? graphClaimTopics(entities) : NO_TOPICS),
+    [enabled, entities]
+  );
+
+  return {
+    claims,
+    topicsByClaimId,
+    // `enabled: false` leaves react-query pending forever, which a caller folding this into its own
+    // loading state would read as "still looking" and never settle.
+    isLoading: enabled && pages.isLoading,
+    isFetchingNextPage: pages.isFetchingNextPage,
+    hasNextPage: enabled && pages.hasNextPage,
+    fetchNextPage: pages.fetchNextPage,
+    error: enabled ? pages.error : null,
+  };
+}

--- a/apps/web/core/debates/use-graph-claim-tail.ts
+++ b/apps/web/core/debates/use-graph-claim-tail.ts
@@ -6,7 +6,7 @@ import * as React from 'react';
 
 import type { MatchmakingClaim, MatchmakingTopic } from './api';
 import { type ClaimPickerEntity } from './claim-picker-page';
-import { claimIdsBySpace, graphClaimRow, graphClaimTopics } from './graph-claim-rows';
+import { type GraphClaimSource, claimIdsBySpace, graphClaimRow, graphClaimTopics } from './graph-claim-rows';
 import { type GraphClaimsQuery, fetchGraphClaims, graphClaimsQueryKey } from './graph-claims';
 import { useDebateClaimsBySpaces } from './hooks';
 
@@ -15,16 +15,25 @@ const NO_ENTITIES: ClaimPickerEntity[] = [];
 const NO_GROUPS: Array<{ spaceId: string; claimIds: string[] }> = [];
 const NO_TOPICS = new Map<string, MatchmakingTopic[]>();
 
-export type GraphClaimTail = {
-  /** Rows in the shape the hub's cards speak, ready to append after geo-chat's. */
-  claims: MatchmakingClaim[];
-  /** Topics of those claims, for the menus to union with geo-chat's facet. */
-  topicsByClaimId: Map<string, MatchmakingTopic[]>;
+type TailPaging = {
   isLoading: boolean;
   isFetchingNextPage: boolean;
   hasNextPage: boolean;
   fetchNextPage: () => void;
   error: unknown;
+};
+
+export type GraphClaimTailSources = TailPaging & {
+  /** Each claim with the space it belongs to decided, ready to be built into a row. */
+  sources: GraphClaimSource[];
+  /** Topics of those claims, for the menus to union with geo-chat's facet. */
+  topicsByClaimId: Map<string, MatchmakingTopic[]>;
+};
+
+export type GraphClaimTail = TailPaging & {
+  /** Rows in the shape the hub's cards speak, ready to append after geo-chat's. */
+  claims: MatchmakingClaim[];
+  topicsByClaimId: Map<string, MatchmakingTopic[]>;
 };
 
 /**
@@ -39,7 +48,7 @@ export type GraphClaimTail = {
  * claim's spaces the row belongs to, and returning `null` drops the claim — which is how a caller
  * refuses one whose only spaces it may not show.
  */
-export function useGraphClaimTail({
+export function useGraphClaimTailSources({
   query,
   enabled,
   homeSpaceOf,
@@ -47,7 +56,7 @@ export function useGraphClaimTail({
   query: GraphClaimsQuery;
   enabled: boolean;
   homeSpaceOf: (entity: ClaimPickerEntity) => string | null;
-}): GraphClaimTail {
+}): GraphClaimTailSources {
   const pages = useInfiniteQuery({
     queryKey: graphClaimsQueryKey(query),
     queryFn: ({ pageParam, signal }) => fetchGraphClaims(query, pageParam, signal),
@@ -76,24 +85,13 @@ export function useGraphClaimTail({
     [entities, homeSpaceOf]
   );
 
-  // Sides and readiness are geo-chat's and nobody else's, and its only lookup for claims it hasn't
-  // ranked is the per-space one — so these are asked for by id, grouped by the space they landed in.
-  const groups = React.useMemo(() => (placed.length > 0 ? claimIdsBySpace(placed) : NO_GROUPS), [placed]);
-  const rows = useDebateClaimsBySpaces(groups);
-
-  const claims = React.useMemo(() => {
-    if (!enabled || placed.length === 0) return NO_CLAIMS;
-    const rowsByClaimId = new Map(rows.claims.map(row => [row.claim_entity_id, row]));
-    return placed.map(source => graphClaimRow(source, rowsByClaimId.get(source.claimEntityId)));
-  }, [enabled, placed, rows.claims]);
-
   const topicsByClaimId = React.useMemo(
     () => (enabled && entities.length > 0 ? graphClaimTopics(entities) : NO_TOPICS),
     [enabled, entities]
   );
 
   return {
-    claims,
+    sources: placed,
     topicsByClaimId,
     // `enabled: false` leaves react-query pending forever, which a caller folding this into its own
     // loading state would read as "still looking" and never settle.
@@ -103,4 +101,32 @@ export function useGraphClaimTail({
     fetchNextPage: pages.fetchNextPage,
     error: enabled ? pages.error : null,
   };
+}
+
+/**
+ * The same tail, built into the rows the hub's cards speak.
+ *
+ * The rematch picker takes {@link useGraphClaimTailSources} instead: its rows carry session flags
+ * and both debaters' sides, so it builds them itself and asks geo-chat through the session's own
+ * lookup rather than the per-space one below.
+ */
+export function useGraphClaimTail(args: {
+  query: GraphClaimsQuery;
+  enabled: boolean;
+  homeSpaceOf: (entity: ClaimPickerEntity) => string | null;
+}): GraphClaimTail {
+  const { sources, topicsByClaimId, ...paging } = useGraphClaimTailSources(args);
+
+  // Sides and readiness are geo-chat's and nobody else's, and its only lookup for claims it hasn't
+  // ranked is the per-space one — so these are asked for by id, grouped by the space they landed in.
+  const groups = React.useMemo(() => (sources.length > 0 ? claimIdsBySpace(sources) : NO_GROUPS), [sources]);
+  const rows = useDebateClaimsBySpaces(groups);
+
+  const claims = React.useMemo(() => {
+    if (sources.length === 0) return NO_CLAIMS;
+    const rowsByClaimId = new Map(rows.claims.map(row => [row.claim_entity_id, row]));
+    return sources.map(source => graphClaimRow(source, rowsByClaimId.get(source.claimEntityId)));
+  }, [rows.claims, sources]);
+
+  return { claims, topicsByClaimId, ...paging };
 }


### PR DESCRIPTION
[GEO-2704](https://linear.app/geobrowser/issue/GEO-2704/debates-source-claim-discovery-from-the-graph-and-keep-geo-chat-for)

**Ready to test.** Both surfaces are wired.

## The bug

Both claim lists page through geo-chat's `/matchmaking/claims`. A claim geo-chat has no row for can't be listed, however plainly it exists on Geo. And because Featured reads the graph while everything else reads geo-chat, the two disagree — with Health selected, Featured offers the topic "Morning routine" and All claims doesn't offer it at all.

That topic has exactly 3 claims, all in Health, all tagged Featured: *Waking up early improves health and productivity*, *Morning exercise is better than evening exercise*, *Caffeine should be delayed after waking*.

## Approach: a tail, not a replacement

The graph **continues** geo-chat's list rather than replacing it. Once geo-chat has no next page, the graph is asked for claims matching the same filters, minus the ones already on screen, and those rows are appended.

Strictly additive, so there's no behaviour to re-earn: geo-chat's ordering, readiness and session exclusions stay intact for every row it knows about. It also doesn't depend on the open question of why geo-chat's index is thin — if that gets backfilled, the tail simply shrinks.

Appended, not interleaved: the two are ordered by different things (presence and positions there, ranking score here), and merging them would produce a sequence answering to neither. One sentinel drives both, in order.

## Two sources behind one hook

| Viewer state | Source | Measured |
|---|---|---|
| Browsing | `entitiesRankedForFeedConnection` (Explore's Best) | 418ms across four spaces; 981ms one space |
| Searching | REST `/search`, scoped to Claim | 508ms unscoped; 361ms one space |

The walk can't answer a search — a substring filter over it measured at **10.1s**, because it walks a long way to find few rows. The endpoint is indexed, returns matches rather than claims, and its ids are hydrated through the picker's projection so both sources produce identical rows.

They're two queries rather than one with a branch, because their page params are different kinds (cursor vs offset); keying separately means clearing a search returns to the walk's pages rather than refetching them.

Exclusions go in the walk's query (`id: { notIn: [...] }`, verified working) rather than after the fetch — geo-chat orders by presence and the graph by ranking score, so the overlap is scattered rather than at the front, and filtering afterwards would leave pages arriving mostly empty with no way to tell that from the end.

## The topic menu

This is what reaches the reported bug. geo-chat's `topic_facets` stays — it's count-descending over the whole corpus it knows, which is the right shape — and the topics of tailed claims are unioned into it. A topic carried only by claims geo-chat never indexed is now *selectable*, where before it was absent from the menu and therefore unreachable.

The tail's half of a count grows as you page it, which is the behaviour GEO-2653 moved away from. That's a deliberate step back in one narrow respect, and it applies only to topics that are otherwise missing entirely.

## Rejected: replacing the list outright

The first version derived the menu from a ranked sample of the top N claims. Measured against ground truth for Health (844 topic relations, 125 distinct topics):

| N | topics found | of true 125 | counts exact |
|---|---|---|---|
| 100 | 6 | 5% | 0/6 |
| 500 | 30 | **24%** | 23/30 |
| 1000 | 31 | 25% | 24/31 |

Raising N doesn't help — 500 → 1000 added one topic — because Health has 10,736 claims but only 844 topic relations, so most claims carry no topic and walking further down a quality ranking finds few. Exact enumeration doesn't scale either: Health 1 page, Crypto 12, Podcasts 57 (198s). That menu would have been worse than the one we have.

## Where the tail is off

- **`mine` / `debate_now`** — questions about the viewer's own state, which the graph can't answer
- **Featured / Recommended** — already graph-backed, or a fixed curated set
- **While geo-chat still has pages** — its list is the list until it runs out

## Testing

New: `graph-claims.test.ts`, `graph-claim-search.test.ts`, plus tail suites on both surfaces covering append-order, the exhaustion gate, filter parity, exclusions, the topic union and count merge, search routing, and sentinel handoff. The two union tests were confirmed failing against the un-unioned menu.

Full web suite: **320 files passing**. `bun run build` clean.

## Known gaps

- The tail's topic counts grow while paging (above)
- Podcasts alone is ~6s for the walk; realistic multi-space scopes are 418ms
- The geo-chat index question is still open and worth answering — if a backfill there is possible, it's the cheaper fix and this becomes a safety net

🤖 Generated with [Claude Code](https://claude.com/claude-code)
