### PR TITLE
fix(debates): resolve the feed anchor by id instead of from the capped space listing

### DIFF
--- a/apps/web/app/space/[id]/(space)/debates/debates-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/debates-page-client.test.tsx
@@ -59,6 +59,9 @@ vi.mock('~/core/debates/hooks', () => ({
   useDebateTranscript: () => ({ data: { segments: [] }, isLoading: false, error: null }),
   useDebateClaims: () => ({ data: { claims: [] } }),
   useJoinDebateQueue: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  // The feed resolves an anchor by id when the space listing does not contain it (GEO-2764).
+  // These tests never anchor, so it stays idle.
+  useDebate: () => ({ data: null, isLoading: false, error: null }),
 }));
 
 // The feed orders itself by the explore "Best" ranking. These tests are about readiness and

--- a/apps/web/core/debates/browse/debate-feed.test.tsx
+++ b/apps/web/core/debates/browse/debate-feed.test.tsx
@@ -39,6 +39,10 @@ const mocks = vi.hoisted(() => ({
   authenticated: true,
   /** False while Privy is still restoring the session. */
   authReady: true,
+  /** The anchor fetched by id when it is not in the space listing (GEO-2764). */
+  anchorDebate: null as ReturnType<typeof completedDebate> | null,
+  anchorLoading: false,
+  anchorError: null as Error | null,
 }));
 
 type ObserverRecord = {
@@ -58,6 +62,7 @@ vi.mock('~/core/debates/hooks', () => ({
     hasError: mocks.mediaError,
   }),
   useDebateMediaArtifactUrl: () => ({ mutate: mocks.mediaMutate }),
+  useDebate: () => ({ data: mocks.anchorDebate, isLoading: mocks.anchorLoading, error: mocks.anchorError }),
 }));
 
 vi.mock('./use-debates-best-order', async () => {
@@ -169,6 +174,9 @@ beforeEach(() => {
   mocks.entityVoteProps.length = 0;
   mocks.debates = [completedDebate('debate-1', 'Debates are useful', '2026-07-02T00:01:10.000Z')];
   mocks.processedIds = null;
+  mocks.anchorDebate = null;
+  mocks.anchorLoading = false;
+  mocks.anchorError = null;
   mocks.bestOrderIds = [];
   mocks.bestOrderLoading = false;
   mocks.claimsCount = 0;
@@ -415,6 +423,61 @@ describe('DebatesBrowseFeed video sharing', () => {
     expect(screen.getByText('Entity page')).toBeInTheDocument();
     // An ordinary entity page renders here and does want the chrome.
     expect(store.get(debateFullscreenActiveAtom)).toBe(false);
+  });
+
+  // GEO-2764. `list_space_debates` is `LIMIT 50` with no pagination, so a watchable debate can be
+  // past the window and simply absent from the listing. Resolving the anchor from that listing
+  // silently rendered the ordinary entity page instead of the feed.
+  it('plays an anchor that is past the space listing window', () => {
+    mocks.debates = [completedDebate('debate-1', 'In the window', '2026-07-02T00:01:10.000Z')];
+    mocks.anchorDebate = completedDebate('debate-99', 'Past the window', '2026-07-01T00:00:00.000Z');
+    mocks.processedIds = ['debate-1', 'debate-99'];
+
+    const store = createStore();
+    render(
+      <Provider store={store}>
+        <DebatesBrowseFeed spaceId="space-1" initialDebateId="debate-99" fallback={<div>Entity page</div>} />
+      </Provider>
+    );
+
+    expect(screen.queryByText('Entity page')).not.toBeInTheDocument();
+    expect(screen.getByTestId('player-debate-99')).toBeInTheDocument();
+    // And it takes over the chrome, which the fallback path deliberately does not.
+    expect(store.get(debateFullscreenActiveAtom)).toBe(true);
+  });
+
+  // Being navigated to is not a reason to play a debate with no video: the directly-fetched anchor
+  // goes through the same media gate as everything in the listing.
+  it('still falls back when the fetched anchor has no processed video', () => {
+    mocks.debates = [completedDebate('debate-1', 'In the window', '2026-07-02T00:01:10.000Z')];
+    mocks.anchorDebate = completedDebate('debate-99', 'Past the window', '2026-07-01T00:00:00.000Z');
+    mocks.processedIds = ['debate-1'];
+
+    render(<DebatesBrowseFeed spaceId="space-1" initialDebateId="debate-99" fallback={<div>Entity page</div>} />);
+
+    expect(screen.getByText('Entity page')).toBeInTheDocument();
+  });
+
+  // Falling back while the direct fetch is still in flight is the bug itself, one race later.
+  it('waits for the anchor fetch rather than falling back mid-flight', () => {
+    mocks.debates = [completedDebate('debate-1', 'In the window', '2026-07-02T00:01:10.000Z')];
+    mocks.anchorDebate = null;
+    mocks.anchorLoading = true;
+
+    render(<DebatesBrowseFeed spaceId="space-1" initialDebateId="debate-99" fallback={<div>Entity page</div>} />);
+
+    expect(screen.queryByText('Entity page')).not.toBeInTheDocument();
+    expect(screen.getByText('Loading debates…')).toBeInTheDocument();
+  });
+
+  // A debate that genuinely is not watchable anywhere still reaches the entity page.
+  it('falls back when the anchor cannot be resolved at all', () => {
+    mocks.debates = [completedDebate('debate-1', 'In the window', '2026-07-02T00:01:10.000Z')];
+    mocks.anchorDebate = null;
+
+    render(<DebatesBrowseFeed spaceId="space-1" initialDebateId="debate-99" fallback={<div>Entity page</div>} />);
+
+    expect(screen.getByText('Entity page')).toBeInTheDocument();
   });
 
   it('nudges only when there is something below to scroll to', () => {

--- a/apps/web/core/debates/browse/debate-feed.tsx
+++ b/apps/web/core/debates/browse/debate-feed.tsx
@@ -9,7 +9,7 @@ import { useSetAtom } from 'jotai';
 
 import { CLAIM_TYPE_ID, TOPICS_PROPERTY_ID } from '~/core/claims/ontology';
 import type { Debate } from '~/core/debates/api';
-import { useProcessedVideoDebateIds, useSpaceDebates } from '~/core/debates/hooks';
+import { useDebate, useProcessedVideoDebateIds, useSpaceDebates } from '~/core/debates/hooks';
 import { useGeoChatAuth } from '~/core/debates/hooks';
 import { useDebatesHub } from '~/core/debates/matchmaking/use-debates-hub';
 import { isWatchableDebate } from '~/core/debates/playback-utils';
@@ -58,12 +58,37 @@ export function DebatesBrowseFeed({
   const debatesQuery = useSpaceDebates(spaceId, true);
   const { space } = useSpace(spaceId);
 
+  const listedDebates = React.useMemo(() => debatesQuery.data?.debates ?? [], [debatesQuery.data?.debates]);
+
+  // GEO-2764. The space listing is capped — `list_space_debates` is `LIMIT 50` with no pagination
+  // and no way to ask for one specific debate — so a perfectly watchable debate can simply be past
+  // the window and absent from it. Resolving the anchor from that listing therefore fails for
+  // reasons that have nothing to do with the debate: the AI space sits at exactly 50 today, and a
+  // viewer who participated in any incomplete debate there pushes their own count over and loses
+  // the oldest few. The next completed debate in that space tips it for everyone at once.
+  //
+  // So fetch the anchor by id instead of requiring it to appear. Gated on the listing having
+  // settled without it, which keeps the common case at one request — this only fires where the
+  // feed would otherwise have silently rendered the wrong page.
+  const anchorListed =
+    initialDebateId != null && listedDebates.some(debate => ID.equals(debate.id, initialDebateId));
+  const anchorQuery = useDebate(
+    initialDebateId ?? '',
+    initialDebateId != null && !debatesQuery.isLoading && !anchorListed
+  );
+
   // Two-stage gate (GEO-2412). `isWatchableDebate` only proves both raw recordings exist; a debate
   // whose media job failed or never ran still passes it, so readiness decides what renders.
-  const candidates = React.useMemo(
-    () => (debatesQuery.data?.debates ?? []).filter(isWatchableDebate),
-    [debatesQuery.data?.debates]
-  );
+  //
+  // The directly-fetched anchor goes through the same gate as everything else — being navigated to
+  // is not a reason to play a debate that has no video.
+  const candidates = React.useMemo(() => {
+    const watchable = listedDebates.filter(isWatchableDebate);
+    const anchor = anchorQuery.data;
+    if (!anchor || !isWatchableDebate(anchor)) return watchable;
+    if (watchable.some(debate => ID.equals(debate.id, anchor.id))) return watchable;
+    return [...watchable, anchor];
+  }, [listedDebates, anchorQuery.data]);
   const candidateIds = React.useMemo(() => candidates.map(debate => debate.id), [candidates]);
   const {
     processedIds,
@@ -151,7 +176,9 @@ export function DebatesBrowseFeed({
   // flashes "no debates" and strands a valid anchor.
   // Waiting on the ranking too, so the feed doesn't paint in recency order and then resequence
   // itself underneath someone who has already started scrolling.
-  const isLoading = debatesQuery.isLoading || mediaLoading || bestOrderLoading;
+  // `anchorQuery` is part of the load: without it the feed reaches `anchorMissing` while the
+  // direct fetch is still in flight and falls back anyway, which is the bug.
+  const isLoading = debatesQuery.isLoading || anchorQuery.isLoading || mediaLoading || bestOrderLoading;
 
   const anchorPresent = React.useMemo(
     () => initialDebateId == null || debates.some(debate => ID.equals(debate.id, initialDebateId)),
@@ -163,7 +190,8 @@ export function DebatesBrowseFeed({
   // An anchor absent after a failed lookup is *unknown*, not missing: falling
   // back would misread a transient readiness/query error as "this debate has no
   // video", so the feed stays up and shows its own error state instead.
-  const anchorErrored = anchorUnresolved && !isLoading && (mediaError || debatesQuery.error != null);
+  const anchorErrored =
+    anchorUnresolved && !isLoading && (mediaError || debatesQuery.error != null || anchorQuery.error != null);
 
   // Hold an anchored feed until the anchor itself is ready: the per-debate
   // readiness lookups resolve one at a time, so painting the partial list would


### PR DESCRIPTION
GEO-2764. Opening a Debate entity page in the AI space rendered the ordinary entity page instead of the full-screen feed — no error, nothing in the console.

Diagnosis is Preston's, on the ticket. This implements the fix he suggested there.

## The feed wasn't failing — it was bailing out

`anchorUnresolved` means the debate you navigated to isn't in the list the feed built for that space, and on that path it hands back the caller's `fallback`. That fallback exists so a non-watchable debate is never hidden outright, but it can't distinguish *"this debate has no video"* from *"the feed never saw this debate"* — and it was the second case biting.

The listing is capped: `list_space_debates` is `LIMIT 50`, ordered by recency, no pagination, and no way to ask for one specific debate. A perfectly watchable debate can just be past the window.

## Why it looked like one person's problem

Measured against the live database:

| viewer | candidate rows | past the cap |
| --- | --- | --- |
| Preston (participant) | **55** | **yes** |
| anonymous viewer | **50** | no — *exactly* at it |
| next-heaviest participant | 28 | no |

The AI space holds exactly 50 complete debates. A viewer who also participated in an incomplete one there gets pulled over the cap by the `OR p.user_id IS NOT NULL` arm and loses the oldest few — hence one person, one space.

**A non-participant sits precisely at 50.** The next completed debate in that space tips it for every viewer at once. This is a cliff, not a slope, which is why it's worth fixing now rather than when it spreads.

## The fix

Fetch the anchor by id via `useDebate` and merge it into the candidates, making resolution independent of the window entirely.

It still passes the same `isWatchableDebate` and processed-video gates as everything in the listing — being navigated to is not a reason to play a debate with no video.

Two details that matter:

- The fetch is **gated on the listing having settled without the anchor**, so the common case stays at one request. It only fires where the feed would otherwise have silently rendered the wrong page.
- `anchorQuery.isLoading` joins the load gate. Without it the feed reaches `anchorMissing` while the direct fetch is still in flight and falls back anyway — the same bug, one race later.

Paginating `list_space_debates` is still worth doing, but on its own it moves the cliff rather than removing it.

## Testing

50 tests in this file (4 new), 1009 across `core/debates`, typecheck clean.

Mutation-tested:

| mutation | result |
| --- | --- |
| don't merge the fetched anchor into candidates | window test fails |
| drop `anchorQuery.isLoading` from the load gate | mid-flight test fails |

## Not covered here

`partials/explore/debate-explore-feed-card.tsx` mirrors the same fallback pattern and has the same blind spot — flagged on the ticket.

Related: **GEO-2763** — 28 of those 50 AI slots are held by debates with no media job at all, so the cap is largely spent on debates that can never render. Excluding them would buy headroom immediately.