### PR TITLE
Fix plus-button block help text

### DIFF
--- a/apps/web/partials/editor/block-reorder.test.ts
+++ b/apps/web/partials/editor/block-reorder.test.ts
@@ -72,6 +72,7 @@ describe('BlockDragHandle', () => {
     expect(addButton.compareDocumentPosition(dragButton)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
     expect(hoverCluster).toHaveAttribute('data-block-drag-handle');
     expect(hoverCluster).toHaveClass('w-[60px]');
+    expect(addButton.firstElementChild).toHaveClass('size-[15px]', '-translate-y-px');
 
     fireEvent.click(addButton);
     expect(onInsertBelow).toHaveBeenCalledOnce();

--- a/apps/web/partials/editor/block-reorder.test.ts
+++ b/apps/web/partials/editor/block-reorder.test.ts
@@ -4,6 +4,7 @@ import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/re
 import Document from '@tiptap/extension-document';
 import Paragraph from '@tiptap/extension-paragraph';
 import Text from '@tiptap/extension-text';
+import { Placeholder } from '@tiptap/extensions';
 import { Editor } from '@tiptap/react';
 
 import React from 'react';
@@ -239,6 +240,33 @@ describe('insertTextBlockBelow', () => {
 
     expect(insertTextBlockBelow(editor, 1)).toBe(true);
     expect(blockText(editor)).toEqual(['A', 'B', '']);
+  });
+
+  it('shows the empty-block help text as soon as the inserted block receives focus', async () => {
+    const helpText = 'Empty block help';
+    const editor = new Editor({
+      extensions: [
+        Document,
+        Paragraph,
+        Text,
+        Placeholder.configure({
+          showOnlyCurrent: false,
+          placeholder: ({ editor: currentEditor, hasAnchor }) => (currentEditor.isFocused && hasAnchor ? helpText : ''),
+        }),
+      ],
+      content: { type: 'doc', content: [{ type: 'paragraph', content: [{ type: 'text', text: 'A' }] }] },
+    });
+    editors.push(editor);
+    document.body.appendChild(editor.view.dom);
+
+    expect(insertTextBlockBelow(editor, 0)).toBe(true);
+    await waitFor(() => expect(editor.isFocused).toBe(true));
+
+    expect(
+      Array.from(editor.view.dom.querySelectorAll('[data-placeholder]')).map(node =>
+        node.getAttribute('data-placeholder')
+      )
+    ).toEqual([helpText]);
   });
 
   it('does not change the document for an invalid block index', () => {

--- a/apps/web/partials/editor/block-reorder.tsx
+++ b/apps/web/partials/editor/block-reorder.tsx
@@ -875,6 +875,11 @@ export function insertTextBlockBelow(editor: Editor, childIndex: number): boolea
   if (childIndex < 0 || childIndex >= doc.childCount) return false;
 
   const insertPosition = positionBeforeChild(doc, childIndex + 1);
+  // The plus button lives outside ProseMirror. Restore DOM focus before the
+  // insertion transaction so focus-dependent decorations (notably the empty
+  // block slash hint) are calculated for the newly inserted paragraph.
+  editor.view.focus();
+
   return editor
     .chain()
     .insertContentAt(insertPosition, { type: 'paragraph' })

--- a/apps/web/partials/editor/block-reorder.tsx
+++ b/apps/web/partials/editor/block-reorder.tsx
@@ -604,7 +604,9 @@ export function BlockDragHandle({
           onFocus={() => setIsFocused(true)}
           onBlur={() => setIsFocused(false)}
         >
-          <Plus />
+          <span aria-hidden="true" className="flex size-[15px] -translate-y-px [&>svg]:size-full">
+            <Plus />
+          </span>
         </button>
       ) : null}
       <Menu


### PR DESCRIPTION
## Summary

- restore editor DOM focus before the plus-button insertion transaction
- render the empty-block slash-command help immediately on the inserted block
- add regression coverage for the focus-dependent placeholder decoration

## Test plan

- `bun run test partials/editor/block-reorder.test.ts`
- changed-file ESLint and Prettier checks

Follow-up to #2266.