### PR TITLE
perf(explore): stop sending typeIds on Best; filter the rows instead (GEO-2793)

### DIFF
--- a/apps/web/core/explore/explore-type-filter.test.ts
+++ b/apps/web/core/explore/explore-type-filter.test.ts
@@ -5,6 +5,7 @@ import { DEBATE_TYPE_ID } from '~/core/debates/ontology';
 
 import { DEFAULT_EXPLORE_TYPE_IDS, EXPLORE_ENTITY_TYPE_IDS, NEWS_STORY_TYPE_ID } from './explore-constants';
 import {
+  entityMatchesExploreTypeIds,
   exploreTypeFilterLabel,
   parseExploreTypeIdsParam,
   parseStoredExploreTypeIds,
@@ -112,5 +113,51 @@ describe('exploreTypeFilterLabel', () => {
     expect(exploreTypeFilterLabel(0)).toBe('0 types');
     expect(exploreTypeFilterLabel(1)).toBe('1 type');
     expect(exploreTypeFilterLabel(11)).toBe('11 types');
+  });
+});
+
+// GEO-2793. Best stopped sending `typeIds` to the server, because supplying it makes
+// `entities_ranked_for_feed` sort all ~48.9M rows of `entity_ranking_scores` instead of walking
+// its ranked index — 43ms without, 5.8s with twelve types, statement timeout with one rare type.
+// This predicate is what replaces it, so it has to mean the same thing the SQL predicate did.
+describe('entityMatchesExploreTypeIds', () => {
+  const entity = (...typeIds: string[]) => ({ types: typeIds.map(id => ({ id })) });
+
+  it('keeps an entity carrying any one of the selected types', () => {
+    expect(entityMatchesExploreTypeIds(entity(DEBATE_TYPE_ID), [NEWS_STORY_TYPE_ID, DEBATE_TYPE_ID])).toBe(true);
+    expect(entityMatchesExploreTypeIds(entity(CLAIM_TYPE_ID, DEBATE_TYPE_ID), [DEBATE_TYPE_ID])).toBe(true);
+  });
+
+  it('drops an entity carrying none of them', () => {
+    expect(entityMatchesExploreTypeIds(entity(CLAIM_TYPE_ID), [NEWS_STORY_TYPE_ID, DEBATE_TYPE_ID])).toBe(false);
+  });
+
+  // The server predicate is an EXISTS on a TYPES relation, so an untyped entity never matched it
+  // either. Keeping it here would surface rows the old query provably excluded.
+  it('drops an untyped entity when a selection is active', () => {
+    expect(entityMatchesExploreTypeIds(entity(), [DEBATE_TYPE_ID])).toBe(false);
+  });
+
+  // An empty selection is "no restriction", matching the server reading a missing argument the
+  // same way. If this returned false the feed would go blank rather than unfiltered.
+  it('keeps everything when nothing is selected', () => {
+    expect(entityMatchesExploreTypeIds(entity(), [])).toBe(true);
+    expect(entityMatchesExploreTypeIds(entity(CLAIM_TYPE_ID), [])).toBe(true);
+  });
+
+  // Ids reach this from two directions — the constants are unhyphenated, a card's relation ids
+  // come back from the API hyphenated — so comparing them raw silently matches nothing.
+  it('matches regardless of hyphenation or case', () => {
+    const hyphenated = 'fd51f935-2063-4617-be39-7b672b23364c';
+    expect(hyphenated.replace(/-/g, '')).toBe(DEBATE_TYPE_ID);
+    expect(entityMatchesExploreTypeIds(entity(hyphenated), [DEBATE_TYPE_ID])).toBe(true);
+    expect(entityMatchesExploreTypeIds(entity(DEBATE_TYPE_ID.toUpperCase()), [DEBATE_TYPE_ID])).toBe(true);
+    expect(entityMatchesExploreTypeIds(entity(DEBATE_TYPE_ID), [hyphenated])).toBe(true);
+  });
+
+  it('accepts the full twelve-type whitelist the menu can produce', () => {
+    for (const id of EXPLORE_ENTITY_TYPE_IDS) {
+      expect(entityMatchesExploreTypeIds(entity(id), [...EXPLORE_ENTITY_TYPE_IDS])).toBe(true);
+    }
   });
 });

