### PR TITLE
feat(explore): open the types filter on news story, debate and claim

### DIFF
--- a/apps/web/core/explore/explore-constants.ts
+++ b/apps/web/core/explore/explore-constants.ts
@@ -6,9 +6,18 @@ export const EPISODE_TYPE_ID = '972d201ad78045689e01543f67b26bee';
 export const TWEET_TYPE_ID = 'd6f0506def324d8e9de4976b986e78ec';
 export const PAPER_TYPE_ID = '5e24fb52856c4189a9716af4387b1b89';
 
-/** Entity types shown on Explore (Geo ontology IDs, hyphenless for GraphQL variables). */
+/**
+ * Entity types shown on Explore (Geo ontology IDs, hyphenless for GraphQL variables).
+ *
+ * This array is the single source of order: the dropdown maps it directly, and
+ * `sanitizeExploreTypeIds` sorts every selection into it. The three defaults lead the list so the
+ * boxes a reader arrives with are the ones they see first, instead of being scattered down it —
+ * Debate and Claim used to sit at the bottom. The rest keep the order they already had.
+ */
 export const EXPLORE_ENTITY_TYPES = [
   { id: NEWS_STORY_TYPE_ID, label: 'News story' },
+  { id: DEBATE_TYPE_ID, label: 'Debate' },
+  { id: CLAIM_TYPE_ID, label: 'Claim' },
   { id: EPISODE_TYPE_ID, label: 'Episode' },
   { id: 'f3d4461486b74d2583d89709c9d84f65', label: 'Post' },
   { id: TWEET_TYPE_ID, label: 'Tweet' },
@@ -18,8 +27,6 @@ export const EXPLORE_ENTITY_TYPES = [
   { id: '484a18c5030a499cb0f2ef588ff16d50', label: 'Project' },
   { id: '150db6defe2344f0805afa57502e2c32', label: 'Ranking block' },
   { id: '0419ca20118b4cdb84dfdb9ed73b50c2', label: 'Community call event' },
-  { id: DEBATE_TYPE_ID, label: 'Debate' },
-  { id: CLAIM_TYPE_ID, label: 'Claim' },
 ] as const;
 
 export const EXPLORE_ENTITY_TYPE_IDS = EXPLORE_ENTITY_TYPES.map(type => type.id);
@@ -30,9 +37,11 @@ export const EXPLORE_ENTITY_TYPE_IDS = EXPLORE_ENTITY_TYPES.map(type => type.id)
  * A narrower opening view, not a narrower feed: every option above stays in the dropdown and a
  * reader can tick any of them. This is only what is selected before anyone touches it.
  *
- * Derived from `EXPLORE_ENTITY_TYPES` rather than written out, so the order always matches the
- * canonical list — `sanitizeExploreTypeIds` sorts selections into that order, and a default in a
- * different one would compare unequal to the same set chosen by hand.
+ * Still derived from `EXPLORE_ENTITY_TYPES` by membership rather than sliced off the front, even
+ * though these now lead the list. `sanitizeExploreTypeIds` sorts selections into that order and the
+ * feed compares them as joined keys, so a default ordered differently would look like a different
+ * selection from the same three ticked by hand — deriving it keeps the two in step through any
+ * future reshuffle, where a `slice(0, 3)` would silently follow the list somewhere else.
  */
 const DEFAULT_SELECTED_TYPE_IDS: ReadonlySet<string> = new Set([NEWS_STORY_TYPE_ID, DEBATE_TYPE_ID, CLAIM_TYPE_ID]);
 

--- a/apps/web/core/explore/explore-constants.ts
+++ b/apps/web/core/explore/explore-constants.ts
@@ -1,4 +1,5 @@
 import { CLAIM_TYPE_ID } from '~/core/claims/ontology';
+import { DEBATE_TYPE_ID } from '~/core/debates/ontology';
 
 export const NEWS_STORY_TYPE_ID = 'e550fe517e904b2c8fffdf13408f5634';
 export const EPISODE_TYPE_ID = '972d201ad78045689e01543f67b26bee';
@@ -17,11 +18,27 @@ export const EXPLORE_ENTITY_TYPES = [
   { id: '484a18c5030a499cb0f2ef588ff16d50', label: 'Project' },
   { id: '150db6defe2344f0805afa57502e2c32', label: 'Ranking block' },
   { id: '0419ca20118b4cdb84dfdb9ed73b50c2', label: 'Community call event' },
-  { id: 'fd51f93520634617be397b672b23364c', label: 'Debate' },
+  { id: DEBATE_TYPE_ID, label: 'Debate' },
   { id: CLAIM_TYPE_ID, label: 'Claim' },
 ] as const;
 
 export const EXPLORE_ENTITY_TYPE_IDS = EXPLORE_ENTITY_TYPES.map(type => type.id);
+
+/**
+ * What the types filter arrives checked with (GEO-2790).
+ *
+ * A narrower opening view, not a narrower feed: every option above stays in the dropdown and a
+ * reader can tick any of them. This is only what is selected before anyone touches it.
+ *
+ * Derived from `EXPLORE_ENTITY_TYPES` rather than written out, so the order always matches the
+ * canonical list — `sanitizeExploreTypeIds` sorts selections into that order, and a default in a
+ * different one would compare unequal to the same set chosen by hand.
+ */
+const DEFAULT_SELECTED_TYPE_IDS: ReadonlySet<string> = new Set([NEWS_STORY_TYPE_ID, DEBATE_TYPE_ID, CLAIM_TYPE_ID]);
+
+export const DEFAULT_EXPLORE_TYPE_IDS = EXPLORE_ENTITY_TYPES.filter(type => DEFAULT_SELECTED_TYPE_IDS.has(type.id)).map(
+  type => type.id
+);
 
 export const EXPLORE_ENTITY_NAME_PROPERTY_ID = 'a126ca530c8e48d5b88882c734c38935';
 export const EXPLORE_ENTITY_DESCRIPTION_PROPERTY_ID = '9b1f76ff9711404c861e59dc3fa7d037';

--- a/apps/web/core/explore/explore-diversity.test.ts
+++ b/apps/web/core/explore/explore-diversity.test.ts
@@ -4,6 +4,7 @@ import { CLAIM_TYPE_ID } from '~/core/claims/ontology';
 
 import {
   EPISODE_TYPE_ID,
+  EXPLORE_ENTITY_TYPE_IDS,
   EXPLORE_PAGE_SIZE,
   NEWS_STORY_TYPE_ID,
   TWEET_TYPE_ID,
@@ -15,11 +16,7 @@ import {
   exploreItemTypeKey,
   longestTypeRun,
 } from './explore-diversity';
-import {
-  decodeExploreWindowCursor,
-  encodeExploreWindowCursor,
-  nextExploreWindowCursor,
-} from './explore-window-cursor';
+import { decodeExploreWindowCursor, encodeExploreWindowCursor, nextExploreWindowCursor } from './explore-window-cursor';
 
 type Item = { id: string; types: { id: string }[] };
 
@@ -46,16 +43,29 @@ describe('exploreItemTypeKey', () => {
   it('is stable across relation order', () => {
     // `types` comes from relations, whose order is not meaningful. Two identical entities
     // must not land in different diversity buckets because the rows came back swapped.
-    expect(key(item('a', CLAIM_TYPE_ID, NEWS_STORY_TYPE_ID))).toBe(
-      key(item('b', NEWS_STORY_TYPE_ID, CLAIM_TYPE_ID))
-    );
+    expect(key(item('a', CLAIM_TYPE_ID, NEWS_STORY_TYPE_ID))).toBe(key(item('b', NEWS_STORY_TYPE_ID, CLAIM_TYPE_ID)));
   });
 
   it('classifies a multi-typed claim as its more specific type', () => {
-    // Claim is declared last in EXPLORE_ENTITY_TYPES, so it loses every tie. That is the
-    // useful direction: such an item can break a claim run instead of extending one.
+    // Claim classifies last, so it loses every tie. That is the useful direction: such an item can
+    // break a claim run instead of extending one.
+    //
+    // It used to lose ties by being declared last in EXPLORE_ENTITY_TYPES, which made this
+    // behaviour a side effect of menu order — GEO-2790 moved Claim to the top of the menu and
+    // inverted it. The priority is stated separately now, and the test below guards the split.
     expect(key(item('a', CLAIM_TYPE_ID, EPISODE_TYPE_ID))).not.toBe(key(item('b', CLAIM_TYPE_ID)));
     expect(key(item('a', CLAIM_TYPE_ID, EPISODE_TYPE_ID))).toBe(key(item('c', EPISODE_TYPE_ID)));
+  });
+
+  it('classifies independently of the order the menu lists types in', () => {
+    // The invariant that keeps the two apart. Claim leads the dropdown so the boxes a reader
+    // arrives with read first; it must still lose classification ties to a more specific type, or
+    // the diversity cap starts extending claim runs instead of breaking them — the exact failure
+    // this module exists to prevent.
+    expect(EXPLORE_ENTITY_TYPE_IDS.indexOf(CLAIM_TYPE_ID)).toBeLessThan(
+      EXPLORE_ENTITY_TYPE_IDS.indexOf(EPISODE_TYPE_ID)
+    );
+    expect(key(item('a', CLAIM_TYPE_ID, EPISODE_TYPE_ID))).toBe(key(item('b', EPISODE_TYPE_ID)));
   });
 
   it('is case- and hyphen-insensitive, matching the ids the feed actually returns', () => {
@@ -94,9 +104,7 @@ describe('applyDiversityCap', () => {
     expect(expectedBreaks).toBe(5);
     expect(news.length).toBeGreaterThanOrEqual(expectedBreaks);
     // The measured 100% is now at most 77%, which is the floor a run cap alone can reach.
-    expect(firstScreenAfter.length - news.length).toBeLessThanOrEqual(
-      EXPLORE_PAGE_SIZE - expectedBreaks
-    );
+    expect(firstScreenAfter.length - news.length).toBeLessThanOrEqual(EXPLORE_PAGE_SIZE - expectedBreaks);
   });
 
   it('caps runs across the whole window, not just the first page', () => {

--- a/apps/web/core/explore/explore-diversity.ts
+++ b/apps/web/core/explore/explore-diversity.ts
@@ -1,7 +1,7 @@
 import { CLAIM_TYPE_ID } from '~/core/claims/ontology';
 import { DEBATE_TYPE_ID } from '~/core/debates/ontology';
 
-import { EXPLORE_ENTITY_TYPES, EXPLORE_PAGE_SIZE } from './explore-constants';
+import { EXPLORE_ENTITY_TYPE_IDS, EXPLORE_PAGE_SIZE } from './explore-constants';
 
 /**
  * Read-time diversity cap for the "Best" feed (GEO-2690).
@@ -77,10 +77,9 @@ const CLASSIFIES_LAST = [DEBATE_TYPE_ID, CLAIM_TYPE_ID];
  * Membership is still derived, so a type added to the menu is classifiable without a second edit;
  * only the ordering intent is stated by hand.
  */
-const TYPE_PRIORITY = [
-  ...EXPLORE_ENTITY_TYPES.map(type => type.id).filter(id => !CLASSIFIES_LAST.includes(id)),
-  ...CLASSIFIES_LAST,
-].map(normId);
+const TYPE_PRIORITY = [...EXPLORE_ENTITY_TYPE_IDS.filter(id => !CLASSIFIES_LAST.includes(id)), ...CLASSIFIES_LAST].map(
+  normId
+);
 
 /** Types the feed shows but that carry no useful signal for diversity. */
 export const UNTYPED_DIVERSITY_KEY = '';

--- a/apps/web/core/explore/explore-diversity.ts
+++ b/apps/web/core/explore/explore-diversity.ts
@@ -1,3 +1,6 @@
+import { CLAIM_TYPE_ID } from '~/core/claims/ontology';
+import { DEBATE_TYPE_ID } from '~/core/debates/ontology';
+
 import { EXPLORE_ENTITY_TYPES, EXPLORE_PAGE_SIZE } from './explore-constants';
 
 /**
@@ -51,16 +54,33 @@ export const EXPLORE_DIVERSITY_SCAN_MULTIPLIER = 3;
 export const EXPLORE_DIVERSITY_WINDOW_SIZE = EXPLORE_PAGE_SIZE * EXPLORE_DIVERSITY_SCAN_MULTIPLIER;
 
 /**
- * Explore's declared type order, used as a classification priority.
+ * Types that lose every classification tie, least specific last.
  *
- * Entities carry several `types` relations and the relation order is not meaningful, so
- * the run cap needs one deterministic type per item. Walking `EXPLORE_ENTITY_TYPES` in
- * its declared order gives that, and gives it a useful bias for free: Claim is declared
- * last, so an entity that is both a Claim and something more specific is classified as
- * the something more specific. That is both the more informative label and the safer
- * default here — it lets such an item break a claim run rather than extend one.
+ * Deliberately separate from the menu order. This priority used to *be* `EXPLORE_ENTITY_TYPES` in
+ * its declared order, which worked only because Debate and Claim happened to sit at the bottom of
+ * that list. GEO-2790 moved them to the top so the default boxes read first — a presentational
+ * change that silently inverted this one, reclassifying a Claim-and-Episode entity as a Claim and
+ * letting it *extend* a claim run rather than break one. The two orders answer different questions
+ * and are now written down separately.
  */
-const TYPE_PRIORITY = EXPLORE_ENTITY_TYPES.map(type => normId(type.id));
+const CLASSIFIES_LAST = [DEBATE_TYPE_ID, CLAIM_TYPE_ID];
+
+/**
+ * Classification priority: one deterministic type per item, most specific first.
+ *
+ * Entities carry several `types` relations and the relation order is not meaningful, so the run cap
+ * needs to pick one. Everything the menu knows about, in menu order, except the types above — which
+ * go last so an entity that is both a Claim and something more specific is classified as the
+ * something more specific. That is the more informative label and the safer default here: such an
+ * item can break a claim run instead of extending one.
+ *
+ * Membership is still derived, so a type added to the menu is classifiable without a second edit;
+ * only the ordering intent is stated by hand.
+ */
+const TYPE_PRIORITY = [
+  ...EXPLORE_ENTITY_TYPES.map(type => type.id).filter(id => !CLASSIFIES_LAST.includes(id)),
+  ...CLASSIFIES_LAST,
+].map(normId);
 
 /** Types the feed shows but that carry no useful signal for diversity. */
 export const UNTYPED_DIVERSITY_KEY = '';

--- a/apps/web/core/explore/explore-type-filter.test.ts
+++ b/apps/web/core/explore/explore-type-filter.test.ts
@@ -20,6 +20,12 @@ describe('Explore default types', () => {
     expect(parseStoredExploreTypeIds(null)).toEqual(DEFAULT_EXPLORE_TYPE_IDS);
   });
 
+  it('lists the defaults first, so the boxes on arrival are the ones seen first', () => {
+    // The dropdown maps `EXPLORE_ENTITY_TYPES` directly, so this array is the menu order. Debate and
+    // Claim used to sit at the bottom of it, which put two of the three checked boxes out of view.
+    expect(EXPLORE_ENTITY_TYPE_IDS.slice(0, DEFAULT_EXPLORE_TYPE_IDS.length)).toEqual(DEFAULT_EXPLORE_TYPE_IDS);
+  });
+
   it('keeps every type available to choose', () => {
     // The scope of GEO-2790 is what is checked on arrival, not what the feed can show. Every
     // default has to still be an option, and the options list has to still be the longer one.

--- a/apps/web/core/explore/explore-type-filter.test.ts
+++ b/apps/web/core/explore/explore-type-filter.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
 import { CLAIM_TYPE_ID } from '~/core/claims/ontology';
+import { DEBATE_TYPE_ID } from '~/core/debates/ontology';
 
-import { EXPLORE_ENTITY_TYPE_IDS } from './explore-constants';
+import { DEFAULT_EXPLORE_TYPE_IDS, EXPLORE_ENTITY_TYPE_IDS, NEWS_STORY_TYPE_ID } from './explore-constants';
 import {
   exploreTypeFilterLabel,
   parseExploreTypeIdsParam,
@@ -12,25 +13,51 @@ import {
 } from './explore-type-filter';
 
 describe('Explore default types', () => {
-  // The rest of this suite is written against EXPLORE_ENTITY_TYPE_IDS, so it follows the
-  // list wherever it goes and would stay green if a type were dropped. Claim is pinned
-  // explicitly: Explore is where claims get discovered, so it defaulting off is a
-  // regression rather than a preference.
-  //
-  // Asserted by ID only. The menu label is display copy, and the entry's shape is already
-  // a compile-time guarantee, so pinning the string here would only fail on a rename.
-  it('includes Claim, selected by default', () => {
-    expect(EXPLORE_ENTITY_TYPE_IDS).toContain(CLAIM_TYPE_ID);
-    expect(parseStoredExploreTypeIds(null)).toContain(CLAIM_TYPE_ID);
-    expect(parseExploreTypeIdsParam(null)).toContain(CLAIM_TYPE_ID);
+  // Pinned by ID, never by label: the menu string is display copy, and matching on it would make
+  // a rename silently change which types a reader arrives with.
+  it('arrives with news story, debate and claim selected', () => {
+    expect(DEFAULT_EXPLORE_TYPE_IDS).toEqual([NEWS_STORY_TYPE_ID, DEBATE_TYPE_ID, CLAIM_TYPE_ID]);
+    expect(parseStoredExploreTypeIds(null)).toEqual(DEFAULT_EXPLORE_TYPE_IDS);
+  });
+
+  it('keeps every type available to choose', () => {
+    // The scope of GEO-2790 is what is checked on arrival, not what the feed can show. Every
+    // default has to still be an option, and the options list has to still be the longer one.
+    for (const id of DEFAULT_EXPLORE_TYPE_IDS) expect(EXPLORE_ENTITY_TYPE_IDS).toContain(id);
+    expect(EXPLORE_ENTITY_TYPE_IDS.length).toBeGreaterThan(DEFAULT_EXPLORE_TYPE_IDS.length);
+  });
+
+  it('orders the default the way a hand-picked selection would be ordered', () => {
+    // `sanitizeExploreTypeIds` sorts into `EXPLORE_ENTITY_TYPES` order, and the feed compares
+    // selections by length and by joined key — so a default in a different order would look like a
+    // different selection from the same three types ticked by hand.
+    expect(sanitizeExploreTypeIds(DEFAULT_EXPLORE_TYPE_IDS)).toEqual(DEFAULT_EXPLORE_TYPE_IDS);
+    expect(sanitizeExploreTypeIds([CLAIM_TYPE_ID, DEBATE_TYPE_ID, NEWS_STORY_TYPE_ID])).toEqual(
+      DEFAULT_EXPLORE_TYPE_IDS
+    );
+  });
+
+  it('does not narrow the API when the client sends no types param', () => {
+    // The trap this change had to avoid. `entity-feed` omits `typeIds` *precisely when every type
+    // is selected*, so if the server read a missing param as the default three, ticking all twelve
+    // boxes would hand back three types. The two defaults are separate functions for this reason.
+    expect(parseExploreTypeIdsParam(null)).toEqual(EXPLORE_ENTITY_TYPE_IDS);
+    expect(parseExploreTypeIdsParam(null)).not.toEqual(DEFAULT_EXPLORE_TYPE_IDS);
+  });
+
+  it('leaves a reader who chose their own types alone', () => {
+    // Only a deliberate toggle writes the key, so anything stored is someone having said what they
+    // want. The new default is for people who never said.
+    expect(parseStoredExploreTypeIds(JSON.stringify([NEWS_STORY_TYPE_ID]))).toEqual([NEWS_STORY_TYPE_ID]);
+    expect(parseStoredExploreTypeIds(JSON.stringify(EXPLORE_ENTITY_TYPE_IDS))).toEqual(EXPLORE_ENTITY_TYPE_IDS);
   });
 });
 
 describe('parseStoredExploreTypeIds', () => {
-  it('defaults to every Explore type when cache is missing or corrupt', () => {
-    expect(parseStoredExploreTypeIds(null)).toEqual(EXPLORE_ENTITY_TYPE_IDS);
-    expect(parseStoredExploreTypeIds('not-json')).toEqual(EXPLORE_ENTITY_TYPE_IDS);
-    expect(parseStoredExploreTypeIds('{}')).toEqual(EXPLORE_ENTITY_TYPE_IDS);
+  it('falls back to the default selection when the cache is missing or corrupt', () => {
+    expect(parseStoredExploreTypeIds(null)).toEqual(DEFAULT_EXPLORE_TYPE_IDS);
+    expect(parseStoredExploreTypeIds('not-json')).toEqual(DEFAULT_EXPLORE_TYPE_IDS);
+    expect(parseStoredExploreTypeIds('{}')).toEqual(DEFAULT_EXPLORE_TYPE_IDS);
   });
 
   it('preserves a deliberately empty cached selection', () => {

--- a/apps/web/core/explore/explore-type-filter.ts
+++ b/apps/web/core/explore/explore-type-filter.ts
@@ -1,4 +1,4 @@
-import { EXPLORE_ENTITY_TYPES } from './explore-constants';
+import { DEFAULT_EXPLORE_TYPE_IDS, EXPLORE_ENTITY_TYPES } from './explore-constants';
 
 export const EXPLORE_TYPE_FILTER_STORAGE_KEY = 'exploreSelectedTypeIds';
 
@@ -8,7 +8,14 @@ function normalizeId(id: string): string {
   return id.replace(/-/g, '').toLowerCase();
 }
 
-function defaultExploreTypeIds(): string[] {
+/**
+ * Every type there is. Distinct from `DEFAULT_EXPLORE_TYPE_IDS`, and the distinction matters more
+ * than it looks: these two were one function until GEO-2790, and collapsing them again would be a
+ * quiet bug. The client omits the `typeIds` param *precisely when every type is selected*, so the
+ * server reading a missing param as "the default three" would hand back three types to the reader
+ * who had just ticked all twelve.
+ */
+function allExploreTypeIds(): string[] {
   return EXPLORE_ENTITY_TYPES.map(type => type.id);
 }
 
@@ -24,21 +31,33 @@ export function sanitizeExploreTypeIds(ids: readonly unknown[]): string[] {
   return EXPLORE_ENTITY_TYPES.map(type => type.id).filter(id => selected.has(id));
 }
 
-/** Missing or corrupt cache means the default: every Explore type selected. */
+/**
+ * What the dropdown opens with. Nothing stored, or something unreadable, means the default.
+ *
+ * Only a deliberate toggle writes this key, so "nothing stored" is the same population as "has
+ * never touched the filter" — which is why a reader who once chose their own types keeps them, and
+ * only someone who never expressed a preference is given the new one. A default is a guess about
+ * what someone wants before they say; a stored selection is them having said.
+ */
 export function parseStoredExploreTypeIds(raw: string | null): string[] {
-  if (raw === null) return defaultExploreTypeIds();
+  if (raw === null) return [...DEFAULT_EXPLORE_TYPE_IDS];
 
   try {
     const parsed: unknown = JSON.parse(raw);
-    return Array.isArray(parsed) ? sanitizeExploreTypeIds(parsed) : defaultExploreTypeIds();
+    return Array.isArray(parsed) ? sanitizeExploreTypeIds(parsed) : [...DEFAULT_EXPLORE_TYPE_IDS];
   } catch {
-    return defaultExploreTypeIds();
+    return [...DEFAULT_EXPLORE_TYPE_IDS];
   }
 }
 
-/** Missing query params preserve the historical all-types API behavior; an empty value means none. */
+/**
+ * Missing query params preserve the historical all-types API behavior; an empty value means none.
+ *
+ * Deliberately *not* the new default. The client drops the param when every type is selected, so
+ * this is the "all twelve" path, not the "hasn't chosen yet" one — see `allExploreTypeIds`.
+ */
 export function parseExploreTypeIdsParam(raw: string | null): string[] {
-  if (raw === null) return defaultExploreTypeIds();
+  if (raw === null) return allExploreTypeIds();
   if (raw === '') return [];
   return sanitizeExploreTypeIds(raw.split(','));
 }

--- a/apps/web/core/explore/explore-type-filter.ts
+++ b/apps/web/core/explore/explore-type-filter.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_EXPLORE_TYPE_IDS, EXPLORE_ENTITY_TYPES } from './explore-constants';
+import { DEFAULT_EXPLORE_TYPE_IDS, EXPLORE_ENTITY_TYPES, EXPLORE_ENTITY_TYPE_IDS } from './explore-constants';
 
 export const EXPLORE_TYPE_FILTER_STORAGE_KEY = 'exploreSelectedTypeIds';
 
@@ -16,7 +16,19 @@ function normalizeId(id: string): string {
  * who had just ticked all twelve.
  */
 function allExploreTypeIds(): string[] {
-  return EXPLORE_ENTITY_TYPES.map(type => type.id);
+  return [...EXPLORE_ENTITY_TYPE_IDS];
+}
+
+/**
+ * A selection, put back into the order the menu declares.
+ *
+ * Order is not cosmetic here. The feed keys its query on the joined ids and compares selections by
+ * length, so the same three types in two orders would look like two different selections and refetch
+ * for a change nobody made. Both callers below build a set and then need it ordered, so the rule
+ * lives once rather than being spelled out at each of them.
+ */
+function inCanonicalOrder(selected: ReadonlySet<string>): string[] {
+  return EXPLORE_ENTITY_TYPE_IDS.filter(id => selected.has(id));
 }
 
 export function sanitizeExploreTypeIds(ids: readonly unknown[]): string[] {
@@ -28,7 +40,7 @@ export function sanitizeExploreTypeIds(ids: readonly unknown[]): string[] {
     if (canonical) selected.add(canonical);
   }
 
-  return EXPLORE_ENTITY_TYPES.map(type => type.id).filter(id => selected.has(id));
+  return inCanonicalOrder(selected);
 }
 
 /**
@@ -70,7 +82,7 @@ export function toggleExploreTypeId(selectedTypeIds: readonly string[], typeId: 
   if (selected.has(canonicalTypeId)) selected.delete(canonicalTypeId);
   else selected.add(canonicalTypeId);
 
-  return EXPLORE_ENTITY_TYPES.map(type => type.id).filter(id => selected.has(id));
+  return inCanonicalOrder(selected);
 }
 
 export function exploreTypeFilterLabel(selectedCount: number): string {

--- a/apps/web/partials/feed/entity-feed.test.tsx
+++ b/apps/web/partials/feed/entity-feed.test.tsx
@@ -4,7 +4,11 @@ import * as React from 'react';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { DEFAULT_EXPLORE_TYPE_IDS, EXPLORE_ENTITY_TYPE_IDS } from '~/core/explore/explore-constants';
+import {
+  DEFAULT_EXPLORE_TYPE_IDS,
+  EXPLORE_ENTITY_TYPES,
+  EXPLORE_ENTITY_TYPE_IDS,
+} from '~/core/explore/explore-constants';
 import { EXPLORE_TYPE_FILTER_STORAGE_KEY, exploreTypeFilterLabel } from '~/core/explore/explore-type-filter';
 
 import { EntityFeed } from './entity-feed';
@@ -282,20 +286,27 @@ describe('EntityFeed Explore type filter', () => {
   });
 
   it('applies rapid toggles to the latest selection', async () => {
-    const [first, second, third] = EXPLORE_ENTITY_TYPE_IDS;
-    window.localStorage.setItem(EXPLORE_TYPE_FILTER_STORAGE_KEY, JSON.stringify([first]));
+    // Labels and ids both come from `EXPLORE_ENTITY_TYPES`, so the test clicks the same entries it
+    // asserts on. It used to take the first three ids positionally while clicking Episode and Post
+    // by name, which only agreed because those happened to be positions two and three — reordering
+    // the menu for GEO-2790 broke it. Which types these are does not matter to what is being
+    // tested; that they are the same ones does.
+    const [first, second, third] = EXPLORE_ENTITY_TYPES;
+    window.localStorage.setItem(EXPLORE_TYPE_FILTER_STORAGE_KEY, JSON.stringify([first.id]));
 
     render(<EntityFeed apiEndpoint="/api/explore/feed" initialSpaceOptions={[]} showSortFilter showTypeFilter />);
     await screen.findByText('1 type');
 
     act(() => {
-      screen.getByRole('button', { name: /Episode/ }).click();
-      screen.getByRole('button', { name: /Post/ }).click();
+      screen.getByRole('button', { name: new RegExp(second.label) }).click();
+      screen.getByRole('button', { name: new RegExp(third.label) }).click();
     });
 
     await screen.findByText('3 types');
     await waitFor(() =>
-      expect(window.localStorage.getItem(EXPLORE_TYPE_FILTER_STORAGE_KEY)).toBe(JSON.stringify([first, second, third]))
+      expect(window.localStorage.getItem(EXPLORE_TYPE_FILTER_STORAGE_KEY)).toBe(
+        JSON.stringify([first.id, second.id, third.id])
+      )
     );
   });
 

--- a/apps/web/partials/feed/entity-feed.test.tsx
+++ b/apps/web/partials/feed/entity-feed.test.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { EXPLORE_ENTITY_TYPE_IDS } from '~/core/explore/explore-constants';
+import { DEFAULT_EXPLORE_TYPE_IDS, EXPLORE_ENTITY_TYPE_IDS } from '~/core/explore/explore-constants';
 import { EXPLORE_TYPE_FILTER_STORAGE_KEY, exploreTypeFilterLabel } from '~/core/explore/explore-type-filter';
 
 import { EntityFeed } from './entity-feed';
@@ -224,12 +224,35 @@ describe('EntityFeed time range visibility', () => {
 });
 
 describe('EntityFeed Explore type filter', () => {
-  it('omits the type parameter and does not persist before the user changes the default selection', async () => {
+  it('arrives on the default types, sends them, and persists nothing until the reader chooses', async () => {
+    // GEO-2790. The default is a real selection now rather than "everything", so it has to be sent:
+    // an omitted param means all types to the route, not the default. See the test below.
+    render(<EntityFeed apiEndpoint="/api/explore/feed" initialSpaceOptions={[]} showSortFilter showTypeFilter />);
+
+    await screen.findByText(exploreTypeFilterLabel(DEFAULT_EXPLORE_TYPE_IDS.length));
+    await waitFor(() => expect(mocks.queryOptions?.enabled).toBe(true));
+    // Still nothing written. A default is a guess about what someone wants before they say, and
+    // persisting it would make every arriving reader indistinguishable from one who chose it.
+    expect(window.localStorage.getItem(EXPLORE_TYPE_FILTER_STORAGE_KEY)).toBeNull();
+
+    const queryFn = mocks.queryOptions?.queryFn as (args: { pageParam?: string }) => Promise<unknown>;
+    await queryFn({ pageParam: undefined });
+    const requestUrl = mocks.fetch.mock.calls[0]?.[0] as string;
+    // Read the param rather than substring the URL: `URLSearchParams` percent-encodes the commas.
+    const sentTypeIds = new URLSearchParams(requestUrl.split('?')[1]).get('typeIds');
+    expect(sentTypeIds).toBe(DEFAULT_EXPLORE_TYPE_IDS.join(','));
+  });
+
+  it('omits the type parameter only when every type is selected', async () => {
+    // The trap this change had to avoid, guarded end to end. The client drops `typeIds` precisely
+    // when all of them are ticked, and the route reads a missing param as "all types" — so if that
+    // fallback were ever changed to the default three, ticking every box would return three types.
+    window.localStorage.setItem(EXPLORE_TYPE_FILTER_STORAGE_KEY, JSON.stringify(EXPLORE_ENTITY_TYPE_IDS));
+
     render(<EntityFeed apiEndpoint="/api/explore/feed" initialSpaceOptions={[]} showSortFilter showTypeFilter />);
 
     await screen.findByText(exploreTypeFilterLabel(EXPLORE_ENTITY_TYPE_IDS.length));
     await waitFor(() => expect(mocks.queryOptions?.enabled).toBe(true));
-    expect(window.localStorage.getItem(EXPLORE_TYPE_FILTER_STORAGE_KEY)).toBeNull();
 
     const queryFn = mocks.queryOptions?.queryFn as (args: { pageParam?: string }) => Promise<unknown>;
     await queryFn({ pageParam: undefined });
@@ -278,17 +301,18 @@ describe('EntityFeed Explore type filter', () => {
 
   it('selects and unselects all types from the menu action', async () => {
     render(<EntityFeed apiEndpoint="/api/explore/feed" initialSpaceOptions={[]} showSortFilter showTypeFilter />);
-    await screen.findByText(exploreTypeFilterLabel(EXPLORE_ENTITY_TYPE_IDS.length));
-
-    fireEvent.click(screen.getByRole('button', { name: 'Unselect all' }));
-    await screen.findByText('0 types');
-    await waitFor(() => expect(window.localStorage.getItem(EXPLORE_TYPE_FILTER_STORAGE_KEY)).toBe('[]'));
+    // The default is a subset now, so the action on arrival is Select all rather than Unselect all.
+    await screen.findByText(exploreTypeFilterLabel(DEFAULT_EXPLORE_TYPE_IDS.length));
 
     fireEvent.click(screen.getByRole('button', { name: 'Select all' }));
     await screen.findByText(exploreTypeFilterLabel(EXPLORE_ENTITY_TYPE_IDS.length));
     await waitFor(() =>
       expect(window.localStorage.getItem(EXPLORE_TYPE_FILTER_STORAGE_KEY)).toBe(JSON.stringify(EXPLORE_ENTITY_TYPE_IDS))
     );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Unselect all' }));
+    await screen.findByText('0 types');
+    await waitFor(() => expect(window.localStorage.getItem(EXPLORE_TYPE_FILTER_STORAGE_KEY)).toBe('[]'));
   });
 
   it('preserves the historical query key for feeds without the Explore type filter', () => {

--- a/apps/web/partials/feed/entity-feed.tsx
+++ b/apps/web/partials/feed/entity-feed.tsx
@@ -6,7 +6,7 @@ import * as React from 'react';
 
 import cx from 'classnames';
 
-import { EXPLORE_ENTITY_TYPE_IDS } from '~/core/explore/explore-constants';
+import { DEFAULT_EXPLORE_TYPE_IDS, EXPLORE_ENTITY_TYPE_IDS } from '~/core/explore/explore-constants';
 import {
   EXPLORE_TYPE_FILTER_STORAGE_KEY,
   parseStoredExploreTypeIds,
@@ -139,7 +139,10 @@ export function EntityFeed({
   const [sortMenuOpen, setSortMenuOpen] = React.useState(false);
   const [timeMenuOpen, setTimeMenuOpen] = React.useState(false);
   const [spaceMenuOpen, setSpaceMenuOpen] = React.useState(false);
-  const [selectedTypeIds, setSelectedTypeIds] = React.useState<string[]>([...EXPLORE_ENTITY_TYPE_IDS]);
+  // Seeded with the default rather than every type, so the first paint is what the effect below
+  // will settle on for a reader with nothing stored — the common case. Starting from all twelve
+  // showed a wider feed for a frame and then narrowed it.
+  const [selectedTypeIds, setSelectedTypeIds] = React.useState<string[]>([...DEFAULT_EXPLORE_TYPE_IDS]);
   const [typeSelectionLoaded, setTypeSelectionLoaded] = React.useState(!showTypeFilter);
   const shouldPersistTypeSelectionRef = React.useRef(false);
   const spaceId = lockedSpaceId ?? selectedSpaceId;


### PR DESCRIPTION
Fixes GEO-2790.

The types filter now arrives checked with **News story, Debate and Claim**. Every option stays in the
dropdown and a reader can tick any of them — this only changes what is selected before anyone
touches it.

> **On the ticket title:** the URL slug reads "restrict the feed", but the body is explicit that this
> is a default-selection change and that nothing is removed from the feed's capability. I built the
> body. Say so if the slug was the real intent and I will narrow it properly.

## The three questions in the ticket

**Does the default persist?** The machinery already existed and answers this better than either
option in the ticket. The storage key is written *only on a deliberate toggle*, so "nothing stored"
is exactly the population that has never touched the filter.

- Never touched it → gets the new default, every visit, until they choose.
- Chose something once → keeps their choice, including if that choice was all twelve.

A default is a guess about what someone wants before they say; a stored selection is them having
said. Overriding the second with the first would be the app forgetting an answer it already had.

**Type IDs, not display names.** All three already existed as constants — and `DEBATE_TYPE_ID` was
already declared in `core/debates/ontology.ts` while `explore-constants.ts` carried the same literal
a second time. Reused the existing one rather than adding a third copy.

**"At least one of", not "exactly one".** Confirmed rather than assumed: the filter is
`typeIds: { overlaps: [...] }`, which is has-at-least-one. An entity typed both Claim and Post still
appears.

## The trap

Both defaults ran through a single function, and the client omits the `typeIds` param **precisely
when every type is selected**:

```ts
const typeIds = selectedTypeIds.length !== EXPLORE_ENTITY_TYPE_IDS.length ? selectedTypeIds : undefined;
```

So the route reads a missing param as "all types". Changing the shared default to three would have
meant **ticking every box returns three types** — a regression nobody would connect back to this
ticket. The two meanings are now separate functions:

- `parseStoredExploreTypeIds(null)` → the default three. What the dropdown opens with.
- `parseExploreTypeIdsParam(null)` → all twelve. Unchanged: the "no param" path, which is the
  all-selected case, not the hasn't-chosen-yet one.

Both carry a comment saying why they must not be recombined, and two tests pin it — one on the
helpers, one end-to-end through the component.

## Menu order, and what it was quietly carrying

The three defaults now lead the dropdown — **News story, Debate, Claim**, then the previous order
unchanged. Debate and Claim used to sit at the bottom, which put two of the three checked boxes out
of view.

That presentational change had a non-presentational consequence worth reading. `EXPLORE_ENTITY_TYPES`
declared order was *also* the classification priority in `explore-diversity.ts`, which picks one
deterministic type per multi-typed entity for the Best feed's run cap. The comment there said so:

> Claim is declared last, so an entity that is both a Claim and something more specific is classified
> as the something more specific ... it lets such an item break a claim run rather than extend one.

Moving Claim to the top inverted it: a Claim-and-Episode entity would classify as **Claim** and start
*extending* claim runs — the exact behaviour the diversity cap exists to prevent, arriving through a
menu reorder. The diversity suite caught it.

The two orders answer different questions and are separate now. Menu order is a presentation
decision; `CLASSIFIES_LAST = [Debate, Claim]` names the types that lose ties, reproducing the
previous priority exactly while the menu reorders freely. Membership stays derived from the menu, so
a new type is still a single edit, and a test pins the split.

## Also

The initial React state is seeded with the default rather than all twelve, so the first paint is
what the effect settles on for a reader with nothing stored. Starting from twelve rendered a wider
feed for a frame and then narrowed it.

## Tests

Two existing tests failed, and both were telling me something real rather than needing a number
retuned:

- `omits the type parameter … before the user changes the default selection` asserted the arrival
  state sends **no** `typeIds`. True when the default was everything; false by design now, because a
  default that is a real subset has to be transmitted. Rewritten to assert three shown, three sent,
  nothing persisted.
- `selects and unselects all types` began from twelve. With a subset default the menu action on
  arrival is **Select all**, not Unselect all, so the flow is restructured.

Added `omits the type parameter only when every type is selected`, which guards the trap through the
component.

The reorder then surfaced a third, and it was a fair catch on the test rather than the code:
`applies rapid toggles` read the first three ids *positionally* while clicking two of them *by name*,
which agreed only because those labels happened to sit at those positions. It now reads labels and
ids from the same entries, so a future reshuffle cannot quietly break it.

## Review pass

**Reuse.** `EXPLORE_ENTITY_TYPE_IDS` is exported for exactly this purpose and was being re-derived as
`EXPLORE_ENTITY_TYPES.map(type => type.id)` in four places — two of them added by this branch, in
`allExploreTypeIds` and the diversity priority. All four now read the constant, and a grep is down to
its own definition.

Two of those were also the same expression as each other, in `sanitizeExploreTypeIds` and
`toggleExploreTypeId`: a selection put back into the order the menu declares. That is a concept
rather than a coincidence, so it is named — `inCanonicalOrder` — and the name carries the reason.
Order is not cosmetic: the feed keys its query on the joined ids, so the same three types in two
orders would look like two selections and refetch for a change nobody made.

Behaviour-preserving, and the suite says so: the same 4006 tests pass before and after.

**Correctness.** The one real defect this branch produced was the menu order silently doubling as
diversity classification priority, described above; it is fixed and pinned by a test. Nothing further
surfaced.

## Worth watching

The ticket's own note: narrowing the default reduces how much there is to rank on arrival, so **Best
may behave differently in practice**. Worth a look after it ships. Related, the diversity window in
`fetch-explore-feed` applies whenever the selection is not exactly one type, so it still applies at
three — no change there, but that is where to look if Best feels off.

## Verification

- Full `apps/web` suite: **371 files / 4006 tests, 0 failures.**
- `NEXT_PUBLIC_CHAIN_ID=55516 bun run build --force`.
- One unrelated flake seen on an earlier run,
  `recording-upload-coordinator.integration` — passes in isolation (35/35) and passed on the clean
  run; retry timing under full-suite parallelism, nothing to do with this change.

## Worth a look, deliberately not in this PR

`NEWS_STORY_TYPE_ID` is declared **three times** with the same value — `core/constants.ts`,
`core/topics/ontology.ts` and `core/explore/explore-constants.ts` — each with live consumers
(`fetch-curator-leaderboard`, `topic-composition`, `generate-new-space-template`). Pre-existing, and
this PR does not add a copy: the Debate id *was* consolidated here precisely because this change
would otherwise have made a second one.

Folding a three-module constant refactor into a default-selection change would make this harder to
review than it needs to be, so it is flagged rather than done. Happy to take it as a follow-up.
