### PR TITLE
feat(explore): make the Explore welcome banner debate-focused and open the debates hub

### DIFF
--- a/apps/web/partials/explore/explore-welcome-banner.test.tsx
+++ b/apps/web/partials/explore/explore-welcome-banner.test.tsx
@@ -1,0 +1,61 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { Provider, createStore } from 'jotai';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { ExploreWelcomeBanner } from './explore-welcome-banner';
+import { debatesHubAtom, dismissedNoticesAtom } from '~/atoms';
+
+function renderBanner(store = createStore()) {
+  render(
+    <Provider store={store}>
+      <ExploreWelcomeBanner />
+    </Provider>
+  );
+
+  return store;
+}
+
+afterEach(cleanup);
+
+describe('ExploreWelcomeBanner', () => {
+  it('opens the debates hub on the claims tab when the inline link is clicked', async () => {
+    const store = renderBanner();
+    expect(store.get(debatesHubAtom)).toBeNull();
+
+    await userEvent.click(screen.getByRole('button', { name: 'debate hub' }));
+
+    // Claims is the hub's default tab, and the one the banner's copy points at.
+    expect(store.get(debatesHubAtom)).toEqual({ tab: 'claims' });
+  });
+
+  // The link and the dismiss button sit in the same card; opening the hub shouldn't cost the
+  // user the banner, and dismissing shouldn't open a panel they didn't ask for.
+  it('keeps the banner visible after opening the hub', async () => {
+    const store = renderBanner();
+
+    await userEvent.click(screen.getByRole('button', { name: 'debate hub' }));
+
+    expect(store.get(dismissedNoticesAtom)).not.toContain('exploreWelcomeCurator');
+    expect(screen.getByRole('button', { name: 'debate hub' })).toBeInTheDocument();
+  });
+
+  it('dismisses without opening the hub', async () => {
+    const store = renderBanner();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Dismiss welcome banner' }));
+
+    expect(store.get(debatesHubAtom)).toBeNull();
+    expect(screen.queryByRole('button', { name: 'debate hub' })).not.toBeInTheDocument();
+  });
+
+  it('stays hidden once the notice has already been dismissed', () => {
+    const store = createStore();
+    store.set(dismissedNoticesAtom, ['exploreWelcomeCurator']);
+    renderBanner(store);
+
+    expect(screen.queryByRole('button', { name: 'debate hub' })).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/partials/explore/explore-welcome-banner.test.tsx
+++ b/apps/web/partials/explore/explore-welcome-banner.test.tsx
@@ -3,10 +3,16 @@ import { cleanup, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { Provider, createStore } from 'jotai';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { ExploreWelcomeBanner } from './explore-welcome-banner';
 import { debatesHubAtom, dismissedNoticesAtom } from '~/atoms';
+
+// Deliberately the literal rather than an import of the component's `WELCOME_BANNER_ID`. The id is
+// a persistence contract: it is already in real users' localStorage, and renaming it re-shows the
+// banner to everyone who has dismissed it. Importing the const would let a rename slip through
+// green; hardcoding it means the rename has to be a conscious edit here too.
+const PERSISTED_NOTICE_ID = 'exploreWelcomeCurator';
 
 function renderBanner(store = createStore()) {
   render(
@@ -18,6 +24,13 @@ function renderBanner(store = createStore()) {
   return store;
 }
 
+const hubLink = () => screen.getByRole('button', { name: 'debate hub' });
+
+// `dismissedNoticesAtom` is an `atomWithStorage`, so a fresh `createStore()` is not a fresh slate —
+// it rehydrates from localStorage, and a dismissal in one case would otherwise hide the banner in
+// every case after it.
+beforeEach(() => localStorage.clear());
+
 afterEach(cleanup);
 
 describe('ExploreWelcomeBanner', () => {
@@ -25,21 +38,22 @@ describe('ExploreWelcomeBanner', () => {
     const store = renderBanner();
     expect(store.get(debatesHubAtom)).toBeNull();
 
-    await userEvent.click(screen.getByRole('button', { name: 'debate hub' }));
+    await userEvent.click(hubLink());
 
-    // Claims is the hub's default tab, and the one the banner's copy points at.
+    // Claims is where the copy points the reader — taking a position on a claim is the first step,
+    // not requests or matches.
     expect(store.get(debatesHubAtom)).toEqual({ tab: 'claims' });
   });
 
-  // The link and the dismiss button sit in the same card; opening the hub shouldn't cost the
-  // user the banner, and dismissing shouldn't open a panel they didn't ask for.
+  // The link and the dismiss button sit in the same card, and the panel overlays the page the
+  // banner is on. Opening the hub shouldn't cost the user the banner underneath it.
   it('keeps the banner visible after opening the hub', async () => {
     const store = renderBanner();
 
-    await userEvent.click(screen.getByRole('button', { name: 'debate hub' }));
+    await userEvent.click(hubLink());
 
-    expect(store.get(dismissedNoticesAtom)).not.toContain('exploreWelcomeCurator');
-    expect(screen.getByRole('button', { name: 'debate hub' })).toBeInTheDocument();
+    expect(store.get(dismissedNoticesAtom)).not.toContain(PERSISTED_NOTICE_ID);
+    expect(hubLink()).toBeInTheDocument();
   });
 
   it('dismisses without opening the hub', async () => {
@@ -51,9 +65,19 @@ describe('ExploreWelcomeBanner', () => {
     expect(screen.queryByRole('button', { name: 'debate hub' })).not.toBeInTheDocument();
   });
 
+  // Pins the stored value itself, not just the round trip: users who dismissed the curator-era
+  // banner must stay dismissed now that the copy is debate-focused.
+  it('dismisses under the notice id already persisted for existing users', async () => {
+    const store = renderBanner();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Dismiss welcome banner' }));
+
+    expect(store.get(dismissedNoticesAtom)).toEqual([PERSISTED_NOTICE_ID]);
+  });
+
   it('stays hidden once the notice has already been dismissed', () => {
     const store = createStore();
-    store.set(dismissedNoticesAtom, ['exploreWelcomeCurator']);
+    store.set(dismissedNoticesAtom, [PERSISTED_NOTICE_ID]);
     renderBanner(store);
 
     expect(screen.queryByRole('button', { name: 'debate hub' })).not.toBeInTheDocument();

--- a/apps/web/partials/explore/explore-welcome-banner.test.tsx
+++ b/apps/web/partials/explore/explore-welcome-banner.test.tsx
@@ -45,6 +45,17 @@ describe('ExploreWelcomeBanner', () => {
     expect(store.get(debatesHubAtom)).toEqual({ tab: 'claims' });
   });
 
+  // The desktop panel is a non-modal aside that takes no focus, so this attribute is the only
+  // signal a screen-reader user gets that pressing the link did anything.
+  it("reports the hub's expanded state to assistive tech", async () => {
+    renderBanner();
+    expect(hubLink()).toHaveAttribute('aria-expanded', 'false');
+
+    await userEvent.click(hubLink());
+
+    expect(hubLink()).toHaveAttribute('aria-expanded', 'true');
+  });
+
   // The link and the dismiss button sit in the same card, and the panel overlays the page the
   // banner is on. Opening the hub shouldn't cost the user the banner underneath it.
   it('keeps the banner visible after opening the hub', async () => {

--- a/apps/web/partials/explore/explore-welcome-banner.tsx
+++ b/apps/web/partials/explore/explore-welcome-banner.tsx
@@ -16,7 +16,7 @@ import { dismissedNoticesAtom } from '~/atoms';
 const WELCOME_BANNER_ID = 'exploreWelcomeCurator';
 
 /**
- * "Welcome to Geo: Find your first debate!" banner shown above the explore feed. Dismissible
+ * "Welcome to Geo - Find your first debate!" banner shown above the explore feed. Dismissible
  * via the close button in the top-right; the dismissed state persists in localStorage.
  *
  * Gated behind `ClientOnly` so we never SSR a banner the user has already dismissed
@@ -59,11 +59,11 @@ function WelcomeBanner() {
           <span aria-hidden className="mr-1.5">
             👋
           </span>
-          Welcome to Geo: Find your first debate!
+          Welcome to Geo - Find your first debate!
         </h2>
         <p className="mt-2 max-w-[338px] text-[16px] leading-[18px] font-normal tracking-[-0.48px] text-white">
           Take a position on claims you care about, then get matched with someone who wants to take the other side.
-          Record the debate and publish it.
+          Record the debate and publish it. Open the debate hub to get started!
         </p>
       </div>
 

--- a/apps/web/partials/explore/explore-welcome-banner.tsx
+++ b/apps/web/partials/explore/explore-welcome-banner.tsx
@@ -34,8 +34,6 @@ export function ExploreWelcomeBanner() {
 
 function WelcomeBanner() {
   const [dismissedNotices, setDismissedNotices] = useAtom(dismissedNoticesAtom);
-  // `open()` with no argument lands on the hub's Claims tab, which is where the sentence above
-  // sends the reader: taking a position on a claim is the first step, not requests or matches.
   const { open: openDebatesHub } = useDebatesHub();
 
   // Functional setter form so concurrent dismissals can't drop each other via a stale
@@ -70,11 +68,20 @@ function WelcomeBanner() {
           Take a position on claims you care about, then match with someone on the other side. Record the debate and
           publish it. Open the{' '}
           {/* The hub is a panel rather than a route, so this is a button and not a link — there is no
-              href to give it. Underlined so it still reads as the one actionable phrase in the sentence. */}
+              href to give it. `NavUtils.toDebatesPanel` is for links arriving from elsewhere; from a
+              page the hub is already mounted on, opening it directly beats navigating to do it.
+
+              Claims named explicitly rather than leaning on the hook's default, matching "Join a
+              debate" in the debate feed: this is where the copy above sends the reader, and it
+              shouldn't follow the default if that default is ever retuned for the navbar badge.
+
+              Styled as the inline prose link in the onboarding dialog, in white for the dark ground.
+              `button` inherits font and letter-spacing from the base layer, so it reads as part of
+              the sentence rather than a control dropped into it. */}
           <button
             type="button"
-            onClick={() => openDebatesHub()}
-            className="underline decoration-white/50 underline-offset-2 transition-colors duration-200 hover:decoration-white"
+            onClick={() => openDebatesHub('claims')}
+            className="text-white underline decoration-white underline-offset-2"
           >
             debate hub
           </button>{' '}

--- a/apps/web/partials/explore/explore-welcome-banner.tsx
+++ b/apps/web/partials/explore/explore-welcome-banner.tsx
@@ -11,10 +11,12 @@ import { dismissedNoticesAtom } from '~/atoms';
 
 // Persisted alongside the other one-time notices (see `dismissedNoticesAtom`). Once the
 // user dismisses the banner this id is appended to the list and it never renders again.
+// The id keeps its original `Curator` suffix even though the copy is now debate-focused —
+// changing it would re-show the banner to everyone who has already dismissed it.
 const WELCOME_BANNER_ID = 'exploreWelcomeCurator';
 
 /**
- * "Welcome to Geo - Become a curator!" banner shown above the explore feed. Dismissible
+ * "Welcome to Geo: Find your first debate!" banner shown above the explore feed. Dismissible
  * via the close button in the top-right; the dismissed state persists in localStorage.
  *
  * Gated behind `ClientOnly` so we never SSR a banner the user has already dismissed
@@ -57,11 +59,11 @@ function WelcomeBanner() {
           <span aria-hidden className="mr-1.5">
             👋
           </span>
-          Welcome to Geo - Become a curator!
+          Welcome to Geo: Find your first debate!
         </h2>
         <p className="mt-2 max-w-[338px] text-[16px] leading-[18px] font-normal tracking-[-0.48px] text-white">
-          Help organize topics, questions, claims, and relevant sources to improve the quality of discourse. Join spaces
-          and start contributing there.
+          Take a position on claims you care about, then get matched with someone who wants to take the other side.
+          Record the debate and publish it.
         </p>
       </div>
 

--- a/apps/web/partials/explore/explore-welcome-banner.tsx
+++ b/apps/web/partials/explore/explore-welcome-banner.tsx
@@ -4,6 +4,8 @@ import { useCallback } from 'react';
 
 import { useAtom } from 'jotai';
 
+import { useDebatesHub } from '~/core/debates/matchmaking/use-debates-hub';
+
 import { ClientOnly } from '~/design-system/client-only';
 import { CloseSmall } from '~/design-system/icons/close-small';
 
@@ -32,6 +34,9 @@ export function ExploreWelcomeBanner() {
 
 function WelcomeBanner() {
   const [dismissedNotices, setDismissedNotices] = useAtom(dismissedNoticesAtom);
+  // `open()` with no argument lands on the hub's Claims tab, which is where the sentence above
+  // sends the reader: taking a position on a claim is the first step, not requests or matches.
+  const { open: openDebatesHub } = useDebatesHub();
 
   // Functional setter form so concurrent dismissals can't drop each other via a stale
   // closure, and the guard keeps the id from being appended twice on a repeat click.
@@ -62,8 +67,18 @@ function WelcomeBanner() {
           Welcome to Geo - Find your first debate!
         </h2>
         <p className="mt-2 max-w-[338px] text-[16px] leading-[18px] font-normal tracking-[-0.48px] text-white">
-          Take a position on claims you care about, then get matched with someone who wants to take the other side.
-          Record the debate and publish it. Open the debate hub to get started!
+          Take a position on claims you care about, then match with someone on the other side. Record the debate and
+          publish it. Open the{' '}
+          {/* The hub is a panel rather than a route, so this is a button and not a link — there is no
+              href to give it. Underlined so it still reads as the one actionable phrase in the sentence. */}
+          <button
+            type="button"
+            onClick={() => openDebatesHub()}
+            className="underline decoration-white/50 underline-offset-2 transition-colors duration-200 hover:decoration-white"
+          >
+            debate hub
+          </button>{' '}
+          to get started!
         </p>
       </div>
 

--- a/apps/web/partials/explore/explore-welcome-banner.tsx
+++ b/apps/web/partials/explore/explore-welcome-banner.tsx
@@ -34,7 +34,7 @@ export function ExploreWelcomeBanner() {
 
 function WelcomeBanner() {
   const [dismissedNotices, setDismissedNotices] = useAtom(dismissedNoticesAtom);
-  const { open: openDebatesHub } = useDebatesHub();
+  const { isOpen: isDebatesHubOpen, open: openDebatesHub } = useDebatesHub();
 
   // Functional setter form so concurrent dismissals can't drop each other via a stale
   // closure, and the guard keeps the id from being appended twice on a repeat click.
@@ -77,9 +77,19 @@ function WelcomeBanner() {
 
               Styled as the inline prose link in the onboarding dialog, in white for the dark ground.
               `button` inherits font and letter-spacing from the base layer, so it reads as part of
-              the sentence rather than a control dropped into it. */}
+              the sentence rather than a control dropped into it.
+
+              `aria-expanded` because the desktop panel is a non-modal aside portaled to the end of
+              document.body: it takes no focus and sits nowhere near this sentence in reading order,
+              so without it activating this button announces nothing at all. (The mobile sheet traps
+              focus, so it announces itself either way.) Reports state rather than promising a
+              toggle — this button only ever opens, and the panel carries its own close affordances.
+              No `aria-controls` to go with it: the panel unmounts when closed, so the id it would
+              point at is absent exactly when the attribute would be read. Same call the navbar
+              opener makes. */}
           <button
             type="button"
+            aria-expanded={isDebatesHubOpen}
             onClick={() => openDebatesHub('claims')}
             className="text-white underline decoration-white underline-offset-2"
           >


### PR DESCRIPTION
Closes [GEO-2791](https://linear.app/geobrowser/issue/GEO-2791/explore-update-onboarding-card-copy-to-be-debate-focused)

## Why

Explore is shifting toward debate as the primary experience (see GEO-2790). The first thing a new user reads on the page was still a pitch to become a curator, which no longer matches what we want them to do next.

## What changed

`apps/web/partials/explore/explore-welcome-banner.tsx` — 25 lines changed, plus a new test file.

**Copy**

| | Before | After |
|---|---|---|
| Title | 👋 Welcome to Geo - Become a curator! | 👋 Welcome to Geo - Find your first debate! |
| Body | Help organize topics, questions, claims, and relevant sources to improve the quality of discourse. Join spaces and start contributing there. | Take a position on claims you care about, then match with someone on the other side. Record the debate and publish it. Open the debate hub to get started! |

**Behavior** — "debate hub" is now clickable and opens the debates matchmaking hub on its Claims tab.

## Design decisions

**Opens the panel directly rather than deep-linking.** There are two ways into the hub: `useDebatesHub().open()`, and the `?modal=debates` deep link behind `NavUtils.toDebatesPanel`. The deep link is documented as "the link that opens the debates hub *on arrival*" — for links pasted into emails and arriving from elsewhere. The banner is already on a page where the hub is mounted app-wide, so navigating in order to open a panel that's one atom set away would be the long way round, and the deep-link params strip themselves on arrival anyway so nothing is gained in the URL. Direct precedent: "Join a debate" in [`debate-feed.tsx`](apps/web/core/debates/browse/debate-feed.tsx#L167) does exactly this.

**Names the `claims` tab explicitly**, rather than relying on `useDebatesHub`'s default. Same precedent. The hook's default is a product decision about what the navbar megaphone should land on when nothing is pending — if that's ever retuned, this banner shouldn't silently follow it somewhere its own copy doesn't point.

**A `<button>`, not an `<a>`.** The hub is a panel, not a route; there's no `href` to give it. Styled to match the inline prose link in [`onboarding/dialog.tsx`](apps/web/partials/onboarding/dialog.tsx#L538) (`underline decoration-* underline-offset-2`), which is the existing pattern for a link inside a sentence, recoloured white for the dark ground. The base layer already gives `button` `cursor: pointer` and inherited font/letter-spacing, so it reads as part of the sentence.

**Not reusing `design-system/text-button.tsx`.** `TextButton` is `flex items-center` with a fixed `text-smallButton` size and grey/CTA colors — it would break out of the text flow and carry the wrong type and color for a word mid-paragraph.

**Clicking the link does not dismiss the banner.** Opening a panel and dismissing a notice are different intents, and the panel overlays the page the banner sits on. Pinned by a test in both directions.

**The dismissal id is unchanged on purpose.** `WELCOME_BANNER_ID` stays `'exploreWelcomeCurator'` even though the name now reads stale — it's already in real users' localStorage, and renaming it re-shows the banner to everyone who dismissed it. The test hardcodes the literal rather than importing the const, deliberately: importing it would let a rename pass green, and this id is a persistence contract that should require a conscious edit. Both are commented in place.

**Reports expanded state to assistive tech.** The desktop hub is a non-modal `<aside>` portaled to `document.body` — it takes no focus and lands nowhere near the banner in reading order, so the link needs `aria-expanded` to announce that anything happened. (The mobile sheet traps focus and announces itself regardless.) No `aria-controls`: the panel unmounts when closed, so the id would be absent exactly when the attribute is read — the navbar opener omits it for the same reason. Raised by Copilot.

**Signed-out visitors can use this.** The banner's audience is new users, so the destination has to work anonymously. It does — the hub coerces signed-in-only tabs to Claims for anonymous viewers (`visibleTab`, GEO-2725), and Claims is exactly where this link lands.

## Notes for review

**Wrapping.** The paragraph is capped at `max-w-[338px]`, so the wrap point doesn't move with viewport width — the copy just produces more lines and a slightly taller card. The `pr-48` → `sm:pr-5` reserve for the decorative image is untouched, so there's no new overflow risk from GEO-2774.

**Scope — the "Curator onboarding" card.** The ticket's notes mention a card titled "Curator onboarding" with a progress bar. That's a *different* component: `CuratorOnboardingSection` in the right-hand `explore-side-panel`, driven by `CURATOR_ONBOARDING_STEPS`. The copy quoted in the ticket lives only in this banner. The side-panel card and its curation-tracking steps are still curator-framed — making them debate-focused is a real behavior change (new milestones, new completion tracking) and wants its own ticket.

**Unrelated bug spotted, not fixed here.** [`personal-home-dashboard.tsx:303`](apps/web/app/home/personal-home-dashboard.tsx#L303) declares its own local `atomWithStorage` on the *same* `'dismissedNotices'` storage key instead of importing the shared atom from `~/atoms`. Two `atomWithStorage` instances on one key don't share in-memory state, so dismissals there and elsewhere won't agree until a reload. Pre-existing and outside this diff — flagging for a separate ticket.

## Testing

New `explore-welcome-banner.test.tsx`, 6 cases, all passing:

- clicking "debate hub" sets `debatesHubAtom` to the claims tab
- clicking it leaves the banner mounted and undismissed
- dismissing does not open the hub
- dismissing writes exactly the already-persisted notice id
- an already-dismissed notice keeps the banner hidden
- the link reports `aria-expanded` false → true across the click

The suite clears `localStorage` between cases — `dismissedNoticesAtom` is an `atomWithStorage`, so a fresh `createStore()` still rehydrates the previous case's dismissal and every test after the first would render an empty banner. That bit me while writing these.

Full `partials/explore` + `core/debates/matchmaking` suites: 386 passing. Prettier clean. `tsc --noEmit` reports nothing in the touched files (the 5 errors it does report are pre-existing in `core/responses/entity-response.test.ts`, byte-identical to base).