### PR TITLE
fix: bounty card grids render one column too narrow on the Community tab

### DIFF
--- a/apps/web/partials/community-tab/bounty-card.test.tsx
+++ b/apps/web/partials/community-tab/bounty-card.test.tsx
@@ -1,0 +1,85 @@
+import { render } from '@testing-library/react';
+
+import * as React from 'react';
+
+import { describe, expect, it, vi } from 'vitest';
+
+import type { SpaceBounty } from '~/core/community/bounty-types';
+
+import { AvailableBountyCard, BountyCard, InProgressBountyCard } from './bounty-card';
+
+vi.mock('~/core/hooks/use-entity-side-panel', () => ({
+  useEntitySidePanel: () => ({ openSidePanel: vi.fn(), closeSidePanel: vi.fn(), sidePanelTarget: null }),
+}));
+
+vi.mock('~/core/hooks/use-smart-account', () => ({ useSmartAccount: () => ({ smartAccount: null }) }));
+
+vi.mock('~/core/state/sign-in-prompt-store', () => ({
+  useSignInPrompt: () => ({ action: null, open: vi.fn(), close: vi.fn() }),
+}));
+
+vi.mock('~/design-system/avatar', () => ({ Avatar: () => <div data-testid="avatar" /> }));
+
+function bounty(overrides: Partial<SpaceBounty> = {}): SpaceBounty {
+  return {
+    id: 'bounty-1',
+    spaceId: 'space-1',
+    name: 'Add credible sources',
+    description: 'Add the sites and outlets this space should be tracking.',
+    budget: 500,
+    difficulty: 'Easy',
+    skills: ['Research'],
+    contributors: [],
+    isFeatured: false,
+    ...overrides,
+  } as SpaceBounty;
+}
+
+/**
+ * GEO-2733. The cards used to carry a fixed pixel width, and the grids had no column definition at
+ * all — so how many fit per row was decided by whether that width happened to divide into the
+ * content column. It didn't: both grids came up one column short.
+ *
+ * The column count now lives in the grid (`repeat(auto-fill, minmax(...))`) and a card fills the
+ * track it is given. jsdom has no layout engine, so the count itself is verified in a browser, but
+ * the half of the contract that lives on the card — carry no width of your own — is checkable here,
+ * and it is the half a later edit is most likely to undo.
+ */
+describe('bounty cards', () => {
+  const cases = [
+    ['completed', () => <BountyCard bounty={bounty()} />],
+    ['in progress', () => <InProgressBountyCard bounty={bounty()} />],
+    [
+      'available',
+      () => (
+        <AvailableBountyCard
+          bounty={bounty()}
+          isInterested={false}
+          isPending={false}
+          isInterestLoading={false}
+          canRegisterInterest
+          onRegisterInterest={vi.fn()}
+        />
+      ),
+    ],
+  ] as const;
+
+  it.each(cases)('a %s card fills its column rather than setting a width', (_name, renderCard) => {
+    const { container } = render(renderCard());
+
+    const card = container.querySelector<HTMLElement>('[data-bounty-card]')!;
+
+    expect(card.style.width).toBe('');
+    expect(card.className).toContain('w-full');
+  });
+
+  // The fixed height is deliberate and stays — rows are meant to line up, and the cards' line
+  // clamps are tuned to it. Only the width was ever the problem.
+  it.each(cases)('a %s card keeps its fixed height', (_name, renderCard) => {
+    const { container } = render(renderCard());
+
+    const card = container.querySelector<HTMLElement>('[data-bounty-card]')!;
+
+    expect(card.style.height).toMatch(/^\d+px$/);
+  });
+});

--- a/apps/web/partials/community-tab/bounty-card.tsx
+++ b/apps/web/partials/community-tab/bounty-card.tsx
@@ -44,18 +44,22 @@ function BountyGeoIcon() {
   );
 }
 
-export const CARD_WIDTH_PX = 249;
 export const COMPLETED_CARD_HEIGHT_PX = 143;
 export const IN_PROGRESS_CARD_HEIGHT_PX = 110;
-export const AVAILABLE_CARD_WIDTH_PX = 378;
 export const AVAILABLE_CARD_HEIGHT_PX = 240;
 const CARD_PADDING_PX = 20;
 
