### PR TITLE
fix(debates): report when the recorder actually starts, so the clock can wait for it (GEO-2644)

### DIFF
--- a/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
@@ -30,6 +30,7 @@ const mocks = vi.hoisted(() => ({
   mediaRecorderStart: vi.fn(),
   mediaRecorderConstruct: vi.fn(),
   readyMutateAsync: vi.fn(),
+  capturingMutateAsync: vi.fn().mockResolvedValue(undefined),
   liveKitJoinMutateAsync: vi.fn(),
   markJoinedMutateAsync: vi.fn(),
   createLocalTracks: vi.fn(),
@@ -108,6 +109,7 @@ vi.mock('~/core/debates/hooks', () => ({
   useLiveKitJoin: () => ({ mutateAsync: mocks.liveKitJoinMutateAsync, isPending: false }),
   useMarkDebateJoined: () => ({ mutateAsync: mocks.markJoinedMutateAsync, isPending: false }),
   useMarkDebateReady: () => ({ mutateAsync: mocks.readyMutateAsync, isPending: false }),
+  useMarkDebateCapturing: () => ({ mutateAsync: mocks.capturingMutateAsync, isPending: false }),
 }));
 
 vi.mock('~/core/debates/recording-upload-queue', () => ({

--- a/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.tsx
@@ -18,7 +18,6 @@ import {
   getServerTime,
 } from '~/core/debates/api';
 import { DebatePreScreen } from '~/core/debates/debate-pre-join-screen';
-import { usePrefetchClaimSpaceAllowlist } from '~/core/debates/use-prefetch-claim-space-allowlist';
 import { consumeDebateReturnDestination } from '~/core/debates/debate-return-navigation';
 import {
   CameraIcon,
@@ -44,6 +43,7 @@ import {
   useEndDebateTurn,
   useLeaveDebateRematch,
   useLiveKitJoin,
+  useMarkDebateCapturing,
   useMarkDebateJoined,
   useMarkDebateReady,
 } from '~/core/debates/hooks';
@@ -65,6 +65,7 @@ import {
 } from '~/core/debates/recording-upload-queue';
 import { createLocalServerClock, synchronizeServerClock } from '~/core/debates/server-clock';
 import { useSetThankingDebate } from '~/core/debates/thanking-debate-store';
+import { usePrefetchClaimSpaceAllowlist } from '~/core/debates/use-prefetch-claim-space-allowlist';
 import { ExtendedReconnectPolicy } from '~/core/livekit/extended-reconnect-policy';
 import { useFeatureFlag } from '~/core/state/feature-flags';
 
@@ -231,6 +232,7 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
   const liveKitJoin = useLiveKitJoin(debateId);
   const markJoined = useMarkDebateJoined(debateId);
   const markReady = useMarkDebateReady(debateId);
+  const markCapturing = useMarkDebateCapturing(debateId);
   const abortDebate = useAbortDebate(debateId);
   const endDebateTurn = useEndDebateTurn(debateId);
   const clearDebateActivity = useClearDebateActivity();
@@ -305,6 +307,10 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
   const connectionFailureRedirectTimerRef = React.useRef<number | null>(null);
   const remoteParticipantRefetchTimerRef = React.useRef<number | null>(null);
   const serverNowRef = React.useRef(serverClock.now);
+  // Held in a ref rather than closed over: `useMutation` returns a fresh object whenever its state
+  // changes, and `startLocalRecorder` feeds an effect that clears and re-arms the capture timers.
+  // Depending on the mutation object directly would churn that effect on every retry.
+  const markCapturingRef = React.useRef<() => void>(() => undefined);
   const preflightEndsAtMsRef = React.useRef<number | null>(null);
   const finalizedDebateRef = React.useRef<string | null>(null);
   const debateExitStartedRef = React.useRef(false);
@@ -361,8 +367,7 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
   // teardown back until the answer is real.
   const rematchSessionStatus = rematchQuery.data?.status ?? null;
   const rematchQueryFailed = (rematchQuery.error ?? null) !== null;
-  const rematchOutcomeResolved =
-    !debate?.rematch_session_id || rematchSessionStatus !== null || rematchQueryFailed;
+  const rematchOutcomeResolved = !debate?.rematch_session_id || rematchSessionStatus !== null || rematchQueryFailed;
   const rematchSurvivesCancellation =
     Boolean(debate?.rematch_session_id) &&
     !rematchQueryFailed &&
@@ -512,7 +517,8 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
 
   React.useEffect(() => {
     serverNowRef.current = serverClock.now;
-  }, [serverClock]);
+    markCapturingRef.current = () => void markCapturing.mutateAsync().catch(() => undefined);
+  }, [markCapturing, serverClock]);
 
   React.useEffect(() => {
     setLocalTrackPreferences(
@@ -645,6 +651,16 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
       'start',
       () => {
         recordingStartedAtRef.current = serverNowRef.current();
+        // GEO-2644. This event is the first instant capture is genuinely underway, and the debate
+        // clock waits on it. `/ready` fires after a camera *preview* exists and `/joined` fires on
+        // room connection, both before LiveKit has published the tracks this recorder consumes —
+        // so the window used to open while one participant was still acquiring a device, costing
+        // 20-50s off the head of their recording, permanently.
+        //
+        // Fire-and-forget: the mutation retries itself, and a failure must not stop a recorder
+        // that is already running. The worst case is the server waiting out its grace, which is
+        // the old behaviour rather than a new one.
+        markCapturingRef.current();
       },
       { once: true }
     );

--- a/apps/web/core/debates/api.ts
+++ b/apps/web/core/debates/api.ts
@@ -1036,6 +1036,27 @@ export async function markDebateReady(
   });
 }
 
+/**
+ * Report that this participant's recorder is producing frames (GEO-2644).
+ *
+ * The debate clock waits on this rather than on `/ready` or `/joined`, both of which fire before a
+ * camera is delivering anything — `/joined` deliberately so, to keep the connecting deadline about
+ * room presence rather than device setup. Called from the `MediaRecorder` `start` event, which is
+ * the first moment capture is genuinely underway.
+ */
+export async function markDebateCapturing(
+  debateId: string,
+  getPrivyIdentityToken: GetPrivyIdentityToken,
+  accountKey: string | null
+) {
+  return geoChatRequest<Debate>(`/debates/${debateId}/capturing`, {
+    method: 'POST',
+    auth: true,
+    getPrivyIdentityToken,
+    accountKey,
+  });
+}
+
 export async function endDebateTurn(
   debateId: string,
   turnIndex: number,

--- a/apps/web/core/debates/hooks.ts
+++ b/apps/web/core/debates/hooks.ts
@@ -55,6 +55,7 @@ import {
   listDebateRematchClaims,
   listDebateSharePrompts,
   listSpaceDebates,
+  markDebateCapturing,
   markDebateJoined,
   markDebateReady,
   rejectDebateChallenge,
@@ -560,6 +561,29 @@ export function useMarkDebateReady(debateId: string) {
     onSuccess: debate => {
       queryClient.setQueryData(debateQueryKeys.debate(debate.id), debate);
       void queryClient.invalidateQueries({ queryKey: debateQueryKeys.debate(debate.id) });
+    },
+  });
+}
+
+/**
+ * Tells the server this participant is genuinely capturing, which is what arms the clock
+ * (GEO-2644).
+ *
+ * Retried, unlike `useMarkDebateReady`. A dropped `/ready` leaves a visible stuck button someone
+ * will press again; a dropped `/capturing` is silent, and its cost is that the debate waits out the
+ * full grace and then starts without this participant's head — the exact failure this replaces. The
+ * request is idempotent server-side, so a retry cannot move the timestamp.
+ */
+export function useMarkDebateCapturing(debateId: string) {
+  const queryClient = useQueryClient();
+  const { accountKey, getPrivyIdentityToken } = useGeoChatAuth();
+
+  return useMutation({
+    mutationFn: () => markDebateCapturing(debateId, getPrivyIdentityToken, accountKey),
+    retry: 3,
+    retryDelay: attempt => Math.min(1_000 * 2 ** attempt, 5_000),
+    onSuccess: debate => {
+      queryClient.setQueryData(debateQueryKeys.debate(debate.id), debate);
     },
   });
 }


### PR DESCRIPTION
Client half of GEO-2644. Server half: **geobrowser/geo-chat#93** — merge that first.

## Why

The debate clock was armed by a timer five seconds after both participants called `/ready`, and nothing checked whether either camera was producing frames. `/ready` fires once a camera *preview* exists; `/joined` fires on room connection. Both are before LiveKit has published the tracks the recorder actually consumes.

So whichever participant was still acquiring a device lost 20–50 seconds off the head of their recording — permanently, since the content was never captured. Measured across the eight debates lost to it, one participant records within 0.2s of the clock and the other starts 21.7–52.2s late, every time. **43% of debates in the last week with real volume.**

## What this does

Reports `POST /debates/{id}/capturing` from the `MediaRecorder` `start` event — the first instant capture is genuinely underway, and already the event that stamps `recordingStartedAtRef`, so both timestamps derive from the same moment. The server then derives the timed window from it.

Three deliberate choices:

**Fire-and-forget, retried 3x with backoff.** A dropped `/ready` leaves a visible stuck button someone presses again; a dropped `/capturing` is silent, and its cost is the debate waiting out the server's grace and then starting without this participant's head — the exact failure this replaces. Idempotent server-side, so retries can't move the timestamp.

**A failure must never stop a recorder that is already running**, hence the swallowed catch.

**The report goes through a ref rather than being closed over.** `useMutation` returns a fresh object whenever its state changes, and `startLocalRecorder` feeds an effect that clears and re-arms the capture timers — depending on the mutation object directly would churn that effect on every retry.

## Testing

83 test files / 1179 tests pass. The room test's hook mock needed the new export added.

Worth saying plainly: this is verified by unit tests and by reasoning about the timestamps, **not** by a real two-participant debate. The failure it fixes only appears with two real cameras racing, so it wants one live debate on testnet — watching that both participants report and that `missing at start` comes back 0 — before it's trusted.