### PR TITLE
perf: collapse OR-ed `relations.some` filters into one `typeId: { in: [...] }`

### DIFF
--- a/apps/web/core/io/queries.ts
+++ b/apps/web/core/io/queries.ts
@@ -87,6 +87,7 @@ import {
 import { restFetch } from './rest';
 import { capSearchQuery } from './search-query';
 import { type SortOrder } from './sort-order';
+import { collapseRelationOrFilter } from './relation-or-filter';
 import { extractSingleSpaceIdFromFilter, extractSpaceIdsFromFilter, removeSpaceIdsFromFilter } from './space-filter';
 import { extractSingleTypeIdFromFilter, extractTypeIdsFromFilter, removeTypeIdsFromFilter } from './type-filter';
 
@@ -240,7 +241,10 @@ export function getAllEntities(
     const topLevelTypeId = typeId ?? extractedTypeId;
     const topLevelTypeIds = topLevelTypeId ? undefined : (typeIds ?? extractedTypeIds);
 
-    let normalizedFilter = filter;
+    // Collapse OR-ed `relations.some` branches before anything else looks at the
+    // filter: the OR form makes Postgres scan until the 30s statement timeout.
+    // See relation-or-filter.ts.
+    let normalizedFilter = collapseRelationOrFilter(filter);
     if (topLevelSpaceId || topLevelSpaceIds) {
       normalizedFilter = removeSpaceIdsFromFilter(normalizedFilter);
     }
@@ -370,7 +374,8 @@ export function getEntitiesOrderedByPropertyConnection(
   const topLevelTypeIds =
     nonEmptyIds(typeIds) ?? idsFromUuidFilter(extractedTypeIds) ?? (extractedTypeId ? [extractedTypeId] : undefined);
 
-  let normalizedFilter = filter;
+  // See relation-or-filter.ts — same 30s-timeout shape reaches this path too.
+  let normalizedFilter = collapseRelationOrFilter(filter);
   if (topLevelSpaceId || topLevelSpaceIds) {
     normalizedFilter = removeSpaceIdsFromFilter(normalizedFilter);
   }

--- a/apps/web/core/io/relation-or-filter.test.ts
+++ b/apps/web/core/io/relation-or-filter.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+
+import type { EntityFilter } from '~/core/gql/graphql';
+
+import { collapseRelationOrFilter } from './relation-or-filter';
+
+const A = '39e40cadb23d4f63ab2faea1596436c7';
+const B = '4b5bbddf32b247bab0a6dbbab27f457d';
+const TARGET = '2b277091284f40bfb809e2262f601022';
+
+const someOfType = (typeId: string, toEntityId = TARGET): EntityFilter => ({
+  relations: { some: { typeId: { is: typeId }, toEntityId: { is: toEntityId } } },
+});
+
+describe('collapseRelationOrFilter', () => {
+  it('collapses the production explore shape into one relations.some', () => {
+    const input: EntityFilter = {
+      and: [{ or: [someOfType(A), someOfType(B)] }, { name: { isNull: false, isNot: '' } }],
+    };
+
+    expect(collapseRelationOrFilter(input)).toEqual({
+      and: [
+        { relations: { some: { toEntityId: { is: TARGET }, typeId: { in: [A, B] } } } },
+        { name: { isNull: false, isNot: '' } },
+      ],
+    });
+  });
+
+  it('collapses a top-level or', () => {
+    expect(collapseRelationOrFilter({ or: [someOfType(A), someOfType(B)] })).toEqual({
+      relations: { some: { toEntityId: { is: TARGET }, typeId: { in: [A, B] } } },
+    });
+  });
+
+  it('dedupes repeated type ids and unwraps a single survivor to `is`', () => {
+    expect(collapseRelationOrFilter({ or: [someOfType(A), someOfType(A)] })).toEqual({
+      relations: { some: { toEntityId: { is: TARGET }, typeId: { is: A } } },
+    });
+  });
+
+  it('leaves branches alone when they differ by more than typeId', () => {
+    // Different targets: EXISTS(A->X) OR EXISTS(B->Y) is NOT EXISTS(type in [A,B] -> ?).
+    const input: EntityFilter = { or: [someOfType(A, TARGET), someOfType(B, 'ffffffff')] };
+    expect(collapseRelationOrFilter(input)).toBe(input);
+  });
+
+  it('leaves `none` alone — the equivalence only holds for `some`', () => {
+    const input: EntityFilter = {
+      or: [
+        { relations: { none: { typeId: { is: A } } } },
+        { relations: { none: { typeId: { is: B } } } },
+      ],
+    };
+    expect(collapseRelationOrFilter(input)).toBe(input);
+  });
+
+  it('leaves branches carrying anything besides `relations` alone', () => {
+    const input: EntityFilter = {
+      or: [{ ...someOfType(A), name: { isNot: '' } }, someOfType(B)],
+    };
+    expect(collapseRelationOrFilter(input)).toBe(input);
+  });
+
+  it('does not merge a typeId that is already a list', () => {
+    const input: EntityFilter = {
+      or: [{ relations: { some: { typeId: { in: [A] } } } }, someOfType(B)],
+    };
+    expect(collapseRelationOrFilter(input)).toBe(input);
+  });
+
+  it('preserves an existing sibling relations clause instead of overwriting it', () => {
+    const existing = { some: { typeId: { is: 'aaaa' } } };
+    const result = collapseRelationOrFilter({
+      relations: existing,
+      or: [someOfType(A), someOfType(B)],
+    });
+
+    expect(result).toEqual({
+      relations: existing,
+      and: [{ relations: { some: { toEntityId: { is: TARGET }, typeId: { in: [A, B] } } } }],
+    });
+  });
+
+  it('collapses nested inside and/not without duplicating siblings', () => {
+    const result = collapseRelationOrFilter({
+      and: [{ not: { or: [someOfType(A), someOfType(B)] } }, { name: { isNot: '' } }],
+    });
+
+    expect(result).toEqual({
+      and: [
+        { not: { relations: { some: { toEntityId: { is: TARGET }, typeId: { in: [A, B] } } } } },
+        { name: { isNot: '' } },
+      ],
+    });
+  });
+
+  it('returns the same reference when there is nothing to collapse', () => {
+    const input: EntityFilter = { name: { isNot: '' } };
+    expect(collapseRelationOrFilter(input)).toBe(input);
+    expect(collapseRelationOrFilter(undefined)).toBeUndefined();
+  });
+});

--- a/apps/web/core/io/relation-or-filter.ts
+++ b/apps/web/core/io/relation-or-filter.ts
@@ -1,0 +1,167 @@
+import type { EntityFilter, RelationFilter } from '~/core/gql/graphql';
+
+/**
+ * Collapse `or: [ { relations: { some: X, typeId: A } }, { relations: { some: X, typeId: B } } ]`
+ * into a single `relations: { some: { ...X, typeId: { in: [A, B] } } }`.
+ *
+ * Why this exists: PostGraphile's connection-filter compiles every `relations.some`
+ * into its own EXISTS subquery. OR-ing two of them leaves the planner unable to use
+ * the relation indexes, and with a small `LIMIT` it picks a scan that never fills —
+ * so the query does not merely run slowly, it runs until the 30s statement timeout
+ * and comes back `INTERNAL` with no data. Measured against production on the shape
+ * the explore feed was sending (two Subtopic-ish relation types to one target, plus
+ * a name predicate, `first: 10`):
+ *
+ *   or of two `relations.some`        30,387 ms  -> statement timeout, no rows
+ *   one `relations.some` + typeId in       338 ms  -> 6 rows
+ *
+ * ~90x, same results. The collapsed form is one EXISTS with `toEntityId = X AND
+ * typeId IN (…)`, which matches `relations_to_entity_type_idx` in the api schema.
+ *
+ * The rewrite is only sound for `some`. `EXISTS(typeId=A ∧ P) ∨ EXISTS(typeId=B ∧ P)`
+ * is the same question as `EXISTS((typeId=A ∨ typeId=B) ∧ P)` — both ask whether at
+ * least one relation matches P with either type. That equivalence does not hold for
+ * `none` or `every`, which are deliberately left alone.
+ *
+ * Filters reach us from data-block definitions authored in the graph, not only from
+ * code, so this normalizes at the query layer rather than at any one call site.
+ */
+
+/** `{ is: "…" }` and nothing else — the only typeId shape we can safely merge. */
+function singleTypeId(relation: RelationFilter): string | undefined {
+  const typeId = relation.typeId;
+  if (!typeId || typeof typeId !== 'object') return undefined;
+  const keys = Object.keys(typeId).filter(k => (typeId as Record<string, unknown>)[k] !== undefined);
+  if (keys.length !== 1 || keys[0] !== 'is') return undefined;
+  return typeof typeId.is === 'string' ? typeId.is : undefined;
+}
+
+/** The branch's `relations.some`, if the branch is *only* that and nothing else. */
+function soleRelationsSome(branch: EntityFilter): RelationFilter | undefined {
+  const keys = Object.keys(branch).filter(k => (branch as Record<string, unknown>)[k] != null);
+  if (keys.length !== 1 || keys[0] !== 'relations') return undefined;
+
+  const relations = branch.relations;
+  if (!relations) return undefined;
+  const relationKeys = Object.keys(relations).filter(
+    k => (relations as Record<string, unknown>)[k] != null
+  );
+  if (relationKeys.length !== 1 || relationKeys[0] !== 'some') return undefined;
+
+  return relations.some ?? undefined;
+}
+
+/**
+ * Order-independent structural identity. Deliberately not `JSON.stringify(v, keys)`:
+ * an array replacer filters by key name at *every* depth, so nested clauses like
+ * `toEntityId: { is: … }` would be stripped and two different branches would compare
+ * equal. This sorts keys at each level instead and keeps all of them.
+ */
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value) ?? 'null';
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(',')}]`;
+  const entries = Object.entries(value as Record<string, unknown>)
+    .filter(([, v]) => v !== undefined)
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+  return `{${entries.map(([k, v]) => `${JSON.stringify(k)}:${stableStringify(v)}`).join(',')}}`;
+}
+
+/** Stable identity for "everything about this branch except which type it matches". */
+function shapeWithoutTypeId(relation: RelationFilter): string {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { typeId: _omitted, ...rest } = relation;
+  return stableStringify(rest);
+}
+
+/**
+ * Rewrite one `or` array, or return undefined when it is not the collapsible shape.
+ * Requires at least two branches, every branch a bare `relations.some` carrying a
+ * single `typeId: { is }`, and all branches identical once typeId is set aside.
+ */
+function collapseOrBranches(branches: readonly EntityFilter[]): EntityFilter | undefined {
+  if (branches.length < 2) return undefined;
+
+  const relations: RelationFilter[] = [];
+  for (const branch of branches) {
+    if (!branch) return undefined;
+    const some = soleRelationsSome(branch);
+    if (!some) return undefined;
+    relations.push(some);
+  }
+
+  const typeIds: string[] = [];
+  for (const relation of relations) {
+    const id = singleTypeId(relation);
+    if (!id) return undefined;
+    typeIds.push(id);
+  }
+
+  const shape = shapeWithoutTypeId(relations[0]!);
+  if (!relations.every(r => shapeWithoutTypeId(r) === shape)) return undefined;
+
+  const unique = [...new Set(typeIds)];
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { typeId: _omitted, ...shared } = relations[0]!;
+
+  return {
+    relations: {
+      some: {
+        ...shared,
+        typeId: unique.length === 1 ? { is: unique[0]! } : { in: unique },
+      },
+    },
+  };
+}
+
+/**
+ * Walk the filter and collapse every OR-of-`relations.some` it contains, at any
+ * depth. Returns the input unchanged (by reference) when there is nothing to do,
+ * so callers can keep using it as an effect dependency.
+ */
+export function collapseRelationOrFilter(filter?: EntityFilter): EntityFilter | undefined {
+  if (!filter) return filter;
+
+  let changed = false;
+  const next: EntityFilter = { ...filter };
+
+  // Children first, so an `or` collapsed below appends to an already-walked `and`
+  // rather than re-appending the original children alongside it.
+  if (filter.and) {
+    const walked = filter.and.map(child => collapseRelationOrFilter(child) ?? child);
+    if (walked.some((child, i) => child !== filter.and![i])) {
+      next.and = walked;
+      changed = true;
+    }
+  }
+
+  if (filter.not) {
+    const walked = collapseRelationOrFilter(filter.not);
+    if (walked !== filter.not) {
+      next.not = walked;
+      changed = true;
+    }
+  }
+
+  if (filter.or) {
+    const collapsed = collapseOrBranches(filter.or);
+    if (collapsed) {
+      delete next.or;
+      // A collapsed `or` becomes a `relations` clause. If the filter already carries
+      // one, AND them together rather than silently dropping either.
+      if (next.relations) {
+        next.and = [...(next.and ?? []), collapsed];
+      } else {
+        next.relations = collapsed.relations;
+      }
+      changed = true;
+    } else {
+      const walked = filter.or.map(child => collapseRelationOrFilter(child) ?? child);
+      if (walked.some((child, i) => child !== filter.or![i])) {
+        next.or = walked;
+        changed = true;
+      }
+    }
+  }
+
+  return changed ? next : filter;
+}


### PR DESCRIPTION
Preston asked why the explore page loads so slowly. It doesn't — it **fails**.

In the gaia api pod logs, `Slow GraphQL query` lines for `AllEntitiesConnection` have a **median `durationMs` of 30,019** (max 35,052). A median sitting exactly on 30s is a statement-timeout wall, not load: the query runs until Postgres kills it and the page renders empty.

## The shape

Taken from the logged `variables` — an OR of two `relations.some` branches against the same target, plus a name predicate and `first: 10`. PostGraphile's connection-filter compiles each `some` into its own EXISTS subquery; OR-ing them leaves the planner unable to use the relation indexes, and with a small LIMIT it picks a scan that never fills.

Replaying both shapes against production, same 10-row request:

| filter | result |
| --- | --- |
| `or: [ relations.some{typeId is A}, relations.some{typeId is B} ]` | **30,387 ms → statement timeout, `INTERNAL`, no rows** |
| `relations.some{ typeId: { in: [A, B] } }` | **338 ms → 6 rows** |

~90x, identical results. The collapsed form is a single EXISTS with `toEntityId = X AND typeId IN (…)`, which matches `relations_to_entity_type_idx` in the api schema. **11 of the 14 slow samples** in a 15-minute window were this shape.

## Why normalize in `queries.ts` rather than fix a call site

There is no call site to fix. The type ids in the logged filters appear **nowhere in this repo**, so the filter is reaching us from a data-block definition authored in the graph. This sits beside `removeSpaceIdsFromFilter` and `removeTypeIdsFromFilter`, which exist for the same reason: keeping graph-authored filters on the indexed query path.

## Soundness

The rewrite is confined to `some`, where `EXISTS(typeId=A ∧ P) ∨ EXISTS(typeId=B ∧ P)` really is `EXISTS((typeId=A ∨ typeId=B) ∧ P)` — both ask whether at least one relation matches P with either type.

Left alone, with tests pinning each:
- `none` and `every`, where that equivalence does **not** hold
- branches differing by anything other than `typeId`
- branches whose `typeId` is already a list
- branches carrying keys besides `relations`

An existing sibling `relations` clause is AND-ed rather than overwritten. Unchanged filters are returned by reference so callers can keep using them as effect deps.

## Scope

Measured the explore feed's own `relations: { none: { or: […] } }` exclusion filter while I was in there — **314–429 ms**, so it's not part of this, and the normalizer deliberately skips it.

**Does not explain `ExploreBestConnection`**, which had one 30,011 ms sample in the same window and a different shape. Untouched here and still open.

## Verification

10 new unit tests; 257 io tests pass. `tsc --noEmit` shows the same 5 pre-existing errors as `master`, none in the touched files. `eslint` clean.