### PR TITLE
perf(debates): show the viewer's own position immediately instead of waiting on the indexer

### DIFF
--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -173,7 +173,13 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   // Both participants' sides on every claim, straight from the knowledge graph. A position is an
   // on-chain claim response; geo-chat only mirrors them, a hundred claim ids per request. This is
   // one query for both people, and it is what the opponent's tab is a list of.
-  const positions = useParticipantPositions(participants);
+  // The viewer's own personal space id, so `useParticipantPositions` can show their in-flight
+  // writes without waiting on the indexer (GEO-2784). Derived before the hook because the overlay
+  // has to be attributed to somebody — an unattributed optimistic row would be filtered straight
+  // back out by `participantSidesOn`, which matches on the current participants' space ids.
+  const localParticipant =
+    currentUserId === null ? null : (participants.find(participant => participant.user_id === currentUserId) ?? null);
+  const positions = useParticipantPositions(participants, localParticipant?.profile_space_id ?? null);
 
   const remoteParticipant =
     currentUserId === null ? null : (participants.find(participant => participant.user_id !== currentUserId) ?? null);

--- a/apps/web/core/debates/claim-response-indexed-notifier.ts
+++ b/apps/web/core/debates/claim-response-indexed-notifier.ts
@@ -38,6 +38,38 @@ export function claimResponseIndexedEvent(queryKey: readonly unknown[], data: un
   };
 }
 
