### PR TITLE
feat(debates): label the challenge buttons "Request debate"

### DIFF
--- a/apps/web/core/debates/matchmaking/hub-pill-button.test.tsx
+++ b/apps/web/core/debates/matchmaking/hub-pill-button.test.tsx
@@ -11,7 +11,8 @@ describe('HubPillButton', () => {
   /**
    * The pill is a fixed `h-7`. In a flex row — the People tab pairs one with a person's name —
    * a label long enough to be squeezed wraps to a second line and spills out of that height.
-   * Rows already give the name `min-w-0 truncate` so it can absorb the shrinking instead.
+   * nowrap is what prevents it: min-content becomes max-content, so a flex item's default
+   * `min-width: auto` stops the row squeezing the pill, and the name truncates instead.
    */
   it('holds its width and keeps its label on one line', () => {
     render(<HubPillButton>Request debate</HubPillButton>);

--- a/apps/web/core/debates/matchmaking/hub-pill-button.test.tsx
+++ b/apps/web/core/debates/matchmaking/hub-pill-button.test.tsx
@@ -1,0 +1,34 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { HubPillButton } from './hub-pill-button';
+
+afterEach(cleanup);
+
+describe('HubPillButton', () => {
+  /**
+   * The pill is a fixed `h-7`. In a flex row — the People tab pairs one with a person's name —
+   * a label long enough to be squeezed wraps to a second line and spills out of that height.
+   * Rows already give the name `min-w-0 truncate` so it can absorb the shrinking instead.
+   */
+  it('holds its width and keeps its label on one line', () => {
+    render(<HubPillButton>Request debate</HubPillButton>);
+
+    expect(screen.getByRole('button')).toHaveClass('shrink-0', 'whitespace-nowrap', 'h-7');
+  });
+
+  it('swaps in the pending label and stops taking clicks while pending', () => {
+    render(
+      <HubPillButton pending pendingLabel="Requesting…">
+        Request debate
+      </HubPillButton>
+    );
+
+    const button = screen.getByRole('button');
+    expect(button).toHaveTextContent('Requesting…');
+    expect(button).toBeDisabled();
+    expect(button).toHaveAttribute('aria-busy', 'true');
+  });
+});

--- a/apps/web/core/debates/matchmaking/hub-pill-button.tsx
+++ b/apps/web/core/debates/matchmaking/hub-pill-button.tsx
@@ -32,7 +32,10 @@ export function HubPillButton({
       disabled={disabled || pending}
       aria-busy={pending || undefined}
       className={cx(
-        'inline-flex h-7 items-center justify-center rounded-full px-3 text-metadata transition-colors disabled:opacity-50',
+        // shrink-0 + nowrap because `h-7` is a fixed height: in a flex row a label long enough to
+        // be squeezed wraps to a second line and spills out of the pill. Rows that pair this with
+        // a name already give the name `min-w-0 truncate`, so it absorbs the shrinking instead.
+        'inline-flex h-7 shrink-0 items-center justify-center rounded-full px-3 text-metadata whitespace-nowrap transition-colors disabled:opacity-50',
         variant === 'primary'
           ? 'bg-text text-white hover:bg-text/90'
           : 'border border-grey-02 text-text hover:bg-grey-01',

--- a/apps/web/core/debates/matchmaking/hub-pill-button.tsx
+++ b/apps/web/core/debates/matchmaking/hub-pill-button.tsx
@@ -32,9 +32,12 @@ export function HubPillButton({
       disabled={disabled || pending}
       aria-busy={pending || undefined}
       className={cx(
-        // shrink-0 + nowrap because `h-7` is a fixed height: in a flex row a label long enough to
-        // be squeezed wraps to a second line and spills out of the pill. Rows that pair this with
-        // a name already give the name `min-w-0 truncate`, so it absorbs the shrinking instead.
+        // `h-7` is a fixed height, so a label that wraps to a second line spills out of the pill.
+        // nowrap is what prevents that: it makes min-content equal max-content, and a flex item's
+        // default `min-width: auto` then stops the row from squeezing the pill at all — the name
+        // beside it absorbs the shrinking instead, which is why rows give it `min-w-0 truncate`.
+        // shrink-0 is redundant today and kept only to survive a later `min-w-0` on this button,
+        // which would defeat the `min-width: auto` this leans on.
         'inline-flex h-7 shrink-0 items-center justify-center rounded-full px-3 text-metadata whitespace-nowrap transition-colors disabled:opacity-50',
         variant === 'primary'
           ? 'bg-text text-white hover:bg-text/90'

--- a/apps/web/core/debates/matchmaking/people-tab.test.tsx
+++ b/apps/web/core/debates/matchmaking/people-tab.test.tsx
@@ -133,7 +133,7 @@ describe('PeopleTab', () => {
     render(<PeopleTab />);
 
     expect(card()).not.toBeInTheDocument();
-    expect(screen.getAllByRole('button', { name: 'Debate' })[0]).toBeEnabled();
+    expect(screen.getAllByRole('button', { name: 'Request debate' })[0]).toBeEnabled();
   });
 
   // Matches the Matches tab: a request you're waiting on gets a card rather than a sentence, and
@@ -159,11 +159,11 @@ describe('PeopleTab', () => {
     expect(within(request).getByText('VS')).toBeInTheDocument();
   });
 
-  it('still greys out every Debate button while the request is open', () => {
+  it('still greys out every Request debate button while the request is open', () => {
     mocks.challenge = challenge('requester');
     render(<PeopleTab />);
 
-    for (const button of screen.getAllByRole('button', { name: 'Debate' })) {
+    for (const button of screen.getAllByRole('button', { name: 'Request debate' })) {
       expect(button).toBeDisabled();
     }
   });
@@ -205,7 +205,7 @@ describe('PeopleTab', () => {
 
   // The activity payload keeps reporting a challenge as pending until the server says otherwise,
   // so expiry has to be applied here — the same filter every other request surface uses. Without
-  // it the tab sat on an "Expired" card with every Debate button still dead underneath it.
+  // it the tab sat on an "Expired" card with every Request debate button still dead underneath it.
   it('drops an expired challenge instead of waiting for the server to say so', () => {
     mocks.challenge = challenge('requester', -1_000);
     render(<PeopleTab />);
@@ -214,11 +214,11 @@ describe('PeopleTab', () => {
     expect(screen.queryByText('Expired')).not.toBeInTheDocument();
   });
 
-  it('re-enables the Debate buttons once the request has expired', () => {
+  it('re-enables the Request debate buttons once the request has expired', () => {
     mocks.challenge = challenge('requester', -1_000);
     render(<PeopleTab />);
 
-    expect(screen.getAllByRole('button', { name: 'Debate' })[0]).toBeEnabled();
+    expect(screen.getAllByRole('button', { name: 'Request debate' })[0]).toBeEnabled();
   });
 
   it('drops an expired incoming challenge too, sentence and all', () => {
@@ -226,7 +226,7 @@ describe('PeopleTab', () => {
     render(<PeopleTab />);
 
     expect(screen.queryByText(awaitingText)).not.toBeInTheDocument();
-    expect(screen.getAllByRole('button', { name: 'Debate' })[0]).toBeEnabled();
+    expect(screen.getAllByRole('button', { name: 'Request debate' })[0]).toBeEnabled();
   });
 
   // The same action the Requests tab offers on this challenge, reachable without leaving People.

--- a/apps/web/core/debates/matchmaking/people-tab.tsx
+++ b/apps/web/core/debates/matchmaking/people-tab.tsx
@@ -152,7 +152,7 @@ function PersonRow({
         pendingLabel="Requesting…"
         title={disabled ? disabledReason : undefined}
       >
-        {person.in_debate ? 'In a debate' : 'Debate'}
+        {person.in_debate ? 'In a debate' : 'Request debate'}
       </HubPillButton>
     </li>
   );

--- a/apps/web/core/debates/profile-debate-button.test.tsx
+++ b/apps/web/core/debates/profile-debate-button.test.tsx
@@ -42,6 +42,17 @@ describe('ProfileDebateButton', () => {
     expect(mocks.createChallenge).toHaveBeenCalledWith({ recipient_profile_space_id: 'profile-them' });
   });
 
+  /**
+   * This sits at the end of the profile name row. `h-7` is fixed and the button's own `shrink-0`
+   * only governs height (its wrapper is `flex-col`), so without nowrap a long display name
+   * squeezed the pill until "Request debate" wrapped and spilled out of it.
+   */
+  it('keeps its label on one line however long the name beside it is', () => {
+    render(<ProfileDebateButton spaceId="profile-them" />);
+
+    expect(screen.getByRole('button')).toHaveClass('whitespace-nowrap', 'h-7');
+  });
+
   it('reports the request in flight', () => {
     mocks.isPending = true;
     render(<ProfileDebateButton spaceId="profile-them" />);

--- a/apps/web/core/debates/profile-debate-button.test.tsx
+++ b/apps/web/core/debates/profile-debate-button.test.tsx
@@ -1,0 +1,58 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  canChallenge: true,
+  createChallenge: vi.fn(),
+  isPending: false,
+}));
+
+vi.mock('./hooks', () => ({
+  useDebateProfile: () => ({ data: { can_challenge: mocks.canChallenge } }),
+  useCreateDebateChallenge: () => ({
+    mutate: mocks.createChallenge,
+    isPending: mocks.isPending,
+    error: null,
+  }),
+}));
+
+const { ProfileDebateButton } = await import('./profile-debate-button');
+
+beforeEach(() => {
+  mocks.canChallenge = true;
+  mocks.isPending = false;
+  mocks.createChallenge.mockReset();
+});
+
+afterEach(cleanup);
+
+describe('ProfileDebateButton', () => {
+  /**
+   * Same mutation the People tab row fires, so it carries the same label: clicking sends a
+   * request the other person has to accept, it does not start a debate.
+   */
+  it('asks for a debate rather than promising one', () => {
+    render(<ProfileDebateButton spaceId="profile-them" />);
+
+    const button = screen.getByRole('button', { name: 'Request debate' });
+    fireEvent.click(button);
+
+    expect(mocks.createChallenge).toHaveBeenCalledWith({ recipient_profile_space_id: 'profile-them' });
+  });
+
+  it('reports the request in flight', () => {
+    mocks.isPending = true;
+    render(<ProfileDebateButton spaceId="profile-them" />);
+
+    expect(screen.getByRole('button', { name: 'Requesting...' })).toBeDisabled();
+  });
+
+  it('stays hidden when the server says this person cannot be challenged', () => {
+    mocks.canChallenge = false;
+    const { container } = render(<ProfileDebateButton spaceId="profile-them" />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/apps/web/core/debates/profile-debate-button.tsx
+++ b/apps/web/core/debates/profile-debate-button.tsx
@@ -27,7 +27,7 @@ export function ProfileDebateButton({ spaceId }: { spaceId: string }) {
         disabled={createChallenge.isPending}
         className="inline-flex h-7 shrink-0 items-center rounded-full bg-text px-2.5 text-metadata text-white transition-colors hover:bg-text/90 disabled:opacity-50"
       >
-        {createChallenge.isPending ? 'Requesting...' : 'Debate'}
+        {createChallenge.isPending ? 'Requesting...' : 'Request debate'}
       </button>
       {error && (
         <Text as="p" variant="footnote" color="red-01">

--- a/apps/web/core/debates/profile-debate-button.tsx
+++ b/apps/web/core/debates/profile-debate-button.tsx
@@ -25,7 +25,10 @@ export function ProfileDebateButton({ spaceId }: { spaceId: string }) {
         type="button"
         onClick={() => createChallenge.mutate({ recipient_profile_space_id: spaceId })}
         disabled={createChallenge.isPending}
-        className="inline-flex h-7 shrink-0 items-center rounded-full bg-text px-2.5 text-metadata text-white transition-colors hover:bg-text/90 disabled:opacity-50"
+        // nowrap for the same reason as HubPillButton: `h-7` is fixed, and this sits at the end of
+        // the profile name row, so a long name squeezes it until the label wraps out of the pill.
+        // `shrink-0` does not help here — the wrapper is `flex-col`, so it governs height, not width.
+        className="inline-flex h-7 shrink-0 items-center rounded-full bg-text px-2.5 text-metadata whitespace-nowrap text-white transition-colors hover:bg-text/90 disabled:opacity-50"
       >
         {createChallenge.isPending ? 'Requesting...' : 'Request debate'}
       </button>


### PR DESCRIPTION
Closes [GEO-2729](https://linear.app/geobrowser/issue/GEO-2729/debates-change-people-tab-button-label-from-debate-to-request-debate).

## What

The People tab row button now reads **Request debate** instead of **Debate**.

## Which other "Debate" labels change — and which don't

The ticket asked to settle this rather than leave them inconsistent by accident. There are four:

| Where | Interaction | Verdict |
|---|---|---|
| People tab row | `useCreateDebateChallenge` → sends a request | **Changed** |
| Profile page button | **the same mutation, same payload** | **Changed** |
| Claim rows (`claim-debate-readiness`) | `role="switch"` toggle for whether a claim is available to debate | Unchanged |
| Nav bar entry point | Navigation, not an action | Unchanged — [GEO-2689](https://linear.app/geobrowser/issue/GEO-2689) owns that wording |

The ticket guessed the other instance was the claim rows. It isn't — those are a `<Toggle>` behind `role="switch"`, so "Debate" is right there and "Request debate" would be actively wrong.

The one that *does* match is the profile button, which the ticket doesn't mention. It calls the same `useCreateDebateChallenge` with the same `{ recipient_profile_space_id }`, and already says `Requesting...` while pending — so the ticket's reasoning ("Debate implies the debate starts on click") applies to it verbatim. Changing only the People tab would have swapped one accidental inconsistency for another. Flagging it since it's outside the literal scope; it's a one-line revert if you'd rather keep it.

## The longer label didn't fit

The ticket asked to check this, and the answer was no. `HubPillButton` is a fixed `h-7` with no `shrink-0` or `whitespace-nowrap`, so in the People tab's flex row a long enough name squeezed the pill until its label wrapped to a second line and spilled out:

| Panel | Natural pill | Squeezed to |
|---|---|---|
| Desktop hub — 368px content | 120px | **81px** |
| Mobile sheet — 343px content | 120px | **77px** |

On mobile this triggers at a merely long display name, not a pathological one. `Debate` at 69px never had to compress, which is why the bug was invisible before.

Fix is `whitespace-nowrap` on the button, so the pill keeps its width and the name truncates instead — which the rows already expect, since the name carries `min-w-0 truncate`. Verified every pill holds its full 120px afterwards. The component's two other call sites are `grid grid-cols-2` cells, where `flex-shrink` doesn't apply and both labels clear the cell width, so they're unaffected.

`whitespace-nowrap` is what does the work: it makes min-content equal max-content, and a flex item's default `min-width: auto` then stops the row squeezing the pill at all. `shrink-0` is on there too but is redundant today — kept only to survive a later `min-w-0` on the button, which would defeat the `min-width: auto` this leans on. (Measured both ways to confirm; my first description of this credited `shrink-0`, which was wrong.)

### The profile button needed it separately

Caught by Copilot in review. That button already had `shrink-0`, but its wrapper is `flex-col`, so `shrink-0` governs height rather than width — horizontal pressure from a long name still squeezed it. Same break as the People tab, reached by a different route:

| Name in the header | Pill |
|---|---|
| `Arturas` | 114px, fine |
| `Alexandra Konstantinopoulos` | 114px, fine |
| `Bartholomew Wolfeschlegelsteinhausenberger` | **96px — label wraps and spills out of the pill** |

Fixed with `whitespace-nowrap` there as well, and pinned by a test.

## Testing

- `people-tab.test.tsx` — 4 role queries updated to the new accessible name
- New `hub-pill-button.test.tsx` — pins `shrink-0`/`whitespace-nowrap`/`h-7` with the failure it prevents written down, plus the pending-label behaviour
- New `profile-debate-button.test.tsx` — pins the label, the nowrap that keeps it on one line, that clicking fires the challenge mutation, the pending state, and that it hides when `can_challenge` is false
- Confirmed the new tests fail when the fix and the label are reverted
- `vitest run core/debates` — 73 files, 929 tests, all passing
- `tsc --noEmit` — no new errors. Three test files error on clean master too (`sort-open-proposals`, `entity-response`, `use-privy-sign-in`); verified by typechecking with my changes stashed.
