### PR TITLE
Sink exhausted dropdown options to the end of the menu

### DIFF
--- a/apps/web/core/blocks/data/use-dropdown-options.test.ts
+++ b/apps/web/core/blocks/data/use-dropdown-options.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+
+import { type DropdownOption, orderDropdownOptions } from './use-dropdown-options';
+
+const counts = (entries: Record<string, number>) => new Map(Object.entries(entries));
+const facet = (entries: Record<string, number>) => Object.entries(entries).map(([id, count]) => ({ id, count }));
+const ids = (options: DropdownOption[]) => options.map(option => option.id);
+
+describe('orderDropdownOptions', () => {
+  it('sinks exhausted options below every option that can still narrow', () => {
+    const options = orderDropdownOptions({
+      pinned: [],
+      entries: facet({ a: 9, b: 0, c: 4, d: 0, e: 1 }),
+      counts: counts({ a: 9, b: 0, c: 4, d: 0, e: 1 }),
+      checkedIds: [],
+    });
+    expect(ids(options)).toEqual(['a', 'c', 'e', 'b', 'd']);
+  });
+
+  it('preserves the incoming order within each half — sinking only moves rows between halves', () => {
+    // The facet arrives count-descending and stays that way; the zeros keep
+    // their own relative order too rather than being re-sorted.
+    const options = orderDropdownOptions({
+      pinned: [],
+      entries: facet({ z: 0, a: 5, y: 0, b: 3 }),
+      counts: counts({ z: 0, a: 5, y: 0, b: 3 }),
+      checkedIds: [],
+    });
+    expect(ids(options)).toEqual(['a', 'b', 'z', 'y']);
+  });
+
+  it('keeps a checked option in place at zero, so a selection stays reachable to undo', () => {
+    // In intersection mode the viewer's own picks are what drove the other
+    // counts to zero; burying the pick would strand them.
+    const options = orderDropdownOptions({
+      pinned: [],
+      entries: facet({ a: 4, picked: 0, b: 0 }),
+      counts: counts({ a: 4, picked: 0, b: 0 }),
+      checkedIds: ['picked'],
+    });
+    expect(ids(options)).toEqual(['a', 'picked', 'b']);
+    expect(options.find(option => option.id === 'picked')?.isExhausted).toBe(false);
+    expect(options.find(option => option.id === 'b')?.isExhausted).toBe(true);
+  });
+
+  it('matches a checked id whatever its dash spelling', () => {
+    const options = orderDropdownOptions({
+      pinned: [],
+      entries: facet({ '591f5d7cc3ff48de932ac6f190d21b7b': 0, a: 2 }),
+      counts: counts({ '591f5d7cc3ff48de932ac6f190d21b7b': 0, a: 2 }),
+      checkedIds: ['591F5D7C-C3FF-48DE-932A-C6F190D21B7B'],
+    });
+    expect(ids(options)).toEqual(['591f5d7cc3ff48de932ac6f190d21b7b', 'a']);
+  });
+
+  it('leads with pinned entries, and sinks an exhausted unchecked pin like any other row', () => {
+    const options = orderDropdownOptions({
+      pinned: [
+        { id: 'preset', name: 'Preset' },
+        { id: 'gone', name: 'Gone' },
+      ],
+      entries: facet({ a: 1 }),
+      counts: counts({ preset: 7, a: 1 }),
+      checkedIds: ['preset'],
+    });
+    expect(ids(options)).toEqual(['preset', 'a', 'gone']);
+    // A pin the facet never returned counts zero, and keeps its resolved name.
+    expect(options[2]).toEqual({ id: 'gone', name: 'Gone', count: 0, isExhausted: true });
+  });
+
+  it('sinks nothing while the counts are still unknown', () => {
+    // Counts are null between a re-keyed population and its facet landing;
+    // an undefined count is not a definite zero, so the list must not churn.
+    const options = orderDropdownOptions({
+      pinned: [{ id: 'preset', name: 'Preset' }],
+      entries: facet({ a: 0, b: 0 }),
+      counts: null,
+      checkedIds: [],
+    });
+    expect(ids(options)).toEqual(['preset', 'a', 'b']);
+    expect(options.every(option => option.isExhausted === false)).toBe(true);
+    expect(options.every(option => option.count === undefined)).toBe(true);
+  });
+
+  it('does not list a facet entry that is already pinned', () => {
+    const options = orderDropdownOptions({
+      pinned: [{ id: 'a', name: 'Alpha' }],
+      entries: facet({ a: 3, b: 1 }),
+      counts: counts({ a: 3, b: 1 }),
+      checkedIds: [],
+    });
+    expect(ids(options)).toEqual(['a', 'b']);
+    expect(options[0].name).toBe('Alpha');
+  });
+});

