### PR TITLE
Debates: unify Request debate on the match, not a position its endpoint never reads

### DIFF
--- a/apps/web/core/claims/browse/claim-end-slot.tsx
+++ b/apps/web/core/claims/browse/claim-end-slot.tsx
@@ -12,7 +12,6 @@ import Link from 'next/link';
 import type { Debate } from '~/core/debates/api';
 import { debatePath } from '~/core/debates/debate-routes';
 
-import { type DebateRequestPosition, debateRequestGate } from '~/core/debates/request-gate';
 import { useClaimMatchup } from './use-claim-matchup';
 
 /**
@@ -44,22 +43,10 @@ export function ClaimEndSlot({
   activeDebate,
   enabled = true,
   variant = 'inline',
-  position,
   className,
 }: {
   claimId: string;
   spaceId: string;
-  /**
-   * The viewer's position on this claim, from both clocks, so the offer only appears once geo-chat
-   * will honour it (GEO-2808).
-   *
-   * geo-chat validates a request against its *own* copy of the position and rejects an early one
-   * with `claim_response_required`. Every host of this slot already runs `useClaimPositionControl`,
-   * which holds both readings — so this is required rather than optional: a host that could not
-   * answer would be offering a debate it has no way to know is valid, which is what the hub and the
-   * feed cards were doing.
-   */
-  position: DebateRequestPosition;
   /**
    * The live debate on this claim.
    *
@@ -100,16 +87,6 @@ export function ClaimEndSlot({
     enabled,
   });
 
-  // `match` is this surface's opponent half — somebody standing ready on the other side. The
-  // position half is the shared rule, so every surface waits on the same fact and names it the
-  // same way.
-  const gate = debateRequestGate({
-    chatPosition: position.chat,
-    localPosition: position.local,
-    opponentReady: match !== null,
-    indexingDelayed: position.indexingDelayed,
-  });
-
   // Sized to the row it sits in rather than to itself.
   //
   // It was the explore page's "Rank" CTA — 16px in a 28px pill — which is right for a standalone
@@ -131,6 +108,14 @@ export function ClaimEndSlot({
   // A match is derived from the same `debate_claim_readiness` rows `create_debate_request_as` reads,
   // so no additional position check belongs here — one against the graph would only be slower.
   //
+  // #2354 added one anyway, generalising the rematch picker's fix across every Request debate
+  // control. The picker needs it: it posts to `/debate-rematch-requests`, which resolves positions
+  // from the graph and refuses with `claim_response_required` until the write indexes. This button
+  // posts to `/debate-requests`, which validates against the readiness rows the match above is
+  // already drawn from — so the position it would have waited for is one geo-chat demonstrably
+  // holds. The wait was pure cost, and visible: the hub sat on "Publishing your position…" while
+  // the explore card offered the same claim and the request went through.
+  //
   // Not a guarantee the request will be accepted: the match query omits that endpoint's
   // `validation_failed_at IS NULL` / `last_validated_at IS NOT NULL` predicates and its
   // attempted-recipient exclusion, so a failed validation sweep or an already-tried opponent still
@@ -141,7 +126,7 @@ export function ClaimEndSlot({
         <button
           type="button"
           onClick={request}
-          disabled={Boolean(blockedReason) || isRequesting || !gate.canRequest}
+          disabled={Boolean(blockedReason) || isRequesting}
           // Shown rather than left to a `title`: native tooltips never appear on touch and are
           // unreliable on a disabled button, which is exactly when the explanation matters.
           title={blockedReason}
@@ -157,35 +142,19 @@ export function ClaimEndSlot({
           {/* Both labels stacked in one grid cell, so the button is always as wide as the longer of
               them. "Requesting…" is the shorter, and a button that shrinks the moment you press it
               reads as something having gone wrong. The grid is on this span rather than the button
-              so it cannot fight the button's own `inline-flex`.
-              
-              Only while the offer is pressable. The pending label is longer than "Request debate",
-              so sizing against it would hold every idle button that much wider — and this slot sits
-              in a meta row built not to grow. A press cannot happen while pending, which is the
-              only transition the sizer exists to smooth. */}
-          {gate.pending ? (
-            <span>{gate.pendingLabel}</span>
-          ) : (
-            <span className="grid place-items-center">
-              <span className="invisible col-start-1 row-start-1" aria-hidden>
-                Request debate
-              </span>
-              <span className="col-start-1 row-start-1">{isRequesting ? 'Requesting…' : 'Request debate'}</span>
+              so it cannot fight the button's own `inline-flex`. */}
+          <span className="grid place-items-center">
+            <span className="invisible col-start-1 row-start-1" aria-hidden>
+              Request debate
             </span>
-          )}
+            <span className="col-start-1 row-start-1">{isRequesting ? 'Requesting…' : 'Request debate'}</span>
+          </span>
         </button>
         {/* A blocked reason is a standing condition the reader can see for themselves, so it is
             ordinary text. A failed request is an event that happens after they press, with nothing
             on screen to mark it — `role="alert"` is what makes it reach anyone not watching this
             corner. The Matches tab's old button announced it; losing that when the button moved
             would have been a silent regression. */}
