### PR TITLE
fix(telemetry): stop aborted RSC prefetch streams burying the real errors

### DIFF
--- a/apps/web/core/telemetry/noise.test.ts
+++ b/apps/web/core/telemetry/noise.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+
+import { isAbortedResponseStream } from './noise';
+
+describe('isAbortedResponseStream', () => {
+  it('drops the aborted-stream error Next throws when a client goes away mid-render', () => {
+    expect(
+      isAbortedResponseStream({
+        exception: { values: [{ value: 'Error: The destination stream closed early.' }] },
+      })
+    ).toBe(true);
+  });
+
+  /**
+   * The whole point of the filter is volume, so it has to be narrow enough that a real fault with
+   * a stack in the same area still reports. A filter that swallowed these would trade one blind
+   * spot for a worse one.
+   */
+  it('keeps other stream failures, and everything else', () => {
+    for (const value of [
+      'Error: The destination stream errored.',
+      'Error: Premature close',
+      "TypeError: Cannot read properties of undefined (reading 'replace')",
+    ]) {
+      expect(isAbortedResponseStream({ exception: { values: [{ value }] } })).toBe(false);
+    }
+  });
+
+  it('survives events with no exception, no values, or no message', () => {
+    expect(isAbortedResponseStream({})).toBe(false);
+    expect(isAbortedResponseStream({ exception: {} })).toBe(false);
+    expect(isAbortedResponseStream({ exception: { values: [] } })).toBe(false);
+    expect(isAbortedResponseStream({ exception: { values: [{}] } })).toBe(false);
+  });
+
+  it('matches when the aborted stream is one of several exception values', () => {
+    expect(
+      isAbortedResponseStream({
+        exception: { values: [{ value: 'Error: something else' }, { value: 'The destination stream closed early.' }] },
+      })
+    ).toBe(true);
+  });
+});

--- a/apps/web/core/telemetry/noise.ts
+++ b/apps/web/core/telemetry/noise.ts
@@ -1,0 +1,43 @@
+/**
+ * Errors that are reported to Sentry but cannot be acted on, and whose volume hides the ones that
+ * can.
+ *
+ * Kept out of `sentry.server.config.ts` so it can be tested without running `Sentry.init` as an
+ * import side effect. The client has its own equivalent for ad-blocked analytics beacons; this is
+ * the server half.
+ */
+
+type SentryExceptionValue = { value?: string };
+type SentryEventLike = { exception?: { values?: SentryExceptionValue[] } };
+
+/**
+ * Next aborts a streaming render when the client goes away mid-response — a navigation away, or a
+ * cancelled `?_rsc=` prefetch, which the App Router fires on link hover and on viewport entry.
+ *
+ * That surfaces as an unhandled `Error: The destination stream closed early.` thrown from inside
+ * Next's own runtime and reported through `onRequestError`. It is not actionable: the stack contains
+ * no application frames, and it is a normal consequence of someone clicking before a prefetch
+ * finishes.
+ *
+ * Measured before filtering: **1,149 occurrences over seven weeks with zero users impacted**, spread
+ * evenly across every route — `/space/[id]`, `/home`, `/root`, governance, community — which is what
+ * rules out a route-specific bug. It was simultaneously the **largest error group in production**,
+ * 265 events in two days, more than every other group combined.
+ *
+ * That volume is the reason to filter it. GEO-2670 stayed open for two weeks partly because a real
+ * user report could not be found among noise like this, and the same triage will be needed again.
+ */
+const ABORTED_STREAM_MESSAGE = 'The destination stream closed early.';
+
+/**
+ * Matched on the message rather than the frame, deliberately. The frames are all inside Next's
+ * bundled runtime and their paths carry a version hash (`next@16.3.0-preview.6+4bbfba1a...`), so a
+ * frame match would silently stop working on the next Next upgrade — the failure mode being that
+ * the noise quietly returns. The message is Next's own and stable across versions.
+ *
+ * Narrow on purpose: an unrelated stream failure, or this one with a different message, still
+ * reports.
+ */
+export function isAbortedResponseStream(event: SentryEventLike): boolean {
+  return (event.exception?.values ?? []).some(value => value.value?.includes(ABORTED_STREAM_MESSAGE) === true);
+}

--- a/apps/web/sentry.server.config.ts
+++ b/apps/web/sentry.server.config.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 import { isTelemetryEnabled, telemetryDsn } from '~/core/telemetry/config';
+import { isAbortedResponseStream } from '~/core/telemetry/noise';
 
 if (isTelemetryEnabled) {
   Sentry.init({
@@ -15,6 +16,10 @@ if (isTelemetryEnabled) {
     tracesSampleRate: process.env.NODE_ENV === 'development' ? 1.0 : 0.2,
 
     beforeSend(event) {
+      // Dropped before anything else: this was the largest error group in production, with zero
+      // users impacted, and its volume is what makes real reports hard to find. See noise.ts.
+      if (isAbortedResponseStream(event)) return null;
+
       if (event.request?.headers) {
         delete event.request.headers.authorization;
         delete event.request.headers.Authorization;


### PR DESCRIPTION
`Error: The destination stream closed early.` is the **largest error group in production** — 265 events in two days, more than every other group combined, and 1,149 over seven weeks.

It is not actionable:

- **Zero users impacted**, across all 1,149 occurrences.
- **No application frames.** The whole stack is inside Next's bundled runtime, reported through `onRequestError`.
- **Spread evenly across every route** — `/space/[id]` (129), `/home` (73), `POST /space/[id]` (66), governance (43+32), `/root` (33+29), community (18) — which is what rules out a route-specific bug.

Next throws it when a client goes away mid-render: a navigation away, or a cancelled `?_rsc=` prefetch, which the App Router fires on link hover and on viewport entry. Someone clicking before a prefetch finishes is the normal case, not a fault.

## Why bother filtering something harmless

The volume is the cost. GEO-2670 has been open for two weeks partly because a real user report cannot be found among noise like this — and having just spent a while triaging that ticket through Sentry, this group is the single biggest obstacle to doing it again. The client already filters ad-blocked analytics beacons for the same reason; the server had **no noise filtering at all**, only header scrubbing.

## Shape of the change

The predicate lives in `core/telemetry/noise.ts` rather than inline in `sentry.server.config.ts`, so it can be tested without running `Sentry.init` as an import side effect.

Matched on Next's **message**, not on a stack frame. The frames are all inside Next's bundled runtime and their paths carry a version hash (`next@16.3.0-preview.6+4bbfba1a...`), so a frame match would quietly stop working on the next Next upgrade — and the failure mode of that is the noise silently returning. The message is Next's own and stable across versions.

Narrow on purpose. Tests assert that `The destination stream errored.`, `Premature close`, and an ordinary `TypeError` all still report, along with the malformed-event cases (no exception, no values, no message) and the multi-value case.

## Tests

3552 pass across 330 files. ESLint and Prettier clean.

## Note

This only stops **new** events. The existing GEOGENESIS-9D group will go quiet on deploy; whether to archive the historical events is a Sentry-side call, not a code one, and I have left it alone.
