### PR TITLE
perf(explore): only exclude blocks and system rows when no type whitelist applies

### DIFF
--- a/apps/web/core/explore/feed-filter.test.ts
+++ b/apps/web/core/explore/feed-filter.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+
+import { EXPLORE_ENTITY_TYPE_IDS } from './explore-constants';
+import { buildFeedFilter } from './fetch-explore-feed';
+
+const SPACES = ['41e851610e13a19441c4d980f2f2ce6b'];
+
+/**
+ * The block/system exclusion is a `relations: { none: { or: [...] } }` clause — NOT EXISTS
+ * over a disjunction, which is the shape a planner handles worst. It only earns that where
+ * nothing narrower already constrains what comes back.
+ */
+describe('buildFeedFilter block/system exclusion', () => {
+  it('is dropped when a type whitelist already says what to include', () => {
+    const filter = buildFeedFilter({ spaceIds: SPACES, time: 'all', typeIds: EXPLORE_ENTITY_TYPE_IDS });
+
+    // Every Explore type is a concrete content type, so a block or a system-managed row
+    // cannot match one. Measured on testnet: over 400 entities under this whitelist the
+    // exclusion removed none of them.
+    expect(filter.relations).toBeUndefined();
+  });
+
+  it('is kept when there is no type whitelist, which is how Activity queries', () => {
+    const filter = buildFeedFilter({ spaceIds: SPACES, time: 'all' });
+
+    // Activity passes `typeIds: undefined` on purpose. Without this clause the same page
+    // carries blocks and system rows — 74 of 400 on testnet, 49 of them blocks.
+    expect(filter.relations).toBeDefined();
+    expect(filter.relations?.none?.or).toHaveLength(2);
+  });
+
+  it('treats an empty type list as no whitelist rather than as a whitelist of nothing', () => {
+    expect(buildFeedFilter({ spaceIds: SPACES, time: 'all', typeIds: [] }).relations).toBeDefined();
+  });
+
+  it('leaves the other clauses alone either way', () => {
+    const withTypes = buildFeedFilter({ spaceIds: SPACES, time: 'week', typeIds: EXPLORE_ENTITY_TYPE_IDS });
+    const withoutTypes = buildFeedFilter({ spaceIds: SPACES, time: 'week' });
+
+    // The name requirement and the recency window are independent of the exclusion.
+    for (const filter of [withTypes, withoutTypes]) {
+      expect(filter.values?.some?.propertyId).toBeDefined();
+      expect(filter.createdAt?.greaterThanOrEqualTo).toBeDefined();
+    }
+  });
+
+  it('still scopes by type in the filter when the caller asks for entity scope', () => {
+    const filter = buildFeedFilter({
+      spaceIds: SPACES,
+      time: 'all',
+      typeIds: EXPLORE_ENTITY_TYPE_IDS,
+      includeEntityScopeInFilter: true,
+    });
+
+    // Dropping the exclusion must not drop the whitelist it relies on being there.
+    expect(filter.typeIds?.overlaps).toEqual([...EXPLORE_ENTITY_TYPE_IDS]);
+    expect(filter.relations).toBeUndefined();
+  });
+});

