### PR TITLE
feat(debates): add a Related tab and land the pair there after a debate (GEO-2758)

### DIFF
--- a/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
@@ -14,6 +14,7 @@ import { DebateRoomPageClient, isDebateInThankYouPeriod, upcomingTurnLabel } fro
 
 const mocks = vi.hoisted(() => ({
   prefetchAllowlist: vi.fn(),
+  warmRelatedClaims: vi.fn(),
   back: vi.fn(),
   push: vi.fn(),
   replace: vi.fn(),
@@ -270,10 +271,21 @@ vi.mock('~/core/debates/use-prefetch-claim-space-allowlist', () => ({
   usePrefetchClaimSpaceAllowlist: (enabled: boolean) => mocks.prefetchAllowlist(enabled),
 }));
 
+// The same arrangement, for the same reason: the room warms this one too and reads nothing back, so
+// the only question here is whether it asks — with the claim being argued, and only once the debate
+// is actually under way. Its real implementation wants a sync engine this suite does not stand up.
+vi.mock('~/core/debates/use-related-debate-claims', () => ({
+  useRelatedDebateClaims: (options: unknown) => {
+    mocks.warmRelatedClaims(options);
+    return { claimIds: [], spaceId: null, enabled: false, isLoading: false, error: null };
+  },
+}));
+
 beforeEach(() => {
   mocks.publishOptOutOffer = { debateId: null, busy: false, cancelled: false };
   mocks.setPublishOptOutRequest.mockReset();
   mocks.prefetchAllowlist.mockReset();
+  mocks.warmRelatedClaims.mockReset();
   clearDebateReturnDestination();
   setHistoryLength(1);
   mocks.back.mockReset();
@@ -498,6 +510,37 @@ describe('DebateRoomPageClient', () => {
     render(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
 
     expect(mocks.prefetchAllowlist).toHaveBeenCalledWith(true);
+  });
+
+  // GEO-2758. The picker that opens when this debate ends offers the claims related to the one
+  // being argued, and finding them is three serial requests. Asked from here, they are answered
+  // long before anyone is waiting on them.
+  it("warms the claims related to the one being argued, once the debate is under way", () => {
+    render(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
+
+    expect(mocks.warmRelatedClaims).toHaveBeenCalledWith(
+      expect.objectContaining({ claim: expect.objectContaining({ claim_entity_id: 'claim-entity-1' }), enabled: true })
+    );
+  });
+
+  // A preflight that times out, or a room nobody joins, is a debate that never happens — and a
+  // warm cache for one is a request spent on nothing.
+  it('does not warm them before the debate has started', () => {
+    const now = Date.parse('2026-07-02T00:00:05.000Z');
+    vi.spyOn(Date, 'now').mockReturnValue(now);
+    mocks.debate = {
+      ...completedDebate(),
+      status: 'preflight',
+      current_turn_index: 0,
+      current_speaker_slot: null,
+      preflight_ends_at: new Date(now + 5_000).toISOString(),
+      completed_at: null,
+    };
+
+    render(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
+
+    expect(mocks.warmRelatedClaims).toHaveBeenCalled();
+    expect(mocks.warmRelatedClaims).not.toHaveBeenCalledWith(expect.objectContaining({ enabled: true }));
   });
 
   it('returns through browser history without rendering an already-completed room', async () => {

--- a/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.tsx
@@ -72,6 +72,7 @@ import {
   useSetThankingDebate,
 } from '~/core/debates/thanking-debate-store';
 import { usePrefetchClaimSpaceAllowlist } from '~/core/debates/use-prefetch-claim-space-allowlist';
+import { useRelatedDebateClaims } from '~/core/debates/use-related-debate-claims';
 import { useScrollLock } from '~/core/debates/use-scroll-lock';
 import { ExtendedReconnectPolicy } from '~/core/livekit/extended-reconnect-policy';
 import { useFeatureFlag } from '~/core/state/feature-flags';
@@ -392,6 +393,22 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
     Boolean(debate?.rematch_session_id) && debate?.status !== 'cancelled'
   );
   const leaveRematch = useLeaveDebateRematch(debate?.rematch_session_id ?? '');
+
+  /**
+   * GEO-2758. Asked here and thrown away: when this debate ends, the pair are offered another, and
+   * the picker's Related tab is the claims sharing a topic with the one being argued right now.
+   * Finding them is three serial requests, which is a second of the picker settling after it has
+   * already drawn — so it is spent here instead, where there is a debate in front of the viewer and
+   * nothing waiting on the answer. `useRelatedDebateClaims` warms the keys the picker reads.
+   *
+   * Only once the debate is actually under way. Before that it may never happen — a preflight that
+   * times out, a room nobody joins — and a warm cache for a debate that did not take place is a
+   * request spent on nothing.
+   */
+  useRelatedDebateClaims({
+    claim: debate?.claim,
+    enabled: debate?.status === 'in_progress' || debate?.status === 'thanking' || debate?.status === 'complete',
+  });
   const countdown = useDebateCountdown(countdownDebate, serverClock.now);
   debateStatusRef.current = countdown.effectiveStatus;
   const currentUserId = getCurrentGeoChatUserId();
@@ -2195,9 +2212,7 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
             onVideoInputChange={changeVideoInput}
             onRetryMedia={() => void ensureLocalPreview({ forceRestart: true }).catch(() => undefined)}
             devicesLocked={
-              Boolean(preScreenLocalParticipant?.ready_at) ||
-              roomState === 'connecting' ||
-              roomState === 'reconnecting'
+              Boolean(preScreenLocalParticipant?.ready_at) || roomState === 'connecting' || roomState === 'reconnecting'
             }
             connectionSettling={roomState === 'connecting' || roomState === 'reconnecting'}
             canRetryConnection={roomState === 'idle' && roomError !== null && !connectionConflict}

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
@@ -50,6 +50,7 @@ const mocks = vi.hoisted(() => ({
   relatedWheres: [] as unknown[],
   relatedFirsts: [] as Array<number | undefined>,
   relatedAfters: [] as Array<string | undefined>,
+  excludedClaimIds: [CLAIM_SOURCE] as string[],
   relatedDefers: [] as Array<boolean | undefined>,
   relatedPrefetches: [] as Array<boolean | undefined>,
   entityHydrations: [] as Array<{ id: string; spaceId?: string }>,
@@ -305,7 +306,7 @@ function rematchClaimsLookup(claimIds: string[]) {
     return { data: { claims: [], excluded_claim_ids: [] }, isLoading: true, error: null };
   }
   return {
-    data: { claims: mocks.claims, excluded_claim_ids: [CLAIM_SOURCE] },
+    data: { claims: mocks.claims, excluded_claim_ids: mocks.excludedClaimIds },
     isLoading: false,
     error: null,
   };
@@ -797,6 +798,7 @@ beforeEach(() => {
   mocks.relatedWheres.length = 0;
   mocks.relatedFirsts.length = 0;
   mocks.relatedAfters.length = 0;
+  mocks.excludedClaimIds = [CLAIM_SOURCE];
   mocks.relatedDefers.length = 0;
   mocks.relatedPrefetches.length = 0;
   mocks.entityHydrations.length = 0;
@@ -4078,7 +4080,7 @@ describe('the Related tab', () => {
   const RELATED = '019fedb9-7db8-7a05-9b88-9de4cf60bb75';
   const GOV_TOPIC = { id: 'topic-gov', name: 'Governance' };
 
-  function topicEntity(id: string, name: string) {
+  function topicEntity(id: string, name: string, topic = GOV_TOPIC) {
     return {
       id,
       name,
@@ -4086,10 +4088,13 @@ describe('the Related tab', () => {
       spaces: [SPACE_1],
       values: [{ property: { id: NAME_PROPERTY }, spaceId: SPACE_1, value: name }],
       relations: [
-        { type: { id: TOPICS_PROPERTY_ID }, spaceId: SPACE_1.replace(/-/g, ''), toEntity: GOV_TOPIC, isDeleted: false },
+        { type: { id: TOPICS_PROPERTY_ID }, spaceId: SPACE_1.replace(/-/g, ''), toEntity: topic, isDeleted: false },
       ],
     };
   }
+
+  /** The graph's spelling of an id geo-chat writes with hyphens. */
+  const bareHex = (id: string) => id.replace(/-/g, '');
 
   /** The claim the pair just argued, carrying the topic its neighbours are found by. */
   const sourceClaimEntity = () => topicEntity(CLAIM_SOURCE, 'The claim just debated');
@@ -4221,6 +4226,121 @@ describe('the Related tab', () => {
     }
   });
 
+  // The session is the head of the chain, and until it lands there is no `source_debate_id` to
+  // disable discovery *with* — so an idle chain there says nothing, and reading it as "no
+  // neighbours" drew the strip without Related and then moved the pair when the session arrived.
+  it('holds the slot while the session itself is still loading', async () => {
+    debateWithRelated();
+    mocks.session = null;
+    mocks.sessionLoading = true;
+
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+
+    expect(await screen.findByRole('button', { name: 'Related' })).toBeInTheDocument();
+  });
+
+  /**
+   * The allowlist fails open — a null set reads as "don't filter" — so while it is in flight the
+   * query runs for a space the response may go on to exclude. Treating that as a settled answer
+   * offered the tab and then took it away, which is the one thing the reservation exists to avoid.
+   */
+  it('holds the slot while the publishable-space allowlist is still resolving', async () => {
+    debateWithRelated();
+    mocks.relatedEntities = [];
+    mocks.publishableSpacesLoading = true;
+
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+
+    expect(await screen.findByRole('button', { name: 'Related' })).toBeInTheDocument();
+  });
+
+  /**
+   * A tab can be picked while its slot is only reserved, and the count can then land empty. The
+   * button goes, and a choice that outlived it left the viewer on a tab that was neither visible
+   * nor reachable, showing nothing.
+   */
+  it('discards a chosen Related tab once it stops being offered', async () => {
+    debateWithRelated();
+    mocks.relatedEntitiesLoading = true;
+    const { rerender } = render(<DebateRematchPageClient sessionId="rematch-1" />);
+
+    // Picked while reserved, which is the only window in which this can happen.
+    fireEvent.click(await screen.findByRole('button', { name: 'Related' }));
+
+    // And the count lands empty: only the debated claim came back.
+    mocks.relatedEntitiesLoading = false;
+    mocks.relatedEntities = [sourceClaimEntity()];
+    rerender(<DebateRematchPageClient sessionId="rematch-1" />);
+    await settleTabSwap();
+
+    expect(screen.queryByRole('button', { name: 'Related' })).toBeNull();
+    expect(screen.getByRole('button', { name: /positions/ })).toHaveAttribute('aria-selected', 'true');
+  });
+
+  /**
+   * `rowFromEntity` treats the space it is handed as a preference and falls back to the claim's own
+   * ranking when a debate could not be published there. For every other source that fallback is a
+   * reasonable second answer; here it is a wrong one — the topic and the Debate tag were satisfied
+   * in the debated claim's space and nothing was asked about any other, so a row drawn elsewhere
+   * rests on relations that may not exist there.
+   */
+  it('drops a neighbour that would be drawn in a space the clause never asked about', async () => {
+    const elsewhere = {
+      ...relatedEntity(),
+      // Named in both — `claimHomeSpaceId` ranks the spaces a claim is *named* in, so a second
+      // space it is merely listed under is not a home it can fall back to — and only the second can
+      // carry a published debate.
+      spaces: [SPACE_1, SPACE_2],
+      values: [
+        { property: { id: NAME_PROPERTY }, spaceId: SPACE_1, value: 'A claim on the same topic' },
+        { property: { id: NAME_PROPERTY }, spaceId: SPACE_2, value: 'A claim on the same topic' },
+      ],
+    };
+    mocks.entities = [sharedEntity(), sourceClaimEntity(), elsewhere];
+    mocks.relatedEntities = [sourceClaimEntity(), elsewhere];
+    // A personal space cannot carry a published debate, so the preference is refused and the row
+    // would otherwise be drawn under SPACE_2.
+    mocks.spaceTypes = { [SPACE_1]: 'PERSONAL' };
+
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+    await settleTabSwap();
+
+    expect(screen.queryByText('A claim on the same topic')).toBeNull();
+  });
+
+  /**
+   * geo-chat spells a claim id as a hyphenated UUID and the graph as bare hex, and every list on
+   * this page joins the two. The fixtures above use one spelling for both sides — as master's do —
+   * so they cannot see that join fail; these two use the spellings production uses.
+   *
+   * Not a Related-specific hazard. The page keys its session rows, exclusions, rejected ids and
+   * topics on geo-chat's spelling and reads all four back with a graph entity id, so this is the
+   * whole page's join and these two tests stand for it.
+   */
+  it('flags a Related row geo-chat rejected under the other spelling of its id', async () => {
+    mocks.entities = [sharedEntity(), sourceClaimEntity(), relatedEntity(bareHex(RELATED))];
+    mocks.relatedEntities = [sourceClaimEntity(), relatedEntity(bareHex(RELATED))];
+    // geo-chat's own spelling, as the session carries it.
+    mocks.session = session({ recently_rejected_claim_ids: [RELATED] });
+
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+    await screen.findByRole('button', { name: 'Related' });
+
+    expect(await screen.findByText('A claim on the same topic')).toBeInTheDocument();
+    expect(screen.getByText('Recently rejected')).toBeInTheDocument();
+  });
+
+  it('drops a Related row geo-chat excluded under the other spelling of its id', async () => {
+    mocks.entities = [sharedEntity(), sourceClaimEntity(), relatedEntity(bareHex(RELATED))];
+    mocks.relatedEntities = [sourceClaimEntity(), relatedEntity(bareHex(RELATED))];
+    mocks.excludedClaimIds = [CLAIM_SOURCE, RELATED];
+
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+    await settleTabSwap();
+
+    expect(screen.queryByText('A claim on the same topic')).toBeNull();
+  });
+
   /**
    * A whole window can come back undrawable — the debated claim is in it, and so is every neighbour
    * whose name has not indexed — and the count of what is left decides whether the tab exists. So
@@ -4245,6 +4365,41 @@ describe('the Related tab', () => {
     expect(await screen.findByText('A claim on the same topic')).toBeInTheDocument();
     // Anchored on the first window's end rather than restarting it, so the walk is a step forward.
     expect(mocks.relatedAfters.filter(Boolean)).toContain('33');
+  });
+
+  /**
+   * The topics are part of the question, not just the claim. They arrive from hydration, so a first
+   * window can be walked against a cached topic set and a later one replaces it — and a cursor from
+   * the old result set anchors nothing in the new one. Kept, it starts the new query midway through
+   * a result set it never saw the front of, silently skipping its first window.
+   */
+  it('walks from the start again when the claim’s topics arrive', async () => {
+    const undrawable = Array.from({ length: 34 }, (_, index) => ({
+      ...topicEntity(`019fedb9-7db8-7a05-9b88-9de4cf60bc${index.toString().padStart(2, '0')}`, 'unindexed'),
+      name: null,
+    }));
+    mocks.entities = [sharedEntity(), sourceClaimEntity()];
+    mocks.relatedEntities = undrawable;
+
+    const { rerender } = render(<DebateRematchPageClient sessionId="rematch-1" />);
+    await settleTabSwap();
+    expect(mocks.relatedAfters.filter(Boolean)).toContain('33');
+
+    // Hydration lands a different topic set for the same claim, so the query is a new question.
+    const OTHER_TOPIC = { id: 'topic-eth', name: 'Ethics' };
+    mocks.entities = [
+      sharedEntity(),
+      topicEntity(CLAIM_SOURCE, 'The claim just debated', OTHER_TOPIC),
+      relatedEntity(),
+    ];
+    mocks.relatedEntities = [relatedEntity()];
+    mocks.relatedAfters.length = 0;
+    rerender(<DebateRematchPageClient sessionId="rematch-1" />);
+    await settleTabSwap();
+
+    // Every window asked for since the topics changed starts at the front.
+    expect(mocks.relatedAfters.filter(Boolean)).toEqual([]);
+    expect(await screen.findByText('A claim on the same topic')).toBeInTheDocument();
   });
 
   // The walk is bounded: each step is a request, and a topic whose claims are mostly unnamed would

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
@@ -4370,6 +4370,43 @@ describe('the Related tab', () => {
   });
 
   /**
+   * A failed discovery is not reliably an empty one. `useQueryEntities` falls back to whatever the
+   * local store already matches when its fetch fails, so the count can be non-zero on a failure —
+   * and the pair would be dropped onto a tab built from whatever the store happened to hold, which
+   * is not the fallback this tab documents.
+   */
+  it('offers no tab when discovery failed, even holding rows it could draw', async () => {
+    debateWithRelated();
+    // Rows, as the local store would answer them, and a failure alongside.
+    mocks.relatedEntitiesError = new Error('discovery failed');
+
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+    await settleTabSwap();
+
+    expect(screen.queryByRole('button', { name: 'Related' })).toBeNull();
+    expect(screen.getByRole('button', { name: /positions/ })).toHaveAttribute('aria-selected', 'true');
+  });
+
+  /**
+   * An unresolved space type reads as publishable, deliberately, so a slow lookup does not empty a
+   * list. Every other tab accepts that, because a viewer reaches those by choosing them. This is
+   * the tab they are dropped onto, so a row drawn actionable before its type resolves is a debate
+   * that can be requested and could never be published — and Related is the source most likely to
+   * be the only one naming that space.
+   */
+  it('holds the slot rather than drawing rows whose spaces are still unresolved', async () => {
+    debateWithRelated();
+    mocks.spacesHeldOver = true;
+
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+    await settleTabSwap();
+
+    // The slot is kept — this is a wait, not an absence — and nothing actionable is drawn in it.
+    expect(screen.getByRole('button', { name: 'Related' })).toBeInTheDocument();
+    expect(screen.queryByText('A claim on the same topic')).toBeNull();
+  });
+
+  /**
    * Two gates sit between what discovery found and what the tab shows: the claims this session
    * excludes, and the ones whose space cannot carry a published debate. Whether the tab exists has
    * to be asked after them.

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
@@ -301,6 +301,13 @@ vi.mock('~/core/debates/hooks', () => ({
 
 function rematchClaimsLookup(claimIds: string[]) {
   mocks.rematchClaimIds.push(claimIds);
+  // Nothing asked for is nothing in flight, as it is on the hook this stands in for: no ids means
+  // no batches, and `useQueries([])` reports `isLoading: false`. A double that reported a load here
+  // let an empty list read as "still settling", which is a state the page cannot actually reach and
+  // a caller waiting on it could not be tested honestly.
+  if (claimIds.length === 0) {
+    return { data: { claims: [], excluded_claim_ids: [] }, isLoading: false, error: null };
+  }
   const isCuratedLookup = mocks.curatedIds.length > 0 && claimIds.every(claimId => mocks.curatedIds.includes(claimId));
   if (mocks.browsedLookupLoading && !isCuratedLookup) {
     return { data: { claims: [], excluded_claim_ids: [] }, isLoading: true, error: null };
@@ -538,6 +545,9 @@ vi.mock('~/core/sync/use-store', () => ({
 vi.mock('~/core/debates/claim-picker-page', () => ({
   useClaimEntitiesByIds: (ids: string[]) => {
     mocks.entityIdLookups.push(ids);
+    // Idle on an empty list, for the same reason as `rematchClaimsLookup` above: the real hook
+    // batches the ids and `useQueries([])` has nothing to load.
+    if (ids.length === 0) return { entities: [], isLoading: false, error: null };
     // Answerless while loading, as react-query is on a cold key. Without that a "loading" lookup
     // still handed back its fixtures, so nothing downstream could tell the two apart — and the
     // states that exist to wait for hydration were untestable.
@@ -4171,6 +4181,22 @@ describe('the Related tab', () => {
    * one place this tab gets ahead of what is known, and getting ahead of it here would mean a tab
    * appearing and vanishing on a session that could never have had one.
    */
+  /**
+   * And not even while the page-wide allowlist is in flight. That request runs whatever the session
+   * is, so counting it as pending here invented a tab on a session that can never have one — the
+   * allowlist only decides something where there is a claim for it to decide about.
+   */
+  it('holds no place for a challenge session while the allowlist is still out', async () => {
+    mocks.session = session({ source_debate_id: null });
+    debateWithRelated();
+    mocks.publishableSpacesLoading = true;
+
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+    await settleTabSwap();
+
+    expect(screen.queryByRole('button', { name: 'Related' })).toBeNull();
+  });
+
   it('holds no place for a session with no debate behind it', async () => {
     mocks.session = session({ source_debate_id: null });
     debateWithRelated();
@@ -4339,6 +4365,32 @@ describe('the Related tab', () => {
     await settleTabSwap();
 
     expect(screen.queryByText('A claim on the same topic')).toBeNull();
+    // And the tab goes with it — see the test below.
+    expect(screen.queryByRole('button', { name: 'Related' })).toBeNull();
+  });
+
+  /**
+   * Two gates sit between what discovery found and what the tab shows: the claims this session
+   * excludes, and the ones whose space cannot carry a published debate. Whether the tab exists has
+   * to be asked after them.
+   *
+   * Asked before, a single neighbour that either gate removes still read as "has neighbours", and
+   * the pair were landed on a tab whose list was empty — the state the tab exists to avoid, arrived
+   * at by the tab itself. The fallback for "nothing left to argue" only works if the count is of
+   * what is left.
+   */
+  it('offers no tab when the only neighbour is one this session rules out', async () => {
+    mocks.entities = [sharedEntity(), sourceClaimEntity(), relatedEntity()];
+    // Discovery finds one, and the session has already ruled it out.
+    mocks.relatedEntities = [sourceClaimEntity(), relatedEntity()];
+    mocks.excludedClaimIds = [CLAIM_SOURCE, RELATED];
+
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+    await settleTabSwap();
+
+    expect(screen.queryByRole('button', { name: 'Related' })).toBeNull();
+    expect(screen.getByRole('button', { name: /positions/ })).toHaveAttribute('aria-selected', 'true');
+    expect(screen.queryByText('No related claims are left to debate.')).toBeNull();
   });
 
   /**

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
@@ -49,6 +49,7 @@ const mocks = vi.hoisted(() => ({
   relatedEntitiesError: null as Error | null,
   relatedWheres: [] as unknown[],
   relatedFirsts: [] as Array<number | undefined>,
+  relatedAfters: [] as Array<string | undefined>,
   relatedDefers: [] as Array<boolean | undefined>,
   relatedPrefetches: [] as Array<boolean | undefined>,
   entityHydrations: [] as Array<{ id: string; spaceId?: string }>,
@@ -489,12 +490,14 @@ vi.mock('~/core/sync/use-store', () => ({
   useQueryEntities: ({
     where,
     first,
+    after,
     enabled,
     deferUntilFetched,
     prefetchNextPage,
   }: {
     where: unknown;
     first?: number;
+    after?: string;
     enabled?: boolean;
     deferUntilFetched?: boolean;
     prefetchNextPage?: boolean;
@@ -509,13 +512,23 @@ vi.mock('~/core/sync/use-store', () => ({
     // `first` is a real cap, as it is on the query this stands in for. Ignoring it let a fixture
     // hand back more rows than were asked for, which is how a caller that asks for too few still
     // looks like it returned enough.
-    const page = first === undefined ? mocks.relatedEntities : mocks.relatedEntities.slice(0, first);
+    //
+    // And it pages, as the query does: `relatedEntities` is the whole result set, `after` is an
+    // offset into it, and `hasNextPage` says whether anything is left. Without this the double
+    // always claimed to be exhausted, so a caller walking past an undrawable window had nowhere to
+    // walk to and the walk itself was untestable.
+    const from = after === undefined ? 0 : Number(after);
+    const page =
+      first === undefined ? mocks.relatedEntities.slice(from) : mocks.relatedEntities.slice(from, from + first);
+    const reached = from + page.length;
+    const hasNextPage = enabled !== false && reached < mocks.relatedEntities.length;
+    mocks.relatedAfters.push(after);
     return {
       entities: enabled === false || loading ? [] : page,
       isLoading: loading,
       isPlaceholderData: false,
-      endCursor: null,
-      hasNextPage: false,
+      endCursor: hasNextPage ? String(reached) : null,
+      hasNextPage,
       error: enabled === false ? null : mocks.relatedEntitiesError,
     };
   },
@@ -783,6 +796,7 @@ beforeEach(() => {
   mocks.relatedEntitiesError = null;
   mocks.relatedWheres.length = 0;
   mocks.relatedFirsts.length = 0;
+  mocks.relatedAfters.length = 0;
   mocks.relatedDefers.length = 0;
   mocks.relatedPrefetches.length = 0;
   mocks.entityHydrations.length = 0;
@@ -4205,6 +4219,53 @@ describe('the Related tab', () => {
     for (const relation of where.relations) {
       expect(relation.space).toEqual({ equals: SPACE_1.replace(/-/g, '') });
     }
+  });
+
+  /**
+   * A whole window can come back undrawable — the debated claim is in it, and so is every neighbour
+   * whose name has not indexed — and the count of what is left decides whether the tab exists. So
+   * discovery walks to the next window rather than reading an undrawable one as "no neighbours".
+   *
+   * Raised twice in review, and the second time with the right argument: the claim page's gallery
+   * skips forward on exactly this data, so a tab that gave up where the gallery does not would have
+   * been two surfaces disagreeing about the same claim.
+   */
+  it('walks past a window it cannot draw any of', async () => {
+    // A full window of the debated claim and unnamed neighbours, with a drawable one behind it.
+    const unnamed = Array.from({ length: 32 }, (_, index) => ({
+      ...topicEntity(`019fedb9-7db8-7a05-9b88-9de4cf60bb${index.toString().padStart(2, '0')}`, 'unindexed'),
+      name: null,
+    }));
+    mocks.entities = [sharedEntity(), sourceClaimEntity(), relatedEntity()];
+    mocks.relatedEntities = [sourceClaimEntity(), ...unnamed, relatedEntity()];
+
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+
+    expect(await screen.findByRole('button', { name: 'Related' })).toBeInTheDocument();
+    expect(await screen.findByText('A claim on the same topic')).toBeInTheDocument();
+    // Anchored on the first window's end rather than restarting it, so the walk is a step forward.
+    expect(mocks.relatedAfters.filter(Boolean)).toContain('33');
+  });
+
+  // The walk is bounded: each step is a request, and a topic whose claims are mostly unnamed would
+  // otherwise spend an unbounded number of them on a tab nobody asked for.
+  it('gives up after four further windows', async () => {
+    const undrawable = Array.from({ length: 33 * 6 }, (_, index) => ({
+      ...topicEntity(`019fedb9-7db8-7a05-9b88-9de4cf6${index.toString().padStart(5, '0')}`, 'unindexed'),
+      name: null,
+    }));
+    // The debated claim is hydrated for its topics; without it discovery never starts, and a walk
+    // that never began would pass this test for the wrong reason.
+    mocks.entities = [sharedEntity(), sourceClaimEntity()];
+    mocks.relatedEntities = undrawable;
+
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+    await settleTabSwap();
+
+    expect(screen.queryByRole('button', { name: 'Related' })).toBeNull();
+    // Four steps past the first window, and no fifth.
+    expect(mocks.relatedAfters.filter(Boolean)).toContain('132');
+    expect(mocks.relatedAfters.filter(Boolean)).not.toContain('165');
   });
 
   /**

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
@@ -551,11 +551,19 @@ vi.mock('~/core/debates/claim-picker-page', () => ({
     // Answerless while loading, as react-query is on a cold key. Without that a "loading" lookup
     // still handed back its fixtures, so nothing downstream could tell the two apart — and the
     // states that exist to wait for hydration were untestable.
+    // Answerless on a failure too, as react-query is on a cold key: `data` is undefined, so there
+    // are no entities *and* an error. Handing back fixtures alongside the error let a caller that
+    // ignored the failure still draw every row, so the states that exist to handle one could not
+    // fail a test.
+    const failed = Boolean(mocks.entityHydrationErrorFor && ids.includes(mocks.entityHydrationErrorFor));
     return {
-      entities: mocks.entityHydrationLoading ? [] : mocks.entities.filter(entity => ids.includes(entity.id as string)),
+      entities:
+        mocks.entityHydrationLoading || failed
+          ? []
+          : mocks.entities.filter(entity => ids.includes(entity.id as string)),
       isLoading: mocks.entityHydrationLoading,
       // Stable identity: a fresh Error each render would be a new value for every memo below it.
-      error: mocks.entityHydrationErrorFor && ids.includes(mocks.entityHydrationErrorFor) ? HYDRATION_ERROR : null,
+      error: failed ? HYDRATION_ERROR : null,
     };
   },
 }));
@@ -1963,6 +1971,31 @@ describe('DebateRematchPageClient', () => {
     expect(screen.getByRole('heading', { name: 'Geopolitics & chips' })).toBeInTheDocument();
     // Not just the card: its sides come from the graph, so nothing here waits on the browsed list.
     expect(await screen.findByRole('button', { name: 'Request debate' })).toBeInTheDocument();
+  });
+
+  /**
+   * The curator names its claims in the graph's spelling; a row geo-chat supplied carries geo-chat's.
+   * Joined raw, the section lost precisely the claims geo-chat had a row for — which is to say the
+   * curated claims with any session history at all, the ones most worth showing.
+   *
+   * Latent until the session lookup itself was canonicalized: before that geo-chat's rows were never
+   * found, so every row carried the entity's spelling and the two sides happened to agree. Making
+   * one join work is what exposed the next one.
+   */
+  it('keeps a curated claim in its section when geo-chat spelled its id differently', async () => {
+    // The graph's side of it — the curator's list and the entity — in bare hex, as the graph
+    // answers. geo-chat's row for the same claim keeps its hyphens (`mocks.claims`, by default).
+    const graphId = CLAIM_SHARED.replace(/-/g, '');
+    mocks.curatedIds = [graphId];
+    mocks.savedClaims = [];
+    mocks.recommendedSections = [{ id: 'block-1', name: 'Geopolitics & chips', claimIds: [graphId] }];
+    mocks.recommendedEntities = [{ ...sharedEntity(), id: graphId }];
+
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+    await showRecommended();
+
+    expect(screen.getByRole('heading', { name: 'Geopolitics & chips' })).toBeInTheDocument();
+    expect(screen.getByText('A claim both participants chose')).toBeInTheDocument();
   });
 
   // The session's own claims arrive in one round trip; they shouldn't sit behind the scan either.
@@ -4367,6 +4400,85 @@ describe('the Related tab', () => {
     expect(screen.queryByText('A claim on the same topic')).toBeNull();
     // And the tab goes with it — see the test below.
     expect(screen.queryByRole('button', { name: 'Related' })).toBeNull();
+  });
+
+  /**
+   * The hook accepts a claim summary with no space, and a space is required rather than merely used:
+   * hydrating unscoped asks for topics from every space at once, and discovery can never run without
+   * a space anyway. Reported as loading, that pointless hydration reserved a tab that was always
+   * going to vanish when it finished.
+   */
+  it('holds no slot for a source claim that arrived without a space', async () => {
+    debateWithRelated();
+    mocks.sourceDebate = { claim: { claim_entity_id: CLAIM_SOURCE, space_id: undefined } };
+    mocks.entityHydrationLoading = true;
+
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+    await settleTabSwap();
+
+    expect(screen.queryByRole('button', { name: 'Related' })).toBeNull();
+  });
+
+  /**
+   * A space reached through two sources is still one space. Rows carry whichever spelling their
+   * source used — a Related row built from the graph carries bare hex, geo-chat's rows for the
+   * opponent's claims carry the same space with hyphens — so a raw set counted it twice and opened
+   * two gateway scopes on it, which is every event on that space delivered twice.
+   */
+  it('opens one scope on a space two sources spell differently', async () => {
+    const hexSpace = SPACE_1.replace(/-/g, '');
+    // The neighbour lives in the debated claim's space, spelled as the graph spells it.
+    const hexSpaced = {
+      ...relatedEntity(),
+      spaces: [hexSpace],
+      values: [{ property: { id: NAME_PROPERTY }, spaceId: hexSpace, value: 'A claim on the same topic' }],
+    };
+    mocks.entities = [sharedEntity(), sourceClaimEntity(), hexSpaced];
+    mocks.relatedEntities = [sourceClaimEntity(), hexSpaced];
+
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+    await screen.findByRole('button', { name: 'Related' });
+
+    const scoped = mocks.gatewaySpaceScopes.filter(scope => scope.enabled).at(-1)?.spaceIds ?? [];
+    const canonical = scoped.map(spaceId => spaceId.replace(/-/g, ''));
+    expect(canonical).toEqual([...new Set(canonical)]);
+    // And the space is genuinely there, so this is a deduplication rather than a disappearance.
+    expect(canonical).toContain(hexSpace);
+  });
+
+  /**
+   * `publishabilityPending` is not this tab's own lookup — it covers every catalog source — so on a
+   * session with no related claims at all another tab's space lookup was holding this one's slot
+   * open. A phantom tab reached from the other end: not discovery saying "wait", but an unrelated
+   * request that happened not to have finished.
+   */
+  it('holds no slot on another tab’s space lookup when discovery found nothing', async () => {
+    mocks.entities = [sharedEntity(), sourceClaimEntity()];
+    mocks.relatedEntities = [sourceClaimEntity()];
+    mocks.spacesHeldOver = true;
+
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+    await settleTabSwap();
+
+    expect(screen.queryByRole('button', { name: 'Related' })).toBeNull();
+  });
+
+  /**
+   * A tab that exists and could not draw is an error where the rows would be, not a missing tab.
+   * Reading availability off the row count collapsed the two: a cold failure leaves no rows and
+   * nothing settling, which looked exactly like "no neighbours", so the failure was never reported
+   * to anyone. What separates them is that discovery found ids.
+   */
+  it('keeps the tab and reports the failure when the rows could not be built', async () => {
+    debateWithRelated();
+    // The row projection fails for the neighbour discovery found.
+    mocks.entityHydrationErrorFor = RELATED;
+
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+    await settleTabSwap();
+
+    expect(screen.getByRole('button', { name: 'Related' })).toBeInTheDocument();
+    expect(screen.queryByText('No related claims are left to debate.')).toBeNull();
   });
 
   /**

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
@@ -8,6 +8,7 @@ import { Provider, createStore } from 'jotai';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { TOPICS_PROPERTY_ID } from '~/core/claims/ontology';
+import { TAG_PROPERTY_ID } from '~/core/constants';
 import type { DebateRematchClaim, DebateRematchSession, MatchmakingClaim } from '~/core/debates/api';
 import { clearDebateReturnDestination, rememberDebateReturnDestination } from '~/core/debates/debate-return-navigation';
 import type { ParticipantPosition } from '~/core/debates/participant-positions';
@@ -40,6 +41,18 @@ const {
 }));
 
 const mocks = vi.hoisted(() => ({
+  sourceDebate: { claim: { claim_entity_id: CLAIM_SOURCE, space_id: SPACE_1 } } as unknown,
+  sourceDebateLoading: false,
+  /** GEO-2758. The Related tab's discovery: the topic query and the source claim's hydration. */
+  relatedEntities: [] as any[],
+  relatedEntitiesLoading: false,
+  relatedEntitiesError: null as Error | null,
+  relatedWheres: [] as unknown[],
+  relatedFirsts: [] as Array<number | undefined>,
+  relatedDefers: [] as Array<boolean | undefined>,
+  relatedPrefetches: [] as Array<boolean | undefined>,
+  entityHydrations: [] as Array<{ id: string; spaceId?: string }>,
+  singleHydrationErrorFor: null as string | null,
   session: null as DebateRematchSession | null,
   /** The session lookup itself is in flight — everything below it is keyed on what it returns. */
   sessionLoading: false,
@@ -240,7 +253,10 @@ vi.mock('~/core/debates/hooks', () => ({
   // Two lookups run: one for the curated ids, one for the browsed ones. `curatedIds` lets a test
   // stall the browsed lookup on its own, which is the whole point of their being separate.
   useDebateRematchClaimsForIds: (_sessionId: string, claimIds: string[]) => rematchClaimsLookup(claimIds),
-  useDebate: () => ({ data: { claim: { claim_entity_id: CLAIM_SOURCE } } }),
+  // The source debate, and the head of the Related tab's discovery chain. Carries the claim's space
+  // as the real payload does: topics are assigned per space, so the space is what the claim is
+  // hydrated with.
+  useDebate: () => ({ data: mocks.sourceDebate, isLoading: mocks.sourceDebateLoading, error: null }),
   useDebateClaimsBySpaces: (groups: Array<{ spaceId: string; claimIds: string[] }>) => {
     mocks.perSpaceReadinessGroups.push(groups);
     return {
@@ -437,6 +453,66 @@ vi.mock('~/core/debates/tagged-claims', async importOriginal => ({
 const HYDRATION_ERROR = new Error('hydration exploded');
 
 // The opponent's claims are hydrated from the graph by id, through the picker's narrow projection.
+vi.mock('~/core/sync/use-store', () => ({
+  // Topics are assigned per space, so the source claim is hydrated with the debate's space. This
+  // records what it was asked for; the scoping itself happens in `store.getEntity`, outside the
+  // component.
+  useQueryEntity: ({ id, spaceId, enabled }: { id: string; spaceId?: string; enabled?: boolean }) => {
+    if (enabled !== false && id) mocks.entityHydrations.push({ id, spaceId });
+    // Matched canonically, as the store is: a strict compare here would be stricter than the thing
+    // this stands in for and would fail a caller that correctly normalized before asking.
+    const wanted = id.replace(/-/g, '').toLowerCase();
+    const entity =
+      enabled === false
+        ? null
+        : (mocks.entities.find(candidate => (candidate.id as string).replace(/-/g, '').toLowerCase() === wanted) ??
+          null);
+    // `error` as well, as the hook reports since this review: a failed hydration still answers from
+    // the store, so a caller gating on failure cannot infer one from a missing entity.
+    const singleFailed =
+      mocks.singleHydrationErrorFor !== null &&
+      mocks.singleHydrationErrorFor.replace(/-/g, '').toLowerCase() === wanted;
+    return {
+      entity,
+      isLoading: enabled !== false && Boolean(id) && mocks.entityHydrationLoading,
+      error: enabled !== false && singleFailed ? HYDRATION_ERROR : null,
+    };
+  },
+  useQueryEntities: ({
+    where,
+    first,
+    enabled,
+    deferUntilFetched,
+    prefetchNextPage,
+  }: {
+    where: unknown;
+    first?: number;
+    enabled?: boolean;
+    deferUntilFetched?: boolean;
+    prefetchNextPage?: boolean;
+  }) => {
+    mocks.relatedWheres.push(where);
+    mocks.relatedFirsts.push(first);
+    mocks.relatedDefers.push(deferUntilFetched);
+    mocks.relatedPrefetches.push(prefetchNextPage);
+    // A first load has no rows yet -- returning them *and* `isLoading` is a state react-query
+    // never produces, and a test written against it passes whatever the picker does with the flag.
+    const loading = enabled !== false && mocks.relatedEntitiesLoading;
+    // `first` is a real cap, as it is on the query this stands in for. Ignoring it let a fixture
+    // hand back more rows than were asked for, which is how a caller that asks for too few still
+    // looks like it returned enough.
+    const page = first === undefined ? mocks.relatedEntities : mocks.relatedEntities.slice(0, first);
+    return {
+      entities: enabled === false || loading ? [] : page,
+      isLoading: loading,
+      isPlaceholderData: false,
+      endCursor: null,
+      hasNextPage: false,
+      error: enabled === false ? null : mocks.relatedEntitiesError,
+    };
+  },
+}));
+
 vi.mock('~/core/debates/claim-picker-page', () => ({
   useClaimEntitiesByIds: (ids: string[]) => {
     mocks.entityIdLookups.push(ids);
@@ -692,6 +768,17 @@ function mutation(mutate = mocks.mutate) {
 }
 
 beforeEach(() => {
+  mocks.sourceDebate = { claim: { claim_entity_id: CLAIM_SOURCE, space_id: SPACE_1 } };
+  mocks.sourceDebateLoading = false;
+  mocks.relatedEntities = [];
+  mocks.relatedEntitiesLoading = false;
+  mocks.relatedEntitiesError = null;
+  mocks.relatedWheres.length = 0;
+  mocks.relatedFirsts.length = 0;
+  mocks.relatedDefers.length = 0;
+  mocks.relatedPrefetches.length = 0;
+  mocks.entityHydrations.length = 0;
+  mocks.singleHydrationErrorFor = null;
   localStorage.clear();
 
   clearDebateReturnDestination();
@@ -3956,3 +4043,132 @@ function publishedEntity(id = CLAIM_MORE, name = 'A newly published claim') {
 function claimSummary(id: string, claim: string) {
   return { id, space_id: SPACE_1, claim_entity_id: id, claim, description: null };
 }
+
+/**
+ * GEO-2758. The Related tab: claims sharing a topic with the one this pair just argued, and where
+ * they land when there is one.
+ *
+ * A tab rather than an Explore source (GEO-2861 review): Explore's sources are four answers to
+ * "which claims?", and this is not a way of browsing — it is the continuation of the debate that
+ * just happened.
+ */
+describe('the Related tab', () => {
+  const RELATED = '019fedb9-7db8-7a05-9b88-9de4cf60bb75';
+  const GOV_TOPIC = { id: 'topic-gov', name: 'Governance' };
+
+  function topicEntity(id: string, name: string) {
+    return {
+      id,
+      name,
+      description: null,
+      spaces: [SPACE_1],
+      values: [{ property: { id: NAME_PROPERTY }, spaceId: SPACE_1, value: name }],
+      relations: [
+        { type: { id: TOPICS_PROPERTY_ID }, spaceId: SPACE_1.replace(/-/g, ''), toEntity: GOV_TOPIC, isDeleted: false },
+      ],
+    };
+  }
+
+  /** The claim the pair just argued, carrying the topic its neighbours are found by. */
+  const sourceClaimEntity = () => topicEntity(CLAIM_SOURCE, 'The claim just debated');
+  /** A neighbour in the same space on the same topic. */
+  const relatedEntity = (id = RELATED, name = 'A claim on the same topic') => topicEntity(id, name);
+
+  /**
+   * The graph returns the debated claim in its own related list — it holds the topics the clause
+   * matches on — so a fixture without it describes a result the query cannot produce.
+   */
+  function debateWithRelated() {
+    mocks.entities = [sharedEntity(), sourceClaimEntity(), relatedEntity()];
+    mocks.relatedEntities = [sourceClaimEntity(), relatedEntity()];
+  }
+
+  it('lands the pair on Related when the claim they argued has neighbours', async () => {
+    debateWithRelated();
+
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+
+    expect(await screen.findByRole('button', { name: 'Related' })).toBeInTheDocument();
+    expect(await screen.findByText('A claim on the same topic')).toBeInTheDocument();
+  });
+
+  // The GEO-2861 landing place, and still right when there is no debate to continue from.
+  it('lands on the opponent’s positions when there are no neighbours', async () => {
+    mocks.entities = [sharedEntity(), sourceClaimEntity()];
+    // Only the debated claim comes back, which is what "no neighbours" looks like.
+    mocks.relatedEntities = [sourceClaimEntity()];
+
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+    await settleTabSwap();
+
+    expect(screen.queryByRole('button', { name: 'Related' })).toBeNull();
+    expect(screen.getByRole('button', { name: /positions/ })).toBeInTheDocument();
+  });
+
+  // A tab that leads to an empty list is worse than no tab: the strip is not where someone should
+  // learn a lookup came back empty.
+  it('does not offer the tab at all without neighbours', async () => {
+    mocks.entities = [sharedEntity()];
+    mocks.relatedEntities = [];
+
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+    await settleTabSwap();
+
+    expect(screen.queryByRole('button', { name: 'Related' })).toBeNull();
+  });
+
+  /**
+   * Three round trips stand between arriving and knowing whether Related exists — the source debate,
+   * that claim's topics, and the topic query. Until they land, "no neighbours" and "not yet" are the
+   * same observation, so the strip must not name a landing place it will move away from.
+   */
+  it('withholds the tab while discovery is still out', async () => {
+    debateWithRelated();
+    mocks.relatedEntitiesLoading = true;
+
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+
+    await waitFor(() => expect(screen.getByRole('button', { name: /positions/ })).toBeInTheDocument());
+    expect(screen.queryByRole('button', { name: 'Related' })).toBeNull();
+  });
+
+  /**
+   * The clause is shared with the claim page's Related gallery so the two surfaces cannot disagree
+   * about what "related" means — and narrowed here to the Debate tag, because this tab asks what the
+   * pair should argue next rather than where else a reader can go.
+   *
+   * Both relations carry the space: topics and tags are assigned per space, and `spaces` on the
+   * entity only says the claim is *named* there.
+   */
+  it('asks the shared clause, tag-narrowed and scoped to the debated claim’s space', async () => {
+    debateWithRelated();
+
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+    await screen.findByRole('button', { name: 'Related' });
+
+    const where = mocks.relatedWheres.at(-1) as {
+      spaces: Array<{ equals: string }>;
+      relations: Array<{ typeOf: { id: { equals: string } }; space?: { equals: string } }>;
+    };
+    expect(where.spaces).toEqual([{ equals: SPACE_1.replace(/-/g, '') }]);
+    expect(where.relations.map(relation => relation.typeOf.id.equals)).toEqual([TOPICS_PROPERTY_ID, TAG_PROPERTY_ID]);
+    for (const relation of where.relations) {
+      expect(relation.space).toEqual({ equals: SPACE_1.replace(/-/g, '') });
+    }
+  });
+
+  /**
+   * The debated claim is always in its own related list, and an unnamed neighbour cannot be drawn.
+   * Both are dropped before the count that decides the tab exists — counting either makes a claim
+   * with no neighbours look like a claim with one.
+   */
+  it('counts neither the debated claim nor an unnamed neighbour', async () => {
+    mocks.entities = [sharedEntity(), sourceClaimEntity()];
+    mocks.relatedEntities = [sourceClaimEntity(), { ...relatedEntity(), name: null }];
+
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+    await settleTabSwap();
+
+    expect(screen.queryByRole('button', { name: 'Related' })).toBeNull();
+  });
+});

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
@@ -4420,6 +4420,59 @@ describe('the Related tab', () => {
   });
 
   /**
+   * The member-space default is spent on whatever menu it sees, and it is a default about browsing.
+   * Its gate said "not the opponent's tab", which was the same sentence as "only on Explore" while
+   * there were two tabs to choose between — and stopped being one the moment this tab landed the
+   * pair somewhere else. Spent here, it would be spent against a menu of one space, the debated
+   * claim's, which Explore would then inherit as a deliberate-looking choice nobody made.
+   */
+  it('does not spend the member-space default on the Related tab', async () => {
+    debateWithRelated();
+    mocks.memberSpaceIds = new Set([SPACE_1.replace(/-/g, '')]);
+
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+    await screen.findByRole('button', { name: 'Related' });
+    await settleTabSwap();
+
+    // Unspent: the trigger still offers every space rather than naming one.
+    expect(screen.getByRole('button', { name: /Any space/ })).toBeInTheDocument();
+
+    // And spent as soon as the tab it is about is open.
+    await showAllClaims();
+    await waitFor(() => expect(screen.getByRole('button', { name: /Crypto/ })).toBeInTheDocument());
+  });
+
+  /**
+   * The space filter is a selection made against whatever spelling the menu offered, and a row
+   * carries whatever spelling its source used. Compared raw, switching to Related hid a row under a
+   * filter naming that very space — the filter and the row agreeing about the space and disagreeing
+   * about how to write it.
+   */
+  it('keeps a Related row under a filter naming its space in the other spelling', async () => {
+    const hexSpace = SPACE_1.replace(/-/g, '');
+    const hexSpaced = {
+      ...relatedEntity(),
+      spaces: [hexSpace],
+      values: [{ property: { id: NAME_PROPERTY }, spaceId: hexSpace, value: 'A claim on the same topic' }],
+    };
+    mocks.entities = [sharedEntity(), sourceClaimEntity(), hexSpaced];
+    mocks.relatedEntities = [sourceClaimEntity(), hexSpaced];
+
+    // The selection is made over on Explore, against a menu built from rows geo-chat named with
+    // hyphens, and it outlives the tab (GEO-2850) — which is how the two spellings meet.
+    mocks.memberSpaceIds = new Set([SPACE_1.replace(/-/g, '')]);
+
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+    await screen.findByRole('button', { name: 'Related' });
+    await showAllClaims();
+    await waitFor(() => expect(screen.getByRole('button', { name: /Crypto/ })).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole('button', { name: 'Related' }));
+
+    expect(await screen.findByText('A claim on the same topic')).toBeInTheDocument();
+  });
+
+  /**
    * A space reached through two sources is still one space. Rows carry whichever spelling their
    * source used — a Related row built from the graph carries bare hex, geo-chat's rows for the
    * opponent's claims carry the same space with hyphens — so a raw set counted it twice and opened

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
@@ -256,7 +256,15 @@ vi.mock('~/core/debates/hooks', () => ({
   // The source debate, and the head of the Related tab's discovery chain. Carries the claim's space
   // as the real payload does: topics are assigned per space, so the space is what the claim is
   // hydrated with.
-  useDebate: () => ({ data: mocks.sourceDebate, isLoading: mocks.sourceDebateLoading, error: null }),
+  //
+  // Answerless and idle when disabled, as react-query is: a session with no debate behind it passes
+  // `enabled: false` here, and a double that answered anyway would run a whole discovery chain the
+  // page never runs — the states that exist because there is nothing to discover would be untestable.
+  useDebate: (_debateId: string, enabled: boolean) => ({
+    data: enabled ? mocks.sourceDebate : undefined,
+    isLoading: enabled && mocks.sourceDebateLoading,
+    error: null,
+  }),
   useDebateClaimsBySpaces: (groups: Array<{ spaceId: string; claimIds: string[] }>) => {
     mocks.perSpaceReadinessGroups.push(groups);
     return {
@@ -4118,11 +4126,34 @@ describe('the Related tab', () => {
   });
 
   /**
-   * Three round trips stand between arriving and knowing whether Related exists — the source debate,
-   * that claim's topics, and the topic query. Until they land, "no neighbours" and "not yet" are the
-   * same observation, so the strip must not name a landing place it will move away from.
+   * Discovery is three serial requests, and the tab does not wait for them.
+   *
+   * It used to: the strip rendered without Related, the pair started on the opponent's positions,
+   * and a moment later the tab appeared and moved them — on every rematch out of a debate. Holding
+   * the slot instead costs a tab that goes away when the claim turns out to have no neighbours,
+   * which is the rarer case. The room warms the same query while the debate runs, so this window is
+   * usually not reached at all.
    */
-  it('withholds the tab while discovery is still out', async () => {
+  it('holds the tab’s place while the count is still out', async () => {
+    debateWithRelated();
+    mocks.relatedEntitiesLoading = true;
+
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+
+    const related = await screen.findByRole('button', { name: 'Related' });
+    // And the pair are on it, rather than being moved onto it once the count lands.
+    expect(related).toHaveAttribute('aria-selected', 'true');
+  });
+
+  /**
+   * The slot is held for a session still counting its neighbours, not for every session — and what
+   * separates them is that a session from a profile challenge has no debated claim, so discovery
+   * never starts and there is nothing to hold a place for. Asserted because the reservation is the
+   * one place this tab gets ahead of what is known, and getting ahead of it here would mean a tab
+   * appearing and vanishing on a session that could never have had one.
+   */
+  it('holds no place for a session with no debate behind it', async () => {
+    mocks.session = session({ source_debate_id: null });
     debateWithRelated();
     mocks.relatedEntitiesLoading = true;
 
@@ -4130,6 +4161,25 @@ describe('the Related tab', () => {
 
     await waitFor(() => expect(screen.getByRole('button', { name: /positions/ })).toBeInTheDocument());
     expect(screen.queryByRole('button', { name: 'Related' })).toBeNull();
+  });
+
+  // Related is where the pair land, and a strip that opens on its second item reads as though
+  // something moved.
+  it('puts Related ahead of the opponent’s positions', async () => {
+    debateWithRelated();
+
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+    await screen.findByRole('button', { name: 'Related' });
+
+    // The strip's tabs are the buttons carrying a selected state; Leave is the only other button
+    // in the header and carries none.
+    const tabs = screen
+      .getAllByRole('button')
+      .filter(button => button.hasAttribute('aria-selected'))
+      .map(button => button.textContent ?? '');
+    expect(tabs[0]).toBe('Related');
+    expect(tabs[1]).toMatch(/positions/);
+    expect(tabs[2]).toBe('Explore');
   });
 
   /**

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -1376,7 +1376,12 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
     [isRematchable, matchesOnlyHere]
   );
   const passesSpace = React.useCallback(
-    (claim: DebateRematchClaim) => spaceIds.length === 0 || spaceIds.includes(claim.claim.space_id),
+    // Canonically, as everything that joins a row's space to another source's now is. A row carries
+    // whichever spelling its source used — a Related row built from the graph carries bare hex where
+    // the selection made on the opponent's tab carries geo-chat's — so a raw `includes` hid a row
+    // under a filter naming that very space.
+    (claim: DebateRematchClaim) =>
+      spaceIds.length === 0 || spaceIds.some(spaceId => idEquals(spaceId, claim.claim.space_id)),
     [spaceIds]
   );
   const passesTopics = React.useCallback(
@@ -1534,16 +1539,21 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
     // than the menu's: sign-up sends one membership proposal per picked space and they land
     // seconds apart, so the first non-empty answer is a fraction of what they chose (GEO-2834).
     //
-    // And never on the opponent's tab, which is the landing tab since GEO-2861. That list is the
-    // claims *they* hold a side on, and seeding it with the spaces the viewer belongs to would hide
-    // the opponent's positions everywhere else — the one thing the tab is for. The default is about
-    // browsing, so it waits for Explore, where the seed is spent against a menu it is about.
+    // And only on Explore. That list is the one the default is about; the opponent's positions are
+    // the claims *they* hold a side on, and seeding those with the spaces the viewer belongs to
+    // would hide the opponent's positions everywhere else — the one thing the tab is for.
+    //
+    // Written as "not browsing" rather than "not the opponent's tab", which was the same sentence
+    // while there were two tabs to choose between and stopped being one when GEO-2758 added a
+    // third: the seed is spent against whatever menu it sees, and on Related that is a menu of one
+    // space — the debated claim's — which Explore would then inherit as a deliberate-looking choice
+    // the viewer never made.
     //
     // Not gated on the *source*, though. Explore always opens on a browsing one, so the seed is
     // already spent by the time My positions can be picked, and it inherits the filter bar from
     // whatever was showing — the same as switching between All claims and Featured does.
     pending:
-      tab === 'opponent' ||
+      !browsing ||
       tabIsLoading ||
       publishabilityPending ||
       publishableSpacesLoading ||

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -8,6 +8,8 @@ import cx from 'classnames';
 import { useAtom } from 'jotai';
 import { useRouter } from 'next/navigation';
 
+import { TOPICS_PROPERTY_ID } from '~/core/claims/ontology';
+import { relatedClaimsWhere } from '~/core/claims/related-claims';
 import { claimResponseKind } from '~/core/claims/response-kind';
 import { FEATURED_TAG_ID } from '~/core/constants';
 import {
@@ -76,12 +78,14 @@ import {
 import { useClaimSpaceAllowlist } from '~/core/debates/use-claim-space-allowlist';
 import { useCurrentGeoChatUserId } from '~/core/debates/use-current-geo-chat-user-id';
 import { isSpaceDebatePublishable, useDebatePublishableSpaces } from '~/core/debates/use-debate-publishable-spaces';
+import { EntitiesOrderBy } from '~/core/gql/graphql';
 import { useEntitySidePanel } from '~/core/hooks/use-entity-side-panel';
 import { useEntityResponse, useEntityResponseIndexingSnapshot } from '~/core/hooks/use-entity-vote';
 import { useInfiniteScrollSentinel } from '~/core/hooks/use-infinite-scroll-sentinel';
 import { useSpacesByIds } from '~/core/hooks/use-spaces-by-ids';
 import { equals as idEquals, uuidToHex } from '~/core/id/normalize';
 import { responsePositionLabel } from '~/core/responses/entity-response';
+import { useQueryEntities, useQueryEntity } from '~/core/sync/use-store';
 import { getTopRankedSpaceId } from '~/core/utils/space/space-ranking';
 import { validateEntityId } from '~/core/utils/utils';
 
@@ -117,8 +121,27 @@ function useLastSettled<T>(value: T, settling: boolean, resetKey: string): T {
   return settling && lastSettledRef.current ? lastSettledRef.current.value : value;
 }
 
-/** Renamed from `claims` with GEO-2861, to match the hub's own browse tab. */
-type PickerTab = 'explore' | 'opponent';
+/**
+ * `explore` was renamed from `claims` with GEO-2861, to match the hub's own browse tab. `related`
+ * joined with GEO-2758: claims sharing a topic with the one this pair just argued.
+ *
+ * Related is a tab rather than another Explore source because of where it sits in the question being
+ * asked. Explore's sources are four answers to "which claims?" — a catalogue the viewer browses.
+ * Related is not a way of browsing; it is the continuation of the debate that just happened, which is
+ * why it is also where the pair land.
+ */
+type PickerTab = 'related' | 'explore' | 'opponent';
+/** How many neighbours the Related tab offers. */
+export const RELATED_CLAIMS_LIMIT = 25;
+
+/**
+ * Extra rows discovery asks for, to absorb the ones dropped before the limit applies: the debated
+ * claim itself, and any neighbour whose name has not indexed.
+ */
+const RELATED_DROPPED_ROW_SLACK = 8;
+
+/** Stable empty list, so a skipped discovery is not a new array each render. */
+const NO_RELATED_IDS: string[] = [];
 
 /**
  * GEO-2683. Where Explore draws its list from. Recommended, All claims, Featured and the viewer's
@@ -212,7 +235,6 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   // they just debated each other, so a general catalogue is not the first thing they came for —
   // the claims their opponent has already taken a side on are. And it opens there for *each* pair:
   // a choice made about the last opponent is not a choice about this one.
-  const tab: PickerTab = chosenTab?.sessionId === sessionId ? chosenTab.tab : 'opponent';
   const setTab = React.useCallback((next: PickerTab) => setChosenTab({ sessionId, tab: next }), [sessionId]);
 
   const savedClaimsQuery = useDebateRematchClaims(sessionId);
@@ -306,6 +328,153 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   // is spent on a space the reconciliation then removes, leaving the viewer with no default at all.
   // After an error `isLoading` is false and the ids stay null, so fail-open is preserved.
   const { publishableSpaceIds, isLoading: publishableSpacesLoading } = useDebatePublishableSpaces();
+
+  /* -----------------------------------------------------------------------------------------------
+   * GEO-2758. Related claims: the tab the pair land on straight out of a debate.
+   *
+   * Three lookups stand between arriving and a list: the source debate, that claim's entity — for
+   * its topics — and the topic query itself. Each needs the one before it, so this is a chain rather
+   * than a fan-out, and nothing here can be known until it finishes.
+   * ---------------------------------------------------------------------------------------------*/
+
+  /**
+   * geo-chat hands out dashed uuids where the graph stores bare hex, so the boundary is crossed once,
+   * here. Everything downstream is a graph question — the entity, the topic clause, the space it is
+   * scoped to — and converting per use is how one missed call becomes a silently empty list.
+   */
+  // Each field guarded on its own rather than on the claim existing. A summary can arrive without a
+  // space — and `uuidToHex` normalizes with `String.replace`, so a missing one throws rather than
+  // reading as absent.
+  const sourceClaim = sourceDebateQuery.data?.claim ?? null;
+  const relatedSourceClaimId = sourceClaim?.claim_entity_id ? uuidToHex(sourceClaim.claim_entity_id) : null;
+  const relatedSourceSpaceId = sourceClaim?.space_id ? uuidToHex(sourceClaim.space_id) : null;
+
+  /**
+   * Topics live on the graph entity rather than geo-chat's claim summary, and they are assigned *per
+   * space* — so the claim is hydrated with the debate's space, the same way the claim page hydrates
+   * it for the same purpose.
+   *
+   * `useClaimEntitiesByIds` was the obvious hook and is the wrong one: its projection selects
+   * relations with no space filter, so a topic assigned only in some other space would come back and
+   * pull in neighbours the claim's own Related gallery does not show.
+   */
+  const relatedSourceQuery = useQueryEntity({
+    id: relatedSourceClaimId ?? '',
+    spaceId: relatedSourceSpaceId ?? undefined,
+    enabled: relatedSourceClaimId !== null,
+  });
+
+  const relatedTopicIds = React.useMemo(() => {
+    const entity = relatedSourceQuery.entity;
+    if (!entity) return NO_RELATED_IDS;
+    return entity.relations
+      .filter(relation => relation.isDeleted !== true && idEquals(relation.type.id, TOPICS_PROPERTY_ID))
+      .map(relation => relation.toEntity.id);
+  }, [relatedSourceQuery.entity]);
+
+  /**
+   * The same clause the claim page's Related gallery runs, so the two surfaces cannot disagree about
+   * which claims are related to this one — and narrowed further to the Debate tag, because this tab
+   * asks "what should this pair argue next" rather than "where else can I go from here".
+   *
+   * Skipped with no topics rather than asked with an empty `in`, which matches no relation and would
+   * quietly return the space's entire claim list. Skipped too when the debated claim's own space
+   * cannot carry a published debate: every row here is drawn in that space, so there is nothing to
+   * ask for.
+   */
+  const relatedEnabled =
+    relatedSourceClaimId !== null &&
+    relatedSourceSpaceId !== null &&
+    relatedTopicIds.length > 0 &&
+    isSpaceDebatePublishable(relatedSourceSpaceId, publishableSpaceIds);
+
+  const relatedEntitiesQuery = useQueryEntities({
+    where: relatedClaimsWhere({
+      spaceId: relatedSourceSpaceId ?? '',
+      topicIds: relatedTopicIds,
+      requireTagId: DEBATE_TAG_ID,
+    }),
+    // Sized against what this page drops before the limit applies — the debated claim itself, which
+    // carries the topics the clause matches on, and any neighbour whose name has not indexed and so
+    // cannot be drawn. Slack rather than a second request: this tab does not page.
+    first: RELATED_CLAIMS_LIMIT + RELATED_DROPPED_ROW_SLACK,
+    // Without this, `useQueryEntities` answers from the local store before the first fetch resolves,
+    // and those ids fire the row lookups below a moment before the real answer replaces them.
+    deferUntilFetched: true,
+    prefetchNextPage: false,
+    orderBy: [EntitiesOrderBy.UpdatedAtDesc],
+    enabled: relatedEnabled,
+  });
+
+  /**
+   * The debated claim carries its own topics, so the graph returns it in its own related list — and,
+   * having just been debated, near the front of it. Dropped here rather than left to
+   * `excludedClaimIds`, because the count below decides whether the tab exists at all: leaving it in
+   * makes a claim with no neighbours look like a claim with one.
+   *
+   * Unnamed neighbours go for the same reason — `rowFromEntity` cannot draw them, and a missing name
+   * is knowable from this very query.
+   */
+  const relatedClaimIds = React.useMemo(
+    () =>
+      relatedEnabled && relatedSourceClaimId
+        ? relatedEntitiesQuery.entities
+            .filter(entity => Boolean(entity.name))
+            .map(entity => entity.id)
+            .filter(id => !idEquals(id, relatedSourceClaimId))
+            .slice(0, RELATED_CLAIMS_LIMIT)
+        : NO_RELATED_IDS,
+    [relatedEnabled, relatedEntitiesQuery.entities, relatedSourceClaimId]
+  );
+
+  const relatedEntitiesByIdQuery = useClaimEntitiesByIds(relatedClaimIds);
+  const relatedClaimsQuery = useDebateRematchClaimsForIds(sessionId, relatedClaimIds);
+
+  // Every lookup in the chain, so the gates below cannot enumerate a different subset each — the
+  // mistake that let one gate pass while another was still waiting.
+  const relatedDiscoveryLookups: ReadonlyArray<{ isLoading: boolean; error: unknown }> = [
+    sourceDebateQuery,
+    relatedSourceQuery,
+    relatedEntitiesQuery,
+  ];
+  const relatedDiscoveryError = relatedDiscoveryLookups.find(lookup => lookup.error)?.error ?? null;
+  const relatedDiscoveryPending = relatedDiscoveryLookups.some(lookup => lookup.isLoading);
+
+  /**
+   * Whether the tab exists at all.
+   *
+   * A discovery failure reads as "no related claims" rather than surfacing an error, the same way a
+   * failed curator lookup leaves Recommended out of the Explore menu: this tab is an enhancement on
+   * top of a picker that works without it, so a lookup nobody asked for should not put an error in
+   * front of someone who came here to choose a claim.
+   */
+  const hasRelated = relatedDiscoveryError === null && relatedClaimIds.length > 0;
+
+  /**
+   * Whether that answer can be trusted yet — and so whether the landing tab is known.
+   *
+   * Until the chain lands, "no related claims" and "not yet" are the same observation, and the tab
+   * strip would name one landing place and then move the viewer to another. Only waited on when
+   * there is a source debate to wait for: without one this tab can never appear.
+   *
+   * A failure decides it as surely as an answer does, so nothing still in flight is waited on past
+   * that point.
+   */
+  const relatedUndecided =
+    sessionQuery.isLoading ||
+    (Boolean(session?.source_debate_id) && relatedDiscoveryError === null && relatedDiscoveryPending);
+
+  /**
+   * Where the pair land, and it is not a fixed answer.
+   *
+   * Related when this session came out of a debate that has neighbours to argue next — the
+   * continuation of what just happened is closer to what they came for than any catalogue. The
+   * opponent's positions otherwise, which is where GEO-2861 put it and remains right when there is no
+   * debate behind the session.
+   *
+   * Per pair, not per viewer: a choice made about the last opponent is not a choice about this one.
+   */
+  const tab: PickerTab = chosenTab?.sessionId === sessionId ? chosenTab.tab : hasRelated ? 'related' : 'opponent';
 
   // GEO-2683. Fetched only when Featured is the source on screen — it is one option in a menu, and
   // the other two answer for themselves.
@@ -892,6 +1061,38 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   );
   const curatedClaims = useLastSettled(curatedClaimsNow, curatedClaimsSettling, sessionId);
 
+  /**
+   * The Related tab's rows, built exactly as the curated list is: the same projection, the same
+   * session flags, the same two gates. Only the ids differ.
+   *
+   * Held while its lookups settle so a refetch does not blank a list that is still right.
+   */
+  const relatedClaimsSettling = relatedUndecided || relatedEntitiesByIdQuery.isLoading || relatedClaimsQuery.isLoading;
+  const relatedClaimsNow = React.useMemo(
+    () =>
+      relatedClaimsSettling
+        ? []
+        : relatedClaimIds.flatMap(claimId => {
+            if (excludedClaimIds.has(claimId)) return [];
+            const entity = relatedEntitiesByIdQuery.entities.find(candidate => idEquals(candidate.id, claimId));
+            // The debated claim's own space, not the claim's ranking: the clause found this neighbour
+            // on a topic and a tag assigned *there*, so drawing it anywhere else would offer it on
+            // something that is not true where the debate would be published.
+            const row = entity ? rowFromEntity(entity, relatedSourceSpaceId ?? undefined) : null;
+            return row && canPublishDebateIn(row.claim.space_id) ? [row] : [];
+          }),
+    [
+      canPublishDebateIn,
+      excludedClaimIds,
+      relatedClaimIds,
+      relatedClaimsSettling,
+      relatedEntitiesByIdQuery.entities,
+      relatedSourceSpaceId,
+      rowFromEntity,
+    ]
+  );
+  const relatedClaims = useLastSettled(relatedClaimsNow, relatedClaimsSettling, sessionId);
+
   // Featured, in the order the tag query ranked it. Built exactly as the curated list is — the
   // entities are the same projection and the rows carry the same session flags — and held the same
   // way while its lookups settle.
@@ -1093,14 +1294,16 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   const claims =
     tab === 'opponent'
       ? opponentClaims
-      : source === 'recommended'
-        ? curatedClaims
-        : source === 'mine'
-          ? viewerClaims
-          : // Featured and All are the same list asked of two tags. Nothing is merged into either
-            // any more (GEO-2798): the Claims tab is the graph's answer, and the session's own rows
-            // live on the opponent's tab and under Recommended, where they always also were.
-            taggedClaims;
+      : tab === 'related'
+        ? relatedClaims
+        : source === 'recommended'
+          ? curatedClaims
+          : source === 'mine'
+            ? viewerClaims
+            : // Featured and All are the same list asked of two tags. Nothing is merged into either
+              // any more (GEO-2798): the Claims tab is the graph's answer, and the session's own rows
+              // live on the opponent's tab and under Recommended, where they always also were.
+              taggedClaims;
 
   // Whether the list on screen was narrowed by its own query. Only the tagged sources are.
   const graphFiltered = tab === 'explore' && (source === 'featured' || source === 'all');
@@ -1257,11 +1460,13 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
       ? // Through `opponentClaimsSettling` rather than listing its queries again, so the tab and the
         // badge above cannot come to different answers about the same list.
         positions.isLoading || opponentClaimsSettling
-      : source === 'recommended'
-        ? recommendedLoading || curatedClaimsQuery.isLoading
-        : source === 'mine'
-          ? viewerClaimsSettling
-          : taggedClaimsSettling);
+      : tab === 'related'
+        ? relatedClaimsSettling
+        : source === 'recommended'
+          ? recommendedLoading || curatedClaimsQuery.isLoading
+          : source === 'mine'
+            ? viewerClaimsSettling
+            : taggedClaimsSettling);
 
   // The menu, and the handlers that drive it. Defaults to the spaces the viewer belongs to
   // (GEO-2789).
@@ -1308,16 +1513,21 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
     sessionQuery.error ??
     (tab === 'opponent'
       ? (positions.error ?? opponentEntitiesQuery.error)
-      : source === 'mine'
-        ? // The same two lookups the opponent's tab is built from, asked about the viewer.
-          (positions.error ?? viewerEntitiesQuery.error)
-        : source === 'featured' || source === 'all'
-          ? // The page is the list, and it carries everything a row is built from — so its failure
-            // is the only one that leaves nothing to show. geo-chat's row lookup is metadata beside
-            // it: losing it costs the faces and the readiness, not the claims, and blanking the tab
-            // for that trades a short list for no list.
-            taggedCatalogError
-          : curatedClaimsQuery.error);
+      : tab === 'related'
+        ? // Discovery's failure is deliberately *not* here: it takes the tab out of the strip rather
+          // than showing an error, so a viewer on Related is on it because rows were found. What can
+          // still fail is turning those ids into rows.
+          (relatedEntitiesByIdQuery.error ?? relatedClaimsQuery.error)
+        : source === 'mine'
+          ? // The same two lookups the opponent's tab is built from, asked about the viewer.
+            (positions.error ?? viewerEntitiesQuery.error)
+          : source === 'featured' || source === 'all'
+            ? // The page is the list, and it carries everything a row is built from — so its failure
+              // is the only one that leaves nothing to show. geo-chat's row lookup is metadata beside
+              // it: losing it costs the faces and the readiness, not the claims, and blanking the tab
+              // for that trades a short list for no list.
+              taggedCatalogError
+            : curatedClaimsQuery.error);
 
   // A topic the menu no longer offers is unpickable as well as empty — the chip filtering the
   // list would not be in the menu to clear. Unlike the Claims tab, the topics here arrive with
@@ -1507,8 +1717,18 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
                   )}
                 </span>
               </TabButton>
-              {/* Second, and named for the hub's browse tab: this is the wider catalogue you reach
-                  for once the opponent's own positions are not what you want. */}
+              {/* Only while it has something in it, which is the same condition that lands the pair
+                  here: an empty Related tab would be a place to go that says nothing, and the tab
+                  strip is not where a viewer should learn that a lookup came back empty. Withheld
+                  while discovery is still out for the same reason the landing tab waits on it —
+                  appearing a moment late is better than appearing and then vanishing. */}
+              {hasRelated && !relatedUndecided ? (
+                <TabButton active={tab === 'related'} onClick={() => setTab('related')}>
+                  Related
+                </TabButton>
+              ) : null}
+              {/* Named for the hub's browse tab: the wider catalogue you reach for once neither the
+                  opponent's positions nor the debate you just had is what you want. */}
               <TabButton active={tab === 'explore'} onClick={() => setTab('explore')}>
                 Explore
               </TabButton>
@@ -1611,13 +1831,18 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
                 ? `You and ${remoteName} haven’t taken opposite sides on anything yet.`
                 : tab === 'opponent'
                   ? `${remoteName} hasn’t responded yet. When they do, those claims show up here.`
-                  : source === 'recommended'
-                    ? `Nothing recommended for you and ${remoteName} yet.`
-                    : source === 'mine'
-                      ? 'You haven’t taken a position on any claims yet.'
-                      : source === 'featured'
-                        ? 'No featured claims are available to debate yet.'
-                        : 'No other eligible claims are available yet.'
+                  : tab === 'related'
+                    ? // Reachable even though the tab only appears when neighbours were found: every
+                      // one of them can still be ruled out by this session — already debated, or in a
+                      // space that cannot carry a published debate.
+                      'No related claims are left to debate.'
+                    : source === 'recommended'
+                      ? `Nothing recommended for you and ${remoteName} yet.`
+                      : source === 'mine'
+                        ? 'You haven’t taken a position on any claims yet.'
+                        : source === 'featured'
+                          ? 'No featured claims are available to debate yet.'
+                          : 'No other eligible claims are available yet.'
           }
           // Four dead ends, and each has a different way out. Ordered by how much the viewer has
           // to give up: clearing their filters, then dropping the toggle, then leaving the tab or

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -8,8 +8,6 @@ import cx from 'classnames';
 import { useAtom } from 'jotai';
 import { useRouter } from 'next/navigation';
 
-import { TOPICS_PROPERTY_ID } from '~/core/claims/ontology';
-import { relatedClaimsWhere } from '~/core/claims/related-claims';
 import { claimResponseKind } from '~/core/claims/response-kind';
 import { FEATURED_TAG_ID } from '~/core/constants';
 import {
@@ -78,14 +76,13 @@ import {
 import { useClaimSpaceAllowlist } from '~/core/debates/use-claim-space-allowlist';
 import { useCurrentGeoChatUserId } from '~/core/debates/use-current-geo-chat-user-id';
 import { isSpaceDebatePublishable, useDebatePublishableSpaces } from '~/core/debates/use-debate-publishable-spaces';
-import { EntitiesOrderBy } from '~/core/gql/graphql';
+import { useRelatedDebateClaims } from '~/core/debates/use-related-debate-claims';
 import { useEntitySidePanel } from '~/core/hooks/use-entity-side-panel';
 import { useEntityResponse, useEntityResponseIndexingSnapshot } from '~/core/hooks/use-entity-vote';
 import { useInfiniteScrollSentinel } from '~/core/hooks/use-infinite-scroll-sentinel';
 import { useSpacesByIds } from '~/core/hooks/use-spaces-by-ids';
 import { equals as idEquals, uuidToHex } from '~/core/id/normalize';
 import { responsePositionLabel } from '~/core/responses/entity-response';
-import { useQueryEntities, useQueryEntity } from '~/core/sync/use-store';
 import { getTopRankedSpaceId } from '~/core/utils/space/space-ranking';
 import { validateEntityId } from '~/core/utils/utils';
 
@@ -131,18 +128,6 @@ function useLastSettled<T>(value: T, settling: boolean, resetKey: string): T {
  * why it is also where the pair land.
  */
 type PickerTab = 'related' | 'explore' | 'opponent';
-/** How many neighbours the Related tab offers. */
-export const RELATED_CLAIMS_LIMIT = 25;
-
-/**
- * Extra rows discovery asks for, to absorb the ones dropped before the limit applies: the debated
- * claim itself, and any neighbour whose name has not indexed.
- */
-const RELATED_DROPPED_ROW_SLACK = 8;
-
-/** Stable empty list, so a skipped discovery is not a new array each render. */
-const NO_RELATED_IDS: string[] = [];
-
 /**
  * GEO-2683. Where Explore draws its list from. Recommended, All claims, Featured and the viewer's
  * own positions are four answers to one question — "which claims?" — so they belong in a menu
@@ -332,116 +317,28 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   /* -----------------------------------------------------------------------------------------------
    * GEO-2758. Related claims: the tab the pair land on straight out of a debate.
    *
-   * Three lookups stand between arriving and a list: the source debate, that claim's entity — for
-   * its topics — and the topic query itself. Each needs the one before it, so this is a chain rather
-   * than a fan-out, and nothing here can be known until it finishes.
+   * Discovery lives in `useRelatedDebateClaims` rather than here, because the debate room runs the
+   * same hook while the debate is still going. The chain from a claim to a list of neighbours is
+   * three serial requests, and run from here it is a second of tab strip arriving after the page
+   * did — the thing that made the tab flash into place. Run from the room, the answer is already in
+   * the cache by the time the pair get here.
    * ---------------------------------------------------------------------------------------------*/
 
-  /**
-   * geo-chat hands out dashed uuids where the graph stores bare hex, so the boundary is crossed once,
-   * here. Everything downstream is a graph question — the entity, the topic clause, the space it is
-   * scoped to — and converting per use is how one missed call becomes a silently empty list.
-   */
-  // Each field guarded on its own rather than on the claim existing. A summary can arrive without a
-  // space — and `uuidToHex` normalizes with `String.replace`, so a missing one throws rather than
-  // reading as absent.
-  const sourceClaim = sourceDebateQuery.data?.claim ?? null;
-  const relatedSourceClaimId = sourceClaim?.claim_entity_id ? uuidToHex(sourceClaim.claim_entity_id) : null;
-  const relatedSourceSpaceId = sourceClaim?.space_id ? uuidToHex(sourceClaim.space_id) : null;
-
-  /**
-   * Topics live on the graph entity rather than geo-chat's claim summary, and they are assigned *per
-   * space* — so the claim is hydrated with the debate's space, the same way the claim page hydrates
-   * it for the same purpose.
-   *
-   * `useClaimEntitiesByIds` was the obvious hook and is the wrong one: its projection selects
-   * relations with no space filter, so a topic assigned only in some other space would come back and
-   * pull in neighbours the claim's own Related gallery does not show.
-   */
-  const relatedSourceQuery = useQueryEntity({
-    id: relatedSourceClaimId ?? '',
-    spaceId: relatedSourceSpaceId ?? undefined,
-    enabled: relatedSourceClaimId !== null,
-  });
-
-  const relatedTopicIds = React.useMemo(() => {
-    const entity = relatedSourceQuery.entity;
-    if (!entity) return NO_RELATED_IDS;
-    return entity.relations
-      .filter(relation => relation.isDeleted !== true && idEquals(relation.type.id, TOPICS_PROPERTY_ID))
-      .map(relation => relation.toEntity.id);
-  }, [relatedSourceQuery.entity]);
-
-  /**
-   * The same clause the claim page's Related gallery runs, so the two surfaces cannot disagree about
-   * which claims are related to this one — and narrowed further to the Debate tag, because this tab
-   * asks "what should this pair argue next" rather than "where else can I go from here".
-   *
-   * Skipped with no topics rather than asked with an empty `in`, which matches no relation and would
-   * quietly return the space's entire claim list. Skipped too when the debated claim's own space
-   * cannot carry a published debate: every row here is drawn in that space, so there is nothing to
-   * ask for.
-   */
-  const relatedEnabled =
-    relatedSourceClaimId !== null &&
-    relatedSourceSpaceId !== null &&
-    relatedTopicIds.length > 0 &&
-    isSpaceDebatePublishable(relatedSourceSpaceId, publishableSpaceIds);
-
-  const relatedEntitiesQuery = useQueryEntities({
-    where: relatedClaimsWhere({
-      spaceId: relatedSourceSpaceId ?? '',
-      topicIds: relatedTopicIds,
-      requireTagId: DEBATE_TAG_ID,
-    }),
-    // Sized against what this page drops before the limit applies — the debated claim itself, which
-    // carries the topics the clause matches on, and any neighbour whose name has not indexed and so
-    // cannot be drawn. Slack rather than a second request: this tab does not page.
-    first: RELATED_CLAIMS_LIMIT + RELATED_DROPPED_ROW_SLACK,
-    // Without this, `useQueryEntities` answers from the local store before the first fetch resolves,
-    // and those ids fire the row lookups below a moment before the real answer replaces them.
-    deferUntilFetched: true,
-    prefetchNextPage: false,
-    orderBy: [EntitiesOrderBy.UpdatedAtDesc],
-    enabled: relatedEnabled,
-  });
-
-  /**
-   * The debated claim carries its own topics, so the graph returns it in its own related list — and,
-   * having just been debated, near the front of it. Dropped here rather than left to
-   * `excludedClaimIds`, because the count below decides whether the tab exists at all: leaving it in
-   * makes a claim with no neighbours look like a claim with one.
-   *
-   * Unnamed neighbours go for the same reason — `rowFromEntity` cannot draw them, and a missing name
-   * is knowable from this very query.
-   */
-  const relatedClaimIds = React.useMemo(
-    () =>
-      relatedEnabled && relatedSourceClaimId
-        ? relatedEntitiesQuery.entities
-            .filter(entity => Boolean(entity.name))
-            .map(entity => entity.id)
-            .filter(id => !idEquals(id, relatedSourceClaimId))
-            .slice(0, RELATED_CLAIMS_LIMIT)
-        : NO_RELATED_IDS,
-    [relatedEnabled, relatedEntitiesQuery.entities, relatedSourceClaimId]
-  );
+  const related = useRelatedDebateClaims({ claim: sourceDebateQuery.data?.claim });
+  const relatedSourceSpaceId = related.spaceId;
+  const relatedClaimIds = related.claimIds;
 
   const relatedEntitiesByIdQuery = useClaimEntitiesByIds(relatedClaimIds);
   const relatedClaimsQuery = useDebateRematchClaimsForIds(sessionId, relatedClaimIds);
 
-  // Every lookup in the chain, so the gates below cannot enumerate a different subset each — the
-  // mistake that let one gate pass while another was still waiting.
-  const relatedDiscoveryLookups: ReadonlyArray<{ isLoading: boolean; error: unknown }> = [
-    sourceDebateQuery,
-    relatedSourceQuery,
-    relatedEntitiesQuery,
-  ];
-  const relatedDiscoveryError = relatedDiscoveryLookups.find(lookup => lookup.error)?.error ?? null;
-  const relatedDiscoveryPending = relatedDiscoveryLookups.some(lookup => lookup.isLoading);
+  // The whole chain, enumerated once, so the gates below cannot each wait on a different subset of
+  // it — the mistake that let one gate pass while another was still waiting. The source debate is
+  // this page's own hop; the rest belongs to the hook.
+  const relatedDiscoveryError = sourceDebateQuery.error ?? related.error ?? null;
+  const relatedDiscoveryPending = sourceDebateQuery.isLoading || related.isLoading;
 
   /**
-   * Whether the tab exists at all.
+   * Whether it has rows.
    *
    * A discovery failure reads as "no related claims" rather than surfacing an error, the same way a
    * failed curator lookup leaves Recommended out of the Explore menu: this tab is an enhancement on
@@ -451,30 +348,42 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   const hasRelated = relatedDiscoveryError === null && relatedClaimIds.length > 0;
 
   /**
-   * Whether that answer can be trusted yet — and so whether the landing tab is known.
+   * Whether it is still being counted. A failure decides it as surely as an answer does, so nothing
+   * still in flight is waited on past that point.
    *
-   * Until the chain lands, "no related claims" and "not yet" are the same observation, and the tab
-   * strip would name one landing place and then move the viewer to another. Only waited on when
-   * there is a source debate to wait for: without one this tab can never appear.
-   *
-   * A failure decides it as surely as an answer does, so nothing still in flight is waited on past
-   * that point.
+   * Nothing to discover reads as decided, without asking the session whether it came out of a
+   * debate: a session from a profile challenge disables the source-debate query, and no claim
+   * disables the two behind it, so there is nothing in flight to be undecided about. The gate on
+   * `source_debate_id` this used to carry was the same question asked twice.
    */
-  const relatedUndecided =
-    sessionQuery.isLoading ||
-    (Boolean(session?.source_debate_id) && relatedDiscoveryError === null && relatedDiscoveryPending);
+  const relatedPending = relatedDiscoveryError === null && relatedDiscoveryPending;
+
+  /**
+   * Whether the tab is offered — and it is offered while still being counted, not only once it has
+   * rows.
+   *
+   * This is the one place the tab deliberately gets ahead of what is known, and it is the lesser of
+   * two flickers. Withholding it until the count landed meant the strip rendered without Related and
+   * the pair started on the opponent's positions, then a moment later the tab appeared and moved
+   * them — on every rematch out of a debate, which is the common case. Holding the slot instead
+   * costs a tab that goes away when a debated claim turns out to have no neighbours left to argue,
+   * which is the rare one. Both are a reflow; only one of them happens most of the time.
+   *
+   * Cheap to hold because the room has usually already answered it — see `useRelatedDebateClaims`.
+   */
+  const relatedOffered = hasRelated || relatedPending;
 
   /**
    * Where the pair land, and it is not a fixed answer.
    *
-   * Related when this session came out of a debate that has neighbours to argue next — the
-   * continuation of what just happened is closer to what they came for than any catalogue. The
-   * opponent's positions otherwise, which is where GEO-2861 put it and remains right when there is no
-   * debate behind the session.
+   * Related when this session came out of a debate with neighbours to argue next — the continuation
+   * of what just happened is closer to what they came for than any catalogue. The opponent's
+   * positions otherwise, which is where GEO-2861 put it and remains right when there is no debate
+   * behind the session.
    *
    * Per pair, not per viewer: a choice made about the last opponent is not a choice about this one.
    */
-  const tab: PickerTab = chosenTab?.sessionId === sessionId ? chosenTab.tab : hasRelated ? 'related' : 'opponent';
+  const tab: PickerTab = chosenTab?.sessionId === sessionId ? chosenTab.tab : relatedOffered ? 'related' : 'opponent';
 
   // GEO-2683. Fetched only when Featured is the source on screen — it is one option in a menu, and
   // the other two answer for themselves.
@@ -1067,7 +976,8 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
    *
    * Held while its lookups settle so a refetch does not blank a list that is still right.
    */
-  const relatedClaimsSettling = relatedUndecided || relatedEntitiesByIdQuery.isLoading || relatedClaimsQuery.isLoading;
+  const relatedClaimsSettling =
+    sessionQuery.isLoading || relatedPending || relatedEntitiesByIdQuery.isLoading || relatedClaimsQuery.isLoading;
   const relatedClaimsNow = React.useMemo(
     () =>
       relatedClaimsSettling
@@ -1699,6 +1609,14 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
                 gives those tabs somewhere to go, and `overscroll-x-contain` stops a swipe that
                 reaches the end from chaining into the browser's back gesture. */}
             <div className="no-scrollbar flex min-w-0 flex-1 items-center gap-5 overflow-x-auto overscroll-x-contain">
+              {/* First, because it is where the pair land: a tab strip that opens on its second
+                  item reads as though something moved. Rendered while the count is still out too —
+                  see `relatedOffered` for why the slot is held rather than filled late. */}
+              {relatedOffered ? (
+                <TabButton active={tab === 'related'} onClick={() => setTab('related')}>
+                  Related
+                </TabButton>
+              ) : null}
               <TabButton active={tab === 'opponent'} onClick={() => setTab('opponent')}>
                 <span className="max-w-[10rem] truncate">{firstNamePossessive(remoteName)} positions</span>
                 <span
@@ -1717,16 +1635,6 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
                   )}
                 </span>
               </TabButton>
-              {/* Only while it has something in it, which is the same condition that lands the pair
-                  here: an empty Related tab would be a place to go that says nothing, and the tab
-                  strip is not where a viewer should learn that a lookup came back empty. Withheld
-                  while discovery is still out for the same reason the landing tab waits on it —
-                  appearing a moment late is better than appearing and then vanishing. */}
-              {hasRelated && !relatedUndecided ? (
-                <TabButton active={tab === 'related'} onClick={() => setTab('related')}>
-                  Related
-                </TabButton>
-              ) : null}
               {/* Named for the hub's browse tab: the wider catalogue you reach for once neither the
                   opponent's positions nor the debate you just had is what you want. */}
               <TabButton active={tab === 'explore'} onClick={() => setTab('explore')}>

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -52,6 +52,7 @@ import {
   keepSelectableTopics,
   orderFacetOptions,
   toggleId,
+  topicsFor,
 } from '~/core/debates/matchmaking/topic-facets';
 import { useDebouncedSearch } from '~/core/debates/matchmaking/use-debounced-search';
 import { useDebouncedSelection } from '~/core/debates/matchmaking/use-debounced-selection';
@@ -83,6 +84,7 @@ import { useInfiniteScrollSentinel } from '~/core/hooks/use-infinite-scroll-sent
 import { useSpacesByIds } from '~/core/hooks/use-spaces-by-ids';
 import { equals as idEquals, uuidToHex } from '~/core/id/normalize';
 import { responsePositionLabel } from '~/core/responses/entity-response';
+import { normId } from '~/core/utils/norm-id';
 import { getTopRankedSpaceId } from '~/core/utils/space/space-ranking';
 import { validateEntityId } from '~/core/utils/utils';
 
@@ -355,8 +357,14 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
    * debate: a session from a profile challenge disables the source-debate query, and no claim
    * disables the two behind it, so there is nothing in flight to be undecided about. The gate on
    * `source_debate_id` this used to carry was the same question asked twice.
+   *
+   * The session lookup itself counts, though, and leaving it out reintroduced the flicker one step
+   * earlier: until it lands there is no `source_debate_id` to disable anything *with*, so discovery
+   * is idle for a reason that says nothing, the strip drew without Related, and the tab appeared and
+   * moved the pair the moment the session arrived. Usually already warm — the room holds this same
+   * session while the debate runs — so this is a window that mostly does not happen.
    */
-  const relatedPending = relatedDiscoveryError === null && relatedDiscoveryPending;
+  const relatedPending = sessionQuery.isLoading || (relatedDiscoveryError === null && relatedDiscoveryPending);
 
   /**
    * Whether the tab is offered — and it is offered while still being counted, not only once it has
@@ -383,7 +391,18 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
    *
    * Per pair, not per viewer: a choice made about the last opponent is not a choice about this one.
    */
-  const tab: PickerTab = chosenTab?.sessionId === sessionId ? chosenTab.tab : relatedOffered ? 'related' : 'opponent';
+  /**
+   * A choice is honoured except when it names a tab that is no longer there.
+   *
+   * Related can be picked while its slot is only reserved, and then the count can land empty or the
+   * lookup can fail — taking the button away while `chosenTab` still says `related`, which left the
+   * viewer on a tab with no way back to it and nothing in it. A choice cannot outlive its tab, so it
+   * falls back to the same place the landing decision does.
+   */
+  const chosenForSession = chosenTab?.sessionId === sessionId ? chosenTab.tab : null;
+  const chosenIsAvailable = chosenForSession !== 'related' || relatedOffered;
+  const tab: PickerTab =
+    chosenForSession !== null && chosenIsAvailable ? chosenForSession : relatedOffered ? 'related' : 'opponent';
 
   // GEO-2683. Fetched only when Featured is the source on screen — it is one option in a menu, and
   // the other two answer for themselves.
@@ -587,31 +606,63 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
     [participants, positions.byClaim]
   );
 
+  /**
+   * Every geo-chat rematch-claim lookup on this page, in one list.
+   *
+   * Three aggregates below are built from "all of them", and each used to spell that out for
+   * itself. Adding a sixth source meant remembering three places, and the Related tab arrived
+   * missing from all three: its rows lost `recently_rejected`, `previously_debated`, shared
+   * preference and readiness, and the claims this session excludes were not excluded from it.
+   * Enumerated once so a seventh source cannot be half-wired the same way.
+   */
+  const rematchClaimLookups = React.useMemo(
+    () => [
+      savedClaimsQuery.data,
+      opponentClaimsQuery.data,
+      viewerClaimsQuery.data,
+      curatedClaimsQuery.data,
+      taggedClaimsQuery.data,
+      relatedClaimsQuery.data,
+    ],
+    [
+      savedClaimsQuery.data,
+      opponentClaimsQuery.data,
+      viewerClaimsQuery.data,
+      curatedClaimsQuery.data,
+      taggedClaimsQuery.data,
+      relatedClaimsQuery.data,
+    ]
+  );
+
+  /**
+   * Keyed canonically, and read through {@link isClaimExcluded}.
+   *
+   * These ids come from geo-chat, which spells them as UUIDs; every caller tests them against a
+   * graph entity id, which is bare hex. A raw `has` across that boundary is always false, so the
+   * exclusions geo-chat sends were never applied to any graph-sourced list — the claim the pair
+   * just debated included, which this set adds by hand for exactly that reason.
+   */
   const excludedClaimIds = React.useMemo(() => {
-    const excluded = new Set([
-      ...(savedClaimsQuery.data?.excluded_claim_ids ?? []),
-      ...(opponentClaimsQuery.data?.excluded_claim_ids ?? []),
-      ...(viewerClaimsQuery.data?.excluded_claim_ids ?? []),
-      ...(curatedClaimsQuery.data?.excluded_claim_ids ?? []),
-      ...(taggedClaimsQuery.data?.excluded_claim_ids ?? []),
-    ]);
+    const excluded = new Set(
+      rematchClaimLookups.flatMap(data => (data?.excluded_claim_ids ?? []).map(claimId => normId(claimId)))
+    );
     const sourceClaimId = sourceDebateQuery.data?.claim.claim_entity_id;
-    if (sourceClaimId) excluded.add(sourceClaimId);
+    if (sourceClaimId) excluded.add(normId(sourceClaimId));
     return excluded;
-  }, [
-    curatedClaimsQuery.data,
-    taggedClaimsQuery.data,
-    opponentClaimsQuery.data,
-    viewerClaimsQuery.data,
-    savedClaimsQuery.data,
-    session?.recently_rejected_claim_ids,
-    sourceDebateQuery.data,
-  ]);
+  }, [rematchClaimLookups, sourceDebateQuery.data]);
+
+  /** Whether this session excludes a claim, whichever spelling of its id the caller holds. */
+  const isClaimExcluded = React.useCallback(
+    (claimEntityId: string) => excludedClaimIds.has(normId(claimEntityId)),
+    [excludedClaimIds]
+  );
 
   // A claim either side recently rejected stays listed with its request disabled, as geo-chat's
   // own rows flag it; the hub's index knows nothing of this session, so its rows read the list.
   const recentlyRejectedClaimIds = React.useMemo(
-    () => new Set(session?.recently_rejected_claim_ids ?? []),
+    // Canonical for the same reason as the exclusions above: geo-chat's spelling, read against a
+    // graph entity id.
+    () => new Set((session?.recently_rejected_claim_ids ?? []).map(claimId => normId(claimId))),
     [session?.recently_rejected_claim_ids]
   );
 
@@ -619,21 +670,9 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   // row for has no readiness row either: not ready is the truth, not a guess to send per space.
   // A backend that predates readiness on these rows leaves every claim to the per-space lookup.
   const sessionCarriesReadiness = React.useMemo(() => {
-    const rows = [
-      ...(savedClaimsQuery.data?.claims ?? []),
-      ...(opponentClaimsQuery.data?.claims ?? []),
-      ...(viewerClaimsQuery.data?.claims ?? []),
-      ...(curatedClaimsQuery.data?.claims ?? []),
-      ...(taggedClaimsQuery.data?.claims ?? []),
-    ];
+    const rows = rematchClaimLookups.flatMap(data => data?.claims ?? []);
     return rows.length === 0 || rows[0]!.viewer_debate_ready !== undefined;
-  }, [
-    curatedClaimsQuery.data,
-    taggedClaimsQuery.data,
-    opponentClaimsQuery.data,
-    viewerClaimsQuery.data,
-    savedClaimsQuery.data,
-  ]);
+  }, [rematchClaimLookups]);
 
   // geo-chat's row for a claim, where it has one. It carries the session flags and readiness; the
   // sides on it are replaced by the graph's below, which is what the card draws.
@@ -643,24 +682,29 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   // starts, while the graph waits on `web.write.entity_response` (p50 9.9s). The sides are still
   // drawn from the graph — that is the shape the page draws, and both agree in the end — but the
   // *gate* is measured against geo-chat below, because geo-chat is what rejects an early request.
+  /**
+   * Keyed canonically, and read through {@link sessionRowFor}.
+   *
+   * The keys are geo-chat's `claim_entity_id` and every lookup is a graph entity id, so a raw `get`
+   * across that boundary answers "no row" for a claim geo-chat does have one for — and "no row" is
+   * not visible as a failure. It reads as a claim with no session history: no recently-rejected
+   * flag, no previously-debated flag, no shared preference, and readiness defaulting to false,
+   * which disables the request button and says nothing about why.
+   */
   const sessionRowsByClaimId = React.useMemo(
     () =>
       new Map(
-        [
-          ...(savedClaimsQuery.data?.claims ?? []),
-          ...(opponentClaimsQuery.data?.claims ?? []),
-          ...(viewerClaimsQuery.data?.claims ?? []),
-          ...(curatedClaimsQuery.data?.claims ?? []),
-          ...(taggedClaimsQuery.data?.claims ?? []),
-        ].map(claim => [claim.claim.claim_entity_id, claim])
+        rematchClaimLookups
+          .flatMap(data => data?.claims ?? [])
+          .map(claim => [normId(claim.claim.claim_entity_id), claim] as const)
       ),
-    [
-      curatedClaimsQuery.data,
-      taggedClaimsQuery.data,
-      opponentClaimsQuery.data,
-      viewerClaimsQuery.data,
-      savedClaimsQuery.data,
-    ]
+    [rematchClaimLookups]
+  );
+
+  /** geo-chat's row for a claim, whichever spelling of its id the caller holds. */
+  const sessionRowFor = React.useCallback(
+    (claimEntityId: string) => sessionRowsByClaimId.get(normId(claimEntityId)),
+    [sessionRowsByClaimId]
   );
 
   /**
@@ -695,7 +739,9 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
       // that predates the field. Collapsing the two would make an old backend look like a
       // deliberate absence.
       const viewerParticipant = row.participants.find(side => side.user_id === currentUserId);
-      byClaim.set(row.claim.claim_entity_id, {
+      // Canonical, as every id-keyed structure on this page is: these keys are geo-chat's and the
+      // reader below is handed whichever spelling the row it is drawing carries.
+      byClaim.set(normId(row.claim.claim_entity_id), {
         spaceId: row.claim.space_id,
         position: row.viewer_position !== undefined ? row.viewer_position : (viewerParticipant?.position ?? null),
       });
@@ -706,7 +752,7 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   /** geo-chat's position for this claim *in this space*, or `undefined` when it has no such row. */
   const chatPositionFor = React.useCallback(
     (claimEntityId: string, spaceId: string): boolean | null | undefined => {
-      const recorded = chatPositionByClaimId.get(claimEntityId);
+      const recorded = chatPositionByClaimId.get(normId(claimEntityId));
       if (!recorded || !idEquals(recorded.spaceId, spaceId)) return undefined;
       return recorded.position;
     },
@@ -729,25 +775,40 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   // space, which is the one thing this gate exists to exclude, and the one-shot default would be
   // spent on it and pruned once its page finally arrived. Asking about the ids the menu is built
   // from is what makes "settled" mean settled; the tag spans a handful of spaces, so it is cheap.
-  const candidateSpaceIds = React.useMemo(() => {
-    const ids = new Set<string>();
-    for (const entity of [
+  /**
+   * Every claim entity any list on this page draws from, in one place.
+   *
+   * Both aggregates below are "all of them", and both used to spell it out separately — so the
+   * Related tab arrived in neither. That cost more than a missing label: an entity absent from the
+   * space lookup never has its space *type* resolved, and an unresolved type deliberately reads as
+   * publishable, so a personal space reachable only through Related would have passed the one gate
+   * that exists to exclude it.
+   */
+  const catalogEntities = React.useMemo(
+    () => [
       ...opponentEntitiesQuery.entities,
       ...viewerEntitiesQuery.entities,
       ...recommendedEntities,
+      ...relatedEntitiesByIdQuery.entities,
       ...taggedCatalog.map(claim => claim.entity),
-    ]) {
+    ],
+    [
+      opponentEntitiesQuery.entities,
+      viewerEntitiesQuery.entities,
+      recommendedEntities,
+      relatedEntitiesByIdQuery.entities,
+      taggedCatalog,
+    ]
+  );
+
+  const candidateSpaceIds = React.useMemo(() => {
+    const ids = new Set<string>();
+    for (const entity of catalogEntities) {
       for (const spaceId of claimCandidateSpaceIds(entity)) ids.add(spaceId);
     }
     for (const space of taggedSpaceFacet.spaces) ids.add(space.id);
     return [...ids];
-  }, [
-    opponentEntitiesQuery.entities,
-    viewerEntitiesQuery.entities,
-    recommendedEntities,
-    taggedCatalog,
-    taggedSpaceFacet.spaces,
-  ]);
+  }, [catalogEntities, taggedSpaceFacet.spaces]);
   const {
     spacesById: candidateSpaces,
     isLoading: candidateSpacesPending,
@@ -799,7 +860,7 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
       // A row for a different space describes a different card, so it is treated as no row at all —
       // the same path a claim geo-chat has never seen already takes. The other three sources pass
       // no preference and are unchanged: there the row's space is the authoritative one.
-      const recordedRow = sessionRowsByClaimId.get(entity.id);
+      const recordedRow = sessionRowFor(entity.id);
       const sessionRow =
         preferred && recordedRow && !idEquals(recordedRow.claim.space_id, preferred) ? undefined : recordedRow;
       const responseKind = sessionRow?.response_kind ?? claimResponseKind(entity, homeSpaceId);
@@ -814,14 +875,14 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
         response_kind: responseKind,
         participants: sidesOf(entity.id, sessionRow?.claim.space_id ?? homeSpaceId, responseKind),
         shared_preference: sessionRow?.shared_preference ?? false,
-        recently_rejected: sessionRow?.recently_rejected ?? recentlyRejectedClaimIds.has(entity.id),
+        recently_rejected: sessionRow?.recently_rejected ?? recentlyRejectedClaimIds.has(normId(entity.id)),
         previously_debated: sessionRow?.previously_debated ?? false,
         // These rows only list once their geo-chat batch has settled (see `sessionCarriesReadiness`).
         viewer_debate_ready: sessionRow ? sessionRow.viewer_debate_ready : sessionCarriesReadiness ? false : undefined,
         readiness_disabled_reason: sessionRow ? sessionRow.readiness_disabled_reason : null,
       };
     },
-    [canPublishDebateIn, recentlyRejectedClaimIds, sessionCarriesReadiness, sessionRowsByClaimId, sidesOf]
+    [canPublishDebateIn, recentlyRejectedClaimIds, sessionCarriesReadiness, sessionRowFor, sidesOf]
   );
 
   // Topics live on the KG claim entity, so resolve them here to label each card and drive the
@@ -831,16 +892,7 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   // folding those in never added anything — the topics have to come from the entity or not at all,
   // which is why the saved claims are hydrated above rather than trusted to carry their own, and
   // why reading that empty array the other way round emptied the list in GEO-2714.
-  const topicsByClaimId = React.useMemo(
-    () =>
-      claimTopicsById([
-        ...opponentEntitiesQuery.entities,
-        ...viewerEntitiesQuery.entities,
-        ...recommendedEntities,
-        ...taggedCatalog.map(claim => claim.entity),
-      ]),
-    [opponentEntitiesQuery.entities, viewerEntitiesQuery.entities, recommendedEntities, taggedCatalog]
-  );
+  const topicsByClaimId = React.useMemo(() => claimTopicsById(catalogEntities), [catalogEntities]);
 
   /**
    * Whether a claim survives the topic filter.
@@ -856,7 +908,7 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
    * there is nothing to defer to and nothing to gate.
    */
   const carriesPickedTopics = React.useCallback(
-    (claimEntityId: string) => carriesEveryTopic(topicsByClaimId.get(claimEntityId), topicIds),
+    (claimEntityId: string) => carriesEveryTopic(topicsFor(topicsByClaimId, claimEntityId), topicIds),
     [topicIds, topicsByClaimId]
   );
 
@@ -879,7 +931,7 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
       const entitiesById = new Map(entities.map(entity => [entity.id, entity]));
       const rows: DebateRematchClaim[] = [];
       for (const claimId of claimIds) {
-        if (excludedClaimIds.has(claimId)) continue;
+        if (isClaimExcluded(claimId)) continue;
         const entity = entitiesById.get(claimId);
         const row = entity ? rowFromEntity(entity) : null;
         if (row && row.participants.some(side => holdsSide(side.user_id) && side.position !== null)) rows.push(row);
@@ -888,7 +940,7 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
         .filter(row => canPublishDebateIn(row.claim.space_id))
         .sort((a, b) => Number(b.shared_preference) - Number(a.shared_preference));
     },
-    [canPublishDebateIn, excludedClaimIds, rowFromEntity]
+    [canPublishDebateIn, isClaimExcluded, rowFromEntity]
   );
 
   const opponentClaimsSettling =
@@ -954,7 +1006,7 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
       curatedClaimsSettling
         ? []
         : recommendedClaimIds.flatMap(claimId => {
-            if (excludedClaimIds.has(claimId)) return [];
+            if (isClaimExcluded(claimId)) return [];
             const entity = recommendedEntities.find(candidate => candidate.id === claimId);
             const row = entity ? rowFromEntity(entity) : null;
             return row && canPublishDebateIn(row.claim.space_id) ? [row] : [];
@@ -962,7 +1014,7 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
     [
       canPublishDebateIn,
       curatedClaimsSettling,
-      excludedClaimIds,
+      isClaimExcluded,
       recommendedClaimIds,
       recommendedEntities,
       rowFromEntity,
@@ -983,17 +1035,26 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
       relatedClaimsSettling
         ? []
         : relatedClaimIds.flatMap(claimId => {
-            if (excludedClaimIds.has(claimId)) return [];
+            if (isClaimExcluded(claimId)) return [];
             const entity = relatedEntitiesByIdQuery.entities.find(candidate => idEquals(candidate.id, claimId));
             // The debated claim's own space, not the claim's ranking: the clause found this neighbour
             // on a topic and a tag assigned *there*, so drawing it anywhere else would offer it on
             // something that is not true where the debate would be published.
+            //
+            // A preference is all `rowFromEntity` takes, though — it falls back to the claim's own
+            // ranking when the preferred space cannot carry a debate — and for this list a fallback
+            // is not a lesser answer, it is a wrong one: the topic and tag predicates were satisfied
+            // in the source space, and nothing was asked about any other. So the space is required
+            // rather than preferred, and a row that came back drawn somewhere else is dropped.
             const row = entity ? rowFromEntity(entity, relatedSourceSpaceId ?? undefined) : null;
-            return row && canPublishDebateIn(row.claim.space_id) ? [row] : [];
+            if (!row || relatedSourceSpaceId === null) return [];
+            return idEquals(row.claim.space_id, relatedSourceSpaceId) && canPublishDebateIn(row.claim.space_id)
+              ? [row]
+              : [];
           }),
     [
       canPublishDebateIn,
-      excludedClaimIds,
+      isClaimExcluded,
       relatedClaimIds,
       relatedClaimsSettling,
       relatedEntitiesByIdQuery.entities,
@@ -1058,7 +1119,7 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
       taggedClaimsSettling
         ? []
         : taggedCatalog.flatMap(claim => {
-            if (excludedClaimIds.has(claim.entity.id)) return [];
+            if (isClaimExcluded(claim.entity.id)) return [];
             const spaceId = tagDisplaySpaceId(
               claim,
               spaceIds,
@@ -1071,7 +1132,7 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
             if (!row || !canPublishDebateIn(row.claim.space_id)) return [];
             return isClaimSpaceAllowed(row.claim.space_id, spaceAllowlist) ? [row] : [];
           }),
-    [canPublishDebateIn, excludedClaimIds, rowFromEntity, spaceAllowlist, spaceIds, taggedCatalog, taggedClaimsSettling]
+    [canPublishDebateIn, isClaimExcluded, rowFromEntity, spaceAllowlist, spaceIds, taggedCatalog, taggedClaimsSettling]
   );
 
   // Keyed on the tag as well as the session.
@@ -1328,7 +1389,10 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
       claims
         .filter(claim => passesMatchesOnly(claim) && passesSpace(claim) && passesSearch(claim) && passesTopics(claim))
         .flatMap(claim =>
-          (topicsByClaimId.get(claim.claim.claim_entity_id) ?? []).map(topic => ({ id: topic.id, name: topic.name }))
+          (topicsFor(topicsByClaimId, claim.claim.claim_entity_id) ?? []).map(topic => ({
+            id: topic.id,
+            name: topic.name,
+          }))
         )
     );
     return orderFacetOptions(source, topicIds);
@@ -1499,11 +1563,14 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   //   scope from at the moment it matters.
   const scopedSpaceIds = React.useMemo(() => {
     const ids = new Set<string>();
-    for (const claim of [...opponentClaims, ...viewerClaims, ...curatedClaims, ...taggedClaims])
+    // Related included since GEO-2758. It is a visible source like the others, so without its
+    // spaces here a claim reachable only through Related holds no `claims_changed` subscription and
+    // the opponent's moves on the tab in front of the viewer wait for the next poll.
+    for (const claim of [...opponentClaims, ...viewerClaims, ...curatedClaims, ...taggedClaims, ...relatedClaims])
       ids.add(claim.claim.space_id);
     for (const participant of participants) ids.add(participant.profile_space_id);
     return [...ids].sort((a, b) => a.localeCompare(b));
-  }, [curatedClaims, taggedClaims, opponentClaims, viewerClaims, participants]);
+  }, [curatedClaims, taggedClaims, opponentClaims, viewerClaims, relatedClaims, participants]);
   useDebateGatewaySpaceScopes(scopedSpaceIds, geoChatAuthenticated && scopedSpaceIds.length > 0);
 
   // Readiness is reported by the card. geo-chat now carries it on the rematch claims

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -340,18 +340,9 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   const relatedDiscoveryPending = sourceDebateQuery.isLoading || related.isLoading;
 
   /**
-   * Whether it has rows.
-   *
-   * A discovery failure reads as "no related claims" rather than surfacing an error, the same way a
-   * failed curator lookup leaves Recommended out of the Explore menu: this tab is an enhancement on
-   * top of a picker that works without it, so a lookup nobody asked for should not put an error in
-   * front of someone who came here to choose a claim.
-   */
-  const hasRelated = relatedDiscoveryError === null && relatedClaimIds.length > 0;
-
-  /**
-   * Whether it is still being counted. A failure decides it as surely as an answer does, so nothing
-   * still in flight is waited on past that point.
+   * Whether discovery is still working, which is the first half of whether the tab is offered. A
+   * failure decides it as surely as an answer does, so nothing still in flight is waited on past
+   * that point.
    *
    * Nothing to discover reads as decided, without asking the session whether it came out of a
    * debate: a session from a profile challenge disables the source-debate query, and no claim
@@ -367,42 +358,17 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   const relatedPending = sessionQuery.isLoading || (relatedDiscoveryError === null && relatedDiscoveryPending);
 
   /**
-   * Whether the tab is offered — and it is offered while still being counted, not only once it has
-   * rows.
+   * A tab the viewer picked, where it is this session's.
    *
-   * This is the one place the tab deliberately gets ahead of what is known, and it is the lesser of
-   * two flickers. Withholding it until the count landed meant the strip rendered without Related and
-   * the pair started on the opponent's positions, then a moment later the tab appeared and moved
-   * them — on every rematch out of a debate, which is the common case. Holding the slot instead
-   * costs a tab that goes away when a debated claim turns out to have no neighbours left to argue,
-   * which is the rare one. Both are a reflow; only one of them happens most of the time.
-   *
-   * Cheap to hold because the room has usually already answered it — see `useRelatedDebateClaims`.
-   */
-  const relatedOffered = hasRelated || relatedPending;
-
-  /**
-   * Where the pair land, and it is not a fixed answer.
-   *
-   * Related when this session came out of a debate with neighbours to argue next — the continuation
-   * of what just happened is closer to what they came for than any catalogue. The opponent's
-   * positions otherwise, which is where GEO-2861 put it and remains right when there is no debate
-   * behind the session.
-   *
-   * Per pair, not per viewer: a choice made about the last opponent is not a choice about this one.
-   */
-  /**
-   * A choice is honoured except when it names a tab that is no longer there.
-   *
-   * Related can be picked while its slot is only reserved, and then the count can land empty or the
-   * lookup can fail — taking the button away while `chosenTab` still says `related`, which left the
-   * viewer on a tab with no way back to it and nothing in it. A choice cannot outlive its tab, so it
-   * falls back to the same place the landing decision does.
+   * Read here rather than at the landing decision below, because two queries are gated on Explore
+   * being open and the resolved tab is not available yet — it now waits on the Related rows, which
+   * wait on those queries. Asking the choice instead is not a weaker question: Explore is only ever
+   * reached by picking it, so a resolved `tab` of `explore` and a *chosen* one are the same state.
    */
   const chosenForSession = chosenTab?.sessionId === sessionId ? chosenTab.tab : null;
-  const chosenIsAvailable = chosenForSession !== 'related' || relatedOffered;
-  const tab: PickerTab =
-    chosenForSession !== null && chosenIsAvailable ? chosenForSession : relatedOffered ? 'related' : 'opponent';
+
+  /** Whether the viewer is in the browse tab, which is the only way to be in it. */
+  const browsing = chosenForSession === 'explore';
 
   // GEO-2683. Fetched only when Featured is the source on screen — it is one option in a menu, and
   // the other two answer for themselves.
@@ -447,7 +413,7 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
    * on screen. The picker lands on the opponent's positions, and a returning pair should not wait
    * behind a lookup for a list nobody has asked for. Same shape as `taggedEnabled` below.
    */
-  const viewerSourced = tab === 'explore' && source === 'mine';
+  const viewerSourced = browsing && source === 'mine';
   const viewerClaimIds = React.useMemo(
     () => (viewerSourced ? claimIdsAnsweredBy(positions.byClaim, localParticipant?.profile_space_id ?? null) : []),
     [localParticipant, positions.byClaim, viewerSourced]
@@ -486,7 +452,7 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   // would open Explore cold. The rows lookup is keyed on the session; the warm-up has to be too.
   const [warmedSessionId, setWarmedSessionId] = React.useState<string | null>(null);
   const browseWarmed = warmedSessionId === sessionId;
-  const taggedEnabled = (tab === 'explore' || !browseWarmed) && (source === 'featured' || source === 'all');
+  const taggedEnabled = (browsing || !browseWarmed) && (source === 'featured' || source === 'all');
   // What goes to the server, so the page and both facet menus describe the same set of spaces.
   //
   // Two of the three gates can be sent; one cannot. The viewer's allowlist and the acceptor's
@@ -908,7 +874,10 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
    * there is nothing to defer to and nothing to gate.
    */
   const carriesPickedTopics = React.useCallback(
-    (claimEntityId: string) => carriesEveryTopic(topicsFor(topicsByClaimId, claimEntityId), topicIds),
+    // Scoped to the space the card is drawn under: topics are assigned per space, so a topic the
+    // claim carries somewhere else is not one it carries here.
+    (claimEntityId: string, spaceId: string) =>
+      carriesEveryTopic(topicsFor(topicsByClaimId, claimEntityId, spaceId), topicIds),
     [topicIds, topicsByClaimId]
   );
 
@@ -1063,6 +1032,51 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
     ]
   );
   const relatedClaims = useLastSettled(relatedClaimsNow, relatedClaimsSettling, sessionId);
+
+  /**
+   * Whether the tab is offered — and so, below, whether it is where the pair land.
+   *
+   * Read off the finished rows rather than off what discovery found, because between the two sit
+   * two gates that can empty the list: the claims this session excludes, and the ones whose space
+   * cannot carry a published debate. Counting discovery's answer meant a single neighbour that
+   * `excluded_claim_ids` removes still read as "has neighbours", and the pair landed on a tab whose
+   * list was empty — the state this tab is meant to avoid, arrived at by the tab itself.
+   *
+   * Offered while the rows are still settling, too, which is the one place it deliberately gets
+   * ahead of what is known, and is the lesser of two flickers. Withholding it until the count landed
+   * meant the strip rendered without Related and the pair started on the opponent's positions, then
+   * a moment later the tab appeared and moved them — on every rematch out of a debate, which is the
+   * common case. Holding the slot costs a tab that goes away when a debated claim turns out to have
+   * nothing left to argue, which is the rare one. Both are a reflow; only one happens most of the
+   * time. And cheap to hold, because the room has usually answered it already — see
+   * `useRelatedDebateClaims`.
+   *
+   * A discovery failure reads as "no related claims" rather than surfacing an error, the same way a
+   * failed curator lookup leaves Recommended out of the Explore menu: this tab is an enhancement on
+   * top of a picker that works without it, so a lookup nobody asked for should not put an error in
+   * front of someone who came here to choose a claim. `relatedClaimsSettling` carries the same
+   * `relatedPending` that a failure releases, so nothing waits on a lookup that has already failed.
+   */
+  const relatedOffered = relatedClaims.length > 0 || relatedClaimsSettling;
+
+  /**
+   * Where the pair land, and it is not a fixed answer.
+   *
+   * Related when this session came out of a debate with claims left to argue next — the
+   * continuation of what just happened is closer to what they came for than any catalogue. The
+   * opponent's positions otherwise, which is where GEO-2861 put it and remains right when there is
+   * no debate behind the session.
+   *
+   * Per pair, not per viewer: a choice made about the last opponent is not a choice about this one.
+   *
+   * A choice is honoured except when it names a tab that is no longer there. Related can be picked
+   * while its slot is only reserved, and the rows can then land empty — taking the button away while
+   * `chosenTab` still said `related`, which left the viewer on a tab with no way back to it and
+   * nothing in it.
+   */
+  const chosenIsAvailable = chosenForSession !== 'related' || relatedOffered;
+  const tab: PickerTab =
+    chosenForSession !== null && chosenIsAvailable ? chosenForSession : relatedOffered ? 'related' : 'opponent';
 
   // Featured, in the order the tag query ranked it. Built exactly as the curated list is — the
   // entities are the same projection and the rows carry the same session flags — and held the same
@@ -1311,7 +1325,7 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
     [spaceIds]
   );
   const passesTopics = React.useCallback(
-    (claim: DebateRematchClaim) => carriesPickedTopics(claim.claim.claim_entity_id),
+    (claim: DebateRematchClaim) => carriesPickedTopics(claim.claim.claim_entity_id, claim.claim.space_id),
     [carriesPickedTopics]
   );
   const passesSearch = React.useCallback(
@@ -1389,7 +1403,7 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
       claims
         .filter(claim => passesMatchesOnly(claim) && passesSpace(claim) && passesSearch(claim) && passesTopics(claim))
         .flatMap(claim =>
-          (topicsFor(topicsByClaimId, claim.claim.claim_entity_id) ?? []).map(topic => ({
+          (topicsFor(topicsByClaimId, claim.claim.claim_entity_id, claim.claim.space_id) ?? []).map(topic => ({
             id: topic.id,
             name: topic.name,
           }))

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -333,6 +333,12 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   const relatedEntitiesByIdQuery = useClaimEntitiesByIds(relatedClaimIds);
   const relatedClaimsQuery = useDebateRematchClaimsForIds(sessionId, relatedClaimIds);
 
+  /**
+   * Turning discovery's ids into rows, as opposed to finding them. Named once so the tab's error
+   * state and the decision to keep the tab at all cannot disagree about which failures are which.
+   */
+  const relatedRowsError = relatedEntitiesByIdQuery.error ?? relatedClaimsQuery.error ?? null;
+
   // The whole chain, enumerated once, so the gates below cannot each wait on a different subset of
   // it — the mistake that let one gate pass while another was still waiting. The source debate is
   // this page's own hop; the rest belongs to the hook.
@@ -831,6 +837,16 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
         preferred && recordedRow && !idEquals(recordedRow.claim.space_id, preferred) ? undefined : recordedRow;
       const responseKind = sessionRow?.response_kind ?? claimResponseKind(entity, homeSpaceId);
       return {
+        /**
+         * Left in whichever spelling its source used, deliberately.
+         *
+         * A row geo-chat supplied carries its hyphenated UUIDs; one built from the entity carries
+         * the graph's bare hex. Canonicalizing here would give the page one spelling — and would
+         * also change what goes back *out*: this object is the payload for the debate request, the
+         * side panel and the readiness lookup, and geo-chat would stop receiving the ids it handed
+         * over. So the normalization lives at each join instead, on both sides, where it cannot
+         * change anything but the matching.
+         */
         claim: sessionRow?.claim ?? {
           id: entity.id,
           space_id: homeSpaceId,
@@ -937,7 +953,9 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   // empty list mid-flight and lose the order at the moment it is needed.
   const opponentClaims = useStableListOrder(
     opponentClaimsHeld,
-    row => `${row.claim.space_id}:${row.claim.claim_entity_id}`,
+    // Canonical, because a row's ids carry whichever spelling its source used and this key is what
+    // decides whether two sources describing the same claim are the same row.
+    row => `${normId(row.claim.space_id)}:${normId(row.claim.claim_entity_id)}`,
     sessionId
   );
 
@@ -963,7 +981,9 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   // carry the rest of the list with it.
   const viewerClaims = useStableListOrder(
     viewerClaimsHeld,
-    row => `${row.claim.space_id}:${row.claim.claim_entity_id}`,
+    // Canonical, because a row's ids carry whichever spelling its source used and this key is what
+    // decides whether two sources describing the same claim are the same row.
+    row => `${normId(row.claim.space_id)}:${normId(row.claim.claim_entity_id)}`,
     sessionId
   );
 
@@ -997,6 +1017,13 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
    *
    * Held while its lookups settle so a refetch does not blank a list that is still right.
    *
+   * Only once discovery has found something to draw. The row waits below are about *these* rows, and
+   * `publishabilityPending` is not even this tab's own lookup — it covers every catalog source — so
+   * ungated it let another tab's space lookup hold this one's slot open on a session that had no
+   * related claims at all, which is a phantom tab arrived at from the other end. `relatedPending`
+   * stays unconditional: it is discovery itself, and its whole job is the window before there are
+   * ids to count.
+   *
    * `publishabilityPending` is here and on none of the other lists, which is a deliberate asymmetry
    * rather than an oversight. An unresolved space type reads as publishable — fail-open, so a slow
    * lookup does not empty a list — and every other tab accepts that, because a viewer reaches those
@@ -1009,12 +1036,10 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
    * It costs a held slot rather than a blank one — the reservation below already covers settling —
    * so the price is rows arriving with the space types instead of before them.
    */
-  const relatedClaimsSettling =
-    sessionQuery.isLoading ||
-    relatedPending ||
-    publishabilityPending ||
-    relatedEntitiesByIdQuery.isLoading ||
-    relatedClaimsQuery.isLoading;
+  const relatedRowsPending =
+    relatedClaimIds.length > 0 &&
+    (publishabilityPending || relatedEntitiesByIdQuery.isLoading || relatedClaimsQuery.isLoading);
+  const relatedClaimsSettling = sessionQuery.isLoading || relatedPending || relatedRowsPending;
   const relatedClaimsNow = React.useMemo(
     () =>
       relatedClaimsSettling
@@ -1079,7 +1104,15 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
    * the row lookups below is a tab that exists and could not draw, which `tabError` reports where
    * the rows would be.
    */
-  const relatedOffered = relatedDiscoveryError === null && (relatedClaims.length > 0 || relatedClaimsSettling);
+  /**
+   * A row lookup that failed is a tab that exists and could not draw, which is what `tabError`
+   * reports where the rows would be. Without this the tab went instead: the rows are empty and
+   * nothing is settling, so a cold failure looked exactly like "no neighbours" and the error was
+   * never shown to anyone. Discovery having found ids is what separates the two.
+   */
+  const relatedRowsFailed = relatedClaimIds.length > 0 && relatedRowsError !== null;
+  const relatedOffered =
+    relatedDiscoveryError === null && (relatedClaims.length > 0 || relatedClaimsSettling || relatedRowsFailed);
 
   /**
    * Where the pair land, and it is not a fixed answer.
@@ -1527,7 +1560,7 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
         ? // Discovery's failure is deliberately *not* here: it takes the tab out of the strip rather
           // than showing an error, so a viewer on Related is on it because rows were found. What can
           // still fail is turning those ids into rows.
-          (relatedEntitiesByIdQuery.error ?? relatedClaimsQuery.error)
+          relatedRowsError
         : source === 'mine'
           ? // The same two lookups the opponent's tab is built from, asked about the viewer.
             (positions.error ?? viewerEntitiesQuery.error)
@@ -1575,13 +1608,16 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   const showsSections = tab === 'explore' && source === 'recommended';
   const visibleSections = React.useMemo(() => {
     if (!showsSections) return [];
-    const visibleById = new Map(visibleClaims.map(claim => [claim.claim.claim_entity_id, claim]));
+    // Canonical on both sides. The keys are row ids and the lookups are the curator's, which come
+    // from the graph — so a raw join dropped any claim whose row geo-chat supplied, which is to say
+    // exactly the curated claims with session history.
+    const visibleById = new Map(visibleClaims.map(claim => [normId(claim.claim.claim_entity_id), claim]));
 
     return recommendedSections
       .map(section => ({
         ...section,
         claims: section.claimIds
-          .map(claimId => visibleById.get(claimId))
+          .map(claimId => visibleById.get(normId(claimId)))
           .filter((claim): claim is DebateRematchClaim => claim !== undefined),
       }))
       .filter(section => section.claims.length > 0);
@@ -1598,14 +1634,22 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   //   about — the opponent taking their *first* position — so there would be no claim to derive the
   //   scope from at the moment it matters.
   const scopedSpaceIds = React.useMemo(() => {
-    const ids = new Set<string>();
+    // Deduplicated canonically, but subscribed to in a real spelling. A row carries whichever
+    // spelling its source used, so the same space reached through two sources — the graph's bare
+    // hex from a Related row, geo-chat's UUID from a participant — counted as two and was
+    // subscribed to twice, which is two scopes and two deliveries of every event on it.
+    //
+    // geo-chat's spelling wins where both are seen, since geo-chat is what the scope is opened
+    // against: the participants are added last and overwrite.
+    const byCanonical = new Map<string, string>();
     // Related included since GEO-2758. It is a visible source like the others, so without its
     // spaces here a claim reachable only through Related holds no `claims_changed` subscription and
     // the opponent's moves on the tab in front of the viewer wait for the next poll.
     for (const claim of [...opponentClaims, ...viewerClaims, ...curatedClaims, ...taggedClaims, ...relatedClaims])
-      ids.add(claim.claim.space_id);
-    for (const participant of participants) ids.add(participant.profile_space_id);
-    return [...ids].sort((a, b) => a.localeCompare(b));
+      byCanonical.set(normId(claim.claim.space_id), claim.claim.space_id);
+    for (const participant of participants)
+      byCanonical.set(normId(participant.profile_space_id), participant.profile_space_id);
+    return [...byCanonical.values()].sort((a, b) => a.localeCompare(b));
   }, [curatedClaims, taggedClaims, opponentClaims, viewerClaims, relatedClaims, participants]);
   useDebateGatewaySpaceScopes(scopedSpaceIds, geoChatAuthenticated && scopedSpaceIds.length > 0);
 
@@ -1645,7 +1689,10 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   /** The last request failure, and whether the claim it was sent for is still on screen. */
   const requestError = createRequest.error instanceof Error ? createRequest.error.message : null;
   const requestErrorClaimId = requestError ? createRequest.variables?.claim_id : undefined;
-  const hasClaimId = (claim: DebateRematchClaim) => claim.claim.claim_entity_id === requestErrorClaimId;
+  // Compared canonically: the error carries whichever spelling the failed request used, and the row
+  // carries this page's.
+  const hasClaimId = (claim: DebateRematchClaim) =>
+    requestErrorClaimId != null && idEquals(claim.claim.claim_entity_id, requestErrorClaimId);
   const requestErrorHasCard =
     requestErrorClaimId !== undefined &&
     (showsSections ? visibleSections.some(section => section.claims.some(hasClaimId)) : visibleClaims.some(hasClaimId));
@@ -1657,7 +1704,7 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
       session={session}
       currentUserId={currentUserId}
       chatPosition={chatPositionFor(claim.claim.claim_entity_id, claim.claim.space_id)}
-      readiness={readinessByClaimId.get(claim.claim.claim_entity_id) ?? null}
+      readiness={readinessByClaimId.get(normId(claim.claim.claim_entity_id)) ?? null}
       onRequest={() =>
         createRequest.mutate({
           source_space_id: claim.claim.space_id,
@@ -1974,15 +2021,18 @@ function useClaimReadinessByClaimId({
 
   const byClaimId = React.useMemo(() => {
     const map = new Map<string, ClaimReadinessState>();
+    // Two sources in one map — geo-chat's per-space response and the rows themselves — so both are
+    // keyed canonically, and {@link readinessFor} reads it the same way. Raw, the second loop's
+    // entries could never overwrite the first's for the same claim.
     for (const claim of perSpace.claims) {
-      map.set(claim.claim_entity_id, {
+      map.set(normId(claim.claim_entity_id), {
         viewer_debate_ready: claim.viewer_debate_ready,
         readiness_disabled_reason: claim.readiness_disabled_reason,
       });
     }
     for (const claim of claims) {
       if (claim.viewer_debate_ready === undefined) continue;
-      map.set(claim.claim.claim_entity_id, {
+      map.set(normId(claim.claim.claim_entity_id), {
         viewer_debate_ready: claim.viewer_debate_ready,
         readiness_disabled_reason: claim.readiness_disabled_reason ?? null,
       });
@@ -2119,7 +2169,9 @@ function RematchClaimCard({
   const request = session?.request;
 
   const requesting =
-    session?.status === 'request_pending' && request?.claim.claim_entity_id === claim.claim.claim_entity_id;
+    session?.status === 'request_pending' &&
+    request != null &&
+    idEquals(request.claim.claim_entity_id, claim.claim.claim_entity_id);
 
   const positions = React.useMemo(
     () => rematchPositionSummaries(claim, session, responseKind),

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -996,9 +996,25 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
    * session flags, the same two gates. Only the ids differ.
    *
    * Held while its lookups settle so a refetch does not blank a list that is still right.
+   *
+   * `publishabilityPending` is here and on none of the other lists, which is a deliberate asymmetry
+   * rather than an oversight. An unresolved space type reads as publishable — fail-open, so a slow
+   * lookup does not empty a list — and every other tab accepts that, because a viewer reaches those
+   * by choosing them and a row that proves unpublishable simply goes. This is the tab the pair are
+   * *dropped* onto: they are looking at it before they chose anything, so the window where a row is
+   * drawn actionable and turns out to be in a personal space is a window where a debate can be
+   * requested that could never be published. Related is also the tab most likely to open that
+   * window, since it can be the only source naming the debated claim's space.
+   *
+   * It costs a held slot rather than a blank one — the reservation below already covers settling —
+   * so the price is rows arriving with the space types instead of before them.
    */
   const relatedClaimsSettling =
-    sessionQuery.isLoading || relatedPending || relatedEntitiesByIdQuery.isLoading || relatedClaimsQuery.isLoading;
+    sessionQuery.isLoading ||
+    relatedPending ||
+    publishabilityPending ||
+    relatedEntitiesByIdQuery.isLoading ||
+    relatedClaimsQuery.isLoading;
   const relatedClaimsNow = React.useMemo(
     () =>
       relatedClaimsSettling
@@ -1054,10 +1070,16 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
    * A discovery failure reads as "no related claims" rather than surfacing an error, the same way a
    * failed curator lookup leaves Recommended out of the Explore menu: this tab is an enhancement on
    * top of a picker that works without it, so a lookup nobody asked for should not put an error in
-   * front of someone who came here to choose a claim. `relatedClaimsSettling` carries the same
-   * `relatedPending` that a failure releases, so nothing waits on a lookup that has already failed.
+   * front of someone who came here to choose a claim.
+   *
+   * Tested here rather than left to the row count, because a failure does not reliably produce an
+   * empty one: `useQueryEntities` falls back to matching rows already in the local store when its
+   * fetch fails, so a failed discovery can still hand back claims — and the pair would be landed on
+   * a tab built from whatever the store happened to hold. Only *discovery* failures. An error from
+   * the row lookups below is a tab that exists and could not draw, which `tabError` reports where
+   * the rows would be.
    */
-  const relatedOffered = relatedClaims.length > 0 || relatedClaimsSettling;
+  const relatedOffered = relatedDiscoveryError === null && (relatedClaims.length > 0 || relatedClaimsSettling);
 
   /**
    * Where the pair land, and it is not a fixed answer.

--- a/apps/web/core/claims/browse/claim-related-claims.tsx
+++ b/apps/web/core/claims/browse/claim-related-claims.tsx
@@ -4,7 +4,7 @@ import { keepPreviousData } from '@tanstack/react-query';
 
 import * as React from 'react';
 
-import { CLAIM_TYPE_ID, TOPICS_PROPERTY_ID } from '~/core/claims/ontology';
+import { relatedClaimsWhere } from '~/core/claims/related-claims';
 import type { DebateClaim } from '~/core/debates/api';
 import { sortClaimsByBest, useClaimsBestOrder } from '~/core/debates/claims-best-order';
 import { useDebateClaims } from '~/core/debates/hooks';
@@ -74,11 +74,9 @@ export function ClaimRelatedClaims({
     endCursor,
     hasNextPage,
   } = useQueryEntities({
-    where: {
-      types: [{ id: { equals: CLAIM_TYPE_ID } }],
-      spaces: [{ equals: spaceId }],
-      relations: [{ typeOf: { id: { equals: TOPICS_PROPERTY_ID } }, toEntity: { id: { in: topicIds } } }],
-    },
+    // Shared with the debate-again picker's Related claims source, so the two surfaces cannot
+    // drift into disagreeing about what "related" means (GEO-2758).
+    where: relatedClaimsWhere({ spaceId, topicIds }),
     first: RELATED_PAGE_SIZE,
     after: pages.cursor,
     orderBy: [EntitiesOrderBy.UpdatedAtDesc],

--- a/apps/web/core/claims/related-claims.ts
+++ b/apps/web/core/claims/related-claims.ts
@@ -1,0 +1,95 @@
+import { TAG_PROPERTY_ID } from '~/core/constants';
+import type { WhereCondition } from '~/core/sync/experimental_query-layer';
+
+import { CLAIM_TYPE_ID, TOPICS_PROPERTY_ID } from './ontology';
+
+/**
+ * What "related" means for a claim, in one place: another claim carrying at least one of this
+ * claim's topics *in this space* — topics are assigned per space, so the space is part of the
+ * relation rather than a filter applied beside it.
+ *
+ * Two surfaces ask the question — the gallery at the foot of a claim page, and the Related claims
+ * source in the debate-again picker (GEO-2758) — and a reader who sees a claim in one and not the
+ * other has no way to tell which is lying. The relation is a curator's, so the answer has to come
+ * from the same clause rather than from two hand-written notions of similarity that agree until
+ * one of them is edited.
+ *
+ * Deliberately not a similarity score. Topics are assigned in the knowledge graph, and reusing
+ * that assignment is the whole point: it keeps "related" something a curator decides rather than
+ * something each caller infers.
+ *
+ * The claim itself matches this clause — it carries its own topics — so it comes back in its own
+ * related list, and as the *only* row when it has no neighbours. Every caller must drop it, and
+ * before drawing any conclusion from how many rows came back: the picker counts them to decide
+ * whether to offer Related claims at all, so counting the claim itself makes "no neighbours" look
+ * like "one neighbour" (GEO-2758).
+ *
+ * Left to the caller rather than folded in here because the clause is also the shape the two
+ * surfaces are compared on, and because neither caller can pass an id the other would want
+ * excluded — the page has `claimId`, the picker has the source debate's.
+ *
+ * `topicIds` empty means there is nothing to be related *by*, and the clause would otherwise match
+ * no relation at all and quietly return the space's entire claim list. Callers must not run the
+ * query in that case; both gate on it.
+ */
+export function relatedClaimsWhere({
+  spaceId,
+  topicIds,
+  requireTagId,
+}: {
+  spaceId: string;
+  topicIds: string[];
+  /**
+   * Narrow further to claims carrying a `Tags` relation to this tag.
+   *
+   * The one place the two surfaces deliberately differ, and it is a difference in *purpose* rather
+   * than in what "related" means: the picker is asking which claim this pair should debate next,
+   * so it wants only the ones a curator has marked for debating. The claim page's gallery is a way
+   * out of the page and takes the whole relation.
+   *
+   * Passed rather than hard-coded here so the divergence is visible at the call site — a reader of
+   * the picker can see that its list is narrower without having to know this module's internals.
+   */
+  requireTagId?: string;
+}): WhereCondition {
+  return {
+    types: [{ id: { equals: CLAIM_TYPE_ID } }],
+    // Entity membership, which is the weaker of the two space tests here and is kept for what it
+    // says: the claim is named in this space at all. It is *not* what ties either relation below to
+    // this space — see the note on `space` there.
+    spaces: [{ equals: spaceId }],
+    relations: [
+      // Both relations carry `space`, because both are assigned per space and `spaces` above does
+      // not scope them. `tagged-claims.ts` learned this on the Debate tag and wrote down what it
+      // measured: filtering on the entity's space set returned claims tagged in one space for a
+      // space they merely also appeared in — four claims across three spaces, two of them in spaces
+      // the facet counted as holding none. Topics behave the same way, which is why the source
+      // claim's own topics are read through a space-scoped entity query rather than off an
+      // unfiltered projection.
+      //
+      // Without this, "related" meant "shares a topic *somewhere*", so a claim related only in
+      // another space was offered here — and, for the picker, offered as something to debate and
+      // publish into *this* space.
+      {
+        typeOf: { id: { equals: TOPICS_PROPERTY_ID } },
+        toEntity: { id: { in: topicIds } },
+        space: { equals: spaceId },
+      },
+      // Two relation conditions are ANDed, each satisfied by *some* relation — checked against
+      // both the local matcher (`matchesRelations`: `conditions.every(... relations.some(...))`)
+      // and the GraphQL converter (`filter.and` of `relations: { some }`), which agree. A `values`
+      // array does *not* agree across those two, so this is worth stating rather than assuming.
+      // `space` is honoured on both paths too: `cond.space` against `relation.spaceId` locally, and
+      // `filter.spaceId` once converted.
+      ...(requireTagId
+        ? [
+            {
+              typeOf: { id: { equals: TAG_PROPERTY_ID } },
+              toEntity: { id: { in: [requireTagId] } },
+              space: { equals: spaceId },
+            },
+          ]
+        : []),
+    ],
+  };
+}

--- a/apps/web/core/debates/claim-picker-page.test.ts
+++ b/apps/web/core/debates/claim-picker-page.test.ts
@@ -59,7 +59,11 @@ describe('fetchClaimPickerEntities', () => {
             { spaceId: 'space-b', propertyId: SystemIds.NAME_PROPERTY, text: null, boolean: null },
             null,
           ],
-          relationsList: [{ toEntity: { id: 'topic-1', name: 'Fashion' } }, { toEntity: null }, null],
+          relationsList: [
+            { spaceId: 'space-a', toEntity: { id: 'topic-1', name: 'Fashion' } },
+            { spaceId: 'space-b', toEntity: null },
+            null,
+          ],
         },
         null,
       ],
@@ -79,7 +83,12 @@ describe('fetchClaimPickerEntities', () => {
           { property: { id: CLAIM_IS_FACTUAL_PROPERTY_ID }, spaceId: 'space-a', value: '1' },
           { property: { id: CLAIM_IS_FACTUAL_PROPERTY_ID }, spaceId: 'space-b', value: '0' },
         ],
-        relations: [{ type: { id: TOPICS_PROPERTY_ID }, toEntity: { id: 'topic-1', name: 'Fashion' } }],
+        // The space the topic was assigned in is carried through, not dropped. Topics are per-space,
+        // so a caller scoped to one space cannot otherwise tell an assignment made there from one
+        // made somewhere else — which is what let another space's topic into the picker's facet.
+        relations: [
+          { type: { id: TOPICS_PROPERTY_ID }, spaceId: 'space-a', toEntity: { id: 'topic-1', name: 'Fashion' } },
+        ],
       },
     ]);
   });

--- a/apps/web/core/debates/claim-picker-page.ts
+++ b/apps/web/core/debates/claim-picker-page.ts
@@ -39,6 +39,10 @@ const CLAIM_PICKER_ENTITIES_SOURCE = /* GraphQL */ `
           boolean
         }
         relationsList(first: 100, filter: { typeId: { is: $topicsPropertyId } }) {
+          # Topics are assigned per space, so which space the assignment was made in is part of the
+          # answer rather than metadata about it. Without it a caller scoped to one space cannot tell
+          # a topic assigned there from one assigned somewhere else entirely.
+          spaceId
           toEntity {
             id
             name
@@ -62,7 +66,11 @@ type ClaimPickerEntitiesQuery = {
         text: string | null;
         boolean: boolean | null;
       } | null> | null;
-      relationsList: Array<{ toEntity: { id: string; name: string | null } | null } | null> | null;
+      // Nullable, as `tagged-claims.ts` also models it: a relation can carry no space.
+      relationsList: Array<{
+        spaceId: string | null;
+        toEntity: { id: string; name: string | null } | null;
+      } | null> | null;
     } | null> | null;
   } | null;
 };
@@ -86,7 +94,19 @@ export type ClaimPickerEntity = {
   description: string | null;
   spaces: string[];
   values: Array<{ isDeleted?: boolean; property: { id: string }; spaceId: string; value: string }>;
-  relations: Array<{ isDeleted?: boolean; type: { id: string }; toEntity: { id: string; name: string | null } }>;
+  relations: Array<{
+    isDeleted?: boolean;
+    type: { id: string };
+    /**
+     * The space the relation was written in.
+     *
+     * Optional so a full `Entity` still satisfies this, and nullable because the API models it that
+     * way — a relation can carry no space at all. Both mean the same thing to a caller: the space is
+     * not known, so it cannot be compared against one.
+     */
+    spaceId?: string | null;
+    toEntity: { id: string; name: string | null };
+  }>;
 };
 
 /** The graph caps `first` on `entitiesConnection`; ids are asked for in lists this long. */
@@ -111,7 +131,13 @@ function decodeClaimPickerEntities(data: ClaimPickerEntitiesQuery): ClaimPickerE
       }),
       relations: (node.relationsList ?? []).flatMap(relation =>
         relation?.toEntity
-          ? [{ type: { id: TOPICS_PROPERTY_ID }, toEntity: { id: relation.toEntity.id, name: relation.toEntity.name } }]
+          ? [
+              {
+                type: { id: TOPICS_PROPERTY_ID },
+                spaceId: relation.spaceId,
+                toEntity: { id: relation.toEntity.id, name: relation.toEntity.name },
+              },
+            ]
           : []
       ),
     });

--- a/apps/web/core/debates/matchmaking/hub-filter-menu.tsx
+++ b/apps/web/core/debates/matchmaking/hub-filter-menu.tsx
@@ -33,6 +33,12 @@ type Props<T extends string> = {
   showImages?: boolean;
   /** As {@link HubFilterOption.pending}, for the name in the trigger pill. */
   labelPending?: boolean;
+  /**
+   * What the skeleton in the trigger announces while `labelPending` holds. Defaults to the space
+   * menu's wording, which is what this component was built for; the Claims source menu waits on
+   * something else entirely and would otherwise tell a screen reader it was loading a space name.
+   */
+  labelPendingAnnouncement?: string;
 };
 
 /**
@@ -50,6 +56,7 @@ export function HubFilterMenu<T extends string>({
   onChange,
   showImages,
   labelPending,
+  labelPendingAnnouncement = 'Loading space name',
 }: Props<T>) {
   const [open, setOpen] = React.useState(false);
 
@@ -64,7 +71,7 @@ export function HubFilterMenu<T extends string>({
         <SmallButton icon={<ChevronDownSmall />} className="max-w-[160px]">
           {labelPending ? (
             // Sized to the pill's line box so the trigger doesn't resize when the name lands.
-            <Skeleton className="h-[1em] w-16" aria-label="Loading space name" />
+            <Skeleton className="h-[1em] w-16" aria-label={labelPendingAnnouncement} />
           ) : (
             <span className="truncate">{label}</span>
           )}

--- a/apps/web/core/debates/matchmaking/matches-list.tsx
+++ b/apps/web/core/debates/matchmaking/matches-list.tsx
@@ -159,7 +159,8 @@ export function MatchesList({
   );
   const passesTopics = React.useCallback(
     (match: MatchmakingMatch) =>
-      !topicsResolved || carriesEveryTopic(topicsFor(topicsByClaimId, match.claim.claim_entity_id), topicIds),
+      !topicsResolved ||
+      carriesEveryTopic(topicsFor(topicsByClaimId, match.claim.claim_entity_id, match.claim.space_id), topicIds),
     [topicIds, topicsByClaimId, topicsResolved]
   );
   const passesSearch = React.useCallback(
@@ -209,7 +210,7 @@ export function MatchesList({
           countBy(
             matches
               .filter(match => passesSpace(match) && passesSearch(match) && passesTopics(match))
-              .flatMap(match => topicsFor(topicsByClaimId, match.claim.claim_entity_id) ?? [])
+              .flatMap(match => topicsFor(topicsByClaimId, match.claim.claim_entity_id, match.claim.space_id) ?? [])
           ),
           topicIds
         ),

--- a/apps/web/core/debates/matchmaking/matches-list.tsx
+++ b/apps/web/core/debates/matchmaking/matches-list.tsx
@@ -23,6 +23,7 @@ import {
   keepSelectedVisible,
   orderFacetOptions,
   toggleId,
+  topicsFor,
 } from './topic-facets';
 import { useDebouncedSearch } from './use-debounced-search';
 import { useSpaceFilterMenu } from './use-space-filter-selection';
@@ -158,7 +159,7 @@ export function MatchesList({
   );
   const passesTopics = React.useCallback(
     (match: MatchmakingMatch) =>
-      !topicsResolved || carriesEveryTopic(topicsByClaimId.get(match.claim.claim_entity_id), topicIds),
+      !topicsResolved || carriesEveryTopic(topicsFor(topicsByClaimId, match.claim.claim_entity_id), topicIds),
     [topicIds, topicsByClaimId, topicsResolved]
   );
   const passesSearch = React.useCallback(
@@ -208,7 +209,7 @@ export function MatchesList({
           countBy(
             matches
               .filter(match => passesSpace(match) && passesSearch(match) && passesTopics(match))
-              .flatMap(match => topicsByClaimId.get(match.claim.claim_entity_id) ?? [])
+              .flatMap(match => topicsFor(topicsByClaimId, match.claim.claim_entity_id) ?? [])
           ),
           topicIds
         ),

--- a/apps/web/core/debates/matchmaking/topic-facets.test.ts
+++ b/apps/web/core/debates/matchmaking/topic-facets.test.ts
@@ -12,6 +12,7 @@ import {
   keepSelectableTopics,
   keepSelectedVisible,
   orderFacetOptions,
+  topicsFor,
 } from './topic-facets';
 
 const ai: MatchmakingTopic = { id: 'topic-ai', name: 'AI' };
@@ -42,7 +43,7 @@ describe('claimTopicsById', () => {
   it('keys each claim entity by id, carrying the topics it points at', () => {
     const map = claimTopicsById([entity('claim-1', [{ topicId: 'topic-ai', name: 'AI' }])]);
 
-    expect(map.get('claim-1')).toEqual([ai]);
+    expect(topicsFor(map, 'claim-1')).toEqual([ai]);
   });
 
   // The rule the three call sites were each spelling out: a relation of another type is not a
@@ -56,22 +57,35 @@ describe('claimTopicsById', () => {
       ]),
     ]);
 
-    expect(map.get('claim-1')).toEqual([ai]);
+    expect(topicsFor(map, 'claim-1')).toEqual([ai]);
   });
 
-  // So `get(id) ?? []` and `carriesEveryTopic(get(id), …)` read "none" the same way whether the
-  // claim was looked up and carries nothing or was never looked up at all.
+  // So `topicsFor(map, id) ?? []` and `carriesEveryTopic(topicsFor(map, id), …)` read "none" the
+  // same way whether the claim was looked up and carries nothing or was never looked up at all.
   it('leaves out a claim carrying no topics rather than mapping it to an empty list', () => {
     const map = claimTopicsById([entity('claim-1', []), entity('claim-2', [{ topicId: 'topic-ai', name: 'AI' }])]);
 
-    expect(map.has('claim-1')).toBe(false);
-    expect([...map.keys()]).toEqual(['claim-2']);
+    expect(topicsFor(map, 'claim-1')).toBeUndefined();
+    expect(topicsFor(map, 'claim-2')).toEqual([ai]);
+    expect(map.size).toBe(1);
+  });
+
+  /**
+   * The keys are graph entity ids — bare hex — and every caller looks them up by the
+   * `claim_entity_id` on a geo-chat row, which is a hyphenated UUID for the same claim. A raw `get`
+   * across that boundary answers "no topics", and nothing about that reads as a failure: the claim
+   * simply loses its labels, leaves the facet, and vanishes the moment a topic is picked.
+   */
+  it('answers for a geo-chat spelling of the same claim', () => {
+    const map = claimTopicsById([entity('a1b2c3d4e5f6478899aabbccddeeff00', [{ topicId: 'topic-ai', name: 'AI' }])]);
+
+    expect(topicsFor(map, 'a1b2c3d4-e5f6-4788-99aa-bbccddeeff00')).toEqual([ai]);
   });
 
   it('carries an unnamed topic as null rather than dropping it', () => {
     const map = claimTopicsById([entity('claim-1', [{ topicId: 'topic-unnamed' }])]);
 
-    expect(map.get('claim-1')).toEqual([unnamed]);
+    expect(topicsFor(map, 'claim-1')).toEqual([unnamed]);
   });
 });
 

--- a/apps/web/core/debates/matchmaking/topic-facets.test.ts
+++ b/apps/web/core/debates/matchmaking/topic-facets.test.ts
@@ -117,6 +117,36 @@ describe('claimTopicsById', () => {
   });
 
   /**
+   * Callers hand this several projections of the same pool and a claim can be in more than one. The
+   * rematch picker appends its tagged catalog last, and that projection does not select relation
+   * spaces — so a Debate-tagged claim also reached by id had its spaces replaced by a projection
+   * that never asked for them, and the space filter went back to keeping everything.
+   */
+  it('keeps the spaces a second projection of the same claim never asked for', () => {
+    const map = claimTopicsById([
+      // The by-id projection, which knows where each topic was assigned.
+      {
+        id: 'claim-1',
+        relations: [
+          { type: { id: TOPICS_PROPERTY_ID }, spaceId: 'space-here', toEntity: { id: 'topic-ai', name: 'AI' } },
+          {
+            type: { id: TOPICS_PROPERTY_ID },
+            spaceId: 'space-elsewhere',
+            toEntity: { id: 'topic-health', name: 'Health' },
+          },
+        ],
+      },
+      // The tagged catalog, carrying the same claim with no spaces at all.
+      entity('claim-1', [
+        { topicId: 'topic-ai', name: 'AI' },
+        { topicId: 'topic-health', name: 'Health' },
+      ]),
+    ]);
+
+    expect(topicsFor(map, 'claim-1', 'space-here')).toEqual([ai]);
+  });
+
+  /**
    * Not every projection selects the relation's space — the tagged catalog does not — and an unknown
    * space cannot be compared to one. Dropping those would empty the facet for a whole source rather
    * than narrow it, which is a worse answer than a slightly wide one.

--- a/apps/web/core/debates/matchmaking/topic-facets.test.ts
+++ b/apps/web/core/debates/matchmaking/topic-facets.test.ts
@@ -8,6 +8,7 @@ import {
   availableTopics,
   carriesEveryTopic,
   claimTopicsById,
+  countBy,
   formatFacetCount,
   keepSelectableTopic,
   keepSelectableTopics,
@@ -147,6 +148,29 @@ describe('claimTopicsById', () => {
   });
 
   /**
+   * The preference is between two copies of the *same* topic. Asked of the whole claim, one
+   * space-aware relation discarded every unknown-space relation beside it — so a topic that only
+   * one projection knew about disappeared rather than being kept unscoped, which is a deletion
+   * dressed up as a narrowing.
+   */
+  it('keeps an unknown-space topic that no projection knew a space for', () => {
+    const map = claimTopicsById([
+      {
+        id: 'claim-1',
+        relations: [
+          { type: { id: TOPICS_PROPERTY_ID }, spaceId: 'space-here', toEntity: { id: 'topic-ai', name: 'AI' } },
+          // No space, and no other projection supplies one for this topic.
+          { type: { id: TOPICS_PROPERTY_ID }, toEntity: { id: 'topic-health', name: 'Health' } },
+        ],
+      },
+    ]);
+
+    expect(topicsFor(map, 'claim-1', 'space-here')).toEqual([ai, health]);
+    // And elsewhere it keeps only the one nothing was claimed about.
+    expect(topicsFor(map, 'claim-1', 'space-elsewhere')).toEqual([health]);
+  });
+
+  /**
    * Not every projection selects the relation's space — the tagged catalog does not — and an unknown
    * space cannot be compared to one. Dropping those would empty the facet for a whole source rather
    * than narrow it, which is a worse answer than a slightly wide one.
@@ -161,6 +185,26 @@ describe('claimTopicsById', () => {
     const map = claimTopicsById([entity('claim-1', [{ topicId: 'topic-unnamed' }])]);
 
     expect(topicsFor(map, 'claim-1')).toEqual([unnamed]);
+  });
+});
+
+describe('countBy', () => {
+  /**
+   * These entries are built from row ids, and a row carries whichever spelling its source used —
+   * so one space reached through a geo-chat row and a graph-built one was counted as two, and the
+   * menu offered the same space twice with its rows split between the entries.
+   */
+  it('buckets two spellings of the same id together', () => {
+    const counted = countBy([
+      { id: '019fedae-72b6-7ab2-927a-df044d57c566', name: 'Crypto' },
+      { id: '019fedae72b67ab2927adf044d57c566', name: null },
+    ]);
+
+    expect(counted).toHaveLength(1);
+    expect(counted[0]!.count).toBe(2);
+    // The first real spelling is kept, and a name arriving with the second entry is not lost.
+    expect(counted[0]!.id).toBe('019fedae-72b6-7ab2-927a-df044d57c566');
+    expect(counted[0]!.name).toBe('Crypto');
   });
 });
 

--- a/apps/web/core/debates/matchmaking/topic-facets.test.ts
+++ b/apps/web/core/debates/matchmaking/topic-facets.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import { TOPICS_PROPERTY_ID } from '~/core/claims/ontology';
 import type { MatchmakingTopic } from '~/core/debates/api';
+import { normId } from '~/core/utils/norm-id';
 
 import {
   availableTopics,
@@ -19,12 +20,18 @@ const ai: MatchmakingTopic = { id: 'topic-ai', name: 'AI' };
 const health: MatchmakingTopic = { id: 'topic-health', name: 'Health' };
 const unnamed: MatchmakingTopic = { id: 'topic-unnamed', name: null };
 
-const topicsByClaimId = new Map<string, MatchmakingTopic[]>([
-  ['claim-in-crypto', [ai]],
-  ['claim-in-health', [health]],
-  ['claim-in-both', [ai, health]],
-  ['claim-unnamed-topic', [unnamed]],
-]);
+// Keyed as `claimTopicsById` keys it, and carrying the relation's space as it does — `null` here,
+// which is "unknown" and so never narrows.
+const topicsByClaimId = new Map<string, Array<MatchmakingTopic & { spaceId: string | null }>>(
+  (
+    [
+      ['claim-in-crypto', [ai]],
+      ['claim-in-health', [health]],
+      ['claim-in-both', [ai, health]],
+      ['claim-unnamed-topic', [unnamed]],
+    ] as const
+  ).map(([claimId, topics]) => [normId(claimId), topics.map(topic => ({ ...topic, spaceId: null }))])
+);
 
 describe('claimTopicsById', () => {
   const TYPE_PROPERTY = '8f151ba4de204e3c9cb499ddf96f48f1';
@@ -80,6 +87,44 @@ describe('claimTopicsById', () => {
     const map = claimTopicsById([entity('a1b2c3d4e5f6478899aabbccddeeff00', [{ topicId: 'topic-ai', name: 'AI' }])]);
 
     expect(topicsFor(map, 'a1b2c3d4-e5f6-4788-99aa-bbccddeeff00')).toEqual([ai]);
+  });
+
+  /**
+   * Topics are assigned per space and a card is always drawn under one, so a topic the claim carries
+   * in another space is not one it carries here. Shown anyway, it went into the facet beside the
+   * card and picking it filtered the card in or out on something that is not true where the debate
+   * would be published — the query side of this is what `relatedClaimsWhere` scopes.
+   */
+  it('answers only for the space the card is drawn under', () => {
+    const map = claimTopicsById([
+      {
+        id: 'claim-1',
+        relations: [
+          { type: { id: TOPICS_PROPERTY_ID }, spaceId: 'space-here', toEntity: { id: 'topic-ai', name: 'AI' } },
+          {
+            type: { id: TOPICS_PROPERTY_ID },
+            spaceId: 'space-elsewhere',
+            toEntity: { id: 'topic-health', name: 'Health' },
+          },
+        ],
+      },
+    ]);
+
+    expect(topicsFor(map, 'claim-1', 'space-here')).toEqual([ai]);
+    expect(topicsFor(map, 'claim-1', 'space-elsewhere')).toEqual([health]);
+    // No space asked about is no narrowing, which is what the facets do when they have none.
+    expect(topicsFor(map, 'claim-1')).toEqual([ai, health]);
+  });
+
+  /**
+   * Not every projection selects the relation's space — the tagged catalog does not — and an unknown
+   * space cannot be compared to one. Dropping those would empty the facet for a whole source rather
+   * than narrow it, which is a worse answer than a slightly wide one.
+   */
+  it('keeps a topic whose space it was never told', () => {
+    const map = claimTopicsById([entity('claim-1', [{ topicId: 'topic-ai', name: 'AI' }])]);
+
+    expect(topicsFor(map, 'claim-1', 'space-here')).toEqual([ai]);
   });
 
   it('carries an unnamed topic as null rather than dropping it', () => {

--- a/apps/web/core/debates/matchmaking/topic-facets.ts
+++ b/apps/web/core/debates/matchmaking/topic-facets.ts
@@ -65,10 +65,14 @@ export function claimTopicsById(
  * scoping for that claim.
  */
 function preferKnownSpaces(topics: SpacedTopic[]): SpacedTopic[] {
-  const known = topics.some(topic => topic.spaceId !== null);
+  // Per topic, not per claim. Asked of the whole claim, one space-aware relation discarded every
+  // unknown-space relation beside it — so a claim whose AI topic came back with a space and whose
+  // Health topic did not lost Health entirely, which is not a narrowing, it is a deletion. The rule
+  // is only ever about two copies of the *same* topic.
+  const known = new Set(topics.filter(topic => topic.spaceId !== null).map(topic => normId(topic.id)));
   const byIdentity = new Map<string, SpacedTopic>();
   for (const topic of topics) {
-    if (known && topic.spaceId === null) continue;
+    if (topic.spaceId === null && known.has(normId(topic.id))) continue;
     byIdentity.set(`${normId(topic.id)}:${topic.spaceId === null ? '' : normId(topic.spaceId)}`, topic);
   }
   return [...byIdentity.values()];
@@ -226,7 +230,13 @@ export function orderFacetOptions<T extends { id: string; count: number }>(optio
  * picked in is at least the viewer's own.
  */
 export function toggleId(selected: string[], id: string): string[] {
-  return selected.includes(id) ? selected.filter(entry => entry !== id) : [...selected, id];
+  // Compared canonically: a space id reaches the menu in whichever spelling its rows carried, so
+  // unticking could otherwise add a second spelling of a space that was already picked instead of
+  // removing it.
+  const key = normId(id);
+  return selected.some(entry => normId(entry) === key)
+    ? selected.filter(entry => normId(entry) !== key)
+    : [...selected, id];
 }
 
 /**
@@ -257,15 +267,28 @@ export function mergeFacetCounts(
   return [...merged.values()];
 }
 
-/** Counts how many of `values` fall into each bucket, as facet options. */
+/**
+ * Counts how many of `values` fall into each bucket, as facet options.
+ *
+ * Bucketed canonically while keeping the first real spelling seen, the same way the picker's
+ * gateway scopes are. These entries are built from row ids, and a row carries whichever spelling
+ * its source used — so the same space reached through a geo-chat row and a graph-built one counted
+ * as two, and the menu offered one space twice with its rows split between them.
+ */
 export function countBy(
   entries: { id: string; name: string | null }[]
 ): { id: string; name: string | null; count: number }[] {
   const counts = new Map<string, { id: string; name: string | null; count: number }>();
   for (const entry of entries) {
-    const existing = counts.get(entry.id);
-    if (existing) existing.count += 1;
-    else counts.set(entry.id, { id: entry.id, name: entry.name, count: 1 });
+    const key = normId(entry.id);
+    const existing = counts.get(key);
+    if (existing) {
+      existing.count += 1;
+      // A later entry can be the one that carries the name.
+      if (existing.name === null && entry.name !== null) existing.name = entry.name;
+    } else {
+      counts.set(key, { id: entry.id, name: entry.name, count: 1 });
+    }
   }
   return [...counts.values()];
 }
@@ -289,8 +312,11 @@ export function keepSelectedVisible<T extends { id: string; name: string | null;
   options: T[],
   selected: string[]
 ): (T | { id: string; name: string | null; count: number })[] {
-  const present = new Set(options.map(option => option.id));
-  const missing = selected.filter(id => !present.has(id)).map(id => ({ id, name: null, count: 0 }));
+  // Canonically, because an option's id comes from a row and a selection comes from whatever the
+  // menu offered when it was picked — two spellings of one space would put it back at zero *beside*
+  // its real entry, which is the duplicate this exists to prevent.
+  const present = new Set(options.map(option => normId(option.id)));
+  const missing = selected.filter(id => !present.has(normId(id))).map(id => ({ id, name: null, count: 0 }));
   return missing.length === 0 ? options : [...options, ...missing];
 }
 

--- a/apps/web/core/debates/matchmaking/topic-facets.ts
+++ b/apps/web/core/debates/matchmaking/topic-facets.ts
@@ -40,10 +40,38 @@ export function claimTopicsById(
         name: relation.toEntity.name ?? null,
         spaceId: relation.spaceId ?? null,
       }));
-    if (topics.length > 0) map.set(normId(entity.id), topics);
+    if (topics.length === 0) continue;
+
+    // Merged rather than overwritten. Callers hand this several projections of the same pool, and a
+    // claim in two of them arrived twice — where the last one won, whatever it knew. In the rematch
+    // picker the tagged catalog comes last and does not select relation spaces, so a Debate-tagged
+    // claim also reached by id lost its spaces to a projection that never asked for them, and the
+    // per-space filter below went back to keeping everything.
+    const merged = [...(map.get(normId(entity.id)) ?? []), ...topics];
+    map.set(normId(entity.id), preferKnownSpaces(merged));
   }
 
   return map;
+}
+
+/**
+ * One entry per topic-and-space, and — where any projection knew the spaces — only the ones that
+ * did.
+ *
+ * An unknown space is kept when it is all there is, because it cannot be compared to anything and
+ * dropping it would empty a source's facet. But once *some* projection has reported real spaces for
+ * a claim, an unknown-space copy of the same topic is not extra information, it is the same topic
+ * seen by a query that did not ask — and keeping it would slip past the space filter and undo the
+ * scoping for that claim.
+ */
+function preferKnownSpaces(topics: SpacedTopic[]): SpacedTopic[] {
+  const known = topics.some(topic => topic.spaceId !== null);
+  const byIdentity = new Map<string, SpacedTopic>();
+  for (const topic of topics) {
+    if (known && topic.spaceId === null) continue;
+    byIdentity.set(`${normId(topic.id)}:${topic.spaceId === null ? '' : normId(topic.spaceId)}`, topic);
+  }
+  return [...byIdentity.values()];
 }
 
 /**

--- a/apps/web/core/debates/matchmaking/topic-facets.ts
+++ b/apps/web/core/debates/matchmaking/topic-facets.ts
@@ -4,6 +4,13 @@ import type { ClaimPickerEntity } from '~/core/debates/claim-picker-page';
 import { normId } from '~/core/utils/norm-id';
 
 /**
+ * A topic and the space its relation was written in, which is how the graph records it: the same
+ * claim can carry different topics in different spaces. `null` where the projection did not select
+ * the space — unknown rather than unscoped.
+ */
+type SpacedTopic = MatchmakingTopic & { spaceId: string | null };
+
+/**
  * The topics each claim entity carries, keyed by claim id.
  *
  * The graph is the only source for these. geo-chat fills `topics: []` on every matchmaking and
@@ -22,13 +29,17 @@ import { normId } from '~/core/utils/norm-id';
  */
 export function claimTopicsById(
   entities: Iterable<Pick<ClaimPickerEntity, 'id' | 'relations'>>
-): Map<string, MatchmakingTopic[]> {
-  const map = new Map<string, MatchmakingTopic[]>();
+): Map<string, SpacedTopic[]> {
+  const map = new Map<string, SpacedTopic[]>();
 
   for (const entity of entities) {
     const topics = entity.relations
       .filter(relation => relation.type.id === TOPICS_PROPERTY_ID && relation.isDeleted !== true)
-      .map(relation => ({ id: relation.toEntity.id, name: relation.toEntity.name ?? null }));
+      .map(relation => ({
+        id: relation.toEntity.id,
+        name: relation.toEntity.name ?? null,
+        spaceId: relation.spaceId ?? null,
+      }));
     if (topics.length > 0) map.set(normId(entity.id), topics);
   }
 
@@ -36,16 +47,31 @@ export function claimTopicsById(
 }
 
 /**
- * The topics recorded for a claim, whichever spelling of its id the caller holds.
+ * The topics recorded for a claim, whichever spelling of its id the caller holds — and, given a
+ * space, only the ones assigned *in* it.
  *
  * Exists so no caller reaches into the map directly: the normalization has to happen on both sides
  * of the lookup to be worth anything, and a `get` that skipped it would fail silently.
+ *
+ * Topics are assigned per space, and a card is always drawn under one space. Without the filter a
+ * topic assigned only somewhere else was shown on the card and put in the facet beside it, so
+ * picking it filtered the card in or out on something that is not true where the debate would be
+ * published — the same mistake `relatedClaimsWhere` exists to avoid on the query side.
+ *
+ * A topic whose space is unknown is kept rather than dropped. Not every projection selects the
+ * relation's space (the tagged catalog does not), and an unknown space cannot be compared to one —
+ * dropping it would empty the facet for a whole source rather than narrow it.
  */
 export function topicsFor(
-  topicsByClaimId: ReadonlyMap<string, MatchmakingTopic[]>,
-  claimEntityId: string
+  topicsByClaimId: ReadonlyMap<string, SpacedTopic[]>,
+  claimEntityId: string,
+  spaceId?: string | null
 ): MatchmakingTopic[] | undefined {
-  return topicsByClaimId.get(normId(claimEntityId));
+  const topics = topicsByClaimId.get(normId(claimEntityId));
+  if (!topics) return undefined;
+  return topics
+    .filter(topic => spaceId == null || topic.spaceId == null || normId(topic.spaceId) === normId(spaceId))
+    .map(topic => ({ id: topic.id, name: topic.name }));
 }
 
 /**
@@ -67,11 +93,11 @@ export function topicsFor(
  */
 export function availableTopics(
   claimEntityIds: Iterable<string>,
-  topicsByClaimId: ReadonlyMap<string, MatchmakingTopic[]>
+  topicsByClaimId: ReadonlyMap<string, SpacedTopic[]>
 ): MatchmakingTopic[] {
   const seen = new Map<string, MatchmakingTopic>();
   for (const claimEntityId of claimEntityIds) {
-    for (const topic of topicsByClaimId.get(claimEntityId) ?? []) {
+    for (const topic of topicsFor(topicsByClaimId, claimEntityId) ?? []) {
       if (!seen.has(topic.id)) seen.set(topic.id, topic);
     }
   }

--- a/apps/web/core/debates/matchmaking/topic-facets.ts
+++ b/apps/web/core/debates/matchmaking/topic-facets.ts
@@ -1,6 +1,7 @@
 import { TOPICS_PROPERTY_ID } from '~/core/claims/ontology';
 import type { MatchmakingTopic } from '~/core/debates/api';
 import type { ClaimPickerEntity } from '~/core/debates/claim-picker-page';
+import { normId } from '~/core/utils/norm-id';
 
 /**
  * The topics each claim entity carries, keyed by claim id.
@@ -10,8 +11,14 @@ import type { ClaimPickerEntity } from '~/core/debates/claim-picker-page';
  * a list built from its rows resolves them from the entity or not at all — reading that empty array
  * the other way round is what emptied the list in GEO-2714.
  *
- * A claim carrying none is left out rather than mapped to an empty array, so `get(id) ?? []` and
+ * A claim carrying none is left out rather than mapped to an empty array, so {@link topicsFor} and
  * {@link carriesEveryTopic} both read "none" the same way whether the claim was looked up or not.
+ *
+ * Keyed canonically, and read back through {@link topicsFor} rather than `get`. The keys are graph
+ * entity ids — bare hex — while every caller looks these up by the `claim_entity_id` on a geo-chat
+ * row, which is a UUID and may carry hyphens. A raw `get` across that boundary silently answers
+ * "no topics", which is not an absence anyone can see: the claim just quietly loses its topic
+ * labels, drops out of the facet, and disappears from the list the moment a topic is picked.
  */
 export function claimTopicsById(
   entities: Iterable<Pick<ClaimPickerEntity, 'id' | 'relations'>>
@@ -22,10 +29,23 @@ export function claimTopicsById(
     const topics = entity.relations
       .filter(relation => relation.type.id === TOPICS_PROPERTY_ID && relation.isDeleted !== true)
       .map(relation => ({ id: relation.toEntity.id, name: relation.toEntity.name ?? null }));
-    if (topics.length > 0) map.set(entity.id, topics);
+    if (topics.length > 0) map.set(normId(entity.id), topics);
   }
 
   return map;
+}
+
+/**
+ * The topics recorded for a claim, whichever spelling of its id the caller holds.
+ *
+ * Exists so no caller reaches into the map directly: the normalization has to happen on both sides
+ * of the lookup to be worth anything, and a `get` that skipped it would fail silently.
+ */
+export function topicsFor(
+  topicsByClaimId: ReadonlyMap<string, MatchmakingTopic[]>,
+  claimEntityId: string
+): MatchmakingTopic[] | undefined {
+  return topicsByClaimId.get(normId(claimEntityId));
 }
 
 /**

--- a/apps/web/core/debates/ontology.ts
+++ b/apps/web/core/debates/ontology.ts
@@ -19,6 +19,10 @@ export const DEBATE_TYPE_ID = 'fd51f93520634617be397b672b23364c';
  * Curation rather than a property on the claim, which is what lets the debates surfaces ask the
  * graph for their whole corpus in one query: a few hundred tagged claims out of three hundred
  * thousand, so the tag is what gets asked for and the claims come back with it.
+ *
+ * It also narrows the debate-again picker's Related claims source, which offers a claim as
+ * something to debate next. The claim page's Related claims gallery is deliberately *not* narrowed
+ * by it — that gallery is a way out of the page rather than an invitation to a debate (GEO-2758).
  */
 export const DEBATE_TAG_ID = '55c95b2626f8482cb9739ea99dfde438';
 

--- a/apps/web/core/debates/use-debate-publishable-spaces.ts
+++ b/apps/web/core/debates/use-debate-publishable-spaces.ts
@@ -18,12 +18,17 @@ import { normId } from '~/core/utils/norm-id';
  * "don't filter on this", never as "nothing is publishable"; the alternative empties every list in
  * the picker on a transient error, and local environments run with no acceptor at all.
  */
-export function useDebatePublishableSpaces(): {
+export function useDebatePublishableSpaces({ enabled = true }: { enabled?: boolean } = {}): {
   /** Normalized space ids, or null while unknown. */
   publishableSpaceIds: Set<string> | null;
   isLoading: boolean;
 } {
   const { data, isLoading } = useQuery({
+    // Hooks cannot be mounted conditionally, so a caller that only *might* need this answer says so
+    // here. The debate room asks for related claims from the moment a debate is under way and not
+    // before — a preflight that times out is a debate that never happened — and without this the
+    // request went out anyway, since a disabled caller still runs every hook it calls.
+    enabled,
     queryKey: ['debates', 'publishable-spaces'],
     queryFn: async (): Promise<string[] | null> => {
       const response = await fetch('/api/debates/publishable-spaces');
@@ -45,12 +50,11 @@ export function useDebatePublishableSpaces(): {
     retryDelay: attempt => Math.min(1_000 * 2 ** attempt, 5_000),
   });
 
-  const publishableSpaceIds = React.useMemo(
-    () => (data ? new Set(data.map(normId)) : null),
-    [data]
-  );
+  const publishableSpaceIds = React.useMemo(() => (data ? new Set(data.map(normId)) : null), [data]);
 
-  return { publishableSpaceIds, isLoading };
+  // Nothing asked for is nothing in flight: react-query reports a disabled query as pending, and a
+  // caller gating a loading state on this would wait on a request that is never made.
+  return { publishableSpaceIds, isLoading: enabled && isLoading };
 }
 
 /**

--- a/apps/web/core/debates/use-related-debate-claims.ts
+++ b/apps/web/core/debates/use-related-debate-claims.ts
@@ -24,8 +24,8 @@ const RELATED_DROPPED_ROW_SLACK = 8;
  *
  * A cap rather than "until the server runs out": each step is a request, and a topic whose claims
  * are mostly unnamed would spend an unbounded number of them to populate a tab nobody asked for.
- * Four windows is 132 rows deep, past which "no neighbours left to argue" is the honest answer even
- * if one is hiding further down.
+ * Four *further* windows on top of the first is five requests and 165 rows, past which "no
+ * neighbours left to argue" is the honest answer even if one is hiding further down.
  */
 const RELATED_MAX_EXTRA_WINDOWS = 4;
 
@@ -81,7 +81,7 @@ export function useRelatedDebateClaims({
   // as "don't filter" — see that hook. Discovery fails open for the same reason its other callers
   // do: a list that briefly offers a space the reconciliation goes on to remove is better than a
   // list that waits on it.
-  const { publishableSpaceIds, isLoading: publishableSpacesLoading } = useDebatePublishableSpaces();
+  const { publishableSpaceIds, isLoading: publishableSpacesLoading } = useDebatePublishableSpaces({ enabled });
 
   /**
    * Topics live on the graph entity rather than geo-chat's claim summary, and they are assigned *per
@@ -95,7 +95,12 @@ export function useRelatedDebateClaims({
   const sourceQuery = useQueryEntity({
     id: claimId ?? '',
     spaceId: spaceId ?? undefined,
-    enabled: enabled && claimId !== null,
+    // The space is required, not merely used: this hook allows a claim summary that carries no
+    // space, and hydrating one unscoped asks a question whose answer can never be used — the topics
+    // would come from every space at once, and `discoverable` below can never be true without a
+    // space anyway. Reported as loading, it reserved a Related tab that was always going to vanish
+    // when the pointless hydration finished. If the space arrives later, this enables then.
+    enabled: enabled && claimId !== null && spaceId !== null,
   });
 
   const topicIds = React.useMemo(() => {

--- a/apps/web/core/debates/use-related-debate-claims.ts
+++ b/apps/web/core/debates/use-related-debate-claims.ts
@@ -19,6 +19,16 @@ export const RELATED_CLAIMS_LIMIT = 25;
  */
 const RELATED_DROPPED_ROW_SLACK = 8;
 
+/**
+ * How many further windows discovery will walk when a whole one turns out to be undrawable.
+ *
+ * A cap rather than "until the server runs out": each step is a request, and a topic whose claims
+ * are mostly unnamed would spend an unbounded number of them to populate a tab nobody asked for.
+ * Four windows is 132 rows deep, past which "no neighbours left to argue" is the honest answer even
+ * if one is hiding further down.
+ */
+const RELATED_MAX_EXTRA_WINDOWS = 4;
+
 /** Stable empty list, so a skipped discovery is not a new array each render. */
 const NO_RELATED_IDS: string[] = [];
 
@@ -108,7 +118,26 @@ export function useRelatedDebateClaims({
     topicIds.length > 0 &&
     isSpaceDebatePublishable(spaceId, publishableSpaceIds);
 
+  /**
+   * Where discovery has walked to, and how far.
+   *
+   * A window can come back entirely undrawable — the debated claim is in its own related list, and
+   * neighbours whose names have not indexed cannot be drawn — and the count decides whether the tab
+   * exists. Treating that window as the whole answer hid the tab from a claim that does have
+   * neighbours, a page further down. The claim page's gallery skips forward on exactly this data
+   * (`claim-related-claims.tsx`), so a tab that gave up where the gallery does not would have been
+   * two surfaces disagreeing about the same claim.
+   */
+  const [walked, setWalked] = React.useState<{ cursor: string; windows: number } | null>(null);
+
+  // Back to the first window whenever the question changes; a cursor from the previous claim's
+  // result set anchors nothing in this one.
+  React.useEffect(() => {
+    setWalked(null);
+  }, [claimId, spaceId]);
+
   const entitiesQuery = useQueryEntities({
+    after: walked?.cursor,
     where: relatedClaimsWhere({
       spaceId: spaceId ?? '',
       topicIds,
@@ -149,13 +178,42 @@ export function useRelatedDebateClaims({
     [queryEnabled, entitiesQuery.entities, claimId]
   );
 
+  /**
+   * Whether this window answered nothing and there is another to try.
+   *
+   * Only while the window is empty: one drawable neighbour is enough for the tab to exist, and
+   * walking on to fill the list would spend requests to lengthen a list most pairs take the first
+   * row of.
+   */
+  const walking =
+    queryEnabled &&
+    !entitiesQuery.isLoading &&
+    claimIds.length === 0 &&
+    entitiesQuery.hasNextPage &&
+    entitiesQuery.endCursor !== null &&
+    (walked?.windows ?? 0) < RELATED_MAX_EXTRA_WINDOWS;
+
+  React.useEffect(() => {
+    if (!walking) return;
+    const cursor = entitiesQuery.endCursor;
+    if (cursor === null) return;
+    // Guarded on the cursor rather than set outright: this effect re-runs while the next window is
+    // in flight, and re-setting the same anchor would be a render loop rather than a step.
+    setWalked(current => (current?.cursor === cursor ? current : { cursor, windows: (current?.windows ?? 0) + 1 }));
+  }, [walking, entitiesQuery.endCursor]);
+
   return {
     claimIds,
     spaceId,
     enabled: queryEnabled,
     // Both lookups, reported together, so a caller cannot gate on a different subset than it reads —
     // the mistake that let one gate pass while the other was still waiting.
-    isLoading: sourceQuery.isLoading || entitiesQuery.isLoading,
+    //
+    // A walk to the next window counts as loading: the count is not final until it stops, and a
+    // caller that read "empty, settled" between two windows would drop the tab and then bring it
+    // back. Not covered by a test — `render` flushes the whole walk inside one `act`, so every
+    // assertion lands after it, and an assertion that cannot see the gap would pass without it.
+    isLoading: sourceQuery.isLoading || entitiesQuery.isLoading || walking,
     error: sourceQuery.error ?? entitiesQuery.error ?? null,
   };
 }

--- a/apps/web/core/debates/use-related-debate-claims.ts
+++ b/apps/web/core/debates/use-related-debate-claims.ts
@@ -111,12 +111,16 @@ export function useRelatedDebateClaims({
    * quietly return the space's entire claim list. Skipped too when the claim's own space cannot
    * carry a published debate: every row is drawn in that space, so there is nothing to ask for.
    */
-  const queryEnabled =
-    enabled &&
-    claimId !== null &&
-    spaceId !== null &&
-    topicIds.length > 0 &&
-    isSpaceDebatePublishable(spaceId, publishableSpaceIds);
+  /**
+   * Whether there is anything to discover at all — a claim, its space, and something to be related
+   * *by*. Separate from {@link queryEnabled} because the allowlist below is the one input that can
+   * still be in flight when the answer is already no, and reporting that as pending invented a tab
+   * on a session that could never have one: a profile-challenge rematch has no debated claim, but
+   * the allowlist is a page-wide request that is in flight regardless.
+   */
+  const discoverable = enabled && claimId !== null && spaceId !== null && topicIds.length > 0;
+
+  const queryEnabled = discoverable && isSpaceDebatePublishable(spaceId ?? '', publishableSpaceIds);
 
   /**
    * Where discovery has walked to, and how far.
@@ -223,12 +227,15 @@ export function useRelatedDebateClaims({
     // caller that read "empty, settled" between two windows would drop the tab and then bring it
     // back. Not covered by a test — `render` flushes the whole walk inside one `act`, so every
     // assertion lands after it, and an assertion that cannot see the gap would pass without it.
-    // The allowlist counts too. It fails open — a null set reads as "don't filter" — so while it is
-    // in flight `queryEnabled` can be true for a space the response goes on to exclude, and a caller
-    // that treated this as settled would offer the tab and then take it away. Only while in flight:
-    // after an error the ids stay null and fail-open is the final answer, so waiting past that would
-    // be waiting forever.
-    isLoading: publishableSpacesLoading || sourceQuery.isLoading || entitiesQuery.isLoading || walking,
+    // The allowlist counts too, but only where there is something for it to decide. It fails open —
+    // a null set reads as "don't filter" — so while it is in flight `queryEnabled` can be true for a
+    // space the response goes on to exclude, and a caller that treated this as settled would offer
+    // the tab and then take it away. Where nothing is discoverable it decides nothing, and reporting
+    // it would hold a slot open on a session that can never fill it. Only while in flight, either
+    // way: after an error the ids stay null and fail-open is the final answer, so waiting past that
+    // would be waiting forever.
+    isLoading:
+      (discoverable && publishableSpacesLoading) || sourceQuery.isLoading || entitiesQuery.isLoading || walking,
     error: sourceQuery.error ?? entitiesQuery.error ?? null,
   };
 }

--- a/apps/web/core/debates/use-related-debate-claims.ts
+++ b/apps/web/core/debates/use-related-debate-claims.ts
@@ -1,0 +1,161 @@
+import * as React from 'react';
+
+import { TOPICS_PROPERTY_ID } from '~/core/claims/ontology';
+import { relatedClaimsWhere } from '~/core/claims/related-claims';
+import { EntitiesOrderBy } from '~/core/gql/graphql';
+import { equals as idEquals, uuidToHex } from '~/core/id/normalize';
+import { useQueryEntities, useQueryEntity } from '~/core/sync/use-store';
+
+import type { DebateClaimSummary } from './api';
+import { DEBATE_TAG_ID } from './ontology';
+import { isSpaceDebatePublishable, useDebatePublishableSpaces } from './use-debate-publishable-spaces';
+
+/** How many neighbours the Related tab offers. */
+export const RELATED_CLAIMS_LIMIT = 25;
+
+/**
+ * Extra rows discovery asks for, to absorb the ones dropped before the limit applies: the debated
+ * claim itself, and any neighbour whose name has not indexed.
+ */
+const RELATED_DROPPED_ROW_SLACK = 8;
+
+/** Stable empty list, so a skipped discovery is not a new array each render. */
+const NO_RELATED_IDS: string[] = [];
+
+export type RelatedDebateClaims = {
+  /** Neighbours worth offering, with the debated claim and undrawable rows already dropped. */
+  claimIds: string[];
+  /**
+   * The debated claim's space, in graph spelling — the space every row here belongs to, and so the
+   * one a caller should prefer when drawing them.
+   */
+  spaceId: string | null;
+  /** Whether the question was asked at all: no claim, no topics, or a space that cannot publish. */
+  enabled: boolean;
+  isLoading: boolean;
+  error: unknown;
+};
+
+/**
+ * The claims a pair could argue next: another claim carrying one of this claim's topics, tagged for
+ * debating, in the same space (GEO-2758).
+ *
+ * Two callers, for two different reasons. The rematch picker reads the answer — it is the Related
+ * tab. The debate room asks the same question while the debate is still running and throws the
+ * answer away, because the wait is the problem this hook exists to solve: the claim being debated is
+ * known minutes before the pair are offered another, but the chain from it to a list is three serial
+ * requests — the debate, the claim's entity for its topics, then the topic query. Run at the moment
+ * the picker mounts, that chain is a second of tab strip arriving after the page did. Run from the
+ * room, it is already answered.
+ *
+ * Warming works because both callers land on the same keys — `useQueryEntity` on the claim id, and
+ * `useQueryEntities` on a clause this module builds identically for both — so the picker's copy is a
+ * cache read rather than a second round trip. That is also why the clause lives here rather than at
+ * each call site: two spellings of the same question would warm a key nobody reads.
+ */
+export function useRelatedDebateClaims({
+  claim,
+  enabled = true,
+}: {
+  claim: DebateClaimSummary | null | undefined;
+  enabled?: boolean;
+}): RelatedDebateClaims {
+  // geo-chat hands out dashed uuids where the graph stores bare hex, so the boundary is crossed
+  // once, here, and everything downstream is a graph question. Each field is guarded on its own
+  // rather than on the claim existing: a summary can arrive without a space, and `uuidToHex`
+  // normalizes with `String.replace`, so a missing one throws rather than reading as absent.
+  const claimId = claim?.claim_entity_id ? uuidToHex(claim.claim_entity_id) : null;
+  const spaceId = claim?.space_id ? uuidToHex(claim.space_id) : null;
+
+  // Null from this means "not known yet" and must not filter, so `isSpaceDebatePublishable` reads it
+  // as "don't filter" — see that hook. Discovery fails open for the same reason its other callers
+  // do: a list that briefly offers a space the reconciliation goes on to remove is better than a
+  // list that waits on it.
+  const { publishableSpaceIds } = useDebatePublishableSpaces();
+
+  /**
+   * Topics live on the graph entity rather than geo-chat's claim summary, and they are assigned *per
+   * space* — so the claim is hydrated with the debate's space, the same way the claim page hydrates
+   * it for the same purpose.
+   *
+   * `useClaimEntitiesByIds` was the obvious hook and is the wrong one: its projection selects
+   * relations with no space filter, so a topic assigned only in some other space would come back and
+   * pull in neighbours the claim's own Related gallery does not show.
+   */
+  const sourceQuery = useQueryEntity({
+    id: claimId ?? '',
+    spaceId: spaceId ?? undefined,
+    enabled: enabled && claimId !== null,
+  });
+
+  const topicIds = React.useMemo(() => {
+    const entity = sourceQuery.entity;
+    if (!entity) return NO_RELATED_IDS;
+    return entity.relations
+      .filter(relation => relation.isDeleted !== true && idEquals(relation.type.id, TOPICS_PROPERTY_ID))
+      .map(relation => relation.toEntity.id);
+  }, [sourceQuery.entity]);
+
+  /**
+   * Skipped with no topics rather than asked with an empty `in`, which matches no relation and would
+   * quietly return the space's entire claim list. Skipped too when the claim's own space cannot
+   * carry a published debate: every row is drawn in that space, so there is nothing to ask for.
+   */
+  const queryEnabled =
+    enabled &&
+    claimId !== null &&
+    spaceId !== null &&
+    topicIds.length > 0 &&
+    isSpaceDebatePublishable(spaceId, publishableSpaceIds);
+
+  const entitiesQuery = useQueryEntities({
+    where: relatedClaimsWhere({
+      spaceId: spaceId ?? '',
+      topicIds,
+      // The one place this diverges from the claim page's gallery, and it is a difference in
+      // purpose: this list answers "what should this pair argue next", so it wants only what a
+      // curator marked for debating.
+      requireTagId: DEBATE_TAG_ID,
+    }),
+    // Sized against what is dropped below before the limit applies. Slack rather than a second
+    // request: this list does not page.
+    first: RELATED_CLAIMS_LIMIT + RELATED_DROPPED_ROW_SLACK,
+    // Without this, `useQueryEntities` answers from the local store before the first fetch resolves,
+    // and those ids fire a caller's row lookups a moment before the real answer replaces them.
+    deferUntilFetched: true,
+    prefetchNextPage: false,
+    orderBy: [EntitiesOrderBy.UpdatedAtDesc],
+    enabled: queryEnabled,
+  });
+
+  /**
+   * The debated claim carries its own topics, so the graph returns it in its own related list — and,
+   * having just been debated, near the front of it. Dropped here rather than left to the caller's
+   * exclusions, because the count decides whether the Related tab exists at all: leaving it in makes
+   * a claim with no neighbours look like a claim with one.
+   *
+   * Unnamed neighbours go for the same reason — they cannot be drawn, and a missing name is knowable
+   * from this very query.
+   */
+  const claimIds = React.useMemo(
+    () =>
+      queryEnabled && claimId
+        ? entitiesQuery.entities
+            .filter(entity => Boolean(entity.name))
+            .map(entity => entity.id)
+            .filter(id => !idEquals(id, claimId))
+            .slice(0, RELATED_CLAIMS_LIMIT)
+        : NO_RELATED_IDS,
+    [queryEnabled, entitiesQuery.entities, claimId]
+  );
+
+  return {
+    claimIds,
+    spaceId,
+    enabled: queryEnabled,
+    // Both lookups, reported together, so a caller cannot gate on a different subset than it reads —
+    // the mistake that let one gate pass while the other was still waiting.
+    isLoading: sourceQuery.isLoading || entitiesQuery.isLoading,
+    error: sourceQuery.error ?? entitiesQuery.error ?? null,
+  };
+}

--- a/apps/web/core/debates/use-related-debate-claims.ts
+++ b/apps/web/core/debates/use-related-debate-claims.ts
@@ -81,7 +81,7 @@ export function useRelatedDebateClaims({
   // as "don't filter" — see that hook. Discovery fails open for the same reason its other callers
   // do: a list that briefly offers a space the reconciliation goes on to remove is better than a
   // list that waits on it.
-  const { publishableSpaceIds } = useDebatePublishableSpaces();
+  const { publishableSpaceIds, isLoading: publishableSpacesLoading } = useDebatePublishableSpaces();
 
   /**
    * Topics live on the graph entity rather than geo-chat's claim summary, and they are assigned *per
@@ -128,16 +128,22 @@ export function useRelatedDebateClaims({
    * (`claim-related-claims.tsx`), so a tab that gave up where the gallery does not would have been
    * two surfaces disagreeing about the same claim.
    */
-  const [walked, setWalked] = React.useState<{ cursor: string; windows: number } | null>(null);
-
-  // Back to the first window whenever the question changes; a cursor from the previous claim's
-  // result set anchors nothing in this one.
-  React.useEffect(() => {
-    setWalked(null);
-  }, [claimId, spaceId]);
+  /**
+   * A cursor belongs to the question it was issued against, so it is stored with that question and
+   * ignored the moment the question changes — rather than cleared by an effect, which would run a
+   * render *after* the change and spend one request anchored in the old result set.
+   *
+   * The topics are part of the question, not just the claim: they arrive from hydration, so the
+   * first windows can be walked against a cached topic set and a later one replaces it. A cursor
+   * kept across that starts the new query midway through a result set it never saw the front of,
+   * and the rows it skipped are simply never offered.
+   */
+  const question = `${claimId ?? ''}:${spaceId ?? ''}:${topicIds.join(',')}`;
+  const [walked, setWalked] = React.useState<{ question: string; cursor: string; windows: number } | null>(null);
+  const walkedHere = walked?.question === question ? walked : null;
 
   const entitiesQuery = useQueryEntities({
-    after: walked?.cursor,
+    after: walkedHere?.cursor,
     where: relatedClaimsWhere({
       spaceId: spaceId ?? '',
       topicIds,
@@ -191,7 +197,7 @@ export function useRelatedDebateClaims({
     claimIds.length === 0 &&
     entitiesQuery.hasNextPage &&
     entitiesQuery.endCursor !== null &&
-    (walked?.windows ?? 0) < RELATED_MAX_EXTRA_WINDOWS;
+    (walkedHere?.windows ?? 0) < RELATED_MAX_EXTRA_WINDOWS;
 
   React.useEffect(() => {
     if (!walking) return;
@@ -199,8 +205,12 @@ export function useRelatedDebateClaims({
     if (cursor === null) return;
     // Guarded on the cursor rather than set outright: this effect re-runs while the next window is
     // in flight, and re-setting the same anchor would be a render loop rather than a step.
-    setWalked(current => (current?.cursor === cursor ? current : { cursor, windows: (current?.windows ?? 0) + 1 }));
-  }, [walking, entitiesQuery.endCursor]);
+    setWalked(current =>
+      current?.question === question && current.cursor === cursor
+        ? current
+        : { question, cursor, windows: (current?.question === question ? current.windows : 0) + 1 }
+    );
+  }, [walking, entitiesQuery.endCursor, question]);
 
   return {
     claimIds,
@@ -213,7 +223,12 @@ export function useRelatedDebateClaims({
     // caller that read "empty, settled" between two windows would drop the tab and then bring it
     // back. Not covered by a test — `render` flushes the whole walk inside one `act`, so every
     // assertion lands after it, and an assertion that cannot see the gap would pass without it.
-    isLoading: sourceQuery.isLoading || entitiesQuery.isLoading || walking,
+    // The allowlist counts too. It fails open — a null set reads as "don't filter" — so while it is
+    // in flight `queryEnabled` can be true for a space the response goes on to exclude, and a caller
+    // that treated this as settled would offer the tab and then take it away. Only while in flight:
+    // after an error the ids stay null and fail-open is the final answer, so waiting past that would
+    // be waiting forever.
+    isLoading: publishableSpacesLoading || sourceQuery.isLoading || entitiesQuery.isLoading || walking,
     error: sourceQuery.error ?? entitiesQuery.error ?? null,
   };
 }

--- a/apps/web/core/sync/use-store.tsx
+++ b/apps/web/core/sync/use-store.tsx
@@ -128,7 +128,10 @@ export function useHydrateEntity({ id, enabled = true }: OmitStrict<QueryEntityO
   const cache = useQueryClient();
   const { store, stream } = useSyncEngine();
 
-  const { isFetched } = useQuery({
+  // `error` as well as `isFetched`. A caller that gates on a hydration failure cannot see one
+  // otherwise — and a failed hydration leaves whatever the store already held, so "no error" and
+  // "answered from cache" look identical from outside.
+  const { isFetched, error } = useQuery({
     enabled: Boolean(id) && enabled,
     queryKey: GeoStore.queryKey(id),
     queryFn: async () => {
@@ -151,7 +154,7 @@ export function useHydrateEntity({ id, enabled = true }: OmitStrict<QueryEntityO
     },
   });
 
-  return { isFetched };
+  return { isFetched, error };
 }
 
 type HydrateEntitiesOptions = {
@@ -202,7 +205,7 @@ export function useHydrateEntities({ ids, enabled = true, spaceId }: HydrateEnti
  */
 export function useQueryEntity({ id, spaceId, includeDeleted = false, enabled = true }: QueryEntityOptions) {
   const { store } = useSyncEngine();
-  const { isFetched } = useHydrateEntity({ id, enabled });
+  const { isFetched, error } = useHydrateEntity({ id, enabled });
 
   const entity = useSelector(
     reactive,
@@ -219,6 +222,10 @@ export function useQueryEntity({ id, spaceId, includeDeleted = false, enabled = 
   return {
     entity,
     isLoading: !isFetched && Boolean(id) && enabled,
+    // Surfaced so a caller can tell a hydration failure from an entity that simply is not there:
+    // `entity` still answers from the store either way, so the failure is not inferable from an
+    // absence. The rematch picker's discovery gate was reading an `error` this hook never returned.
+    error,
   };
 }
 
@@ -275,6 +282,14 @@ type QueryEntitiesOptions = {
    * the reactive store while the remote query is still in flight.
    */
   deferUntilFetched?: boolean;
+  /**
+   * Warm the next cursor page once this one resolves. On by default, which is right for anything
+   * with a "Next" control behind it.
+   *
+   * Off for a caller that is deliberately bounded — one that asks for a fixed number of rows and
+   * exposes no way to page — where the prefetch doubles the payload for a page nothing ever reads.
+   */
+  prefetchNextPage?: boolean;
 
   /**
    * When true, prepends unpublished local entities that match `where` to the
@@ -308,6 +323,7 @@ export function useQueryEntities({
   enabled = true,
   placeholderData = undefined,
   deferUntilFetched = false,
+  prefetchNextPage = true,
   includeUnpublishedLocal = false,
   sort,
   orderBy,
@@ -361,7 +377,7 @@ export function useQueryEntities({
   // useQuery call inside the data block will deduplicate against this entry.
   // Skip while showing placeholder data — the endCursor is from the prior
   // page in that window and would seed the wrong anchor.
-  const prefetchEndCursor = !isPlaceholderData && data?.hasNextPage ? data.endCursor : null;
+  const prefetchEndCursor = prefetchNextPage && !isPlaceholderData && data?.hasNextPage ? data.endCursor : null;
   // Stringify ref-unstable inputs (callers like useCollection rebuild `where`
   // inline each render) so the effect only re-runs when the semantic key
   // changes, not on every render.


### PR DESCRIPTION
Closes GEO-2758.

When a debate ends, the pair are offered another. This adds a **Related** tab to the claim picker holding the claims that share a topic with the one they just argued, and lands them there — the next debate is usually the neighbouring claim, not a fresh search.

### Rebased for the tab reorganisation

This PR originally made Related a fifth source in the Explore dropdown and the default selection. #2406 has since renamed that tab and made the opponent's positions the landing tab, and a fifth source no longer fits: Explore's sources are four answers to *which claims?* — a catalogue someone browses — and this is not a way of browsing. It is the continuation of the debate that just happened, which is also why it is where the pair land. So Related is a tab now, and Explore keeps the four sources it had.

Because the reshaping was larger than the conflicts, I took master's two rematch files wholesale rather than resolving 21 conflicts toward a design that no longer existed, then re-implemented on top. What carried over is the part that was never about source selection:

- `core/claims/related-claims.ts` — the shared "related" clause, so the claim page's gallery and the picker cannot disagree about what related means
- the relation's space carried through the claim-picker projection (`spaceId`, nullable)
- `useQueryEntities`'s `prefetchNextPage`, and `useQueryEntity` surfacing `error`

What did **not** carry over is the source-selection state machine, and dropping it is most of the value of the rebase. It existed only because Related had to compete with Featured and Recommended for a single default — it was the source of most of this PR's review findings. As a tab, the question is just which tab to open on.

### Landing behaviour

Derived, not fixed:

| | lands on |
|---|---|
| session came out of a debate whose claim has neighbours left to argue | **Related** |
| no debate behind the session, or no neighbours | the opponent's positions (#2406's choice, still right) |

Per pair, not per viewer — both sides see the same tab. It sits first in the strip, because landing on the second item reads as though something moved.

The tab is offered while the count is still out, rather than after it lands. Withholding it was the safer-looking choice and was wrong: the strip rendered without Related and the pair started on the opponent's positions, then a moment later the tab appeared and moved them — on every rematch out of a debate. Holding the slot instead costs a tab that goes away when a debated claim has no neighbours left, which is the rarer case. Both are a reflow; only one happens most of the time. It is withheld entirely once the count lands empty: a tab leading to an empty list is worse than no tab.

### Answered before the picker opens

The chain from a claim to its neighbours is three serial requests — the debate, the claim's entity for its topics, then the topic query — and run at the moment the picker mounted it was a visible second of tab strip arriving after the page. But the claim a pair are arguing is known for the whole debate, so `useRelatedDebateClaims` is called from the debate room too, which throws the answer away. Both callers land on the same query keys, so the picker's copy is a cache read. Warmed only once a debate is actually under way: a preflight that times out is a debate that never happened.

That is also why the clause lives in the module rather than at each call site — two spellings of the same question would warm a key nobody reads.

### Scoping

Topics and tags are assigned **per space**, and an entity's `spaces` only means "named in" — so both relations in the clause carry `space`. `tagged-claims.ts` measured this on the Debate tag: filtering on the entity's space set returned claims tagged in one space for a space they merely also appeared in. Without it, "related" would mean "shares a topic *somewhere*", and the picker would offer a claim to debate and publish into a space nobody related it in. The picker narrows further to the Debate tag — it wants what a curator marked for debating; the claim page's gallery takes the whole relation.

### Tests

Master's tests pass unchanged. Ten cover this work, each mutation-checked: where the pair land with and without neighbours; the slot held while the count is out, and held for no session that never had a debate; Related ahead of the opponent's positions; the tab absent once the count lands empty; the clause tag-narrowed and space-scoped; neither the debated claim nor an unnamed neighbour counting toward whether the tab exists; and the room warming the query only once the debate is under way.

One test double was laxer than the thing it stands in for — this suite's `useDebate` answered while disabled, where react-query does not — which made a redundant `source_debate_id` gate look load-bearing. Fixed the double and dropped the gate.

Three fixes from the original PR are no longer behaviourally covered — `rowFromEntity`'s space requirement, and two that belonged to the deleted source-selection machinery. Their tests passed with the fix removed, so I deleted them rather than ship coverage that proves nothing.

### Known gap

Discovery reads a bounded window. If a whole window is claims that can't be displayed, the tab is hidden even though neighbours exist. Fixing it needs a cursor plus folding the extra hop into the undecided gate; the test double returns `endCursor: null`, so it can't be covered yet. Deferred deliberately.
