### PR TITLE
feat(debates): gate every Request debate control on geo-chat's position

### DIFF
--- a/apps/web/core/claims/browse/claim-end-slot.tsx
+++ b/apps/web/core/claims/browse/claim-end-slot.tsx
@@ -12,6 +12,7 @@ import Link from 'next/link';
 import type { Debate } from '~/core/debates/api';
 import { debatePath } from '~/core/debates/debate-routes';
 
+import { debateRequestGate } from '~/core/debates/request-gate';
 import { useClaimMatchup } from './use-claim-matchup';
 
 /**
@@ -43,10 +44,28 @@ export function ClaimEndSlot({
   activeDebate,
   enabled = true,
   variant = 'inline',
+  position,
   className,
 }: {
   claimId: string;
   spaceId: string;
+  /**
+   * The viewer's position on this claim, from both clocks, so the offer only appears once geo-chat
+   * will honour it (GEO-2808).
+   *
+   * geo-chat validates a request against its *own* copy of the position and rejects an early one
+   * with `claim_response_required`. Every host of this slot already runs `useClaimPositionControl`,
+   * which holds both readings — so this is required rather than optional: a host that could not
+   * answer would be offering a debate it has no way to know is valid, which is what the hub and the
+   * feed cards were doing.
+   */
+  position: {
+    /** geo-chat's copy, from the readiness row. `undefined` when it has no row for this claim. */
+    chat: boolean | null | undefined;
+    /** What the viewer believes they hold — optimistic while a response is in flight. */
+    local: boolean | null;
+    indexingDelayed?: boolean;
+  };
   /**
    * The live debate on this claim.
    *
@@ -87,6 +106,16 @@ export function ClaimEndSlot({
     enabled,
   });
 
+  // `match` is this surface's opponent half — somebody standing ready on the other side. The
+  // position half is the shared rule, so every surface waits on the same fact and names it the
+  // same way.
+  const gate = debateRequestGate({
+    chatPosition: position.chat,
+    localPosition: position.local,
+    opponentReady: match !== null,
+    indexingDelayed: position.indexingDelayed,
+  });
+
   // Sized to the row it sits in rather than to itself.
   //
   // It was the explore page's "Rank" CTA — 16px in a 28px pill — which is right for a standalone
@@ -118,7 +147,7 @@ export function ClaimEndSlot({
         <button
           type="button"
           onClick={request}
-          disabled={Boolean(blockedReason) || isRequesting}
+          disabled={Boolean(blockedReason) || isRequesting || !gate.canRequest}
           // Shown rather than left to a `title`: native tooltips never appear on touch and are
           // unreliable on a disabled button, which is exactly when the explanation matters.
           title={blockedReason}
@@ -134,19 +163,35 @@ export function ClaimEndSlot({
           {/* Both labels stacked in one grid cell, so the button is always as wide as the longer of
               them. "Requesting…" is the shorter, and a button that shrinks the moment you press it
               reads as something having gone wrong. The grid is on this span rather than the button
-              so it cannot fight the button's own `inline-flex`. */}
-          <span className="grid place-items-center">
-            <span className="invisible col-start-1 row-start-1" aria-hidden>
-              Request debate
+              so it cannot fight the button's own `inline-flex`.
+              
+              Only while the offer is pressable. The pending label is longer than "Request debate",
+              so sizing against it would hold every idle button that much wider — and this slot sits
+              in a meta row built not to grow. A press cannot happen while pending, which is the
+              only transition the sizer exists to smooth. */}
+          {gate.pending ? (
+            <span>{gate.pendingLabel}</span>
+          ) : (
+            <span className="grid place-items-center">
+              <span className="invisible col-start-1 row-start-1" aria-hidden>
+                Request debate
+              </span>
+              <span className="col-start-1 row-start-1">{isRequesting ? 'Requesting…' : 'Request debate'}</span>
             </span>
-            <span className="col-start-1 row-start-1">{isRequesting ? 'Requesting…' : 'Request debate'}</span>
-          </span>
+          )}
         </button>
         {/* A blocked reason is a standing condition the reader can see for themselves, so it is
             ordinary text. A failed request is an event that happens after they press, with nothing
             on screen to mark it — `role="alert"` is what makes it reach anyone not watching this
             corner. The Matches tab's old button announced it; losing that when the button moved
             would have been a silent regression. */}
