### PR TITLE
feat(explore): let a debate title navigate to the debate

### DIFF
--- a/apps/web/app/space/(entity)/[id]/[entityId]/page.tsx
+++ b/apps/web/app/space/(entity)/[id]/[entityId]/page.tsx
@@ -5,7 +5,7 @@ import { notFound } from 'next/navigation';
 import { EVENT_SCHEMA } from '~/core/community-calls/constants';
 import { getRecordingUrls } from '~/core/community-calls/recordings';
 import { DebateEntityView } from '~/core/debates/browse/debate-entity-view';
-import { DEBATE_TYPE_ID } from '~/core/debates/ontology';
+import { isDebateEntity } from '~/core/debates/is-debate-entity';
 import { entityHasOnlyPostType } from '~/core/utils/entity/entities';
 
 import { CommunityCallRecording } from '~/partials/community-calls/community-call-recording';
@@ -40,7 +40,7 @@ export default async function EntityTemplateStrategy(props: Props) {
 
   // A Debate is a live video, not a value sheet: browse mode drops you into the debates feed
   // anchored to this debate, and the raw entity page is reserved for edit mode.
-  if (result?.entity?.types.some(t => t.id === DEBATE_TYPE_ID)) {
+  if (isDebateEntity(result?.entity?.types)) {
     return (
       <DebateEntityView
         spaceId={params.id}

--- a/apps/web/core/debates/is-debate-entity.test.ts
+++ b/apps/web/core/debates/is-debate-entity.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+
+import { CLAIM_TYPE_ID } from '~/core/claims/ontology';
+
+import { isDebateEntity } from './is-debate-entity';
+import { DEBATE_TYPE_ID } from './ontology';
+
+const type = (id: string) => ({ id });
+
+describe('isDebateEntity', () => {
+  it('recognises a debate', () => {
+    expect(isDebateEntity([type(DEBATE_TYPE_ID)])).toBe(true);
+  });
+
+  it('recognises a debate that is also something else', () => {
+    // "is a debate", not "is only a debate" — multi-typed entities are ordinary, and the
+    // full-screen experience is what the entity has whatever else it also is.
+    expect(isDebateEntity([type(CLAIM_TYPE_ID), type(DEBATE_TYPE_ID)])).toBe(true);
+  });
+
+  it('does not recognise anything else', () => {
+    expect(isDebateEntity([type(CLAIM_TYPE_ID)])).toBe(false);
+    expect(isDebateEntity([])).toBe(false);
+  });
+
+  it('treats a missing type list as not a debate', () => {
+    // The entity route reads this off a fetch that can come back empty, so undefined has to be an
+    // answer rather than a crash.
+    expect(isDebateEntity(undefined)).toBe(false);
+  });
+
+  it('matches whichever spelling of the id arrives', () => {
+    // Ids reach the client hyphenless from some queries and UUID-formatted from others.
+    const hyphenated = DEBATE_TYPE_ID.replace(/^(.{8})(.{4})(.{4})(.{4})/, '$1-$2-$3-$4-');
+
+    expect(isDebateEntity([type(hyphenated)])).toBe(true);
+    expect(isDebateEntity([type(hyphenated.toUpperCase())])).toBe(true);
+  });
+});

--- a/apps/web/core/debates/is-debate-entity.ts
+++ b/apps/web/core/debates/is-debate-entity.ts
@@ -1,0 +1,26 @@
+import { normId } from '~/core/utils/norm-id';
+
+import { DEBATE_TYPE_ID } from './ontology';
+
+const DEBATE_TYPE = normId(DEBATE_TYPE_ID);
+
+/**
+ * Whether an entity is a debate.
+ *
+ * One predicate because it is one decision, asked at both ends of the same journey: Explore reads
+ * it to send a title to the debate rather than the side panel (GEO-2794), and the entity route
+ * reads it to render the full-screen debates feed rather than a value sheet. Two spellings of that
+ * question could disagree, and the way they would show up is a reader clicking a debate and landing
+ * on a page that does not think it is one.
+ *
+ * Keyed on the entity's types rather than on whatever drew it. `ExploreFeedCard` hands a debate to
+ * `DebateExploreFeedCard`, which falls back to the generic card when the debate cannot be watched —
+ * so a rule written against the card would stop applying to exactly those debates.
+ *
+ * Ids are normalized on both sides. The API returns them hyphenless today and every caller happens
+ * to match already, but ids reach the client in both spellings depending on the query that found
+ * them, and this is not a comparison worth leaving to that.
+ */
+export function isDebateEntity(types: readonly { id: string }[] | undefined): boolean {
+  return types?.some(type => normId(type.id) === DEBATE_TYPE) ?? false;
+}

--- a/apps/web/core/explore/explore-card-item.ts
+++ b/apps/web/core/explore/explore-card-item.ts
@@ -1,7 +1,7 @@
 import { ContentIds, SystemIds } from '@geoprotocol/geo-sdk/lite';
 
 import { getRecordingUrls } from '~/core/community-calls/recordings';
-import { DEBATE_TYPE_ID, DEBATE_VIDEOS_PROPERTY_ID } from '~/core/debates/ontology';
+import { DEBATE_VIDEOS_PROPERTY_ID } from '~/core/debates/ontology';
 import { EntityDecoder } from '~/core/io/decoders/entity';
 import type { Entity } from '~/core/types';
 import { normId } from '~/core/utils/norm-id';
@@ -48,21 +48,6 @@ export type ExploreFeedItem = {
  * the browse sidebar it already has, Coverage looks up arbitrary spaces it has never seen.
  */
 export type ExploreFeedRow = Omit<ExploreFeedItem, 'spaceName' | 'spaceImage' | 'hasPendingMembershipRequest'>;
-
-/**
- * Whether the entity behind a card is a debate.
- *
- * Keyed on the entity's own types rather than on which card component drew it, which is the part
- * that matters: `ExploreFeedCard` hands a debate to `DebateExploreFeedCard`, but that card falls
- * back to the generic one whenever the debate cannot actually be watched — so a rule written
- * against the card would quietly stop applying to exactly the debates that took the fallback.
- *
- * `normId` because ids reach the feed in both UUID and hyphenless spellings depending on the query
- * that found them.
- */
-export function isDebateEntity(types: readonly { id: string }[]): boolean {
-  return types.some(type => normId(type.id) === normId(DEBATE_TYPE_ID));
-}
 
 /** A decoded entity plus the two fields the card needs that aren't part of `Entity`. */
 export type ExploreCardEntity = Entity & { commentCount: number; createdAt?: string };

--- a/apps/web/core/explore/explore-card-item.ts
+++ b/apps/web/core/explore/explore-card-item.ts
@@ -1,7 +1,7 @@
 import { ContentIds, SystemIds } from '@geoprotocol/geo-sdk/lite';
 
 import { getRecordingUrls } from '~/core/community-calls/recordings';
-import { DEBATE_VIDEOS_PROPERTY_ID } from '~/core/debates/ontology';
+import { DEBATE_TYPE_ID, DEBATE_VIDEOS_PROPERTY_ID } from '~/core/debates/ontology';
 import { EntityDecoder } from '~/core/io/decoders/entity';
 import type { Entity } from '~/core/types';
 import { normId } from '~/core/utils/norm-id';
@@ -48,6 +48,21 @@ export type ExploreFeedItem = {
  * the browse sidebar it already has, Coverage looks up arbitrary spaces it has never seen.
  */
 export type ExploreFeedRow = Omit<ExploreFeedItem, 'spaceName' | 'spaceImage' | 'hasPendingMembershipRequest'>;
+
+/**
+ * Whether the entity behind a card is a debate.
+ *
+ * Keyed on the entity's own types rather than on which card component drew it, which is the part
+ * that matters: `ExploreFeedCard` hands a debate to `DebateExploreFeedCard`, but that card falls
+ * back to the generic one whenever the debate cannot actually be watched — so a rule written
+ * against the card would quietly stop applying to exactly the debates that took the fallback.
+ *
+ * `normId` because ids reach the feed in both UUID and hyphenless spellings depending on the query
+ * that found them.
+ */
+export function isDebateEntity(types: readonly { id: string }[]): boolean {
+  return types.some(type => normId(type.id) === normId(DEBATE_TYPE_ID));
+}
 
 /** A decoded entity plus the two fields the card needs that aren't part of `Entity`. */
 export type ExploreCardEntity = Entity & { commentCount: number; createdAt?: string };

--- a/apps/web/partials/explore/explore-card-entity-link.test.tsx
+++ b/apps/web/partials/explore/explore-card-entity-link.test.tsx
@@ -6,6 +6,8 @@ import type React from 'react';
 import { Provider, useAtomValue } from 'jotai';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { CLAIM_TYPE_ID } from '~/core/claims/ontology';
+import { DEBATE_TYPE_ID } from '~/core/debates/ontology';
 import { NavUtils } from '~/core/utils/utils';
 
 import { ExploreCardEntityLink } from './explore-card-entity-link';
@@ -27,17 +29,18 @@ vi.mock('~/design-system/prefetch-link', () => ({
   } & React.AnchorHTMLAttributes<HTMLAnchorElement>) => <a {...rest}>{children}</a>,
 }));
 
-const item = { entityId: 'entity-1', spaceId: 'space-1' };
+const item = { entityId: 'entity-1', spaceId: 'space-1', types: [{ id: CLAIM_TYPE_ID, name: 'Claim' }] };
+const debateItem = { entityId: 'debate-1', spaceId: 'space-1', types: [{ id: DEBATE_TYPE_ID, name: 'Debate' }] };
 
 function PanelProbe() {
   const target = useAtomValue(entitySidePanelAtom);
   return <div data-testid="panel">{target ? `${target.entityId} in ${target.spaceId}` : 'closed'}</div>;
 }
 
-function renderLink(opensSidePanel: boolean) {
+function renderLink(opensSidePanel: boolean, linkItem = item) {
   return render(
     <Provider>
-      <ExploreCardEntityLink item={item} opensSidePanel={opensSidePanel}>
+      <ExploreCardEntityLink item={linkItem} opensSidePanel={opensSidePanel}>
         <h2>A claim</h2>
       </ExploreCardEntityLink>
       <PanelProbe />
@@ -114,5 +117,46 @@ describe('ExploreCardEntityLink', () => {
 
     expect(screen.getByTestId('panel')).toHaveTextContent('closed');
     expect(event.defaultPrevented).toBe(false);
+  });
+
+  // GEO-2794, amending GEO-2757. A debate is a full-screen video experience; the panel would be a
+  // worse version of the thing the reader is trying to reach, so its title navigates even here.
+  describe('debates', () => {
+    it('navigates to the debate instead of opening the panel', () => {
+      renderLink(true, debateItem);
+
+      const event = clickName();
+
+      expect(screen.getByTestId('panel')).toHaveTextContent('closed');
+      expect(event.defaultPrevented).toBe(false);
+    });
+
+    it('does not claim to be an opener, since it does not open anything', () => {
+      // The attribute exempts a link from the panel's outside-pointerdown close. A debate title
+      // that kept it would suppress that close while navigating away, leaving the panel behind.
+      renderLink(true, debateItem);
+
+      expect(screen.getByRole('link')).not.toHaveAttribute('data-entity-side-panel-opener');
+    });
+
+    it('still carries the href every other title carries', () => {
+      renderLink(true, debateItem);
+
+      expect(screen.getByRole('link')).toHaveAttribute('href', NavUtils.toEntity('space-1', 'debate-1'));
+    });
+
+    it('applies to an entity typed both debate and something else', () => {
+      // Multi-typed entities are ordinary here, and the rule is "is a debate", not "is only a
+      // debate" — the full-screen experience is what it has, whatever else it also is.
+      renderLink(true, {
+        ...debateItem,
+        types: [{ id: CLAIM_TYPE_ID, name: 'Claim' }, ...debateItem.types],
+      });
+
+      const event = clickName();
+
+      expect(event.defaultPrevented).toBe(false);
+      expect(screen.getByTestId('panel')).toHaveTextContent('closed');
+    });
   });
 });

--- a/apps/web/partials/explore/explore-card-entity-link.tsx
+++ b/apps/web/partials/explore/explore-card-entity-link.tsx
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 
-import { isDebateEntity } from '~/core/explore/explore-card-item';
+import { isDebateEntity } from '~/core/debates/is-debate-entity';
 import type { ExploreFeedItem } from '~/core/explore/fetch-explore-feed';
 import { useEntitySidePanel } from '~/core/hooks/use-entity-side-panel';
 import { isModifiedClick } from '~/core/utils/is-modified-click';

--- a/apps/web/partials/explore/explore-card-entity-link.tsx
+++ b/apps/web/partials/explore/explore-card-entity-link.tsx
@@ -2,6 +2,7 @@
 
 import * as React from 'react';
 
+import { isDebateEntity } from '~/core/explore/explore-card-item';
 import type { ExploreFeedItem } from '~/core/explore/fetch-explore-feed';
 import { useEntitySidePanel } from '~/core/hooks/use-entity-side-panel';
 import { isModifiedClick } from '~/core/utils/is-modified-click';
@@ -10,7 +11,7 @@ import { NavUtils } from '~/core/utils/utils';
 import { PrefetchLink as Link } from '~/design-system/prefetch-link';
 
 type Props = {
-  item: Pick<ExploreFeedItem, 'entityId' | 'spaceId'>;
+  item: Pick<ExploreFeedItem, 'entityId' | 'spaceId' | 'types'>;
   /**
    * Whether an unmodified left click opens the side panel instead of navigating (GEO-2757).
    * Off by default: `ExploreFeedCard` is also the row for a space's activity tab, a topic's
@@ -40,9 +41,16 @@ type Props = {
 export function ExploreCardEntityLink({ item, opensSidePanel = false, className, children }: Props) {
   const { openSidePanel } = useEntitySidePanel();
 
+  // A debate is a full-screen video experience, so its title navigates even on Explore, where every
+  // other title opens the panel (GEO-2794 amending GEO-2757). Putting the exception here rather
+  // than at the four call sites is what makes it hold wherever a debate card is drawn — including
+  // when `DebateExploreFeedCard` falls back to the generic card, which is a debate the panel would
+  // serve especially badly.
+  const opensPanel = opensSidePanel && !isDebateEntity(item.types);
+
   const onClick = React.useCallback(
     (event: React.MouseEvent<HTMLAnchorElement>) => {
-      if (!opensSidePanel) return;
+      if (!opensPanel) return;
       if (isModifiedClick(event)) return;
       event.preventDefault();
       event.stopPropagation();
@@ -50,7 +58,7 @@ export function ExploreCardEntityLink({ item, opensSidePanel = false, className,
       // main-view edit session to return the viewer to.
       openSidePanel(item.entityId, item.spaceId, false);
     },
-    [item.entityId, item.spaceId, opensSidePanel, openSidePanel]
+    [item.entityId, item.spaceId, opensPanel, openSidePanel]
   );
 
   return (
@@ -69,7 +77,7 @@ export function ExploreCardEntityLink({ item, opensSidePanel = false, className,
       // block explore view renders this same card *inside the editor*, which reads the attribute
       // too (`editor.tsx`) — and there the name navigates, so it is not an opener and must not
       // claim to be one.
-      {...(opensSidePanel ? { 'data-entity-side-panel-opener': '' } : {})}
+      {...(opensPanel ? { 'data-entity-side-panel-opener': '' } : {})}
     >
       {children}
     </Link>

--- a/apps/web/partials/explore/explore-feed-card.tsx
+++ b/apps/web/partials/explore/explore-feed-card.tsx
@@ -5,9 +5,10 @@ import * as React from 'react';
 import { CLAIM_TYPE_ID } from '~/core/claims/ontology';
 import { EVENT_SCHEMA } from '~/core/community-calls/constants';
 import { useRecordingSources } from '~/core/community-calls/use-recording-sources';
-import { DEBATE_TYPE_ID } from '~/core/debates/ontology';
+import { isDebateEntity } from '~/core/explore/explore-card-item';
 import type { ExploreFeedItem } from '~/core/explore/fetch-explore-feed';
 import { RANKING_BLOCK_TYPE_ID } from '~/core/ranking-block-ids';
+import { normId } from '~/core/utils/norm-id';
 import { NavUtils } from '~/core/utils/utils';
 
 import { FallbackImage } from '~/design-system/fallback-image';
@@ -45,11 +46,9 @@ function ExploreFeedCommentLink({ href, count }: { href: string; count: number }
   );
 }
 
-const normalizeId = (id: string) => id.replace(/-/g, '').toLowerCase();
-const COMMUNITY_CALL_EVENT_TYPE = normalizeId(EVENT_SCHEMA.COMMUNITY_CALL_EVENT_TYPE);
-const DEBATE_TYPE = normalizeId(DEBATE_TYPE_ID);
-const CLAIM_TYPE = normalizeId(CLAIM_TYPE_ID);
-const RANKING_BLOCK_TYPE = normalizeId(RANKING_BLOCK_TYPE_ID);
+const COMMUNITY_CALL_EVENT_TYPE = normId(EVENT_SCHEMA.COMMUNITY_CALL_EVENT_TYPE);
+const CLAIM_TYPE = normId(CLAIM_TYPE_ID);
+const RANKING_BLOCK_TYPE = normId(RANKING_BLOCK_TYPE_ID);
 
 function CardTitle({ item, opensSidePanel }: { item: ExploreFeedItem; opensSidePanel: boolean }) {
   return (
@@ -130,7 +129,7 @@ function CommunityCallCardBody({ item, actions, titleOpensSidePanel }: CardBodyP
  * the debate can't actually be watched. Everything else renders one of the bodies below.
  */
 export function ExploreFeedCard(props: ExploreFeedCardProps) {
-  const isDebate = props.item.types.some(type => normalizeId(type.id) === DEBATE_TYPE);
+  const isDebate = isDebateEntity(props.item.types);
   if (isDebate) {
     return (
       <DebateExploreFeedCard
@@ -146,7 +145,7 @@ export function ExploreFeedCard(props: ExploreFeedCardProps) {
   // Claims get the card built for them — labelled position pills, the shared verdict, and no
   // thumbnail well they have no image to fill. Narrowly gated on purpose: every other type keeps
   // the generic card exactly as it was, so this changes what a Claim looks like and nothing else.
-  const isClaim = props.item.types.some(type => normalizeId(type.id) === CLAIM_TYPE);
+  const isClaim = props.item.types.some(type => normId(type.id) === CLAIM_TYPE);
   if (isClaim) {
     return (
       <ClaimExploreFeedCard
@@ -167,8 +166,8 @@ function BaseExploreFeedCard({
   hideJoinButton = false,
   titleOpensSidePanel = false,
 }: ExploreFeedCardProps) {
-  const isCommunityCall = item.types.some(type => normalizeId(type.id) === COMMUNITY_CALL_EVENT_TYPE);
-  const isRanking = item.types.some(type => normalizeId(type.id) === RANKING_BLOCK_TYPE);
+  const isCommunityCall = item.types.some(type => normId(type.id) === COMMUNITY_CALL_EVENT_TYPE);
+  const isRanking = item.types.some(type => normId(type.id) === RANKING_BLOCK_TYPE);
   const entityHref = `${NavUtils.toEntity(item.spaceId, item.entityId)}#entity-comments`;
   const cardActions = (
     <EntityRowActions entityId={item.entityId} spaceId={item.spaceId} className="mt-1">

--- a/apps/web/partials/explore/explore-feed-card.tsx
+++ b/apps/web/partials/explore/explore-feed-card.tsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 import { CLAIM_TYPE_ID } from '~/core/claims/ontology';
 import { EVENT_SCHEMA } from '~/core/community-calls/constants';
 import { useRecordingSources } from '~/core/community-calls/use-recording-sources';
-import { isDebateEntity } from '~/core/explore/explore-card-item';
+import { isDebateEntity } from '~/core/debates/is-debate-entity';
 import type { ExploreFeedItem } from '~/core/explore/fetch-explore-feed';
 import { RANKING_BLOCK_TYPE_ID } from '~/core/ranking-block-ids';
 import { normId } from '~/core/utils/norm-id';


### PR DESCRIPTION
Fixes GEO-2794.

A debate title on Explore navigates to the debate. Every other title still opens the side panel, per
GEO-2757.

## Where the rule lives, and why it matters

The ticket asks to confirm the rule keys off the entity's type rather than the card layout. There is
a concrete trap behind that: `DebateExploreFeedCard` **falls back to the generic card** whenever the
debate cannot actually be watched. A rule written against the debate card would quietly stop
applying to exactly those debates — and a debate that will not play is one the panel serves
especially badly.

So the exception sits in `ExploreCardEntityLink`, the single component all four title call sites go
through, keyed on `item.types`. It holds for the debate card, the generic fallback, the ranking card
body, and anywhere a debate card is drawn later.

## Two details

**The opener attribute goes too.** `data-entity-side-panel-opener` exempts a link from the panel's
capture-phase outside-pointerdown close. A debate title that kept it would suppress that close
*while navigating away*, leaving a panel behind on the page it left. The link now claims to be an
opener only when it actually opens something.

**No new route was needed.** `NavUtils.toEntity` already *is* the debate: a debate entity page
renders the full-screen feed from the ordinary `/space/{id}/{entityId}` route. "Navigate to the
debate" therefore means not intercepting the click, which leaves the anchor, the `href`, and the
modifier-click behaviour from GEO-2701 and GEO-2757 exactly as they were.

## Reuse

- `normId` already existed in `core/utils/norm-id.ts` with three byte-identical local copies.
  This uses the shared one and removes the copy in `explore-feed-card.tsx`.
- The debate check is now one exported `isDebateEntity`, used by both the card dispatch and the
  link, so the two cannot disagree about what a debate is. `ExploreFeedCard` had its own inline
  version.

## Review pass

**The predicate was in the wrong place, and the right place already had a caller.** The entity route
(`app/space/(entity)/[id]/[entityId]/page.tsx`) was already asking "is this entity a debate" inline,
to decide whether to render the full-screen debates feed instead of a value sheet. This PR had put a
second spelling of that one decision in an explore module — at the other end of the journey it
enables. Explore says "this is a debate, navigate there"; the route decides whether to give them a
debate. If those two ever disagreed, the symptom is a reader clicking a debate and landing on a page
that does not think it is one.

Checked before acting: **not a live bug.** The API returns type ids hyphenless, so the route's raw
`t.id === DEBATE_TYPE_ID` matches today and the normalization here is belt and braces rather than a
fix. It is a bug waiting for the first id that arrives in the other spelling.

`isDebateEntity` therefore moved to `core/debates/is-debate-entity.ts`, alongside the other small
single-purpose modules there, and all three callers read it — the Explore title link, the card
dispatch, and the entity route. It accepts `undefined` because the route asks off a fetch that can
come back empty, matching the shape the `Entities` relation helpers already use.

**Other reuse in this PR:** `normId` from `core/utils/norm-id.ts` rather than the third
byte-identical local copy, which is removed from `explore-feed-card.tsx`; and that file's inline
debate check folded into the shared predicate.

## Tests

Five cases on the predicate itself, including the multi-typed entity and both id spellings.

Four on the link: a debate navigates rather than opening the panel; it does not claim to
be an opener; it still carries the same `href` every other title carries; and the rule is "is a
debate" rather than "is only a debate", since multi-typed entities are ordinary here.

The existing GEO-2701 modifier-click cases are untouched and still pass — this change must not cost
anything there.

## Worth a look

The ticket's own first note: **GEO-2757 says "any card type" explicitly**, so anyone implementing it
from the ticket alone would build over this exception. Worth folding this amendment into GEO-2757's
description rather than leaving two tickets that contradict each other on first read.

## Verification

- Full `apps/web` suite: **373 files / 4048 tests, 0 failures.**
- `NEXT_PUBLIC_CHAIN_ID=55516 bun run build --force`.
