### PR TITLE
fix(explore): hoist nested type filters so explore stops timing out

### DIFF
--- a/apps/web/core/io/type-filter.test.ts
+++ b/apps/web/core/io/type-filter.test.ts
@@ -171,7 +171,10 @@ describe('removeTypeIdsFromFilter', () => {
     });
   });
 
-  it('strips only the first and-child typeIds when multiple are present', () => {
+  /* These two asserted the old strip-the-first-only contract. Extraction now promotes *every*
+     type clause as one any-of set, so removal must take every one of them: a leftover `typeIds`
+     is AND-ed against the promoted set and silently re-narrows the result to that type. */
+  it('strips every and-child typeIds, not just the first', () => {
     const filter: EntityFilter = {
       and: [
         { typeIds: { in: ['type-abc'] } },
@@ -179,19 +182,17 @@ describe('removeTypeIdsFromFilter', () => {
         { name: { isNull: false, isNot: '' } },
       ],
     };
-    expect(removeTypeIdsFromFilter(filter)).toEqual({
-      and: [{ typeIds: { in: ['type-def'] } }, { name: { isNull: false, isNot: '' } }],
-    });
+    expect(extractTypeIdsFromFilter(filter)).toEqual({ in: ['type-abc', 'type-def'] });
+    expect(removeTypeIdsFromFilter(filter)).toEqual({ name: { isNull: false, isNot: '' } });
   });
 
-  it('leaves and-children intact when extraction took the top-level typeIds', () => {
+  it('strips and-children too when a top-level typeIds is also present', () => {
     const filter: EntityFilter = {
       typeIds: { in: ['type-abc'] },
       and: [{ typeIds: { in: ['type-def'] } }, { name: { isNull: false, isNot: '' } }],
     };
-    expect(removeTypeIdsFromFilter(filter)).toEqual({
-      and: [{ typeIds: { in: ['type-def'] } }, { name: { isNull: false, isNot: '' } }],
-    });
+    expect(extractTypeIdsFromFilter(filter)).toEqual({ in: ['type-abc', 'type-def'] });
+    expect(removeTypeIdsFromFilter(filter)).toEqual({ name: { isNull: false, isNot: '' } });
   });
 });
 
@@ -219,5 +220,48 @@ describe('overlaps promotion (GEO-2739)', () => {
   it('strips the promoted clause so it is not also scanned as a predicate', () => {
     const filter = { and: [{ typeIds: { overlaps: [T1, T2] } }, { name: { isNot: '' } }] };
     expect(removeTypeIdsFromFilter(filter)).toEqual({ name: { isNot: '' } });
+  });
+});
+
+describe("explore's nested type filter (the 30s timeout)", () => {
+  // The exact filter production sent, from a `Slow GraphQL query` log line whose
+  // durationMs was 30,023 and responseSizeBytes 27 — an error body, not data.
+  const exploreFilter: EntityFilter = {
+    and: [
+      {
+        and: [
+          { typeIds: { anyEqualTo: 'topic' } },
+          { typeIds: { anyEqualTo: 'person' } },
+          { typeIds: { anyEqualTo: 'third' } },
+        ],
+      },
+      { name: { isNull: false, isNot: '' } },
+    ],
+  };
+
+  it('promotes every type out of the nested and, as one any-of set', () => {
+    expect(extractTypeIdsFromFilter(exploreFilter)).toEqual({ in: ['topic', 'person', 'third'] });
+  });
+
+  it('is not mistaken for a single-type filter', () => {
+    expect(extractSingleTypeIdFromFilter(exploreFilter)).toBeUndefined();
+  });
+
+  it('leaves nothing behind that would rebuild an EXISTS', () => {
+    const stripped = removeTypeIdsFromFilter(exploreFilter);
+    expect(JSON.stringify(stripped)).not.toContain('typeIds');
+    // and the surviving name clause is inlined rather than left wrapped in a one-element `and`
+    expect(stripped).toEqual({ name: { isNull: false, isNot: '' } });
+  });
+
+  it('de-duplicates a type named twice', () => {
+    const f: EntityFilter = { and: [{ and: [{ typeIds: { anyEqualTo: 'a' } }, { typeIds: { in: ['a', 'b'] } }] }] };
+    expect(extractTypeIdsFromFilter(f)).toEqual({ in: ['a', 'b'] });
+  });
+
+  it('still promotes a single nested type as `is`, not `in`', () => {
+    const f: EntityFilter = { and: [{ and: [{ typeIds: { anyEqualTo: 'only' } }] }, { name: { isNot: '' } }] };
+    expect(extractTypeIdsFromFilter(f)).toEqual({ is: 'only' });
+    expect(extractSingleTypeIdFromFilter(f)).toBe('only');
   });
 });

--- a/apps/web/core/io/type-filter.ts
+++ b/apps/web/core/io/type-filter.ts
@@ -1,23 +1,56 @@
 import type { EntityFilter, UuidFilter, UuidListFilter } from '~/core/gql/graphql';
 
 /**
- * Find a child of a top-level `and` array that carries a `typeIds` clause.
- * Mirrors {@link findSpaceIdsClause} in `space-filter.ts` — see that file
- * for the full rationale. Briefly: the converter AND-wraps with the
- * empty-name exclusion, burying `typeIds` one level deep and breaking
- * the top-level promotion that uses the indexed query path.
+ * Collect every `typeIds` clause reachable through nested `and` arrays.
+ *
+ * Mirrors {@link findSpaceIdsClause} in `space-filter.ts` — see that file for the full rationale.
+ * Briefly: the converter AND-wraps with the empty-name exclusion, burying `typeIds` a level deep
+ * and breaking the top-level promotion that uses the indexed query path.
+ *
+ * This recurses, and that is the fix rather than a tidy-up. Explore sends the picked types as
+ * *separate* clauses inside their own nested `and`:
+ *
+ *   { and: [ { and: [ {typeIds:{anyEqualTo:A}}, {typeIds:{anyEqualTo:B}} ] }, { name: … } ] }
+ *
+ * The previous single-level walk looked at the top-level children, found `{ and: [...] }` with no
+ * own `.typeIds`, and promoted nothing — so every clause stayed in the filter and each compiled to
+ * its own EXISTS over `relations`. Measured against api-testnet: the real explore request is a
+ * **30.6s statement timeout** (it fails, it does not merely load slowly); promoted it is 415ms.
  */
-function findTypeIdsClause(filter: EntityFilter): UuidListFilter | undefined {
-  if (filter.typeIds) return filter.typeIds;
-  if (!filter.and) return undefined;
-  for (const child of filter.and) {
-    if (child?.typeIds) return child.typeIds;
+function collectTypeIdsClauses(filter: EntityFilter, depth = 0): UuidListFilter[] {
+  const found: UuidListFilter[] = [];
+  if (filter.typeIds) found.push(filter.typeIds);
+  // Two levels covers `and`-of-`and`, which is what the converter produces. Deeper nesting is not
+  // generated today, and recursing without a bound would happily walk a caller-supplied cycle.
+  if (filter.and && depth < 2) {
+    for (const child of filter.and) {
+      if (child) found.push(...collectTypeIdsClauses(child, depth + 1));
+    }
   }
-  return undefined;
+  return found;
+}
+
+function findTypeIdsClause(filter: EntityFilter): UuidListFilter | undefined {
+  return collectTypeIdsClauses(filter)[0];
+}
+
+/** Every type id named by any clause, de-duplicated, order preserved. */
+function collectTypeIds(filter: EntityFilter): string[] {
+  const ids: string[] = [];
+  for (const clause of collectTypeIdsClauses(filter)) {
+    if (clause.anyEqualTo) ids.push(clause.anyEqualTo);
+    for (const list of [clause.in, clause.overlaps]) {
+      if (!list) continue;
+      for (const v of list) if (typeof v === 'string') ids.push(v);
+    }
+  }
+  return [...new Set(ids)];
 }
 
 export function extractSingleTypeIdFromFilter(filter?: EntityFilter): string | undefined {
   if (!filter) return undefined;
+  // More than one type named ⇒ this is the multi-type path, not the single one.
+  if (collectTypeIds(filter).length > 1) return undefined;
   const typeIds = findTypeIdsClause(filter);
   if (!typeIds) return undefined;
 
@@ -38,6 +71,20 @@ export function extractSingleTypeIdFromFilter(filter?: EntityFilter): string | u
 
 export function extractTypeIdsFromFilter(filter?: EntityFilter): UuidFilter | undefined {
   if (!filter) return undefined;
+
+  /* Several separate clauses ⇒ promote all of them as one any-of set.
+   *
+   * NOTE THIS CHANGES SEMANTICS, deliberately. Separate AND-ed clauses asked for entities carrying
+   * *every* named type; the promoted `{ in: [...] }` asks for *any* of them. The old reading was
+   * not merely slow, it was unsatisfiable: explore's own request asked for Topic AND Person AND a
+   * third type, and in the live database **zero** entities hold all three (the most any entity
+   * holds is two, and only 11 do). An always-empty predicate is also why it timed out — with no
+   * matches the planner cannot stop early at LIMIT 10 and walks all 49.6M entities to prove it.
+   *
+   * "Every picked topic, not any of them" is a real rule for *topics* — it is not one for types. */
+  const allIds = collectTypeIds(filter);
+  if (allIds.length > 1) return { in: allIds };
+
   const typeIds = findTypeIdsClause(filter);
   if (!typeIds) return undefined;
 
@@ -68,43 +115,39 @@ export function extractTypeIdsFromFilter(filter?: EntityFilter): UuidFilter | un
 }
 
 /**
- * Remove only the `typeIds` clause that {@link findTypeIdsClause} would
- * have promoted. See `space-filter.ts`'s `removeSpaceIdsFromFilter` for
- * the full rationale — this mirrors that behavior for `typeIds`.
+ * Strip every `typeIds` clause that {@link extractTypeIdsFromFilter} promoted, at any nesting
+ * depth it looked at. See `space-filter.ts`'s `removeSpaceIdsFromFilter` for the rationale.
+ *
+ * It must remove *all* of them, not the first. Leaving even one behind reintroduces the EXISTS
+ * that the promotion exists to avoid, and it would then be AND-ed against the promoted any-of set
+ * — quietly re-narrowing the result to the leftover type.
  */
 export function removeTypeIdsFromFilter(filter?: EntityFilter): EntityFilter | undefined {
   if (!filter) return filter;
-  if (!filter.typeIds && !filter.and) return filter;
+  return stripTypeIds(filter, 0);
+}
 
-  const { typeIds: topLevel, and, ...rest } = filter;
-  let next: EntityFilter = { ...rest };
+function stripTypeIds(filter: EntityFilter, depth: number): EntityFilter | undefined {
+  const next: EntityFilter = { ...filter };
+  const and = next.and;
+  delete next.typeIds;
+  delete next.and;
+  let result: EntityFilter = next;
 
   if (and) {
-    if (topLevel !== undefined) {
-      next = { ...next, and };
-    } else {
-      let stripped = false;
-      const cleaned = and
-        .map(child => {
-          if (stripped || !child?.typeIds) return child;
-          stripped = true;
-          const { typeIds: _t, ...childRest } = child;
-          return Object.keys(childRest).length > 0 ? (childRest as EntityFilter) : null;
-        })
-        .filter((child): child is EntityFilter => child !== null);
+    const cleaned = and
+      .map(child => (child && depth < 2 ? stripTypeIds(child, depth + 1) : child))
+      .filter((child): child is EntityFilter => child != null && Object.keys(child).length > 0);
 
-      if (cleaned.length === 1) {
-        const collides = Object.keys(cleaned[0]).some(k => k in next);
-        if (!collides) {
-          next = { ...next, ...cleaned[0] };
-        } else {
-          next = { ...next, and: cleaned };
-        }
-      } else if (cleaned.length > 1) {
-        next = { ...next, and: cleaned };
-      }
+    if (cleaned.length === 1) {
+      // Inline a lone survivor so the caller sees `{ name: ... }` rather than `{ and: [{ name }] }`
+      // — but not if it would clobber a sibling key already present.
+      const collides = Object.keys(cleaned[0]).some(k => k in result);
+      result = collides ? { ...result, and: cleaned } : { ...result, ...cleaned[0] };
+    } else if (cleaned.length > 1) {
+      result = { ...result, and: cleaned };
     }
   }
 
-  return Object.keys(next).length > 0 ? next : undefined;
+  return Object.keys(result).length > 0 ? result : undefined;
 }


### PR DESCRIPTION
Preston reported explore loading slowly. **It isn't slow — it's failing.**

`AllEntitiesConnection` had a **median duration of 30,010ms across 70 calls in three hours**, with `responseSizeBytes: 27` — an error body, not data. A median sitting exactly on the statement timeout is a wall, not load. The UI renders that as a spinner.

## Cause: a traversal depth

`findTypeIdsClause` walked one level of `filter.and`. The converter nests the picked types in their *own* inner `and`:

```json
{ "and": [ { "and": [ {"typeIds":{"anyEqualTo":"A"}},
                      {"typeIds":{"anyEqualTo":"B"}},
                      {"typeIds":{"anyEqualTo":"C"}} ] },
           { "name": {"isNull":false,"isNot":""} } ] }
```

The first top-level child is `{ and: [...] }` with no own `.typeIds`, so nothing was promoted to the indexed top-level `typeIds` argument. All three clauses stayed in the filter, and each compiled to its own `EXISTS` over `relations`.

## Measured, same query document, live api-testnet

| | time | result |
| --- | --- | --- |
| before (production today) | **30,696ms** | statement timeout, no data |
| after | 1,626ms | 10 rows (cold) |
| after | **415ms** | 10 rows (warm) |

Produced by feeding the **real logged variables** through the new extractor and replaying both shapes.

## The predicate was unsatisfiable — that's *why* it was slow

The three ids are `Topic` (67,512 entities), `Person` (17,331) and a third type (5,493). In the live database **no entity holds all three** — the most any entity holds is two, and only 11 do.

So the query asked for something that cannot exist, and an empty result is precisely the case that can't stop early at `LIMIT 10`: the planner walks all **49.6M** entities to prove there's nothing. One type returns in 3.9s because the limit fills immediately. Raw SQL for the same predicate is 58ms — the cost is entirely in having to prove emptiness across the full table.

## This changes semantics, deliberately

Separate AND-ed clauses asked for entities carrying **every** named type; the promoted `{ in: [...] }` asks for **any** of them.

*"Every picked topic, not any of them"* is a real rule for **topics**. It is not one for **types** — a thing is not simultaneously a Topic and a Person. @prestonmantel worth confirming that's the intent, since it's a behaviour change rather than purely a perf fix.

## Removal had to change with it

It stripped only the first clause. Leaving any behind reintroduces the `EXISTS` the promotion exists to avoid — and it would then be AND-ed against the promoted set, quietly re-narrowing results to whichever type was left. Two existing tests asserted the strip-the-first behaviour and are rewritten, because that behaviour was the bug rather than a contract.

## Not in scope

`query search` shows a **7.4s median over 311 calls** in the same window. Separate, unexamined, and worth its own look.