### PR TITLE
fix(community-calls): only offer the call form to someone who can save it

### DIFF
--- a/apps/web/partials/community-calls/call-form.tsx
+++ b/apps/web/partials/community-calls/call-form.tsx
@@ -16,6 +16,7 @@ import { buildCreateCallOps, buildUpdateCallOps } from '~/core/community-calls/c
 import { CALL_SCHEMA } from '~/core/community-calls/constants';
 import { notifyScheduleChange } from '~/core/community-calls/notify-schedule-change';
 import { useCommunityCallIdentityToken } from '~/core/community-calls/use-identity-token';
+import { useAccessControl } from '~/core/hooks/use-access-control';
 import { usePublish } from '~/core/hooks/use-publish';
 import { useToast } from '~/core/hooks/use-toast';
 import { getRelationsByFromEntityId } from '~/core/io/queries';
@@ -93,6 +94,14 @@ export function CallForm(props: Props) {
   const [submitting, setSubmitting] = React.useState(false);
 
   const configured = Boolean(CALL_SCHEMA.COMMUNITY_CALL_TYPE && CALL_SCHEMA.MEETING_TIME_PROPERTY);
+
+  // Nothing gated this form before — not the page, not a layout, not the form. Anyone who
+  // could reach the URL got a fully editable form with a live Save button, and only found
+  // out they had no rights when the write reverted on chain: `InvalidFromSpace()`
+  // (`0x196f9913`), surfaced as "Something went wrong" over a wall of raw
+  // `zd_sponsorUserOperation` calldata. That is after the edit has already been published to
+  // IPFS, so the wasted round trip is real and the error is unreadable.
+  const { isEditor, isLoading: accessLoading } = useAccessControl(spaceId);
   const backHref = `/space/${spaceId}/community`;
 
   const buildSchedule = () => {
@@ -182,6 +191,26 @@ export function CallForm(props: Props) {
       onError: () => setSubmitting(false),
     });
   };
+
+  // Access resolves after hydration, so render nothing rather than flashing either the form
+  // or the refusal at someone who turns out to be the opposite.
+  if (accessLoading) return null;
+
+  if (!isEditor) {
+    return (
+      <div className="mx-auto flex max-w-[820px] flex-col gap-4 px-4 py-8">
+        <h1 className="text-mainPage">Only editors can schedule calls</h1>
+        <p className="text-metadata text-grey-04">
+          You need edit access to this space to {props.mode === 'edit' ? 'change this call' : 'schedule a call'}.
+        </p>
+        <div className="flex justify-start">
+          <Button variant="secondary" onClick={() => router.push(backHref)}>
+            Back to community
+          </Button>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="mx-auto flex max-w-[820px] flex-col gap-4 px-4 py-8">


### PR DESCRIPTION
Fourth PR from the community-calls audit. Independent of #2369, #2370 and #2373.

## The problem

Nothing gated this form — **not the page, not a layout, not the form itself**. No `useAccessControl` or `isEditor` anywhere in `edit/page.tsx`, `new/page.tsx` or `CallForm`, and no layout in that route group.

So anyone who could reach the URL got a fully editable form with a live Save button, filled it in, and only learned they had no rights when the write reverted on chain:

```
UserOperation reverted during simulation with reason: 0x196f9913
```

That selector is `InvalidFromSpace()`. What the user sees is "Something went wrong" above a wall of raw `zd_sponsorUserOperation` calldata.

Two things wrong with that. The edit has **already been published to IPFS** by the time it reverts, so the wasted round trip is real. And the message is unreadable to anyone who doesn't decode revert selectors for a living.

I found it by walking into it — trying to repair a stranded call in a space I'm not an editor of. That's exactly the shape a curator hits when they open someone else's call from a link.

## The fix

Gate on `useAccessControl`, the same check the community rail and the last-editor warning already use. Render nothing while access resolves, rather than flashing either the form or the refusal at someone who turns out to be the opposite.

Covers both the edit and new-call routes, since both mount this form.

The gate is client-side because the check is: it needs the viewer's personal space id, which the server component doesn't have. A server-side gate would be stronger, but this is not a security boundary — the chain is, and it already refused. This is about not walking someone into a dead end.

## Scope

Deliberately not translating `InvalidFromSpace()` into a friendly message. That dialog comes from the shared publish machinery, and mapping revert selectors there is a wider change than this audit should carry. Gating the form removes the main path to it.

## Verification

- `vitest run core/community-calls partials/community-calls` — 89 passed.
- `tsc --noEmit` and `eslint` clean on the touched file.
- Not covered by a test: `CallForm` has no test file and adding a harness for it (Privy, React Query, publish machinery) is disproportionate to a three-line guard. The behaviour is a straight branch on an existing, already-tested hook.