### PR TITLE
fix(debates): grace a hidden tab before reporting it offline (GEO-2836)

### DIFF
--- a/apps/web/core/debates/debate-attention.test.ts
+++ b/apps/web/core/debates/debate-attention.test.ts
@@ -157,20 +157,59 @@ describe('debate presence', () => {
     expect(store.getSnapshot()).toBe(true);
   });
 
-  it('drops when the tab is hidden and returns when it is shown again', () => {
+  // GEO-2836. Hiding the tab starts a countdown rather than reporting a departure, because most
+  // hides are not departures — the viewer looks something up and comes back.
+  it('holds presence through a brief hide and drops once the grace expires', () => {
     subscribe();
     expect(store.getSnapshot()).toBe(true);
 
     visibilityState = 'hidden';
     document.dispatchEvent(new Event('visibilitychange'));
+    vi.advanceTimersByTime(59_000);
+    expect(store.getSnapshot()).toBe(true);
+
+    vi.advanceTimersByTime(1_000);
     expect(store.getSnapshot()).toBe(false);
+  });
+
+  it('cancels the grace when the tab comes back, and starts a fresh one on the next hide', () => {
+    subscribe();
+
+    visibilityState = 'hidden';
+    document.dispatchEvent(new Event('visibilitychange'));
+    vi.advanceTimersByTime(30_000);
 
     visibilityState = 'visible';
     document.dispatchEvent(new Event('visibilitychange'));
+    vi.advanceTimersByTime(60_000);
     expect(store.getSnapshot()).toBe(true);
+
+    visibilityState = 'hidden';
+    document.dispatchEvent(new Event('visibilitychange'));
+    vi.advanceTimersByTime(59_000);
+    expect(store.getSnapshot()).toBe(true);
+
+    vi.advanceTimersByTime(1_000);
+    expect(store.getSnapshot()).toBe(false);
   });
 
-  it('drops on pagehide and reconciles from the back-forward cache', () => {
+  // A tab that wakes for a moment every so often — a throttled timer, a background render — must
+  // still expire. Restarting the deadline on each `visibilitychange` would let it live forever.
+  it('does not extend the deadline for repeated hidden visibilitychange events', () => {
+    subscribe();
+
+    visibilityState = 'hidden';
+    document.dispatchEvent(new Event('visibilitychange'));
+    vi.advanceTimersByTime(30_000);
+    document.dispatchEvent(new Event('visibilitychange'));
+    vi.advanceTimersByTime(30_000);
+
+    expect(store.getSnapshot()).toBe(false);
+  });
+
+  // The one departure we can be sure of, so it skips the grace entirely: nobody should be offered
+  // a debate by someone who has already closed the tab.
+  it('drops on pagehide without waiting for the grace, and reconciles from the back-forward cache', () => {
     subscribe();
 
     window.dispatchEvent(new Event('pagehide'));
@@ -178,6 +217,16 @@ describe('debate presence', () => {
 
     window.dispatchEvent(new Event('pageshow'));
     expect(store.getSnapshot()).toBe(true);
+  });
+
+  it('drops on pagehide while a hide grace is already running', () => {
+    subscribe();
+
+    visibilityState = 'hidden';
+    document.dispatchEvent(new Event('visibilitychange'));
+    window.dispatchEvent(new Event('pagehide'));
+
+    expect(store.getSnapshot()).toBe(false);
   });
 
   it('reconciles when listeners return after a gap', () => {

--- a/apps/web/core/debates/debate-attention.ts
+++ b/apps/web/core/debates/debate-attention.ts
@@ -97,6 +97,8 @@ export function createDebateAttentionStore(
   };
 }
 
+const DEFAULT_HIDE_GRACE_MS = 60_000;
+
 /**
  * Presence, unlike attention, asks only whether this tab is *open and on screen* — not whether it
  * is the frontmost window.
@@ -107,9 +109,24 @@ export function createDebateAttentionStore(
  * requests from an offline requester are filtered out). Keying either on focus meant a request
  * disappeared the moment its requester clicked into another window, well inside its 25-minute
  * lifetime — and, with several browsers open on one machine, only ever one user could be online.
+ *
+ * Hiding the tab is graced rather than acted on at once (GEO-2836). Visibility is a much sharper
+ * signal than the thing it stands in for: checking a calendar in another tab for ten seconds is
+ * not leaving, but it used to report as leaving, and the report was immediate because the gateway
+ * flushes a heartbeat on every presence transition. Someone who is about to come back should not
+ * vanish from other people's matchmaking lists in the meantime.
+ *
+ * Closing the tab is *not* graced. `pagehide` drops presence at once, so the case a grace would
+ * genuinely get wrong — offering a debate to someone who has already gone — keeps its explicit
+ * signal, and the grace only ever covers a tab that is still there.
  */
-export function createDebatePresenceStore(windowRef: Window, documentRef: Document): DebateAttentionStore {
+export function createDebatePresenceStore(
+  windowRef: Window,
+  documentRef: Document,
+  hideGraceMs = DEFAULT_HIDE_GRACE_MS
+): DebateAttentionStore {
   let visible = documentRef.visibilityState === 'visible';
+  let hideTimer: ReturnType<typeof setTimeout> | null = null;
   const listeners = new Set<() => void>();
 
   const setVisible = (nextVisible: boolean) => {
@@ -118,10 +135,34 @@ export function createDebatePresenceStore(windowRef: Window, documentRef: Docume
     for (const listener of listeners) listener();
   };
 
-  const reconcile = () => setVisible(documentRef.visibilityState === 'visible');
+  const clearHideTimer = () => {
+    if (!hideTimer) return;
+    clearTimeout(hideTimer);
+    hideTimer = null;
+  };
+
+  const reconcile = () => {
+    if (documentRef.visibilityState === 'visible') {
+      clearHideTimer();
+      setVisible(true);
+      return;
+    }
+    // Already counting down, or already gone: either way the deadline stands as it is. Restarting
+    // it on each `visibilitychange` would let a tab that keeps waking briefly never expire.
+    if (hideTimer || !visible) return;
+    hideTimer = setTimeout(() => {
+      hideTimer = null;
+      if (documentRef.visibilityState !== 'visible') setVisible(false);
+    }, hideGraceMs);
+  };
+
   // `pagehide` covers the back-forward cache, where `visibilitychange` alone can leave a frozen
-  // page reporting itself as present.
-  const hide = () => setVisible(false);
+  // page reporting itself as present. It is also the one departure we can be sure of, so unlike a
+  // plain hide it takes effect immediately.
+  const hide = () => {
+    clearHideTimer();
+    setVisible(false);
+  };
 
   const attach = () => {
     documentRef.addEventListener('visibilitychange', reconcile);
@@ -130,6 +171,7 @@ export function createDebatePresenceStore(windowRef: Window, documentRef: Docume
   };
 
   const detach = () => {
+    clearHideTimer();
     documentRef.removeEventListener('visibilitychange', reconcile);
     windowRef.removeEventListener('pagehide', hide);
     windowRef.removeEventListener('pageshow', reconcile);
@@ -141,7 +183,10 @@ export function createDebatePresenceStore(windowRef: Window, documentRef: Docume
       listeners.add(listener);
       if (listeners.size === 1) {
         attach();
-        reconcile();
+        // A store nobody was listening to ran no timer, so the grace does not apply across the
+        // gap: settle on what the document says now.
+        clearHideTimer();
+        setVisible(documentRef.visibilityState === 'visible');
       }
       return () => {
         listeners.delete(listener);
@@ -178,7 +223,7 @@ export function useDebateAttention() {
   return React.useSyncExternalStore(store.subscribe, store.getSnapshot, getServerSnapshot);
 }
 
-/** Is this tab on screen at all? Drives the gateway's `debate_presence`. */
+/** Is this tab on screen, or recently so? Drives the gateway's `debate_presence`. */
 export function useDebatePresence() {
   const store = getBrowserPresenceStore();
   return React.useSyncExternalStore(store.subscribe, store.getSnapshot, getServerSnapshot);


### PR DESCRIPTION
Closes GEO-2836.

### The ticket's premise doesn't hold, but the symptom is real

The ticket asks to loosen an "is online" activity window from 3 seconds to 1 minute. There is no 3-second window in the `is_online` path:

- **Server-side freshness is already 90 seconds** — `last_seen_at >= now() - interval '90 seconds'`, nine call sites in geo-chat's `db_debates.rs`. The gateway heartbeat is 30s. Neither was ever 3.
- The only 3s nearby is `DEFAULT_BLUR_GRACE_MS` in the **attention** store, and attention gates polling cadence, not presence. `debate_presence` comes from `useDebatePresence()`.

So raising a threshold would have fixed nothing. The actual cause of the symptom is the opposite problem: presence had **no grace at all**.

`useDebatePresence()` was keyed directly on `document.visibilityState`, so it flipped the instant the tab went to the background — and `DebateGateway` flushes a heartbeat on every presence transition, so the "offline" report went out immediately too. The server's 90-second freshness window never got a chance to help, because presence arrives as an explicit boolean rather than as a timeout.

The user-visible cost: checking a calendar in another tab for ten seconds read as leaving. The viewer dropped out of `/matchmaking/people` and their pending requests dropped out of every recipient's inbox, well inside the 25-minute lifetime those requests are meant to have.

### The change

Hiding the tab now starts a 60-second countdown instead of reporting a departure. Coming back cancels it. Repeated `visibilitychange` events while hidden do **not** restart it, so a tab that keeps waking briefly — a throttled timer, a background render — still expires on the original deadline rather than living forever.

`pagehide` is untouched and still drops presence at once. That is the one departure we can be sure of, so the case a grace would genuinely get wrong — offering a debate to someone who has already closed the tab — keeps its explicit signal, and the grace only ever covers a tab that is still open. This is the "explicit disconnect signal on tab close" the ticket asks for; it was already there.

### One consequence worth a look

Presence is also the `refetchInterval` switch for `useDebateActivity` and `useDebateRematch`, so a hidden tab now keeps polling for up to a minute. I think that is correct rather than incidental — a tab we are still advertising as reachable should still be collecting what it is reachable for — but it is a background-cost change and worth agreeing on.

### Testing

`vitest run core/debates/debate-attention.test.ts` — 16/16 pass. New coverage: the grace holds and then expires, a return cancels it and the next hide gets a fresh one, repeated hidden `visibilitychange` events don't extend the deadline, and `pagehide` drops immediately both from visible and from mid-grace.
