### PR TITLE
Scope dropdown property eligibility to the table's spaces

### DIFF
--- a/apps/web/core/blocks/data/use-dropdown-query-overlay.ts
+++ b/apps/web/core/blocks/data/use-dropdown-query-overlay.ts
@@ -1,9 +1,11 @@
 'use client';
 
 import { Position, SystemIds } from '@geoprotocol/geo-sdk/lite';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 
 import * as React from 'react';
 
+import { getSchemaFromTypeIds } from '~/core/database/entities';
 import { ID } from '~/core/id';
 import { useEditorStoreLite } from '~/core/state/editor/use-editor';
 import { useQueryEntity } from '~/core/sync/use-store';
@@ -95,12 +97,52 @@ export function useDropdownQueryOverlay({
   // the eye menu, the dropdown picker, and the overlay's gate all see it.
   const collectionMemberProperties = useCollectionMemberSchema(collectionItemIds);
 
+  // Dropdown ELIGIBILITY is scoped to the table's own spaces — a deliberate,
+  // dropdown-only divergence from the graph-wide schema union (GEO-2202)
+  // that feeds the column/sort/filter menus. The union lets ANY space graft
+  // a same-named twin property onto a shared type and have it surface in
+  // every picker in the graph; a table's dropdowns should only offer
+  // properties the table's selected spaces (or its own space) actually
+  // declare. GEO tables scope to the whole graph by definition and
+  // COLLECTION schemas already derive from the members, so only SPACES
+  // sources are restricted.
+  const typesInFilter = React.useMemo(
+    () => baseFilterState.filter(f => ID.equals(f.columnId, SystemIds.TYPES_PROPERTY)).map(f => f.value),
+    [baseFilterState]
+  );
+  const tableSpaceIds = React.useMemo(() => {
+    const ids = baseFilterState.filter(f => ID.equals(f.columnId, SystemIds.SPACE_FILTER)).map(f => f.value);
+    if (spaceId && !ids.some(id => ID.equals(id, spaceId))) ids.push(spaceId);
+    return ids;
+  }, [baseFilterState, spaceId]);
+  const restrictToTableSpaces = source.type === 'SPACES';
+  const { data: tableSpaceSchema } = useQuery({
+    enabled: restrictToTableSpaces && typesInFilter.length > 0 && tableSpaceIds.length > 0,
+    queryKey: ['data-block', 'dropdown-eligible-schema', [...typesInFilter].sort(), [...tableSpaceIds].sort()],
+    placeholderData: keepPreviousData,
+    queryFn: async () =>
+      // The type entities' schema relations read ONLY from the table's
+      // spaces: the spaceId hint scopes the native fetch and the second
+      // argument adds each selected space; includeAllTypeSpaces stays off.
+      getSchemaFromTypeIds(
+        typesInFilter.map(id => ({ id, spaceId: tableSpaceIds[0] })),
+        tableSpaceIds,
+        { includeAllTypeSpaces: false }
+      ),
+  });
+  /** Relation property ids declared by the table's spaces; null = unrestricted (GEO/COLLECTION, or loading). */
+  const dropdownEligibleIds = React.useMemo(() => {
+    if (!restrictToTableSpaces || !tableSpaceSchema) return null;
+    return tableSpaceSchema.filter(property => property.dataType === 'RELATION').map(property => property.id);
+  }, [restrictToTableSpaces, tableSpaceSchema]);
+
   const appliedColumnIds = React.useMemo(() => {
     const pillProperties = [...filterableProperties, ...(extraPillProperties ?? []), ...collectionMemberProperties];
     return configs
       .map(config => config.propertyId)
-      .filter(id => pillProperties.some(p => ID.equals(p.id, id) && p.dataType === 'RELATION'));
-  }, [configs, filterableProperties, extraPillProperties, collectionMemberProperties]);
+      .filter(id => pillProperties.some(p => ID.equals(p.id, id) && p.dataType === 'RELATION'))
+      .filter(id => dropdownEligibleIds === null || dropdownEligibleIds.some(e => ID.equals(e, id)));
+  }, [configs, filterableProperties, extraPillProperties, collectionMemberProperties, dropdownEligibleIds]);
 
   const isActive = !isEditing && supportsDropdowns && hydrated && appliedColumnIds.length > 0;
 
