### PR TITLE
test: stop the gateway-scopes suite paying an import inside a test timeout

### DIFF
--- a/apps/web/core/debates/use-debate-gateway-space-scopes.test.tsx
+++ b/apps/web/core/debates/use-debate-gateway-space-scopes.test.tsx
@@ -9,16 +9,22 @@ const mocks = vi.hoisted(() => ({
 
 // No module mock: the hook and the gateway singleton are the pair under test, and the singleton
 // opens no socket until `start()`. Spying on `retainScope` is enough to count commands.
+//
+// Imported statically rather than with `await import` inside `beforeEach`, which is what GEO-2645
+// was: `beforeEach` counts against the *test's* timeout, so the first test in this file paid the
+// whole cold-import cost of `debate-gateway` and its dependency graph — 5.6 seconds on an idle
+// machine against a 10s limit, while every other test here runs in under 10ms. Under a full suite,
+// with workers competing for CPU, that crossed the limit and the file failed on a timeout rather
+// than an assertion. The dynamic import bought nothing either way: `await import` returns the
+// cached module after the first call, so every `beforeEach` was already re-spying the same
+// singleton.
+import { debateGateway, useDebateGatewaySpaceScopes } from './debate-gateway';
 
 describe('useDebateGatewaySpaceScopes', () => {
-  let useDebateGatewaySpaceScopes: typeof import('./debate-gateway').useDebateGatewaySpaceScopes;
-
-  beforeEach(async () => {
+  beforeEach(() => {
     mocks.retain.mockReset();
     mocks.release.mockReset();
-    const mod = await import('./debate-gateway');
-    useDebateGatewaySpaceScopes = mod.useDebateGatewaySpaceScopes;
-    vi.spyOn(mod.debateGateway, 'retainScope').mockImplementation(scope => {
+    vi.spyOn(debateGateway, 'retainScope').mockImplementation(scope => {
       mocks.retain(scope);
       return () => mocks.release(scope);
     });


### PR DESCRIPTION
Part of [GEO-2645](https://linear.app/geobrowser/issue/GEO-2645) — the ticket where CI goes red at random with every test passing. This is its most reproducible instance, and it isn't a teardown race.

## What it actually is

`retains one scope per space` timed out at ~10s in full-suite runs while passing in well under a second alone. `beforeEach` did `await import('./debate-gateway')`, and **`beforeEach` counts against the test's timeout** — so the first test in the file paid the entire cold-import cost of that module and its dependency graph.

Measured with `--reporter=verbose`, idle machine:

| test | duration |
| -- | -- |
| **retains one scope per space** | **5625ms** |
| costs one retain and no releases when a space is added | 10ms |
| releases only the space that left | 9ms |
| does nothing when the same spaces arrive in a different order | 4ms |
| releases everything on unmount | 10ms |
| releases everything when it is disabled, and retains again | 8ms |

One test 500× the others, and it's the first one. Against a 10s limit that leaves no headroom — under a full suite with workers competing for CPU it crosses, and the file fails on a **timeout rather than an assertion**. That's why *which* file goes red carried no information about which change was at fault.

## The fix

Static import. The dynamic one bought nothing: `await import` returns the cached module after the first call, so every `beforeEach` was already re-spying the same singleton. Behaviour identical; the cost moves to module load, which isn't charged to a test.

**5625ms → 50ms.**

Verified by running the whole directory that was failing: **69 files / 862 tests pass**, where master fails this file.

## Not the whole ticket, and I'd rather say so

Failures also moved to `rematch-page-client.test.tsx`. That's a **different cause** — 129 tests, 70.7s total, slowest single test 1282ms, no outlier. Genuinely slow rather than paying an import, so it can only cross a 10s per-test limit under heavy contention, which is exactly why it comes and goes.

That wants `testTimeout` raised in `vite.config.js` (currently unset, so the default). I left it out deliberately: choosing the suite's timeout is a project-wide call, and a longer one trades away hang detection. Happy to add `testTimeout: 20_000` as a one-liner if you want it — the data above is the argument for it.

## Checked and deliberately not changed

28 test files use `await import(...)`, but most are inside `vi.mock` factories, where it's required, or paired with `vi.resetModules()` to test module-level state, where removing it would break the test. `debate-feed.test.tsx` is one of those — its `await import` is in a mock factory and its timings are uniform (355–899ms), so it's unaffected.

## Why this matters beyond the one test

A permanently unreliable Test job trains everyone to merge through it. **I did exactly that today**: I dismissed two genuine CI failures as this flakiness, and the second time CI was right — it had correctly caught tests my change broke. That's the real cost of the ticket, and it's why I went after a cause rather than raising the timeout and moving on.