### PR TITLE
feat(debates): catch readiness up for positions held before the toggle went

### DIFF
--- a/apps/web/app/space/[id]/(space)/claims/claims-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/claims/claims-page-client.tsx
@@ -10,6 +10,7 @@ import { isClaimPublishedInSpace } from '~/core/claims/publish';
 import { claimResponseKind } from '~/core/claims/response-kind';
 import type { DebateClaim } from '~/core/debates/api';
 import { DebateEntityResponseControls } from '~/core/debates/debate-entity-response-controls';
+import { useBackfillReadinessForHeldPosition } from '~/core/debates/backfill-readiness-for-held-position';
 import { useRetireConfirmedResponseIndexing } from '~/core/debates/retire-confirmed-response-indexing';
 import { useDebateClaims } from '~/core/debates/hooks';
 import {
@@ -75,10 +76,6 @@ export function ClaimsPageClient({ spaceId }: ClaimsPageClientProps) {
     }
     return map;
   }, [debateClaimsQuery.data?.claims]);
-  const activeDebates = React.useMemo(
-    () => (debateClaimsQuery.data?.claims ?? []).flatMap(claim => (claim.active_debate ? [claim.active_debate] : [])),
-    [debateClaimsQuery.data?.claims]
-  );
   const responseKindsByEntityId = React.useMemo(
     () =>
       new Map(
@@ -130,7 +127,6 @@ export function ClaimsPageClient({ spaceId }: ClaimsPageClientProps) {
             claims={claims}
             isLoading={isLoading}
             spaceId={spaceId}
-            debateJoinBlocked={activeDebates.length > 0}
             debateClaimsByEntityId={debateClaimsByEntityId}
             responseKindsByEntityId={responseKindsByEntityId}
             debateStatus={debateClaimsQuery.error instanceof Error ? debateClaimsQuery.error.message : null}
@@ -250,7 +246,6 @@ function ClaimsList({
   claims,
   isLoading,
   spaceId,
-  debateJoinBlocked,
   debateClaimsByEntityId,
   responseKindsByEntityId,
   debateStatus,
@@ -258,7 +253,6 @@ function ClaimsList({
   claims: Entity[];
   isLoading: boolean;
   spaceId: string;
-  debateJoinBlocked: boolean;
   debateClaimsByEntityId: Map<string, DebateClaim>;
   responseKindsByEntityId: Map<string, 'stance' | 'veracity'>;
   debateStatus: string | null;
@@ -296,7 +290,6 @@ function ClaimsList({
           key={claim.id}
           claim={claim}
           spaceId={spaceId}
-          debateJoinBlocked={debateJoinBlocked}
           debateClaim={debateClaimsByEntityId.get(claim.id) ?? null}
           responseKind={responseKindsByEntityId.get(claim.id) ?? claimResponseKind(claim, spaceId)}
         />
@@ -308,22 +301,22 @@ function ClaimsList({
 function ClaimListItem({
   claim,
   spaceId,
-  debateJoinBlocked,
   debateClaim,
   responseKind,
 }: {
   claim: Entity;
   spaceId: string;
-  debateJoinBlocked: boolean;
   debateClaim: DebateClaim | null;
   responseKind: 'stance' | 'veracity';
 }) {
   const topics = relationsForProperty(claim.relations, TOPICS_PROPERTY_ID);
   const published = isClaimPublishedInSpace(claim, spaceId);
-  const activeDebate = debateClaim?.active_debate ?? null;
   // Kept when the Debate toggle went (GEO-2740): the toggle drew this side effect, but the
   // snapshot it retires is what drives the notification that now creates readiness server-side.
   useRetireConfirmedResponseIndexing({ debateClaim, entityId: claim.id, spaceId });
+  // Catches up readiness for a position the viewer already held before GEO-2740. Temporary; see
+  // the hook.
+  useBackfillReadinessForHeldPosition({ debateClaim, entityId: claim.id, spaceId });
 
   return (
     <article className="rounded-lg border border-grey-02 bg-white px-5 py-4 shadow-light">

--- a/apps/web/core/claims/browse/claim-page-view.tsx
+++ b/apps/web/core/claims/browse/claim-page-view.tsx
@@ -7,6 +7,7 @@ import { claimResponseKind } from '~/core/claims/response-kind';
 import { TAG_PROPERTY_ID } from '~/core/constants';
 import type { DebateClaim } from '~/core/debates/api';
 import { useDebateActivity, useDebateClaims } from '~/core/debates/hooks';
+import { useBackfillReadinessForHeldPosition } from '~/core/debates/backfill-readiness-for-held-position';
 import { useRetireConfirmedResponseIndexing } from '~/core/debates/retire-confirmed-response-indexing';
 import { useCreateDebateRequest, useDebateRequests, useMatchmakingMatches } from '~/core/debates/matchmaking/hooks';
 import { HubPillButton } from '~/core/debates/matchmaking/hub-pill-button';
@@ -227,6 +228,7 @@ function ClaimPositionSection({
   // See claims-page-client: retiring the optimistic snapshot outlived the toggle that used to own
   // it, because `claim-response-summary` on this page reads that snapshot for display.
   useRetireConfirmedResponseIndexing({ debateClaim: row, entityId, spaceId });
+  useBackfillReadinessForHeldPosition({ debateClaim: row, entityId, spaceId });
 
   return (
     <section aria-label="Your position" className="rounded-lg border border-grey-02 bg-white p-4 @[560px]:p-5">

--- a/apps/web/core/debates/backfill-readiness-for-held-position.test.tsx
+++ b/apps/web/core/debates/backfill-readiness-for-held-position.test.tsx
@@ -1,0 +1,103 @@
+import { render } from '@testing-library/react';
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { DebateClaim } from './api';
+import { useBackfillReadinessForHeldPosition } from './backfill-readiness-for-held-position';
+
+const mocks = vi.hoisted(() => ({
+  notify: vi.fn(() => Promise.resolve()),
+  ready: true,
+  authenticated: true,
+  accountKey: 'account-1' as string | null,
+}));
+
+vi.mock('./api', () => ({
+  notifyClaimResponseIndexed: (...args: unknown[]) => mocks.notify(...(args as [])),
+}));
+
+vi.mock('./hooks', () => ({
+  useGeoChatAuth: () => ({
+    ready: mocks.ready,
+    authenticated: mocks.authenticated,
+    accountKey: mocks.accountKey,
+    getPrivyIdentityToken: () => Promise.resolve('token'),
+  }),
+}));
+
+function claim(overrides: Partial<DebateClaim> = {}): DebateClaim {
+  return {
+    claim_entity_id: 'claim-1',
+    response_kind: 'stance',
+    viewer_response: { position: true, position_label: 'Agree' },
+    viewer_debate_ready: false,
+    readiness_disabled_reason: null,
+    ...overrides,
+  } as DebateClaim;
+}
+
+function Harness({ debateClaim }: { debateClaim: DebateClaim | null }) {
+  useBackfillReadinessForHeldPosition({ debateClaim, entityId: 'claim-1', spaceId: 'space-1' });
+  return null;
+}
+
+describe('useBackfillReadinessForHeldPosition', () => {
+  beforeEach(() => {
+    mocks.notify.mockClear();
+    mocks.ready = true;
+    mocks.authenticated = true;
+    mocks.accountKey = 'account-1';
+  });
+
+  it('tells geo-chat about a position it has a response for but no readiness', () => {
+    render(<Harness debateClaim={claim()} />);
+
+    expect(mocks.notify).toHaveBeenCalledTimes(1);
+    expect(mocks.notify.mock.calls[0]?.slice(0, 4)).toEqual(['space-1', 'claim-1', 'stance', true]);
+  });
+
+  it('sends once per claim however often the row refetches', () => {
+    const view = render(<Harness debateClaim={claim()} />);
+    view.rerender(<Harness debateClaim={claim()} />);
+    view.rerender(<Harness debateClaim={claim()} />);
+
+    expect(mocks.notify).toHaveBeenCalledTimes(1);
+  });
+
+  it('stays quiet once readiness is already on', () => {
+    render(<Harness debateClaim={claim({ viewer_debate_ready: true })} />);
+
+    expect(mocks.notify).not.toHaveBeenCalled();
+  });
+
+  it('stays quiet when the response moved underneath the stored position', () => {
+    // `claim_response_kind_changed` is drift the reconcile sweep owns. Standing someone up from a
+    // stale side would publish a position they may no longer hold — the one case where guessing is
+    // worse than leaving them off.
+    render(<Harness debateClaim={claim({ readiness_disabled_reason: 'claim_response_kind_changed' })} />);
+
+    expect(mocks.notify).not.toHaveBeenCalled();
+  });
+
+  it('stays quiet without a response to stand on', () => {
+    render(<Harness debateClaim={claim({ viewer_response: null })} />);
+
+    expect(mocks.notify).not.toHaveBeenCalled();
+  });
+
+  it('stays quiet with no claim row at all', () => {
+    render(<Harness debateClaim={null} />);
+
+    expect(mocks.notify).not.toHaveBeenCalled();
+  });
+
+  it('waits for auth rather than sending unauthenticated', () => {
+    mocks.authenticated = false;
+    const view = render(<Harness debateClaim={claim()} />);
+    expect(mocks.notify).not.toHaveBeenCalled();
+
+    mocks.authenticated = true;
+    view.rerender(<Harness debateClaim={claim()} />);
+    expect(mocks.notify).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/core/debates/backfill-readiness-for-held-position.ts
+++ b/apps/web/core/debates/backfill-readiness-for-held-position.ts
@@ -1,0 +1,100 @@
+'use client';
+
+import * as React from 'react';
+
+import { type DebateClaim, notifyClaimResponseIndexed } from './api';
+import { useGeoChatAuth } from './hooks';
+
+/** Keeps a session from re-sending for the same claim, and from growing without bound. */
+const MAX_TRACKED = 256;
+
+/**
+ * Tells geo-chat about a position the viewer already holds, so readiness catches up.
+ *
+ * After GEO-2740 readiness is written by `notify_claim_response_indexed`, and the notifier that
+ * calls it only fires for a response this client just watched index — it reads
+ * `indexingState.pending`, which exists only for an in-flight submission. So the change reaches
+ * everyone who responds *from now on*, and nobody who already had. Those users hold a position,
+ * would have shown up as debatable under the old toggle, and silently do not.
+ *
+ * This closes that without a backfill job. geo-chat cannot do it in SQL — it does not store
+ * responses, it resolves them from the graph — and resolving every historical (user, claim) pair
+ * server-side is a lot of work to do once. Here the pair is already resolved and on screen.
+ *
+ * Deliberately narrow. It fires only when geo-chat itself reports the gap:
+ *
+ *   - it has a row for the claim, and that row carries the viewer's response, so the position is
+ *     geo-chat's own and the server's `validate_indexed_response_notification` will agree with it;
+ *   - readiness is off;
+ *   - and no `readiness_disabled_reason`. `claim_response_kind_changed` means the response moved
+ *     underneath the stored position, which the reconcile sweep owns — standing someone up from a
+ *     stale side would publish a claim they may not hold.
+ *
+ * Once per claim per session, and it stops firing as soon as the write lands, because the next
+ * read reports `viewer_debate_ready`. The endpoint is rate limited per user/space/claim besides.
+ *
+ * No user intent is overridden: `user_disabled` rows were flipped by migration 0038, and with the
+ * toggle gone there is no way to be deliberately not-ready on a claim you hold a position on.
+ *
+ * Remove this once the population has turned over. It is a migration wearing a hook's clothes.
+ */
+export function useBackfillReadinessForHeldPosition({
+  debateClaim,
+  entityId,
+  spaceId,
+}: {
+  debateClaim: DebateClaim | null;
+  entityId: string;
+  spaceId: string;
+}) {
+  const { ready, authenticated, accountKey, getPrivyIdentityToken } = useGeoChatAuth();
+  const sent = React.useRef(new Set<string>());
+  const sentOrder = React.useRef<string[]>([]);
+
+  const viewerResponse = debateClaim?.viewer_response ?? null;
+  const responseKind = debateClaim?.response_kind ?? null;
+  const alreadyReady = debateClaim?.viewer_debate_ready ?? false;
+  const disabledReason = debateClaim?.readiness_disabled_reason ?? null;
+
+  React.useEffect(() => {
+    if (!ready || !authenticated || !accountKey) return;
+    if (!viewerResponse || !responseKind) return;
+    if (alreadyReady || disabledReason) return;
+
+    const key = `${accountKey}:${spaceId}:${entityId}`;
+    if (sent.current.has(key)) return;
+    sent.current.add(key);
+    sentOrder.current.push(key);
+    if (sentOrder.current.length > MAX_TRACKED) {
+      const evicted = sentOrder.current.shift();
+      if (evicted) sent.current.delete(evicted);
+    }
+
+    const controller = new AbortController();
+    // Nothing on screen depends on the outcome: the row already renders the position, and readiness
+    // is not drawn any more. A failure means the next visit tries again, which is the right amount
+    // of effort for a backfill.
+    void notifyClaimResponseIndexed(
+      spaceId,
+      entityId,
+      responseKind,
+      viewerResponse.position,
+      getPrivyIdentityToken,
+      accountKey,
+      controller.signal
+    ).catch(() => {});
+
+    return () => controller.abort();
+  }, [
+    accountKey,
+    alreadyReady,
+    authenticated,
+    disabledReason,
+    entityId,
+    getPrivyIdentityToken,
+    ready,
+    responseKind,
+    spaceId,
+    viewerResponse,
+  ]);
+}


### PR DESCRIPTION
Closes the gap #2302 and geo-chat#82 left behind — the one that would otherwise make the whole change look like it did nothing.

## The gap

Readiness is now written by `notify_claim_response_indexed`. The notifier that calls it only fires for a response *this client just watched index* — it reads `indexingState.pending`, which exists only for an in-flight submission.

So the change reaches everyone who responds **from now on**, and **nobody who already had**. Those users hold a position, would have shown up as debatable under the old toggle, and silently don't.

## Why not a migration or a server-side backfill

geo-chat can't fix this in SQL: it doesn't store responses, it resolves them from the graph. A migration has nothing to read, and a server-side backfill means resolving every historical (user, claim) pair.

Here the pair is **already resolved and on screen** — geo-chat is itself telling us it has the response and no readiness.

## Conditions

Fires only when all of:

- geo-chat has a row carrying the viewer's response, so the position is geo-chat's own and the server's `validate_indexed_response_notification` will agree with it;
- readiness is off;
- and there's no `readiness_disabled_reason`. **`claim_response_kind_changed` is deliberately excluded** — it means the response moved underneath the stored position, the reconcile sweep owns that, and standing someone up from a stale side would publish a position they may no longer hold. The one case where guessing is worse than waiting.

Once per claim per session. Stops on its own as soon as the write lands, because the next read reports `viewer_debate_ready`. The endpoint is rate limited per user/space/claim besides. Nothing on screen depends on the result, so a failure just means the next visit tries again.

No user intent is overridden: migration 0038 flipped the `user_disabled` rows, and with the toggle gone there's no way to be deliberately not-ready on a claim you hold a position on.

## It should be deleted later

This is a migration wearing a hook's clothes. It should come out once the population has turned over, and the comment in the file says so. Flagging it here so it doesn't quietly become permanent.

## Also

Removes `debateJoinBlocked` and the `activeDebates` memo — dead since #2302 stopped gating anything on them. They shipped as lint warnings rather than errors.

## Verification

340 files / 3635 tests pass, 7 of them new and covering each condition above including the drift exclusion. `tsc --noEmit` reports the same 6 pre-existing errors as `origin/master`. `eslint` clean on the diff.