### PR TITLE
feat(debates): tell geo-chat a position while the write is in flight (GEO-2784)

### DIFF
--- a/apps/web/core/debates/claim-response-indexed-notifier.test.tsx
+++ b/apps/web/core/debates/claim-response-indexed-notifier.test.tsx
@@ -54,6 +54,65 @@ describe('useClaimResponseIndexedNotifier', () => {
     expect(mocks.notify).toHaveBeenCalledOnce();
   });
 
+  // GEO-2784. The whole point of the change: geo-chat is told while the write is in flight, so the
+  // opposite side's "Request debate" appears at once instead of ~10s later (p50 9.9s for
+  // web.write.entity_response). Before this, the notification waited for `status: 'indexed'` and
+  // geo-chat 409'd anything unconfirmed.
+  it('notifies geo-chat while the write is still in flight, before it is indexed', async () => {
+    const { queryClient, wrapper } = createHarness();
+    const getPrivyIdentityToken = vi.fn();
+    renderHook(() => useClaimResponseIndexedNotifier(true, getPrivyIdentityToken, 'account-1'), { wrapper });
+    const queryKey = ['entity-response-indexing', 'profile-1', 'claim-1', 'space-1', 'stance'] as const;
+
+    act(() =>
+      queryClient.setQueryData(queryKey, {
+        status: 'pending',
+        pending: {
+          entityId: 'claim-1',
+          expectedResponse: 'positive',
+          personalSpaceId: 'profile-1',
+          responseKind: 'stance',
+          spaceId: 'space-1',
+        },
+        runId: 'run-1',
+      })
+    );
+
+    await waitFor(() =>
+      expect(mocks.notify).toHaveBeenCalledWith(
+        'space-1',
+        'claim-1',
+        'stance',
+        true,
+        getPrivyIdentityToken,
+        'account-1',
+        expect.any(AbortSignal)
+      )
+    );
+  });
+
+  // The in-flight report is not a replacement for the confirmed one — that second call is the
+  // reconciliation, and geo-chat converges on it if the write never landed. Keyed separately so
+  // the dedupe does not swallow it.
+  it('still notifies again once the same response is indexed', async () => {
+    const { queryClient, wrapper } = createHarness();
+    renderHook(() => useClaimResponseIndexedNotifier(true, vi.fn(), 'account-1'), { wrapper });
+    const queryKey = ['entity-response-indexing', 'profile-1', 'claim-1', 'space-1', 'stance'] as const;
+    const pending = {
+      entityId: 'claim-1',
+      expectedResponse: 'positive',
+      personalSpaceId: 'profile-1',
+      responseKind: 'stance',
+      spaceId: 'space-1',
+    } as const;
+
+    act(() => queryClient.setQueryData(queryKey, { status: 'pending', pending, runId: 'run-1' }));
+    await waitFor(() => expect(mocks.notify).toHaveBeenCalledOnce());
+
+    act(() => queryClient.setQueryData(queryKey, { status: 'indexed', pending, runId: 'run-1' }));
+    await waitFor(() => expect(mocks.notify).toHaveBeenCalledTimes(2));
+  });
+
   it('reports cleared responses and ignores curation indexing', async () => {
     const { queryClient, wrapper } = createHarness();
     renderHook(() => useClaimResponseIndexedNotifier(true, vi.fn(), 'account-1'), { wrapper });

--- a/apps/web/core/debates/claim-response-indexed-notifier.ts
+++ b/apps/web/core/debates/claim-response-indexed-notifier.ts
@@ -10,11 +10,16 @@ import { type DebateResponseKind, type GetPrivyIdentityToken, notifyClaimRespons
 import { refreshRematchClaimBatches, rematchClaimBatchesWithClaim } from './rematch-claims-query-key';
 
 const MAX_NOTIFIED_RUNS = 256;
-type IndexedClaimResponse = NonNullable<ReturnType<typeof claimResponseIndexedEvent>>;
+/**
+ * What sending a notification actually needs. The indexed variant additionally carries `runId`,
+ * but that is only used to build the dedupe key at the call site — never inside the send — so both
+ * the in-flight and the confirmed response satisfy this (GEO-2784).
+ */
+type NotifiableClaimResponse = NonNullable<ReturnType<typeof pendingClaimResponse>>;
 type InterruptedNotification = {
   accountKey: string;
   notificationKey: string;
-  response: IndexedClaimResponse;
+  response: NotifiableClaimResponse;
 };
 
 export function claimResponseIndexedEvent(queryKey: readonly unknown[], data: unknown) {
@@ -90,7 +95,7 @@ export function useClaimResponseIndexedNotifier(
       notifiedRunOrder.current = notifiedRunOrder.current.filter(key => key !== notificationKey);
     };
 
-    const startNotification = (notificationKey: string, response: IndexedClaimResponse) => {
+    const startNotification = (notificationKey: string, response: NotifiableClaimResponse) => {
       if (notifiedRuns.current.has(notificationKey)) return;
 
       notifiedRuns.current.add(notificationKey);
@@ -130,9 +135,29 @@ export function useClaimResponseIndexedNotifier(
 
     const unsubscribe = queryClient.getQueryCache().subscribe(event => {
       if (event.type !== 'updated' || event.action.type !== 'success') return;
-      const response = claimResponseIndexedEvent(event.query.queryKey, event.query.state.data);
-      if (!response) return;
-      startNotification(`${event.query.queryHash}:${response.runId}`, response);
+      const queryHash = event.query.queryHash;
+
+      const indexed = claimResponseIndexedEvent(event.query.queryKey, event.query.state.data);
+      if (indexed) {
+        // Still sent once the chain confirms, and it is not redundant: this is the reconciliation
+        // half. If the in-flight notification below reported a position the write never landed,
+        // this one carries the truth and geo-chat converges on it.
+        startNotification(`${queryHash}:${indexed.runId}`, indexed);
+        return;
+      }
+
+      // GEO-2784. Tell geo-chat the moment the write starts rather than when it finishes.
+      // `web.write.entity_response` is p50 9.9s / p95 48.6s, and geo-chat used to refuse an
+      // unindexed position outright (409 `claim_response_not_indexed`), so nobody could be offered
+      // a debate against a position for ~10s after the click. geo-chat is now the authority on
+      // readiness and takes the report immediately.
+      //
+      // Keyed separately from the indexed notification so both fire: this one makes the opposite
+      // side's Request debate appear at once, that one reconciles it. Keyed on the position too,
+      // so toggling a side off and on again is reported rather than swallowed as a duplicate.
+      const pending = pendingClaimResponse(event.query.queryKey, event.query.state.data);
+      if (!pending) return;
+      startNotification(`${queryHash}:pending:${String(pending.position)}`, pending);
     });
 
     for (const [notificationKey, interrupted] of interruptedNotifications.current) {


### PR DESCRIPTION
Client half of making positions appear instantly.

## ⚠️ Requires geo-chat#95 to ship first

Against the current server these notifications get `409 claim_response_not_indexed` — harmless but noisy, and no faster. geo-chat#95 is backward-compatible on its own, so it can land whenever; this one should not go first.

## What changed

The notifier only fired on `status === 'indexed'`, because geo-chat refused an unindexed position outright. With `web.write.entity_response` at **p50 9.9s / p95 48.6s**, nobody could be offered a debate against a position for ~10s after the click.

#2338 made the viewer's *own* position render immediately — which is exactly why Preston reported it feeling faster to the person clicking and still slow for everyone watching. That local optimism deliberately does not notify geo-chat, because the call would have been refused.

geo-chat#95 makes geo-chat the authority on readiness, so this now notifies off the in-flight event too.

## The confirmed notification still fires, and is not redundant

It's the reconciliation half. If the in-flight report named a position the write never landed, the confirmed one carries the truth and geo-chat converges on it.

The two are keyed separately so the dedupe doesn't swallow the second. The in-flight key also includes the position, so toggling a side off and on again is reported rather than treated as a duplicate — which matters because a removal is exactly the case a user notices.

## Tests

Two added, and **the pair is the point** — either alone would look correct while the behaviour was wrong:

- `notifies geo-chat while the write is still in flight, before it is indexed` — the fix.
- `still notifies again once the same response is indexed` — proves the reconciliation survives the dedupe.

8 passing in `claim-response-indexed-notifier.test.tsx`. Prettier and typecheck clean.

## Two things worth knowing

**Notification volume doubles.** geo-chat rate-limits per `(user, space, claim)` at 10/60s, so the effective ceiling becomes 5 position toggles per minute on a single claim. Fine for real use, but that's the number if anyone reports a 429.

**`startNotification` widened** from the indexed-only shape to what sending actually needs. `runId` is used only to build the dedupe key at the call site, never inside the send, so both the in-flight and confirmed shapes satisfy it — no behaviour change, just a type that matches what the function reads.
