### PR TITLE
feat(community-calls): let an editor extend a call, and stop the recording at the cutoff

### DIFF
--- a/apps/web/core/community-calls/use-call-extension.test.tsx
+++ b/apps/web/core/community-calls/use-call-extension.test.tsx
@@ -1,0 +1,170 @@
+import { act, renderHook } from '@testing-library/react';
+
+import { RoomEvent } from 'livekit-client';
+import type { Room } from 'livekit-client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { CALL_EXTENSION_MS, MAX_CALL_EXTENSION_MS, useCallExtension } from './use-call-extension';
+
+/**
+ * `useDataChannel` is the transport under test's only outside dependency. The fake keeps the
+ * registered handler so a test can deliver a message as if a peer had sent it, and records
+ * what this client published.
+ */
+const channel = {
+  handler: null as ((msg: { payload: Uint8Array; from?: { metadata?: string } }) => void) | null,
+  sent: [] as unknown[],
+};
+
+vi.mock('@livekit/components-react', () => ({
+  useDataChannel: (_topic: string, handler: (msg: { payload: Uint8Array; from?: { metadata?: string } }) => void) => {
+    channel.handler = handler;
+    return {
+      send: (payload: Uint8Array) => {
+        channel.sent.push(JSON.parse(new TextDecoder().decode(payload)));
+      },
+    };
+  },
+}));
+
+function createFakeRoom() {
+  const listeners = new Map<string, Set<(...args: unknown[]) => void>>();
+  const room = {
+    on(event: string, handler: (...args: unknown[]) => void) {
+      if (!listeners.has(event)) listeners.set(event, new Set());
+      listeners.get(event)!.add(handler);
+      return room;
+    },
+    off(event: string, handler: (...args: unknown[]) => void) {
+      listeners.get(event)?.delete(handler);
+      return room;
+    },
+  };
+  const emit = (event: string, ...args: unknown[]) => {
+    for (const handler of [...(listeners.get(event) ?? [])]) handler(...args);
+  };
+  return { room: room as unknown as Room, emit };
+}
+
+const editor = { metadata: JSON.stringify({ isEditor: true }) };
+const guest = { metadata: JSON.stringify({ isEditor: false }) };
+
+const deliver = (from: { metadata?: string } | undefined, body: unknown) =>
+  act(() => {
+    channel.handler?.({ payload: new TextEncoder().encode(JSON.stringify(body)), from });
+  });
+
+afterEach(() => {
+  channel.handler = null;
+  channel.sent = [];
+});
+
+describe('useCallExtension', () => {
+  it('extends the call and tells the rest of the room', () => {
+    const { room } = createFakeRoom();
+    const { result } = renderHook(() => useCallExtension({ room, canExtend: true }));
+
+    act(() => result.current.extend());
+
+    expect(result.current.extensionMs).toBe(CALL_EXTENSION_MS);
+    expect(channel.sent).toEqual([{ extensionMs: CALL_EXTENSION_MS }]);
+  });
+
+  it('accepts an extension announced by an editor', () => {
+    // The point of the whole mechanism: every client enforces the cutoff itself, so a host
+    // who extended only locally would keep talking while everyone else was dropped.
+    const { room } = createFakeRoom();
+    const { result } = renderHook(() => useCallExtension({ room, canExtend: false }));
+
+    deliver(editor, { extensionMs: CALL_EXTENSION_MS });
+
+    expect(result.current.extensionMs).toBe(CALL_EXTENSION_MS);
+  });
+
+  it('ignores an extension from a participant who is not an editor', () => {
+    // Any participant can publish data, so gating the button alone would be decoration.
+    const { room } = createFakeRoom();
+    const { result } = renderHook(() => useCallExtension({ room, canExtend: false }));
+
+    deliver(guest, { extensionMs: CALL_EXTENSION_MS });
+
+    expect(result.current.extensionMs).toBe(0);
+  });
+
+  it('never shortens a call, whatever arrives', () => {
+    // Monotonicity is what makes rebroadcasting safe — duplicates and out-of-order
+    // messages have to be harmless.
+    const { room } = createFakeRoom();
+    const { result } = renderHook(() => useCallExtension({ room, canExtend: true }));
+
+    act(() => result.current.extend());
+    act(() => result.current.extend());
+    deliver(editor, { extensionMs: CALL_EXTENSION_MS });
+
+    expect(result.current.extensionMs).toBe(2 * CALL_EXTENSION_MS);
+  });
+
+  it('re-announces the extension when someone joins late', () => {
+    const { room, emit } = createFakeRoom();
+    const { result } = renderHook(() => useCallExtension({ room, canExtend: true }));
+
+    act(() => result.current.extend());
+    channel.sent = [];
+    act(() => emit(RoomEvent.ParticipantConnected));
+
+    expect(channel.sent).toEqual([{ extensionMs: CALL_EXTENSION_MS }]);
+  });
+
+  it('stays quiet on a join when nothing has been extended', () => {
+    const { room, emit } = createFakeRoom();
+    renderHook(() => useCallExtension({ room, canExtend: true }));
+
+    act(() => emit(RoomEvent.ParticipantConnected));
+
+    expect(channel.sent).toEqual([]);
+  });
+
+  it('stops extending at the ceiling', () => {
+    // A call left open by accident still has to end.
+    const { room } = createFakeRoom();
+    const { result } = renderHook(() => useCallExtension({ room, canExtend: true }));
+
+    for (let i = 0; i < 10; i++) act(() => result.current.extend());
+
+    expect(result.current.extensionMs).toBe(MAX_CALL_EXTENSION_MS);
+    expect(result.current.canExtendFurther).toBe(false);
+  });
+
+  it('clamps an announced extension to the ceiling too', () => {
+    const { room } = createFakeRoom();
+    const { result } = renderHook(() => useCallExtension({ room, canExtend: false }));
+
+    deliver(editor, { extensionMs: 99 * 60 * 60 * 1000 });
+
+    expect(result.current.extensionMs).toBe(MAX_CALL_EXTENSION_MS);
+  });
+
+  it('does not extend for someone who may not', () => {
+    const { room } = createFakeRoom();
+    const { result } = renderHook(() => useCallExtension({ room, canExtend: false }));
+
+    act(() => result.current.extend());
+
+    expect(result.current.extensionMs).toBe(0);
+    expect(channel.sent).toEqual([]);
+  });
+
+  it('ignores malformed and nonsensical payloads', () => {
+    const { room } = createFakeRoom();
+    const { result } = renderHook(() => useCallExtension({ room, canExtend: false }));
+
+    deliver(editor, { extensionMs: 'soon' });
+    deliver(editor, { extensionMs: -CALL_EXTENSION_MS });
+    deliver(editor, {});
+    act(() => {
+      channel.handler?.({ payload: new TextEncoder().encode('not json'), from: editor });
+    });
+
+    expect(result.current.extensionMs).toBe(0);
+  });
+});

