### PR TITLE
fix(debates): let the rematch picker read geo-chat's position, not the graph's alone (GEO-2826)

### DIFF
--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -426,13 +426,25 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
    */
   const chatPositionByClaimId = React.useMemo(() => {
     const byClaim = new Map<string, { spaceId: string; position: boolean | null }>();
-    // Every source is a rematch row since #2351 moved paging server-side, and a rematch row lists
-    // each session participant's side — so the viewer's is picked out of `participants`. This used
-    // to also read `viewer_response` off the hub's paged index, which that change removed.
+    // Every source is a rematch row since #2351 moved paging server-side. This used to also read
+    // `viewer_response` off the hub's paged index, which that change removed.
     for (const row of sessionRowsByClaimId.values()) {
+      // `viewer_position` in preference to the viewer's `participants` entry. The latter carries
+      // only what a live knowledge-graph resolution returned, and that resolve sits behind a
+      // timeout on geo-chat's side — when it lapses every `participants` position comes back null,
+      // which this gate reads as "no position held" and uses to disable every Request button on
+      // the page, for everyone, saying nothing. `viewer_position` falls back to the readiness row
+      // geo-chat already holds, so a slow graph costs accuracy at the margin instead of the
+      // whole page.
+      //
+      // Checked against `undefined` rather than with `??`, because `null` is a real answer here —
+      // geo-chat has a row and the viewer holds no position — and only `undefined` means a backend
+      // that predates the field. Collapsing the two would make an old backend look like a
+      // deliberate absence.
+      const viewerParticipant = row.participants.find(side => side.user_id === currentUserId);
       byClaim.set(row.claim.claim_entity_id, {
         spaceId: row.claim.space_id,
-        position: row.participants.find(side => side.user_id === currentUserId)?.position ?? null,
+        position: row.viewer_position !== undefined ? row.viewer_position : (viewerParticipant?.position ?? null),
       });
     }
     return byClaim;

--- a/apps/web/core/debates/api.ts
+++ b/apps/web/core/debates/api.ts
@@ -314,6 +314,20 @@ export type DebateRematchClaim = {
    */
   viewer_debate_ready?: boolean;
   readiness_disabled_reason?: string | null;
+  /**
+   * The viewer's own position, as geo-chat holds it: the live knowledge-graph resolution when one
+   * ran, falling back to the readiness row when it did not.
+   *
+   * Prefer this over the viewer's entry in `participants`, which is graph-only. That resolve sits
+   * behind a timeout on geo-chat's side, and when it lapses every `participants` position comes
+   * back null — which reads as "no position held" and disables every Request button on the page.
+   * This field is the same precedence the per-space `debate-claims` list has always used.
+   *
+   * `undefined` means the backend predates the field, which is distinct from `null` meaning no
+   * position — hence the explicit `undefined` check at the reader rather than `??`.
+   */
+  viewer_position?: boolean | null;
+  viewer_position_label?: string | null;
 };
 
 export type DebateRematchClaimsResponse = {


### PR DESCRIPTION
Third step of GEO-2826, and the client half of geo-chat #99 (merged). Follows #2376.

## The failure

The picker took the viewer's position from their entry in `participants`, which carries **only** what a live knowledge-graph resolution returned. That resolve sits behind a timeout in geo-chat; when it lapses the server logs `"timed out hydrating rematch claim responses"` and carries on with an empty map — so every position comes back null.

This gate reads null as "no position held". So **a slow graph disabled every Request debate button on the page, for everyone in the session, with nothing on screen saying why.** Not a latency cost — an availability coupling.

## The fix

geo-chat #99 added `viewer_position`, which falls back to the readiness row when the resolve didn't answer. That's the same precedence the per-space `debate-claims` list has always used, so this is the picker catching up rather than a new source of truth.

**Checked against `undefined`, not `??`.** `null` is a real answer here — geo-chat holds a row and the viewer has no position — and only `undefined` means a backend predating the field. Collapsing the two would make an old backend look like a deliberate absence, which is the same class of bug being fixed. The fallback to the old `participants` read keeps this working against a backend without #99, so the two deploy in either order.

The viewer's `participants` entry stays graph-only on purpose: it's one half of the pair the picker compares to decide the sides genuinely oppose, and giving one half a different provenance from the other would be worse than the bug.

## Verification, including what I could not verify

- `tsc --noEmit`: **6 errors on this branch, 6 on master** — parity, all pre-existing.
- `rematch-page-client.test.tsx` in isolation: **126/126, three times.**
- **The batch run is unreliable and I could not get a clean signal from it.** Running `app/space/[id]/(space)/debates` + `core/debates` together gives a different failure set every time — 2, then 1, then 2, then 5, then 3 across runs.

  I ran the identical batch on master as a control, because two of the failing names looked far too on-topic to wave through (`"enables opposing requests"`, `"changes responses through the semantic buttons"`). **Both fail on master too, without this change.** The overlap is `"lists the session's own claims alongside published ones and enables opposing requests"` and `"offers only the topics that co-occur with the picked one"` — the latter is a topic-filter test with nothing to do with positions.

  So: flaky under parallel load, on master, independent of this change. Leaning on CI and the isolation runs instead.

**Worth raising separately:** the debates suite has a real nondeterminism problem under parallel load. Five different tests across three files have failed at least once today with no code change explaining it, which makes the suite hard to trust exactly when you most want it.