### PR TITLE
feat(debates): put the paused live-updates banner behind the debug flag

### DIFF
--- a/apps/web/core/debates/debate-coordinator.test.tsx
+++ b/apps/web/core/debates/debate-coordinator.test.tsx
@@ -34,6 +34,7 @@ const mocks = vi.hoisted(() => ({
   authenticated: true,
   gatewayPaused: false,
   gatewayPauseReason: null as string | null,
+  debateDebugging: false,
   currentUserId: 'user-for' as string | null,
   // What the token exchange answers with when the stored session hasn't been written yet.
   resolvedUserId: null as string | null,
@@ -118,7 +119,10 @@ vi.mock('./debate-return-navigation', () => ({
   rememberDebateReturnDestination: mocks.rememberDebateReturnDestination,
 }));
 
-vi.mock('~/core/state/feature-flags', () => ({}));
+vi.mock('~/core/state/feature-flags', async importOriginal => ({
+  ...(await importOriginal<typeof import('~/core/state/feature-flags')>()),
+  useFeatureFlag: (id: string) => (id === 'debateDebugging' ? mocks.debateDebugging : false),
+}));
 
 beforeEach(() => {
   sessionStorage.clear();
@@ -145,6 +149,7 @@ beforeEach(() => {
   mocks.authenticated = true;
   mocks.gatewayPaused = false;
   mocks.gatewayPauseReason = null;
+  mocks.debateDebugging = false;
   mocks.currentUserId = 'user-for';
   mocks.resolvedUserId = null;
   mocks.refetch.mockReset();
@@ -180,6 +185,7 @@ afterEach(() => {
 
 describe('DebateCoordinator', () => {
   it('shows a non-blocking warning while live updates are paused and clears it on recovery', () => {
+    mocks.debateDebugging = true;
     mocks.gatewayPaused = true;
     const { rerender } = render(<DebateCoordinator />);
 
@@ -197,6 +203,7 @@ describe('DebateCoordinator', () => {
    * something a reader can act on, and the reason reaches the DOM for the ones that get screenshot.
    */
   it('says what kind of pause it is, rather than always claiming to reconnect', () => {
+    mocks.debateDebugging = true;
     const expected: Array<[string | null, string]> = [
       ['rate_limited', 'Live debate updates are catching up.'],
       ['subscription_limit', 'Too many claims on this page to follow live. Some may be out of date.'],
@@ -219,6 +226,34 @@ describe('DebateCoordinator', () => {
 
       unmount();
     }
+  });
+
+  // Only debuggers see the banner, so the reason has to reach everyone else some other way.
+  it('keeps the paused banner off screen without the debate debugging flag, but still logs the pause', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    mocks.debateDebugging = false;
+    mocks.gatewayPaused = true;
+    mocks.gatewayPauseReason = 'subscription_limit';
+
+    const { rerender } = render(<DebateCoordinator />);
+
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('subscription_limit'));
+
+    // One line per transition. A pause holds for as long as it takes to reconnect, and re-render is
+    // exactly what a paused page does most, so logging per render would bury the line above.
+    rerender(<DebateCoordinator />);
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  it('says nothing about a gateway that was never paused', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const info = vi.spyOn(console, 'info').mockImplementation(() => {});
+
+    render(<DebateCoordinator />);
+
+    expect(warn).not.toHaveBeenCalled();
+    expect(info).not.toHaveBeenCalled();
   });
 
   it('does not route another tab into a shared debate-again browser', async () => {

--- a/apps/web/core/debates/debate-coordinator.tsx
+++ b/apps/web/core/debates/debate-coordinator.tsx
@@ -4,6 +4,8 @@ import * as React from 'react';
 
 import { usePathname, useRouter } from 'next/navigation';
 
+import { useFeatureFlag } from '~/core/state/feature-flags';
+
 import { Button } from '~/design-system/button';
 import { Upload } from '~/design-system/icons/upload';
 import { Spinner } from '~/design-system/spinner';
@@ -70,9 +72,27 @@ function pausedBannerText(reason: DebateGatewayPauseReason | null | undefined) {
   }
 }
 
+/**
+ * Console fallback for the banner, now that only `debateDebugging` sees it. Hiding it must not cost
+ * the diagnosis GEO-2670 put into it, so every viewer still gets the reason — once per transition,
+ * and a recovery is only remembered, not announced.
+ */
+function useDebateGatewayPauseLog(paused: boolean, reason: DebateGatewayPauseReason | null | undefined) {
+  // 'resumed', not null: a mount that was never paused has nothing to report.
+  const lastLoggedRef = React.useRef<string>('resumed');
+
+  React.useEffect(() => {
+    const state = paused ? (reason ?? 'unknown') : 'resumed';
+    if (lastLoggedRef.current === state) return;
+    lastLoggedRef.current = state;
+    if (paused) console.warn(`[debates] live updates paused (${state}): ${pausedBannerText(reason)}`);
+  }, [paused, reason]);
+}
+
 export function DebateCoordinator() {
   const router = useRouter();
   const pathname = usePathname();
+  const debateDebuggingEnabled = useFeatureFlag('debateDebugging');
   const geoChatAuth = useGeoChatAuth();
   // Presence, not attention: being available to debate has to survive looking at another window.
   const debatePresence = useDebatePresence();
@@ -84,6 +104,7 @@ export function DebateCoordinator() {
     geoChatAuth.accountKey,
     debatePresence
   );
+  useDebateGatewayPauseLog(gateway.paused, gateway.pauseReason);
   useClaimResponseIndexedNotifier(
     geoChatAuth.ready && geoChatAuth.authenticated,
     geoChatAuth.getPrivyIdentityToken,
@@ -262,7 +283,7 @@ export function DebateCoordinator() {
 
   return (
     <>
-      {gateway.paused && (
+      {gateway.paused && debateDebuggingEnabled && (
         <div
           role="status"
           aria-live="polite"

--- a/apps/web/core/debates/hooks.test.tsx
+++ b/apps/web/core/debates/hooks.test.tsx
@@ -56,7 +56,12 @@ vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: mocks.push, back: mocks.back }),
 }));
 
-vi.mock('~/core/state/feature-flags', () => ({}));
+// The coordinator reads `debateDebugging` to decide whether to draw the paused banner. Nothing here
+// asserts on it, so it stays off, and the rest of the module is kept rather than blanked.
+vi.mock('~/core/state/feature-flags', async importOriginal => ({
+  ...(await importOriginal<typeof import('~/core/state/feature-flags')>()),
+  useFeatureFlag: () => false,
+}));
 
 vi.mock('@geogenesis/auth', () => ({
   getIdentityToken: mocks.getIdentityToken,

--- a/apps/web/core/state/feature-flags.ts
+++ b/apps/web/core/state/feature-flags.ts
@@ -9,7 +9,7 @@ export const featureFlagDefinitions = [
   {
     id: 'debateDebugging',
     label: 'Debate debugging',
-    description: 'Show manual debugging controls during debate recording.',
+    description: 'Show debate recording debug controls and the paused live-updates banner.',
   },
   {
     id: 'debateFormatSelector',


### PR DESCRIPTION
The banner covers the top of every page for as long as a pause lasts, and five of its six reasons are ours to fix rather than anything a reader can act on, so it now renders only with `debateDebugging` on.

Only the display moves. The gateway still detects, reports and retries every pause exactly as before, and its rate-limit console.error is untouched. Since the banner was the only signal an ordinary viewer left behind, the reason now goes to the console for everyone, once per transition.

hooks.test.tsx renders the coordinator too, so its blanked feature-flags mock needed the new export; both mocks now spread the real module rather than replacing it.