### PR TITLE
feat(debates): name the closing arguments round in the debate UI (GEO-2852)

### DIFF
--- a/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
@@ -10,7 +10,7 @@ import { clearDebateReturnDestination, rememberDebateReturnDestination } from '~
 import type { DebateRoomTakeoverContext } from '~/core/debates/debate-room-ownership';
 import { ExtendedReconnectPolicy } from '~/core/livekit/extended-reconnect-policy';
 
-import { DebateRoomPageClient, isDebateInThankYouPeriod } from './debate-room-page-client';
+import { DebateRoomPageClient, isDebateInThankYouPeriod, upcomingTurnLabel } from './debate-room-page-client';
 
 const mocks = vi.hoisted(() => ({
   prefetchAllowlist: vi.fn(),
@@ -445,6 +445,40 @@ describe('isDebateInThankYouPeriod', () => {
         deadline
       )
     ).toBe(false);
+  });
+});
+
+describe('upcomingTurnLabel', () => {
+  // Only the fields the label reads. The room renders this string verbatim into the count-in
+  // overlay, and the rebuttal branch is covered end to end by the DOM test further down; this
+  // covers the branch a two-round format cannot reach.
+  const countdownAt = (turnIndex: number) =>
+    ({ effectiveStatus: 'in_progress', turnIndex }) as Parameters<typeof upcomingTurnLabel>[1];
+  const debateWith = (turnDurationsMs: number[]) =>
+    ({ turn_durations_ms: turnDurationsMs }) as Parameters<typeof upcomingTurnLabel>[0];
+
+  const threeRounds = debateWith([60_000, 60_000, 45_000, 45_000, 30_000, 30_000]);
+
+  it('names the closing argument when counting into the third round', () => {
+    expect(upcomingTurnLabel(threeRounds, countdownAt(3))).toBe('Closing argument in');
+    expect(upcomingTurnLabel(threeRounds, countdownAt(4))).toBe('Closing argument in');
+  });
+
+  it('still names the rebuttal, which is now the middle round', () => {
+    expect(upcomingTurnLabel(threeRounds, countdownAt(1))).toBe('Rebut in');
+  });
+
+  it('leaves the opening round and the final turn to the generic label', () => {
+    expect(upcomingTurnLabel(threeRounds, countdownAt(0))).toBeNull();
+    // Nothing comes after the last turn, so there is no turn to count into.
+    expect(upcomingTurnLabel(threeRounds, countdownAt(5))).toBeNull();
+  });
+
+  it('reads a debate recorded before the closing round as two rounds', () => {
+    const twoRounds = debateWith([60_000, 60_000, 45_000, 45_000]);
+
+    expect(upcomingTurnLabel(twoRounds, countdownAt(1))).toBe('Rebut in');
+    expect(upcomingTurnLabel(twoRounds, countdownAt(0))).toBeNull();
   });
 });
 

--- a/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.tsx
@@ -33,6 +33,7 @@ import {
   createDebateRoomOwnershipCoordinator,
   debateRoomTabPriority,
 } from '~/core/debates/debate-room-ownership';
