### PR TITLE
feat(debates): point empty matchmaking tabs at debate hours (GEO-2840)

### DIFF
--- a/apps/web/core/debates/debate-hours.test.ts
+++ b/apps/web/core/debates/debate-hours.test.ts
@@ -108,18 +108,26 @@ describe('formatLocalDebateHours', () => {
 });
 
 describe('debateHoursNote', () => {
-  it('tells an outside-hours viewer when to come back, in their own time', () => {
-    expect(debateHoursNote({ isOpen: false, ...range(9, 0, 10, 0), nextTransition: new Date() })).toBe(
+  const closed = { isOpen: false, ...range(9, 0, 10, 0), nextTransition: new Date() };
+  const open = { isOpen: true, ...range(9, 0, 10, 0), nextTransition: new Date() };
+
+  it.each([true, false])('tells an outside-hours viewer when to come back, in their own time (live=%s)', live => {
+    // Nothing is coming for anyone outside the window, so `live` has nothing to change here.
+    expect(debateHoursNote(closed, { live })).toBe(
       'Debate hours are every day between 9-10am. Come back then to join a debate!'
     );
   });
 
-  // The lists live-update off `debate.matchmaking_changed`, so "check back later" would send people
-  // away from the only place the match can happen.
-  it('tells an in-hours viewer to stay', () => {
-    expect(debateHoursNote({ isOpen: true, ...range(9, 0, 10, 0), nextTransition: new Date() })).toBe(
-      'Stay here and you’ll be matched as soon as someone joins.'
-    );
+  // A signed-in list live-updates off `debate.matchmaking_changed`, so "check back later" would
+  // send people away from the only place the match can happen.
+  it('tells an in-hours viewer on a live list to stay', () => {
+    expect(debateHoursNote(open, { live: true })).toBe('Stay here and you’ll be matched as soon as someone joins.');
+  });
+
+  // Signed out on People there is no gateway scope behind the list and no matching to wait for, so
+  // "stay here and you'll be matched" would promise two things that cannot happen.
+  it('tells an in-hours viewer on a static list to check back', () => {
+    expect(debateHoursNote(open, { live: false })).toBe('Check back in a few minutes to find a debate!');
   });
 });
 
@@ -133,11 +141,20 @@ describe('parseDebateHours', () => {
     });
   });
 
-  // A deploy variable is not worth a crashed tab, so every bad shape lands on the default.
-  it.each(['', undefined, 'nonsense', '9-10', '25:00-26:00', '09:00', '09:00-10:00@Not/AZone'])(
-    'falls back to 9-10am Pacific for %j',
-    value => {
-      expect(parseDebateHours(value)).toEqual(PACIFIC_9_TO_10);
-    }
-  );
+  // A deploy variable is not worth a crashed tab, so every bad shape lands on the default. The
+  // trailing three are the ones a lenient parser would accept while quietly dropping the part it
+  // could not use — stating a window nobody chose, which is worse than ignoring the variable.
+  it.each([
+    '',
+    undefined,
+    'nonsense',
+    '9-10',
+    '25:00-26:00',
+    '09:00',
+    '09:00-10:00@Not/AZone',
+    '09:00-10:00-11:00',
+    '09:00-10:00@UTC@typo',
+  ])('falls back to 9-10am Pacific for %j', value => {
+    expect(parseDebateHours(value)).toEqual(PACIFIC_9_TO_10);
+  });
 });

--- a/apps/web/core/debates/debate-hours.test.ts
+++ b/apps/web/core/debates/debate-hours.test.ts
@@ -121,11 +121,11 @@ describe('debateHoursNote', () => {
   // A signed-in list live-updates off `debate.matchmaking_changed`, so "check back later" would
   // send people away from the only place the match can happen.
   it('tells an in-hours viewer on a live list to stay', () => {
-    expect(debateHoursNote(open, { live: true })).toBe('Stay here and you’ll be matched as soon as someone joins.');
+    expect(debateHoursNote(open, { live: true })).toBe('Stay here — this list fills in as people come online.');
   });
 
-  // Signed out on People there is no gateway scope behind the list and no matching to wait for, so
-  // "stay here and you'll be matched" would promise two things that cannot happen.
+  // Signed out on People there is no gateway scope behind the list, so nothing will arrive while
+  // the viewer waits — and they could not be matched from it either.
   it('tells an in-hours viewer on a static list to check back', () => {
     expect(debateHoursNote(open, { live: false })).toBe('Check back in a few minutes to find a debate!');
   });

--- a/apps/web/core/debates/debate-hours.test.ts
+++ b/apps/web/core/debates/debate-hours.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  type DebateHoursConfig,
+  debateHoursNote,
+  debateHoursWindow,
+  formatLocalDebateHours,
+  parseDebateHours,
+} from './debate-hours';
+
+const PACIFIC_9_TO_10: DebateHoursConfig = { timeZone: 'America/Los_Angeles', start: '09:00', end: '10:00' };
+
+/**
+ * `formatLocalDebateHours` reads the *runtime's* zone, because that is what "the viewer's local
+ * time" means — and the suite sets no `TZ`, so an assertion pinned to a UTC instant would come out
+ * differently on every machine. Building the range from local-field `Date`s instead makes these
+ * cases say what they mean whatever zone they run in: the formatter reads back the same wall clock
+ * that went in.
+ */
+function range(startHour: number, startMinute: number, endHour: number, endMinute: number) {
+  const start = new Date(2026, 8, 8, startHour, startMinute);
+  const end = new Date(2026, 8, 8, endHour, endMinute);
+  return { start, end };
+}
+
+describe('debateHoursWindow', () => {
+  it('is open from the start of the window, inclusive', () => {
+    // 2026-09-08 is PDT, UTC-7, so 09:00 PT is 16:00Z.
+    const window = debateHoursWindow(new Date('2026-09-08T16:00:00Z'), PACIFIC_9_TO_10);
+
+    expect(window.isOpen).toBe(true);
+    expect(window.start.toISOString()).toBe('2026-09-08T16:00:00.000Z');
+    // While open, the next flip is the window closing.
+    expect(window.nextTransition.toISOString()).toBe('2026-09-08T17:00:00.000Z');
+  });
+
+  it('is closed one minute before the window opens, and points at that opening', () => {
+    const window = debateHoursWindow(new Date('2026-09-08T15:59:00Z'), PACIFIC_9_TO_10);
+
+    expect(window.isOpen).toBe(false);
+    expect(window.nextTransition.toISOString()).toBe('2026-09-08T16:00:00.000Z');
+  });
+
+  it('is closed at the end of the window, exclusive, and rolls to tomorrow', () => {
+    const window = debateHoursWindow(new Date('2026-09-08T17:00:00Z'), PACIFIC_9_TO_10);
+
+    expect(window.isOpen).toBe(false);
+    expect(window.start.toISOString()).toBe('2026-09-09T16:00:00.000Z');
+    expect(window.nextTransition.toISOString()).toBe('2026-09-09T16:00:00.000Z');
+  });
+
+  // The whole reason the offset is not stored: the US leaves daylight saving on 2026-11-01, so the
+  // same 09:00 PT window is 16:00Z the week before and 17:00Z the week after.
+  it('tracks Pacific daylight saving across the November transition', () => {
+    // Oct 30, 07:00 PDT — the window opens two hours later, still on daylight time.
+    const beforeFallBack = debateHoursWindow(new Date('2026-10-30T14:00:00Z'), PACIFIC_9_TO_10);
+    // Nov 2, 12:00 PST — the next window is Nov 3, on standard time.
+    const afterFallBack = debateHoursWindow(new Date('2026-11-02T20:00:00Z'), PACIFIC_9_TO_10);
+
+    expect(beforeFallBack.start.toISOString()).toBe('2026-10-30T16:00:00.000Z');
+    expect(afterFallBack.start.toISOString()).toBe('2026-11-03T17:00:00.000Z');
+  });
+
+  // A viewer far enough east is inside a window that started on the previous Pacific calendar day,
+  // which is only found by looking back a day as well as forward.
+  it('finds the open window when it began on the previous day in Pacific', () => {
+    // 22:00-23:00 PT on the 8th is 05:00-06:00Z on the 9th.
+    const overnight: DebateHoursConfig = { timeZone: 'America/Los_Angeles', start: '22:00', end: '23:00' };
+    const window = debateHoursWindow(new Date('2026-09-09T05:30:00Z'), overnight);
+
+    expect(window.isOpen).toBe(true);
+    expect(window.start.toISOString()).toBe('2026-09-09T05:00:00.000Z');
+  });
+
+  it('closes a configured window that crosses midnight in its own zone on the following day', () => {
+    const acrossMidnight: DebateHoursConfig = { timeZone: 'America/Los_Angeles', start: '23:00', end: '01:00' };
+    const window = debateHoursWindow(new Date('2026-09-09T07:00:00Z'), acrossMidnight);
+
+    // 23:00 PT on the 8th → 06:00Z on the 9th; 01:00 PT on the 9th → 08:00Z.
+    expect(window.isOpen).toBe(true);
+    expect(window.start.toISOString()).toBe('2026-09-09T06:00:00.000Z');
+    expect(window.end.toISOString()).toBe('2026-09-09T08:00:00.000Z');
+  });
+});
+
+describe('formatLocalDebateHours', () => {
+  it('drops the leading meridiem when both ends share one', () => {
+    expect(formatLocalDebateHours(range(9, 0, 10, 0))).toBe('9-10am');
+    expect(formatLocalDebateHours(range(17, 0, 18, 0))).toBe('5-6pm');
+  });
+
+  it('keeps both meridiems when the window crosses noon or midnight', () => {
+    expect(formatLocalDebateHours(range(11, 0, 12, 0))).toBe('11am-12pm');
+    expect(formatLocalDebateHours(range(23, 0, 0, 0))).toBe('11pm-12am');
+  });
+
+  // The overnight case GEO-2840 asks about: a Tokyo viewer sees 1-2am, which is as true every day
+  // as 9-10am is in Pacific, so it carries no day name.
+  it('reads sensibly overnight', () => {
+    expect(formatLocalDebateHours(range(1, 0, 2, 0))).toBe('1-2am');
+    expect(formatLocalDebateHours(range(2, 0, 3, 0))).toBe('2-3am');
+  });
+
+  it('shows minutes only when there are any', () => {
+    expect(formatLocalDebateHours(range(9, 30, 10, 15))).toBe('9:30-10:15am');
+    expect(formatLocalDebateHours(range(12, 0, 13, 0))).toBe('12-1pm');
+  });
+});
+
+describe('debateHoursNote', () => {
+  it('tells an outside-hours viewer when to come back, in their own time', () => {
+    expect(debateHoursNote({ isOpen: false, ...range(9, 0, 10, 0), nextTransition: new Date() })).toBe(
+      'Debate hours are every day between 9-10am. Come back then to join a debate!'
+    );
+  });
+
+  // The lists live-update off `debate.matchmaking_changed`, so "check back later" would send people
+  // away from the only place the match can happen.
+  it('tells an in-hours viewer to stay', () => {
+    expect(debateHoursNote({ isOpen: true, ...range(9, 0, 10, 0), nextTransition: new Date() })).toBe(
+      'Stay here and you’ll be matched as soon as someone joins.'
+    );
+  });
+});
+
+describe('parseDebateHours', () => {
+  it('reads a range, with and without a zone', () => {
+    expect(parseDebateHours('09:00-10:00')).toEqual(PACIFIC_9_TO_10);
+    expect(parseDebateHours('18:00-19:30@Europe/London')).toEqual({
+      timeZone: 'Europe/London',
+      start: '18:00',
+      end: '19:30',
+    });
+  });
+
+  // A deploy variable is not worth a crashed tab, so every bad shape lands on the default.
+  it.each(['', undefined, 'nonsense', '9-10', '25:00-26:00', '09:00', '09:00-10:00@Not/AZone'])(
+    'falls back to 9-10am Pacific for %j',
+    value => {
+      expect(parseDebateHours(value)).toEqual(PACIFIC_9_TO_10);
+    }
+  );
+});

--- a/apps/web/core/debates/debate-hours.ts
+++ b/apps/web/core/debates/debate-hours.ts
@@ -38,9 +38,19 @@ const WALL_CLOCK = /^([01]\d|2[0-3]):([0-5]\d)$/;
 export function parseDebateHours(value: string | undefined): DebateHoursConfig {
   if (!value) return DEFAULT_DEBATE_HOURS;
 
-  const [range, zone] = value.trim().split('@');
-  const [start, end] = (range ?? '').split('-');
-  if (!WALL_CLOCK.test(start ?? '') || !WALL_CLOCK.test(end ?? '')) return DEFAULT_DEBATE_HOURS;
+  // Counted rather than destructured. Destructuring takes the first two parts and drops the rest,
+  // so `09:00-10:00-11:00` and `09:00-10:00@UTC@typo` would both parse as something the author did
+  // not write — which is worse than ignoring them, because the tab would then state a window
+  // nobody chose. Every extra separator is a typo, and a typo falls back like any other.
+  const parts = value.trim().split('@');
+  if (parts.length > 2) return DEFAULT_DEBATE_HOURS;
+
+  const [range, zone] = parts;
+  const bounds = (range ?? '').split('-');
+  if (bounds.length !== 2) return DEFAULT_DEBATE_HOURS;
+
+  const [start, end] = bounds;
+  if (!WALL_CLOCK.test(start) || !WALL_CLOCK.test(end)) return DEFAULT_DEBATE_HOURS;
 
   const timeZone = zone?.trim() || DEFAULT_DEBATE_HOURS.timeZone;
   // A bad zone only fails when it reaches Intl, which is at render time in a tab, so prove it here.
@@ -152,13 +162,19 @@ export function formatLocalDebateHours({ start, end }: Pick<DebateHoursWindow, '
  * The line added beneath a tab's own empty message.
  *
  * A second sentence rather than a replacement: two of the three tabs already open by saying nobody
- * is around, so the during-hours variant contributes only what they don't say — that the list fills
- * itself in, and that leaving is the one thing that won't help. The lists do live-update, from
- * `debate.matchmaking_changed`, which is what makes "stay here" the honest instruction rather than
- * the ticket's original "check back in a few minutes".
+ * is around, so the during-hours variant contributes only what they don't say.
+ *
+ * What it has to say depends on whether the list behind it updates itself — `live`. Signed in it
+ * does, off `debate.matchmaking_changed`, so "stay here" is the honest instruction and the ticket's
+ * original "check back" would send viewers away from the one place the match can happen. Signed
+ * out there is no socket to carry that, and no matching either, so the same sentence would promise
+ * twice over what the page cannot deliver — that viewer gets the ticket's original.
  */
-export function debateHoursNote(window: DebateHoursWindow) {
-  return window.isOpen
+export function debateHoursNote(window: DebateHoursWindow, { live }: { live: boolean }) {
+  if (!window.isOpen) {
+    return `Debate hours are every day between ${formatLocalDebateHours(window)}. Come back then to join a debate!`;
+  }
+  return live
     ? 'Stay here and you’ll be matched as soon as someone joins.'
-    : `Debate hours are every day between ${formatLocalDebateHours(window)}. Come back then to join a debate!`;
+    : 'Check back in a few minutes to find a debate!';
 }

--- a/apps/web/core/debates/debate-hours.ts
+++ b/apps/web/core/debates/debate-hours.ts
@@ -1,0 +1,157 @@
+/**
+ * The daily window when debates actually happen, and the copy that points people at it.
+ *
+ * Pure and React-free so the arithmetic can be tested against fixed instants and fixed zones —
+ * `use-debate-hours` owns the ticking and the "what time is it" part.
+ */
+import { fromZonedTime } from 'date-fns-tz';
+
+export type DebateHoursConfig = {
+  /**
+   * The zone the window is *defined* in. The window is a fixed hour in Pacific, so its local
+   * equivalent moves twice a year with US daylight saving — and moves independently again for
+   * viewers whose own region changes on different dates. Converting from this zone at render time
+   * is what keeps that correct; a stored offset would be wrong for weeks at a stretch.
+   */
+  timeZone: string;
+  /** 24-hour wall-clock times in `timeZone`, `HH:mm`. */
+  start: string;
+  end: string;
+};
+
+const DEFAULT_DEBATE_HOURS: DebateHoursConfig = {
+  timeZone: 'America/Los_Angeles',
+  start: '09:00',
+  end: '10:00',
+};
+
+const WALL_CLOCK = /^([01]\d|2[0-3]):([0-5]\d)$/;
+
+/**
+ * `NEXT_PUBLIC_DEBATE_HOURS`, as `start-end` or `start-end@zone` — e.g. `09:00-10:00` or
+ * `18:00-19:00@Europe/London`.
+ *
+ * Anything unparseable falls back to the default rather than throwing: the window is the subject of
+ * an empty-state sentence, and a typo in a deploy variable should not take a tab down with it.
+ */
+export function parseDebateHours(value: string | undefined): DebateHoursConfig {
+  if (!value) return DEFAULT_DEBATE_HOURS;
+
+  const [range, zone] = value.trim().split('@');
+  const [start, end] = (range ?? '').split('-');
+  if (!WALL_CLOCK.test(start ?? '') || !WALL_CLOCK.test(end ?? '')) return DEFAULT_DEBATE_HOURS;
+
+  const timeZone = zone?.trim() || DEFAULT_DEBATE_HOURS.timeZone;
+  // A bad zone only fails when it reaches Intl, which is at render time in a tab, so prove it here.
+  try {
+    new Intl.DateTimeFormat('en-US', { timeZone });
+  } catch {
+    return DEFAULT_DEBATE_HOURS;
+  }
+
+  return { timeZone, start, end };
+}
+
+export const DEBATE_HOURS = parseDebateHours(process.env.NEXT_PUBLIC_DEBATE_HOURS);
+
+export type DebateHoursWindow = {
+  /** Whether `now` falls inside the window: start inclusive, end exclusive. */
+  isOpen: boolean;
+  /** The window in progress when open, otherwise the next one to come. */
+  start: Date;
+  end: Date;
+  /**
+   * When the answer to `isOpen` changes — the end of the window in progress, or the start of the
+   * next one. What the hook schedules its re-render on, so the copy flips without a refresh.
+   */
+  nextTransition: Date;
+};
+
+/** The calendar day `instant` falls on *in `timeZone`*, as `yyyy-MM-dd`. */
+function zonedDay(instant: Date, timeZone: string, dayOffset = 0) {
+  // `en-CA` is ISO-ordered, so this needs no part reassembly.
+  const day = new Intl.DateTimeFormat('en-CA', {
+    timeZone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(instant);
+
+  if (dayOffset === 0) return day;
+  // Stepped as UTC midnight so the offset is pure calendar arithmetic — this is a date, not an
+  // instant, so no zone applies to it and DST cannot make the day come out short.
+  const stepped = new Date(`${day}T00:00:00Z`);
+  stepped.setUTCDate(stepped.getUTCDate() + dayOffset);
+  return stepped.toISOString().slice(0, 10);
+}
+
+/** The instant a `HH:mm` wall-clock time on `day` in `timeZone` actually happens at. */
+function instantAt(day: string, wallClock: string, timeZone: string) {
+  return fromZonedTime(`${day}T${wallClock}:00`, timeZone);
+}
+
+function windowOn(day: string, config: DebateHoursConfig) {
+  const start = instantAt(day, config.start, config.timeZone);
+  let end = instantAt(day, config.end, config.timeZone);
+  // An end at or before the start means the window runs past midnight in its own zone, so it closes
+  // on the following day. `09:00-10:00` never does; a configured `22:00-01:00` would.
+  if (end.getTime() <= start.getTime()) {
+    end = instantAt(zonedDay(start, config.timeZone, 1), config.end, config.timeZone);
+  }
+  return { start, end };
+}
+
+/**
+ * Where `now` sits relative to the window, and when that changes.
+ *
+ * Yesterday's window is considered as well as today's: for a viewer far enough east, the window
+ * that is open right now started on the previous calendar day back in Pacific.
+ */
+export function debateHoursWindow(now: Date, config: DebateHoursConfig = DEBATE_HOURS): DebateHoursWindow {
+  const candidates = [-1, 0, 1].map(offset => windowOn(zonedDay(now, config.timeZone, offset), config));
+
+  const open = candidates.find(({ start, end }) => now >= start && now < end);
+  if (open) return { isOpen: true, start: open.start, end: open.end, nextTransition: open.end };
+
+  // The first window that has not started yet. `candidates` is in ascending order by construction.
+  const next = candidates.find(({ start }) => start > now) ?? candidates[candidates.length - 1];
+  return { isOpen: false, start: next.start, end: next.end, nextTransition: next.start };
+}
+
+function clockLabel(date: Date, withMeridiem: boolean) {
+  const hours = date.getHours();
+  const minutes = date.getMinutes();
+  const hour12 = hours % 12 === 0 ? 12 : hours % 12;
+  const minuteLabel = minutes === 0 ? '' : `:${String(minutes).padStart(2, '0')}`;
+  return `${hour12}${minuteLabel}${withMeridiem ? (hours < 12 ? 'am' : 'pm') : ''}`;
+}
+
+/**
+ * The window in the viewer's own local time, e.g. `9-10am`, `11am-12pm`, `2-3am`.
+ *
+ * The leading meridiem is dropped when both ends share one, which is what makes the common case
+ * read as the single span it is rather than as two separate times.
+ *
+ * Deliberately unqualified by day. The window recurs every 24 hours, so it recurs every day in the
+ * viewer's zone too even when it lands overnight — a Tokyo viewer's `1-2am` is as true daily as a
+ * London viewer's `5-6pm`, and naming a day would imply the wrong thing about both.
+ */
+export function formatLocalDebateHours({ start, end }: Pick<DebateHoursWindow, 'start' | 'end'>) {
+  const sameMeridiem = start.getHours() < 12 === end.getHours() < 12;
+  return `${clockLabel(start, !sameMeridiem)}-${clockLabel(end, true)}`;
+}
+
+/**
+ * The line added beneath a tab's own empty message.
+ *
+ * A second sentence rather than a replacement: two of the three tabs already open by saying nobody
+ * is around, so the during-hours variant contributes only what they don't say — that the list fills
+ * itself in, and that leaving is the one thing that won't help. The lists do live-update, from
+ * `debate.matchmaking_changed`, which is what makes "stay here" the honest instruction rather than
+ * the ticket's original "check back in a few minutes".
+ */
+export function debateHoursNote(window: DebateHoursWindow) {
+  return window.isOpen
+    ? 'Stay here and you’ll be matched as soon as someone joins.'
+    : `Debate hours are every day between ${formatLocalDebateHours(window)}. Come back then to join a debate!`;
+}

--- a/apps/web/core/debates/debate-hours.ts
+++ b/apps/web/core/debates/debate-hours.ts
@@ -80,13 +80,20 @@ export type DebateHoursWindow = {
 
 /** The calendar day `instant` falls on *in `timeZone`*, as `yyyy-MM-dd`. */
 function zonedDay(instant: Date, timeZone: string, dayOffset = 0) {
-  // `en-CA` is ISO-ordered, so this needs no part reassembly.
-  const day = new Intl.DateTimeFormat('en-CA', {
+  // Assembled from parts rather than read off a formatted string. Field order and separators are
+  // locale data, not an API guarantee — and a runtime built against a trimmed ICU serves en-US for
+  // every locale asked of it, so an `en-CA` format call can hand back `09/08/2026`. That string
+  // reaches `fromZonedTime` and comes out an Invalid Date, which would take out the note and its
+  // timer for a configuration that is perfectly valid. Parts are keyed by type, so neither matters.
+  const parts = new Intl.DateTimeFormat('en-US', {
     timeZone,
     year: 'numeric',
     month: '2-digit',
     day: '2-digit',
-  }).format(instant);
+  }).formatToParts(instant);
+
+  const partValue = (type: Intl.DateTimeFormatPartTypes) => parts.find(part => part.type === type)?.value ?? '';
+  const day = `${partValue('year').padStart(4, '0')}-${partValue('month')}-${partValue('day')}`;
 
   if (dayOffset === 0) return day;
   // Stepped as UTC midnight so the offset is pure calendar arithmetic — this is a date, not an
@@ -169,12 +176,18 @@ export function formatLocalDebateHours({ start, end }: Pick<DebateHoursWindow, '
  * original "check back" would send viewers away from the one place the match can happen. Signed
  * out there is no socket to carry that, and no matching either, so the same sentence would promise
  * twice over what the page cannot deliver — that viewer gets the ticket's original.
+ *
+ * The live line promises the *list* will fill, not that the viewer will be matched. The ticket
+ * sketched "you'll be matched as soon as someone joins", which is not true on Matches: that
+ * endpoint answers only once the viewer holds a position too, so a viewer with none could watch
+ * the whole hour go by without a row appearing, however many people came online. What every tab
+ * can promise is the one thing `debate.matchmaking_changed` actually delivers.
  */
 export function debateHoursNote(window: DebateHoursWindow, { live }: { live: boolean }) {
   if (!window.isOpen) {
     return `Debate hours are every day between ${formatLocalDebateHours(window)}. Come back then to join a debate!`;
   }
   return live
-    ? 'Stay here and you’ll be matched as soon as someone joins.'
+    ? 'Stay here — this list fills in as people come online.'
     : 'Check back in a few minutes to find a debate!';
 }

--- a/apps/web/core/debates/debate-hours.ts
+++ b/apps/web/core/debates/debate-hours.ts
@@ -2,8 +2,9 @@
  * The daily window when debates actually happen, and the copy that points people at it.
  *
  * Pure and React-free so the arithmetic can be tested against fixed instants and fixed zones —
- * `use-debate-hours` owns the ticking and the "what time is it" part.
+ * `matchmaking/debate-hours-note` owns the ticking and the "what time is it" part.
  */
+import { format } from 'date-fns';
 import { fromZonedTime } from 'date-fns-tz';
 
 export type DebateHoursConfig = {
@@ -118,12 +119,18 @@ export function debateHoursWindow(now: Date, config: DebateHoursConfig = DEBATE_
   return { isOpen: false, start: next.start, end: next.end, nextTransition: next.start };
 }
 
+/**
+ * A local wall-clock time, in the `h:mmaaa` shape the rest of the app formats times in — see
+ * `DEFAULT_TIME_FORMAT` and `formatGovernanceOutcomeTime`.
+ *
+ * Two departures from that constant, both for reading a *range* rather than a timestamp: a whole
+ * hour drops its `:00`, and the opening end drops its meridiem when the closing end already carries
+ * the same one. `format` runs in the runtime's zone, which is what makes the output the viewer's
+ * own local time.
+ */
 function clockLabel(date: Date, withMeridiem: boolean) {
-  const hours = date.getHours();
-  const minutes = date.getMinutes();
-  const hour12 = hours % 12 === 0 ? 12 : hours % 12;
-  const minuteLabel = minutes === 0 ? '' : `:${String(minutes).padStart(2, '0')}`;
-  return `${hour12}${minuteLabel}${withMeridiem ? (hours < 12 ? 'am' : 'pm') : ''}`;
+  const hour = date.getMinutes() === 0 ? 'h' : 'h:mm';
+  return format(date, withMeridiem ? `${hour}aaa` : hour);
 }
 
 /**

--- a/apps/web/core/debates/matchmaking/claims-tab.test.tsx
+++ b/apps/web/core/debates/matchmaking/claims-tab.test.tsx
@@ -1662,12 +1662,12 @@ describe('All claims reads the Debate tag', () => {
     render(<ClaimsTab />);
 
     await showAllClaims();
-    expect(screen.queryByText(/Debate hours are every day between|Stay here and you/)).toBeNull();
+    expect(screen.queryByText(/Debate hours are every day between|Stay here —/)).toBeNull();
 
     chooseFilter('All claims', 'Debate now');
 
     expect(await screen.findByText('Nobody is ready to debate you on a claim right now.')).toBeInTheDocument();
-    expect(screen.getByText(/Debate hours are every day between|Stay here and you/)).toBeInTheDocument();
+    expect(screen.getByText(/Debate hours are every day between|Stay here —/)).toBeInTheDocument();
   });
 });
 

--- a/apps/web/core/debates/matchmaking/claims-tab.test.tsx
+++ b/apps/web/core/debates/matchmaking/claims-tab.test.tsx
@@ -1652,6 +1652,23 @@ describe('All claims reads the Debate tag', () => {
 
     expect(screen.getByText('No claims have been tagged for debate yet.')).toBeInTheDocument();
   });
+
+  // GEO-2840. "Debate now" is the only filter on this tab scored on who is online, so it is the
+  // only one whose empty list means "nobody is around" — the other three are statements about
+  // curation or about the viewer's own positions, and debate hours would not explain any of them.
+  it('adds the debate hours line under Debate now, and not under All claims', async () => {
+    mocks.taggedClaims[DEBATE_TAG] = [];
+    mocks.claims = [];
+    render(<ClaimsTab />);
+
+    await showAllClaims();
+    expect(screen.queryByText(/Debate hours are every day between|Stay here and you/)).toBeNull();
+
+    chooseFilter('All claims', 'Debate now');
+
+    expect(await screen.findByText('Nobody is ready to debate you on a claim right now.')).toBeInTheDocument();
+    expect(screen.getByText(/Debate hours are every day between|Stay here and you/)).toBeInTheDocument();
+  });
 });
 
 // GEO-2653. The menu is the server's topic facet, which describes every claim the current

--- a/apps/web/core/debates/matchmaking/claims-tab.tsx
+++ b/apps/web/core/debates/matchmaking/claims-tab.tsx
@@ -37,6 +37,7 @@ import {
 } from '../tagged-claims';
 import { useClaimSpaceAllowlist } from '../use-claim-space-allowlist';
 import { isSpaceDebatePublishable, useDebatePublishableSpaces } from '../use-debate-publishable-spaces';
+import { DebateHoursNote } from './debate-hours-note';
 import { useDebateRequests } from './hooks';
 import { HubFilterMenu, type HubFilterOption, HubMultiFilterMenu, pickerLabel } from './hub-filter-menu';
 import { HubCardList } from './hub-motion';
@@ -654,6 +655,12 @@ export function ClaimsTab() {
                 : 'No claims match these filters.'
               : NOTHING_HERE[filter]
           }
+          // "Debate now" is the only filter here scored on who is online, so it is the only one an
+          // empty list means "nobody is around" for — Featured and All claims are statements about
+          // curation, and My positions is about the viewer. Withheld under a narrowing filter for
+          // the same reason it is on the other tabs: that emptiness has a different cause
+          // (GEO-2840).
+          emptyNote={filter === 'debate_now' && !hasNarrowingFilters ? <DebateHoursNote /> : undefined}
           emptyAction={
             hasFilters
               ? {

--- a/apps/web/core/debates/matchmaking/claims-tab.tsx
+++ b/apps/web/core/debates/matchmaking/claims-tab.tsx
@@ -660,7 +660,9 @@ export function ClaimsTab() {
           // curation, and My positions is about the viewer. Withheld under a narrowing filter for
           // the same reason it is on the other tabs: that emptiness has a different cause
           // (GEO-2840).
-          emptyNote={filter === 'debate_now' && !hasNarrowingFilters ? <DebateHoursNote /> : undefined}
+          // `live` unconditionally: `SIGNED_OUT_HIDDEN_FILTERS` takes "Debate now" out of the menu
+          // signed out, so reaching this note at all means holding the gateway scope.
+          emptyNote={filter === 'debate_now' && !hasNarrowingFilters ? <DebateHoursNote live /> : undefined}
           emptyAction={
             hasFilters
               ? {

--- a/apps/web/core/debates/matchmaking/debate-hours-note.test.tsx
+++ b/apps/web/core/debates/matchmaking/debate-hours-note.test.tsx
@@ -50,12 +50,11 @@ describe('DebateHoursNote', () => {
   it('tells a viewer inside the window to stay', () => {
     renderAt('2026-09-08T16:30:00Z');
 
-    expect(screen.getByText('Stay here and you’ll be matched as soon as someone joins.')).toBeTruthy();
+    expect(screen.getByText('Stay here — this list fills in as people come online.')).toBeTruthy();
   });
 
   // Signed out on People there is no gateway scope, so the list will not fill itself in while the
-  // viewer waits — and they could not be matched from it anyway. Asking them to stay would promise
-  // both.
+  // viewer waits. "Stay here" would promise exactly the thing that cannot happen.
   it('tells a viewer whose list does not update itself to check back instead', () => {
     renderAt('2026-09-08T16:30:00Z', { live: false });
 
@@ -83,7 +82,7 @@ describe('DebateHoursNote', () => {
     });
 
     expect(screen.queryByText(/Come back then/)).toBeNull();
-    expect(screen.getByText('Stay here and you’ll be matched as soon as someone joins.')).toBeTruthy();
+    expect(screen.getByText('Stay here — this list fills in as people come online.')).toBeTruthy();
   });
 
   it('flips back when the window closes', () => {

--- a/apps/web/core/debates/matchmaking/debate-hours-note.test.tsx
+++ b/apps/web/core/debates/matchmaking/debate-hours-note.test.tsx
@@ -22,14 +22,18 @@ beforeEach(() => {
 afterEach(() => {
   cleanup();
   vi.useRealTimers();
-  process.env.TZ = originalTimeZone;
+  // Deleted rather than assigned back when there was nothing to restore: `process.env.TZ = undefined`
+  // stores the *string* `"undefined"`, which is not a zone, and leaves the process running in the
+  // UTC fallback for anything that shares it.
+  if (originalTimeZone === undefined) delete process.env.TZ;
+  else process.env.TZ = originalTimeZone;
 });
 
-function renderAt(iso: string) {
+function renderAt(iso: string, { live = true }: { live?: boolean } = {}) {
   vi.setSystemTime(new Date(iso));
   // The note renders nothing until its mount effect has run, so flush it the way the browser would.
   act(() => {
-    render(<DebateHoursNote />);
+    render(<DebateHoursNote live={live} />);
   });
 }
 
@@ -47,6 +51,25 @@ describe('DebateHoursNote', () => {
     renderAt('2026-09-08T16:30:00Z');
 
     expect(screen.getByText('Stay here and you’ll be matched as soon as someone joins.')).toBeTruthy();
+  });
+
+  // Signed out on People there is no gateway scope, so the list will not fill itself in while the
+  // viewer waits — and they could not be matched from it anyway. Asking them to stay would promise
+  // both.
+  it('tells a viewer whose list does not update itself to check back instead', () => {
+    renderAt('2026-09-08T16:30:00Z', { live: false });
+
+    expect(screen.getByText('Check back in a few minutes to find a debate!')).toBeTruthy();
+    expect(screen.queryByText(/Stay here/)).toBeNull();
+  });
+
+  // Outside the window nothing is coming for anyone, so both viewers get the same answer.
+  it('gives the same outside-hours line either way', () => {
+    renderAt('2026-09-08T15:00:00Z', { live: false });
+
+    expect(
+      screen.getByText('Debate hours are every day between 9-10am. Come back then to join a debate!')
+    ).toBeTruthy();
   });
 
   // The boundary requirement: 8:59 shows one variant and 9:00 the other, with no refresh in between.

--- a/apps/web/core/debates/matchmaking/debate-hours-note.test.tsx
+++ b/apps/web/core/debates/matchmaking/debate-hours-note.test.tsx
@@ -1,0 +1,101 @@
+import { act, cleanup, render, screen } from '@testing-library/react';
+
+import * as React from 'react';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { DebateHoursNote } from './debate-hours-note';
+
+/**
+ * Pinned to Pacific so "9-10am local" is a fact rather than a coincidence of the machine running
+ * the suite — the copy is the same shape everywhere, but only here can it be asserted literally.
+ * `TZ` has to be set before jsdom's `Date` is first used for the process to honour it, which is why
+ * every case reaches for it through the shared setup below.
+ */
+const originalTimeZone = process.env.TZ;
+
+beforeEach(() => {
+  process.env.TZ = 'America/Los_Angeles';
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+  process.env.TZ = originalTimeZone;
+});
+
+function renderAt(iso: string) {
+  vi.setSystemTime(new Date(iso));
+  // The note renders nothing until its mount effect has run, so flush it the way the browser would.
+  act(() => {
+    render(<DebateHoursNote />);
+  });
+}
+
+describe('DebateHoursNote', () => {
+  it('points an outside-hours viewer at the window in their own local time', () => {
+    // 15:00Z is 08:00 PDT — an hour before the window opens.
+    renderAt('2026-09-08T15:00:00Z');
+
+    expect(
+      screen.getByText('Debate hours are every day between 9-10am. Come back then to join a debate!')
+    ).toBeTruthy();
+  });
+
+  it('tells a viewer inside the window to stay', () => {
+    renderAt('2026-09-08T16:30:00Z');
+
+    expect(screen.getByText('Stay here and you’ll be matched as soon as someone joins.')).toBeTruthy();
+  });
+
+  // The boundary requirement: 8:59 shows one variant and 9:00 the other, with no refresh in between.
+  it('flips at the start of the window without being re-rendered', () => {
+    renderAt('2026-09-08T15:59:00Z');
+    expect(screen.getByText(/Come back then/)).toBeTruthy();
+
+    act(() => {
+      vi.advanceTimersByTime(61_000 + 1_000);
+    });
+
+    expect(screen.queryByText(/Come back then/)).toBeNull();
+    expect(screen.getByText('Stay here and you’ll be matched as soon as someone joins.')).toBeTruthy();
+  });
+
+  it('flips back when the window closes', () => {
+    renderAt('2026-09-08T16:59:00Z');
+    expect(screen.getByText(/Stay here/)).toBeTruthy();
+
+    act(() => {
+      vi.advanceTimersByTime(61_000 + 1_000);
+    });
+
+    expect(screen.getByText(/Come back then/)).toBeTruthy();
+  });
+
+  // A throttled or sleeping tab can miss its callback entirely, so returning to the tab has to be
+  // enough on its own.
+  it('re-reads the clock when the tab becomes visible again', () => {
+    renderAt('2026-09-08T15:59:00Z');
+    expect(screen.getByText(/Come back then/)).toBeTruthy();
+
+    act(() => {
+      // Time moved on without the timer firing, which is what a sleeping machine looks like.
+      vi.setSystemTime(new Date('2026-09-08T16:30:00Z'));
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+
+    expect(screen.getByText(/Stay here/)).toBeTruthy();
+  });
+
+  it('stops its timer when unmounted', () => {
+    renderAt('2026-09-08T15:59:00Z');
+    const clearTimeoutSpy = vi.spyOn(globalThis, 'clearTimeout');
+
+    act(() => {
+      cleanup();
+    });
+
+    expect(clearTimeoutSpy).toHaveBeenCalled();
+  });
+});

--- a/apps/web/core/debates/matchmaking/debate-hours-note.test.tsx
+++ b/apps/web/core/debates/matchmaking/debate-hours-note.test.tsx
@@ -78,7 +78,8 @@ describe('DebateHoursNote', () => {
     expect(screen.getByText(/Come back then/)).toBeTruthy();
 
     act(() => {
-      vi.advanceTimersByTime(61_000 + 1_000);
+      // Just past the boundary, not a second past it: the flip has to be effectively immediate.
+      vi.advanceTimersByTime(60_000 + 100);
     });
 
     expect(screen.queryByText(/Come back then/)).toBeNull();
@@ -90,7 +91,8 @@ describe('DebateHoursNote', () => {
     expect(screen.getByText(/Stay here/)).toBeTruthy();
 
     act(() => {
-      vi.advanceTimersByTime(61_000 + 1_000);
+      // Just past the boundary, not a second past it: the flip has to be effectively immediate.
+      vi.advanceTimersByTime(60_000 + 100);
     });
 
     expect(screen.getByText(/Come back then/)).toBeTruthy();

--- a/apps/web/core/debates/matchmaking/debate-hours-note.tsx
+++ b/apps/web/core/debates/matchmaking/debate-hours-note.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import * as React from 'react';
+
+import { debateHoursNote, debateHoursWindow } from '../debate-hours';
+
+/**
+ * "Debate hours are every day between 5-6pm…" / "Stay here and you'll be matched…", under a hub
+ * tab's own empty message.
+ *
+ * A component rather than a string the tab computes, for two reasons. It only mounts while an
+ * empty state is on screen, so the timer below exists only when something depends on it. And the
+ * ticking re-render lands here instead of on the tab, which is holding a query, a filter set and a
+ * list order that have no interest in the clock.
+ *
+ * Rendered by the caller only when the list is empty *because nobody is online* — a list emptied by
+ * the viewer's own filters is a different problem with a different answer, and GEO-2840 explicitly
+ * leaves it alone.
+ */
+export function DebateHoursNote() {
+  const now = useTickingNow();
+  // Null until mounted. The window is expressed in the viewer's local zone, which the server does
+  // not have and cannot guess, so rendering it during SSR would hydrate as a mismatch.
+  if (!now) return null;
+  return <>{debateHoursNote(debateHoursWindow(now))}</>;
+}
+
+/**
+ * `now`, re-read each time the open/closed answer changes.
+ *
+ * Scheduled to the boundary rather than polled: the copy has to flip at 9:00 without a refresh, and
+ * a window that opens once a day does not need a heartbeat for the other 23 hours to find that out.
+ */
+function useTickingNow() {
+  const [now, setNow] = React.useState<Date | null>(null);
+
+  React.useEffect(() => {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    const tick = () => {
+      const current = new Date();
+      setNow(current);
+      const { nextTransition } = debateHoursWindow(current);
+      // Aimed just past the boundary. A timer that fires a millisecond early would recompute the
+      // same side of it and reschedule for ~0ms, and the floor keeps that from becoming a spin.
+      timer = setTimeout(tick, Math.max(1_000, nextTransition.getTime() - current.getTime() + 1_000));
+    };
+
+    tick();
+
+    // Background tabs are throttled and sleeping machines don't run timers at all, so a window can
+    // open while this one is owed a callback it never got. Coming back into view is the moment that
+    // matters — it is also when `useDebatePeople` refetches presence — so re-read the clock then.
+    const onVisibilityChange = () => {
+      if (document.visibilityState !== 'visible') return;
+      clearTimeout(timer);
+      tick();
+    };
+
+    document.addEventListener('visibilitychange', onVisibilityChange);
+    return () => {
+      clearTimeout(timer);
+      document.removeEventListener('visibilitychange', onVisibilityChange);
+    };
+  }, []);
+
+  return now;
+}

--- a/apps/web/core/debates/matchmaking/debate-hours-note.tsx
+++ b/apps/web/core/debates/matchmaking/debate-hours-note.tsx
@@ -37,6 +37,20 @@ export function DebateHoursNote({
 }
 
 /**
+ * Enough to clear the boundary rather than land a hair short of it — `setTimeout` counts on a
+ * different clock than `Date`, so a wake aimed exactly at 9:00:00 can read 8:59:59.999. Small
+ * enough that nobody sees it: the copy is a second sentence in an empty state, not a countdown.
+ */
+const BOUNDARY_OVERSHOOT_MS = 50;
+
+/**
+ * Floor on a reschedule. A wake that lands early anyway recomputes the same side and asks for the
+ * few milliseconds it was short by, and this keeps that from becoming a busy loop — at the cost of
+ * at most this much staleness at the boundary, which is the only place it can apply.
+ */
+const MIN_TICK_MS = 250;
+
+/**
  * `now`, re-read each time the open/closed answer changes.
  *
  * Scheduled to the boundary rather than polled: the copy has to flip at 9:00 without a refresh, and
@@ -52,9 +66,10 @@ function useTickingNow() {
       const current = new Date();
       setNow(current);
       const { nextTransition } = debateHoursWindow(current);
-      // Aimed just past the boundary. A timer that fires a millisecond early would recompute the
-      // same side of it and reschedule for ~0ms, and the floor keeps that from becoming a spin.
-      timer = setTimeout(tick, Math.max(1_000, nextTransition.getTime() - current.getTime() + 1_000));
+      timer = setTimeout(
+        tick,
+        Math.max(MIN_TICK_MS, nextTransition.getTime() - current.getTime() + BOUNDARY_OVERSHOOT_MS)
+      );
     };
 
     tick();

--- a/apps/web/core/debates/matchmaking/debate-hours-note.tsx
+++ b/apps/web/core/debates/matchmaking/debate-hours-note.tsx
@@ -3,6 +3,7 @@
 import * as React from 'react';
 
 import { debateHoursNote, debateHoursWindow } from '../debate-hours';
+import { HubMessageNote } from './hub-states';
 
 /**
  * "Debate hours are every day between 5-6pm…" / "Stay here and you'll be matched…", under a hub
@@ -19,10 +20,11 @@ import { debateHoursNote, debateHoursWindow } from '../debate-hours';
  */
 export function DebateHoursNote() {
   const now = useTickingNow();
-  // Null until mounted. The window is expressed in the viewer's local zone, which the server does
-  // not have and cannot guess, so rendering it during SSR would hydrate as a mismatch.
+  // Null until mounted — the paragraph included, so nothing empty is left standing in its place.
+  // The window is expressed in the viewer's local zone, which the server does not have and cannot
+  // guess, so rendering it during SSR would hydrate as a mismatch.
   if (!now) return null;
-  return <>{debateHoursNote(debateHoursWindow(now))}</>;
+  return <HubMessageNote>{debateHoursNote(debateHoursWindow(now))}</HubMessageNote>;
 }
 
 /**

--- a/apps/web/core/debates/matchmaking/debate-hours-note.tsx
+++ b/apps/web/core/debates/matchmaking/debate-hours-note.tsx
@@ -6,7 +6,7 @@ import { debateHoursNote, debateHoursWindow } from '../debate-hours';
 import { HubMessageNote } from './hub-states';
 
 /**
- * "Debate hours are every day between 5-6pm…" / "Stay here and you'll be matched…", under a hub
+ * "Debate hours are every day between 5-6pm…" / "Stay here — this list fills in…", under a hub
  * tab's own empty message.
  *
  * A component rather than a string the tab computes, for two reasons. It only mounts while an

--- a/apps/web/core/debates/matchmaking/debate-hours-note.tsx
+++ b/apps/web/core/debates/matchmaking/debate-hours-note.tsx
@@ -18,13 +18,22 @@ import { HubMessageNote } from './hub-states';
  * the viewer's own filters is a different problem with a different answer, and GEO-2840 explicitly
  * leaves it alone.
  */
-export function DebateHoursNote() {
+export function DebateHoursNote({
+  /**
+   * Whether the list under this note fills itself in, which decides what the during-hours variant
+   * can honestly ask of the viewer. Passed rather than read from auth here: it is a fact about the
+   * caller's list, and only People can be looking at one that doesn't update.
+   */
+  live,
+}: {
+  live: boolean;
+}) {
   const now = useTickingNow();
   // Null until mounted — the paragraph included, so nothing empty is left standing in its place.
   // The window is expressed in the viewer's local zone, which the server does not have and cannot
   // guess, so rendering it during SSR would hydrate as a mismatch.
   if (!now) return null;
-  return <HubMessageNote>{debateHoursNote(debateHoursWindow(now))}</HubMessageNote>;
+  return <HubMessageNote>{debateHoursNote(debateHoursWindow(now), { live })}</HubMessageNote>;
 }
 
 /**

--- a/apps/web/core/debates/matchmaking/debates-hub-panel.tsx
+++ b/apps/web/core/debates/matchmaking/debates-hub-panel.tsx
@@ -349,7 +349,7 @@ function DebatesHubSurface({ activeTab: requestedTab, onTabChange, onClose }: Su
             ) : activeTab === 'claims' ? (
               <ClaimsTab />
             ) : (
-              <PeopleTab />
+              <PeopleTab onTabChange={changeTab} />
             )}
           </HubSwap>
         )}

--- a/apps/web/core/debates/matchmaking/hub-states.tsx
+++ b/apps/web/core/debates/matchmaking/hub-states.tsx
@@ -40,7 +40,13 @@ export function HubMessage({
   action,
 }: {
   children: React.ReactNode;
-  /** A second sentence under the message, set closer to it than the action is. */
+  /**
+   * A second sentence under the message, set closer to it than the action is.
+   *
+   * Rendered as given rather than wrapped in a `Text` of its own: a note that decides at runtime it
+   * has nothing to say returns null, and a wrapper here would still leave an empty paragraph in the
+   * markup and the a11y tree. Notes bring their own {@link HubMessageNote}.
+   */
   note?: React.ReactNode;
   action?: React.ReactNode;
 }) {
@@ -50,14 +56,19 @@ export function HubMessage({
         <Text as="p" variant="metadata" color="grey-04">
           {children}
         </Text>
-        {note ? (
-          <Text as="p" variant="metadata" color="grey-04">
-            {note}
-          </Text>
-        ) : null}
+        {note}
       </div>
       {action}
     </div>
+  );
+}
+
+/** The type the message itself is set in, so a `note` sits with it rather than beside it. */
+export function HubMessageNote({ children }: { children: React.ReactNode }) {
+  return (
+    <Text as="p" variant="metadata" color="grey-04">
+      {children}
+    </Text>
   );
 }
 

--- a/apps/web/core/debates/matchmaking/hub-states.tsx
+++ b/apps/web/core/debates/matchmaking/hub-states.tsx
@@ -34,12 +34,28 @@ export function isSignInRequired(error: unknown) {
  * Horizontally neutral: every tab already insets its content by 16px, so self-padding here would
  * double it and make the empty state sit further in than the list it replaces.
  */
-export function HubMessage({ children, action }: { children: React.ReactNode; action?: React.ReactNode }) {
+export function HubMessage({
+  children,
+  note,
+  action,
+}: {
+  children: React.ReactNode;
+  /** A second sentence under the message, set closer to it than the action is. */
+  note?: React.ReactNode;
+  action?: React.ReactNode;
+}) {
   return (
     <div className="flex flex-col items-center gap-3 py-10 text-center">
-      <Text as="p" variant="metadata" color="grey-04">
-        {children}
-      </Text>
+      <div className="flex flex-col gap-1">
+        <Text as="p" variant="metadata" color="grey-04">
+          {children}
+        </Text>
+        {note ? (
+          <Text as="p" variant="metadata" color="grey-04">
+            {note}
+          </Text>
+        ) : null}
+      </div>
       {action}
     </div>
   );
@@ -50,6 +66,12 @@ type HubQueryStateProps = {
   error: unknown;
   isEmpty: boolean;
   emptyMessage: string;
+  /**
+   * A second line under `emptyMessage`. Where {@link DebateHoursNote} goes — which is why it is a
+   * node rather than a string: it holds a timer of its own, so it has to mount and unmount with the
+   * empty state rather than be computed by a tab that is rendering for other reasons.
+   */
+  emptyNote?: React.ReactNode;
   /** Offered alongside `emptyMessage` — an empty tab should say what to do next. */
   emptyAction?: { label: string; onClick: () => void };
   /** Enables a retry on the error state. */
@@ -65,6 +87,7 @@ export function HubQueryState({
   error,
   isEmpty,
   emptyMessage,
+  emptyNote,
   emptyAction,
   onRetry,
   signInAction,
@@ -94,6 +117,7 @@ export function HubQueryState({
         <HubSkeleton />
       ) : state === 'empty' ? (
         <HubMessage
+          note={emptyNote}
           action={emptyAction ? <HubPillButton onClick={emptyAction.onClick}>{emptyAction.label}</HubPillButton> : null}
         >
           {emptyMessage}

--- a/apps/web/core/debates/matchmaking/matches-tab.test.tsx
+++ b/apps/web/core/debates/matchmaking/matches-tab.test.tsx
@@ -359,25 +359,27 @@ describe('MatchesTab', () => {
     const { rerender } = render(<MatchesTab onTabChange={vi.fn()} />);
 
     expect(screen.queryByText(/Matches appear once you/)).not.toBeInTheDocument();
-    expect(screen.queryByText(/Debate hours are every day between|Stay here —/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/marked unavailable/)).not.toBeInTheDocument();
 
     mocks.activityLoading = false;
     rerender(<MatchesTab onTabChange={vi.fn()} />);
 
+    // The message is what needed the answer; the note never did. Awaited rather than read
+    // synchronously: the note renders nothing until its own mount effect has run, and here it is
+    // mounting for the first time as the skeleton cross-fades out.
     expect(await screen.findByText(/marked unavailable/)).toBeInTheDocument();
-    expect(screen.queryByText(/Debate hours are every day between|Stay here —/)).not.toBeInTheDocument();
+    expect(await screen.findByText(/Debate hours are every day between|Stay here —/)).toBeInTheDocument();
   });
 
-  // An activity request that has run out of retries settles with no data: `isLoading` false,
-  // `available_to_debate` unknown rather than confirmed. The skeleton above cannot wait that out,
-  // so the note has to require the positive answer instead of reading "not false" as "available".
-  it('withholds the debate hours line when the availability answer never arrives', async () => {
+  // The note does not read availability at all, so an activity request that ran out of retries
+  // cannot take it away. Only the message above depends on that answer.
+  it('still shows the debate hours line when the availability answer never arrives', async () => {
     mocks.matches = [];
     mocks.activityErrored = true;
     render(<MatchesTab onTabChange={vi.fn()} />);
 
     expect(await screen.findByText(/Matches appear once you/)).toBeInTheDocument();
-    expect(screen.queryByText(/Debate hours are every day between|Stay here —/)).not.toBeInTheDocument();
+    expect(screen.getByText(/Debate hours are every day between|Stay here —/)).toBeInTheDocument();
   });
 
   // Only while there is nothing to show. A list with rows renders on the matches alone.
@@ -388,14 +390,17 @@ describe('MatchesTab', () => {
     expect(screen.getByText('Chips are better than fries')).toBeInTheDocument();
   });
 
-  // Being marked unavailable is a cause the viewer owns and can undo in a click, so the empty list
-  // is already explained. Debate hours would answer a question they are not asking.
-  it('withholds the debate hours line when the viewer is the reason the list is empty', async () => {
+  // Being marked unavailable is not why the list is empty: geo-chat's matches query never reads
+  // the viewer's own `available_to_debate`, only the opposite side's — which is also why a viewer
+  // with matches still sees them while unavailable, just with the request button disabled. So an
+  // unavailable viewer's empty list is a nobody-is-online list, and the pointer to debate hours is
+  // the half of the answer they can actually use.
+  it('still shows the debate hours line to a viewer who is marked unavailable', async () => {
     mocks.matches = [];
     mocks.availableToDebate = false;
     render(<MatchesTab onTabChange={vi.fn()} />);
 
     expect(await screen.findByText(/marked unavailable/)).toBeInTheDocument();
-    expect(screen.queryByText(/Debate hours are every day between|Stay here —/)).not.toBeInTheDocument();
+    expect(screen.getByText(/Debate hours are every day between|Stay here —/)).toBeInTheDocument();
   });
 });

--- a/apps/web/core/debates/matchmaking/matches-tab.test.tsx
+++ b/apps/web/core/debates/matchmaking/matches-tab.test.tsx
@@ -24,6 +24,8 @@ const mocks = vi.hoisted(() => ({
   availableToDebate: true,
   /** Whether the activity query has landed yet. It races the matches query. */
   activityLoading: false,
+  /** A settled activity query with no data — what an exhausted retry looks like. */
+  activityErrored: false,
   /** What the shared summary reports for every claim in the fixture. */
   responseCounts: { positive: 0, negative: 0 },
 }));
@@ -32,7 +34,10 @@ vi.mock('../hooks', () => ({
   useDebateActivity: () => ({
     // Undefined while loading, exactly as react-query reports it — the empty state has to wait for
     // this rather than read `available_to_debate` off nothing.
-    data: mocks.activityLoading ? undefined : { outbound_request: null, available_to_debate: mocks.availableToDebate },
+    data:
+      mocks.activityLoading || mocks.activityErrored
+        ? undefined
+        : { outbound_request: null, available_to_debate: mocks.availableToDebate },
     isLoading: mocks.activityLoading,
   }),
   // Mirrors the real key factory: `vi.mock` replaces the whole module, so every query key read
@@ -168,6 +173,7 @@ beforeEach(() => {
   mocks.isConnected = true;
   mocks.availableToDebate = true;
   mocks.activityLoading = false;
+  mocks.activityErrored = false;
 });
 
 afterEach(cleanup);
@@ -340,7 +346,7 @@ describe('MatchesTab', () => {
     render(<MatchesTab onTabChange={vi.fn()} />);
 
     expect(await screen.findByText(/Matches appear once you/)).toBeInTheDocument();
-    expect(screen.getByText(/Debate hours are every day between|Stay here and you/)).toBeInTheDocument();
+    expect(screen.getByText(/Debate hours are every day between|Stay here —/)).toBeInTheDocument();
   });
 
   // `activity` is a second request racing the matches one. Landing second, it used to let the tab
@@ -353,13 +359,25 @@ describe('MatchesTab', () => {
     const { rerender } = render(<MatchesTab onTabChange={vi.fn()} />);
 
     expect(screen.queryByText(/Matches appear once you/)).not.toBeInTheDocument();
-    expect(screen.queryByText(/Debate hours are every day between|Stay here and you/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Debate hours are every day between|Stay here —/)).not.toBeInTheDocument();
 
     mocks.activityLoading = false;
     rerender(<MatchesTab onTabChange={vi.fn()} />);
 
     expect(await screen.findByText(/marked unavailable/)).toBeInTheDocument();
-    expect(screen.queryByText(/Debate hours are every day between|Stay here and you/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Debate hours are every day between|Stay here —/)).not.toBeInTheDocument();
+  });
+
+  // An activity request that has run out of retries settles with no data: `isLoading` false,
+  // `available_to_debate` unknown rather than confirmed. The skeleton above cannot wait that out,
+  // so the note has to require the positive answer instead of reading "not false" as "available".
+  it('withholds the debate hours line when the availability answer never arrives', async () => {
+    mocks.matches = [];
+    mocks.activityErrored = true;
+    render(<MatchesTab onTabChange={vi.fn()} />);
+
+    expect(await screen.findByText(/Matches appear once you/)).toBeInTheDocument();
+    expect(screen.queryByText(/Debate hours are every day between|Stay here —/)).not.toBeInTheDocument();
   });
 
   // Only while there is nothing to show. A list with rows renders on the matches alone.
@@ -378,6 +396,6 @@ describe('MatchesTab', () => {
     render(<MatchesTab onTabChange={vi.fn()} />);
 
     expect(await screen.findByText(/marked unavailable/)).toBeInTheDocument();
-    expect(screen.queryByText(/Debate hours are every day between|Stay here and you/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Debate hours are every day between|Stay here —/)).not.toBeInTheDocument();
   });
 });

--- a/apps/web/core/debates/matchmaking/matches-tab.test.tsx
+++ b/apps/web/core/debates/matchmaking/matches-tab.test.tsx
@@ -22,12 +22,19 @@ const mocks = vi.hoisted(() => ({
   resetIndexing: vi.fn(),
   isConnected: true,
   availableToDebate: true,
+  /** Whether the activity query has landed yet. It races the matches query. */
+  activityLoading: false,
   /** What the shared summary reports for every claim in the fixture. */
   responseCounts: { positive: 0, negative: 0 },
 }));
 
 vi.mock('../hooks', () => ({
-  useDebateActivity: () => ({ data: { outbound_request: null, available_to_debate: mocks.availableToDebate } }),
+  useDebateActivity: () => ({
+    // Undefined while loading, exactly as react-query reports it — the empty state has to wait for
+    // this rather than read `available_to_debate` off nothing.
+    data: mocks.activityLoading ? undefined : { outbound_request: null, available_to_debate: mocks.availableToDebate },
+    isLoading: mocks.activityLoading,
+  }),
   // Mirrors the real key factory: `vi.mock` replaces the whole module, so every query key read
   // below this needs one here.
   debateQueryKeys: {
@@ -160,6 +167,7 @@ beforeEach(() => {
   mocks.resetIndexing.mockReset();
   mocks.isConnected = true;
   mocks.availableToDebate = true;
+  mocks.activityLoading = false;
 });
 
 afterEach(cleanup);
@@ -333,6 +341,33 @@ describe('MatchesTab', () => {
 
     expect(await screen.findByText(/Matches appear once you/)).toBeInTheDocument();
     expect(screen.getByText(/Debate hours are every day between|Stay here and you/)).toBeInTheDocument();
+  });
+
+  // `activity` is a second request racing the matches one. Landing second, it used to let the tab
+  // assert the wrong empty state first — the generic message and the debate-hours line, shown to a
+  // viewer who had marked themselves unavailable — and then correct itself.
+  it('waits for the availability answer before describing an empty list', async () => {
+    mocks.matches = [];
+    mocks.availableToDebate = false;
+    mocks.activityLoading = true;
+    const { rerender } = render(<MatchesTab onTabChange={vi.fn()} />);
+
+    expect(screen.queryByText(/Matches appear once you/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Debate hours are every day between|Stay here and you/)).not.toBeInTheDocument();
+
+    mocks.activityLoading = false;
+    rerender(<MatchesTab onTabChange={vi.fn()} />);
+
+    expect(await screen.findByText(/marked unavailable/)).toBeInTheDocument();
+    expect(screen.queryByText(/Debate hours are every day between|Stay here and you/)).not.toBeInTheDocument();
+  });
+
+  // Only while there is nothing to show. A list with rows renders on the matches alone.
+  it('still renders matches while the availability answer is outstanding', () => {
+    mocks.activityLoading = true;
+    render(<MatchesTab onTabChange={vi.fn()} />);
+
+    expect(screen.getByText('Chips are better than fries')).toBeInTheDocument();
   });
 
   // Being marked unavailable is a cause the viewer owns and can undo in a click, so the empty list

--- a/apps/web/core/debates/matchmaking/matches-tab.test.tsx
+++ b/apps/web/core/debates/matchmaking/matches-tab.test.tsx
@@ -325,4 +325,24 @@ describe('MatchesTab', () => {
 
     expect(screen.getByRole('button', { name: /Any space/ }).closest('.sticky')).not.toBeNull();
   });
+
+  // GEO-2840.
+  it('adds the debate hours line to the empty state', async () => {
+    mocks.matches = [];
+    render(<MatchesTab onTabChange={vi.fn()} />);
+
+    expect(await screen.findByText(/Matches appear once you/)).toBeInTheDocument();
+    expect(screen.getByText(/Debate hours are every day between|Stay here and you/)).toBeInTheDocument();
+  });
+
+  // Being marked unavailable is a cause the viewer owns and can undo in a click, so the empty list
+  // is already explained. Debate hours would answer a question they are not asking.
+  it('withholds the debate hours line when the viewer is the reason the list is empty', async () => {
+    mocks.matches = [];
+    mocks.availableToDebate = false;
+    render(<MatchesTab onTabChange={vi.fn()} />);
+
+    expect(await screen.findByText(/marked unavailable/)).toBeInTheDocument();
+    expect(screen.queryByText(/Debate hours are every day between|Stay here and you/)).not.toBeInTheDocument();
+  });
 });

--- a/apps/web/core/debates/matchmaking/matches-tab.tsx
+++ b/apps/web/core/debates/matchmaking/matches-tab.tsx
@@ -28,7 +28,8 @@ export function MatchesTab({ onTabChange }: { onTabChange: (tab: DebatesHubTab) 
 
   const matchesQuery = useMatchmakingMatches(true);
   const requestsQuery = useDebateRequests(true);
-  const { data: activity } = useDebateActivity(true);
+  const activityQuery = useDebateActivity(true);
+  const activity = activityQuery.data;
 
   const serverMatches = React.useMemo(() => matchesQuery.data?.matches ?? [], [matchesQuery.data]);
   const outbound = requestsQuery.data?.outbound ?? activity?.outbound_request ?? null;
@@ -69,7 +70,15 @@ export function MatchesTab({ onTabChange }: { onTabChange: (tab: DebatesHubTab) 
 
       <div className="flex flex-col gap-3 px-4 py-3">
         <HubQueryState
-          isLoading={matchesQuery.isLoading}
+          // `activity` is a second query, and an empty list cannot be described without it: both
+          // the message and the note below say something different depending on whether the viewer
+          // has marked themselves unavailable. Whichever request lands second decides what this
+          // reads, so with nothing to show the skeleton waits for the answer rather than asserting
+          // the wrong one and correcting itself a moment later.
+          //
+          // Only while empty. A list with rows in it renders on the matches alone, as it always
+          // has — nothing above depends on `activity` then.
+          isLoading={matchesQuery.isLoading || (filtered.length === 0 && activityQuery.isLoading)}
           error={matchesQuery.error}
           onRetry={() => void matchesQuery.refetch()}
           isEmpty={filtered.length === 0}

--- a/apps/web/core/debates/matchmaking/matches-tab.tsx
+++ b/apps/web/core/debates/matchmaking/matches-tab.tsx
@@ -90,21 +90,21 @@ export function MatchesTab({ onTabChange }: { onTabChange: (tab: DebatesHubTab) 
               ? 'You’re marked unavailable, so nobody can be matched with you.'
               : 'Matches appear once you’ve taken a position on a claim and someone holding the opposite position is online and ready too.'
           }
-          // GEO-2840, and withheld in the two cases where the empty list has a cause of its own.
-          // Read off `serverMatches` rather than off the space filter: with nothing to match on at
-          // all, the filter is not what emptied the list, so the test is whether anyone is there
-          // and not whether the viewer has narrowed. Being marked unavailable is the viewer's own
-          // switch, undoable in a click, and "come back at 9am" does not answer it.
+          // GEO-2840. Read off `serverMatches` rather than off the space filter: with nothing to
+          // match on at all, the filter is not what emptied the list, so the test is whether anyone
+          // is there and not whether the viewer has narrowed.
+          //
+          // Deliberately *not* also gated on the viewer's availability, though the message above
+          // branches on it. geo-chat's matches query never reads the viewer's own
+          // `available_to_debate` — it walks their readiness rows and drops a claim only when the
+          // opposite side has nobody available — so an unavailable viewer's empty list is a
+          // nobody-is-online list like anyone else's. Withholding the pointer to debate hours from
+          // them left the one explanation they can act on being one that would not change anything.
+          // Availability gates *sending a request*, which is where the card already says so.
+          //
           // `live` unconditionally: `SIGNED_OUT_TABS` in the panel keeps this tab off the signed-out
           // hub entirely, so every viewer here holds the gateway scope.
-          //
-          // `=== true`, not `!== false`. The skeleton above waits out the loading case, but an
-          // activity request that has exhausted its retries leaves `isLoading` false and `data`
-          // undefined — availability unknown rather than confirmed. Requiring the positive value
-          // withholds the note there instead of guessing the viewer is available.
-          emptyNote={
-            serverMatches.length === 0 && activity?.available_to_debate === true ? <DebateHoursNote live /> : undefined
-          }
+          emptyNote={serverMatches.length === 0 ? <DebateHoursNote live /> : undefined}
           emptyAction={{ label: 'Browse claims', onClick: () => onTabChange('claims') }}
         >
           <HubCardList>

--- a/apps/web/core/debates/matchmaking/matches-tab.tsx
+++ b/apps/web/core/debates/matchmaking/matches-tab.tsx
@@ -81,10 +81,14 @@ export function MatchesTab({ onTabChange }: { onTabChange: (tab: DebatesHubTab) 
               ? 'You’re marked unavailable, so nobody can be matched with you.'
               : 'Matches appear once you’ve taken a position on a claim and someone holding the opposite position is online and ready too.'
           }
-          // Withheld in the two cases where the empty list has a cause of its own. A space filter
-          // means the viewer excluded the matches, and being marked unavailable means the viewer
-          // excluded themselves — neither is answered by "come back at 9am" (GEO-2840).
-          emptyNote={spaceIds.length === 0 && activity?.available_to_debate !== false ? <DebateHoursNote /> : undefined}
+          // GEO-2840, and withheld in the two cases where the empty list has a cause of its own.
+          // Read off `serverMatches` rather than off the space filter: with nothing to match on at
+          // all, the filter is not what emptied the list, so the test is whether anyone is there
+          // and not whether the viewer has narrowed. Being marked unavailable is the viewer's own
+          // switch, undoable in a click, and "come back at 9am" does not answer it.
+          emptyNote={
+            serverMatches.length === 0 && activity?.available_to_debate !== false ? <DebateHoursNote /> : undefined
+          }
           emptyAction={{ label: 'Browse claims', onClick: () => onTabChange('claims') }}
         >
           <HubCardList>

--- a/apps/web/core/debates/matchmaking/matches-tab.tsx
+++ b/apps/web/core/debates/matchmaking/matches-tab.tsx
@@ -5,6 +5,7 @@ import * as React from 'react';
 import type { MatchmakingMatch } from '../api';
 import { useDebateActivity } from '../hooks';
 import { HubStickyControls, SpaceTopicFilters } from './claims-tab';
+import { DebateHoursNote } from './debate-hours-note';
 import { useDebateRequests, useMatchmakingMatches } from './hooks';
 import { HubCardList } from './hub-motion';
 import { HubQueryState } from './hub-states';
@@ -80,6 +81,10 @@ export function MatchesTab({ onTabChange }: { onTabChange: (tab: DebatesHubTab) 
               ? 'You’re marked unavailable, so nobody can be matched with you.'
               : 'Matches appear once you’ve taken a position on a claim and someone holding the opposite position is online and ready too.'
           }
+          // Withheld in the two cases where the empty list has a cause of its own. A space filter
+          // means the viewer excluded the matches, and being marked unavailable means the viewer
+          // excluded themselves — neither is answered by "come back at 9am" (GEO-2840).
+          emptyNote={spaceIds.length === 0 && activity?.available_to_debate !== false ? <DebateHoursNote /> : undefined}
           emptyAction={{ label: 'Browse claims', onClick: () => onTabChange('claims') }}
         >
           <HubCardList>

--- a/apps/web/core/debates/matchmaking/matches-tab.tsx
+++ b/apps/web/core/debates/matchmaking/matches-tab.tsx
@@ -86,8 +86,10 @@ export function MatchesTab({ onTabChange }: { onTabChange: (tab: DebatesHubTab) 
           // all, the filter is not what emptied the list, so the test is whether anyone is there
           // and not whether the viewer has narrowed. Being marked unavailable is the viewer's own
           // switch, undoable in a click, and "come back at 9am" does not answer it.
+          // `live` unconditionally: `SIGNED_OUT_TABS` in the panel keeps this tab off the signed-out
+          // hub entirely, so every viewer here holds the gateway scope.
           emptyNote={
-            serverMatches.length === 0 && activity?.available_to_debate !== false ? <DebateHoursNote /> : undefined
+            serverMatches.length === 0 && activity?.available_to_debate !== false ? <DebateHoursNote live /> : undefined
           }
           emptyAction={{ label: 'Browse claims', onClick: () => onTabChange('claims') }}
         >

--- a/apps/web/core/debates/matchmaking/matches-tab.tsx
+++ b/apps/web/core/debates/matchmaking/matches-tab.tsx
@@ -105,7 +105,9 @@ export function MatchesTab({ onTabChange }: { onTabChange: (tab: DebatesHubTab) 
           // `live` unconditionally: `SIGNED_OUT_TABS` in the panel keeps this tab off the signed-out
           // hub entirely, so every viewer here holds the gateway scope.
           emptyNote={serverMatches.length === 0 ? <DebateHoursNote live /> : undefined}
-          emptyAction={{ label: 'Browse claims', onClick: () => onTabChange('claims') }}
+          // Same label as People's, because it is the same action out of the same dead end. Two
+          // names for one button in one panel is a difference that implies something.
+          emptyAction={{ label: 'Explore claims', onClick: () => onTabChange('claims') }}
         >
           <HubCardList>
             {filtered.map(match => (

--- a/apps/web/core/debates/matchmaking/matches-tab.tsx
+++ b/apps/web/core/debates/matchmaking/matches-tab.tsx
@@ -97,8 +97,13 @@ export function MatchesTab({ onTabChange }: { onTabChange: (tab: DebatesHubTab) 
           // switch, undoable in a click, and "come back at 9am" does not answer it.
           // `live` unconditionally: `SIGNED_OUT_TABS` in the panel keeps this tab off the signed-out
           // hub entirely, so every viewer here holds the gateway scope.
+          //
+          // `=== true`, not `!== false`. The skeleton above waits out the loading case, but an
+          // activity request that has exhausted its retries leaves `isLoading` false and `data`
+          // undefined — availability unknown rather than confirmed. Requiring the positive value
+          // withholds the note there instead of guessing the viewer is available.
           emptyNote={
-            serverMatches.length === 0 && activity?.available_to_debate !== false ? <DebateHoursNote live /> : undefined
+            serverMatches.length === 0 && activity?.available_to_debate === true ? <DebateHoursNote live /> : undefined
           }
           emptyAction={{ label: 'Browse claims', onClick: () => onTabChange('claims') }}
         >

--- a/apps/web/core/debates/matchmaking/people-tab.test.tsx
+++ b/apps/web/core/debates/matchmaking/people-tab.test.tsx
@@ -197,6 +197,42 @@ describe('PeopleTab', () => {
     expect(screen.queryByRole('button', { name: 'Clear search' })).not.toBeInTheDocument();
   });
 
+  // People is the one tab a signed-out viewer can reach this note from (GEO-2725), and their list
+  // is static: `useMatchmakingScope` gates the gateway on a session. Waiting will not fill it, and
+  // they could not be matched from it either, so "stay here and you'll be matched" would promise
+  // both. The clock is pinned inside debate hours because that is the only variant that differs.
+  it('does not tell a signed-out viewer to wait for a list that cannot update', async () => {
+    // Real time still advances, so testing-library's async helpers are not frozen out.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    // 16:30Z is 09:30 PDT — inside the window, whatever zone this suite runs in.
+    vi.setSystemTime(new Date('2026-09-08T16:30:00Z'));
+    mocks.authenticated = false;
+    mocks.people = [];
+
+    try {
+      render(<PeopleTab />);
+
+      expect(await screen.findByText('Check back in a few minutes to find a debate!')).toBeInTheDocument();
+      expect(screen.queryByText(/Stay here/)).not.toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('tells a signed-in viewer to stay, because their list does update', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.setSystemTime(new Date('2026-09-08T16:30:00Z'));
+    mocks.people = [];
+
+    try {
+      render(<PeopleTab />);
+
+      expect(await screen.findByText('Stay here and you’ll be matched as soon as someone joins.')).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('pins search alongside a sent request rather than in a second sticky', () => {
     // Two stickies would both claim top-0 and overlap; the card is conditional, so search could
     // not be offset by a known height either.

--- a/apps/web/core/debates/matchmaking/people-tab.test.tsx
+++ b/apps/web/core/debates/matchmaking/people-tab.test.tsx
@@ -164,6 +164,24 @@ describe('PeopleTab', () => {
     expect(await screen.findByText('Arturas')).toBeInTheDocument();
   });
 
+  // GEO-2840. The debate-hours line belongs to the nobody-online state only; a list the viewer
+  // emptied with their own search is a different problem, and pointing at 9am does not answer it.
+  it('adds the debate hours line when nobody is online, but not when a search emptied the list', async () => {
+    mocks.people = [];
+    render(<PeopleTab />);
+
+    expect(await screen.findByText('Nobody is available to debate right now.')).toBeInTheDocument();
+    expect(screen.getByText(/Debate hours are every day between|Stay here and you/)).toBeInTheDocument();
+
+    cleanup();
+    mocks.people = [person('user-them', 'Arturas')];
+    render(<PeopleTab />);
+    fireEvent.change(screen.getByLabelText('Search people'), { target: { value: 'nobody-by-this-name' } });
+
+    expect(await screen.findByText('Nobody available matches that search.')).toBeInTheDocument();
+    expect(screen.queryByText(/Debate hours are every day between|Stay here and you/)).not.toBeInTheDocument();
+  });
+
   it('pins search alongside a sent request rather than in a second sticky', () => {
     // Two stickies would both claim top-0 and overlap; the card is conditional, so search could
     // not be offset by a known height either.

--- a/apps/web/core/debates/matchmaking/people-tab.test.tsx
+++ b/apps/web/core/debates/matchmaking/people-tab.test.tsx
@@ -171,7 +171,7 @@ describe('PeopleTab', () => {
     render(<PeopleTab />);
 
     expect(await screen.findByText('Nobody is available to debate right now.')).toBeInTheDocument();
-    expect(screen.getByText(/Debate hours are every day between|Stay here and you/)).toBeInTheDocument();
+    expect(screen.getByText(/Debate hours are every day between|Stay here —/)).toBeInTheDocument();
 
     cleanup();
     mocks.people = [person('user-them', 'Arturas')];
@@ -179,7 +179,7 @@ describe('PeopleTab', () => {
     fireEvent.change(screen.getByLabelText('Search people'), { target: { value: 'nobody-by-this-name' } });
 
     expect(await screen.findByText('Nobody available matches that search.')).toBeInTheDocument();
-    expect(screen.queryByText(/Debate hours are every day between|Stay here and you/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Debate hours are every day between|Stay here —/)).not.toBeInTheDocument();
   });
 
   // Both states are reachable with text in the search box, so the box cannot be what tells them
@@ -192,7 +192,7 @@ describe('PeopleTab', () => {
     fireEvent.change(screen.getByLabelText('Search people'), { target: { value: 'artur' } });
 
     expect(await screen.findByText('Nobody is available to debate right now.')).toBeInTheDocument();
-    expect(screen.getByText(/Debate hours are every day between|Stay here and you/)).toBeInTheDocument();
+    expect(screen.getByText(/Debate hours are every day between|Stay here —/)).toBeInTheDocument();
     // Clearing a search that excluded nobody would put the same empty list back.
     expect(screen.queryByRole('button', { name: 'Clear search' })).not.toBeInTheDocument();
   });
@@ -227,7 +227,7 @@ describe('PeopleTab', () => {
     try {
       render(<PeopleTab />);
 
-      expect(await screen.findByText('Stay here and you’ll be matched as soon as someone joins.')).toBeInTheDocument();
+      expect(await screen.findByText('Stay here — this list fills in as people come online.')).toBeInTheDocument();
     } finally {
       vi.useRealTimers();
     }

--- a/apps/web/core/debates/matchmaking/people-tab.test.tsx
+++ b/apps/web/core/debates/matchmaking/people-tab.test.tsx
@@ -182,6 +182,21 @@ describe('PeopleTab', () => {
     expect(screen.queryByText(/Debate hours are every day between|Stay here and you/)).not.toBeInTheDocument();
   });
 
+  // Both states are reachable with text in the search box, so the box cannot be what tells them
+  // apart: search for a name at 3am, or be mid-search when the last person drops off, and the
+  // reason the list is empty is that nobody is online — which is the state GEO-2840 is about.
+  it('blames nobody being online rather than the search when there is nobody to search', async () => {
+    mocks.people = [];
+    render(<PeopleTab />);
+
+    fireEvent.change(screen.getByLabelText('Search people'), { target: { value: 'artur' } });
+
+    expect(await screen.findByText('Nobody is available to debate right now.')).toBeInTheDocument();
+    expect(screen.getByText(/Debate hours are every day between|Stay here and you/)).toBeInTheDocument();
+    // Clearing a search that excluded nobody would put the same empty list back.
+    expect(screen.queryByRole('button', { name: 'Clear search' })).not.toBeInTheDocument();
+  });
+
   it('pins search alongside a sent request rather than in a second sticky', () => {
     // Two stickies would both claim top-0 and overlap; the card is conditional, so search could
     // not be offset by a known height either.

--- a/apps/web/core/debates/matchmaking/people-tab.test.tsx
+++ b/apps/web/core/debates/matchmaking/people-tab.test.tsx
@@ -19,6 +19,7 @@ const mocks = vi.hoisted(() => ({
   activeDebate: null as unknown,
   currentUserId: 'user-me' as string | null,
   createChallenge: vi.fn(),
+  onTabChange: vi.fn(),
   cancelChallenge: vi.fn(),
   cancelPending: false,
   cancelError: null as Error | null,
@@ -125,6 +126,7 @@ beforeEach(() => {
   mocks.activeDebate = null;
   mocks.currentUserId = 'user-me';
   mocks.createChallenge.mockReset();
+  mocks.onTabChange.mockReset();
   mocks.cancelChallenge.mockReset();
   mocks.cancelPending = false;
   mocks.cancelError = null;
@@ -138,7 +140,7 @@ describe('PeopleTab', () => {
   // Filtered client-side: the endpoint has no search parameter and returns everyone available in
   // one unpaginated list, so there is nothing to page back for.
   it('narrows the list to people matching the search', () => {
-    render(<PeopleTab />);
+    render(<PeopleTab onTabChange={mocks.onTabChange} />);
 
     expect(screen.getByText('Arturas')).toBeInTheDocument();
     expect(screen.getByText('Vytautas')).toBeInTheDocument();
@@ -152,7 +154,7 @@ describe('PeopleTab', () => {
   it('says so when a search matches nobody, and offers a way back', async () => {
     // Distinct from the "nobody is available" state: one is a filter the viewer can undo, the
     // other is the room being empty.
-    render(<PeopleTab />);
+    render(<PeopleTab onTabChange={mocks.onTabChange} />);
 
     fireEvent.change(screen.getByLabelText('Search people'), { target: { value: 'nobody-by-this-name' } });
 
@@ -168,18 +170,40 @@ describe('PeopleTab', () => {
   // emptied with their own search is a different problem, and pointing at 9am does not answer it.
   it('adds the debate hours line when nobody is online, but not when a search emptied the list', async () => {
     mocks.people = [];
-    render(<PeopleTab />);
+    render(<PeopleTab onTabChange={mocks.onTabChange} />);
 
     expect(await screen.findByText('Nobody is available to debate right now.')).toBeInTheDocument();
     expect(screen.getByText(/Debate hours are every day between|Stay here —/)).toBeInTheDocument();
 
     cleanup();
     mocks.people = [person('user-them', 'Arturas')];
-    render(<PeopleTab />);
+    render(<PeopleTab onTabChange={mocks.onTabChange} />);
     fireEvent.change(screen.getByLabelText('Search people'), { target: { value: 'nobody-by-this-name' } });
 
     expect(await screen.findByText('Nobody available matches that search.')).toBeInTheDocument();
     expect(screen.queryByText(/Debate hours are every day between|Stay here —/)).not.toBeInTheDocument();
+  });
+
+  // GEO-2840. Waiting is the only other thing to do while the room is empty, so the empty state
+  // offers somewhere to go instead — the Claims tab, which is full whether or not anyone is online.
+  it('offers a way through to claims when nobody is online', async () => {
+    mocks.people = [];
+    render(<PeopleTab onTabChange={mocks.onTabChange} />);
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Explore claims' }));
+
+    expect(mocks.onTabChange).toHaveBeenCalledWith('claims');
+  });
+
+  // A search the viewer can undo gets the undo instead: there is something to do here, so sending
+  // them to another tab would be answering a question they did not ask.
+  it('offers the undo rather than claims when a search emptied the list', async () => {
+    render(<PeopleTab onTabChange={mocks.onTabChange} />);
+
+    fireEvent.change(screen.getByLabelText('Search people'), { target: { value: 'nobody-by-this-name' } });
+
+    expect(await screen.findByRole('button', { name: 'Clear search' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Explore claims' })).not.toBeInTheDocument();
   });
 
   // Both states are reachable with text in the search box, so the box cannot be what tells them
@@ -187,7 +211,7 @@ describe('PeopleTab', () => {
   // reason the list is empty is that nobody is online — which is the state GEO-2840 is about.
   it('blames nobody being online rather than the search when there is nobody to search', async () => {
     mocks.people = [];
-    render(<PeopleTab />);
+    render(<PeopleTab onTabChange={mocks.onTabChange} />);
 
     fireEvent.change(screen.getByLabelText('Search people'), { target: { value: 'artur' } });
 
@@ -210,7 +234,7 @@ describe('PeopleTab', () => {
     mocks.people = [];
 
     try {
-      render(<PeopleTab />);
+      render(<PeopleTab onTabChange={mocks.onTabChange} />);
 
       expect(await screen.findByText('Check back in a few minutes to find a debate!')).toBeInTheDocument();
       expect(screen.queryByText(/Stay here/)).not.toBeInTheDocument();
@@ -225,7 +249,7 @@ describe('PeopleTab', () => {
     mocks.people = [];
 
     try {
-      render(<PeopleTab />);
+      render(<PeopleTab onTabChange={mocks.onTabChange} />);
 
       expect(await screen.findByText('Stay here — this list fills in as people come online.')).toBeInTheDocument();
     } finally {
@@ -237,7 +261,7 @@ describe('PeopleTab', () => {
     // Two stickies would both claim top-0 and overlap; the card is conditional, so search could
     // not be offset by a known height either.
     mocks.challenge = challenge('requester');
-    render(<PeopleTab />);
+    render(<PeopleTab onTabChange={mocks.onTabChange} />);
 
     const pinned = screen.getByLabelText('Search people').closest('.sticky');
     expect(pinned).not.toBeNull();
@@ -245,7 +269,7 @@ describe('PeopleTab', () => {
   });
 
   it('shows no request card when nothing is outstanding', () => {
-    render(<PeopleTab />);
+    render(<PeopleTab onTabChange={mocks.onTabChange} />);
 
     expect(card()).not.toBeInTheDocument();
     expect(screen.getAllByRole('button', { name: 'Request debate' })[0]).toBeEnabled();
@@ -255,7 +279,7 @@ describe('PeopleTab', () => {
   // stays in view rather than scrolling away behind people you can no longer ask.
   it('puts a sticky card above the list for a request you sent', () => {
     mocks.challenge = challenge('requester');
-    render(<PeopleTab />);
+    render(<PeopleTab onTabChange={mocks.onTabChange} />);
 
     const request = card();
     expect(request).toBeInTheDocument();
@@ -266,7 +290,7 @@ describe('PeopleTab', () => {
 
   it('names the person you asked, without a claim or space to show', () => {
     mocks.challenge = challenge('requester');
-    render(<PeopleTab />);
+    render(<PeopleTab onTabChange={mocks.onTabChange} />);
 
     const request = card()!;
     expect(within(request).getByText('You')).toBeInTheDocument();
@@ -276,7 +300,7 @@ describe('PeopleTab', () => {
 
   it('still greys out every Request debate button while the request is open', () => {
     mocks.challenge = challenge('requester');
-    render(<PeopleTab />);
+    render(<PeopleTab onTabChange={mocks.onTabChange} />);
 
     for (const button of screen.getAllByRole('button', { name: 'Request debate' })) {
       expect(button).toBeDisabled();
@@ -287,7 +311,7 @@ describe('PeopleTab', () => {
   // request you sent, so it keeps the sentence rather than claiming you're waiting on a reply.
   it('keeps the sentence when the challenge is one you received', () => {
     mocks.challenge = challenge('recipient');
-    render(<PeopleTab />);
+    render(<PeopleTab onTabChange={mocks.onTabChange} />);
 
     expect(card()).not.toBeInTheDocument();
     expect(screen.getByText(awaitingText)).toBeInTheDocument();
@@ -298,7 +322,7 @@ describe('PeopleTab', () => {
   it('holds the card back until the viewer is identified', () => {
     mocks.challenge = challenge('requester');
     mocks.currentUserId = null;
-    render(<PeopleTab />);
+    render(<PeopleTab onTabChange={mocks.onTabChange} />);
 
     expect(card()).not.toBeInTheDocument();
     expect(screen.getByText(awaitingText)).toBeInTheDocument();
@@ -307,7 +331,7 @@ describe('PeopleTab', () => {
   // The clock and what you can do about it lead the card, above the pairing they apply to.
   it('leads with the countdown and the cancel action, before the two people', () => {
     mocks.challenge = challenge('requester');
-    render(<PeopleTab />);
+    render(<PeopleTab onTabChange={mocks.onTabChange} />);
 
     const request = card()!;
     const countdown = within(request).getByText(/Expires in/);
@@ -323,7 +347,7 @@ describe('PeopleTab', () => {
   // it the tab sat on an "Expired" card with every Request debate button still dead underneath it.
   it('drops an expired challenge instead of waiting for the server to say so', () => {
     mocks.challenge = challenge('requester', -1_000);
-    render(<PeopleTab />);
+    render(<PeopleTab onTabChange={mocks.onTabChange} />);
 
     expect(card()).not.toBeInTheDocument();
     expect(screen.queryByText('Expired')).not.toBeInTheDocument();
@@ -331,14 +355,14 @@ describe('PeopleTab', () => {
 
   it('re-enables the Request debate buttons once the request has expired', () => {
     mocks.challenge = challenge('requester', -1_000);
-    render(<PeopleTab />);
+    render(<PeopleTab onTabChange={mocks.onTabChange} />);
 
     expect(screen.getAllByRole('button', { name: 'Request debate' })[0]).toBeEnabled();
   });
 
   it('drops an expired incoming challenge too, sentence and all', () => {
     mocks.challenge = challenge('recipient', -1_000);
-    render(<PeopleTab />);
+    render(<PeopleTab onTabChange={mocks.onTabChange} />);
 
     expect(screen.queryByText(awaitingText)).not.toBeInTheDocument();
     expect(screen.getAllByRole('button', { name: 'Request debate' })[0]).toBeEnabled();
@@ -347,7 +371,7 @@ describe('PeopleTab', () => {
   // The same action the Requests tab offers on this challenge, reachable without leaving People.
   it('cancels the request from the card', () => {
     mocks.challenge = challenge('requester');
-    render(<PeopleTab />);
+    render(<PeopleTab onTabChange={mocks.onTabChange} />);
 
     fireEvent.click(within(card()!).getByRole('button', { name: 'Cancel request' }));
 
@@ -357,7 +381,7 @@ describe('PeopleTab', () => {
   it('holds the cancel button while it is in flight', () => {
     mocks.challenge = challenge('requester');
     mocks.cancelPending = true;
-    render(<PeopleTab />);
+    render(<PeopleTab onTabChange={mocks.onTabChange} />);
 
     expect(within(card()!).getByRole('button', { name: 'Cancelling…' })).toBeDisabled();
   });
@@ -365,14 +389,14 @@ describe('PeopleTab', () => {
   it('announces a failed cancel rather than only drawing it', () => {
     mocks.challenge = challenge('requester');
     mocks.cancelError = new Error('Challenge already answered.');
-    render(<PeopleTab />);
+    render(<PeopleTab onTabChange={mocks.onTabChange} />);
 
     expect(screen.getByRole('alert')).toHaveTextContent('Challenge already answered.');
   });
 
   it('leaves the other blocked reasons alone', () => {
     mocks.outboundRequest = { id: 'request-1' };
-    render(<PeopleTab />);
+    render(<PeopleTab onTabChange={mocks.onTabChange} />);
 
     expect(card()).not.toBeInTheDocument();
     expect(
@@ -384,7 +408,7 @@ describe('PeopleTab', () => {
   // rather than sending a request that could only fail at the token exchange.
   it('sends a signed-out visitor to sign in instead of requesting a debate', () => {
     mocks.authenticated = false;
-    render(<PeopleTab />);
+    render(<PeopleTab onTabChange={mocks.onTabChange} />);
 
     fireEvent.click(screen.getAllByRole('button', { name: 'Request debate' })[0]);
 
@@ -408,7 +432,7 @@ describe('PeopleTab', () => {
         },
       ],
     ]);
-    render(<PeopleTab />);
+    render(<PeopleTab onTabChange={mocks.onTabChange} />);
 
     expect(screen.getByText('119 positions')).toBeInTheDocument();
     expect(screen.getByText('Won 8 of 11 debates')).toBeInTheDocument();
@@ -421,7 +445,7 @@ describe('PeopleTab', () => {
   it('keeps the button live signed out when only the viewer-relative flag is off', () => {
     mocks.authenticated = false;
     mocks.people = [{ ...person('user-them', 'Arturas'), can_challenge: false }];
-    render(<PeopleTab />);
+    render(<PeopleTab onTabChange={mocks.onTabChange} />);
 
     expect(screen.getByRole('button', { name: 'Request debate' })).not.toBeDisabled();
   });
@@ -431,7 +455,7 @@ describe('PeopleTab', () => {
   it('still refuses a person already in a debate when signed out', () => {
     mocks.authenticated = false;
     mocks.people = [{ ...person('user-them', 'Arturas'), in_debate: true }];
-    render(<PeopleTab />);
+    render(<PeopleTab onTabChange={mocks.onTabChange} />);
 
     expect(screen.getByRole('button', { name: 'In a debate' })).toBeDisabled();
   });
@@ -441,7 +465,7 @@ describe('PeopleTab', () => {
 // way — which is why this needs no click handler and so keeps cmd-click and middle click working.
 describe('the person link', () => {
   it("points the name at the person's space", () => {
-    render(<PeopleTab />);
+    render(<PeopleTab onTabChange={mocks.onTabChange} />);
 
     expect(screen.getByRole('link', { name: 'Arturas' })).toHaveAttribute(
       'href',
@@ -458,7 +482,7 @@ describe('the person link', () => {
   // `defaultPrevented` check would only describe the mock and would pass whether or not the real
   // component ever received a handler.
   it('adds no click handler of its own to the name', () => {
-    render(<PeopleTab />);
+    render(<PeopleTab onTabChange={mocks.onTabChange} />);
 
     const nameLink = mocks.linkProps.find(props => props.href === NavUtils.toSpace(PROFILE_SPACE_IDS['user-them']));
     expect(nameLink).toBeDefined();
@@ -468,7 +492,7 @@ describe('the person link', () => {
   // An anchor to `/space/undefined` looks identical until it is clicked.
   it('leaves the name unlinked when there is no space to point at', () => {
     mocks.people = [person('user-nospace', 'Nameless')];
-    render(<PeopleTab />);
+    render(<PeopleTab onTabChange={mocks.onTabChange} />);
 
     expect(screen.getByText('Nameless')).toBeInTheDocument();
     expect(screen.queryByRole('link', { name: 'Nameless' })).toBeNull();

--- a/apps/web/core/debates/matchmaking/people-tab.tsx
+++ b/apps/web/core/debates/matchmaking/people-tab.tsx
@@ -17,6 +17,7 @@ import { speakerLabel } from '../playback-utils';
 import { useCurrentGeoChatUserId } from '../use-current-geo-chat-user-id';
 import { DebateChallengeCard } from './challenge-card';
 import { HubStickyControls } from './claims-tab';
+import { DebateHoursNote } from './debate-hours-note';
 import { useDebatePeople, useDebateRequests } from './hooks';
 import { HubPillButton } from './hub-pill-button';
 import { HubQueryState } from './hub-states';
@@ -116,6 +117,9 @@ export function PeopleTab() {
           emptyMessage={
             search.trim() ? 'Nobody available matches that search.' : 'Nobody is available to debate right now.'
           }
+          // Only the nobody-online case. A search that matched nothing is the viewer's own filter,
+          // and pointing them at debate hours would answer a question they didn't ask (GEO-2840).
+          emptyNote={search.trim() ? undefined : <DebateHoursNote />}
           emptyAction={search.trim() ? { label: 'Clear search', onClick: () => setSearch('') } : undefined}
           signInAction={
             onRequireSignIn

--- a/apps/web/core/debates/matchmaking/people-tab.tsx
+++ b/apps/web/core/debates/matchmaking/people-tab.tsx
@@ -25,12 +25,13 @@ import type { PersonRecord } from './person-record';
 import { PersonRecordLine } from './person-record-line';
 import { usePersonRecords } from './use-person-records';
 import { useUnexpiredRequests } from './use-request-countdown';
+import type { DebatesHubTab } from '~/atoms';
 
 /**
  * Everyone online and available right now. The Debate button sends the same claimless challenge as
  * `ProfileDebateButton` on a person's home space — `DebateCoordinator` owns the resulting dialog.
  */
-export function PeopleTab() {
+export function PeopleTab({ onTabChange }: { onTabChange: (tab: DebatesHubTab) => void }) {
   const { authenticated } = useGeoChatAuth();
   const promptSignIn = usePrivySignIn();
   // Undefined when signed in, so every path below keeps behaving exactly as it did.
@@ -136,7 +137,14 @@ export function PeopleTab() {
           // static and no amount of waiting will fill it. They cannot be matched either. `live` is
           // what keeps the copy from promising both.
           emptyNote={searchExcludedEveryone ? undefined : <DebateHoursNote live={authenticated} />}
-          emptyAction={searchExcludedEveryone ? { label: 'Clear search', onClick: () => setSearch('') } : undefined}
+          // Exactly one action, and which one follows the same question the message and the note do.
+          // A search the viewer can undo gets the undo; a room that is genuinely empty gets somewhere
+          // to go, because there is nothing to undo and waiting is the only other option (GEO-2840).
+          emptyAction={
+            searchExcludedEveryone
+              ? { label: 'Clear search', onClick: () => setSearch('') }
+              : { label: 'Explore claims', onClick: () => onTabChange('claims') }
+          }
           signInAction={
             onRequireSignIn
               ? { label: 'Sign in', message: 'Sign in to see who is available to debate.', onClick: onRequireSignIn }

--- a/apps/web/core/debates/matchmaking/people-tab.tsx
+++ b/apps/web/core/debates/matchmaking/people-tab.tsx
@@ -131,7 +131,11 @@ export function PeopleTab() {
           // GEO-2840 scopes this to the nobody-online case, which is exactly the other side of that
           // same question: a list the viewer emptied with their own search is a different problem,
           // and debate hours does not answer it.
-          emptyNote={searchExcludedEveryone ? undefined : <DebateHoursNote />}
+          // The one tab that can show this to a signed-out viewer — People is readable anonymously
+          // (GEO-2725), but `useMatchmakingScope` gates the gateway on a session, so their list is
+          // static and no amount of waiting will fill it. They cannot be matched either. `live` is
+          // what keeps the copy from promising both.
+          emptyNote={searchExcludedEveryone ? undefined : <DebateHoursNote live={authenticated} />}
           emptyAction={searchExcludedEveryone ? { label: 'Clear search', onClick: () => setSearch('') } : undefined}
           signInAction={
             onRequireSignIn

--- a/apps/web/core/debates/matchmaking/people-tab.tsx
+++ b/apps/web/core/debates/matchmaking/people-tab.tsx
@@ -54,6 +54,11 @@ export function PeopleTab() {
     return allPeople.filter(person => speakerLabel(person).toLowerCase().includes(term));
   }, [allPeople, search]);
 
+  // Whether the viewer's own search is what emptied the list, as opposed to nobody being online.
+  // The two empty states, the debate-hours line and the "Clear search" action all hang off it, so
+  // they cannot disagree about which of the two this is.
+  const searchExcludedEveryone = Boolean(search.trim()) && allPeople.length > 0;
+
   // Keyed on everyone available rather than on the filtered list, so typing in the search box
   // re-slices a batch that is already cached instead of firing a request per keystroke.
   const records = usePersonRecords(React.useMemo(() => allPeople.map(person => person.profile_space_id), [allPeople]));
@@ -114,13 +119,20 @@ export function PeopleTab() {
           isLoading={peopleQuery.isLoading}
           error={peopleQuery.error}
           isEmpty={people.length === 0}
+          // Which of the two empty states this is turns on whether anyone is online *at all*, not
+          // on whether the search box has something in it. With nobody available, a search is not
+          // what emptied the list — saying it was would blame a filter for the room being empty,
+          // and "Clear search" would be an action that changes nothing.
           emptyMessage={
-            search.trim() ? 'Nobody available matches that search.' : 'Nobody is available to debate right now.'
+            searchExcludedEveryone
+              ? 'Nobody available matches that search.'
+              : 'Nobody is available to debate right now.'
           }
-          // Only the nobody-online case. A search that matched nothing is the viewer's own filter,
-          // and pointing them at debate hours would answer a question they didn't ask (GEO-2840).
-          emptyNote={search.trim() ? undefined : <DebateHoursNote />}
-          emptyAction={search.trim() ? { label: 'Clear search', onClick: () => setSearch('') } : undefined}
+          // GEO-2840 scopes this to the nobody-online case, which is exactly the other side of that
+          // same question: a list the viewer emptied with their own search is a different problem,
+          // and debate hours does not answer it.
+          emptyNote={searchExcludedEveryone ? undefined : <DebateHoursNote />}
+          emptyAction={searchExcludedEveryone ? { label: 'Clear search', onClick: () => setSearch('') } : undefined}
           signInAction={
             onRequireSignIn
               ? { label: 'Sign in', message: 'Sign in to see who is available to debate.', onClick: onRequireSignIn }


### PR DESCRIPTION
Closes [GEO-2840](https://linear.app/geobrowser/issue/GEO-2840/debates-add-debate-hours-copy-to-empty-states-in-matches-debate-now).

Matches, People and the Claims tab's **Debate now** filter all go empty when nobody is online, and said so without saying when anyone would be. This adds a second line to those empty states pointing at debate hours.

## Copy

Added **under** each tab's existing message rather than replacing it — two of the three already open by saying nobody is around, so the new line contributes only what they don't say.

| | |
|---|---|
| Outside hours | `Debate hours are every day between 9-10am. Come back then to join a debate!` |
| During hours, live list | `Stay here — this list fills in as people come online.` |
| During hours, static list | `Check back in a few minutes to find a debate!` |

The live line promises the *list* will fill, not that the viewer will be matched. The ticket sketched "you'll be matched as soon as someone joins", which isn't true on Matches: that endpoint answers only once the viewer holds a position too, so a viewer with none could watch the whole hour go by without a row appearing. What every tab can promise is the one thing `debate.matchmaking_changed` actually delivers.

The third row is the signed-out People case. `useMatchmakingScope` gates the gateway on a session, so an anonymous viewer's list has no socket behind it and won't fill itself in — and every Debate button on it routes to sign-in, so they couldn't be matched from it anyway. Telling them to stay would promise both. They get the ticket's original wording, which is true of a static list. Matches and Claims are signed-in only (`SIGNED_OUT_TABS`, `SIGNED_OUT_HIDDEN_FILTERS`), so People is the only tab this applies to.

## The open question: yes, the views live-update

The ticket flagged that "check back in a few minutes" is only correct if the list doesn't refresh itself. It does — `debate.matchmaking_changed` invalidates the `people`, `matches` and `matchmaking-claims` queries through the gateway ([`debate-gateway.ts:450-462`](https://github.com/geobrowser/geogenesis/blob/master/apps/web/core/debates/debate-gateway.ts#L450-L462)), and the hub holds the `matchmaking` scope for as long as it's open.

So this uses the ticket's **alternate** copy. Telling people to leave would send them away from the one place the match can happen, during the one hour a day it can happen in.

## Time conversion

`9-10am PT` is a fixed window in Pacific, so it's converted from `America/Los_Angeles` **at render time**, never stored as an offset — the local equivalent moves twice a year with US daylight saving, and moves again on different dates for viewers whose own region changes on its own schedule. Covered by a test that pins the same window at `16:00Z` the week before the November transition and `17:00Z` the week after.

The range formats to the viewer's own clock: `9-10am` in PT, `5-6pm` in London, `1-2am` in Tokyo. The leading meridiem drops when both ends share one, so `11am-12pm` still reads correctly.

**On naming the day** (the ticket asked): deliberately not. The window recurs every 24 hours, so it recurs every *day* in the viewer's zone too even when it lands overnight — a Tokyo viewer's `1-2am` is as true daily as a London viewer's `5-6pm`, and naming a day would imply the wrong thing about both.

## Config

`NEXT_PUBLIC_DEBATE_HOURS`, as `start-end` or `start-end@zone` (e.g. `09:00-10:00`, `18:00-19:30@Europe/London`). Unset defaults to 9-10am Pacific, and anything unparseable falls back to the default rather than throwing — a typo in a deploy variable shouldn't take a tab down with it.

One caveat worth naming: `NEXT_PUBLIC_*` is inlined at build time, so changing the window needs a redeploy. It's a config edit rather than a code edit, which is what the ticket asked for, but it isn't a live knob. If it needs to be one, geo-chat would have to serve it.

## Boundary behavior

`8:59am` shows outside-hours, `9:00am` shows during-hours, **without a refresh**. `DebateHoursNote` schedules a single `setTimeout` at the next transition rather than polling — a window that opens once a day doesn't need a heartbeat for the other 23 hours to notice. Because a throttled or sleeping tab can miss that callback entirely, it also re-reads the clock on `visibilitychange`, which is the same moment `useDebatePeople` refetches presence.

The component only mounts while an empty state is on screen, so no timer exists while a list has content, and the ticking re-render lands on the note rather than on a tab holding a query, a filter set and a list order.

## Scope: nobody-online only

Per the ticket, the line is withheld wherever the empty list has a cause of its own:

The test is **"is anyone actually online"**, not "has the viewer narrowed the list" — those come apart, and keying on the filter hid the line from the exact state it was added for (search for a name at 3am, and the search isn't why the list is empty).

- **People** — shown unless `allPeople` is non-empty and a search excluded everyone
- **Matches** — shown unless `serverMatches` is non-empty and a filter excluded everything, or the viewer has marked themselves unavailable (their own switch, undoable in a click)
- **Claims** — only under `Debate now`, and only with nothing narrowing the list. It's the one filter here scored on who's online; Featured and All claims are statements about curation and My positions is about the viewer.

## Testing

- `bun run build` passes (`NEXT_PUBLIC_CHAIN_ID=55516`).
- Full `core/debates/` suite: **1276 passed / 91 files**. New coverage spans the window arithmetic (DST across the November transition, overnight, cross-midnight, boundaries), local-time formatting, config parsing and its fallbacks, all three copy variants, the live boundary flip, the `visibilitychange` catch-up, and the empty-state gating on each of the three tabs.

Not visually verified in a browser: the empty state needs a signed-in session against geo-chat with nobody online, which isn't reproducible locally. The rendered copy and the boundary flip are asserted in jsdom instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