+        {/* A disabled control nobody is focused on announces nothing, so the wait is a `status` as
+            well as a label. */}
+        {gate.pending && !isRequesting ? (
+          <span role="status" aria-live="polite" className="sr-only">
+            {gate.pendingLabel}
+          </span>
+        ) : null}
         {blockedReason ? (
           <span className={cx('text-footnote text-grey-04', variant === 'block' ? 'text-left' : 'text-right')}>
             {blockedReason}

--- a/apps/web/core/claims/browse/claim-end-slot.tsx
+++ b/apps/web/core/claims/browse/claim-end-slot.tsx
@@ -12,7 +12,7 @@ import Link from 'next/link';
 import type { Debate } from '~/core/debates/api';
 import { debatePath } from '~/core/debates/debate-routes';
 
-import { debateRequestGate } from '~/core/debates/request-gate';
+import { type DebateRequestPosition, debateRequestGate } from '~/core/debates/request-gate';
 import { useClaimMatchup } from './use-claim-matchup';
 
 /**
@@ -59,13 +59,7 @@ export function ClaimEndSlot({
    * answer would be offering a debate it has no way to know is valid, which is what the hub and the
    * feed cards were doing.
    */
-  position: {
-    /** geo-chat's copy, from the readiness row. `undefined` when it has no row for this claim. */
-    chat: boolean | null | undefined;
-    /** What the viewer believes they hold — optimistic while a response is in flight. */
-    local: boolean | null;
-    indexingDelayed?: boolean;
-  };
+  position: DebateRequestPosition;
   /**
    * The live debate on this claim.
    *

--- a/apps/web/core/claims/browse/claim-page-view.test.tsx
+++ b/apps/web/core/claims/browse/claim-page-view.test.tsx
@@ -80,6 +80,8 @@ vi.mock('~/core/debates/matchmaking/matchmaking-claim-card', () => ({
     viewerPosition: null,
     respond: () => {},
     canRespond: false,
+    // Mirrors the hook: the request offer reads this to tell a late index from a publish in flight.
+    responseIndexing: { status: 'idle', pending: null, runId: null },
     actionTitle: () => undefined,
     responseError: null,
   }),

--- a/apps/web/core/claims/browse/claim-page-view.test.tsx
+++ b/apps/web/core/claims/browse/claim-page-view.test.tsx
@@ -80,8 +80,8 @@ vi.mock('~/core/debates/matchmaking/matchmaking-claim-card', () => ({
     viewerPosition: null,
     respond: () => {},
     canRespond: false,
-    // Mirrors the hook: the request offer reads this to tell a late index from a publish in flight.
-    responseIndexing: { status: 'idle', pending: null, runId: null },
+    // Mirrors the hook: the request offer reads this to decide whether to make itself.
+    requestPosition: { chat: null, local: null, indexingDelayed: false },
     actionTitle: () => undefined,
     responseError: null,
   }),

--- a/apps/web/core/claims/browse/claim-page-view.tsx
+++ b/apps/web/core/claims/browse/claim-page-view.tsx
@@ -238,11 +238,7 @@ function ClaimPositionSection({
         className="mt-2"
         // The offer sits directly under the pills that set the position it depends on, so it has to
         // wait for the same fact those pills are publishing (GEO-2808).
-        position={{
-          chat: readiness.viewer_response?.position ?? null,
-          local: control.viewerPosition,
-          indexingDelayed: control.responseIndexing.status === 'delayed',
-        }}
+        position={control.requestPosition}
       />
     </section>
   );

--- a/apps/web/core/claims/browse/claim-page-view.tsx
+++ b/apps/web/core/claims/browse/claim-page-view.tsx
@@ -236,6 +236,13 @@ function ClaimPositionSection({
         activeDebate={row?.active_debate}
         variant="block"
         className="mt-2"
+        // The offer sits directly under the pills that set the position it depends on, so it has to
+        // wait for the same fact those pills are publishing (GEO-2808).
+        position={{
+          chat: readiness.viewer_response?.position ?? null,
+          local: control.viewerPosition,
+          indexingDelayed: control.responseIndexing.status === 'delayed',
+        }}
       />
     </section>
   );

--- a/apps/web/core/debates/browse/debate-claims-panel.test.tsx
+++ b/apps/web/core/debates/browse/debate-claims-panel.test.tsx
@@ -93,6 +93,8 @@ vi.mock('~/core/debates/matchmaking/matchmaking-claim-card', () => ({
       actionTitle: () => (answersReady ? '' : 'Loading this claim’s responses…'),
       responseError: null,
       canRespond: answersReady,
+    // Mirrors the hook: the request offer reads this to tell a late index from a publish in flight.
+    responseIndexing: { status: 'idle', pending: null, runId: null },
     };
   },
 }));

--- a/apps/web/core/debates/browse/debate-claims-panel.test.tsx
+++ b/apps/web/core/debates/browse/debate-claims-panel.test.tsx
@@ -93,8 +93,8 @@ vi.mock('~/core/debates/matchmaking/matchmaking-claim-card', () => ({
       actionTitle: () => (answersReady ? '' : 'Loading this claim’s responses…'),
       responseError: null,
       canRespond: answersReady,
-    // Mirrors the hook: the request offer reads this to tell a late index from a publish in flight.
-    responseIndexing: { status: 'idle', pending: null, runId: null },
+    // Mirrors the hook: the request offer reads this to decide whether to make itself.
+    requestPosition: { chat: null, local: null, indexingDelayed: false },
     };
   },
 }));

--- a/apps/web/core/debates/matchmaking/matchmaking-claim-card.test.tsx
+++ b/apps/web/core/debates/matchmaking/matchmaking-claim-card.test.tsx
@@ -254,6 +254,52 @@ describe('position avatar stack', () => {
     expect(within(disagree).queryByText(/^\+/)).toBeNull();
   });
 
+  /**
+   * GEO-2808. The offer used to appear the instant a match existed, with no regard for whether
+   * geo-chat held the viewer's position — so the request was pressable and geo-chat rejected it
+   * with `claim_response_required`. It now waits on the same fact the picker waits on and wears the
+   * same label.
+   */
+  describe('the request waits for geo-chat to hold the viewer position', () => {
+    const twoSides = () =>
+      withCounts([
+        { total_count: 1, available_now_count: 1, present_count: 1, participants: [participant('a')] },
+        { total_count: 1, available_now_count: 1, present_count: 1, participants: [participant('b')] },
+      ]);
+
+    it('names the wait while geo-chat has not caught up', () => {
+      mocks.match = { id: 'match-1' };
+      // An answer still reconciling is what the card draws its optimistic side from.
+      mocks.indexing = { status: 'reconciling', pending: { expectedResponse: 'positive' }, runId: 'run-1' };
+      renderCard(
+        <MatchmakingClaimCard claim={claim} positions={twoSides()} readiness={readiness({ viewer_response: null })} />
+      );
+
+      expect(screen.getByRole('button', { name: 'Publishing your position…' })).toBeDisabled();
+      expect(screen.queryByRole('button', { name: 'Request debate' })).not.toBeInTheDocument();
+    });
+
+    it('offers the debate once geo-chat holds the side on screen', () => {
+      mocks.match = { id: 'match-1' };
+      renderCard(<MatchmakingClaimCard claim={claim} positions={twoSides()} readiness={readiness()} />);
+
+      expect(screen.getByRole('button', { name: 'Request debate' })).toBeEnabled();
+    });
+
+    // A claim nobody has answered is not publishing anything. The hub's opponent half is a match,
+    // which does not require a position the way the picker's `opposing` does, so without this the
+    // card announced a wait nobody had started.
+    it('does not name a wait on a claim the viewer has not answered', () => {
+      mocks.match = { id: 'match-1' };
+      renderCard(
+        <MatchmakingClaimCard claim={claim} positions={twoSides()} readiness={readiness({ viewer_response: null })} />
+      );
+
+      expect(screen.queryByRole('button', { name: 'Publishing your position…' })).not.toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Request debate' })).toBeDisabled();
+    });
+  });
+
   // The regression that caused the revert. Drawing the stack from `available_now_count` looked
   // right until you noticed it is viewer-relative: it excludes the viewer and anyone they have
   // already debated on this claim. So a claim you had actually argued showed an empty stack — to

--- a/apps/web/core/debates/matchmaking/matchmaking-claim-card.tsx
+++ b/apps/web/core/debates/matchmaking/matchmaking-claim-card.tsx
@@ -7,6 +7,7 @@ import { motion } from 'framer-motion';
 import Link from 'next/link';
 
 import { ClaimEndSlot } from '~/core/claims/browse/claim-end-slot';
+import type { DebateRequestPosition } from '~/core/debates/request-gate';
 import { useClaimResponseSummary } from '~/core/claims/browse/claim-response-summary';
 import { ClaimSummary, ControversialTag } from '~/core/claims/browse/claim-summary';
 import { useClaimMatchup, withMatchParticipants } from '~/core/claims/browse/use-claim-matchup';
@@ -464,8 +465,16 @@ export function useClaimPositionControl({
     respond,
     actionTitle,
     responseError,
-    /** Exposed so a request offer can name a late index differently from a publish in flight. */
-    responseIndexing,
+    /**
+     * Both clocks a request offer needs, composed here rather than at each `ClaimEndSlot`. Four
+     * surfaces render that control and every one was spelling this out identically — the same
+     * duplicated derivation that let the card and its own footer disagree (GEO-2808).
+     */
+    requestPosition: {
+      chat: readiness.viewer_response?.position ?? null,
+      local: viewerPosition,
+      indexingDelayed: responseIndexing.status === 'delayed',
+    } satisfies DebateRequestPosition,
     /**
      * False only while the account genuinely cannot publish, never while one is in flight.
      *
@@ -513,7 +522,7 @@ function RespondableControls({
     actionTitle,
     responseError,
     canRespond,
-    responseIndexing,
+    requestPosition,
   } = useClaimPositionControl({
     claim,
     positions,
@@ -560,11 +569,7 @@ function RespondableControls({
               claimId={claim.claim_entity_id}
               spaceId={claim.space_id}
               activeDebate={activeDebate}
-              position={{
-                chat: readiness.viewer_response?.position ?? null,
-                local: viewerPosition,
-                indexingDelayed: responseIndexing.status === 'delayed',
-              }}
+              position={requestPosition}
             />
           )
         }

--- a/apps/web/core/debates/matchmaking/matchmaking-claim-card.tsx
+++ b/apps/web/core/debates/matchmaking/matchmaking-claim-card.tsx
@@ -464,6 +464,8 @@ export function useClaimPositionControl({
     respond,
     actionTitle,
     responseError,
+    /** Exposed so a request offer can name a late index differently from a publish in flight. */
+    responseIndexing,
     /**
      * False only while the account genuinely cannot publish, never while one is in flight.
      *
@@ -504,11 +506,18 @@ function RespondableControls({
   onRequireSignIn?: () => void;
   hideEndSlot?: boolean;
 }) {
-  const { viewerPosition, optimisticPositions, respond, actionTitle, responseError, canRespond } =
-    useClaimPositionControl({
-      claim,
-      positions,
-      readiness,
+  const {
+    viewerPosition,
+    optimisticPositions,
+    respond,
+    actionTitle,
+    responseError,
+    canRespond,
+    responseIndexing,
+  } = useClaimPositionControl({
+    claim,
+    positions,
+    readiness,
       answersReady,
       responseBlockedReason,
       viewerIdentityPending,
@@ -547,7 +556,16 @@ function RespondableControls({
         isControversial={summary.isControversial}
         endSlot={
           hideEndSlot ? null : (
-            <ClaimEndSlot claimId={claim.claim_entity_id} spaceId={claim.space_id} activeDebate={activeDebate} />
+            <ClaimEndSlot
+              claimId={claim.claim_entity_id}
+              spaceId={claim.space_id}
+              activeDebate={activeDebate}
+              position={{
+                chat: readiness.viewer_response?.position ?? null,
+                local: viewerPosition,
+                indexingDelayed: responseIndexing.status === 'delayed',
+              }}
+            />
           )
         }
       />
@@ -735,7 +753,20 @@ function UnresolvableControls({
              footer button that used to offer it is gone. Masking an action the server would accept
              is not the safe direction to be wrong in. */
           hideEndSlot ? null : (
-            <ClaimEndSlot claimId={claim.claim_entity_id} spaceId={claim.space_id} activeDebate={activeDebate} />
+            <ClaimEndSlot
+              claimId={claim.claim_entity_id}
+              spaceId={claim.space_id}
+              activeDebate={activeDebate}
+              // This card draws no response control, so it has no optimistic side of its own and
+              // both readings are geo-chat's. That is not the self-comparison GEO-2808 removed —
+              // there the fallback was the *graph*, a different source from the one that validates
+              // the request. Here it is the validating source agreeing with itself, which is the
+              // honest answer to "does geo-chat hold a position for this viewer".
+              position={{
+                chat: readiness.viewer_response?.position ?? null,
+                local: readiness.viewer_response?.position ?? null,
+              }}
+            />
           )
         }
       />

--- a/apps/web/core/debates/request-gate.ts
+++ b/apps/web/core/debates/request-gate.ts
@@ -15,6 +15,21 @@
  * both read `debate_claim_readiness`, which the in-flight response notification writes, so a
  * graph-backed position check there would hold a button the server would have accepted.
  */
+/**
+ * The viewer's position on a claim, read from both clocks, as a request offer needs it.
+ *
+ * Derived once by `useClaimPositionControl`, which already holds both readings, and passed straight
+ * to `ClaimEndSlot`. Every surface that offers a debate needs the same three values, and deriving
+ * them per surface is how the two clocks drifted apart in the first place (GEO-2808).
+ */
+export type DebateRequestPosition = {
+  /** geo-chat's copy. `undefined` when it has no row for this claim yet. */
+  chat: boolean | null | undefined;
+  /** What the viewer believes they hold — optimistic while a response is in flight. */
+  local: boolean | null;
+  indexingDelayed?: boolean;
+};
+
 export type DebateRequestGateInput = {
   /**
    * The position the request will be validated against, as the surface last heard it.

--- a/apps/web/partials/explore/claim-explore-feed-card.test.tsx
+++ b/apps/web/partials/explore/claim-explore-feed-card.test.tsx
@@ -91,8 +91,8 @@ vi.mock('~/core/debates/matchmaking/matchmaking-claim-card', () => ({
     respond: vi.fn(),
     actionTitle: () => (answersReady ? '' : 'Loading this claim’s responses…'),
     responseError: null,
-    // Mirrors the hook: the request offer reads this to tell a late index from a publish in flight.
-    responseIndexing: { status: 'idle', pending: null, runId: null },
+    // Mirrors the hook: the request offer reads this to decide whether to make itself.
+    requestPosition: { chat: null, local: null, indexingDelayed: false },
     canRespond: answersReady,
   }),
 }));

--- a/apps/web/partials/explore/claim-explore-feed-card.test.tsx
+++ b/apps/web/partials/explore/claim-explore-feed-card.test.tsx
@@ -91,6 +91,8 @@ vi.mock('~/core/debates/matchmaking/matchmaking-claim-card', () => ({
     respond: vi.fn(),
     actionTitle: () => (answersReady ? '' : 'Loading this claim’s responses…'),
     responseError: null,
+    // Mirrors the hook: the request offer reads this to tell a late index from a publish in flight.
+    responseIndexing: { status: 'idle', pending: null, runId: null },
     canRespond: answersReady,
   }),
 }));

--- a/apps/web/partials/explore/claim-explore-feed-card.tsx
+++ b/apps/web/partials/explore/claim-explore-feed-card.tsx
@@ -184,6 +184,11 @@ export function ClaimExploreFeedCard({
               activeDebate={row?.active_debate}
               enabled={nearViewport}
               className="ml-auto"
+              position={{
+                chat: readiness.viewer_response?.position ?? null,
+                local: control.viewerPosition,
+                indexingDelayed: control.responseIndexing.status === 'delayed',
+              }}
             />
           }
           className="col-start-1 row-start-1 mb-3 claim-card-narrow:mb-0"

--- a/apps/web/partials/explore/claim-explore-feed-card.tsx
+++ b/apps/web/partials/explore/claim-explore-feed-card.tsx
@@ -184,11 +184,7 @@ export function ClaimExploreFeedCard({
               activeDebate={row?.active_debate}
               enabled={nearViewport}
               className="ml-auto"
-              position={{
-                chat: readiness.viewer_response?.position ?? null,
-                local: control.viewerPosition,
-                indexingDelayed: control.responseIndexing.status === 'delayed',
-              }}
+              position={control.requestPosition}
             />
           }
           className="col-start-1 row-start-1 mb-3 claim-card-narrow:mb-0"


### PR DESCRIPTION
Follow-up to #2352, which fixed the "debate again" picker and deliberately left the other surfaces alone so the picker could be tested on its own.

They have the same hole. Each offers a debate before geo-chat holds the position it validates the request against — so the button is pressable, and the request comes back `claim_response_required`.

## What changed

`ClaimEndSlot` runs `debateRequestGate` and takes the position as a **required** prop.

Optional was the wrong call in #2352: it let a host silently keep the old behaviour, which is exactly how the hub ended up offering a debate it had no way to know was valid. Every host already runs `useClaimPositionControl`, so every host *can* answer — making it required turned "did I remember to wire this one?" into four compiler errors.

All four render sites are wired:

| surface | file |
|---|---|
| hub card (respondable) | `matchmaking-claim-card.tsx` |
| hub card (unresolvable) | `matchmaking-claim-card.tsx` |
| claim page | `claim-page-view.tsx` |
| explore feed card | `claim-explore-feed-card.tsx` |

The opponent half stays per-surface — here it is `match`, geo-chat's own matchmaking decision. The position half is the shared rule, so every surface waits on the same fact and names it with the same label.

## Two judgement calls worth checking

**The unresolvable card passes geo-chat's copy as both readings.** That is not the self-comparison GEO-2808 removed: there the fallback was the *graph*, a different source from the one that validates the request. Here it is the validating source agreeing with itself, which is the honest answer to "does geo-chat hold a position for this viewer". It draws no response control, so it has no optimistic side of its own to compare against.

**The inline slot only sizes itself against "Request debate" while the offer is pressable.** The pending label is longer, and this control sits in a meta row whose comment is explicit that it must not grow — sizing against the longer label would have held every idle button that much wider. A press cannot happen while pending, which is the only transition that sizer exists to smooth. This was the one cosmetic risk flagged in #2352's review and it is why the hub half was pulled from that PR.

## Verification

**380 test files, 4238 tests passing.** Real `bun run build` — not just `tsc` — after #2352 taught me the difference. `tsc --noEmit` at 5 errors, identical on master. ESLint clean.

Mutation-checked:

- drop the gate from `disabled` → `names the wait while geo-chat has not caught up` and `does not name a wait on a claim the viewer has not answered` both fail
- never render the pending label → `names the wait…` fails

Three test mocks of `useClaimPositionControl` gained the field the hook returns. A mock that does not mirror its hook is how the last round of these bugs stayed hidden, so they are corrected rather than worked around at the call site.

## Still not addressed

The backend race from #2352: geo-chat's rows report a position slightly before its request endpoint honours one against it, so a request sent the instant the gate opens can still be rejected. A client timer large enough to cover that is large enough to feel — it belongs on the backend.

The card-design alignment (GEO-2808 scope bullet 4) is still open. This is the behaviour half only.
