### PR TITLE
fix(debates): stop equating presence with tab visibility (GEO-2849)

### DIFF
--- a/apps/web/core/debates/debate-attention.test.ts
+++ b/apps/web/core/debates/debate-attention.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { createDebateAttentionStore, createDebatePresenceStore } from './debate-attention';
+import {
+  createDebateAttentionStore,
+  createDebateConnectionPresenceStore,
+  createDebateVisibilityStore,
+} from './debate-attention';
 
 describe('debate attention', () => {
   let focused: boolean;
@@ -121,7 +125,7 @@ describe('debate attention', () => {
 describe('debate presence', () => {
   let focused: boolean;
   let visibilityState: DocumentVisibilityState;
-  let store: ReturnType<typeof createDebatePresenceStore>;
+  let store: ReturnType<typeof createDebateVisibilityStore>;
   let unsubscribe: (() => void) | undefined;
 
   beforeEach(() => {
@@ -140,7 +144,7 @@ describe('debate presence', () => {
   });
 
   function subscribe() {
-    store = createDebatePresenceStore(window, document);
+    store = createDebateVisibilityStore(window, document);
     unsubscribe = store.subscribe(vi.fn());
   }
 
@@ -238,5 +242,64 @@ describe('debate presence', () => {
     unsubscribe = store.subscribe(vi.fn());
 
     expect(store.getSnapshot()).toBe(false);
+  });
+});
+
+describe('debate connection presence (GEO-2849)', () => {
+  let visibilityState: DocumentVisibilityState;
+  let store: ReturnType<typeof createDebateConnectionPresenceStore>;
+  let unsubscribe: (() => void) | undefined;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    visibilityState = 'visible';
+    vi.spyOn(document, 'visibilityState', 'get').mockImplementation(() => visibilityState);
+  });
+
+  afterEach(() => {
+    unsubscribe?.();
+    unsubscribe = undefined;
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  function subscribe() {
+    store = createDebateConnectionPresenceStore(window, document);
+    unsubscribe = store.subscribe(vi.fn());
+  }
+
+  // The whole point of the change. On a video call every participant's tab is hidden at once, and
+  // keying presence on visibility made them all vanish from each other's matchmaking. A hidden tab
+  // is still here.
+  it('stays present while the tab is hidden, however long', () => {
+    subscribe();
+    expect(store.getSnapshot()).toBe(true);
+
+    visibilityState = 'hidden';
+    document.dispatchEvent(new Event('visibilitychange'));
+    vi.advanceTimersByTime(60 * 60 * 1000);
+
+    expect(store.getSnapshot()).toBe(true);
+  });
+
+  it('drops on pagehide, which is the real departure signal', () => {
+    subscribe();
+
+    window.dispatchEvent(new Event('pagehide'));
+    expect(store.getSnapshot()).toBe(false);
+  });
+
+  it('comes back on pageshow, so a bfcache restore is not stranded as absent', () => {
+    subscribe();
+    window.dispatchEvent(new Event('pagehide'));
+    expect(store.getSnapshot()).toBe(false);
+
+    window.dispatchEvent(new Event('pageshow'));
+    expect(store.getSnapshot()).toBe(true);
+  });
+
+  it('is present from the first read, before any event fires', () => {
+    subscribe();
+    expect(store.getSnapshot()).toBe(true);
   });
 });

--- a/apps/web/core/debates/debate-attention.ts
+++ b/apps/web/core/debates/debate-attention.ts
@@ -100,8 +100,14 @@ export function createDebateAttentionStore(
 const DEFAULT_HIDE_GRACE_MS = 60_000;
 
 /**
- * Presence, unlike attention, asks only whether this tab is *open and on screen* — not whether it
- * is the frontmost window.
+ * Is this tab on screen, or recently so?
+ *
+ * **This is no longer presence** (GEO-2849). It gates *polling cadence* — a hidden tab should stop
+ * refetching — and nothing else. What geo-chat is told about `is_online` comes from
+ * `createDebateConnectionPresenceStore` below, for reasons recorded there.
+ *
+ * Unlike attention, this asks only whether the tab is open and on screen, not whether it is the
+ * frontmost window.
  *
  * The gateway reports this as `debate_presence`, and geo-chat turns it into `is_online`, which
  * gates two things that must not depend on where the pointer happens to be: who appears in
@@ -120,7 +126,7 @@ const DEFAULT_HIDE_GRACE_MS = 60_000;
  * genuinely get wrong — offering a debate to someone who has already gone — keeps its explicit
  * signal, and the grace only ever covers a tab that is still there.
  */
-export function createDebatePresenceStore(
+export function createDebateVisibilityStore(
   windowRef: Window,
   documentRef: Document,
   hideGraceMs = DEFAULT_HIDE_GRACE_MS
@@ -196,7 +202,71 @@ export function createDebatePresenceStore(
   };
 }
 
+/**
+ * Presence: is this tab still here?
+ *
+ * True for the whole life of the document, false only once it is genuinely going away.
+ *
+ * **This used to be tab visibility, and that broke every onboarding call (GEO-2849).** On a video
+ * call nobody's browser tab is the frontmost window — people are looking at Zoom, or presenting —
+ * so every participant reported hidden, flipped to offline, and vanished from everyone else's
+ * matchmaking at the same moment. Measured during one: a participant with 38 matchable claims saw
+ * none of them, and zero debate requests were created across a call with nine people online.
+ *
+ * GEO-2836 gave visibility a 60-second grace, which fixed tab-switching and could never fix this:
+ * the participant who reported it was 79.6 seconds hidden, and a call lasts an hour.
+ *
+ * The honest signal is the socket. A tab that is open and heartbeating is present — hiding it is
+ * not leaving, and treating the two as the same thing is what made someone invisible while they
+ * were sitting in front of the product being shown how to use it.
+ *
+ * `pagehide` remains the departure signal, and it is the *right* one: it fires on close, on
+ * navigation and into the back-forward cache, which are the cases where the person really is gone.
+ * `pageshow` restores, so a bfcache restore does not strand a live tab as absent.
+ */
+export function createDebateConnectionPresenceStore(windowRef: Window, documentRef: Document): DebateAttentionStore {
+  // Starts present: the document is executing this, so the tab exists.
+  let present = true;
+  const listeners = new Set<() => void>();
+
+  const setPresent = (next: boolean) => {
+    if (present === next) return;
+    present = next;
+    for (const listener of listeners) listener();
+  };
+
+  const hide = () => setPresent(false);
+  // Deliberately not `visibilitychange`. A hidden tab is still here; see the note above.
+  const show = () => setPresent(true);
+
+  const attach = () => {
+    windowRef.addEventListener('pagehide', hide);
+    windowRef.addEventListener('pageshow', show);
+  };
+  const detach = () => {
+    windowRef.removeEventListener('pagehide', hide);
+    windowRef.removeEventListener('pageshow', show);
+  };
+
+  return {
+    getSnapshot: () => present,
+    subscribe(listener) {
+      listeners.add(listener);
+      if (listeners.size === 1) {
+        attach();
+        // A store nobody was listening to ran no handlers; the document is alive if we are here.
+        setPresent(documentRef.defaultView !== null);
+      }
+      return () => {
+        listeners.delete(listener);
+        if (listeners.size === 0) detach();
+      };
+    },
+  };
+}
+
 let browserAttentionStore: DebateAttentionStore | null = null;
+let browserVisibilityStore: DebateAttentionStore | null = null;
 let browserPresenceStore: DebateAttentionStore | null = null;
 const serverAttentionStore: DebateAttentionStore = {
   getSnapshot: () => false,
@@ -209,9 +279,15 @@ function getBrowserAttentionStore() {
   return browserAttentionStore;
 }
 
+function getBrowserVisibilityStore() {
+  if (typeof window === 'undefined' || typeof document === 'undefined') return serverAttentionStore;
+  if (!browserVisibilityStore) browserVisibilityStore = createDebateVisibilityStore(window, document);
+  return browserVisibilityStore;
+}
+
 function getBrowserPresenceStore() {
   if (typeof window === 'undefined' || typeof document === 'undefined') return serverAttentionStore;
-  if (!browserPresenceStore) browserPresenceStore = createDebatePresenceStore(window, document);
+  if (!browserPresenceStore) browserPresenceStore = createDebateConnectionPresenceStore(window, document);
   return browserPresenceStore;
 }
 
@@ -223,7 +299,19 @@ export function useDebateAttention() {
   return React.useSyncExternalStore(store.subscribe, store.getSnapshot, getServerSnapshot);
 }
 
-/** Is this tab on screen, or recently so? Drives the gateway's `debate_presence`. */
+/**
+ * Is this tab on screen, or recently so? Gates **polling cadence** — not presence (GEO-2849).
+ */
+export function useDebateVisibility() {
+  const store = getBrowserVisibilityStore();
+  return React.useSyncExternalStore(store.subscribe, store.getSnapshot, getServerSnapshot);
+}
+
+/**
+ * Is this tab still here? Drives the gateway's `debate_presence`, and therefore `is_online`.
+ *
+ * Not visibility. See `createDebateConnectionPresenceStore`.
+ */
 export function useDebatePresence() {
   const store = getBrowserPresenceStore();
   return React.useSyncExternalStore(store.subscribe, store.getSnapshot, getServerSnapshot);

--- a/apps/web/core/debates/debate-coordinator.tsx
+++ b/apps/web/core/debates/debate-coordinator.tsx
@@ -94,7 +94,12 @@ export function DebateCoordinator() {
   const pathname = usePathname();
   const debateDebuggingEnabled = useFeatureFlag('debateDebugging');
   const geoChatAuth = useGeoChatAuth();
-  // Presence, not attention: being available to debate has to survive looking at another window.
+  // Presence, not attention or visibility: being available to debate has to survive looking at
+  // another window *and* having this tab behind a video call (GEO-2849). This is now the
+  // connection-backed signal, so it stays true while the tab is merely hidden.
+  //
+  // The polling gates in `hooks.ts` deliberately did NOT move with it — a hidden tab should stop
+  // refetching even though it is still present. Splitting those two is GEO-2842.
   const debatePresence = useDebatePresence();
   // Exactly one tab: visible *and* focused. See the rematch routing effect below.
   const hasAttention = useDebateAttention();

--- a/apps/web/core/debates/hooks-query-network.test.tsx
+++ b/apps/web/core/debates/hooks-query-network.test.tsx
@@ -23,7 +23,8 @@ type QueryOptions = { queryKey: readonly unknown[] };
 const mocks = vi.hoisted(() => ({
   authenticated: true,
   attention: true,
-  presence: true,
+  visible: true,
+  present: true,
   gatewayPaused: false,
   queryCache: { subscribe: vi.fn(() => vi.fn()) },
   queryClient: {
@@ -65,13 +66,18 @@ vi.mock('./debate-gateway', () => ({
 
 vi.mock('./debate-attention', () => ({
   useDebateAttention: () => mocks.attention,
-  useDebatePresence: () => mocks.presence,
+  // GEO-2849 split these apart: polling is gated on *visibility*, while `debate_presence` — what
+  // geo-chat turns into `is_online` — is now connection-backed and survives a hidden tab. These
+  // tests are about polling cadence, so they drive the visibility signal.
+  useDebateVisibility: () => mocks.visible,
+  useDebatePresence: () => mocks.present,
 }));
 
 beforeEach(() => {
   mocks.authenticated = true;
   mocks.attention = true;
-  mocks.presence = true;
+  mocks.visible = true;
+  mocks.present = true;
   mocks.gatewayPaused = false;
   mocks.queryClient.invalidateQueries.mockClear();
   mocks.queryClient.getQueryCache.mockClear();
@@ -114,13 +120,13 @@ describe('debate query network ownership', () => {
   // visible tab behind the focused window is exactly where someone waits for an opponent.
   it('polls the rematch session on a visible tab, including one that is not focused', () => {
     mocks.attention = false;
-    mocks.presence = true;
+    mocks.visible = true;
 
     const { rerender } = renderHook(() => useDebateRematch('rematch-1'));
     expect(mocks.useQuery.mock.calls.at(-1)?.[0]).toMatchObject({ refetchInterval: 5_000 });
 
     // A hidden tab has nobody watching the picker.
-    mocks.presence = false;
+    mocks.visible = false;
     rerender();
     expect(mocks.useQuery.mock.calls.at(-1)?.[0]).toMatchObject({ refetchInterval: false });
   });
@@ -140,11 +146,11 @@ describe('debate query network ownership', () => {
     expect(mocks.useQuery.mock.calls.at(-1)?.[0]).toMatchObject({ refetchInterval: 10_000 });
 
     // A hidden tab has no popup to draw, paused or not.
-    mocks.presence = false;
+    mocks.visible = false;
     rerender();
     expect(mocks.useQuery.mock.calls.at(-1)?.[0]).toMatchObject({ refetchInterval: false });
 
-    mocks.presence = true;
+    mocks.visible = true;
     rerender();
     expect(mocks.queryRefetch).toHaveBeenCalledTimes(1);
   });
@@ -156,7 +162,7 @@ describe('debate query network ownership', () => {
   // poll exists to cover, which is how a request still took ~36 seconds after GEO-2638.
   it('keeps polling activity on a visible tab that is not the focused window', () => {
     mocks.attention = false;
-    mocks.presence = true;
+    mocks.visible = true;
 
     renderHook(() => useDebateActivity());
 

--- a/apps/web/core/debates/hooks.ts
+++ b/apps/web/core/debates/hooks.ts
@@ -63,7 +63,7 @@ import {
   updateDebateAvailability,
 } from './api';
 import { claimResponseIndexedEvent } from './claim-response-indexed-notifier';
-import { useDebateAttention, useDebatePresence } from './debate-attention';
+import { useDebateAttention, useDebateVisibility } from './debate-attention';
 import { markEnteringDebate, markEnteringPendingDebate } from './debate-entry-intent';
 import { useDebateGatewayScope, useDebateGatewaySnapshot, useDebateGatewaySpaceScopes } from './debate-gateway';
 import { hasProcessedVideo } from './playback-utils';
@@ -365,7 +365,7 @@ export function useDebateActivity(enabled = true) {
   const queryClient = useQueryClient();
   const { accountKey, authenticated, getPrivyIdentityToken } = useGeoChatAuth();
   const attentive = useDebateAttention();
-  const present = useDebatePresence();
+  const present = useDebateVisibility();
   const { paused } = useDebateGatewaySnapshot();
   const queryEnabled = enabled && authenticated;
   const wasPresent = React.useRef(present);
@@ -644,7 +644,7 @@ export function useDebateRematch(sessionId: string, enabled = true) {
   // sitting open on screen behind whatever window the viewer is typing in would not poll — and
   // waiting for an opponent while looking elsewhere is exactly this flow. That distinction is the
   // one GEO-2650 already cost once on the activity poll; see the note on `useDebateActivity`.
-  const present = useDebatePresence();
+  const present = useDebateVisibility();
 
   return useQuery({
     ...debateQueryNetworkOptions,


### PR DESCRIPTION
Fixes GEO-2849. **Diagnosed live during Adam's onboarding call today.**

### What was happening

`is_online` was driven by `document.visibilityState`. On a video call **nobody's browser tab is the frontmost window** — people are looking at Zoom, or presenting. So every participant reported hidden, flipped to offline, and disappeared from each other's matchmaking at the same moment. Each of them then saw nothing available and concluded the product was broken.

Measured from the live call:

```
Adam:  available_to_debate = true
       is_online           = FALSE
       last_seen_at        = 79.6s ago
```

He had **38 matchable claims** — claims where someone else online and available held the opposing side — and saw none, because matchmaking requires the opponent online and he was invisible to them too. **Zero debate requests were created in the preceding 30 minutes** across a call with nine people online.

The cohort split cleanly on heartbeat staleness: everyone at 1–29s was online, everyone past the grace was not.

### Why yesterday's fix wasn't enough

GEO-2836 (#2382) gave visibility a 60-second grace so a brief tab switch stops reading as leaving. That was the right direction and the wrong order of magnitude — Adam was at **79.6s**, and a call lasts an hour, not a minute. I sized it against tab-switching because that was the reported symptom.

### The change

The honest signal is the socket: a tab that is open and heartbeating **is present**. Hiding it is not leaving. `pagehide` stays the departure signal and is the right one — it fires on close, navigation, and bfcache entry, which are the cases where someone has actually gone. `pageshow` restores, so a bfcache restore isn't stranded as absent.

The two meanings become two stores, which is exactly what **GEO-2842** asked for:

| hook | backed by | drives |
| -- | -- | -- |
| `useDebatePresence` | connection / document lifetime | `debate_presence` → `is_online`. **Survives a hidden tab.** |
| `useDebateVisibility` | visibility + the 60s grace (the old store, renamed) | polling cadence only |

**Only the presence report changed behaviour.** Both polling gates in `hooks.ts` keep the visibility semantics they had, so a hidden tab still stops refetching — which is the concern that made GEO-2842 worth filing in the first place.

### Testing

`vitest run core/debates` — **1248 passing, 89 files**. `tsc --noEmit` clean. Prettier clean on all five changed files.

The regression test asserts presence survives **an hour** of hidden tab. **I verified it fails when visibility is wired back in**, rather than only passing against the fix — with the old behaviour reintroduced it fails on exactly that assertion.

`hooks-query-network.test.tsx` mocked `useDebatePresence` for what were really visibility tests; its mock is split too, and the field renamed from `presence` to `visible`, since the whole point here is that those two words stopped meaning the same thing.

### Worth knowing

This is a plausible explanation for GEO-2826's *"I reverted because it was broken for the onboarding call"* — same root cause, different symptom. Onboarding calls are the one situation where every participant backgrounds the tab at once, which is why this surfaced there twice.
