### PR TITLE
feat(explore): cap how much of a screen one space can hold (GEO-2841)

### DIFF
--- a/apps/web/core/explore/explore-diversity.test.ts
+++ b/apps/web/core/explore/explore-diversity.test.ts
@@ -13,7 +13,9 @@ import {
   EXPLORE_DIVERSITY_MAX_RUN,
   EXPLORE_DIVERSITY_WINDOW_SIZE,
   applyDiversityCap,
+  applyPerSpaceQuota,
   exploreItemTypeKey,
+  largestWindowShare,
   longestTypeRun,
 } from './explore-diversity';
 import { decodeExploreWindowCursor, encodeExploreWindowCursor, nextExploreWindowCursor } from './explore-window-cursor';
@@ -295,5 +297,94 @@ describe('paging the reordered window end to end', () => {
 
     expect(cursor).toBeNull();
     expect(ids(served)).toEqual(ids(window));
+  });
+});
+
+describe('the per-space quota', () => {
+  const item = (spaceId: string, id: string) => ({ spaceId, entityId: id });
+  const spaceOf = (i: { spaceId: string }) => i.spaceId;
+
+  it('holds one space to the quota on the screen the reader sees, when supply allows', () => {
+    // Six spaces, as measured in the live 66-row window, with enough supply that a 22-slot
+    // page can be filled at 5 each. The dominant space arrives holding 20 of the first 22.
+    const rows = [
+      ...Array.from({ length: 20 }, (_, n) => item('rel', `rel${n}`)),
+      ...Array.from({ length: 8 }, (_, n) => item('crypto', `c${n}`)),
+      ...Array.from({ length: 6 }, (_, n) => item('world', `w${n}`)),
+      ...Array.from({ length: 5 }, (_, n) => item('ai', `a${n}`)),
+      ...Array.from({ length: 5 }, (_, n) => item('us', `u${n}`)),
+      ...Array.from({ length: 5 }, (_, n) => item('health', `h${n}`)),
+    ];
+    expect(largestWindowShare(rows.slice(0, 22), spaceOf, 22)).toBe(20);
+
+    const ordered = applyPerSpaceQuota(rows, spaceOf, 5, 22);
+    expect(largestWindowShare(ordered.slice(0, 22), spaceOf, 22)).toBeLessThanOrEqual(5);
+    expect(ordered).toHaveLength(rows.length);
+    expect(new Set(ordered.map(r => r.entityId))).toEqual(new Set(rows.map(r => r.entityId)));
+  });
+
+  it('fills the screen rather than honouring the quota, when supply will not stretch', () => {
+    // The live shape on 2026-09-10, and the reason the default is 5 and not 4: six spaces
+    // holding 38/14/6/4/3/1 of a 66-row window. At a quota of 4 the most a page can draw is
+    // sum(min(count, 4)) = 20, two short of the 22 it needs — so the quota *cannot* hold and
+    // the only question is whether the reader gets a short screen or a repeated space.
+    // They get the full screen.
+    const supply: Array<[string, number]> = [
+      ['rel', 38],
+      ['crypto', 14],
+      ['world', 6],
+      ['ai', 4],
+      ['us', 3],
+      ['health', 1],
+    ];
+    const rows = supply.flatMap(([space, n]) => Array.from({ length: n }, (_, i) => item(space, `${space}${i}`)));
+
+    const atFour = applyPerSpaceQuota(rows, spaceOf, 4, 22);
+    expect(atFour.slice(0, 22)).toHaveLength(22);
+    expect(largestWindowShare(atFour.slice(0, 22), spaceOf, 22)).toBeGreaterThan(4);
+
+    // At 5 it fits: sum(min(count, 5)) = 23 >= 22.
+    const atFive = applyPerSpaceQuota(rows, spaceOf, 5, 22);
+    expect(largestWindowShare(atFive.slice(0, 22), spaceOf, 22)).toBeLessThanOrEqual(5);
+  });
+
+  it('drops nothing when one space is all there is', () => {
+    // Every remaining item over quota: emit the best of them rather than stalling or
+    // truncating the feed. A single-space graph must still get a feed.
+    const rows = Array.from({ length: 9 }, (_, n) => item('only', `o${n}`));
+    const ordered = applyPerSpaceQuota(rows, spaceOf, 4, 20);
+    expect(ordered.map(r => r.entityId)).toEqual(rows.map(r => r.entityId));
+  });
+
+  it('leaves a already-diverse ranking in its ranked order', () => {
+    // The quota must be inert when it does not bind — "Best" still has to mean best.
+    const rows = [item('a', '1'), item('b', '2'), item('c', '3'), item('a', '4'), item('b', '5')];
+    expect(applyPerSpaceQuota(rows, spaceOf, 4, 20).map(r => r.entityId)).toEqual(['1', '2', '3', '4', '5']);
+  });
+
+  it('defers rather than reorders wholesale', () => {
+    // Relative order within a space is the ranking, and it must survive.
+    const rows = [...Array.from({ length: 6 }, (_, n) => item('rel', `rel${n}`)), item('other', 'x')];
+    const ordered = applyPerSpaceQuota(rows, spaceOf, 4, 20);
+    expect(ordered.filter(r => r.spaceId === 'rel').map(r => r.entityId)).toEqual([
+      'rel0',
+      'rel1',
+      'rel2',
+      'rel3',
+      'rel4',
+      'rel5',
+    ]);
+  });
+
+  it('is unaffected by the type cap being inert, which is today', () => {
+    // Every row one type, as measured: applyDiversityCap is a no-op and the space quota is
+    // the only thing doing any work. Composed in the order fetchExploreFeed uses.
+    const rows = Array.from({ length: 24 }, (_, n) => ({
+      ...item(n % 3 === 0 ? 'rel' : 'rel', `r${n}`),
+      types: [{ id: CLAIM_TYPE_ID }],
+    }));
+    const typed = applyDiversityCap(rows, exploreItemTypeKey);
+    expect(typed).toHaveLength(rows.length);
+    expect(applyPerSpaceQuota(typed, spaceOf, 4, 20)).toHaveLength(rows.length);
   });
 });

