### PR TITLE
feat(debates): publish debate media as durable geo-chat URLs instead of pinning to IPFS

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -62,6 +62,10 @@ CURATOR_BACKEND_URL=https://curator-api-staging-testnet.up.railway.app
 # Features (optional)
 # NEXT_PUBLIC_MAPBOX_TOKEN=
 # NEXT_PUBLIC_GEO_CHAT_API_BASE_URL=http://localhost:8080
+# Host used to build published debate media URLs. These go on-chain and can never change for
+# already-published debates, so keep it a public hostname you control independently of the API
+# host. Defaults to NEXT_PUBLIC_GEO_CHAT_API_BASE_URL when unset.
+# NEXT_PUBLIC_DEBATE_MEDIA_BASE_URL=http://localhost:8080
 
 # Build (optional)
 # DISABLE_REACT_COMPILER=1

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -62,12 +62,9 @@ CURATOR_BACKEND_URL=https://curator-api-staging-testnet.up.railway.app
 # Features (optional)
 # NEXT_PUBLIC_MAPBOX_TOKEN=
 # NEXT_PUBLIC_GEO_CHAT_API_BASE_URL=http://localhost:8080
-# Host used to build published debate media URLs. These go on-chain and can never change for
-# already-published debates, so keep it a public hostname you control independently of the API
-# host. Defaults to NEXT_PUBLIC_GEO_CHAT_API_BASE_URL when unset; in production one of the two
-# must be set or the publish sweep refuses to run. It must be an absolute http(s) URL: if you use
-# the /geo-chat-proxy dev setup for NEXT_PUBLIC_GEO_CHAT_API_BASE_URL, set this to the real
-# upstream host, or the sweep throws rather than publish a relative URL.
+# Public host for published debate media URLs (written on-chain). Defaults to
+# NEXT_PUBLIC_GEO_CHAT_API_BASE_URL; in production one of the two must be set. Must be an absolute
+# http(s) URL, so set it explicitly when using the /geo-chat-proxy dev setup.
 # NEXT_PUBLIC_DEBATE_MEDIA_BASE_URL=http://localhost:8080
 
 # Build (optional)

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -64,7 +64,10 @@ CURATOR_BACKEND_URL=https://curator-api-staging-testnet.up.railway.app
 # NEXT_PUBLIC_GEO_CHAT_API_BASE_URL=http://localhost:8080
 # Host used to build published debate media URLs. These go on-chain and can never change for
 # already-published debates, so keep it a public hostname you control independently of the API
-# host. Defaults to NEXT_PUBLIC_GEO_CHAT_API_BASE_URL when unset.
+# host. Defaults to NEXT_PUBLIC_GEO_CHAT_API_BASE_URL when unset; in production one of the two
+# must be set or the publish sweep refuses to run. It must be an absolute http(s) URL: if you use
+# the /geo-chat-proxy dev setup for NEXT_PUBLIC_GEO_CHAT_API_BASE_URL, set this to the real
+# upstream host, or the sweep throws rather than publish a relative URL.
 # NEXT_PUBLIC_DEBATE_MEDIA_BASE_URL=http://localhost:8080
 
 # Build (optional)

--- a/apps/web/app/api/debates/publish-sweep/route.test.ts
+++ b/apps/web/app/api/debates/publish-sweep/route.test.ts
@@ -106,8 +106,6 @@ describe('publish sweep', () => {
     await expect(sweep()).resolves.toMatchObject({ mediaFailed: [], pending: 0 });
   });
 
