### PR TITLE
feat(debates): link the feed's space chip and claim title

### DIFF
--- a/apps/web/app/space/[id]/(space)/debates/debates-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/debates-page-client.test.tsx
@@ -37,7 +37,13 @@ vi.mock('~/partials/entity-page/entity-vote-buttons', () => ({
 }));
 
 vi.mock('next/navigation', () => ({
-  useRouter: () => ({ replace: mocks.replace }),
+  // `prefetch` is for PrefetchLink, which the feed header's space and claim links use.
+  useRouter: () => ({ replace: mocks.replace, prefetch: vi.fn() }),
+}));
+
+// PrefetchLink hydrates the entity it points at on hover, which reaches for the sync engine.
+vi.mock('~/core/sync/use-sync-engine', () => ({
+  useSyncEngine: () => ({ hydrate: vi.fn() }),
 }));
 
 vi.mock('~/core/state/feature-flags', () => ({

--- a/apps/web/core/debates/browse/debate-feed.test.tsx
+++ b/apps/web/core/debates/browse/debate-feed.test.tsx
@@ -86,6 +86,16 @@ vi.mock('~/core/hooks/use-space', () => ({
   useSpace: () => ({ space: { entity: { name: 'Fashion', image: null } }, isLoading: false }),
 }));
 
+// PrefetchLink hydrates the entity it points at on hover, so it reaches for the sync engine and
+// the router. Stubbing those keeps the real anchor — and therefore the real hrefs — under test.
+vi.mock('~/core/sync/use-sync-engine', () => ({
+  useSyncEngine: () => ({ hydrate: vi.fn() }),
+}));
+vi.mock('next/navigation', async () => {
+  const actual = await vi.importActual<typeof import('next/navigation')>('next/navigation');
+  return { ...actual, useRouter: () => ({ prefetch: vi.fn(), push: vi.fn(), replace: vi.fn(), back: vi.fn() }) };
+});
+
 vi.mock('~/core/sync/use-store', () => ({
   useQueryEntities: () => ({ entities: [], isLoading: false }),
 }));
@@ -215,6 +225,31 @@ afterEach(() => {
   cleanup();
   vi.useRealTimers();
   vi.unstubAllGlobals();
+});
+
+describe('DebatesBrowseFeed header links', () => {
+  // Both name something that has a page, and neither was reachable.
+  it('links the space chip to the space and the claim title to its entity', () => {
+    render(<DebatesBrowseFeed spaceId="space-1" />);
+
+    const heading = screen.getByRole('heading', { name: 'Debates are useful' });
+    // Inside the h2, not instead of it: the ref, the line clamp and the overflow measurement all
+    // stay on the element they were written for.
+    expect(within(heading).getByRole('link', { name: 'Debates are useful' })).toHaveAttribute(
+      'href',
+      '/space/space-1/claim-entity-debate-1'
+    );
+
+    expect(screen.getAllByRole('link', { name: 'Fashion' })[0]).toHaveAttribute('href', '/space/space-1');
+  });
+
+  // Truncation runs parent -> anchor -> text, and an anchor at its default `min-width: auto` would
+  // refuse to shrink, pushing the topics off the row instead of ellipsing the name.
+  it('keeps the space link shrinkable so the name still truncates', () => {
+    render(<DebatesBrowseFeed spaceId="space-1" />);
+
+    expect(screen.getAllByRole('link', { name: 'Fashion' })[0]).toHaveClass('min-w-0');
+  });
 });
 
 describe('DebatesBrowseFeed video sharing', () => {

--- a/apps/web/core/debates/browse/debate-feed.tsx
+++ b/apps/web/core/debates/browse/debate-feed.tsx
@@ -17,9 +17,11 @@ import { useComments } from '~/core/hooks/use-comments';
 import { useSpace } from '~/core/hooks/use-space';
 import { ID } from '~/core/id';
 import { useQueryEntities } from '~/core/sync/use-store';
+import { NavUtils } from '~/core/utils/utils';
 
 import { Avatar } from '~/design-system/avatar';
 import { Button } from '~/design-system/button';
+import { PrefetchLink as Link } from '~/design-system/prefetch-link';
 import { Text } from '~/design-system/text';
 
 import { EntityCommentsPanel } from '~/partials/comments/entity-comments-panel';
@@ -396,6 +398,8 @@ function DebateFeedItem({
             <DebateTitleHeader
               key={debate.claim.claim}
               claim={debate.claim.claim}
+              claimEntityId={debate.claim.claim_entity_id}
+              spaceId={spaceId}
               spaceName={spaceName}
               spaceImage={spaceImage}
               topics={topics}
@@ -427,12 +431,16 @@ function DebateFeedItem({
 
 function DebateTitleHeader({
   claim,
+  claimEntityId,
+  spaceId,
   spaceName,
   spaceImage,
   topics,
   onOpenJoin,
 }: {
   claim: string;
+  claimEntityId: string;
+  spaceId: string;
   spaceName: string;
   spaceImage?: string | null;
   topics: string[];
@@ -462,12 +470,17 @@ function DebateTitleHeader({
     <div className="flex flex-col gap-1">
       <div className="flex items-center justify-between gap-2">
         <div className="flex min-w-0 items-center gap-1.5">
-          <span className="block size-4 shrink-0 overflow-hidden rounded-full bg-grey-02">
-            <Avatar avatarUrl={spaceImage} value={spaceName} size={16} />
-          </span>
-          <Text as="span" variant="metadata" color="text" className="truncate !leading-[13px] !tracking-[-0.35px]">
-            {spaceName}
-          </Text>
+          {/* `min-w-0` again on the anchor: the truncation chain runs parent → anchor → text, and
+              a link left at its default `min-width: auto` would refuse to shrink and push the
+              topics off the row instead of ellipsing the name. */}
+          <Link href={NavUtils.toSpace(spaceId)} className="flex min-w-0 items-center gap-1.5 hover:underline">
+            <span className="block size-4 shrink-0 overflow-hidden rounded-full bg-grey-02">
+              <Avatar avatarUrl={spaceImage} value={spaceName} size={16} />
+            </span>
+            <Text as="span" variant="metadata" color="text" className="truncate !leading-[13px] !tracking-[-0.35px]">
+              {spaceName}
+            </Text>
+          </Link>
           {topics.map(topic => (
             <React.Fragment key={topic}>
               <Text as="span" variant="metadata" color="grey-04" className="!leading-[13px] !tracking-[-0.35px]">
@@ -505,7 +518,14 @@ function DebateTitleHeader({
           isClaimExpanded ? 'line-clamp-2 md:line-clamp-none' : 'line-clamp-2'
         }`}
       >
-        {claim}
+        <Link
+          href={NavUtils.toEntity(spaceId, claimEntityId)}
+          entityId={claimEntityId}
+          spaceId={spaceId}
+          className="hover:underline"
+        >
+          {claim}
+        </Link>
       </h2>
       {isClaimOverflowing && (
         <button


### PR DESCRIPTION
Closes [GEO-2715](https://linear.app/geobrowser/issue/GEO-2715/debates-feed-link-the-space-chip-and-claim-title-to-their-pages).

The space chip opens the space, the claim title opens the claim's entity page.

```
core/debates/browse/debate-feed.tsx                +23 -6
core/debates/browse/debate-feed.test.tsx           +33
app/space/[id]/(space)/debates/debates-page-client.test.tsx  +7 -1
```

## Both ids were already in scope

No new queries. `spaceId` is already a prop of `DebateFeedItem`, and `debate.claim.claim_entity_id` was already read at the call site for the topics lookup — both just needed passing one level down into `DebateTitleHeader`.

## Two details that decided the markup

**The claim's anchor goes inside the `<h2>`, not around it.** `claimRef` measures `scrollHeight > clientHeight` on that element to decide whether "show more" appears, and the clamp classes live there too. Wrapping the heading would have moved the ref off the clamped box and quietly broken that measurement; an inline anchor inside leaves all three where they were written.

The click conflict people expect here does not exist: the expand affordance is a **separate button** underneath, and the `<h2>` never had a handler.

**The space anchor carries `min-w-0`.** Truncation runs parent → anchor → text, and a flex child at its default `min-width: auto` refuses to shrink — so without it the link would push the topic chips off the row instead of ellipsing the name. There is a test pinning that specifically, because it is invisible until a space has a long name.

The anchor wraps the avatar and name only. The topic chips stay siblings outside it, so they are not swept into the space link.

## `PrefetchLink`, not a bare anchor

It is what the rest of the app links entities with, and it hydrates the target entity on hover — worth having on the claim, which is a page the viewer is one tap from.

It also reaches for the sync engine and the router, which two feed suites do not stand up. I mocked those rather than the link itself, so the real anchor and therefore the real `href`s stay under test. That is why `debates-page-client.test.tsx` appears in the diff.

## Left out on purpose

**The topic chips are still plain text.** They sit in the same row and are also entities, so this does leave two of three linked — I flagged it on the ticket and it is still the odd one out.

It is not free, which is why it is not here: `topicsByClaimId` maps a claim id to **names** (`relation.toEntity.name ?? relation.toEntity.id`), discarding the ids. Linking them means reshaping that map to `{ id, name }[]` and threading it through two components — a bigger diff on a change you will want to eyeball, and beyond what was reported. Say the word and it is a small follow-up.

## Tests

Two added, both confirmed to fail against the previous markup:

- the space chip's `href` is the space and the claim title's is the entity, with the title's anchor asserted **inside** the heading
- the space link keeps `min-w-0`

`326 files / 3533 tests` pass. `tsc` clean apart from the four pre-existing errors tracked in [GEO-2699](https://linear.app/geobrowser/issue/GEO-2699/tooling-nothing-type-checks-test-files-and-four-type-errors-have). Lint and build clean.

## Not verified in a browser

Worth a look on a phone for two things a test cannot answer: whether the hover underline reads right on the claim title at that size, and whether returning from a link restores the feed's scroll position.