### PR TITLE
fix(onboarding): serve the sign-up terms from geobrowser.io (GEO-2854)

### DIFF
--- a/apps/web/partials/onboarding/dialog.tsx
+++ b/apps/web/partials/onboarding/dialog.tsx
@@ -83,7 +83,7 @@ const ONBOARDING_DESTINATION = NavUtils.toExplore();
 // How long the completion screen shows before we route the user onward. The
 // personal space keeps creating in the background regardless.
 const COMPLETION_ANIMATION_MS = 3000;
-const TERMS_AND_CONDITIONS_URL = 'https://docs.google.com/document/d/106bM0qopWGJ8aAausnO7LYtkkDJz__xc/edit';
+const TERMS_AND_CONDITIONS_URL = 'https://www.geobrowser.io/terms';
 
 const ONBOARDING_PERSONAL_SEARCH_TYPES = [SystemIds.SPACE_TYPE, SystemIds.PROJECT_TYPE, SystemIds.PERSON_TYPE];
 


### PR DESCRIPTION
Closes [GEO-2854](https://linear.app/geobrowser/issue/GEO-2854/account-creation-point-the-terms-of-service-link-at-geobrowserioterms)

## Problem

The "Terms & Conditions" link in the account creation dialog pointed at a Google Doc (`docs.google.com/document/d/106bM0qopWGJ8aAausnO7LYtkkDJz__xc/edit`). That's a document a user is being asked to legally agree to, living on infrastructure we don't control: its sharing permissions can change without notice, it has no stable versioning, and it doesn't present as a legal document.

## Change

One line in [dialog.tsx:86](apps/web/partials/onboarding/dialog.tsx#L86) — the URL now points at `https://www.geobrowser.io/terms`.

## Verification of the ticket's open questions

- **Is the destination live?** Yes. `https://www.geobrowser.io/terms` returns 200 with `<title>Terms | Geo</title>` and ~130KB of rendered content. It's also already an explicitly routed marketing path in [next.config.ts:14](apps/web/next.config.ts#L14), so it's a first-class route, not an accident.
- **Does the Google Docs link appear anywhere else?** No. A repo-wide grep for `docs.google.com` (excluding `node_modules`/`.next`) returns exactly this one hit.
- **Is there a privacy policy link with the same problem?** No — there is no privacy policy link in the app. Grepping `apps/web` and `packages/auth` for legal-link config (including Privy's `legal.termsAndConditionsUrl` / `privacyPolicyUrl`) turns up nothing; the onboarding dialog's anchor is the only legal link in the product.

## Note

Kept as an absolute URL rather than a relative `/terms`. The anchor is `target="_blank"`, and the absolute form resolves correctly from preview deploys and any non-production host, where the marketing rewrite may not be in play.