-  // A debate parked in a space the acceptor will never edit is terminal and costs nothing to
-  // detect, so a row of them must not eat the per-tick budget ahead of a publishable one.
   it('does not spend the attempt budget on debates the acceptor cannot edit', async () => {
     const parked = Array.from({ length: 8 }, (_, i) => `parked-${i}`);
     mocks.candidates = { 'space-1': [...parked, 'publishable'] };
@@ -118,9 +116,6 @@ describe('publish sweep', () => {
     await expect(sweep()).resolves.toMatchObject({ notEditor: 8, published: ['publishable'] });
   });
 
-  // The function must stop *between* publishes, never be killed inside one: a publish cut off
-  // after its proposal lands has no Debate entity for the idempotency check to find, and the next
-  // tick would mint a second set of media and transcript entities for the same debate.
   it('stops starting publishes once the time budget is spent', async () => {
     vi.useFakeTimers();
     mocks.editorSpaceIds = ['space-1', 'space-2'];
@@ -134,8 +129,6 @@ describe('publish sweep', () => {
     expect(mocks.publish).toHaveBeenCalledTimes(1);
   });
 
-  // One refusal for the run, before any debate is touched — not one failed attempt (and one
-  // orphaned share-card pin) per candidate per tick.
   it('refuses the whole run when the media host is misconfigured', async () => {
     vi.stubEnv('NODE_ENV', 'production');
     vi.stubEnv('NEXT_PUBLIC_GEO_CHAT_API_BASE_URL', '');

--- a/apps/web/app/api/debates/publish-sweep/route.test.ts
+++ b/apps/web/app/api/debates/publish-sweep/route.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { DebateNotPublishableError } from '~/core/debates/server/debate-source';
 
@@ -29,7 +29,9 @@ vi.mock('~/core/debates/server/publish-debate', () => ({
 
 async function sweep() {
   const { GET } = await import('./route');
-  const response = await GET(new Request('https://geo.test/api/debates/publish-sweep', { headers: { authorization: 'Bearer test-secret' } }));
+  const response = await GET(
+    new Request('https://geo.test/api/debates/publish-sweep', { headers: { authorization: 'Bearer test-secret' } })
+  );
   return response.json();
 }
 
@@ -39,6 +41,13 @@ beforeEach(() => {
   mocks.candidates = {};
   mocks.publish.mockReset();
 });
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllEnvs();
+});
+
+const publishedResult = { status: 'published', debateEntityId: 'e', spaceId: 'space-1', userOpHash: '0x1' };
 
 describe('publish sweep', () => {
   it('refuses a request without the cron secret', async () => {
@@ -50,7 +59,12 @@ describe('publish sweep', () => {
 
   it('publishes an eligible debate', async () => {
     mocks.candidates = { 'space-1': ['debate-1'] };
-    mocks.publish.mockResolvedValue({ status: 'published', debateEntityId: 'e1', spaceId: 'space-1', userOpHash: '0x1' });
+    mocks.publish.mockResolvedValue({
+      status: 'published',
+      debateEntityId: 'e1',
+      spaceId: 'space-1',
+      userOpHash: '0x1',
+    });
 
     await expect(sweep()).resolves.toMatchObject({ ok: true, published: ['debate-1'] });
   });
@@ -90,5 +104,51 @@ describe('publish sweep', () => {
     mocks.candidates = { 'space-1': [] };
 
     await expect(sweep()).resolves.toMatchObject({ mediaFailed: [], pending: 0 });
+  });
+
+  // A debate parked in a space the acceptor will never edit is terminal and costs nothing to
+  // detect, so a row of them must not eat the per-tick budget ahead of a publishable one.
+  it('does not spend the attempt budget on debates the acceptor cannot edit', async () => {
+    const parked = Array.from({ length: 8 }, (_, i) => `parked-${i}`);
+    mocks.candidates = { 'space-1': [...parked, 'publishable'] };
+    mocks.publish.mockImplementation(async (debateId: string) =>
+      debateId === 'publishable' ? publishedResult : { status: 'not_editor', debateEntityId: 'e', spaceId: 'space-1' }
+    );
+
+    await expect(sweep()).resolves.toMatchObject({ notEditor: 8, published: ['publishable'] });
+  });
+
+  // The function must stop *between* publishes, never be killed inside one: a publish cut off
+  // after its proposal lands has no Debate entity for the idempotency check to find, and the next
+  // tick would mint a second set of media and transcript entities for the same debate.
+  it('stops starting publishes once the time budget is spent', async () => {
+    vi.useFakeTimers();
+    mocks.editorSpaceIds = ['space-1', 'space-2'];
+    mocks.candidates = { 'space-1': ['first', 'second'], 'space-2': ['third'] };
+    mocks.publish.mockImplementation(async () => {
+      vi.setSystemTime(Date.now() + 181_000);
+      return publishedResult;
+    });
+
+    await expect(sweep()).resolves.toMatchObject({ published: ['first'] });
+    expect(mocks.publish).toHaveBeenCalledTimes(1);
+  });
+
+  // One refusal for the run, before any debate is touched — not one failed attempt (and one
+  // orphaned share-card pin) per candidate per tick.
+  it('refuses the whole run when the media host is misconfigured', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('NEXT_PUBLIC_GEO_CHAT_API_BASE_URL', '');
+    vi.stubEnv('NEXT_PUBLIC_DEBATE_MEDIA_BASE_URL', '');
+    mocks.candidates = { 'space-1': ['debate-1'] };
+
+    const { GET } = await import('./route');
+    const response = await GET(
+      new Request('https://geo.test/api/debates/publish-sweep', { headers: { authorization: 'Bearer test-secret' } })
+    );
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toMatchObject({ ok: false, error: expect.stringMatching(/media host/) });
+    expect(mocks.publish).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/app/api/debates/publish-sweep/route.ts
+++ b/apps/web/app/api/debates/publish-sweep/route.ts
@@ -1,7 +1,11 @@
 import { NextResponse } from 'next/server';
 
 import { getDebateAcceptorConfig } from '~/core/debates/server/acceptor-config';
-import { DebateNotPublishableError, listSweepCandidateDebateIds } from '~/core/debates/server/debate-source';
+import {
+  DebateNotPublishableError,
+  assertDebateMediaHostConfigured,
+  listSweepCandidateDebateIds,
+} from '~/core/debates/server/debate-source';
 import { listEditorSpaceIds } from '~/core/debates/server/editor-spaces';
 import { publishDebateAsAcceptor } from '~/core/debates/server/publish-debate';
 
@@ -10,11 +14,18 @@ export const maxDuration = 300;
 export const dynamic = 'force-dynamic';
 
 // Bound the work per invocation. Anything left over is picked up on the next tick, where the
-// idempotency check makes re-scanning already-published debates cheap. Media stays in object
-// storage (no IPFS pinning), so a publish is dominated by on-chain signing and several fit inside
-// `maxDuration`. Counts attempts rather than successes: a failed on-chain publish has already
-// spent the time.
+// idempotency check makes re-scanning already-published debates cheap. The video and keyframe no
+// longer get downloaded and pinned to IPFS, so what remains per publish is the share-card pin and
+// two or three confirmed on-chain user operations. Counts attempts rather than successes: a failed
+// on-chain publish has already spent the time.
 const MAX_PUBLISH_ATTEMPTS_PER_SWEEP = 8;
+
+// No publish *starts* after this point in the run, whatever the attempt count. What matters is
+// that the function is never killed at `maxDuration` in the middle of one: a publish cut off
+// after its proposal lands but before the vote leaves no Debate entity for the idempotency check
+// to find, so the next tick mints a second set of Video, keyframe, Transcript and Claim entities
+// (all random ids) for the same debate. The remaining headroom is for the publish in flight.
+const PUBLISH_START_DEADLINE_MS = 180_000;
 
 /**
  * Cron sweep: publish finished debates to the knowledge graph as the debate acceptor.
@@ -37,6 +48,20 @@ export async function GET(request: Request) {
     return NextResponse.json({ ok: true, skipped: 'acceptor_not_configured' });
   }
 
+  // A media host that can never yield a valid on-chain URL fails the whole run here, once, rather
+  // than as one failed attempt per candidate debate on every tick.
+  try {
+    assertDebateMediaHostConfigured();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error('[debate-acceptor] sweep refused: media host misconfigured', { error: message });
+    return NextResponse.json({ ok: false, error: message }, { status: 500 });
+  }
+
+  const startedAt = Date.now();
+  const budgetExhausted = (attempted: number) =>
+    attempted >= MAX_PUBLISH_ATTEMPTS_PER_SWEEP || Date.now() - startedAt >= PUBLISH_START_DEADLINE_MS;
+
   const spaceIds = await listEditorSpaceIds(config.spaceId);
   const published: string[] = [];
   const failed: Array<{ debateId: string; error: string }> = [];
@@ -50,6 +75,7 @@ export async function GET(request: Request) {
   const mediaFailed: string[] = [];
 
   for (const spaceId of spaceIds) {
+    if (budgetExhausted(attempted)) break;
     let debateIds: string[];
     try {
       debateIds = await listSweepCandidateDebateIds(spaceId);
@@ -59,16 +85,21 @@ export async function GET(request: Request) {
     }
 
     for (const debateId of debateIds) {
-      if (attempted >= MAX_PUBLISH_ATTEMPTS_PER_SWEEP) break;
+      if (budgetExhausted(attempted)) break;
       try {
         const result = await publishDebateAsAcceptor(debateId);
         if (result.status === 'already_published') {
           alreadyPublished += 1;
           continue;
         }
+        if (result.status === 'not_editor') {
+          // Terminal and cheap (the editor check runs before any source is loaded), so it does not
+          // spend a slot: a handful of debates parked in personal spaces must not stall the queue.
+          notEditor += 1;
+          continue;
+        }
         attempted += 1;
         if (result.status === 'published') published.push(debateId);
-        else if (result.status === 'not_editor') notEditor += 1;
       } catch (error) {
         if (error instanceof DebateNotPublishableError) {
           if (error.code === 'media_failed') {

--- a/apps/web/app/api/debates/publish-sweep/route.ts
+++ b/apps/web/app/api/debates/publish-sweep/route.ts
@@ -13,18 +13,14 @@ import { publishDebateAsAcceptor } from '~/core/debates/server/publish-debate';
 export const maxDuration = 300;
 export const dynamic = 'force-dynamic';
 
-// Bound the work per invocation. Anything left over is picked up on the next tick, where the
-// idempotency check makes re-scanning already-published debates cheap. The video and keyframe no
-// longer get downloaded and pinned to IPFS, so what remains per publish is the share-card pin and
-// two or three confirmed on-chain user operations. Counts attempts rather than successes: a failed
-// on-chain publish has already spent the time.
+// Bound the work per invocation; anything left over is picked up on the next tick. A publish is
+// the share-card pin plus two or three confirmed on-chain user operations. Counts attempts rather
+// than successes, since a failed publish has already spent the time.
 const MAX_PUBLISH_ATTEMPTS_PER_SWEEP = 8;
 
-// No publish *starts* after this point in the run, whatever the attempt count. What matters is
-// that the function is never killed at `maxDuration` in the middle of one: a publish cut off
-// after its proposal lands but before the vote leaves no Debate entity for the idempotency check
-// to find, so the next tick mints a second set of Video, keyframe, Transcript and Claim entities
-// (all random ids) for the same debate. The remaining headroom is for the publish in flight.
+// No publish starts after this point in the run. A publish interrupted by `maxDuration` after its
+// proposal lands leaves no Debate entity for the idempotency check, so the next tick would create
+// duplicate media and transcript entities. The remaining time is headroom for the publish in flight.
 const PUBLISH_START_DEADLINE_MS = 180_000;
 
 /**
@@ -48,8 +44,7 @@ export async function GET(request: Request) {
     return NextResponse.json({ ok: true, skipped: 'acceptor_not_configured' });
   }
 
-  // A media host that can never yield a valid on-chain URL fails the whole run here, once, rather
-  // than as one failed attempt per candidate debate on every tick.
+  // Fail the run once on a misconfigured media host rather than once per candidate debate.
   try {
     assertDebateMediaHostConfigured();
   } catch (error) {
@@ -93,8 +88,7 @@ export async function GET(request: Request) {
           continue;
         }
         if (result.status === 'not_editor') {
-          // Terminal and cheap (the editor check runs before any source is loaded), so it does not
-          // spend a slot: a handful of debates parked in personal spaces must not stall the queue.
+          // Terminal and cheap (checked before any source is loaded), so it does not spend a slot.
           notEditor += 1;
           continue;
         }

--- a/apps/web/app/api/debates/publish-sweep/route.ts
+++ b/apps/web/app/api/debates/publish-sweep/route.ts
@@ -10,10 +10,11 @@ export const maxDuration = 300;
 export const dynamic = 'force-dynamic';
 
 // Bound the work per invocation. Anything left over is picked up on the next tick, where the
-// idempotency check makes re-scanning already-published debates cheap. Each publish pins the final
-// video to IPFS before signing, so only a couple fit inside `maxDuration`. Counts attempts rather
-// than successes: a debate that pins its video and then fails on-chain has already spent the time.
-const MAX_PUBLISH_ATTEMPTS_PER_SWEEP = 2;
+// idempotency check makes re-scanning already-published debates cheap. Media stays in object
+// storage (no IPFS pinning), so a publish is dominated by on-chain signing and several fit inside
+// `maxDuration`. Counts attempts rather than successes: a failed on-chain publish has already
+// spent the time.
+const MAX_PUBLISH_ATTEMPTS_PER_SWEEP = 8;
 
 /**
  * Cron sweep: publish finished debates to the knowledge graph as the debate acceptor.

--- a/apps/web/core/claims/browse/use-debate-keyframes.ts
+++ b/apps/web/core/claims/browse/use-debate-keyframes.ts
@@ -60,10 +60,8 @@ export function useDebateKeyframes(debates: Entity[]): Map<string, string> {
   const urlByKeyframeId = React.useMemo(() => {
     const map = new Map<string, string>();
     for (const keyframe of keyframes) {
-      // `IPFS URL` first: it is what the media decoders read and what pinned stills carry, so
-      // already-published keyframes resolve exactly as before. Debate stills that stayed in object
-      // storage instead of being pinned carry a durable geo-chat URL on `Web URL` — read only as a
-      // fallback, and only here, where the entity is already known to be a keyframe image.
+      // `IPFS URL` first for pinned stills; `Web URL` carries the geo-chat URL for stills left in
+      // object storage.
       const url = valueForProperty(keyframe, IMAGE_URL_PROPERTY_ID) ?? valueForProperty(keyframe, WEB_URL_PROPERTY_ID);
       if (url) map.set(keyframe.id, url);
     }

--- a/apps/web/core/claims/browse/use-debate-keyframes.ts
+++ b/apps/web/core/claims/browse/use-debate-keyframes.ts
@@ -2,7 +2,12 @@
 
 import * as React from 'react';
 
-import { DEBATE_VIDEOS_PROPERTY_ID, IMAGE_URL_PROPERTY_ID, KEY_FRAME_IMAGE_PROPERTY_ID } from '~/core/debates/ontology';
+import {
+  DEBATE_VIDEOS_PROPERTY_ID,
+  IMAGE_URL_PROPERTY_ID,
+  KEY_FRAME_IMAGE_PROPERTY_ID,
+  WEB_URL_PROPERTY_ID,
+} from '~/core/debates/ontology';
 import { ID } from '~/core/id';
 import { useQueryEntities } from '~/core/sync/use-store';
 import type { Entity, Relation } from '~/core/types';
@@ -55,11 +60,11 @@ export function useDebateKeyframes(debates: Entity[]): Map<string, string> {
   const urlByKeyframeId = React.useMemo(() => {
     const map = new Map<string, string>();
     for (const keyframe of keyframes) {
-      // `IPFS URL` is the property the media decoders read, and what the publish path writes for
-      // both stills and videos despite the name.
-      const url = keyframe.values?.find(
-        value => value.isDeleted !== true && ID.equals(value.property.id, IMAGE_URL_PROPERTY_ID)
-      )?.value;
+      // `IPFS URL` first: it is what the media decoders read and what pinned stills carry, so
+      // already-published keyframes resolve exactly as before. Debate stills that stayed in object
+      // storage instead of being pinned carry a durable geo-chat URL on `Web URL` — read only as a
+      // fallback, and only here, where the entity is already known to be a keyframe image.
+      const url = valueForProperty(keyframe, IMAGE_URL_PROPERTY_ID) ?? valueForProperty(keyframe, WEB_URL_PROPERTY_ID);
       if (url) map.set(keyframe.id, url);
     }
     return map;
@@ -79,6 +84,11 @@ export function useDebateKeyframes(debates: Entity[]): Map<string, string> {
     }
     return byDebateId;
   }, [keyframeIdByVideoId, urlByKeyframeId, videoIdsByDebateId]);
+}
+
+function valueForProperty(entity: Entity, propertyId: string): string | undefined {
+  const value = entity.values?.find(v => v.isDeleted !== true && ID.equals(v.property.id, propertyId))?.value;
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
 }
 
 function relationTargets(relations: Relation[], propertyId: string): string[] {

--- a/apps/web/core/claims/browse/use-debate-keyframes.ts
+++ b/apps/web/core/claims/browse/use-debate-keyframes.ts
@@ -11,6 +11,7 @@ import {
 import { ID } from '~/core/id';
 import { useQueryEntities } from '~/core/sync/use-store';
 import type { Entity, Relation } from '~/core/types';
+import { isDirectMediaUrl } from '~/core/utils/media-url';
 
 /**
  * The poster still for each debate, keyed by debate id.
@@ -62,7 +63,8 @@ export function useDebateKeyframes(debates: Entity[]): Map<string, string> {
     for (const keyframe of keyframes) {
       // `IPFS URL` first for pinned stills; `Web URL` carries the geo-chat URL for stills left in
       // object storage.
-      const url = valueForProperty(keyframe, IMAGE_URL_PROPERTY_ID) ?? valueForProperty(keyframe, WEB_URL_PROPERTY_ID);
+      const webUrl = valueForProperty(keyframe, WEB_URL_PROPERTY_ID);
+      const url = valueForProperty(keyframe, IMAGE_URL_PROPERTY_ID) ?? (isDirectMediaUrl(webUrl) ? webUrl : null);
       if (url) map.set(keyframe.id, url);
     }
     return map;

--- a/apps/web/core/debates/debate-publish-draft.test.ts
+++ b/apps/web/core/debates/debate-publish-draft.test.ts
@@ -1,3 +1,4 @@
+import { SystemIds } from '@geoprotocol/geo-sdk/lite';
 import { Effect } from 'effect';
 import { describe, expect, it } from 'vitest';
 
@@ -18,7 +19,6 @@ import {
   DEBATE_SUPPORTED_BY_PROPERTY_ID,
   DEBATE_TYPE_ID,
   IMAGE_TYPE_ID,
-  IMAGE_URL_PROPERTY_ID,
   KEY_FRAME_IMAGE_PROPERTY_ID,
   NAME_PROPERTY_ID,
   OG_IMAGE_PROPERTY_ID,
@@ -27,6 +27,7 @@ import {
   TYPES_PROPERTY_ID,
   VIDEO_TYPE_ID,
   VIDEO_URL_PROPERTY_ID,
+  WEB_URL_PROPERTY_ID,
 } from './ontology';
 
 const SPACE = '8b5c8625ff017732063d56e85d24dbed';
@@ -49,11 +50,12 @@ function baseInput(overrides: Partial<DebatePublishInput> = {}): DebatePublishIn
       { spaceEntityId: YES_SPACE, displayName: 'Arturas', position: true, participantSlot: 1 },
       { spaceEntityId: NO_SPACE, displayName: 'Preston', position: false, participantSlot: 2 },
     ],
-    videoUrl: 'ipfs://bafyfinalvideo',
+    videoUrl: 'https://chat.example/debates/11112222-3333-4444-5555-666677778888/media/artifacts/final_video/content',
     // Default off: most cases here are about the debate, video and transcript entities. The share
     // card gets its own block below, where its absence is also asserted.
     ogImageUrl: null,
-    keyframeUrl: 'ipfs://bafykeyframe',
+    keyframeUrl:
+      'https://chat.example/debates/11112222-3333-4444-5555-666677778888/media/artifacts/preview_image/content',
     transcriptTurns: [
       { turnIndex: 0, speakerSpaceEntityId: YES_SPACE, speakerName: 'Arturas', text: 'Iran was building a nuke.' },
       {
@@ -141,13 +143,17 @@ describe('buildDebatePublishDraft', () => {
     expect(draft.relations.some(r => r.toEntity.id === VIDEO_TYPE_ID)).toBe(false);
   });
 
-  // A Video that sets nothing but `Video URL` renders as an empty relation.
-  it('writes the video URL to both the unified IPFS URL property and Video URL', () => {
-    const draft = buildDebatePublishDraft(baseInput(), { createEntityId: idFactory(), createPosition: () => 'a0' });
+  // A Video that sets nothing but `Video URL` renders as an empty relation: the relation decoder
+  // reads media URLs from `Web URL` (or the legacy `IPFS URL`), never from `Video URL`.
+  it('writes the video URL to both the Web URL property and Video URL, and never to IPFS URL', () => {
+    const input = baseInput();
+    const draft = buildDebatePublishDraft(input, { createEntityId: idFactory(), createPosition: () => 'a0' });
     const videoId = draft.relations.find(r => r.toEntity.id === VIDEO_TYPE_ID)?.fromEntity.id;
     const videoValues = draft.values.filter(v => v.entity.id === videoId);
-    expect(videoValues.find(v => v.property.id === IMAGE_URL_PROPERTY_ID)?.value).toBe('ipfs://bafyfinalvideo');
-    expect(videoValues.find(v => v.property.id === VIDEO_URL_PROPERTY_ID)?.value).toBe('ipfs://bafyfinalvideo');
+    expect(videoValues.find(v => v.property.id === WEB_URL_PROPERTY_ID)?.value).toBe(input.videoUrl);
+    expect(videoValues.find(v => v.property.id === VIDEO_URL_PROPERTY_ID)?.value).toBe(input.videoUrl);
+    // Publishing to IPFS URL would imply pinning; the media must stay deletable in object storage.
+    expect(draft.values.some(v => v.property.id === SystemIds.IMAGE_URL_PROPERTY)).toBe(false);
   });
 
   it('hangs the share card off the debate, not the video', () => {
@@ -189,19 +195,20 @@ describe('buildDebatePublishDraft', () => {
   });
 
   it('links a Key frame Image onto the Video', () => {
-    const draft = buildDebatePublishDraft(baseInput(), { createEntityId: idFactory(), createPosition: () => 'a0' });
+    const input = baseInput();
+    const draft = buildDebatePublishDraft(input, { createEntityId: idFactory(), createPosition: () => 'a0' });
     const videoId = draft.relations.find(r => r.toEntity.id === VIDEO_TYPE_ID)?.fromEntity.id;
     const keyframe = draft.relations.find(r => r.type.id === KEY_FRAME_IMAGE_PROPERTY_ID);
     expect(keyframe?.fromEntity.id).toBe(videoId);
     expect(
-      draft.values.find(v => v.entity.id === keyframe?.toEntity.id && v.property.id === IMAGE_URL_PROPERTY_ID)?.value
-    ).toBe('ipfs://bafykeyframe');
+      draft.values.find(v => v.entity.id === keyframe?.toEntity.id && v.property.id === WEB_URL_PROPERTY_ID)?.value
+    ).toBe(input.keyframeUrl);
     expect(
       draft.relations.some(r => r.fromEntity.id === keyframe?.toEntity.id && r.toEntity.id === IMAGE_TYPE_ID)
     ).toBe(true);
   });
 
-  it('publishes the Video without a Key frame when no keyframe was pinned', () => {
+  it('publishes the Video without a Key frame when no keyframe was composed', () => {
     const draft = buildDebatePublishDraft(baseInput({ keyframeUrl: null }), {
       createEntityId: idFactory(),
       createPosition: () => 'a0',

--- a/apps/web/core/debates/debate-publish-draft.test.ts
+++ b/apps/web/core/debates/debate-publish-draft.test.ts
@@ -145,8 +145,7 @@ describe('buildDebatePublishDraft', () => {
     expect(draft.relations.some(r => r.toEntity.id === VIDEO_TYPE_ID)).toBe(false);
   });
 
-  // A Video that sets nothing but `Video URL` renders as an empty relation: the relation decoder
-  // reads media URLs from `Web URL` (or the legacy `IPFS URL`), never from `Video URL`.
+  // The relation decoder reads media URLs from `Web URL` (or `IPFS URL`), not `Video URL`.
   it('writes the video URL to both the Web URL property and Video URL, and never to IPFS URL', () => {
     const input = baseInput();
     const draft = buildDebatePublishDraft(input, { createEntityId: idFactory(), createPosition: () => 'a0' });
@@ -154,7 +153,6 @@ describe('buildDebatePublishDraft', () => {
     const videoValues = draft.values.filter(v => v.entity.id === videoId);
     expect(videoValues.find(v => v.property.id === WEB_URL_PROPERTY_ID)?.value).toBe(input.videoUrl);
     expect(videoValues.find(v => v.property.id === VIDEO_URL_PROPERTY_ID)?.value).toBe(input.videoUrl);
-    // Publishing to IPFS URL would imply pinning; the media must stay deletable in object storage.
     expect(draft.values.some(v => v.property.id === SystemIds.IMAGE_URL_PROPERTY)).toBe(false);
   });
 

--- a/apps/web/core/debates/debate-publish-draft.test.ts
+++ b/apps/web/core/debates/debate-publish-draft.test.ts
@@ -1,4 +1,5 @@
 import { SystemIds } from '@geoprotocol/geo-sdk/lite';
+
 import { Effect } from 'effect';
 import { describe, expect, it } from 'vitest';
 
@@ -19,6 +20,7 @@ import {
   DEBATE_SUPPORTED_BY_PROPERTY_ID,
   DEBATE_TYPE_ID,
   IMAGE_TYPE_ID,
+  IMAGE_URL_PROPERTY_ID,
   KEY_FRAME_IMAGE_PROPERTY_ID,
   NAME_PROPERTY_ID,
   OG_IMAGE_PROPERTY_ID,

--- a/apps/web/core/debates/debate-publish-draft.ts
+++ b/apps/web/core/debates/debate-publish-draft.ts
@@ -15,10 +15,11 @@ import {
   DEBATE_TYPE_ID,
   DEBATE_VIDEOS_PROPERTY_ID,
   IMAGE_TYPE_ID,
+  IMAGE_URL_PROPERTY_ID,
   KEY_FRAME_IMAGE_PROPERTY_ID,
-  OG_IMAGE_PROPERTY_ID,
   MARKDOWN_CONTENT_PROPERTY_ID,
   NAME_PROPERTY_ID,
+  OG_IMAGE_PROPERTY_ID,
   SOURCES_PROPERTY_ID,
   TEXT_BLOCK_TYPE_ID,
   TRANSCRIPT_TYPE_ID,
@@ -345,7 +346,12 @@ export function buildDebatePublishDraft(input: DebatePublishInput, options: Buil
         const claimId = createEntityId();
         const claimRef = { id: claimId, name: claimEntityText };
         setText(claimId, claimEntityText, NAME_PROPERTY_ID, claimEntityText);
-        relate({ fromEntity: claimRef, propertyId: TYPES_PROPERTY_ID, toEntityId: CLAIM_TYPE_ID, toEntityName: 'Claim' });
+        relate({
+          fromEntity: claimRef,
+          propertyId: TYPES_PROPERTY_ID,
+          toEntityId: CLAIM_TYPE_ID,
+          toEntityName: 'Claim',
+        });
         if (claim.isFactual !== null) {
           setBoolean(claimId, claimEntityText, CLAIM_IS_FACTUAL_PROPERTY_ID, claim.isFactual);
         }

--- a/apps/web/core/debates/debate-publish-draft.ts
+++ b/apps/web/core/debates/debate-publish-draft.ts
@@ -15,7 +15,6 @@ import {
   DEBATE_TYPE_ID,
   DEBATE_VIDEOS_PROPERTY_ID,
   IMAGE_TYPE_ID,
-  IMAGE_URL_PROPERTY_ID,
   KEY_FRAME_IMAGE_PROPERTY_ID,
   OG_IMAGE_PROPERTY_ID,
   MARKDOWN_CONTENT_PROPERTY_ID,
@@ -26,6 +25,7 @@ import {
   TYPES_PROPERTY_ID,
   VIDEO_TYPE_ID,
   VIDEO_URL_PROPERTY_ID,
+  WEB_URL_PROPERTY_ID,
 } from './ontology';
 
 export type DebatePublishParticipant = {
@@ -74,11 +74,12 @@ export type DebatePublishInput = {
   claimText: string;
   participants: DebatePublishParticipant[];
   /**
-   * `ipfs://` URI for the rendered final video, or null to skip the Video entity. Goes on-chain,
-   * so it has to outlive geo-chat's presigned object-store URLs.
+   * Durable https URL for the rendered final video, or null to skip the Video entity. Goes
+   * on-chain, so it must outlive geo-chat's presigned object-store URLs — the geo-chat
+   * `…/media/artifacts/{kind}/content` redirect URL is the intended shape.
    */
   videoUrl: string | null;
-  /** `ipfs://` URI for the video's poster still, or null to publish the Video without one. */
+  /** Durable https URL for the video's poster still, or null to publish the Video without one. */
   keyframeUrl: string | null;
   /**
    * `ipfs://` URI for the rendered share card, or null to publish without one.
@@ -237,10 +238,11 @@ export function buildDebatePublishDraft(input: DebatePublishInput, options: Buil
     const videoName = `${debateName} video`;
     const videoRef = { id: videoId, name: videoName };
     setText(videoId, videoName, NAME_PROPERTY_ID, videoName);
-    // Both carry the same ipfs:// URI: `Video URL` is what the debates ontology spec names,
-    // `IPFS URL` is what the relation decoder actually reads.
+    // Both carry the same https URL: `Video URL` is what the debates ontology spec names,
+    // `Web URL` is what the relation decoder reads for media entities (instead of `IPFS URL`,
+    // which would require pinning — Web URL keeps the media deletable).
     setText(videoId, videoName, VIDEO_URL_PROPERTY_ID, input.videoUrl);
-    setText(videoId, videoName, IMAGE_URL_PROPERTY_ID, input.videoUrl);
+    setText(videoId, videoName, WEB_URL_PROPERTY_ID, input.videoUrl);
     relate({
       fromEntity: videoRef,
       propertyId: TYPES_PROPERTY_ID,
@@ -259,7 +261,7 @@ export function buildDebatePublishDraft(input: DebatePublishInput, options: Buil
       const keyframeName = `${debateName} keyframe`;
       const keyframeRef = { id: keyframeId, name: keyframeName };
       setText(keyframeId, keyframeName, NAME_PROPERTY_ID, keyframeName);
-      setText(keyframeId, keyframeName, IMAGE_URL_PROPERTY_ID, input.keyframeUrl);
+      setText(keyframeId, keyframeName, WEB_URL_PROPERTY_ID, input.keyframeUrl);
       relate({
         fromEntity: keyframeRef,
         propertyId: TYPES_PROPERTY_ID,

--- a/apps/web/core/debates/debate-publish-draft.ts
+++ b/apps/web/core/debates/debate-publish-draft.ts
@@ -75,9 +75,8 @@ export type DebatePublishInput = {
   claimText: string;
   participants: DebatePublishParticipant[];
   /**
-   * Durable https URL for the rendered final video, or null to skip the Video entity. Goes
-   * on-chain, so it must outlive geo-chat's presigned object-store URLs — the geo-chat
-   * `…/media/artifacts/{kind}/content` redirect URL is the intended shape.
+   * Durable https URL for the rendered final video (the geo-chat `…/media/artifacts/{kind}/content`
+   * redirect), or null to skip the Video entity.
    */
   videoUrl: string | null;
   /** Durable https URL for the video's poster still, or null to publish the Video without one. */
@@ -239,9 +238,8 @@ export function buildDebatePublishDraft(input: DebatePublishInput, options: Buil
     const videoName = `${debateName} video`;
     const videoRef = { id: videoId, name: videoName };
     setText(videoId, videoName, NAME_PROPERTY_ID, videoName);
-    // Both carry the same https URL: `Video URL` is what the debates ontology spec names,
-    // `Web URL` is what the relation decoder reads for media entities (instead of `IPFS URL`,
-    // which would require pinning — Web URL keeps the media deletable).
+    // Both carry the same URL: `Video URL` is what the debates ontology spec names, `Web URL` is
+    // what the relation decoder reads for media entities.
     setText(videoId, videoName, VIDEO_URL_PROPERTY_ID, input.videoUrl);
     setText(videoId, videoName, WEB_URL_PROPERTY_ID, input.videoUrl);
     relate({

--- a/apps/web/core/debates/ontology.ts
+++ b/apps/web/core/debates/ontology.ts
@@ -1,4 +1,4 @@
-import { SystemIds } from '@geoprotocol/geo-sdk/lite';
+import { ContentIds, SystemIds } from '@geoprotocol/geo-sdk/lite';
 
 import { KEY_FRAME_IMAGE_PROPERTY } from '~/core/constants';
 
@@ -70,11 +70,12 @@ export const VIDEO_TYPE_ID = SystemIds.VIDEO_TYPE; // d7a4817c… (matches spec)
 export const VIDEO_URL_PROPERTY_ID = SystemIds.VIDEO_URL_PROPERTY; // 33da2ef5…
 export const IMAGE_TYPE_ID = SystemIds.IMAGE_TYPE; // ba4e4146…
 /**
- * The unified IPFS URL property. Despite the name it carries the `ipfs://` URI for Video entities
- * as well as Images. `RelationDtoLive` and the media hooks read a media entity's URL from here and
- * nowhere else, so a Video that only sets `Video URL` renders as an empty relation.
+ * The canonical URL-typed link property ("Web URL"). Debate media entities carry their durable
+ * geo-chat content URL here instead of pinning to IPFS (`IMAGE_URL_PROPERTY`, the "IPFS URL"),
+ * which is what lets published media be permanently deleted. `RelationDtoLive` falls back to this
+ * property for Image/Video-typed entities, so media referenced by it renders identically.
  */
-export const IMAGE_URL_PROPERTY_ID = SystemIds.IMAGE_URL_PROPERTY; // 8a743832…
+export const WEB_URL_PROPERTY_ID = ContentIds.WEB_URL_PROPERTY; // 412ff593…
 export const BLOCKS_PROPERTY_ID = SystemIds.BLOCKS; // beaba5cb…
 export const TEXT_BLOCK_TYPE_ID = SystemIds.TEXT_BLOCK; // 76474f2f…
 export const MARKDOWN_CONTENT_PROPERTY_ID = SystemIds.MARKDOWN_CONTENT; // e3e363d1… (matches spec)

--- a/apps/web/core/debates/ontology.ts
+++ b/apps/web/core/debates/ontology.ts
@@ -71,19 +71,13 @@ export const VIDEO_URL_PROPERTY_ID = SystemIds.VIDEO_URL_PROPERTY; // 33da2ef5�
 export const IMAGE_TYPE_ID = SystemIds.IMAGE_TYPE; // ba4e4146…
 /**
  * The unified IPFS URL property. Despite the name it carries the `ipfs://` URI for Video entities
- * as well as Images. Everything that resolves media reads this property first, so entities
- * published before debate media moved off IPFS keep rendering byte-identically.
+ * as well as Images. Media resolution reads this property first.
  */
 export const IMAGE_URL_PROPERTY_ID = SystemIds.IMAGE_URL_PROPERTY; // 8a743832…
 /**
- * The canonical URL-typed link property ("Web URL"). Debate media entities carry their durable
- * geo-chat content URL here instead of pinning to IPFS (`IMAGE_URL_PROPERTY`, the "IPFS URL"),
- * which is what lets published media be permanently deleted. `RelationDtoLive` falls back to this
- * property for Image/Video-typed entities, so media referenced by it renders identically.
- *
- * It is a general-purpose canonical link, so it must only ever be read as a *fallback* on an
- * entity already known to be media. Never promote a renderable type or scan values blankly on it:
- * an ordinary entity's `Web URL` source link would turn into a broken image.
+ * The canonical link property ("Web URL"). Debate media entities carry their durable geo-chat
+ * content URL here instead of an IPFS pin. It is also a general-purpose link, so it is only read
+ * as a media URL on entities already typed Image/Video, and never promotes a renderable type.
  */
 export const WEB_URL_PROPERTY_ID = ContentIds.WEB_URL_PROPERTY; // 412ff593…
 export const BLOCKS_PROPERTY_ID = SystemIds.BLOCKS; // beaba5cb…

--- a/apps/web/core/debates/ontology.ts
+++ b/apps/web/core/debates/ontology.ts
@@ -70,10 +70,20 @@ export const VIDEO_TYPE_ID = SystemIds.VIDEO_TYPE; // d7a4817c… (matches spec)
 export const VIDEO_URL_PROPERTY_ID = SystemIds.VIDEO_URL_PROPERTY; // 33da2ef5…
 export const IMAGE_TYPE_ID = SystemIds.IMAGE_TYPE; // ba4e4146…
 /**
+ * The unified IPFS URL property. Despite the name it carries the `ipfs://` URI for Video entities
+ * as well as Images. Everything that resolves media reads this property first, so entities
+ * published before debate media moved off IPFS keep rendering byte-identically.
+ */
+export const IMAGE_URL_PROPERTY_ID = SystemIds.IMAGE_URL_PROPERTY; // 8a743832…
+/**
  * The canonical URL-typed link property ("Web URL"). Debate media entities carry their durable
  * geo-chat content URL here instead of pinning to IPFS (`IMAGE_URL_PROPERTY`, the "IPFS URL"),
  * which is what lets published media be permanently deleted. `RelationDtoLive` falls back to this
  * property for Image/Video-typed entities, so media referenced by it renders identically.
+ *
+ * It is a general-purpose canonical link, so it must only ever be read as a *fallback* on an
+ * entity already known to be media. Never promote a renderable type or scan values blankly on it:
+ * an ordinary entity's `Web URL` source link would turn into a broken image.
  */
 export const WEB_URL_PROPERTY_ID = ContentIds.WEB_URL_PROPERTY; // 412ff593…
 export const BLOCKS_PROPERTY_ID = SystemIds.BLOCKS; // beaba5cb…

--- a/apps/web/core/debates/server/debate-source.test.ts
+++ b/apps/web/core/debates/server/debate-source.test.ts
@@ -104,6 +104,23 @@ describe('loadDebatePublishSource media gating', () => {
     expect(shareCardWasBuilt()).toBe(false);
   });
 
+  it('refuses a media host that carries a query string or fragment', async () => {
+    vi.stubEnv('NEXT_PUBLIC_DEBATE_MEDIA_BASE_URL', 'https://media.example?health=1');
+    mockGeoChat({ job: { status: 'succeeded' }, artifacts: [{ kind: 'final_video' }] });
+
+    await expect(loadDebatePublishSource(DEBATE_ID)).rejects.toThrow(/query string or fragment/);
+    expect(shareCardWasBuilt()).toBe(false);
+  });
+
+  it('refuses a plain http media host in production', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('NEXT_PUBLIC_GEO_CHAT_API_BASE_URL', 'http://chat.example');
+    mockGeoChat({ job: { status: 'succeeded' }, artifacts: [{ kind: 'final_video' }] });
+
+    await expect(loadDebatePublishSource(DEBATE_ID)).rejects.toThrow(/https in production/);
+    expect(shareCardWasBuilt()).toBe(false);
+  });
+
   it('falls back to localhost outside production when no public media host is configured', async () => {
     vi.stubEnv('NEXT_PUBLIC_GEO_CHAT_API_BASE_URL', '');
     mockGeoChat({ job: { status: 'succeeded' }, artifacts: [{ kind: 'final_video' }] });

--- a/apps/web/core/debates/server/debate-source.test.ts
+++ b/apps/web/core/debates/server/debate-source.test.ts
@@ -23,12 +23,16 @@ function debateBody(overrides: Record<string, unknown> = {}) {
   };
 }
 
-/** Routes each geo-chat path the loader touches to a canned response. */
-function mockGeoChat(media: unknown, debate = debateBody(), claims: unknown = null) {
+/**
+ * Routes each geo-chat path the loader touches to a canned response. `contentStatus` is what the
+ * durable `/content` route answers to the pre-publish HEAD probe.
+ */
+function mockGeoChat(media: unknown, debate = debateBody(), claims: unknown = null, contentStatus = 200) {
   vi.stubGlobal(
     'fetch',
     vi.fn(async (input: string | URL) => {
       const url = String(input);
+      if (url.endsWith('/content')) return new Response(null, { status: contentStatus });
       const body = url.endsWith('/media')
         ? media
         : url.endsWith('/claims')
@@ -39,6 +43,11 @@ function mockGeoChat(media: unknown, debate = debateBody(), claims: unknown = nu
       return new Response(JSON.stringify(body), { status: 200 });
     })
   );
+}
+
+/** Whether the loader got as far as rendering the share card (the one IPFS pin left on this path). */
+function shareCardWasBuilt(): boolean {
+  return vi.mocked(fetch).mock.calls.some(([input]) => String(input).includes('/media/artifacts/url'));
 }
 
 afterEach(() => {
@@ -93,6 +102,48 @@ describe('loadDebatePublishSource media gating', () => {
     mockGeoChat({ job: { status: 'succeeded' }, artifacts: [{ kind: 'final_video' }] });
 
     await expect(loadDebatePublishSource(DEBATE_ID)).rejects.toThrow(/absolute http\(s\) URL/);
+    // Refused before the share card is pinned, or every refused tick leaves an orphan on IPFS.
+    expect(shareCardWasBuilt()).toBe(false);
+  });
+
+  // The localhost fallback exists for development only. A production deploy carrying just the
+  // server-side GEO_CHAT_API_BASE_URL reads every debate fine and would otherwise write
+  // `http://localhost:8080/...` on-chain for each of them.
+  it('refuses to publish in production when no public media host is configured', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('NEXT_PUBLIC_GEO_CHAT_API_BASE_URL', '');
+    mockGeoChat({ job: { status: 'succeeded' }, artifacts: [{ kind: 'final_video' }] });
+
+    await expect(loadDebatePublishSource(DEBATE_ID)).rejects.toThrow(/no public media host is configured/);
+    expect(shareCardWasBuilt()).toBe(false);
+  });
+
+  it('falls back to localhost outside production when no public media host is configured', async () => {
+    vi.stubEnv('NEXT_PUBLIC_GEO_CHAT_API_BASE_URL', '');
+    mockGeoChat({ job: { status: 'succeeded' }, artifacts: [{ kind: 'final_video' }] });
+
+    const { input } = await loadDebatePublishSource(DEBATE_ID);
+    expect(input.videoUrl).toBe(`http://localhost:8080/debates/${DEBATE_ID}/media/artifacts/final_video/content`);
+  });
+
+  // The URL is string-built, so this probe is the only thing standing between "geo-chat has not
+  // deployed the content route yet" and a permanently dead URL on-chain. A wait, not a failure.
+  it('waits when the durable content URL does not resolve yet', async () => {
+    mockGeoChat({ job: { status: 'succeeded' }, artifacts: [{ kind: 'final_video' }] }, debateBody(), null, 404);
+
+    await expect(loadDebatePublishSource(DEBATE_ID)).rejects.toMatchObject({ code: 'media_not_ready' });
+    expect(shareCardWasBuilt()).toBe(false);
+  });
+
+  // The healthy answer from the content route is the redirect itself, not what it points at.
+  it('accepts a redirect from the durable content URL as resolving', async () => {
+    mockGeoChat({ job: { status: 'succeeded' }, artifacts: [{ kind: 'final_video' }] }, debateBody(), null, 302);
+
+    const { input } = await loadDebatePublishSource(DEBATE_ID);
+    expect(input.videoUrl).toBe(`${PUBLIC_GEO_CHAT_HOST}/debates/${DEBATE_ID}/media/artifacts/final_video/content`);
+    const probes = vi.mocked(fetch).mock.calls.filter(([input]) => String(input).endsWith('/content'));
+    expect(probes.map(([, init]) => init?.method)).toEqual(['HEAD']);
+    expect(probes.map(([, init]) => init?.redirect)).toEqual(['manual']);
   });
 
   it('uses geo-chat canonical turns + pre-attributed claims when available', async () => {

--- a/apps/web/core/debates/server/debate-source.test.ts
+++ b/apps/web/core/debates/server/debate-source.test.ts
@@ -23,10 +23,7 @@ function debateBody(overrides: Record<string, unknown> = {}) {
   };
 }
 
-/**
- * Routes each geo-chat path the loader touches to a canned response. `contentStatus` is what the
- * durable `/content` route answers to the pre-publish HEAD probe.
- */
+/** Routes each geo-chat path the loader touches to a canned response; `contentStatus` answers the `/content` HEAD probe. */
 function mockGeoChat(media: unknown, debate = debateBody(), claims: unknown = null, contentStatus = 200) {
   vi.stubGlobal(
     'fetch',
@@ -45,7 +42,7 @@ function mockGeoChat(media: unknown, debate = debateBody(), claims: unknown = nu
   );
 }
 
-/** Whether the loader got as far as rendering the share card (the one IPFS pin left on this path). */
+/** Whether the loader got as far as rendering the share card. */
 function shareCardWasBuilt(): boolean {
   return vi.mocked(fetch).mock.calls.some(([input]) => String(input).includes('/media/artifacts/url'));
 }
@@ -60,14 +57,11 @@ describe('loadDebatePublishSource media gating', () => {
   beforeEach(() => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-07-30T12:00:00.000Z'));
-    // The media URLs go on-chain, so they must be built on the public host even when the
-    // server-side base URL points at a cluster-internal one.
+    // Media URLs must be built on the public host even when the server-side one is internal.
     vi.stubEnv('NEXT_PUBLIC_GEO_CHAT_API_BASE_URL', PUBLIC_GEO_CHAT_HOST);
     vi.stubEnv('GEO_CHAT_API_BASE_URL', 'http://geo-chat.internal:8080');
   });
 
-  // geo-chat's presigned URLs expire after 15 minutes; the durable content route 302-redirects to
-  // a fresh one per request, so it is the only URL shape safe to put on-chain.
   it('publishes the durable content URL for the processed final_video', async () => {
     mockGeoChat({ job: { status: 'succeeded' }, artifacts: [{ kind: 'final_video' }] });
 
@@ -84,8 +78,6 @@ describe('loadDebatePublishSource media gating', () => {
     );
   });
 
-  // The media host is on-chain forever, so it is configured separately from the API host — that is
-  // what lets media move behind a CDN or object-store domain later without touching published data.
   it('prefers the dedicated media host over the geo-chat API host', async () => {
     vi.stubEnv('NEXT_PUBLIC_DEBATE_MEDIA_BASE_URL', 'https://media.example/');
     mockGeoChat({ job: { status: 'succeeded' }, artifacts: [{ kind: 'final_video' }] });
@@ -94,21 +86,15 @@ describe('loadDebatePublishSource media gating', () => {
     expect(input.videoUrl).toBe(`https://media.example/debates/${DEBATE_ID}/media/artifacts/final_video/content`);
   });
 
-  // `next.config.ts` documents pointing NEXT_PUBLIC_GEO_CHAT_API_BASE_URL at `/geo-chat-proxy` to
-  // dodge CORS in development. That works for the browser's own API calls and is meaningless
-  // on-chain, so publishing must fail rather than bake a relative URL into a published entity.
+  // The `/geo-chat-proxy` dev setup from `next.config.ts`.
   it('refuses to publish when the media host is not an absolute URL', async () => {
     vi.stubEnv('NEXT_PUBLIC_GEO_CHAT_API_BASE_URL', '/geo-chat-proxy');
     mockGeoChat({ job: { status: 'succeeded' }, artifacts: [{ kind: 'final_video' }] });
 
     await expect(loadDebatePublishSource(DEBATE_ID)).rejects.toThrow(/absolute http\(s\) URL/);
-    // Refused before the share card is pinned, or every refused tick leaves an orphan on IPFS.
     expect(shareCardWasBuilt()).toBe(false);
   });
 
-  // The localhost fallback exists for development only. A production deploy carrying just the
-  // server-side GEO_CHAT_API_BASE_URL reads every debate fine and would otherwise write
-  // `http://localhost:8080/...` on-chain for each of them.
   it('refuses to publish in production when no public media host is configured', async () => {
     vi.stubEnv('NODE_ENV', 'production');
     vi.stubEnv('NEXT_PUBLIC_GEO_CHAT_API_BASE_URL', '');
@@ -126,8 +112,6 @@ describe('loadDebatePublishSource media gating', () => {
     expect(input.videoUrl).toBe(`http://localhost:8080/debates/${DEBATE_ID}/media/artifacts/final_video/content`);
   });
 
-  // The URL is string-built, so this probe is the only thing standing between "geo-chat has not
-  // deployed the content route yet" and a permanently dead URL on-chain. A wait, not a failure.
   it('waits when the durable content URL does not resolve yet', async () => {
     mockGeoChat({ job: { status: 'succeeded' }, artifacts: [{ kind: 'final_video' }] }, debateBody(), null, 404);
 
@@ -135,7 +119,6 @@ describe('loadDebatePublishSource media gating', () => {
     expect(shareCardWasBuilt()).toBe(false);
   });
 
-  // The healthy answer from the content route is the redirect itself, not what it points at.
   it('accepts a redirect from the durable content URL as resolving', async () => {
     mockGeoChat({ job: { status: 'succeeded' }, artifacts: [{ kind: 'final_video' }] }, debateBody(), null, 302);
 

--- a/apps/web/core/debates/server/debate-source.test.ts
+++ b/apps/web/core/debates/server/debate-source.test.ts
@@ -4,16 +4,8 @@ import { DebateNotPublishableError, listSweepCandidateDebateIds, loadDebatePubli
 
 const DEBATE_ID = '019f89dc2124799193daafd5bc4ffa0a';
 
-const OBJECT_STORE_HOST = 'https://r2.example';
-
-// Stands in for the IPFS upload. Each artifact's fake bytes are its kind, so the returned CID
-// records which artifact was actually pinned.
-const { uploadGeoImage, pinToFakeIpfs } = vi.hoisted(() => {
-  const pinToFakeIpfs = async ({ blob }: { blob: Blob }) => ({ cid: `ipfs://cid-for-${await blob.text()}` });
-  return { uploadGeoImage: vi.fn(pinToFakeIpfs), pinToFakeIpfs };
-});
-
-vi.mock('~/core/sdk/geo-client', () => ({ uploadGeoImage }));
+/** The browser-reachable geo-chat host the published media URLs must be built on. */
+const PUBLIC_GEO_CHAT_HOST = 'https://chat.example';
 
 function debateBody(overrides: Record<string, unknown> = {}) {
   return {
@@ -31,71 +23,70 @@ function debateBody(overrides: Record<string, unknown> = {}) {
   };
 }
 
-/** Routes each geo-chat path the loader touches — plus the object store it redirects to — to a canned response. */
-function mockGeoChat(media: unknown, debate = debateBody(), artifactStatus = 200, claims: unknown = null) {
+/** Routes each geo-chat path the loader touches to a canned response. */
+function mockGeoChat(media: unknown, debate = debateBody(), claims: unknown = null) {
   vi.stubGlobal(
     'fetch',
-    vi.fn(async (input: string | URL, init?: RequestInit) => {
+    vi.fn(async (input: string | URL) => {
       const url = String(input);
-      if (url.startsWith(OBJECT_STORE_HOST)) {
-        return new Response(new URL(url).pathname.slice(1), { status: artifactStatus });
-      }
       const body = url.endsWith('/media')
         ? media
         : url.endsWith('/claims')
           ? claims
           : url.includes('/transcript')
             ? { segments: [] }
-            : url.includes('/media/artifacts/url')
-              ? { upload: { url: presignedUrlFor(String(init?.body)) } }
-              : debate;
+            : debate;
       return new Response(JSON.stringify(body), { status: 200 });
     })
   );
 }
 
-/** geo-chat presigns a distinct short-lived URL per artifact kind. */
-function presignedUrlFor(requestBody: string) {
-  const { kind } = JSON.parse(requestBody) as { kind: string };
-  return `${OBJECT_STORE_HOST}/${kind}?X-Amz-Expires=900`;
-}
-
 afterEach(() => {
   vi.useRealTimers();
   vi.unstubAllGlobals();
-  uploadGeoImage.mockReset();
-  uploadGeoImage.mockImplementation(pinToFakeIpfs);
+  vi.unstubAllEnvs();
 });
 
 describe('loadDebatePublishSource media gating', () => {
   beforeEach(() => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-07-30T12:00:00.000Z'));
+    // The media URLs go on-chain, so they must be built on the public host even when the
+    // server-side base URL points at a cluster-internal one.
+    vi.stubEnv('NEXT_PUBLIC_GEO_CHAT_API_BASE_URL', PUBLIC_GEO_CHAT_HOST);
+    vi.stubEnv('GEO_CHAT_API_BASE_URL', 'http://geo-chat.internal:8080');
   });
 
-  // Publishing geo-chat's presigned URL puts a link on-chain that expires 15 minutes later.
-  it('pins the processed final_video and publishes its permanent ipfs:// URI', async () => {
+  // geo-chat's presigned URLs expire after 15 minutes; the durable content route 302-redirects to
+  // a fresh one per request, so it is the only URL shape safe to put on-chain.
+  it('publishes the durable content URL for the processed final_video', async () => {
     mockGeoChat({ job: { status: 'succeeded' }, artifacts: [{ kind: 'final_video' }] });
 
     const { input } = await loadDebatePublishSource(DEBATE_ID);
-    // Handed over as the artifact's bytes, never as the presigned URL: the SDK's URL path rejects a
-    // webm body. Asserted by reading the blob rather than `expect.any(Blob)`, which is an
-    // `instanceof` against the test realm's global and fails on the Blob `fetch` actually returns.
-    const [uploaded] = uploadGeoImage.mock.calls[0];
-    expect(uploaded).not.toHaveProperty('url');
-    expect(await uploaded.blob.text()).toBe('final_video');
-    expect(input.videoUrl).toBe('ipfs://cid-for-final_video');
+    expect(input.videoUrl).toBe(`${PUBLIC_GEO_CHAT_HOST}/debates/${DEBATE_ID}/media/artifacts/final_video/content`);
   });
 
-  it('pins the preview_image as the video keyframe', async () => {
+  it('publishes the preview_image content URL as the video keyframe', async () => {
     mockGeoChat({ job: { status: 'succeeded' }, artifacts: [{ kind: 'final_video' }, { kind: 'preview_image' }] });
 
     const { input } = await loadDebatePublishSource(DEBATE_ID);
-    expect(input.keyframeUrl).toBe('ipfs://cid-for-preview_image');
+    expect(input.keyframeUrl).toBe(
+      `${PUBLIC_GEO_CHAT_HOST}/debates/${DEBATE_ID}/media/artifacts/preview_image/content`
+    );
+  });
+
+  // The media host is on-chain forever, so it is configured separately from the API host — that is
+  // what lets media move behind a CDN or object-store domain later without touching published data.
+  it('prefers the dedicated media host over the geo-chat API host', async () => {
+    vi.stubEnv('NEXT_PUBLIC_DEBATE_MEDIA_BASE_URL', 'https://media.example/');
+    mockGeoChat({ job: { status: 'succeeded' }, artifacts: [{ kind: 'final_video' }] });
+
+    const { input } = await loadDebatePublishSource(DEBATE_ID);
+    expect(input.videoUrl).toBe(`https://media.example/debates/${DEBATE_ID}/media/artifacts/final_video/content`);
   });
 
   it('uses geo-chat canonical turns + pre-attributed claims when available', async () => {
-    mockGeoChat({ job: { status: 'succeeded' }, artifacts: [{ kind: 'final_video' }] }, debateBody(), 200, {
+    mockGeoChat({ job: { status: 'succeeded' }, artifacts: [{ kind: 'final_video' }] }, debateBody(), {
       turns: [
         { turn_index: 0, participant_slot: 1, attributed_space_id: 'space-1', speaker_name: 'Specter', text: 'Nuclear program was advancing.' },
         { turn_index: 1, participant_slot: 2, attributed_space_id: 'space-2', speaker_name: 'Antispecter', text: 'There was no congressional approval.' },
@@ -130,27 +121,6 @@ describe('loadDebatePublishSource media gating', () => {
 
     const { input } = await loadDebatePublishSource(DEBATE_ID);
     expect(input.keyframeUrl).toBeNull();
-    expect(uploadGeoImage).toHaveBeenCalledTimes(1);
-  });
-
-  it('still publishes the video when pinning the keyframe fails', async () => {
-    mockGeoChat({ job: { status: 'succeeded' }, artifacts: [{ kind: 'final_video' }, { kind: 'preview_image' }] });
-    uploadGeoImage.mockImplementation(async ({ blob }: { blob: Blob }) => {
-      if ((await blob.text()) === 'preview_image') throw new Error('ipfs upload failed');
-      return { cid: 'ipfs://cid-for-final_video' };
-    });
-
-    const { input } = await loadDebatePublishSource(DEBATE_ID);
-    expect(input.videoUrl).toBe('ipfs://cid-for-final_video');
-    expect(input.keyframeUrl).toBeNull();
-  });
-
-  // An expired or revoked presigned URL must fail the publish, not pin the object store's error page.
-  it('fails the publish when the artifact download is rejected', async () => {
-    mockGeoChat({ job: { status: 'succeeded' }, artifacts: [{ kind: 'final_video' }] }, debateBody(), 403);
-
-    await expect(loadDebatePublishSource(DEBATE_ID)).rejects.toThrow(/Downloading final_video/);
-    expect(uploadGeoImage).not.toHaveBeenCalled();
   });
 
   // Without this gate, a succeeded job missing final_video publishes a videoless Debate entity.

--- a/apps/web/core/debates/server/debate-source.test.ts
+++ b/apps/web/core/debates/server/debate-source.test.ts
@@ -85,11 +85,33 @@ describe('loadDebatePublishSource media gating', () => {
     expect(input.videoUrl).toBe(`https://media.example/debates/${DEBATE_ID}/media/artifacts/final_video/content`);
   });
 
+  // `next.config.ts` documents pointing NEXT_PUBLIC_GEO_CHAT_API_BASE_URL at `/geo-chat-proxy` to
+  // dodge CORS in development. That works for the browser's own API calls and is meaningless
+  // on-chain, so publishing must fail rather than bake a relative URL into a published entity.
+  it('refuses to publish when the media host is not an absolute URL', async () => {
+    vi.stubEnv('NEXT_PUBLIC_GEO_CHAT_API_BASE_URL', '/geo-chat-proxy');
+    mockGeoChat({ job: { status: 'succeeded' }, artifacts: [{ kind: 'final_video' }] });
+
+    await expect(loadDebatePublishSource(DEBATE_ID)).rejects.toThrow(/absolute http\(s\) URL/);
+  });
+
   it('uses geo-chat canonical turns + pre-attributed claims when available', async () => {
     mockGeoChat({ job: { status: 'succeeded' }, artifacts: [{ kind: 'final_video' }] }, debateBody(), {
       turns: [
-        { turn_index: 0, participant_slot: 1, attributed_space_id: 'space-1', speaker_name: 'Specter', text: 'Nuclear program was advancing.' },
-        { turn_index: 1, participant_slot: 2, attributed_space_id: 'space-2', speaker_name: 'Antispecter', text: 'There was no congressional approval.' },
+        {
+          turn_index: 0,
+          participant_slot: 1,
+          attributed_space_id: 'space-1',
+          speaker_name: 'Specter',
+          text: 'Nuclear program was advancing.',
+        },
+        {
+          turn_index: 1,
+          participant_slot: 2,
+          attributed_space_id: 'space-2',
+          speaker_name: 'Antispecter',
+          text: 'There was no congressional approval.',
+        },
       ],
       claims: [
         { text: 'The nuclear program was advancing.', is_factual: true, turn_index: 0 },

--- a/apps/web/core/debates/server/debate-source.ts
+++ b/apps/web/core/debates/server/debate-source.ts
@@ -37,12 +37,22 @@ function geoChatBaseUrl() {
  * published entity. It falls back to the geo-chat host so nothing breaks when it is unset.
  */
 function debateMediaBaseUrl() {
-  const base =
+  const configured =
     process.env.NEXT_PUBLIC_DEBATE_MEDIA_BASE_URL ||
     process.env.NEXT_PUBLIC_GEO_CHAT_API_BASE_URL ||
-    process.env.GEO_CHAT_API_BASE_URL ||
-    'http://localhost:8080';
-  return base.replace(/\/+$/, '');
+    process.env.GEO_CHAT_API_BASE_URL;
+  const base = (configured || 'http://localhost:8080').replace(/\/+$/, '');
+  // A published URL cannot be edited once it is on-chain, so a misconfigured host is not a bug you
+  // fix by redeploying — every debate published under it is permanently broken. Refuse to build one
+  // outside development rather than bake a localhost default into the knowledge graph.
+  if (process.env.NODE_ENV === 'production' && /^https?:\/\/(localhost|127\.0\.0\.1|\[::1\])(:|\/|$)/i.test(base)) {
+    throw new Error(
+      'Refusing to publish debate media URLs pointing at ' +
+        `${base}: set NEXT_PUBLIC_DEBATE_MEDIA_BASE_URL to a public host. ` +
+        'These URLs are written on-chain and cannot be changed afterwards.'
+    );
+  }
+  return base;
 }
 
 /**
@@ -89,11 +99,7 @@ export type DebateSource = {
  * backlog.
  */
 export type DebateNotPublishableCode =
-  | 'not_complete'
-  | 'recording_cancelled'
-  | 'cancellation_window_open'
-  | 'media_not_ready'
-  | 'media_failed';
+  'not_complete' | 'recording_cancelled' | 'cancellation_window_open' | 'media_not_ready' | 'media_failed';
 
 export class DebateNotPublishableError extends Error {
   code: DebateNotPublishableCode;

--- a/apps/web/core/debates/server/debate-source.ts
+++ b/apps/web/core/debates/server/debate-source.ts
@@ -1,4 +1,8 @@
-import { type DebateOgCardData, type DebateOgSpeaker, generateDebateOgImageResponse } from '~/core/debates/debate-og-image';
+import {
+  type DebateOgCardData,
+  type DebateOgSpeaker,
+  generateDebateOgImageResponse,
+} from '~/core/debates/debate-og-image';
 import { uploadGeoImage } from '~/core/sdk/geo-client';
 import { getImagePath } from '~/core/utils/utils';
 
@@ -71,6 +75,19 @@ export class GeoChatRequestError extends Error {
 
 async function geoChatGet<T>(path: string): Promise<T> {
   const response = await fetch(`${geoChatBaseUrl()}${path}`, { cache: 'no-store' });
+  if (!response.ok) {
+    throw new GeoChatRequestError(response.status, `geo-chat ${path} failed (${response.status})`);
+  }
+  return response.json() as Promise<T>;
+}
+
+async function geoChatPost<T>(path: string, body: unknown): Promise<T> {
+  const response = await fetch(`${geoChatBaseUrl()}${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+    cache: 'no-store',
+  });
   if (!response.ok) {
     throw new GeoChatRequestError(response.status, `geo-chat ${path} failed (${response.status})`);
   }
@@ -299,9 +316,7 @@ async function buildDebateShareCard(
 
     const hasStill = (kind: string) => media.artifacts.some(artifact => artifact.kind === kind);
     if (!hasStill('speaker_still_slot_1') || !hasStill('speaker_still_slot_2')) {
-      console.warn(
-        `[debate-acceptor] debate ${debateId} has no speaker stills; publishing without a share card.`
-      );
+      console.warn(`[debate-acceptor] debate ${debateId} has no speaker stills; publishing without a share card.`);
       return null;
     }
 

--- a/apps/web/core/debates/server/debate-source.ts
+++ b/apps/web/core/debates/server/debate-source.ts
@@ -31,25 +31,14 @@ function geoChatBaseUrl() {
 }
 
 /**
- * The host published media URLs are built from. These URLs go on-chain and are opened by browsers,
- * so this must be a public host, and it can never change for already-published debates.
- *
- * Only `NEXT_PUBLIC_` variables are read, deliberately. `GEO_CHAT_API_BASE_URL` is the server-side
- * host and is allowed to be cluster-internal; the publish sweep is a cron that runs server-side, so
- * reading it here would let a deploy with only the server-side variable set publish perfectly
- * healthy-looking URLs that no browser can reach — permanently, since they are on-chain. A
- * `NEXT_PUBLIC_` value is browser-reachable by definition.
- *
- * `NEXT_PUBLIC_DEBATE_MEDIA_BASE_URL` exists so media can be served from a dedicated hostname that
- * is independent of geo-chat's API host. It is unset today (there is only the one geo-chat host);
- * setting it later, to a CDN or an object-store custom domain, costs a DNS change instead of a
- * migration of every published entity.
+ * The public host published media URLs are built from. Published URLs are written on-chain and
+ * opened by browsers, so only `NEXT_PUBLIC_` variables are read; `GEO_CHAT_API_BASE_URL` may be a
+ * cluster-internal host. `NEXT_PUBLIC_DEBATE_MEDIA_BASE_URL` allows media to move to its own
+ * hostname later without touching published entities.
  */
 function debateMediaBaseUrl() {
   const configured = process.env.NEXT_PUBLIC_DEBATE_MEDIA_BASE_URL || process.env.NEXT_PUBLIC_GEO_CHAT_API_BASE_URL;
-  // The localhost fallback is a development convenience. In production it is never right: a sweep
-  // deployed with only the server-side `GEO_CHAT_API_BASE_URL` would load every debate fine and
-  // then write `http://localhost:8080/...` on-chain for each of them, permanently.
+  // The localhost fallback is for development only.
   if (!configured && process.env.NODE_ENV === 'production') {
     throw new Error(
       'Refusing to publish debate media URLs: no public media host is configured. Set ' +
@@ -58,11 +47,8 @@ function debateMediaBaseUrl() {
     );
   }
   const base = (configured || 'http://localhost:8080').replace(/\/+$/, '');
-  // A relative base is a real configuration, not a hypothetical: `next.config.ts` documents
-  // pointing NEXT_PUBLIC_GEO_CHAT_API_BASE_URL at `/geo-chat-proxy` to dodge CORS in development.
-  // It works for the browser's own API calls and is meaningless on-chain — a published
-  // `/geo-chat-proxy/...` value resolves against whatever origin later renders it, if at all.
-  // Refuse rather than write one, since a published URL cannot be corrected afterwards.
+  // The `/geo-chat-proxy` dev setup in `next.config.ts` makes this a relative path, which cannot
+  // be used as a published URL.
   if (!/^https?:\/\//i.test(base)) {
     throw new Error(
       `Refusing to publish debate media URLs built on ${base}: the media host must be an absolute ` +
@@ -73,35 +59,23 @@ function debateMediaBaseUrl() {
   return base;
 }
 
-/**
- * Fail fast on a media host that can never produce a valid published URL. The sweep calls this
- * once before touching any debate, so a configuration error is one line in one response rather
- * than one failed attempt (and one orphaned share-card pin) per candidate debate per tick.
- */
+/** Throws if the media host cannot produce a valid published URL. The sweep calls this once up front. */
 export function assertDebateMediaHostConfigured(): void {
   debateMediaBaseUrl();
 }
 
 /**
- * The durable URL for a debate media artifact: geo-chat 302-redirects it to a fresh presigned
- * object-store GET on every request, and resolves it by (debate, kind), so it stays live across
- * media reprocessing and 404s once the artifact is deleted. This is what lets published media
- * stay off IPFS while remaining permanently deletable.
+ * The durable URL for a debate media artifact. geo-chat resolves it by (debate, kind) and
+ * 302-redirects to a fresh presigned GET, so it survives reprocessing and 404s once deleted.
  */
 function durableArtifactUrl(debateId: string, kind: DebateMediaArtifactKind): string {
   return `${debateMediaBaseUrl()}/debates/${debateId}/media/artifacts/${kind}/content`;
 }
 
 /**
- * Prove a durable URL resolves before it is written on-chain, where it can never be corrected.
- *
- * The URL is built by string concatenation, so nothing else on this path checks that geo-chat
- * actually serves it — the old IPFS pin did that implicitly by downloading the bytes. A dead URL
- * here is a wait, not a permanent failure: the usual cause is geo-chat not yet running a build
- * with the content route, and the next tick after it deploys publishes normally.
- *
- * `redirect: 'manual'` because the healthy answer is the 302 itself; following it would download
- * the artifact from object storage for nothing.
+ * Checks that geo-chat serves the durable URL before it is written on-chain. A non-2xx/3xx answer
+ * is treated as not ready (typically geo-chat has not deployed the content route yet). The 302 is
+ * the expected answer, so redirects are not followed.
  */
 async function assertDurableArtifactUrlResolves(debateId: string, url: string): Promise<void> {
   const response = await fetch(url, { method: 'HEAD', redirect: 'manual', cache: 'no-store' });
@@ -183,10 +157,8 @@ export async function listSweepCandidateDebateIds(spaceId: string): Promise<stri
 }
 
 /**
- * The space a debate publishes into: the one its claim lives in. One small read, so the acceptor
- * can check its editor rights there *before* {@link loadDebatePublishSource} renders and pins the
- * share card — a debate in a space the acceptor will never edit is terminal, and should not leave
- * a fresh orphan on IPFS every tick.
+ * The space a debate publishes into (its claim's space). Lets the acceptor check editor rights
+ * before {@link loadDebatePublishSource} renders and pins the share card.
  */
 export async function loadDebateClaimSpaceId(debateId: string): Promise<string> {
   const debate = await geoChatGet<Debate>(`/debates/${debateId}`);
@@ -237,10 +209,8 @@ export async function loadDebatePublishSource(debateId: string): Promise<DebateS
     );
   }
 
-  // The durable URLs come first, and are checked, before the share card is rendered and pinned.
-  // Everything above this line is a read; the share card is the one write on this path (an IPFS
-  // pin that nothing ever unpins), so anything that can still refuse the publish must run before
-  // it or every refused attempt leaves an orphan behind.
+  // Build and check the durable URLs before the share card is pinned, so a refused publish does not
+  // leave an orphaned IPFS pin.
   const videoUrl = durableArtifactUrl(debateId, 'final_video');
   const keyframeUrl = media.artifacts.some(artifact => artifact.kind === 'preview_image')
     ? durableArtifactUrl(debateId, 'preview_image')
@@ -322,8 +292,7 @@ async function artifactUrl(debateId: string, kind: DebateMediaArtifactKind): Pro
  *
  * Null on any failure, deliberately. This sits in the path that writes the Debate and Video
  * entities on-chain, and a debate that fails to publish is a far worse outcome than one published
- * without a share card. (The video and keyframe URLs need no such rule: they are built, not
- * fetched, and cannot fail here.)
+ * without a share card.
  *
  * **Both speaker stills are required.** The card is generated once at publish time and never
  * revisited, so falling back to the placeholder panels would bake them in permanently. A debate

--- a/apps/web/core/debates/server/debate-source.ts
+++ b/apps/web/core/debates/server/debate-source.ts
@@ -28,31 +28,25 @@ function geoChatBaseUrl() {
 
 /**
  * The host published media URLs are built from. These URLs go on-chain and are opened by browsers,
- * so this must be a public host — never a cluster-internal one that `GEO_CHAT_API_BASE_URL` may
- * point at — and it can never change for already-published debates.
+ * so this must be a public host, and it can never change for already-published debates.
+ *
+ * Only `NEXT_PUBLIC_` variables are read, deliberately. `GEO_CHAT_API_BASE_URL` is the server-side
+ * host and is allowed to be cluster-internal; the publish sweep is a cron that runs server-side, so
+ * reading it here would let a deploy with only the server-side variable set publish perfectly
+ * healthy-looking URLs that no browser can reach — permanently, since they are on-chain. A
+ * `NEXT_PUBLIC_` value is browser-reachable by definition.
  *
  * `NEXT_PUBLIC_DEBATE_MEDIA_BASE_URL` exists so media can be served from a dedicated hostname that
- * is independent of geo-chat's API host. Point it at geo-chat today; repointing it later (at a CDN,
- * or an object-store custom domain) then costs a DNS change instead of a migration of every
- * published entity. It falls back to the geo-chat host so nothing breaks when it is unset.
+ * is independent of geo-chat's API host. It is unset today (there is only the one geo-chat host);
+ * setting it later, to a CDN or an object-store custom domain, costs a DNS change instead of a
+ * migration of every published entity.
  */
 function debateMediaBaseUrl() {
-  const configured =
+  const base =
     process.env.NEXT_PUBLIC_DEBATE_MEDIA_BASE_URL ||
     process.env.NEXT_PUBLIC_GEO_CHAT_API_BASE_URL ||
-    process.env.GEO_CHAT_API_BASE_URL;
-  const base = (configured || 'http://localhost:8080').replace(/\/+$/, '');
-  // A published URL cannot be edited once it is on-chain, so a misconfigured host is not a bug you
-  // fix by redeploying — every debate published under it is permanently broken. Refuse to build one
-  // outside development rather than bake a localhost default into the knowledge graph.
-  if (process.env.NODE_ENV === 'production' && /^https?:\/\/(localhost|127\.0\.0\.1|\[::1\])(:|\/|$)/i.test(base)) {
-    throw new Error(
-      'Refusing to publish debate media URLs pointing at ' +
-        `${base}: set NEXT_PUBLIC_DEBATE_MEDIA_BASE_URL to a public host. ` +
-        'These URLs are written on-chain and cannot be changed afterwards.'
-    );
-  }
-  return base;
+    'http://localhost:8080';
+  return base.replace(/\/+$/, '');
 }
 
 /**

--- a/apps/web/core/debates/server/debate-source.ts
+++ b/apps/web/core/debates/server/debate-source.ts
@@ -46,11 +46,18 @@ function geoChatBaseUrl() {
  * migration of every published entity.
  */
 function debateMediaBaseUrl() {
-  const base = (
-    process.env.NEXT_PUBLIC_DEBATE_MEDIA_BASE_URL ||
-    process.env.NEXT_PUBLIC_GEO_CHAT_API_BASE_URL ||
-    'http://localhost:8080'
-  ).replace(/\/+$/, '');
+  const configured = process.env.NEXT_PUBLIC_DEBATE_MEDIA_BASE_URL || process.env.NEXT_PUBLIC_GEO_CHAT_API_BASE_URL;
+  // The localhost fallback is a development convenience. In production it is never right: a sweep
+  // deployed with only the server-side `GEO_CHAT_API_BASE_URL` would load every debate fine and
+  // then write `http://localhost:8080/...` on-chain for each of them, permanently.
+  if (!configured && process.env.NODE_ENV === 'production') {
+    throw new Error(
+      'Refusing to publish debate media URLs: no public media host is configured. Set ' +
+        'NEXT_PUBLIC_DEBATE_MEDIA_BASE_URL (or NEXT_PUBLIC_GEO_CHAT_API_BASE_URL) to the browser-reachable ' +
+        'geo-chat host, because published URLs are written on-chain and cannot be changed afterwards.'
+    );
+  }
+  const base = (configured || 'http://localhost:8080').replace(/\/+$/, '');
   // A relative base is a real configuration, not a hypothetical: `next.config.ts` documents
   // pointing NEXT_PUBLIC_GEO_CHAT_API_BASE_URL at `/geo-chat-proxy` to dodge CORS in development.
   // It works for the browser's own API calls and is meaningless on-chain — a published
@@ -67,6 +74,15 @@ function debateMediaBaseUrl() {
 }
 
 /**
+ * Fail fast on a media host that can never produce a valid published URL. The sweep calls this
+ * once before touching any debate, so a configuration error is one line in one response rather
+ * than one failed attempt (and one orphaned share-card pin) per candidate debate per tick.
+ */
+export function assertDebateMediaHostConfigured(): void {
+  debateMediaBaseUrl();
+}
+
+/**
  * The durable URL for a debate media artifact: geo-chat 302-redirects it to a fresh presigned
  * object-store GET on every request, and resolves it by (debate, kind), so it stays live across
  * media reprocessing and 404s once the artifact is deleted. This is what lets published media
@@ -74,6 +90,26 @@ function debateMediaBaseUrl() {
  */
 function durableArtifactUrl(debateId: string, kind: DebateMediaArtifactKind): string {
   return `${debateMediaBaseUrl()}/debates/${debateId}/media/artifacts/${kind}/content`;
+}
+
+/**
+ * Prove a durable URL resolves before it is written on-chain, where it can never be corrected.
+ *
+ * The URL is built by string concatenation, so nothing else on this path checks that geo-chat
+ * actually serves it — the old IPFS pin did that implicitly by downloading the bytes. A dead URL
+ * here is a wait, not a permanent failure: the usual cause is geo-chat not yet running a build
+ * with the content route, and the next tick after it deploys publishes normally.
+ *
+ * `redirect: 'manual'` because the healthy answer is the 302 itself; following it would download
+ * the artifact from object storage for nothing.
+ */
+async function assertDurableArtifactUrlResolves(debateId: string, url: string): Promise<void> {
+  const response = await fetch(url, { method: 'HEAD', redirect: 'manual', cache: 'no-store' });
+  if (response.status >= 200 && response.status < 400) return;
+  throw new DebateNotPublishableError(
+    'media_not_ready',
+    `Debate ${debateId} durable media URL ${url} does not resolve yet (${response.status}).`
+  );
 }
 
 /** Carries geo-chat's HTTP status so the route can tell a permanent 4xx (bad id) from a transient 5xx. */
@@ -147,6 +183,17 @@ export async function listSweepCandidateDebateIds(spaceId: string): Promise<stri
 }
 
 /**
+ * The space a debate publishes into: the one its claim lives in. One small read, so the acceptor
+ * can check its editor rights there *before* {@link loadDebatePublishSource} renders and pins the
+ * share card — a debate in a space the acceptor will never edit is terminal, and should not leave
+ * a fresh orphan on IPFS every tick.
+ */
+export async function loadDebateClaimSpaceId(debateId: string): Promise<string> {
+  const debate = await geoChatGet<Debate>(`/debates/${debateId}`);
+  return debate.claim.space_id;
+}
+
+/**
  * Gather everything the KG publish needs for a finished debate straight from geo-chat, and
  * assemble the pure `DebatePublishInput`. Throws {@link DebateNotPublishableError} unless the
  * debate is complete, its cancellation window has settled, and its media job has succeeded (the
@@ -190,11 +237,18 @@ export async function loadDebatePublishSource(debateId: string): Promise<DebateS
     );
   }
 
-  const ogImageUrl = await buildDebateShareCard(debateId, debate, media);
+  // The durable URLs come first, and are checked, before the share card is rendered and pinned.
+  // Everything above this line is a read; the share card is the one write on this path (an IPFS
+  // pin that nothing ever unpins), so anything that can still refuse the publish must run before
+  // it or every refused attempt leaves an orphan behind.
   const videoUrl = durableArtifactUrl(debateId, 'final_video');
   const keyframeUrl = media.artifacts.some(artifact => artifact.kind === 'preview_image')
     ? durableArtifactUrl(debateId, 'preview_image')
     : null;
+  await assertDurableArtifactUrlResolves(debateId, videoUrl);
+  if (keyframeUrl) await assertDurableArtifactUrlResolves(debateId, keyframeUrl);
+
+  const ogImageUrl = await buildDebateShareCard(debateId, debate, media);
   // Prefer geo-chat's canonical turns + pre-attributed claims (extracted in its media job, next to
   // transcription). geo-chat is the single authority on turn boundaries, so its `turn_index` lines
   // the published transcript blocks up with the claims exactly. Falls back to merging the raw
@@ -268,7 +322,8 @@ async function artifactUrl(debateId: string, kind: DebateMediaArtifactKind): Pro
  *
  * Null on any failure, deliberately. This sits in the path that writes the Debate and Video
  * entities on-chain, and a debate that fails to publish is a far worse outcome than one published
- * without a share card — the same rule the keyframe pin already follows.
+ * without a share card. (The video and keyframe URLs need no such rule: they are built, not
+ * fetched, and cannot fail here.)
  *
  * **Both speaker stills are required.** The card is generated once at publish time and never
  * revisited, so falling back to the placeholder panels would bake them in permanently. A debate

--- a/apps/web/core/debates/server/debate-source.ts
+++ b/apps/web/core/debates/server/debate-source.ts
@@ -46,11 +46,24 @@ function geoChatBaseUrl() {
  * migration of every published entity.
  */
 function debateMediaBaseUrl() {
-  const base =
+  const base = (
     process.env.NEXT_PUBLIC_DEBATE_MEDIA_BASE_URL ||
     process.env.NEXT_PUBLIC_GEO_CHAT_API_BASE_URL ||
-    'http://localhost:8080';
-  return base.replace(/\/+$/, '');
+    'http://localhost:8080'
+  ).replace(/\/+$/, '');
+  // A relative base is a real configuration, not a hypothetical: `next.config.ts` documents
+  // pointing NEXT_PUBLIC_GEO_CHAT_API_BASE_URL at `/geo-chat-proxy` to dodge CORS in development.
+  // It works for the browser's own API calls and is meaningless on-chain — a published
+  // `/geo-chat-proxy/...` value resolves against whatever origin later renders it, if at all.
+  // Refuse rather than write one, since a published URL cannot be corrected afterwards.
+  if (!/^https?:\/\//i.test(base)) {
+    throw new Error(
+      `Refusing to publish debate media URLs built on ${base}: the media host must be an absolute ` +
+        'http(s) URL, because it is written on-chain and cannot be changed afterwards. ' +
+        'Set NEXT_PUBLIC_DEBATE_MEDIA_BASE_URL to a public host.'
+    );
+  }
+  return base;
 }
 
 /**

--- a/apps/web/core/debates/server/debate-source.ts
+++ b/apps/web/core/debates/server/debate-source.ts
@@ -26,6 +26,35 @@ function geoChatBaseUrl() {
   return base.replace(/\/+$/, '');
 }
 
+/**
+ * The host published media URLs are built from. These URLs go on-chain and are opened by browsers,
+ * so this must be a public host — never a cluster-internal one that `GEO_CHAT_API_BASE_URL` may
+ * point at — and it can never change for already-published debates.
+ *
+ * `NEXT_PUBLIC_DEBATE_MEDIA_BASE_URL` exists so media can be served from a dedicated hostname that
+ * is independent of geo-chat's API host. Point it at geo-chat today; repointing it later (at a CDN,
+ * or an object-store custom domain) then costs a DNS change instead of a migration of every
+ * published entity. It falls back to the geo-chat host so nothing breaks when it is unset.
+ */
+function debateMediaBaseUrl() {
+  const base =
+    process.env.NEXT_PUBLIC_DEBATE_MEDIA_BASE_URL ||
+    process.env.NEXT_PUBLIC_GEO_CHAT_API_BASE_URL ||
+    process.env.GEO_CHAT_API_BASE_URL ||
+    'http://localhost:8080';
+  return base.replace(/\/+$/, '');
+}
+
+/**
+ * The durable URL for a debate media artifact: geo-chat 302-redirects it to a fresh presigned
+ * object-store GET on every request, and resolves it by (debate, kind), so it stays live across
+ * media reprocessing and 404s once the artifact is deleted. This is what lets published media
+ * stay off IPFS while remaining permanently deletable.
+ */
+function durableArtifactUrl(debateId: string, kind: DebateMediaArtifactKind): string {
+  return `${debateMediaBaseUrl()}/debates/${debateId}/media/artifacts/${kind}/content`;
+}
+
 /** Carries geo-chat's HTTP status so the route can tell a permanent 4xx (bad id) from a transient 5xx. */
 export class GeoChatRequestError extends Error {
   status: number;
@@ -38,19 +67,6 @@ export class GeoChatRequestError extends Error {
 
 async function geoChatGet<T>(path: string): Promise<T> {
   const response = await fetch(`${geoChatBaseUrl()}${path}`, { cache: 'no-store' });
-  if (!response.ok) {
-    throw new GeoChatRequestError(response.status, `geo-chat ${path} failed (${response.status})`);
-  }
-  return response.json() as Promise<T>;
-}
-
-async function geoChatPost<T>(path: string, body: unknown): Promise<T> {
-  const response = await fetch(`${geoChatBaseUrl()}${path}`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(body),
-    cache: 'no-store',
-  });
   if (!response.ok) {
     throw new GeoChatRequestError(response.status, `geo-chat ${path} failed (${response.status})`);
   }
@@ -145,9 +161,9 @@ export async function loadDebatePublishSource(debateId: string): Promise<DebateS
   }
 
   const ogImageUrl = await buildDebateShareCard(debateId, debate, media);
-  const videoUrl = await pinArtifactToIpfs(debateId, 'final_video');
+  const videoUrl = durableArtifactUrl(debateId, 'final_video');
   const keyframeUrl = media.artifacts.some(artifact => artifact.kind === 'preview_image')
-    ? await pinKeyframeToIpfs(debateId)
+    ? durableArtifactUrl(debateId, 'preview_image')
     : null;
   // Prefer geo-chat's canonical turns + pre-attributed claims (extracted in its media job, next to
   // transcription). geo-chat is the single authority on turn boundaries, so its `turn_index` lines
@@ -209,16 +225,6 @@ function debatePublicationDeadline(debate: Debate): number | null {
   return Number.isFinite(timestamp) ? timestamp : null;
 }
 
-/**
- * Pin a geo-chat media artifact to IPFS and return its permanent `ipfs://` URI.
- *
- * geo-chat only hands out presigned object-store URLs, and those expire after 15 minutes, so a
- * published one is dead well before anyone opens the entity. Download the bytes while the URL is
- * still valid and pin those instead.
- *
- * Uploaded as a blob rather than by URL: the SDK's URL path rejects any body that isn't an image,
- * and the final video is a webm.
- */
 /** A presigned object-store URL for one media artifact. Expires in ~15 minutes. */
 async function artifactUrl(debateId: string, kind: DebateMediaArtifactKind): Promise<string> {
   const { upload } = await geoChatPost<{ upload: { url: string } }>(`/debates/${debateId}/media/artifacts/url`, {
@@ -313,28 +319,6 @@ async function buildDebateShareCard(
     return cid;
   } catch (error) {
     console.warn(`[debate-acceptor] could not build a share card for ${debateId}; publishing without one.`, error);
-    return null;
-  }
-}
-
-async function pinArtifactToIpfs(debateId: string, kind: DebateMediaArtifactKind): Promise<string> {
-  const { upload } = await geoChatPost<{ upload: { url: string } }>(`/debates/${debateId}/media/artifacts/url`, {
-    kind,
-  });
-  const response = await fetch(upload.url, { cache: 'no-store' });
-  if (!response.ok) {
-    throw new Error(`Downloading ${kind} for debate ${debateId} failed (${response.status}).`);
-  }
-  const { cid } = await uploadGeoImage({ blob: await response.blob() });
-  return cid;
-}
-
-async function pinKeyframeToIpfs(debateId: string): Promise<string | null> {
-  try {
-    return await pinArtifactToIpfs(debateId, 'preview_image');
-  } catch (error) {
-    // A missing poster shouldn't hold back the Debate + Video entities.
-    console.warn(`[debate-acceptor] could not pin keyframe for ${debateId}; publishing without one.`, error);
     return null;
   }
 }

--- a/apps/web/core/debates/server/debate-source.ts
+++ b/apps/web/core/debates/server/debate-source.ts
@@ -49,14 +49,36 @@ function debateMediaBaseUrl() {
   const base = (configured || 'http://localhost:8080').replace(/\/+$/, '');
   // The `/geo-chat-proxy` dev setup in `next.config.ts` makes this a relative path, which cannot
   // be used as a published URL.
-  if (!/^https?:\/\//i.test(base)) {
+  const parsed = parseAbsoluteHttpUrl(base);
+  if (!parsed) {
     throw new Error(
       `Refusing to publish debate media URLs built on ${base}: the media host must be an absolute ` +
         'http(s) URL, because it is written on-chain and cannot be changed afterwards. ' +
         'Set NEXT_PUBLIC_DEBATE_MEDIA_BASE_URL to a public host.'
     );
   }
+  // A query or fragment on the base would take the artifact path into the query string.
+  if (/[?#]/.test(base)) {
+    throw new Error(
+      `Refusing to publish debate media URLs built on ${base}: the media host must not carry a query string or fragment.`
+    );
+  }
+  // Geo is served over https; http media would be blocked as mixed content.
+  if (process.env.NODE_ENV === 'production' && parsed.protocol !== 'https:') {
+    throw new Error(
+      `Refusing to publish debate media URLs built on ${base}: the media host must use https in production.`
+    );
+  }
   return base;
+}
+
+function parseAbsoluteHttpUrl(value: string): URL | null {
+  if (!/^https?:\/\//i.test(value)) return null;
+  try {
+    return new URL(value);
+  } catch {
+    return null;
+  }
 }
 
 /** Throws if the media host cannot produce a valid published URL. The sweep calls this once up front. */

--- a/apps/web/core/debates/server/publish-debate.ts
+++ b/apps/web/core/debates/server/publish-debate.ts
@@ -15,7 +15,7 @@ import { Publish } from '~/core/utils/publish';
 
 import { buildDebatePublishDraft } from '../debate-publish-draft';
 import { getDebateAcceptorConfig } from './acceptor-config';
-import { loadDebatePublishSource } from './debate-source';
+import { loadDebateClaimSpaceId, loadDebatePublishSource } from './debate-source';
 
 export type PublishDebateResult =
   | { status: 'published'; debateEntityId: string; spaceId: string; userOpHash: string }
@@ -43,33 +43,35 @@ export async function publishDebateAsAcceptor(debateId: string): Promise<Publish
     return { status: 'already_published', debateEntityId };
   }
 
-  const { input } = await loadDebatePublishSource(debateId);
-  const draft = buildDebatePublishDraft(input);
-
-  const space = await Effect.runPromise(getSpace(input.spaceId));
-  if (!space) {
-    throw new Error(`Space ${input.spaceId} could not be loaded for debate publishing.`);
-  }
-
   // Only auto-publish into spaces the acceptor actually edits. Publishing needs editor rights (a
   // member can propose but not vote+execute), and attempting it elsewhere just reverts on-chain
-  // (CanNotExecute).
+  // (CanNotExecute). Checked before loading the publish source, which renders and pins the share
+  // card: a not-editor debate is terminal and would otherwise leave a new orphan on IPFS per tick.
+  const spaceId = await loadDebateClaimSpaceId(debateId);
+  const space = await Effect.runPromise(getSpace(spaceId));
+  if (!space) {
+    throw new Error(`Space ${spaceId} could not be loaded for debate publishing.`);
+  }
+
   const access = await Effect.runPromise(getSpaceAccess(space, config.spaceId));
   if (!access.isEditor) {
     // `console.error`, not `log`: this is terminal, not a retry. The debate is recorded, its claim
     // lives somewhere the acceptor can never publish, and every sweep from here on will reach this
-    // same line and spend one of its attempt slots doing it. A personal space is the usual cause —
-    // editor rights there belong to the owner alone — which is why the rematch picker refuses to
-    // offer such a claim in the first place (see `isDebatePublishableSpace`). Reaching here means a
-    // debate got past that, so it wants looking at rather than filing under routine.
+    // same line. A personal space is the usual cause — editor rights there belong to the owner
+    // alone — which is why the rematch picker refuses to offer such a claim in the first place
+    // (see `isDebatePublishableSpace`). Reaching here means a debate got past that, so it wants
+    // looking at rather than filing under routine.
     console.error('[debate-acceptor] debate cannot be published: acceptor is not an editor of the space', {
       debateId,
-      spaceId: input.spaceId,
+      spaceId,
       spaceType: space.type,
       acceptorSpaceId: config.spaceId,
     });
-    return { status: 'not_editor', debateEntityId: draft.debateEntityId, spaceId: input.spaceId };
+    return { status: 'not_editor', debateEntityId, spaceId };
   }
+
+  const { input } = await loadDebatePublishSource(debateId);
+  const draft = buildDebatePublishDraft(input);
 
   const ops = await Effect.runPromise(
     Publish.prepareLocalDataForPublishing(draft.values, draft.relations, input.spaceId)

--- a/apps/web/core/debates/server/publish-debate.ts
+++ b/apps/web/core/debates/server/publish-debate.ts
@@ -45,8 +45,7 @@ export async function publishDebateAsAcceptor(debateId: string): Promise<Publish
 
   // Only auto-publish into spaces the acceptor actually edits. Publishing needs editor rights (a
   // member can propose but not vote+execute), and attempting it elsewhere just reverts on-chain
-  // (CanNotExecute). Checked before loading the publish source, which renders and pins the share
-  // card: a not-editor debate is terminal and would otherwise leave a new orphan on IPFS per tick.
+  // (CanNotExecute). Checked before loading the publish source, which pins the share card to IPFS.
   const spaceId = await loadDebateClaimSpaceId(debateId);
   const space = await Effect.runPromise(getSpace(spaceId));
   if (!space) {

--- a/apps/web/core/hooks/use-block-main-media-url.ts
+++ b/apps/web/core/hooks/use-block-main-media-url.ts
@@ -5,13 +5,10 @@ import * as React from 'react';
 import type { BlockMediaKind } from '~/core/blocks/data/resolve-main-media-property';
 import { ID } from '~/core/id';
 import { useSpaceAwareRelation, useValues } from '~/core/sync/use-store';
+import { isDirectMediaUrl } from '~/core/utils/media-url';
 import { useEntityMedia } from '~/core/utils/use-entity-media';
 
 import { useVideoKeyframeUrl } from './use-video-keyframe-url';
-
-function isDirectMediaUrl(value: string | null | undefined): value is string {
-  return Boolean(value && (value.startsWith('ipfs://') || value.startsWith('http://') || value.startsWith('https://')));
-}
 
 export type BlockMainMediaUrl = {
   url: string | undefined;

--- a/apps/web/core/hooks/use-video-keyframe-url.ts
+++ b/apps/web/core/hooks/use-video-keyframe-url.ts
@@ -10,10 +10,7 @@ import { KEY_FRAME_IMAGE_PROPERTY } from '~/core/constants';
 import { ID } from '~/core/id';
 import { getRelationsByFromEntityId } from '~/core/io/queries';
 import { useSpaceAwareRelation, useValues } from '~/core/sync/use-store';
-
-function isDirectMediaUrl(value: string | null | undefined): value is string {
-  return Boolean(value && (value.startsWith('ipfs://') || value.startsWith('http://') || value.startsWith('https://')));
-}
+import { isDirectMediaUrl } from '~/core/utils/media-url';
 
 export type VideoKeyframeUrl = {
   url: string | undefined;

--- a/apps/web/core/io/dto/relations.test.ts
+++ b/apps/web/core/io/dto/relations.test.ts
@@ -1,0 +1,80 @@
+import { ContentIds, SystemIds } from '@geoprotocol/geo-sdk/lite';
+import { describe, expect, it } from 'vitest';
+
+import { RelationDtoLive, type RemoteRelationWithTarget } from './relations';
+
+const SPACE_ID = 'c9f267dcb0d270718c2a3c45a64afd32';
+const IPFS_URL_PROPERTY_HEX = SystemIds.IMAGE_URL_PROPERTY.replace(/-/g, '');
+const WEB_URL_PROPERTY_HEX = ContentIds.WEB_URL_PROPERTY.replace(/-/g, '');
+const IMAGE_TYPE_HEX = SystemIds.IMAGE_TYPE.replace(/-/g, '');
+const VIDEO_TYPE_HEX = SystemIds.VIDEO_TYPE.replace(/-/g, '');
+
+const WEB_URL = 'https://chat.example/debates/deb-1/media/artifacts/final_video/content';
+const IPFS_URL = 'ipfs://bafymediacid';
+
+function remoteRelation({
+  types = [],
+  valuesList = [],
+}: {
+  types?: { id: string }[];
+  valuesList?: { spaceId: string; propertyId: string; text: string | null }[];
+}): RemoteRelationWithTarget {
+  return {
+    id: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    spaceId: SPACE_ID,
+    position: null,
+    verified: null,
+    fromEntity: { id: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb', name: 'Debate' },
+    toEntity: { id: 'cccccccccccccccccccccccccccccccc', name: 'Debate video', types, valuesList },
+    toSpaceId: null,
+    type: { id: 'dddddddddddddddddddddddddddddddd', name: 'Debate videos' },
+  } as unknown as RemoteRelationWithTarget;
+}
+
+function value(propertyId: string, text: string) {
+  return { spaceId: SPACE_ID, propertyId, text };
+}
+
+describe('RelationDtoLive media URL resolution', () => {
+  it('reads the Web URL property for a Video-typed target', () => {
+    const relation = RelationDtoLive(
+      remoteRelation({ types: [{ id: VIDEO_TYPE_HEX }], valuesList: [value(WEB_URL_PROPERTY_HEX, WEB_URL)] })
+    );
+    expect(relation.renderableType).toBe('VIDEO');
+    expect(relation.toEntity.value).toBe(WEB_URL);
+  });
+
+  it('reads the Web URL property for an Image-typed target', () => {
+    const relation = RelationDtoLive(
+      remoteRelation({ types: [{ id: IMAGE_TYPE_HEX }], valuesList: [value(WEB_URL_PROPERTY_HEX, WEB_URL)] })
+    );
+    expect(relation.renderableType).toBe('IMAGE');
+    expect(relation.toEntity.value).toBe(WEB_URL);
+  });
+
+  // Pre-existing IPFS-pinned entities must keep resolving exactly as before the Web URL fallback.
+  it('prefers the IPFS URL when both properties are present', () => {
+    const relation = RelationDtoLive(
+      remoteRelation({
+        types: [{ id: VIDEO_TYPE_HEX }],
+        valuesList: [value(WEB_URL_PROPERTY_HEX, WEB_URL), value(IPFS_URL_PROPERTY_HEX, IPFS_URL)],
+      })
+    );
+    expect(relation.toEntity.value).toBe(IPFS_URL);
+  });
+
+  // `Web URL` is the generic canonical-link property (sources, articles, …): its presence on an
+  // untyped target must not turn an ordinary relation into a broken image render.
+  it('does not promote an untyped target to IMAGE on a Web URL value', () => {
+    const relation = RelationDtoLive(remoteRelation({ valuesList: [value(WEB_URL_PROPERTY_HEX, WEB_URL)] }));
+    expect(relation.renderableType).toBe('RELATION');
+    expect(relation.toEntity.value).toBe('cccccccccccccccccccccccccccccccc');
+  });
+
+  // The legacy behavior: an IPFS URL alone promotes an untyped target to IMAGE.
+  it('still promotes an untyped target to IMAGE on an IPFS URL value', () => {
+    const relation = RelationDtoLive(remoteRelation({ valuesList: [value(IPFS_URL_PROPERTY_HEX, IPFS_URL)] }));
+    expect(relation.renderableType).toBe('IMAGE');
+    expect(relation.toEntity.value).toBe(IPFS_URL);
+  });
+});

--- a/apps/web/core/io/dto/relations.test.ts
+++ b/apps/web/core/io/dto/relations.test.ts
@@ -63,6 +63,14 @@ describe('RelationDtoLive media URL resolution', () => {
     expect(relation.toEntity.value).toBe(IPFS_URL);
   });
 
+  it('ignores a Web URL value that is not a loadable media URL', () => {
+    const relation = RelationDtoLive(
+      remoteRelation({ types: [{ id: VIDEO_TYPE_HEX }], valuesList: [value(WEB_URL_PROPERTY_HEX, 'mailto:a@b.c')] })
+    );
+    expect(relation.renderableType).toBe('VIDEO');
+    expect(relation.toEntity.value).toBe('');
+  });
+
   it('falls through to the Web URL when the IPFS URL value is blank', () => {
     const relation = RelationDtoLive(
       remoteRelation({

--- a/apps/web/core/io/dto/relations.test.ts
+++ b/apps/web/core/io/dto/relations.test.ts
@@ -1,4 +1,5 @@
 import { ContentIds, SystemIds } from '@geoprotocol/geo-sdk/lite';
+
 import { describe, expect, it } from 'vitest';
 
 import { RelationDtoLive, type RemoteRelationWithTarget } from './relations';
@@ -61,6 +62,18 @@ describe('RelationDtoLive media URL resolution', () => {
       })
     );
     expect(relation.toEntity.value).toBe(IPFS_URL);
+  });
+
+  // A blank IPFS URL value is "no IPFS URL", not a URL that beats the fallback.
+  it('falls through to the Web URL when the IPFS URL value is blank', () => {
+    const relation = RelationDtoLive(
+      remoteRelation({
+        types: [{ id: IMAGE_TYPE_HEX }],
+        valuesList: [value(IPFS_URL_PROPERTY_HEX, ''), value(WEB_URL_PROPERTY_HEX, WEB_URL)],
+      })
+    );
+    expect(relation.renderableType).toBe('IMAGE');
+    expect(relation.toEntity.value).toBe(WEB_URL);
   });
 
   // `Web URL` is the generic canonical-link property (sources, articles, …): its presence on an

--- a/apps/web/core/io/dto/relations.test.ts
+++ b/apps/web/core/io/dto/relations.test.ts
@@ -53,7 +53,6 @@ describe('RelationDtoLive media URL resolution', () => {
     expect(relation.toEntity.value).toBe(WEB_URL);
   });
 
-  // Pre-existing IPFS-pinned entities must keep resolving exactly as before the Web URL fallback.
   it('prefers the IPFS URL when both properties are present', () => {
     const relation = RelationDtoLive(
       remoteRelation({
@@ -64,7 +63,6 @@ describe('RelationDtoLive media URL resolution', () => {
     expect(relation.toEntity.value).toBe(IPFS_URL);
   });
 
-  // A blank IPFS URL value is "no IPFS URL", not a URL that beats the fallback.
   it('falls through to the Web URL when the IPFS URL value is blank', () => {
     const relation = RelationDtoLive(
       remoteRelation({
@@ -76,15 +74,13 @@ describe('RelationDtoLive media URL resolution', () => {
     expect(relation.toEntity.value).toBe(WEB_URL);
   });
 
-  // `Web URL` is the generic canonical-link property (sources, articles, …): its presence on an
-  // untyped target must not turn an ordinary relation into a broken image render.
+  // `Web URL` is also a general canonical-link property.
   it('does not promote an untyped target to IMAGE on a Web URL value', () => {
     const relation = RelationDtoLive(remoteRelation({ valuesList: [value(WEB_URL_PROPERTY_HEX, WEB_URL)] }));
     expect(relation.renderableType).toBe('RELATION');
     expect(relation.toEntity.value).toBe('cccccccccccccccccccccccccccccccc');
   });
 
-  // The legacy behavior: an IPFS URL alone promotes an untyped target to IMAGE.
   it('still promotes an untyped target to IMAGE on an IPFS URL value', () => {
     const relation = RelationDtoLive(remoteRelation({ valuesList: [value(IPFS_URL_PROPERTY_HEX, IPFS_URL)] }));
     expect(relation.renderableType).toBe('IMAGE');

--- a/apps/web/core/io/dto/relations.ts
+++ b/apps/web/core/io/dto/relations.ts
@@ -20,14 +20,12 @@ export function hasRelationTarget(relation: RemoteRelation): relation is RemoteR
 export function RelationDtoLive(relation: RemoteRelationWithTarget): Relation {
   const ipfsUrlPropertyHex = SystemIds.IMAGE_URL_PROPERTY.replace(/-/g, '');
   const webUrlPropertyHex = ContentIds.WEB_URL_PROPERTY.replace(/-/g, '');
-  // `|| null`, not `?? null`: a present-but-blank value must not shadow the fallback below.
+  // `||` so a blank value falls through to the Web URL below.
   const ipfsUrlValue = relation.toEntity.valuesList.find(v => v.propertyId === ipfsUrlPropertyHex)?.text || null;
   const baseRenderableType = v2_getRenderableEntityType(relation.toEntity.types);
 
-  // `Web URL` is the generic canonical-link property (sources, articles, …), so unlike `IPFS URL`
-  // it only counts as a media URL when the target is explicitly typed Image/Video — debate media
-  // published to object storage instead of IPFS carries its URL here. IPFS URL wins when both are
-  // present so pre-existing entities render byte-identically.
+  // `Web URL` is also a general canonical-link property, so it only counts as a media URL when the
+  // target is typed Image/Video. IPFS URL wins when both are present.
   const webUrlValue =
     baseRenderableType === 'IMAGE' || baseRenderableType === 'VIDEO'
       ? relation.toEntity.valuesList.find(v => v.propertyId === webUrlPropertyHex)?.text || null

--- a/apps/web/core/io/dto/relations.ts
+++ b/apps/web/core/io/dto/relations.ts
@@ -2,6 +2,7 @@ import { ContentIds, SystemIds } from '@geoprotocol/geo-sdk/lite';
 
 import { RemoteRelation } from '~/core/io/schema';
 import { Relation, RenderableEntityType } from '~/core/types';
+import { isDirectMediaUrl } from '~/core/utils/media-url';
 import { getSpaceRank } from '~/core/utils/space/space-ranking';
 
 /** A relation whose target entity resolved. Dangling relations (`toEntity: null`) are dropped upstream. */
@@ -28,7 +29,8 @@ export function RelationDtoLive(relation: RemoteRelationWithTarget): Relation {
   // target is typed Image/Video. IPFS URL wins when both are present.
   const webUrlValue =
     baseRenderableType === 'IMAGE' || baseRenderableType === 'VIDEO'
-      ? relation.toEntity.valuesList.find(v => v.propertyId === webUrlPropertyHex)?.text || null
+      ? (relation.toEntity.valuesList.find(v => v.propertyId === webUrlPropertyHex && isDirectMediaUrl(v.text))?.text ??
+        null)
       : null;
   const mediaEntityUrlValue = ipfsUrlValue ?? webUrlValue;
 

--- a/apps/web/core/io/dto/relations.ts
+++ b/apps/web/core/io/dto/relations.ts
@@ -1,4 +1,4 @@
-import { SystemIds } from '@geoprotocol/geo-sdk/lite';
+import { ContentIds, SystemIds } from '@geoprotocol/geo-sdk/lite';
 
 import { RemoteRelation } from '~/core/io/schema';
 import { Relation, RenderableEntityType } from '~/core/types';
@@ -19,10 +19,21 @@ export function hasRelationTarget(relation: RemoteRelation): relation is RemoteR
 
 export function RelationDtoLive(relation: RemoteRelationWithTarget): Relation {
   const ipfsUrlPropertyHex = SystemIds.IMAGE_URL_PROPERTY.replace(/-/g, '');
-  const mediaEntityUrlValue = relation.toEntity.valuesList.find(v => v.propertyId === ipfsUrlPropertyHex)?.text ?? null;
+  const webUrlPropertyHex = ContentIds.WEB_URL_PROPERTY.replace(/-/g, '');
+  const ipfsUrlValue = relation.toEntity.valuesList.find(v => v.propertyId === ipfsUrlPropertyHex)?.text ?? null;
   const baseRenderableType = v2_getRenderableEntityType(relation.toEntity.types);
 
-  const renderableType = mediaEntityUrlValue && baseRenderableType === 'RELATION' ? 'IMAGE' : baseRenderableType;
+  // `Web URL` is the generic canonical-link property (sources, articles, …), so unlike `IPFS URL`
+  // it only counts as a media URL when the target is explicitly typed Image/Video — debate media
+  // published to object storage instead of IPFS carries its URL here. IPFS URL wins when both are
+  // present so pre-existing entities render byte-identically.
+  const webUrlValue =
+    baseRenderableType === 'IMAGE' || baseRenderableType === 'VIDEO'
+      ? (relation.toEntity.valuesList.find(v => v.propertyId === webUrlPropertyHex)?.text ?? null)
+      : null;
+  const mediaEntityUrlValue = ipfsUrlValue ?? webUrlValue;
+
+  const renderableType = ipfsUrlValue && baseRenderableType === 'RELATION' ? 'IMAGE' : baseRenderableType;
 
   const toEntityId = relation.toEntity.id;
   const toEntityName = resolveToEntityName(relation);

--- a/apps/web/core/io/dto/relations.ts
+++ b/apps/web/core/io/dto/relations.ts
@@ -20,7 +20,8 @@ export function hasRelationTarget(relation: RemoteRelation): relation is RemoteR
 export function RelationDtoLive(relation: RemoteRelationWithTarget): Relation {
   const ipfsUrlPropertyHex = SystemIds.IMAGE_URL_PROPERTY.replace(/-/g, '');
   const webUrlPropertyHex = ContentIds.WEB_URL_PROPERTY.replace(/-/g, '');
-  const ipfsUrlValue = relation.toEntity.valuesList.find(v => v.propertyId === ipfsUrlPropertyHex)?.text ?? null;
+  // `|| null`, not `?? null`: a present-but-blank value must not shadow the fallback below.
+  const ipfsUrlValue = relation.toEntity.valuesList.find(v => v.propertyId === ipfsUrlPropertyHex)?.text || null;
   const baseRenderableType = v2_getRenderableEntityType(relation.toEntity.types);
 
   // `Web URL` is the generic canonical-link property (sources, articles, …), so unlike `IPFS URL`
@@ -29,7 +30,7 @@ export function RelationDtoLive(relation: RemoteRelationWithTarget): Relation {
   // present so pre-existing entities render byte-identically.
   const webUrlValue =
     baseRenderableType === 'IMAGE' || baseRenderableType === 'VIDEO'
-      ? (relation.toEntity.valuesList.find(v => v.propertyId === webUrlPropertyHex)?.text ?? null)
+      ? relation.toEntity.valuesList.find(v => v.propertyId === webUrlPropertyHex)?.text || null
       : null;
   const mediaEntityUrlValue = ipfsUrlValue ?? webUrlValue;
 

--- a/apps/web/core/utils/diff/diff.test.ts
+++ b/apps/web/core/utils/diff/diff.test.ts
@@ -2,7 +2,9 @@ import { ContentIds, SystemIds } from '@geoprotocol/geo-sdk/lite';
 
 import { describe, expect, it } from 'vitest';
 
-import { resolveMediaUrlSide } from './diff';
+import type { Entity } from '~/core/types';
+
+import { resolveImageUrlFromEntity, resolveMediaUrlSide } from './diff';
 
 // The same ids `diff.ts` matches on, straight from the SDK.
 const IPFS_URL_PROPERTY = SystemIds.IMAGE_URL_PROPERTY;
@@ -61,5 +63,34 @@ describe('resolveMediaUrlSide', () => {
     const values = [value('some-other-property', null, 'ipfs://bafyloose')];
 
     expect(resolveMediaUrlSide(values, 'after')).toBe('ipfs://bafyloose');
+  });
+});
+
+describe('resolveImageUrlFromEntity', () => {
+  const WEB_URL = 'https://chat.example/debates/1/media/artifacts/preview_image/content';
+  const entity = (...values: Array<{ propertyId: string; value: string }>) =>
+    ({ values: values.map(v => ({ value: v.value, property: { id: v.propertyId } })) }) as unknown as Entity;
+
+  it('reads an http(s) URL from the Web URL property', () => {
+    expect(resolveImageUrlFromEntity(entity({ propertyId: WEB_URL_PROPERTY, value: WEB_URL }))).toBe(WEB_URL);
+  });
+
+  // The relation diff gates on the relation type (Avatar/Cover), not on the target's entity type,
+  // so a target that is an ordinary page with a canonical link must not have it shown as an avatar.
+  it('ignores http(s) values on any other property', () => {
+    const page = entity({ propertyId: 'some-source-property', value: 'https://example.com/article' });
+    expect(resolveImageUrlFromEntity(page)).toBeNull();
+  });
+
+  it('prefers an ipfs:// value from any property', () => {
+    const both = entity(
+      { propertyId: WEB_URL_PROPERTY, value: WEB_URL },
+      { propertyId: 'loose', value: 'ipfs://bafyold' }
+    );
+    expect(resolveImageUrlFromEntity(both)).toBe('ipfs://bafyold');
+  });
+
+  it('returns null for a missing entity', () => {
+    expect(resolveImageUrlFromEntity(undefined)).toBeNull();
   });
 });

--- a/apps/web/core/utils/diff/diff.test.ts
+++ b/apps/web/core/utils/diff/diff.test.ts
@@ -17,9 +17,7 @@ const value = (propertyId: string, before: string | null, after: string | null) 
 });
 
 describe('resolveMediaUrlSide', () => {
-  // The reason each side is resolved on its own. A proposal that moves media off IPFS carries the
-  // removal and the addition together; reading both sides off whichever value matched first would
-  // take `after: null` from the IPFS entry and render the media as deleted.
+  // A proposal moving media off IPFS removes IPFS URL and adds Web URL in the same diff.
   it('shows the replacement when a proposal swaps IPFS URL for Web URL', () => {
     const values = [
       value(IPFS_URL_PROPERTY, 'ipfs://bafyold', null),
@@ -50,7 +48,7 @@ describe('resolveMediaUrlSide', () => {
     expect(resolveMediaUrlSide(values, 'after')).toBe('https://chat.example/after');
   });
 
-  // Image entities also carry width/height, which must never be mistaken for the media URL.
+  // Image entities also carry width/height values.
   it('ignores unrelated properties and reports no URL when none is present', () => {
     const values = [value('width', '1080', '1080'), value('height', '1640', '1640')];
 
@@ -75,8 +73,6 @@ describe('resolveImageUrlFromEntity', () => {
     expect(resolveImageUrlFromEntity(entity({ propertyId: WEB_URL_PROPERTY, value: WEB_URL }))).toBe(WEB_URL);
   });
 
-  // The relation diff gates on the relation type (Avatar/Cover), not on the target's entity type,
-  // so a target that is an ordinary page with a canonical link must not have it shown as an avatar.
   it('ignores http(s) values on any other property', () => {
     const page = entity({ propertyId: 'some-source-property', value: 'https://example.com/article' });
     expect(resolveImageUrlFromEntity(page)).toBeNull();

--- a/apps/web/core/utils/diff/diff.test.ts
+++ b/apps/web/core/utils/diff/diff.test.ts
@@ -1,0 +1,65 @@
+import { ContentIds, SystemIds } from '@geoprotocol/geo-sdk/lite';
+
+import { describe, expect, it } from 'vitest';
+
+import { resolveMediaUrlSide } from './diff';
+
+// The same ids `diff.ts` matches on, straight from the SDK.
+const IPFS_URL_PROPERTY = SystemIds.IMAGE_URL_PROPERTY;
+const WEB_URL_PROPERTY = ContentIds.WEB_URL_PROPERTY;
+
+const value = (propertyId: string, before: string | null, after: string | null) => ({
+  propertyId,
+  before,
+  after,
+});
+
+describe('resolveMediaUrlSide', () => {
+  // The reason each side is resolved on its own. A proposal that moves media off IPFS carries the
+  // removal and the addition together; reading both sides off whichever value matched first would
+  // take `after: null` from the IPFS entry and render the media as deleted.
+  it('shows the replacement when a proposal swaps IPFS URL for Web URL', () => {
+    const values = [
+      value(IPFS_URL_PROPERTY, 'ipfs://bafyold', null),
+      value(WEB_URL_PROPERTY, null, 'https://chat.example/debates/1/media/artifacts/final_video/content'),
+    ];
+
+    expect(resolveMediaUrlSide(values, 'before')).toBe('ipfs://bafyold');
+    expect(resolveMediaUrlSide(values, 'after')).toBe(
+      'https://chat.example/debates/1/media/artifacts/final_video/content'
+    );
+  });
+
+  it('prefers IPFS URL over Web URL on a side that has both', () => {
+    const values = [
+      value(IPFS_URL_PROPERTY, 'ipfs://bafybefore', 'ipfs://bafyafter'),
+      value(WEB_URL_PROPERTY, 'https://chat.example/before', 'https://chat.example/after'),
+    ];
+
+    expect(resolveMediaUrlSide(values, 'before')).toBe('ipfs://bafybefore');
+    expect(resolveMediaUrlSide(values, 'after')).toBe('ipfs://bafyafter');
+  });
+
+  // Debate media published after the move off IPFS only ever carries Web URL.
+  it('falls back to Web URL when there is no IPFS URL at all', () => {
+    const values = [value(WEB_URL_PROPERTY, null, 'https://chat.example/after')];
+
+    expect(resolveMediaUrlSide(values, 'before')).toBeNull();
+    expect(resolveMediaUrlSide(values, 'after')).toBe('https://chat.example/after');
+  });
+
+  // Image entities also carry width/height, which must never be mistaken for the media URL.
+  it('ignores unrelated properties and reports no URL when none is present', () => {
+    const values = [value('width', '1080', '1080'), value('height', '1640', '1640')];
+
+    expect(resolveMediaUrlSide(values, 'before')).toBeNull();
+    expect(resolveMediaUrlSide(values, 'after')).toBeNull();
+  });
+
+  // Legacy media blocks store the URI on an unlabelled value, matched by scheme.
+  it('finds an ipfs:// value that is not on a known media property', () => {
+    const values = [value('some-other-property', null, 'ipfs://bafyloose')];
+
+    expect(resolveMediaUrlSide(values, 'after')).toBe('ipfs://bafyloose');
+  });
+});

--- a/apps/web/core/utils/diff/diff.test.ts
+++ b/apps/web/core/utils/diff/diff.test.ts
@@ -48,6 +48,13 @@ describe('resolveMediaUrlSide', () => {
     expect(resolveMediaUrlSide(values, 'after')).toBe('https://chat.example/after');
   });
 
+  // `Web URL` is a general link property, so only loadable media schemes count.
+  it('ignores a Web URL value that is not a loadable media URL', () => {
+    const values = [value(WEB_URL_PROPERTY, null, 'mailto:someone@example.com')];
+
+    expect(resolveMediaUrlSide(values, 'after')).toBeNull();
+  });
+
   // Image entities also carry width/height values.
   it('ignores unrelated properties and reports no URL when none is present', () => {
     const values = [value('width', '1080', '1080'), value('height', '1640', '1640')];

--- a/apps/web/core/utils/diff/diff.ts
+++ b/apps/web/core/utils/diff/diff.ts
@@ -284,18 +284,20 @@ export async function postProcessDiffs(
   for (const entityId of mediaPropertyEntityIds) {
     const entity = entityMap.get(entityId);
     if (!entity) continue;
+    // `blockTypeEntities` covers every block type, text and data blocks included. Only image/video
+    // typed entities carry media: a text block that happens to have a `Web URL` value is not one,
+    // and reading its link as an image URL would render it as a broken picture in the diff.
+    let mediaType: 'image' | 'video' | null = null;
+    for (const rel of entity.relations) {
+      if (rel.typeId !== TYPES_PROPERTY) continue;
+      const typeId = rel.after?.toEntityId ?? rel.before?.toEntityId;
+      if (typeId === VIDEO_TYPE || typeId === VIDEO_BLOCK) mediaType = 'video';
+      else if ((typeId === IMAGE_TYPE || typeId === IMAGE_BLOCK) && mediaType === null) mediaType = 'image';
+    }
+    if (mediaType === null) continue;
     const before = resolveMediaUrlSide(entity.values, 'before');
     const after = resolveMediaUrlSide(entity.values, 'after');
     if (before || after) {
-      let mediaType: 'image' | 'video' = 'image';
-      for (const rel of entity.relations) {
-        if (rel.typeId === TYPES_PROPERTY) {
-          const typeId = rel.after?.toEntityId ?? rel.before?.toEntityId;
-          if (typeId === VIDEO_TYPE || typeId === VIDEO_BLOCK) {
-            mediaType = 'video';
-          }
-        }
-      }
       mediaPropertyEntityUrls.set(entityId, { before, after, mediaType });
     }
   }
@@ -1062,13 +1064,18 @@ export function resolveMediaUrlSide(
   );
 }
 
-function resolveImageUrlFromEntity(entity: Entity | undefined): string | null {
+/**
+ * The media URL of a fetched Avatar/Cover target, for the relation diff. Any `ipfs://` value counts
+ * (legacy), but an http(s) URL only from `Web URL`: the caller gates on the *relation* type, not the
+ * target's entity type, so a target that is an ordinary page with a canonical link must not have
+ * that link rendered as its avatar.
+ */
+export function resolveImageUrlFromEntity(entity: Entity | undefined): string | null {
   if (!entity) return null;
-  const imageValue =
-    entity.values.find(v => typeof v.value === 'string' && v.value.startsWith('ipfs://')) ??
-    entity.values.find(v => typeof v.value === 'string' && isDirectMediaUrl(v.value));
-
-  return typeof imageValue?.value === 'string' ? imageValue.value : null;
+  const ipfsValue = entity.values.find(v => typeof v.value === 'string' && v.value.startsWith('ipfs://'));
+  if (typeof ipfsValue?.value === 'string') return ipfsValue.value;
+  const webUrlValue = entity.values.find(v => v.property.id === WEB_URL_PROPERTY && isDirectMediaUrl(v.value));
+  return typeof webUrlValue?.value === 'string' ? webUrlValue.value : null;
 }
 
 function computeRelationChanges(

--- a/apps/web/core/utils/diff/diff.ts
+++ b/apps/web/core/utils/diff/diff.ts
@@ -284,9 +284,7 @@ export async function postProcessDiffs(
   for (const entityId of mediaPropertyEntityIds) {
     const entity = entityMap.get(entityId);
     if (!entity) continue;
-    // `blockTypeEntities` covers every block type, text and data blocks included. Only image/video
-    // typed entities carry media: a text block that happens to have a `Web URL` value is not one,
-    // and reading its link as an image URL would render it as a broken picture in the diff.
+    // `blockTypeEntities` includes text and data blocks; only image/video-typed entities carry media.
     let mediaType: 'image' | 'video' | null = null;
     for (const rel of entity.relations) {
       if (rel.typeId !== TYPES_PROPERTY) continue;
@@ -1040,15 +1038,9 @@ function isMediaRelationType(typeId: string): boolean {
 }
 
 /**
- * The media URL on one side of a diff, IPFS URL first and Web URL second.
- *
- * Each side is resolved independently, and that is the whole point. Picking one value entry and
- * reading both its sides breaks the proposal that moves an entity off IPFS: the IPFS value matches
- * first (it has a `before`), its `after` is null, and the diff renders the media as deleted even
- * though the same proposal added a Web URL. Resolving per side shows the real replacement.
- *
- * `IMAGE_URL_PROPERTY` stays preferred so image entities, which also carry width/height values,
- * don't resolve to one of those.
+ * The media URL on one side of a diff: IPFS URL, then Web URL, then any loose `ipfs://` value.
+ * Sides are resolved independently so a proposal that replaces IPFS URL with Web URL shows the
+ * new URL rather than a removal.
  */
 export function resolveMediaUrlSide(
   values: Array<{ propertyId: string; before: string | null; after: string | null }>,
@@ -1065,10 +1057,8 @@ export function resolveMediaUrlSide(
 }
 
 /**
- * The media URL of a fetched Avatar/Cover target, for the relation diff. Any `ipfs://` value counts
- * (legacy), but an http(s) URL only from `Web URL`: the caller gates on the *relation* type, not the
- * target's entity type, so a target that is an ordinary page with a canonical link must not have
- * that link rendered as its avatar.
+ * The media URL of a fetched Avatar/Cover target. Any `ipfs://` value counts; an http(s) URL is
+ * read only from `Web URL`, since the caller checks the relation type, not the target's type.
  */
 export function resolveImageUrlFromEntity(entity: Entity | undefined): string | null {
   if (!entity) return null;

--- a/apps/web/core/utils/diff/diff.ts
+++ b/apps/web/core/utils/diff/diff.ts
@@ -7,6 +7,7 @@ import { getBatchEntities, getEntityBacklinks } from '~/core/io/queries';
 import type { ApiEntityDiffShape } from '~/core/io/rest';
 import { RANKING_BLOCK_TYPE_ID } from '~/core/ranking-block-ids';
 import type { Entity, Relation, Value } from '~/core/types';
+import { isDirectMediaUrl } from '~/core/utils/media-url';
 
 import type {
   BlockChange,
@@ -39,6 +40,10 @@ const {
   SHOWN_COLUMNS,
   PROPERTIES,
 } = SystemIds;
+
+// Media entities published to object storage (e.g. debate videos/keyframes) carry their URL on
+// the canonical `Web URL` property instead of `IPFS URL`.
+const WEB_URL_PROPERTY = ContentIds.WEB_URL_PROPERTY;
 
 type ApiValueDiff = ApiEntityDiffShape['values'][number];
 type ApiRelationDiff = ApiEntityDiffShape['relations'][number];
@@ -282,6 +287,7 @@ export async function postProcessDiffs(
     // Prefer IMAGE_URL_PROPERTY — image entities also carry width/height values.
     const mediaValue =
       entity.values.find(v => v.propertyId === IMAGE_URL_PROPERTY && (v.after || v.before)) ??
+      entity.values.find(v => v.propertyId === WEB_URL_PROPERTY && (v.after || v.before)) ??
       entity.values.find(
         v => (v.after && v.after.startsWith('ipfs://')) || (v.before && v.before.startsWith('ipfs://'))
       );
@@ -865,6 +871,7 @@ export async function fromLocal(
   for (const diff of diffs) {
     const resolveMediaValue = () =>
       diff.values.find(v => v.propertyId === IMAGE_URL_PROPERTY && (v.after || v.before)) ??
+      diff.values.find(v => v.propertyId === WEB_URL_PROPERTY && (v.after || v.before)) ??
       diff.values.find(v => (v.after && v.after.startsWith('ipfs://')) || (v.before && v.before.startsWith('ipfs://')));
     if (imageEntityIds.has(diff.entityId)) {
       const ipfsValue = resolveMediaValue();
@@ -1039,9 +1046,11 @@ function isMediaRelationType(typeId: string): boolean {
 
 function resolveImageUrlFromEntity(entity: Entity | undefined): string | null {
   if (!entity) return null;
-  const imageValue = entity.values.find(v => typeof v.value === 'string' && v.value.startsWith('ipfs://'));
+  const imageValue =
+    entity.values.find(v => typeof v.value === 'string' && v.value.startsWith('ipfs://')) ??
+    entity.values.find(v => typeof v.value === 'string' && isDirectMediaUrl(v.value));
 
-  return imageValue?.value ?? null;
+  return typeof imageValue?.value === 'string' ? imageValue.value : null;
 }
 
 function computeRelationChanges(

--- a/apps/web/core/utils/diff/diff.ts
+++ b/apps/web/core/utils/diff/diff.ts
@@ -284,14 +284,9 @@ export async function postProcessDiffs(
   for (const entityId of mediaPropertyEntityIds) {
     const entity = entityMap.get(entityId);
     if (!entity) continue;
-    // Prefer IMAGE_URL_PROPERTY — image entities also carry width/height values.
-    const mediaValue =
-      entity.values.find(v => v.propertyId === IMAGE_URL_PROPERTY && (v.after || v.before)) ??
-      entity.values.find(v => v.propertyId === WEB_URL_PROPERTY && (v.after || v.before)) ??
-      entity.values.find(
-        v => (v.after && v.after.startsWith('ipfs://')) || (v.before && v.before.startsWith('ipfs://'))
-      );
-    if (mediaValue) {
+    const before = resolveMediaUrlSide(entity.values, 'before');
+    const after = resolveMediaUrlSide(entity.values, 'after');
+    if (before || after) {
       let mediaType: 'image' | 'video' = 'image';
       for (const rel of entity.relations) {
         if (rel.typeId === TYPES_PROPERTY) {
@@ -301,7 +296,7 @@ export async function postProcessDiffs(
           }
         }
       }
-      mediaPropertyEntityUrls.set(entityId, { before: mediaValue.before, after: mediaValue.after, mediaType });
+      mediaPropertyEntityUrls.set(entityId, { before, after, mediaType });
     }
   }
 
@@ -869,19 +864,17 @@ export async function fromLocal(
   const imageEntityUrls = new Map<string, MediaSides>();
   const videoEntityUrls = new Map<string, MediaSides>();
   for (const diff of diffs) {
-    const resolveMediaValue = () =>
-      diff.values.find(v => v.propertyId === IMAGE_URL_PROPERTY && (v.after || v.before)) ??
-      diff.values.find(v => v.propertyId === WEB_URL_PROPERTY && (v.after || v.before)) ??
-      diff.values.find(v => (v.after && v.after.startsWith('ipfs://')) || (v.before && v.before.startsWith('ipfs://')));
+    const sides = () => ({
+      before: resolveMediaUrlSide(diff.values, 'before'),
+      after: resolveMediaUrlSide(diff.values, 'after'),
+    });
     if (imageEntityIds.has(diff.entityId)) {
-      const ipfsValue = resolveMediaValue();
-      if (ipfsValue)
-        imageEntityUrls.set(diff.entityId, { before: ipfsValue.before ?? null, after: ipfsValue.after ?? null });
+      const media = sides();
+      if (media.before || media.after) imageEntityUrls.set(diff.entityId, media);
     }
     if (videoEntityIds.has(diff.entityId)) {
-      const ipfsValue = resolveMediaValue();
-      if (ipfsValue)
-        videoEntityUrls.set(diff.entityId, { before: ipfsValue.before ?? null, after: ipfsValue.after ?? null });
+      const media = sides();
+      if (media.before || media.after) videoEntityUrls.set(diff.entityId, media);
     }
   }
   // Fall back to remote entity for media entities with no local changes.
@@ -1042,6 +1035,31 @@ function computeValueChanges(localValues: Value[], remoteEntity: Entity | undefi
 
 function isMediaRelationType(typeId: string): boolean {
   return typeId === ContentIds.AVATAR_PROPERTY || typeId === COVER_PROPERTY;
+}
+
+/**
+ * The media URL on one side of a diff, IPFS URL first and Web URL second.
+ *
+ * Each side is resolved independently, and that is the whole point. Picking one value entry and
+ * reading both its sides breaks the proposal that moves an entity off IPFS: the IPFS value matches
+ * first (it has a `before`), its `after` is null, and the diff renders the media as deleted even
+ * though the same proposal added a Web URL. Resolving per side shows the real replacement.
+ *
+ * `IMAGE_URL_PROPERTY` stays preferred so image entities, which also carry width/height values,
+ * don't resolve to one of those.
+ */
+export function resolveMediaUrlSide(
+  values: Array<{ propertyId: string; before: string | null; after: string | null }>,
+  side: 'before' | 'after'
+): string | null {
+  const pick = (predicate: (value: (typeof values)[number]) => boolean) =>
+    values.find(value => value[side] && predicate(value))?.[side] ?? null;
+
+  return (
+    pick(value => value.propertyId === IMAGE_URL_PROPERTY) ??
+    pick(value => value.propertyId === WEB_URL_PROPERTY) ??
+    pick(value => Boolean(value[side]?.startsWith('ipfs://')))
+  );
 }
 
 function resolveImageUrlFromEntity(entity: Entity | undefined): string | null {

--- a/apps/web/core/utils/diff/diff.ts
+++ b/apps/web/core/utils/diff/diff.ts
@@ -1051,7 +1051,7 @@ export function resolveMediaUrlSide(
 
   return (
     pick(value => value.propertyId === IMAGE_URL_PROPERTY) ??
-    pick(value => value.propertyId === WEB_URL_PROPERTY) ??
+    pick(value => value.propertyId === WEB_URL_PROPERTY && isDirectMediaUrl(value[side])) ??
     pick(value => Boolean(value[side]?.startsWith('ipfs://')))
   );
 }

--- a/apps/web/core/utils/media-url.ts
+++ b/apps/web/core/utils/media-url.ts
@@ -1,0 +1,8 @@
+/**
+ * A value that is already a browser-loadable media URL: an `ipfs://` URI (resolved through a
+ * gateway by `getImagePath`/`getVideoPath`) or a direct http(s) URL — e.g. debate media left in
+ * object storage and referenced via the `Web URL` property instead of being pinned to IPFS.
+ */
+export function isDirectMediaUrl(value: string | null | undefined): value is string {
+  return Boolean(value && (value.startsWith('ipfs://') || value.startsWith('http://') || value.startsWith('https://')));
+}

--- a/apps/web/core/utils/media-url.ts
+++ b/apps/web/core/utils/media-url.ts
@@ -1,8 +1,4 @@
-/**
- * A value that is already a browser-loadable media URL: an `ipfs://` URI (resolved through a
- * gateway by `getImagePath`/`getVideoPath`) or a direct http(s) URL — e.g. debate media left in
- * object storage and referenced via the `Web URL` property instead of being pinned to IPFS.
- */
+/** Whether a value is a loadable media URL: an `ipfs://` URI (resolved via gateway) or an http(s) URL. */
 export function isDirectMediaUrl(value: string | null | undefined): value is string {
   return Boolean(value && (value.startsWith('ipfs://') || value.startsWith('http://') || value.startsWith('https://')));
 }

--- a/apps/web/core/utils/use-entity-media.test.tsx
+++ b/apps/web/core/utils/use-entity-media.test.tsx
@@ -66,14 +66,10 @@ describe('findMediaUrlValue', () => {
     expect(findMediaUrlValue([value('width', '1080'), value(ContentIds.WEB_URL_PROPERTY, WEB_URL)])).toBe(WEB_URL);
   });
 
-  // The callers gate on the property being image-typed, never on the target entity. `Web URL` is
-  // also the canonical link on articles and sources, so any other http(s) value must be ignored or
-  // an Avatar relation pointed at an article would render its page URL as a broken image.
   it('ignores http(s) values on any other property', () => {
     expect(findMediaUrlValue([value('some-source-property', 'https://example.com/article')])).toBeUndefined();
   });
 
-  // Legacy media blocks keep the URI on an unlabelled value, and pinned media must keep winning.
   it('prefers an ipfs:// value from any property', () => {
     const values = [value(ContentIds.WEB_URL_PROPERTY, WEB_URL), value('unlabelled', 'ipfs://bafylegacy')];
     expect(findMediaUrlValue(values)).toBe('ipfs://bafylegacy');

--- a/apps/web/core/utils/use-entity-media.test.tsx
+++ b/apps/web/core/utils/use-entity-media.test.tsx
@@ -43,7 +43,7 @@ vi.mock('effect', () => ({
   },
 }));
 
-const { useEntityMedia } = await import('./use-entity-media');
+const { findMediaUrlValue, useEntityMedia } = await import('./use-entity-media');
 const { ContentIds } = await import('@geoprotocol/geo-sdk/lite');
 
 const wrapper = ({ children }: { children: React.ReactNode }) => (
@@ -56,6 +56,28 @@ beforeEach(() => {
   mocks.relationsByEntity = {};
   mocks.gates = new Map();
   mocks.failing = new Set();
+});
+
+describe('findMediaUrlValue', () => {
+  const WEB_URL = 'https://chat.example/debates/1/media/artifacts/final_video/content';
+  const value = (propertyId: string, value: string) => ({ value, property: { id: propertyId } });
+
+  it('reads an http(s) URL from the Web URL property', () => {
+    expect(findMediaUrlValue([value('width', '1080'), value(ContentIds.WEB_URL_PROPERTY, WEB_URL)])).toBe(WEB_URL);
+  });
+
+  // The callers gate on the property being image-typed, never on the target entity. `Web URL` is
+  // also the canonical link on articles and sources, so any other http(s) value must be ignored or
+  // an Avatar relation pointed at an article would render its page URL as a broken image.
+  it('ignores http(s) values on any other property', () => {
+    expect(findMediaUrlValue([value('some-source-property', 'https://example.com/article')])).toBeUndefined();
+  });
+
+  // Legacy media blocks keep the URI on an unlabelled value, and pinned media must keep winning.
+  it('prefers an ipfs:// value from any property', () => {
+    const values = [value(ContentIds.WEB_URL_PROPERTY, WEB_URL), value('unlabelled', 'ipfs://bafylegacy')];
+    expect(findMediaUrlValue(values)).toBe('ipfs://bafylegacy');
+  });
 });
 
 /** Holds every request for `entityId` until the returned function is called. */

--- a/apps/web/core/utils/use-entity-media.ts
+++ b/apps/web/core/utils/use-entity-media.ts
@@ -7,17 +7,30 @@ import * as React from 'react';
 
 import { Effect } from 'effect';
 
+import { ID } from '~/core/id';
 import { getRelationsByFromEntityId } from '~/core/io/queries';
 import { useRelation, useValues } from '~/core/sync/use-store';
 import { isDirectMediaUrl } from '~/core/utils/media-url';
 
-// ipfs:// stays preferred over http(s) so pre-existing IPFS-pinned media resolves exactly as
-// before; http(s) covers media left in object storage and referenced via `Web URL`.
-function findMediaUrlValue(values: { value: unknown }[]): string | undefined {
+/**
+ * The media URL among an image/video entity's values.
+ *
+ * `ipfs://` is accepted from any value, and preferred: legacy media blocks keep the URI on an
+ * unlabelled value, and pre-existing pinned media must resolve exactly as before. An http(s) URL
+ * is accepted only from `Web URL` — media left in object storage is published there — because
+ * `Web URL` is also the general-purpose canonical-link property, and the callers of this helper
+ * gate on the *property* being image-typed, never on the target entity. Scanning every value
+ * would turn an article's source link into a broken image the moment someone pointed an Avatar
+ * relation at it.
+ */
+export function findMediaUrlValue(values: { value: unknown; property: { id: string } }[]): string | undefined {
   const ipfsValue = values.find(v => typeof v.value === 'string' && v.value.startsWith('ipfs://'));
   if (typeof ipfsValue?.value === 'string') return ipfsValue.value;
-  const directValue = values.find(v => typeof v.value === 'string' && isDirectMediaUrl(v.value));
-  return typeof directValue?.value === 'string' ? directValue.value : undefined;
+  const webUrlValue = values.find(
+    v =>
+      ID.equals(v.property.id, ContentIds.WEB_URL_PROPERTY) && typeof v.value === 'string' && isDirectMediaUrl(v.value)
+  );
+  return typeof webUrlValue?.value === 'string' ? webUrlValue.value : undefined;
 }
 
 export function useImageUrlFromEntity(imageEntityId: string | undefined, spaceId: string): string | undefined {

--- a/apps/web/core/utils/use-entity-media.ts
+++ b/apps/web/core/utils/use-entity-media.ts
@@ -13,15 +13,9 @@ import { useRelation, useValues } from '~/core/sync/use-store';
 import { isDirectMediaUrl } from '~/core/utils/media-url';
 
 /**
- * The media URL among an image/video entity's values.
- *
- * `ipfs://` is accepted from any value, and preferred: legacy media blocks keep the URI on an
- * unlabelled value, and pre-existing pinned media must resolve exactly as before. An http(s) URL
- * is accepted only from `Web URL` — media left in object storage is published there — because
- * `Web URL` is also the general-purpose canonical-link property, and the callers of this helper
- * gate on the *property* being image-typed, never on the target entity. Scanning every value
- * would turn an article's source link into a broken image the moment someone pointed an Avatar
- * relation at it.
+ * The media URL among an image/video entity's values. An `ipfs://` value on any property wins
+ * (legacy media blocks keep it unlabelled); an http(s) URL is read only from `Web URL`, since that
+ * property is also a general canonical link and the callers do not check the target's entity type.
  */
 export function findMediaUrlValue(values: { value: unknown; property: { id: string } }[]): string | undefined {
   const ipfsValue = values.find(v => typeof v.value === 'string' && v.value.startsWith('ipfs://'));

--- a/apps/web/core/utils/use-entity-media.ts
+++ b/apps/web/core/utils/use-entity-media.ts
@@ -9,6 +9,16 @@ import { Effect } from 'effect';
 
 import { getRelationsByFromEntityId } from '~/core/io/queries';
 import { useRelation, useValues } from '~/core/sync/use-store';
+import { isDirectMediaUrl } from '~/core/utils/media-url';
+
+// ipfs:// stays preferred over http(s) so pre-existing IPFS-pinned media resolves exactly as
+// before; http(s) covers media left in object storage and referenced via `Web URL`.
+function findMediaUrlValue(values: { value: unknown }[]): string | undefined {
+  const ipfsValue = values.find(v => typeof v.value === 'string' && v.value.startsWith('ipfs://'));
+  if (typeof ipfsValue?.value === 'string') return ipfsValue.value;
+  const directValue = values.find(v => typeof v.value === 'string' && isDirectMediaUrl(v.value));
+  return typeof directValue?.value === 'string' ? directValue.value : undefined;
+}
 
 export function useImageUrlFromEntity(imageEntityId: string | undefined, spaceId: string): string | undefined {
   const imageValues = useValues({
@@ -17,9 +27,7 @@ export function useImageUrlFromEntity(imageEntityId: string | undefined, spaceId
 
   if (!imageEntityId || imageValues.length === 0) return undefined;
 
-  const imageUrlValue = imageValues.find(v => typeof v.value === 'string' && v.value.startsWith('ipfs://'));
-
-  return imageUrlValue?.value;
+  return findMediaUrlValue(imageValues);
 }
 
 export function useVideoUrlFromEntity(videoEntityId: string | undefined, spaceId: string): string | undefined {
@@ -29,9 +37,7 @@ export function useVideoUrlFromEntity(videoEntityId: string | undefined, spaceId
 
   if (!videoEntityId || videoValues.length === 0) return undefined;
 
-  const videoUrlValue = videoValues.find(v => typeof v.value === 'string' && v.value.startsWith('ipfs://'));
-
-  return videoUrlValue?.value;
+  return findMediaUrlValue(videoValues);
 }
 
 export function useEntityAvatarUrl(entityId: string | undefined, spaceId: string): string | undefined {
@@ -68,7 +74,7 @@ export function useEntityAvatarUrl(entityId: string | undefined, spaceId: string
         if (!avatarRelation) return;
 
         const imageUrl = avatarRelation.toEntity.value;
-        if (imageUrl && typeof imageUrl === 'string' && imageUrl.startsWith('ipfs://')) {
+        if (typeof imageUrl === 'string' && isDirectMediaUrl(imageUrl)) {
           setFetchedAvatarUrl(imageUrl);
         }
       } catch {
@@ -116,7 +122,7 @@ export function useEntityCoverUrl(entityId: string | undefined, spaceId: string)
         if (!coverRelation) return;
 
         const imageUrl = coverRelation.toEntity.value;
-        if (imageUrl && typeof imageUrl === 'string' && imageUrl.startsWith('ipfs://')) {
+        if (typeof imageUrl === 'string' && isDirectMediaUrl(imageUrl)) {
           setFetchedCoverUrl(imageUrl);
         }
       } catch {
@@ -254,5 +260,5 @@ export function useEntityMedia(
 }
 
 function asImageUrl(value: unknown): string | undefined {
-  return typeof value === 'string' && value.startsWith('ipfs://') ? value : undefined;
+  return typeof value === 'string' && isDirectMediaUrl(value) ? value : undefined;
 }


### PR DESCRIPTION
## Summary

Publishing a debate used to download the final video and keyframe from geo-chat's presigned R2 URLs and re-pin them to IPFS. Pinning made the media effectively permanent, which blocks user deletion, and it was the slow step that capped the publish sweep at two debates per run.

Publish now writes a durable geo-chat redirect URL under the **Web URL** property instead. The bytes stay in R2; deleting the artifact row makes the published URL 404, which is what unblocks deletion as a follow-up.

**Requires geo-chat #89 to be deployed first** — the URLs this publishes only resolve once that route is live.

## Publish side

- `debate-source.ts`: `pinArtifactToIpfs` / `pinKeyframeToIpfs` are gone; `durableArtifactUrl()` builds `{host}/debates/{id}/media/artifacts/{kind}/content`. No download, no re-upload — publishing gets substantially faster.
- `debate-publish-draft.ts`: Video and keyframe entities carry `Web URL`; Video keeps `Video URL` (ontology-spec). No `IPFS URL` is written for new debates.
- `publish-sweep`: `MAX_PUBLISH_ATTEMPTS_PER_SWEEP` 2 → 8, since the per-debate cost is now signing rather than pinning.

The media host is read only from `NEXT_PUBLIC_` variables, deliberately. `GEO_CHAT_API_BASE_URL` is the server-side host and is allowed to be cluster-internal; the sweep is a cron that runs server-side, so reading it would let a deploy with only that variable set publish healthy-looking URLs no browser can reach — permanently, since they are on-chain. `NEXT_PUBLIC_DEBATE_MEDIA_BASE_URL` is unset for now and falls through to the geo-chat host; it exists so moving media to a CDN or custom domain later is a DNS change rather than a migration of every published entity.

## Render side

Precedence is **IPFS URL first, Web URL second**, everywhere. Every already-published entity therefore renders byte-identically, and no migration or backfill is needed — new debates simply only carry Web URL, so the fallback is what fires for them.

`RelationDtoLive` is the choke point and covers most surfaces at once (entity-page video cells, keyframe posters, gallery/list thumbnails, table chips). `use-entity-media`, `use-video-keyframe-url`, `use-block-main-media-url`, `use-debate-keyframes` and the proposal diff each prefer `ipfs://` and fall back to a direct media URL via a shared `isDirectMediaUrl` helper.

**The important constraint:** `Web URL` is a general-purpose canonical link already used on source and article entities. It is only ever read as a *fallback* on an entity already known to be Image/Video-typed, and it never promotes a relation's renderable type. Reading it blankly would turn an ordinary entity's source link into a broken image. There is a test asserting a RELATION-typed target carrying only `Web URL` is not promoted.

## Worth a reviewer's attention

The durable URL resolves by `(debate_id, kind)`, so the URL is stable but the bytes behind it are **mutable across reprocessing**. Intended — it is what keeps a published URL live when media is reprocessed — but the content-addressed immutability IPFS gave us is gone by design.

This branch was rebased over ~170 commits of master. Two conflict resolutions are worth a look: `use-entity-media.ts`, where master refactored the ipfs filter into a new `asImageUrl()` and the Web URL fallback moved into it, and `debate-source.test.ts`, where the geo-chat mock signature changed on both sides.

## Out of scope

Deletion itself (this only enables it), and the social share video, which never touched IPFS.

## Testing

- 1449 vitest tests pass; `tsc --noEmit` clean apart from three pre-existing errors in files this branch does not touch (`sort-open-proposals.test`, `use-privy-sign-in.test`, `entity-response.test`).
- New `RelationDtoLive` test covering IPFS-wins-when-both-present, Web URL used on Image/Video targets, and no promotion of a RELATION-typed target.
- Staging end-to-end still to run: publish sweep produces a Video entity with `Web URL` + `Video URL` and no `IPFS URL`; video plays and seeks, poster and thumbnails render, proposal diff shows media, and a previously published IPFS debate renders unchanged.