### PR TITLE
fix(tables): scope relation and backlink filters to the block's space (GEO-2865)

### DIFF
--- a/apps/web/core/blocks/data/filter-state-to-where.test.ts
+++ b/apps/web/core/blocks/data/filter-state-to-where.test.ts
@@ -117,6 +117,80 @@ describe('filterStateToWhere', () => {
   });
 });
 
+describe('relation filters are scoped to the block space (GEO-2865)', () => {
+  const SPACE = 'cccccccccccccccccccccccccccccccc';
+  const OTHER = 'dddddddddddddddddddddddddddddddd';
+
+  it('scopes a single relation filter to the space it was given', () => {
+    const where = filterStateToWhere([relationFilter(PROPERTY_A, 'v1')], {}, SPACE);
+
+    expect(where).toEqual({
+      relations: [
+        { typeOf: { id: { equals: PROPERTY_A } }, toEntity: { id: { equals: 'v1' } }, space: { equals: SPACE } },
+      ],
+    });
+  });
+
+  it('scopes backlink filters in the same way', () => {
+    const backlink: Filter = { ...relationFilter(PROPERTY_A, 'v1'), isBacklink: true };
+
+    const where = filterStateToWhere([backlink], {}, SPACE);
+
+    expect(where).toEqual({
+      backlinks: [
+        { typeOf: { id: { equals: PROPERTY_A } }, fromEntity: { id: { equals: 'v1' } }, space: { equals: SPACE } },
+      ],
+    });
+  });
+
+  it('scopes every branch of an OR group, not just the first', () => {
+    const where = filterStateToWhere(
+      [relationFilter(PROPERTY_A, 'v1'), relationFilter(PROPERTY_A, 'v2')],
+      { [PROPERTY_A]: 'OR' },
+      SPACE
+    );
+
+    const branches = (where.OR ?? []) as Array<{ relations?: Array<{ space?: { equals: string } }> }>;
+    expect(branches).toHaveLength(2);
+    for (const branch of branches) {
+      expect(branch.relations?.[0].space).toEqual({ equals: SPACE });
+    }
+  });
+
+  it('leaves the query unscoped when no space is supplied, preserving previous behaviour', () => {
+    // Two callers have no block space in scope; omitting it must not invent one.
+    const where = filterStateToWhere([relationFilter(PROPERTY_A, 'v1')]);
+
+    expect(where).toEqual({
+      relations: [{ typeOf: { id: { equals: PROPERTY_A } }, toEntity: { id: { equals: 'v1' } } }],
+    });
+  });
+
+  it('does not touch the Types branch, which scopes by the chosen type instead', () => {
+    const typesFilter: Filter = {
+      columnId: SystemIds.TYPES_PROPERTY,
+      columnName: 'Types',
+      valueType: 'RELATION',
+      value: 'type-1',
+      valueName: 'Type 1',
+      typesRelationSpaceId: OTHER,
+    };
+
+    const where = filterStateToWhere([typesFilter], {}, SPACE);
+
+    // OTHER, not SPACE: the type's own space still wins here by design.
+    expect(where).toEqual({
+      relations: [
+        {
+          typeOf: { id: { equals: SystemIds.TYPES_PROPERTY } },
+          toEntity: { id: { equals: 'type-1' } },
+          space: { equals: OTHER },
+        },
+      ],
+    });
+  });
+});
+
 describe('isBacklinkFilter', () => {
   const base: Filter = { columnId: 'p', columnName: 'Topics', valueType: 'RELATION', value: 'v', valueName: null };
 

--- a/apps/web/core/blocks/data/filter-state-to-where.ts
+++ b/apps/web/core/blocks/data/filter-state-to-where.ts
@@ -5,9 +5,28 @@ import type { WhereCondition } from '~/core/sync/experimental_query-layer';
 
 import type { Filter, FilterMode, ModesByColumn } from './filters';
 
-export function filterStateToWhere(filterState: Filter[], modesByColumn: ModesByColumn = {}): WhereCondition {
+/**
+ * `relationSpaceId` scopes relation and backlink filters to the space the block lives in
+ * (GEO-2865). Without it, `Tags -> Main topic` matched an entity holding that relation in *any*
+ * space, so a World Affairs table listed topics tagged Main topic only in US Politics. Measured on
+ * production: 31 relations point at "Main topic" across three spaces, and every table filtered on
+ * it showed all 31 regardless of which space it was in.
+ *
+ * Optional on purpose. Two callers — the ranking row accumulator and the filter-value dropdown —
+ * have no block space in scope, and passing nothing keeps exactly the previous behaviour there
+ * rather than inventing a scope for them. Omitting it is the old, unscoped query.
+ *
+ * The Types branch is deliberately untouched: it already scopes, via `typesRelationSpaceId`, by
+ * where the *chosen type* is defined rather than by the block. That is a different question with a
+ * different answer, and changing it would move behaviour nobody reported.
+ */
+export function filterStateToWhere(
+  filterState: Filter[],
+  modesByColumn: ModesByColumn = {},
+  relationSpaceId?: string | null
+): WhereCondition {
   if (filterState.length === 0) return {};
-  if (filterState.length === 1) return buildSingleFilterWhere(filterState[0]);
+  if (filterState.length === 1) return buildSingleFilterWhere(filterState[0], relationSpaceId);
 
   // Group filters by property AND direction (see filterGroupKey). Each group
   // chooses its own mode; distinct groups are always combined with AND by
@@ -27,15 +46,15 @@ export function filterStateToWhere(filterState: Filter[], modesByColumn: ModesBy
     // several ever coexist in memory, each stays required.
     const mode: FilterMode = isBacklinkFilter(filters[0]) ? 'AND' : (modesByColumn[columnId] ?? 'AND');
     if (filters.length === 1) {
-      groupConditions.push(buildSingleFilterWhere(filters[0]));
+      groupConditions.push(buildSingleFilterWhere(filters[0], relationSpaceId));
     } else if (ID.equals(columnId, SystemIds.SPACE_FILTER)) {
       // Multiple spaces are always OR, whatever the mode says: an entity lives
       // in one space, so "in A and in B" is an empty set nobody asks for.
       groupConditions.push(buildSpaceFiltersWhere(filters));
     } else if (mode === 'OR') {
-      groupConditions.push(buildOrWhere(filters));
+      groupConditions.push(buildOrWhere(filters, relationSpaceId));
     } else {
-      groupConditions.push(buildAndWhere(filters));
+      groupConditions.push(buildAndWhere(filters, relationSpaceId));
     }
   }
 
@@ -123,7 +142,7 @@ export function filterGroupKey(filter: Filter): string {
   return isBacklinkFilter(filter) ? `backlink:${filter.columnId}` : filter.columnId;
 }
 
-function buildSingleFilterWhere(filter: Filter): WhereCondition {
+function buildSingleFilterWhere(filter: Filter, relationSpaceId?: string | null): WhereCondition {
   if (filter.valueType === 'TEXT') {
     if (ID.equals(filter.columnId, SystemIds.NAME_PROPERTY)) {
       return { name: { contains: filter.value } };
@@ -151,13 +170,28 @@ function buildSingleFilterWhere(filter: Filter): WhereCondition {
       }
       return { types: [{ id: { equals: filter.value } }] };
     }
+    // Both branches carry the block's space when it is known (GEO-2865). A relation lives in a
+    // space, so an unscoped predicate matches the relation wherever it was written — which is the
+    // reported bug, and applies equally in the reverse direction.
     if (isBacklinkFilter(filter)) {
       return {
-        backlinks: [{ typeOf: { id: { equals: filter.columnId } }, fromEntity: { id: { equals: filter.value } } }],
+        backlinks: [
+          {
+            typeOf: { id: { equals: filter.columnId } },
+            fromEntity: { id: { equals: filter.value } },
+            ...(relationSpaceId ? { space: { equals: relationSpaceId } } : {}),
+          },
+        ],
       };
     }
     return {
-      relations: [{ typeOf: { id: { equals: filter.columnId } }, toEntity: { id: { equals: filter.value } } }],
+      relations: [
+        {
+          typeOf: { id: { equals: filter.columnId } },
+          toEntity: { id: { equals: filter.value } },
+          ...(relationSpaceId ? { space: { equals: relationSpaceId } } : {}),
+        },
+      ],
     };
   }
 
@@ -169,6 +203,8 @@ function buildSpaceFiltersWhere(filters: Filter[]): WhereCondition {
   const ids = [...new Set(filters.map(filter => filter.value).filter(Boolean))];
   if (ids.length === 0) return {};
   if (ids.length === 1) {
+    // No space to thread: this path only ever handles SPACE_FILTER, which never reaches the
+    // relation branches.
     return buildSingleFilterWhere({ ...filters[0], value: ids[0] });
   }
   return {
@@ -176,12 +212,12 @@ function buildSpaceFiltersWhere(filters: Filter[]): WhereCondition {
   };
 }
 
-function buildOrWhere(filters: Filter[]): WhereCondition {
-  return { OR: filters.map(filter => buildSingleFilterWhere(filter)) };
+function buildOrWhere(filters: Filter[], relationSpaceId?: string | null): WhereCondition {
+  return { OR: filters.map(filter => buildSingleFilterWhere(filter, relationSpaceId)) };
 }
 
-function buildAndWhere(filters: Filter[]): WhereCondition {
+function buildAndWhere(filters: Filter[], relationSpaceId?: string | null): WhereCondition {
   // Each chip remains an independent clause so one entity must satisfy all
   // selected values for this property.
-  return { AND: filters.map(filter => buildSingleFilterWhere(filter)) };
+  return { AND: filters.map(filter => buildSingleFilterWhere(filter, relationSpaceId)) };
 }

--- a/apps/web/core/blocks/data/use-data-block.tsx
+++ b/apps/web/core/blocks/data/use-data-block.tsx
@@ -153,8 +153,10 @@ export function useDataBlock(options?: UseDataBlockOptions) {
     // same WhereCondition reference even when their input identities change.
     const stableFilterState = JSON.parse(filterStateKey) as Filter[];
     const stableModesByColumn = JSON.parse(filterModesKey) as ModesByColumn;
-    return filterStateToWhere(stableFilterState, stableModesByColumn);
-  }, [filterStateKey, filterModesKey]);
+    // The block's own space scopes relation and backlink filters (GEO-2865): a table in one
+    // space must not list entities whose matching relation was written in another.
+    return filterStateToWhere(stableFilterState, stableModesByColumn, spaceId);
+  }, [filterStateKey, filterModesKey, spaceId]);
 
   /**
    * The query's own identity. Deliberately derived from `where` rather than `filterStateKey`:

--- a/apps/web/core/blocks/ranking/use-vote-tab-entities.ts
+++ b/apps/web/core/blocks/ranking/use-vote-tab-entities.ts
@@ -44,8 +44,9 @@ const EMPTY_VOTE_TAB_HYDRATION: VoteTabHydration = { entries: [], signatures: {}
 export function useVoteTabEntities(direction: EntityVoteDirectionFilter | null) {
   const { filterState, modesByColumn, spaceId } = useDataBlock();
   const blockWhere = React.useMemo(
-    () => filterStateToWhere(filterState, modesByColumn),
-    [filterState, modesByColumn]
+    // Space-scoped like the data block itself (GEO-2865).
+    () => filterStateToWhere(filterState, modesByColumn, spaceId),
+    [filterState, modesByColumn, spaceId]
   );
 
   const enabled = direction !== null;


### PR DESCRIPTION
Fixes GEO-2865, reported by Armando: a World Affairs table listing topics tagged **Main topic** only in **US Politics**.

### The bug

Relation filters carried no space clause, so `Tags → Main topic` matched an entity holding that relation in *any* space.

Measured on production — "Main topic" is `d9aae6e352d04f54acbf1947cd7f9159`:

```
31 relations point at it, across 3 spaces (19 / 8 / 4)
```

| table's space | should show | actually showed |
| --- | --- | --- |
| `4582fbbe…` | 19 | **31** |
| `52c7ae14…` | 8 | **31** |
| `89bd89bf…` | 4 | **31** |

### Two things made this cheap

**The fix already existed ten lines above.** The Types branch scopes via `typesRelationSpaceId`. Someone hit this for Types and the general case was left behind — which is the strongest evidence it was an oversight rather than a choice.

**The converters were already ready.** Both `convertRelationConditionToRelationFilter` and `convertBacklinkConditionToRelationFilter` map `space → spaceId` today. The builder simply never populated it, so no plumbing was needed downstream.

### The change

`filterStateToWhere` takes the block's space and applies it to the generic **relation** and **backlink** branches. Backlinks had the identical gap in the reverse direction and would have arrived as its own bug report later.

Threaded at `use-data-block` (tables — the reported surface) and `use-vote-tab-entities`.

### Three deliberate omissions

**The Types branch is untouched.** It scopes by where the *chosen type* is defined, not by the block. That is a different question with a different answer, and changing it would move behaviour nobody reported. A test pins this: with a block space *and* a `typesRelationSpaceId`, the type's own space still wins.

**The parameter is optional.** The ranking row accumulator and the filter-value dropdown have no block space in scope. Passing nothing preserves exactly the previous behaviour there rather than inventing a scope for them — a test pins that too.

**Power tools stays unscoped.** It is an admin/exploration surface where cross-space is arguable. Flagging rather than silently changing it; happy to scope it if you disagree.

### One interpretation to confirm

Preston said "they should be space scoped". I read that as **the block's space**, because that is what fixes the reported case. The alternative — scoping by the picked value's space, following the Types precedent — would have scoped by where "Main topic" lives rather than where the table is, and might have left Armando's table wrong in a subtler way. Say the word if you meant the other one.

### Testing

Five new tests: single relation, backlinks, every branch of an OR group, the unscoped default, and the Types branch staying put. `vitest run core/blocks core/io` — **674 passed across 79 files**. `tsc --noEmit` clean on the touched files. Prettier clean.