### PR TITLE
fix(debates): hold the positions list while its query key changes

### DIFF
--- a/apps/web/core/debates/participant-positions.test.ts
+++ b/apps/web/core/debates/participant-positions.test.ts
@@ -1,4 +1,21 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+
+import * as React from 'react';
+
+import { Effect } from 'effect';
+
 import { describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({ graphql: vi.fn(), attention: true }));
+
+// The hook's own `queryFn` calls the real `fetchParticipantPositions`, which reaches the graph
+// through this module — so this is the seam for a hook-level test. The pure-function tests below
+// inject `fetchPage` directly and are unaffected.
+vi.mock('~/core/io/graphql-client', () => ({
+  graphql: (...args: unknown[]) => mocks.graphql(...args),
+}));
+vi.mock('./debate-attention', () => ({ useDebateAttention: () => mocks.attention }));
 
 import type { DebateRematchParticipant } from './api';
 import {
@@ -7,6 +24,7 @@ import {
   isParticipantPositionsQueryKey,
   participantPositionsQueryKey,
   participantSidesOn,
+  useParticipantPositions,
 } from './participant-positions';
 
 const LOCAL: DebateRematchParticipant = {
@@ -143,4 +161,50 @@ it('keys the query outside the debates family, in participant order', () => {
   expect(key).toEqual(participantPositionsQueryKey(['a', 'b']));
   expect(isParticipantPositionsQueryKey(key)).toBe(true);
   expect(isParticipantPositionsQueryKey(['debates', 'claims'])).toBe(false);
+});
+
+/**
+ * GEO-2599. Preston: "randomly the positions also dissapear. I just lost all of Dovile's positions
+ * without doing anything whilst I was typing."
+ *
+ * The list is grouped from `query.data`, which is `undefined` for any key the cache has not seen —
+ * so a key change emptied the whole thing rather than showing the previous answer. And the trigger
+ * need not be a real change: `enabled` is `profileSpaceIds.length > 0`, so a session refetch that
+ * momentarily yields no participants swaps to the empty-ids key, which holds no data.
+ */
+describe('useParticipantPositions holding its list', () => {
+  const row = (userId: string, objectId: string) => ({
+    userId,
+    objectId,
+    spaceId: '019fedae72b67ab2927adf044d57c560',
+    voteType: 0,
+    voteKind: 1,
+  });
+
+  const renderPositions = (initial: DebateRematchParticipant[]) => {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    return renderHook(({ participants }) => useParticipantPositions(participants), {
+      initialProps: { participants: initial },
+      wrapper: ({ children }) => React.createElement(QueryClientProvider, { client }, children),
+    });
+  };
+
+  it('keeps the previous positions on screen while a new set loads', async () => {
+    mocks.attention = true;
+    // One page, short, so `fetchParticipantPositions` stops after it.
+    // `graphql()` returns an Effect of the *decoded* rows — the real one applies the decoder
+    // internally, so succeeding with the decoded shape is the honest stub.
+    mocks.graphql.mockImplementation(() => Effect.succeed([row(LOCAL.profile_space_id, 'claim-1')]));
+
+    const { result, rerender } = renderPositions([LOCAL, REMOTE]);
+    await waitFor(() => expect(result.current.byClaim.size).toBe(1));
+
+    // A different participant set is a different query key, so the cache has nothing for it. The
+    // list must not blank in the meantime — that is the reported bug.
+    // Never settles, so the new key stays pending and only the placeholder can satisfy the assert.
+    mocks.graphql.mockImplementation(() => Effect.never);
+    rerender({ participants: [LOCAL] });
+
+    expect(result.current.byClaim.size).toBe(1);
+  });
 });

--- a/apps/web/core/debates/participant-positions.ts
+++ b/apps/web/core/debates/participant-positions.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import type { TypedDocumentNode } from '@graphql-typed-document-node/core';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { keepPreviousData, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import * as React from 'react';
 
@@ -210,6 +210,27 @@ export function useParticipantPositions(participants: DebateRematchParticipant[]
     // can respond somewhere it doesn't, and that claim should still turn up. A slow poll covers it.
     refetchInterval: foreground ? PARTICIPANT_POSITIONS_POLL_MS : false,
     staleTime: 5_000,
+    /**
+     * Hold the last list while a new one is fetched (GEO-2599). Preston: "randomly the positions
+     * also dissapear. I just lost all of Dovile's positions without doing anything whilst I was
+     * typing."
+     *
+     * Without this, `query.data` is `undefined` for any key the cache has not seen, and `byClaim`
+     * below collapses to an empty map — so the whole list blanks rather than showing the previous
+     * answer. The trigger does not have to be a real change: `enabled` is `profileSpaceIds.length >
+     * 0`, so a session refetch that momentarily yields no participants swaps to the empty-ids key,
+     * which has no data, and every position vanishes with nothing having actually happened.
+     *
+     * Stale rows cannot leak to the wrong people, which is what makes this safe rather than merely
+     * nicer: every read goes through `participantSidesOn`, which matches on the *current*
+     * participants' profile space ids, so a row belonging to someone no longer here is filtered out
+     * rather than displayed.
+     *
+     * Note the key itself is already stable — `profileSpaceIds` is deduped and sorted, and React
+     * Query hashes keys structurally, so a session refetch returning an equal-but-new array is the
+     * same cache entry. This is for the cases where the key genuinely differs.
+     */
+    placeholderData: keepPreviousData,
   });
 
   const byClaim = React.useMemo(() => groupParticipantPositions(query.data ?? []), [query.data]);


### PR DESCRIPTION
## The symptom

From GEO-2599, Preston: *"randomly the positions also dissapear"*.

## Why

`useParticipantPositions` is gated on `enabled: profileSpaceIds.length > 0`, and those space ids are derived from the participant list. When a session transiently reports no participants, the query key swaps to the empty-ids variant — which has no cached data — so the hook returns `undefined` and the list renders empty. When the real key comes back it refetches from scratch.

## The fix

`placeholderData: keepPreviousData` keeps the last successful list on screen across the key swap.

## Test

Hook-level and behavioural, not a config assertion: mount with two participants, switch to one (a deliberately never-settling key), assert the list is still rendered. Mutation-checked — removing `placeholderData` fails it.

Two things the test had to get right that aren't obvious: `graphql()` returns an **Effect**, not a Promise, and the mock must resolve with the *decoded* shape because the real function applies the decoder internally.

## Scope

This is **one of four symptoms** filed under GEO-2599. The other three overlap GEO-2656 (open) and GEO-2687 (in review), so this doesn't close the ticket.