### PR TITLE
fix(debates): batch per-row claim reads, and say why the gateway paused

### DIFF
--- a/apps/web/core/debates/api.test.ts
+++ b/apps/web/core/debates/api.test.ts
@@ -387,6 +387,77 @@ describe('debate claim hydration authentication', () => {
     expect(fetch).not.toHaveBeenCalled();
   });
 
+  /**
+   * GEO-2724. `ClaimDebateButton` renders per entity row and asks only for its own claim, so a table
+   * of fifty claim entities made fifty requests to an endpoint that takes all fifty ids — each one
+   * sending geo-chat to the Knowledge Graph, which is the load it answers 503 to.
+   */
+  it('collapses concurrent single-claim reads for one space into one request', async () => {
+    const fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ claims: [{ claim_entity_id: 'claim-1' }, { claim_entity_id: 'claim-2' }] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+    vi.stubGlobal('fetch', fetch);
+
+    const [first, second] = await Promise.all([
+      listDebateClaims('space-1', ['claim-1']),
+      listDebateClaims('space-1', ['claim-2']),
+    ]);
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(fetch).toHaveBeenCalledWith(
+      'http://localhost:8080/spaces/space-1/debate-claims?claim_ids=claim-1%2Cclaim-2',
+      expect.objectContaining({ headers: {} })
+    );
+    // Each caller is answered with what it asked for, not the union. A superset would be a real
+    // behaviour change: `claims-page-client` derives its active debates from every row in its
+    // response and would pick up a sibling's.
+    expect(first.claims.map(claim => claim.claim_entity_id)).toEqual(['claim-1']);
+    expect(second.claims.map(claim => claim.claim_entity_id)).toEqual(['claim-2']);
+  });
+
+  /** A fresh `Response` per call: these tests make more than one request, and a body reads once. */
+  function stubFreshJson(body: unknown) {
+    const fetch = vi
+      .fn()
+      .mockImplementation(() =>
+        Promise.resolve(
+          new Response(JSON.stringify(body), { status: 200, headers: { 'Content-Type': 'application/json' } })
+        )
+      );
+    vi.stubGlobal('fetch', fetch);
+    return fetch;
+  }
+
+  const claimRequests = (fetch: ReturnType<typeof vi.fn>) =>
+    fetch.mock.calls.filter(([url]) => String(url).includes('/debate-claims'));
+
+  it('keeps a whole-space read out of the id batch', async () => {
+    const fetch = stubFreshJson({ claims: [] });
+
+    // No ids means every claim in the space. Folding that into a batch of ids, or answering it from
+    // one, would silently narrow it.
+    await Promise.all([listDebateClaims('space-1', []), listDebateClaims('space-1', ['claim-1'])]);
+
+    expect(claimRequests(fetch)).toHaveLength(2);
+  });
+
+  it('never answers one account from another account\u2019s response', async () => {
+    const fetch = stubFreshJson({ claims: [] });
+    const getPrivyIdentityToken = vi.fn().mockResolvedValue('token');
+
+    // Readiness is per viewer, so two identities asking about the same claim are asking different
+    // questions and must not share a response.
+    await Promise.all([
+      listDebateClaims('space-1', ['claim-1'], getPrivyIdentityToken, 'user-a'),
+      listDebateClaims('space-1', ['claim-1'], getPrivyIdentityToken, 'user-b'),
+    ]);
+
+    expect(claimRequests(fetch)).toHaveLength(2);
+  });
+
   it('keeps anonymous claim browsing available without an authorization header', async () => {
     const fetch = vi.fn().mockResolvedValue(
       new Response(JSON.stringify({ claims: [] }), {

--- a/apps/web/core/debates/api.ts
+++ b/apps/web/core/debates/api.ts
@@ -748,7 +748,7 @@ export async function listDebateSharePrompts(
   });
 }
 
-export async function listDebateClaims(
+async function fetchDebateClaims(
   spaceId: string,
   claimIds: string[],
   getPrivyIdentityToken?: GetPrivyIdentityToken,
@@ -762,6 +762,114 @@ export async function listDebateClaims(
     accountKey,
     signal,
   });
+}
+
+/**
+ * How long to hold an id before asking, so a render's worth of rows travels as one request.
+ *
+ * A task, not a microtask: rows fire their queries from effects that react-query schedules, and
+ * those do not reliably land in the same microtask. Ten milliseconds is under a frame, so nothing
+ * waits perceptibly longer, and it is wide enough to catch a table committing its rows.
+ */
+const CLAIM_BATCH_WINDOW_MS = 10;
+
+/** Caps the query string. Fifty ids is roughly 1.7KB of URL; this leaves generous headroom. */
+const CLAIM_BATCH_LIMIT = 100;
+
+type ClaimBatchCaller = {
+  claimIds: string[];
+  resolve: (value: DebateClaimsResponse) => void;
+  reject: (reason: unknown) => void;
+};
+
+type ClaimBatch = {
+  ids: Set<string>;
+  callers: ClaimBatchCaller[];
+  getPrivyIdentityToken?: GetPrivyIdentityToken;
+  accountKey?: string | null;
+};
+
+const pendingClaimBatches = new Map<string, ClaimBatch>();
+
+/**
+ * Concurrent claim reads for one space, collapsed into one request.
+ *
+ * `ClaimDebateButton` renders once per entity row and asks only for its own claim, so a table of
+ * fifty claim entities issued fifty requests to an endpoint that takes all fifty ids at once — and
+ * every one of them made geo-chat resolve claim responses against the Knowledge Graph, which is
+ * exactly the load that endpoint answers 503 to (GEO-2724).
+ *
+ * Coalescing here rather than in the hook is deliberate: every caller keeps its own react-query
+ * cache entry and its own key, so no component changes and no key churn. They only share the fetch.
+ *
+ * Each caller is resolved with the claims **it asked for**, not the union. A caller handed a
+ * superset would be a real behaviour change — `claims-page-client` derives its active debates from
+ * every row in the response, and would pick up rows belonging to a sibling.
+ */
+function batchDebateClaims(
+  spaceId: string,
+  claimIds: string[],
+  getPrivyIdentityToken?: GetPrivyIdentityToken,
+  accountKey?: string | null
+): Promise<DebateClaimsResponse> {
+  // Keyed by account as well as space: two identities must never read one response, and the
+  // endpoint answers differently for each (readiness is per viewer).
+  const key = `${spaceId}\u0000${accountKey ?? ''}`;
+  let batch = pendingClaimBatches.get(key);
+
+  if (!batch) {
+    batch = { ids: new Set(), callers: [], getPrivyIdentityToken, accountKey };
+    pendingClaimBatches.set(key, batch);
+    setTimeout(() => flushClaimBatch(key, spaceId), CLAIM_BATCH_WINDOW_MS);
+  }
+
+  for (const claimId of claimIds) batch.ids.add(claimId);
+
+  return new Promise<DebateClaimsResponse>((resolve, reject) => {
+    batch.callers.push({ claimIds, resolve, reject });
+  });
+}
+
+function flushClaimBatch(key: string, spaceId: string) {
+  const batch = pendingClaimBatches.get(key);
+  if (!batch) return;
+  pendingClaimBatches.delete(key);
+
+  const ids = [...batch.ids];
+  const chunks: string[][] = [];
+  for (let index = 0; index < ids.length; index += CLAIM_BATCH_LIMIT) {
+    chunks.push(ids.slice(index, index + CLAIM_BATCH_LIMIT));
+  }
+
+  // Deliberately unsignalled. One row unmounting must not abort the request its siblings are
+  // waiting on, and a caller that has gone away simply has its own promise settled into a cache
+  // entry nobody reads.
+  Promise.all(chunks.map(chunk => fetchDebateClaims(spaceId, chunk, batch.getPrivyIdentityToken, batch.accountKey)))
+    .then(responses => {
+      const claims = responses.flatMap(response => response.claims);
+      for (const caller of batch.callers) {
+        const wanted = new Set(caller.claimIds);
+        caller.resolve({ claims: claims.filter(claim => wanted.has(claim.claim_entity_id)) });
+      }
+    })
+    .catch(error => {
+      for (const caller of batch.callers) caller.reject(error);
+    });
+}
+
+export async function listDebateClaims(
+  spaceId: string,
+  claimIds: string[],
+  getPrivyIdentityToken?: GetPrivyIdentityToken,
+  accountKey?: string | null,
+  signal?: AbortSignal
+) {
+  // An empty list means "every claim in this space", which is a different question and must not be
+  // folded into a batch of ids — nor answered from one.
+  if (claimIds.length === 0) {
+    return fetchDebateClaims(spaceId, claimIds, getPrivyIdentityToken, accountKey, signal);
+  }
+  return batchDebateClaims(spaceId, claimIds, getPrivyIdentityToken, accountKey);
 }
 
 /**

--- a/apps/web/core/debates/debate-coordinator.test.tsx
+++ b/apps/web/core/debates/debate-coordinator.test.tsx
@@ -33,6 +33,7 @@ const mocks = vi.hoisted(() => ({
   capture: vi.fn(),
   authenticated: true,
   gatewayPaused: false,
+  gatewayPauseReason: null as string | null,
   currentUserId: 'user-for' as string | null,
   // What the token exchange answers with when the stored session hasn't been written yet.
   resolvedUserId: null as string | null,
@@ -79,6 +80,7 @@ vi.mock('./debate-gateway', () => ({
   useDebateGateway: () => ({
     status: mocks.gatewayPaused ? 'degraded' : 'ready',
     paused: mocks.gatewayPaused,
+    pauseReason: mocks.gatewayPauseReason,
     capabilities: [],
   }),
   useDebateGatewayScope: () => undefined,
@@ -142,6 +144,7 @@ beforeEach(() => {
   mocks.promptsFetching = false;
   mocks.authenticated = true;
   mocks.gatewayPaused = false;
+  mocks.gatewayPauseReason = null;
   mocks.currentUserId = 'user-for';
   mocks.resolvedUserId = null;
   mocks.refetch.mockReset();
@@ -185,6 +188,37 @@ describe('DebateCoordinator', () => {
     mocks.gatewayPaused = false;
     rerender(<DebateCoordinator />);
     expect(screen.queryByText('Live debate updates are paused while reconnecting.')).not.toBeInTheDocument();
+  });
+
+  /**
+   * GEO-2670. The banner said "reconnecting" for all six pause reasons, two of which are not
+   * reconnecting and one of which never recovers — so a report of it carried no information and
+   * every occurrence had to be re-diagnosed from the subscription code. Each cause now says
+   * something a reader can act on, and the reason reaches the DOM for the ones that get screenshot.
+   */
+  it('says what kind of pause it is, rather than always claiming to reconnect', () => {
+    const expected: Array<[string | null, string]> = [
+      ['rate_limited', 'Live debate updates are catching up.'],
+      ['subscription_limit', 'Too many claims on this page to follow live. Some may be out of date.'],
+      ['unsupported', 'Live debate updates are unavailable.'],
+      ['error', 'Live debate updates are paused while retrying.'],
+      // Transport trouble is the one case where the original wording was honest.
+      ['disconnected', 'Live debate updates are paused while reconnecting.'],
+      ['session', 'Live debate updates are paused while reconnecting.'],
+      [null, 'Live debate updates are paused while reconnecting.'],
+    ];
+
+    for (const [reason, text] of expected) {
+      mocks.gatewayPaused = true;
+      mocks.gatewayPauseReason = reason;
+      const { unmount } = render(<DebateCoordinator />);
+
+      const banner = screen.getByRole('status');
+      expect(banner).toHaveTextContent(text);
+      expect(banner).toHaveAttribute('data-pause-reason', reason ?? 'unknown');
+
+      unmount();
+    }
   });
 
   it('does not route another tab into a shared debate-again browser', async () => {

--- a/apps/web/core/debates/debate-coordinator.tsx
+++ b/apps/web/core/debates/debate-coordinator.tsx
@@ -15,7 +15,7 @@ import { useClaimResponseIndexedNotifier } from './claim-response-indexed-notifi
 import { useDebateAttention, useDebatePresence } from './debate-attention';
 import { DebateChallengeDialog } from './debate-challenge-dialog';
 import { clearEnteringDebate, useEnteringDebateId, useEnteringDebatePending } from './debate-entry-intent';
-import { useDebateGateway } from './debate-gateway';
+import { type DebateGatewayPauseReason, useDebateGateway } from './debate-gateway';
 import { DebateReadyPrompt, DebateRejoinBar } from './debate-ready-prompt';
 import { rememberDebateReturnDestination } from './debate-return-navigation';
 import {
@@ -37,6 +37,38 @@ import {
 } from './social-video-share';
 import { useCurrentGeoChatUserId } from './use-current-geo-chat-user-id';
 import { useScrollLock } from './use-scroll-lock';
+
+/**
+ * What to tell the viewer about a paused gateway, given why it paused.
+ *
+ * One sentence used to cover all six reasons, and it said "reconnecting" for every one of them.
+ * That is how GEO-2670 stayed open for two weeks: a client spending its command budget, a page
+ * holding more scopes than the server will follow, and an actual dropped socket all produced the
+ * same words, so every report had to be re-diagnosed from scratch and two of the causes were not
+ * reconnecting at all.
+ *
+ * `disconnected` and `session` keep the original wording because for those it is true. The rest say
+ * what is actually happening, without asking the reader to care that a gateway exists.
+ */
+function pausedBannerText(reason: DebateGatewayPauseReason | null | undefined) {
+  switch (reason) {
+    // Our own command budget. It does resume on its own, so the viewer needs to know it is
+    // temporary and nothing is broken on their end.
+    case 'rate_limited':
+      return 'Live debate updates are catching up.';
+    // A ceiling, not a fault: the rest of the page is live, and only the claims past the limit are
+    // not. Saying "reconnecting" here promised a recovery that was never coming.
+    case 'subscription_limit':
+      return 'Too many claims on this page to follow live. Some may be out of date.';
+    // Needs a deploy. Nothing the viewer or the client can do will change it.
+    case 'unsupported':
+      return 'Live debate updates are unavailable.';
+    case 'error':
+      return 'Live debate updates are paused while retrying.';
+    default:
+      return 'Live debate updates are paused while reconnecting.';
+  }
+}
 
 export function DebateCoordinator() {
   const router = useRouter();
@@ -82,7 +114,8 @@ export function DebateCoordinator() {
   // known, so it cannot be matched against one.
   const enteringPending = useEnteringDebatePending();
   const atDebate =
-    enteringPending || Boolean(debate && (pathname.includes(`/debates/${debate.id}`) || debate.id === enteringDebateId));
+    enteringPending ||
+    Boolean(debate && (pathname.includes(`/debates/${debate.id}`) || debate.id === enteringDebateId));
   // The rematch page walks the viewer into its own converted debate, and accepting fires a single
   // `debate.rematch_changed` that the gateway turns into *two* refetches — the account's activity
   // and the rematch session — either of which can land first. When activity wins, this coordinator
@@ -233,9 +266,12 @@ export function DebateCoordinator() {
         <div
           role="status"
           aria-live="polite"
+          // Exposed in the DOM so a report can name the cause without needing the console. Two
+          // weeks of GEO-2670 went into establishing which of six pauses a screenshot meant.
+          data-pause-reason={gateway.pauseReason ?? 'unknown'}
           className="pointer-events-none fixed top-3 left-1/2 z-[1400] w-[calc(100%-1.5rem)] max-w-md -translate-x-1/2 rounded-full bg-text px-4 py-2 text-center text-sm text-white shadow-card sm:w-auto"
         >
-          Live debate updates are paused while reconnecting.
+          {pausedBannerText(gateway.pauseReason)}
         </div>
       )}
       {promptedDebate && currentUserId && !activity?.rematch && (


### PR DESCRIPTION
Two changes from GEO-2670, where the report is that the reconnecting banner appears intermittently on debates pages, while recording a debate, and on claim pages or pages that link to a bunch of claim entities.

Both live in `core/debates/` and came out of the same investigation, so they are one PR — master lands a commit every ~11 minutes and branches must be up to date to merge, and splitting this would mean racing that twice for no reviewer benefit.

## 1. Per-row claim reads are now one request per space

`ClaimDebateButton` renders once per entity row (`entity-row-actions.tsx`) and each instance independently calls `useDebateClaims(spaceId, [entityId], isClaim)`. So a table of fifty claim entities issued **fifty requests** to `/spaces/:id/debate-claims`, an endpoint that takes all fifty ids in one call — and each of those made geo-chat resolve claim responses against the Knowledge Graph, which is the load that endpoint is currently answering 503 to about 122 times an hour (GEO-2724).

Coalescing happens in `api.ts`, **below** react-query rather than in the hook. That is the deliberate part: every caller keeps its own cache entry and its own query key, so no component changes and — importantly — no key churn. They share only the fetch. Doing this in the hook would mean a key built from a growing id set, which is the same `2N+1` mistake `useDebateGatewaySpaceScopes` was written to undo, in HTTP form.

Three properties the tests pin, because each would be a real regression:

- **Each caller gets the claims it asked for, not the union.** A superset would leak a sibling's row into `claims-page-client`, which derives its active debates from every row in its response.
- **A read with no ids stays out of the batch.** An empty list means "every claim in this space" — a different question, which must not be folded into a batch of ids nor answered from one.
- **Two accounts are never answered from one response.** Readiness is per viewer, so the batch is keyed by account as well as space.

The window is 10ms — a task rather than a microtask, since rows fire their queries from effects that react-query schedules and those do not reliably land in the same microtask. That is under a frame, so nothing waits perceptibly longer.

## 2. The banner says which pause it is

One sentence covered all six pause reasons and said "reconnecting" for every one of them. So a client spending its command budget, a page holding more scopes than the server will follow, and an actual dropped socket produced identical words. Two of those are not reconnecting at all, and one never recovers without a deploy.

That is the mechanical reason GEO-2670 stayed open for two weeks: every report had to be re-diagnosed from the subscription code, because the message carried no information.

| reason | now says |
| --- | --- |
| `rate_limited` | Live debate updates are catching up. |
| `subscription_limit` | Too many claims on this page to follow live. Some may be out of date. |
| `unsupported` | Live debate updates are unavailable. |
| `error` | Live debate updates are paused while retrying. |
| `disconnected`, `session`, unknown | Live debate updates are paused while reconnecting. |

`disconnected` and `session` keep the original wording because for them it is true. The reason is also exposed as `data-pause-reason` on the banner, so a screenshot carries the cause without needing the console.

## What this does not do

**It does not confirm the cause of GEO-2670.** I have not reproduced the banner, and I am not claiming the per-row fan-out is what Preston is hitting — the fan-out is worth removing on its own merits either way. Two gaps remain, both noted on the ticket: the report may be the full-page error boundary rather than this banner, and **"while recording a debate" is not explained** by any of this, since a debate room holds a single scope. The banner change is partly there so the next report answers the question instead of restarting it.

## Tests

3552 tests pass across 329 files. ESLint and Prettier clean on the changed files.
