### PR TITLE
feat(explore): open the space filter on the spaces you belong to

### DIFF
--- a/apps/web/app/api/activity/feed/route.ts
+++ b/apps/web/app/api/activity/feed/route.ts
@@ -30,7 +30,9 @@ function parseTime(raw: string | null): ExploreTime {
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const time = parseTime(searchParams.get('time'));
-  const spaceId = searchParams.get('spaceId');
+  // `spaceIds` since the feed's filter became a multi-select; `spaceId` still accepted because this
+  // route is pinned to exactly one space and that is the older, simpler thing to send.
+  const spaceId = searchParams.get('spaceIds')?.split(',')[0] || searchParams.get('spaceId');
   const cursor = searchParams.get('cursor');
 
   if (!spaceId) {
@@ -69,7 +71,7 @@ export async function GET(request: Request) {
       browse,
       sort: 'new',
       time,
-      spaceFilterId: spaceId,
+      spaceFilterIds: [spaceId],
       cursor,
       walletAddress: cookieWallet ?? null,
       memberOrEditorSpaceIds,

--- a/apps/web/app/api/explore/feed/route.ts
+++ b/apps/web/app/api/explore/feed/route.ts
@@ -38,7 +38,9 @@ export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const sort = parseSort(searchParams.get('sort'));
   const time = parseTime(searchParams.get('time'));
-  const spaceId = searchParams.get('spaceId');
+  // A list since GEO-2789's explore half. `spaceId` is still read so an older client, or a link
+  // someone kept, still narrows to the one space it names.
+  const spaceIdsParam = searchParams.get('spaceIds') ?? searchParams.get('spaceId');
   const cursor = searchParams.get('cursor');
   const typeIds = parseExploreTypeIdsParam(searchParams.get('typeIds'));
 
@@ -80,11 +82,17 @@ export async function GET(request: Request) {
     }
   }
 
-  let spaceFilter: string | null = null;
-  if (spaceId && spaceId !== 'all') {
-    const want = normId(spaceId);
-    const match = [...browse.featured, ...browse.editorOf, ...browse.memberOf].find(r => normId(r.id) === want);
-    if (match) spaceFilter = match.id;
+  // Only spaces this reader may see, whatever they asked for. `all` and an empty parameter both
+  // mean no narrowing; so does a list that matches nothing they can see, because a filter naming
+  // only spaces they cannot see is a request we have no honest way to answer and an empty feed is
+  // the wrong answer to it.
+  let spaceFilter: string[] | null = null;
+  if (spaceIdsParam && spaceIdsParam !== 'all') {
+    const wanted = new Set(spaceIdsParam.split(',').map(normId).filter(Boolean));
+    const visible = [...browse.featured, ...browse.editorOf, ...browse.memberOf]
+      .filter(row => wanted.has(normId(row.id)))
+      .map(row => row.id);
+    if (visible.length > 0) spaceFilter = visible;
   }
 
   try {
@@ -92,7 +100,7 @@ export async function GET(request: Request) {
       browse,
       sort,
       time,
-      spaceFilterId: spaceFilter,
+      spaceFilterIds: spaceFilter,
       cursor,
       walletAddress: cookieWallet ?? null,
       memberOrEditorSpaceIds,

--- a/apps/web/app/explore/page.tsx
+++ b/apps/web/app/explore/page.tsx
@@ -4,6 +4,7 @@ import type { BrowseSidebarData } from '~/core/browse/fetch-browse-sidebar-data'
 import { fetchBrowseSidebarData } from '~/core/browse/fetch-browse-sidebar-data';
 import { resolveMemberSpaceFromWalletSafe } from '~/core/browse/resolve-member-space-from-wallet';
 import { WALLET_ADDRESS } from '~/core/cookie';
+import { browseSidebarMemberSpaceIds } from '~/core/debates/claim-space-allowlist';
 import { fetchExploreSidePanelData } from '~/core/explore/fetch-explore-side-panel-data';
 import { type FeaturedSpace, fetchFeaturedSpacesShared } from '~/core/io/subgraph/fetch-featured-spaces';
 import { normId } from '~/core/utils/norm-id';
@@ -52,12 +53,17 @@ export default async function ExploreRoutePage() {
     initialSpaceOptions.push({ value: row.id, label: row.name });
   }
 
-  // Joined, or with a membership still pending — the spaces the filter opens on (GEO-2789). Asked
-  // for as one set because the reader does not experience the difference: they chose the space at
-  // sign-up and it is theirs from that moment, whether or not an approval has landed yet.
-  const memberSpaceIds = [
-    ...new Set([...sidePanel.memberOrEditorSpaceIds, ...sidePanel.pendingMembershipSpaceIds].map(normId)),
-  ];
+  // Joined, or with a membership still pending — the spaces the filter opens on (GEO-2789). One
+  // set because the reader does not experience the difference: they chose the space at sign-up and
+  // it is theirs from that moment, whether or not an approval has landed yet.
+  //
+  // Read off `browse`, the same rows that build the menu above, and through the same helper the
+  // debates surfaces use — so the two cannot disagree about what "yours" means, and a space cannot
+  // be offered as an option without being recognised as one of theirs. The side panel's
+  // `pendingMembershipSpaceIds` looks like the obvious source and is not: it only checks pending
+  // requests against *featured* spaces, so a pending membership anywhere else was listed on the
+  // menu and left unticked.
+  const memberSpaceIds = [...browseSidebarMemberSpaceIds(browse, browse.personalSpaceId)];
 
   return (
     <ExplorePage

--- a/apps/web/app/explore/page.tsx
+++ b/apps/web/app/explore/page.tsx
@@ -52,9 +52,17 @@ export default async function ExploreRoutePage() {
     initialSpaceOptions.push({ value: row.id, label: row.name });
   }
 
+  // Joined, or with a membership still pending — the spaces the filter opens on (GEO-2789). Asked
+  // for as one set because the reader does not experience the difference: they chose the space at
+  // sign-up and it is theirs from that moment, whether or not an approval has landed yet.
+  const memberSpaceIds = [
+    ...new Set([...sidePanel.memberOrEditorSpaceIds, ...sidePanel.pendingMembershipSpaceIds].map(normId)),
+  ];
+
   return (
     <ExplorePage
       initialSpaceOptions={initialSpaceOptions}
+      memberSpaceIds={memberSpaceIds}
       featuredSpaces={sidePanel.featuredSpaces}
       featuredRankings={sidePanel.featuredRankings}
       pendingMembershipSpaceIds={sidePanel.pendingMembershipSpaceIds}

--- a/apps/web/core/debates/matchmaking/claims-tab.tsx
+++ b/apps/web/core/debates/matchmaking/claims-tab.tsx
@@ -38,7 +38,7 @@ import {
 import { useClaimSpaceAllowlist } from '../use-claim-space-allowlist';
 import { isSpaceDebatePublishable, useDebatePublishableSpaces } from '../use-debate-publishable-spaces';
 import { useDebateRequests } from './hooks';
-import { HubFilterMenu, type HubFilterOption, HubMultiFilterMenu } from './hub-filter-menu';
+import { HubFilterMenu, type HubFilterOption, HubMultiFilterMenu, pickerLabel } from './hub-filter-menu';
 import { HubCardList } from './hub-motion';
 import { HubQueryState } from './hub-states';
 import { MatchmakingClaimCard } from './matchmaking-claim-card';
@@ -872,14 +872,4 @@ export function SpaceTopicFilters({
       ) : null}
     </div>
   );
-}
-
-/**
- * What the trigger pill says. One selection reads as its own name — the useful case, and the one
- * the viewer is most often in — while several collapse to a count, because two names rarely fit
- * and a truncated pair reads as one bad name.
- */
-function pickerLabel(count: number, empty: string, single: () => string, many: (count: number) => string) {
-  if (count === 0) return empty;
-  return count === 1 ? single() : many(count);
 }

--- a/apps/web/core/debates/matchmaking/hub-filter-menu.tsx
+++ b/apps/web/core/debates/matchmaking/hub-filter-menu.tsx
@@ -277,3 +277,16 @@ function pendingLabelWidth(value: string) {
   for (let i = 0; i < value.length; i++) hash = (hash * 31 + value.charCodeAt(i)) >>> 0;
   return `${60 + (hash % 5) * 15}px`;
 }
+
+/**
+ * What a filter's trigger pill says, given how many options are ticked.
+ *
+ * One selection reads as its own name — the useful case, and the one the viewer is most often in —
+ * while several collapse to a count, because two names rarely fit and a truncated pair reads as one
+ * bad name. Lives beside the menu rather than with any one caller: it is the rule for that
+ * component's `label`, and the debates panel and Explore both have to say it the same way.
+ */
+export function pickerLabel(count: number, empty: string, single: () => string, many: (count: number) => string) {
+  if (count === 0) return empty;
+  return count === 1 ? single() : many(count);
+}

--- a/apps/web/core/debates/matchmaking/use-space-filter-selection.ts
+++ b/apps/web/core/debates/matchmaking/use-space-filter-selection.ts
@@ -58,6 +58,28 @@ import { keepSelectedVisible, orderFacetOptions, toggleId } from './topic-facets
  * everything, which is what they saw before this existed, rather than an empty list filtered by a
  * membership they do not have.
  */
+/**
+ * Which of the offered spaces are the viewer's — the selection the default would apply.
+ *
+ * Both sides through `normId`, not just the ids being tested. The two sets arrive by different
+ * routes and neither promises a shape, so normalizing only one leaves an implicit contract that a
+ * mismatch would break silently — and a mismatch here looks exactly like a viewer who belongs to
+ * nothing, which is the case that quietly falls back to showing everything.
+ *
+ * Exported because a surface whose options are a server prop knows both sides on its very first
+ * render, and can seed its state directly rather than waiting for the effect below — which would
+ * otherwise fire one unfiltered request before the narrowed one and show the wide feed in between.
+ * The effect stays for the surfaces whose options arrive from a query.
+ */
+export function memberSpaceSelection(
+  availableSpaceIds: string[],
+  memberSpaceIds: ReadonlySet<string> | null
+): string[] {
+  if (memberSpaceIds === null) return [];
+  const mine = new Set([...memberSpaceIds].map(normId));
+  return availableSpaceIds.filter(id => mine.has(normId(id)));
+}
+
 export function useMemberSpaceDefault({
   memberSpaceIds,
   availableSpaceIds,
@@ -84,12 +106,7 @@ export function useMemberSpaceDefault({
     // this holds the seed rather than spending it.
     if (availableSpaceIds.length === 0) return;
 
-    // Both sides through `normId`, not just the ids being tested. The two sets arrive by different
-    // routes and neither promises a shape, so normalizing only one leaves an implicit contract that
-    // a mismatch would break silently — and a mismatch here looks exactly like a viewer who belongs
-    // to nothing, which is the case that quietly falls back to showing everything.
-    const mine = new Set([...memberSpaceIds].map(normId));
-    const seeded = availableSpaceIds.filter(id => mine.has(normId(id)));
+    const seeded = memberSpaceSelection(availableSpaceIds, memberSpaceIds);
 
     // Spent on a match, not on an attempt. A menu with options the viewer belongs to none of is no
     // more an answer about them than an empty one is, and the surfaces open on exactly such a menu
@@ -158,11 +175,24 @@ export function useSpaceFilterMenu({
 } {
   const offeredSpaceIds = React.useMemo(() => offeredSpaces.map(space => space.id), [offeredSpaces]);
 
+  // Read through a ref so the handlers below keep one identity for the life of the surface. They
+  // are passed to a memoized filter bar, and an identity that changed with the selection would
+  // re-render the menu on every tick.
+  const spaceIdsRef = React.useRef(spaceIds);
+  spaceIdsRef.current = spaceIds;
+
   const markChosen = useMemberSpaceDefault({
     memberSpaceIds,
     availableSpaceIds: offeredSpaceIds,
     pending,
-    onSeed: setSpaceIds,
+    // A seed the selection already holds is not worth a render. A surface whose options are a
+    // server prop applies the default in its own initial state — see `memberSpaceSelection` — and
+    // the effect then arrives at the same answer a beat later.
+    onSeed: next => {
+      const current = spaceIdsRef.current;
+      if (current.length === next.length && next.every((id, index) => current[index] === id)) return;
+      setSpaceIds(next);
+    },
   });
 
   // An absent *selection* comes back at zero, or its checkbox disappears while the trigger goes on
@@ -171,12 +201,6 @@ export function useSpaceFilterMenu({
     () => orderFacetOptions(keepSelectedVisible(offeredSpaces, spaceIds), spaceIds),
     [offeredSpaces, spaceIds]
   );
-
-  // Read through a ref so the handlers below keep one identity for the life of the surface. They
-  // are passed to a memoized filter bar, and an identity that changed with the selection would
-  // re-render the menu on every tick.
-  const spaceIdsRef = React.useRef(spaceIds);
-  spaceIdsRef.current = spaceIds;
 
   const onSpaceToggle = React.useCallback(
     (spaceId: string) => {

--- a/apps/web/core/explore/fetch-explore-feed.ts
+++ b/apps/web/core/explore/fetch-explore-feed.ts
@@ -277,7 +277,16 @@ export async function fetchExploreFeed(args: {
   browse: BrowseSidebarData;
   sort: ExploreSort;
   time: ExploreTime;
-  spaceFilterId: string | null;
+  /**
+   * The spaces the reader has narrowed to, or `null` for no narrowing at all.
+   *
+   * A list rather than one id since GEO-2789's explore half: the space filter is a multi-select
+   * now, and the reader opens on the spaces they belong to, which is usually more than one. An
+   * *empty* list is not the same as `null` and is not expressible here on purpose — the caller
+   * resolves "nothing ticked" to `null` before this is reached, because a filter matching no space
+   * is a feed with nothing in it rather than an unfiltered one.
+   */
+  spaceFilterIds: string[] | null;
   cursor: string | null;
   walletAddress?: string | null;
   memberOrEditorSpaceIds: string[];
@@ -287,9 +296,8 @@ export async function fetchExploreFeed(args: {
   requireName?: boolean;
 }): Promise<ExploreFeedResult> {
   const spaceMeta = browseSpaceRowsToMap(args.browse);
-  const baseIds = [...new Set([...spaceMeta.keys()].map(normId))].filter(id =>
-    args.spaceFilterId ? id === normId(args.spaceFilterId) : true
-  );
+  const wanted = args.spaceFilterIds === null ? null : new Set(args.spaceFilterIds.map(normId));
+  const baseIds = [...new Set([...spaceMeta.keys()].map(normId))].filter(id => (wanted ? wanted.has(id) : true));
   if (baseIds.length === 0) {
     return { items: [], nextCursor: null };
   }

--- a/apps/web/partials/explore/explore-page.tsx
+++ b/apps/web/partials/explore/explore-page.tsx
@@ -12,6 +12,8 @@ import { ExploreWelcomeBanner } from './explore-welcome-banner';
 
 type Props = {
   initialSpaceOptions: SpaceOption[];
+  /** Joined or pending — what the space filter opens on. */
+  memberSpaceIds: string[];
   featuredSpaces: FeaturedSpace[];
   featuredRankings: FeaturedRanking[];
   pendingMembershipSpaceIds: string[];
@@ -21,6 +23,7 @@ type Props = {
 
 export function ExplorePage({
   initialSpaceOptions,
+  memberSpaceIds,
   featuredSpaces,
   featuredRankings,
   pendingMembershipSpaceIds,
@@ -46,6 +49,7 @@ export function ExplorePage({
         <EntityFeed
           apiEndpoint="/api/explore/feed"
           initialSpaceOptions={initialSpaceOptions}
+          memberSpaceIds={memberSpaceIds}
           initialTime="month"
           initialSort="best"
           showSortFilter

--- a/apps/web/partials/feed/entity-feed.test.tsx
+++ b/apps/web/partials/feed/entity-feed.test.tsx
@@ -369,3 +369,80 @@ describe('EntityFeed Explore type filter', () => {
     });
   });
 });
+
+/**
+ * GEO-2789, the explore half. The feed used to open unfiltered over every space the reader may
+ * see — featured ones included, which say nothing about who is asking. It opens on theirs now,
+ * with the rest still on the menu to widen back to, and the same multi-select the debates side
+ * panel uses so the two filters read and behave alike.
+ */
+describe('the space filter', () => {
+  const OPTIONS = [
+    { value: 'space-featured', label: 'Crypto' },
+    { value: 'space-mine', label: 'Relationships' },
+    { value: 'space-pending', label: 'US Politics' },
+  ];
+
+  function renderFeed(memberSpaceIds?: string[]) {
+    return render(
+      <EntityFeed
+        apiEndpoint="/api/explore/feed"
+        initialSpaceOptions={OPTIONS}
+        memberSpaceIds={memberSpaceIds}
+        showSortFilter
+      />
+    );
+  }
+
+  /** The trigger, which the mocked Menu renders alongside the options. */
+  const spaceTrigger = () => screen.getAllByRole('button', { name: /Any space|Relationships|spaces$/ })[0];
+
+  const sentSpaceIds = async () => new URLSearchParams((await requestedUrl()).split('?')[1]).get('spaceIds');
+
+  it('opens on the spaces the reader belongs to', async () => {
+    renderFeed(['space-mine']);
+
+    expect(await sentSpaceIds()).toBe('space-mine');
+  });
+
+  // A membership the reader has asked for is one of theirs: they chose it at sign-up, and nothing
+  // should lurch when the approval lands.
+  it('counts a pending membership as one of theirs', async () => {
+    renderFeed(['space-mine', 'space-pending']);
+
+    expect((await sentSpaceIds())?.split(',').sort()).toEqual(['space-mine', 'space-pending']);
+  });
+
+  // The fallback, and the case every signed-out reader is in.
+  it('shows everything when the reader belongs to none of the spaces on offer', async () => {
+    renderFeed([]);
+
+    expect(await sentSpaceIds()).toBeNull();
+    expect(spaceTrigger().textContent).toContain('Any space');
+  });
+
+  it('holds the default while their memberships are still unknown', async () => {
+    // Undefined is not empty: spending the default on a viewer whose spaces had not arrived would
+    // land them on the fallback for the whole visit.
+    renderFeed(undefined);
+
+    expect(await sentSpaceIds()).toBeNull();
+  });
+
+  it('lets the reader widen to a featured space they have not joined', async () => {
+    renderFeed(['space-mine']);
+
+    pickOption('Crypto');
+
+    expect((await sentSpaceIds())?.split(',').sort()).toEqual(['space-featured', 'space-mine']);
+  });
+
+  it('clears back to every space, and the default does not put theirs back', async () => {
+    renderFeed(['space-mine']);
+    expect(await sentSpaceIds()).toBe('space-mine');
+
+    pickOption('Any space');
+
+    expect(await sentSpaceIds()).toBeNull();
+  });
+});

--- a/apps/web/partials/feed/entity-feed.test.tsx
+++ b/apps/web/partials/feed/entity-feed.test.tsx
@@ -15,6 +15,8 @@ import { EntityFeed } from './entity-feed';
 
 const mocks = vi.hoisted(() => ({
   queryOptions: null as Record<string, unknown> | null,
+  /** Every key the feed has subscribed under, so a test can see what it asked for *first*. */
+  queryKeys: [] as unknown[][],
   fetch: vi.fn(),
   /** Pages the mocked infinite query hands back, so a test can put a card on the page. */
   pages: null as { items: Record<string, unknown>[] }[] | null,
@@ -40,6 +42,7 @@ function createLocalStorage(): Storage {
 vi.mock('@tanstack/react-query', () => ({
   useInfiniteQuery: (options: Record<string, unknown>) => {
     mocks.queryOptions = options;
+    mocks.queryKeys.push(options.queryKey as unknown[]);
     return {
       data: mocks.pages ? { pages: mocks.pages } : undefined,
       isLoading: false,
@@ -81,6 +84,7 @@ beforeEach(() => {
   mocks.queryOptions = null;
   mocks.pages = null;
   mocks.cardProps = null;
+  mocks.queryKeys = [];
   mocks.fetch.mockReset();
   mocks.fetch.mockResolvedValue({ ok: true, json: async () => ({ items: [], nextCursor: null }) });
   vi.stubGlobal('fetch', mocks.fetch);
@@ -407,6 +411,17 @@ describe('the space filter', () => {
 
   // A membership the reader has asked for is one of theirs: they chose it at sign-up, and nothing
   // should lurch when the approval lands.
+  // The default is applied in the feed's own initial state rather than by the hook's effect, because
+  // both sides are server props here and the answer is already in hand. Starting empty would
+  // subscribe to the unfiltered query, fire that request, and only then narrow — two requests on
+  // every load, with the wide feed on screen in between.
+  it('never subscribes to the unfiltered feed on the way to the default', () => {
+    renderFeed(['space-mine']);
+
+    expect(mocks.queryKeys.length).toBeGreaterThan(0);
+    for (const key of mocks.queryKeys) expect(key).toContain('space-mine');
+  });
+
   it('counts a pending membership as one of theirs', async () => {
     renderFeed(['space-mine', 'space-pending']);
 

--- a/apps/web/partials/feed/entity-feed.tsx
+++ b/apps/web/partials/feed/entity-feed.tsx
@@ -6,7 +6,7 @@ import * as React from 'react';
 
 import cx from 'classnames';
 
-import { HubMultiFilterMenu } from '~/core/debates/matchmaking/hub-filter-menu';
+import { HubMultiFilterMenu, pickerLabel } from '~/core/debates/matchmaking/hub-filter-menu';
 import { useSpaceFilterMenu } from '~/core/debates/matchmaking/use-space-filter-selection';
 import { DEFAULT_EXPLORE_TYPE_IDS, EXPLORE_ENTITY_TYPE_IDS } from '~/core/explore/explore-constants';
 import {
@@ -276,25 +276,20 @@ export function EntityFeed({
     // The options are a server prop rather than a query, so they are never half-arrived here.
     pending: false,
   });
-
-  // The menu's own shape. `facetSpaces` is skipped deliberately: it exists to keep a *selected*
-  // option visible after a count drops it, and nothing here drops one — the options are a fixed
-  // list, so a ticked space is always still on it.
-  const spaceMenuOptions = React.useMemo(
-    () => initialSpaceOptions.map(option => ({ value: option.value, label: option.label })),
-    [initialSpaceOptions]
-  );
+  // The hook's `facetSpaces` is deliberately unused. It keeps a *selected* option visible after a
+  // count drops it and orders by that count — neither of which applies to a fixed server-rendered
+  // list, where ordering by a count these rows do not have would replace featured-first with
+  // alphabetical-by-id. `initialSpaceOptions` is already a `HubFilterOption`, so the menu takes it
+  // as it stands.
 
   const timeLabel = TIME_OPTIONS.find(o => o.value === time)?.label ?? time;
   const sortLabel = SORT_OPTIONS.find(o => o.value === sort)?.label ?? sort;
-  // The one name while a single space is ticked, a count past that — the debates panel's wording,
-  // so the two filters read the same way.
-  const spaceLabel =
-    spaceIds.length === 0
-      ? 'Any space'
-      : spaceIds.length === 1
-        ? (initialSpaceOptions.find(option => option.value === spaceIds[0])?.label ?? 'Any space')
-        : `${spaceIds.length} spaces`;
+  const spaceLabel = pickerLabel(
+    spaceIds.length,
+    'Any space',
+    () => initialSpaceOptions.find(option => option.value === spaceIds[0])?.label ?? 'Any space',
+    count => `${count} spaces`
+  );
 
   return (
     <div className="mx-auto w-full max-w-[880px]">
@@ -373,7 +368,7 @@ export function EntityFeed({
               {lockedSpaceId == null ? (
                 <HubMultiFilterMenu
                   label={spaceLabel}
-                  options={spaceMenuOptions}
+                  options={initialSpaceOptions}
                   values={spaceIds}
                   onToggle={onSpaceToggle}
                   onClear={onSpacesClear}

--- a/apps/web/partials/feed/entity-feed.tsx
+++ b/apps/web/partials/feed/entity-feed.tsx
@@ -7,7 +7,7 @@ import * as React from 'react';
 import cx from 'classnames';
 
 import { HubMultiFilterMenu, pickerLabel } from '~/core/debates/matchmaking/hub-filter-menu';
-import { useSpaceFilterMenu } from '~/core/debates/matchmaking/use-space-filter-selection';
+import { memberSpaceSelection, useSpaceFilterMenu } from '~/core/debates/matchmaking/use-space-filter-selection';
 import { DEFAULT_EXPLORE_TYPE_IDS, EXPLORE_ENTITY_TYPE_IDS } from '~/core/explore/explore-constants';
 import {
   EXPLORE_TYPE_FILTER_STORAGE_KEY,
@@ -73,9 +73,9 @@ type EntityFeedProps = {
    * opens on whichever of them are on offer, and on nothing at all when there are none, which is
    * the unfiltered feed a reader with no memberships already saw (GEO-2789).
    *
-   * Undefined while unknown, which is not the same as empty: empty is a settled answer and takes
-   * the fallback, whereas unknown holds the default rather than spending it on a viewer whose
-   * memberships had not arrived.
+   * Undefined means the caller has no membership data to give — the activity feed, which pins its
+   * own space and draws no menu. There is nothing to wait for in that case, so it reads as the
+   * fallback rather than holding the feed: every space this reader may see.
    */
   memberSpaceIds?: string[];
   /** When set, the feed is pinned to this space. No space dropdown is rendered. */
@@ -151,7 +151,16 @@ export function EntityFeed({
 }: EntityFeedProps) {
   const [time, setTime] = React.useState<ExploreTime>(initialTime);
   const [sort, setSort] = React.useState<ExploreSort>(initialSort);
-  const [spaceIds, setSpaceIds] = React.useState<string[]>([]);
+  // Seeded on the first render rather than by the hook's effect. Both sides are server props on
+  // this surface, so the answer is already in hand — and starting empty would subscribe the feed to
+  // the unfiltered query, fire that request, and only then narrow, showing the wide feed in
+  // between. The hook's effect still runs and arrives at the same answer, which it then skips.
+  const [spaceIds, setSpaceIds] = React.useState<string[]>(() =>
+    memberSpaceSelection(
+      initialSpaceOptions.map(option => option.value),
+      memberSpaceIds === undefined ? null : new Set(memberSpaceIds)
+    )
+  );
   const [sortMenuOpen, setSortMenuOpen] = React.useState(false);
   const [timeMenuOpen, setTimeMenuOpen] = React.useState(false);
   // Seeded with the default rather than every type, so the first paint is what the effect below

--- a/apps/web/partials/feed/entity-feed.tsx
+++ b/apps/web/partials/feed/entity-feed.tsx
@@ -6,6 +6,8 @@ import * as React from 'react';
 
 import cx from 'classnames';
 
+import { HubMultiFilterMenu } from '~/core/debates/matchmaking/hub-filter-menu';
+import { useSpaceFilterMenu } from '~/core/debates/matchmaking/use-space-filter-selection';
 import { DEFAULT_EXPLORE_TYPE_IDS, EXPLORE_ENTITY_TYPE_IDS } from '~/core/explore/explore-constants';
 import {
   EXPLORE_TYPE_FILTER_STORAGE_KEY,
@@ -66,6 +68,16 @@ type EntityFeedProps = {
   apiEndpoint: string;
   /** Space options for the space dropdown. Required when `lockedSpaceId` is not set. */
   initialSpaceOptions?: SpaceOption[];
+  /**
+   * The spaces this reader belongs to — joined, or with a membership still pending. The filter
+   * opens on whichever of them are on offer, and on nothing at all when there are none, which is
+   * the unfiltered feed a reader with no memberships already saw (GEO-2789).
+   *
+   * Undefined while unknown, which is not the same as empty: empty is a settled answer and takes
+   * the fallback, whereas unknown holds the default rather than spending it on a viewer whose
+   * memberships had not arrived.
+   */
+  memberSpaceIds?: string[];
   /** When set, the feed is pinned to this space. No space dropdown is rendered. */
   lockedSpaceId?: string;
   /** Initial value for the time dropdown. Defaults to "week". */
@@ -96,7 +108,8 @@ async function fetchFeedPage(
     sort: ExploreSort;
     /** Omitted when the feed's sort has no time range. */
     time: ExploreTime | undefined;
-    spaceId: string;
+    /** Empty means no space narrowing at all. */
+    spaceIds: readonly string[];
     typeIds: readonly string[] | undefined;
     cursor: string | undefined;
   }
@@ -106,7 +119,9 @@ async function fetchFeedPage(
   // Absent means "no time filter" — see the route's parseTime. Sending nothing is what keeps a
   // hidden range out of the feed it isn't shown for.
   if (params.time !== undefined) sp.set('time', params.time);
-  sp.set('spaceId', params.spaceId);
+  // Omitted rather than sent as `all` when nothing is ticked: the routes read an absent parameter
+  // as "no narrowing", which is the same answer with one fewer special string in it.
+  if (params.spaceIds.length > 0) sp.set('spaceIds', params.spaceIds.join(','));
   if (params.typeIds !== undefined) sp.set('typeIds', params.typeIds.join(','));
   if (params.cursor) sp.set('cursor', params.cursor);
   const res = await fetch(`${apiEndpoint}?${sp.toString()}`, { credentials: 'include' });
@@ -123,6 +138,7 @@ async function fetchFeedPage(
 export function EntityFeed({
   apiEndpoint,
   initialSpaceOptions = [],
+  memberSpaceIds,
   lockedSpaceId,
   initialTime = 'week',
   initialSort = 'new',
@@ -135,17 +151,22 @@ export function EntityFeed({
 }: EntityFeedProps) {
   const [time, setTime] = React.useState<ExploreTime>(initialTime);
   const [sort, setSort] = React.useState<ExploreSort>(initialSort);
-  const [selectedSpaceId, setSelectedSpaceId] = React.useState<string>('all');
+  const [spaceIds, setSpaceIds] = React.useState<string[]>([]);
   const [sortMenuOpen, setSortMenuOpen] = React.useState(false);
   const [timeMenuOpen, setTimeMenuOpen] = React.useState(false);
-  const [spaceMenuOpen, setSpaceMenuOpen] = React.useState(false);
   // Seeded with the default rather than every type, so the first paint is what the effect below
   // will settle on for a reader with nothing stored — the common case. Starting from all twelve
   // showed a wider feed for a frame and then narrowed it.
   const [selectedTypeIds, setSelectedTypeIds] = React.useState<string[]>([...DEFAULT_EXPLORE_TYPE_IDS]);
   const [typeSelectionLoaded, setTypeSelectionLoaded] = React.useState(!showTypeFilter);
   const shouldPersistTypeSelectionRef = React.useRef(false);
-  const spaceId = lockedSpaceId ?? selectedSpaceId;
+  // A locked space is the whole filter and there is no menu to reconcile it with; otherwise it is
+  // whatever is ticked, and nothing ticked means every space the reader may see.
+  const requestedSpaceIds = React.useMemo(
+    () => (lockedSpaceId ? [lockedSpaceId] : spaceIds),
+    [lockedSpaceId, spaceIds]
+  );
+  const spaceIdsKey = requestedSpaceIds.join(',');
   const typeIds =
     showTypeFilter && selectedTypeIds.length !== EXPLORE_ENTITY_TYPE_IDS.length ? selectedTypeIds : undefined;
   const typeIdsKey = typeIds?.join(',') ?? null;
@@ -189,8 +210,8 @@ export function EntityFeed({
   // Keyed on what is actually sent: two Best feeds differing only in a hidden range are the same
   // request, and caching them apart would refetch on a change the viewer never made.
   const queryKey = showTypeFilter
-    ? [apiEndpoint, sort, requestedTime, spaceId, typeIdsKey, smartAccountAddress]
-    : [apiEndpoint, sort, requestedTime, spaceId, smartAccountAddress];
+    ? [apiEndpoint, sort, requestedTime, spaceIdsKey, typeIdsKey, smartAccountAddress]
+    : [apiEndpoint, sort, requestedTime, spaceIdsKey, smartAccountAddress];
 
   const { data, isLoading, isFetchingNextPage, fetchNextPage, hasNextPage, error } = useInfiniteQuery({
     queryKey,
@@ -198,7 +219,7 @@ export function EntityFeed({
       fetchFeedPage(apiEndpoint, {
         sort,
         time: requestedTime,
-        spaceId,
+        spaceIds: requestedSpaceIds,
         typeIds,
         cursor: pageParam as string | undefined,
       }),
@@ -233,12 +254,47 @@ export function EntityFeed({
     return flat;
   }, [data?.pages]);
 
+  // The space filter, defaulted and driven the same way the debates side panel's is (GEO-2789), by
+  // the same hook — so the two surfaces cannot drift on what "your spaces" means or on what a tick
+  // does. `count` is left off: the feed has no per-space totals to offer, and the menu draws a row
+  // without one rather than a zero.
+  const offeredSpaces = React.useMemo(
+    () => initialSpaceOptions.map(option => ({ id: option.value, name: option.label, count: 0 })),
+    [initialSpaceOptions]
+  );
+
+  const memberSpaces = React.useMemo(
+    () => (memberSpaceIds === undefined ? null : new Set(memberSpaceIds)),
+    [memberSpaceIds]
+  );
+
+  const { onSpaceToggle, onSpacesClear } = useSpaceFilterMenu({
+    offeredSpaces,
+    spaceIds,
+    setSpaceIds,
+    memberSpaceIds: memberSpaces,
+    // The options are a server prop rather than a query, so they are never half-arrived here.
+    pending: false,
+  });
+
+  // The menu's own shape. `facetSpaces` is skipped deliberately: it exists to keep a *selected*
+  // option visible after a count drops it, and nothing here drops one — the options are a fixed
+  // list, so a ticked space is always still on it.
+  const spaceMenuOptions = React.useMemo(
+    () => initialSpaceOptions.map(option => ({ value: option.value, label: option.label })),
+    [initialSpaceOptions]
+  );
+
   const timeLabel = TIME_OPTIONS.find(o => o.value === time)?.label ?? time;
   const sortLabel = SORT_OPTIONS.find(o => o.value === sort)?.label ?? sort;
+  // The one name while a single space is ticked, a count past that — the debates panel's wording,
+  // so the two filters read the same way.
   const spaceLabel =
-    selectedSpaceId === 'all'
+    spaceIds.length === 0
       ? 'Any space'
-      : (initialSpaceOptions.find(o => o.value === selectedSpaceId)?.label ?? 'Any space');
+      : spaceIds.length === 1
+        ? (initialSpaceOptions.find(option => option.value === spaceIds[0])?.label ?? 'Any space')
+        : `${spaceIds.length} spaces`;
 
   return (
     <div className="mx-auto w-full max-w-[880px]">
@@ -315,48 +371,15 @@ export function EntityFeed({
           {lockedSpaceId == null || showTypeFilter ? (
             <div className="ml-auto flex items-center gap-3">
               {lockedSpaceId == null ? (
-                <Menu
-                  asChild
-                  open={spaceMenuOpen}
-                  onOpenChange={setSpaceMenuOpen}
-                  sideOffset={8}
-                  className="max-w-60 bg-white"
-                  trigger={
-                    <button
-                      type="button"
-                      className="flex h-6 items-center gap-1.5 rounded border border-grey-02 pr-2 pl-1.5 text-metadata text-grey-04 shadow-button transition-colors duration-150 focus-within:border-text"
-                    >
-                      <span>{spaceLabel}</span>
-                      <span
-                        className={cx('inline-flex transition-transform duration-200', spaceMenuOpen && 'rotate-180')}
-                      >
-                        <ChevronDownSmall color="grey-04" />
-                      </span>
-                    </button>
-                  }
-                >
-                  <MenuItem
-                    active={selectedSpaceId === 'all'}
-                    onClick={() => {
-                      setSelectedSpaceId('all');
-                      setSpaceMenuOpen(false);
-                    }}
-                  >
-                    Any space
-                  </MenuItem>
-                  {initialSpaceOptions.map(o => (
-                    <MenuItem
-                      key={o.value}
-                      active={o.value === selectedSpaceId}
-                      onClick={() => {
-                        setSelectedSpaceId(o.value);
-                        setSpaceMenuOpen(false);
-                      }}
-                    >
-                      {o.label}
-                    </MenuItem>
-                  ))}
-                </Menu>
+                <HubMultiFilterMenu
+                  label={spaceLabel}
+                  options={spaceMenuOptions}
+                  values={spaceIds}
+                  onToggle={onSpaceToggle}
+                  onClear={onSpacesClear}
+                  clearLabel="Any space"
+                  showImages={false}
+                />
               ) : null}
               {showTypeFilter ? (
                 <ExploreTypeFilterMenu


### PR DESCRIPTION
Carries [GEO-2789](https://linear.app/geobrowser/issue/GEO-2789) from the debates side panel to Explore, and aligns the two filters.

## What changes

Explore opened unfiltered over every space the reader may see — featured ones included, which say nothing about who is asking. It opens on **theirs** now: joined, or with a membership still pending.

- **A member of some spaces** → those are ticked, the feed opens on them.
- **A member of none** (every signed-out reader included) → nothing ticked, which is the unfiltered feed they already saw.
- **Every featured space stays on the menu** whether or not they joined it, so widening back is one tick — and a space they belong to that isn't featured is listed alongside.

Pending counts as theirs, deliberately: a reader picks their spaces at sign-up, and nothing should lurch when an approval lands. Same rule the debates allowlist settled on.

## The dropdown

Was single-select with a tick; the debates panel's is multi-select with checkboxes. It is now `HubMultiFilterMenu` — the debates component — and the default comes from `useSpaceFilterMenu`, the debates hook.

Reused rather than reimplemented for one reason worth stating: that hook also owns *forfeiting the default when the reader touches the filter*. That was six call sites of remembering before it was consolidated, and forgetting one turns a default into a policy — the seed lands on top of a space the reader just picked.

`facetSpaces` is deliberately **not** used. It exists to keep a selected option visible after a count drops it, and it orders by count. Neither applies here: the options are a fixed server-rendered list, and ordering by a count they don't have would replace featured-first with alphabetical-by-id.

## Plumbing

The filter is a list rather than one id, end to end.

- `spaceFilterId` → `spaceFilterIds` in `fetchExploreFeed`, whose internals already worked on a list (`baseIds`).
- Both routes read `spaceIds` and still accept `spaceId`, so an older client or a kept link narrows to the space it names.
- An empty selection sends **no parameter** rather than the string `all`.
- The explore route intersects what was asked for with what the reader may see before filtering — a list naming only spaces they can't see falls through to unfiltered rather than to an empty feed.

**The activity feed is untouched by design.** It passes `lockedSpaceId`, draws no dropdown, and its query key is byte-identical — which the existing test still pins.

## Testing

387 files, 4317 passing. Six new, four of which fail with the seed unwired: the default, pending memberships counting, the no-memberships fallback, unknown-not-empty, widening to a featured space, and clearing back.

**Not verified in a browser.** Worth an eye on the trigger, which now reads a space name with one ticked and "N spaces" past that.
