### PR TITLE
feat(claims): clamp long descriptions on the custom claim page

### DIFF
--- a/apps/web/core/claims/browse/claim-page-view.test.tsx
+++ b/apps/web/core/claims/browse/claim-page-view.test.tsx
@@ -5,14 +5,25 @@ import type React from 'react';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { ENTITY_DESCRIPTION_MAX_LINES } from '~/partials/entity-page/entity-page-inline-description';
-
 import { ClaimPageView } from './claim-page-view';
 
 const mocks = vi.hoisted(() => ({
   entity: null as Record<string, unknown> | null,
   /** Props the description's clamp received, or null if it rendered no clamp at all. */
   clamp: null as Record<string, unknown> | null,
+  /**
+   * Deliberately not 3.
+   *
+   * Asserting against the real constant proves nothing: its value is 3, so a page that wrote
+   * `maxLines={3}` — the duplication the shared constant exists to prevent — would satisfy it just
+   * as well. Stubbing the module to a value the page could not have arrived at on its own is what
+   * makes the assertion about where the number came from rather than what it happens to be.
+   */
+  maxLines: 5,
+}));
+
+vi.mock('~/partials/entity-page/entity-page-inline-description', () => ({
+  ENTITY_DESCRIPTION_MAX_LINES: mocks.maxLines,
 }));
 
 // jsdom has no layout, so the real clamp can never measure an overflow. What this file is about is
@@ -103,11 +114,12 @@ describe('ClaimPageView description', () => {
   });
 
   // The number lives with the entity-page component and is imported here. Restating `3` on this
