### PR TITLE
fix(debates): show the viewer's face on a side they took in an earlier session

### DIFF
--- a/apps/web/core/debates/matchmaking/matchmaking-claim-card.tsx
+++ b/apps/web/core/debates/matchmaking/matchmaking-claim-card.tsx
@@ -651,7 +651,23 @@ export function withViewerPosition({
   const listedOnAnotherSide = positions.some(
     side => side.position !== viewerPosition && side.participants.some(heldByViewer)
   );
-  if (viewerPosition === serverPosition && !listedOnAnotherSide) return positions;
+  // ...and the side they *do* hold may not carry them either. `participants` is presence-driven —
+  // the hub's rows build it from `online_choices` — while `serverPosition` is the stored response,
+  // so for any position taken outside this session geo-chat agrees about the side and still lists
+  // nobody on it. Returning early there left the pill filled with the viewer's colour and no face,
+  // which is the exact failure this function exists to prevent; GEO-2807 covered the case where the
+  // lists put the viewer on the *wrong* side, and this is the case where they put them on none.
+  //
+  // Falling through costs the counts nothing: `countsViewer` already reports the viewer as counted
+  // when `serverPosition` names this side, so `withViewer` adds the face with `missing = 0` rather
+  // than inventing a "+1" beside it.
+  //
+  // `viewerPosition === null` still returns early — there is no held side to be missing from, and
+  // a stale entry on either side is what `listedOnAnotherSide` already catches.
+  const listedOnHeldSide =
+    viewerPosition === null ||
+    positions.some(side => side.position === viewerPosition && side.participants.some(heldByViewer));
+  if (viewerPosition === serverPosition && !listedOnAnotherSide && listedOnHeldSide) return positions;
 
   const copy = ENTITY_RESPONSE_COPY[responseKind];
   const viewer = {

--- a/apps/web/core/debates/matchmaking/with-viewer-position.test.ts
+++ b/apps/web/core/debates/matchmaking/with-viewer-position.test.ts
@@ -223,4 +223,50 @@ describe('withViewerPosition', () => {
     // `presentCount` falls back to the face count, so the badge cannot claim a remainder.
     expect(presentCount(disagree)).toBe(1);
   });
+
+  // GEO-2820. `participants` is presence-driven and `serverPosition` is the stored response, so
+  // for a position taken in an earlier session geo-chat names the side and lists nobody on it.
+  // Agreeing about the side used to be enough to return early, which left the pill filled with the
+  // viewer's colour and no face — the very failure this function exists to prevent.
+  it('adds the viewer to the side they hold when the lists carry them nowhere', () => {
+    const sides = place(
+      [
+        side(true, { total_count: 3, participants: [participant(OTHER_SPACE)] }),
+        side(false, { total_count: 12, participants: [participant(OTHER_SPACE)] }),
+      ],
+      false,
+      false
+    );
+
+    const disagree = on(sides, false);
+    expect(disagree.participants.map(p => p.profile_space_id)).toContain(VIEWER_SPACE);
+    // The count already included them — only the face was missing, so no "+1" appears beside it.
+    expect(disagree.total_count).toBe(12);
+  });
+
+  // The other side is rebuilt too, and must not gain a face it never had.
+  it('leaves the opposing side alone when filling in the held side', () => {
+    const sides = place(
+      [
+        side(true, { total_count: 3, participants: [participant(OTHER_SPACE)] }),
+        side(false, { total_count: 12, participants: [participant(OTHER_SPACE)] }),
+      ],
+      false,
+      false
+    );
+
+    const agree = on(sides, true);
+    expect(agree.participants.map(p => p.profile_space_id)).toEqual([OTHER_SPACE]);
+    expect(agree.total_count).toBe(3);
+  });
+
+  // A viewer who holds nothing has no side to be missing from, so the early return still stands.
+  it('returns the same array for a viewer with no position and no stale entry', () => {
+    const positions = [
+      side(true, { total_count: 1, participants: [participant(OTHER_SPACE)] }),
+      side(false, { total_count: 1, participants: [participant(OTHER_SPACE)] }),
+    ];
+
+    expect(place(positions, null, null)).toBe(positions);
+  });
 });


### PR DESCRIPTION
Closes [GEO-2820](https://linear.app/geobrowser/issue/GEO-2820/claim-pills-show-the-viewers-colour-but-not-their-avatar-for-positions)

## The bug

On the Explore feed and in the Debates side panel, a claim the viewer has responded to draws the pill in their colour (green Agree / red Disagree) with **no avatar inside it** — unless the response was made in the current session. Reported with four claims on one screen: the first showed the viewer's face, the other three showed colour alone.

## This is a client bug, not bad geo-chat data

The colour and the face are read from different fields, and **both are correct**:

| | source | answers |
|---|---|---|
| Pill colour | `viewer_response` | the viewer's *stored* position |
| Avatar stack | `positions[].participants` | who is **present** on that side (`online_choices`) |

For a position taken in an earlier session geo-chat correctly reports `viewer_response: false` while listing nobody present on that side. The two fields answer different questions; `withViewerPosition` exists to reconcile them, and its own docstring names this exact failure:

> …so without this the side you just took fills in with your colour but not your face, which reads as the response not having counted.

## Root cause

```ts
const listedOnAnotherSide = positions.some(
  side => side.position !== viewerPosition && side.participants.some(heldByViewer)
);
if (viewerPosition === serverPosition && !listedOnAnotherSide) return positions;
```

`listedOnAnotherSide` only asks whether the viewer is on the **wrong** side. Nothing asks whether they are on the side they actually **hold**. When geo-chat agrees about the position but lists the viewer nowhere, both conditions pass and the untouched lists are returned — colour, no face.

GEO-2807 fixed the case where the lists put the viewer on the *wrong* side. This is the case where they put them on **none**.

## The fix

```ts
const listedOnHeldSide =
  viewerPosition === null ||
  positions.some(side => side.position === viewerPosition && side.participants.some(heldByViewer));
if (viewerPosition === serverPosition && !listedOnAnotherSide && listedOnHeldSide) return positions;
```

**Counts are untouched.** `countsViewer` already reports the viewer as counted when `serverPosition` names that side, so `withViewer` adds the face with `missing = 0` — no double count, no phantom "+1" beside a single face.

**`viewerPosition === null` still returns early.** A viewer holding nothing has no side to be missing from, and a stale entry on either side is what `listedOnAnotherSide` already catches. Referential equality is preserved in both no-op cases, which an existing test pins.

## Testing

Three cases added to `with-viewer-position.test.ts`:

- **the regression** — server agrees about the side, lists carry the viewer nowhere → face appears, `total_count` unchanged at 12. **Verified failing on master and passing with the fix.**
- the opposing side is left alone while the held side is filled in (guards the fix itself)
- a viewer with no position and no stale entry still gets the same array back (guards the early return)

The last two pass either way by design — they exist so a future change can't "fix" this by over-correcting.

**1,349 tests pass** across `core/debates`, `partials/explore` and `partials/entity-page`. `tsc --noEmit` reports nothing in the touched files.

## Notes for review

**No unrelated reformatting.** `matchmaking-claim-card.tsx` is not prettier-clean on master (import order and a destructuring reflow). Running `prettier --write` pulled 20 lines of unrelated churn into the diff, so I reverted it and re-applied only this hunk — the diff is 18 added lines and 1 changed. Worth a separate cleanup pass if you want the file conformant.

**One thing I could not verify from outside:** that geo-chat populates `participants` from presence is read from the code and the observed pattern, not confirmed against a live payload. It doesn't change the fix — the client has to reconcile the two fields either way — but capturing one `readiness` payload for an affected claim would settle it.

## How to test

Respond to a claim, reload the page (or come back in a later session), and check the Explore feed and the Debates panel: the pill should carry your avatar, not just your colour. The response count beside it should not change.