### PR TITLE
fix(ranking): re-ranking after a roll-off starts from your last ballot, not an empty sheet (GEO-2871)

### DIFF
--- a/apps/web/core/blocks/ranking/ranking-rolling.test.ts
+++ b/apps/web/core/blocks/ranking/ranking-rolling.test.ts
@@ -107,3 +107,19 @@ describe('formatRollingSubmissionLabel', () => {
     ).toBe('Vote again in -6 hrs');
   });
 });
+
+describe('what survives a roll-off (GEO-2871)', () => {
+  // Not a test of `ranking-rolling` itself but of the invariant it sits inside, and this is
+  // where a reader looking for roll-off behaviour will come.
+  //
+  // The indexer keeps only the newest ballot per (block, personal space) — `dedup_latest`.
+  // So a ballot rebuilt from an empty sheet permanently supersedes the fuller one it replaces.
+  // Re-ranking has to start from what the author last said, or the difference is lost.
+  it('still mints a fresh entity once the window has elapsed', () => {
+    // Unchanged, and load-bearing: the fresh entity is what carries a fresh `submitted_at`,
+    // without which the re-ranked list would stay decayed at its original date.
+    expect(shouldMintNewRankEntity({ isRolling: true, hasExistingBallot: true, isSubmissionLive: false })).toBe(true);
+    // ...and does not while it is live, so an edit stays an edit.
+    expect(shouldMintNewRankEntity({ isRolling: true, hasExistingBallot: true, isSubmissionLive: true })).toBe(false);
+  });
+});

