### PR TITLE
feat(debates): keep the hub open while browsing, and link a person's name

### DIFF
--- a/apps/web/core/debates/matchmaking/debates-hub-panel.test.tsx
+++ b/apps/web/core/debates/matchmaking/debates-hub-panel.test.tsx
@@ -1,5 +1,6 @@
 import '@testing-library/jest-dom/vitest';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+
 import * as React from 'react';
 
 import { Provider, createStore, useSetAtom } from 'jotai';
@@ -274,9 +275,10 @@ describe('DebatesHubPanel', () => {
   });
 });
 
-// Accepting a request from the Requests tab now walks the viewer into the debate room; the panel
-// would otherwise stay mounted on top of it, covering the pre-screen.
-it('closes itself once a navigation lands', () => {
+// Accepting a request from the Requests tab walks the viewer into the debate room; the panel would
+// otherwise stay mounted on top of it, covering the pre-screen. This is the one navigation that
+// still closes it, and the reason the effect exists at all.
+it('closes itself on the way into a debate room', () => {
   const store = renderOpen('requests');
   expect(screen.getByRole('button', { name: /^Requests/ })).toBeInTheDocument();
 
@@ -284,6 +286,22 @@ it('closes itself once a navigation lands', () => {
   store.rerender();
 
   expect(store.get(debatesHubAtom)).toBeNull();
+});
+
+// GEO-2788. Following a claim out of the Claims tab, or a person out of the People tab, used to
+// shut the list the viewer was working through — so coming back meant reopening the hub, finding
+// the tab and finding their place again. The hub follows them instead.
+it.each([
+  ['a claim or entity page', '/space/space-1/entity-1'],
+  ["a person's space", '/space/person-space-1'],
+  ['the debates feed', '/space/space-1/debates'],
+])('stays open when the viewer navigates to %s', (_label, pathname) => {
+  const store = renderOpen('claims');
+
+  mocks.pathname = pathname;
+  store.rerender();
+
+  expect(store.get(debatesHubAtom)).toEqual({ tab: 'claims' });
 });
 
 // `?modal=debates` reached by client-side navigation opens the hub from the same commit that

--- a/apps/web/core/debates/matchmaking/debates-hub-panel.test.tsx
+++ b/apps/web/core/debates/matchmaking/debates-hub-panel.test.tsx
@@ -8,6 +8,7 @@ import { usePathname } from 'next/navigation';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { GeoChatRequestError } from '../api';
+import { DEBATES_MODAL } from '../debates-panel-deep-link';
 import { DebatesHubPanel } from './debates-hub-panel';
 import { type DebatesHubTab, debatesHubAtom } from '~/atoms';
 
@@ -299,6 +300,31 @@ it.each([
   const store = renderOpen('claims');
 
   mocks.pathname = pathname;
+  store.rerender();
+
+  expect(store.get(debatesHubAtom)).toEqual({ tab: 'claims' });
+});
+
+// Desktop only. On mobile the hub is a full-screen `aria-modal` sheet over a backdrop, so staying
+// open would navigate the page behind an opaque overlay — the tap would appear to do nothing, and
+// the destination would be hidden from assistive tech until the sheet was dismissed by hand.
+it('closes on any navigation on mobile, where it covers the destination', () => {
+  mocks.isMobile = true;
+  const store = renderOpen('claims');
+
+  mocks.pathname = '/space/space-1/entity-1';
+  store.rerender();
+
+  expect(store.get(debatesHubAtom)).toBeNull();
+});
+
+// A link that explicitly asks for the hub still wins, on either layout.
+it('stays open on mobile when the destination itself asks for the hub', () => {
+  mocks.isMobile = true;
+  mocks.searchParams = new URLSearchParams(`modal=${DEBATES_MODAL}`);
+  const store = renderOpen('claims');
+
+  mocks.pathname = '/space/space-1/entity-1';
   store.rerender();
 
   expect(store.get(debatesHubAtom)).toEqual({ tab: 'claims' });

--- a/apps/web/core/debates/matchmaking/debates-hub-panel.tsx
+++ b/apps/web/core/debates/matchmaking/debates-hub-panel.tsx
@@ -95,7 +95,8 @@ export function DebatesHubPanel() {
   // effect, so by the time effects run the answer would depend on which of the two ran first.
   const requestedByLink = requestsModal(useSearchParams(), DEBATES_MODAL);
 
-  // The hub follows the viewer while they browse and stops at the door of a debate (GEO-2788).
+  // The hub follows the viewer while they browse and stops at the door of a debate (GEO-2788),
+  // on the layout where it can — see the mobile branch below.
   //
   // It used to close on every navigation. That made the Claims tab a dead end — following a claim
   // shut the list you were working through — so `hubClosesOnArrivalAt` names the two rooms it must
@@ -114,9 +115,15 @@ export function DebatesHubPanel() {
     // hub should win even where the route would otherwise close it, which is what makes
     // `?modal=debates` a way to open the hub anywhere rather than a way to open it in most places.
     if (requestedByLink) return;
-    if (!hubClosesOnArrivalAt(pathname)) return;
+    // Desktop only. The hub is a companion column there, so the destination is visible beside it —
+    // which is the whole premise of keeping it open. On mobile it is a full-screen `aria-modal`
+    // sheet over a backdrop, so persisting would navigate the page *behind* an opaque overlay:
+    // the viewer taps a claim, nothing appears to happen, and the page they landed on is hidden
+    // from assistive tech until they dismiss the sheet by hand. Closing is what makes the tap
+    // arrive somewhere.
+    if (!isMobile && !hubClosesOnArrivalAt(pathname)) return;
     close();
-  }, [close, pathname, requestedByLink]);
+  }, [close, isMobile, pathname, requestedByLink]);
 
   React.useEffect(() => {
     if (!isOpen) return;

--- a/apps/web/core/debates/matchmaking/debates-hub-panel.tsx
+++ b/apps/web/core/debates/matchmaking/debates-hub-panel.tsx
@@ -19,6 +19,7 @@ import { useDebateActivity, useGeoChatAuth, useUpdateDebateAvailability } from '
 import { ClaimsTab } from './claims-tab';
 import { useDebateRequests, useMatchmakingScope } from './hooks';
 import { HubSwap } from './hub-motion';
+import { hubClosesOnArrivalAt } from './hub-navigation';
 import { HubMessage } from './hub-states';
 import { MatchesTab } from './matches-tab';
 import { PeopleTab } from './people-tab';
@@ -94,9 +95,12 @@ export function DebatesHubPanel() {
   // effect, so by the time effects run the answer would depend on which of the two ran first.
   const requestedByLink = requestsModal(useSearchParams(), DEBATES_MODAL);
 
-  // Anything that navigates has taken the viewer somewhere they asked to go — accepting a request
-  // walks them into the debate room — and the panel would otherwise sit on top of it. Only on a
-  // change: closing on mount would shut the panel the moment it opened.
+  // The hub follows the viewer while they browse and stops at the door of a debate (GEO-2788).
+  //
+  // It used to close on every navigation. That made the Claims tab a dead end — following a claim
+  // shut the list you were working through — so `hubClosesOnArrivalAt` names the two rooms it must
+  // not sit on top of instead, and everywhere else keeps it. Only on a change: closing on mount
+  // would shut the panel the moment it opened.
   React.useEffect(() => {
     if (lastPathnameRef.current === pathname) return;
     lastPathnameRef.current = pathname;
@@ -105,7 +109,12 @@ export function DebatesHubPanel() {
     // link just did. Decided from the render's params rather than from effect order, so the link
     // wins whether this effect runs before or after `DeepLinkHandler`'s — and whether or not the
     // hub was already open when the viewer followed it.
+    //
+    // Kept ahead of the route test rather than folded into it: a link that explicitly asks for the
+    // hub should win even where the route would otherwise close it, which is what makes
+    // `?modal=debates` a way to open the hub anywhere rather than a way to open it in most places.
     if (requestedByLink) return;
+    if (!hubClosesOnArrivalAt(pathname)) return;
     close();
   }, [close, pathname, requestedByLink]);
 

--- a/apps/web/core/debates/matchmaking/hub-navigation.test.ts
+++ b/apps/web/core/debates/matchmaking/hub-navigation.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+
+import { hubClosesOnArrivalAt } from './hub-navigation';
+
+const SPACE = 'space-1';
+
+describe('hubClosesOnArrivalAt', () => {
+  // The two rooms the hub must not sit on top of. Accepting a request walks the viewer straight
+  // into the first of them, which is what the old blanket close existed for.
+  it.each([
+    ['a debate room', `/space/${SPACE}/debates/debate-1`],
+    ['a rematch room', `/space/${SPACE}/debates/rematches/session-1`],
+  ])('closes on arriving at %s', (_label, pathname) => {
+    expect(hubClosesOnArrivalAt(pathname)).toBe(true);
+  });
+
+  // GEO-2788. Everything here is browsing, and closing the hub on any of it is what made the
+  // Claims tab a dead end: following a claim shut the list you were working through.
+  it.each([
+    ['the debates feed', `/space/${SPACE}/debates`],
+    ['a claim or entity page', `/space/${SPACE}/entity-1`],
+    ['a space home page, which is also a profile', `/space/${SPACE}`],
+    ['Explore', '/explore'],
+    ['the root space', '/root'],
+    ['a space community tab', `/space/${SPACE}/community`],
+  ])('stays open on arriving at %s', (_label, pathname) => {
+    expect(hubClosesOnArrivalAt(pathname)).toBe(false);
+  });
+
+  // `/rematches` on its own is not a route. Reading the bare segment as a room would close the hub
+  // on a path that renders nothing.
+  it('does not treat the bare rematches segment as a room', () => {
+    expect(hubClosesOnArrivalAt(`/space/${SPACE}/debates/rematches`)).toBe(false);
+  });
+
+  it('ignores a trailing slash', () => {
+    expect(hubClosesOnArrivalAt(`/space/${SPACE}/debates/debate-1/`)).toBe(true);
+    expect(hubClosesOnArrivalAt(`/space/${SPACE}/debates/`)).toBe(false);
+  });
+
+  // A `debates` segment somewhere other than a space route is not a debate room — the check is
+  // positional rather than a substring match, and this is what says so.
+  it('only reads debates under a space route', () => {
+    expect(hubClosesOnArrivalAt('/debates/debate-1')).toBe(false);
+    expect(hubClosesOnArrivalAt('/explore/debates/debate-1')).toBe(false);
+  });
+});

--- a/apps/web/core/debates/matchmaking/hub-navigation.test.ts
+++ b/apps/web/core/debates/matchmaking/hub-navigation.test.ts
@@ -23,6 +23,10 @@ describe('hubClosesOnArrivalAt', () => {
     ['Explore', '/explore'],
     ['the root space', '/root'],
     ['a space community tab', `/space/${SPACE}/community`],
+    // A sibling of the room, not the room: an ordinary in-layout page showing a published
+    // recording, where the live room is a `fixed inset-0` takeover. A catch-all on "anything under
+    // a debate id" closed the hub here.
+    ['the public recording viewer', `/space/${SPACE}/debates/debate-1/recording`],
   ])('stays open on arriving at %s', (_label, pathname) => {
     expect(hubClosesOnArrivalAt(pathname)).toBe(false);
   });
@@ -31,6 +35,13 @@ describe('hubClosesOnArrivalAt', () => {
   // on a path that renders nothing.
   it('does not treat the bare rematches segment as a room', () => {
     expect(hubClosesOnArrivalAt(`/space/${SPACE}/debates/rematches`)).toBe(false);
+  });
+
+  // Both rooms match at an exact depth, so a sub-route added under either later is a sibling of the
+  // room and keeps the hub, rather than silently inheriting the room's behaviour.
+  it('matches each room at its own depth and no deeper', () => {
+    expect(hubClosesOnArrivalAt(`/space/${SPACE}/debates/debate-1/anything`)).toBe(false);
+    expect(hubClosesOnArrivalAt(`/space/${SPACE}/debates/rematches/session-1/anything`)).toBe(false);
   });
 
   it('ignores a trailing slash', () => {

--- a/apps/web/core/debates/matchmaking/hub-navigation.ts
+++ b/apps/web/core/debates/matchmaking/hub-navigation.ts
@@ -11,9 +11,11 @@
  * them straight into one. A panel sitting over a live debate is the case the old blanket close
  * existed for, and it is the case this keeps.
  *
- * The debates feed at `/space/{id}/debates` is deliberately not in that set. It is a browsing
- * surface, it is where the hub is opened from most often, and closing there would reintroduce the
- * dead end one route down.
+ * The debates feed at `/space/{id}/debates` is deliberately not in that set, and neither is the
+ * public recording viewer at `/debates/{debateId}/recording`. Both are browsing surfaces — the feed
+ * is where the hub is opened from most often, and the recording page is an ordinary page in the
+ * space chrome rather than a takeover. Closing on either would reintroduce the dead end one route
+ * down.
  *
  * Dismissal is unaffected and is what makes a persistent panel reasonable: the navbar toggle,
  * Escape, a click outside on desktop, a drag down on mobile.
@@ -27,13 +29,16 @@ export function hubClosesOnArrivalAt(pathname: string): boolean {
 
   const withinDebates = segments.slice(3);
 
-  // `/space/{id}/debates` — the feed.
-  if (withinDebates.length === 0) return false;
+  // Exact shapes, not a catch-all on "anything under a debate id". `/debates/{debateId}/recording`
+  // is a sibling of the room, and it is a public recording viewer — an ordinary in-layout page like
+  // the feed, not the `fixed inset-0` takeover the room is. A catch-all closed the hub there, which
+  // is the opposite of the rule this function exists to state, and it would have swallowed every
+  // sub-route added under a room from here on.
+  //
+  // `/space/{id}/debates/rematches/{sessionId}` — a rematch room, and only at that exact depth.
+  // `/rematches` alone is not a route, and anything longer is a sibling rather than the room.
+  if (withinDebates[0] === 'rematches') return withinDebates.length === 2;
 
-  // `/space/{id}/debates/rematches/{sessionId}` is a room; `/rematches` alone is not a route, and
-  // treating the bare segment as one would close the hub on a path that renders nothing.
-  if (withinDebates[0] === 'rematches') return withinDebates.length > 1;
-
-  // `/space/{id}/debates/{debateId}` — the room itself.
-  return true;
+  // `/space/{id}/debates/{debateId}` — the room itself. Length zero is the feed.
+  return withinDebates.length === 1;
 }

--- a/apps/web/core/debates/matchmaking/hub-navigation.ts
+++ b/apps/web/core/debates/matchmaking/hub-navigation.ts
@@ -1,0 +1,39 @@
+/**
+ * Whether arriving at this path should close the debates hub (GEO-2788).
+ *
+ * The hub used to close on every navigation, which made it a dead end: the Claims tab exists to be
+ * read, and following a claim from it shut the list you were working through, so coming back meant
+ * reopening the hub, returning to the tab and finding your place again. Same for a person's profile.
+ *
+ * So the rule is inverted — it stays open, and this names the places it must not follow the viewer
+ * into. That is the debate room and the rematch room, and only those: both are full-screen, both
+ * are somewhere the viewer is *doing* something rather than browsing, and accepting a request walks
+ * them straight into one. A panel sitting over a live debate is the case the old blanket close
+ * existed for, and it is the case this keeps.
+ *
+ * The debates feed at `/space/{id}/debates` is deliberately not in that set. It is a browsing
+ * surface, it is where the hub is opened from most often, and closing there would reintroduce the
+ * dead end one route down.
+ *
+ * Dismissal is unaffected and is what makes a persistent panel reasonable: the navbar toggle,
+ * Escape, a click outside on desktop, a drag down on mobile.
+ */
+export function hubClosesOnArrivalAt(pathname: string): boolean {
+  const segments = pathname.split('/').filter(Boolean);
+
+  // Every debate surface lives under a space. Anything else — Explore, an entity, a profile — is
+  // somewhere the hub is welcome.
+  if (segments[0] !== 'space' || segments[2] !== 'debates') return false;
+
+  const withinDebates = segments.slice(3);
+
+  // `/space/{id}/debates` — the feed.
+  if (withinDebates.length === 0) return false;
+
+  // `/space/{id}/debates/rematches/{sessionId}` is a room; `/rematches` alone is not a route, and
+  // treating the bare segment as one would close the hub on a path that renders nothing.
+  if (withinDebates[0] === 'rematches') return withinDebates.length > 1;
+
+  // `/space/{id}/debates/{debateId}` — the room itself.
+  return true;
+}

--- a/apps/web/core/debates/matchmaking/hub-navigation.ts
+++ b/apps/web/core/debates/matchmaking/hub-navigation.ts
@@ -12,10 +12,10 @@
  * existed for, and it is the case this keeps.
  *
  * The debates feed at `/space/{id}/debates` is deliberately not in that set, and neither is the
- * public recording viewer at `/debates/{debateId}/recording`. Both are browsing surfaces — the feed
- * is where the hub is opened from most often, and the recording page is an ordinary page in the
- * space chrome rather than a takeover. Closing on either would reintroduce the dead end one route
- * down.
+ * public recording viewer at `/space/{id}/debates/{debateId}/recording`. Both are browsing
+ * surfaces — the feed is where the hub is opened from most often, and the recording page is an
+ * ordinary page in the space chrome rather than a takeover. Closing on either would reintroduce
+ * the dead end one route down.
  *
  * Dismissal is unaffected and is what makes a persistent panel reasonable: the navbar toggle,
  * Escape, a click outside on desktop, a drag down on mobile.
@@ -29,11 +29,11 @@ export function hubClosesOnArrivalAt(pathname: string): boolean {
 
   const withinDebates = segments.slice(3);
 
-  // Exact shapes, not a catch-all on "anything under a debate id". `/debates/{debateId}/recording`
-  // is a sibling of the room, and it is a public recording viewer — an ordinary in-layout page like
-  // the feed, not the `fixed inset-0` takeover the room is. A catch-all closed the hub there, which
-  // is the opposite of the rule this function exists to state, and it would have swallowed every
-  // sub-route added under a room from here on.
+  // Exact shapes, not a catch-all on "anything under a debate id".
+  // `/space/{id}/debates/{debateId}/recording` is a sibling of the room, and it is a public
+  // recording viewer — an ordinary in-layout page like the feed, not the `fixed inset-0` takeover
+  // the room is. A catch-all closed the hub there, which is the opposite of the rule this function
+  // exists to state, and it would have swallowed every sub-route added under a room from here on.
   //
   // `/space/{id}/debates/rematches/{sessionId}` — a rematch room, and only at that exact depth.
   // `/rematches` alone is not a route, and anything longer is a sibling rather than the room.

--- a/apps/web/core/debates/matchmaking/people-tab.test.tsx
+++ b/apps/web/core/debates/matchmaking/people-tab.test.tsx
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom/vitest';
-import { cleanup, createEvent, fireEvent, render, screen, within } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
 
 import type React from 'react';
 

--- a/apps/web/core/debates/matchmaking/people-tab.test.tsx
+++ b/apps/web/core/debates/matchmaking/people-tab.test.tsx
@@ -23,16 +23,21 @@ const mocks = vi.hoisted(() => ({
   cancelPending: false,
   cancelError: null as Error | null,
   records: new Map<string, unknown>(),
+  /** Every prop set handed to a link this render, so a stray handler is visible. */
+  linkProps: [] as Record<string, unknown>[],
 }));
 
 // The real one reaches for the sync engine and the router; a plain anchor is what the assertions
 // below are about — a real href, and nothing intercepting the click.
 vi.mock('~/design-system/prefetch-link', () => ({
-  PrefetchLink: ({ children, href, className }: { children: React.ReactNode; href: string; className?: string }) => (
-    <a href={href} className={className}>
-      {children}
-    </a>
-  ),
+  PrefetchLink: ({ children, ...props }: { children: React.ReactNode } & Record<string, unknown>) => {
+    mocks.linkProps.push(props);
+    return (
+      <a href={props.href as string} className={props.className as string | undefined}>
+        {children}
+      </a>
+    );
+  },
 }));
 
 vi.mock('../hooks', () => ({
@@ -124,6 +129,7 @@ beforeEach(() => {
   mocks.cancelPending = false;
   mocks.cancelError = null;
   mocks.records = new Map();
+  mocks.linkProps = [];
 });
 
 afterEach(cleanup);
@@ -374,16 +380,20 @@ describe('the person link', () => {
     );
   });
 
-  // A real anchor with nothing intercepting it. An onClick here would take cmd-click, middle click
-  // and "copy link address" out on this surface, which is what GEO-2701 restored.
-  it('leaves the navigation to the browser', () => {
+  // The guarantee is that *we* add no handler of our own. `next/link` underneath does intercept a
+  // plain left click — that is how client-side routing works, and it already honours cmd-click and
+  // middle click. A second handler layered on top is what would break them, which is what GEO-2701
+  // restored, so the absence of one is the thing worth pinning.
+  //
+  // Asserted on the props rather than by dispatching a click: the mock here is a bare anchor, so a
+  // `defaultPrevented` check would only describe the mock and would pass whether or not the real
+  // component ever received a handler.
+  it('adds no click handler of its own to the name', () => {
     render(<PeopleTab />);
-    const link = screen.getByRole('link', { name: 'Arturas' });
 
-    const event = createEvent.click(link);
-    fireEvent(link, event);
-
-    expect(event.defaultPrevented).toBe(false);
+    const nameLink = mocks.linkProps.find(props => props.href === NavUtils.toSpace(PROFILE_SPACE_IDS['user-them']));
+    expect(nameLink).toBeDefined();
+    expect(nameLink).not.toHaveProperty('onClick');
   });
 
   // An anchor to `/space/undefined` looks identical until it is clicked.

--- a/apps/web/core/debates/matchmaking/people-tab.test.tsx
+++ b/apps/web/core/debates/matchmaking/people-tab.test.tsx
@@ -1,7 +1,11 @@
 import '@testing-library/jest-dom/vitest';
-import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import { cleanup, createEvent, fireEvent, render, screen, within } from '@testing-library/react';
+
+import type React from 'react';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { NavUtils } from '~/core/utils/utils';
 
 import type { DebateChallenge, DebatePerson } from '../api';
 
@@ -19,6 +23,16 @@ const mocks = vi.hoisted(() => ({
   cancelPending: false,
   cancelError: null as Error | null,
   records: new Map<string, unknown>(),
+}));
+
+// The real one reaches for the sync engine and the router; a plain anchor is what the assertions
+// below are about — a real href, and nothing intercepting the click.
+vi.mock('~/design-system/prefetch-link', () => ({
+  PrefetchLink: ({ children, href, className }: { children: React.ReactNode; href: string; className?: string }) => (
+    <a href={href} className={className}>
+      {children}
+    </a>
+  ),
 }));
 
 vi.mock('../hooks', () => ({
@@ -58,10 +72,16 @@ vi.mock('~/core/hooks/use-privy-sign-in', () => ({
 
 const { PeopleTab } = await import('./people-tab');
 
+/** A real space id shape. `profile-user-them` is not one, and the profile link is gated on it. */
+const PROFILE_SPACE_IDS: Record<string, string> = {
+  'user-them': '019fedae-72b6-7ab2-927a-df044d57c566',
+  'user-other': '019fedae-72b6-7ab2-927a-df044d57c599',
+};
+
 function person(userId: string, name: string): DebatePerson {
   return {
     user_id: userId,
-    profile_space_id: `profile-${userId}`,
+    profile_space_id: PROFILE_SPACE_IDS[userId] ?? `profile-${userId}`,
     display_name: name,
     avatar_cid: null,
     online: true,
@@ -304,7 +324,7 @@ describe('PeopleTab', () => {
     mocks.authenticated = false;
     mocks.records = new Map([
       [
-        'profile-user-them',
+        PROFILE_SPACE_IDS['user-them'],
         {
           positions: 119,
           debatesArgued: 11,
@@ -339,5 +359,39 @@ describe('PeopleTab', () => {
     render(<PeopleTab />);
 
     expect(screen.getByRole('button', { name: 'In a debate' })).toBeDisabled();
+  });
+});
+
+// GEO-2788 / GEO-2611. The name goes to the person's personal space, and the hub stays open on the
+// way — which is why this needs no click handler and so keeps cmd-click and middle click working.
+describe('the person link', () => {
+  it("points the name at the person's space", () => {
+    render(<PeopleTab />);
+
+    expect(screen.getByRole('link', { name: 'Arturas' })).toHaveAttribute(
+      'href',
+      NavUtils.toSpace(PROFILE_SPACE_IDS['user-them'])
+    );
+  });
+
+  // A real anchor with nothing intercepting it. An onClick here would take cmd-click, middle click
+  // and "copy link address" out on this surface, which is what GEO-2701 restored.
+  it('leaves the navigation to the browser', () => {
+    render(<PeopleTab />);
+    const link = screen.getByRole('link', { name: 'Arturas' });
+
+    const event = createEvent.click(link);
+    fireEvent(link, event);
+
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  // An anchor to `/space/undefined` looks identical until it is clicked.
+  it('leaves the name unlinked when there is no space to point at', () => {
+    mocks.people = [person('user-nospace', 'Nameless')];
+    render(<PeopleTab />);
+
+    expect(screen.getByText('Nameless')).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'Nameless' })).toBeNull();
   });
 });

--- a/apps/web/core/debates/matchmaking/people-tab.tsx
+++ b/apps/web/core/debates/matchmaking/people-tab.tsx
@@ -3,9 +3,11 @@
 import * as React from 'react';
 
 import { usePrivySignIn } from '~/core/hooks/use-privy-sign-in';
+import { NavUtils, validateSpaceId } from '~/core/utils/utils';
 
 import { Avatar } from '~/design-system/avatar';
 import { Input } from '~/design-system/input';
+import { PrefetchLink as Link } from '~/design-system/prefetch-link';
 import { Text } from '~/design-system/text';
 
 import { activeDebate } from '../activity-state';
@@ -166,6 +168,7 @@ function PersonRow({
   onRequireSignIn?: () => void;
 }) {
   const createChallenge = useCreateDebateChallenge();
+  const profileHref = validateSpaceId(person.profile_space_id) ? NavUtils.toSpace(person.profile_space_id) : null;
 
   return (
     // Three columns rather than a flex run, so the button sits in its own track instead of sharing a
@@ -177,9 +180,24 @@ function PersonRow({
         <Avatar avatarUrl={person.avatar_cid} value={person.profile_space_id} size={32} />
       </div>
       <div className="flex min-w-0 flex-col gap-0.5">
-        <Text as="p" variant="metadataMedium" className="truncate">
-          {speakerLabel(person)}
-        </Text>
+        {/* The name goes to their personal space, which is the profile page GEO-2611 settled on.
+            A plain anchor, with no click handler at all: the hub survives the navigation on its
+            own now (GEO-2788), so there is nothing to intercept — which is also what keeps
+            cmd-click, middle click and "copy link address" working here (GEO-2701).
+
+            Unlinked when the id is not a space id. Rendering an anchor to `/space/undefined`
+            would look identical until it was clicked. */}
+        {profileHref ? (
+          <Link href={profileHref} className="min-w-0">
+            <Text as="span" variant="metadataMedium" className="block truncate hover:underline">
+              {speakerLabel(person)}
+            </Text>
+          </Link>
+        ) : (
+          <Text as="p" variant="metadataMedium" className="truncate">
+            {speakerLabel(person)}
+          </Text>
+        )}
         {record && <PersonRecordLine record={record} />}
       </div>
       <HubPillButton


### PR DESCRIPTION
[GEO-2788](https://linear.app/geobrowser/issue/GEO-2788/debates-side-panel-should-stay-open-when-navigating-to-a-claim-or-a)

The hub closed on every navigation, which made the Claims tab a dead end: following a claim shut the list you were working through, so coming back meant reopening the hub, returning to the tab and finding your place again — on the one surface whose whole job is to be read through.

## The ticket's first question: unmount, or explicit close?

**Explicit close.** State lives in `debatesHubAtom`, a module-level jotai atom that survives navigation on its own. `DebatesHubPanel` had an effect that called `close()` on any pathname change.

That matters, because it means the fix is the *rule*, not the plumbing — no URL state, no new mechanism.

## The rule

**Desktop only.** `hubClosesOnArrivalAt` names the places the hub must not follow the viewer into, and everywhere else keeps it:

| Destination | Hub (desktop) | Hub (mobile) |
|---|---|---|
| `/space/{id}/debates/{debateId}` — a debate room | closes | closes |
| `/space/{id}/debates/rematches/{sessionId}` — a rematch room | closes | closes |
| `/space/{id}/debates` — the feed | stays | closes |
| a claim or entity page | stays | closes |
| a person's space | stays | closes |
| Explore, root, community, anything else | stays | closes |
| any destination carrying `?modal=debates` | stays | stays |

Both rooms are full-screen, both are somewhere the viewer is *doing* rather than browsing, and accepting a request walks them straight into one. That is the case the blanket close existed for, and it is the case this keeps — the existing test for it still passes, renamed to say what it now actually proves.

The debates feed is deliberately *not* in that set on desktop: it is a browsing surface and the place the hub is opened from most often, so closing there would move the dead end one route down rather than remove it.

### Why mobile keeps the old behavior

Persisting is premised on the hub being a companion column with the destination visible *beside* it. That premise holds on desktop, where it is a 400px `aside`. It does not hold below 1023px, where the hub is a `fixed inset-0` `aria-modal` sheet over a backdrop: keeping it open would navigate the page **behind an opaque overlay**, so the viewer taps a claim, nothing appears to happen, and the page they landed on is hidden from assistive tech until they dismiss the sheet by hand.

So on mobile, tapping a claim or a person navigates *and* closes — which is the same outcome the ticket is asking for, reached the only way that layout allows. A link that explicitly asks for the hub (`?modal=debates`) still wins on either layout.

This is the one place the implementation departs from a literal reading of the ticket, so it is called out rather than assumed.

**"Users need an obvious way to dismiss it"** — unchanged and already there: the navbar toggle, Escape, a click outside on desktop, and on mobile a drag handle, a close button and a tappable backdrop.

## On sharing a mechanism with GEO-2746

The ticket suggested panel state might become part of the URL so persistence follows naturally. It already partly is — GEO-2746 shipped `?modal=debates`, and the effect already exempts it.

I kept that exemption *ahead* of the route test rather than folding the two together. A link that explicitly asks for the hub should win even where the route would otherwise close it — that is what makes `?modal=debates` a way to open the hub anywhere rather than a way to open it in most places. Going further and encoding open/closed in the URL on every navigation would dirty every link for a state the atom already holds correctly.

## The two cases

**Clicking a claim** needed no component change — the card's title was already a real `<Link>`. It was the close that made it feel like a one-way door.

**Clicking a person** did: the People tab rendered names as plain text. They are now links to the person's space, the profile page GEO-2611 settled on. Plain anchors with **no click handler** — the hub survives the navigation on its own, so there is nothing to intercept, which is also what keeps cmd-click, middle click and "copy link address" working (GEO-2701). Unlinked when the id is not a space id, since an anchor to `/space/undefined` looks identical until it is clicked.

## Testing

`hub-navigation.test.ts` (new, 11 cases) covers the rule directly: both rooms close; the feed, entity pages, spaces, Explore and root stay; a bare `/rematches` is not a room; trailing slashes; and `debates` outside a space route is not a debate route — the check is positional, not a substring match.

`debates-hub-panel.test.tsx` covers it through the component: the existing debate-room case, plus three destinations that must now keep it open.

`people-tab.test.tsx` covers the link: right href, nothing preventing the default, and no anchor when there is no space id.

One fixture change worth knowing about: the suite's people used `profile_space_id: 'profile-user-them'`, which is not a valid space id, so the link would never have rendered under test and the new assertions would have passed for the wrong reason. They now use real space-id shapes, and the records fixture is rekeyed to match.

Verified by reverting each half — restoring the blanket close fails the 3 stay-open cases; unlinking the name fails 2.

`vitest run core/debates`: 1072 passed. `tsc --noEmit`: 5 errors, all pre-existing on master in unrelated test files. prettier clean; eslint reports only a pre-existing unused `HubMessage` import in the panel, which warns on clean master too.

## Worth a look

Not verified in a browser. The behaviour change is the kind you feel rather than read: worth opening the hub, following a claim, following a person, and then accepting a request to confirm the room still clears it.