--- a/apps/web/core/blocks/data/use-dropdown-options.ts
+++ b/apps/web/core/blocks/data/use-dropdown-options.ts
@@ -24,8 +24,68 @@ import {
   filterDefaultsForColumn,
 } from './table-dropdown-selections';
 
-/** An option row: entity id, name when known (pinned entries carry theirs), exact count when known. */
-export type DropdownOption = { id: string; name: string | null; count?: number };
+/**
+ * An option row: entity id, name when known (pinned entries carry theirs),
+ * exact count when known, and whether the current filters have exhausted it.
+ *
+ * `isExhausted` is set by {@link orderDropdownOptions} and is what the menu
+ * grays out — the rule lives here rather than in the component so that what
+ * sinks to the bottom of the list and what is drawn inert can never disagree.
+ */
+export type DropdownOption = { id: string; name: string | null; count?: number; isExhausted?: boolean };
+
+/**
+ * The menu's row order: pinned entries first (block defaults and the viewer's
+ * own picks — a preset must never go missing), then the facet's own
+ * count-descending order, and finally the options the current filters have
+ * exhausted.
+ *
+ * A definite zero can only take the table to an empty view, so it sinks below
+ * everything that can still narrow — the value stays listed and discoverable
+ * (and countable at a glance), it just stops occupying the rows a viewer
+ * reads first. Sinking is a STABLE partition: both halves keep the order they
+ * were built in, so it only ever changes which half a row is in.
+ *
+ * A checked option never sinks however low its count, because a row the
+ * viewer cannot reach is a selection they cannot undo — and in intersection
+ * mode their own picks are exactly what drove the other counts to zero.
+ */
+export function orderDropdownOptions({
+  pinned,
+  entries,
+  counts,
+  checkedIds,
+}: {
+  pinned: DropdownOption[];
+  entries: DropdownFacetEntry[];
+  /** Null while the counts for this population are still unknown — nothing sinks yet. */
+  counts: Map<string, number> | null;
+  checkedIds: string[];
+}): DropdownOption[] {
+  const checked = new Set(checkedIds.map(uuidToHex));
+  const seen = new Set<string>();
+  const available: DropdownOption[] = [];
+  const exhausted: DropdownOption[] = [];
+
+  const place = (option: DropdownOption, key: string) => {
+    const isExhausted = option.count === 0 && !checked.has(key);
+    (isExhausted ? exhausted : available).push({ ...option, isExhausted });
+  };
+
+  for (const pin of pinned) {
+    const key = uuidToHex(pin.id);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    place({ ...pin, count: counts?.get(key) ?? (counts ? 0 : undefined) }, key);
+  }
+  for (const entry of entries) {
+    if (seen.has(entry.id)) continue;
+    seen.add(entry.id);
+    place({ id: entry.id, name: null, count: counts ? (counts.get(entry.id) ?? 0) : undefined }, entry.id);
+  }
+
+  return exhausted.length === 0 ? available : [...available, ...exhausted];
+}
 
 function populationKeyOf(population: DropdownPopulation): string {
   return population.kind === 'ids'
@@ -155,23 +215,12 @@ export function useDropdownOptions({
     return new Map(source.map(entry => [entry.id, entry.count]));
   }, [countsDiverge, countFacet.data, listFacet.data, listFacet.isPlaceholderData]);
 
-  // Pinned first (dedup by canonical id form), then the facet count-descending.
-  const options: DropdownOption[] = React.useMemo(() => {
-    const seen = new Set<string>();
-    const out: DropdownOption[] = [];
-    for (const pin of pinned) {
-      const key = uuidToHex(pin.id);
-      if (seen.has(key)) continue;
-      seen.add(key);
-      out.push({ ...pin, count: counts?.get(key) ?? (counts ? 0 : undefined) });
-    }
-    for (const entry of listFacet.data ?? []) {
-      if (seen.has(entry.id)) continue;
-      seen.add(entry.id);
-      out.push({ id: entry.id, name: null, count: counts ? (counts.get(entry.id) ?? 0) : undefined });
-    }
-    return out;
-  }, [pinned, listFacet.data, counts]);
+  const options: DropdownOption[] = React.useMemo(
+    // `ownSelected` is a stable reference (a stored array or the memoized
+    // defaults), so this does not recompute the list on every render.
+    () => orderDropdownOptions({ pinned, entries: listFacet.data ?? [], counts, checkedIds: ownSelected }),
+    [pinned, listFacet.data, counts, ownSelected]
+  );
 
   return {
     options,

--- a/apps/web/partials/blocks/table/table-block-dropdowns.tsx
+++ b/apps/web/partials/blocks/table/table-block-dropdowns.tsx
@@ -400,20 +400,21 @@ function TableBlockDropdown({
             // pending (skeleton) only while a re-keyed population or the
             // All-mode facet resolves. A definite zero is shown but inert
             // (bounty-board facet behavior) — unless checked, so it can
-            // still be unselected.
+            // still be unselected. The hook decides which those are, and
+            // sinks exactly the same rows to the end of the list.
             const count = option.count;
-            const isInertZero = count === 0 && !checked;
+            const isExhausted = option.isExhausted ?? false;
             return (
               <button
                 key={option.id}
                 type="button"
                 role="checkbox"
                 aria-checked={checked}
-                disabled={isInertZero}
+                disabled={isExhausted}
                 onClick={() => toggle(option.id)}
                 className={cx(
                   'flex items-center gap-2 rounded px-2 py-2 text-left text-sm text-text hover:bg-grey-01',
-                  isInertZero && 'opacity-50 hover:bg-transparent'
+                  isExhausted && 'opacity-50 hover:bg-transparent'
                 )}
               >
                 <CheckboxVisual checked={checked} />


### PR DESCRIPTION
## What

Dropdown options the current filters have driven to **0** are already drawn grayed and inert, but they kept whatever position the facet's count-descending order gave them. On a narrowed table that meant the first rows a viewer reads could be options that lead nowhere, while the options that still narrow got pushed past the 25-row reveal window.

They now sort **after** every option that can still narrow.

```
before                     after
─────────────────          ─────────────────
Robotics        41         Robotics        41
Nuclear          0   →     LLMs             7
LLMs             7         Ethics           2
Ethics           2         Nuclear          0
Fusion           0         Fusion           0
```

The internal ordering is untouched, as asked: this is a **stable partition**, so both halves keep the order they were built in (pinned entries first, then the facet's count-descending order). Sinking only ever changes which half a row is in.

## Rules that fall out of it

- **A checked option never sinks**, however low its count. A row the viewer cannot reach is a selection they cannot undo — and in intersection ('All') mode their own picks are precisely what drove the other counts to zero.
- **Nothing sinks while counts are unknown.** Between a re-keyed population and its facet landing, counts are `null`; an undefined count is not a definite zero, so the list does not churn under the skeleton badges and then settle.
- **One source of truth.** The ordering moved into an exported pure `orderDropdownOptions`, which tags each row `isExhausted`; the menu grays exactly that flag instead of re-deriving `count === 0 && !checked`. What sinks and what is drawn inert can no longer disagree.

Side benefit: the revealed window — and the lazy name lookups it drives — now spend themselves on options that can actually be picked.

## Verification

- 7 new unit tests on `orderDropdownOptions`: the sink itself, order preservation within both halves, checked-at-zero staying put (including dashed/dashless id spelling), pinned entries leading, the counts-unknown case, and pin/facet dedup.
- Full suite: 442 files / 4,879 tests green. ESLint + Prettier clean, `tsc --noEmit` clean for tracked sources, env-stubbed production build passes.

Follows #2400, which made every count exact and complete in one request — which is what makes "this option is definitely empty" trustworthy enough to reorder on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015a2qTB8H4TuZtVBYABrpMo