### PR TITLE
feat(debates): reuse an existing Claim when geo-chat matched a transcript claim to one

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -66,6 +66,11 @@ CURATOR_BACKEND_URL=https://curator-api-staging-testnet.up.railway.app
 # NEXT_PUBLIC_GEO_CHAT_API_BASE_URL; in production one of the two must be set. Must be an absolute
 # http(s) URL, so set it explicitly when using the /geo-chat-proxy dev setup.
 # NEXT_PUBLIC_DEBATE_MEDIA_BASE_URL=http://localhost:8080
+# Debate acceptor find-or-create (server only). When true, a transcript claim geo-chat matched to an
+# existing Claim in the debate's space is linked to that entity instead of minted again, after the
+# publisher re-verifies it. Off by default: geo-chat's matching then runs in shadow mode and its
+# verdicts can be read from geo-chat's GET /debates/{id}/claims before any entity is reused.
+# DEBATE_CLAIM_REUSE_ENABLED=false
 
 # Build (optional)
 # DISABLE_REACT_COMPILER=1

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -66,10 +66,10 @@ CURATOR_BACKEND_URL=https://curator-api-staging-testnet.up.railway.app
 # NEXT_PUBLIC_GEO_CHAT_API_BASE_URL; in production one of the two must be set. Must be an absolute
 # http(s) URL, so set it explicitly when using the /geo-chat-proxy dev setup.
 # NEXT_PUBLIC_DEBATE_MEDIA_BASE_URL=http://localhost:8080
-# Debate acceptor find-or-create (server only). When true, a transcript claim geo-chat matched to an
-# existing Claim in the debate's space is linked to that entity instead of minted again, after the
-# publisher re-verifies it. Off by default: geo-chat's matching then runs in shadow mode and its
-# verdicts can be read from geo-chat's GET /debates/{id}/claims before any entity is reused.
+# Debate acceptor find-or-create (server only). A transcript claim geo-chat matched to an existing
+# Claim in the debate's space is linked to that entity instead of minted again, after the publisher
+# re-verifies it. On by default; set to false for shadow mode, where geo-chat's matching still runs
+# and its verdicts can be read from geo-chat's GET /debates/{id}/claims but no entity is reused.
 # DEBATE_CLAIM_REUSE_ENABLED=false
 
 # Build (optional)

