### PR TITLE
fix(space): stop a failed subtopics lookup crashing the space page

### DIFF
--- a/apps/web/app/space/[id]/(space)/page.tsx
+++ b/apps/web/app/space/[id]/(space)/page.tsx
@@ -8,7 +8,6 @@ import { notFound } from 'next/navigation';
 
 import { fetchShownPropertyEntitiesForBlocks } from '~/core/blocks/data/fetch-block-shown-properties';
 import { fetchCollectionItemsForBlocks } from '~/core/blocks/data/fetch-collection-items';
-import { fetchSubtopics } from '~/core/io/subgraph/fetch-subtopics';
 import { firstLine } from '~/core/opengraph';
 import { RouteEditorProvider, type Tabs } from '~/core/state/editor/editor-provider';
 import { EntityStoreProvider } from '~/core/state/entity-page-store/entity-store-provider';
@@ -28,7 +27,7 @@ import { EntityPageSidebarLayout } from '~/partials/entity-page/entity-page-side
 import { ToggleEntityPage } from '~/partials/entity-page/toggle-entity-page';
 import { RootExploreSidePanelContainer } from '~/partials/explore/root-explore-side-panel-container';
 import { SpaceOverviewSidePanel } from '~/partials/space-page/space-overview-side-panel';
-import { SubtopicGallery } from '~/partials/space-page/subtopic-gallery';
+import { SubtopicGalleryServerContainer } from '~/partials/space-page/subtopic-gallery-server-container';
 
 import { cachedFetchEntitiesBatch, cachedFetchEntityPage } from '../../(entity)/[id]/[entityId]/cached-fetch-entity';
 import { cachedFetchSpace } from '../cached-fetch-space';