+import { debateTurnRole } from '~/core/debates/formats';
 import {
   useAbortDebate,
   useClearDebateActivity,
@@ -2089,9 +2090,7 @@ function DebateRecordingModal({
   const localUpcomingLabel =
     countdown.yieldingSlot && !countdown.preservesExistingCountIn
       ? 'Your turn in'
-      : upcomingTurnIsRebuttal(debate, countdown)
-        ? 'Rebut in'
-        : "You're up in";
+      : (upcomingTurnLabel(debate, countdown) ?? "You're up in");
   const showLocalGo = localTurnGoIsVisible(countdown, localSlot);
   const showLocalWrapItUp = wrapItUpIsVisible(countdown, localSlot);
   const showLocalDebateEndsSoon = debateEndsSoonIsVisible(debate, countdown, localSlot);
@@ -2656,15 +2655,26 @@ function wrapItUpIsVisible(countdown: DebateCountdown, slot: ParticipantSlot | n
   );
 }
 
-function upcomingTurnIsRebuttal(debate: Debate, countdown: DebateCountdown) {
-  if (countdown.effectiveStatus !== 'in_progress' || countdown.turnIndex === null) return false;
+/**
+ * Names the turn you are counting into, when it is one the format gives a distinct purpose.
+ *
+ * `null` falls back to the generic "You're up in". The closing round exists to address the
+ * audience rather than the opponent (GEO-2852), and the countdown is the only moment the room can
+ * say so before someone starts talking — so it says it in full rather than abbreviating.
+ */
+export function upcomingTurnLabel(debate: Debate, countdown: DebateCountdown) {
+  if (countdown.effectiveStatus !== 'in_progress' || countdown.turnIndex === null) return null;
   const nextTurnIndex = countdown.turnIndex + 1;
   const turnCount = debate.turn_durations_ms.length;
-  if (nextTurnIndex >= turnCount) return false;
-  // Mirror format-details.tsx: round 0 is always an opening argument, so a turn is a
-  // rebuttal only when it falls in the last round and that round is not the opening one.
-  const roundIndex = Math.floor(nextTurnIndex / 2);
-  return roundIndex !== 0 && roundIndex === Math.floor((turnCount - 1) / 2);
+  if (nextTurnIndex >= turnCount) return null;
+  switch (debateTurnRole(nextTurnIndex, turnCount)) {
+    case 'rebuttal':
+      return 'Rebut in';
+    case 'closing':
+      return 'Closing argument in';
+    default:
+      return null;
+  }
 }
 
 function debateEndsSoonIsVisible(debate: Debate, countdown: DebateCountdown, localSlot: ParticipantSlot | null) {

--- a/apps/web/core/debates/format-details.tsx
+++ b/apps/web/core/debates/format-details.tsx
@@ -3,7 +3,7 @@
 import { Avatar } from '~/design-system/avatar';
 import { Text } from '~/design-system/text';
 
-import { debateFormatById, defaultDebateFormatId } from './formats';
+import { debateFormatById, debateTurnRole, defaultDebateFormatId } from './formats';
 
 type FormatParticipant = {
   user_id: string;
@@ -60,10 +60,17 @@ export function DebateFormatDetails({
 
 function turnLabel(participant: FormatParticipant, currentUserId: string, turnIndex: number, turnCount: number) {
   const name = participant.user_id === currentUserId ? 'You' : speakerLabel(participant);
-  const roundIndex = Math.floor(turnIndex / 2);
-  if (roundIndex === 0) return `${name} ${name === 'You' ? 'make' : 'makes'} an argument`;
-  if (roundIndex === Math.floor((turnCount - 1) / 2)) return `${name} ${name === 'You' ? 'rebut' : 'rebuts'}`;
-  return `${name} ${name === 'You' ? 'respond' : 'responds'}`;
+  const you = name === 'You';
+  switch (debateTurnRole(turnIndex, turnCount)) {
+    case 'opening':
+      return `${name} ${you ? 'make' : 'makes'} an argument`;
+    case 'rebuttal':
+      return `${name} ${you ? 'rebut' : 'rebuts'}`;
+    case 'closing':
+      return `${name} ${you ? 'close' : 'closes'} to the audience`;
+    default:
+      return `${name} ${you ? 'respond' : 'responds'}`;
+  }
 }
 
 function formatTurnDuration(durationMs: number) {

--- a/apps/web/core/debates/formats.test.ts
+++ b/apps/web/core/debates/formats.test.ts
@@ -1,15 +1,22 @@
 import { describe, expect, it } from 'vitest';
 
-import { debateFormatById, debateFormats, debateTimingSummary, defaultDebateFormatId } from './formats';
+import { debateFormatById, debateFormats, debateTimingSummary, debateTurnRole, defaultDebateFormatId } from './formats';
 
 describe('debate formats', () => {
   it('matches the prototype format catalog', () => {
     expect(debateFormats.map(format => [format.id, format.label, format.turnDurationsMs])).toEqual([
-      ['dev-short', '7/7 4/4', [7_000, 7_000, 4_000, 4_000]],
-      ['standard', '1/1 45/45', [60_000, 60_000, 45_000, 45_000]],
+      ['dev-short', '7/7 4/4 3/3', [7_000, 7_000, 4_000, 4_000, 3_000, 3_000]],
+      ['standard', '1/1 45/45 30/30', [60_000, 60_000, 45_000, 45_000, 30_000, 30_000]],
       ['extended-standard', '45/45 30/30', [45_000, 45_000, 30_000, 30_000]],
       ['triple-standard', '45/45 30/30 30/30', [45_000, 45_000, 30_000, 30_000, 30_000, 30_000]],
     ]);
+  });
+
+  it('matches the geo-chat catalog for the live format', () => {
+    // geo-chat resolves the id independently in `DebateFormat::standard()` and writes the
+    // durations onto the debate row. If the two catalogs drift, the request dialog previews turns
+    // the debate will not actually run.
+    expect(debateFormatById('standard')?.turnDurationsMs).toEqual([60_000, 60_000, 45_000, 45_000, 30_000, 30_000]);
   });
 
   it('formats round summaries', () => {
@@ -21,5 +28,26 @@ describe('debate formats', () => {
 
   it('defaults to a configured format id', () => {
     expect(debateFormatById(defaultDebateFormatId)).not.toBeNull();
+  });
+
+  it('reads a third round as the closing argument', () => {
+    expect([0, 1, 2, 3, 4, 5].map(index => debateTurnRole(index, 6))).toEqual([
+      'opening',
+      'opening',
+      'rebuttal',
+      'rebuttal',
+      'closing',
+      'closing',
+    ]);
+  });
+
+  it('keeps the two-round reading for debates recorded before the closing round', () => {
+    // Old debates replay from their own `turn_durations_ms`, so a four-turn debate must still
+    // label its last round a rebuttal rather than inventing a closing argument it never had.
+    expect([0, 1, 2, 3].map(index => debateTurnRole(index, 4))).toEqual(['opening', 'opening', 'rebuttal', 'rebuttal']);
+  });
+
+  it('puts the rebuttal second-to-last when a format has more rounds', () => {
+    expect([0, 2, 4, 6].map(index => debateTurnRole(index, 8))).toEqual(['opening', 'response', 'rebuttal', 'closing']);
   });
 });

--- a/apps/web/core/debates/formats.ts
+++ b/apps/web/core/debates/formats.ts
@@ -12,14 +12,14 @@ export type DebateFormat = {
 export const debateFormats: DebateFormat[] = [
   {
     id: 'dev-short',
-    label: '7/7 4/4',
-    turnDurationsMs: [7_000, 7_000, 4_000, 4_000],
+    label: '7/7 4/4 3/3',
+    turnDurationsMs: [7_000, 7_000, 4_000, 4_000, 3_000, 3_000],
     developmentOnly: true,
   },
   {
     id: 'standard',
-    label: '1/1 45/45',
-    turnDurationsMs: [60_000, 60_000, 45_000, 45_000],
+    label: '1/1 45/45 30/30',
+    turnDurationsMs: [60_000, 60_000, 45_000, 45_000, 30_000, 30_000],
   },
   {
     id: 'extended-standard',
@@ -41,6 +41,27 @@ export function debateFormatById(id: string | null | undefined): DebateFormat | 
 
 export function isDebateFormatId(id: string | null | undefined): id is DebateFormatId {
   return debateFormatById(id) !== null;
+}
+
+export type DebateTurnRole = 'opening' | 'response' | 'rebuttal' | 'closing';
+
+/**
+ * What a turn *is*, from its position in the format (GEO-2852).
+ *
+ * Derived from the turn count rather than the format id, because everything downstream of a
+ * started debate reads `turn_durations_ms` off the debate row and never sees the id again — a
+ * debate recorded under the old four-turn `standard` still has to label its turns correctly.
+ *
+ * Two rounds keep their existing reading: open, then rebut. A third round makes the middle one the
+ * rebuttal and hands the last one to closing arguments, which is the round GEO-2852 added.
+ */
+export function debateTurnRole(turnIndex: number, turnCount: number): DebateTurnRole {
+  const roundCount = Math.ceil(turnCount / 2);
+  const roundIndex = Math.floor(turnIndex / 2);
+  if (roundIndex <= 0) return 'opening';
+  if (roundIndex >= roundCount - 1) return roundCount >= 3 ? 'closing' : 'rebuttal';
+  if (roundIndex === roundCount - 2) return 'rebuttal';
+  return 'response';
 }
 
 export function debateRoundSummaries(format: DebateFormat) {


### PR DESCRIPTION
Closes GEO-2852 (UI half). Pairs with geobrowser/geo-chat#107, which adds the round itself.

Mirrors geo-chat's catalog — `standard` is **1/1 45/45 30/30** — and teaches the two places that describe a turn what a third round means.

### The labelling was going to be wrong

Both `turnLabel` (the request dialog's turn preview) and the room's count-in classified the **last** round as the rebuttal. Add a third round and the closing arguments get announced as a rebuttal, while the actual rebuttal degrades to a generic "responds".

Both now go through `debateTurnRole`, which derives the role from the turn count rather than the format id:

- two rounds — open, rebut (unchanged, which is what a debate recorded before this change replays as)
- three rounds — open, rebut, close
- more — open, respond…, rebut, close

Deriving it from the count rather than the id matters because nothing downstream of a started debate ever sees the id again: playback reads `turn_durations_ms` off the debate row, so a four-turn debate has to keep labelling itself as two rounds. The two call sites previously duplicated the rule, with a comment in the room asking the reader to keep it in step with `format-details.tsx` by hand; it is now written once.

### The room says it in full

"Closing argument in", not an abbreviation. The count-in is the only moment the room can tell someone this round is addressed to the audience rather than the opponent before they start talking, which is the distinction GEO-2852 asked to make unmistakable.

### One thing I did not do, and why

I did not extend the room's DOM test for the count-in. Its existing rebuttal case still passes and covers the wiring.

A six-turn fixture built the same way renders no count-in overlay at all. I probed five clock positions across the debate and confirmed the countdown itself is correct at each one (the phase timer reads exactly the expected remaining seconds), so the fixture and the clock are right — but no overlay renders. A byte-identical copy of the *passing* rebuttal fixture, pasted into a new `it()` in the same file, also renders nothing, while the original passes in isolation. So the failure is in how that test is set up rather than in this change, and I did not want to leave a test that passes for a reason I cannot state.

The label is covered directly instead, against the exported function the room renders from — including the four-turn legacy case and the final turn, which has nothing to count into.

### Testing

- `vitest run core/debates app/space` — 1640 passed across 99 files
- `tsc --noEmit` — no new errors in the touched files (the repo has pre-existing errors in `core/governance`, `core/hooks` and `core/responses`)
- prettier clean