+/**
+ * The same parse as {@link claimResponseIndexedEvent}, but for a response that is still *in
+ * flight* rather than one the indexer has confirmed (GEO-2784).
+ *
+ * `claimResponseIndexedEvent` deliberately waits for `status === 'indexed'`, because its job is to
+ * tell geo-chat something true. This one exists for the opposite reason: the viewer's own button
+ * should not wait on the indexer. `web.write.entity_response` measures p50 9.9s / p95 48.6s, and
+ * `pending.expectedResponse` is known locally the instant the write starts — so the UI can show
+ * the position immediately and let the real row replace it when it lands.
+ *
+ * `expectedResponse === null` is a *removal*, and callers must honour it: clicking a position off
+ * should disappear as fast as clicking one on.
+ */
+export function pendingClaimResponse(queryKey: readonly unknown[], data: unknown) {
+  const [scope, , entityId, spaceId, responseKind] = queryKey;
+  const indexingState = data as EntityResponseIndexingState | undefined;
+  if (
+    scope !== 'entity-response-indexing' ||
+    !indexingState?.pending ||
+    (responseKind !== 'stance' && responseKind !== 'veracity')
+  ) {
+    return null;
+  }
+  return {
+    entityId: String(entityId),
+    position:
+      indexingState.pending.expectedResponse === null ? null : indexingState.pending.expectedResponse === 'positive',
+    responseKind: responseKind as DebateResponseKind,
+    spaceId: String(spaceId),
+  };
+}
+
 export function useClaimResponseIndexedNotifier(
   enabled: boolean,
   getPrivyIdentityToken: GetPrivyIdentityToken,

--- a/apps/web/core/debates/participant-positions.test.ts
+++ b/apps/web/core/debates/participant-positions.test.ts
@@ -4,8 +4,19 @@ import { renderHook, waitFor } from '@testing-library/react';
 import * as React from 'react';
 
 import { Effect } from 'effect';
-
 import { describe, expect, it, vi } from 'vitest';
+
+import type { DebateRematchParticipant } from './api';
+import type { ParticipantPosition } from './participant-positions';
+import {
+  applyPendingPositions,
+  fetchParticipantPositions,
+  groupParticipantPositions,
+  isParticipantPositionsQueryKey,
+  participantPositionsQueryKey,
+  participantSidesOn,
+  useParticipantPositions,
+} from './participant-positions';
 
 const mocks = vi.hoisted(() => ({ graphql: vi.fn(), attention: true }));
 
@@ -16,16 +27,6 @@ vi.mock('~/core/io/graphql-client', () => ({
   graphql: (...args: unknown[]) => mocks.graphql(...args),
 }));
 vi.mock('./debate-attention', () => ({ useDebateAttention: () => mocks.attention }));
-
-import type { DebateRematchParticipant } from './api';
-import {
-  fetchParticipantPositions,
-  groupParticipantPositions,
-  isParticipantPositionsQueryKey,
-  participantPositionsQueryKey,
-  participantSidesOn,
-  useParticipantPositions,
-} from './participant-positions';
 
 const LOCAL: DebateRematchParticipant = {
   user_id: 'user-local',
@@ -206,5 +207,59 @@ describe('useParticipantPositions holding its list', () => {
     rerender({ participants: [LOCAL] });
 
     expect(result.current.byClaim.size).toBe(1);
+  });
+});
+
+describe('applyPendingPositions (GEO-2784)', () => {
+  const FETCHED: ParticipantPosition[] = [
+    { profileSpaceId: 'me', claimId: 'c1', spaceId: 's1', responseKind: 'stance', position: true },
+    { profileSpaceId: 'them', claimId: 'c2', spaceId: 's1', responseKind: 'stance', position: false },
+  ];
+
+  it('shows an in-flight position that the fetch has not returned yet', () => {
+    const pending: ParticipantPosition[] = [
+      { profileSpaceId: 'me', claimId: 'c9', spaceId: 's1', responseKind: 'stance', position: true },
+    ];
+    const merged = applyPendingPositions(FETCHED, pending);
+    expect(merged).toHaveLength(3);
+    expect(merged.find(r => r.claimId === 'c9')?.position).toBe(true);
+  });
+
+  it('a pending write overrides a stale fetched row for the same claim', () => {
+    const pending: ParticipantPosition[] = [
+      { profileSpaceId: 'me', claimId: 'c1', spaceId: 's1', responseKind: 'stance', position: false },
+    ];
+    const merged = applyPendingPositions(FETCHED, pending);
+    expect(merged).toHaveLength(2);
+    expect(merged.find(r => r.claimId === 'c1')?.position).toBe(false);
+  });
+
+  /* The removal case, and the reason a tombstone is carried rather than dropped: without it the
+     stale fetched row keeps the position on screen until the next refetch. */
+  it('a pending removal hides the fetched row immediately', () => {
+    const pending = [
+      { profileSpaceId: 'me', claimId: 'c1', spaceId: 's1', responseKind: 'stance', position: null },
+    ] as unknown as ParticipantPosition[];
+    const merged = applyPendingPositions(FETCHED, pending);
+    expect(merged.map(r => r.claimId)).toEqual(['c2']);
+  });
+
+  it('matches ids regardless of dash spelling, like every other comparison here', () => {
+    const pending: ParticipantPosition[] = [
+      { profileSpaceId: 'ME', claimId: 'C1', spaceId: 's1', responseKind: 'stance', position: false },
+    ];
+    expect(applyPendingPositions(FETCHED, pending)).toHaveLength(2);
+  });
+
+  it('leaves the fetched list untouched when nothing is in flight', () => {
+    expect(applyPendingPositions(FETCHED, [])).toBe(FETCHED);
+  });
+
+  it("does not touch the opponent's rows", () => {
+    const pending: ParticipantPosition[] = [
+      { profileSpaceId: 'me', claimId: 'c2', spaceId: 's1', responseKind: 'stance', position: true },
+    ];
+    const merged = applyPendingPositions(FETCHED, pending);
+    expect(merged.filter(r => r.claimId === 'c2')).toHaveLength(2);
   });
 });

--- a/apps/web/core/debates/participant-positions.ts
+++ b/apps/web/core/debates/participant-positions.ts
@@ -12,7 +12,7 @@ import { graphql } from '~/core/io/graphql-client';
 import { decodeActiveResponseDirection, responseKindToVoteKind } from '~/core/responses/entity-response';
 
 import type { DebateRematchParticipant, DebateResponseKind } from './api';
