### PR TITLE
feat(entity): show an entity's other tabs beside its custom claim or topic view

### DIFF
--- a/apps/web/core/claims/browse/claim-page-view.test.tsx
+++ b/apps/web/core/claims/browse/claim-page-view.test.tsx
@@ -78,12 +78,12 @@ vi.mock('~/core/debates/backfill-readiness-for-held-position', () => ({
   useBackfillReadinessForHeldPosition: () => {},
 }));
 vi.mock('./claim-verdict', () => ({ ClaimVerdict: () => null }));
-vi.mock('./claim-debates', () => ({ ClaimDebates: () => null }));
-vi.mock('./claim-provenance', () => ({ ClaimProvenance: () => null }));
+vi.mock('./claim-debates', () => ({ ClaimDebates: () => <div data-testid="claim-debates" /> }));
+vi.mock('./claim-provenance', () => ({ ClaimProvenance: () => <div data-testid="claim-provenance" /> }));
 vi.mock('./claim-related-claims', () => ({ ClaimRelatedClaims: () => null }));
 vi.mock('./claim-end-slot', () => ({ ClaimEndSlot: () => null }));
 vi.mock('./claim-summary', () => ({ ControversialTag: () => null }));
-vi.mock('~/partials/comments/comments-section', () => ({ CommentSection: () => null }));
+vi.mock('~/partials/comments/comments-section', () => ({ CommentSection: () => <div data-testid="claim-comments" /> }));
 
 function claimEntity(description: string | null) {
   return {
@@ -127,5 +127,44 @@ describe('ClaimPageView description', () => {
     render(<ClaimPageView entityId="claim-1" spaceId="space-1" />);
 
     expect(screen.queryByTestId('clamped-description')).toBeNull();
+  });
+});
+
+/**
+ * The bar sits under My position, not above the page: what is above it says which claim this is and
+ * lets you take a side, and that holds whichever tab is open (GEO-2779).
+ */
+describe('ClaimPageView tabs', () => {
+  const slot = (body: React.ReactNode | null) => ({ bar: <div data-testid="tab-bar" />, body });
+
+  const isBefore = (a: HTMLElement, b: HTMLElement) =>
+    Boolean(a.compareDocumentPosition(b) & Node.DOCUMENT_POSITION_FOLLOWING);
+
+  it('renders exactly as before when the entity has no other tabs', () => {
+    render(<ClaimPageView entityId="claim-1" spaceId="space-1" tabs={{ bar: null, body: null }} />);
+
+    expect(screen.queryByTestId('tab-bar')).not.toBeInTheDocument();
+    expect(screen.getByTestId('claim-debates')).toBeInTheDocument();
+    expect(screen.getByTestId('claim-comments')).toBeInTheDocument();
+  });
+
+  it('places the bar below My position and above the Overview content', () => {
+    render(<ClaimPageView entityId="claim-1" spaceId="space-1" tabs={slot(null)} />);
+
+    const bar = screen.getByTestId('tab-bar');
+    // The hero and taking a side both describe the claim, so they sit above the seam.
+    expect(isBefore(screen.getByTestId('clamped-description'), bar)).toBe(true);
+    expect(isBefore(screen.getByRole('region', { name: 'Your position' }), bar)).toBe(true);
+    expect(isBefore(bar, screen.getByTestId('claim-debates'))).toBe(true);
+  });
+
+  it("swaps the Overview content for the selected tab's blocks, keeping what is above the bar", () => {
+    render(<ClaimPageView entityId="claim-1" spaceId="space-1" tabs={slot(<div data-testid="tab-blocks" />)} />);
+
+    expect(screen.getByTestId('tab-blocks')).toBeInTheDocument();
+    expect(screen.getByTestId('clamped-description')).toBeInTheDocument();
+    for (const belowTheSeam of ['claim-debates', 'claim-provenance', 'claim-comments']) {
+      expect(screen.queryByTestId(belowTheSeam)).not.toBeInTheDocument();
+    }
   });
 });

--- a/apps/web/core/claims/browse/claim-page-view.tsx
+++ b/apps/web/core/claims/browse/claim-page-view.tsx
@@ -21,6 +21,7 @@ import { Skeleton } from '~/design-system/skeleton';
 import { Text } from '~/design-system/text';
 
 import { CommentSection } from '~/partials/comments/comments-section';
+import type { CustomViewTabsSlot } from '~/partials/entity-page/custom-view-tabs';
 import { ENTITY_DESCRIPTION_MAX_LINES } from '~/partials/entity-page/entity-page-inline-description';
 
 import { ClaimDebates } from './claim-debates';
@@ -50,7 +51,16 @@ const TOPIC_CHIP_CAP = 3;
  * never been debated, that carries no topics and was authored by hand shows its text, its space,
  * and the controls to act on it — and nothing else.
  */
-export function ClaimPageView({ entityId, spaceId }: { entityId: string; spaceId: string }) {
+export function ClaimPageView({
+  entityId,
+  spaceId,
+  tabs,
+}: {
+  entityId: string;
+  spaceId: string;
+  /** The entity's other tabs. Everything above the bar is shared across all of them. */
+  tabs?: CustomViewTabsSlot;
+}) {
   const { entity, isLoading } = useQueryEntity({ id: entityId, spaceId });
 
   // Hoisted so one lookup answers for the whole page. geo-chat's row and the graph's `Is factual`
@@ -156,17 +166,26 @@ export function ClaimPageView({ entityId, spaceId }: { entityId: string; spaceId
 
         <ClaimPositionSection entityId={entityId} spaceId={spaceId} state={state} row={row} />
 
-        <ClaimDebates claimId={entityId} spaceId={spaceId} responseKind={responseKind} />
+        {/* The seam. What sits above says which claim this is and lets you take a side on it, and
+            that holds whichever tab is open; what sits below is this claim's Overview content, and
+            is what another tab replaces. */}
+        {tabs?.bar}
 
-        <ClaimProvenance claimId={entityId} claimRelations={entity.relations} spaceId={spaceId} />
+        {tabs?.body ?? (
+          <>
+            <ClaimDebates claimId={entityId} spaceId={spaceId} responseKind={responseKind} />
 
-        <ClaimRelatedClaims claimId={entityId} spaceId={spaceId} topicIds={topicIds} />
+            <ClaimProvenance claimId={entityId} claimRelations={entity.relations} spaceId={spaceId} />
 
-        {/* Last, and in the same `page` variant a regular entity uses — the entity body renders it
-            this way for both the route and the side panel, and only the dedicated comments panel
-            asks for the `panel` variant. Unlike the modules above, this one always renders: an
-            empty thread is an invitation to start it, not an absence to hide. */}
-        <CommentSection entityId={entityId} spaceId={spaceId} />
+            <ClaimRelatedClaims claimId={entityId} spaceId={spaceId} topicIds={topicIds} />
+
+            {/* Last, and in the same `page` variant a regular entity uses — the entity body renders
+                it this way for both the route and the side panel, and only the dedicated comments
+                panel asks for the `panel` variant. Unlike the modules above, this one always
+                renders: an empty thread is an invitation to start it, not an absence to hide. */}
+            <CommentSection entityId={entityId} spaceId={spaceId} />
+          </>
+        )}
       </div>
     </div>
   );

--- a/apps/web/core/topics/browse/topic-page-view.test.tsx
+++ b/apps/web/core/topics/browse/topic-page-view.test.tsx
@@ -1,0 +1,76 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+
+import type React from 'react';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  entity: {
+    id: 'topic-1',
+    name: 'Renewable energy',
+    description: 'A topic description.',
+    relations: [],
+    types: [],
+  } as Record<string, unknown> | null,
+}));
+
+vi.mock('~/core/sync/use-store', () => ({
+  useQueryEntity: () => ({ entity: mocks.entity, isLoading: false }),
+}));
+
+vi.mock('./use-topic-ancestors', () => ({ useTopicAncestors: () => ({ ancestors: [], isLoading: false }) }));
+
+// The distribution strip is the last thing shared across tabs; everything after it is this topic's
+// own Overview content. Each is identified so its position relative to the bar is assertable.
+vi.mock('./topic-composition', () => ({ TopicComposition: () => <div data-testid="topic-composition" /> }));
+vi.mock('./topic-debates', () => ({ TopicDebates: () => <div data-testid="topic-debates" /> }));
+vi.mock('./topic-claims', () => ({ TopicClaims: () => <div data-testid="topic-claims" /> }));
+vi.mock('./topic-coverage', () => ({ TopicCoverage: () => <div data-testid="topic-coverage" /> }));
+vi.mock('~/partials/comments/comments-section', () => ({
+  CommentSection: () => <div data-testid="topic-comments" />,
+}));
+
+const { TopicPageView } = await import('./topic-page-view');
+
+const slot = (body: React.ReactNode | null) => ({ bar: <div data-testid="tab-bar" />, body });
+
+const isBefore = (a: HTMLElement, b: HTMLElement) =>
+  Boolean(a.compareDocumentPosition(b) & Node.DOCUMENT_POSITION_FOLLOWING);
+
+afterEach(cleanup);
+
+/**
+ * The bar sits under the distribution strip, not above the page: what is above it says which topic
+ * this is and how it is made up, and that holds whichever tab is open (GEO-2779).
+ */
+describe('TopicPageView tabs', () => {
+  it('renders exactly as before when the entity has no other tabs', () => {
+    render(<TopicPageView entityId="topic-1" spaceId="space-1" tabs={{ bar: null, body: null }} />);
+
+    expect(screen.queryByTestId('tab-bar')).not.toBeInTheDocument();
+    expect(screen.getByTestId('topic-composition')).toBeInTheDocument();
+    expect(screen.getByTestId('topic-debates')).toBeInTheDocument();
+    expect(screen.getByTestId('topic-comments')).toBeInTheDocument();
+  });
+
+  it('places the bar below the distribution strip and above the Overview content', () => {
+    render(<TopicPageView entityId="topic-1" spaceId="space-1" tabs={slot(null)} />);
+
+    const bar = screen.getByTestId('tab-bar');
+    expect(isBefore(screen.getByTestId('topic-composition'), bar)).toBe(true);
+    expect(isBefore(bar, screen.getByTestId('topic-debates'))).toBe(true);
+  });
+
+  it("swaps the Overview content for the selected tab's blocks, keeping what is above the bar", () => {
+    render(<TopicPageView entityId="topic-1" spaceId="space-1" tabs={slot(<div data-testid="tab-blocks" />)} />);
+
+    expect(screen.getByTestId('tab-blocks')).toBeInTheDocument();
+    // The name and the strip describe the topic, so they hold across tabs.
+    expect(screen.getByText('Renewable energy')).toBeInTheDocument();
+    expect(screen.getByTestId('topic-composition')).toBeInTheDocument();
+    for (const belowTheSeam of ['topic-debates', 'topic-claims', 'topic-coverage', 'topic-comments']) {
+      expect(screen.queryByTestId(belowTheSeam)).not.toBeInTheDocument();
+    }
+  });
+});

