### PR TITLE
fix(community-calls): make drop telemetry able to attribute a drop (GEO-2584)

### DIFF
--- a/apps/web/core/community-calls/disconnect-telemetry.test.ts
+++ b/apps/web/core/community-calls/disconnect-telemetry.test.ts
@@ -13,6 +13,7 @@ const CONTEXT = {
   roomName: 'space-1::call-1::1772130000000',
   occurrenceStart: 1772130000000,
   role: 'participant' as const,
+  participantIdentity: 'participant-a',
 };
 
 afterEach(() => {
@@ -25,6 +26,14 @@ function reportedTags(): Record<string, unknown> | null {
   if (calls.length === 0) return null;
   expect(calls).toHaveLength(1);
   return calls[0][0].tags ?? {};
+}
+
+/** The `extra` payload of the single reported event, or null if nothing was reported. */
+function reportedExtra(): Record<string, unknown> | null {
+  const calls = vi.mocked(reportEvent).mock.calls;
+  if (calls.length === 0) return null;
+  expect(calls).toHaveLength(1);
+  return calls[0][0].extra ?? {};
 }
 
 describe('disconnectReasonName', () => {
@@ -134,5 +143,19 @@ describe('reportCallDisconnect', () => {
   it('distinguishes viewers from participants', () => {
     reportCallDisconnect({ ...CONTEXT, role: 'viewer' }, { outcome: 'gave_up', reason: undefined });
     expect(reportedTags()).toMatchObject({ role: 'viewer', reason: 'NOT_REPORTED' });
+  });
+});
+
+// Without these two, an episode says a drop happened but nothing about whose or how
+// widespread — which is the only question the module was built to answer.
+describe('drop attribution', () => {
+  it("tags the participant so a room's episodes can be grouped by person", () => {
+    reportCallDisconnect(CONTEXT, { outcome: 'recovered', reason: undefined });
+    expect(reportedTags()).toMatchObject({ participantIdentity: 'participant-a' });
+  });
+
+  it('carries the room size the episode opened with', () => {
+    reportCallDisconnect(CONTEXT, { outcome: 'gave_up', reason: undefined, participantCount: 7 });
+    expect(reportedExtra()).toMatchObject({ participantCount: 7 });
   });
 });

--- a/apps/web/core/community-calls/disconnect-telemetry.ts
+++ b/apps/web/core/community-calls/disconnect-telemetry.ts
@@ -106,6 +106,13 @@ export type CallTelemetryContext = {
   roomName: string;
   occurrenceStart: number;
   role: 'participant' | 'viewer';
+  /**
+   * This client's LiveKit identity. Without it the correlation this module exists to
+   * support cannot be done: five episodes in one room over ninety minutes read identically
+   * whether they are one person with bad wifi reconnecting five times or five people hit by
+   * one server event, and those call for opposite responses.
+   */
+  participantIdentity: string;
 };
 
 export type DisconnectEpisode = {
@@ -117,6 +124,13 @@ export type DisconnectEpisode = {
   reconnectingMs?: number;
   /** How far into the call the episode began — "did this happen at the start or the end". */
   msSinceJoin?: number;
+  /**
+   * Room size when the episode *opened*, not when it closed. By the time a disconnect
+   * resolves the room's participant list has already been torn down, so a count read then
+   * is always 1 and says nothing. Read at the start, it answers "was this person alone or
+   * was the room busy" — the denominator for any claim that a drop was widespread.
+   */
+  participantCount?: number;
 };
 
 /**
@@ -125,6 +139,11 @@ export type DisconnectEpisode = {
  * `roomName` is deliberately `extra` rather than a tag: it embeds the occurrence timestamp,
  * so as a tag it would be unbounded cardinality. `callId` is a tag because the set of calls
  * is small and "which call is dropping people" is the first question anyone asks.
+ *
+ * `participantIdentity` is a tag for the same reason, and it is the one that makes the rest
+ * useful: grouping a room's episodes by participant is what separates one flaky connection
+ * from a server event. Its cardinality is the number of people who attend calls, which is
+ * the same order as `callId` and far below `roomName`.
  */
 export function reportCallDisconnect(context: CallTelemetryContext, episode: DisconnectEpisode): void {
   // A voluntary leave is not a drop, and counting it as one would bury the real signal
@@ -145,12 +164,14 @@ export function reportCallDisconnect(context: CallTelemetryContext, episode: Dis
       role: context.role,
       callId: context.callId,
       spaceId: context.spaceId,
+      participantIdentity: context.participantIdentity,
     },
     extra: {
       roomName: context.roomName,
       occurrenceStart: context.occurrenceStart,
       reconnectingMs: episode.reconnectingMs,
       msSinceJoin: episode.msSinceJoin,
+      participantCount: episode.participantCount,
     },
   });
 }

--- a/apps/web/core/community-calls/use-reconnection-state.test.tsx
+++ b/apps/web/core/community-calls/use-reconnection-state.test.tsx
@@ -14,6 +14,7 @@ const TELEMETRY = {
   roomName: 'space-1::call-1::1772130000000',
   occurrenceStart: 1772130000000,
   role: 'participant' as const,
+  participantIdentity: 'participant-a',
 };
 
 /**
@@ -23,6 +24,8 @@ const TELEMETRY = {
 function createFakeRoom() {
   const listeners = new Map<string, Set<(...args: unknown[]) => void>>();
   const room = {
+    // The real Room always has this; the episode's participant count reads it.
+    remoteParticipants: new Map<string, unknown>(),
     on(event: string, handler: (...args: unknown[]) => void) {
       if (!listeners.has(event)) listeners.set(event, new Set());
       listeners.get(event)!.add(handler);
@@ -36,7 +39,7 @@ function createFakeRoom() {
   const emit = (event: string, ...args: unknown[]) => {
     for (const handler of [...(listeners.get(event) ?? [])]) handler(...args);
   };
-  return { room: room as unknown as Room, emit };
+  return { room: room as unknown as Room, emit, remotes: room.remoteParticipants };
 }
 
 const episodes = () => vi.mocked(reportCallDisconnect).mock.calls.map(([, episode]) => episode);
@@ -187,5 +190,35 @@ describe('useReconnectionState cutoff handling', () => {
     expect(result.current.status).toBe('disconnected');
     expect(result.current.disconnectReason).toBe(DisconnectReason.DUPLICATE_IDENTITY);
     expect(onPermanentDisconnect).not.toHaveBeenCalled();
+  });
+});
+
+// Attribution was the module's whole purpose and it could not do it: with no identity and
+// no room size, five episodes in one room read identically whether that is one flaky
+// connection or five people hit by one server event.
+describe('useReconnectionState drop attribution', () => {
+  it('reports the room size as it was when the trouble started, not after the teardown', () => {
+    const { room, emit, remotes } = createFakeRoom();
+    remotes.set('b', {});
+    remotes.set('c', {});
+    renderHook(() => useReconnectionState(room, () => {}, TELEMETRY));
+
+    act(() => emit('reconnecting'));
+    // LiveKit tears the participant list down before the disconnect resolves, so a count
+    // read at report time would always be 1.
+    remotes.clear();
+    act(() => emit('disconnected', DisconnectReason.SIGNAL_CLOSE));
+
+    expect(episodes()[0]?.participantCount).toBe(3);
+  });
+
+  it('still reports a count for an immediate disconnect with no episode open', () => {
+    const { room, emit, remotes } = createFakeRoom();
+    remotes.set('b', {});
+    renderHook(() => useReconnectionState(room, () => {}, TELEMETRY));
+
+    act(() => emit('disconnected', DisconnectReason.SERVER_SHUTDOWN));
+
+    expect(episodes()[0]?.participantCount).toBe(2);
   });
 });

--- a/apps/web/core/community-calls/use-reconnection-state.ts
+++ b/apps/web/core/community-calls/use-reconnection-state.ts
@@ -45,6 +45,16 @@ const NAVIGATE_AWAY_REASONS = new Set([DisconnectReason.CLIENT_INITIATED]);
  * Also the reporting point for drop telemetry, since it is the one place that observes
  * every connection transition — see disconnect-telemetry.ts.
  */
+/**
+ * Local participant plus remotes. Defensive because it is called from inside the disconnect
+ * handler: a throw here would take the reconnection overlay down with it, and an unknown
+ * room size is never worth that.
+ */
+function roomSize(room: Room): number | undefined {
+  const remotes = room.remoteParticipants?.size;
+  return remotes === undefined ? undefined : remotes + 1;
+}
+
 export function useReconnectionState(
   room: Room,
   onPermanentDisconnect: () => void,
@@ -70,6 +80,9 @@ export function useReconnectionState(
   // emits `reconnecting` and `signalReconnecting` repeatedly through one outage, so this is
   // what collapses that burst into a single episode with one outcome.
   const episodeStartedAtRef = React.useRef<number | null>(null);
+  // Captured when the episode opens. Reading it at report time is useless — the room's
+  // participant list is already torn down by then, so it would always be 1.
+  const episodeParticipantCountRef = React.useRef<number | undefined>(undefined);
   const joinedAtRef = React.useRef(Date.now());
   const endedByCutoffRef = React.useRef(false);
   // A single disconnect reaches us twice — once via the `disconnected` event and once via
@@ -77,22 +90,28 @@ export function useReconnectionState(
   // double every count, so the terminal report is latched until the next reconnect.
   const reportedTerminalRef = React.useRef(false);
 
-  const reportEpisode = React.useCallback((outcome: EpisodeOutcome, reason: DisconnectReason | undefined) => {
-    const context = telemetryRef.current;
-    const startedAt = episodeStartedAtRef.current;
-    episodeStartedAtRef.current = null;
-    if (!context) return;
+  const reportEpisode = React.useCallback(
+    (outcome: EpisodeOutcome, reason: DisconnectReason | undefined) => {
+      const context = telemetryRef.current;
+      const startedAt = episodeStartedAtRef.current;
+      const participantCount = episodeParticipantCountRef.current ?? roomSize(room);
+      episodeStartedAtRef.current = null;
+      episodeParticipantCountRef.current = undefined;
+      if (!context) return;
 
-    reportCallDisconnect(context, {
-      outcome,
-      reason,
-      endedByCutoff: endedByCutoffRef.current,
-      reconnectingMs: startedAt === null ? undefined : Date.now() - startedAt,
-      // Measured from when the trouble started, not when it resolved, so "how far into the
-      // call did this happen" isn't skewed by however long the retry ran.
-      msSinceJoin: (startedAt ?? Date.now()) - joinedAtRef.current,
-    });
-  }, []);
+      reportCallDisconnect(context, {
+        outcome,
+        reason,
+        endedByCutoff: endedByCutoffRef.current,
+        reconnectingMs: startedAt === null ? undefined : Date.now() - startedAt,
+        // Measured from when the trouble started, not when it resolved, so "how far into the
+        // call did this happen" isn't skewed by however long the retry ran.
+        msSinceJoin: (startedAt ?? Date.now()) - joinedAtRef.current,
+        participantCount,
+      });
+    },
+    [room]
+  );
 
   const markEndedByCutoff = React.useCallback(() => {
     endedByCutoffRef.current = true;
@@ -111,6 +130,7 @@ export function useReconnectionState(
       // measured duration collapses to the last retry rather than the whole outage.
       if (episodeStartedAtRef.current === null) {
         episodeStartedAtRef.current = Date.now();
+        episodeParticipantCountRef.current = roomSize(room);
       }
       setStatus('reconnecting');
     };

--- a/apps/web/partials/community-calls/live-room.tsx
+++ b/apps/web/partials/community-calls/live-room.tsx
@@ -41,6 +41,7 @@ import { ChatEntry, usePersistentChat } from '~/core/community-calls/use-persist
 import { useReconnectionState } from '~/core/community-calls/use-reconnection-state';
 import { useRecordingMetadataSync } from '~/core/community-calls/use-recording-metadata-sync';
 import { ExtendedReconnectPolicy } from '~/core/livekit/extended-reconnect-policy';
+import { setTelemetryUser } from '~/core/telemetry/logger';
 import { TrackedErrorBoundary } from '~/core/telemetry/tracked-error-boundary';
 
 import { Avatar } from '~/design-system/avatar';
@@ -201,6 +202,17 @@ function RoomBody({
   // agreed across the room rather than held locally — see `useCallExtension`.
   const { extensionMs, extend, canExtendFurther } = useCallExtension({ room, canExtend: isActiveEditor });
 
+  // Every Sentry issue on this app reported "Users: 0" — `setTelemetryUser` existed and was
+  // never called from anywhere, so nothing was ever attributed to a person. Without it the
+  // drop telemetry can count episodes but not people, and "11 drops" reads the same whether
+  // it is eleven users once or one user eleven times. Set from the room rather than at
+  // sign-in because that is where this audit needed it; the identity is the participant's
+  // own and stays correct after they leave, so it is not cleared on unmount.
+  const localIdentity = room.localParticipant.identity;
+  React.useEffect(() => {
+    if (localIdentity) setTelemetryUser({ id: localIdentity });
+  }, [localIdentity]);
+
   // Moderation's "stop screen share" only mutes the track server-side, which doesn't
   // stop the browser's own capture (its "you're sharing your screen" indicator stays
   // up) — the moderator's client also sends this data message so the sharer's own
@@ -234,8 +246,9 @@ function RoomBody({
       roomName,
       occurrenceStart,
       role: isViewer ? ('viewer' as const) : ('participant' as const),
+      participantIdentity: localIdentity,
     }),
-    [spaceId, callId, roomName, occurrenceStart, isViewer]
+    [spaceId, callId, roomName, occurrenceStart, isViewer, localIdentity]
   );
 
   // Distinguishes an intentional Leave (CLIENT_INITIATED) — navigate away directly —


### PR DESCRIPTION
Third PR from the community-calls audit. Independent of #2369 and #2370.

## The instrument answers its own question zero times out of 11

`disconnect-telemetry.ts` was written for GEO-2584 so we could tell "was that the server or their wifi" without asking the person what the dialog said. Every episode in production for the last 90 days:

```
outcome: recovered   reason: NOT_REPORTED   cause: unknown    ×11
```

The good news buried in that: **no `gave_up` episodes at all** — nobody has been permanently ejected. The bad news is that the attribution the module exists for has never once worked, and one call dropped 5 times in 90 minutes with no way to tell whether that was one person's wifi or a server event hitting five people.

## What was missing

**Participant identity.** The module's own doc comment says correlating several participants' episodes in the same room is "the strongest available evidence of a server-side cause, and exactly what we could not do before" — but without identity you cannot group episodes by person, so you cannot tell one flaky connection from many. It's a tag for the same reason `callId` is: that grouping is the query, and the cardinality is the number of people who attend calls — same order as `callId`, far below `roomName`.

**Room size when the episode opened.** Read at report time it's always 1, because LiveKit has torn the participant list down by then. Read at the start it gives the denominator for any claim that a drop was widespread.

## And the Sentry user has never been set

`setTelemetryUser` exists in `core/telemetry/logger.ts` and **is called from nowhere in the codebase**. That's why every issue in this project reports `Users: 0` — no event has ever been attributable to a person. "11 drops" reads identically whether that's eleven users once or one user eleven times.

Set from the room rather than at sign-in, because that's where this audit needed it. Not cleared on unmount: the identity is the participant's own and stays correct after they leave.

## A note on robustness

`roomSize` is deliberately defensive. It's read inside the disconnect handler, so a throw there would take the reconnection overlay down with it — an unknown room size is never worth that. The test fake was missing `remoteParticipants` entirely, which is how I found it.

## Verification

- 4 new tests: identity tagged; room size carried; size captured at episode open and not after teardown; size still reported for an immediate disconnect with no episode open.
- `vitest run core/community-calls partials/community-calls` — 93 passed.
- `tsc --noEmit` clean. Worth noting it caught a stale test fixture that **vitest did not** — the suite passed green while the types were wrong, so the type check is doing real work here.
- `eslint` clean.