--- a/apps/web/core/community-calls/use-call-extension.ts
+++ b/apps/web/core/community-calls/use-call-extension.ts
@@ -1,0 +1,107 @@
+'use client';
+
+import { useDataChannel } from '@livekit/components-react';
+
+import * as React from 'react';
+
+import { RoomEvent } from 'livekit-client';
+import type { Room } from 'livekit-client';
+
+import { parseParticipantMetadata } from './types';
+
+/** How much one press of Extend buys. */
+export const CALL_EXTENSION_MS = 15 * 60 * 1000;
+
+/**
+ * Ceiling on total extension, so a call left open by accident still ends. Four presses;
+ * past that the room is being used as a standing space, not an overrunning meeting.
+ */
+export const MAX_CALL_EXTENSION_MS = 60 * 60 * 1000;
+
+const CUTOFF_TOPIC = 'call-cutoff';
+
+/**
+ * Shared, editor-controlled extension of a call's hard cutoff.
+ *
+ * The cutoff is enforced independently by each client — every participant runs its own
+ * `CallEndTimer` and disconnects itself. So an extension is only meaningful if every client
+ * agrees on it: a host who extended locally would keep talking while everyone else was
+ * dropped at the original time, which is worse than no extension at all.
+ *
+ * Agreement is reached over the data channel rather than through room metadata. Metadata
+ * would be the more durable home — `useRecordingMetadataSync` uses it, and a late joiner
+ * would read it for free — but writing it requires the server API, and this is deliberately
+ * a client-only change.
+ *
+ * Two properties make the broadcast safe without coordination:
+ *
+ * - **Monotonic.** Receivers take the larger of what they hold and what they were sent, so
+ *   messages may arrive repeatedly, out of order, or late without ever shortening a call.
+ *   That is what lets anyone holding an extension rebroadcast on a join, which is how a late
+ *   joiner learns the cutoff has moved.
+ * - **Editor-gated on receipt, not just on send.** Any participant can publish data, so a
+ *   sender-side check would only be a UI courtesy. The extension is honoured only when the
+ *   sending participant's own metadata says they are an editor — the same `isEditor` the
+ *   participants panel and the last-editor warning read.
+ */
+export function useCallExtension({ room, canExtend }: { room: Room; canExtend: boolean }) {
+  const [extensionMs, setExtensionMs] = React.useState(0);
+
+  // Read by the rebroadcast effect and the send callback, neither of which should re-run
+  // (and re-subscribe, or churn the button identity) every time the value changes.
+  const extensionRef = React.useRef(0);
+  extensionRef.current = extensionMs;
+
+  const applyExtension = React.useCallback((next: number) => {
+    if (!Number.isFinite(next) || next <= 0) return;
+    const clamped = Math.min(next, MAX_CALL_EXTENSION_MS);
+    setExtensionMs(current => (clamped > current ? clamped : current));
+  }, []);
+
+  const { send } = useDataChannel(CUTOFF_TOPIC, msg => {
+    if (!parseParticipantMetadata(msg.from?.metadata).isEditor) return;
+    try {
+      const decoded = JSON.parse(new TextDecoder().decode(msg.payload));
+      if (typeof decoded?.extensionMs === 'number') applyExtension(decoded.extensionMs);
+    } catch {
+      // ignore malformed payloads
+    }
+  });
+
+  const broadcast = React.useCallback(
+    (value: number) => {
+      send(new TextEncoder().encode(JSON.stringify({ extensionMs: value })), { reliable: true });
+    },
+    [send]
+  );
+
+  /**
+   * Someone who joins after the extension was announced never saw the message. Whoever holds
+   * an extension re-announces it when a participant connects; `applyExtension`'s max makes
+   * the duplicate arrivals at everyone else harmless.
+   */
+  React.useEffect(() => {
+    const onParticipantConnected = () => {
+      if (extensionRef.current > 0) broadcast(extensionRef.current);
+    };
+    room.on(RoomEvent.ParticipantConnected, onParticipantConnected);
+    return () => {
+      room.off(RoomEvent.ParticipantConnected, onParticipantConnected);
+    };
+  }, [room, broadcast]);
+
+  const extend = React.useCallback(() => {
+    if (!canExtend) return;
+    const next = Math.min(extensionRef.current + CALL_EXTENSION_MS, MAX_CALL_EXTENSION_MS);
+    if (next === extensionRef.current) return;
+    applyExtension(next);
+    broadcast(next);
+  }, [canExtend, applyExtension, broadcast]);
+
+  return {
+    /** Added to the occurrence's scheduled end, moving both the warning banner and the cutoff. */
+    extensionMs,
+    extend,
+    canExtendFurther: canExtend && extensionMs < MAX_CALL_EXTENSION_MS,
+  };
+}