--- a/apps/web/core/explore/explore-diversity.ts
+++ b/apps/web/core/explore/explore-diversity.ts
@@ -142,6 +142,121 @@ export function applyDiversityCap<T>(
   return ordered;
 }
 
+/**
+ * At most this many items from one space may appear in any `EXPLORE_PAGE_SIZE` consecutive
+ * items — one screen (GEO-2841).
+ *
+ * Sized from two measurements on the same query, two days apart. On 2026-09-08 the
+ * Relationships space held **14 of the top 20** and 28 of the top 50; on 2026-09-10, after
+ * the debate-tag gate landed, still **12 of 20** and 24 of 50. So this is not a batch working
+ * its way out of the feed, and the ranking will not resolve it: `rankingScore` has no decay
+ * term at all, and the participation those claims carry never erodes.
+ *
+ * **5, not the 4 that was proposed, because 4 is not reachable.** The bound here is supply,
+ * not the algorithm. The 66-row window measured on 2026-09-10 holds six spaces —
+ * 38 / 14 / 6 / 4 / 3 / 1 — so the most a page can draw at `q` per space is
+ * `sum(min(count, q))`:
+ *
+ *   * q=3 -> 16 items, six short of a 22-slot page
+ *   * q=4 -> 20 items, two short
+ *   * q=5 -> 23 items, the first value that fills a page at all
+ *
+ * At q=4 the quota would be silently violated on every single page, because the alternative
+ * is a short screen. 5 is therefore the tightest honest setting for the feed as it is today.
+ * Reaching 4 needs *more spaces in the window*, not a smaller number here — either a deeper
+ * scan (GEO-2853 option 1, at proportional payload cost) or more spaces publishing
+ * debate-tagged claims.
+ */
+export const EXPLORE_SPACE_MAX_PER_PAGE = 5;
+
+/**
+ * The space a feed item is shown in. Unlike {@link exploreItemTypeKey} there is nothing to
+ * classify: a card is rendered in exactly one space, and that is the one crowding the screen.
+ */
+export function exploreItemSpaceKey(item: { spaceId: string }): string {
+  return normId(item.spaceId);
+}
+
+/**
+ * Reorder a ranked list so no `groupSize` consecutive items hold more than `quota` from one
+ * space, *while other spaces still have items to offer*. Nothing is dropped — an item over
+ * quota is deferred, and reappears once the window has moved past enough of its space-mates.
+ *
+ * The qualifier is not hedging, it is arithmetic. `quota x distinct spaces` has to reach
+ * `groupSize` for the quota to be satisfiable at all, and each space has to actually supply
+ * its share; when it cannot, this emits the best-ranked remaining item rather than leaving
+ * the screen short. A feed with one space and a hard quota would otherwise be empty. See
+ * `EXPLORE_SPACE_MAX_PER_PAGE` for the measured numbers that set the default.
+ *
+ * Separate from {@link applyDiversityCap} on purpose, because they bound different things and
+ * only one of them addresses the reported problem:
+ *
+ *   * `applyDiversityCap` bounds a **run** of one *type*. A space holding 12 of 20 satisfies
+ *     it completely as long as those 12 are interleaved — which, measured, they are. It also
+ *     keys on type, so it says nothing about spaces at all, and with every row in the top 50
+ *     typed `Claim` its key is constant and it is a no-op.
+ *   * this bounds the **share** held by one *space* over a window.
+ *
+ * Applied *after* the type cap in `fetchExploreFeed`, so the space guarantee is the one that
+ * holds outright. That order can locally weaken the type cap's run guarantee once the type cap
+ * has real input again (GEO-2853) — the trade is deliberate: an over-long run of one type is
+ * an aesthetic complaint, one space owning the screen is the bug that was reported.
+ */
+export function applyPerSpaceQuota<T>(
+  items: readonly T[],
+  keyOf: (item: T) => string,
+  quota: number = EXPLORE_SPACE_MAX_PER_PAGE,
+  groupSize: number = EXPLORE_PAGE_SIZE
+): T[] {
+  if (quota <= 0 || groupSize <= 1 || items.length <= quota) return [...items];
+
+  const remaining = items.slice();
+  const ordered: T[] = [];
+
+  while (remaining.length > 0) {
+    // The trailing window the next item joins. Requiring `< quota` here means that after it is
+    // appended, no `groupSize` window holds more than `quota` of its space.
+    const trailing = ordered.slice(Math.max(0, ordered.length - (groupSize - 1)));
+    const counts = new Map<string, number>();
+    for (const item of trailing) {
+      const key = keyOf(item);
+      counts.set(key, (counts.get(key) ?? 0) + 1);
+    }
+
+    // Highest-ranked item still under quota. `remaining` is in rank order and stays that way,
+    // so this preserves the ranking wherever the quota does not bind.
+    let index = remaining.findIndex(item => (counts.get(keyOf(item)) ?? 0) < quota);
+    // -1 means every remaining item is from a space already at quota: emit the best of them
+    // rather than dropping or stalling. Reachable whenever the tail of the window is one space,
+    // which is exactly the case being fixed.
+    if (index < 0) index = 0;
+
+    const [picked] = remaining.splice(index, 1);
+    ordered.push(picked);
+  }
+
+  return ordered;
+}
+
+/** Largest share one key holds in any `groupSize` window — the property the quota bounds. */
+export function largestWindowShare<T>(
+  items: readonly T[],
+  keyOf: (item: T) => string,
+  groupSize: number = EXPLORE_PAGE_SIZE
+): number {
+  let largest = 0;
+  for (let start = 0; start < items.length; start += 1) {
+    const counts = new Map<string, number>();
+    for (const item of items.slice(start, start + groupSize)) {
+      const key = keyOf(item);
+      const next = (counts.get(key) ?? 0) + 1;
+      counts.set(key, next);
+      if (next > largest) largest = next;
+    }
+  }
+  return largest;
+}
+
 /** Longest run of one type in a list — the property the cap exists to bound. */
 export function longestTypeRun<T>(items: readonly T[], keyOf: (item: T) => string): number {
   let longest = 0;

--- a/apps/web/core/explore/fetch-explore-feed.ts
+++ b/apps/web/core/explore/fetch-explore-feed.ts
@@ -19,7 +19,13 @@ import {
 } from './explore-card-item';
 import { EXPLORE_ENTITY_NAME_PROPERTY_ID, EXPLORE_PAGE_SIZE } from './explore-constants';
 import { claimsRequireDebateTagFilter } from './explore-debate-tag-filter';
-import { EXPLORE_DIVERSITY_WINDOW_SIZE, applyDiversityCap, exploreItemTypeKey } from './explore-diversity';
+import {
+  EXPLORE_DIVERSITY_WINDOW_SIZE,
+  applyDiversityCap,
+  applyPerSpaceQuota,
+  exploreItemSpaceKey,
+  exploreItemTypeKey,
+} from './explore-diversity';
 import { exploreEntitiesByPropertyConnectionDocument } from './explore-entities-by-property-document';
 import { exploreEntitiesConnectionDocument } from './explore-entities-document';
 import { parseEntityUpdatedAtToUnixSec } from './explore-relative-time';
@@ -446,7 +452,12 @@ export async function fetchExploreFeed(args: {
     // "Best" is the only sort that reorders (GEO-2690). "New" is reverse-chronological and
     // an activity log that shuffles is simply wrong; "Top" is an explicit "rank by score"
     // request, and the crowding-out was measured on Best, which is also the default tab.
-    return args.sort === 'best' ? applyDiversityCap(rows, exploreItemTypeKey) : rows;
+    // Two different crowding problems, two passes (GEO-2690 for type, GEO-2841 for space).
+    // The space quota runs last so its guarantee is the one that holds outright; see
+    // `applyPerSpaceQuota` for why that trade is the right way round.
+    return args.sort === 'best'
+      ? applyPerSpaceQuota(applyDiversityCap(rows, exploreItemTypeKey), exploreItemSpaceKey)
+      : rows;
   };
 
   // A window that survives none of the above is not the end of the feed, and returning it as an


### PR DESCRIPTION
Fixes GEO-2841.

The ticket asked for the time component to decay faster. Measured twice, that would have made it worse, so this does what the goal needs instead.

## Why not the requested change

- **There is no decay function.** `rankingScore` adds `created_at / tau` — time-invariant by design, no periodic sweep. Nothing to speed up.
- **Recency is the only term currently working against the dominant space.** Its claims sit on participation that never erodes; the only things displacing them are newer items. Weakening recency entrenches the incumbent.
- **Votes are not involved.** Every entity in the top 50 carries the identical zero-vote Wilson prior `0.0945286548008661`, so quality contributes **0.00 units**. The ticket's account — "created and subsequently voted on" — is not what the data shows. Positions order this feed.

Concentration after the debate-tag gate shipped: **14 of the top 20 → 12**. 28 of 50 → 24. Marginal.

## Why the existing cap cannot help

`applyDiversityCap` keys on entity **type** and bounds a consecutive **run** (max 3). A space holding 12 of 20 satisfies it completely when interleaved — which is how they arrive. And all 50 of the top 50 are `Claim`, so its key is constant and it is a literal no-op today.

Type crowding and space crowding are different axes. Only one had a mechanism.

## The change

`applyPerSpaceQuota` — same shape as the existing cap, keyed on space, bounding **share over a page** rather than run length. Applied after the type cap so the space guarantee is the one that holds outright.

## The quota is 5, not the 4 I proposed, and that is arithmetic

The live 66-row window holds six spaces: **38 / 14 / 6 / 4 / 3 / 1**. The most a page can draw at `q` per space is `sum(min(count, q))`:

| quota | usable per page | 22-slot page |
| -- | -- | -- |
| 3 | 16 | six short |
| **4** | **20** | **two short** |
| 5 | 23 | fits |

At 4 the quota would be violated on **every page**, silently, because the alternative is a short screen. 5 is the tightest honest setting for the feed as it stands. Reaching 4 needs *more spaces in the window* — a deeper scan (GEO-2853 option 1, at payload cost) or more spaces publishing debate-tagged claims — not a smaller constant.

I found this because the first test I wrote failed. It is documented in the constant so the next person does not re-propose 4.

## Behaviour

- Nothing is dropped. An item over quota is deferred and reappears further down; relative order within a space is preserved, so the ranking survives wherever the quota does not bind.
- When supply will not stretch, the best-ranked remaining item is emitted rather than leaving the screen short. A single-space graph still gets a full feed.

Both pinned by tests, including one that reproduces the live 38/14/6/4/3/1 supply and asserts the quota **is exceeded** at 4 — the failure mode written down rather than hidden.

## Testing

- `vitest run core/explore` — 73 passed
- `vitest run core/explore core/blocks` — 469 passed across 53 files
- `tsc --noEmit` — 8 errors, the pre-existing baseline in `entity-response.test.ts`, unchanged
- prettier clean on every file touched (the one warning in `core/explore/` is `explore-card-selection.ts`, pre-existing on master and not touched here)