@@ -127,6 +169,7 @@ export function useDropdownQueryOverlay({
       collectionItemIds,
       populationReady,
       collectionMemberProperties,
+      dropdownEligibleIds,
     },
   };
 }

--- a/apps/web/partials/blocks/table/table-block-dropdowns-config.tsx
+++ b/apps/web/partials/blocks/table/table-block-dropdowns-config.tsx
@@ -19,6 +19,12 @@ type TableBlockDropdownsConfigProps = {
   configs: BlockDropdownConfig[];
   properties: Property[];
   toggleDropdownProperty: (property: { id: string; name: string | null }) => void;
+  /**
+   * Relation property ids the table's spaces declare (null = unrestricted).
+   * Filters the PICK list only — already-configured chips stay visible so a
+   * config that became ineligible can still be removed.
+   */
+  eligiblePropertyIds?: string[] | null;
 };
 
 /**
@@ -32,6 +38,7 @@ export function TableBlockDropdownsConfigTrigger({
   configs,
   properties,
   toggleDropdownProperty,
+  eligiblePropertyIds,
 }: TableBlockDropdownsConfigProps) {
   const [open, setOpen] = React.useState(false);
   const [search, setSearch] = React.useState('');
@@ -44,9 +51,10 @@ export function TableBlockDropdownsConfigTrigger({
     () =>
       properties
         .filter(p => p.dataType === 'RELATION' && !ID.equals(p.id, SystemIds.NAME_PROPERTY))
+        .filter(p => eligiblePropertyIds == null || eligiblePropertyIds.some(e => ID.equals(e, p.id)))
         .filter((p, index, all) => all.findIndex(other => ID.equals(other.id, p.id)) === index)
         .sort((a, b) => (a.name ?? a.id).localeCompare(b.name ?? b.id)),
-    [properties]
+    [properties, eligiblePropertyIds]
   );
 
   const query = search.trim().toLowerCase();

--- a/apps/web/partials/blocks/table/table-block.tsx
+++ b/apps/web/partials/blocks/table/table-block.tsx
@@ -1210,6 +1210,7 @@ const ConfiguredTableBlock = ({
                           supportsDropdowns ? (
                             <TableBlockDropdownsConfigTrigger
                               configs={browseDropdowns.configs}
+                              eligiblePropertyIds={browseDropdowns.dropdownEligibleIds}
                               properties={mergedBlockProperties}
                               toggleDropdownProperty={browseDropdowns.toggleDropdownProperty}
                             />

--- a/apps/web/partials/power-tools/power-tools-screen.tsx
+++ b/apps/web/partials/power-tools/power-tools-screen.tsx
@@ -1044,6 +1044,7 @@ export function PowerToolsScreen() {
               isEditing && supportsDropdowns ? (
                 <TableBlockDropdownsConfigTrigger
                   configs={browseDropdowns.configs}
+                  eligiblePropertyIds={browseDropdowns.dropdownEligibleIds}
                   properties={dropdownUiProperties}
                   toggleDropdownProperty={browseDropdowns.toggleDropdownProperty}
                 />


### PR DESCRIPTION
Follow-up to #2213. The "+ Dropdown" picker inherited the graph-wide schema union (GEO-2202), so any space could graft a same-named twin property onto a shared type and surface it in every table's picker — users saw "Topics" listed twice with no way to tell the canonical apart from a stray space's duplicate.

## What changed
- **Dropdown eligibility is now scoped to the table's spaces** (selected spaces + the block's own space): a second, space-restricted schema read using the existing `getSchemaFromTypeIds` machinery with `includeAllTypeSpaces` off — zero changes to shared code.
- **Dropdown-only, SPACES-source-only.** The column/sort/filter menus keep the GEO-2202 union untouched; GEO tables scope to the whole graph by definition; COLLECTION schemas already derive from the members.
- The pick list and the overlay's applied set share the same eligibility (a stored config outside it is inert, per the pills invariant); already-configured chips stay visible so a stale config remains removable.

## Behavior to be aware of
A table whose selected spaces declare **no** relation properties for its row types now gets an empty "+ Dropdown" pick list — by design, since nothing those spaces declare can be offered. If product ever wants the type's home-ontology properties always included, it's a one-line widening of the space list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015a2qTB8H4TuZtVBYABrpMo