### PR TITLE
fix(debates): drop the feed's own back arrow on mobile

### DIFF
--- a/apps/web/core/debates/browse/debate-feed.test.tsx
+++ b/apps/web/core/debates/browse/debate-feed.test.tsx
@@ -212,7 +212,9 @@ describe('DebatesBrowseFeed video sharing', () => {
 
     const heading = screen.getByRole('heading', { name: 'Debates are useful' });
     expect(screen.getByRole('button', { name: 'Join a debate' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Back' })).toHaveClass('size-8', 'justify-center', '-mb-3');
+    // The feed carried its own back arrow on mobile because it covers the navbar there. The
+    // browser's own back is the way out now, so nothing in the feed should offer a second one.
+    expect(screen.queryByRole('button', { name: 'Back' })).not.toBeInTheDocument();
     const feedItem = heading.closest('section');
     assert(feedItem, 'Expected the debate heading to be rendered inside a feed item');
     // `pt-5` is the design's 20px gap under the navbar; `md:py-3` overrides it on mobile.

--- a/apps/web/core/debates/browse/debate-feed.tsx
+++ b/apps/web/core/debates/browse/debate-feed.tsx
@@ -19,7 +19,6 @@ import { useQueryEntities } from '~/core/sync/use-store';
 
 import { Avatar } from '~/design-system/avatar';
 import { Button } from '~/design-system/button';
-import { ArrowLeft } from '~/design-system/icons/arrow-left';
 import { Text } from '~/design-system/text';
 
 import { EntityCommentsPanel } from '~/partials/comments/entity-comments-panel';
@@ -389,16 +388,6 @@ function DebateFeedItem({
           className="relative flex w-[var(--debate-feed-column-width)] min-w-0 flex-col md:w-[calc(100vw-1rem)]"
           style={DEBATE_COLUMN_STYLE}
         >
-          {/* Mobile-only back arrow; desktop keeps the app nav. NB: breakpoints
-              here are desktop-first (md = max-width:767px), so md: targets mobile. */}
-          <button
-            type="button"
-            aria-label="Back"
-            onClick={() => window.history.back()}
-            className="-mb-3 hidden size-8 items-center justify-center text-text md:flex"
-          >
-            <ArrowLeft />
-          </button>
           <div className="md:mt-4">
             <DebateTitleHeader
               key={debate.claim.claim}


### PR DESCRIPTION
Closes [GEO-2716](https://linear.app/geobrowser/issue/GEO-2716/debates-feed-remove-the-mobile-only-back-arrow-from-the-top-left).

Removes the back arrow above the space chip in the debates browse feed. It rendered below 768px only (`hidden … md:flex`, and `md` is `max-width: 767px` here).

```
core/debates/browse/debate-feed.tsx        -11
core/debates/browse/debate-feed.test.tsx    +3 -1
```

## Why it existed, and why it can go

It was deliberate: the feed is `fixed inset-0 z-[70]` on mobile and covers the navbar, so the app's own back affordance is unreachable while browsing, and the arrow filled that gap.

The browser's back already covers it — the swipe gesture in mobile Safari, the toolbar arrow in an in-app browser. Confirmed as an acceptable outcome on the ticket. The one case it does not cover is a PWA in standalone display mode, which has neither; that is the tradeoff being taken, not an oversight.

`ArrowLeft` was imported for this and nothing else, so the import goes with it.

## One thing to look at on a phone

`-mb-3` on the button and `md:mt-4` on the header wrapper were **added together** in [#2121](https://github.com/geobrowser/geogenesis/pull/2121) — they were a tuned pair, positioning the header relative to the arrow. Removing the arrow leaves `md:mt-4` doing a different job than it was set for.

Net effect on mobile, above the space chip:

| | before | after |
|---|---|---|
| back arrow | `size-8` = 2rem | — |
| its `-mb-3` | −0.75rem | — |
| header `md:mt-4` | 1rem | 1rem |
| **total** | **2.25rem** | **1rem** |

So the claim moves up 1.25rem, which is the point — the arrow's space is reclaimed. I kept `md:mt-4` rather than removing it too, on the grounds that it still gives the chip breathing room from the top edge and dropping both would leave the header flush against the section's `md:py-3` alone. That is a judgment call and the exact gap is worth your eye, since it is the one thing here a test cannot tell you. Easy to drop the `md:mt-4` as well if it reads as too much now.

## Tests

The suite pinned the button's classes (`size-8`, `justify-center`, `-mb-3`) in `uses the full-screen responsive layout and design copy`. That assertion is inverted rather than deleted — it now asserts no `Back` button is in the document, so nothing puts a second back control in the feed later without someone noticing.

Checked for other references: nothing else in the app or in e2e touches it.

`72 files / 1167 tests` pass across `core/debates` and `app/space/[id]/(space)/debates`. `tsc` clean apart from the four pre-existing errors tracked in [GEO-2699](https://linear.app/geobrowser/issue/GEO-2699/tooling-nothing-type-checks-test-files-and-four-type-errors-have). Lint and build clean.