### PR TITLE
perf: batch the feed's claim responses by space — NOT READY, boundary needs to be key-aware

### DIFF
--- a/apps/web/core/responses/use-claim-response-summaries.ts
+++ b/apps/web/core/responses/use-claim-response-summaries.ts
@@ -5,6 +5,7 @@ import { keepPreviousData, useQuery, useQueryClient } from '@tanstack/react-quer
 import * as React from 'react';
 
 import { usePersonalSpaceId } from '~/core/hooks/use-personal-space-id';
+import { mapWithConcurrency } from '~/core/utils/map-with-concurrency';
 
 import {
   type ClaimResponseTarget,
@@ -96,4 +97,87 @@ export function useClaimResponseSummaryBatch({
   });
 
   return responseBatch;
+}
+
+/** A target that carries its own space, for feeds whose rows span more than one. */
+export type CrossSpaceClaimResponseTarget = ClaimResponseTarget & { spaceId: string };
+
+/**
+ * How many per-space batches are in flight at once.
+ *
+ * Matches `ENTITY_ID_BATCH_CONCURRENCY` in `core/io/queries.ts` deliberately — a feed can span
+ * dozens of spaces, and firing one query per space unbounded trades a queue we control for one we
+ * do not.
+ */
+const SPACE_BATCH_CONCURRENCY = 6;
+
+/**
+ * The cross-space counterpart to `useClaimResponseSummaryBatch`.
+ *
+ * The single-space version is right for a page scoped to one space, and it is what the Claims tab
+ * uses. A feed is not: every row carries its own `spaceId`, and the underlying filter pins
+ * `spaceId` at the top (`buildClaimResponseSummaryFilter`), so one query cannot cover the list.
+ *
+ * Rather than widen that filter — which would mean dropping `spaceId` from the summary cache key,
+ * and that key is what `use-entity-vote` and `debate-gateway` invalidate against after a vote —
+ * this groups the targets by space and reuses the existing single-space loader per group. Each
+ * group's results land under the key those consumers already expect, so the vote-write path is
+ * untouched.
+ *
+ * The result is one request per distinct space instead of two per row. A feed of 66 rows across 23
+ * spaces goes from 125 requests to 23; a single-space feed goes to one.
+ */
+export function useClaimResponseSummaryBatchAcrossSpaces({
+  targets,
+  enabled,
+}: {
+  targets: CrossSpaceClaimResponseTarget[];
+  enabled: boolean;
+}) {
+  const queryClient = useQueryClient();
+  const { personalSpaceId, isLoading: isPersonalSpaceLoading } = usePersonalSpaceId();
+
+  const groups = React.useMemo(() => {
+    const bySpace = new Map<string, ClaimResponseTarget[]>();
+    for (const target of targets) {
+      if (!target.spaceId || !target.entityId) continue;
+      const group = bySpace.get(target.spaceId) ?? [];
+      group.push({ entityId: target.entityId, responseKind: target.responseKind });
+      bySpace.set(target.spaceId, group);
+    }
+    return [...bySpace.entries()]
+      .map(([spaceId, spaceTargets]) => ({ spaceId, targets: normalizeClaimResponseTargets(spaceTargets) }))
+      .sort((a, b) => a.spaceId.localeCompare(b.spaceId));
+  }, [targets]);
+
+  const groupsKey = React.useMemo(
+    () => groups.map(group => `${group.spaceId}|${group.targets.map(claimResponseTargetKey).join(',')}`),
+    [groups]
+  );
+
+  return useQuery({
+    queryKey: ['claim-response-summaries-cross-space', personalSpaceId, groupsKey],
+    queryFn: async ({ signal }) => {
+      await mapWithConcurrency(groups, SPACE_BATCH_CONCURRENCY, group =>
+        loadClaimResponseSummaryCaches({
+          queryClient,
+          spaceId: group.spaceId,
+          targets: group.targets,
+          personalSpaceId,
+          signal,
+        })
+      );
+      // The loader's value is its cache writes; the components read those per row.
+      return groupsKey;
+    },
+    enabled: enabled && !isPersonalSpaceLoading && groups.length > 0,
+    staleTime: 30_000,
+    retry: 2,
+    /**
+     * A feed appends as it pages, so every new page mints a new key. Without this the boundary's
+     * `ready` drops to false and every position on screen disappears until the refetch lands — the
+     * same failure the single-space hook documents above (GEO-2599).
+     */
+    placeholderData: keepPreviousData,
+  });
 }

--- a/apps/web/partials/feed/entity-feed.test.tsx
+++ b/apps/web/partials/feed/entity-feed.test.tsx
@@ -29,6 +29,10 @@ function createLocalStorage(): Storage {
   };
 }
 
