### PR TITLE
feat:  animate the hub cards that arrive, leave, and reorder

### DIFF
--- a/apps/web/core/debates/matchmaking/claims-tab.tsx
+++ b/apps/web/core/debates/matchmaking/claims-tab.tsx
@@ -36,7 +36,7 @@ import { useClaimSpaceAllowlist } from '../use-claim-space-allowlist';
 import { isSpaceDebatePublishable, useDebatePublishableSpaces } from '../use-debate-publishable-spaces';
 import { useDebateRequests } from './hooks';
 import { HubFilterMenu, type HubFilterOption, HubMultiFilterMenu } from './hub-filter-menu';
-import { HubCardList } from './hub-motion';
+import { HubCardList, HubPinnedSlot } from './hub-motion';
 import { HubQueryState } from './hub-states';
 import { MatchmakingClaimCard } from './matchmaking-claim-card';
 import { OutboundRequestCard } from './outbound-request-card';
@@ -505,7 +505,7 @@ export function ClaimsTab() {
             and the only evidence was on another tab. It rides inside the sticky block rather than
             above it because two stickies would both claim `top-0` and overlap, and this one is
             conditional so the filters could not be offset by a known height. */}
-        {outbound ? <OutboundRequestCard request={outbound} /> : null}
+        <HubPinnedSlot>{outbound ? <OutboundRequestCard request={outbound} /> : null}</HubPinnedSlot>
 
         <Input
           withSearchIcon

