### PR TITLE
fix: serve the new marketing website alongside Genesis

### DIFF
--- a/apps/web/next.config.test.ts
+++ b/apps/web/next.config.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from 'vitest';
+import { getPathMatch } from 'next/dist/shared/lib/router/utils/path-match';
+
+vi.mock('@sentry/nextjs', () => ({ withSentryConfig: (config: unknown) => config }));
+vi.mock('./app/api/environment', () => ({ ServerEnvironment: { sentryBuild: {} } }));
+
+import config from './next.config';
+
+async function marketingRoutes() {
+  const rewrites = await config.rewrites!();
+  if (Array.isArray(rewrites)) throw new Error('Expected phased rewrites');
+  return rewrites.beforeFiles!.filter(route =>
+    route.destination.startsWith('https://geo-website-livid.vercel.app')
+  );
+}
+
+function matches(source: string, path: string) {
+  return Boolean(getPathMatch(source)(path));
+}
+
+describe('marketing routing', () => {
+  it.each(['/', '/terms', '/api/subscribe', '/_marketing/_next/static/chunk.js',
+    '/_marketing/image', '/hero/logo.svg', '/hero/debates/debate-1.webm',
+    '/curators/card-grey-1.webp', '/opengraph-image.jpg', '/twitter-image.jpg'])
+  ('forwards %s to the marketing deployment without changing its path', async path => {
+    const routes = await marketingRoutes();
+    const route = routes.find(route => matches(route.source, path));
+    expect(route).toBeDefined();
+    expect(route!.destination).toBe(`https://geo-website-livid.vercel.app${route!.source}`);
+  });
+
+  it.each(['/root', '/explore', '/space/123', '/space/123/debates/456',
+    '/api/chat', '/api/debates/publish-sweep', '/_next/image', '/_next/static/chunk.js',
+    '/early-access', '/curator-program', '/ending-homelessness', '/blog'])
+  ('does not capture existing Genesis or legacy route %s', async path => {
+    expect((await marketingRoutes()).some(route => matches(route.source, path))).toBe(false);
+  });
+});

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -6,6 +6,35 @@ import { ServerEnvironment } from './app/api/environment';
 
 const isDev = process.env.NODE_ENV === 'development';
 
+const marketingOrigin = 'https://geo-website-livid.vercel.app';
+// Only marketing-owned paths are forwarded. Genesis retains /_next, app APIs,
+// /root, /explore and /space, and legacy campaigns keep their existing hosts.
+const marketingPaths = [
+  '/',
+  '/terms',
+  '/api/subscribe',
+  '/_marketing/:path*',
+  '/opengraph-image.jpg',
+  '/twitter-image.jpg',
+  '/favicon.ico',
+  '/icon.png',
+  '/apple-icon.png',
+  '/browse/:path*',
+  '/collage/:path*',
+  '/community/:path*',
+  '/curators/:path*',
+  '/deck/:path*',
+  '/hero/:path*',
+  '/match/:path*',
+  '/panel/:path*',
+  '/platform2/:path*',
+  '/platform3/:path*',
+  '/rays/:path*',
+  '/social/:path*',
+  '/trust/:path*',
+  '/voice/:path*',
+];
+
 // Faster local dev. Opt in with ENABLE_TURBOPACK_OPTIMIZATIONS=1.
 // Flags defined on ExperimentalConfig:
 // https://github.com/vercel/next.js/blob/canary/packages/next/src/server/config-shared.ts
@@ -140,10 +169,10 @@ const nextConfig: NextConfig = {
     return {
       beforeFiles: [
         ...geoChatProxyRewrites,
-        {
-          source: '/',
-          destination: 'https://geo.framer.website/',
-        },
+        ...marketingPaths.map(source => ({
+          source,
+          destination: `${marketingOrigin}${source}`,
+        })),
         {
           source: '/early-access',
           destination: 'https://geobrowser-v2.vercel.app/early-access',


### PR DESCRIPTION
## Summary
Serve the new Geo marketing website at geobrowser.io while keeping Genesis at /root, /explore, /space and its existing API routes. The domain stays assigned to Genesis; the homepage no longer proxies Framer.

The prerequisite asset isolation is already deployed in geobrowser/geo-website commit 4ddb864. Marketing JavaScript, styles, fonts and optimized images use /_marketing, leaving Genesis's /_next endpoints intact. Explicit marketing media, terms, subscribe and social-preview routes go to https://geo-website-livid.vercel.app. Existing campaign and blog destinations are preserved.

## Validation
- 22 Vitest routing tests pass using Next.js's path matcher, covering marketing routing and exclusion of Genesis and legacy routes.
- ESLint passes for the Genesis config and tests.
- Marketing production build passes; 60 prefixed asset requests pass against its local production server.
- Live stable marketing deployment serves prefixed JS, CSS, fonts and optimized images successfully.
- End-to-end public-domain verification remains: unauthenticated automated requests to existing /root and /explore return HTTP 403 before this change. Confirm homepage, sign-in, Explore, a space page, and newsletter submission in a browser after deployment.

## Rollout
Merge after preview review. No domain reassignment is needed. If homepage assets or Genesis navigation fail after deployment, revert this routing commit; the marketing asset prefix can remain deployed independently.