-function cardStyle(height: number, width: number = CARD_WIDTH_PX): React.CSSProperties {
-  return { boxSizing: 'border-box', width, height, padding: CARD_PADDING_PX };
+/**
+ * Height is fixed — the rows are meant to line up, and the clamps below are tuned to it. Width is
+ * not: a card fills whatever column the grid gives it (see the grid classes in
+ * `community-bounties-sections`). A fixed width is what put both grids one column short — the
+ * cards asked for more than the content column had and wrapped early.
+ */
+function cardStyle(height: number): React.CSSProperties {
+  return { boxSizing: 'border-box', height, padding: CARD_PADDING_PX };
 }
 
-const CARD_CLASS = 'flex flex-col overflow-hidden rounded-lg border border-grey-02 bg-white text-left';
+const CARD_CLASS = 'flex w-full flex-col overflow-hidden rounded-lg border border-grey-02 bg-white text-left';
 
 const CARD_INTERACTIVE_CLASS =
   'cursor-pointer transition-colors duration-150 hover:border-grey-03 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-text';
@@ -67,19 +71,17 @@ const CARD_INTERACTIVE_CLASS =
 function BountyCardShell({
   bounty,
   height,
-  width,
   className,
   children,
 }: {
   bounty: SpaceBounty;
   height: number;
-  width?: number;
   className?: string;
   children: React.ReactNode;
 }) {
   const { openSidePanel } = useEntitySidePanel();
 
-  const style = cardStyle(height, width);
+  const style = cardStyle(height);
   const classes = [CARD_CLASS, CARD_INTERACTIVE_CLASS, className].filter(Boolean).join(' ');
 
   const open = () => {
@@ -290,7 +292,7 @@ export function AvailableBountyCard({
   onRegisterInterest: (bounty: SpaceBounty) => void;
 }) {
   return (
-    <BountyCardShell bounty={bounty} height={AVAILABLE_CARD_HEIGHT_PX} width={AVAILABLE_CARD_WIDTH_PX}>
+    <BountyCardShell bounty={bounty} height={AVAILABLE_CARD_HEIGHT_PX}>
       <div className="flex shrink-0 items-center justify-between gap-3">
         <BudgetBadge budget={bounty.budget} />
         <InterestButton

--- a/apps/web/partials/community-tab/community-bounties-sections.tsx
+++ b/apps/web/partials/community-tab/community-bounties-sections.tsx
@@ -27,10 +27,8 @@ import { Skeleton } from '~/design-system/skeleton';
 
 import {
   AVAILABLE_CARD_HEIGHT_PX,
-  AVAILABLE_CARD_WIDTH_PX,
   AvailableBountyCard,
   BountyCard,
-  CARD_WIDTH_PX,
   COMPLETED_CARD_HEIGHT_PX,
   IN_PROGRESS_CARD_HEIGHT_PX,
   InProgressBountyCard,
@@ -74,11 +72,42 @@ function applyFilters(
 
 type BountyCardComponent = (props: { bounty: SpaceBounty }) => React.ReactElement;
 
-const GRID_CLASS = 'flex flex-wrap gap-4';
+/**
+ * Column counts follow the container, not the viewport.
+ *
+ * These grids sit in a column whose width three separate things move — the left nav expanding
+ * (200px), the right rail appearing (360px + margin), and the full-screen "View all" route having
+ * neither. Only the first of those changes the viewport, so viewport breakpoints cannot express
+ * "three across when there is room for three". `auto-fill` reads the container instead, and the
+ * minimum track width below is the only number that decides the count.
+ *
+ * `auto-fill` rather than `auto-fit`: empty tracks are kept, so a section holding one bounty shows
+ * one card rather than one card stretched across the row.
+ *
+ * The minimums are chosen to land on the intended counts across the widths this column actually
+ * takes — 750px with the rail, 900px without:
+ *
+ * - 220px → three narrow cards at 750px (needs 692) and still three at 900px (four would need 928).
+ * - 340px → two wide cards at 750px (needs 696) and still two at 900px (three would need 1052).
+ *
+ * Below those widths each drops a column on its own, which is the intended narrow behaviour.
+ */
+const GRID_CLASS = 'grid grid-cols-[repeat(auto-fill,minmax(220px,1fr))] gap-4';
 
-function BountyGrid({ bounties, card: Card }: { bounties: SpaceBounty[]; card: BountyCardComponent }) {
+/** Available cards carry a description, so they are given roughly half again the room. */
+const AVAILABLE_GRID_CLASS = 'grid grid-cols-[repeat(auto-fill,minmax(340px,1fr))] gap-4';
+
+function BountyGrid({
+  bounties,
+  card: Card,
+  className = GRID_CLASS,
+}: {
+  bounties: SpaceBounty[];
+  card: BountyCardComponent;
+  className?: string;
+}) {
   return (
-    <div className={GRID_CLASS}>
+    <div className={className}>
       {bounties.map(bounty => (
         <Card key={bounty.id} bounty={bounty} />
       ))}
@@ -110,7 +139,7 @@ function AvailableBountyGrid({ bounties, allBounties }: BountyGridProps) {
   const { registerInterest, pendingBountyId, canRegisterInterest } = useInterestedInBounty();
 
   return (
-    <div className={GRID_CLASS}>
+    <div className={AVAILABLE_GRID_CLASS}>
       {bounties.map(bounty => (
         <AvailableBountyCard
           key={bounty.id}
@@ -344,7 +373,7 @@ function BountiesSection({
   emptyMessage,
   grid: Grid,
   cardHeightPx,
-  cardWidthPx = CARD_WIDTH_PX,
+  gridClassName = GRID_CLASS,
   isInfinite = false,
   viewAllHref,
 }: {
@@ -354,7 +383,8 @@ function BountiesSection({
   emptyMessage: string;
   grid: BountyGridComponent;
   cardHeightPx: number;
-  cardWidthPx?: number;
+  /** Matches the grid the section's cards use, so the skeletons occupy the same columns. */
+  gridClassName?: string;
   isInfinite?: boolean;
   /** "View all" navigates to this full-screen route. */
   viewAllHref: string;
@@ -405,9 +435,9 @@ function BountiesSection({
       {isError ? (
         <BountiesErrorState onRetry={() => void refetch()} />
       ) : isLoading ? (
-        <div className="flex flex-wrap gap-4">
+        <div className={gridClassName}>
           {Array.from({ length: INLINE_CARD_LIMIT }).map((_, index) => (
-            <Skeleton key={index} className="rounded-lg" style={{ width: cardWidthPx, height: cardHeightPx }} />
+            <Skeleton key={index} className="w-full rounded-lg" style={{ height: cardHeightPx }} />
           ))}
         </div>
       ) : filtered.length === 0 ? (
@@ -453,7 +483,7 @@ function BountiesFullView({
   backHref,
   grid: Grid,
   cardHeightPx,
-  cardWidthPx = CARD_WIDTH_PX,
+  gridClassName = GRID_CLASS,
   emptyMessage,
 }: {
   spaceId: string;
@@ -462,7 +492,8 @@ function BountiesFullView({
   backHref: string;
   grid: BountyGridComponent;
   cardHeightPx: number;
-  cardWidthPx?: number;
+  /** Matches the grid the view's cards use, so the skeletons occupy the same columns. */
+  gridClassName?: string;
   emptyMessage: string;
 }) {
   const { bounties, skills, isLoading, isError, refetch, truncated, totalCount } = useSpaceBounties(
@@ -491,9 +522,9 @@ function BountiesFullView({
         {isError ? (
           <BountiesErrorState onRetry={() => void refetch()} />
         ) : isLoading ? (
-          <div className="flex flex-wrap gap-4">
+          <div className={gridClassName}>
             {Array.from({ length: INLINE_CARD_LIMIT }).map((_, index) => (
-              <Skeleton key={index} className="rounded-lg" style={{ width: cardWidthPx, height: cardHeightPx }} />
+              <Skeleton key={index} className="w-full rounded-lg" style={{ height: cardHeightPx }} />
             ))}
           </div>
         ) : filtered.length === 0 ? (
@@ -514,7 +545,7 @@ type BountyStatusConfig = {
   taskStatusId: string;
   grid: BountyGridComponent;
   cardHeightPx: number;
-  cardWidthPx: number;
+  gridClassName: string;
   emptyMessage: string;
   isInfinite?: boolean;
 };
@@ -525,7 +556,7 @@ const BOUNTY_STATUS_CONFIG: Record<BountyStatusSlug, BountyStatusConfig> = {
     taskStatusId: BOUNTY_TASK_STATUS_DONE_ENTITY_ID,
     grid: CompletedBountyGrid,
     cardHeightPx: COMPLETED_CARD_HEIGHT_PX,
-    cardWidthPx: CARD_WIDTH_PX,
+    gridClassName: GRID_CLASS,
     emptyMessage: 'No completed bounties yet.',
   },
   'in-progress': {
@@ -533,7 +564,7 @@ const BOUNTY_STATUS_CONFIG: Record<BountyStatusSlug, BountyStatusConfig> = {
     taskStatusId: BOUNTY_TASK_STATUS_IN_PROGRESS_ENTITY_ID,
     grid: InProgressBountyGrid,
     cardHeightPx: IN_PROGRESS_CARD_HEIGHT_PX,
-    cardWidthPx: CARD_WIDTH_PX,
+    gridClassName: GRID_CLASS,
     emptyMessage: 'No in progress bounties yet.',
   },
   available: {
@@ -541,7 +572,7 @@ const BOUNTY_STATUS_CONFIG: Record<BountyStatusSlug, BountyStatusConfig> = {
     taskStatusId: BOUNTY_TASK_STATUS_TODO_ENTITY_ID,
     grid: AvailableBountyGrid,
     cardHeightPx: AVAILABLE_CARD_HEIGHT_PX,
-    cardWidthPx: AVAILABLE_CARD_WIDTH_PX,
+    gridClassName: AVAILABLE_GRID_CLASS,
     emptyMessage: 'No available bounties yet.',
     isInfinite: true,
   },

--- a/apps/web/partials/community-tab/community-bounties-sections.tsx
+++ b/apps/web/partials/community-tab/community-bounties-sections.tsx
@@ -76,21 +76,24 @@ type BountyCardComponent = (props: { bounty: SpaceBounty }) => React.ReactElemen
  * Column counts follow the container, not the viewport.
  *
  * These grids sit in a column whose width three separate things move — the left nav expanding
- * (200px), the right rail appearing (360px + margin), and the full-screen "View all" route having
- * neither. Only the first of those changes the viewport, so viewport breakpoints cannot express
- * "three across when there is room for three". `auto-fill` reads the container instead, and the
- * minimum track width below is the only number that decides the count.
+ * (200px), the right rail appearing (360px + a 32px margin), and the full-screen "View all" route
+ * having neither. None of the three changes the viewport width, which is the whole reason for
+ * sizing from the container: a viewport breakpoint cannot see any of them, so it cannot express
+ * "three across when there is room for three". `auto-fill` measures the container instead.
  *
  * `auto-fill` rather than `auto-fit`: empty tracks are kept, so a section holding one bounty shows
  * one card rather than one card stretched across the row.
  *
- * The minimums are chosen to land on the intended counts across the widths this column actually
- * takes — 750px with the rail, 900px without:
+ * The count is set by the minimum track width together with the gap — n columns fit when
+ * `n * min + (n - 1) * gap` is within the container. With the 16px gap below, the minimums land on
+ * the intended counts across the widths this column actually takes, 750px with the rail and 900px
+ * without:
  *
- * - 220px → three narrow cards at 750px (needs 692) and still three at 900px (four would need 928).
- * - 340px → two wide cards at 750px (needs 696) and still two at 900px (three would need 1052).
+ * - 220px → three narrow cards at 750px (3 needs 692) and still three at 900px (4 would need 928).
+ * - 340px → two wide cards at 750px (2 needs 696) and still two at 900px (3 would need 1052).
  *
- * Below those widths each drops a column on its own, which is the intended narrow behaviour.
+ * Below those widths each drops a column on its own, which is the intended narrow behaviour. Both
+ * grids therefore depend on `gap-4` staying 16px; changing it moves every threshold above.
  */
 const GRID_CLASS = 'grid grid-cols-[repeat(auto-fill,minmax(220px,1fr))] gap-4';
 

--- a/apps/web/partials/community-tab/community-bounties-sections.tsx
+++ b/apps/web/partials/community-tab/community-bounties-sections.tsx
@@ -94,11 +94,19 @@ type BountyCardComponent = (props: { bounty: SpaceBounty }) => React.ReactElemen
  *
  * Below those widths each drops a column on its own, which is the intended narrow behaviour. Both
  * grids therefore depend on `gap-4` staying 16px; changing it moves every threshold above.
+ *
+ * `min(<minimum>, 100%)` rather than the bare minimum: `auto-fill` always lays down at least one
+ * track, and a bare minimum is a floor that track cannot go below — so a container narrower than
+ * the minimum gets one oversized track that overflows it. The full-screen route reaches that on a
+ * phone (`px-6` leaves 327px at a 375px viewport) and clips the overflow rather than scrolling it,
+ * since its wrapper is `overflow-hidden`. Capping at `100%` lets the last column shrink to the
+ * container. It changes nothing above the minimum, where `min()` resolves to the minimum itself,
+ * so every threshold listed above is untouched.
  */
-const GRID_CLASS = 'grid grid-cols-[repeat(auto-fill,minmax(220px,1fr))] gap-4';
+const GRID_CLASS = 'grid grid-cols-[repeat(auto-fill,minmax(min(220px,100%),1fr))] gap-4';
 
 /** Available cards carry a description, so they are given roughly half again the room. */
-const AVAILABLE_GRID_CLASS = 'grid grid-cols-[repeat(auto-fill,minmax(340px,1fr))] gap-4';
+const AVAILABLE_GRID_CLASS = 'grid grid-cols-[repeat(auto-fill,minmax(min(340px,100%),1fr))] gap-4';
 
 function BountyGrid({
   bounties,


### PR DESCRIPTION
Closes [GEO-2733](https://linear.app/geobrowser/issue/GEO-2733/community-tab-bounty-card-grids-render-one-column-too-narrow).

## Why both grids were off by exactly one

Your hunch in the ticket was right — it's one shared cause, not two bugs.

The grids had **no column definition at all**. `GRID_CLASS` was `flex flex-wrap gap-4`, so the column count was whatever fell out of dividing a fixed card width into the content column.

With the right-hand rail present that column is **750px**: the `1142px` container cap, less the `360px` rail and its `32px` margin.

| Section | Card | Needs for the intended count | Has | Result |
| -- | -- | -- | -- | -- |
| Completed | 249px | `249×3 + 16×2` = **779px** | 750px | wraps to 2 |
| Available | 378px | `378×2 + 16` = **772px** | 750px | wraps to 1 |

Both short by under 30px — which is exactly why both landed one column low rather than being independently wrong. Your screenshots confirm it to the pixel: the leaderboard table above spans 747px, the rail 360px, and the cards measure 246–247px with a 17px gap.

## The fix

The count now lives in the grid, and cards fill the track they're given:

- Narrow cards (completed, in progress): `repeat(auto-fill, minmax(220px, 1fr))`
- Available: `repeat(auto-fill, minmax(340px, 1fr))`

**Container-driven, not viewport-driven** — and this is the part worth a look. You asked for explicit breakpoints covering the left nav expanded. Viewport breakpoints can't express that case: the nav takes 200px from the content column *without changing the viewport width at all*, so `lg:`/`md:` would be blind to exactly the scenario you named. `auto-fill` reads the container, so the nav, the rail, and the full-screen "View all" route are all handled by one definition.

`auto-fill` rather than `auto-fit` so a section holding a single bounty shows one card, not one card stretched across the row.

Fixed heights stay — rows are meant to line up and the line clamps are tuned to them. Only the width was ever the problem. Skeletons moved into the same grid, so the layout no longer shifts when bounties land.

## Verification

jsdom has no layout engine, so I measured in Chromium against the app's own compiled CSS, reproducing the real chrome (nav 200px, container 1142/900, rail 360px + `ml-8`):

| Scenario | Content | Completed | Available |
| -- | -- | -- | -- |
| **Wide + nav + rail (the report)** | 750px | **2 → 3** | **1 → 2** |
| Wide + nav, no rail | 900px | 3 → 3 | 2 → 2 |
| Narrow desktop 1280 + nav + rail | 688px | 2 → 2 | 1 → 1 |
| Tablet 1000 + nav | 800px | 3 → 3 | 2 → 2 |
| Phone 600 | 600px | 2 → 2 | 1 → 1 |

The harness reproduces the bug before the change, which is what makes the "after" column trustworthy. Widths already correct are undisturbed; narrow widths drop a column on their own, which is the intended degradation.

Also added a unit test for the half of the contract jsdom *can* check — that a card sets no width of its own — confirmed failing against master. A test asserting the grid's className would only restate the source, so I didn't write one.

## Two things to confirm

**Available being 2-wide is intentional, and I kept it.** You flagged this as worth checking. It is deliberate: those cards carry a description and are 240px tall against completed's 143px. The wider track exists for the description text.

**`INLINE_CARD_LIMIT` is 4, which now leaves an orphan.** Completed previously showed 4 cards as two tidy rows of 2; at 3 columns that becomes a row of 3 plus one. Available stays tidy at 2×2. I left the constant alone — how many bounties to preview is a product call, not part of this bug — but it's a visible consequence, so tell me if you'd rather it were 3 or 6.
