### PR TITLE
feat: linkable URL that opens the Privy sign-in modal on Explore

### DIFF
--- a/apps/web/app/entry.tsx
+++ b/apps/web/app/entry.tsx
@@ -75,6 +75,11 @@ const PostAuthRedirect = dynamic(
   { ssr: false }
 );
 
+const SignInDeepLinkHandler = dynamic(
+  () => import('~/partials/auth/sign-in-deep-link-handler').then(m => ({ default: m.SignInDeepLinkHandler })),
+  { ssr: false }
+);
+
 const ReviewChanges = dynamic(
   () => import('~/partials/review/review-changes').then(m => ({ default: m.ReviewChanges })),
   { ssr: false }
@@ -143,6 +148,9 @@ export function App({ children }: { children: React.ReactNode }) {
           <PendingCreatedSpaceStatus />
           <SignInPrompt />
           <PostAuthRedirect />
+          <React.Suspense fallback={null}>
+            <SignInDeepLinkHandler />
+          </React.Suspense>
           <Toast />
           <GovernanceReopenEditLoadingBar />
           <FlowBar />

--- a/apps/web/core/auth/sign-in-deep-link.test.ts
+++ b/apps/web/core/auth/sign-in-deep-link.test.ts
@@ -64,6 +64,32 @@ describe('urlWithoutSignInModal', () => {
     );
   });
 
+  // A fragment is route state in this app, not decoration — `block-reorder` resolves a linked
+  // block out of `window.location.hash`. Rebuilding the URL without it drops the anchor the
+  // viewer followed, and `replaceState` rewrites the whole URL, so the loss is not recoverable.
+  it('keeps the fragment', () => {
+    expect(urlWithoutSignInModal('/space/space-1/entity-1', params('modal=signin&source=email'), '#block-1')).toBe(
+      '/space/space-1/entity-1#block-1'
+    );
+  });
+
+  it('orders the fragment after the surviving params', () => {
+    expect(urlWithoutSignInModal('/space/space-1/entity-1', params('modal=signin&tabId=tab-2'), '#block-1')).toBe(
+      '/space/space-1/entity-1?tabId=tab-2#block-1'
+    );
+  });
+
+  // `location.hash` is '' when there is no anchor and '#' for a bare one, and neither should
+  // leave a dangling marker on the tidied URL.
+  it('adds no marker when there is no anchor', () => {
+    expect(urlWithoutSignInModal('/explore', params('modal=signin'), '')).toBe('/explore');
+    expect(urlWithoutSignInModal('/explore', params('modal=signin'), '#')).toBe('/explore');
+  });
+
+  it('tolerates a bare id from a caller that is not reading location.hash', () => {
+    expect(urlWithoutSignInModal('/explore', params('modal=signin'), 'block-1')).toBe('/explore#block-1');
+  });
+
   it('is a no-op on a URL that never carried the trigger', () => {
     expect(urlWithoutSignInModal('/explore', params('tabId=tab-2'))).toBe('/explore?tabId=tab-2');
     expect(urlWithoutSignInModal('/explore', null)).toBe('/explore');

--- a/apps/web/core/auth/sign-in-deep-link.test.ts
+++ b/apps/web/core/auth/sign-in-deep-link.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+
+import { requestsSignInModal, signInModalSource, toSignIn, urlWithoutSignInModal } from './sign-in-deep-link';
+
+const params = (search: string) => new URLSearchParams(search);
+
+describe('toSignIn', () => {
+  // The marketing site hardcodes whatever this returns, so the shape is the deliverable.
+  it('builds the link the marketing site hardcodes', () => {
+    expect(toSignIn({ source: 'marketing' })).toBe('/explore?modal=signin&source=marketing');
+  });
+
+  it('omits the attribution when there is none to record', () => {
+    expect(toSignIn()).toBe('/explore?modal=signin');
+  });
+
+  // Nothing about the trigger is specific to Explore — the handler is app-wide — so the same
+  // link works for the next surface that wants one.
+  it('takes the trigger to another route', () => {
+    expect(toSignIn({ pathname: '/root', source: 'email' })).toBe('/root?modal=signin&source=email');
+  });
+
+  it('round-trips through the readers', () => {
+    const built = new URL(toSignIn({ source: 'marketing' }), 'https://geobrowser.io');
+
+    expect(requestsSignInModal(built.searchParams)).toBe(true);
+    expect(signInModalSource(built.searchParams)).toBe('marketing');
+  });
+});
+
+describe('requestsSignInModal', () => {
+  it('recognises the trigger', () => {
+    expect(requestsSignInModal(params('modal=signin'))).toBe(true);
+  });
+
+  it('ignores a different modal, so an unrelated deep link never opens the login', () => {
+    expect(requestsSignInModal(params('modal=something-else'))).toBe(false);
+    expect(requestsSignInModal(params(''))).toBe(false);
+    expect(requestsSignInModal(null)).toBe(false);
+  });
+});
+
+describe('signInModalSource', () => {
+  it('reads the attribution', () => {
+    expect(signInModalSource(params('modal=signin&source=marketing'))).toBe('marketing');
+  });
+
+  it('is null when absent or empty rather than an empty string', () => {
+    expect(signInModalSource(params('modal=signin'))).toBeNull();
+    expect(signInModalSource(params('modal=signin&source='))).toBeNull();
+  });
+});
+
+describe('urlWithoutSignInModal', () => {
+  it('leaves a clean route once the trigger is spent', () => {
+    expect(urlWithoutSignInModal('/explore', params('modal=signin&source=marketing'))).toBe('/explore');
+  });
+
+  // The viewer may have landed somewhere that carries its own state. Dropping it to tidy up the
+  // trigger would be a worse bug than the one the tidying prevents.
+  it('keeps every other param', () => {
+    expect(urlWithoutSignInModal('/space/space-1/entity-1', params('modal=signin&source=marketing&tabId=tab-2'))).toBe(
+      '/space/space-1/entity-1?tabId=tab-2'
+    );
+  });
+
+  it('is a no-op on a URL that never carried the trigger', () => {
+    expect(urlWithoutSignInModal('/explore', params('tabId=tab-2'))).toBe('/explore?tabId=tab-2');
+    expect(urlWithoutSignInModal('/explore', null)).toBe('/explore');
+  });
+});

--- a/apps/web/core/auth/sign-in-deep-link.ts
+++ b/apps/web/core/auth/sign-in-deep-link.ts
@@ -1,0 +1,72 @@
+/**
+ * GEO-2727. The link the marketing site points its "Sign in / Sign up" button at.
+ *
+ *     /explore?modal=signin&source=marketing
+ *
+ * Once that site ships the URL is hardcoded off-repo, so the shape below is a contract rather
+ * than an internal detail — hence one module owning the param names, the reader, and the builder,
+ * so a change here is a change everywhere.
+ *
+ * On the shape:
+ *
+ * - `modal=signin`, not `signin=true`. A named value takes the next deep link (a different modal,
+ *   an entity action) without a new param each time, and has no meaningless `signin=false` state.
+ * - `source` already exists in the repo — `buildBlockLink` writes `?source=copy_link` and
+ *   `block-reorder` reads it — so attribution reuses that key rather than inventing a parallel one.
+ *   Values are lowercase, `snake_case` when they need more than a word, matching `copy_link`.
+ *
+ * Both params are stripped once the trigger has been acted on, so a refresh, a back button, or a
+ * URL copied out of the address bar doesn't reopen the modal for someone who never asked.
+ */
+
+export const MODAL_PARAM = 'modal';
+export const SOURCE_PARAM = 'source';
+
+/** The one `modal` value in use today. Others join it here as deep links are added. */
+export const SIGN_IN_MODAL = 'signin';
+
+/** Where the marketing button lands. Its own page owns nothing about this — the handler is global. */
+const SIGN_IN_PATHNAME = '/explore';
+
+/**
+ * Structural rather than `URLSearchParams` itself: what `useSearchParams` hands back is a
+ * `ReadonlyURLSearchParams`, and narrowing to the concrete class would make every caller cast.
+ */
+type ReadableParams = Pick<URLSearchParams, 'get' | 'toString'> | null | undefined;
+
+/** True when the URL is asking for the sign-in modal. */
+export function requestsSignInModal(params: ReadableParams): boolean {
+  return params?.get(MODAL_PARAM) === SIGN_IN_MODAL;
+}
+
+/**
+ * The attribution value carried alongside the trigger, if any. Free-form on purpose: the marketing
+ * site, an email, or a partner page can each name itself without a deploy here.
+ */
+export function signInModalSource(params: ReadableParams): string | null {
+  return params?.get(SOURCE_PARAM) || null;
+}
+
+/**
+ * The same URL with the trigger removed, preserving every other param — the viewer may have
+ * arrived on a route that carries its own state, and dropping it would be a worse bug than the
+ * one this clearing exists to prevent.
+ */
+export function urlWithoutSignInModal(pathname: string, params: ReadableParams): string {
+  const next = new URLSearchParams(params?.toString() ?? '');
+  next.delete(MODAL_PARAM);
+  next.delete(SOURCE_PARAM);
+  const search = next.toString();
+  return search ? `${pathname}?${search}` : pathname;
+}
+
+/**
+ * Builds the link. Exposed through `NavUtils.toSignIn` as well, which is where anyone looking for
+ * a route in this codebase looks first.
+ */
+export function toSignIn(options?: { source?: string; pathname?: string }): string {
+  const params = new URLSearchParams();
+  params.set(MODAL_PARAM, SIGN_IN_MODAL);
+  if (options?.source) params.set(SOURCE_PARAM, options.source);
+  return `${options?.pathname ?? SIGN_IN_PATHNAME}?${params.toString()}`;
+}

--- a/apps/web/core/auth/sign-in-deep-link.ts
+++ b/apps/web/core/auth/sign-in-deep-link.ts
@@ -51,13 +51,20 @@ export function signInModalSource(params: ReadableParams): string | null {
  * The same URL with the trigger removed, preserving every other param — the viewer may have
  * arrived on a route that carries its own state, and dropping it would be a worse bug than the
  * one this clearing exists to prevent.
+ *
+ * The fragment has to be passed in: `usePathname` and `useSearchParams` both omit it, and a
+ * fragment is route state here rather than decoration — `block-reorder` resolves a linked block
+ * out of `window.location.hash`. Rebuilding a URL without it would silently drop the anchor a
+ * viewer followed.
  */
-export function urlWithoutSignInModal(pathname: string, params: ReadableParams): string {
+export function urlWithoutSignInModal(pathname: string, params: ReadableParams, hash = ''): string {
   const next = new URLSearchParams(params?.toString() ?? '');
   next.delete(MODAL_PARAM);
   next.delete(SOURCE_PARAM);
   const search = next.toString();
-  return search ? `${pathname}?${search}` : pathname;
+  // Accepts `location.hash` as-is, which already carries the `#`, and tolerates a bare id.
+  const fragment = !hash || hash === '#' ? '' : hash.startsWith('#') ? hash : `#${hash}`;
+  return `${pathname}${search ? `?${search}` : ''}${fragment}`;
 }
 
 /**

--- a/apps/web/core/hooks/use-privy-sign-in.test.tsx
+++ b/apps/web/core/hooks/use-privy-sign-in.test.tsx
@@ -81,6 +81,59 @@ describe('usePrivySignIn', () => {
     expect(onComplete).toHaveBeenCalledOnce();
   });
 
+  // `AnalyticsUserIdentifier` already reports restores, as restores. Recording one here as a
+  // manual login double-counted it and mislabelled it — and since this hook is now mounted
+  // app-wide for the sign-in deep link, that would have been every page load with a live session.
+  it('records a login only for a sign-in it started', () => {
+    const { result } = renderHook(() => usePrivySignIn());
+
+    act(() => mocks.privyOnComplete?.({}));
+    expect(mocks.trackPrivyAuth).not.toHaveBeenCalled();
+
+    act(() => result.current());
+    act(() => mocks.privyOnComplete?.({}));
+    expect(mocks.trackPrivyAuth).toHaveBeenCalledOnce();
+    expect(mocks.trackPrivyAuth.mock.calls[0]?.[1]).toMatchObject({ auth_flow: 'manual_login' });
+  });
+
+  // The deep link strips its own params as it opens the dialog, so the render that sees the
+  // completion no longer knows where the viewer came from. Reading the attribution then would
+  // lose it in exactly the case it exists for.
+  it('keeps the attribution from the press, not from whatever the page says later', () => {
+    const { result, rerender } = renderHook(
+      (props: { analytics?: Record<string, unknown> }) => usePrivySignIn(undefined, props),
+      { initialProps: { analytics: { link_source: 'marketing' } } }
+    );
+
+    act(() => result.current());
+
+    // The URL is cleaned, the handler rerenders, the source is gone.
+    rerender({ analytics: { link_source: undefined } });
+
+    act(() => mocks.privyOnComplete?.({}));
+
+    expect(mocks.trackPrivyAuth.mock.calls[0]?.[1]).toMatchObject({
+      auth_flow: 'manual_login',
+      link_source: 'marketing',
+    });
+  });
+
+  it('does not carry attribution from one attempt into the next', () => {
+    const { result, rerender } = renderHook(
+      (props: { analytics?: Record<string, unknown> }) => usePrivySignIn(undefined, props),
+      { initialProps: { analytics: { link_source: 'marketing' } as Record<string, unknown> | undefined } }
+    );
+
+    act(() => result.current());
+    act(() => mocks.privyOnError?.('exited_auth_flow'));
+
+    rerender({ analytics: undefined });
+    act(() => result.current());
+    act(() => mocks.privyOnComplete?.({}));
+
+    expect(mocks.trackPrivyAuth.mock.calls[0]?.[1]).not.toHaveProperty('link_source');
+  });
+
   // Dismissing the modal abandons the press. Staying armed would hand it to whatever completion
   // came next — a restore, or a login started elsewhere on the page.
   it('forgets an abandoned sign-in rather than replaying it later', () => {

--- a/apps/web/core/hooks/use-privy-sign-in.ts
+++ b/apps/web/core/hooks/use-privy-sign-in.ts
@@ -7,11 +7,22 @@ import * as React from 'react';
 import { useSetAtom } from 'jotai';
 import { usePathname, useSearchParams } from 'next/navigation';
 
-import { trackPrivyAuth } from '~/core/analytics';
+import { type AnalyticsProperties, trackPrivyAuth } from '~/core/analytics';
 
 import { avatarAtom, nameAtom, spaceIdAtom, stepAtom, topicIdAtom } from '~/partials/onboarding/dialog';
 
 import { postOnboardingRedirectAtom } from '~/atoms/post-onboarding-redirect';
+
+type UsePrivySignInOptions = {
+  /**
+   * Where to send the viewer once they are through. Defaults to the page they are on, which is
+   * right for a control they pressed. A deep link overrides it, because the URL that carried them
+   * here still holds the trigger that opened this dialog and replaying it would reopen the dialog.
+   */
+  redirectTo?: string;
+  /** Merged into the login event — attribution for a sign-in that started off-site, say. */
+  analytics?: AnalyticsProperties;
+};
 
 /**
  * Opens Privy's own "Log in or sign up" dialog straight away, the way the upvote control does.
@@ -23,7 +34,7 @@ import { postOnboardingRedirectAtom } from '~/atoms/post-onboarding-redirect';
  * Clears any half-finished onboarding first, and records where to return to so the viewer lands
  * back on the page they left rather than being bounced to explore.
  */
-export function usePrivySignIn(onComplete?: () => void) {
+export function usePrivySignIn(onComplete?: () => void, options?: UsePrivySignInOptions) {
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const setPostOnboardingRedirect = useSetAtom(postOnboardingRedirectAtom);
@@ -38,6 +49,10 @@ export function usePrivySignIn(onComplete?: () => void) {
   const onCompleteRef = React.useRef(onComplete);
   onCompleteRef.current = onComplete;
 
+  // Held for the same reason, so a caller can pass an inline object literal.
+  const optionsRef = React.useRef(options);
+  optionsRef.current = options;
+
   // Privy fires `onComplete` on session restoration too, not just on a login someone asked for —
   // opening a second tab is enough (see the note in `core/wallet/wallet.tsx`). So the consumer's
   // callback is armed here and only fires for a sign-in this hook actually started. Without it,
@@ -46,7 +61,7 @@ export function usePrivySignIn(onComplete?: () => void) {
 
   const { login } = useGeoLogin({
     onComplete: args => {
-      trackPrivyAuth(args, { auth_flow: 'manual_login' });
+      trackPrivyAuth(args, { auth_flow: 'manual_login', ...optionsRef.current?.analytics });
       if (!requestedRef.current) return;
       requestedRef.current = false;
       onCompleteRef.current?.();
@@ -62,7 +77,7 @@ export function usePrivySignIn(onComplete?: () => void) {
 
   return React.useCallback(() => {
     const search = searchParams?.toString();
-    setPostOnboardingRedirect(`${pathname}${search ? `?${search}` : ''}`);
+    setPostOnboardingRedirect(optionsRef.current?.redirectTo ?? `${pathname}${search ? `?${search}` : ''}`);
     setName('');
     setTopicId('');
     setAvatar('');

--- a/apps/web/core/hooks/use-privy-sign-in.ts
+++ b/apps/web/core/hooks/use-privy-sign-in.ts
@@ -20,7 +20,11 @@ type UsePrivySignInOptions = {
    * here still holds the trigger that opened this dialog and replaying it would reopen the dialog.
    */
   redirectTo?: string;
-  /** Merged into the login event — attribution for a sign-in that started off-site, say. */
+  /**
+   * Merged into the login event — attribution for a sign-in that started off-site, say. Snapshot
+   * when the viewer presses, not when Privy finishes, which can be minutes later on a different
+   * URL.
+   */
   analytics?: AnalyticsProperties;
 };
 
@@ -59,11 +63,23 @@ export function usePrivySignIn(onComplete?: () => void, options?: UsePrivySignIn
   // loading the feed in a new tab would open the hub with nobody having pressed anything.
   const requestedRef = React.useRef(false);
 
+  // The attribution belongs to the attempt, not to whatever the page looks like when Privy
+  // finishes. A deep link clears its own params the moment it opens the dialog, so by the time
+  // someone has typed an emailed code the current render no longer knows where they came from.
+  // Taken at the press, spent on completion.
+  const requestedAnalyticsRef = React.useRef<AnalyticsProperties | undefined>(undefined);
+
   const { login } = useGeoLogin({
     onComplete: args => {
-      trackPrivyAuth(args, { auth_flow: 'manual_login', ...optionsRef.current?.analytics });
+      // Only a sign-in this hook started is a login. An unrequested completion is a session
+      // restore, which `AnalyticsUserIdentifier` already reports as one — tracking it here as
+      // `manual_login` made every page load carrying this hook look like somebody signing in.
       if (!requestedRef.current) return;
       requestedRef.current = false;
+
+      trackPrivyAuth(args, { auth_flow: 'manual_login', ...requestedAnalyticsRef.current });
+      requestedAnalyticsRef.current = undefined;
+
       onCompleteRef.current?.();
     },
     // Privy calls this when the attempt fails and when the viewer dismisses the modal. Leaving
@@ -72,6 +88,7 @@ export function usePrivySignIn(onComplete?: () => void, options?: UsePrivySignIn
     // arming exists to prevent, just later.
     onError: () => {
       requestedRef.current = false;
+      requestedAnalyticsRef.current = undefined;
     },
   });
 
@@ -84,6 +101,9 @@ export function usePrivySignIn(onComplete?: () => void, options?: UsePrivySignIn
     setSpaceId('');
     setStep('start');
     requestedRef.current = true;
+    // Copied rather than referenced, so a caller rebuilding the object cannot rewrite an
+    // attempt that is already in flight.
+    requestedAnalyticsRef.current = optionsRef.current?.analytics ? { ...optionsRef.current.analytics } : undefined;
     login();
   }, [login, pathname, searchParams, setAvatar, setName, setPostOnboardingRedirect, setSpaceId, setStep, setTopicId]);
 }

--- a/apps/web/core/utils/utils.ts
+++ b/apps/web/core/utils/utils.ts
@@ -5,6 +5,7 @@ import { formatInTimeZone } from 'date-fns-tz';
 import { IntlMessageFormat } from 'intl-messageformat';
 import { validate as uuidValidate, version as uuidVersion } from 'uuid';
 
+import { toSignIn as toSignInLink } from '~/core/auth/sign-in-deep-link';
 import {
   FILEBASE_GATEWAY_READ_PATH,
   LIGHTHOUSE_GATEWAY_READ_PATH,
@@ -21,6 +22,11 @@ import { Entities } from './entity';
 export const NavUtils = {
   toRoot: () => '/root',
   toExplore: () => '/explore',
+  /**
+   * Explore, with the Privy sign-in modal opening on arrival. Built for the marketing site's
+   * "Sign in / Sign up" button — see `core/auth/sign-in-deep-link` for the param contract.
+   */
+  toSignIn: toSignInLink,
   toHome: () => `/home`,
   toAdmin: (spaceId: string) => `/space/${spaceId}/access-control`,
   toSpace: (spaceId: string) => (spaceId === ROOT_SPACE ? `/root` : `/space/${spaceId}`),

--- a/apps/web/partials/auth/sign-in-deep-link-handler.test.tsx
+++ b/apps/web/partials/auth/sign-in-deep-link-handler.test.tsx
@@ -41,6 +41,8 @@ describe('SignInDeepLinkHandler', () => {
     mocks.signInOptions = null;
     mocks.openSignIn.mockReset();
     mocks.replaceState.mockReset();
+    // Set by one test below, and it would otherwise leak an anchor into every later assertion.
+    window.location.hash = '';
     vi.spyOn(window.history, 'replaceState').mockImplementation(mocks.replaceState);
   });
 
@@ -56,6 +58,19 @@ describe('SignInDeepLinkHandler', () => {
     render(<SignInDeepLinkHandler />);
 
     expect(mocks.replaceState).toHaveBeenCalledWith(null, '', '/explore');
+  });
+
+  // `replaceState` rewrites the whole URL, so an anchor missing from `cleanUrl` is an anchor
+  // thrown away — and this app resolves linked blocks out of `window.location.hash`.
+  it('keeps the anchor the viewer followed', () => {
+    mocks.pathname = '/space/space-1/entity-1';
+    mocks.search = 'modal=signin&source=email';
+    window.location.hash = '#block-1';
+
+    render(<SignInDeepLinkHandler />);
+
+    expect(mocks.replaceState).toHaveBeenCalledWith(null, '', '/space/space-1/entity-1#block-1');
+    expect(mocks.signInOptions?.redirectTo).toBe('/space/space-1/entity-1#block-1');
   });
 
   it('keeps any other param the route was carrying', () => {

--- a/apps/web/partials/auth/sign-in-deep-link-handler.test.tsx
+++ b/apps/web/partials/auth/sign-in-deep-link-handler.test.tsx
@@ -1,0 +1,147 @@
+import { render } from '@testing-library/react';
+
+import * as React from 'react';
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { SignInDeepLinkHandler } from './sign-in-deep-link-handler';
+
+const mocks = {
+  pathname: '/explore',
+  search: 'modal=signin&source=marketing',
+  ready: true,
+  authenticated: false,
+  openSignIn: vi.fn(),
+  signInOptions: null as { redirectTo?: string; analytics?: Record<string, unknown> } | null,
+  replaceState: vi.fn(),
+};
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => mocks.pathname,
+  useSearchParams: () => new URLSearchParams(mocks.search),
+}));
+
+vi.mock('@geogenesis/auth', () => ({
+  usePrivy: () => ({ ready: mocks.ready, authenticated: mocks.authenticated }),
+}));
+
+vi.mock('~/core/hooks/use-privy-sign-in', () => ({
+  usePrivySignIn: (_onComplete: unknown, options: (typeof mocks)['signInOptions']) => {
+    mocks.signInOptions = options;
+    return mocks.openSignIn;
+  },
+}));
+
+describe('SignInDeepLinkHandler', () => {
+  beforeEach(() => {
+    mocks.pathname = '/explore';
+    mocks.search = 'modal=signin&source=marketing';
+    mocks.ready = true;
+    mocks.authenticated = false;
+    mocks.signInOptions = null;
+    mocks.openSignIn.mockReset();
+    mocks.replaceState.mockReset();
+    vi.spyOn(window.history, 'replaceState').mockImplementation(mocks.replaceState);
+  });
+
+  it('opens the sign-in dialog for a viewer who arrived on the link', () => {
+    render(<SignInDeepLinkHandler />);
+
+    expect(mocks.openSignIn).toHaveBeenCalledTimes(1);
+  });
+
+  // A trigger left in the address bar reopens on refresh, on back, and for whoever the viewer
+  // sends the URL to — none of whom asked to sign in.
+  it('clears the trigger from the URL', () => {
+    render(<SignInDeepLinkHandler />);
+
+    expect(mocks.replaceState).toHaveBeenCalledWith(null, '', '/explore');
+  });
+
+  it('keeps any other param the route was carrying', () => {
+    mocks.pathname = '/space/space-1/entity-1';
+    mocks.search = 'modal=signin&source=marketing&tabId=tab-2';
+
+    render(<SignInDeepLinkHandler />);
+
+    expect(mocks.replaceState).toHaveBeenCalledWith(null, '', '/space/space-1/entity-1?tabId=tab-2');
+  });
+
+  // The ticket's stated behaviour: a login dialog over a live session is noise, and the link has
+  // already done its job by landing them here.
+  it('does not open the dialog for someone who is already signed in', () => {
+    mocks.authenticated = true;
+
+    render(<SignInDeepLinkHandler />);
+
+    expect(mocks.openSignIn).not.toHaveBeenCalled();
+    expect(mocks.replaceState).toHaveBeenCalledWith(null, '', '/explore');
+  });
+
+  // `authenticated` reads false while Privy is still restoring, so acting early would show the
+  // login to a signed-in viewer — the case above, missed by a few hundred milliseconds.
+  it('waits for Privy before deciding', () => {
+    mocks.ready = false;
+
+    const { rerender } = render(<SignInDeepLinkHandler />);
+    expect(mocks.openSignIn).not.toHaveBeenCalled();
+    expect(mocks.replaceState).not.toHaveBeenCalled();
+
+    mocks.ready = true;
+    rerender(<SignInDeepLinkHandler />);
+
+    expect(mocks.openSignIn).toHaveBeenCalledTimes(1);
+  });
+
+  it('stays out of the way of an ordinary page load', () => {
+    mocks.search = '';
+
+    render(<SignInDeepLinkHandler />);
+
+    expect(mocks.openSignIn).not.toHaveBeenCalled();
+    expect(mocks.replaceState).not.toHaveBeenCalled();
+  });
+
+  // Another deep link — a different modal, an entity action — must not land on the login.
+  it('ignores a modal it does not own', () => {
+    mocks.search = 'modal=something-else';
+
+    render(<SignInDeepLinkHandler />);
+
+    expect(mocks.openSignIn).not.toHaveBeenCalled();
+  });
+
+  // The params are cleared above, but Next does not necessarily resync `useSearchParams` in the
+  // same tick — so something else on the page writing a param of its own can re-run this while
+  // the trigger is still visible, and a second dialog is not what the viewer asked for.
+  it('opens once per arrival, even if the URL changes underneath it', () => {
+    const { rerender } = render(<SignInDeepLinkHandler />);
+
+    mocks.search = 'modal=signin&source=marketing&tabId=tab-2';
+    rerender(<SignInDeepLinkHandler />);
+
+    expect(mocks.openSignIn).toHaveBeenCalledTimes(1);
+  });
+
+  // Signing up runs onboarding, which pushes the viewer back to the recorded destination. Left as
+  // the arrival URL that would be the trigger again, handing them the dialog they just came from.
+  it('records the cleaned URL as the post-auth destination', () => {
+    render(<SignInDeepLinkHandler />);
+
+    expect(mocks.signInOptions?.redirectTo).toBe('/explore');
+  });
+
+  it('carries the attribution into the login event', () => {
+    render(<SignInDeepLinkHandler />);
+
+    expect(mocks.signInOptions?.analytics).toEqual({ link_source: 'marketing' });
+  });
+
+  it('sends no attribution when the link carried none', () => {
+    mocks.search = 'modal=signin';
+
+    render(<SignInDeepLinkHandler />);
+
+    expect(mocks.signInOptions?.analytics).toEqual({ link_source: undefined });
+  });
+});

--- a/apps/web/partials/auth/sign-in-deep-link-handler.tsx
+++ b/apps/web/partials/auth/sign-in-deep-link-handler.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import { usePrivy } from '@geogenesis/auth';
+
+import * as React from 'react';
+
+import { usePathname, useSearchParams } from 'next/navigation';
+
+import { requestsSignInModal, signInModalSource, urlWithoutSignInModal } from '~/core/auth/sign-in-deep-link';
+import { usePrivySignIn } from '~/core/hooks/use-privy-sign-in';
+
+/**
+ * GEO-2727. Opens the Privy sign-in dialog for a viewer who arrived on `?modal=signin`.
+ *
+ * Mounted app-wide rather than on Explore, even though `/explore?modal=signin` is the only link
+ * anyone is shipping today. The trigger is a property of the URL, not of that page, and a handler
+ * that lives on one route has to be re-implemented for the second link — which the ticket already
+ * anticipates. Nothing here reads the pathname beyond preserving it.
+ */
+export function SignInDeepLinkHandler() {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const { ready, authenticated } = usePrivy();
+
+  const requested = requestsSignInModal(searchParams);
+  const source = signInModalSource(searchParams);
+  const cleanUrl = urlWithoutSignInModal(pathname ?? '/', searchParams);
+
+  const openSignIn = usePrivySignIn(undefined, {
+    // Not the current URL, which still holds the trigger: a viewer who signs up goes through
+    // onboarding and gets pushed back here afterwards, and being handed the modal a second time
+    // is exactly the confusion the modal was opened to resolve.
+    redirectTo: cleanUrl,
+    analytics: { link_source: source ?? undefined },
+  });
+
+  // One open per arrival. The params are cleared below, so this is belt-and-braces against the
+  // window between `replaceState` and Next syncing `useSearchParams` — but that window is real,
+  // and without the guard the dialog would be asked to open twice in it.
+  const handledRef = React.useRef(false);
+
+  React.useEffect(() => {
+    if (!requested) {
+      handledRef.current = false;
+      return;
+    }
+    if (handledRef.current) return;
+    // `authenticated` is not trustworthy until Privy has finished restoring a session, and
+    // acting early would open a login dialog for somebody who is already signed in.
+    if (!ready) return;
+
+    handledRef.current = true;
+
+    // Cleared whether or not the dialog opens, and before it does. A trigger that survives in the
+    // address bar reopens on refresh, on back, and for whoever the viewer sends the URL to.
+    window.history.replaceState(null, '', cleanUrl);
+
+    // Already signed in: the link has done its job by landing them here, and a login dialog over
+    // a live session is noise. This is the ticket's stated behaviour for that case.
+    if (authenticated) return;
+
+    openSignIn();
+  }, [authenticated, cleanUrl, openSignIn, ready, requested]);
+
+  return null;
+}

--- a/apps/web/partials/auth/sign-in-deep-link-handler.tsx
+++ b/apps/web/partials/auth/sign-in-deep-link-handler.tsx
@@ -24,7 +24,12 @@ export function SignInDeepLinkHandler() {
 
   const requested = requestsSignInModal(searchParams);
   const source = signInModalSource(searchParams);
-  const cleanUrl = urlWithoutSignInModal(pathname ?? '/', searchParams);
+  // Neither `usePathname` nor `useSearchParams` reports the fragment, so it is read off the
+  // location or it is lost — and `replaceState` below rewrites the whole URL, anchor included.
+  // Safe to read during render: this component is client-only, and the value is settled by the
+  // time the effect that consumes it runs.
+  const hash = typeof window === 'undefined' ? '' : window.location.hash;
+  const cleanUrl = urlWithoutSignInModal(pathname ?? '/', searchParams, hash);
 
   const openSignIn = usePrivySignIn(undefined, {
     // Not the current URL, which still holds the trigger: a viewer who signs up goes through


### PR DESCRIPTION
Closes [GEO-2727](https://linear.app/geobrowser/issue/GEO-2727/add-a-linkable-url-that-opens-the-privy-sign-in-modal-on-the-explore).

## The link

```
/explore?modal=signin&source=marketing
```

Lands on Explore and opens the Privy login dialog on arrival, no second click. `NavUtils.toSignIn({ source: 'marketing' })` builds it.

## The audit the ticket asked for

**Param casing.** Every key read through `searchParams.get` in this repo is camelCase — `tabId`, `spaceId`, `rankEntityId`, `returnSearch`. `modal` and `source` are single words, so nothing to decide.

**`source` is not a new param.** `buildBlockLink` in `partials/editor/block-clipboard.ts` already writes `?source=copy_link`, and `block-reorder.tsx:292` reads it to reveal a linked block. Attribution reuses that key rather than inventing a parallel one. Values are lowercase, `snake_case` past one word, matching `copy_link`.

**No modal-triggering param exists yet**, so `modal=signin` is the new half. Named value rather than `signin=true`: it takes the next deep link — a different modal, an entity action — without a new param each time, and has no meaningless `signin=false` state. This is the convention GEO-2681 can extend rather than re-invent.

**Nothing else auto-opens on Explore.** `ExploreWelcomeBanner` is inline and dismissible, so no collision.

## What was built

`core/auth/sign-in-deep-link.ts` owns the contract — param names, reader, builder — so a change is a change everywhere. `NavUtils.toSignIn` delegates to it, since a route helper is where anyone here looks first.

`partials/auth/sign-in-deep-link-handler.tsx` acts on it, mounted app-wide in `app/entry.tsx` rather than on Explore. The trigger is a property of the URL, not of that page; a route-local handler has to be rebuilt for the second link, which GEO-2681 already needs. Nothing in it reads the pathname beyond preserving it.

`usePrivySignIn` gained two options — `redirectTo` and `analytics` — both needed here and neither disturbing its three existing callers.

## The decisions the ticket flagged

**Params clear.** Stripped via `replaceState` before the dialog opens, whether or not it opens. A trigger left in the address bar reopens on refresh, on back, and for whoever the viewer sends the URL to. Other params on the route are preserved — dropping a route's own state to tidy up the trigger would be a worse bug than the one the tidying prevents.

**Already signed in → Explore, no dialog.** As the ticket proposed. The link has done its job by landing them there.

**Nothing acts until Privy reports `ready`.** `authenticated` reads false while a session is still restoring, so acting early would show the login to a signed-in viewer — the case above, missed by a few hundred milliseconds.

**After signing in, they stay on Explore.** The recorded post-auth destination is the *cleaned* URL. Left as the arrival URL, a viewer who signs up goes through onboarding, gets pushed back, and is handed the dialog they just came from.

**`source` reaches analytics** as `link_source` on the login event, rather than being a decorative param. It does not clobber the existing `source: 'privy'` property on that event.

## Testing

`/explore?modal=signin&source=marketing` signed out → Explore loads, Privy dialog opens, address bar reads `/explore`. Signed in → Explore, no dialog, same clean URL. Refresh after either → no dialog. Sign up through the dialog → onboarding, then Explore, no dialog.

Worth also confirming block links still work (`?source=copy_link` on a space page), since they share the `source` key — the handler ignores any URL without `modal=signin`, so they should be untouched.

333 test files passing, `next build` clean. 22 new tests; the once-per-arrival guard was confirmed failing against the unguarded version rather than passing by construction.

## Note

The URL becomes an external dependency the moment the marketing site ships it. Worth treating as a contract — it is pinned in one module here for that reason.
