### PR TITLE
feat(debates): semantic search over the hub's claim lists via geo-lens, with word fallback

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -66,6 +66,13 @@ CURATOR_BACKEND_URL=https://curator-api-staging-testnet.up.railway.app
 # NEXT_PUBLIC_GEO_CHAT_API_BASE_URL; in production one of the two must be set. Must be an absolute
 # http(s) URL, so set it explicitly when using the /geo-chat-proxy dev setup.
 # NEXT_PUBLIC_DEBATE_MEDIA_BASE_URL=http://localhost:8080
+# Semantic search for the debates hub's claim lists (server-only; the key never reaches the
+# browser). Unset, the search box matches words as before. The key is a geo-lens consumer key
+# (LENS_API_KEYS on the Railway geo-lens-api service).
+# GEO_LENS_URL=https://geo-lens-api-production.up.railway.app
+# GEO_LENS_API_KEY=
+# GEO_LENS_SEARCH_MIN_SCORE=0.8                 # geo-lens's normalised cosine, (1 + cos) / 2
+# GEO_LENS_TIMEOUT_MS=6000
 
 # Build (optional)
 # DISABLE_REACT_COMPILER=1

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -71,7 +71,7 @@ CURATOR_BACKEND_URL=https://curator-api-staging-testnet.up.railway.app
 # (LENS_API_KEYS on the Railway geo-lens-api service).
 # GEO_LENS_URL=https://geo-lens-api-production.up.railway.app
 # GEO_LENS_API_KEY=
-# GEO_LENS_SEARCH_MIN_SCORE=0.8                 # geo-lens's normalised cosine, (1 + cos) / 2
+# GEO_LENS_SEARCH_MIN_SCORE=0.85                # geo-lens's normalised cosine, (1 + cos) / 2
 # GEO_LENS_TIMEOUT_MS=6000
 
 # Build (optional)

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -67,7 +67,8 @@ CURATOR_BACKEND_URL=https://curator-api-staging-testnet.up.railway.app
 # http(s) URL, so set it explicitly when using the /geo-chat-proxy dev setup.
 # NEXT_PUBLIC_DEBATE_MEDIA_BASE_URL=http://localhost:8080
 # Semantic search for the debates hub's claim lists (server-only; the key never reaches the
-# browser). Unset, the search box matches words as before. The key is a geo-lens consumer key
+# browser). Unset, the search box matches words as before; set, geo-lens's answer is the answer.
+# The key is a geo-lens consumer key
 # (LENS_API_KEYS on the Railway geo-lens-api service).
 # GEO_LENS_URL=https://geo-lens-api-production.up.railway.app
 # GEO_LENS_API_KEY=

--- a/apps/web/app/api/debates/claims/semantic-search/route.test.ts
+++ b/apps/web/app/api/debates/claims/semantic-search/route.test.ts
@@ -76,7 +76,7 @@ describe('POST /api/debates/claims/semantic-search', () => {
     );
   });
 
-  it('answers 502 when geo-lens fails, so the client falls back to the words', async () => {
+  it('answers 502 when geo-lens fails, which the client shows as the search failing', async () => {
     mocks.search.mockRejectedValue(new Error('geo-lens replied 500'));
     vi.spyOn(console, 'error').mockImplementation(() => {});
     expect((await post({ query: 'q', tagId: TAG })).status).toBe(502);

--- a/apps/web/app/api/debates/claims/semantic-search/route.test.ts
+++ b/apps/web/app/api/debates/claims/semantic-search/route.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  config: null as null | { url: string; apiKey: string; minScore: number; timeoutMs: number },
+  configError: null as null | Error,
+  search: vi.fn(),
+}));
+
+vi.mock('~/core/debates/server/geo-lens-search', () => ({
+  getGeoLensSearchConfig: () => {
+    if (mocks.configError) throw mocks.configError;
+    return mocks.config;
+  },
+  searchSemanticClaims: (...args: unknown[]) => mocks.search(...args),
+}));
+
+const TAG = 'ec3086a54ddf43d8aaefd6cc6e1b0556';
+
+async function post(body: unknown, headers: Record<string, string> = {}) {
+  const { POST } = await import('./route');
+  return POST(
+    new Request('https://geo.test/api/debates/claims/semantic-search', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', host: 'geo.test', origin: 'https://geo.test', ...headers },
+      body: typeof body === 'string' ? body : JSON.stringify(body),
+    })
+  );
+}
+
+beforeEach(() => {
+  mocks.config = { url: 'https://lens.test', apiKey: 'k', minScore: 0.8, timeoutMs: 1000 };
+  mocks.configError = null;
+  mocks.search.mockReset();
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+});
+
+describe('POST /api/debates/claims/semantic-search', () => {
+  it('refuses another origin', async () => {
+    const response = await post({ query: 'q', tagId: TAG }, { origin: 'https://elsewhere.test' });
+    expect(response.status).toBe(403);
+    expect(mocks.search).not.toHaveBeenCalled();
+  });
+
+  it('refuses a body that is not JSON, and one that is not a request', async () => {
+    expect((await post('{not json')).status).toBe(400);
+    expect((await post({ query: '', tagId: TAG })).status).toBe(400);
+    expect(mocks.search).not.toHaveBeenCalled();
+  });
+
+  it('answers null hits, without asking, when geo-lens is not configured', async () => {
+    mocks.config = null;
+    const response = await post({ query: 'q', tagId: TAG });
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ hits: null });
+    expect(mocks.search).not.toHaveBeenCalled();
+  });
+
+  it('reports a misconfiguration rather than pretending to be off', async () => {
+    mocks.configError = new Error('GEO_LENS_API_KEY is required');
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    expect((await post({ query: 'q', tagId: TAG })).status).toBe(503);
+  });
+
+  it('hands the parsed request to geo-lens and returns its hits', async () => {
+    mocks.search.mockResolvedValue([{ id: 'a1', score: 0.9 }]);
+    const response = await post({ query: ' trump ', tagId: TAG.toUpperCase(), spaceIds: null, topicIds: [] });
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ hits: [{ id: 'a1', score: 0.9 }] });
+    expect(mocks.search).toHaveBeenCalledWith(
+      { query: 'trump', tagId: TAG, spaceIds: null, topicIds: [] },
+      mocks.config
+    );
+  });
+
+  it('answers 502 when geo-lens fails, so the client falls back to the words', async () => {
+    mocks.search.mockRejectedValue(new Error('geo-lens replied 500'));
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    expect((await post({ query: 'q', tagId: TAG })).status).toBe(502);
+  });
+});

--- a/apps/web/app/api/debates/claims/semantic-search/route.ts
+++ b/apps/web/app/api/debates/claims/semantic-search/route.ts
@@ -22,9 +22,9 @@ import { getGeoLensSearchConfig, searchSemanticClaims } from '~/core/debates/ser
  * and id caps bound one request's work.
  *
  * `{ hits: null }` is a real answer meaning "not configured on this deployment": the client reads it
- * as "match the words", which is what the box did before this route existed. A misconfiguration
- * (URL without key) is a 503 rather than a quiet null, so it is seen; the client falls back to the
- * words on that too.
+ * as "match the words", which is what the box did before this route existed and the only search
+ * such a deployment has. A misconfiguration (URL without key) is a 503 rather than a quiet null, so
+ * it is seen; like any other failure the client shows it as the list's error, with a retry.
  */
 export const dynamic = 'force-dynamic';
 

--- a/apps/web/app/api/debates/claims/semantic-search/route.ts
+++ b/apps/web/app/api/debates/claims/semantic-search/route.ts
@@ -1,0 +1,74 @@
+import { NextResponse } from 'next/server';
+
+import {
+  type SemanticClaimSearchResponse,
+  parseSemanticClaimSearchRequest,
+} from '~/core/debates/semantic-claim-search-contract';
+import { getGeoLensSearchConfig, searchSemanticClaims } from '~/core/debates/server/geo-lens-search';
+
+/**
+ * Semantic search over a tagged claim list, for the debates hub's search box.
+ *
+ * A proxy for geo-lens, and deliberately a narrow one. geo-lens answers with a key this route holds
+ * and the browser must not; and it answers any relation-shaped question about the cache, while
+ * the search box asks exactly one — "which claims carrying this tag (in these spaces) and these
+ * topics mean these words?" The relation types, the cache, the strategy and the floor are fixed
+ * here (`geo-lens-search`), so the request body can only choose the tag, spaces, topics and words,
+ * and every id in it is normalized before it is trusted.
+ *
+ * Reachable signed out, because Featured and All claims are: the answer is over public graph data
+ * and costs geo-lens an index seek plus a walk of the tag's members, which is milliseconds. The
+ * same-origin check keeps it from being a free embedding service for other sites; the query cap
+ * and id caps bound one request's work.
+ *
+ * `{ hits: null }` is a real answer meaning "not configured on this deployment": the client reads it
+ * as "match the words", which is what the box did before this route existed. A misconfiguration
+ * (URL without key) is a 503 rather than a quiet null, so it is seen; the client falls back to the
+ * words on that too.
+ */
+export const dynamic = 'force-dynamic';
+
+function isSameOrigin(req: Request): boolean {
+  const origin = req.headers.get('origin');
+  const host = req.headers.get('host');
+  if (!origin) return process.env.NODE_ENV !== 'production';
+  try {
+    return new URL(origin).host === host;
+  } catch {
+    return false;
+  }
+}
+
+function jsonError(status: number, message: string) {
+  return NextResponse.json({ error: message }, { status });
+}
+
+export async function POST(req: Request) {
+  if (!isSameOrigin(req)) return jsonError(403, 'Forbidden');
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return jsonError(400, 'Body must be JSON.');
+  }
+  const parsed = parseSemanticClaimSearchRequest(body);
+  if (!parsed.ok) return jsonError(400, parsed.error);
+
+  let config;
+  try {
+    config = getGeoLensSearchConfig();
+  } catch (error) {
+    console.error('[debates/semantic-search] geo-lens is misconfigured', error);
+    return jsonError(503, 'Semantic search is misconfigured.');
+  }
+  if (!config) return NextResponse.json({ hits: null } satisfies SemanticClaimSearchResponse);
+
+  try {
+    const hits = await searchSemanticClaims(parsed.request, config);
+    return NextResponse.json({ hits } satisfies SemanticClaimSearchResponse);
+  } catch (error) {
+    console.error('[debates/semantic-search] geo-lens query failed', error);
+    return jsonError(502, 'Semantic search is unavailable.');
+  }
+}

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.test.tsx
@@ -666,7 +666,23 @@ function mutation(mutate = mocks.mutate) {
   return { mutate, mutateAsync: mutate, isPending: false, error: null };
 }
 
