### PR TITLE
feat(explore): let only debate-tagged claims into the feed (GEO-2835)

### DIFF
--- a/apps/web/app/api/explore/feed/route.ts
+++ b/apps/web/app/api/explore/feed/route.ts
@@ -106,6 +106,9 @@ export async function GET(request: Request) {
       memberOrEditorSpaceIds,
       typeIds,
       requireName: true,
+      // GEO-2835. A restriction on the feed rather than on the selection, unlike the types filter:
+      // ticking Claim asks for the claims Explore has, and an untagged one is not among them.
+      requireDebateTagOnClaims: true,
     });
     return NextResponse.json(result);
   } catch (e) {

--- a/apps/web/core/explore/explore-best-document.ts
+++ b/apps/web/core/explore/explore-best-document.ts
@@ -9,8 +9,8 @@ const FRAGMENT = 'ExploreBestFragment';
 /**
  * The "Best" sort — Phase A ranked feed, backed by `entities_ranked_for_feed`.
  *
- * Deliberately passes no `filter`. The other two sorts build one with
- * `buildFeedFilter`, but every clause of it is enforced inside the function now:
+ * Deliberately sends none of `buildFeedFilter`. The other two sorts build one, but every
+ * clause of it is enforced inside the function now:
  *
  *   * name presence            -> migration 0075
  *   * system entities          -> 0076, keyed on the unforgeable System Type relation
@@ -21,8 +21,15 @@ const FRAGMENT = 'ExploreBestFragment';
  * Sending them again would be redundant, and not free: `filter` combined with
  * `totalCount` and `edges` on this connection exceeds the statement timeout, because
  * totalCount scans the filtered candidate set while edges walks it again. This document
- * requests neither `totalCount` nor `filter`, which keeps it on the fast path — an
- * index-ordered walk of the ranking index that stops as soon as `first` rows are found.
+ * requests no `totalCount`, which keeps it on the fast path — an index-ordered walk of
+ * the ranking index that stops as soon as `first` rows are found.
+ *
+ * `filter` is nonetheless declared, for the one clause the function does not know: the
+ * debate-tag gate on claims (GEO-2835), which the caller sends and nothing else. It is
+ * the `totalCount` half of the pair above that this document must keep avoiding, and the
+ * cost of the clause on its own was measured rather than assumed — 0.42s against 0.38s
+ * unfiltered for a 66-row window, unchanged ten pages deep and with no space scoping at
+ * all, and paging stays exact because the offset cursor runs over the filtered rows.
  *
  * There is no `orderBy` either: ordering is the function's own
  * `ORDER BY ranking_score DESC, entity_id DESC`, and the cursor is offset-based over
@@ -40,6 +47,7 @@ const EXPLORE_BEST_SOURCE = /* GraphQL */ `
     $spaceIds: [UUID!]
     $typeIds: [UUID!]
     $createdAfter: String
+    $filter: EntityFilter
     $spaceIdsForLists: [UUID!]!
   ) {
     entitiesRankedForFeedConnection(
@@ -48,6 +56,7 @@ const EXPLORE_BEST_SOURCE = /* GraphQL */ `
       spaceIds: $spaceIds
       typeIds: $typeIds
       createdAfter: $createdAfter
+      filter: $filter
     ) {
       pageInfo {
         endCursor

--- a/apps/web/core/explore/explore-debate-tag-filter.test.ts
+++ b/apps/web/core/explore/explore-debate-tag-filter.test.ts
@@ -31,9 +31,17 @@ describe('the explore debate-tag clause', () => {
   });
 
   it('lets everything that is not a claim through, rather than restricting the whole feed', () => {
-    // The negation is the half that keeps this scoped. Explore is a mixed feed and the tag says
-    // nothing about a news story or a debate; written as `some`, this branch would require every
-    // row in the feed to carry a claim tag and empty it.
+    // The negation is the half that keeps this scoped, and getting it backwards inverts the
+    // feature rather than breaking it loudly. `none` reads "is not a claim", so the clause is
+    // "not a claim, or tagged". With `some` it reads "is a claim", and the clause becomes "is a
+    // claim, or tagged":
+    //
+    //                          none (as written)     some (inverted)
+    //   news story, untagged   passes                excluded
+    //   claim, untagged        excluded              passes
+    //
+    // — every untagged claim back in the feed, and untagged news stories and debates out of it.
+    // Exactly the two things this is supposed to do, both the wrong way round.
     expect(FILTER.or[0]).toEqual({
       relations: { none: { typeId: { is: SystemIds.TYPES_PROPERTY }, toEntityId: { is: CLAIM_TYPE_ID } } },
     });

--- a/apps/web/core/explore/explore-debate-tag-filter.test.ts
+++ b/apps/web/core/explore/explore-debate-tag-filter.test.ts
@@ -1,0 +1,52 @@
+import { SystemIds } from '@geoprotocol/geo-sdk/lite';
+
+import { describe, expect, it } from 'vitest';
+
+import { CLAIM_TYPE_ID } from '~/core/claims/ontology';
+import { TAG_PROPERTY_ID } from '~/core/constants';
+import { DEBATE_TAG_ID } from '~/core/debates/ontology';
+
+import { CLAIMS_REQUIRE_DEBATE_TAG_FILTER as FILTER } from './explore-debate-tag-filter';
+
+/**
+ * The clause is evaluated by the server, so what a test here can pin is its *shape* — and the two
+ * ways that shape can be wrong are both silent. A `some` where the first branch has a `none` turns
+ * a restriction on claims into one on the whole feed; a key other than `or` collides with the
+ * exclusion clause it is spread alongside and drops that clause instead.
+ *
+ * The behaviour itself was checked against testnet (2026-09-08): scoped to Claim the clause returns
+ * 1,151 of 326,020, and scoped to Debate it returns 36 of 36 — every non-claim untouched.
+ */
+describe('the explore debate-tag clause', () => {
+  it('is a single `or`, so spreading it cannot displace the feed filter it joins', () => {
+    // `buildFeedFilter` composes by spreading. `FEED_EXCLUDED_RELATIONS_FILTER` is keyed on
+    // `relations`, so a clause written as a bare `relations` — the obvious first attempt — would
+    // replace the system-entity and block-type exclusions rather than narrow alongside them.
+    expect(Object.keys(FILTER)).toEqual(['or']);
+    expect(FILTER.or).toHaveLength(2);
+  });
+
+  it('lets everything that is not a claim through, rather than restricting the whole feed', () => {
+    // The negation is the half that keeps this scoped. Explore is a mixed feed and the tag says
+    // nothing about a news story or a debate; written as `some`, this branch would require every
+    // row in the feed to carry a claim tag and empty it.
+    expect(FILTER.or[0]).toEqual({
+      relations: { none: { typeId: { is: SystemIds.TYPES_PROPERTY }, toEntityId: { is: CLAIM_TYPE_ID } } },
+    });
+  });
+
+  it('admits a claim on the Debate tag, matched by id', () => {
+    // Ids, not names: `Debate` names both a tag entity and a type, and either display name can be
+    // edited by anyone with rights to it.
+    expect(FILTER.or[1]).toEqual({
+      relations: { some: { typeId: { is: TAG_PROPERTY_ID }, toEntityId: { is: DEBATE_TAG_ID } } },
+    });
+  });
+
+  it('does not scope the tag to a space', () => {
+    // Unlike the claims tab, where the tag's space is what a card is built against. Here the card
+    // is built against the entity's display space and the tag is only a gate, so scoping it would
+    // drop claims for the space they were curated in rather than the one they are read in.
+    expect(JSON.stringify(FILTER)).not.toContain('spaceId');
+  });
+});

--- a/apps/web/core/explore/explore-debate-tag-filter.test.ts
+++ b/apps/web/core/explore/explore-debate-tag-filter.test.ts
@@ -6,13 +6,17 @@ import { CLAIM_TYPE_ID } from '~/core/claims/ontology';
 import { TAG_PROPERTY_ID } from '~/core/constants';
 import { DEBATE_TAG_ID } from '~/core/debates/ontology';
 
-import { CLAIMS_REQUIRE_DEBATE_TAG_FILTER as FILTER } from './explore-debate-tag-filter';
+import { claimsRequireDebateTagFilter } from './explore-debate-tag-filter';
+
+const SPACES = ['aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'];
+const FILTER = claimsRequireDebateTagFilter(SPACES);
 
 /**
- * The clause is evaluated by the server, so what a test here can pin is its *shape* — and the two
- * ways that shape can be wrong are both silent. A `some` where the first branch has a `none` turns
- * a restriction on claims into one on the whole feed; a key other than `or` collides with the
- * exclusion clause it is spread alongside and drops that clause instead.
+ * The clause is evaluated by the server, so what a test here can pin is its *shape* — and the ways
+ * that shape can be wrong are all silent. A `some` where the first branch has a `none` turns a
+ * restriction on claims into one on the whole feed; a key other than `or` collides with the
+ * exclusion clause it is spread alongside and drops that clause instead; and an unscoped tag half
+ * turns a curation gate into an open one.
  *
  * The behaviour itself was checked against testnet (2026-09-08): scoped to Claim the clause returns
  * 1,151 of 326,020, and scoped to Debate it returns 36 of 36 — every non-claim untouched.
@@ -35,18 +39,33 @@ describe('the explore debate-tag clause', () => {
     });
   });
 
-  it('admits a claim on the Debate tag, matched by id', () => {
+  it('admits a claim on the Debate tag, matched by id and scoped to the feed’s spaces', () => {
     // Ids, not names: `Debate` names both a tag entity and a type, and either display name can be
     // edited by anyone with rights to it.
+    //
+    // The `spaceId` is not decoration. Relations carry their own space, so without it the clause
+    // accepts a tag written from any space at all — and anyone with a space of their own could put
+    // an arbitrary claim in front of every reader (GEO-2835 review).
     expect(FILTER.or[1]).toEqual({
-      relations: { some: { typeId: { is: TAG_PROPERTY_ID }, toEntityId: { is: DEBATE_TAG_ID } } },
+      relations: {
+        some: {
+          typeId: { is: TAG_PROPERTY_ID },
+          toEntityId: { is: DEBATE_TAG_ID },
+          spaceId: { in: SPACES },
+        },
+      },
     });
   });
 
-  it('does not scope the tag to a space', () => {
-    // Unlike the claims tab, where the tag's space is what a card is built against. Here the card
-    // is built against the entity's display space and the tag is only a gate, so scoping it would
-    // drop claims for the space they were curated in rather than the one they are read in.
-    expect(JSON.stringify(FILTER)).not.toContain('spaceId');
+  it('copies the space list rather than aliasing the caller’s array', () => {
+    const spaces = ['cccccccccccccccccccccccccccccccc'];
+    const filter = claimsRequireDebateTagFilter(spaces);
+    spaces.push('dddddddddddddddddddddddddddddddd');
+
+    // The feed builds this per request from `baseIds` and the clause outlives the call; sharing the
+    // array would let a later mutation widen a filter that has already been reasoned about.
+    expect((filter.or[1] as { relations: { some: { spaceId: { in: string[] } } } }).relations.some.spaceId.in).toEqual([
+      'cccccccccccccccccccccccccccccccc',
+    ]);
   });
 });

--- a/apps/web/core/explore/explore-debate-tag-filter.ts
+++ b/apps/web/core/explore/explore-debate-tag-filter.ts
@@ -24,9 +24,25 @@ import type { EntityFilter } from '~/core/gql/graphql';
  * it would drop claims for the space they were curated in rather than the space they are read in.
  *
  * Measured before relying on it (testnet, 2026-09-08): 1,151 of 326,020 claims carry the tag, so
- * this removes almost every claim from the feed — which is the intent, and worth knowing. On all
- * three sorts the clause is free or better: New 0.31s with against 0.49s without, Top 0.37s against
- * 0.29s, Best 0.42s against 0.38s, warm.
+ * this removes almost every claim from the feed — which is the intent, and worth knowing.
+ *
+ * Cost, from paired interleaved A/B through the route — every request the Explore UI can actually
+ * issue, ten to thirty pairs each, alternating which arm ran first:
+ *
+ *   Best (unwindowed)   357ms with, 355ms without
+ *   New  (unwindowed)   285ms with, 325ms without
+ *   Top  every window   within ±4%, no window worse than noise
+ *
+ * In each the gated arm was the slower one in about half the pairs, which is what a free clause
+ * looks like. It is not free everywhere, though, and the exception is worth knowing about before
+ * anyone widens the feed:
+ *
+ *   **This clause roughly doubles a query that also carries a `createdAt` window.** Best over the
+ *   last year went 462ms -> 939ms and New over the last week 1985ms -> 3356ms, each slower in
+ *   10 of 10 pairs with no overlap between the two arms' ranges. Nothing reaches that combination
+ *   today: `SORTS_WITH_TIME_RANGE` in `entity-feed` is `['top']`, so Best and New leave the `time`
+ *   param off entirely, and Top — the one sort that does send a window — is unaffected. Adding
+ *   Best or New to that list without re-measuring would make the feed about twice as slow.
  */
 export const CLAIMS_REQUIRE_DEBATE_TAG_FILTER = {
   or: [

--- a/apps/web/core/explore/explore-debate-tag-filter.ts
+++ b/apps/web/core/explore/explore-debate-tag-filter.ts
@@ -1,0 +1,41 @@
+import { SystemIds } from '@geoprotocol/geo-sdk/lite';
+
+import { CLAIM_TYPE_ID } from '~/core/claims/ontology';
+import { TAG_PROPERTY_ID } from '~/core/constants';
+import { DEBATE_TAG_ID } from '~/core/debates/ontology';
+import type { EntityFilter } from '~/core/gql/graphql';
+
+/**
+ * Explore's claims are the debatable ones (GEO-2835): a claim reaches the feed only if a curator
+ * has tagged it `Debate`, and everything else reaches it exactly as before.
+ *
+ * Read as an OR of "is not a claim" and "carries the tag", which is what keeps this a restriction
+ * on claims rather than on the feed. Written as one clause rather than as a claim-specific query
+ * because Explore is a mixed feed — one page carries news stories, debates and claims together, and
+ * the tag has nothing to say about the first two.
+ *
+ * Both halves match on ids rather than names. `Debate` is a tag entity and a type, and the display
+ * name of either can be edited by anyone with rights to it; an id cannot.
+ *
+ * Note what this is *not* scoped by: neither half mentions a space, so a claim tagged in any space
+ * passes. The alternative — the tag having to be in one of the spaces the feed is scoped to — is
+ * what `tagged-claims` needs, because there the tag's space is what a card is built against. Here
+ * the card is built against the entity's own display space and the tag is only a gate, so scoping
+ * it would drop claims for the space they were curated in rather than the space they are read in.
+ *
+ * Measured before relying on it (testnet, 2026-09-08): 1,151 of 326,020 claims carry the tag, so
+ * this removes almost every claim from the feed — which is the intent, and worth knowing. On all
+ * three sorts the clause is free or better: New 0.31s with against 0.49s without, Top 0.37s against
+ * 0.29s, Best 0.42s against 0.38s, warm.
+ */
+export const CLAIMS_REQUIRE_DEBATE_TAG_FILTER = {
+  or: [
+    // Not a claim. The types *relation*, not the `typeIds` argument, because a filter can only
+    // negate a relation — and this half has to be a negation, or the clause would silently exclude
+    // every news story and debate too.
+    { relations: { none: { typeId: { is: SystemIds.TYPES_PROPERTY }, toEntityId: { is: CLAIM_TYPE_ID } } } },
+    // Or carries the tag. Same property and shape the claims tab filters on, so the two surfaces
+    // agree about what "tagged for debate" means.
+    { relations: { some: { typeId: { is: TAG_PROPERTY_ID }, toEntityId: { is: DEBATE_TAG_ID } } } },
+  ],
+} satisfies EntityFilter;

--- a/apps/web/core/explore/explore-debate-tag-filter.ts
+++ b/apps/web/core/explore/explore-debate-tag-filter.ts
@@ -17,11 +17,23 @@ import type { EntityFilter } from '~/core/gql/graphql';
  * Both halves match on ids rather than names. `Debate` is a tag entity and a type, and the display
  * name of either can be edited by anyone with rights to it; an id cannot.
  *
- * Note what this is *not* scoped by: neither half mentions a space, so a claim tagged in any space
- * passes. The alternative — the tag having to be in one of the spaces the feed is scoped to — is
- * what `tagged-claims` needs, because there the tag's space is what a card is built against. Here
- * the card is built against the entity's own display space and the tag is only a gate, so scoping
- * it would drop claims for the space they were curated in rather than the space they are read in.
+ * The tag half is scoped to the spaces the feed is already reading from, and that scoping is the
+ * whole difference between a curation gate and an open one (GEO-2835 review). Relations carry
+ * their own space, independent of the entity's, so an unscoped clause accepts a `Tags -> Debate`
+ * relation written from *anywhere* — including a personal space nobody else reads. Anyone able to
+ * write to a space of their own could therefore put an arbitrary claim in front of every reader,
+ * provided it already lived in a space they browse. Scoping to the feed's own spaces closes that,
+ * and it costs very little: of 1,311 tag relations on testnet (2026-09-08), zero were applied from
+ * a space the tagged claim does not itself live in, so nothing curated today depends on the
+ * loophole. Measured against the eleven spaces that hold tagged claims, scoping admits the same
+ * 1,308 claims the unscoped clause did — no loss at all for a reader who browses the spaces doing
+ * the curating. It does bite a reader narrowed to fewer: a three-space subset loses 4 of 304 and a
+ * single space 5 of 352, around 1.4%, each a claim living in the space they picked but tagged in
+ * one of the others. That is the price, and it buys the paragraph above.
+ *
+ * It also settles a disagreement this was supposed to end. `taggedEntityFilter` in
+ * `core/debates/tagged-claims` puts `spaceId` on the tag relation too, so an unscoped clause here
+ * meant a claim could pass Explore's gate and still never appear in the claims tab.
  *
  * Measured before relying on it (testnet, 2026-09-08): 1,151 of 326,020 claims carry the tag, so
  * this removes almost every claim from the feed — which is the intent, and worth knowing.
@@ -29,13 +41,16 @@ import type { EntityFilter } from '~/core/gql/graphql';
  * Cost, from paired interleaved A/B through the route — every request the Explore UI can actually
  * issue, ten to thirty pairs each, alternating which arm ran first:
  *
- *   Best (unwindowed)   357ms with, 355ms without
- *   New  (unwindowed)   285ms with, 325ms without
- *   Top  every window   within ±4%, no window worse than noise
+ *   Best (unwindowed)   355ms with, 376ms without — slower in 12 of 30 pairs
+ *   New  (unwindowed)   366ms with, 367ms without — slower in 15 of 30 pairs
+ *   Top  every window   within ±9%, none worse than a coin flip
  *
- * In each the gated arm was the slower one in about half the pairs, which is what a free clause
- * looks like. It is not free everywhere, though, and the exception is worth knowing about before
- * anyone widens the feed:
+ * Fifteen of thirty is exactly a coin flip, which is what a free clause looks like. Ten pairs is
+ * not enough to see that: the same two rows first measured at +15.6% and +29.4%, and both went to
+ * nothing at thirty. Re-measure with enough pairs before believing a delta here.
+ *
+ * It is not free everywhere, though, and the exception is worth knowing about before anyone widens
+ * the feed:
  *
  *   **This clause roughly doubles a query that also carries a `createdAt` window.** Best over the
  *   last year went 462ms -> 939ms and New over the last week 1985ms -> 3356ms, each slower in
@@ -44,14 +59,25 @@ import type { EntityFilter } from '~/core/gql/graphql';
  *   param off entirely, and Top — the one sort that does send a window — is unaffected. Adding
  *   Best or New to that list without re-measuring would make the feed about twice as slow.
  */
-export const CLAIMS_REQUIRE_DEBATE_TAG_FILTER = {
-  or: [
-    // Not a claim. The types *relation*, not the `typeIds` argument, because a filter can only
-    // negate a relation — and this half has to be a negation, or the clause would silently exclude
-    // every news story and debate too.
-    { relations: { none: { typeId: { is: SystemIds.TYPES_PROPERTY }, toEntityId: { is: CLAIM_TYPE_ID } } } },
-    // Or carries the tag. Same property and shape the claims tab filters on, so the two surfaces
-    // agree about what "tagged for debate" means.
-    { relations: { some: { typeId: { is: TAG_PROPERTY_ID }, toEntityId: { is: DEBATE_TAG_ID } } } },
-  ],
-} satisfies EntityFilter;
+export function claimsRequireDebateTagFilter(spaceIds: readonly string[]) {
+  return {
+    or: [
+      // Not a claim. The types *relation*, not the `typeIds` argument, because a filter can only
+      // negate a relation — and this half has to be a negation, or the clause would silently
+      // exclude every news story and debate too.
+      { relations: { none: { typeId: { is: SystemIds.TYPES_PROPERTY }, toEntityId: { is: CLAIM_TYPE_ID } } } },
+      // Or carries the tag, applied from one of the spaces this feed is already scoped to. Same
+      // property, target and space-scoping the claims tab filters on, so the two surfaces agree
+      // about what "tagged for debate" means.
+      {
+        relations: {
+          some: {
+            typeId: { is: TAG_PROPERTY_ID },
+            toEntityId: { is: DEBATE_TAG_ID },
+            spaceId: { in: [...spaceIds] },
+          },
+        },
+      },
+    ],
+  } satisfies EntityFilter;
+}

--- a/apps/web/core/explore/explore-debate-tag-filter.ts
+++ b/apps/web/core/explore/explore-debate-tag-filter.ts
@@ -31,6 +31,10 @@ import type { EntityFilter } from '~/core/gql/graphql';
  * single space 5 of 352, around 1.4%, each a claim living in the space they picked but tagged in
  * one of the others. That is the price, and it buys the paragraph above.
  *
+ * That trade was put to Preston with those numbers and confirmed: scoped, deliberately, rather
+ * than an oversight to be tidied up by widening it again. Anyone who does widen it is choosing the
+ * 1.4% over the open gate, so measure both before deciding it was only a scoping mistake.
+ *
  * It also settles a disagreement this was supposed to end. `taggedEntityFilter` in
  * `core/debates/tagged-claims` puts `spaceId` on the tag relation too, so an unscoped clause here
  * meant a claim could pass Explore's gate and still never appear in the claims tab.

--- a/apps/web/core/explore/explore-feed-documents.test.ts
+++ b/apps/web/core/explore/explore-feed-documents.test.ts
@@ -61,19 +61,21 @@ describe('explore feed documents', () => {
   describe('the Best sort', () => {
     it('passes space, type and recency scoping as connection arguments', () => {
       expect(argNames(rootField(exploreBestConnectionDocument))).toEqual(
-        ['after', 'createdAfter', 'first', 'spaceIds', 'typeIds'].sort()
+        ['after', 'createdAfter', 'filter', 'first', 'spaceIds', 'typeIds'].sort()
       );
     });
 
-    it('sends no `filter`', () => {
+    it('can carry a `filter`, for the one clause the ranked function does not know', () => {
       // Every clause buildFeedFilter would add is enforced inside
       // entities_ranked_for_feed: name presence (0075), system entities (0076),
-      // excluded block types (config), space/type/recency (0077 arguments).
+      // excluded block types (config), space/type/recency (0077 arguments) — and none of
+      // them is sent here.
       //
-      // Re-adding one is not merely redundant: `filter` together with `totalCount` and
-      // `edges` on this connection exceeds the statement timeout.
-      expect(variableNames(exploreBestConnectionDocument)).not.toContain('filter');
-      expect(argNames(rootField(exploreBestConnectionDocument))).not.toContain('filter');
+      // The debate-tag gate on claims is not among them, so it goes through `filter`
+      // (GEO-2835). What made a filter dangerous on this connection was pairing it with
+      // `totalCount`, which the test below still pins.
+      expect(variableNames(exploreBestConnectionDocument)).toContain('filter');
+      expect(argNames(rootField(exploreBestConnectionDocument))).toContain('filter');
     });
 
     it('requests no top-level totalCount', () => {

--- a/apps/web/core/explore/fetch-explore-feed.test.ts
+++ b/apps/web/core/explore/fetch-explore-feed.test.ts
@@ -1,0 +1,162 @@
+import { SystemIds } from '@geoprotocol/geo-sdk/lite';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import * as Effect from 'effect/Effect';
+
+import { CLAIM_TYPE_ID } from '~/core/claims/ontology';
+
+import { NEWS_STORY_TYPE_ID } from './explore-constants';
+
+/**
+ * The graph is mocked at `graphql()` — the single boundary every sort's fetcher goes through —
+ * so a test can hand the feed an exact sequence of windows. `graphql` resolves to whatever its
+ * `decoder` would have produced, which is the page shape below, so the mock returns that directly.
+ */
+const windows = vi.hoisted(() => ({ queue: [] as unknown[], calls: 0 }));
+
+vi.mock('~/core/io/graphql-client', () => ({
+  graphql: () => {
+    const next = windows.queue[Math.min(windows.calls, windows.queue.length - 1)];
+    windows.calls += 1;
+    return Effect.succeed(next);
+  },
+}));
+
+// Only reached when a wallet is passed, which these cases do not do; mocked so the module graph
+// does not pull the subgraph client in.
+vi.mock('~/core/io/subgraph', () => ({ fetchProfile: () => Effect.succeed(null) }));
+vi.mock('~/core/io/subgraph/fetch-proposed-members', () => ({ fetchActiveMemberRequest: async () => null }));
+
+const { fetchExploreFeed } = await import('./fetch-explore-feed');
+
+const SPACE = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+
+const browse = {
+  featured: [{ id: SPACE, name: 'Space', image: null }],
+  editorOf: [],
+  memberOf: [],
+  documentationImage: null,
+  personalSpaceId: null,
+} as never;
+
+/**
+ * One card-shaped entity carrying a single type. Cast rather than fully built: `Entity` has a
+ * dozen fields the feed never reads for this, and spelling them out would obscure the one thing
+ * each fixture is about — which type the row lands on.
+ */
+function entity(id: string, typeId: string) {
+  return {
+    id,
+    name: `entity-${id}`,
+    description: null,
+    spaces: [SPACE],
+    types: [{ id: typeId, name: null }],
+    values: [],
+    relations: [
+      {
+        id: `rel-${id}`,
+        spaceId: SPACE,
+        type: { id: SystemIds.TYPES_PROPERTY },
+        toEntity: { id: typeId, name: null, types: [], values: [] },
+      },
+    ],
+    commentCount: 0,
+    createdAt: '1780000000',
+  } as never;
+}
+
+function windowOf(entities: unknown[], opts: { hasNextPage: boolean; endCursor: string | null }) {
+  return { entities, endCursor: opts.endCursor, hasNextPage: opts.hasNextPage };
+}
+
+const feedArgs = {
+  browse,
+  sort: 'best' as const,
+  time: 'all' as const,
+  spaceFilterIds: null,
+  cursor: null,
+  memberOrEditorSpaceIds: [],
+  typeIds: [CLAIM_TYPE_ID],
+  requireDebateTagOnClaims: true,
+};
+
+beforeEach(() => {
+  windows.queue = [];
+  windows.calls = 0;
+});
+
+/**
+ * GEO-2835 review. Best cannot filter by type in the query (GEO-2793), so it filters the window
+ * here — and with the debate-tag gate applied, a Claim-only selection can match nothing in a
+ * window while the connection still reports another page.
+ *
+ * An empty page that carries a cursor is not a pause: the client's sentinel has an 8000px
+ * rootMargin, so with nothing rendered it stays intersecting and refires as soon as the request
+ * settles. That is an unbounded loop of round trips that get slower with depth.
+ */
+describe('a window with nothing servable in it', () => {
+  it('scans on rather than returning an empty page', async () => {
+    windows.queue = [
+      // Nothing a Claim-only selection can use...
+      windowOf([entity('n1', NEWS_STORY_TYPE_ID)], { hasNextPage: true, endCursor: 'c1' }),
+      windowOf([entity('n2', NEWS_STORY_TYPE_ID)], { hasNextPage: true, endCursor: 'c2' }),
+      // ...until this one.
+      windowOf([entity('c3', CLAIM_TYPE_ID)], { hasNextPage: true, endCursor: 'c3' }),
+    ];
+
+    const result = await fetchExploreFeed(feedArgs);
+
+    expect(result.items.map(i => i.entityId)).toEqual(['c3']);
+    expect(windows.calls).toBe(3);
+  });
+
+  it('never hands back a cursor on an empty page, which is what made it spin', async () => {
+    // Every window is unusable and the connection always claims another page — the shape the
+    // ranked feed really produces past the last tagged claim.
+    windows.queue = [windowOf([entity('n1', NEWS_STORY_TYPE_ID)], { hasNextPage: true, endCursor: 'c1' })];
+
+    const result = await fetchExploreFeed(feedArgs);
+
+    expect(result.items).toEqual([]);
+    expect(result.nextCursor).toBeNull();
+  });
+
+  it('bounds how many windows one request will look at', async () => {
+    windows.queue = [windowOf([entity('n1', NEWS_STORY_TYPE_ID)], { hasNextPage: true, endCursor: 'c1' })];
+
+    await fetchExploreFeed(feedArgs);
+
+    // The first window plus the scan budget's worth, and no more. Without a bound this is the
+    // request that ran for 81 seconds.
+    expect(windows.calls).toBeLessThanOrEqual(7);
+  });
+
+  it('stops at a genuine end of feed without spending the budget', async () => {
+    windows.queue = [windowOf([entity('n1', NEWS_STORY_TYPE_ID)], { hasNextPage: false, endCursor: null })];
+
+    const result = await fetchExploreFeed(feedArgs);
+
+    expect(result.items).toEqual([]);
+    expect(result.nextCursor).toBeNull();
+    // `hasNextPage: false` is the connection saying there is nothing further; scanning past that
+    // would be asking a question already answered.
+    expect(windows.calls).toBe(1);
+  });
+});
+
+describe('a window that does have rows', () => {
+  it('serves them and keeps paging, without extra fetches', async () => {
+    windows.queue = [
+      windowOf([entity('c1', CLAIM_TYPE_ID), entity('c2', CLAIM_TYPE_ID)], {
+        hasNextPage: true,
+        endCursor: 'next',
+      }),
+    ];
+
+    const result = await fetchExploreFeed(feedArgs);
+
+    expect(result.items.map(i => i.entityId)).toEqual(['c1', 'c2']);
+    expect(result.nextCursor).not.toBeNull();
+    expect(windows.calls).toBe(1);
+  });
+});

--- a/apps/web/core/explore/fetch-explore-feed.test.ts
+++ b/apps/web/core/explore/fetch-explore-feed.test.ts
@@ -1,23 +1,35 @@
 import { SystemIds } from '@geoprotocol/geo-sdk/lite';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import * as Effect from 'effect/Effect';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { CLAIM_TYPE_ID } from '~/core/claims/ontology';
 
 import { NEWS_STORY_TYPE_ID } from './explore-constants';
+import { claimsRequireDebateTagFilter } from './explore-debate-tag-filter';
 
 /**
  * The graph is mocked at `graphql()` — the single boundary every sort's fetcher goes through —
  * so a test can hand the feed an exact sequence of windows. `graphql` resolves to whatever its
  * `decoder` would have produced, which is the page shape below, so the mock returns that directly.
  */
-const windows = vi.hoisted(() => ({ queue: [] as unknown[], calls: 0 }));
+const windows = vi.hoisted(() => ({
+  queue: [] as unknown[],
+  calls: 0,
+  /**
+   * What each call actually asked the graph for. Kept because the interesting half of this module
+   * is what it *sends*: a mock that only feeds rows back cannot tell whether the debate-tag clause
+   * still reaches the query, so every one of these tests would go on passing if the gate silently
+   * stopped being forwarded.
+   */
+  variables: [] as Record<string, unknown>[],
+}));
 
 vi.mock('~/core/io/graphql-client', () => ({
-  graphql: () => {
+  graphql: ({ variables }: { variables: Record<string, unknown> }) => {
     const next = windows.queue[Math.min(windows.calls, windows.queue.length - 1)];
     windows.calls += 1;
+    windows.variables.push(variables);
     return Effect.succeed(next);
   },
 }));
@@ -83,6 +95,44 @@ const feedArgs = {
 beforeEach(() => {
   windows.queue = [];
   windows.calls = 0;
+  windows.variables = [];
+});
+
+/**
+ * The clause has to survive the trip into every sort's query, and each sort composes it
+ * differently — Best sends it as the whole `filter`, while New and Top spread it into the one
+ * `buildFeedFilter` builds. The `or` key is the part that is the gate, so that is what these
+ * compare, and it is the same assertion for all three.
+ *
+ * Worth pinning rather than reading: `buildFeedFilter(args)` picks the flag off the args object it
+ * is handed, so a sort that forgets to pass it through fails silently and completely — the feed
+ * just goes back to serving every claim.
+ */
+describe('the debate-tag clause reaching the query', () => {
+  const sorts = ['best', 'new', 'top'] as const;
+
+  function sentFilter() {
+    return windows.variables[0]?.filter as { or?: unknown } | undefined;
+  }
+
+  it.each(sorts)('is sent for the %s sort when the caller asks for it', async sort => {
+    windows.queue = [windowOf([entity('c1', CLAIM_TYPE_ID)], { hasNextPage: false, endCursor: null })];
+
+    await fetchExploreFeed({ ...feedArgs, sort });
+
+    // Compared against the module that builds it, so the space-scoping travels too: a clause that
+    // arrived unscoped would be an open gate, which is the thing the scoping exists to prevent.
+    expect(sentFilter()?.or).toEqual(claimsRequireDebateTagFilter([SPACE]).or);
+  });
+
+  it.each(sorts)('is absent for the %s sort when it is not asked for', async sort => {
+    windows.queue = [windowOf([entity('c1', CLAIM_TYPE_ID)], { hasNextPage: false, endCursor: null })];
+
+    await fetchExploreFeed({ ...feedArgs, sort, requireDebateTagOnClaims: false });
+
+    // The activity feed shares this fetcher and must keep seeing untagged claims.
+    expect(sentFilter()?.or).toBeUndefined();
+  });
 });
 
 /**

--- a/apps/web/core/explore/fetch-explore-feed.ts
+++ b/apps/web/core/explore/fetch-explore-feed.ts
@@ -18,7 +18,7 @@ import {
   decodeExploreCardEntity,
 } from './explore-card-item';
 import { EXPLORE_ENTITY_NAME_PROPERTY_ID, EXPLORE_PAGE_SIZE } from './explore-constants';
-import { CLAIMS_REQUIRE_DEBATE_TAG_FILTER } from './explore-debate-tag-filter';
+import { claimsRequireDebateTagFilter } from './explore-debate-tag-filter';
 import { EXPLORE_DIVERSITY_WINDOW_SIZE, applyDiversityCap, exploreItemTypeKey } from './explore-diversity';
 import { exploreEntitiesByPropertyConnectionDocument } from './explore-entities-by-property-document';
 import { exploreEntitiesConnectionDocument } from './explore-entities-document';
@@ -68,6 +68,24 @@ const FEED_EXCLUDED_RELATIONS_FILTER = {
     },
   },
 } satisfies EntityFilter;
+
+/**
+ * How long one request will keep scanning for a window with something in it, and the hard stop on
+ * how many it will look at. See the loop in `fetchExploreFeed` for why the scan happens here.
+ *
+ * A clock rather than a count, because a window's cost is not a constant and a count budget prices
+ * it as one. Measured cold, one shot per cursor, which is what a reader scrolling actually does: a
+ * window near the top of the ranking is 0.3-2s, and by offset 300 it is 11-12s — the ranked
+ * connection's own cost at depth, present before any of this and unchanged by it. A flat budget of
+ * six windows therefore meant a 2-second request near the top and an *81-second* one at depth,
+ * measured, which is a worse failure than the empty-page loop it was meant to fix.
+ *
+ * Checked before each additional fetch, so the budget buys many windows where they are cheap —
+ * which is where the crossable thin patches are — and at most one where they are not. The hard cap
+ * bounds the cheap end, where the clock alone would allow a great many.
+ */
+const MAX_EMPTY_WINDOW_SCAN_MS = 3_000;
+const MAX_EMPTY_WINDOW_SCANS = 6;
 
 function timeThresholdSec(filter: ExploreTime): number | null {
   const now = Math.floor(Date.now() / 1000);
@@ -137,7 +155,7 @@ function buildFeedFilter(args: {
   const t = timeThresholdSec(args.time);
   return {
     ...FEED_EXCLUDED_RELATIONS_FILTER,
-    ...(args.requireDebateTagOnClaims ? CLAIMS_REQUIRE_DEBATE_TAG_FILTER : {}),
+    ...(args.requireDebateTagOnClaims ? claimsRequireDebateTagFilter(args.spaceIds) : {}),
     ...(args.includeEntityScopeInFilter
       ? {
           spaceIds: { overlaps: [...args.spaceIds] },
@@ -269,7 +287,7 @@ async function fetchBestEntitiesPage(args: {
         createdAfter: t != null ? String(t) : undefined,
         // Left undefined when the caller does not ask for the tag gate, so the sort keeps its
         // no-filter fast path unless there is a clause the connection genuinely does not know.
-        filter: args.requireDebateTagOnClaims ? CLAIMS_REQUIRE_DEBATE_TAG_FILTER : undefined,
+        filter: args.requireDebateTagOnClaims ? claimsRequireDebateTagFilter(args.spaceIds) : undefined,
         spaceIdsForLists: args.spaceIds,
       },
     })
@@ -382,67 +400,120 @@ export async function fetchExploreFeed(args: {
   const windowSize =
     args.sort === 'best' && (args.typeIds?.length ?? 0) !== 1 ? EXPLORE_DIVERSITY_WINDOW_SIZE : scanChunk;
 
-  const page =
+  const fetchWindow = (windowAfter: string | null) =>
     args.sort === 'best'
-      ? await fetchBestEntitiesPage({
+      ? fetchBestEntitiesPage({
           spaceIds: baseIds,
           time: args.time,
           limit: windowSize,
-          after,
+          after: windowAfter,
           requireDebateTagOnClaims: args.requireDebateTagOnClaims,
         })
       : args.sort === 'top'
-        ? await fetchTopEntitiesPage({
+        ? fetchTopEntitiesPage({
             spaceIds: baseIds,
             time: args.time,
             limit: windowSize,
-            after,
+            after: windowAfter,
             typeIds: args.typeIds,
             requireName: args.requireName,
             requireDebateTagOnClaims: args.requireDebateTagOnClaims,
           })
-        : await fetchExploreEntitiesPage({
+        : fetchExploreEntitiesPage({
             spaceIds: baseIds,
             time: args.time,
             limit: windowSize,
-            after,
+            after: windowAfter,
             orderBy: [EntitiesOrderBy.CreatedAtDesc],
             typeIds: args.typeIds,
             requireName: args.requireName,
             requireDebateTagOnClaims: args.requireDebateTagOnClaims,
           });
 
-  const allRows = buildExploreFeedRows(page.entities, allowed, memberOrEditorSet);
+  const orderWindow = (entities: ExploreCardEntity[]): ExploreFeedRow[] => {
+    const allRows = buildExploreFeedRows(entities, allowed, memberOrEditorSet);
 
-  // Best filters by type here rather than in the query (see `fetchBestEntitiesPage`). The other
-  // sorts already came back filtered, so re-checking them would be redundant — and worse than
-  // redundant: a card's types are the TYPES relations *in its display space*, while the server's
-  // predicate is not space-scoped, so the two can disagree at the margin. Applying it only where
-  // the server no longer does keeps exactly one source of truth per sort.
-  const typeFiltered =
-    args.sort === 'best' && (args.typeIds?.length ?? 0) > 0
-      ? allRows.filter(row => entityMatchesExploreTypeIds(row, args.typeIds ?? []))
-      : allRows;
-  const rows = typeFiltered;
+    // Best filters by type here rather than in the query (see `fetchBestEntitiesPage`). The other
+    // sorts already came back filtered, so re-checking them would be redundant — and worse than
+    // redundant: a card's types are the TYPES relations *in its display space*, while the server's
+    // predicate is not space-scoped, so the two can disagree at the margin. Applying it only where
+    // the server no longer does keeps exactly one source of truth per sort.
+    const rows =
+      args.sort === 'best' && (args.typeIds?.length ?? 0) > 0
+        ? allRows.filter(row => entityMatchesExploreTypeIds(row, args.typeIds ?? []))
+        : allRows;
 
-  // "Best" is the only sort that reorders (GEO-2690). "New" is reverse-chronological and
-  // an activity log that shuffles is simply wrong; "Top" is an explicit "rank by score"
-  // request, and the crowding-out was measured on Best, which is also the default tab.
-  const ordered = args.sort === 'best' ? applyDiversityCap(rows, exploreItemTypeKey) : rows;
+    // "Best" is the only sort that reorders (GEO-2690). "New" is reverse-chronological and
+    // an activity log that shuffles is simply wrong; "Top" is an explicit "rank by score"
+    // request, and the crowding-out was measured on Best, which is also the default tab.
+    return args.sort === 'best' ? applyDiversityCap(rows, exploreItemTypeKey) : rows;
+  };
+
+  // A window that survives none of the above is not the end of the feed, and returning it as an
+  // empty page is what makes it behave like one — badly (GEO-2835 review). The client's sentinel
+  // has an 8000px rootMargin, so with nothing rendered it stays intersecting and refires the
+  // instant the request settles; an empty page that still carries a cursor is therefore an
+  // unbounded loop of round trips that get slower with depth, not a pause.
+  //
+  // Reachable since the debate-tag gate: Best cannot filter by type in the query (GEO-2793), so it
+  // scans a window and applies the whitelist here — and past the ranked depth where tagged claims
+  // run thin, a Claim-only selection matches nothing in a 30-row window while the connection still
+  // reports another page. Measured over the eleven spaces that hold tagged claims: at offset 600 a
+  // gated window held 0 claims against 13 ungated. Claim is one of the three default types, so
+  // unticking the other two is all it takes.
+  //
+  // So the scan continues here, where one round trip covers it, rather than being handed back to a
+  // client that will only ask again. Bounded because the alternative is unbounded: the ranked
+  // connection reports `hasNextPage` for a long way past the last tagged claim, and the offset cap
+  // that would end it applies only to the explicit `offset` argument, not to the `after` cursor
+  // this uses — `["natural",1200]` as `after` still returns a full window.
+  //
+  // Budget spent with nothing found is reported as the end of the feed. That can end it while
+  // something is still reachable further down — measured, offset 757 found nothing and offset 907
+  // held 13 — so it is a real cost, taken because the alternative is a feed that scrolls forever
+  // and because a reader this deep into a one-type selection can still widen the filter. There is
+  // no third option here: the empty page has to either stop or be retried, and only the client can
+  // do the latter without spinning.
+  let windowAfter = after;
+  let windowOffset = offset;
+  let extraScans = 0;
+  let scanBudgetSpent = false;
+  let page = await fetchWindow(windowAfter);
+  let ordered = orderWindow(page.entities);
+
+  const scanDeadline = Date.now() + MAX_EMPTY_WINDOW_SCAN_MS;
+
+  while (ordered.length <= windowOffset) {
+    // The connection itself says there is nothing further: a genuine end, not a thin patch.
+    if (!page.hasNextPage || !page.endCursor) break;
+    if (extraScans >= MAX_EMPTY_WINDOW_SCANS || Date.now() >= scanDeadline) {
+      scanBudgetSpent = true;
+      break;
+    }
+    extraScans += 1;
+    windowAfter = page.endCursor;
+    // A fresh window is served from its start; the offset only ever indexed the window the
+    // cursor named.
+    windowOffset = 0;
+    page = await fetchWindow(windowAfter);
+    ordered = orderWindow(page.entities);
+  }
 
   // Serving a prefix and advancing the cursor past the whole scan is what dropped ranks
   // 23-30 of every page before (GEO-2695). The offset keeps the rest reachable.
-  const slice = ordered.slice(offset, offset + pageSize);
+  const slice = ordered.slice(windowOffset, windowOffset + pageSize);
 
   return {
     items: await attachMeta(slice),
-    nextCursor: nextExploreWindowCursor({
-      after,
-      offset,
-      served: slice.length,
-      windowLength: ordered.length,
-      hasNextPage: page.hasNextPage,
-      endCursor: page.endCursor,
-    }),
+    nextCursor: scanBudgetSpent
+      ? null
+      : nextExploreWindowCursor({
+          after: windowAfter,
+          offset: windowOffset,
+          served: slice.length,
+          windowLength: ordered.length,
+          hasNextPage: page.hasNextPage,
+          endCursor: page.endCursor,
+        }),
   };
 }

--- a/apps/web/core/explore/fetch-explore-feed.ts
+++ b/apps/web/core/explore/fetch-explore-feed.ts
@@ -18,6 +18,7 @@ import {
   decodeExploreCardEntity,
 } from './explore-card-item';
 import { EXPLORE_ENTITY_NAME_PROPERTY_ID, EXPLORE_PAGE_SIZE } from './explore-constants';
+import { CLAIMS_REQUIRE_DEBATE_TAG_FILTER } from './explore-debate-tag-filter';
 import { EXPLORE_DIVERSITY_WINDOW_SIZE, applyDiversityCap, exploreItemTypeKey } from './explore-diversity';
 import { exploreEntitiesByPropertyConnectionDocument } from './explore-entities-by-property-document';
 import { exploreEntitiesConnectionDocument } from './explore-entities-document';
@@ -130,11 +131,13 @@ function buildFeedFilter(args: {
   time: ExploreTime;
   typeIds?: readonly string[];
   requireName?: boolean;
+  requireDebateTagOnClaims?: boolean;
   includeEntityScopeInFilter?: boolean;
 }): EntityFilter {
   const t = timeThresholdSec(args.time);
   return {
     ...FEED_EXCLUDED_RELATIONS_FILTER,
+    ...(args.requireDebateTagOnClaims ? CLAIMS_REQUIRE_DEBATE_TAG_FILTER : {}),
     ...(args.includeEntityScopeInFilter
       ? {
           spaceIds: { overlaps: [...args.spaceIds] },
@@ -164,6 +167,7 @@ async function fetchExploreEntitiesPage(args: {
   orderBy: EntitiesOrderBy[];
   typeIds?: readonly string[];
   requireName?: boolean;
+  requireDebateTagOnClaims?: boolean;
 }): Promise<ExploreEntitiesPageResponse> {
   return Effect.runPromise(
     graphql({
@@ -190,6 +194,7 @@ async function fetchTopEntitiesPage(args: {
   after: string | null;
   typeIds?: readonly string[];
   requireName?: boolean;
+  requireDebateTagOnClaims?: boolean;
 }): Promise<ExploreEntitiesPageResponse> {
   return Effect.runPromise(
     graphql({
@@ -216,11 +221,16 @@ async function fetchTopEntitiesPage(args: {
 
 // "Best" sort: the Phase A ranked feed via `entitiesRankedForFeedConnection`.
 //
-// Unlike the other two this passes no `filter`. Candidate generation inside
-// `entities_ranked_for_feed` already enforces every clause `buildFeedFilter` builds —
-// name presence, system entities, excluded block types — and takes space, type and
-// recency as its own arguments. See explore-best-document for why sending them twice is
-// not merely redundant.
+// Unlike the other two this sends no `buildFeedFilter`. Candidate generation inside
+// `entities_ranked_for_feed` already enforces every clause it builds — name presence,
+// system entities, excluded block types — and takes space, type and recency as its own
+// arguments. See explore-best-document for why sending them twice is not merely
+// redundant.
+//
+// The debate-tag clause is the one thing that connection does not already know about, so
+// it is the only `filter` this sort ever sends (GEO-2835). It could not be applied to the
+// rows here instead: the tag is not part of the card selection, and a page that dropped
+// most of its claims after the fact would serve short pages and page unevenly.
 //
 // `requireName` is therefore not honoured here: an entity with no name is never a
 // candidate, server-side, and cannot be opted back in. Nothing passes
@@ -234,6 +244,7 @@ async function fetchBestEntitiesPage(args: {
   time: ExploreTime;
   limit: number;
   after: string | null;
+  requireDebateTagOnClaims?: boolean;
 }): Promise<ExploreEntitiesPageResponse> {
   const t = timeThresholdSec(args.time);
   return Effect.runPromise(
@@ -256,6 +267,9 @@ async function fetchBestEntitiesPage(args: {
         // are 1.7x and 2.3x slower with the argument rather than 135x, and they have no
         // equivalent cliff, so New and Top keep filtering server-side where it is exact.
         createdAfter: t != null ? String(t) : undefined,
+        // Left undefined when the caller does not ask for the tag gate, so the sort keeps its
+        // no-filter fast path unless there is a clause the connection genuinely does not know.
+        filter: args.requireDebateTagOnClaims ? CLAIMS_REQUIRE_DEBATE_TAG_FILTER : undefined,
         spaceIdsForLists: args.spaceIds,
       },
     })
@@ -294,6 +308,13 @@ export async function fetchExploreFeed(args: {
   typeIds?: readonly string[];
   /** If true (default), filter out entities with null or empty `name`. */
   requireName?: boolean;
+  /**
+   * If true, a Claim reaches the feed only if it carries the `Debate` tag (GEO-2835). Every other
+   * type is unaffected. Off by default, and off for the one caller that is not Explore: a space's
+   * activity feed is a log of what has been edited there, and a claim nobody has curated yet is
+   * precisely the kind of edit it exists to show.
+   */
+  requireDebateTagOnClaims?: boolean;
 }): Promise<ExploreFeedResult> {
   const spaceMeta = browseSpaceRowsToMap(args.browse);
   const wanted = args.spaceFilterIds === null ? null : new Set(args.spaceFilterIds.map(normId));
@@ -368,6 +389,7 @@ export async function fetchExploreFeed(args: {
           time: args.time,
           limit: windowSize,
           after,
+          requireDebateTagOnClaims: args.requireDebateTagOnClaims,
         })
       : args.sort === 'top'
         ? await fetchTopEntitiesPage({
@@ -377,6 +399,7 @@ export async function fetchExploreFeed(args: {
             after,
             typeIds: args.typeIds,
             requireName: args.requireName,
+            requireDebateTagOnClaims: args.requireDebateTagOnClaims,
           })
         : await fetchExploreEntitiesPage({
             spaceIds: baseIds,
@@ -386,6 +409,7 @@ export async function fetchExploreFeed(args: {
             orderBy: [EntitiesOrderBy.CreatedAtDesc],
             typeIds: args.typeIds,
             requireName: args.requireName,
+            requireDebateTagOnClaims: args.requireDebateTagOnClaims,
           });
 
   const allRows = buildExploreFeedRows(page.entities, allowed, memberOrEditorSet);

--- a/apps/web/partials/feed/entity-feed.tsx
+++ b/apps/web/partials/feed/entity-feed.tsx
@@ -51,6 +51,11 @@ const SORT_OPTIONS: { value: ExploreSort; label: string }[] = [
  * answer mean anything. "Best" is ranked server-side and "New" is ordered by recency already, so a
  * window over either is a filter the viewer never asked for and can't see they have. The dropdown
  * is hidden for those, and the range leaves the request with it.
+ *
+ * There is now a performance reason not to widen this without measuring, on top of the product one:
+ * Explore's debate-tag clause roughly doubles a query that also carries a `createdAt` window, and
+ * Top is unaffected only because its own window happens not to hit that path. See
+ * `explore-debate-tag-filter` for the numbers.
  */
 const SORTS_WITH_TIME_RANGE: readonly ExploreSort[] = ['top'];
 


### PR DESCRIPTION
Closes [GEO-2835](https://linear.app/geobrowser/issue/GEO-2835/explore-only-include-claims-with-the-debate-tag-in-the-feed-query).

Explore's claims are meant to be the debatable ones, but the feed took every claim in the graph. A claim now reaches Explore only if a curator has tagged it `Debate`, **from one of the spaces the feed is already reading**. Every other type is untouched.

### How much this removes

Measured on testnet:

| | |
|---|---|
| Claims in the graph | 326,020 |
| Claims carrying the `Debate` tag | **1,151** |
| Spaces holding a tagged claim | 11 |

A large cut, deliberately — but worth seeing the number before it ships, since it's the answer to the ticket's last note.

### How it's done

One clause, in `explore-debate-tag-filter.ts`, spread into all three sorts:

```
or: [ not a claim,  carries the Debate tag in one of this feed's spaces ]
```

The `or` keeps this a restriction on *claims* — the first branch has to be a negation, or the clause would demand a claim tag of every news story and debate and empty the feed. Both halves match on ids, not display names.

Server-side rather than on the returned rows: at 1,151 in 326,020, a page filtered after the fact would be almost entirely discarded and would page unevenly.

**Best had to start sending a `filter`,** which its own comment argued against. That argument was about `filter` together with `totalCount` — the pair that blew the statement timeout — and this document still requests no `totalCount`. Paging stays exact: the offset cursor runs over the filtered rows (`page1 + page2 == first 132`, verified).

**The gate is a caller's flag, not automatic,** because `fetchExploreFeed` also backs a space's activity feed. That's a log of what's been edited in a space, and an uncurated claim is exactly the edit it exists to show — so only the Explore route passes `requireDebateTagOnClaims: true`. Verified: activity still returns untagged claims.

### Why the tag is space-scoped

Relations carry their own space, independent of the entity's. An unscoped clause accepts a `Tags → Debate` written from *anywhere*, so anyone able to write to a space of their own could put an arbitrary claim in front of every reader, provided it already lived in a space they browse. Scoping closes that, and makes Explore agree with `taggedEntityFilter` in the claims tab, which scopes the same way.

The cost is small and was measured rather than assumed:

| | |
|---|---|
| Tag relations applied from outside the claim's own spaces | **0 of 1,311** |
| Claims admitted over the 11 curating spaces, scoped vs not | **1,308 vs 1,308** |
| A reader narrowed to 3 spaces | loses 4 of 304 |
| A reader narrowed to 1 space | loses 5 of 352 (~1.4%) |

Confirmed with Preston as the intended trade.

### Performance

Paired interleaved A/B through the route — same process, alternating which arm runs first.

| request | with gate | without | delta | gated arm slower |
|---|---|---|---|---|
| `sort=best` (no time param) | 355ms | 376ms | −5.7% | 12/30 |
| `sort=new` (no time param) | 366ms | 367ms | −0.3% | **15/30** |
| `sort=top` × all 5 windows | — | — | within ±9% | 1–7/10 |

15/30 is an exact coin flip. **Caveat worth carrying:** at 10 pairs those same two rows read +15.6% and +29.4%, and both vanished at 30 — don't trust a delta here without enough pairs.

**Where it is not free:** combined with a `createdAt` window the clause roughly doubles the query (`best&time=year` 462→939ms, `new&time=week` 1985→3356ms, each 10/10 pairs). Nothing reaches it — `SORTS_WITH_TIME_RANGE` is `['top']`, so Best and New omit `time` entirely and Top measures clean. Noted on the clause and on that list, since widening it is what would make it bite.

### Review fixes (b8ca7899f)

@ohohoreilly caught a real bug this PR introduced.

**Best + a Claim-only type filter looped on empty pages.** Best can't filter by type in the query (GEO-2793), so it scans a window and filters after. Past the depth where tagged claims thin out, a Claim-only selection matched nothing while the connection still reported another page — 0 claims at offset 600 against 13 ungated. The empty page still carried a cursor, and the client's sentinel has an 8000px rootMargin, so it refired the instant the request settled: an unbounded loop of round trips that get slower with depth. Claim is one of the three default types, so unticking the other two reached it.

The scan now continues inside the request that found the gap, and a spent budget ends the feed rather than offering another page. Invariant restored: **an empty page never carries a cursor**, verified at depths 607–2000 across three type selections.

Bounded by a clock, not a count — and this part is worth reading, because the first fix was worse than the bug:

| | before fix | count budget (6 windows) | clock budget (3s) |
|---|---|---|---|
| worst case at depth | unbounded loop | **81.3s** | **23.1s** |
| empty page with live cursor | yes | no | no |

A window is 0.3–2s near the top of the ranking and 11–12s by offset 300, so a flat count prices it as a constant it isn't. The residual 23s is one deep window plus the single extra scan the clock allows; the ~11.5s per deep window is the ranked connection's own cost and predates this PR.

Regression test in `fetch-explore-feed.test.ts` mocks the graph and drives the loop directly — the scan, the null cursor, the bound, and the genuine end-of-feed case.

### Note for GEO-2702

If the geo-chat union lands, this clause has to apply to both sides — the graph side is covered here, geo-chat's isn't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
