### PR TITLE
feat(explore): open an entity in the side panel from its name on a card

### DIFF
--- a/apps/web/partials/explore/debate-explore-feed-card.tsx
+++ b/apps/web/partials/explore/debate-explore-feed-card.tsx
@@ -22,6 +22,7 @@ import { Tooltip } from '~/design-system/tooltip';
 import { EntityCommentsButton } from '~/partials/comments/entity-comments-button';
 import { EntityRowActions } from '~/partials/entity-page/entity-row-actions';
 
+import { ExploreCardEntityLink } from './explore-card-entity-link';
 import { ExploreClaimsIcon } from './explore-claims-icon';
 import { ExploreJoinSpaceButton } from './explore-join-space-button';
 import { ExploreShareIcon } from './explore-share-icon';
@@ -33,6 +34,8 @@ type DebateExploreFeedCardProps = {
   hideSpaceLink?: boolean;
   /** Hide the Join-space chip in the meta row (same semantics as ExploreFeedCard). */
   hideJoinButton?: boolean;
+  /** Whether the claim title opens the side panel rather than navigating (same semantics as ExploreFeedCard). */
+  titleOpensSidePanel?: boolean;
   /**
    * Rendered instead of the debate card when the debate can't be shown as a video — feature flag
    * off, the geo-chat record is missing or unwatchable, or its final video isn't processed yet.
@@ -50,6 +53,7 @@ export function DebateExploreFeedCard({
   item,
   hideSpaceLink = false,
   hideJoinButton = false,
+  titleOpensSidePanel = false,
   fallback,
 }: DebateExploreFeedCardProps) {
   // A Debate entity's id is its geo-chat debate id (see useDebateVotes), modulo hyphenation.
@@ -148,11 +152,11 @@ export function DebateExploreFeedCard({
         </Link>
       </div>
 
-      <Link href={NavUtils.toEntity(item.spaceId, item.entityId)}>
+      <ExploreCardEntityLink item={item} opensSidePanel={titleOpensSidePanel}>
         <h2 className="mt-0! text-[19px]! leading-[23px]! font-semibold! tracking-[-0.02em] text-text hover:underline">
           {item.title}
         </h2>
-      </Link>
+      </ExploreCardEntityLink>
 
       {/* Cap the media at the width the designs (and the full-screen feed) use — feed columns,
           especially data blocks, can be much wider and full-bleed videos dwarf the card. */}

