### PR TITLE
feat: add curator program accretion dashboard

### DIFF
--- a/apps/web/app/api/space/[id]/accretion/route.ts
+++ b/apps/web/app/api/space/[id]/accretion/route.ts
@@ -2,12 +2,13 @@ import { IdUtils } from '@geoprotocol/geo-sdk/lite';
 
 import { NextResponse } from 'next/server';
 
-import type { AccretionPeriod } from '~/core/community/accretion-types';
+import type { AccretionPeriod, AccretionScope } from '~/core/community/accretion-types';
 import { fetchAccretionDashboard } from '~/core/community/fetch-accretion-dashboard';
 
 export const revalidate = 300;
 
 const VALID_PERIODS = new Set<AccretionPeriod>(['week', 'month', 'year', 'all']);
+const VALID_SCOPES = new Set<AccretionScope>(['space', 'protocol']);
 
 type RouteContext = {
   params: Promise<{ id: string }>;
@@ -21,9 +22,11 @@ export async function GET(request: Request, context: RouteContext) {
 
   const periodParam = new URL(request.url).searchParams.get('period') ?? 'year';
   const period = VALID_PERIODS.has(periodParam as AccretionPeriod) ? (periodParam as AccretionPeriod) : 'year';
+  const scopeParam = new URL(request.url).searchParams.get('scope') ?? 'space';
+  const scope = VALID_SCOPES.has(scopeParam as AccretionScope) ? (scopeParam as AccretionScope) : 'space';
 
   try {
-    const data = await fetchAccretionDashboard({ spaceId, period });
+    const data = await fetchAccretionDashboard({ spaceId, scope, period });
     return NextResponse.json(data, {
       headers: { 'Cache-Control': 'public, s-maxage=300, stale-while-revalidate=600' },
     });

--- a/apps/web/app/api/space/[id]/accretion/route.ts
+++ b/apps/web/app/api/space/[id]/accretion/route.ts
@@ -1,0 +1,34 @@
+import { IdUtils } from '@geoprotocol/geo-sdk/lite';
+
+import { NextResponse } from 'next/server';
+
+import type { AccretionPeriod } from '~/core/community/accretion-types';
+import { fetchAccretionDashboard } from '~/core/community/fetch-accretion-dashboard';
+
+export const revalidate = 300;
+
+const VALID_PERIODS = new Set<AccretionPeriod>(['week', 'month', 'year', 'all']);
+
+type RouteContext = {
+  params: Promise<{ id: string }>;
+};
+
+export async function GET(request: Request, context: RouteContext) {
+  const { id: spaceId } = await context.params;
+  if (!IdUtils.isValid(spaceId)) {
+    return NextResponse.json({ error: 'Invalid space id' }, { status: 400 });
+  }
+
+  const periodParam = new URL(request.url).searchParams.get('period') ?? 'year';
+  const period = VALID_PERIODS.has(periodParam as AccretionPeriod) ? (periodParam as AccretionPeriod) : 'year';
+
+  try {
+    const data = await fetchAccretionDashboard({ spaceId, period });
+    return NextResponse.json(data, {
+      headers: { 'Cache-Control': 'public, s-maxage=300, stale-while-revalidate=600' },
+    });
+  } catch (error) {
+    console.error('[ACCRETION_DASHBOARD] Failed to build dashboard', error);
+    return NextResponse.json({ error: 'Failed to load accretion dashboard' }, { status: 502 });
+  }
+}

--- a/apps/web/app/space/[id]/(space)/community/accretion/page.tsx
+++ b/apps/web/app/space/[id]/(space)/community/accretion/page.tsx
@@ -31,7 +31,7 @@ export default async function AccretionDashboardPage({ params }: Props) {
 
   return (
     <EntityPageSidebarLayout sidebar={sidebar}>
-      <AccretionDashboard spaceId={spaceId} />
+      <AccretionDashboard spaceId={spaceId} initialScope={spaceId === ROOT_SPACE ? 'protocol' : 'space'} />
     </EntityPageSidebarLayout>
   );
 }

--- a/apps/web/app/space/[id]/(space)/community/accretion/page.tsx
+++ b/apps/web/app/space/[id]/(space)/community/accretion/page.tsx
@@ -1,0 +1,37 @@
+import { IdUtils } from '@geoprotocol/geo-sdk/lite';
+
+import * as React from 'react';
+
+import { notFound } from 'next/navigation';
+
+import { fetchCommunityCalls } from '~/core/community-calls/fetch-community-calls';
+import { ROOT_SPACE } from '~/core/constants';
+
+import { AccretionDashboard } from '~/partials/community-tab/accretion-dashboard';
+import { EntityPageSidebarLayout } from '~/partials/entity-page/entity-page-sidebar-layout';
+import { RootExploreSidePanelContainer } from '~/partials/explore/root-explore-side-panel-container';
+import { SpaceOverviewSidePanel } from '~/partials/space-page/space-overview-side-panel';
+
+type Props = {
+  params: Promise<{ id: string }>;
+};
+
+export default async function AccretionDashboardPage({ params }: Props) {
+  const { id: spaceId } = await params;
+  if (!IdUtils.isValid(spaceId)) notFound();
+
+  const sidebar =
+    spaceId === ROOT_SPACE ? (
+      <React.Suspense fallback={null}>
+        <RootExploreSidePanelContainer />
+      </React.Suspense>
+    ) : (
+      <SpaceOverviewSidePanel spaceId={spaceId} communityCalls={await fetchCommunityCalls(spaceId).catch(() => [])} />
+    );
+
+  return (
+    <EntityPageSidebarLayout sidebar={sidebar}>
+      <AccretionDashboard spaceId={spaceId} />
+    </EntityPageSidebarLayout>
+  );
+}

--- a/apps/web/core/community/accretion-metrics.test.ts
+++ b/apps/web/core/community/accretion-metrics.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildAccretionDashboard, classifyArtifactOperation, median } from './accretion-metrics';
+import type { AccretionMetricInputs } from './accretion-types';
+
+const NOW_SECONDS = Date.UTC(2026, 7, 29) / 1000;
+
+function inputs(overrides: Partial<AccretionMetricInputs> = {}): AccretionMetricInputs {
+  return {
+    period: 'year',
+    nowSeconds: NOW_SECONDS,
+    bounties: [
+      {
+        id: 'bounty-1',
+        name: 'Build claims',
+        createdAt: NOW_SECONDS - 10_000,
+        budget: 100,
+        deadline: NOW_SECONDS + 10_000,
+        status: 'Done',
+        curatorIds: ['curator-1'],
+        curatorNames: { 'curator-1': 'Ada' },
+      },
+    ],
+    proposals: [
+      {
+        id: 'proposal-1',
+        spaceId: 'space-1',
+        bountyIds: ['bounty-1'],
+        proposedBy: 'curator-1',
+        proposedByName: 'Ada',
+        createdAt: NOW_SECONDS - 8_000,
+        executedAt: NOW_SECONDS - 5_000,
+      },
+    ],
+    payouts: [
+      {
+        id: 'payout-1',
+        bountyId: 'bounty-1',
+        proposalIds: ['proposal-1'],
+        amount: 100,
+        createdAt: NOW_SECONDS - 4_000,
+        recipientId: null,
+        recipientName: null,
+      },
+    ],
+    proposalOutputs: [
+      {
+        proposalId: 'proposal-1',
+        artifacts: [
+          {
+            entityId: 'claim-1',
+            typeId: 'claim-type',
+            typeName: 'Claim',
+            operation: 'created',
+            weightedUnits: 1,
+          },
+        ],
+      },
+    ],
+    diffProposalLimit: 24,
+    diffLimitReached: false,
+    sourceTruncated: false,
+    ...overrides,
+  };
+}
+
+describe('accretion metrics', () => {
+  it('calculates medians for odd and even samples', () => {
+    expect(median([9, 1, 5])).toBe(5);
+    expect(median([10, 2, 8, 4])).toBe(6);
+    expect(median([])).toBe(0);
+  });
+
+  it('classifies all-new diffs as created and existing edits as reused', () => {
+    expect(
+      classifyArtifactOperation({
+        values: [{ before: null, after: 'A claim' }],
+        relations: [{ before: null, after: { toEntityId: 'type' } }],
+        blocks: [],
+      })
+    ).toBe('created');
+
+    expect(
+      classifyArtifactOperation({
+        values: [{ before: 'Old', after: 'New' }],
+        relations: [],
+        blocks: [],
+      })
+    ).toBe('reused');
+  });
+
+  it('builds the six dashboard metrics without using them as payout inputs', () => {
+    const result = buildAccretionDashboard(inputs());
+
+    expect(result.summary).toMatchObject({
+      bountiesPosted: 1,
+      acceptedProposals: 1,
+      payoutAmount: 100,
+      modeledPayoutAmount: 100,
+      acceptedArtifacts: 1,
+      replacementValue: 100,
+      retroactiveRoi: 1,
+    });
+    expect(result.unitCosts).toEqual([
+      expect.objectContaining({ typeName: 'Claim', rawUnits: 1, proposalSamples: 1, medianUnitCost: 100 }),
+    ]);
+    expect(result.delivery.map(stage => stage.count)).toEqual([1, 1, 1, 1, 1, 1]);
+    expect(result.curatorCohorts[0]).toMatchObject({
+      curatorId: 'curator-1',
+      name: 'Ada',
+      payoutAmount: 100,
+      outputUnits: 1,
+      efficiency: 1,
+      inferred: true,
+    });
+    expect(result.duplication).toMatchObject({ native: 1, reused: 0, unknown: 0 });
+  });
+
+  it('allocates one payout across multiple proposals without double counting spend', () => {
+    const base = inputs();
+    const result = buildAccretionDashboard(
+      inputs({
+        proposals: [
+          ...base.proposals,
+          {
+            id: 'proposal-2',
+            spaceId: 'space-1',
+            bountyIds: ['bounty-1'],
+            proposedBy: 'curator-1',
+            proposedByName: 'Ada',
+            createdAt: NOW_SECONDS - 7_000,
+            executedAt: NOW_SECONDS - 4_500,
+          },
+        ],
+        payouts: [{ ...base.payouts[0], proposalIds: ['proposal-1', 'proposal-2'] }],
+        proposalOutputs: [
+          ...base.proposalOutputs,
+          {
+            proposalId: 'proposal-2',
+            artifacts: [
+              {
+                entityId: 'claim-2',
+                typeId: 'claim-type',
+                typeName: 'Claim',
+                operation: 'created',
+                weightedUnits: 1,
+              },
+            ],
+          },
+        ],
+      })
+    );
+
+    expect(result.summary.payoutAmount).toBe(100);
+    expect(result.unitCosts[0]).toMatchObject({ medianUnitCost: 50, modeledSpend: 100 });
+    expect(result.summary.replacementValue).toBe(100);
+    expect(result.summary.retroactiveRoi).toBe(1);
+  });
+
+  it('excludes partially classified payout bundles from unit-cost estimates', () => {
+    const base = inputs();
+    const result = buildAccretionDashboard(
+      inputs({
+        proposals: [
+          ...base.proposals,
+          {
+            id: 'proposal-2',
+            spaceId: 'space-1',
+            bountyIds: ['bounty-1'],
+            proposedBy: 'curator-1',
+            proposedByName: 'Ada',
+            createdAt: NOW_SECONDS - 7_000,
+            executedAt: NOW_SECONDS - 4_500,
+          },
+        ],
+        payouts: [{ ...base.payouts[0], proposalIds: ['proposal-1', 'proposal-2'] }],
+      })
+    );
+
+    expect(result.unitCosts).toEqual([]);
+    expect(result.summary.retroactiveRoi).toBeNull();
+    expect(result.duplication.unclassifiedProposals).toBe(1);
+  });
+});

--- a/apps/web/core/community/accretion-metrics.ts
+++ b/apps/web/core/community/accretion-metrics.ts
@@ -364,7 +364,7 @@ export function buildAccretionDashboard(inputs: AccretionMetricInputs): Accretio
   const reused = periodArtifacts.filter(artifact => artifact.operation === 'reused').length;
   const unknown = periodArtifacts.filter(artifact => artifact.operation === 'unknown').length;
 
-  const warnings = ['Payout amounts are nominal because historical currency and USD conversion are not modeled.'];
+  const warnings = ['Payout amounts and unit costs are shown in protocol points; no fiat conversion is applied.'];
   if (inputs.payouts.some(payout => payout.recipientId === null)) {
     warnings.push('Curator cohorts are provisional because direct payout recipients are not populated consistently.');
   }

--- a/apps/web/core/community/accretion-metrics.ts
+++ b/apps/web/core/community/accretion-metrics.ts
@@ -1,0 +1,427 @@
+import type {
+  AccretionArtifact,
+  AccretionArtifactOperation,
+  AccretionBountyInput,
+  AccretionCuratorCohort,
+  AccretionDashboardResult,
+  AccretionMetricInputs,
+  AccretionPeriod,
+  AccretionProposalInput,
+  AccretionTimelinePoint,
+  AccretionUnitCostRow,
+} from './accretion-types';
+
+const DAY_SECONDS = 24 * 60 * 60;
+
+const PERIOD_DAYS: Record<Exclude<AccretionPeriod, 'all'>, number> = {
+  week: 7,
+  month: 30,
+  year: 365,
+};
+
+export function accretionPeriodStart(period: AccretionPeriod, nowSeconds: number): number | null {
+  return period === 'all' ? null : nowSeconds - PERIOD_DAYS[period] * DAY_SECONDS;
+}
+
+function isInPeriod(timestamp: number | null, start: number | null): boolean {
+  return timestamp !== null && (start === null || timestamp >= start);
+}
+
+export function median(values: number[]): number {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const middle = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0 ? (sorted[middle - 1] + sorted[middle]) / 2 : sorted[middle];
+}
+
+type DiffLike = {
+  values: readonly { readonly before: string | null; readonly after: string | null }[];
+  relations: readonly { readonly before?: unknown | null; readonly after?: unknown | null }[];
+  blocks: readonly { readonly before: string | null; readonly after: string | null }[];
+};
+
+export function classifyArtifactOperation(diff: DiffLike): AccretionArtifactOperation {
+  const changes = [
+    ...diff.values.map(value => ({ before: value.before, after: value.after })),
+    ...diff.relations.map(relation => ({ before: relation.before ?? null, after: relation.after ?? null })),
+    ...diff.blocks.map(block => ({ before: block.before, after: block.after })),
+  ];
+
+  if (changes.length === 0) return 'unknown';
+  return changes.every(change => change.before == null && change.after != null) ? 'created' : 'reused';
+}
+
+type TypeAccumulator = {
+  typeId: string | null;
+  typeName: string;
+  rawUnits: number;
+  weightedUnits: number;
+  observations: number[];
+  modeledSpend: number;
+  proposalIds: Set<string>;
+};
+
+function artifactKey(artifact: AccretionArtifact): string {
+  return artifact.typeId ?? `name:${artifact.typeName}`;
+}
+
+function buildUnitCosts(
+  payouts: AccretionMetricInputs['payouts'],
+  proposalById: Map<string, AccretionProposalInput>,
+  outputByProposalId: Map<string, AccretionMetricInputs['proposalOutputs'][number]>
+): AccretionUnitCostRow[] {
+  const byType = new Map<string, TypeAccumulator>();
+
+  for (const payout of payouts) {
+    if (payout.amount === null || payout.amount < 0) continue;
+
+    const acceptedProposalIds = [...new Set(payout.proposalIds)].filter(
+      proposalId => proposalById.get(proposalId)?.executedAt != null
+    );
+    if (acceptedProposalIds.length === 0) continue;
+
+    const outputs = acceptedProposalIds.map(proposalId => outputByProposalId.get(proposalId));
+    if (outputs.some(output => !output || output.artifacts.length === 0)) continue;
+
+    const proposalShare = payout.amount / acceptedProposalIds.length;
+
+    for (const output of outputs) {
+      if (!output) continue;
+      const totalWeightedUnits = output.artifacts.reduce((sum, artifact) => sum + artifact.weightedUnits, 0);
+      if (totalWeightedUnits <= 0) continue;
+
+      const artifactGroups = new Map<string, AccretionArtifact[]>();
+      for (const artifact of output.artifacts) {
+        const key = artifactKey(artifact);
+        const group = artifactGroups.get(key) ?? [];
+        group.push(artifact);
+        artifactGroups.set(key, group);
+      }
+
+      for (const [key, artifacts] of artifactGroups) {
+        const weightedUnits = artifacts.reduce((sum, artifact) => sum + artifact.weightedUnits, 0);
+        const allocatedSpend = proposalShare * (weightedUnits / totalWeightedUnits);
+        const unitCost = weightedUnits > 0 ? allocatedSpend / weightedUnits : 0;
+        const first = artifacts[0];
+        const accumulator = byType.get(key) ?? {
+          typeId: first.typeId,
+          typeName: first.typeName,
+          rawUnits: 0,
+          weightedUnits: 0,
+          observations: [],
+          modeledSpend: 0,
+          proposalIds: new Set<string>(),
+        };
+
+        accumulator.rawUnits += artifacts.length;
+        accumulator.weightedUnits += weightedUnits;
+        accumulator.observations.push(unitCost);
+        accumulator.modeledSpend += allocatedSpend;
+        accumulator.proposalIds.add(output.proposalId);
+        byType.set(key, accumulator);
+      }
+    }
+  }
+
+  return [...byType.values()]
+    .map(row => ({
+      typeId: row.typeId,
+      typeName: row.typeName,
+      rawUnits: row.rawUnits,
+      weightedUnits: row.weightedUnits,
+      proposalSamples: row.proposalIds.size,
+      medianUnitCost: median(row.observations),
+      modeledSpend: row.modeledSpend,
+    }))
+    .sort((a, b) => b.weightedUnits - a.weightedUnits || a.typeName.localeCompare(b.typeName));
+}
+
+function bucketFor(timestamp: number, period: AccretionPeriod): { key: string; label: string } {
+  const date = new Date(timestamp * 1000);
+
+  if (period === 'week') {
+    return {
+      key: date.toISOString().slice(0, 10),
+      label: new Intl.DateTimeFormat('en', { weekday: 'short', timeZone: 'UTC' }).format(date),
+    };
+  }
+
+  if (period === 'month') {
+    const day = date.getUTCDay();
+    const mondayOffset = day === 0 ? -6 : 1 - day;
+    date.setUTCDate(date.getUTCDate() + mondayOffset);
+    return {
+      key: date.toISOString().slice(0, 10),
+      label: new Intl.DateTimeFormat('en', { month: 'short', day: 'numeric', timeZone: 'UTC' }).format(date),
+    };
+  }
+
+  return {
+    key: date.toISOString().slice(0, 7),
+    label: new Intl.DateTimeFormat('en', { month: 'short', year: '2-digit', timeZone: 'UTC' }).format(date),
+  };
+}
+
+function buildTimeline(
+  period: AccretionPeriod,
+  bounties: AccretionBountyInput[],
+  proposals: AccretionProposalInput[],
+  payouts: AccretionMetricInputs['payouts'],
+  start: number | null
+): AccretionTimelinePoint[] {
+  type MutablePoint = AccretionTimelinePoint & { deliveredBountyIds: Set<string> };
+  const points = new Map<string, MutablePoint>();
+
+  const pointAt = (timestamp: number) => {
+    const bucket = bucketFor(timestamp, period);
+    const existing = points.get(bucket.key);
+    if (existing) return existing;
+    const point: MutablePoint = {
+      ...bucket,
+      bountiesPosted: 0,
+      bountiesDelivered: 0,
+      payoutAmount: 0,
+      deliveredBountyIds: new Set<string>(),
+    };
+    points.set(bucket.key, point);
+    return point;
+  };
+
+  for (const bounty of bounties) {
+    if (isInPeriod(bounty.createdAt, start)) pointAt(bounty.createdAt as number).bountiesPosted += 1;
+  }
+
+  for (const proposal of proposals) {
+    if (!isInPeriod(proposal.executedAt, start)) continue;
+    const point = pointAt(proposal.executedAt as number);
+    proposal.bountyIds.forEach(id => point.deliveredBountyIds.add(id));
+  }
+
+  for (const payout of payouts) {
+    if (!isInPeriod(payout.createdAt, start) || payout.amount === null) continue;
+    pointAt(payout.createdAt as number).payoutAmount += payout.amount;
+  }
+
+  return [...points.values()]
+    .sort((a, b) => a.key.localeCompare(b.key))
+    .slice(-12)
+    .map(({ deliveredBountyIds, ...point }) => ({
+      ...point,
+      bountiesDelivered: deliveredBountyIds.size,
+    }));
+}
+
+function resolveCurator(
+  payout: AccretionMetricInputs['payouts'][number],
+  bountyById: Map<string, AccretionBountyInput>,
+  proposalById: Map<string, AccretionProposalInput>
+): { id: string; name: string; inferred: boolean } {
+  if (payout.recipientId) {
+    return { id: payout.recipientId, name: payout.recipientName ?? 'Unnamed curator', inferred: false };
+  }
+
+  const bounty = payout.bountyId ? bountyById.get(payout.bountyId) : null;
+  if (bounty?.curatorIds.length === 1) {
+    const id = bounty.curatorIds[0];
+    return { id, name: bounty.curatorNames[id] ?? 'Unnamed curator', inferred: true };
+  }
+
+  const authors = [
+    ...new Set(
+      payout.proposalIds.map(id => proposalById.get(id)?.proposedBy).filter((id): id is string => Boolean(id))
+    ),
+  ];
+  if (authors.length === 1) {
+    const proposal = payout.proposalIds.map(id => proposalById.get(id)).find(value => value?.proposedBy === authors[0]);
+    return {
+      id: authors[0],
+      name: proposal?.proposedByName ?? `Curator ${authors[0].slice(0, 6)}`,
+      inferred: true,
+    };
+  }
+
+  return { id: 'unattributed', name: 'Unattributed', inferred: true };
+}
+
+function buildCuratorCohorts(
+  payouts: AccretionMetricInputs['payouts'],
+  bountyById: Map<string, AccretionBountyInput>,
+  proposalById: Map<string, AccretionProposalInput>,
+  outputByProposalId: Map<string, AccretionMetricInputs['proposalOutputs'][number]>,
+  unitCostByType: Map<string, number>
+): AccretionCuratorCohort[] {
+  const cohorts = new Map<string, Omit<AccretionCuratorCohort, 'efficiency'>>();
+  const payoutCountByProposal = new Map<string, number>();
+
+  payouts.forEach(payout => {
+    new Set(payout.proposalIds).forEach(proposalId =>
+      payoutCountByProposal.set(proposalId, (payoutCountByProposal.get(proposalId) ?? 0) + 1)
+    );
+  });
+
+  for (const payout of payouts) {
+    if (payout.amount === null) continue;
+    const curator = resolveCurator(payout, bountyById, proposalById);
+    const existing = cohorts.get(curator.id) ?? {
+      curatorId: curator.id,
+      name: curator.name,
+      payoutAmount: 0,
+      outputUnits: 0,
+      replacementValue: 0,
+      inferred: curator.inferred,
+    };
+    existing.payoutAmount += payout.amount;
+    existing.inferred ||= curator.inferred;
+
+    for (const proposalId of new Set(payout.proposalIds)) {
+      const output = outputByProposalId.get(proposalId);
+      if (!output) continue;
+      const divisor = payoutCountByProposal.get(proposalId) ?? 1;
+      for (const artifact of output.artifacts) {
+        const allocatedUnits = artifact.weightedUnits / divisor;
+        existing.outputUnits += allocatedUnits;
+        existing.replacementValue += (unitCostByType.get(artifactKey(artifact)) ?? 0) * allocatedUnits;
+      }
+    }
+
+    cohorts.set(curator.id, existing);
+  }
+
+  return [...cohorts.values()]
+    .map(row => ({
+      ...row,
+      efficiency: row.payoutAmount > 0 ? row.replacementValue / row.payoutAmount : null,
+    }))
+    .sort((a, b) => b.payoutAmount - a.payoutAmount)
+    .slice(0, 8);
+}
+
+function uniqueBountyIds(proposals: AccretionProposalInput[], acceptedOnly: boolean): Set<string> {
+  return new Set(
+    proposals.filter(proposal => !acceptedOnly || proposal.executedAt !== null).flatMap(proposal => proposal.bountyIds)
+  );
+}
+
+export function buildAccretionDashboard(inputs: AccretionMetricInputs): AccretionDashboardResult {
+  const start = accretionPeriodStart(inputs.period, inputs.nowSeconds);
+  const bountyById = new Map(inputs.bounties.map(bounty => [bounty.id, bounty]));
+  const proposalById = new Map(inputs.proposals.map(proposal => [proposal.id, proposal]));
+  const outputByProposalId = new Map(inputs.proposalOutputs.map(output => [output.proposalId, output]));
+
+  const periodBounties = inputs.bounties.filter(bounty => isInPeriod(bounty.createdAt, start));
+  const periodPayouts = inputs.payouts.filter(payout => isInPeriod(payout.createdAt, start));
+  const acceptedPeriodProposals = inputs.proposals.filter(proposal => isInPeriod(proposal.executedAt, start));
+
+  const unitCosts = buildUnitCosts(periodPayouts, proposalById, outputByProposalId);
+  const unitCostByType = new Map(unitCosts.map(row => [row.typeId ?? `name:${row.typeName}`, row.medianUnitCost]));
+
+  const periodOutputProposalIds = new Set(acceptedPeriodProposals.map(proposal => proposal.id));
+  const periodArtifacts = inputs.proposalOutputs
+    .filter(output => periodOutputProposalIds.has(output.proposalId))
+    .flatMap(output => output.artifacts);
+
+  const payoutProposalIds = new Set<string>();
+  for (const payout of periodPayouts) {
+    if (payout.amount === null) continue;
+    const acceptedIds = [...new Set(payout.proposalIds)].filter(
+      proposalId => proposalById.get(proposalId)?.executedAt !== null
+    );
+    if (
+      acceptedIds.length > 0 &&
+      acceptedIds.every(proposalId => (outputByProposalId.get(proposalId)?.artifacts.length ?? 0) > 0)
+    ) {
+      acceptedIds.forEach(proposalId => payoutProposalIds.add(proposalId));
+    }
+  }
+  const retroArtifacts = inputs.proposalOutputs
+    .filter(output => payoutProposalIds.has(output.proposalId))
+    .flatMap(output => output.artifacts);
+  const replacementValue = retroArtifacts.reduce(
+    (sum, artifact) => sum + (unitCostByType.get(artifactKey(artifact)) ?? 0) * artifact.weightedUnits,
+    0
+  );
+  const payoutAmount = periodPayouts.reduce((sum, payout) => sum + (payout.amount ?? 0), 0);
+  const modeledPayoutAmount = unitCosts.reduce((sum, row) => sum + row.modeledSpend, 0);
+
+  const postedIds = new Set(periodBounties.map(bounty => bounty.id));
+  const submittedIds = uniqueBountyIds(inputs.proposals, false);
+  const acceptedIds = uniqueBountyIds(inputs.proposals, true);
+  const paidIds = new Set(periodPayouts.map(payout => payout.bountyId).filter((id): id is string => Boolean(id)));
+  const onTimeIds = new Set<string>();
+  for (const proposal of inputs.proposals) {
+    if (proposal.executedAt === null) continue;
+    for (const bountyId of proposal.bountyIds) {
+      const deadline = bountyById.get(bountyId)?.deadline;
+      if (deadline !== null && deadline !== undefined && proposal.executedAt <= deadline) onTimeIds.add(bountyId);
+    }
+  }
+
+  const countPosted = (predicate: (id: string) => boolean) => [...postedIds].filter(predicate).length;
+  const classifiedProposalCount = acceptedPeriodProposals.filter(proposal =>
+    outputByProposalId.has(proposal.id)
+  ).length;
+  const native = periodArtifacts.filter(artifact => artifact.operation === 'created').length;
+  const reused = periodArtifacts.filter(artifact => artifact.operation === 'reused').length;
+  const unknown = periodArtifacts.filter(artifact => artifact.operation === 'unknown').length;
+
+  const warnings = ['Payout amounts are nominal because historical currency and USD conversion are not modeled.'];
+  if (inputs.payouts.some(payout => payout.recipientId === null)) {
+    warnings.push('Curator cohorts are provisional because direct payout recipients are not populated consistently.');
+  }
+  if (inputs.diffLimitReached) {
+    warnings.push(`Artifact metrics use the ${inputs.diffProposalLimit} most recent relevant proposal diffs.`);
+  }
+  if (inputs.sourceTruncated) warnings.push('At least one source collection reached its pagination safety cap.');
+
+  return {
+    period: inputs.period,
+    asOf: new Date(inputs.nowSeconds * 1000).toISOString(),
+    methodologyVersion: 'curator-program-v1',
+    summary: {
+      bountiesPosted: periodBounties.length,
+      acceptedProposals: acceptedPeriodProposals.length,
+      payoutAmount,
+      modeledPayoutAmount,
+      acceptedArtifacts: periodArtifacts.length,
+      weightedOutputUnits: periodArtifacts.reduce((sum, artifact) => sum + artifact.weightedUnits, 0),
+      replacementValue,
+      retroactiveRoi: modeledPayoutAmount > 0 && replacementValue > 0 ? replacementValue / modeledPayoutAmount : null,
+    },
+    unitCosts,
+    timeline: buildTimeline(inputs.period, inputs.bounties, inputs.proposals, inputs.payouts, start),
+    curatorCohorts: buildCuratorCohorts(periodPayouts, bountyById, proposalById, outputByProposalId, unitCostByType),
+    delivery: [
+      { key: 'posted', label: 'Published', count: postedIds.size },
+      {
+        key: 'allocated',
+        label: 'Allocated',
+        count: countPosted(id => (bountyById.get(id)?.curatorIds.length ?? 0) > 0),
+      },
+      { key: 'submitted', label: 'Submitted', count: countPosted(id => submittedIds.has(id)) },
+      { key: 'accepted', label: 'Accepted', count: countPosted(id => acceptedIds.has(id)) },
+      { key: 'paid', label: 'Paid', count: countPosted(id => paidIds.has(id)) },
+      { key: 'on-time', label: 'On time', count: countPosted(id => onTimeIds.has(id)) },
+    ],
+    duplication: {
+      native,
+      reused,
+      unknown,
+      unclassifiedProposals: Math.max(0, acceptedPeriodProposals.length - classifiedProposalCount),
+    },
+    coverage: {
+      bounties: inputs.bounties.length,
+      bountiesWithBudget: inputs.bounties.filter(bounty => bounty.budget !== null).length,
+      bountiesWithStatus: inputs.bounties.filter(bounty => bounty.status !== null).length,
+      bountiesWithDeadline: inputs.bounties.filter(bounty => bounty.deadline !== null).length,
+      payouts: inputs.payouts.length,
+      payoutsWithAmount: inputs.payouts.filter(payout => payout.amount !== null).length,
+      payoutsWithRecipient: inputs.payouts.filter(payout => payout.recipientId !== null).length,
+      acceptedProposals: acceptedPeriodProposals.length,
+      classifiedProposals: classifiedProposalCount,
+      diffProposalLimit: inputs.diffProposalLimit,
+      diffLimitReached: inputs.diffLimitReached,
+      sourceTruncated: inputs.sourceTruncated,
+    },
+    warnings,
+  };
+}

--- a/apps/web/core/community/accretion-types.ts
+++ b/apps/web/core/community/accretion-types.ts
@@ -1,5 +1,12 @@
 export type AccretionPeriod = 'week' | 'month' | 'year' | 'all';
 
+export type AccretionScope = 'space' | 'protocol';
+
+export const ACCRETION_SCOPE_OPTIONS: { value: AccretionScope; label: string }[] = [
+  { value: 'space', label: 'This space' },
+  { value: 'protocol', label: 'Protocol' },
+];
+
 export const ACCRETION_PERIOD_OPTIONS: { value: AccretionPeriod; label: string }[] = [
   { value: 'week', label: 'Last week' },
   { value: 'month', label: 'Last month' },

--- a/apps/web/core/community/accretion-types.ts
+++ b/apps/web/core/community/accretion-types.ts
@@ -1,0 +1,143 @@
+export type AccretionPeriod = 'week' | 'month' | 'year' | 'all';
+
+export const ACCRETION_PERIOD_OPTIONS: { value: AccretionPeriod; label: string }[] = [
+  { value: 'week', label: 'Last week' },
+  { value: 'month', label: 'Last month' },
+  { value: 'year', label: 'Last year' },
+  { value: 'all', label: 'All time' },
+];
+
+export type AccretionArtifactOperation = 'created' | 'reused' | 'unknown';
+
+export type AccretionArtifact = {
+  entityId: string;
+  typeId: string | null;
+  typeName: string;
+  operation: AccretionArtifactOperation;
+  weightedUnits: number;
+};
+
+export type AccretionBountyInput = {
+  id: string;
+  name: string;
+  createdAt: number | null;
+  budget: number | null;
+  deadline: number | null;
+  status: string | null;
+  curatorIds: string[];
+  curatorNames: Record<string, string>;
+};
+
+export type AccretionProposalInput = {
+  id: string;
+  spaceId: string;
+  bountyIds: string[];
+  proposedBy: string;
+  proposedByName: string | null;
+  createdAt: number | null;
+  executedAt: number | null;
+};
+
+export type AccretionPayoutInput = {
+  id: string;
+  bountyId: string | null;
+  proposalIds: string[];
+  amount: number | null;
+  createdAt: number | null;
+  recipientId: string | null;
+  recipientName: string | null;
+};
+
+export type AccretionProposalOutputInput = {
+  proposalId: string;
+  artifacts: AccretionArtifact[];
+};
+
+export type AccretionMetricInputs = {
+  period: AccretionPeriod;
+  nowSeconds: number;
+  bounties: AccretionBountyInput[];
+  proposals: AccretionProposalInput[];
+  payouts: AccretionPayoutInput[];
+  proposalOutputs: AccretionProposalOutputInput[];
+  diffProposalLimit: number;
+  diffLimitReached: boolean;
+  sourceTruncated: boolean;
+};
+
+export type AccretionUnitCostRow = {
+  typeId: string | null;
+  typeName: string;
+  rawUnits: number;
+  weightedUnits: number;
+  proposalSamples: number;
+  medianUnitCost: number;
+  modeledSpend: number;
+};
+
+export type AccretionTimelinePoint = {
+  key: string;
+  label: string;
+  bountiesPosted: number;
+  bountiesDelivered: number;
+  payoutAmount: number;
+};
+
+export type AccretionCuratorCohort = {
+  curatorId: string;
+  name: string;
+  payoutAmount: number;
+  outputUnits: number;
+  replacementValue: number;
+  efficiency: number | null;
+  inferred: boolean;
+};
+
+export type AccretionDeliveryStage = {
+  key: 'posted' | 'allocated' | 'submitted' | 'accepted' | 'paid' | 'on-time';
+  label: string;
+  count: number;
+};
+
+export type AccretionCoverage = {
+  bounties: number;
+  bountiesWithBudget: number;
+  bountiesWithStatus: number;
+  bountiesWithDeadline: number;
+  payouts: number;
+  payoutsWithAmount: number;
+  payoutsWithRecipient: number;
+  acceptedProposals: number;
+  classifiedProposals: number;
+  diffProposalLimit: number;
+  diffLimitReached: boolean;
+  sourceTruncated: boolean;
+};
+
+export type AccretionDashboardResult = {
+  period: AccretionPeriod;
+  asOf: string;
+  methodologyVersion: 'curator-program-v1';
+  summary: {
+    bountiesPosted: number;
+    acceptedProposals: number;
+    payoutAmount: number;
+    modeledPayoutAmount: number;
+    acceptedArtifacts: number;
+    weightedOutputUnits: number;
+    replacementValue: number;
+    retroactiveRoi: number | null;
+  };
+  unitCosts: AccretionUnitCostRow[];
+  timeline: AccretionTimelinePoint[];
+  curatorCohorts: AccretionCuratorCohort[];
+  delivery: AccretionDeliveryStage[];
+  duplication: {
+    native: number;
+    reused: number;
+    unknown: number;
+    unclassifiedProposals: number;
+  };
+  coverage: AccretionCoverage;
+  warnings: string[];
+};

--- a/apps/web/core/community/fetch-accretion-dashboard.ts
+++ b/apps/web/core/community/fetch-accretion-dashboard.ts
@@ -1,0 +1,422 @@
+import { Effect, Either, Schema } from 'effect';
+
+import {
+  BOUNTIES_RELATION_TYPE,
+  BOUNTY_ALLOCATED_PROPERTY_ID,
+  BOUNTY_BUDGET_PROPERTY_ID,
+  BOUNTY_DEADLINE_PROPERTY_ID,
+  BOUNTY_TASK_STATUS_PROPERTY_ID,
+  BOUNTY_TYPE_ID,
+  PAYOUT_AMOUNT_PROPERTY_ID,
+  PAYOUT_BOUNTY_PROPERTY_ID,
+  PAYOUT_PROPOSALS_PROPERTY_ID,
+  PAYOUT_RECIPIENT_PROPERTY_ID,
+  PAYOUT_TYPE_ID,
+} from '~/core/constants';
+import { Environment } from '~/core/environment';
+import { ID } from '~/core/id';
+import { ApiProposalDiffResponseSchema, encodePathSegment, restFetch } from '~/core/io/rest';
+import type { ApiEntityDiff } from '~/core/io/rest';
+import { fetchProfilesBySpaceIds } from '~/core/io/subgraph/fetch-profile';
+import { mapWithConcurrency } from '~/core/utils/map-with-concurrency';
+
+import { buildAccretionDashboard, classifyArtifactOperation } from './accretion-metrics';
+import { accretionPeriodStart } from './accretion-metrics';
+import type {
+  AccretionArtifact,
+  AccretionBountyInput,
+  AccretionDashboardResult,
+  AccretionPayoutInput,
+  AccretionPeriod,
+  AccretionProposalInput,
+  AccretionProposalOutputInput,
+} from './accretion-types';
+import { ID_CHUNK_SIZE, afterArg, chunk, collectConnection, gqlId, gqlIdList, runQuery } from './community-graphql';
+import { toUnixSeconds } from './curator-leaderboard-period';
+
+const ENTITY_PAGE_SIZE = 100;
+const RELATION_PAGE_SIZE = 500;
+const DIFF_PROPOSAL_LIMIT = 24;
+const DIFF_CONCURRENCY = 6;
+const DIFF_MAX_PAGES = 10;
+
+type GraphValue = {
+  propertyId: string;
+  text: string | null;
+  float: number | null;
+  decimal: string | null;
+  integer: string | null;
+  date: string | null;
+  datetime: string | null;
+};
+
+type RelationTarget = {
+  id: string;
+  name: string | null;
+};
+
+type GraphRelation = {
+  typeId: string;
+  toEntity: RelationTarget;
+};
+
+type BountyNode = {
+  id: string;
+  name: string | null;
+  createdAt: string | null;
+  valuesList: GraphValue[];
+  relationsList: GraphRelation[];
+};
+
+type PayoutNode = {
+  id: string;
+  createdAt: string | null;
+  valuesList: GraphValue[];
+  relationsList: GraphRelation[];
+};
+
+type ProposalLink = {
+  fromEntityId: string;
+  toEntityId: string;
+};
+
+type IndexedProposal = {
+  id: string;
+  spaceId: string;
+  proposedBy: string;
+  createdAt: string | null;
+  executedAt: string | null;
+};
+
+function numberFromValue(value: GraphValue | undefined): number | null {
+  if (!value) return null;
+  const candidates: unknown[] = [value.decimal, value.float, value.integer, value.text];
+  for (const candidate of candidates) {
+    if (candidate == null || candidate === '') continue;
+    const normalized = typeof candidate === 'string' ? candidate.replace(/[^0-9.-]/g, '') : candidate;
+    const parsed = Number(normalized);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return null;
+}
+
+function valueFor(node: { valuesList: GraphValue[] }, propertyId: string): GraphValue | undefined {
+  return node.valuesList.find(value => ID.equals(value.propertyId, propertyId));
+}
+
+function targetsFor(node: { relationsList: GraphRelation[] }, propertyId: string): RelationTarget[] {
+  return node.relationsList
+    .filter(relation => ID.equals(relation.typeId, propertyId))
+    .map(relation => relation.toEntity);
+}
+
+async function fetchBounties(spaceHex: string) {
+  return collectConnection<BountyNode>(
+    'accretion bounties',
+    after => `query {
+      entitiesConnection(
+        first: ${ENTITY_PAGE_SIZE}${afterArg(after)}
+        spaceId: "${spaceHex}"
+        typeId: "${gqlId(BOUNTY_TYPE_ID)}"
+      ) {
+        totalCount
+        pageInfo { endCursor hasNextPage }
+        nodes {
+          id
+          name
+          createdAt
+          valuesList(first: 50) { propertyId text float decimal integer date datetime }
+          relationsList(first: 100) { typeId toEntity { id name } }
+        }
+      }
+    }`,
+    data => data.entitiesConnection
+  );
+}
+
+async function fetchPayouts(spaceHex: string) {
+  return collectConnection<PayoutNode>(
+    'accretion payouts',
+    after => `query {
+      entitiesConnection(
+        first: ${ENTITY_PAGE_SIZE}${afterArg(after)}
+        spaceId: "${spaceHex}"
+        typeId: "${gqlId(PAYOUT_TYPE_ID)}"
+      ) {
+        totalCount
+        pageInfo { endCursor hasNextPage }
+        nodes {
+          id
+          createdAt
+          valuesList(first: 30) { propertyId text float decimal integer date datetime }
+          relationsList(first: 100) { typeId toEntity { id name } }
+        }
+      }
+    }`,
+    data => data.entitiesConnection
+  );
+}
+
+async function fetchProposalLinks(spaceHex: string) {
+  return collectConnection<ProposalLink>(
+    'accretion bounty proposal links',
+    after => `query {
+      relationsConnection(
+        first: ${RELATION_PAGE_SIZE}${afterArg(after)}
+        filter: {
+          typeId: { is: "${gqlId(BOUNTIES_RELATION_TYPE)}" }
+          toSpaceId: { is: "${spaceHex}" }
+        }
+      ) {
+        totalCount
+        pageInfo { endCursor hasNextPage }
+        nodes { fromEntityId toEntityId }
+      }
+    }`,
+    data => data.relationsConnection
+  );
+}
+
+async function fetchIndexedProposals(proposalIds: string[]): Promise<IndexedProposal[]> {
+  if (proposalIds.length === 0) return [];
+  const pages = await mapWithConcurrency(chunk(proposalIds, ID_CHUNK_SIZE), 6, ids =>
+    runQuery<{ proposalsConnection?: { nodes: IndexedProposal[] } }>(
+      'accretion indexed proposals',
+      `query {
+        proposalsConnection(
+          first: ${ids.length}
+          filter: { id: { in: [${gqlIdList(ids)}] } }
+        ) {
+          nodes { id spaceId proposedBy createdAt executedAt }
+        }
+      }`
+    )
+  );
+  return pages.flatMap(page => page.proposalsConnection?.nodes ?? []);
+}
+
+async function fetchProposalDiff(proposalId: string, spaceId: string): Promise<ApiEntityDiff[] | null> {
+  const endpoint = Environment.getConfig().api;
+  const entities: ApiEntityDiff[] = [];
+  let cursor: string | null = null;
+
+  for (let pageIndex = 0; pageIndex < DIFF_MAX_PAGES; pageIndex++) {
+    const params = new URLSearchParams({ spaceId, limit: '100' });
+    if (cursor) params.set('cursor', cursor);
+    const path = `/versioned/proposals/${encodePathSegment(proposalId)}/diff?${params.toString()}`;
+    const result = await Effect.runPromise(Effect.either(restFetch<unknown>({ endpoint, path })));
+    if (Either.isLeft(result)) return null;
+
+    const decoded = Schema.decodeUnknownEither(ApiProposalDiffResponseSchema)(result.right);
+    if (Either.isLeft(decoded)) return null;
+    entities.push(...decoded.right.entities);
+
+    if (!decoded.right.pagination.hasMore || !decoded.right.pagination.cursor) return entities;
+    cursor = decoded.right.pagination.cursor;
+  }
+
+  return entities;
+}
+
+type EntityTypeNode = {
+  id: string;
+  types: { id: string; name: string | null }[] | null;
+};
+
+async function fetchArtifactTypes(entityIds: string[]): Promise<Map<string, { id: string; name: string }>> {
+  const byEntityId = new Map<string, { id: string; name: string }>();
+  if (entityIds.length === 0) return byEntityId;
+
+  const pages = await mapWithConcurrency(chunk(entityIds, ID_CHUNK_SIZE), 6, ids =>
+    runQuery<{ entitiesConnection?: { nodes: EntityTypeNode[] } }>(
+      'accretion artifact types',
+      `query {
+        entitiesConnection(first: ${ids.length}, filter: { id: { in: [${gqlIdList(ids)}] } }) {
+          nodes { id types { id name } }
+        }
+      }`
+    ).catch(() => ({ entitiesConnection: { nodes: [] } }))
+  );
+
+  const metaTypes = new Set(['Type', 'Property', 'Space']);
+  for (const page of pages) {
+    for (const entity of page.entitiesConnection?.nodes ?? []) {
+      const namedTypes = (entity.types ?? []).filter(type => type.name);
+      const selected = namedTypes.find(type => !metaTypes.has(type.name as string)) ?? namedTypes[0];
+      if (selected?.name) byEntityId.set(entity.id, { id: selected.id, name: selected.name });
+    }
+  }
+
+  return byEntityId;
+}
+
+function mapBounty(node: BountyNode): AccretionBountyInput {
+  const deadlineValue = valueFor(node, BOUNTY_DEADLINE_PROPERTY_ID);
+  const curatorTargets = targetsFor(node, BOUNTY_ALLOCATED_PROPERTY_ID);
+  return {
+    id: node.id,
+    name: node.name?.trim() || 'Untitled bounty',
+    createdAt: toUnixSeconds(node.createdAt),
+    budget: numberFromValue(valueFor(node, BOUNTY_BUDGET_PROPERTY_ID)),
+    deadline: toUnixSeconds(deadlineValue?.datetime ?? deadlineValue?.date ?? deadlineValue?.text),
+    status: targetsFor(node, BOUNTY_TASK_STATUS_PROPERTY_ID)[0]?.name?.trim() ?? null,
+    curatorIds: [...new Set(curatorTargets.map(target => target.id))],
+    curatorNames: Object.fromEntries(
+      curatorTargets.map(target => [target.id, target.name?.trim() || `Curator ${target.id.slice(0, 6)}`])
+    ),
+  };
+}
+
+function mapPayout(node: PayoutNode): AccretionPayoutInput {
+  const bounty = targetsFor(node, PAYOUT_BOUNTY_PROPERTY_ID)[0];
+  const recipient = targetsFor(node, PAYOUT_RECIPIENT_PROPERTY_ID)[0];
+  return {
+    id: node.id,
+    bountyId: bounty?.id ?? null,
+    proposalIds: [...new Set(targetsFor(node, PAYOUT_PROPOSALS_PROPERTY_ID).map(target => target.id))],
+    amount: numberFromValue(valueFor(node, PAYOUT_AMOUNT_PROPERTY_ID)),
+    createdAt: toUnixSeconds(node.createdAt),
+    recipientId: recipient?.id ?? null,
+    recipientName: recipient?.name?.trim() ?? null,
+  };
+}
+
+function mapProposal(
+  proposal: IndexedProposal,
+  bountyIds: string[],
+  profileName: string | null
+): AccretionProposalInput {
+  return {
+    id: proposal.id,
+    spaceId: proposal.spaceId,
+    bountyIds,
+    proposedBy: proposal.proposedBy,
+    proposedByName: profileName,
+    createdAt: toUnixSeconds(proposal.createdAt),
+    executedAt: toUnixSeconds(proposal.executedAt),
+  };
+}
+
+function buildProposalOutputs(
+  proposalDiffs: { proposalId: string; diffs: ApiEntityDiff[] }[],
+  typeByEntityId: Map<string, { id: string; name: string }>
+): AccretionProposalOutputInput[] {
+  return proposalDiffs.map(({ proposalId, diffs }) => ({
+    proposalId,
+    artifacts: diffs.map((diff): AccretionArtifact => {
+      const entityType = typeByEntityId.get(diff.entityId);
+      const isStructural = !entityType && diff.values.length === 0 && diff.relations.length > 0;
+      return {
+        entityId: diff.entityId,
+        typeId: entityType?.id ?? null,
+        typeName: entityType?.name ?? (isStructural ? 'Structure' : 'Untyped entity'),
+        operation: classifyArtifactOperation(diff),
+        weightedUnits: 1,
+      };
+    }),
+  }));
+}
+
+export async function fetchAccretionDashboard({
+  spaceId,
+  period,
+  now = Date.now(),
+}: {
+  spaceId: string;
+  period: AccretionPeriod;
+  now?: number;
+}): Promise<AccretionDashboardResult> {
+  const spaceHex = gqlId(spaceId);
+  if (!spaceHex) throw new Error('Invalid space id');
+
+  const [bountyResult, payoutResult, proposalLinkResult] = await Promise.all([
+    fetchBounties(spaceHex),
+    fetchPayouts(spaceHex),
+    fetchProposalLinks(spaceHex),
+  ]);
+
+  const bounties = bountyResult.nodes.map(mapBounty);
+  const payouts = payoutResult.nodes.map(mapPayout);
+  const bountyIdsByProposalId = new Map<string, string[]>();
+  for (const link of proposalLinkResult.nodes) {
+    const ids = bountyIdsByProposalId.get(link.fromEntityId) ?? [];
+    if (!ids.includes(link.toEntityId)) ids.push(link.toEntityId);
+    bountyIdsByProposalId.set(link.fromEntityId, ids);
+  }
+
+  const proposalIds = [...new Set([...bountyIdsByProposalId.keys(), ...payouts.flatMap(payout => payout.proposalIds)])];
+  const indexedProposals = await fetchIndexedProposals(proposalIds);
+
+  const authorIds = [...new Set(indexedProposals.map(proposal => proposal.proposedBy).filter(Boolean))];
+  const profiles = authorIds.length > 0 ? await Effect.runPromise(fetchProfilesBySpaceIds(authorIds)) : [];
+  const profileNameBySpaceId = new Map(
+    authorIds.map((id, index) => [ID.uuidToHex(id), profiles[index]?.name?.trim() ?? null])
+  );
+  const proposals = indexedProposals.map(proposal =>
+    mapProposal(
+      proposal,
+      bountyIdsByProposalId.get(proposal.id) ?? [],
+      profileNameBySpaceId.get(ID.uuidToHex(proposal.proposedBy)) ?? null
+    )
+  );
+
+  const nowSeconds = Math.floor(now / 1000);
+  const periodStart = accretionPeriodStart(period, nowSeconds);
+  const periodPayoutProposalIds = new Set(
+    payouts
+      .filter(payout => payout.createdAt !== null && (periodStart === null || payout.createdAt >= periodStart))
+      .flatMap(payout => payout.proposalIds)
+  );
+  const relevantAccepted = proposals
+    .filter(
+      proposal =>
+        proposal.executedAt !== null &&
+        (periodStart === null || proposal.executedAt >= periodStart || periodPayoutProposalIds.has(proposal.id))
+    )
+    .sort((a, b) => (b.executedAt ?? 0) - (a.executedAt ?? 0));
+  const acceptedById = new Map(relevantAccepted.map(proposal => [proposal.id, proposal]));
+  const selectedIds = new Set<string>();
+  const periodPayoutsByRecency = payouts
+    .filter(payout => payout.createdAt !== null && (periodStart === null || payout.createdAt >= periodStart))
+    .sort((a, b) => (b.createdAt ?? 0) - (a.createdAt ?? 0));
+
+  // Complete payout bundles produce defensible unit costs. A plain "latest N proposals" sample
+  // usually captures only part of each many-to-many payout, which correctly gets excluded by the
+  // metric transformer but leaves the deck empty even when good linked data exists.
+  for (const payout of periodPayoutsByRecency) {
+    const bundleIds = [...new Set(payout.proposalIds)].filter(id => acceptedById.has(id));
+    const missingIds = bundleIds.filter(id => !selectedIds.has(id));
+    if (missingIds.length > 0 && selectedIds.size + missingIds.length <= DIFF_PROPOSAL_LIMIT) {
+      missingIds.forEach(id => selectedIds.add(id));
+    }
+  }
+  for (const proposal of relevantAccepted) {
+    if (selectedIds.size >= DIFF_PROPOSAL_LIMIT) break;
+    selectedIds.add(proposal.id);
+  }
+  const selectedProposals = [...selectedIds]
+    .map(id => acceptedById.get(id))
+    .filter((proposal): proposal is AccretionProposalInput => proposal !== undefined);
+  const diffResults = await mapWithConcurrency(selectedProposals, DIFF_CONCURRENCY, async proposal => ({
+    proposalId: proposal.id,
+    diffs: await fetchProposalDiff(proposal.id, proposal.spaceId),
+  }));
+  const successfulDiffs = diffResults.filter(
+    (result): result is { proposalId: string; diffs: ApiEntityDiff[] } => result.diffs !== null
+  );
+  const artifactEntityIds = [...new Set(successfulDiffs.flatMap(result => result.diffs.map(diff => diff.entityId)))];
+  const typeByEntityId = await fetchArtifactTypes(artifactEntityIds);
+  const proposalOutputs = buildProposalOutputs(successfulDiffs, typeByEntityId);
+
+  return buildAccretionDashboard({
+    period,
+    nowSeconds,
+    bounties,
+    proposals,
+    payouts,
+    proposalOutputs,
+    diffProposalLimit: DIFF_PROPOSAL_LIMIT,
+    diffLimitReached: relevantAccepted.length > DIFF_PROPOSAL_LIMIT,
+    sourceTruncated: bountyResult.truncated || payoutResult.truncated || proposalLinkResult.truncated,
+  });
+}

--- a/apps/web/core/community/fetch-accretion-dashboard.ts
+++ b/apps/web/core/community/fetch-accretion-dashboard.ts
@@ -30,6 +30,7 @@ import type {
   AccretionPeriod,
   AccretionProposalInput,
   AccretionProposalOutputInput,
+  AccretionScope,
 } from './accretion-types';
 import { ID_CHUNK_SIZE, afterArg, chunk, collectConnection, gqlId, gqlIdList, runQuery } from './community-graphql';
 import { toUnixSeconds } from './curator-leaderboard-period';
@@ -110,13 +111,13 @@ function targetsFor(node: { relationsList: GraphRelation[] }, propertyId: string
     .map(relation => relation.toEntity);
 }
 
-async function fetchBounties(spaceHex: string) {
+async function fetchBounties(spaceHex: string | null) {
   return collectConnection<BountyNode>(
     'accretion bounties',
     after => `query {
       entitiesConnection(
         first: ${ENTITY_PAGE_SIZE}${afterArg(after)}
-        spaceId: "${spaceHex}"
+        ${spaceHex ? `spaceId: "${spaceHex}"` : ''}
         typeId: "${gqlId(BOUNTY_TYPE_ID)}"
       ) {
         totalCount
@@ -134,13 +135,13 @@ async function fetchBounties(spaceHex: string) {
   );
 }
 
-async function fetchPayouts(spaceHex: string) {
+async function fetchPayouts(spaceHex: string | null) {
   return collectConnection<PayoutNode>(
     'accretion payouts',
     after => `query {
       entitiesConnection(
         first: ${ENTITY_PAGE_SIZE}${afterArg(after)}
-        spaceId: "${spaceHex}"
+        ${spaceHex ? `spaceId: "${spaceHex}"` : ''}
         typeId: "${gqlId(PAYOUT_TYPE_ID)}"
       ) {
         totalCount
@@ -157,7 +158,7 @@ async function fetchPayouts(spaceHex: string) {
   );
 }
 
-async function fetchProposalLinks(spaceHex: string) {
+async function fetchProposalLinks(spaceHex: string | null) {
   return collectConnection<ProposalLink>(
     'accretion bounty proposal links',
     after => `query {
@@ -165,7 +166,7 @@ async function fetchProposalLinks(spaceHex: string) {
         first: ${RELATION_PAGE_SIZE}${afterArg(after)}
         filter: {
           typeId: { is: "${gqlId(BOUNTIES_RELATION_TYPE)}" }
-          toSpaceId: { is: "${spaceHex}" }
+          ${spaceHex ? `toSpaceId: { is: "${spaceHex}" }` : ''}
         }
       ) {
         totalCount
@@ -319,15 +320,18 @@ function buildProposalOutputs(
 
 export async function fetchAccretionDashboard({
   spaceId,
+  scope = 'space',
   period,
   now = Date.now(),
 }: {
   spaceId: string;
+  scope?: AccretionScope;
   period: AccretionPeriod;
   now?: number;
 }): Promise<AccretionDashboardResult> {
-  const spaceHex = gqlId(spaceId);
-  if (!spaceHex) throw new Error('Invalid space id');
+  const validatedSpaceHex = gqlId(spaceId);
+  if (!validatedSpaceHex) throw new Error('Invalid space id');
+  const spaceHex = scope === 'protocol' ? null : validatedSpaceHex;
 
   const [bountyResult, payoutResult, proposalLinkResult] = await Promise.all([
     fetchBounties(spaceHex),
@@ -337,8 +341,10 @@ export async function fetchAccretionDashboard({
 
   const bounties = bountyResult.nodes.map(mapBounty);
   const payouts = payoutResult.nodes.map(mapPayout);
+  const bountyIds = new Set(bounties.map(bounty => bounty.id));
   const bountyIdsByProposalId = new Map<string, string[]>();
   for (const link of proposalLinkResult.nodes) {
+    if (!bountyIds.has(link.toEntityId)) continue;
     const ids = bountyIdsByProposalId.get(link.fromEntityId) ?? [];
     if (!ids.includes(link.toEntityId)) ids.push(link.toEntityId);
     bountyIdsByProposalId.set(link.fromEntityId, ids);

--- a/apps/web/core/constants.ts
+++ b/apps/web/core/constants.ts
@@ -67,6 +67,13 @@ export type BountyDifficultyLevel = (typeof BOUNTY_DIFFICULTY_LEVELS)[number];
 export const BOUNTY_EST_PAYOUT_RATIO = 0.2;
 export const PROPOSAL_TYPE_ID = '490a7c90ad4b4029b2b4d85d22fe203a';
 
+// Curator-program accretion analytics
+export const PAYOUT_TYPE_ID = 'f5132deb102d64553049f1e9cb662f50';
+export const PAYOUT_AMOUNT_PROPERTY_ID = '82fe45a31df74c0291afa6e68d41cddf';
+export const PAYOUT_BOUNTY_PROPERTY_ID = '1b595a8b81fc25856a9b503e3e993331';
+export const PAYOUT_PROPOSALS_PROPERTY_ID = '8128964c1ec54829beb380a21ab64c51';
+export const PAYOUT_RECIPIENT_PROPERTY_ID = '151b0bd3440d435ab093ed5fab73db6c';
+
 export const NEWS_STORY_TYPE_ID = 'e550fe517e904b2c8fffdf13408f5634';
 export const AVATAR_PROPERTY_ID = '1155befffad549b7a2e0da4777b8792c';
 

--- a/apps/web/core/utils/utils.ts
+++ b/apps/web/core/utils/utils.ts
@@ -31,6 +31,7 @@ export const NavUtils = {
   toAdmin: (spaceId: string) => `/space/${spaceId}/access-control`,
   toSpace: (spaceId: string) => (spaceId === ROOT_SPACE ? `/root` : `/space/${spaceId}`),
   toCommunity: (spaceId: string) => `${NavUtils.toSpace(spaceId)}/community`,
+  toCommunityAccretion: (spaceId: string) => `${NavUtils.toCommunity(spaceId)}/accretion`,
   toCommunityBounties: (spaceId: string, status: 'completed' | 'in-progress' | 'available') =>
     `${NavUtils.toSpace(spaceId)}/community/bounties/${status}`,
   toProposal: (spaceId: string, proposalId: string, from?: string, governanceHomeReturnSearch?: string) => {

--- a/apps/web/partials/community-tab/accretion-dashboard-card.tsx
+++ b/apps/web/partials/community-tab/accretion-dashboard-card.tsx
@@ -1,0 +1,30 @@
+import { NavUtils } from '~/core/utils/utils';
+
+import { PrefetchLink as Link } from '~/design-system/prefetch-link';
+
+export function AccretionDashboardCard({ spaceId }: { spaceId: string }) {
+  return (
+    <section className="overflow-hidden rounded-xl border border-grey-02 bg-white">
+      <div className="flex flex-col justify-between gap-6 p-6 sm:flex-row sm:items-center">
+        <div className="max-w-2xl">
+          <div className="mb-2 flex items-center gap-2">
+            <span className="size-2 rounded-full bg-purple" aria-hidden />
+            <p className="text-[14px] leading-[18px] font-medium tracking-[-0.2px] text-purple">Allocation health</p>
+          </div>
+          <h2 className="text-[24px] leading-[29px] font-semibold tracking-[-0.75px] text-[#2A2B2E]">
+            Accretion dashboard
+          </h2>
+          <p className="mt-2 text-[16px] leading-[23px] text-grey-04">
+            See whether this space turns bounty spending into accepted, additive graph output.
+          </p>
+        </div>
+        <Link
+          href={NavUtils.toCommunityAccretion(spaceId)}
+          className="inline-flex shrink-0 items-center justify-center rounded-lg bg-[#2A2B2E] px-4 py-2.5 text-[16px] leading-[20px] font-medium text-white hover:bg-black"
+        >
+          View dashboard
+        </Link>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/partials/community-tab/accretion-dashboard.test.tsx
+++ b/apps/web/partials/community-tab/accretion-dashboard.test.tsx
@@ -1,17 +1,26 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 
 import * as React from 'react';
 
 import { describe, expect, it, vi } from 'vitest';
 
-import type { AccretionDashboardResult } from '~/core/community/accretion-types';
+import type { AccretionDashboardResult, AccretionScope } from '~/core/community/accretion-types';
 
 import { AccretionDashboard } from './accretion-dashboard';
 
 vi.mock('~/design-system/prefetch-link', () => ({
   PrefetchLink: ({ children, href }: { children: React.ReactNode; href: string }) => <a href={href}>{children}</a>,
 }));
+
+vi.stubGlobal(
+  'ResizeObserver',
+  class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+);
 
 const result: AccretionDashboardResult = {
   period: 'year',
@@ -73,14 +82,14 @@ const result: AccretionDashboardResult = {
     diffLimitReached: false,
     sourceTruncated: false,
   },
-  warnings: ['Payout amounts are nominal.'],
+  warnings: ['Payout amounts and unit costs are shown in protocol points; no fiat conversion is applied.'],
 };
 
-function renderDashboard() {
+function renderDashboard(initialScope: AccretionScope = 'space') {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return render(
     <QueryClientProvider client={client}>
-      <AccretionDashboard spaceId="space-1" initialData={result} />
+      <AccretionDashboard spaceId="space-1" initialScope={initialScope} initialData={result} />
     </QueryClientProvider>
   );
 }
@@ -104,6 +113,28 @@ describe('AccretionDashboard', () => {
     expect(screen.getAllByText(/curator-program-v1/).length).toBeGreaterThan(0);
     expect(screen.getAllByText('Direct recipients').length).toBeGreaterThan(0);
     expect(screen.getAllByText('inferred').length).toBeGreaterThan(0);
-    expect(screen.getAllByText('Payout amounts are nominal.').length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/shown in protocol points/).length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Median unit cost (points)').length).toBeGreaterThan(0);
+  });
+
+  it('loads the protocol rollup when the scope changes', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => result });
+    vi.stubGlobal('fetch', fetchMock);
+    renderDashboard();
+
+    fireEvent.click(screen.getAllByRole('button', { name: /This space/i }).at(-1)!);
+    fireEvent.click(within(screen.getByRole('dialog')).getByRole('button', { name: 'Protocol' }));
+
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith('/api/space/space-1/accretion?period=year&scope=protocol')
+    );
+    expect(screen.getByText(/Is the protocol allocating bounty spending/)).toBeTruthy();
+  });
+
+  it('can open directly in protocol scope', () => {
+    renderDashboard('protocol');
+
+    expect(screen.getAllByRole('button', { name: /Protocol/i }).at(-1)).toBeTruthy();
+    expect(screen.getAllByText(/Is the protocol allocating bounty spending/).at(-1)).toBeTruthy();
   });
 });

--- a/apps/web/partials/community-tab/accretion-dashboard.test.tsx
+++ b/apps/web/partials/community-tab/accretion-dashboard.test.tsx
@@ -1,0 +1,109 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+
+import * as React from 'react';
+
+import { describe, expect, it, vi } from 'vitest';
+
+import type { AccretionDashboardResult } from '~/core/community/accretion-types';
+
+import { AccretionDashboard } from './accretion-dashboard';
+
+vi.mock('~/design-system/prefetch-link', () => ({
+  PrefetchLink: ({ children, href }: { children: React.ReactNode; href: string }) => <a href={href}>{children}</a>,
+}));
+
+const result: AccretionDashboardResult = {
+  period: 'year',
+  asOf: '2026-08-29T00:00:00.000Z',
+  methodologyVersion: 'curator-program-v1',
+  summary: {
+    bountiesPosted: 4,
+    acceptedProposals: 3,
+    payoutAmount: 500,
+    modeledPayoutAmount: 200,
+    acceptedArtifacts: 8,
+    weightedOutputUnits: 8,
+    replacementValue: 240,
+    retroactiveRoi: 1.2,
+  },
+  unitCosts: [
+    {
+      typeId: 'claim-type',
+      typeName: 'Claim',
+      rawUnits: 8,
+      weightedUnits: 8,
+      proposalSamples: 3,
+      medianUnitCost: 30,
+      modeledSpend: 200,
+    },
+  ],
+  timeline: [{ key: '2026-08', label: "Aug '26", bountiesPosted: 4, bountiesDelivered: 3, payoutAmount: 500 }],
+  curatorCohorts: [
+    {
+      curatorId: 'curator-1',
+      name: 'Ada',
+      payoutAmount: 200,
+      outputUnits: 8,
+      replacementValue: 240,
+      efficiency: 1.2,
+      inferred: true,
+    },
+  ],
+  delivery: [
+    { key: 'posted', label: 'Published', count: 4 },
+    { key: 'allocated', label: 'Allocated', count: 4 },
+    { key: 'submitted', label: 'Submitted', count: 3 },
+    { key: 'accepted', label: 'Accepted', count: 3 },
+    { key: 'paid', label: 'Paid', count: 2 },
+    { key: 'on-time', label: 'On time', count: 2 },
+  ],
+  duplication: { native: 6, reused: 2, unknown: 0, unclassifiedProposals: 0 },
+  coverage: {
+    bounties: 4,
+    bountiesWithBudget: 4,
+    bountiesWithStatus: 4,
+    bountiesWithDeadline: 3,
+    payouts: 2,
+    payoutsWithAmount: 2,
+    payoutsWithRecipient: 0,
+    acceptedProposals: 3,
+    classifiedProposals: 3,
+    diffProposalLimit: 24,
+    diffLimitReached: false,
+    sourceTruncated: false,
+  },
+  warnings: ['Payout amounts are nominal.'],
+};
+
+function renderDashboard() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <AccretionDashboard spaceId="space-1" initialData={result} />
+    </QueryClientProvider>
+  );
+}
+
+describe('AccretionDashboard', () => {
+  it('renders all six pre-launch panels and the compensation boundary', () => {
+    renderDashboard();
+
+    expect(screen.getAllByText('Unit cost deck').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Retroactive ROI').length).toBeGreaterThan(0);
+    expect(screen.getByText('Absorption curve')).toBeTruthy();
+    expect(screen.getByText('Spend-to-output by curator')).toBeTruthy();
+    expect(screen.getByText('Declared versus delivered')).toBeTruthy();
+    expect(screen.getByText('Duplication check')).toBeTruthy();
+    expect(screen.getByText(/Payment remains a separate, human-adjudicated clearing decision/)).toBeTruthy();
+  });
+
+  it('shows methodology, coverage, and provisional attribution', () => {
+    renderDashboard();
+
+    expect(screen.getAllByText(/curator-program-v1/).length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Direct recipients').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('inferred').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Payout amounts are nominal.').length).toBeGreaterThan(0);
+  });
+});

--- a/apps/web/partials/community-tab/accretion-dashboard.tsx
+++ b/apps/web/partials/community-tab/accretion-dashboard.tsx
@@ -8,9 +8,11 @@ import cx from 'classnames';
 
 import {
   ACCRETION_PERIOD_OPTIONS,
+  ACCRETION_SCOPE_OPTIONS,
   type AccretionCoverage,
   type AccretionDashboardResult,
   type AccretionPeriod,
+  type AccretionScope,
 } from '~/core/community/accretion-types';
 import { NavUtils } from '~/core/utils/utils';
 
@@ -64,10 +66,7 @@ function EmptyMetric({ children }: { children: React.ReactNode }) {
 function UnitCostDeck({ data }: { data: AccretionDashboardResult }) {
   return (
     <section className={PANEL_CLASS}>
-      <PanelHeader
-        title="Unit cost deck"
-        description="Median nominal payout allocated to each accepted artifact type."
-      />
+      <PanelHeader title="Unit cost deck" description="Median points allocated to each accepted artifact type." />
       {data.unitCosts.length === 0 ? (
         <EmptyMetric>No fully linked payout and proposal-diff samples are available for this period.</EmptyMetric>
       ) : (
@@ -78,7 +77,7 @@ function UnitCostDeck({ data }: { data: AccretionDashboardResult }) {
                 <th className="pb-3 font-normal">Artifact type</th>
                 <th className="pb-3 text-right font-normal">Artifacts</th>
                 <th className="pb-3 text-right font-normal">Proposals</th>
-                <th className="pb-3 text-right font-normal">Median unit cost</th>
+                <th className="pb-3 text-right font-normal">Median unit cost (points)</th>
               </tr>
             </thead>
             <tbody>
@@ -111,7 +110,7 @@ function RetroactiveRoi({ data }: { data: AccretionDashboardResult }) {
     <section className={PANEL_CLASS}>
       <PanelHeader
         title="Retroactive ROI"
-        description="Modeled replacement-cost value divided by observed payout volume."
+        description="Modeled replacement-cost points divided by observed payout points."
       />
       {roi === null ? (
         <EmptyMetric>ROI appears when payout-linked proposal outputs can be classified.</EmptyMetric>
@@ -122,9 +121,9 @@ function RetroactiveRoi({ data }: { data: AccretionDashboardResult }) {
               {formatDecimal(roi)}×
             </p>
             <p className="pb-1 text-right text-[13px] leading-[18px] text-grey-04">
-              {formatCompact(data.summary.replacementValue)} modeled value
+              {formatCompact(data.summary.replacementValue)} modeled points
               <br />
-              {formatCompact(data.summary.modeledPayoutAmount)} classified payout volume
+              {formatCompact(data.summary.modeledPayoutAmount)} classified payout points
             </p>
           </div>
           <div className="relative mt-6 h-2 overflow-hidden rounded-full bg-grey-02">
@@ -171,7 +170,7 @@ function AbsorptionCurve({ data }: { data: AccretionDashboardResult }) {
                 </div>
                 <p className="mt-2 truncate text-[12px] leading-[16px] text-grey-04">{point.label}</p>
                 <p className="mt-0.5 truncate text-[11px] leading-[14px] text-grey-04">
-                  {point.payoutAmount > 0 ? `${formatCompact(point.payoutAmount)} paid` : '—'}
+                  {point.payoutAmount > 0 ? `${formatCompact(point.payoutAmount)} points` : '—'}
                 </p>
               </div>
             ))}
@@ -209,7 +208,7 @@ function CuratorCohorts({ data }: { data: AccretionDashboardResult }) {
               <div className="min-w-0">
                 <p className={cx('truncate text-[15px] leading-[20px] font-medium', INK)}>{row.name}</p>
                 <p className="text-[12px] leading-[16px] text-grey-04">
-                  {formatCompact(row.payoutAmount)} paid · {formatCompact(row.outputUnits)} output units
+                  {formatCompact(row.payoutAmount)} points · {formatCompact(row.outputUnits)} output units
                 </p>
               </div>
               <div className="shrink-0 text-right">
@@ -366,21 +365,24 @@ function DashboardSkeleton() {
 
 export function AccretionDashboard({
   spaceId,
+  initialScope = 'space',
   initialData,
 }: {
   spaceId: string;
+  initialScope?: AccretionScope;
   initialData?: AccretionDashboardResult;
 }) {
   const [period, setPeriod] = React.useState<AccretionPeriod>('year');
+  const [scope, setScope] = React.useState<AccretionScope>(initialScope);
   const { data, isPending, isError, refetch } = useQuery({
-    queryKey: ['accretion-dashboard', spaceId, period],
+    queryKey: ['accretion-dashboard', spaceId, scope, period],
     queryFn: async () => {
-      const params = new URLSearchParams({ period });
+      const params = new URLSearchParams({ period, scope });
       const response = await fetch(`/api/space/${spaceId}/accretion?${params.toString()}`);
       if (!response.ok) throw new Error('Failed to load accretion dashboard');
       return (await response.json()) as AccretionDashboardResult;
     },
-    initialData,
+    initialData: scope === initialScope && period === 'year' ? initialData : undefined,
     staleTime: 5 * 60_000,
     retry: 1,
   });
@@ -399,10 +401,15 @@ export function AccretionDashboard({
             Accretion dashboard
           </h1>
           <p className="mt-2 max-w-2xl text-[16px] leading-[23px] text-grey-04">
-            Is this space allocating bounty spending into accepted, additive graph output?
+            {scope === 'protocol'
+              ? 'Is the protocol allocating bounty spending into accepted, additive graph output?'
+              : 'Is this space allocating bounty spending into accepted, additive graph output?'}
           </p>
         </div>
-        <SingleSelectPill value={period} options={ACCRETION_PERIOD_OPTIONS} onChange={setPeriod} />
+        <div className="flex flex-wrap items-center gap-2">
+          <SingleSelectPill value={scope} options={ACCRETION_SCOPE_OPTIONS} onChange={setScope} />
+          <SingleSelectPill value={period} options={ACCRETION_PERIOD_OPTIONS} onChange={setPeriod} />
+        </div>
       </div>
 
       <div className="mb-6 flex items-start gap-3 rounded-xl border border-purple/20 bg-purple/5 p-4">
@@ -432,9 +439,9 @@ export function AccretionDashboard({
         <div className="space-y-4">
           <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
             <MetricCard
-              label="Payout volume"
+              label="Payout volume (points)"
               value={formatCompact(data.summary.payoutAmount)}
-              detail="Nominal amount; currency normalization pending"
+              detail={scope === 'protocol' ? 'Paid across protocol spaces' : 'Paid in this space'}
             />
             <MetricCard
               label="Accepted proposals"

--- a/apps/web/partials/community-tab/accretion-dashboard.tsx
+++ b/apps/web/partials/community-tab/accretion-dashboard.tsx
@@ -1,0 +1,473 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+
+import * as React from 'react';
+
+import cx from 'classnames';
+
+import {
+  ACCRETION_PERIOD_OPTIONS,
+  type AccretionCoverage,
+  type AccretionDashboardResult,
+  type AccretionPeriod,
+} from '~/core/community/accretion-types';
+import { NavUtils } from '~/core/utils/utils';
+
+import { InfoSmall } from '~/design-system/icons/info-small';
+import { PrefetchLink as Link } from '~/design-system/prefetch-link';
+import { Skeleton } from '~/design-system/skeleton';
+
+import { SingleSelectPill } from './community-filter-pill';
+
+const INK = 'text-[#2A2B2E]';
+const PANEL_CLASS = 'rounded-xl border border-grey-02 bg-white p-5';
+
+function formatCompact(value: number, maximumFractionDigits = 1): string {
+  return new Intl.NumberFormat('en', {
+    notation: Math.abs(value) >= 1_000 ? 'compact' : 'standard',
+    maximumFractionDigits,
+  }).format(value);
+}
+
+function formatDecimal(value: number, digits = 2): string {
+  return new Intl.NumberFormat('en', { maximumFractionDigits: digits }).format(value);
+}
+
+function MetricCard({ label, value, detail }: { label: string; value: string; detail: string }) {
+  return (
+    <div className={cx(PANEL_CLASS, 'min-w-0')}>
+      <p className="text-[14px] leading-[18px] text-grey-04">{label}</p>
+      <p className={cx('mt-2 text-[30px] leading-[34px] font-semibold tracking-[-1px] tabular-nums', INK)}>{value}</p>
+      <p className="mt-2 text-[13px] leading-[18px] text-grey-04">{detail}</p>
+    </div>
+  );
+}
+
+function PanelHeader({ title, description }: { title: string; description: string }) {
+  return (
+    <div className="mb-5">
+      <h2 className={cx('text-[19px] leading-[24px] font-semibold tracking-[-0.35px]', INK)}>{title}</h2>
+      <p className="mt-1 text-[14px] leading-[20px] text-grey-04">{description}</p>
+    </div>
+  );
+}
+
+function EmptyMetric({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex min-h-32 items-center justify-center rounded-lg bg-grey-01 px-6 text-center text-[14px] leading-[20px] text-grey-04">
+      {children}
+    </div>
+  );
+}
+
+function UnitCostDeck({ data }: { data: AccretionDashboardResult }) {
+  return (
+    <section className={PANEL_CLASS}>
+      <PanelHeader
+        title="Unit cost deck"
+        description="Median nominal payout allocated to each accepted artifact type."
+      />
+      {data.unitCosts.length === 0 ? (
+        <EmptyMetric>No fully linked payout and proposal-diff samples are available for this period.</EmptyMetric>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full min-w-[560px] border-collapse text-left">
+            <thead>
+              <tr className="border-b border-grey-02 text-[13px] leading-[18px] text-grey-04">
+                <th className="pb-3 font-normal">Artifact type</th>
+                <th className="pb-3 text-right font-normal">Artifacts</th>
+                <th className="pb-3 text-right font-normal">Proposals</th>
+                <th className="pb-3 text-right font-normal">Median unit cost</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.unitCosts.slice(0, 8).map(row => (
+                <tr key={row.typeId ?? row.typeName} className="border-b border-grey-02 last:border-0">
+                  <td className={cx('py-3 text-[15px] leading-[20px] font-medium', INK)}>{row.typeName}</td>
+                  <td className="py-3 text-right text-[15px] leading-[20px] text-grey-04 tabular-nums">
+                    {formatCompact(row.rawUnits, 0)}
+                  </td>
+                  <td className="py-3 text-right text-[15px] leading-[20px] text-grey-04 tabular-nums">
+                    {formatCompact(row.proposalSamples, 0)}
+                  </td>
+                  <td className={cx('py-3 text-right text-[15px] leading-[20px] font-medium tabular-nums', INK)}>
+                    {formatDecimal(row.medianUnitCost)}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function RetroactiveRoi({ data }: { data: AccretionDashboardResult }) {
+  const roi = data.summary.retroactiveRoi;
+  const width = roi === null ? 0 : Math.min(100, roi * 50);
+  return (
+    <section className={PANEL_CLASS}>
+      <PanelHeader
+        title="Retroactive ROI"
+        description="Modeled replacement-cost value divided by observed payout volume."
+      />
+      {roi === null ? (
+        <EmptyMetric>ROI appears when payout-linked proposal outputs can be classified.</EmptyMetric>
+      ) : (
+        <>
+          <div className="flex items-end justify-between gap-4">
+            <p className={cx('text-[42px] leading-[44px] font-semibold tracking-[-1.5px] tabular-nums', INK)}>
+              {formatDecimal(roi)}×
+            </p>
+            <p className="pb-1 text-right text-[13px] leading-[18px] text-grey-04">
+              {formatCompact(data.summary.replacementValue)} modeled value
+              <br />
+              {formatCompact(data.summary.modeledPayoutAmount)} classified payout volume
+            </p>
+          </div>
+          <div className="relative mt-6 h-2 overflow-hidden rounded-full bg-grey-02">
+            <div className="absolute inset-y-0 left-0 rounded-full bg-purple" style={{ width: `${width}%` }} />
+            <div className="absolute inset-y-[-3px] left-1/2 w-px bg-[#2A2B2E]" aria-hidden />
+          </div>
+          <div className="mt-2 flex justify-between text-[12px] leading-[16px] text-grey-04">
+            <span>0×</span>
+            <span>1× accretive threshold</span>
+            <span>2×+</span>
+          </div>
+        </>
+      )}
+    </section>
+  );
+}
+
+function AbsorptionCurve({ data }: { data: AccretionDashboardResult }) {
+  const maxCount = Math.max(1, ...data.timeline.flatMap(point => [point.bountiesPosted, point.bountiesDelivered]));
+  return (
+    <section className={cx(PANEL_CLASS, 'lg:col-span-2')}>
+      <PanelHeader
+        title="Absorption curve"
+        description="Bounties posted versus bounties with accepted work over time."
+      />
+      {data.timeline.length === 0 ? (
+        <EmptyMetric>No bounty activity is available for this period.</EmptyMetric>
+      ) : (
+        <div className="overflow-x-auto">
+          <div className="flex min-w-[560px] items-end gap-3 pt-4">
+            {data.timeline.map(point => (
+              <div key={point.key} className="flex min-w-0 flex-1 flex-col items-center">
+                <div className="flex h-36 w-full items-end justify-center gap-1.5">
+                  <div
+                    title={`${point.bountiesPosted} posted`}
+                    className="w-[38%] rounded-t bg-grey-02"
+                    style={{ height: `${Math.max(4, (point.bountiesPosted / maxCount) * 100)}%` }}
+                  />
+                  <div
+                    title={`${point.bountiesDelivered} delivered`}
+                    className="w-[38%] rounded-t bg-purple"
+                    style={{ height: `${Math.max(4, (point.bountiesDelivered / maxCount) * 100)}%` }}
+                  />
+                </div>
+                <p className="mt-2 truncate text-[12px] leading-[16px] text-grey-04">{point.label}</p>
+                <p className="mt-0.5 truncate text-[11px] leading-[14px] text-grey-04">
+                  {point.payoutAmount > 0 ? `${formatCompact(point.payoutAmount)} paid` : '—'}
+                </p>
+              </div>
+            ))}
+          </div>
+          <div className="mt-4 flex items-center gap-5 text-[12px] leading-[16px] text-grey-04">
+            <span className="flex items-center gap-2">
+              <span className="size-2.5 rounded-sm bg-grey-02" /> Posted
+            </span>
+            <span className="flex items-center gap-2">
+              <span className="size-2.5 rounded-sm bg-purple" /> Accepted
+            </span>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function CuratorCohorts({ data }: { data: AccretionDashboardResult }) {
+  return (
+    <section className={PANEL_CLASS}>
+      <PanelHeader
+        title="Spend-to-output by curator"
+        description="Provisional attribution until direct payout recipients are populated."
+      />
+      {data.curatorCohorts.length === 0 ? (
+        <EmptyMetric>No attributable payout cohorts are available for this period.</EmptyMetric>
+      ) : (
+        <div className="space-y-3">
+          {data.curatorCohorts.slice(0, 6).map(row => (
+            <div
+              key={row.curatorId}
+              className="flex items-center justify-between gap-4 border-b border-grey-02 pb-3 last:border-0 last:pb-0"
+            >
+              <div className="min-w-0">
+                <p className={cx('truncate text-[15px] leading-[20px] font-medium', INK)}>{row.name}</p>
+                <p className="text-[12px] leading-[16px] text-grey-04">
+                  {formatCompact(row.payoutAmount)} paid · {formatCompact(row.outputUnits)} output units
+                </p>
+              </div>
+              <div className="shrink-0 text-right">
+                <p className={cx('text-[15px] leading-[20px] font-medium tabular-nums', INK)}>
+                  {row.efficiency === null ? '—' : `${formatDecimal(row.efficiency)}×`}
+                </p>
+                <p className="text-[11px] leading-[14px] text-grey-04">{row.inferred ? 'inferred' : 'direct'}</p>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function DeclaredVsDelivered({ data }: { data: AccretionDashboardResult }) {
+  const maximum = Math.max(1, data.delivery[0]?.count ?? 0);
+  return (
+    <section className={PANEL_CLASS}>
+      <PanelHeader
+        title="Declared versus delivered"
+        description="The forward-book funnel for bounties published during this period."
+      />
+      <div className="space-y-3">
+        {data.delivery.map(stage => (
+          <div key={stage.key}>
+            <div className="mb-1.5 flex items-center justify-between gap-3 text-[13px] leading-[17px]">
+              <span className={INK}>{stage.label}</span>
+              <span className="text-grey-04 tabular-nums">{stage.count}</span>
+            </div>
+            <div className="h-2 overflow-hidden rounded-full bg-grey-01">
+              <div
+                className={cx('h-full rounded-full', stage.key === 'posted' ? 'bg-[#2A2B2E]' : 'bg-purple')}
+                style={{ width: `${Math.max(stage.count > 0 ? 2 : 0, (stage.count / maximum) * 100)}%` }}
+              />
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function DuplicationCheck({ data }: { data: AccretionDashboardResult }) {
+  const rows = [
+    { label: 'Native entities', value: data.duplication.native, color: 'bg-purple' },
+    { label: 'Existing entities reused', value: data.duplication.reused, color: 'bg-[#2A2B2E]' },
+    { label: 'Unknown', value: data.duplication.unknown, color: 'bg-grey-03' },
+  ];
+  const total = Math.max(
+    1,
+    rows.reduce((sum, row) => sum + row.value, 0)
+  );
+  return (
+    <section className={PANEL_CLASS}>
+      <PanelHeader
+        title="Duplication check"
+        description="Exact entity creation versus useful work on entities that already existed."
+      />
+      {total === 1 && rows.every(row => row.value === 0) ? (
+        <EmptyMetric>No proposal output has been classified for this period.</EmptyMetric>
+      ) : (
+        <>
+          <div className="flex h-3 overflow-hidden rounded-full bg-grey-01">
+            {rows.map(row =>
+              row.value > 0 ? (
+                <div key={row.label} className={row.color} style={{ width: `${(row.value / total) * 100}%` }} />
+              ) : null
+            )}
+          </div>
+          <div className="mt-5 space-y-3">
+            {rows.map(row => (
+              <div key={row.label} className="flex items-center justify-between gap-3 text-[14px] leading-[19px]">
+                <span className="flex items-center gap-2 text-grey-04">
+                  <span className={cx('size-2.5 rounded-sm', row.color)} /> {row.label}
+                </span>
+                <span className={cx('font-medium tabular-nums', INK)}>
+                  {row.value} · {formatDecimal((row.value / total) * 100, 0)}%
+                </span>
+              </div>
+            ))}
+          </div>
+          {data.duplication.unclassifiedProposals > 0 ? (
+            <p className="mt-4 text-[12px] leading-[17px] text-grey-04">
+              {data.duplication.unclassifiedProposals} accepted proposals are outside the current diff sample.
+            </p>
+          ) : null}
+        </>
+      )}
+    </section>
+  );
+}
+
+function coverageRatio(part: number, total: number): string {
+  if (total === 0) return '—';
+  return `${Math.round((part / total) * 100)}%`;
+}
+
+function DataCoverage({ coverage, warnings }: { coverage: AccretionCoverage; warnings: string[] }) {
+  const items = [
+    { label: 'Bounty budgets', value: coverageRatio(coverage.bountiesWithBudget, coverage.bounties) },
+    { label: 'Bounty statuses', value: coverageRatio(coverage.bountiesWithStatus, coverage.bounties) },
+    { label: 'Deadlines', value: coverageRatio(coverage.bountiesWithDeadline, coverage.bounties) },
+    { label: 'Payout amounts', value: coverageRatio(coverage.payoutsWithAmount, coverage.payouts) },
+    { label: 'Direct recipients', value: coverageRatio(coverage.payoutsWithRecipient, coverage.payouts) },
+    {
+      label: 'Proposal outputs',
+      value: coverageRatio(coverage.classifiedProposals, coverage.acceptedProposals),
+    },
+  ];
+
+  return (
+    <section className={PANEL_CLASS}>
+      <PanelHeader title="Data coverage" description="What is observed, missing, or sampled in this result." />
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        {items.map(item => (
+          <div key={item.label} className="rounded-lg bg-grey-01 px-3 py-3">
+            <p className="text-[12px] leading-[16px] text-grey-04">{item.label}</p>
+            <p className={cx('mt-1 text-[18px] leading-[22px] font-semibold tabular-nums', INK)}>{item.value}</p>
+          </div>
+        ))}
+      </div>
+      <div className="mt-5 space-y-2">
+        {warnings.map(warning => (
+          <p key={warning} className="flex items-start gap-2 text-[12px] leading-[18px] text-grey-04">
+            <span className="mt-0.5 shrink-0 text-grey-04">
+              <InfoSmall />
+            </span>
+            {warning}
+          </p>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function DashboardSkeleton() {
+  return (
+    <div className="space-y-6">
+      <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+        {Array.from({ length: 4 }).map((_, index) => (
+          <Skeleton key={index} className="h-32 w-full rounded-xl" />
+        ))}
+      </div>
+      <div className="grid gap-4 lg:grid-cols-2">
+        {Array.from({ length: 6 }).map((_, index) => (
+          <Skeleton key={index} className="h-72 w-full rounded-xl" />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function AccretionDashboard({
+  spaceId,
+  initialData,
+}: {
+  spaceId: string;
+  initialData?: AccretionDashboardResult;
+}) {
+  const [period, setPeriod] = React.useState<AccretionPeriod>('year');
+  const { data, isPending, isError, refetch } = useQuery({
+    queryKey: ['accretion-dashboard', spaceId, period],
+    queryFn: async () => {
+      const params = new URLSearchParams({ period });
+      const response = await fetch(`/api/space/${spaceId}/accretion?${params.toString()}`);
+      if (!response.ok) throw new Error('Failed to load accretion dashboard');
+      return (await response.json()) as AccretionDashboardResult;
+    },
+    initialData,
+    staleTime: 5 * 60_000,
+    retry: 1,
+  });
+
+  return (
+    <div className="min-w-0 pb-10">
+      <div className="mb-6 flex flex-col justify-between gap-4 sm:flex-row sm:items-end">
+        <div>
+          <Link
+            href={NavUtils.toCommunity(spaceId)}
+            className="text-[14px] leading-[18px] text-grey-04 hover:underline"
+          >
+            Community
+          </Link>
+          <h1 className={cx('mt-2 text-[30px] leading-[35px] font-semibold tracking-[-1px]', INK)}>
+            Accretion dashboard
+          </h1>
+          <p className="mt-2 max-w-2xl text-[16px] leading-[23px] text-grey-04">
+            Is this space allocating bounty spending into accepted, additive graph output?
+          </p>
+        </div>
+        <SingleSelectPill value={period} options={ACCRETION_PERIOD_OPTIONS} onChange={setPeriod} />
+      </div>
+
+      <div className="mb-6 flex items-start gap-3 rounded-xl border border-purple/20 bg-purple/5 p-4">
+        <span className="mt-1 size-2 shrink-0 rounded-full bg-purple" aria-hidden />
+        <p className="text-[13px] leading-[19px] text-grey-04">
+          These metrics inform governance and allocation choices only. Payment remains a separate, human-adjudicated
+          clearing decision.
+        </p>
+      </div>
+
+      {isPending ? <DashboardSkeleton /> : null}
+
+      {isError ? (
+        <div className="rounded-xl border border-grey-02 bg-white px-6 py-14 text-center">
+          <p className={cx('text-[16px] leading-[22px] font-medium', INK)}>Could not load the dashboard.</p>
+          <button
+            type="button"
+            onClick={() => void refetch()}
+            className="mt-4 rounded-lg border border-grey-02 px-4 py-2 text-[14px] leading-[18px] text-[#2A2B2E] hover:bg-grey-01"
+          >
+            Try again
+          </button>
+        </div>
+      ) : null}
+
+      {data ? (
+        <div className="space-y-4">
+          <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+            <MetricCard
+              label="Payout volume"
+              value={formatCompact(data.summary.payoutAmount)}
+              detail="Nominal amount; currency normalization pending"
+            />
+            <MetricCard
+              label="Accepted proposals"
+              value={formatCompact(data.summary.acceptedProposals, 0)}
+              detail={`${formatCompact(data.summary.bountiesPosted, 0)} bounties posted`}
+            />
+            <MetricCard
+              label="Accepted artifacts"
+              value={formatCompact(data.summary.acceptedArtifacts, 0)}
+              detail={`${formatCompact(data.summary.weightedOutputUnits)} weighted output units`}
+            />
+            <MetricCard
+              label="Retroactive ROI"
+              value={data.summary.retroactiveRoi === null ? '—' : `${formatDecimal(data.summary.retroactiveRoi)}×`}
+              detail={`Methodology ${data.methodologyVersion}`}
+            />
+          </div>
+
+          <div className="grid gap-4 lg:grid-cols-2">
+            <UnitCostDeck data={data} />
+            <RetroactiveRoi data={data} />
+            <AbsorptionCurve data={data} />
+            <CuratorCohorts data={data} />
+            <DeclaredVsDelivered data={data} />
+            <DuplicationCheck data={data} />
+          </div>
+
+          <DataCoverage coverage={data.coverage} warnings={data.warnings} />
+          <p className="text-right text-[11px] leading-[15px] text-grey-04">
+            As of {new Date(data.asOf).toLocaleString()} · {data.methodologyVersion}
+          </p>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/partials/community-tab/community-tab-page.tsx
+++ b/apps/web/partials/community-tab/community-tab-page.tsx
@@ -2,6 +2,7 @@
 
 import * as React from 'react';
 
+import { AccretionDashboardCard } from './accretion-dashboard-card';
 import { BountiesStatusSection } from './community-bounties-sections';
 import { CuratorLeaderboardSection } from './curator-leaderboard-section';
 
@@ -12,6 +13,7 @@ type Props = {
 export function CommunityTabPage({ spaceId }: Props) {
   return (
     <div className="flex min-w-0 flex-col gap-10 pb-8">
+      <AccretionDashboardCard spaceId={spaceId} />
       <CuratorLeaderboardSection spaceId={spaceId} />
       <BountiesStatusSection spaceId={spaceId} status="completed" />
       <BountiesStatusSection spaceId={spaceId} status="in-progress" />

--- a/docs/research/2026-08-29-accretion-dashboard-data-spec.md
+++ b/docs/research/2026-08-29-accretion-dashboard-data-spec.md
@@ -1,0 +1,612 @@
+# Accretion Dashboard: Product and Data Specification
+
+**Date:** 2026-08-29
+
+**Status:** Research artifact and implementation specification
+
+**Source:** [Accretion dashboard: what gets measured](https://app.notion.com/p/Accretion-dashboard-what-gets-measured-3cb273e214eb81df8bb2e2eb758d250a) and its [Tokenomics Hub](https://app.notion.com/p/Tokenomics-Hub-3cb273e214eb8081b53aed1d5fbc214e) context
+
+**Live data inspected:** `https://api-testnet.geobrowser.io/graphql`
+**Snapshot caveat:** Counts below are a testnet snapshot from 2026-08-29. They prove schema and coverage, not production economic performance.
+
+## Executive summary
+
+The pre-launch accretion dashboard is feasible with current data, but it is a multi-source analytics feature rather than a single GraphQL query.
+
+The Geo graph already contains a strong curator-program spine:
+
+- Bounties with budget, scope, status, deadlines, difficulty, skills, and allocated curators.
+- Payouts with amounts and mandatory links to bounties.
+- Many-to-many links between bounties, governance proposals, and payouts.
+- Governance proposal authorship, submission time, and execution time.
+- Proposal diffs capable of describing the entities, claims, relations, and structure produced by accepted work.
+
+The graph does **not** yet provide a reliable direct payout recipient, adjudication state history, rejection/rework events, token/currency metadata, funding balances, issuance, stake positions, commissions, appeals, affiliate relationships, or lifecycle declarations. Those gaps block the complete network, space, and staker dashboards, but they do not block a useful pre-launch curator-program dashboard.
+
+The recommended first implementation is a read-only analytics surface with six panels:
+
+1. Unit cost deck
+2. Retroactive ROI
+3. Absorption curve
+4. Spend-to-output by curator cohort
+5. Declared versus delivered
+6. Duplication check
+
+The implementation must preserve the source document's central boundary: these metrics inform governance, display, ranking, and staker choice. They must never automatically determine an individual's payment.
+
+## Non-negotiable product boundary
+
+The three levels answer different questions and must remain separate.
+
+| Level   | Question                       | Allowed effect                                                          |
+| ------- | ------------------------------ | ----------------------------------------------------------------------- |
+| Network | Is issuance accretive?         | Governance judgment about issuance rate, split, and program design only |
+| Space   | Is this space allocating well? | Public display, ranking inputs, and staker choice; never direct payment |
+| Money   | Did adjudicated work clear?    | Binary human decision to pay or not pay; no continuous score            |
+
+### Guardrails
+
+- Do not expose a combined "curator score" that can become a shadow payout formula.
+- Do not feed dashboard outputs into payout creation, payout amount, or adjudication.
+- Display methodology, coverage, and incomplete-data warnings beside computed metrics.
+- Keep observed facts separate from modeled value. For example, payout amount is observed; replacement-cost value is derived.
+- Version formulas and artifact weights so historical charts do not silently change when methodology changes.
+
+## Live source-system inventory
+
+### 1. Knowledge graph entities, values, and relations
+
+The public GraphQL endpoint provides the curator-program domain objects and their joins.
+
+| Concept                  | Graph representation            | ID / field                         | Snapshot coverage                                    |
+| ------------------------ | ------------------------------- | ---------------------------------- | ---------------------------------------------------- |
+| Bounty                   | Type                            | `808af0bad5884e3391f09dd4b25e18be` | 215 entities                                         |
+| Bounty budget            | Decimal/number property         | `9ece325c592d42d5b2e785e8e6fe05b6` | 211/215 bounties (98.1%)                             |
+| Bounty description/scope | Text property                   | `9b1f76ff9711404c861e59dc3fa7d037` | Present on many, not required                        |
+| Bounty allocation        | Bounty to person/space relation | `cfeb642223c54df4b3f9375a489d9e22` | 475 links; 135 unique identities across 131 bounties |
+| Bounty task status       | Bounty to status relation       | `054a7993ec2843e29688c84ac7a09220` | 131/215 bounties (60.9%)                             |
+| Submission deadline      | Date-like property              | `7566286ca054405a83e185ffd60492fb` | 77/215 bounties (35.8%)                              |
+| Proposal                 | Graph type mirror               | `490a7c90ad4b4029b2b4d85d22fe203a` | 3,927 typed entities                                 |
+| Proposal to bounty       | Relation                        | `3b4c516ff3ac41e0a939374119a27d6e` | 3,942 links                                          |
+| Payout                   | Type                            | `f5132deb102d64553049f1e9cb662f50` | 785 entities                                         |
+| Payout amount            | Decimal property                | `82fe45a31df74c0291afa6e68d41cddf` | 770/785 payouts (98.1%)                              |
+| Payout to bounty         | Relation                        | `1b595a8b81fc25856a9b503e3e993331` | 785 links; one for every payout                      |
+| Payout to proposal       | Relation                        | `8128964c1ec54829beb380a21ab64c51` | 2,651 links                                          |
+| Payout recipient         | Declared relation property      | `151b0bd3440d435ab093ed5fab73db6c` | 0 links; schema exists but is unused                 |
+
+The payout amount sum in the snapshot is 587,575 across 770 populated records. This is a data-integrity observation only: the graph does not consistently identify currency, token, USD conversion, or whether historical testnet records represent real settlement.
+
+The allocation relation currently provides the best graph-native view of curator participation: 475 allocation links cover 135 unique target identities, 131 bounties, and 32 spaces. Most targets are both Person and Space entities because personal spaces carry both types. A separate type named `Curator` exists, but its description is specific to a Paris content domain and it is not the curator-program identity model. Do not filter program participants by that type.
+
+Current task-status distribution among the 131 bounties that have a status:
+
+| Status      | Entity ID                          | Count |
+| ----------- | ---------------------------------- | ----: |
+| Todo        | `76b5b831a5fa4203ad61b3f93915edec` |    60 |
+| Done        | `425f3e809cf9488696581775159dfc33` |    25 |
+| Backlog     | `ee3dd49a49754ff696d0af79044dc21c` |    22 |
+| In Progress | `548fca08e94743668457b0d8429d5bf9` |    19 |
+| In review   | `16f543624376498ea00d5aad45096a45` |     4 |
+| Cancelled   | `0fb6253b9f2c405886bc49f170f317b3` |     1 |
+
+### 2. Governance indexer and REST API
+
+Governance proposals have two relevant representations:
+
+- `proposalsConnection` is the complete indexed governance table. The snapshot contains 30,244 proposals and exposes `id`, `spaceId`, `proposedBy`, `createdAt`, `executedAt`, and `unexecutableAt`.
+- Proposal entities of type `490a7c90ad4b4029b2b4d85d22fe203a` are a smaller graph mirror used for semantic relations such as bounty and payout links. They are not a complete proposal-history source.
+
+The application already uses the REST API for richer governance state:
+
+- `GET /proposals/space/{spaceId}/status` supplies status, voting mode, actions, votes, timing, and executability.
+- `GET /versioned/proposals/{proposalId}/diff?spaceId=...` supplies entity-level proposal diffs.
+
+Use the indexed governance table for complete proposal identity, authorship, submission time, and execution time. Use the graph proposal entity for semantic joins. Use the REST status/diff endpoints for acceptance state and output classification.
+
+### 3. Version history and authorship
+
+The GraphQL API exposes relation and edit version history:
+
+- `relationVersionsConnection` provides `validFromKey` and `validToKey`.
+- `editVersionsConnection` maps a version key to `createdAt` and `createdById`.
+
+This can recover when a bounty status or allocation relation changed and who published an entity's first version. The existing curator leaderboard already uses this pattern to attribute newly accepted news stories to their originating curator.
+
+Version-history derivation is useful for backfill, but explicit lifecycle timestamps are preferable for future data. Reconstructing business events from arbitrary graph edits is costly and can be ambiguous.
+
+### 4. Protocol/on-chain data not found as first-class dashboard types
+
+The inspected graph has no relevant first-class types named Stake, Commission, Stipend, Appeal, or Issuance. A generic Funding round type exists, but it is not a curator-program funding ledger. The complete protocol dashboard therefore needs a separate indexed contract/accounting source for:
+
+- Issuance by cycle and its USD value
+- Curator and staker issuance shares
+- Stake positions and position aging
+- Commission accrual and settlement
+- Space balances and funding windows
+- Aggregator management fees
+
+### 5. Existing application touchpoints
+
+The web application already contains useful query and transformation patterns:
+
+| File                                                        | Reusable responsibility                                                                   |
+| ----------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| `apps/web/core/constants.ts`                                | Bounty, status, allocation, and proposal-link IDs                                         |
+| `apps/web/core/community/fetch-space-bounties.ts`           | Space-scoped bounty, budget, status, skill, and allocation query                          |
+| `apps/web/core/community/fetch-curator-leaderboard.ts`      | Paginated aggregation, proposal execution filtering, and first-version author attribution |
+| `apps/web/partials/review/bounty-linking/build-bounties.ts` | Normalized bounty construction and allocation/status logic                                |
+| `apps/web/core/io/subgraph/fetch-proposals.ts`              | Rich proposal lifecycle data from the REST API                                            |
+| `apps/web/core/io/subgraph/fetch-proposal-diffs.ts`         | Paginated proposal-diff retrieval and post-processing                                     |
+| `apps/web/core/community/community-graphql.ts`              | Capped pagination, UUID normalization, and query error handling                           |
+
+These are good references, but dashboard aggregation should move server-side rather than importing UI-oriented fetchers into a large client query.
+
+## Canonical curator-program join model
+
+The dashboard's present-day analytical path should be:
+
+```text
+Space
+  └─ Bounty
+      ├─ budget / scope / deadline / current status
+      ├─ allocated → curator personal space or person
+      ├─ linked from → Proposal
+      │    ├─ proposedBy / createdAt / executedAt
+      │    └─ proposal diff → created and updated graph artifacts
+      └─ linked from → Payout
+           ├─ amount
+           └─ linked to → one or more accepted proposals
+```
+
+### Join rules
+
+1. Normalize all UUIDs to bare lowercase hex before joining. REST responses may be hyphenated while GraphQL IDs are generally bare.
+2. Treat `Payout -> Payout bounty` as the canonical payout-to-bounty edge; snapshot coverage is complete.
+3. Treat `Proposal -> Bounties` as the canonical submission-to-bounty edge.
+4. A proposal is **accepted** for pre-launch analytics when the governance indexer has a non-null `executedAt`. Do not infer acceptance from the bounty's current `Done` status.
+5. A payout may link to multiple proposals. Do not double-count the full payout amount once per proposal.
+6. A bounty may have multiple allocated curators. Until `Payout recipient` is populated, recipient-level and cohort metrics are ambiguous and must be labeled provisional or omitted.
+7. Treat payout amount as nominal until currency/token and USD-normalization fields exist.
+8. Use proposal diffs to determine output; never use proposal title keywords as the production count.
+
+## Artifact classification
+
+The output side of the dashboard needs a stable classification contract.
+
+### Recommended output record
+
+Each accepted proposal diff should be transformed into one or more analytical output records:
+
+| Field                 | Meaning                                                                                    |
+| --------------------- | ------------------------------------------------------------------------------------------ |
+| `proposal_id`         | Governance proposal that delivered the change                                              |
+| `bounty_id`           | Bounty linked to the proposal                                                              |
+| `space_id`            | Space accepting the work                                                                   |
+| `curator_id`          | Explicit payout recipient when available; otherwise provisional proposal author/allocation |
+| `accepted_at`         | Proposal `executedAt`                                                                      |
+| `entity_id`           | Changed graph entity                                                                       |
+| `operation`           | `created`, `updated`, `related`, or `removed`                                              |
+| `artifact_type_id`    | Primary graph type of the output entity                                                    |
+| `artifact_type_name`  | Display name such as Claim, Topic, News story, or structural relation                      |
+| `native_flag`         | Exact-new, reused-existing, or unknown                                                     |
+| `weighted_units`      | Methodology-versioned output weight                                                        |
+| `methodology_version` | Version of classification and weight rules                                                 |
+
+### Creation versus reuse
+
+- **Exact new:** the proposal creates the entity's first accepted version.
+- **Reused existing:** the proposal adds values, relations, or space presence to an entity that already existed.
+- **Structural:** the proposal primarily adds or changes relations, ordering, or blocks.
+- **Semantic duplicate:** a newly created entity is substantially equivalent to an existing entity. This cannot be determined reliably from IDs alone; use embeddings plus a reviewed sample.
+
+### Quality weighting
+
+Start with transparent weights by artifact type and version them. Do not optimize weights against individual payouts. A defensible first release may display both raw counts and weighted units, with the weighted series explicitly marked experimental.
+
+## Metric specification
+
+### Pre-launch panels
+
+#### 1. Unit cost deck
+
+**Question:** What does accepted curator work actually cost by artifact type?
+
+**Recommended formula:**
+
+```text
+clearing_unit_cost(type, trailing_window)
+  = median(
+      allocated_payout_amount_for_type
+      / accepted_weighted_units_for_type
+    )
+```
+
+**Inputs:** payout amount, payout-to-bounty link, payout-to-proposal link, accepted proposal execution time, proposal diff, artifact classification.
+
+**Allocation rule:**
+
+- Use directly attributable single-type proposals first.
+- For mixed-output proposals, allocate payout proportionally by predeclared artifact weights.
+- Never count the bounty budget as the clearing price when a payout amount exists.
+- Keep records with missing amounts or output classification out of the median and disclose the excluded count.
+
+**MVP status:** Buildable after the output transformer is implemented. Currency normalization remains a limitation.
+
+#### 2. Retroactive ROI
+
+**Question:** Was the curator program's accepted output worth at least what it cost?
+
+```text
+replacement_cost_value
+  = sum(accepted_weighted_units_by_type × unit_cost_deck_by_type)
+
+retroactive_roi
+  = replacement_cost_value / cleared_payout_amount
+```
+
+Display the numerator, denominator, methodology version, and coverage beside the ratio. Because a unit-cost deck derived from the same program can make the result partly circular, add external benchmark rates when available and show a sensitivity range.
+
+**MVP status:** Buildable as a modeled estimate, not an accounting fact.
+
+#### 3. Absorption curve
+
+**Question:** How much declared work can the contributor base complete?
+
+Show cycle/week cohorts for:
+
+- Bounties posted
+- Budget posted
+- Bounties with at least one accepted proposal
+- Accepted payout amount
+- Median time to first accepted proposal
+- Median time to final accepted proposal
+
+```text
+bounty_absorption_rate = bounties_with_accepted_work / bounties_posted
+budget_absorption_rate = cleared_payout_amount / bounty_budget_posted
+```
+
+Use bounty creation time for posting and proposal `executedAt` for accepted delivery. Track current task status separately. A `Done` relation is a declaration, not proof of accepted work.
+
+**MVP status:** Buildable. Historical status-transition timing is derivable but should be replaced with explicit lifecycle timestamps.
+
+#### 4. Spend-to-output by curator cohort
+
+**Question:** Does allocation efficiency differ meaningfully across curator cohorts?
+
+```text
+cohort_efficiency
+  = accepted_replacement_cost_value / cleared_payout_amount
+```
+
+Suggested cohorts: first payout month, space, artifact specialty, or new-versus-returning. Require a minimum sample size and show distributions rather than a public individual leaderboard.
+
+**MVP status:** Blocked for a trustworthy release by the unused direct `Payout recipient` relation. A provisional private analysis can join through proposal author and bounty allocation, but multiple allocations make that attribution unsafe for public display.
+
+#### 5. Declared versus delivered
+
+**Question:** Does a space deliver the work it advertises?
+
+For each posting cohort, show:
+
+- Bounties published
+- Bounties funded (requires an explicit funding definition)
+- Bounties allocated
+- Bounties with submitted proposals
+- Bounties with accepted/executed proposals
+- Bounties paid
+- Delivered by deadline
+- Median days to acceptance
+
+**MVP status:** Partially buildable. Published, allocated, submitted, accepted, paid, and deadline timeliness are available. "Funded" is not yet represented independently from a stated budget.
+
+#### 6. Duplication check
+
+**Question:** How much output is genuinely additive?
+
+Release in two layers:
+
+1. **Exact reuse:** classify created entity IDs versus edits to pre-existing IDs from proposal diffs.
+2. **Semantic duplication:** compare new entity names/descriptions/embeddings against existing entities and manually review a stratified sample.
+
+Report `new`, `reused`, `suspected duplicate`, and `unknown` separately. Do not collapse reuse and duplication: extending an existing entity can be valuable maintenance.
+
+**MVP status:** Exact reuse is buildable. Semantic duplication needs a new analysis job or a hand-audited sample.
+
+### Network dashboard
+
+| Metric                    | Formula                                                             | Current status                                                  |
+| ------------------------- | ------------------------------------------------------------------- | --------------------------------------------------------------- |
+| Gross issuance ROI        | Change in replacement-cost curated graph value / total issuance USD | Blocked by issuance and price data; numerator can be prototyped |
+| Curator ROI               | Same numerator / curator issuance share USD                         | Blocked by issuance split data                                  |
+| Curated artifacts created | Accepted quality-weighted units by type                             | Buildable from proposal diffs                                   |
+| Unit cost by type         | Trailing median clearing price per artifact type                    | Buildable with limitations described above                      |
+| Maintenance decay         | Share of curated value not refreshed in trailing period             | Derivable after defining refresh eligibility and decay windows  |
+| Absorption                | Cleared spend / issuance available to spend                         | Cleared spend partially available; issuance unavailable         |
+| Cleared vs stopped        | Volume by cleared/stopped/appealed/overturned state                 | Blocked by payout adjudication events                           |
+| Native vs duplicated      | New versus reused/semantically duplicated output                    | Exact layer buildable; semantic layer needs analysis            |
+
+### Space dashboard
+
+| Metric                              | Required source                                    | Current status                                   |
+| ----------------------------------- | -------------------------------------------------- | ------------------------------------------------ |
+| Spend-to-output                     | Payouts + accepted proposal diffs + unit-cost deck | Buildable after output transformer               |
+| Commission per unit stake           | Commission ledger + stake snapshots                | Not available in inspected graph                 |
+| Cleared payout volume by cycle/type | Payout amount, kind, currency, state, cycle        | Amount exists; kind/currency/state/cycle missing |
+| Promised vs available funds         | Obligations + space balance/funding windows        | Not available                                    |
+| Declared vs delivered               | Bounties + proposals + payouts + deadlines         | Partially buildable                              |
+| Editor self-payment ratio           | Recipient + editor/affiliate snapshot              | Recipient unused; affiliate data missing         |
+| Payout concentration                | Explicit recipient + normalized amount             | Blocked by recipient and currency gaps           |
+| Curator churn                       | Explicit recipient + payout timestamp              | Blocked by recipient gap                         |
+| Stop/appeal record                  | Adjudication event ledger                          | Not available                                    |
+| Lifecycle and seasonality           | Space declaration + observed spend                 | Declaration model missing; spend derivable       |
+| Aggregator management fee           | Fee declaration + settlement ledger                | Not available                                    |
+
+### Staker dashboard
+
+| Metric                   | Required source                                      | Current status                                                            |
+| ------------------------ | ---------------------------------------------------- | ------------------------------------------------------------------------- |
+| Realized commission rate | Position-level stake and commission settlements      | Not available                                                             |
+| Pending claims           | Funding windows, uncleared work, expected settlement | Not available                                                             |
+| Benchmark comparison     | Position returns + aggregator blended return         | Not available                                                             |
+| Position aging           | Stake open/close timestamps and balances             | Not available                                                             |
+| Opportunity view         | Forward bounty book + interests + space track record | Bounty book and track record partially available; stake interests missing |
+
+## Required data contracts and backfills
+
+### Priority 0: needed for a credible pre-launch release
+
+1. Populate `Payout recipient` on every new payout and backfill historical payouts.
+2. Add `currency_or_token`, raw amount, decimals, and settlement-time USD value.
+3. Define whether payout entity creation means human-cleared settlement; if not, add an explicit state.
+4. Provide a stable proposal-diff analytics endpoint or batch export. The current per-proposal REST endpoint is suitable for UI review but expensive for a full historical dashboard.
+5. Define artifact types and methodology-versioned output weights.
+6. Record lifecycle events explicitly: posted, funded, allocated, submitted, accepted, rejected, rework requested, completed, and cancelled.
+
+### Priority 1: needed for the complete space dashboard
+
+Add a payout adjudication event model:
+
+```text
+payout_id
+state: CLEARED | STOPPED | APPEALED | OVERTURNED
+occurred_at
+actor_id
+reason_code
+supersedes_event_id
+```
+
+Also add:
+
+- Payout kind: bounty, stipend, round, or manual
+- Cycle/season ID
+- Settlement transaction/reference
+- Bounty funding reservation and release
+- Editor and affiliate membership snapshots at payout time
+- Space lifecycle declaration and aggregator fee declaration
+
+### Priority 2: needed for network and staker dashboards
+
+- Issuance ledger by cycle with curator/staker split and USD conversion
+- Stake-position event stream
+- Commission attribution and settlement ledger
+- Space/aggregator balance snapshots
+- Funding-window and pending-claim records
+
+## Recommended analytics architecture
+
+Do not calculate the entire dashboard in the browser. The joins span paginated graph collections, governance records, historical proposal diffs, and eventually on-chain/accounting data.
+
+### Ingestion
+
+Incrementally ingest:
+
+- Graph bounty, payout, proposal-entity, relation, value, and version changes
+- Governance proposal lifecycle records
+- Proposal diffs for bounty-linked proposals
+- Future settlement, issuance, stake, and commission events
+
+### Canonical facts
+
+Materialize at least:
+
+- `fact_bounty`
+- `fact_bounty_lifecycle_event`
+- `fact_proposal_delivery`
+- `fact_artifact_output`
+- `fact_payout`
+- `fact_payout_adjudication_event`
+- `dim_curator`
+- `dim_space`
+- `dim_cycle`
+- `dim_artifact_type_weight`
+
+### Serving API
+
+Expose pre-aggregated, methodology-versioned responses, for example:
+
+```text
+GET /analytics/accretion/network?from=&to=&methodology=
+GET /analytics/accretion/spaces/{space_id}?from=&to=&methodology=
+GET /analytics/accretion/curator-program?from=&to=&space_id=
+GET /analytics/accretion/methodologies/{version}
+```
+
+Every response should include:
+
+- `as_of`
+- `methodology_version`
+- source-row counts
+- missing/unclassified counts
+- currency coverage
+- whether the result is observed, derived, or modeled
+
+## Suggested first Linear ticket
+
+### Title
+
+**Accretion dashboard: build curator-program data pipeline and pre-launch panels**
+
+### Scope
+
+Build a read-only curator-program dashboard using bounty, payout, governance proposal, and proposal-diff data. Include the six pre-launch panels, methodology/coverage disclosure, space and time filters, and CSV export for validation.
+
+### Acceptance criteria
+
+- The dashboard joins payouts to bounties and accepted proposals without double-counting many-to-many links.
+- Accepted work is defined by non-null proposal `executedAt` and output is sourced from proposal diffs.
+- Unit cost is shown by artifact type with raw count, weighted units, median, sample size, and excluded-record count.
+- Retroactive ROI displays numerator, denominator, methodology version, and a sensitivity range.
+- The absorption chart shows posted, accepted, and paid cohorts over time plus time-to-acceptance.
+- Declared-versus-delivered distinguishes published, allocated, submitted, accepted, paid, and on-time.
+- Duplication distinguishes exact-new, reused-existing, suspected semantic duplicate, and unknown.
+- Curator-cohort metrics are hidden or marked provisional until direct payout-recipient coverage is sufficient.
+- All panels support time and space filters and show an `as of` timestamp.
+- Missing budget, amount, status, deadline, recipient, and output-classification coverage is visible.
+- Test fixtures cover one bounty with multiple proposals, one payout with multiple proposals, multiple curators allocated to one bounty, missing amount, missing deadline, and a mixed-output proposal.
+- No dashboard metric is imported by or callable from payout creation/adjudication code.
+
+### Explicitly out of scope for the first ticket
+
+- Automated payout decisions
+- Stake or commission dashboards
+- Issuance ROI using live token economics
+- Appeal/overturn analysis before an adjudication event model exists
+- Public individual curator rankings
+- Fully automated semantic-duplication judgment
+
+## Implementation work breakdown
+
+1. **Data contract and backfill**
+   - Populate payout recipient and currency metadata.
+   - Confirm lifecycle semantics and create fixture coverage.
+2. **Historical extractor**
+   - Fetch bounty/payout/proposal joins.
+   - Batch and cache proposal diffs.
+   - Normalize IDs and timestamps.
+3. **Output transformer**
+   - Classify entity creation, reuse, relation work, and artifact type.
+   - Apply versioned weights.
+4. **Metric aggregation**
+   - Produce unit cost, ROI, absorption, cohorts, delivery, and duplication series.
+   - Emit coverage metadata with every aggregation.
+5. **Dashboard UI**
+   - Build six panels, filters, methodology drawer, warnings, and CSV export.
+6. **Validation**
+   - Reconcile a hand-selected bounty sample against graph records and human program records.
+   - Compare aggregate payout totals with the source-of-truth payment ledger.
+
+## Open decisions
+
+These decisions should be resolved before implementation estimates are final:
+
+1. What currency/token does each historical payout amount represent, and what is the USD conversion policy?
+2. Does creating a payout entity guarantee that payment cleared, or is it merely a payout request?
+3. Which event is authoritative for delivery: accepted proposal execution, bounty status `Done`, payout creation, or a new adjudication event?
+4. How should one payout be allocated across multiple proposals and artifact types?
+5. Who is the curator of record: payout recipient, proposal author, bounty allocation, or a team split?
+6. What are the initial artifact-type weights, who governs them, and how often may they change?
+7. What is the cycle boundary for historical curator-program data?
+8. What qualifies as "funded" rather than merely budgeted?
+9. What trailing window defines maintenance refresh and which artifact types decay?
+10. What minimum sample size is required before cohort efficiency is displayed?
+
+## Risks
+
+- **Currency ambiguity:** Summing nominal payout amounts can produce a convincing but invalid financial chart.
+- **Attribution ambiguity:** Bounty allocations are many-to-many and cannot safely substitute for a payout recipient.
+- **Survivorship bias:** Proposal diffs emphasize accepted work; rejected and rework attempts need explicit events.
+- **Circular valuation:** Deriving replacement value from the same payouts used as cost can mechanically pull ROI toward 1.
+- **Graph mirror incompleteness:** Typed Proposal entities are a subset of indexed governance proposals.
+- **Mutable methodology:** Changing artifact weights without versioning rewrites history.
+- **Goodhart pressure:** Public individual efficiency rankings could become compensation proxies even without a direct code path.
+- **Testnet contamination:** Seeded or synthetic records must not be presented as production economics.
+
+## Queries used to validate the live model
+
+The following are abbreviated forms of the read-only queries run against the testnet endpoint.
+
+### Type counts
+
+```graphql
+query {
+  bounties: entitiesConnection(
+    first: 1
+    typeId: "808af0bad5884e3391f09dd4b25e18be"
+  ) {
+    totalCount
+  }
+
+  payouts: entitiesConnection(
+    first: 1
+    typeId: "f5132deb102d64553049f1e9cb662f50"
+  ) {
+    totalCount
+  }
+
+  proposalsConnection(first: 1) {
+    totalCount
+  }
+}
+```
+
+### Payout coverage
+
+```graphql
+query {
+  amounts: valuesConnection(
+    first: 1000
+    filter: {
+      propertyId: { is: "82fe45a31df74c0291afa6e68d41cddf" }
+      entity: { typeIds: { overlaps: ["f5132deb102d64553049f1e9cb662f50"] } }
+    }
+  ) {
+    totalCount
+    nodes {
+      entityId
+      decimal
+      spaceId
+    }
+  }
+
+  bountyLinks: relationsConnection(
+    first: 1
+    filter: {
+      typeId: { is: "1b595a8b81fc25856a9b503e3e993331" }
+      fromEntity: {
+        typeIds: { overlaps: ["f5132deb102d64553049f1e9cb662f50"] }
+      }
+    }
+  ) {
+    totalCount
+  }
+}
+```
+
+### Accepted bounty submissions
+
+```graphql
+query AcceptedBountySubmissions($spaceId: UUID!, $proposalIds: [UUID!]) {
+  proposalsConnection(
+    first: 200
+    filter: {
+      spaceId: { is: $spaceId }
+      id: { in: $proposalIds }
+      executedAt: { isNull: false }
+    }
+  ) {
+    nodes {
+      id
+      proposedBy
+      createdAt
+      executedAt
+    }
+  }
+}
+```
+
+## Final recommendation
+
+Proceed with the pre-launch dashboard as an analytics and instrumentation project. The data is already rich enough to validate the core accretion thesis, especially unit cost, accepted output, absorption, delivery, and exact reuse. Start by fixing recipient/currency/lifecycle data and by materializing proposal diffs. Defer protocol-level issuance, commission, and staker panels until their accounting event sources exist.
+
+Above all, retain the boundary that makes the framework robust: measurement may inform governance and choice, while payment remains a separate human-adjudicated clearing decision.

--- a/docs/research/2026-08-29-accretion-dashboard-data-spec.md
+++ b/docs/research/2026-08-29-accretion-dashboard-data-spec.md
@@ -21,7 +21,7 @@ The Geo graph already contains a strong curator-program spine:
 - Governance proposal authorship, submission time, and execution time.
 - Proposal diffs capable of describing the entities, claims, relations, and structure produced by accepted work.
 
-The graph does **not** yet provide a reliable direct payout recipient, adjudication state history, rejection/rework events, token/currency metadata, funding balances, issuance, stake positions, commissions, appeals, affiliate relationships, or lifecycle declarations. Those gaps block the complete network, space, and staker dashboards, but they do not block a useful pre-launch curator-program dashboard.
+The graph does **not** yet provide a reliable direct payout recipient, adjudication state history, rejection/rework events, funding balances, issuance, stake positions, commissions, appeals, affiliate relationships, or lifecycle declarations. Payout values are currently denominated in protocol points, although that unit is not encoded alongside every historical amount. Those gaps block the complete network, space, and staker dashboards, but they do not block a useful curator-program dashboard at either protocol or individual-space scope.
 
 The recommended first implementation is a read-only analytics surface with six panels:
 
@@ -74,7 +74,7 @@ The public GraphQL endpoint provides the curator-program domain objects and thei
 | Payout to proposal       | Relation                        | `8128964c1ec54829beb380a21ab64c51` | 2,651 links                                          |
 | Payout recipient         | Declared relation property      | `151b0bd3440d435ab093ed5fab73db6c` | 0 links; schema exists but is unused                 |
 
-The payout amount sum in the snapshot is 587,575 across 770 populated records. This is a data-integrity observation only: the graph does not consistently identify currency, token, USD conversion, or whether historical testnet records represent real settlement.
+The payout amount sum in the snapshot is 587,575 points across 770 populated records. This is a data-integrity observation only: the graph does not encode fiat conversion or whether every historical testnet record represents real settlement.
 
 The allocation relation currently provides the best graph-native view of curator participation: 475 allocation links cover 135 unique target identities, 131 bounties, and 32 spaces. Most targets are both Person and Space entities because personal spaces carry both types. A separate type named `Curator` exists, but its description is specific to a Paris content domain and it is not the curator-program identity model. Do not filter program participants by that type.
 
@@ -166,7 +166,7 @@ Space
 4. A proposal is **accepted** for pre-launch analytics when the governance indexer has a non-null `executedAt`. Do not infer acceptance from the bounty's current `Done` status.
 5. A payout may link to multiple proposals. Do not double-count the full payout amount once per proposal.
 6. A bounty may have multiple allocated curators. Until `Payout recipient` is populated, recipient-level and cohort metrics are ambiguous and must be labeled provisional or omitted.
-7. Treat payout amount as nominal until currency/token and USD-normalization fields exist.
+7. Treat payout amounts as protocol points. Do not imply a fiat value unless an explicit settlement-time conversion source is added.
 8. Use proposal diffs to determine output; never use proposal title keywords as the production count.
 
 ## Artifact classification
@@ -230,7 +230,7 @@ clearing_unit_cost(type, trailing_window)
 - Never count the bounty budget as the clearing price when a payout amount exists.
 - Keep records with missing amounts or output classification out of the median and disclose the excluded count.
 
-**MVP status:** Buildable after the output transformer is implemented. Currency normalization remains a limitation.
+**MVP status:** Buildable after the output transformer is implemented. Display all costs explicitly in protocol points.
 
 #### 2. Retroactive ROI
 
@@ -328,19 +328,19 @@ Report `new`, `reused`, `suspected duplicate`, and `unknown` separately. Do not 
 
 ### Space dashboard
 
-| Metric                              | Required source                                    | Current status                                   |
-| ----------------------------------- | -------------------------------------------------- | ------------------------------------------------ |
-| Spend-to-output                     | Payouts + accepted proposal diffs + unit-cost deck | Buildable after output transformer               |
-| Commission per unit stake           | Commission ledger + stake snapshots                | Not available in inspected graph                 |
-| Cleared payout volume by cycle/type | Payout amount, kind, currency, state, cycle        | Amount exists; kind/currency/state/cycle missing |
-| Promised vs available funds         | Obligations + space balance/funding windows        | Not available                                    |
-| Declared vs delivered               | Bounties + proposals + payouts + deadlines         | Partially buildable                              |
-| Editor self-payment ratio           | Recipient + editor/affiliate snapshot              | Recipient unused; affiliate data missing         |
-| Payout concentration                | Explicit recipient + normalized amount             | Blocked by recipient and currency gaps           |
-| Curator churn                       | Explicit recipient + payout timestamp              | Blocked by recipient gap                         |
-| Stop/appeal record                  | Adjudication event ledger                          | Not available                                    |
-| Lifecycle and seasonality           | Space declaration + observed spend                 | Declaration model missing; spend derivable       |
-| Aggregator management fee           | Fee declaration + settlement ledger                | Not available                                    |
+| Metric                              | Required source                                    | Current status                                |
+| ----------------------------------- | -------------------------------------------------- | --------------------------------------------- |
+| Spend-to-output                     | Payouts + accepted proposal diffs + unit-cost deck | Buildable after output transformer            |
+| Commission per unit stake           | Commission ledger + stake snapshots                | Not available in inspected graph              |
+| Cleared payout volume by cycle/type | Payout amount, kind, unit, state, cycle            | Point amount exists; kind/state/cycle missing |
+| Promised vs available funds         | Obligations + space balance/funding windows        | Not available                                 |
+| Declared vs delivered               | Bounties + proposals + payouts + deadlines         | Partially buildable                           |
+| Editor self-payment ratio           | Recipient + editor/affiliate snapshot              | Recipient unused; affiliate data missing      |
+| Payout concentration                | Explicit recipient + point amount                  | Blocked by recipient gap                      |
+| Curator churn                       | Explicit recipient + payout timestamp              | Blocked by recipient gap                      |
+| Stop/appeal record                  | Adjudication event ledger                          | Not available                                 |
+| Lifecycle and seasonality           | Space declaration + observed spend                 | Declaration model missing; spend derivable    |
+| Aggregator management fee           | Fee declaration + settlement ledger                | Not available                                 |
 
 ### Staker dashboard
 
@@ -357,7 +357,7 @@ Report `new`, `reused`, `suspected duplicate`, and `unknown` separately. Do not 
 ### Priority 0: needed for a credible pre-launch release
 
 1. Populate `Payout recipient` on every new payout and backfill historical payouts.
-2. Add `currency_or_token`, raw amount, decimals, and settlement-time USD value.
+2. Encode `unit = points` alongside payout amounts; add a separate settlement-time fiat value only if governance needs one.
 3. Define whether payout entity creation means human-cleared settlement; if not, add an explicit state.
 4. Provide a stable proposal-diff analytics endpoint or batch export. The current per-proposal REST endpoint is suitable for UI review but expensive for a full historical dashboard.
 5. Define artifact types and methodology-versioned output weights.
@@ -438,7 +438,7 @@ Every response should include:
 - `methodology_version`
 - source-row counts
 - missing/unclassified counts
-- currency coverage
+- point-unit coverage
 - whether the result is observed, derived, or modeled
 
 ## Suggested first Linear ticket
@@ -478,7 +478,7 @@ Build a read-only curator-program dashboard using bounty, payout, governance pro
 ## Implementation work breakdown
 
 1. **Data contract and backfill**
-   - Populate payout recipient and currency metadata.
+   - Populate payout recipient and encode the points unit explicitly.
    - Confirm lifecycle semantics and create fixture coverage.
 2. **Historical extractor**
    - Fetch bounty/payout/proposal joins.
@@ -500,7 +500,7 @@ Build a read-only curator-program dashboard using bounty, payout, governance pro
 
 These decisions should be resolved before implementation estimates are final:
 
-1. What currency/token does each historical payout amount represent, and what is the USD conversion policy?
+1. Should protocol points ever receive a displayed fiat conversion, and if so, what timestamp and price source governs it?
 2. Does creating a payout entity guarantee that payment cleared, or is it merely a payout request?
 3. Which event is authoritative for delivery: accepted proposal execution, bounty status `Done`, payout creation, or a new adjudication event?
 4. How should one payout be allocated across multiple proposals and artifact types?
@@ -513,7 +513,7 @@ These decisions should be resolved before implementation estimates are final:
 
 ## Risks
 
-- **Currency ambiguity:** Summing nominal payout amounts can produce a convincing but invalid financial chart.
+- **Unit ambiguity in historical data:** The current mechanism uses points, but old records do not encode that unit directly.
 - **Attribution ambiguity:** Bounty allocations are many-to-many and cannot safely substitute for a payout recipient.
 - **Survivorship bias:** Proposal diffs emphasize accepted work; rejected and rework attempts need explicit events.
 - **Circular valuation:** Deriving replacement value from the same payouts used as cost can mechanically pull ROI toward 1.
@@ -607,6 +607,6 @@ query AcceptedBountySubmissions($spaceId: UUID!, $proposalIds: [UUID!]) {
 
 ## Final recommendation
 
-Proceed with the pre-launch dashboard as an analytics and instrumentation project. The data is already rich enough to validate the core accretion thesis, especially unit cost, accepted output, absorption, delivery, and exact reuse. Start by fixing recipient/currency/lifecycle data and by materializing proposal diffs. Defer protocol-level issuance, commission, and staker panels until their accounting event sources exist.
+Proceed with the dashboard as an analytics and instrumentation project, with a selector between a protocol-wide curator-program rollup and the current space. The data is already rich enough to validate the core accretion thesis, especially point-denominated unit cost, accepted output, absorption, delivery, and exact reuse. Start by fixing recipient/unit/lifecycle data and by materializing proposal diffs. Defer protocol-level issuance, commission, and staker panels until their accounting event sources exist.
 
 Above all, retain the boundary that makes the framework robust: measurement may inform governance and choice, while payment remains a separate human-adjudicated clearing decision.


### PR DESCRIPTION
## Summary

- add a Community → Accretion dashboard with unit-cost, ROI, absorption, curator-cohort, delivery, and duplication panels
- support both a protocol-wide rollup and per-space views through a scope selector; Root opens protocol scope by default
- aggregate live bounty, payout, proposal, profile, and proposal-diff data behind a cached space API route
- label payout amounts and unit costs explicitly in protocol points
- disclose sample limits, incomplete recipient attribution, and other coverage gaps in the UI
- include the graph research and implementation specification used to define the methodology

## Methodology notes

- protocol scope uses global paginated type and relation queries rather than treating Root as the entire protocol
- proposal-diff classification is capped at 24 relevant accepted proposals per request and prioritizes complete payout bundles
- ROI only uses payout bundles whose accepted proposal outputs were fully classified, avoiding partial many-to-many allocation
- curator attribution is labeled inferred when a direct payout recipient is unavailable
- dashboard metrics are advisory inputs for governance, not an automated payment mechanism

## Validation

- `bun run test core/community/accretion-metrics.test.ts partials/community-tab/accretion-dashboard.test.tsx` — 9 tests pass
- focused Prettier and ESLint checks pass for all dashboard files
- live one-year protocol aggregation completed in under nine seconds: 215 bounties, 785 payouts, 3,410 accepted proposals, and 587,575 points
- local page and API route both returned HTTP 200 against live testnet data
- no dashboard TypeScript errors; the repository typecheck retains unrelated pre-existing test errors
- the full web suite completed with 3,391 passing tests and 56 unrelated failures, predominantly from the existing localStorage test-environment issue
- the production build reached Next/Turbopack optimization without surfacing a code error, but did not complete locally after two extended runs