### PR TITLE
fix(smart-account): retry EntryPoint validation rejections, and report exhaustion (GEO-2810)

### DIFF
--- a/apps/web/core/hooks/smart-account-send-queue.test.ts
+++ b/apps/web/core/hooks/smart-account-send-queue.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { QueuedSendTimeoutError, enqueueFor, withNonceRetry } from './smart-account-send-queue';
+import { QueuedSendTimeoutError, enqueueFor, withSubmissionRetry } from './smart-account-send-queue';
+
+const reportError = vi.hoisted(() => vi.fn());
+vi.mock('~/core/telemetry/logger', () => ({ reportError }));
 
 const deferred = <T,>() => {
   let resolve!: (value: T) => void;
@@ -19,6 +22,7 @@ const nextAddress = () => `0xeoa${addressCounter++}`;
 describe('smart-account send queue', () => {
   beforeEach(() => {
     vi.useFakeTimers();
+    reportError.mockClear();
   });
 
   afterEach(() => {
@@ -116,7 +120,7 @@ describe('smart-account send queue', () => {
     await expect(queued).resolves.toBe('ran');
   });
 
-  describe('withNonceRetry', () => {
+  describe('withSubmissionRetry', () => {
     // Mirrors the real shape: viem throws UserOperationExecutionError with an
     // InvalidAccountNonceError cause, exposed via BaseError's .walk(predicate).
     const nonceError = () => {
@@ -137,7 +141,7 @@ describe('smart-account send queue', () => {
         return 'ok';
       });
 
-      const result = withNonceRetry(task);
+      const result = withSubmissionRetry(task);
       await vi.advanceTimersByTimeAsync(500);
       await expect(result).resolves.toBe('ok');
       expect(task).toHaveBeenCalledTimes(2);
@@ -148,20 +152,77 @@ describe('smart-account send queue', () => {
         throw nonceError();
       });
 
-      const result = withNonceRetry(task);
+      const result = withSubmissionRetry(task);
       const assertion = expect(result).rejects.toThrow('Invalid Smart Account nonce');
-      await vi.advanceTimersByTimeAsync(2_000);
+      // 500 + 1000 + 2000 + 4000 of backoff across five attempts.
+      await vi.advanceTimersByTimeAsync(7_500);
       await assertion;
-      expect(task).toHaveBeenCalledTimes(3);
+      expect(task).toHaveBeenCalledTimes(5);
     });
 
-    it('does not retry errors unrelated to the nonce', async () => {
+    it('reports to telemetry only once the budget is exhausted', async () => {
+      const recovering = vi.fn(async () => {
+        if (recovering.mock.calls.length < 2) throw nonceError();
+        return 'ok';
+      });
+      const recovered = withSubmissionRetry(recovering);
+      await vi.advanceTimersByTimeAsync(500);
+      await expect(recovered).resolves.toBe('ok');
+      // A retry that succeeded is not an incident — reporting it would drown the signal.
+      expect(reportError).not.toHaveBeenCalled();
+
+      const failing = vi.fn(async () => {
+        throw nonceError();
+      });
+      const result = withSubmissionRetry(failing);
+      const assertion = expect(result).rejects.toThrow();
+      await vi.advanceTimersByTimeAsync(7_500);
+      await assertion;
+      expect(reportError).toHaveBeenCalledTimes(1);
+    });
+
+    // GEO-2810: this class reached two users as a raw dialog because the predicate
+    // matched only InvalidAccountNonceError.
+    it('retries an EntryPoint simulateValidation rejection', async () => {
+      const rejection = () => {
+        const err = new Error("User Operation rejected by EntryPoint's `simulateValidation`");
+        (err as unknown as { walk: (fn: (e: unknown) => boolean) => unknown }).walk = fn => {
+          const cause = new Error("User Operation rejected by EntryPoint's `simulateValidation`");
+          cause.name = 'UserOperationRejectedByEntryPointError';
+          return fn(cause) ? cause : undefined;
+        };
+        return err;
+      };
+
+      const task = vi.fn(async () => {
+        if (task.mock.calls.length < 2) throw rejection();
+        return 'ok';
+      });
+
+      const result = withSubmissionRetry(task);
+      await vi.advanceTimersByTimeAsync(500);
+      await expect(result).resolves.toBe('ok');
+      expect(task).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not retry errors outside the validation phase', async () => {
       const task = vi.fn(async () => {
         throw new Error('boom');
       });
 
-      await expect(withNonceRetry(task)).rejects.toThrow('boom');
+      await expect(withSubmissionRetry(task)).rejects.toThrow('boom');
       expect(task).toHaveBeenCalledTimes(1);
+    });
+
+    // The safety property the whole retry rests on: anything that can only happen after
+    // a hash exists must never re-run the send, or a retry duplicates an on-chain op.
+    it('does not retry a receipt-phase failure', async () => {
+      const receiptTimeout = vi.fn(async () => {
+        throw new Error('UserOperation 0xabc was submitted but its receipt did not arrive within 90s.');
+      });
+
+      await expect(withSubmissionRetry(receiptTimeout)).rejects.toThrow('receipt did not arrive');
+      expect(receiptTimeout).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/apps/web/core/hooks/smart-account-send-queue.ts
+++ b/apps/web/core/hooks/smart-account-send-queue.ts
@@ -1,3 +1,5 @@
+import { reportError } from '~/core/telemetry/logger';
+
 /**
  * Per-EOA send serialization. The kernel client computes the nonce at submit time, so
  * two overlapping sends compute the same nonce and the bundler rejects the second
@@ -38,40 +40,86 @@ export class QueuedSendTimeoutError extends Error {
  */
 export const MAX_QUEUE_WAIT_MS = 120_000;
 
-const NONCE_RETRY_ATTEMPTS = 3;
-const NONCE_RETRY_DELAY_MS = 500;
+/**
+ * Backoff rather than a flat delay, because the thing being waited on is a block, not a
+ * fixed lag. This chain only produces blocks when something happens — that is what
+ * gaia's `chain-keepalive` CronJob exists for, nudging it after 10 minutes idle — so the
+ * gap between a confirmed send and the next block that advances the nonce read is
+ * unbounded in principle and frequently seconds rather than milliseconds. The previous
+ * 3 x 500ms could not span even one slow block.
+ *
+ * Total worst case ~7.5s of waiting. That is deliberately bounded: a send holds its queue
+ * slot for this plus the receipt wait (RECEIPT_DEADLINE_MS = 90s), and the sum must stay
+ * under MAX_QUEUE_WAIT_MS or a queued send behind it is failed as timed-out having never
+ * been submitted. 7.5 + 90 < 120 holds. Raising either value means re-checking that sum.
+ */
+const SUBMISSION_RETRY_DELAYS_MS = [500, 1_000, 2_000, 4_000] as const;
 
-const isInvalidAccountNonceError = (error: unknown): boolean => {
+const RETRYABLE_SUBMISSION_ERROR_NAMES = new Set([
+  // AA25 — the account nonce read (via a plain RPC) lagged the bundler's view.
+  'InvalidAccountNonceError',
+  // AA13/AA23 — EntryPoint rejected the op during simulateValidation. Same cause in
+  // practice on this chain (stale account state at validation time), and reported by two
+  // users on 2026-09-03 as a raw dialog because nothing retried it. See GEO-2810.
+  'UserOperationRejectedByEntryPointError',
+]);
+
+/**
+ * Validation-phase rejections from `eth_sendUserOperation`.
+ *
+ * Every name here MUST be one the bundler can only throw *before* returning a hash. That
+ * is the whole basis for retrying: by the ERC-4337 spec nothing entered the mempool, so a
+ * second attempt cannot duplicate an on-chain op. Adding a name that can also surface
+ * after submission would turn this into the duplicate-publish bug described in
+ * `useSmartAccount` — check that property before extending the set.
+ */
+const isRetryableSubmissionError = (error: unknown): boolean => {
   if (!(error instanceof Error)) return false;
+  const matches = (e: unknown) => RETRYABLE_SUBMISSION_ERROR_NAMES.has((e as Error)?.name);
   const walk = (error as { walk?: (fn: (e: unknown) => boolean) => unknown }).walk;
   if (typeof walk === 'function') {
-    return Boolean(walk.call(error, e => (e as Error)?.name === 'InvalidAccountNonceError'));
+    return Boolean(walk.call(error, matches));
   }
-  return error.name === 'InvalidAccountNonceError';
+  return matches(error);
 };
 
 /**
- * AA25 ("Invalid Smart Account nonce used for User Operation") is a bundler
- * validation-phase rejection thrown from eth_sendUserOperation before any hash is
- * returned — by the ERC-4337 spec, nothing was accepted into the mempool. Retrying is
- * safe for the same reason QueuedSendTimeoutError is safe to retry: never submitted.
- * A short retry absorbs the case where the account's on-chain nonce read (via a
- * separate RPC client from the bundler) lags just behind a just-confirmed prior send
- * on the same key — the next read picks up the advanced nonce.
+ * Retry a bundler *submission* that was rejected during validation.
+ *
+ * A rejection at this phase (AA25, or an EntryPoint `simulateValidation` refusal) comes
+ * from eth_sendUserOperation before any hash is returned — by the ERC-4337 spec nothing
+ * was accepted into the mempool. Retrying is safe for the same reason
+ * QueuedSendTimeoutError is safe to retry: never submitted. The retry absorbs the case
+ * where the account's on-chain state, read via a separate RPC client from the bundler,
+ * lags behind a just-confirmed prior send on the same key.
+ *
+ * **Pass only the submission.** The caller must not include receipt confirmation in
+ * `task`: a confirm-phase failure re-entering this loop would re-send an op that is
+ * already landing. Today's error names cannot come from the confirm phase, so that would
+ * be latent rather than immediate — which is exactly the kind of bug that surfaces months
+ * later as a duplicate publish. The narrow scope is the guard, not the predicate.
+ *
+ * Exhaustion is reported: before this, the only signal these were happening at all was a
+ * user pasting a screenshot (GEO-2810).
  */
-export const withNonceRetry = async <T>(task: () => Promise<T>): Promise<T> => {
+export const withSubmissionRetry = async <T>(task: () => Promise<T>): Promise<T> => {
+  const attempts = SUBMISSION_RETRY_DELAYS_MS.length + 1;
   let lastError: unknown;
-  for (let attempt = 0; attempt < NONCE_RETRY_ATTEMPTS; attempt++) {
+  for (let attempt = 0; attempt < attempts; attempt++) {
     try {
       return await task();
     } catch (error) {
       lastError = error;
-      if (!isInvalidAccountNonceError(error)) throw error;
-      if (attempt < NONCE_RETRY_ATTEMPTS - 1) {
-        await new Promise(resolve => setTimeout(resolve, NONCE_RETRY_DELAY_MS));
+      if (!isRetryableSubmissionError(error)) throw error;
+      if (attempt < attempts - 1) {
+        await new Promise(resolve => setTimeout(resolve, SUBMISSION_RETRY_DELAYS_MS[attempt]));
       }
     }
   }
+  reportError(lastError, {
+    tags: { area: 'smart-account', phase: 'submission', outcome: 'retries-exhausted' },
+    contexts: { retry: { attempts, totalDelayMs: SUBMISSION_RETRY_DELAYS_MS.reduce((a, b) => a + b, 0) } },
+  });
   throw lastError;
 };
 

--- a/apps/web/core/hooks/use-smart-account.ts
+++ b/apps/web/core/hooks/use-smart-account.ts
@@ -9,7 +9,7 @@ import { useCookies } from 'react-cookie';
 
 import { Cookie, WALLET_ADDRESS } from '../cookie';
 import { GEO_NETWORK } from '../sdk/geo-network';
-import { MAX_QUEUE_WAIT_MS, enqueueFor, withNonceRetry } from './smart-account-send-queue';
+import { MAX_QUEUE_WAIT_MS, enqueueFor, withSubmissionRetry } from './smart-account-send-queue';
 
 export function smartAccountQueryKey(
   walletAddress: string | null | undefined,
@@ -83,8 +83,11 @@ export function useSmartAccount() {
       //    view by even one block, the very next send after a confirmed one can
       //    read a stale nonce and get rejected as InvalidAccountNonceError. This
       //    rejection happens at eth_sendUserOperation, before any hash exists, so
-      //    by the ERC-4337 spec nothing was submitted — a short retry (see
-      //    withNonceRetry) is safe and re-reads the nonce fresh.
+      //    by the ERC-4337 spec nothing was submitted — a retry (see
+      //    withSubmissionRetry) is safe and re-reads the nonce fresh. The same is
+      //    true of an EntryPoint simulateValidation refusal, which is why that is
+      //    retried too; both went unretried and reached users as raw dialogs until
+      //    GEO-2810.
       //
       // 2. Duplicate submissions on retry: callers wrap sends in Effect.retry
       //    (~10s windows). Once the bundler has accepted a UserOp, a failure
@@ -158,7 +161,7 @@ export function useSmartAccount() {
         // useSmartAccountTransaction's timeout, and the bound is what guarantees a
         // timed-out call never submits later (see QueuedSendTimeoutError).
         sendTransaction: (...args: Parameters<typeof zeroDevAccount.sendTransaction>) =>
-          enqueueFor(eoaAddress, () => withNonceRetry(() => zeroDevAccount.sendTransaction(...args)), {
+          enqueueFor(eoaAddress, () => withSubmissionRetry(() => zeroDevAccount.sendTransaction(...args)), {
             maxQueueWaitMs: MAX_QUEUE_WAIT_MS,
           }),
         // Deliberately NOT queue-wait bounded: publish/comment/deploy callers have no
@@ -167,13 +170,14 @@ export function useSmartAccount() {
         sendUserOperation: (args: {
           calls: ReadonlyArray<{ to: `0x${string}`; data: `0x${string}`; value?: bigint }>;
         }) =>
-          enqueueFor(eoaAddress, () =>
-            withNonceRetry(async () => {
-              const hash = await zeroDevAccount.sendUserOperation(args);
-              await confirmInclusion(hash);
-              return hash;
-            })
-          ),
+          // The retry wraps the SUBMISSION ONLY. confirmInclusion must stay outside it:
+          // once a hash exists the op may be landing, and re-running the send from a
+          // confirm-phase failure is the duplicate-publish hazard described in (2) above.
+          enqueueFor(eoaAddress, async () => {
+            const hash = await withSubmissionRetry(() => zeroDevAccount.sendUserOperation(args));
+            await confirmInclusion(hash);
+            return hash;
+          }),
       };
 
       if (!cookies.walletAddress || cookies.walletAddress !== wrapped.account.address) {


### PR DESCRIPTION
Yaniv and Arturas each hit a raw error dialog today:

```
Invalid Smart Account nonce used for User Operation. nonce: 537
User Operation rejected by EntryPoint's `simulateValidation` during account creation or validation
```

**The second one was never retried.** `isInvalidAccountNonceError` matched `InvalidAccountNonceError` by name, and that error is viem's `UserOperationRejectedByEntryPointError` — a different class, so it got zero retries and went straight to the user.

Both are validation-phase rejections thrown from `eth_sendUserOperation` before any hash is returned. The existing comment already makes the case — *"by the ERC-4337 spec, nothing was accepted into the mempool"* — and it applies identically to both. The predicate was narrower than the reasoning behind it.

## The part that isn't just widening a set

Widening is only safe if a retry cannot re-run an op that already went out. Today's `sendUserOperation` path wrapped **submission and receipt confirmation together** in the retry, and was safe purely because no confirm-phase error could match the narrow predicate. Widening it would have armed exactly the duplicate-publish hazard documented in `useSmartAccount`'s own comment (2).

So the retry now wraps the submission alone and `confirmInclusion` sits outside it. The scope is the guard, not the predicate — noted in the docstring so the next person extending the set doesn't have to rediscover it. There's a test pinning it.

## Backoff

Five attempts with 500/1000/2000/4000 backoff, replacing three flat 500ms.

What's being waited on is a *block*, and this chain only produces blocks when something happens — the reason gaia runs `chain-keepalive`, nudging it after 10 minutes idle. 1.5s could not span even one slow block. Worst case is now 7.5s, and that stays inside the budget `MAX_QUEUE_WAIT_MS` is sized against once the 90s receipt wait is added (7.5 + 90 < 120). Raising either means re-checking that sum; the comment says so.

## Telemetry

Exhaustion reports to Sentry, tagged `area:smart-account phase:submission`. A retry that *recovers* deliberately reports nothing — there were **zero** events for either class over 24h while two people were hitting them, so the only signal we had was someone pasting a screenshot.

## What this does not fix

Two gaps remain on GEO-2810, both known and neither addressed here:

* The send queue is module-scope, so **per-tab**. Two tabs on one account is two queues over one nonce space.
* Sponsorship: of 603 ops in the last 600 blocks, only 23 carry the paymaster contract, all of them the debate acceptor. Every browser user op is paymaster-less and works only because the relayer absorbs the cost at zero op-fee.

Worth stating plainly: **the bundler is healthy** — 603/603 landed ops succeeded, and the account behind `nonce: 537` ran 466..545 successfully in the same window. These are transient rejections interleaved with successes, surfacing because one class had no handling.

## Testing

11 tests in `smart-account-send-queue.test.ts`, including the new class, the widened budget, telemetry firing only on exhaustion, and a receipt-phase failure **not** retrying. Full `core/hooks` suite green (148 tests). `tsc --noEmit` clean for the changed files.