### PR TITLE
fix(debates): stop reporting a playback block on a video that plays (GEO-2783)

### DIFF
--- a/apps/web/core/debates/playback-utils.test.ts
+++ b/apps/web/core/debates/playback-utils.test.ts
@@ -158,6 +158,55 @@ describe('playBothWithMutedFallback (GEO-2783)', () => {
     return video;
   }
 
+  /**
+   * A video whose `play()` resolves but leaves `paused` true for a moment, which is what a real
+   * element does while it transitions. This is the shape that produced the false "Could not play
+   * both videos" on every scroll: the old check read `paused` on the next microtask and called it
+   * a block.
+   */
+  function laggyVideo({ pollsUntilPlaying }: { pollsUntilPlaying: number }) {
+    const video = {
+      muted: true,
+      paused: true,
+      plays: 0,
+      polls: 0,
+      async play() {
+        this.plays += 1;
+      },
+      /** Flips to playing only after the helper has waited `pollsUntilPlaying` times. */
+      tick() {
+        this.polls += 1;
+        if (this.polls >= pollsUntilPlaying) this.paused = false;
+      },
+    };
+    return video;
+  }
+
+  it('does not report a block when the element is only slow to leave paused (GEO-2783 follow-up)', async () => {
+    const a = laggyVideo({ pollsUntilPlaying: 2 });
+    const b = laggyVideo({ pollsUntilPlaying: 2 });
+    const wait = async () => {
+      a.tick();
+      b.tick();
+    };
+
+    expect(await playBothWithMutedFallback(a, b, wait)).toBe('playing');
+    // The point of the fix: no muted retry, because it was never actually blocked.
+    expect([a.plays, b.plays]).toEqual([1, 1]);
+  });
+
+  it('still reports a block when the element never starts', async () => {
+    const a = laggyVideo({ pollsUntilPlaying: Number.POSITIVE_INFINITY });
+    const b = laggyVideo({ pollsUntilPlaying: Number.POSITIVE_INFINITY });
+    const wait = async () => {
+      a.tick();
+      b.tick();
+    };
+
+    // Both already muted, so there is no fallback to try — this must not be reported as playing.
+    expect(await playBothWithMutedFallback(a, b, wait)).toBe('blocked');
+  });
+
   it('plays straight away when the browser allows it', async () => {
     const a = fakeVideo({ muted: true });
     const b = fakeVideo({ muted: true });

--- a/apps/web/core/debates/playback-utils.ts
+++ b/apps/web/core/debates/playback-utils.ts
@@ -125,16 +125,42 @@ export type PlayBothOutcome = 'playing' | 'playing-muted' | 'blocked';
  * caller has to record that audio is now off — otherwise the UI offers a "mute" control on a
  * silent video and the next autoplay fails identically.
  *
- * Both elements are checked for `paused` as well as the promise settling: a rejected `play()` and
- * a resolved-but-still-paused one are both blocks, and only one of them throws.
+ * Success is judged by whether both elements are actually running shortly afterwards, not by
+ * whether `play()` resolved. `play()` can resolve while the element is still transitioning out of
+ * `paused`, so checking `paused` on the very next microtask reports a block on a video that plays
+ * a moment later — which is why the feed showed "Could not play both videos" on essentially every
+ * scroll while the recordings played fine. A rejected `play()` needs no special case: a rejection
+ * leaves the element paused, so it fails the same check.
+ *
+ * The grace window is deliberately short. It only has to outlast the paused -> playing transition,
+ * and every millisecond of it delays the muted retry on a genuine block.
  */
+const PLAY_CONFIRM_POLLS = 4;
+const PLAY_CONFIRM_INTERVAL_MS = 75;
+
+const defaultWait = (ms: number) => new Promise<void>(resolve => setTimeout(resolve, ms));
+
+async function bothRunning(
+  primary: PlayableVideo,
+  secondary: PlayableVideo,
+  wait: (ms: number) => Promise<void>
+): Promise<boolean> {
+  for (let poll = 0; poll < PLAY_CONFIRM_POLLS; poll++) {
+    if (!primary.paused && !secondary.paused) return true;
+    await wait(PLAY_CONFIRM_INTERVAL_MS);
+  }
+  return !primary.paused && !secondary.paused;
+}
+
 export async function playBothWithMutedFallback(
   primary: PlayableVideo,
-  secondary: PlayableVideo
+  secondary: PlayableVideo,
+  /** Injectable so tests do not wait on real timers. */
+  wait: (ms: number) => Promise<void> = defaultWait
 ): Promise<PlayBothOutcome> {
   const attempt = async () => {
-    const results = await Promise.allSettled([primary.play(), secondary.play()]);
-    return results.every(result => result.status === 'fulfilled') && !primary.paused && !secondary.paused;
+    await Promise.allSettled([primary.play(), secondary.play()]);
+    return bothRunning(primary, secondary, wait);
   };
 
   if (await attempt()) return 'playing';


### PR DESCRIPTION
Follow-up to #2339. The muted fallback fixed the blocked-autoplay case, but Preston still sees *"Could not play both videos"* on essentially every scroll — while the recordings play fine.

## Cause

`attempt()` judged success by `play()` resolving **and** `paused` being false on the very next microtask:

```ts
const results = await Promise.allSettled([primary.play(), secondary.play()]);
return results.every(r => r.status === 'fulfilled') && !primary.paused && !secondary.paused;
```

A real `HTMLVideoElement` can still be transitioning out of `paused` at that instant, so a video that starts a moment later is reported as `'blocked'`. On a scroll-driven autoplay that's the *common* case, not the edge case — which is exactly the symptom: error shown, video playing.

## Fix

Judge success by whether both elements are **actually running** within a short grace window (4 polls, 75 ms apart) instead of by what `play()` returned.

This also lets the `results.every(fulfilled)` condition go, which is a simplification rather than a loosening: a rejected `play()` leaves the element paused, so it fails the running check anyway. What matters is whether the videos are playing, not whether the promise resolved.

The window is deliberately short. It only has to outlast the paused → playing transition, and every millisecond of it delays the muted retry on a genuine block.

## On "just hide the error"

Preston's suggestion was to hide it outright. This removes it for the case he's hitting *without* suppressing it — a genuine double-block still reports `'blocked'` and still surfaces. Hiding it unconditionally would also hide real failures, and that error is the only signal a viewer gets that their tap is needed to start playback. If the false positive is gone, there's nothing left to annoy anyone.

## Tests

Two new, and the pair is the point:

- `does not report a block when the element is only slow to leave paused` — reports `'playing'` and asserts **no muted retry** (`plays === 1` each), because it was never blocked. This is the reported bug.
- `still reports a block when the element never starts` — reports `'blocked'`, so the fix can't be mistaken for "always succeed".

`wait` is injectable, so neither test waits on real timers. `core/debates/playback-utils.test.ts`: **30 passing**. Prettier and typecheck clean.

## Note

This does not change `use-debate-playback.ts` — the error text and the `'blocked'` branch stay as they are. The only thing that changed is how confidently we conclude a block happened.
