### PR TITLE
fix(debates): stabilize claim positions and rematch feedback

### DIFF
--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
@@ -2813,23 +2813,37 @@ describe('DebateRematchPageClient', () => {
 
   // Request errors are rendered on the claim card that initiated the mutation.
   it('reports a refused request on the card it was sent from', async () => {
+    // Through the press, so the claim the error is keyed to is the one the mutation was actually
+    // sent for — `variables` is react-query's record of that call, not a value this test picks.
+    mocks.mutate.mockImplementation((variables: { claim_id: string }) => {
+      mocks.requestVariables = variables;
+    });
     mocks.requestError = new Error('respond to this claim before requesting a rematch');
-    mocks.requestVariables = { claim_id: CLAIM_SHARED };
+    const view = render(<DebateRematchPageClient sessionId="rematch-1" />);
+    await showOpponentClaims();
+
+    const card = screen.getByText('A claim both participants chose').closest('article');
+    fireEvent.click(within(card!).getByRole('button', { name: 'Request debate' }));
+    view.rerender(<DebateRematchPageClient sessionId="rematch-1" />);
+
+    expect(mocks.requestVariables?.claim_id).toBe(CLAIM_SHARED);
+    expect(within(card!).getByRole('alert')).toHaveTextContent('respond to this claim before requesting a rematch');
+    // One report, not one per surface.
+    expect(screen.getAllByRole('alert')).toHaveLength(1);
+  });
+
+  // The shared mutation must not expose one claim's error on other cards — and the card it belongs
+  // to can leave the list (a tab swap, a search, a filter), so the page keeps the fallback rather
+  // than letting the message go down with it.
+  it('keeps a refusal on the page when its card is not on screen', async () => {
+    mocks.requestError = new Error('respond to this claim before requesting a rematch');
+    mocks.requestVariables = { claim_id: 'a-claim-this-tab-does-not-show' };
     render(<DebateRematchPageClient sessionId="rematch-1" />);
     await showOpponentClaims();
 
     const card = screen.getByText('A claim both participants chose').closest('article');
-    expect(within(card!).getByRole('alert')).toHaveTextContent('respond to this claim before requesting a rematch');
-  });
-
-  // The shared mutation must not expose one claim's error on other cards.
-  it('leaves the other cards alone when one request is refused', async () => {
-    mocks.requestError = new Error('respond to this claim before requesting a rematch');
-    mocks.requestVariables = { claim_id: 'some-other-claim' };
-    render(<DebateRematchPageClient sessionId="rematch-1" />);
-    await showOpponentClaims();
-
-    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(within(card!).queryByRole('alert')).not.toBeInTheDocument();
+    expect(screen.getByRole('alert')).toHaveTextContent('respond to this claim before requesting a rematch');
   });
 
   // GEO-2652. The wait is real — a publish, an index and a notification — so it is named rather

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
@@ -49,6 +49,9 @@ const mocks = vi.hoisted(() => ({
   leaveMutate: vi.fn(),
   acceptMutate: vi.fn(),
   rejectMutate: vi.fn(),
+  /** The last rematch request error and its variables. */
+  requestError: null as Error | null,
+  requestVariables: undefined as { claim_id: string } | undefined,
   submitResponse: vi.fn(),
   optimisticResponses: new Map<string, 'positive' | 'negative' | null>(),
   /** Overrides the snapshot status, so the window where it is `indexed` is reachable. */
@@ -233,7 +236,11 @@ vi.mock('~/core/debates/hooks', () => ({
       isError: mocks.claimReadinessError,
     };
   },
-  useCreateDebateRematchRequest: () => mutation(),
+  useCreateDebateRematchRequest: () => ({
+    ...mutation(),
+    error: mocks.requestError,
+    variables: mocks.requestVariables,
+  }),
   useLeaveDebateRematch: () => mutation(mocks.leaveMutate),
   useAcceptDebateRematchRequest: () => mutation(mocks.acceptMutate),
   useRejectDebateRematchRequest: () => mutation(mocks.rejectMutate),
@@ -675,6 +682,8 @@ beforeEach(() => {
   mocks.leaveMutate.mockReset();
   mocks.acceptMutate.mockReset();
   mocks.rejectMutate.mockReset();
+  mocks.requestError = null;
+  mocks.requestVariables = undefined;
   mocks.submitResponse.mockReset();
   mocks.optimisticResponses.clear();
   mocks.responseIndexingDelayed = false;
@@ -2800,6 +2809,27 @@ describe('DebateRematchPageClient', () => {
     expect(button).toHaveAttribute('aria-busy', 'true');
     // The old separate spinner line is gone: there is one element, not a message beside a gap.
     expect(screen.queryByRole('button', { name: 'Request debate' })).not.toBeInTheDocument();
+  });
+
+  // Request errors are rendered on the claim card that initiated the mutation.
+  it('reports a refused request on the card it was sent from', async () => {
+    mocks.requestError = new Error('respond to this claim before requesting a rematch');
+    mocks.requestVariables = { claim_id: CLAIM_SHARED };
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+    await showOpponentClaims();
+
+    const card = screen.getByText('A claim both participants chose').closest('article');
+    expect(within(card!).getByRole('alert')).toHaveTextContent('respond to this claim before requesting a rematch');
+  });
+
+  // The shared mutation must not expose one claim's error on other cards.
+  it('leaves the other cards alone when one request is refused', async () => {
+    mocks.requestError = new Error('respond to this claim before requesting a rematch');
+    mocks.requestVariables = { claim_id: 'some-other-claim' };
+    render(<DebateRematchPageClient sessionId="rematch-1" />);
+    await showOpponentClaims();
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
   });
 
   // GEO-2652. The wait is real — a publish, an index and a notification — so it is named rather

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -1012,6 +1012,14 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
     });
   };
 
+  /** The last request failure, and whether the claim it was sent for is still on screen. */
+  const requestError = createRequest.error instanceof Error ? createRequest.error.message : null;
+  const requestErrorClaimId = requestError ? createRequest.variables?.claim_id : undefined;
+  const hasClaimId = (claim: DebateRematchClaim) => claim.claim.claim_entity_id === requestErrorClaimId;
+  const requestErrorHasCard =
+    requestErrorClaimId !== undefined &&
+    (showsSections ? visibleSections.some(section => section.claims.some(hasClaimId)) : visibleClaims.some(hasClaimId));
+
   const renderClaimCard = (claim: DebateRematchClaim) => (
     <RematchClaimCard
       key={claim.claim.claim_entity_id}
@@ -1029,11 +1037,7 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
       }
       busy={createRequest.isPending || session?.status === 'request_pending'}
       // Associate the shared mutation error with the claim that initiated it.
-      requestError={
-        createRequest.error instanceof Error && createRequest.variables?.claim_id === claim.claim.claim_entity_id
-          ? createRequest.error.message
-          : null
-      }
+      requestError={hasClaimId(claim) ? requestError : null}
     />
   );
 
@@ -1162,12 +1166,18 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
           </div>
         </div>
 
-        {/* Request errors are rendered on their claim cards. */}
-        {leaveSession.error instanceof Error && (
+        {/* A request error belongs on the card it was sent from; this line is the fallback for when
+            that card is no longer drawn — a tab swap, a search, a filter. Losing the message because
+            the list moved underneath it is how the failure read as silence (GEO-2807). */}
+        {leaveSession.error instanceof Error ? (
           <Text color="red-01" className="mb-4">
             {leaveSession.error.message}
           </Text>
-        )}
+        ) : requestError && !requestErrorHasCard ? (
+          <div role="alert" className="mb-4">
+            <Text color="red-01">{requestError}</Text>
+          </div>
+        ) : null}
         {session?.request?.status === 'expired' && session.request.cancellation_reason && (
           <Text color="red-01" className="mb-4">
             {rematchCancellationMessage(session.request.cancellation_reason)}
@@ -1481,6 +1491,11 @@ function RematchClaimCard({
       // lands. Until then `chatPosition` reads as "no position" for someone the summaries
       // may already count, and the card would draw them onto a second side.
       viewerIdentityPending={currentUserId === null}
+      // geo-chat has no row for this claim, which `readiness.viewer_response` below flattens to the
+      // same `null` it uses for "no position". The card needs the difference: its sides here are the
+      // graph's, and correcting them against an answer nobody gave takes the viewer off the side
+      // the graph says they hold (GEO-2807).
+      viewerResponseUnknown={chatPosition === undefined}
       // Reading a claim shouldn't cost the session: navigating to its entity page would leave the
       // rematch behind, so open it beside the picker instead.
       onOpenClaim={() => openSidePanel(claim.claim.claim_entity_id, claim.claim.space_id, false)}

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -59,8 +59,8 @@ import { useDebouncedSelection } from '~/core/debates/matchmaking/use-debounced-
 import { useStableListOrder } from '~/core/debates/matchmaking/use-stable-list-order';
 import { DEBATE_TAG_ID } from '~/core/debates/ontology';
 import { participantSidesOn, useParticipantPositions } from '~/core/debates/participant-positions';
-import { REQUEST_PENDING_LABEL, debateRequestGate } from '~/core/debates/request-gate';
 import { useRecommendedClaimSections } from '~/core/debates/recommended-claims';
+import { REQUEST_PENDING_LABEL, debateRequestGate } from '~/core/debates/request-gate';
 import {
   type TaggedClaimFilters,
   tagDisplaySpaceId,
@@ -1028,6 +1028,12 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
         })
       }
       busy={createRequest.isPending || session?.status === 'request_pending'}
+      // Associate the shared mutation error with the claim that initiated it.
+      requestError={
+        createRequest.error instanceof Error && createRequest.variables?.claim_id === claim.claim.claim_entity_id
+          ? createRequest.error.message
+          : null
+      }
     />
   );
 
@@ -1156,13 +1162,10 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
           </div>
         </div>
 
-        {(createRequest.error instanceof Error || leaveSession.error instanceof Error) && (
+        {/* Request errors are rendered on their claim cards. */}
+        {leaveSession.error instanceof Error && (
           <Text color="red-01" className="mb-4">
-            {createRequest.error instanceof Error
-              ? createRequest.error.message
-              : leaveSession.error instanceof Error
-                ? leaveSession.error.message
-                : null}
+            {leaveSession.error.message}
           </Text>
         )}
         {session?.request?.status === 'expired' && session.request.cancellation_reason && (
@@ -1324,6 +1327,7 @@ function RematchClaimCard({
   readiness: claimReadiness,
   onRequest,
   busy,
+  requestError,
 }: {
   claim: DebateRematchClaim;
   session: DebateRematchSession | null;
@@ -1334,6 +1338,8 @@ function RematchClaimCard({
   /** True while any readiness lookup is still running or has failed. */
   onRequest: () => void;
   busy: boolean;
+  /** The last request error for this claim. */
+  requestError?: string | null;
 }) {
   const remotePosition = claim.participants.find(side => side.user_id !== currentUserId)?.position ?? null;
 
@@ -1379,7 +1385,8 @@ function RematchClaimCard({
    *
    * Matching the card's threshold is what keeps a card and its own footer describing one moment.
    */
-  const inFlightResponse = optimisticResponse !== undefined ? optimisticResponse : responseIndexing.pending?.expectedResponse;
+  const inFlightResponse =
+    optimisticResponse !== undefined ? optimisticResponse : responseIndexing.pending?.expectedResponse;
 
   const localPosition =
     inFlightResponse === undefined
@@ -1481,7 +1488,7 @@ function RematchClaimCard({
         // `recently_rejected` too: the note lives in this footer, and it is a standing fact about
         // the claim rather than a state of the offer. Without it a rejected claim the viewer has no
         // position on lost the explanation along with the button.
-        awaitingResponse || canRequest || requesting || claim.recently_rejected ? (
+        awaitingResponse || canRequest || requesting || claim.recently_rejected || requestError ? (
           <div className="mt-3">
             {/* GEO-2697. The wait lives on the control it is blocking. This used to be a separate
                 spinner line rendered *instead* of the button, which left the viewer watching a
@@ -1509,6 +1516,14 @@ function RematchClaimCard({
               <Text as="p" variant="footnote" color="grey-04" className="mt-1">
                 Recently rejected
               </Text>
+            ) : null}
+            {/* Keep request feedback with the claim that initiated the mutation. */}
+            {requestError ? (
+              <div role="alert" className="mt-1">
+                <Text as="p" variant="footnote" color="red-01">
+                  {requestError}
+                </Text>
+              </div>
             ) : null}
           </div>
         ) : null

--- a/apps/web/core/claims/browse/claim-end-slot.tsx
+++ b/apps/web/core/claims/browse/claim-end-slot.tsx
@@ -105,6 +105,8 @@ export function ClaimEndSlot({
       : 'inline-flex h-5 shrink-0 px-2.5 text-[14px] leading-none'
   );
 
+  // A match is derived from the same readiness rows validated by `create_debate_request_as`, so no
+  // additional position check is required on this surface.
   if (match) {
     return (
       <span className={cx('flex flex-col gap-1', variant === 'block' ? 'w-full' : 'shrink-0 items-end', className)}>

--- a/apps/web/core/claims/browse/claim-end-slot.tsx
+++ b/apps/web/core/claims/browse/claim-end-slot.tsx
@@ -105,8 +105,13 @@ export function ClaimEndSlot({
       : 'inline-flex h-5 shrink-0 px-2.5 text-[14px] leading-none'
   );
 
-  // A match is derived from the same readiness rows validated by `create_debate_request_as`, so no
-  // additional position check is required on this surface.
+  // A match is derived from the same `debate_claim_readiness` rows `create_debate_request_as` reads,
+  // so no additional position check belongs here — one against the graph would only be slower.
+  //
+  // Not a guarantee the request will be accepted: the match query omits that endpoint's
+  // `validation_failed_at IS NULL` / `last_validated_at IS NOT NULL` predicates and its
+  // attempted-recipient exclusion, so a failed validation sweep or an already-tried opponent still
+  // draws a live button. Which is why the refusal below is rendered rather than swallowed.
   if (match) {
     return (
       <span className={cx('flex flex-col gap-1', variant === 'block' ? 'w-full' : 'shrink-0 items-end', className)}>

--- a/apps/web/core/debates/claim-response-indexed-notifier.ts
+++ b/apps/web/core/debates/claim-response-indexed-notifier.ts
@@ -56,7 +56,7 @@ export function claimResponseIndexedEvent(queryKey: readonly unknown[], data: un
  * should disappear as fast as clicking one on.
  */
 export function pendingClaimResponse(queryKey: readonly unknown[], data: unknown) {
-  const [scope, , entityId, spaceId, responseKind] = queryKey;
+  const [scope, personalSpaceId, entityId, spaceId, responseKind] = queryKey;
   const indexingState = data as EntityResponseIndexingState | undefined;
   if (
     scope !== 'entity-response-indexing' ||
@@ -71,6 +71,8 @@ export function pendingClaimResponse(queryKey: readonly unknown[], data: unknown
       indexingState.pending.expectedResponse === null ? null : indexingState.pending.expectedResponse === 'positive',
     responseKind: responseKind as DebateResponseKind,
     spaceId: String(spaceId),
+    /** Whose write this is, so a reader can attribute the row without assuming the current viewer. */
+    personalSpaceId: String(personalSpaceId),
     /** Used to distinguish confirmed responses from rolled-back responses. */
     status: indexingState.status,
   };

--- a/apps/web/core/debates/claim-response-indexed-notifier.ts
+++ b/apps/web/core/debates/claim-response-indexed-notifier.ts
@@ -10,12 +10,11 @@ import { type DebateResponseKind, type GetPrivyIdentityToken, notifyClaimRespons
 import { refreshRematchClaimBatches, rematchClaimBatchesWithClaim } from './rematch-claims-query-key';
 
 const MAX_NOTIFIED_RUNS = 256;
-/**
- * What sending a notification actually needs. The indexed variant additionally carries `runId`,
- * but that is only used to build the dedupe key at the call site — never inside the send — so both
- * the in-flight and the confirmed response satisfy this (GEO-2784).
- */
-type NotifiableClaimResponse = NonNullable<ReturnType<typeof pendingClaimResponse>>;
+/** Fields shared by pending and indexed response notifications. */
+type NotifiableClaimResponse = Pick<
+  NonNullable<ReturnType<typeof pendingClaimResponse>>,
+  'entityId' | 'position' | 'responseKind' | 'spaceId'
+>;
 type InterruptedNotification = {
   accountKey: string;
   notificationKey: string;
@@ -72,6 +71,8 @@ export function pendingClaimResponse(queryKey: readonly unknown[], data: unknown
       indexingState.pending.expectedResponse === null ? null : indexingState.pending.expectedResponse === 'positive',
     responseKind: responseKind as DebateResponseKind,
     spaceId: String(spaceId),
+    /** Used to distinguish confirmed responses from rolled-back responses. */
+    status: indexingState.status,
   };
 }
 

--- a/apps/web/core/debates/matchmaking/matchmaking-claim-card.tsx
+++ b/apps/web/core/debates/matchmaking/matchmaking-claim-card.tsx
@@ -591,7 +591,17 @@ export function withViewerPosition({
   viewerName: string | null;
   viewerAvatarUrl: string | null;
 }): DebateClaimPositionSummary[] {
-  if (!viewerSpaceId || viewerPosition === serverPosition) return positions;
+  if (!viewerSpaceId) return positions;
+
+  // Profile space IDs may use dashed or bare-hex forms.
+  const heldByViewer = (participant: DebateParticipantSummary) =>
+    ID.equals(participant.profile_space_id, viewerSpaceId);
+
+  // Participant lists may lag behind `serverPosition`, so also check for a stale viewer entry.
+  const listedOnAnotherSide = positions.some(
+    side => side.position !== viewerPosition && side.participants.some(heldByViewer)
+  );
+  if (viewerPosition === serverPosition && !listedOnAnotherSide) return positions;
 
   const copy = ENTITY_RESPONSE_COPY[responseKind];
   const viewer = {
@@ -602,13 +612,6 @@ export function withViewerPosition({
     display_name: viewerName,
     avatar_cid: viewerAvatarUrl,
   };
-
-  // `ID.equals` rather than `===`: `viewerSpaceId` is a graph id, which is always bare hex, while
-  // geo-chat ids are treated as possibly dashed throughout this directory. A raw comparison against
-  // a dashed `profile_space_id` silently fails to match, which would leave the viewer drawn on both
-  // sides at once — the count decrements either way.
-  const heldByViewer = (participant: DebateParticipantSummary) =>
-    ID.equals(participant.profile_space_id, viewerSpaceId);
 
   // Counts follow `serverPosition`, but the participant lists are rebuilt from scratch on every
   // side. Removing the viewer only from the side the server reports assumed those two agree about

--- a/apps/web/core/debates/matchmaking/matchmaking-claim-card.tsx
+++ b/apps/web/core/debates/matchmaking/matchmaking-claim-card.tsx
@@ -86,6 +86,8 @@ type Props = {
    * that only means "don't know yet", which would draw the viewer onto two sides at once.
    */
   viewerIdentityPending?: boolean;
+  /** The host has no answer about the viewer's side, rather than an answer of "none" — see below. */
+  viewerResponseUnknown?: boolean;
   /**
    * Sends a signed-out viewer to Privy instead of publishing. Set by hosts that render to signed-out
    * viewers — the hub's Claims tab and the claim page — and left unset when signing in is not a
@@ -128,6 +130,7 @@ export function MatchmakingClaimCard({
   footer,
   onOpenClaim,
   viewerIdentityPending,
+  viewerResponseUnknown,
   onRequireSignIn,
   hideEndSlot,
   ref,
@@ -184,6 +187,7 @@ export function MatchmakingClaimCard({
           readResponses={readResponses}
           onOpenClaim={onOpenClaim}
           viewerIdentityPending={viewerIdentityPending}
+          viewerResponseUnknown={viewerResponseUnknown}
           onRequireSignIn={onRequireSignIn}
           hideEndSlot={hideEndSlot}
         />
@@ -280,6 +284,7 @@ export function useClaimPositionControl({
   answersReady = true,
   responseBlockedReason = null,
   viewerIdentityPending,
+  viewerResponseUnknown,
   onRequireSignIn,
   offersDebate = true,
 }: {
@@ -308,6 +313,16 @@ export function useClaimPositionControl({
    */
   responseBlockedReason?: string | null;
   viewerIdentityPending?: boolean;
+  /**
+   * Set when the host holds no answer about the viewer's side, as opposed to an answer of "none".
+   *
+   * `readiness.viewer_response` is `null` for both, and the difference decides whether the
+   * participant lists can be corrected: with no answer they are the only account of where the viewer
+   * stands, and "correcting" them means erasing the viewer from the side they hold (GEO-2807). Only
+   * the rematch picker can tell the two apart — geo-chat reports `undefined` for a claim it has no
+   * row for — so only it sets this.
+   */
+  viewerResponseUnknown?: boolean;
   /**
    * What to do when a signed-out visitor presses a side. Given one, the pills stay live while
    * signed out and pressing prompts sign-in — matching the vote arrows on an entity page. Without
@@ -382,7 +397,9 @@ export function useClaimPositionControl({
         : withViewerPosition({
             positions: positionsWithOpponents,
             responseKind: readiness.response_kind,
-            serverPosition: readiness.viewer_response?.position ?? null,
+            // `undefined` where the host cannot say, which is not the same as "no position" — see
+            // `viewerResponseUnknown`.
+            serverPosition: viewerResponseUnknown ? undefined : (readiness.viewer_response?.position ?? null),
             viewerPosition,
             viewerSpaceId: personalSpaceId,
             viewerName: viewerProfile?.name ?? null,
@@ -395,6 +412,7 @@ export function useClaimPositionControl({
       readiness.viewer_response?.position,
       viewerIdentityPending,
       viewerPosition,
+      viewerResponseUnknown,
       viewerProfile?.avatarUrl,
       viewerProfile?.name,
     ]
@@ -468,6 +486,7 @@ function RespondableControls({
   readResponses = true,
   onOpenClaim,
   viewerIdentityPending,
+  viewerResponseUnknown,
   onRequireSignIn,
   hideEndSlot,
 }: {
@@ -481,6 +500,7 @@ function RespondableControls({
   readResponses?: boolean;
   onOpenClaim?: () => void;
   viewerIdentityPending?: boolean;
+  viewerResponseUnknown?: boolean;
   onRequireSignIn?: () => void;
   hideEndSlot?: boolean;
 }) {
@@ -492,6 +512,7 @@ function RespondableControls({
       answersReady,
       responseBlockedReason,
       viewerIdentityPending,
+      viewerResponseUnknown,
       onRequireSignIn,
       // The faces the match implies belong with the offer the match makes. Where the slot is hidden
       // there is no offer, so there is nothing for them to be coherent with — see `offersDebate`.
@@ -583,15 +604,21 @@ export function withViewerPosition({
 }: {
   positions: DebateClaimPositionSummary[];
   responseKind: MatchmakingReadiness['response_kind'];
-  /** The position geo-chat currently reports for the viewer. */
-  serverPosition: boolean | null;
+  /**
+   * The position geo-chat currently reports for the viewer, or `undefined` where it has not
+   * answered — which is not the same as an answer of "no position". See `viewerResponseUnknown`.
+   */
+  serverPosition: boolean | null | undefined;
   /** The position this client knows the viewer holds. */
   viewerPosition: boolean | null;
   viewerSpaceId: string | null;
   viewerName: string | null;
   viewerAvatarUrl: string | null;
 }): DebateClaimPositionSummary[] {
-  if (!viewerSpaceId) return positions;
+  // Nothing to reconcile the lists against. A `null` viewer position here would otherwise read as
+  // "holds nothing" and take their face off every side, including the one the list says they hold
+  // (GEO-2807) — the rematch picker draws graph-derived sides for claims geo-chat has no row for.
+  if (!viewerSpaceId || serverPosition === undefined) return positions;
 
   // Profile space IDs may use dashed or bare-hex forms.
   const heldByViewer = (participant: DebateParticipantSummary) =>
@@ -627,8 +654,13 @@ export function withViewerPosition({
   // `viewer_response`, so a bump keyed on `serverPosition` alone counted them twice: one face and
   // a "+1" beside it, on a side only the viewer holds. `available_now_count` is never adjusted: it
   // means "people this viewer could request", which the viewer is not and never becomes.
+  //
+  // `serverPosition` is only trusted to answer that where the lists agree with it. Where they put
+  // the viewer on a different side, whatever built the counts counted them *there* — so the side
+  // they actually hold is short by one, and taking `serverPosition`'s word for it prepended a face
+  // without a number and pushed a real person out of the stack (GEO-2807).
   const countsViewer = (side: DebateClaimPositionSummary) =>
-    serverPosition === side.position || side.participants.some(heldByViewer);
+    (serverPosition === side.position && !listedOnAnotherSide) || side.participants.some(heldByViewer);
 
   const withViewer = (side: DebateClaimPositionSummary): DebateClaimPositionSummary => {
     const missing = countsViewer(side) ? 0 : 1;

--- a/apps/web/core/debates/matchmaking/with-viewer-position.test.ts
+++ b/apps/web/core/debates/matchmaking/with-viewer-position.test.ts
@@ -151,8 +151,58 @@ describe('withViewerPosition', () => {
 
     expect(on(sides, true).participants).toHaveLength(0);
     expect(on(sides, false).participants.map(p => p.profile_space_id)).toEqual([VIEWER_SPACE]);
-    // The server count already includes the viewer on the new side.
-    expect(presentCount(on(sides, false))).toBe(1);
+    // The viewer moves rather than appears: `present_count` describes the same population as
+    // `participants` on every surface that sets it, so the side listing the viewer was counting
+    // them and the side they hold was not. One off Agree, one onto Disagree.
+    expect(presentCount(on(sides, true))).toBe(0);
+    expect(presentCount(on(sides, false))).toBe(2);
+  });
+
+  // The held side's own population, which the correction has to keep whole. Trusting
+  // `serverPosition` to mean "this side already counts the viewer" prepended a face without a
+  // number, and the stack then reported fewer people than it knows about.
+  it('counts the viewer onto the side they hold when the lists had them elsewhere', () => {
+    const sides = place(
+      [
+        side(true, {
+          total_count: 3,
+          present_count: 3,
+          participants: [participant(OTHER_SPACE), participant('019fedb3aaaa7a4f8b223d8e6f9c5521')],
+        }),
+        side(false, { total_count: 1, present_count: 1, participants: [participant(VIEWER_SPACE)] }),
+      ],
+      true,
+      true
+    );
+
+    const agree = on(sides, true);
+    expect(agree.participants.map(p => p.profile_space_id)[0]).toBe(VIEWER_SPACE);
+    expect(presentCount(agree)).toBe(4);
+    // What the "+N" behind the two rendered faces is drawn from.
+    expect(presentCount(agree) - 2).toBe(2);
+    expect(presentCount(on(sides, false))).toBe(0);
+  });
+
+  // "geo-chat has not answered" is not "the viewer holds nothing". The rematch picker draws
+  // graph-derived sides for claims geo-chat has no row for, and stripping them there took the
+  // viewer off the side the graph says they hold.
+  it('leaves the lists alone when the server has given no answer', () => {
+    const positions = [
+      side(true, { total_count: 1, present_count: 1, participants: [participant(VIEWER_SPACE)] }),
+      side(false),
+    ];
+
+    const sides = withViewerPosition({
+      positions,
+      responseKind: 'stance',
+      serverPosition: undefined,
+      viewerPosition: null,
+      viewerSpaceId: VIEWER_SPACE,
+      viewerName: 'You',
+      viewerAvatarUrl: null,
+    });
+
+    expect(sides).toBe(positions);
   });
 
   // Preserve referential equality when no correction is required.

--- a/apps/web/core/debates/matchmaking/with-viewer-position.test.ts
+++ b/apps/web/core/debates/matchmaking/with-viewer-position.test.ts
@@ -122,6 +122,49 @@ describe('withViewerPosition', () => {
     expect(agree.participants.map(p => p.profile_space_id)).toEqual([OTHER_SPACE]);
   });
 
+  // Participant lists can retain the viewer after the reported position has been removed.
+  it('takes the viewer off a side the list still shows them on, even once the server agrees', () => {
+    const sides = place(
+      [
+        side(true, { total_count: 1, present_count: 1, participants: [participant(VIEWER_SPACE)] }),
+        side(false, { total_count: 0, present_count: 0 }),
+      ],
+      null,
+      null
+    );
+
+    const agree = on(sides, true);
+    expect(agree.participants).toHaveLength(0);
+    expect(agree.present_count).toBe(0);
+  });
+
+  // A stale participant list must not duplicate the viewer after a side change.
+  it('moves the viewer off the old side when the server has already caught up with the new one', () => {
+    const sides = place(
+      [
+        side(true, { total_count: 1, present_count: 1, participants: [participant(VIEWER_SPACE)] }),
+        side(false, { total_count: 1, present_count: 1 }),
+      ],
+      false,
+      false
+    );
+
+    expect(on(sides, true).participants).toHaveLength(0);
+    expect(on(sides, false).participants.map(p => p.profile_space_id)).toEqual([VIEWER_SPACE]);
+    // The server count already includes the viewer on the new side.
+    expect(presentCount(on(sides, false))).toBe(1);
+  });
+
+  // Preserve referential equality when no correction is required.
+  it('returns the same array when both sources already agree', () => {
+    const positions = [
+      side(true, { total_count: 1, present_count: 1, participants: [participant(VIEWER_SPACE)] }),
+      side(false),
+    ];
+
+    expect(place(positions, true, true)).toBe(positions);
+  });
+
   it('leaves present_count undefined where the server sent none, so the faces still answer', () => {
     const sides = place([side(true), side(false)], null, false);
 

--- a/apps/web/core/debates/participant-positions.test.ts
+++ b/apps/web/core/debates/participant-positions.test.ts
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 
 import * as React from 'react';
 
@@ -207,6 +207,111 @@ describe('useParticipantPositions holding its list', () => {
     rerender({ participants: [LOCAL] });
 
     expect(result.current.byClaim.size).toBe(1);
+  });
+});
+
+/** Confirmed position overlays remain active until participant positions are refetched. */
+describe('useParticipantPositions holding a settled write (GEO-2807)', () => {
+  const CLAIM = 'claim-1';
+  const SPACE = '019fedae72b67ab2927adf044d57c560';
+  const INDEXING_KEY = ['entity-response-indexing', LOCAL.profile_space_id, CLAIM, SPACE, 'stance'] as const;
+
+  const snapshot = (status: 'reconciling' | 'indexed', expectedResponse: 'positive' | 'negative' | null) => ({
+    status,
+    pending: {
+      entityId: CLAIM,
+      expectedResponse,
+      personalSpaceId: LOCAL.profile_space_id,
+      responseKind: 'stance',
+      spaceId: SPACE,
+    },
+    runId: 'run-1',
+  });
+
+  const sideOf = (result: { current: { byClaim: Map<string, unknown> } }) =>
+    participantSidesOn(result.current.byClaim as ReturnType<typeof groupParticipantPositions>, CLAIM, SPACE, [
+      LOCAL,
+      REMOTE,
+    ])[0]!.position;
+
+  const renderPositions = (client: QueryClient) =>
+    renderHook(() => useParticipantPositions([LOCAL, REMOTE], LOCAL.profile_space_id), {
+      wrapper: ({ children }) => React.createElement(QueryClientProvider, { client }, children),
+    });
+
+  it('keeps the position on screen between the write confirming and the refetch landing', async () => {
+    mocks.attention = true;
+    // The graph has not returned the new position yet.
+    mocks.graphql.mockImplementation(() => Effect.succeed([]));
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const { result } = renderPositions(client);
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    await act(async () => void client.setQueryData(INDEXING_KEY, snapshot('reconciling', 'positive')));
+    expect(sideOf(result)).toBe(true);
+
+    // Retire the indexing snapshot before the participant refetch completes.
+    await act(async () => void client.setQueryData(INDEXING_KEY, snapshot('indexed', 'positive')));
+    await act(async () => void client.setQueryData(INDEXING_KEY, { status: 'idle', pending: null, runId: null }));
+
+    expect(sideOf(result)).toBe(true);
+  });
+
+  it('hands back to the fetched list once a refetch has landed', async () => {
+    mocks.attention = true;
+    mocks.graphql.mockImplementation(() => Effect.succeed([]));
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const { result } = renderPositions(client);
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    await act(async () => void client.setQueryData(INDEXING_KEY, snapshot('indexed', 'positive')));
+    expect(sideOf(result)).toBe(true);
+    await act(async () => void client.setQueryData(INDEXING_KEY, { status: 'idle', pending: null, runId: null }));
+
+    // Ensure the refetch timestamp is later than the overlay retirement timestamp.
+    await new Promise(resolve => setTimeout(resolve, 5));
+    mocks.graphql.mockImplementation(() =>
+      Effect.succeed([{ userId: LOCAL.profile_space_id, objectId: CLAIM, spaceId: SPACE, voteType: 0, voteKind: 1 }])
+    );
+    await client.invalidateQueries({
+      queryKey: participantPositionsQueryKey([LOCAL.profile_space_id, REMOTE.profile_space_id]),
+    });
+
+    // The fetched row replaces the overlay without changing the displayed position.
+    await waitFor(() => expect(sideOf(result)).toBe(true));
+    expect(result.current.byClaim.get(CLAIM)).toHaveLength(1);
+  });
+
+  // Keep a removal tombstone until the fetched data reflects the removal.
+  it('keeps a removal hidden until the refetch confirms it', async () => {
+    mocks.attention = true;
+    mocks.graphql.mockImplementation(() =>
+      Effect.succeed([{ userId: LOCAL.profile_space_id, objectId: CLAIM, spaceId: SPACE, voteType: 0, voteKind: 1 }])
+    );
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const { result } = renderPositions(client);
+    await waitFor(() => expect(sideOf(result)).toBe(true));
+
+    await act(async () => void client.setQueryData(INDEXING_KEY, snapshot('indexed', null)));
+    expect(sideOf(result)).toBe(null);
+
+    await act(async () => void client.setQueryData(INDEXING_KEY, { status: 'idle', pending: null, runId: null }));
+    expect(sideOf(result)).toBe(null);
+  });
+
+  // A response that returns to idle without reaching indexed was rolled back.
+  it('drops a rolled-back write immediately', async () => {
+    mocks.attention = true;
+    mocks.graphql.mockImplementation(() => Effect.succeed([]));
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const { result } = renderPositions(client);
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    await act(async () => void client.setQueryData(INDEXING_KEY, snapshot('reconciling', 'positive')));
+    expect(sideOf(result)).toBe(true);
+
+    await act(async () => void client.setQueryData(INDEXING_KEY, { status: 'idle', pending: null, runId: null }));
+    expect(sideOf(result)).toBe(null);
   });
 });
 

--- a/apps/web/core/debates/participant-positions.test.ts
+++ b/apps/web/core/debates/participant-positions.test.ts
@@ -7,7 +7,7 @@ import { Effect } from 'effect';
 import { describe, expect, it, vi } from 'vitest';
 
 import type { DebateRematchParticipant } from './api';
-import type { ParticipantPosition } from './participant-positions';
+import type { ParticipantPosition, PendingParticipantPosition } from './participant-positions';
 import {
   applyPendingPositions,
   fetchParticipantPositions,
@@ -299,6 +299,29 @@ describe('useParticipantPositions holding a settled write (GEO-2807)', () => {
     expect(sideOf(result)).toBe(null);
   });
 
+  // A retained row carries the profile space it was written for, so it cannot outlive that viewer.
+  it('drops retained rows when the viewer goes away', async () => {
+    mocks.attention = true;
+    mocks.graphql.mockImplementation(() => Effect.succeed([]));
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const { result, rerender } = renderHook(
+      ({ profileSpaceId }: { profileSpaceId: string | null }) =>
+        useParticipantPositions([LOCAL, REMOTE], profileSpaceId),
+      {
+        initialProps: { profileSpaceId: LOCAL.profile_space_id as string | null },
+        wrapper: ({ children }) => React.createElement(QueryClientProvider, { client }, children),
+      }
+    );
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    await act(async () => void client.setQueryData(INDEXING_KEY, snapshot('indexed', 'positive')));
+    await act(async () => void client.setQueryData(INDEXING_KEY, { status: 'idle', pending: null, runId: null }));
+    expect(sideOf(result)).toBe(true);
+
+    await act(async () => rerender({ profileSpaceId: null }));
+    expect(sideOf(result)).toBe(null);
+  });
+
   // A response that returns to idle without reaching indexed was rolled back.
   it('drops a rolled-back write immediately', async () => {
     mocks.attention = true;
@@ -342,9 +365,9 @@ describe('applyPendingPositions (GEO-2784)', () => {
   /* The removal case, and the reason a tombstone is carried rather than dropped: without it the
      stale fetched row keeps the position on screen until the next refetch. */
   it('a pending removal hides the fetched row immediately', () => {
-    const pending = [
+    const pending: PendingParticipantPosition[] = [
       { profileSpaceId: 'me', claimId: 'c1', spaceId: 's1', responseKind: 'stance', position: null },
-    ] as unknown as ParticipantPosition[];
+    ];
     const merged = applyPendingPositions(FETCHED, pending);
     expect(merged.map(r => r.claimId)).toEqual(['c2']);
   });

--- a/apps/web/core/debates/participant-positions.test.ts
+++ b/apps/web/core/debates/participant-positions.test.ts
@@ -257,29 +257,83 @@ describe('useParticipantPositions holding a settled write (GEO-2807)', () => {
     expect(sideOf(result)).toBe(true);
   });
 
-  it('hands back to the fetched list once a refetch has landed', async () => {
+  /**
+   * The release, asserted where it is observable: the fetch has to *contradict* the overlay, or a
+   * held row and a released one look identical. A refetch returning the same answer proves nothing,
+   * and neither does the row count — the overlay and the fetched row share a `positionKey`, so the
+   * merge cannot produce two of them whatever it does.
+   */
+  it('hands back to the fetched list once it agrees, and stops asserting anything after that', async () => {
     mocks.attention = true;
-    mocks.graphql.mockImplementation(() => Effect.succeed([]));
+    const graphRow = (voteType: number) => [
+      { userId: LOCAL.profile_space_id, objectId: CLAIM, spaceId: SPACE, voteType, voteKind: 1 },
+    ];
+    const refetch = () =>
+      act(async () => {
+        await client.invalidateQueries({
+          queryKey: participantPositionsQueryKey([LOCAL.profile_space_id, REMOTE.profile_space_id]),
+        });
+      });
+
+    mocks.graphql.mockImplementation(() => Effect.succeed(graphRow(0)));
     const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
     const { result } = renderPositions(client);
-    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    await waitFor(() => expect(sideOf(result)).toBe(true));
 
-    await act(async () => void client.setQueryData(INDEXING_KEY, snapshot('indexed', 'positive')));
-    expect(sideOf(result)).toBe(true);
+    // The viewer switches sides, it confirms, and the snapshot retires.
+    await act(async () => void client.setQueryData(INDEXING_KEY, snapshot('indexed', 'negative')));
     await act(async () => void client.setQueryData(INDEXING_KEY, { status: 'idle', pending: null, runId: null }));
+    expect(sideOf(result)).toBe(false);
 
-    // Ensure the refetch timestamp is later than the overlay retirement timestamp.
-    await new Promise(resolve => setTimeout(resolve, 5));
+    // The graph catches up, which is what the overlay was waiting for.
+    mocks.graphql.mockImplementation(() => Effect.succeed(graphRow(1)));
+    await refetch();
+    expect(sideOf(result)).toBe(false);
+
+    // Handing back is only observable afterwards: a row still held would keep asserting the side it
+    // was retired with, whatever the graph goes on to say.
+    mocks.graphql.mockImplementation(() => Effect.succeed(graphRow(0)));
+    await refetch();
+    await waitFor(() => expect(sideOf(result)).toBe(true));
+  });
+
+  /**
+   * The half that made the old release rule wrong: `dataUpdatedAt` is when a response *landed*, so
+   * any newer response released the overlay — including a poll that was already in flight when the
+   * write confirmed and therefore carries rows from before it. Landing is not agreeing.
+   */
+  it('is not released by a fetch that still holds the pre-write rows', async () => {
+    mocks.attention = true;
     mocks.graphql.mockImplementation(() =>
       Effect.succeed([{ userId: LOCAL.profile_space_id, objectId: CLAIM, spaceId: SPACE, voteType: 0, voteKind: 1 }])
     );
-    await client.invalidateQueries({
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const { result } = renderPositions(client);
+    await waitFor(() => expect(sideOf(result)).toBe(true));
+
+    // A fetch that will answer with the pre-write rows, held open across the confirmation.
+    let answer: (rows: unknown[]) => void = () => {};
+    mocks.graphql.mockImplementation(() => Effect.promise(() => new Promise(resolve => (answer = resolve))));
+    void client.refetchQueries({
       queryKey: participantPositionsQueryKey([LOCAL.profile_space_id, REMOTE.profile_space_id]),
     });
+    await waitFor(() =>
+      expect(
+        client.getQueryState(participantPositionsQueryKey([LOCAL.profile_space_id, REMOTE.profile_space_id]))
+          ?.fetchStatus
+      ).toBe('fetching')
+    );
 
-    // The fetched row replaces the overlay without changing the displayed position.
-    await waitFor(() => expect(sideOf(result)).toBe(true));
-    expect(result.current.byClaim.get(CLAIM)).toHaveLength(1);
+    await act(async () => void client.setQueryData(INDEXING_KEY, snapshot('indexed', 'negative')));
+    await act(async () => void client.setQueryData(INDEXING_KEY, { status: 'idle', pending: null, runId: null }));
+    expect(sideOf(result)).toBe(false);
+
+    await act(async () => {
+      answer([{ userId: LOCAL.profile_space_id, objectId: CLAIM, spaceId: SPACE, voteType: 0, voteKind: 1 }]);
+      await Promise.resolve();
+    });
+
+    expect(sideOf(result)).toBe(false);
   });
 
   // Keep a removal tombstone until the fetched data reflects the removal.
@@ -319,6 +373,26 @@ describe('useParticipantPositions holding a settled write (GEO-2807)', () => {
     expect(sideOf(result)).toBe(true);
 
     await act(async () => rerender({ profileSpaceId: null }));
+    expect(sideOf(result)).toBe(null);
+  });
+
+  /**
+   * An `entity-response-indexing` query has no observers, so react-query garbage collects it on its
+   * own schedule — five minutes after the write started, whatever state it is in. That arrives as a
+   * `removed` event, and a hook watching only `updated` kept the row overlaid for the rest of the
+   * session: a write that never indexed, still drawn as a position and still gated on.
+   */
+  it('drops a position whose snapshot is garbage collected', async () => {
+    mocks.attention = true;
+    mocks.graphql.mockImplementation(() => Effect.succeed([]));
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const { result } = renderPositions(client);
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    await act(async () => void client.setQueryData(INDEXING_KEY, snapshot('reconciling', 'positive')));
+    expect(sideOf(result)).toBe(true);
+
+    await act(async () => client.removeQueries({ queryKey: INDEXING_KEY }));
     expect(sideOf(result)).toBe(null);
   });
 

--- a/apps/web/core/debates/participant-positions.ts
+++ b/apps/web/core/debates/participant-positions.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import type { TypedDocumentNode } from '@graphql-typed-document-node/core';
-import { keepPreviousData, useQuery, useQueryClient } from '@tanstack/react-query';
+import { hashKey, keepPreviousData, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import * as React from 'react';
 
@@ -197,8 +197,23 @@ function sameId(left: string, right: string) {
  */
 export type PendingParticipantPosition = Omit<ParticipantPosition, 'position'> & { position: boolean | null };
 
-/** A confirmed position retained until participant positions are refetched. */
+/** A confirmed position retained until this query's own fetch accounts for it. */
 type SettlingPosition = { row: PendingParticipantPosition; retiredAt: number };
+
+/**
+ * How long a confirmed row is held while the fetched list still disagrees.
+ *
+ * Longer than a poll interval, so the ordinary case is decided by agreement rather than by this;
+ * short enough that a row whose write silently vanished stops being asserted. Only reachable when
+ * the graph confirmed the write and then kept answering without it.
+ */
+const SETTLING_MAX_HOLD_MS = 30_000;
+
+/** Whether the fetched list already says what a retained row says, so the row has nothing left to do. */
+function fetchedAgrees(fetched: ParticipantPosition[], row: PendingParticipantPosition) {
+  const match = fetched.find(candidate => positionKey(candidate) === positionKey(row));
+  return row.position === null ? match === undefined : match?.position === row.position;
+}
 
 /**
  * The viewer's own in-flight responses, as positions (GEO-2784).
@@ -211,29 +226,44 @@ type SettlingPosition = { row: PendingParticipantPosition; retiredAt: number };
  * Subscribed rather than read once: the pending set changes as writes start and settle, and none
  * of those transitions re-render this hook on their own.
  *
- * Confirmed positions remain overlaid after their indexing snapshots are retired. The overlay is
- * released when the participant positions query receives newer data. Responses that return to
- * idle without reaching `indexed` are treated as rollbacks and are not retained.
+ * ## Why a row outlives the snapshot it came from (GEO-2807)
+ *
+ * A confirmed row stays overlaid after its snapshot is retired, because retirement happens when the
+ * *write* is confirmed and this query is only invalidated at that moment — an invalidation is a
+ * fetch starting, not a fetch landing. Dropping the overlay there leaves a gap where the position is
+ * in neither place, which is the flicker; on a removal the stale row reappears instead.
+ *
+ * A retained row is released when this query's own data agrees with it — not merely when newer data
+ * arrives. `dataUpdatedAt` is when a response *landed*, so a poll already in flight when the write
+ * confirmed would otherwise release the overlay onto rows fetched before it, which is the flicker
+ * again. Nor can a disagreeing fetch be read as "the write did not survive": the invalidation that
+ * follows `indexed` often issues its fetch *after* the retirement, and `userVotes` can trail the
+ * read that confirmed the write. So disagreement means "not yet", bounded by {@link SETTLING_MAX_HOLD_MS}
+ * so a row cannot outlive its usefulness if the two never agree.
+ *
+ * A response that returns to idle without ever reaching `indexed` was rolled back by a failed
+ * publish, and is dropped rather than retained.
  */
 function useOwnPendingPositions(
   localProfileSpaceId: string | null | undefined,
-  /** Timestamp of the latest participant positions result. */
-  dataUpdatedAt: number
+  /** This hook's own query, watched for the fetches that release a retained row. */
+  queryKey: readonly unknown[]
 ): PendingParticipantPosition[] {
   const queryClient = useQueryClient();
   const [pending, setPending] = React.useState<PendingParticipantPosition[]>([]);
   const [settling, setSettling] = React.useState<SettlingPosition[]>([]);
   // Track the previous cache state to identify confirmed snapshots that were retired.
   const lastRead = React.useRef(new Map<string, { row: PendingParticipantPosition; indexed: boolean }>());
+  const lastViewer = React.useRef(localProfileSpaceId);
+  const queryHash = hashKey(queryKey);
 
   React.useEffect(() => {
-    if (!localProfileSpaceId) {
-      // Retained rows carry the previous viewer's profile space, so they have to go with them:
-      // signing out or switching accounts would otherwise keep overlaying somebody else's side.
+    // A different viewer — or none — inherits nothing. Without this, signing out retires the
+    // outgoing viewer's rows into the retained set and keeps overlaying them.
+    if (lastViewer.current !== localProfileSpaceId) {
+      lastViewer.current = localProfileSpaceId;
       lastRead.current = new Map();
-      setPending(current => (current.length === 0 ? current : []));
       setSettling(current => (current.length === 0 ? current : []));
-      return;
     }
     const cache = queryClient.getQueryCache();
 
@@ -242,9 +272,11 @@ function useOwnPendingPositions(
       const seen = new Map<string, { row: PendingParticipantPosition; indexed: boolean }>();
       for (const query of cache.getAll()) {
         const parsed = pendingClaimResponse(query.queryKey, query.state.data);
-        if (!parsed) continue;
+        // Attributed to whoever made the write, and kept only while that is this viewer. Stamping
+        // the current viewer onto every row instead would hand one account's response to the next.
+        if (!parsed || !localProfileSpaceId || !sameId(parsed.personalSpaceId, localProfileSpaceId)) continue;
         const row: PendingParticipantPosition = {
-          profileSpaceId: localProfileSpaceId,
+          profileSpaceId: parsed.personalSpaceId,
           claimId: parsed.entityId,
           spaceId: parsed.spaceId,
           responseKind: parsed.responseKind,
@@ -273,19 +305,26 @@ function useOwnPendingPositions(
 
     read();
     return cache.subscribe(event => {
-      if (event.type !== 'updated') return;
-      if (event.query.queryKey[0] !== 'entity-response-indexing') return;
-      read();
-    });
-  }, [localProfileSpaceId, queryClient]);
+      // Every event, not only `updated`. An `entity-response-indexing` query has no observers, so
+      // it is garbage collected on its own schedule — and a `removed` this hook ignored left the
+      // row overlaid for the rest of the session, outside the retention rule entirely.
+      if (event.query.queryKey[0] === 'entity-response-indexing') {
+        read();
+        return;
+      }
 
-  // Release retained rows after a newer participant positions result arrives.
-  React.useEffect(() => {
-    setSettling(current => {
-      const held = current.filter(entry => entry.retiredAt >= dataUpdatedAt);
-      return held.length === current.length ? current : held;
+      if (event.query.queryHash !== queryHash) return;
+      if (event.type !== 'updated' || event.action.type !== 'success') return;
+      const fetched = (event.query.state.data ?? []) as ParticipantPosition[];
+      const now = Date.now();
+      setSettling(current => {
+        const held = current.filter(
+          entry => !fetchedAgrees(fetched, entry.row) && now - entry.retiredAt < SETTLING_MAX_HOLD_MS
+        );
+        return held.length === current.length ? current : held;
+      });
     });
-  }, [dataUpdatedAt]);
+  }, [localProfileSpaceId, queryClient, queryHash]);
 
   // Apply active responses after retained responses so newer input takes precedence.
   return React.useMemo(
@@ -308,9 +347,16 @@ function samePositions(a: PendingParticipantPosition[], b: PendingParticipantPos
   });
 }
 
-/** Key a position by who took it, on what, in which kind — the identity the graph enforces. */
-function positionKey(row: Pick<ParticipantPosition, 'profileSpaceId' | 'claimId' | 'responseKind'>) {
-  return `${row.profileSpaceId.replace(/-/g, '').toLowerCase()}|${row.claimId.replace(/-/g, '').toLowerCase()}|${row.responseKind}`;
+/**
+ * Key a position by who took it, on what, where, in which kind — the identity the graph enforces.
+ *
+ * `spaceId` is part of it because a response is space-scoped and `participantSidesOn` reads it that
+ * way: without it an overlay for a claim in one space evicts the fetched row for the same claim in
+ * another, and that side then reads as no position at all.
+ */
+function positionKey(row: Pick<ParticipantPosition, 'profileSpaceId' | 'claimId' | 'spaceId' | 'responseKind'>) {
+  const bare = (id: string) => id.replace(/-/g, '').toLowerCase();
+  return `${bare(row.profileSpaceId)}|${bare(row.claimId)}|${bare(row.spaceId)}|${row.responseKind}`;
 }
 
 /**
@@ -391,7 +437,10 @@ export function useParticipantPositions(
     placeholderData: keepPreviousData,
   });
 
-  const ownPending = useOwnPendingPositions(localProfileSpaceId, query.dataUpdatedAt);
+  // The key, not `query.dataUpdatedAt`: reading that timestamp makes it a tracked property, and it
+  // changes on every poll — so the whole page re-rendered every 20s for a refetch that returned the
+  // same rows.
+  const ownPending = useOwnPendingPositions(localProfileSpaceId, queryKey);
   const byClaim = React.useMemo(
     () => groupParticipantPositions(applyPendingPositions(query.data ?? [], ownPending)),
     [query.data, ownPending]

--- a/apps/web/core/debates/participant-positions.ts
+++ b/apps/web/core/debates/participant-positions.ts
@@ -188,8 +188,17 @@ function sameId(left: string, right: string) {
   return left.replace(/-/g, '').toLowerCase() === right.replace(/-/g, '').toLowerCase();
 }
 
+/**
+ * A position the viewer's own client knows about before the graph does.
+ *
+ * `position: null` is a removal, which the merge resolves by deleting the fetched row rather than
+ * adding one — so this cannot be a `ParticipantPosition`, whose `position` is the side someone
+ * holds.
+ */
+export type PendingParticipantPosition = Omit<ParticipantPosition, 'position'> & { position: boolean | null };
+
 /** A confirmed position retained until participant positions are refetched. */
-type SettlingPosition = { row: ParticipantPosition; retiredAt: number };
+type SettlingPosition = { row: PendingParticipantPosition; retiredAt: number };
 
 /**
  * The viewer's own in-flight responses, as positions (GEO-2784).
@@ -210,28 +219,31 @@ function useOwnPendingPositions(
   localProfileSpaceId: string | null | undefined,
   /** Timestamp of the latest participant positions result. */
   dataUpdatedAt: number
-): ParticipantPosition[] {
+): PendingParticipantPosition[] {
   const queryClient = useQueryClient();
-  const [pending, setPending] = React.useState<ParticipantPosition[]>([]);
+  const [pending, setPending] = React.useState<PendingParticipantPosition[]>([]);
   const [settling, setSettling] = React.useState<SettlingPosition[]>([]);
   // Track the previous cache state to identify confirmed snapshots that were retired.
-  const lastRead = React.useRef(new Map<string, { row: ParticipantPosition; indexed: boolean }>());
+  const lastRead = React.useRef(new Map<string, { row: PendingParticipantPosition; indexed: boolean }>());
 
   React.useEffect(() => {
     if (!localProfileSpaceId) {
+      // Retained rows carry the previous viewer's profile space, so they have to go with them:
+      // signing out or switching accounts would otherwise keep overlaying somebody else's side.
       lastRead.current = new Map();
       setPending(current => (current.length === 0 ? current : []));
+      setSettling(current => (current.length === 0 ? current : []));
       return;
     }
     const cache = queryClient.getQueryCache();
 
     const read = () => {
-      const rows: ParticipantPosition[] = [];
-      const seen = new Map<string, { row: ParticipantPosition; indexed: boolean }>();
+      const rows: PendingParticipantPosition[] = [];
+      const seen = new Map<string, { row: PendingParticipantPosition; indexed: boolean }>();
       for (const query of cache.getAll()) {
         const parsed = pendingClaimResponse(query.queryKey, query.state.data);
         if (!parsed) continue;
-        const row = {
+        const row: PendingParticipantPosition = {
           profileSpaceId: localProfileSpaceId,
           claimId: parsed.entityId,
           spaceId: parsed.spaceId,
@@ -239,7 +251,7 @@ function useOwnPendingPositions(
           // `null` means the viewer is *removing* the position. Carried through as a tombstone and
           // resolved in the merge below, because dropping it here would let the stale fetched row
           // keep the position visible until the next refetch.
-          position: parsed.position as boolean,
+          position: parsed.position,
         };
         rows.push(row);
         seen.set(positionKey(row), { row, indexed: parsed.status === 'indexed' });
@@ -282,7 +294,7 @@ function useOwnPendingPositions(
   );
 }
 
-function samePositions(a: ParticipantPosition[], b: ParticipantPosition[]) {
+function samePositions(a: PendingParticipantPosition[], b: PendingParticipantPosition[]) {
   if (a.length !== b.length) return false;
   return a.every((row, i) => {
     const other = b[i];
@@ -311,13 +323,14 @@ function positionKey(row: Pick<ParticipantPosition, 'profileSpaceId' | 'claimId'
  */
 export function applyPendingPositions(
   fetched: ParticipantPosition[],
-  pending: ParticipantPosition[]
+  pending: PendingParticipantPosition[]
 ): ParticipantPosition[] {
   if (pending.length === 0) return fetched;
   const merged = new Map(fetched.map(row => [positionKey(row), row]));
   for (const row of pending) {
-    if (row.position === null) merged.delete(positionKey(row));
-    else merged.set(positionKey(row), row);
+    const { position } = row;
+    if (position === null) merged.delete(positionKey(row));
+    else merged.set(positionKey(row), { ...row, position });
   }
   return [...merged.values()];
 }

--- a/apps/web/core/debates/participant-positions.ts
+++ b/apps/web/core/debates/participant-positions.ts
@@ -188,6 +188,9 @@ function sameId(left: string, right: string) {
   return left.replace(/-/g, '').toLowerCase() === right.replace(/-/g, '').toLowerCase();
 }
 
+/** A confirmed position retained until participant positions are refetched. */
+type SettlingPosition = { row: ParticipantPosition; retiredAt: number };
+
 /**
  * The viewer's own in-flight responses, as positions (GEO-2784).
  *
@@ -198,13 +201,25 @@ function sameId(left: string, right: string) {
  *
  * Subscribed rather than read once: the pending set changes as writes start and settle, and none
  * of those transitions re-render this hook on their own.
+ *
+ * Confirmed positions remain overlaid after their indexing snapshots are retired. The overlay is
+ * released when the participant positions query receives newer data. Responses that return to
+ * idle without reaching `indexed` are treated as rollbacks and are not retained.
  */
-function useOwnPendingPositions(localProfileSpaceId: string | null | undefined): ParticipantPosition[] {
+function useOwnPendingPositions(
+  localProfileSpaceId: string | null | undefined,
+  /** Timestamp of the latest participant positions result. */
+  dataUpdatedAt: number
+): ParticipantPosition[] {
   const queryClient = useQueryClient();
   const [pending, setPending] = React.useState<ParticipantPosition[]>([]);
+  const [settling, setSettling] = React.useState<SettlingPosition[]>([]);
+  // Track the previous cache state to identify confirmed snapshots that were retired.
+  const lastRead = React.useRef(new Map<string, { row: ParticipantPosition; indexed: boolean }>());
 
   React.useEffect(() => {
     if (!localProfileSpaceId) {
+      lastRead.current = new Map();
       setPending(current => (current.length === 0 ? current : []));
       return;
     }
@@ -212,10 +227,11 @@ function useOwnPendingPositions(localProfileSpaceId: string | null | undefined):
 
     const read = () => {
       const rows: ParticipantPosition[] = [];
+      const seen = new Map<string, { row: ParticipantPosition; indexed: boolean }>();
       for (const query of cache.getAll()) {
         const parsed = pendingClaimResponse(query.queryKey, query.state.data);
         if (!parsed) continue;
-        rows.push({
+        const row = {
           profileSpaceId: localProfileSpaceId,
           claimId: parsed.entityId,
           spaceId: parsed.spaceId,
@@ -224,7 +240,20 @@ function useOwnPendingPositions(localProfileSpaceId: string | null | undefined):
           // resolved in the merge below, because dropping it here would let the stale fetched row
           // keep the position visible until the next refetch.
           position: parsed.position as boolean,
-        });
+        };
+        rows.push(row);
+        seen.set(positionKey(row), { row, indexed: parsed.status === 'indexed' });
+      }
+
+      const retiredAt = Date.now();
+      const retired = [...lastRead.current]
+        .filter(([key, previous]) => !seen.has(key) && previous.indexed)
+        .map(([, previous]) => ({ row: previous.row, retiredAt }));
+      lastRead.current = seen;
+
+      if (retired.length > 0) {
+        const held = new Set(retired.map(entry => positionKey(entry.row)));
+        setSettling(current => [...current.filter(entry => !held.has(positionKey(entry.row))), ...retired]);
       }
       // Referential stability matters: this feeds a `useMemo` that regroups every position.
       setPending(current => (samePositions(current, rows) ? current : rows));
@@ -238,7 +267,19 @@ function useOwnPendingPositions(localProfileSpaceId: string | null | undefined):
     });
   }, [localProfileSpaceId, queryClient]);
 
-  return pending;
+  // Release retained rows after a newer participant positions result arrives.
+  React.useEffect(() => {
+    setSettling(current => {
+      const held = current.filter(entry => entry.retiredAt >= dataUpdatedAt);
+      return held.length === current.length ? current : held;
+    });
+  }, [dataUpdatedAt]);
+
+  // Apply active responses after retained responses so newer input takes precedence.
+  return React.useMemo(
+    () => (settling.length === 0 ? pending : [...settling.map(entry => entry.row), ...pending]),
+    [pending, settling]
+  );
 }
 
 function samePositions(a: ParticipantPosition[], b: ParticipantPosition[]) {
@@ -337,7 +378,7 @@ export function useParticipantPositions(
     placeholderData: keepPreviousData,
   });
 
-  const ownPending = useOwnPendingPositions(localProfileSpaceId);
+  const ownPending = useOwnPendingPositions(localProfileSpaceId, query.dataUpdatedAt);
   const byClaim = React.useMemo(
     () => groupParticipantPositions(applyPendingPositions(query.data ?? [], ownPending)),
     [query.data, ownPending]

--- a/apps/web/core/debates/request-gate.ts
+++ b/apps/web/core/debates/request-gate.ts
@@ -1,40 +1,12 @@
 /**
- * May this viewer request a debate on this claim, right now?
+ * Determines whether a debate request can be created for a claim.
  *
- * Written to be the one answer for both surfaces that ask it — the "debate again" picker and the
- * debates hub side panel — which used to decide separately and disagree: the hub never waited and
- * never explained, the picker waited on the wrong thing and explained that (GEO-2808).
+ * The rematch endpoint validates graph-resolved positions, so the picker compares the viewer's
+ * local position with the position reported by geo-chat before enabling a request. Comparing the
+ * values also prevents requests while a side change is still being reconciled.
  *
- * Only the picker reads it today. The hub is deliberately left alone here: it was working, and
- * changing a working surface belongs in its own change where someone can look at it. That is also
- * why the opponent half is a parameter rather than something this module decides — see
- * `opponentReady`.
- *
- * ## The wait is on geo-chat, so the gate is measured against geo-chat
- *
- * geo-chat validates a request against *its own* copy of the viewer's position and rejects an early
- * one with `claim_response_required`. That is the only thing the wait protects against, so it is
- * the only clock worth watching.
- *
- * The picker was watching the other one. Its `serverLocalPosition` came from `participantSidesOn`,
- * which reads the knowledge graph — so it waited on the indexer (`web.write.entity_response` p50
- * 9.9s, p95 48.6s) to clear a check geo-chat had already passed. Since #2348 geo-chat learns the
- * position the moment the write starts, so gating on geo-chat collapses the wait to about one round
- * trip while the graph catches up in its own time.
- *
- * Both surfaces already hold geo-chat's copy: the hub as `DebateClaim.viewer_response`, the picker
- * as the `participants` on the raw rematch row — which it fetched and then overwrote with
- * graph-derived sides before asking.
- *
- * ## Comparing two sources rather than one against itself
- *
- * `chatPosition` and `localPosition` must come from different places for this to mean anything. The
- * picker's old `serverLocalPosition === localPosition` did not: `localPosition` falls back to
- * `serverLocalPosition` whenever there is no optimistic answer, so the comparison went trivially
- * true and opened a button geo-chat would still reject — pressable, and nothing happens.
- *
- * Comparing rather than null-checking also covers switching sides, where geo-chat still holds the
- * side just moved off. That is equally invalid to act on, and a null check would miss it.
+ * The debates hub does not use this gate. Its match data and request validation both use
+ * `debate_claim_readiness`, so an additional graph-backed position check would delay valid requests.
  */
 export type DebateRequestGateInput = {
   /**
@@ -48,12 +20,7 @@ export type DebateRequestGateInput = {
   /** The side the viewer believes they hold, optimistic where the surface has one. */
   localPosition: boolean | null;
   /**
-   * The surface's own opponent question, deliberately not shared.
-   *
-   * The picker asks whether *this* opponent holds the other side (`opposing`). The hub asks
-   * whether *anyone* is standing ready (`match`). A rematch has one possible opponent and the hub
-   * has many, so these are different questions with the same shape — the position half is shared,
-   * the opponent half stays with whoever can answer it.
+   * Whether the relevant opponent condition for the current surface is satisfied.
    */
   opponentReady: boolean;
   /**
@@ -98,4 +65,3 @@ export function debateRequestGate({
     pendingLabel: pending ? (indexingDelayed ? REQUEST_PENDING_DELAYED_LABEL : REQUEST_PENDING_LABEL) : null,
   };
 }
-

--- a/apps/web/core/debates/request-gate.ts
+++ b/apps/web/core/debates/request-gate.ts
@@ -1,20 +1,29 @@
 /**
  * Determines whether a debate request can be created for a claim.
  *
- * The rematch endpoint validates graph-resolved positions, so the picker compares the viewer's
- * local position with the position reported by geo-chat before enabling a request. Comparing the
- * values also prevents requests while a side change is still being reconciled.
+ * `create_rematch_request` resolves both participants' positions from the knowledge graph and
+ * refuses with `claim_response_required` until the write is indexed. So the picker holds the
+ * request until the position it will be validated against is the one the viewer holds — a wait of
+ * `web.write.entity_response`, p50 9.9s / p95 48.6s, which no client change shortens.
  *
- * The debates hub does not use this gate. Its match data and request validation both use
- * `debate_claim_readiness`, so an additional graph-backed position check would delay valid requests.
+ * Compare the two sources rather than null-checking one: `localPosition` falls back to
+ * `chatPosition`, so `chatPosition === localPosition` written against a single source goes trivially
+ * true and opens a button the server still refuses — pressable, and nothing happens. Comparing also
+ * covers switching sides, where the server still holds the side just moved off.
+ *
+ * The debates hub does not use this gate, deliberately. Its match data and `create_debate_request_as`
+ * both read `debate_claim_readiness`, which the in-flight response notification writes, so a
+ * graph-backed position check there would hold a button the server would have accepted.
  */
 export type DebateRequestGateInput = {
   /**
-   * geo-chat's own copy of the viewer's position on this claim.
+   * The position the request will be validated against, as the surface last heard it.
    *
-   * `undefined` when geo-chat has not answered for this claim yet, which is not the same as `null`
-   * — "no position" is an answer, "no row" is not. Both block the request; only the distinction
-   * keeps a missing row from reading as a deliberate absence.
+   * Named for where the picker reads it — geo-chat's rematch rows — though geo-chat derives those
+   * from the graph, so this trails the chain rather than the server's own record. `undefined` is "no
+   * row", and a `null` can also be a hydration timeout on that endpoint rather than a deliberate
+   * absence. All of which block the request, which is the point: none of them is the viewer's
+   * position confirmed.
    */
   chatPosition: boolean | null | undefined;
   /** The side the viewer believes they hold, optimistic where the surface has one. */


### PR DESCRIPTION
Positions are read from three sources that move at different speeds — the local write, geo-chat, and the knowledge graph — and each reported symptom was a place where one was trusted while another had not caught up.

## Main behaviour changes

- Prevents position/avatar flicker while an indexed response refetches. A confirmed update or removal stays displayed until the fetched data **agrees** with it, rather than until any newer data arrives — a poll already in flight when the write confirmed carries rows from before it. Bounded, so a row whose write silently vanished stops being asserted.
- Correctly removes or moves the viewer's avatar when stale participant lists still show the old position, and counts the move on both sides so the stack stops under-reporting who is there.
- Leaves the lists alone where geo-chat has given no answer at all, which is not the same as an answer of "no position". The rematch picker draws graph-derived sides for claims geo-chat has no row for, and correcting those took the viewer off the side they hold.
- Shows a rejected rematch request on the claim card it was sent from, with the page keeping a fallback for when that card is no longer drawn — a tab swap, a search, a filter.
- Distinguishes confirmed indexed writes from failed/rolled-back writes, so a failed optimistic update disappears immediately.

## Also, from the review of this branch

- The picker no longer re-renders on every 20s poll that returned the same rows (reading `dataUpdatedAt` had made it a tracked property).
- A garbage-collected indexing snapshot now retires its row. These queries have no observers, so they are collected five minutes in whatever state they are in, and a write that never indexed stayed overlaid for the session.
- The overlay merge key is space-scoped, so a row for a claim in one space no longer evicts the same claim in another.
- Overlay rows are attributed to the write's own `personalSpaceId` and kept only while that is the current viewer.

## Not fixed here

**GEO-2807's 20–30 second "Publishing your position…" wait is not addressed by this PR, and cannot be from this repo.** `create_rematch_request` resolves both participants' positions from the knowledge graph and refuses with `claim_response_required` until the write is indexed, so the picker's wait is honest. The debates hub is fast because `create_debate_request_as` reads `debate_claim_readiness`, which the in-flight response notification writes. Making the rematch path read readiness the way the hub's does is the fix, and it belongs in geo-chat.

Related and also geo-chat's: a removal (`position: None`) does not clear the readiness row, so for roughly 30s to several minutes a viewer stays discoverable — and requestable — on a position they removed.

Two code comments were corrected against geo-chat's source while verifying the above: a match does not guarantee the request is accepted (the match query omits `create_debate_request_as`'s validation predicates and its attempted-recipient exclusion), and `chatPosition` is geo-chat's rematch row, which geo-chat derives from the graph — so it trails the chain rather than being the server's own record.