--- a/apps/web/partials/explore/explore-card-entity-link.test.tsx
+++ b/apps/web/partials/explore/explore-card-entity-link.test.tsx
@@ -1,0 +1,105 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup, createEvent, fireEvent, render, screen } from '@testing-library/react';
+
+import type React from 'react';
+
+import { Provider, useAtomValue } from 'jotai';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { NavUtils } from '~/core/utils/utils';
+
+import { ExploreCardEntityLink } from './explore-card-entity-link';
+import { entitySidePanelAtom } from '~/atoms';
+
+// The real one reaches for the sync engine and the router. What matters here is that it forwards
+// `href` and `onClick` to a real anchor, which is the contract this component depends on.
+vi.mock('~/design-system/prefetch-link', () => ({
+  PrefetchLink: ({
+    children,
+    href,
+    className,
+    onClick,
+  }: {
+    children: React.ReactNode;
+    href: string;
+    className?: string;
+    onClick?: (event: React.MouseEvent<HTMLAnchorElement>) => void;
+  }) => (
+    <a href={href} className={className} onClick={onClick}>
+      {children}
+    </a>
+  ),
+}));
+
+const item = { entityId: 'entity-1', spaceId: 'space-1' };
+
+function PanelProbe() {
+  const target = useAtomValue(entitySidePanelAtom);
+  return <div data-testid="panel">{target ? `${target.entityId} in ${target.spaceId}` : 'closed'}</div>;
+}
+
+function renderLink(opensSidePanel: boolean) {
+  return render(
+    <Provider>
+      <ExploreCardEntityLink item={item} opensSidePanel={opensSidePanel}>
+        <h2>A claim</h2>
+      </ExploreCardEntityLink>
+      <PanelProbe />
+    </Provider>
+  );
+}
+
+/** Dispatches a click the same way a browser would, so `defaultPrevented` is observable. */
+function clickName(init?: MouseEventInit) {
+  const anchor = screen.getByRole('link');
+  const event = createEvent.click(anchor, init);
+  fireEvent(anchor, event);
+  return event;
+}
+
+afterEach(cleanup);
+
+describe('ExploreCardEntityLink', () => {
+  it('opens the entity in the side panel instead of navigating', () => {
+    renderLink(true);
+
+    const event = clickName();
+
+    expect(screen.getByTestId('panel')).toHaveTextContent('entity-1 in space-1');
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  // A panel is not a page. GEO-2701 restored these across the app, and swapping the anchor for a
+  // button — or intercepting every click — would take them back out on this surface alone.
+  it.each([
+    ['cmd/ctrl', { metaKey: true }],
+    ['ctrl', { ctrlKey: true }],
+    ['shift', { shiftKey: true }],
+    ['alt', { altKey: true }],
+  ])('leaves a %s click to the browser so it can open a new tab or window', (_label, init) => {
+    renderLink(true);
+
+    const event = clickName(init);
+
+    expect(screen.getByTestId('panel')).toHaveTextContent('closed');
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  // Not decoration: "copy link address", the status-bar preview and middle click all read the
+  // attribute rather than the handler, and the panel's own "Open entity full page" is the only
+  // other route to the page once the card stops navigating.
+  it('keeps a real href to the entity page even while it opens the panel', () => {
+    renderLink(true);
+
+    expect(screen.getByRole('link')).toHaveAttribute('href', NavUtils.toEntity('space-1', 'entity-1'));
+  });
+
+  it('navigates as usual on a surface that has not opted in', () => {
+    renderLink(false);
+
+    const event = clickName();
+
+    expect(screen.getByTestId('panel')).toHaveTextContent('closed');
+    expect(event.defaultPrevented).toBe(false);
+  });
+});

--- a/apps/web/partials/explore/explore-card-entity-link.test.tsx
+++ b/apps/web/partials/explore/explore-card-entity-link.test.tsx
@@ -12,23 +12,19 @@ import { ExploreCardEntityLink } from './explore-card-entity-link';
 import { entitySidePanelAtom } from '~/atoms';
 
 // The real one reaches for the sync engine and the router. What matters here is that it forwards
-// `href` and `onClick` to a real anchor, which is the contract this component depends on.
+// everything to a real anchor, which is the contract this component depends on — `href` and
+// `onClick`, and the opener data attribute, which is a prop like any other.
 vi.mock('~/design-system/prefetch-link', () => ({
   PrefetchLink: ({
     children,
-    href,
-    className,
-    onClick,
+    entityId: _entityId,
+    spaceId: _spaceId,
+    ...rest
   }: {
     children: React.ReactNode;
-    href: string;
-    className?: string;
-    onClick?: (event: React.MouseEvent<HTMLAnchorElement>) => void;
-  }) => (
-    <a href={href} className={className} onClick={onClick}>
-      {children}
-    </a>
-  ),
+    entityId?: string;
+    spaceId?: string;
+  } & React.AnchorHTMLAttributes<HTMLAnchorElement>) => <a {...rest}>{children}</a>,
 }));
 
 const item = { entityId: 'entity-1', spaceId: 'space-1' };
@@ -92,6 +88,23 @@ describe('ExploreCardEntityLink', () => {
     renderLink(true);
 
     expect(screen.getByRole('link')).toHaveAttribute('href', NavUtils.toEntity('space-1', 'entity-1'));
+  });
+
+  // The panel closes on any outside pointerdown that is not marked as an opener, and pointerdown
+  // beats click. Without the marker, clicking a second card tears the panel down and the click
+  // rebuilds it — a close/reopen where the viewer asked to switch targets.
+  it('marks itself as a side-panel opener so an open panel switches instead of closing', () => {
+    renderLink(true);
+
+    expect(screen.getByRole('link')).toHaveAttribute('data-entity-side-panel-opener');
+  });
+
+  // The data block explore view renders this same card inside the editor, which reads the same
+  // attribute. There the name navigates, so claiming to be an opener would be a lie.
+  it('does not claim to be an opener on a surface that has not opted in', () => {
+    renderLink(false);
+
+    expect(screen.getByRole('link')).not.toHaveAttribute('data-entity-side-panel-opener');
   });
 
   it('navigates as usual on a surface that has not opted in', () => {

--- a/apps/web/partials/explore/explore-card-entity-link.tsx
+++ b/apps/web/partials/explore/explore-card-entity-link.tsx
@@ -60,6 +60,16 @@ export function ExploreCardEntityLink({ item, opensSidePanel = false, className,
       spaceId={item.spaceId}
       className={className}
       onClick={onClick}
+      // Exempts this link from the panel's capture-phase outside-pointerdown close
+      // (`entity-side-panel.tsx`). Without it, clicking a second card while the panel is open
+      // tears the panel down on `pointerdown` and the `onClick` below builds it again — a
+      // close/reopen where the viewer asked to switch targets, running close cleanup in between.
+      //
+      // Conditional, and on the opt-in rather than on whether a panel happens to be open: the data
+      // block explore view renders this same card *inside the editor*, which reads the attribute
+      // too (`editor.tsx`) — and there the name navigates, so it is not an opener and must not
+      // claim to be one.
+      {...(opensSidePanel ? { 'data-entity-side-panel-opener': '' } : {})}
     >
       {children}
     </Link>

--- a/apps/web/partials/explore/explore-card-entity-link.tsx
+++ b/apps/web/partials/explore/explore-card-entity-link.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import * as React from 'react';
+
+import type { ExploreFeedItem } from '~/core/explore/fetch-explore-feed';
+import { useEntitySidePanel } from '~/core/hooks/use-entity-side-panel';
+import { isModifiedClick } from '~/core/utils/is-modified-click';
+import { NavUtils } from '~/core/utils/utils';
+
+import { PrefetchLink as Link } from '~/design-system/prefetch-link';
+
+type Props = {
+  item: Pick<ExploreFeedItem, 'entityId' | 'spaceId'>;
+  /**
+   * Whether an unmodified left click opens the side panel instead of navigating (GEO-2757).
+   * Off by default: `ExploreFeedCard` is also the row for a space's activity tab, a topic's
+   * Coverage section, and a data block's explore view, and this only changes Explore.
+   */
+  opensSidePanel?: boolean;
+  className?: string;
+  children: React.ReactNode;
+};
+
+/**
+ * The entity name on an Explore card.
+ *
+ * Deliberately a real anchor with a real `href` even when it opens the panel, and only unmodified
+ * left clicks are intercepted. A panel is not a page: cmd/ctrl-click, shift-click and middle click
+ * have to keep opening the entity page in a new tab or window, which is how people read a graph
+ * (GEO-2701). A button with an `onClick` would look identical and break every one of them, along
+ * with "copy link address" and the status-bar preview.
+ *
+ * Middle click needs no branch here — browsers deliver it as `auxclick`, so this handler never
+ * runs and the anchor's own behavior stands. The check in {@link isModifiedClick} covers it anyway
+ * for the sake of one rule rather than two.
+ *
+ * The panel itself is mounted globally in `app/entry.tsx`, so nothing has to be rendered alongside
+ * the card for this to have somewhere to land.
+ */
+export function ExploreCardEntityLink({ item, opensSidePanel = false, className, children }: Props) {
+  const { openSidePanel } = useEntitySidePanel();
+
+  const onClick = React.useCallback(
+    (event: React.MouseEvent<HTMLAnchorElement>) => {
+      if (!opensSidePanel) return;
+      if (isModifiedClick(event)) return;
+      event.preventDefault();
+      event.stopPropagation();
+      // `openedWithMainViewEditing: false` — Explore has no editor behind it, so the panel has no
+      // main-view edit session to return the viewer to.
+      openSidePanel(item.entityId, item.spaceId, false);
+    },
+    [item.entityId, item.spaceId, opensSidePanel, openSidePanel]
+  );
+
+  return (
+    <Link
+      href={NavUtils.toEntity(item.spaceId, item.entityId)}
+      entityId={item.entityId}
+      spaceId={item.spaceId}
+      className={className}
+      onClick={onClick}
+    >
+      {children}
+    </Link>
+  );
+}

--- a/apps/web/partials/explore/explore-feed-card.test.tsx
+++ b/apps/web/partials/explore/explore-feed-card.test.tsx
@@ -1,3 +1,4 @@
+import '@testing-library/jest-dom/vitest';
 import { cleanup, render, screen } from '@testing-library/react';
 
 import type React from 'react';
@@ -34,12 +35,33 @@ vi.mock('./explore-join-space-button', () => ({
 // The ranking body pulls the sync store; stub it and surface whatever `actions` it is handed so we
 // can assert the card still threads a comment link into rankings.
 vi.mock('./explore-ranking-card-body', () => ({
-  RankingCardBody: ({ actions }: { actions?: React.ReactNode }) => <div data-testid="ranking-body">{actions}</div>,
+  RankingCardBody: ({ actions, titleOpensSidePanel }: { actions?: React.ReactNode; titleOpensSidePanel?: boolean }) => (
+    <div data-testid="ranking-body" data-opens-side-panel={String(titleOpensSidePanel)}>
+      {actions}
+    </div>
+  ),
 }));
 
 vi.mock('./debate-explore-feed-card', () => ({
-  DebateExploreFeedCard: ({ fallback }: { fallback: React.ReactNode }) => (
-    <div data-testid="debate-card">{fallback}</div>
+  DebateExploreFeedCard: ({
+    fallback,
+    titleOpensSidePanel,
+  }: {
+    fallback: React.ReactNode;
+    titleOpensSidePanel?: boolean;
+  }) => (
+    <div data-testid="debate-card" data-opens-side-panel={String(titleOpensSidePanel)}>
+      {fallback}
+    </div>
+  ),
+}));
+
+// The link's own behaviour has its own suite; here we only need to see which flag it was handed.
+vi.mock('./explore-card-entity-link', () => ({
+  ExploreCardEntityLink: ({ children, opensSidePanel }: { children: React.ReactNode; opensSidePanel?: boolean }) => (
+    <a href="#" data-testid="card-title-link" data-opens-side-panel={String(opensSidePanel)}>
+      {children}
+    </a>
   ),
 }));
 
@@ -113,5 +135,41 @@ describe('ExploreFeedCard', () => {
     expect(commentLink?.getAttribute('href')).toContain('#entity-comments');
     expect(rowActions.contains(commentLink)).toBe(true);
     expect(screen.getByTestId('ranking-body').contains(rowActions)).toBe(true);
+  });
+  // GEO-2757. The flag travels page -> EntityFeed -> ExploreFeedCard -> body -> title, and every
+  // rendition draws its own title, so a card type added later is exactly what goes quietly
+  // unwired. One case per rendition, and one for the default (off) that keeps the card's other
+  // homes navigating.
+  describe('titleOpensSidePanel', () => {
+    const COMMUNITY_CALL_TYPE_ID = '0419ca20118b4cdb84dfdb9ed73b50c2';
+    const DEBATE_TYPE_ID = 'fd51f935-2063-4617-be39-7b672b23364c';
+
+    it('reaches the default card title', () => {
+      render(<ExploreFeedCard item={item} titleOpensSidePanel />);
+      expect(screen.getByTestId('card-title-link')).toHaveAttribute('data-opens-side-panel', 'true');
+    });
+
+    it('reaches the community call card title', () => {
+      const call = { ...item, types: [{ id: COMMUNITY_CALL_TYPE_ID, name: 'Community call' }] };
+      render(<ExploreFeedCard item={call} titleOpensSidePanel />);
+      expect(screen.getByTestId('card-title-link')).toHaveAttribute('data-opens-side-panel', 'true');
+    });
+
+    it('reaches the ranking card body', () => {
+      const ranking = { ...item, types: [{ id: RANKING_BLOCK_TYPE_ID, name: 'Ranking block' }] };
+      render(<ExploreFeedCard item={ranking} titleOpensSidePanel />);
+      expect(screen.getByTestId('ranking-body')).toHaveAttribute('data-opens-side-panel', 'true');
+    });
+
+    it('reaches the debate card', () => {
+      const debate = { ...item, types: [{ id: DEBATE_TYPE_ID, name: 'Debate' }] };
+      render(<ExploreFeedCard item={debate} titleOpensSidePanel />);
+      expect(screen.getByTestId('debate-card')).toHaveAttribute('data-opens-side-panel', 'true');
+    });
+
+    it('stays off by default, so the card keeps navigating everywhere else it is used', () => {
+      render(<ExploreFeedCard item={item} />);
+      expect(screen.getByTestId('card-title-link')).toHaveAttribute('data-opens-side-panel', 'false');
+    });
   });
 });

--- a/apps/web/partials/explore/explore-feed-card.tsx
+++ b/apps/web/partials/explore/explore-feed-card.tsx
@@ -17,6 +17,7 @@ import { PublishedRecordingPlayer } from '~/partials/community-calls/published-r
 import { EntityRowActions } from '~/partials/entity-page/entity-row-actions';
 
 import { DebateExploreFeedCard } from './debate-explore-feed-card';
+import { ExploreCardEntityLink } from './explore-card-entity-link';
 import { ExploreCommentsIcon } from './explore-comments-icon';
 import { ExploreJoinSpaceButton } from './explore-join-space-button';
 import { RankingCardBody } from './explore-ranking-card-body';
@@ -27,6 +28,11 @@ type ExploreFeedCardProps = {
   hideSpaceLink?: boolean;
   /** Hide the Join button next to the space name. */
   hideJoinButton?: boolean;
+  /**
+   * Whether clicking the entity name opens it in the side panel rather than navigating (GEO-2757).
+   * Explore turns this on; the other surfaces this card serves keep navigating.
+   */
+  titleOpensSidePanel?: boolean;
 };
 
 function SpaceThumb({ image, name }: { image: string | null; name: string }) {
@@ -63,13 +69,13 @@ const COMMUNITY_CALL_EVENT_TYPE = normalizeId(EVENT_SCHEMA.COMMUNITY_CALL_EVENT_
 const DEBATE_TYPE = normalizeId(DEBATE_TYPE_ID);
 const RANKING_BLOCK_TYPE = normalizeId(RANKING_BLOCK_TYPE_ID);
 
-function CardTitle({ item }: { item: ExploreFeedItem }) {
+function CardTitle({ item, opensSidePanel }: { item: ExploreFeedItem; opensSidePanel: boolean }) {
   return (
-    <Link href={NavUtils.toEntity(item.spaceId, item.entityId)}>
+    <ExploreCardEntityLink item={item} opensSidePanel={opensSidePanel}>
       <h2 className="mt-0! text-[19px]! leading-[23px]! font-semibold! tracking-[-0.02em] text-text hover:underline">
         {item.title}
       </h2>
-    </Link>
+    </ExploreCardEntityLink>
   );
 }
 
@@ -77,10 +83,12 @@ type CardBodyProps = {
   item: ExploreFeedItem;
   /** The vote / comment row, owned by the shell so bodies render it identically. Not every body takes it. */
   actions: React.ReactNode;
+  /** Threaded to the title only. The thumbnail beside it still navigates — see `BaseExploreFeedCard`. */
+  titleOpensSidePanel: boolean;
 };
 
 /** The default body: thumbnail on the left, title and description beside it. */
-function DefaultCardBody({ item, actions }: CardBodyProps) {
+function DefaultCardBody({ item, actions, titleOpensSidePanel }: CardBodyProps) {
   return (
     <div className="flex items-start gap-4">
       {item.imageUrl ? (
@@ -93,7 +101,7 @@ function DefaultCardBody({ item, actions }: CardBodyProps) {
       ) : null}
       <div className="flex min-w-0 flex-1 flex-col gap-2">
         <div className="min-w-0">
-          <CardTitle item={item} />
+          <CardTitle item={item} opensSidePanel={titleOpensSidePanel} />
           {item.description ? (
             <p className="mt-1 line-clamp-2 text-[16px]! leading-[20px]! font-normal! tracking-[-0.03em] text-grey-04">
               {item.description}
@@ -108,7 +116,7 @@ function DefaultCardBody({ item, actions }: CardBodyProps) {
 }
 
 /** A Community call event's body */
-function CommunityCallCardBody({ item, actions }: CardBodyProps) {
+function CommunityCallCardBody({ item, actions, titleOpensSidePanel }: CardBodyProps) {
   const sources = useRecordingSources({
     entityId: item.entityId,
     spaceId: item.spaceId,
@@ -117,7 +125,7 @@ function CommunityCallCardBody({ item, actions }: CardBodyProps) {
 
   return (
     <div className="flex min-w-0 flex-col gap-3">
-      <CardTitle item={item} />
+      <CardTitle item={item} opensSidePanel={titleOpensSidePanel} />
       {sources.length > 0 ? (
         <div className="w-full max-w-[773px]">
           <PublishedRecordingPlayer
@@ -147,6 +155,7 @@ export function ExploreFeedCard(props: ExploreFeedCardProps) {
         item={props.item}
         hideSpaceLink={props.hideSpaceLink}
         hideJoinButton={props.hideJoinButton}
+        titleOpensSidePanel={props.titleOpensSidePanel}
         fallback={<BaseExploreFeedCard {...props} />}
       />
     );
@@ -154,7 +163,12 @@ export function ExploreFeedCard(props: ExploreFeedCardProps) {
   return <BaseExploreFeedCard {...props} />;
 }
 
-function BaseExploreFeedCard({ item, hideSpaceLink = false, hideJoinButton = false }: ExploreFeedCardProps) {
+function BaseExploreFeedCard({
+  item,
+  hideSpaceLink = false,
+  hideJoinButton = false,
+  titleOpensSidePanel = false,
+}: ExploreFeedCardProps) {
   const isCommunityCall = item.types.some(type => normalizeId(type.id) === COMMUNITY_CALL_EVENT_TYPE);
   const isRanking = item.types.some(type => normalizeId(type.id) === RANKING_BLOCK_TYPE);
   const uniqueTypes = React.useMemo(() => {
@@ -244,11 +258,11 @@ function BaseExploreFeedCard({ item, hideSpaceLink = false, hideJoinButton = fal
       ) : null}
 
       {isCommunityCall ? (
-        <CommunityCallCardBody item={item} actions={cardActions} />
+        <CommunityCallCardBody item={item} actions={cardActions} titleOpensSidePanel={titleOpensSidePanel} />
       ) : isRanking ? (
-        <RankingCardBody item={item} actions={cardActions} />
+        <RankingCardBody item={item} actions={cardActions} titleOpensSidePanel={titleOpensSidePanel} />
       ) : (
-        <DefaultCardBody item={item} actions={cardActions} />
+        <DefaultCardBody item={item} actions={cardActions} titleOpensSidePanel={titleOpensSidePanel} />
       )}
     </article>
   );

--- a/apps/web/partials/explore/explore-page.tsx
+++ b/apps/web/partials/explore/explore-page.tsx
@@ -51,6 +51,7 @@ export function ExplorePage({
           showSortFilter
           showTypeFilter
           dividerBeforeFeed
+          titleOpensSidePanel
           feedTopSpacingClassName=""
         />
       </main>

--- a/apps/web/partials/explore/explore-ranking-card-body.tsx
+++ b/apps/web/partials/explore/explore-ranking-card-body.tsx
@@ -32,6 +32,8 @@ import { RankingBlockGlobalPagination } from '~/partials/blocks/table/ranking-bl
 import { RankingAggregatedSubmitterAvatars } from '~/partials/blocks/table/ranking-period-metadata';
 import { EntityVoteButtons } from '~/partials/entity-page/entity-vote-buttons';
 
+import { ExploreCardEntityLink } from './explore-card-entity-link';
+
 const EXPLORE_RANKING_PAGE_SIZE = 4;
 const ROW_IMAGE_SIZE = 32;
 
@@ -177,7 +179,15 @@ export function RankingRow({
 }
 
 /** Ranking Block body: ordered leaderboard rows; images only when the entry has avatar/cover. */
-export function RankingCardBody({ item, actions }: { item: ExploreFeedItem; actions?: React.ReactNode }) {
+export function RankingCardBody({
+  item,
+  actions,
+  titleOpensSidePanel = false,
+}: {
+  item: ExploreFeedItem;
+  actions?: React.ReactNode;
+  titleOpensSidePanel?: boolean;
+}) {
   const [pageNumber, setPageNumber] = React.useState(0);
   const { globalRankingEntityIds, aggregatedSubmitterSpaceIds, aggregatedRankingCount, isBlockLoading } =
     useExploreRankingBlockData(item.entityId, item.spaceId);
@@ -203,11 +213,11 @@ export function RankingCardBody({ item, actions }: { item: ExploreFeedItem; acti
   return (
     <div className="flex min-w-0 flex-col gap-3">
       <div className="flex min-w-0 items-center gap-3">
-        <Link href={NavUtils.toEntity(item.spaceId, item.entityId)} className="min-w-0 flex-1">
+        <ExploreCardEntityLink item={item} opensSidePanel={titleOpensSidePanel} className="min-w-0 flex-1">
           <h2 className="mt-0! truncate text-[19px]! leading-[21px]! font-medium! text-[#2A2B2E] hover:underline">
             {item.title}
           </h2>
-        </Link>
+        </ExploreCardEntityLink>
         <RankingVoteButton item={item} />
       </div>
 

--- a/apps/web/partials/feed/entity-feed.test.tsx
+++ b/apps/web/partials/feed/entity-feed.test.tsx
@@ -12,6 +12,10 @@ import { EntityFeed } from './entity-feed';
 const mocks = vi.hoisted(() => ({
   queryOptions: null as Record<string, unknown> | null,
   fetch: vi.fn(),
+  /** Pages the mocked infinite query hands back, so a test can put a card on the page. */
+  pages: null as { items: Record<string, unknown>[] }[] | null,
+  /** Props the last rendered card received. */
+  cardProps: null as Record<string, unknown> | null,
 }));
 
 function createLocalStorage(): Storage {
@@ -33,7 +37,7 @@ vi.mock('@tanstack/react-query', () => ({
   useInfiniteQuery: (options: Record<string, unknown>) => {
     mocks.queryOptions = options;
     return {
-      data: undefined,
+      data: mocks.pages ? { pages: mocks.pages } : undefined,
       isLoading: false,
       isFetchingNextPage: false,
       fetchNextPage: vi.fn(),
@@ -62,12 +66,17 @@ vi.mock('~/design-system/menu', () => ({
 }));
 
 vi.mock('~/partials/explore/explore-feed-card', () => ({
-  ExploreFeedCard: () => null,
+  ExploreFeedCard: (props: Record<string, unknown>) => {
+    mocks.cardProps = props;
+    return null;
+  },
 }));
 
 beforeEach(() => {
   vi.stubGlobal('localStorage', createLocalStorage());
   mocks.queryOptions = null;
+  mocks.pages = null;
+  mocks.cardProps = null;
   mocks.fetch.mockReset();
   mocks.fetch.mockResolvedValue({ ok: true, json: async () => ({ items: [], nextCursor: null }) });
   vi.stubGlobal('fetch', mocks.fetch);
@@ -288,5 +297,40 @@ describe('EntityFeed Explore type filter', () => {
     // The time slot is empty rather than 'week': this feed sorts by New, which carries no range,
     // so there is nothing to send and nothing to key on. Same positions otherwise.
     expect(mocks.queryOptions?.queryKey).toEqual(['/api/activity/feed', 'new', undefined, 'space-id', null]);
+  });
+  // GEO-2757. Explore opts its cards into opening the side panel; the space activity tab, which
+  // renders this same feed, does not. The flag is a single forward, so nothing but a test says it
+  // is still being made.
+  describe('titleOpensSidePanel', () => {
+    const item = {
+      entityId: 'entity-1',
+      spaceId: 'space-1',
+      spaceName: 'Space',
+      spaceImage: null,
+      types: [],
+      createdAtSec: 0,
+      title: 'An entity',
+      description: null,
+      imageUrl: null,
+      commentCount: 0,
+      recordingUrls: [],
+      debateVideoUrls: [],
+      isMemberOrEditor: true,
+      hasPendingMembershipRequest: false,
+    };
+
+    it('hands the flag to every card when the feed is opted in', () => {
+      mocks.pages = [{ items: [item] }];
+      render(<EntityFeed apiEndpoint="/api/explore/feed" titleOpensSidePanel />);
+
+      expect(mocks.cardProps?.titleOpensSidePanel).toBe(true);
+    });
+
+    it('leaves cards navigating when it is not', () => {
+      mocks.pages = [{ items: [item] }];
+      render(<EntityFeed apiEndpoint="/api/activity/feed" lockedSpaceId="space-1" />);
+
+      expect(mocks.cardProps?.titleOpensSidePanel).toBe(false);
+    });
   });
 });

--- a/apps/web/partials/feed/entity-feed.tsx
+++ b/apps/web/partials/feed/entity-feed.tsx
@@ -82,6 +82,12 @@ type EntityFeedProps = {
   feedTopSpacingClassName?: string;
   /** When true, renders a divider line between the filter row and the first feed card. */
   dividerBeforeFeed?: boolean;
+  /**
+   * Whether a card's entity name opens the side panel instead of navigating (GEO-2757). Explore
+   * turns this on. Off for the space activity tab, which is a feed inside a space rather than the
+   * cross-space browsing surface the panel was asked for.
+   */
+  titleOpensSidePanel?: boolean;
 };
 
 async function fetchFeedPage(
@@ -125,6 +131,7 @@ export function EntityFeed({
   showTypeFilter = false,
   feedTopSpacingClassName,
   dividerBeforeFeed = false,
+  titleOpensSidePanel = false,
 }: EntityFeedProps) {
   const [time, setTime] = React.useState<ExploreTime>(initialTime);
   const [sort, setSort] = React.useState<ExploreSort>(initialSort);
@@ -379,6 +386,7 @@ export function EntityFeed({
               item={item}
               hideSpaceLink={lockedSpaceId != null}
               hideJoinButton={lockedSpaceId != null}
+              titleOpensSidePanel={titleOpensSidePanel}
             />
           ))
         )}


### PR DESCRIPTION
[GEO-2757](https://linear.app/geobrowser/issue/GEO-2757/explore-clicking-an-entity-name-on-a-card-should-open-the-side-panel)

Clicking an entity name on Explore now opens it in the side panel beside the feed instead of navigating. Browsing Explore is a scanning activity, and every look at an entity used to cost a full navigation and a trip back.

## Card types covered

Four renditions draw their own title, so each is wired separately and each is tested:

| Card | Where the title lives |
|---|---|
| Default | `CardTitle` in `explore-feed-card.tsx` |
| Community call | `CardTitle` (same component) |
| Ranking | `RankingCardBody` — its own title, different type scale |
| Debate | `DebateExploreFeedCard` — its own copy of the title markup |

**Not merged yet, and it will need the same treatment:** `ClaimExploreFeedCard`, on your `preston/geo-2730-unify-claim-card` branch, is a fifth rendition with its own title. It branches before the bodies below, so it will render with the old behavior and no test will complain. Whichever of these two lands second should pick it up.

## Modifier clicks

Kept as a real anchor with a real `href`; only unmodified left clicks are intercepted. Per the ticket's note about [GEO-2701](https://linear.app/geobrowser/issue/GEO-2701/standard-modifier-click-and-keyboard-link-behaviors-dont-work-open-in), a panel is not a page — cmd/ctrl-click, shift-click and middle click keep opening the entity page in a new tab or window. `isModifiedClick` (which GEO-2701 added) is the guard.

A button with an `onClick` would have looked identical and broken every one of them, plus "copy link address" and the status-bar preview.

## The two open questions in the ticket

**What the rest of the card does.** Only the name changes. The thumbnail beside it, the space chip and the comment count still navigate. They point at different things, and the panel is for the entity the name names — so the two targets doing two things is the deliberate answer rather than the omitted one. Easy to widen if you'd rather the whole card opened the panel.

**Reaching the full entity page.** Already there — the panel header has an **Open** button (`aria-label="Open entity full page"`, `entity-side-panel.tsx:170`) pointing at `NavUtils.toEntity`. Nothing becomes unreachable.

## Scope: an opt-in prop, not a change to the card

`ExploreFeedCard` is also the row for a space's activity tab, a topic's Coverage section, a data block's explore view, and the ranking explore view. Changing the card itself would have changed all five surfaces; the ticket asks for Explore.

So the behavior is off by default and Explore turns it on — `titleOpensSidePanel` travels `ExplorePage` → `EntityFeed` → `ExploreFeedCard` → body → title. If you want it everywhere, it's one line on each caller (or delete the prop and default it on).

## Testing

`explore-card-entity-link.test.tsx` (new, 7 cases) covers the click behavior: opens the panel and prevents default; leaves cmd/ctrl/shift/alt clicks alone; keeps the real `href`; does nothing on a surface that hasn't opted in.

The wiring is tested separately, at both hops — `EntityFeed` → card, and card → each of the four renditions. That path is the part that goes quietly wrong: a title is easy to add and easy to forget to wire, and TypeScript is happy either way since the prop is optional.

Each guard was verified by reverting it and watching the right tests fail:

- drop the `isModifiedClick` check → the 4 modifier cases fail
- drop the opt-in check → the "not opted in" case fails
- drop the prop from the card's bodies → all 5 wiring cases fail
- drop the forward in `EntityFeed` → both feed cases fail

`vitest run partials/explore partials/feed partials/blocks/table core/topics`: 173 passed. `tsc --noEmit`: 5 errors, all pre-existing on master in unrelated test files (same count before and after — GEO-2699 territory). eslint and prettier clean.

## Worth a look

Not verified in a browser — this is the kind of change where the feel of it matters, so worth a click on the preview across the four card types before it comes out of draft.