### PR TITLE
fix(explore): let a claim's name open the side panel, like every other card

### DIFF
--- a/apps/web/partials/explore/claim-explore-feed-card.tsx
+++ b/apps/web/partials/explore/claim-explore-feed-card.tsx
@@ -42,7 +42,12 @@ import { ExploreMetaRow } from './explore-meta-row';
  * did not support — 33 debates against 311,047 claims — and then comments and Share, which is what
  * the generic card has. Even that earned less than it cost here: a strip of small grey glyphs under
  * a card whose whole lower half is already the response controls and the verdict. The claim's title
- * links to its page, where the comments are.
+ * is the way through to all of it.
+ *
+ * Where that title goes is the host's call, through `titleOpensSidePanel`: the side panel on
+ * Explore, the entity page everywhere else this card is used. Either way it stays a real anchor
+ * with a real href — only unmodified left clicks are intercepted — so cmd-click, shift-click and
+ * middle click still open the page, and so does anyone reading the status bar before they click.
  *
  * Scoped to Claim entities by the caller. Every other type keeps the generic card untouched.
  */

--- a/apps/web/partials/explore/claim-explore-feed-card.tsx
+++ b/apps/web/partials/explore/claim-explore-feed-card.tsx
@@ -16,11 +16,10 @@ import { useNearViewport } from '~/core/hooks/use-near-viewport';
 import { usePrivySignIn } from '~/core/hooks/use-privy-sign-in';
 import { ENTITY_RESPONSE_COPY } from '~/core/responses/entity-response';
 import { useQueryEntity } from '~/core/sync/use-store';
-import { NavUtils } from '~/core/utils/utils';
 
-import { PrefetchLink as Link } from '~/design-system/prefetch-link';
 import { Text } from '~/design-system/text';
 
+import { ExploreCardEntityLink } from './explore-card-entity-link';
 import { ExploreMetaRow } from './explore-meta-row';
 
 /**
@@ -51,10 +50,20 @@ export function ClaimExploreFeedCard({
   item,
   hideSpaceLink = false,
   hideJoinButton = false,
+  titleOpensSidePanel = false,
 }: {
   item: ExploreFeedItem;
   hideSpaceLink?: boolean;
   hideJoinButton?: boolean;
+  /**
+   * Whether the claim's name opens the entity side panel rather than navigating (GEO-2757).
+   *
+   * Threaded through for the same reason every other card body takes it: on Explore this card
+   * *replaces* the generic one, so a claim that did not accept it would be the single card type on
+   * that page whose name still navigated away — a difference nobody chose, introduced by this card
+   * existing.
+   */
+  titleOpensSidePanel?: boolean;
 }) {
   // The feed pre-mounts cards thousands of pixels below the fold, so the counts and the geo-chat
   // row are gated on proximity rather than on mount — otherwise every claim in every loaded page
@@ -169,14 +178,15 @@ export function ClaimExploreFeedCard({
         {/* No thumbnail: claims carry no image, so the generic card's 60px well is either an empty
             gutter or a placeholder that says nothing. The sentence gets the column instead — it
             runs to a median of 108 characters and needs it. */}
-        <Link
-          href={NavUtils.toEntity(item.spaceId, item.entityId)}
+        <ExploreCardEntityLink
+          item={item}
+          opensSidePanel={titleOpensSidePanel}
           className="group/title col-start-1 row-start-2 min-w-0"
         >
           <h2 className="mt-0! text-[19px]! leading-[23px]! font-semibold! tracking-[-0.02em] text-pretty text-text group-hover/title:underline">
             {item.title}
           </h2>
-        </Link>
+        </ExploreCardEntityLink>
 
         <div
           className={cx(

--- a/apps/web/partials/explore/explore-feed-card.test.tsx
+++ b/apps/web/partials/explore/explore-feed-card.test.tsx
@@ -22,7 +22,17 @@ vi.mock('~/core/state/pending-personal-space', () => ({
 }));
 
 vi.mock('./claim-explore-feed-card', () => ({
-  ClaimExploreFeedCard: ({ item }: { item: { title: string } }) => <div data-testid="claim-card">{item.title}</div>,
+  ClaimExploreFeedCard: ({
+    item,
+    titleOpensSidePanel,
+  }: {
+    item: { title: string };
+    titleOpensSidePanel?: boolean;
+  }) => (
+    <div data-testid="claim-card" data-opens-side-panel={String(titleOpensSidePanel)}>
+      {item.title}
+    </div>
+  ),
 }));
 
 vi.mock('~/design-system/fallback-image', () => ({
@@ -205,6 +215,15 @@ describe('ExploreFeedCard', () => {
       const debate = { ...item, types: [{ id: DEBATE_TYPE_ID, name: 'Debate' }] };
       render(<ExploreFeedCard item={debate} titleOpensSidePanel />);
       expect(screen.getByTestId('debate-card')).toHaveAttribute('data-opens-side-panel', 'true');
+    });
+
+    // The card type this PR added, and the one the note above predicted: on Explore it *replaces*
+    // the default rendition, so a claim that did not take this prop would be the only card on the
+    // page whose name still navigated away.
+    it('reaches the claim card', () => {
+      const claim = { ...item, types: [{ id: '96f859ef-a1ca-4b22-9372-c86ad58b694b', name: 'Claim' }] };
+      render(<ExploreFeedCard item={claim} titleOpensSidePanel />);
+      expect(screen.getByTestId('claim-card')).toHaveAttribute('data-opens-side-panel', 'true');
     });
 
     it('stays off by default, so the card keeps navigating everywhere else it is used', () => {

--- a/apps/web/partials/explore/explore-feed-card.tsx
+++ b/apps/web/partials/explore/explore-feed-card.tsx
@@ -153,6 +153,7 @@ export function ExploreFeedCard(props: ExploreFeedCardProps) {
         item={props.item}
         hideSpaceLink={props.hideSpaceLink}
         hideJoinButton={props.hideJoinButton}
+        titleOpensSidePanel={props.titleOpensSidePanel}
       />
     );
   }


### PR DESCRIPTION
Finishes GEO-2757 for the one card type it could not have covered.

That ticket's scope is "all card types on Explore, not just one — worth enumerating them during implementation so none are missed." #2309 did enumerate them, and wired `titleOpensSidePanel` through each rendition. #2297 then added a card type that did not exist when it was written.

So on master right now, every card's name on Explore opens the entity side panel **except a Claim**, which navigates away. Neither PR could see it alone; it only exists in the pair, and both were green.

#2309's own test note called the shape of it in advance:

> a card rendition draws its own title, so a card type added later is exactly what goes quietly unwired

## The change

`ClaimExploreFeedCard` takes `titleOpensSidePanel` and draws its title with the shared `ExploreCardEntityLink` rather than its own `PrefetchLink`.

Using the shared link is the point rather than a tidiness preference: it keeps a real anchor with a real `href` and intercepts only unmodified left clicks, which is what GEO-2701 needs. A claim card that reimplemented the panel open with a button and an `onClick` would look identical and break cmd/ctrl-click, shift-click, middle click, "copy link address" and the status-bar preview.

## Testing

The claim case joins the existing `titleOpensSidePanel` block in `explore-feed-card.test.tsx` that already covers the other four renditions, so a fifth card type has to answer it too. Verified non-vacuous by dropping the prop again.

Explore suites green (52 tests), typecheck clean on the changed files.

Not browser-tested. The mechanism is one shared component already in use on four other card types, but the click behaviour itself is the kind of thing that has been invisible to this suite before.