--- a/apps/web/partials/community-calls/call-end-timer.tsx
+++ b/apps/web/partials/community-calls/call-end-timer.tsx
@@ -3,12 +3,19 @@
 import * as React from 'react';
 
 import { CALL_END_TIMER_DELAY_MINUTES, LIVE_MEETING_GRACE_MINUTES } from '~/core/community-calls/constants';
+import { CALL_EXTENSION_MS } from '~/core/community-calls/use-call-extension';
 
 type Props = {
-  /** The occurrence's scheduled end time. */
+  /**
+   * The occurrence's scheduled end, plus any extension the room has agreed on. Extending
+   * moves the banner and the cutoff together, so a call granted more time goes quiet again
+   * until the new deadline approaches.
+   */
   endTime: Date;
   /** Fired once, when the countdown reaches zero — the caller should disconnect the room. */
   onTimeUp?: () => void;
+  /** Adds {@link CALL_EXTENSION_MS} for everyone. Omitted for anyone who may not extend. */
+  onExtend?: () => void;
 };
 
 function formatTimeRemaining(totalSeconds: number): string {
@@ -21,9 +28,12 @@ function formatTimeRemaining(totalSeconds: number): string {
  * Banner that appears CALL_END_TIMER_DELAY_MINUTES after the occurrence's scheduled
  * end, counts down to the hard cutoff (LIVE_MEETING_GRACE_MINUTES after end), and
  * fires `onTimeUp` exactly once at zero so the caller can force-disconnect this client.
- * No activity-based extension — the cutoff is fixed at mount.
+ *
+ * Still no *activity-based* extension — a call does not keep itself alive by being busy,
+ * because that is how a forgotten room runs forever. An editor can extend it explicitly
+ * via `onExtend`, which moves `endTime` for everyone and so re-arms this banner.
  */
-export function CallEndTimer({ endTime, onTimeUp }: Props) {
+export function CallEndTimer({ endTime, onTimeUp, onExtend }: Props) {
   const [secondsLeft, setSecondsLeft] = React.useState<number | null>(null);
   const firedRef = React.useRef(false);
 
@@ -61,11 +71,22 @@ export function CallEndTimer({ endTime, onTimeUp }: Props) {
 
   if (secondsLeft === null) return null;
 
+  const extensionMinutes = Math.round(CALL_EXTENSION_MS / 60000);
+
   return (
-    <div className="flex h-[30px] w-full items-center justify-center gap-2.5 rounded-lg bg-errorTertiary px-2 py-1">
+    <div className="flex min-h-[30px] w-full items-center justify-center gap-2.5 rounded-lg bg-errorTertiary px-2 py-1">
       <p className="text-metadataMedium text-red-01">
         {secondsLeft > 0 ? `This call will end in ${formatTimeRemaining(secondsLeft)}` : 'This call has ended'}
       </p>
+      {onExtend && secondsLeft > 0 ? (
+        <button
+          type="button"
+          onClick={onExtend}
+          className="rounded bg-red-01 px-2 py-0.5 text-metadataMedium text-white"
+        >
+          {`Add ${extensionMinutes} minutes`}
+        </button>
+      ) : null}
     </div>
   );
 }

--- a/apps/web/partials/community-calls/live-room.tsx
+++ b/apps/web/partials/community-calls/live-room.tsx
@@ -33,6 +33,7 @@ import {
 import { LAST_EDITOR_CONFIRM_DELAY_MS } from '~/core/community-calls/constants';
 import { formatDuration } from '~/core/community-calls/format';
 import { Recording, parseParticipantMetadata } from '~/core/community-calls/types';
+import { useCallExtension } from '~/core/community-calls/use-call-extension';
 import { useCallTimeUp } from '~/core/community-calls/use-call-time-up';
 import { useCommunityCallIdentityToken } from '~/core/community-calls/use-identity-token';
 import { useIsMobileCallLayout } from '~/core/community-calls/use-is-mobile-call-layout';
@@ -196,6 +197,10 @@ function RoomBody({
   const isActiveEditor = isEditor && !isViewer;
   const canControlRecording = isActiveEditor && Boolean(egressId);
 
+  // Shared cutoff extension. Every client enforces the cutoff itself, so this has to be
+  // agreed across the room rather than held locally — see `useCallExtension`.
+  const { extensionMs, extend, canExtendFurther } = useCallExtension({ room, canExtend: isActiveEditor });
+
   // Moderation's "stop screen share" only mutes the track server-side, which doesn't
   // stop the browser's own capture (its "you're sharing your screen" indicator stays
   // up) — the moderator's client also sends this data message so the sharer's own
@@ -319,11 +324,29 @@ function RoomBody({
 
   // Forced-timeout path: fires once when the CallEndTimer banner counts down to
   // zero, converging on the same disconnect as the manual leave dialog but flagging
-  // itself first so the overlay can say why. No recording-stop confirmation on this
-  // path — the call ends regardless of whether a recording is still running.
+  // itself first so the overlay can say why.
+  //
+  // No *confirmation* on this path — the call ends regardless — but the recording is still
+  // stopped, which it previously was not. Both graceful exits stop egress first and this one
+  // did not, so the one meeting guaranteed to hit the cutoff (the one that ran over, and so
+  // the one most worth having) was also the one whose recording nothing closed out. The
+  // room emptying does eventually stop egress on LiveKit's side, but "eventually, as a side
+  // effect" is not what the other two paths rely on and not what this should either.
+  //
+  // Only the client that owns recording control sends it: every participant runs this same
+  // cutoff, so an ungated stop would fire once per person in the room.
   const handleTimeUp = useCallTimeUp(() => {
     reconnection.markEndedByCutoff();
-    onLeave();
+    if (!canControlRecording || !egressId) {
+      onLeave();
+      return;
+    }
+    // Disconnect regardless of how the stop goes — a failed or slow stop must not leave this
+    // client sitting in a call the rest of the room has already left.
+    void getToken()
+      .then(token => (token ? stopRecording({ egressId, room: roomName }, token) : undefined))
+      .catch(() => {})
+      .finally(onLeave);
   });
 
   const onStopRecordingAndLeave = async () => {
@@ -372,7 +395,11 @@ function RoomBody({
 
       {occurrenceEnd !== undefined && (
         <div className="px-3 pt-3">
-          <CallEndTimer endTime={new Date(occurrenceEnd)} onTimeUp={handleTimeUp} />
+          <CallEndTimer
+            endTime={new Date(occurrenceEnd + extensionMs)}
+            onTimeUp={handleTimeUp}
+            onExtend={canExtendFurther ? extend : undefined}
+          />
         </div>
       )}
 


### PR DESCRIPTION
Second PR from the community-calls audit, ahead of using calls for the weekly community meeting. Independent of #2369.

## The problem

A call is force-ended **30 minutes after its scheduled end**. Every client shows a red banner at +25 and disconnects itself at +30. Nothing could move it — the code said so plainly:

> No activity-based extension — the cutoff is fixed at mount.

And `occurrenceEnd` is a page-load prop, so even editing the occurrence's end time mid-call left the cutoff where it was. For a weekly community meeting that occasionally runs long, that's the sharpest behavioural difference from Meet or Zoom.

Being straight about the evidence: no `cause: scheduled` episode has ever fired in production, so this is a latent risk rather than an observed failure. It becomes a real one the first week a meeting overruns.

## Extending

An editor can now add 15 minutes from the banner, up to an hour total. The ceiling is deliberate — a call left open by accident still has to end, so this stays an explicit act rather than becoming activity-based keepalive.

**The extension has to be agreed across the room, not held locally.** Each client enforces its own cutoff, so a host who extended alone would keep talking while everyone else was dropped on time — worse than not extending at all.

Agreement goes over the data channel. Room metadata would be more durable (`useRecordingMetadataSync` uses it, and a late joiner would read it for free) but writing it needs the server API, and this is deliberately client-only. Two properties make the broadcast safe without coordination:

- **Monotonic** — receivers take the larger of held and received, so duplicate, late and out-of-order messages can never shorten a call. That's what makes it safe for whoever holds an extension to re-announce when someone joins, which is how a late joiner learns the cutoff moved.
- **Editor-gated on receipt, not just on send** — any participant can publish data, so gating the button alone would be decoration. An extension counts only if the sending participant's own metadata says they're an editor, the same `isEditor` the participants panel reads.

## Stopping the recording

The cutoff was the one path that never stopped egress. Both graceful exits stop it first; `handleTimeUp` just disconnected. So the one meeting guaranteed to reach the cutoff — the one that ran over, and therefore the one most worth keeping — was the one whose recording nothing closed out.

The room emptying does eventually stop egress LiveKit-side, but "eventually, as a side effect" isn't what the other two paths rely on. Only the client holding recording control sends the stop, since every participant runs this same cutoff and an ungated stop would fire once per person. The disconnect happens regardless of how the stop goes, so a slow or failed stop can't strand someone in a room everyone else has left.

## Verification

- 10 new unit tests: extend and broadcast; accept from an editor; **ignore from a non-editor**; never shorten; re-announce on join; silent when nothing extended; ceiling on both local and announced extensions; no-op for someone who may not extend; malformed and negative payloads.
- `vitest run core/community-calls partials/community-calls` — 99 passed.
- `tsc --noEmit` and `eslint` clean on the touched files.

Not covered: I haven't exercised this in a live room with two clients. The multi-client agreement is unit-tested at the hook boundary, but the LiveKit round trip isn't.