### PR TITLE
fix(community-calls): let the edit page open a call with no meeting time (GEO-2816)

### DIFF
--- a/apps/web/app/space/[id]/(community-new)/community/[callId]/edit/page.tsx
+++ b/apps/web/app/space/[id]/(community-new)/community/[callId]/edit/page.tsx
@@ -20,11 +20,21 @@ export default async function EditCommunityCallPage(props: Props) {
   }
 
   const entity = await Effect.runPromise(getEntity(params.callId, params.id));
-  const schedule = entity?.values.find(v => v.property.id === CALL_SCHEMA.MEETING_TIME_PROPERTY)?.value;
 
-  if (!entity || !schedule) {
+  // Gate on the type, not on the schedule (GEO-2816). This used to 404 whenever Meeting Time
+  // was missing or empty — which is exactly the state that needs repairing, and the only page
+  // that can repair it. A call written with an empty schedule is invisible in every list, so
+  // its edit page is the one route back; refusing to open it left the entity stranded with no
+  // way to fix or even delete it. `assertScheduleWritable` still refuses to *save* one blank,
+  // so admitting it here cannot reintroduce the state it fixes.
+  //
+  // The type check replaces the accidental filtering the schedule check used to do: without
+  // it, any entity id in the URL would open a Community Call form over an unrelated entity.
+  if (!entity || !entity.types.some(type => type.id === CALL_SCHEMA.COMMUNITY_CALL_TYPE)) {
     notFound();
   }
+
+  const schedule = entity.values.find(v => v.property.id === CALL_SCHEMA.MEETING_TIME_PROPERTY)?.value ?? '';
 
   const autoPublishAhead = Number(
     entity.values.find(v => v.property.id === CALL_SCHEMA.AUTO_PUBLISH_AHEAD_PROPERTY)?.value ?? 0


### PR DESCRIPTION
Closes GEO-2816.

Dovile reported a curator call she created in the browser that never appears anywhere. Its `Meeting Time` is stored as the **empty string** — written empty on the first version and re-written empty seven more times as she tried to fix it.

Every reader drops a falsy schedule, so the call is invisible in all of them. Verified live:

| surface | before |
|---|---|
| space front page / Community rail | not rendered |
| `/community/<id>/details` | 404 |
| `/community/<id>/edit` | 404 |
| `/community/call/<id>` | 404 |
| `/api/community-call/ics/…` | HTTP 404 |
| curator app | filtered out on `occurrence.end` |

Writing this state is already prevented — #2202 added `assertScheduleWritable` on both write paths, and it is holding: across all **388** Community Call entities in the graph this is the only one with an empty schedule. What #2202 did not do is give the existing row a way back.

## Change

`edit/page.tsx` gated on the schedule; it now gates on the **type**. That is the one page that can repair the call, and it was refusing to load it exactly when repair was needed — leaving the entity stranded with no way to fix it or even delete it.

Admitting an empty schedule here cannot reintroduce the state it fixes: `validateSchedule` and `assertScheduleWritable` still refuse to save one blank, and `parseSchedule('')` already yields empty form fields for the editor to fill in.

The type check is not incidental — the schedule test was accidentally doing that filtering. Without it, any entity id in the URL would open a Community Call form over an unrelated entity.

The matching `!schedule` guards on the details page and the ICS route are left alone: a call with no time genuinely has nothing to show or put in a calendar.

## Verification

- `tsc --noEmit` clean for the touched file.
- `vitest run core/community-calls partials/community-calls` — 83 passed.
- The stranded row itself still needs repairing once this lands; tracked on the ticket.

Follow-up filed separately as GEO-2817 for the third thing Dovile reported (time changes not reaching calendar invites).