--- a/apps/web/core/blocks/ranking/use-ranking-submissions.ts
+++ b/apps/web/core/blocks/ranking/use-ranking-submissions.ts
@@ -152,28 +152,42 @@ export function useRankingSubmissions(blockId: string, spaceId: string, blockNam
 
   const hasRolledOff = isRolling && Boolean(myRankEntity) && !isSubmissionLive;
 
-  // A rolled-off ballot is treated as absent everywhere: the block's views and
-  // the compose flow open fresh, as if the author hadn't ranked yet.
-  // `hasRolledOff` still drives the "Rank" call to action, and publishing still
-  // mints a fresh rank entity below (keyed off myRankEntity, not mySubmission).
+  // A rolled-off ballot reads as absent to the block's views and to the call to action, so the
+  // author is prompted to rank again. `hasRolledOff` still drives that prompt, and publishing
+  // still mints a fresh rank entity below (keyed off myRankEntity, not mySubmission).
   //
-  // **The justification that used to sit here was false.** It said the #2122
-  // failure — rebuilding a short ballot from scratch permanently superseding a
-  // fuller one — was fixed because "the indexer now retains every ballot in the
-  // aggregate, so a fresh submission adds to it instead of replacing". It does
-  // not. `ranking-indexer/src/dedup.rs` keeps only the most-recently-updated
-  // submission per (block, personal space), by design: one vote per person.
-  // Verified on live data — 9 in-window ballots from 5 people produced exactly 5
+  // It is *not* absent to the compose screen any more — see `myLastSubmission` below. That
+  // split is the GEO-2871 fix, and this comment is where the reason lives.
+  //
+  // **The justification that used to sit here was false.** It said the #2122 failure —
+  // rebuilding a short ballot from scratch permanently superseding a fuller one — was fixed
+  // because "the indexer now retains every ballot in the aggregate, so a fresh submission adds
+  // to it instead of replacing". It does not. `ranking-indexer/src/dedup.rs` keeps only the
+  // most-recently-updated submission per (block, personal space), by design: one vote per
+  // person. Verified on live data — 9 in-window ballots from 5 people produced exactly 5
   // aggregated rankings.
   //
-  // So #2122 is still live: blank the sheet, rank 3 things, and the 20 you ranked
-  // before are gone from your contribution. Fixing it means decoupling this
-  // blanking from the CTA — `showEditRankingButton` currently clears *because*
-  // `mySubmission` goes null (see `ranking-block-body.tsx`), so simply pre-filling
-  // the compose screen also removes the prompt to rank again. Tracked in GEO-2871;
-  // left alone here because it changes visible behaviour.
+  // So #2122 was still live: blank the sheet, rank 3 things, and the 20 you ranked before were
+  // gone from your contribution. The reason it could not be fixed by simply un-blanking here is
+  // that the blanking is what *produces* the prompt — `showEditRankingButton` clears **because**
+  // `mySubmission` goes null (see `ranking-block-body.tsx`). Hence the second value rather than
+  // a change to this one: the prompt keeps its cause, and the ballot survives.
   const mySubmission = hasRolledOff ? null : apiMySubmission;
   const hasMySubmission = (mySubmission?.orderedEntityIds.length ?? 0) > 0;
+
+  // The same ballot, *not* blanked on roll-off — what the author last ranked, which the
+  // indexer is still counting (see the note above about `dedup_latest`).
+  //
+  // The compose screen seeds from this rather than `mySubmission`, so re-ranking starts from
+  // "here is what you said, change what you want" instead of an empty sheet. That is the
+  // GEO-2871 fix and it is deliberately narrow: `mySubmission` keeps blanking, so the "Add my
+  // ranking" call to action still appears and the prompt to re-rank survives. Fixing the loss
+  // by un-blanking `mySubmission` outright would have taken the prompt with it.
+  //
+  // It also leaves `hasUnpublishedChanges` reading true against an empty published key, which
+  // is correct on roll-off: publishing has to mint a fresh rank entity to get a fresh
+  // `submitted_at`, and `shouldMintNewRankEntity` already does.
+  const myLastSubmission = apiMySubmission;
 
   const saveMySubmission = React.useCallback(
     async (
@@ -395,6 +409,7 @@ export function useRankingSubmissions(blockId: string, spaceId: string, blockNam
   return {
     submissions: [] as RankingSubmissionRecord[],
     mySubmission,
+    myLastSubmission,
     hasMySubmission,
     saveMySubmission,
     isLoading: isLoadingMyRanking,

--- a/apps/web/partials/blocks/table/ranking-compose-screen.tsx
+++ b/apps/web/partials/blocks/table/ranking-compose-screen.tsx
@@ -22,7 +22,6 @@ import {
   getRowDisplayName,
   splitRankableEntityIds,
 } from '~/core/blocks/ranking/ranking-rankable-list';
-import { formatRollingSubmissionLabel } from '~/core/blocks/ranking/ranking-rolling';
 import { useRankingAccumulatedRows } from '~/core/blocks/ranking/use-ranking-accumulated-rows';
 import { useRankingBlockDates } from '~/core/blocks/ranking/use-ranking-block-dates';
 import { useRankingBlockRelations } from '~/core/blocks/ranking/use-ranking-block-relations';
@@ -124,6 +123,7 @@ export function RankingComposeScreen({ spaceId, rankingStartDate = '', rankingEn
   const {
     submissions,
     mySubmission,
+    myLastSubmission,
     hasMySubmission,
     saveMySubmission,
     isSaving,
@@ -175,7 +175,9 @@ export function RankingComposeScreen({ spaceId, rankingStartDate = '', rankingEn
     allRankableEntityIds
   );
 
-  const [orderedIds, setOrderedIds] = React.useState<string[]>(mySubmission?.orderedEntityIds ?? []);
+  // Seeded from the author's last ballot, which survives roll-off, rather than from
+  // `mySubmission`, which is blanked by it. See `myLastSubmission` (GEO-2871).
+  const [orderedIds, setOrderedIds] = React.useState<string[]>(myLastSubmission?.orderedEntityIds ?? []);
   const [searchQuery, setSearchQuery] = React.useState('');
   const [activeSwipeRowKey, setActiveSwipeRowKey] = React.useState<string | null>(null);
   const [entitySheetTarget, setEntitySheetTarget] = React.useState<{
@@ -245,10 +247,10 @@ export function RankingComposeScreen({ spaceId, rankingStartDate = '', rankingEn
 
   const { entries: searchEntries } = useRankingEntryEntities(spaceId, isSearchActive ? searchEntityIds : []);
 
-  const mySubmissionIdsKey = (mySubmission?.orderedEntityIds ?? []).join('|');
+  const mySubmissionIdsKey = (myLastSubmission?.orderedEntityIds ?? []).join('|');
 
   React.useEffect(() => {
-    const next = mySubmission?.orderedEntityIds ?? [];
+    const next = myLastSubmission?.orderedEntityIds ?? [];
     setOrderedIds(prev => {
       if (prev.length === next.length && prev.every((id, index) => id === next[index])) {
         return prev;

--- a/apps/web/partials/blocks/table/use-ranking-block-state.ts
+++ b/apps/web/partials/blocks/table/use-ranking-block-state.ts
@@ -26,7 +26,6 @@ import {
   isPlaceholderRankingEntry,
 } from '~/core/blocks/ranking/ranking-pending-proposal-entries';
 import { getRowDescription, getRowDisplayName } from '~/core/blocks/ranking/ranking-rankable-list';
-import { formatRollingSubmissionLabel } from '~/core/blocks/ranking/ranking-rolling';
 import { getScopeFromFilters } from '~/core/blocks/ranking/ranking-scope';
 import {
   buildAbsoluteRankingShareUrl,


### PR DESCRIPTION
Fixes GEO-2871.

## The bug

Rolling blocks blank your ballot in the compose view once the submission window elapses, so you rank again from scratch. But the indexer keeps only the newest submission per (block, personal space) — `dedup_latest`, one vote per person — so the rebuilt short ballot **permanently supersedes** the fuller one.

Rank 20 things last month, rank 3 today, and the other 17 are gone from your contribution.

Confirmed on live data: block `41e85161…` has 9 in-window ballots from **5 distinct people**, and carries exactly **5** `Aggregated rankings`.

## Why it survived

The comment justifying the blanking said the opposite:

> The indexer now retains every ballot in the aggregate, so a fresh submission adds to it instead of replacing.

It does not. geogenesis#2409 corrected that comment (and a second false one alongside it). This is the behaviour fix.

## Why the change is this narrow

The blanking is **load-bearing for the call to action**: `showEditRankingButton` clears *because* `mySubmission` goes null, which is what produces the fresh "Add my ranking" prompt. Un-blanking it outright fixes the data loss and silently removes the prompt to re-rank.

So `mySubmission` keeps blanking, and the hook exposes `myLastSubmission` — the same ballot without it. The compose screen seeds from that. The author gets *"here is what you said, change what you want"*; the prompt is untouched; no button logic moves.

`hasUnpublishedChanges` then reads true against an empty published key, which is correct on roll-off: publishing has to mint a fresh rank entity to get a fresh `submitted_at`, or the re-ranked list stays decayed at its original date. `shouldMintNewRankEntity` already does this, and a test now pins it, since it is the part a later refactor could quietly break.

## Also: a prompt that has never existed

Removes two imports of `formatRollingSubmissionLabel`. It is **called nowhere in the app** — only from its own tests — so "Vote again in N hrs" has never rendered, and both files imported it without using it.

Worth stating on its own: the only signal a user currently gets that their ballot rolled off is the blank sheet this PR stops producing. Whether roll-off should *say* something is a design question, so I have left the helper in place and filed the question rather than inventing copy.

## Testing

- `vitest run core/blocks/ranking partials/blocks/table` — 313 passed across 50 files
- `tsc --noEmit` — 8 errors, the pre-existing baseline in `entity-response.test.ts`, unchanged
- prettier clean