### PR TITLE
perf(explore): find featured spaces in one query instead of a tree walk

### DIFF
--- a/apps/web/app/api/activity/feed/route.ts
+++ b/apps/web/app/api/activity/feed/route.ts
@@ -71,7 +71,7 @@ export async function GET(request: Request) {
       time,
       spaceFilterId: spaceId,
       cursor,
-      walletAddress: cookieWallet ?? null,
+      personalMemberSpaceId,
       memberOrEditorSpaceIds,
       // Activity: no type whitelist, but keep the name requirement so unnamed
       // entities (e.g. property system rows) don't clutter the feed.

--- a/apps/web/app/api/explore/feed/route.ts
+++ b/apps/web/app/api/explore/feed/route.ts
@@ -34,6 +34,38 @@ function parseTime(raw: string | null): ExploreTime {
   return 'all';
 }
 
+const EMPTY_BROWSE: BrowseSidebarData = {
+  featured: [],
+  editorOf: [],
+  memberOf: [],
+  documentationImage: null,
+  personalSpaceId: null,
+};
+
+/** The viewer's own spaces, degrading to just their personal space if governance is down. */
+async function resolveMemberOrEditorSpaceIds(personalMemberSpaceId: string | null): Promise<string[]> {
+  if (!personalMemberSpaceId) return [];
+  try {
+    const ctx = await getGovernanceHomeSpaceContext(personalMemberSpaceId);
+    return [...new Set([...ctx.editorIds, ...ctx.myProposalSpaceIds, personalMemberSpaceId])];
+  } catch {
+    return [personalMemberSpaceId];
+  }
+}
+
+/** Sidebar data, retried signed-out before giving up, so one bad member lookup isn't fatal. */
+async function resolveBrowseSidebarData(personalMemberSpaceId: string | null): Promise<BrowseSidebarData> {
+  try {
+    return await fetchBrowseSidebarData(personalMemberSpaceId);
+  } catch {
+    try {
+      return await fetchBrowseSidebarData(null);
+    } catch {
+      return EMPTY_BROWSE;
+    }
+  }
+}
+
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const sort = parseSort(searchParams.get('sort'));
@@ -48,37 +80,18 @@ export async function GET(request: Request) {
 
   const cookieWallet = (await cookies()).get(WALLET_ADDRESS)?.value;
 
-  let personalMemberSpaceId: string | null = null;
-  let memberOrEditorSpaceIds: string[] = [];
+  const personalMemberSpaceId = cookieWallet ? await resolveMemberSpaceFromWalletSafe(cookieWallet) : null;
 
-  if (cookieWallet) {
-    personalMemberSpaceId = await resolveMemberSpaceFromWalletSafe(cookieWallet);
-    if (personalMemberSpaceId) {
-      try {
-        const ctx = await getGovernanceHomeSpaceContext(personalMemberSpaceId);
-        memberOrEditorSpaceIds = [...new Set([...ctx.editorIds, ...ctx.myProposalSpaceIds, personalMemberSpaceId])];
-      } catch {
-        memberOrEditorSpaceIds = [personalMemberSpaceId];
-      }
-    }
-  }
-
-  let browse: BrowseSidebarData;
-  try {
-    browse = await fetchBrowseSidebarData(personalMemberSpaceId);
-  } catch {
-    try {
-      browse = await fetchBrowseSidebarData(null);
-    } catch {
-      browse = {
-        featured: [],
-        editorOf: [],
-        memberOf: [],
-        documentationImage: null,
-        personalSpaceId: null,
-      };
-    }
-  }
+  // Concurrent, because neither consumes the other's output: both need only
+  // `personalMemberSpaceId`, and `memberOrEditorSpaceIds` is handed to `fetchExploreFeed`
+  // separately from the sidebar data. Awaiting them one after the other spent a round trip
+  // on nothing. (They do overlap in what they ask for — both want the viewer's editor and
+  // member spaces — but that is deduped by the request-level memos on `fetchEditorSpaceIds`
+  // and `fetchMemberSpaces` rather than by ordering.)
+  const [memberOrEditorSpaceIds, browse] = await Promise.all([
+    resolveMemberOrEditorSpaceIds(personalMemberSpaceId),
+    resolveBrowseSidebarData(personalMemberSpaceId),
+  ]);
 
   let spaceFilter: string | null = null;
   if (spaceId && spaceId !== 'all') {
@@ -94,7 +107,7 @@ export async function GET(request: Request) {
       time,
       spaceFilterId: spaceFilter,
       cursor,
-      walletAddress: cookieWallet ?? null,
+      personalMemberSpaceId,
       memberOrEditorSpaceIds,
       typeIds,
       requireName: true,

--- a/apps/web/app/home/governance-home-space-ids.ts
+++ b/apps/web/app/home/governance-home-space-ids.ts
@@ -2,10 +2,8 @@ import { IdUtils } from '@geoprotocol/geo-sdk/lite';
 
 import { cache } from 'react';
 
-import * as Effect from 'effect/Effect';
-
-import { getSpacesWhereMember } from '~/core/io/queries';
 import { fetchEditorSpaceIds } from '~/core/io/subgraph/fetch-editor-space-ids';
+import { fetchMemberSpaces } from '~/core/io/subgraph/fetch-member-spaces';
 
 const EMPTY_CONTEXT = { editorIds: [] as string[], myProposalSpaceIds: [] as string[] };
 
@@ -30,7 +28,7 @@ export const getGovernanceHomeSpaceContext = cache(async (memberSpaceId: string)
 
   const [editorIds, memberSpaces] = await Promise.all([
     fetchEditorSpaceIds(memberSpaceId),
-    Effect.runPromise(getSpacesWhereMember(memberSpaceId)),
+    fetchMemberSpaces(memberSpaceId),
   ]);
 
   const memberIds = memberSpaces.map(s => s.id).filter(id => id !== memberSpaceId);

--- a/apps/web/core/browse/fetch-browse-sidebar-data.ts
+++ b/apps/web/core/browse/fetch-browse-sidebar-data.ts
@@ -3,10 +3,11 @@ import * as Either from 'effect/Either';
 
 import { DOCUMENTATION_SPACE_ID, PLACEHOLDER_SPACE_IMAGE } from '~/core/constants';
 import type { Space } from '~/core/io/dto/spaces';
-import { getSpaces, getSpacesWhereMember } from '~/core/io/queries';
+import { getSpaces } from '~/core/io/queries';
 import { AbortError } from '~/core/io/subgraph/errors';
 import { fetchEditorSpaceIds } from '~/core/io/subgraph/fetch-editor-space-ids';
 import { type FeaturedSpace, fetchFeaturedSpacesShared } from '~/core/io/subgraph/fetch-featured-spaces';
+import { fetchMemberSpaces } from '~/core/io/subgraph/fetch-member-spaces';
 import {
   fetchPendingEditorshipSpaceIds,
   fetchPendingMembershipSpaceIds,
@@ -94,7 +95,7 @@ async function fetchSpaceRows(
 async function fetchBrowseSidebarSources(memberSpaceId: string) {
   const [editorIds, memberSpaces, pendingMemberIds, pendingEditorIds] = await Promise.all([
     fetchEditorSpaceIds(memberSpaceId),
-    Effect.runPromise(getSpacesWhereMember(memberSpaceId)),
+    fetchMemberSpaces(memberSpaceId),
     fetchPendingMembershipSpaceIds(memberSpaceId).catch(() => [] as string[]),
     fetchPendingEditorshipSpaceIds(memberSpaceId).catch(() => [] as string[]),
   ]);

--- a/apps/web/core/explore/fetch-explore-feed.ts
+++ b/apps/web/core/explore/fetch-explore-feed.ts
@@ -6,7 +6,6 @@ import type { BrowseSidebarData } from '~/core/browse/fetch-browse-sidebar-data'
 import { SCORE_SYSTEM_PROPERTY } from '~/core/constants';
 import { EntitiesOrderBy, type EntityFilter } from '~/core/gql/graphql';
 import { graphql } from '~/core/io/graphql-client';
-import { fetchProfile } from '~/core/io/subgraph';
 import { fetchActiveMemberRequest } from '~/core/io/subgraph/fetch-proposed-members';
 
 import {
@@ -273,7 +272,19 @@ export async function fetchExploreFeed(args: {
   time: ExploreTime;
   spaceFilterId: string | null;
   cursor: string | null;
-  walletAddress?: string | null;
+  /**
+   * The viewer's personal space, already resolved and validated by the caller.
+   *
+   * Passed in rather than re-derived here. Both routes resolve it before they get this
+   * far, so looking it up again cost a second `fetchProfile` for the same wallet in a
+   * later sequential stage — and the value they hold is the better one: `fetchProfile`
+   * puts the *wallet address* in `spaceId` on all three of its failure paths, which
+   * passes a truthy check and then reaches a `UUID!` argument (see the note on
+   * `getGovernanceHomeSpaceContext`). `resolveMemberSpaceFromWallet` validates it and
+   * falls back to `getSpaceByAddress`, so pending-membership state stops being silently
+   * wrong for exactly the users whose profile lookup already failed.
+   */
+  personalMemberSpaceId?: string | null;
   memberOrEditorSpaceIds: string[];
   /** Restrict surfaced entities to these type IDs (via `filter.typeIds.overlaps`). Omit for no type filter. */
   typeIds?: readonly string[];
@@ -304,17 +315,13 @@ export async function fetchExploreFeed(args: {
       hasPendingMembershipRequest: false,
     }));
 
-    const wallet = args.walletAddress;
-    if (!wallet) return out;
+    const memberSpaceId = args.personalMemberSpaceId;
+    if (!memberSpaceId) return out;
 
     const pendingTargets = [...new Set(out.filter(o => !o.isMemberOrEditor).map(o => o.spaceId))];
     if (pendingTargets.length === 0) return out;
 
     try {
-      const profile = await Effect.runPromise(fetchProfile(wallet));
-      const memberSpaceId = profile?.spaceId;
-      if (!memberSpaceId) return out;
-
       const pendingMap = new Map<string, boolean>();
       await Promise.all(
         pendingTargets.map(async sid => {
@@ -335,7 +342,7 @@ export async function fetchExploreFeed(args: {
         }
       }
     } catch {
-      /* Profile / membership checks must not drop the whole feed when subgraph is flaky. */
+      /* Membership checks must not drop the whole feed when subgraph is flaky. */
     }
     return out;
   };

--- a/apps/web/core/explore/fetch-explore-side-panel-data.ts
+++ b/apps/web/core/explore/fetch-explore-side-panel-data.ts
@@ -6,7 +6,7 @@ import { resolveMemberSpaceFromWalletSafe } from '~/core/browse/resolve-member-s
 import { type ExploreCall, fetchCommunityCallsForExplore } from '~/core/community-calls/fetch-community-calls';
 import { WALLET_ADDRESS } from '~/core/cookie';
 import { type FeaturedRanking, fetchFeaturedRankings } from '~/core/io/subgraph/fetch-featured-rankings';
-import { type FeaturedSpace, fetchFeaturedSpaces } from '~/core/io/subgraph/fetch-featured-spaces';
+import { type FeaturedSpace, fetchFeaturedSpacesShared } from '~/core/io/subgraph/fetch-featured-spaces';
 import { fetchActiveMemberRequest } from '~/core/io/subgraph/fetch-proposed-members';
 import { mapWithConcurrency } from '~/core/utils/map-with-concurrency';
 import { normId } from '~/core/utils/norm-id';
@@ -40,8 +40,12 @@ export const fetchExploreSidePanelData = cache(
       }
     }
 
+    // Shared, not raw. `RootExploreSidePanelContainer` calls this with no options, so the
+    // fallback is the live path for the Root rail rather than a corner — and the raw fetch
+    // bypasses the TTL cache and the in-flight sharing entirely, making every Root request
+    // pay for the Featured list from scratch.
     const featuredSpacesPromise =
-      options.featuredSpacesPromise ?? fetchFeaturedSpaces().catch(() => [] as FeaturedSpace[]);
+      options.featuredSpacesPromise ?? fetchFeaturedSpacesShared().catch(() => [] as FeaturedSpace[]);
     const featuredRankingsPromise = fetchFeaturedRankings().catch(() => [] as FeaturedRanking[]);
     const communityCallsPromise = fetchCommunityCallsForExplore().catch(() => [] as ExploreCall[]);
     const governancePromise = memberSpaceId

--- a/apps/web/core/io/subgraph/fetch-featured-spaces.test.ts
+++ b/apps/web/core/io/subgraph/fetch-featured-spaces.test.ts
@@ -1,7 +1,7 @@
 import { Effect } from 'effect';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { FEATURED_TAG_ID, ROOT_SPACE, TAG_PROPERTY_ID } from '~/core/constants';
+import { FEATURED_TAG_ID, ROOT_SPACE, TAG_PROPERTY_ID, TOPIC_TYPE_ID } from '~/core/constants';
 
 import { clearFeaturedSpacesCache, fetchFeaturedSpaces, fetchFeaturedSpacesShared } from './fetch-featured-spaces';
 
@@ -17,7 +17,7 @@ vi.mock('./graphql', () => ({
   graphql: (...args: unknown[]) => graphqlMock(...args),
 }));
 
-// Curated rank ids (from space-ranking): Crypto=2, AI=3.
+// Curated rank ids (from space-ranking): Root=0, Crypto=2, AI=3.
 const AI_SPACE = '41e851610e13a19441c4d980f2f2ce6b';
 const CRYPTO_SPACE = 'c9f267dcb0d270718c2a3c45a64afd32';
 
@@ -25,223 +25,85 @@ function spaceNode(id: string, name: string) {
   return { id, page: { id: `page-${id}`, name, relationsList: [] }, members: { totalCount: 1 } };
 }
 
-function featuredTags(isFeatured = true, spaceId = ROOT_SPACE) {
-  return isFeatured ? [{ spaceId, toEntity: { id: FEATURED_TAG_ID } }] : [];
+/** One row of the Featured-tag relation list: the tagged topic and the spaces claiming it. */
+function taggedTopic(id: string, name: string, spaces: ReturnType<typeof spaceNode>[]) {
+  return { fromEntity: { id, name, spacesByTopicIdConnection: { nodes: spaces } } };
 }
 
 function query(arg: unknown): string {
   return (arg as { query?: string } | undefined)?.query ?? '';
 }
 
+function respondWith(relations: unknown[]) {
+  graphqlMock.mockImplementation(() => Effect.succeed({ relations }));
+}
+
 describe('fetchFeaturedSpaces', () => {
   beforeEach(() => graphqlMock.mockReset());
 
-  it('walks the subtopic tree, excludes the root topic, and orders by space rank', async () => {
-    // Tree: root t0 -> [t1 (AI space), t2 (no space) -> t3 (Crypto space)].
-    // BFS discovers AI before Crypto, but the result must be rank-sorted (Crypto 2, AI 3).
-    graphqlMock.mockImplementation((arg: unknown) => {
-      const q = query(arg);
-      if (q.includes('space(id:')) return Effect.succeed({ space: { topicId: 't0' } });
-      if (q.includes('"t3"')) {
-        return Effect.succeed({
-          entities: [
-            {
-              id: 't3',
-              name: 'Crypto',
-              spacesByTopicIdConnection: { totalCount: 1, nodes: [spaceNode(CRYPTO_SPACE, 'Crypto')] },
-              featuredTags: featuredTags(),
-              subtopics: [],
-            },
-          ],
-        });
-      }
-      if (q.includes('"t1"')) {
-        return Effect.succeed({
-          entities: [
-            {
-              id: 't1',
-              name: 'AI',
-              spacesByTopicIdConnection: { totalCount: 1, nodes: [spaceNode(AI_SPACE, 'AI')] },
-              featuredTags: featuredTags(),
-              subtopics: [],
-            },
-            {
-              id: 't2',
-              name: 'Science',
-              spacesByTopicIdConnection: { totalCount: 0, nodes: [] },
-              featuredTags: featuredTags(false),
-              subtopics: [{ toEntity: { id: 't3' } }],
-            },
-          ],
-        });
-      }
-      // Root topic frontier (t0): no space of its own, two children.
-      return Effect.succeed({
-        entities: [
-          {
-            id: 't0',
-            name: 'Geo',
-            spacesByTopicIdConnection: { totalCount: 0, nodes: [] },
-            featuredTags: featuredTags(false),
-            subtopics: [{ toEntity: { id: 't1' } }, { toEntity: { id: 't2' } }],
-          },
-        ],
-      });
-    });
+  it('asks only for Topic entities tagged Featured in Root, in a single request', async () => {
+    respondWith([taggedTopic('t1', 'AI', [spaceNode(AI_SPACE, 'AI')])]);
+
+    await fetchFeaturedSpaces();
+
+    // The whole point of the change: one round trip, not a tree walk.
+    expect(graphqlMock.mock.calls.length).toBe(1);
+
+    const q = query(graphqlMock.mock.calls[0][0]);
+    expect(q).toContain(TAG_PROPERTY_ID);
+    expect(q).toContain(FEATURED_TAG_ID);
+    expect(q).toContain(`spaceId: { is: "${ROOT_SPACE}" }`);
+    // Narrowing to Topic server-side is what keeps non-topic Featured things (rankings,
+    // for one) out of the pill list without a second pass here.
+    expect(q).toContain(TOPIC_TYPE_ID);
+  });
+
+  it('resolves each topic to its claiming space and orders by curated space rank', async () => {
+    // Returned AI-first to prove the ordering is rank-based, not response order.
+    respondWith([
+      taggedTopic('t1', 'AI', [spaceNode(AI_SPACE, 'AI')]),
+      taggedTopic('t2', 'Crypto', [spaceNode(CRYPTO_SPACE, 'Crypto')]),
+    ]);
 
     const result = await fetchFeaturedSpaces();
 
     expect(result.map(r => r.spaceId)).toEqual([CRYPTO_SPACE, AI_SPACE]);
     expect(result.map(r => r.name)).toEqual(['Crypto', 'AI']);
-    // Root topic ("Geo") is only a seed — never featured.
-    expect(result.some(r => r.name === 'Geo')).toBe(false);
-
-    const frontierQueries = graphqlMock.mock.calls
-      .map(([arg]) => query(arg))
-      .filter(q => q.includes('entities(filter:'));
-    expect(frontierQueries[0]).toContain(TAG_PROPERTY_ID);
-    expect(frontierQueries[0]).toContain(FEATURED_TAG_ID);
-    expect(frontierQueries[0]).toContain(`spaceId: { is: "${ROOT_SPACE}" }`);
+    expect(result.map(r => r.topicId)).toEqual(['t2', 't1']);
   });
 
-  it('dedupes a space that claims more than one topic', async () => {
-    graphqlMock.mockImplementation((arg: unknown) => {
-      const q = query(arg);
-      if (q.includes('space(id:')) return Effect.succeed({ space: { topicId: 't0' } });
-      if (q.includes('"t1"')) {
-        // Both children resolve to the same claiming space.
-        return Effect.succeed({
-          entities: [
-            {
-              id: 't1',
-              name: 'AI',
-              spacesByTopicIdConnection: { totalCount: 1, nodes: [spaceNode(AI_SPACE, 'AI')] },
-              featuredTags: featuredTags(),
-              subtopics: [],
-            },
-            {
-              id: 't2',
-              name: 'AI (alias)',
-              spacesByTopicIdConnection: { totalCount: 1, nodes: [spaceNode(AI_SPACE, 'AI')] },
-              featuredTags: featuredTags(),
-              subtopics: [],
-            },
-          ],
-        });
-      }
-      return Effect.succeed({
-        entities: [
-          {
-            id: 't0',
-            name: 'Geo',
-            spacesByTopicIdConnection: { totalCount: 0, nodes: [] },
-            featuredTags: featuredTags(false),
-            subtopics: [{ toEntity: { id: 't1' } }, { toEntity: { id: 't2' } }],
-          },
-        ],
-      });
-    });
+  it('dedupes a space that claims more than one featured topic', async () => {
+    respondWith([
+      taggedTopic('t1', 'AI', [spaceNode(AI_SPACE, 'AI')]),
+      taggedTopic('t2', 'AI (alias)', [spaceNode(AI_SPACE, 'AI')]),
+    ]);
 
-    const result = await fetchFeaturedSpaces();
-    expect(result.map(r => r.spaceId)).toEqual([AI_SPACE]);
+    expect((await fetchFeaturedSpaces()).map(r => r.spaceId)).toEqual([AI_SPACE]);
   });
 
-  it('skips untagged topics but still traverses them to find featured descendants', async () => {
-    const untaggedSpace = '11111111111111111111111111111111';
+  it('skips a tagged topic that no space claims', async () => {
+    respondWith([taggedTopic('t1', 'Unclaimed', []), taggedTopic('t2', 'AI', [spaceNode(AI_SPACE, 'AI')])]);
 
-    graphqlMock.mockImplementation((arg: unknown) => {
-      const q = query(arg);
-      if (q.includes('space(id:')) return Effect.succeed({ space: { topicId: 'root' } });
-      if (q.includes('"featured-child"')) {
-        return Effect.succeed({
-          entities: [
-            {
-              id: 'featured-child',
-              name: 'AI',
-              spacesByTopicIdConnection: { totalCount: 1, nodes: [spaceNode(AI_SPACE, 'AI')] },
-              featuredTags: featuredTags(),
-              subtopics: [],
-            },
-          ],
-        });
-      }
-      if (q.includes('"untagged-parent"')) {
-        return Effect.succeed({
-          entities: [
-            {
-              id: 'untagged-parent',
-              name: 'Unfeatured',
-              spacesByTopicIdConnection: { totalCount: 1, nodes: [spaceNode(untaggedSpace, 'Unfeatured')] },
-              featuredTags: featuredTags(false),
-              subtopics: [{ toEntity: { id: 'featured-child' } }],
-            },
-          ],
-        });
-      }
-      return Effect.succeed({
-        entities: [
-          {
-            id: 'root',
-            name: 'Geo',
-            spacesByTopicIdConnection: { totalCount: 0, nodes: [] },
-            featuredTags: featuredTags(false),
-            subtopics: [{ toEntity: { id: 'untagged-parent' } }],
-          },
-        ],
-      });
-    });
-
-    const result = await fetchFeaturedSpaces();
-
-    expect(result.map(r => r.spaceId)).toEqual([AI_SPACE]);
-    expect(result.some(r => r.spaceId === untaggedSpace)).toBe(false);
+    expect((await fetchFeaturedSpaces()).map(r => r.spaceId)).toEqual([AI_SPACE]);
   });
 
-  it('ignores a Featured tag attributed in a space other than Root', async () => {
-    graphqlMock.mockImplementation((arg: unknown) => {
-      const q = query(arg);
-      if (q.includes('space(id:')) return Effect.succeed({ space: { topicId: 'root' } });
-      if (q.includes('"topic"')) {
-        return Effect.succeed({
-          entities: [
-            {
-              id: 'topic',
-              name: 'AI',
-              spacesByTopicIdConnection: { totalCount: 1, nodes: [spaceNode(AI_SPACE, 'AI')] },
-              featuredTags: featuredTags(true, '11111111111111111111111111111111'),
-              subtopics: [],
-            },
-          ],
-        });
-      }
-      return Effect.succeed({
-        entities: [
-          {
-            id: 'root',
-            name: 'Geo',
-            spacesByTopicIdConnection: { totalCount: 0, nodes: [] },
-            featuredTags: featuredTags(false),
-            subtopics: [{ toEntity: { id: 'topic' } }],
-          },
-        ],
-      });
-    });
+  // Root is never offered in its own Join-spaces panel. It also outranks everything, so
+  // dropping it from the candidates rather than skipping the topic outright is what keeps
+  // a shared topic resolving to the space actually worth joining.
+  it('never features the Root space, and picks the next-ranked claimant instead', async () => {
+    respondWith([taggedTopic('t1', 'Geo', [spaceNode(ROOT_SPACE, 'Root'), spaceNode(AI_SPACE, 'AI')])]);
 
+    expect((await fetchFeaturedSpaces()).map(r => r.spaceId)).toEqual([AI_SPACE]);
+  });
+
+  it('returns [] when nothing is tagged Featured', async () => {
+    respondWith([]);
     expect(await fetchFeaturedSpaces()).toEqual([]);
   });
 
-  it('returns [] when the root space has no topic', async () => {
-    graphqlMock.mockImplementation(() => Effect.succeed({ space: { topicId: null } }));
-    expect(await fetchFeaturedSpaces()).toEqual([]);
-  });
-
-  it('throws when the root query fails, so a failure is not indistinguishable from no featured spaces', async () => {
+  it('throws when the query fails, so a failure is not indistinguishable from no featured spaces', async () => {
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
-    graphqlMock.mockImplementation((arg: unknown) => {
-      const q = query(arg);
-      if (q.includes('space(id:')) return Effect.fail({ _tag: 'GraphqlRuntimeError' });
-      return Effect.succeed({ entities: [] });
-    });
+    graphqlMock.mockImplementation(() => Effect.fail({ _tag: 'GraphqlRuntimeError' }));
 
     await expect(fetchFeaturedSpaces()).rejects.toThrow();
     consoleError.mockRestore();
@@ -249,35 +111,13 @@ describe('fetchFeaturedSpaces', () => {
 });
 
 /**
- * The traversal is the most expensive thing on the Explore path — five sequential round
- * trips over ~2,900 topic nodes in production — and `/api/explore/feed` ran it per
- * request. These cover the sharing, not the traversal, which the suite above owns.
+ * These cover the sharing, not the fetch, which the suite above owns. Much less
+ * load-bearing than when this list cost five sequential round trips, but the in-flight
+ * join still matters: `/api/explore/feed` runs per request and cannot hand its promise to
+ * the next one the way `app/explore/page.tsx` hands one to the sidebar.
  */
 describe('fetchFeaturedSpacesShared', () => {
-  const AI_ONLY = () => {
-    graphqlMock.mockImplementation((arg: unknown) => {
-      const q = query(arg);
-      if (q.includes('space(id:')) return Effect.succeed({ space: { topicId: 't0' } });
-      return Effect.succeed({
-        entities: [
-          {
-            id: 't0',
-            name: 'Root',
-            spacesByTopicIdConnection: { totalCount: 0, nodes: [] },
-            featuredTags: featuredTags(false),
-            subtopics: [{ toEntity: { id: 't1' } }],
-          },
-          {
-            id: 't1',
-            name: 'AI',
-            spacesByTopicIdConnection: { totalCount: 1, nodes: [spaceNode(AI_SPACE, 'AI')] },
-            featuredTags: featuredTags(),
-            subtopics: [],
-          },
-        ],
-      });
-    });
-  };
+  const AI_ONLY = () => respondWith([taggedTopic('t1', 'AI', [spaceNode(AI_SPACE, 'AI')])]);
 
   beforeEach(() => {
     graphqlMock.mockReset();
@@ -285,7 +125,7 @@ describe('fetchFeaturedSpacesShared', () => {
     vi.useRealTimers();
   });
 
-  it('walks the tree once and reuses the answer', async () => {
+  it('fetches once and reuses the answer', async () => {
     AI_ONLY();
 
     const first = await fetchFeaturedSpacesShared();
@@ -297,11 +137,7 @@ describe('fetchFeaturedSpacesShared', () => {
     expect(graphqlMock.mock.calls.length).toBe(callsAfterFirst);
   });
 
-  // The one that matters in production: `/api/explore/feed` cannot hand its promise to the
-  // next request the way `app/explore/page.tsx` hands one to the sidebar, so simultaneous
-  // Explore loads were each walking the whole topic tree. Callers arriving *before* the
-  // first traversal resolves must join it, not start their own.
-  it('makes concurrent callers join the traversal already running', async () => {
+  it('makes concurrent callers join the fetch already running', async () => {
     AI_ONLY();
 
     const [a, b, c] = await Promise.all([
@@ -309,14 +145,13 @@ describe('fetchFeaturedSpacesShared', () => {
       fetchFeaturedSpacesShared(),
       fetchFeaturedSpacesShared(),
     ]);
-    const rootQueries = graphqlMock.mock.calls.filter(call => query(call[0]).includes('space(id:')).length;
 
-    expect(rootQueries).toBe(1);
+    expect(graphqlMock.mock.calls.length).toBe(1);
     expect(a).toEqual(b);
     expect(b).toEqual(c);
   });
 
-  it('walks again once the list has gone stale', async () => {
+  it('fetches again once the list has gone stale', async () => {
     AI_ONLY();
 
     await fetchFeaturedSpacesShared();
@@ -328,7 +163,7 @@ describe('fetchFeaturedSpacesShared', () => {
     expect(graphqlMock.mock.calls.length).toBeGreaterThan(callsAfterFirst);
   });
 
-  // A transient GraphQL failure must cost one traversal, not five minutes of an empty
+  // A transient GraphQL failure must cost one request, not five minutes of an empty
   // Featured panel. `runQuery` re-throws cancellation on purpose, so the same applies to an
   // aborted caller: it must not leave its rejection behind for everyone else.
   it('does not keep a rejection', async () => {

--- a/apps/web/core/io/subgraph/fetch-featured-spaces.ts
+++ b/apps/web/core/io/subgraph/fetch-featured-spaces.ts
@@ -1,6 +1,6 @@
 import { Effect, Either } from 'effect';
 
-import { FEATURED_TAG_ID, ROOT_SPACE, SUBTOPIC_RELATION_TYPE_ID, TAG_PROPERTY_ID } from '~/core/constants';
+import { FEATURED_TAG_ID, ROOT_SPACE, TAG_PROPERTY_ID, TOPIC_TYPE_ID } from '~/core/constants';
 import { Environment } from '~/core/environment';
 import { getSpaceRank, getTopRankedSpaceId } from '~/core/utils/space/space-ranking';
 
@@ -14,21 +14,25 @@ import {
 } from './space-image';
 import { PLACEHOLDER_TOPIC_NAME } from './topic-space-usage';
 
-// Featured spaces are discovered by walking the Subtopic relation tree that
-// hangs off the Root space's topic entity, breadth-first. We start at the top
-// (Root's direct subtopics) and work down, so shallow — i.e. most prominent —
-// topics surface first. A topic becomes a pill only if it is tagged Featured in
-// the Root space and has at least one space claiming it; when several spaces
-// share a topic we feature the top-ranked one (see getTopRankedSpaceId).
+// Featured spaces are the Topic entities tagged Featured in the Root space, resolved to
+// the top-ranked space claiming each one (see getTopRankedSpaceId). A topic becomes a
+// pill only if a space claims it.
+//
+// This used to be discovered by walking the Subtopic tree hanging off the Root topic
+// breadth-first, checking every node for the tag. That walk was pure discovery overhead:
+// nothing downstream used tree position — the list is ordered by curated space rank, and
+// always was. Measured against testnet it cost five *sequential* round trips, 2.95s and
+// 276 KB to visit 3,038 nodes and find five spaces, all five of which were already found
+// by round three. It also never finished: MAX_NODES capped the walk at 2,500 nodes with
+// ~2,600 still queued, so a featured topic deep in the tree was simply invisible.
+//
+// The tag is an ordinary relation, so it can be asked for directly. One round trip,
+// ~0.33s, ~4.5 KB — at the measured floor for *any* request to the API, so there is
+// nothing further to win here by trimming fields. Optimise round trips, not selections.
 
-// How many entity ids we expand per round. Batching keeps the number of
-// sequential round-trips small while staying well under any query-size limit.
-const BATCH_SIZE = 200;
-
-// Hard ceilings so a pathological tree (the subtopic graph has cycles and
-// duplicate relations) can't balloon the SSR cost. Top-down BFS means the cap
-// trims the deepest, least-prominent topics first — exactly what we'd drop.
-const MAX_NODES = 2500;
+// Ceiling on the pill list. Also bounds the query: the Featured tag is applied to things
+// other than topics (rankings, for one), and the type filter below already narrows to
+// Topic, so this is a sanity bound rather than a working limit.
 const MAX_FEATURED = 60;
 
 export interface FeaturedSpace {
@@ -53,78 +57,61 @@ interface TopicNode {
   id: string;
   name: string | null;
   spacesByTopicIdConnection: {
-    totalCount: number;
     nodes: SpaceNode[];
   } | null;
-  featuredTags: Array<{ spaceId: string; toEntity: { id: string } | null }> | null;
-  subtopics: Array<{ toEntity: { id: string } | null }> | null;
 }
 
-interface RootResult {
-  space: { topicId: string | null } | null;
+interface FeaturedTopicsResult {
+  relations: Array<{ fromEntity: TopicNode | null }> | null;
 }
 
-interface FrontierResult {
-  entities: TopicNode[];
-}
-
-const ROOT_QUERY = `
+// Every Topic tagged Featured in Root, with the spaces claiming it and the page data the
+// pill renders from.
+//
+// The Topic type filter is enforced here rather than after the fact, and it is load
+// bearing: on testnet it takes the row count from 16 to 5 and the payload from 7.7 KB to
+// 4.5 KB, and leaves nothing for the caller to filter out.
+//
+// Written relations-first on purpose. The entities-first shape — asking `entities` for
+// Topic-typed rows carrying this relation — does not compile: `EntityToManyRelationFilter`
+// has no `typeId` field. It would also be the wrong shape anyway, starting from a scan of
+// every Topic rather than from the handful of indexed tag rows.
+const FEATURED_TOPICS_QUERY = `
   {
-    space(id: ${JSON.stringify(ROOT_SPACE)}) {
-      topicId
-    }
-  }
-`;
-
-// Resolve one frontier batch: each topic's claiming spaces (for pill data) and
-// its immediate subtopics (for the next frontier).
-function frontierQuery(ids: string[]): string {
-  return `
-  {
-    entities(filter: { id: { in: ${JSON.stringify(ids)} } }) {
-      id
-      name
-      spacesByTopicIdConnection(first: 20) {
-        totalCount
-        nodes {
-          id
-          page {
+    relations(filter: {
+      typeId: { is: ${JSON.stringify(TAG_PROPERTY_ID)} }
+      toEntityId: { is: ${JSON.stringify(FEATURED_TAG_ID)} }
+      spaceId: { is: ${JSON.stringify(ROOT_SPACE)} }
+      fromEntity: { typeIds: { overlaps: [${JSON.stringify(TOPIC_TYPE_ID)}] } }
+    }, first: ${MAX_FEATURED}) {
+      fromEntity {
+        id
+        name
+        spacesByTopicIdConnection(first: 20) {
+          nodes {
             id
-            name
-            relationsList(filter: { typeId: { in: [${JSON.stringify(AVATAR_PROPERTY_ID)}, ${JSON.stringify(COVER_PROPERTY_ID)}] } }) {
-              typeId
-              toEntity {
-                valuesList(filter: { propertyId: { is: ${JSON.stringify(IMAGE_URL_PROPERTY_ID)} } }) {
-                  propertyId
-                  text
+            page {
+              id
+              name
+              relationsList(filter: { typeId: { in: [${JSON.stringify(AVATAR_PROPERTY_ID)}, ${JSON.stringify(COVER_PROPERTY_ID)}] } }) {
+                typeId
+                toEntity {
+                  valuesList(filter: { propertyId: { is: ${JSON.stringify(IMAGE_URL_PROPERTY_ID)} } }) {
+                    propertyId
+                    text
+                  }
                 }
               }
             }
+            members {
+              totalCount
+            }
           }
-          members {
-            totalCount
-          }
-        }
-      }
-      featuredTags: relationsList(filter: {
-        typeId: { is: ${JSON.stringify(TAG_PROPERTY_ID)} }
-        toEntityId: { is: ${JSON.stringify(FEATURED_TAG_ID)} }
-        spaceId: { is: ${JSON.stringify(ROOT_SPACE)} }
-      }) {
-        spaceId
-        toEntity {
-          id
-        }
-      }
-      subtopics: relationsList(filter: { typeId: { is: ${JSON.stringify(SUBTOPIC_RELATION_TYPE_ID)} } }) {
-        toEntity {
-          id
         }
       }
     }
   }
 `;
-}
 
 function resolveTopicName(name: string | null | undefined): string {
   if (!name || !name.trim()) return PLACEHOLDER_TOPIC_NAME;
@@ -148,21 +135,20 @@ async function runQuery<T>(query: string): Promise<T | null> {
 
 /**
  * How long a resolved Featured list is reused. The set is curated — an editor tags a
- * topic Featured in the Root space — so it changes on human timescales, while the
- * traversal that discovers it is the most expensive thing on the Explore path.
+ * topic Featured in the Root space — so it changes on human timescales.
  *
- * The cost is a real measurement, not a guess: against production the traversal is five
- * *sequential* round trips that visit 2,941 topic nodes and transfer 274 KB to discover
- * four featured spaces, and `/api/explore/feed` — which runs it on every request — takes
- * 4.2-4.5 s end to end while the ranked feed query it exists to serve is ~300 ms of that.
+ * Much less load-bearing than it was. This existed because discovering the list cost five
+ * sequential round trips and `/api/explore/feed` ran it per request, which put Explore at
+ * 4.2-4.5 s end to end while the ranked feed query it exists to serve was ~300 ms of that.
+ * A cold miss now costs one round trip, so this is an ordinary "don't re-ask constantly"
+ * cache rather than the thing standing between Explore and a four-second load.
  */
 const FEATURED_SPACES_TTL_MS = 5 * 60 * 1000;
 
 let shared: Promise<FeaturedSpace[]> | null = null;
 // `null` means "still in flight". Kept distinct from a timestamp of 0 on purpose: while the
-// traversal is unresolved there is nothing to expire, and treating it as infinitely stale
-// sends every concurrent caller off to start a traversal of its own — which is the exact
-// pile-up this function exists to stop.
+// list is unresolved there is nothing to expire, and treating it as infinitely stale sends
+// every concurrent caller off to fetch its own — which is the pile-up this exists to stop.
 let resolvedAt: number | null = null;
 
 /** Exported for tests; no caller should need to reach for this. */
@@ -172,20 +158,18 @@ export function clearFeaturedSpacesCache(): void {
 }
 
 /**
- * {@link fetchFeaturedSpaces} with the traversal shared rather than repeated.
+ * {@link fetchFeaturedSpaces} with the fetch shared rather than repeated.
  *
- * Two distinct wins, and the second is the one that showed up in production. Within the
- * TTL a resolved list is reused outright; *before* it resolves, concurrent callers join
- * the one in-flight traversal instead of each starting their own. `/api/explore/feed`
- * runs per request with no way to share a promise the way `app/explore/page.tsx` does
- * with the sidebar, so every simultaneous Explore load was walking the whole topic tree
- * on its own.
+ * Within the TTL a resolved list is reused outright; *before* it resolves, concurrent
+ * callers join the one request in flight instead of each starting their own.
+ * `/api/explore/feed` runs per request with no way to share a promise the way
+ * `app/explore/page.tsx` does with the sidebar.
  *
- * A rejection is never cached, so a transient GraphQL failure costs one traversal rather
- * than five minutes of empty Featured panels. That includes the cancellation
- * `resolveFeaturedSpaces` deliberately re-throws: an aborted caller must not leave an
- * aborted promise behind for everyone else. Nothing here is per-request, so no signal is
- * threaded through and one caller going away cannot cancel the traversal for the rest.
+ * A rejection is never cached, so a transient GraphQL failure costs one request rather
+ * than five minutes of empty Featured panels. That includes the cancellation `runQuery`
+ * deliberately re-throws: an aborted caller must not leave an aborted promise behind for
+ * everyone else. Nothing here is per-request, so no signal is threaded through and one
+ * caller going away cannot cancel the fetch for the rest.
  */
 export function fetchFeaturedSpacesShared(): Promise<FeaturedSpace[]> {
   if (shared && (resolvedAt === null || Date.now() - resolvedAt < FEATURED_SPACES_TTL_MS)) return shared;
@@ -194,7 +178,7 @@ export function fetchFeaturedSpacesShared(): Promise<FeaturedSpace[]> {
   shared = started;
   resolvedAt = null;
   // Only start the clock once the answer exists. Timing from the *call* would let a slow
-  // traversal burn its own TTL and expire the moment it landed.
+  // fetch burn its own TTL and expire the moment it landed.
   started.then(
     () => {
       if (shared === started) resolvedAt = Date.now();
@@ -207,59 +191,26 @@ export function fetchFeaturedSpacesShared(): Promise<FeaturedSpace[]> {
 }
 
 /**
- * Builds the explore panel's "Join spaces" list by walking the Root space's
- * subtopic tree top-down and emitting one entry per topic tagged Featured in
- * the Root space that has a claiming space. The Root topic itself is used only
- * as the traversal seed — it is not featured. Untagged topics are still
- * traversed so featured descendants remain discoverable. Spaces are deduped (a
- * space can claim multiple topics). Traversal order is top-down only so the node
- * cap trims the deepest topics first; the returned list is ordered by space rank
- * (then name), not tree position.
+ * Builds the explore panel's "Join spaces" list: one entry per Topic tagged Featured in
+ * the Root space that has a claiming space, resolved to the top-ranked claimant. Spaces
+ * are deduped (a space can claim several featured topics). Ordered by curated space rank,
+ * then name.
  */
 export async function fetchFeaturedSpaces(): Promise<FeaturedSpace[]> {
-  const root = await runQuery<RootResult>(ROOT_QUERY);
-  // `runQuery` returns null only on a failed request (aborts already rethrew).
-  if (root === null) throw new Error('Failed to load featured spaces');
-  const rootTopicId = root.space?.topicId;
-  if (!rootTopicId) return [];
+  const result = await runQuery<FeaturedTopicsResult>(FEATURED_TOPICS_QUERY);
+  // `runQuery` returns null only on a failed request (aborts already rethrew). Throwing
+  // keeps a failure distinguishable from a genuinely empty Featured list, which is what
+  // lets `fetchFeaturedSpacesShared` decline to cache it.
+  if (result === null) throw new Error('Failed to load featured spaces');
 
-  // Seed the traversal with the Root topic's children so the Root topic (and
-  // therefore the Root space) is never featured in its own panel.
-  const visited = new Set<string>([rootTopicId]);
   const seenSpaceIds = new Set<string>();
   const featured: FeaturedSpace[] = [];
 
-  let frontier: string[] = [rootTopicId];
-
-  while (frontier.length > 0 && visited.size < MAX_NODES && featured.length < MAX_FEATURED) {
-    const batch = frontier.slice(0, BATCH_SIZE);
-    const overflow = frontier.slice(BATCH_SIZE);
-
-    const result = await runQuery<FrontierResult>(frontierQuery(batch));
-    const topics = result?.entities ?? [];
-
-    const nextFrontier: string[] = [];
-
-    for (const topic of topics) {
-      // Emit a pill if this topic is tagged Featured in Root and a space claims
-      // it. Skip the Root topic seed (it still comes back in round 1).
-      if (topic.id !== rootTopicId) {
-        addFeaturedFromTopic(topic, seenSpaceIds, featured);
-      }
-
-      for (const rel of topic.subtopics ?? []) {
-        const childId = rel.toEntity?.id;
-        if (!childId || visited.has(childId)) continue;
-        visited.add(childId);
-        nextFrontier.push(childId);
-      }
-    }
-
-    frontier = [...overflow, ...nextFrontier];
+  for (const relation of result.relations ?? []) {
+    if (relation.fromEntity) addFeaturedFromTopic(relation.fromEntity, seenSpaceIds, featured);
   }
 
-  // Display order is by curated space rank, then name — independent of where
-  // the space sat in the subtopic tree.
+  // Display order is by curated space rank, then name.
   featured.sort((a, b) => {
     const rankDelta = getSpaceRank(a.spaceId) - getSpaceRank(b.spaceId);
     if (rankDelta !== 0) return rankDelta;
@@ -270,12 +221,12 @@ export async function fetchFeaturedSpaces(): Promise<FeaturedSpace[]> {
 }
 
 function addFeaturedFromTopic(topic: TopicNode, seenSpaceIds: Set<string>, featured: FeaturedSpace[]): void {
-  const hasRootFeaturedTag = (topic.featuredTags ?? []).some(
-    relation => relation.spaceId === ROOT_SPACE && relation.toEntity?.id === FEATURED_TAG_ID
-  );
-  if (!hasRootFeaturedTag) return;
-
-  const spaceNodes = topic.spacesByTopicIdConnection?.nodes ?? [];
+  // Root is never offered in its own Join-spaces panel. The traversal got this for free by
+  // using the Root topic only as a seed and never emitting it; without a seed it has to be
+  // said outright. Dropping Root from the *candidates* rather than skipping the whole topic
+  // is the deliberate part: Root outranks everything (rank 0), so a topic claimed by both
+  // Root and a real space would otherwise resolve to Root and lose the space worth joining.
+  const spaceNodes = (topic.spacesByTopicIdConnection?.nodes ?? []).filter(s => s.id !== ROOT_SPACE);
   if (spaceNodes.length === 0) return;
 
   const topRankedId = getTopRankedSpaceId(spaceNodes.map(s => s.id));

--- a/apps/web/core/io/subgraph/fetch-member-spaces.ts
+++ b/apps/web/core/io/subgraph/fetch-member-spaces.ts
@@ -1,0 +1,27 @@
+import { cache } from 'react';
+
+import * as Effect from 'effect/Effect';
+
+import { getSpacesWhereMember } from '~/core/io/queries';
+
+/**
+ * The spaces a member space belongs to, memoized for the request.
+ *
+ * `getSpacesWhereMember` is an Effect — a description, not a promise — so memoizing the
+ * Effect itself would dedupe nothing: every `Effect.runPromise` would re-run it. The
+ * memo has to sit on the resolved promise, which is what this wrapper is for.
+ *
+ * Two callers ask for exactly this, one after the other, on every signed-in Explore
+ * request: `getGovernanceHomeSpaceContext` and `fetchBrowseSidebarSources`. They sit in
+ * different sequential stages, so the duplicate was serial latency rather than a
+ * concurrent double-fetch. It is not a cheap query to repeat — it pulls the whole
+ * `FullSpace` fragment (members list, editors list, topic, page) for every space the user
+ * belongs to, measured at ~0.5s and ~20 KB for a user in just three spaces, and it grows
+ * with the user's space count.
+ *
+ * Mirrors `fetchEditorSpaceIds`, which is memoized the same way and for the same reason —
+ * it is the other half of both call sites and was already deduped.
+ */
+export const fetchMemberSpaces = cache(async (memberSpaceId: string) =>
+  Effect.runPromise(getSpacesWhereMember(memberSpaceId))
+);


### PR DESCRIPTION
Closes [GEO-2777](https://linear.app/geobrowser/issue/GEO-2777/speed-up-explore-load-replace-the-featured-spaces-tree-walk-fix-the).

Explore spent most of its load time discovering **five featured spaces**. Three fixes, all measured against testnet — where the RTT floor is **0.36s** (`{ __typename }`, a query that does no work), so each is really a count of round trips.

## 1. Replace the tree walk with one query

`fetchFeaturedSpaces` walked the Subtopic tree off Root's topic entity, checking every node for a Featured tag. Measured live, round by round:

| Round | Time | Payload | Nodes visited | Featured found |
|---|---|---|---|---|
| 1 `ROOT_QUERY` | 0.41s | 0.1 KB | — | 0 |
| 2 | 0.37s | 1.1 KB | 16 | 0 |
| 3 | 0.47s | 20.8 KB | 212 | **5 — all of them** |
| 4 | 0.76s | 89.4 KB | 1,181 | 5 |
| 5 | 0.94s | 164.4 KB | 3,038 | 5 |
| **Total** | **2.95s** | **276 KB** | **3,038** | **5** |

Matches the production figure the function's own docstring already recorded (2,941 nodes, 274 KB).

Every featured space is found by round 3 — rounds 4 and 5 are 92% of the payload and discover nothing. The walk also never completed: `MAX_NODES` cut it off with ~2,600 nodes still queued, so a featured topic deep in the tree was simply invisible.

The walk was pure discovery overhead. Nothing downstream used tree position — the list is ordered by curated space rank, and always was. The Featured tag is an ordinary relation, so it can be asked for directly:

**1 round trip, 0.33s, 4.5 KB** — with names, member counts and images, and the **same five spaces** the traversal returns (verified by running both against testnet: Crypto, AI, Health, World affairs, US Politics).

Deletes `ROOT_QUERY`, `frontierQuery`, the frontier loop, `BATCH_SIZE`, `MAX_NODES`, the `visited` cycle guard.

Notes from testing, recorded so nobody re-derives them:
- Narrowing to `Topic` server-side is load-bearing — 16 rows to 5, 7.7 KB to 4.5 KB, nothing left to filter client-side.
- The entities-first shape doesn't compile: `EntityToManyRelationFilter` has no `typeId`.
- Field-trimming is pointless at the RTT floor; dropping the unused `totalCount` measured *slower*. Optimise round trips, not selections.

## 2. Root rail was bypassing the cache entirely

`RootExploreSidePanelContainer` calls `fetchExploreSidePanelData()` with no options, so it took the fallback — which used raw `fetchFeaturedSpaces()` instead of `fetchFeaturedSpacesShared()`, skipping both the TTL cache and the in-flight sharing. Every `/root` request paid full price. One identifier.

## 3. Two queries ran twice per signed-in feed request

| Stage | Calls |
|---|---|
| 1. `resolveMemberSpaceFromWalletSafe` | `fetchProfile(wallet)` |
| 2. `getGovernanceHomeSpaceContext` | `fetchEditorSpaceIds`, **`getSpacesWhereMember`** |
| 3. `fetchBrowseSidebarSources` | `fetchEditorSpaceIds` ✅ memoized, **`getSpacesWhereMember`** ← again |
| 4. `attachMeta` | **`fetchProfile(wallet)`** ← again |

`fetchEditorSpaceIds` was already memoized; the other two weren't, and sat in different sequential stages — serial extra latency, not a concurrent double-fetch. `getSpacesWhereMember` measured **0.52s / 20 KB** for a user in only *three* spaces (it pulls the whole `FullSpace` fragment per space, so it scales with the user's space count).

- New `fetchMemberSpaces`, memoized the way `fetchEditorSpaceIds` already is. It has to wrap the resolved promise: `getSpacesWhereMember` returns an Effect, and memoizing a description dedupes nothing.
- `attachMeta` now takes the caller's already-resolved `personalMemberSpaceId` instead of re-deriving it. `walletAddress` was left with no remaining use, so it's gone from the args.
- The route's last two stages are independent given `personalMemberSpaceId`, so they run concurrently.

**Also fixes a latent bug.** `attachMeta` did `const memberSpaceId = profile?.spaceId; if (!memberSpaceId) return out;` — the exact hazard documented on `getGovernanceHomeSpaceContext`. `fetchProfile` returns the *wallet address* in `spaceId` on all three of its failure paths; that passes a truthy check, then reaches a `UUID!` argument. Here it was swallowed by the inner `catch`, so pending-membership state was quietly wrong on every card for exactly the users whose profile lookup had already failed. `personalMemberSpaceId` is validated and falls back to `getSpaceByAddress`.

## Worth a look

- **Root is now excluded from claiming candidates, not just as a topic.** The traversal got "Root is never featured in its own panel" for free by using the Root topic only as a seed. Without a seed that has to be explicit. I drop Root from the *candidates* rather than skipping the whole topic, because Root outranks everything (rank 0) — so a topic claimed by both Root and a real space would otherwise resolve to Root and lose the space actually worth joining. No effect on today's data (none of the five topics is claimed by Root); flagging it because it's a deliberate judgment call, not a mechanical port.
- **This may surface topics that are invisible today.** `MAX_NODES` was already truncating, so a featured topic below the cutoff never appeared. Diffing old vs new on testnet gives an identical set, but production has a bigger tree — worth a look there before merge.
- **Root-space filter semantics.** I kept filtering on the *tag relation* living in Root (`relation.spaceId === ROOT_SPACE`), matching what `addFeaturedFromTopic` checked. If the intent was that the topic *entity* must be in Root, that's a different filter.

## Not done, deliberately

- **Narrowing the feed's `spaceIds` to featured spaces.** Measured and rejected: the ranked query is flat at 0.65–0.78s across 0/1/10/50/100/200 spaces and across page depth. Space scoping on `entitiesRankedForFeedConnection` is a function argument on the ranking index fast path (migration 0077), not a filter clause, so cost tracks `first`. It's ~7% of the request, and narrowing would drop users' own spaces' content for nothing.
- **A cross-instance shared cache.** Its value is cold-miss frequency × cold-miss cost; this PR cuts the cost term from 2.95s to 0.33s, collapsing the benefit ~89%.

## Testing

- Full `apps/web` suite green: **361 files, 3893 tests**, run twice.
- `fetch-featured-spaces.test.ts` rewritten for the single query — it asserted traversal mechanics that no longer exist. New coverage: one-round-trip assertion, the Topic/Featured/Root filter, rank ordering, dedupe, unclaimed topics, the Root-exclusion rule above, and the sharing/TTL behaviour carried over intact.
- Typecheck clean for every changed file (the repo has pre-existing errors in `partials/editor/*` and four unrelated test files; none are touched here).
- The generated query was smoke-tested against `api-testnet.geobrowser.io` and returns all five spaces with images and member counts.

## Caveat on the numbers

Measured from a laptop against testnet, where one RTT is ~0.35s. Server-side in-region the absolute savings shrink, but the 5 → 1 round-trip ratio holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
