### PR TITLE
docs(ranking): correct two false claims about the indexer in the roll-off comments (GEO-2871)

### DIFF
--- a/apps/web/core/blocks/ranking/use-ranking-submissions.ts
+++ b/apps/web/core/blocks/ranking/use-ranking-submissions.ts
@@ -132,8 +132,18 @@ export function useRankingSubmissions(blockId: string, spaceId: string, blockNam
   );
 
   // Purely clock-based: the ballot is live until the block's submission window
-  // has elapsed since it was created. The block's Aggregated rankings relations
-  // are no help here — they retain every past ballot indefinitely.
+  // has elapsed since it was created.
+  //
+  // The block's `Aggregated rankings` relations cannot answer this. They hold one
+  // relation per *contributing author*, not every past ballot — the indexer
+  // rewrites them from the ballots that fed the current projection each sweep. A
+  // block with 56 submissions from 5 people carries 5. (An earlier comment here
+  // claimed they "retain every past ballot indefinitely"; they do not. GEO-2871.)
+  //
+  // Note this clock is the client's alone. Since gaia#921 (GEO-2869) the indexer
+  // does not expire ballots at all — an old one is weighted down, never dropped —
+  // so "rolled off" now means only "time to rank again", never "your ranking
+  // stopped counting".
   const isSubmissionLive = React.useMemo(() => {
     if (!isRolling || !myRankEntity) return true;
     if (submissionFrequencyHours == null || submittedAtMs === 0) return true;
@@ -143,13 +153,25 @@ export function useRankingSubmissions(blockId: string, spaceId: string, blockNam
   const hasRolledOff = isRolling && Boolean(myRankEntity) && !isSubmissionLive;
 
   // A rolled-off ballot is treated as absent everywhere: the block's views and
-  // the compose flow open fresh, as if the author hadn't ranked yet. (An earlier
-  // iteration retained the expired ballot because the indexer kept only the
-  // newest rank per author, so a rebuilt-from-scratch short ballot permanently
-  // superseded the fuller one — see #2122. The indexer now retains every ballot
-  // in the aggregate, so a fresh submission adds to it instead of replacing.)
+  // the compose flow open fresh, as if the author hadn't ranked yet.
   // `hasRolledOff` still drives the "Rank" call to action, and publishing still
   // mints a fresh rank entity below (keyed off myRankEntity, not mySubmission).
+  //
+  // **The justification that used to sit here was false.** It said the #2122
+  // failure — rebuilding a short ballot from scratch permanently superseding a
+  // fuller one — was fixed because "the indexer now retains every ballot in the
+  // aggregate, so a fresh submission adds to it instead of replacing". It does
+  // not. `ranking-indexer/src/dedup.rs` keeps only the most-recently-updated
+  // submission per (block, personal space), by design: one vote per person.
+  // Verified on live data — 9 in-window ballots from 5 people produced exactly 5
+  // aggregated rankings.
+  //
+  // So #2122 is still live: blank the sheet, rank 3 things, and the 20 you ranked
+  // before are gone from your contribution. Fixing it means decoupling this
+  // blanking from the CTA — `showEditRankingButton` currently clears *because*
+  // `mySubmission` goes null (see `ranking-block-body.tsx`), so simply pre-filling
+  // the compose screen also removes the prompt to rank again. Tracked in GEO-2871;
+  // left alone here because it changes visible behaviour.
   const mySubmission = hasRolledOff ? null : apiMySubmission;
   const hasMySubmission = (mySubmission?.orderedEntityIds.length ?? 0) > 0;
 

--- a/apps/web/partials/blocks/table/ranking-block-body.tsx
+++ b/apps/web/partials/blocks/table/ranking-block-body.tsx
@@ -54,6 +54,11 @@ function buildMyRankingActionButton(state: RankingBlockState) {
   // A rolled-off ballot is treated as absent (useRankingSubmissions blanks
   // `mySubmission`), so `showEditRankingButton` clears on roll-off and this
   // naturally falls back to the fresh "Add my ranking" call to action.
+  //
+  // That coupling is why GEO-2871 is not a one-line fix: the blanking is what
+  // produces this CTA, and it is also what loses the author's previous ballot
+  // when they re-rank. Whatever replaces it has to keep the prompt while keeping
+  // the ranking.
   return showEditRankingButton ? (
     <Button
       variant="secondary"


### PR DESCRIPTION
Comments only — no behaviour change. Both corrected claims were load-bearing for a decision, and both are wrong.

Found while diagnosing GEO-2869.

## 1. "a fresh submission adds to it instead of replacing"

`use-ranking-submissions.ts` justified blanking a rolled-off ballot like this:

> An earlier iteration retained the expired ballot because the indexer kept only the newest rank per author, so a rebuilt-from-scratch short ballot permanently superseded the fuller one — see #2122. **The indexer now retains every ballot in the aggregate, so a fresh submission adds to it instead of replacing.**

It does not. `ranking-indexer/src/dedup.rs`:

```rust
//! Deduplication: keep only the most-recently-updated submission per
//! (block, personal space).
```

One vote per person, by design. Verified on live data: block `41e85161…` has **9 in-window ballots from 5 distinct people** and carries exactly **5** `Aggregated rankings`.

So the #2122 failure that sentence claims to have fixed is still live: blank the sheet, rank 3 things, and the 20 you ranked before are gone from your contribution.

## 2. "they retain every past ballot indefinitely"

Said of the block's `Aggregated rankings` relations. They hold one relation per *contributing author*, rewritten from the ballots that fed the current projection on each sweep. A block with 56 submissions from 5 people carries 5.

## Also recorded: the two clocks now disagree

Since gaia#921 (GEO-2869) the indexer does not expire ballots at all — an old one is weighted down, never dropped. `isSubmissionLive` here is pure client-side arithmetic against one `submissionFrequencyHours` and was untouched by that change.

So "rolled off" now means **"time to rank again"**, never "your ranking stopped counting" — and the client's model is the pessimistic one. Worth having written down before someone reads the blanking as reflecting server state.

## Why no fix here

The blanking is coupled to the call to action: `showEditRankingButton` clears *because* `mySubmission` goes null (`ranking-block-body.tsx`). So simply pre-filling the compose screen with the author's last ballot also removes the prompt to rank again — and `hasMySubmission` additionally gates the Rank button's disabled state and the edit-vs-publish branch in `use-ranking-block-state.ts`.

Whatever replaces it has to keep the prompt while keeping the ranking. That is a visible behaviour change and belongs to GEO-2871, not to a comment fix. Noted at both ends of the coupling so the next person finds it from either file.

A wrong comment is worse than no comment; this one is why nobody had looked.

## Testing

- `tsc --noEmit`: **8 errors before and after**, all pre-existing in `core/responses/entity-response.test.ts`. Comments cannot introduce type errors, but I checked rather than asserted.
- `vitest run core/blocks/ranking partials/blocks/table`: **312 passed across 50 files**.
- prettier clean.