### PR TITLE
fix(debates): fall back when an anchored debate is gone, not just unresolvable (GEO-2785)

### DIFF
--- a/apps/web/core/debates/browse/debate-feed.test.tsx
+++ b/apps/web/core/debates/browse/debate-feed.test.tsx
@@ -4,7 +4,7 @@ import { act, cleanup, fireEvent, render, screen, within } from '@testing-librar
 import { Provider, createStore } from 'jotai';
 import { afterEach, assert, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import type { Debate } from '~/core/debates/api';
+import { type Debate, GeoChatRequestError } from '~/core/debates/api';
 
 import { DebatesBrowseFeed } from './debate-feed';
 import { debateFullscreenActiveAtom } from '~/atoms';
@@ -446,6 +446,32 @@ describe('DebatesBrowseFeed layout and scroll nudge', () => {
 
     expect(screen.queryByText('Entity page')).not.toBeInTheDocument();
     expect(screen.getByText('Loading debates…')).toBeInTheDocument();
+  });
+
+  // GEO-2785. A hidden debate reads as 404 on every by-id route, so the anchor fetch fails with a
+  // definitive answer rather than an ambiguous one. That has to fall back to the entity page: the
+  // transient-error path below deliberately HOLDS the feed, and holding it for a debate that is
+  // deliberately gone would strand the visitor on an error for content we chose to hide.
+  it('falls back when the anchor is gone (404), rather than holding on an error', () => {
+    mocks.debates = [completedDebate('debate-1', 'In the window', '2026-07-02T00:01:10.000Z')];
+    mocks.anchorDebate = null;
+    mocks.anchorError = new GeoChatRequestError('404 Not Found', 'debate_not_found', 404);
+
+    render(<DebatesBrowseFeed spaceId="space-1" initialDebateId="debate-99" fallback={<div>Entity page</div>} />);
+
+    expect(screen.getByText('Entity page')).toBeInTheDocument();
+  });
+
+  // The contrast that makes the case above load-bearing: a transient failure is *unknown*, so it
+  // must NOT fall back -- that would misreport a blip as "this debate has no video".
+  it('holds the feed on a non-404 anchor error instead of falling back', () => {
+    mocks.debates = [completedDebate('debate-1', 'In the window', '2026-07-02T00:01:10.000Z')];
+    mocks.anchorDebate = null;
+    mocks.anchorError = new GeoChatRequestError('500 Internal Server Error', null, 500);
+
+    render(<DebatesBrowseFeed spaceId="space-1" initialDebateId="debate-99" fallback={<div>Entity page</div>} />);
+
+    expect(screen.queryByText('Entity page')).not.toBeInTheDocument();
   });
 
   // A debate that genuinely is not watchable anywhere still reaches the entity page.

--- a/apps/web/core/debates/browse/debate-feed.tsx
+++ b/apps/web/core/debates/browse/debate-feed.tsx
@@ -8,7 +8,7 @@ import cx from 'classnames';
 import { useSetAtom } from 'jotai';
 
 import { CLAIM_TYPE_ID, TOPICS_PROPERTY_ID } from '~/core/claims/ontology';
-import type { Debate } from '~/core/debates/api';
+import { type Debate, GeoChatRequestError } from '~/core/debates/api';
 import { useDebate, useProcessedVideoDebateIds, useSpaceDebates } from '~/core/debates/hooks';
 import { useGeoChatAuth } from '~/core/debates/hooks';
 import { useDebatesHub } from '~/core/debates/matchmaking/use-debates-hub';
@@ -187,11 +187,21 @@ export function DebatesBrowseFeed({
 
   const anchorUnresolved = initialDebateId != null && !anchorPresent;
 
+  // A 404 is the exception to the rule below: it is a definitive answer, not a failed lookup. The
+  // debate is not there -- it never existed, or it has been hidden (GEO-2785, which makes every
+  // by-id route read as absent). Treating that as "unknown" would hold the feed on an error state
+  // for a debate that is deliberately gone, so it falls through to `anchorMissing` and the
+  // caller's fallback view instead.
+  const anchorGone = anchorQuery.error instanceof GeoChatRequestError && anchorQuery.error.status === 404;
+
   // An anchor absent after a failed lookup is *unknown*, not missing: falling
   // back would misread a transient readiness/query error as "this debate has no
   // video", so the feed stays up and shows its own error state instead.
   const anchorErrored =
-    anchorUnresolved && !isLoading && (mediaError || debatesQuery.error != null || anchorQuery.error != null);
+    anchorUnresolved &&
+    !isLoading &&
+    !anchorGone &&
+    (mediaError || debatesQuery.error != null || anchorQuery.error != null);
 
   // Hold an anchored feed until the anchor itself is ready: the per-debate
   // readiness lookups resolve one at a time, so painting the partial list would


### PR DESCRIPTION
## What

A 404 from the anchor fetch now falls back to the caller's view instead of holding the feed on an error state.

## Why

Pairs with **geo-chat#94**, which makes a hidden debate read as `debate_not_found` on every by-id route.

The feed resolves an anchor that is missing from the space listing by fetching it **by id** (the GEO-2764 path). With hiding in place that fetch 404s, and the error landed in `anchorErrored` — which deliberately *holds* the feed rather than falling back. That's the right call for a transient failure and the wrong one here: a visitor following a link to a hidden debate would be stranded on an error for content we chose to hide.

A 404 is a definitive answer, not a failed lookup, so it falls through to `anchorMissing` and the fallback view — the same place an unwatchable or unlisted debate already lands. Every other error keeps holding the feed, because "unknown" must not be reported to the viewer as "this debate has no video".

This also matters beyond hiding: a debate deleted or never-existent previously produced the same stuck error state.

## How it can tell

`GeoChatRequestError` carries the HTTP `status`, so 404 is separable from a blip. `retry: false` on the debate queries means it surfaces immediately rather than after three retries.

## Tests

Two, and the pair is the point:

- `falls back when the anchor is gone (404), rather than holding on an error`
- `holds the feed on a non-404 anchor error instead of falling back` — the contrast that makes the first one load-bearing rather than a blanket "always fall back"

I verified the 404 test **fails without the fix** (and that the 500 test still passes with the fix removed, confirming it's genuinely discriminating on status rather than on the presence of an error). Full file: 42 passed.

## Sequencing

Independent of geo-chat#94 — safe to land in either order. Before #94 deploys, nothing 404s and this is dormant; after, it's what keeps the hidden case from looking like a bug.
