### PR TITLE
fix(community-calls): wait for the indexer before resending calendar invites (GEO-2817)

### DIFF
--- a/apps/web/core/community-calls/notify-schedule-change.test.ts
+++ b/apps/web/core/community-calls/notify-schedule-change.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { notifyScheduleChange } from './notify-schedule-change';
+
+const OLD = 'DTSTART;TZID=Europe/Vilnius:20260821T170000\nDTEND;TZID=Europe/Vilnius:20260821T171500';
+const NEW = 'DTSTART;TZID=Europe/Vilnius:20260821T220000\nDTEND;TZID=Europe/Vilnius:20260821T230000';
+
+/** A clock that only moves when the code under test sleeps, so the tests don't. */
+function fakeClock() {
+  let t = 0;
+  return {
+    now: () => t,
+    sleep: async (ms: number) => {
+      t += ms;
+    },
+  };
+}
+
+function harness(
+  overrides: Partial<Parameters<typeof notifyScheduleChange>[0]> & {
+    schedules?: (string | null)[];
+  } = {}
+) {
+  const { schedules, ...rest } = overrides;
+  const clock = fakeClock();
+  const notify = vi.fn().mockResolvedValue({ notified: 3 });
+  const queue = [...(schedules ?? [NEW])];
+  const readIndexedSchedule = vi.fn().mockImplementation(async () => (queue.length > 1 ? queue.shift()! : queue[0]));
+
+  return {
+    notify,
+    readIndexedSchedule,
+    run: () =>
+      notifyScheduleChange({
+        spaceId: 'space-1',
+        callId: 'call-1',
+        next: NEW,
+        previous: OLD,
+        getToken: async () => 'token',
+        readIndexedSchedule,
+        notify,
+        sleep: clock.sleep,
+        now: clock.now,
+        timeoutMs: 10_000,
+        pollMs: 3_000,
+        ...rest,
+      }),
+  };
+}
+
+describe('notifyScheduleChange', () => {
+  it('waits for the indexer to report the new schedule before notifying', async () => {
+    // The whole point of GEO-2817: notifying while the indexer still has the old time mails
+    // that old time with a bumped SEQUENCE, and nothing fires again to correct it.
+    const h = harness({ schedules: [OLD, OLD, NEW] });
+
+    await expect(h.run()).resolves.toEqual({ status: 'notified' });
+
+    expect(h.readIndexedSchedule).toHaveBeenCalledTimes(3);
+    expect(h.notify).toHaveBeenCalledExactlyOnceWith({ spaceId: 'space-1', callId: 'call-1' }, 'token');
+  });
+
+  it('does not notify at all when the indexer never catches up', async () => {
+    // Deliberately worse-is-better: a missed resend leaves the old time and can be retried,
+    // where a resend *of* the old time spends the sequence number a correct resend would need.
+    const h = harness({ schedules: [OLD] });
+
+    await expect(h.run()).resolves.toEqual({ status: 'timed-out', lastSeen: OLD });
+
+    expect(h.notify).not.toHaveBeenCalled();
+  });
+
+  it('notifies immediately when the edit did not touch the time', async () => {
+    // A rename still needs the invite resent — the title is in it — but there is nothing to
+    // wait for, so it must not sit through the whole poll window.
+    const h = harness({ previous: NEW, schedules: [OLD] });
+
+    await expect(h.run()).resolves.toEqual({ status: 'notified' });
+
+    expect(h.readIndexedSchedule).not.toHaveBeenCalled();
+    expect(h.notify).toHaveBeenCalledOnce();
+  });
+
+  it('keeps polling through a failed read', async () => {
+    const readIndexedSchedule = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('network'))
+      .mockResolvedValue(NEW);
+    const h = harness({ readIndexedSchedule });
+
+    await expect(h.run()).resolves.toEqual({ status: 'notified' });
+
+    expect(readIndexedSchedule).toHaveBeenCalledTimes(2);
+  });
+
+  it('reports a missing identity token rather than silently doing nothing', async () => {
+    const h = harness({ getToken: async () => null });
+
+    await expect(h.run()).resolves.toEqual({ status: 'skipped-no-token' });
+
+    expect(h.notify).not.toHaveBeenCalled();
+  });
+
+  it('reports a rejected notification', async () => {
+    const error = new Error('curator-backend said no');
+    const notify = vi.fn().mockRejectedValue(error);
+    const h = harness({ notify });
+
+    await expect(h.run()).resolves.toEqual({ status: 'failed', error });
+  });
+});

