### PR TITLE
Revert the Request debate position gate on ClaimEndSlot (GEO-2826)

### DIFF
--- a/apps/web/core/claims/browse/claim-end-slot.tsx
+++ b/apps/web/core/claims/browse/claim-end-slot.tsx
@@ -12,7 +12,6 @@ import Link from 'next/link';
 import type { Debate } from '~/core/debates/api';
 import { debatePath } from '~/core/debates/debate-routes';
 
-import { type DebateRequestPosition, debateRequestGate } from '~/core/debates/request-gate';
 import { useClaimMatchup } from './use-claim-matchup';
 
 /**
@@ -44,22 +43,10 @@ export function ClaimEndSlot({
   activeDebate,
   enabled = true,
   variant = 'inline',
-  position,
   className,
 }: {
   claimId: string;
   spaceId: string;
-  /**
-   * The viewer's position on this claim, from both clocks, so the offer only appears once geo-chat
-   * will honour it (GEO-2808).
-   *
-   * geo-chat validates a request against its *own* copy of the position and rejects an early one
-   * with `claim_response_required`. Every host of this slot already runs `useClaimPositionControl`,
-   * which holds both readings — so this is required rather than optional: a host that could not
-   * answer would be offering a debate it has no way to know is valid, which is what the hub and the
-   * feed cards were doing.
-   */
-  position: DebateRequestPosition;
   /**
    * The live debate on this claim.
    *
@@ -100,16 +87,6 @@ export function ClaimEndSlot({
     enabled,
   });
 
-  // `match` is this surface's opponent half — somebody standing ready on the other side. The
-  // position half is the shared rule, so every surface waits on the same fact and names it the
-  // same way.
-  const gate = debateRequestGate({
-    chatPosition: position.chat,
-    localPosition: position.local,
-    opponentReady: match !== null,
-    indexingDelayed: position.indexingDelayed,
-  });
-
   // Sized to the row it sits in rather than to itself.
   //
   // It was the explore page's "Rank" CTA — 16px in a 28px pill — which is right for a standalone
@@ -141,7 +118,7 @@ export function ClaimEndSlot({
         <button
           type="button"
           onClick={request}
-          disabled={Boolean(blockedReason) || isRequesting || !gate.canRequest}
+          disabled={Boolean(blockedReason) || isRequesting}
           // Shown rather than left to a `title`: native tooltips never appear on touch and are
           // unreliable on a disabled button, which is exactly when the explanation matters.
           title={blockedReason}
@@ -157,35 +134,19 @@ export function ClaimEndSlot({
           {/* Both labels stacked in one grid cell, so the button is always as wide as the longer of
               them. "Requesting…" is the shorter, and a button that shrinks the moment you press it
               reads as something having gone wrong. The grid is on this span rather than the button
-              so it cannot fight the button's own `inline-flex`.
-              
-              Only while the offer is pressable. The pending label is longer than "Request debate",
-              so sizing against it would hold every idle button that much wider — and this slot sits
-              in a meta row built not to grow. A press cannot happen while pending, which is the
-              only transition the sizer exists to smooth. */}
-          {gate.pending ? (
-            <span>{gate.pendingLabel}</span>
-          ) : (
-            <span className="grid place-items-center">
-              <span className="invisible col-start-1 row-start-1" aria-hidden>
-                Request debate
-              </span>
-              <span className="col-start-1 row-start-1">{isRequesting ? 'Requesting…' : 'Request debate'}</span>
+              so it cannot fight the button's own `inline-flex`. */}
+          <span className="grid place-items-center">
+            <span className="invisible col-start-1 row-start-1" aria-hidden>
+              Request debate
             </span>
-          )}
+            <span className="col-start-1 row-start-1">{isRequesting ? 'Requesting…' : 'Request debate'}</span>
+          </span>
         </button>
         {/* A blocked reason is a standing condition the reader can see for themselves, so it is
             ordinary text. A failed request is an event that happens after they press, with nothing
             on screen to mark it — `role="alert"` is what makes it reach anyone not watching this
             corner. The Matches tab's old button announced it; losing that when the button moved
             would have been a silent regression. */}
