### PR TITLE
fix(debates): fall back to muted when the browser blocks unmuted autoplay

### DIFF
--- a/apps/web/core/debates/playback-utils.test.ts
+++ b/apps/web/core/debates/playback-utils.test.ts
@@ -5,6 +5,7 @@ import {
   clampSeconds,
   hasProcessedVideo,
   normalizeTurnDurationsMs,
+  playBothWithMutedFallback,
   recordingWindowOffsetsSeconds,
   timelineSecondsFor,
   turnStateForTime,
@@ -134,5 +135,79 @@ describe('recordingWindowOffsetsSeconds', () => {
     const offsets = recordingWindowOffsetsSeconds('not-a-date', null, Number.NaN);
     expect(offsets.slot1).toBe(0);
     expect(offsets.slot2).toBe(0);
+  });
+});
+
+describe('playBothWithMutedFallback (GEO-2783)', () => {
+  /**
+   * A fake video whose `play()` refuses while it has audio, which is what the autoplay policy
+   * does outside a user gesture. `blockUnmuted: false` models a gesture-driven play, where the
+   * browser allows sound.
+   */
+  function fakeVideo({ muted, blockUnmuted = true }: { muted: boolean; blockUnmuted?: boolean }) {
+    const video = {
+      muted,
+      paused: true,
+      plays: 0,
+      async play() {
+        this.plays += 1;
+        if (blockUnmuted && !this.muted) throw new Error('NotAllowedError');
+        this.paused = false;
+      },
+    };
+    return video;
+  }
+
+  it('plays straight away when the browser allows it', async () => {
+    const a = fakeVideo({ muted: true });
+    const b = fakeVideo({ muted: true });
+    expect(await playBothWithMutedFallback(a, b)).toBe('playing');
+    expect([a.plays, b.plays]).toEqual([1, 1]);
+  });
+
+  /* The actual bug: unmuted autoplay is blocked, and the viewer used to get an error. */
+  it('retries muted when unmuted autoplay is blocked, and says so', async () => {
+    const a = fakeVideo({ muted: false });
+    const b = fakeVideo({ muted: false });
+    expect(await playBothWithMutedFallback(a, b)).toBe('playing-muted');
+    expect(a.muted).toBe(true);
+    expect(b.muted).toBe(true);
+    expect(a.paused).toBe(false);
+  });
+
+  it('retries when only one of the two is unmuted — the speaking slot is the audible one', async () => {
+    const a = fakeVideo({ muted: false });
+    const b = fakeVideo({ muted: true });
+    expect(await playBothWithMutedFallback(a, b)).toBe('playing-muted');
+  });
+
+  /* Already muted and still blocked means the cause is not the autoplay policy, so there is
+     nothing to retry and reporting 'playing-muted' would be a lie. */
+  it('does not retry when both were already muted', async () => {
+    const a = fakeVideo({ muted: true, blockUnmuted: false });
+    const b = fakeVideo({ muted: true, blockUnmuted: false });
+    a.play = async () => {
+      a.plays += 1;
+    }; // resolves but stays paused
+    expect(await playBothWithMutedFallback(a, b)).toBe('blocked');
+    expect(a.plays).toBe(1);
+  });
+
+  /* A resolved play() that leaves the element paused is also a block — only one of the two
+     failure shapes throws, which is why `paused` is checked as well as the promise. */
+  it('treats a resolved-but-paused play as blocked', async () => {
+    const a = fakeVideo({ muted: true });
+    a.play = async () => {
+      a.plays += 1;
+    };
+    const b = fakeVideo({ muted: true });
+    expect(await playBothWithMutedFallback(a, b)).toBe('blocked');
+  });
+
+  it('keeps sound when the play is gesture-driven', async () => {
+    const a = fakeVideo({ muted: false, blockUnmuted: false });
+    const b = fakeVideo({ muted: false, blockUnmuted: false });
+    expect(await playBothWithMutedFallback(a, b)).toBe('playing');
+    expect(a.muted).toBe(false);
   });
 });

