### PR TITLE
fix(explore): apply the space filter default when memberships land (GEO-2815)

### DIFF
--- a/apps/web/core/debates/claim-space-allowlist.test.ts
+++ b/apps/web/core/debates/claim-space-allowlist.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from 'vitest';
 
 import type { BrowseSidebarData, BrowseSpaceRow } from '~/core/browse/fetch-browse-sidebar-data';
+import { type RequestedMembershipSpace } from '~/core/state/requested-membership';
 import { normId } from '~/core/utils/norm-id';
 
 import {
+  REQUESTED_MEMBERSHIP_SETTLE_MS,
+  awaitsRequestedMembership,
   browseSidebarClaimSpaceAllowlist,
   browseSidebarMemberSpaceIds,
   buildClaimSpaceAllowlist,
@@ -21,6 +24,7 @@ const MEMBER = '019fedae-72b6-7ab2-927a-df044d57c568';
 const PENDING = '019fedae-72b6-7ab2-927a-df044d57c569';
 const PERSONAL = '019fedae-72b6-7ab2-927a-df044d57c570';
 const STRANGER = '019fedae-72b6-7ab2-927a-df044d57c571';
+const WALLET = '0x1234567890abcdef1234567890abcdef12345678';
 
 describe('buildClaimSpaceAllowlist', () => {
   it('covers featured spaces and the spaces the viewer belongs to', () => {
@@ -160,5 +164,103 @@ describe('buildMemberSpaceIds', () => {
 
   it('is empty for a viewer who belongs to nothing, which is the fallback case', () => {
     expect(buildMemberSpaceIds({ editorOf: [], memberOf: [], personalSpaceId: null }).size).toBe(0);
+  });
+});
+
+// GEO-2815. A membership request reaches the indexer about a minute after the transaction, so the
+// payload fetched at the moment of writing answers a question that has already changed — and
+// nothing asked again until a remount or a tab refocus, which in practice meant a hard refresh.
+describe('awaitsRequestedMembership', () => {
+  const NOW = 1_700_000_000_000;
+
+  function requested(id: string, overrides: Partial<RequestedMembershipSpace> = {}): RequestedMembershipSpace {
+    return { id, ownerId: PERSONAL, requestedAt: NOW - 1_000, ...overrides };
+  }
+
+  function data(overrides: Partial<BrowseSidebarData> = {}): BrowseSidebarData {
+    return {
+      featured: [row(FEATURED)],
+      editorOf: [],
+      memberOf: [],
+      personalSpaceId: PERSONAL,
+      ...overrides,
+    } as unknown as BrowseSidebarData;
+  }
+
+  const awaits = (requestedSpaces: RequestedMembershipSpace[], sidebar: BrowseSidebarData | undefined) =>
+    awaitsRequestedMembership({
+      requestedSpaces,
+      personalSpaceId: PERSONAL,
+      walletAddress: null,
+      data: sidebar,
+      now: NOW,
+    });
+
+  it('waits while a request the viewer just made is missing from the payload', () => {
+    expect(awaits([requested(PENDING)], data())).toBe(true);
+  });
+
+  it('stops once the payload reports it', () => {
+    const sidebar = data({ memberOf: [row(PENDING, { pendingLabel: 'Membership pending' })] });
+
+    expect(awaits([requested(PENDING)], sidebar)).toBe(false);
+  });
+
+  it('does not wait when the viewer has made no request', () => {
+    expect(awaits([], data())).toBe(false);
+  });
+
+  // The bound on a request that never lands, and it has to be much tighter than the bridge's own
+  // five-minute TTL: a rejected or vote-ended proposal is dropped by `fetchPendingMembershipSpaceIds`
+  // outright, so it can never arrive, and every tick spent waiting is a full sidebar payload while
+  // the filter sits open on nothing.
+  it('gives up on a request that has passed the settle window', () => {
+    const stale = requested(PENDING, { requestedAt: NOW - REQUESTED_MEMBERSHIP_SETTLE_MS - 1 });
+
+    expect(awaits([stale], data())).toBe(false);
+  });
+
+  it('is still waiting just inside the settle window', () => {
+    const recent = requested(PENDING, { requestedAt: NOW - REQUESTED_MEMBERSHIP_SETTLE_MS + 1_000 });
+
+    expect(awaits([recent], data())).toBe(true);
+  });
+
+  // The window the whole ticket is about, and the one case that must NOT poll: onboarding seeds
+  // bridge entries under the wallet address before the personal space exists, while its own
+  // membership requests are still queued behind that space being created. There is nothing for the
+  // server to report yet, and on this branch the query is a server action.
+  it('does not wait before the viewer has a personal space', () => {
+    const seeded: RequestedMembershipSpace = { id: PENDING, ownerId: WALLET, requestedAt: NOW - 1_000 };
+
+    expect(
+      awaitsRequestedMembership({
+        requestedSpaces: [seeded],
+        personalSpaceId: null,
+        walletAddress: WALLET,
+        data: undefined,
+        now: NOW,
+      })
+    ).toBe(false);
+  });
+
+  // A featured space is what sign-up offers, so a request for one is the ordinary case. Comparing
+  // against the allowlist rather than the viewer's own spaces would read it as already answered.
+  it('waits for a request whose space is also featured', () => {
+    expect(awaits([requested(FEATURED)], data())).toBe(true);
+  });
+
+  it('does not wait when there is no request and no payload either', () => {
+    expect(awaits([], undefined)).toBe(false);
+  });
+
+  it('treats a payload that has not arrived as still owing', () => {
+    expect(awaits([requested(PENDING)], undefined)).toBe(true);
+  });
+
+  // A request belonging to a different account says nothing about this viewer, and waiting on it
+  // would poll for the rest of the bridge's life.
+  it('ignores a request made by another account', () => {
+    expect(awaits([requested(PENDING, { ownerId: STRANGER })], data())).toBe(false);
   });
 });

--- a/apps/web/core/debates/claim-space-allowlist.ts
+++ b/apps/web/core/debates/claim-space-allowlist.ts
@@ -1,4 +1,9 @@
 import type { BrowseSidebarData, BrowseSpaceRow } from '~/core/browse/fetch-browse-sidebar-data';
+import {
+  type RequestedMembershipSpace,
+  activeRequestedSpacesForOwner,
+  requestedMembershipIdSet,
+} from '~/core/state/requested-membership';
 import { normId } from '~/core/utils/norm-id';
 
 /**
@@ -84,6 +89,70 @@ export function browseSidebarMemberSpaceIds(
     memberOf: data.memberOf,
     personalSpaceId: personalSpaceId ?? data.personalSpaceId,
   });
+}
+
+/**
+ * How long a request is treated as still settling.
+ *
+ * Deliberately much shorter than `REQUEST_BRIDGE_TTL_MS`, which the bridge needs for a different
+ * job: keeping a "Membership pending" label up until the server can be trusted to contradict it.
+ * This bounds two things that must not run for five minutes — how long the sidebar payload is
+ * re-asked for, and how long the space filter holds its default waiting for one more answer.
+ *
+ * Sized on the observed gap, which is tens of seconds. A request still missing after this either
+ * failed or was rejected — `fetchPendingMembershipSpaceIds` drops a vote-ended proposal outright,
+ * so it can *never* arrive — and continuing to wait costs a full sidebar payload every tick while
+ * the filter stays open on nothing.
+ */
+export const REQUESTED_MEMBERSHIP_SETTLE_MS = 90_000;
+
+/**
+ * Whether this payload still owes the viewer a membership request they have already made.
+ *
+ * The gap it measures is real and about a minute wide: the request reaches the chain when the
+ * transaction does and the indexer some time after, so a payload fetched in between is a correct
+ * answer to a question that has since changed. Everything reading these lists — the space filter's
+ * default among it — was left on the pre-request answer until something happened to refetch, which
+ * in practice meant a hard refresh (GEO-2815).
+ *
+ * The optimistic bridge is the only thing that knows a request was made before the server does, so
+ * it is what says whether waiting is worth it — it decides *when to re-ask*, never what the answer
+ * is. Two things stop the wait: the request appearing here, and
+ * {@link REQUESTED_MEMBERSHIP_SETTLE_MS} passing, which is what retires one that never lands.
+ *
+ * No data yet is treated as owing: there is a live request and nothing to say it has arrived.
+ */
+export function awaitsRequestedMembership({
+  requestedSpaces,
+  personalSpaceId,
+  walletAddress,
+  data,
+  now,
+}: {
+  requestedSpaces: RequestedMembershipSpace[];
+  personalSpaceId: string | null | undefined;
+  walletAddress: string | null | undefined;
+  data: BrowseSidebarData | undefined;
+  now: number;
+}): boolean {
+  // Nothing to wait for until the viewer has a personal space. Membership is proposed *by* that
+  // space, so the sources behind this payload cannot report a request before it exists — and
+  // onboarding seeds bridge entries under the wallet address minutes earlier, while its own
+  // requests are still queued behind the space being created. Polling on those re-asks a question
+  // that has no answer yet, for the whole of signup, and on that branch the query is a *server
+  // action* (`loadBrowseSidebarData`) rather than a plain fetch.
+  if (!personalSpaceId) return false;
+
+  const settling = activeRequestedSpacesForOwner(requestedSpaces, personalSpaceId, now, walletAddress).filter(
+    space => now - space.requestedAt < REQUESTED_MEMBERSHIP_SETTLE_MS
+  );
+
+  const requested = requestedMembershipIdSet(settling);
+  if (requested.size === 0) return false;
+  if (!data) return true;
+
+  const answered = browseSidebarMemberSpaceIds(data, personalSpaceId);
+  return [...requested].some(id => !answered.has(id));
 }
 
 export function browseSidebarClaimSpaceAllowlist(

--- a/apps/web/core/debates/use-claim-space-allowlist.ts
+++ b/apps/web/core/debates/use-claim-space-allowlist.ts
@@ -4,13 +4,27 @@ import { useQuery } from '@tanstack/react-query';
 
 import * as React from 'react';
 
+import { useAtomValue } from 'jotai';
+
 import { browseSidebarDataQueryKey } from '~/core/browse/browse-sidebar-query';
 import { fetchBrowseSidebarData } from '~/core/browse/fetch-browse-sidebar-data';
 import { useBrowseSidebarQuerySource } from '~/core/browse/use-browse-sidebar-cache';
+import { requestedMembershipSpacesAtom } from '~/core/state/requested-membership';
 
 import { loadBrowseSidebarData } from '~/partials/browse-sidebar/load-browse-sidebar-data';
 
-import { browseSidebarClaimSpaceAllowlist, browseSidebarMemberSpaceIds } from './claim-space-allowlist';
+import {
+  awaitsRequestedMembership,
+  browseSidebarClaimSpaceAllowlist,
+  browseSidebarMemberSpaceIds,
+} from './claim-space-allowlist';
+
+/**
+ * How often to re-ask while a request the viewer just made is missing from the answer. Indexing
+ * lands in tens of seconds, and the poll can only run while an unexpired bridge entry says there
+ * is something to wait for.
+ */
+const REQUESTED_MEMBERSHIP_POLL_MS = 10_000;
 
 /**
  * The spaces the viewer may see claims from — featured spaces, plus the spaces they are a member
@@ -31,10 +45,19 @@ import { browseSidebarClaimSpaceAllowlist, browseSidebarMemberSpaceIds } from '.
  * belongs to, which the space filter defaults to (GEO-2789) — is null on the same terms, and comes
  * off this query rather than its own: it is the same sidebar payload, read two ways.
  */
-export function useClaimSpaceAllowlist(): {
+export function useClaimSpaceAllowlist(enabled: boolean = true): {
   allowlist: Set<string> | null;
   memberSpaceIds: Set<string> | null;
   isLoading: boolean;
+  /**
+   * Whether a request the viewer has made is still missing from `memberSpaceIds`.
+   *
+   * The answer arrives in pieces — sign-up sends one proposal per picked space and they land
+   * seconds apart — so a caller that treats the first non-empty answer as the final one acts on a
+   * fraction of what the viewer chose. Read it as "one more answer is coming", bounded by
+   * `REQUESTED_MEMBERSHIP_SETTLE_MS`.
+   */
+  isSettlingMemberships: boolean;
 } {
   const { personalSpaceId, walletAddress, keyInput, isLoading: personalSpaceLoading } = useBrowseSidebarQuerySource();
 
@@ -42,13 +65,44 @@ export function useClaimSpaceAllowlist(): {
   // smart account itself). Fetching before then would key and cache a featured-only sidebar — the
   // signed-out answer — under the no-wallet key for a signed-in viewer, and drop their own spaces
   // out of the allowlist for as long as that entry stayed fresh.
-  const enabled = !personalSpaceLoading;
+  //
+  // `enabled` narrows that further for callers that only sometimes need the answer — a feed pinned
+  // to one space asks nothing of the viewer's own — so they can hold the hook's position in the
+  // render without paying for a request they will not read.
+  const queryEnabled = enabled && !personalSpaceLoading;
+
+  const requestedSpaces = useAtomValue(requestedMembershipSpacesAtom);
 
   const { data, isLoading } = useQuery({
     queryKey: browseSidebarDataQueryKey(keyInput),
     queryFn: () => (personalSpaceId ? fetchBrowseSidebarData(personalSpaceId) : loadBrowseSidebarData(walletAddress)),
-    enabled,
+    enabled: queryEnabled,
     staleTime: 60_000,
+    // Re-ask while a request the viewer has just made is missing from the answer.
+    //
+    // A membership request reaches the indexer a minute or so after the transaction does, so the
+    // invalidation `requestSpaceMembership` fires at the moment of writing refetches the answer
+    // from *before* it — and nothing tried again until a remount or a tab refocus. What reads this
+    // payload sat on the pre-request answer until a hard refresh, the space filter's default among
+    // it (GEO-2815).
+    //
+    // Driven from the optimistic bridge rather than a timer of its own, which bounds it twice over:
+    // a request stops counting the moment it lands here, and one that never lands stops counting
+    // when `REQUESTED_MEMBERSHIP_SETTLE_MS` passes. The bridge decides only *when to re-ask* —
+    // what this hook reports is still the server's answer.
+    refetchInterval: query =>
+      awaitsRequestedMembership({
+        requestedSpaces,
+        personalSpaceId,
+        walletAddress,
+        data: query.state.data,
+        now: Date.now(),
+      })
+        ? REQUESTED_MEMBERSHIP_POLL_MS
+        : false,
+    // Same reason `usePersonalSpaceId` sets it: a tab nobody is looking at should not spend
+    // requests, and a refocus refetches this anyway.
+    refetchIntervalInBackground: false,
   });
 
   // `enabled: false` only stops the fetch — a cache entry already sitting under this key is still
@@ -56,18 +110,33 @@ export function useClaimSpaceAllowlist(): {
   // identity we have so far, so a signed-out, featured-only entry left over from earlier in the
   // session would answer here and pass for a settled allowlist: the viewer's own spaces filtered
   // out of their own panel, with nothing marking it as still loading. Same gate as the fetch.
+  //
+  // `enabled: false` joins the same gate. It stops the fetch *and* the refetch interval, so the
+  // entry under this key can only go stale from here — handing it back as an answer would let a
+  // caller seed off a set this hook was told not to maintain.
+  const unresolved = personalSpaceLoading || !enabled || !data;
+
   const allowlist = React.useMemo(
-    () => (personalSpaceLoading || !data ? null : browseSidebarClaimSpaceAllowlist(data, personalSpaceId)),
-    [data, personalSpaceId, personalSpaceLoading]
+    () => (unresolved ? null : browseSidebarClaimSpaceAllowlist(data, personalSpaceId)),
+    [data, personalSpaceId, unresolved]
   );
 
   // Same gate, for the same reason: a signed-out entry left over under a partial key would read as
   // a settled answer of "you belong to nothing", which is the case the default treats as a viewer
   // with no memberships and falls back to showing everything. Held as null until it is real.
   const memberSpaceIds = React.useMemo(
-    () => (personalSpaceLoading || !data ? null : browseSidebarMemberSpaceIds(data, personalSpaceId)),
-    [data, personalSpaceId, personalSpaceLoading]
+    () => (unresolved ? null : browseSidebarMemberSpaceIds(data, personalSpaceId)),
+    [data, personalSpaceId, unresolved]
   );
 
-  return { allowlist, memberSpaceIds, isLoading: personalSpaceLoading || (enabled && isLoading) };
+  // Same question the interval asks, answered against the data the caller is being handed.
+  const isSettlingMemberships =
+    enabled && awaitsRequestedMembership({ requestedSpaces, personalSpaceId, walletAddress, data, now: Date.now() });
+
+  return {
+    allowlist,
+    memberSpaceIds,
+    isLoading: personalSpaceLoading || (queryEnabled && isLoading),
+    isSettlingMemberships,
+  };
 }

--- a/apps/web/partials/feed/entity-feed.test.tsx
+++ b/apps/web/partials/feed/entity-feed.test.tsx
@@ -22,6 +22,12 @@ const mocks = vi.hoisted(() => ({
   pages: null as { items: Record<string, unknown>[] }[] | null,
   /** Props the last rendered card received. */
   cardProps: null as Record<string, unknown> | null,
+  /** The viewer's spaces as the live query answers them; null until it does. */
+  liveMemberSpaceIds: null as Set<string> | null,
+  /** Whether a request the viewer made is still missing from that answer. */
+  isSettlingMemberships: false,
+  /** What the feed asked the allowlist hook for. */
+  allowlistEnabled: undefined as boolean | undefined,
 }));
 
 function createLocalStorage(): Storage {
@@ -50,6 +56,18 @@ vi.mock('@tanstack/react-query', () => ({
       fetchNextPage: vi.fn(),
       hasNextPage: false,
       error: null,
+    };
+  },
+}));
+
+vi.mock('~/core/debates/use-claim-space-allowlist', () => ({
+  useClaimSpaceAllowlist: (enabled?: boolean) => {
+    mocks.allowlistEnabled = enabled;
+    return {
+      allowlist: null,
+      memberSpaceIds: mocks.liveMemberSpaceIds,
+      isLoading: false,
+      isSettlingMemberships: mocks.isSettlingMemberships,
     };
   },
 }));
@@ -85,6 +103,9 @@ beforeEach(() => {
   mocks.pages = null;
   mocks.cardProps = null;
   mocks.queryKeys = [];
+  mocks.liveMemberSpaceIds = null;
+  mocks.isSettlingMemberships = false;
+  mocks.allowlistEnabled = undefined;
   mocks.fetch.mockReset();
   mocks.fetch.mockResolvedValue({ ok: true, json: async () => ({ items: [], nextCursor: null }) });
   vi.stubGlobal('fetch', mocks.fetch);
@@ -442,6 +463,79 @@ describe('the space filter', () => {
     renderFeed(undefined);
 
     expect(await sentSpaceIds()).toBeNull();
+  });
+
+  // GEO-2815. The prop is what their spaces were when the page was rendered, and a reader who has
+  // just signed up is rendered before they have any: the personal space takes minutes to land and
+  // the requests behind their sign-up picks are fired after it. The filter opened on nothing — the
+  // unfiltered feed over every featured space — and a server prop cannot move, so it stayed there
+  // until a hard refresh.
+  it('applies the default when their memberships arrive after the page was rendered', async () => {
+    const { rerender } = renderFeed([]);
+    expect(await sentSpaceIds()).toBeNull();
+
+    mocks.liveMemberSpaceIds = new Set(['space-pending']);
+    rerender(
+      <EntityFeed apiEndpoint="/api/explore/feed" initialSpaceOptions={OPTIONS} memberSpaceIds={[]} showSortFilter />
+    );
+
+    await waitFor(async () => expect(await sentSpaceIds()).toBe('space-pending'));
+  });
+
+  // The seed is spent on a match, so a reader who acted before their memberships landed keeps what
+  // they asked for. Without this the late answer would be a policy rather than a default.
+  it('leaves a reader who has already touched the filter alone', async () => {
+    const { rerender } = renderFeed([]);
+    pickOption('Crypto');
+    expect(await sentSpaceIds()).toBe('space-featured');
+
+    mocks.liveMemberSpaceIds = new Set(['space-pending']);
+    rerender(
+      <EntityFeed apiEndpoint="/api/explore/feed" initialSpaceOptions={OPTIONS} memberSpaceIds={[]} showSortFilter />
+    );
+
+    expect(await sentSpaceIds()).toBe('space-featured');
+  });
+
+  // Inverting this gate reinstates the bug in full — Explore never asks for the memberships, so the
+  // live answer never arrives — while spending a request on every space-pinned feed. Nothing else
+  // in the suite notices, because the argument is otherwise invisible from outside.
+  it('asks for the viewer’s spaces on the cross-space feed, and not on a pinned one', () => {
+    renderFeed(['space-mine']);
+    expect(mocks.allowlistEnabled).toBe(true);
+    cleanup();
+
+    render(<EntityFeed apiEndpoint="/api/activity/feed" lockedSpaceId="space-id" />);
+    expect(mocks.allowlistEnabled).toBe(false);
+  });
+
+  // The live value is not reliably the fresher of the two: it can be a cache entry up to a minute
+  // old that the sidebar filled on another route, while the prop was computed during this render.
+  // Preferring it would drop a space the reader had just joined back out of their own default.
+  it('keeps a space the server prop knows about but the cached answer does not', async () => {
+    mocks.liveMemberSpaceIds = new Set(['space-mine']);
+    renderFeed(['space-mine', 'space-pending']);
+
+    expect((await sentSpaceIds())?.split(',').sort()).toEqual(['space-mine', 'space-pending']);
+  });
+
+  // The seed is spent on the first non-empty match, and sign-up sends one proposal per picked
+  // space — they land seconds apart. Spending it on the first to arrive pins the reader to that one
+  // and silently drops the rest of what they chose.
+  it('holds the default while more of their memberships are still landing', async () => {
+    mocks.isSettlingMemberships = true;
+    mocks.liveMemberSpaceIds = new Set(['space-mine']);
+    const { rerender } = renderFeed([]);
+
+    expect(await sentSpaceIds()).toBeNull();
+
+    mocks.isSettlingMemberships = false;
+    mocks.liveMemberSpaceIds = new Set(['space-mine', 'space-pending']);
+    rerender(
+      <EntityFeed apiEndpoint="/api/explore/feed" initialSpaceOptions={OPTIONS} memberSpaceIds={[]} showSortFilter />
+    );
+
+    expect((await sentSpaceIds())?.split(',').sort()).toEqual(['space-mine', 'space-pending']);
   });
 
   it('lets the reader widen to a featured space they have not joined', async () => {

--- a/apps/web/partials/feed/entity-feed.tsx
+++ b/apps/web/partials/feed/entity-feed.tsx
@@ -8,6 +8,7 @@ import cx from 'classnames';
 
 import { HubMultiFilterMenu, pickerLabel } from '~/core/debates/matchmaking/hub-filter-menu';
 import { memberSpaceSelection, useSpaceFilterMenu } from '~/core/debates/matchmaking/use-space-filter-selection';
+import { useClaimSpaceAllowlist } from '~/core/debates/use-claim-space-allowlist';
 import { DEFAULT_EXPLORE_TYPE_IDS, EXPLORE_ENTITY_TYPE_IDS } from '~/core/explore/explore-constants';
 import {
   EXPLORE_TYPE_FILTER_STORAGE_KEY,
@@ -272,18 +273,51 @@ export function EntityFeed({
     [initialSpaceOptions]
   );
 
-  const memberSpaces = React.useMemo(
-    () => (memberSpaceIds === undefined ? null : new Set(memberSpaceIds)),
-    [memberSpaceIds]
-  );
+  // The prop is what the viewer's spaces were when the page was *rendered*, which for someone who
+  // has just signed up is before they had any: their personal space takes 30s-3min to land and the
+  // membership requests behind their sign-up picks are fired after it, so the server answers with
+  // an empty set and the filter opens on nothing — the unfiltered feed, over every featured space
+  // (GEO-2815). Nothing then moved it, because a server prop cannot: the requests landed a minute
+  // later and only a hard refresh re-rendered the page that computes it.
+  //
+  // So the prop seeds the first paint and the live query takes over the moment it answers. Same
+  // value, same helper, same sidebar payload the server read — this is the client's copy of it,
+  // shared with the debates surfaces rather than fetched again, and it refreshes when a membership
+  // request is published (see `requestSpaceMembership`).
+  //
+  // `useMemberSpaceDefault` is already written for a late answer: its seed is spent on a match, so
+  // an empty first answer leaves it armed and the real one applies when it arrives. A viewer who
+  // touches the filter before then forfeits it, which is the behaviour that makes this a default
+  // rather than a policy.
+  const {
+    memberSpaceIds: liveMemberSpaceIds,
+    isSettlingMemberships,
+    isLoading: memberSpacesLoading,
+  } = useClaimSpaceAllowlist(lockedSpaceId == null);
+
+  // The union of the two, not the live one in place of the prop. Neither is reliably the fresher:
+  // the prop was computed during *this* render of the page, while the live value can be a cache
+  // entry up to a minute old that the sidebar filled on another route — so a reader who joined a
+  // space and navigated here would have had the space in the prop and missing from the cache, and
+  // preferring the cache would seed the default without it. Both lists answer "spaces that are
+  // mine", so a union can only be too generous, and too generous means one extra box ticked in a
+  // menu the reader can edit.
+  const memberSpaces = React.useMemo(() => {
+    if (liveMemberSpaceIds === null && memberSpaceIds === undefined) return null;
+    return new Set([...(liveMemberSpaceIds ?? []), ...(memberSpaceIds ?? [])]);
+  }, [liveMemberSpaceIds, memberSpaceIds]);
 
   const { onSpaceToggle, onSpacesClear } = useSpaceFilterMenu({
     offeredSpaces,
     spaceIds,
     setSpaceIds,
     memberSpaceIds: memberSpaces,
-    // The options are a server prop rather than a query, so they are never half-arrived here.
-    pending: false,
+    // The *options* are a server prop and are never half-arrived. The viewer's spaces are, and the
+    // seed is spent on the first non-empty match — so reporting anything but the truth here spends
+    // it on a fraction of the answer. Sign-up sends one membership proposal per picked space and
+    // they land seconds apart: a reader who picked three spaces would otherwise be pinned to
+    // whichever indexed first, with the other two silently dropped.
+    pending: memberSpacesLoading || isSettlingMemberships,
   });
   // The hook's `facetSpaces` is deliberately unused. It keeps a *selected* option visible after a
   // count drops it and orders by that count — neither of which applies to a fixed server-rendered


### PR DESCRIPTION
The filter opens on the spaces the reader belongs to (GEO-2789), from a server prop computed while the page rendered. For a reader who has just signed up that render happens before they belong to anything: the personal space takes 30s-3min to land and the membership requests behind their sign-up picks are fired after it. So the prop is empty, the selection is empty, and an empty selection means any space — the unfiltered feed, over every featured space, which is a wall of claims from whichever one ranks highest. Their picks had no bearing on it.

Nothing then moved it, because a server prop cannot. The requests landed a minute later and only a hard refresh re-rendered the page that computes the prop.

`useMemberSpaceDefault` was already written for a late answer — its seed is spent on a match, so an empty first answer leaves it armed — it just never got a second one. So the prop seeds the first paint and the live query answers over it, from the same sidebar payload the server read, shared with the debates surfaces rather than fetched again. A reader who touches the filter first still forfeits the default, which is what keeps this a default rather than a policy.

The two sets are unioned rather than one replacing the other. Neither is reliably the fresher: the prop is from this render, the live value can be a cache entry a minute old that the sidebar filled on another route. Preferring the cache dropped a space the reader had just joined back out of their own default — the same bug inverted.

That query also had to re-ask. A membership request reaches the indexer about a minute after the transaction, so the invalidation `requestSpaceMembership` fires at the moment of writing refetches the answer from before it, and nothing tried again until a remount or a tab refocus. It now polls while a request the reader has made is missing from the answer.

Three bounds on that poll, each one load-bearing:

- It does not run before the personal space exists. Membership is proposed *by* that space, so nothing can report a request before it — and on that branch the query is `loadBrowseSidebarData`, a server action, which made this a server RPC every 10s through the whole of signup. That flickered the onboarding dialog against the explore page for as long as setup ran.
- It stops after REQUESTED_MEMBERSHIP_SETTLE_MS rather than at the bridge's 5-minute TTL, which exists for a different job. A rejected or vote-ended proposal is dropped by `fetchPendingMembershipSpaceIds` outright and can never arrive, and each wasted tick is a full sidebar payload.
- Same window holds the filter's seed. The answer arrives in pieces — sign-up sends one proposal per picked space, landing seconds apart — and the seed is spent on the first non-empty match, so a reader who picked three spaces was pinned to whichever indexed first with the other two silently dropped.

`useClaimSpaceAllowlist` takes an `enabled` argument so a feed pinned to one space can hold the hook's position without paying for a request it will not read. Disabled, it reports null rather than handing back a cache entry it can no longer maintain.

No filtering logic changed, and "any space" still means every space the reader may see. Reviewed by three agents; every finding is either fixed here or noted. Each new test verified to fail when the change it covers is reverted.