@@ -103,7 +102,7 @@ export default async function SpacePage(props0: Props) {
   return (
     <EntityPageSidebarLayout sidebar={sidebar}>
       <React.Suspense fallback={<SubtopicGallerySkeleton />}>
-        <SubtopicGalleryContainer spaceId={params.id} />
+        <SubtopicGalleryServerContainer spaceId={params.id} />
       </React.Suspense>
       <React.Suspense fallback={null}>
         <Editor spaceId={spaceId} shouldHandleOwnSpacing />
@@ -140,7 +139,7 @@ async function TopicEntityBody({ spaceId, topicEntityId }: { spaceId: string; to
       >
         <EntityPageContentContainer>
           <React.Suspense fallback={<SubtopicGallerySkeleton />}>
-            <SubtopicGalleryContainer spaceId={spaceId} />
+            <SubtopicGalleryServerContainer spaceId={spaceId} />
           </React.Suspense>
           <React.Suspense fallback={null}>
             <Editor spaceId={spaceId} shouldHandleOwnSpacing />
@@ -231,26 +230,6 @@ const SubtopicGallerySkeleton = () => {
       <Spacer height={40} />
     </>
   );
-};
-
-type SubtopicGalleryContainerProps = {
-  spaceId: string;
-};
-
-const SubtopicGalleryContainer = async ({ spaceId }: SubtopicGalleryContainerProps) => {
-  const space = await cachedFetchSpace(spaceId);
-
-  if (!space) {
-    return null;
-  }
-
-  const subtopics = await fetchSubtopics(spaceId);
-
-  if (subtopics.length === 0) {
-    return null;
-  }
-
-  return <SubtopicGallery spaceId={spaceId} subtopics={subtopics} />;
 };
 
 const getSpaceFrontPage = async (space: Awaited<ReturnType<typeof cachedFetchSpace>>) => {

--- a/apps/web/partials/space-page/subtopic-gallery-server-container.test.tsx
+++ b/apps/web/partials/space-page/subtopic-gallery-server-container.test.tsx
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { SubtopicGalleryServerContainer } from './subtopic-gallery-server-container';
+
+const mocks = vi.hoisted(() => ({
+  cachedFetchSpace: vi.fn(),
+  fetchSubtopics: vi.fn(),
+  reportError: vi.fn(),
+}));
+
+vi.mock('~/app/space/[id]/cached-fetch-space', () => ({ cachedFetchSpace: mocks.cachedFetchSpace }));
+vi.mock('~/core/io/subgraph/fetch-subtopics', () => ({ fetchSubtopics: mocks.fetchSubtopics }));
+vi.mock('~/core/telemetry/logger', () => ({ reportError: mocks.reportError }));
+vi.mock('~/partials/space-page/subtopic-gallery', () => ({
+  SubtopicGallery: ({ spaceId, subtopics }: { spaceId: string; subtopics: unknown[] }) => (
+    <div data-testid="gallery" data-space-id={spaceId} data-count={subtopics.length} />
+  ),
+}));
+
+const SPACE_ID = 'a19c345ab9866679b001d7d2138d88a1';
+
+beforeEach(() => {
+  mocks.cachedFetchSpace.mockReset().mockResolvedValue({ id: SPACE_ID });
+  mocks.fetchSubtopics.mockReset();
+  mocks.reportError.mockReset();
+});
+
+describe('SubtopicGalleryServerContainer', () => {
+  it('renders the gallery when subtopics resolve', async () => {
+    mocks.fetchSubtopics.mockResolvedValue([{ id: 'topic-1' }, { id: 'topic-2' }]);
+
+    const result = await SubtopicGalleryServerContainer({ spaceId: SPACE_ID });
+
+    expect(result).not.toBeNull();
+    expect(result?.props.subtopics).toHaveLength(2);
+    expect(mocks.reportError).not.toHaveBeenCalled();
+  });
+
+  it('renders nothing when the space has no subtopics', async () => {
+    mocks.fetchSubtopics.mockResolvedValue([]);
+
+    expect(await SubtopicGalleryServerContainer({ spaceId: SPACE_ID })).toBeNull();
+    expect(mocks.reportError).not.toHaveBeenCalled();
+  });
+
+  /**
+   * GEOGENESIS-1T. The upstream returns transient 503s under database pressure, `fetchSubtopics`
+   * turns any transport failure into a throw, and this is an async Server Component — so before
+   * this the throw escaped and took the whole space page's render with it, 1,945 times since March.
+   */
+  it('degrades to nothing instead of throwing when the subtopics lookup fails', async () => {
+    const failure = new Error(`Failed to fetch subtopics for space ${SPACE_ID}`);
+    mocks.fetchSubtopics.mockRejectedValue(failure);
+
+    await expect(SubtopicGalleryServerContainer({ spaceId: SPACE_ID })).resolves.toBeNull();
+  });
+
+  it('still reports the failure, as handled', async () => {
+    const failure = new Error('Service temporarily unavailable due to database pressure; please retry.');
+    mocks.fetchSubtopics.mockRejectedValue(failure);
+
+    await SubtopicGalleryServerContainer({ spaceId: SPACE_ID });
+
+    expect(mocks.reportError).toHaveBeenCalledWith(failure, {
+      tags: { surface: 'subtopic-gallery' },
+      contexts: { space: { spaceId: SPACE_ID } },
+    });
+  });
+
+  it('renders nothing, and asks for no subtopics, when the space itself is missing', async () => {
+    mocks.cachedFetchSpace.mockResolvedValue(null);
+
+    expect(await SubtopicGalleryServerContainer({ spaceId: SPACE_ID })).toBeNull();
+    expect(mocks.fetchSubtopics).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/partials/space-page/subtopic-gallery-server-container.tsx
+++ b/apps/web/partials/space-page/subtopic-gallery-server-container.tsx
@@ -1,0 +1,47 @@
+import { cachedFetchSpace } from '~/app/space/[id]/cached-fetch-space';
+import { fetchSubtopics } from '~/core/io/subgraph/fetch-subtopics';
+import { reportError } from '~/core/telemetry/logger';
+
+import { SubtopicGallery } from '~/partials/space-page/subtopic-gallery';
+
+type SubtopicGalleryServerContainerProps = {
+  spaceId: string;
+};
+
+/**
+ * The space overview's subtopic gallery, which is decoration: every path below returns `null` and
+ * the page is expected to render without it.
+ *
+ * That matters because it used to be able to take the page down with it. `fetchSubtopics` throws on
+ * *any* transport failure, this is an async Server Component, and nothing caught it — so a
+ * transient upstream failure became an unhandled render error on the space page. GEOGENESIS-1T:
+ * 1,945 of them since March, still ongoing on the current release, nearly all on `/root`. The
+ * upstream says why in as many words elsewhere in the same project ("Service temporarily
+ * unavailable due to database pressure; please retry", GEOGENESIS-9K/9J/7S), so this is a retryable
+ * blip being treated as fatal.
+ *
+ * Lives here rather than inline in `page.tsx` so the degradation is testable — the page module
+ * pulls in the whole editor surface, and this container is the unit that has to fail soft.
+ */
+export const SubtopicGalleryServerContainer = async ({ spaceId }: SubtopicGalleryServerContainerProps) => {
+  const space = await cachedFetchSpace(spaceId);
+
+  if (!space) {
+    return null;
+  }
+
+  let subtopics: Awaited<ReturnType<typeof fetchSubtopics>>;
+  try {
+    subtopics = await fetchSubtopics(spaceId);
+  } catch (error) {
+    // Reported as handled: the signal is worth keeping, an unhandled render crash is not.
+    reportError(error, { tags: { surface: 'subtopic-gallery' }, contexts: { space: { spaceId } } });
+    return null;
+  }
+
+  if (subtopics.length === 0) {
+    return null;
+  }
+
+  return <SubtopicGallery spaceId={spaceId} subtopics={subtopics} />;
+};


### PR DESCRIPTION
Fixes GEOGENESIS-1T. Found by going through Sentry rather than from a ticket.

## The bug

The subtopic gallery is **decoration** — every path through the container returns `null`, and the space page renders fine without it. But:

- `fetchSubtopics` throws on *any* transport failure (`core/io/subgraph/fetch-subtopics.ts:108`)
- the container is an **async Server Component**
- nothing caught it

So a transient upstream blip became an unhandled render error on the space page.

## Scale

| | |
|---|---|
| occurrences | **1,945** since 2026-03-20 |
| status | ongoing, on the **current** production release |
| route | almost entirely `/root` |
| handled | no |

It is the top ongoing error in the project by a wide margin, and it has been open for five months.

## Why it's a blip, not a real failure

The same upstream says so in as many words elsewhere in this project — GEOGENESIS-9K / 9J / 7S are all `Service temporarily unavailable due to database pressure; please retry`. A retryable 503 was being treated as fatal.

## The fix

Degrade to no gallery, and report the failure as **handled** — the signal is worth keeping, the render crash is not. Failing closed here is exactly what the component already does one line further down when a space genuinely has no subtopics.

## On the extraction

Moved out of `page.tsx` into `partials/space-page/` so the degradation is testable: the page module pulls in the whole editor surface, while this container is the unit that has to fail soft. It follows the existing `*-server-container.tsx` convention in that directory, and `partials/space-page/space-members.tsx` already imports `cachedFetchSpace` the same way.

No behaviour change beyond the catch — both render sites are unchanged.

## Tests

5 tests covering renders / empty / **throws** / reports-as-handled / missing space. Mutation-checked: removing the `try`/`catch` fails two of them.

`tsc` at its 5-error baseline, none in the touched files.