--- a/apps/web/core/explore/explore-type-filter.ts
+++ b/apps/web/core/explore/explore-type-filter.ts
@@ -88,3 +88,29 @@ export function toggleExploreTypeId(selectedTypeIds: readonly string[], typeId: 
 export function exploreTypeFilterLabel(selectedCount: number): string {
   return `${selectedCount} ${selectedCount === 1 ? 'type' : 'types'}`;
 }
+
+/**
+ * Does this entity carry at least one of the selected types?
+ *
+ * Client-side counterpart to the server's `typeIds` argument, which Best no longer sends
+ * (GEO-2793). `entities_ranked_for_feed` abandons its ranked index walk the moment `type_ids` is
+ * present and sorts all ~48.9M rows of `entity_ranking_scores` instead: 43ms without the argument,
+ * 5.8s with the twelve Explore types, and a statement timeout with a single rare one. The rows come
+ * back ranked either way, so the whitelist is cheap to apply here and ruinous to apply there.
+ *
+ * An empty selection means "no restriction", matching the server reading a missing argument the
+ * same way. An entity with no types is dropped when a selection is active, which is also what the
+ * server did — its predicate is an EXISTS on a TYPES relation, so an untyped entity never matched.
+ *
+ * Measured before relying on it: of a 66-row Best window, 64 carry a whitelisted type — 97%, against
+ * the 22 a page serves. Both the unscoped `types` field and the in-space TYPES relations agree on
+ * all 64, so the fact that a card's types are space-scoped does not narrow this in practice.
+ */
+export function entityMatchesExploreTypeIds(
+  entity: { types: readonly { id: string }[] },
+  selectedTypeIds: readonly string[]
+): boolean {
+  if (selectedTypeIds.length === 0) return true;
+  const selected = new Set(selectedTypeIds.map(normalizeId));
+  return entity.types.some(type => selected.has(normalizeId(type.id)));
+}

--- a/apps/web/core/explore/fetch-explore-feed.ts
+++ b/apps/web/core/explore/fetch-explore-feed.ts
@@ -9,10 +9,6 @@ import { graphql } from '~/core/io/graphql-client';
 import { fetchProfile } from '~/core/io/subgraph';
 import { fetchActiveMemberRequest } from '~/core/io/subgraph/fetch-proposed-members';
 
-import {
-  EXPLORE_ENTITY_NAME_PROPERTY_ID,
-  EXPLORE_PAGE_SIZE,
-} from './explore-constants';
 import { exploreBestConnectionDocument } from './explore-best-document';
 import {
   type ExploreCardEntity,
@@ -21,14 +17,12 @@ import {
   buildExploreFeedRows,
   decodeExploreCardEntity,
 } from './explore-card-item';
-import {
-  EXPLORE_DIVERSITY_WINDOW_SIZE,
-  applyDiversityCap,
-  exploreItemTypeKey,
-} from './explore-diversity';
+import { EXPLORE_ENTITY_NAME_PROPERTY_ID, EXPLORE_PAGE_SIZE } from './explore-constants';
+import { EXPLORE_DIVERSITY_WINDOW_SIZE, applyDiversityCap, exploreItemTypeKey } from './explore-diversity';
 import { exploreEntitiesByPropertyConnectionDocument } from './explore-entities-by-property-document';
 import { exploreEntitiesConnectionDocument } from './explore-entities-document';
 import { parseEntityUpdatedAtToUnixSec } from './explore-relative-time';
+import { entityMatchesExploreTypeIds } from './explore-type-filter';
 import { decodeExploreWindowCursor, nextExploreWindowCursor } from './explore-window-cursor';
 
 /**
@@ -232,12 +226,14 @@ async function fetchTopEntitiesPage(args: {
 // candidate, server-side, and cannot be opted back in. Nothing passes
 // `requireName: false` today, and for this feed it would be a request to serve rows that
 // render as a raw uuid.
+// No `typeIds` parameter, deliberately: this connection cannot filter by type at a usable speed
+// (GEO-2793), so accepting one and ignoring it would be worse than not offering it. The caller
+// applies the whitelist to the rows instead.
 async function fetchBestEntitiesPage(args: {
   spaceIds: string[];
   time: ExploreTime;
   limit: number;
   after: string | null;
-  typeIds?: readonly string[];
 }): Promise<ExploreEntitiesPageResponse> {
   const t = timeThresholdSec(args.time);
   return Effect.runPromise(
@@ -248,7 +244,17 @@ async function fetchBestEntitiesPage(args: {
         first: args.limit,
         after: args.after,
         spaceIds: args.spaceIds,
-        typeIds: args.typeIds?.length ? [...args.typeIds] : undefined,
+        // `typeIds` is deliberately NOT sent (GEO-2793). Supplying it makes
+        // `entities_ranked_for_feed` abandon its ranked index walk and sort all ~48.9M rows of
+        // `entity_ranking_scores`: 43ms without it, 5.8s with the twelve Explore types, and a
+        // statement timeout with one rare type — which rendered an *empty* feed, not a slow one.
+        // The whitelist is applied to the returned rows instead, in `fetchExploreFeed`. Rows come
+        // back in ranking order either way, so filtering here costs only yield, and the yield is
+        // 64 of 66 against the 22 a page serves.
+        //
+        // Only Best is changed. `entitiesConnection` and `entitiesOrderedByPropertyConnection`
+        // are 1.7x and 2.3x slower with the argument rather than 135x, and they have no
+        // equivalent cliff, so New and Top keep filtering server-side where it is exact.
         createdAfter: t != null ? String(t) : undefined,
         spaceIdsForLists: args.spaceIds,
       },
@@ -294,9 +300,7 @@ export async function fetchExploreFeed(args: {
   const pageSize = EXPLORE_PAGE_SIZE;
   const scanChunk = 30;
 
-  const attachMeta = async (
-    rows: ExploreFeedRow[]
-  ): Promise<ExploreFeedItem[]> => {
+  const attachMeta = async (rows: ExploreFeedRow[]): Promise<ExploreFeedItem[]> => {
     const out: ExploreFeedItem[] = rows.map(r => ({
       ...r,
       spaceName: spaceMeta.get(normId(r.spaceId))?.name ?? r.spaceId.slice(0, 8),
@@ -356,28 +360,38 @@ export async function fetchExploreFeed(args: {
           time: args.time,
           limit: windowSize,
           after,
-          typeIds: args.typeIds,
         })
       : args.sort === 'top'
-      ? await fetchTopEntitiesPage({
-          spaceIds: baseIds,
-          time: args.time,
-          limit: windowSize,
-          after,
-          typeIds: args.typeIds,
-          requireName: args.requireName,
-        })
-      : await fetchExploreEntitiesPage({
-          spaceIds: baseIds,
-          time: args.time,
-          limit: windowSize,
-          after,
-          orderBy: [EntitiesOrderBy.CreatedAtDesc],
-          typeIds: args.typeIds,
-          requireName: args.requireName,
-        });
+        ? await fetchTopEntitiesPage({
+            spaceIds: baseIds,
+            time: args.time,
+            limit: windowSize,
+            after,
+            typeIds: args.typeIds,
+            requireName: args.requireName,
+          })
+        : await fetchExploreEntitiesPage({
+            spaceIds: baseIds,
+            time: args.time,
+            limit: windowSize,
+            after,
+            orderBy: [EntitiesOrderBy.CreatedAtDesc],
+            typeIds: args.typeIds,
+            requireName: args.requireName,
+          });
 
-  const rows = buildExploreFeedRows(page.entities, allowed, memberOrEditorSet);
+  const allRows = buildExploreFeedRows(page.entities, allowed, memberOrEditorSet);
+
+  // Best filters by type here rather than in the query (see `fetchBestEntitiesPage`). The other
+  // sorts already came back filtered, so re-checking them would be redundant — and worse than
+  // redundant: a card's types are the TYPES relations *in its display space*, while the server's
+  // predicate is not space-scoped, so the two can disagree at the margin. Applying it only where
+  // the server no longer does keeps exactly one source of truth per sort.
+  const typeFiltered =
+    args.sort === 'best' && (args.typeIds?.length ?? 0) > 0
+      ? allRows.filter(row => entityMatchesExploreTypeIds(row, args.typeIds ?? []))
+      : allRows;
+  const rows = typeFiltered;
 
   // "Best" is the only sort that reorders (GEO-2690). "New" is reverse-chronological and
   // an activity log that shuffles is simply wrong; "Top" is an explicit "rank by score"


### PR DESCRIPTION
## What

Best no longer sends `typeIds` to `entitiesRankedForFeedConnection`. The type whitelist is applied to the returned rows instead.

## Why

Measured against the **real** `entities_ranked_for_feed` (not a hand-written equivalent — that mattered, see below):

| call | time |
| -- | -- |
| `type_ids => NULL`, LIMIT 66 | **43 ms** |
| 12 Explore types, LIMIT 66 | **5,811 ms** |
| 1 rare type (Debate), LIMIT 30 | **>60,000 ms — statement timeout** |

The type probe was never the cost. Supplying `type_ids` makes the function abandon its ranked index walk and sort the whole ranking table:

```
Limit
  -> Subquery Scan on entities_ranked_for_feed
       -> Gather Merge
            -> Sort  (Sort Key: rs.ranking_score DESC, rs.entity_id DESC)
                 -> Parallel Seq Scan on entity_ranking_scores rs     -- all 48,886,108 rows
```

This contradicts 0077's stated premise — that inlining lets PostGraphile's LIMIT push down into an index-ordered walk of `entity_ranking_scores_ranking_desc_idx` that terminates early. It does, but **only** on the `type_ids => NULL` path. That's why omitting the argument is 135× faster rather than incrementally faster, and it explains the symptoms better than "typeIds is expensive": it degrades on *presence*, the selection set is irrelevant, and it looks intermittent because a warm result skips the sort.

The rare-type case is the one worth stressing — it wasn't slow, it **returned no data**, so Explore rendered an empty feed. This removes that failure mode entirely, because it only exists on the `type_ids`-present path.

## Why filtering client-side is safe here

Rows come back in ranking order either way, so moving the whitelist costs only *yield*. Measured before relying on it: of a 66-row Best window, **64 carry a whitelisted type — 97%**, against the 22 a page serves.

I also checked the one thing that could have made this subtly wrong: a card's `types` are the TYPES relations **in its display space**, while the server's predicate is not space-scoped, so the two could disagree at the margin. They don't — the unscoped `types` field and the in-space relations agree on all 64 of 64.

(An earlier 48% figure I quoted on the ticket was the whole 230k named-in-space population, not the top-ranked window. Among ranked rows it's 97%.)

## Scope

**Only Best changes.** New and Top are 1.7× and 2.3× slower with the argument rather than 135×, and neither falls off a cliff, so they keep filtering server-side where it is exact. The type filter is applied only where the server no longer does it, so there is exactly one source of truth per sort.

`fetchBestEntitiesPage` no longer *accepts* a `typeIds` parameter — accepting one and ignoring it would be worse than not offering it. The document still declares `$typeIds`, so re-enabling is one line once the backend is fixed.

## Tests

Six cases on `entityMatchesExploreTypeIds`, chosen to pin the semantics of the SQL predicate it replaces:

- matches on any one of several selected types
- drops an entity carrying none
- **drops an untyped entity when a selection is active** — the server predicate is an EXISTS on a TYPES relation, so an untyped entity never matched it either
- **keeps everything when nothing is selected** — an empty selection is "no restriction", matching the server reading a missing argument the same way; returning false here would blank the feed
- matches regardless of hyphenation or case — the constants are unhyphenated and API relation ids are hyphenated, so comparing raw silently matches nothing
- accepts the full twelve-type whitelist the menu can produce

`core/explore/`: 52 passed. Typecheck and prettier clean.

## This is a stopgap, not the fix

The planner behaviour still wants solving, and the proper fix has to be **cardinality-aware**: forcing the ordered walk is 643 ms for twelve types but **33.9 s** for one rare type, where the planner's own choice is 13.9 ms. The two cases want opposite plans, so pinning either one regresses the other. Tracked on GEO-2793 (GEO-2737 merged into it).

I also built and measured a `(from_entity_id, type_id, to_entity_id)` covering index on `relations` on the theory that the per-candidate type probe was the cost. **It wasn't** — 4,895 ms vs 5,022 ms, noise. Recorded on the ticket so nobody retries it.
