### PR TITLE
feat(debates): ring the local avatar while you are speaking

### DIFF
--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-voice.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-voice.test.tsx
@@ -42,6 +42,7 @@ const mocks = vi.hoisted(() => ({
   setMicrophoneEnabled: vi.fn(),
   isMicrophoneEnabled: true,
   isSpeaking: false,
+  localIsSpeaking: false,
   isMuted: false,
   /** Props of every `<LiveKitRoom>` mount, so tests can drive its callbacks. */
   livekitRoomProps: [] as Array<Record<string, unknown>>,
@@ -67,9 +68,10 @@ vi.mock('@livekit/components-react', () => ({
   useAudioPlayback: () => ({ canPlayAudio: mocks.canPlayAudio, startAudio: mocks.startAudio }),
   useConnectionState: () => mocks.connectionState,
   useIsMuted: () => mocks.isMuted,
-  useIsSpeaking: () => mocks.isSpeaking,
+  useIsSpeaking: (participant?: { identity?: string }) =>
+    participant?.identity === 'me' ? mocks.localIsSpeaking : mocks.isSpeaking,
   useLocalParticipant: () => ({
-    localParticipant: { setMicrophoneEnabled: mocks.setMicrophoneEnabled },
+    localParticipant: { identity: 'me', setMicrophoneEnabled: mocks.setMicrophoneEnabled },
     isMicrophoneEnabled: mocks.isMicrophoneEnabled,
   }),
   useRemoteParticipants: () => mocks.remoteParticipants,
@@ -212,6 +214,11 @@ async function flushOwnership() {
   });
 }
 
+/** The avatar box next to a name in the dock — the element that carries the speaking ring. */
+function avatarFor(name: string) {
+  return screen.getByText(name).previousElementSibling;
+}
+
 function setVisibility(state: DocumentVisibilityState) {
   Object.defineProperty(document, 'visibilityState', { configurable: true, get: () => state });
 }
@@ -279,6 +286,7 @@ beforeEach(() => {
   mocks.setMicrophoneEnabled.mockReset();
   mocks.isMicrophoneEnabled = true;
   mocks.isSpeaking = false;
+  mocks.localIsSpeaking = false;
   mocks.isMuted = false;
   mocks.livekitRoomProps = [];
   mocks.livekitRoomMounts = [];
@@ -355,11 +363,42 @@ describe('RematchVoicePill', () => {
   it('shows the opponent as muted when they mute themselves', async () => {
     mocks.remoteParticipants = [{ identity: 'them' }];
     mocks.isMuted = true;
+    // A speaker update that arrives just before the mute leaves `isSpeaking` set until the next
+    // one; the row must not contradict itself in that window.
+    mocks.isSpeaking = true;
     render(<RematchVoicePill session={makeSession('browsing')} currentUserId="me" />);
     await flushOwnership();
     const chip = screen.getByRole('img', { name: 'Salina is muted' });
     expect(chip).toBeInTheDocument();
     expect(chip).toHaveClass('bg-errorTertiary');
+    expect(avatarFor('Salina')).not.toHaveClass('ring-green');
+  });
+
+  it('rings the speaking participant, whichever side is talking', async () => {
+    mocks.remoteParticipants = [{ identity: 'them' }];
+    mocks.localIsSpeaking = true;
+    render(<RematchVoicePill session={makeSession('browsing')} currentUserId="me" />);
+    await flushOwnership();
+    expect(avatarFor('You')).toHaveClass('ring-green');
+    expect(avatarFor('Salina')).not.toHaveClass('ring-green');
+
+    cleanup();
+    mocks.localIsSpeaking = false;
+    mocks.isSpeaking = true;
+    render(<RematchVoicePill session={makeSession('browsing')} currentUserId="me" />);
+    await flushOwnership();
+    expect(avatarFor('Salina')).toHaveClass('ring-green');
+    expect(avatarFor('You')).not.toHaveClass('ring-green');
+  });
+
+  // Muting does not retract the active-speaker update that preceded it, so a stale one would
+  // otherwise leave the ring lit on a microphone nobody can hear.
+  it('drops the local ring the moment the microphone is off', async () => {
+    mocks.localIsSpeaking = true;
+    mocks.isMicrophoneEnabled = false;
+    render(<RematchVoicePill session={makeSession('browsing')} currentUserId="me" />);
+    await flushOwnership();
+    expect(avatarFor('You')).not.toHaveClass('ring-green');
   });
 
   it('mutes and unmutes the local microphone', async () => {

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-voice.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-voice.tsx
@@ -381,10 +381,7 @@ function VoiceDockBody({
   }
 
   const localRow = (
-    <>
-      <ParticipantIdentity name="You" avatarUrl={local?.avatar_cid} avatarValue={local?.profile_space_id} />
-      <LocalAudioControls room={room} micFailure={micFailure} onMicIntentChange={onMicIntentChange} />
-    </>
+    <LocalRow local={local} room={room} micFailure={micFailure} onMicIntentChange={onMicIntentChange} />
   );
   const opponentRow = <OpponentRow participant={opponentParticipant} opponent={opponent} name={opponentName} />;
   // The mute button can only go dim and grow a tooltip, which says nothing to a keyboard or screen
@@ -475,6 +472,41 @@ function ParticipantIdentity({
   );
 }
 
+/**
+ * The user's own row. Same green ring as the opponent gets: without it the speaking cue reads as a
+ * fact about the other person rather than about who currently has the floor, and there is nothing
+ * to check when you suspect the room cannot hear you.
+ */
+function LocalRow({
+  local,
+  room,
+  micFailure,
+  onMicIntentChange,
+}: {
+  local: DebateRematchParticipant | null;
+  room: Room;
+  micFailure: MediaDeviceFailure | null;
+  onMicIntentChange: (enabled: boolean) => void;
+}) {
+  const { localParticipant, isMicrophoneEnabled } = useLocalParticipant();
+  // Muting publishes nothing, but it does not retract the active-speaker update that came just
+  // before it, so the ring has to answer to the mute state as well or it can stay lit on a
+  // microphone the room has stopped hearing.
+  const speaking = useIsSpeaking(localParticipant) && isMicrophoneEnabled && !micFailure;
+
+  return (
+    <>
+      <ParticipantIdentity
+        name="You"
+        avatarUrl={local?.avatar_cid}
+        avatarValue={local?.profile_space_id}
+        speaking={speaking}
+      />
+      <LocalAudioControls room={room} micFailure={micFailure} onMicIntentChange={onMicIntentChange} />
+    </>
+  );
+}
+
 function OpponentRow({
   participant,
   opponent,
@@ -510,6 +542,9 @@ function ConnectedOpponentRow({
 }) {
   const speaking = useIsSpeaking(participant);
   const muted = useIsMuted({ participant, source: Track.Source.Microphone });
+  // Muted outranks speaking for the same reason it does on the local row: the server clears
+  // `isSpeaking` only on its next speaker update, so a ring that ignored the mute state would sit
+  // lit beside a chip that has already gone red.
 
   return (
     <>
@@ -517,7 +552,7 @@ function ConnectedOpponentRow({
         name={name}
         avatarUrl={opponent.avatar_cid}
         avatarValue={opponent.profile_space_id}
-        speaking={speaking}
+        speaking={speaking && !muted}
       />
       <OpponentMicChip state={muted ? 'muted' : 'live'} name={name} />
     </>


### PR DESCRIPTION
## Summary

In the rematch picker's voice dock, the green speaking ring was drawn on the opponent's avatar only. This adds the same ring to the local user's avatar, so the cue reads as "who has the floor" rather than as a fact about the other person.

## The change

`ParticipantIdentity` already accepted a `speaking` prop and rendered the ring; only the opponent row passed it. The local row was inline JSX in `VoiceDockBody`, which cannot subscribe to `useIsSpeaking` — that hook needs a participant, and the local one only exists inside the room.

So the local row becomes a `LocalRow` component, mirroring the existing `ConnectedOpponentRow` split:

```tsx
const { localParticipant, isMicrophoneEnabled } = useLocalParticipant();
const speaking = useIsSpeaking(localParticipant) && isMicrophoneEnabled && !micFailure;
```

`useIsSpeaking` accepts any `Participant`, and livekit-client drives the local flag directly: both `handleActiveSpeakersUpdate` and `handleSpeakersChanged` special-case `speaker.sid === localParticipant.sid` and call `localParticipant.setIsSpeaking(...)`, clearing it when the local sid is absent from the update.

`VoiceDockBody`'s own hooks all still run before its early returns — the `<LocalRow />` element is constructed after them — and nothing new reaches `<LiveKitRoom>`, so there is no remount or Room rebuild.

## Muted now outranks speaking on both rows

Muting publishes nothing, but it does not retract the active-speaker update that arrived just before it: the server clears `isSpeaking` only on its next speaker update. Without a gate, a participant who stops talking and mutes keeps a green ring for up to about a second, next to a mic chip that has already gone red.

The local ring gates on `isMicrophoneEnabled` (which flips synchronously on the local `TrackMuted` event) and on `micFailure`. The opponent ring, which had this window since it was added, now gates on the `muted` its row already computes for the chip.

## Tests

`rematch-voice.test.tsx` mocks `useIsSpeaking` per participant instead of globally, so the two sides can be driven independently. Added:

- the ring follows whichever side is talking, and only that side
- the local ring drops while the microphone is off
- the opponent's ring is absent while they are muted, even with `isSpeaking` still set

Each was mutation-checked: removing the corresponding clause in `rematch-voice.tsx` fails the test. 28 tests pass, `tsc --noEmit` and eslint clean.
