### PR TITLE
Scope dropdown property eligibility to canonical spaces

### DIFF
--- a/apps/web/core/blocks/data/use-collection-member-schema.ts
+++ b/apps/web/core/blocks/data/use-collection-member-schema.ts
@@ -25,7 +25,13 @@ const MAX_MEMBER_TYPE_PAGES = 20;
  * fingerprint; Power Tools consumes this same hook via the overlay rather
  * than keeping its own loaded-page approximation for the dropdown UI.
  */
-export function useCollectionMemberSchema(collectionItemIds: string[] | null): Property[] {
+export type CollectionMemberSchema = {
+  properties: Property[];
+  /** The distinct types found across the whole membership — canonical-eligibility needs them. */
+  typeIds: string[];
+};
+
+export function useCollectionMemberSchema(collectionItemIds: string[] | null): CollectionMemberSchema {
   const enabled = collectionItemIds !== null && collectionItemIds.length > 0;
   const membershipKey = collectionItemIds ? fingerprintIdList(collectionItemIds) : 'none';
 
@@ -47,12 +53,13 @@ export function useCollectionMemberSchema(collectionItemIds: string[] | null): P
         if (!result.hasNextPage) break;
         after = result.endCursor;
       }
-      if (typeIds.size === 0) return [];
-      return await getSchemaFromTypeIds(
+      if (typeIds.size === 0) return { properties: [], typeIds: [] };
+      const properties = await getSchemaFromTypeIds(
         [...typeIds].map(id => ({ id })),
         undefined,
         { includeAllTypeSpaces: true }
       );
+      return { properties, typeIds: [...typeIds] };
     },
     staleTime: Infinity,
     refetchOnWindowFocus: false,
@@ -62,4 +69,4 @@ export function useCollectionMemberSchema(collectionItemIds: string[] | null): P
   return data ?? EMPTY_SCHEMA;
 }
 
-const EMPTY_SCHEMA: Property[] = [];
+const EMPTY_SCHEMA: CollectionMemberSchema = { properties: [], typeIds: [] };

--- a/apps/web/core/blocks/data/use-dropdown-query-overlay.ts
+++ b/apps/web/core/blocks/data/use-dropdown-query-overlay.ts
@@ -10,6 +10,7 @@ import { ID } from '~/core/id';
 import { useEditorStoreLite } from '~/core/state/editor/use-editor';
 import { useQueryEntity } from '~/core/sync/use-store';
 import type { Property } from '~/core/types';
+import { RANKED_SPACE_IDS } from '~/core/utils/space/space-ranking';
 
 import type { Filter, ModesByColumn } from './filters';
 import type { Source } from './source';