--- a/apps/web/core/explore/fetch-explore-feed.ts
+++ b/apps/web/core/explore/fetch-explore-feed.ts
@@ -131,7 +131,8 @@ function decodeExploreBest(data: {
   return decodeConnection(data.entitiesRankedForFeedConnection ?? null);
 }
 
-function buildFeedFilter(args: {
+/** Exported for tests; callers should go through the page fetchers. */
+export function buildFeedFilter(args: {
   spaceIds: string[];
   time: ExploreTime;
   typeIds?: readonly string[];
@@ -140,7 +141,20 @@ function buildFeedFilter(args: {
 }): EntityFilter {
   const t = timeThresholdSec(args.time);
   return {
-    ...FEED_EXCLUDED_RELATIONS_FILTER,
+    // Only when nothing narrower is already saying what to include. A type whitelist
+    // subsumes this: every type Explore offers is a concrete content type, so a block or
+    // a system-managed row cannot match one in the first place. Measured against testnet
+    // — 400 entities under the full 12-type whitelist, the exclusion removed 0 of them,
+    // and not one carried a Data or Text block type.
+    //
+    // The Activity feed is the caller that needs it: it passes no `typeIds` at all, and
+    // without this the same 400 rows include 74 it would have to render — 49 of them
+    // blocks. So this is scoped, not deleted.
+    //
+    // Worth dropping where it is redundant because it is not free: `none` with an inner
+    // `or` compiles to NOT EXISTS over a disjunction, which cannot use an index per
+    // branch the way two separate NOT EXISTS clauses could.
+    ...(args.typeIds?.length ? {} : FEED_EXCLUDED_RELATIONS_FILTER),
     ...(args.includeEntityScopeInFilter
       ? {
           spaceIds: { overlaps: [...args.spaceIds] },


### PR DESCRIPTION
Relates to [GEO-2777](https://linear.app/geobrowser/issue/GEO-2777/speed-up-explore-load-replace-the-featured-spaces-tree-walk-fix-the).

`buildFeedFilter` unconditionally added the block/system exclusion:

```ts
relations: { none: { or: [
  { typeId: SYSTEM_TYPE, toEntityId: SYSTEM_ENTITY },
  { typeId: TYPES_PROPERTY, toEntityId: { in: [DATA_BLOCK, TEXT_BLOCK] } },
] } }
```

That compiles to `NOT EXISTS` over a disjunction — the shape a planner handles worst, since it can't use an index per branch the way two separate `NOT EXISTS` clauses could. Worth carrying only where it actually does something.

## It does nothing under a type whitelist

Every type Explore offers is a concrete content type — News story, Episode, Post, Tweet, Event, Paper, Person, Project, Ranking block, Community call event, Debate, Claim. A Data block, a Text block or a system-managed row can't match one to begin with.

Measured against testnet, 400 entities, full 12-type whitelist:

| Path | Rows removed by the exclusion | Carrying a Data/Text block type |
|---|---|---|
| **Explore** (12-type whitelist) | **0 of 400** | **0** |
| **Activity** (`typeIds: undefined`) | **74 of 400** | 49 |

So it's scoped, not deleted. Activity passes no `typeIds` at all ([activity/feed/route.ts:78](https://github.com/geobrowser/geogenesis/blob/master/apps/web/app/api/activity/feed/route.ts#L78)) and genuinely needs it — without the clause 18% of its page is blocks and system rows.

## Why it's safe

The whitelist is enforced independently of this filter: `fetchExploreEntitiesPage` and `fetchTopEntitiesPage` both pass `typeIds` as their own top-level variable, so it applies whether or not `includeEntityScopeInFilter` also puts a copy inside the filter. Dropping the exclusion can't drop the constraint it relies on.

Empty `typeIds` is treated as "no whitelist" rather than "a whitelist of nothing", matching how the fetchers already read it (`args.typeIds?.length`).

## Scope — please read before expecting a speedup

**This touches New and Top only.** Best passes no `filter` at all; its exclusions live inside `entities_ranked_for_feed`. Best is the default sort, and it's the one measured at `queryMs: 10324` on a slow load — so this is a correctness/simplification win, **not** a fix for the cold-load problem.

I'm being explicit because an earlier PR on that ticket was written as a cold-load fix and turned out to address something that accounts for ~200ms of an 11,000ms request. I don't want to repeat that framing. What I can say for this change: it removes a clause that provably does nothing on the Explore path.

If the same disjunctive-`NOT EXISTS` pattern exists inside `entities_ranked_for_feed`, the equivalent change there would land on the default sort — but that's a backend migration and I can't see that function from here.

## Two things worth a look

- **`Ranking block` is in the Explore whitelist** while [explore-best-document.ts](https://github.com/geobrowser/geogenesis/blob/master/apps/web/core/explore/explore-best-document.ts#L15) says ranking blocks are excluded server-side for Best. So Best and New/Top may already disagree about ranking blocks, independent of this PR.
- **"0 of 400" is current data, not a guarantee.** An entity carrying both a whitelisted type *and* a block type would now reach Explore. None exist today.

## Testing

- New `feed-filter.test.ts` — 5 cases: dropped under a whitelist, kept without one, empty list treated as no whitelist, other clauses (name requirement, recency window) unaffected either way, and the whitelist still present when `includeEntityScopeInFilter` is set.
- `buildFeedFilter` is now exported for those tests; callers still go through the page fetchers.
- Full `apps/web` suite green: **372 files, 4010 tests**.
- Typecheck clean. Formatted the new test only — `fetch-explore-feed.ts` is not prettier-clean on master, so running it over the whole file would have added unrelated churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
