### PR TITLE
fix(explore,debates): apply the space filter default on account creation (GEO-2834)

### DIFF
--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
@@ -136,6 +136,7 @@ const mocks = vi.hoisted(() => ({
   currentUserId: 'user-local' as string | null,
   spaceAllowlist: null as Set<string> | null,
   memberSpaceIds: null as Set<string> | null,
+  isSettlingMemberships: false,
   allowlistLoading: false,
   spaceTypes: {} as Record<string, 'DAO' | 'PERSONAL'>,
   publishableSpaceIds: null as Set<string> | null,
@@ -620,6 +621,7 @@ vi.mock('~/core/debates/use-claim-space-allowlist', () => ({
     // about the member default set it explicitly.
     memberSpaceIds: mocks.memberSpaceIds,
     isLoading: mocks.allowlistLoading,
+    isSettlingMemberships: mocks.isSettlingMemberships,
   }),
 }));
 
@@ -734,6 +736,7 @@ beforeEach(() => {
   mocks.responseIndexingStatus = null;
   mocks.spaceAllowlist = null;
   mocks.memberSpaceIds = null;
+  mocks.isSettlingMemberships = false;
   mocks.allowlistLoading = false;
   mocks.spaceTypes = {};
   mocks.publishableSpaceIds = null;
@@ -2056,6 +2059,29 @@ describe('DebateRematchPageClient', () => {
 
     // The default is still there to spend, and spends it on the space that survived.
     await waitFor(() => expect(screen.getByRole('button', { name: /Crypto/ })).toBeInTheDocument());
+    expect(screen.queryByRole('button', { name: /Any space/ })).toBeNull();
+  });
+
+  // GEO-2834. Same rule as the publishable gate above, applied to the *viewer's* side of the match:
+  // sign-up sends one membership proposal per picked space and they land seconds apart, so the
+  // first non-empty answer is a fraction of what the reader chose — and the seed fires once.
+  it('waits for the rest of their memberships before taking its one default', async () => {
+    // Only the first proposal has been indexed so far.
+    mocks.memberSpaceIds = new Set([SPACE_1.replace(/-/g, '')]);
+    mocks.isSettlingMemberships = true;
+    const view = render(<DebateRematchPageClient sessionId="rematch-1" />);
+    await showAllClaims();
+
+    // Unspent, rather than spent on the one space that happens to have landed.
+    await waitFor(() => expect(screen.getByRole('button', { name: /Any space/ })).toBeInTheDocument());
+
+    // The rest of what they picked lands.
+    mocks.memberSpaceIds = new Set([SPACE_1.replace(/-/g, ''), SPACE_2.replace(/-/g, '')]);
+    mocks.isSettlingMemberships = false;
+    view.rerender(<DebateRematchPageClient sessionId="rematch-1" />);
+
+    // Seeded with both of theirs, which a seed taken against the partial answer would have missed.
+    await waitFor(() => expect(screen.getByRole('button', { name: /2 spaces/ })).toBeInTheDocument());
     expect(screen.queryByRole('button', { name: /Any space/ })).toBeNull();
   });
 

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -231,7 +231,12 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   // whether the source is worth showing. Applying it there emptied both tabs in the ordinary case:
   // a debater's claims live in their personal space, which nobody else is a member of, so the
   // opponent's positions and a curator's page were dropped wholesale on the other side.
-  const { allowlist: spaceAllowlist, memberSpaceIds, isLoading: allowlistLoading } = useClaimSpaceAllowlist();
+  const {
+    allowlist: spaceAllowlist,
+    memberSpaceIds,
+    isLoading: allowlistLoading,
+    isSettlingMemberships,
+  } = useClaimSpaceAllowlist();
 
   // While it is still resolving there is no telling an allowed space from one the viewer has
   // nothing to do with. Every list waits for it rather than showing the unfiltered set and
@@ -969,11 +974,16 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
     // space offered provisionally and rejected a moment later takes the default with it.
     // `sourceDebateQuery` for the same reason from the other end: the source debate's own claim is
     // one of the exclusions, so until it lands a row-derived menu can still be counting its space.
+    //
+    // `isSettlingMemberships` is the same rule applied to the *viewer's* side of the match rather
+    // than the menu's: sign-up sends one membership proposal per picked space and they land
+    // seconds apart, so the first non-empty answer is a fraction of what they chose (GEO-2834).
     pending:
       tabIsLoading ||
       publishabilityPending ||
       publishableSpacesLoading ||
       sourceDebateQuery.isLoading ||
+      isSettlingMemberships ||
       (graphFiltered && !taggedSpaceFacet.settled),
   });
 

--- a/apps/web/core/debates/claim-space-allowlist.ts
+++ b/apps/web/core/debates/claim-space-allowlist.ts
@@ -1,5 +1,6 @@
 import type { BrowseSidebarData, BrowseSpaceRow } from '~/core/browse/fetch-browse-sidebar-data';
 import {
+  REQUEST_BRIDGE_TTL_MS,
   type RequestedMembershipSpace,
   activeRequestedSpacesForOwner,
   requestedMembershipIdSet,
@@ -105,6 +106,42 @@ export function browseSidebarMemberSpaceIds(
  * the filter stays open on nothing.
  */
 export const REQUESTED_MEMBERSHIP_SETTLE_MS = 90_000;
+
+/**
+ * When this hook's answer next changes on its own, as a timestamp — or null if nothing is pending.
+ *
+ * Both deadlines here are read off a clock sampled during render, so neither can retire anything by
+ * itself: once the membership poll stops there may be no further render, and an entry that never
+ * landed would sit in `memberSpaceIds` for the rest of the visit while `isSettlingMemberships` held
+ * the filter default unspent. Callers schedule a render against this so elapsed time is something
+ * the hook observes rather than something it happens to notice.
+ *
+ * The boundaries are {@link REQUESTED_MEMBERSHIP_SETTLE_MS}, after which a request stops being
+ * waited on, and {@link REQUEST_BRIDGE_TTL_MS}, after which it stops counting as a membership at
+ * all. Only future ones count: an entry already past a boundary needs no wake-up for it.
+ */
+export function nextRequestedMembershipDeadline({
+  requestedSpaces,
+  personalSpaceId,
+  walletAddress,
+  now,
+}: {
+  requestedSpaces: RequestedMembershipSpace[];
+  personalSpaceId: string | null | undefined;
+  walletAddress: string | null | undefined;
+  now: number;
+}): number | null {
+  let next: number | null = null;
+  for (const space of activeRequestedSpacesForOwner(requestedSpaces, personalSpaceId, now, walletAddress)) {
+    for (const deadline of [
+      space.requestedAt + REQUESTED_MEMBERSHIP_SETTLE_MS,
+      space.requestedAt + REQUEST_BRIDGE_TTL_MS,
+    ]) {
+      if (deadline > now && (next === null || deadline < next)) next = deadline;
+    }
+  }
+  return next;
+}
 
 /**
  * Whether this payload still owes the viewer a membership request they have already made.

--- a/apps/web/core/debates/matchmaking/claims-tab.test.tsx
+++ b/apps/web/core/debates/matchmaking/claims-tab.test.tsx
@@ -70,6 +70,7 @@ const mocks = vi.hoisted(() => ({
   spaceAllowlist: null as Set<string> | null,
   memberSpaceIds: null as Set<string> | null,
   allowlistLoading: false,
+  isSettlingMemberships: false,
   publishableSpaceIds: null as Set<string> | null,
   publishableLoading: false,
   scopeHeldOver: false,
@@ -105,6 +106,7 @@ vi.mock('~/core/debates/use-claim-space-allowlist', () => ({
     // about the member default set it explicitly.
     memberSpaceIds: mocks.memberSpaceIds,
     isLoading: mocks.allowlistLoading,
+    isSettlingMemberships: mocks.isSettlingMemberships,
   }),
 }));
 
@@ -624,6 +626,7 @@ beforeEach(() => {
   mocks.spaceAllowlist = null;
   mocks.memberSpaceIds = null;
   mocks.allowlistLoading = false;
+  mocks.isSettlingMemberships = false;
   // Same shape, same reason: settled-with-no-answer does not filter, which is what every
   // pre-existing case here runs under.
   mocks.publishableSpaceIds = null;
@@ -1900,6 +1903,28 @@ describe('topic menu', () => {
 
     // Seeded with theirs, which a seed taken against the partial list would have missed.
     await waitFor(() => expect(screen.queryByRole('button', { name: /Any space/ })).toBeNull());
+  });
+
+  // GEO-2834. The other half of "the menu has finished arriving": so has the *viewer's* side of it.
+  // Sign-up sends one membership proposal per picked space and they land seconds apart, so the
+  // first non-empty answer is a fraction of what the reader chose — and the seed is spent on it.
+  it('holds the default while more of their memberships are still landing', async () => {
+    mocks.spaceAllowlist = new Set([SPACE_ID, OTHER_SPACE_ID].map(id => id.replace(/-/g, '')));
+    mocks.memberSpaceIds = new Set([SPACE_ID.replace(/-/g, '')]);
+    mocks.isSettlingMemberships = true;
+    const view = render(<ClaimsTab />);
+    await showIndexedClaims();
+
+    await waitFor(() => expect(mocks.lastQuery).toBeTruthy());
+    expect(screen.getByRole('button', { name: /Any space/ })).toBeInTheDocument();
+
+    // The rest of what they picked lands.
+    mocks.memberSpaceIds = new Set([SPACE_ID, OTHER_SPACE_ID].map(id => id.replace(/-/g, '')));
+    mocks.isSettlingMemberships = false;
+    view.rerender(<ClaimsTab />);
+
+    // Both of theirs, which a seed taken against the partial answer would have missed.
+    await waitFor(() => expect(mocks.lastQuery).toMatchObject({ spaceIds: [SPACE_ID, OTHER_SPACE_ID] }));
   });
 
   // A default, not a policy: once it has applied, the viewer's own choice stands — including the

--- a/apps/web/core/debates/matchmaking/claims-tab.tsx
+++ b/apps/web/core/debates/matchmaking/claims-tab.tsx
@@ -161,7 +161,12 @@ export function ClaimsTab() {
   const [spaceIds, setSpaceIds] = React.useState<string[]>([]);
   const [topicIds, setTopicIds] = React.useState<string[]>([]);
 
-  const { allowlist: spaceAllowlist, memberSpaceIds, isLoading: allowlistLoading } = useClaimSpaceAllowlist();
+  const {
+    allowlist: spaceAllowlist,
+    memberSpaceIds,
+    isLoading: allowlistLoading,
+    isSettlingMemberships,
+  } = useClaimSpaceAllowlist();
 
   // Until the allowlist settles there is no telling an allowed space from one the viewer has
   // nothing to do with, so the tab waits instead of showing the unfiltered set and trimming it
@@ -471,7 +476,10 @@ export function ClaimsTab() {
     spaceIds,
     setSpaceIds,
     memberSpaceIds,
-    pending: spacesPending || !facetsSettled,
+    // The menu *and* the viewer's spaces, both. Sign-up sends one membership proposal per picked
+    // space and they land seconds apart, so the first non-empty answer is a fraction of what the
+    // reader chose — and the seed fires once. Same reason the explore feed reports it (GEO-2834).
+    pending: spacesPending || !facetsSettled || isSettlingMemberships,
   });
 
   // The server re-sorts on every readiness change, so hold the order the user is looking at until

--- a/apps/web/core/debates/use-claim-space-allowlist.test.tsx
+++ b/apps/web/core/debates/use-claim-space-allowlist.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { cleanup, renderHook } from '@testing-library/react';
+import { act, cleanup, renderHook } from '@testing-library/react';
 
 import * as React from 'react';
 
@@ -11,6 +11,7 @@ import type { BrowseSidebarData } from '~/core/browse/fetch-browse-sidebar-data'
 import { REQUEST_BRIDGE_TTL_MS, requestedMembershipSpacesAtom } from '~/core/state/requested-membership';
 import { normId } from '~/core/utils/norm-id';
 
+import { REQUESTED_MEMBERSHIP_SETTLE_MS } from './claim-space-allowlist';
 import { isClaimSpaceAllowed } from './claim-space-allowlist';
 import { useClaimSpaceAllowlist } from './use-claim-space-allowlist';
 
@@ -192,6 +193,46 @@ describe('useClaimSpaceAllowlist', () => {
 
     expect(result.current.memberSpaceIds?.has(normId(REQUESTED))).toBe(true);
     expect(result.current.allowlist?.has(normId(REQUESTED))).toBe(true);
+  });
+
+  // Both deadlines are read off a clock sampled during render, and the membership poll — the only
+  // thing reliably re-rendering this hook — stops at the settle deadline. Without a timer of its
+  // own the hook would never observe either boundary passing.
+  it('retires a bridge entry on its TTL with nothing else re-rendering', () => {
+    vi.useFakeTimers();
+    try {
+      mocks.source = { personalSpaceId: PERSONAL, walletAddress: WALLET, keyInput: PERSONAL, isLoading: false };
+      bridgeRequest(REQUESTED, PERSONAL);
+      const { result } = renderWithCache(PERSONAL, sidebarData({ memberOf: [] }));
+
+      expect(result.current.memberSpaceIds?.has(normId(REQUESTED))).toBe(true);
+
+      act(() => void vi.advanceTimersByTime(REQUEST_BRIDGE_TTL_MS + 10));
+
+      expect(result.current.memberSpaceIds?.has(normId(REQUESTED))).toBe(false);
+      expect(result.current.allowlist?.has(normId(REQUESTED))).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // The same boundary on the other flag: a request that never lands has to stop holding the
+  // default it gates, or the filter it feeds stays unspent for the rest of the visit.
+  it('stops settling on the deadline with nothing else re-rendering', () => {
+    vi.useFakeTimers();
+    try {
+      mocks.source = { personalSpaceId: PERSONAL, walletAddress: WALLET, keyInput: PERSONAL, isLoading: false };
+      bridgeRequest(REQUESTED, PERSONAL);
+      const { result } = renderWithCache(PERSONAL, sidebarData({ memberOf: [] }));
+
+      expect(result.current.isSettlingMemberships).toBe(true);
+
+      act(() => void vi.advanceTimersByTime(REQUESTED_MEMBERSHIP_SETTLE_MS + 10));
+
+      expect(result.current.isSettlingMemberships).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('picks the cached sidebar up as soon as the account settles', () => {

--- a/apps/web/core/debates/use-claim-space-allowlist.test.tsx
+++ b/apps/web/core/debates/use-claim-space-allowlist.test.tsx
@@ -3,10 +3,13 @@ import { cleanup, renderHook } from '@testing-library/react';
 
 import * as React from 'react';
 
+import { getDefaultStore } from 'jotai';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { browseSidebarDataQueryKey } from '~/core/browse/browse-sidebar-query';
 import type { BrowseSidebarData } from '~/core/browse/fetch-browse-sidebar-data';
+import { REQUEST_BRIDGE_TTL_MS, requestedMembershipSpacesAtom } from '~/core/state/requested-membership';
+import { normId } from '~/core/utils/norm-id';
 
 import { isClaimSpaceAllowed } from './claim-space-allowlist';
 import { useClaimSpaceAllowlist } from './use-claim-space-allowlist';
@@ -15,6 +18,8 @@ const WALLET = '0x1234567890abcdef1234567890abcdef12345678';
 const PERSONAL = '019fedae-72b6-7ab2-927a-df044d57c560';
 const FEATURED = '019fedae-72b6-7ab2-927a-df044d57c566';
 const MEMBER = '019fedae-72b6-7ab2-927a-df044d57c567';
+const REQUESTED = '019fedae-72b6-7ab2-927a-df044d57c568';
+const OTHER_WALLET = '0xfedcba9876543210fedcba9876543210fedcba98';
 
 const mocks = vi.hoisted(() => ({
   source: {
@@ -62,10 +67,16 @@ function renderWithCache(key: string | null, cached: BrowseSidebarData | undefin
   });
 }
 
+/** Seeds the optimistic "Membership pending" bridge onboarding and the Join buttons write to. */
+function bridgeRequest(spaceId: string, ownerId: string, requestedAt = Date.now()) {
+  getDefaultStore().set(requestedMembershipSpacesAtom, [{ id: spaceId, ownerId, requestedAt }]);
+}
+
 beforeEach(() => {
   mocks.source = { personalSpaceId: null, walletAddress: undefined, keyInput: null, isLoading: false };
   mocks.fetchBrowseSidebarData.mockReset().mockResolvedValue(sidebarData());
   mocks.loadBrowseSidebarData.mockReset().mockResolvedValue(sidebarData());
+  getDefaultStore().set(requestedMembershipSpacesAtom, []);
 });
 
 afterEach(cleanup);
@@ -99,6 +110,88 @@ describe('useClaimSpaceAllowlist', () => {
     const { result } = renderWithCache(WALLET, sidebarData());
 
     expect(result.current.allowlist === null && result.current.isLoading).toBe(true);
+  });
+
+  // GEO-2834. A new account picks its spaces minutes before the server can report them: the
+  // personal space has to land on-chain, the membership proposals are fired after that, and the
+  // indexer trails those again. Until this the sidebar payload was the only source, so every
+  // membership-derived filter opened unfiltered until the reader refreshed the page.
+  it('counts a space the viewer has asked to join before the server reports it', () => {
+    mocks.source = { personalSpaceId: null, walletAddress: WALLET, keyInput: WALLET, isLoading: false };
+    // Onboarding seeds the bridge under the wallet address — the personal space id does not exist
+    // yet when the picks are made.
+    bridgeRequest(REQUESTED, WALLET);
+    const { result } = renderWithCache(WALLET, sidebarData({ memberOf: [], personalSpaceId: null }));
+
+    expect(result.current.memberSpaceIds?.has(normId(REQUESTED))).toBe(true);
+    // Kept a superset: a space that counts as the viewer's has to be one they may see claims from.
+    expect(isClaimSpaceAllowed(REQUESTED, result.current.allowlist)).toBe(true);
+  });
+
+  it('widens the server answer rather than replacing it', () => {
+    mocks.source = { personalSpaceId: PERSONAL, walletAddress: WALLET, keyInput: PERSONAL, isLoading: false };
+    bridgeRequest(REQUESTED, PERSONAL);
+    const { result } = renderWithCache(PERSONAL, sidebarData());
+
+    expect(result.current.memberSpaceIds?.has(normId(MEMBER))).toBe(true);
+    expect(result.current.memberSpaceIds?.has(normId(REQUESTED))).toBe(true);
+  });
+
+  it('ignores a bridge entry left behind by another account', () => {
+    mocks.source = { personalSpaceId: null, walletAddress: WALLET, keyInput: WALLET, isLoading: false };
+    bridgeRequest(REQUESTED, OTHER_WALLET);
+    const { result } = renderWithCache(WALLET, sidebarData({ memberOf: [], personalSpaceId: null }));
+
+    expect(result.current.memberSpaceIds?.has(normId(REQUESTED))).toBe(false);
+  });
+
+  it('ignores a bridge entry past its TTL', () => {
+    mocks.source = { personalSpaceId: null, walletAddress: WALLET, keyInput: WALLET, isLoading: false };
+    bridgeRequest(REQUESTED, WALLET, Date.now() - REQUEST_BRIDGE_TTL_MS - 1);
+    const { result } = renderWithCache(WALLET, sidebarData({ memberOf: [], personalSpaceId: null }));
+
+    expect(result.current.memberSpaceIds?.has(normId(REQUESTED))).toBe(false);
+  });
+
+  // The bridge widens a resolved answer; it does not stand in for one. The default it feeds is
+  // spent the first time it matches, so answering off a handful of local ids while the real list
+  // is in flight could spend it on one space and drop the viewer's other memberships for the visit.
+  //
+  // Both legs of the gate are checked with the wallet known — that is how the bridge got seeded in
+  // the first place. With it unset the owner filter drops the entry on its own and the gate is
+  // never reached, so the assertion would hold whether or not the gate exists.
+  it('does not answer from the bridge alone while the personal space is still resolving', () => {
+    mocks.source = { personalSpaceId: null, walletAddress: WALLET, keyInput: WALLET, isLoading: true };
+    bridgeRequest(REQUESTED, WALLET);
+    const { result } = renderWithCache(WALLET, sidebarData());
+
+    expect(result.current.memberSpaceIds).toBeNull();
+    expect(result.current.allowlist).toBeNull();
+  });
+
+  it('does not answer from the bridge alone before the sidebar payload arrives', () => {
+    mocks.source = { personalSpaceId: null, walletAddress: WALLET, keyInput: WALLET, isLoading: false };
+    bridgeRequest(REQUESTED, WALLET);
+    const { result } = renderWithCache(WALLET, undefined);
+
+    expect(result.current.memberSpaceIds).toBeNull();
+    expect(result.current.allowlist).toBeNull();
+  });
+
+  // The GEO-2834 sequence itself: the picks are seeded under the wallet while the account is still
+  // resolving, and have to land the moment it does — without a refresh.
+  it('applies the bridge as soon as the account settles', () => {
+    mocks.source = { personalSpaceId: null, walletAddress: WALLET, keyInput: WALLET, isLoading: true };
+    bridgeRequest(REQUESTED, WALLET);
+    const { result, rerender } = renderWithCache(WALLET, sidebarData({ memberOf: [], personalSpaceId: null }));
+
+    expect(result.current.memberSpaceIds).toBeNull();
+
+    mocks.source = { personalSpaceId: null, walletAddress: WALLET, keyInput: WALLET, isLoading: false };
+    rerender();
+
+    expect(result.current.memberSpaceIds?.has(normId(REQUESTED))).toBe(true);
+    expect(result.current.allowlist?.has(normId(REQUESTED))).toBe(true);
   });
 
   it('picks the cached sidebar up as soon as the account settles', () => {

--- a/apps/web/core/debates/use-claim-space-allowlist.ts
+++ b/apps/web/core/debates/use-claim-space-allowlist.ts
@@ -9,7 +9,11 @@ import { useAtomValue } from 'jotai';
 import { browseSidebarDataQueryKey } from '~/core/browse/browse-sidebar-query';
 import { fetchBrowseSidebarData } from '~/core/browse/fetch-browse-sidebar-data';
 import { useBrowseSidebarQuerySource } from '~/core/browse/use-browse-sidebar-cache';
-import { requestedMembershipSpacesAtom } from '~/core/state/requested-membership';
+import {
+  activeRequestedSpacesForOwner,
+  requestedMembershipIdSet,
+  requestedMembershipSpacesAtom,
+} from '~/core/state/requested-membership';
 
 import { loadBrowseSidebarData } from '~/partials/browse-sidebar/load-browse-sidebar-data';
 
@@ -56,6 +60,10 @@ export function useClaimSpaceAllowlist(enabled: boolean = true): {
    * seconds apart — so a caller that treats the first non-empty answer as the final one acts on a
    * fraction of what the viewer chose. Read it as "one more answer is coming", bounded by
    * `REQUESTED_MEMBERSHIP_SETTLE_MS`.
+   *
+   * False until the personal space exists, since `awaitsRequestedMembership` has nothing to ask
+   * about before then. That window needs no guard: onboarding writes every pick to the bridge in
+   * one atom set, so `memberSpaceIds` is already whole the first time a caller reads it.
    */
   isSettlingMemberships: boolean;
 } {
@@ -116,18 +124,55 @@ export function useClaimSpaceAllowlist(enabled: boolean = true): {
   // caller seed off a set this hook was told not to maintain.
   const unresolved = personalSpaceLoading || !enabled || !data;
 
-  const allowlist = React.useMemo(
-    () => (unresolved ? null : browseSidebarClaimSpaceAllowlist(data, personalSpaceId)),
-    [data, personalSpaceId, unresolved]
+  // The spaces this viewer has asked to join that the server has not caught up on yet.
+  //
+  // A new account picks its spaces minutes before the sidebar payload can report them: the
+  // personal space is created on-chain first, the membership proposals are fired after that, and
+  // the indexer trails those again. For all of it the server correctly answers "you belong to
+  // nothing", so every filter defaulted from it opened unfiltered until the reader refreshed
+  // (GEO-2834). The bridge is the only source that knows sooner.
+  //
+  // Pending counts as belonging — the same call `buildMemberSpaceIds` makes about the server's own
+  // pending rows, applied a few minutes earlier.
+  //
+  // Matched on the wallet address as well as the personal space: onboarding seeds these entries
+  // under the address, since the personal space id does not exist when the picks are made.
+  const requestedIdsKey = [
+    ...requestedMembershipIdSet(
+      activeRequestedSpacesForOwner(requestedSpaces, personalSpaceId, Date.now(), walletAddress)
+    ),
+  ]
+    .sort()
+    .join(',');
+  // Rebuilt from the key so the set keeps one identity while the entries do — the consumers hang a
+  // once-only effect off it. Ids are UUID-derived hex, so a comma can't appear inside one.
+  const requestedSpaceIds = React.useMemo(
+    () => new Set(requestedIdsKey === '' ? [] : requestedIdsKey.split(',')),
+    [requestedIdsKey]
   );
+
+  const allowlist = React.useMemo(() => {
+    if (unresolved) return null;
+    const allowed = browseSidebarClaimSpaceAllowlist(data, personalSpaceId);
+    // Kept a superset of `memberSpaceIds` below, which is the invariant `buildClaimSpaceAllowlist`
+    // states: a space that counts as the viewer's has to be one they may see claims from.
+    for (const id of requestedSpaceIds) allowed.add(id);
+    return allowed;
+  }, [data, personalSpaceId, requestedSpaceIds, unresolved]);
 
   // Same gate, for the same reason: a signed-out entry left over under a partial key would read as
   // a settled answer of "you belong to nothing", which is the case the default treats as a viewer
   // with no memberships and falls back to showing everything. Held as null until it is real.
-  const memberSpaceIds = React.useMemo(
-    () => (unresolved ? null : browseSidebarMemberSpaceIds(data, personalSpaceId)),
-    [data, personalSpaceId, unresolved]
-  );
+  //
+  // The bridge widens a resolved answer rather than standing in for one. The default it feeds is
+  // spent the first time it matches, so answering off a few local ids while the real list is in
+  // flight could spend it on one space and drop the viewer's other memberships for the visit.
+  const memberSpaceIds = React.useMemo(() => {
+    if (unresolved) return null;
+    const mine = browseSidebarMemberSpaceIds(data, personalSpaceId);
+    for (const id of requestedSpaceIds) mine.add(id);
+    return mine;
+  }, [data, personalSpaceId, requestedSpaceIds, unresolved]);
 
   // Same question the interval asks, answered against the data the caller is being handed.
   const isSettlingMemberships =

--- a/apps/web/core/debates/use-claim-space-allowlist.ts
+++ b/apps/web/core/debates/use-claim-space-allowlist.ts
@@ -21,6 +21,7 @@ import {
   awaitsRequestedMembership,
   browseSidebarClaimSpaceAllowlist,
   browseSidebarMemberSpaceIds,
+  nextRequestedMembershipDeadline,
 } from './claim-space-allowlist';
 
 /**
@@ -80,6 +81,26 @@ export function useClaimSpaceAllowlist(enabled: boolean = true): {
   const queryEnabled = enabled && !personalSpaceLoading;
 
   const requestedSpaces = useAtomValue(requestedMembershipSpacesAtom);
+
+  // Everything below reads the clock during render, so without this the two bridge deadlines only
+  // take effect when something else happens to re-render. Nothing else reliably does: the poll
+  // below is the main source of renders here and it stops at the settle deadline, so a request that
+  // never landed would hold `isSettlingMemberships` true — and its space in `memberSpaceIds` — for
+  // the rest of the visit, leaving the default it gates unspent. Wake once per deadline instead.
+  const [, observeDeadline] = React.useReducer((n: number) => n + 1, 0);
+  const nextDeadline = nextRequestedMembershipDeadline({
+    requestedSpaces,
+    personalSpaceId,
+    walletAddress,
+    now: Date.now(),
+  });
+  React.useEffect(() => {
+    if (nextDeadline === null) return;
+    // Absolute, so this re-arms only when the deadline itself moves, not on every render. The extra
+    // millisecond keeps an early-firing timer from waking to a boundary that has not passed yet.
+    const timer = setTimeout(observeDeadline, Math.max(0, nextDeadline - Date.now()) + 1);
+    return () => clearTimeout(timer);
+  }, [nextDeadline]);
 
   const { data, isLoading } = useQuery({
     queryKey: browseSidebarDataQueryKey(keyInput),

--- a/apps/web/core/topics/use-topic-space-scope.ts
+++ b/apps/web/core/topics/use-topic-space-scope.ts
@@ -21,7 +21,10 @@ import { validateSpaceId } from '~/core/utils/utils';
  * spend its first minutes looking at a page with none of the spaces it had just chosen. Worth
  * knowing here because this is the one consumer of the allowlist with no second gate behind it:
  * the debates surfaces narrow again by whether a debate can be published in a space, and this
- * does not, so the widening reaches a topic page whole.
+ * does not, so the widening reaches a topic page whole. Since GEO-2834 those requested spaces
+ * include ones only the local bridge knows about, ahead of any server row. This stays a query
+ * scope over public content, never an authorization check, so an id the server has not confirmed
+ * can widen what is shown but cannot grant access to anything.
  *
  * The route's space is added on top, so a topic opened inside a space always shows that space's
  * content even when it isn't curated. That is the half of this that a viewer would notice


### PR DESCRIPTION
A new account picks its spaces minutes before the server can report them: the personal space is created on-chain first, the membership proposals are fired after that, and the indexer trails those again. For that whole window the sidebar payload correctly answers "you belong to nothing", so the filters defaulted from it — Explore's and the debates side panel's — opened unfiltered until the reader refreshed the page.

Union the optimistic membership bridge into the allowlist hook's `memberSpaceIds`. It already knows the picks from the moment onboarding seeds them, under the wallet address, before the personal space id exists. Pending counting as belonging is the same call `buildMemberSpaceIds` already makes about the server's own pending rows, applied a few minutes earlier. It widens a resolved answer rather than standing in for one, so a stale entry can't spend the once-only seed on its own. The allowlist takes the same ids, keeping it the superset of `memberSpaceIds` it is documented to be.

Also report `isSettlingMemberships` through the claims tab's and the rematch picker's `pending`, as the explore feed already does. Sign-up sends one proposal per picked space and they land seconds apart, so the first non-empty answer is a fraction of what the reader chose — and the seed fires once.