@@ -95,46 +96,42 @@ export function useDropdownQueryOverlay({
   // Collections derive their schema from the members (a collection has no
   // type predicate for the filter-driven derivation to read). Shared here so
   // the eye menu, the dropdown picker, and the overlay's gate all see it.
-  const collectionMemberProperties = useCollectionMemberSchema(collectionItemIds);
+  const { properties: collectionMemberProperties, typeIds: collectionMemberTypeIds } =
+    useCollectionMemberSchema(collectionItemIds);
 
-  // Dropdown ELIGIBILITY is scoped to the table's own spaces — a deliberate,
-  // dropdown-only divergence from the graph-wide schema union (GEO-2202)
-  // that feeds the column/sort/filter menus. The union lets ANY space graft
-  // a same-named twin property onto a shared type and have it surface in
-  // every picker in the graph; a table's dropdowns should only offer
-  // properties the table's selected spaces (or its own space) actually
-  // declare. GEO tables scope to the whole graph by definition and
-  // COLLECTION schemas already derive from the members, so only SPACES
-  // sources are restricted.
+  // Dropdown ELIGIBILITY is scoped to the CANONICAL spaces (space-ranking's
+  // ranked set): any unranked space can graft same-named twin properties
+  // onto a shared type — observed live, an unnamed space attached a whole
+  // parallel vocabulary to the Topic and Claim types — and the graph-wide
+  // schema union (GEO-2202) dutifully surfaced it in every picker. Only a
+  // declaration made in a canonical space qualifies a property for a
+  // dropdown; query blocks take their types from the filter, collections
+  // from their members. The sort/filter/column menus keep the full union.
   const typesInFilter = React.useMemo(
     () => baseFilterState.filter(f => ID.equals(f.columnId, SystemIds.TYPES_PROPERTY)).map(f => f.value),
     [baseFilterState]
   );
-  const tableSpaceIds = React.useMemo(() => {
-    const ids = baseFilterState.filter(f => ID.equals(f.columnId, SystemIds.SPACE_FILTER)).map(f => f.value);
-    if (spaceId && !ids.some(id => ID.equals(id, spaceId))) ids.push(spaceId);
-    return ids;
-  }, [baseFilterState, spaceId]);
-  const restrictToTableSpaces = source.type === 'SPACES';
-  const { data: tableSpaceSchema } = useQuery({
-    enabled: restrictToTableSpaces && typesInFilter.length > 0 && tableSpaceIds.length > 0,
-    queryKey: ['data-block', 'dropdown-eligible-schema', [...typesInFilter].sort(), [...tableSpaceIds].sort()],
+  const typesForEligibility = source.type === 'COLLECTION' ? collectionMemberTypeIds : typesInFilter;
+  const { data: canonicalSchema } = useQuery({
+    enabled: typesForEligibility.length > 0,
+    queryKey: ['data-block', 'dropdown-canonical-schema', [...typesForEligibility].sort()],
     placeholderData: keepPreviousData,
     queryFn: async () =>
-      // The type entities' schema relations read ONLY from the table's
-      // spaces: the spaceId hint scopes the native fetch and the second
-      // argument adds each selected space; includeAllTypeSpaces stays off.
+      // Schema relations read ONLY from the canonical spaces: the spaceId
+      // hint scopes the native fetch to the best-ranked space and the second
+      // argument adds each remaining canonical space; the all-spaces union
+      // stays off.
       getSchemaFromTypeIds(
-        typesInFilter.map(id => ({ id, spaceId: tableSpaceIds[0] })),
-        tableSpaceIds,
+        typesForEligibility.map(id => ({ id, spaceId: RANKED_SPACE_IDS[0] })),
+        [...RANKED_SPACE_IDS],
         { includeAllTypeSpaces: false }
       ),
   });
-  /** Relation property ids declared by the table's spaces; null = unrestricted (GEO/COLLECTION, or loading). */
+  /** Relation property ids declared canonically; null = unrestricted (no known types yet, or loading). */
   const dropdownEligibleIds = React.useMemo(() => {
-    if (!restrictToTableSpaces || !tableSpaceSchema) return null;
-    return tableSpaceSchema.filter(property => property.dataType === 'RELATION').map(property => property.id);
-  }, [restrictToTableSpaces, tableSpaceSchema]);
+    if (typesForEligibility.length === 0 || !canonicalSchema) return null;
+    return canonicalSchema.filter(property => property.dataType === 'RELATION').map(property => property.id);
+  }, [typesForEligibility, canonicalSchema]);
 
   const appliedColumnIds = React.useMemo(() => {
     const pillProperties = [...filterableProperties, ...(extraPillProperties ?? []), ...collectionMemberProperties];

--- a/apps/web/core/utils/space/space-ranking.ts
+++ b/apps/web/core/utils/space/space-ranking.ts
@@ -21,6 +21,15 @@ const SPACE_RANK: Record<string, number> = {
 const UNRANKED = Number.MAX_SAFE_INTEGER;
 
 /**
+ * The canonical spaces, best-ranked first. This IS the product's current
+ * definition of "canonical" — schema eligibility and space precedence both
+ * read it; replace alongside SPACE_RANK when true ranking ships.
+ */
+export const RANKED_SPACE_IDS: readonly string[] = Object.entries(SPACE_RANK)
+  .sort(([, a], [, b]) => a - b)
+  .map(([id]) => id);
+
+/**
  * Same normalization as `uuidToHex`, inlined to keep this module import-free (see the note above
  * `ROOT_SPACE`). The keys of `SPACE_RANK` are undashed lowercase hex, and REST hands back the same
  * bytes either way (`core/io/rest/validation.ts`) — so without this a dashed or uppercase id looks


### PR DESCRIPTION
Supersedes the table-spaces eligibility rule from #2380 after a spec change, and closes the gap it left: collection blocks derived their dropdown picker from the graph-wide member-schema union, so same-named twin properties (duplicate `Topics`, duplicate `Related claims`) still surfaced there.

## What changed
- **A property is dropdown-eligible only when a canonical space declares it.** "Canonical" = the ranked set in `space-ranking.ts` (`SPACE_RANK`), now exported as `RANKED_SPACE_IDS` and documented as the single source of that definition.
- **Uniform across sources:** query blocks take their types from the filter; collections from their members (`useCollectionMemberSchema` now also returns the member type ids). GEO tables included.
- Everything else untouched: sort/filter/column menus keep the full GEO-2202 schema union, configured chips stay removable, stored configs outside eligibility are inert (pills invariant).

## Live validation (reported block `591f5d7c…`, a claims collection)
The Claim type's canonical declarations (Root/Geo, Crypto, Health) carry the complete useful schema with the single true `Topics (806d52bc)`. The twin `Topics (3b7759e5)` and a parallel phantom vocabulary exist only in the unranked space `dc0f0d36…`; the duplicate `Related claims` pair splits the same way. Canonical-only eligibility removes every duplicate with nothing useful lost.

## Known edges
- A type declared **only** in unranked/personal spaces gets zero dropdown-eligible properties — the strict reading of the spec. A home-space fallback is a few lines if product wants it.
- Unranked **Knowledge Commons** loses its (currently redundant) say; if KC should be canonical, add it to `SPACE_RANK` — now the one place that decides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015a2qTB8H4TuZtVBYABrpMo