--- a/apps/web/core/community-calls/notify-schedule-change.ts
+++ b/apps/web/core/community-calls/notify-schedule-change.ts
@@ -1,0 +1,121 @@
+import { Effect } from 'effect';
+
+import { getEntity } from '~/core/io/queries';
+
+import { notifyCommunityCallUpdate } from './api';
+import { CALL_SCHEMA } from './constants';
+
+/**
+ * How long to wait for the indexer to catch up before giving up on notifying (GEO-2817).
+ *
+ * Sized against the indexing latency we actually measure on entity writes — p50 9.9s,
+ * p95 48.6s — with headroom, because giving up early is the expensive outcome: it leaves
+ * subscribers holding the old time.
+ */
+export const INDEXED_SCHEDULE_TIMEOUT_MS = 120_000;
+export const INDEXED_SCHEDULE_POLL_MS = 3_000;
+
+export type NotifyScheduleChangeResult =
+  /** curator-backend accepted the resend. */
+  | { status: 'notified' }
+  /** No identity token, so we never called. Subscribers still hold the old time. */
+  | { status: 'skipped-no-token' }
+  /** The indexer never caught up. Deliberately did not notify — see below. */
+  | { status: 'timed-out'; lastSeen: string | null }
+  /** curator-backend rejected the resend, or the network failed. */
+  | { status: 'failed'; error: unknown };
+
+type Deps = {
+  spaceId: string;
+  callId: string;
+  /** The schedule this save just wrote. */
+  next: string;
+  /** The schedule the call had before this save. */
+  previous: string;
+  getToken: () => Promise<string | null>;
+  /** Injectable for tests. Reads the schedule the indexer currently reports. */
+  readIndexedSchedule?: (spaceId: string, callId: string) => Promise<string | null>;
+  notify?: (args: { spaceId: string; callId: string }, token: string) => Promise<unknown>;
+  sleep?: (ms: number) => Promise<void>;
+  now?: () => number;
+  timeoutMs?: number;
+  pollMs?: number;
+};
+
+async function readScheduleFromIndexer(spaceId: string, callId: string): Promise<string | null> {
+  const entity = await Effect.runPromise(getEntity(callId, spaceId));
+  return entity?.values.find(v => v.property.id === CALL_SCHEMA.MEETING_TIME_PROPERTY)?.value ?? null;
+}
+
+const defaultSleep = (ms: number) => new Promise<void>(resolve => setTimeout(resolve, ms));
+
+/**
+ * Resend calendar invites for a call whose series was just edited — but only once the
+ * indexer agrees the new schedule is there (GEO-2817).
+ *
+ * curator-backend does not take the new time from us; its `notify-update` handler reads the
+ * call back through `Entity.findOnePublic` and builds the iMIP from whatever the indexer
+ * reports. That read-back is deliberate — the endpoint authenticates the caller but does not
+ * check they may edit the space, so trusting a client-supplied time would let any signed-in
+ * user mail arbitrary reschedules to a call's subscribers. It does mean the notification is
+ * only correct once indexing has caught up.
+ *
+ * The old call site fired from `makeProposal`'s `onSuccess`, which resolves on the
+ * user-operation receipt — chain confirmation, not indexing. Notifying in that window resends
+ * the **old** time with an incremented SEQUENCE, so the subscriber's calendar accepts a
+ * revision that changes nothing and, since nothing fires again, stays wrong permanently.
+ *
+ * Hence: wait, and on timeout do **not** notify. A missed resend leaves the old time in place
+ * and can be retried; a resend of the old time burns the sequence number that a later correct
+ * resend would need in order to win.
+ */
+export async function notifyScheduleChange(deps: Deps): Promise<NotifyScheduleChangeResult> {
+  const {
+    spaceId,
+    callId,
+    next,
+    previous,
+    getToken,
+    readIndexedSchedule = readScheduleFromIndexer,
+    notify = notifyCommunityCallUpdate,
+    sleep = defaultSleep,
+    now = Date.now,
+    timeoutMs = INDEXED_SCHEDULE_TIMEOUT_MS,
+    pollMs = INDEXED_SCHEDULE_POLL_MS,
+  } = deps;
+
+  const send = async (): Promise<NotifyScheduleChangeResult> => {
+    const token = await getToken();
+    if (!token) return { status: 'skipped-no-token' };
+
+    try {
+      await notify({ spaceId, callId }, token);
+      return { status: 'notified' };
+    } catch (error) {
+      return { status: 'failed', error };
+    }
+  };
+
+  // An edit that left the time alone — a rename, or a change to auto-publish — has nothing to
+  // wait for: whatever the indexer reports is already the time we want the invite to carry.
+  // The invite still carries the title, so it is worth resending.
+  if (next === previous) {
+    return send();
+  }
+
+  const deadline = now() + timeoutMs;
+  let lastSeen: string | null = null;
+
+  for (;;) {
+    try {
+      lastSeen = await readIndexedSchedule(spaceId, callId);
+      if (lastSeen === next) return send();
+    } catch {
+      // A failed read is indistinguishable from "not yet" as far as the decision here goes,
+      // so keep polling and let the deadline end it.
+    }
+
+    if (now() >= deadline) return { status: 'timed-out', lastSeen };
+    await sleep(pollMs);
+  }
+}

