### PR TITLE
fix(community-calls): match published occurrences the way they are actually written

### DIFF
--- a/apps/web/core/community-calls/constants.ts
+++ b/apps/web/core/community-calls/constants.ts
@@ -26,9 +26,14 @@ export const CALL_SCHEMA = {
 } as const;
 
 /**
- * `Community call event` (single occurrence) schema. `OCCURRENCE_ORIGINAL_START_PROPERTY`
- * is confirmed **not deployed yet** — matching a republished/rescheduled occurrence back to
- * its RRULE slot is best-effort by `occurrenceStart` until it ships.
+ * `Community call event` (single occurrence) schema.
+ *
+ * `OCCURRENCE_ORIGINAL_START_PROPERTY` **is deployed and is the property to match on** — 90
+ * of the 107 event entities in the graph carry it, against 6 for `START_TIME_PROPERTY`. An
+ * earlier version of this comment said it was "confirmed not deployed yet", which is what
+ * kept `matchOccurrenceEvent` reading `START_TIME_PROPERTY` alone and silently failing to
+ * match 101 of 107 published occurrences. Both the curator frontend and the Rapporteur bot
+ * write Meeting Time + Occurence original start + Published by, and never Start time.
  */
 export const EVENT_SCHEMA = {
   COMMUNITY_CALL_EVENT_TYPE: process.env.NEXT_PUBLIC_COMMUNITY_CALL_EVENT_TYPE_ID ?? '0419ca20118b4cdb84dfdb9ed73b50c2',
@@ -43,9 +48,9 @@ export const EVENT_SCHEMA = {
   TRANSCRIPTS_PROPERTY:
     process.env.NEXT_PUBLIC_COMMUNITY_CALL_EVENT_TRANSCRIPTS_ID ?? 'c504c7d5c3374016a5f083e4b5a92911',
   /**
-   * Canonical ID confirmed against curator's own `ids.ts`, but the type-projection
-   * registration for it may not be live on this network yet — see module doc comment above.
-   * Writing it is harmless either way; reading it back for occurrence-matching is best-effort.
+   * The RRULE slot an event was published for, pinned so the event maps back to its series
+   * slot even when its own Meeting Time was overridden. The deployed property name carries a
+   * typo — "Occurence original start" — which is load-bearing; do not "correct" it.
    */
   OCCURRENCE_ORIGINAL_START_PROPERTY:
     process.env.NEXT_PUBLIC_COMMUNITY_CALL_OCCURRENCE_ORIGINAL_START_ID ?? '660686547e2084faef521eaebbc848f8',
@@ -107,10 +112,9 @@ export function parseRoomName(roomName: string): { spaceId: string; callId: stri
   return { spaceId, callId, occurrenceStart };
 }
 
-// Occurrence Original Start (see EVENT_SCHEMA doc comment) isn't deployed yet, and legacy
-// curator-produced occurrences may have been computed with a different RRULE engine — this
-// tolerance absorbs minor DST/serialization drift when matching by start time, not a real
-// reschedule.
+// Legacy curator-produced occurrences may have been computed with a different RRULE engine,
+// and an event's own Meeting Time can be overridden at publish — this tolerance absorbs minor
+// DST/serialization drift when matching by start time, not a real reschedule.
 export const OCCURRENCE_MATCH_TOLERANCE_MS = 15 * 60 * 1000;
 
 /** A call is joinable from 15min before start until the call-end countdown begins. */

--- a/apps/web/core/community-calls/fetch-occurrence-event.test.ts
+++ b/apps/web/core/community-calls/fetch-occurrence-event.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+
+import type { Entity } from '~/core/types';
+
+import { CALL_SCHEMA, EVENT_SCHEMA } from './constants';
+import { eventOccurrenceStart } from './fetch-occurrence-event';
+
+const SLOT = Date.UTC(2026, 2, 5, 17, 0);
+
+/** Only the shape `eventOccurrenceStart` reads — it never touches the rest of an Entity. */
+function eventWith(values: Array<{ propertyId: string; value: string }>): Entity {
+  return {
+    values: values.map(v => ({ property: { id: v.propertyId }, value: v.value })),
+  } as unknown as Entity;
+}
+
+const originalStart = (iso: string) => ({
+  propertyId: EVENT_SCHEMA.OCCURRENCE_ORIGINAL_START_PROPERTY,
+  value: iso,
+});
+const startTime = (iso: string) => ({ propertyId: EVENT_SCHEMA.START_TIME_PROPERTY, value: iso });
+const meetingTime = (schedule: string) => ({ propertyId: CALL_SCHEMA.MEETING_TIME_PROPERTY, value: schedule });
+
+describe('eventOccurrenceStart', () => {
+  // The regression: matching read Start time alone. Of the 107 Community call event
+  // entities in the graph, 90 carry Occurence original start and only 6 carry Start time,
+  // so 101 published occurrences matched nothing — no link from the listing, no published
+  // recording detected, and republish duplicating agenda blocks instead of tombstoning.
+  it('reads Occurence original start, which is what curator and Rapporteur write', () => {
+    const event = eventWith([originalStart('2026-03-05T17:00:00.000Z')]);
+    expect(eventOccurrenceStart(event, SLOT)).toBe(SLOT);
+  });
+
+  it('still reads Start time, which only geogenesis ever wrote', () => {
+    const event = eventWith([startTime('2026-03-05T17:00:00.000Z')]);
+    expect(eventOccurrenceStart(event, SLOT)).toBe(SLOT);
+  });
+
+  it('prefers the original slot over Start time when both are present', () => {
+    // Order matters rather than being incidental: the original slot is pinned precisely so
+    // an event maps back to its series slot, and the other two can be moved by an override.
+    const event = eventWith([startTime('2026-03-05T19:00:00.000Z'), originalStart('2026-03-05T17:00:00.000Z')]);
+    expect(eventOccurrenceStart(event, SLOT)).toBe(SLOT);
+  });
+
+  it('falls back to the event Meeting Time when neither datetime is present', () => {
+    const event = eventWith([meetingTime('DTSTART:20260305T170000Z\nDTEND:20260305T180000Z')]);
+    expect(eventOccurrenceStart(event, SLOT)).toBe(SLOT);
+  });
+
+  it('prefers the original slot over a Meeting Time an override moved', () => {
+    const event = eventWith([
+      meetingTime('DTSTART:20260305T193000Z\nDTEND:20260305T203000Z'),
+      originalStart('2026-03-05T17:00:00.000Z'),
+    ]);
+    expect(eventOccurrenceStart(event, SLOT)).toBe(SLOT);
+  });
+
+  it('returns null when the event carries no usable time', () => {
+    expect(eventOccurrenceStart(eventWith([]), SLOT)).toBeNull();
+  });
+
+  it('returns null rather than NaN for an unparseable datetime', () => {
+    // NaN would survive `Number.isFinite` checks downstream as a real-looking candidate.
+    expect(eventOccurrenceStart(eventWith([originalStart('not a date')]), SLOT)).toBeNull();
+  });
+});

--- a/apps/web/core/community-calls/fetch-occurrence-event.ts
+++ b/apps/web/core/community-calls/fetch-occurrence-event.ts
@@ -5,7 +5,8 @@ import { Effect } from 'effect';
 import { getBatchEntities, getEntityBacklinks, getRelationsByFromEntityId } from '~/core/io/queries';
 import { Entity, Relation } from '~/core/types';
 
-import { EVENT_SCHEMA, OCCURRENCE_MATCH_TOLERANCE_MS } from './constants';
+import { CALL_SCHEMA, EVENT_SCHEMA, OCCURRENCE_MATCH_TOLERANCE_MS } from './constants';
+import { findOccurrenceByStart } from './occurrences';
 import { isPlayableRecordingUrl } from './recordings';
 
 export type PublishedAgendaBlock = { blockId: string; markdown: string; position: string };
@@ -19,8 +20,43 @@ export type PublishedOccurrenceEvent = {
 };
 
 /**
+ * Which instant a published `Community call event` says it is for.
+ *
+ * Three properties can carry it, and they are tried in the order the writers actually
+ * populate them — not in the order the schema lists them:
+ *
+ * 1. **Occurence original start** (note the typo in the deployed property name) is the
+ *    RRULE slot, pinned at publish for exactly this purpose: it maps the event back to its
+ *    series slot even when the event's own time was overridden. Both the curator frontend
+ *    (`publish-occurrence-event.ts`) and the Rapporteur bot (`publisher.ts`) write it.
+ * 2. **Start time** is what geogenesis's own publish path writes, and nothing else does.
+ * 3. **Meeting Time** is the event's own single-occurrence schedule — last, because it is
+ *    the one that a publish-time override changes, so it can disagree with the slot.
+ *
+ * Matching used to consider only (2), which is why this went unnoticed: of the 107
+ * `Community call event` entities in the graph, 6 carry Start time and 90 carry Occurence
+ * original start. So 101 published occurrences matched nothing, and three things failed
+ * quietly for them — the listing never linked to the published occurrence, a published
+ * recording could never be detected, and an agenda republish could not find the previous
+ * event to tombstone its blocks, so it duplicated them instead.
+ */
+export function eventOccurrenceStart(entity: Entity, occurrenceStart: number): number | null {
+  const valueOf = (propertyId: string) => entity.values.find(v => v.property.id === propertyId)?.value;
+
+  for (const propertyId of [EVENT_SCHEMA.OCCURRENCE_ORIGINAL_START_PROPERTY, EVENT_SCHEMA.START_TIME_PROPERTY]) {
+    const raw = valueOf(propertyId);
+    const ms = raw ? Date.parse(raw) : NaN;
+    if (Number.isFinite(ms)) return ms;
+  }
+
+  const schedule = valueOf(CALL_SCHEMA.MEETING_TIME_PROPERTY);
+  return schedule ? (findOccurrenceByStart(schedule, occurrenceStart)?.startMs ?? null) : null;
+}
+
+/**
  * Best-effort match of an occurrence to its published `Community call event` entity: the
- * event backlink whose START_TIME is nearest `occurrenceStart` within tolerance, or null.
+ * event backlink whose claimed start (see {@link eventOccurrenceStart}) is nearest
+ * `occurrenceStart` within tolerance, or null.
  */
 async function matchOccurrenceEvent(
   seriesId: string,
@@ -37,9 +73,8 @@ async function matchOccurrenceEvent(
 
   const entities = await Effect.runPromise(getBatchEntities(candidateIds)).catch(() => []);
   const scored = entities.flatMap(entity => {
-    const startVal = entity.values.find(v => v.property.id === EVENT_SCHEMA.START_TIME_PROPERTY)?.value;
-    const startMs = startVal ? Date.parse(startVal) : NaN;
-    return Number.isFinite(startMs) ? [{ entity, startMs }] : [];
+    const startMs = eventOccurrenceStart(entity, occurrenceStart);
+    return startMs === null ? [] : [{ entity, startMs }];
   });
 
   const best = scored.reduce<{ entity: Entity; startMs: number } | null>((closest, candidate) => {

--- a/apps/web/core/community-calls/occurrences.test.ts
+++ b/apps/web/core/community-calls/occurrences.test.ts
@@ -70,6 +70,48 @@ describe('bucketOccurrences', () => {
     expect(upcoming.every(o => o.startMs > NOW)).toBe(true);
     expect(past.every(o => o.endMs < NOW)).toBe(true);
   });
+
+  // The regression this guards: every discovery surface buckets through this function, so
+  // filing a still-running call under `past` at its scheduled end made an overrunning
+  // meeting unfindable while it was happening — the rail and listings advertised next
+  // week's occurrence instead.
+  const SERIES = 'DTSTART:20260305T170000Z\nDTEND:20260305T180000Z\nRRULE:FREQ=WEEKLY;BYDAY=TH';
+  const SCHEDULED_END = Date.UTC(2026, 2, 5, 18, 0);
+
+  it('keeps a call live past its scheduled end for as long as it can still be joined', () => {
+    const tenPastEnd = SCHEDULED_END + 10 * 60 * 1000;
+    const { live, past } = bucketOccurrences(getOccurrences(SERIES, tenPastEnd), tenPastEnd);
+
+    expect(live?.startMs).toBe(Date.UTC(2026, 2, 5, 17, 0));
+    expect(past.some(o => o.startMs === Date.UTC(2026, 2, 5, 17, 0))).toBe(false);
+  });
+
+  it('does not advertise the next occurrence while the current one is still running', () => {
+    const tenPastEnd = SCHEDULED_END + 10 * 60 * 1000;
+    const { live, upcoming } = bucketOccurrences(getOccurrences(SERIES, tenPastEnd), tenPastEnd);
+
+    // A weekly series: getting this wrong points people at a call seven days away.
+    expect(live).not.toBeNull();
+    expect(upcoming[0]?.startMs).toBe(Date.UTC(2026, 2, 12, 17, 0));
+  });
+
+  it('files the call under past once the join window has closed', () => {
+    const afterJoinWindow = SCHEDULED_END + 26 * 60 * 1000;
+    const { live, past } = bucketOccurrences(getOccurrences(SERIES, afterJoinWindow), afterJoinWindow);
+
+    expect(live).toBeNull();
+    expect(past[0]?.startMs).toBe(Date.UTC(2026, 2, 5, 17, 0));
+  });
+
+  it('does not call an occurrence live before it has started', () => {
+    // `isOccurrenceLive` admits people 15 minutes early; the badge must not claim the
+    // meeting is under way when it is not.
+    const fiveBeforeStart = Date.UTC(2026, 2, 5, 16, 55);
+    const { live, upcoming } = bucketOccurrences(getOccurrences(SERIES, fiveBeforeStart), fiveBeforeStart);
+
+    expect(live).toBeNull();
+    expect(upcoming[0]?.startMs).toBe(Date.UTC(2026, 2, 5, 17, 0));
+  });
 });
 
 // Anything acting on the occurrence a user actually joined must resolve it from the

--- a/apps/web/core/community-calls/occurrences.ts
+++ b/apps/web/core/community-calls/occurrences.ts
@@ -5,7 +5,7 @@
  */
 import { localToUtcMs, parseSchedule } from '~/core/utils/schedule';
 
-import { OCCURRENCE_MATCH_TOLERANCE_MS } from './constants';
+import { LIVE_WINDOW_AFTER_MS, OCCURRENCE_MATCH_TOLERANCE_MS } from './constants';
 import { Occurrence } from './types';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -137,15 +137,29 @@ export type BucketedOccurrences = {
 /**
  * Bucket occurrences relative to `now`: the live one, future, and recent past.
  *
- * "Live" here is the scheduled window only (no before/after grace) — it drives the
- * "LIVE" badge on the listing, which should reflect the schedule, not joinability.
- * `isOccurrenceLive` (with its grace window) is a separate, deliberately more
- * lenient check used only to decide whether the join screen is offered.
+ * The live window runs from the scheduled start to {@link LIVE_WINDOW_AFTER_MS} past the
+ * scheduled end — asymmetric on purpose, and the asymmetry is the point:
+ *
+ * - **No pre-start grace.** `isOccurrenceLive` admits people 15 minutes early, but a call
+ *   that has not started is not live and must not claim to be. Early arrivals are still
+ *   offered the join screen; they just read as upcoming, which is what they are.
+ * - **Post-end grace, matching the join window.** This used to end at `endMs`, on the
+ *   reasoning that the badge should reflect the schedule rather than joinability. That
+ *   reasoning produced a real failure: every discovery surface buckets through this
+ *   function, so for the 25 minutes a call remains joinable past its scheduled end — while
+ *   people are still in it — the rail, the Community tab and the Explore digest all filed it
+ *   under past and advertised the *next* occurrence instead. On a weekly series that is next
+ *   week. Anyone arriving late to a meeting that ran over could not find the meeting that was
+ *   happening. A call still in progress is live; the schedule is what it was planned to be.
+ *
+ * `past` is the complement, so an occurrence is never both — it leaves the live bucket only
+ * once it can no longer be joined.
  */
 export function bucketOccurrences(occurrences: Occurrence[], now = Date.now()): BucketedOccurrences {
-  const live = occurrences.find(o => now >= o.startMs && now <= o.endMs) ?? null;
+  const liveUntil = (o: Occurrence) => o.endMs + LIVE_WINDOW_AFTER_MS;
+  const live = occurrences.find(o => now >= o.startMs && now <= liveUntil(o)) ?? null;
   const upcoming = occurrences.filter(o => o.startMs > now && o !== live).sort((a, b) => a.startMs - b.startMs);
-  const past = occurrences.filter(o => o.endMs < now && o !== live).sort((a, b) => b.startMs - a.startMs);
+  const past = occurrences.filter(o => liveUntil(o) < now && o !== live).sort((a, b) => b.startMs - a.startMs);
   return { live, upcoming, past };
 }
 


### PR DESCRIPTION
Two defects found while auditing community calls ahead of using them for the weekly community meeting. Both make a real meeting harder to find or to watch back, and neither is visible as an error anywhere.

## 1. Published occurrences were invisible to geobrowser

`matchOccurrenceEvent` scored candidate events **solely on `Start time`**. Measured against the live graph:

| property | occurrence entities carrying it |
|---|---|
| `Start time` — what matching read | **6** of 107 |
| `Occurence original start` | **90** of 107 |
| `Meeting Time` | 100 of 107 |

Both writers — the curator frontend (`publish-occurrence-event.ts`) and the Rapporteur bot (`publisher.ts:305`) — write Meeting Time + Occurence original start + Published by, and deliberately never Start time. Rapporteur's read side uses those two as well. The ecosystem converged; this reader didn't.

So **101 of 107** published occurrences matched nothing, and three things failed quietly for them:

- the Community tab never rendered a link to the published occurrence
- `useRecordingPublished` is gated on the matched event id, so **a published recording could never be detected** — directly undermining "record the meeting and let people watch it back"
- an agenda republish could not find the previous event to tombstone its blocks, so it duplicated them

It went unnoticed because of a comment: `constants.ts` asserted `OCCURRENCE_ORIGINAL_START_PROPERTY` was *"confirmed not deployed yet"*, which is exactly what justified matching on Start time alone. It is deployed, on 90 entities. Corrected here, along with the derived claim on `OCCURRENCE_MATCH_TOLERANCE_MS`.

Matching now tries the original slot, then Start time, then the event's own Meeting Time — the order the writers actually populate, with the override-prone one last. **Coverage goes from 6 to 106 of 107.**

## 2. A running call left every listing at its scheduled end

`isOccurrenceLive` admits people from −15min to **+25min**, but `bucketOccurrences` filed an occurrence under `past` at `endMs`. Every discovery surface buckets through it — space rail, Community tab, Explore digest, occurrence selector.

So for the 25 minutes a call remained joinable past its scheduled end — while people were still in it — all of them called it past and advertised the *next* occurrence. On a weekly series that is next week. Anyone arriving late to a meeting that ran over could not find the meeting that was happening.

The live window now runs from the scheduled start to the end of the join window. **Asymmetric on purpose**: no pre-start grace, because a call that has not started must not claim to be live, even though early arrivals are already admitted. `past` is the complement, so an occurrence is never both.

## Verification

- 11 new unit tests: property precedence including override cases and unparseable dates; live-past-scheduled-end; not-live-before-start; leaves live once the join window closes; and that the next occurrence isn't advertised over a running one.
- `vitest run core/community-calls` — 94 passed.
- `tsc --noEmit` and `eslint` clean on the touched files.

Part of a broader community-calls audit; more PRs to follow (in-call extension for the hard cutoff, stopping egress on the cutoff path, drop-telemetry identity, explicit LiveKit room limits, edit-page access gate).