### PR TITLE
fix(debates): give the rematch session a delivery backstop

### DIFF
--- a/apps/web/core/debates/hooks-query-network.test.tsx
+++ b/apps/web/core/debates/hooks-query-network.test.tsx
@@ -91,18 +91,38 @@ describe('debate query network ownership', () => {
       useDebateClaims('space-1', ['claim-1'], true);
       useSpaceDebates('space-1', true);
       useDebate('debate-1', true);
-      useDebateRematch('rematch-1');
       useDebateRematchClaims('rematch-1', ['claim-1']);
       useDebateSharePrompts();
       useDebateMedia('debate-1', true);
       useDebateTranscript('debate-1');
     });
 
-    expect(mocks.useQuery).toHaveBeenCalledTimes(8);
+    expect(mocks.useQuery).toHaveBeenCalledTimes(7);
     for (const [options] of mocks.useQuery.mock.calls) {
       expect(options).toMatchObject({ retry: false, refetchOnReconnect: false, refetchOnWindowFocus: false });
       expect(options).not.toHaveProperty('refetchInterval');
     }
+  });
+
+  // GEO-2650. The rematch session had no polling at all, so a push that never arrived meant the
+  // request never appeared — and the push has a 30-second failure budget, because a silently dead
+  // socket is not noticed until the next heartbeat. Every other link measures far below that: the
+  // outbox publishes rematch events in 1.28s average and 2.27s worst over the last week, and the
+  // client coalesces invalidations for 50ms.
+  //
+  // Gated on presence rather than attention for the reason the activity poll already learned: a
+  // visible tab behind the focused window is exactly where someone waits for an opponent.
+  it('polls the rematch session on a visible tab, including one that is not focused', () => {
+    mocks.attention = false;
+    mocks.presence = true;
+
+    const { rerender } = renderHook(() => useDebateRematch('rematch-1'));
+    expect(mocks.useQuery.mock.calls.at(-1)?.[0]).toMatchObject({ refetchInterval: 5_000 });
+
+    // A hidden tab has nobody watching the picker.
+    mocks.presence = false;
+    rerender();
+    expect(mocks.useQuery.mock.calls.at(-1)?.[0]).toMatchObject({ refetchInterval: false });
   });
 
   // Activity gates the incoming-request popup, and the socket has two ways to be deaf: reconnect

--- a/apps/web/core/debates/hooks.ts
+++ b/apps/web/core/debates/hooks.ts
@@ -332,6 +332,25 @@ export function useLeaveDebateQueue(spaceId: string) {
   });
 }
 
+/**
+ * How often the rematch session re-asks while its picker is on screen (GEO-2650).
+ *
+ * A backstop, not the delivery mechanism. `debate.rematch_changed` still arrives by push and is
+ * what normally updates this — measured at 1.28s average and 2.27s worst from emit to Kafka
+ * publish, across every rematch event in the last week.
+ *
+ * It exists because this query had no fallback at all, and the push has one failure mode with a
+ * 30-second budget: a socket that dies silently is not noticed until the next heartbeat
+ * (`DEFAULT_HEARTBEAT_INTERVAL_MS` in `debate-gateway`), and only then reconnects and refetches.
+ * Preston measured a request taking ~36 seconds to reach an opponent, which is that window plus a
+ * reconnect and handshake — and every other link in the chain measures well under it.
+ *
+ * Five seconds because both people are sitting there waiting for each other: this is the one flow
+ * where a stale list is the whole problem rather than a cosmetic lag. It only runs while the picker
+ * is foregrounded, so an idle tab still costs nothing.
+ */
+const REMATCH_POLL_MS = 5_000;
+
 /** How often activity re-asks while this tab is on screen, with a live gateway behind it. */
 const ACTIVITY_POLL_MS = 30_000;
 /** And while the gateway is paused, when this is the only thing still asking. */
