### PR TITLE
feat(claims): draw a claim's Topics with the topic view's Subtopics section

### DIFF
--- a/apps/web/core/claims/browse/claim-debates.tsx
+++ b/apps/web/core/claims/browse/claim-debates.tsx
@@ -29,6 +29,8 @@ import { PrefetchLink as Link } from '~/design-system/prefetch-link';
 import { Skeleton } from '~/design-system/skeleton';
 import { Text } from '~/design-system/text';
 
+import { SectionTitle } from '~/partials/entity-page/section-title';
+
 import { CursorPager, useCursorPages } from './use-cursor-pages';
 import { useDebateKeyframes } from './use-debate-keyframes';
 
@@ -131,9 +133,7 @@ export function ClaimDebates({
 
   return (
     <section aria-label="Debates on this claim">
-      <Text as="h2" variant="smallTitle" color="text" className="mb-3 block">
-        Debates on this claim
-      </Text>
+      <SectionTitle>Debates on this claim</SectionTitle>
       <ul className="m-0 flex list-none flex-col gap-2 p-0">
         {debates.map(debate => (
           <li key={debate.id}>

--- a/apps/web/core/claims/browse/claim-page-view.test.tsx
+++ b/apps/web/core/claims/browse/claim-page-view.test.tsx
@@ -5,12 +5,17 @@ import type React from 'react';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { TOPICS_PROPERTY_ID } from '~/core/claims/ontology';
+import { TAG_PROPERTY_ID } from '~/core/constants';
+
 import { ClaimPageView } from './claim-page-view';
 
 const mocks = vi.hoisted(() => ({
   entity: null as Record<string, unknown> | null,
   /** Props the description's clamp received, or null if it rendered no clamp at all. */
   clamp: null as Record<string, unknown> | null,
+  /** Props the chip section received, or null if the page rendered none. */
+  chipSection: null as Record<string, unknown> | null,
   /**
    * Deliberately not 3.
    *
@@ -33,6 +38,15 @@ vi.mock('~/design-system/clamped-text', () => ({
   ClampedText: (props: Record<string, unknown>) => {
     mocks.clamp = props;
     return <p data-testid="clamped-description">{props.text as string}</p>;
+  },
+}));
+
+// Its own suite covers the chips and the expander; here we only need to see what it was handed.
+vi.mock('~/partials/entity-page/relation-chip-section', () => ({
+  META_CHIP_CLASS: 'meta-chip',
+  RelationChipSection: (props: Record<string, unknown>) => {
+    mocks.chipSection = props;
+    return <div data-testid="chip-section" data-label={props.label as string} />;
   },
 }));
 
@@ -98,6 +112,7 @@ function claimEntity(description: string | null) {
 beforeEach(() => {
   mocks.entity = claimEntity('A description long enough that the page has something to collapse.');
   mocks.clamp = null;
+  mocks.chipSection = null;
 });
 
 afterEach(cleanup);
@@ -127,5 +142,40 @@ describe('ClaimPageView description', () => {
     render(<ClaimPageView entityId="claim-1" spaceId="space-1" />);
 
     expect(screen.queryByTestId('clamped-description')).toBeNull();
+  });
+});
+
+// GEO-2781. Topics used to be a run of chips crammed into the header's meta row, capped at three
+// and with a `+N` that only counted. It is now the topic view's Subtopics section, which is the
+// same question asked of the reader and so should not be a second thing that merely looks like it.
+describe('ClaimPageView topics', () => {
+  const topicRelation = {
+    id: 'relation-1',
+    type: { id: TOPICS_PROPERTY_ID },
+    toEntity: { id: 'topic-1', name: 'Ethics' },
+  };
+
+  it('draws them with the shared chip section, under the label Topics', () => {
+    mocks.entity = { ...claimEntity('Anything'), relations: [topicRelation] };
+    render(<ClaimPageView entityId="claim-1" spaceId="space-1" />);
+
+    expect(screen.getByTestId('chip-section')).toHaveAttribute('data-label', 'Topics');
+  });
+
+  it('hands the section the topic relations, scoped to the viewing space', () => {
+    mocks.entity = { ...claimEntity('Anything'), relations: [topicRelation] };
+    render(<ClaimPageView entityId="claim-1" spaceId="space-1" />);
+
+    expect(mocks.chipSection?.relations).toEqual([topicRelation]);
+    expect(mocks.chipSection?.spaceId).toBe('space-1');
+  });
+
+  // Tags share the header row with the type and are a different relation; only Topics moved.
+  it('passes only topic relations, not the tags beside the type', () => {
+    const tagRelation = { id: 'relation-2', type: { id: TAG_PROPERTY_ID }, toEntity: { id: 'tag-1', name: 'Draft' } };
+    mocks.entity = { ...claimEntity('Anything'), relations: [topicRelation, tagRelation] };
+    render(<ClaimPageView entityId="claim-1" spaceId="space-1" />);
+
+    expect(mocks.chipSection?.relations).toEqual([topicRelation]);
   });
 });

--- a/apps/web/core/claims/browse/claim-page-view.tsx
+++ b/apps/web/core/claims/browse/claim-page-view.tsx
@@ -13,15 +13,14 @@ import { usePrivySignIn } from '~/core/hooks/use-privy-sign-in';
 import { ID } from '~/core/id';
 import { useQueryEntity } from '~/core/sync/use-store';
 import type { Relation } from '~/core/types';
-import { NavUtils } from '~/core/utils/utils';
 
 import { ClampedText } from '~/design-system/clamped-text';
-import { PrefetchLink as Link } from '~/design-system/prefetch-link';
 import { Skeleton } from '~/design-system/skeleton';
 import { Text } from '~/design-system/text';
 
 import { CommentSection } from '~/partials/comments/comments-section';
 import { ENTITY_DESCRIPTION_MAX_LINES } from '~/partials/entity-page/entity-page-inline-description';
+import { META_CHIP_CLASS, RelationChipSection } from '~/partials/entity-page/relation-chip-section';
 
 import { ClaimDebates } from './claim-debates';
 import { ClaimEndSlot } from './claim-end-slot';
@@ -30,9 +29,6 @@ import { ClaimRelatedClaims } from './claim-related-claims';
 import { ControversialTag } from './claim-summary';
 import { ClaimVerdict } from './claim-verdict';
 import { type ClaimResponseState, useClaimResponseState } from './use-claim-response-state';
-
-/** Topic chips shown inline before the rest collapse into a count. */
-const TOPIC_CHIP_CAP = 3;
 
 /**
  * The browse-mode read view for a Claim.
@@ -116,41 +112,26 @@ export function ClaimPageView({ entityId, spaceId }: { entityId: string; spaceId
             />
           )}
 
-          {/* What this is on the left, what it's about on the right. The two answer different
-              questions, so pushing them to opposite ends reads faster than one undifferentiated
-              run of chips — and `flex-wrap` lets the topics drop to their own line in the side
-              panel rather than crushing the type against them. */}
-          <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-2">
-            <div className="flex min-w-0 flex-wrap items-center gap-1.5">
-              {typeName && <MetaChip>{typeName}</MetaChip>}
-              {tags.map(tag => (
-                <MetaChip key={tag.id}>{tag.toEntity.name ?? tag.toEntity.id}</MetaChip>
-              ))}
-              {/* Among the chips that say what this is, which is what "contested" is — and the same
-                  component the cards use, rather than a second span at a size the scale lacks. */}
-              {summary.isControversial ? <ControversialTag /> : null}
-            </div>
-
-            {topics.length > 0 && (
-              <div className="flex min-w-0 flex-wrap items-center gap-1.5">
-                {topics.slice(0, TOPIC_CHIP_CAP).map(topic => (
-                  <Link
-                    key={topic.id}
-                    href={NavUtils.toEntity(spaceId, topic.toEntity.id)}
-                    className={`${META_CHIP_CLASS} text-text transition-colors hover:border-text`}
-                  >
-                    <span className="truncate">{topic.toEntity.name ?? topic.toEntity.id}</span>
-                  </Link>
-                ))}
-                {topics.length > TOPIC_CHIP_CAP && (
-                  <span className={`${META_CHIP_CLASS} text-grey-04 tabular-nums`}>
-                    +{topics.length - TOPIC_CHIP_CAP}
-                  </span>
-                )}
-              </div>
-            )}
+          {/* What this is. Topics — what it is *about* — used to sit opposite these, pushed to the
+              right of the same row; they are their own section below now (GEO-2781), so this row
+              has one job and no longer has to survive being squeezed from both ends in the side
+              panel. */}
+          <div className="flex min-w-0 flex-wrap items-center gap-1.5">
+            {typeName && <MetaChip>{typeName}</MetaChip>}
+            {tags.map(tag => (
+              <MetaChip key={tag.id}>{tag.toEntity.name ?? tag.toEntity.id}</MetaChip>
+            ))}
+            {/* Among the chips that say what this is, which is what "contested" is — and the same
+                component the cards use, rather than a second span at a size the scale lacks. */}
+            {summary.isControversial ? <ControversialTag /> : null}
           </div>
         </header>
+
+        {/* The topic view's Subtopics, drawing a claim's Topics (GEO-2781) — same question for the
+            reader, so the same answer rather than two that look alike until one of them changes.
+            Directly under the header, where the topic view puts its own: on a claim the thing worth
+            offering before the argument itself is somewhere else to take it. */}
+        <RelationChipSection label="Topics" relations={topics} spaceId={spaceId} />
 
         <ClaimVerdict entityId={entityId} spaceId={spaceId} responseKind={responseKind} summary={summary} />
 
@@ -262,14 +243,14 @@ function ClaimPositionSection({
 }
 
 /**
- * The chip a space homepage uses for its types, reused here for the claim's type, its tags and its
- * topics — the same shape in all three places, since they are the same kind of label.
+ * The chip a space homepage uses for its types, reused here for the claim's type and its tags —
+ * the same shape in both places, since they are the same kind of label.
  *
- * `asChild` is not used: the topic variant is a link and needs its own hover state, so the class
- * string is exported and composed rather than the element being wrapped.
+ * A plain span, and not a component wrapping the class: topics used to be drawn here too and
+ * needed to be links with their own hover state, which is why {@link META_CHIP_CLASS} is a string
+ * that callers compose rather than an element. Topics now come from `RelationChipSection`, which
+ * composes it the same way.
  */
-const META_CHIP_CLASS = 'flex h-6 max-w-full items-center rounded border border-grey-02 bg-white px-1.5 text-metadata';
-
 function MetaChip({ children }: { children: React.ReactNode }) {
   return (
     <span className={`${META_CHIP_CLASS} text-text`}>

--- a/apps/web/core/claims/browse/claim-page-view.tsx
+++ b/apps/web/core/claims/browse/claim-page-view.tsx
@@ -21,6 +21,7 @@ import { Text } from '~/design-system/text';
 import { CommentSection } from '~/partials/comments/comments-section';
 import { ENTITY_DESCRIPTION_MAX_LINES } from '~/partials/entity-page/entity-page-inline-description';
 import { META_CHIP_CLASS, RelationChipSection } from '~/partials/entity-page/relation-chip-section';
+import { SectionTitle } from '~/partials/entity-page/section-title';
 
 import { ClaimDebates } from './claim-debates';
 import { ClaimEndSlot } from './claim-end-slot';
@@ -207,9 +208,7 @@ function ClaimPositionSection({
     <section aria-label="Your position" className="rounded-lg border border-grey-02 bg-white p-4 @[560px]:p-5">
       {/* No readiness switch — the Debate toggle is gone from the product. Master left the header
           row that used to hold it; with nothing on its right there is no row, just a label. */}
-      <Text as="div" variant="metadataMedium" color="grey-04" className="mb-2.5 block">
-        Your position
-      </Text>
+      <SectionTitle>Your position</SectionTitle>
       <PositionRow
         positions={control.optimisticPositions}
         responseKind={readiness.response_kind}

--- a/apps/web/core/claims/browse/claim-related-claims.tsx
+++ b/apps/web/core/claims/browse/claim-related-claims.tsx
@@ -14,7 +14,7 @@ import { ID } from '~/core/id';
 import { useQueryEntities } from '~/core/sync/use-store';
 import type { Entity } from '~/core/types';
 
-import { Text } from '~/design-system/text';
+import { SectionTitle } from '~/partials/entity-page/section-title';
 
 import { useClaimResponseState } from './use-claim-response-state';
 import { CursorPager, useCursorPages } from './use-cursor-pages';
@@ -144,9 +144,7 @@ export function ClaimRelatedClaims({
 
   return (
     <section aria-label="Related claims">
-      <Text as="h2" variant="smallTitle" color="text" className="mb-3 block">
-        Related claims
-      </Text>
+      <SectionTitle>Related claims</SectionTitle>
       {/* Two up where there is room, one up in the side panel and on a phone — the same container
           query the rest of the page lays out against, so the gallery follows the panel's width
           rather than the window's. */}

--- a/apps/web/core/topics/browse/topic-claims.tsx
+++ b/apps/web/core/topics/browse/topic-claims.tsx
@@ -6,10 +6,11 @@ import { CursorPager, useCursorPages } from '~/core/claims/browse/use-cursor-pag
 import { CLAIM_TYPE_ID } from '~/core/claims/ontology';
 
 import { Skeleton } from '~/design-system/skeleton';
-import { Text } from '~/design-system/text';
 
-import { TopicClaimCard } from './topic-claim-card';
+import { SectionTitle } from '~/partials/entity-page/section-title';
+
 import { useTopicSpaceScope } from '../use-topic-space-scope';
+import { TopicClaimCard } from './topic-claim-card';
 import { useTopicLinkedEntities } from './use-topic-linked-entities';
 
 const CLAIMS_PAGE_SIZE = 4;
@@ -45,9 +46,7 @@ export function TopicClaims({ topicId, spaceId }: { topicId: string; spaceId: st
 
   return (
     <section aria-label="Claims on this topic">
-      <Text as="h2" variant="mediumTitle" color="text" className="mb-3 block">
-        Claims
-      </Text>
+      <SectionTitle>Claims</SectionTitle>
       <div className="grid grid-cols-1 gap-3 @[560px]:grid-cols-2">
         {claims.map(claim => (
           <TopicClaimCard key={claim.id} claim={claim} fallbackSpaceId={spaceId} />

--- a/apps/web/core/topics/browse/topic-coverage.tsx
+++ b/apps/web/core/topics/browse/topic-coverage.tsx
@@ -6,13 +6,12 @@ import { CursorPager, useCursorPages } from '~/core/claims/browse/use-cursor-pag
 import type { ExploreFeedItem } from '~/core/explore/explore-card-item';
 import { type SpaceLabel, spaceLabel, useSpaceLabels } from '~/core/hooks/use-space-labels';
 
-import { useTopicSpaceScope } from '../use-topic-space-scope';
-
 import { Skeleton } from '~/design-system/skeleton';
-import { Text } from '~/design-system/text';
 
+import { SectionTitle } from '~/partials/entity-page/section-title';
 import { ExploreFeedCard } from '~/partials/explore/explore-feed-card';
 
+import { useTopicSpaceScope } from '../use-topic-space-scope';
 import { useTopicCoverage } from './use-topic-coverage';
 
 const COVERAGE_PAGE_SIZE = 8;
@@ -70,9 +69,7 @@ export function TopicCoverage({ topicId, spaceId }: { topicId: string; spaceId: 
 
   return (
     <section aria-label="Coverage">
-      <Text as="h2" variant="mediumTitle" color="text" className="mb-3 block">
-        Coverage
-      </Text>
+      <SectionTitle>Coverage</SectionTitle>
       {/* Cards as direct siblings, exactly as the feed renders them: their bottom rule is a
           `last:border-b-0` on the card itself, so a wrapper around each one would leave a rule
           hanging under the final row.

--- a/apps/web/core/topics/browse/topic-debates.tsx
+++ b/apps/web/core/topics/browse/topic-debates.tsx
@@ -20,7 +20,8 @@ import { useQueryEntities } from '~/core/sync/use-store';
 import { resolveEntitySpaceId } from '~/core/utils/space/entity-home-space';
 
 import { Skeleton } from '~/design-system/skeleton';
-import { Text } from '~/design-system/text';
+
+import { SectionTitle } from '~/partials/entity-page/section-title';
 
 import { useTopicSpaceScope } from '../use-topic-space-scope';
 import { useTopicLinkedEntities } from './use-topic-linked-entities';
@@ -153,9 +154,7 @@ export function TopicDebates({ topicId, spaceId }: { topicId: string; spaceId: s
 
   return (
     <section aria-label="Debates on this topic">
-      <Text as="h2" variant="mediumTitle" color="text" className="mb-3 block">
-        Debates
-      </Text>
+      <SectionTitle>Debates</SectionTitle>
       <ul className="m-0 flex list-none flex-col gap-2 p-0">
         {debates.map(debate => (
           <li key={debate.id}>

--- a/apps/web/core/topics/browse/topic-page-view.test.tsx
+++ b/apps/web/core/topics/browse/topic-page-view.test.tsx
@@ -5,12 +5,16 @@ import type React from 'react';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { SUBTOPIC_RELATION_TYPE_ID } from '~/core/constants';
+
 import { TopicPageView } from './topic-page-view';
 
 const mocks = vi.hoisted(() => ({
   entity: null as Record<string, unknown> | null,
   /** Props the description's clamp received, or null if it rendered no clamp at all. */
   clamp: null as Record<string, unknown> | null,
+  /** Props the chip section received, or null if the page rendered none. */
+  chipSection: null as Record<string, unknown> | null,
   /**
    * Deliberately not 3.
    *
@@ -33,6 +37,16 @@ vi.mock('~/design-system/clamped-text', () => ({
   ClampedText: (props: Record<string, unknown>) => {
     mocks.clamp = props;
     return <p data-testid="clamped-description">{props.text as string}</p>;
+  },
+}));
+
+// The section moved out of this file in GEO-2781 and is shared with the claim view. Its own suite
+// covers the chips and the expander; this only checks that subtopics still reach it unchanged.
+vi.mock('~/partials/entity-page/relation-chip-section', () => ({
+  META_CHIP_CLASS: 'meta-chip',
+  RelationChipSection: (props: Record<string, unknown>) => {
+    mocks.chipSection = props;
+    return <div data-testid="chip-section" data-label={props.label as string} />;
   },
 }));
 
@@ -63,6 +77,7 @@ function topicEntity(description: string | null) {
 beforeEach(() => {
   mocks.entity = topicEntity('A description long enough that the page has something to collapse.');
   mocks.clamp = null;
+  mocks.chipSection = null;
 });
 
 afterEach(cleanup);
@@ -93,5 +108,25 @@ describe('TopicPageView description', () => {
     render(<TopicPageView entityId="topic-1" spaceId="space-1" />);
 
     expect(screen.queryByTestId('clamped-description')).toBeNull();
+  });
+});
+
+// GEO-2781 lifted this section out of this file so the claim view could draw its Topics with it.
+// Extracting a component is where a caller quietly loses an argument, so the subtopics side is
+// pinned too rather than only the new one.
+describe('TopicPageView subtopics', () => {
+  const subtopicRelation = {
+    id: 'relation-1',
+    type: { id: SUBTOPIC_RELATION_TYPE_ID },
+    toEntity: { id: 'subtopic-1', name: 'Alignment' },
+  };
+
+  it('still draws them with the shared chip section, under the label Subtopics', () => {
+    mocks.entity = { ...topicEntity('Anything'), relations: [subtopicRelation] };
+    render(<TopicPageView entityId="topic-1" spaceId="space-1" />);
+
+    expect(screen.getByTestId('chip-section')).toHaveAttribute('data-label', 'Subtopics');
+    expect(mocks.chipSection?.relations).toEqual([subtopicRelation]);
+    expect(mocks.chipSection?.spaceId).toBe('space-1');
   });
 });

--- a/apps/web/core/topics/browse/topic-page-view.tsx
+++ b/apps/web/core/topics/browse/topic-page-view.tsx
@@ -17,6 +17,7 @@ import { Text } from '~/design-system/text';
 
 import { CommentSection } from '~/partials/comments/comments-section';
 import { ENTITY_DESCRIPTION_MAX_LINES } from '~/partials/entity-page/entity-page-inline-description';
+import { META_CHIP_CLASS, RelationChipSection } from '~/partials/entity-page/relation-chip-section';
 
 import { UNNAMED_SUBTOPIC_PROPERTY_ID } from '../ontology';
 import { TopicClaims } from './topic-claims';
@@ -24,11 +25,6 @@ import { TopicComposition } from './topic-composition';
 import { TopicCoverage } from './topic-coverage';
 import { TopicDebates } from './topic-debates';
 import { useTopicAncestors } from './use-topic-ancestors';
-
-/** Subtopic chips shown before the rest collapse into a count. */
-const SUBTOPIC_CHIP_CAP = 8;
-
-const META_CHIP_CLASS = 'flex h-6 max-w-full items-center rounded border border-grey-02 bg-white px-1.5 text-metadata';
 
 /**
  * The browse-mode read view for a Topic.
@@ -162,7 +158,7 @@ export function TopicPageView({ entityId, spaceId }: { entityId: string; spaceId
 
         <TopicComposition topicId={entityId} spaceId={spaceId} />
 
-        <TopicSubtopics subtopics={subtopics} spaceId={spaceId} />
+        <RelationChipSection label="Subtopics" relations={subtopics} spaceId={spaceId} />
 
         <TopicDebates topicId={entityId} spaceId={spaceId} />
 
@@ -173,49 +169,5 @@ export function TopicPageView({ entityId, spaceId }: { entityId: string; spaceId
         <CommentSection entityId={entityId} spaceId={spaceId} />
       </div>
     </div>
-  );
-}
-
-/**
- * Where to go next, high on the page.
- *
- * Chips rather than cards: a topic with fourteen subtopics should cost a line or two, not a screen.
- * Placed directly under the header because on a broad topic the most useful thing a reader can do is
- * narrow — and on a thin one, this is the section that still has something to offer.
- */
-function TopicSubtopics({ subtopics, spaceId }: { subtopics: Relation[]; spaceId: string }) {
-  const [expanded, setExpanded] = React.useState(false);
-
-  if (subtopics.length === 0) return null;
-
-  const visible = expanded ? subtopics : subtopics.slice(0, SUBTOPIC_CHIP_CAP);
-  const hidden = subtopics.length - visible.length;
-
-  return (
-    <section aria-label="Subtopics">
-      <Text as="h2" variant="mediumTitle" color="text" className="mb-3 block">
-        Subtopics
-      </Text>
-      <div className="flex flex-wrap gap-1.5">
-        {visible.map(relation => (
-          <Link
-            key={relation.id}
-            href={NavUtils.toEntity(spaceId, relation.toEntity.id)}
-            className={`${META_CHIP_CLASS} text-text transition-colors hover:border-text`}
-          >
-            <span className="truncate">{relation.toEntity.name ?? relation.toEntity.id}</span>
-          </Link>
-        ))}
-        {hidden > 0 && (
-          <button
-            type="button"
-            onClick={() => setExpanded(true)}
-            className={`${META_CHIP_CLASS} text-grey-04 tabular-nums transition-colors hover:border-text hover:text-text`}
-          >
-            +{hidden}
-          </button>
-        )}
-      </div>
-    </section>
   );
 }

--- a/apps/web/partials/entity-page/relation-chip-section.test.tsx
+++ b/apps/web/partials/entity-page/relation-chip-section.test.tsx
@@ -1,0 +1,83 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+
+import type React from 'react';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { Relation } from '~/core/types';
+import { NavUtils } from '~/core/utils/utils';
+
+import { RelationChipSection } from './relation-chip-section';
+
+vi.mock('~/design-system/prefetch-link', () => ({
+  PrefetchLink: ({ children, href }: { children: React.ReactNode; href: string }) => <a href={href}>{children}</a>,
+}));
+
+function relation(id: string, name: string | null): Relation {
+  return { id, toEntity: { id: `${id}-entity`, name } } as unknown as Relation;
+}
+
+function relations(count: number): Relation[] {
+  return Array.from({ length: count }, (_, index) => relation(`relation-${index}`, `Topic ${index}`));
+}
+
+afterEach(cleanup);
+
+describe('RelationChipSection', () => {
+  it('names the section and its heading with the label it is given', () => {
+    render(<RelationChipSection label="Topics" relations={relations(2)} spaceId="space-1" />);
+
+    expect(screen.getByRole('region', { name: 'Topics' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Topics' })).toBeInTheDocument();
+  });
+
+  it('links each chip to its entity in the space it was given', () => {
+    render(<RelationChipSection label="Topics" relations={[relation('a', 'Ethics')]} spaceId="space-1" />);
+
+    expect(screen.getByRole('link', { name: 'Ethics' })).toHaveAttribute(
+      'href',
+      NavUtils.toEntity('space-1', 'a-entity')
+    );
+  });
+
+  // An unnamed relation still has to be reachable; the id says less than a name but more than a gap.
+  it('falls back to the entity id when a relation has no name', () => {
+    render(<RelationChipSection label="Topics" relations={[relation('a', null)]} spaceId="space-1" />);
+
+    expect(screen.getByRole('link', { name: 'a-entity' })).toBeInTheDocument();
+  });
+
+  it('renders nothing at all when there are no relations', () => {
+    const { container } = render(<RelationChipSection label="Topics" relations={[]} spaceId="space-1" />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  describe('the +N expander', () => {
+    it('stays out of the way while everything fits', () => {
+      render(<RelationChipSection label="Topics" relations={relations(8)} spaceId="space-1" />);
+
+      expect(screen.getAllByRole('link')).toHaveLength(8);
+      expect(screen.queryByRole('button')).toBeNull();
+    });
+
+    it('counts what it is hiding', () => {
+      render(<RelationChipSection label="Topics" relations={relations(11)} spaceId="space-1" />);
+
+      expect(screen.getAllByRole('link')).toHaveLength(8);
+      expect(screen.getByRole('button', { name: '+3' })).toBeInTheDocument();
+    });
+
+    // Expands in place rather than linking away — the section exists to be scanned without
+    // leaving the page.
+    it('reveals the rest in place and then has nothing left to offer', () => {
+      render(<RelationChipSection label="Topics" relations={relations(11)} spaceId="space-1" />);
+
+      fireEvent.click(screen.getByRole('button', { name: '+3' }));
+
+      expect(screen.getAllByRole('link')).toHaveLength(11);
+      expect(screen.queryByRole('button')).toBeNull();
+    });
+  });
+});

--- a/apps/web/partials/entity-page/relation-chip-section.test.tsx
+++ b/apps/web/partials/entity-page/relation-chip-section.test.tsx
@@ -19,7 +19,7 @@ function relation(id: string, name: string | null): Relation {
 }
 
 /** What the expander is called once it says what it reveals — see the component. */
-const EXPANDER_NAME = '+3, show 3 more Topics';
+const EXPANDER_NAME = '+3, show 3 more in Topics';
 
 function relations(count: number): Relation[] {
   return Array.from({ length: count }, (_, index) => relation(`relation-${index}`, `Topic ${index}`));
@@ -84,14 +84,22 @@ describe('RelationChipSection', () => {
     it('says what it reveals, and still answers to what it shows', () => {
       render(<RelationChipSection label="Topics" relations={relations(11)} spaceId="space-1" />);
 
-      const expander = screen.getByRole('button', { name: '+3, show 3 more Topics' });
+      const expander = screen.getByRole('button', { name: '+3, show 3 more in Topics' });
       expect(expander).toHaveTextContent('+3');
+    });
+
+    // `label` is a section name and already plural, so counting with it ("1 more Topics") reads
+    // wrong at exactly one. Naming the section as a place works at every count.
+    it('reads correctly when it is hiding exactly one', () => {
+      render(<RelationChipSection label="Topics" relations={relations(9)} spaceId="space-1" />);
+
+      expect(screen.getByRole('button', { name: '+1, show 1 more in Topics' })).toBeInTheDocument();
     });
 
     it('names itself after the section it belongs to', () => {
       render(<RelationChipSection label="Subtopics" relations={relations(11)} spaceId="space-1" />);
 
-      expect(screen.getByRole('button', { name: '+3, show 3 more Subtopics' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: '+3, show 3 more in Subtopics' })).toBeInTheDocument();
     });
 
     // The button reveals everything and so removes itself, which leaves focus on a detached
@@ -117,7 +125,7 @@ describe('RelationChipSection', () => {
       rerender(<RelationChipSection label="Topics" relations={next} spaceId="space-1" />);
 
       expect(screen.getAllByRole('link')).toHaveLength(8);
-      expect(screen.getByRole('button', { name: '+4, show 4 more Topics' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: '+4, show 4 more in Topics' })).toBeInTheDocument();
     });
 
     // Re-rendering the same entity is not navigation; a parent re-render must not shut the section

--- a/apps/web/partials/entity-page/relation-chip-section.test.tsx
+++ b/apps/web/partials/entity-page/relation-chip-section.test.tsx
@@ -18,6 +18,9 @@ function relation(id: string, name: string | null): Relation {
   return { id, toEntity: { id: `${id}-entity`, name } } as unknown as Relation;
 }
 
+/** What the expander is called once it says what it reveals — see the component. */
+const EXPANDER_NAME = '+3, show 3 more Topics';
+
 function relations(count: number): Relation[] {
   return Array.from({ length: count }, (_, index) => relation(`relation-${index}`, `Topic ${index}`));
 }
@@ -66,13 +69,29 @@ describe('RelationChipSection', () => {
       render(<RelationChipSection label="Topics" relations={relations(11)} spaceId="space-1" />);
 
       expect(screen.getAllByRole('link')).toHaveLength(8);
-      expect(screen.getByRole('button', { name: '+3' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: EXPANDER_NAME })).toBeInTheDocument();
     });
 
     it('marks itself as collapsed while it is hiding something', () => {
       render(<RelationChipSection label="Topics" relations={relations(11)} spaceId="space-1" />);
 
-      expect(screen.getByRole('button', { name: '+3' })).toHaveAttribute('aria-expanded', 'false');
+      expect(screen.getByRole('button', { name: EXPANDER_NAME })).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    // `+3` on its own is a number with no subject: a screen reader listing the page's buttons would
+    // announce it and nothing about what it opens. The visible text still leads the name, which is
+    // what keeps the control addressable by voice.
+    it('says what it reveals, and still answers to what it shows', () => {
+      render(<RelationChipSection label="Topics" relations={relations(11)} spaceId="space-1" />);
+
+      const expander = screen.getByRole('button', { name: '+3, show 3 more Topics' });
+      expect(expander).toHaveTextContent('+3');
+    });
+
+    it('names itself after the section it belongs to', () => {
+      render(<RelationChipSection label="Subtopics" relations={relations(11)} spaceId="space-1" />);
+
+      expect(screen.getByRole('button', { name: '+3, show 3 more Subtopics' })).toBeInTheDocument();
     });
 
     // The button reveals everything and so removes itself, which leaves focus on a detached
@@ -81,7 +100,7 @@ describe('RelationChipSection', () => {
     it('moves focus to the first revealed chip rather than losing it', () => {
       render(<RelationChipSection label="Topics" relations={relations(11)} spaceId="space-1" />);
 
-      fireEvent.click(screen.getByRole('button', { name: '+3' }));
+      fireEvent.click(screen.getByRole('button', { name: EXPANDER_NAME }));
 
       expect(screen.getByRole('link', { name: 'Topic 8' })).toHaveFocus();
     });
@@ -91,7 +110,7 @@ describe('RelationChipSection', () => {
     it('reveals the rest in place and then has nothing left to offer', () => {
       render(<RelationChipSection label="Topics" relations={relations(11)} spaceId="space-1" />);
 
-      fireEvent.click(screen.getByRole('button', { name: '+3' }));
+      fireEvent.click(screen.getByRole('button', { name: EXPANDER_NAME }));
 
       expect(screen.getAllByRole('link')).toHaveLength(11);
       expect(screen.queryByRole('button')).toBeNull();

--- a/apps/web/partials/entity-page/relation-chip-section.test.tsx
+++ b/apps/web/partials/entity-page/relation-chip-section.test.tsx
@@ -105,6 +105,33 @@ describe('RelationChipSection', () => {
       expect(screen.getByRole('link', { name: 'Topic 8' })).toHaveFocus();
     });
 
+    // The route does not remount these views on navigation, so following a chip from one entity to
+    // the next reuses this component. An expansion carried across would render the next entity's
+    // chips with no cap at all — and following a chip is exactly what this section is for.
+    it('collapses again when it is pointed at a different entity', () => {
+      const { rerender } = render(<RelationChipSection label="Topics" relations={relations(11)} spaceId="space-1" />);
+      fireEvent.click(screen.getByRole('button', { name: EXPANDER_NAME }));
+      expect(screen.getAllByRole('link')).toHaveLength(11);
+
+      const next = Array.from({ length: 12 }, (_, index) => relation(`other-${index}`, `Other ${index}`));
+      rerender(<RelationChipSection label="Topics" relations={next} spaceId="space-1" />);
+
+      expect(screen.getAllByRole('link')).toHaveLength(8);
+      expect(screen.getByRole('button', { name: '+4, show 4 more Topics' })).toBeInTheDocument();
+    });
+
+    // Re-rendering the same entity is not navigation; a parent re-render must not shut the section
+    // the viewer just opened.
+    it('stays open across a re-render of the same relations', () => {
+      const same = relations(11);
+      const { rerender } = render(<RelationChipSection label="Topics" relations={same} spaceId="space-1" />);
+      fireEvent.click(screen.getByRole('button', { name: EXPANDER_NAME }));
+
+      rerender(<RelationChipSection label="Topics" relations={[...same]} spaceId="space-1" />);
+
+      expect(screen.getAllByRole('link')).toHaveLength(11);
+    });
+
     // Expands in place rather than linking away — the section exists to be scanned without
     // leaving the page.
     it('reveals the rest in place and then has nothing left to offer', () => {

--- a/apps/web/partials/entity-page/relation-chip-section.test.tsx
+++ b/apps/web/partials/entity-page/relation-chip-section.test.tsx
@@ -69,6 +69,23 @@ describe('RelationChipSection', () => {
       expect(screen.getByRole('button', { name: '+3' })).toBeInTheDocument();
     });
 
+    it('marks itself as collapsed while it is hiding something', () => {
+      render(<RelationChipSection label="Topics" relations={relations(11)} spaceId="space-1" />);
+
+      expect(screen.getByRole('button', { name: '+3' })).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    // The button reveals everything and so removes itself, which leaves focus on a detached
+    // element and drops it to `<body>`. A keyboard viewer would have to tab from the top of the
+    // page to reach the chips they just asked to see.
+    it('moves focus to the first revealed chip rather than losing it', () => {
+      render(<RelationChipSection label="Topics" relations={relations(11)} spaceId="space-1" />);
+
+      fireEvent.click(screen.getByRole('button', { name: '+3' }));
+
+      expect(screen.getByRole('link', { name: 'Topic 8' })).toHaveFocus();
+    });
+
     // Expands in place rather than linking away — the section exists to be scanned without
     // leaving the page.
     it('reveals the rest in place and then has nothing left to offer', () => {

--- a/apps/web/partials/entity-page/relation-chip-section.tsx
+++ b/apps/web/partials/entity-page/relation-chip-section.tsx
@@ -87,6 +87,12 @@ export function RelationChipSection({
           <button
             type="button"
             aria-expanded={false}
+            // `+3` alone is the whole accessible name without this, so a screen reader listing the
+            // page's buttons announces a number and nothing about what it reveals. The visible text
+            // leads the label rather than being replaced by it: WCAG's Label in Name asks that what
+            // a control is called contains what it says, so "+3" still has to be in there for
+            // anyone driving the page by voice.
+            aria-label={`+${hidden}, show ${hidden} more ${label}`}
             onClick={() => {
               focusAfterExpandRef.current = true;
               setExpanded(true);

--- a/apps/web/partials/entity-page/relation-chip-section.tsx
+++ b/apps/web/partials/entity-page/relation-chip-section.tsx
@@ -56,6 +56,23 @@ export function RelationChipSection({
   // and not on mount.
   const focusAfterExpandRef = React.useRef(false);
 
+  // Collapse again when the section is pointed at a different entity.
+  //
+  // Not paranoia about a case that cannot happen: the route path does not remount these views on
+  // navigation. `default-entity-page` renders `EntityPageBody` unkeyed, so following a chip from
+  // one topic to the next — the whole point of this section — reuses this component, and an
+  // expansion left over from the previous entity would render the next one's chips uncapped. The
+  // side panel escapes it only because `EntitySidePanelBody` is keyed on the entity; the route is
+  // not, and the route is where the chips lead.
+  //
+  // Keyed on the relation ids rather than the array, which is a fresh reference on every render.
+  // Same shape as `ClampedText`, which collapses its own toggle when its text changes.
+  const relationIds = relations.map(relation => relation.id).join('|');
+  React.useLayoutEffect(() => {
+    setExpanded(false);
+    focusAfterExpandRef.current = false;
+  }, [relationIds]);
+
   // The `+N` removes itself by revealing everything, which leaves focus on a detached button and
   // the browser drops it to `<body>`. A keyboard viewer would then have to tab from the top of the
   // page to reach the very chips they just asked to see, so send them to the first of them.

--- a/apps/web/partials/entity-page/relation-chip-section.tsx
+++ b/apps/web/partials/entity-page/relation-chip-section.tsx
@@ -6,7 +6,8 @@ import type { Relation } from '~/core/types';
 import { NavUtils } from '~/core/utils/utils';
 
 import { PrefetchLink as Link } from '~/design-system/prefetch-link';
-import { Text } from '~/design-system/text';
+
+import { SectionTitle } from '~/partials/entity-page/section-title';
 
 /**
  * The small bordered chip the custom entity views label things with — a topic's type, a claim's
@@ -58,9 +59,7 @@ export function RelationChipSection({
 
   return (
     <section aria-label={label}>
-      <Text as="h2" variant="mediumTitle" color="text" className="mb-3 block">
-        {label}
-      </Text>
+      <SectionTitle>{label}</SectionTitle>
       <div className="flex flex-wrap gap-1.5">
         {visible.map(relation => (
           <Link

--- a/apps/web/partials/entity-page/relation-chip-section.tsx
+++ b/apps/web/partials/entity-page/relation-chip-section.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import * as React from 'react';
+
+import type { Relation } from '~/core/types';
+import { NavUtils } from '~/core/utils/utils';
+
+import { PrefetchLink as Link } from '~/design-system/prefetch-link';
+import { Text } from '~/design-system/text';
+
+/**
+ * The small bordered chip the custom entity views label things with — a topic's type, a claim's
+ * tags, and every chip in {@link RelationChipSection}.
+ *
+ * One definition. The claim view and the topic view each carried a byte-identical copy of this
+ * string, which is how the two drifted apart in the first place.
+ */
+export const META_CHIP_CLASS =
+  'flex h-6 max-w-full items-center rounded border border-grey-02 bg-white px-1.5 text-metadata';
+
+/**
+ * How many chips show before the rest collapse behind a `+N`.
+ *
+ * Eight, which is what the topic view's subtopics have always used. The claim view's topics used to
+ * cap at three, but that number was chosen for a run of chips squeezed into the header's meta row
+ * beside the type — as a section of its own there is room, and the two answer the same question.
+ */
+const CHIP_CAP = 8;
+
+/**
+ * A labelled row of entity chips with a `+N` that reveals the rest.
+ *
+ * Chips rather than cards: fourteen of these should cost a line or two, not a screen. `+N` expands
+ * in place rather than linking somewhere, because the whole point of the section is to be scanned
+ * without leaving the page.
+ *
+ * Generic over the relation it draws (GEO-2781). It began as the topic view's Subtopics and is now
+ * the claim view's Topics as well — different relations, same question for the reader ("what else
+ * is this about, and where can I go next"), so they get the same answer rather than two that look
+ * alike until one of them changes.
+ */
+export function RelationChipSection({
+  label,
+  relations,
+  spaceId,
+}: {
+  /** Also the section's accessible name, so the two can never disagree. */
+  label: string;
+  relations: Relation[];
+  spaceId: string;
+}) {
+  const [expanded, setExpanded] = React.useState(false);
+
+  if (relations.length === 0) return null;
+
+  const visible = expanded ? relations : relations.slice(0, CHIP_CAP);
+  const hidden = relations.length - visible.length;
+
+  return (
+    <section aria-label={label}>
+      <Text as="h2" variant="mediumTitle" color="text" className="mb-3 block">
+        {label}
+      </Text>
+      <div className="flex flex-wrap gap-1.5">
+        {visible.map(relation => (
+          <Link
+            key={relation.id}
+            href={NavUtils.toEntity(spaceId, relation.toEntity.id)}
+            className={`${META_CHIP_CLASS} text-text transition-colors hover:border-text`}
+          >
+            <span className="truncate">{relation.toEntity.name ?? relation.toEntity.id}</span>
+          </Link>
+        ))}
+        {hidden > 0 && (
+          <button
+            type="button"
+            onClick={() => setExpanded(true)}
+            className={`${META_CHIP_CLASS} text-grey-04 tabular-nums transition-colors hover:border-text hover:text-text`}
+          >
+            +{hidden}
+          </button>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/partials/entity-page/relation-chip-section.tsx
+++ b/apps/web/partials/entity-page/relation-chip-section.tsx
@@ -51,6 +51,19 @@ export function RelationChipSection({
   spaceId: string;
 }) {
   const [expanded, setExpanded] = React.useState(false);
+  const chipsRef = React.useRef<HTMLDivElement>(null);
+  // Only when the viewer asked for it — not on a section that renders expanded for another reason,
+  // and not on mount.
+  const focusAfterExpandRef = React.useRef(false);
+
+  // The `+N` removes itself by revealing everything, which leaves focus on a detached button and
+  // the browser drops it to `<body>`. A keyboard viewer would then have to tab from the top of the
+  // page to reach the very chips they just asked to see, so send them to the first of them.
+  React.useEffect(() => {
+    if (!expanded || !focusAfterExpandRef.current) return;
+    focusAfterExpandRef.current = false;
+    chipsRef.current?.querySelectorAll<HTMLAnchorElement>('a')[CHIP_CAP]?.focus();
+  }, [expanded]);
 
   if (relations.length === 0) return null;
 
@@ -60,7 +73,7 @@ export function RelationChipSection({
   return (
     <section aria-label={label}>
       <SectionTitle>{label}</SectionTitle>
-      <div className="flex flex-wrap gap-1.5">
+      <div ref={chipsRef} className="flex flex-wrap gap-1.5">
         {visible.map(relation => (
           <Link
             key={relation.id}
@@ -73,7 +86,11 @@ export function RelationChipSection({
         {hidden > 0 && (
           <button
             type="button"
-            onClick={() => setExpanded(true)}
+            aria-expanded={false}
+            onClick={() => {
+              focusAfterExpandRef.current = true;
+              setExpanded(true);
+            }}
             className={`${META_CHIP_CLASS} text-grey-04 tabular-nums transition-colors hover:border-text hover:text-text`}
           >
             +{hidden}

--- a/apps/web/partials/entity-page/relation-chip-section.tsx
+++ b/apps/web/partials/entity-page/relation-chip-section.tsx
@@ -109,7 +109,12 @@ export function RelationChipSection({
             // leads the label rather than being replaced by it: WCAG's Label in Name asks that what
             // a control is called contains what it says, so "+3" still has to be in there for
             // anyone driving the page by voice.
-            aria-label={`+${hidden}, show ${hidden} more ${label}`}
+            //
+            // "more in Topics" rather than "more Topics", which needs `label` to be a count noun it
+            // can pluralise — it is a section name and already plural, so a single hidden chip read
+            // as "show 1 more Topics". Naming the section as a place instead of a quantity is right
+            // at every count and needs no plural rule.
+            aria-label={`+${hidden}, show ${hidden} more in ${label}`}
             onClick={() => {
               focusAfterExpandRef.current = true;
               setExpanded(true);

--- a/apps/web/partials/entity-page/section-title.test.tsx
+++ b/apps/web/partials/entity-page/section-title.test.tsx
@@ -1,0 +1,35 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { textStyles } from '~/design-system/theme/typography';
+
+import { SectionTitle } from './section-title';
+
+afterEach(cleanup);
+
+describe('SectionTitle', () => {
+  it('renders a heading, so the sections sit under the page title in the outline', () => {
+    render(<SectionTitle>Related claims</SectionTitle>);
+
+    expect(screen.getByRole('heading', { level: 2, name: 'Related claims' })).toBeInTheDocument();
+  });
+
+  // The size the comments section uses, which is what every other section is matched to. Asserted
+  // through the typography table rather than against a literal class, so renaming the token moves
+  // this with it instead of leaving a test that passes on a class nobody emits any more.
+  it('uses the same type token as the comments heading', () => {
+    render(<SectionTitle>Related claims</SectionTitle>);
+
+    expect(screen.getByRole('heading', { name: 'Related claims' })).toHaveClass(textStyles.mediumTitle);
+  });
+
+  it('keeps its own spacing while allowing a caller to add to it', () => {
+    render(<SectionTitle className="mt-4">Related claims</SectionTitle>);
+
+    const heading = screen.getByRole('heading', { name: 'Related claims' });
+    expect(heading).toHaveClass('mb-3');
+    expect(heading).toHaveClass('mt-4');
+  });
+});

--- a/apps/web/partials/entity-page/section-title.tsx
+++ b/apps/web/partials/entity-page/section-title.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+
+import cx from 'classnames';
+
+import { Text } from '~/design-system/text';
+
+/**
+ * The heading over a section of a custom entity view.
+ *
+ * One component rather than the token repeated per section, because "every section on this page is
+ * titled the same way" is a rule and a repeated `variant="mediumTitle"` is only a coincidence that
+ * has held so far. The claim view had three sections at two different sizes before this.
+ *
+ * `mediumTitle` is the comments section's size, which is the one every other section is matched to:
+ * comments appear under every entity, custom view or not, so it is the heading a reader has already
+ * seen by the time they reach one of these pages.
+ *
+ * An `h2` because these sit under the page's `h1`. `CommentSection` still draws its own as a `div`
+ * with the class — same size, weaker semantics — and is not changed here: it renders on every
+ * entity page, so moving it is a wider change than the surface this belongs to.
+ */
+export function SectionTitle({ children, className }: { children: React.ReactNode; className?: string }) {
+  return (
+    <Text as="h2" variant="mediumTitle" color="text" className={cx('mb-3 block', className)}>
+      {children}
+    </Text>
+  );
+}


### PR DESCRIPTION
[GEO-2781](https://linear.app/geobrowser/issue/GEO-2781/custom-claim-view-reuse-the-subtopics-ui-for-the-topics-section)

A claim's Topics were a run of chips squeezed into the right half of the header's meta row, capped at three, with a `+N` that only counted. A topic's Subtopics were a proper section: heading, full-width chips, and a `+N` that expands. Two answers to the same reader question — *what else is this about, and where can I go next* — that looked alike until one of them changed.

Extracted the subtopics section into `partials/entity-page/relation-chip-section.tsx` and pointed both views at it, rather than restyling the claim to match.

## Answers to the ticket's four questions

**"Confirm it takes the relation as input rather than assuming one."** It did — `subtopics: Relation[]` was already a plain list. The only thing hardcoded was the label, in two places (the `<h2>` and `aria-label="Subtopics"`). That's now a single `label` prop feeding both, so the heading and the accessible name can't disagree.

**"Confirm the section keeps the label Topics."** It does. `<RelationChipSection label="Topics" …>`, and there's a test asserting exactly that.

**"Behavior beyond display?"** One thing: the `+N` is a button that expands in place. That carries over, and is an upgrade for claims — theirs was a dead `<span>` that counted hidden topics and offered no way to see them. No add/remove in edit mode on either side, so nothing else to decide.

**"Reuse rather than restyle."** Done, and it turned up a second copy worth folding in: `META_CHIP_CLASS` was defined **byte-identically in both files**. That's how the two drifted apart in the first place, so it moves into the shared module and both import it.

## Three knock-on decisions worth your eye

**Cap goes 3 → 8** on claims, the number subtopics already used. Three was chosen for chips competing for half a header row; a section of its own has the room, and `+N` now expands rather than dead-ending.

**Placement: directly under the header**, before the verdict — where the topic view puts its own. On a claim, the thing worth offering before the argument itself is somewhere else to take it. This does push the verdict down by roughly a heading plus a chip row. The ticket didn't specify placement, so this is the most defensible mirror of the topic view rather than a settled call — easy to move below `ClaimVerdict` if you'd rather the verdict stay first.

**The meta row loses `justify-between`** and its right-hand group. With topics gone it has one job and no longer has to survive being squeezed from both ends in the side panel.

## Also in this PR: one heading style for every section

Requested separately while this was in review, and kept here because it lands on the same two views and shares the extraction.

The claim view titled its sections three different ways. They are now all the comments section's `mediumTitle`, via a `SectionTitle` component:

| Section | Was | Now |
|---|---|---|
| Topics | `mediumTitle` | unchanged |
| Your position | `metadataMedium` div, grey-04 | `mediumTitle` h2 |
| Debates on this claim | `smallTitle` | `mediumTitle` |
| Related claims | `smallTitle` | `mediumTitle` |
| Comments *(the reference)* | `mediumTitle` | unchanged |

`ClaimVerdict` and `ClaimProvenance` have no visible title, only an `aria-label`, so there was nothing to restyle; no titles were added.

The topic view's `Claims`, `Debates` and `Coverage` headings adopt the component too. Those were already `mediumTitle` with identical weight and spacing, so that part is a pure refactor with no visual change — it just stops three more copies of the markup from drifting.

**This is a material visual change and it is not browser-verified.** Two specific things to look at, both open:

1. **`mediumTitle` is 1.5rem, and the claim's own `h1` is also 1.5rem below a 560px container** — so in the side panel and on a phone, section headings render the same size as the page title. `smallTitle` used to be a clear step down. The topic view does not have this problem because its `h1` is `mainPage` at 2.75rem; the claim's much smaller `h1` is the outlier between the two custom views. Raising the claim `h1` (`largeTitle`, 2rem) would restore the hierarchy without the 2.75rem that would read badly on a claim, which is a full sentence — but that is a change to the hero and is not made here.
2. **"Your position" is now a 24px heading while the `ClaimVerdict` card directly above it still has no visible title**, so the two stacked cards read as different components. Either the verdict gains a title or "Your position" goes back to a label.

Happy to split this half into its own PR if the extraction should land on its own.

## Testing

`relation-chip-section.test.tsx` is new — 7 cases on the component itself: label drives both the heading and the region name, chips link into the given space, unnamed relations fall back to the id, empty renders nothing, and the expander stays hidden at 8, counts correctly at 11, and reveals the rest in place.

Both call sites are pinned separately, because extracting a component is exactly where a caller quietly loses an argument:

- claim view — label is `Topics`, receives the topic relations and the viewing space, and does **not** receive the tags that share the header row
- topic view — still passes its subtopics, still labelled `Subtopics`

Verified by reverting each: passing `tags` instead of `topics` fails 2, changing the label fails 1, dropping the topic view's relations fails 1.

`vitest run core/claims core/topics partials/entity-page design-system`: 156 passed. `tsc --noEmit`: 5 errors, all pre-existing on master in unrelated test files. prettier clean.

## Worth a look

**Not verified in a browser.** This is a visible layout change on two surfaces — worth looking at a claim with many topics and one with none, in both the route view and the side panel.

**One pre-existing lint warning left alone**, same as #2326: `TOPICS_PROPERTY_ID` is imported and unused at `topic-page-view.tsx:5`. It warns on clean master, so it isn't from this change. Say the word and I'll sweep it.

**Sequencing:** GEO-2781 is one of five Urgent tickets reshaping these two views (with GEO-2778, GEO-2779, GEO-2780 and the shipped GEO-2772). This one adds the first genuinely shared module between them, which should make the rest cheaper — but they'll all touch these files, so merge order will matter.