-import { claimResponseIndexedEvent } from './claim-response-indexed-notifier';
+import { claimResponseIndexedEvent, pendingClaimResponse } from './claim-response-indexed-notifier';
 import { useDebateAttention } from './debate-attention';
 
 /**
@@ -188,7 +188,104 @@ function sameId(left: string, right: string) {
   return left.replace(/-/g, '').toLowerCase() === right.replace(/-/g, '').toLowerCase();
 }
 
-export function useParticipantPositions(participants: DebateRematchParticipant[]) {
+/**
+ * The viewer's own in-flight responses, as positions (GEO-2784).
+ *
+ * Reads the `entity-response-indexing` entries this browser has in flight and turns each one into
+ * the position it is about to become. Without this the viewer waits on their own write before the
+ * UI reacts — p50 9.9s, p95 48.6s (`web.write.entity_response`) — which is what makes the
+ * "request debate" button feel broken after clicking a position.
+ *
+ * Subscribed rather than read once: the pending set changes as writes start and settle, and none
+ * of those transitions re-render this hook on their own.
+ */
+function useOwnPendingPositions(localProfileSpaceId: string | null | undefined): ParticipantPosition[] {
+  const queryClient = useQueryClient();
+  const [pending, setPending] = React.useState<ParticipantPosition[]>([]);
+
+  React.useEffect(() => {
+    if (!localProfileSpaceId) {
+      setPending(current => (current.length === 0 ? current : []));
+      return;
+    }
+    const cache = queryClient.getQueryCache();
+
+    const read = () => {
+      const rows: ParticipantPosition[] = [];
+      for (const query of cache.getAll()) {
+        const parsed = pendingClaimResponse(query.queryKey, query.state.data);
+        if (!parsed) continue;
+        rows.push({
+          profileSpaceId: localProfileSpaceId,
+          claimId: parsed.entityId,
+          spaceId: parsed.spaceId,
+          responseKind: parsed.responseKind,
+          // `null` means the viewer is *removing* the position. Carried through as a tombstone and
+          // resolved in the merge below, because dropping it here would let the stale fetched row
+          // keep the position visible until the next refetch.
+          position: parsed.position as boolean,
+        });
+      }
+      // Referential stability matters: this feeds a `useMemo` that regroups every position.
+      setPending(current => (samePositions(current, rows) ? current : rows));
+    };
+
+    read();
+    return cache.subscribe(event => {
+      if (event.type !== 'updated') return;
+      if (event.query.queryKey[0] !== 'entity-response-indexing') return;
+      read();
+    });
+  }, [localProfileSpaceId, queryClient]);
+
+  return pending;
+}
+
+function samePositions(a: ParticipantPosition[], b: ParticipantPosition[]) {
+  if (a.length !== b.length) return false;
+  return a.every((row, i) => {
+    const other = b[i];
+    return (
+      row.claimId === other.claimId &&
+      row.spaceId === other.spaceId &&
+      row.responseKind === other.responseKind &&
+      row.position === other.position &&
+      row.profileSpaceId === other.profileSpaceId
+    );
+  });
+}
+
+/** Key a position by who took it, on what, in which kind — the identity the graph enforces. */
+function positionKey(row: Pick<ParticipantPosition, 'profileSpaceId' | 'claimId' | 'responseKind'>) {
+  return `${row.profileSpaceId.replace(/-/g, '').toLowerCase()}|${row.claimId.replace(/-/g, '').toLowerCase()}|${row.responseKind}`;
+}
+
+/**
+ * Fetched rows, with the viewer's in-flight writes applied on top.
+ *
+ * A pending write is by definition newer than anything the query returned, so it wins — and a
+ * pending *removal* (`position === null`) deletes the row rather than adding one. Once the write
+ * lands and the refetch arrives the two agree, so the overlay stops being visible without needing
+ * to be torn down.
+ */
+export function applyPendingPositions(
+  fetched: ParticipantPosition[],
+  pending: ParticipantPosition[]
+): ParticipantPosition[] {
+  if (pending.length === 0) return fetched;
+  const merged = new Map(fetched.map(row => [positionKey(row), row]));
+  for (const row of pending) {
+    if (row.position === null) merged.delete(positionKey(row));
+    else merged.set(positionKey(row), row);
+  }
+  return [...merged.values()];
+}
+
+export function useParticipantPositions(
+  participants: DebateRematchParticipant[],
+  /** The viewer's own personal space id, so their in-flight writes can be shown immediately. */
+  localProfileSpaceId?: string | null
+) {
   const queryClient = useQueryClient();
   const foreground = useDebateAttention();
   const profileSpaceIds = React.useMemo(
@@ -240,7 +337,11 @@ export function useParticipantPositions(participants: DebateRematchParticipant[]
     placeholderData: keepPreviousData,
   });
 
-  const byClaim = React.useMemo(() => groupParticipantPositions(query.data ?? []), [query.data]);
+  const ownPending = useOwnPendingPositions(localProfileSpaceId);
+  const byClaim = React.useMemo(
+    () => groupParticipantPositions(applyPendingPositions(query.data ?? [], ownPending)),
+    [query.data, ownPending]
+  );
 
   return { byClaim, isLoading: query.isLoading, error: query.error };
 }


