### PR TITLE
feat(debates): publish extractor-assigned Topics on minted transcript claims

### DIFF
--- a/apps/web/core/debates/debate-publish-draft.test.ts
+++ b/apps/web/core/debates/debate-publish-draft.test.ts
@@ -371,7 +371,13 @@ describe('buildDebatePublishDraft', () => {
           // The same reused entity appears behind both debaters' restatements with the same
           // topic: one relation, not two. (Topics the entity already carries on the graph were
           // subtracted upstream by the reuse policy.)
-          { text: 'A restated point.', isFactual: null, turnIndex: 0, existingClaimEntityId: EXISTING, topics: [TOPIC] },
+          {
+            text: 'A restated point.',
+            isFactual: null,
+            turnIndex: 0,
+            existingClaimEntityId: EXISTING,
+            topics: [TOPIC],
+          },
           { text: 'Restated again.', isFactual: null, turnIndex: 1, existingClaimEntityId: EXISTING, topics: [TOPIC] },
         ],
       }),
@@ -383,6 +389,32 @@ describe('buildDebatePublishDraft', () => {
       [`${mintedId}->${TOPIC.id}`, `${mintedId}->${OTHER.id}`, `${EXISTING}->${TOPIC.id}`].sort()
     );
     expect(topicRelations.find(r => r.fromEntity.id === EXISTING)?.toEntity.name).toBe(TOPIC.name);
+  });
+
+  it('treats dashed and dashless forms of one topic as a single relation', () => {
+    const EXISTING = '4f12f5ea073442cbaa0fb10f70a9a876';
+    const draft = buildDebatePublishDraft(
+      baseInput({
+        claims: [
+          {
+            text: 'Restated once.',
+            isFactual: null,
+            turnIndex: 0,
+            existingClaimEntityId: EXISTING,
+            topics: [{ id: '27b73193-ecea-48fd-aa46-fdee40c0b717', name: 'AI and mental health' }],
+          },
+          {
+            text: 'Restated twice.',
+            isFactual: null,
+            turnIndex: 1,
+            existingClaimEntityId: EXISTING,
+            topics: [{ id: '27b73193ecea48fdaa46fdee40c0b717', name: 'AI and mental health' }],
+          },
+        ],
+      }),
+      { createEntityId: idFactory(), createPosition: () => 'a0' }
+    );
+    expect(draft.relations.filter(r => r.type.id === TOPICS_PROPERTY_ID)).toHaveLength(1);
   });
 
   it('writes each relation once when several claims resolve to the same existing entity', () => {

--- a/apps/web/core/debates/debate-publish-draft.test.ts
+++ b/apps/web/core/debates/debate-publish-draft.test.ts
@@ -3,7 +3,7 @@ import { SystemIds } from '@geoprotocol/geo-sdk/lite';
 import { Effect } from 'effect';
 import { describe, expect, it } from 'vitest';
 
-import { CLAIM_IS_FACTUAL_PROPERTY_ID, CLAIM_TYPE_ID } from '~/core/claims/ontology';
+import { CLAIM_IS_FACTUAL_PROPERTY_ID, CLAIM_TYPE_ID, TOPICS_PROPERTY_ID } from '~/core/claims/ontology';
 import { ID } from '~/core/id';
 import { Publish } from '~/core/utils/publish';
 
@@ -358,6 +358,26 @@ describe('buildDebatePublishDraft', () => {
     ).toBe(true);
     // The novel claim is minted and attributed as before.
     expect(blockAuthoringClaim(draft, claimIdByName(draft, 'A novel point.'))).toBe(NO_SPACE);
+  });
+
+  it('adds Topics relations to minted claims but never to reused entities', () => {
+    const EXISTING = '4f12f5ea073442cbaa0fb10f70a9a876';
+    const TOPIC = { id: '27b73193ecea48fdaa46fdee40c0b717', name: 'AI and mental health' };
+    const draft = buildDebatePublishDraft(
+      baseInput({
+        claims: [
+          { text: 'A novel point.', isFactual: true, turnIndex: 0, topics: [TOPIC] },
+          { text: 'A restated point.', isFactual: null, turnIndex: 1, existingClaimEntityId: EXISTING, topics: [TOPIC] },
+        ],
+      }),
+      { createEntityId: idFactory(), createPosition: () => 'a0' }
+    );
+    // Only the minted claim gets the Topics relation; the reused entity keeps its own topics.
+    const topicRelations = draft.relations.filter(r => r.type.id === TOPICS_PROPERTY_ID);
+    expect(topicRelations).toHaveLength(1);
+    expect(topicRelations[0].fromEntity.id).toBe(claimIdByName(draft, 'A novel point.'));
+    expect(topicRelations[0].toEntity.id).toBe(TOPIC.id);
+    expect(topicRelations[0].toEntity.name).toBe(TOPIC.name);
   });
 
   it('writes each relation once when several claims resolve to the same existing entity', () => {

--- a/apps/web/core/debates/debate-publish-draft.test.ts
+++ b/apps/web/core/debates/debate-publish-draft.test.ts
@@ -360,24 +360,29 @@ describe('buildDebatePublishDraft', () => {
     expect(blockAuthoringClaim(draft, claimIdByName(draft, 'A novel point.'))).toBe(NO_SPACE);
   });
 
-  it('adds Topics relations to minted claims but never to reused entities', () => {
+  it('adds Topics relations on minted and reused claims, deduped per claim and topic', () => {
     const EXISTING = '4f12f5ea073442cbaa0fb10f70a9a876';
     const TOPIC = { id: '27b73193ecea48fdaa46fdee40c0b717', name: 'AI and mental health' };
+    const OTHER = { id: '3f2044d6609746cd964da85414f7ba63', name: 'Morning routine' };
     const draft = buildDebatePublishDraft(
       baseInput({
         claims: [
-          { text: 'A novel point.', isFactual: true, turnIndex: 0, topics: [TOPIC] },
-          { text: 'A restated point.', isFactual: null, turnIndex: 1, existingClaimEntityId: EXISTING, topics: [TOPIC] },
+          { text: 'A novel point.', isFactual: true, turnIndex: 0, topics: [TOPIC, OTHER] },
+          // The same reused entity appears behind both debaters' restatements with the same
+          // topic: one relation, not two. (Topics the entity already carries on the graph were
+          // subtracted upstream by the reuse policy.)
+          { text: 'A restated point.', isFactual: null, turnIndex: 0, existingClaimEntityId: EXISTING, topics: [TOPIC] },
+          { text: 'Restated again.', isFactual: null, turnIndex: 1, existingClaimEntityId: EXISTING, topics: [TOPIC] },
         ],
       }),
       { createEntityId: idFactory(), createPosition: () => 'a0' }
     );
-    // Only the minted claim gets the Topics relation; the reused entity keeps its own topics.
     const topicRelations = draft.relations.filter(r => r.type.id === TOPICS_PROPERTY_ID);
-    expect(topicRelations).toHaveLength(1);
-    expect(topicRelations[0].fromEntity.id).toBe(claimIdByName(draft, 'A novel point.'));
-    expect(topicRelations[0].toEntity.id).toBe(TOPIC.id);
-    expect(topicRelations[0].toEntity.name).toBe(TOPIC.name);
+    const mintedId = claimIdByName(draft, 'A novel point.');
+    expect(topicRelations.map(r => `${r.fromEntity.id}->${r.toEntity.id}`).sort()).toEqual(
+      [`${mintedId}->${TOPIC.id}`, `${mintedId}->${OTHER.id}`, `${EXISTING}->${TOPIC.id}`].sort()
+    );
+    expect(topicRelations.find(r => r.fromEntity.id === EXISTING)?.toEntity.name).toBe(TOPIC.name);
   });
 
   it('writes each relation once when several claims resolve to the same existing entity', () => {

--- a/apps/web/core/debates/debate-publish-draft.ts
+++ b/apps/web/core/debates/debate-publish-draft.ts
@@ -1,6 +1,6 @@
 import { Position } from '@geoprotocol/geo-sdk/lite';
 
-import { CLAIM_IS_FACTUAL_PROPERTY_ID, CLAIM_TYPE_ID } from '~/core/claims/ontology';
+import { CLAIM_IS_FACTUAL_PROPERTY_ID, CLAIM_TYPE_ID, TOPICS_PROPERTY_ID } from '~/core/claims/ontology';
 import { ID } from '~/core/id';
 import type { DataType, Relation, Value } from '~/core/types';
 
@@ -71,6 +71,12 @@ export type DebateClaimInput = {
    * facts. Null/absent mints a fresh Claim as before.
    */
   existingClaimEntityId?: string | null;
+  /**
+   * Topics the extractor assigned to this claim, selected from the debated claim's own topic
+   * set ({KG entity id, name}). Written only when the claim mints a fresh entity — a reused
+   * entity keeps its own topics, like its Name, Types and Is factual.
+   */
+  topics?: { id: string; name: string | null }[];
 };
 
 export type DebatePublishInput = {
@@ -375,6 +381,14 @@ export function buildDebatePublishDraft(input: DebatePublishInput, options: Buil
           });
           if (claim.isFactual !== null) {
             setBoolean(claimId, claimEntityText, CLAIM_IS_FACTUAL_PROPERTY_ID, claim.isFactual);
+          }
+          for (const topic of claim.topics ?? []) {
+            relate({
+              fromEntity: claimRef,
+              propertyId: TOPICS_PROPERTY_ID,
+              toEntityId: topic.id,
+              toEntityName: topic.name,
+            });
           }
         }
         const blockClaimKey = `${blockId}:${claimId}`;

--- a/apps/web/core/debates/debate-publish-draft.ts
+++ b/apps/web/core/debates/debate-publish-draft.ts
@@ -364,9 +364,11 @@ export function buildDebatePublishDraft(input: DebatePublishInput, options: Buil
       // Supported/Opposed-by membership on the Debate.
       //
       // Find-or-create: a claim geo-chat matched to an existing Claim in this space reuses that
-      // entity. Only the two relations are written — the block's Claims and the claim's Sources —
-      // and nothing on the entity itself, so a claim someone else published keeps its own Name,
-      // Types and Is factual even where this extraction would have said otherwise.
+      // entity. Nothing describing the claim is written onto it — no Name, no Types, no Is
+      // factual — so a claim someone else published keeps its own facts even where this
+      // extraction would have said otherwise. What is written is membership: the block's Claims
+      // relation, the claim's Sources relation, and any Topics the entity does not already carry
+      // in this space (the reuse policy subtracts the ones it does).
       for (const claim of claimsByTurnIndex.get(turn.turnIndex) ?? []) {
         const claimEntityText = claim.text.trim();
         if (claimEntityText.length === 0) continue;
@@ -390,7 +392,9 @@ export function buildDebatePublishDraft(input: DebatePublishInput, options: Buil
         // (claim, topic): a reused entity can appear behind several extracted claims carrying the
         // same topic, and `relate` does not dedupe.
         for (const topic of claim.topics ?? []) {
-          const edge = `${claimId}:${topic.id}`;
+          // Keyed on normalized ids so the dedupe agrees with the reuse policy, which compares
+          // topics as hex: the same entity written once dashed and once dashless is one edge.
+          const edge = `${normalizeId(claimId)}:${normalizeId(topic.id)}`;
           if (claimTopicEdges.has(edge)) continue;
           claimTopicEdges.add(edge);
           relate({
@@ -453,6 +457,11 @@ export function mergeTranscriptSegmentsIntoTurns(
     }
   }
   return turns;
+}
+
+/** Dashless, lower-case — the form ids are compared in, so one entity is one key. */
+function normalizeId(id: string): string {
+  return id.replace(/-/g, '').toLowerCase();
 }
 
 const TEXT_DATA_TYPE: DataType = 'TEXT';

--- a/apps/web/core/debates/debate-publish-draft.ts
+++ b/apps/web/core/debates/debate-publish-draft.ts
@@ -73,8 +73,9 @@ export type DebateClaimInput = {
   existingClaimEntityId?: string | null;
   /**
    * Topics the extractor assigned to this claim, selected from the debated claim's own topic
-   * set ({KG entity id, name}). Written only when the claim mints a fresh entity — a reused
-   * entity keeps its own topics, like its Name, Types and Is factual.
+   * set ({KG entity id, name}). Written on minted and reused claims alike; for a reused entity
+   * the reuse policy has already subtracted the topics the entity carries on the graph, so the
+   * draft never writes a duplicate Topics relation.
    */
   topics?: { id: string; name: string | null }[];
 };
@@ -323,6 +324,7 @@ export function buildDebatePublishDraft(input: DebatePublishInput, options: Buil
     // claim per debate.
     const linkedBlockClaims = new Set<string>();
     const sourcedClaims = new Set<string>();
+    const claimTopicEdges = new Set<string>();
 
     turns.forEach(turn => {
       const speakerName = turn.speakerName?.trim() ? turn.speakerName.trim() : 'Anonymous';
@@ -382,14 +384,21 @@ export function buildDebatePublishDraft(input: DebatePublishInput, options: Buil
           if (claim.isFactual !== null) {
             setBoolean(claimId, claimEntityText, CLAIM_IS_FACTUAL_PROPERTY_ID, claim.isFactual);
           }
-          for (const topic of claim.topics ?? []) {
-            relate({
-              fromEntity: claimRef,
-              propertyId: TOPICS_PROPERTY_ID,
-              toEntityId: topic.id,
-              toEntityName: topic.name,
-            });
-          }
+        }
+        // Topics ride both branches — a minted claim gets its full set, a reused entity only what
+        // the reuse policy left after subtracting the graph's current relations. Deduped per
+        // (claim, topic): a reused entity can appear behind several extracted claims carrying the
+        // same topic, and `relate` does not dedupe.
+        for (const topic of claim.topics ?? []) {
+          const edge = `${claimId}:${topic.id}`;
+          if (claimTopicEdges.has(edge)) continue;
+          claimTopicEdges.add(edge);
+          relate({
+            fromEntity: claimRef,
+            propertyId: TOPICS_PROPERTY_ID,
+            toEntityId: topic.id,
+            toEntityName: topic.name,
+          });
         }
         const blockClaimKey = `${blockId}:${claimId}`;
         if (!linkedBlockClaims.has(blockClaimKey)) {

--- a/apps/web/core/debates/server/claim-reuse.test.ts
+++ b/apps/web/core/debates/server/claim-reuse.test.ts
@@ -42,6 +42,17 @@ afterEach(() => {
 });
 
 describe('applyClaimReusePolicy', () => {
+  it('reads topics scoped to the publication space', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    const lookup = vi.fn<ExistingClaimLookup>(async () => graph);
+
+    await applyClaimReusePolicy(claims, SPACE, { enabled: true, lookup });
+
+    // Relations are per-space: a topic the entity carries in another space is not a duplicate
+    // here, so the read has to be scoped or the writer would skip a relation this space needs.
+    expect(lookup.mock.calls[0]?.[1]).toBe(SPACE);
+  });
+
   it('subtracts topics the reused entity already carries and keeps the rest', async () => {
     vi.spyOn(console, 'log').mockImplementation(() => {});
     const CARRIED = { id: '27b73193ecea48fdaa46fdee40c0b717', name: 'AI and mental health' };

--- a/apps/web/core/debates/server/claim-reuse.test.ts
+++ b/apps/web/core/debates/server/claim-reuse.test.ts
@@ -42,6 +42,48 @@ afterEach(() => {
 });
 
 describe('applyClaimReusePolicy', () => {
+  it('subtracts topics the reused entity already carries and keeps the rest', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    const CARRIED = { id: '27b73193ecea48fdaa46fdee40c0b717', name: 'AI and mental health' };
+    const MISSING = { id: '3f2044d6609746cd964da85414f7ba63', name: 'Morning routine' };
+    const lookup = vi.fn<ExistingClaimLookup>(async () => [
+      { id: EXISTING, spaces: [SPACE], types: [{ id: CLAIM_TYPE_ID }], topicIds: [CARRIED.id] },
+    ]);
+
+    const result = await applyClaimReusePolicy(
+      [
+        {
+          text: 'Matched.',
+          isFactual: null,
+          turnIndex: 0,
+          existingClaimEntityId: EXISTING,
+          topics: [CARRIED, MISSING],
+        },
+      ],
+      SPACE,
+      { enabled: true, lookup }
+    );
+
+    expect(result[0].existingClaimEntityId).toBe(EXISTING);
+    expect(result[0].topics).toEqual([MISSING]);
+  });
+
+  it('keeps every topic on a claim whose reference is dropped (it mints a fresh entity)', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const TOPIC = { id: '27b73193ecea48fdaa46fdee40c0b717', name: 'AI and mental health' };
+    const lookup = vi.fn<ExistingClaimLookup>(async () => []);
+
+    const result = await applyClaimReusePolicy(
+      [{ text: 'Gone.', isFactual: null, turnIndex: 0, existingClaimEntityId: GONE, topics: [TOPIC] }],
+      SPACE,
+      { enabled: true, lookup }
+    );
+
+    expect(result[0].existingClaimEntityId).toBeNull();
+    expect(result[0].topics).toEqual([TOPIC]);
+  });
+
   it('drops every reference and never reads the graph while reuse is off (shadow mode)', async () => {
     vi.spyOn(console, 'log').mockImplementation(() => {});
     const lookup = vi.fn(async () => graph);

--- a/apps/web/core/debates/server/claim-reuse.ts
+++ b/apps/web/core/debates/server/claim-reuse.ts
@@ -1,6 +1,6 @@
 import { Effect } from 'effect';
 
-import { CLAIM_TYPE_ID } from '~/core/claims/ontology';
+import { CLAIM_TYPE_ID, TOPICS_PROPERTY_ID } from '~/core/claims/ontology';
 import { uuidToHex } from '~/core/id/normalize';
 import { graphql } from '~/core/io/graphql-client';
 
@@ -31,6 +31,12 @@ export type ExistingClaimEntity = {
   /** Every space holding a value or relation of the entity. */
   spaces: string[];
   types: Array<{ id: string }>;
+  /**
+   * Targets of the entity's existing Topics relations. The topics writer adds only what is
+   * missing, because `relate` does not dedupe and a repeated Topics relation renders twice.
+   * Optional so injected test lookups predating topics stay valid; absent reads as none.
+   */
+  topicIds?: string[];
 };
 
 export type ExistingClaimLookup = (entityIds: string[]) => Promise<ExistingClaimEntity[]>;
@@ -47,11 +53,14 @@ const lookupInGraph: ExistingClaimLookup = entityIds =>
                   id: entity.id,
                   spaces: (entity.spaceIds ?? []).filter((id): id is string => typeof id === 'string'),
                   types: (entity.types ?? []).flatMap(type => (type ? [{ id: type.id }] : [])),
+                  topicIds: (entity.topicRelations ?? []).flatMap(relation =>
+                    relation?.toEntityId ? [relation.toEntityId] : []
+                  ),
                 },
               ]
             : []
         ),
-      variables: { ids: entityIds },
+      variables: { ids: entityIds, topicsPropertyId: TOPICS_PROPERTY_ID },
     })
   );
 
@@ -129,6 +138,7 @@ export async function applyClaimReusePolicy(
     ),
   ];
   let verified: Set<string>;
+  const existingTopicsByEntity = new Map<string, Set<string>>();
   try {
     const entities = ids.length > 0 ? await (options.lookup ?? lookupInGraph)(ids) : [];
     const spaceKey = uuidToHex(spaceId);
@@ -141,6 +151,9 @@ export async function applyClaimReusePolicy(
         )
         .map(entity => uuidToHex(entity.id))
     );
+    for (const entity of entities) {
+      existingTopicsByEntity.set(uuidToHex(entity.id), new Set((entity.topicIds ?? []).map(uuidToHex)));
+    }
   } catch (error) {
     console.warn('[debate-acceptor] could not verify matched claims; minting all of them instead', {
       debateId: options.debateId,
@@ -159,6 +172,14 @@ export async function applyClaimReusePolicy(
       verified.has(uuidToHex(claim.existingClaimEntityId))
     ) {
       reused += 1;
+      // Topics ride reused claims too, but only the ones the entity does not already carry —
+      // the same graph read that verified the entity says which those are. Everything minted
+      // keeps its full topic set (a fresh entity has nothing to duplicate).
+      const existingTopics = existingTopicsByEntity.get(uuidToHex(claim.existingClaimEntityId));
+      if (existingTopics?.size && claim.topics?.length) {
+        const missing = claim.topics.filter(topic => !existingTopics.has(uuidToHex(topic.id)));
+        if (missing.length !== claim.topics.length) return { ...claim, topics: missing };
+      }
       return claim;
     }
     return withoutReference(claim);

--- a/apps/web/core/debates/server/claim-reuse.ts
+++ b/apps/web/core/debates/server/claim-reuse.ts
@@ -39,9 +39,9 @@ export type ExistingClaimEntity = {
   topicIds?: string[];
 };
 
-export type ExistingClaimLookup = (entityIds: string[]) => Promise<ExistingClaimEntity[]>;
+export type ExistingClaimLookup = (entityIds: string[], spaceId: string) => Promise<ExistingClaimEntity[]>;
 
-const lookupInGraph: ExistingClaimLookup = entityIds =>
+const lookupInGraph: ExistingClaimLookup = (entityIds, spaceId) =>
   Effect.runPromise(
     graphql({
       query: existingClaimsDocument,
@@ -60,13 +60,22 @@ const lookupInGraph: ExistingClaimLookup = entityIds =>
               ]
             : []
         ),
-      variables: { ids: entityIds, topicsPropertyId: TOPICS_PROPERTY_ID },
+      variables: { ids: entityIds, topicsPropertyId: TOPICS_PROPERTY_ID, spaceId },
     })
   );
 
-/** A Geo entity id in either shape: 32 hex chars, dashed or not. Anything else cannot be queried. */
+/**
+ * A Geo entity id in either shape the SDK accepts: 32 hex chars, or the dashed UUID form.
+ * Anything else cannot be queried — and, more importantly, `Graph.createRelation` runs
+ * `assertValid` on every id it is handed and THROWS, which fails the whole edit. This mirrors
+ * the SDK's own `Id.isValid` exactly (dashless OR canonically-dashed); a laxer test would let
+ * a half-dashed id through to a throw at publish time.
+ */
+const DASHLESS_ID = /^[0-9a-f]{32}$/i;
+const DASHED_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 export function looksLikeEntityId(id: string): boolean {
-  return /^[0-9a-f]{32}$/i.test(id.replace(/-/g, ''));
+  return DASHLESS_ID.test(id) || DASHED_ID.test(id);
 }
 
 export function isDebateClaimReuseEnabled(): boolean {
@@ -140,7 +149,7 @@ export async function applyClaimReusePolicy(
   let verified: Set<string>;
   const existingTopicsByEntity = new Map<string, Set<string>>();
   try {
-    const entities = ids.length > 0 ? await (options.lookup ?? lookupInGraph)(ids) : [];
+    const entities = ids.length > 0 ? await (options.lookup ?? lookupInGraph)(ids, spaceId) : [];
     const spaceKey = uuidToHex(spaceId);
     verified = new Set(
       entities
@@ -172,9 +181,14 @@ export async function applyClaimReusePolicy(
       verified.has(uuidToHex(claim.existingClaimEntityId))
     ) {
       reused += 1;
-      // Topics ride reused claims too, but only the ones the entity does not already carry —
-      // the same graph read that verified the entity says which those are. Everything minted
-      // keeps its full topic set (a fresh entity has nothing to duplicate).
+      // Topics ride reused claims too, but only the ones the entity does not already carry in
+      // THIS space — the same graph read that verified the entity says which those are.
+      // Everything minted keeps its full topic set (a fresh entity has nothing to duplicate).
+      //
+      // The read is a pre-submit snapshot, so it cannot see an edit that has not indexed yet:
+      // two debates in one sweep that reuse the same entity and share a topic can each write
+      // the relation once. That window is the sweep's, not this policy's — deduping across it
+      // would need a post-index pass.
       const existingTopics = existingTopicsByEntity.get(uuidToHex(claim.existingClaimEntityId));
       if (existingTopics?.size && claim.topics?.length) {
         const missing = claim.topics.filter(topic => !existingTopics.has(uuidToHex(topic.id)));

--- a/apps/web/core/debates/server/debate-source.test.ts
+++ b/apps/web/core/debates/server/debate-source.test.ts
@@ -183,7 +183,13 @@ describe('loadDebatePublishSource media gating', () => {
     expect(input.transcriptTurns[0].text).toBe('Nuclear program was advancing.');
     // Claims arrive pre-attributed, keyed to the same turn indices.
     expect(input.claims).toEqual([
-      { text: 'The nuclear program was advancing.', isFactual: true, turnIndex: 0, existingClaimEntityId: null, topics: [] },
+      {
+        text: 'The nuclear program was advancing.',
+        isFactual: true,
+        turnIndex: 0,
+        existingClaimEntityId: null,
+        topics: [],
+      },
       { text: 'The action was unjustified.', isFactual: false, turnIndex: 1, existingClaimEntityId: null, topics: [] },
     ]);
   });

--- a/apps/web/core/debates/server/debate-source.test.ts
+++ b/apps/web/core/debates/server/debate-source.test.ts
@@ -183,8 +183,8 @@ describe('loadDebatePublishSource media gating', () => {
     expect(input.transcriptTurns[0].text).toBe('Nuclear program was advancing.');
     // Claims arrive pre-attributed, keyed to the same turn indices.
     expect(input.claims).toEqual([
-      { text: 'The nuclear program was advancing.', isFactual: true, turnIndex: 0, existingClaimEntityId: null },
-      { text: 'The action was unjustified.', isFactual: false, turnIndex: 1, existingClaimEntityId: null },
+      { text: 'The nuclear program was advancing.', isFactual: true, turnIndex: 0, existingClaimEntityId: null, topics: [] },
+      { text: 'The action was unjustified.', isFactual: false, turnIndex: 1, existingClaimEntityId: null, topics: [] },
     ]);
   });
 

--- a/apps/web/core/debates/server/existing-claims-document.ts
+++ b/apps/web/core/debates/server/existing-claims-document.ts
@@ -10,14 +10,17 @@ import { parse } from 'graphql';
  * "not a Claim here" and mint a duplicate for.
  */
 const EXISTING_CLAIMS_SOURCE = /* GraphQL */ `
-  query ExistingClaims($ids: [UUID!]!, $topicsPropertyId: UUID!) {
+  query ExistingClaims($ids: [UUID!]!, $topicsPropertyId: UUID!, $spaceId: UUID!) {
     entities(filter: { id: { in: $ids } }) {
       id
       spaceIds
       types {
         id
       }
-      topicRelations: relationsList(filter: { typeId: { is: $topicsPropertyId } }) {
+      topicRelations: relationsList(
+        first: 100
+        filter: { typeId: { is: $topicsPropertyId }, spaceId: { is: $spaceId } }
+      ) {
         toEntityId
       }
     }
@@ -29,14 +32,19 @@ export type ExistingClaimsQuery = {
     id: string;
     spaceIds: Array<string | null> | null;
     types: Array<{ id: string } | null> | null;
-    /** The entity's existing Topics relations — what the topics writer must not duplicate.
-     * `relationsList` serves at most the server's 100-row default page, which no claim's
-     * topic set approaches. */
+    /**
+     * The entity's existing Topics relations **in the publication space** — what the topics
+     * writer must not duplicate. Space-scoped deliberately: relations are per-space, so a
+     * topic the entity carries only in some other space is not a duplicate here and must
+     * still be written (verified: an entity in two spaces returns 4 relations unscoped and 2
+     * scoped). Paged at 100 like every other topics query in the repo rather than relying on
+     * a server default.
+     */
     topicRelations: Array<{ toEntityId: string | null } | null> | null;
   } | null> | null;
 };
 
 export const existingClaimsDocument = parse(EXISTING_CLAIMS_SOURCE) as TypedDocumentNode<
   ExistingClaimsQuery,
-  { ids: string[]; topicsPropertyId: string }
+  { ids: string[]; topicsPropertyId: string; spaceId: string }
 >;

--- a/apps/web/core/debates/server/existing-claims-document.ts
+++ b/apps/web/core/debates/server/existing-claims-document.ts
@@ -10,12 +10,15 @@ import { parse } from 'graphql';
  * "not a Claim here" and mint a duplicate for.
  */
 const EXISTING_CLAIMS_SOURCE = /* GraphQL */ `
-  query ExistingClaims($ids: [UUID!]!) {
+  query ExistingClaims($ids: [UUID!]!, $topicsPropertyId: UUID!) {
     entities(filter: { id: { in: $ids } }) {
       id
       spaceIds
       types {
         id
+      }
+      topicRelations: relationsList(filter: { typeId: { is: $topicsPropertyId } }) {
+        toEntityId
       }
     }
   }
@@ -26,10 +29,14 @@ export type ExistingClaimsQuery = {
     id: string;
     spaceIds: Array<string | null> | null;
     types: Array<{ id: string } | null> | null;
+    /** The entity's existing Topics relations — what the topics writer must not duplicate.
+     * `relationsList` serves at most the server's 100-row default page, which no claim's
+     * topic set approaches. */
+    topicRelations: Array<{ toEntityId: string | null } | null> | null;
   } | null> | null;
 };
 
 export const existingClaimsDocument = parse(EXISTING_CLAIMS_SOURCE) as TypedDocumentNode<
   ExistingClaimsQuery,
-  { ids: string[] }
+  { ids: string[]; topicsPropertyId: string }
 >;

--- a/apps/web/core/debates/server/extracted-claims.test.ts
+++ b/apps/web/core/debates/server/extracted-claims.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+
+import { decodeExtractedClaims } from './extracted-claims';
+
+const turn = { turn_index: 0, participant_slot: 0, attributed_space_id: 'space-a', speaker_name: 'A', text: 'hello' };
+
+describe('decodeExtractedClaims topics', () => {
+  it('maps topic rows to {id, name}, dropping blank ids and defaulting absent topics', () => {
+    const { claims } = decodeExtractedClaims({
+      turns: [turn],
+      claims: [
+        {
+          text: 'With topics',
+          is_factual: true,
+          turn_index: 0,
+          topics: [
+            { entity_id: '27b73193ecea48fdaa46fdee40c0b717', name: 'AI and mental health' },
+            // Drift guard: a row without a usable id must not become an empty entity reference.
+            { entity_id: '   ', name: 'Blank id' },
+          ],
+        },
+        // A payload from before topic assignment shipped has no `topics` key at all.
+        { text: 'Without topics', is_factual: null, turn_index: 0 },
+      ],
+    });
+    expect(claims[0].topics).toEqual([{ id: '27b73193ecea48fdaa46fdee40c0b717', name: 'AI and mental health' }]);
+    expect(claims[1].topics).toEqual([]);
+  });
+});

--- a/apps/web/core/debates/server/extracted-claims.test.ts
+++ b/apps/web/core/debates/server/extracted-claims.test.ts
@@ -1,8 +1,12 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { decodeExtractedClaims } from './extracted-claims';
 
 const turn = { turn_index: 0, participant_slot: 0, attributed_space_id: 'space-a', speaker_name: 'A', text: 'hello' };
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe('decodeExtractedClaims topics', () => {
   it('maps topic rows to {id, name}, dropping blank ids and defaulting absent topics', () => {
@@ -25,5 +29,41 @@ describe('decodeExtractedClaims topics', () => {
     });
     expect(claims[0].topics).toEqual([{ id: '27b73193ecea48fdaa46fdee40c0b717', name: 'AI and mental health' }]);
     expect(claims[1].topics).toEqual([]);
+  });
+
+  it('drops topic ids the publish path would throw on, and says so', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { claims } = decodeExtractedClaims({
+      turns: [turn],
+      claims: [
+        {
+          text: 'Bad topic ids',
+          is_factual: true,
+          turn_index: 0,
+          topics: [
+            // A slug, and a half-dashed id: `Graph.createRelation` asserts every id and throws,
+            // which would fail the whole edit — so neither may reach the draft.
+            { entity_id: 'ai-and-mental-health', name: 'AI and mental health' },
+            { entity_id: '4f12-f5ea073442cbaa0fb10f70a9a876', name: 'Half dashed' },
+            { entity_id: '27b73193-ecea-48fd-aa46-fdee40c0b717', name: 'Canonically dashed' },
+          ],
+        },
+      ],
+    });
+    expect(claims[0].topics).toEqual([{ id: '27b73193-ecea-48fd-aa46-fdee40c0b717', name: 'Canonically dashed' }]);
+    expect(warn).toHaveBeenCalledOnce();
+  });
+
+  it('treats a mis-shaped topics or claims field as no data rather than throwing', () => {
+    expect(() =>
+      decodeExtractedClaims({
+        turns: [turn],
+        // A map instead of a list, from a hypothetical geo-chat shape change.
+        claims: [{ text: 'x', is_factual: null, turn_index: 0, topics: { a: 'b' } as never }],
+      })
+    ).not.toThrow();
+    // `decodeExtractedClaims` runs outside the caller's try/catch, so a throw here would abort
+    // the publish instead of falling back to the raw transcript.
+    expect(decodeExtractedClaims({ turns: [turn], claims: 'nope' as never }).claims).toEqual([]);
   });
 });

--- a/apps/web/core/debates/server/extracted-claims.ts
+++ b/apps/web/core/debates/server/extracted-claims.ts
@@ -1,4 +1,5 @@
 import type { DebateClaimInput, DebatePublishTurn } from '../debate-publish-draft';
+import { looksLikeEntityId } from './claim-reuse';
 
 /** One turn of geo-chat's `GET /debates/{id}/claims` payload. */
 export type DebateExtractedClaimsTurn = {
@@ -51,7 +52,8 @@ export function decodeExtractedClaims(response: DebateExtractedClaimsResponse): 
       speakerName: turn.speaker_name,
       text: turn.text,
     }));
-  const claims: DebateClaimInput[] = (response.claims ?? []).map(claim => ({
+  const droppedTopics: unknown[] = [];
+  const claims: DebateClaimInput[] = (Array.isArray(response.claims) ? response.claims : []).map(claim => ({
     text: claim.text,
     isFactual: claim.is_factual ?? null,
     turnIndex: claim.turn_index,
@@ -59,10 +61,38 @@ export function decodeExtractedClaims(response: DebateExtractedClaimsResponse): 
       typeof claim.existing_entity_id === 'string' && claim.existing_entity_id.trim().length > 0
         ? claim.existing_entity_id.trim()
         : null,
-    topics: (claim.topics ?? []).flatMap(topic => {
-      const id = typeof topic?.entity_id === 'string' ? topic.entity_id.trim() : '';
-      return id.length > 0 ? [{ id, name: topic.name ?? null }] : [];
-    }),
+    topics: decodeTopics(claim.topics, droppedTopics),
   }));
+  if (droppedTopics.length > 0) {
+    // Loud, like the malformed-claim-id path in `claim-reuse`: a field rename upstream would
+    // otherwise publish every debate topic-less with nothing in the logs to say why.
+    console.warn('[debate-acceptor] dropping extracted-claim topics that are not entity ids', {
+      count: droppedTopics.length,
+      sample: droppedTopics.slice(0, 5),
+    });
+  }
   return { transcriptTurns, claims };
+}
+
+/**
+ * Topic rows → `{id, name}`, keeping only ids the publish path can actually use.
+ *
+ * An id that is not a valid entity id is not a cosmetic problem: `Graph.createRelation`
+ * asserts every id and throws, so one bad topic would fail `prepareLocalDataForPublishing`
+ * and the debate would never publish — on this sweep or any later one. Dropping the topic
+ * costs a tag; keeping it costs the whole debate.
+ */
+function decodeTopics(
+  topics: DebateExtractedClaimsClaim['topics'],
+  dropped: unknown[]
+): { id: string; name: string | null }[] {
+  if (!Array.isArray(topics)) return [];
+  return topics.flatMap(topic => {
+    const id = typeof topic?.entity_id === 'string' ? topic.entity_id.trim() : '';
+    if (id.length === 0 || !looksLikeEntityId(id)) {
+      if (topic != null) dropped.push(topic);
+      return [];
+    }
+    return [{ id, name: topic.name ?? null }];
+  });
 }

--- a/apps/web/core/debates/server/extracted-claims.ts
+++ b/apps/web/core/debates/server/extracted-claims.ts
@@ -21,6 +21,12 @@ export type DebateExtractedClaimsClaim = {
    * `match` audit object next to it, which the publisher does not read.
    */
   existing_entity_id?: string | null;
+  /**
+   * Topics the extractor assigned to this claim, drawn from the debated claim's own topic set
+   * (geo-chat's replica naming: entity_id + name). Absent on payloads from before topic
+   * assignment shipped, and empty when the debated claim has no topics.
+   */
+  topics?: { entity_id: string; name: string | null }[] | null;
 };
 
 export type DebateExtractedClaimsResponse = {
@@ -53,6 +59,10 @@ export function decodeExtractedClaims(response: DebateExtractedClaimsResponse): 
       typeof claim.existing_entity_id === 'string' && claim.existing_entity_id.trim().length > 0
         ? claim.existing_entity_id.trim()
         : null,
+    topics: (claim.topics ?? []).flatMap(topic => {
+      const id = typeof topic?.entity_id === 'string' ? topic.entity_id.trim() : '';
+      return id.length > 0 ? [{ id, name: topic.name ?? null }] : [];
+    }),
   }));
   return { transcriptTurns, claims };
 }

--- a/apps/web/scripts/live-claim-reuse.ts
+++ b/apps/web/scripts/live-claim-reuse.ts
@@ -15,7 +15,7 @@
 import { Effect } from 'effect';
 import { readFile } from 'node:fs/promises';
 
-import { CLAIM_IS_FACTUAL_PROPERTY_ID, CLAIM_TYPE_ID } from '~/core/claims/ontology';
+import { CLAIM_IS_FACTUAL_PROPERTY_ID, CLAIM_TYPE_ID, TOPICS_PROPERTY_ID } from '~/core/claims/ontology';
 import {
   type DebateClaimInput,
   type DebatePublishInput,
@@ -93,6 +93,12 @@ const claimsToReused = draft.relations.filter(r => reusedIds.has(r.toEntity.id) 
 const mintedClaims = draft.relations.filter(r => r.type.id === TYPES_PROPERTY_ID && r.toEntity.id === CLAIM_TYPE_ID);
 const opsByType = ops.reduce<Record<string, number>>((acc, op) => ({ ...acc, [op.type]: (acc[op.type] ?? 0) + 1 }), {});
 
+// Topics DO get written onto reused entities — only the ones the reuse policy found missing in
+// this space. Counted rather than asserted at 0, unlike values/types, which must stay untouched.
+const topicsFromReused = draft.relations.filter(
+  r => r.type.id === TOPICS_PROPERTY_ID && reusedIds.has(r.fromEntity.id)
+);
+
 console.log('\ndraft:');
 console.log(`  minted Claim entities:                 ${mintedClaims.length}`);
 console.log(`  reused Claim entities:                 ${reusedIds.size}`);
@@ -100,6 +106,7 @@ console.log(`  values written on reused entities:     ${valuesOnReused.length}  
 console.log(`  Types relations from reused entities:  ${typesOnReused.length}  (must be 0)`);
 console.log(`  block→Claims relations to reused:      ${claimsToReused.length}`);
 console.log(`  claim→Sources relations from reused:   ${sourcesFromReused.length}`);
+console.log(`  Topics relations from reused entities: ${topicsFromReused.length}  (only what the space lacks)`);
 console.log(
   `  Name values written:                   ${draft.values.filter(v => v.property.id === NAME_PROPERTY_ID).length}`
 );


### PR DESCRIPTION
## What

Completes the topics pipeline (extraction: geo-explorers/extraction-api#45 → payload: geobrowser/geo-chat#111 → **publish**): the debated claim's own Topics, assigned per transcript claim by the extractor, become on-chain Topics relations — on minted **and** reused claims, without ever duplicating a relation.

- `extracted-claims.ts`: the wire type gains per-claim `topics?: [{entity_id, name}]`; the decoder maps them to `DebateClaimInput.topics` (`{id, name}`, blank ids dropped as drift, absent key → `[]` so pre-feature payloads publish unchanged).
- `claim-reuse.ts` + `existing-claims-document.ts`: the reuse policy's existing batched graph read also selects each referenced entity's current Topics relations (`relationsList(filter: { typeId })`), and an honoured reference **subtracts what the entity already carries** from the claim's topic list.
- `debate-publish-draft.ts`: writes one Topics relation per remaining topic on both branches, deduped per (claim, topic) — a reused entity can appear behind several extracted claims carrying the same topic, and `relate` doesn't dedupe.

Fail-safes keep their old meaning: a dropped/unverifiable reference or a failed graph read mints a fresh entity with its full topic set — a new entity has nothing to duplicate.

This addresses the third item of Preston's 2026-08-28 report (extracted claims published with no topics).

## Testing

`bunx vitest run` on `debate-publish-draft.test.ts`, `extracted-claims.test.ts` (new), `debate-source.test.ts`, `claim-reuse.test.ts` — 62 tests pass. New coverage: minted claim gets its Topics relations; reused entity gets only the topics the graph read says it's missing; same reused entity behind multiple claims writes one relation; dropped reference keeps all topics; decoder drops blank ids and defaults absent `topics`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015a2qTB8H4TuZtVBYABrpMo
