### PR TITLE
fix(votes): make the vote controls one grey, not four treatments

### DIFF
--- a/apps/web/partials/entity-page/entity-vote-buttons.selected-state.test.tsx
+++ b/apps/web/partials/entity-page/entity-vote-buttons.selected-state.test.tsx
@@ -114,6 +114,20 @@ describe('the selected vote treatment', () => {
       expect(inlineButtons().up).toHaveClass(VOTE_CHEVRON_SELECTED_CLASS);
     });
 
+    // Presence is not enough, and this is the assertion the first version of this file was missing.
+    // `cx` is `classnames`: it concatenates rather than resolving conflicting Tailwind utilities,
+    // so emitting the grey alongside the darker colour leaves the winner to whichever rule Tailwind
+    // emits second — and it emitted grey, silently deleting this exception. jsdom evaluates no
+    // cascade, so only the absence of the competing class can catch it.
+    it('does not also carry the grey it is meant to override', () => {
+      mocks.optimisticResponse = 'positive';
+      render(<EntityVoteButtons entityId="entity-1" spaceId={SPACE} responseKind="veracity" />, { wrapper });
+
+      const { up } = inlineButtons();
+      expect(up).not.toHaveClass('text-grey-03');
+      expect(up.className.match(/(^|\s)text-/g) ?? []).toHaveLength(1);
+    });
+
     it('leaves the direction the viewer did not pick grey', () => {
       mocks.optimisticResponse = 'positive';
       render(<EntityVoteButtons entityId="entity-1" spaceId={SPACE} responseKind="veracity" />, { wrapper });

--- a/apps/web/partials/entity-page/entity-vote-buttons.selected-state.test.tsx
+++ b/apps/web/partials/entity-page/entity-vote-buttons.selected-state.test.tsx
@@ -10,15 +10,15 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ResponseKind } from '~/core/responses/entity-response';
 
 import { EntityVoteButtons } from './entity-vote-buttons';
-import { VOTE_SELECTED_CLASS } from './vote-button-styles';
+import { VOTE_BUTTON_CLASS, VOTE_CHEVRON_SELECTED_CLASS } from './vote-button-styles';
 
 /**
  * GEO-2792. Four surfaces had four answers for "this is the one you picked": curation said it with
- * fill alone, stance said `grey-04`, veracity said a hand-written `#2A2B2E`, and the debates pill
- * said blue for up and red for down.
+ * fill alone, stance darkened to `grey-04`, veracity used a hand-written `#2A2B2E`, and the debates
+ * pill went blue for up and red for down.
  *
- * These assert the shared class rather than a literal, so the treatment can be changed in one place
- * — but they still fail if a surface stops reading it, which is the drift that produced the ticket.
+ * They now all say it the way curation always did — grey, with the filled icon carrying the signal.
+ * The chevrons keep their darker selected colour, since a chevron has no filled form to switch to.
  */
 const SPACE = '41e851610e13a19441c4d980f2f2ce6b';
 
@@ -79,26 +79,47 @@ beforeEach(() => {
 afterEach(cleanup);
 
 describe('the selected vote treatment', () => {
-  // Every inline response kind, including curation — which used to get no colour class at all and
-  // pinned its arrow to `grey-03`, so a curated row looked the same voted or not.
+  // Grey in both states. Being picked is said by the icon filling in, not by the colour changing —
+  // which is how the curation arrows on tables and Explore have always worked.
   describe.each<[string, ResponseKind]>([
     ['curation arrows', 'curation'],
     ['stance thumbs', 'stance'],
-    ['veracity chevrons', 'veracity'],
   ])('%s', (_label, responseKind) => {
-    it('marks the picked direction with the shared class', () => {
+    it('stays grey whether or not it is the one picked', () => {
       mocks.optimisticResponse = 'positive';
       render(<EntityVoteButtons entityId="entity-1" spaceId={SPACE} responseKind={responseKind} />, { wrapper });
 
-      expect(inlineButtons().up).toHaveClass(VOTE_SELECTED_CLASS);
+      const { up, down } = inlineButtons();
+      expect(up).toHaveClass('text-grey-03');
+      expect(down).toHaveClass('text-grey-03');
+    });
+
+    // The thumbs used to darken to `grey-04` when picked, which is the drift this closes.
+    it('does not darken the picked direction', () => {
+      mocks.optimisticResponse = 'positive';
+      render(<EntityVoteButtons entityId="entity-1" spaceId={SPACE} responseKind={responseKind} />, { wrapper });
+
+      expect(inlineButtons().up).not.toHaveClass('text-text');
+      expect(inlineButtons().up.className).not.toMatch(/(^|\s)text-grey-04(\s|$)/);
+    });
+  });
+
+  // Deliberately exempt, and unchanged from what shipped: a chevron has no filled form, so colour
+  // is the only signal it has.
+  describe('veracity chevrons', () => {
+    it('keeps its own darker selected colour', () => {
+      mocks.optimisticResponse = 'positive';
+      render(<EntityVoteButtons entityId="entity-1" spaceId={SPACE} responseKind="veracity" />, { wrapper });
+
+      expect(inlineButtons().up).toHaveClass(VOTE_CHEVRON_SELECTED_CLASS);
     });
 
     it('leaves the direction the viewer did not pick grey', () => {
       mocks.optimisticResponse = 'positive';
-      render(<EntityVoteButtons entityId="entity-1" spaceId={SPACE} responseKind={responseKind} />, { wrapper });
+      render(<EntityVoteButtons entityId="entity-1" spaceId={SPACE} responseKind="veracity" />, { wrapper });
 
       const { down } = inlineButtons();
-      expect(down).not.toHaveClass(VOTE_SELECTED_CLASS);
+      expect(down).not.toHaveClass(VOTE_CHEVRON_SELECTED_CLASS);
       expect(down).toHaveClass('text-grey-03');
     });
   });
@@ -121,16 +142,6 @@ describe('the selected vote treatment', () => {
       };
     }
 
-    it.each([
-      ['up', 'positive' as const],
-      ['down', 'negative' as const],
-    ])('marks a picked %s with the same class as everywhere else', (_direction, response) => {
-      mocks.optimisticResponse = response;
-      const { pressed } = renderPill();
-
-      expect(pressed).toHaveClass(VOTE_SELECTED_CLASS);
-    });
-
     // The specific complaint: full screen rendered `ctaPrimary` for up and `red-01` for down, the
     // only surface in the app using either for this.
     it.each([
@@ -145,18 +156,27 @@ describe('the selected vote treatment', () => {
       expect(pressed.className).not.toMatch(/aria-pressed:text-(ctaPrimary|red-01)/);
     });
 
-    it('leaves the direction the viewer did not pick grey', () => {
+    it('reads the same grey as every other surface, picked or not', () => {
       mocks.optimisticResponse = 'positive';
-      const { unpressed } = renderPill();
+      const { pressed, unpressed } = renderPill();
 
-      expect(unpressed).not.toHaveClass(VOTE_SELECTED_CLASS);
-      expect(unpressed).toHaveClass('text-grey-04');
+      expect(pressed).toHaveClass('text-grey-03');
+      expect(unpressed).toHaveClass('text-grey-03');
+    });
+
+    // It rested a shade darker than the inline controls and hovered all the way to black, which is
+    // the same divergence one state over.
+    it('no longer rests darker or hovers to black', () => {
+      mocks.optimisticResponse = 'positive';
+      const { pressed } = renderPill();
+
+      expect(pressed.className).not.toMatch(/(^|\s)text-grey-04(\s|$)/);
+      expect(pressed).not.toHaveClass('hover:text-text');
     });
   });
 
-  // The token, not a near-black typed by hand. `#2A2B2E` appears in a dozen files and is not in the
-  // theme; `text` is, at `#202020`.
-  it('uses a theme token rather than a hardcoded colour', () => {
-    expect(VOTE_SELECTED_CLASS).toBe('text-text');
+  // One definition, so the greys cannot drift apart again.
+  it('shares one class between the pill and the inline controls', () => {
+    expect(VOTE_BUTTON_CLASS).toBe('text-grey-03 hover:text-grey-04');
   });
 });

--- a/apps/web/partials/entity-page/entity-vote-buttons.selected-state.test.tsx
+++ b/apps/web/partials/entity-page/entity-vote-buttons.selected-state.test.tsx
@@ -1,0 +1,162 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import '@testing-library/jest-dom/vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+
+import type { ReactNode } from 'react';
+
+import { Effect } from 'effect';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { ResponseKind } from '~/core/responses/entity-response';
+
+import { EntityVoteButtons } from './entity-vote-buttons';
+import { VOTE_SELECTED_CLASS } from './vote-button-styles';
+
+/**
+ * GEO-2792. Four surfaces had four answers for "this is the one you picked": curation said it with
+ * fill alone, stance said `grey-04`, veracity said a hand-written `#2A2B2E`, and the debates pill
+ * said blue for up and red for down.
+ *
+ * These assert the shared class rather than a literal, so the treatment can be changed in one place
+ * — but they still fail if a surface stops reading it, which is the drift that produced the ticket.
+ */
+const SPACE = '41e851610e13a19441c4d980f2f2ce6b';
+
+const mocks = vi.hoisted(() => ({
+  optimisticResponse: undefined as 'positive' | 'negative' | undefined,
+}));
+
+vi.mock('@geogenesis/auth', () => ({ useGeoLogin: () => ({ login: vi.fn() }) }));
+
+vi.mock('~/core/analytics', () => ({
+  downvoted: vi.fn(),
+  trackPrivyAuth: vi.fn(),
+  upvoted: vi.fn(),
+  voteCast: vi.fn(),
+}));
+
+vi.mock('~/core/hooks/use-entity-vote', () => ({
+  useEntityResponse: () => ({
+    submitResponse: vi.fn(),
+    submitResponseAsync: vi.fn(),
+    optimisticResponse: mocks.optimisticResponse,
+    isResponseIndexingDelayed: false,
+    isConnected: true,
+    personalSpaceId: 'profile-1',
+  }),
+}));
+
+vi.mock('~/core/hooks/use-smart-account', () => ({ useSmartAccount: () => ({ smartAccount: {} }) }));
+
+vi.mock('~/core/io/queries', () => ({
+  getClaimResponseSummaryPage: () => Effect.succeed([]),
+  getEntityResponseCounts: () => Effect.succeed({ positive: 2, negative: 1 }),
+  getEntityResponders: () => Effect.succeed([]),
+  getSpaces: () => Effect.succeed([]),
+  getUserEntityResponse: () => Effect.succeed(null),
+}));
+
+vi.mock('~/core/io/subgraph/fetch-profile', () => ({ fetchProfilesBySpaceIds: () => Effect.succeed([]) }));
+vi.mock('~/core/state/pending-personal-space', () => ({ usePendingPersonalSpace: () => ({ isPending: false }) }));
+vi.mock('~/core/sync/use-store', () => ({ useQueryEntity: () => ({ entity: null, isLoading: false }) }));
+vi.mock('~/partials/entity-page/claim-voter-avatars', () => ({ ClaimResponderAvatars: () => null }));
+
+function wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+/** Inline draws up, the score, then down. The score is a popover trigger, hence the gap. */
+function inlineButtons() {
+  const buttons = screen.getAllByRole('button');
+  return { up: buttons[0]!, down: buttons[2]! };
+}
+
+beforeEach(() => {
+  mocks.optimisticResponse = undefined;
+});
+
+afterEach(cleanup);
+
+describe('the selected vote treatment', () => {
+  // Every inline response kind, including curation — which used to get no colour class at all and
+  // pinned its arrow to `grey-03`, so a curated row looked the same voted or not.
+  describe.each<[string, ResponseKind]>([
+    ['curation arrows', 'curation'],
+    ['stance thumbs', 'stance'],
+    ['veracity chevrons', 'veracity'],
+  ])('%s', (_label, responseKind) => {
+    it('marks the picked direction with the shared class', () => {
+      mocks.optimisticResponse = 'positive';
+      render(<EntityVoteButtons entityId="entity-1" spaceId={SPACE} responseKind={responseKind} />, { wrapper });
+
+      expect(inlineButtons().up).toHaveClass(VOTE_SELECTED_CLASS);
+    });
+
+    it('leaves the direction the viewer did not pick grey', () => {
+      mocks.optimisticResponse = 'positive';
+      render(<EntityVoteButtons entityId="entity-1" spaceId={SPACE} responseKind={responseKind} />, { wrapper });
+
+      const { down } = inlineButtons();
+      expect(down).not.toHaveClass(VOTE_SELECTED_CLASS);
+      expect(down).toHaveClass('text-grey-03');
+    });
+  });
+
+  // The surface the ticket was filed about. `aria-pressed` is what tells the two apart here.
+  describe('the debates pill', () => {
+    function renderPill() {
+      render(
+        <EntityVoteButtons
+          entityId="entity-1"
+          spaceId={SPACE}
+          responseKind="curation"
+          presentation="debate-horizontal"
+        />,
+        { wrapper }
+      );
+      return {
+        pressed: screen.getByRole('button', { pressed: true }),
+        unpressed: screen.getByRole('button', { pressed: false }),
+      };
+    }
+
+    it.each([
+      ['up', 'positive' as const],
+      ['down', 'negative' as const],
+    ])('marks a picked %s with the same class as everywhere else', (_direction, response) => {
+      mocks.optimisticResponse = response;
+      const { pressed } = renderPill();
+
+      expect(pressed).toHaveClass(VOTE_SELECTED_CLASS);
+    });
+
+    // The specific complaint: full screen rendered `ctaPrimary` for up and `red-01` for down, the
+    // only surface in the app using either for this.
+    it.each([
+      ['up', 'positive' as const],
+      ['down', 'negative' as const],
+    ])('no longer colours a picked %s blue or red', (_direction, response) => {
+      mocks.optimisticResponse = response;
+      const { pressed } = renderPill();
+
+      expect(pressed).not.toHaveClass('text-ctaPrimary');
+      expect(pressed).not.toHaveClass('text-red-01');
+      expect(pressed.className).not.toMatch(/aria-pressed:text-(ctaPrimary|red-01)/);
+    });
+
+    it('leaves the direction the viewer did not pick grey', () => {
+      mocks.optimisticResponse = 'positive';
+      const { unpressed } = renderPill();
+
+      expect(unpressed).not.toHaveClass(VOTE_SELECTED_CLASS);
+      expect(unpressed).toHaveClass('text-grey-04');
+    });
+  });
+
+  // The token, not a near-black typed by hand. `#2A2B2E` appears in a dozen files and is not in the
+  // theme; `text` is, at `#202020`.
+  it('uses a theme token rather than a hardcoded colour', () => {
+    expect(VOTE_SELECTED_CLASS).toBe('text-text');
+  });
+});

--- a/apps/web/partials/entity-page/entity-vote-buttons.selected-state.test.tsx
+++ b/apps/web/partials/entity-page/entity-vote-buttons.selected-state.test.tsx
@@ -18,6 +18,9 @@ import { VOTE_BUTTON_CLASS, VOTE_CHEVRON_SELECTED_CLASS } from './vote-button-st
  * pill went blue for up and red for down.
  *
  * They now all say it the way curation always did — grey, with the filled icon carrying the signal.
+ * The shade is `grey-04` rather than the lighter `grey-03` most of them rested at: these icons are
+ * the control, so WCAG 1.4.11 asks 3:1 of them, and `grey-03` gives 2.03:1 on white.
+ *
  * The chevrons keep their darker selected colour, since a chevron has no filled form to switch to.
  */
 const SPACE = '41e851610e13a19441c4d980f2f2ce6b';
@@ -90,17 +93,18 @@ describe('the selected vote treatment', () => {
       render(<EntityVoteButtons entityId="entity-1" spaceId={SPACE} responseKind={responseKind} />, { wrapper });
 
       const { up, down } = inlineButtons();
-      expect(up).toHaveClass('text-grey-03');
-      expect(down).toHaveClass('text-grey-03');
+      expect(up).toHaveClass('text-grey-04');
+      expect(down).toHaveClass('text-grey-04');
     });
 
-    // The thumbs used to darken to `grey-04` when picked, which is the drift this closes.
-    it('does not darken the picked direction', () => {
+    // The thumbs used to darken when picked, which is the drift this closes: the two directions
+    // now differ only by fill.
+    it('does not colour the picked direction differently from the other', () => {
       mocks.optimisticResponse = 'positive';
       render(<EntityVoteButtons entityId="entity-1" spaceId={SPACE} responseKind={responseKind} />, { wrapper });
 
-      expect(inlineButtons().up).not.toHaveClass('text-text');
-      expect(inlineButtons().up.className).not.toMatch(/(^|\s)text-grey-04(\s|$)/);
+      const { up, down } = inlineButtons();
+      expect(up.className).toBe(down.className);
     });
   });
 
@@ -124,7 +128,7 @@ describe('the selected vote treatment', () => {
       render(<EntityVoteButtons entityId="entity-1" spaceId={SPACE} responseKind="veracity" />, { wrapper });
 
       const { up } = inlineButtons();
-      expect(up).not.toHaveClass('text-grey-03');
+      expect(up).not.toHaveClass('text-grey-04');
       expect(up.className.match(/(^|\s)text-/g) ?? []).toHaveLength(1);
     });
 
@@ -134,7 +138,7 @@ describe('the selected vote treatment', () => {
 
       const { down } = inlineButtons();
       expect(down).not.toHaveClass(VOTE_CHEVRON_SELECTED_CLASS);
-      expect(down).toHaveClass('text-grey-03');
+      expect(down).toHaveClass('text-grey-04');
     });
   });
 
@@ -174,23 +178,15 @@ describe('the selected vote treatment', () => {
       mocks.optimisticResponse = 'positive';
       const { pressed, unpressed } = renderPill();
 
-      expect(pressed).toHaveClass('text-grey-03');
-      expect(unpressed).toHaveClass('text-grey-03');
-    });
-
-    // It rested a shade darker than the inline controls and hovered all the way to black, which is
-    // the same divergence one state over.
-    it('no longer rests darker or hovers to black', () => {
-      mocks.optimisticResponse = 'positive';
-      const { pressed } = renderPill();
-
-      expect(pressed.className).not.toMatch(/(^|\s)text-grey-04(\s|$)/);
-      expect(pressed).not.toHaveClass('hover:text-text');
+      expect(pressed).toHaveClass('text-grey-04');
+      expect(unpressed).toHaveClass('text-grey-04');
     });
   });
 
-  // One definition, so the greys cannot drift apart again.
+  // One definition, so the greys cannot drift apart again. Pinned to the literal because the
+  // *value* is the point: `grey-03` reads 2.03:1 on white and fails WCAG 1.4.11's 3:1 for a
+  // control, which is what these icons are.
   it('shares one class between the pill and the inline controls', () => {
-    expect(VOTE_BUTTON_CLASS).toBe('text-grey-03 hover:text-grey-04');
+    expect(VOTE_BUTTON_CLASS).toBe('text-grey-04 hover:text-text');
   });
 });

--- a/apps/web/partials/entity-page/entity-vote-buttons.tsx
+++ b/apps/web/partials/entity-page/entity-vote-buttons.tsx
@@ -48,6 +48,7 @@ import { PrefetchLink as Link } from '~/design-system/prefetch-link';
 import { Skeleton } from '~/design-system/skeleton';
 
 import { ClaimResponderAvatars } from '~/partials/entity-page/claim-voter-avatars';
+import { VOTE_SELECTED_CLASS } from '~/partials/entity-page/vote-button-styles';
 import { avatarAtom, nameAtom, spaceIdAtom, stepAtom, topicIdAtom } from '~/partials/onboarding/dialog';
 
 import { postOnboardingRedirectAtom } from '~/atoms/post-onboarding-redirect';
@@ -337,15 +338,16 @@ export function EntityVoteButtons({
       return direction === 'up' ? <ThumbUp filled={active} /> : <ThumbDown filled={active} />;
     }
 
-    return <VoteArrow direction={direction} filled={active} color="grey-03" />;
+    // No `color`: the arrow takes `currentColor` from the button, so the one selected treatment
+    // below reaches curation too. Pinned to `grey-03` it stayed grey once picked, and `fill` alone
+    // had to carry the whole signal.
+    return <VoteArrow direction={direction} filled={active} />;
   };
 
-  const claimResponseButtonColor = (active: boolean) => {
-    if (variant === 'chevrons') {
-      return active ? 'text-[#2A2B2E]' : 'text-grey-03 hover:text-grey-04';
-    }
-    return isClaimVariant && (active ? 'text-grey-04' : 'text-grey-03 hover:text-grey-04');
-  };
+  // Every inline variant, curation included. It used to branch three ways — a hand-written
+  // near-black for chevrons, `grey-04` for thumbs, and nothing at all for curation, whose arrows
+  // pinned their own colour instead.
+  const responseButtonColor = (active: boolean) => (active ? VOTE_SELECTED_CLASS : 'text-grey-03 hover:text-grey-04');
 
   const claimResponderAvatars = isClaimVariant ? (
     <ClaimResponderAvatars
@@ -408,7 +410,7 @@ export function EntityVoteButtons({
         title={positiveTitle}
         className={cx(
           'group/vote flex h-5 w-5 items-center justify-center rounded transition-colors',
-          claimResponseButtonColor(positiveActive),
+          responseButtonColor(positiveActive),
           responseDisabled && 'cursor-default opacity-50'
         )}
       >
@@ -456,7 +458,7 @@ export function EntityVoteButtons({
         title={negativeTitle}
         className={cx(
           'group/vote flex h-5 w-5 items-center justify-center rounded transition-colors',
-          claimResponseButtonColor(negativeActive),
+          responseButtonColor(negativeActive),
           responseDisabled && 'cursor-default opacity-50'
         )}
       >
@@ -510,9 +512,12 @@ function DebateVotePill({
         disabled={disabled}
         title={positiveTitle}
         onClick={onPositive}
-        className="group/vote flex items-center justify-center text-grey-04 transition-colors hover:text-text disabled:cursor-default disabled:opacity-50 aria-pressed:text-ctaPrimary"
+        className={cx(
+          'group/vote flex items-center justify-center text-grey-04 transition-colors hover:text-text disabled:cursor-default disabled:opacity-50',
+          positiveActive && VOTE_SELECTED_CLASS
+        )}
       >
-        <VoteArrow direction="up" filled={positiveActive} color={positiveActive ? 'ctaPrimary' : undefined} />
+        <VoteArrow direction="up" filled={positiveActive} />
       </button>
       <span className="text-metadataMedium text-text tabular-nums">{score}</span>
       <button
@@ -522,9 +527,12 @@ function DebateVotePill({
         disabled={disabled}
         title={negativeTitle}
         onClick={onNegative}
-        className="group/vote flex items-center justify-center text-grey-04 transition-colors hover:text-text disabled:cursor-default disabled:opacity-50 aria-pressed:text-red-01"
+        className={cx(
+          'group/vote flex items-center justify-center text-grey-04 transition-colors hover:text-text disabled:cursor-default disabled:opacity-50',
+          negativeActive && VOTE_SELECTED_CLASS
+        )}
       >
-        <VoteArrow direction="down" filled={negativeActive} color={negativeActive ? 'red-01' : undefined} />
+        <VoteArrow direction="down" filled={negativeActive} />
       </button>
     </div>
   );

--- a/apps/web/partials/entity-page/entity-vote-buttons.tsx
+++ b/apps/web/partials/entity-page/entity-vote-buttons.tsx
@@ -48,7 +48,7 @@ import { PrefetchLink as Link } from '~/design-system/prefetch-link';
 import { Skeleton } from '~/design-system/skeleton';
 
 import { ClaimResponderAvatars } from '~/partials/entity-page/claim-voter-avatars';
-import { VOTE_SELECTED_CLASS } from '~/partials/entity-page/vote-button-styles';
+import { VOTE_BUTTON_CLASS, VOTE_CHEVRON_SELECTED_CLASS } from '~/partials/entity-page/vote-button-styles';
 import { avatarAtom, nameAtom, spaceIdAtom, stepAtom, topicIdAtom } from '~/partials/onboarding/dialog';
 
 import { postOnboardingRedirectAtom } from '~/atoms/post-onboarding-redirect';
@@ -338,16 +338,20 @@ export function EntityVoteButtons({
       return direction === 'up' ? <ThumbUp filled={active} /> : <ThumbDown filled={active} />;
     }
 
-    // No `color`: the arrow takes `currentColor` from the button, so the one selected treatment
-    // below reaches curation too. Pinned to `grey-03` it stayed grey once picked, and `fill` alone
-    // had to carry the whole signal.
+    // No `color`: the arrow takes `currentColor` from the button, which is where the grey now lives
+    // for every variant. Pinning it here meant this one icon answered for its own colour while the
+    // other two read the button's, which is how the three drifted apart.
     return <VoteArrow direction={direction} filled={active} />;
   };
 
-  // Every inline variant, curation included. It used to branch three ways — a hand-written
-  // near-black for chevrons, `grey-04` for thumbs, and nothing at all for curation, whose arrows
-  // pinned their own colour instead.
-  const responseButtonColor = (active: boolean) => (active ? VOTE_SELECTED_CLASS : 'text-grey-03 hover:text-grey-04');
+  // Grey either way; the filled icon says which one you picked. The thumbs used to darken to
+  // `grey-04` when picked and curation got no class at all, pinning its arrows' colour on the icon
+  // instead — three spellings of a control that should look the same everywhere.
+  //
+  // Chevrons are the exception, unchanged: a chevron has no filled form to switch to, so colour is
+  // the only signal it has.
+  const responseButtonColor = (active: boolean) =>
+    cx(VOTE_BUTTON_CLASS, variant === 'chevrons' && active && VOTE_CHEVRON_SELECTED_CLASS);
 
   const claimResponderAvatars = isClaimVariant ? (
     <ClaimResponderAvatars
@@ -513,8 +517,8 @@ function DebateVotePill({
         title={positiveTitle}
         onClick={onPositive}
         className={cx(
-          'group/vote flex items-center justify-center text-grey-04 transition-colors hover:text-text disabled:cursor-default disabled:opacity-50',
-          positiveActive && VOTE_SELECTED_CLASS
+          'group/vote flex items-center justify-center transition-colors disabled:cursor-default disabled:opacity-50',
+          VOTE_BUTTON_CLASS
         )}
       >
         <VoteArrow direction="up" filled={positiveActive} />
@@ -528,8 +532,8 @@ function DebateVotePill({
         title={negativeTitle}
         onClick={onNegative}
         className={cx(
-          'group/vote flex items-center justify-center text-grey-04 transition-colors hover:text-text disabled:cursor-default disabled:opacity-50',
-          negativeActive && VOTE_SELECTED_CLASS
+          'group/vote flex items-center justify-center transition-colors disabled:cursor-default disabled:opacity-50',
+          VOTE_BUTTON_CLASS
         )}
       >
         <VoteArrow direction="down" filled={negativeActive} />

--- a/apps/web/partials/entity-page/entity-vote-buttons.tsx
+++ b/apps/web/partials/entity-page/entity-vote-buttons.tsx
@@ -350,8 +350,13 @@ export function EntityVoteButtons({
   //
   // Chevrons are the exception, unchanged: a chevron has no filled form to switch to, so colour is
   // the only signal it has.
+  //
+  // One class or the other, never both. `cx` is `classnames`, which concatenates — it does not
+  // resolve conflicting Tailwind utilities the way `tailwind-merge` would, and this repo does not
+  // use that. Emitting `text-grey-03` alongside `text-[#2A2B2E]` leaves the winner to whichever
+  // rule Tailwind happens to emit second, which is not something this file gets to decide.
   const responseButtonColor = (active: boolean) =>
-    cx(VOTE_BUTTON_CLASS, variant === 'chevrons' && active && VOTE_CHEVRON_SELECTED_CLASS);
+    variant === 'chevrons' && active ? VOTE_CHEVRON_SELECTED_CLASS : VOTE_BUTTON_CLASS;
 
   const claimResponderAvatars = isClaimVariant ? (
     <ClaimResponderAvatars

--- a/apps/web/partials/entity-page/entity-vote-buttons.tsx
+++ b/apps/web/partials/entity-page/entity-vote-buttons.tsx
@@ -344,9 +344,10 @@ export function EntityVoteButtons({
     return <VoteArrow direction={direction} filled={active} />;
   };
 
-  // Grey either way; the filled icon says which one you picked. The thumbs used to darken to
-  // `grey-04` when picked and curation got no class at all, pinning its arrows' colour on the icon
-  // instead — three spellings of a control that should look the same everywhere.
+  // Grey either way; the filled icon says which one you picked. The thumbs used to rest lighter
+  // and darken when picked, and curation got no class at all, pinning its arrows' colour on the
+  // icon instead — three spellings of a control that should look the same everywhere. See
+  // `vote-button-styles` for why the shade is `grey-04` rather than the lighter `grey-03`.
   //
   // Chevrons are the exception, unchanged: a chevron has no filled form to switch to, so colour is
   // the only signal it has.

--- a/apps/web/partials/entity-page/vote-button-styles.ts
+++ b/apps/web/partials/entity-page/vote-button-styles.ts
@@ -1,27 +1,38 @@
 /**
  * How an upvote / downvote button is coloured, picked or not (GEO-2792).
  *
- * `grey-03`, in both states. Being the one you picked is said by the icon filling in — an arrow, a
- * thumb — not by the colour changing. That is how the curation arrows on tables and Explore have
- * always worked, and it is the treatment the other surfaces had drifted away from:
+ * `grey-04`, in both states. Being the one you picked is said by the icon filling in — an arrow, a
+ * thumb — not by the colour changing. That was already how the curation arrows on tables and
+ * Explore worked; what varied was the shade, and four surfaces had four answers:
  *
- * - the stance thumbs darkened to `grey-04` when picked
- * - the debates pill went `ctaPrimary` for up and `red-01` for down — blue and red, on the only
- *   surface in the app using either for this
+ * - curation arrows sat at `grey-03`, pinned on the icon rather than the button
+ * - the stance thumbs rested at `grey-03` and darkened to `grey-04` when picked
+ * - the debates pill rested at `grey-04` and went `ctaPrimary` for up, `red-01` for down — blue and
+ *   red, on the only surface in the app using either for this
  *
- * The veracity chevrons are the deliberate exception and keep their own darker selected state. A
- * chevron has no filled form to switch to, so colour is the only signal it has.
+ * `grey-04` rather than the lighter `grey-03` these mostly rested at, because these icons are the
+ * control: they carry both the affordance and the selected state, so WCAG 1.4.11 asks 3:1 of them
+ * against the white behind them. `grey-03` (`#B6B6B6`) gives 2.03:1 and fails; `grey-04`
+ * (`#606060`) gives 6.29:1. The pill was already the one surface meeting it, which is why hover
+ * borrows its `text` as well — a control resting at `grey-04` has to go somewhere darker still.
  *
- * One definition so the greys cannot drift apart again; the pill also rested a shade darker at
- * `grey-04`, which is the same divergence one state over.
+ * The veracity chevrons are the deliberate exception and keep their own selected colour. A chevron
+ * has no filled form to switch to, so colour is the only signal it has.
+ *
+ * One definition so these cannot drift apart again.
  */
-export const VOTE_BUTTON_CLASS = 'text-grey-03 hover:text-grey-04';
+export const VOTE_BUTTON_CLASS = 'text-grey-04 hover:text-text';
 
 /**
  * The veracity chevrons' selected colour, kept exactly as it shipped.
  *
  * Not a token: `#2A2B2E` is a near-black written by hand in about a dozen files, ten units off the
- * theme's own `text` (`#202020`). Left alone here because this ticket is about the greys, but it is
- * the one hardcoded colour still in this control.
+ * theme's own `text` (`#202020`). Left alone because this ticket is about the greys, but it is the
+ * one hardcoded colour still in this control.
+ *
+ * Applied *instead of* {@link VOTE_BUTTON_CLASS}, never alongside it. `cx` is `classnames`, which
+ * concatenates — it does not resolve conflicting Tailwind utilities the way `tailwind-merge` would,
+ * and this repo does not use that. Emitting both leaves the winner to whichever rule Tailwind
+ * happens to emit second, which is not something a component gets to decide.
  */
 export const VOTE_CHEVRON_SELECTED_CLASS = 'text-[#2A2B2E]';

--- a/apps/web/partials/entity-page/vote-button-styles.ts
+++ b/apps/web/partials/entity-page/vote-button-styles.ts
@@ -1,0 +1,25 @@
+/**
+ * How an upvote / downvote button says it is the one you picked (GEO-2792).
+ *
+ * One constant, because four surfaces had four answers and none of them referenced the others:
+ *
+ * - curation arrows on tables and entity pages said it with `fill` alone, leaving the arrow
+ *   `grey-03` whether or not you had voted
+ * - the stance thumbs said `text-grey-04`
+ * - the veracity chevrons said `text-[#2A2B2E]`, which is not a token — it is a near-black used
+ *   informally in a dozen files, ten units off the one the theme actually defines
+ * - the debates pill said `ctaPrimary` for up and `red-01` for down: blue and red, on the only
+ *   surface that used either
+ *
+ * `text` is the theme's own ink (`#202020`), which is what the chevrons were reaching for when
+ * they wrote `#2A2B2E` by hand. Selected means ink; everything else stays grey. The direction is
+ * already carried by the icon — an arrow, a thumb or a chevron, and its filled shape — so colour
+ * does not have to say it a second time, which is why up and down converge on one value rather
+ * than keeping the pill's blue/red pair.
+ *
+ * The resting and hover greys are deliberately *not* here. They differ by surface for a reason the
+ * selected state does not share: the pill sits on white with a border and rests at `grey-04`,
+ * while an inline row rests at the lighter `grey-03`. That is contrast against different
+ * backgrounds, not a disagreement about what "picked" looks like.
+ */
+export const VOTE_SELECTED_CLASS = 'text-text';

--- a/apps/web/partials/entity-page/vote-button-styles.ts
+++ b/apps/web/partials/entity-page/vote-button-styles.ts
@@ -1,25 +1,27 @@
 /**
- * How an upvote / downvote button says it is the one you picked (GEO-2792).
+ * How an upvote / downvote button is coloured, picked or not (GEO-2792).
  *
- * One constant, because four surfaces had four answers and none of them referenced the others:
+ * `grey-03`, in both states. Being the one you picked is said by the icon filling in — an arrow, a
+ * thumb — not by the colour changing. That is how the curation arrows on tables and Explore have
+ * always worked, and it is the treatment the other surfaces had drifted away from:
  *
- * - curation arrows on tables and entity pages said it with `fill` alone, leaving the arrow
- *   `grey-03` whether or not you had voted
- * - the stance thumbs said `text-grey-04`
- * - the veracity chevrons said `text-[#2A2B2E]`, which is not a token — it is a near-black used
- *   informally in a dozen files, ten units off the one the theme actually defines
- * - the debates pill said `ctaPrimary` for up and `red-01` for down: blue and red, on the only
- *   surface that used either
+ * - the stance thumbs darkened to `grey-04` when picked
+ * - the debates pill went `ctaPrimary` for up and `red-01` for down — blue and red, on the only
+ *   surface in the app using either for this
  *
- * `text` is the theme's own ink (`#202020`), which is what the chevrons were reaching for when
- * they wrote `#2A2B2E` by hand. Selected means ink; everything else stays grey. The direction is
- * already carried by the icon — an arrow, a thumb or a chevron, and its filled shape — so colour
- * does not have to say it a second time, which is why up and down converge on one value rather
- * than keeping the pill's blue/red pair.
+ * The veracity chevrons are the deliberate exception and keep their own darker selected state. A
+ * chevron has no filled form to switch to, so colour is the only signal it has.
  *
- * The resting and hover greys are deliberately *not* here. They differ by surface for a reason the
- * selected state does not share: the pill sits on white with a border and rests at `grey-04`,
- * while an inline row rests at the lighter `grey-03`. That is contrast against different
- * backgrounds, not a disagreement about what "picked" looks like.
+ * One definition so the greys cannot drift apart again; the pill also rested a shade darker at
+ * `grey-04`, which is the same divergence one state over.
  */
-export const VOTE_SELECTED_CLASS = 'text-text';
+export const VOTE_BUTTON_CLASS = 'text-grey-03 hover:text-grey-04';
+
+/**
+ * The veracity chevrons' selected colour, kept exactly as it shipped.
+ *
+ * Not a token: `#2A2B2E` is a near-black written by hand in about a dozen files, ten units off the
+ * theme's own `text` (`#202020`). Left alone here because this ticket is about the greys, but it is
+ * the one hardcoded colour still in this control.
+ */
+export const VOTE_CHEVRON_SELECTED_CLASS = 'text-[#2A2B2E]';


### PR DESCRIPTION
[GEO-2792](https://linear.app/geobrowser/issue/GEO-2792/audit-and-unify-the-upvote-downvote-selected-state-across-the-app)

## The audit

Every surface in the ticket's scope renders the same component, `EntityVoteButtons`, in one of two presentations — so the divergence was inside one file. Four answers to "this is the one you picked", none referencing the others:

| Where | Response kind | Selected was | |
|---|---|---|---|
| Tables, entity pages, entity rows, Explore ranking rows | curation | `grey-03`, filled — the fill was the whole signal | pinned on the icon |
| Claim cards, Explore, debates side panel | stance (thumbs) | rested `grey-03`, darkened to `grey-04` | |
| Claim surfaces with a veracity kind | veracity (chevrons) | `text-[#2A2B2E]` | not a token |
| Debates full screen + action row | any | `ctaPrimary` up / `red-01` down | the reported blue |

## The treatment

**`grey-04`, in both states.** Being picked is said by the icon filling in — an arrow, a thumb — not by the colour changing. That is how the curation arrows on tables and Explore have always worked, and it is what the other surfaces had drifted from.

One exported constant, `VOTE_BUTTON_CLASS`, read by the inline controls and the pill alike. The reasoning lives beside it in `vote-button-styles.ts` as the written reference the ticket asked for.

**Why `grey-04` and not the lighter `grey-03` most of these rested at.** These icons are the control — they carry the affordance and the selected state both — so WCAG 1.4.11 asks 3:1 of them against the white behind them. `grey-03` (`#B6B6B6`) gives **2.03:1** and fails; `grey-04` (`#606060`) gives **6.29:1**. The inline surfaces have sat at `grey-03` since long before this branch, so that shortfall is pre-existing — but the pill was already at `grey-04`, so unifying downward would have taken the one passing surface and broken it. Unify upward instead. Hover borrows the pill's `text` for the same reason: a control resting at `grey-04` has to go somewhere darker still.

Curation's arrows stop passing their own `color` to the icon and inherit from the button like the other two, so one place decides the colour instead of the icon answering for itself.

## The deliberate exception

**Veracity chevrons keep their darker selected colour.** A chevron has no filled form to switch to, so colour is the only signal it has — take it away and there is no selected state at all.

`#2A2B2E` is still not a token, and still ten units off the theme's `text` (`#202020`). It is now named and explained where it lives rather than sitting inline, but tokenizing it would change how the chevrons look, which is outside this ticket. Worth its own.

## Testing

`entity-vote-buttons.selected-state.test.tsx` is new — 11 cases: curation and stance stay grey picked or not and never darken; chevrons keep their exception and still leave the unpicked side grey; the pill drops blue and red, reads the same grey as everything else, and no longer rests darker or hovers to black.

Verified by reverting each behaviour separately — restoring the pill's blue and darker rest fails 3, restoring the thumbs' darkening fails 1, dropping the chevron exception fails 1.

`vitest run partials/entity-page core/debates`: 1158 passed. `tsc --noEmit`: 5 errors, all pre-existing on master in unrelated test files. eslint and prettier clean on every changed file.

## Worth a look

**Not verified in a browser, and this is entirely visual.** Worth seeing a voted table row, a voted claim card, a voted veracity claim and the full-screen pill together.

**One thing found but not fixed:** the inline buttons carry no `aria-pressed`, so on six of the seven surfaces a screen reader cannot tell which direction you picked — and now that colour no longer changes for them, the filled icon is the only signal, which assistive tech cannot see at all. The pill has `aria-pressed`. Same question in a different medium; happy to file it.