-  // surface is what would let the two cut at different points after a change to either.
-  it('uses the same line budget as entity pages and the side panel', () => {
+  // surface is what would let the two cut at different points after a change to either — so the
+  // module is stubbed to a different number, and the page has to follow it.
+  it('takes its line budget from the shared constant rather than restating it', () => {
     render(<ClaimPageView entityId="claim-1" spaceId="space-1" />);
 
-    expect(mocks.clamp?.maxLines).toBe(ENTITY_DESCRIPTION_MAX_LINES);
+    expect(mocks.clamp?.maxLines).toBe(mocks.maxLines);
   });
 
   it('renders no description block when the claim has none', () => {

--- a/apps/web/core/claims/browse/claim-page-view.test.tsx
+++ b/apps/web/core/claims/browse/claim-page-view.test.tsx
@@ -1,0 +1,119 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+
+import type React from 'react';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ENTITY_DESCRIPTION_MAX_LINES } from '~/partials/entity-page/entity-page-inline-description';
+
+import { ClaimPageView } from './claim-page-view';
+
+const mocks = vi.hoisted(() => ({
+  entity: null as Record<string, unknown> | null,
+  /** Props the description's clamp received, or null if it rendered no clamp at all. */
+  clamp: null as Record<string, unknown> | null,
+}));
+
+// jsdom has no layout, so the real clamp can never measure an overflow. What this file is about is
+// that the description is handed to it at all, and with the shared line budget — the measuring
+// itself belongs to `ClampedText`.
+vi.mock('~/design-system/clamped-text', () => ({
+  ClampedText: (props: Record<string, unknown>) => {
+    mocks.clamp = props;
+    return <p data-testid="clamped-description">{props.text as string}</p>;
+  },
+}));
+
+vi.mock('~/core/sync/use-store', () => ({
+  useQueryEntity: () => ({ entity: mocks.entity, isLoading: false }),
+}));
+
+vi.mock('~/core/debates/hooks', () => ({
+  useDebateClaims: () => ({ data: { claims: [] } }),
+}));
+
+vi.mock('./use-claim-response-state', () => ({
+  useClaimResponseState: () => ({
+    responseKind: 'stance',
+    summary: { isControversial: false },
+    claim: null,
+    positions: [],
+    readiness: { response_kind: 'stance' },
+    isResponseKindResolved: true,
+    isViewerResponseResolved: true,
+    responseBlockedReason: null,
+  }),
+}));
+
+// The page's modules each reach for the sync engine, geo-chat or Privy. None of them is what this
+// file is asserting, and the hero renders above all of them.
+vi.mock('~/core/debates/matchmaking/matchmaking-claim-card', () => ({
+  PositionRow: () => null,
+  useClaimPositionControl: () => ({
+    optimisticPositions: [],
+    viewerPosition: null,
+    respond: () => {},
+    canRespond: false,
+    actionTitle: () => undefined,
+    responseError: null,
+  }),
+}));
+vi.mock('~/core/hooks/use-privy-sign-in', () => ({ usePrivySignIn: () => () => {} }));
+vi.mock('~/core/debates/retire-confirmed-response-indexing', () => ({
+  useRetireConfirmedResponseIndexing: () => {},
+}));
+vi.mock('~/core/debates/backfill-readiness-for-held-position', () => ({
+  useBackfillReadinessForHeldPosition: () => {},
+}));
+vi.mock('./claim-verdict', () => ({ ClaimVerdict: () => null }));
+vi.mock('./claim-debates', () => ({ ClaimDebates: () => null }));
+vi.mock('./claim-provenance', () => ({ ClaimProvenance: () => null }));
+vi.mock('./claim-related-claims', () => ({ ClaimRelatedClaims: () => null }));
+vi.mock('./claim-end-slot', () => ({ ClaimEndSlot: () => null }));
+vi.mock('./claim-summary', () => ({ ControversialTag: () => null }));
+vi.mock('~/partials/comments/comments-section', () => ({ CommentSection: () => null }));
+
+function claimEntity(description: string | null) {
+  return {
+    id: 'claim-1',
+    name: 'Pineapple belongs on pizza',
+    description,
+    relations: [],
+    types: [],
+  };
+}
+
+beforeEach(() => {
+  mocks.entity = claimEntity('A description long enough that the page has something to collapse.');
+  mocks.clamp = null;
+});
+
+afterEach(cleanup);
+
+describe('ClaimPageView description', () => {
+  // GEO-2772. It used to be a plain paragraph, so a long description pushed the whole page down —
+  // worst in the side panel, which renders this same view at a much narrower width.
+  it('clamps the description instead of printing it in full', () => {
+    render(<ClaimPageView entityId="claim-1" spaceId="space-1" />);
+
+    expect(screen.getByTestId('clamped-description')).toHaveTextContent(
+      'A description long enough that the page has something to collapse.'
+    );
+  });
+
+  // The number lives with the entity-page component and is imported here. Restating `3` on this
+  // surface is what would let the two cut at different points after a change to either.
+  it('uses the same line budget as entity pages and the side panel', () => {
+    render(<ClaimPageView entityId="claim-1" spaceId="space-1" />);
+
+    expect(mocks.clamp?.maxLines).toBe(ENTITY_DESCRIPTION_MAX_LINES);
+  });
+
+  it('renders no description block when the claim has none', () => {
+    mocks.entity = claimEntity(null);
+    render(<ClaimPageView entityId="claim-1" spaceId="space-1" />);
+
+    expect(screen.queryByTestId('clamped-description')).toBeNull();
+  });
+});

--- a/apps/web/core/claims/browse/claim-page-view.tsx
+++ b/apps/web/core/claims/browse/claim-page-view.tsx
@@ -97,9 +97,13 @@ export function ClaimPageView({ entityId, spaceId }: { entityId: string; spaceId
             {entity.name ?? entity.id}
           </h1>
 
-          {/* Clamped, like entity pages and the side panel (GEO-2772). Line-based rather than a
-              character count, so the same description cuts at the same place whether this page is
-              the route, the side panel or a phone — three widths of one layout, per the note above.
+          {/* Clamped, like entity pages and the side panel (GEO-2772). What is shared is the line
+              budget, not the cut: wrapping differs with width, so the route, the side panel and a
+              phone — three widths of one layout, per the note above — break at different words.
+              They give up the same three lines of vertical space, which a character count could
+              not do; the same count spends a different number of lines at each width, which is the
+              measurement the reader actually feels.
+
               `ClampedText` measures an unclamped clone, so the toggle appears only when something
               is genuinely hidden, and it is unaffected by the naive-overflow bug GEO-2756 fixed in
               the feed's own title. */}

--- a/apps/web/core/claims/browse/claim-page-view.tsx
+++ b/apps/web/core/claims/browse/claim-page-view.tsx
@@ -15,11 +15,13 @@ import { useQueryEntity } from '~/core/sync/use-store';
 import type { Relation } from '~/core/types';
 import { NavUtils } from '~/core/utils/utils';
 
+import { ClampedText } from '~/design-system/clamped-text';
 import { PrefetchLink as Link } from '~/design-system/prefetch-link';
 import { Skeleton } from '~/design-system/skeleton';
 import { Text } from '~/design-system/text';
 
 import { CommentSection } from '~/partials/comments/comments-section';
+import { ENTITY_DESCRIPTION_MAX_LINES } from '~/partials/entity-page/entity-page-inline-description';
 
 import { ClaimDebates } from './claim-debates';
 import { ClaimEndSlot } from './claim-end-slot';
@@ -95,10 +97,19 @@ export function ClaimPageView({ entityId, spaceId }: { entityId: string; spaceId
             {entity.name ?? entity.id}
           </h1>
 
+          {/* Clamped, like entity pages and the side panel (GEO-2772). Line-based rather than a
+              character count, so the same description cuts at the same place whether this page is
+              the route, the side panel or a phone — three widths of one layout, per the note above.
+              `ClampedText` measures an unclamped clone, so the toggle appears only when something
+              is genuinely hidden, and it is unaffected by the naive-overflow bug GEO-2756 fixed in
+              the feed's own title. */}
           {entity.description && (
-            <Text as="p" variant="body" color="grey-04">
-              {entity.description}
-            </Text>
+            <ClampedText
+              text={entity.description}
+              maxLines={ENTITY_DESCRIPTION_MAX_LINES}
+              variant="body"
+              textClassName="wrap-break-word text-grey-04"
+            />
           )}
 
           {/* What this is on the left, what it's about on the right. The two answer different

--- a/apps/web/partials/entity-page/entity-page-inline-description.tsx
+++ b/apps/web/partials/entity-page/entity-page-inline-description.tsx
@@ -9,7 +9,15 @@ import { useValue } from '~/core/sync/use-store';
 import { ClampedText } from '~/design-system/clamped-text';
 import { PageStringField } from '~/design-system/editable-fields/editable-fields';
 
-const MAX_LINES = 3;
+/**
+ * How many lines a description shows before it collapses behind More.
+ *
+ * Exported because the custom claim page clamps its own description with the same primitive
+ * rather than through this component (GEO-2772) — it has the entity in hand, renders no edit
+ * field, and carries its own colour and spacing. Sharing the number is what keeps the two
+ * surfaces cutting at the same place.
+ */
+export const ENTITY_DESCRIPTION_MAX_LINES = 3;
 
 export function EntityPageInlineDescription({
   entityId,
@@ -77,7 +85,12 @@ export function EntityPageInlineDescription({
 
   return (
     <div className="-mt-3 mb-5">
-      <ClampedText text={description} maxLines={MAX_LINES} variant="body" textClassName="wrap-break-word text-text" />
+      <ClampedText
+        text={description}
+        maxLines={ENTITY_DESCRIPTION_MAX_LINES}
+        variant="body"
+        textClassName="wrap-break-word text-text"
+      />
     </div>
   );
 }

--- a/apps/web/partials/entity-page/entity-page-inline-description.tsx
+++ b/apps/web/partials/entity-page/entity-page-inline-description.tsx
@@ -15,7 +15,8 @@ import { PageStringField } from '~/design-system/editable-fields/editable-fields
  * Exported because the custom claim page clamps its own description with the same primitive
  * rather than through this component (GEO-2772) — it has the entity in hand, renders no edit
  * field, and carries its own colour and spacing. Sharing the number is what keeps the two
- * surfaces cutting at the same place.
+ * surfaces spending the same amount of the page on a description before hiding the rest. Where
+ * each one breaks still depends on its own width, since that is where the wrapping happens.
  */
 export const ENTITY_DESCRIPTION_MAX_LINES = 3;
 


### PR DESCRIPTION
[GEO-2772](https://linear.app/geobrowser/issue/GEO-2772/custom-claim-ui-implement-more-less-for-long-descriptions)

The claim page printed its description as a plain paragraph while entity pages and the side panel clamped theirs to three lines behind a More toggle. A long description pushed the verdict, the position control and everything below it off the first screen — worst in the side panel, which renders this same view at a much narrower width.

```diff
-<Text as="p" variant="body" color="grey-04">
-  {entity.description}
-</Text>
+<ClampedText
+  text={entity.description}
+  maxLines={ENTITY_DESCRIPTION_MAX_LINES}
+  variant="body"
+  textClassName="wrap-break-word text-grey-04"
+/>
```

## What it reuses, and what it doesn't

The ticket says reuse GEO-2718's work rather than reimplement. The reusable piece is `ClampedText` — the primitive entity pages and the side panel both go through — not `EntityPageInlineDescription` itself. That component does its own `useValue` lookup for the description, renders the edit field, and carries `-mt-3 mb-5`; this page is a read view that already has the entity in hand, uses `grey-04`, and sits in a `gap-3` column.

What actually has to match between the surfaces is the **line budget**, so that is what's shared: `MAX_LINES` in the entity-page module becomes an exported `ENTITY_DESCRIPTION_MAX_LINES`, and this page imports it instead of writing a second `3`.

## On the GEO-2756 note in the ticket

Not inherited here, and the ticket's worry about a character threshold doesn't apply. `ClampedText` measures an unclamped clone of the element and compares heights with a 1px tolerance, so the toggle appears only when content is genuinely hidden. GEO-2756 was a *separate* implementation in the full-screen feed's claim title using `scrollHeight > clientHeight`; #2312 fixed that one and its commit body explicitly notes `ClampedText` was checked and left alone as already correct.

So no coordination is needed and this doesn't need to wait — GEO-2756 already landed anyway.

## Desktop, mobile and the panel

One change covers all three. `entity-page-body.tsx` routes the route view and the side panel through `ClaimPageView`, and the page is one column at every width with container queries, not viewport media queries — its own header comment calls the three "three widths of one layout".

## Testing

`claim-page-view.test.tsx` is new — nothing rendered this view before. Three cases: the description goes through the clamp; it uses the shared line budget rather than a local number; no description renders no block.

jsdom has no layout, so the real clamp can never measure an overflow — the mock stands in for it and the assertions are about the wiring. The measurement itself belongs to `ClampedText`, which is exercised on the two surfaces that already use it.

Verified by reverting to the plain paragraph: the first two cases fail, the third still passes.

`vitest run core/claims partials/entity-page design-system`: 134 passed. `tsc --noEmit`: 5 errors, all pre-existing on master in unrelated test files. eslint and prettier clean.

## Worth a look

**`TopicPageView` has the identical block** — `topic-page-view.tsx:135-139`, same plain `<Text as="p" variant="body" color="grey-04">`. It's the other custom entity view, so it has the same gap this ticket describes. Left alone since the ticket scopes to the claim UI, but it's the same two-line change if you want a sibling ticket.

Not verified in a browser. Worth a look at a genuinely long claim description in both the route and the side panel before this leaves draft.