### PR TITLE
fix(debates): only offer to expand a claim title that is actually clamped

### DIFF
--- a/apps/web/core/debates/browse/debate-feed.test.tsx
+++ b/apps/web/core/debates/browse/debate-feed.test.tsx
@@ -290,17 +290,84 @@ describe('DebatesBrowseFeed video sharing', () => {
     expect(() => render(<DebatesBrowseFeed spaceId="space-1" />)).not.toThrow();
   });
 
-  it('clamps long claims and lets mobile users expand them', () => {
+  /**
+   * jsdom has no layout, so the heading's measurements are supplied. The numbers are the ones
+   * Chromium reports for the real type scale at 390px: a 24px face on 24px leading, where one
+   * rendered line of glyphs is 26px of content inside a 24px box.
+   */
+  function stubHeadingMetrics({ contentHeight, clampedHeight }: { contentHeight: number; clampedHeight: number }) {
+    const isHeading = (el: HTMLElement) => el.tagName === 'H2';
     const scrollHeight = vi.spyOn(HTMLElement.prototype, 'scrollHeight', 'get').mockImplementation(function (
       this: HTMLElement
     ) {
-      return this.tagName === 'H2' ? 72 : 0;
+      return isHeading(this) ? contentHeight : 0;
     });
     const clientHeight = vi.spyOn(HTMLElement.prototype, 'clientHeight', 'get').mockImplementation(function (
       this: HTMLElement
     ) {
-      return this.tagName === 'H2' ? 48 : 0;
+      return isHeading(this) ? clampedHeight : 0;
     });
+    const original = window.getComputedStyle.bind(window);
+    // Proxied rather than spread: a spread `CSSStyleDeclaration` is a plain object, and Testing
+    // Library's accessible-name computation calls `getPropertyValue` on whatever this returns.
+    const computed = vi.spyOn(window, 'getComputedStyle').mockImplementation((el: Element, pseudo?: string | null) => {
+      const style = original(el, pseudo);
+      if (!(el instanceof HTMLElement) || !isHeading(el)) return style;
+      return new Proxy(style, {
+        get(target, property) {
+          if (property === 'lineHeight') return '24px';
+          const value = Reflect.get(target, property, target);
+          return typeof value === 'function' ? value.bind(target) : value;
+        },
+      });
+    });
+    return () => {
+      scrollHeight.mockRestore();
+      clientHeight.mockRestore();
+      computed.mockRestore();
+    };
+  }
+
+  /**
+   * GEO-2756. The old check was `scrollHeight > clientHeight`, and the claim title's leading is
+   * tighter than its glyphs — so every title measured two pixels over its own box and the control
+   * was offered permanently. It only ever showed on mobile, which is where it was reported, because
+   * the button is `hidden md:inline-flex` and `md` here is `max-width: 767px`.
+   */
+  it('offers no expand control for a claim that fits', () => {
+    const restore = stubHeadingMetrics({ contentHeight: 26, clampedHeight: 24 });
+
+    try {
+      const claim = 'Bitcoin is money';
+      mocks.debates = [completedDebate('debate-1', claim, '2026-07-02T00:01:10.000Z')];
+      render(<DebatesBrowseFeed spaceId="space-1" />);
+
+      const heading = screen.getByRole('heading', { name: claim });
+      expect(heading).toHaveClass('line-clamp-2');
+      // No tooltip either: it repeated a title the reader can already see in full.
+      expect(heading).not.toHaveAttribute('title');
+      expect(screen.queryByRole('button', { name: 'Show more' })).not.toBeInTheDocument();
+    } finally {
+      restore();
+    }
+  });
+
+  it('offers no expand control for a claim that exactly fills the clamp', () => {
+    const restore = stubHeadingMetrics({ contentHeight: 50, clampedHeight: 48 });
+
+    try {
+      const claim = 'A claim that wraps onto a second line and stops there';
+      mocks.debates = [completedDebate('debate-1', claim, '2026-07-02T00:01:10.000Z')];
+      render(<DebatesBrowseFeed spaceId="space-1" />);
+
+      expect(screen.queryByRole('button', { name: 'Show more' })).not.toBeInTheDocument();
+    } finally {
+      restore();
+    }
+  });
+
+  it('clamps long claims and lets mobile users expand them', () => {
+    const restore = stubHeadingMetrics({ contentHeight: 74, clampedHeight: 48 });
 
     try {
       const claim = 'A claim long enough to wrap beyond the two lines reserved by the debate header';
@@ -319,8 +386,7 @@ describe('DebatesBrowseFeed video sharing', () => {
       expect(heading).toHaveClass('md:line-clamp-none');
       expect(screen.getByRole('button', { name: 'Show less' })).toHaveAttribute('aria-expanded', 'true');
     } finally {
-      scrollHeight.mockRestore();
-      clientHeight.mockRestore();
+      restore();
     }
   });
 
@@ -668,9 +734,7 @@ describe('DebatesBrowseFeed comments', () => {
   it('marks the button as a hub opener so the panel does not dismiss on pointerdown', () => {
     render(<DebatesBrowseFeed spaceId="space-1" />);
 
-    expect(screen.getAllByRole('button', { name: 'Join a debate' })[0]).toHaveAttribute(
-      'data-debates-hub-opener'
-    );
+    expect(screen.getAllByRole('button', { name: 'Join a debate' })[0]).toHaveAttribute('data-debates-hub-opener');
   });
 
   // `useSmartAccount` reads null while the account restores and after an init failure as well as

--- a/apps/web/core/debates/browse/debate-feed.tsx
+++ b/apps/web/core/debates/browse/debate-feed.tsx
@@ -34,6 +34,7 @@ import { DebateClaimsPanel } from './debate-claims-panel';
 import { DebateFeedPlayer } from './debate-feed-player';
 import { DebateInteractionBar } from './debate-interaction-bar';
 import { DebateScrollHint, scrollHintBounceProps, useDebateScrollHint } from './debate-scroll-hint';
+import { exceedsLineClamp } from './line-clamp-overflow';
 import { useDebateShareAction } from './use-debate-share-action';
 import { useDebatesBestOrder } from './use-debates-best-order';
 import { debateFullscreenActiveAtom } from '~/atoms';
@@ -429,6 +430,15 @@ function DebateFeedItem({
   );
 }
 
+/**
+ * Lines the claim title shows before it offers to expand.
+ *
+ * Must agree with the `line-clamp-2` literal on the heading below — Tailwind only emits classes it
+ * can read as literals, so the class cannot be built from this and the two are kept together
+ * instead. If one changes, change both.
+ */
+const CLAIM_CLAMP_LINES = 2;
+
 function DebateTitleHeader({
   claim,
   claimEntityId,
@@ -456,7 +466,17 @@ function DebateTitleHeader({
     const element = claimRef.current;
     if (!element || isClaimExpanded) return;
 
-    const measureOverflow = () => setIsClaimOverflowing(element.scrollHeight > element.clientHeight + 1);
+    const measureOverflow = () =>
+      setIsClaimOverflowing(
+        exceedsLineClamp({
+          contentHeight: element.scrollHeight,
+          clampedHeight: element.clientHeight,
+          // Read on every measure rather than once: the breakpoint swaps the whole type scale, so a
+          // rotation or a resize past 767px changes the line height this is counting in.
+          lineHeight: parseFloat(getComputedStyle(element).lineHeight),
+          maxLines: CLAIM_CLAMP_LINES,
+        })
+      );
     measureOverflow();
 
     if (typeof ResizeObserver === 'undefined') return;

--- a/apps/web/core/debates/browse/line-clamp-overflow.test.ts
+++ b/apps/web/core/debates/browse/line-clamp-overflow.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+
+import { exceedsLineClamp } from './line-clamp-overflow';
+
+/**
+ * The numbers below are measured, not invented: Chromium rendering the debate claim title at its
+ * real type scale. Mobile is a 24px face on 24px leading, desktop a 22.4px face on 21px leading, and
+ * in both a rendered line of glyphs is two to three pixels taller than the box holding it.
+ */
+const MOBILE = { lineHeight: 24, maxLines: 2 };
+const DESKTOP = { lineHeight: 21, maxLines: 2 };
+
+describe('exceedsLineClamp', () => {
+  // The bug: every one of these was reported as overflowing, so the control was permanent.
+  it('does not call a single line overflowing when the glyphs outgrow their line box', () => {
+    expect(exceedsLineClamp({ contentHeight: 26, clampedHeight: 24, ...MOBILE })).toBe(false);
+    expect(exceedsLineClamp({ contentHeight: 24, clampedHeight: 21, ...DESKTOP })).toBe(false);
+  });
+
+  it('does not call a full clamp overflowing', () => {
+    expect(exceedsLineClamp({ contentHeight: 50, clampedHeight: 48, ...MOBILE })).toBe(false);
+    expect(exceedsLineClamp({ contentHeight: 45, clampedHeight: 42, ...DESKTOP })).toBe(false);
+  });
+
+  it('reports the first line the clamp actually hides', () => {
+    expect(exceedsLineClamp({ contentHeight: 74, clampedHeight: 48, ...MOBILE })).toBe(true);
+    expect(exceedsLineClamp({ contentHeight: 66, clampedHeight: 42, ...DESKTOP })).toBe(true);
+  });
+
+  it('reports a title far past the clamp', () => {
+    expect(exceedsLineClamp({ contentHeight: 386, clampedHeight: 48, ...MOBILE })).toBe(true);
+  });
+
+  // The breakpoint swaps the type scale, so the same claim is a different number of lines on each
+  // side of it. Measured: sixteen words wrap to six lines at 390px and to two at 1280px, which is
+  // why the line height has to be re-read on every measure rather than captured once.
+  it('answers differently for the same claim at each breakpoint', () => {
+    expect(exceedsLineClamp({ contentHeight: 146, clampedHeight: 48, ...MOBILE })).toBe(true);
+    expect(exceedsLineClamp({ contentHeight: 45, clampedHeight: 42, ...DESKTOP })).toBe(false);
+  });
+
+  // `line-height: normal` leaves nothing to count with, and is also the case where the box is sized
+  // to the glyphs — so the height comparison is accurate there rather than merely available.
+  it('falls back to comparing heights when there is no line height to count', () => {
+    expect(exceedsLineClamp({ contentHeight: 72, clampedHeight: 48, lineHeight: NaN, maxLines: 2 })).toBe(true);
+    expect(exceedsLineClamp({ contentHeight: 48, clampedHeight: 48, lineHeight: NaN, maxLines: 2 })).toBe(false);
+    expect(exceedsLineClamp({ contentHeight: 72, clampedHeight: 48, lineHeight: 0, maxLines: 2 })).toBe(true);
+  });
+});

--- a/apps/web/core/debates/browse/line-clamp-overflow.ts
+++ b/apps/web/core/debates/browse/line-clamp-overflow.ts
@@ -1,0 +1,43 @@
+/**
+ * Whether line-clamped text actually has more lines than the clamp is showing.
+ *
+ * The obvious test — `scrollHeight > clientHeight` — is wrong whenever `line-height` is set tighter
+ * than the glyphs need, and the debate claim title sets exactly that: 24px leading on a 24px face on
+ * mobile, 21px on a 22.4px face on desktop. `clientHeight` is the clamp's box, `lines × line-height`.
+ * `scrollHeight` is the height the *content* wants, and a 24px face wants about 26px. So the
+ * difference is two or three pixels for every title ever rendered — one word or fifty — and the
+ * control that comparison gates is offered permanently.
+ *
+ * Measured in Chromium against the real type scale: the height comparison called 6 of 14 sample
+ * lengths overflowing at 390px and 12 of 14 at 1280px that were not, and never once said no.
+ *
+ * Counting lines is immune to it. Content that occupies n lines is `n * lineHeight` plus that same
+ * sub-line overflow, so "reaches into line `maxLines + 1`" is precisely "there is more here than the
+ * clamp shows" — correct on all 84 samples across both widths and all three type scales.
+ *
+ * `~/design-system/clamped-text` solves the same problem a different way, by measuring an unclamped
+ * clone; that is also correct and is left alone. This exists because the debate title clamps a
+ * heading wrapped in a link and toggles it from a separate control, which `ClampedText` does not do.
+ */
+export function exceedsLineClamp({
+  /** `scrollHeight`. A clamped box still reports the full height its content wants. */
+  contentHeight,
+  /** `clientHeight`. Only used for the `line-height: normal` fallback below. */
+  clampedHeight,
+  /** The computed `line-height` in pixels, re-read on every measure — it changes at the breakpoint. */
+  lineHeight,
+  /** The `line-clamp-N` the element is rendered with. */
+  maxLines,
+}: {
+  contentHeight: number;
+  clampedHeight: number;
+  lineHeight: number;
+  maxLines: number;
+}): boolean {
+  // `line-height: normal` parses to no number, so there is nothing to count with. It is also the one
+  // case where comparing heights is accurate — a normal line box is sized to the glyphs, so there is
+  // no standing overflow to mistake for a wrapped line — so fall back to it rather than guess.
+  if (!Number.isFinite(lineHeight) || lineHeight <= 0) return contentHeight > clampedHeight + 1;
+
+  return contentHeight >= (maxLines + 1) * lineHeight;
+}


### PR DESCRIPTION
Closes [GEO-2756](https://linear.app/geobrowser/issue/GEO-2756/debates-mobile-show-more-appears-under-claim-title-in-full-screen-even).

"Show more" sat under the full-screen feed's claim title for every claim, however short.

## The cause

The check was `scrollHeight > clientHeight`.

`clientHeight` is the clamp's box — lines × `line-height`. `scrollHeight` is the height the content actually wants. The title deliberately sets its leading **tighter than its glyphs**: 24px leading on a 24px face on mobile, 21px on a 22.4px face on desktop. So one rendered line is about 26px of content inside a 24px box, and the comparison is true by two or three pixels for **every title ever rendered** — one word or fifty.

Measured in Chromium against the real type scale, sweeping 14 claim lengths:

| | wrongly flagged | ever said "fits" |
|---|---|---|
| 390px | 6 of 14 | never |
| 1280px | 12 of 14 | never |

Not a mistuned threshold, and not a fixed character count — the measurement is unconditional.

## Why it reads as mobile-only

The button is `hidden … md:inline-flex`, and **`md` in this app is `max-width: 767px`** — `styles.css` defines the breakpoints desktop-first:

```css
@custom-variant md (@media (max-width: 767px));
```

So that class shows the button on mobile and hides it everywhere else. Desktop had exactly the same wrong measurement and simply no button to reveal it. The redundant `title` tooltip the same flag gates *was* visible on both.

## The fix

Count lines rather than compare heights. Content on n lines is n line-heights plus that same sub-line overflow, so "reaches into line `maxLines + 1`" is precisely "there is more here than the clamp shows":

```ts
contentHeight >= (maxLines + 1) * lineHeight
```

Correct on **all 84 samples** — both widths, all three type scales on the page, every length from one word to forty-eight.

The line height is re-read on every measure rather than captured once: crossing the breakpoint swaps the whole type scale, so a rotation or resize changes the unit being counted in. `line-height: normal` falls back to the height comparison, which is accurate in exactly that case — a normal line box is sized to the glyphs, so there is no standing overflow to mistake for a wrapped line.

## The reverse bug the ticket asked about

The ticket flagged that a fixed threshold usually leaves truncated content somewhere with no control offered. Checked: the only other clamp-with-toggle is `~/design-system/clamped-text`, which measures an **unclamped clone** instead. That technique is immune to the tight-leading problem, and I verified it at both variants it is used with (`body` and `mainPage`, the entity page's `h1` — which is a claim title too): **0 wrong out of 28**. So the side panel and entity pages are fine, and I have left the shared component alone.

## Testing

- `line-clamp-overflow.test.ts` — the fits/exactly-fills/overflows boundaries at both type scales, the breakpoint swap, and the `normal` fallback. Numbers are the measured Chromium values, not invented.
- `debate-feed.test.tsx` — two component regressions: a claim that fits and a claim that exactly fills the clamp both render no control and no tooltip. **Revert-checked**: both fail against the old comparison.
- `vitest run core/debates core/claims` — 81 files, 992 tests, all pass
- `eslint` clean; `tsc --noEmit` unchanged (3 pre-existing failures, none in touched files)

## One note

Prettier reports `debate-feed.tsx` as unformatted on `master` (an import block). I deliberately left that alone rather than let a formatting pass bulk up a bug-fix diff — happy to do it separately.
