### PR TITLE
feat(debates): open the hub's Claims and People tabs to signed-out viewers

### DIFF
--- a/apps/web/core/debates/api.test.ts
+++ b/apps/web/core/debates/api.test.ts
@@ -14,6 +14,7 @@ import {
   getRematchLiveKitToken,
   joinDebateQueue,
   listDebateClaims,
+  listDebatePeople,
   listMatchmakingClaims,
   notifyClaimResponseIndexed,
   resetGeoChatSession,
@@ -365,6 +366,77 @@ describe('debate queue readiness', () => {
 
     await expect(joinDebateQueue('space-1', 'claim-1', vi.fn(), 'user-a')).rejects.toBeInstanceOf(GeoChatRequestError);
     expect(fetch).toHaveBeenCalledOnce();
+  });
+});
+
+// GEO-2725 opened both matchmaking reads to signed-out viewers. The risk in doing that is the
+// mirror of the case below: a blanket `auth: 'optional'` would also treat a signed-in viewer's
+// failed token exchange as "no account" and fetch anonymously, and that answer would be cached
+// under their account key — leaving viewer-relative fields like `can_challenge` quietly wrong.
+describe('matchmaking read authentication', () => {
+  const okResponse = (body: unknown) =>
+    vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify(body), { status: 200, headers: { 'Content-Type': 'application/json' } })
+      );
+
+  beforeEach(() => {
+    resetGeoChatSession();
+    window.localStorage.removeItem('geo:chat-session');
+  });
+
+  it('reads people anonymously when nobody is signed in', async () => {
+    const fetch = okResponse({ people: [] });
+    vi.stubGlobal('fetch', fetch);
+
+    // Passed but never consulted: with no account there is no exchange to make, which is what
+    // keeps this path anonymous rather than merely tokenless.
+    const getPrivyIdentityToken = vi.fn();
+
+    await expect(listDebatePeople(getPrivyIdentityToken, null)).resolves.toEqual({ people: [] });
+    expect(fetch).toHaveBeenCalledWith(
+      'http://localhost:8080/matchmaking/people',
+      expect.objectContaining({ headers: {} })
+    );
+    expect(getPrivyIdentityToken).not.toHaveBeenCalled();
+  });
+
+  it('does not downgrade a signed-in people request to anonymous when the token exchange fails', async () => {
+    const fetch = okResponse({ people: [] });
+    vi.stubGlobal('fetch', fetch);
+    const getPrivyIdentityToken = vi.fn().mockRejectedValue(new Error('Identity token unavailable'));
+
+    await expect(listDebatePeople(getPrivyIdentityToken, 'user-a')).rejects.toThrow('Identity token unavailable');
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('reads matchmaking claims anonymously when nobody is signed in', async () => {
+    const fetch = okResponse({ claims: [], next_cursor: null });
+    vi.stubGlobal('fetch', fetch);
+
+    const getPrivyIdentityToken = vi.fn();
+
+    await expect(listMatchmakingClaims({ filter: 'all' }, getPrivyIdentityToken, null)).resolves.toEqual({
+      claims: [],
+      next_cursor: null,
+    });
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/matchmaking/claims'),
+      expect.objectContaining({ headers: {} })
+    );
+    expect(getPrivyIdentityToken).not.toHaveBeenCalled();
+  });
+
+  it('does not downgrade a signed-in claims request to anonymous when the token exchange fails', async () => {
+    const fetch = okResponse({ claims: [], next_cursor: null });
+    vi.stubGlobal('fetch', fetch);
+    const getPrivyIdentityToken = vi.fn().mockRejectedValue(new Error('Identity token unavailable'));
+
+    await expect(listMatchmakingClaims({ filter: 'all' }, getPrivyIdentityToken, 'user-a')).rejects.toThrow(
+      'Identity token unavailable'
+    );
+    expect(fetch).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/web/core/debates/api.ts
+++ b/apps/web/core/debates/api.ts
@@ -1110,7 +1110,9 @@ export async function listDebatePeople(
   signal?: AbortSignal
 ) {
   return geoChatRequest<DebatePeopleResponse>('/matchmaking/people', {
-    auth: true,
+    // Attempted anonymously so the hub's People tab can render signed out. geo-chat decides
+    // whether to serve it; a refusal surfaces as the sign-in state rather than an error.
+    auth: 'optional',
     getPrivyIdentityToken,
     accountKey,
     signal,
@@ -1146,7 +1148,8 @@ export async function listMatchmakingClaims(
 
   const search = params.toString();
   return geoChatRequest<MatchmakingClaimsResponse>(`/matchmaking/claims${search ? `?${search}` : ''}`, {
-    auth: true,
+    // Same as People above: anonymous read, with geo-chat free to refuse it.
+    auth: 'optional',
     getPrivyIdentityToken,
     accountKey,
     signal,

--- a/apps/web/core/debates/api.ts
+++ b/apps/web/core/debates/api.ts
@@ -1110,9 +1110,11 @@ export async function listDebatePeople(
   signal?: AbortSignal
 ) {
   return geoChatRequest<DebatePeopleResponse>('/matchmaking/people', {
-    // Attempted anonymously so the hub's People tab can render signed out. geo-chat decides
-    // whether to serve it; a refusal surfaces as the sign-in state rather than an error.
-    auth: 'optional',
+    // Anonymous only when there is genuinely nobody signed in, matching `listDebateClaims`. A flat
+    // 'optional' would also swallow a token-exchange failure for a signed-in viewer and send the
+    // request anonymously — and the anonymous answer would then be cached under their account key,
+    // leaving viewer-relative fields like `can_challenge` quietly wrong with nothing to retry.
+    auth: accountKey ? true : 'optional',
     getPrivyIdentityToken,
     accountKey,
     signal,
@@ -1148,8 +1150,9 @@ export async function listMatchmakingClaims(
 
   const search = params.toString();
   return geoChatRequest<MatchmakingClaimsResponse>(`/matchmaking/claims${search ? `?${search}` : ''}`, {
-    // Same as People above: anonymous read, with geo-chat free to refuse it.
-    auth: 'optional',
+    // Same as People above: anonymous only with nobody signed in, never as a fallback for a
+    // signed-in viewer whose token exchange failed.
+    auth: accountKey ? true : 'optional',
     getPrivyIdentityToken,
     accountKey,
     signal,

--- a/apps/web/core/debates/matchmaking/claims-tab.test.tsx
+++ b/apps/web/core/debates/matchmaking/claims-tab.test.tsx
@@ -1262,4 +1262,21 @@ describe('ClaimsTab -- Featured', () => {
     expect(screen.getByRole('button', { name: 'My positions' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Debate now' })).toBeInTheDocument();
   });
+
+  // Signing out with a viewer-relative filter selected used to leave the tab querying it
+  // anonymously, with a trigger showing a value no longer in the menu.
+  it('falls back to Featured when the selected filter is hidden by signing out', async () => {
+    const view = render(<ClaimsTab />);
+
+    fireEvent.click(await screen.findByRole('button', { name: /Featured/ }));
+    fireEvent.click(screen.getByRole('button', { name: 'My positions' }));
+    expect(screen.getByRole('button', { name: /My positions/ })).toBeInTheDocument();
+
+    mocks.authenticated = false;
+    view.rerender(<ClaimsTab />);
+
+    expect(screen.getByRole('button', { name: /Featured/ })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /My positions/ })).not.toBeInTheDocument();
+    expect(mocks.lastQuery).not.toMatchObject({ filter: 'mine' });
+  });
 });

--- a/apps/web/core/debates/matchmaking/claims-tab.test.tsx
+++ b/apps/web/core/debates/matchmaking/claims-tab.test.tsx
@@ -1240,23 +1240,26 @@ describe('ClaimsTab -- Featured', () => {
     expect(mocks.lastEnabled).toBe(false);
   });
 
-  // GEO-2725. "My positions" is the viewer's own list, so signed out it can only ever be empty —
-  // an option that looks broken rather than one that says something.
-  it('drops the My positions filter when signed out', async () => {
+  // GEO-2725. Both are viewer-relative: "My positions" is the viewer's own list, and "Debate now"
+  // is scored on who is available to debate *you*. Signed out neither has a subject.
+  it('drops the viewer-relative filters when signed out', async () => {
     mocks.authenticated = false;
     render(<ClaimsTab />);
 
     fireEvent.click(await screen.findByRole('button', { name: /Featured/ }));
 
     expect(screen.queryByRole('button', { name: 'My positions' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Debate now' })).not.toBeInTheDocument();
+    // Featured and All claims describe the corpus, so both stay.
     expect(screen.getByRole('button', { name: 'All claims' })).toBeInTheDocument();
   });
 
-  it('keeps My positions for a signed-in viewer', async () => {
+  it('keeps both for a signed-in viewer', async () => {
     render(<ClaimsTab />);
 
     fireEvent.click(await screen.findByRole('button', { name: /Featured/ }));
 
     expect(screen.getByRole('button', { name: 'My positions' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Debate now' })).toBeInTheDocument();
   });
 });

--- a/apps/web/core/debates/matchmaking/claims-tab.test.tsx
+++ b/apps/web/core/debates/matchmaking/claims-tab.test.tsx
@@ -1279,4 +1279,25 @@ describe('ClaimsTab -- Featured', () => {
     expect(screen.queryByRole('button', { name: /My positions/ })).not.toBeInTheDocument();
     expect(mocks.lastQuery).not.toMatchObject({ filter: 'mine' });
   });
+
+  // `debateQueryKeys.claims` is keyed on space and ids but not on the account, and a disabled
+  // react-query observer still returns whatever that key already holds — so asking at all after a
+  // sign-out would draw the previous viewer's response and readiness onto these cards. Asking for
+  // nothing is what makes that unreachable; the fields all have graph-derived fallbacks.
+  it('asks for no per-space readiness while signed out', async () => {
+    mocks.authenticated = false;
+    mocks.featuredClaims = [featuredClaim(FEATURED_A, 'Nuclear power is the cheapest clean energy')];
+    render(<ClaimsTab />);
+    await screen.findByText('Nuclear power is the cheapest clean energy');
+
+    expect(mocks.debateClaimGroups.at(-1)).toEqual([]);
+  });
+
+  it('asks for it again once signed in', async () => {
+    mocks.featuredClaims = [featuredClaim(FEATURED_A, 'Nuclear power is the cheapest clean energy')];
+    render(<ClaimsTab />);
+    await screen.findByText('Nuclear power is the cheapest clean energy');
+
+    expect(mocks.debateClaimGroups.at(-1)).not.toEqual([]);
+  });
 });

--- a/apps/web/core/debates/matchmaking/claims-tab.test.tsx
+++ b/apps/web/core/debates/matchmaking/claims-tab.test.tsx
@@ -10,6 +10,9 @@ import type { MatchmakingClaim } from '../api';
 import { ClaimsTab } from './claims-tab';
 
 const mocks = vi.hoisted(() => ({
+  promptSignIn: vi.fn(),
+  /** Privy's answer; the tab's signed-out paths hang off it. */
+  authenticated: true,
   claims: [] as MatchmakingClaim[],
   featuredClaims: [] as Array<{
     claimEntityId: string;
@@ -174,7 +177,7 @@ vi.mock('../hooks', () => ({
     matches: (accountKey: string | null) => ['debates', 'account', accountKey, 'matches'] as const,
     rematchRoot: (accountKey: string | null) => ['debates', 'account', accountKey, 'rematch'] as const,
   },
-  useGeoChatAuth: () => ({ ready: true, authenticated: true, accountKey: 'account-1' }),
+  useGeoChatAuth: () => ({ ready: true, authenticated: mocks.authenticated, accountKey: 'account-1' }),
   useJoinDebateQueue: () => ({ mutateAsync: vi.fn(), reset: vi.fn(), isPending: false, error: null }),
   useLeaveDebateQueue: () => ({ mutateAsync: vi.fn(), isPending: false, error: null }),
   // Featured rows are hydrated by the per-space debate-claims lookup. Records what it was asked
@@ -236,6 +239,12 @@ vi.mock('~/core/hooks/use-spaces-by-ids', () => ({
 
 vi.mock('~/core/sync/use-store', () => ({
   useQueryEntities: () => ({ entities: [] }),
+}));
+
+// `usePrivySignIn` reaches for Privy's context, which these suites do not stand up. The signed-out
+// paths assert that it is *called*, so the stub is shared through `mocks.promptSignIn`.
+vi.mock('~/core/hooks/use-privy-sign-in', () => ({
+  usePrivySignIn: () => mocks.promptSignIn,
 }));
 
 function render(ui: ReactElement) {
@@ -306,6 +315,8 @@ const MINE = '019fedb1-0c41-7f3e-9a11-2c7d5e8b4419';
 const THEIRS = '019fedb2-1d52-7a4f-8b22-3d8e6f9c5520';
 
 beforeEach(() => {
+  // Not a mock fn, so `resetAllMocks` does not restore it.
+  mocks.authenticated = true;
   mocks.hasNextPage = false;
   mocks.facetSpaceIds = [];
   mocks.featuredClaims = [];
@@ -1227,5 +1238,25 @@ describe('ClaimsTab -- Featured', () => {
 
     await waitFor(() => expect(screen.getByText('Nuclear power is the cheapest clean energy')).toBeInTheDocument());
     expect(mocks.lastEnabled).toBe(false);
+  });
+
+  // GEO-2725. "My positions" is the viewer's own list, so signed out it can only ever be empty —
+  // an option that looks broken rather than one that says something.
+  it('drops the My positions filter when signed out', async () => {
+    mocks.authenticated = false;
+    render(<ClaimsTab />);
+
+    fireEvent.click(await screen.findByRole('button', { name: /Featured/ }));
+
+    expect(screen.queryByRole('button', { name: 'My positions' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'All claims' })).toBeInTheDocument();
+  });
+
+  it('keeps My positions for a signed-in viewer', async () => {
+    render(<ClaimsTab />);
+
+    fireEvent.click(await screen.findByRole('button', { name: /Featured/ }));
+
+    expect(screen.getByRole('button', { name: 'My positions' })).toBeInTheDocument();
   });
 });

--- a/apps/web/core/debates/matchmaking/claims-tab.tsx
+++ b/apps/web/core/debates/matchmaking/claims-tab.tsx
@@ -7,6 +7,7 @@ import cx from 'classnames';
 import { TOPICS_PROPERTY_ID } from '~/core/claims/ontology';
 import { claimResponseKind } from '~/core/claims/response-kind';
 import { useInfiniteScrollSentinel } from '~/core/hooks/use-infinite-scroll-sentinel';
+import { usePrivySignIn } from '~/core/hooks/use-privy-sign-in';
 import { spaceLabel, useSpaceLabels } from '~/core/hooks/use-space-labels';
 import { ID } from '~/core/id';
 import { responsePositionLabel } from '~/core/responses/entity-response';
@@ -30,6 +31,7 @@ import {
   featuredClaimIdsBySpace,
   useFeaturedClaims,
 } from '../featured-claims';
+import { useGeoChatAuth } from '../hooks';
 import { useDebateClaimsBySpaces } from '../hooks';
 import { useClaimSpaceAllowlist } from '../use-claim-space-allowlist';
 import { isSpaceDebatePublishable, useDebatePublishableSpaces } from '../use-debate-publishable-spaces';
@@ -58,6 +60,14 @@ const FILTER_OPTIONS: HubFilterOption<ClaimsTabFilter>[] = [
   { value: 'debate_now', label: 'Debate now' },
 ];
 
+/**
+ * "My positions" is the viewer's own list, so signed out it can only ever be empty — an option that
+ * looks broken rather than one that says something. The rest describe the corpus and still answer.
+ */
+function filterOptionsFor(authenticated: boolean) {
+  return authenticated ? FILTER_OPTIONS : FILTER_OPTIONS.filter(option => option.value !== 'mine');
+}
+
 /** Stable identity so the geo-chat lookups don't restart on every render of a non-featured list. */
 const NO_FEATURED_CLAIMS: FeaturedClaim[] = [];
 
@@ -73,6 +83,14 @@ const NO_FEATURED_CLAIMS: FeaturedClaim[] = [];
  * disallowed — so the sentinel that asks for the next page sits outside the empty state below.
  */
 export function ClaimsTab() {
+  const { authenticated } = useGeoChatAuth();
+  // A signed-out viewer gets Privy rather than a dead pill, the same hook and for the same reason
+  // the claim page and the entity vote arrows use it. Passed as `undefined` when signed in so the
+  // card keeps publishing directly.
+  const promptSignIn = usePrivySignIn();
+  const onRequireSignIn = authenticated ? undefined : promptSignIn;
+  const filterOptions = React.useMemo(() => filterOptionsFor(authenticated), [authenticated]);
+
   const [search, setSearch] = React.useState('');
   const [debouncedSearch, setDebouncedSearch] = React.useState('');
   // Featured is where the tab opens. The whole corpus is the wider net but the shallower one — a
@@ -417,7 +435,7 @@ export function ClaimsTab() {
           leading={
             <HubFilterMenu
               label={FILTER_OPTIONS.find(option => option.value === filter)?.label ?? 'All claims'}
-              options={FILTER_OPTIONS}
+              options={filterOptions}
               value={filter}
               onChange={setFilter}
             />
@@ -431,6 +449,11 @@ export function ClaimsTab() {
           error={featured ? featuredError : claimsQuery.error}
           onRetry={() => void (featured ? refetchFeatured() : claimsQuery.refetch())}
           isEmpty={visibleClaims.length === 0}
+          signInAction={
+            onRequireSignIn
+              ? { label: 'Sign in', message: 'Sign in to browse claims to debate.', onClick: onRequireSignIn }
+              : undefined
+          }
           emptyMessage={
             featured
               ? hasFilters
@@ -470,6 +493,7 @@ export function ClaimsTab() {
                 // is in fact standing ready on. The paged rows come with readiness on them, so this
                 // only ever applies to Featured.
                 hideReadinessToggle={featuredReadinessUnresolved}
+                onRequireSignIn={onRequireSignIn}
               />
             ))}
           </HubCardList>

--- a/apps/web/core/debates/matchmaking/claims-tab.tsx
+++ b/apps/web/core/debates/matchmaking/claims-tab.tsx
@@ -61,11 +61,21 @@ const FILTER_OPTIONS: HubFilterOption<ClaimsTabFilter>[] = [
 ];
 
 /**
- * "My positions" is the viewer's own list, so signed out it can only ever be empty — an option that
- * looks broken rather than one that says something. The rest describe the corpus and still answer.
+ * The two viewer-relative filters leave the menu signed out.
+ *
+ * "My positions" is the viewer's own list, so it could only ever come back empty. "Debate now" is
+ * viewer-relative in a less obvious way — geo-chat scores it on who is available to debate *you*,
+ * excluding anyone you are already pair-blocked with — so with no viewer it is not a stricter
+ * "all claims" but a question with no subject.
+ *
+ * Featured and All claims describe the corpus rather than the viewer, and both still answer.
  */
+const SIGNED_OUT_HIDDEN_FILTERS: ClaimsTabFilter[] = ['mine', 'debate_now'];
+
 function filterOptionsFor(authenticated: boolean) {
-  return authenticated ? FILTER_OPTIONS : FILTER_OPTIONS.filter(option => option.value !== 'mine');
+  return authenticated
+    ? FILTER_OPTIONS
+    : FILTER_OPTIONS.filter(option => !SIGNED_OUT_HIDDEN_FILTERS.includes(option.value));
 }
 
 /** Stable identity so the geo-chat lookups don't restart on every render of a non-featured list. */

--- a/apps/web/core/debates/matchmaking/claims-tab.tsx
+++ b/apps/web/core/debates/matchmaking/claims-tab.tsx
@@ -244,7 +244,17 @@ export function ClaimsTab() {
   // Deliberately the whole allowed set rather than what search currently matches: typing then
   // filters a list that is already loaded instead of restarting a fan-out of per-space requests on
   // every keystroke, and the gateway scopes those lookups hold stay put while it happens.
-  const featuredGroups = React.useMemo(() => featuredClaimIdsBySpace(featuredAllowed), [featuredAllowed]);
+  //
+  // Nothing is asked for signed out, and deliberately not just because the lookup would be
+  // disabled: `debateQueryKeys.claims` is keyed on space and ids but not on the account, and a
+  // disabled react-query observer still hands back whatever that key already holds. Left to it,
+  // the first signed-out render after a sign-out would draw the previous viewer's `viewer_response`
+  // and `viewer_debate_ready` onto these cards. Empty groups mean no key to read, and every field
+  // it would have carried already has the graph-derived fallback below.
+  const featuredGroups = React.useMemo(
+    () => (authenticated ? featuredClaimIdsBySpace(featuredAllowed) : []),
+    [authenticated, featuredAllowed]
+  );
   const featuredRows = useDebateClaimsBySpaces(featuredGroups);
   const featuredReadinessUnresolved = featured && (featuredRows.isLoading || featuredRows.isError);
 

--- a/apps/web/core/debates/matchmaking/claims-tab.tsx
+++ b/apps/web/core/debates/matchmaking/claims-tab.tsx
@@ -106,7 +106,12 @@ export function ClaimsTab() {
   // Featured is where the tab opens. The whole corpus is the wider net but the shallower one — a
   // curator's pick is a better first thing to put in front of someone than whatever the index
   // ranked highest, and All claims is one option below.
-  const [filter, setFilter] = React.useState<ClaimsTabFilter>('featured');
+  const [selectedFilter, setFilter] = React.useState<ClaimsTabFilter>('featured');
+  // Signing out with a viewer-relative filter selected would otherwise leave the tab querying it
+  // anonymously and showing a trigger value that is no longer in the menu. Derived rather than
+  // reset through an effect so the query, the menu label, the ordering key and the empty state all
+  // read the same value on the very first render after the session goes away.
+  const filter = !authenticated && SIGNED_OUT_HIDDEN_FILTERS.includes(selectedFilter) ? 'featured' : selectedFilter;
   const [spaceIds, setSpaceIds] = React.useState<string[]>([]);
   const [topicIds, setTopicIds] = React.useState<string[]>([]);
 
@@ -444,7 +449,7 @@ export function ClaimsTab() {
           facetTopics={facetTopics}
           leading={
             <HubFilterMenu
-              label={FILTER_OPTIONS.find(option => option.value === filter)?.label ?? 'All claims'}
+              label={filterOptions.find(option => option.value === filter)?.label ?? 'All claims'}
               options={filterOptions}
               value={filter}
               onChange={setFilter}

--- a/apps/web/core/debates/matchmaking/debates-hub-button.test.tsx
+++ b/apps/web/core/debates/matchmaking/debates-hub-button.test.tsx
@@ -44,21 +44,35 @@ describe('DebatesHubButton', () => {
     expect(screen.getByRole('button', { name: 'Debate' })).toBeInTheDocument();
   });
 
-  it('stays hidden for a signed-out visitor', () => {
+  // GEO-2725. It used to be hidden signed out, because every tab behind it needed an identity.
+  // Claims and People are readable anonymously now, and this is the only opener for them — hiding
+  // it left them unreachable.
+  it('shows for a signed-out visitor', () => {
     mocks.authenticated = false;
     renderButton();
-    // The hub is the only opener for the panel, and every tab behind it needs an identity.
-    expect(screen.queryByRole('button', { name: /Debate/ })).not.toBeInTheDocument();
+
+    expect(screen.getByRole('button', { name: 'Debate' })).toBeInTheDocument();
   });
 
-  it('stays hidden until Privy has restored the session', () => {
-    // `authenticated` is false while Privy is still resolving, so a returning user sees the button
-    // appear late rather than watching it flash in and out.
+  it('shows while Privy is still restoring the session', () => {
     mocks.ready = false;
     mocks.authenticated = false;
     renderButton();
 
-    expect(screen.queryByRole('button', { name: /Debate/ })).not.toBeInTheDocument();
+    // No longer anything to wait for: the button is the same for both answers, so there is no
+    // flash of it appearing or disappearing once Privy resolves.
+    expect(screen.getByRole('button', { name: 'Debate' })).toBeInTheDocument();
+  });
+
+  // The badge counts requests addressed to somebody, so signed out there is nobody to badge it
+  // for — and a cache left over from a session that has since signed out must not leak into it.
+  it('never badges a signed-out visitor, even with a stale count cached', () => {
+    mocks.authenticated = false;
+    mocks.incomingRequestCount = 3;
+    renderButton();
+
+    expect(screen.getByRole('button', { name: 'Debate' })).toBeInTheDocument();
+    expect(screen.queryByText('3')).not.toBeInTheDocument();
   });
 
   it('keeps announcing the pending request count while signed in', () => {

--- a/apps/web/core/debates/matchmaking/debates-hub-button.tsx
+++ b/apps/web/core/debates/matchmaking/debates-hub-button.tsx
@@ -12,14 +12,17 @@ import { useDebatesHub } from './use-debates-hub';
 import { useUnexpiredRequests } from './use-request-countdown';
 
 /**
- * Navbar entry point for the matchmaking hub. Shown to signed-in users once debates are enabled —
- * including those who are not available to debate, since the hub is where they turn it on. Every
- * tab behind it is geo-chat data that needs an identity, so a signed-out visitor has nothing to
- * open it for.
+ * Navbar entry point for the matchmaking hub.
+ *
+ * Shown to everyone, signed in or not (GEO-2725). It used to be hidden signed out, on the grounds
+ * that every tab behind it needed an identity — true until Claims and People became readable
+ * anonymously, at which point hiding it left the one way into them unreachable.
+ *
+ * The badge is still a signed-in thing: it counts requests addressed to somebody. Both lookups
+ * behind it are gated on the session already — `useDebateActivity` on `authenticated`, and the
+ * requests list is read-only here — so signed out nothing is fetched and the count is simply zero.
  */
 export function DebatesHubButton() {
-  // False until Privy has restored the session, so the button stays hidden until we actually know
-  // — appearing late beats flashing in and out for someone who was never signed in.
   const { authenticated } = useGeoChatAuth();
   const { isOpen, toggle } = useDebatesHub();
   const { data: activity } = useDebateActivity();
@@ -28,9 +31,9 @@ export function DebatesHubButton() {
   const { data: requests } = useDebateRequests(false);
   const incoming = useUnexpiredRequests(requests?.incoming ?? []);
 
-  if (!authenticated) return null;
-
-  const requestCount = requests ? incoming.length : (activity?.incoming_request_count ?? 0);
+  // Guarded rather than relying on the lookups being empty: a stale cache from a session that has
+  // since signed out would otherwise badge the button for nobody.
+  const requestCount = !authenticated ? 0 : requests ? incoming.length : (activity?.incoming_request_count ?? 0);
 
   return (
     <button

--- a/apps/web/core/debates/matchmaking/debates-hub-panel.test.tsx
+++ b/apps/web/core/debates/matchmaking/debates-hub-panel.test.tsx
@@ -9,6 +9,7 @@ import { DebatesHubPanel } from './debates-hub-panel';
 import { debatesHubAtom } from '~/atoms';
 
 const mocks = vi.hoisted(() => ({
+  promptSignIn: vi.fn(),
   authenticated: true,
   available: false,
   updateAvailability: vi.fn(),
@@ -62,6 +63,20 @@ vi.mock('~/core/browse/use-browse-sidebar-cache', () => ({
 
 vi.mock('~/core/hooks/use-spaces-by-ids', () => ({
   useSpacesByIds: () => ({ spaces: [], spacesById: new Map(), isLoading: false }),
+}));
+
+// This suite is about the tab row and which body it selects, not the Claims list itself — which
+// reaches for the space allowlist and the knowledge graph through react-query. `HubStickyControls`
+// stays real because the People tab renders it.
+vi.mock('./claims-tab', async () => {
+  const actual = await vi.importActual<typeof import('./claims-tab')>('./claims-tab');
+  return { ...actual, ClaimsTab: () => <div data-testid="claims-tab" /> };
+});
+
+// `usePrivySignIn` reaches for Privy's context, which these suites do not stand up. The signed-out
+// paths assert that it is *called*, so the stub is shared through `mocks.promptSignIn`.
+vi.mock('~/core/hooks/use-privy-sign-in', () => ({
+  usePrivySignIn: () => mocks.promptSignIn,
 }));
 
 function renderOpen(tab: 'requests' | 'matches' | 'claims' | 'people' = 'requests') {
@@ -147,11 +162,35 @@ describe('DebatesHubPanel', () => {
     expect(screen.getByText("Matchmaking isn't available yet.")).toBeInTheDocument();
   });
 
-  it('asks anonymous visitors to sign in', () => {
+  // GEO-2725. The hub used to be one sign-in message end to end. Claims and People describe the
+  // corpus rather than the viewer, so both are readable signed out and are what the row offers.
+  it('offers Claims and People to anonymous visitors, and shows the Claims list', () => {
     mocks.authenticated = false;
     renderOpen();
 
-    expect(screen.getByText('Sign in to find people to debate.')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Claims' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'People' })).toBeInTheDocument();
+    expect(screen.queryByText('Sign in to find people to debate.')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Claims' })).toHaveAttribute('aria-current', 'true');
+    expect(screen.getByTestId('claims-tab')).toBeInTheDocument();
+  });
+
+  // Matches and Requests are a particular person's, so signed out they have no possible contents.
+  it('leaves Matches and Requests out of the row when signed out', () => {
+    mocks.authenticated = false;
+    renderOpen();
+
+    expect(screen.queryByRole('button', { name: /Matches/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Requests/ })).not.toBeInTheDocument();
+  });
+
+  // Signing out with Matches open would otherwise leave a tab body showing with no tab selected.
+  it('falls back to Claims when signed out on a tab that is no longer offered', () => {
+    mocks.authenticated = false;
+    renderOpen('matches');
+
+    expect(screen.getByRole('button', { name: 'Claims' })).toHaveAttribute('aria-current', 'true');
+    expect(screen.queryByRole('button', { name: /Matches/ })).not.toBeInTheDocument();
   });
 
   // `aria-modal` on the sheet hides the navbar toggle and the backdrop from assistive tech, so

--- a/apps/web/core/debates/matchmaking/debates-hub-panel.test.tsx
+++ b/apps/web/core/debates/matchmaking/debates-hub-panel.test.tsx
@@ -10,6 +10,7 @@ import { debatesHubAtom } from '~/atoms';
 
 const mocks = vi.hoisted(() => ({
   promptSignIn: vi.fn(),
+  ready: true,
   authenticated: true,
   available: false,
   updateAvailability: vi.fn(),
@@ -24,7 +25,7 @@ vi.mock('next/navigation', () => ({ usePathname: () => mocks.pathname }));
 vi.mock('~/core/hooks/use-is-mobile-layout', () => ({ useIsMobileLayout: () => mocks.isMobile }));
 
 vi.mock('../hooks', () => ({
-  useGeoChatAuth: () => ({ ready: true, authenticated: mocks.authenticated, accountKey: 'user-a' }),
+  useGeoChatAuth: () => ({ ready: mocks.ready, authenticated: mocks.authenticated, accountKey: 'user-a' }),
   useDebateActivity: () => ({ data: { available_to_debate: mocks.available, incoming_request_count: 0 } }),
   useUpdateDebateAvailability: () => ({ mutate: mocks.updateAvailability, isPending: false }),
   useCreateDebateChallenge: () => ({ mutate: vi.fn(), isPending: false, error: null }),
@@ -98,6 +99,7 @@ function renderOpen(tab: 'requests' | 'matches' | 'claims' | 'people' = 'request
 }
 
 beforeEach(() => {
+  mocks.ready = true;
   mocks.authenticated = true;
   mocks.available = false;
   mocks.people = [];
@@ -182,6 +184,25 @@ describe('DebatesHubPanel', () => {
 
     expect(screen.queryByRole('button', { name: /Matches/ })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /Requests/ })).not.toBeInTheDocument();
+  });
+
+  // `authenticated` is false while Privy restores, so a row drawn before then is the signed-out
+  // one — a returning viewer would watch Matches and Requests appear and their selected tab jump.
+  it('hides the tab row until Privy has resolved, rather than drawing the signed-out one', () => {
+    mocks.ready = false;
+    mocks.authenticated = false;
+    renderOpen('matches');
+
+    // `aria-hidden` takes the row out of the accessibility tree, so it is not reachable at all —
+    // which is the point: nothing is announced or focusable until we know which row it should be.
+    expect(screen.queryByRole('button', { name: 'Claims' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Claims', hidden: true })).toBeInTheDocument();
+  });
+
+  it('shows the tab row once Privy has resolved', () => {
+    renderOpen('matches');
+
+    expect(screen.getByRole('button', { name: 'Claims' })).toBeInTheDocument();
   });
 
   // Signing out with Matches open would otherwise leave a tab body showing with no tab selected.

--- a/apps/web/core/debates/matchmaking/debates-hub-panel.tsx
+++ b/apps/web/core/debates/matchmaking/debates-hub-panel.tsx
@@ -42,6 +42,26 @@ const TABS: { id: DebatesHubTab; label: string }[] = [
   { id: 'requests', label: 'Requests' },
 ];
 
+/**
+ * GEO-2725. Matches and Requests are a particular person's, so signed out they have no possible
+ * contents — not an empty list but a meaningless one. Claims and People describe the world rather
+ * than the viewer, so both read fine anonymously and are what the hub offers before sign-in.
+ */
+const SIGNED_OUT_TABS: DebatesHubTab[] = ['claims', 'people'];
+
+function tabsFor(authenticated: boolean) {
+  return authenticated ? TABS : TABS.filter(tab => SIGNED_OUT_TABS.includes(tab.id));
+}
+
+/**
+ * Signing out with Matches or Requests open would otherwise leave the panel on a tab that is no
+ * longer in the row, showing a tab body with no tab selected.
+ */
+function visibleTab(activeTab: DebatesHubTab, authenticated: boolean): DebatesHubTab {
+  if (authenticated || SIGNED_OUT_TABS.includes(activeTab)) return activeTab;
+  return 'claims';
+}
+
 function isInteractiveDragTarget(target: EventTarget | null): boolean {
   if (!(target instanceof Element)) return false;
   return Boolean(
@@ -198,8 +218,10 @@ type SurfaceProps = {
   onClose?: () => void;
 };
 
-function DebatesHubSurface({ activeTab, onTabChange, onClose }: SurfaceProps) {
+function DebatesHubSurface({ activeTab: requestedTab, onTabChange, onClose }: SurfaceProps) {
   const { authenticated, ready } = useGeoChatAuth();
+  const tabs = tabsFor(authenticated);
+  const activeTab = visibleTab(requestedTab, authenticated);
   const { data: activity } = useDebateActivity(authenticated);
   const { data: requests } = useDebateRequests(authenticated);
 
@@ -246,7 +268,7 @@ function DebatesHubSurface({ activeTab, onTabChange, onClose }: SurfaceProps) {
               already fits, and Requests carries the badge, so it is the worst one to lose. */}
           <div className="no-scrollbar overflow-x-auto">
             <div className="relative flex w-max items-center gap-6 pb-2">
-              {TABS.map(tab => (
+              {tabs.map(tab => (
                 <button
                   key={tab.id}
                   type="button"
@@ -288,9 +310,9 @@ function DebatesHubSurface({ activeTab, onTabChange, onClose }: SurfaceProps) {
         data-debates-hub-scroll
         className="min-h-0 flex-1 overflow-y-auto overscroll-contain pb-6"
       >
-        {!ready ? null : !authenticated ? (
-          <HubMessage>Sign in to find people to debate.</HubMessage>
-        ) : (
+        {/* Still gated on `ready`: rendering before Privy has restored the session would show the
+            signed-out tab row for a beat to someone who is in fact signed in. */}
+        {!ready ? null : (
           <HubSwap activeKey={activeTab}>
             {activeTab === 'requests' ? (
               <RequestsTab />

--- a/apps/web/core/debates/matchmaking/debates-hub-panel.tsx
+++ b/apps/web/core/debates/matchmaking/debates-hub-panel.tsx
@@ -260,7 +260,10 @@ function DebatesHubSurface({ activeTab: requestedTab, onTabChange, onClose }: Su
         </div>
       </div>
 
-      <div className="shrink-0 px-4">
+      {/* Hidden until Privy resolves, not just the body below it. `authenticated` is false during
+          restoration, so a row drawn before then is the signed-out one — a returning viewer would
+          watch Matches and Requests appear, and a selected tab of theirs jump to Claims. */}
+      <div className={cx('shrink-0 px-4', !ready && 'invisible')} aria-hidden={!ready}>
         <div className="relative">
           {/* The row is `w-max` so the labels never compress, and both panel shells are
               `overflow-hidden` — so on a narrow phone whichever tab sits last is simply cut off
@@ -310,8 +313,6 @@ function DebatesHubSurface({ activeTab: requestedTab, onTabChange, onClose }: Su
         data-debates-hub-scroll
         className="min-h-0 flex-1 overflow-y-auto overscroll-contain pb-6"
       >
-        {/* Still gated on `ready`: rendering before Privy has restored the session would show the
-            signed-out tab row for a beat to someone who is in fact signed in. */}
         {!ready ? null : (
           <HubSwap activeKey={activeTab}>
             {activeTab === 'requests' ? (

--- a/apps/web/core/debates/matchmaking/hooks.ts
+++ b/apps/web/core/debates/matchmaking/hooks.ts
@@ -43,6 +43,13 @@ const MATCHMAKING_CLAIMS_PAGE_SIZE = 20;
  * switch and the round trip that followed — UNSUBSCRIBE, SUBSCRIBE, READY — re-reconciled the whole
  * scope, refetching every loaded claims page and eating into the session's SUBSCRIBE budget.
  */
+/**
+ * Subscribes to matchmaking's live updates, which need a session, and reports whether there is one.
+ *
+ * The two used to be the same answer: no session meant no socket *and* no list. Claims and People
+ * are readable signed out now (GEO-2725), so the socket stays gated while the lists no longer are
+ * — a signed-out viewer gets a static list rather than none, which is the trade the hub wants.
+ */
 export function useMatchmakingScope(enabled: boolean) {
   const { authenticated } = useGeoChatAuth();
   useDebateGatewayScope({ scope: 'matchmaking' }, enabled && authenticated);
@@ -51,13 +58,15 @@ export function useMatchmakingScope(enabled: boolean) {
 
 export function useDebatePeople(enabled: boolean) {
   const { accountKey, getPrivyIdentityToken } = useGeoChatAuth();
-  const authenticated = useMatchmakingScope(enabled);
+  useMatchmakingScope(enabled);
 
   return useQuery({
     ...debateQueryNetworkOptions,
+    // `accountKey` is null signed out, which keys the anonymous list separately from anyone's —
+    // so signing in cannot serve the signed-out answer, and signing out cannot leak the other way.
     queryKey: debateQueryKeys.people(accountKey),
     queryFn: ({ signal }) => listDebatePeople(getPrivyIdentityToken, accountKey, signal),
-    enabled: enabled && authenticated,
+    enabled,
     // Presence is the most volatile thing the hub shows, and coming back to the window is exactly
     // when it is most likely to have moved on without us.
     refetchOnWindowFocus: true,
@@ -66,7 +75,7 @@ export function useDebatePeople(enabled: boolean) {
 
 export function useMatchmakingClaims(query: MatchmakingClaimsQuery, enabled: boolean) {
   const { accountKey, getPrivyIdentityToken } = useGeoChatAuth();
-  const authenticated = useMatchmakingScope(enabled);
+  useMatchmakingScope(enabled);
 
   return useInfiniteQuery({
     ...debateQueryNetworkOptions,
@@ -83,7 +92,7 @@ export function useMatchmakingClaims(query: MatchmakingClaimsQuery, enabled: boo
     // Changing a filter or typing in search changes the query key; without this the list would be
     // replaced by a skeleton on every keystroke.
     placeholderData: keepPreviousData,
-    enabled: enabled && authenticated,
+    enabled,
   });
 }
 

--- a/apps/web/core/debates/matchmaking/hooks.ts
+++ b/apps/web/core/debates/matchmaking/hooks.ts
@@ -50,6 +50,16 @@ const MATCHMAKING_CLAIMS_PAGE_SIZE = 20;
  * are readable signed out now (GEO-2725), so the socket stays gated while the lists no longer are
  * — a signed-out viewer gets a static list rather than none, which is the trade the hub wants.
  */
+/**
+ * Whether a previous query's key belongs to the account asking now.
+ *
+ * `debateQueryKeys.matchmakingClaims` puts `accountKey` in the key, so comparing that one element
+ * is enough — and it is read positionally because the key is built here and nowhere else.
+ */
+function sameQueryAccount(previousKey: readonly unknown[], accountKey: string | null) {
+  return previousKey[2] === accountKey;
+}
+
 export function useMatchmakingScope(enabled: boolean) {
   const { authenticated } = useGeoChatAuth();
   useDebateGatewayScope({ scope: 'matchmaking' }, enabled && authenticated);
@@ -91,7 +101,13 @@ export function useMatchmakingClaims(query: MatchmakingClaimsQuery, enabled: boo
     getNextPageParam: lastPage => lastPage.next_cursor,
     // Changing a filter or typing in search changes the query key; without this the list would be
     // replaced by a skeleton on every keystroke.
-    placeholderData: keepPreviousData,
+    //
+    // Only within one account, though. Signing out changes `accountKey` in the key too, and holding
+    // the previous pages through that would render the signed-in list — `mine` results, viewer
+    // readiness — as the anonymous answer until the new request lands. A skeleton is the honest
+    // state there, so the carry-over is dropped when the account behind the previous query differs.
+    placeholderData: (previousData, previousQuery) =>
+      previousQuery && !sameQueryAccount(previousQuery.queryKey, accountKey) ? undefined : previousData,
     enabled,
   });
 }

--- a/apps/web/core/debates/matchmaking/hub-states.tsx
+++ b/apps/web/core/debates/matchmaking/hub-states.tsx
@@ -18,6 +18,19 @@ export function isMatchmakingUnavailable(error: unknown) {
 }
 
 /**
+ * geo-chat refusing an anonymous read of a matchmaking list.
+ *
+ * The logged-out hub asks for Claims and People without a token. Whether geo-chat serves those
+ * anonymously is its call, not ours, and it can change without this UI changing — so a refusal is
+ * handled as a defined state rather than an error, the same way the 404 above is. If it serves
+ * them, nobody sees this; if it doesn't, a signed-out viewer gets the sign-in prompt they would
+ * have got anyway instead of "Something went wrong."
+ */
+export function isSignInRequired(error: unknown) {
+  return error instanceof GeoChatRequestError && (error.status === 401 || error.status === 403);
+}
+
+/**
  * Horizontally neutral: every tab already insets its content by 16px, so self-padding here would
  * double it and make the empty state sit further in than the list it replaces.
  */
@@ -41,6 +54,8 @@ type HubQueryStateProps = {
   emptyAction?: { label: string; onClick: () => void };
   /** Enables a retry on the error state. */
   onRetry?: () => void;
+  /** Offered when the list is only reachable signed in. See {@link isSignInRequired}. */
+  signInAction?: { label: string; message: string; onClick: () => void };
   children: React.ReactNode;
 };
 
@@ -52,13 +67,19 @@ export function HubQueryState({
   emptyMessage,
   emptyAction,
   onRetry,
+  signInAction,
   children,
 }: HubQueryStateProps) {
-  const state = error ? 'error' : isLoading ? 'loading' : isEmpty ? 'empty' : 'content';
+  const needsSignIn = Boolean(signInAction) && isSignInRequired(error);
+  const state = needsSignIn ? 'sign-in' : error ? 'error' : isLoading ? 'loading' : isEmpty ? 'empty' : 'content';
 
   return (
     <HubSwap activeKey={state}>
-      {state === 'error' ? (
+      {state === 'sign-in' ? (
+        <HubMessage action={<HubPillButton onClick={signInAction!.onClick}>{signInAction!.label}</HubPillButton>}>
+          {signInAction!.message}
+        </HubMessage>
+      ) : state === 'error' ? (
         <HubMessage
           action={
             // A "not deployed yet" 404 won't resolve by retrying, so only offer it for real errors.

--- a/apps/web/core/debates/matchmaking/matchmaking-claim-card.tsx
+++ b/apps/web/core/debates/matchmaking/matchmaking-claim-card.tsx
@@ -60,6 +60,12 @@ type Props = {
    * that only means "don't know yet", which would draw the viewer onto two sides at once.
    */
   viewerIdentityPending?: boolean;
+  /**
+   * Sends a signed-out viewer to Privy instead of publishing. Set by hosts that render to signed-out
+   * viewers — the hub's Claims tab and the claim page — and left unset when signing in is not a
+   * possibility the host has to handle, which keeps the response path unchanged for everyone else.
+   */
+  onRequireSignIn?: () => void;
   /** `AnimatePresence mode="popLayout"` measures the exiting row through this; without it the row
    * never pops out of flow and the rows above close the gap only after the fade finishes. */
   ref?: React.Ref<HTMLElement>;
@@ -88,6 +94,7 @@ export function MatchmakingClaimCard({
   onOpenClaim,
   hideReadinessToggle,
   viewerIdentityPending,
+  onRequireSignIn,
   ref,
 }: Props) {
   // geo-chat can hand back a claim the graph has never seen. Responding to one is impossible, and
@@ -107,6 +114,7 @@ export function MatchmakingClaimCard({
           onOpenClaim={onOpenClaim}
           hideReadinessToggle={hideReadinessToggle}
           viewerIdentityPending={viewerIdentityPending}
+          onRequireSignIn={onRequireSignIn}
         />
       ) : (
         <UnresolvableControls
@@ -312,6 +320,7 @@ function RespondableControls({
   onOpenClaim,
   hideReadinessToggle,
   viewerIdentityPending,
+  onRequireSignIn,
 }: {
   claim: DebateClaimSummary;
   positions: DebateClaimPositionSummary[];
@@ -320,9 +329,10 @@ function RespondableControls({
   onOpenClaim?: () => void;
   hideReadinessToggle?: boolean;
   viewerIdentityPending?: boolean;
+  onRequireSignIn?: () => void;
 }) {
   const { viewerPosition, optimisticPositions, respond, actionTitle, responseError, canRespond } =
-    useClaimPositionControl({ claim, positions, readiness, viewerIdentityPending });
+    useClaimPositionControl({ claim, positions, readiness, viewerIdentityPending, onRequireSignIn });
   return (
     <>
       <ClaimHeader

--- a/apps/web/core/debates/matchmaking/people-tab.test.tsx
+++ b/apps/web/core/debates/matchmaking/people-tab.test.tsx
@@ -6,6 +6,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { DebateChallenge, DebatePerson } from '../api';
 
 const mocks = vi.hoisted(() => ({
+  promptSignIn: vi.fn(),
+  /** Privy's answer; the tab's signed-out paths hang off it. */
+  authenticated: true,
   people: [] as DebatePerson[],
   challenge: null as DebateChallenge | null,
   outboundRequest: null as unknown,
@@ -18,6 +21,7 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock('../hooks', () => ({
+  useGeoChatAuth: () => ({ authenticated: mocks.authenticated, ready: true, accountKey: 'user-a' }),
   useDebateActivity: () => ({
     data: { challenge: mocks.challenge, outbound_request: mocks.outboundRequest, debate: mocks.activeDebate },
   }),
@@ -37,6 +41,12 @@ vi.mock('./hooks', () => ({
 
 vi.mock('../use-current-geo-chat-user-id', () => ({
   useCurrentGeoChatUserId: () => mocks.currentUserId,
+}));
+
+// `usePrivySignIn` reaches for Privy's context, which these suites do not stand up. The signed-out
+// paths assert that it is *called*, so the stub is shared through `mocks.promptSignIn`.
+vi.mock('~/core/hooks/use-privy-sign-in', () => ({
+  usePrivySignIn: () => mocks.promptSignIn,
 }));
 
 const { PeopleTab } = await import('./people-tab');
@@ -75,6 +85,8 @@ const awaitingText = 'You have a debate request awaiting a reply.';
 const card = () => screen.queryByRole('article');
 
 beforeEach(() => {
+  // Not a mock fn, so `resetAllMocks` does not restore it.
+  mocks.authenticated = true;
   mocks.people = [person('user-them', 'Arturas'), person('user-other', 'Vytautas')];
   mocks.challenge = null;
   mocks.outboundRequest = null;
@@ -263,5 +275,27 @@ describe('PeopleTab', () => {
     expect(
       screen.getByText('You already have an open request — withdraw it to challenge someone else.')
     ).toBeInTheDocument();
+  });
+
+  // GEO-2725. Signed out the button is the entry to signing in, so it stays live and opens Privy
+  // rather than sending a request that could only fail at the token exchange.
+  it('sends a signed-out visitor to sign in instead of requesting a debate', () => {
+    mocks.authenticated = false;
+    render(<PeopleTab />);
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Debate' })[0]);
+
+    expect(mocks.promptSignIn).toHaveBeenCalled();
+    expect(mocks.createChallenge).not.toHaveBeenCalled();
+  });
+
+  // The row's availability flags describe a pairing with somebody, and signed out there is nobody
+  // to pair with — so they are not a reason to refuse the press that starts the sign-in.
+  it('keeps the button live signed out even when the row reads unavailable', () => {
+    mocks.authenticated = false;
+    mocks.people = [{ ...person('user-them', 'Arturas'), can_challenge: false }];
+    render(<PeopleTab />);
+
+    expect(screen.getByRole('button', { name: 'Debate' })).not.toBeDisabled();
   });
 });

--- a/apps/web/core/debates/matchmaking/people-tab.test.tsx
+++ b/apps/web/core/debates/matchmaking/people-tab.test.tsx
@@ -291,11 +291,21 @@ describe('PeopleTab', () => {
 
   // The row's availability flags describe a pairing with somebody, and signed out there is nobody
   // to pair with — so they are not a reason to refuse the press that starts the sign-in.
-  it('keeps the button live signed out even when the row reads unavailable', () => {
+  it('keeps the button live signed out when only the viewer-relative flag is off', () => {
     mocks.authenticated = false;
     mocks.people = [{ ...person('user-them', 'Arturas'), can_challenge: false }];
     render(<PeopleTab />);
 
     expect(screen.getByRole('button', { name: 'Debate' })).not.toBeDisabled();
+  });
+
+  // `in_debate` is true of the person, not of any viewer, so signing in would not make them
+  // available — offering the press would spend a login on an answer that does not change.
+  it('still refuses a person already in a debate when signed out', () => {
+    mocks.authenticated = false;
+    mocks.people = [{ ...person('user-them', 'Arturas'), in_debate: true }];
+    render(<PeopleTab />);
+
+    expect(screen.getByRole('button', { name: 'In a debate' })).toBeDisabled();
   });
 });

--- a/apps/web/core/debates/matchmaking/people-tab.test.tsx
+++ b/apps/web/core/debates/matchmaking/people-tab.test.tsx
@@ -283,7 +283,7 @@ describe('PeopleTab', () => {
     mocks.authenticated = false;
     render(<PeopleTab />);
 
-    fireEvent.click(screen.getAllByRole('button', { name: 'Debate' })[0]);
+    fireEvent.click(screen.getAllByRole('button', { name: 'Request debate' })[0]);
 
     expect(mocks.promptSignIn).toHaveBeenCalled();
     expect(mocks.createChallenge).not.toHaveBeenCalled();
@@ -296,7 +296,7 @@ describe('PeopleTab', () => {
     mocks.people = [{ ...person('user-them', 'Arturas'), can_challenge: false }];
     render(<PeopleTab />);
 
-    expect(screen.getByRole('button', { name: 'Debate' })).not.toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Request debate' })).not.toBeDisabled();
   });
 
   // `in_debate` is true of the person, not of any viewer, so signing in would not make them

--- a/apps/web/core/debates/matchmaking/people-tab.tsx
+++ b/apps/web/core/debates/matchmaking/people-tab.tsx
@@ -2,13 +2,15 @@
 
 import * as React from 'react';
 
+import { usePrivySignIn } from '~/core/hooks/use-privy-sign-in';
+
 import { Avatar } from '~/design-system/avatar';
 import { Input } from '~/design-system/input';
 import { Text } from '~/design-system/text';
 
 import { activeDebate } from '../activity-state';
 import type { DebatePerson } from '../api';
-import { useCreateDebateChallenge, useDebateActivity } from '../hooks';
+import { useCreateDebateChallenge, useDebateActivity, useGeoChatAuth } from '../hooks';
 import { speakerLabel } from '../playback-utils';
 import { useCurrentGeoChatUserId } from '../use-current-geo-chat-user-id';
 import { DebateChallengeCard } from './challenge-card';
@@ -23,9 +25,16 @@ import { useUnexpiredRequests } from './use-request-countdown';
  * `ProfileDebateButton` on a person's home space — `DebateCoordinator` owns the resulting dialog.
  */
 export function PeopleTab() {
+  const { authenticated } = useGeoChatAuth();
+  const promptSignIn = usePrivySignIn();
+  // Undefined when signed in, so every path below keeps behaving exactly as it did.
+  const onRequireSignIn = authenticated ? undefined : promptSignIn;
+
   const peopleQuery = useDebatePeople(true);
-  const { data: activity } = useDebateActivity(true);
-  const { data: requests } = useDebateRequests(true);
+  // Both describe the viewer's own state, so signed out there is nothing to ask for. Passing
+  // `authenticated` rather than `true` keeps them from firing a request that can only 401.
+  const { data: activity } = useDebateActivity(authenticated);
+  const { data: requests } = useDebateRequests(authenticated);
   const currentUserId = useCurrentGeoChatUserId();
   const allPeople = React.useMemo(() => peopleQuery.data?.people ?? [], [peopleQuery.data]);
 
@@ -99,6 +108,11 @@ export function PeopleTab() {
             search.trim() ? 'Nobody available matches that search.' : 'Nobody is available to debate right now.'
           }
           emptyAction={search.trim() ? { label: 'Clear search', onClick: () => setSearch('') } : undefined}
+          signInAction={
+            onRequireSignIn
+              ? { label: 'Sign in', message: 'Sign in to see who is available to debate.', onClick: onRequireSignIn }
+              : undefined
+          }
         >
           <>
             {blockedReason ? (
@@ -113,6 +127,7 @@ export function PeopleTab() {
                   person={person}
                   disabled={buttonsDisabled}
                   disabledReason={blockedReason ?? 'You have a debate request awaiting a reply.'}
+                  onRequireSignIn={onRequireSignIn}
                 />
               ))}
             </ul>
@@ -127,11 +142,17 @@ function PersonRow({
   person,
   disabled,
   disabledReason,
+  onRequireSignIn,
 }: {
   person: DebatePerson;
   disabled: boolean;
   /** Only surfaced on hover, so it explains the greyed-out button without repeating the card. */
   disabledReason: string;
+  /**
+   * Set only when signed out. Pressing Debate then opens Privy instead of sending a request, which
+   * would fail at the token exchange with an error the viewer can do nothing about.
+   */
+  onRequireSignIn?: () => void;
 }) {
   const createChallenge = useCreateDebateChallenge();
 
@@ -146,8 +167,14 @@ function PersonRow({
         </Text>
       </div>
       <HubPillButton
-        onClick={() => createChallenge.mutate({ recipient_profile_space_id: person.profile_space_id })}
-        disabled={!person.can_challenge || person.in_debate || disabled}
+        onClick={() =>
+          onRequireSignIn
+            ? onRequireSignIn()
+            : createChallenge.mutate({ recipient_profile_space_id: person.profile_space_id })
+        }
+        // Signed out, the row's own availability flags are about nobody in particular, so they are
+        // not a reason to refuse the press — the press is what starts the sign-in.
+        disabled={!onRequireSignIn && (!person.can_challenge || person.in_debate || disabled)}
         pending={createChallenge.isPending}
         pendingLabel="Requesting…"
         title={disabled ? disabledReason : undefined}

--- a/apps/web/core/debates/matchmaking/people-tab.tsx
+++ b/apps/web/core/debates/matchmaking/people-tab.tsx
@@ -172,9 +172,11 @@ function PersonRow({
             ? onRequireSignIn()
             : createChallenge.mutate({ recipient_profile_space_id: person.profile_space_id })
         }
-        // Signed out, the row's own availability flags are about nobody in particular, so they are
-        // not a reason to refuse the press — the press is what starts the sign-in.
-        disabled={!onRequireSignIn && (!person.can_challenge || person.in_debate || disabled)}
+        // `in_debate` holds signed out too: it means this person is in an active debate right now,
+        // which is true of them rather than of any viewer, so signing in would not make them
+        // available. `can_challenge` and the viewer's own pending request are the viewer-relative
+        // ones, and those are what the press bypasses on its way to the sign-in.
+        disabled={person.in_debate || (!onRequireSignIn && (!person.can_challenge || disabled))}
         pending={createChallenge.isPending}
         pendingLabel="Requesting…"
         title={disabled ? disabledReason : undefined}


### PR DESCRIPTION
Closes [GEO-2725](https://linear.app/geobrowser/issue/GEO-2725/debates-make-the-side-panel-accessible-logged-out-claims-and-people)

## What changed

The hub was a single sign-in message end to end. Now:

| | Signed in | Signed out |
|---|---|---|
| Claims | ✓ | ✓ |
| People | ✓ | ✓ |
| Matches | ✓ | — |
| Requests | ✓ | — |

Matches and Requests are a particular person's, so signed out they have no possible contents — not an empty list but a meaningless one. They drop out of the tab row, and signing out with either open falls back to Claims rather than leaving a tab body showing with no tab selected.

## ⚠️ One thing needs your answer: does geo-chat serve these anonymously?

**I could not verify this, and it decides whether the tabs have content.**

`/matchmaking/claims` and `/matchmaking/people` were `auth: true`. They now go out as `auth: 'optional'` — the same mode `/debates/{id}`, the media and the transcript reads already use, which is how the logged-out browse feed works today. But whether geo-chat *serves* them without a token is the backend's call, and I had no way to check: the `.external` checkout predates matchmaking (2026-08-11), and there is no reachable deployment URL in this repo.

Rather than guess, I made it correct under **both** answers. `isSignInRequired` treats a 401/403 the way `isMatchmakingUnavailable` already treats a 404 — a defined state, not an error:

- **If geo-chat serves them** → the tabs have content, nothing else to do.
- **If it refuses** → a signed-out viewer gets a "Sign in to browse claims to debate." prompt instead of "Something went wrong." No worse than today's message.

So this is safe to merge either way, but **if the endpoints need opening up, that's a geo-chat change this PR can't make.** Worth confirming before this counts as done.

## Actions prompt Privy

Both paths the ticket names, through the same `usePrivySignIn` the vote arrows and the claim page already use — so session restoration isn't mistaken for a login someone asked for.

- **Claim positions.** `MatchmakingClaimCard` gains `onRequireSignIn` and forwards it to `useClaimPositionControl`, which already supported it for the claim page (#2281). The card was the only thing not passing it through — so this is wiring, not new behavior.
- **Debate request on People.** Signed out, the row's `can_challenge` / `in_debate` flags describe a pairing with nobody, so they no longer disable the press that starts sign-in.

On your "return to intended action" note: **not implemented.** `usePrivySignIn` takes an `onComplete`, so the hook supports it, but resuming a *position* means holding which claim and which side across the redirect. Called out below rather than half-built.

## Data scoping

- **"My positions" leaves the filter menu signed out** — it's the viewer's own list, so it could only ever come back empty, which reads as broken rather than as an answer. Featured stays the landing filter, which matches your GEO-2683 note.
- The **activity** and **requests** lookups behind People are skipped rather than fired at a 401.
- The live socket scope stays authenticated. Signed-out viewers get a static list rather than none.
- **Nothing new is exposed on People**: it renders display name and avatar, both already public on a profile.

## Testing

- `debates-hub-panel.test.tsx` — the old "asks anonymous visitors to sign in" test is replaced by three: the signed-out tab set, Matches/Requests absent, and the fallback when signed out on a tab that's gone. ClaimsTab is stubbed here since this suite is about the tab row, not the list.
- `people-tab.test.tsx` — pressing Debate signed out calls Privy and does *not* send a challenge; the button stays live even when the row reads unavailable.
- `claims-tab.test.tsx` — "My positions" absent signed out, present signed in.
- Full suite: **331 files, 3577 tests, all passing.** Typecheck clean; lint clean (2 pre-existing warnings in files I reverted).

## Not covered

- Resuming the intended action after sign-in (above).
- The default landing tab is unchanged (`claims`) for both states — your ticket asked for that to be confirmed rather than changed.

---

## Follow-up: the navbar button

The hub opened to signed-out viewers, but `DebatesHubButton` still returned `null` for them — so Claims and People were reachable only by someone already signed in, which is nobody who needed them. The signed-out navbar had just Search and Log in.

The button now renders for everyone. Two things fall out of that:

- **The badge stays signed-in only.** It counts requests addressed to somebody. Both lookups behind it are already gated on the session, so signed out nothing is fetched — and the count is guarded explicitly too, since a cache left from a session that has since signed out would otherwise badge the button for nobody. Covered by a test.
- **It no longer waits on Privy.** The old comment justified hiding it until the session resolved, to avoid flashing in and out. The button is the same for both answers now, so there's nothing to wait for.

`debates-hub-button.test.tsx`: the two "stays hidden" tests are replaced by shows-when-signed-out, shows-while-Privy-resolves, and never-badges-a-signed-out-visitor.

Full suite: **331 files, 3578 tests, all passing.**


---

## Update: what a signed-out viewer actually sees

Chased down the open question. **The default view works signed out with no backend change**, because Featured does not come from geo-chat:

| Filter | Source | Signed out |
|---|---|---|
| **Featured** (default) | public knowledge graph | ✅ works — **verified, 50 claims** |
| All claims | geo-chat `/matchmaking/claims` | depends on geo-chat |
| My positions | geo-chat, viewer-relative | hidden |
| Debate now | geo-chat, viewer-relative | hidden |

`useFeaturedClaims` goes to the GraphQL knowledge graph, not geo-chat — `featured-claims.ts` says so ("the index has no notion of the tag, so picking it swaps the list's source for the knowledge graph"). That endpoint takes no auth at all. I ran the exact query anonymously against testnet: **50 featured claims**, including "The United States should remain NATO's principal security guarantor" and "AI companions are better than social isolation".

Since Featured is the landing filter, a signed-out viewer opens the hub onto a populated list either way. The geo-chat question now only affects **All claims**, and it degrades to the sign-in prompt rather than an error.

## Debate now leaves the menu signed out

Viewer-relative in a way its label doesn't show: geo-chat scores it on who is available to debate *you*, excluding anyone you're already pair-blocked with. With no viewer it isn't a stricter "All claims" — it's a question with no subject. It now leaves the menu alongside "My positions", so signed out the menu is **Featured** and **All claims**.

Full suite: **331 files, 3578 tests, all passing.**
