### PR TITLE
feat(governance): let a space change fast path access for new members

### DIFF
--- a/apps/web/core/io/dto/proposals.ts
+++ b/apps/web/core/io/dto/proposals.ts
@@ -36,8 +36,8 @@ export type SpaceTopicProposalDetails = {
  * from the API action: `slowThreshold`/`universalThreshold` are contract ratios (1e7 = 100%),
  * `duration` is in seconds, and `fastThreshold`/`quorum` are editor counts.
  *
- * `disableFastPathForNewMembers` is plumbed through but the API does not send it yet, so it is
- * always undefined today and its row is skipped. Grace period is not surfaced at all.
+ * `disableFastPathForNewMembers` is a boolean rather than a count. Grace period is the one field of
+ * the seven `updateVotingSettings` writes that still isn't surfaced.
  */
 export type VotingSettingsProposalDetails = {
   slowThreshold?: number;

--- a/apps/web/core/io/dto/proposals.ts
+++ b/apps/web/core/io/dto/proposals.ts
@@ -34,8 +34,10 @@ export type SpaceTopicProposalDetails = {
 /**
  * Proposed new voting settings for an `UPDATE_VOTING_SETTINGS` proposal. Values are raw
  * from the API action: `slowThreshold`/`universalThreshold` are contract ratios (1e7 = 100%),
- * `duration` is in seconds, and `fastThreshold`/`quorum` are editor counts. (Grace period and
- * new-member fast-path aren't surfaced.)
+ * `duration` is in seconds, and `fastThreshold`/`quorum` are editor counts.
+ *
+ * `disableFastPathForNewMembers` is plumbed through but the API does not send it yet, so it is
+ * always undefined today and its row is skipped. Grace period is not surfaced at all.
  */
 export type VotingSettingsProposalDetails = {
   slowThreshold?: number;
@@ -43,6 +45,7 @@ export type VotingSettingsProposalDetails = {
   fastThreshold?: number;
   quorum?: number;
   durationSeconds?: number;
+  disableFastPathForNewMembers?: boolean;
 };
 
 export type Proposal = {

--- a/apps/web/core/io/rest/schemas/proposal.test.ts
+++ b/apps/web/core/io/rest/schemas/proposal.test.ts
@@ -139,6 +139,31 @@ describe('getVotingSettingsProposalDetails', () => {
   it('returns null when the action carries none of the settings values', () => {
     expect(getVotingSettingsProposalDetails([{ actionType: 'UPDATE_VOTING_SETTINGS' }])).toBeNull();
   });
+
+  // `false` is the meaningful half of this field — it is what grants new members the fast path —
+  // and it is the value a truthiness check would drop on the floor. Both directions are asserted
+  // so neither can be mistaken for "absent".
+  it.each([
+    ['granting new members the fast path', false],
+    ['withholding it', true],
+  ])('carries the new-member fast-path value through when it is %s', (_label, disabled) => {
+    expect(
+      getVotingSettingsProposalDetails([
+        { actionType: 'UPDATE_VOTING_SETTINGS', quorum: 3, disableFastPathAccessForNewMembers: disabled },
+      ])
+    ).toEqual({ quorum: 3, disableFastPathForNewMembers: disabled });
+  });
+
+  // `hasAnyValue` tests `!== undefined` rather than truthiness. A proposal whose only reported
+  // change is `false` still has something to say, and returning null here would hide it entirely
+  // rather than merely leaving its row out.
+  it('does not treat a lone false as an empty action', () => {
+    expect(
+      getVotingSettingsProposalDetails([
+        { actionType: 'UPDATE_VOTING_SETTINGS', disableFastPathAccessForNewMembers: false },
+      ])
+    ).toEqual({ disableFastPathForNewMembers: false });
+  });
 });
 
 describe('mapApiActionsToProposalType — voting settings', () => {

--- a/apps/web/core/io/rest/schemas/proposal.ts
+++ b/apps/web/core/io/rest/schemas/proposal.ts
@@ -81,6 +81,11 @@ export const ApiActionSchema = Schema.Struct({
   slowThreshold: Schema.optional(Schema.Number),
   universalPercentageSupportThreshold: Schema.optional(Schema.Number),
   duration: Schema.optional(Schema.Number),
+  /**
+   * Whether the proposal also flips new-member fast-path access. Optional like its siblings, and
+   * currently never sent — see {@link getVotingSettingsProposalDetails}.
+   */
+  disableFastPathAccessForNewMembers: Schema.optional(Schema.Boolean),
   targetSpaceId: Schema.optional(Schema.String),
   targetTopicId: Schema.optional(Schema.String),
 });
@@ -324,6 +329,12 @@ export function getSpaceTopicProposalDetails(actions: readonly ApiAction[]): Spa
  * carries the new values (`slowThreshold`, `universalPercentageSupportThreshold`,
  * `fastThreshold`, `quorum`, `duration`) directly on the action; returns null if there's no
  * such action or it carries none of them.
+ *
+ * `disableFastPathAccessForNewMembers` is read here and threaded through to the review page, but
+ * the API does not send it yet — `updateVotingSettings` takes seven fields and the action carries
+ * five. Until it does, a proposal that only flips that switch shows no changed row, which is worth
+ * fixing on the API side: it is an access-control change, and a voter should be able to see it
+ * before approving. The plumbing is in place so the row appears the moment the value arrives.
  */
 export function getVotingSettingsProposalDetails(actions: readonly ApiAction[]): VotingSettingsProposalDetails | null {
   const action = actions.find(a => a.actionType === 'UPDATE_VOTING_SETTINGS');
@@ -337,6 +348,7 @@ export function getVotingSettingsProposalDetails(actions: readonly ApiAction[]):
     fastThreshold: action.fastThreshold,
     quorum: action.quorum,
     durationSeconds: action.duration,
+    disableFastPathForNewMembers: action.disableFastPathAccessForNewMembers,
   };
 
   const hasAnyValue = Object.values(details).some(value => value !== undefined);

--- a/apps/web/core/io/rest/schemas/proposal.ts
+++ b/apps/web/core/io/rest/schemas/proposal.ts
@@ -82,8 +82,11 @@ export const ApiActionSchema = Schema.Struct({
   universalPercentageSupportThreshold: Schema.optional(Schema.Number),
   duration: Schema.optional(Schema.Number),
   /**
-   * Whether the proposal also flips new-member fast-path access. Optional like its siblings, and
-   * currently never sent — see {@link getVotingSettingsProposalDetails}.
+   * Whether the proposal also flips new-member fast-path access.
+   *
+   * The API had been sending this all along; the schema simply did not declare it, and decoding
+   * drops what it does not know about. So the value was arriving and being thrown away one layer
+   * before anything could read it — which is why the review page showed nothing.
    */
   disableFastPathAccessForNewMembers: Schema.optional(Schema.Boolean),
   targetSpaceId: Schema.optional(Schema.String),
@@ -330,11 +333,10 @@ export function getSpaceTopicProposalDetails(actions: readonly ApiAction[]): Spa
  * `fastThreshold`, `quorum`, `duration`) directly on the action; returns null if there's no
  * such action or it carries none of them.
  *
- * `disableFastPathAccessForNewMembers` is read here and threaded through to the review page, but
- * the API does not send it yet — `updateVotingSettings` takes seven fields and the action carries
- * five. Until it does, a proposal that only flips that switch shows no changed row, which is worth
- * fixing on the API side: it is an access-control change, and a voter should be able to see it
- * before approving. The plumbing is in place so the row appears the moment the value arrives.
+ * `disableFastPathAccessForNewMembers` is read here too. It was absent from the schema until the
+ * setting became editable, so decoding dropped it and a proposal that only flipped that switch
+ * rendered as a no-op — five rows, none of them changed, over an access-control change. Nothing
+ * about the API had to change; the field only had to be declared.
  */
 export function getVotingSettingsProposalDetails(actions: readonly ApiAction[]): VotingSettingsProposalDetails | null {
   const action = actions.find(a => a.actionType === 'UPDATE_VOTING_SETTINGS');

--- a/apps/web/partials/active-proposal/voting-settings-proposal.tsx
+++ b/apps/web/partials/active-proposal/voting-settings-proposal.tsx
@@ -108,7 +108,24 @@ function buildRows(
     );
   }
 
+  // An access-control change, so it belongs in front of a voter rather than only in the calldata.
+  // Skipped while the API omits the field, exactly as the five above are when absent.
+  if (details.disableFastPathForNewMembers !== undefined) {
+    rows.push(
+      makeRow(
+        'Fast path for new members',
+        current ? formatFastPathForNewMembers(current.disableFastPathForNewMembers) : null,
+        formatFastPathForNewMembers(details.disableFastPathForNewMembers)
+      )
+    );
+  }
+
   return rows;
+}
+
+/** Phrased as what it grants, matching the switch in governance settings. */
+function formatFastPathForNewMembers(disabled: boolean): string {
+  return disabled ? 'Off' : 'On';
 }
 
 function makeRow(label: string, current: string | null, proposed: string): Row {

--- a/apps/web/partials/active-proposal/voting-settings-proposal.tsx
+++ b/apps/web/partials/active-proposal/voting-settings-proposal.tsx
@@ -109,7 +109,7 @@ function buildRows(
   }
 
   // An access-control change, so it belongs in front of a voter rather than only in the calldata.
-  // Skipped while the API omits the field, exactly as the five above are when absent.
+  // Guarded like the five above: absent means the proposal did not report it, not that it is off.
   if (details.disableFastPathForNewMembers !== undefined) {
     rows.push(
       makeRow(

--- a/apps/web/partials/create-space/create-space-dialog.tsx
+++ b/apps/web/partials/create-space/create-space-dialog.tsx
@@ -496,8 +496,8 @@ function StepConfigureGovernance() {
     : DEFAULT_VOTING_SETTINGS_SNAPSHOT;
 
   const [state, setState] = React.useState<VotingSettingsFormState>(() => snapshotToFormState(initialSnapshot));
-  // Grace period and the new-member fast-path toggle aren't in the form; carry whatever
-  // the draft started with through unchanged. (Universal support is now an exposed field.)
+  // Grace period isn't in the form; carry whatever the draft started with through unchanged.
+  // (Universal support and the new-member fast-path switch are both exposed fields now.)
   const hidden = React.useMemo(() => snapshotToHidden(initialSnapshot), [initialSnapshot]);
 
   const parsed = parseVotingSettingsForm(state, hidden, NEW_SPACE_INITIAL_EDITOR_COUNT);

--- a/apps/web/partials/governance/voting-settings-fields.tsx
+++ b/apps/web/partials/governance/voting-settings-fields.tsx
@@ -18,8 +18,8 @@ type Props = {
 /**
  * The governance settings the form exposes: slow-path threshold (slider), universal
  * (early-execution) threshold (slider), vote duration (days/hours/minutes/seconds),
- * fast-path votes, and quorum. Shared between create-space "advanced" settings and the
- * edit-existing-space proposal modal.
+ * fast-path votes, fast path for new members (switch), and quorum. Shared between
+ * create-space "advanced" settings and the edit-existing-space proposal modal.
  */
 export function VotingSettingsFields({ state, onChange, disabled = false }: Props) {
   // Keyed to the field's own type: every text input holds a string, and the fast-path switch a
@@ -119,14 +119,14 @@ export function VotingSettingsFields({ state, onChange, disabled = false }: Prop
         <ValueInput value={state.fastPathVotes} onChange={v => set('fastPathVotes', v)} disabled={disabled} />
       </SettingRow>
 
-      <Divider />
-
+      {/* Kept against Fast path votes with no rule between them: both answer "who gets the fast
+          path, and on what terms", which is one question asked twice. */}
       {/* A switch rather than a number, phrased as what it grants rather than what it disables:
           the stored field is `disableFastPathForNewMembers`, and a control labelled with a negative
           that is then toggled off asks the reader to hold two inversions at once. */}
       <SettingRow
         label="Fast path for new members"
-        hint="When off, members who join from now on can only propose on the review path until an editor lifts the restriction. Existing members are unaffected either way."
+        hint="When off, members who join from now on can only propose on the review path. Members who already joined keep whatever access they have — turning this back on does not restore theirs."
       >
         <button
           type="button"
@@ -140,6 +140,8 @@ export function VotingSettingsFields({ state, onChange, disabled = false }: Prop
           <Toggle checked={!state.disableFastPathForNewMembers} />
         </button>
       </SettingRow>
+
+      <Divider />
 
       <SettingRow
         label="Quorum"

--- a/apps/web/partials/governance/voting-settings-fields.tsx
+++ b/apps/web/partials/governance/voting-settings-fields.tsx
@@ -1,9 +1,11 @@
 'use client';
 
 import * as React from 'react';
+
 import { createPortal } from 'react-dom';
 
 import { QuestionCircle } from '~/design-system/icons/question-circle';
+import { Toggle } from '~/design-system/toggle';
 
 import type { VotingSettingsFormState } from './voting-settings';
 
@@ -20,7 +22,9 @@ type Props = {
  * edit-existing-space proposal modal.
  */
 export function VotingSettingsFields({ state, onChange, disabled = false }: Props) {
-  const set = <K extends keyof VotingSettingsFormState>(key: K, value: string) => {
+  // Keyed to the field's own type: every text input holds a string, and the fast-path switch a
+  // boolean, so a single `string` here would have made the switch unassignable.
+  const set = <K extends keyof VotingSettingsFormState>(key: K, value: VotingSettingsFormState[K]) => {
     onChange({ ...state, [key]: value });
   };
 
@@ -79,8 +83,18 @@ export function VotingSettingsFields({ state, onChange, disabled = false }: Prop
       <div className="flex flex-col gap-3">
         <SettingLabel label="Vote duration" hint="How long a review-path proposal stays open for voting." />
         <div className="flex items-stretch gap-1.5 text-center">
-          <DurationInput label="Day" value={state.durationDays} onChange={v => set('durationDays', v)} disabled={disabled} />
-          <DurationInput label="Hours" value={state.durationHours} onChange={v => set('durationHours', v)} disabled={disabled} />
+          <DurationInput
+            label="Day"
+            value={state.durationDays}
+            onChange={v => set('durationDays', v)}
+            disabled={disabled}
+          />
+          <DurationInput
+            label="Hours"
+            value={state.durationHours}
+            onChange={v => set('durationHours', v)}
+            disabled={disabled}
+          />
           <DurationInput
             label="Minutes"
             value={state.durationMinutes}
@@ -107,7 +121,30 @@ export function VotingSettingsFields({ state, onChange, disabled = false }: Prop
 
       <Divider />
 
-      <SettingRow label="Quorum" hint="Minimum number of editors that must vote for a review-path proposal to be valid.">
+      {/* A switch rather than a number, phrased as what it grants rather than what it disables:
+          the stored field is `disableFastPathForNewMembers`, and a control labelled with a negative
+          that is then toggled off asks the reader to hold two inversions at once. */}
+      <SettingRow
+        label="Fast path for new members"
+        hint="When off, members who join from now on can only propose on the review path until an editor lifts the restriction. Existing members are unaffected either way."
+      >
+        <button
+          type="button"
+          role="switch"
+          aria-checked={!state.disableFastPathForNewMembers}
+          aria-label="Fast path for new members"
+          disabled={disabled}
+          onClick={() => set('disableFastPathForNewMembers', !state.disableFastPathForNewMembers)}
+          className="flex h-8 items-center justify-end px-2 disabled:opacity-50"
+        >
+          <Toggle checked={!state.disableFastPathForNewMembers} />
+        </button>
+      </SettingRow>
+
+      <SettingRow
+        label="Quorum"
+        hint="Minimum number of editors that must vote for a review-path proposal to be valid."
+      >
         <ValueInput value={state.quorum} onChange={v => set('quorum', v)} disabled={disabled} />
       </SettingRow>
     </div>
@@ -212,7 +249,15 @@ function DurationInput({ label, value, onChange, disabled }: DurationInputProps)
   );
 }
 
-function ValueInput({ value, onChange, disabled }: { value: string; onChange: (next: string) => void; disabled?: boolean }) {
+function ValueInput({
+  value,
+  onChange,
+  disabled,
+}: {
+  value: string;
+  onChange: (next: string) => void;
+  disabled?: boolean;
+}) {
   return (
     <input
       value={value}

--- a/apps/web/partials/governance/voting-settings.test.ts
+++ b/apps/web/partials/governance/voting-settings.test.ts
@@ -50,6 +50,7 @@ describe('snapshotToFormState', () => {
       durationSeconds: '15',
       fastPathVotes: '2',
       quorum: '3',
+      disableFastPathForNewMembers: true,
     });
   });
 });
@@ -64,6 +65,7 @@ describe('parseVotingSettingsForm', () => {
     durationSeconds: '0',
     fastPathVotes: '1',
     quorum: '1',
+    disableFastPathForNewMembers: true,
   };
 
   it('accepts a valid form, reads the universal threshold, and preserves hidden fields', () => {
@@ -77,7 +79,7 @@ describe('parseVotingSettingsForm', () => {
       quorum: 1,
       durationInSeconds: 86400,
       executionGracePeriodInDays: hidden.graceDays,
-      disableFastPathAccessForNewMembers: hidden.disableFastPathForNewMembers,
+      disableFastPathAccessForNewMembers: validForm.disableFastPathForNewMembers,
     });
   });
 
@@ -165,6 +167,7 @@ describe('votingSettingsWarnings', () => {
     durationSeconds: '0',
     fastPathVotes: '1',
     quorum: '1',
+    disableFastPathForNewMembers: true,
   };
 
   it('warns on a likely-decimal slow path threshold', () => {
@@ -179,5 +182,46 @@ describe('votingSettingsWarnings', () => {
 
   it('does not warn when the universal threshold is at or above the pass threshold', () => {
     expect(votingSettingsWarnings(baseForm)).toEqual([]);
+  });
+});
+
+// The field was carried through `HiddenVotingSettings` unchanged, so a space created with the
+// restriction on had no way to turn it off: the only surface that writes voting settings passed
+// back whatever it read.
+describe('fast path for new members', () => {
+  // Built from the defaults rather than borrowing another block's fixture, so this reads on its own.
+  const form = snapshotToFormState(DEFAULT_VOTING_SETTINGS_SNAPSHOT);
+  const carried = snapshotToHidden(DEFAULT_VOTING_SETTINGS_SNAPSHOT);
+
+  it('is written from the form rather than carried through unchanged', () => {
+    const result = parseVotingSettingsForm({ ...form, disableFastPathForNewMembers: false }, carried);
+
+    expect(result.kind).toBe('ok');
+    if (result.kind !== 'ok') return;
+    expect(result.value.disableFastPathAccessForNewMembers).toBe(false);
+  });
+
+  it('still writes the restriction when the form leaves it on', () => {
+    const result = parseVotingSettingsForm({ ...form, disableFastPathForNewMembers: true }, carried);
+
+    expect(result.kind).toBe('ok');
+    if (result.kind !== 'ok') return;
+    expect(result.value.disableFastPathAccessForNewMembers).toBe(true);
+  });
+
+  it('prefills the form from what the space currently has', () => {
+    expect(
+      snapshotToFormState({ ...DEFAULT_VOTING_SETTINGS_SNAPSHOT, disableFastPathForNewMembers: false })
+    ).toMatchObject({
+      disableFastPathForNewMembers: false,
+    });
+  });
+
+  // Blank-field validation runs over the text inputs; a boolean has no blank state and must not be
+  // swept into it, or leaving the switch off would read as an empty field.
+  it('does not treat the switch as a required text field', () => {
+    const result = parseVotingSettingsForm({ ...form, disableFastPathForNewMembers: false }, carried);
+
+    expect(result.kind).toBe('ok');
   });
 });

--- a/apps/web/partials/governance/voting-settings.ts
+++ b/apps/web/partials/governance/voting-settings.ts
@@ -65,12 +65,25 @@ export type VotingSettingsFormState = {
   durationSeconds: string;
   fastPathVotes: string;
   quorum: string;
+  /**
+   * Whether members who join from now on are barred from the fast path.
+   *
+   * A boolean rather than a string: it is a switch, not something anyone types, so it has no
+   * half-entered state to hold. It was a hidden field until the space had no way to change its
+   * mind about it — see `HiddenVotingSettings`.
+   */
+  disableFastPathForNewMembers: boolean;
 };
 
-/** Fields the form doesn't expose but the SDK still requires; carried through unchanged. */
+/**
+ * Fields the form doesn't expose but the SDK still requires; carried through unchanged.
+ *
+ * `disableFastPathForNewMembers` used to live here. It is on-chain and `updateVotingSettings`
+ * always carried it, so a space could be created with it on and then had no way to turn it off:
+ * the only surface that writes voting settings passed whatever it read straight back.
+ */
 export type HiddenVotingSettings = {
   graceDays: number;
-  disableFastPathForNewMembers: boolean;
 };
 
 /**
@@ -134,19 +147,17 @@ export function snapshotToFormState(snapshot: VotingSettingsSnapshot): VotingSet
     durationSeconds: String(seconds),
     fastPathVotes: String(snapshot.flat),
     quorum: String(snapshot.quorum),
+    disableFastPathForNewMembers: snapshot.disableFastPathForNewMembers,
   };
 }
 
 export function snapshotToHidden(snapshot: VotingSettingsSnapshot): HiddenVotingSettings {
   return {
     graceDays: snapshot.graceDays,
-    disableFastPathForNewMembers: snapshot.disableFastPathForNewMembers,
   };
 }
 
-export type ParseVotingSettingsResult =
-  | { kind: 'ok'; value: VotingSettingsInput }
-  | { kind: 'error'; message: string };
+export type ParseVotingSettingsResult = { kind: 'ok'; value: VotingSettingsInput } | { kind: 'error'; message: string };
 
 /**
  * Validate the form and produce a VotingSettingsInput, preserving the hidden fields.
@@ -215,7 +226,7 @@ export function parseVotingSettingsForm(
     flatSupportThreshold: flat,
     quorum,
     durationInSeconds,
-    disableFastPathAccessForNewMembers: hidden.disableFastPathForNewMembers,
+    disableFastPathAccessForNewMembers: state.disableFastPathForNewMembers,
     executionGracePeriodInDays: hidden.graceDays,
   };
 

--- a/apps/web/partials/governance/voting-settings.ts
+++ b/apps/web/partials/governance/voting-settings.ts
@@ -25,7 +25,7 @@ export type VotingSettingsSnapshot = {
   durationSeconds: number;
   /** Execution grace period in days — not shown in the form, preserved on edit. */
   graceDays: number;
-  /** Not shown in the form, preserved on edit. */
+  /** Whether members joining from now on are barred from the fast path. Editable — see the form. */
   disableFastPathForNewMembers: boolean;
 };
 


### PR DESCRIPTION
Two features were asked for. **One is here; the other is blocked**, and the reason matters.

## Shipped: the governance toggle

`disableFastPathAccessForNewMembers` is on-chain and `updateVotingSettings` always carried it — but the only surface that writes voting settings read it and passed it straight back as a hidden field. A space created with the restriction on had no way to turn it off, and no way to see that it was on.

It is now a switch in the governance settings modal, phrased as what it grants rather than what it disables. The stored flag is a negative, and a control labelled with a negative that is then toggled off asks the reader to hold two inversions at once.

`set` in `VotingSettingsFields` now takes the field's own type rather than `string` — this is the form's first non-text field.

**Scope:** this decides what happens to members who join from here on. It does not clear the role anyone already holds.

## Also in here: the change is visible to voters

An `UPDATE_VOTING_SETTINGS` proposal that flips only this switch used to render five rows, every one unchanged — a voter would see what looked like a no-op and approve an access-control change they could not inspect. Before this branch the field was unchangeable, so no proposal could carry it; making it editable is what exposed the gap.

The cause was client-side and one line deep: `ApiActionSchema` never declared `disableFastPathAccessForNewMembers`, and Effect Schema drops undeclared properties on decode, so the value arrived from the API and was discarded before anything could read it. Declaring it, threading it through the DTO and extractor, and adding a row is the fix.

**Verified on the deploy** — a toggle-only proposal now renders `Fast path for new members  Off → On`.

## The other half is a separate ticket

The "Enable fast path" control for the manage-editors menu is **not** in this PR. It lifts the `FAST_PATH_RESTRICTED` role from a member who already has it, which this toggle cannot do — this decides what happens to members who join from here on.

* **GEO-2802** — the SDK has no `unrestrictSpace` helper, and the proposal encoding is SDK-internal, so it cannot be worked around in the app. Assigned to Faruk.
* **GEO-2803** — the button itself, blocked on GEO-2802. Assigned to Bryan.

GEO-2802 also carries an unresolved question worth knowing about: the contract's `actionIsFastPathValid` returns false for `unrestrictSpace`, which suggests it needs a review-path proposal rather than the instant escalation it sounds like. Not conclusive — `publish` returns false too and edits demonstrably can take the fast path — so it needs someone with the DAOSpace source.

## Testing

Four new cases in `voting-settings.test.ts`: the flag is written from the form in both directions, prefills from what the space currently has, and is not swept into the blank-field validation that runs over the text inputs. Existing fixtures updated for the new field.

Verified by pinning the flag back to `true` — the round-trip case fails.

`vitest run partials/governance`: 22 passed. eslint and prettier clean.

Plus three cases pinning the new field through the proposal mapper: both directions survive extraction, and a lone `false` is not mistaken for an empty action — `hasAnyValue` tests `!== undefined`, and had it tested truthiness a proposal reporting only `false` would have vanished from the review page entirely.

**Note on typecheck:** master currently has 163 pre-existing `tsc --noEmit` errors (up from 5 a few days ago — something regressed there independently). None are in the files this touches.

## Worth a look

**Verified on the deploy**: the toggle submits a real review-path proposal, and the review page shows `Fast path for new members  Off → On`.

One thing left alone: the settings modal is `overflow-hidden` with no max-height, so on short viewports the submit button can drift out of reach. Pre-existing — create-space guards the same fields with `overflow-y-auto` — but the row this adds moves the threshold, so it is worth a look on a phone.
