### PR TITLE
Debates: remove the last readiness switch and the plumbing behind it (GEO-2813)

### DIFF
--- a/apps/web/app/space/[id]/(space)/claims/claims-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/claims/claims-page-client.test.tsx
@@ -53,8 +53,8 @@ vi.mock('~/core/hooks/use-entity-vote', () => ({
 }));
 
 vi.mock('~/core/debates/hooks', () => ({
-  // Mirrors the real key factory: the readiness machine refetches these families before it
-  // retries a `claim_response_required`.
+  // Mirrors the real key factory: `vi.mock` replaces the whole module, so every query key read
+  // below this needs one here.
   debateQueryKeys: {
     matchmakingClaimsRoot: (accountKey: string | null) =>
       ['debates', 'account', accountKey, 'matchmaking-claims'] as const,

--- a/apps/web/app/space/[id]/(space)/claims/claims-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/claims/claims-page-client.test.tsx
@@ -29,15 +29,12 @@ const mocks = vi.hoisted(() => ({
   setActiveSpace: vi.fn(),
   bumpReviewVersion: vi.fn(),
   setIsReviewOpen: vi.fn(),
-  joinMutate: vi.fn(),
-  leaveMutate: vi.fn(),
   responseBatchCalls: [] as unknown[],
   refetchResponseBatch: vi.fn(),
 }));
 
 let claims: Entity[] = [];
 let claimsLoading = false;
-let joinPending = false;
 let lastQueryEntitiesOptions: unknown = null;
 let debateClaimsResponse: { claims: unknown[] } = { claims: [] };
 let responseBatchReady = true;
@@ -66,13 +63,6 @@ vi.mock('~/core/debates/hooks', () => ({
   },
   useGeoChatAuth: () => ({ ready: true, authenticated: true, accountKey: 'account-1' }),
   useDebateClaims: () => ({ data: debateClaimsResponse, error: null }),
-  useJoinDebateQueue: () => ({
-    mutateAsync: mocks.joinMutate,
-    reset: vi.fn(),
-    isPending: joinPending,
-    error: null,
-  }),
-  useLeaveDebateQueue: () => ({ mutateAsync: mocks.leaveMutate, isPending: false, error: null }),
 }));
 
 vi.mock('~/core/responses/use-claim-response-summaries', () => ({
@@ -173,14 +163,11 @@ vi.mock('~/design-system/select-entity-compact', () => ({
 beforeEach(() => {
   claims = [];
   claimsLoading = false;
-  joinPending = false;
   lastQueryEntitiesOptions = null;
   debateClaimsResponse = { claims: [] };
   responseBatchReady = true;
   responseBatchError = false;
   vi.clearAllMocks();
-  mocks.joinMutate.mockReturnValue(new Promise(() => undefined));
-  mocks.leaveMutate.mockReturnValue(new Promise(() => undefined));
   mocks.responseBatchCalls.length = 0;
 });
 

--- a/apps/web/app/space/[id]/(space)/debates/debates-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/debates-page-client.test.tsx
@@ -59,7 +59,6 @@ vi.mock('~/core/debates/hooks', () => ({
   useDebateMedia: () => ({ data: undefined, isLoading: false, isError: false }),
   useDebateTranscript: () => ({ data: { segments: [] }, isLoading: false, error: null }),
   useDebateClaims: () => ({ data: { claims: [] } }),
-  useJoinDebateQueue: () => ({ mutateAsync: vi.fn(), isPending: false }),
   // The feed resolves an anchor by id when the space listing does not contain it (GEO-2764).
   // These tests never anchor, so it stays idle.
   useDebate: () => ({ data: null, isLoading: false, error: null }),

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
@@ -58,13 +58,6 @@ const mocks = vi.hoisted(() => ({
   responseIndexingStatus: null as 'reconciling' | 'delayed' | 'indexed' | null,
   /** Drives the indexing machine's own "taking longer than it should" signal. */
   responseIndexingDelayed: false,
-  setReadiness: vi.fn(),
-  joinQueue: vi.fn((_variables: { spaceId: string; claimId: string }) => Promise.resolve({ claim: null, match: null })),
-  /** Which space each card wired its readiness machine to, in mount order. */
-  joinQueueSpaceIds: [] as string[],
-  leaveQueue: vi.fn((_variables: { spaceId: string; claimId: string }) =>
-    Promise.resolve({ claim: null, match: null })
-  ),
   openSidePanel: vi.fn(),
   /** Every query the All tab handed the hub's claims lookup, in render order. */
   entityQueries: [] as Array<{ search: string | null; spaceIds?: string[] | null; topicIds?: string[] | null }>,
@@ -253,21 +246,6 @@ vi.mock('~/core/debates/hooks', () => ({
     rematchRoot: (accountKey: string | null) => ['debates', 'account', accountKey, 'rematch'] as const,
   },
   useGeoChatAuth: () => ({ ready: true, authenticated: true, accountKey: 'account-a', getPrivyIdentityToken: vi.fn() }),
-  // The card's Debate switch shares the entity page's queue-backed readiness machine.
-  useJoinDebateQueue: (spaceId: string) => {
-    mocks.joinQueueSpaceIds.push(spaceId);
-    return {
-      mutateAsync: (variables: { claimId: string }) => mocks.joinQueue({ spaceId, ...variables }),
-      reset: vi.fn(),
-      isPending: false,
-      error: null,
-    };
-  },
-  useLeaveDebateQueue: (spaceId: string) => ({
-    mutateAsync: (variables: { claimId: string }) => mocks.leaveQueue({ spaceId, ...variables }),
-    isPending: false,
-    error: null,
-  }),
 }));
 
 function rematchClaimsLookup(claimIds: string[]) {
@@ -488,9 +466,7 @@ vi.mock('~/core/hooks/use-entity-vote', () => ({
   useResetEntityResponseIndexingSnapshot: () => vi.fn(),
 }));
 
-// The card's Debate toggle publishes readiness through this.
 vi.mock('~/core/debates/matchmaking/hooks', () => ({
-  useClaimReadiness: () => ({ mutate: mocks.setReadiness, isPending: false, error: null }),
   // The shared position control asks whether this claim has a match, to put the opponent's face on
   // the opposing side. The picker hides its own end slot — a rematch request is a different
   // mutation — so there is never an offer here, and these only have to answer "no".
@@ -690,10 +666,6 @@ beforeEach(() => {
   mocks.claimReadiness = [];
   mocks.claimReadinessLoading = false;
   mocks.claimReadinessError = false;
-  mocks.setReadiness.mockReset();
-  mocks.joinQueue.mockClear();
-  mocks.leaveQueue.mockClear();
-  mocks.joinQueueSpaceIds.length = 0;
   mocks.openSidePanel.mockReset();
   mocks.entityQueries.length = 0;
   mocks.entityIdLookups.length = 0;
@@ -2702,64 +2674,6 @@ describe('DebateRematchPageClient', () => {
     await showOpponentClaims();
 
     expect(mocks.perSpaceReadinessGroups.some(groups => groups.length > 0)).toBe(true);
-  });
-
-  // Taking a side here means you want to debate it, so readiness shouldn't be a second step.
-  // A position can appear without anyone picking one — here because geo-chat's copy of a claim the
-  // viewer had already answered lands after the card is on screen. That looks identical to a fresh
-  // pick, and standing them ready for it reverses a stand-down they made elsewhere.
-  it('does not stand the viewer ready when geo-chat reports a position they already held', async () => {
-    mocks.claims = [
-      {
-        ...sharedClaim(),
-        participants: [
-          { user_id: 'user-local', position: null, position_label: null },
-          { user_id: 'user-remote', position: false, position_label: 'Disagree' },
-        ],
-      },
-    ];
-    const view = render(<DebateRematchPageClient sessionId="rematch-1" />);
-
-    mocks.claims = [
-      {
-        ...sharedClaim(),
-        participants: [
-          { user_id: 'user-local', position: true, position_label: 'Agree' },
-          { user_id: 'user-remote', position: false, position_label: 'Disagree' },
-        ],
-      },
-    ];
-    view.rerender(<DebateRematchPageClient sessionId="rematch-1" />);
-
-    expect(mocks.setReadiness).not.toHaveBeenCalled();
-  });
-
-  // Standing down elsewhere is deliberate; arriving here mustn't quietly reverse it.
-  it('leaves readiness alone for positions already held on arrival', async () => {
-    render(<DebateRematchPageClient sessionId="rematch-1" />);
-
-    expect(mocks.setReadiness).not.toHaveBeenCalled();
-  });
-
-  it('does not re-publish readiness that is already on', async () => {
-    mocks.claims = [
-      {
-        ...sharedClaim(),
-        participants: [
-          { user_id: 'user-local', position: null, position_label: null },
-          { user_id: 'user-remote', position: false, position_label: 'Disagree' },
-        ],
-      },
-    ];
-    mocks.claimReadiness = [
-      { claim_entity_id: CLAIM_SHARED, viewer_debate_ready: true, readiness_disabled_reason: null },
-    ];
-    const { rerender } = render(<DebateRematchPageClient sessionId="rematch-1" />);
-
-    mocks.optimisticResponses.set(CLAIM_SHARED, 'positive');
-    rerender(<DebateRematchPageClient sessionId="rematch-1" />);
-
-    expect(mocks.setReadiness).not.toHaveBeenCalled();
   });
 
   // Waiting for geo-chat to echo the response back would leave the side you just picked

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
@@ -237,8 +237,8 @@ vi.mock('~/core/debates/hooks', () => ({
   useLeaveDebateRematch: () => mutation(mocks.leaveMutate),
   useAcceptDebateRematchRequest: () => mutation(mocks.acceptMutate),
   useRejectDebateRematchRequest: () => mutation(mocks.rejectMutate),
-  // Mirrors the real key factory: the readiness machine refetches these families before it
-  // retries a `claim_response_required`.
+  // Mirrors the real key factory: `vi.mock` replaces the whole module, so every query key read
+  // below this needs one here.
   debateQueryKeys: {
     matchmakingClaimsRoot: (accountKey: string | null) =>
       ['debates', 'account', accountKey, 'matchmaking-claims'] as const,

--- a/apps/web/core/debates/api.ts
+++ b/apps/web/core/debates/api.ts
@@ -1331,7 +1331,10 @@ export async function listMatchmakingMatches(
 
 /*
  * There is no debate-intent endpoint. A position is an on-chain claim response, never something
- * the client sends — `joinDebateQueue` / `leaveDebateQueue` toggle readiness on top of it.
+ * the client sends, and since GEO-2740 readiness follows from holding one: geo-chat writes it from
+ * `notify_claim_response_indexed`. GEO-2813 removed the last readiness switch in the app, so
+ * nothing here calls `joinDebateQueue` / `leaveDebateQueue` any more. They stay as the binding for
+ * endpoints geo-chat still serves, not as something the UI is expected to drive.
  */
 
 export async function listDebateRequests(

--- a/apps/web/core/debates/debate-coordinator.test.tsx
+++ b/apps/web/core/debates/debate-coordinator.test.tsx
@@ -92,7 +92,6 @@ vi.mock('./matchmaking/hooks', () => ({
   useAcceptDebateRequest: () => ({ mutate: mocks.acceptRequestMutate, isPending: false, error: null }),
   useDismissDebateRequest: () => ({ mutate: mocks.dismissRequestMutate, isPending: false, error: null }),
   useBlockDebateUser: () => ({ mutate: mocks.blockUserMutate, isPending: false, error: null }),
-  useClaimReadiness: () => ({ mutate: vi.fn(), isPending: false, error: null }),
 }));
 
 // useSpaceLabels reads the browse sidebar's cache before falling back to the mock below. These

--- a/apps/web/core/debates/debate-request-dialog.tsx
+++ b/apps/web/core/debates/debate-request-dialog.tsx
@@ -50,8 +50,6 @@ type DebateRequestDialogProps = {
   eyebrow?: React.ReactNode;
   /** GEO-2430: a text action beside the "Debate format" heading, e.g. "Dismiss forever". */
   formatAction?: { label: string; onClick: () => void };
-  /** Rendered centred under the claim, e.g. the claim's response control. */
-  headerNote?: React.ReactNode;
   /** GEO-2430: overflow ("…") menu anchored to the participants card, e.g. to block a user. */
   overflowMenu?: React.ReactNode;
 };
@@ -71,7 +69,6 @@ export function DebateRequestDialog({
   actionsLayout = 'stacked',
   eyebrow,
   formatAction,
-  headerNote,
   overflowMenu,
 }: DebateRequestDialogProps) {
   const titleId = React.useId();
@@ -110,7 +107,6 @@ export function DebateRequestDialog({
           <h2 id={titleId} className="mt-3 text-cardEntityTitle leading-[1.375rem]">
             {claim}
           </h2>
-          {headerNote ? <div className="mt-3 flex justify-center">{headerNote}</div> : null}
         </header>
 
         <div className="min-h-0 overflow-y-auto pr-1">

--- a/apps/web/core/debates/hooks.ts
+++ b/apps/web/core/debates/hooks.ts
@@ -48,8 +48,6 @@ import {
   getRecordingUrl,
   getRematchLiveKitToken,
   handleDebateSharePrompt,
-  joinDebateQueue,
-  leaveDebateQueue,
   leaveDebateRematch,
   listDebateClaims,
   listDebateRematchClaims,
@@ -307,44 +305,6 @@ function claimIdHash(claimId: string) {
 export function invalidateDebatesOutsideRematchClaims(queryClient: QueryClient) {
   return queryClient.invalidateQueries({
     predicate: query => query.queryKey[0] === 'debates' && !isRematchClaimsQueryKey(query.queryKey),
-  });
-}
-
-/**
- * Standing ready (or down) on one claim moves that claim's readiness wherever it is listed and
- * re-sorts who is matchable. Nothing else under `'debates'` changes, so only those families go.
- */
-function invalidateAfterReadinessChange(queryClient: QueryClient, accountKey: string | null, claimId: string) {
-  for (const queryKey of [
-    ['debates', 'claims'] as const,
-    debateQueryKeys.matchmakingClaimsRoot(accountKey),
-    debateQueryKeys.matches(accountKey),
-    debateQueryKeys.activity(accountKey),
-  ]) {
-    void queryClient.invalidateQueries({ queryKey });
-  }
-  void refreshRematchClaimBatches(queryClient, rematchClaimBatchesWithClaim(accountKey, claimId));
-}
-
-export function useJoinDebateQueue(spaceId: string) {
-  const queryClient = useQueryClient();
-  const { accountKey, getPrivyIdentityToken } = useGeoChatAuth();
-
-  return useMutation({
-    mutationFn: ({ claimId }: { claimId: string }) =>
-      joinDebateQueue(spaceId, claimId, getPrivyIdentityToken, accountKey),
-    onSuccess: (_result, { claimId }) => invalidateAfterReadinessChange(queryClient, accountKey, claimId),
-  });
-}
-
-export function useLeaveDebateQueue(spaceId: string) {
-  const queryClient = useQueryClient();
-  const { accountKey, getPrivyIdentityToken } = useGeoChatAuth();
-
-  return useMutation({
-    mutationFn: ({ claimId }: { claimId: string }) =>
-      leaveDebateQueue(spaceId, claimId, getPrivyIdentityToken, accountKey),
-    onSuccess: (_result, { claimId }) => invalidateAfterReadinessChange(queryClient, accountKey, claimId),
   });
 }
 

--- a/apps/web/core/debates/matchmaking/claims-tab.test.tsx
+++ b/apps/web/core/debates/matchmaking/claims-tab.test.tsx
@@ -244,11 +244,9 @@ vi.mock('~/core/claims/browse/claim-response-summary', () => ({
   }),
 }));
 
-// The readiness switch rides the shared queue-backed machine, which reaches for geo-chat auth and
-// the join/leave mutations rather than a one-shot readiness mutation.
 vi.mock('../hooks', () => ({
-  // Mirrors the real key factory: the readiness machine refetches these families before it
-  // retries a `claim_response_required`.
+  // Mirrors the real key factory: `vi.mock` replaces the whole module, so every query key read
+  // below this needs one here.
   debateQueryKeys: {
     matchmakingClaimsRoot: (accountKey: string | null) =>
       ['debates', 'account', accountKey, 'matchmaking-claims'] as const,
@@ -419,11 +417,9 @@ vi.mock('~/core/claims/browse/claim-response-summary', () => ({
   }),
 }));
 
-// The readiness switch rides the shared queue-backed machine, which reaches for geo-chat auth and
-// the join/leave mutations rather than a one-shot readiness mutation.
 vi.mock('../hooks', () => ({
-  // Mirrors the real key factory: the readiness machine refetches these families before it
-  // retries a `claim_response_required`.
+  // Mirrors the real key factory: `vi.mock` replaces the whole module, so every query key read
+  // below this needs one here.
   debateQueryKeys: {
     matchmakingClaimsRoot: (accountKey: string | null) =>
       ['debates', 'account', accountKey, 'matchmaking-claims'] as const,

--- a/apps/web/core/debates/matchmaking/claims-tab.test.tsx
+++ b/apps/web/core/debates/matchmaking/claims-tab.test.tsx
@@ -258,8 +258,6 @@ vi.mock('../hooks', () => ({
   useGeoChatAuth: () => ({ ready: true, authenticated: mocks.authenticated, accountKey: mocks.accountKey }),
   // Read by the end slot's match lookup; the tab's tests do not exercise availability.
   useDebateActivity: () => ({ data: null, isLoading: false, error: null }),
-  useJoinDebateQueue: () => ({ mutateAsync: vi.fn(), reset: vi.fn(), isPending: false, error: null }),
-  useLeaveDebateQueue: () => ({ mutateAsync: vi.fn(), isPending: false, error: null }),
   // Featured rows are hydrated by the per-space debate-claims lookup. Records what it was asked
   // for so the suites can assert the tab only asks about spaces it may show.
   useDebateClaimsBySpaces: (groups: Array<{ spaceId: string; claimIds: string[] }>) => {
@@ -435,8 +433,6 @@ vi.mock('../hooks', () => ({
   useGeoChatAuth: () => ({ ready: true, authenticated: mocks.authenticated, accountKey: mocks.accountKey }),
   // Read by the end slot's match lookup; the tab's tests do not exercise availability.
   useDebateActivity: () => ({ data: null, isLoading: false, error: null }),
-  useJoinDebateQueue: () => ({ mutateAsync: vi.fn(), reset: vi.fn(), isPending: false, error: null }),
-  useLeaveDebateQueue: () => ({ mutateAsync: vi.fn(), isPending: false, error: null }),
   // Featured rows are hydrated by the per-space debate-claims lookup. Records what it was asked
   // for so the suites can assert the tab only asks about spaces it may show.
   useDebateClaimsBySpaces: (groups: Array<{ spaceId: string; claimIds: string[] }>) => {

--- a/apps/web/core/debates/matchmaking/debates-hub-panel.test.tsx
+++ b/apps/web/core/debates/matchmaking/debates-hub-panel.test.tsx
@@ -50,7 +50,6 @@ vi.mock('./hooks', () => ({
   }),
   useMatchmakingClaims: () => ({ data: undefined, isLoading: false, error: null, hasNextPage: false }),
   useMatchmakingMatches: () => ({ data: { matches: [] }, isLoading: false, error: null }),
-  useClaimReadiness: () => ({ mutate: vi.fn(), isPending: false, error: null }),
   useCreateDebateRequest: () => ({ mutate: vi.fn(), isPending: false, error: null }),
   useWithdrawDebateRequest: () => ({ mutate: vi.fn(), isPending: false, error: null }),
   useAcceptDebateRequest: () => ({ mutate: vi.fn(), isPending: false, error: null }),

--- a/apps/web/core/debates/matchmaking/hooks.test.tsx
+++ b/apps/web/core/debates/matchmaking/hooks.test.tsx
@@ -7,12 +7,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { Debate } from '../api';
 import { clearEnteringDebate, useEnteringDebateId } from '../debate-entry-intent';
-import { useAcceptDebateRequest, useClaimReadiness } from './hooks';
+import { useAcceptDebateRequest } from './hooks';
 
 const mocks = vi.hoisted(() => ({
   push: vi.fn(),
   acceptDebateRequest: vi.fn(),
-  joinDebateQueue: vi.fn(),
 }));
 
 vi.mock('next/navigation', () => ({
@@ -21,7 +20,7 @@ vi.mock('next/navigation', () => ({
 
 vi.mock('../api', async importOriginal => {
   const actual = await importOriginal<typeof import('../api')>();
-  return { ...actual, acceptDebateRequest: mocks.acceptDebateRequest, joinDebateQueue: mocks.joinDebateQueue };
+  return { ...actual, acceptDebateRequest: mocks.acceptDebateRequest };
 });
 
 vi.mock('../hooks', async importOriginal => {
@@ -49,7 +48,6 @@ function wrapper({ children }: { children: ReactNode }) {
 beforeEach(() => {
   mocks.push.mockReset();
   mocks.acceptDebateRequest.mockReset();
-  mocks.joinDebateQueue.mockReset();
   clearEnteringDebate();
 });
 
@@ -85,67 +83,5 @@ describe('useAcceptDebateRequest', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(mocks.push).not.toHaveBeenCalled();
-  });
-});
-
-describe('useClaimReadiness', () => {
-  // Readiness is keyed (space, claim) server-side and the Claims tab is cross-space, so the same
-  // claim entity can hold two rows with different readiness.
-  it('moves only the switch for the space it was told about', async () => {
-    mocks.joinDebateQueue.mockResolvedValue({ claim: { id: 'claim-row-1' }, match: null });
-    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-    const key = ['debates', 'account', 'user-a', 'matchmaking-claims', { filter: 'all' }];
-    queryClient.setQueryData(key, {
-      pages: [
-        {
-          claims: [
-            { claim: { space_id: 'space-1', claim_entity_id: 'claim-1' }, viewer_debate_ready: false },
-            { claim: { space_id: 'space-2', claim_entity_id: 'claim-1' }, viewer_debate_ready: false },
-          ],
-        },
-      ],
-    });
-
-    const { result } = renderHook(() => useClaimReadiness(), {
-      wrapper: ({ children }: { children: ReactNode }) => (
-        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-      ),
-    });
-    result.current.mutate({ spaceId: 'space-1', claimId: 'claim-1', ready: true });
-
-    await waitFor(() => {
-      const claims = (queryClient.getQueryData(key) as { pages: { claims: { viewer_debate_ready: boolean }[] }[] })
-        .pages[0]!.claims;
-      expect(claims[0]!.viewer_debate_ready).toBe(true);
-      expect(claims[1]!.viewer_debate_ready).toBe(false);
-    });
-  });
-
-  // The rematch picker reads readiness from the per-space claims family, which keys the ids on the
-  // entry rather than nesting them under `claim`. Missing it left that toggle unmoved on click.
-  it('moves the switch in the per-space claims family too', async () => {
-    mocks.joinDebateQueue.mockResolvedValue({ claim: { id: 'claim-row-1' }, match: null });
-    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-    const key = ['debates', 'claims', 'space-1', ['claim-1']];
-    queryClient.setQueryData(key, {
-      claims: [
-        { space_id: 'space-1', claim_entity_id: 'claim-1', viewer_debate_ready: false },
-        { space_id: 'space-2', claim_entity_id: 'claim-1', viewer_debate_ready: false },
-      ],
-    });
-
-    const { result } = renderHook(() => useClaimReadiness(), {
-      wrapper: ({ children }: { children: ReactNode }) => (
-        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-      ),
-    });
-    result.current.mutate({ spaceId: 'space-1', claimId: 'claim-1', ready: true });
-
-    await waitFor(() => {
-      const claims = (queryClient.getQueryData(key) as { claims: { viewer_debate_ready: boolean }[] }).claims;
-      expect(claims[0]!.viewer_debate_ready).toBe(true);
-      // Same claim entity in another space keeps its own switch.
-      expect(claims[1]!.viewer_debate_ready).toBe(false);
-    });
   });
 });

--- a/apps/web/core/debates/matchmaking/hooks.ts
+++ b/apps/web/core/debates/matchmaking/hooks.ts
@@ -12,8 +12,6 @@ import {
   blockDebateUser,
   createDebateRequest,
   dismissDebateRequest,
-  joinDebateQueue,
-  leaveDebateQueue,
   listDebateBlocks,
   listDebatePeople,
   listDebateRequests,
@@ -150,120 +148,6 @@ export function useDebateBlocks(enabled: boolean) {
     queryFn: ({ signal }) => listDebateBlocks(getPrivyIdentityToken, accountKey, signal),
     enabled: enabled && authenticated,
   });
-}
-
-/**
- * Readiness for one claim. A position is an on-chain claim response, so the hub can only turn
- * readiness on (the server requires an indexed active response) or off — it never sends a side.
- * Both directions are the plain queue endpoints, keyed per claim so cards can pass their own space.
- */
-/**
- * Every cached family that carries `viewer_debate_ready`, so the switch moves in whichever surface
- * the viewer is looking at. `['debates', 'claims']` is the per-space family the rematch picker
- * reads; leaving it out left that toggle unmoved until the settle refetch landed.
- */
-const READINESS_FAMILIES = (accountKey: string | null) =>
-  [
-    debateQueryKeys.matchmakingClaimsRoot(accountKey),
-    debateQueryKeys.matches(accountKey),
-    ['debates', 'claims'],
-  ] as const;
-
-export function useClaimReadiness() {
-  const queryClient = useQueryClient();
-  const { accountKey, getPrivyIdentityToken } = useGeoChatAuth();
-
-  return useMutation({
-    mutationFn: ({ spaceId, claimId, ready }: { spaceId: string; claimId: string; ready: boolean }) =>
-      ready
-        ? joinDebateQueue(spaceId, claimId, getPrivyIdentityToken, accountKey)
-        : leaveDebateQueue(spaceId, claimId, getPrivyIdentityToken, accountKey),
-    // The switch moves now rather than a round trip and a refetch later, mirroring the
-    // availability switch in the panel header.
-    onMutate: async ({ spaceId, claimId, ready }) => {
-      const families = READINESS_FAMILIES(accountKey);
-      await Promise.all(families.map(queryKey => queryClient.cancelQueries({ queryKey })));
-      for (const queryKey of families) {
-        queryClient.setQueriesData({ queryKey }, (current: unknown) =>
-          patchClaimReadiness(current, spaceId, claimId, ready)
-        );
-      }
-    },
-    // Undo just this claim rather than restoring a snapshot of both families: every card holds its
-    // own copy of this mutation, so a snapshot rollback would also revert a toggle on another claim
-    // and any gateway refetch that landed in between.
-    onError: (_error, { spaceId, claimId, ready }) => {
-      for (const queryKey of READINESS_FAMILIES(accountKey)) {
-        queryClient.setQueriesData({ queryKey }, (current: unknown) =>
-          patchClaimReadiness(current, spaceId, claimId, !ready)
-        );
-      }
-    },
-    // Readiness changes who is matchable, so let the server re-sort — but only the families it
-    // actually affects, rather than every debate query.
-    onSettled: () => {
-      for (const queryKey of [
-        debateQueryKeys.matchmakingClaimsRoot(accountKey),
-        debateQueryKeys.matches(accountKey),
-        debateQueryKeys.activity(accountKey),
-        ['debates', 'claims'] as const,
-      ]) {
-        void queryClient.invalidateQueries({ queryKey });
-      }
-    },
-  });
-}
-
-/**
- * Flips `viewer_debate_ready` on one claim wherever it appears, in both the flat matches response
- * and the paged claims response. Anything else is returned untouched.
- *
- * Readiness is per (space, claim): geo-chat keys it on `(public_dao_space_id, claim_entity_id)`,
- * and the Claims tab is cross-space, so the same claim entity can hold two rows with different
- * readiness. Matching on the entity alone would move both switches for one round trip.
- */
-function patchClaimReadiness(data: unknown, spaceId: string, claimId: string, ready: boolean): unknown {
-  const patchOne = <T extends { claim: { space_id: string; claim_entity_id: string }; viewer_debate_ready: boolean }>(
-    entry: T
-  ) =>
-    entry.claim.claim_entity_id === claimId && entry.claim.space_id === spaceId
-      ? { ...entry, viewer_debate_ready: ready }
-      : entry;
-
-  if (!data || typeof data !== 'object') return data;
-
-  // The per-space family (`DebateClaimsResponse`) keys the ids on the entry itself rather than
-  // nesting them under `claim`, so it needs its own matcher.
-  const patchFlat = <T extends { space_id: string; claim_entity_id: string; viewer_debate_ready: boolean }>(
-    entry: T
-  ) =>
-    entry.claim_entity_id === claimId && entry.space_id === spaceId ? { ...entry, viewer_debate_ready: ready } : entry;
-
-  if ('matches' in data && Array.isArray(data.matches)) {
-    return { ...data, matches: data.matches.map(patchOne) };
-  }
-
-  if ('claims' in data && Array.isArray(data.claims)) {
-    return {
-      ...data,
-      claims: data.claims.map((entry: unknown) =>
-        entry && typeof entry === 'object' && 'claim_entity_id' in entry ? patchFlat(entry as never) : entry
-      ),
-    };
-  }
-
-  if ('pages' in data && Array.isArray(data.pages)) {
-    return {
-      ...data,
-      pages: data.pages.map((page: unknown) =>
-        page && typeof page === 'object' && 'claims' in page && Array.isArray(page.claims)
-          ? { ...page, claims: page.claims.map(patchOne) }
-          : page
-      ),
-    };
-  }
-
-  return data;
 }
 
 export function useCreateDebateRequest() {

--- a/apps/web/core/debates/matchmaking/incoming-request-card.tsx
+++ b/apps/web/core/debates/matchmaking/incoming-request-card.tsx
@@ -15,6 +15,7 @@ import { HubPillButton } from './hub-pill-button';
 import { SpaceChip } from './matchmaking-claim-card';
 import { RequestOverflowMenu } from './request-overflow-menu';
 import { RequestParties } from './request-parties';
+import { useAnswerOnce } from './use-answer-once';
 import { useRequestCountdown } from './use-request-countdown';
 
 /**
@@ -33,14 +34,7 @@ export function IncomingRequestCard({ request, ref }: { request: DebateRequest; 
 
   const busy = acceptRequest.isPending || dismissRequest.isPending || blockUser.isPending;
   const unavailable = request.requester.in_debate;
-  // `isPending` only disables the button on the *next* render, so a double tap gets two accepts in
-  // before it takes effect — and the second one 409s over a request the first already took.
-  const answered = React.useRef(false);
-  const answerOnce = (answer: () => void) => {
-    if (answered.current) return;
-    answered.current = true;
-    answer();
-  };
+  const { answerOnce } = useAnswerOnce();
 
   return (
     // Expiry is owned by the list (`useUnexpiredRequests`) rather than this card, so the card can

--- a/apps/web/core/debates/matchmaking/incoming-request-card.tsx
+++ b/apps/web/core/debates/matchmaking/incoming-request-card.tsx
@@ -65,10 +65,17 @@ export function IncomingRequestCard({ request, ref }: { request: DebateRequest; 
           <RequestOverflowMenu
             actions={[
               {
+                // Guarded like the buttons: this is the same dismiss endpoint they use, so an
+                // answer already taken would 409 here.
                 label: "I don't want to debate this claim",
-                onClick: () => dismissRequest.mutate({ requestId: request.id, removeIntent: true }),
+                onClick: () =>
+                  answerOnce(() => dismissRequest.mutate({ requestId: request.id, removeIntent: true }, releaseAnswer)),
               },
               {
+                // Deliberately outside the guard. Blocking writes the viewer's block list
+                // (`PUT /me/debate-blocks/{userId}`) rather than answering this request, so it
+                // cannot collide with one — and gating it would let an answer already taken
+                // swallow a safety action, which is the worse failure by far.
                 label: `Block ${speakerLabel(request.requester)}`,
                 destructive: true,
                 onClick: () => blockUser.mutate(request.requester.user_id),

--- a/apps/web/core/debates/matchmaking/incoming-request-card.tsx
+++ b/apps/web/core/debates/matchmaking/incoming-request-card.tsx
@@ -34,7 +34,7 @@ export function IncomingRequestCard({ request, ref }: { request: DebateRequest; 
 
   const busy = acceptRequest.isPending || dismissRequest.isPending || blockUser.isPending;
   const unavailable = request.requester.in_debate;
-  const { answerOnce } = useAnswerOnce();
+  const { answerOnce, releaseAnswer } = useAnswerOnce();
 
   return (
     // Expiry is owned by the list (`useUnexpiredRequests`) rather than this card, so the card can
@@ -86,7 +86,7 @@ export function IncomingRequestCard({ request, ref }: { request: DebateRequest; 
 
       <div className="grid grid-cols-2 gap-2">
         <HubPillButton
-          onClick={() => answerOnce(() => dismissRequest.mutate({ requestId: request.id }))}
+          onClick={() => answerOnce(() => dismissRequest.mutate({ requestId: request.id }, releaseAnswer))}
           disabled={busy}
           pending={dismissRequest.isPending}
           pendingLabel="Dismissing…"
@@ -95,7 +95,7 @@ export function IncomingRequestCard({ request, ref }: { request: DebateRequest; 
         </HubPillButton>
         <HubPillButton
           variant="primary"
-          onClick={() => answerOnce(() => acceptRequest.mutate({ requestId: request.id }))}
+          onClick={() => answerOnce(() => acceptRequest.mutate({ requestId: request.id }, releaseAnswer))}
           disabled={busy || unavailable}
           pending={acceptRequest.isPending}
           pendingLabel="Accepting…"

--- a/apps/web/core/debates/matchmaking/incoming-request-popup.test.tsx
+++ b/apps/web/core/debates/matchmaking/incoming-request-popup.test.tsx
@@ -11,8 +11,6 @@ const mocks = vi.hoisted(() => ({
   dismiss: vi.fn(),
   dismissIsError: false,
   block: vi.fn(),
-  setReadiness: vi.fn(),
-  readinessIsError: false,
 }));
 
 vi.mock('./hooks', () => ({
@@ -24,12 +22,6 @@ vi.mock('./hooks', () => ({
     error: mocks.dismissIsError ? new Error('nope') : null,
   }),
   useBlockDebateUser: () => ({ mutate: mocks.block, isPending: false, isError: false, error: null }),
-  useClaimReadiness: () => ({
-    mutate: mocks.setReadiness,
-    isPending: false,
-    isError: mocks.readinessIsError,
-    error: mocks.readinessIsError ? new Error('queue down') : null,
-  }),
 }));
 
 // useSpaceLabels reads the browse sidebar's cache before falling back to the mock below. These
@@ -92,11 +84,6 @@ beforeEach(() => {
   mocks.dismiss.mockReset();
   mocks.dismissIsError = false;
   mocks.block.mockReset();
-  mocks.setReadiness.mockReset();
-  mocks.readinessIsError = false;
-  // The dismissal is chained off leaving the queue, so the default mock has to succeed the way
-  // react-query does or nothing downstream of it ever runs.
-  mocks.setReadiness.mockImplementation((_variables, options) => options?.onSuccess?.());
 
   // Radix popovers measure their content; jsdom ships neither observer.
   window.ResizeObserver ??= class {
@@ -140,37 +127,23 @@ describe('IncomingRequestPopup', () => {
     expect(mocks.dismiss).toHaveBeenCalledWith({ requestId: 'request-1', removeIntent: true }, expect.anything());
   });
 
-  // Saying you don't want to debate the claim answers this request too: leaving it pending would
-  // offer a debate the viewer just declined, and hold the requester waiting on someone who has
-  // stood down. Dismissing with the intent removed does both, and the server clears the request
-  // for the requester as well.
-  it('rejects the request when the viewer turns the claim toggle off', () => {
+  // GEO-2813 removed the "Debate this claim" switch, which was the only control here that stood the
+  // viewer down on the claim itself. Readiness now follows from holding a position, so dismissing
+  // answers the request and drops the intent, and nothing in the client writes readiness.
+  it('offers no readiness switch', () => {
     renderPopup();
 
-    const toggle = screen.getByRole('switch', { name: 'Debate this claim' });
-    expect(toggle).toHaveAttribute('aria-checked', 'true');
-
-    fireEvent.click(toggle);
-
-    expect(mocks.dismiss).toHaveBeenCalledWith({ requestId: 'request-1', removeIntent: true }, expect.anything());
-    // And leave the claim's queue: dismissing answers this request, but only leaving the queue
-    // takes the viewer out of everyone else's matches for the claim.
-    expect(mocks.setReadiness).toHaveBeenCalledWith(
-      { spaceId: 'space-1', claimId: 'claim-1', ready: false },
-      expect.anything()
-    );
-    expect(mocks.accept).not.toHaveBeenCalled();
+    expect(screen.queryByRole('switch')).not.toBeInTheDocument();
   });
 
-  it('answers once however fast the toggle is tapped', () => {
+  it('answers once however fast the dismissal is tapped', () => {
     renderPopup();
 
-    const toggle = screen.getByRole('switch', { name: 'Debate this claim' });
-    fireEvent.click(toggle);
-    fireEvent.click(toggle);
+    const dismiss = screen.getByRole('button', { name: 'Dismiss forever' });
+    fireEvent.click(dismiss);
+    fireEvent.click(dismiss);
 
     expect(mocks.dismiss).toHaveBeenCalledTimes(1);
-    expect(mocks.setReadiness).toHaveBeenCalledTimes(1);
   });
 
   it('offers blocking behind the overflow menu', () => {
@@ -195,22 +168,6 @@ describe('IncomingRequestPopup answers', () => {
     expect(mocks.accept).toHaveBeenCalledTimes(1);
   });
 
-  // Otherwise the switch reads as "you are out of matchmaking for this claim" while the server
-  // still has the viewer standing ready and the request live. Starting in the error state would
-  // never move the switch off, so this walks the real sequence: off on the press, back on when the
-  // rejection comes back failed.
-  it('puts the claim toggle back when the rejection fails', () => {
-    const view = render(<IncomingRequestPopup request={request} currentUserId="user-me" onNotNow={vi.fn()} />);
-
-    fireEvent.click(screen.getByRole('switch', { name: 'Debate this claim' }));
-    expect(screen.getByRole('switch', { name: 'Debate this claim' })).toHaveAttribute('aria-checked', 'false');
-
-    mocks.dismissIsError = true;
-    view.rerender(<IncomingRequestPopup request={request} currentUserId="user-me" onNotNow={vi.fn()} />);
-
-    expect(screen.getByRole('switch', { name: 'Debate this claim' })).toHaveAttribute('aria-checked', 'true');
-  });
-
   // The controls come back after a failure, so the press that follows has to land — otherwise the
   // request can never be answered from this popup again.
   it('lets the viewer answer again after a failed answer', () => {
@@ -221,48 +178,24 @@ describe('IncomingRequestPopup answers', () => {
     });
     const view = render(<IncomingRequestPopup request={request} currentUserId="user-me" onNotNow={vi.fn()} />);
 
-    fireEvent.click(screen.getByRole('switch', { name: 'Debate this claim' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss forever' }));
     expect(mocks.dismiss).toHaveBeenCalledTimes(1);
 
     view.rerender(<IncomingRequestPopup request={request} currentUserId="user-me" onNotNow={vi.fn()} />);
-    fireEvent.click(screen.getByRole('switch', { name: 'Debate this claim' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss forever' }));
 
     expect(mocks.dismiss).toHaveBeenCalledTimes(2);
   });
 
-  // The two calls can fail independently and no endpoint does both. Dismissing first would close
-  // the popup on a viewer who is still in the queue — matchable on a claim they just declined, with
-  // nothing left to retry from. Leaving the queue first keeps the failure recoverable.
-  it('does not dismiss the request when leaving the claim queue fails', () => {
-    mocks.setReadiness.mockImplementation((_variables, options) => {
-      mocks.readinessIsError = true;
-      options?.onError?.(new Error('queue down'));
-    });
-    const view = render(<IncomingRequestPopup request={request} currentUserId="user-me" onNotNow={vi.fn()} />);
-
-    fireEvent.click(screen.getByRole('switch', { name: 'Debate this claim' }));
-
-    expect(mocks.dismiss).not.toHaveBeenCalled();
-
-    // The request is still live, so the switch has to come back and the next press has to land.
-    view.rerender(<IncomingRequestPopup request={request} currentUserId="user-me" onNotNow={vi.fn()} />);
-    expect(screen.getByRole('switch', { name: 'Debate this claim' })).toHaveAttribute('aria-checked', 'true');
-
-    fireEvent.click(screen.getByRole('switch', { name: 'Debate this claim' }));
-    expect(mocks.setReadiness).toHaveBeenCalledTimes(2);
-  });
-
-  // The switch moves on press rather than on the response, so it has to check that the press was
-  // actually taken: accepting first consumes the answer, and a failed accept would otherwise leave
-  // the switch off with no stand-down behind it.
-  it('leaves the claim toggle alone when the request was already answered', () => {
+  // Accepting consumes the answer, so a dismissal landing behind it would answer a request the
+  // server has already taken — the second call 409s over the first.
+  it('ignores a dismissal once the request was already answered', () => {
     render(<IncomingRequestPopup request={request} currentUserId="user-me" onNotNow={vi.fn()} />);
 
     fireEvent.click(screen.getByRole('button', { name: 'Accept' }));
-    fireEvent.click(screen.getByRole('switch', { name: 'Debate this claim' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss forever' }));
 
-    expect(mocks.setReadiness).not.toHaveBeenCalled();
+    expect(mocks.accept).toHaveBeenCalledTimes(1);
     expect(mocks.dismiss).not.toHaveBeenCalled();
-    expect(screen.getByRole('switch', { name: 'Debate this claim' })).toHaveAttribute('aria-checked', 'true');
   });
 });

--- a/apps/web/core/debates/matchmaking/incoming-request-popup.tsx
+++ b/apps/web/core/debates/matchmaking/incoming-request-popup.tsx
@@ -73,6 +73,10 @@ export function IncomingRequestPopup({
         <RequestOverflowMenu
           actions={[
             {
+              // Deliberately outside the answer guard. Blocking writes the viewer's block list
+              // (`PUT /me/debate-blocks/{userId}`) rather than answering this request, so it
+              // cannot collide with one — and gating it would let an answer already taken swallow
+              // a safety action, which is the worse failure by far.
               label: `Block ${speakerLabel(request.requester)}`,
               destructive: true,
               onClick: () => blockUser.mutate(request.requester.user_id),

--- a/apps/web/core/debates/matchmaking/incoming-request-popup.tsx
+++ b/apps/web/core/debates/matchmaking/incoming-request-popup.tsx
@@ -2,12 +2,10 @@
 
 import * as React from 'react';
 
-import { Toggle } from '~/design-system/toggle';
-
 import type { DebateRequest, DebateRequestParty } from '../api';
 import { DebateRequestDialog, type DebateRequestDialogParticipant } from '../debate-request-dialog';
 import { speakerLabel } from '../playback-utils';
-import { useAcceptDebateRequest, useBlockDebateUser, useClaimReadiness, useDismissDebateRequest } from './hooks';
+import { useAcceptDebateRequest, useBlockDebateUser, useDismissDebateRequest } from './hooks';
 import { SpaceChip } from './matchmaking-claim-card';
 import { RequestOverflowMenu } from './request-overflow-menu';
 
@@ -18,9 +16,6 @@ import { RequestOverflowMenu } from './request-overflow-menu';
  * - Not now → local only. The request stays live in the hub's Requests tab, under "Received",
  *   until it expires 25 minutes after it was sent.
  * - "Dismiss forever" → dismisses and drops the viewer's intent for that claim.
- * - "Debate this claim" off → the same thing. Saying you don't want to debate the claim answers
- *   this request too: leaving it pending would offer a debate the viewer just declined, and hold
- *   the requester waiting on someone who has stood down.
  * - Block → dismisses and hides both users from each other's matchmaking.
  *
  * Dismissing (unlike "Not now") lets the server advance the request to the next candidate.
@@ -36,7 +31,6 @@ export function IncomingRequestPopup({
 }) {
   const acceptRequest = useAcceptDebateRequest();
   const dismissRequest = useDismissDebateRequest();
-  const setReadiness = useClaimReadiness();
   const blockUser = useBlockDebateUser();
 
   const participants = React.useMemo<DebateRequestDialogParticipant[]>(
@@ -44,25 +38,22 @@ export function IncomingRequestPopup({
     [request.recipient, request.requester]
   );
 
-  const busy = acceptRequest.isPending || dismissRequest.isPending || setReadiness.isPending || blockUser.isPending;
-  const error = [acceptRequest.error, dismissRequest.error, setReadiness.error, blockUser.error].find(
+  const busy = acceptRequest.isPending || dismissRequest.isPending || blockUser.isPending;
+  const error = [acceptRequest.error, dismissRequest.error, blockUser.error].find(
     (candidate): candidate is Error => candidate instanceof Error
   );
   // `isPending` only disables the buttons on the *next* render, so a double tap gets two answers in
   // before it takes effect — and the second one 409s over a request the first already took.
   const answered = React.useRef(false);
-  // Reports whether the answer was taken, so a control that also moves on press (the switch) can
-  // stay put when the guard turned it down instead of showing an answer that never happened.
   const answerOnce = (answer: () => void) => {
-    if (answered.current) return false;
+    if (answered.current) return;
     answered.current = true;
     answer();
-    return true;
   };
   // A failed answer has to give the guard back, or the request is unanswerable from this popup for
-  // the rest of its life: the controls re-enable and the switch returns, but every press after that
-  // is swallowed. Pass it to each mutation rather than watching an error flag, so it fires on the
-  // attempt that actually failed however many follow it.
+  // the rest of its life: the controls re-enable, but every press after that is swallowed. Pass it
+  // to each mutation rather than watching an error flag, so it fires on the attempt that actually
+  // failed however many follow it.
   const releaseAnswer = { onError: () => void (answered.current = false) };
 
   return (
@@ -89,44 +80,6 @@ export function IncomingRequestPopup({
         onClick: () =>
           answerOnce(() => dismissRequest.mutate({ requestId: request.id, removeIntent: true }, releaseAnswer)),
       }}
-      headerNote={
-        <ClaimDebateToggle
-          disabled={busy}
-          failed={Boolean(dismissRequest.isError || setReadiness.isError)}
-          onStandDown={() =>
-            answerOnce(() => {
-              // Two calls because they undo two different things. The dismiss answers *this*
-              // request, for both parties. Leaving the queue is what takes the viewer out of
-              // matchmaking on the claim — `remove_intent` alone left them standing as a match in
-              // everyone else's list, still offered for debates they had just declined.
-              //
-              // Chained, not fired side by side, because the two can fail independently and there
-              // is no single endpoint that does both. Dismissing first and failing to leave the
-              // queue is the unrecoverable order: the dismissal closes this popup, so the viewer
-              // never learns they are still matchable and has nothing left to retry from. Leaving
-              // the queue first fails safe instead — the request stays pending, the switch comes
-              // back on, and pressing it again re-runs both.
-              setReadiness.mutate(
-                {
-                  spaceId: request.claim.space_id,
-                  claimId: request.claim.claim_entity_id,
-                  ready: false,
-                },
-                {
-                  ...releaseAnswer,
-                  // remove_intent is the variant behind "I don't want to debate this claim", which
-                  // is what this switch says. (Sending a plain dismiss instead was tried while
-                  // chasing a requester-side "nobody holding the opposite position is available"
-                  // error and made no difference, so the exclusion comes from the dismissal itself,
-                  // not this flag.)
-                  onSuccess: () =>
-                    dismissRequest.mutate({ requestId: request.id, removeIntent: true }, releaseAnswer),
-                }
-              );
-            })
-          }
-        />
-      }
       overflowMenu={
         <RequestOverflowMenu
           actions={[
@@ -139,57 +92,6 @@ export function IncomingRequestPopup({
         />
       }
     />
-  );
-}
-
-/**
- * Readiness for the claim this request is about. You only received the request because you were
- * standing ready on the claim, so it starts on — turning it off withdraws you from the claim and
- * answers this request with it, the same way "Dismiss forever" does. The popup then closes on its
- * own: the coordinator only prompts for requests that are still pending.
- */
-function ClaimDebateToggle({
-  disabled,
-  failed,
-  onStandDown,
-}: {
-  disabled: boolean;
-  failed: boolean;
-  /** Returns false when the request was already answered, e.g. Accept is mid-flight. */
-  onStandDown: () => boolean;
-}) {
-  const [standDownRequested, setStandDownRequested] = React.useState(false);
-
-  // Derived rather than mirrored with an effect: the switch has to move before the round trip (the
-  // popup is about to close, so waiting reads as unanswered) but go back if the rejection fails —
-  // otherwise it says "you are out of matchmaking for this claim" while the server still has the
-  // viewer standing ready and the request live. An effect watching `failed` only fires on the
-  // transition, so it misses a mutation that was already in an error state.
-  const ready = !standDownRequested || failed;
-
-  // Only move the switch if the press actually answered the request. Accepting and then hitting
-  // this before the popup closes used to turn it off over an accept that was still going through,
-  // and a failed accept then left it off with no stand-down behind it.
-  const toggle = () => {
-    if (!ready) return;
-    if (onStandDown()) setStandDownRequested(true);
-  };
-
-  return (
-    <div className="flex flex-col items-center gap-1">
-      <button
-        type="button"
-        role="switch"
-        aria-checked={ready}
-        aria-label="Debate this claim"
-        disabled={disabled}
-        onClick={toggle}
-        className="flex items-center gap-2 text-[15px] leading-[14px] font-medium tracking-[-0.25px] text-grey-04 transition-colors hover:text-text disabled:opacity-50"
-      >
-        <Toggle checked={ready} className="shrink-0" />
-        <span>Debate this claim</span>
-      </button>
-    </div>
   );
 }
 

--- a/apps/web/core/debates/matchmaking/incoming-request-popup.tsx
+++ b/apps/web/core/debates/matchmaking/incoming-request-popup.tsx
@@ -8,6 +8,7 @@ import { speakerLabel } from '../playback-utils';
 import { useAcceptDebateRequest, useBlockDebateUser, useDismissDebateRequest } from './hooks';
 import { SpaceChip } from './matchmaking-claim-card';
 import { RequestOverflowMenu } from './request-overflow-menu';
+import { useAnswerOnce } from './use-answer-once';
 
 /**
  * GEO-2430. The popup a recipient sees the moment a request arrives:
@@ -42,19 +43,7 @@ export function IncomingRequestPopup({
   const error = [acceptRequest.error, dismissRequest.error, blockUser.error].find(
     (candidate): candidate is Error => candidate instanceof Error
   );
-  // `isPending` only disables the buttons on the *next* render, so a double tap gets two answers in
-  // before it takes effect — and the second one 409s over a request the first already took.
-  const answered = React.useRef(false);
-  const answerOnce = (answer: () => void) => {
-    if (answered.current) return;
-    answered.current = true;
-    answer();
-  };
-  // A failed answer has to give the guard back, or the request is unanswerable from this popup for
-  // the rest of its life: the controls re-enable, but every press after that is swallowed. Pass it
-  // to each mutation rather than watching an error flag, so it fires on the attempt that actually
-  // failed however many follow it.
-  const releaseAnswer = { onError: () => void (answered.current = false) };
+  const { answerOnce, releaseAnswer } = useAnswerOnce();
 
   return (
     <DebateRequestDialog

--- a/apps/web/core/debates/matchmaking/matches-tab.test.tsx
+++ b/apps/web/core/debates/matchmaking/matches-tab.test.tsx
@@ -28,9 +28,8 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock('../hooks', () => ({
   useDebateActivity: () => ({ data: { outbound_request: null, available_to_debate: mocks.availableToDebate } }),
-  // The readiness switch rides the shared queue-backed machine rather than a one-shot mutation.
-  // Mirrors the real key factory: the readiness machine refetches these families before it
-  // retries a `claim_response_required`.
+  // Mirrors the real key factory: `vi.mock` replaces the whole module, so every query key read
+  // below this needs one here.
   debateQueryKeys: {
     matchmakingClaimsRoot: (accountKey: string | null) =>
       ['debates', 'account', accountKey, 'matchmaking-claims'] as const,

--- a/apps/web/core/debates/matchmaking/matches-tab.test.tsx
+++ b/apps/web/core/debates/matchmaking/matches-tab.test.tsx
@@ -12,8 +12,6 @@ import { MatchesTab } from './matches-tab';
 const mocks = vi.hoisted(() => ({
   matches: [] as MatchmakingMatch[],
   outbound: null as unknown,
-  joinMutateAsync: vi.fn(),
-  leaveMutateAsync: vi.fn(),
   createRequestMutate: vi.fn(),
   submitResponse: vi.fn(),
   indexing: { status: 'idle', pending: null, runId: null } as {
@@ -40,8 +38,6 @@ vi.mock('../hooks', () => ({
     rematchRoot: (accountKey: string | null) => ['debates', 'account', accountKey, 'rematch'] as const,
   },
   useGeoChatAuth: () => ({ ready: true, authenticated: true, accountKey: 'account-1' }),
-  useJoinDebateQueue: () => ({ mutateAsync: mocks.joinMutateAsync, reset: vi.fn(), isPending: false, error: null }),
-  useLeaveDebateQueue: () => ({ mutateAsync: mocks.leaveMutateAsync, isPending: false, error: null }),
 }));
 
 vi.mock('./hooks', () => ({
@@ -158,10 +154,6 @@ function match(overrides: Partial<MatchmakingMatch> = {}): MatchmakingMatch {
 beforeEach(() => {
   mocks.matches = [match()];
   mocks.outbound = null;
-  mocks.joinMutateAsync.mockReset();
-  mocks.joinMutateAsync.mockResolvedValue({ claim: null, match: null });
-  mocks.leaveMutateAsync.mockReset();
-  mocks.leaveMutateAsync.mockResolvedValue({ claim: null, match: null });
   mocks.createRequestMutate.mockReset();
   mocks.submitResponse.mockReset();
   mocks.indexing = { status: 'idle', pending: null, runId: null };

--- a/apps/web/core/debates/matchmaking/matchmaking-claim-card.test.tsx
+++ b/apps/web/core/debates/matchmaking/matchmaking-claim-card.test.tsx
@@ -13,8 +13,6 @@ import { MatchmakingClaimCard } from './matchmaking-claim-card';
 // refuses to touch the graph for anything else. The space id is hoisted because `vi.mock` factories
 // are lifted above every module-level declaration, so a mock that reads it can't use a plain const.
 const mocks = vi.hoisted(() => ({
-  joinMutateAsync: vi.fn(),
-  leaveMutateAsync: vi.fn(),
   submitResponse: vi.fn(),
   indexing: { status: 'idle', pending: null, runId: null } as {
     status: 'idle' | 'reconciling' | 'delayed' | 'indexed';
@@ -45,8 +43,6 @@ vi.mock('../hooks', () => ({
     rematchRoot: (accountKey: string | null) => ['debates', 'account', accountKey, 'rematch'] as const,
   },
   useGeoChatAuth: () => ({ ready: true, authenticated: true, accountKey: 'account-1' }),
-  useJoinDebateQueue: () => ({ mutateAsync: mocks.joinMutateAsync, reset: vi.fn(), isPending: false, error: null }),
-  useLeaveDebateQueue: () => ({ mutateAsync: mocks.leaveMutateAsync, isPending: false, error: null }),
 }));
 
 // The end slot asks the hub whether there is a debate to be had. That is one shared query at
@@ -204,10 +200,6 @@ function renderCard(card: ReactElement) {
 }
 
 beforeEach(() => {
-  mocks.joinMutateAsync.mockReset();
-  mocks.joinMutateAsync.mockResolvedValue({ claim: null, match: null });
-  mocks.leaveMutateAsync.mockReset();
-  mocks.leaveMutateAsync.mockResolvedValue({ claim: null, match: null });
   mocks.submitResponse.mockReset();
   mocks.indexing = { status: 'idle', pending: null, runId: null };
   mocks.spaceName = 'Crypto';

--- a/apps/web/core/debates/matchmaking/matchmaking-claim-card.test.tsx
+++ b/apps/web/core/debates/matchmaking/matchmaking-claim-card.test.tsx
@@ -31,11 +31,9 @@ const mocks = vi.hoisted(() => ({
   summaryEnabled: [] as boolean[],
 }));
 
-// The readiness switch shares the entity page's queue-backed machine, so it needs geo-chat auth
-// and the join/leave mutations rather than the hub's old one-shot readiness mutation.
 vi.mock('../hooks', () => ({
-  // Mirrors the real key factory: the readiness machine refetches these families before it
-  // retries a `claim_response_required`.
+  // Mirrors the real key factory: `vi.mock` replaces the whole module, so every query key read
+  // below this needs one here.
   debateQueryKeys: {
     matchmakingClaimsRoot: (accountKey: string | null) =>
       ['debates', 'account', accountKey, 'matchmaking-claims'] as const,

--- a/apps/web/core/debates/matchmaking/requests-tab.test.tsx
+++ b/apps/web/core/debates/matchmaking/requests-tab.test.tsx
@@ -169,7 +169,45 @@ describe('RequestsTab', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Dismiss' }));
 
-    expect(mocks.dismiss).toHaveBeenCalledWith({ requestId: 'request-1' });
+    expect(mocks.dismiss).toHaveBeenCalledWith({ requestId: 'request-1' }, expect.anything());
+  });
+
+  // One answer per card however fast the taps land: `isPending` only disables the button on the
+  // next render, so both taps of a double tap run against a still-enabled one, and the second
+  // answer 409s over the request the first already took.
+  it('answers once however fast the card is tapped', () => {
+    render(<RequestsTab />);
+
+    const dismiss = screen.getByRole('button', { name: 'Dismiss' });
+    fireEvent.click(dismiss);
+    fireEvent.click(dismiss);
+
+    expect(mocks.dismiss).toHaveBeenCalledTimes(1);
+  });
+
+  // Copilot caught this on PR #2359. The guard has to come back when an answer fails, or the card
+  // is answerable exactly once ever: react-query clears `isPending` so the buttons re-enable, but
+  // every press after that is swallowed and the request can only be answered by reloading.
+  it('lets the viewer answer again after a failed answer', () => {
+    mocks.dismiss.mockImplementation((_variables, options) => options?.onError?.(new Error('nope')));
+    render(<RequestsTab />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss' }));
+
+    expect(mocks.dismiss).toHaveBeenCalledTimes(2);
+  });
+
+  // The two buttons share one guard, so a failed Accept has to free the card for Dismiss too.
+  it('frees the other action when an answer fails', () => {
+    mocks.accept.mockImplementation((_variables, options) => options?.onError?.(new Error('nope')));
+    render(<RequestsTab />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Accept' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss' }));
+
+    expect(mocks.accept).toHaveBeenCalledTimes(1);
+    expect(mocks.dismiss).toHaveBeenCalledTimes(1);
   });
 
   it('separates the request you sent from the ones you received', () => {

--- a/apps/web/core/debates/matchmaking/requests-tab.test.tsx
+++ b/apps/web/core/debates/matchmaking/requests-tab.test.tsx
@@ -210,6 +210,31 @@ describe('RequestsTab', () => {
     expect(mocks.dismiss).toHaveBeenCalledTimes(1);
   });
 
+  // Copilot raised this on PR #2359. "I don't want to debate this claim" is the same dismiss
+  // endpoint the buttons use, so an answer already taken would 409 behind it.
+  it('counts the overflow dismissal as the card answer', () => {
+    render(<RequestsTab />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'More options' }));
+    fireEvent.click(screen.getByRole('button', { name: "I don't want to debate this claim" }));
+    fireEvent.click(screen.getByRole('button', { name: 'Accept' }));
+
+    expect(mocks.dismiss).toHaveBeenCalledWith({ requestId: 'request-1', removeIntent: true }, expect.anything());
+    expect(mocks.accept).not.toHaveBeenCalled();
+  });
+
+  // Blocking writes the viewer's block list rather than answering the request, so it must not be
+  // gated: swallowing a safety action because an answer was already taken is the worse failure.
+  it('blocks even once the request has been answered', () => {
+    render(<RequestsTab />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss' }));
+    fireEvent.click(screen.getByRole('button', { name: 'More options' }));
+    fireEvent.click(screen.getByRole('button', { name: /^Block/ }));
+
+    expect(mocks.block).toHaveBeenCalledWith('user-them');
+  });
+
   it('separates the request you sent from the ones you received', () => {
     mocks.outbound = request('request-2', SPACE_A, 'Chips are better than fries');
     render(<RequestsTab />);

--- a/apps/web/core/debates/matchmaking/use-answer-once.test.ts
+++ b/apps/web/core/debates/matchmaking/use-answer-once.test.ts
@@ -1,0 +1,59 @@
+import { renderHook } from '@testing-library/react';
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { useAnswerOnce } from './use-answer-once';
+
+describe('useAnswerOnce', () => {
+  // `isPending` only disables a control on the next render, so both taps of a double tap run
+  // against a still-enabled button. The second answer would 409 over the first.
+  it('runs the first answer and swallows the rest', () => {
+    const answer = vi.fn();
+    const { result } = renderHook(() => useAnswerOnce());
+
+    result.current.answerOnce(answer);
+    result.current.answerOnce(answer);
+    result.current.answerOnce(answer);
+
+    expect(answer).toHaveBeenCalledTimes(1);
+  });
+
+  // Each press is its own answer, so the guard must not be per-callback.
+  it('guards across different answers, not just repeats of one', () => {
+    const accept = vi.fn();
+    const dismiss = vi.fn();
+    const { result } = renderHook(() => useAnswerOnce());
+
+    result.current.answerOnce(accept);
+    result.current.answerOnce(dismiss);
+
+    expect(accept).toHaveBeenCalledOnce();
+    expect(dismiss).not.toHaveBeenCalled();
+  });
+
+  // Without this the surface is answerable exactly once ever: the controls re-enable after a
+  // failure, but the guard is still held and every press after it is swallowed.
+  it('lets the next press land once a failed answer releases the guard', () => {
+    const answer = vi.fn();
+    const { result } = renderHook(() => useAnswerOnce());
+
+    result.current.answerOnce(answer);
+    result.current.releaseAnswer.onError();
+    result.current.answerOnce(answer);
+
+    expect(answer).toHaveBeenCalledTimes(2);
+  });
+
+  // The guard outlives a render: re-rendering between taps is the ordinary case, since answering
+  // flips the mutation's `isPending`.
+  it('holds the guard across re-renders', () => {
+    const answer = vi.fn();
+    const { result, rerender } = renderHook(() => useAnswerOnce());
+
+    result.current.answerOnce(answer);
+    rerender();
+    result.current.answerOnce(answer);
+
+    expect(answer).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/core/debates/matchmaking/use-answer-once.ts
+++ b/apps/web/core/debates/matchmaking/use-answer-once.ts
@@ -1,0 +1,26 @@
+'use client';
+
+import * as React from 'react';
+
+/**
+ * One answer per request, however fast the taps land.
+ *
+ * `isPending` only disables a control on the *next* render, so a double tap gets two answers in
+ * before it takes effect — and the second one 409s over a request the first already took.
+ *
+ * `releaseAnswer` gives the guard back when an answer fails. A surface that does not pass it stays
+ * answerable only until its first failure: the controls re-enable, but every press after that is
+ * swallowed. Pass it to each mutation rather than watching an error flag, so it fires on the
+ * attempt that actually failed however many follow it.
+ */
+export function useAnswerOnce() {
+  const answered = React.useRef(false);
+
+  const answerOnce = (answer: () => void) => {
+    if (answered.current) return;
+    answered.current = true;
+    answer();
+  };
+
+  return { answerOnce, releaseAnswer: { onError: () => void (answered.current = false) } };
+}


### PR DESCRIPTION
Closes [GEO-2813](https://linear.app/geobrowser/issue/GEO-2813/debates-remove-the-remaining-debate-toggle-from-the-request-to-debate).

## What this removes

The **"Debate this claim" switch on the incoming request popup** — the last readiness toggle in the app.

## Sweep results

The ticket asked for a full sweep. Every `role="switch"` in the app, and every consumer of the design-system `Toggle`:

| Surface | Verdict |
|---|---|
| Request-to-debate popup | **Removed** — the one the ticket found |
| Claim cards (list / bulleted), table rows, side panel, Claims tab, Explore cards | Already clean. `matchmaking-claim-card.tsx` even documents it: *"The readiness switch used to ride in the header. It has moved off the card entirely."* |
| Hub header "Available to debate" | Kept — global availability, a different feature |
| Debate room "publish this debate" + Krisp noise filter | Kept — unrelated |
| Voting settings, date format, number options, table filters, search | Kept — unrelated |

## This one was wired to live behavior

Flagging it as the ticket asked. It wasn't dead UI: turning it off chained `leaveDebateQueue` into a dismissal-with-intent-removed, so **removing it is a deliberate capability removal**. Three things make that the right call rather than a regression:

1. **The product model already assumes it's gone.** GEO-2740 moved readiness onto the position itself, and #2303 states the end state outright: *"with the toggle gone there is no way to be deliberately not-ready on a claim you hold a position on."* This popup was the straggler contradicting it.
2. **"Dismiss forever" already is the answer.** It sends `remove_intent` — exactly what the Requests-tab card's version does. The two are now the same action, which this file's own doc comment already claimed they were.
3. **The queue-leave was self-undoing.** `backfill-readiness-for-held-position` stands a viewer back up whenever they hold a position with readiness off and no `readiness_disabled_reason` — precisely the state the switch created. Keeping it would have meant keeping a control the next page visit could quietly reverse.

## Dead code the ticket asked about

> *Worth confirming whether the toggle component itself should be deleted once no call sites remain.*

- **`design-system/Toggle` stays** — eight unrelated call sites.
- **`useClaimReadiness`** + its optimistic-patch helpers: removed, no call sites left.
- **`useJoinDebateQueue` / `useLeaveDebateQueue`**: removed. These were **already dead before this ticket** — zero non-test callers, surviving only in test mocks. Exactly the resurfacing the ticket predicted.
- **`api.ts` bindings kept.** geo-chat still serves the endpoints, and their tests document a contract worth keeping (426s on any body at all). Their stale comment, which claimed the client toggles readiness, is corrected. Say the word if you'd rather they go too.

## Tests

Three rematch tests asserting readiness is never published are removed along with the hook they named — with it gone, the assertion could no longer fail. The popup keeps its answer-guard coverage, re-pointed at "Dismiss forever", plus a new guard that no switch renders.

**386 files / 4272 tests pass.** `tsc --noEmit` reports the same 5 pre-existing errors as master, none in a file this touches. Build run with `--force` (`Cached: 0 cached`).

## Related

[GEO-2792](https://linear.app/geobrowser/issue/GEO-2792/audit-and-unify-the-upvote-downvote-selected-state-across-the-app) sweeps the same surfaces for upvote/downvote selected state — untouched here.

---

## Review pass (second commit)

**DRY — a duplication this PR created.** Removing the switch left `incoming-request-popup` and `incoming-request-card` with byte-identical answer guards. They differed before only because the popup's returned a boolean the switch read to decide whether to move; with the switch gone, so is that reason. Extracted to `useAnswerOnce`, following the folder's `use-*` convention (`use-request-countdown`, `use-delayed-flag`, …), which also puts the 409-race explanation in one place. Behavior unchanged in both: the popup still takes `releaseAnswer`, the card still takes only the guard.

It gets its own suite, matching the six other `use-*` hooks in the folder that have one — worth having directly, since the card's tests never exercised the guard and its only coverage was through the popup.

**Stale comments the removal outdated.** Six mock comments across five suites still described a "readiness machine" refetching families before retrying a `claim_response_required`, and three lead-ins described the join/leave mocks this PR deletes. Corrected to what is true now.

### Two things left deliberately, flagged rather than fixed

- **`debateQueryKeys.matchmakingClaimsRoot` is now unused** (3 source uses on master → 0). It is the prefix for bulk-invalidating every filter combination of `matchmakingClaims`, which only readiness did. Kept because `rematchRoot` already sits unused on master for the same reason, and it is the invalidation prefix for a live key — hand-rolling it later is the more likely mistake. Easy to drop if you'd rather.
- **Two comments in `core/debates/hooks.ts`** still use "a readiness switch" as the example of what a caller might draw. Already stale on master — the switch left those surfaces in earlier tickets — so not corrected here.

### On test flakiness

One run of the full suite failed on `rematch-page-client.test.tsx > holds the request unpressable…`; it passed in isolation and on a clean re-run. Not from this change: the diff to that file is comment-only plus deletion of three independent tests, and `beforeEach` fully resets the shared mock state. The cause is `settleTabSwap`, a fixed 200ms real-timer sleep rather than a `waitFor`, used by 41 tests in that file — load-sensitive by construction. Out of scope here, but worth a ticket.

**387 files / 4276 tests pass.** Build re-run with `--force` (`Cached: 0 cached`); `tsc --noEmit` still reports only the 5 pre-existing errors; eslint reports 0 errors and the same 4 pre-existing warnings, verified symbol-by-symbol against master.


---

## Copilot review (third commit)

One comment, no suppressed ones — and it was right.

**`IncomingRequestCard` discarded `releaseAnswer`.** A failed Accept or Dismiss left the card answerable exactly once ever: react-query clears `isPending` so the buttons re-enable, but `answerOnce` swallows every press after, with a reload as the only way out. Both actions now pass `releaseAnswer`, as the popup does.

Pre-existing rather than introduced here — the card's own inline guard had no release either — but extracting `useAnswerOnce` is what made the omission visible, which is a point in favour of having extracted it.

**Coverage.** Nothing caught this because the card has no tests of its own. Rather than stand up a fourth `DebateRequest` fixture beside the three already in the repo, the coverage went into `requests-tab.test.tsx`, which already mounts the card with the mutation mocks and fixture builder it needs: one test that a failed dismiss doesn't wedge the card, and one that a failed Accept frees Dismiss too (the two buttons share one guard). Both fail without the fix, verified by reverting it.

**387 files / 4279 tests pass.** Build re-run with `--force` (`Cached: 0 cached`); prettier and eslint clean on the changed files.


---

## Second Copilot review (fourth commit)

Two comments, no suppressed ones. Both said the same thing about two actions that turn out to be different, so one is taken and one is declined.

**Taken — the card's "I don't want to debate this claim" is now guarded.** It posts to `/debate-requests/{id}/dismiss`, the same endpoint Dismiss and Accept use, so an answer already taken would 409 behind it. It goes through `answerOnce` with `releaseAnswer` like the buttons. The card renders no error state at all, so that 409 was invisible rather than merely ugly.

**Declined — Block stays outside the guard, on both surfaces.** `blockDebateUser` is `PUT /me/debate-blocks/{userId}`: it writes the viewer's block list and carries no request id, on a different resource from the dismiss endpoint, so it is not an answer to this request and cannot collide with one. The doc line saying Block dismisses the request is true, but that is a server-side consequence, not something the client sends.

Guarding it would trade a spurious 409 for a worse failure: the guard is shared, so in the ordering people actually hit — accept, then think better of it and block — `answerOnce` would swallow the block and leave the user un-blocked, silently. A safety action doing nothing beats a redundant request being rejected only if you don't mind which way it fails.

Both call sites now carry a comment saying which side of the guard they are on, and both behaviors are pinned: `counts the overflow dismissal as the card answer` (fails without the fix, verified by reverting) and `blocks even once the request has been answered`, so the Block decision isn't quietly reversed later by someone reading the call site without this context.

**387 files / 4281 tests pass.** Build re-run with `--force` (`Cached: 0 cached`); prettier and eslint clean on the changed files.
