### PR TITLE
feat: clamp long side panel descriptions like entity pages

### DIFF
--- a/apps/web/partials/entity-page/entity-page-body.tsx
+++ b/apps/web/partials/entity-page/entity-page-body.tsx
@@ -215,7 +215,6 @@ export function EntityPageBody(props: EntityPageBodyProps) {
                 <EntityPageInlineDescription
                   entityId={entityId}
                   spaceId={spaceId}
-                  truncate={false}
                   fallbackDescription={previewDescription}
                 />
               )}

--- a/apps/web/partials/entity-page/entity-page-inline-description.test.tsx
+++ b/apps/web/partials/entity-page/entity-page-inline-description.test.tsx
@@ -1,0 +1,39 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { EntityPageInlineDescription } from './entity-page-inline-description';
+
+const LONG_DESCRIPTION =
+  'A description long enough that it would run past three lines in the narrow side panel, ' +
+  'which is the whole reason it needs the same More/Less treatment the entity page already gives it.';
+
+vi.mock('~/core/hooks/use-user-is-editing', () => ({ useUserIsEditing: () => false }));
+vi.mock('~/core/sync/use-mutate', () => ({ useMutate: () => ({ storage: { values: {} } }) }));
+vi.mock('~/core/sync/use-store', () => ({ useValue: () => undefined }));
+
+afterEach(cleanup);
+
+/**
+ * The side panel used to opt out of clamping with `truncate={false}`, so the same
+ * description rendered fully there and clamped on the entity page. Both surfaces now
+ * render this one component with no opt-out.
+ *
+ * jsdom reports every box as zero-sized, so ClampedText's overflow measurement can't
+ * run and the More button never appears here. The clamp class is applied regardless of
+ * measurement, so that is what these assert.
+ */
+describe('EntityPageInlineDescription', () => {
+  it('clamps a long description to three lines', () => {
+    render(<EntityPageInlineDescription entityId="e1" spaceId="s1" fallbackDescription={LONG_DESCRIPTION} />);
+
+    expect(screen.getByText(LONG_DESCRIPTION)).toHaveClass('line-clamp-3');
+  });
+
+  it('renders nothing without a description', () => {
+    const { container } = render(<EntityPageInlineDescription entityId="e1" spaceId="s1" />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/apps/web/partials/entity-page/entity-page-inline-description.tsx
+++ b/apps/web/partials/entity-page/entity-page-inline-description.tsx
@@ -14,12 +14,10 @@ const MAX_LINES = 3;
 export function EntityPageInlineDescription({
   entityId,
   spaceId,
-  truncate = true,
   fallbackDescription,
 }: {
   entityId: string;
   spaceId: string;
-  truncate?: boolean;
   fallbackDescription?: string | null;
 }) {
   const isEditing = useUserIsEditing(spaceId);
@@ -75,14 +73,6 @@ export function EntityPageInlineDescription({
 
   if (!description) {
     return null;
-  }
-
-  if (!truncate) {
-    return (
-      <div className="-mt-3 mb-5">
-        <p className="text-body wrap-break-word text-text">{description}</p>
-      </div>
-    );
   }
 
   return (


### PR DESCRIPTION
Closes [GEO-2718](https://linear.app/geobrowser/issue/GEO-2718/side-panel-use-the-same-more-less-behavior-as-entity-pages-for-long).

## What

Long descriptions in the side panel now clamp to three lines with the same **More / Less** toggle entity pages already use.

## Why it diverged

Both surfaces already render the same `EntityPageInlineDescription` — the panel just passed `truncate={false}`, which routed it to a plain `<p>` instead of `ClampedText`:

```tsx
<EntityPageInlineDescription
  entityId={entityId}
  spaceId={spaceId}
  truncate={false}          // ← the whole bug
  fallbackDescription={previewDescription}
/>
```

That flag arrived with #1824, the refactor that merged the route page and side panel onto `EntityPageBody`. It looks like it preserved how the panel happened to look at the time rather than a decision that clamping was wrong there — nothing in that PR argues for it.

So this is a deletion, not a reimplementation: the shared component was already in place and already correct.

## The prop goes too

The panel was the only caller passing `truncate={false}`, so leaving the prop behind would leave a dead branch — and the exact escape hatch that let these two surfaces drift apart in the first place. Removing it means the compiler now enforces the ticket's "keep them in sync" requirement rather than a convention. That's the one piece here beyond the literal ask; trivial to put back if you'd rather keep the option.

## Line-based, as the ticket asked

The ticket flagged whether the cutoff should be line-based rather than a fixed character count. It already is — `ClampedText` uses CSS `line-clamp` with `maxLines={3}`, so the same three lines adapt to each surface's width instead of a character count that would cut at a different visual point on each. Rendered with the app's Calibre face at `text-body` (20px / 29px):

| Surface | Content width | Result |
|---|---|---|
| Entity page | 900px | 3 lines, More in the reserved gutter |
| Side panel, desktop | ~560px (`w-[min(600px,100vw)]` less `px-5`) | 3 lines, same toggle |
| Side panel, mobile | ~343px | 3 lines, same toggle |

Desktop and mobile share one `panelBody` → `EntitySidePanelSurface` → `EntityPageBody variant="sidePanel"`, so both follow from the single change.

## Testing

- New `entity-page-inline-description.test.tsx` pins that a long description renders clamped, and that an empty one renders nothing. Confirmed the clamp assertion fails if `ClampedText` is swapped back for a plain paragraph.
  - jsdom reports every box as zero-sized, so `ClampedText`'s overflow measurement can't run there and the More button never appears — the clamp class is applied regardless of measurement, so that's what the test asserts. The visual check above covers the toggle itself.
- `vitest run partials/entity-page` — 10 files, 38 tests, all passing
- `tsc --noEmit` — no new errors (4 pre-existing, in `sort-open-proposals.test.ts` and `entity-response.test.ts`, untouched here)