### PR TITLE
fix(assistant): report assistant failures to Sentry (GEO-2510)

### DIFF
--- a/apps/web/partials/chat/chat-widget.tsx
+++ b/apps/web/partials/chat/chat-widget.tsx
@@ -44,6 +44,7 @@ import {
 import { useDiff } from '~/core/state/diff-store';
 import { useEditable } from '~/core/state/editable-store';
 import { useReportError } from '~/core/state/status-bar-store';
+import { reportError as captureAssistantError } from '~/core/telemetry/logger';
 import { describeError } from '~/core/utils/error-diagnostics';
 import { NavUtils } from '~/core/utils/utils';
 
@@ -312,6 +313,17 @@ export function ChatWidget() {
   // mid-stream Anthropic error) surfaces through the global StatusBar modal —
   // the same surface publish failures use. Deduped by Error instance so
   // re-renders don't re-fire the same error.
+  //
+  // GEO-2510. It also goes to Sentry now. `useReportError` here is the *status bar* one, which
+  // only dispatches to a Jotai atom — despite the name, nothing about it is telemetry, and
+  // nothing else in `partials/chat` or `core/chat` captures either. So every assistant failure
+  // showed the user "An error occurred." and told us nothing: the one report we have (2026-08-05)
+  // came with browser, OS and wallet pasted in by hand, and a month later there was still no way
+  // to tell whether it was rare or constant.
+  //
+  // This effect is the right seam rather than a new one — it already sees the whole class the
+  // ticket describes, and it already dedupes by Error instance, so a capture here cannot fire
+  // twice for one failure.
   const reportError = useReportError();
   const reportedErrorRef = React.useRef<Error | null>(null);
   const regenerateRef = React.useRef(regenerate);
@@ -325,6 +337,9 @@ export function ChatWidget() {
     }
     if (reportedErrorRef.current === error) return;
     reportedErrorRef.current = error;
+    // Tagged so assistant failures are separable from the rest of the app's errors, which is the
+    // question the ticket actually needs answered: how often, and on what.
+    captureAssistantError(error, { tags: { surface: 'ai-assistant' } });
     reportError(describeChatError(error), () => {
       stoppedRef.current = false;
       regenerateRef.current();


### PR DESCRIPTION
Part of GEO-2510. **This does not fix the assistant — it makes the next failure diagnosable.**

### Why the ticket has been stuck for a month

One report, from 2026-08-05, and no way to tell whether the assistant fails constantly or almost never.

Because **nothing in `partials/chat` or `core/chat` reports anything**. No `captureException`, no Sentry import, no telemetry of any kind. I grepped both.

The trap is a name collision, and it is an easy one to fall into:

| | what it does |
| -- | -- |
| `useReportError` from `core/state/status-bar-store` | dispatches to a Jotai atom — draws a message in the status bar, and stops |
| `reportError` from `core/telemetry/logger` | `Sentry.captureException`, returns the event id |

The chat widget imports the first. The second's own doc comment describes exactly this case — it returns an event id *"so a surface that shows the user an error can quote a reference that leads straight back to it."*

So every assistant failure showed the user `An error occurred.` and told us nothing. The one report we have arrived with browser, OS, wallet and personal space pasted in by hand, because that was the only way to send any of it.

### What Sentry does have

Four `/api/chat/*` events in **ninety days**, all `POST /api/chat/authorize-write` returning 503 *"Service temporarily unavailable due to database pressure; please retry."* — gaia's deliberate admission-control shedding.

That is unlikely to be the whole story. It is the part that happened to be server-side and therefore visible at all; everything client-side has been invisible by construction.

### The change

One capture in the effect that already handles this, rather than a new seam. That effect:

* already covers the whole class the ticket describes — *"4xx/5xx from /api/chat, network failure, mid-stream Anthropic error"*,
* already dedupes by `Error` instance, so a capture cannot fire twice for one failure.

Tagged `surface: ai-assistant`, so "how often, and on what" becomes one query instead of waiting for someone to hand-copy diagnostics into a ticket again.

### Deliberately not included

**Surfacing the event id to the user.** `reportError` returns it for that purpose and the reporter's pain was having no reference to quote — but it changes user-visible copy, which is a product call rather than a telemetry one. Easy follow-up if wanted.

### Testing

`tsc --noEmit` clean, Prettier clean, `vitest run core/chat` — 145 tests passing. The chat widget has no test file of its own; the change is a single additive call inside an existing, already-deduped effect.
