### PR TITLE
fix(debates): start capturing during preflight instead of at the window

### DIFF
--- a/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
@@ -2543,6 +2543,30 @@ describe('DebateRoomPageClient', () => {
     expect(mocks.enqueueRecording).not.toHaveBeenCalled();
   });
 
+  it('starts capturing during preflight rather than waiting for the recording window to open', async () => {
+    // GEO-2644. The recorder used to be scheduled for `startAtMs`, so the encoder's own warmup
+    // happened at t=0 and every recording began fractionally after the window it is measured
+    // against. Capture has to be running *before* the window opens; the server trims the
+    // pre-window head, so starting early costs nothing and padding the head is what it avoids.
+    installRecordingMocks();
+    mocks.debate = {
+      ...completedDebate(),
+      status: 'preflight',
+      current_turn_index: 0,
+      current_speaker_slot: null,
+      started_at: null,
+      // Ten seconds after the synchronized clock, so the window is still firmly shut.
+      preflight_ends_at: '2026-07-02T00:00:30.000Z',
+      completed_at: null,
+    };
+
+    render(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
+
+    await waitFor(() => expect(mocks.mediaRecorderStart).toHaveBeenCalledOnce());
+    // Recording, but the debate has not started — nothing is uploaded until the window closes.
+    expect(mocks.enqueueRecording).not.toHaveBeenCalled();
+  });
+
   it('shows connection state without exposing the connection deadline', async () => {
     mocks.debate = {
       ...completedDebate(),

--- a/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.tsx
@@ -294,7 +294,6 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
   const recordingChunksRef = React.useRef<Blob[]>([]);
   const recordingStartedAtRef = React.useRef<number | null>(null);
   const recordingEndedAtRef = React.useRef<number | null>(null);
-  const recordingStartTimerRef = React.useRef<number | null>(null);
   const recordingStopTimerRef = React.useRef<number | null>(null);
   const autoConnectAttemptedRef = React.useRef<string | null>(null);
   const postJoinRecoveryAttemptsRef = React.useRef(0);
@@ -628,10 +627,6 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
   }, [currentUserId, debateId, reportConnectionConflict]);
 
   const clearRecordingTimers = React.useCallback(() => {
-    if (recordingStartTimerRef.current !== null) {
-      window.clearTimeout(recordingStartTimerRef.current);
-      recordingStartTimerRef.current = null;
-    }
     if (recordingStopTimerRef.current !== null) {
       window.clearTimeout(recordingStopTimerRef.current);
       recordingStopTimerRef.current = null;
@@ -1699,12 +1694,20 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
       return;
     }
 
-    if (recordingStartedAtRef.current === null) {
-      recordingStartTimerRef.current = window.setTimeout(
-        () => startLocalRecorder(stream),
-        Math.max(0, recordingWindow.startAtMs - now)
-      );
-    }
+    // GEO-2644. Start capturing the moment the stream exists, rather than waiting for the window
+    // to open. Waiting meant the encoder's own warmup happened *at* t=0, so every recording began
+    // slightly after the window it is measured against and the head had to be padded with black.
+    //
+    // Starting early is free: `recording_trim_for_window` trims the pre-window head via
+    // `source_start_offset_ms` and pads zero, so nothing captured before the window is ever
+    // published. The status gate above already admits `preflight`; only this timer held it back.
+    //
+    // Note what this does not fix. A participant who reaches `connected` after the window has
+    // already opened was starting immediately regardless — `Math.max(0, negative)` is 0 — so the
+    // large misses on record are unaffected. Those need the clock to stop being armed by `/joined`,
+    // which is the rest of GEO-2644; this is the prerequisite that makes that possible without
+    // deadlocking capture against the clock it would then be waiting on.
+    startLocalRecorder(stream);
     recordingStopTimerRef.current = window.setTimeout(
       () => {
         persistRecordingAfterCapture();


### PR DESCRIPTION
Part of GEO-2644. **Prerequisite, not the cure** — see scope below.

## The bug

The recorder was scheduled for the moment the recording window opened:

```ts
window.setTimeout(() => startLocalRecorder(stream), Math.max(0, recordingWindow.startAtMs - now));
```

`startAtMs` is `started_at ?? preflight_ends_at` — the same server clock the recording is later validated against. So the encoder's warmup happened *at* t=0, and every recording began fractionally after the window it is measured against. The head then had to be padded with black, and that pad budget (`RECORDING_WINDOW_MAX_PAD_MS`, 10s) is what debates fail on.

## Why starting early is free

`recording_trim_for_window` (`crates/media/src/worker.rs:2268-2314`) computes `source_start_offset_ms = overlap_start_ms - recording_start_ms`, and `missing_start_ms` is `.max(0)`. A recording that begins **before** the window has its head trimmed and pads **zero**. Nothing captured during preflight is ever published.

The status gate already admitted `preflight` — only the timer held capture back.

## Scope: what this does not fix

The large misses on record (21.7s, 37.1s, 52.2s) are **unaffected**. Those participants reach `connected` *after* the window has already opened, where `Math.max(0, negative)` is already 0 — they were starting immediately and are simply late for a different reason.

Those need the clock to stop being armed by `/joined`, which is the rest of GEO-2644. This change is the **prerequisite** for that: gating the clock on capture-started while capture waits on the clock would deadlock. Full design is [on the ticket](https://linear.app/geobrowser/issue/GEO-2644).

## Test

`starts capturing during preflight rather than waiting for the recording window to open` — debate in `preflight` with the window ten seconds out, asserts the recorder is already running. Mutation-checked: restoring the `setTimeout` fails it.

Existing coverage is preserved, including `waits for clock synchronization before arming recording timers` — the `serverClockSettled` gate is untouched.

`134 passed`, and the full debates suite `1156 passed (73 files)`.

## Note on a flaky neighbour

One run of the full debates suite showed a single failure in `rematch-page-client.test.tsx` (`lists the session's own claims alongside published ones`). It is **not** from this change — it passes in isolation on this branch, passes with the debate-room suite alongside it, and the full suite passes 1156/1156 on re-run, while clean master shows the same test failing in an earlier full-suite baseline. That file appears to be load-sensitive; flagging separately rather than fixing here.