-        {/* A disabled control nobody is focused on announces nothing, so the wait is a `status` as
-            well as a label. */}
-        {gate.pending && !isRequesting ? (
-          <span role="status" aria-live="polite" className="sr-only">
-            {gate.pendingLabel}
-          </span>
-        ) : null}
         {blockedReason ? (
           <span className={cx('text-footnote text-grey-04', variant === 'block' ? 'text-left' : 'text-right')}>
             {blockedReason}

--- a/apps/web/core/claims/browse/claim-page-view.test.tsx
+++ b/apps/web/core/claims/browse/claim-page-view.test.tsx
@@ -80,8 +80,6 @@ vi.mock('~/core/debates/matchmaking/matchmaking-claim-card', () => ({
     viewerPosition: null,
     respond: () => {},
     canRespond: false,
-    // Mirrors the hook: the request offer reads this to decide whether to make itself.
-    requestPosition: { chat: null, local: null, indexingDelayed: false },
     actionTitle: () => undefined,
     responseError: null,
   }),

--- a/apps/web/core/claims/browse/claim-page-view.tsx
+++ b/apps/web/core/claims/browse/claim-page-view.tsx
@@ -236,9 +236,6 @@ function ClaimPositionSection({
         activeDebate={row?.active_debate}
         variant="block"
         className="mt-2"
-        // The offer sits directly under the pills that set the position it depends on, so it has to
-        // wait for the same fact those pills are publishing (GEO-2808).
-        position={control.requestPosition}
       />
     </section>
   );

--- a/apps/web/core/debates/browse/debate-claims-panel.test.tsx
+++ b/apps/web/core/debates/browse/debate-claims-panel.test.tsx
@@ -93,8 +93,6 @@ vi.mock('~/core/debates/matchmaking/matchmaking-claim-card', () => ({
       actionTitle: () => (answersReady ? '' : 'Loading this claim’s responses…'),
       responseError: null,
       canRespond: answersReady,
-    // Mirrors the hook: the request offer reads this to decide whether to make itself.
-    requestPosition: { chat: null, local: null, indexingDelayed: false },
     };
   },
 }));

--- a/apps/web/core/debates/matchmaking/matchmaking-claim-card.test.tsx
+++ b/apps/web/core/debates/matchmaking/matchmaking-claim-card.test.tsx
@@ -244,52 +244,6 @@ describe('position avatar stack', () => {
     expect(within(disagree).queryByText(/^\+/)).toBeNull();
   });
 
-  /**
-   * GEO-2808. The offer used to appear the instant a match existed, with no regard for whether
-   * geo-chat held the viewer's position — so the request was pressable and geo-chat rejected it
-   * with `claim_response_required`. It now waits on the same fact the picker waits on and wears the
-   * same label.
-   */
-  describe('the request waits for geo-chat to hold the viewer position', () => {
-    const twoSides = () =>
-      withCounts([
-        { total_count: 1, available_now_count: 1, present_count: 1, participants: [participant('a')] },
-        { total_count: 1, available_now_count: 1, present_count: 1, participants: [participant('b')] },
-      ]);
-
-    it('names the wait while geo-chat has not caught up', () => {
-      mocks.match = { id: 'match-1' };
-      // An answer still reconciling is what the card draws its optimistic side from.
-      mocks.indexing = { status: 'reconciling', pending: { expectedResponse: 'positive' }, runId: 'run-1' };
-      renderCard(
-        <MatchmakingClaimCard claim={claim} positions={twoSides()} readiness={readiness({ viewer_response: null })} />
-      );
-
-      expect(screen.getByRole('button', { name: 'Publishing your position…' })).toBeDisabled();
-      expect(screen.queryByRole('button', { name: 'Request debate' })).not.toBeInTheDocument();
-    });
-
-    it('offers the debate once geo-chat holds the side on screen', () => {
-      mocks.match = { id: 'match-1' };
-      renderCard(<MatchmakingClaimCard claim={claim} positions={twoSides()} readiness={readiness()} />);
-
-      expect(screen.getByRole('button', { name: 'Request debate' })).toBeEnabled();
-    });
-
-    // A claim nobody has answered is not publishing anything. The hub's opponent half is a match,
-    // which does not require a position the way the picker's `opposing` does, so without this the
-    // card announced a wait nobody had started.
-    it('does not name a wait on a claim the viewer has not answered', () => {
-      mocks.match = { id: 'match-1' };
-      renderCard(
-        <MatchmakingClaimCard claim={claim} positions={twoSides()} readiness={readiness({ viewer_response: null })} />
-      );
-
-      expect(screen.queryByRole('button', { name: 'Publishing your position…' })).not.toBeInTheDocument();
-      expect(screen.getByRole('button', { name: 'Request debate' })).toBeDisabled();
-    });
-  });
-
   // The regression that caused the revert. Drawing the stack from `available_now_count` looked
   // right until you noticed it is viewer-relative: it excludes the viewer and anyone they have
   // already debated on this claim. So a claim you had actually argued showed an empty stack — to

--- a/apps/web/core/debates/matchmaking/matchmaking-claim-card.tsx
+++ b/apps/web/core/debates/matchmaking/matchmaking-claim-card.tsx
@@ -7,7 +7,6 @@ import { motion } from 'framer-motion';
 import Link from 'next/link';
 
 import { ClaimEndSlot } from '~/core/claims/browse/claim-end-slot';
-import type { DebateRequestPosition } from '~/core/debates/request-gate';
 import { useClaimResponseSummary } from '~/core/claims/browse/claim-response-summary';
 import { ClaimSummary, ControversialTag } from '~/core/claims/browse/claim-summary';
 import { useClaimMatchup, withMatchParticipants } from '~/core/claims/browse/use-claim-matchup';
@@ -466,16 +465,6 @@ export function useClaimPositionControl({
     actionTitle,
     responseError,
     /**
-     * Both clocks a request offer needs, composed here rather than at each `ClaimEndSlot`. Four
-     * surfaces render that control and every one was spelling this out identically — the same
-     * duplicated derivation that let the card and its own footer disagree (GEO-2808).
-     */
-    requestPosition: {
-      chat: readiness.viewer_response?.position ?? null,
-      local: viewerPosition,
-      indexingDelayed: responseIndexing.status === 'delayed',
-    } satisfies DebateRequestPosition,
-    /**
      * False only while the account genuinely cannot publish, never while one is in flight.
      *
      * Being signed out doesn't disable the pills where a sign-in prompt was supplied: a disabled
@@ -515,18 +504,11 @@ function RespondableControls({
   onRequireSignIn?: () => void;
   hideEndSlot?: boolean;
 }) {
-  const {
-    viewerPosition,
-    optimisticPositions,
-    respond,
-    actionTitle,
-    responseError,
-    canRespond,
-    requestPosition,
-  } = useClaimPositionControl({
-    claim,
-    positions,
-    readiness,
+  const { viewerPosition, optimisticPositions, respond, actionTitle, responseError, canRespond } =
+    useClaimPositionControl({
+      claim,
+      positions,
+      readiness,
       answersReady,
       responseBlockedReason,
       viewerIdentityPending,
@@ -565,12 +547,7 @@ function RespondableControls({
         isControversial={summary.isControversial}
         endSlot={
           hideEndSlot ? null : (
-            <ClaimEndSlot
-              claimId={claim.claim_entity_id}
-              spaceId={claim.space_id}
-              activeDebate={activeDebate}
-              position={requestPosition}
-            />
+            <ClaimEndSlot claimId={claim.claim_entity_id} spaceId={claim.space_id} activeDebate={activeDebate} />
           )
         }
       />
@@ -758,20 +735,7 @@ function UnresolvableControls({
              footer button that used to offer it is gone. Masking an action the server would accept
              is not the safe direction to be wrong in. */
           hideEndSlot ? null : (
-            <ClaimEndSlot
-              claimId={claim.claim_entity_id}
-              spaceId={claim.space_id}
-              activeDebate={activeDebate}
-              // This card draws no response control, so it has no optimistic side of its own and
-              // both readings are geo-chat's. That is not the self-comparison GEO-2808 removed —
-              // there the fallback was the *graph*, a different source from the one that validates
-              // the request. Here it is the validating source agreeing with itself, which is the
-              // honest answer to "does geo-chat hold a position for this viewer".
-              position={{
-                chat: readiness.viewer_response?.position ?? null,
-                local: readiness.viewer_response?.position ?? null,
-              }}
-            />
+            <ClaimEndSlot claimId={claim.claim_entity_id} spaceId={claim.space_id} activeDebate={activeDebate} />
           )
         }
       />

--- a/apps/web/core/debates/request-gate.ts
+++ b/apps/web/core/debates/request-gate.ts
@@ -15,21 +15,6 @@
  * both read `debate_claim_readiness`, which the in-flight response notification writes, so a
  * graph-backed position check there would hold a button the server would have accepted.
  */
-/**
- * The viewer's position on a claim, read from both clocks, as a request offer needs it.
- *
- * Derived once by `useClaimPositionControl`, which already holds both readings, and passed straight
- * to `ClaimEndSlot`. Every surface that offers a debate needs the same three values, and deriving
- * them per surface is how the two clocks drifted apart in the first place (GEO-2808).
- */
-export type DebateRequestPosition = {
-  /** geo-chat's copy. `undefined` when it has no row for this claim yet. */
-  chat: boolean | null | undefined;
-  /** What the viewer believes they hold — optimistic while a response is in flight. */
-  local: boolean | null;
-  indexingDelayed?: boolean;
-};
-
 export type DebateRequestGateInput = {
   /**
    * The position the request will be validated against, as the surface last heard it.

--- a/apps/web/core/debates/request-gate.ts
+++ b/apps/web/core/debates/request-gate.ts
@@ -14,6 +14,11 @@
  * The debates hub does not use this gate, deliberately. Its match data and `create_debate_request_as`
  * both read `debate_claim_readiness`, which the in-flight response notification writes, so a
  * graph-backed position check there would hold a button the server would have accepted.
+ *
+ * That was tried, in #2354, and reverted. Wiring this into `ClaimEndSlot` re-asked a question
+ * `match` had already answered, using a field that can disagree with it — so a viewer with a live
+ * match and no `viewer_response` got a rendered, permanently disabled "Request debate" with nothing
+ * saying why. The warning above and the one in `claim-end-slot.tsx` both predate that attempt.
  */
 export type DebateRequestGateInput = {
   /**
@@ -64,8 +69,8 @@ export function debateRequestGate({
   const positionSettled = held && chatPosition === localPosition;
   // Waiting means something is actually in flight. A viewer who has not answered at all is not
   // waiting for anything, and saying "Publishing your position…" at them names work nobody
-  // started — which is what this did on the hub, where the opponent half does not already
-  // require a position the way the picker's `opposing` does.
+  // started. The picker's `opposing` already requires a position, so this is unreachable from the
+  // one caller — it is guarded for any future caller whose opponent half does not.
   const pending = opponentReady && held && !positionSettled;
 
   return {

--- a/apps/web/partials/explore/claim-explore-feed-card.test.tsx
+++ b/apps/web/partials/explore/claim-explore-feed-card.test.tsx
@@ -91,8 +91,6 @@ vi.mock('~/core/debates/matchmaking/matchmaking-claim-card', () => ({
     respond: vi.fn(),
     actionTitle: () => (answersReady ? '' : 'Loading this claim’s responses…'),
     responseError: null,
-    // Mirrors the hook: the request offer reads this to decide whether to make itself.
-    requestPosition: { chat: null, local: null, indexingDelayed: false },
     canRespond: answersReady,
   }),
 }));

--- a/apps/web/partials/explore/claim-explore-feed-card.tsx
+++ b/apps/web/partials/explore/claim-explore-feed-card.tsx
@@ -184,7 +184,6 @@ export function ClaimExploreFeedCard({
               activeDebate={row?.active_debate}
               enabled={nearViewport}
               className="ml-auto"
-              position={control.requestPosition}
             />
           }
           className="col-start-1 row-start-1 mb-3 claim-card-narrow:mb-0"


### PR DESCRIPTION
Continues @jwalkingjew's #2371, which was closed unmerged and handed off. Both commits keep their original authorship — this is their diff rebased onto current master, not a rewrite. Picked up as the first step of GEO-2826.

## The bug is live in production

Remove your position, refresh, and the hub shows a **rendered but permanently disabled "Request debate"** with nothing saying why.

`ClaimEndSlot`'s button only renders when `match` exists, and `match` is derived from the same `debate_claim_readiness` rows `create_debate_request_as` reads — so viability is already settled before the button appears. #2354 then *additionally* required `readiness.viewer_response` to hold a position. When those two disagree you get a live match, an empty `viewer_response`, and a disabled button whose request would have succeeded. Refreshing can't help, because it isn't staleness.

Very likely GEO-2822, and plausibly GEO-2824.

## Master already said not to do this, twice

Both warnings are in files #2354 edited, and both predate it:

> `claim-end-slot.tsx` (#2353, one commit earlier) — A match is derived from the same `debate_claim_readiness` rows `create_debate_request_as` reads, **so no additional position check belongs here**.

> `request-gate.ts` — The debates hub does not use this gate, **deliberately**.

`claim-end-slot.tsx` currently carries the warning at line 132 and the check at line 106 that contradicts it. The follow-up commit records that the attempt was made and reverted, so the next person doesn't rediscover it in a browser.

## What is kept

`debateRequestGate` stays, with its call sites in `rematch-page-client.tsx`. The gate is genuinely earned on the rematch picker and only there: the picker's opponent half is `opposing`, computed client-side from two positions with no server guarantee. That's what #2352 fixed and it is untouched.

## Not "making it optimistic"

Worth stating, since the shorthand is going around: removing this gate does not make the button trust the client. `match` is still geo-chat's own answer, derived from the very rows the request endpoint reads. The gate was redundant, not protective.

## Verification

- `tsc --noEmit`: **6 errors on this branch, 6 on master** — exact parity, all pre-existing (`sort-open-proposals.test.ts`, `use-entity-vote.ts`, `use-privy-sign-in.test.tsx`). Counted both sides rather than eyeballed.
- Changed areas — `core/claims`, `core/debates`, `partials/explore`: **106 files, 1347 tests, all passing.**
- No dangling references to the removed API. The one `position={false}` hit is `PositionButton`'s own boolean side.
- Full suite: 4363 of 4365 passing, 2 failures in a single file **outside** the changed areas. My captured output was truncated before I could name it, so a clean re-run is in flight and I'll post the filename here rather than wave it through. Every consumer of the removed prop lives in the areas that are green.

## Known and accepted

These four surfaces go back to occasionally offering a request the server refuses — the pre-#2354 behaviour, with the refusal rendered rather than swallowed. Preston has accepted that as the interim state; GEO-2807 covers closing it properly, and GEO-2826 continues with moving the rematch picker off `DebateClaimKgValidator`.