--- a/apps/web/partials/community-calls/call-form.tsx
+++ b/apps/web/partials/community-calls/call-form.tsx
@@ -11,9 +11,10 @@ import { useRouter } from 'next/navigation';
 import Textarea from 'react-textarea-autosize';
 
 import { parseAgendaText } from '~/core/community-calls/agenda';
-import { notifyCommunityCallUpdate, reconcileAutoPublish } from '~/core/community-calls/api';
+import { reconcileAutoPublish } from '~/core/community-calls/api';
 import { buildCreateCallOps, buildUpdateCallOps } from '~/core/community-calls/call-ops';
 import { CALL_SCHEMA } from '~/core/community-calls/constants';
+import { notifyScheduleChange } from '~/core/community-calls/notify-schedule-change';
 import { useCommunityCallIdentityToken } from '~/core/community-calls/use-identity-token';
 import { usePublish } from '~/core/hooks/use-publish';
 import { useToast } from '~/core/hooks/use-toast';
@@ -127,12 +128,25 @@ export function CallForm(props: Props) {
         spaceId,
         name: `Update ${name}`,
         onSuccess: async () => {
-          // Fire after the write, not before: the update replaces `meetingTime` rather than
-          // unsetting it, so curator-backend must read the entity post-write to resend an
-          // invite with the *new* schedule — firing earlier would notify subscribers with the
-          // stale pre-edit time.
-          const notifyToken = await getToken();
-          if (notifyToken) await notifyCommunityCallUpdate({ spaceId, callId }, notifyToken).catch(() => {});
+          // Resend the calendar invites, but not from here: curator-backend reads the new time
+          // back out of the indexer, and `onSuccess` only means the user operation was
+          // confirmed on chain. Notifying in that window mails the *old* time with a bumped
+          // SEQUENCE, which is worse than not notifying at all (GEO-2817). `notifyScheduleChange`
+          // waits for the indexer first, so it is detached rather than awaited — an editor
+          // should not sit on this form for the length of an indexing round trip. The toast is
+          // a global atom, so it still reaches them after `router.push` below.
+          void notifyScheduleChange({
+            spaceId,
+            callId,
+            next: schedule,
+            previous: initial?.schedule ?? '',
+            getToken,
+          }).then(result => {
+            if (result.status === 'notified') return;
+            // Say so. Swallowing this is how "the calendar just never updates" became
+            // indistinguishable from "there was nobody to tell".
+            setToast(<>Call saved, but subscribers weren’t sent the new time.</>);
+          });
 
           if (autoPublishAhead > 0) {
             const token = await getToken();


### PR DESCRIPTION
Closes GEO-2817.

Dovile: "when time is changed on Geo, the info is not updated in third-party curator calendars."

Since GEO-2440 removed the add-to-calendar controls, the only way a call reaches anyone's calendar is the RSVP email invite (iMIP) sent by rendezvous. So "update the calendar" means one thing: resend that invite with a bumped SEQUENCE. That path exists and is wired up — it just resends the wrong time.

## The race

`onSuccess` on `makeProposal` resolves on the **user-operation receipt** — chain confirmation, not indexing. curator-backend's `notify-update` handler then reads the call back through `Entity.findOnePublic` and builds the iMIP from whatever the indexer reports.

In the window between those two, the resend carries the **old** time with an **incremented SEQUENCE**. The subscriber's calendar accepts a revision that changes nothing, and because nothing fires again, it stays wrong permanently. Entity writes here measure p50 9.9s / p95 48.6s to index, so that window is the normal case, not an edge.

## Why not just send the time in the request

That was my first instinct and it's wrong. `notify-update` authenticates its caller but never checks they may edit the space — so accepting a client-supplied time would let any signed-in user mail arbitrary reschedules to a call's subscribers. The read-back is what makes the endpoint trustworthy, so it stays.

## Change

New `notifyScheduleChange` waits until the indexer agrees the new schedule is there, then notifies.

- **On timeout it does not notify.** A missed resend leaves the old time in place and can be retried; a resend *of* the old time spends the sequence number a later correct resend would need in order to win. Worse-is-better, deliberately.
- **An edit that left the time alone skips the wait**, since there's nothing to wait for. The invite carries the title too, so it's still worth resending.
- **Detached, not awaited** — an editor shouldn't sit on the form for an indexing round trip. The toast is a global jotai atom, so it still reaches them after the redirect.
- **Stops swallowing the outcome.** `if (notifyToken)` and `.catch(() => {})` made "we never told anyone" indistinguishable from "there was nobody to tell" — which is exactly why this surfaced as a mystery instead of an error.

## Verification

- 6 new unit tests covering: waits then notifies; never notifies on timeout; skips the wait when the time is unchanged; survives a failed poll; reports a missing token; reports a rejected notification.
- `vitest run core/community-calls partials/community-calls` — 89 passed.
- `tsc --noEmit` and `eslint` clean on the touched files.

One caveat worth stating: I have not proven this specific race is what bit Dovile — she may simply not have RSVP'd, in which case nothing would ever have updated her calendar. The defect stands either way and is noted on the ticket.