@@ -622,12 +641,20 @@ export function useConsentToDebateRematch(debateId: string) {
 
 export function useDebateRematch(sessionId: string, enabled = true) {
   const { accountKey, getPrivyIdentityToken } = useGeoChatAuth();
+  // Presence, not attention. `useDebateAttention` also requires `document.hasFocus()`, so a tab
+  // sitting open on screen behind whatever window the viewer is typing in would not poll — and
+  // waiting for an opponent while looking elsewhere is exactly this flow. That distinction is the
+  // one GEO-2650 already cost once on the activity poll; see the note on `useDebateActivity`.
+  const present = useDebatePresence();
 
   return useQuery({
     ...debateQueryNetworkOptions,
     queryKey: debateQueryKeys.rematch(accountKey, sessionId),
     queryFn: ({ signal }) => getDebateRematch(sessionId, getPrivyIdentityToken, accountKey, signal),
     enabled: enabled && Boolean(sessionId),
+    // See REMATCH_POLL_MS. The push still does the work; this bounds the case where it never
+    // arrives, which this query previously had no answer to.
+    refetchInterval: present ? REMATCH_POLL_MS : false,
   });
 }
 


### PR DESCRIPTION
Closes [GEO-2650](https://linear.app/geobrowser/issue/GEO-2650). Preston: a debate request took **~36 seconds** to reach his opponent.

The ticket's own note is that the fix depends entirely on which link is slow, so I profiled every one against a week of real traffic rather than guessing.

| link | measured |
| -- | -- |
| emit → outbox row | same transaction |
| **outbox → Kafka publish** | **1.28s avg, 2.27s max** for `debate.rematch_changed` — 188 events, **0 unpublished**, one attempt each |
| worst publish lag of *any* event type, ever | 8.19s |
| client handler → invalidation | correct, 50ms coalesce |
| **silently dead socket → detection** | **up to 30s** |

Only the last one has a 36-second budget. `DEFAULT_HEARTBEAT_INTERVAL_MS` is 30 seconds, so a socket that dies quietly — sleep, network blip, proxy timeout — isn't noticed until the next heartbeat, and only then reconnects and refetches. 30s + reconnect + a 10s handshake budget is the reported number.

And **`useDebateRematch` had no `refetchInterval` at all**, so during that window there was no fallback whatsoever: the request sat in the database, published to Kafka inside two seconds, with nobody listening.

## The change

A 5-second poll while the picker is on screen. The push still does the work — this only bounds the case where the push never arrives. Five seconds because both people are sitting there waiting for each other; this is the one flow where a stale list *is* the problem rather than a cosmetic lag.

**Gated on presence, not attention** — and that isn't incidental. `useDebateAttention` also requires `document.hasFocus()`, so a tab open on screen behind whatever window the viewer is typing in wouldn't poll, which is exactly where someone waits for an opponent. A test in this same file records GEO-2650 already costing that once on the activity poll. I made the same mistake in my first draft; that comment is what caught it.

## Ruled out, so nobody re-checks

- **`create_rematch_request` does emit.** I initially reported it didn't — my grep window stopped short of line 5110, where `emit_rematch_changed` sits immediately before the commit. Wrong, and worth recording.
- **The outbox is neither slow nor lossy** — 0 unpublished across 183,329 events, every one on its first attempt.
- **Volume isn't it either.** All 8 event types share a single Kafka topic, because the topic name derives from `aggregate_type` and everything is `debate` — so 188 rematch events genuinely do queue behind ~182k others. But peak is 571 events/min and the worst publish lag ever recorded is 8.19s, so there's no backlog to blame. Worth knowing the shared topic exists if volume ever grows.

## Verification

- 12 network-policy tests pass; `tsc` at its 5-error baseline.
- **Mutation-tested twice**: removing the poll fails the new test, and gating on attention instead of presence fails it too — so the presence distinction is pinned, not just commented.

## Unrelated failure worth flagging

`retains one scope per space` in `use-debate-gateway-space-scopes.test.tsx` **times out on master too** — 10502ms there, 10040ms here — and touches nothing in this change. I ran the same directory on master to confirm before concluding it was unrelated. It passes in isolation, so it's a full-suite timeout, and it will make this PR's CI red through no fault of the diff.

## Related

GEO-2651 (a request that "didn't register" before the thank-you period ended) is likely the same root cause: with no polling fallback, a missed push meant the request never appeared at all.
