### PR TITLE
feat(debates): tag contestable transcript claims as debate claims

### DIFF
--- a/apps/web/core/debates/debate-publish-draft.test.ts
+++ b/apps/web/core/debates/debate-publish-draft.test.ts
@@ -427,6 +427,21 @@ describe('buildDebatePublishDraft', () => {
     expect(claimIdByName(draft, 'A narrow fact.')).toBeTruthy();
   });
 
+  it('tags one motion when a proposition is extracted twice and matched to nothing', () => {
+    const draft = buildDebatePublishDraft(
+      baseInput({
+        claims: [
+          // Both mint their own entity (long-standing behaviour), but a fresh id per
+          // claim means an id-keyed dedupe would never fire — two rival motions.
+          { text: 'AI chatbots are effective therapy.', isFactual: false, turnIndex: 0, isContestable: true },
+          { text: 'AI chatbots are effective therapy.', isFactual: false, turnIndex: 1, isContestable: true },
+        ],
+      }),
+      { createEntityId: idFactory(), createPosition: () => 'a0' }
+    );
+    expect(draft.relations.filter(r => r.type.id === TAG_PROPERTY_ID)).toHaveLength(1);
+  });
+
   it('treats dashed and dashless forms of one topic as a single relation', () => {
     const EXISTING = '4f12f5ea073442cbaa0fb10f70a9a876';
     const draft = buildDebatePublishDraft(

--- a/apps/web/core/debates/debate-publish-draft.test.ts
+++ b/apps/web/core/debates/debate-publish-draft.test.ts
@@ -4,6 +4,8 @@ import { Effect } from 'effect';
 import { describe, expect, it } from 'vitest';
 
 import { CLAIM_IS_FACTUAL_PROPERTY_ID, CLAIM_TYPE_ID, TOPICS_PROPERTY_ID } from '~/core/claims/ontology';
+import { TAG_PROPERTY_ID } from '~/core/constants';
+import { DEBATE_TAG_ID } from '~/core/debates/ontology';
 import { ID } from '~/core/id';
 import { Publish } from '~/core/utils/publish';
 
@@ -389,6 +391,40 @@ describe('buildDebatePublishDraft', () => {
       [`${mintedId}->${TOPIC.id}`, `${mintedId}->${OTHER.id}`, `${EXISTING}->${TOPIC.id}`].sort()
     );
     expect(topicRelations.find(r => r.fromEntity.id === EXISTING)?.toEntity.name).toBe(TOPIC.name);
+  });
+
+  it('tags only contestable claims as Debate, minted or reused, once per entity', () => {
+    const EXISTING = '4f12f5ea073442cbaa0fb10f70a9a876';
+    const draft = buildDebatePublishDraft(
+      baseInput({
+        claims: [
+          { text: 'A broad position.', isFactual: false, turnIndex: 0, isContestable: true },
+          // Narrowly verifiable: still published as a Claim, just not offered as a motion.
+          { text: 'A narrow fact.', isFactual: true, turnIndex: 0, isContestable: false },
+          // The same reused entity behind two restatements gets one tag, not two.
+          {
+            text: 'Restated once.',
+            isFactual: null,
+            turnIndex: 1,
+            existingClaimEntityId: EXISTING,
+            isContestable: true,
+          },
+          {
+            text: 'Restated twice.',
+            isFactual: null,
+            turnIndex: 1,
+            existingClaimEntityId: EXISTING,
+            isContestable: true,
+          },
+        ],
+      }),
+      { createEntityId: idFactory(), createPosition: () => 'a0' }
+    );
+    const tags = draft.relations.filter(r => r.type.id === TAG_PROPERTY_ID);
+    expect(tags.map(r => r.fromEntity.id).sort()).toEqual([claimIdByName(draft, 'A broad position.'), EXISTING].sort());
+    expect(tags.every(r => r.toEntity.id === DEBATE_TAG_ID)).toBe(true);
+    // The narrow claim is still published as a Claim, it just carries no Debate tag.
+    expect(claimIdByName(draft, 'A narrow fact.')).toBeTruthy();
   });
 
   it('treats dashed and dashless forms of one topic as a single relation', () => {

--- a/apps/web/core/debates/debate-publish-draft.ts
+++ b/apps/web/core/debates/debate-publish-draft.ts
@@ -1,6 +1,7 @@
 import { Position } from '@geoprotocol/geo-sdk/lite';
 
 import { CLAIM_IS_FACTUAL_PROPERTY_ID, CLAIM_TYPE_ID, TOPICS_PROPERTY_ID } from '~/core/claims/ontology';
+import { TAG_PROPERTY_ID } from '~/core/constants';
 import { ID } from '~/core/id';
 import type { DataType, Relation, Value } from '~/core/types';
 
@@ -11,6 +12,7 @@ import {
   DEBATE_OPPOSED_BY_PROPERTY_ID,
   DEBATE_PARTICIPANTS_PROPERTY_ID,
   DEBATE_SUPPORTED_BY_PROPERTY_ID,
+  DEBATE_TAG_ID,
   DEBATE_TRANSCRIPTS_PROPERTY_ID,
   DEBATE_TYPE_ID,
   DEBATE_VIDEOS_PROPERTY_ID,
@@ -78,6 +80,13 @@ export type DebateClaimInput = {
    * draft never writes a duplicate Topics relation.
    */
   topics?: { id: string; name: string | null }[];
+  /**
+   * True when the claim is broad enough to be argued for and against. Tagged `Debate`
+   * so it joins the claim picker's candidate motions; a narrowly verifiable claim
+   * publishes as a Claim like any other, just untagged. For a reused entity the reuse
+   * policy has already cleared this when the entity carries the tag already.
+   */
+  isContestable?: boolean;
 };
 
 export type DebatePublishInput = {
@@ -325,6 +334,7 @@ export function buildDebatePublishDraft(input: DebatePublishInput, options: Buil
     const linkedBlockClaims = new Set<string>();
     const sourcedClaims = new Set<string>();
     const claimTopicEdges = new Set<string>();
+    const debateTaggedClaims = new Set<string>();
 
     turns.forEach(turn => {
       const speakerName = turn.speakerName?.trim() ? turn.speakerName.trim() : 'Anonymous';
@@ -391,6 +401,17 @@ export function buildDebatePublishDraft(input: DebatePublishInput, options: Buil
         // the reuse policy left after subtracting the graph's current relations. Deduped per
         // (claim, topic): a reused entity can appear behind several extracted claims carrying the
         // same topic, and `relate` does not dedupe.
+        // The Debate tag is what makes a claim a candidate motion in the picker, so it
+        // goes on contestable claims only — minted or reused alike, once per entity.
+        if (claim.isContestable && !debateTaggedClaims.has(normalizeId(claimId))) {
+          debateTaggedClaims.add(normalizeId(claimId));
+          relate({
+            fromEntity: claimRef,
+            propertyId: TAG_PROPERTY_ID,
+            toEntityId: DEBATE_TAG_ID,
+            toEntityName: 'Debate',
+          });
+        }
         for (const topic of claim.topics ?? []) {
           // Keyed on normalized ids so the dedupe agrees with the reuse policy, which compares
           // topics as hex: the same entity written once dashed and once dashless is one edge.

--- a/apps/web/core/debates/debate-publish-draft.ts
+++ b/apps/web/core/debates/debate-publish-draft.ts
@@ -403,8 +403,14 @@ export function buildDebatePublishDraft(input: DebatePublishInput, options: Buil
         // same topic, and `relate` does not dedupe.
         // The Debate tag is what makes a claim a candidate motion in the picker, so it
         // goes on contestable claims only — minted or reused alike, once per entity.
-        if (claim.isContestable && !debateTaggedClaims.has(normalizeId(claimId))) {
-          debateTaggedClaims.add(normalizeId(claimId));
+        // Reused entities key on their id; minted ones cannot, because `createEntityId`
+        // returns a fresh id per claim, so keying on it would dedupe nothing. Two
+        // verbatim extractions of one proposition therefore mint two entities (the
+        // long-standing behaviour) but yield a single motion. Near-duplicates that
+        // differ in wording still slip through — matching upstream is what catches those.
+        const tagKey = existingClaimId ? normalizeId(existingClaimId) : `text:${claimEntityText.toLowerCase()}`;
+        if (claim.isContestable && !debateTaggedClaims.has(tagKey)) {
+          debateTaggedClaims.add(tagKey);
           relate({
             fromEntity: claimRef,
             propertyId: TAG_PROPERTY_ID,

--- a/apps/web/core/debates/server/claim-reuse.test.ts
+++ b/apps/web/core/debates/server/claim-reuse.test.ts
@@ -53,6 +53,38 @@ describe('applyClaimReusePolicy', () => {
     expect(lookup.mock.calls[0]?.[1]).toBe(SPACE);
   });
 
+  it('does not re-tag a reused entity that already carries the Debate tag', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    const DEBATE_TAG = '55c95b2626f8482cb9739ea99dfde438';
+    const lookup = vi.fn<ExistingClaimLookup>(async () => [
+      { id: EXISTING, spaces: [SPACE], types: [{ id: CLAIM_TYPE_ID }], tagIds: [DEBATE_TAG] },
+    ]);
+
+    const result = await applyClaimReusePolicy(
+      [{ text: 'Matched.', isFactual: null, turnIndex: 0, existingClaimEntityId: EXISTING, isContestable: true }],
+      SPACE,
+      { enabled: true, lookup }
+    );
+
+    expect(result[0].existingClaimEntityId).toBe(EXISTING);
+    expect(result[0].isContestable).toBe(false);
+  });
+
+  it('tags a reused entity that is not yet a debate claim', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    const lookup = vi.fn<ExistingClaimLookup>(async () => [
+      { id: EXISTING, spaces: [SPACE], types: [{ id: CLAIM_TYPE_ID }], tagIds: [] },
+    ]);
+
+    const result = await applyClaimReusePolicy(
+      [{ text: 'Matched.', isFactual: null, turnIndex: 0, existingClaimEntityId: EXISTING, isContestable: true }],
+      SPACE,
+      { enabled: true, lookup }
+    );
+
+    expect(result[0].isContestable).toBe(true);
+  });
+
   it('subtracts topics the reused entity already carries and keeps the rest', async () => {
     vi.spyOn(console, 'log').mockImplementation(() => {});
     const CARRIED = { id: '27b73193ecea48fdaa46fdee40c0b717', name: 'AI and mental health' };

--- a/apps/web/core/debates/server/claim-reuse.test.ts
+++ b/apps/web/core/debates/server/claim-reuse.test.ts
@@ -53,6 +53,59 @@ describe('applyClaimReusePolicy', () => {
     expect(lookup.mock.calls[0]?.[1]).toBe(SPACE);
   });
 
+  it('withholds motion candidacy wherever a reference is dropped blind', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const MOTION = '00000000000000000000000000000009';
+    const contestable = (id: string | null) => ({
+      text: 'A restatement.',
+      isFactual: null,
+      turnIndex: 0,
+      existingClaimEntityId: id,
+      isContestable: true,
+    });
+
+    // The debate's own motion: refused reuse so a restatement cannot hijack it, and it
+    // must not be minted as a rival motion either — the motion is Debate-tagged already.
+    const motion = await applyClaimReusePolicy([contestable(MOTION)], SPACE, {
+      enabled: true,
+      lookup: vi.fn<ExistingClaimLookup>(async () => graph),
+      motionClaimEntityId: MOTION,
+    });
+    expect(motion[0].existingClaimEntityId).toBeNull();
+    expect(motion[0].isContestable).toBe(false);
+
+    // Shadow mode promises to change nothing but the counters.
+    const shadow = await applyClaimReusePolicy([contestable(EXISTING)], SPACE, {
+      enabled: false,
+      lookup: vi.fn<ExistingClaimLookup>(async () => graph),
+    });
+    expect(shadow[0].isContestable).toBe(false);
+
+    // The read that would have said which targets are tagged is the one that failed.
+    const failed = await applyClaimReusePolicy([contestable(EXISTING)], SPACE, {
+      enabled: true,
+      lookup: vi.fn<ExistingClaimLookup>(async () => {
+        throw new Error('graph down');
+      }),
+    });
+    expect(failed[0].isContestable).toBe(false);
+  });
+
+  it('keeps candidacy when the graph confirms the target is not a Claim here', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    // Tags are space-scoped, so an entity that lives only in another space cannot
+    // already be a motion here — minting a tagged replacement duplicates nothing.
+    const result = await applyClaimReusePolicy(
+      [{ text: 'Elsewhere.', isFactual: null, turnIndex: 0, existingClaimEntityId: ELSEWHERE, isContestable: true }],
+      SPACE,
+      { enabled: true, lookup: vi.fn<ExistingClaimLookup>(async () => graph) }
+    );
+    expect(result[0].existingClaimEntityId).toBeNull();
+    expect(result[0].isContestable).toBe(true);
+  });
+
   it('does not re-tag a reused entity that already carries the Debate tag', async () => {
     vi.spyOn(console, 'log').mockImplementation(() => {});
     const DEBATE_TAG = '55c95b2626f8482cb9739ea99dfde438';

--- a/apps/web/core/debates/server/claim-reuse.ts
+++ b/apps/web/core/debates/server/claim-reuse.ts
@@ -125,7 +125,9 @@ export async function applyClaimReusePolicy(
       claims: claims.length,
       matched: referenced.length,
     });
-    return claims.map(withoutReference);
+    // Shadow mode promises to change nothing but the counters. Minting Debate-tagged
+    // twins of claims that already carry the tag in this space would break that.
+    return claims.map(withoutReferenceOrCandidacy);
   }
 
   // One malformed id would fail the whole batched read (the API rejects the query, not the id), and
@@ -181,7 +183,9 @@ export async function applyClaimReusePolicy(
       matched: referenced.length,
       error,
     });
-    return claims.map(withoutReference);
+    // The read that would have told us which targets are already tagged is the one
+    // that failed, so no claim in this sweep may be minted as a motion.
+    return claims.map(withoutReferenceOrCandidacy);
   }
 
   let reused = 0;
@@ -214,6 +218,9 @@ export async function applyClaimReusePolicy(
       }
       return next;
     }
+    // A reference to the debate's own motion is refused above so a restatement cannot
+    // hijack it; it must not be minted as a rival motion either.
+    if (isMotion(claim.existingClaimEntityId)) return withoutReferenceOrCandidacy(claim);
     return withoutReference(claim);
   });
   const dropped = referenced.length - reused;
@@ -223,6 +230,10 @@ export async function applyClaimReusePolicy(
     matched: referenced.length,
     reused,
     dropped,
+    // Zero here while claims are being published is the signature of the upstream
+    // flag going missing — a renamed field, or a facade that predates the
+    // classification. Without a count, that regression is invisible.
+    debateCandidates: result.filter(candidate => candidate.isContestable).length,
   });
   if (dropped > 0) {
     console.warn('[debate-acceptor] matched claims no longer verifiable as Claims in this space; minted instead', {
@@ -241,4 +252,24 @@ export async function applyClaimReusePolicy(
 
 function withoutReference(claim: DebateClaimInput): DebateClaimInput {
   return claim.existingClaimEntityId ? { ...claim, existingClaimEntityId: null } : claim;
+}
+
+/**
+ * Drop the reference AND the claim's candidacy as a debate motion.
+ *
+ * Tags are space-scoped, so most dropped references are harmless: an entity that was
+ * deleted, re-typed, or lives in another space cannot already be tagged *here*, and
+ * minting a tagged replacement duplicates nothing. Three paths are different, because
+ * they drop the reference without ever learning what the target carries in this space
+ * — the debate's own motion (which is tagged by construction: motions are drawn from
+ * the Debate-tagged claims list), shadow mode, and a failed graph read. Minting a
+ * tagged twin of one of those puts a second candidate motion for the same proposition
+ * in the picker, which is the outcome the tag subtraction exists to prevent.
+ *
+ * Minting the duplicate entity is the long-standing, tolerated failure. Tagging it is
+ * not, so the tag is what gets withheld.
+ */
+function withoutReferenceOrCandidacy(claim: DebateClaimInput): DebateClaimInput {
+  const dropped = withoutReference(claim);
+  return dropped.isContestable ? { ...dropped, isContestable: false } : dropped;
 }

--- a/apps/web/core/debates/server/claim-reuse.ts
+++ b/apps/web/core/debates/server/claim-reuse.ts
@@ -1,6 +1,8 @@
 import { Effect } from 'effect';
 
 import { CLAIM_TYPE_ID, TOPICS_PROPERTY_ID } from '~/core/claims/ontology';
+import { TAG_PROPERTY_ID } from '~/core/constants';
+import { DEBATE_TAG_ID } from '~/core/debates/ontology';
 import { uuidToHex } from '~/core/id/normalize';
 import { graphql } from '~/core/io/graphql-client';
 
@@ -37,6 +39,9 @@ export type ExistingClaimEntity = {
    * Optional so injected test lookups predating topics stay valid; absent reads as none.
    */
   topicIds?: string[];
+  /** Targets of the entity's Tags relations in the publication space. Optional for the
+   * same reason as `topicIds`: injected test lookups predating tags stay valid. */
+  tagIds?: string[];
 };
 
 export type ExistingClaimLookup = (entityIds: string[], spaceId: string) => Promise<ExistingClaimEntity[]>;
@@ -56,11 +61,14 @@ const lookupInGraph: ExistingClaimLookup = (entityIds, spaceId) =>
                   topicIds: (entity.topicRelations ?? []).flatMap(relation =>
                     relation?.toEntityId ? [relation.toEntityId] : []
                   ),
+                  tagIds: (entity.tagRelations ?? []).flatMap(relation =>
+                    relation?.toEntityId ? [relation.toEntityId] : []
+                  ),
                 },
               ]
             : []
         ),
-      variables: { ids: entityIds, topicsPropertyId: TOPICS_PROPERTY_ID, spaceId },
+      variables: { ids: entityIds, topicsPropertyId: TOPICS_PROPERTY_ID, tagPropertyId: TAG_PROPERTY_ID, spaceId },
     })
   );
 
@@ -148,6 +156,7 @@ export async function applyClaimReusePolicy(
   ];
   let verified: Set<string>;
   const existingTopicsByEntity = new Map<string, Set<string>>();
+  const alreadyTaggedDebate = new Set<string>();
   try {
     const entities = ids.length > 0 ? await (options.lookup ?? lookupInGraph)(ids, spaceId) : [];
     const spaceKey = uuidToHex(spaceId);
@@ -162,6 +171,9 @@ export async function applyClaimReusePolicy(
     );
     for (const entity of entities) {
       existingTopicsByEntity.set(uuidToHex(entity.id), new Set((entity.topicIds ?? []).map(uuidToHex)));
+      if ((entity.tagIds ?? []).some(tag => uuidToHex(tag) === uuidToHex(DEBATE_TAG_ID))) {
+        alreadyTaggedDebate.add(uuidToHex(entity.id));
+      }
     }
   } catch (error) {
     console.warn('[debate-acceptor] could not verify matched claims; minting all of them instead', {
@@ -190,11 +202,17 @@ export async function applyClaimReusePolicy(
       // the relation once. That window is the sweep's, not this policy's — deduping across it
       // would need a post-index pass.
       const existingTopics = existingTopicsByEntity.get(uuidToHex(claim.existingClaimEntityId));
+      let next = claim;
       if (existingTopics?.size && claim.topics?.length) {
         const missing = claim.topics.filter(topic => !existingTopics.has(uuidToHex(topic.id)));
-        if (missing.length !== claim.topics.length) return { ...claim, topics: missing };
+        if (missing.length !== claim.topics.length) next = { ...next, topics: missing };
       }
-      return claim;
+      // Same rule for the Debate tag: an entity already listed as a debate claim in this
+      // space must not be tagged a second time.
+      if (next.isContestable && alreadyTaggedDebate.has(uuidToHex(claim.existingClaimEntityId))) {
+        next = { ...next, isContestable: false };
+      }
+      return next;
     }
     return withoutReference(claim);
   });

--- a/apps/web/core/debates/server/debate-source.test.ts
+++ b/apps/web/core/debates/server/debate-source.test.ts
@@ -189,8 +189,16 @@ describe('loadDebatePublishSource media gating', () => {
         turnIndex: 0,
         existingClaimEntityId: null,
         topics: [],
+        isContestable: false,
       },
-      { text: 'The action was unjustified.', isFactual: false, turnIndex: 1, existingClaimEntityId: null, topics: [] },
+      {
+        text: 'The action was unjustified.',
+        isFactual: false,
+        turnIndex: 1,
+        existingClaimEntityId: null,
+        topics: [],
+        isContestable: false,
+      },
     ]);
   });
 

--- a/apps/web/core/debates/server/existing-claims-document.ts
+++ b/apps/web/core/debates/server/existing-claims-document.ts
@@ -10,7 +10,7 @@ import { parse } from 'graphql';
  * "not a Claim here" and mint a duplicate for.
  */
 const EXISTING_CLAIMS_SOURCE = /* GraphQL */ `
-  query ExistingClaims($ids: [UUID!]!, $topicsPropertyId: UUID!, $spaceId: UUID!) {
+  query ExistingClaims($ids: [UUID!]!, $topicsPropertyId: UUID!, $tagPropertyId: UUID!, $spaceId: UUID!) {
     entities(filter: { id: { in: $ids } }) {
       id
       spaceIds
@@ -21,6 +21,9 @@ const EXISTING_CLAIMS_SOURCE = /* GraphQL */ `
         first: 100
         filter: { typeId: { is: $topicsPropertyId }, spaceId: { is: $spaceId } }
       ) {
+        toEntityId
+      }
+      tagRelations: relationsList(first: 100, filter: { typeId: { is: $tagPropertyId }, spaceId: { is: $spaceId } }) {
         toEntityId
       }
     }
@@ -41,10 +44,13 @@ export type ExistingClaimsQuery = {
      * a server default.
      */
     topicRelations: Array<{ toEntityId: string | null } | null> | null;
+    /** The entity's existing Tags relations in the publication space — read for the same
+     * reason as topics: a tag it already carries here must not be written twice. */
+    tagRelations: Array<{ toEntityId: string | null } | null> | null;
   } | null> | null;
 };
 
 export const existingClaimsDocument = parse(EXISTING_CLAIMS_SOURCE) as TypedDocumentNode<
   ExistingClaimsQuery,
-  { ids: string[]; topicsPropertyId: string; spaceId: string }
+  { ids: string[]; topicsPropertyId: string; tagPropertyId: string; spaceId: string }
 >;

--- a/apps/web/core/debates/server/extracted-claims.test.ts
+++ b/apps/web/core/debates/server/extracted-claims.test.ts
@@ -31,6 +31,19 @@ describe('decodeExtractedClaims topics', () => {
     expect(claims[1].topics).toEqual([]);
   });
 
+  it('maps is_contestable, defaulting a missing flag to not-a-motion', () => {
+    const { claims } = decodeExtractedClaims({
+      turns: [turn],
+      claims: [
+        { text: 'Broad position', is_factual: false, turn_index: 0, is_contestable: true },
+        { text: 'Narrow fact', is_factual: true, turn_index: 0, is_contestable: false },
+        // Payload from before the classification shipped.
+        { text: 'Unclassified', is_factual: null, turn_index: 0 },
+      ],
+    });
+    expect(claims.map(c => c.isContestable)).toEqual([true, false, false]);
+  });
+
   it('drops topic ids the publish path would throw on, and says so', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const { claims } = decodeExtractedClaims({

--- a/apps/web/core/debates/server/extracted-claims.ts
+++ b/apps/web/core/debates/server/extracted-claims.ts
@@ -28,6 +28,13 @@ export type DebateExtractedClaimsClaim = {
    * assignment shipped, and empty when the debated claim has no topics.
    */
   topics?: { entity_id: string; name: string | null }[] | null;
+  /**
+   * True when the claim's main assertion is broad enough to hold positions for and
+   * against it. Only these are tagged as debate claims on Geo, because the tag is what
+   * the claim picker lists as candidate motions. Absent on payloads from before the
+   * classification shipped, which read as "not a motion".
+   */
+  is_contestable?: boolean | null;
 };
 
 export type DebateExtractedClaimsResponse = {
@@ -62,6 +69,7 @@ export function decodeExtractedClaims(response: DebateExtractedClaimsResponse): 
         ? claim.existing_entity_id.trim()
         : null,
     topics: decodeTopics(claim.topics, droppedTopics),
+    isContestable: claim.is_contestable === true,
   }));
   if (droppedTopics.length > 0) {
     // Loud, like the malformed-claim-id path in `claim-reuse`: a field rename upstream would


### PR DESCRIPTION
## Why

Geo's claim picker is populated by asking the `Debate` tag for its claims (`tagged-claims.ts`, GEO-2771), so **tagging an extracted claim makes it a candidate motion for a future debate**. Until now nothing distinguished a claim worth arguing from an incidental fact, and we tagged neither — so extracted claims never entered the picker at all.

## What changed

`claims.extract` now classifies the **scope** of each claim's main assertion and geo-chat carries it through as `is_contestable` (geo-explorers/extraction-api#46, geobrowser/geo-chat#112).

- `extracted-claims.ts` — decode `is_contestable` onto `DebateClaimInput.isContestable`; an absent flag reads as "not a motion", so pre-feature payloads publish unchanged.
- `debate-publish-draft.ts` — write `Tags → Debate` (`55c95b26…`, the existing `DEBATE_TAG_ID`) on claims flagged contestable, minted and reused alike, following the topics rule.
- `claim-reuse.ts` + `existing-claims-document.ts` — the batched verification read now also selects each referenced entity's `Tags` relations **in the publication space**, and clears `isContestable` for an entity already carrying the Debate tag there.

**Nothing is filtered anywhere in the pipeline.** A narrowly verifiable claim still publishes as a Claim with its Sources, Topics and Is factual intact — it simply isn't offered as a motion. A misjudged claim therefore costs a tag, not a claim, which is why the classification doesn't have to be perfect to be safe.

Duplicate-safe on both axes: the graph subtraction above, plus a per-entity dedupe on normalised ids in the draft so one reused entity behind several restatements is tagged once.

Note the tag id: `55c95b26…` (1,488 claims, what the picker queries). The PM's spec page lists `92bddd7a…`, which resolves to a different entity — an organisational browse tag named "debate claim" with 249 claims. Confirmed with Faruk that the former is authoritative.

## Testing

`bunx vitest run` over the four debate suites — **70 passed**. New coverage: contestable claims tagged and narrow ones not; one tag per reused entity across restatements; a reused entity already tagged is not re-tagged; one not yet tagged is; decoder defaults a missing flag to false. `tsc --noEmit` clean in all touched files; prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015a2qTB8H4TuZtVBYABrpMo
