### PR TITLE
fix(debates): refresh every readiness source after a position is reported (GEO-2814)

### DIFF
--- a/apps/web/core/debates/claim-response-indexed-notifier.test.tsx
+++ b/apps/web/core/debates/claim-response-indexed-notifier.test.tsx
@@ -154,7 +154,41 @@ describe('useClaimResponseIndexedNotifier', () => {
     );
   });
 
-  it('falls back to a silent local claim refresh when notification fails', async () => {
+  // GEO-2814. Every Request debate control reads geo-chat's copy of the position from one of three
+  // independently-keyed queries. Only the rematch picker was refreshed after the notification, so
+  // the rest converged whenever they happened to refetch next — Explore asks per card behind
+  // `nearViewport` and so refetched constantly, the hub asks once per tab and sat stale. That gap
+  // is the inconsistency, not the gate, which all of them already share.
+  it('refreshes every readiness source once geo-chat has been told', async () => {
+    const { queryClient, wrapper } = createHarness();
+    const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries');
+    renderHook(() => useClaimResponseIndexedNotifier(true, vi.fn(), 'account-1'), { wrapper });
+
+    act(() => {
+      queryClient.setQueryData(['entity-response-indexing', 'profile-1', 'claim-1', 'space-1', 'stance'], {
+        status: 'indexed',
+        pending: {
+          entityId: 'claim-1',
+          expectedResponse: 'positive',
+          personalSpaceId: 'profile-1',
+          responseKind: 'stance',
+          spaceId: 'space-1',
+        },
+        runId: 'run-readiness',
+      });
+    });
+
+    await waitFor(() => expect(mocks.notify).toHaveBeenCalledOnce());
+    for (const queryKey of [
+      ['debates', 'claims', 'space-1'],
+      ['debates', 'account', 'account-1', 'matchmaking-claims'],
+      ['debates', 'account', 'account-1', 'matches'],
+    ]) {
+      await waitFor(() => expect(invalidateQueries).toHaveBeenCalledWith({ queryKey }));
+    }
+  });
+
+  it('refreshes the readiness sources even when the notification fails', async () => {
     mocks.notify.mockRejectedValue(new Error('geo-chat unavailable'));
     const { queryClient, wrapper } = createHarness();
     const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries');
@@ -267,9 +301,9 @@ describe('useClaimResponseIndexedNotifier', () => {
     mocks.notify.mockResolvedValue(undefined);
     rerender({ enabled: true });
     await waitFor(() => expect(mocks.notify).toHaveBeenCalledTimes(2));
-    // The retry landed, so the picker is asked again — but the failure fallback still must not fire.
+    // The retry landed, so the picker and the readiness sources are asked again.
     await waitFor(() => expect(invalidateQueries).toHaveBeenCalled());
-    expect(invalidateQueries).not.toHaveBeenCalledWith({ queryKey: ['debates', 'claims', 'space-1'] });
+    await waitFor(() => expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['debates', 'claims', 'space-1'] }));
   });
 
   it('does not replay an interrupted notification for another account', async () => {

--- a/apps/web/core/debates/claim-response-indexed-notifier.ts
+++ b/apps/web/core/debates/claim-response-indexed-notifier.ts
@@ -10,6 +10,29 @@ import { type DebateResponseKind, type GetPrivyIdentityToken, notifyClaimRespons
 import { refreshRematchClaimBatches, rematchClaimBatchesWithClaim } from './rematch-claims-query-key';
 
 const MAX_NOTIFIED_RUNS = 256;
+
+/**
+ * Every query whose answer a position write changes, as key prefixes (GEO-2814).
+ *
+ * These are the three sources the Request debate control reads geo-chat's copy of the position
+ * from — Explore's per-space claims, the hub's Claims tab, and the hub's Matches tab. They ask the
+ * same question of the same service and are keyed independently, so a refresh has to name all
+ * three. Prefixes, because the full keys carry a claim-id batch and a filter set respectively,
+ * neither of which is reconstructable from a notification.
+ *
+ * `matches` is included because a new position can create or dissolve a match outright, not merely
+ * change how one renders.
+ */
+function readinessQueryPrefixes(accountKey: string, spaceId: string) {
+  return [
+    // Explore cards and the claim page: ['debates', 'claims', spaceId, claimIds, accountKey]
+    ['debates', 'claims', spaceId],
+    // Hub Claims tab: ['debates', 'account', accountKey, 'matchmaking-claims', filters]
+    ['debates', 'account', accountKey, 'matchmaking-claims'],
+    // Hub Matches tab: ['debates', 'account', accountKey, 'matches']
+    ['debates', 'account', accountKey, 'matches'],
+  ] as const;
+}
 /** Fields shared by pending and indexed response notifications. */
 type NotifiableClaimResponse = Pick<
   NonNullable<ReturnType<typeof pendingClaimResponse>>,
@@ -120,8 +143,11 @@ export function useClaimResponseIndexedNotifier(
         controller.signal
       )
         .catch(error => {
+          // Swallowed so `.finally` still runs and the promise never rejects unhandled. This used
+          // to invalidate the claims query as a fallback; the refresh below now covers that key on
+          // every path, so a second one here would only make "the notification failed" and "the
+          // notification succeeded" indistinguishable at the cache (GEO-2814).
           if (isAbortError(error)) return;
-          return queryClient.invalidateQueries({ queryKey: ['debates', 'claims', response.spaceId] });
         })
         .finally(() => {
           notificationControllers.delete(controller);
@@ -133,6 +159,20 @@ export function useClaimResponseIndexedNotifier(
           // until something unrelated happened to refetch. Asking again once the notification has
           // settled is the only refresh guaranteed to postdate it.
           void refreshRematchClaimBatches(queryClient, rematchClaimBatchesWithClaim(accountKey, response.entityId));
+
+          // GEO-2814. The rematch picker was the only surface refreshed here, so every *other*
+          // Request debate control converged on geo-chat's new answer by luck — whenever its own
+          // query happened to refetch next. Explore asks per card behind `nearViewport`, so
+          // scrolling refetches it constantly and its button opened first; the hub asks once per
+          // tab and sat on a stale answer, which is the reported inconsistency.
+          //
+          // The same argument as the rematch refresh above applies to all of them: this is the
+          // only refresh guaranteed to postdate the notification, so it is where they belong.
+          // Invalidated by prefix rather than by exact key because the claims queries are keyed by
+          // claim-id batch and the hub's by filter set — neither is reconstructable from here.
+          for (const queryKey of readinessQueryPrefixes(accountKey, response.spaceId)) {
+            void queryClient.invalidateQueries({ queryKey });
+          }
         });
     };
 


### PR DESCRIPTION
Request debate opens at different times depending on where it appears — earlier on an Explore card than in the debates side panel.

## The gate is not the problem

`debateRequestGate` is a single shared condition and `useClaimPositionControl` derives the position once, so **every claim surface already applies identical logic**. What differs is *when each one hears that geo-chat's copy has changed*.

Three independently-keyed queries answer that question:

| surface | readiness query | key |
| -- | -- | -- |
| Explore card / claim page | `/spaces/{id}/debate-claims` | `['debates','claims',spaceId,…]` |
| Hub Claims tab | `/matchmaking/claims` | `['debates','account',key,'matchmaking-claims',…]` |
| Hub Matches tab | `/matchmaking/matches` | `['debates','account',key,'matches']` |

After the notification only the **rematch picker** was refreshed. The other three converged whenever they happened to refetch next — and `debateQueryNetworkOptions` sets `refetchOnWindowFocus: false` and `refetchOnReconnect: false`, so that was rarely.

Explore asks *per card* behind `nearViewport`, so scrolling refetches it constantly and its button opened first. The hub asks once per tab and sat on a stale answer. That is the reported ordering, and it is incidental rather than designed.

## Which timing is correct

**Explore's.** The refresh is driven by the notification completing, not by optimism, so this does not spread GEO-2807 — the hub was simply late. The fix brings the others up to Explore's timing rather than slowing Explore down.

Worth noting `request-gate.ts`'s own docstring predicts the *opposite* ordering, arguing the hub should open sooner because `debate_claim_readiness` is written by the in-flight notification while the graph waits on indexing. That reasoning is sound and was defeated in practice by the missing refresh.

## The change

All three keys are invalidated where the rematch picker already was — in the `.finally`, which the existing comment there argues is *"the only refresh guaranteed to postdate it"*. Same argument, same place.

Invalidated **by prefix**, because the full keys carry a claim-id batch and a filter set respectively, neither reconstructable from a notification. `matches` is included because a new position can create or dissolve a match outright, not merely change how one renders.

**The `.catch` invalidation is dropped.** It used to re-read the claims query when the notification failed; the refresh above now covers that key on every path, and keeping both would make "the notification failed" and "the notification succeeded" indistinguishable at the cache — a distinction one of the existing tests relied on.

## Testing

9 tests in `claim-response-indexed-notifier.test.tsx`, including a new one asserting all three keys are invalidated, and the failure-path test rewritten to match the collapsed behaviour. Full `core/debates` suite: **88 files, 1206 tests, 0 failures.** `tsc --noEmit` clean for the changed file.

One process note: an intermediate run showed 3 failures in `claims-tab.test.tsx` that did not reproduce on a clean re-run of the same suite — that is GEO-2645, the known Vitest teardown flake, not this change.

## Not addressed here

Three queries answering the same question is what let them drift in the first place — the same lesson as GEO-2808. Collapsing them onto one source is the follow-up, and is noted on the ticket. The People tab and profile button stay outside the gate deliberately: they are person challenges with no claim and no position (GEO-2729 covers the shared label).