### PR DESCRIPTION
Closes the *own-position* half of **GEO-2784** — "this includes my own positions registering faster so the request debate button appears more quickly after my position is clicked."

## The wait is the write, not the polling

`use-entity-vote.ts` already records the number: **`web.write.entity_response` is p50 9.9s / p95 48.6s** (Sentry, 200 samples over 7 days). Nothing about refetch cadence changes that, so this stops waiting for it.

`pending.expectedResponse` is known locally the instant the write starts. The position is now shown from that and replaced by the real row when it lands — so the button appears on click rather than ~10 seconds later.

## Three implementation details that matter

**A pending removal is a tombstone, not a no-op.** `expectedResponse === null` means the viewer is taking a position *off*. Without carrying that through, the stale fetched row keeps it on screen until the next refetch — clicking on would have got fast while clicking off stayed slow.

**The overlay is attributed to the viewer's own profile space id**, passed in by the caller. An unattributed row is filtered straight back out by `participantSidesOn`, which matches on the current participants' space ids.

**The pending set is read through a cache subscription, not once.** Writes starting and settling are precisely the transitions that need to re-render this, and none of them re-render the hook on their own.

`pendingClaimResponse` is a deliberate sibling of `claimResponseIndexedEvent` rather than a relaxation of it — that one must keep waiting for `indexed`, because its job is to tell geo-chat something true.

## What this does *not* fix

The **opponent** still learns about a position only after this client notices it is indexed and notifies geo-chat, which emits `debate.claims_changed`. That path is untouched and still carries the full write latency, plus a 20s poll as backstop. So GEO-2784's cross-user half remains open, and it is a harder problem — it needs either a server-side notify before indexing completes, or the opponent trusting an unindexed signal.

Separately, the two latency findings from my #2311 review still stand and are the other lever on that half: `sourceUndecided` chains four queries serially before Featured can start, and `useClaimEntitiesByIds` lacks `retry: false` so one failing batch holds the skeleton through three retries with backoff (~7s).

## Testing

6 new tests on the merge (in-flight insert, override of a stale row, removal tombstone, dash-insensitive id matching, referential passthrough when nothing is pending, opponent rows untouched). 13 pass in `participant-positions.test.ts`; `tsc` clean.

**On the wider suite, being straight about it:** these directories are flaky in combined runs. Master shows 5 failures, this branch settles at 4, and the one test that differed on a first diff (`disables debate requests while a rematch request is pending`) passed in both repeat runs and passes in isolation. So no regression I can find — but the flakiness is real and pre-existing, and someone should look at the state leaking between those files.