### PR TITLE
feat(debates): relate both participants side-agnostically on publish

### DIFF
--- a/apps/web/core/debates/debate-publish-draft.test.ts
+++ b/apps/web/core/debates/debate-publish-draft.test.ts
@@ -15,6 +15,7 @@ import {
   AUTHORS_PROPERTY_ID,
   DEBATE_CLAIMS_PROPERTY_ID,
   DEBATE_OPPOSED_BY_PROPERTY_ID,
+  DEBATE_PARTICIPANTS_PROPERTY_ID,
   DEBATE_SUPPORTED_BY_PROPERTY_ID,
   DEBATE_TYPE_ID,
   IMAGE_TYPE_ID,
@@ -76,6 +77,36 @@ describe('buildDebatePublishDraft', () => {
       { createEntityId: idFactory(), createPosition: () => 'a0' }
     );
     expect(draft.debateName).toBe('Arturas vs. Preston on The US should have attacked Iran');
+  });
+
+  // Preston: "Can we also add a participants relation to both participants. This will be useful for
+  // creating a data block with all the debates that I have participated in."
+  //
+  // Supported by / Opposed by already name everyone, but they encode which side — so that data
+  // block would have to union two relations and know which one to look on. This is the
+  // side-agnostic membership, and it uses the canonical `SystemIds.PARTICIPANTS_PROPERTY` so the
+  // query is the same one any other participant-bearing entity answers to.
+  it('relates both participants side-agnostically, as well as by side', () => {
+    const draft = buildDebatePublishDraft(baseInput(), { createEntityId: idFactory(), createPosition: () => 'a0' });
+
+    const participants = draft.relations.filter(r => r.type.id === DEBATE_PARTICIPANTS_PROPERTY_ID);
+    expect(participants).toHaveLength(2);
+
+    // Both sides, one relation. Sorted so the assertion does not depend on slot order.
+    const supported = draft.relations.find(r => r.type.id === DEBATE_SUPPORTED_BY_PROPERTY_ID);
+    const opposed = draft.relations.find(r => r.type.id === DEBATE_OPPOSED_BY_PROPERTY_ID);
+    expect([...participants.map(r => r.toEntity.id)].sort()).toEqual(
+      [supported!.toEntity.id, opposed!.toEntity.id].sort()
+    );
+
+    // And it does not replace them — a debate still records who argued which way.
+    expect(supported).toBeDefined();
+    expect(opposed).toBeDefined();
+
+    // Every Participants relation hangs off the debate itself, not off a block or the claim.
+    for (const relation of participants) {
+      expect(relation.fromEntity.id).toBe(draft.debateEntityId);
+    }
   });
 
   it('links Supported by to the yes participant and Opposed by to the no participant', () => {

--- a/apps/web/core/debates/debate-publish-draft.ts
+++ b/apps/web/core/debates/debate-publish-draft.ts
@@ -9,6 +9,7 @@ import {
   BLOCKS_PROPERTY_ID,
   DEBATE_CLAIMS_PROPERTY_ID,
   DEBATE_OPPOSED_BY_PROPERTY_ID,
+  DEBATE_PARTICIPANTS_PROPERTY_ID,
   DEBATE_SUPPORTED_BY_PROPERTY_ID,
   DEBATE_TRANSCRIPTS_PROPERTY_ID,
   DEBATE_TYPE_ID,
@@ -183,6 +184,16 @@ export function buildDebatePublishDraft(input: DebatePublishInput, options: Buil
     relate({
       fromEntity: debateRef,
       propertyId: p.position ? DEBATE_SUPPORTED_BY_PROPERTY_ID : DEBATE_OPPOSED_BY_PROPERTY_ID,
+      toEntityId: p.spaceEntityId,
+      toEntityName: p.displayName,
+    });
+    // Both participants also get the side-agnostic Participants relation. Supported by / Opposed by
+    // already name them, but they encode *which side* — so "every debate this person was in" would
+    // mean unioning two relations and knowing which one to look on. One relation makes that a
+    // single filter, which is what a data block needs.
+    relate({
+      fromEntity: debateRef,
+      propertyId: DEBATE_PARTICIPANTS_PROPERTY_ID,
       toEntityId: p.spaceEntityId,
       toEntityName: p.displayName,
     });

--- a/apps/web/core/debates/ontology.ts
+++ b/apps/web/core/debates/ontology.ts
@@ -37,6 +37,19 @@ export const DEBATE_SUPPORTED_BY_PROPERTY_ID = 'd19fad5651364a7f8309daf5c7bf99dd
 export const DEBATE_OPPOSED_BY_PROPERTY_ID = 'c57de77c3eee4e7ba0d2258d18aab11c';
 
 /**
+ * Participants (RELATION) → both participants, regardless of side.
+ *
+ * Supported by / Opposed by already name everyone in a debate, but they answer "who argued which
+ * way" and so cannot be filtered as one set: a data block of "debates I was in" would have to union
+ * two relations and know which side to look on. This is the side-agnostic membership.
+ *
+ * `SystemIds.PARTICIPANTS_PROPERTY` rather than a debates-specific id, deliberately — a query for
+ * the canonical property finds these debates alongside anything else that uses it, which is the
+ * point of a shared ontology. A private id would have needed every consumer to learn about it.
+ */
+export const DEBATE_PARTICIPANTS_PROPERTY_ID = SystemIds.PARTICIPANTS_PROPERTY; // 0b9b1a35…
+
+/**
  * Vote (TYPE) — one viewer's pick of who won a debate. Lives in the voter's personal
  * space and is auto-published there, the same way comments are.
  */


### PR DESCRIPTION
Preston: *"Can we also add a participants relation to both participants. This will be useful for creating a data block with all the debates that I have participated in."*

## Why a third relation rather than reusing the two

Supported by / Opposed by already name everyone in a debate — but they encode **which side**. So "every debate this person was in" means unioning two relations and knowing which one to look on, which a data block can't express as one filter. Participants is the side-agnostic membership.

Both existing relations stay. The debate still records who argued which way; this is additive.

## The one choice worth arguing with

It uses **`SystemIds.PARTICIPANTS_PROPERTY`** (`0b9b1a35…`) rather than a debates-specific id.

A private id would work. I went with the canonical one because a query for it finds these debates alongside anything else that carries participants — which is the point of a shared ontology, and it means the data block is an ordinary participants query rather than something that has to know debates exist.

The tradeoff: a debate now answers to a property other entity types also use, so a participants query returns debates mixed with whatever else. If you'd rather they were separable, say so and I'll switch to a dedicated id.

## Verification

- 20 tests pass; `tsc` at its 5-error baseline.
- **Mutation-tested**: dropping the relation fails, and relating only one side fails — so "both participants" is pinned, not just the property.
- The test also asserts the relations hang off the debate entity itself rather than a block or the claim, since that's what makes the reverse query work.