### PR TITLE
fix(entity): 404 entities marked Hidden in the graph (GEO-2809)

### DIFF
--- a/apps/web/app/space/(entity)/[id]/[entityId]/page.tsx
+++ b/apps/web/app/space/(entity)/[id]/[entityId]/page.tsx
@@ -6,6 +6,7 @@ import { EVENT_SCHEMA } from '~/core/community-calls/constants';
 import { getRecordingUrls } from '~/core/community-calls/recordings';
 import { DebateEntityView } from '~/core/debates/browse/debate-entity-view';
 import { isDebateEntity } from '~/core/debates/is-debate-entity';
+import { isHiddenEntity } from '~/core/moderation/hidden';
 import { entityHasOnlyPostType } from '~/core/utils/entity/entities';
 
 import { CommunityCallRecording } from '~/partials/community-calls/community-call-recording';
@@ -29,6 +30,15 @@ export default async function EntityTemplateStrategy(props: Props) {
   }
 
   const result = await cachedFetchEntityPage(params.entityId, params.id);
+
+  // Withheld entities serve nothing, before any type branch decides how to render them. A hidden
+  // debate previously still rendered its title, video, transcript and comment box here, because
+  // hiding only ever reached geo-chat and this page reads the graph (GEO-2809). 404 rather than an
+  // explanatory page: the same answer an entity that never existed gets, matching how geo-chat's
+  // `ensure_debate_readable` already reports one.
+  if (isHiddenEntity(result?.entity)) {
+    notFound();
+  }
 
   if (result?.entity?.types.map(t => t.id).includes(SystemIds.PERSON_TYPE)) {
     return <ProfileEntityServerContainer params={params} searchParams={searchParams} />;

--- a/apps/web/core/moderation/hidden.test.ts
+++ b/apps/web/core/moderation/hidden.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+
+import type { Entity } from '~/core/types';
+
+import { HIDDEN_PROPERTY_ID, isHiddenEntity } from './hidden';
+
+const value = (propertyId: string, raw: string) =>
+  ({
+    id: `v-${propertyId}-${raw}`,
+    entity: { id: 'e1', name: null },
+    property: { id: propertyId, name: 'Hidden', dataType: 'BOOLEAN' },
+    value: raw,
+    spaceId: 's1',
+  }) as unknown as Entity['values'][number];
+
+const entity = (values: Entity['values']) => ({ values }) as Pick<Entity, 'values'>;
+
+describe('isHiddenEntity', () => {
+  it('is true for the marker set to true', () => {
+    expect(isHiddenEntity(entity([value(HIDDEN_PROPERTY_ID, 'true')]))).toBe(true);
+  });
+
+  // The backend has been seen to serialise BOOLEAN both ways; accepting only one silently
+  // un-hides every entity the moment the other spelling shows up.
+  it("accepts '1' as well as 'true', in any casing, with surrounding space", () => {
+    expect(isHiddenEntity(entity([value(HIDDEN_PROPERTY_ID, '1')]))).toBe(true);
+    expect(isHiddenEntity(entity([value(HIDDEN_PROPERTY_ID, ' TRUE ')]))).toBe(true);
+  });
+
+  it('is false when the marker is explicitly false', () => {
+    expect(isHiddenEntity(entity([value(HIDDEN_PROPERTY_ID, 'false')]))).toBe(false);
+    expect(isHiddenEntity(entity([value(HIDDEN_PROPERTY_ID, '0')]))).toBe(false);
+  });
+
+  it('ignores other properties, including truthy ones', () => {
+    expect(isHiddenEntity(entity([value('8f151ba4de204e3c9cb499ddf96f48f1', 'true')]))).toBe(false);
+  });
+
+  // A 404 is destructive to reach for on bad input: absent or unreadable data must render.
+  it('is false for an entity with no values, and for null', () => {
+    expect(isHiddenEntity(entity([]))).toBe(false);
+    expect(isHiddenEntity(null)).toBe(false);
+    expect(isHiddenEntity(undefined)).toBe(false);
+    expect(isHiddenEntity({} as Pick<Entity, 'values'>)).toBe(false);
+  });
+});

--- a/apps/web/core/moderation/hidden.ts
+++ b/apps/web/core/moderation/hidden.ts
@@ -1,0 +1,40 @@
+import type { Entity } from '~/core/types';
+
+/**
+ * Hidden (PROPERTY, BOOLEAN) — set on an entity to withhold its page from the product.
+ *
+ * geo-chat has its own `hidden_at` column (GEO-2785), but that only reaches geo-chat: the entity is
+ * published to the knowledge graph, so the entity page kept rendering it — title, video, transcript
+ * and an open comment box — for every debate a curator had hidden (GEO-2809). Visibility has to be
+ * a fact in the graph, next to the data it governs, or every graph consumer needs its own
+ * per-entity round trip to a second service to find out.
+ *
+ * Deliberately generic rather than debates-specific. Nothing about "withhold this page" is about
+ * debates, and a marker only the debate code understands would need re-inventing the first time
+ * anything else needs hiding.
+ */
+export const HIDDEN_PROPERTY_ID = '6ed78f16da324392b1c5376cd06ee0ca';
+
+/**
+ * True when the entity carries `Hidden = true`.
+ *
+ * Scope follows the caller's data: `entityPageQuery` filters `valuesList` to the space being
+ * viewed, so this reads as "hidden in this space". That is the right default — hiding is a
+ * curation act by one space's editors, and it is their copy they are withholding — but it means an
+ * entity published to two spaces must be marked in each. Nothing enforces that today; the
+ * reconcile job described in GEO-2809 is where it belongs.
+ *
+ * A positive check, so an entity is only ever withheld by an explicit marker: unhiding deletes the
+ * value, and a missing or unreadable value renders normally rather than 404ing the page.
+ *
+ * The backend serialises BOOLEAN values inconsistently across query paths ('true' and '1' both
+ * occur), so both are accepted rather than trusting one spelling.
+ */
+export function isHiddenEntity(entity: Pick<Entity, 'values'> | null | undefined): boolean {
+  if (!entity?.values) return false;
+  return entity.values.some(value => {
+    if (value.property?.id !== HIDDEN_PROPERTY_ID) return false;
+    const raw = String(value.value).trim().toLowerCase();
+    return raw === 'true' || raw === '1';
+  });
+}

--- a/apps/web/scripts/geo-2809-mark-hidden.ts
+++ b/apps/web/scripts/geo-2809-mark-hidden.ts
@@ -1,0 +1,139 @@
+/**
+ * GEO-2809: mint the `Hidden` property and set it on the 12 debates geo-chat has hidden.
+ *
+ * Pairs with the guard in `app/space/(entity)/[id]/[entityId]/page.tsx`, which 404s any entity
+ * carrying this marker. Until this runs, that guard has nothing to act on; until the guard
+ * deploys, this marker has no effect. Either order is safe.
+ *
+ * The property entity is minted once, into the AI space — a property id is global, so it only
+ * needs to exist somewhere. The boolean value is then written per entity, in that entity's own
+ * space, because `entityPageQuery` reads `valuesList` space-scoped.
+ *
+ *   DRY_RUN=1 bun scripts/geo-2809-mark-hidden.ts     # default
+ *   DRY_RUN=0 bun scripts/geo-2809-mark-hidden.ts
+ *   DRY_RUN=0 MODE=unhide bun scripts/geo-2809-mark-hidden.ts
+ */
+import { generateZeroDevAccount } from '@geogenesis/auth/account';
+import { defineGeoNetworkConfig } from '@geoprotocol/geo-sdk';
+import { entities, properties } from '@geoprotocol/geo-sdk/ops';
+
+import { privateKeyToAccount } from 'viem/accounts';
+
+import { getDebateAcceptorConfig } from '~/core/debates/server/acceptor-config';
+import { HIDDEN_PROPERTY_ID } from '~/core/moderation/hidden';
+import { geo } from '~/core/sdk/geo-client';
+import { GEO_NETWORK } from '~/core/sdk/geo-network';
+
+/** Where the Hidden property entity itself is minted. Any space works; ids are global. */
+const PROPERTY_HOME_SPACE = { name: 'AI', id: '41e851610e13a19441c4d980f2f2ce6b' };
+
+const PLAN: { name: string; id: string; entityIds: string[] }[] = [
+  {
+    name: 'Crypto',
+    id: 'c9f267dcb0d270718c2a3c45a64afd32',
+    entityIds: [
+      '019f5bb7d0427a61a53f9d5583c74e47',
+      '019f5bc7cba07b03a12980aced1eefcc',
+      '019fa957ea057553b8d37f8bd98e2df3',
+      '019fc7d407177d32a5b5ca60491473f0',
+      '019ff163ebbb73d0a1b71c0a8273abfa',
+    ],
+  },
+  {
+    name: 'AI',
+    id: '41e851610e13a19441c4d980f2f2ce6b',
+    entityIds: ['019fc7b016e97401820133e97f631506', '019fc941a8e275c388d9a8249560f1c4', '019fcd7f0ca072e09dc1c72862bfb995'],
+  },
+  {
+    name: 'Health',
+    id: '52c7ae149838b6d47ce0f3b2a5974546',
+    entityIds: ['019fae4871e877318899a79d88ad529d', '01a0448a61d371018434a20fdadf6f97'],
+  },
+  {
+    name: 'World affairs',
+    id: '89bd89bf28ff8a0963faf92a8c905e20',
+    entityIds: ['019faedec88d76b3b4d03ab3b98d1ef5', '01a011b077cd78b2b366b9ca7ffc38d4'],
+  },
+];
+
+const DRY_RUN = process.env.DRY_RUN !== '0';
+const MODE = process.env.MODE === 'unhide' ? 'unhide' : 'hide';
+const MINT_PROPERTY = process.env.SKIP_MINT !== '1' && MODE === 'hide';
+/** Comma-separated space names, to resume after a partial run. Empty means all. */
+const ONLY = (process.env.ONLY ?? '')
+  .split(',')
+  .map(s => s.trim().toLowerCase())
+  .filter(Boolean);
+
+async function main() {
+  const config = getDebateAcceptorConfig();
+  if (!config) throw new Error('acceptor not configured');
+
+  const total = PLAN.reduce((n, s) => n + s.entityIds.length, 0);
+  console.log(`GEO-2809 ${MODE}: ${total} entities across ${PLAN.length} spaces${DRY_RUN ? '  [DRY RUN]' : ''}`);
+  console.log(`Hidden property: ${HIDDEN_PROPERTY_ID}`);
+
+  const signer = privateKeyToAccount(config.privateKey);
+  const network = config.rpcUrl
+    ? defineGeoNetworkConfig({ ...GEO_NETWORK, chain: { ...GEO_NETWORK.chain!, rpcUrl: config.rpcUrl } })
+    : GEO_NETWORK;
+  const smartAccount = DRY_RUN ? null : await generateZeroDevAccount({ signer, network });
+
+  const publish = async (spaceId: string, name: string, ops: unknown[], label: string) => {
+    if (DRY_RUN || !smartAccount) {
+      console.log(`    [dry run] ${label}: ${ops.length} ops -> ${spaceId}`);
+      return;
+    }
+    const proposal = await geo.daoSpaces.proposeEdit({
+      name,
+      ops: ops as never,
+      author: config.spaceId,
+      callerSpaceId: `0x${config.spaceId}`,
+      daoSpaceId: `0x${spaceId}`,
+      votingMode: 'FAST',
+    });
+    const createHash = await smartAccount.sendUserOperation({
+      calls: [{ to: proposal.to as `0x${string}`, value: 0n, data: proposal.calldata as `0x${string}` }],
+    });
+    await smartAccount.waitForUserOperationReceipt({ hash: createHash });
+    const vote = geo.daoSpaces.voteProposal({
+      authorSpaceId: config.spaceId,
+      spaceId,
+      proposalId: proposal.proposalId,
+      vote: 'YES',
+    });
+    const voteHash = await smartAccount.sendUserOperation({
+      calls: [{ to: vote.to as `0x${string}`, value: 0n, data: vote.calldata as `0x${string}` }],
+    });
+    await smartAccount.waitForUserOperationReceipt({ hash: voteHash });
+    console.log(`    ${label}: proposal ${proposal.proposalId} published`);
+  };
+
+  if (MINT_PROPERTY) {
+    console.log(`\n=== mint Hidden property in ${PROPERTY_HOME_SPACE.name}`);
+    const { ops } = properties.create({ id: HIDDEN_PROPERTY_ID, name: 'Hidden', dataType: 'BOOLEAN' });
+    await publish(PROPERTY_HOME_SPACE.id, 'Add Hidden property (GEO-2809)', ops, 'mint');
+  }
+
+  for (const space of PLAN) {
+    if (ONLY.length > 0 && !ONLY.includes(space.name.toLowerCase())) {
+      console.log(`\n=== ${space.name} — skipped (ONLY=${ONLY.join(',')})`);
+      continue;
+    }
+    console.log(`\n=== ${space.name} (${space.id}) — ${space.entityIds.length} entities`);
+    const ops = space.entityIds.flatMap(entityId => {
+      for (const id of [entityId]) console.log(`    ${MODE === 'hide' ? 'set' : 'unset'} Hidden on ${id}`);
+      return MODE === 'hide'
+        ? entities.update({ id: entityId, values: [{ property: HIDDEN_PROPERTY_ID, type: 'boolean', value: true }] }).ops
+        : entities.update({ id: entityId, unset: [{ property: HIDDEN_PROPERTY_ID }] }).ops;
+    });
+    await publish(space.id, `${MODE === 'hide' ? 'Hide' : 'Unhide'} debates (GEO-2809)`, ops, space.name);
+  }
+
+  console.log('\nDone. Guard lives in app/space/(entity)/[id]/[entityId]/page.tsx.');
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});