--- a/apps/web/core/debates/matchmaking/hub-motion.test.tsx
+++ b/apps/web/core/debates/matchmaking/hub-motion.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react';
+
+import { describe, expect, it } from 'vitest';
+
+import { HubPinnedSlot, hubRowMotion } from './hub-motion';
+
+describe('HubPinnedSlot', () => {
+  it('renders nothing at all when the slot is empty', () => {
+    const { container } = render(<HubPinnedSlot>{null}</HubPinnedSlot>);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('clips the card it holds so an animating height cannot spill over the filters', () => {
+    render(
+      <HubPinnedSlot>
+        <article>Awaiting response</article>
+      </HubPinnedSlot>
+    );
+
+    const wrapper = screen.getByText('Awaiting response').parentElement;
+    expect(wrapper?.className).toContain('overflow-hidden');
+  });
+});
+
+describe('hubRowMotion', () => {
+  it('does not define an exit, so a filtered-out row leaves immediately', () => {
+    expect(hubRowMotion).not.toHaveProperty('exit');
+  });
+
+  it('animates layout so a row that changes place slides instead of jumping', () => {
+    expect(hubRowMotion.layout).toBe(true);
+  });
+});

--- a/apps/web/core/debates/matchmaking/hub-motion.tsx
+++ b/apps/web/core/debates/matchmaking/hub-motion.tsx
@@ -41,6 +41,35 @@ export function HubCardList({ children, className }: { children: React.ReactNode
   );
 }
 
+/**
+ * The slot pinned above a tab's filters, holding at most one card — today the request you've sent.
+ */
+export function HubPinnedSlot({ children }: { children: React.ReactNode }) {
+  return (
+    <AnimatePresence initial={false}>
+      {children ? (
+        <motion.div
+          key="hub-pinned-slot"
+          initial={{ opacity: 0, height: 0 }}
+          animate={{ opacity: 1, height: 'auto' }}
+          exit={{ opacity: 0, height: 0 }}
+          transition={HUB_LAYOUT_TRANSITION}
+          className="overflow-hidden"
+        >
+          {children}
+        </motion.div>
+      ) : null}
+    </AnimatePresence>
+  );
+}
+
+export const hubRowMotion = {
+  layout: true,
+  initial: { opacity: 0 },
+  animate: { opacity: 1 },
+  transition: HUB_LAYOUT_TRANSITION,
+} as const;
+
 /** Cross-fades between two states of the same region — skeleton to content, tab to tab. */
 export function HubSwap({ activeKey, children }: { activeKey: string; children: React.ReactNode }) {
   return (

--- a/apps/web/core/debates/matchmaking/matches-tab.tsx
+++ b/apps/web/core/debates/matchmaking/matches-tab.tsx
@@ -6,7 +6,7 @@ import type { MatchmakingMatch } from '../api';
 import { useDebateActivity } from '../hooks';
 import { HubStickyControls, SpaceTopicFilters } from './claims-tab';
 import { useDebateRequests, useMatchmakingMatches } from './hooks';
-import { HubCardList } from './hub-motion';
+import { HubCardList, HubPinnedSlot } from './hub-motion';
 import { HubQueryState } from './hub-states';
 import { MatchmakingClaimCard } from './matchmaking-claim-card';
 import { OutboundRequestCard } from './outbound-request-card';
@@ -57,7 +57,7 @@ export function MatchesTab({ onTabChange }: { onTabChange: (tab: DebatesHubTab) 
           both claim `top-0` and overlap, and the outbound card is conditional so the filters
           couldn't be offset by a known height. */}
       <HubStickyControls>
-        {outbound ? <OutboundRequestCard request={outbound} /> : null}
+        <HubPinnedSlot>{outbound ? <OutboundRequestCard request={outbound} /> : null}</HubPinnedSlot>
         <SpaceTopicFilters
           spaceIds={spaceIds}
           onSpaceToggle={id => setSpaceIds(current => toggleId(current, id))}

--- a/apps/web/core/debates/matchmaking/people-tab.test.tsx
+++ b/apps/web/core/debates/matchmaking/people-tab.test.tsx
@@ -164,7 +164,7 @@ describe('PeopleTab', () => {
 
     const request = card();
     expect(request).toBeInTheDocument();
-    expect(request?.parentElement).toHaveClass('sticky', 'top-0');
+    expect(request?.closest('.sticky')).toHaveClass('sticky', 'top-0');
     expect(within(request!).getByText('Awaiting response')).toBeInTheDocument();
     expect(screen.queryByText(awaitingText)).not.toBeInTheDocument();
   });

--- a/apps/web/core/debates/matchmaking/people-tab.tsx
+++ b/apps/web/core/debates/matchmaking/people-tab.tsx
@@ -2,6 +2,8 @@
 
 import * as React from 'react';
 
+import { motion } from 'framer-motion';
+
 import { usePrivySignIn } from '~/core/hooks/use-privy-sign-in';
 
 import { Avatar } from '~/design-system/avatar';
@@ -16,6 +18,7 @@ import { useCurrentGeoChatUserId } from '../use-current-geo-chat-user-id';
 import { DebateChallengeCard } from './challenge-card';
 import { HubStickyControls } from './claims-tab';
 import { useDebatePeople, useDebateRequests } from './hooks';
+import { hubRowMotion } from './hub-motion';
 import { HubPillButton } from './hub-pill-button';
 import { HubQueryState } from './hub-states';
 import type { PersonRecord } from './person-record';
@@ -172,7 +175,10 @@ function PersonRow({
     // row box with the name — where it was the tallest thing and set the name's line height. All
     // three tracks centre on the row: hanging them from the top clustered everything up there and
     // left the join date trailing under an empty right-hand side.
-    <li className="grid grid-cols-[2rem_minmax(0,1fr)_auto] items-center gap-x-2.5 border-b border-grey-02 py-2.5 last:border-b-0">
+    <motion.li
+      {...hubRowMotion}
+      className="grid grid-cols-[2rem_minmax(0,1fr)_auto] items-center gap-x-2.5 border-b border-grey-02 py-2.5 last:border-b-0"
+    >
       <div className="relative h-8 w-8 shrink-0 overflow-hidden rounded-full">
         <Avatar avatarUrl={person.avatar_cid} value={person.profile_space_id} size={32} />
       </div>
@@ -199,6 +205,6 @@ function PersonRow({
       >
         {person.in_debate ? 'In a debate' : 'Request debate'}
       </HubPillButton>
-    </li>
+    </motion.li>
   );
 }

--- a/apps/web/core/debates/matchmaking/people-tab.tsx
+++ b/apps/web/core/debates/matchmaking/people-tab.tsx
@@ -18,7 +18,7 @@ import { useCurrentGeoChatUserId } from '../use-current-geo-chat-user-id';
 import { DebateChallengeCard } from './challenge-card';
 import { HubStickyControls } from './claims-tab';
 import { useDebatePeople, useDebateRequests } from './hooks';
-import { hubRowMotion } from './hub-motion';
+import { HubPinnedSlot, hubRowMotion } from './hub-motion';
 import { HubPillButton } from './hub-pill-button';
 import { HubQueryState } from './hub-states';
 import type { PersonRecord } from './person-record';
@@ -98,7 +98,9 @@ export function PeopleTab() {
           claim `top-0` and overlap, and the card is conditional so search couldn't be offset by a
           known height. */}
       <HubStickyControls>
-        {outboundChallenge ? <DebateChallengeCard challenge={outboundChallenge} role="requester" /> : null}
+        <HubPinnedSlot>
+          {outboundChallenge ? <DebateChallengeCard challenge={outboundChallenge} role="requester" /> : null}
+        </HubPinnedSlot>
         <Input
           withSearchIcon
           value={search}


### PR DESCRIPTION
Feat:
Cards in the debates side panel changed between frames — no movement to follow.

Gaps:
1. The pinned request card (Matches and Claims tabs).
It already had an exit animation from hubCardMotion, but an exit only runs inside an AnimatePresence and neither tab had one. So sending a request popped a card into the header, and withdrawing popped it back out, with the filters below jumping to fill the space.
2. The People tab had no motion at all. Rows jumped as people came online or went into debates.

Fixed:
hub-motion.tsx — two additions to the module's existing motion vocabulary:

- HubPinnedSlot — wraps the pinned card in an AnimatePresence and animates its own height, so the filters slide with the card instead of snapping once the fade ends.
- hubRowMotion — layout: true, for rows that reorder in place.
- people-tab.tsx — rows are motion.li with hubRowMotion, so they slide to their new position.