--- a/apps/web/core/debates/playback-utils.ts
+++ b/apps/web/core/debates/playback-utils.ts
@@ -104,3 +104,45 @@ export function orderedParticipants(debate: Debate) {
 export function speakerLabel(participant: Pick<DebateParticipant, 'display_name' | 'profile_space_id'>) {
   return participant.display_name || participant.profile_space_id;
 }
+
+/** The two elements this helper needs, so tests do not have to build a whole `HTMLVideoElement`. */
+export type PlayableVideo = Pick<HTMLVideoElement, 'muted' | 'paused'> & { play: () => Promise<void> };
+
+export type PlayBothOutcome = 'playing' | 'playing-muted' | 'blocked';
+
+/**
+ * Start both recordings, falling back to muted when the browser blocks unmuted autoplay
+ * (GEO-2783).
+ *
+ * `play()` is rejected — or resolves while leaving the element paused — when it is not driven by a
+ * user gesture and the video has audio. The debate feed calls this from an effect as a debate
+ * scrolls into view, and the viewer's mute preference is a session-wide atom, so once anything has
+ * been unmuted every later autoplay is blocked and the viewer sees "Could not play both videos"
+ * for doing nothing.
+ *
+ * A blocked unmuted play is a request the browser will honour muted, so it is asked again muted
+ * before giving up. `'playing-muted'` is reported rather than folded into `'playing'` because the
+ * caller has to record that audio is now off — otherwise the UI offers a "mute" control on a
+ * silent video and the next autoplay fails identically.
+ *
+ * Both elements are checked for `paused` as well as the promise settling: a rejected `play()` and
+ * a resolved-but-still-paused one are both blocks, and only one of them throws.
+ */
+export async function playBothWithMutedFallback(
+  primary: PlayableVideo,
+  secondary: PlayableVideo
+): Promise<PlayBothOutcome> {
+  const attempt = async () => {
+    const results = await Promise.allSettled([primary.play(), secondary.play()]);
+    return results.every(result => result.status === 'fulfilled') && !primary.paused && !secondary.paused;
+  };
+
+  if (await attempt()) return 'playing';
+
+  // Nothing to retry if audio was already off — the block is not the autoplay policy.
+  if (primary.muted && secondary.muted) return 'blocked';
+
+  primary.muted = true;
+  secondary.muted = true;
+  return (await attempt()) ? 'playing-muted' : 'blocked';
+}

--- a/apps/web/core/debates/use-debate-playback.ts
+++ b/apps/web/core/debates/use-debate-playback.ts
@@ -11,6 +11,7 @@ import {
   clampSeconds,
   normalizeTurnDurationsMs,
   participantForSlot,
+  playBothWithMutedFallback,
   recordingWindowOffsetsSeconds,
   timelineSecondsFor,
   turnStateForTime,
@@ -212,19 +213,22 @@ export function useDebatePlayback(debate: Debate, enabled: boolean) {
     // allSettled never rejects, so a failed play() (e.g. blocked by autoplay
     // policy) leaves the video paused rather than throwing — check both the
     // settled results and the paused state, and surface the error inline.
-    const results = await Promise.allSettled([primaryVideo.play(), secondaryVideo.play()]);
-    const ok = results.every(result => result.status === 'fulfilled') && !primaryVideo.paused && !secondaryVideo.paused;
-    if (ok) {
-      setPlaying(true);
-      setUserPaused(false);
-    } else {
+    const outcome = await playBothWithMutedFallback(primaryVideo, secondaryVideo);
+    if (outcome === 'blocked') {
       primaryVideo.pause();
       secondaryVideo.pause();
       setPlaying(false);
       setTurnState(null);
       setError('Could not play both videos. Try Play again.');
+      return;
     }
-  }, [offsets.slot1, seekVideosTo, timelineSeconds]);
+    // The browser only allowed it muted (GEO-2783) — record that so the unmute control is honest
+    // and later autoplays stop being blocked the same way. The viewer's next tap is a gesture and
+    // will be allowed.
+    if (outcome === 'playing-muted') setMutedByUser(true);
+    setPlaying(true);
+    setUserPaused(false);
+  }, [offsets.slot1, seekVideosTo, setMutedByUser, timelineSeconds]);
 
   const playFromStart = React.useCallback(async () => {
     const primaryVideo = slot1VideoRef.current;


### PR DESCRIPTION
Closes **GEO-2783** — *"Could not play both videos. Try Play again."* on loading a debate full screen.

## Nothing was wrong with the videos

`mutedByUser` is a **session-wide atom**, deliberately, so unmuting one debate holds as you scroll to the next. It defaults to muted so a cold start is allowed — but once the viewer unmutes *anything* it stays unmuted, and `muted={!audible || mutedByUser}` leaves the speaking slot audible.

The feed then starts playback from an **effect** as a debate comes into view (`debate-feed-player.tsx:65`) — no user gesture. The browser refuses `play()`, `resumeBoth` sees both videos still paused, and the viewer gets an error for doing nothing wrong.

That explains why it looked intermittent and load-specific: **it only happens after you have unmuted once**, which anyone watching a debate does immediately. The hook's own comment flags this hazard for unmuting *mid-autoplay*, but nothing guarded a fresh autoplay when the atom was already unmuted.

## The fix

A blocked unmuted play is a request the browser *will* honour muted, so it is asked again muted before giving up.

`setMutedByUser(true)` on that path is not incidental — audio really is off, and leaving the atom claiming otherwise would show a "mute" control over a silent video and leave every later autoplay failing identically. The viewer's next tap on unmute **is** a gesture, so it is allowed.

## Why it moved out of the hook

Inside a `useCallback` closed over refs, this could not be tested. `playBothWithMutedFallback` now lives in `playback-utils` and reports `'playing'` / `'playing-muted'` / `'blocked'`, so the caller can distinguish "playing" from "playing, but I had to turn the sound off".

Both elements are checked for `paused` as well as the promise settling — a rejected `play()` and a resolved-but-still-paused one are both blocks and only one of them throws. That was already true of the original code and is preserved.

`playFromStart` delegates to `resumeBoth`, so it inherits the fallback.

## Testing

6 new tests (28 in `playback-utils.test.ts`), covering: the allowed case, the blocked-unmuted retry, only-one-slot-unmuted, the resolved-but-paused block, gesture-driven plays keeping sound, and the already-muted case where there is nothing to retry and reporting `'playing-muted'` would be a lie. `tsc` and prettier clean.

**On the wider suite:** `core/debates/` is flaky in combined runs — 2 failures on this branch, 2 on master, and *different tests each run* (`claims-tab` topic menu, `debates-hub-panel`). Verified by running master under the same conditions. So no regression, but the flakiness is real, pre-existing, and looks like state leaking between test files — worth someone's time separately.

## Not covered

If the block is not the autoplay policy — a decode failure, a 403 on the recording URL — this still reports `'blocked'` and shows the same message. That is correct behaviour, but it does mean the error string covers two very different causes, and a viewer who sees it after this lands has a genuinely broken video rather than a muting problem.