### PR TITLE
fix(chat): keep the assistant launcher off the mobile debates feed

### DIFF
--- a/apps/web/core/hooks/use-is-compact-layout.ts
+++ b/apps/web/core/hooks/use-is-compact-layout.ts
@@ -1,0 +1,34 @@
+'use client';
+
+import * as React from 'react';
+
+/**
+ * Matches `@custom-variant md` in styles.css (`max-width: 767px`) — the width at which surfaces
+ * that go full-bleed on phones actually do so.
+ *
+ * Distinct from the app-wide `useIsMobileLayout` (1023px), which is the sidebar's threshold: a
+ * viewport can be "mobile" by that measure while a full-bleed surface is still laid out as
+ * desktop, so the two are not interchangeable.
+ */
+export const COMPACT_LAYOUT_MAX_WIDTH_PX = 767;
+
+const QUERY = `(max-width: ${COMPACT_LAYOUT_MAX_WIDTH_PX}px)`;
+
+function subscribe(onStoreChange: () => void) {
+  const mq = window.matchMedia(QUERY);
+  mq.addEventListener('change', onStoreChange);
+  return () => mq.removeEventListener('change', onStoreChange);
+}
+
+function getSnapshot() {
+  return window.matchMedia(QUERY).matches;
+}
+
+function getServerSnapshot() {
+  return false;
+}
+
+/** True when the viewport is at most 767px wide (the project's `md:` breakpoint). */
+export function useIsCompactLayout() {
+  return React.useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}

--- a/apps/web/partials/chat/assistant-visibility.test.ts
+++ b/apps/web/partials/chat/assistant-visibility.test.ts
@@ -2,51 +2,53 @@ import { describe, expect, it } from 'vitest';
 
 import { shouldHideAssistant } from './assistant-visibility';
 
