### PR TITLE
feat(onboarding): point the terms link at the current doc and say content is shared onchain

### DIFF
--- a/apps/web/partials/onboarding/dialog.tsx
+++ b/apps/web/partials/onboarding/dialog.tsx
@@ -83,8 +83,7 @@ const ONBOARDING_DESTINATION = NavUtils.toExplore();
 // How long the completion screen shows before we route the user onward. The
 // personal space keeps creating in the background regardless.
 const COMPLETION_ANIMATION_MS = 3000;
-const TERMS_AND_CONDITIONS_URL =
-  'https://docs.google.com/document/d/1clBax9yApV8uI1m36gX9pEf6jrpMEslsqxmqXW2w9I4/edit?tab=t.0';
+const TERMS_AND_CONDITIONS_URL = 'https://docs.google.com/document/d/106bM0qopWGJ8aAausnO7LYtkkDJz__xc/edit';
 
 const ONBOARDING_PERSONAL_SEARCH_TYPES = [SystemIds.SPACE_TYPE, SystemIds.PROJECT_TYPE, SystemIds.PERSON_TYPE];
 
@@ -529,7 +528,9 @@ function StepWelcome({ onProfileContinue }: StepOnboardingProps) {
       <div className="relative">
         <div className="absolute top-0 right-0 left-0 z-100 flex -translate-y-full justify-center pb-4">
           <Text as="p" variant="footnote" className="text-center text-grey-04">
-            All content is public. By signing up, you agree to our{' '}
+            All content is public and shared onchain.
+            <br />
+            By signing up, you agree to our{' '}
             <a
               href={TERMS_AND_CONDITIONS_URL}
               target="_blank"


### PR DESCRIPTION
## What

Two lines in the onboarding profile step (avatar + name).

**Copy.** The disclaimer now reads, on two lines:

> All content is public and shared onchain.
> By signing up, you agree to our Terms & Conditions

**Link.** The Terms & Conditions link pointed at an old Google Doc
(`.../document/d/1clBax9yApV8uI1m36gX9pEf6jrpMEslsqxmqXW2w9I4`). It now points at the current one
(`.../document/d/106bM0qopWGJ8aAausnO7LYtkkDJz__xc`), which holds the Geo Participation and Services
Terms effective 2026-08-25.

## Notes

- The explicit `<br />` splits the disclaimer at the sentence rather than letting it wrap mid-clause.
  It was one line before and is two now; there is ~145px of slack between the name input and the
  Continue button, so it grows into empty space and nothing moves.
- Confirmed the new doc is readable without a Google account, so the link doesn't put a sign-in wall
  in front of someone mid-signup.
- Link still opens in a new tab, so reading the terms doesn't drop the user out of onboarding.

## Verification

- `NEXT_PUBLIC_CHAIN_ID=55516 bun run build` passes.