--- a/apps/web/core/claims/browse/claim-provenance.tsx
+++ b/apps/web/core/claims/browse/claim-provenance.tsx
@@ -41,12 +41,25 @@ export function ClaimProvenance({
   claimRelations: Relation[];
   spaceId: string;
 }) {
-  const source = React.useMemo(() => {
-    const relation = claimRelations.find(
-      candidate => candidate.isDeleted !== true && ID.equals(candidate.type.id, SOURCES_PROPERTY_ID)
-    );
-    return relation ? { id: relation.toEntity.id, name: relation.toEntity.name } : null;
+  // Every source, in relation order, deduped by target. A claim used to carry exactly one `Sources`
+  // relation because every debate minted its own Claim; with find-or-create a transcript claim that
+  // already exists in the space is linked to the existing entity, which then collects one `Sources`
+  // per debate that stated it. The first is rendered as the primary source and the rest listed, so
+  // no debate is hidden behind another.
+  const sources = React.useMemo(() => {
+    const seen = new Set<string>();
+    const out: Array<{ id: string; name: string | null }> = [];
+    for (const relation of claimRelations) {
+      if (relation.isDeleted === true || !ID.equals(relation.type.id, SOURCES_PROPERTY_ID)) continue;
+      const key = ID.uuidToHex(relation.toEntity.id);
+      if (seen.has(key)) continue;
+      seen.add(key);
+      out.push({ id: relation.toEntity.id, name: relation.toEntity.name });
+    }
+    return out;
   }, [claimRelations]);
+  const source = sources[0] ?? null;
+  const otherSources = sources.slice(1);
 
   // Only asked for once we know there is a source to attribute the claim to, and constrained to
   // blocks belonging to *that* source. A claim can be quoted by more than one transcript — the same
@@ -105,7 +118,9 @@ export function ClaimProvenance({
         <Text as="span" variant="metadata" color="grey-04">
           {speaker?.name ? (
             <>
-              First stated by{' '}
+              {/* Relation order says nothing about chronology, so "First" is only claimed when
+                  there is a single source to be first in. */}
+              {otherSources.length > 0 ? 'Stated by' : 'First stated by'}{' '}
               {/* Linked when the profile resolves to one. `profileLink` is nullable — a speaker
                   whose personal space has no front-page entity has nowhere to go, and a link to
                   nothing is worse than plain text. `whitespace-nowrap` keeps a two-word name from
@@ -125,6 +140,25 @@ export function ClaimProvenance({
         <Link href={NavUtils.toEntity(spaceId, source.id)} className="truncate text-metadata text-text hover:underline">
           {source.name ?? `this ${sourceKind}`}
         </Link>
+        {otherSources.length > 0 && (
+          <span className="truncate">
+            <Text as="span" variant="metadata" color="grey-04">
+              Also in{' '}
+            </Text>
+            {otherSources.map((other, index) => (
+              <React.Fragment key={other.id}>
+                {index > 0 ? (
+                  <Text as="span" variant="metadata" color="grey-04">
+                    ,{' '}
+                  </Text>
+                ) : null}
+                <Link href={NavUtils.toEntity(spaceId, other.id)} className="text-metadata text-text hover:underline">
+                  {other.name ?? `this ${sourceKind}`}
+                </Link>
+              </React.Fragment>
+            ))}
+          </span>
+        )}
       </div>
     </section>
   );

--- a/apps/web/core/claims/browse/claim-provenance.tsx
+++ b/apps/web/core/claims/browse/claim-provenance.tsx
@@ -118,9 +118,10 @@ export function ClaimProvenance({
         <Text as="span" variant="metadata" color="grey-04">
           {speaker?.name ? (
             <>
-              {/* Relation order says nothing about chronology, so "First" is only claimed when
-                  there is a single source to be first in. */}
-              {otherSources.length > 0 ? 'Stated by' : 'First stated by'}{' '}
+              {/* Not "First stated by": relation order says nothing about chronology, and a claim
+                  authored in the space by hand and reused by one debate carries a single Sources
+                  relation while predating that debate. */}
+              Stated by{' '}
               {/* Linked when the profile resolves to one. `profileLink` is nullable — a speaker
                   whose personal space has no front-page entity has nowhere to go, and a link to
                   nothing is worse than plain text. `whitespace-nowrap` keeps a two-word name from

--- a/apps/web/core/claims/browse/claim-provenance.tsx
+++ b/apps/web/core/claims/browse/claim-provenance.tsx
@@ -12,6 +12,7 @@ import { useProfilesBySpaceIds } from '~/core/hooks/use-profiles-by-space-ids';
 import { ID } from '~/core/id';
 import { useQueryEntities, useQueryEntity } from '~/core/sync/use-store';
 import type { Relation } from '~/core/types';
+import { dedupeRelationsByToEntityId } from '~/core/utils/dedupe-relations';
 import { NavUtils } from '~/core/utils/utils';
 
 import { Avatar } from '~/design-system/avatar';
@@ -25,9 +26,11 @@ import { Text } from '~/design-system/text';
  * cheap half of this. That source is not always a debate — an article can carry claims too — so
  * the sentence names it by its own type rather than asserting one.
  *
- * The speaker is the expensive half, and only debates have one: attribution rides the *text
- * block's* `Authors` relation rather than the claim's, so it takes a second hop back through
- * whichever block quoted the claim. Without a speaker the row still names the source.
+ * The speakers are the expensive half, and only debates have them: attribution rides the *text
+ * block's* `Authors` relation rather than the claim's, so it takes a second hop back through the
+ * blocks that quoted the claim. With find-or-create one claim can be quoted by both debaters of the
+ * same debate, so every block for the source is read and every distinct author named. Without a
+ * speaker the row still names the source.
  *
  * Renders nothing for a claim authored directly in a space — there is nothing to point at, and a
  * row that is empty more often than not is worse than no row.
@@ -46,18 +49,15 @@ export function ClaimProvenance({
   // already exists in the space is linked to the existing entity, which then collects one `Sources`
   // per debate that stated it. The first is rendered as the primary source and the rest listed, so
   // no debate is hidden behind another.
-  const sources = React.useMemo(() => {
-    const seen = new Set<string>();
-    const out: Array<{ id: string; name: string | null }> = [];
-    for (const relation of claimRelations) {
-      if (relation.isDeleted === true || !ID.equals(relation.type.id, SOURCES_PROPERTY_ID)) continue;
-      const key = ID.uuidToHex(relation.toEntity.id);
-      if (seen.has(key)) continue;
-      seen.add(key);
-      out.push({ id: relation.toEntity.id, name: relation.toEntity.name });
-    }
-    return out;
-  }, [claimRelations]);
+  const sources = React.useMemo(
+    () =>
+      dedupeRelationsByToEntityId(
+        claimRelations.filter(
+          relation => relation.isDeleted !== true && ID.equals(relation.type.id, SOURCES_PROPERTY_ID)
+        )
+      ).map(relation => ({ id: relation.toEntity.id, name: relation.toEntity.name })),
+    [claimRelations]
+  );
   const source = sources[0] ?? null;
   const otherSources = sources.slice(1);
 
@@ -65,7 +65,8 @@ export function ClaimProvenance({
   // blocks belonging to *that* source. A claim can be quoted by more than one transcript — the same
   // sentence surfacing in a later debate is the ordinary case, not an edge one — and a lookup keyed
   // on the claim alone would take whichever block came back first and hang someone else's name on
-  // it. Both clauses have to hold: relations given as an array are AND-ed.
+  // it. Both clauses have to hold: relations given as an array are AND-ed. All of the source's
+  // blocks are read, not the first: both debaters of one debate can quote the same claim.
   const { entities: blocks } = useQueryEntities({
     where: {
       types: [{ id: { equals: TEXT_BLOCK_TYPE_ID } }],
@@ -74,18 +75,23 @@ export function ClaimProvenance({
         { typeOf: { id: { equals: SOURCES_PROPERTY_ID } }, toEntity: { id: { equals: source?.id ?? '' } } },
       ],
     },
-    first: 1,
+    first: 20,
     enabled: source !== null,
   });
 
-  const speakerSpaceId = React.useMemo(() => {
+  const speakerSpaceIds = React.useMemo(() => {
+    const seen = new Set<string>();
+    const out: string[] = [];
     for (const block of blocks) {
-      const author = block.relations.find(
-        relation => relation.isDeleted !== true && ID.equals(relation.type.id, AUTHORS_PROPERTY_ID)
-      );
-      if (author) return author.toEntity.id;
+      for (const relation of block.relations) {
+        if (relation.isDeleted === true || !ID.equals(relation.type.id, AUTHORS_PROPERTY_ID)) continue;
+        const key = ID.uuidToHex(relation.toEntity.id);
+        if (seen.has(key)) continue;
+        seen.add(key);
+        out.push(relation.toEntity.id);
+      }
     }
-    return null;
+    return out;
   }, [blocks]);
 
   // `Sources` points wherever the claim came from, which is not always a debate — a claim pulled
@@ -94,9 +100,10 @@ export function ClaimProvenance({
   const { entity: sourceEntity } = useQueryEntity({ id: source?.id ?? '', enabled: source !== null });
   const sourceKind = sourceEntity?.types.find(type => type.name)?.name?.toLowerCase() ?? 'source';
 
-  const speakerSpaceIds = React.useMemo(() => (speakerSpaceId ? [speakerSpaceId] : []), [speakerSpaceId]);
   const { profilesBySpaceId } = useProfilesBySpaceIds(speakerSpaceIds, speakerSpaceIds.length > 0);
-  const speaker = speakerSpaceId ? profilesBySpaceId.get(speakerSpaceId) : undefined;
+  const speakers = speakerSpaceIds
+    .map(id => ({ id, profile: profilesBySpaceId.get(id) }))
+    .filter(speaker => Boolean(speaker.profile?.name));
 
   if (!source) return null;
 
@@ -105,9 +112,13 @@ export function ClaimProvenance({
       aria-label="Where this claim came from"
       className="flex items-center gap-2.5 rounded-lg border border-dashed border-grey-02 bg-grey-01 px-4 py-3"
     >
-      {speakerSpaceId && (
-        <span className="block size-6 shrink-0 overflow-hidden rounded-full bg-grey-02">
-          <Avatar avatarUrl={speaker?.avatarUrl} value={speakerSpaceId} size={24} />
+      {speakers.length > 0 && (
+        <span className="flex shrink-0 -space-x-2">
+          {speakers.map(speaker => (
+            <span key={speaker.id} className="block size-6 overflow-hidden rounded-full bg-grey-02">
+              <Avatar avatarUrl={speaker.profile?.avatarUrl} value={speaker.id} size={24} />
+            </span>
+          ))}
         </span>
       )}
       {/* Two lines rather than one sentence. Debate names are built from both debaters and the
@@ -116,23 +127,28 @@ export function ClaimProvenance({
           them puts the person on one line and what they said it in on the next. */}
       <div className="flex min-w-0 flex-col">
         <Text as="span" variant="metadata" color="grey-04">
-          {speaker?.name ? (
+          {speakers.length > 0 ? (
             <>
               {/* Not "First stated by": relation order says nothing about chronology, and a claim
                   authored in the space by hand and reused by one debate carries a single Sources
                   relation while predating that debate. */}
               Stated by{' '}
-              {/* Linked when the profile resolves to one. `profileLink` is nullable — a speaker
-                  whose personal space has no front-page entity has nowhere to go, and a link to
-                  nothing is worse than plain text. `whitespace-nowrap` keeps a two-word name from
-                  breaking across lines. */}
-              {speaker.profileLink ? (
-                <Link href={speaker.profileLink} className="whitespace-nowrap text-text hover:underline">
-                  {speaker.name}
-                </Link>
-              ) : (
-                <span className="whitespace-nowrap text-text">{speaker.name}</span>
-              )}
+              {speakers.map((speaker, index) => (
+                <React.Fragment key={speaker.id}>
+                  {index > 0 ? (index === speakers.length - 1 ? ' and ' : ', ') : null}
+                  {/* Linked when the profile resolves to one. `profileLink` is nullable — a speaker
+                      whose personal space has no front-page entity has nowhere to go, and a link to
+                      nothing is worse than plain text. `whitespace-nowrap` keeps a two-word name from
+                      breaking across lines. */}
+                  {speaker.profile?.profileLink ? (
+                    <Link href={speaker.profile.profileLink} className="whitespace-nowrap text-text hover:underline">
+                      {speaker.profile.name}
+                    </Link>
+                  ) : (
+                    <span className="whitespace-nowrap text-text">{speaker.profile?.name}</span>
+                  )}
+                </React.Fragment>
+              ))}
             </>
           ) : (
             `From the ${sourceKind}`

--- a/apps/web/core/debates/debate-publish-draft.test.ts
+++ b/apps/web/core/debates/debate-publish-draft.test.ts
@@ -324,6 +324,84 @@ describe('buildDebatePublishDraft', () => {
     );
   });
 
+  it('references an existing Claim instead of minting one when geo-chat matched it', () => {
+    const EXISTING = '4f12f5ea073442cbaa0fb10f70a9a876';
+    const draft = buildDebatePublishDraft(
+      baseInput({
+        claims: [
+          {
+            text: 'The burden to obtain an ID for voting may be too high.',
+            isFactual: false,
+            turnIndex: 0,
+            existingClaimEntityId: EXISTING,
+          },
+          { text: 'A novel point.', isFactual: true, turnIndex: 1 },
+        ],
+      }),
+      { createEntityId: idFactory(), createPosition: () => 'a0' }
+    );
+
+    // Nothing is written on the existing entity: no Name, no Types, no Is factual — an entity we did
+    // not create keeps its own facts even where this extraction disagrees.
+    expect(draft.values.some(v => v.entity.id === EXISTING)).toBe(false);
+    expect(draft.relations.some(r => r.fromEntity.id === EXISTING && r.type.id === TYPES_PROPERTY_ID)).toBe(false);
+    // Only the novel claim is minted.
+    expect(
+      draft.relations.filter(r => r.type.id === TYPES_PROPERTY_ID && r.toEntity.id === CLAIM_TYPE_ID)
+    ).toHaveLength(1);
+    // The speaker's block links to the existing claim, which gains this debate as a source.
+    expect(blockAuthoringClaim(draft, EXISTING)).toBe(YES_SPACE);
+    expect(
+      draft.relations.some(
+        r => r.type.id === SOURCES_PROPERTY_ID && r.fromEntity.id === EXISTING && r.toEntity.id === draft.debateEntityId
+      )
+    ).toBe(true);
+    // The novel claim is minted and attributed as before.
+    expect(blockAuthoringClaim(draft, claimIdByName(draft, 'A novel point.'))).toBe(NO_SPACE);
+  });
+
+  it('mints a fresh Claim when the existing id is blank or null', () => {
+    const draft = buildDebatePublishDraft(
+      baseInput({
+        claims: [
+          { text: 'Blank reference', isFactual: null, turnIndex: 0, existingClaimEntityId: '   ' },
+          { text: 'Null reference', isFactual: null, turnIndex: 0, existingClaimEntityId: null },
+        ],
+      }),
+      { createEntityId: idFactory(), createPosition: () => 'a0' }
+    );
+    expect(claimIdByName(draft, 'Blank reference')).toBeTruthy();
+    expect(claimIdByName(draft, 'Null reference')).toBeTruthy();
+    expect(
+      draft.relations.filter(r => r.type.id === TYPES_PROPERTY_ID && r.toEntity.id === CLAIM_TYPE_ID)
+    ).toHaveLength(2);
+  });
+
+  it('a reused claim survives the real publish pipeline as relations only', async () => {
+    const EXISTING = '4f12f5ea073442cbaa0fb10f70a9a876';
+    // Real entity ids: the op pipeline validates them, unlike the draft-only tests above. Ids are
+    // encoded as bytes in ops, so the two drafts are compared by op shape rather than by id.
+    const claim = { text: 'Reused claim', isFactual: true, turnIndex: 0 };
+    const minted = buildDebatePublishDraft(baseInput({ claims: [claim] }), { createEntityId: ID.createEntityId });
+    const reused = buildDebatePublishDraft(baseInput({ claims: [{ ...claim, existingClaimEntityId: EXISTING }] }), {
+      createEntityId: ID.createEntityId,
+    });
+    const mintedOps = await Effect.runPromise(
+      Publish.prepareLocalDataForPublishing(minted.values, minted.relations, SPACE)
+    );
+    const reusedOps = await Effect.runPromise(
+      Publish.prepareLocalDataForPublishing(reused.values, reused.relations, SPACE)
+    );
+    const relationOps = (ops: typeof mintedOps) => ops.filter(op => op.type === 'createRelation').length;
+    const otherOps = (ops: typeof mintedOps) => ops.filter(op => op.type !== 'createRelation').length;
+
+    expect(reusedOps.length).toBeGreaterThan(0);
+    // Reuse drops exactly the Types relation and every value op on the claim (Name, Is factual);
+    // the block→Claims and claim→Sources relations are still there.
+    expect(relationOps(reusedOps)).toBe(relationOps(mintedOps) - 1);
+    expect(otherOps(reusedOps)).toBeLessThan(otherOps(mintedOps));
+  });
+
   it('mints no Claim entities when no claims are provided (backwards compatible)', () => {
     const draft = buildDebatePublishDraft(baseInput(), { createEntityId: idFactory(), createPosition: () => 'a0' });
     expect(draft.relations.some(r => r.type.id === TYPES_PROPERTY_ID && r.toEntity.id === CLAIM_TYPE_ID)).toBe(false);

--- a/apps/web/core/debates/debate-publish-draft.test.ts
+++ b/apps/web/core/debates/debate-publish-draft.test.ts
@@ -360,6 +360,30 @@ describe('buildDebatePublishDraft', () => {
     expect(blockAuthoringClaim(draft, claimIdByName(draft, 'A novel point.'))).toBe(NO_SPACE);
   });
 
+  it('writes each relation once when several claims resolve to the same existing entity', () => {
+    const EXISTING = '4f12f5ea073442cbaa0fb10f70a9a876';
+    const draft = buildDebatePublishDraft(
+      baseInput({
+        claims: [
+          // Both debaters restate the same published point, and one restates it twice in a turn.
+          { text: 'Same point, yes side.', isFactual: null, turnIndex: 0, existingClaimEntityId: EXISTING },
+          { text: 'Same point again, yes side.', isFactual: null, turnIndex: 0, existingClaimEntityId: EXISTING },
+          { text: 'Same point, no side.', isFactual: null, turnIndex: 1, existingClaimEntityId: EXISTING },
+        ],
+      }),
+      { createEntityId: idFactory(), createPosition: () => 'a0' }
+    );
+    const sources = draft.relations.filter(r => r.type.id === SOURCES_PROPERTY_ID && r.fromEntity.id === EXISTING);
+    expect(sources).toHaveLength(1);
+    expect(sources[0].toEntity.id).toBe(draft.debateEntityId);
+    const blockLinks = draft.relations.filter(
+      r => r.type.id === DEBATE_CLAIMS_PROPERTY_ID && r.toEntity.id === EXISTING
+    );
+    // One Claims edge per block, not per extracted claim.
+    expect(blockLinks).toHaveLength(2);
+    expect(new Set(blockLinks.map(r => r.fromEntity.id)).size).toBe(2);
+  });
+
   it('mints a fresh Claim when the existing id is blank or null', () => {
     const draft = buildDebatePublishDraft(
       baseInput({

--- a/apps/web/core/debates/debate-publish-draft.ts
+++ b/apps/web/core/debates/debate-publish-draft.ts
@@ -63,6 +63,14 @@ export type DebateClaimInput = {
    * rides its Authors relation for speaker attribution.
    */
   turnIndex: number;
+  /**
+   * Find-or-create: the already-published Claim entity in the debate's space that geo-chat judged
+   * logically equivalent to this claim (its `existing_entity_id`). When set, the draft references
+   * that entity — the block's Claims relation and the claim's Sources relation point at it — and
+   * mints nothing: no Name, no Types, no Is factual, so an entity we did not create keeps its own
+   * facts. Null/absent mints a fresh Claim as before.
+   */
+  existingClaimEntityId?: string | null;
 };
 
 export type DebatePublishInput = {
@@ -338,20 +346,28 @@ export function buildDebatePublishDraft(input: DebatePublishInput, options: Buil
       // the Claims relation — so attribution rides the block's Authors relation (the speaker), with no
       // separate claim→speaker property. Side (for/against) is recoverable from the participant's
       // Supported/Opposed-by membership on the Debate.
+      //
+      // Find-or-create: a claim geo-chat matched to an existing Claim in this space reuses that
+      // entity. Only the two relations are written — the block's Claims and the claim's Sources —
+      // and nothing on the entity itself, so a claim someone else published keeps its own Name,
+      // Types and Is factual even where this extraction would have said otherwise.
       for (const claim of claimsByTurnIndex.get(turn.turnIndex) ?? []) {
         const claimEntityText = claim.text.trim();
         if (claimEntityText.length === 0) continue;
-        const claimId = createEntityId();
+        const existingClaimId = claim.existingClaimEntityId?.trim() || null;
+        const claimId = existingClaimId ?? createEntityId();
         const claimRef = { id: claimId, name: claimEntityText };
-        setText(claimId, claimEntityText, NAME_PROPERTY_ID, claimEntityText);
-        relate({
-          fromEntity: claimRef,
-          propertyId: TYPES_PROPERTY_ID,
-          toEntityId: CLAIM_TYPE_ID,
-          toEntityName: 'Claim',
-        });
-        if (claim.isFactual !== null) {
-          setBoolean(claimId, claimEntityText, CLAIM_IS_FACTUAL_PROPERTY_ID, claim.isFactual);
+        if (existingClaimId === null) {
+          setText(claimId, claimEntityText, NAME_PROPERTY_ID, claimEntityText);
+          relate({
+            fromEntity: claimRef,
+            propertyId: TYPES_PROPERTY_ID,
+            toEntityId: CLAIM_TYPE_ID,
+            toEntityName: 'Claim',
+          });
+          if (claim.isFactual !== null) {
+            setBoolean(claimId, claimEntityText, CLAIM_IS_FACTUAL_PROPERTY_ID, claim.isFactual);
+          }
         }
         relate({
           fromEntity: blockRef,

--- a/apps/web/core/debates/debate-publish-draft.ts
+++ b/apps/web/core/debates/debate-publish-draft.ts
@@ -310,6 +310,14 @@ export function buildDebatePublishDraft(input: DebatePublishInput, options: Buil
       toEntityName: transcriptName,
     });
 
+    // Every iteration used to mint a fresh claim id, which made these pairs unique by construction.
+    // A reused entity can appear behind several extracted claims (both debaters restating the same
+    // published point, or two near-duplicate extractions from one turn), and `relate` does not
+    // dedupe, so the pairs are tracked: one Claims edge per (block, claim), one Sources edge per
+    // claim per debate.
+    const linkedBlockClaims = new Set<string>();
+    const sourcedClaims = new Set<string>();
+
     turns.forEach(turn => {
       const speakerName = turn.speakerName?.trim() ? turn.speakerName.trim() : 'Anonymous';
       const blockId = createEntityId();
@@ -369,18 +377,25 @@ export function buildDebatePublishDraft(input: DebatePublishInput, options: Buil
             setBoolean(claimId, claimEntityText, CLAIM_IS_FACTUAL_PROPERTY_ID, claim.isFactual);
           }
         }
-        relate({
-          fromEntity: blockRef,
-          propertyId: DEBATE_CLAIMS_PROPERTY_ID,
-          toEntityId: claimId,
-          toEntityName: claimEntityText,
-        });
-        relate({
-          fromEntity: claimRef,
-          propertyId: SOURCES_PROPERTY_ID,
-          toEntityId: debateEntityId,
-          toEntityName: debateName,
-        });
+        const blockClaimKey = `${blockId}:${claimId}`;
+        if (!linkedBlockClaims.has(blockClaimKey)) {
+          linkedBlockClaims.add(blockClaimKey);
+          relate({
+            fromEntity: blockRef,
+            propertyId: DEBATE_CLAIMS_PROPERTY_ID,
+            toEntityId: claimId,
+            toEntityName: claimEntityText,
+          });
+        }
+        if (!sourcedClaims.has(claimId)) {
+          sourcedClaims.add(claimId);
+          relate({
+            fromEntity: claimRef,
+            propertyId: SOURCES_PROPERTY_ID,
+            toEntityId: debateEntityId,
+            toEntityName: debateName,
+          });
+        }
       }
     });
   }

--- a/apps/web/core/debates/server/acceptor-config.ts
+++ b/apps/web/core/debates/server/acceptor-config.ts
@@ -19,7 +19,7 @@ export type DebateAcceptorConfig = {
 };
 
 /** Secrets UIs and shell exports often keep the wrapping quotes as part of the value. */
-function readEnv(name: string): string {
+export function readEnv(name: string): string {
   const value = process.env[name]?.trim() ?? '';
   const quoted = /^(['"])([\s\S]*)\1$/.exec(value);
   return quoted ? quoted[2].trim() : value;

--- a/apps/web/core/debates/server/claim-reuse.test.ts
+++ b/apps/web/core/debates/server/claim-reuse.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { CLAIM_TYPE_ID } from '~/core/claims/ontology';
+
+import type { DebateClaimInput } from '../debate-publish-draft';
+import {
+  type ExistingClaimEntity,
+  type ExistingClaimLookup,
+  applyClaimReusePolicy,
+  isDebateClaimReuseEnabled,
+} from './claim-reuse';
+
+const SPACE = 'c9f267dcb0d270718c2a3c45a64afd32';
+const OTHER_SPACE = '4582fbbee28a16589154f7e36f1ee3c5';
+const EXISTING = '4f12f5ea073442cbaa0fb10f70a9a876';
+const GONE = '00000000000000000000000000000001';
+const ELSEWHERE = '00000000000000000000000000000002';
+const NOT_A_CLAIM = '00000000000000000000000000000003';
+
+const claims: DebateClaimInput[] = [
+  {
+    text: 'The burden to obtain an ID for voting may be too high.',
+    isFactual: false,
+    turnIndex: 0,
+    existingClaimEntityId: EXISTING,
+  },
+  { text: 'A novel point.', isFactual: true, turnIndex: 1, existingClaimEntityId: null },
+  { text: 'Deleted since the match.', isFactual: null, turnIndex: 1, existingClaimEntityId: GONE },
+  { text: 'Lives in another space.', isFactual: null, turnIndex: 2, existingClaimEntityId: ELSEWHERE },
+  { text: 'Re-typed since the match.', isFactual: null, turnIndex: 2, existingClaimEntityId: NOT_A_CLAIM },
+];
+
+const graph: ExistingClaimEntity[] = [
+  { id: EXISTING, spaces: [SPACE, OTHER_SPACE], types: [{ id: CLAIM_TYPE_ID }] },
+  { id: ELSEWHERE, spaces: [OTHER_SPACE], types: [{ id: CLAIM_TYPE_ID }] },
+  { id: NOT_A_CLAIM, spaces: [SPACE], types: [{ id: 'dec3c8cae071482394f1dc4de11e7fb6' }] },
+];
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+});
+
+describe('applyClaimReusePolicy', () => {
+  it('drops every reference and never reads the graph while reuse is off (shadow mode)', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    const lookup = vi.fn(async () => graph);
+
+    const result = await applyClaimReusePolicy(claims, SPACE, { enabled: false, lookup });
+
+    expect(lookup).not.toHaveBeenCalled();
+    expect(result.map(claim => claim.existingClaimEntityId)).toEqual([null, null, null, null, null]);
+    // Nothing else about the claims changes.
+    expect(result.map(claim => claim.text)).toEqual(claims.map(claim => claim.text));
+  });
+
+  it('keeps a reference only when the entity still exists as a Claim in this space', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const lookup = vi.fn<ExistingClaimLookup>(async () => graph);
+
+    const result = await applyClaimReusePolicy(claims, SPACE, { enabled: true, lookup });
+
+    // One batched read over the distinct referenced ids.
+    expect(lookup).toHaveBeenCalledTimes(1);
+    expect([...(lookup.mock.calls[0]?.[0] ?? [])].sort()).toEqual([EXISTING, GONE, ELSEWHERE, NOT_A_CLAIM].sort());
+    expect(result.map(claim => claim.existingClaimEntityId)).toEqual([EXISTING, null, null, null, null]);
+  });
+
+  it('accepts a space id in dashed form against the graph’s hex spaceIds', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    const lookup = vi.fn(async () => graph);
+    const dashed = 'c9f267dc-b0d2-7071-8c2a-3c45a64afd32';
+
+    const result = await applyClaimReusePolicy([claims[0]], dashed, { enabled: true, lookup });
+
+    expect(result[0].existingClaimEntityId).toBe(EXISTING);
+  });
+
+  it('mints everything when the verification read fails, rather than trusting stale references', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const lookup = vi.fn(async () => {
+      throw new Error('graph unavailable');
+    });
+
+    const result = await applyClaimReusePolicy(claims, SPACE, { enabled: true, lookup });
+
+    expect(result.every(claim => claim.existingClaimEntityId === null)).toBe(true);
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it('returns the input untouched when nothing was matched', async () => {
+    const lookup = vi.fn(async () => graph);
+    const unmatched = claims.map(claim => ({ ...claim, existingClaimEntityId: null }));
+
+    const result = await applyClaimReusePolicy(unmatched, SPACE, { enabled: true, lookup });
+
+    expect(result).toBe(unmatched);
+    expect(lookup).not.toHaveBeenCalled();
+  });
+});
+
+describe('isDebateClaimReuseEnabled', () => {
+  it('is off by default and on for the usual truthy spellings, quoted or not', () => {
+    vi.stubEnv('DEBATE_CLAIM_REUSE_ENABLED', '');
+    expect(isDebateClaimReuseEnabled()).toBe(false);
+    vi.stubEnv('DEBATE_CLAIM_REUSE_ENABLED', 'false');
+    expect(isDebateClaimReuseEnabled()).toBe(false);
+    vi.stubEnv('DEBATE_CLAIM_REUSE_ENABLED', 'true');
+    expect(isDebateClaimReuseEnabled()).toBe(true);
+    vi.stubEnv('DEBATE_CLAIM_REUSE_ENABLED', '"1"');
+    expect(isDebateClaimReuseEnabled()).toBe(true);
+  });
+});

--- a/apps/web/core/debates/server/claim-reuse.test.ts
+++ b/apps/web/core/debates/server/claim-reuse.test.ts
@@ -149,14 +149,16 @@ describe('applyClaimReusePolicy', () => {
 });
 
 describe('isDebateClaimReuseEnabled', () => {
-  it('is off by default and on for the usual truthy spellings, quoted or not', () => {
+  it('is on by default and off for the usual falsy spellings, quoted or not', () => {
     vi.stubEnv('DEBATE_CLAIM_REUSE_ENABLED', '');
-    expect(isDebateClaimReuseEnabled()).toBe(false);
-    vi.stubEnv('DEBATE_CLAIM_REUSE_ENABLED', 'false');
-    expect(isDebateClaimReuseEnabled()).toBe(false);
+    expect(isDebateClaimReuseEnabled()).toBe(true);
     vi.stubEnv('DEBATE_CLAIM_REUSE_ENABLED', 'true');
     expect(isDebateClaimReuseEnabled()).toBe(true);
-    vi.stubEnv('DEBATE_CLAIM_REUSE_ENABLED', '"1"');
-    expect(isDebateClaimReuseEnabled()).toBe(true);
+    vi.stubEnv('DEBATE_CLAIM_REUSE_ENABLED', 'false');
+    expect(isDebateClaimReuseEnabled()).toBe(false);
+    vi.stubEnv('DEBATE_CLAIM_REUSE_ENABLED', '"0"');
+    expect(isDebateClaimReuseEnabled()).toBe(false);
+    vi.stubEnv('DEBATE_CLAIM_REUSE_ENABLED', 'off');
+    expect(isDebateClaimReuseEnabled()).toBe(false);
   });
 });

--- a/apps/web/core/debates/server/claim-reuse.test.ts
+++ b/apps/web/core/debates/server/claim-reuse.test.ts
@@ -67,6 +67,33 @@ describe('applyClaimReusePolicy', () => {
     expect(result.map(claim => claim.existingClaimEntityId)).toEqual([EXISTING, null, null, null, null]);
   });
 
+  it('never reuses the debate motion, even though it is a Claim in the space', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const motion = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+    const lookup = vi.fn<ExistingClaimLookup>(async () => [
+      ...graph,
+      { id: motion, spaces: [SPACE], types: [{ id: CLAIM_TYPE_ID }] },
+    ]);
+    const restated: DebateClaimInput = {
+      text: 'The motion, restated.',
+      isFactual: null,
+      turnIndex: 0,
+      existingClaimEntityId: 'AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA',
+    };
+
+    const result = await applyClaimReusePolicy([restated, claims[0]], SPACE, {
+      enabled: true,
+      lookup,
+      motionClaimEntityId: motion,
+    });
+
+    expect(result.map(claim => claim.existingClaimEntityId)).toEqual([null, EXISTING]);
+    // The motion is not even looked up.
+    expect(lookup.mock.calls[0]?.[0]).toEqual([EXISTING]);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('debate motion'), expect.objectContaining({ count: 1 }));
+  });
+
   it('accepts a space id in dashed form against the graph’s hex spaceIds', async () => {
     vi.spyOn(console, 'log').mockImplementation(() => {});
     const lookup = vi.fn(async () => graph);

--- a/apps/web/core/debates/server/claim-reuse.test.ts
+++ b/apps/web/core/debates/server/claim-reuse.test.ts
@@ -94,6 +94,27 @@ describe('applyClaimReusePolicy', () => {
     expect(warn).toHaveBeenCalledWith(expect.stringContaining('debate motion'), expect.objectContaining({ count: 1 }));
   });
 
+  it('drops references that are not entity ids without failing the batch for the rest', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const lookup = vi.fn<ExistingClaimLookup>(async () => graph);
+    const broken: DebateClaimInput = {
+      text: 'Bad reference.',
+      isFactual: null,
+      turnIndex: 0,
+      existingClaimEntityId: 'not-an-id',
+    };
+
+    const result = await applyClaimReusePolicy([broken, claims[0]], SPACE, { enabled: true, lookup });
+
+    expect(result.map(claim => claim.existingClaimEntityId)).toEqual([null, EXISTING]);
+    expect(lookup.mock.calls[0]?.[0]).toEqual([EXISTING]);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('not entity ids'),
+      expect.objectContaining({ ids: ['not-an-id'] })
+    );
+  });
+
   it('accepts a space id in dashed form against the graph’s hex spaceIds', async () => {
     vi.spyOn(console, 'log').mockImplementation(() => {});
     const lookup = vi.fn(async () => graph);

--- a/apps/web/core/debates/server/claim-reuse.ts
+++ b/apps/web/core/debates/server/claim-reuse.ts
@@ -1,0 +1,139 @@
+import { Effect } from 'effect';
+
+import { CLAIM_TYPE_ID } from '~/core/claims/ontology';
+import { uuidToHex } from '~/core/id/normalize';
+import { getBatchEntities } from '~/core/io/queries';
+
+import type { DebateClaimInput } from '../debate-publish-draft';
+
+/**
+ * Find-or-create, half two: which of geo-chat's `existing_entity_id` references the publisher may
+ * honour.
+ *
+ * geo-chat's media worker matched each extracted claim against the published claims in the debate's
+ * space (geo-lens retrieval, then extraction-api's equivalence judge) about an hour before this
+ * sweep runs. Two things can still be wrong with a reference by now, so each is checked in one
+ * batched graph read before the draft is built: the entity may have been deleted or re-typed, or it
+ * may live in another space after all. Anything that fails is minted as a fresh Claim, exactly as
+ * before matching existed — a duplicate is the known, tolerable failure; attaching a debater to the
+ * wrong entity is not.
+ *
+ * Behind `DEBATE_CLAIM_REUSE_ENABLED`. With it off (the default) every reference is dropped and only
+ * counted, so a deployment can run geo-chat's matching in shadow mode and read its verdicts from
+ * `GET /debates/{id}/claims` before a single entity is reused.
+ */
+
+/** What the verifier needs to know about a referenced entity. */
+export type ExistingClaimEntity = {
+  id: string;
+  /** Every space holding a value or relation of the entity. */
+  spaces: string[];
+  types: Array<{ id: string }>;
+};
+
+export type ExistingClaimLookup = (entityIds: string[]) => Promise<ExistingClaimEntity[]>;
+
+const lookupInGraph: ExistingClaimLookup = async entityIds => {
+  const entities = await Effect.runPromise(getBatchEntities(entityIds));
+  return entities.map(entity => ({ id: entity.id, spaces: entity.spaces, types: entity.types }));
+};
+
+/** Secrets UIs and shell exports often keep the wrapping quotes as part of the value. */
+function readEnv(name: string): string {
+  const value = process.env[name]?.trim() ?? '';
+  const quoted = /^(['"])([\s\S]*)\1$/.exec(value);
+  return quoted ? quoted[2].trim() : value;
+}
+
+export function isDebateClaimReuseEnabled(): boolean {
+  return /^(true|1|yes|on)$/i.test(readEnv('DEBATE_CLAIM_REUSE_ENABLED'));
+}
+
+export type ClaimReuseOptions = {
+  /** Defaults to `DEBATE_CLAIM_REUSE_ENABLED`. */
+  enabled?: boolean;
+  /** Defaults to a batched graph read. Injectable for tests. */
+  lookup?: ExistingClaimLookup;
+  /** For the log line only. */
+  debateId?: string;
+};
+
+/**
+ * Returns the claims with `existingClaimEntityId` kept only where reuse is enabled AND the entity
+ * exists, carries the Claim type and lives in `spaceId`. Every other reference becomes null. Never
+ * throws: a failed graph read drops every reference (and says so), because minting duplicates is the
+ * pre-matching behaviour and the safe side.
+ */
+export async function applyClaimReusePolicy(
+  claims: DebateClaimInput[],
+  spaceId: string,
+  options: ClaimReuseOptions = {}
+): Promise<DebateClaimInput[]> {
+  const referenced = claims.filter(claim => Boolean(claim.existingClaimEntityId));
+  if (referenced.length === 0) return claims;
+
+  const enabled = options.enabled ?? isDebateClaimReuseEnabled();
+  if (!enabled) {
+    console.log('[debate-acceptor] claim reuse is off; minting matched claims (shadow mode)', {
+      debateId: options.debateId,
+      claims: claims.length,
+      matched: referenced.length,
+    });
+    return claims.map(withoutReference);
+  }
+
+  const ids = [...new Set(referenced.map(claim => claim.existingClaimEntityId as string))];
+  let verified: Set<string>;
+  try {
+    const entities = await (options.lookup ?? lookupInGraph)(ids);
+    const spaceKey = uuidToHex(spaceId);
+    verified = new Set(
+      entities
+        .filter(
+          entity =>
+            entity.types.some(type => uuidToHex(type.id) === uuidToHex(CLAIM_TYPE_ID)) &&
+            entity.spaces.some(space => uuidToHex(space) === spaceKey)
+        )
+        .map(entity => uuidToHex(entity.id))
+    );
+  } catch (error) {
+    console.warn('[debate-acceptor] could not verify matched claims; minting all of them instead', {
+      debateId: options.debateId,
+      matched: referenced.length,
+      error,
+    });
+    return claims.map(withoutReference);
+  }
+
+  let reused = 0;
+  const result = claims.map(claim => {
+    if (!claim.existingClaimEntityId) return claim;
+    if (verified.has(uuidToHex(claim.existingClaimEntityId))) {
+      reused += 1;
+      return claim;
+    }
+    return withoutReference(claim);
+  });
+  const dropped = referenced.length - reused;
+  console.log('[debate-acceptor] claim reuse decided', {
+    debateId: options.debateId,
+    claims: claims.length,
+    matched: referenced.length,
+    reused,
+    dropped,
+  });
+  if (dropped > 0) {
+    console.warn('[debate-acceptor] matched claims no longer verifiable as Claims in this space; minted instead', {
+      debateId: options.debateId,
+      spaceId,
+      entityIds: referenced
+        .filter(claim => !verified.has(uuidToHex(claim.existingClaimEntityId as string)))
+        .map(claim => claim.existingClaimEntityId),
+    });
+  }
+  return result;
+}
+
+function withoutReference(claim: DebateClaimInput): DebateClaimInput {
+  return claim.existingClaimEntityId ? { ...claim, existingClaimEntityId: null } : claim;
+}

--- a/apps/web/core/debates/server/claim-reuse.ts
+++ b/apps/web/core/debates/server/claim-reuse.ts
@@ -2,10 +2,11 @@ import { Effect } from 'effect';
 
 import { CLAIM_TYPE_ID } from '~/core/claims/ontology';
 import { uuidToHex } from '~/core/id/normalize';
-import { getBatchEntities } from '~/core/io/queries';
+import { graphql } from '~/core/io/graphql-client';
 
 import type { DebateClaimInput } from '../debate-publish-draft';
 import { readEnv } from './acceptor-config';
+import { existingClaimsDocument } from './existing-claims-document';
 
 /**
  * Find-or-create, half two: which of geo-chat's `existing_entity_id` references the publisher may
@@ -34,10 +35,30 @@ export type ExistingClaimEntity = {
 
 export type ExistingClaimLookup = (entityIds: string[]) => Promise<ExistingClaimEntity[]>;
 
-const lookupInGraph: ExistingClaimLookup = async entityIds => {
-  const entities = await Effect.runPromise(getBatchEntities(entityIds));
-  return entities.map(entity => ({ id: entity.id, spaces: entity.spaces, types: entity.types }));
-};
+const lookupInGraph: ExistingClaimLookup = entityIds =>
+  Effect.runPromise(
+    graphql({
+      query: existingClaimsDocument,
+      decoder: data =>
+        (data.entities ?? []).flatMap(entity =>
+          entity
+            ? [
+                {
+                  id: entity.id,
+                  spaces: (entity.spaceIds ?? []).filter((id): id is string => typeof id === 'string'),
+                  types: (entity.types ?? []).flatMap(type => (type ? [{ id: type.id }] : [])),
+                },
+              ]
+            : []
+        ),
+      variables: { ids: entityIds },
+    })
+  );
+
+/** A Geo entity id in either shape: 32 hex chars, dashed or not. Anything else cannot be queried. */
+export function looksLikeEntityId(id: string): boolean {
+  return /^[0-9a-f]{32}$/i.test(id.replace(/-/g, ''));
+}
 
 export function isDebateClaimReuseEnabled(): boolean {
   return /^(true|1|yes|on)$/i.test(readEnv('DEBATE_CLAIM_REUSE_ENABLED'));
@@ -81,6 +102,17 @@ export async function applyClaimReusePolicy(
     return claims.map(withoutReference);
   }
 
+  // One malformed id would fail the whole batched read (the API rejects the query, not the id), and
+  // the fail-safe below would then mint every matched claim in the debate. Drop those first.
+  const isMalformed = (id: string) => !looksLikeEntityId(id);
+  const malformed = referenced.filter(claim => isMalformed(claim.existingClaimEntityId as string));
+  if (malformed.length > 0) {
+    console.warn('[debate-acceptor] matched claims carry ids that are not entity ids; minting them instead', {
+      debateId: options.debateId,
+      ids: malformed.map(claim => claim.existingClaimEntityId),
+    });
+  }
+
   const motionKey = options.motionClaimEntityId ? uuidToHex(options.motionClaimEntityId) : null;
   const isMotion = (id: string) => motionKey !== null && uuidToHex(id) === motionKey;
   const motionReferences = referenced.filter(claim => isMotion(claim.existingClaimEntityId as string));
@@ -91,7 +123,11 @@ export async function applyClaimReusePolicy(
     });
   }
 
-  const ids = [...new Set(referenced.map(claim => claim.existingClaimEntityId as string).filter(id => !isMotion(id)))];
+  const ids = [
+    ...new Set(
+      referenced.map(claim => claim.existingClaimEntityId as string).filter(id => !isMalformed(id) && !isMotion(id))
+    ),
+  ];
   let verified: Set<string>;
   try {
     const entities = ids.length > 0 ? await (options.lookup ?? lookupInGraph)(ids) : [];
@@ -117,7 +153,11 @@ export async function applyClaimReusePolicy(
   let reused = 0;
   const result = claims.map(claim => {
     if (!claim.existingClaimEntityId) return claim;
-    if (!isMotion(claim.existingClaimEntityId) && verified.has(uuidToHex(claim.existingClaimEntityId))) {
+    if (
+      !isMalformed(claim.existingClaimEntityId) &&
+      !isMotion(claim.existingClaimEntityId) &&
+      verified.has(uuidToHex(claim.existingClaimEntityId))
+    ) {
       reused += 1;
       return claim;
     }
@@ -138,7 +178,7 @@ export async function applyClaimReusePolicy(
       entityIds: referenced
         .filter(claim => {
           const id = claim.existingClaimEntityId as string;
-          return isMotion(id) || !verified.has(uuidToHex(id));
+          return isMalformed(id) || isMotion(id) || !verified.has(uuidToHex(id));
         })
         .map(claim => claim.existingClaimEntityId),
     });

--- a/apps/web/core/debates/server/claim-reuse.ts
+++ b/apps/web/core/debates/server/claim-reuse.ts
@@ -5,6 +5,7 @@ import { uuidToHex } from '~/core/id/normalize';
 import { getBatchEntities } from '~/core/io/queries';
 
 import type { DebateClaimInput } from '../debate-publish-draft';
+import { readEnv } from './acceptor-config';
 
 /**
  * Find-or-create, half two: which of geo-chat's `existing_entity_id` references the publisher may
@@ -38,13 +39,6 @@ const lookupInGraph: ExistingClaimLookup = async entityIds => {
   return entities.map(entity => ({ id: entity.id, spaces: entity.spaces, types: entity.types }));
 };
 
-/** Secrets UIs and shell exports often keep the wrapping quotes as part of the value. */
-function readEnv(name: string): string {
-  const value = process.env[name]?.trim() ?? '';
-  const quoted = /^(['"])([\s\S]*)\1$/.exec(value);
-  return quoted ? quoted[2].trim() : value;
-}
-
 export function isDebateClaimReuseEnabled(): boolean {
   return /^(true|1|yes|on)$/i.test(readEnv('DEBATE_CLAIM_REUSE_ENABLED'));
 }
@@ -54,6 +48,11 @@ export type ClaimReuseOptions = {
   enabled?: boolean;
   /** Defaults to a batched graph read. Injectable for tests. */
   lookup?: ExistingClaimLookup;
+  /**
+   * The debate's own motion. It is a Claim in the publication space, so it passes every other check,
+   * but a debater restating the motion must not make the motion "their" transcript claim.
+   */
+  motionClaimEntityId?: string;
   /** For the log line only. */
   debateId?: string;
 };
@@ -82,10 +81,20 @@ export async function applyClaimReusePolicy(
     return claims.map(withoutReference);
   }
 
-  const ids = [...new Set(referenced.map(claim => claim.existingClaimEntityId as string))];
+  const motionKey = options.motionClaimEntityId ? uuidToHex(options.motionClaimEntityId) : null;
+  const isMotion = (id: string) => motionKey !== null && uuidToHex(id) === motionKey;
+  const motionReferences = referenced.filter(claim => isMotion(claim.existingClaimEntityId as string));
+  if (motionReferences.length > 0) {
+    console.warn('[debate-acceptor] matched claims point at the debate motion; minting them instead', {
+      debateId: options.debateId,
+      count: motionReferences.length,
+    });
+  }
+
+  const ids = [...new Set(referenced.map(claim => claim.existingClaimEntityId as string).filter(id => !isMotion(id)))];
   let verified: Set<string>;
   try {
-    const entities = await (options.lookup ?? lookupInGraph)(ids);
+    const entities = ids.length > 0 ? await (options.lookup ?? lookupInGraph)(ids) : [];
     const spaceKey = uuidToHex(spaceId);
     verified = new Set(
       entities
@@ -108,7 +117,7 @@ export async function applyClaimReusePolicy(
   let reused = 0;
   const result = claims.map(claim => {
     if (!claim.existingClaimEntityId) return claim;
-    if (verified.has(uuidToHex(claim.existingClaimEntityId))) {
+    if (!isMotion(claim.existingClaimEntityId) && verified.has(uuidToHex(claim.existingClaimEntityId))) {
       reused += 1;
       return claim;
     }
@@ -127,7 +136,10 @@ export async function applyClaimReusePolicy(
       debateId: options.debateId,
       spaceId,
       entityIds: referenced
-        .filter(claim => !verified.has(uuidToHex(claim.existingClaimEntityId as string)))
+        .filter(claim => {
+          const id = claim.existingClaimEntityId as string;
+          return isMotion(id) || !verified.has(uuidToHex(id));
+        })
         .map(claim => claim.existingClaimEntityId),
     });
   }

--- a/apps/web/core/debates/server/claim-reuse.ts
+++ b/apps/web/core/debates/server/claim-reuse.ts
@@ -20,9 +20,9 @@ import { existingClaimsDocument } from './existing-claims-document';
  * before matching existed — a duplicate is the known, tolerable failure; attaching a debater to the
  * wrong entity is not.
  *
- * Behind `DEBATE_CLAIM_REUSE_ENABLED`. With it off (the default) every reference is dropped and only
- * counted, so a deployment can run geo-chat's matching in shadow mode and read its verdicts from
- * `GET /debates/{id}/claims` before a single entity is reused.
+ * On by default. `DEBATE_CLAIM_REUSE_ENABLED=false` turns it off: every reference is then dropped and
+ * only counted, so a deployment can run geo-chat's matching in shadow mode and read its verdicts
+ * from `GET /debates/{id}/claims` without reusing a single entity.
  */
 
 /** What the verifier needs to know about a referenced entity. */
@@ -61,7 +61,7 @@ export function looksLikeEntityId(id: string): boolean {
 }
 
 export function isDebateClaimReuseEnabled(): boolean {
-  return /^(true|1|yes|on)$/i.test(readEnv('DEBATE_CLAIM_REUSE_ENABLED'));
+  return !/^(false|0|no|off)$/i.test(readEnv('DEBATE_CLAIM_REUSE_ENABLED'));
 }
 
 export type ClaimReuseOptions = {

--- a/apps/web/core/debates/server/debate-source.test.ts
+++ b/apps/web/core/debates/server/debate-source.test.ts
@@ -1,6 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { applyClaimReusePolicy } from './claim-reuse';
 import { DebateNotPublishableError, listSweepCandidateDebateIds, loadDebatePublishSource } from './debate-source';
+
+// The reuse policy needs a graph read and its own flag, both covered in `claim-reuse.test.ts`. Here it
+// passes claims through, so what the loader decodes from geo-chat is observable on the input.
+vi.mock('./claim-reuse', () => ({
+  applyClaimReusePolicy: vi.fn(async (claims: unknown) => claims),
+}));
 
 const DEBATE_ID = '019f89dc2124799193daafd5bc4ffa0a';
 
@@ -176,9 +183,38 @@ describe('loadDebatePublishSource media gating', () => {
     expect(input.transcriptTurns[0].text).toBe('Nuclear program was advancing.');
     // Claims arrive pre-attributed, keyed to the same turn indices.
     expect(input.claims).toEqual([
-      { text: 'The nuclear program was advancing.', isFactual: true, turnIndex: 0 },
-      { text: 'The action was unjustified.', isFactual: false, turnIndex: 1 },
+      { text: 'The nuclear program was advancing.', isFactual: true, turnIndex: 0, existingClaimEntityId: null },
+      { text: 'The action was unjustified.', isFactual: false, turnIndex: 1, existingClaimEntityId: null },
     ]);
+  });
+
+  it('decodes geo-chat’s existing_entity_id and hands the claims to the reuse policy with the debate space', async () => {
+    const EXISTING = '4f12f5ea073442cbaa0fb10f70a9a876';
+    mockGeoChat({ job: { status: 'succeeded' }, artifacts: [{ kind: 'final_video' }] }, debateBody(), {
+      turns: [
+        { turn_index: 0, participant_slot: 1, attributed_space_id: 'space-1', speaker_name: 'Specter', text: 'Turn.' },
+      ],
+      claims: [
+        {
+          text: 'Matched to a published claim.',
+          is_factual: false,
+          turn_index: 0,
+          existing_entity_id: EXISTING,
+          match: { candidates: 3, best_score: 0.97, judged: true, verdict: 'equivalent' },
+        },
+        { text: 'Blank id means none.', is_factual: null, turn_index: 0, existing_entity_id: '   ' },
+        { text: 'Pre-matching payload shape.', is_factual: null, turn_index: 0 },
+      ],
+    });
+
+    const { input } = await loadDebatePublishSource(DEBATE_ID);
+
+    expect((input.claims ?? []).map(claim => claim.existingClaimEntityId)).toEqual([EXISTING, null, null]);
+    expect(vi.mocked(applyClaimReusePolicy)).toHaveBeenCalledWith(
+      expect.arrayContaining([expect.objectContaining({ existingClaimEntityId: EXISTING })]),
+      'c9f267dcb0d270718c2a3c45a64afd32',
+      { debateId: DEBATE_ID }
+    );
   });
 
   it('falls back to the raw transcript with no claims when geo-chat reports none', async () => {

--- a/apps/web/core/debates/server/debate-source.test.ts
+++ b/apps/web/core/debates/server/debate-source.test.ts
@@ -213,7 +213,7 @@ describe('loadDebatePublishSource media gating', () => {
     expect(vi.mocked(applyClaimReusePolicy)).toHaveBeenCalledWith(
       expect.arrayContaining([expect.objectContaining({ existingClaimEntityId: EXISTING })]),
       'c9f267dcb0d270718c2a3c45a64afd32',
-      { debateId: DEBATE_ID }
+      { debateId: DEBATE_ID, motionClaimEntityId: 'claim-1' }
     );
   });
 

--- a/apps/web/core/debates/server/debate-source.ts
+++ b/apps/web/core/debates/server/debate-source.ts
@@ -21,6 +21,7 @@ import {
   mergeTranscriptSegmentsIntoTurns,
 } from '../debate-publish-draft';
 import { hasProcessedVideo } from '../playback-utils';
+import { applyClaimReusePolicy } from './claim-reuse';
 
 const debatePublishSettlementMs = 60_000;
 
@@ -247,7 +248,10 @@ export async function loadDebatePublishSource(debateId: string): Promise<DebateS
   // transcript ourselves (and publishing no claims) when claims aren't available yet.
   const extracted = await loadDebateClaims(debateId);
   const transcriptTurns = extracted?.transcriptTurns ?? (await loadTranscriptTurns(debateId, debate));
-  const claims = extracted?.claims ?? [];
+  // geo-chat decided an hour ago which claims duplicate a published one; the policy decides which
+  // of those references the draft may honour now (flag, and the entity still being a Claim in
+  // this space). Everything it drops is minted as before.
+  const claims = await applyClaimReusePolicy(extracted?.claims ?? [], debate.claim.space_id, { debateId });
 
   const participants: DebatePublishParticipant[] = debate.participants.map(p => ({
     spaceEntityId: p.profile_space_id,
@@ -405,7 +409,17 @@ type DebateExtractedClaimsTurn = {
   speaker_name: string | null;
   text: string;
 };
-type DebateExtractedClaimsClaim = { text: string; is_factual: boolean | null; turn_index: number };
+type DebateExtractedClaimsClaim = {
+  text: string;
+  is_factual: boolean | null;
+  turn_index: number;
+  /**
+   * Find-or-create: the published Claim in the debate's space geo-chat judged logically equivalent
+   * to this one, or null/absent when it found none (or matching was off). geo-chat also sends a
+   * `match` audit object next to it, which the publisher does not read.
+   */
+  existing_entity_id?: string | null;
+};
 type DebateExtractedClaimsResponse = { turns: DebateExtractedClaimsTurn[]; claims: DebateExtractedClaimsClaim[] };
 
 /**
@@ -442,6 +456,10 @@ async function loadDebateClaims(
     text: claim.text,
     isFactual: claim.is_factual ?? null,
     turnIndex: claim.turn_index,
+    existingClaimEntityId:
+      typeof claim.existing_entity_id === 'string' && claim.existing_entity_id.trim().length > 0
+        ? claim.existing_entity_id.trim()
+        : null,
   }));
   return { transcriptTurns, claims };
 }

--- a/apps/web/core/debates/server/debate-source.ts
+++ b/apps/web/core/debates/server/debate-source.ts
@@ -22,6 +22,7 @@ import {
 } from '../debate-publish-draft';
 import { hasProcessedVideo } from '../playback-utils';
 import { applyClaimReusePolicy } from './claim-reuse';
+import { type DebateExtractedClaimsResponse, decodeExtractedClaims } from './extracted-claims';
 
 const debatePublishSettlementMs = 60_000;
 
@@ -251,7 +252,10 @@ export async function loadDebatePublishSource(debateId: string): Promise<DebateS
   // geo-chat decided an hour ago which claims duplicate a published one; the policy decides which
   // of those references the draft may honour now (flag, and the entity still being a Claim in
   // this space). Everything it drops is minted as before.
-  const claims = await applyClaimReusePolicy(extracted?.claims ?? [], debate.claim.space_id, { debateId });
+  const claims = await applyClaimReusePolicy(extracted?.claims ?? [], debate.claim.space_id, {
+    debateId,
+    motionClaimEntityId: debate.claim.claim_entity_id,
+  });
 
   const participants: DebatePublishParticipant[] = debate.participants.map(p => ({
     spaceEntityId: p.profile_space_id,
@@ -401,27 +405,6 @@ async function buildDebateShareCard(
   }
 }
 
-type DebateExtractedClaimsTurn = {
-  turn_index: number;
-  participant_slot: number;
-  /** The turn speaker's Geo personal-space entity id (the Authors relation target). */
-  attributed_space_id: string;
-  speaker_name: string | null;
-  text: string;
-};
-type DebateExtractedClaimsClaim = {
-  text: string;
-  is_factual: boolean | null;
-  turn_index: number;
-  /**
-   * Find-or-create: the published Claim in the debate's space geo-chat judged logically equivalent
-   * to this one, or null/absent when it found none (or matching was off). geo-chat also sends a
-   * `match` audit object next to it, which the publisher does not read.
-   */
-  existing_entity_id?: string | null;
-};
-type DebateExtractedClaimsResponse = { turns: DebateExtractedClaimsTurn[]; claims: DebateExtractedClaimsClaim[] };
-
 /**
  * Load geo-chat's pre-computed, pre-attributed debate claims. geo-chat extracts them in its media
  * job (beside Whisper) and returns the canonical per-turn structure PLUS the claims keyed to it by
@@ -443,25 +426,7 @@ async function loadDebateClaims(
     return null;
   }
   if (!response || !Array.isArray(response.turns) || response.turns.length === 0) return null;
-
-  const transcriptTurns: DebatePublishTurn[] = [...response.turns]
-    .sort((a, b) => a.turn_index - b.turn_index)
-    .map(turn => ({
-      turnIndex: turn.turn_index,
-      speakerSpaceEntityId: turn.attributed_space_id,
-      speakerName: turn.speaker_name,
-      text: turn.text,
-    }));
-  const claims: DebateClaimInput[] = (response.claims ?? []).map(claim => ({
-    text: claim.text,
-    isFactual: claim.is_factual ?? null,
-    turnIndex: claim.turn_index,
-    existingClaimEntityId:
-      typeof claim.existing_entity_id === 'string' && claim.existing_entity_id.trim().length > 0
-        ? claim.existing_entity_id.trim()
-        : null,
-  }));
-  return { transcriptTurns, claims };
+  return decodeExtractedClaims(response);
 }
 
 async function loadTranscriptTurns(debateId: string, debate: Debate) {

--- a/apps/web/core/debates/server/existing-claims-document.ts
+++ b/apps/web/core/debates/server/existing-claims-document.ts
@@ -1,0 +1,35 @@
+import type { TypedDocumentNode } from '@graphql-typed-document-node/core';
+
+import { parse } from 'graphql';
+
+/**
+ * The three facts the reuse policy verifies about a referenced entity: that it exists, which spaces
+ * hold its content, and which types it carries. Deliberately not the full entity query — that one
+ * pulls every value and relation (0.31 MB per 50 claims, measured) through a strict decoder that
+ * drops the whole entity when any unrelated value fails to parse, which the verifier would read as
+ * "not a Claim here" and mint a duplicate for.
+ */
+const EXISTING_CLAIMS_SOURCE = /* GraphQL */ `
+  query ExistingClaims($ids: [UUID!]!) {
+    entities(filter: { id: { in: $ids } }) {
+      id
+      spaceIds
+      types {
+        id
+      }
+    }
+  }
+`;
+
+export type ExistingClaimsQuery = {
+  entities: Array<{
+    id: string;
+    spaceIds: Array<string | null> | null;
+    types: Array<{ id: string } | null> | null;
+  } | null> | null;
+};
+
+export const existingClaimsDocument = parse(EXISTING_CLAIMS_SOURCE) as TypedDocumentNode<
+  ExistingClaimsQuery,
+  { ids: string[] }
+>;

--- a/apps/web/core/debates/server/extracted-claims.ts
+++ b/apps/web/core/debates/server/extracted-claims.ts
@@ -1,0 +1,58 @@
+import type { DebateClaimInput, DebatePublishTurn } from '../debate-publish-draft';
+
+/** One turn of geo-chat's `GET /debates/{id}/claims` payload. */
+export type DebateExtractedClaimsTurn = {
+  turn_index: number;
+  participant_slot: number;
+  /** The turn speaker's Geo personal-space entity id (the Authors relation target). */
+  attributed_space_id: string;
+  speaker_name: string | null;
+  text: string;
+};
+
+/** One extracted claim of that payload. */
+export type DebateExtractedClaimsClaim = {
+  text: string;
+  is_factual: boolean | null;
+  turn_index: number;
+  /**
+   * Find-or-create: the published Claim in the debate's space geo-chat judged logically equivalent
+   * to this one, or null/absent when it found none (or matching was off). geo-chat also sends a
+   * `match` audit object next to it, which the publisher does not read.
+   */
+  existing_entity_id?: string | null;
+};
+
+export type DebateExtractedClaimsResponse = {
+  turns: DebateExtractedClaimsTurn[];
+  claims: DebateExtractedClaimsClaim[];
+};
+
+/**
+ * geo-chat's payload → the publish input's turns and claims. Pure, so the publish sweep and the live
+ * harness (`scripts/live-claim-reuse.ts`) decode the same way. `turn_index` is expected 0-based and
+ * contiguous over non-empty turns; a blank or absent `existing_entity_id` is null.
+ */
+export function decodeExtractedClaims(response: DebateExtractedClaimsResponse): {
+  transcriptTurns: DebatePublishTurn[];
+  claims: DebateClaimInput[];
+} {
+  const transcriptTurns: DebatePublishTurn[] = [...response.turns]
+    .sort((a, b) => a.turn_index - b.turn_index)
+    .map(turn => ({
+      turnIndex: turn.turn_index,
+      speakerSpaceEntityId: turn.attributed_space_id,
+      speakerName: turn.speaker_name,
+      text: turn.text,
+    }));
+  const claims: DebateClaimInput[] = (response.claims ?? []).map(claim => ({
+    text: claim.text,
+    isFactual: claim.is_factual ?? null,
+    turnIndex: claim.turn_index,
+    existingClaimEntityId:
+      typeof claim.existing_entity_id === 'string' && claim.existing_entity_id.trim().length > 0
+        ? claim.existing_entity_id.trim()
+        : null,
+  }));
+  return { transcriptTurns, claims };
+}

--- a/apps/web/core/debates/transcript-claims.test.ts
+++ b/apps/web/core/debates/transcript-claims.test.ts
@@ -125,7 +125,10 @@ describe('groupTranscriptClaims', () => {
     expect(claimsForParticipant(grouped, PRESTON)).toHaveLength(1);
   });
 
-  it('attributes a claim repeated by the other debater to whoever said it first', () => {
+  it('lists a claim both debaters stated under each of them, but counts it once', () => {
+    // With find-or-create a transcript claim that already exists in the space is linked to the
+    // existing entity, so the same claim id under two speakers is the ordinary case, not a quotation
+    // to attribute to whoever came first.
     const grouped = group(
       response([
         { id: 'block-1', position: 'a1', author: PRESTON, claims: [{ id: 'claim-1' }] },
@@ -134,7 +137,23 @@ describe('groupTranscriptClaims', () => {
     );
 
     expect(claimsForParticipant(grouped, PRESTON)).toHaveLength(1);
-    expect(claimsForParticipant(grouped, ARTURAS)).toHaveLength(0);
+    expect(claimsForParticipant(grouped, ARTURAS)).toHaveLength(1);
+    expect(claimsForParticipant(grouped, PRESTON)[0]).toBe(claimsForParticipant(grouped, ARTURAS)[0]);
+    expect(grouped.totalCount).toBe(1);
+    expect(grouped.all).toHaveLength(1);
+  });
+
+  it('still lists a claim once per speaker when that speaker repeats it', () => {
+    const grouped = group(
+      response([
+        { id: 'block-1', position: 'a1', author: PRESTON, claims: [{ id: 'claim-1' }] },
+        { id: 'block-2', position: 'a2', author: ARTURAS, claims: [{ id: 'claim-1' }] },
+        { id: 'block-3', position: 'a3', author: PRESTON, claims: [{ id: 'claim-1' }] },
+      ])
+    );
+
+    expect(claimsForParticipant(grouped, PRESTON)).toHaveLength(1);
+    expect(claimsForParticipant(grouped, ARTURAS)).toHaveLength(1);
   });
 
   it('drops claims with no text, since the text is the name', () => {

--- a/apps/web/core/debates/transcript-claims.test.ts
+++ b/apps/web/core/debates/transcript-claims.test.ts
@@ -244,6 +244,26 @@ describe('unmatchedClaims', () => {
   });
 });
 
+describe('unmatchedClaims with reused claims', () => {
+  it('keeps a claim a participant stated when an unknown author stated it too', () => {
+    const OUTSIDER = 'dddddddddddddddddddddddddddddddd';
+    const grouped = group(
+      response([
+        { id: 'block-1', position: 'a1', author: PRESTON, claims: [{ id: 'claim-1' }] },
+        { id: 'block-2', position: 'a2', author: OUTSIDER, claims: [{ id: 'claim-1' }] },
+      ])
+    );
+    expect(unmatchedClaims(grouped, [PRESTON]).map(claim => claim.id)).toEqual(['claim-1']);
+    const reversed = group(
+      response([
+        { id: 'block-1', position: 'a1', author: OUTSIDER, claims: [{ id: 'claim-1' }] },
+        { id: 'block-2', position: 'a2', author: PRESTON, claims: [{ id: 'claim-1' }] },
+      ])
+    );
+    expect(unmatchedClaims(reversed, [PRESTON]).map(claim => claim.id)).toEqual(['claim-1']);
+  });
+});
+
 describe('claim space', () => {
   it('carries the claim’s own space, which is where its responses are published', () => {
     const grouped = group(response([{ id: 'block-1', author: PRESTON, claims: [{ id: 'claim-1' }] }]));

--- a/apps/web/core/debates/transcript-claims.ts
+++ b/apps/web/core/debates/transcript-claims.ts
@@ -104,16 +104,21 @@ function resolveClaimNaming(claim: ClaimEntityNaming, debateSpaceId: string): { 
  * Relations are sorted by `position` rather than trusted in list order, so claims read in
  * transcript order inside each speaker's group.
  *
- * A claim id is kept once, under the first block that carries it: the graph can return the same
- * relation twice (duplicate publishes do happen), and a claim repeated across two of a speaker's
- * turns should still be one row. Deduping globally rather than per-block also means a claim quoted
- * by both debaters is attributed to whoever said it first rather than counted twice.
+ * A claim id appears once in `all`, at its first block: the graph can return the same relation twice
+ * (duplicate publishes do happen), and a claim repeated across two of a speaker's turns should still
+ * be one row and one count. Per speaker the unit is the (speaker, claim) pair, so a claim both
+ * debaters stated is listed under each of them. That used to be a rare quotation; with
+ * find-or-create it is the ordinary case, because a transcript claim that already exists in the
+ * space is linked to the existing entity instead of minted again, and dropping the second speaker's
+ * row would silently erase what they said.
  */
 export function groupTranscriptClaims(data: DebateTranscriptClaimsQuery, spaceId: string): DebateTranscriptClaims {
   const all: TranscriptClaim[] = [];
   const byAuthorSpaceId = new Map<string, TranscriptClaim[]>();
   const unattributed: TranscriptClaim[] = [];
-  const seenClaimIds = new Set<string>();
+  const rowsByClaimId = new Map<string, TranscriptClaim>();
+  /** `${authorKey}:${claimKey}`; the empty author key stands for unattributed. */
+  const seenPairs = new Set<string>();
 
   for (const transcript of presentRelations(data.entity?.transcripts)) {
     for (const block of presentRelations(transcript.toEntity.blocks)) {
@@ -126,24 +131,27 @@ export function groupTranscriptClaims(data: DebateTranscriptClaimsQuery, spaceId
       for (const claim of presentRelations(blockEntity.claims)) {
         const claimEntity = claim.toEntity;
         const key = uuidToHex(claimEntity.id);
-        if (seenClaimIds.has(key)) continue;
 
-        const resolved = resolveClaimNaming(claimEntity, spaceId);
-        // A claim with no name has nothing to render — its text *is* its name.
-        if (!resolved.text) continue;
+        let row = rowsByClaimId.get(key);
+        if (!row) {
+          const resolved = resolveClaimNaming(claimEntity, spaceId);
+          // A claim with no name has nothing to render — its text *is* its name.
+          if (!resolved.text) continue;
+          row = { id: claimEntity.id, text: resolved.text, spaceId: resolved.spaceId };
+          rowsByClaimId.set(key, row);
+          all.push(row);
+        }
 
-        seenClaimIds.add(key);
-
-        const row: TranscriptClaim = { id: claimEntity.id, text: resolved.text, spaceId: resolved.spaceId };
-
-        all.push(row);
+        const authorKey = authorSpaceId ? uuidToHex(authorSpaceId) : '';
+        const pairKey = `${authorKey}:${key}`;
+        if (seenPairs.has(pairKey)) continue;
+        seenPairs.add(pairKey);
 
         if (!authorSpaceId) {
           unattributed.push(row);
           continue;
         }
 
-        const authorKey = uuidToHex(authorSpaceId);
         const existing = byAuthorSpaceId.get(authorKey);
         if (existing) existing.push(row);
         else byAuthorSpaceId.set(authorKey, [row]);

--- a/apps/web/core/debates/transcript-claims.ts
+++ b/apps/web/core/debates/transcript-claims.ts
@@ -173,16 +173,20 @@ export function groupTranscriptClaims(data: DebateTranscriptClaimsQuery, spaceId
 export function unmatchedClaims(claims: DebateTranscriptClaims, participantSpaceIds: string[]): TranscriptClaim[] {
   const known = new Set(participantSpaceIds.map(uuidToHex));
 
-  const claimed = new Set<string>();
+  // The unit is the statement — an (author, claim) pair — not the claim. With reuse one claim can
+  // be stated by a participant and by an author outside the list; the participant's row does not
+  // cover the other statement, which would otherwise vanish from the panel.
+  const unmatched = new Set<string>();
   for (const [authorSpaceId, rows] of claims.byAuthorSpaceId) {
-    if (known.has(authorSpaceId)) for (const row of rows) claimed.add(uuidToHex(row.id));
+    if (!known.has(authorSpaceId)) for (const row of rows) unmatched.add(uuidToHex(row.id));
   }
+  for (const row of claims.unattributed) unmatched.add(uuidToHex(row.id));
 
   // Filtered out of the flat list rather than assembled from the author map: walking the map would
   // emit one unknown author's claims together and then every unattributed one after them, so an
   // A/B/A transcript came out A/A/B. `all` is already in transcript order, which is the order this
   // is documented to fall back to.
-  return claims.all.filter(claim => !claimed.has(uuidToHex(claim.id)));
+  return claims.all.filter(claim => unmatched.has(uuidToHex(claim.id)));
 }
 
 /** The claims a given participant made, in transcript order. */

--- a/apps/web/scripts/live-claim-reuse.ts
+++ b/apps/web/scripts/live-claim-reuse.ts
@@ -12,6 +12,7 @@
  *   bun run scripts/live-claim-reuse.ts <payload.json> <debate space id>
  */
 import { Effect } from 'effect';
+import { readFile } from 'node:fs/promises';
 
 import { CLAIM_IS_FACTUAL_PROPERTY_ID, CLAIM_TYPE_ID } from '~/core/claims/ontology';
 import {
@@ -39,7 +40,8 @@ if (!payloadPath || !spaceId) {
   console.error('usage: bun run scripts/live-claim-reuse.ts <payload.json> <debate space id>');
   process.exit(2);
 }
-const payload = JSON.parse(await Bun.file(payloadPath).text()) as Payload;
+// Node's fs rather than `Bun.file`: the Next build type-checks `scripts/**` and has no Bun types.
+const payload = JSON.parse(await readFile(payloadPath, 'utf8')) as Payload;
 
 // Same decode as `loadDebateClaims` in debate-source.ts (private there, and it needs geo-chat).
 const claims: DebateClaimInput[] = payload.claims.map(claim => ({

--- a/apps/web/scripts/live-claim-reuse.ts
+++ b/apps/web/scripts/live-claim-reuse.ts
@@ -1,0 +1,126 @@
+/**
+ * Live harness for the find-or-create publisher half, runnable without a geo-chat deployment.
+ *
+ * Feeds a real `{ turns, claims }` payload — as produced by geo-chat's `live_matching` harness
+ * (`cargo test -p geo-media live_matching -- --ignored --nocapture`, the `LIVE_PAYLOAD` line) —
+ * through the same steps the publish sweep runs: decode, the reuse policy with a REAL graph read,
+ * the draft builder and the op pipeline. Prints what would be reused and the ops that would be
+ * published. Submits nothing.
+ *
+ *   NEXT_PUBLIC_CHAIN_ID=55516 NEXT_PUBLIC_PRIVY_APP_ID=live NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID=live \
+ *   DEBATE_CLAIM_REUSE_ENABLED=true \
+ *   bun run scripts/live-claim-reuse.ts <payload.json> <debate space id>
+ */
+import { Effect } from 'effect';
+
+import { CLAIM_IS_FACTUAL_PROPERTY_ID, CLAIM_TYPE_ID } from '~/core/claims/ontology';
+import {
+  type DebateClaimInput,
+  type DebatePublishInput,
+  buildDebatePublishDraft,
+} from '~/core/debates/debate-publish-draft';
+import { NAME_PROPERTY_ID, SOURCES_PROPERTY_ID, TYPES_PROPERTY_ID } from '~/core/debates/ontology';
+import { applyClaimReusePolicy } from '~/core/debates/server/claim-reuse';
+import { Publish } from '~/core/utils/publish';
+
+type Payload = {
+  turns: Array<{ turn_index: number; attributed_space_id: string; speaker_name: string | null; text: string }>;
+  claims: Array<{
+    text: string;
+    is_factual: boolean | null;
+    turn_index: number;
+    existing_entity_id?: string | null;
+    match?: { verdict?: string; best_score?: number | null; candidates?: number } | null;
+  }>;
+};
+
+const [payloadPath, spaceId] = process.argv.slice(2);
+if (!payloadPath || !spaceId) {
+  console.error('usage: bun run scripts/live-claim-reuse.ts <payload.json> <debate space id>');
+  process.exit(2);
+}
+const payload = JSON.parse(await Bun.file(payloadPath).text()) as Payload;
+
+// Same decode as `loadDebateClaims` in debate-source.ts (private there, and it needs geo-chat).
+const claims: DebateClaimInput[] = payload.claims.map(claim => ({
+  text: claim.text,
+  isFactual: claim.is_factual ?? null,
+  turnIndex: claim.turn_index,
+  existingClaimEntityId:
+    typeof claim.existing_entity_id === 'string' && claim.existing_entity_id.trim().length > 0
+      ? claim.existing_entity_id.trim()
+      : null,
+}));
+
+console.log(`policy: DEBATE_CLAIM_REUSE_ENABLED=${process.env.DEBATE_CLAIM_REUSE_ENABLED ?? '(unset)'}`);
+const decided = await applyClaimReusePolicy(claims, spaceId, { debateId: 'live-harness' });
+
+// Stand-in speakers with well-formed ids; the harness turn carries a placeholder space id.
+const YES = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+const NO = 'cccccccccccccccccccccccccccccccc';
+const input: DebatePublishInput = {
+  debateId: '11112222-3333-4444-5555-666677778888',
+  spaceId,
+  claimEntityId: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+  claimText: 'Live harness motion',
+  participants: [
+    { spaceEntityId: YES, displayName: 'Yes speaker', position: true, participantSlot: 1 },
+    { spaceEntityId: NO, displayName: 'No speaker', position: false, participantSlot: 2 },
+  ],
+  videoUrl: null,
+  keyframeUrl: null,
+  ogImageUrl: null,
+  transcriptTurns: payload.turns.map(turn => ({
+    turnIndex: turn.turn_index,
+    speakerSpaceEntityId: turn.turn_index % 2 === 0 ? YES : NO,
+    speakerName: turn.speaker_name,
+    text: turn.text,
+  })),
+  claims: decided,
+};
+
+const draft = buildDebatePublishDraft(input);
+const ops = await Effect.runPromise(Publish.prepareLocalDataForPublishing(draft.values, draft.relations, spaceId));
+
+console.log('\nclaims:');
+for (const [index, claim] of decided.entries()) {
+  const fromGeoChat = claims[index].existingClaimEntityId;
+  const verdict = payload.claims[index].match?.verdict ?? '-';
+  const outcome = claim.existingClaimEntityId
+    ? `REUSE ${claim.existingClaimEntityId}`
+    : fromGeoChat
+      ? `MINT (reference ${fromGeoChat} dropped by policy)`
+      : 'MINT';
+  console.log(`  ${outcome.padEnd(52)} geo-chat: ${verdict.padEnd(14)} | ${claim.text}`);
+}
+
+const reusedIds = new Set(decided.map(claim => claim.existingClaimEntityId).filter((id): id is string => !!id));
+const valuesOnReused = draft.values.filter(value => reusedIds.has(value.entity.id));
+const typesOnReused = draft.relations.filter(r => reusedIds.has(r.fromEntity.id) && r.type.id === TYPES_PROPERTY_ID);
+const sourcesFromReused = draft.relations.filter(
+  r => reusedIds.has(r.fromEntity.id) && r.type.id === SOURCES_PROPERTY_ID
+);
+const claimsToReused = draft.relations.filter(r => reusedIds.has(r.toEntity.id) && r.type.id !== TYPES_PROPERTY_ID);
+const mintedClaims = draft.relations.filter(r => r.type.id === TYPES_PROPERTY_ID && r.toEntity.id === CLAIM_TYPE_ID);
+const opsByType = ops.reduce<Record<string, number>>((acc, op) => ({ ...acc, [op.type]: (acc[op.type] ?? 0) + 1 }), {});
+
+console.log('\ndraft:');
+console.log(`  minted Claim entities:                 ${mintedClaims.length}`);
+console.log(`  reused Claim entities:                 ${reusedIds.size}`);
+console.log(`  values written on reused entities:     ${valuesOnReused.length}  (must be 0)`);
+console.log(`  Types relations from reused entities:  ${typesOnReused.length}  (must be 0)`);
+console.log(`  block→Claims relations to reused:      ${claimsToReused.length}`);
+console.log(`  claim→Sources relations from reused:   ${sourcesFromReused.length}`);
+console.log(
+  `  Name values written:                   ${draft.values.filter(v => v.property.id === NAME_PROPERTY_ID).length}`
+);
+console.log(
+  `  Is factual values written:             ${draft.values.filter(v => v.property.id === CLAIM_IS_FACTUAL_PROPERTY_ID).length}`
+);
+console.log(`  ops by type:                           ${JSON.stringify(opsByType)}`);
+console.log('\nnothing was submitted.');
+
+if (valuesOnReused.length > 0 || typesOnReused.length > 0) {
+  console.error('FAIL: the draft wrote onto a reused entity');
+  process.exit(1);
+}

--- a/apps/web/scripts/live-claim-reuse.ts
+++ b/apps/web/scripts/live-claim-reuse.ts
@@ -8,8 +8,9 @@
  * published. Submits nothing.
  *
  *   NEXT_PUBLIC_CHAIN_ID=55516 NEXT_PUBLIC_PRIVY_APP_ID=live NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID=live \
- *   DEBATE_CLAIM_REUSE_ENABLED=true \
  *   bun run scripts/live-claim-reuse.ts <payload.json> <debate space id> [motion claim entity id]
+ *
+ * Reuse is on by default; add DEBATE_CLAIM_REUSE_ENABLED=false to see the shadow-mode path.
  */
 import { Effect } from 'effect';
 import { readFile } from 'node:fs/promises';

--- a/apps/web/scripts/live-claim-reuse.ts
+++ b/apps/web/scripts/live-claim-reuse.ts
@@ -9,7 +9,7 @@
  *
  *   NEXT_PUBLIC_CHAIN_ID=55516 NEXT_PUBLIC_PRIVY_APP_ID=live NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID=live \
  *   DEBATE_CLAIM_REUSE_ENABLED=true \
- *   bun run scripts/live-claim-reuse.ts <payload.json> <debate space id>
+ *   bun run scripts/live-claim-reuse.ts <payload.json> <debate space id> [motion claim entity id]
  */
 import { Effect } from 'effect';
 import { readFile } from 'node:fs/promises';
@@ -22,40 +22,26 @@ import {
 } from '~/core/debates/debate-publish-draft';
 import { NAME_PROPERTY_ID, SOURCES_PROPERTY_ID, TYPES_PROPERTY_ID } from '~/core/debates/ontology';
 import { applyClaimReusePolicy } from '~/core/debates/server/claim-reuse';
+import { type DebateExtractedClaimsResponse, decodeExtractedClaims } from '~/core/debates/server/extracted-claims';
 import { Publish } from '~/core/utils/publish';
 
-type Payload = {
-  turns: Array<{ turn_index: number; attributed_space_id: string; speaker_name: string | null; text: string }>;
-  claims: Array<{
-    text: string;
-    is_factual: boolean | null;
-    turn_index: number;
-    existing_entity_id?: string | null;
-    match?: { verdict?: string; best_score?: number | null; candidates?: number } | null;
-  }>;
+type Payload = DebateExtractedClaimsResponse & {
+  claims: Array<{ match?: { verdict?: string; best_score?: number | null; candidates?: number } | null }>;
 };
 
-const [payloadPath, spaceId] = process.argv.slice(2);
+const [payloadPath, spaceId, motionClaimEntityId] = process.argv.slice(2);
 if (!payloadPath || !spaceId) {
-  console.error('usage: bun run scripts/live-claim-reuse.ts <payload.json> <debate space id>');
+  console.error('usage: bun run scripts/live-claim-reuse.ts <payload.json> <debate space id> [motion claim entity id]');
   process.exit(2);
 }
 // Node's fs rather than `Bun.file`: the Next build type-checks `scripts/**` and has no Bun types.
 const payload = JSON.parse(await readFile(payloadPath, 'utf8')) as Payload;
 
-// Same decode as `loadDebateClaims` in debate-source.ts (private there, and it needs geo-chat).
-const claims: DebateClaimInput[] = payload.claims.map(claim => ({
-  text: claim.text,
-  isFactual: claim.is_factual ?? null,
-  turnIndex: claim.turn_index,
-  existingClaimEntityId:
-    typeof claim.existing_entity_id === 'string' && claim.existing_entity_id.trim().length > 0
-      ? claim.existing_entity_id.trim()
-      : null,
-}));
+// The same decode the publish sweep runs.
+const { claims }: { claims: DebateClaimInput[] } = decodeExtractedClaims(payload);
 
 console.log(`policy: DEBATE_CLAIM_REUSE_ENABLED=${process.env.DEBATE_CLAIM_REUSE_ENABLED ?? '(unset)'}`);
-const decided = await applyClaimReusePolicy(claims, spaceId, { debateId: 'live-harness' });
+const decided = await applyClaimReusePolicy(claims, spaceId, { debateId: 'live-harness', motionClaimEntityId });
 
 // Stand-in speakers with well-formed ids; the harness turn carries a placeholder space id.
 const YES = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';


### PR DESCRIPTION
## What

Find-or-create for debate transcript claims, **half two** (half one is [geo-chat#98](https://github.com/geobrowser/geo-chat/pull/98)). geo-chat's media worker now reports, per extracted claim, the published Claim in the debate's space it judged logically equivalent (`existing_entity_id`). The acceptor decodes it and, when honoured, the draft **references that entity instead of minting a duplicate**.

Ticket: *Find or create when extracting claims from debates* — same point and sentiment, same space, never a merely similar claim.

## How

- `DebateClaimInput.existingClaimEntityId` (optional, null when geo-chat found nothing or matching was off). `debate-source.ts` decodes it from the payload; blank/absent → null, so pre-matching payloads decode identically.
- `buildDebatePublishDraft`: a matched claim reuses the id and emits **only two relations**, each written once per (block, claim) / per claim per debate even when several extracted claims resolve to the same entity — the speaker's block → `Claims` → existing claim, and existing claim → `Sources` → this debate. No Name, no Types, no Is factual: an entity we did not create keeps its own facts even where this extraction would have said otherwise. The builder stays pure; the decision is upstream.
- `core/debates/server/claim-reuse.ts` — `applyClaimReusePolicy`, controlled by **`DEBATE_CLAIM_REUSE_ENABLED`** (default **on**; `false` for shadow mode):
  - **off**: every reference is dropped and counted in a log line → geo-chat's matching runs in *shadow mode*; its verdicts (candidates, scores, judge verdict) are readable from geo-chat's `GET /debates/{id}/claims` before any entity is reused;
  - **on**: references to the debate's own motion are dropped first (it is a Claim in the space and would otherwise pass), then one batched graph read (`getBatchEntities`) verifies each remaining id still exists, is typed Claim and lives in the publication space — geo-chat decided about an hour earlier. Anything that fails is minted as before, with a warning naming the ids; a failed read mints everything.
- Two views assumed a claim belongs to one speaker, which reuse makes false on the first shared claim:
  - `transcript-claims.ts` deduped globally, first block wins → the second debater's row silently vanished. Now dedupes per (speaker, claim); `all`/`totalCount` still count each claim once.
  - `claim-provenance.tsx` rendered only the first `Sources` relation. Now lists every source ("Also in …") and says "Stated by" rather than "First stated by": relation order says nothing about chronology, and a hand-authored claim reused by one debate has a single Sources relation while predating that debate.

## Verification

- `vitest run core/debates core/claims partials/explore`: 107 files, 1,351 tests pass.
- New tests: reuse emits no values/Types for the existing id and attributes the block correctly; blank or null ids mint; a reused claim through the real `Publish.prepareLocalDataForPublishing` pipeline yields one fewer relation op and fewer value ops than a minted one (ids are byte-encoded in ops, hence shape comparison); loader decoding + delegation to the policy with the debate space; policy: shadow mode never reads the graph, verification keeps only exists+Claim+in-space, dashed space ids, failing lookup mints all, untouched input when nothing matched; flag parsing; shared claim under both speakers, counted once.
- ESLint + Prettier clean on every changed file; `tsc --noEmit` clean in the touched modules (the 5 remaining errors are pre-existing in governance / sign-in / responses tests).

## Rollout

1. Merge geo-chat#98 and set `GEO_LENS_API_KEY` on the geo-chat testnet worker → payloads start carrying `existing_entity_id` + `match` audits (shadow).
2. Merge this: reuse is on by default, so the next sweep after a matched debate links its transcript claims to the existing entities it re-verified. Set `DEBATE_CLAIM_REUSE_ENABLED=false` on the Vercel project to fall back to shadow mode (acceptor keeps minting, logs `matched` counts per debate).
3. Read the verdicts geo-chat records (`GET /debates/{id}/claims`) and the acceptor's reuse log lines; tune geo-chat's `CLAIM_MATCHING_MIN_SCORE_PERCENT` / `CLAIM_MATCHING_CANDIDATES` from them.

Decisions agreed for v1: same space only; never override the duplicate's properties; mainnet out of scope. Tone/sentiment beyond logical equivalence is deferred.

Dev note: a fresh checkout needs `bun install` and a build of `packages/auth` (`cd packages/auth && bun run build`) before tests importing `@geogenesis/auth/*` resolve — pre-existing, not changed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TQHB3QEWjjDKPLC4VUUw9P

## Review fixes (2026-09-07)

From the multi-agent review: motion exclusion in the policy (with the motion id passed from the debate), one relation per pair in the builder, "Stated by" wording, `readEnv` shared from acceptor-config, the payload decode in one place (`extracted-claims.ts`) used by the sweep and the live harness (which now takes the motion id as a third argument).

## Review fixes, round 2 (2026-09-07)

Provenance names every speaker whose block quotes the claim in the source debate (was `first: 1`, an arbitrary one of two); `unmatchedClaims` is per (author, claim) so a statement by a non-participant survives when a participant stated the same claim; the reuse policy verifies with a light `id / spaceIds / types` query (`existing-claims-document.ts`) instead of the full entity query, and drops references that are not entity ids before the batched read.