-const FEED = '/space/25omwWh6HYgeRQKCaSpVpa/debates';
-const WIDE = false;
-const COMPACT = true;
+const SPACE = '25omwWh6HYgeRQKCaSpVpa';
+const FEED_ROUTE = `/space/${SPACE}/debates`;
+// What a shared debate link opens: the same feed, rendered by DebateEntityView under the generic
+// entity route. Nothing in this path says "debate".
+const ENTITY_ROUTE = `/space/${SPACE}/8f2c1d4e9a0b4c7d8e5f6a7b8c9d0e1f`;
+const TAKEOVER = true;
+const NO_TAKEOVER = false;
 
 describe('shouldHideAssistant', () => {
-  // The launcher is fixed bottom-right at z-1100. Below `md` the feed is full-bleed and its
+  // The launcher is fixed bottom-right at z-1100. While the feed fills a compact viewport its
   // interaction bar runs horizontally under the videos, putting share directly beneath it.
-  it('hides on the debates feed only once the layout is compact', () => {
-    expect(shouldHideAssistant(FEED, COMPACT)).toBe(true);
-    expect(shouldHideAssistant(FEED, WIDE)).toBe(false);
+  it('hides wherever the feed has taken over a compact viewport', () => {
+    expect(shouldHideAssistant(FEED_ROUTE, TAKEOVER)).toBe(true);
+    // The route this is really about: a shared link, where the path gives nothing away.
+    expect(shouldHideAssistant(ENTITY_ROUTE, TAKEOVER)).toBe(true);
   });
 
-  // Its bar is a vertical rail beside the column at this width, so there is nothing to obstruct
-  // and no reason to take the assistant away.
-  it('leaves the desktop feed alone', () => {
-    expect(shouldHideAssistant(FEED, WIDE)).toBe(false);
+  // Wider viewports put that bar in a vertical rail beside the column, so nothing is obstructed
+  // and there is no reason to take the assistant away.
+  it('leaves both routes alone when the feed is not a compact takeover', () => {
+    expect(shouldHideAssistant(FEED_ROUTE, NO_TAKEOVER)).toBe(false);
+    expect(shouldHideAssistant(ENTITY_ROUTE, NO_TAKEOVER)).toBe(false);
   });
 
-  // Full-screen at every width and parks a voice dock in the same corner, so width is irrelevant.
-  it('keeps hiding on the rematch picker at any width', () => {
-    const picker = '/space/25omwWh6HYgeRQKCaSpVpa/debates/rematches/session-1';
-    expect(shouldHideAssistant(picker, COMPACT)).toBe(true);
-    expect(shouldHideAssistant(picker, WIDE)).toBe(true);
+  // Full-screen at every width and parks a voice dock in the same corner, so the takeover flag
+  // is irrelevant to it.
+  it('keeps hiding on the rematch picker either way', () => {
+    const picker = `/space/${SPACE}/debates/rematches/session-1`;
+    expect(shouldHideAssistant(picker, TAKEOVER)).toBe(true);
+    expect(shouldHideAssistant(picker, NO_TAKEOVER)).toBe(true);
   });
 
-  it('keeps hiding on ranking-compose at any width', () => {
-    const compose = '/space/25omwWh6HYgeRQKCaSpVpa/ranking-compose';
-    expect(shouldHideAssistant(compose, COMPACT)).toBe(true);
-    expect(shouldHideAssistant(compose, WIDE)).toBe(true);
+  it('keeps hiding on ranking-compose either way', () => {
+    const compose = `/space/${SPACE}/ranking-compose`;
+    expect(shouldHideAssistant(compose, TAKEOVER)).toBe(true);
+    expect(shouldHideAssistant(compose, NO_TAKEOVER)).toBe(true);
   });
 
-  // The pattern is anchored, so it must not swallow the room or anything nested under it.
-  it('does not match routes below the feed', () => {
-    for (const pathname of [
-      '/space/25omwWh6HYgeRQKCaSpVpa/debates/debate-1',
-      '/space/25omwWh6HYgeRQKCaSpVpa/debates/rematches',
-    ]) {
-      expect(shouldHideAssistant(pathname, COMPACT)).toBe(false);
-    }
+  // An ordinary entity page is the same path shape as the shared-link case above, so nothing may
+  // hang off the path — only off the takeover the feed announces.
+  it('leaves an ordinary entity page alone', () => {
+    expect(shouldHideAssistant(ENTITY_ROUTE, NO_TAKEOVER)).toBe(false);
   });
 
-  it('leaves unrelated routes alone at both widths', () => {
-    for (const pathname of ['/', '/root', '/space/25omwWh6HYgeRQKCaSpVpa', '/space/25omwWh6HYgeRQKCaSpVpa/community']) {
-      expect(shouldHideAssistant(pathname, COMPACT)).toBe(false);
-      expect(shouldHideAssistant(pathname, WIDE)).toBe(false);
+  it('leaves unrelated routes alone either way', () => {
+    for (const pathname of ['/', '/root', `/space/${SPACE}`, `/space/${SPACE}/community`]) {
+      expect(shouldHideAssistant(pathname, NO_TAKEOVER)).toBe(false);
     }
   });
 });

--- a/apps/web/partials/chat/assistant-visibility.test.ts
+++ b/apps/web/partials/chat/assistant-visibility.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+
+import { shouldHideAssistant } from './assistant-visibility';
+
+const FEED = '/space/25omwWh6HYgeRQKCaSpVpa/debates';
+const WIDE = false;
+const COMPACT = true;
+
+describe('shouldHideAssistant', () => {
+  // The launcher is fixed bottom-right at z-1100. Below `md` the feed is full-bleed and its
+  // interaction bar runs horizontally under the videos, putting share directly beneath it.
+  it('hides on the debates feed only once the layout is compact', () => {
+    expect(shouldHideAssistant(FEED, COMPACT)).toBe(true);
+    expect(shouldHideAssistant(FEED, WIDE)).toBe(false);
+  });
+
+  // Its bar is a vertical rail beside the column at this width, so there is nothing to obstruct
+  // and no reason to take the assistant away.
+  it('leaves the desktop feed alone', () => {
+    expect(shouldHideAssistant(FEED, WIDE)).toBe(false);
+  });
+
+  // Full-screen at every width and parks a voice dock in the same corner, so width is irrelevant.
+  it('keeps hiding on the rematch picker at any width', () => {
+    const picker = '/space/25omwWh6HYgeRQKCaSpVpa/debates/rematches/session-1';
+    expect(shouldHideAssistant(picker, COMPACT)).toBe(true);
+    expect(shouldHideAssistant(picker, WIDE)).toBe(true);
+  });
+
+  it('keeps hiding on ranking-compose at any width', () => {
+    const compose = '/space/25omwWh6HYgeRQKCaSpVpa/ranking-compose';
+    expect(shouldHideAssistant(compose, COMPACT)).toBe(true);
+    expect(shouldHideAssistant(compose, WIDE)).toBe(true);
+  });
+
+  // The pattern is anchored, so it must not swallow the room or anything nested under it.
+  it('does not match routes below the feed', () => {
+    for (const pathname of [
+      '/space/25omwWh6HYgeRQKCaSpVpa/debates/debate-1',
+      '/space/25omwWh6HYgeRQKCaSpVpa/debates/rematches',
+    ]) {
+      expect(shouldHideAssistant(pathname, COMPACT)).toBe(false);
+    }
+  });
+
+  it('leaves unrelated routes alone at both widths', () => {
+    for (const pathname of ['/', '/root', '/space/25omwWh6HYgeRQKCaSpVpa', '/space/25omwWh6HYgeRQKCaSpVpa/community']) {
+      expect(shouldHideAssistant(pathname, COMPACT)).toBe(false);
+      expect(shouldHideAssistant(pathname, WIDE)).toBe(false);
+    }
+  });
+});

--- a/apps/web/partials/chat/assistant-visibility.ts
+++ b/apps/web/partials/chat/assistant-visibility.ts
@@ -1,16 +1,10 @@
-/** Routes whose own full-screen chrome would sit under the assistant's floating launcher. */
+/** Routes and surfaces whose own chrome would sit under the assistant's floating launcher. */
 
 const FULLSCREEN_CHILD_ROUTE_SUFFIXES = ['/ranking-compose'] as const;
 
 // The claim-exploration picker is its own full-screen overlay, and it parks a voice dock in the
 // bottom-right corner — exactly where the assistant's launcher floats.
 const FULLSCREEN_CHILD_ROUTE_PATTERNS = [/\/debates\/rematches\/[^/]+$/] as const;
-
-// The debates browse feed is full-bleed only below `md`, where its interaction bar becomes a
-// horizontal row under the videos and puts share directly beneath the launcher. Wider than that
-// the bar is a vertical rail beside the column and nothing overlaps — so unlike the routes above,
-// this one is hidden by width as well as by path rather than everywhere.
-const COMPACT_FULLSCREEN_ROUTE_PATTERNS = [/\/space\/[^/]+\/debates$/] as const;
 
 function isFullscreenChildRoute(pathname: string): boolean {
   return (
@@ -19,17 +13,16 @@ function isFullscreenChildRoute(pathname: string): boolean {
   );
 }
 
-function isCompactFullscreenRoute(pathname: string): boolean {
-  return COMPACT_FULLSCREEN_ROUTE_PATTERNS.some(pattern => pattern.test(pathname));
-}
-
 /**
  * Whether the assistant should keep out of the way entirely — no launcher, no panel, no hotkey.
  *
- * `isCompactLayout` is the project's `md:` breakpoint (at most 767px), not the app-wide mobile
- * threshold: between the two the debates feed is still laid out as desktop, so hiding there would
- * take the assistant away from a screen it does not obstruct.
+ * `hasCompactTakeover` is the debates feed filling the viewport at a width where its interaction
+ * bar runs horizontally under the videos, putting share directly beneath the launcher. It is not
+ * a route test on purpose: the same feed renders both at `/space/{id}/debates` and on a Debate
+ * entity page at `/space/{id}/{entityId}`, which is what a shared link opens — and on that route
+ * the path alone cannot tell a Debate from any other entity. The feed already announces itself
+ * through `debateFullscreenActiveAtom` for the app shell, so that is the honest signal to read.
  */
-export function shouldHideAssistant(pathname: string, isCompactLayout: boolean): boolean {
-  return isFullscreenChildRoute(pathname) || (isCompactLayout && isCompactFullscreenRoute(pathname));
+export function shouldHideAssistant(pathname: string, hasCompactTakeover: boolean): boolean {
+  return isFullscreenChildRoute(pathname) || hasCompactTakeover;
 }

--- a/apps/web/partials/chat/assistant-visibility.ts
+++ b/apps/web/partials/chat/assistant-visibility.ts
@@ -1,0 +1,35 @@
+/** Routes whose own full-screen chrome would sit under the assistant's floating launcher. */
+
+const FULLSCREEN_CHILD_ROUTE_SUFFIXES = ['/ranking-compose'] as const;
+
+// The claim-exploration picker is its own full-screen overlay, and it parks a voice dock in the
+// bottom-right corner — exactly where the assistant's launcher floats.
+const FULLSCREEN_CHILD_ROUTE_PATTERNS = [/\/debates\/rematches\/[^/]+$/] as const;
+
+// The debates browse feed is full-bleed only below `md`, where its interaction bar becomes a
+// horizontal row under the videos and puts share directly beneath the launcher. Wider than that
+// the bar is a vertical rail beside the column and nothing overlaps — so unlike the routes above,
+// this one is hidden by width as well as by path rather than everywhere.
+const COMPACT_FULLSCREEN_ROUTE_PATTERNS = [/\/space\/[^/]+\/debates$/] as const;
+
+function isFullscreenChildRoute(pathname: string): boolean {
+  return (
+    FULLSCREEN_CHILD_ROUTE_SUFFIXES.some(suffix => pathname.endsWith(suffix)) ||
+    FULLSCREEN_CHILD_ROUTE_PATTERNS.some(pattern => pattern.test(pathname))
+  );
+}
+
+function isCompactFullscreenRoute(pathname: string): boolean {
+  return COMPACT_FULLSCREEN_ROUTE_PATTERNS.some(pattern => pattern.test(pathname));
+}
+
+/**
+ * Whether the assistant should keep out of the way entirely — no launcher, no panel, no hotkey.
+ *
+ * `isCompactLayout` is the project's `md:` breakpoint (at most 767px), not the app-wide mobile
+ * threshold: between the two the debates feed is still laid out as desktop, so hiding there would
+ * take the assistant away from a screen it does not obstruct.
+ */
+export function shouldHideAssistant(pathname: string, isCompactLayout: boolean): boolean {
+  return isFullscreenChildRoute(pathname) || (isCompactLayout && isCompactFullscreenRoute(pathname));
+}

--- a/apps/web/partials/chat/chat-widget.tsx
+++ b/apps/web/partials/chat/chat-widget.tsx
@@ -50,6 +50,8 @@ import { NavUtils } from '~/core/utils/utils';
 
 import { AssistantSparkle } from '~/design-system/icons/assistant-sparkle';
 
+import { debateFullscreenActiveAtom } from '~/atoms';
+
 import { shouldHideAssistant } from './assistant-visibility';
 import { ChatPanel } from './chat-panel';
 
@@ -200,7 +202,9 @@ export function ChatWidget() {
 
   const pathname = usePathname() ?? '';
   const isCompactLayout = useIsCompactLayout();
-  const hideAssistantOnRoute = shouldHideAssistant(pathname, isCompactLayout);
+  // The feed sets this while it fills the viewport, on whichever route it is rendering under.
+  const debateFullscreenActive = useAtomValue(debateFullscreenActiveAtom);
+  const hideAssistantOnRoute = shouldHideAssistant(pathname, isCompactLayout && debateFullscreenActive);
   const params = useParams();
 
   React.useLayoutEffect(() => {

--- a/apps/web/partials/chat/chat-widget.tsx
+++ b/apps/web/partials/chat/chat-widget.tsx
@@ -29,6 +29,7 @@ import { useSearchImagesDispatcher } from '~/core/chat/search-images-dispatcher'
 import { useWebFetchDispatcher } from '~/core/chat/web-fetch-dispatcher';
 import { ROOT_SPACE } from '~/core/constants';
 import { useInjectJob } from '~/core/hooks/use-inject-job';
+import { useIsCompactLayout } from '~/core/hooks/use-is-compact-layout';
 import { useSpace } from '~/core/hooks/use-space';
 import { completeDailyUploadActivity } from '~/core/space/use-space-daily-activities';
 import {
@@ -49,24 +50,12 @@ import { NavUtils } from '~/core/utils/utils';
 
 import { AssistantSparkle } from '~/design-system/icons/assistant-sparkle';
 
+import { shouldHideAssistant } from './assistant-visibility';
 import { ChatPanel } from './chat-panel';
 
 type AssistantSuggestionSource = 'welcome' | 'follow_up';
 type AssistantPanelAction = 'opened' | 'closed';
 type AssistantMessageSource = 'typed' | 'option_click';
-
-const FULLSCREEN_CHILD_ROUTE_SUFFIXES = ['/ranking-compose'] as const;
-
-// The claim-exploration picker is its own full-screen overlay, and it parks a voice dock in the
-// bottom-right corner — exactly where the assistant's launcher floats.
-const FULLSCREEN_CHILD_ROUTE_PATTERNS = [/\/debates\/rematches\/[^/]+$/] as const;
-
-function isFullscreenChildRoute(pathname: string): boolean {
-  return (
-    FULLSCREEN_CHILD_ROUTE_SUFFIXES.some(suffix => pathname.endsWith(suffix)) ||
-    FULLSCREEN_CHILD_ROUTE_PATTERNS.some(pattern => pattern.test(pathname))
-  );
-}
 
 // Guard router.push against hallucinated id shapes.
 function validId(value: string | undefined): value is string {
@@ -210,7 +199,8 @@ export function ChatWidget() {
   const currentChatIdRef = React.useRef<string | null>(persistedCurrent?.id ?? null);
 
   const pathname = usePathname() ?? '';
-  const hideAssistantOnRoute = isFullscreenChildRoute(pathname);
+  const isCompactLayout = useIsCompactLayout();
+  const hideAssistantOnRoute = shouldHideAssistant(pathname, isCompactLayout);
   const params = useParams();
 
   React.useLayoutEffect(() => {


### PR DESCRIPTION
Closes [GEO-2719](https://linear.app/geobrowser/issue/GEO-2719/debates-feed-the-assistant-launcher-covers-the-share-button-on-mobile).

The assistant's floating launcher sat on top of the debates feed's share button on mobile.

```
partials/chat/assistant-visibility.ts        new
partials/chat/assistant-visibility.test.ts   new
partials/chat/chat-widget.tsx                +5 -14
core/hooks/use-is-compact-layout.ts          new
```

## Why they collide, and only on mobile

The launcher is `fixed right-4 bottom-[max(1rem,env(safe-area-inset-bottom))] z-1100`.

Below 768px the feed goes full-bleed (`md:fixed md:inset-0 md:z-[70]`) and its interaction bar becomes a **horizontal** row under the videos, with share at the right end — directly under the launcher, which outranks it. Above that width the same bar is a **vertical rail** beside the video column, so nothing overlaps.

## Not a route test, and that is the point

`chat-widget` already hides itself per route, and the obvious fix was to add `/space/{id}/debates` to that list. **That does not work**, and testing on a shared link is how it showed:

`DebateEntityView` renders the same feed under the generic entity page at `/space/{id}/{entityId}`, which is the route a shared debate link opens. On that path a Debate is indistinguishable from any other entity, so no pattern can match it without also hiding the assistant on every entity page.

The feed already announces itself for exactly this reason — it sets `debateFullscreenActiveAtom` so the app shell drops its page chrome, on whichever route it is rendering under, and deliberately not on the fallback path where an ordinary entity page renders. That is the honest signal, so the predicate takes the takeover rather than a second path pattern.

## Width still matters

The takeover happens at every width; the collision does not. So the hide is `isCompactLayout && debateFullscreenActive`.

**`useIsMobileLayout` is the wrong threshold** and worth being explicit about: it is `max-width: 1023px`, the sidebar's breakpoint. Between 768 and 1023 the feed is still laid out as desktop with the vertical rail, so using it would hide the launcher on screens it does not obstruct. `useIsCompactLayout` is the project's `md:` variant (767px) — the same number the feed itself uses — and its doc comment says why the two are not interchangeable.

## The rule moved out of the widget

`chat-widget.tsx` has no tests, and rendering it means standing up transports, atoms and a dozen hooks to assert a boolean. The predicate is pure, so it moved to `assistant-visibility.ts` and is tested directly. That is why the diff there is `+5 -14` rather than purely additive — the existing route constants moved with it, unchanged.

## Tests

Six cases in `assistant-visibility.test.ts`, including the one this PR got wrong first time round: **a shared-link entity path hides when the feed has taken over, and an identical path does not when it has not** — so nothing can go back to keying off the route.

Also covered: the rematch picker and `ranking-compose` keep hiding regardless of the takeover flag, and unrelated routes are untouched.

The contract this now leans on was already tested from the other side — `debate-feed.test.tsx` asserts the atom is set while the feed is on screen and left alone on the fallback path.

**The one seam without coverage** is the wiring in `chat-widget` itself: that the widget reads the atom and combines it with the width. It is a single expression, but it is also precisely where the first version of this went wrong, so it is worth saying plainly rather than implying the tests cover more than they do.

Full suite: **327 files / 3537 tests** pass. `tsc` clean apart from the four pre-existing errors tracked in [GEO-2699](https://linear.app/geobrowser/issue/GEO-2699/tooling-nothing-type-checks-test-files-and-four-type-errors-have). Lint and build clean.

## Note

Hiding the launcher also disables the assistant's hotkey and closes an open panel — existing behaviour of the same flag, now reaching one more surface at one more width.