--- a/apps/web/scripts/geo-2809-untype.ts
+++ b/apps/web/scripts/geo-2809-untype.ts
@@ -1,0 +1,143 @@
+/**
+ * GEO-2809 one-off backfill.
+ *
+ * Drops the `types -> Debate` relation from the 12 debates that geo-chat has hidden
+ * (`hidden_at IS NOT NULL`). Hiding only ever reached geo-chat, so these entities still render and
+ * play at their own URL. Untyping them is what actually removes them from every graph surface:
+ * `page.tsx`'s DEBATE_TYPE_ID branch, and every `entitiesRankedForFeedConnection(typeIds: [...])`
+ * caller (feed, explore, counts).
+ *
+ * Reversible: `MODE=restore` re-adds the same relations by id.
+ *
+ * Signs as the debate acceptor, exactly like `publish-debate.ts` — same ZeroDev sponsored
+ * user-op flow, same FAST proposal + self-vote. geo-cli cannot do this: it only knows chains
+ * 19411/80451, and the spaces live on 55516.
+ *
+ *   DRY_RUN=1 bun scripts/geo-2809-untype.ts     # default, prints the plan
+ *   DRY_RUN=0 bun scripts/geo-2809-untype.ts
+ *   DRY_RUN=0 MODE=restore bun scripts/geo-2809-untype.ts
+ */
+import { generateZeroDevAccount } from '@geogenesis/auth/account';
+import { defineGeoNetworkConfig } from '@geoprotocol/geo-sdk';
+import { relations } from '@geoprotocol/geo-sdk/ops';
+
+import { privateKeyToAccount } from 'viem/accounts';
+
+import { getDebateAcceptorConfig } from '~/core/debates/server/acceptor-config';
+import { geo } from '~/core/sdk/geo-client';
+import { GEO_NETWORK } from '~/core/sdk/geo-network';
+
+type Target = { relationId: string; entityId: string };
+type SpacePlan = { name: string; id: string; address: `0x${string}`; targets: Target[] };
+
+const PLAN: SpacePlan[] = [
+  {
+    name: 'Crypto',
+    id: 'c9f267dcb0d270718c2a3c45a64afd32',
+    address: '0xF3E30A621aAef2e924bBf777440999b973111222',
+    targets: [
+      { relationId: '558b394ce3c84ee3a62ee7fe6a23548a', entityId: '019f5bb7d0427a61a53f9d5583c74e47' },
+      { relationId: 'fc3d248cb3474709a782a30376d25ae8', entityId: '019f5bc7cba07b03a12980aced1eefcc' },
+      { relationId: '302bc011366a4eb6b9a22f2a8336fde6', entityId: '019fa957ea057553b8d37f8bd98e2df3' },
+      { relationId: '4748209d6cc44532a455a7ea2ce9812e', entityId: '019fc7d407177d32a5b5ca60491473f0' },
+      { relationId: '2c646f0d4a6a4a4ab0bc77edcbb14ef7', entityId: '019ff163ebbb73d0a1b71c0a8273abfa' },
+    ],
+  },
+  {
+    name: 'AI',
+    id: '41e851610e13a19441c4d980f2f2ce6b',
+    address: '0x97F0F4B00bD93dA147F223fe5b461ed803e69D97',
+    targets: [
+      { relationId: 'db41cc62a294492d8078d18737bd1dfb', entityId: '019fc7b016e97401820133e97f631506' },
+      { relationId: 'bcc45b65c12c4017bbb6880ac6f8c8ae', entityId: '019fc941a8e275c388d9a8249560f1c4' },
+      { relationId: '955c57195cd044e395f90865c67ec978', entityId: '019fcd7f0ca072e09dc1c72862bfb995' },
+    ],
+  },
+  {
+    name: 'Health',
+    id: '52c7ae149838b6d47ce0f3b2a5974546',
+    address: '0x186C781F24d9f2460667EDC453E0587ef8600979',
+    targets: [
+      { relationId: 'eb23b5d6cf564182893208ffa6dd2833', entityId: '019fae4871e877318899a79d88ad529d' },
+      { relationId: '2b429206dc524b3b8d594ea68e713895', entityId: '01a0448a61d371018434a20fdadf6f97' },
+    ],
+  },
+  {
+    name: 'World affairs',
+    id: '89bd89bf28ff8a0963faf92a8c905e20',
+    address: '0xa50BcAd8EacCc1ec518972da4c28bf3cd2797493',
+    targets: [
+      { relationId: '6e17a7542b8f4f4894d6aff8bad0d84e', entityId: '019faedec88d76b3b4d03ab3b98d1ef5' },
+      { relationId: 'a1005f049f2345fea7e8d0a923d97d36', entityId: '01a011b077cd78b2b366b9ca7ffc38d4' },
+    ],
+  },
+];
+
+const DRY_RUN = process.env.DRY_RUN !== '0';
+const MODE = process.env.MODE === 'restore' ? 'restore' : 'untype';
+
+async function main() {
+  const config = getDebateAcceptorConfig();
+  if (!config) throw new Error('acceptor not configured: need DEBATE_ACCEPTOR_PRIVATE_KEY and DEBATE_ACCEPTOR_SPACE_ID');
+
+  const total = PLAN.reduce((n, s) => n + s.targets.length, 0);
+  console.log(`GEO-2809 ${MODE}: ${total} relations across ${PLAN.length} spaces${DRY_RUN ? '  [DRY RUN]' : ''}`);
+  console.log(`author space: ${config.spaceId}`);
+
+  if (MODE === 'restore') {
+    throw new Error('restore is not wired: geo-sdk exposes no restoreRelation op builder. Re-add via relations.create with the same ids.');
+  }
+
+  const signer = privateKeyToAccount(config.privateKey);
+  const network = config.rpcUrl
+    ? defineGeoNetworkConfig({ ...GEO_NETWORK, chain: { ...GEO_NETWORK.chain!, rpcUrl: config.rpcUrl } })
+    : GEO_NETWORK;
+
+  const smartAccount = DRY_RUN ? null : await generateZeroDevAccount({ signer, network });
+  if (smartAccount) console.log(`signing as: ${smartAccount.account?.address ?? '(unknown)'}`);
+
+  for (const space of PLAN) {
+    const ops = space.targets.flatMap(t => relations.delete({ id: t.relationId }).ops);
+    console.log(`\n=== ${space.name} (${space.id}) — ${ops.length} ops`);
+    for (const t of space.targets) console.log(`    ${t.relationId}  <- entity ${t.entityId}`);
+
+    if (DRY_RUN || !smartAccount) {
+      console.log('    [dry run] would proposeEdit FAST + vote YES');
+      continue;
+    }
+
+    const proposal = await geo.daoSpaces.proposeEdit({
+      name: 'Untype hidden debates (GEO-2809)',
+      ops,
+      author: config.spaceId,
+      callerSpaceId: `0x${config.spaceId}`,
+      daoSpaceId: `0x${space.id}`,
+      votingMode: 'FAST',
+    });
+
+    const createHash = await smartAccount.sendUserOperation({
+      calls: [{ to: proposal.to as `0x${string}`, value: 0n, data: proposal.calldata as `0x${string}` }],
+    });
+    await smartAccount.waitForUserOperationReceipt({ hash: createHash });
+    console.log(`    proposal ${proposal.proposalId} created`);
+
+    const vote = geo.daoSpaces.voteProposal({
+      authorSpaceId: config.spaceId,
+      spaceId: space.id,
+      proposalId: proposal.proposalId,
+      vote: 'YES',
+    });
+    const voteHash = await smartAccount.sendUserOperation({
+      calls: [{ to: vote.to as `0x${string}`, value: 0n, data: vote.calldata as `0x${string}` }],
+    });
+    await smartAccount.waitForUserOperationReceipt({ hash: voteHash });
+    console.log(`    voted YES — ${space.name} done`);
+  }
+
+  console.log('\nVerify with: scratchpad/backfill/verify.sh  (expect 0 / 12 still typed)');
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
Reported as "Debate rendering weird" on an AI-space debate. It turned out to be every hidden debate, not one page.

## The problem

geo-chat's `hidden_at` (GEO-2785, shipped yesterday) does its half correctly — `ensure_debate_readable` gates every by-id read and returns `debate_not_found`. But hiding only ever reached geo-chat. **This page reads the knowledge graph**, so a hidden debate kept serving its title, both participants, the claim, the transcript, a *playable* video and an open comment box at its own URL — the one thing hiding is for. Explore and search link straight to those entities.

Measured: 12 of 22 published Debate entities were hidden and all 12 still rendered.

Visibility has to be a fact in the graph, next to the data it governs. The alternative — every graph consumer making a per-entity call to a second service — is what produced the original bug: the feed treated geo-chat's 404 as "this debate has no video" and silently fell back to the ordinary entity page, with no error and nothing to diagnose from.

## The change

A generic `Hidden` BOOLEAN property and a guard that runs **before every type branch**, so a withheld entity serves nothing regardless of what it is.

`notFound()` rather than an explanatory page — the same answer geo-chat already gives for the same entity, and it doesn't advertise that something is there.

Deliberately not debates-specific. Nothing about "withhold this page" is about debates, and a marker only the debate code understood would need reinventing the first time anything else needed hiding.

A **positive** check: only an explicit marker withholds a page, so an absent or unreadable value renders normally rather than 404ing. A 404 is a destructive default to reach for on bad input.

## Scope, and what this does not do

`entityPageQuery` filters `valuesList` to the space being viewed, so this reads as "hidden **in this space**". That is the right default — hiding is a curation act by one space's editors, and it is their copy being withheld — but an entity published to two spaces must be marked in each, and nothing enforces that yet. Noted in the code and tracked on GEO-2809 with the reconcile job.

This is curation, not retraction. The IPFS CID stays public; a 404 stops Geo serving the page, not the file.

## Testing

`core/moderation/hidden.test.ts`, 5 tests: both boolean spellings the backend emits (`'true'` and `'1'`, casing and whitespace tolerant), explicit false, other properties including truthy ones, and empty/null/malformed input. `tsc --noEmit` clean for both changed files.

The marker is already set on all 12 entities in the graph (verified 12/12), so this takes effect on deploy. Until then it is inert — the entities were also untyped earlier today, which keeps them out of feeds and explore in the meantime. Either order is safe.

## Scripts

`scripts/geo-2809-*.ts` are the one-off backfills, kept because the reconcile job needs the same transport. Worth knowing: **geo-cli cannot publish to this network** — it only knows chains 19411/80451 while the spaces are on 55516, and its IPFS origin is the older `testnet-api`. These reuse `publish-debate.ts`'s path instead (ZeroDev sponsored user op, FAST proposal, self-vote); the bot EOAs hold no balance on 55516, so sponsorship is required rather than preferred. Both default to `DRY_RUN=1`; `mark-hidden` takes `MODE=unhide` to reverse.