+// The semantic-search route is not configured in this environment: it answers `hits: null`, and
+// the search matches words — the behaviour these tests cover. Every other request stays refused,
+// as the setup file has it.
+const refuseNetwork = globalThis.fetch;
+const semanticRouteUnconfigured: typeof fetch = async (input, init) => {
+  const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+  if (url.includes('/api/debates/claims/semantic-search')) {
+    return new Response(JSON.stringify({ hits: null }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  }
+  return refuseNetwork(input, init);
+};
+
 beforeEach(() => {
+  vi.stubGlobal('fetch', semanticRouteUnconfigured);
   clearDebateReturnDestination();
   mocks.replace.mockReset();
   mocks.back.mockReset();
@@ -780,6 +796,7 @@ beforeEach(() => {
 afterEach(() => {
   clearDebateReturnDestination();
   vi.restoreAllMocks();
+  vi.unstubAllGlobals();
   cleanup();
 });
 

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -302,13 +302,14 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
     [debouncedSearch, debouncedTopicIds, eligibleSpaceIds, spaceIds]
   );
 
-  // The search, resolved the way the hub resolves it: geo-lens's answer to the words when it has
-  // one, the words themselves otherwise, and the previous filters held while it is being asked.
-  const { filters: taggedFilters, pending: semanticPending } = useSemanticTaggedFilters(
-    claimsTagId,
-    typedTaggedFilters,
-    taggedEnabled && !allowlistPending
-  );
+  // The search, resolved the way the hub resolves it: geo-lens's answer to the words, an empty
+  // answer included, the previous filters held while it is being asked, and a failure reported
+  // as the tab's error.
+  const {
+    filters: taggedFilters,
+    pending: semanticPending,
+    error: semanticError,
+  } = useSemanticTaggedFilters(claimsTagId, typedTaggedFilters, taggedEnabled && !allowlistPending);
 
   // One ranked, filtered page of the tag at a time (GEO-2798), carrying its own topics and its
   // "Is factual" value — so there is no entity lookup behind it and no corpus held to show the top
@@ -994,8 +995,8 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
         ? // The page is the list, and it carries everything a row is built from — so its failure is
           // the only one that leaves nothing to show. geo-chat's row lookup is metadata beside it:
           // losing it costs the faces and the readiness, not the claims, and blanking the tab for
-          // that trades a short list for no list.
-          taggedCatalogError
+          // that trades a short list for no list. The search that chose the page is part of it.
+          (taggedCatalogError ?? semanticError)
         : curatedClaimsQuery.error);
 
   // A topic the menu no longer offers is unpickable as well as empty — the chip filtering the

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -61,6 +61,7 @@ import { DEBATE_TAG_ID } from '~/core/debates/ontology';
 import { participantSidesOn, useParticipantPositions } from '~/core/debates/participant-positions';
 import { useRecommendedClaimSections } from '~/core/debates/recommended-claims';
 import { REQUEST_PENDING_LABEL, debateRequestGate } from '~/core/debates/request-gate';
+import { useSemanticTaggedFilters } from '~/core/debates/semantic-claim-search';
 import {
   type TaggedClaimFilters,
   tagDisplaySpaceId,
@@ -296,9 +297,17 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
 
   const { value: debouncedTopicIds, pending: topicsSettling } = useDebouncedSelection(topicIds);
 
-  const taggedFilters = React.useMemo<TaggedClaimFilters>(
+  const typedTaggedFilters = React.useMemo<TaggedClaimFilters>(
     () => ({ search: debouncedSearch, topicIds: debouncedTopicIds, spaceIds, eligibleSpaceIds }),
     [debouncedSearch, debouncedTopicIds, eligibleSpaceIds, spaceIds]
+  );
+
+  // The search, resolved the way the hub resolves it: geo-lens's answer to the words when it has
+  // one, the words themselves otherwise, and the previous filters held while it is being asked.
+  const { filters: taggedFilters, pending: semanticPending } = useSemanticTaggedFilters(
+    claimsTagId,
+    typedTaggedFilters,
+    taggedEnabled && !allowlistPending
   );
 
   // One ranked, filtered page of the tag at a time (GEO-2798), carrying its own topics and its
@@ -1017,9 +1026,10 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
     // already cached settles it instantly while the facet is still out, and the menu it hands over
     // in that gap is empty for the same reason an outage's is. Same rule as the two above, applied
     // to the one source whose menu does not come from its own rows.
-    const resolved = !topicsSettling && !tabIsLoading && !tabError && (!graphFiltered || taggedTopicFacet.settled);
+    const resolved =
+      !topicsSettling && !semanticPending && !tabIsLoading && !tabError && (!graphFiltered || taggedTopicFacet.settled);
     setTopicIds(current => keepSelectableTopics(current, facetTopics, resolved));
-  }, [facetTopics, graphFiltered, tabError, tabIsLoading, taggedTopicFacet.settled, topicsSettling]);
+  }, [facetTopics, graphFiltered, semanticPending, tabError, tabIsLoading, taggedTopicFacet.settled, topicsSettling]);
 
   // The curated tab groups by block rather than listing flat, but narrows on the same filters.
   const showsSections = tab === 'claims' && source === 'recommended';
@@ -1215,7 +1225,8 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
               // blinking, so without this they read as current for a debounce plus a request.
               countsPending={
                 searchSettling ||
-                (graphFiltered && (topicsSettling || !taggedTopicFacet.settled || !taggedSpaceFacet.settled))
+                (graphFiltered &&
+                  (topicsSettling || semanticPending || !taggedTopicFacet.settled || !taggedSpaceFacet.settled))
               }
               topicAtEnd
               // Only on Claims: the opponent's tab is one fixed source — their own responses — and

--- a/apps/web/core/debates/matchmaking/claims-tab.test.tsx
+++ b/apps/web/core/debates/matchmaking/claims-tab.test.tsx
@@ -594,7 +594,23 @@ async function showAllClaims() {
 const MINE = '019fedb1-0c41-7f3e-9a11-2c7d5e8b4419';
 const THEIRS = '019fedb2-1d52-7a4f-8b22-3d8e6f9c5520';
 
+// The semantic-search route is not configured in this environment: it answers `hits: null`, and
+// the search matches words — the behaviour these tests cover. Every other request stays refused,
+// as the setup file has it.
+const refuseNetwork = globalThis.fetch;
+const semanticRouteUnconfigured: typeof fetch = async (input, init) => {
+  const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+  if (url.includes('/api/debates/claims/semantic-search')) {
+    return new Response(JSON.stringify({ hits: null }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  }
+  return refuseNetwork(input, init);
+};
+
 beforeEach(() => {
+  vi.stubGlobal('fetch', semanticRouteUnconfigured);
   // Not a mock fn, so `resetAllMocks` does not restore it.
   mocks.authenticated = true;
   mocks.accountKey = 'account-1' as string | null;
@@ -672,7 +688,10 @@ beforeEach(() => {
   } as unknown as typeof ResizeObserver;
 });
 
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
 
 describe('ClaimsTab', () => {
   // GEO-2684. The list pages forever, so controls left in the scrolling body meant scrolling back

--- a/apps/web/core/debates/matchmaking/claims-tab.tsx
+++ b/apps/web/core/debates/matchmaking/claims-tab.tsx
@@ -306,15 +306,17 @@ export function ClaimsTab() {
   // now would fetch and cache a page scoped to every space and then narrow it under the viewer.
   const taggedEnabled = graphSourced && !spacesPending;
 
-  // The search, resolved: geo-lens's answer to the words when it has one, the words themselves
-  // otherwise. Resolved before the list and both facets are asked, so all three describe one set.
-  // While geo-lens is being asked the previous filters stand, which is what keeps the rows on
-  // screen; `semanticPending` covers the counts for that window like the debounce does.
-  const { filters: taggedFilters, pending: semanticPending } = useSemanticTaggedFilters(
-    claimsTagId,
-    typedTaggedFilters,
-    taggedEnabled
-  );
+  // The search, resolved: geo-lens's answer to the words, an empty answer included. Resolved
+  // before the list and both facets are asked, so all three describe one set. While geo-lens is
+  // being asked the previous filters stand, which is what keeps the rows on screen;
+  // `semanticPending` covers the counts for that window like the debounce does. A failed search
+  // is the list's error, with the same retry.
+  const {
+    filters: taggedFilters,
+    pending: semanticPending,
+    error: semanticError,
+    refetch: refetchSemantic,
+  } = useSemanticTaggedFilters(claimsTagId, typedTaggedFilters, taggedEnabled);
   const {
     claims: taggedClaims,
     isLoading: taggedLoading,
@@ -639,7 +641,7 @@ export function ClaimsTab() {
           // viewer's topic selection is not spent, and `taggedKindResolvedFor` keeps a card
           // unpressable until its vocabulary and the viewer's own side have actually arrived. A
           // short list beats a blank one; a wrong publish beats neither, and is what those guard.
-          error={graphSourced ? taggedError : claimsQuery.error}
+          error={graphSourced ? (taggedError ?? semanticError) : claimsQuery.error}
           // Retries whatever failed, not just the catalog. The error above can come from either of
           // the two lookups behind the list, and neither is keyed on the catalog — so refetching
           // only that left the failed dependency untouched and the error state exactly where it
@@ -649,6 +651,7 @@ export function ClaimsTab() {
           onRetry={() =>
             void (graphSourced
               ? Promise.all([
+                  refetchSemantic(),
                   refetchTagged(),
                   queryClient.invalidateQueries({ queryKey: CLAIM_ENTITIES_QUERY_PREFIX }),
                   queryClient.invalidateQueries({ queryKey: DEBATE_CLAIMS_QUERY_PREFIX }),

--- a/apps/web/core/debates/matchmaking/claims-tab.tsx
+++ b/apps/web/core/debates/matchmaking/claims-tab.tsx
@@ -27,6 +27,7 @@ import type {
 } from '../api';
 import { eligibleClaimSpaceIds, isClaimSpaceAllowed } from '../claim-space-allowlist';
 import { useDebateActivity, useDebateClaimsBySpaces, useGeoChatAuth } from '../hooks';
+import { useSemanticTaggedFilters } from '../semantic-claim-search';
 import {
   type TaggedClaim,
   type TaggedClaimFilters,
@@ -291,7 +292,7 @@ export function ClaimsTab() {
   // set. Without that a topic living only in a space the viewer cannot see is still offered, and
   // picking it returns rows the client then removes — an option that can only produce an empty list
   // (GEO-2653). It is the same list geo-chat's own query is scoped by, for the same reason.
-  const taggedFilters = React.useMemo<TaggedClaimFilters>(
+  const typedTaggedFilters = React.useMemo<TaggedClaimFilters>(
     () => ({
       search: debouncedSearch,
       topicIds: debouncedTopicIds,
@@ -304,6 +305,16 @@ export function ClaimsTab() {
   // Held while the space gates are still resolving: they pass everything until they land, so asking
   // now would fetch and cache a page scoped to every space and then narrow it under the viewer.
   const taggedEnabled = graphSourced && !spacesPending;
+
+  // The search, resolved: geo-lens's answer to the words when it has one, the words themselves
+  // otherwise. Resolved before the list and both facets are asked, so all three describe one set.
+  // While geo-lens is being asked the previous filters stand, which is what keeps the rows on
+  // screen; `semanticPending` covers the counts for that window like the debounce does.
+  const { filters: taggedFilters, pending: semanticPending } = useSemanticTaggedFilters(
+    claimsTagId,
+    typedTaggedFilters,
+    taggedEnabled
+  );
   const {
     claims: taggedClaims,
     isLoading: taggedLoading,
@@ -506,7 +517,9 @@ export function ClaimsTab() {
   // window this flag exists to mark, or the old counts read as current for a debounce plus a
   // request. `facetsSettled` is the same question these menus already answer with.
   const countsPending =
-    searchSettling || indexedCountsPending || (graphSourced && (topicsSettling || spacesSettling || !facetsSettled));
+    searchSettling ||
+    indexedCountsPending ||
+    (graphSourced && (topicsSettling || spacesSettling || semanticPending || !facetsSettled));
 
   // The space is let go on the condition that actually means "not yours to pick" — the gates
   // stopped admitting it — rather than on its absence from the facet.
@@ -539,9 +552,14 @@ export function ClaimsTab() {
   // re-runs on its own output while the query is still debounced on the previous selection and
   // `facetsSettled` is still true from it — reconciling repeatedly against one stale answer and
   // draining the whole selection in a single tick, rather than one pick per server response.
+  //
+  // `semanticPending` for the same reason as `topicsSettling`: the menu in hand answers the search
+  // the viewer has moved on from, and is settled only for that one.
   React.useEffect(() => {
-    setTopicIds(current => keepSelectableTopics(current, facetTopics, facetsSettled && !topicsSettling));
-  }, [facetTopics, facetsSettled, topicsSettling]);
+    setTopicIds(current =>
+      keepSelectableTopics(current, facetTopics, facetsSettled && !topicsSettling && !semanticPending)
+    );
+  }, [facetTopics, facetsSettled, semanticPending, topicsSettling]);
 
   // Featured is not counted: it chooses which list is on screen rather than narrowing one, so an
   // empty Featured tab should say nothing is featured — not that filters are hiding things — and

--- a/apps/web/core/debates/semantic-claim-search-contract.test.ts
+++ b/apps/web/core/debates/semantic-claim-search-contract.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  MAX_SEMANTIC_SPACE_IDS,
+  MAX_SEMANTIC_TOPIC_IDS,
+  normalizeGeoId,
+  parseSemanticClaimSearchRequest,
+} from './semantic-claim-search-contract';
+
+const TAG = 'ec3086a54ddf43d8aaefd6cc6e1b0556';
+const SPACE = '019fedae72b67ab2927adf044d57c566';
+const TOPIC = '5d050707bc5840119b1e81ad3adb6244';
+
+describe('normalizeGeoId', () => {
+  it('accepts dashed or dashless ids and answers dashless lowercase', () => {
+    expect(normalizeGeoId('EC3086A5-4DDF-43D8-AAEF-D6CC6E1B0556')).toBe(TAG);
+    expect(normalizeGeoId(TAG)).toBe(TAG);
+  });
+
+  it('refuses anything that is not a Geo id', () => {
+    expect(normalizeGeoId('not-an-id')).toBeNull();
+    expect(normalizeGeoId(TAG.slice(1))).toBeNull();
+    expect(normalizeGeoId(42)).toBeNull();
+    expect(normalizeGeoId(null)).toBeNull();
+  });
+});
+
+describe('parseSemanticClaimSearchRequest', () => {
+  it('normalizes every id and trims and caps the query', () => {
+    const parsed = parseSemanticClaimSearchRequest({
+      query: `  ${'x'.repeat(150)}`,
+      tagId: 'EC3086A5-4DDF-43D8-AAEF-D6CC6E1B0556',
+      spaceIds: [SPACE.toUpperCase()],
+      topicIds: [TOPIC],
+    });
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) return;
+    expect(parsed.request.query).toBe('x'.repeat(100));
+    expect(parsed.request.tagId).toBe(TAG);
+    expect(parsed.request.spaceIds).toEqual([SPACE]);
+    expect(parsed.request.topicIds).toEqual([TOPIC]);
+  });
+
+  it('reads a missing space list as any space and a missing topic list as none', () => {
+    const parsed = parseSemanticClaimSearchRequest({ query: 'q', tagId: TAG, spaceIds: null });
+    expect(parsed).toEqual({ ok: true, request: { query: 'q', tagId: TAG, spaceIds: null, topicIds: [] } });
+    expect(parseSemanticClaimSearchRequest({ query: 'q', tagId: TAG })).toEqual(parsed);
+  });
+
+  it.each([
+    ['not an object', 'nope'],
+    ['no query', { tagId: TAG }],
+    ['a blank query', { query: '   ', tagId: TAG }],
+    ['no tag', { query: 'q' }],
+    ['a bad tag', { query: 'q', tagId: 'tag' }],
+    ['a bad space id', { query: 'q', tagId: TAG, spaceIds: ['space'] }],
+    ['a bad topic id', { query: 'q', tagId: TAG, topicIds: [42] }],
+    ['too many spaces', { query: 'q', tagId: TAG, spaceIds: Array(MAX_SEMANTIC_SPACE_IDS + 1).fill(SPACE) }],
+    ['too many topics', { query: 'q', tagId: TAG, topicIds: Array(MAX_SEMANTIC_TOPIC_IDS + 1).fill(TOPIC) }],
+  ])('refuses %s', (_label, body) => {
+    expect(parseSemanticClaimSearchRequest(body).ok).toBe(false);
+  });
+});

--- a/apps/web/core/debates/semantic-claim-search-contract.ts
+++ b/apps/web/core/debates/semantic-claim-search-contract.ts
@@ -1,0 +1,99 @@
+import { capSearchQuery } from '~/core/io/search-query';
+
+/**
+ * The wire between the hub's search box and `POST /api/debates/claims/semantic-search`, shared by
+ * the route and the client hook so neither can drift from the other.
+ *
+ * Deliberately narrow. The route is a proxy for geo-lens, which answers arbitrary graph questions
+ * given the key it holds; what crosses this boundary is only what the search box can ask — which
+ * tag, which spaces, which topics, which words — and the route fixes everything else (the relation
+ * types, the cache, the strategy, the floor) on its side. No relation type, no strategy name and
+ * no score threshold ever arrives from the browser.
+ */
+export type SemanticClaimSearchRequest = {
+  /** The words typed, already debounced and trimmed. Capped like every other search box. */
+  query: string;
+  /** The curation tag the list is drawn from — Featured or Debate. */
+  tagId: string;
+  /**
+   * The spaces the claim must be *tagged* in, or `null` for any. The viewer's eligible set, never
+   * the picked one: the picked spaces narrow the rows and the topic menu on the graph side, and
+   * the space menu must not be narrowed by its own selection — the same rule `taggedEntityFilter`
+   * follows, applied one step earlier.
+   */
+  spaceIds: string[] | null;
+  /** AND-ed, as everywhere else: a claim has to carry every one of them. */
+  topicIds: string[];
+};
+
+export type SemanticClaimSearchResponse = {
+  /**
+   * Closest first, already above the floor. `null` means the search was not made — geo-lens is not
+   * configured on this deployment — which the client reads as "use the words", not as "nothing".
+   */
+  hits: Array<{ id: string; score: number }> | null;
+};
+
+/** Enough claims to fill a page of the list; the list shows a semantic answer as one page. */
+export const SEMANTIC_SEARCH_K = 50;
+
+/**
+ * The most topics a request may carry. geo-lens bounds its relation filters at eight and the tag
+ * takes one of them; nobody narrowing a list of a few hundred claims picks more.
+ */
+export const MAX_SEMANTIC_TOPIC_IDS = 7;
+
+/** The most spaces a request may name. The widest viewer allowlist is a few dozen. */
+export const MAX_SEMANTIC_SPACE_IDS = 200;
+
+const HEX32 = /^[0-9a-f]{32}$/;
+
+/** Dashless lowercase, the spelling geo-lens stores; `null` for anything that is not a Geo id. */
+export function normalizeGeoId(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const normalized = value.replace(/-/g, '').toLowerCase();
+  return HEX32.test(normalized) ? normalized : null;
+}
+
+function normalizeIdList(value: unknown, max: number): string[] | null {
+  if (!Array.isArray(value) || value.length > max) return null;
+  const ids: string[] = [];
+  for (const item of value) {
+    const id = normalizeGeoId(item);
+    if (!id) return null;
+    ids.push(id);
+  }
+  return ids;
+}
+
+export type ParsedSemanticClaimSearchRequest =
+  { ok: true; request: SemanticClaimSearchRequest } | { ok: false; error: string };
+
+/**
+ * A request as the route accepts it, or why it does not.
+ *
+ * Every id is normalized here rather than trusted, so the route can hand them to geo-lens as-is;
+ * a query that caps to nothing is refused rather than sent, since geo-lens would refuse it too.
+ */
+export function parseSemanticClaimSearchRequest(body: unknown): ParsedSemanticClaimSearchRequest {
+  if (typeof body !== 'object' || body === null) return { ok: false, error: 'Body must be a JSON object.' };
+  const raw = body as Record<string, unknown>;
+
+  const query = typeof raw.query === 'string' ? capSearchQuery(raw.query).trim() : '';
+  if (!query) return { ok: false, error: 'query must be a non-empty string.' };
+
+  const tagId = normalizeGeoId(raw.tagId);
+  if (!tagId) return { ok: false, error: 'tagId must be a Geo entity id.' };
+
+  const spaceIds =
+    raw.spaceIds === null || raw.spaceIds === undefined ? null : normalizeIdList(raw.spaceIds, MAX_SEMANTIC_SPACE_IDS);
+  if (raw.spaceIds !== null && raw.spaceIds !== undefined && spaceIds === null) {
+    return { ok: false, error: `spaceIds must be null or up to ${MAX_SEMANTIC_SPACE_IDS} Geo space ids.` };
+  }
+
+  const topicIds = raw.topicIds === undefined ? [] : normalizeIdList(raw.topicIds, MAX_SEMANTIC_TOPIC_IDS);
+  if (topicIds === null)
+    return { ok: false, error: `topicIds must be up to ${MAX_SEMANTIC_TOPIC_IDS} Geo entity ids.` };
+
+  return { ok: true, request: { query, tagId, spaceIds, topicIds } };
+}

--- a/apps/web/core/debates/semantic-claim-search.test.ts
+++ b/apps/web/core/debates/semantic-claim-search.test.ts
@@ -66,19 +66,30 @@ describe('resolveSemanticSearch', () => {
     );
   });
 
-  it('falls back to the words on an error, an empty answer, or an unconfigured route', () => {
-    for (const args of [
-      { status: 'error' as const, hits: undefined },
-      { status: 'success' as const, hits: [] },
-      { status: 'success' as const, hits: null },
-    ]) {
-      expect(resolveSemanticSearch({ search: 'q', enabled: true, ...args })).toEqual({ mode: 'text', hits: null });
-    }
+  it('takes an empty answer as the answer, never the words', () => {
+    expect(resolveSemanticSearch({ search: 'q', enabled: true, status: 'success', hits: [] })).toEqual({
+      mode: 'answered',
+      hits: [],
+    });
   });
 
-  it('is semantic with hits', () => {
+  it('empties the list on a failure and reports it', () => {
+    expect(resolveSemanticSearch({ search: 'q', enabled: true, status: 'error', hits: undefined })).toEqual({
+      mode: 'error',
+      hits: [],
+    });
+  });
+
+  it('hands the words through only when the route is not configured', () => {
+    expect(resolveSemanticSearch({ search: 'q', enabled: true, status: 'success', hits: null })).toEqual({
+      mode: 'unconfigured',
+      hits: null,
+    });
+  });
+
+  it('is answered with hits', () => {
     expect(resolveSemanticSearch({ search: 'q', enabled: true, status: 'success', hits: HITS })).toEqual({
-      mode: 'semantic',
+      mode: 'answered',
       hits: HITS,
     });
   });
@@ -90,6 +101,7 @@ describe('sameTaggedFilters', () => {
     expect(sameTaggedFilters(filters({ semanticHits: HITS }), filters({ semanticHits: [...HITS] }))).toBe(true);
     expect(sameTaggedFilters(filters(), filters({ search: 'other' }))).toBe(false);
     expect(sameTaggedFilters(filters(), filters({ semanticHits: HITS }))).toBe(false);
+    expect(sameTaggedFilters(filters({ semanticHits: [] }), filters({ semanticHits: null }))).toBe(false);
     expect(sameTaggedFilters(filters(), filters({ eligibleSpaceIds: null }))).toBe(false);
   });
 });
@@ -100,7 +112,7 @@ describe('useSemanticTaggedFilters', () => {
     // A fresh filters object every render, on purpose: the hook must settle rather than re-hold.
     const { result } = renderHook(() => useSemanticTaggedFilters(TAG, filters(), true), { wrapper });
 
-    await waitFor(() => expect(result.current.mode).toBe('semantic'));
+    await waitFor(() => expect(result.current.mode).toBe('answered'));
     expect(sentBody(fetchMock)).toEqual({
       query: 'trump affair',
       tagId: TAG,
@@ -110,28 +122,50 @@ describe('useSemanticTaggedFilters', () => {
     // the hits ride on the filters; the words and every other filter stay as they were
     expect(result.current.filters).toEqual({ ...filters(), semanticHits: HITS });
     expect(result.current.pending).toBe(false);
+    expect(result.current.error).toBeNull();
   });
 
-  it('hands the words through when geo-lens finds nothing', async () => {
+  it('hands an empty answer to the list as an empty answer, not as the words', async () => {
     stubRoute({ body: { hits: [] } });
     const typed = filters();
     const { result } = renderHook(() => useSemanticTaggedFilters(TAG, typed, true), { wrapper });
 
-    await waitFor(() => expect(result.current.mode).toBe('text'));
-    expect(result.current.filters).toEqual({ ...filters(), semanticHits: null });
+    await waitFor(() => expect(result.current.mode).toBe('answered'));
+    expect(result.current.filters).toEqual({ ...typed, semanticHits: [] });
+    expect(result.current.error).toBeNull();
   });
 
-  it('hands the words through when the route is not configured, or fails', async () => {
-    const typed = filters();
-    stubRoute({ body: { hits: null } });
-    const off = renderHook(() => useSemanticTaggedFilters(TAG, typed, true), { wrapper });
-    await waitFor(() => expect(off.result.current.mode).toBe('text'));
-    expect(off.result.current.filters.semanticHits).toBeNull();
-
+  it('empties the list and reports the failure when the route fails', async () => {
     stubRoute({ status: 502, body: { error: 'down' } });
-    const failed = renderHook(() => useSemanticTaggedFilters(TAG, typed, true), { wrapper });
-    await waitFor(() => expect(failed.result.current.mode).toBe('text'));
-    expect(failed.result.current.filters).toEqual({ ...filters(), semanticHits: null });
+    const typed = filters();
+    const { result } = renderHook(() => useSemanticTaggedFilters(TAG, typed, true), { wrapper });
+
+    await waitFor(() => expect(result.current.mode).toBe('error'));
+    expect(result.current.filters).toEqual({ ...typed, semanticHits: [] });
+    expect(result.current.error).toBeInstanceOf(Error);
+  });
+
+  it('asks again on retry', async () => {
+    const fetchMock = stubRoute({ status: 502, body: { error: 'down' } });
+    const typed = filters();
+    const { result } = renderHook(() => useSemanticTaggedFilters(TAG, typed, true), { wrapper });
+    await waitFor(() => expect(result.current.mode).toBe('error'));
+
+    stubRoute({ body: { hits: HITS } });
+    await result.current.refetch();
+    await waitFor(() => expect(result.current.mode).toBe('answered'));
+    expect(result.current.filters.semanticHits).toEqual(HITS);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('hands the words through when the route is not configured', async () => {
+    stubRoute({ body: { hits: null } });
+    const typed = filters();
+    const { result } = renderHook(() => useSemanticTaggedFilters(TAG, typed, true), { wrapper });
+
+    await waitFor(() => expect(result.current.mode).toBe('unconfigured'));
+    expect(result.current.filters).toEqual({ ...typed, semanticHits: null });
+    expect(result.current.error).toBeNull();
   });
 
   it('does not ask with nothing typed, and passes the filters through', () => {
@@ -139,7 +173,8 @@ describe('useSemanticTaggedFilters', () => {
     const empty = filters({ search: '' });
     const { result } = renderHook(() => useSemanticTaggedFilters(TAG, empty, true), { wrapper });
 
-    expect(result.current).toEqual({ filters: { ...empty, semanticHits: null }, pending: false, mode: 'off' });
+    expect(result.current.filters).toEqual({ ...empty, semanticHits: null });
+    expect(result.current).toMatchObject({ pending: false, error: null, mode: 'off' });
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
@@ -167,7 +202,7 @@ describe('useSemanticTaggedFilters', () => {
       ({ current }: { current: TaggedClaimFilters }) => useSemanticTaggedFilters(TAG, current, true),
       { wrapper, initialProps: { current: filters() } }
     );
-    await waitFor(() => expect(result.current.mode).toBe('semantic'));
+    await waitFor(() => expect(result.current.mode).toBe('answered'));
     const settled = result.current.filters;
 
     stubRoute({ body: { hits: [] }, delayMs: 50 });
@@ -178,7 +213,7 @@ describe('useSemanticTaggedFilters', () => {
     expect(result.current.pending).toBe(true);
     expect(result.current.filters).toBe(settled);
 
-    await waitFor(() => expect(result.current.mode).toBe('text'));
-    expect(result.current.filters).toEqual({ ...retyped, semanticHits: null });
+    await waitFor(() => expect(result.current.mode).toBe('answered'));
+    expect(result.current.filters).toEqual({ ...retyped, semanticHits: [] });
   });
 });

--- a/apps/web/core/debates/semantic-claim-search.test.ts
+++ b/apps/web/core/debates/semantic-claim-search.test.ts
@@ -1,0 +1,184 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+
+import * as React from 'react';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { resolveSemanticSearch, sameTaggedFilters, useSemanticTaggedFilters } from './semantic-claim-search';
+import { NO_TAGGED_CLAIM_FILTERS, type TaggedClaimFilters } from './tagged-claims';
+
+const TAG = 'ec3086a54ddf43d8aaefd6cc6e1b0556';
+const SPACE = '019fedae72b67ab2927adf044d57c566';
+const TOPIC = '5d050707bc5840119b1e81ad3adb6244';
+const HITS = [
+  { id: 'a2', score: 0.93 },
+  { id: 'a1', score: 0.85 },
+];
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return React.createElement(QueryClientProvider, { client }, children);
+}
+
+/** The route, answering every request with `body` (or failing with `status`). */
+function stubRoute(answer: { body?: unknown; status?: number; delayMs?: number }) {
+  const fetchMock = vi.fn(async () => {
+    if (answer.delayMs) await new Promise(resolve => setTimeout(resolve, answer.delayMs));
+    return new Response(JSON.stringify(answer.body ?? { hits: null }), {
+      status: answer.status ?? 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  });
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+}
+
+function sentBody(fetchMock: ReturnType<typeof vi.fn>, call = 0) {
+  return JSON.parse(String((fetchMock.mock.calls[call][1] as RequestInit).body));
+}
+
+const filters = (overrides: Partial<TaggedClaimFilters> = {}): TaggedClaimFilters => ({
+  ...NO_TAGGED_CLAIM_FILTERS,
+  search: 'trump affair',
+  topicIds: [TOPIC],
+  spaceIds: [SPACE],
+  eligibleSpaceIds: [SPACE, 'b'.repeat(32)],
+  ...overrides,
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('resolveSemanticSearch', () => {
+  it('is off with nothing typed or the list not asked', () => {
+    expect(resolveSemanticSearch({ search: '', enabled: true, status: 'success', hits: HITS })).toEqual({
+      mode: 'off',
+      hits: null,
+    });
+    expect(resolveSemanticSearch({ search: 'q', enabled: false, status: 'success', hits: HITS }).mode).toBe('off');
+  });
+
+  it('is pending until geo-lens answers', () => {
+    expect(resolveSemanticSearch({ search: 'q', enabled: true, status: 'pending', hits: undefined }).mode).toBe(
+      'pending'
+    );
+  });
+
+  it('falls back to the words on an error, an empty answer, or an unconfigured route', () => {
+    for (const args of [
+      { status: 'error' as const, hits: undefined },
+      { status: 'success' as const, hits: [] },
+      { status: 'success' as const, hits: null },
+    ]) {
+      expect(resolveSemanticSearch({ search: 'q', enabled: true, ...args })).toEqual({ mode: 'text', hits: null });
+    }
+  });
+
+  it('is semantic with hits', () => {
+    expect(resolveSemanticSearch({ search: 'q', enabled: true, status: 'success', hits: HITS })).toEqual({
+      mode: 'semantic',
+      hits: HITS,
+    });
+  });
+});
+
+describe('sameTaggedFilters', () => {
+  it('compares by value, hits included', () => {
+    expect(sameTaggedFilters(filters(), filters())).toBe(true);
+    expect(sameTaggedFilters(filters({ semanticHits: HITS }), filters({ semanticHits: [...HITS] }))).toBe(true);
+    expect(sameTaggedFilters(filters(), filters({ search: 'other' }))).toBe(false);
+    expect(sameTaggedFilters(filters(), filters({ semanticHits: HITS }))).toBe(false);
+    expect(sameTaggedFilters(filters(), filters({ eligibleSpaceIds: null }))).toBe(false);
+  });
+});
+
+describe('useSemanticTaggedFilters', () => {
+  it('asks the route over the tag, the eligible spaces and the topics — never the picked spaces', async () => {
+    const fetchMock = stubRoute({ body: { hits: HITS } });
+    // A fresh filters object every render, on purpose: the hook must settle rather than re-hold.
+    const { result } = renderHook(() => useSemanticTaggedFilters(TAG, filters(), true), { wrapper });
+
+    await waitFor(() => expect(result.current.mode).toBe('semantic'));
+    expect(sentBody(fetchMock)).toEqual({
+      query: 'trump affair',
+      tagId: TAG,
+      spaceIds: [SPACE, 'b'.repeat(32)],
+      topicIds: [TOPIC],
+    });
+    // the hits ride on the filters; the words and every other filter stay as they were
+    expect(result.current.filters).toEqual({ ...filters(), semanticHits: HITS });
+    expect(result.current.pending).toBe(false);
+  });
+
+  it('hands the words through when geo-lens finds nothing', async () => {
+    stubRoute({ body: { hits: [] } });
+    const typed = filters();
+    const { result } = renderHook(() => useSemanticTaggedFilters(TAG, typed, true), { wrapper });
+
+    await waitFor(() => expect(result.current.mode).toBe('text'));
+    expect(result.current.filters).toEqual({ ...filters(), semanticHits: null });
+  });
+
+  it('hands the words through when the route is not configured, or fails', async () => {
+    const typed = filters();
+    stubRoute({ body: { hits: null } });
+    const off = renderHook(() => useSemanticTaggedFilters(TAG, typed, true), { wrapper });
+    await waitFor(() => expect(off.result.current.mode).toBe('text'));
+    expect(off.result.current.filters.semanticHits).toBeNull();
+
+    stubRoute({ status: 502, body: { error: 'down' } });
+    const failed = renderHook(() => useSemanticTaggedFilters(TAG, typed, true), { wrapper });
+    await waitFor(() => expect(failed.result.current.mode).toBe('text'));
+    expect(failed.result.current.filters).toEqual({ ...filters(), semanticHits: null });
+  });
+
+  it('does not ask with nothing typed, and passes the filters through', () => {
+    const fetchMock = stubRoute({ body: { hits: HITS } });
+    const empty = filters({ search: '' });
+    const { result } = renderHook(() => useSemanticTaggedFilters(TAG, empty, true), { wrapper });
+
+    expect(result.current).toEqual({ filters: { ...empty, semanticHits: null }, pending: false, mode: 'off' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('shows the tag, not the words, while a search present at mount is being asked', () => {
+    stubRoute({ body: { hits: HITS }, delayMs: 50 });
+    const typed = filters();
+    const { result } = renderHook(() => useSemanticTaggedFilters(TAG, typed, true), { wrapper });
+
+    expect(result.current.pending).toBe(true);
+    expect(result.current.filters).toEqual({ ...typed, search: '', semanticHits: null });
+  });
+
+  it('does not ask for a list that is not being shown', () => {
+    const fetchMock = stubRoute({ body: { hits: HITS } });
+    const typed = filters();
+    const { result } = renderHook(() => useSemanticTaggedFilters(TAG, typed, false), { wrapper });
+
+    expect(result.current.mode).toBe('off');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('holds the previous answer while the next one is being asked', async () => {
+    stubRoute({ body: { hits: HITS } });
+    const { result, rerender } = renderHook(
+      ({ current }: { current: TaggedClaimFilters }) => useSemanticTaggedFilters(TAG, current, true),
+      { wrapper, initialProps: { current: filters() } }
+    );
+    await waitFor(() => expect(result.current.mode).toBe('semantic'));
+    const settled = result.current.filters;
+
+    stubRoute({ body: { hits: [] }, delayMs: 50 });
+    const retyped = filters({ search: 'trump affair allegations' });
+    rerender({ current: retyped });
+
+    // pending: the rows stay on the answer in hand, and the counts are told so
+    expect(result.current.pending).toBe(true);
+    expect(result.current.filters).toBe(settled);
+
+    await waitFor(() => expect(result.current.mode).toBe('text'));
+    expect(result.current.filters).toEqual({ ...retyped, semanticHits: null });
+  });
+});

--- a/apps/web/core/debates/semantic-claim-search.ts
+++ b/apps/web/core/debates/semantic-claim-search.ts
@@ -1,0 +1,150 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+
+import * as React from 'react';
+
+import type { SemanticClaimSearchRequest, SemanticClaimSearchResponse } from './semantic-claim-search-contract';
+import { type SemanticClaimHit, TAGGED_STALE_TIME, type TaggedClaimFilters } from './tagged-claims';
+
+/**
+ * Semantic search for the tagged claim lists — the hub's Featured and All claims, and the same two
+ * sources in the debate-again picker.
+ *
+ * The words typed go to geo-lens (through `/api/debates/claims/semantic-search`, which holds the
+ * key), which answers with the claims that *mean* them, over the same tag, spaces and topics the
+ * list is drawn from. Those ids become the list's filter in place of the word-by-word match, and
+ * the rows come back closest-first. When geo-lens finds nothing above its floor, is not configured,
+ * or fails, the words are matched as they always were — so the worst case is exactly what the box
+ * did before, never an empty list that a substring would have filled.
+ *
+ * Why the answer is resolved *before* the list is asked, rather than merged after: the facets. Both
+ * menus count over the same filter the rows use, and a search that changed the rows without
+ * changing the counts would offer topics that lead nowhere — GEO-2653 by another route.
+ */
+
+export type SemanticSearchMode =
+  /** No search, or this list is not being asked: the filters pass through untouched. */
+  | 'off'
+  /** geo-lens has been asked and has not answered. */
+  | 'pending'
+  /** geo-lens named claims; they are the list. */
+  | 'semantic'
+  /** geo-lens named nothing, is off, or failed: the words are matched instead. */
+  | 'text';
+
+/** The route's answer; `null` is "not configured here", which reads as the words, not as nothing. */
+export async function fetchSemanticClaimHits(
+  request: SemanticClaimSearchRequest,
+  signal?: AbortSignal
+): Promise<SemanticClaimHit[] | null> {
+  const response = await fetch('/api/debates/claims/semantic-search', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(request),
+    signal,
+  });
+  if (!response.ok) throw new Error(`Semantic search failed with status ${response.status}`);
+  const body = (await response.json()) as SemanticClaimSearchResponse;
+  return body.hits ?? null;
+}
+
+/**
+ * What the search box means for the list, given where geo-lens's answer stands.
+ *
+ * Pure, because the fallback is the part that matters and the part hardest to exercise through a
+ * hook: an error, an empty answer and an unconfigured deployment all have to land on the words.
+ */
+export function resolveSemanticSearch(args: {
+  search: string;
+  enabled: boolean;
+  status: 'pending' | 'error' | 'success';
+  hits: SemanticClaimHit[] | null | undefined;
+}): { mode: SemanticSearchMode; hits: SemanticClaimHit[] | null } {
+  if (!args.enabled || args.search === '') return { mode: 'off', hits: null };
+  if (args.status === 'pending') return { mode: 'pending', hits: null };
+  if (args.status === 'error' || !args.hits || args.hits.length === 0) return { mode: 'text', hits: null };
+  return { mode: 'semantic', hits: args.hits };
+}
+
+/**
+ * Alongside the tagged keys, and for the same reason: these come from geo-lens by way of our own
+ * route, not from geo-chat, so the gateway's reconnect refetch has no business touching them.
+ */
+export const semanticSearchQueryKey = (tagId: string, filters: TaggedClaimFilters) =>
+  ['tagged-claims', 'semantic', tagId, filters.search, filters.topicIds, filters.eligibleSpaceIds] as const;
+
+/**
+ * The filters to hand the tagged hooks, with the search resolved.
+ *
+ * While geo-lens is being asked, the filters last *resolved* are returned instead — so the rows on
+ * screen stay what they were, exactly as the debounce leaves them today, rather than blanking for a
+ * round trip. `pending` says so, for the counts: the menus describe the previous search until the
+ * new one lands, which is the window `countsPending` already covers for every other filter.
+ *
+ * The picked spaces are deliberately not part of the request. They narrow the rows and the topic
+ * menu on the graph side, where `taggedEntityFilter` applies them; the space menu must not be
+ * narrowed by its own selection, and it could not un-narrow an answer that was already cut.
+ */
+export function useSemanticTaggedFilters(
+  tagId: string,
+  filters: TaggedClaimFilters,
+  enabled: boolean
+): { filters: TaggedClaimFilters; pending: boolean; mode: SemanticSearchMode } {
+  const active = enabled && filters.search !== '';
+  const query = useQuery({
+    queryKey: semanticSearchQueryKey(tagId, filters),
+    queryFn: ({ signal }) =>
+      fetchSemanticClaimHits(
+        { query: filters.search, tagId, spaceIds: filters.eligibleSpaceIds, topicIds: filters.topicIds },
+        signal
+      ),
+    enabled: active,
+    // The tag's own answer stays fresh this long; a search over it has no reason to differ.
+    staleTime: TAGGED_STALE_TIME,
+    // The fallback *is* the retry. Waiting out a backoff to try geo-lens again would hold the list
+    // on a stale search for seconds when the words could answer it now.
+    retry: false,
+  });
+
+  const { mode, hits } = resolveSemanticSearch({
+    search: filters.search,
+    enabled,
+    status: query.status,
+    hits: query.data,
+  });
+
+  const resolved = React.useMemo<TaggedClaimFilters | null>(() => {
+    if (mode === 'pending') return null;
+    return { ...filters, semanticHits: mode === 'semantic' ? hits : null };
+  }, [filters, hits, mode]);
+
+  // The last answer, for the window in which there is no current one. Before there is any, the
+  // list as it stands with nothing typed: mounting with words already in the box shows the tag
+  // until geo-lens answers, rather than matching the words once and swapping. Kept by value, not
+  // identity: a caller re-rendering with an equal but fresh filters object would otherwise re-set
+  // the held copy on every render and re-render on every set.
+  const [held, setHeld] = React.useState<TaggedClaimFilters>(() => ({ ...filters, search: '', semanticHits: null }));
+  React.useEffect(() => {
+    if (resolved) setHeld(current => (sameTaggedFilters(current, resolved) ? current : resolved));
+  }, [resolved]);
+
+  return { filters: resolved ?? held, pending: mode === 'pending', mode };
+}
+
+function sameIds(a: readonly string[] | null | undefined, b: readonly string[] | null | undefined): boolean {
+  if (a === b) return true;
+  if (!a || !b || a.length !== b.length) return false;
+  return a.every((id, index) => id === b[index]);
+}
+
+/** Equal by what the tagged hooks read, which is also what their query keys are built from. */
+export function sameTaggedFilters(a: TaggedClaimFilters, b: TaggedClaimFilters): boolean {
+  return (
+    a.search === b.search &&
+    sameIds(a.topicIds, b.topicIds) &&
+    sameIds(a.spaceIds, b.spaceIds) &&
+    sameIds(a.eligibleSpaceIds, b.eligibleSpaceIds) &&
+    sameIds(a.semanticHits?.map(hit => hit.id) ?? null, b.semanticHits?.map(hit => hit.id) ?? null)
+  );
+}

--- a/apps/web/core/debates/semantic-claim-search.ts
+++ b/apps/web/core/debates/semantic-claim-search.ts
@@ -13,10 +13,16 @@ import { type SemanticClaimHit, TAGGED_STALE_TIME, type TaggedClaimFilters } fro
  *
  * The words typed go to geo-lens (through `/api/debates/claims/semantic-search`, which holds the
  * key), which answers with the claims that *mean* them, over the same tag, spaces and topics the
- * list is drawn from. Those ids become the list's filter in place of the word-by-word match, and
- * the rows come back closest-first. When geo-lens finds nothing above its floor, is not configured,
- * or fails, the words are matched as they always were — so the worst case is exactly what the box
- * did before, never an empty list that a substring would have filled.
+ * list is drawn from. Those ids become the list's filter, and the rows come back closest-first.
+ *
+ * geo-lens's answer is the answer, including an empty one. This used to fall back to matching the
+ * words when geo-lens named nothing, and that fallback was the source of every complaint: the
+ * words are matched as substrings, so "art" listed seventy-two claims about *part*ners, *part*ies
+ * and *start*ing, none about art, while geo-lens had correctly said there were none. A search that
+ * finds nothing now shows nothing, and a search that fails shows the list's error state with a
+ * retry, the same as the list failing. The one thing still matched by words is a deployment with
+ * no geo-lens configured at all — the route answers `hits: null` — because there the words are
+ * the only search there is.
  *
  * Why the answer is resolved *before* the list is asked, rather than merged after: the facets. Both
  * menus count over the same filter the rows use, and a search that changed the rows without
@@ -28,12 +34,14 @@ export type SemanticSearchMode =
   | 'off'
   /** geo-lens has been asked and has not answered. */
   | 'pending'
-  /** geo-lens named claims; they are the list. */
-  | 'semantic'
-  /** geo-lens named nothing, is off, or failed: the words are matched instead. */
-  | 'text';
+  /** geo-lens answered; the claims it named are the list, and none is an answer too. */
+  | 'answered'
+  /** The request failed: the list is empty and the failure is reported for the error state. */
+  | 'error'
+  /** No geo-lens on this deployment: the words are matched, there being nothing else. */
+  | 'unconfigured';
 
-/** The route's answer; `null` is "not configured here", which reads as the words, not as nothing. */
+/** The route's answer; `null` is "not configured here". */
 export async function fetchSemanticClaimHits(
   request: SemanticClaimSearchRequest,
   signal?: AbortSignal
@@ -49,11 +57,13 @@ export async function fetchSemanticClaimHits(
   return body.hits ?? null;
 }
 
+const NO_HITS: SemanticClaimHit[] = [];
+
 /**
  * What the search box means for the list, given where geo-lens's answer stands.
  *
- * Pure, because the fallback is the part that matters and the part hardest to exercise through a
- * hook: an error, an empty answer and an unconfigured deployment all have to land on the words.
+ * Pure, because the edges are the part that matters: an empty answer and a failure both have to
+ * produce an empty list — never the words — and only the unconfigured route may fall through.
  */
 export function resolveSemanticSearch(args: {
   search: string;
@@ -63,8 +73,9 @@ export function resolveSemanticSearch(args: {
 }): { mode: SemanticSearchMode; hits: SemanticClaimHit[] | null } {
   if (!args.enabled || args.search === '') return { mode: 'off', hits: null };
   if (args.status === 'pending') return { mode: 'pending', hits: null };
-  if (args.status === 'error' || !args.hits || args.hits.length === 0) return { mode: 'text', hits: null };
-  return { mode: 'semantic', hits: args.hits };
+  if (args.status === 'error') return { mode: 'error', hits: NO_HITS };
+  if (args.hits === null || args.hits === undefined) return { mode: 'unconfigured', hits: null };
+  return { mode: 'answered', hits: args.hits };
 }
 
 /**
@@ -73,6 +84,18 @@ export function resolveSemanticSearch(args: {
  */
 export const semanticSearchQueryKey = (tagId: string, filters: TaggedClaimFilters) =>
   ['tagged-claims', 'semantic', tagId, filters.search, filters.topicIds, filters.eligibleSpaceIds] as const;
+
+export type SemanticTaggedFilters = {
+  /** The filters to hand the tagged hooks, with the search resolved. */
+  filters: TaggedClaimFilters;
+  /** geo-lens is being asked; the filters are the previous answer's until it answers. */
+  pending: boolean;
+  /** The failed request, for the list's error state. `null` otherwise. */
+  error: unknown;
+  /** Ask geo-lens again after a failure; a no-op when nothing failed. */
+  refetch: () => Promise<unknown>;
+  mode: SemanticSearchMode;
+};
 
 /**
  * The filters to hand the tagged hooks, with the search resolved.
@@ -90,7 +113,7 @@ export function useSemanticTaggedFilters(
   tagId: string,
   filters: TaggedClaimFilters,
   enabled: boolean
-): { filters: TaggedClaimFilters; pending: boolean; mode: SemanticSearchMode } {
+): SemanticTaggedFilters {
   const active = enabled && filters.search !== '';
   const query = useQuery({
     queryKey: semanticSearchQueryKey(tagId, filters),
@@ -102,8 +125,8 @@ export function useSemanticTaggedFilters(
     enabled: active,
     // The tag's own answer stays fresh this long; a search over it has no reason to differ.
     staleTime: TAGGED_STALE_TIME,
-    // The fallback *is* the retry. Waiting out a backoff to try geo-lens again would hold the list
-    // on a stale search for seconds when the words could answer it now.
+    // A failure is shown, with a retry, rather than waited out: react-query's backoff would hold
+    // the list on the previous search for seconds with nothing on screen to say why.
     retry: false,
   });
 
@@ -116,7 +139,7 @@ export function useSemanticTaggedFilters(
 
   const resolved = React.useMemo<TaggedClaimFilters | null>(() => {
     if (mode === 'pending') return null;
-    return { ...filters, semanticHits: mode === 'semantic' ? hits : null };
+    return { ...filters, semanticHits: hits };
   }, [filters, hits, mode]);
 
   // The last answer, for the window in which there is no current one. Before there is any, the
@@ -129,7 +152,13 @@ export function useSemanticTaggedFilters(
     if (resolved) setHeld(current => (sameTaggedFilters(current, resolved) ? current : resolved));
   }, [resolved]);
 
-  return { filters: resolved ?? held, pending: mode === 'pending', mode };
+  return {
+    filters: resolved ?? held,
+    pending: mode === 'pending',
+    error: mode === 'error' ? (query.error ?? new Error('Semantic search failed')) : null,
+    refetch: query.refetch,
+    mode,
+  };
 }
 
 function sameIds(a: readonly string[] | null | undefined, b: readonly string[] | null | undefined): boolean {

--- a/apps/web/core/debates/server/geo-lens-search.test.ts
+++ b/apps/web/core/debates/server/geo-lens-search.test.ts
@@ -1,0 +1,185 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { CLAIM_TYPE_ID, TOPICS_PROPERTY_ID } from '~/core/claims/ontology';
+import { TAG_PROPERTY_ID } from '~/core/constants';
+
+import { SEMANTIC_SEARCH_K } from '../semantic-claim-search-contract';
+import {
+  CLAIMS_CACHE_SPEC,
+  DEFAULT_GEO_LENS_SEARCH_MIN_SCORE,
+  type GeoLensSearchConfig,
+  buildSemanticQuery,
+  getGeoLensSearchConfig,
+  resetClaimsCacheIdForTests,
+  resolveClaimsCacheId,
+  searchSemanticClaims,
+} from './geo-lens-search';
+
+const TAG = 'ec3086a54ddf43d8aaefd6cc6e1b0556';
+const SPACE = '019fedae72b67ab2927adf044d57c566';
+const TOPIC = '5d050707bc5840119b1e81ad3adb6244';
+const CACHE_ID = '28644288d488eac0';
+
+const config: GeoLensSearchConfig = { url: 'https://lens.test', apiKey: 'k', minScore: 0.8, timeoutMs: 1000 };
+
+function json(status: number, body: unknown) {
+  return new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } });
+}
+
+/** A geo-lens that registers the cache and answers queries, recording what it was sent. */
+function lens(answers: { register?: () => Response; query?: () => Response } = {}) {
+  const calls: Array<{ path: string; body: any }> = [];
+  const fetchImpl = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+    const path = String(input).replace(config.url, '');
+    calls.push({ path, body: JSON.parse(String(init?.body)) });
+    if (path === '/caches')
+      return (answers.register ?? (() => json(202, { id: CACHE_ID, handle: 'claims', status: 'ready' })))();
+    return (answers.query ?? (() => json(200, { hits: [] })))();
+  });
+  return { fetchImpl: fetchImpl as unknown as typeof fetch, calls };
+}
+
+beforeEach(() => {
+  resetClaimsCacheIdForTests();
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('getGeoLensSearchConfig', () => {
+  it('is off without a URL', () => {
+    vi.stubEnv('GEO_LENS_URL', '');
+    vi.stubEnv('GEO_LENS_API_KEY', 'k');
+    expect(getGeoLensSearchConfig()).toBeNull();
+  });
+
+  it('reads the URL, the key and the defaults, trimming quotes and trailing slashes', () => {
+    vi.stubEnv('GEO_LENS_URL', '"https://lens.test/"');
+    vi.stubEnv('GEO_LENS_API_KEY', "'k'");
+    vi.stubEnv('GEO_LENS_SEARCH_MIN_SCORE', '');
+    expect(getGeoLensSearchConfig()).toEqual({
+      url: 'https://lens.test',
+      apiKey: 'k',
+      minScore: DEFAULT_GEO_LENS_SEARCH_MIN_SCORE,
+      timeoutMs: 6000,
+    });
+  });
+
+  it('takes a floor and a timeout from the environment', () => {
+    vi.stubEnv('GEO_LENS_URL', 'https://lens.test');
+    vi.stubEnv('GEO_LENS_API_KEY', 'k');
+    vi.stubEnv('GEO_LENS_SEARCH_MIN_SCORE', '0.9');
+    vi.stubEnv('GEO_LENS_TIMEOUT_MS', '250');
+    expect(getGeoLensSearchConfig()).toMatchObject({ minScore: 0.9, timeoutMs: 250 });
+  });
+
+  it('fails fast on a URL without a key, or a floor that is not a score', () => {
+    vi.stubEnv('GEO_LENS_URL', 'https://lens.test');
+    vi.stubEnv('GEO_LENS_API_KEY', '');
+    expect(() => getGeoLensSearchConfig()).toThrow(/GEO_LENS_API_KEY/);
+
+    vi.stubEnv('GEO_LENS_API_KEY', 'k');
+    vi.stubEnv('GEO_LENS_SEARCH_MIN_SCORE', '1.5');
+    expect(() => getGeoLensSearchConfig()).toThrow(/GEO_LENS_SEARCH_MIN_SCORE/);
+  });
+});
+
+describe('buildSemanticQuery', () => {
+  it('asks the vector strategy for the tag first, then every topic, floor and page size fixed', () => {
+    expect(
+      buildSemanticQuery({ query: 'trump affair', tagId: TAG, spaceIds: [SPACE], topicIds: [TOPIC] }, 0.8)
+    ).toEqual({
+      strategy: 'vector',
+      input: { text: 'trump affair' },
+      k: SEMANTIC_SEARCH_K,
+      min_score: 0.8,
+      filters: {
+        relations: [
+          { typeId: TAG_PROPERTY_ID, toEntityId: TAG, spaceIds: [SPACE] },
+          { typeId: TOPICS_PROPERTY_ID, toEntityId: TOPIC },
+        ],
+      },
+      consistency: 'cached',
+    });
+  });
+
+  it('sends no spaces on the tag when any space will do', () => {
+    const query = buildSemanticQuery({ query: 'q', tagId: TAG, spaceIds: null, topicIds: [] }, 0.8);
+    expect(query.filters.relations).toEqual([{ typeId: TAG_PROPERTY_ID, toEntityId: TAG, spaceIds: [] }]);
+  });
+});
+
+describe('resolveClaimsCacheId', () => {
+  it('registers the shared claims spec once and keeps the id', async () => {
+    const { fetchImpl, calls } = lens();
+    await expect(resolveClaimsCacheId(config, fetchImpl)).resolves.toBe(CACHE_ID);
+    await expect(resolveClaimsCacheId(config, fetchImpl)).resolves.toBe(CACHE_ID);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].body).toEqual({ name: 'claims', spec: CLAIMS_CACHE_SPEC, visibility: 'shared' });
+    expect(CLAIMS_CACHE_SPEC.type_ids).toEqual([CLAIM_TYPE_ID]);
+  });
+
+  it('does not keep a cache that is still warming, nor a failed registration', async () => {
+    const warming = lens({ register: () => json(202, { id: CACHE_ID, handle: 'claims', status: 'warming' }) });
+    await expect(resolveClaimsCacheId(config, warming.fetchImpl)).rejects.toThrow(/warming/);
+
+    const down = lens({ register: () => json(503, 'down') });
+    await expect(resolveClaimsCacheId(config, down.fetchImpl)).rejects.toThrow(/503/);
+    // the next call tries again rather than replaying the failure
+    const up = lens();
+    await expect(resolveClaimsCacheId(config, up.fetchImpl)).resolves.toBe(CACHE_ID);
+  });
+});
+
+describe('searchSemanticClaims', () => {
+  it('queries the registered cache and answers ids with scores, closest first as geo-lens sent them', async () => {
+    const { fetchImpl, calls } = lens({
+      query: () =>
+        json(200, {
+          hits: [
+            { id: 'a2', name: 'Two', score: 0.93 },
+            { id: 'a1', name: 'One', score: 0.85 },
+          ],
+        }),
+    });
+    const hits = await searchSemanticClaims(
+      { query: 'q', tagId: TAG, spaceIds: null, topicIds: [] },
+      config,
+      fetchImpl
+    );
+    expect(hits).toEqual([
+      { id: 'a2', score: 0.93 },
+      { id: 'a1', score: 0.85 },
+    ]);
+    expect(calls.map(call => call.path)).toEqual(['/caches', `/caches/${CACHE_ID}/query`]);
+    expect(calls[1].body).toMatchObject({ strategy: 'vector', min_score: 0.8 });
+  });
+
+  it('forgets the cache id on a 404 so the next search registers again', async () => {
+    let queries = 0;
+    const { fetchImpl, calls } = lens({
+      query: () => (queries++ === 0 ? json(404, 'No cache') : json(200, { hits: [] })),
+    });
+    const request = { query: 'q', tagId: TAG, spaceIds: null, topicIds: [] };
+    await expect(searchSemanticClaims(request, config, fetchImpl)).rejects.toThrow(/404/);
+    await expect(searchSemanticClaims(request, config, fetchImpl)).resolves.toEqual([]);
+    expect(calls.map(call => call.path)).toEqual([
+      '/caches',
+      `/caches/${CACHE_ID}/query`,
+      '/caches',
+      `/caches/${CACHE_ID}/query`,
+    ]);
+  });
+
+  it('keeps the cache id across an ordinary failure', async () => {
+    let queries = 0;
+    const { fetchImpl, calls } = lens({
+      query: () => (queries++ === 0 ? json(500, 'boom') : json(200, { hits: [] })),
+    });
+    const request = { query: 'q', tagId: TAG, spaceIds: null, topicIds: [] };
+    await expect(searchSemanticClaims(request, config, fetchImpl)).rejects.toThrow(/500/);
+    await expect(searchSemanticClaims(request, config, fetchImpl)).resolves.toEqual([]);
+    expect(calls.filter(call => call.path === '/caches')).toHaveLength(1);
+  });
+});

--- a/apps/web/core/debates/server/geo-lens-search.ts
+++ b/apps/web/core/debates/server/geo-lens-search.ts
@@ -9,9 +9,9 @@ import { SEMANTIC_SEARCH_K, type SemanticClaimSearchRequest } from '../semantic-
  *
  * Unprefixed env vars, like the acceptor's, so the key never reaches the client bundle. Presence
  * of `GEO_LENS_URL` turns the feature on — the same switch geo-chat's media worker uses — and a
- * deployment without it answers every search with "not configured", which the hub reads as "use
- * the words". `GEO_LENS_API_KEY` is then required: a URL with no key is a misconfiguration, not a
- * quieter way of being off.
+ * deployment without it answers every search with "not configured", which the hub reads as "match
+ * the words", the only search it then has. `GEO_LENS_API_KEY` is then required: a URL with no key
+ * is a misconfiguration, not a quieter way of being off.
  */
 export type GeoLensSearchConfig = {
   url: string;
@@ -27,7 +27,7 @@ export type GeoLensSearchConfig = {
    * embedding model and the corpus, and both are geo-lens's to change.
    */
   minScore: number;
-  /** How long one geo-lens round trip may take before the hub falls back to the words. */
+  /** How long one geo-lens round trip may take before the hub reports the search as failed. */
   timeoutMs: number;
 };
 

--- a/apps/web/core/debates/server/geo-lens-search.ts
+++ b/apps/web/core/debates/server/geo-lens-search.ts
@@ -1,0 +1,211 @@
+import { CLAIM_TYPE_ID, TOPICS_PROPERTY_ID } from '~/core/claims/ontology';
+import { TAG_PROPERTY_ID } from '~/core/constants';
+
+import { SEMANTIC_SEARCH_K, type SemanticClaimSearchRequest } from '../semantic-claim-search-contract';
+
+/**
+ * Server-only client for geo-lens, the graph cache that answers "which claims mean this?" in
+ * milliseconds (geo-lens `docs/design.md`). Used by the semantic-search route for the debates hub.
+ *
+ * Unprefixed env vars, like the acceptor's, so the key never reaches the client bundle. Presence
+ * of `GEO_LENS_URL` turns the feature on — the same switch geo-chat's media worker uses — and a
+ * deployment without it answers every search with "not configured", which the hub reads as "use
+ * the words". `GEO_LENS_API_KEY` is then required: a URL with no key is a misconfiguration, not a
+ * quieter way of being off.
+ */
+export type GeoLensSearchConfig = {
+  url: string;
+  apiKey: string;
+  /**
+   * The score a claim must reach to count as an answer, on geo-lens's normalised cosine scale
+   * (`(1 + cos) / 2`). Verbatim duplicates score 0.99+; topically related but different claims land
+   * around 0.85–0.93 (measured for the debate dedup); a claim about something else sits below 0.8.
+   * A search wants the related ones and not the unrelated, hence the default. Tunable per
+   * deployment because the right floor is a property of the embedding model and the corpus, and
+   * both are geo-lens's to change.
+   */
+  minScore: number;
+  /** How long one geo-lens round trip may take before the hub falls back to the words. */
+  timeoutMs: number;
+};
+
+export const DEFAULT_GEO_LENS_SEARCH_MIN_SCORE = 0.8;
+export const DEFAULT_GEO_LENS_TIMEOUT_MS = 6_000;
+
+/**
+ * Our handle name for the claims cache. Handles are per consumer, but the spec below hashes to the
+ * one cache every consumer of "all Claim entities, embedded by name" shares — geo-chat registers
+ * the identical spec — so registering it is idempotent and free once that cache is warm.
+ */
+const CLAIMS_CACHE_NAME = 'claims';
+
+/** Byte-for-byte the spec geo-chat's media worker sends; a different spec would hash to a different cache. */
+export const CLAIMS_CACHE_SPEC = {
+  kind: 'type',
+  type_ids: [CLAIM_TYPE_ID],
+  embed: [{ field: 'name' }],
+  strategies: ['exact', 'text', 'vector'],
+} as const;
+
+/** Secrets UIs and shell exports often keep the wrapping quotes as part of the value. */
+function readEnv(name: string): string {
+  const value = process.env[name]?.trim() ?? '';
+  const quoted = /^(['"])([\s\S]*)\1$/.exec(value);
+  return quoted ? quoted[2].trim() : value;
+}
+
+function readNumber(name: string, fallback: number, valid: (n: number) => boolean): number {
+  const raw = readEnv(name);
+  if (!raw) return fallback;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || !valid(parsed)) {
+    throw new Error(`${name} must be a number (got ${JSON.stringify(raw)})`);
+  }
+  return parsed;
+}
+
+/**
+ * The geo-lens config, or `null` when the feature is off. A URL without a key throws: fail-fast on
+ * bad config, mirroring `getDebateAcceptorConfig`.
+ */
+export function getGeoLensSearchConfig(): GeoLensSearchConfig | null {
+  const url = readEnv('GEO_LENS_URL').replace(/\/+$/, '');
+  if (!url) return null;
+  const apiKey = readEnv('GEO_LENS_API_KEY');
+  if (!apiKey) throw new Error('GEO_LENS_API_KEY is required when GEO_LENS_URL is set');
+  return {
+    url,
+    apiKey,
+    minScore: readNumber('GEO_LENS_SEARCH_MIN_SCORE', DEFAULT_GEO_LENS_SEARCH_MIN_SCORE, n => n >= 0 && n <= 1),
+    timeoutMs: readNumber('GEO_LENS_TIMEOUT_MS', DEFAULT_GEO_LENS_TIMEOUT_MS, n => n > 0),
+  };
+}
+
+/** A non-2xx reply, kept typed so the caller can tell "cache gone" from "request failed". */
+export class GeoLensStatusError extends Error {
+  constructor(
+    public readonly status: number,
+    detail: string
+  ) {
+    super(`geo-lens replied ${status}: ${detail}`);
+    this.name = 'GeoLensStatusError';
+  }
+}
+
+type FetchLike = typeof fetch;
+
+async function postJson<T>(
+  config: GeoLensSearchConfig,
+  path: string,
+  body: unknown,
+  fetchImpl: FetchLike,
+  signal?: AbortSignal
+): Promise<T> {
+  const response = await fetchImpl(`${config.url}${path}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', 'x-api-key': config.apiKey },
+    body: JSON.stringify(body),
+    signal: signal ?? AbortSignal.timeout(config.timeoutMs),
+  });
+  if (!response.ok) {
+    const detail = await response.text().catch(() => '');
+    throw new GeoLensStatusError(response.status, detail.slice(0, 200));
+  }
+  return (await response.json()) as T;
+}
+
+type CacheView = { id: string; handle: string; status: string };
+
+/**
+ * The claims cache's id, registered on first use and remembered for the life of the instance.
+ *
+ * The id rather than the handle name, as geo-chat's client does: geo-lens resolves a name with
+ * `LIMIT 1` and no order, so a name registered against two specs would be ambiguous, while the id
+ * is exact. One in-flight registration is shared by concurrent callers, and a failed one is not
+ * remembered, so the next request tries again rather than failing until the instance recycles.
+ */
+let claimsCacheId: Promise<string> | null = null;
+
+export function resolveClaimsCacheId(config: GeoLensSearchConfig, fetchImpl: FetchLike = fetch): Promise<string> {
+  if (!claimsCacheId) {
+    claimsCacheId = postJson<CacheView>(
+      config,
+      '/caches',
+      { name: CLAIMS_CACHE_NAME, spec: CLAIMS_CACHE_SPEC, visibility: 'shared' },
+      fetchImpl
+    )
+      .then(view => {
+        if (view.status !== 'ready') {
+          throw new Error(`geo-lens claims cache '${view.handle}' (${view.id}) is ${view.status}, not ready`);
+        }
+        return view.id;
+      })
+      .catch(error => {
+        claimsCacheId = null;
+        throw error;
+      });
+  }
+  return claimsCacheId;
+}
+
+/** Drop the remembered id if it is still the one that failed, so a straggler cannot wipe a fresh one. */
+async function forgetClaimsCacheId(failed: string) {
+  const current = await claimsCacheId?.catch(() => null);
+  if (current === failed) claimsCacheId = null;
+}
+
+/** Test seam: the module-level memo outlives a test. */
+export function resetClaimsCacheIdForTests() {
+  claimsCacheId = null;
+}
+
+/**
+ * The query the search box's request becomes, as geo-lens reads it (`filters.relations`, AND-ed,
+ * first one anchoring the scan). The tag goes first because it is by far the most selective —
+ * 1.2k claims carry the Debate tag against 318k in the cache — and its spaces are the spaces the
+ * claim was *tagged in*, the relation's own, which is what the hub filters by.
+ */
+export function buildSemanticQuery(request: SemanticClaimSearchRequest, minScore: number) {
+  return {
+    strategy: 'vector',
+    input: { text: request.query },
+    k: SEMANTIC_SEARCH_K,
+    min_score: minScore,
+    filters: {
+      relations: [
+        { typeId: TAG_PROPERTY_ID, toEntityId: request.tagId, spaceIds: request.spaceIds ?? [] },
+        ...request.topicIds.map(topicId => ({ typeId: TOPICS_PROPERTY_ID, toEntityId: topicId })),
+      ],
+    },
+    // The mirror validates every five minutes; a search does not wait on a refresh.
+    consistency: 'cached',
+  };
+}
+
+type QueryResponse = { hits?: Array<{ id: string; name?: string | null; score: number }> };
+
+/**
+ * The claims closest in meaning to the words, among those carrying the tag (in the spaces) and
+ * every topic — closest first, floor applied by geo-lens.
+ */
+export async function searchSemanticClaims(
+  request: SemanticClaimSearchRequest,
+  config: GeoLensSearchConfig,
+  fetchImpl: FetchLike = fetch
+): Promise<Array<{ id: string; score: number }>> {
+  const cacheId = await resolveClaimsCacheId(config, fetchImpl);
+  try {
+    const response = await postJson<QueryResponse>(
+      config,
+      `/caches/${cacheId}/query`,
+      buildSemanticQuery(request, config.minScore),
+      fetchImpl
+    );
+    return (response.hits ?? []).map(hit => ({ id: hit.id, score: hit.score }));
+  } catch (error) {
+    // geo-lens no longer knows the cache under this id (re-created, or our handle dropped): let the
+    // next request register again rather than fail until the instance is replaced.
+    if (error instanceof GeoLensStatusError && error.status === 404) await forgetClaimsCacheId(cacheId);
+    throw error;
+  }
+}

--- a/apps/web/core/debates/server/geo-lens-search.ts
+++ b/apps/web/core/debates/server/geo-lens-search.ts
@@ -18,18 +18,20 @@ export type GeoLensSearchConfig = {
   apiKey: string;
   /**
    * The score a claim must reach to count as an answer, on geo-lens's normalised cosine scale
-   * (`(1 + cos) / 2`). Verbatim duplicates score 0.99+; topically related but different claims land
-   * around 0.85–0.93 (measured for the debate dedup); a claim about something else sits below 0.8.
-   * A search wants the related ones and not the unrelated, hence the default. Tunable per
-   * deployment because the right floor is a property of the embedding model and the corpus, and
-   * both are geo-lens's to change.
+   * (`(1 + cos) / 2`). Measured against the deployed claims cache over the Debate tag
+   * (2026-09-09): claims that answer the words score 0.855–0.90 ("Trump affair allegations" →
+   * the affair claims at 0.873–0.895; "dating apps" → "Dating apps have made relationships
+   * worse" at 0.901); tangential neighbours 0.82–0.85 ("climate change" → "ICE should be
+   * abolished" at 0.822); gibberish tops out at 0.794. 0.85 is the line between the first two
+   * in every sample. Tunable per deployment because the right floor is a property of the
+   * embedding model and the corpus, and both are geo-lens's to change.
    */
   minScore: number;
   /** How long one geo-lens round trip may take before the hub falls back to the words. */
   timeoutMs: number;
 };
 
-export const DEFAULT_GEO_LENS_SEARCH_MIN_SCORE = 0.8;
+export const DEFAULT_GEO_LENS_SEARCH_MIN_SCORE = 0.85;
 export const DEFAULT_GEO_LENS_TIMEOUT_MS = 6_000;
 
 /**

--- a/apps/web/core/debates/tagged-claims.test.ts
+++ b/apps/web/core/debates/tagged-claims.test.ts
@@ -505,6 +505,17 @@ describe('a semantic answer to the search', () => {
     expect(result.current.claims.map(claim => claim.entity.id)).toEqual(['a2', 'a1']);
   });
 
+  it('asks for nothing when geo-lens named nothing, rather than for the words', async () => {
+    respondWithPages([[]]);
+    const { result } = renderClaims({ ...NO_TAGGED_CLAIM_FILTERS, search: 'art', semanticHits: [] });
+    await waitFor(() => expect(graphqlMock).toHaveBeenCalled());
+
+    const filter = JSON.stringify(sentVariables().filter);
+    expect(filter).toContain('"id":{"in":[]}');
+    expect(filter).not.toContain('includesInsensitive');
+    expect(result.current.claims).toEqual([]);
+  });
+
   it('is its own query, distinct from the same words matched literally', () => {
     const words: TaggedClaimFilters = { ...NO_TAGGED_CLAIM_FILTERS, search: 'trump affair' };
     const semantic: TaggedClaimFilters = { ...words, semanticHits: hits };

--- a/apps/web/core/debates/tagged-claims.test.ts
+++ b/apps/web/core/debates/tagged-claims.test.ts
@@ -12,7 +12,10 @@ import {
   NO_TAGGED_CLAIM_FILTERS,
   TAGGED_CLAIMS_PAGE_SIZE,
   type TaggedClaimFilters,
+  orderBySemanticScore,
   searchTerms,
+  taggedClaimsQueryKey,
+  taggedFacetQueryKey,
   useTaggedClaims,
   useTaggedSpaceFacet,
   useTaggedTopicFacet,
@@ -475,5 +478,67 @@ describe('the facet menus', () => {
     // An error leaves the menu empty while it stops loading. Read as settled, that empty menu says
     // the viewer's picked space no longer exists, and the reconciliation spends their selection.
     expect(result.current.settled).toBe(false);
+  });
+});
+
+describe('a semantic answer to the search', () => {
+  const hits = [
+    { id: 'a2', score: 0.93 },
+    { id: 'a1', score: 0.85 },
+  ];
+
+  it('asks for the claims geo-lens named, and not for the words', async () => {
+    respondWithPages([[node('a1', 'One'), node('a2', 'Two')]]);
+    const { result } = renderClaims({ ...NO_TAGGED_CLAIM_FILTERS, search: 'trump affair', semanticHits: hits });
+    await waitFor(() => expect(result.current.claims).toHaveLength(2));
+
+    const filter = JSON.stringify(sentVariables().filter);
+    expect(filter).toContain('"id":{"in":["a2","a1"]}');
+    expect(filter).not.toContain('includesInsensitive');
+  });
+
+  it('shows them closest first, whatever the server ranked them', async () => {
+    respondWithPages([[node('a1', 'One', { rankingScore: '20' }), node('a2', 'Two', { rankingScore: '10' })]]);
+    const { result } = renderClaims({ ...NO_TAGGED_CLAIM_FILTERS, search: 'trump affair', semanticHits: hits });
+    await waitFor(() => expect(result.current.claims).toHaveLength(2));
+
+    expect(result.current.claims.map(claim => claim.entity.id)).toEqual(['a2', 'a1']);
+  });
+
+  it('is its own query, distinct from the same words matched literally', () => {
+    const words: TaggedClaimFilters = { ...NO_TAGGED_CLAIM_FILTERS, search: 'trump affair' };
+    const semantic: TaggedClaimFilters = { ...words, semanticHits: hits };
+    expect(taggedClaimsQueryKey(TAG, words)).not.toEqual(taggedClaimsQueryKey(TAG, semantic));
+    expect(taggedFacetQueryKey('topics', TAG, words)).not.toEqual(taggedFacetQueryKey('topics', TAG, semantic));
+    expect(taggedFacetQueryKey('spaces', TAG, words)).not.toEqual(taggedFacetQueryKey('spaces', TAG, semantic));
+  });
+
+  it('counts both menus over the named claims too', async () => {
+    graphqlMock.mockImplementation(({ decoder }) =>
+      Effect.succeed(decoder({ relationsConnection: { groupedAggregates: [] } }))
+    );
+    renderHook(
+      () => useTaggedTopicFacet(TAG, { ...NO_TAGGED_CLAIM_FILTERS, search: 'trump', semanticHits: hits }, true),
+      { wrapper }
+    );
+    await waitFor(() => expect(graphqlMock).toHaveBeenCalled());
+    expect(JSON.stringify(sentVariables().fromEntity)).toContain('"id":{"in":["a2","a1"]}');
+  });
+});
+
+describe('orderBySemanticScore', () => {
+  const claim = (id: string) => ({
+    entity: { id, name: id, description: null, spaces: [], values: [], relations: [] },
+    tagSpaceIds: [SPACE],
+    rankingScore: null,
+  });
+
+  it('follows the hits, accepts either id spelling, and keeps unnamed rows last in their own order', () => {
+    const rows = [claim('a1'), claim('zz'), claim('a2'), claim('yy')];
+    const hits = [
+      { id: 'a2', score: 0.9 },
+      { id: 'a1', score: 0.8 },
+    ];
+    expect(orderBySemanticScore(rows, hits).map(row => row.entity.id)).toEqual(['a2', 'a1', 'zz', 'yy']);
   });
 });

--- a/apps/web/core/debates/tagged-claims.ts
+++ b/apps/web/core/debates/tagged-claims.ts
@@ -140,9 +140,9 @@ export type TaggedClaimFilters = {
    * What `search` resolved to when geo-lens answered it: the claims whose meaning is closest to the
    * words typed, over this tag, the eligible spaces and the picked topics. Set, the list is these
    * claims and nothing else — the words themselves are not matched — ordered by how close they
-   * came. `null` (or absent) is the word-by-word match above, which is also what a search geo-lens
-   * found nothing for falls back to. Resolved by `useSemanticTaggedFilters`; never empty when set,
-   * because an empty answer *is* the fallback.
+   * came. Empty is an answer: geo-lens found nothing, so the list shows nothing. `null` (or absent)
+   * is the word-by-word match above, kept for a deployment with no geo-lens to ask; see
+   * `useSemanticTaggedFilters` for why nothing else falls through to it.
    */
   semanticHits?: readonly SemanticClaimHit[] | null;
   /** AND, not OR: a claim has to carry every picked topic. */
@@ -298,7 +298,9 @@ function taggedEntityFilter(tagId: string, filters: TaggedClaimFilters, omit?: '
   if (filters.semanticHits) {
     // The search already happened, in geo-lens, over the same tag, spaces and topics as above; what
     // is left is to fetch the claims it named. The words are deliberately not matched as well — a
-    // claim that means what was typed need not contain it, which is the whole point.
+    // claim that means what was typed need not contain it, which is the whole point. An empty
+    // answer is asked for as `in: []`, which the graph answers with nothing, so the list and both
+    // menus empty together.
     and.push({ id: { in: filters.semanticHits.map(hit => hit.id) } });
     return { and };
   }

--- a/apps/web/core/debates/tagged-claims.ts
+++ b/apps/web/core/debates/tagged-claims.ts
@@ -110,13 +110,16 @@ type TaggedClaimsQuery = {
  * at human speed, so every caller asking for the same tag and filters shares one request for a good
  * while.
  */
-const TAGGED_STALE_TIME = 5 * 60_000;
+export const TAGGED_STALE_TIME = 5 * 60_000;
 
 /** Topic names outlive any one filter click by a long way; they are not what goes stale here. */
 const TOPIC_NAMES_STALE_TIME = 30 * 60_000;
 
 /** Rows per request. Small enough that the first screen is not waiting on the rest of the page. */
 export const TAGGED_CLAIMS_PAGE_SIZE = 50;
+
+/** One claim geo-lens found for the search box, and how close it came. */
+export type SemanticClaimHit = { id: string; score: number };
 
 /** What narrows the list. Every one of these reaches the server. */
 export type TaggedClaimFilters = {
@@ -133,6 +136,15 @@ export type TaggedClaimFilters = {
    * finds, for eight round trips a keystroke. GEO-2806.
    */
   search: string;
+  /**
+   * What `search` resolved to when geo-lens answered it: the claims whose meaning is closest to the
+   * words typed, over this tag, the eligible spaces and the picked topics. Set, the list is these
+   * claims and nothing else — the words themselves are not matched — ordered by how close they
+   * came. `null` (or absent) is the word-by-word match above, which is also what a search geo-lens
+   * found nothing for falls back to. Resolved by `useSemanticTaggedFilters`; never empty when set,
+   * because an empty answer *is* the fallback.
+   */
+  semanticHits?: readonly SemanticClaimHit[] | null;
   /** AND, not OR: a claim has to carry every picked topic. */
   topicIds: string[];
   /** OR: any of the picked spaces. Left out of the space facet, which must not narrow by itself. */
@@ -149,6 +161,7 @@ export type TaggedClaimFilters = {
 
 export const NO_TAGGED_CLAIM_FILTERS: TaggedClaimFilters = {
   search: '',
+  semanticHits: null,
   topicIds: [],
   spaceIds: [],
   eligibleSpaceIds: null,
@@ -282,6 +295,14 @@ function taggedEntityFilter(tagId: string, filters: TaggedClaimFilters, omit?: '
     and.push({ relations: { some: { typeId: { is: TOPICS_PROPERTY_ID }, toEntityId: { is: topicId } } } });
   }
 
+  if (filters.semanticHits) {
+    // The search already happened, in geo-lens, over the same tag, spaces and topics as above; what
+    // is left is to fetch the claims it named. The words are deliberately not matched as well — a
+    // claim that means what was typed need not contain it, which is the whole point.
+    and.push({ id: { in: filters.semanticHits.map(hit => hit.id) } });
+    return { and };
+  }
+
   // One clause per word, ANDed, so the words may appear in any order and with anything between
   // them: as a single phrase, "Trump affair" missed "Allegations of an affair between President
   // Donald Trump…" and "Israel Gaza" missed all six claims about both. A claim containing the whole
@@ -291,6 +312,28 @@ function taggedEntityFilter(tagId: string, filters: TaggedClaimFilters, omit?: '
   }
 
   return { and };
+}
+
+/** The part of the filters' identity the semantic answer contributes: which claims, in which order. */
+function semanticKey(filters: TaggedClaimFilters): string[] | null {
+  return filters.semanticHits ? filters.semanticHits.map(hit => hit.id) : null;
+}
+
+/**
+ * Semantic hits in their own order — closest first — rather than the ranking the server paged by.
+ *
+ * The server sorts every page by ranking score, which is right for browsing a tag and wrong for a
+ * search: someone who typed a sentence wants the claim that means it at the top, not the one the
+ * feed happens to rank highest among the matches. A claim geo-lens named but the server did not
+ * return (untagged in the meantime) is simply absent; one the server returned but geo-lens did
+ * not name cannot happen, since the ids are the filter.
+ */
+export function orderBySemanticScore(claims: TaggedClaim[], hits: readonly SemanticClaimHit[]): TaggedClaim[] {
+  const rank = new Map(hits.map((hit, index) => [uuidToHex(hit.id), index]));
+  return claims
+    .map((claim, index) => ({ claim, index, rank: rank.get(uuidToHex(claim.entity.id)) ?? Number.MAX_SAFE_INTEGER }))
+    .sort((a, b) => a.rank - b.rank || a.index - b.index)
+    .map(entry => entry.claim);
 }
 
 /**
@@ -331,6 +374,7 @@ export const taggedClaimsQueryKey = (tagId: string, filters: TaggedClaimFilters)
     'claims',
     tagId,
     filters.search,
+    semanticKey(filters),
     filters.topicIds,
     filters.spaceIds,
     filters.eligibleSpaceIds,
@@ -345,7 +389,10 @@ const noFetch = async () => undefined;
  * One ranked, filtered page of tagged claims at a time.
  *
  * Ranked by the server, which is Explore's "Best" order — `entities_ranked_for_feed`'s own
- * `ORDER BY ranking_score DESC, entity_id DESC`, unscored claims last. Nothing is sorted here.
+ * `ORDER BY ranking_score DESC, entity_id DESC`, unscored claims last. Nothing is sorted here,
+ * with one exception: a semantic search (`filters.semanticHits`) is shown closest-first, because
+ * its rows were chosen by meaning and the ranking says nothing about that — see
+ * {@link orderBySemanticScore}.
  *
  * Curation moves at human speed, so a page stays fresh for a good while; every caller asking for the
  * same tag and the same filters shares one request.
@@ -380,10 +427,13 @@ export function useTaggedClaims(tagId: string, filters: TaggedClaimFilters, enab
     enabled,
   });
 
-  const claims = React.useMemo(
-    () => query.data?.pages.flatMap(page => page.claims) ?? NO_TAGGED_CLAIMS,
-    [query.data?.pages]
-  );
+  const semanticHits = filters.semanticHits ?? null;
+  const claims = React.useMemo(() => {
+    const rows = query.data?.pages.flatMap(page => page.claims) ?? NO_TAGGED_CLAIMS;
+    // A semantic answer is at most one page (`SEMANTIC_SEARCH_K` is the page size), so re-ordering
+    // the rows in hand is re-ordering the whole list, not one page of a ranked cursor.
+    return semanticHits && rows.length > 0 ? orderBySemanticScore(rows, semanticHits) : rows;
+  }, [query.data?.pages, semanticHits]);
 
   return {
     // Disabled means no answer, not the last one.
@@ -509,6 +559,7 @@ export const taggedFacetQueryKey = (dimension: 'topics' | 'spaces', tagId: strin
     dimension,
     tagId,
     filters.search,
+    semanticKey(filters),
     filters.topicIds,
     // The space facet does not narrow by the picked spaces, so they are not part of its identity.
     dimension === 'spaces' ? null : filters.spaceIds,


### PR DESCRIPTION
## What

The search box on **Featured** and **All claims** in the debates hub, and the same two sources in the debate-again picker, now searches by meaning through geo-lens. geo-lens's answer is the answer: an empty one shows an empty list, a failed request shows the list's error state with retry.

- `POST /api/debates/claims/semantic-search` — server-only proxy for geo-lens. Holds `GEO_LENS_URL` / `GEO_LENS_API_KEY`, fixes the relation types, strategy and score floor on its side so the browser can only choose the tag, spaces, topics and words; normalizes every id; same-origin only; registers the shared claims cache once per instance with the same spec geo-chat's media worker sends. Unset, it answers `{ hits: null }`.
- `core/debates/server/geo-lens-search.ts` — config (presence-gated on `GEO_LENS_URL`, fail-fast on a URL without a key), cache-id memo with 404 re-registration, query builder.
- `core/debates/semantic-claim-search.ts` — `useSemanticTaggedFilters`: resolves the search *before* the tagged list and both facets are asked, so rows and menus describe one set. Holds the previous filters while geo-lens is being asked so rows do not blank; reports `pending` for the counts and `error` (with `refetch`) for the list's error state.
- `core/debates/tagged-claims.ts` — `semanticHits` on `TaggedClaimFilters`: an `id in` filter in place of the word clauses, part of every query key, rows ordered closest-first.
- `claims-tab.tsx`, `rematch-page-client.tsx` — wiring, plus `semanticPending` folded into `countsPending` and the topic reconciliation gate alongside `topicsSettling`.

**No fallback on an empty answer.** The first version matched the words when geo-lens named nothing, and that was the source of every false positive: `includesInsensitive: "art"` listed 72 Debate-tagged claims about *part*ners, *part*ies and *start*ing — none about art — while geo-lens had correctly said there were none. Now zero hits is an empty list and a failure is the error state. The only path still matched by words is a deployment with no geo-lens configured (`hits: null`), where the words are the only search there is.

## Why geo-lens does the narrowing

Measured on testnet: the Debate tag holds 1,254 claims and Featured 198, inside a claims cache of 318k. A plain top-k over the cache would almost never intersect a tag — the same failure `tagged-claims.ts` already documents for the app's OpenSearch endpoint (a tagged claim named "Allegations of an affair…" came 521st of 697). Shipping the tag's ids from the browser per keystroke does not scale either. So the request carries the tag, the eligible spaces and the topics, and geo-lens's new `filters.relations` scans from the tag's own edges. Depends on geobrowser/geo-lens#1.

The picked spaces are deliberately not sent: they narrow the rows and the topic menu on the graph side, and the space menu must not be narrowed by its own selection.

## Out of scope

**My positions** and **Debate now** stay on geo-chat's `ILIKE`. Semantic search there needs `/matchmaking/claims` to accept an include list of claim ids (Rust, geo-chat).

## Deploy

1. Add a `geogenesis` consumer key to `LENS_API_KEYS` on the Railway `geo-lens-api` service.
2. Set `GEO_LENS_URL` and `GEO_LENS_API_KEY` on Vercel. `GEO_LENS_SEARCH_MIN_SCORE` defaults to `0.85` on geo-lens's normalised cosine scale, measured on the deployed cache: answers score 0.855–0.90, tangential neighbours 0.82–0.85, gibberish ≤ 0.794.
3. ~~Deploy geo-lens with the relation filter first~~ — done 2026-09-09 (geo-lens#1 merged and deployed; the `geogenesis` consumer key exists).

## Test plan

- [x] `vitest run` on the five touched/new test files — 78 passed (route: origin check, validation, disabled, misconfigured, success, upstream failure; server client: config, query shape, cache-id memo/404 re-registration; hook: request shape, empty answer stays empty, failure reported and retried, unconfigured → words, hold-while-pending; tagged-claims: `id in` filter incl. `in: []`, closest-first ordering, key identity, facets over the named claims).
- [x] Existing `claims-tab`, `use-scoped-claims`, `rematch-page-client`, `rematch-voice` suites — 269 passed; the two component suites stub the route as unconfigured (`hits: null`), which is the deployment their word-search assertions describe.
- [x] `eslint` and `prettier --check` on touched files; `tsc --noEmit` adds no errors.
- [ ] On testnet with the env set: type a sentence on Featured, see claims ordered by meaning; type "art" on All claims, see an empty list rather than partners and parties; unset `GEO_LENS_URL`, see today's behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ZWdRUhBq4tKLp4Z2kTwDw
