### PR TITLE
Extend browse dropdowns to collection blocks, add per-option match counts

### DIFF
--- a/apps/web/core/blocks/data/fetch-dropdown-options.test.ts
+++ b/apps/web/core/blocks/data/fetch-dropdown-options.test.ts
@@ -1,33 +1,74 @@
 import { describe, expect, it } from 'vitest';
 
-import { populationVariablesFromWhere, toDropdownOptions } from './fetch-dropdown-options';
+import {
+  DROPDOWN_POPULATION_PAGE_SIZE,
+  mergeDropdownOptionCounts,
+  populationVariablesForIds,
+  populationVariablesFromWhere,
+  slicePopulationIds,
+  tallyDropdownOptions,
+} from './fetch-dropdown-options';
 
-describe('toDropdownOptions', () => {
-  it('collapses relations to distinct to-entities sorted by name', () => {
-    const options = toDropdownOptions({
+describe('tallyDropdownOptions', () => {
+  it('collapses relations to distinct to-entities sorted by name, counting distinct rows', () => {
+    const options = tallyDropdownOptions({
       relations: [
-        { toEntity: { id: 'b', name: 'Beta' } },
-        { toEntity: { id: 'a', name: 'Alpha' } },
-        { toEntity: { id: 'b', name: 'Beta' } },
-        { toEntity: null },
+        { fromEntityId: 'row-1', toEntity: { id: 'b', name: 'Beta' } },
+        { fromEntityId: 'row-1', toEntity: { id: 'a', name: 'Alpha' } },
+        { fromEntityId: 'row-2', toEntity: { id: 'b', name: 'Beta' } },
+        { fromEntityId: 'row-3', toEntity: null },
       ],
     });
     expect(options).toEqual([
-      { id: 'a', name: 'Alpha' },
-      { id: 'b', name: 'Beta' },
+      { id: 'a', name: 'Alpha', count: 1 },
+      { id: 'b', name: 'Beta', count: 2 },
     ]);
   });
 
-  it('keeps a known name when a later relation resolves the same entity without one', () => {
-    const options = toDropdownOptions({
-      relations: [{ toEntity: { id: 'a', name: 'Alpha' } }, { toEntity: { id: 'a', name: null } }],
+  it('counts a row once even when it carries duplicate relations to the same value', () => {
+    const options = tallyDropdownOptions({
+      relations: [
+        { fromEntityId: 'row-1', toEntity: { id: 'a', name: 'Alpha' } },
+        { fromEntityId: 'row-1', toEntity: { id: 'a', name: 'Alpha' } },
+      ],
     });
-    expect(options).toEqual([{ id: 'a', name: 'Alpha' }]);
+    expect(options).toEqual([{ id: 'a', name: 'Alpha', count: 1 }]);
+  });
+
+  it('keeps a known name when a later relation resolves the same entity without one', () => {
+    const options = tallyDropdownOptions({
+      relations: [
+        { fromEntityId: 'row-1', toEntity: { id: 'a', name: 'Alpha' } },
+        { fromEntityId: 'row-2', toEntity: { id: 'a', name: null } },
+      ],
+    });
+    expect(options).toEqual([{ id: 'a', name: 'Alpha', count: 2 }]);
   });
 
   it('handles an empty or null relation list', () => {
-    expect(toDropdownOptions({ relations: null })).toEqual([]);
-    expect(toDropdownOptions({ relations: [] })).toEqual([]);
+    expect(tallyDropdownOptions({ relations: null })).toEqual([]);
+    expect(tallyDropdownOptions({ relations: [] })).toEqual([]);
+  });
+});
+
+describe('mergeDropdownOptionCounts', () => {
+  it('sums counts across disjoint partitions and backfills names', () => {
+    const merged = mergeDropdownOptionCounts([
+      [
+        { id: 'a', name: null, count: 2 },
+        { id: 'b', name: 'Beta', count: 1 },
+      ],
+      [{ id: 'a', name: 'Alpha', count: 3 }],
+    ]);
+    expect(merged).toEqual([
+      { id: 'a', name: 'Alpha', count: 5 },
+      { id: 'b', name: 'Beta', count: 1 },
+    ]);
+  });
+
+  it('leaves a count undefined only when no partition supplied one', () => {
+    const merged = mergeDropdownOptionCounts([[{ id: 'a', name: 'Alpha' }], [{ id: 'a', name: 'Alpha', count: 2 }]]);
+    expect(merged).toEqual([{ id: 'a', name: 'Alpha', count: 2 }]);
   });
 });
 
@@ -65,5 +106,49 @@ describe('populationVariablesFromWhere', () => {
       first: 50,
       after: null,
     });
+  });
+});
+
+describe('populationVariablesForIds', () => {
+  it('joins the id constraint onto the normalized filter and keeps promotion', () => {
+    const variables = populationVariablesForIds(['id-1', 'id-2'], {
+      AND: [{ spaces: [{ equals: 'space-1' }] }, { types: [{ id: { equals: 'type-a' } }] }],
+    });
+
+    expect(variables.spaceId).toBe('space-1');
+    expect(variables.typeId).toBe('type-a');
+    expect(variables.filter).toMatchObject({ id: { in: ['id-1', 'id-2'] } });
+    expect(variables.first).toBe(2);
+  });
+
+  it('produces a bare id filter for an empty where', () => {
+    const variables = populationVariablesForIds(['id-1'], {});
+    expect(variables.filter).toEqual({ id: { in: ['id-1'] } });
+    expect(variables.spaceId).toBeNull();
+  });
+});
+
+describe('slicePopulationIds', () => {
+  const ids = Array.from({ length: DROPDOWN_POPULATION_PAGE_SIZE + 5 }, (_, i) => `id-${i}`);
+
+  it('takes the first page from a null cursor and reports more', () => {
+    const { slice, endCursor, hasNextPage } = slicePopulationIds(ids, null);
+    expect(slice).toHaveLength(DROPDOWN_POPULATION_PAGE_SIZE);
+    expect(slice[0]).toBe('id-0');
+    expect(endCursor).toBe(String(DROPDOWN_POPULATION_PAGE_SIZE));
+    expect(hasNextPage).toBe(true);
+  });
+
+  it('resumes from a numeric cursor and ends the walk at the tail', () => {
+    const { slice, endCursor, hasNextPage } = slicePopulationIds(ids, String(DROPDOWN_POPULATION_PAGE_SIZE));
+    expect(slice).toEqual(['id-1000', 'id-1001', 'id-1002', 'id-1003', 'id-1004']);
+    expect(endCursor).toBe(String(ids.length));
+    expect(hasNextPage).toBe(false);
+  });
+
+  it('returns an empty terminal slice past the end', () => {
+    const { slice, hasNextPage } = slicePopulationIds(['a'], '5');
+    expect(slice).toEqual([]);
+    expect(hasNextPage).toBe(false);
   });
 });

--- a/apps/web/core/blocks/data/fetch-dropdown-options.ts
+++ b/apps/web/core/blocks/data/fetch-dropdown-options.ts
@@ -18,7 +18,24 @@ import {
 } from '~/core/io/type-filter';
 import type { WhereCondition } from '~/core/sync/experimental_query-layer';
 
-export type DropdownOption = { id: string; name: string | null };
+/**
+ * `count` is how many population rows carry this value, summed as the walk
+ * progresses: exact once the scope is exhausted, a lower bound while more of
+ * it remains. Undefined only for pinned entries the walk has not reached.
+ */
+export type DropdownOption = { id: string; name: string | null; count?: number };
+
+/**
+ * Where a dropdown's population comes from:
+ * - `query`: the block's (overlaid) filter, walked via entitiesConnection —
+ *   SPACES/GEO blocks.
+ * - `ids`: an explicit ordered id list — COLLECTION blocks, whose membership
+ *   is enumerated relations rather than a query. The `where` still applies
+ *   (block filters and other dropdowns' selections narrow the population);
+ *   it is evaluated server-side against each id slice.
+ */
+export type DropdownPopulation =
+  { kind: 'query'; where: WhereCondition } | { kind: 'ids'; ids: string[]; where: WhereCondition };
 
 /**
  * A dropdown's scope is the table's population: the entities the block's
@@ -31,6 +48,11 @@ export type DropdownOption = { id: string; name: string | null };
  * same normalized connection query the table runs, and each page's
  * relations for the property are read by `fromEntityId` (indexed). Pages
  * are pulled as the user scrolls or searches.
+ *
+ * Per-option counts ride along for free: the walk already reads every
+ * (row → value) relation, so counting rows per value is a tally, not a
+ * query. A server-side COUNT per option was measured at 2–22s on the live
+ * API and is deliberately not used.
  */
 export const DROPDOWN_POPULATION_PAGE_SIZE = 1000;
 /**
@@ -88,7 +110,7 @@ const POPULATION_PAGE_DOCUMENT = parse(/* GraphQL */ `
 `) as unknown as TypedDocumentNode<PopulationPageResult, PopulationPageVariables>;
 
 type RelationsResult = {
-  relations: { toEntity: { id: string; name: string | null } | null }[] | null;
+  relations: { fromEntityId: string | null; toEntity: { id: string; name: string | null } | null }[] | null;
 };
 type RelationsChunk = { options: DropdownOption[]; windowHit: boolean };
 type RelationsVariables = { propertyId: string; fromEntityIds: string[]; first: number };
@@ -100,6 +122,7 @@ const RELATIONS_DOCUMENT = parse(/* GraphQL */ `
       first: $first
       orderBy: TO_ENTITY_ID_ASC
     ) {
+      fromEntityId
       toEntity {
         id
         name
@@ -138,15 +161,59 @@ export function populationVariablesFromWhere(
   };
 }
 
-/** Distinct to-entities, name-sorted; a later relation never overwrites a known name with null. */
-export function toDropdownOptions(result: RelationsResult): DropdownOption[] {
-  const byId = new Map<string, DropdownOption>();
+/**
+ * Variables asking "which of these ids match the where" — the population
+ * check for an id-list (collection) slice. The id constraint joins the
+ * normalized filter; space/type promotion applies as usual.
+ */
+export function populationVariablesForIds(ids: string[], where: WhereCondition): PopulationPageVariables {
+  const variables = populationVariablesFromWhere(where, ids.length);
+  return {
+    ...variables,
+    filter: { ...(variables.filter ?? {}), id: { in: ids } } as EntityFilter,
+  };
+}
+
+/**
+ * Tally one relations result into options: distinct to-entities, name-sorted,
+ * each counting its DISTINCT from-entities — a row with duplicate relations
+ * to the same value counts once. A later relation never overwrites a known
+ * name with null.
+ */
+export function tallyDropdownOptions(result: RelationsResult): DropdownOption[] {
+  const byId = new Map<string, { id: string; name: string | null; fromIds: Set<string> }>();
   for (const relation of result.relations ?? []) {
     const target = relation.toEntity;
     if (!target?.id) continue;
     const existing = byId.get(target.id);
-    if (!existing || (!existing.name && target.name)) {
-      byId.set(target.id, { id: target.id, name: target.name ?? null });
+    if (!existing) {
+      byId.set(target.id, { id: target.id, name: target.name ?? null, fromIds: new Set() });
+    } else if (!existing.name && target.name) {
+      existing.name = target.name;
+    }
+    if (relation.fromEntityId) byId.get(target.id)?.fromIds.add(relation.fromEntityId);
+  }
+  return [...byId.values()]
+    .map(({ id, name, fromIds }) => ({ id, name, count: fromIds.size }))
+    .sort((a, b) => (a.name ?? '').localeCompare(b.name ?? ''));
+}
+
+/**
+ * Merge option lists whose underlying from-entity sets are DISJOINT (relation
+ * chunks of one page, split halves of one chunk, successive walk pages), so
+ * counts add. Names keep the first known value; order is name-sorted.
+ */
+export function mergeDropdownOptionCounts(lists: DropdownOption[][]): DropdownOption[] {
+  const byId = new Map<string, DropdownOption>();
+  for (const list of lists) {
+    for (const option of list) {
+      const existing = byId.get(option.id);
+      if (!existing) {
+        byId.set(option.id, { ...option });
+        continue;
+      }
+      if (!existing.name && option.name) existing.name = option.name;
+      if (option.count !== undefined) existing.count = (existing.count ?? 0) + option.count;
     }
   }
   return [...byId.values()].sort((a, b) => (a.name ?? '').localeCompare(b.name ?? ''));
@@ -180,7 +247,7 @@ function fetchRelationsForChunk({
     const chunk: RelationsChunk = yield* graphql({
       query: RELATIONS_DOCUMENT,
       decoder: (result: RelationsResult) => ({
-        options: toDropdownOptions(result),
+        options: tallyDropdownOptions(result),
         windowHit: (result.relations ?? []).length >= DROPDOWN_RELATION_WINDOW,
       }),
       variables: { propertyId, fromEntityIds, first: DROPDOWN_RELATION_WINDOW },
@@ -199,42 +266,90 @@ function fetchRelationsForChunk({
       ],
       { concurrency: 2 }
     );
-    return halves.flat();
+    // Halves partition the ids, so their per-option counts add.
+    return mergeDropdownOptionCounts(halves);
+  });
+}
+
+/** The next slice of an id-list population, with its cursor math. */
+export function slicePopulationIds(
+  ids: string[],
+  after: string | null | undefined
+): { slice: string[]; endCursor: string | null; hasNextPage: boolean } {
+  const offset = after ? Number.parseInt(after, 10) || 0 : 0;
+  const slice = ids.slice(offset, offset + DROPDOWN_POPULATION_PAGE_SIZE);
+  const end = offset + slice.length;
+  return { slice, endCursor: String(end), hasNextPage: end < ids.length };
+}
+
+function fetchPopulationIds(
+  population: DropdownPopulation,
+  after: string | null | undefined,
+  signal?: AbortSignal
+): Effect.Effect<{ ids: string[]; populationCount: number; endCursor: string | null; hasNextPage: boolean }, unknown> {
+  return Effect.gen(function* () {
+    if (population.kind === 'ids') {
+      const { slice, endCursor, hasNextPage } = slicePopulationIds(population.ids, after);
+      if (slice.length === 0) {
+        return { ids: [], populationCount: 0, endCursor, hasNextPage: false };
+      }
+      if (Object.keys(population.where).length === 0) {
+        return { ids: slice, populationCount: slice.length, endCursor, hasNextPage };
+      }
+      // The where narrows which collection rows belong to the population
+      // (block filters plus other dropdowns' selections); ask the server
+      // which of this slice's ids survive it.
+      const matching = yield* graphql({
+        query: POPULATION_PAGE_DOCUMENT,
+        decoder: (data: PopulationPageResult) => (data.entitiesConnection?.nodes ?? []).map(node => node.id),
+        variables: populationVariablesForIds(slice, population.where),
+        signal,
+      });
+      return { ids: matching, populationCount: slice.length, endCursor, hasNextPage };
+    }
+
+    const page = yield* graphql({
+      query: POPULATION_PAGE_DOCUMENT,
+      decoder: (data: PopulationPageResult) => ({
+        ids: (data.entitiesConnection?.nodes ?? []).map(node => node.id),
+        endCursor: data.entitiesConnection?.pageInfo.endCursor ?? null,
+        hasNextPage: data.entitiesConnection?.pageInfo.hasNextPage ?? false,
+      }),
+      variables: populationVariablesFromWhere(population.where, DROPDOWN_POPULATION_PAGE_SIZE, after),
+      signal,
+    });
+    return {
+      ids: page.ids,
+      populationCount: page.ids.length,
+      endCursor: page.endCursor,
+      hasNextPage: page.hasNextPage,
+    };
   });
 }
 
 /** One page of the scope: the property's values across the next slice of the table's population. */
 export function fetchDropdownOptionsPage({
   propertyId,
-  where,
+  population,
   after,
   signal,
 }: {
   propertyId: string;
-  where: WhereCondition;
+  population: DropdownPopulation;
   after?: string | null;
   signal?: AbortSignal;
 }): Promise<DropdownOptionsPage> {
   return Effect.runPromise(
     Effect.gen(function* () {
-      const population = yield* graphql({
-        query: POPULATION_PAGE_DOCUMENT,
-        decoder: (data: PopulationPageResult) => ({
-          ids: (data.entitiesConnection?.nodes ?? []).map(node => node.id),
-          endCursor: data.entitiesConnection?.pageInfo.endCursor ?? null,
-          hasNextPage: data.entitiesConnection?.pageInfo.hasNextPage ?? false,
-        }),
-        variables: populationVariablesFromWhere(where, DROPDOWN_POPULATION_PAGE_SIZE, after),
-        signal,
-      });
+      const { ids, populationCount, endCursor, hasNextPage } = yield* fetchPopulationIds(population, after, signal);
 
-      if (population.ids.length === 0) {
-        return { options: [], endCursor: population.endCursor, hasNextPage: false, populationCount: 0 };
+      if (ids.length === 0) {
+        return { options: [], endCursor, hasNextPage, populationCount };
       }
 
       const chunks: string[][] = [];
-      for (let start = 0; start < population.ids.length; start += DROPDOWN_RELATION_CHUNK) {
-        chunks.push(population.ids.slice(start, start + DROPDOWN_RELATION_CHUNK));
+      for (let start = 0; start < ids.length; start += DROPDOWN_RELATION_CHUNK) {
+        chunks.push(ids.slice(start, start + DROPDOWN_RELATION_CHUNK));
       }
 
       const perChunk = yield* Effect.all(
@@ -243,12 +358,11 @@ export function fetchDropdownOptionsPage({
       );
 
       return {
-        options: toDropdownOptions({
-          relations: perChunk.flat().map(option => ({ toEntity: { id: option.id, name: option.name } })),
-        }),
-        endCursor: population.endCursor,
-        hasNextPage: population.hasNextPage,
-        populationCount: population.ids.length,
+        // Chunks partition the page's ids, so their counts add.
+        options: mergeDropdownOptionCounts(perChunk),
+        endCursor,
+        hasNextPage,
+        populationCount,
       };
     })
   );

--- a/apps/web/core/blocks/data/use-dropdown-options.ts
+++ b/apps/web/core/blocks/data/use-dropdown-options.ts
@@ -6,31 +6,55 @@ import * as React from 'react';
 
 import { ID } from '~/core/id';
 
-import { type DropdownOption, fetchDropdownOptionsPage } from './fetch-dropdown-options';
+import { type DropdownOption, type DropdownPopulation, fetchDropdownOptionsPage } from './fetch-dropdown-options';
 import { filterStateToWhere } from './filter-state-to-where';
 import type { Filter, ModesByColumn } from './filters';
+import { type DropdownSelections, applyDropdownSelectionsToFilters } from './table-dropdown-selections';
 
 export type { DropdownOption } from './fetch-dropdown-options';
 
 /** Pages (× 1000 population rows) read without any user intent. */
 const AUTO_WALK_PAGES = 3;
 
+/** Cheap stable fingerprint for an id list — FNV-1a over the joined ids. */
+function fingerprintIds(ids: string[]): string {
+  let hash = 0x811c9dc5;
+  for (const id of ids) {
+    for (let i = 0; i < id.length; i++) {
+      hash ^= id.charCodeAt(i);
+      hash = Math.imul(hash, 0x01000193);
+    }
+    hash ^= 0x2c; // separator
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return `${ids.length}:${(hash >>> 0).toString(36)}`;
+}
+
 /**
- * The values of one property across the table's population — the block's
- * filter with this property's own constraint removed, so the list is not
- * narrowed by what is currently selected. The walk reads the first
- * AUTO_WALK_PAGES pages on its own; past that it advances only on demand
- * (the user scrolling to the end of the list, or a typed search), so a
- * dropdown on a huge scope cannot crawl the corpus just by sitting open.
- * Closing the menu stops the walk; reopening resumes from the cursor.
- * "No values"/"no matches" are only ever reported once the scope is
- * exhausted — a paused walk says so instead. Selected and filter-default
- * entities are always present so a preset never goes missing.
+ * The values of one property across the table's population, with per-option
+ * counts (rows carrying the value). The population is faceted the way the
+ * bounty board's filters are: the block's filter plus the OTHER dropdowns'
+ * selections apply, this property's own constraint is removed, so the list
+ * is never narrowed by what is currently selected here but does react to
+ * the other columns.
+ *
+ * The walk reads the first AUTO_WALK_PAGES pages on its own; past that it
+ * advances only on demand (the user scrolling to the end of the list, or a
+ * typed search), so a dropdown on a huge scope cannot crawl the corpus just
+ * by sitting open. Closing the menu stops the walk; reopening resumes from
+ * the cursor. "No values"/"no matches" are only ever reported once the
+ * scope is exhausted — a paused walk says so instead. Selected and
+ * filter-default entities are always present so a preset never goes
+ * missing. Counts are exact once the scope is exhausted and a lower bound
+ * ("N+") while it is not.
  */
 export function useDropdownOptions({
   columnId,
   baseFilterState,
   baseModesByColumn,
+  selections,
+  facetColumnIds,
+  collectionItemIds,
   pinned,
   enabled,
   demand = false,
@@ -38,28 +62,43 @@ export function useDropdownOptions({
   columnId: string;
   baseFilterState: Filter[];
   baseModesByColumn: ModesByColumn;
+  /** Personal selections; the ones on OTHER facet columns narrow this population. */
+  selections: DropdownSelections;
+  /** The overlay's applied columns — the facet dimensions. */
+  facetColumnIds: string[];
+  /** COLLECTION blocks: the ordered item ids that ARE the population; null for query sources. */
+  collectionItemIds: string[] | null;
   /** Ids (with names when known) that must appear regardless of what has loaded. */
   pinned: DropdownOption[];
   enabled: boolean;
   /** User intent to read past the auto-walk window: scrolled to the end, or searching. */
   demand?: boolean;
 }) {
-  const where = React.useMemo(() => {
-    const withoutColumn = baseFilterState.filter(f => !(ID.equals(f.columnId, columnId) && !f.isBacklink));
-    return filterStateToWhere(withoutColumn, baseModesByColumn);
-  }, [baseFilterState, baseModesByColumn, columnId]);
+  const population: DropdownPopulation = React.useMemo(() => {
+    const otherColumns = facetColumnIds.filter(id => !ID.equals(id, columnId));
+    const overlaid = applyDropdownSelectionsToFilters(baseFilterState, baseModesByColumn, selections, otherColumns);
+    const withoutColumn = overlaid.filterState.filter(f => !(ID.equals(f.columnId, columnId) && !f.isBacklink));
+    const where = filterStateToWhere(withoutColumn, overlaid.modesByColumn);
+    return collectionItemIds ? { kind: 'ids', ids: collectionItemIds, where } : { kind: 'query', where };
+  }, [baseFilterState, baseModesByColumn, selections, facetColumnIds, columnId, collectionItemIds]);
 
-  const whereKey = React.useMemo(() => JSON.stringify(where), [where]);
+  const populationKey = React.useMemo(
+    () =>
+      population.kind === 'ids'
+        ? `ids:${fingerprintIds(population.ids)}:${JSON.stringify(population.where)}`
+        : `query:${JSON.stringify(population.where)}`,
+    [population]
+  );
 
   const { data, isFetching, isError, fetchNextPage, hasNextPage, refetch } = useInfiniteQuery({
-    queryKey: ['data-block', 'dropdown-options', columnId, whereKey],
+    queryKey: ['data-block', 'dropdown-options', columnId, populationKey],
     enabled,
     initialPageParam: null as string | null,
     queryFn: ({ pageParam, signal }) =>
-      fetchDropdownOptionsPage({ propertyId: columnId, where, after: pageParam, signal }),
+      fetchDropdownOptionsPage({ propertyId: columnId, population, after: pageParam, signal }),
     getNextPageParam: lastPage => (lastPage.hasNextPage ? lastPage.endCursor : undefined),
-    // The scope for a fixed where does not change mid-session, and a focus
-    // refetch would replay every accumulated page of the walk serially.
+    // The scope for a fixed population does not change mid-session, and a
+    // focus refetch would replay every accumulated page of the walk serially.
     staleTime: Infinity,
     refetchOnWindowFocus: false,
   });
@@ -84,6 +123,9 @@ export function useDropdownOptions({
   /** More of the scope exists beyond what has been read. */
   const hasMoreInScope = Boolean(hasNextPage);
 
+  /** The whole scope has been read: counts are exact, absences are real. */
+  const scopeExhausted = enabled && !isError && data !== undefined && !hasMoreInScope && !isFetching;
+
   /** How many population rows the walk has checked so far. */
   const scannedCount = React.useMemo(
     () => (data?.pages ?? []).reduce((sum, page) => sum + page.populationCount, 0),
@@ -91,13 +133,18 @@ export function useDropdownOptions({
   );
 
   // Pinned first, then values in arrival order (each page name-sorted) so
-  // the list never reshuffles under the cursor as pages arrive.
+  // the list never reshuffles under the cursor as pages arrive. Walk pages
+  // partition the population, so per-option counts add across them.
   const options: DropdownOption[] = React.useMemo(() => {
     const byId = new Map<string, DropdownOption>();
     const add = (option: DropdownOption) => {
       const existing = byId.get(option.id);
-      if (!existing) byId.set(option.id, option);
-      else if (!existing.name && option.name) byId.set(option.id, { ...existing, name: option.name });
+      if (!existing) {
+        byId.set(option.id, { ...option });
+        return;
+      }
+      if (!existing.name && option.name) existing.name = option.name;
+      if (option.count !== undefined) existing.count = (existing.count ?? 0) + option.count;
     };
     pinned.forEach(add);
     for (const page of data?.pages ?? []) page.options.forEach(add);
@@ -109,5 +156,5 @@ export function useDropdownOptions({
     [options]
   );
 
-  return { options, nameOf, isWalking, hasMoreInScope, isError, retry: refetch, scannedCount };
+  return { options, nameOf, isWalking, hasMoreInScope, scopeExhausted, isError, retry: refetch, scannedCount };
 }

--- a/apps/web/core/blocks/data/use-dropdown-query-overlay.ts
+++ b/apps/web/core/blocks/data/use-dropdown-query-overlay.ts
@@ -1,15 +1,30 @@
 'use client';
 
+import { Position, SystemIds } from '@geoprotocol/geo-sdk/lite';
+
 import * as React from 'react';
 
 import { ID } from '~/core/id';
+import { useQueryEntity } from '~/core/sync/use-store';
 import type { Property } from '~/core/types';
 
 import type { Filter, ModesByColumn } from './filters';
 import type { Source } from './source';
 import { applyDropdownSelectionsToFilters } from './table-dropdown-selections';
 import { useBlockDropdowns } from './use-block-dropdowns';
+import { useDataBlockInstance } from './use-data-block';
 import { useTableDropdownSelections } from './use-table-dropdown-selections';
+
+/**
+ * Sources whose rows can carry a personal dropdown filter. SPACES/GEO rows
+ * come from the block's query and COLLECTION rows flow through the same
+ * where (useCollection filters its enumerated ids by it), so the overlay
+ * mechanism is identical. RELATIONS is out: its rows are selector
+ * projections of a single entity, not entities matched by predicates.
+ */
+export function sourceSupportsDropdowns(source: Source): boolean {
+  return source.type === 'SPACES' || source.type === 'GEO' || source.type === 'COLLECTION';
+}
 
 /**
  * The single owner of the browse-dropdown query overlay, shared by
@@ -17,8 +32,8 @@ import { useTableDropdownSelections } from './use-table-dropdown-selections';
  * which columns apply or when.
  *
  * Invariants centralized here:
- * - Dropdowns act on the block's query; Collection and Relations sources
- *   have none, so the overlay is inert there (matching the hidden UI).
+ * - Dropdowns act on the block's population; Relations sources have none,
+ *   so the overlay is inert there (matching the hidden UI).
  * - `appliedColumnIds` is THE list: the overlay applies exactly these
  *   columns and the pills render exactly these columns, so a stored
  *   selection can never filter the table without a visible control.
@@ -42,7 +57,27 @@ export function useDropdownQueryOverlay({
   const { blocksRelationEntityId, dropdowns: configs, toggleDropdownProperty } = useBlockDropdowns();
   const { selections, updateSelections, hydrated } = useTableDropdownSelections(blocksRelationEntityId);
 
-  const isQuerySource = source.type === 'SPACES' || source.type === 'GEO';
+  const supportsDropdowns = sourceSupportsDropdowns(source);
+
+  // COLLECTION populations are the block's enumerated item ids. Read them
+  // here — the one place both surfaces share — so the options walk and the
+  // row filter can never disagree about membership. Mirrors useCollection's
+  // own enumeration (dedupe by target, Position order).
+  const { entityId, spaceId } = useDataBlockInstance();
+  const { entity: blockEntity } = useQueryEntity({
+    spaceId,
+    id: entityId,
+    enabled: source.type === 'COLLECTION',
+  });
+  const collectionItemIds = React.useMemo(() => {
+    if (source.type !== 'COLLECTION' || !blockEntity) return source.type === 'COLLECTION' ? [] : null;
+    const seen = new Set<string>();
+    return blockEntity.relations
+      .filter(r => r.fromEntity.id === source.value && r.type.id === SystemIds.COLLECTION_ITEM_RELATION_TYPE)
+      .sort((a, z) => Position.compare(a.position ?? null, z.position ?? null))
+      .map(r => r.toEntity.id)
+      .filter(id => (seen.has(id) ? false : (seen.add(id), true)));
+  }, [source, blockEntity]);
 
   const appliedColumnIds = React.useMemo(() => {
     const pillProperties = [...filterableProperties, ...(extraPillProperties ?? [])];
@@ -51,7 +86,7 @@ export function useDropdownQueryOverlay({
       .filter(id => pillProperties.some(p => ID.equals(p.id, id) && p.dataType === 'RELATION'));
   }, [configs, filterableProperties, extraPillProperties]);
 
-  const isActive = !isEditing && isQuerySource && hydrated && appliedColumnIds.length > 0;
+  const isActive = !isEditing && supportsDropdowns && hydrated && appliedColumnIds.length > 0;
 
   const { filterState: queryFilterState, modesByColumn: queryModesByColumn } = React.useMemo(
     () =>
@@ -72,7 +107,8 @@ export function useDropdownQueryOverlay({
       updateSelections,
       hydrated,
       appliedColumnIds,
-      isQuerySource,
+      supportsDropdowns,
+      collectionItemIds,
     },
   };
 }

--- a/apps/web/partials/blocks/table/table-block-dropdowns.tsx
+++ b/apps/web/partials/blocks/table/table-block-dropdowns.tsx
@@ -43,6 +43,8 @@ type TableBlockDropdownsProps = {
   selections: DropdownSelections;
   updateSelections: (updater: (current: DropdownSelections) => DropdownSelections) => void;
   hydrated: boolean;
+  /** COLLECTION blocks: the ordered item ids forming the population; null for query sources. */
+  collectionItemIds: string[] | null;
 };
 
 /**
@@ -62,6 +64,7 @@ export function TableBlockDropdowns({
   selections,
   updateSelections,
   hydrated,
+  collectionItemIds,
 }: TableBlockDropdownsProps) {
   const [openColumnId, setOpenColumnId] = React.useState<string | null>(null);
 
@@ -88,6 +91,8 @@ export function TableBlockDropdowns({
           selections={selections}
           updateSelections={updateSelections}
           hydrated={hydrated}
+          facetColumnIds={appliedColumnIds}
+          collectionItemIds={collectionItemIds}
           open={openColumnId === config.propertyId}
           onOpenChange={open =>
             setOpenColumnId(current => (open ? config.propertyId : current === config.propertyId ? null : current))
@@ -106,11 +111,15 @@ function TableBlockDropdown({
   selections,
   updateSelections,
   hydrated,
+  facetColumnIds,
+  collectionItemIds,
   open,
   onOpenChange,
 }: Omit<TableBlockDropdownsProps, 'configs' | 'appliedColumnIds' | 'properties' | 'spaceId'> & {
   config: BlockDropdownConfig;
   property: Property | undefined;
+  /** The overlay's applied columns — the other facets narrowing this population. */
+  facetColumnIds: string[];
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }) {
@@ -155,14 +164,18 @@ function TableBlockDropdown({
 
   // The dropdown's one scope: this property's values across the table's
   // population; the first pages load on their own, the rest on demand.
-  const { options, nameOf, isWalking, hasMoreInScope, isError, retry, scannedCount } = useDropdownOptions({
-    columnId,
-    baseFilterState,
-    baseModesByColumn,
-    pinned,
-    enabled: open,
-    demand: query.length > 0 || scrolledToEnd,
-  });
+  const { options, nameOf, isWalking, hasMoreInScope, scopeExhausted, isError, retry, scannedCount } =
+    useDropdownOptions({
+      columnId,
+      baseFilterState,
+      baseModesByColumn,
+      selections,
+      facetColumnIds,
+      collectionItemIds,
+      pinned,
+      enabled: open,
+      demand: query.length > 0 || scrolledToEnd,
+    });
 
   const visibleOptions = React.useMemo(() => {
     if (!query) return options;
@@ -313,17 +326,34 @@ function TableBlockDropdown({
           )}
           {renderedOptions.map(option => {
             const checked = selected.some(id => ID.equals(id, option.id));
+            // Counts follow the walk: exact once the scope is exhausted, a
+            // lower bound ("N+") while more of it remains, absent for pinned
+            // values the walk has not reached. A definite zero is shown but
+            // inert (bounty-board facet behavior) — unless checked, so it can
+            // still be unselected.
+            const count = option.count ?? (scopeExhausted ? 0 : undefined);
+            const isInertZero = scopeExhausted && (option.count ?? 0) === 0 && !checked;
             return (
               <button
                 key={option.id}
                 type="button"
                 role="menuitemcheckbox"
                 aria-checked={checked}
+                disabled={isInertZero}
                 onClick={() => toggle(option.id)}
-                className="flex items-center gap-2 rounded px-2 py-2 text-left text-sm text-text hover:bg-grey-01"
+                className={cx(
+                  'flex items-center gap-2 rounded px-2 py-2 text-left text-sm text-text hover:bg-grey-01',
+                  isInertZero && 'opacity-50 hover:bg-transparent'
+                )}
               >
                 <CheckboxVisual checked={checked} />
                 <span className="min-w-0 truncate">{option.name ?? option.id}</span>
+                {count !== undefined && (
+                  <span className="ml-auto shrink-0 pl-2 text-footnote text-grey-04">
+                    {count.toLocaleString()}
+                    {hasMoreInScope ? '+' : ''}
+                  </span>
+                )}
               </button>
             );
           })}

--- a/apps/web/partials/blocks/table/table-block.tsx
+++ b/apps/web/partials/blocks/table/table-block.tsx
@@ -21,6 +21,7 @@ import { columnPropertyIdFromRelation } from '~/core/blocks/data/shown-column-re
 import { Source } from '~/core/blocks/data/source';
 import { useBlockInfiniteScroll } from '~/core/blocks/data/use-block-infinite-scroll';
 import { useDataBlock, useDataBlockInstance } from '~/core/blocks/data/use-data-block';
+import { sourceSupportsDropdowns } from '~/core/blocks/data/use-dropdown-query-overlay';
 import { useFilters } from '~/core/blocks/data/use-filters';
 import {
   isEntityVisibleInBlock,
@@ -752,8 +753,8 @@ const ConfiguredTableBlock = ({
     return out;
   }, [filterableProperties, properties]);
 
-  /** Dropdowns act on the block's query; Collection and Relations blocks have none. */
-  const isQuerySource = source.type === 'SPACES' || source.type === 'GEO';
+  /** Dropdowns cover query and collection populations; Relations blocks have none to filter. */
+  const supportsDropdowns = sourceSupportsDropdowns(source);
 
   // Infinite scroll is opt-in via the Infinite scroll BOOLEAN on the Blocks
   // relation entity (same entity that holds View and Properties).
@@ -1140,7 +1141,7 @@ const ConfiguredTableBlock = ({
 
         <BlockLinkIngestionPanel />
 
-        {!isEditing && isQuerySource && browseDropdowns.configs.length > 0 && (
+        {!isEditing && supportsDropdowns && browseDropdowns.configs.length > 0 && (
           <div className="flex flex-wrap items-center gap-2 py-2" onMouseDown={e => e.stopPropagation()}>
             <TableBlockDropdowns
               configs={browseDropdowns.configs}
@@ -1152,6 +1153,7 @@ const ConfiguredTableBlock = ({
               selections={browseDropdowns.selections}
               updateSelections={browseDropdowns.updateSelections}
               hydrated={browseDropdowns.hydrated}
+              collectionItemIds={browseDropdowns.collectionItemIds}
             />
           </div>
         )}
@@ -1203,7 +1205,7 @@ const ConfiguredTableBlock = ({
                         orderedColumnIds={orderedFilterColumnIds}
                         isEditing={isEditing}
                         afterFilterTrigger={
-                          isQuerySource ? (
+                          supportsDropdowns ? (
                             <TableBlockDropdownsConfigTrigger
                               configs={browseDropdowns.configs}
                               properties={mergedBlockProperties}
@@ -1238,9 +1240,10 @@ const ConfiguredTableBlock = ({
                 </div>
 
                 {isEditing &&
-                  (filterGroupsForToolbarPills.length > 0 || (isQuerySource && browseDropdowns.configs.length > 0)) && (
+                  (filterGroupsForToolbarPills.length > 0 ||
+                    (supportsDropdowns && browseDropdowns.configs.length > 0)) && (
                     <div className="flex flex-wrap items-center gap-2">
-                      {isQuerySource && (
+                      {supportsDropdowns && (
                         <TableBlockDropdownsConfigChips
                           configs={browseDropdowns.configs}
                           properties={mergedBlockProperties}

--- a/apps/web/partials/power-tools/power-tools-screen.tsx
+++ b/apps/web/partials/power-tools/power-tools-screen.tsx
@@ -935,9 +935,9 @@ export function PowerToolsScreen() {
 
   const hasActiveFilters = effectiveFilterState.length > 0;
 
-  const isQuerySource = browseDropdowns.isQuerySource;
-  const showBrowseDropdownsRow = !isEditing && isQuerySource && browseDropdowns.configs.length > 0;
-  const showPillsRow = hasActiveFilters || (isEditing && isQuerySource && browseDropdowns.configs.length > 0);
+  const supportsDropdowns = browseDropdowns.supportsDropdowns;
+  const showBrowseDropdownsRow = !isEditing && supportsDropdowns && browseDropdowns.configs.length > 0;
+  const showPillsRow = hasActiveFilters || (isEditing && supportsDropdowns && browseDropdowns.configs.length > 0);
 
   const filterGroups = React.useMemo(() => groupFilters(effectiveFilterState), [effectiveFilterState]);
 
@@ -1015,7 +1015,7 @@ export function PowerToolsScreen() {
             setFilterState={effectiveSetFilterState}
             modesByColumn={activeModesByColumn}
             afterFilterTrigger={
-              isEditing && isQuerySource ? (
+              isEditing && supportsDropdowns ? (
                 <TableBlockDropdownsConfigTrigger
                   configs={browseDropdowns.configs}
                   properties={data.properties}
@@ -1090,6 +1090,7 @@ export function PowerToolsScreen() {
             selections={browseDropdowns.selections}
             updateSelections={browseDropdowns.updateSelections}
             hydrated={browseDropdowns.hydrated}
+            collectionItemIds={browseDropdowns.collectionItemIds}
           />
         </div>
       )}
@@ -1097,7 +1098,7 @@ export function PowerToolsScreen() {
       {showPillsRow && (
         <div className="flex items-center gap-2 border-b border-grey-02 px-4 py-2">
           <div className="flex flex-wrap items-center gap-1.5">
-            {isEditing && isQuerySource && (
+            {isEditing && supportsDropdowns && (
               <TableBlockDropdownsConfigChips
                 configs={browseDropdowns.configs}
                 properties={data.properties}


### PR DESCRIPTION
Stacked on #2213. Extends the browse-mode table dropdowns (GEO-2592) to COLLECTION source blocks and adds bounty-board-style match counts to every option.

## What changed

**Collections get dropdowns**
- `DropdownPopulation` union: query blocks walk `entitiesConnection` as before; collection blocks feed their enumerated, Position-ordered item ids through the same page/chunk pipeline. When a `where` applies it is checked per id-slice with one indexed `id-in + filter` query.
- Row filtering needed no new machinery: the overlay's filter state already flows into `useCollection({ where })`, which intersects the enumerated ids server-side with collection order preserved. The only blocker was the gate — now `sourceSupportsDropdowns` (SPACES/GEO/COLLECTION), applied on the table block and Power Tools alike.
- RELATIONS blocks stay excluded: their rows are selector projections of a single entity, with no population a checkbox predicate could filter.

**Per-option counts, considering the totality of filters**
- Each option shows how many rows carry it. The population is faceted the way the bounty board's filters are: the block's filter plus the OTHER dropdowns' selections apply; the property's own constraint is removed.
- Counts are computed from the relations the walk already reads — zero extra queries. (Server-side `totalCount` per option was measured at 2–22s per option on api-testnet, pathological for OR shapes, and deliberately not used.)
- Display: exact (`312`) once the scope is exhausted, lower bound (`312+`) while more remains, no badge for pinned values the walk hasn't reached. Definite zeros render inert (greyed) unless selected, so they can still be unselected.

## Verification
- 8 new unit tests (tally row-dedupe, disjoint count merging, id-cursor math, id-filter promotion); full suite 3701/3701.
- `tsc --noEmit` clean; local production build green.
- Live-API probes informing the design (49.5M-entity graph): whole-graph count 6.9s, single predicate ~2.5s, OR-of-two 22.3s → client-side tally chosen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KSsRb6kYhhrKJf5ZEsTWp3