--- a/apps/web/core/topics/browse/topic-page-view.tsx
+++ b/apps/web/core/topics/browse/topic-page-view.tsx
@@ -15,6 +15,7 @@ import { Skeleton } from '~/design-system/skeleton';
 import { Text } from '~/design-system/text';
 
 import { CommentSection } from '~/partials/comments/comments-section';
+import type { CustomViewTabsSlot } from '~/partials/entity-page/custom-view-tabs';
 
 import { UNNAMED_SUBTOPIC_PROPERTY_ID } from '../ontology';
 import { TopicClaims } from './topic-claims';
@@ -47,7 +48,16 @@ const META_CHIP_CLASS = 'flex h-6 max-w-full items-center rounded border border-
  * Sections render only when they have something to show, and the order is fixed — the composition
  * strip carries the variation between topics instead, so every topic is structurally the same page.
  */
-export function TopicPageView({ entityId, spaceId }: { entityId: string; spaceId: string }) {
+export function TopicPageView({
+  entityId,
+  spaceId,
+  tabs,
+}: {
+  entityId: string;
+  spaceId: string;
+  /** The entity's other tabs. Everything above the bar is shared across all of them. */
+  tabs?: CustomViewTabsSlot;
+}) {
   const { entity, isLoading } = useQueryEntity({ id: entityId, spaceId });
 
   const subtopics = React.useMemo(() => {
@@ -128,7 +138,7 @@ export function TopicPageView({ entityId, spaceId }: { entityId: string; spaceId
               isn't either, so scaling this one down in the side panel would reintroduce exactly the
               mismatch it is here to remove. `text-pretty` stays — it governs where the line breaks,
               not how big it is. */}
-          <Text as="h1" variant="mainPage" color="text" className="block wrap-break-word text-pretty">
+          <Text as="h1" variant="mainPage" color="text" className="block text-pretty wrap-break-word">
             {entity.name ?? entity.id}
           </Text>
 
@@ -146,15 +156,24 @@ export function TopicPageView({ entityId, spaceId }: { entityId: string; spaceId
 
         <TopicComposition topicId={entityId} spaceId={spaceId} />
 
-        <TopicSubtopics subtopics={subtopics} spaceId={spaceId} />
+        {/* The seam. What sits above says which topic this is and how it is made up, and that holds
+            whichever tab is open; what sits below is this topic's Overview content, and is what
+            another tab replaces. */}
+        {tabs?.bar}
 
-        <TopicDebates topicId={entityId} spaceId={spaceId} />
+        {tabs?.body ?? (
+          <>
+            <TopicSubtopics subtopics={subtopics} spaceId={spaceId} />
 
-        <TopicClaims topicId={entityId} spaceId={spaceId} />
+            <TopicDebates topicId={entityId} spaceId={spaceId} />
 
-        <TopicCoverage topicId={entityId} spaceId={spaceId} />
+            <TopicClaims topicId={entityId} spaceId={spaceId} />
 
-        <CommentSection entityId={entityId} spaceId={spaceId} />
+            <TopicCoverage topicId={entityId} spaceId={spaceId} />
+
+            <CommentSection entityId={entityId} spaceId={spaceId} />
+          </>
+        )}
       </div>
     </div>
   );

--- a/apps/web/design-system/tab-group.test.tsx
+++ b/apps/web/design-system/tab-group.test.tsx
@@ -1,0 +1,100 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  pathname: '/space/space-1/entity-1',
+  activeTabId: null as string | null,
+}));
+
+vi.mock('next/navigation', () => ({ usePathname: () => mocks.pathname }));
+vi.mock('~/core/state/editable-store', () => ({ useEditable: () => ({ editable: false }) }));
+vi.mock('~/core/state/editor/editor-provider', () => ({ useActiveTabIdForEditor: () => mocks.activeTabId }));
+vi.mock('~/core/state/entity-side-panel-active-tab', () => ({ useEntitySidePanelActiveTab: () => null }));
+vi.mock('~/design-system/prefetch-link', () => ({
+  PrefetchLink: ({ children, prefetch: _prefetch, ...props }: React.ComponentProps<'a'> & { prefetch?: boolean }) => (
+    <a {...props}>{children}</a>
+  ),
+}));
+
+const { TabGroup } = await import('./tab-group');
+
+const OVERVIEW = '/space/space-1/entity-1';
+const SOURCES = '/space/space-1/entity-1?tabId=tab-sources';
+
+/**
+ * Unselected tabs are grey. Matched on that rather than on the selected colour, because the
+ * unselected class is `text-grey-04 hover:text-text` — it contains the selected colour too, so
+ * looking for `text-text` would match every tab.
+ */
+const isSelected = (name: string) => !screen.getByRole('link', { name }).className.includes('text-grey-04');
+
+function renderGroup(overviewActive?: boolean) {
+  render(
+    <TabGroup
+      tabs={[
+        { label: 'Overview', href: OVERVIEW, active: overviewActive },
+        { label: 'Sources', href: SOURCES },
+      ]}
+    />
+  );
+}
+
+beforeEach(() => {
+  mocks.activeTabId = null;
+});
+
+afterEach(cleanup);
+
+describe('TabGroup selection', () => {
+  it('selects the tab whose href matches the active one', () => {
+    renderGroup();
+
+    expect(isSelected('Overview')).toBe(true);
+    expect(isSelected('Sources')).toBe(false);
+  });
+
+  it('follows the active tab as it changes', () => {
+    mocks.activeTabId = 'tab-sources';
+    renderGroup();
+
+    expect(isSelected('Sources')).toBe(true);
+    expect(isSelected('Overview')).toBe(false);
+  });
+
+  /**
+   * The href comparison assumes the active tab is in the list. A surface that hides a tab while
+   * still answering for it — the custom claim and topic views, which drop the entity's own
+   * "Overview" — has to say which tab is selected, or nothing in the bar is.
+   */
+  it('leaves every tab unselected when the active one is not in the list', () => {
+    mocks.activeTabId = 'tab-not-listed';
+    renderGroup();
+
+    expect(isSelected('Overview')).toBe(false);
+    expect(isSelected('Sources')).toBe(false);
+  });
+
+  it('honours a caller that says which tab is selected', () => {
+    mocks.activeTabId = 'tab-not-listed';
+    renderGroup(true);
+
+    expect(isSelected('Overview')).toBe(true);
+    expect(isSelected('Sources')).toBe(false);
+  });
+
+  // The override is only an override: `false` still means not selected, even when the href matches.
+  it('lets a caller unselect a tab the comparison would have chosen', () => {
+    render(
+      <TabGroup
+        tabs={[
+          { label: 'Overview', href: OVERVIEW, active: false },
+          { label: 'Sources', href: SOURCES },
+        ]}
+      />
+    );
+
+    expect(isSelected('Overview')).toBe(false);
+  });
+});

--- a/apps/web/design-system/tab-group.tsx
+++ b/apps/web/design-system/tab-group.tsx
@@ -15,7 +15,22 @@ import { validateEntityId } from '~/core/utils/utils';
 import { PrefetchLink as Link } from '~/design-system/prefetch-link';
 
 interface TabGroupProps {
-  tabs: Array<{ href: string; label: string; badge?: string; disabled?: boolean; hidden?: boolean }>;
+  tabs: Array<{
+    href: string;
+    label: string;
+    badge?: string;
+    disabled?: boolean;
+    hidden?: boolean;
+    /**
+     * Overrides which tab reads as selected.
+     *
+     * Otherwise a tab is selected when its href matches the active one, which assumes the active
+     * tab is in this list. A surface that hides a tab while still showing its place — the custom
+     * claim and topic views, which drop the entity's own "Overview" and answer for it — has to say
+     * so, or a link to the hidden tab leaves every tab looking unselected.
+     */
+    active?: boolean;
+  }>;
   className?: string;
 }
 
@@ -137,6 +152,8 @@ interface TabProps {
   badge?: React.ReactNode;
   disabled?: boolean;
   hidden?: boolean;
+  /** See `TabGroupProps`. */
+  active?: boolean;
 }
 
 /** Shared with entity/space `TabGroup` and governance home tab rows (same underline behavior). */
@@ -166,7 +183,7 @@ function tabIdFromEntityTabHref(href: string): string | null {
   return validateEntityId(raw) ? raw : null;
 }
 
-function Tab({ href, label, badge, disabled, hidden }: TabProps) {
+function Tab({ href, label, badge, disabled, hidden, active: activeOverride }: TabProps) {
   const { editable } = useEditable();
 
   const path = usePathname();
@@ -174,11 +191,12 @@ function Tab({ href, label, badge, disabled, hidden }: TabProps) {
   const sidePanelTab = useEntitySidePanelActiveTab();
 
   const fullPath = activeTabId ? `${path}?tabId=${activeTabId}` : `${path}`;
-  const active = sidePanelTab
+  const derivedActive = sidePanelTab
     ? tabIdFromEntityTabHref(href) === null
       ? activeTabId === null
       : activeTabId === tabIdFromEntityTabHref(href)
     : href === fullPath;
+  const active = activeOverride ?? derivedActive;
 
   if (!editable && hidden) {
     return null;

--- a/apps/web/design-system/tab-group.tsx
+++ b/apps/web/design-system/tab-group.tsx
@@ -131,7 +131,15 @@ export function TabGroup({ tabs, className = '' }: TabGroupProps) {
       >
         <div className="relative flex w-max items-center gap-6 pb-2">
           {tabs.map(t => (
-            <Tab key={t.href} href={t.href} label={t.label} badge={t.badge} disabled={t.disabled} hidden={t.hidden} />
+            <Tab
+              key={t.href}
+              href={t.href}
+              label={t.label}
+              badge={t.badge}
+              disabled={t.disabled}
+              hidden={t.hidden}
+              active={t.active}
+            />
           ))}
         </div>
         <div className="sticky right-0 bottom-0 left-0 z-0 h-px bg-grey-02" />

--- a/apps/web/partials/entity-page/custom-view-tabs.test.tsx
+++ b/apps/web/partials/entity-page/custom-view-tabs.test.tsx
@@ -21,10 +21,10 @@ vi.mock('~/core/state/editor/editor-provider', () => ({
 
 // The tab bar and the editor are exercised elsewhere; here they only need to be identifiable.
 vi.mock('~/design-system/tab-group', () => ({
-  TabGroup: ({ tabs }: { tabs: Array<{ label: string; href: string }> }) => (
+  TabGroup: ({ tabs }: { tabs: Array<{ label: string; href: string; active?: boolean }> }) => (
     <nav data-testid="tab-group">
       {tabs.map(tab => (
-        <a key={tab.href} href={tab.href}>
+        <a key={tab.href} href={tab.href} data-active={tab.active === undefined ? 'derived' : String(tab.active)}>
           {tab.label}
         </a>
       ))}
@@ -100,6 +100,16 @@ describe('useCustomViewTabs', () => {
     expect(screen.queryByTestId('tab-blocks')).not.toBeInTheDocument();
   });
 
+  // With a real tab open, the href comparison is right and is left to decide.
+  it('leaves the selected tab to be matched by href', () => {
+    mocks.tabs = [{ id: 'tab-sources', name: 'Sources' }];
+    mocks.activeTabId = 'tab-sources';
+    render(<Harness />);
+
+    expect(screen.getByRole('link', { name: 'Overview' })).toHaveAttribute('data-active', 'false');
+    expect(screen.getByRole('link', { name: 'Sources' })).toHaveAttribute('data-active', 'derived');
+  });
+
   it("hands back the selected tab's blocks in place of the view's own content", () => {
     mocks.tabs = [{ id: 'tab-sources', name: 'Sources' }];
     mocks.activeTabId = 'tab-sources';
@@ -154,6 +164,25 @@ describe('useCustomViewTabs', () => {
 
       expect(screen.getByTestId('overview-content')).toBeInTheDocument();
       expect(screen.queryByTestId('tab-blocks')).not.toBeInTheDocument();
+    });
+
+    /**
+     * `TabGroup` decides which tab is selected by matching hrefs, which assumes the active tab is
+     * in the list. It is not here: the URL names a tab that was dropped, so without saying outright
+     * that Overview is the selected one, every tab in the bar reads as unselected.
+     *
+     * Reachable from a shared link, and from leaving edit mode while the entity's own Overview tab
+     * is open — the editable bar still links to it.
+     */
+    it('keeps Overview reading as selected when the link points at the suppressed tab', () => {
+      mocks.tabs = [
+        { id: 'tab-overview', name: 'Overview' },
+        { id: 'tab-sources', name: 'Sources' },
+      ];
+      mocks.activeTabId = 'tab-overview';
+      render(<Harness />);
+
+      expect(screen.getByRole('link', { name: 'Overview' })).toHaveAttribute('data-active', 'true');
     });
 
     it('offers no bar when the only other tab was the suppressed one', () => {

--- a/apps/web/partials/entity-page/custom-view-tabs.test.tsx
+++ b/apps/web/partials/entity-page/custom-view-tabs.test.tsx
@@ -19,7 +19,7 @@ vi.mock('~/core/state/editor/editor-provider', () => ({
   useActiveTabIdForEditor: () => mocks.activeTabId,
 }));
 
-// The tab bar and the editor are both exercised elsewhere; here they only need to be identifiable.
+// The tab bar and the editor are exercised elsewhere; here they only need to be identifiable.
 vi.mock('~/design-system/tab-group', () => ({
   TabGroup: ({ tabs }: { tabs: Array<{ label: string; href: string }> }) => (
     <nav data-testid="tab-group">
@@ -36,16 +36,25 @@ vi.mock('~/partials/editor/editor', () => ({
   Editor: () => <div data-testid="tab-blocks">tab blocks</div>,
 }));
 
-const { CustomViewTabs } = await import('./custom-view-tabs');
+const { useCustomViewTabs } = await import('./custom-view-tabs');
 
 const ENTITY = '07842862d2c3654c0324a07bc7cce1a4';
 const SPACE = 'a379046c74a140178e1c0545c72767c5';
 
-function view() {
-  return render(
-    <CustomViewTabs entityId={ENTITY} spaceId={SPACE} initialTabRelations={[]} tabEntities={[]}>
-      <div data-testid="custom-view">custom view</div>
-    </CustomViewTabs>
+/** Renders the slot the way a custom view does: the bar at its seam, the body under it. */
+function Harness() {
+  const { bar, body } = useCustomViewTabs({
+    entityId: ENTITY,
+    spaceId: SPACE,
+    initialTabRelations: [],
+    tabEntities: [],
+  });
+  return (
+    <div>
+      <div data-testid="shared-chrome">shared</div>
+      {bar}
+      {body ?? <div data-testid="overview-content">overview</div>}
+    </div>
   );
 }
 
@@ -58,14 +67,13 @@ beforeEach(() => {
 
 afterEach(cleanup);
 
-describe('CustomViewTabs', () => {
-  // A lone "Overview" tab is chrome that does nothing, which is what the generic page already
-  // decides for itself.
-  it('renders the custom view alone when the entity has no other tabs', () => {
-    view();
+describe('useCustomViewTabs', () => {
+  // A lone "Overview" is chrome that does nothing, which is what the generic page already decides.
+  it('offers no bar when the entity has no other tabs', () => {
+    render(<Harness />);
 
-    expect(screen.getByTestId('custom-view')).toBeInTheDocument();
     expect(screen.queryByTestId('tab-group')).not.toBeInTheDocument();
+    expect(screen.getByTestId('overview-content')).toBeInTheDocument();
   });
 
   it('puts the custom view first, as Overview, and the entity tabs after it in order', () => {
@@ -73,7 +81,7 @@ describe('CustomViewTabs', () => {
       { id: 'tab-sources', name: 'Sources' },
       { id: 'tab-timeline', name: 'Timeline' },
     ];
-    view();
+    render(<Harness />);
 
     expect(tabLabels()).toEqual(['Overview', 'Sources', 'Timeline']);
     // Overview is where the page lands, so it carries no tab parameter.
@@ -84,31 +92,39 @@ describe('CustomViewTabs', () => {
     );
   });
 
-  it('shows the custom view on the Overview tab', () => {
+  it('leaves the view its own content on the Overview tab', () => {
     mocks.tabs = [{ id: 'tab-sources', name: 'Sources' }];
-    view();
+    render(<Harness />);
 
-    expect(screen.getByTestId('custom-view')).toBeInTheDocument();
+    expect(screen.getByTestId('overview-content')).toBeInTheDocument();
     expect(screen.queryByTestId('tab-blocks')).not.toBeInTheDocument();
   });
 
-  it("shows the selected tab's blocks instead of the custom view", () => {
+  it("hands back the selected tab's blocks in place of the view's own content", () => {
     mocks.tabs = [{ id: 'tab-sources', name: 'Sources' }];
     mocks.activeTabId = 'tab-sources';
-    view();
+    render(<Harness />);
 
     expect(screen.getByTestId('tab-blocks')).toBeInTheDocument();
-    expect(screen.queryByTestId('custom-view')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('overview-content')).not.toBeInTheDocument();
   });
 
-  // There is only ever one Overview, and on these views it is always the custom view.
+  // Everything the view renders above the bar describes the entity, so it stays put.
+  it('replaces only what sits below the bar', () => {
+    mocks.tabs = [{ id: 'tab-sources', name: 'Sources' }];
+    mocks.activeTabId = 'tab-sources';
+    render(<Harness />);
+
+    expect(screen.getByTestId('shared-chrome')).toBeInTheDocument();
+  });
+
   describe('Overview collision', () => {
     it("drops the entity's own Overview tab", () => {
       mocks.tabs = [
         { id: 'tab-overview', name: 'Overview' },
         { id: 'tab-sources', name: 'Sources' },
       ];
-      view();
+      render(<Harness />);
 
       expect(tabLabels()).toEqual(['Overview', 'Sources']);
       expect(screen.getByRole('link', { name: 'Overview' })).toHaveAttribute('href', `/space/${SPACE}/${ENTITY}`);
@@ -121,32 +137,31 @@ describe('CustomViewTabs', () => {
         { id: 'tab-b', name: 'OVERVIEW' },
         { id: 'tab-c', name: 'Sources' },
       ];
-      view();
+      render(<Harness />);
 
       expect(tabLabels()).toEqual(['Overview', 'Sources']);
     });
 
-    // A link to the suppressed tab resolves to the custom view, since a dropped tab is not in the
-    // list the active tab is matched against.
+    // A dropped tab is not in the list the active tab is matched against, so a link to it lands on
+    // the custom view rather than on nothing.
     it('lands on the custom view when a link points at the suppressed tab', () => {
       mocks.tabs = [
         { id: 'tab-overview', name: 'Overview' },
         { id: 'tab-sources', name: 'Sources' },
       ];
       mocks.activeTabId = 'tab-overview';
-      view();
+      render(<Harness />);
 
-      expect(screen.getByTestId('custom-view')).toBeInTheDocument();
+      expect(screen.getByTestId('overview-content')).toBeInTheDocument();
       expect(screen.queryByTestId('tab-blocks')).not.toBeInTheDocument();
     });
 
-    // An entity whose only other tab is its own Overview has nothing to switch to.
-    it('renders no bar when the only other tab was the suppressed one', () => {
+    it('offers no bar when the only other tab was the suppressed one', () => {
       mocks.tabs = [{ id: 'tab-overview', name: 'Overview' }];
-      view();
+      render(<Harness />);
 
       expect(screen.queryByTestId('tab-group')).not.toBeInTheDocument();
-      expect(screen.getByTestId('custom-view')).toBeInTheDocument();
+      expect(screen.getByTestId('overview-content')).toBeInTheDocument();
     });
   });
 });

--- a/apps/web/partials/entity-page/custom-view-tabs.test.tsx
+++ b/apps/web/partials/entity-page/custom-view-tabs.test.tsx
@@ -1,0 +1,152 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { TabEntity } from '~/core/types';
+
+const mocks = vi.hoisted(() => ({
+  tabs: [] as TabEntity[],
+  activeTabId: null as string | null,
+}));
+
+vi.mock('./use-entity-tab-entities', async () => {
+  const actual = await vi.importActual<typeof import('./use-entity-tab-entities')>('./use-entity-tab-entities');
+  return { ...actual, useEntityTabEntities: () => ({ tabRelations: [], tabs: mocks.tabs }) };
+});
+
+vi.mock('~/core/state/editor/editor-provider', () => ({
+  useActiveTabIdForEditor: () => mocks.activeTabId,
+}));
+
+// The tab bar and the editor are both exercised elsewhere; here they only need to be identifiable.
+vi.mock('~/design-system/tab-group', () => ({
+  TabGroup: ({ tabs }: { tabs: Array<{ label: string; href: string }> }) => (
+    <nav data-testid="tab-group">
+      {tabs.map(tab => (
+        <a key={tab.href} href={tab.href}>
+          {tab.label}
+        </a>
+      ))}
+    </nav>
+  ),
+}));
+
+vi.mock('~/partials/editor/editor', () => ({
+  Editor: () => <div data-testid="tab-blocks">tab blocks</div>,
+}));
+
+const { CustomViewTabs } = await import('./custom-view-tabs');
+
+const ENTITY = '07842862d2c3654c0324a07bc7cce1a4';
+const SPACE = 'a379046c74a140178e1c0545c72767c5';
+
+function view() {
+  return render(
+    <CustomViewTabs entityId={ENTITY} spaceId={SPACE} initialTabRelations={[]} tabEntities={[]}>
+      <div data-testid="custom-view">custom view</div>
+    </CustomViewTabs>
+  );
+}
+
+const tabLabels = () => screen.getAllByRole('link').map(link => link.textContent);
+
+beforeEach(() => {
+  mocks.tabs = [];
+  mocks.activeTabId = null;
+});
+
+afterEach(cleanup);
+
+describe('CustomViewTabs', () => {
+  // A lone "Overview" tab is chrome that does nothing, which is what the generic page already
+  // decides for itself.
+  it('renders the custom view alone when the entity has no other tabs', () => {
+    view();
+
+    expect(screen.getByTestId('custom-view')).toBeInTheDocument();
+    expect(screen.queryByTestId('tab-group')).not.toBeInTheDocument();
+  });
+
+  it('puts the custom view first, as Overview, and the entity tabs after it in order', () => {
+    mocks.tabs = [
+      { id: 'tab-sources', name: 'Sources' },
+      { id: 'tab-timeline', name: 'Timeline' },
+    ];
+    view();
+
+    expect(tabLabels()).toEqual(['Overview', 'Sources', 'Timeline']);
+    // Overview is where the page lands, so it carries no tab parameter.
+    expect(screen.getByRole('link', { name: 'Overview' })).toHaveAttribute('href', `/space/${SPACE}/${ENTITY}`);
+    expect(screen.getByRole('link', { name: 'Sources' })).toHaveAttribute(
+      'href',
+      `/space/${SPACE}/${ENTITY}?tabId=tab-sources`
+    );
+  });
+
+  it('shows the custom view on the Overview tab', () => {
+    mocks.tabs = [{ id: 'tab-sources', name: 'Sources' }];
+    view();
+
+    expect(screen.getByTestId('custom-view')).toBeInTheDocument();
+    expect(screen.queryByTestId('tab-blocks')).not.toBeInTheDocument();
+  });
+
+  it("shows the selected tab's blocks instead of the custom view", () => {
+    mocks.tabs = [{ id: 'tab-sources', name: 'Sources' }];
+    mocks.activeTabId = 'tab-sources';
+    view();
+
+    expect(screen.getByTestId('tab-blocks')).toBeInTheDocument();
+    expect(screen.queryByTestId('custom-view')).not.toBeInTheDocument();
+  });
+
+  // There is only ever one Overview, and on these views it is always the custom view.
+  describe('Overview collision', () => {
+    it("drops the entity's own Overview tab", () => {
+      mocks.tabs = [
+        { id: 'tab-overview', name: 'Overview' },
+        { id: 'tab-sources', name: 'Sources' },
+      ];
+      view();
+
+      expect(tabLabels()).toEqual(['Overview', 'Sources']);
+      expect(screen.getByRole('link', { name: 'Overview' })).toHaveAttribute('href', `/space/${SPACE}/${ENTITY}`);
+    });
+
+    // Matched against a name somebody typed, not against an id.
+    it('drops it however it was capitalised or spaced', () => {
+      mocks.tabs = [
+        { id: 'tab-a', name: '  overview ' },
+        { id: 'tab-b', name: 'OVERVIEW' },
+        { id: 'tab-c', name: 'Sources' },
+      ];
+      view();
+
+      expect(tabLabels()).toEqual(['Overview', 'Sources']);
+    });
+
+    // A link to the suppressed tab resolves to the custom view, since a dropped tab is not in the
+    // list the active tab is matched against.
+    it('lands on the custom view when a link points at the suppressed tab', () => {
+      mocks.tabs = [
+        { id: 'tab-overview', name: 'Overview' },
+        { id: 'tab-sources', name: 'Sources' },
+      ];
+      mocks.activeTabId = 'tab-overview';
+      view();
+
+      expect(screen.getByTestId('custom-view')).toBeInTheDocument();
+      expect(screen.queryByTestId('tab-blocks')).not.toBeInTheDocument();
+    });
+
+    // An entity whose only other tab is its own Overview has nothing to switch to.
+    it('renders no bar when the only other tab was the suppressed one', () => {
+      mocks.tabs = [{ id: 'tab-overview', name: 'Overview' }];
+      view();
+
+      expect(screen.queryByTestId('tab-group')).not.toBeInTheDocument();
+      expect(screen.getByTestId('custom-view')).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/partials/entity-page/custom-view-tabs.tsx
+++ b/apps/web/partials/entity-page/custom-view-tabs.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import * as React from 'react';
+
+import { useActiveTabIdForEditor } from '~/core/state/editor/editor-provider';
+import type { Relation, TabEntity } from '~/core/types';
+import { NavUtils } from '~/core/utils/utils';
+
+import { TabGroup } from '~/design-system/tab-group';
+
+import { Editor } from '~/partials/editor/editor';
+
+import { OVERVIEW_TAB_LABEL, isOverviewTabName, useEntityTabEntities } from './use-entity-tab-entities';
+
+type CustomViewTabsProps = {
+  entityId: string;
+  spaceId: string;
+  initialTabRelations: Relation[];
+  tabEntities: TabEntity[];
+  /** The custom view. It is what the Overview tab shows. */
+  children: React.ReactNode;
+};
+
+/**
+ * The column the custom claim and topic views lay themselves out in.
+ *
+ * Repeated here rather than imported from either of them: the tab bar and a tab's blocks have to
+ * line up with whichever view is underneath, and both use these measurements. Kept in one constant
+ * so the three cannot drift apart.
+ */
+const COLUMN_CLASS_NAME = 'mx-auto w-full max-w-[720px] px-4 @[560px]:px-5';
+
+/**
+ * A custom view, with the underlying entity's other tabs beside it (GEO-2779).
+ *
+ * The claim and topic views replace the generic entity page rather than sitting inside it, so they
+ * never reached the tab bar and an entity's other tabs were simply unreachable from them. Here the
+ * custom view *is* the Overview tab — the first tab and the one the page lands on — and the
+ * entity's own tabs follow, in the order the entity defines them.
+ *
+ * Two rules from the ticket fall out of that framing rather than needing to be enforced separately:
+ *
+ * - **No bar for a lone tab.** With nothing to switch to, a single "Overview" tab is chrome that
+ *   does nothing, so the custom view renders alone — matching what the generic page already does.
+ * - **One Overview.** An entity that names one of its own tabs "Overview" does not get a second
+ *   one; the custom view has taken that place. Its blocks are unreachable from this surface, which
+ *   is the trade the ticket chose. A `?tabId=` pointing at it lands on the custom view, because a
+ *   suppressed tab is not in the list this matches against.
+ */
+export function CustomViewTabs({ entityId, spaceId, initialTabRelations, tabEntities, children }: CustomViewTabsProps) {
+  const { tabs } = useEntityTabEntities({ entityId, spaceId, initialTabRelations, tabEntities });
+  const activeTabId = useActiveTabIdForEditor();
+
+  const additionalTabs = React.useMemo(() => tabs.filter(tab => !isOverviewTabName(tab.name)), [tabs]);
+
+  if (additionalTabs.length === 0) {
+    return <>{children}</>;
+  }
+
+  const overviewHref = NavUtils.toEntity(spaceId, entityId);
+  const isAdditionalTabActive = additionalTabs.some(tab => tab.id === activeTabId);
+
+  return (
+    <div className="@container">
+      <div className={`${COLUMN_CLASS_NAME} pt-6 @[560px]:pt-8`}>
+        <TabGroup
+          tabs={[
+            { label: OVERVIEW_TAB_LABEL, href: overviewHref },
+            ...additionalTabs.map(tab => ({
+              label: tab.name ?? '',
+              href: `${overviewHref}?tabId=${tab.id}`,
+            })),
+          ]}
+        />
+      </div>
+      {isAdditionalTabActive ? (
+        // The editor is already scoped to `?tabId=` by `EditorBlocksProvider`, so this renders the
+        // selected tab's blocks without being told which tab is open.
+        <div className={`${COLUMN_CLASS_NAME} pt-6 pb-8 @[560px]:pt-8`}>
+          <Editor spaceId={spaceId} shouldHandleOwnSpacing />
+        </div>
+      ) : (
+        children
+      )}
+    </div>
+  );
+}

--- a/apps/web/partials/entity-page/custom-view-tabs.tsx
+++ b/apps/web/partials/entity-page/custom-view-tabs.tsx
@@ -4,13 +4,12 @@ import * as React from 'react';
 
 import { useActiveTabIdForEditor } from '~/core/state/editor/editor-provider';
 import type { Relation, TabEntity } from '~/core/types';
-import { NavUtils } from '~/core/utils/utils';
 
 import { TabGroup } from '~/design-system/tab-group';
 
 import { Editor } from '~/partials/editor/editor';
 
-import { OVERVIEW_TAB_LABEL, isOverviewTabName, useEntityTabEntities } from './use-entity-tab-entities';
+import { entityTabLinks, isOverviewTabName, useEntityTabEntities } from './use-entity-tab-entities';
 
 /**
  * The tab bar and the switched region, handed to a custom view to place itself.
@@ -66,15 +65,19 @@ export function useCustomViewTabs({
   return React.useMemo(() => {
     if (additionalTabs.length === 0) return { bar: null, body: null };
 
-    const overviewHref = NavUtils.toEntity(spaceId, entityId);
+    const [overview, ...rest] = entityTabLinks({ spaceId, entityId, tabs: additionalTabs });
     const isAdditionalTabActive = additionalTabs.some(tab => tab.id === activeTabId);
 
     return {
       bar: (
         <TabGroup
           tabs={[
-            { label: OVERVIEW_TAB_LABEL, href: overviewHref },
-            ...additionalTabs.map(tab => ({ label: tab.name ?? '', href: `${overviewHref}?tabId=${tab.id}` })),
+            // Said outright rather than left to the href comparison, which assumes the active tab
+            // is in this list. It is not when `?tabId=` names the entity's own suppressed
+            // "Overview" — reachable from a shared link, or from leaving edit mode while that tab
+            // is open — and the view answers for that tab, so Overview is what is selected.
+            { ...overview, active: !isAdditionalTabActive },
+            ...rest,
           ]}
         />
       ),

--- a/apps/web/partials/entity-page/custom-view-tabs.tsx
+++ b/apps/web/partials/entity-page/custom-view-tabs.tsx
@@ -12,76 +12,75 @@ import { Editor } from '~/partials/editor/editor';
 
 import { OVERVIEW_TAB_LABEL, isOverviewTabName, useEntityTabEntities } from './use-entity-tab-entities';
 
-type CustomViewTabsProps = {
+/**
+ * The tab bar and the switched region, handed to a custom view to place itself.
+ *
+ * The view decides the seam, because only it knows which of its sections describe the entity and
+ * which are its Overview content: on a claim the split falls after My position, on a topic after
+ * the distribution strip. Everything the view renders above `bar` stays put whichever tab is open.
+ */
+export type CustomViewTabsSlot = {
+  /** The tab bar. `null` when the entity has no other tabs and there is nothing to switch to. */
+  bar: React.ReactNode;
+  /** The selected tab's blocks, or `null` while Overview is showing and the view renders its own. */
+  body: React.ReactNode | null;
+};
+
+export type CustomViewTabsInput = {
   entityId: string;
   spaceId: string;
   initialTabRelations: Relation[];
   tabEntities: TabEntity[];
-  /** The custom view. It is what the Overview tab shows. */
-  children: React.ReactNode;
 };
 
 /**
- * The column the custom claim and topic views lay themselves out in.
+ * An entity's other tabs, for a custom claim or topic view (GEO-2779).
  *
- * Repeated here rather than imported from either of them: the tab bar and a tab's blocks have to
- * line up with whichever view is underneath, and both use these measurements. Kept in one constant
- * so the three cannot drift apart.
- */
-const COLUMN_CLASS_NAME = 'mx-auto w-full max-w-[720px] px-4 @[560px]:px-5';
-
-/**
- * A custom view, with the underlying entity's other tabs beside it (GEO-2779).
- *
- * The claim and topic views replace the generic entity page rather than sitting inside it, so they
- * never reached the tab bar and an entity's other tabs were simply unreachable from them. Here the
- * custom view *is* the Overview tab — the first tab and the one the page lands on — and the
- * entity's own tabs follow, in the order the entity defines them.
+ * These views replace the generic entity page rather than sitting inside it, so they never reached
+ * the tab bar and an entity's other tabs were unreachable from them. Here the custom view *is* the
+ * Overview tab — the first tab and the one the page lands on — and the entity's own tabs follow, in
+ * the order the entity defines them.
  *
  * Two rules from the ticket fall out of that framing rather than needing to be enforced separately:
  *
- * - **No bar for a lone tab.** With nothing to switch to, a single "Overview" tab is chrome that
- *   does nothing, so the custom view renders alone — matching what the generic page already does.
+ * - **No bar for a lone tab.** With nothing to switch to, a single "Overview" is chrome that does
+ *   nothing, so the view renders alone — matching what the generic page already decides.
  * - **One Overview.** An entity that names one of its own tabs "Overview" does not get a second
- *   one; the custom view has taken that place. Its blocks are unreachable from this surface, which
- *   is the trade the ticket chose. A `?tabId=` pointing at it lands on the custom view, because a
- *   suppressed tab is not in the list this matches against.
+ *   one; the custom view has taken that place. A `?tabId=` pointing at it lands on the custom view,
+ *   because a suppressed tab is not in the list the active tab is matched against.
+ *
+ * A hook rather than a wrapper: the bar belongs partway down the view, under the sections that say
+ * what the entity is, and a component wrapped around the view could only put it above everything.
  */
-export function CustomViewTabs({ entityId, spaceId, initialTabRelations, tabEntities, children }: CustomViewTabsProps) {
+export function useCustomViewTabs({
+  entityId,
+  spaceId,
+  initialTabRelations,
+  tabEntities,
+}: CustomViewTabsInput): CustomViewTabsSlot {
   const { tabs } = useEntityTabEntities({ entityId, spaceId, initialTabRelations, tabEntities });
   const activeTabId = useActiveTabIdForEditor();
 
   const additionalTabs = React.useMemo(() => tabs.filter(tab => !isOverviewTabName(tab.name)), [tabs]);
 
-  if (additionalTabs.length === 0) {
-    return <>{children}</>;
-  }
+  return React.useMemo(() => {
+    if (additionalTabs.length === 0) return { bar: null, body: null };
 
-  const overviewHref = NavUtils.toEntity(spaceId, entityId);
-  const isAdditionalTabActive = additionalTabs.some(tab => tab.id === activeTabId);
+    const overviewHref = NavUtils.toEntity(spaceId, entityId);
+    const isAdditionalTabActive = additionalTabs.some(tab => tab.id === activeTabId);
 
-  return (
-    <div className="@container">
-      <div className={`${COLUMN_CLASS_NAME} pt-6 @[560px]:pt-8`}>
+    return {
+      bar: (
         <TabGroup
           tabs={[
             { label: OVERVIEW_TAB_LABEL, href: overviewHref },
-            ...additionalTabs.map(tab => ({
-              label: tab.name ?? '',
-              href: `${overviewHref}?tabId=${tab.id}`,
-            })),
+            ...additionalTabs.map(tab => ({ label: tab.name ?? '', href: `${overviewHref}?tabId=${tab.id}` })),
           ]}
         />
-      </div>
-      {isAdditionalTabActive ? (
-        // The editor is already scoped to `?tabId=` by `EditorBlocksProvider`, so this renders the
-        // selected tab's blocks without being told which tab is open.
-        <div className={`${COLUMN_CLASS_NAME} pt-6 pb-8 @[560px]:pt-8`}>
-          <Editor spaceId={spaceId} shouldHandleOwnSpacing />
-        </div>
-      ) : (
-        children
-      )}
-    </div>
-  );
+      ),
+      // The editor is already scoped to the active tab by `EditorBlocksProvider`, so this renders
+      // the selected tab's blocks without being told which one is open.
+      body: isAdditionalTabActive ? <Editor spaceId={spaceId} shouldHandleOwnSpacing /> : null,
+    };
+  }, [additionalTabs, activeTabId, entityId, spaceId]);
 }

--- a/apps/web/partials/entity-page/entity-page-body.tsx
+++ b/apps/web/partials/entity-page/entity-page-body.tsx
@@ -131,6 +131,30 @@ function EditorFooter({
 }
 
 /**
+ * A custom view with the entity's other tabs.
+ *
+ * Its own component so `useCustomViewTabs` runs only on the pages that render it. Called from
+ * `EntityPageBody` it would have to sit above that component's early returns, and would then scan
+ * the relation and value stores on every generic entity page and side panel for a result nothing
+ * reads — twice over, since `EntityTabs` does the same scan below.
+ */
+function CustomBrowseView({
+  view,
+  entityId,
+  spaceId,
+  initialTabRelations,
+  tabEntities,
+}: Pick<SharedProps, 'entityId' | 'spaceId' | 'initialTabRelations' | 'tabEntities'> & { view: 'claim' | 'topic' }) {
+  const tabs = useCustomViewTabs({ entityId, spaceId, initialTabRelations, tabEntities });
+
+  return view === 'claim' ? (
+    <ClaimPageView entityId={entityId} spaceId={spaceId} tabs={tabs} />
+  ) : (
+    <TopicPageView entityId={entityId} spaceId={spaceId} tabs={tabs} />
+  );
+}
+
+/**
  * Which custom read view this entity gets, if any.
  *
  * Editing always falls through to the generic page: these are read surfaces with no property editor
@@ -173,8 +197,6 @@ export function EntityPageBody(props: EntityPageBodyProps) {
       ? previewImageUrl
       : (previewImageResolvedUrl ?? previewImageUrl);
 
-  const customViewTabs = useCustomViewTabs({ entityId, spaceId, initialTabRelations, tabEntities });
-
   // After every hook above, so the branch can't change the hook order between renders — the flag
   // flips when edit mode is toggled, which happens without remounting.
   //
@@ -188,12 +210,16 @@ export function EntityPageBody(props: EntityPageBodyProps) {
   // tabs were unreachable from them until now. The custom view is the Overview tab, and each view
   // places the bar at its own seam — everything it renders above that is shared across every tab
   // (GEO-2779). With no other tabs the slot is empty and the views render exactly as before.
-  if (customView === 'claim') {
-    return <ClaimPageView entityId={entityId} spaceId={spaceId} tabs={customViewTabs} />;
-  }
-
-  if (customView === 'topic') {
-    return <TopicPageView entityId={entityId} spaceId={spaceId} tabs={customViewTabs} />;
+  if (customView === 'claim' || customView === 'topic') {
+    return (
+      <CustomBrowseView
+        view={customView}
+        entityId={entityId}
+        spaceId={spaceId}
+        initialTabRelations={initialTabRelations}
+        tabEntities={tabEntities}
+      />
+    );
   }
 
   const tabsSection = (

--- a/apps/web/partials/entity-page/entity-page-body.tsx
+++ b/apps/web/partials/entity-page/entity-page-body.tsx
@@ -20,7 +20,7 @@ import { CommentSection } from '~/partials/comments/comments-section';
 import { Editor } from '~/partials/editor/editor';
 import { AutomaticModeToggle } from '~/partials/entity-page/automatic-mode-toggle';
 import { BacklinksClientContainer } from '~/partials/entity-page/backlinks-client-container';
-import { CustomViewTabs } from '~/partials/entity-page/custom-view-tabs';
+import { useCustomViewTabs } from '~/partials/entity-page/custom-view-tabs';
 import { EditableHeading } from '~/partials/entity-page/editable-entity-header';
 import { EntityPageContentContainer } from '~/partials/entity-page/entity-page-content-container';
 import { EntityPageCover } from '~/partials/entity-page/entity-page-cover';
@@ -173,6 +173,8 @@ export function EntityPageBody(props: EntityPageBodyProps) {
       ? previewImageUrl
       : (previewImageResolvedUrl ?? previewImageUrl);
 
+  const customViewTabs = useCustomViewTabs({ entityId, spaceId, initialTabRelations, tabEntities });
+
   // After every hook above, so the branch can't change the hook order between renders — the flag
   // flips when edit mode is toggled, which happens without remounting.
   //
@@ -183,23 +185,15 @@ export function EntityPageBody(props: EntityPageBodyProps) {
   if (customView === 'pending') return null;
 
   // The custom views replace the generic page rather than sitting inside it, so the entity's other
-  // tabs were unreachable from them until now. The custom view is the Overview tab; the wrapper
-  // renders it unchanged when the entity has no other tabs (GEO-2779).
-  if (customView === 'claim' || customView === 'topic') {
-    return (
-      <CustomViewTabs
-        entityId={entityId}
-        spaceId={spaceId}
-        initialTabRelations={initialTabRelations}
-        tabEntities={tabEntities}
-      >
-        {customView === 'claim' ? (
-          <ClaimPageView entityId={entityId} spaceId={spaceId} />
-        ) : (
-          <TopicPageView entityId={entityId} spaceId={spaceId} />
-        )}
-      </CustomViewTabs>
-    );
+  // tabs were unreachable from them until now. The custom view is the Overview tab, and each view
+  // places the bar at its own seam — everything it renders above that is shared across every tab
+  // (GEO-2779). With no other tabs the slot is empty and the views render exactly as before.
+  if (customView === 'claim') {
+    return <ClaimPageView entityId={entityId} spaceId={spaceId} tabs={customViewTabs} />;
+  }
+
+  if (customView === 'topic') {
+    return <TopicPageView entityId={entityId} spaceId={spaceId} tabs={customViewTabs} />;
   }
 
   const tabsSection = (

--- a/apps/web/partials/entity-page/entity-page-body.tsx
+++ b/apps/web/partials/entity-page/entity-page-body.tsx
@@ -20,6 +20,7 @@ import { CommentSection } from '~/partials/comments/comments-section';
 import { Editor } from '~/partials/editor/editor';
 import { AutomaticModeToggle } from '~/partials/entity-page/automatic-mode-toggle';
 import { BacklinksClientContainer } from '~/partials/entity-page/backlinks-client-container';
+import { CustomViewTabs } from '~/partials/entity-page/custom-view-tabs';
 import { EditableHeading } from '~/partials/entity-page/editable-entity-header';
 import { EntityPageContentContainer } from '~/partials/entity-page/entity-page-content-container';
 import { EntityPageCover } from '~/partials/entity-page/entity-page-cover';
@@ -181,12 +182,24 @@ export function EntityPageBody(props: EntityPageBodyProps) {
   // generic value sheet and swapping it out from under the reader.
   if (customView === 'pending') return null;
 
-  if (customView === 'claim') {
-    return <ClaimPageView entityId={entityId} spaceId={spaceId} />;
-  }
-
-  if (customView === 'topic') {
-    return <TopicPageView entityId={entityId} spaceId={spaceId} />;
+  // The custom views replace the generic page rather than sitting inside it, so the entity's other
+  // tabs were unreachable from them until now. The custom view is the Overview tab; the wrapper
+  // renders it unchanged when the entity has no other tabs (GEO-2779).
+  if (customView === 'claim' || customView === 'topic') {
+    return (
+      <CustomViewTabs
+        entityId={entityId}
+        spaceId={spaceId}
+        initialTabRelations={initialTabRelations}
+        tabEntities={tabEntities}
+      >
+        {customView === 'claim' ? (
+          <ClaimPageView entityId={entityId} spaceId={spaceId} />
+        ) : (
+          <TopicPageView entityId={entityId} spaceId={spaceId} />
+        )}
+      </CustomViewTabs>
+    );
   }
 
   const tabsSection = (

--- a/apps/web/partials/entity-page/entity-tabs.tsx
+++ b/apps/web/partials/entity-page/entity-tabs.tsx
@@ -13,7 +13,7 @@ import { NavUtils } from '~/core/utils/utils';
 import { TabGroup } from '~/design-system/tab-group';
 
 import { EditableTabGroup } from './editable-tab-group';
-import { OVERVIEW_TAB_LABEL, useEntityTabEntities } from './use-entity-tab-entities';
+import { entityTabLinks, useEntityTabEntities } from './use-entity-tab-entities';
 
 type EntityTabsProps = {
   entityId: string;
@@ -46,14 +46,16 @@ export function EntityTabs({ entityId, spaceId, initialTabRelations, tabEntities
     return null;
   }
 
-  const overviewHref = NavUtils.toEntity(spaceId, entityId);
+  const allTabs = entityTabLinks({ spaceId, entityId, tabs: sortedTabEntities });
+  const [overviewLink] = allTabs;
+  const overviewHref = overviewLink.href;
 
   if (effectiveEditable) {
     const editableTabs = sortedTabRelations.map((relation, i) => ({
       relation,
       entityId: sortedTabEntities[i].id,
       name: sortedTabEntities[i].name ?? '',
-      href: `${overviewHref}?tabId=${sortedTabEntities[i].id}`,
+      href: NavUtils.toEntity(spaceId, entityId, undefined, undefined, { tabId: sortedTabEntities[i].id }),
     }));
 
     return (
@@ -61,26 +63,11 @@ export function EntityTabs({ entityId, spaceId, initialTabRelations, tabEntities
         entityId={entityId}
         spaceId={spaceId}
         editableTabs={editableTabs}
-        systemTabsBefore={[{ label: OVERVIEW_TAB_LABEL, href: overviewHref }]}
+        systemTabsBefore={[overviewLink]}
         overviewHref={overviewHref}
       />
     );
   }
-
-  // Build tabs in the correct order
-  const tabs = sortedTabEntities.map(entity => ({
-    label: entity.name ?? '',
-    href: `${overviewHref}?tabId=${entity.id}`,
-  }));
-
-  // Add Overview tab at the beginning
-  const allTabs = [
-    {
-      label: OVERVIEW_TAB_LABEL,
-      href: overviewHref,
-    },
-    ...tabs,
-  ];
 
   if (allTabs.length <= 1) {
     return null;

--- a/apps/web/partials/entity-page/entity-tabs.tsx
+++ b/apps/web/partials/entity-page/entity-tabs.tsx
@@ -1,20 +1,19 @@
 'use client';
 
-import { SystemIds } from '@geoprotocol/geo-sdk/lite';
-
 import * as React from 'react';
 
 import { useEditable } from '~/core/state/editable-store';
 import { EntitySidePanelEditContext } from '~/core/state/entity-side-panel-edit-context';
-import { useQueryEntity, useRelations, useValues } from '~/core/sync/use-store';
+import { useQueryEntity } from '~/core/sync/use-store';
 import { TabEntity } from '~/core/types';
 import { Relation } from '~/core/types';
 import { entityHasOnlyPostType } from '~/core/utils/entity/entities';
-import { NavUtils, sortRelations } from '~/core/utils/utils';
+import { NavUtils } from '~/core/utils/utils';
 
 import { TabGroup } from '~/design-system/tab-group';
 
 import { EditableTabGroup } from './editable-tab-group';
+import { OVERVIEW_TAB_LABEL, useEntityTabEntities } from './use-entity-tab-entities';
 
 type EntityTabsProps = {
   entityId: string;
@@ -36,49 +35,16 @@ export function EntityTabs({ entityId, spaceId, initialTabRelations, tabEntities
    */
   const effectiveEditable = sidePanelEdit != null ? sidePanelEdit.panelWantsEdit : editable;
 
-  const initialTabRelationIds = React.useMemo(() => new Set(initialTabRelations.map(r => r.id)), [initialTabRelations]);
-
-  // Merge local tab relation changes with server data. Tab relations keep their relation `spaceId`;
-  // it may differ from the entity URL scope — include merged rows by id so tabs don’t disappear
-  // (especially in the side panel).
-  const mergedTabRelations = useRelations({
-    mergeWith: initialTabRelations,
-    selector: r => {
-      if (r.fromEntity.id !== entityId || r.type.id !== SystemIds.TABS_PROPERTY) return false;
-      if (Boolean(r.isDeleted)) return false;
-      if (r.spaceId === spaceId) return true;
-      return initialTabRelationIds.has(r.id);
-    },
+  const { tabRelations: sortedTabRelations, tabs: sortedTabEntities } = useEntityTabEntities({
+    entityId,
+    spaceId,
+    initialTabRelations,
+    tabEntities,
   });
-
-  // Sort by position to get correct order
-  const sortedTabRelations = sortRelations(mergedTabRelations);
-
-  // Map sorted relations to tab entities, maintaining order.
-  // For new local tabs (not yet published), fall back to the relation's toEntity data.
-  const tabEntityMap = new Map(tabEntities.map(e => [e.id, e]));
-
-  // Subscribe to live name values so inline renames show up without re-fetch.
-  const tabEntityIdSet = React.useMemo(() => new Set(sortedTabRelations.map(r => r.toEntity.id)), [sortedTabRelations]);
-  const liveNameValues = useValues({
-    selector: v =>
-      v.property.id === SystemIds.NAME_PROPERTY && v.spaceId === spaceId && tabEntityIdSet.has(v.entity.id),
-  });
-  const liveNameMap = React.useMemo(() => {
-    const map = new Map<string, string>();
-    for (const v of liveNameValues) map.set(v.entity.id, v.value);
-    return map;
-  }, [liveNameValues]);
 
   if (entityHasOnlyPostType(entity)) {
     return null;
   }
-
-  const sortedTabEntities = sortedTabRelations.map(r => {
-    const base = tabEntityMap.get(r.toEntity.id) ?? { id: r.toEntity.id, name: r.toEntity.name };
-    const liveName = liveNameMap.get(r.toEntity.id);
-    return liveName !== undefined ? { ...base, name: liveName } : base;
-  });
 
   const overviewHref = NavUtils.toEntity(spaceId, entityId);
 
@@ -95,7 +61,7 @@ export function EntityTabs({ entityId, spaceId, initialTabRelations, tabEntities
         entityId={entityId}
         spaceId={spaceId}
         editableTabs={editableTabs}
-        systemTabsBefore={[{ label: 'Overview', href: overviewHref }]}
+        systemTabsBefore={[{ label: OVERVIEW_TAB_LABEL, href: overviewHref }]}
         overviewHref={overviewHref}
       />
     );
@@ -110,7 +76,7 @@ export function EntityTabs({ entityId, spaceId, initialTabRelations, tabEntities
   // Add Overview tab at the beginning
   const allTabs = [
     {
-      label: 'Overview',
+      label: OVERVIEW_TAB_LABEL,
       href: overviewHref,
     },
     ...tabs,

--- a/apps/web/partials/entity-page/use-entity-tab-entities.ts
+++ b/apps/web/partials/entity-page/use-entity-tab-entities.ts
@@ -6,7 +6,7 @@ import * as React from 'react';
 
 import { useRelations, useValues } from '~/core/sync/use-store';
 import type { Relation, TabEntity } from '~/core/types';
-import { sortRelations } from '~/core/utils/utils';
+import { NavUtils, sortRelations } from '~/core/utils/utils';
 
 /**
  * The label the entity page gives its own blocks, and the one a custom view takes over.
@@ -81,4 +81,30 @@ export function useEntityTabEntities({ entityId, spaceId, initialTabRelations, t
   });
 
   return { tabRelations, tabs };
+}
+
+/**
+ * The Overview-first link list both tab bars render.
+ *
+ * Shared so the label, the ordering and the URL scheme are stated once: the generic page and the
+ * custom claim and topic views are the same bar over the same tabs, and only what fills Overview
+ * differs. Hrefs come from `NavUtils.toEntity`, which already knows how a tab is addressed — built
+ * by hand in three places before this, which is three places to update if the parameter ever moves.
+ */
+export function entityTabLinks({
+  spaceId,
+  entityId,
+  tabs,
+}: {
+  spaceId: string;
+  entityId: string;
+  tabs: TabEntity[];
+}): Array<{ label: string; href: string }> {
+  return [
+    { label: OVERVIEW_TAB_LABEL, href: NavUtils.toEntity(spaceId, entityId) },
+    ...tabs.map(tab => ({
+      label: tab.name ?? '',
+      href: NavUtils.toEntity(spaceId, entityId, undefined, undefined, { tabId: tab.id }),
+    })),
+  ];
 }

--- a/apps/web/partials/entity-page/use-entity-tab-entities.ts
+++ b/apps/web/partials/entity-page/use-entity-tab-entities.ts
@@ -1,0 +1,84 @@
+'use client';
+
+import { SystemIds } from '@geoprotocol/geo-sdk/lite';
+
+import * as React from 'react';
+
+import { useRelations, useValues } from '~/core/sync/use-store';
+import type { Relation, TabEntity } from '~/core/types';
+import { sortRelations } from '~/core/utils/utils';
+
+/**
+ * The label the entity page gives its own blocks, and the one a custom view takes over.
+ *
+ * Compared case- and whitespace-insensitively: this is matched against a name an author typed, not
+ * against an id.
+ */
+export const OVERVIEW_TAB_LABEL = 'Overview';
+
+export function isOverviewTabName(name: string | null | undefined): boolean {
+  return (name ?? '').trim().toLowerCase() === OVERVIEW_TAB_LABEL.toLowerCase();
+}
+
+export type EntityTabsInput = {
+  entityId: string;
+  spaceId: string;
+  initialTabRelations: Relation[];
+  tabEntities: TabEntity[];
+};
+
+/**
+ * An entity's tabs, in the order the entity defines them, with local edits and renames folded in.
+ *
+ * Extracted from `EntityTabs` so the custom claim and topic views list the same tabs in the same
+ * order as the generic page (GEO-2779). Order comes from the `Tabs` relations' positions, which is
+ * where the entity already defines it — re-deriving it anywhere else is how two surfaces start
+ * disagreeing about what comes after what.
+ *
+ * Returns the relations alongside the entities because the editable tab bar needs both, and pairing
+ * them by index only holds while one list is built from the other.
+ */
+export function useEntityTabEntities({ entityId, spaceId, initialTabRelations, tabEntities }: EntityTabsInput): {
+  tabRelations: Relation[];
+  tabs: TabEntity[];
+} {
+  const initialTabRelationIds = React.useMemo(() => new Set(initialTabRelations.map(r => r.id)), [initialTabRelations]);
+
+  // Merge local tab relation changes with server data. Tab relations keep their relation `spaceId`;
+  // it may differ from the entity URL scope — include merged rows by id so tabs don't disappear
+  // (especially in the side panel).
+  const mergedTabRelations = useRelations({
+    mergeWith: initialTabRelations,
+    selector: r => {
+      if (r.fromEntity.id !== entityId || r.type.id !== SystemIds.TABS_PROPERTY) return false;
+      if (Boolean(r.isDeleted)) return false;
+      if (r.spaceId === spaceId) return true;
+      return initialTabRelationIds.has(r.id);
+    },
+  });
+
+  const tabRelations = sortRelations(mergedTabRelations);
+
+  // Subscribe to live name values so inline renames show up without re-fetch.
+  const tabEntityIdSet = React.useMemo(() => new Set(tabRelations.map(r => r.toEntity.id)), [tabRelations]);
+  const liveNameValues = useValues({
+    selector: v =>
+      v.property.id === SystemIds.NAME_PROPERTY && v.spaceId === spaceId && tabEntityIdSet.has(v.entity.id),
+  });
+  const liveNameMap = React.useMemo(() => {
+    const map = new Map<string, string>();
+    for (const v of liveNameValues) map.set(v.entity.id, v.value);
+    return map;
+  }, [liveNameValues]);
+
+  const tabEntityMap = React.useMemo(() => new Map(tabEntities.map(e => [e.id, e])), [tabEntities]);
+
+  const tabs = tabRelations.map(r => {
+    // A tab added locally has no fetched entity yet, so the relation's own target carries the name.
+    const base = tabEntityMap.get(r.toEntity.id) ?? { id: r.toEntity.id, name: r.toEntity.name };
+    const liveName = liveNameMap.get(r.toEntity.id);
+    return liveName !== undefined ? { ...base, name: liveName } : base;
+  });
+
+  return { tabRelations, tabs };
+}


### PR DESCRIPTION
Closes [GEO-2779](https://linear.app/geobrowser/issue/GEO-2779/custom-topic-and-claim-views-show-the-entitys-additional-block-content).

A claim or topic renders a custom read view that **replaces** the generic entity page rather than sitting inside it, so `EntityPageBody` returned before it ever reached the tab bar. An entity with tabs of block content had them silently unreachable from the surface people actually land on.

The custom view is now the **Overview** tab — first, and where the page lands — with the entity's own tabs after it.

## Where the bar sits

Each view places the bar at its own seam, and **everything above it is shared across every tab**:

| View | Above the bar (always shown) | Below the bar (what a tab replaces) |
| --- | --- | --- |
| **Claim** | hero, verdict, **My position** | debates, provenance, related claims, comments |
| **Topic** | hero, **distribution strip** | subtopics, debates, claims, coverage, comments |

So switching tabs never takes the claim or topic with it — the page keeps saying what it is about.

Because only the view knows where that seam falls, this is a hook (`useCustomViewTabs`) handing back the bar and the selected tab's blocks, rather than a wrapper component — a wrapper could only ever put the bar above everything. Both views take the slot as an optional prop and render exactly as before without one.

## What already existed

Worth saying, because it kept the change small. `EntityTabs` already put Overview first, ordered the rest by the `Tabs` relations' positions, linked them with `?tabId=`, and rendered nothing when there was only Overview. The gap was purely that the custom views never got there.

So rather than reimplement any of that, the resolution `EntityTabs` was doing inline moves to `useEntityTabEntities` and both surfaces call it — including the live-rename subscription and local-edit merging, which a second implementation would have had to grow on its own before the two agreed about anything. `EntityTabs` behaves exactly as before.

## The ticket's rules, and where they live

Two of them fall out of framing the custom view *as* the Overview tab, rather than needing separate enforcement:

**"Presumably no tab bar at all rather than a single lone tab. Worth confirming."** — Confirmed, and it's what the generic page already decides for itself (`allTabs.length <= 1` returns `null`). Same here: an entity with no other tabs renders the custom view alone.

**Overview collision** — an entity that names one of its own tabs "Overview" doesn't get a second one. Matched case- and whitespace-insensitively, since this is a name somebody typed, not an id.

**"Note the collision rule means an Overview URL resolves to the custom view."** — It does, and for free: a suppressed tab isn't in the list the active tab is matched against, so `?tabId=<suppressed>` falls through to the custom view. No special case.

**Tab order** — comes from the `Tabs` relation positions, which is where the entity already states it. Nothing is re-derived here.

**"Worth confirming whether the tabs are addressable by URL."** — They are, through the existing `?tabId=` parameter, so no third scheme was invented.

## Side panel

Works without a branch here. `TabGroup` already swaps navigation for panel state when it's inside a side panel, and `useActiveTabIdForEditor` reads the panel's resolved tab rather than the host page URL. Since the claim/topic branch sits above the route/side-panel split, both surfaces get tabs from one code path.

## Decisions worth your eye

**The suppressed Overview tab's content becomes unreachable here.** The ticket flagged this and chose it; I've implemented it as specified rather than renaming the tab to something its author never called it. Flagging it because it's the one place an author loses content they wrote — say the word and I'll render it as a trailing tab instead.

**The generic entity page is untouched**, including its own duplicate-Overview behaviour: it also prepends a synthetic Overview without suppressing an entity-defined one. That's out of scope, and changing it would hide block content on pages that render it today. Easy follow-up if you want the two consistent.

**GEO-2778 interaction**: the tabs come from the underlying entity, so whichever space that entity is read from decides which tabs appear. This reads it the same way the rest of the page does, so the two stay in agreement automatically — but if GEO-2778 changes the resolution, this follows it rather than needing its own fix.

## Review pass

A review found two defects and one piece of duplication, all fixed in `5550545`:

**Overview read as unselected when a link named the suppressed tab.** `TabGroup` decides which tab is selected by matching hrefs, which assumes the active tab is in the list it was given. On these views it isn't — the entity's own "Overview" is dropped and the custom view answers for it — so `?tabId=<dropped tab>` matched nothing and *every* tab came up unselected while the content was correct. Reachable from a shared link, and from leaving edit mode with that tab open, since the editable bar still links to it. `TabGroup` now takes an `active` override for when a caller knows better than the comparison, and the custom view says outright that Overview is selected. With a real tab open the comparison is right and is still left to decide.

**A store subscription on every page that had no use for it.** `useCustomViewTabs` sat above `EntityPageBody`'s early returns, so every generic entity page and side panel scanned the relation and value stores for a result only claims and topics read — twice over, since `EntityTabs` scans again below. It moved into a small `CustomBrowseView` that only those two pages render.

**Three copies of a tab href.** `NavUtils.toEntity` already takes a `tabId`, and the Overview-first list is the same list on both bars. `entityTabLinks` builds it once and both call it, so the label, the ordering and the URL scheme live in one place instead of being assembled by hand wherever a bar is drawn.

### Reuse, checked

- `EntityTabs`' tab resolution → `useEntityTabEntities`, called by both bars (live renames and local-edit merging included, so a second copy can't drift).
- Tab href construction → the existing `NavUtils.toEntity(..., { tabId })` rather than string concatenation.
- Overview label, ordering and link list → `entityTabLinks`, shared.
- The tab bar itself → the existing `TabGroup`, which already handles side-panel state, so no branch was needed for the panel.
- Tab content → the existing `Editor`, already scoped to the active tab by `EditorBlocksProvider`.

Left alone deliberately: `space-tabs.tsx` is a parallel Overview-first bar for spaces, and `create-post-flow.ts` / `personal-profile-suggested-card.tsx` / `editable-tab-group.tsx` also build `?tabId=` by hand. Unifying those is a real follow-up but well outside this ticket, and would touch surfaces this branch has no other reason to move.

## Testing

- `custom-view-tabs.test.tsx` — 9 cases on the hook: no bar without other tabs, Overview first and entity order after, Overview leaves the view its own content, a selected tab's blocks replace it, what sits above the bar survives the switch, and four on the collision rule (dropped, case/whitespace variants, a link to the suppressed tab landing on the custom view, no bar when the suppressed tab was the only other one). **Revert-checked**: removing the suppression fails exactly the four collision cases.
- `claim-page-view.test.tsx` and `topic-page-view.test.tsx` — placement is under test, not incidental: the bar falls after the section that ends the shared chrome (`Your position`; the distribution strip) and before the first piece of Overview content, and switching tabs keeps everything above it. **Revert-checked**: moving the claim's bar up by one section fails its ordering test.
- Active-state cases: Overview stays selected when the link names the suppressed tab, and a genuinely selected tab is left to the href comparison. **Revert-checked**: dropping the override fails both.
- Full unit suite — **365 files, 3929 tests, all pass**
- `eslint` and `prettier` clean; `tsc --noEmit` unchanged (3 pre-existing failures, none in touched files)