-        {/* A disabled control nobody is focused on announces nothing, so the wait is a `status` as
-            well as a label. */}
-        {gate.pending && !isRequesting ? (
-          <span role="status" aria-live="polite" className="sr-only">
-            {gate.pendingLabel}
-          </span>
-        ) : null}
         {blockedReason ? (
           <span className={cx('text-footnote text-grey-04', variant === 'block' ? 'text-left' : 'text-right')}>
             {blockedReason}

--- a/apps/web/core/claims/browse/claim-page-view.test.tsx
+++ b/apps/web/core/claims/browse/claim-page-view.test.tsx
@@ -80,8 +80,6 @@ vi.mock('~/core/debates/matchmaking/matchmaking-claim-card', () => ({
     viewerPosition: null,
     respond: () => {},
     canRespond: false,
-    // Mirrors the hook: the request offer reads this to decide whether to make itself.
-    requestPosition: { chat: null, local: null, indexingDelayed: false },
     actionTitle: () => undefined,
     responseError: null,
   }),

--- a/apps/web/core/claims/browse/claim-page-view.tsx
+++ b/apps/web/core/claims/browse/claim-page-view.tsx
@@ -238,7 +238,6 @@ function ClaimPositionSection({
         className="mt-2"
         // The offer sits directly under the pills that set the position it depends on, so it has to
         // wait for the same fact those pills are publishing (GEO-2808).
-        position={control.requestPosition}
       />
     </section>
   );

--- a/apps/web/core/debates/browse/debate-claims-panel.test.tsx
+++ b/apps/web/core/debates/browse/debate-claims-panel.test.tsx
@@ -93,8 +93,6 @@ vi.mock('~/core/debates/matchmaking/matchmaking-claim-card', () => ({
       actionTitle: () => (answersReady ? '' : 'Loading this claim’s responses…'),
       responseError: null,
       canRespond: answersReady,
-    // Mirrors the hook: the request offer reads this to decide whether to make itself.
-    requestPosition: { chat: null, local: null, indexingDelayed: false },
     };
   },
 }));

--- a/apps/web/core/debates/matchmaking/matchmaking-claim-card.test.tsx
+++ b/apps/web/core/debates/matchmaking/matchmaking-claim-card.test.tsx
@@ -250,23 +250,29 @@ describe('position avatar stack', () => {
    * with `claim_response_required`. It now waits on the same fact the picker waits on and wears the
    * same label.
    */
-  describe('the request waits for geo-chat to hold the viewer position', () => {
+  describe('the request follows the match, not the graph position', () => {
     const twoSides = () =>
       withCounts([
         { total_count: 1, available_now_count: 1, present_count: 1, participants: [participant('a')] },
         { total_count: 1, available_now_count: 1, present_count: 1, participants: [participant('b')] },
       ]);
 
-    it('names the wait while geo-chat has not caught up', () => {
+    // The reported bug: the hub sat on "Publishing your position…" while the explore card offered
+    // the same claim and the request went through. This button posts to `/debate-requests`, which
+    // validates against the same `debate_claim_readiness` rows the match is drawn from — so a
+    // position geo-chat has not yet derived from the graph is not something to wait for. #2354
+    // waited on it anyway, having generalised the rematch picker's graph-validated fix.
+    it('offers the debate while the response is still indexing', () => {
       mocks.match = { id: 'match-1' };
-      // An answer still reconciling is what the card draws its optimistic side from.
+      // An answer still reconciling is what the card draws its optimistic side from, and the state
+      // geo-chat's own row has not caught up with.
       mocks.indexing = { status: 'reconciling', pending: { expectedResponse: 'positive' }, runId: 'run-1' };
       renderCard(
         <MatchmakingClaimCard claim={claim} positions={twoSides()} readiness={readiness({ viewer_response: null })} />
       );
 
-      expect(screen.getByRole('button', { name: 'Publishing your position…' })).toBeDisabled();
-      expect(screen.queryByRole('button', { name: 'Request debate' })).not.toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Request debate' })).toBeEnabled();
+      expect(screen.queryByText('Publishing your position…')).not.toBeInTheDocument();
     });
 
     it('offers the debate once geo-chat holds the side on screen', () => {
@@ -276,17 +282,12 @@ describe('position avatar stack', () => {
       expect(screen.getByRole('button', { name: 'Request debate' })).toBeEnabled();
     });
 
-    // A claim nobody has answered is not publishing anything. The hub's opponent half is a match,
-    // which does not require a position the way the picker's `opposing` does, so without this the
-    // card announced a wait nobody had started.
-    it('does not name a wait on a claim the viewer has not answered', () => {
-      mocks.match = { id: 'match-1' };
-      renderCard(
-        <MatchmakingClaimCard claim={claim} positions={twoSides()} readiness={readiness({ viewer_response: null })} />
-      );
+    // Without a match there is no opponent to ask, which is the only condition this control has.
+    it('offers nothing when geo-chat reports no match', () => {
+      mocks.match = null;
+      renderCard(<MatchmakingClaimCard claim={claim} positions={twoSides()} readiness={readiness()} />);
 
-      expect(screen.queryByRole('button', { name: 'Publishing your position…' })).not.toBeInTheDocument();
-      expect(screen.getByRole('button', { name: 'Request debate' })).toBeDisabled();
+      expect(screen.queryByRole('button', { name: 'Request debate' })).not.toBeInTheDocument();
     });
   });
 

--- a/apps/web/core/debates/matchmaking/matchmaking-claim-card.tsx
+++ b/apps/web/core/debates/matchmaking/matchmaking-claim-card.tsx
@@ -7,7 +7,6 @@ import { motion } from 'framer-motion';
 import Link from 'next/link';
 
 import { ClaimEndSlot } from '~/core/claims/browse/claim-end-slot';
-import type { DebateRequestPosition } from '~/core/debates/request-gate';
 import { useClaimResponseSummary } from '~/core/claims/browse/claim-response-summary';
 import { ClaimSummary, ControversialTag } from '~/core/claims/browse/claim-summary';
 import { useClaimMatchup, withMatchParticipants } from '~/core/claims/browse/use-claim-matchup';
@@ -466,16 +465,6 @@ export function useClaimPositionControl({
     actionTitle,
     responseError,
     /**
-     * Both clocks a request offer needs, composed here rather than at each `ClaimEndSlot`. Four
-     * surfaces render that control and every one was spelling this out identically — the same
-     * duplicated derivation that let the card and its own footer disagree (GEO-2808).
-     */
-    requestPosition: {
-      chat: readiness.viewer_response?.position ?? null,
-      local: viewerPosition,
-      indexingDelayed: responseIndexing.status === 'delayed',
-    } satisfies DebateRequestPosition,
-    /**
      * False only while the account genuinely cannot publish, never while one is in flight.
      *
      * Being signed out doesn't disable the pills where a sign-in prompt was supplied: a disabled
@@ -515,18 +504,11 @@ function RespondableControls({
   onRequireSignIn?: () => void;
   hideEndSlot?: boolean;
 }) {
-  const {
-    viewerPosition,
-    optimisticPositions,
-    respond,
-    actionTitle,
-    responseError,
-    canRespond,
-    requestPosition,
-  } = useClaimPositionControl({
-    claim,
-    positions,
-    readiness,
+  const { viewerPosition, optimisticPositions, respond, actionTitle, responseError, canRespond } =
+    useClaimPositionControl({
+      claim,
+      positions,
+      readiness,
       answersReady,
       responseBlockedReason,
       viewerIdentityPending,
@@ -565,12 +547,7 @@ function RespondableControls({
         isControversial={summary.isControversial}
         endSlot={
           hideEndSlot ? null : (
-            <ClaimEndSlot
-              claimId={claim.claim_entity_id}
-              spaceId={claim.space_id}
-              activeDebate={activeDebate}
-              position={requestPosition}
-            />
+            <ClaimEndSlot claimId={claim.claim_entity_id} spaceId={claim.space_id} activeDebate={activeDebate} />
           )
         }
       />
@@ -758,20 +735,7 @@ function UnresolvableControls({
              footer button that used to offer it is gone. Masking an action the server would accept
              is not the safe direction to be wrong in. */
           hideEndSlot ? null : (
-            <ClaimEndSlot
-              claimId={claim.claim_entity_id}
-              spaceId={claim.space_id}
-              activeDebate={activeDebate}
-              // This card draws no response control, so it has no optimistic side of its own and
-              // both readings are geo-chat's. That is not the self-comparison GEO-2808 removed —
-              // there the fallback was the *graph*, a different source from the one that validates
-              // the request. Here it is the validating source agreeing with itself, which is the
-              // honest answer to "does geo-chat hold a position for this viewer".
-              position={{
-                chat: readiness.viewer_response?.position ?? null,
-                local: readiness.viewer_response?.position ?? null,
-              }}
-            />
+            <ClaimEndSlot claimId={claim.claim_entity_id} spaceId={claim.space_id} activeDebate={activeDebate} />
           )
         }
       />

--- a/apps/web/core/debates/request-gate.ts
+++ b/apps/web/core/debates/request-gate.ts
@@ -1,5 +1,5 @@
 /**
- * Determines whether a debate request can be created for a claim.
+ * Whether the rematch picker can create a debate request for a claim.
  *
  * `create_rematch_request` resolves both participants' positions from the knowledge graph and
  * refuses with `claim_response_required` until the write is indexed. So the picker holds the
@@ -11,25 +11,14 @@
  * true and opens a button the server still refuses — pressable, and nothing happens. Comparing also
  * covers switching sides, where the server still holds the side just moved off.
  *
- * The debates hub does not use this gate, deliberately. Its match data and `create_debate_request_as`
- * both read `debate_claim_readiness`, which the in-flight response notification writes, so a
- * graph-backed position check there would hold a button the server would have accepted.
+ * The picker is the only caller, and the only surface that should be. Every other Request debate
+ * control is `ClaimEndSlot`, which posts to `/debate-requests` — validated against the same
+ * `debate_claim_readiness` rows its match is drawn from, so a graph-backed position check there
+ * waits on a fact the server neither reads nor needs. #2354 applied this gate to all of them, and
+ * that is what went wrong: the hub sat on "Publishing your position…" while the explore card
+ * offered the same claim and the request went through. Before adding a caller, check which endpoint
+ * it posts to.
  */
-/**
- * The viewer's position on a claim, read from both clocks, as a request offer needs it.
- *
- * Derived once by `useClaimPositionControl`, which already holds both readings, and passed straight
- * to `ClaimEndSlot`. Every surface that offers a debate needs the same three values, and deriving
- * them per surface is how the two clocks drifted apart in the first place (GEO-2808).
- */
-export type DebateRequestPosition = {
-  /** geo-chat's copy. `undefined` when it has no row for this claim yet. */
-  chat: boolean | null | undefined;
-  /** What the viewer believes they hold — optimistic while a response is in flight. */
-  local: boolean | null;
-  indexingDelayed?: boolean;
-};
-
 export type DebateRequestGateInput = {
   /**
    * The position the request will be validated against, as the surface last heard it.

--- a/apps/web/partials/explore/claim-explore-feed-card.test.tsx
+++ b/apps/web/partials/explore/claim-explore-feed-card.test.tsx
@@ -91,8 +91,6 @@ vi.mock('~/core/debates/matchmaking/matchmaking-claim-card', () => ({
     respond: vi.fn(),
     actionTitle: () => (answersReady ? '' : 'Loading this claim’s responses…'),
     responseError: null,
-    // Mirrors the hook: the request offer reads this to decide whether to make itself.
-    requestPosition: { chat: null, local: null, indexingDelayed: false },
     canRespond: answersReady,
   }),
 }));

--- a/apps/web/partials/explore/claim-explore-feed-card.tsx
+++ b/apps/web/partials/explore/claim-explore-feed-card.tsx
@@ -184,7 +184,6 @@ export function ClaimExploreFeedCard({
               activeDebate={row?.active_debate}
               enabled={nearViewport}
               className="ml-auto"
-              position={control.requestPosition}
             />
           }
           className="col-start-1 row-start-1 mb-3 claim-card-narrow:mb-0"


### PR DESCRIPTION
Fixes the split you saw: the debates side panel showing **"Publishing your position…"** on a claim the explore feed offered as **"Request debate"** — where the request worked.

## Is it the frontend or geo-chat?

**The frontend.** geo-chat was consistent throughout, and your test proves it: the request succeeded, so `/debate-requests` was happy to accept it while the hub was still saying "publishing".

## Why the two surfaces disagreed

Both render the same `ClaimEndSlot` with the same `debateRequestGate`, so the code was already shared — the split was in what each host **feeds** it:

| | `readiness` source | `chat` reading while indexing |
|---|---|---|
| Explore card, claim page | `useClaimResponseState` | falls back to the **on-chain summary** → holds the position |
| Debates hub | geo-chat's row, raw (`readiness={entry}`) | `null` until geo-chat's graph-derived copy catches up |

The gate compares `chat` against the optimistic `local` reading, and they differ **only while a response is in flight**. Explore never noticed because its fallback filled `chat` in; the hub had no fallback, so it sat on the mismatch for as long as geo-chat took to derive the position from the graph.

## The real defect: the gate doesn't belong here

Rather than give the hub a matching fallback, this removes the gate from this control, because the endpoint never reads what it was waiting for:

- **Rematch picker** → `/debate-rematch-requests`, which resolves positions **from the graph** and refuses with `claim_response_required` until the write indexes. It genuinely needs the wait (p50 9.9s / p95 48.6s). **Unchanged.**
- **`ClaimEndSlot`** → `/debate-requests`, validated against the same `debate_claim_readiness` rows its own match is drawn from. A match exists only where geo-chat already holds both sides' positions, so the button appears only once the request would be accepted.

#2354 applied the gate to *every* Request debate control, generalising #2352's picker fix across two endpoints that validate differently. `claim-end-slot.tsx` had said so since #2353 — *"no additional position check belongs here — one against the graph would only be slower"* — sitting directly above the check. The comment outlived the decision by one PR.

## What changed

- `ClaimEndSlot` drops the `position` prop and the gate; the offer is the match.
- `useClaimPositionControl` drops `requestPosition`; `DebateRequestPosition` goes with it.
- The two surfaces **cannot** disagree now: neither passes a position.
- `request-gate.ts` documents which endpoint each control posts to, so the next person generalising a picker fix sees the distinction.

Worth noting the unresolvable hub card was already passing geo-chat's copy as *both* readings — a self-comparison that could only ever be true, so the gate was decorative there.

## Tests

Two tests pinned the removed behaviour and are rewritten. One asserted `Request debate` stays disabled when the viewer has no position while a match exists — unreachable in practice, since a match requires the viewer standing ready. They now pin the new contract: the offer follows the match, is live while the response indexes, and is absent with no match.

**389 files / 4328 tests pass.** `tsc --noEmit` reports the same 5 pre-existing errors; build run with `--force` (`Cached: 0 cached`).

One full-suite run failed on `recording-upload-coordinator.integration.test.tsx`, which passes in isolation and shares no code with this change — the second load-sensitive flake in this repo, alongside `settleTabSwap`'s fixed 200ms sleep.