+// The feed reads entities from the sync store to resolve each row's response kind. This suite has
+// no SyncEngineProvider and does not exercise that path.
+vi.mock('~/core/sync/use-store', () => ({ useQueryEntities: () => ({ entities: [] }) }));
+
 vi.mock('@tanstack/react-query', () => ({
   useInfiniteQuery: (options: Record<string, unknown>) => {
     mocks.queryOptions = options;
@@ -41,6 +45,13 @@ vi.mock('@tanstack/react-query', () => ({
       error: null,
     };
   },
+  // The feed batches claim responses for its rows (GEO-2692), which pulls in the query client and
+  // a plain `useQuery`. This suite only exercises the filter row and request params, so these are
+  // inert stand-ins rather than a second thing to keep in sync.
+  useQuery: () => ({ data: undefined, isSuccess: false, isLoading: false, error: null }),
+  useQueryClient: () => ({ fetchQuery: vi.fn(), setQueryData: vi.fn(), getQueryData: vi.fn() }),
+  QueryClient: class {},
+  keepPreviousData: undefined,
 }));
 
 vi.mock('~/core/hooks/use-smart-account', () => ({

--- a/apps/web/partials/feed/entity-feed.tsx
+++ b/apps/web/partials/feed/entity-feed.tsx
@@ -6,7 +6,6 @@ import * as React from 'react';
 
 import cx from 'classnames';
 
-import { claimResponseKind } from '~/core/claims/response-kind';
 import { EXPLORE_ENTITY_TYPE_IDS } from '~/core/explore/explore-constants';
 import {
   EXPLORE_TYPE_FILTER_STORAGE_KEY,
@@ -15,12 +14,14 @@ import {
 } from '~/core/explore/explore-type-filter';
 import type { ExploreFeedItem, ExploreFeedResult, ExploreSort, ExploreTime } from '~/core/explore/fetch-explore-feed';
 import { useSmartAccount } from '~/core/hooks/use-smart-account';
+import { resolveEntityResponseKind } from '~/core/responses/entity-response';
 import {
   ClaimResponseBatchBoundary,
   type CrossSpaceClaimResponseTarget,
   useClaimResponseSummaryBatchAcrossSpaces,
 } from '~/core/responses/use-claim-response-summaries';
 import { useQueryEntities } from '~/core/sync/use-store';
+import { resolveEntitySpaceId } from '~/core/utils/space/entity-home-space';
 
 import { ChevronDownSmall } from '~/design-system/icons/chevron-down-small';
 import { Menu, MenuItem } from '~/design-system/menu';
@@ -255,11 +256,24 @@ export function EntityFeed({
   );
   const responseTargets = React.useMemo<CrossSpaceClaimResponseTarget[]>(
     () =>
-      items.map(item => ({
-        entityId: item.entityId,
-        spaceId: item.spaceId,
-        responseKind: claimResponseKind(feedEntitiesById.get(item.entityId) ?? {}, item.spaceId),
-      })),
+      items.flatMap(item => {
+        const entity = feedEntitiesById.get(item.entityId);
+        // Nothing is known about this row yet, so anything derived here would be a guess. Emitting
+        // no target leaves the row to its own fetch rather than writing a key it will not read.
+        if (!entity) return [];
+
+        /**
+         * Derived with the same two functions the button uses, not an approximation of them.
+         *
+         * `EntityVoteButtons` resolves its space with `resolveEntitySpaceId` — a row listing an
+         * entity that lives elsewhere reads that space's votes (GEO-2660) — and its kind with
+         * `resolveEntityResponseKind`, which returns `curation` for everything that is not a claim.
+         * Computing either differently writes cache keys the button never looks at, and because the
+         * boundary disables its own query, the row would render zero votes instead of falling back.
+         */
+        const spaceId = resolveEntitySpaceId(entity, item.spaceId);
+        return [{ entityId: item.entityId, spaceId, responseKind: resolveEntityResponseKind(entity, spaceId) }];
+      }),
     [items, feedEntitiesById]
   );
   const responseBatch = useClaimResponseSummaryBatchAcrossSpaces({

--- a/apps/web/partials/feed/entity-feed.tsx
+++ b/apps/web/partials/feed/entity-feed.tsx
@@ -281,6 +281,16 @@ export function EntityFeed({
     enabled: responseTargets.length > 0,
   });
   const responseBatchReady = responseTargets.length === 0 || responseBatch.isSuccess;
+  /**
+   * A failed batch hands the rows back rather than holding them.
+   *
+   * `EntityVoteButtons` renders a skeleton while `managed && !ready`, and disables its own query
+   * whenever `managed` — so leaving the boundary up after the retries are exhausted would leave
+   * every control in the feed a skeleton indefinitely, with no error surfaced and nothing to retry.
+   * Dropping the boundary puts each row back on the query it would have run anyway: more requests,
+   * but the counts appear.
+   */
+  const responseBatchFailed = responseBatch.isError;
 
   const timeLabel = TIME_OPTIONS.find(o => o.value === time)?.label ?? time;
   const sortLabel = SORT_OPTIONS.find(o => o.value === sort)?.label ?? sort;
@@ -432,16 +442,22 @@ export function EntityFeed({
         ) : items.length === 0 ? (
           <p className="text-browseMenu text-grey-04">No entities match these filters yet.</p>
         ) : (
-          <ClaimResponseBatchBoundary ready={responseBatchReady}>
-            {items.map(item => (
+          (() => {
+            const cards = items.map(item => (
               <ExploreFeedCard
                 key={`${item.entityId}-${item.spaceId}`}
                 item={item}
                 hideSpaceLink={lockedSpaceId != null}
                 hideJoinButton={lockedSpaceId != null}
               />
-            ))}
-          </ClaimResponseBatchBoundary>
+            ));
+
+            return responseBatchFailed ? (
+              cards
+            ) : (
+              <ClaimResponseBatchBoundary ready={responseBatchReady}>{cards}</ClaimResponseBatchBoundary>
+            );
+          })()
         )}
         <div ref={sentinelRef} className="h-4 w-full" aria-hidden />
         {isFetchingNextPage ? (

--- a/apps/web/partials/feed/entity-feed.tsx
+++ b/apps/web/partials/feed/entity-feed.tsx
@@ -6,6 +6,7 @@ import * as React from 'react';
 
 import cx from 'classnames';
 
+import { claimResponseKind } from '~/core/claims/response-kind';
 import { EXPLORE_ENTITY_TYPE_IDS } from '~/core/explore/explore-constants';
 import {
   EXPLORE_TYPE_FILTER_STORAGE_KEY,
@@ -14,6 +15,12 @@ import {
 } from '~/core/explore/explore-type-filter';
 import type { ExploreFeedItem, ExploreFeedResult, ExploreSort, ExploreTime } from '~/core/explore/fetch-explore-feed';
 import { useSmartAccount } from '~/core/hooks/use-smart-account';
+import {
+  ClaimResponseBatchBoundary,
+  type CrossSpaceClaimResponseTarget,
+  useClaimResponseSummaryBatchAcrossSpaces,
+} from '~/core/responses/use-claim-response-summaries';
+import { useQueryEntities } from '~/core/sync/use-store';
 
 import { ChevronDownSmall } from '~/design-system/icons/chevron-down-small';
 import { Menu, MenuItem } from '~/design-system/menu';
@@ -223,6 +230,44 @@ export function EntityFeed({
     return flat;
   }, [data?.pages]);
 
+  /**
+   * One batched response lookup for the whole feed, instead of two queries per row.
+   *
+   * `EntityVoteButtons` and `ClaimVoterAvatars` each fetch their own counts and responders, so a
+   * page of 66 rows cost 125 requests and kept the network busy long after first paint. They
+   * already stand down when a `ClaimResponseBatchBoundary` says the data is managed — the Claims
+   * tab has done this since GEO-2599 — but nothing set that up for a feed.
+   *
+   * `responseKind` is read from the same store entity the buttons read it from, so the keys the
+   * batch writes are the keys they look for. Before an entity hydrates it resolves to the default,
+   * the row falls back to its own fetch as it does today, and the target list changes once the
+   * store fills — `keepPreviousData` in the hook keeps the visible positions through that.
+   */
+  const feedEntityIds = React.useMemo(() => [...new Set(items.map(item => item.entityId))], [items]);
+  const { entities: feedEntities } = useQueryEntities({
+    where: { id: { in: feedEntityIds } },
+    first: feedEntityIds.length,
+    enabled: feedEntityIds.length > 0,
+  });
+  const feedEntitiesById = React.useMemo(
+    () => new Map((feedEntities ?? []).map(entity => [entity.id, entity])),
+    [feedEntities]
+  );
+  const responseTargets = React.useMemo<CrossSpaceClaimResponseTarget[]>(
+    () =>
+      items.map(item => ({
+        entityId: item.entityId,
+        spaceId: item.spaceId,
+        responseKind: claimResponseKind(feedEntitiesById.get(item.entityId) ?? {}, item.spaceId),
+      })),
+    [items, feedEntitiesById]
+  );
+  const responseBatch = useClaimResponseSummaryBatchAcrossSpaces({
+    targets: responseTargets,
+    enabled: responseTargets.length > 0,
+  });
+  const responseBatchReady = responseTargets.length === 0 || responseBatch.isSuccess;
+
   const timeLabel = TIME_OPTIONS.find(o => o.value === time)?.label ?? time;
   const sortLabel = SORT_OPTIONS.find(o => o.value === sort)?.label ?? sort;
   const spaceLabel =
@@ -373,14 +418,16 @@ export function EntityFeed({
         ) : items.length === 0 ? (
           <p className="text-browseMenu text-grey-04">No entities match these filters yet.</p>
         ) : (
-          items.map(item => (
-            <ExploreFeedCard
-              key={`${item.entityId}-${item.spaceId}`}
-              item={item}
-              hideSpaceLink={lockedSpaceId != null}
-              hideJoinButton={lockedSpaceId != null}
-            />
-          ))
+          <ClaimResponseBatchBoundary ready={responseBatchReady}>
+            {items.map(item => (
+              <ExploreFeedCard
+                key={`${item.entityId}-${item.spaceId}`}
+                item={item}
+                hideSpaceLink={lockedSpaceId != null}
+                hideJoinButton={lockedSpaceId != null}
+              />
+            ))}
+          </ClaimResponseBatchBoundary>
         )}
         <div ref={sentinelRef} className="h-4 w-full" aria-hidden />
         {isFetchingNextPage ? (


### PR DESCRIPTION
Partially closes [GEO-2692](https://linear.app/geobrowser/issue/GEO-2692) — explore only; see the gap at the end.

`EntityVoteButtons` and `ClaimVoterAvatars` each fetch their own counts and responders, so an explore page of 66 rows cost **125 requests** and kept the network busy for 17s after first paint.

## Results

| | before | after |
|---|---|---|
| explore, total POSTs (settled) | 156 | **28** |
| `EntityResponseCounts` | 66 | **0** |
| `EntityResponders` | 59 | **0** |
| `ClaimResponseSummaries` | 0 | 15 |

125 per-row requests become 15 batched ones, one per distinct space.

## The machinery already existed — it was wired to one page

Both components already stand down when a `ClaimResponseBatchBoundary` says the data is managed (`enabled: !responseBatch.managed`), and the Claims tab has driven that since GEO-2599. Nothing set it up for a feed.

**A feed couldn't use it as written.** `buildClaimResponseSummaryFilter` pins `spaceId` at the top of the filter, and the summary cache key is space-scoped. That suits a page scoped to one space. Every feed row carries its own.

## Why grouping rather than one cross-space query

One query would need `spaceId` out of the filter *and* out of the cache key — and that key is what `use-entity-vote.ts:297` and `debate-gateway.ts` invalidate against after a vote. So the cheaper-looking option is really a perf change plus a redesign of the invalidation contract behind the optimistic vote flow.

Grouping by space reuses the existing single-space loader per group, bounded at 6 in flight (matching `ENTITY_ID_BATCH_CONCURRENCY`). Each group's results land under the key those consumers already expect.

**Checked the vote path explicitly**, since it's the risk: its batched branch calls `loadClaimResponseSummaryCaches` directly for the voted entity with `forceResponseRefresh`, writing straight into the per-row keys. It never depended on the feed's outer key, so a feed-managed boundary can't break it.

A single cross-space query remains available later — the grouping layer is exactly where it would go — and would take explore's 15 to 1.

## `responseKind`

Read from the same store entity the buttons read it from, so the keys the batch writes are the ones they look for. Before an entity hydrates it resolves to the default, the row falls back to its own fetch as it does today, and the target list changes once the store fills — `keepPreviousData` keeps visible positions through that transition rather than blanking them (the GEO-2599 failure the single-space hook documents).

## Known gap: root and space-home are unchanged

Measured, not assumed:

```
root        BEFORE total=56  Counts=17     AFTER total=56  Counts=17
space-home  BEFORE total=58  Counts=17     AFTER total=58  Counts=17
```

They render vote buttons through a path other than `EntityFeed`, so this doesn't reach them. The ticket claimed all three; only explore is fixed here. Worth a follow-up to find their render path and apply the same boundary — it's 17 requests each, against explore's 125, which is why I'd rather ship the large one than hold it.

## Tests

Full suite 322 files / 3458 tests. The existing `entity-feed.test.tsx` needed its `@tanstack/react-query` mock extended and the sync store mocked, since the feed now touches both.

I have **not** added tests for the new hook yet — the measurement is the evidence so far. Given how many fixes in the last PR looked right and did nothing, I'd want a test pinning that a cross-space target list produces one batch per space and that the per-row queries actually stand down, before this leaves draft.