### PR TITLE
feat(profile): add work and education to the Edit profile modal (GEO-2858)

### DIFF
--- a/apps/web/core/hooks/reverted-user-operation.test.ts
+++ b/apps/web/core/hooks/reverted-user-operation.test.ts
@@ -1,4 +1,5 @@
 import { RevertedUserOperationError, isRevertedUserOperationError } from '@geogenesis/auth/account';
+
 import { describe, expect, it } from 'vitest';
 
 import { TransactionWriteFailedError } from '~/core/errors';

--- a/apps/web/core/hooks/search-additional-space-ids.ts
+++ b/apps/web/core/hooks/search-additional-space-ids.ts
@@ -1,3 +1,5 @@
+import { MAX_SEARCH_ADDITIONAL_SPACE_IDS } from './global-search-space-ids';
+
 /**
  * Decides whether a search request should widen eligibility to the scoped
  * spaces from useGlobalSearchSpaceIds (root/current/personal/member/editor),
@@ -12,20 +14,36 @@
  *   to "canonical plus scoped spaces" instead of truly everything.
  *
  * Otherwise (includeNonCanonical omitted or false, no filterBySpace),
- * globalAdditionalSpaceIds is returned unchanged.
+ * globalAdditionalSpaceIds is returned, with any `alsoSearchSpaceIds` the caller
+ * named appended.
+ *
+ * `alsoSearchSpaceIds` is for a picker that knows which space holds the thing it
+ * is searching for — a curated taxonomy nobody is a member of, say. It widens
+ * eligibility to that space and nothing else, which is the narrow version of
+ * what `includeNonCanonical: true` does by lifting the restriction entirely.
  */
 export function selectSearchAdditionalSpaceIds({
   filterBySpace,
   includeNonCanonical,
   globalAdditionalSpaceIds,
+  alsoSearchSpaceIds,
 }: {
   filterBySpace: string | undefined;
   includeNonCanonical: boolean | undefined;
   globalAdditionalSpaceIds: string[];
+  alsoSearchSpaceIds?: string[];
 }): string[] | undefined {
   const isScopedToOneSpace = Boolean(filterBySpace);
   const wantsUnrestrictedSearch = includeNonCanonical === true;
   const skipAdditionalSpaceIds = isScopedToOneSpace || wantsUnrestrictedSearch;
 
-  return skipAdditionalSpaceIds ? undefined : globalAdditionalSpaceIds;
+  if (skipAdditionalSpaceIds) return undefined;
+  if (!alsoSearchSpaceIds?.length) return globalAdditionalSpaceIds;
+
+  // The caller's spaces go first. The list is capped, and a space asked for by
+  // name is a worse thing to drop than the hundredth space someone edits.
+  return Array.from(new Set([...alsoSearchSpaceIds, ...globalAdditionalSpaceIds])).slice(
+    0,
+    MAX_SEARCH_ADDITIONAL_SPACE_IDS
+  );
 }

--- a/apps/web/core/hooks/smart-account-send-queue.test.ts
+++ b/apps/web/core/hooks/smart-account-send-queue.test.ts
@@ -5,7 +5,7 @@ import { QueuedSendTimeoutError, enqueueFor, withSubmissionRetry } from './smart
 const reportError = vi.hoisted(() => vi.fn());
 vi.mock('~/core/telemetry/logger', () => ({ reportError }));
 
-const deferred = <T,>() => {
+const deferred = <T>() => {
   let resolve!: (value: T) => void;
   let reject!: (error: unknown) => void;
   const promise = new Promise<T>((res, rej) => {

--- a/apps/web/core/hooks/use-edit-profile.ts
+++ b/apps/web/core/hooks/use-edit-profile.ts
@@ -617,7 +617,7 @@ export function useEditProfile({ isOpen }: { isOpen: boolean }) {
       // it. Written into the store here so staging collects them like its own, and
       // so a failure rolls them back with the rest.
       const extra = extraRows ?? { values: [], relations: [] };
-      extra.values.forEach(value => storage.values.set(value));
+      extra.values.forEach(value => (value.isDeleted ? storage.values.delete(value) : storage.values.set(value)));
       extra.relations.forEach(relation =>
         relation.isDeleted ? storage.relations.delete(relation) : storage.relations.set(relation)
       );

--- a/apps/web/core/hooks/use-edit-profile.ts
+++ b/apps/web/core/hooks/use-edit-profile.ts
@@ -255,15 +255,19 @@ export function useEditProfile({ isOpen }: { isOpen: boolean }) {
   );
 
   const stage = React.useCallback(
-    async (draft: ProfileDraft, baseline: StagedEdit['baseline']): Promise<StagedEdit> => {
+    async (
+      draft: ProfileDraft,
+      baseline: StagedEdit['baseline'],
+      extra: { values: Value[]; relations: Relation[] } = { values: [], relations: [] }
+    ): Promise<StagedEdit> => {
       // Row ids this modal wrote, tracked as it goes so a failed upload can undo
       // the writes that already landed. Scoping the collection below to these —
       // rather than to everything unpublished on the person entity — keeps an
       // unrelated pending edit from riding along on the publish, and from being
       // rolled back when this one is abandoned.
       const written = {
-        valueIds: new Set<string>(),
-        relationIds: new Set<string>(),
+        valueIds: new Set<string>(extra.values.map(value => value.id)),
+        relationIds: new Set<string>(extra.relations.map(relation => relation.id)),
         overwritten: [] as Value[],
         overwrittenRelations: [] as Relation[],
       };
@@ -579,7 +583,7 @@ export function useEditProfile({ isOpen }: { isOpen: boolean }) {
   }, [dispatch]);
 
   const publish = React.useCallback(
-    async (draft: ProfileDraft) => {
+    async (draft: ProfileDraft, extraRows?: { values: Value[]; relations: Relation[] }) => {
       if (!canEdit) return;
 
       // Retry re-sends the staged rows so the uploads inside only run once — but
@@ -608,6 +612,16 @@ export function useEditProfile({ isOpen }: { isOpen: boolean }) {
       setErrorMessage(null);
       ownsPendingError.current = false;
 
+      // Rows from elsewhere in the modal — the work and education sections — go
+      // out in the same edit as the four header fields, because Save means all of
+      // it. Written into the store here so staging collects them like its own, and
+      // so a failure rolls them back with the rest.
+      const extra = extraRows ?? { values: [], relations: [] };
+      extra.values.forEach(value => storage.values.set(value));
+      extra.relations.forEach(relation =>
+        relation.isDeleted ? storage.relations.delete(relation) : storage.relations.set(relation)
+      );
+
       if (!stagedRef.current) {
         // Staging uploads to IPFS before `makeProposal` touches the status bar, and
         // that upload can be long. Closing during it is meant to hand off to the
@@ -623,7 +637,7 @@ export function useEditProfile({ isOpen }: { isOpen: boolean }) {
         }
 
         try {
-          const stagedEdit = await stage(draft, baseline);
+          const stagedEdit = await stage(draft, baseline, extra);
 
           // The account can change while that upload runs. The effect that abandons
           // an outstanding edit cannot see this one — `stagedRef` was still null

--- a/apps/web/core/hooks/use-profile-history.test.tsx
+++ b/apps/web/core/hooks/use-profile-history.test.tsx
@@ -3,6 +3,7 @@ import { act, renderHook } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
+  EMPLOYER_TYPE,
   EMPLOYMENT_PROPERTY,
   EMPLOYMENT_STATUS_PROPERTY,
   ROLES_PROPERTY,
@@ -210,6 +211,40 @@ describe('useProfileHistory', () => {
       const employment = relations.find(relation => relation.type.id === EMPLOYMENT_PROPERTY && !relation.isDeleted);
       expect(employment?.toEntity.id).toBe('org-Coinbase');
       expect(result.current.employment.map(card => card.organization.name)).toEqual(['Coinbase']);
+    });
+
+    // The bug this exists for: reopening an unsaved row rebuilt its draft from
+    // what the card displayed, which does not show that the company was created
+    // here. `isNew` came back false, so neither the name nor the type was staged
+    // and the employer published as "Untitled" with no types at all.
+    it('keeps a created company named and typed when the row is reopened', () => {
+      const { result } = setup();
+
+      const created = draft('Digital Paradise', 'Cofounder');
+      created.company.isNew = true;
+
+      act(() => result.current.addPosition(created));
+
+      const entry = result.current.employment[0].entries[0];
+      const reopened = result.current.draftFor(entry) as PositionDraft | undefined;
+
+      expect(reopened?.company.isNew).toBe(true);
+
+      act(() => {
+        const card = result.current.employment[0];
+        result.current.editEntry(card, card.entries[0], 'employment', { ...reopened!, description: 'Edited' });
+      });
+
+      const { values, relations } = result.current.stagePending();
+
+      expect(values).toContainEqual(
+        expect.objectContaining({ entity: { id: 'org-Digital Paradise', name: null }, value: 'Digital Paradise' })
+      );
+      expect(
+        relations.some(
+          relation => relation.fromEntity.id === 'org-Digital Paradise' && relation.toEntity.id === EMPLOYER_TYPE
+        )
+      ).toBe(true);
     });
 
     it('rewrites an unsaved row in place rather than queuing a delete', () => {

--- a/apps/web/core/hooks/use-profile-history.test.tsx
+++ b/apps/web/core/hooks/use-profile-history.test.tsx
@@ -76,6 +76,9 @@ const draft = (company: string, title: string, overrides: Partial<PositionDraft>
 
 const setup = () => renderHook(() => useProfileHistory({ entityId: ENTITY_ID, spaceId: SPACE_ID }));
 
+/** A subtree row in the space this modal publishes to, which is the common case. */
+const inSpace = (id: string) => ({ id, spaceId: SPACE_ID });
+
 const tombstones = (relations: { isDeleted?: boolean; id: string; type: { id: string } }[]) =>
   relations.filter(relation => relation.isDeleted);
 
@@ -149,11 +152,11 @@ describe('useProfileHistory', () => {
     it('takes everything on the row with the row', () => {
       const card = savedCard('Geo', ['Engineer']);
       card.entries[0].subtree = {
-        relationIds: ['rel-status', 'rel-employment-type', 'rel-skill-1', 'rel-types'],
+        relations: ['rel-status', 'rel-employment-type', 'rel-skill-1', 'rel-types'].map(inSpace),
         values: [
-          { id: 'value-start', propertyId: START_DATE_PROPERTY },
-          { id: 'value-end', propertyId: 'end-date-property' },
-          { id: 'value-description', propertyId: 'description-property' },
+          { id: 'value-start', propertyId: START_DATE_PROPERTY, spaceId: SPACE_ID },
+          { id: 'value-end', propertyId: 'end-date-property', spaceId: SPACE_ID },
+          { id: 'value-description', propertyId: 'description-property', spaceId: SPACE_ID },
         ],
       };
       mocks.employment = [card];
@@ -179,12 +182,41 @@ describe('useProfileHistory', () => {
       expect(values.find(value => value.id === 'value-start')?.property.id).toBe(START_DATE_PROPERTY);
     });
 
+    // This edit reaches one space. A row somebody else wrote against the same
+    // tenure in another space is not ours to delete, and a tombstone for it would
+    // be a delete aimed at a space the row is not in. The SDK's own deleteEntity
+    // scopes the same way.
+    it('leaves rows in another space alone', () => {
+      const card = savedCard('Geo', ['Engineer']);
+      card.entries[0].subtree = {
+        relations: [inSpace('rel-ours'), { id: 'rel-theirs', spaceId: 'some-other-space' }],
+        values: [
+          { id: 'value-ours', propertyId: START_DATE_PROPERTY, spaceId: SPACE_ID },
+          { id: 'value-theirs', propertyId: START_DATE_PROPERTY, spaceId: 'some-other-space' },
+        ],
+      };
+      mocks.employment = [card];
+
+      const { result } = setup();
+
+      act(() => {
+        const merged = result.current.employment[0];
+        result.current.removeEntry(merged, merged.entries[0], 'employment');
+      });
+
+      const { relations, values } = result.current.stagePending();
+
+      expect(relations.map(relation => relation.id)).toContain('rel-ours');
+      expect(relations.map(relation => relation.id)).not.toContain('rel-theirs');
+      expect(values.map(value => value.id)).toEqual(['value-ours']);
+    });
+
     // The stint carries its own type, and the legacy records carry dates on it.
     it('cleans the employment record too when the edge goes with the last role', () => {
       const card = savedCard('Geo', ['Engineer']);
       card.edges[0].subtree = {
-        relationIds: ['stint-types'],
-        values: [{ id: 'stint-legacy-start', propertyId: START_DATE_PROPERTY }],
+        relations: [inSpace('stint-types')],
+        values: [{ id: 'stint-legacy-start', propertyId: START_DATE_PROPERTY, spaceId: SPACE_ID }],
       };
       card.entries[0].edge = card.edges[0];
       mocks.employment = [card];
@@ -206,7 +238,7 @@ describe('useProfileHistory', () => {
     // — only the row being removed is cleaned.
     it('leaves the employment record alone while a sibling still needs it', () => {
       const card = savedCard('Geo', ['Engineer', 'Product Lead']);
-      card.edges[0].subtree = { relationIds: ['stint-types'], values: [] };
+      card.edges[0].subtree = { relations: [inSpace('stint-types')], values: [] };
       mocks.employment = [card];
 
       const { result } = setup();
@@ -335,8 +367,8 @@ describe('useProfileHistory', () => {
     it('clears what hung off a row it replaces', () => {
       const card = savedCard('Geo', ['Engineer']);
       card.entries[0].subtree = {
-        relationIds: ['rel-old-skill'],
-        values: [{ id: 'value-old-description', propertyId: 'description-property' }],
+        relations: [inSpace('rel-old-skill')],
+        values: [{ id: 'value-old-description', propertyId: 'description-property', spaceId: SPACE_ID }],
       };
       mocks.employment = [card];
 

--- a/apps/web/core/hooks/use-profile-history.test.tsx
+++ b/apps/web/core/hooks/use-profile-history.test.tsx
@@ -1,0 +1,282 @@
+import { act, renderHook } from '@testing-library/react';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  EMPLOYMENT_PROPERTY,
+  EMPLOYMENT_STATUS_PROPERTY,
+  ROLES_PROPERTY,
+  START_DATE_PROPERTY,
+} from '~/core/profile/history-ontology';
+import type { EmploymentCard } from '~/core/profile/normalize-history';
+import type { PositionDraft } from '~/core/profile/stage-history';
+
+import { useProfileHistory } from './use-profile-history';
+
+const ENTITY_ID = '6caf2067e9a64f3696ff22fb7bc94947';
+const SPACE_ID = 'c3cdf799eb8a469abbb609b7c3ecdb83';
+
+const mocks = vi.hoisted(() => ({
+  employment: [] as unknown[],
+  invalidateQueries: vi.fn(),
+}));
+
+vi.mock('@tanstack/react-query', () => ({
+  useQuery: () => ({ data: { employment: mocks.employment, education: [] }, isLoading: false }),
+  useQueryClient: () => ({ invalidateQueries: mocks.invalidateQueries }),
+}));
+
+vi.mock('~/core/io/subgraph/fetch-profile-history', () => ({
+  fetchProfileHistory: vi.fn(),
+  profileHistoryQueryKey: (entityId: string) => ['profile-history', entityId],
+}));
+
+afterEach(() => {
+  mocks.employment = [];
+  vi.clearAllMocks();
+});
+
+/** One employer, with as many saved roles under one Employment edge as named. */
+const savedCard = (org: string, roles: string[], stint = `stint-${org}`): EmploymentCard => ({
+  organization: { id: `org-${org}`, name: org },
+  edges: [{ relationId: `edge-${org}`, stintId: stint }],
+  entries: roles.map(role => ({
+    relationId: `rel-${role}`,
+    tenureId: `tenure-${role}`,
+    edge: { relationId: `edge-${org}`, stintId: stint },
+    subject: { id: `title-${role}`, name: role },
+    startDate: '2022-06-01Z',
+    endDate: null,
+    description: null,
+    isLegacy: false,
+    status: 'current' as const,
+    employmentType: null,
+    skills: [],
+  })),
+});
+
+const draft = (company: string, title: string, overrides: Partial<PositionDraft> = {}): PositionDraft => ({
+  company: { id: `org-${company}`, name: company, isNew: false },
+  title: { id: `title-${title}`, name: title, isNew: false },
+  employmentType: null,
+  skills: [],
+  startDate: '2024-01-01Z',
+  endDate: null,
+  status: 'current',
+  description: '',
+  ...overrides,
+});
+
+const setup = () => renderHook(() => useProfileHistory({ entityId: ENTITY_ID, spaceId: SPACE_ID }));
+
+const tombstones = (relations: { isDeleted?: boolean; id: string; type: { id: string } }[]) =>
+  relations.filter(relation => relation.isDeleted);
+
+describe('useProfileHistory', () => {
+  it('writes nothing until something is staged', () => {
+    mocks.employment = [savedCard('Geo', ['Engineer'])];
+    const { result } = setup();
+
+    expect(result.current.hasPendingChanges).toBe(false);
+    expect(result.current.stagePending()).toEqual({ values: [], relations: [] });
+  });
+
+  describe('removing', () => {
+    // An employer with nothing under it is not a record of anything.
+    it('takes the Employment edge with the last role under it', () => {
+      mocks.employment = [savedCard('Geo', ['Engineer'])];
+      const { result } = setup();
+
+      act(() => {
+        const card = result.current.employment[0];
+        result.current.removeEntry(card, card.entries[0], 'employment');
+      });
+
+      const deleted = tombstones(result.current.stagePending().relations);
+      expect(deleted.map(relation => relation.id).sort()).toEqual(['edge-Geo', 'rel-Engineer']);
+      expect(result.current.employment).toEqual([]);
+    });
+
+    it('leaves the edge standing while another role still hangs off it', () => {
+      mocks.employment = [savedCard('Geo', ['Engineer', 'Product Lead'])];
+      const { result } = setup();
+
+      act(() => {
+        const card = result.current.employment[0];
+        result.current.removeEntry(card, card.entries[0], 'employment');
+      });
+
+      expect(tombstones(result.current.stagePending().relations).map(relation => relation.id)).toEqual([
+        'rel-Engineer',
+      ]);
+    });
+
+    // Two edges to one employer read as one card. A sibling under the other edge
+    // is not under this one, so it cannot keep this one alive.
+    it('counts siblings on the row’s own edge, not across the whole card', () => {
+      const card = savedCard('Geo', ['Engineer']);
+      const second = savedCard('Geo', ['Product Lead'], 'stint-Geo-2');
+      second.entries[0].edge = { relationId: 'edge-Geo-2', stintId: 'stint-Geo-2' };
+      mocks.employment = [
+        { ...card, edges: [...card.edges, ...second.edges], entries: [...card.entries, ...second.entries] },
+      ];
+
+      const { result } = setup();
+
+      act(() => {
+        const merged = result.current.employment[0];
+        result.current.removeEntry(merged, merged.entries[0], 'employment');
+      });
+
+      expect(
+        tombstones(result.current.stagePending().relations)
+          .map(relation => relation.id)
+          .sort()
+      ).toEqual(['edge-Geo', 'rel-Engineer']);
+    });
+
+    it('forgets an unsaved row rather than queuing a delete for it', () => {
+      const { result } = setup();
+
+      act(() => result.current.addPosition(draft('Fathom', 'Engineer')));
+      act(() => {
+        const card = result.current.employment[0];
+        result.current.removeEntry(card, card.entries[0], 'employment');
+      });
+
+      expect(result.current.hasPendingChanges).toBe(false);
+      expect(result.current.stagePending()).toEqual({ values: [], relations: [] });
+    });
+  });
+
+  describe('editing', () => {
+    // The tenure is an anonymous relation entity nothing else points at, so a
+    // replacement and a rewrite come to the same thing — and only a replacement
+    // can also move the row to another company.
+    it('replaces a saved row and reattaches it to the same employer', () => {
+      mocks.employment = [savedCard('Geo', ['Engineer'])];
+      const { result } = setup();
+
+      act(() => {
+        const card = result.current.employment[0];
+        result.current.editEntry(card, card.entries[0], 'employment', draft('Geo', 'Staff Engineer'));
+      });
+
+      const { relations, values } = result.current.stagePending();
+
+      // The row goes; the Employment edge it hung off does not, and nothing
+      // re-creates one.
+      expect(tombstones(relations).map(relation => relation.id)).toEqual(['rel-Engineer']);
+      expect(relations.some(relation => relation.type.id === EMPLOYMENT_PROPERTY && !relation.isDeleted)).toBe(false);
+
+      const roles = relations.find(relation => relation.type.id === ROLES_PROPERTY && !relation.isDeleted);
+      expect(roles?.fromEntity.id).toBe('stint-Geo');
+      expect(roles?.toEntity.id).toBe('title-Staff Engineer');
+      expect(values.some(value => value.property.id === START_DATE_PROPERTY)).toBe(true);
+    });
+
+    it('shows the edited row in place of the one it replaced', () => {
+      mocks.employment = [savedCard('Geo', ['Engineer'])];
+      const { result } = setup();
+
+      act(() => {
+        const card = result.current.employment[0];
+        result.current.editEntry(card, card.entries[0], 'employment', draft('Geo', 'Staff Engineer'));
+      });
+
+      expect(result.current.employment).toHaveLength(1);
+      expect(result.current.employment[0].entries.map(entry => entry.subject.name)).toEqual(['Staff Engineer']);
+    });
+
+    // Correcting the employer, not the role. The old edge has nothing left under
+    // it, so it goes too, and the row opens a new one at the right company.
+    it('moves a row to another employer, edge and all', () => {
+      mocks.employment = [savedCard('Geo', ['Engineer'])];
+      const { result } = setup();
+
+      act(() => {
+        const card = result.current.employment[0];
+        result.current.editEntry(card, card.entries[0], 'employment', draft('Coinbase', 'Engineer'));
+      });
+
+      const { relations } = result.current.stagePending();
+
+      expect(
+        tombstones(relations)
+          .map(relation => relation.id)
+          .sort()
+      ).toEqual(['edge-Geo', 'rel-Engineer']);
+
+      const employment = relations.find(relation => relation.type.id === EMPLOYMENT_PROPERTY && !relation.isDeleted);
+      expect(employment?.toEntity.id).toBe('org-Coinbase');
+      expect(result.current.employment.map(card => card.organization.name)).toEqual(['Coinbase']);
+    });
+
+    it('rewrites an unsaved row in place rather than queuing a delete', () => {
+      const { result } = setup();
+
+      act(() => result.current.addPosition(draft('Fathom', 'Engineer')));
+      act(() => {
+        const card = result.current.employment[0];
+        result.current.editEntry(card, card.entries[0], 'employment', draft('Fathom', 'Staff Engineer'));
+      });
+
+      expect(tombstones(result.current.stagePending().relations)).toEqual([]);
+      expect(result.current.employment[0].entries.map(entry => entry.subject.name)).toEqual(['Staff Engineer']);
+    });
+  });
+
+  describe('staging', () => {
+    // Two roles added at one new employer in a sitting would otherwise publish two
+    // Employment edges and read back as two employers.
+    it('opens one Employment edge for two roles at the same new employer', () => {
+      const { result } = setup();
+
+      act(() => result.current.addPosition(draft('Fathom', 'Engineer')));
+      act(() => result.current.addPosition(draft('Fathom', 'Staff Engineer')));
+
+      const { relations } = result.current.stagePending();
+      const edges = relations.filter(relation => relation.type.id === EMPLOYMENT_PROPERTY);
+      const roles = relations.filter(relation => relation.type.id === ROLES_PROPERTY);
+
+      expect(edges).toHaveLength(1);
+      expect(roles).toHaveLength(2);
+      expect(roles.every(role => role.fromEntity.id === edges[0].entityId)).toBe(true);
+      expect(result.current.employment).toHaveLength(1);
+    });
+
+    it('attaches a new role to the saved edge when the employer is already listed', () => {
+      mocks.employment = [savedCard('Geo', ['Engineer'])];
+      const { result } = setup();
+
+      act(() => result.current.addPosition(draft('Geo', 'Product Lead', { existingStintId: 'stint-Geo' })));
+
+      const { relations } = result.current.stagePending();
+      expect(relations.filter(relation => relation.type.id === EMPLOYMENT_PROPERTY)).toEqual([]);
+      expect(relations.find(relation => relation.type.id === ROLES_PROPERTY)?.fromEntity.id).toBe('stint-Geo');
+    });
+
+    it('records the status on the role rather than on the employer', () => {
+      const { result } = setup();
+
+      act(() => result.current.addPosition(draft('Fathom', 'Engineer')));
+
+      const { relations } = result.current.stagePending();
+      const roles = relations.find(relation => relation.type.id === ROLES_PROPERTY);
+      const status = relations.find(relation => relation.type.id === EMPLOYMENT_STATUS_PROPERTY);
+
+      expect(status?.fromEntity.id).toBe(roles?.entityId);
+    });
+  });
+
+  it('drops everything pending when the modal is dismissed', () => {
+    mocks.employment = [savedCard('Geo', ['Engineer'])];
+    const { result } = setup();
+
+    act(() => result.current.addPosition(draft('Fathom', 'Engineer')));
+    act(() => result.current.discard());
+
+    expect(result.current.hasPendingChanges).toBe(false);
+    expect(result.current.employment.map(card => card.organization.name)).toEqual(['Geo']);
+  });
+});

--- a/apps/web/core/hooks/use-profile-history.test.tsx
+++ b/apps/web/core/hooks/use-profile-history.test.tsx
@@ -10,6 +10,7 @@ import {
   START_DATE_PROPERTY,
 } from '~/core/profile/history-ontology';
 import type { EmploymentCard } from '~/core/profile/normalize-history';
+import { NOTHING_TO_CLEAN } from '~/core/profile/pending-history';
 import type { PositionDraft } from '~/core/profile/stage-history';
 
 import { useProfileHistory } from './use-profile-history';
@@ -40,11 +41,12 @@ afterEach(() => {
 /** One employer, with as many saved roles under one Employment edge as named. */
 const savedCard = (org: string, roles: string[], stint = `stint-${org}`): EmploymentCard => ({
   organization: { id: `org-${org}`, name: org },
-  edges: [{ relationId: `edge-${org}`, stintId: stint }],
+  edges: [{ relationId: `edge-${org}`, stintId: stint, subtree: NOTHING_TO_CLEAN }],
   entries: roles.map(role => ({
     relationId: `rel-${role}`,
     tenureId: `tenure-${role}`,
-    edge: { relationId: `edge-${org}`, stintId: stint },
+    edge: { relationId: `edge-${org}`, stintId: stint, subtree: NOTHING_TO_CLEAN },
+    subtree: NOTHING_TO_CLEAN,
     subject: { id: `title-${role}`, name: role },
     startDate: '2022-06-01Z',
     endDate: null,
@@ -121,7 +123,7 @@ describe('useProfileHistory', () => {
     it('counts siblings on the row’s own edge, not across the whole card', () => {
       const card = savedCard('Geo', ['Engineer']);
       const second = savedCard('Geo', ['Product Lead'], 'stint-Geo-2');
-      second.entries[0].edge = { relationId: 'edge-Geo-2', stintId: 'stint-Geo-2' };
+      second.entries[0].edge = { relationId: 'edge-Geo-2', stintId: 'stint-Geo-2', subtree: NOTHING_TO_CLEAN };
       mocks.employment = [
         { ...card, edges: [...card.edges, ...second.edges], entries: [...card.entries, ...second.entries] },
       ];
@@ -138,6 +140,83 @@ describe('useProfileHistory', () => {
           .map(relation => relation.id)
           .sort()
       ).toEqual(['edge-Geo', 'rel-Engineer']);
+    });
+
+    // The leak this exists for: deleting a relation marks that one row deleted
+    // and touches nothing else, so the tenure survived with its dates,
+    // description, employment type and skills on it — an entity nothing could
+    // reach and nobody could see. Four of them were found in the graph.
+    it('takes everything on the row with the row', () => {
+      const card = savedCard('Geo', ['Engineer']);
+      card.entries[0].subtree = {
+        relationIds: ['rel-status', 'rel-employment-type', 'rel-skill-1', 'rel-types'],
+        values: [
+          { id: 'value-start', propertyId: START_DATE_PROPERTY },
+          { id: 'value-end', propertyId: 'end-date-property' },
+          { id: 'value-description', propertyId: 'description-property' },
+        ],
+      };
+      mocks.employment = [card];
+
+      const { result } = setup();
+
+      act(() => {
+        const merged = result.current.employment[0];
+        result.current.removeEntry(merged, merged.entries[0], 'employment');
+      });
+
+      const { relations, values } = result.current.stagePending();
+
+      expect(relations.every(relation => relation.isDeleted)).toBe(true);
+      expect(relations.map(relation => relation.id).sort()).toEqual(
+        ['edge-Geo', 'rel-Engineer', 'rel-employment-type', 'rel-skill-1', 'rel-status', 'rel-types'].sort()
+      );
+      expect(values.every(value => value.isDeleted)).toBe(true);
+      expect(values.map(value => value.id).sort()).toEqual(['value-description', 'value-end', 'value-start'].sort());
+
+      // The unset op is keyed on the property, so a tombstone that lost it would
+      // publish a delete that clears nothing.
+      expect(values.find(value => value.id === 'value-start')?.property.id).toBe(START_DATE_PROPERTY);
+    });
+
+    // The stint carries its own type, and the legacy records carry dates on it.
+    it('cleans the employment record too when the edge goes with the last role', () => {
+      const card = savedCard('Geo', ['Engineer']);
+      card.edges[0].subtree = {
+        relationIds: ['stint-types'],
+        values: [{ id: 'stint-legacy-start', propertyId: START_DATE_PROPERTY }],
+      };
+      card.entries[0].edge = card.edges[0];
+      mocks.employment = [card];
+
+      const { result } = setup();
+
+      act(() => {
+        const merged = result.current.employment[0];
+        result.current.removeEntry(merged, merged.entries[0], 'employment');
+      });
+
+      const { relations, values } = result.current.stagePending();
+
+      expect(relations.map(relation => relation.id)).toContain('stint-types');
+      expect(values.map(value => value.id)).toContain('stint-legacy-start');
+    });
+
+    // A sibling still hangs off the edge, so the edge and everything on it stays
+    // — only the row being removed is cleaned.
+    it('leaves the employment record alone while a sibling still needs it', () => {
+      const card = savedCard('Geo', ['Engineer', 'Product Lead']);
+      card.edges[0].subtree = { relationIds: ['stint-types'], values: [] };
+      mocks.employment = [card];
+
+      const { result } = setup();
+
+      act(() => {
+        const merged = result.current.employment[0];
+        result.current.removeEntry(merged, merged.entries[0], 'employment');
+      });
+
+      expect(result.current.stagePending().relations.map(relation => relation.id)).not.toContain('stint-types');
     });
 
     it('forgets an unsaved row rather than queuing a delete for it', () => {
@@ -249,6 +328,34 @@ describe('useProfileHistory', () => {
           relation => relation.fromEntity.id === 'org-Digital Paradise' && relation.toEntity.id === EMPLOYER_TYPE
         )
       ).toBe(true);
+    });
+
+    // The replacement writes its own dates and skills; the old ones are not
+    // merged into them, so leaving them behind would have the row claiming both.
+    it('clears what hung off a row it replaces', () => {
+      const card = savedCard('Geo', ['Engineer']);
+      card.entries[0].subtree = {
+        relationIds: ['rel-old-skill'],
+        values: [{ id: 'value-old-description', propertyId: 'description-property' }],
+      };
+      mocks.employment = [card];
+
+      const { result } = setup();
+
+      act(() => {
+        const merged = result.current.employment[0];
+        result.current.editEntry(merged, merged.entries[0], 'employment', draft('Geo', 'Staff Engineer'));
+      });
+
+      const { relations, values } = result.current.stagePending();
+
+      expect(
+        relations
+          .filter(r => r.isDeleted)
+          .map(r => r.id)
+          .sort()
+      ).toEqual(['rel-Engineer', 'rel-old-skill']);
+      expect(values.filter(v => v.isDeleted).map(v => v.id)).toEqual(['value-old-description']);
     });
 
     it('rewrites an unsaved row in place rather than queuing a delete', () => {

--- a/apps/web/core/hooks/use-profile-history.test.tsx
+++ b/apps/web/core/hooks/use-profile-history.test.tsx
@@ -53,6 +53,8 @@ const savedCard = (org: string, roles: string[], stint = `stint-${org}`): Employ
     status: 'current' as const,
     employmentType: null,
     skills: [],
+    location: null,
+    locationType: null,
   })),
 });
 
@@ -61,6 +63,8 @@ const draft = (company: string, title: string, overrides: Partial<PositionDraft>
   title: { id: `title-${title}`, name: title, isNew: false },
   employmentType: null,
   skills: [],
+  location: null,
+  locationType: null,
   startDate: '2024-01-01Z',
   endDate: null,
   status: 'current',

--- a/apps/web/core/hooks/use-profile-history.ts
+++ b/apps/web/core/hooks/use-profile-history.ts
@@ -4,7 +4,7 @@ import { useQuery, useQueryClient } from '@tanstack/react-query';
 
 import * as React from 'react';
 
-import { usePublish } from '~/core/hooks/use-publish';
+import { ID } from '~/core/id';
 import { fetchProfileHistory, profileHistoryQueryKey } from '~/core/io/subgraph/fetch-profile-history';
 import {
   DEGREE_PROPERTY,
@@ -14,36 +14,40 @@ import {
 } from '~/core/profile/history-ontology';
 import type { EducationCard, EmploymentCard, HistoryCard, HistoryEntry } from '~/core/profile/normalize-history';
 import {
+  NOTHING_PENDING,
+  type PendingHistory,
+  type PendingRemoval,
+  dropPendingAddition,
+  hasPendingChanges,
+  isPending,
+  mergePendingEducation,
+  mergePendingEmployment,
+} from '~/core/profile/pending-history';
+import {
   type EducationDraft,
   type PositionDraft,
   type StagedRows,
   stageEducation,
   stagePosition,
 } from '~/core/profile/stage-history';
-import { useMutate } from '~/core/sync/use-mutate';
-import { getRelations, getValues } from '~/core/sync/use-store';
-import { store } from '~/core/sync/use-sync-engine';
 import type { Relation } from '~/core/types';
-
-export type HistoryStatus = 'idle' | 'saving' | 'error';
 
 type Params = { entityId: string; spaceId: string; enabled?: boolean };
 
 /**
  * Work and education on the viewer's own profile (GEO-2858).
  *
- * Kept apart from `useEditProfile` on purpose. The four header fields are one
- * draft the user edits and saves together; a position is a separate unit of
- * work, published the moment it is written, and mixing them would mean a
- * half-written job blocking a name change.
+ * Nothing here writes on its own. Adding a position, adding a degree and removing
+ * either are collected, and the modal's Save publishes them alongside the four
+ * header fields as a single edit — so correcting four things costs one ~10s wait
+ * rather than four, and nothing lands until the user says so.
+ *
+ * The resting state shows saved records merged with whatever is still pending, so
+ * the list reads as the profile they are about to have.
  */
 export function useProfileHistory({ entityId, spaceId, enabled = true }: Params) {
-  const { storage } = useMutate();
-  const { makeProposal } = usePublish();
   const queryClient = useQueryClient();
-
-  const [status, setStatus] = React.useState<HistoryStatus>('idle');
-  const [errorMessage, setErrorMessage] = React.useState<string | null>(null);
+  const [pending, setPending] = React.useState<PendingHistory>(NOTHING_PENDING);
 
   const queryKey = profileHistoryQueryKey(entityId);
 
@@ -54,175 +58,136 @@ export function useProfileHistory({ entityId, spaceId, enabled = true }: Params)
     staleTime: 60_000,
   });
 
-  /**
-   * Writes the rows locally, publishes exactly those, and takes them back out
-   * again if the write fails.
-   *
-   * Collected back out of the store rather than published as constructed: the
-   * store stamps `isLocal` on what it accepts, and the publish layer drops any
-   * value without it — so the rows handed over have to be the stored ones.
-   */
-  const publishRows = React.useCallback(
-    async (rows: StagedRows, editName: string) => {
-      setStatus('saving');
-      setErrorMessage(null);
+  const addPosition = React.useCallback((draft: PositionDraft) => {
+    setPending(current => ({
+      ...current,
+      positions: [...current.positions, { key: ID.createEntityId(), draft }],
+    }));
+  }, []);
 
-      rows.values.forEach(value => storage.values.set(value));
-      rows.relations.forEach(relation => storage.relations.set(relation));
+  const addEducation = React.useCallback((draft: EducationDraft) => {
+    setPending(current => ({
+      ...current,
+      education: [...current.education, { key: ID.createEntityId(), draft }],
+    }));
+  }, []);
 
-      const valueIds = new Set(rows.values.map(value => value.id));
-      const relationIds = new Set(rows.relations.map(relation => relation.id));
-
-      const values = getValues({ includeDeleted: true, selector: value => valueIds.has(value.id) });
-      const relations = getRelations({ includeDeleted: true, selector: relation => relationIds.has(relation.id) });
-
-      let failed = false;
-
-      await makeProposal({
-        values,
-        relations,
-        spaceId,
-        name: editName,
-        onSuccess: () => {
-          setStatus('idle');
-          void queryClient.invalidateQueries({ queryKey });
-        },
-        onError: () => {
-          failed = true;
-        },
-      });
-
-      if (!failed) return;
-
-      // All or nothing. A stint with no role under it renders as a company you
-      // are somehow attached to with nothing to say about it, which is worse
-      // than no entry at all — so a failed write leaves nothing behind.
-      store.clearLocalChangesByIds({
-        spaceId,
-        valueIds: [...valueIds],
-        relationIds: [...relationIds],
-      });
-
-      setStatus('error');
-      setErrorMessage('Couldn’t save that. Nothing was published — please try again.');
-    },
-    [makeProposal, queryClient, queryKey, spaceId, storage]
-  );
-
-  const addPosition = React.useCallback(
-    (draft: PositionDraft) => publishRows(stagePosition(draft, { personEntityId: entityId, spaceId }), 'Add position'),
-    [entityId, publishRows, spaceId]
-  );
-
-  const addEducation = React.useCallback(
-    (draft: EducationDraft) =>
-      publishRows(stageEducation(draft, { personEntityId: entityId, spaceId }), 'Add education'),
-    [entityId, publishRows, spaceId]
-  );
-
-  /**
-   * Deletes by id. The reader returns cards rather than store rows, so these are
-   * the minimum a delete needs — the publish layer only reads `id` off a
-   * tombstoned relation, and the store only needs enough to mark one.
-   */
-  const removeRelations = React.useCallback(
-    async (targets: { relationId: string; entityId: string; typeId: string }[], editName: string) => {
-      setStatus('saving');
-      setErrorMessage(null);
-
-      const tombstones: Relation[] = targets.map(target => ({
-        id: target.relationId,
-        entityId: target.entityId,
-        spaceId,
-        renderableType: 'RELATION',
-        type: { id: target.typeId, name: null },
-        fromEntity: { id: entityId, name: null },
-        toEntity: { id: target.entityId, name: null, value: target.entityId },
-      }));
-
-      tombstones.forEach(relation => storage.relations.delete(relation));
-
-      const ids = new Set(tombstones.map(relation => relation.id));
-      const relations = getRelations({ includeDeleted: true, selector: relation => ids.has(relation.id) });
-
-      let failed = false;
-
-      await makeProposal({
-        values: [],
-        relations,
-        spaceId,
-        name: editName,
-        onSuccess: () => {
-          setStatus('idle');
-          void queryClient.invalidateQueries({ queryKey });
-        },
-        onError: () => {
-          failed = true;
-        },
-      });
-
-      if (!failed) return;
-
-      store.clearLocalChangesByIds({ spaceId, valueIds: [], relationIds: [...ids] });
-      setStatus('error');
-      setErrorMessage('Couldn’t remove that. Nothing was published — please try again.');
-    },
-    [entityId, makeProposal, queryClient, queryKey, spaceId, storage]
-  );
-
-  /**
-   * Removing the last row takes its organisation with it, for the same reason a
-   * position is written all at once: an organisation with nothing under it is
-   * not a record of anything.
-   */
   const removeEntry = React.useCallback(
     (card: HistoryCard<HistoryEntry>, entry: HistoryEntry, kind: 'employment' | 'education') => {
-      const entryType = kind === 'employment' ? ROLES_PROPERTY : DEGREE_PROPERTY;
-      const cardType = kind === 'employment' ? EMPLOYMENT_PROPERTY : EDUCATION_PROPERTY;
-
-      const targets = [{ relationId: entry.relationId, entityId: entry.tenureId, typeId: entryType }];
-      if (card.entries.length <= 1) {
-        targets.push({ relationId: card.relationId, entityId: card.stintId, typeId: cardType });
+      // Never written, so there is nothing to delete — just forget it.
+      if (isPending(entry.relationId)) {
+        setPending(current => dropPendingAddition(current, entry.relationId));
+        return;
       }
 
-      return removeRelations(targets, kind === 'employment' ? 'Remove position' : 'Remove education');
-    },
-    [removeRelations]
-  );
-
-  const removeCard = React.useCallback(
-    (card: HistoryCard<HistoryEntry>, kind: 'employment' | 'education') => {
       const entryType = kind === 'employment' ? ROLES_PROPERTY : DEGREE_PROPERTY;
       const cardType = kind === 'employment' ? EMPLOYMENT_PROPERTY : EDUCATION_PROPERTY;
 
-      return removeRelations(
-        [
-          ...card.entries.map(entry => ({
-            relationId: entry.relationId,
-            entityId: entry.tenureId,
-            typeId: entryType,
-          })),
+      // The last row takes its organisation with it: an organisation with nothing
+      // under it is not a record of anything. Counted over saved rows only — a
+      // sibling that is itself unwritten cannot keep the edge alive.
+      const savedSiblings = card.entries.filter(
+        other => other.relationId !== entry.relationId && !isPending(other.relationId)
+      );
+
+      const removals: PendingRemoval[] = [
+        { relationId: entry.relationId, entityId: entry.tenureId, typeId: entryType },
+      ];
+      if (savedSiblings.length === 0 && !isPending(card.relationId)) {
+        removals.push({ relationId: card.relationId, entityId: card.stintId, typeId: cardType });
+      }
+
+      setPending(current => ({ ...current, removals: [...current.removals, ...removals] }));
+    },
+    []
+  );
+
+  const removeCard = React.useCallback((card: HistoryCard<HistoryEntry>, kind: 'employment' | 'education') => {
+    const entryType = kind === 'employment' ? ROLES_PROPERTY : DEGREE_PROPERTY;
+    const cardType = kind === 'employment' ? EMPLOYMENT_PROPERTY : EDUCATION_PROPERTY;
+
+    setPending(current => {
+      let next = current;
+      for (const entry of card.entries) {
+        if (isPending(entry.relationId)) next = dropPendingAddition(next, entry.relationId);
+      }
+
+      if (isPending(card.relationId)) return next;
+
+      return {
+        ...next,
+        removals: [
+          ...next.removals,
+          ...card.entries
+            .filter(entry => !isPending(entry.relationId))
+            .map(entry => ({ relationId: entry.relationId, entityId: entry.tenureId, typeId: entryType })),
           { relationId: card.relationId, entityId: card.stintId, typeId: cardType },
         ],
-        kind === 'employment' ? 'Remove employer' : 'Remove school'
-      );
-    },
-    [removeRelations]
+      };
+    });
+  }, []);
+
+  /**
+   * Everything pending, as rows for the modal's Save to publish with its own.
+   *
+   * Deletions are expressed as tombstoned relations. The reader returns cards
+   * rather than store rows, so these carry the minimum a delete needs — the
+   * publish layer reads only the id off a tombstone.
+   */
+  const stagePending = React.useCallback((): StagedRows => {
+    const context = { personEntityId: entityId, spaceId };
+
+    const additions = [
+      ...pending.positions.map(addition => stagePosition(addition.draft, context)),
+      ...pending.education.map(addition => stageEducation(addition.draft, context)),
+    ];
+
+    const tombstones: Relation[] = pending.removals.map(removal => ({
+      id: removal.relationId,
+      entityId: removal.entityId,
+      spaceId,
+      renderableType: 'RELATION',
+      isDeleted: true,
+      type: { id: removal.typeId, name: null },
+      fromEntity: { id: entityId, name: null },
+      toEntity: { id: removal.entityId, name: null, value: removal.entityId },
+    }));
+
+    return {
+      values: additions.flatMap(rows => rows.values),
+      relations: [...additions.flatMap(rows => rows.relations), ...tombstones],
+    };
+  }, [entityId, pending, spaceId]);
+
+  /** Called once the save lands, so the merged view falls back to the graph's. */
+  const settle = React.useCallback(() => {
+    setPending(NOTHING_PENDING);
+    void queryClient.invalidateQueries({ queryKey });
+  }, [queryClient, queryKey]);
+
+  const discard = React.useCallback(() => setPending(NOTHING_PENDING), []);
+
+  const employment = React.useMemo(
+    () => mergePendingEmployment(data?.employment ?? [], pending.positions, pending.removals),
+    [data?.employment, pending]
+  );
+
+  const education = React.useMemo(
+    () => mergePendingEducation(data?.education ?? [], pending.education, pending.removals),
+    [data?.education, pending]
   );
 
   return {
-    employment: (data?.employment ?? []) as EmploymentCard[],
-    education: (data?.education ?? []) as EducationCard[],
+    employment: employment as EmploymentCard[],
+    education: education as EducationCard[],
     isLoading,
-    status,
-    errorMessage,
+    hasPendingChanges: hasPendingChanges(pending),
     addPosition,
     addEducation,
     removeEntry,
     removeCard,
-    dismissError: React.useCallback(() => {
-      setStatus('idle');
-      setErrorMessage(null);
-    }, []),
+    stagePending,
+    settle,
+    discard,
   };
 }

--- a/apps/web/core/hooks/use-profile-history.ts
+++ b/apps/web/core/hooks/use-profile-history.ts
@@ -22,6 +22,8 @@ import {
   isPending,
   mergePendingEducation,
   mergePendingEmployment,
+  replacePendingAddition,
+  shareStintsByOrganization,
 } from '~/core/profile/pending-history';
 import {
   type EducationDraft,
@@ -34,13 +36,20 @@ import type { Relation } from '~/core/types';
 
 type Params = { entityId: string; spaceId: string; enabled?: boolean };
 
+type Kind = 'employment' | 'education';
+
+const PROPERTIES: Record<Kind, { entry: string; card: string }> = {
+  employment: { entry: ROLES_PROPERTY, card: EMPLOYMENT_PROPERTY },
+  education: { entry: DEGREE_PROPERTY, card: EDUCATION_PROPERTY },
+};
+
 /**
  * Work and education on the viewer's own profile (GEO-2858).
  *
- * Nothing here writes on its own. Adding a position, adding a degree and removing
- * either are collected, and the modal's Save publishes them alongside the four
- * header fields as a single edit — so correcting four things costs one ~10s wait
- * rather than four, and nothing lands until the user says so.
+ * Nothing here writes on its own. Adding a position, editing one, adding a degree
+ * and removing either are collected, and the modal's Save publishes them
+ * alongside the four header fields as a single edit — so correcting four things
+ * costs one ~10s wait rather than four, and nothing lands until the user says so.
  *
  * The resting state shows saved records merged with whatever is still pending, so
  * the list reads as the profile they are about to have.
@@ -72,60 +81,95 @@ export function useProfileHistory({ entityId, spaceId, enabled = true }: Params)
     }));
   }, []);
 
+  /**
+   * What removing one row costs: the row itself, and the organisation edge it
+   * hung off once nothing saved is left under it.
+   *
+   * Counted over that row's own edge rather than the whole card — a card can
+   * group several edges to one employer, and a sibling under a different edge
+   * cannot keep this one alive.
+   */
+  const removalsFor = React.useCallback((card: HistoryCard<HistoryEntry>, entry: HistoryEntry, kind: Kind) => {
+    const properties = PROPERTIES[kind];
+
+    const savedSiblings = card.entries.filter(
+      other =>
+        other.relationId !== entry.relationId &&
+        other.edge.stintId === entry.edge.stintId &&
+        !isPending(other.relationId)
+    );
+
+    const removals: PendingRemoval[] = [
+      { relationId: entry.relationId, entityId: entry.tenureId, typeId: properties.entry },
+    ];
+
+    if (savedSiblings.length === 0 && !isPending(entry.edge.relationId)) {
+      removals.push({
+        relationId: entry.edge.relationId,
+        entityId: entry.edge.stintId,
+        typeId: properties.card,
+      });
+    }
+
+    return removals;
+  }, []);
+
   const removeEntry = React.useCallback(
-    (card: HistoryCard<HistoryEntry>, entry: HistoryEntry, kind: 'employment' | 'education') => {
+    (card: HistoryCard<HistoryEntry>, entry: HistoryEntry, kind: Kind) => {
       // Never written, so there is nothing to delete — just forget it.
       if (isPending(entry.relationId)) {
         setPending(current => dropPendingAddition(current, entry.relationId));
         return;
       }
 
-      const entryType = kind === 'employment' ? ROLES_PROPERTY : DEGREE_PROPERTY;
-      const cardType = kind === 'employment' ? EMPLOYMENT_PROPERTY : EDUCATION_PROPERTY;
-
-      // The last row takes its organisation with it: an organisation with nothing
-      // under it is not a record of anything. Counted over saved rows only — a
-      // sibling that is itself unwritten cannot keep the edge alive.
-      const savedSiblings = card.entries.filter(
-        other => other.relationId !== entry.relationId && !isPending(other.relationId)
-      );
-
-      const removals: PendingRemoval[] = [
-        { relationId: entry.relationId, entityId: entry.tenureId, typeId: entryType },
-      ];
-      if (savedSiblings.length === 0 && !isPending(card.relationId)) {
-        removals.push({ relationId: card.relationId, entityId: card.stintId, typeId: cardType });
-      }
-
+      const removals = removalsFor(card, entry, kind);
       setPending(current => ({ ...current, removals: [...current.removals, ...removals] }));
     },
-    []
+    [removalsFor]
   );
 
-  const removeCard = React.useCallback((card: HistoryCard<HistoryEntry>, kind: 'employment' | 'education') => {
-    const entryType = kind === 'employment' ? ROLES_PROPERTY : DEGREE_PROPERTY;
-    const cardType = kind === 'employment' ? EMPLOYMENT_PROPERTY : EDUCATION_PROPERTY;
-
-    setPending(current => {
-      let next = current;
-      for (const entry of card.entries) {
-        if (isPending(entry.relationId)) next = dropPendingAddition(next, entry.relationId);
+  /**
+   * Editing a saved row is a replacement: the old row goes, a new one takes its
+   * place under the same employer.
+   *
+   * The tenure is an anonymous relation entity that nothing else points at, so
+   * rewriting it and minting a fresh one come to the same thing — and a
+   * replacement is the only one of the two that can also move the row to a
+   * different company, or clear a date that used to be set.
+   */
+  const editEntry = React.useCallback(
+    (card: HistoryCard<HistoryEntry>, entry: HistoryEntry, kind: Kind, draft: PositionDraft | EducationDraft) => {
+      if (isPending(entry.relationId)) {
+        setPending(current => replacePendingAddition(current, entry.relationId, draft));
+        return;
       }
 
-      if (isPending(card.relationId)) return next;
+      const organizationId = 'company' in draft ? draft.company.id : draft.school.id;
+      const staysPut = organizationId === card.organization.id;
 
-      return {
-        ...next,
-        removals: [
-          ...next.removals,
-          ...card.entries
-            .filter(entry => !isPending(entry.relationId))
-            .map(entry => ({ relationId: entry.relationId, entityId: entry.tenureId, typeId: entryType })),
-          { relationId: card.relationId, entityId: card.stintId, typeId: cardType },
-        ],
-      };
-    });
-  }, []);
+      // Only the row when the employer is unchanged — the edge it hangs off is
+      // still wanted, and the replacement attaches straight back to it.
+      const removals = staysPut
+        ? [{ relationId: entry.relationId, entityId: entry.tenureId, typeId: PROPERTIES[kind].entry }]
+        : removalsFor(card, entry, kind);
+
+      const next = { ...draft, existingStintId: staysPut ? entry.edge.stintId : undefined };
+
+      setPending(current => ({
+        ...current,
+        removals: [...current.removals, ...removals],
+        positions:
+          kind === 'employment'
+            ? [...current.positions, { key: ID.createEntityId(), draft: next as PositionDraft }]
+            : current.positions,
+        education:
+          kind === 'education'
+            ? [...current.education, { key: ID.createEntityId(), draft: next as EducationDraft }]
+            : current.education,
+      }));
+    },
+    [removalsFor]
+  );
 
   /**
    * Everything pending, as rows for the modal's Save to publish with its own.
@@ -136,10 +180,15 @@ export function useProfileHistory({ entityId, spaceId, enabled = true }: Params)
    */
   const stagePending = React.useCallback((): StagedRows => {
     const context = { personEntityId: entityId, spaceId };
+    const mint = () => ID.createEntityId();
 
     const additions = [
-      ...pending.positions.map(addition => stagePosition(addition.draft, context)),
-      ...pending.education.map(addition => stageEducation(addition.draft, context)),
+      ...shareStintsByOrganization(pending.positions, mint).map(({ draft, newStintId }) =>
+        stagePosition(draft, context, newStintId)
+      ),
+      ...shareStintsByOrganization(pending.education, mint).map(({ draft, newStintId }) =>
+        stageEducation(draft, context, newStintId)
+      ),
     ];
 
     const tombstones: Relation[] = pending.removals.map(removal => ({
@@ -185,7 +234,7 @@ export function useProfileHistory({ entityId, spaceId, enabled = true }: Params)
     addPosition,
     addEducation,
     removeEntry,
-    removeCard,
+    editEntry,
     stagePending,
     settle,
     discard,

--- a/apps/web/core/hooks/use-profile-history.ts
+++ b/apps/web/core/hooks/use-profile-history.ts
@@ -1,0 +1,228 @@
+'use client';
+
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+
+import * as React from 'react';
+
+import { usePublish } from '~/core/hooks/use-publish';
+import { fetchProfileHistory, profileHistoryQueryKey } from '~/core/io/subgraph/fetch-profile-history';
+import {
+  DEGREE_PROPERTY,
+  EDUCATION_PROPERTY,
+  EMPLOYMENT_PROPERTY,
+  ROLES_PROPERTY,
+} from '~/core/profile/history-ontology';
+import type { EducationCard, EmploymentCard, HistoryCard, HistoryEntry } from '~/core/profile/normalize-history';
+import {
+  type EducationDraft,
+  type PositionDraft,
+  type StagedRows,
+  stageEducation,
+  stagePosition,
+} from '~/core/profile/stage-history';
+import { useMutate } from '~/core/sync/use-mutate';
+import { getRelations, getValues } from '~/core/sync/use-store';
+import { store } from '~/core/sync/use-sync-engine';
+import type { Relation } from '~/core/types';
+
+export type HistoryStatus = 'idle' | 'saving' | 'error';
+
+type Params = { entityId: string; spaceId: string; enabled?: boolean };
+
+/**
+ * Work and education on the viewer's own profile (GEO-2858).
+ *
+ * Kept apart from `useEditProfile` on purpose. The four header fields are one
+ * draft the user edits and saves together; a position is a separate unit of
+ * work, published the moment it is written, and mixing them would mean a
+ * half-written job blocking a name change.
+ */
+export function useProfileHistory({ entityId, spaceId, enabled = true }: Params) {
+  const { storage } = useMutate();
+  const { makeProposal } = usePublish();
+  const queryClient = useQueryClient();
+
+  const [status, setStatus] = React.useState<HistoryStatus>('idle');
+  const [errorMessage, setErrorMessage] = React.useState<string | null>(null);
+
+  const queryKey = profileHistoryQueryKey(entityId);
+
+  const { data, isLoading } = useQuery({
+    queryKey,
+    enabled: enabled && entityId !== '',
+    queryFn: () => fetchProfileHistory(entityId),
+    staleTime: 60_000,
+  });
+
+  /**
+   * Writes the rows locally, publishes exactly those, and takes them back out
+   * again if the write fails.
+   *
+   * Collected back out of the store rather than published as constructed: the
+   * store stamps `isLocal` on what it accepts, and the publish layer drops any
+   * value without it — so the rows handed over have to be the stored ones.
+   */
+  const publishRows = React.useCallback(
+    async (rows: StagedRows, editName: string) => {
+      setStatus('saving');
+      setErrorMessage(null);
+
+      rows.values.forEach(value => storage.values.set(value));
+      rows.relations.forEach(relation => storage.relations.set(relation));
+
+      const valueIds = new Set(rows.values.map(value => value.id));
+      const relationIds = new Set(rows.relations.map(relation => relation.id));
+
+      const values = getValues({ includeDeleted: true, selector: value => valueIds.has(value.id) });
+      const relations = getRelations({ includeDeleted: true, selector: relation => relationIds.has(relation.id) });
+
+      let failed = false;
+
+      await makeProposal({
+        values,
+        relations,
+        spaceId,
+        name: editName,
+        onSuccess: () => {
+          setStatus('idle');
+          void queryClient.invalidateQueries({ queryKey });
+        },
+        onError: () => {
+          failed = true;
+        },
+      });
+
+      if (!failed) return;
+
+      // All or nothing. A stint with no role under it renders as a company you
+      // are somehow attached to with nothing to say about it, which is worse
+      // than no entry at all — so a failed write leaves nothing behind.
+      store.clearLocalChangesByIds({
+        spaceId,
+        valueIds: [...valueIds],
+        relationIds: [...relationIds],
+      });
+
+      setStatus('error');
+      setErrorMessage('Couldn’t save that. Nothing was published — please try again.');
+    },
+    [makeProposal, queryClient, queryKey, spaceId, storage]
+  );
+
+  const addPosition = React.useCallback(
+    (draft: PositionDraft) => publishRows(stagePosition(draft, { personEntityId: entityId, spaceId }), 'Add position'),
+    [entityId, publishRows, spaceId]
+  );
+
+  const addEducation = React.useCallback(
+    (draft: EducationDraft) =>
+      publishRows(stageEducation(draft, { personEntityId: entityId, spaceId }), 'Add education'),
+    [entityId, publishRows, spaceId]
+  );
+
+  /**
+   * Deletes by id. The reader returns cards rather than store rows, so these are
+   * the minimum a delete needs — the publish layer only reads `id` off a
+   * tombstoned relation, and the store only needs enough to mark one.
+   */
+  const removeRelations = React.useCallback(
+    async (targets: { relationId: string; entityId: string; typeId: string }[], editName: string) => {
+      setStatus('saving');
+      setErrorMessage(null);
+
+      const tombstones: Relation[] = targets.map(target => ({
+        id: target.relationId,
+        entityId: target.entityId,
+        spaceId,
+        renderableType: 'RELATION',
+        type: { id: target.typeId, name: null },
+        fromEntity: { id: entityId, name: null },
+        toEntity: { id: target.entityId, name: null, value: target.entityId },
+      }));
+
+      tombstones.forEach(relation => storage.relations.delete(relation));
+
+      const ids = new Set(tombstones.map(relation => relation.id));
+      const relations = getRelations({ includeDeleted: true, selector: relation => ids.has(relation.id) });
+
+      let failed = false;
+
+      await makeProposal({
+        values: [],
+        relations,
+        spaceId,
+        name: editName,
+        onSuccess: () => {
+          setStatus('idle');
+          void queryClient.invalidateQueries({ queryKey });
+        },
+        onError: () => {
+          failed = true;
+        },
+      });
+
+      if (!failed) return;
+
+      store.clearLocalChangesByIds({ spaceId, valueIds: [], relationIds: [...ids] });
+      setStatus('error');
+      setErrorMessage('Couldn’t remove that. Nothing was published — please try again.');
+    },
+    [entityId, makeProposal, queryClient, queryKey, spaceId, storage]
+  );
+
+  /**
+   * Removing the last row takes its organisation with it, for the same reason a
+   * position is written all at once: an organisation with nothing under it is
+   * not a record of anything.
+   */
+  const removeEntry = React.useCallback(
+    (card: HistoryCard<HistoryEntry>, entry: HistoryEntry, kind: 'employment' | 'education') => {
+      const entryType = kind === 'employment' ? ROLES_PROPERTY : DEGREE_PROPERTY;
+      const cardType = kind === 'employment' ? EMPLOYMENT_PROPERTY : EDUCATION_PROPERTY;
+
+      const targets = [{ relationId: entry.relationId, entityId: entry.tenureId, typeId: entryType }];
+      if (card.entries.length <= 1) {
+        targets.push({ relationId: card.relationId, entityId: card.stintId, typeId: cardType });
+      }
+
+      return removeRelations(targets, kind === 'employment' ? 'Remove position' : 'Remove education');
+    },
+    [removeRelations]
+  );
+
+  const removeCard = React.useCallback(
+    (card: HistoryCard<HistoryEntry>, kind: 'employment' | 'education') => {
+      const entryType = kind === 'employment' ? ROLES_PROPERTY : DEGREE_PROPERTY;
+      const cardType = kind === 'employment' ? EMPLOYMENT_PROPERTY : EDUCATION_PROPERTY;
+
+      return removeRelations(
+        [
+          ...card.entries.map(entry => ({
+            relationId: entry.relationId,
+            entityId: entry.tenureId,
+            typeId: entryType,
+          })),
+          { relationId: card.relationId, entityId: card.stintId, typeId: cardType },
+        ],
+        kind === 'employment' ? 'Remove employer' : 'Remove school'
+      );
+    },
+    [removeRelations]
+  );
+
+  return {
+    employment: (data?.employment ?? []) as EmploymentCard[],
+    education: (data?.education ?? []) as EducationCard[],
+    isLoading,
+    status,
+    errorMessage,
+    addPosition,
+    addEducation,
+    removeEntry,
+    removeCard,
+    dismissError: React.useCallback(() => {
+      setStatus('idle');
+      setErrorMessage(null);
+    }, []),
+  };
+}

--- a/apps/web/core/hooks/use-profile-history.ts
+++ b/apps/web/core/hooks/use-profile-history.ts
@@ -35,7 +35,7 @@ import {
   stageEducation,
   stagePosition,
 } from '~/core/profile/stage-history';
-import type { Relation } from '~/core/types';
+import type { Relation, Value } from '~/core/types';
 
 type Params = { entityId: string; spaceId: string; enabled?: boolean };
 
@@ -119,7 +119,12 @@ export function useProfileHistory({ entityId, spaceId, enabled = true }: Params)
     );
 
     const removals: PendingRemoval[] = [
-      { relationId: entry.relationId, entityId: entry.tenureId, typeId: properties.entry },
+      {
+        relationId: entry.relationId,
+        entityId: entry.tenureId,
+        typeId: properties.entry,
+        subtree: entry.subtree,
+      },
     ];
 
     if (savedSiblings.length === 0 && !isPending(entry.edge.relationId)) {
@@ -127,6 +132,7 @@ export function useProfileHistory({ entityId, spaceId, enabled = true }: Params)
         relationId: entry.edge.relationId,
         entityId: entry.edge.stintId,
         typeId: properties.card,
+        subtree: entry.edge.subtree,
       });
     }
 
@@ -167,9 +173,18 @@ export function useProfileHistory({ entityId, spaceId, enabled = true }: Params)
       const staysPut = organizationId === card.organization.id;
 
       // Only the row when the employer is unchanged — the edge it hangs off is
-      // still wanted, and the replacement attaches straight back to it.
+      // still wanted, and the replacement attaches straight back to it. What hung
+      // off the row goes either way: the replacement writes its own dates and
+      // skills, and the old ones are not merged into them.
       const removals = staysPut
-        ? [{ relationId: entry.relationId, entityId: entry.tenureId, typeId: PROPERTIES[kind].entry }]
+        ? [
+            {
+              relationId: entry.relationId,
+              entityId: entry.tenureId,
+              typeId: PROPERTIES[kind].entry,
+              subtree: entry.subtree,
+            },
+          ]
         : removalsFor(card, entry, kind);
 
       const next = { ...draft, existingStintId: staysPut ? entry.edge.stintId : undefined };
@@ -193,9 +208,10 @@ export function useProfileHistory({ entityId, spaceId, enabled = true }: Params)
   /**
    * Everything pending, as rows for the modal's Save to publish with its own.
    *
-   * Deletions are expressed as tombstoned relations. The reader returns cards
-   * rather than store rows, so these carry the minimum a delete needs — the
-   * publish layer reads only the id off a tombstone.
+   * Deletions are tombstones — rows carrying `isDeleted` — and a removal produces
+   * one for the relation plus one for everything on the entity it carries. The
+   * publish layer reads only the id off a tombstone, so these carry the minimum a
+   * delete needs rather than the row as it stands in the graph.
    */
   const stagePending = React.useCallback((): StagedRows => {
     const context = { personEntityId: entityId, spaceId };
@@ -210,20 +226,48 @@ export function useProfileHistory({ entityId, spaceId, enabled = true }: Params)
       ),
     ];
 
-    const tombstones: Relation[] = pending.removals.map(removal => ({
-      id: removal.relationId,
-      entityId: removal.entityId,
+    const tombstone = (id: string, typeId: string, ownerId: string): Relation => ({
+      id,
+      entityId: ownerId,
       spaceId,
       renderableType: 'RELATION',
       isDeleted: true,
-      type: { id: removal.typeId, name: null },
+      type: { id: typeId, name: null },
       fromEntity: { id: entityId, name: null },
-      toEntity: { id: removal.entityId, name: null, value: removal.entityId },
-    }));
+      toEntity: { id: ownerId, name: null, value: ownerId },
+    });
+
+    const removedRelations: Relation[] = [];
+    const removedValues: Value[] = [];
+
+    for (const removal of pending.removals) {
+      removedRelations.push(tombstone(removal.relationId, removal.typeId, removal.entityId));
+
+      // The relation's own entity goes with it. Its type is not known per row
+      // here and the publish layer does not read one off a tombstone, so the
+      // removal's own type stands in.
+      for (const relationId of removal.subtree.relationIds) {
+        removedRelations.push(tombstone(relationId, removal.typeId, removal.entityId));
+      }
+
+      for (const value of removal.subtree.values) {
+        removedValues.push({
+          id: value.id,
+          entity: { id: removal.entityId, name: null },
+          // The publish layer builds an `unset` from the property id and checks
+          // only that the data type is not RELATION, which a value never is. The
+          // real type is not worth another round trip to state here.
+          property: { id: value.propertyId, name: null, dataType: 'TEXT', renderableType: 'TEXT' },
+          spaceId,
+          value: '',
+          isDeleted: true,
+        });
+      }
+    }
 
     return {
-      values: additions.flatMap(rows => rows.values),
-      relations: [...additions.flatMap(rows => rows.relations), ...tombstones],
+      values: [...additions.flatMap(rows => rows.values), ...removedValues],
+      relations: [...additions.flatMap(rows => rows.relations), ...removedRelations],
     };
   }, [entityId, pending, spaceId]);
 

--- a/apps/web/core/hooks/use-profile-history.ts
+++ b/apps/web/core/hooks/use-profile-history.ts
@@ -5,6 +5,7 @@ import { useQuery, useQueryClient } from '@tanstack/react-query';
 import * as React from 'react';
 
 import { ID } from '~/core/id';
+import { entityAvatarsQueryKey, fetchEntityAvatars } from '~/core/io/subgraph/fetch-entity-avatars';
 import { fetchProfileHistory, profileHistoryQueryKey } from '~/core/io/subgraph/fetch-profile-history';
 import {
   DEGREE_PROPERTY,
@@ -22,6 +23,8 @@ import {
   isPending,
   mergePendingEducation,
   mergePendingEmployment,
+  pendingDraftFor,
+  pendingOrganizationIds,
   replacePendingAddition,
   shareStintsByOrganization,
 } from '~/core/profile/pending-history';
@@ -64,6 +67,22 @@ export function useProfileHistory({ entityId, spaceId, enabled = true }: Params)
     queryKey,
     enabled: enabled && entityId !== '',
     queryFn: () => fetchProfileHistory(entityId),
+    staleTime: 60_000,
+  });
+
+  /**
+   * Logos for employers and schools a pending row names.
+   *
+   * The profile read collects these on its way past an edge; a row being added
+   * has no edge yet. Without this a card showed an initial before saving and a
+   * logo afterwards, which made the merged view look like it was guessing.
+   */
+  const pendingOrgIds = React.useMemo(() => pendingOrganizationIds(pending), [pending]);
+
+  const { data: pendingAvatars } = useQuery({
+    queryKey: entityAvatarsQueryKey(pendingOrgIds),
+    enabled: pendingOrgIds.length > 0,
+    queryFn: () => fetchEntityAvatars(pendingOrgIds),
     staleTime: 60_000,
   });
 
@@ -208,6 +227,18 @@ export function useProfileHistory({ entityId, spaceId, enabled = true }: Params)
     };
   }, [entityId, pending, spaceId]);
 
+  /**
+   * The draft behind an unsaved row, for the sheet to reopen on.
+   *
+   * Rebuilding one from the rendered row loses what the row does not show —
+   * notably that the company was created here and still needs naming, which is
+   * how an employer ended up on a profile as "Untitled".
+   */
+  const draftFor = React.useCallback(
+    (entry: HistoryEntry) => (isPending(entry.relationId) ? pendingDraftFor(pending, entry.relationId) : undefined),
+    [pending]
+  );
+
   /** Called once the save lands, so the merged view falls back to the graph's. */
   const settle = React.useCallback(() => {
     setPending(NOTHING_PENDING);
@@ -217,13 +248,13 @@ export function useProfileHistory({ entityId, spaceId, enabled = true }: Params)
   const discard = React.useCallback(() => setPending(NOTHING_PENDING), []);
 
   const employment = React.useMemo(
-    () => mergePendingEmployment(data?.employment ?? [], pending.positions, pending.removals),
-    [data?.employment, pending]
+    () => mergePendingEmployment(data?.employment ?? [], pending.positions, pending.removals, pendingAvatars),
+    [data?.employment, pending, pendingAvatars]
   );
 
   const education = React.useMemo(
-    () => mergePendingEducation(data?.education ?? [], pending.education, pending.removals),
-    [data?.education, pending]
+    () => mergePendingEducation(data?.education ?? [], pending.education, pending.removals, pendingAvatars),
+    [data?.education, pending, pendingAvatars]
   );
 
   return {
@@ -235,6 +266,7 @@ export function useProfileHistory({ entityId, spaceId, enabled = true }: Params)
     addEducation,
     removeEntry,
     editEntry,
+    draftFor,
     stagePending,
     settle,
     discard,

--- a/apps/web/core/hooks/use-profile-history.ts
+++ b/apps/web/core/hooks/use-profile-history.ts
@@ -243,14 +243,18 @@ export function useProfileHistory({ entityId, spaceId, enabled = true }: Params)
     for (const removal of pending.removals) {
       removedRelations.push(tombstone(removal.relationId, removal.typeId, removal.entityId));
 
-      // The relation's own entity goes with it. Its type is not known per row
-      // here and the publish layer does not read one off a tombstone, so the
-      // removal's own type stands in.
-      for (const relationId of removal.subtree.relationIds) {
-        removedRelations.push(tombstone(relationId, removal.typeId, removal.entityId));
+      // The relation's own entity goes with it, minus anything living in another
+      // space — this edit reaches one space, and a delete aimed at a row that is
+      // not in it does nothing but claim otherwise.
+      const ours = (rowSpaceId: string | null) => rowSpaceId === null || rowSpaceId === spaceId;
+
+      // The type is not known per row here, and the publish layer does not read
+      // one off a tombstone, so the removal's own stands in.
+      for (const relation of removal.subtree.relations.filter(row => ours(row.spaceId))) {
+        removedRelations.push(tombstone(relation.id, removal.typeId, removal.entityId));
       }
 
-      for (const value of removal.subtree.values) {
+      for (const value of removal.subtree.values.filter(row => ours(row.spaceId))) {
         removedValues.push({
           id: value.id,
           entity: { id: removal.entityId, name: null },

--- a/apps/web/core/hooks/use-search.ts
+++ b/apps/web/core/hooks/use-search.ts
@@ -49,6 +49,13 @@ interface SearchOptions {
    *   genuinely wants that specific restriction lifted.
    */
   includeNonCanonical?: boolean;
+  /**
+   * Extra spaces to make eligible, for a caller that knows where the thing it is
+   * searching for lives. Appended to the scoped spaces rather than replacing
+   * them, and ignored when the search is already scoped to one space or has
+   * asked for unrestricted results.
+   */
+  alsoSearchSpaceIds?: string[];
 }
 
 const DEFAULT_SEARCH_PAGE_SIZE = 10;
@@ -96,6 +103,7 @@ export function useSearch({
   enabled,
   pageSize = DEFAULT_SEARCH_PAGE_SIZE,
   includeNonCanonical,
+  alsoSearchSpaceIds,
 }: SearchOptions = {}) {
   const { store } = useSyncEngine();
   const cache = useQueryClient();
@@ -106,6 +114,7 @@ export function useSearch({
   const additionalSpaceIds = selectSearchAdditionalSpaceIds({
     filterBySpace,
     includeNonCanonical,
+    alsoSearchSpaceIds,
     globalAdditionalSpaceIds,
   });
 

--- a/apps/web/core/hooks/use-subspace.ts
+++ b/apps/web/core/hooks/use-subspace.ts
@@ -11,6 +11,7 @@ import { useSmartAccount } from '~/core/hooks/use-smart-account';
 import { useSmartAccountTransaction } from '~/core/hooks/use-smart-account-transaction';
 import { useSpace } from '~/core/hooks/use-space';
 import { uuidToHex } from '~/core/id/normalize';
+import { SPACE_REGISTRY_ADDRESS } from '~/core/sdk/geo-network';
 import { useStatusBar } from '~/core/state/status-bar-store';
 import { runEffectEither } from '~/core/telemetry/effect-runtime';
 import {
@@ -18,7 +19,6 @@ import {
   encodeProposalCreatedData,
   padBytes16ToBytes32,
 } from '~/core/utils/contracts/governance';
-import { SPACE_REGISTRY_ADDRESS } from '~/core/sdk/geo-network';
 import {
   DAOSpaceAbi,
   EMPTY_SIGNATURE,

--- a/apps/web/core/hooks/use-suggested-skills.ts
+++ b/apps/web/core/hooks/use-suggested-skills.ts
@@ -1,0 +1,37 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+
+import * as React from 'react';
+
+import { fetchRoleSkills, roleSkillsQueryKey } from '~/core/io/subgraph/fetch-role-skills';
+import { suggestSkills } from '~/core/profile/rank-role-skills';
+
+type Params = {
+  /** The occupation the user picked, if they have picked one yet. */
+  roleId: string | undefined;
+  /** Skills already on the draft, which are not worth suggesting again. */
+  picked: string[];
+};
+
+/**
+ * Skills worth offering once a role has been chosen.
+ *
+ * Only occupations from the ESCO import have any: a job title somebody typed in
+ * themselves has no skills hanging off it, and the answer is an empty list
+ * rather than a worse one. Nothing here blocks the sheet — the skills picker
+ * works the same whether or not any of this resolves.
+ */
+export function useSuggestedSkills({ roleId, picked }: Params) {
+  const { data, isLoading } = useQuery({
+    queryKey: roleSkillsQueryKey(roleId),
+    enabled: roleId !== undefined && roleId !== '',
+    queryFn: () => fetchRoleSkills(roleId as string),
+    // The taxonomy is a published import, so it does not move under us.
+    staleTime: Infinity,
+  });
+
+  const suggestions = React.useMemo(() => suggestSkills(data ?? [], picked), [data, picked]);
+
+  return { suggestions, isLoading: isLoading && roleId !== undefined };
+}

--- a/apps/web/core/hooks/use-suggested-skills.ts
+++ b/apps/web/core/hooks/use-suggested-skills.ts
@@ -33,5 +33,13 @@ export function useSuggestedSkills({ roleId, picked }: Params) {
 
   const suggestions = React.useMemo(() => suggestSkills(data ?? [], picked), [data, picked]);
 
-  return { suggestions, isLoading: isLoading && roleId !== undefined };
+  /**
+   * The same ranking with nothing trimmed, for the picker to offer before
+   * anything is typed. Five pills are a shortcut past searching; a product
+   * manager has dozens of skills recorded, and choosing from five meant choosing
+   * from whichever five happened to rank highest.
+   */
+  const all = React.useMemo(() => suggestSkills(data ?? [], picked, Infinity), [data, picked]);
+
+  return { suggestions, all, isLoading: isLoading && roleId !== undefined };
 }

--- a/apps/web/core/io/subgraph/fetch-entity-avatars.ts
+++ b/apps/web/core/io/subgraph/fetch-entity-avatars.ts
@@ -1,0 +1,72 @@
+import { Effect, Either } from 'effect';
+
+import { Environment } from '~/core/environment';
+import { AVATAR_PROPERTY } from '~/core/profile/history-ontology';
+import { findMediaUrlValue } from '~/core/utils/media-url';
+
+import { graphql } from './graphql';
+
+interface NetworkResult {
+  entities: {
+    id: string;
+    relationsList: { toEntity: { valuesList: { property: { id: string }; text: string | null }[] } | null }[];
+  }[];
+}
+
+/**
+ * Avatars for organisations the modal knows by id but has no relations for.
+ *
+ * The profile read picks these up on the way past an Employment edge. A position
+ * being added has no edge yet, so the employer's logo has to be asked for
+ * directly — otherwise a card looks different before and after saving, which is
+ * the one thing the merged view exists to avoid.
+ */
+const avatarsQuery = (entityIds: string[]) => `
+  {
+    entities(filter: { id: { in: ${JSON.stringify(entityIds)} } }) {
+      id
+      relationsList(filter: { typeId: { is: ${JSON.stringify(AVATAR_PROPERTY)} } }) {
+        toEntity { valuesList { property { id } text } }
+      }
+    }
+  }
+`;
+
+export function entityAvatarsQueryKey(entityIds: string[]) {
+  return ['entity-avatars', [...entityIds].sort().join(',')] as const;
+}
+
+export async function fetchEntityAvatars(entityIds: string[]): Promise<Record<string, string | null>> {
+  if (entityIds.length === 0) return {};
+
+  const result = await Effect.runPromise(
+    Effect.either(
+      graphql<NetworkResult>({
+        query: avatarsQuery(entityIds),
+        endpoint: Environment.getConfig().api,
+      })
+    )
+  );
+
+  if (Either.isLeft(result)) {
+    console.error('[entity-avatars] failed to fetch avatars:', result.left);
+    // The initial-letter fallback is a perfectly good thumbnail, so a failure
+    // here costs a logo and nothing else.
+    return {};
+  }
+
+  const avatars: Record<string, string | null> = {};
+
+  for (const entity of result.right.entities) {
+    for (const relation of entity.relationsList) {
+      const values = relation.toEntity?.valuesList ?? [];
+      const url = findMediaUrlValue(values.map(value => ({ value: value.text, property: value.property })));
+      if (url) {
+        avatars[entity.id] = url;
+        break;
+      }
+    }
+  }
+
+  return avatars;
+}

--- a/apps/web/core/io/subgraph/fetch-featured-rankings.test.ts
+++ b/apps/web/core/io/subgraph/fetch-featured-rankings.test.ts
@@ -182,7 +182,9 @@ describe('fetchFeaturedRankings', () => {
   });
 
   it('resolves the window from the legacy date properties when the current ones are absent', async () => {
-    getBatchEntitiesMock.mockReturnValue(Effect.succeed([blockEntity({ startDate: PAST, endDate: FUTURE, legacy: true })]));
+    getBatchEntitiesMock.mockReturnValue(
+      Effect.succeed([blockEntity({ startDate: PAST, endDate: FUTURE, legacy: true })])
+    );
 
     const result = await fetchFeaturedRankings();
 
@@ -286,7 +288,7 @@ describe('fetchFeaturedRankings', () => {
     expect(getBatchEntitiesMock).toHaveBeenCalledTimes(2);
   });
 
-  it('takes each placement from the block\'s own space, not whichever the batch returned first', async () => {
+  it("takes each placement from the block's own space, not whichever the batch returned first", async () => {
     // Dropping the per-query space filter widens the response to every space, so a block that is
     // also embedded elsewhere can come back with a foreign placement listed first. The per-block
     // query could never do that; here it has to be excluded by hand.
@@ -314,7 +316,7 @@ describe('fetchFeaturedRankings', () => {
     expect(await fetchFeaturedRankings()).toEqual([]);
   });
 
-  it('keeps one space\'s entity lookup failing from dropping another space\'s rankings', async () => {
+  it("keeps one space's entity lookup failing from dropping another space's rankings", async () => {
     twoBlocksInDifferentSpaces();
     // Batching makes a failure shared by default. It has to stay scoped to the space that failed.
     getBatchEntitiesMock.mockImplementation((ids: string[], spaceId?: string) =>
@@ -377,7 +379,9 @@ describe('fetchFeaturedRankings', () => {
     );
 
     getRelationsByToEntityIdsMock.mockReturnValue(
-      Effect.succeed(BLOCKS.map((id, i) => ({ id: `rel${i}`, fromEntityId: `parent${i}`, toEntityId: id, spaceId: SPACES[i] })))
+      Effect.succeed(
+        BLOCKS.map((id, i) => ({ id: `rel${i}`, fromEntityId: `parent${i}`, toEntityId: id, spaceId: SPACES[i] }))
+      )
     );
 
     const result = await fetchFeaturedRankings();

--- a/apps/web/core/io/subgraph/fetch-featured-rankings.ts
+++ b/apps/web/core/io/subgraph/fetch-featured-rankings.ts
@@ -155,7 +155,9 @@ async function resolveSubmitterSpaceIdsByBlock(
     byBlock.set(
       blockEntityId,
       dedupePreserveOrder(
-        refs.map(ref => ref.spaceId ?? rankEntitySpaceById.get(ref.rankEntityId)).filter((id): id is string => Boolean(id))
+        refs
+          .map(ref => ref.spaceId ?? rankEntitySpaceById.get(ref.rankEntityId))
+          .filter((id): id is string => Boolean(id))
       )
     );
   }
@@ -187,41 +189,37 @@ async function resolveTopEntriesByBlock(
     bySpace.set(request.spaceId, group);
   }
 
-  await mapWithConcurrency(
-    [...bySpace.entries()],
-    SPACE_QUERY_CONCURRENCY,
-    async ([spaceId, group]) => {
-      const ids = dedupePreserveOrder(group.flatMap(request => request.entityIds));
-      try {
-        const { entities } = await Effect.runPromise(
-          getAllEntities({ filter: { id: { in: ids } }, spaceId, limit: ids.length })
+  await mapWithConcurrency([...bySpace.entries()], SPACE_QUERY_CONCURRENCY, async ([spaceId, group]) => {
+    const ids = dedupePreserveOrder(group.flatMap(request => request.entityIds));
+    try {
+      const { entities } = await Effect.runPromise(
+        getAllEntities({ filter: { id: { in: ids } }, spaceId, limit: ids.length })
+      );
+      const entitiesById = new Map(entities.map(entity => [entity.id, entity]));
+      for (const request of group) {
+        byBlock.set(
+          request.blockEntityId,
+          // Kept per ranking and in its own order: an entity missing from the response still
+          // renders as "Untitled" so the leaderboard keeps its positions.
+          request.entityIds.map(entityId => {
+            const entity = entitiesById.get(entityId);
+            return {
+              entityId,
+              name: entity?.name?.trim() || 'Untitled',
+              image: entity ? (Entities.avatar(entity.relations) ?? Entities.cover(entity.relations) ?? null) : null,
+            };
+          })
         );
-        const entitiesById = new Map(entities.map(entity => [entity.id, entity]));
-        for (const request of group) {
-          byBlock.set(
-            request.blockEntityId,
-            // Kept per ranking and in its own order: an entity missing from the response still
-            // renders as "Untitled" so the leaderboard keeps its positions.
-            request.entityIds.map(entityId => {
-              const entity = entitiesById.get(entityId);
-              return {
-                entityId,
-                name: entity?.name?.trim() || 'Untitled',
-                image: entity ? (Entities.avatar(entity.relations) ?? Entities.cover(entity.relations) ?? null) : null,
-              };
-            })
-          );
-        }
-      } catch (error) {
-        // Scoped to the one space that failed: its rankings keep the empty leaderboard they were
-        // seeded with above and still render, exactly as the per-ranking version did. Reported
-        // for the same reason as above — silent before, and now one failure covers every ranking
-        // in the space rather than one card.
-        reportError(error);
-        console.error(`Unable to resolve featured ranking top entries (space ${spaceId})`, error);
       }
+    } catch (error) {
+      // Scoped to the one space that failed: its rankings keep the empty leaderboard they were
+      // seeded with above and still render, exactly as the per-ranking version did. Reported
+      // for the same reason as above — silent before, and now one failure covers every ranking
+      // in the space rather than one card.
+      reportError(error);
+      console.error(`Unable to resolve featured ranking top entries (space ${spaceId})`, error);
     }
-  );
+  });
 
   return byBlock;
 }
@@ -337,27 +335,23 @@ export async function fetchFeaturedRankings(): Promise<FeaturedRanking[]> {
   }
 
   const blockEntities = new Map<string, Entity>();
-  await mapWithConcurrency(
-    [...candidatesBySpace.entries()],
-    SPACE_QUERY_CONCURRENCY,
-    async ([spaceId, group]) => {
-      try {
-        const resolvedEntities = await Effect.runPromise(
-          getBatchEntities(
-            group.map(candidate => candidate.blockEntityId),
-            spaceId
-          )
-        );
-        for (const entity of resolvedEntities) blockEntities.set(entity.id, entity);
-      } catch (error) {
-        // Scoped to the one space that failed — its rankings drop out below for want of an
-        // entity, the rest are unaffected. Reported because batching widened the blast radius
-        // from the single block the per-block fetch would have dropped.
-        reportError(error);
-        console.error(`Unable to resolve featured ranking blocks (space ${spaceId})`, error);
-      }
+  await mapWithConcurrency([...candidatesBySpace.entries()], SPACE_QUERY_CONCURRENCY, async ([spaceId, group]) => {
+    try {
+      const resolvedEntities = await Effect.runPromise(
+        getBatchEntities(
+          group.map(candidate => candidate.blockEntityId),
+          spaceId
+        )
+      );
+      for (const entity of resolvedEntities) blockEntities.set(entity.id, entity);
+    } catch (error) {
+      // Scoped to the one space that failed — its rankings drop out below for want of an
+      // entity, the rest are unaffected. Reported because batching widened the blast radius
+      // from the single block the per-block fetch would have dropped.
+      reportError(error);
+      console.error(`Unable to resolve featured ranking blocks (space ${spaceId})`, error);
     }
-  );
+  });
 
   // 3. Keep the live ones. Pure reads of what phase 2 returned, so this costs no requests and
   //    still runs before the expensive work, as the per-block version did.

--- a/apps/web/core/io/subgraph/fetch-profile-history.ts
+++ b/apps/web/core/io/subgraph/fetch-profile-history.ts
@@ -33,16 +33,20 @@ export interface ProfileHistory {
  * than filtered by property id: the same nested block has to serve the current
  * shape and the legacy one, which puts dates on the stint instead. Both levels
  * hold a handful of rows, so there is nothing to save by narrowing them.
+ *
+ * Row ids come back alongside the content because removing a row has to delete
+ * what hangs off it, and a relation id cannot be reconstructed the way a value id
+ * can.
  */
 const nested = `
-  valuesList { property { id } date text decimal }
+  valuesList { id property { id } date text decimal }
   relationsList {
     id
     entityId
     type { id }
     toEntity { id name }
     entity {
-      valuesList { property { id } date text decimal }
+      valuesList { id property { id } date text decimal }
       relationsList { id entityId type { id } toEntity { id name } entity { valuesList { property { id } date text } } }
     }
   }

--- a/apps/web/core/io/subgraph/fetch-profile-history.ts
+++ b/apps/web/core/io/subgraph/fetch-profile-history.ts
@@ -1,7 +1,7 @@
 import { Effect, Either } from 'effect';
 
 import { Environment } from '~/core/environment';
-import { EDUCATION_PROPERTY, EMPLOYMENT_PROPERTY } from '~/core/profile/history-ontology';
+import { AVATAR_PROPERTY, EDUCATION_PROPERTY, EMPLOYMENT_PROPERTY } from '~/core/profile/history-ontology';
 import {
   type EducationCard,
   type EmploymentCard,
@@ -48,19 +48,29 @@ const nested = `
   }
 `;
 
+/**
+ * The organisation's own avatar, two hops down: the Avatar relation points at an
+ * image entity, and the URL is a value on that.
+ */
+const orgAvatar = `
+  relationsList(filter: { typeId: { is: ${JSON.stringify(AVATAR_PROPERTY)} } }) {
+    toEntity { valuesList { property { id } text } }
+  }
+`;
+
 const profileHistoryQuery = (entityId: string) => `
   {
     entity(id: ${JSON.stringify(entityId)}) {
       employment: relationsList(filter: { typeId: { is: ${JSON.stringify(EMPLOYMENT_PROPERTY)} } }) {
         id
         entityId
-        toEntity { id name }
+        toEntity { id name ${orgAvatar} }
         entity { ${nested} }
       }
       education: relationsList(filter: { typeId: { is: ${JSON.stringify(EDUCATION_PROPERTY)} } }) {
         id
         entityId
-        toEntity { id name }
+        toEntity { id name ${orgAvatar} }
         entity { ${nested} }
       }
     }

--- a/apps/web/core/io/subgraph/fetch-profile-history.ts
+++ b/apps/web/core/io/subgraph/fetch-profile-history.ts
@@ -1,0 +1,98 @@
+import { Effect, Either } from 'effect';
+
+import { Environment } from '~/core/environment';
+import { EDUCATION_PROPERTY, EMPLOYMENT_PROPERTY } from '~/core/profile/history-ontology';
+import {
+  type EducationCard,
+  type EmploymentCard,
+  type HistoryEdgeNode,
+  normalizeEducation,
+  normalizeEmployment,
+} from '~/core/profile/normalize-history';
+
+import { graphql } from './graphql';
+
+interface NetworkResult {
+  entity: {
+    employment: HistoryEdgeNode[];
+    education: HistoryEdgeNode[];
+  } | null;
+}
+
+export interface ProfileHistory {
+  employment: EmploymentCard[];
+  education: EducationCard[];
+}
+
+/**
+ * Three levels in one request. The middle level is the entity each relation
+ * carries — `entity { … }` on a relation — and it is where the roles hang off a
+ * company, and the dates off a role.
+ *
+ * Values and relations are read unfiltered at the stint and tenure levels rather
+ * than filtered by property id: the same nested block has to serve the current
+ * shape and the legacy one, which puts dates on the stint instead. Both levels
+ * hold a handful of rows, so there is nothing to save by narrowing them.
+ */
+const nested = `
+  valuesList { property { id } date text }
+  relationsList {
+    id
+    entityId
+    type { id }
+    toEntity { id name }
+    entity {
+      valuesList { property { id } date text }
+      relationsList { id entityId type { id } toEntity { id name } entity { valuesList { property { id } date text } } }
+    }
+  }
+`;
+
+const profileHistoryQuery = (entityId: string) => `
+  {
+    entity(id: ${JSON.stringify(entityId)}) {
+      employment: relationsList(filter: { typeId: { is: ${JSON.stringify(EMPLOYMENT_PROPERTY)} } }) {
+        id
+        entityId
+        toEntity { id name }
+        entity { ${nested} }
+      }
+      education: relationsList(filter: { typeId: { is: ${JSON.stringify(EDUCATION_PROPERTY)} } }) {
+        id
+        entityId
+        toEntity { id name }
+        entity { ${nested} }
+      }
+    }
+  }
+`;
+
+export function profileHistoryQueryKey(entityId: string | undefined) {
+  return ['profile-history', entityId] as const;
+}
+
+export async function fetchProfileHistory(entityId: string): Promise<ProfileHistory> {
+  const result = await Effect.runPromise(
+    Effect.either(
+      graphql<NetworkResult>({
+        query: profileHistoryQuery(entityId),
+        endpoint: Environment.getConfig().api,
+      })
+    )
+  );
+
+  if (Either.isLeft(result)) {
+    console.error(`[profile-history] failed to fetch history for ${entityId}:`, result.left);
+    // Empty rather than thrown: the sections render as "nothing here yet", which
+    // is wrong but harmless, where a throw would take the whole modal down with
+    // it and block the four fields that have nothing to do with this.
+    return { employment: [], education: [] };
+  }
+
+  const entity = result.right.entity;
+
+  return {
+    employment: normalizeEmployment(entity?.employment ?? []),
+    education: normalizeEducation(entity?.education ?? []),
+  };
+}

--- a/apps/web/core/io/subgraph/fetch-profile-history.ts
+++ b/apps/web/core/io/subgraph/fetch-profile-history.ts
@@ -34,20 +34,28 @@ export interface ProfileHistory {
  * shape and the legacy one, which puts dates on the stint instead. Both levels
  * hold a handful of rows, so there is nothing to save by narrowing them.
  *
- * Row ids come back alongside the content because removing a row has to delete
- * what hangs off it, and a relation id cannot be reconstructed the way a value id
- * can.
+ * Row ids and their spaces come back alongside the content because removing a
+ * row has to delete what hangs off it: a relation id cannot be reconstructed the
+ * way a value id can, and a row in another space is not ours to delete.
  */
 const nested = `
-  valuesList { id property { id } date text decimal }
+  valuesList { id spaceId property { id } date text decimal }
   relationsList {
     id
     entityId
+    spaceId
     type { id }
     toEntity { id name }
     entity {
-      valuesList { id property { id } date text decimal }
-      relationsList { id entityId type { id } toEntity { id name } entity { valuesList { property { id } date text } } }
+      valuesList { id spaceId property { id } date text decimal }
+      relationsList {
+        id
+        entityId
+        spaceId
+        type { id }
+        toEntity { id name }
+        entity { valuesList { property { id } date text } }
+      }
     }
   }
 `;

--- a/apps/web/core/io/subgraph/fetch-profile-history.ts
+++ b/apps/web/core/io/subgraph/fetch-profile-history.ts
@@ -35,14 +35,14 @@ export interface ProfileHistory {
  * hold a handful of rows, so there is nothing to save by narrowing them.
  */
 const nested = `
-  valuesList { property { id } date text }
+  valuesList { property { id } date text decimal }
   relationsList {
     id
     entityId
     type { id }
     toEntity { id name }
     entity {
-      valuesList { property { id } date text }
+      valuesList { property { id } date text decimal }
       relationsList { id entityId type { id } toEntity { id name } entity { valuesList { property { id } date text } } }
     }
   }

--- a/apps/web/core/io/subgraph/fetch-proposal-submitted-times.test.ts
+++ b/apps/web/core/io/subgraph/fetch-proposal-submitted-times.test.ts
@@ -1,5 +1,4 @@
 import { Effect } from 'effect';
-
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { fetchProposalSubmittedTimes, getSubmittedTime } from './fetch-proposal-submitted-times';

--- a/apps/web/core/io/subgraph/fetch-role-skills.ts
+++ b/apps/web/core/io/subgraph/fetch-role-skills.ts
@@ -1,0 +1,89 @@
+import { Effect, Either } from 'effect';
+
+import { Environment } from '~/core/environment';
+import {
+  IS_REQUIRED_PROPERTY,
+  SCOPE_RANK_PROPERTY,
+  SKILLS_PROPERTY,
+  SKILL_SCOPE_PROPERTY,
+} from '~/core/profile/history-ontology';
+import { type RoleSkill, normalizeRoleSkills } from '~/core/profile/rank-role-skills';
+
+import { graphql } from './graphql';
+
+interface NetworkResult {
+  entity: {
+    skills: {
+      entity: { valuesList: { propertyId: string; boolean: boolean | null }[] } | null;
+      toEntity: {
+        id: string;
+        name: string | null;
+        relationsList: { toEntity: { valuesList: { propertyId: string; integer: string | null }[] } | null }[];
+      } | null;
+    }[];
+  } | null;
+}
+
+/**
+ * An occupation's skills, with everything needed to rank them, in one request.
+ *
+ * The obvious shape is two: the role's skills, then the scopes of the skills that
+ * came back. That is what the import memo suggests, and it is one round trip more
+ * than necessary — the scope hangs off the skill, so it can be selected on the
+ * way through. A role tops out around ninety skills, so the whole thing is a
+ * single bounded read.
+ *
+ * `Is required?` is read from `entity` — the relation's own entity — and not from
+ * either end of it. Neither the role nor the skill knows whether the skill is
+ * essential; only the edge between them does.
+ */
+const roleSkillsQuery = (roleId: string) => `
+  {
+    entity(id: ${JSON.stringify(roleId)}) {
+      skills: relationsList(filter: { typeId: { is: ${JSON.stringify(SKILLS_PROPERTY)} } }) {
+        entity { valuesList { propertyId boolean } }
+        toEntity {
+          id
+          name
+          relationsList(filter: { typeId: { is: ${JSON.stringify(SKILL_SCOPE_PROPERTY)} } }) {
+            toEntity { valuesList { propertyId integer } }
+          }
+        }
+      }
+    }
+  }
+`;
+
+export function roleSkillsQueryKey(roleId: string | undefined) {
+  return ['role-skills', roleId] as const;
+}
+
+export async function fetchRoleSkills(roleId: string): Promise<RoleSkill[]> {
+  const result = await Effect.runPromise(
+    Effect.either(
+      graphql<NetworkResult>({
+        query: roleSkillsQuery(roleId),
+        endpoint: Environment.getConfig().api,
+      })
+    )
+  );
+
+  if (Either.isLeft(result)) {
+    console.error(`[role-skills] failed to fetch skills for ${roleId}:`, result.left);
+    // Empty rather than thrown. Suggestions are a convenience on top of a picker
+    // that works without them, so a failure here costs the shortcut and nothing
+    // else — the sheet still saves whatever the user types.
+    return [];
+  }
+
+  return normalizeRoleSkills(
+    (result.right.entity?.skills ?? []).map(relation => ({
+      isRequired: relation.entity?.valuesList.find(value => value.propertyId === IS_REQUIRED_PROPERTY)?.boolean ?? null,
+      skill: relation.toEntity,
+      rank:
+        relation.toEntity?.relationsList[0]?.toEntity?.valuesList.find(
+          value => value.propertyId === SCOPE_RANK_PROPERTY
+        )?.integer ?? null,
+    }))
+  );
+}

--- a/apps/web/core/profile/history-dates.test.ts
+++ b/apps/web/core/profile/history-dates.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { formatDateRange, fromGraphDate, toGraphDate, yearOptions } from './history-dates';
+import { formatDateRange, formatDuration, fromGraphDate, toGraphDate, yearOptions } from './history-dates';
 
 describe('toGraphDate', () => {
   it('writes the shape the graph already uses', () => {
@@ -61,5 +61,35 @@ describe('yearOptions', () => {
 
     expect(years[0]).toBe(2026);
     expect(years.at(-1)).toBe(1950);
+  });
+});
+
+describe('formatDuration', () => {
+  const now = new Date('2026-09-11T00:00:00Z');
+
+  it('reads a closed stretch the way a CV states it', () => {
+    expect(formatDuration('2022-06-01Z', '2024-01-01Z', now)).toBe('1 yr 8 mos');
+  });
+
+  it('counts an open stretch up to today', () => {
+    expect(formatDuration('2025-02-01Z', null, now)).toBe('1 yr 8 mos');
+  });
+
+  // Inclusive of the month it started in, so a job begun and left in the same
+  // month reads as a month rather than as nothing at all.
+  it('counts a single month as a month', () => {
+    expect(formatDuration('2024-03-01Z', '2024-03-01Z', now)).toBe('1 mo');
+  });
+
+  it('drops the months when it lands on a whole year', () => {
+    expect(formatDuration('2023-01-01Z', '2023-12-01Z', now)).toBe('1 yr');
+  });
+
+  it('says nothing without a start', () => {
+    expect(formatDuration(null, '2024-01-01Z', now)).toBeNull();
+  });
+
+  it('says nothing when the dates run backwards', () => {
+    expect(formatDuration('2024-01-01Z', '2022-01-01Z', now)).toBeNull();
   });
 });

--- a/apps/web/core/profile/history-dates.test.ts
+++ b/apps/web/core/profile/history-dates.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatDateRange, fromGraphDate, toGraphDate, yearOptions } from './history-dates';
+
+describe('toGraphDate', () => {
+  it('writes the shape the graph already uses', () => {
+    expect(toGraphDate({ month: 3, year: 2019 })).toBe('2019-03-01Z');
+  });
+
+  it('pads a single-digit month', () => {
+    expect(toGraphDate({ month: 9, year: 2022 })).toBe('2022-09-01Z');
+  });
+});
+
+describe('fromGraphDate', () => {
+  it('reads back what it writes', () => {
+    expect(fromGraphDate(toGraphDate({ month: 6, year: 2022 }))).toEqual({ month: 6, year: 2022 });
+  });
+
+  // These strings were written by other tools over several years, so the reader
+  // accepts anything carrying a usable year and month.
+  it('accepts a full timestamp', () => {
+    expect(fromGraphDate('2019-03-01T00:00:00.000Z')).toEqual({ month: 3, year: 2019 });
+  });
+
+  it('returns nothing for an absent or unusable date', () => {
+    expect(fromGraphDate(null)).toBeNull();
+    expect(fromGraphDate('')).toBeNull();
+    expect(fromGraphDate('sometime in 2019')).toBeNull();
+  });
+
+  it('rejects a month outside the calendar rather than indexing off the end', () => {
+    expect(fromGraphDate('2019-13-01Z')).toBeNull();
+    expect(fromGraphDate('2019-00-01Z')).toBeNull();
+  });
+});
+
+describe('formatDateRange', () => {
+  it('reads a closed range', () => {
+    expect(formatDateRange('2022-06-01Z', '2024-01-01Z')).toBe('Jun 2022 – Jan 2024');
+  });
+
+  it('reads an open range as still held', () => {
+    expect(formatDateRange('2024-01-01Z', null)).toBe('Jan 2024 – Present');
+  });
+
+  // A third of the records carry no dates at all. A lone dash there reads as a
+  // rendering fault rather than as missing data, so the row simply shows none.
+  it('renders nothing when there are no dates', () => {
+    expect(formatDateRange(null, null)).toBeNull();
+  });
+
+  it('still says something useful when only an end survived', () => {
+    expect(formatDateRange(null, '2021-01-01Z')).toBe('Until Jan 2021');
+  });
+});
+
+describe('yearOptions', () => {
+  it('runs from this year backwards', () => {
+    const years = yearOptions(new Date('2026-09-10T00:00:00Z'));
+
+    expect(years[0]).toBe(2026);
+    expect(years.at(-1)).toBe(1950);
+  });
+});

--- a/apps/web/core/profile/history-dates.ts
+++ b/apps/web/core/profile/history-dates.ts
@@ -1,0 +1,79 @@
+/**
+ * Month-and-year dates for work and education.
+ *
+ * Every date already in the graph lands on the first of a month — most on the
+ * first of January — so the stored precision is a month at best and usually a
+ * year. A day picker would advertise a precision nobody has and nobody filling
+ * in a CV remembers, so two dropdowns write `YYYY-MM-01Z`.
+ */
+
+export type MonthYear = { month: number; year: number };
+
+export const MONTH_NAMES = [
+  'January',
+  'February',
+  'March',
+  'April',
+  'May',
+  'June',
+  'July',
+  'August',
+  'September',
+  'October',
+  'November',
+  'December',
+] as const;
+
+/** Oldest year offered. Comfortably before any plausible CV entry. */
+const EARLIEST_YEAR = 1950;
+
+export function yearOptions(now = new Date()): number[] {
+  const latest = now.getUTCFullYear();
+  const years: number[] = [];
+  for (let year = latest; year >= EARLIEST_YEAR; year--) years.push(year);
+  return years;
+}
+
+export function toGraphDate({ month, year }: MonthYear): string {
+  return `${String(year).padStart(4, '0')}-${String(month).padStart(2, '0')}-01Z`;
+}
+
+/**
+ * Reads a stored date back into the two dropdowns. Tolerant on purpose: these
+ * strings were written by other tools over several years, so anything with a
+ * usable year and month is accepted rather than only the exact shape we write.
+ */
+export function fromGraphDate(value: string | null | undefined): MonthYear | null {
+  if (!value) return null;
+
+  const match = /^(\d{4})-(\d{2})/.exec(value.trim());
+  if (!match) return null;
+
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  if (month < 1 || month > 12) return null;
+
+  return { month, year };
+}
+
+/**
+ * How a row reads in the resting state: `Jun 2022 – Jan 2024`, or `– Present`
+ * where a role is still held.
+ *
+ * An entry with no start at all renders as nothing rather than a lone dash —
+ * about a third of the records in the graph carry no dates, and a dash on its
+ * own reads as a rendering fault rather than as missing data.
+ */
+export function formatDateRange(start: string | null, end: string | null): string | null {
+  const from = fromGraphDate(start);
+  const to = fromGraphDate(end);
+
+  if (!from) return to ? `Until ${formatMonthYear(to)}` : null;
+  if (!to) return `${formatMonthYear(from)} – Present`;
+
+  return `${formatMonthYear(from)} – ${formatMonthYear(to)}`;
+}
+
+function formatMonthYear({ month, year }: MonthYear): string {
+  return `${MONTH_NAMES[month - 1].slice(0, 3)} ${year}`;
+}

--- a/apps/web/core/profile/history-dates.ts
+++ b/apps/web/core/profile/history-dates.ts
@@ -77,3 +77,32 @@ export function formatDateRange(start: string | null, end: string | null): strin
 function formatMonthYear({ month, year }: MonthYear): string {
   return `${MONTH_NAMES[month - 1].slice(0, 3)} ${year}`;
 }
+
+/**
+ * How long a stretch ran, the way a CV states it: `4 yrs 2 mos`.
+ *
+ * Rounded to whole months from the first of each, which is all the stored
+ * precision supports. An open range runs to today, so a role still held keeps
+ * counting.
+ */
+export function formatDuration(start: string | null, end: string | null, now = new Date()): string | null {
+  const from = fromGraphDate(start);
+  if (!from) return null;
+
+  const to = fromGraphDate(end) ?? { month: now.getUTCMonth() + 1, year: now.getUTCFullYear() };
+
+  const months = (to.year - from.year) * 12 + (to.month - from.month);
+  if (months < 0) return null;
+
+  // Inclusive of the month it started in, so a job begun and left in March reads
+  // as a month rather than as nothing at all.
+  const total = months + 1;
+  const years = Math.floor(total / 12);
+  const remainder = total % 12;
+
+  const parts: string[] = [];
+  if (years > 0) parts.push(`${years} ${years === 1 ? 'yr' : 'yrs'}`);
+  if (remainder > 0) parts.push(`${remainder} ${remainder === 1 ? 'mo' : 'mos'}`);
+
+  return parts.join(' ') || null;
+}

--- a/apps/web/core/profile/history-ontology.test.ts
+++ b/apps/web/core/profile/history-ontology.test.ts
@@ -17,7 +17,6 @@ import {
   EMPLOYMENT_TYPE_PROPERTY,
   EMPLOYMENT_TYPE_TYPE,
   END_DATE_PROPERTY,
-  INSTITUTION_TYPE,
   IS_REQUIRED_PROPERTY,
   JOB_TYPE,
   LEGACY_DEGREE_TYPE,
@@ -77,8 +76,9 @@ describe('history ontology ids', () => {
     // A second real type of the same name, carrying the degrees that predate the
     // declared one. Searching only the declared one hides all of them.
     ['Degree type (legacy)', LEGACY_DEGREE_TYPE, '65256c5462834981b502aceeb74bd08c'],
+    // The school type the ontology is moving onto. Pinned by id because the
+    // entity may be renamed to `Institution` without becoming a different type.
     ['University', UNIVERSITY_TYPE, '0235f3d2821947a481d39ccd68e2b821'],
-    ['Institution', INSTITUTION_TYPE, '7f5433a40628498f9de6311cb14709a8'],
   ])('%s resolves to the id the graph has', (_name, actual, expected) => {
     expect(actual).toBe(expected);
   });

--- a/apps/web/core/profile/history-ontology.test.ts
+++ b/apps/web/core/profile/history-ontology.test.ts
@@ -4,6 +4,7 @@ import {
   ACADEMIC_FIELDS_PROPERTY,
   ACADEMIC_FIELD_TYPE,
   DEGREE_PROPERTY,
+  DEGREE_TYPE,
   DESCRIPTION_PROPERTY,
   EDUCATION_PROPERTY,
   EDUCATION_STATUS_OPTION,
@@ -19,6 +20,7 @@ import {
   INSTITUTION_TYPE,
   IS_REQUIRED_PROPERTY,
   JOB_TYPE,
+  LEGACY_DEGREE_TYPE,
   LOCATION_PROPERTY,
   LOCATION_TYPE_OPTIONS,
   LOCATION_TYPE_PROPERTY,
@@ -71,6 +73,10 @@ describe('history ontology ids', () => {
     // the rest — so the id matters more here than usual.
     ['Location', LOCATION_PROPERTY, '95d770021faf4f7cb7deb21a7d48cda0'],
     ['Location type', LOCATION_TYPE_PROPERTY, 'ceeb611101554764bea22818b21d3fbd'],
+    ['Degree type', DEGREE_TYPE, 'bfd47a5430aa43e18b8b8b86735919a0'],
+    // A second real type of the same name, carrying the degrees that predate the
+    // declared one. Searching only the declared one hides all of them.
+    ['Degree type (legacy)', LEGACY_DEGREE_TYPE, '65256c5462834981b502aceeb74bd08c'],
     ['University', UNIVERSITY_TYPE, '0235f3d2821947a481d39ccd68e2b821'],
     ['Institution', INSTITUTION_TYPE, '7f5433a40628498f9de6311cb14709a8'],
   ])('%s resolves to the id the graph has', (_name, actual, expected) => {

--- a/apps/web/core/profile/history-ontology.test.ts
+++ b/apps/web/core/profile/history-ontology.test.ts
@@ -16,8 +16,14 @@ import {
   EMPLOYMENT_TYPE_PROPERTY,
   EMPLOYMENT_TYPE_TYPE,
   END_DATE_PROPERTY,
+  IS_REQUIRED_PROPERTY,
+  JOB_TYPE,
   ROLES_PROPERTY,
+  ROLE_INFORMATION_TYPE,
+  SCOPE_RANK_PROPERTY,
   SKILLS_PROPERTY,
+  SKILL_SCOPE_PROPERTY,
+  SKILL_TYPE,
   START_DATE_PROPERTY,
   educationStatusFromOptionId,
   employmentStatusFromOptionId,
@@ -47,8 +53,23 @@ describe('history ontology ids', () => {
     ['Employment type property', EMPLOYMENT_TYPE_PROPERTY, '53a98633a2db40be9f161a4c9da37970'],
     ['Employment type (type)', EMPLOYMENT_TYPE_TYPE, 'f503bfd283d74e1a9b30294fff9d2d7e'],
     ['Skills', SKILLS_PROPERTY, 'a38732e33a3d47f9a459fb369c287709'],
+    ['Skill type', SKILL_TYPE, '9ca6ab1f3a114e49bbaf72e0c9a985cf'],
+    // What `Roles` declares it points at, and what its relation entity is. The
+    // picker searched `Job` until these were read off the property itself.
+    ['Title type (Person role)', JOB_TYPE, 'e4e366e9d5554b6892bf7358e824afd2'],
+    ['Role information', ROLE_INFORMATION_TYPE, '343952488d4a4bc088aae611b931ac0e'],
+    ['Is required?', IS_REQUIRED_PROPERTY, '3d60051c488f4a5ebae67a8264ade8bd'],
+    ['Skill scope', SKILL_SCOPE_PROPERTY, '7426f8535dc84776bd7abce1d069fa06'],
+    ['Scope rank', SCOPE_RANK_PROPERTY, '3ae1e15935864c0f9425652125d03772'],
   ])('%s resolves to the id the graph has', (_name, actual, expected) => {
     expect(actual).toBe(expected);
+  });
+
+  // The reason the Title picker was wrong: `Job` is a real type with 32 entities
+  // behind it, so scoping to it looked right and quietly hid the 2,905
+  // occupations that `Roles` actually points at.
+  it('does not search the type the SDK names Job', () => {
+    expect(JOB_TYPE).not.toBe('5ab7946f82bc42899d02a5f13bd40935');
   });
 });
 

--- a/apps/web/core/profile/history-ontology.test.ts
+++ b/apps/web/core/profile/history-ontology.test.ts
@@ -16,8 +16,12 @@ import {
   EMPLOYMENT_TYPE_PROPERTY,
   EMPLOYMENT_TYPE_TYPE,
   END_DATE_PROPERTY,
+  INSTITUTION_TYPE,
   IS_REQUIRED_PROPERTY,
   JOB_TYPE,
+  LOCATION_PROPERTY,
+  LOCATION_TYPE_OPTIONS,
+  LOCATION_TYPE_PROPERTY,
   ROLES_PROPERTY,
   ROLE_INFORMATION_TYPE,
   SCOPE_RANK_PROPERTY,
@@ -25,6 +29,7 @@ import {
   SKILL_SCOPE_PROPERTY,
   SKILL_TYPE,
   START_DATE_PROPERTY,
+  UNIVERSITY_TYPE,
   educationStatusFromOptionId,
   employmentStatusFromOptionId,
 } from './history-ontology';
@@ -61,6 +66,13 @@ describe('history ontology ids', () => {
     ['Is required?', IS_REQUIRED_PROPERTY, '3d60051c488f4a5ebae67a8264ade8bd'],
     ['Skill scope', SKILL_SCOPE_PROPERTY, '7426f8535dc84776bd7abce1d069fa06'],
     ['Scope rank', SCOPE_RANK_PROPERTY, '3ae1e15935864c0f9425652125d03772'],
+    // Seven properties are named `Location` and three `Location type`. These are
+    // the ones the graph uses — 676 relations and 16, against nothing at all for
+    // the rest — so the id matters more here than usual.
+    ['Location', LOCATION_PROPERTY, '95d770021faf4f7cb7deb21a7d48cda0'],
+    ['Location type', LOCATION_TYPE_PROPERTY, 'ceeb611101554764bea22818b21d3fbd'],
+    ['University', UNIVERSITY_TYPE, '0235f3d2821947a481d39ccd68e2b821'],
+    ['Institution', INSTITUTION_TYPE, '7f5433a40628498f9de6311cb14709a8'],
   ])('%s resolves to the id the graph has', (_name, actual, expected) => {
     expect(actual).toBe(expected);
   });
@@ -130,5 +142,24 @@ describe('employment type options', () => {
   it('gives every option a distinct id', () => {
     const ids = EMPLOYMENT_TYPE_OPTIONS.map(option => option.id);
     expect(new Set(ids).size).toBe(ids.length);
+  });
+});
+
+describe('location type options', () => {
+  // Onsite and Hybrid and Remote are one set: same space, and descriptions that
+  // only make sense together ("Position combines remote and onsite work"). Only
+  // the first and last have ever been used, so Hybrid is the one most likely to
+  // be wrong if any of them is.
+  it.each([
+    ['Onsite', '19db5058ae4849e79fd698f46b6beae4'],
+    ['Hybrid', '18022953fd99439e8feb55e50241dac0'],
+    ['Remote', '8f5e23aa70394ea4b7946fa0a9878da7'],
+  ])('%s resolves to the id the graph has', (name, id) => {
+    expect(LOCATION_TYPE_OPTIONS.find(option => option.name === name)?.id).toBe(id);
+  });
+
+  // The graph spells it `Onsite`. Writing `On-site` would point at nothing.
+  it('spells them the way the graph does', () => {
+    expect(LOCATION_TYPE_OPTIONS.map(option => option.name)).toEqual(['Onsite', 'Hybrid', 'Remote']);
   });
 });

--- a/apps/web/core/profile/history-ontology.test.ts
+++ b/apps/web/core/profile/history-ontology.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  ACADEMIC_FIELDS_PROPERTY,
+  ACADEMIC_FIELD_TYPE,
+  DEGREE_PROPERTY,
+  DESCRIPTION_PROPERTY,
+  EDUCATION_PROPERTY,
+  EDUCATION_STATUS_OPTION,
+  EDUCATION_STATUS_PROPERTY,
+  EMPLOYMENT_PROPERTY,
+  EMPLOYMENT_STATUS_OPTION,
+  EMPLOYMENT_STATUS_PROPERTY,
+  END_DATE_PROPERTY,
+  ROLES_PROPERTY,
+  START_DATE_PROPERTY,
+  educationStatusFromOptionId,
+  employmentStatusFromOptionId,
+} from './history-ontology';
+
+/**
+ * Pins every id to the value read back from the graph on 2026-09-10. Several come
+ * from the SDK under names that describe the first feature to use them rather
+ * than what they are (`RANK_START_DATE_PROPERTY` is the general Start date), so
+ * an upstream rename or repoint would otherwise land silently — as relations
+ * written against an id nothing reads.
+ */
+describe('history ontology ids', () => {
+  it.each([
+    ['Employment', EMPLOYMENT_PROPERTY, 'a2fae35bac864a568b26e69643c68d9d'],
+    ['Roles', ROLES_PROPERTY, '8fcfe5ef3d9147bd83223830a998d26b'],
+    ['Employment status', EMPLOYMENT_STATUS_PROPERTY, '3415e3537e0542099bffe07755fa004f'],
+    ['Education', EDUCATION_PROPERTY, 'dbb41bb9f76f4e5e866590086857fa22'],
+    ['Degree', DEGREE_PROPERTY, '38344c504261406496db13504579e64f'],
+    ['Education status', EDUCATION_STATUS_PROPERTY, 'afff0f059654466e865448d56585a41c'],
+    ['Academic fields', ACADEMIC_FIELDS_PROPERTY, '11692db4ddf54a69bfa044fb6b12f401'],
+    ['Academic field type', ACADEMIC_FIELD_TYPE, '9959eb50b0294a158557b39318cbb91b'],
+    ['Start date', START_DATE_PROPERTY, 'eed03a040acd4a9e81e08272ed70a817'],
+    ['End date', END_DATE_PROPERTY, 'b08b8f63dc1e41568b0819946f2b011c'],
+    ['Description', DESCRIPTION_PROPERTY, '9b1f76ff9711404c861e59dc3fa7d037'],
+  ])('%s resolves to the id the graph has', (_name, actual, expected) => {
+    expect(actual).toBe(expected);
+  });
+});
+
+describe('status options', () => {
+  it('maps employment status both ways', () => {
+    expect(employmentStatusFromOptionId(EMPLOYMENT_STATUS_OPTION.current)).toBe('current');
+    expect(employmentStatusFromOptionId(EMPLOYMENT_STATUS_OPTION.former)).toBe('former');
+  });
+
+  it('maps the two education statuses that exist', () => {
+    expect(educationStatusFromOptionId(EDUCATION_STATUS_OPTION.completed)).toBe('completed');
+    expect(educationStatusFromOptionId(EDUCATION_STATUS_OPTION.incomplete)).toBe('incomplete');
+  });
+
+  // The graph has no "in progress" option. Still studying is expressed by writing
+  // no status and leaving End date empty, so there is deliberately nothing to map.
+  it('has no option id for still studying', () => {
+    expect(EDUCATION_STATUS_OPTION).not.toHaveProperty('studying');
+  });
+
+  it('reads an unknown or absent option as no status', () => {
+    expect(employmentStatusFromOptionId(undefined)).toBeNull();
+    expect(employmentStatusFromOptionId('something-else')).toBeNull();
+    expect(educationStatusFromOptionId(null)).toBeNull();
+  });
+});

--- a/apps/web/core/profile/history-ontology.test.ts
+++ b/apps/web/core/profile/history-ontology.test.ts
@@ -12,8 +12,12 @@ import {
   EMPLOYMENT_PROPERTY,
   EMPLOYMENT_STATUS_OPTION,
   EMPLOYMENT_STATUS_PROPERTY,
+  EMPLOYMENT_TYPE_OPTIONS,
+  EMPLOYMENT_TYPE_PROPERTY,
+  EMPLOYMENT_TYPE_TYPE,
   END_DATE_PROPERTY,
   ROLES_PROPERTY,
+  SKILLS_PROPERTY,
   START_DATE_PROPERTY,
   educationStatusFromOptionId,
   employmentStatusFromOptionId,
@@ -40,6 +44,9 @@ describe('history ontology ids', () => {
     ['End date', END_DATE_PROPERTY, 'b08b8f63dc1e41568b0819946f2b011c'],
     ['Description', DESCRIPTION_PROPERTY, '9b1f76ff9711404c861e59dc3fa7d037'],
     ['Employer type (Project)', EMPLOYER_TYPE, '484a18c5030a499cb0f2ef588ff16d50'],
+    ['Employment type property', EMPLOYMENT_TYPE_PROPERTY, '53a98633a2db40be9f161a4c9da37970'],
+    ['Employment type (type)', EMPLOYMENT_TYPE_TYPE, 'f503bfd283d74e1a9b30294fff9d2d7e'],
+    ['Skills', SKILLS_PROPERTY, 'a38732e33a3d47f9a459fb369c287709'],
   ])('%s resolves to the id the graph has', (_name, actual, expected) => {
     expect(actual).toBe(expected);
   });
@@ -66,5 +73,41 @@ describe('status options', () => {
     expect(employmentStatusFromOptionId(undefined)).toBeNull();
     expect(employmentStatusFromOptionId('something-else')).toBeNull();
     expect(educationStatusFromOptionId(null)).toBeNull();
+  });
+});
+
+describe('employment type options', () => {
+  it('offers the eight LinkedIn types, in that order', () => {
+    expect(EMPLOYMENT_TYPE_OPTIONS.map(option => option.name)).toEqual([
+      'Full-time',
+      'Part-time',
+      'Self-employed',
+      'Freelance',
+      'Contract',
+      'Internship',
+      'Apprenticeship',
+      'Seasonal',
+    ]);
+  });
+
+  // Confirmed against the graph like the rest. Pinned because six other entities
+  // named "Full-time" are typed the same way, so a wrong id here would look
+  // plausible in the data and point at the wrong one.
+  it('pins each option id', () => {
+    expect(Object.fromEntries(EMPLOYMENT_TYPE_OPTIONS.map(o => [o.name, o.id]))).toEqual({
+      'Full-time': 'f4a86b892f094d97894c4bfedd150c30',
+      'Part-time': '5758c248068e44838da7e22109d9993f',
+      'Self-employed': '00f2a3b854f949c7b9f8a1e46872cbcc',
+      Freelance: '75839ffa17ef4d20b4e0621a4780030d',
+      Contract: '80d15f0e3b4f4288b69a1bcb5c3e4a0b',
+      Internship: '6eaed80c39b144f48e31dabf409a0722',
+      Apprenticeship: '946a5333fa084b2aac0c8d89a97b431c',
+      Seasonal: '1a0235d7f32e4cff83f9545f01bd96ba',
+    });
+  });
+
+  it('gives every option a distinct id', () => {
+    const ids = EMPLOYMENT_TYPE_OPTIONS.map(option => option.id);
+    expect(new Set(ids).size).toBe(ids.length);
   });
 });

--- a/apps/web/core/profile/history-ontology.test.ts
+++ b/apps/web/core/profile/history-ontology.test.ts
@@ -1,8 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
 import {
-  ACADEMIC_FIELDS_PROPERTY,
-  ACADEMIC_FIELD_TYPE,
   DEGREE_INFORMATION_TYPE,
   DEGREE_PROPERTY,
   DEGREE_TYPE,
@@ -20,6 +18,8 @@ import {
   EMPLOYMENT_TYPE_PROPERTY,
   EMPLOYMENT_TYPE_TYPE,
   END_DATE_PROPERTY,
+  FIELDS_OF_STUDY_PROPERTY,
+  FIELD_OF_STUDY_TYPE,
   GRADE_PROPERTY,
   IS_REQUIRED_PROPERTY,
   JOB_TYPE,
@@ -54,8 +54,10 @@ describe('history ontology ids', () => {
     ['Education', EDUCATION_PROPERTY, 'dbb41bb9f76f4e5e866590086857fa22'],
     ['Degree', DEGREE_PROPERTY, '38344c504261406496db13504579e64f'],
     ['Education status', EDUCATION_STATUS_PROPERTY, 'afff0f059654466e865448d56585a41c'],
-    ['Academic fields', ACADEMIC_FIELDS_PROPERTY, '11692db4ddf54a69bfa044fb6b12f401'],
-    ['Academic field type', ACADEMIC_FIELD_TYPE, '9959eb50b0294a158557b39318cbb91b'],
+    // Renamed from `Academic fields` after these were pinned. Same ids — which
+    // is the point of pinning ids rather than looking names up.
+    ['Fields of study', FIELDS_OF_STUDY_PROPERTY, '11692db4ddf54a69bfa044fb6b12f401'],
+    ['Field of study type', FIELD_OF_STUDY_TYPE, '9959eb50b0294a158557b39318cbb91b'],
     ['Start date', START_DATE_PROPERTY, 'eed03a040acd4a9e81e08272ed70a817'],
     ['End date', END_DATE_PROPERTY, 'b08b8f63dc1e41568b0819946f2b011c'],
     ['Description', DESCRIPTION_PROPERTY, '9b1f76ff9711404c861e59dc3fa7d037'],

--- a/apps/web/core/profile/history-ontology.test.ts
+++ b/apps/web/core/profile/history-ontology.test.ts
@@ -3,20 +3,24 @@ import { describe, expect, it } from 'vitest';
 import {
   ACADEMIC_FIELDS_PROPERTY,
   ACADEMIC_FIELD_TYPE,
+  DEGREE_INFORMATION_TYPE,
   DEGREE_PROPERTY,
   DEGREE_TYPE,
   DESCRIPTION_PROPERTY,
   EDUCATION_PROPERTY,
+  EDUCATION_RECORD_TYPE,
   EDUCATION_STATUS_OPTION,
   EDUCATION_STATUS_PROPERTY,
   EMPLOYER_TYPE,
   EMPLOYMENT_PROPERTY,
+  EMPLOYMENT_RECORD_TYPE,
   EMPLOYMENT_STATUS_OPTION,
   EMPLOYMENT_STATUS_PROPERTY,
   EMPLOYMENT_TYPE_OPTIONS,
   EMPLOYMENT_TYPE_PROPERTY,
   EMPLOYMENT_TYPE_TYPE,
   END_DATE_PROPERTY,
+  GRADE_PROPERTY,
   IS_REQUIRED_PROPERTY,
   JOB_TYPE,
   LEGACY_DEGREE_TYPE,
@@ -73,6 +77,13 @@ describe('history ontology ids', () => {
     ['Location', LOCATION_PROPERTY, '95d770021faf4f7cb7deb21a7d48cda0'],
     ['Location type', LOCATION_TYPE_PROPERTY, 'ceeb611101554764bea22818b21d3fbd'],
     ['Degree type', DEGREE_TYPE, 'bfd47a5430aa43e18b8b8b86735919a0'],
+    // The four relation-entity types, one per level, each declared by the
+    // property that carries it.
+    ['Employment record', EMPLOYMENT_RECORD_TYPE, '8ff1f25ffa814dc292171ecee721ee17'],
+    ['Role information', ROLE_INFORMATION_TYPE, '343952488d4a4bc088aae611b931ac0e'],
+    ['Education record', EDUCATION_RECORD_TYPE, '333d23cc8a0244e6a3d00c8414429164'],
+    ['Degree information', DEGREE_INFORMATION_TYPE, '45ecd803515d43fd8b2e529bdac330a9'],
+    ['Grade', GRADE_PROPERTY, 'efa26e09c19b4ef9b3bd9698ad5d3abf'],
     // A second real type of the same name, carrying the degrees that predate the
     // declared one. Searching only the declared one hides all of them.
     ['Degree type (legacy)', LEGACY_DEGREE_TYPE, '65256c5462834981b502aceeb74bd08c'],

--- a/apps/web/core/profile/history-ontology.test.ts
+++ b/apps/web/core/profile/history-ontology.test.ts
@@ -8,6 +8,7 @@ import {
   EDUCATION_PROPERTY,
   EDUCATION_STATUS_OPTION,
   EDUCATION_STATUS_PROPERTY,
+  EMPLOYER_TYPE,
   EMPLOYMENT_PROPERTY,
   EMPLOYMENT_STATUS_OPTION,
   EMPLOYMENT_STATUS_PROPERTY,
@@ -38,6 +39,7 @@ describe('history ontology ids', () => {
     ['Start date', START_DATE_PROPERTY, 'eed03a040acd4a9e81e08272ed70a817'],
     ['End date', END_DATE_PROPERTY, 'b08b8f63dc1e41568b0819946f2b011c'],
     ['Description', DESCRIPTION_PROPERTY, '9b1f76ff9711404c861e59dc3fa7d037'],
+    ['Employer type (Project)', EMPLOYER_TYPE, '484a18c5030a499cb0f2ef588ff16d50'],
   ])('%s resolves to the id the graph has', (_name, actual, expected) => {
     expect(actual).toBe(expected);
   });

--- a/apps/web/core/profile/history-ontology.ts
+++ b/apps/web/core/profile/history-ontology.ts
@@ -54,9 +54,9 @@ export const ACADEMIC_FIELD_TYPE = SystemIds.ACADEMIC_FIELD_TYPE;
  * Types to scope the find-or-create pickers, and to stamp on anything created
  * through them so the next person finds it instead of making a second one.
  *
- * Only the two that could be verified. School and Degree have several entities
- * apiece under those names with no obvious canonical one, so those two pickers
- * search unscoped rather than guess an id — a wrong type here is worse than none.
+ * Only those that could be verified. Degree still searches unscoped: several
+ * entities sit under that name with no obvious canonical one, and a wrong type
+ * there is worse than none.
  */
 /**
  * What an Employment edge points at. `Project` rather than `Company`: the graph
@@ -146,6 +146,32 @@ export const SKILL_TYPE = ContentIds.SKILL_TYPE;
 export const IS_REQUIRED_PROPERTY = '3d60051c488f4a5ebae67a8264ade8bd';
 export const SKILL_SCOPE_PROPERTY = '7426f8535dc84776bd7abce1d069fa06';
 export const SCOPE_RANK_PROPERTY = '3ae1e15935864c0f9425652125d03772';
+
+/**
+ * The space the taxonomy was imported into.
+ *
+ * Named here because the pickers have to ask for it explicitly. Search widens
+ * eligibility to the canonical graph plus the spaces the viewer belongs to, and
+ * the import is neither: every one of its 4,014 roles and 14,114 skills comes
+ * back from the search endpoint flagged non-canonical, in a space almost nobody
+ * is a member of. So a search for `Software developer` returned four unrelated
+ * canonical roles and none of the occupations — and the skills box offered the
+ * half-dozen skills Geo's own space happens to hold.
+ */
+export const TAXONOMY_SPACE_ID = 'd69608290513c2a91102c939b3265bd7';
+
+/**
+ * What the School picker searches, and what it types a school it creates as.
+ *
+ * `Education` declares `To entity types: Institution`, which is the broader of
+ * the two and has 108 entities behind it; `University` has 10 and is what
+ * someone filling in a school is usually naming. Both, therefore — searching
+ * either alone hides most of the answers, and a new school is typed as both so
+ * it turns up whichever one the next reader scopes to.
+ */
+export const UNIVERSITY_TYPE = '0235f3d2821947a481d39ccd68e2b821';
+export const INSTITUTION_TYPE = '7f5433a40628498f9de6311cb14709a8';
+export const SCHOOL_TYPES = [UNIVERSITY_TYPE, INSTITUTION_TYPE];
 
 /** What the avatar of a company or school is stored under. */
 export const AVATAR_PROPERTY = ContentIds.AVATAR_PROPERTY;

--- a/apps/web/core/profile/history-ontology.ts
+++ b/apps/web/core/profile/history-ontology.ts
@@ -51,6 +51,17 @@ export const ACADEMIC_FIELDS_PROPERTY = '11692db4ddf54a69bfa044fb6b12f401';
 export const ACADEMIC_FIELD_TYPE = SystemIds.ACADEMIC_FIELD_TYPE;
 
 /**
+ * Types to scope the find-or-create pickers, and to stamp on anything created
+ * through them so the next person finds it instead of making a second one.
+ *
+ * Only the two that could be verified. School and Degree have several entities
+ * apiece under those names with no obvious canonical one, so those two pickers
+ * search unscoped rather than guess an id — a wrong type here is worse than none.
+ */
+export const COMPANY_TYPE = SystemIds.COMPANY_TYPE;
+export const JOB_TYPE = ContentIds.JOB_TYPE;
+
+/**
  * Dates. The SDK names these `RANK_*` after the first thing that used them, but
  * they are the graph's general-purpose Start date / End date properties — the
  * repo already aliases them a second time in `ranking-block-ids.ts`.

--- a/apps/web/core/profile/history-ontology.ts
+++ b/apps/web/core/profile/history-ontology.ts
@@ -45,10 +45,19 @@ export const EDUCATION_STATUS_COMPLETED = '95bc24ff68d148afa6206904da3d5b31';
 export const EDUCATION_STATUS_INCOMPLETE = '99e3e53481334b1aab40fc5a7d232b11';
 
 /** enrolment ──▶ academic field. A relation, so a joint honours degree can repeat it. */
-export const ACADEMIC_FIELDS_PROPERTY = '11692db4ddf54a69bfa044fb6b12f401';
+/**
+ * enrolment ──▶ field of study. A relation, and it repeats for a joint honours.
+ *
+ * Two entities read as "Field of study" and they are not the same thing: this
+ * property (plural, a relation) and {@link LEGACY_FIELD_OF_STUDY_PROPERTY}
+ * (singular, free text). The pair is easy to mix up by name, so both are used by
+ * id and never by lookup.
+ */
+export const FIELDS_OF_STUDY_PROPERTY = '11692db4ddf54a69bfa044fb6b12f401';
 
-/** What `Academic fields` may point at — hand straight to `relationValueTypes`. */
-export const ACADEMIC_FIELD_TYPE = SystemIds.ACADEMIC_FIELD_TYPE;
+/** What `Fields of study` may point at — hand straight to `relationValueTypes`. */
+/** Named for the graph, not the SDK — which still calls this one `ACADEMIC_FIELD_TYPE`. */
+export const FIELD_OF_STUDY_TYPE = SystemIds.ACADEMIC_FIELD_TYPE;
 
 /**
  * Types to scope the find-or-create pickers, and to stamp on anything created
@@ -109,9 +118,11 @@ export const END_DATE_PROPERTY = SystemIds.RANK_END_DATE_PROPERTY;
 export const DESCRIPTION_PROPERTY = SystemIds.DESCRIPTION_PROPERTY;
 
 /**
- * Free-text field of study, used by eleven education records predating
- * `Academic fields`. Read only — those strings are the obvious seed for real
- * Academic field entities, but nothing new should be written here.
+ * Free-text field of study, used by eleven education records predating the
+ * relation. Read only — those strings are the obvious seed for real Field of
+ * study entities, but nothing new should be written here.
+ *
+ * Shares a display name with {@link FIELDS_OF_STUDY_PROPERTY}; see the note there.
  */
 export const LEGACY_FIELD_OF_STUDY_PROPERTY = '8c22d2cd3b0a4a9189f0da6027cf5830';
 

--- a/apps/web/core/profile/history-ontology.ts
+++ b/apps/web/core/profile/history-ontology.ts
@@ -123,6 +123,43 @@ export const EMPLOYMENT_TYPE_OPTIONS = [
   { id: '1a0235d7f32e4cff83f9545f01bd96ba', name: 'Seasonal' },
 ] as const;
 
+/**
+ * Where the role was held, and how.
+ *
+ * Seven properties are named `Location` and three `Location type`; these are the
+ * ones the graph actually uses — 676 relations and 16 against nothing at all for
+ * the rest. Both hang off the tenure beside the dates, because a job moves city
+ * and goes remote without becoming a different job.
+ *
+ * `Location` points at a place rather than holding text, so "San Francisco" is
+ * the same San Francisco everyone else means.
+ */
+export const LOCATION_PROPERTY = '95d770021faf4f7cb7deb21a7d48cda0';
+export const LOCATION_TYPE_PROPERTY = 'ceeb611101554764bea22818b21d3fbd';
+
+/** What `Location` declares it points at. Address is deliberately left out — a
+ * job is held in a city, not at a street number. */
+export const PLACE_TYPE = '783bc688e65f4e54b67fa5643d78345e';
+export const CITY_TYPE = '01b05333941a4b00bc78fac5a15b467d';
+export const REGION_TYPE = 'c188844a722442abb4762991c9c913f1';
+export const COUNTRY_TYPE = '42a0a7618c82459fad0834bfeb437cde';
+export const LOCATION_TYPES = [CITY_TYPE, REGION_TYPE, COUNTRY_TYPE, PLACE_TYPE];
+
+/**
+ * Remote, Onsite and Hybrid — one set, though only the first two have ever been
+ * used. All three sit in the same space with descriptions that read as a set
+ * ("Position combines remote and onsite work"), and none of them is typed, which
+ * is why they cannot be found by type the way employment types can.
+ *
+ * Verified against the graph on 2026-09-11. Note the spelling: `Onsite`, not
+ * `On-site`.
+ */
+export const LOCATION_TYPE_OPTIONS = [
+  { id: '19db5058ae4849e79fd698f46b6beae4', name: 'Onsite' },
+  { id: '18022953fd99439e8feb55e50241dac0', name: 'Hybrid' },
+  { id: '8f5e23aa70394ea4b7946fa0a9878da7', name: 'Remote' },
+] as const;
+
 /** tenure ──▶ skill. A relation, and it repeats. */
 export const SKILLS_PROPERTY = ContentIds.SKILLS_PROPERTY;
 export const SKILL_TYPE = ContentIds.SKILL_TYPE;

--- a/apps/web/core/profile/history-ontology.ts
+++ b/apps/web/core/profile/history-ontology.ts
@@ -75,11 +75,28 @@ export const EMPLOYER_TYPE = SystemIds.PROJECT_TYPE;
 export const JOB_TYPE = 'e4e366e9d5554b6892bf7358e824afd2';
 
 /**
- * What `Roles` declares its *relation* entity is — the tenure. Typing it is what
- * lets anything else find a tenure by its type; an untyped one is reachable only
- * by walking in from the person who holds it.
+ * The four levels' relation-entity types, each declared by the property that
+ * carries it: person ─Employment▶ company, whose entity is the *employment
+ * record*, which ─Roles▶ a title, whose entity is the *role information*. The
+ * education branch mirrors it exactly.
+ *
+ * Typing them is what lets anything else find one by its type. Untyped, a tenure
+ * is reachable only by walking in from the person holding it, which is how the
+ * dates on it stayed invisible to everything but this modal.
+ *
+ * Verified against the graph on 2026-09-12.
  */
+export const EMPLOYMENT_RECORD_TYPE = '8ff1f25ffa814dc292171ecee721ee17';
 export const ROLE_INFORMATION_TYPE = '343952488d4a4bc088aae611b931ac0e';
+export const EDUCATION_RECORD_TYPE = '333d23cc8a0244e6a3d00c8414429164';
+export const DEGREE_INFORMATION_TYPE = '45ecd803515d43fd8b2e529bdac330a9';
+
+/**
+ * A mark on the enrolment — a GPA, a classification, whatever the institution
+ * gave. Decimal, so it is a number rather than the string somebody would
+ * otherwise type into a description.
+ */
+export const GRADE_PROPERTY = 'efa26e09c19b4ef9b3bd9698ad5d3abf';
 
 /**
  * Dates. The SDK names these `RANK_*` after the first thing that used them, but

--- a/apps/web/core/profile/history-ontology.ts
+++ b/apps/web/core/profile/history-ontology.ts
@@ -82,6 +82,37 @@ export const DESCRIPTION_PROPERTY = SystemIds.DESCRIPTION_PROPERTY;
  */
 export const LEGACY_FIELD_OF_STUDY_PROPERTY = '8c22d2cd3b0a4a9189f0da6027cf5830';
 
+/** tenure ──▶ Full-time | Part-time | … */
+export const EMPLOYMENT_TYPE_PROPERTY = '53a98633a2db40be9f161a4c9da37970';
+export const EMPLOYMENT_TYPE_TYPE = 'f503bfd283d74e1a9b30294fff9d2d7e';
+
+/**
+ * The LinkedIn set, published to Geo separately from this work and verified
+ * against the graph on 2026-09-11 — all eight resolve, with these names.
+ *
+ * Worth knowing when reading the graph rather than writing it: six *other*
+ * entities named "Full-time" are also typed `Employment type`, alongside a
+ * "Temporary" and an unnamed one. These eight are the set this modal offers;
+ * older records may point at any of the others.
+ */
+export const EMPLOYMENT_TYPE_OPTIONS = [
+  { id: 'f4a86b892f094d97894c4bfedd150c30', name: 'Full-time' },
+  { id: '5758c248068e44838da7e22109d9993f', name: 'Part-time' },
+  { id: '00f2a3b854f949c7b9f8a1e46872cbcc', name: 'Self-employed' },
+  { id: '75839ffa17ef4d20b4e0621a4780030d', name: 'Freelance' },
+  { id: '80d15f0e3b4f4288b69a1bcb5c3e4a0b', name: 'Contract' },
+  { id: '6eaed80c39b144f48e31dabf409a0722', name: 'Internship' },
+  { id: '946a5333fa084b2aac0c8d89a97b431c', name: 'Apprenticeship' },
+  { id: '1a0235d7f32e4cff83f9545f01bd96ba', name: 'Seasonal' },
+] as const;
+
+/** tenure ──▶ skill. A relation, and it repeats. */
+export const SKILLS_PROPERTY = ContentIds.SKILLS_PROPERTY;
+export const SKILL_TYPE = ContentIds.SKILL_TYPE;
+
+/** What the avatar of a company or school is stored under. */
+export const AVATAR_PROPERTY = ContentIds.AVATAR_PROPERTY;
+
 export type EmploymentStatus = 'current' | 'former';
 export type EducationStatus = 'studying' | 'completed' | 'incomplete';
 

--- a/apps/web/core/profile/history-ontology.ts
+++ b/apps/web/core/profile/history-ontology.ts
@@ -1,0 +1,98 @@
+import { ContentIds, SystemIds } from '@geoprotocol/geo-sdk/lite';
+
+/**
+ * The ontology behind Work and Education on a profile (GEO-2858).
+ *
+ * Every id below was read back from the graph before being written down —
+ * `entities(filter: { id: { in: [...] } }) { id name }` on 2026-09-10 — rather
+ * than copied on trust. A wrong id here writes a relation nobody can read.
+ *
+ * The shape is three levels deep, and the middle level is the part that is easy
+ * to miss: a relation carries an entity of its own (`relation.entityId`), and
+ * that entity is what the next level hangs off.
+ *
+ *   person ──Employment──▶ company
+ *              └─ stint = the Employment relation's own entity
+ *                   └─ ──Roles──▶ job title
+ *                          └─ tenure = the Roles relation's own entity
+ *                               ├─ Employment status ──▶ Current | Former
+ *                               ├─ Start date, End date, Description
+ *
+ * One Employment edge per company, with every role held there hanging off it.
+ * That is what lets a promotion read as two dated rows under one employer.
+ */
+
+/** person ──▶ company. Its entity is the stint. */
+export const EMPLOYMENT_PROPERTY = 'a2fae35bac864a568b26e69643c68d9d';
+
+/** stint ──▶ job title. Its entity is the tenure. Already exported by the SDK. */
+export const ROLES_PROPERTY = ContentIds.ROLES_PROPERTY;
+
+/** tenure ──▶ Current | Former. */
+export const EMPLOYMENT_STATUS_PROPERTY = '3415e3537e0542099bffe07755fa004f';
+export const EMPLOYMENT_STATUS_CURRENT = '3830b07bfa7f487d87a5374aa0dc3253';
+export const EMPLOYMENT_STATUS_FORMER = 'f73b23c396d7493293eb8d3f55352284';
+
+/** person ──▶ school. Its entity is the record. */
+export const EDUCATION_PROPERTY = 'dbb41bb9f76f4e5e866590086857fa22';
+
+/** record ──▶ degree. Its entity is the enrolment. Singular, unlike Roles. */
+export const DEGREE_PROPERTY = '38344c504261406496db13504579e64f';
+
+/** enrolment ──▶ Completed | Incomplete. */
+export const EDUCATION_STATUS_PROPERTY = 'afff0f059654466e865448d56585a41c';
+export const EDUCATION_STATUS_COMPLETED = '95bc24ff68d148afa6206904da3d5b31';
+export const EDUCATION_STATUS_INCOMPLETE = '99e3e53481334b1aab40fc5a7d232b11';
+
+/** enrolment ──▶ academic field. A relation, so a joint honours degree can repeat it. */
+export const ACADEMIC_FIELDS_PROPERTY = '11692db4ddf54a69bfa044fb6b12f401';
+
+/** What `Academic fields` may point at — hand straight to `relationValueTypes`. */
+export const ACADEMIC_FIELD_TYPE = SystemIds.ACADEMIC_FIELD_TYPE;
+
+/**
+ * Dates. The SDK names these `RANK_*` after the first thing that used them, but
+ * they are the graph's general-purpose Start date / End date properties — the
+ * repo already aliases them a second time in `ranking-block-ids.ts`.
+ */
+export const START_DATE_PROPERTY = SystemIds.RANK_START_DATE_PROPERTY;
+export const END_DATE_PROPERTY = SystemIds.RANK_END_DATE_PROPERTY;
+
+export const DESCRIPTION_PROPERTY = SystemIds.DESCRIPTION_PROPERTY;
+
+/**
+ * Free-text field of study, used by eleven education records predating
+ * `Academic fields`. Read only — those strings are the obvious seed for real
+ * Academic field entities, but nothing new should be written here.
+ */
+export const LEGACY_FIELD_OF_STUDY_PROPERTY = '8c22d2cd3b0a4a9189f0da6027cf5830';
+
+export type EmploymentStatus = 'current' | 'former';
+export type EducationStatus = 'studying' | 'completed' | 'incomplete';
+
+export const EMPLOYMENT_STATUS_OPTION: Record<EmploymentStatus, string> = {
+  current: EMPLOYMENT_STATUS_CURRENT,
+  former: EMPLOYMENT_STATUS_FORMER,
+};
+
+/**
+ * `studying` is deliberately absent. The graph has no "in progress" option, and
+ * inventing one is worse than leaving it unsaid — so still-studying writes no
+ * status at all and simply leaves End date empty.
+ */
+export const EDUCATION_STATUS_OPTION: Partial<Record<EducationStatus, string>> = {
+  completed: EDUCATION_STATUS_COMPLETED,
+  incomplete: EDUCATION_STATUS_INCOMPLETE,
+};
+
+export function employmentStatusFromOptionId(id: string | null | undefined): EmploymentStatus | null {
+  if (id === EMPLOYMENT_STATUS_CURRENT) return 'current';
+  if (id === EMPLOYMENT_STATUS_FORMER) return 'former';
+  return null;
+}
+
+export function educationStatusFromOptionId(id: string | null | undefined): EducationStatus | null {
+  if (id === EDUCATION_STATUS_COMPLETED) return 'completed';
+  if (id === EDUCATION_STATUS_INCOMPLETE) return 'incomplete';
+  return null;
+}

--- a/apps/web/core/profile/history-ontology.ts
+++ b/apps/web/core/profile/history-ontology.ts
@@ -58,7 +58,11 @@ export const ACADEMIC_FIELD_TYPE = SystemIds.ACADEMIC_FIELD_TYPE;
  * apiece under those names with no obvious canonical one, so those two pickers
  * search unscoped rather than guess an id — a wrong type here is worse than none.
  */
-export const COMPANY_TYPE = SystemIds.COMPANY_TYPE;
+/**
+ * What an Employment edge points at. `Project` rather than `Company`: the graph
+ * models the thing you were employed on, and plenty of them are not companies.
+ */
+export const EMPLOYER_TYPE = SystemIds.PROJECT_TYPE;
 export const JOB_TYPE = ContentIds.JOB_TYPE;
 
 /**

--- a/apps/web/core/profile/history-ontology.ts
+++ b/apps/web/core/profile/history-ontology.ts
@@ -54,9 +54,8 @@ export const ACADEMIC_FIELD_TYPE = SystemIds.ACADEMIC_FIELD_TYPE;
  * Types to scope the find-or-create pickers, and to stamp on anything created
  * through them so the next person finds it instead of making a second one.
  *
- * Only those that could be verified. Degree still searches unscoped: several
- * entities sit under that name with no obvious canonical one, and a wrong type
- * there is worse than none.
+ * Taken from what each property declares rather than from the name that reads
+ * best — see `JOB_TYPE` for what guessing cost the last time.
  */
 /**
  * What an Employment edge points at. `Project` rather than `Company`: the graph
@@ -206,6 +205,25 @@ export const TAXONOMY_SPACE_ID = 'd69608290513c2a91102c939b3265bd7';
  * either alone hides most of the answers, and a new school is typed as both so
  * it turns up whichever one the next reader scopes to.
  */
+/**
+ * What `Degree` declares it points at, and what a degree created here is typed as.
+ */
+export const DEGREE_TYPE = 'bfd47a5430aa43e18b8b8b86735919a0';
+
+/**
+ * A second entity also named `Degree`, also a real type, carrying 29 degrees the
+ * graph had before the declared one existed — Ph.D., Master, Bachelor, B.S.
+ *
+ * Searched alongside the declared type rather than instead of it. Scoping to the
+ * declared one alone is the correct-looking choice that hides every degree
+ * anybody has actually used, which is the mistake the Title picker made against
+ * `Job` for a fortnight. New degrees are still typed as the declared one, so the
+ * split narrows rather than widens.
+ */
+export const LEGACY_DEGREE_TYPE = '65256c5462834981b502aceeb74bd08c';
+
+export const DEGREE_TYPES = [DEGREE_TYPE, LEGACY_DEGREE_TYPE];
+
 export const UNIVERSITY_TYPE = '0235f3d2821947a481d39ccd68e2b821';
 export const INSTITUTION_TYPE = '7f5433a40628498f9de6311cb14709a8';
 export const SCHOOL_TYPES = [UNIVERSITY_TYPE, INSTITUTION_TYPE];

--- a/apps/web/core/profile/history-ontology.ts
+++ b/apps/web/core/profile/history-ontology.ts
@@ -63,7 +63,24 @@ export const ACADEMIC_FIELD_TYPE = SystemIds.ACADEMIC_FIELD_TYPE;
  * models the thing you were employed on, and plenty of them are not companies.
  */
 export const EMPLOYER_TYPE = SystemIds.PROJECT_TYPE;
-export const JOB_TYPE = ContentIds.JOB_TYPE;
+
+/**
+ * What a Roles relation points at, taken from what the property itself declares
+ * rather than from the name that reads best.
+ *
+ * `Roles` declares `To entity types: Person role`, and the graph agrees: 4,014
+ * entities carry that type against 32 carrying `Job`. The picker searched `Job`
+ * until this was checked, which is why typing a real job title returned three
+ * hand-entered rows and none of the 2,905 occupations the ESCO import added.
+ */
+export const JOB_TYPE = 'e4e366e9d5554b6892bf7358e824afd2';
+
+/**
+ * What `Roles` declares its *relation* entity is — the tenure. Typing it is what
+ * lets anything else find a tenure by its type; an untyped one is reachable only
+ * by walking in from the person who holds it.
+ */
+export const ROLE_INFORMATION_TYPE = '343952488d4a4bc088aae611b931ac0e';
 
 /**
  * Dates. The SDK names these `RANK_*` after the first thing that used them, but
@@ -109,6 +126,26 @@ export const EMPLOYMENT_TYPE_OPTIONS = [
 /** tenure ──▶ skill. A relation, and it repeats. */
 export const SKILLS_PROPERTY = ContentIds.SKILLS_PROPERTY;
 export const SKILL_TYPE = ContentIds.SKILL_TYPE;
+
+/**
+ * The ESCO occupation taxonomy, which hangs off the same `Skills` property a
+ * tenure uses: role ──Skills──▶ skill, 112,114 of them across 2,905 occupations.
+ *
+ * Two things sit off to the side of that edge, and both are needed to recommend
+ * anything worth reading. Whether a skill is essential to the role is on the
+ * relation's own entity — not on the role, and not on the skill. How widely the
+ * skill transfers is on the skill, one hop further out, as a `Skill scope`
+ * pointing at one of four ranked entities.
+ *
+ * Rank is what separates a useful suggestion from a merely true one: in live
+ * data `troubleshoot` is essential to 236 occupations, so a list topped by it is
+ * accurate and tells the reader nothing.
+ *
+ * Verified against the graph on 2026-09-11.
+ */
+export const IS_REQUIRED_PROPERTY = '3d60051c488f4a5ebae67a8264ade8bd';
+export const SKILL_SCOPE_PROPERTY = '7426f8535dc84776bd7abce1d069fa06';
+export const SCOPE_RANK_PROPERTY = '3ae1e15935864c0f9425652125d03772';
 
 /** What the avatar of a company or school is stored under. */
 export const AVATAR_PROPERTY = ContentIds.AVATAR_PROPERTY;

--- a/apps/web/core/profile/history-ontology.ts
+++ b/apps/web/core/profile/history-ontology.ts
@@ -197,15 +197,6 @@ export const SCOPE_RANK_PROPERTY = '3ae1e15935864c0f9425652125d03772';
 export const TAXONOMY_SPACE_ID = 'd69608290513c2a91102c939b3265bd7';
 
 /**
- * What the School picker searches, and what it types a school it creates as.
- *
- * `Education` declares `To entity types: Institution`, which is the broader of
- * the two and has 108 entities behind it; `University` has 10 and is what
- * someone filling in a school is usually naming. Both, therefore — searching
- * either alone hides most of the answers, and a new school is typed as both so
- * it turns up whichever one the next reader scopes to.
- */
-/**
  * What `Degree` declares it points at, and what a degree created here is typed as.
  */
 export const DEGREE_TYPE = 'bfd47a5430aa43e18b8b8b86735919a0';
@@ -224,9 +215,20 @@ export const LEGACY_DEGREE_TYPE = '65256c5462834981b502aceeb74bd08c';
 
 export const DEGREE_TYPES = [DEGREE_TYPE, LEGACY_DEGREE_TYPE];
 
+/**
+ * What the School picker searches, and what it types a school it creates as.
+ *
+ * `Education` still declares `Institution`, and the schools on profiles today are
+ * typed Project or Institution rather than this — the ontology is being moved onto
+ * this id deliberately and those records migrated behind it.
+ *
+ * Written against the id, not the name: the entity may be renamed to
+ * `Institution`, which would not make it a different type. Until the migration
+ * lands the picker finds the twelve schools already carrying it, plus whatever is
+ * created here.
+ */
 export const UNIVERSITY_TYPE = '0235f3d2821947a481d39ccd68e2b821';
-export const INSTITUTION_TYPE = '7f5433a40628498f9de6311cb14709a8';
-export const SCHOOL_TYPES = [UNIVERSITY_TYPE, INSTITUTION_TYPE];
+export const SCHOOL_TYPES = [UNIVERSITY_TYPE];
 
 /** What the avatar of a company or school is stored under. */
 export const AVATAR_PROPERTY = ContentIds.AVATAR_PROPERTY;

--- a/apps/web/core/profile/normalize-history.test.ts
+++ b/apps/web/core/profile/normalize-history.test.ts
@@ -1,0 +1,255 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  ACADEMIC_FIELDS_PROPERTY,
+  DEGREE_PROPERTY,
+  DESCRIPTION_PROPERTY,
+  EDUCATION_STATUS_COMPLETED,
+  EDUCATION_STATUS_PROPERTY,
+  EMPLOYMENT_STATUS_CURRENT,
+  EMPLOYMENT_STATUS_FORMER,
+  EMPLOYMENT_STATUS_PROPERTY,
+  END_DATE_PROPERTY,
+  LEGACY_FIELD_OF_STUDY_PROPERTY,
+  ROLES_PROPERTY,
+  START_DATE_PROPERTY,
+} from './history-ontology';
+import {
+  type HistoryEdgeNode,
+  type HistoryRelationNode,
+  type HistoryValueNode,
+  normalizeEducation,
+  normalizeEmployment,
+} from './normalize-history';
+
+const dateValue = (propertyId: string, date: string): HistoryValueNode => ({
+  property: { id: propertyId },
+  date,
+  text: null,
+});
+
+const textValue = (propertyId: string, text: string): HistoryValueNode => ({
+  property: { id: propertyId },
+  date: null,
+  text,
+});
+
+const statusRelation = (propertyId: string, optionId: string): HistoryRelationNode => ({
+  id: `status-${optionId}`,
+  entityId: `status-entity-${optionId}`,
+  type: { id: propertyId },
+  toEntity: { id: optionId, name: null },
+  entity: null,
+});
+
+// `propertyId` is typed rather than inferred: the SDK brands its ids, so taking
+// the default's type would reject the plain-string constants defined here.
+const role = (
+  name: string,
+  tenure: { values?: HistoryValueNode[]; relations?: HistoryRelationNode[] } = {},
+  propertyId: string = ROLES_PROPERTY
+): HistoryRelationNode => ({
+  id: `rel-${name}`,
+  entityId: `tenure-${name}`,
+  type: { id: propertyId },
+  toEntity: { id: `subject-${name}`, name },
+  entity: { valuesList: tenure.values ?? [], relationsList: tenure.relations ?? [] },
+});
+
+const edge = (
+  org: string,
+  stint: { values?: HistoryValueNode[]; relations?: HistoryRelationNode[] }
+): HistoryEdgeNode => ({
+  id: `edge-${org}`,
+  entityId: `stint-${org}`,
+  toEntity: { id: `org-${org}`, name: org },
+  entity: { valuesList: stint.values ?? [], relationsList: stint.relations ?? [] },
+});
+
+describe('normalizeEmployment', () => {
+  it('reads a role’s dates and status from its own tenure', () => {
+    const [card] = normalizeEmployment([
+      edge('Geo', {
+        relations: [
+          role('Product Lead', {
+            values: [dateValue(START_DATE_PROPERTY, '2024-01-01Z')],
+            relations: [statusRelation(EMPLOYMENT_STATUS_PROPERTY, EMPLOYMENT_STATUS_CURRENT)],
+          }),
+        ],
+      }),
+    ]);
+
+    expect(card.organization.name).toBe('Geo');
+    expect(card.entries).toHaveLength(1);
+    expect(card.entries[0]).toMatchObject({
+      subject: { name: 'Product Lead' },
+      startDate: '2024-01-01Z',
+      endDate: null,
+      status: 'current',
+      isLegacy: false,
+    });
+  });
+
+  // The promotion case, and the whole reason for one Employment edge per company.
+  it('keeps two roles at one company under a single card', () => {
+    const [card] = normalizeEmployment([
+      edge('Geo', {
+        relations: [
+          role('Engineer', {
+            values: [dateValue(START_DATE_PROPERTY, '2022-06-01Z'), dateValue(END_DATE_PROPERTY, '2024-01-01Z')],
+            relations: [statusRelation(EMPLOYMENT_STATUS_PROPERTY, EMPLOYMENT_STATUS_FORMER)],
+          }),
+          role('Product Lead', {
+            values: [dateValue(START_DATE_PROPERTY, '2024-01-01Z')],
+            relations: [statusRelation(EMPLOYMENT_STATUS_PROPERTY, EMPLOYMENT_STATUS_CURRENT)],
+          }),
+        ],
+      }),
+    ]);
+
+    // The role still held sorts above the one that ended.
+    expect(card.entries.map(entry => entry.subject.name)).toEqual(['Product Lead', 'Engineer']);
+  });
+
+  // Modelled on stint 333463c7 in the graph: Start date, Description and status
+  // all sit on the stint, and both tenures are empty.
+  it('falls back to the stint for records written before this shape', () => {
+    const [card] = normalizeEmployment([
+      edge('World Labs', {
+        values: [
+          dateValue(START_DATE_PROPERTY, '2024-01-01Z'),
+          textValue(DESCRIPTION_PROPERTY, 'Co-founded a spatial intelligence company.'),
+        ],
+        relations: [
+          statusRelation(EMPLOYMENT_STATUS_PROPERTY, EMPLOYMENT_STATUS_CURRENT),
+          role('CEO'),
+          role('Co-founder'),
+        ],
+      }),
+    ]);
+
+    expect(card.entries).toHaveLength(2);
+    for (const entry of card.entries) {
+      expect(entry).toMatchObject({
+        startDate: '2024-01-01Z',
+        status: 'current',
+        description: 'Co-founded a spatial intelligence company.',
+        isLegacy: true,
+      });
+    }
+  });
+
+  // Without this, a role held now — a real start and a deliberately empty end —
+  // would look indistinguishable from an unstructured one and adopt the stint's.
+  it('does not treat an open role as legacy', () => {
+    const [card] = normalizeEmployment([
+      edge('Geo', {
+        values: [dateValue(START_DATE_PROPERTY, '2019-01-01Z')],
+        relations: [role('Product Lead', { values: [dateValue(START_DATE_PROPERTY, '2024-01-01Z')] })],
+      }),
+    ]);
+
+    expect(card.entries[0]).toMatchObject({ startDate: '2024-01-01Z', endDate: null, isLegacy: false });
+  });
+
+  it('reads a company with no roles yet as a card with no rows', () => {
+    const [card] = normalizeEmployment([edge('Apple', {})]);
+
+    expect(card.organization.name).toBe('Apple');
+    expect(card.entries).toEqual([]);
+  });
+
+  it('ignores relations on the stint that are not roles', () => {
+    const [card] = normalizeEmployment([
+      edge('Geo', { relations: [statusRelation(EMPLOYMENT_STATUS_PROPERTY, EMPLOYMENT_STATUS_CURRENT)] }),
+    ]);
+
+    expect(card.entries).toEqual([]);
+  });
+});
+
+describe('normalizeEducation', () => {
+  it('reads a degree with its fields and status', () => {
+    const [card] = normalizeEducation([
+      edge('Northumbria University', {
+        relations: [
+          role(
+            'Ph.D.',
+            {
+              values: [dateValue(START_DATE_PROPERTY, '2022-09-01Z')],
+              relations: [
+                statusRelation(EDUCATION_STATUS_PROPERTY, EDUCATION_STATUS_COMPLETED),
+                {
+                  id: 'field-finance',
+                  entityId: 'field-entity',
+                  type: { id: ACADEMIC_FIELDS_PROPERTY },
+                  toEntity: { id: 'finance', name: 'Finance' },
+                  entity: null,
+                },
+              ],
+            },
+            DEGREE_PROPERTY
+          ),
+        ],
+      }),
+    ]);
+
+    expect(card.entries[0]).toMatchObject({
+      subject: { name: 'Ph.D.' },
+      status: 'completed',
+      fields: [{ id: 'finance', name: 'Finance' }],
+    });
+  });
+
+  // Eleven records keep the discipline as free text from before `Academic fields`
+  // existed. Surfaced so they render, but they are not a second way to store one.
+  it('surfaces a legacy text field of study when there is no relation', () => {
+    const [card] = normalizeEducation([
+      edge('Northumbria University', {
+        values: [textValue(LEGACY_FIELD_OF_STUDY_PROPERTY, 'Computer Science')],
+        relations: [role('B.Sc.', {}, DEGREE_PROPERTY)],
+      }),
+    ]);
+
+    expect(card.entries[0].fields).toEqual([{ id: '', name: 'Computer Science' }]);
+  });
+
+  it('prefers real Academic field relations over the legacy text', () => {
+    const [card] = normalizeEducation([
+      edge('Northumbria University', {
+        values: [textValue(LEGACY_FIELD_OF_STUDY_PROPERTY, 'Computer Science')],
+        relations: [
+          role(
+            'B.Sc.',
+            {
+              relations: [
+                {
+                  id: 'field-cs',
+                  entityId: 'field-entity',
+                  type: { id: ACADEMIC_FIELDS_PROPERTY },
+                  toEntity: { id: 'cs', name: 'Computing' },
+                  entity: null,
+                },
+              ],
+            },
+            DEGREE_PROPERTY
+          ),
+        ],
+      }),
+    ]);
+
+    expect(card.entries[0].fields).toEqual([{ id: 'cs', name: 'Computing' }]);
+  });
+
+  // Still studying is the absence of a status, not a status of its own.
+  it('reads a degree with no status as still studying rather than guessing', () => {
+    const [card] = normalizeEducation([
+      edge('Northumbria University', {
+        relations: [role('M.Sc.', { values: [dateValue(START_DATE_PROPERTY, '2020-09-01Z')] }, DEGREE_PROPERTY)],
+      }),
+    ]);
+
+    expect(card.entries[0].status).toBeNull();
+    expect(card.entries[0].endDate).toBeNull();
+  });
+});

--- a/apps/web/core/profile/normalize-history.test.ts
+++ b/apps/web/core/profile/normalize-history.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
 import {
-  ACADEMIC_FIELDS_PROPERTY,
   DEGREE_PROPERTY,
   DESCRIPTION_PROPERTY,
   EDUCATION_STATUS_COMPLETED,
@@ -10,6 +9,7 @@ import {
   EMPLOYMENT_STATUS_FORMER,
   EMPLOYMENT_STATUS_PROPERTY,
   END_DATE_PROPERTY,
+  FIELDS_OF_STUDY_PROPERTY,
   LEGACY_FIELD_OF_STUDY_PROPERTY,
   ROLES_PROPERTY,
   START_DATE_PROPERTY,
@@ -185,7 +185,7 @@ describe('normalizeEducation', () => {
                 {
                   id: 'field-finance',
                   entityId: 'field-entity',
-                  type: { id: ACADEMIC_FIELDS_PROPERTY },
+                  type: { id: FIELDS_OF_STUDY_PROPERTY },
                   toEntity: { id: 'finance', name: 'Finance' },
                   entity: null,
                 },
@@ -204,7 +204,7 @@ describe('normalizeEducation', () => {
     });
   });
 
-  // Eleven records keep the discipline as free text from before `Academic fields`
+  // Eleven records keep the discipline as free text from before `Fields of study`
   // existed. Surfaced so they render, but they are not a second way to store one.
   it('surfaces a legacy text field of study when there is no relation', () => {
     const [card] = normalizeEducation([
@@ -217,7 +217,7 @@ describe('normalizeEducation', () => {
     expect(card.entries[0].fields).toEqual([{ id: '', name: 'Computer Science' }]);
   });
 
-  it('prefers real Academic field relations over the legacy text', () => {
+  it('prefers real Field of study relations over the legacy text', () => {
     const [card] = normalizeEducation([
       edge('Northumbria University', {
         values: [textValue(LEGACY_FIELD_OF_STUDY_PROPERTY, 'Computer Science')],
@@ -229,7 +229,7 @@ describe('normalizeEducation', () => {
                 {
                   id: 'field-cs',
                   entityId: 'field-entity',
-                  type: { id: ACADEMIC_FIELDS_PROPERTY },
+                  type: { id: FIELDS_OF_STUDY_PROPERTY },
                   toEntity: { id: 'cs', name: 'Computing' },
                   entity: null,
                 },

--- a/apps/web/core/profile/normalize-history.test.ts
+++ b/apps/web/core/profile/normalize-history.test.ts
@@ -22,6 +22,9 @@ import {
   normalizeEmployment,
 } from './normalize-history';
 
+const NAME_PROPERTY = 'a126ca530c8e48d5b88882c734c38935';
+const IPFS_URL_PROPERTY = '8a743832c0944a62b6650c3cc2f9c7bc';
+
 const dateValue = (propertyId: string, date: string): HistoryValueNode => ({
   property: { id: propertyId },
   date,
@@ -251,5 +254,68 @@ describe('normalizeEducation', () => {
 
     expect(card.entries[0].status).toBeNull();
     expect(card.entries[0].endDate).toBeNull();
+  });
+});
+
+describe('one card per organisation', () => {
+  // Two Employment edges to one company, which is what an older version of the
+  // modal wrote and what any other tool is free to write. Two cards for one
+  // employer is a rendering fault to the person looking at their own profile.
+  it('folds a second edge to the same employer into one card', () => {
+    const cards = normalizeEmployment([
+      edge('Geo', {
+        relations: [role('Product Manager', { values: [dateValue(START_DATE_PROPERTY, '2026-07-01Z')] })],
+      }),
+      { ...edge('Geo', { relations: [role('Senior Product Designer')] }), id: 'edge-Geo-2', entityId: 'stint-Geo-2' },
+    ]);
+
+    expect(cards).toHaveLength(1);
+    expect(cards[0].entries.map(entry => entry.subject.name)).toEqual(['Product Manager', 'Senior Product Designer']);
+    expect(cards[0].edges.map(cardEdge => cardEdge.stintId)).toEqual(['stint-Geo', 'stint-Geo-2']);
+  });
+
+  // Removing a row has to know which of the employer's edges it hung off, since
+  // a sibling under the other one cannot keep this one alive.
+  it('tells each row which edge it hangs off', () => {
+    const cards = normalizeEmployment([
+      edge('Geo', { relations: [role('Product Manager')] }),
+      { ...edge('Geo', { relations: [role('Designer')] }), id: 'edge-Geo-2', entityId: 'stint-Geo-2' },
+    ]);
+
+    const byName = Object.fromEntries(cards[0].entries.map(entry => [entry.subject.name, entry.edge.stintId]));
+    expect(byName).toEqual({ 'Product Manager': 'stint-Geo', Designer: 'stint-Geo-2' });
+  });
+
+  it('keeps two different employers apart', () => {
+    const cards = normalizeEmployment([
+      edge('Geo', { relations: [role('Product Manager')] }),
+      edge('Coinbase', { relations: [role('Data Analyst')] }),
+    ]);
+
+    expect(cards.map(card => card.organization.name)).toEqual(['Geo', 'Coinbase']);
+  });
+});
+
+describe('the organisation avatar', () => {
+  const withImage = (org: string, values: HistoryValueNode[]): HistoryEdgeNode => ({
+    ...edge(org, { relations: [role('Engineer')] }),
+    toEntity: { id: `org-${org}`, name: org, relationsList: [{ toEntity: { valuesList: values } }] },
+  });
+
+  // An image entity carries its own name and a couple of dimensions beside the
+  // URL. Taking the first value that held a string picked "Geo avatar" and
+  // rendered nothing at all.
+  it('reads the URL rather than the image entity’s name', () => {
+    const cards = normalizeEmployment([
+      withImage('Geo', [textValue(NAME_PROPERTY, 'Geo avatar'), textValue(IPFS_URL_PROPERTY, 'ipfs://bafyavatar')]),
+    ]);
+
+    expect(cards[0].avatarUrl).toBe('ipfs://bafyavatar');
+  });
+
+  it('has none where the image entity holds no URL', () => {
+    const cards = normalizeEmployment([withImage('Geo', [textValue(NAME_PROPERTY, 'Geo avatar')])]);
+
+    expect(cards[0].avatarUrl).toBeNull();
   });
 });

--- a/apps/web/core/profile/normalize-history.ts
+++ b/apps/web/core/profile/normalize-history.ts
@@ -23,6 +23,7 @@ import {
 
 /** Shapes as they come back from the graph; see `fetch-profile-history.ts`. */
 export type HistoryValueNode = {
+  id?: string;
   property: { id: string };
   date: string | null;
   text: string | null;
@@ -48,8 +49,32 @@ export type HistoryEdgeNode = {
 
 export type NamedRef = { id: string; name: string | null };
 
+/**
+ * Everything hanging off a relation's own entity.
+ *
+ * Deleting the relation does not touch any of it — the store marks one row
+ * deleted and nothing else — so removing a position has to name each of these or
+ * leave the dates, the description and the skills behind as an entity nothing can
+ * reach.
+ */
+export type Subtree = {
+  relationIds: string[];
+  /**
+   * Both halves, because deleting a value publishes an `unset` keyed on the
+   * property — the row id alone names the row but not what to clear.
+   */
+  values: { id: string; propertyId: string }[];
+};
+
+const readSubtree = (entity: { valuesList: HistoryValueNode[]; relationsList: HistoryRelationNode[] } | null) => ({
+  relationIds: (entity?.relationsList ?? []).map(relation => relation.id),
+  values: (entity?.valuesList ?? [])
+    .filter((value): value is HistoryValueNode & { id: string } => Boolean(value.id))
+    .map(value => ({ id: value.id, propertyId: value.property.id })),
+});
+
 /** One Employment/Education relation and the entity it carries. */
-export type HistoryEdgeRef = { relationId: string; stintId: string };
+export type HistoryEdgeRef = { relationId: string; stintId: string; subtree: Subtree };
 
 /** One dated row under an organisation — a role held, or a degree read. */
 export type HistoryEntry = {
@@ -62,6 +87,8 @@ export type HistoryEntry = {
    * than per card because one employer can have several edges — see the card.
    */
   edge: HistoryEdgeRef;
+  /** What goes with this row when it is removed. */
+  subtree: Subtree;
   subject: NamedRef;
   startDate: string | null;
   endDate: string | null;
@@ -168,6 +195,7 @@ function readEntry(
   return {
     relationId: relation.id,
     tenureId: relation.entityId,
+    subtree: readSubtree(relation.entity),
     subject: relation.toEntity ?? { id: relation.entityId, name: null },
     startDate: isLegacy ? dateFor(stintValues, START_DATE_PROPERTY) : ownStart,
     endDate: isLegacy ? dateFor(stintValues, END_DATE_PROPERTY) : ownEnd,
@@ -211,7 +239,11 @@ function readCards<TEntry extends HistoryEntry>(
   const byOrganization = new Map<string, HistoryCard<TEntry>>();
 
   for (const edge of edges) {
-    const edgeRef: HistoryEdgeRef = { relationId: edge.id, stintId: edge.entityId };
+    const edgeRef: HistoryEdgeRef = {
+      relationId: edge.id,
+      stintId: edge.entityId,
+      subtree: readSubtree(edge.entity),
+    };
     const organization = edge.toEntity ?? { id: edge.entityId, name: null };
     const entries = readEntries(edgeRef, edge.entity?.valuesList ?? [], edge.entity?.relationsList ?? []);
 

--- a/apps/web/core/profile/normalize-history.ts
+++ b/apps/web/core/profile/normalize-history.ts
@@ -206,7 +206,21 @@ function readCards<TEntry extends HistoryEntry>(
     });
   }
 
-  return [...byOrganization.values()];
+  return [...byOrganization.values()].sort(byMostRecentCard);
+}
+
+/**
+ * Employers newest first, by the most recent thing held at each.
+ *
+ * Entries inside a card are already sorted, so the first one speaks for the card:
+ * a current job puts its employer at the top, which is the order a CV is read in
+ * and the order the graph happens to return records in only by accident.
+ */
+export function byMostRecentCard<TEntry extends HistoryEntry>(a: HistoryCard<TEntry>, b: HistoryCard<TEntry>) {
+  const first = a.entries[0];
+  const second = b.entries[0];
+  if (!first || !second) return first ? -1 : second ? 1 : 0;
+  return byMostRecent(first, second);
 }
 
 export function normalizeEmployment(edges: HistoryEdgeNode[]): EmploymentCard[] {
@@ -274,8 +288,13 @@ export function normalizeEducation(edges: HistoryEdgeNode[]): EducationCard[] {
 /**
  * Most recent first, and anything still open ahead of anything ended. A row with
  * no dates at all sorts last rather than jumping the list on an empty string.
+ *
+ * Exported so the pending rows in the modal sort the same way the saved ones do.
+ * They used to sit in the order they were added, so a promotion entered after the
+ * job before it read as the older of the two until the page was saved and
+ * refetched.
  */
-function byMostRecent(a: HistoryEntry, b: HistoryEntry) {
+export function byMostRecent(a: HistoryEntry, b: HistoryEntry) {
   const aOpen = a.startDate !== null && a.endDate === null;
   const bOpen = b.startDate !== null && b.endDate === null;
   if (aOpen !== bOpen) return aOpen ? -1 : 1;

--- a/apps/web/core/profile/normalize-history.ts
+++ b/apps/web/core/profile/normalize-history.ts
@@ -1,3 +1,5 @@
+import { findMediaUrlValue } from '~/core/utils/media-url';
+
 import {
   ACADEMIC_FIELDS_PROPERTY,
   DEGREE_PROPERTY,
@@ -38,12 +40,20 @@ export type HistoryEdgeNode = {
 
 export type NamedRef = { id: string; name: string | null };
 
+/** One Employment/Education relation and the entity it carries. */
+export type HistoryEdgeRef = { relationId: string; stintId: string };
+
 /** One dated row under an organisation — a role held, or a degree read. */
 export type HistoryEntry = {
   /** The Roles/Degree relation, which is what removing this row deletes. */
   relationId: string;
   /** That relation's own entity, which carries the dates and status. */
   tenureId: string;
+  /**
+   * The Employment/Education edge this row hangs off. Carried per row rather
+   * than per card because one employer can have several edges — see the card.
+   */
+  edge: HistoryEdgeRef;
   subject: NamedRef;
   startDate: string | null;
   endDate: string | null;
@@ -65,11 +75,17 @@ export type EducationEntry = HistoryEntry & { status: EducationStatus | null; fi
 
 /** An organisation and everything held there. One card in the resting state. */
 export type HistoryCard<TEntry> = {
-  /** The Employment/Education relation — removing this drops the whole card. */
-  relationId: string;
-  /** Its entity, which every row hangs off. */
-  stintId: string;
   organization: NamedRef;
+  /**
+   * Every Employment/Education edge pointing at this organisation.
+   *
+   * Usually one. More where the same employer was added twice — by an older
+   * version of this modal, by another tool, or by anyone who did not know a
+   * second edge was not wanted. Those read as one employer here regardless,
+   * since two cards for one company is a rendering fault as far as the person
+   * looking at their own profile is concerned.
+   */
+  edges: HistoryEdgeRef[];
   /** The organisation's own avatar, where it has one. */
   avatarUrl?: string | null;
   entries: TEntry[];
@@ -134,92 +150,124 @@ function readEntry(
   };
 }
 
-/** The image entity's URL, which is whichever of its values looks like one. */
+/**
+ * The organisation's avatar, picked the way every other image in the app is.
+ *
+ * Not simply the first value that holds a string: an image entity carries its own
+ * name and a couple of dimensions alongside the URL, so that picked "Geo avatar"
+ * and rendered nothing.
+ */
 function readAvatar(edge: HistoryEdgeNode): string | null {
   for (const relation of edge.toEntity?.relationsList ?? []) {
-    const url = relation.toEntity?.valuesList.find(value => typeof value.text === 'string' && value.text !== '');
-    if (url?.text) return url.text;
+    const values = relation.toEntity?.valuesList ?? [];
+    const url = findMediaUrlValue(values.map(value => ({ value: value.text, property: value.property })));
+    if (url) return url;
   }
   return null;
 }
 
-function readCard<TEntry>(
-  edge: HistoryEdgeNode,
-  readEntries: (stintValues: HistoryValueNode[], stintRelations: HistoryRelationNode[]) => TEntry[]
-): HistoryCard<TEntry> {
-  const stintValues = edge.entity?.valuesList ?? [];
-  const stintRelations = edge.entity?.relationsList ?? [];
+/**
+ * Edges to cards, one card per organisation.
+ *
+ * A second edge to an employer already listed folds into the card that is there
+ * rather than starting another: someone with two roles at one company means one
+ * employer, however many relations happen to record it.
+ */
+function readCards<TEntry extends HistoryEntry>(
+  edges: HistoryEdgeNode[],
+  readEntries: (
+    edgeRef: HistoryEdgeRef,
+    stintValues: HistoryValueNode[],
+    stintRelations: HistoryRelationNode[]
+  ) => TEntry[]
+): HistoryCard<TEntry>[] {
+  const byOrganization = new Map<string, HistoryCard<TEntry>>();
 
-  return {
-    relationId: edge.id,
-    stintId: edge.entityId,
-    organization: edge.toEntity ?? { id: edge.entityId, name: null },
-    avatarUrl: readAvatar(edge),
-    entries: readEntries(stintValues, stintRelations),
-  };
+  for (const edge of edges) {
+    const edgeRef: HistoryEdgeRef = { relationId: edge.id, stintId: edge.entityId };
+    const organization = edge.toEntity ?? { id: edge.entityId, name: null };
+    const entries = readEntries(edgeRef, edge.entity?.valuesList ?? [], edge.entity?.relationsList ?? []);
+
+    const existing = byOrganization.get(organization.id);
+    if (existing) {
+      existing.edges.push(edgeRef);
+      existing.entries = [...existing.entries, ...entries].sort(byMostRecent);
+      // Whichever edge's organisation resolved an image first; they are the same
+      // entity, so the second look adds nothing but can only be emptier.
+      existing.avatarUrl = existing.avatarUrl ?? readAvatar(edge);
+      continue;
+    }
+
+    byOrganization.set(organization.id, {
+      organization,
+      edges: [edgeRef],
+      avatarUrl: readAvatar(edge),
+      entries,
+    });
+  }
+
+  return [...byOrganization.values()];
 }
 
 export function normalizeEmployment(edges: HistoryEdgeNode[]): EmploymentCard[] {
-  return edges.map(edge =>
-    readCard<EmploymentEntry>(edge, (stintValues, stintRelations) =>
-      stintRelations
-        .filter(relation => relation.type.id === ROLES_PROPERTY)
-        .map(relation => {
-          const { statusOptionId, ...entry } = readEntry(
-            relation,
-            stintValues,
-            stintRelations,
-            EMPLOYMENT_STATUS_PROPERTY
-          );
-          const tenureRelations = relation.entity?.relationsList ?? [];
+  return readCards<EmploymentEntry>(edges, (edgeRef, stintValues, stintRelations) =>
+    stintRelations
+      .filter(relation => relation.type.id === ROLES_PROPERTY)
+      .map(relation => {
+        const { statusOptionId, ...entry } = readEntry(
+          relation,
+          stintValues,
+          stintRelations,
+          EMPLOYMENT_STATUS_PROPERTY
+        );
+        const tenureRelations = relation.entity?.relationsList ?? [];
 
-          return {
-            ...entry,
-            status: employmentStatusFromOptionId(statusOptionId),
-            employmentType: relationTo(tenureRelations, EMPLOYMENT_TYPE_PROPERTY),
-            skills: tenureRelations
-              .filter(skill => skill.type.id === SKILLS_PROPERTY)
-              .map(skill => skill.toEntity)
-              .filter((skill): skill is NamedRef => skill !== null),
-          };
-        })
-        .sort(byMostRecent)
-    )
+        return {
+          ...entry,
+          edge: edgeRef,
+          status: employmentStatusFromOptionId(statusOptionId),
+          employmentType: relationTo(tenureRelations, EMPLOYMENT_TYPE_PROPERTY),
+          skills: tenureRelations
+            .filter(skill => skill.type.id === SKILLS_PROPERTY)
+            .map(skill => skill.toEntity)
+            .filter((skill): skill is NamedRef => skill !== null),
+        };
+      })
+      .sort(byMostRecent)
   );
 }
 
 export function normalizeEducation(edges: HistoryEdgeNode[]): EducationCard[] {
-  return edges.map(edge =>
-    readCard<EducationEntry>(edge, (stintValues, stintRelations) =>
-      stintRelations
-        .filter(relation => relation.type.id === DEGREE_PROPERTY)
-        .map(relation => {
-          const { statusOptionId, ...entry } = readEntry(
-            relation,
-            stintValues,
-            stintRelations,
-            EDUCATION_STATUS_PROPERTY
-          );
+  return readCards<EducationEntry>(edges, (edgeRef, stintValues, stintRelations) =>
+    stintRelations
+      .filter(relation => relation.type.id === DEGREE_PROPERTY)
+      .map(relation => {
+        const { statusOptionId, ...entry } = readEntry(
+          relation,
+          stintValues,
+          stintRelations,
+          EDUCATION_STATUS_PROPERTY
+        );
 
-          const enrolmentRelations = relation.entity?.relationsList ?? [];
-          const fields = enrolmentRelations
-            .filter(field => field.type.id === ACADEMIC_FIELDS_PROPERTY)
-            .map(field => field.toEntity)
-            .filter((field): field is NamedRef => field !== null);
+        const enrolmentRelations = relation.entity?.relationsList ?? [];
+        const fields = enrolmentRelations
+          .filter(field => field.type.id === ACADEMIC_FIELDS_PROPERTY)
+          .map(field => field.toEntity)
+          .filter((field): field is NamedRef => field !== null);
 
-          // Eleven records predate `Academic fields` and keep the discipline as
-          // text on the stint. Shown, never written — they are the seed for real
-          // Academic field entities rather than a second way to store one.
-          const legacyField = textFor(stintValues, LEGACY_FIELD_OF_STUDY_PROPERTY);
+        // Eleven records predate `Academic fields` and keep the discipline as
+        // text on the stint. Shown, never written — they are the seed for real
+        // Academic field entities rather than a second way to store one.
+        const legacyField = textFor(stintValues, LEGACY_FIELD_OF_STUDY_PROPERTY);
 
-          return {
-            ...entry,
-            status: educationStatusFromOptionId(statusOptionId),
-            fields: fields.length > 0 || legacyField === null ? fields : [{ id: '', name: legacyField }],
-          };
-        })
-        .sort(byMostRecent)
-    )
+        return {
+          ...entry,
+          edge: edgeRef,
+          status: educationStatusFromOptionId(statusOptionId),
+          fields: fields.length > 0 || legacyField === null ? fields : [{ id: '', name: legacyField }],
+        };
+      })
+      .sort(byMostRecent)
   );
 }
 

--- a/apps/web/core/profile/normalize-history.ts
+++ b/apps/web/core/profile/normalize-history.ts
@@ -1,7 +1,6 @@
 import { findMediaUrlValue } from '~/core/utils/media-url';
 
 import {
-  ACADEMIC_FIELDS_PROPERTY,
   DEGREE_PROPERTY,
   DESCRIPTION_PROPERTY,
   EDUCATION_STATUS_PROPERTY,
@@ -10,6 +9,7 @@ import {
   END_DATE_PROPERTY,
   type EducationStatus,
   type EmploymentStatus,
+  FIELDS_OF_STUDY_PROPERTY,
   GRADE_PROPERTY,
   LEGACY_FIELD_OF_STUDY_PROPERTY,
   LOCATION_PROPERTY,
@@ -295,13 +295,13 @@ export function normalizeEducation(edges: HistoryEdgeNode[]): EducationCard[] {
         const enrolmentRelations = relation.entity?.relationsList ?? [];
         const enrolmentValues = relation.entity?.valuesList ?? [];
         const fields = enrolmentRelations
-          .filter(field => field.type.id === ACADEMIC_FIELDS_PROPERTY)
+          .filter(field => field.type.id === FIELDS_OF_STUDY_PROPERTY)
           .map(field => field.toEntity)
           .filter((field): field is NamedRef => field !== null);
 
-        // Eleven records predate `Academic fields` and keep the discipline as
+        // Eleven records predate `Fields of study` and keep the discipline as
         // text on the stint. Shown, never written — they are the seed for real
-        // Academic field entities rather than a second way to store one.
+        // Field of study entities rather than a second way to store one.
         const legacyField = textFor(stintValues, LEGACY_FIELD_OF_STUDY_PROPERTY);
 
         return {

--- a/apps/web/core/profile/normalize-history.ts
+++ b/apps/web/core/profile/normalize-history.ts
@@ -24,6 +24,7 @@ import {
 /** Shapes as they come back from the graph; see `fetch-profile-history.ts`. */
 export type HistoryValueNode = {
   id?: string;
+  spaceId?: string;
   property: { id: string };
   date: string | null;
   text: string | null;
@@ -32,6 +33,7 @@ export type HistoryValueNode = {
 export type HistoryRelationNode = {
   id: string;
   entityId: string;
+  spaceId?: string;
   type: { id: string };
   toEntity: { id: string; name: string | null } | null;
   entity: { valuesList: HistoryValueNode[]; relationsList: HistoryRelationNode[] } | null;
@@ -57,20 +59,31 @@ export type NamedRef = { id: string; name: string | null };
  * leave the dates, the description and the skills behind as an entity nothing can
  * reach.
  */
+/**
+ * Everything on a relation's own entity, with the space each row lives in.
+ *
+ * The space matters because a proposal only reaches one of them: a row somebody
+ * else wrote in another space is not ours to delete, and a tombstone for it would
+ * be a delete op aimed at a space the row is not in. The SDK's own `deleteEntity`
+ * scopes the same way, for the same reason.
+ *
+ * Values carry their property as well as their row id, because deleting one
+ * publishes an `unset` keyed on the property — the id names the row without
+ * saying what to clear.
+ */
 export type Subtree = {
-  relationIds: string[];
-  /**
-   * Both halves, because deleting a value publishes an `unset` keyed on the
-   * property — the row id alone names the row but not what to clear.
-   */
-  values: { id: string; propertyId: string }[];
+  relations: { id: string; spaceId: string | null }[];
+  values: { id: string; propertyId: string; spaceId: string | null }[];
 };
 
 const readSubtree = (entity: { valuesList: HistoryValueNode[]; relationsList: HistoryRelationNode[] } | null) => ({
-  relationIds: (entity?.relationsList ?? []).map(relation => relation.id),
+  relations: (entity?.relationsList ?? []).map(relation => ({
+    id: relation.id,
+    spaceId: relation.spaceId ?? null,
+  })),
   values: (entity?.valuesList ?? [])
     .filter((value): value is HistoryValueNode & { id: string } => Boolean(value.id))
-    .map(value => ({ id: value.id, propertyId: value.property.id })),
+    .map(value => ({ id: value.id, propertyId: value.property.id, spaceId: value.spaceId ?? null })),
 });
 
 /** One Employment/Education relation and the entity it carries. */

--- a/apps/web/core/profile/normalize-history.ts
+++ b/apps/web/core/profile/normalize-history.ts
@@ -1,0 +1,209 @@
+import {
+  ACADEMIC_FIELDS_PROPERTY,
+  DEGREE_PROPERTY,
+  DESCRIPTION_PROPERTY,
+  EDUCATION_STATUS_PROPERTY,
+  EMPLOYMENT_STATUS_PROPERTY,
+  END_DATE_PROPERTY,
+  type EducationStatus,
+  type EmploymentStatus,
+  LEGACY_FIELD_OF_STUDY_PROPERTY,
+  ROLES_PROPERTY,
+  START_DATE_PROPERTY,
+  educationStatusFromOptionId,
+  employmentStatusFromOptionId,
+} from './history-ontology';
+
+/** Shapes as they come back from the graph; see `fetch-profile-history.ts`. */
+export type HistoryValueNode = { property: { id: string }; date: string | null; text: string | null };
+export type HistoryRelationNode = {
+  id: string;
+  entityId: string;
+  type: { id: string };
+  toEntity: { id: string; name: string | null } | null;
+  entity: { valuesList: HistoryValueNode[]; relationsList: HistoryRelationNode[] } | null;
+};
+export type HistoryEdgeNode = {
+  id: string;
+  entityId: string;
+  toEntity: { id: string; name: string | null } | null;
+  entity: { valuesList: HistoryValueNode[]; relationsList: HistoryRelationNode[] } | null;
+};
+
+export type NamedRef = { id: string; name: string | null };
+
+/** One dated row under an organisation — a role held, or a degree read. */
+export type HistoryEntry = {
+  /** The Roles/Degree relation, which is what removing this row deletes. */
+  relationId: string;
+  /** That relation's own entity, which carries the dates and status. */
+  tenureId: string;
+  subject: NamedRef;
+  startDate: string | null;
+  endDate: string | null;
+  description: string | null;
+  /**
+   * True when the dates came off the stint rather than this row's own tenure —
+   * the pre-GEO-2858 shape. Rendering treats them the same; editing must not,
+   * since writing to the tenure would leave the stint's copy behind.
+   */
+  isLegacy: boolean;
+};
+
+export type EmploymentEntry = HistoryEntry & { status: EmploymentStatus | null };
+export type EducationEntry = HistoryEntry & { status: EducationStatus | null; fields: NamedRef[] };
+
+/** An organisation and everything held there. One card in the resting state. */
+export type HistoryCard<TEntry> = {
+  /** The Employment/Education relation — removing this drops the whole card. */
+  relationId: string;
+  /** Its entity, which every row hangs off. */
+  stintId: string;
+  organization: NamedRef;
+  entries: TEntry[];
+};
+
+export type EmploymentCard = HistoryCard<EmploymentEntry>;
+export type EducationCard = HistoryCard<EducationEntry>;
+
+function valueFor(values: HistoryValueNode[], propertyId: string) {
+  return values.find(value => value.property.id === propertyId);
+}
+
+function dateFor(values: HistoryValueNode[], propertyId: string) {
+  return valueFor(values, propertyId)?.date ?? null;
+}
+
+function textFor(values: HistoryValueNode[], propertyId: string) {
+  const text = valueFor(values, propertyId)?.text;
+  return text && text.trim() !== '' ? text : null;
+}
+
+function relationTo(relations: HistoryRelationNode[], propertyId: string) {
+  return relations.find(relation => relation.type.id === propertyId)?.toEntity ?? null;
+}
+
+/**
+ * Reads one dated row, preferring its own tenure and falling back to the stint.
+ *
+ * Nineteen records written before this shape existed put the dates, status and
+ * description on the stint instead. Without the fallback they render as a company
+ * and a job title with no dates at all — so the fallback stays until they are
+ * migrated, and `isLegacy` marks the ones still relying on it.
+ */
+function readEntry(
+  relation: HistoryRelationNode,
+  stintValues: HistoryValueNode[],
+  stintRelations: HistoryRelationNode[],
+  statusProperty: string
+) {
+  const tenureValues = relation.entity?.valuesList ?? [];
+  const tenureRelations = relation.entity?.relationsList ?? [];
+
+  const ownStart = dateFor(tenureValues, START_DATE_PROPERTY);
+  const ownEnd = dateFor(tenureValues, END_DATE_PROPERTY);
+  const ownStatus = relationTo(tenureRelations, statusProperty);
+  const ownDescription = textFor(tenureValues, DESCRIPTION_PROPERTY);
+
+  // A tenure that carries nothing at all is the legacy case. Judged on the whole
+  // row rather than field by field, so a row with a real start and a deliberately
+  // empty end is not mistaken for one.
+  const isLegacy = ownStart === null && ownEnd === null && ownStatus === null && ownDescription === null;
+
+  return {
+    relationId: relation.id,
+    tenureId: relation.entityId,
+    subject: relation.toEntity ?? { id: relation.entityId, name: null },
+    startDate: isLegacy ? dateFor(stintValues, START_DATE_PROPERTY) : ownStart,
+    endDate: isLegacy ? dateFor(stintValues, END_DATE_PROPERTY) : ownEnd,
+    description: isLegacy ? textFor(stintValues, DESCRIPTION_PROPERTY) : ownDescription,
+    statusOptionId: (isLegacy ? relationTo(stintRelations, statusProperty) : ownStatus)?.id ?? null,
+    isLegacy,
+  };
+}
+
+function readCard<TEntry>(
+  edge: HistoryEdgeNode,
+  readEntries: (stintValues: HistoryValueNode[], stintRelations: HistoryRelationNode[]) => TEntry[]
+): HistoryCard<TEntry> {
+  const stintValues = edge.entity?.valuesList ?? [];
+  const stintRelations = edge.entity?.relationsList ?? [];
+
+  return {
+    relationId: edge.id,
+    stintId: edge.entityId,
+    organization: edge.toEntity ?? { id: edge.entityId, name: null },
+    entries: readEntries(stintValues, stintRelations),
+  };
+}
+
+export function normalizeEmployment(edges: HistoryEdgeNode[]): EmploymentCard[] {
+  return edges.map(edge =>
+    readCard<EmploymentEntry>(edge, (stintValues, stintRelations) =>
+      stintRelations
+        .filter(relation => relation.type.id === ROLES_PROPERTY)
+        .map(relation => {
+          const { statusOptionId, ...entry } = readEntry(
+            relation,
+            stintValues,
+            stintRelations,
+            EMPLOYMENT_STATUS_PROPERTY
+          );
+          return { ...entry, status: employmentStatusFromOptionId(statusOptionId) };
+        })
+        .sort(byMostRecent)
+    )
+  );
+}
+
+export function normalizeEducation(edges: HistoryEdgeNode[]): EducationCard[] {
+  return edges.map(edge =>
+    readCard<EducationEntry>(edge, (stintValues, stintRelations) =>
+      stintRelations
+        .filter(relation => relation.type.id === DEGREE_PROPERTY)
+        .map(relation => {
+          const { statusOptionId, ...entry } = readEntry(
+            relation,
+            stintValues,
+            stintRelations,
+            EDUCATION_STATUS_PROPERTY
+          );
+
+          const enrolmentRelations = relation.entity?.relationsList ?? [];
+          const fields = enrolmentRelations
+            .filter(field => field.type.id === ACADEMIC_FIELDS_PROPERTY)
+            .map(field => field.toEntity)
+            .filter((field): field is NamedRef => field !== null);
+
+          // Eleven records predate `Academic fields` and keep the discipline as
+          // text on the stint. Shown, never written — they are the seed for real
+          // Academic field entities rather than a second way to store one.
+          const legacyField = textFor(stintValues, LEGACY_FIELD_OF_STUDY_PROPERTY);
+
+          return {
+            ...entry,
+            status: educationStatusFromOptionId(statusOptionId),
+            fields: fields.length > 0 || legacyField === null ? fields : [{ id: '', name: legacyField }],
+          };
+        })
+        .sort(byMostRecent)
+    )
+  );
+}
+
+/**
+ * Most recent first, and anything still open ahead of anything ended. A row with
+ * no dates at all sorts last rather than jumping the list on an empty string.
+ */
+function byMostRecent(a: HistoryEntry, b: HistoryEntry) {
+  const aOpen = a.startDate !== null && a.endDate === null;
+  const bOpen = b.startDate !== null && b.endDate === null;
+  if (aOpen !== bOpen) return aOpen ? -1 : 1;
+
+  const aKey = a.endDate ?? a.startDate;
+  const bKey = b.endDate ?? b.startDate;
+  if (aKey === bKey) return 0;
+  if (aKey === null) return 1;
+  if (bKey === null) return -1;
+  return bKey.localeCompare(aKey);
+}

--- a/apps/web/core/profile/normalize-history.ts
+++ b/apps/web/core/profile/normalize-history.ts
@@ -11,6 +11,8 @@ import {
   type EducationStatus,
   type EmploymentStatus,
   LEGACY_FIELD_OF_STUDY_PROPERTY,
+  LOCATION_PROPERTY,
+  LOCATION_TYPE_PROPERTY,
   ROLES_PROPERTY,
   SKILLS_PROPERTY,
   START_DATE_PROPERTY,
@@ -70,6 +72,8 @@ export type EmploymentEntry = HistoryEntry & {
   status: EmploymentStatus | null;
   employmentType: NamedRef | null;
   skills: NamedRef[];
+  location: NamedRef | null;
+  locationType: NamedRef | null;
 };
 export type EducationEntry = HistoryEntry & { status: EducationStatus | null; fields: NamedRef[] };
 
@@ -241,6 +245,8 @@ export function normalizeEmployment(edges: HistoryEdgeNode[]): EmploymentCard[] 
           edge: edgeRef,
           status: employmentStatusFromOptionId(statusOptionId),
           employmentType: relationTo(tenureRelations, EMPLOYMENT_TYPE_PROPERTY),
+          location: relationTo(tenureRelations, LOCATION_PROPERTY),
+          locationType: relationTo(tenureRelations, LOCATION_TYPE_PROPERTY),
           skills: tenureRelations
             .filter(skill => skill.type.id === SKILLS_PROPERTY)
             .map(skill => skill.toEntity)

--- a/apps/web/core/profile/normalize-history.ts
+++ b/apps/web/core/profile/normalize-history.ts
@@ -4,11 +4,13 @@ import {
   DESCRIPTION_PROPERTY,
   EDUCATION_STATUS_PROPERTY,
   EMPLOYMENT_STATUS_PROPERTY,
+  EMPLOYMENT_TYPE_PROPERTY,
   END_DATE_PROPERTY,
   type EducationStatus,
   type EmploymentStatus,
   LEGACY_FIELD_OF_STUDY_PROPERTY,
   ROLES_PROPERTY,
+  SKILLS_PROPERTY,
   START_DATE_PROPERTY,
   educationStatusFromOptionId,
   employmentStatusFromOptionId,
@@ -26,7 +28,11 @@ export type HistoryRelationNode = {
 export type HistoryEdgeNode = {
   id: string;
   entityId: string;
-  toEntity: { id: string; name: string | null } | null;
+  toEntity: {
+    id: string;
+    name: string | null;
+    relationsList?: { toEntity: { valuesList: HistoryValueNode[] } | null }[];
+  } | null;
   entity: { valuesList: HistoryValueNode[]; relationsList: HistoryRelationNode[] } | null;
 };
 
@@ -50,7 +56,11 @@ export type HistoryEntry = {
   isLegacy: boolean;
 };
 
-export type EmploymentEntry = HistoryEntry & { status: EmploymentStatus | null };
+export type EmploymentEntry = HistoryEntry & {
+  status: EmploymentStatus | null;
+  employmentType: NamedRef | null;
+  skills: NamedRef[];
+};
 export type EducationEntry = HistoryEntry & { status: EducationStatus | null; fields: NamedRef[] };
 
 /** An organisation and everything held there. One card in the resting state. */
@@ -60,6 +70,8 @@ export type HistoryCard<TEntry> = {
   /** Its entity, which every row hangs off. */
   stintId: string;
   organization: NamedRef;
+  /** The organisation's own avatar, where it has one. */
+  avatarUrl?: string | null;
   entries: TEntry[];
 };
 
@@ -122,6 +134,15 @@ function readEntry(
   };
 }
 
+/** The image entity's URL, which is whichever of its values looks like one. */
+function readAvatar(edge: HistoryEdgeNode): string | null {
+  for (const relation of edge.toEntity?.relationsList ?? []) {
+    const url = relation.toEntity?.valuesList.find(value => typeof value.text === 'string' && value.text !== '');
+    if (url?.text) return url.text;
+  }
+  return null;
+}
+
 function readCard<TEntry>(
   edge: HistoryEdgeNode,
   readEntries: (stintValues: HistoryValueNode[], stintRelations: HistoryRelationNode[]) => TEntry[]
@@ -133,6 +154,7 @@ function readCard<TEntry>(
     relationId: edge.id,
     stintId: edge.entityId,
     organization: edge.toEntity ?? { id: edge.entityId, name: null },
+    avatarUrl: readAvatar(edge),
     entries: readEntries(stintValues, stintRelations),
   };
 }
@@ -149,7 +171,17 @@ export function normalizeEmployment(edges: HistoryEdgeNode[]): EmploymentCard[] 
             stintRelations,
             EMPLOYMENT_STATUS_PROPERTY
           );
-          return { ...entry, status: employmentStatusFromOptionId(statusOptionId) };
+          const tenureRelations = relation.entity?.relationsList ?? [];
+
+          return {
+            ...entry,
+            status: employmentStatusFromOptionId(statusOptionId),
+            employmentType: relationTo(tenureRelations, EMPLOYMENT_TYPE_PROPERTY),
+            skills: tenureRelations
+              .filter(skill => skill.type.id === SKILLS_PROPERTY)
+              .map(skill => skill.toEntity)
+              .filter((skill): skill is NamedRef => skill !== null),
+          };
         })
         .sort(byMostRecent)
     )

--- a/apps/web/core/profile/normalize-history.ts
+++ b/apps/web/core/profile/normalize-history.ts
@@ -10,6 +10,7 @@ import {
   END_DATE_PROPERTY,
   type EducationStatus,
   type EmploymentStatus,
+  GRADE_PROPERTY,
   LEGACY_FIELD_OF_STUDY_PROPERTY,
   LOCATION_PROPERTY,
   LOCATION_TYPE_PROPERTY,
@@ -21,7 +22,12 @@ import {
 } from './history-ontology';
 
 /** Shapes as they come back from the graph; see `fetch-profile-history.ts`. */
-export type HistoryValueNode = { property: { id: string }; date: string | null; text: string | null };
+export type HistoryValueNode = {
+  property: { id: string };
+  date: string | null;
+  text: string | null;
+  decimal?: string | null;
+};
 export type HistoryRelationNode = {
   id: string;
   entityId: string;
@@ -75,7 +81,13 @@ export type EmploymentEntry = HistoryEntry & {
   location: NamedRef | null;
   locationType: NamedRef | null;
 };
-export type EducationEntry = HistoryEntry & { status: EducationStatus | null; fields: NamedRef[] };
+export type EducationEntry = HistoryEntry & {
+  status: EducationStatus | null;
+  fields: NamedRef[];
+  skills: NamedRef[];
+  /** A mark, where the institution's was recorded. */
+  grade: number | null;
+};
 
 /** An organisation and everything held there. One card in the resting state. */
 export type HistoryCard<TEntry> = {
@@ -109,6 +121,17 @@ function dateFor(values: HistoryValueNode[], propertyId: string) {
 function textFor(values: HistoryValueNode[], propertyId: string) {
   const text = valueFor(values, propertyId)?.text;
   return text && text.trim() !== '' ? text : null;
+}
+
+/**
+ * A decimal off the graph. It arrives as a string — the endpoint serialises
+ * BigFloat the way it serialises BigInt — so parsing is not optional.
+ */
+function decimalFor(values: HistoryValueNode[], propertyId: string) {
+  const raw = valueFor(values, propertyId)?.decimal;
+  if (raw === null || raw === undefined || raw === '') return null;
+  const parsed = Number.parseFloat(raw);
+  return Number.isFinite(parsed) ? parsed : null;
 }
 
 function relationTo(relations: HistoryRelationNode[], propertyId: string) {
@@ -270,6 +293,7 @@ export function normalizeEducation(edges: HistoryEdgeNode[]): EducationCard[] {
         );
 
         const enrolmentRelations = relation.entity?.relationsList ?? [];
+        const enrolmentValues = relation.entity?.valuesList ?? [];
         const fields = enrolmentRelations
           .filter(field => field.type.id === ACADEMIC_FIELDS_PROPERTY)
           .map(field => field.toEntity)
@@ -285,6 +309,11 @@ export function normalizeEducation(edges: HistoryEdgeNode[]): EducationCard[] {
           edge: edgeRef,
           status: educationStatusFromOptionId(statusOptionId),
           fields: fields.length > 0 || legacyField === null ? fields : [{ id: '', name: legacyField }],
+          skills: enrolmentRelations
+            .filter(skill => skill.type.id === SKILLS_PROPERTY)
+            .map(skill => skill.toEntity)
+            .filter((skill): skill is NamedRef => skill !== null),
+          grade: decimalFor(enrolmentValues, GRADE_PROPERTY),
         };
       })
       .sort(byMostRecent)

--- a/apps/web/core/profile/pending-history.test.ts
+++ b/apps/web/core/profile/pending-history.test.ts
@@ -9,6 +9,8 @@ import {
   hasPendingChanges,
   isPending,
   mergePendingEmployment,
+  replacePendingAddition,
+  shareStintsByOrganization,
 } from './pending-history';
 import type { PositionDraft } from './stage-history';
 
@@ -25,12 +27,12 @@ const draft = (company: string, title: string, overrides: Partial<PositionDraft>
 });
 
 const savedCard = (org: string, roles: string[]): EmploymentCard => ({
-  relationId: `edge-${org}`,
-  stintId: `stint-${org}`,
   organization: { id: `org-${org}`, name: org },
+  edges: [{ relationId: `edge-${org}`, stintId: `stint-${org}` }],
   entries: roles.map(role => ({
     relationId: `rel-${role}`,
     tenureId: `tenure-${role}`,
+    edge: { relationId: `edge-${org}`, stintId: `stint-${org}` },
     subject: { id: `title-${role}`, name: role },
     startDate: '2022-06-01Z',
     endDate: null,
@@ -66,6 +68,8 @@ describe('mergePendingEmployment', () => {
 
     expect(cards).toHaveLength(1);
     expect(cards[0].entries.map(entry => entry.subject.name)).toEqual(['Product Lead', 'Engineer']);
+    // Hung off the saved edge, so removing it later knows which one it belongs to.
+    expect(cards[0].entries[0].edge.stintId).toBe('stint-Geo');
   });
 
   // Two roles at one new employer, added in a single sitting, would otherwise be
@@ -121,6 +125,84 @@ describe('mergePendingEmployment', () => {
 
     expect(cards).toHaveLength(1);
     expect(cards[0].entries.map(entry => entry.subject.name)).toEqual(['Engineer']);
+  });
+});
+
+describe('replacePendingAddition', () => {
+  // Editing something never written is a different draft under the same key —
+  // no removal, and no second row beside the one being changed.
+  it('rewrites an unsaved row in place', () => {
+    const pending = { ...NOTHING_PENDING, positions: [{ key: 'k1', draft: draft('Geo', 'Engineer') }] };
+
+    const after = replacePendingAddition(pending, `${PENDING_PREFIX}k1`, draft('Geo', 'Staff Engineer'));
+
+    expect(after.positions).toHaveLength(1);
+    expect(after.positions[0].key).toBe('k1');
+    expect(after.positions[0].draft.title.name).toBe('Staff Engineer');
+    expect(after.removals).toEqual([]);
+  });
+});
+
+describe('shareStintsByOrganization', () => {
+  const mint = () => {
+    let next = 0;
+    return () => `minted-${++next}`;
+  };
+
+  it('opens one edge for two roles at the same new employer', () => {
+    const assigned = shareStintsByOrganization(
+      [
+        { key: 'k1', draft: draft('Fathom', 'Engineer') },
+        { key: 'k2', draft: draft('Fathom', 'Staff Engineer') },
+      ],
+      mint()
+    );
+
+    // The first mints it and the second attaches to what the first minted, so the
+    // pair publishes as one employer with two roles.
+    expect(assigned[0].draft.existingStintId).toBeUndefined();
+    expect(assigned[0].newStintId).toBe('minted-1');
+    expect(assigned[1].draft.existingStintId).toBe('minted-1');
+  });
+
+  it('opens an edge each for two different employers', () => {
+    const assigned = shareStintsByOrganization(
+      [
+        { key: 'k1', draft: draft('Fathom', 'Engineer') },
+        { key: 'k2', draft: draft('Geo', 'Product Lead') },
+      ],
+      mint()
+    );
+
+    expect(assigned[0].newStintId).toBe('minted-1');
+    expect(assigned[1].newStintId).toBe('minted-2');
+    expect(assigned.every(entry => entry.draft.existingStintId === undefined)).toBe(true);
+  });
+
+  // Whichever order they were added in: a saved edge is the one that exists, so
+  // it is the one everything at that employer attaches to.
+  it('prefers a saved edge over minting, even when the new role came first', () => {
+    const assigned = shareStintsByOrganization(
+      [
+        { key: 'k1', draft: draft('Geo', 'Product Lead') },
+        { key: 'k2', draft: draft('Geo', 'Engineer', { existingStintId: 'stint-Geo' }) },
+      ],
+      mint()
+    );
+
+    expect(assigned.map(entry => entry.draft.existingStintId)).toEqual(['stint-Geo', 'stint-Geo']);
+  });
+
+  // The placeholder `merge` hands the resting state so rows group on screen. It
+  // names nothing in the graph, so it must never be written out as a target.
+  it('mints over a pending stint rather than pointing at one', () => {
+    const assigned = shareStintsByOrganization(
+      [{ key: 'k1', draft: draft('Fathom', 'Engineer', { existingStintId: `${PENDING_PREFIX}org-Fathom-stint` }) }],
+      mint()
+    );
+
+    expect(assigned[0].draft.existingStintId).toBeUndefined();
+    expect(assigned[0].newStintId).toBe('minted-1');
   });
 });
 

--- a/apps/web/core/profile/pending-history.test.ts
+++ b/apps/web/core/profile/pending-history.test.ts
@@ -4,6 +4,7 @@ import { EMPLOYMENT_PROPERTY, ROLES_PROPERTY } from './history-ontology';
 import type { EmploymentCard } from './normalize-history';
 import {
   NOTHING_PENDING,
+  NOTHING_TO_CLEAN,
   PENDING_PREFIX,
   dropPendingAddition,
   hasPendingChanges,
@@ -30,11 +31,12 @@ const draft = (company: string, title: string, overrides: Partial<PositionDraft>
 
 const savedCard = (org: string, roles: string[]): EmploymentCard => ({
   organization: { id: `org-${org}`, name: org },
-  edges: [{ relationId: `edge-${org}`, stintId: `stint-${org}` }],
+  edges: [{ relationId: `edge-${org}`, stintId: `stint-${org}`, subtree: NOTHING_TO_CLEAN }],
   entries: roles.map(role => ({
     relationId: `rel-${role}`,
     tenureId: `tenure-${role}`,
-    edge: { relationId: `edge-${org}`, stintId: `stint-${org}` },
+    edge: { relationId: `edge-${org}`, stintId: `stint-${org}`, subtree: NOTHING_TO_CLEAN },
+    subtree: NOTHING_TO_CLEAN,
     subject: { id: `title-${role}`, name: role },
     startDate: '2022-06-01Z',
     endDate: null,
@@ -142,7 +144,7 @@ describe('mergePendingEmployment', () => {
     const cards = mergePendingEmployment(
       [savedCard('Geo', ['Engineer', 'Product Lead'])],
       [],
-      [{ relationId: 'rel-Engineer', entityId: 'tenure-Engineer', typeId: ROLES_PROPERTY }]
+      [{ relationId: 'rel-Engineer', entityId: 'tenure-Engineer', typeId: ROLES_PROPERTY, subtree: NOTHING_TO_CLEAN }]
     );
 
     expect(cards[0].entries.map(entry => entry.subject.name)).toEqual(['Product Lead']);
@@ -155,8 +157,8 @@ describe('mergePendingEmployment', () => {
       [savedCard('Geo', ['Engineer'])],
       [],
       [
-        { relationId: 'rel-Engineer', entityId: 'tenure-Engineer', typeId: ROLES_PROPERTY },
-        { relationId: 'edge-Geo', entityId: 'stint-Geo', typeId: EMPLOYMENT_PROPERTY },
+        { relationId: 'rel-Engineer', entityId: 'tenure-Engineer', typeId: ROLES_PROPERTY, subtree: NOTHING_TO_CLEAN },
+        { relationId: 'edge-Geo', entityId: 'stint-Geo', typeId: EMPLOYMENT_PROPERTY, subtree: NOTHING_TO_CLEAN },
       ]
     );
 
@@ -267,7 +269,7 @@ describe('hasPendingChanges', () => {
     expect(
       hasPendingChanges({
         ...NOTHING_PENDING,
-        removals: [{ relationId: 'r', entityId: 'e', typeId: ROLES_PROPERTY }],
+        removals: [{ relationId: 'r', entityId: 'e', typeId: ROLES_PROPERTY, subtree: NOTHING_TO_CLEAN }],
       })
     ).toBe(true);
   });

--- a/apps/web/core/profile/pending-history.test.ts
+++ b/apps/web/core/profile/pending-history.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from 'vitest';
+
+import { EMPLOYMENT_PROPERTY, ROLES_PROPERTY } from './history-ontology';
+import type { EmploymentCard } from './normalize-history';
+import {
+  NOTHING_PENDING,
+  PENDING_PREFIX,
+  dropPendingAddition,
+  hasPendingChanges,
+  isPending,
+  mergePendingEmployment,
+} from './pending-history';
+import type { PositionDraft } from './stage-history';
+
+const draft = (company: string, title: string, overrides: Partial<PositionDraft> = {}): PositionDraft => ({
+  company: { id: `org-${company}`, name: company, isNew: false },
+  title: { id: `title-${title}`, name: title, isNew: false },
+  employmentType: null,
+  skills: [],
+  startDate: '2024-01-01Z',
+  endDate: null,
+  status: 'current',
+  description: '',
+  ...overrides,
+});
+
+const savedCard = (org: string, roles: string[]): EmploymentCard => ({
+  relationId: `edge-${org}`,
+  stintId: `stint-${org}`,
+  organization: { id: `org-${org}`, name: org },
+  entries: roles.map(role => ({
+    relationId: `rel-${role}`,
+    tenureId: `tenure-${role}`,
+    subject: { id: `title-${role}`, name: role },
+    startDate: '2022-06-01Z',
+    endDate: null,
+    description: null,
+    isLegacy: false,
+    status: null,
+    employmentType: null,
+    skills: [],
+  })),
+});
+
+describe('mergePendingEmployment', () => {
+  it('shows an unsaved position alongside the saved ones', () => {
+    const cards = mergePendingEmployment(
+      [savedCard('Coinbase', ['Data Analyst'])],
+      [{ key: 'k1', draft: draft('Geo', 'Product Lead') }],
+      []
+    );
+
+    expect(cards.map(card => card.organization.name)).toEqual(['Coinbase', 'Geo']);
+    expect(cards[1].entries[0].subject.name).toBe('Product Lead');
+    expect(isPending(cards[1].entries[0].relationId)).toBe(true);
+  });
+
+  // The promotion case while still unsaved: it belongs under the employer it was
+  // added from, not as a second card for the same company.
+  it('puts a role added to an existing employer under that employer', () => {
+    const cards = mergePendingEmployment(
+      [savedCard('Geo', ['Engineer'])],
+      [{ key: 'k1', draft: draft('Geo', 'Product Lead', { existingStintId: 'stint-Geo' }) }],
+      []
+    );
+
+    expect(cards).toHaveLength(1);
+    expect(cards[0].entries.map(entry => entry.subject.name)).toEqual(['Product Lead', 'Engineer']);
+  });
+
+  // Two roles at one new employer, added in a single sitting, would otherwise be
+  // two cards that merge only after a save and a refetch.
+  it('groups two unsaved roles at the same new employer', () => {
+    const cards = mergePendingEmployment(
+      [],
+      [
+        { key: 'k1', draft: draft('Fathom', 'Engineer') },
+        { key: 'k2', draft: draft('Fathom', 'Staff Engineer') },
+      ],
+      []
+    );
+
+    expect(cards).toHaveLength(1);
+    // Newest first, the same order the saved rows use.
+    expect(cards[0].entries.map(entry => entry.subject.name)).toEqual(['Staff Engineer', 'Engineer']);
+  });
+
+  it('hides a row queued for removal', () => {
+    const cards = mergePendingEmployment(
+      [savedCard('Geo', ['Engineer', 'Product Lead'])],
+      [],
+      [{ relationId: 'rel-Engineer', entityId: 'tenure-Engineer', typeId: ROLES_PROPERTY }]
+    );
+
+    expect(cards[0].entries.map(entry => entry.subject.name)).toEqual(['Product Lead']);
+  });
+
+  // An organisation edge goes with its last row, so leaving the card on screen
+  // would promise something the save will not deliver.
+  it('drops a card once its last row is queued for removal', () => {
+    const cards = mergePendingEmployment(
+      [savedCard('Geo', ['Engineer'])],
+      [],
+      [
+        { relationId: 'rel-Engineer', entityId: 'tenure-Engineer', typeId: ROLES_PROPERTY },
+        { relationId: 'edge-Geo', entityId: 'stint-Geo', typeId: EMPLOYMENT_PROPERTY },
+      ]
+    );
+
+    expect(cards).toEqual([]);
+  });
+
+  it('leaves a saved employer standing when an unsaved role is added and then dropped', () => {
+    const pending = {
+      ...NOTHING_PENDING,
+      positions: [{ key: 'k1', draft: draft('Geo', 'Product Lead', { existingStintId: 'stint-Geo' }) }],
+    };
+
+    const after = dropPendingAddition(pending, `${PENDING_PREFIX}k1`);
+    const cards = mergePendingEmployment([savedCard('Geo', ['Engineer'])], after.positions, after.removals);
+
+    expect(cards).toHaveLength(1);
+    expect(cards[0].entries.map(entry => entry.subject.name)).toEqual(['Engineer']);
+  });
+});
+
+describe('hasPendingChanges', () => {
+  it('is false with nothing queued', () => {
+    expect(hasPendingChanges(NOTHING_PENDING)).toBe(false);
+  });
+
+  it('is true for an addition and for a removal alike', () => {
+    expect(hasPendingChanges({ ...NOTHING_PENDING, positions: [{ key: 'k', draft: draft('Geo', 'Engineer') }] })).toBe(
+      true
+    );
+    expect(
+      hasPendingChanges({
+        ...NOTHING_PENDING,
+        removals: [{ relationId: 'r', entityId: 'e', typeId: ROLES_PROPERTY }],
+      })
+    ).toBe(true);
+  });
+});

--- a/apps/web/core/profile/pending-history.test.ts
+++ b/apps/web/core/profile/pending-history.test.ts
@@ -45,6 +45,8 @@ const savedCard = (org: string, roles: string[]): EmploymentCard => ({
 });
 
 describe('mergePendingEmployment', () => {
+  // Employers newest first, by the most recent thing held at each — the unsaved
+  // role started in 2024 and the saved one in 2022, so it leads.
   it('shows an unsaved position alongside the saved ones', () => {
     const cards = mergePendingEmployment(
       [savedCard('Coinbase', ['Data Analyst'])],
@@ -52,9 +54,26 @@ describe('mergePendingEmployment', () => {
       []
     );
 
-    expect(cards.map(card => card.organization.name)).toEqual(['Coinbase', 'Geo']);
-    expect(cards[1].entries[0].subject.name).toBe('Product Lead');
-    expect(isPending(cards[1].entries[0].relationId)).toBe(true);
+    expect(cards.map(card => card.organization.name)).toEqual(['Geo', 'Coinbase']);
+    expect(cards[0].entries[0].subject.name).toBe('Product Lead');
+    expect(isPending(cards[0].entries[0].relationId)).toBe(true);
+  });
+
+  // A job left in 2022 does not belong above one still held, however recently the
+  // older employer happened to be entered.
+  it('puts the employer with the most recent role first', () => {
+    const cards = mergePendingEmployment(
+      [savedCard('Geo', ['Engineer'])],
+      [
+        {
+          key: 'k1',
+          draft: draft('Digital Paradise', 'Cofounder', { startDate: '2020-03-01Z', endDate: '2022-06-01Z' }),
+        },
+      ],
+      []
+    );
+
+    expect(cards.map(card => card.organization.name)).toEqual(['Geo', 'Digital Paradise']);
   });
 
   // The promotion case while still unsaved: it belongs under the employer it was
@@ -78,15 +97,41 @@ describe('mergePendingEmployment', () => {
     const cards = mergePendingEmployment(
       [],
       [
-        { key: 'k1', draft: draft('Fathom', 'Engineer') },
+        { key: 'k1', draft: draft('Fathom', 'Engineer', { startDate: '2020-01-01Z', endDate: '2022-01-01Z' }) },
         { key: 'k2', draft: draft('Fathom', 'Staff Engineer') },
       ],
       []
     );
 
     expect(cards).toHaveLength(1);
-    // Newest first, the same order the saved rows use.
     expect(cards[0].entries.map(entry => entry.subject.name)).toEqual(['Staff Engineer', 'Engineer']);
+  });
+
+  // They used to sit in the order they were added, so a promotion entered after
+  // the job before it read as the older of the two until a save and a refetch —
+  // the one thing the merged view exists to avoid.
+  it('sorts unsaved rows by date, not by the order they were added', () => {
+    const cards = mergePendingEmployment(
+      [],
+      [
+        // The current role added second, as anyone filling in a CV backwards does.
+        { key: 'k1', draft: draft('Geo', 'Product manager', { startDate: '2025-02-01Z', endDate: '2026-07-01Z' }) },
+        { key: 'k2', draft: draft('Geo', 'Head of Product', { startDate: '2026-07-01Z' }) },
+      ],
+      []
+    );
+
+    expect(cards[0].entries.map(entry => entry.subject.name)).toEqual(['Head of Product', 'Product manager']);
+  });
+
+  // Before saving, a card showed an initial where the saved one showed a logo,
+  // which made the merged view look like it was guessing.
+  it('carries the organisation avatar onto an unsaved card', () => {
+    const cards = mergePendingEmployment([], [{ key: 'k1', draft: draft('Geo', 'Engineer') }], [], {
+      'org-Geo': 'ipfs://bafyavatar',
+    });
+
+    expect(cards[0].avatarUrl).toBe('ipfs://bafyavatar');
   });
 
   it('hides a row queued for removal', () => {

--- a/apps/web/core/profile/pending-history.test.ts
+++ b/apps/web/core/profile/pending-history.test.ts
@@ -19,6 +19,8 @@ const draft = (company: string, title: string, overrides: Partial<PositionDraft>
   title: { id: `title-${title}`, name: title, isNew: false },
   employmentType: null,
   skills: [],
+  location: null,
+  locationType: null,
   startDate: '2024-01-01Z',
   endDate: null,
   status: 'current',
@@ -41,6 +43,8 @@ const savedCard = (org: string, roles: string[]): EmploymentCard => ({
     status: null,
     employmentType: null,
     skills: [],
+    location: null,
+    locationType: null,
   })),
 });
 

--- a/apps/web/core/profile/pending-history.ts
+++ b/apps/web/core/profile/pending-history.ts
@@ -4,6 +4,7 @@ import type {
   EmploymentCard,
   EmploymentEntry,
   HistoryCard,
+  HistoryEdgeRef,
   HistoryEntry,
 } from './normalize-history';
 import type { EducationDraft, PositionDraft } from './stage-history';
@@ -34,9 +35,11 @@ export function hasPendingChanges(pending: PendingHistory) {
   return pending.positions.length > 0 || pending.education.length > 0 || pending.removals.length > 0;
 }
 
+const keyOf = (relationId: string) => relationId.slice(PENDING_PREFIX.length);
+
 /** Forgets an unsaved row. Nothing was written, so there is nothing to delete. */
 export function dropPendingAddition(pending: PendingHistory, relationId: string): PendingHistory {
-  const key = relationId.slice(PENDING_PREFIX.length);
+  const key = keyOf(relationId);
   return {
     ...pending,
     positions: pending.positions.filter(addition => addition.key !== key),
@@ -44,14 +47,35 @@ export function dropPendingAddition(pending: PendingHistory, relationId: string)
   };
 }
 
+/**
+ * Rewrites an unsaved row in place, keeping its key.
+ *
+ * Editing something never written is just a different draft under the same key —
+ * no removal, no second row, and the same position in the list it was already
+ * sitting in.
+ */
+export function replacePendingAddition<TDraft extends PositionDraft | EducationDraft>(
+  pending: PendingHistory,
+  relationId: string,
+  draft: TDraft
+): PendingHistory {
+  const key = keyOf(relationId);
+  const swap = <T>(additions: PendingAddition<T>[]) =>
+    additions.map(addition => (addition.key === key ? { ...addition, draft: draft as unknown as T } : addition));
+
+  return { ...pending, positions: swap(pending.positions), education: swap(pending.education) };
+}
+
 function entryFromDraft(
   key: string,
   draft: PositionDraft | EducationDraft,
-  subject: { id: string; name: string | null }
+  subject: { id: string; name: string | null },
+  edge: HistoryEdgeRef
 ): HistoryEntry {
   return {
     relationId: `${PENDING_PREFIX}${key}`,
     tenureId: `${PENDING_PREFIX}${key}-tenure`,
+    edge,
     subject,
     startDate: draft.startDate,
     endDate: draft.endDate,
@@ -59,6 +83,11 @@ function entryFromDraft(
     isLegacy: false,
   };
 }
+
+const organizationOf = (draft: PositionDraft | EducationDraft) =>
+  'company' in draft
+    ? { id: draft.company.id, name: draft.company.name }
+    : { id: draft.school.id, name: draft.school.name };
 
 /**
  * Saved records with everything still pending folded in, so the list reads as the
@@ -72,50 +101,42 @@ function entryFromDraft(
  */
 function merge<TEntry extends HistoryEntry>(
   saved: HistoryCard<TEntry>[],
-  additions: { key: string; draft: PositionDraft | EducationDraft; entry: TEntry }[],
+  additions: { key: string; draft: PositionDraft | EducationDraft; entry: (edge: HistoryEdgeRef) => TEntry }[],
   removals: PendingRemoval[]
 ): HistoryCard<TEntry>[] {
   const removed = new Set(removals.map(removal => removal.relationId));
 
   const cards: HistoryCard<TEntry>[] = saved.map(card => ({
     ...card,
+    edges: card.edges.filter(edge => !removed.has(edge.relationId)),
     entries: card.entries.filter(entry => !removed.has(entry.relationId)),
   }));
 
-  const byStint = new Map(cards.map(card => [card.stintId, card] as const));
-
   for (const addition of additions) {
-    const organization =
-      'company' in addition.draft
-        ? { id: addition.draft.company.id, name: addition.draft.company.name }
-        : { id: addition.draft.school.id, name: addition.draft.school.name };
+    const organization = organizationOf(addition.draft);
+    const existing = cards.find(card => card.organization.id === organization.id);
 
-    const existing = addition.draft.existingStintId
-      ? byStint.get(addition.draft.existingStintId)
-      : cards.find(card => card.organization.id === organization.id && !removed.has(card.relationId));
+    // A row added against a card that still has a saved edge hangs off that edge;
+    // one at an employer with nothing saved left gets a synthetic edge of its own,
+    // which `stagePending` turns into the single Employment relation they share.
+    const edge: HistoryEdgeRef = existing?.edges[0] ?? {
+      relationId: `${PENDING_PREFIX}${organization.id}-edge`,
+      stintId: addition.draft.existingStintId ?? `${PENDING_PREFIX}${organization.id}-stint`,
+    };
 
-    // Newest first, matching how the saved rows are sorted. The lookup is by
-    // organisation rather than by saved edge, so a second role added at an
-    // employer that is itself still unsaved joins the same card instead of
-    // producing a duplicate that would only merge after a save and a refetch.
+    // Newest first, matching how the saved rows are sorted.
     if (existing) {
-      existing.entries = [addition.entry, ...existing.entries];
+      existing.entries = [addition.entry(edge), ...existing.entries];
       continue;
     }
 
-    const card: HistoryCard<TEntry> = {
-      relationId: `${PENDING_PREFIX}${addition.key}-card`,
-      stintId: `${PENDING_PREFIX}${addition.key}-stint`,
-      organization,
-      entries: [addition.entry],
-    };
-    cards.push(card);
+    cards.push({ organization, edges: [edge], entries: [addition.entry(edge)] });
   }
 
   // A card whose rows have all gone is dropped: the organisation edge goes with
   // the last row, so leaving it on screen would promise something the save will
   // not deliver.
-  return cards.filter(card => !removed.has(card.relationId) && card.entries.length > 0);
+  return cards.filter(card => card.entries.length > 0);
 }
 
 export function mergePendingEmployment(
@@ -127,12 +148,12 @@ export function mergePendingEmployment(
     saved,
     additions.map(addition => ({
       ...addition,
-      entry: {
-        ...entryFromDraft(addition.key, addition.draft, addition.draft.title),
+      entry: (edge: HistoryEdgeRef) => ({
+        ...entryFromDraft(addition.key, addition.draft, addition.draft.title, edge),
         status: addition.draft.status,
         employmentType: addition.draft.employmentType,
         skills: addition.draft.skills,
-      },
+      }),
     })),
     removals
   );
@@ -147,12 +168,48 @@ export function mergePendingEducation(
     saved,
     additions.map(addition => ({
       ...addition,
-      entry: {
-        ...entryFromDraft(addition.key, addition.draft, addition.draft.degree),
+      entry: (edge: HistoryEdgeRef) => ({
+        ...entryFromDraft(addition.key, addition.draft, addition.draft.degree, edge),
         status: addition.draft.status,
         fields: addition.draft.fields,
-      },
+      }),
     })),
     removals
   );
+}
+
+/**
+ * One Employment/Education edge per organisation, across everything pending.
+ *
+ * Drafts are staged one at a time, and a draft with no `existingStintId` opens an
+ * edge of its own — so two roles added at the same new employer in one sitting
+ * would publish two edges and read back as two employers. Deciding the stint here
+ * rather than inside the staging keeps that grouping in one place.
+ */
+export function shareStintsByOrganization<TDraft extends PositionDraft | EducationDraft>(
+  additions: PendingAddition<TDraft>[],
+  mintId: () => string
+): { draft: TDraft; newStintId: string }[] {
+  const stintByOrganization = new Map<string, string>();
+
+  // An explicit stint wins over a minted one, whichever order the drafts are in:
+  // a role added to a saved employer has a real edge to attach to, and the new
+  // roles beside it should attach to the same one rather than opening a second.
+  for (const addition of additions) {
+    const stintId = addition.draft.existingStintId;
+    // A pending stint is the placeholder `merge` hands the resting state so rows
+    // group on screen. It names nothing in the graph, so it is minted here like
+    // any other first role rather than written out as a target.
+    if (stintId && !isPending(stintId)) stintByOrganization.set(organizationOf(addition.draft).id, stintId);
+  }
+
+  return additions.map(addition => {
+    const organizationId = organizationOf(addition.draft).id;
+    const shared = stintByOrganization.get(organizationId);
+    if (shared) return { draft: { ...addition.draft, existingStintId: shared }, newStintId: shared };
+
+    const minted = mintId();
+    stintByOrganization.set(organizationId, minted);
+    return { draft: { ...addition.draft, existingStintId: undefined }, newStintId: minted };
+  });
 }

--- a/apps/web/core/profile/pending-history.ts
+++ b/apps/web/core/profile/pending-history.ts
@@ -6,6 +6,7 @@ import {
   type HistoryCard,
   type HistoryEdgeRef,
   type HistoryEntry,
+  type Subtree,
   byMostRecent,
   byMostRecentCard,
 } from './normalize-history';
@@ -20,7 +21,19 @@ export const PENDING_PREFIX = 'pending:';
 
 export const isPending = (id: string) => id.startsWith(PENDING_PREFIX);
 
-export type PendingRemoval = { relationId: string; entityId: string; typeId: string };
+export type PendingRemoval = {
+  relationId: string;
+  entityId: string;
+  typeId: string;
+  /**
+   * Everything on the relation's own entity, which goes with it.
+   *
+   * Deleting a relation marks that one row deleted and touches nothing else, so
+   * without this a removed position leaves its dates, description, employment
+   * type and skills behind on an entity nothing can reach any more.
+   */
+  subtree: Subtree;
+};
 
 /** A draft plus the key its synthetic rows are built from. */
 export type PendingAddition<TDraft> = { key: string; draft: TDraft };
@@ -68,6 +81,9 @@ export function replacePendingAddition<TDraft extends PositionDraft | EducationD
   return { ...pending, positions: swap(pending.positions), education: swap(pending.education) };
 }
 
+/** An unsaved row has written nothing, so it has nothing hanging off it. */
+export const NOTHING_TO_CLEAN: Subtree = { relationIds: [], values: [] };
+
 function entryFromDraft(
   key: string,
   draft: PositionDraft | EducationDraft,
@@ -77,6 +93,7 @@ function entryFromDraft(
   return {
     relationId: `${PENDING_PREFIX}${key}`,
     tenureId: `${PENDING_PREFIX}${key}-tenure`,
+    subtree: NOTHING_TO_CLEAN,
     edge,
     subject,
     startDate: draft.startDate,
@@ -126,6 +143,7 @@ function merge<TEntry extends HistoryEntry>(
     const edge: HistoryEdgeRef = existing?.edges[0] ?? {
       relationId: `${PENDING_PREFIX}${organization.id}-edge`,
       stintId: addition.draft.existingStintId ?? `${PENDING_PREFIX}${organization.id}-stint`,
+      subtree: NOTHING_TO_CLEAN,
     };
 
     if (existing) {

--- a/apps/web/core/profile/pending-history.ts
+++ b/apps/web/core/profile/pending-history.ts
@@ -82,7 +82,7 @@ export function replacePendingAddition<TDraft extends PositionDraft | EducationD
 }
 
 /** An unsaved row has written nothing, so it has nothing hanging off it. */
-export const NOTHING_TO_CLEAN: Subtree = { relationIds: [], values: [] };
+export const NOTHING_TO_CLEAN: Subtree = { relations: [], values: [] };
 
 function entryFromDraft(
   key: string,

--- a/apps/web/core/profile/pending-history.ts
+++ b/apps/web/core/profile/pending-history.ts
@@ -175,6 +175,8 @@ export function mergePendingEmployment(
         status: addition.draft.status,
         employmentType: addition.draft.employmentType,
         skills: addition.draft.skills,
+        location: addition.draft.location,
+        locationType: addition.draft.locationType,
       }),
     })),
     removals,

--- a/apps/web/core/profile/pending-history.ts
+++ b/apps/web/core/profile/pending-history.ts
@@ -1,11 +1,13 @@
-import type {
-  EducationCard,
-  EducationEntry,
-  EmploymentCard,
-  EmploymentEntry,
-  HistoryCard,
-  HistoryEdgeRef,
-  HistoryEntry,
+import {
+  type EducationCard,
+  type EducationEntry,
+  type EmploymentCard,
+  type EmploymentEntry,
+  type HistoryCard,
+  type HistoryEdgeRef,
+  type HistoryEntry,
+  byMostRecent,
+  byMostRecentCard,
 } from './normalize-history';
 import type { EducationDraft, PositionDraft } from './stage-history';
 
@@ -102,7 +104,9 @@ const organizationOf = (draft: PositionDraft | EducationDraft) =>
 function merge<TEntry extends HistoryEntry>(
   saved: HistoryCard<TEntry>[],
   additions: { key: string; draft: PositionDraft | EducationDraft; entry: (edge: HistoryEdgeRef) => TEntry }[],
-  removals: PendingRemoval[]
+  removals: PendingRemoval[],
+  /** Organisation avatars, for a card the saved data has nothing to say about. */
+  avatars: Record<string, string | null> = {}
 ): HistoryCard<TEntry>[] {
   const removed = new Set(removals.map(removal => removal.relationId));
 
@@ -124,25 +128,43 @@ function merge<TEntry extends HistoryEntry>(
       stintId: addition.draft.existingStintId ?? `${PENDING_PREFIX}${organization.id}-stint`,
     };
 
-    // Newest first, matching how the saved rows are sorted.
     if (existing) {
-      existing.entries = [addition.entry(edge), ...existing.entries];
+      existing.entries = [...existing.entries, addition.entry(edge)];
       continue;
     }
 
-    cards.push({ organization, edges: [edge], entries: [addition.entry(edge)] });
+    cards.push({
+      organization,
+      edges: [edge],
+      // Nothing saved mentions this organisation, so its logo has to be looked up
+      // rather than read off an edge. Without it a position looked different
+      // before and after saving, which is the one thing the merged view is for.
+      avatarUrl: avatars[organization.id] ?? null,
+      entries: [addition.entry(edge)],
+    });
   }
+
+  // Sorted the way the saved rows are, rather than left in the order they were
+  // added: a promotion entered after the job before it is still the newer of the
+  // two, and reading as the older one until a save and a refetch was a lie the
+  // merged view told about itself.
+  for (const card of cards) card.entries = [...card.entries].sort(byMostRecent);
 
   // A card whose rows have all gone is dropped: the organisation edge goes with
   // the last row, so leaving it on screen would promise something the save will
   // not deliver.
-  return cards.filter(card => card.entries.length > 0);
+  //
+  // Re-sorted after that, because a pending row can make an employer the most
+  // recent one — a new job at a new company belongs at the top the moment it is
+  // entered, not after a save.
+  return cards.filter(card => card.entries.length > 0).sort(byMostRecentCard);
 }
 
 export function mergePendingEmployment(
   saved: EmploymentCard[],
   additions: PendingAddition<PositionDraft>[],
-  removals: PendingRemoval[]
+  removals: PendingRemoval[],
+  avatars?: Record<string, string | null>
 ): EmploymentCard[] {
   return merge<EmploymentEntry>(
     saved,
@@ -155,14 +177,16 @@ export function mergePendingEmployment(
         skills: addition.draft.skills,
       }),
     })),
-    removals
+    removals,
+    avatars
   );
 }
 
 export function mergePendingEducation(
   saved: EducationCard[],
   additions: PendingAddition<EducationDraft>[],
-  removals: PendingRemoval[]
+  removals: PendingRemoval[],
+  avatars?: Record<string, string | null>
 ): EducationCard[] {
   return merge<EducationEntry>(
     saved,
@@ -174,7 +198,8 @@ export function mergePendingEducation(
         fields: addition.draft.fields,
       }),
     })),
-    removals
+    removals,
+    avatars
   );
 }
 
@@ -212,4 +237,39 @@ export function shareStintsByOrganization<TDraft extends PositionDraft | Educati
     stintByOrganization.set(organizationId, minted);
     return { draft: { ...addition.draft, existingStintId: undefined }, newStintId: minted };
   });
+}
+
+/**
+ * The draft behind an unsaved row, by the relation id the resting state gave it.
+ *
+ * Editing reopens the sheet on a draft, and rebuilding one from the rendered row
+ * loses whatever the row does not display — including whether the company was
+ * created here, which is what decides if its name gets written. So the original
+ * is handed back rather than reconstructed.
+ */
+export function pendingDraftFor(
+  pending: PendingHistory,
+  relationId: string
+): PositionDraft | EducationDraft | undefined {
+  const key = keyOf(relationId);
+  return (
+    pending.positions.find(addition => addition.key === key)?.draft ??
+    pending.education.find(addition => addition.key === key)?.draft
+  );
+}
+
+/**
+ * The organisations named by pending additions, so their avatars can be fetched.
+ *
+ * A pending row at an employer already on the profile inherits that card's logo.
+ * One at an employer nothing saved mentions has nowhere to read it from, which is
+ * why these need looking up separately.
+ */
+export function pendingOrganizationIds(pending: PendingHistory): string[] {
+  return Array.from(
+    new Set([
+      ...pending.positions.map(addition => addition.draft.company.id),
+      ...pending.education.map(addition => addition.draft.school.id),
+    ])
+  ).filter(id => id !== '');
 }

--- a/apps/web/core/profile/pending-history.ts
+++ b/apps/web/core/profile/pending-history.ts
@@ -198,6 +198,10 @@ export function mergePendingEducation(
         ...entryFromDraft(addition.key, addition.draft, addition.draft.degree, edge),
         status: addition.draft.status,
         fields: addition.draft.fields,
+        skills: addition.draft.skills,
+        grade: Number.isFinite(Number.parseFloat(addition.draft.grade))
+          ? Number.parseFloat(addition.draft.grade)
+          : null,
       }),
     })),
     removals,

--- a/apps/web/core/profile/pending-history.ts
+++ b/apps/web/core/profile/pending-history.ts
@@ -1,0 +1,158 @@
+import type {
+  EducationCard,
+  EducationEntry,
+  EmploymentCard,
+  EmploymentEntry,
+  HistoryCard,
+  HistoryEntry,
+} from './normalize-history';
+import type { EducationDraft, PositionDraft } from './stage-history';
+
+/**
+ * Marks a row that only exists in the modal. Rows carry a relation id everywhere
+ * else, so the prefix is what lets removal tell "drop this from the queue" from
+ * "queue a delete for something the graph already has".
+ */
+export const PENDING_PREFIX = 'pending:';
+
+export const isPending = (id: string) => id.startsWith(PENDING_PREFIX);
+
+export type PendingRemoval = { relationId: string; entityId: string; typeId: string };
+
+/** A draft plus the key its synthetic rows are built from. */
+export type PendingAddition<TDraft> = { key: string; draft: TDraft };
+
+export type PendingHistory = {
+  positions: PendingAddition<PositionDraft>[];
+  education: PendingAddition<EducationDraft>[];
+  removals: PendingRemoval[];
+};
+
+export const NOTHING_PENDING: PendingHistory = { positions: [], education: [], removals: [] };
+
+export function hasPendingChanges(pending: PendingHistory) {
+  return pending.positions.length > 0 || pending.education.length > 0 || pending.removals.length > 0;
+}
+
+/** Forgets an unsaved row. Nothing was written, so there is nothing to delete. */
+export function dropPendingAddition(pending: PendingHistory, relationId: string): PendingHistory {
+  const key = relationId.slice(PENDING_PREFIX.length);
+  return {
+    ...pending,
+    positions: pending.positions.filter(addition => addition.key !== key),
+    education: pending.education.filter(addition => addition.key !== key),
+  };
+}
+
+function entryFromDraft(
+  key: string,
+  draft: PositionDraft | EducationDraft,
+  subject: { id: string; name: string | null }
+): HistoryEntry {
+  return {
+    relationId: `${PENDING_PREFIX}${key}`,
+    tenureId: `${PENDING_PREFIX}${key}-tenure`,
+    subject,
+    startDate: draft.startDate,
+    endDate: draft.endDate,
+    description: draft.description.trim() === '' ? null : draft.description,
+    isLegacy: false,
+  };
+}
+
+/**
+ * Saved records with everything still pending folded in, so the list reads as the
+ * profile the user is about to have rather than the one they still have.
+ *
+ * A pending role at a company already listed joins that company's card, and one
+ * at a company not listed yet makes a card of its own. Matching is by
+ * organisation rather than by saved edge, so two roles added at the same new
+ * employer in one sitting group together rather than producing two cards that
+ * would merge only after a save and a refetch.
+ */
+function merge<TEntry extends HistoryEntry>(
+  saved: HistoryCard<TEntry>[],
+  additions: { key: string; draft: PositionDraft | EducationDraft; entry: TEntry }[],
+  removals: PendingRemoval[]
+): HistoryCard<TEntry>[] {
+  const removed = new Set(removals.map(removal => removal.relationId));
+
+  const cards: HistoryCard<TEntry>[] = saved.map(card => ({
+    ...card,
+    entries: card.entries.filter(entry => !removed.has(entry.relationId)),
+  }));
+
+  const byStint = new Map(cards.map(card => [card.stintId, card] as const));
+
+  for (const addition of additions) {
+    const organization =
+      'company' in addition.draft
+        ? { id: addition.draft.company.id, name: addition.draft.company.name }
+        : { id: addition.draft.school.id, name: addition.draft.school.name };
+
+    const existing = addition.draft.existingStintId
+      ? byStint.get(addition.draft.existingStintId)
+      : cards.find(card => card.organization.id === organization.id && !removed.has(card.relationId));
+
+    // Newest first, matching how the saved rows are sorted. The lookup is by
+    // organisation rather than by saved edge, so a second role added at an
+    // employer that is itself still unsaved joins the same card instead of
+    // producing a duplicate that would only merge after a save and a refetch.
+    if (existing) {
+      existing.entries = [addition.entry, ...existing.entries];
+      continue;
+    }
+
+    const card: HistoryCard<TEntry> = {
+      relationId: `${PENDING_PREFIX}${addition.key}-card`,
+      stintId: `${PENDING_PREFIX}${addition.key}-stint`,
+      organization,
+      entries: [addition.entry],
+    };
+    cards.push(card);
+  }
+
+  // A card whose rows have all gone is dropped: the organisation edge goes with
+  // the last row, so leaving it on screen would promise something the save will
+  // not deliver.
+  return cards.filter(card => !removed.has(card.relationId) && card.entries.length > 0);
+}
+
+export function mergePendingEmployment(
+  saved: EmploymentCard[],
+  additions: PendingAddition<PositionDraft>[],
+  removals: PendingRemoval[]
+): EmploymentCard[] {
+  return merge<EmploymentEntry>(
+    saved,
+    additions.map(addition => ({
+      ...addition,
+      entry: {
+        ...entryFromDraft(addition.key, addition.draft, addition.draft.title),
+        status: addition.draft.status,
+        employmentType: addition.draft.employmentType,
+        skills: addition.draft.skills,
+      },
+    })),
+    removals
+  );
+}
+
+export function mergePendingEducation(
+  saved: EducationCard[],
+  additions: PendingAddition<EducationDraft>[],
+  removals: PendingRemoval[]
+): EducationCard[] {
+  return merge<EducationEntry>(
+    saved,
+    additions.map(addition => ({
+      ...addition,
+      entry: {
+        ...entryFromDraft(addition.key, addition.draft, addition.draft.degree),
+        status: addition.draft.status,
+        fields: addition.draft.fields,
+      },
+    })),
+    removals
+  );
+}

--- a/apps/web/core/profile/rank-role-skills.test.ts
+++ b/apps/web/core/profile/rank-role-skills.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+
+import { type RoleSkill, normalizeRoleSkills, suggestSkills } from './rank-role-skills';
+
+const raw = (name: string, isRequired: boolean | null, rank: string | null) => ({
+  isRequired,
+  skill: { id: `skill-${name}`, name },
+  rank,
+});
+
+const skill = (name: string, isRequired: boolean, rank: number): RoleSkill => ({
+  id: `skill-${name}`,
+  name,
+  isRequired,
+  rank,
+});
+
+describe('normalizeRoleSkills', () => {
+  // The graph stores rank as an integer and GraphQL hands back a BigInt, which
+  // arrives as a string. Sorting those directly is lexicographic — right for 1–4
+  // by luck, wrong the moment the scale grows past 9.
+  it('reads the rank as a number rather than the string it arrives as', () => {
+    const [read] = normalizeRoleSkills([raw('Debug software', true, '3')]);
+
+    expect(read.rank).toBe(3);
+    expect(typeof read.rank).toBe('number');
+  });
+
+  it('sorts a skill with no scope below everything that has one', () => {
+    const skills = normalizeRoleSkills([raw('Unscoped', true, null), raw('Transversal', true, '1')]);
+
+    expect(suggestSkills(skills, []).map(entry => entry.name)).toEqual(['Transversal', 'Unscoped']);
+  });
+
+  it('treats a missing required flag as not required', () => {
+    const [read] = normalizeRoleSkills([raw('Debug software', null, '3')]);
+
+    expect(read.isRequired).toBe(false);
+  });
+
+  it('drops a relation whose skill did not resolve', () => {
+    expect(normalizeRoleSkills([{ isRequired: true, skill: null, rank: '3' }])).toEqual([]);
+  });
+});
+
+describe('suggestSkills', () => {
+  // What ranking is for. `Computer programming` is essential to Software
+  // developer and transversal, so it says almost nothing about the job — in live
+  // data `troubleshoot` is essential to 236 occupations.
+  it('puts the distinctive skills ahead of the ubiquitous ones', () => {
+    const suggestions = suggestSkills(
+      [
+        skill('Computer programming', true, 1),
+        skill('Use software libraries', true, 3),
+        skill('Troubleshoot', true, 2),
+      ],
+      []
+    );
+
+    expect(suggestions.map(entry => entry.name)).toEqual([
+      'Use software libraries',
+      'Troubleshoot',
+      'Computer programming',
+    ]);
+  });
+
+  // Rank alone would put an optional occupation-specific skill above an
+  // essential one, which is a worse answer than either rule gives on its own.
+  it('keeps every essential skill ahead of every optional one', () => {
+    const suggestions = suggestSkills([skill('Optional niche', false, 4), skill('Essential broad', true, 2)], []);
+
+    expect(suggestions.map(entry => entry.name)).toEqual(['Essential broad', 'Optional niche']);
+  });
+
+  // Roles exist with as few as eight essential skills, so filtering to essential
+  // ones alone leaves some showing two suggestions and a gap.
+  it('backfills from the optional skills when the essential ones run out', () => {
+    const suggestions = suggestSkills(
+      [skill('Essential', true, 3), skill('Optional A', false, 4), skill('Optional B', false, 2)],
+      []
+    );
+
+    expect(suggestions.map(entry => entry.name)).toEqual(['Essential', 'Optional A', 'Optional B']);
+  });
+
+  it('does not suggest a skill already on the draft', () => {
+    const suggestions = suggestSkills([skill('Kept', true, 3), skill('Picked', true, 4)], ['skill-Picked']);
+
+    expect(suggestions.map(entry => entry.name)).toEqual(['Kept']);
+  });
+
+  it('offers five at most', () => {
+    const skills = Array.from({ length: 12 }, (_, index) => skill(`Skill ${index}`, true, 3));
+
+    expect(suggestSkills(skills, [])).toHaveLength(5);
+  });
+
+  // A title somebody typed in themselves has nothing hanging off it. That is an
+  // empty list, not a worse one.
+  it('suggests nothing for a role with no skills', () => {
+    expect(suggestSkills([], [])).toEqual([]);
+  });
+});

--- a/apps/web/core/profile/rank-role-skills.ts
+++ b/apps/web/core/profile/rank-role-skills.ts
@@ -1,0 +1,78 @@
+/**
+ * Ranking an occupation's skills into something worth suggesting.
+ *
+ * Kept apart from the fetch so the ordering can be argued with in a test rather
+ * than against the live graph.
+ */
+
+export type RoleSkill = {
+  id: string;
+  name: string | null;
+  /** Essential to the occupation, as recorded on the role→skill relation. */
+  isRequired: boolean;
+  /**
+   * How widely the skill transfers: 1 transversal through 4 occupation-specific.
+   * Higher is more distinctive, so higher is a better suggestion.
+   */
+  rank: number;
+};
+
+type RawRoleSkill = {
+  isRequired: boolean | null;
+  skill: { id: string; name: string | null } | null;
+  rank: string | null;
+};
+
+/** Where a skill with no scope sorts: below everything that has one. */
+const UNSCOPED = 0;
+
+export function normalizeRoleSkills(rows: RawRoleSkill[]): RoleSkill[] {
+  const skills: RoleSkill[] = [];
+
+  for (const row of rows) {
+    if (!row.skill) continue;
+
+    // The graph stores rank as an integer and GraphQL hands it back as a BigInt,
+    // which arrives as a string. Sorting those directly is lexicographic, which
+    // happens to be right for 1–4 and would go wrong the moment the scale grows.
+    const rank = row.rank === null ? Number.NaN : Number.parseInt(row.rank, 10);
+
+    skills.push({
+      id: row.skill.id,
+      name: row.skill.name,
+      isRequired: row.isRequired === true,
+      rank: Number.isNaN(rank) ? UNSCOPED : rank,
+    });
+  }
+
+  return skills;
+}
+
+/**
+ * The five worth offering, given what the user has already picked.
+ *
+ * Essential skills first, then the most distinctive within each group. Both
+ * halves of that matter: taking the essential ones alone leaves roles with only
+ * a handful of them showing two suggestions, and ranking alone puts an optional
+ * occupation-specific skill above an essential one.
+ *
+ * Rank is what keeps the list from being useless. `Computer programming` is
+ * essential to Software developer and transversal, so it says almost nothing
+ * about the job and sorts last of the essential ones rather than into the five.
+ *
+ * Ties are left in the order the graph returned them. The relation's `position`
+ * looks like it should break them and does not — it encodes only that essential
+ * sorts before optional, and within each group it is whatever ESCO happened to
+ * hand over.
+ */
+export function suggestSkills(skills: RoleSkill[], alreadyPicked: string[], limit = 5): RoleSkill[] {
+  const picked = new Set(alreadyPicked);
+
+  return skills
+    .filter(skill => !picked.has(skill.id))
+    .sort((a, b) => {
+      if (a.isRequired !== b.isRequired) return a.isRequired ? -1 : 1;
+      return b.rank - a.rank;
+    })
+    .slice(0, limit);
+}

--- a/apps/web/core/profile/stage-history.test.ts
+++ b/apps/web/core/profile/stage-history.test.ts
@@ -1,0 +1,233 @@
+import { SystemIds } from '@geoprotocol/geo-sdk/lite';
+
+import { describe, expect, it } from 'vitest';
+
+import type { Relation } from '~/core/types';
+
+import {
+  ACADEMIC_FIELDS_PROPERTY,
+  COMPANY_TYPE,
+  DEGREE_PROPERTY,
+  DESCRIPTION_PROPERTY,
+  EDUCATION_PROPERTY,
+  EDUCATION_STATUS_COMPLETED,
+  EDUCATION_STATUS_PROPERTY,
+  EMPLOYMENT_PROPERTY,
+  EMPLOYMENT_STATUS_CURRENT,
+  EMPLOYMENT_STATUS_FORMER,
+  EMPLOYMENT_STATUS_PROPERTY,
+  END_DATE_PROPERTY,
+  JOB_TYPE,
+  ROLES_PROPERTY,
+  START_DATE_PROPERTY,
+} from './history-ontology';
+import { type EducationDraft, type PositionDraft, stageEducation, stagePosition } from './stage-history';
+
+const context = { personEntityId: 'person-1', spaceId: 'space-1' };
+
+const picked = (id: string, name: string) => ({ id, name, isNew: false });
+const created = (id: string, name: string) => ({ id, name, isNew: true });
+
+const position = (overrides: Partial<PositionDraft> = {}): PositionDraft => ({
+  company: picked('coinbase', 'Coinbase'),
+  title: picked('analyst', 'Data Analyst'),
+  startDate: '2019-03-01Z',
+  endDate: '2021-01-01Z',
+  status: 'former',
+  description: '',
+  ...overrides,
+});
+
+const education = (overrides: Partial<EducationDraft> = {}): EducationDraft => ({
+  school: picked('northumbria', 'Northumbria University'),
+  degree: picked('phd', 'Ph.D.'),
+  fields: [picked('finance', 'Finance')],
+  startDate: '2022-09-01Z',
+  endDate: null,
+  status: 'studying',
+  description: '',
+  ...overrides,
+});
+
+const byType = (relations: Relation[], typeId: string) => relations.filter(r => r.type.id === typeId);
+const oneOf = (relations: Relation[], typeId: string) => {
+  const matches = byType(relations, typeId);
+  expect(matches).toHaveLength(1);
+  return matches[0];
+};
+
+describe('stagePosition', () => {
+  it('links person → company → role → status, each level hanging off the one above', () => {
+    const { relations } = stagePosition(position(), context);
+
+    const employment = oneOf(relations, EMPLOYMENT_PROPERTY);
+    expect(employment.fromEntity.id).toBe('person-1');
+    expect(employment.toEntity.id).toBe('coinbase');
+
+    // The Roles edge hangs off the Employment relation's own entity — the stint —
+    // not off the company and not off the person.
+    const roles = oneOf(relations, ROLES_PROPERTY);
+    expect(roles.fromEntity.id).toBe(employment.entityId);
+    expect(roles.toEntity.id).toBe('analyst');
+
+    // Status belongs to the tenure, so one company can hold a role left in 2021
+    // and a role held now.
+    const status = oneOf(relations, EMPLOYMENT_STATUS_PROPERTY);
+    expect(status.fromEntity.id).toBe(roles.entityId);
+    expect(status.toEntity.id).toBe(EMPLOYMENT_STATUS_FORMER);
+  });
+
+  it('puts the dates on the tenure rather than the stint', () => {
+    const { values, relations } = stagePosition(position(), context);
+    const roles = oneOf(relations, ROLES_PROPERTY);
+
+    const start = values.find(value => value.property.id === START_DATE_PROPERTY);
+    const end = values.find(value => value.property.id === END_DATE_PROPERTY);
+
+    expect(start).toMatchObject({ entity: { id: roles.entityId }, value: '2019-03-01Z' });
+    expect(end).toMatchObject({ entity: { id: roles.entityId }, value: '2021-01-01Z' });
+    expect(start?.property.dataType).toBe('DATE');
+  });
+
+  // The promotion case: the company edge already exists, so this costs a relation,
+  // an entity and its dates rather than the full six rows.
+  it('reuses an existing stint when adding a second role at the same company', () => {
+    const { relations } = stagePosition(position({ existingStintId: 'stint-1' }), context);
+
+    expect(byType(relations, EMPLOYMENT_PROPERTY)).toHaveLength(0);
+    expect(oneOf(relations, ROLES_PROPERTY).fromEntity.id).toBe('stint-1');
+  });
+
+  it('leaves End date unwritten for a role still held', () => {
+    const { values } = stagePosition(position({ endDate: null, status: 'current' }), context);
+
+    expect(values.find(value => value.property.id === END_DATE_PROPERTY)).toBeUndefined();
+  });
+
+  it('marks a role still held as Current', () => {
+    const { relations } = stagePosition(position({ status: 'current' }), context);
+
+    expect(oneOf(relations, EMPLOYMENT_STATUS_PROPERTY).toEntity.id).toBe(EMPLOYMENT_STATUS_CURRENT);
+  });
+
+  it('omits an empty description rather than writing a blank value', () => {
+    const { values } = stagePosition(position({ description: '   ' }), context);
+
+    expect(values.find(value => value.property.id === DESCRIPTION_PROPERTY)).toBeUndefined();
+  });
+
+  // `SelectEntity` mints the id and hands it back; nothing exists behind it until
+  // a name is written, and an unnamed target renders as a blank row.
+  it('names and types a company the user typed rather than picked', () => {
+    const { values, relations } = stagePosition(
+      position({ company: created('new-co', 'Fathom'), title: created('new-title', 'Staff Engineer') }),
+      context
+    );
+
+    expect(values).toContainEqual(expect.objectContaining({ entity: { id: 'new-co', name: null }, value: 'Fathom' }));
+
+    const types = byType(relations, SystemIds.TYPES_PROPERTY);
+    expect(types.map(relation => [relation.fromEntity.id, relation.toEntity.id])).toEqual(
+      expect.arrayContaining([
+        ['new-co', COMPANY_TYPE],
+        ['new-title', JOB_TYPE],
+      ])
+    );
+  });
+
+  it('writes nothing extra for an entity that already existed', () => {
+    const { relations } = stagePosition(position(), context);
+
+    expect(byType(relations, SystemIds.TYPES_PROPERTY)).toHaveLength(0);
+  });
+
+  it('gives every row the space being published to', () => {
+    const { values, relations } = stagePosition(position({ company: created('new-co', 'Fathom') }), context);
+
+    for (const row of [...values, ...relations]) expect(row.spaceId).toBe('space-1');
+  });
+});
+
+describe('stageEducation', () => {
+  it('links person → school → degree, with fields and status on the enrolment', () => {
+    const { relations } = stageEducation(education({ status: 'completed' }), context);
+
+    const record = oneOf(relations, EDUCATION_PROPERTY);
+    expect(record.fromEntity.id).toBe('person-1');
+
+    const degree = oneOf(relations, DEGREE_PROPERTY);
+    expect(degree.fromEntity.id).toBe(record.entityId);
+
+    const field = oneOf(relations, ACADEMIC_FIELDS_PROPERTY);
+    expect(field.fromEntity.id).toBe(degree.entityId);
+    expect(field.toEntity.id).toBe('finance');
+
+    expect(oneOf(relations, EDUCATION_STATUS_PROPERTY).toEntity.id).toBe(EDUCATION_STATUS_COMPLETED);
+  });
+
+  // A joint honours degree needs more than one, which is why it is a relation.
+  it('can carry more than one academic field', () => {
+    const { relations } = stageEducation(
+      education({ fields: [picked('finance', 'Finance'), picked('econ', 'Economics')] }),
+      context
+    );
+
+    expect(byType(relations, ACADEMIC_FIELDS_PROPERTY).map(r => r.toEntity.id)).toEqual(['finance', 'econ']);
+  });
+
+  // The graph has Completed and Incomplete and nothing for in-progress. Inventing
+  // one would be worse than leaving it unsaid; the empty End date carries it.
+  it('writes no status at all for still studying', () => {
+    const { relations } = stageEducation(education({ status: 'studying' }), context);
+
+    expect(byType(relations, EDUCATION_STATUS_PROPERTY)).toHaveLength(0);
+  });
+
+  it('creates an Academic field others can then find', () => {
+    const { values, relations } = stageEducation(
+      education({ fields: [created('new-field', 'Computer Science')] }),
+      context
+    );
+
+    expect(values).toContainEqual(
+      expect.objectContaining({ entity: { id: 'new-field', name: null }, value: 'Computer Science' })
+    );
+    expect(byType(relations, SystemIds.TYPES_PROPERTY).map(r => r.toEntity.id)).toContain(
+      SystemIds.ACADEMIC_FIELD_TYPE
+    );
+  });
+
+  it('reuses an existing record when adding a second degree at the same school', () => {
+    const { relations } = stageEducation(education({ existingStintId: 'record-1' }), context);
+
+    expect(byType(relations, EDUCATION_PROPERTY)).toHaveLength(0);
+    expect(oneOf(relations, DEGREE_PROPERTY).fromEntity.id).toBe('record-1');
+  });
+});
+
+describe('row identity', () => {
+  // Every row in one edit has to be distinct, or the store collapses two of them
+  // and the position publishes with a level missing.
+  it('gives every relation in a position its own id and entity', () => {
+    const { relations } = stagePosition(
+      position({ company: created('new-co', 'Fathom'), title: created('new-title', 'Staff Engineer') }),
+      context
+    );
+
+    const ids = relations.map(relation => relation.id);
+    const entityIds = relations.map(relation => relation.entityId);
+
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(new Set(entityIds).size).toBe(entityIds.length);
+  });
+
+  it('gives every value in an education record its own id', () => {
+    const { values } = stageEducation(
+      education({ description: 'Thesis on market microstructure.', endDate: '2026-06-01Z' }),
+      context
+    );
+
+    const ids = values.map(value => value.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});

--- a/apps/web/core/profile/stage-history.test.ts
+++ b/apps/web/core/profile/stage-history.test.ts
@@ -6,23 +6,28 @@ import type { Relation } from '~/core/types';
 
 import {
   ACADEMIC_FIELDS_PROPERTY,
+  DEGREE_INFORMATION_TYPE,
   DEGREE_PROPERTY,
   DEGREE_TYPE,
   DESCRIPTION_PROPERTY,
   EDUCATION_PROPERTY,
+  EDUCATION_RECORD_TYPE,
   EDUCATION_STATUS_COMPLETED,
   EDUCATION_STATUS_PROPERTY,
   EMPLOYER_TYPE,
   EMPLOYMENT_PROPERTY,
+  EMPLOYMENT_RECORD_TYPE,
   EMPLOYMENT_STATUS_CURRENT,
   EMPLOYMENT_STATUS_FORMER,
   EMPLOYMENT_STATUS_PROPERTY,
   END_DATE_PROPERTY,
+  GRADE_PROPERTY,
   JOB_TYPE,
   LOCATION_PROPERTY,
   LOCATION_TYPE_PROPERTY,
   ROLES_PROPERTY,
   ROLE_INFORMATION_TYPE,
+  SKILLS_PROPERTY,
   START_DATE_PROPERTY,
 } from './history-ontology';
 import { type EducationDraft, type PositionDraft, stageEducation, stagePosition } from './stage-history';
@@ -50,6 +55,8 @@ const education = (overrides: Partial<EducationDraft> = {}): EducationDraft => (
   school: picked('northumbria', 'Northumbria University'),
   degree: picked('phd', 'Ph.D.'),
   fields: [picked('finance', 'Finance')],
+  skills: [],
+  grade: '',
   startDate: '2022-09-01Z',
   endDate: null,
   status: 'studying',
@@ -148,10 +155,12 @@ describe('stagePosition', () => {
 
     expect(values.filter(value => value.property.id === SystemIds.NAME_PROPERTY)).toHaveLength(0);
 
-    // The tenure's own type is the exception, and it is not about either picked
-    // entity: it is minted here, so nothing else is going to type it.
+    // The two relation entities are the exception, and neither is about a picked
+    // entity: both are minted here, so nothing else is going to type them.
     const types = byType(relations, SystemIds.TYPES_PROPERTY);
-    expect(types.map(relation => relation.toEntity.id)).toEqual([ROLE_INFORMATION_TYPE]);
+    expect(types.map(relation => relation.toEntity.id).sort()).toEqual(
+      [EMPLOYMENT_RECORD_TYPE, ROLE_INFORMATION_TYPE].sort()
+    );
   });
 
   // `Roles` declares `Role information` as its relation entity type. An untyped
@@ -210,6 +219,27 @@ describe('stagePosition', () => {
     );
   });
 
+  // Each level says what it is. Untyped, a relation entity is reachable only by
+  // walking in from the person holding it.
+  it('types the employment record as well as the tenure', () => {
+    const { relations } = stagePosition(position(), context);
+
+    const employment = oneOf(relations, EMPLOYMENT_PROPERTY);
+    const roles = oneOf(relations, ROLES_PROPERTY);
+    const types = byType(relations, SystemIds.TYPES_PROPERTY);
+
+    expect(types.find(t => t.toEntity.id === EMPLOYMENT_RECORD_TYPE)?.fromEntity.id).toBe(employment.entityId);
+    expect(types.find(t => t.toEntity.id === ROLE_INFORMATION_TYPE)?.fromEntity.id).toBe(roles.entityId);
+  });
+
+  // A promotion reuses the stint, which is already typed, so typing it again
+  // would write a second identical Types relation onto it.
+  it('does not retype an employment record it did not create', () => {
+    const { relations } = stagePosition(position({ existingStintId: 'stint-1' }), context);
+
+    expect(byType(relations, SystemIds.TYPES_PROPERTY).map(t => t.toEntity.id)).toEqual([ROLE_INFORMATION_TYPE]);
+  });
+
   it('gives every row the space being published to', () => {
     const { values, relations } = stagePosition(position({ company: created('new-co', 'Fathom') }), context);
 
@@ -254,6 +284,47 @@ describe('stageEducation', () => {
 
   // Same reason a job title is typed: an untyped degree never turns up in the
   // scoped search that would stop the next person creating a second one.
+  it('types the education record and the enrolment', () => {
+    const { relations } = stageEducation(education(), context);
+
+    const record = oneOf(relations, EDUCATION_PROPERTY);
+    const degree = oneOf(relations, DEGREE_PROPERTY);
+    const types = byType(relations, SystemIds.TYPES_PROPERTY);
+
+    expect(types.find(t => t.toEntity.id === EDUCATION_RECORD_TYPE)?.fromEntity.id).toBe(record.entityId);
+    expect(types.find(t => t.toEntity.id === DEGREE_INFORMATION_TYPE)?.fromEntity.id).toBe(degree.entityId);
+  });
+
+  // Decimal, so it sorts and filters as a number rather than as the string
+  // somebody would otherwise type into the description.
+  it('writes a grade on the enrolment as a decimal', () => {
+    const { values, relations } = stageEducation(education({ grade: '3.8' }), context);
+    const degree = oneOf(relations, DEGREE_PROPERTY);
+
+    const grade = values.find(value => value.property.id === GRADE_PROPERTY);
+    expect(grade).toMatchObject({ entity: { id: degree.entityId }, value: '3.8' });
+    expect(grade?.property.dataType).toBe('DECIMAL');
+  });
+
+  // A classification or a pass has nowhere to go under a numeric property, and
+  // storing it as text there would break every reader that expects a number.
+  it('leaves a grade that is not a number unwritten', () => {
+    for (const grade of ['', '  ', 'First class honours', 'Pass']) {
+      const { values } = stageEducation(education({ grade }), context);
+      expect(values.find(value => value.property.id === GRADE_PROPERTY)).toBeUndefined();
+    }
+  });
+
+  it('hangs skills off the enrolment, beside the dates', () => {
+    const { relations } = stageEducation(education({ skills: [picked('stats', 'Statistics')] }), context);
+
+    const degree = oneOf(relations, DEGREE_PROPERTY);
+    expect(oneOf(relations, SKILLS_PROPERTY)).toMatchObject({
+      fromEntity: { id: degree.entityId },
+      toEntity: { id: 'stats' },
+    });
+  });
+
   it('names and types a degree the user typed rather than picked', () => {
     const { values, relations } = stageEducation(education({ degree: created('new-degree', 'MPhil') }), context);
 

--- a/apps/web/core/profile/stage-history.test.ts
+++ b/apps/web/core/profile/stage-history.test.ts
@@ -18,6 +18,8 @@ import {
   EMPLOYMENT_STATUS_PROPERTY,
   END_DATE_PROPERTY,
   JOB_TYPE,
+  LOCATION_PROPERTY,
+  LOCATION_TYPE_PROPERTY,
   ROLES_PROPERTY,
   ROLE_INFORMATION_TYPE,
   START_DATE_PROPERTY,
@@ -34,6 +36,8 @@ const position = (overrides: Partial<PositionDraft> = {}): PositionDraft => ({
   title: picked('analyst', 'Data Analyst'),
   employmentType: null,
   skills: [],
+  location: null,
+  locationType: null,
   startDate: '2019-03-01Z',
   endDate: '2021-01-01Z',
   status: 'former',
@@ -160,6 +164,49 @@ describe('stagePosition', () => {
     );
 
     expect(tenureType?.fromEntity.id).toBe(roles?.entityId);
+  });
+
+  // Beside the dates, for the same reason: a job moves city and goes remote
+  // without becoming a different job, and the role it is a promotion from may
+  // have been neither.
+  it('puts location and location type on the tenure', () => {
+    const { relations } = stagePosition(
+      position({
+        location: picked('city-sf', 'San Francisco'),
+        locationType: { id: 'loc-remote', name: 'Remote' },
+      }),
+      context
+    );
+
+    const roles = oneOf(relations, ROLES_PROPERTY);
+
+    expect(oneOf(relations, LOCATION_PROPERTY)).toMatchObject({
+      fromEntity: { id: roles.entityId },
+      toEntity: { id: 'city-sf' },
+    });
+    expect(oneOf(relations, LOCATION_TYPE_PROPERTY)).toMatchObject({
+      fromEntity: { id: roles.entityId },
+      toEntity: { id: 'loc-remote' },
+    });
+  });
+
+  // Optional on LinkedIn and optional here. A dangling relation to nothing is
+  // worse than an unanswered question.
+  it('writes neither when they are left unanswered', () => {
+    const { relations } = stagePosition(position(), context);
+
+    expect(byType(relations, LOCATION_PROPERTY)).toHaveLength(0);
+    expect(byType(relations, LOCATION_TYPE_PROPERTY)).toHaveLength(0);
+  });
+
+  // A city the graph has not heard of still has to be a place rather than a
+  // string, or the next person typing it makes a second one.
+  it('names and types a city the user typed rather than picked', () => {
+    const { values } = stagePosition(position({ location: created('new-city', 'Cincinnati') }), context);
+
+    expect(values).toContainEqual(
+      expect.objectContaining({ entity: { id: 'new-city', name: null }, value: 'Cincinnati' })
+    );
   });
 
   it('gives every row the space being published to', () => {

--- a/apps/web/core/profile/stage-history.test.ts
+++ b/apps/web/core/profile/stage-history.test.ts
@@ -19,6 +19,7 @@ import {
   END_DATE_PROPERTY,
   JOB_TYPE,
   ROLES_PROPERTY,
+  ROLE_INFORMATION_TYPE,
   START_DATE_PROPERTY,
 } from './history-ontology';
 import { type EducationDraft, type PositionDraft, stageEducation, stagePosition } from './stage-history';
@@ -137,10 +138,28 @@ describe('stagePosition', () => {
     );
   });
 
-  it('writes nothing extra for an entity that already existed', () => {
+  it('names and types nothing for entities that already existed', () => {
+    const { values, relations } = stagePosition(position(), context);
+
+    expect(values.filter(value => value.property.id === SystemIds.NAME_PROPERTY)).toHaveLength(0);
+
+    // The tenure's own type is the exception, and it is not about either picked
+    // entity: it is minted here, so nothing else is going to type it.
+    const types = byType(relations, SystemIds.TYPES_PROPERTY);
+    expect(types.map(relation => relation.toEntity.id)).toEqual([ROLE_INFORMATION_TYPE]);
+  });
+
+  // `Roles` declares `Role information` as its relation entity type. An untyped
+  // tenure is reachable only by walking in from the person who holds it.
+  it('types the tenure as Role information', () => {
     const { relations } = stagePosition(position(), context);
 
-    expect(byType(relations, SystemIds.TYPES_PROPERTY)).toHaveLength(0);
+    const roles = relations.find(relation => relation.type.id === ROLES_PROPERTY);
+    const tenureType = byType(relations, SystemIds.TYPES_PROPERTY).find(
+      relation => relation.toEntity.id === ROLE_INFORMATION_TYPE
+    );
+
+    expect(tenureType?.fromEntity.id).toBe(roles?.entityId);
   });
 
   it('gives every row the space being published to', () => {

--- a/apps/web/core/profile/stage-history.test.ts
+++ b/apps/web/core/profile/stage-history.test.ts
@@ -5,7 +5,6 @@ import { describe, expect, it } from 'vitest';
 import type { Relation } from '~/core/types';
 
 import {
-  ACADEMIC_FIELDS_PROPERTY,
   DEGREE_INFORMATION_TYPE,
   DEGREE_PROPERTY,
   DEGREE_TYPE,
@@ -21,6 +20,7 @@ import {
   EMPLOYMENT_STATUS_FORMER,
   EMPLOYMENT_STATUS_PROPERTY,
   END_DATE_PROPERTY,
+  FIELDS_OF_STUDY_PROPERTY,
   GRADE_PROPERTY,
   JOB_TYPE,
   LOCATION_PROPERTY,
@@ -257,7 +257,7 @@ describe('stageEducation', () => {
     const degree = oneOf(relations, DEGREE_PROPERTY);
     expect(degree.fromEntity.id).toBe(record.entityId);
 
-    const field = oneOf(relations, ACADEMIC_FIELDS_PROPERTY);
+    const field = oneOf(relations, FIELDS_OF_STUDY_PROPERTY);
     expect(field.fromEntity.id).toBe(degree.entityId);
     expect(field.toEntity.id).toBe('finance');
 
@@ -271,7 +271,7 @@ describe('stageEducation', () => {
       context
     );
 
-    expect(byType(relations, ACADEMIC_FIELDS_PROPERTY).map(r => r.toEntity.id)).toEqual(['finance', 'econ']);
+    expect(byType(relations, FIELDS_OF_STUDY_PROPERTY).map(r => r.toEntity.id)).toEqual(['finance', 'econ']);
   });
 
   // The graph has Completed and Incomplete and nothing for in-progress. Inventing
@@ -338,7 +338,7 @@ describe('stageEducation', () => {
     ).toBe(true);
   });
 
-  it('creates an Academic field others can then find', () => {
+  it('creates a Field of study others can then find', () => {
     const { values, relations } = stageEducation(
       education({ fields: [created('new-field', 'Computer Science')] }),
       context

--- a/apps/web/core/profile/stage-history.test.ts
+++ b/apps/web/core/profile/stage-history.test.ts
@@ -6,12 +6,12 @@ import type { Relation } from '~/core/types';
 
 import {
   ACADEMIC_FIELDS_PROPERTY,
-  COMPANY_TYPE,
   DEGREE_PROPERTY,
   DESCRIPTION_PROPERTY,
   EDUCATION_PROPERTY,
   EDUCATION_STATUS_COMPLETED,
   EDUCATION_STATUS_PROPERTY,
+  EMPLOYER_TYPE,
   EMPLOYMENT_PROPERTY,
   EMPLOYMENT_STATUS_CURRENT,
   EMPLOYMENT_STATUS_FORMER,
@@ -129,7 +129,7 @@ describe('stagePosition', () => {
     const types = byType(relations, SystemIds.TYPES_PROPERTY);
     expect(types.map(relation => [relation.fromEntity.id, relation.toEntity.id])).toEqual(
       expect.arrayContaining([
-        ['new-co', COMPANY_TYPE],
+        ['new-co', EMPLOYER_TYPE],
         ['new-title', JOB_TYPE],
       ])
     );

--- a/apps/web/core/profile/stage-history.test.ts
+++ b/apps/web/core/profile/stage-history.test.ts
@@ -31,6 +31,8 @@ const created = (id: string, name: string) => ({ id, name, isNew: true });
 const position = (overrides: Partial<PositionDraft> = {}): PositionDraft => ({
   company: picked('coinbase', 'Coinbase'),
   title: picked('analyst', 'Data Analyst'),
+  employmentType: null,
+  skills: [],
   startDate: '2019-03-01Z',
   endDate: '2021-01-01Z',
   status: 'former',

--- a/apps/web/core/profile/stage-history.test.ts
+++ b/apps/web/core/profile/stage-history.test.ts
@@ -7,6 +7,7 @@ import type { Relation } from '~/core/types';
 import {
   ACADEMIC_FIELDS_PROPERTY,
   DEGREE_PROPERTY,
+  DEGREE_TYPE,
   DESCRIPTION_PROPERTY,
   EDUCATION_PROPERTY,
   EDUCATION_STATUS_COMPLETED,
@@ -249,6 +250,21 @@ describe('stageEducation', () => {
     const { relations } = stageEducation(education({ status: 'studying' }), context);
 
     expect(byType(relations, EDUCATION_STATUS_PROPERTY)).toHaveLength(0);
+  });
+
+  // Same reason a job title is typed: an untyped degree never turns up in the
+  // scoped search that would stop the next person creating a second one.
+  it('names and types a degree the user typed rather than picked', () => {
+    const { values, relations } = stageEducation(education({ degree: created('new-degree', 'MPhil') }), context);
+
+    expect(values).toContainEqual(
+      expect.objectContaining({ entity: { id: 'new-degree', name: null }, value: 'MPhil' })
+    );
+    expect(
+      byType(relations, SystemIds.TYPES_PROPERTY).some(
+        relation => relation.fromEntity.id === 'new-degree' && relation.toEntity.id === DEGREE_TYPE
+      )
+    ).toBe(true);
   });
 
   it('creates an Academic field others can then find', () => {

--- a/apps/web/core/profile/stage-history.ts
+++ b/apps/web/core/profile/stage-history.ts
@@ -4,8 +4,6 @@ import { ID } from '~/core/id';
 import type { Relation, Value } from '~/core/types';
 
 import {
-  ACADEMIC_FIELDS_PROPERTY,
-  ACADEMIC_FIELD_TYPE,
   CITY_TYPE,
   DEGREE_INFORMATION_TYPE,
   DEGREE_PROPERTY,
@@ -24,6 +22,8 @@ import {
   END_DATE_PROPERTY,
   type EducationStatus,
   type EmploymentStatus,
+  FIELDS_OF_STUDY_PROPERTY,
+  FIELD_OF_STUDY_TYPE,
   GRADE_PROPERTY,
   JOB_TYPE,
   LOCATION_PROPERTY,
@@ -372,7 +372,7 @@ export function stagePosition(
 
 /**
  * One education record, as one edit. A level heavier than a position, because
- * `Academic fields` is a relation and can repeat for a joint honours degree.
+ * `Fields of study` is a relation and can repeat for a joint honours degree.
  */
 export function stageEducation(
   draft: EducationDraft,
@@ -412,7 +412,7 @@ export function stageEducation(
 
   const enrolmentType = typeRow(spaceId, enrolmentId, DEGREE_INFORMATION_TYPE, 'Degree information');
 
-  const fieldRows = draft.fields.map(field => newEntityRows(field, spaceId, [ACADEMIC_FIELD_TYPE]));
+  const fieldRows = draft.fields.map(field => newEntityRows(field, spaceId, [FIELD_OF_STUDY_TYPE]));
 
   const skillRows = draft.skills.map(skill => newEntityRows(skill, spaceId, [SKILL_TYPE]));
   const skillEdges = draft.skills.map(skill =>
@@ -439,8 +439,8 @@ export function stageEducation(
   const fieldEdges = draft.fields.map(field =>
     relationRow({
       spaceId,
-      typeId: ACADEMIC_FIELDS_PROPERTY,
-      typeName: 'Academic fields',
+      typeId: FIELDS_OF_STUDY_PROPERTY,
+      typeName: 'Fields of study',
       fromId: enrolmentId,
       to: field,
     })
@@ -538,7 +538,7 @@ export function educationDraftFromEntry(
     degree: { id: entry.subject.id, name: entry.subject.name, isNew: false },
     // The legacy field-of-study text is shown with no id behind it. There is no
     // entity to relate to, so it cannot come back into a draft — it stays where
-    // it is, on the stint, until someone picks a real Academic field.
+    // it is, on the stint, until someone picks a real Field of study.
     fields: entry.fields.filter(field => field.id !== '').map(field => ({ ...field, isNew: false })),
     skills: entry.skills.map(skill => ({ id: skill.id, name: skill.name, isNew: false })),
     grade: entry.grade === null ? '' : String(entry.grade),

--- a/apps/web/core/profile/stage-history.ts
+++ b/apps/web/core/profile/stage-history.ts
@@ -15,11 +15,14 @@ import {
   EMPLOYMENT_PROPERTY,
   EMPLOYMENT_STATUS_OPTION,
   EMPLOYMENT_STATUS_PROPERTY,
+  EMPLOYMENT_TYPE_PROPERTY,
   END_DATE_PROPERTY,
   type EducationStatus,
   type EmploymentStatus,
   JOB_TYPE,
   ROLES_PROPERTY,
+  SKILLS_PROPERTY,
+  SKILL_TYPE,
   START_DATE_PROPERTY,
 } from './history-ontology';
 
@@ -29,6 +32,10 @@ export type EntityChoice = { id: string; name: string | null; isNew: boolean };
 export type PositionDraft = {
   company: EntityChoice;
   title: EntityChoice;
+  /** Full-time, Contract, and so on. Optional — LinkedIn leaves it unset too. */
+  employmentType: { id: string; name: string } | null;
+  /** Repeats, so it is a relation rather than a value. */
+  skills: EntityChoice[];
   startDate: string | null;
   endDate: string | null;
   status: EmploymentStatus;
@@ -249,8 +256,33 @@ export function stagePosition(draft: PositionDraft, { personEntityId, spaceId }:
     to: { id: EMPLOYMENT_STATUS_OPTION[draft.status], name: draft.status === 'current' ? 'Current' : 'Former' },
   });
 
-  return merge(company, title, employment, {
-    relations: [roles, status],
+  // Both hang off the tenure, beside the dates: a promotion can be full-time
+  // where the role before it was an internship, and the skills differ with it.
+  const employmentType = draft.employmentType
+    ? [
+        relationRow({
+          spaceId,
+          typeId: EMPLOYMENT_TYPE_PROPERTY,
+          typeName: 'Employment type',
+          fromId: tenureId,
+          to: draft.employmentType,
+        }),
+      ]
+    : [];
+
+  const skillRows = draft.skills.map(skill => newEntityRows(skill, spaceId, SKILL_TYPE));
+  const skillEdges = draft.skills.map(skill =>
+    relationRow({
+      spaceId,
+      typeId: SKILLS_PROPERTY,
+      typeName: 'Skills',
+      fromId: tenureId,
+      to: skill,
+    })
+  );
+
+  return merge(company, title, ...skillRows, employment, {
+    relations: [roles, status, ...employmentType, ...skillEdges],
     values: datesAndDescription({
       spaceId,
       tenureId,

--- a/apps/web/core/profile/stage-history.ts
+++ b/apps/web/core/profile/stage-history.ts
@@ -1,0 +1,337 @@
+import { Position, SystemIds } from '@geoprotocol/geo-sdk/lite';
+
+import { ID } from '~/core/id';
+import type { Relation, Value } from '~/core/types';
+
+import {
+  ACADEMIC_FIELDS_PROPERTY,
+  ACADEMIC_FIELD_TYPE,
+  COMPANY_TYPE,
+  DEGREE_PROPERTY,
+  DESCRIPTION_PROPERTY,
+  EDUCATION_PROPERTY,
+  EDUCATION_STATUS_OPTION,
+  EDUCATION_STATUS_PROPERTY,
+  EMPLOYMENT_PROPERTY,
+  EMPLOYMENT_STATUS_OPTION,
+  EMPLOYMENT_STATUS_PROPERTY,
+  END_DATE_PROPERTY,
+  type EducationStatus,
+  type EmploymentStatus,
+  JOB_TYPE,
+  ROLES_PROPERTY,
+  START_DATE_PROPERTY,
+} from './history-ontology';
+
+/** An entity the sheet picked, or one it is about to mint. */
+export type EntityChoice = { id: string; name: string | null; isNew: boolean };
+
+export type PositionDraft = {
+  company: EntityChoice;
+  title: EntityChoice;
+  startDate: string | null;
+  endDate: string | null;
+  status: EmploymentStatus;
+  description: string;
+  /**
+   * Set when adding a second role at a company already on the profile. The
+   * Employment edge and its stint already exist, so this write is one relation,
+   * one entity and its dates rather than the full six rows.
+   */
+  existingStintId?: string;
+};
+
+export type EducationDraft = {
+  school: EntityChoice;
+  degree: EntityChoice;
+  fields: EntityChoice[];
+  startDate: string | null;
+  endDate: string | null;
+  status: EducationStatus;
+  description: string;
+  existingStintId?: string;
+};
+
+export type StagedRows = { values: Value[]; relations: Relation[] };
+
+type Context = { personEntityId: string; spaceId: string };
+
+function relationRow(params: {
+  spaceId: string;
+  typeId: string;
+  typeName: string;
+  fromId: string;
+  fromName?: string | null;
+  to: { id: string; name: string | null };
+  /** The relation's own entity — the level the next tier hangs off. */
+  entityId?: string;
+}): Relation {
+  return {
+    id: ID.createEntityId(),
+    entityId: params.entityId ?? ID.createEntityId(),
+    spaceId: params.spaceId,
+    position: Position.generate(),
+    renderableType: 'RELATION',
+    verified: false,
+    type: { id: params.typeId, name: params.typeName },
+    fromEntity: { id: params.fromId, name: params.fromName ?? null },
+    toEntity: { id: params.to.id, name: params.to.name, value: params.to.id },
+  };
+}
+
+function valueRow(params: {
+  spaceId: string;
+  entityId: string;
+  propertyId: string;
+  propertyName: string;
+  dataType: 'TEXT' | 'DATE';
+  value: string;
+}): Value {
+  return {
+    id: ID.createValueId({ entityId: params.entityId, propertyId: params.propertyId, spaceId: params.spaceId }),
+    entity: { id: params.entityId, name: null },
+    property: {
+      id: params.propertyId,
+      name: params.propertyName,
+      dataType: params.dataType,
+      renderableType: params.dataType === 'DATE' ? 'DATE' : 'TEXT',
+    },
+    spaceId: params.spaceId,
+    value: params.value,
+  };
+}
+
+/**
+ * A company, job title, school or field the user typed rather than picked.
+ *
+ * `SelectEntity` mints the id and hands it back; nothing exists behind it until
+ * someone writes a name. Without this the relation points at an entity with no
+ * name, which renders as a blank row that cannot be searched for afterwards.
+ */
+function newEntityRows(choice: EntityChoice, spaceId: string, typeId?: string): StagedRows {
+  if (!choice.isNew || !choice.name) return { values: [], relations: [] };
+
+  const values = [
+    valueRow({
+      spaceId,
+      entityId: choice.id,
+      propertyId: SystemIds.NAME_PROPERTY,
+      propertyName: 'Name',
+      dataType: 'TEXT',
+      value: choice.name,
+    }),
+  ];
+
+  // Typed where the type is known and verified. An untyped entity still works as
+  // a target, but never turns up in the scoped search that would stop the next
+  // person creating a second one just like it.
+  const relations = typeId
+    ? [
+        relationRow({
+          spaceId,
+          typeId: SystemIds.TYPES_PROPERTY,
+          typeName: 'Types',
+          fromId: choice.id,
+          fromName: choice.name,
+          to: { id: typeId, name: null },
+        }),
+      ]
+    : [];
+
+  return { values, relations };
+}
+
+function datesAndDescription(params: {
+  spaceId: string;
+  tenureId: string;
+  startDate: string | null;
+  endDate: string | null;
+  description: string;
+}): Value[] {
+  const values: Value[] = [];
+  const { spaceId, tenureId } = params;
+
+  if (params.startDate) {
+    values.push(
+      valueRow({
+        spaceId,
+        entityId: tenureId,
+        propertyId: START_DATE_PROPERTY,
+        propertyName: 'Start date',
+        dataType: 'DATE',
+        value: params.startDate,
+      })
+    );
+  }
+
+  if (params.endDate) {
+    values.push(
+      valueRow({
+        spaceId,
+        entityId: tenureId,
+        propertyId: END_DATE_PROPERTY,
+        propertyName: 'End date',
+        dataType: 'DATE',
+        value: params.endDate,
+      })
+    );
+  }
+
+  const description = params.description.trim();
+  if (description !== '') {
+    values.push(
+      valueRow({
+        spaceId,
+        entityId: tenureId,
+        propertyId: DESCRIPTION_PROPERTY,
+        propertyName: 'Description',
+        dataType: 'TEXT',
+        value: description,
+      })
+    );
+  }
+
+  return values;
+}
+
+function merge(...parts: StagedRows[]): StagedRows {
+  return {
+    values: parts.flatMap(part => part.values),
+    relations: parts.flatMap(part => part.relations),
+  };
+}
+
+/**
+ * One position, as one edit.
+ *
+ * Six rows for a first job at a company — the Employment edge, the Roles edge,
+ * the status edge, and the tenure's dates — and roughly half that for a
+ * promotion, where the company edge already exists. They publish together or not
+ * at all: a stint with no role under it renders as a company you are somehow
+ * attached to with nothing to say about it, which is worse than no entry.
+ */
+export function stagePosition(draft: PositionDraft, { personEntityId, spaceId }: Context): StagedRows {
+  const company = newEntityRows(draft.company, spaceId, COMPANY_TYPE);
+  const title = newEntityRows(draft.title, spaceId, JOB_TYPE);
+
+  let stintId = draft.existingStintId;
+  const employment: StagedRows = { values: [], relations: [] };
+
+  if (!stintId) {
+    stintId = ID.createEntityId();
+    employment.relations.push(
+      relationRow({
+        spaceId,
+        typeId: EMPLOYMENT_PROPERTY,
+        typeName: 'Employment',
+        fromId: personEntityId,
+        to: draft.company,
+        entityId: stintId,
+      })
+    );
+  }
+
+  const tenureId = ID.createEntityId();
+  const roles = relationRow({
+    spaceId,
+    typeId: ROLES_PROPERTY,
+    typeName: 'Roles',
+    fromId: stintId,
+    to: draft.title,
+    entityId: tenureId,
+  });
+
+  const status = relationRow({
+    spaceId,
+    typeId: EMPLOYMENT_STATUS_PROPERTY,
+    typeName: 'Employment status',
+    fromId: tenureId,
+    to: { id: EMPLOYMENT_STATUS_OPTION[draft.status], name: draft.status === 'current' ? 'Current' : 'Former' },
+  });
+
+  return merge(company, title, employment, {
+    relations: [roles, status],
+    values: datesAndDescription({
+      spaceId,
+      tenureId,
+      startDate: draft.startDate,
+      endDate: draft.endDate,
+      description: draft.description,
+    }),
+  });
+}
+
+/**
+ * One education record, as one edit. A level heavier than a position, because
+ * `Academic fields` is a relation and can repeat for a joint honours degree.
+ */
+export function stageEducation(draft: EducationDraft, { personEntityId, spaceId }: Context): StagedRows {
+  const school = newEntityRows(draft.school, spaceId);
+  const degree = newEntityRows(draft.degree, spaceId);
+
+  let recordId = draft.existingStintId;
+  const education: StagedRows = { values: [], relations: [] };
+
+  if (!recordId) {
+    recordId = ID.createEntityId();
+    education.relations.push(
+      relationRow({
+        spaceId,
+        typeId: EDUCATION_PROPERTY,
+        typeName: 'Education',
+        fromId: personEntityId,
+        to: draft.school,
+        entityId: recordId,
+      })
+    );
+  }
+
+  const enrolmentId = ID.createEntityId();
+  const degreeEdge = relationRow({
+    spaceId,
+    typeId: DEGREE_PROPERTY,
+    typeName: 'Degree',
+    fromId: recordId,
+    to: draft.degree,
+    entityId: enrolmentId,
+  });
+
+  const fieldRows = draft.fields.map(field => newEntityRows(field, spaceId, ACADEMIC_FIELD_TYPE));
+
+  const fieldEdges = draft.fields.map(field =>
+    relationRow({
+      spaceId,
+      typeId: ACADEMIC_FIELDS_PROPERTY,
+      typeName: 'Academic fields',
+      fromId: enrolmentId,
+      to: field,
+    })
+  );
+
+  // Still studying writes no status at all. The graph has Completed and
+  // Incomplete and nothing for in-progress, and inventing one would be worse
+  // than leaving it unsaid — the empty End date is what carries the meaning.
+  const statusOptionId = EDUCATION_STATUS_OPTION[draft.status];
+  const statusEdge = statusOptionId
+    ? [
+        relationRow({
+          spaceId,
+          typeId: EDUCATION_STATUS_PROPERTY,
+          typeName: 'Education status',
+          fromId: enrolmentId,
+          to: { id: statusOptionId, name: draft.status === 'completed' ? 'Completed' : 'Incomplete' },
+        }),
+      ]
+    : [];
+
+  return merge(school, degree, ...fieldRows, education, {
+    relations: [degreeEdge, ...fieldEdges, ...statusEdge],
+    values: datesAndDescription({
+      spaceId,
+      tenureId: enrolmentId,
+      startDate: draft.startDate,
+      endDate: draft.endDate,
+      description: draft.description,
+    }),
+  });
+}

--- a/apps/web/core/profile/stage-history.ts
+++ b/apps/web/core/profile/stage-history.ts
@@ -217,7 +217,16 @@ function merge(...parts: StagedRows[]): StagedRows {
  * at all: a stint with no role under it renders as a company you are somehow
  * attached to with nothing to say about it, which is worse than no entry.
  */
-export function stagePosition(draft: PositionDraft, { personEntityId, spaceId }: Context): StagedRows {
+export function stagePosition(
+  draft: PositionDraft,
+  { personEntityId, spaceId }: Context,
+  /**
+   * The stint to mint when this is a first role at the company. Supplied by the
+   * caller so two roles added at the same new employer in one sitting share an
+   * Employment edge rather than each opening their own.
+   */
+  newStintId: string = ID.createEntityId()
+): StagedRows {
   const company = newEntityRows(draft.company, spaceId, EMPLOYER_TYPE);
   const title = newEntityRows(draft.title, spaceId, JOB_TYPE);
 
@@ -225,7 +234,7 @@ export function stagePosition(draft: PositionDraft, { personEntityId, spaceId }:
   const employment: StagedRows = { values: [], relations: [] };
 
   if (!stintId) {
-    stintId = ID.createEntityId();
+    stintId = newStintId;
     employment.relations.push(
       relationRow({
         spaceId,
@@ -297,7 +306,11 @@ export function stagePosition(draft: PositionDraft, { personEntityId, spaceId }:
  * One education record, as one edit. A level heavier than a position, because
  * `Academic fields` is a relation and can repeat for a joint honours degree.
  */
-export function stageEducation(draft: EducationDraft, { personEntityId, spaceId }: Context): StagedRows {
+export function stageEducation(
+  draft: EducationDraft,
+  { personEntityId, spaceId }: Context,
+  newStintId: string = ID.createEntityId()
+): StagedRows {
   const school = newEntityRows(draft.school, spaceId);
   const degree = newEntityRows(draft.degree, spaceId);
 
@@ -305,7 +318,7 @@ export function stageEducation(draft: EducationDraft, { personEntityId, spaceId 
   const education: StagedRows = { values: [], relations: [] };
 
   if (!recordId) {
-    recordId = ID.createEntityId();
+    recordId = newStintId;
     education.relations.push(
       relationRow({
         spaceId,
@@ -366,4 +379,68 @@ export function stageEducation(draft: EducationDraft, { personEntityId, spaceId 
       description: draft.description,
     }),
   });
+}
+
+/**
+ * A saved row back into the sheet that wrote it.
+ *
+ * Editing reuses the add sheet, so a row has to be able to answer the same
+ * questions it was filled in from. Everything here was picked from the graph, so
+ * nothing is `isNew` — the entities all exist already.
+ */
+export function positionDraftFromEntry(
+  organization: { id: string; name: string | null },
+  entry: {
+    subject: { id: string; name: string | null };
+    employmentType: { id: string; name: string | null } | null;
+    skills: { id: string; name: string | null }[];
+    startDate: string | null;
+    endDate: string | null;
+    status: EmploymentStatus | null;
+    description: string | null;
+  }
+): PositionDraft {
+  return {
+    company: { id: organization.id, name: organization.name, isNew: false },
+    title: { id: entry.subject.id, name: entry.subject.name, isNew: false },
+    // Kept as it stands even when it is not one of the eight the dropdown offers.
+    // The select shows nothing for an id it does not know, but the draft still
+    // carries it, so editing the dates of an older record does not quietly drop
+    // an employment type somebody else recorded.
+    employmentType: entry.employmentType
+      ? { id: entry.employmentType.id, name: entry.employmentType.name ?? '' }
+      : null,
+    skills: entry.skills.map(skill => ({ id: skill.id, name: skill.name, isNew: false })),
+    startDate: entry.startDate,
+    endDate: entry.endDate,
+    // An older row may carry no status at all. An open end date is what said
+    // "current" before the status property existed, so it still does here.
+    status: entry.status ?? (entry.endDate === null ? 'current' : 'former'),
+    description: entry.description ?? '',
+  };
+}
+
+export function educationDraftFromEntry(
+  organization: { id: string; name: string | null },
+  entry: {
+    subject: { id: string; name: string | null };
+    fields: { id: string; name: string | null }[];
+    startDate: string | null;
+    endDate: string | null;
+    status: EducationStatus | null;
+    description: string | null;
+  }
+): EducationDraft {
+  return {
+    school: { id: organization.id, name: organization.name, isNew: false },
+    degree: { id: entry.subject.id, name: entry.subject.name, isNew: false },
+    // The legacy field-of-study text is shown with no id behind it. There is no
+    // entity to relate to, so it cannot come back into a draft — it stays where
+    // it is, on the stint, until someone picks a real Academic field.
+    fields: entry.fields.filter(field => field.id !== '').map(field => ({ ...field, isNew: false })),
+    startDate: entry.startDate,
+    endDate: entry.endDate,
+    status: entry.status ?? (entry.endDate === null ? 'studying' : 'completed'),
+    description: entry.description ?? '',
+  };
 }

--- a/apps/web/core/profile/stage-history.ts
+++ b/apps/web/core/profile/stage-history.ts
@@ -7,20 +7,24 @@ import {
   ACADEMIC_FIELDS_PROPERTY,
   ACADEMIC_FIELD_TYPE,
   CITY_TYPE,
+  DEGREE_INFORMATION_TYPE,
   DEGREE_PROPERTY,
   DEGREE_TYPE,
   DESCRIPTION_PROPERTY,
   EDUCATION_PROPERTY,
+  EDUCATION_RECORD_TYPE,
   EDUCATION_STATUS_OPTION,
   EDUCATION_STATUS_PROPERTY,
   EMPLOYER_TYPE,
   EMPLOYMENT_PROPERTY,
+  EMPLOYMENT_RECORD_TYPE,
   EMPLOYMENT_STATUS_OPTION,
   EMPLOYMENT_STATUS_PROPERTY,
   EMPLOYMENT_TYPE_PROPERTY,
   END_DATE_PROPERTY,
   type EducationStatus,
   type EmploymentStatus,
+  GRADE_PROPERTY,
   JOB_TYPE,
   LOCATION_PROPERTY,
   LOCATION_TYPE_PROPERTY,
@@ -62,6 +66,10 @@ export type EducationDraft = {
   school: EntityChoice;
   degree: EntityChoice;
   fields: EntityChoice[];
+  /** Repeats, like a position's. */
+  skills: EntityChoice[];
+  /** A mark, as the institution gave it. Empty where none was recorded. */
+  grade: string;
   startDate: string | null;
   endDate: string | null;
   status: EducationStatus;
@@ -101,7 +109,7 @@ function valueRow(params: {
   entityId: string;
   propertyId: string;
   propertyName: string;
-  dataType: 'TEXT' | 'DATE';
+  dataType: 'TEXT' | 'DATE' | 'DECIMAL';
   value: string;
 }): Value {
   return {
@@ -111,7 +119,7 @@ function valueRow(params: {
       id: params.propertyId,
       name: params.propertyName,
       dataType: params.dataType,
-      renderableType: params.dataType === 'DATE' ? 'DATE' : 'TEXT',
+      renderableType: params.dataType,
     },
     spaceId: params.spaceId,
     value: params.value,
@@ -157,6 +165,17 @@ function newEntityRows(choice: EntityChoice, spaceId: string, typeIds: string[] 
   );
 
   return { values, relations };
+}
+
+/** `Types` on a relation's own entity, from what its property declares. */
+function typeRow(spaceId: string, entityId: string, typeId: string, typeName: string): Relation {
+  return relationRow({
+    spaceId,
+    typeId: SystemIds.TYPES_PROPERTY,
+    typeName: 'Types',
+    fromId: entityId,
+    to: { id: typeId, name: typeName },
+  });
 }
 
 function datesAndDescription(params: {
@@ -254,7 +273,8 @@ export function stagePosition(
         fromId: personEntityId,
         to: draft.company,
         entityId: stintId,
-      })
+      }),
+      typeRow(spaceId, stintId, EMPLOYMENT_RECORD_TYPE, 'Employment record')
     );
   }
 
@@ -268,17 +288,10 @@ export function stagePosition(
     entityId: tenureId,
   });
 
-  // The tenure says what it is. `Roles` declares `Role information` as its
-  // relation entity type, and an untyped tenure is reachable only by walking in
-  // from the person holding it — which is exactly how the dates on it stayed
-  // invisible to everything else.
-  const tenureType = relationRow({
-    spaceId,
-    typeId: SystemIds.TYPES_PROPERTY,
-    typeName: 'Types',
-    fromId: tenureId,
-    to: { id: ROLE_INFORMATION_TYPE, name: 'Role information' },
-  });
+  // Each level says what it is, from what its property declares. An untyped
+  // relation entity is reachable only by walking in from the person holding it,
+  // which is how the dates on a tenure stayed invisible to everything else.
+  const tenureType = typeRow(spaceId, tenureId, ROLE_INFORMATION_TYPE, 'Role information');
 
   const status = relationRow({
     spaceId,
@@ -375,6 +388,7 @@ export function stageEducation(
   if (!recordId) {
     recordId = newStintId;
     education.relations.push(
+      typeRow(spaceId, recordId, EDUCATION_RECORD_TYPE, 'Education record'),
       relationRow({
         spaceId,
         typeId: EDUCATION_PROPERTY,
@@ -396,7 +410,31 @@ export function stageEducation(
     entityId: enrolmentId,
   });
 
+  const enrolmentType = typeRow(spaceId, enrolmentId, DEGREE_INFORMATION_TYPE, 'Degree information');
+
   const fieldRows = draft.fields.map(field => newEntityRows(field, spaceId, [ACADEMIC_FIELD_TYPE]));
+
+  const skillRows = draft.skills.map(skill => newEntityRows(skill, spaceId, [SKILL_TYPE]));
+  const skillEdges = draft.skills.map(skill =>
+    relationRow({ spaceId, typeId: SKILLS_PROPERTY, typeName: 'Skills', fromId: enrolmentId, to: skill })
+  );
+
+  // Decimal, so a 3.8 sorts and filters as a number. A mark that is not a number
+  // — a classification, a pass — has nowhere to go here and is left unwritten
+  // rather than stored as text under a numeric property.
+  const grade = Number.parseFloat(draft.grade.trim());
+  const gradeRows: Value[] = Number.isFinite(grade)
+    ? [
+        valueRow({
+          spaceId,
+          entityId: enrolmentId,
+          propertyId: GRADE_PROPERTY,
+          propertyName: 'Grade',
+          dataType: 'DECIMAL',
+          value: String(grade),
+        }),
+      ]
+    : [];
 
   const fieldEdges = draft.fields.map(field =>
     relationRow({
@@ -424,15 +462,18 @@ export function stageEducation(
       ]
     : [];
 
-  return merge(school, degree, ...fieldRows, education, {
-    relations: [degreeEdge, ...fieldEdges, ...statusEdge],
-    values: datesAndDescription({
-      spaceId,
-      tenureId: enrolmentId,
-      startDate: draft.startDate,
-      endDate: draft.endDate,
-      description: draft.description,
-    }),
+  return merge(school, degree, ...fieldRows, ...skillRows, education, {
+    relations: [degreeEdge, enrolmentType, ...fieldEdges, ...skillEdges, ...statusEdge],
+    values: [
+      ...datesAndDescription({
+        spaceId,
+        tenureId: enrolmentId,
+        startDate: draft.startDate,
+        endDate: draft.endDate,
+        description: draft.description,
+      }),
+      ...gradeRows,
+    ],
   });
 }
 
@@ -484,6 +525,8 @@ export function educationDraftFromEntry(
   entry: {
     subject: { id: string; name: string | null };
     fields: { id: string; name: string | null }[];
+    skills: { id: string; name: string | null }[];
+    grade: number | null;
     startDate: string | null;
     endDate: string | null;
     status: EducationStatus | null;
@@ -497,6 +540,8 @@ export function educationDraftFromEntry(
     // entity to relate to, so it cannot come back into a draft — it stays where
     // it is, on the stint, until someone picks a real Academic field.
     fields: entry.fields.filter(field => field.id !== '').map(field => ({ ...field, isNew: false })),
+    skills: entry.skills.map(skill => ({ id: skill.id, name: skill.name, isNew: false })),
+    grade: entry.grade === null ? '' : String(entry.grade),
     startDate: entry.startDate,
     endDate: entry.endDate,
     status: entry.status ?? (entry.endDate === null ? 'studying' : 'completed'),

--- a/apps/web/core/profile/stage-history.ts
+++ b/apps/web/core/profile/stage-history.ts
@@ -6,12 +6,12 @@ import type { Relation, Value } from '~/core/types';
 import {
   ACADEMIC_FIELDS_PROPERTY,
   ACADEMIC_FIELD_TYPE,
-  COMPANY_TYPE,
   DEGREE_PROPERTY,
   DESCRIPTION_PROPERTY,
   EDUCATION_PROPERTY,
   EDUCATION_STATUS_OPTION,
   EDUCATION_STATUS_PROPERTY,
+  EMPLOYER_TYPE,
   EMPLOYMENT_PROPERTY,
   EMPLOYMENT_STATUS_OPTION,
   EMPLOYMENT_STATUS_PROPERTY,
@@ -211,7 +211,7 @@ function merge(...parts: StagedRows[]): StagedRows {
  * attached to with nothing to say about it, which is worse than no entry.
  */
 export function stagePosition(draft: PositionDraft, { personEntityId, spaceId }: Context): StagedRows {
-  const company = newEntityRows(draft.company, spaceId, COMPANY_TYPE);
+  const company = newEntityRows(draft.company, spaceId, EMPLOYER_TYPE);
   const title = newEntityRows(draft.title, spaceId, JOB_TYPE);
 
   let stintId = draft.existingStintId;

--- a/apps/web/core/profile/stage-history.ts
+++ b/apps/web/core/profile/stage-history.ts
@@ -6,6 +6,7 @@ import type { Relation, Value } from '~/core/types';
 import {
   ACADEMIC_FIELDS_PROPERTY,
   ACADEMIC_FIELD_TYPE,
+  CITY_TYPE,
   DEGREE_PROPERTY,
   DESCRIPTION_PROPERTY,
   EDUCATION_PROPERTY,
@@ -20,6 +21,8 @@ import {
   type EducationStatus,
   type EmploymentStatus,
   JOB_TYPE,
+  LOCATION_PROPERTY,
+  LOCATION_TYPE_PROPERTY,
   ROLES_PROPERTY,
   ROLE_INFORMATION_TYPE,
   SCHOOL_TYPES,
@@ -38,6 +41,10 @@ export type PositionDraft = {
   employmentType: { id: string; name: string } | null;
   /** Repeats, so it is a relation rather than a value. */
   skills: EntityChoice[];
+  /** Where it was held. A place in the graph, not a string. */
+  location: EntityChoice | null;
+  /** Onsite, Hybrid or Remote. Optional, as on LinkedIn. */
+  locationType: { id: string; name: string } | null;
   startDate: string | null;
   endDate: string | null;
   status: EmploymentStatus;
@@ -294,6 +301,38 @@ export function stagePosition(
       ]
     : [];
 
+  // Beside the dates, for the same reason: a job moves city and goes remote
+  // without becoming a different job.
+  //
+  // A city typed rather than picked is named and typed like any other new entity.
+  // City rather than Place: someone filling in where they worked is naming a
+  // city, and an untyped one would not turn up for the next person who types it.
+  const locationEntity = newEntityRows(draft.location ?? { id: '', name: null, isNew: false }, spaceId, [CITY_TYPE]);
+
+  const location = draft.location
+    ? [
+        relationRow({
+          spaceId,
+          typeId: LOCATION_PROPERTY,
+          typeName: 'Location',
+          fromId: tenureId,
+          to: draft.location,
+        }),
+      ]
+    : [];
+
+  const locationType = draft.locationType
+    ? [
+        relationRow({
+          spaceId,
+          typeId: LOCATION_TYPE_PROPERTY,
+          typeName: 'Location type',
+          fromId: tenureId,
+          to: draft.locationType,
+        }),
+      ]
+    : [];
+
   const skillRows = draft.skills.map(skill => newEntityRows(skill, spaceId, [SKILL_TYPE]));
   const skillEdges = draft.skills.map(skill =>
     relationRow({
@@ -305,8 +344,8 @@ export function stagePosition(
     })
   );
 
-  return merge(company, title, ...skillRows, employment, {
-    relations: [roles, tenureType, status, ...employmentType, ...skillEdges],
+  return merge(company, title, locationEntity, ...skillRows, employment, {
+    relations: [roles, tenureType, status, ...employmentType, ...location, ...locationType, ...skillEdges],
     values: datesAndDescription({
       spaceId,
       tenureId,
@@ -409,6 +448,8 @@ export function positionDraftFromEntry(
     subject: { id: string; name: string | null };
     employmentType: { id: string; name: string | null } | null;
     skills: { id: string; name: string | null }[];
+    location: { id: string; name: string | null } | null;
+    locationType: { id: string; name: string | null } | null;
     startDate: string | null;
     endDate: string | null;
     status: EmploymentStatus | null;
@@ -426,6 +467,8 @@ export function positionDraftFromEntry(
       ? { id: entry.employmentType.id, name: entry.employmentType.name ?? '' }
       : null,
     skills: entry.skills.map(skill => ({ id: skill.id, name: skill.name, isNew: false })),
+    location: entry.location ? { id: entry.location.id, name: entry.location.name, isNew: false } : null,
+    locationType: entry.locationType ? { id: entry.locationType.id, name: entry.locationType.name ?? '' } : null,
     startDate: entry.startDate,
     endDate: entry.endDate,
     // An older row may carry no status at all. An open end date is what said

--- a/apps/web/core/profile/stage-history.ts
+++ b/apps/web/core/profile/stage-history.ts
@@ -21,6 +21,7 @@ import {
   type EmploymentStatus,
   JOB_TYPE,
   ROLES_PROPERTY,
+  ROLE_INFORMATION_TYPE,
   SKILLS_PROPERTY,
   SKILL_TYPE,
   START_DATE_PROPERTY,
@@ -257,6 +258,18 @@ export function stagePosition(
     entityId: tenureId,
   });
 
+  // The tenure says what it is. `Roles` declares `Role information` as its
+  // relation entity type, and an untyped tenure is reachable only by walking in
+  // from the person holding it — which is exactly how the dates on it stayed
+  // invisible to everything else.
+  const tenureType = relationRow({
+    spaceId,
+    typeId: SystemIds.TYPES_PROPERTY,
+    typeName: 'Types',
+    fromId: tenureId,
+    to: { id: ROLE_INFORMATION_TYPE, name: 'Role information' },
+  });
+
   const status = relationRow({
     spaceId,
     typeId: EMPLOYMENT_STATUS_PROPERTY,
@@ -291,7 +304,7 @@ export function stagePosition(
   );
 
   return merge(company, title, ...skillRows, employment, {
-    relations: [roles, status, ...employmentType, ...skillEdges],
+    relations: [roles, tenureType, status, ...employmentType, ...skillEdges],
     values: datesAndDescription({
       spaceId,
       tenureId,

--- a/apps/web/core/profile/stage-history.ts
+++ b/apps/web/core/profile/stage-history.ts
@@ -8,6 +8,7 @@ import {
   ACADEMIC_FIELD_TYPE,
   CITY_TYPE,
   DEGREE_PROPERTY,
+  DEGREE_TYPE,
   DESCRIPTION_PROPERTY,
   EDUCATION_PROPERTY,
   EDUCATION_STATUS_OPTION,
@@ -366,7 +367,7 @@ export function stageEducation(
   newStintId: string = ID.createEntityId()
 ): StagedRows {
   const school = newEntityRows(draft.school, spaceId, SCHOOL_TYPES);
-  const degree = newEntityRows(draft.degree, spaceId);
+  const degree = newEntityRows(draft.degree, spaceId, [DEGREE_TYPE]);
 
   let recordId = draft.existingStintId;
   const education: StagedRows = { values: [], relations: [] };

--- a/apps/web/core/profile/stage-history.ts
+++ b/apps/web/core/profile/stage-history.ts
@@ -22,6 +22,7 @@ import {
   JOB_TYPE,
   ROLES_PROPERTY,
   ROLE_INFORMATION_TYPE,
+  SCHOOL_TYPES,
   SKILLS_PROPERTY,
   SKILL_TYPE,
   START_DATE_PROPERTY,
@@ -116,7 +117,7 @@ function valueRow(params: {
  * someone writes a name. Without this the relation points at an entity with no
  * name, which renders as a blank row that cannot be searched for afterwards.
  */
-function newEntityRows(choice: EntityChoice, spaceId: string, typeId?: string): StagedRows {
+function newEntityRows(choice: EntityChoice, spaceId: string, typeIds: string[] = []): StagedRows {
   if (!choice.isNew || !choice.name) return { values: [], relations: [] };
 
   const values = [
@@ -133,18 +134,19 @@ function newEntityRows(choice: EntityChoice, spaceId: string, typeId?: string): 
   // Typed where the type is known and verified. An untyped entity still works as
   // a target, but never turns up in the scoped search that would stop the next
   // person creating a second one just like it.
-  const relations = typeId
-    ? [
-        relationRow({
-          spaceId,
-          typeId: SystemIds.TYPES_PROPERTY,
-          typeName: 'Types',
-          fromId: choice.id,
-          fromName: choice.name,
-          to: { id: typeId, name: null },
-        }),
-      ]
-    : [];
+  //
+  // More than one where the thing genuinely is more than one thing — a school is
+  // a University and an Institution, and being findable as either is the point.
+  const relations = typeIds.map(typeId =>
+    relationRow({
+      spaceId,
+      typeId: SystemIds.TYPES_PROPERTY,
+      typeName: 'Types',
+      fromId: choice.id,
+      fromName: choice.name,
+      to: { id: typeId, name: null },
+    })
+  );
 
   return { values, relations };
 }
@@ -228,8 +230,8 @@ export function stagePosition(
    */
   newStintId: string = ID.createEntityId()
 ): StagedRows {
-  const company = newEntityRows(draft.company, spaceId, EMPLOYER_TYPE);
-  const title = newEntityRows(draft.title, spaceId, JOB_TYPE);
+  const company = newEntityRows(draft.company, spaceId, [EMPLOYER_TYPE]);
+  const title = newEntityRows(draft.title, spaceId, [JOB_TYPE]);
 
   let stintId = draft.existingStintId;
   const employment: StagedRows = { values: [], relations: [] };
@@ -292,7 +294,7 @@ export function stagePosition(
       ]
     : [];
 
-  const skillRows = draft.skills.map(skill => newEntityRows(skill, spaceId, SKILL_TYPE));
+  const skillRows = draft.skills.map(skill => newEntityRows(skill, spaceId, [SKILL_TYPE]));
   const skillEdges = draft.skills.map(skill =>
     relationRow({
       spaceId,
@@ -324,7 +326,7 @@ export function stageEducation(
   { personEntityId, spaceId }: Context,
   newStintId: string = ID.createEntityId()
 ): StagedRows {
-  const school = newEntityRows(draft.school, spaceId);
+  const school = newEntityRows(draft.school, spaceId, SCHOOL_TYPES);
   const degree = newEntityRows(draft.degree, spaceId);
 
   let recordId = draft.existingStintId;
@@ -354,7 +356,7 @@ export function stageEducation(
     entityId: enrolmentId,
   });
 
-  const fieldRows = draft.fields.map(field => newEntityRows(field, spaceId, ACADEMIC_FIELD_TYPE));
+  const fieldRows = draft.fields.map(field => newEntityRows(field, spaceId, [ACADEMIC_FIELD_TYPE]));
 
   const fieldEdges = draft.fields.map(field =>
     relationRow({

--- a/apps/web/core/utils/media-url.ts
+++ b/apps/web/core/utils/media-url.ts
@@ -1,4 +1,27 @@
+import { ContentIds } from '@geoprotocol/geo-sdk/lite';
+
+import { ID } from '~/core/id';
+
 /** Whether a value is a loadable media URL: an `ipfs://` URI (resolved via gateway) or an http(s) URL. */
 export function isDirectMediaUrl(value: string | null | undefined): value is string {
   return Boolean(value && (value.startsWith('ipfs://') || value.startsWith('http://') || value.startsWith('https://')));
+}
+
+/**
+ * The media URL among an image/video entity's values. An `ipfs://` value on any property wins
+ * (legacy media blocks keep it unlabelled); an http(s) URL is read only from `Web URL`, since that
+ * property is also a general canonical link and the callers do not check the target's entity type.
+ *
+ * Lives here rather than beside the hooks that use it so the non-React readers —
+ * anything holding values straight off a GraphQL response — can pick the URL the
+ * same way rather than guessing at the first value that looks like a string.
+ */
+export function findMediaUrlValue(values: { value: unknown; property: { id: string } }[]): string | undefined {
+  const ipfsValue = values.find(v => typeof v.value === 'string' && v.value.startsWith('ipfs://'));
+  if (typeof ipfsValue?.value === 'string') return ipfsValue.value;
+  const webUrlValue = values.find(
+    v =>
+      ID.equals(v.property.id, ContentIds.WEB_URL_PROPERTY) && typeof v.value === 'string' && isDirectMediaUrl(v.value)
+  );
+  return typeof webUrlValue?.value === 'string' ? webUrlValue.value : undefined;
 }

--- a/apps/web/core/utils/use-entity-media.ts
+++ b/apps/web/core/utils/use-entity-media.ts
@@ -7,25 +7,13 @@ import * as React from 'react';
 
 import { Effect } from 'effect';
 
-import { ID } from '~/core/id';
 import { getRelationsByFromEntityId } from '~/core/io/queries';
 import { useRelation, useValues } from '~/core/sync/use-store';
-import { isDirectMediaUrl } from '~/core/utils/media-url';
+import { findMediaUrlValue, isDirectMediaUrl } from '~/core/utils/media-url';
 
-/**
- * The media URL among an image/video entity's values. An `ipfs://` value on any property wins
- * (legacy media blocks keep it unlabelled); an http(s) URL is read only from `Web URL`, since that
- * property is also a general canonical link and the callers do not check the target's entity type.
- */
-export function findMediaUrlValue(values: { value: unknown; property: { id: string } }[]): string | undefined {
-  const ipfsValue = values.find(v => typeof v.value === 'string' && v.value.startsWith('ipfs://'));
-  if (typeof ipfsValue?.value === 'string') return ipfsValue.value;
-  const webUrlValue = values.find(
-    v =>
-      ID.equals(v.property.id, ContentIds.WEB_URL_PROPERTY) && typeof v.value === 'string' && isDirectMediaUrl(v.value)
-  );
-  return typeof webUrlValue?.value === 'string' ? webUrlValue.value : undefined;
-}
+// Re-exported from its old home: the readers that hold values straight off a
+// GraphQL response need it too, and they have no business pulling in the store.
+export { findMediaUrlValue };
 
 export function useImageUrlFromEntity(imageEntityId: string | undefined, spaceId: string): string | undefined {
   const imageValues = useValues({

--- a/apps/web/design-system/button.tsx
+++ b/apps/web/design-system/button.tsx
@@ -107,6 +107,11 @@ export const SquareButton = forwardRef(function SquareButton(
       ref={ref}
       className={squareButtonClassNames({ className, isActive, disabled })}
       style={{ fontFeatureSettings: '"tnum" 1', ...style }}
+      // `disabled` was destructured for the styling and never reached the
+      // element, so the button looked disabled and stayed clickable. Both
+      // existing callers passing it — a remove button with no image, a menu
+      // trigger mid-request — meant it to block the click.
+      disabled={disabled}
       {...rest}
     >
       {icon ? icon : <>{children}</>}

--- a/apps/web/design-system/select-entity.tsx
+++ b/apps/web/design-system/select-entity.tsx
@@ -93,6 +93,9 @@ type SelectEntityProps = {
    * the user guess at a search term — the skills an occupation is recorded as
    * needing, say. They are dropped as soon as there is a query, which is the
    * point at which the search itself is the better answer.
+   *
+   * Rendered without the space summary a search hit carries: a suggestion was not
+   * found in a space, it was offered by a caller that already knows it fits.
    */
   pinnedResults?: SearchResult[];
   /** Heading above the pinned rows, so they read as a suggestion not a result. */
@@ -725,7 +728,12 @@ export const SelectEntity = ({
                                     )}
                                   </button>
                                 </div>
-                                {withSelectSpace && (
+                                {/* Not on a pinned row: the space summary counts where a
+                                    search hit was found, and a suggestion was not
+                                    found anywhere — it is offered because the caller
+                                    already knows it fits. Rendering it read "0 spaces"
+                                    beside a "Select space" that had none to pick. */}
+                                {withSelectSpace && index >= pinned.length && (
                                   <div className="-mt-2 p-1">
                                     <button
                                       onClick={() => setResult(result)}

--- a/apps/web/design-system/select-entity.tsx
+++ b/apps/web/design-system/select-entity.tsx
@@ -80,6 +80,25 @@ type SelectEntityProps = {
   initialQuery?: string;
   waitForFilterTypes?: boolean;
   restrictToFilterTypes?: boolean;
+  /**
+   * Extra spaces to make searchable, for a caller that knows where the thing it
+   * is searching for lives — a curated taxonomy in a space the viewer is not a
+   * member of would otherwise be filtered out before it got here.
+   */
+  alsoSearchSpaceIds?: string[];
+  /**
+   * Rows to offer before anything has been typed, above the results.
+   *
+   * For a caller that already knows the likely answers and would rather not make
+   * the user guess at a search term — the skills an occupation is recorded as
+   * needing, say. They are dropped as soon as there is a query, which is the
+   * point at which the search itself is the better answer.
+   */
+  pinnedResults?: SearchResult[];
+  /** Heading above the pinned rows, so they read as a suggestion not a result. */
+  pinnedLabel?: string;
+  /** Heading above the ordinary results, where pinned rows precede them. */
+  restLabel?: string;
   /** When set, the result with this ID gets a "Currently selected" indicator */
   selectedEntityId?: string;
   /** Increment (e.g. on "add row") to move focus into this input even when already mounted. */
@@ -108,6 +127,10 @@ export const SelectEntity = ({
   initialQuery,
   waitForFilterTypes,
   restrictToFilterTypes,
+  alsoSearchSpaceIds,
+  pinnedResults,
+  pinnedLabel,
+  restLabel,
   selectedEntityId,
   focusRequestKey,
 }: SelectEntityProps) => {
@@ -155,15 +178,40 @@ export const SelectEntity = ({
   // unrestricted instead of blocking with no way to get results.
   const userClearedTypeFilters = removedTypeIds.size > 0 && allowedTypes.length === 0;
 
-  const { query, onQueryChange, isLoading, isEmpty, results, hasNextPage, fetchNextPage, isFetchingNextPage } =
-    useSearch({
-      filterByTypes,
-      filterBySpace,
-      initialQuery,
-      enabled: isSearchOpen,
-      waitForFilterTypes,
-      restrictToFilterTypes: restrictToFilterTypes && !userClearedTypeFilters,
-    });
+  const {
+    query,
+    onQueryChange,
+    isLoading,
+    isEmpty,
+    results: searchResults,
+    hasNextPage,
+    fetchNextPage,
+    isFetchingNextPage,
+  } = useSearch({
+    filterByTypes,
+    filterBySpace,
+    initialQuery,
+    enabled: isSearchOpen,
+    waitForFilterTypes,
+    restrictToFilterTypes: restrictToFilterTypes && !userClearedTypeFilters,
+    alsoSearchSpaceIds,
+  });
+
+  /**
+   * Pinned rows sit at the top until the user types, and then get out of the way.
+   *
+   * Merged into the one list the results render and the keyboard walks, so
+   * arrowing down and pressing Enter picks a suggestion the same way it picks a
+   * result. Anything pinned is dropped from the results below it rather than
+   * appearing twice.
+   */
+  const pinned = query.trim() === '' ? (pinnedResults ?? []) : [];
+
+  const results = React.useMemo(() => {
+    if (pinned.length === 0) return searchResults;
+    const pinnedIds = new Set(pinned.map(result => result.id));
+    return [...pinned, ...searchResults.filter(result => !pinnedIds.has(result.id))];
+  }, [pinned, searchResults]);
 
   // Auto focus input when component mounts
   useEffect(() => {
@@ -577,7 +625,7 @@ export const SelectEntity = ({
                             <div className="truncate text-resultTitle text-text">Loading...</div>
                           </div>
                         )}
-                        {isEmpty ? (
+                        {isEmpty && pinned.length === 0 ? (
                           <div className="w-full bg-white px-3 py-2">
                             <div className="truncate text-resultTitle text-text">No results.</div>
                           </div>
@@ -585,6 +633,12 @@ export const SelectEntity = ({
                           <div className="divide-y divide-divider bg-white">
                             {results.map((result, index) => (
                               <div key={index} className="w-full">
+                                {pinnedLabel && pinned.length > 0 && index === 0 && (
+                                  <div className="px-3 pt-2 text-[0.6875rem] text-grey-04">{pinnedLabel}</div>
+                                )}
+                                {restLabel && pinned.length > 0 && index === pinned.length && (
+                                  <div className="px-3 pt-2 text-[0.6875rem] text-grey-04">{restLabel}</div>
+                                )}
                                 <div className="p-1">
                                   <button
                                     onClick={() => {

--- a/apps/web/partials/profile/add-education-sheet.test.tsx
+++ b/apps/web/partials/profile/add-education-sheet.test.tsx
@@ -4,7 +4,7 @@ import userEvent from '@testing-library/user-event';
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { ACADEMIC_FIELD_TYPE } from '~/core/profile/history-ontology';
+import { ACADEMIC_FIELD_TYPE, SCHOOL_TYPES } from '~/core/profile/history-ontology';
 
 import { AddEducationSheet } from './add-education-sheet';
 
@@ -71,11 +71,16 @@ describe('AddEducationSheet', () => {
 
   // School and Degree have several entities apiece under those names with no
   // canonical type, so a wrong filter would hide every real one from the search.
-  it('leaves school and degree unscoped rather than guessing a type', () => {
+  // School is scoped to what `Education` declares plus the narrower type most
+  // schools carry. Degree stays unscoped: several entities sit under that name
+  // with no obvious canonical one, and a wrong filter there hides every answer.
+  it('searches both school types, and leaves degree unscoped rather than guessing', () => {
     renderSheet();
 
     const scopes = pickers().map(button => button.getAttribute('data-scoped-to'));
-    expect(scopes.filter(scope => scope === '')).toHaveLength(2);
+
+    expect(scopes).toContain(SCHOOL_TYPES.join(','));
+    expect(scopes.filter(scope => scope === '')).toHaveLength(1);
   });
 
   it('offers the three states dates alone cannot express', () => {

--- a/apps/web/partials/profile/add-education-sheet.test.tsx
+++ b/apps/web/partials/profile/add-education-sheet.test.tsx
@@ -69,8 +69,6 @@ describe('AddEducationSheet', () => {
     expect(scopes).toContain(ACADEMIC_FIELD_TYPE);
   });
 
-  // School and Degree have several entities apiece under those names with no
-  // canonical type, so a wrong filter would hide every real one from the search.
   // Every picker scoped to what its property declares. School takes the pair,
   // since `Education` declares the broader of the two and most schools carry the
   // narrower one.
@@ -144,7 +142,9 @@ describe('AddEducationSheet', () => {
 
     await userEvent.click(pickers()[0]);
     await userEvent.click(pickers()[0]);
-    await userEvent.click(screen.getAllByRole('button', { name: /create new/ }).at(-1)!);
+    // School and Degree are answered, so their pickers are gone; Field is the
+    // first of the two left, with Skills behind it.
+    await userEvent.click(screen.getAllByRole('button', { name: /create new/ })[0]);
     await userEvent.click(screen.getByRole('button', { name: 'Save education' }));
 
     const draft = props.onSave.mock.calls.at(-1)?.[0];

--- a/apps/web/partials/profile/add-education-sheet.test.tsx
+++ b/apps/web/partials/profile/add-education-sheet.test.tsx
@@ -1,0 +1,157 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { ACADEMIC_FIELD_TYPE } from '~/core/profile/history-ontology';
+
+import { AddEducationSheet } from './add-education-sheet';
+
+let pickCount = 0;
+
+vi.mock('~/design-system/select-entity', () => ({
+  SelectEntity: ({
+    relationValueTypes,
+    onDone,
+  }: {
+    relationValueTypes?: { id: string; name: string | null }[];
+    onDone: (result: { id: string; name: string | null }, fromCreateFn?: boolean) => void;
+  }) => (
+    <div>
+      <button
+        type="button"
+        data-scoped-to={relationValueTypes?.map(type => type.id).join(',') ?? ''}
+        onClick={() => {
+          pickCount += 1;
+          onDone({ id: `picked-${pickCount}`, name: `Picked ${pickCount}` });
+        }}
+      >
+        pick existing
+      </button>
+      <button type="button" onClick={() => onDone({ id: 'new-field', name: 'Computer Science' }, true)}>
+        create new
+      </button>
+    </div>
+  ),
+}));
+
+afterEach(() => {
+  cleanup();
+  pickCount = 0;
+});
+
+function renderSheet(overrides: Partial<Parameters<typeof AddEducationSheet>[0]> = {}) {
+  const onSave = vi.fn();
+  const onCancel = vi.fn();
+  render(<AddEducationSheet spaceId="space-1" isSaving={false} onCancel={onCancel} onSave={onSave} {...overrides} />);
+  return { onSave, onCancel };
+}
+
+const pickers = () => screen.getAllByRole('button', { name: /pick existing/ });
+
+describe('AddEducationSheet', () => {
+  it('needs a school and a degree before it can save', async () => {
+    renderSheet();
+
+    expect(screen.getByRole('button', { name: 'Save education' })).toBeDisabled();
+
+    await userEvent.click(pickers()[0]); // school
+    await userEvent.click(pickers()[0]); // degree
+
+    expect(screen.getByRole('button', { name: 'Save education' })).toBeEnabled();
+  });
+
+  it('scopes the field picker to Academic field', () => {
+    renderSheet();
+
+    const scopes = pickers().map(button => button.getAttribute('data-scoped-to'));
+    expect(scopes).toContain(ACADEMIC_FIELD_TYPE);
+  });
+
+  // School and Degree have several entities apiece under those names with no
+  // canonical type, so a wrong filter would hide every real one from the search.
+  it('leaves school and degree unscoped rather than guessing a type', () => {
+    renderSheet();
+
+    const scopes = pickers().map(button => button.getAttribute('data-scoped-to'));
+    expect(scopes.filter(scope => scope === '')).toHaveLength(2);
+  });
+
+  it('offers the three states dates alone cannot express', () => {
+    renderSheet();
+
+    for (const label of ['Still studying', 'Completed', 'Did not finish']) {
+      expect(screen.getByRole('button', { name: label })).toBeInTheDocument();
+    }
+  });
+
+  // There is no "in progress" option in the graph, and inventing one would be
+  // worse than leaving it unsaid — the empty End date carries the meaning.
+  it('saves still studying as no status and no end date', async () => {
+    const props = renderSheet();
+
+    await userEvent.click(pickers()[0]);
+    await userEvent.click(pickers()[0]);
+    await userEvent.click(screen.getByRole('button', { name: 'Save education' }));
+
+    expect(props.onSave).toHaveBeenCalledWith(expect.objectContaining({ status: 'studying', endDate: null }));
+  });
+
+  it('saves a finished degree with its status and dates', async () => {
+    const props = renderSheet();
+
+    await userEvent.click(pickers()[0]);
+    await userEvent.click(pickers()[0]);
+    await userEvent.click(screen.getByRole('button', { name: 'Completed' }));
+    await userEvent.selectOptions(screen.getByLabelText('Start month'), '9');
+    await userEvent.selectOptions(screen.getByLabelText('Start year'), '2020');
+    await userEvent.selectOptions(screen.getByLabelText('End month'), '6');
+    await userEvent.selectOptions(screen.getByLabelText('End year'), '2022');
+    await userEvent.click(screen.getByRole('button', { name: 'Save education' }));
+
+    expect(props.onSave).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'completed', startDate: '2020-09-01Z', endDate: '2022-06-01Z' })
+    );
+  });
+
+  // A joint honours degree needs more than one, which is why it is a relation.
+  it('collects more than one academic field', async () => {
+    const props = renderSheet();
+
+    await userEvent.click(pickers()[0]); // school
+    await userEvent.click(pickers()[0]); // degree
+    await userEvent.click(pickers()[0]); // first field
+
+    await userEvent.click(screen.getByRole('button', { name: '+ Add another' }));
+    await userEvent.click(pickers()[0]); // second field
+
+    await userEvent.click(screen.getByRole('button', { name: 'Save education' }));
+
+    const draft = props.onSave.mock.calls.at(-1)?.[0];
+    expect(draft.fields).toHaveLength(2);
+  });
+
+  it('marks a field the user typed so it becomes an Academic field others can find', async () => {
+    const props = renderSheet();
+
+    await userEvent.click(pickers()[0]);
+    await userEvent.click(pickers()[0]);
+    await userEvent.click(screen.getAllByRole('button', { name: /create new/ }).at(-1)!);
+    await userEvent.click(screen.getByRole('button', { name: 'Save education' }));
+
+    const draft = props.onSave.mock.calls.at(-1)?.[0];
+    expect(draft.fields).toEqual([{ id: 'new-field', name: 'Computer Science', isNew: true }]);
+  });
+
+  it('locks the school and reuses its record when adding a second degree there', async () => {
+    const props = renderSheet({ school: { id: 'northumbria', name: 'Northumbria', stintId: 'record-1' } });
+
+    expect(screen.getByText(/Already on your profile/)).toBeInTheDocument();
+
+    await userEvent.click(pickers()[0]); // degree
+    await userEvent.click(screen.getByRole('button', { name: 'Save education' }));
+
+    expect(props.onSave).toHaveBeenCalledWith(expect.objectContaining({ existingStintId: 'record-1' }));
+  });
+});

--- a/apps/web/partials/profile/add-education-sheet.test.tsx
+++ b/apps/web/partials/profile/add-education-sheet.test.tsx
@@ -4,7 +4,7 @@ import userEvent from '@testing-library/user-event';
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { ACADEMIC_FIELD_TYPE, DEGREE_TYPES, SCHOOL_TYPES } from '~/core/profile/history-ontology';
+import { DEGREE_TYPES, FIELD_OF_STUDY_TYPE, SCHOOL_TYPES } from '~/core/profile/history-ontology';
 
 import { AddEducationSheet } from './add-education-sheet';
 
@@ -62,11 +62,11 @@ describe('AddEducationSheet', () => {
     expect(screen.getByRole('button', { name: 'Save education' })).toBeEnabled();
   });
 
-  it('scopes the field picker to Academic field', () => {
+  it('scopes the field picker to Field of study', () => {
     renderSheet();
 
     const scopes = pickers().map(button => button.getAttribute('data-scoped-to'));
-    expect(scopes).toContain(ACADEMIC_FIELD_TYPE);
+    expect(scopes).toContain(FIELD_OF_STUDY_TYPE);
   });
 
   // Every picker scoped to what its property declares. School takes the pair,
@@ -79,7 +79,7 @@ describe('AddEducationSheet', () => {
 
     expect(scopes).toContain(SCHOOL_TYPES.join(','));
     expect(scopes).toContain(DEGREE_TYPES.join(','));
-    expect(scopes).toContain(ACADEMIC_FIELD_TYPE);
+    expect(scopes).toContain(FIELD_OF_STUDY_TYPE);
     expect(scopes.filter(scope => scope === '')).toHaveLength(0);
   });
 
@@ -137,7 +137,7 @@ describe('AddEducationSheet', () => {
     expect(draft.fields).toHaveLength(2);
   });
 
-  it('marks a field the user typed so it becomes an Academic field others can find', async () => {
+  it('marks a field the user typed so it becomes a Field of study others can find', async () => {
     const props = renderSheet();
 
     await userEvent.click(pickers()[0]);

--- a/apps/web/partials/profile/add-education-sheet.test.tsx
+++ b/apps/web/partials/profile/add-education-sheet.test.tsx
@@ -4,7 +4,7 @@ import userEvent from '@testing-library/user-event';
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { ACADEMIC_FIELD_TYPE, SCHOOL_TYPES } from '~/core/profile/history-ontology';
+import { ACADEMIC_FIELD_TYPE, DEGREE_TYPES, SCHOOL_TYPES } from '~/core/profile/history-ontology';
 
 import { AddEducationSheet } from './add-education-sheet';
 
@@ -71,16 +71,18 @@ describe('AddEducationSheet', () => {
 
   // School and Degree have several entities apiece under those names with no
   // canonical type, so a wrong filter would hide every real one from the search.
-  // School is scoped to what `Education` declares plus the narrower type most
-  // schools carry. Degree stays unscoped: several entities sit under that name
-  // with no obvious canonical one, and a wrong filter there hides every answer.
-  it('searches both school types, and leaves degree unscoped rather than guessing', () => {
+  // Every picker scoped to what its property declares. School takes the pair,
+  // since `Education` declares the broader of the two and most schools carry the
+  // narrower one.
+  it('scopes each picker to the type its property declares', () => {
     renderSheet();
 
     const scopes = pickers().map(button => button.getAttribute('data-scoped-to'));
 
     expect(scopes).toContain(SCHOOL_TYPES.join(','));
-    expect(scopes.filter(scope => scope === '')).toHaveLength(1);
+    expect(scopes).toContain(DEGREE_TYPES.join(','));
+    expect(scopes).toContain(ACADEMIC_FIELD_TYPE);
+    expect(scopes.filter(scope => scope === '')).toHaveLength(0);
   });
 
   it('offers the three states dates alone cannot express', () => {

--- a/apps/web/partials/profile/add-education-sheet.tsx
+++ b/apps/web/partials/profile/add-education-sheet.tsx
@@ -4,19 +4,21 @@ import * as React from 'react';
 
 import cx from 'classnames';
 
-import { type MonthYear, toGraphDate } from '~/core/profile/history-dates';
+import { type MonthYear, fromGraphDate, toGraphDate } from '~/core/profile/history-dates';
 import { ACADEMIC_FIELD_TYPE, type EducationStatus } from '~/core/profile/history-ontology';
 import type { EducationDraft, EntityChoice } from '~/core/profile/stage-history';
 
 import { inputStyles } from '~/design-system/input';
 import { SelectEntity } from '~/design-system/select-entity';
 
-import { HistorySheet, PickedEntity } from './history-sheet';
+import { HistorySheet, PickedEntity, findOrCreate } from './history-sheet';
 import { MonthYearField } from './month-year-field';
 
 type Props = {
   spaceId: string;
   school?: { id: string; name: string | null; stintId: string };
+  /** The row being changed, when this is an edit rather than an addition. */
+  initial?: EducationDraft;
   isSaving: boolean;
   onCancel: () => void;
   onSave: (draft: EducationDraft) => void;
@@ -36,17 +38,19 @@ const STATUS_OPTIONS: { value: EducationStatus; label: string }[] = [
  * is made explicitly here, and "Still studying" writes no status at all rather
  * than inventing an option the ontology does not have.
  */
-export function AddEducationSheet({ spaceId, school, isSaving, onCancel, onSave }: Props) {
-  const locked = school ? { id: school.id, name: school.name, isNew: false } : null;
+export function AddEducationSheet({ spaceId, school, initial, isSaving, onCancel, onSave }: Props) {
+  const locked = !initial && school ? { id: school.id, name: school.name, isNew: false } : null;
 
-  const [pickedSchool, setPickedSchool] = React.useState<EntityChoice | null>(locked);
-  const [degree, setDegree] = React.useState<EntityChoice | null>(null);
-  const [fields, setFields] = React.useState<EntityChoice[]>([]);
+  const [pickedSchool, setPickedSchool] = React.useState<EntityChoice | null>(
+    initial ? initial.school : (locked ?? null)
+  );
+  const [degree, setDegree] = React.useState<EntityChoice | null>(initial?.degree ?? null);
+  const [fields, setFields] = React.useState<EntityChoice[]>(initial?.fields ?? []);
   const [isAddingField, setIsAddingField] = React.useState(false);
-  const [status, setStatus] = React.useState<EducationStatus>('studying');
-  const [start, setStart] = React.useState<MonthYear | null>(null);
-  const [end, setEnd] = React.useState<MonthYear | null>(null);
-  const [description, setDescription] = React.useState('');
+  const [status, setStatus] = React.useState<EducationStatus>(initial?.status ?? 'studying');
+  const [start, setStart] = React.useState<MonthYear | null>(fromGraphDate(initial?.startDate));
+  const [end, setEnd] = React.useState<MonthYear | null>(fromGraphDate(initial?.endDate));
+  const [description, setDescription] = React.useState(initial?.description ?? '');
 
   const canSave = pickedSchool !== null && degree !== null && !isSaving;
 
@@ -67,7 +71,7 @@ export function AddEducationSheet({ spaceId, school, isSaving, onCancel, onSave 
 
   return (
     <HistorySheet
-      title="Add education"
+      title={initial ? 'Edit education' : 'Add education'}
       isSaving={isSaving}
       canSave={canSave}
       saveLabel="Save education"
@@ -86,6 +90,8 @@ export function AddEducationSheet({ spaceId, school, isSaving, onCancel, onSave 
           // hide every real school from the search.
           <SelectEntity
             spaceId={spaceId}
+            placeholder="Find or create a school..."
+            onCreateEntity={findOrCreate}
             onDone={(result, fromCreateFn) =>
               setPickedSchool({ id: result.id, name: result.name, isNew: Boolean(fromCreateFn) })
             }
@@ -101,6 +107,8 @@ export function AddEducationSheet({ spaceId, school, isSaving, onCancel, onSave 
         ) : (
           <SelectEntity
             spaceId={spaceId}
+            placeholder="Find or create a degree..."
+            onCreateEntity={findOrCreate}
             onDone={(result, fromCreateFn) =>
               setDegree({ id: result.id, name: result.name, isNew: Boolean(fromCreateFn) })
             }
@@ -134,6 +142,8 @@ export function AddEducationSheet({ spaceId, school, isSaving, onCancel, onSave 
           <SelectEntity
             spaceId={spaceId}
             relationValueTypes={[{ id: ACADEMIC_FIELD_TYPE, name: 'Academic field' }]}
+            placeholder="Find or create a field..."
+            onCreateEntity={findOrCreate}
             onDone={(result, fromCreateFn) => {
               setFields(current =>
                 current.some(field => field.id === result.id)

--- a/apps/web/partials/profile/add-education-sheet.tsx
+++ b/apps/web/partials/profile/add-education-sheet.tsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 import cx from 'classnames';
 
 import { type MonthYear, fromGraphDate, toGraphDate } from '~/core/profile/history-dates';
-import { ACADEMIC_FIELD_TYPE, type EducationStatus } from '~/core/profile/history-ontology';
+import { ACADEMIC_FIELD_TYPE, type EducationStatus, SCHOOL_TYPES } from '~/core/profile/history-ontology';
 import type { EducationDraft, EntityChoice } from '~/core/profile/stage-history';
 
 import { inputStyles } from '~/design-system/input';
@@ -23,6 +23,12 @@ type Props = {
   onCancel: () => void;
   onSave: (draft: EducationDraft) => void;
 };
+
+/**
+ * University and Institution both, and stable so it does not re-trigger the
+ * search on every render. See `SCHOOL_TYPES` for why it is the pair.
+ */
+const SCHOOL_TYPE_FILTER = SCHOOL_TYPES.map(id => ({ id, name: null }));
 
 const STATUS_OPTIONS: { value: EducationStatus; label: string }[] = [
   { value: 'studying', label: 'Still studying' },
@@ -85,11 +91,9 @@ export function AddEducationSheet({ spaceId, school, initial, isSaving, onCancel
         ) : pickedSchool ? (
           <PickedEntity name={pickedSchool.name} onClear={() => setPickedSchool(null)} />
         ) : (
-          // Unscoped on purpose: several entities are named "University" and
-          // "School" with no obvious canonical type, and a wrong filter would
-          // hide every real school from the search.
           <SelectEntity
             spaceId={spaceId}
+            relationValueTypes={SCHOOL_TYPE_FILTER}
             placeholder="Find or create a school..."
             onCreateEntity={findOrCreate}
             onDone={(result, fromCreateFn) =>

--- a/apps/web/partials/profile/add-education-sheet.tsx
+++ b/apps/web/partials/profile/add-education-sheet.tsx
@@ -5,7 +5,14 @@ import * as React from 'react';
 import cx from 'classnames';
 
 import { type MonthYear, fromGraphDate, toGraphDate } from '~/core/profile/history-dates';
-import { ACADEMIC_FIELD_TYPE, DEGREE_TYPES, type EducationStatus, SCHOOL_TYPES } from '~/core/profile/history-ontology';
+import {
+  ACADEMIC_FIELD_TYPE,
+  DEGREE_TYPES,
+  type EducationStatus,
+  SCHOOL_TYPES,
+  SKILL_TYPE,
+  TAXONOMY_SPACE_ID,
+} from '~/core/profile/history-ontology';
 import type { EducationDraft, EntityChoice } from '~/core/profile/stage-history';
 
 import { inputStyles } from '~/design-system/input';
@@ -32,6 +39,9 @@ const SCHOOL_TYPE_FILTER = SCHOOL_TYPES.map(id => ({ id, name: null }));
 
 /** Both entities named `Degree`; see `LEGACY_DEGREE_TYPE` for why it is a pair. */
 const DEGREE_TYPE_FILTER = DEGREE_TYPES.map(id => ({ id, name: 'Degree' }));
+
+/** The taxonomy lives in one space nobody is a member of; see `TAXONOMY_SPACE_ID`. */
+const TAXONOMY_SPACE_ID_LIST = [TAXONOMY_SPACE_ID];
 
 const STATUS_OPTIONS: { value: EducationStatus; label: string }[] = [
   { value: 'studying', label: 'Still studying' },
@@ -60,6 +70,9 @@ export function AddEducationSheet({ spaceId, school, initial, isSaving, onCancel
   const [start, setStart] = React.useState<MonthYear | null>(fromGraphDate(initial?.startDate));
   const [end, setEnd] = React.useState<MonthYear | null>(fromGraphDate(initial?.endDate));
   const [description, setDescription] = React.useState(initial?.description ?? '');
+  const [skills, setSkills] = React.useState<EntityChoice[]>(initial?.skills ?? []);
+  const [isAddingSkill, setIsAddingSkill] = React.useState(false);
+  const [grade, setGrade] = React.useState(initial?.grade ?? '');
 
   const canSave = pickedSchool !== null && degree !== null && !isSaving;
 
@@ -70,6 +83,8 @@ export function AddEducationSheet({ spaceId, school, initial, isSaving, onCancel
       school: pickedSchool,
       degree,
       fields,
+      skills,
+      grade,
       startDate: start ? toGraphDate(start) : null,
       endDate: status === 'studying' || !end ? null : toGraphDate(end),
       status,
@@ -202,6 +217,71 @@ export function AddEducationSheet({ spaceId, school, initial, isSaving, onCancel
       <div className="flex flex-wrap items-end gap-4">
         <MonthYearField label="Start" value={start} onChange={setStart} disabled={isSaving} />
         <MonthYearField label="End" value={end} onChange={setEnd} disabled={isSaving || status === 'studying'} />
+      </div>
+
+      <label className="flex flex-col gap-1.5">
+        <span className="text-metadataMedium text-grey-04">Grade</span>
+        {/* A number, because the property is a decimal. A classification or a
+            pass has nowhere to go here and belongs in the description. */}
+        <input
+          type="number"
+          inputMode="decimal"
+          step="any"
+          value={grade}
+          onChange={event => setGrade(event.currentTarget.value)}
+          disabled={isSaving}
+          placeholder="Optional — e.g. 3.8"
+          className={inputStyles()}
+        />
+      </label>
+
+      <div className="flex flex-col gap-1.5">
+        <span className="text-metadataMedium text-grey-04">Skills</span>
+        {skills.length > 0 && (
+          <ul className="flex flex-wrap gap-1.5">
+            {skills.map(skill => (
+              <li key={skill.id} className="flex items-center gap-1.5 rounded bg-divider px-2 py-1">
+                <span className="text-footnote text-text">{skill.name ?? 'Untitled'}</span>
+                {skill.isNew && <span className="text-footnote text-ctaPrimary">NEW</span>}
+                <button
+                  type="button"
+                  onClick={() => setSkills(current => current.filter(item => item.id !== skill.id))}
+                  aria-label={`Remove skill ${skill.name ?? 'skill'}`}
+                  className="text-footnote text-grey-04 hover:underline"
+                >
+                  ×
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+
+        {isAddingSkill || skills.length === 0 ? (
+          <SelectEntity
+            spaceId={spaceId}
+            relationValueTypes={[{ id: SKILL_TYPE, name: 'Skill' }]}
+            placeholder="Find or create a skill..."
+            alsoSearchSpaceIds={TAXONOMY_SPACE_ID_LIST}
+            onCreateEntity={findOrCreate}
+            onDone={(result, fromCreateFn) => {
+              setSkills(current =>
+                current.some(skill => skill.id === result.id)
+                  ? current
+                  : [...current, { id: result.id, name: result.name, isNew: Boolean(fromCreateFn) }]
+              );
+              setIsAddingSkill(false);
+            }}
+            width="full"
+          />
+        ) : (
+          <button
+            type="button"
+            onClick={() => setIsAddingSkill(true)}
+            className="self-start text-footnote text-ctaPrimary hover:underline"
+          >
+            + Add skill
+          </button>
+        )}
       </div>
 
       <label className="flex flex-col gap-1.5">

--- a/apps/web/partials/profile/add-education-sheet.tsx
+++ b/apps/web/partials/profile/add-education-sheet.tsx
@@ -141,7 +141,7 @@ export function AddEducationSheet({ spaceId, school, initial, isSaving, onCancel
       </div>
 
       <div className="flex flex-col gap-1.5">
-        <span className="text-metadataMedium text-grey-04">Field</span>
+        <span className="text-metadataMedium text-grey-04">Field of study</span>
         {fields.length > 0 && (
           <ul className="flex flex-wrap gap-1.5">
             {fields.map(field => (

--- a/apps/web/partials/profile/add-education-sheet.tsx
+++ b/apps/web/partials/profile/add-education-sheet.tsx
@@ -6,9 +6,9 @@ import cx from 'classnames';
 
 import { type MonthYear, fromGraphDate, toGraphDate } from '~/core/profile/history-dates';
 import {
-  ACADEMIC_FIELD_TYPE,
   DEGREE_TYPES,
   type EducationStatus,
+  FIELD_OF_STUDY_TYPE,
   SCHOOL_TYPES,
   SKILL_TYPE,
   TAXONOMY_SPACE_ID,
@@ -112,7 +112,7 @@ export function AddEducationSheet({ spaceId, school, initial, isSaving, onCancel
           <SelectEntity
             spaceId={spaceId}
             relationValueTypes={SCHOOL_TYPE_FILTER}
-            placeholder="Find or create a school..."
+            placeholder="Example: Boston University"
             onCreateEntity={findOrCreate}
             onDone={(result, fromCreateFn) =>
               setPickedSchool({ id: result.id, name: result.name, isNew: Boolean(fromCreateFn) })
@@ -130,7 +130,7 @@ export function AddEducationSheet({ spaceId, school, initial, isSaving, onCancel
           <SelectEntity
             spaceId={spaceId}
             relationValueTypes={DEGREE_TYPE_FILTER}
-            placeholder="Find or create a degree..."
+            placeholder="Example: Bachelor of Science"
             onCreateEntity={findOrCreate}
             onDone={(result, fromCreateFn) =>
               setDegree({ id: result.id, name: result.name, isNew: Boolean(fromCreateFn) })
@@ -164,8 +164,8 @@ export function AddEducationSheet({ spaceId, school, initial, isSaving, onCancel
         {isAddingField || fields.length === 0 ? (
           <SelectEntity
             spaceId={spaceId}
-            relationValueTypes={[{ id: ACADEMIC_FIELD_TYPE, name: 'Academic field' }]}
-            placeholder="Find or create a field..."
+            relationValueTypes={[{ id: FIELD_OF_STUDY_TYPE, name: 'Field of study' }]}
+            placeholder="Example: Business"
             onCreateEntity={findOrCreate}
             onDone={(result, fromCreateFn) => {
               setFields(current =>
@@ -178,7 +178,7 @@ export function AddEducationSheet({ spaceId, school, initial, isSaving, onCancel
             width="full"
           />
         ) : (
-          // A joint honours degree needs more than one, which is why Academic
+          // A joint honours degree needs more than one, which is why Fields of
           // fields is a relation rather than a value.
           <button
             type="button"
@@ -188,7 +188,7 @@ export function AddEducationSheet({ spaceId, school, initial, isSaving, onCancel
             + Add another
           </button>
         )}
-        <span className="text-footnote text-grey-04">Creates an Academic field others can use.</span>
+        <span className="text-footnote text-grey-04">Creates a Field of study others can use.</span>
       </div>
 
       <fieldset className="flex flex-col gap-1.5">
@@ -216,7 +216,13 @@ export function AddEducationSheet({ spaceId, school, initial, isSaving, onCancel
 
       <div className="flex flex-wrap items-end gap-4">
         <MonthYearField label="Start" value={start} onChange={setStart} disabled={isSaving} />
-        <MonthYearField label="End" value={end} onChange={setEnd} disabled={isSaving || status === 'studying'} />
+        <MonthYearField
+          label="End"
+          note="or expected"
+          value={end}
+          onChange={setEnd}
+          disabled={isSaving || status === 'studying'}
+        />
       </div>
 
       <label className="flex flex-col gap-1.5">
@@ -230,13 +236,15 @@ export function AddEducationSheet({ spaceId, school, initial, isSaving, onCancel
           value={grade}
           onChange={event => setGrade(event.currentTarget.value)}
           disabled={isSaving}
-          placeholder="Optional — e.g. 3.8"
+          placeholder="Example: 3.8"
           className={inputStyles()}
         />
+        <span className="text-footnote text-grey-04">A number, as the institution gave it.</span>
       </label>
 
       <div className="flex flex-col gap-1.5">
         <span className="text-metadataMedium text-grey-04">Skills</span>
+        <span className="text-footnote text-grey-04">Add skills to show what you studied.</span>
         {skills.length > 0 && (
           <ul className="flex flex-wrap gap-1.5">
             {skills.map(skill => (
@@ -260,7 +268,7 @@ export function AddEducationSheet({ spaceId, school, initial, isSaving, onCancel
           <SelectEntity
             spaceId={spaceId}
             relationValueTypes={[{ id: SKILL_TYPE, name: 'Skill' }]}
-            placeholder="Find or create a skill..."
+            placeholder="Example: Statistics"
             alsoSearchSpaceIds={TAXONOMY_SPACE_ID_LIST}
             onCreateEntity={findOrCreate}
             onDone={(result, fromCreateFn) => {
@@ -291,7 +299,7 @@ export function AddEducationSheet({ spaceId, school, initial, isSaving, onCancel
           onChange={event => setDescription(event.currentTarget.value)}
           disabled={isSaving}
           rows={3}
-          placeholder="Optional"
+          placeholder="Activities, societies, or what you focused on"
           className={`${inputStyles()} resize-none`}
         />
       </label>

--- a/apps/web/partials/profile/add-education-sheet.tsx
+++ b/apps/web/partials/profile/add-education-sheet.tsx
@@ -1,0 +1,202 @@
+'use client';
+
+import * as React from 'react';
+
+import cx from 'classnames';
+
+import { type MonthYear, toGraphDate } from '~/core/profile/history-dates';
+import { ACADEMIC_FIELD_TYPE, type EducationStatus } from '~/core/profile/history-ontology';
+import type { EducationDraft, EntityChoice } from '~/core/profile/stage-history';
+
+import { inputStyles } from '~/design-system/input';
+import { SelectEntity } from '~/design-system/select-entity';
+
+import { HistorySheet, PickedEntity } from './history-sheet';
+import { MonthYearField } from './month-year-field';
+
+type Props = {
+  spaceId: string;
+  school?: { id: string; name: string | null; stintId: string };
+  isSaving: boolean;
+  onCancel: () => void;
+  onSave: (draft: EducationDraft) => void;
+};
+
+const STATUS_OPTIONS: { value: EducationStatus; label: string }[] = [
+  { value: 'studying', label: 'Still studying' },
+  { value: 'completed', label: 'Completed' },
+  { value: 'incomplete', label: 'Did not finish' },
+];
+
+/**
+ * The one sheet with a three-way status.
+ *
+ * The graph has Completed and Incomplete and nothing for in-progress, and both
+ * of those look identical to still-studying as a missing end date. So the choice
+ * is made explicitly here, and "Still studying" writes no status at all rather
+ * than inventing an option the ontology does not have.
+ */
+export function AddEducationSheet({ spaceId, school, isSaving, onCancel, onSave }: Props) {
+  const locked = school ? { id: school.id, name: school.name, isNew: false } : null;
+
+  const [pickedSchool, setPickedSchool] = React.useState<EntityChoice | null>(locked);
+  const [degree, setDegree] = React.useState<EntityChoice | null>(null);
+  const [fields, setFields] = React.useState<EntityChoice[]>([]);
+  const [isAddingField, setIsAddingField] = React.useState(false);
+  const [status, setStatus] = React.useState<EducationStatus>('studying');
+  const [start, setStart] = React.useState<MonthYear | null>(null);
+  const [end, setEnd] = React.useState<MonthYear | null>(null);
+  const [description, setDescription] = React.useState('');
+
+  const canSave = pickedSchool !== null && degree !== null && !isSaving;
+
+  const save = () => {
+    if (!pickedSchool || !degree) return;
+
+    onSave({
+      school: pickedSchool,
+      degree,
+      fields,
+      startDate: start ? toGraphDate(start) : null,
+      endDate: status === 'studying' || !end ? null : toGraphDate(end),
+      status,
+      description,
+      existingStintId: school?.stintId,
+    });
+  };
+
+  return (
+    <HistorySheet
+      title="Add education"
+      isSaving={isSaving}
+      canSave={canSave}
+      saveLabel="Save education"
+      onCancel={onCancel}
+      onSave={save}
+    >
+      <div className="flex flex-col gap-1.5">
+        <span className="text-metadataMedium text-grey-04">School</span>
+        {locked ? (
+          <PickedEntity name={locked.name} note="Already on your profile — this degree attaches to it." />
+        ) : pickedSchool ? (
+          <PickedEntity name={pickedSchool.name} onClear={() => setPickedSchool(null)} />
+        ) : (
+          // Unscoped on purpose: several entities are named "University" and
+          // "School" with no obvious canonical type, and a wrong filter would
+          // hide every real school from the search.
+          <SelectEntity
+            spaceId={spaceId}
+            onDone={(result, fromCreateFn) =>
+              setPickedSchool({ id: result.id, name: result.name, isNew: Boolean(fromCreateFn) })
+            }
+            width="full"
+          />
+        )}
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        <span className="text-metadataMedium text-grey-04">Degree</span>
+        {degree ? (
+          <PickedEntity name={degree.name} onClear={() => setDegree(null)} />
+        ) : (
+          <SelectEntity
+            spaceId={spaceId}
+            onDone={(result, fromCreateFn) =>
+              setDegree({ id: result.id, name: result.name, isNew: Boolean(fromCreateFn) })
+            }
+            width="full"
+          />
+        )}
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        <span className="text-metadataMedium text-grey-04">Field</span>
+        {fields.length > 0 && (
+          <ul className="flex flex-wrap gap-1.5">
+            {fields.map(field => (
+              <li key={field.id} className="flex items-center gap-1.5 rounded bg-divider px-2 py-1">
+                <span className="text-footnote text-text">{field.name ?? 'Untitled'}</span>
+                {field.isNew && <span className="text-footnote text-ctaPrimary">NEW</span>}
+                <button
+                  type="button"
+                  onClick={() => setFields(current => current.filter(item => item.id !== field.id))}
+                  aria-label={`Remove ${field.name ?? 'field'}`}
+                  className="text-footnote text-grey-04 hover:underline"
+                >
+                  ×
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+
+        {isAddingField || fields.length === 0 ? (
+          <SelectEntity
+            spaceId={spaceId}
+            relationValueTypes={[{ id: ACADEMIC_FIELD_TYPE, name: 'Academic field' }]}
+            onDone={(result, fromCreateFn) => {
+              setFields(current =>
+                current.some(field => field.id === result.id)
+                  ? current
+                  : [...current, { id: result.id, name: result.name, isNew: Boolean(fromCreateFn) }]
+              );
+              setIsAddingField(false);
+            }}
+            width="full"
+          />
+        ) : (
+          // A joint honours degree needs more than one, which is why Academic
+          // fields is a relation rather than a value.
+          <button
+            type="button"
+            onClick={() => setIsAddingField(true)}
+            className="self-start text-footnote text-ctaPrimary hover:underline"
+          >
+            + Add another
+          </button>
+        )}
+        <span className="text-footnote text-grey-04">Creates an Academic field others can use.</span>
+      </div>
+
+      <fieldset className="flex flex-col gap-1.5">
+        <legend className="text-metadataMedium text-grey-04">Status</legend>
+        <div className="flex flex-wrap gap-1.5">
+          {STATUS_OPTIONS.map(option => (
+            <button
+              key={option.value}
+              type="button"
+              aria-pressed={status === option.value}
+              onClick={() => setStatus(option.value)}
+              disabled={isSaving}
+              className={cx(
+                'rounded border px-2.5 py-1.5 text-footnote transition-colors',
+                status === option.value
+                  ? 'border-text bg-text text-white'
+                  : 'border-grey-02 text-text hover:border-text'
+              )}
+            >
+              {option.label}
+            </button>
+          ))}
+        </div>
+      </fieldset>
+
+      <div className="flex flex-wrap items-end gap-4">
+        <MonthYearField label="Start" value={start} onChange={setStart} disabled={isSaving} />
+        <MonthYearField label="End" value={end} onChange={setEnd} disabled={isSaving || status === 'studying'} />
+      </div>
+
+      <label className="flex flex-col gap-1.5">
+        <span className="text-metadataMedium text-grey-04">Description</span>
+        <textarea
+          value={description}
+          onChange={event => setDescription(event.currentTarget.value)}
+          disabled={isSaving}
+          rows={3}
+          placeholder="Optional"
+          className={`${inputStyles()} resize-none`}
+        />
+      </label>
+    </HistorySheet>
+  );
+}

--- a/apps/web/partials/profile/add-education-sheet.tsx
+++ b/apps/web/partials/profile/add-education-sheet.tsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 import cx from 'classnames';
 
 import { type MonthYear, fromGraphDate, toGraphDate } from '~/core/profile/history-dates';
-import { ACADEMIC_FIELD_TYPE, type EducationStatus, SCHOOL_TYPES } from '~/core/profile/history-ontology';
+import { ACADEMIC_FIELD_TYPE, DEGREE_TYPES, type EducationStatus, SCHOOL_TYPES } from '~/core/profile/history-ontology';
 import type { EducationDraft, EntityChoice } from '~/core/profile/stage-history';
 
 import { inputStyles } from '~/design-system/input';
@@ -29,6 +29,9 @@ type Props = {
  * search on every render. See `SCHOOL_TYPES` for why it is the pair.
  */
 const SCHOOL_TYPE_FILTER = SCHOOL_TYPES.map(id => ({ id, name: null }));
+
+/** Both entities named `Degree`; see `LEGACY_DEGREE_TYPE` for why it is a pair. */
+const DEGREE_TYPE_FILTER = DEGREE_TYPES.map(id => ({ id, name: 'Degree' }));
 
 const STATUS_OPTIONS: { value: EducationStatus; label: string }[] = [
   { value: 'studying', label: 'Still studying' },
@@ -111,6 +114,7 @@ export function AddEducationSheet({ spaceId, school, initial, isSaving, onCancel
         ) : (
           <SelectEntity
             spaceId={spaceId}
+            relationValueTypes={DEGREE_TYPE_FILTER}
             placeholder="Find or create a degree..."
             onCreateEntity={findOrCreate}
             onDone={(result, fromCreateFn) =>

--- a/apps/web/partials/profile/add-position-sheet.test.tsx
+++ b/apps/web/partials/profile/add-position-sheet.test.tsx
@@ -9,22 +9,27 @@ import { EMPLOYER_TYPE, JOB_TYPE } from '~/core/profile/history-ontology';
 import { AddPositionSheet } from './add-position-sheet';
 
 /**
- * `SelectEntity` is a search box over the graph. Stubbed down to the two things
- * this sheet depends on: which types it was scoped to, and whether the result
- * came back as an existing entity or one the user is creating.
+ * `SelectEntity` is a search box over the graph. Stubbed down to the three things
+ * this sheet depends on: which types it was scoped to, whether the result came
+ * back as an existing entity or one the user is creating, and whether it was
+ * handed an `onCreateEntity` — the prop whose presence is what makes the real
+ * component offer "Create new" at all.
  */
 vi.mock('~/design-system/select-entity', () => ({
   SelectEntity: ({
     relationValueTypes,
+    onCreateEntity,
     onDone,
   }: {
     relationValueTypes?: { id: string; name: string | null }[];
+    onCreateEntity?: (result: { id: string; name: string | null }) => void | string;
     onDone: (result: { id: string; name: string | null }, fromCreateFn?: boolean) => void;
   }) => (
     <div>
       <button
         type="button"
         data-scoped-to={relationValueTypes?.map(type => type.id).join(',') ?? ''}
+        data-can-create={onCreateEntity ? 'yes' : 'no'}
         onClick={() => onDone({ id: 'picked-id', name: 'Coinbase' })}
       >
         pick existing
@@ -136,6 +141,77 @@ describe('AddPositionSheet', () => {
     await userEvent.click(screen.getByRole('button', { name: 'Save position' }));
 
     expect(props.onSave).toHaveBeenCalledWith(expect.objectContaining({ existingStintId: 'stint-1' }));
+  });
+
+  // The real component's "Create new" footer renders only where an
+  // `onCreateEntity` was supplied, so without it these pickers could find a
+  // company only if somebody else had already entered it.
+  it('offers find-or-create on every picker', () => {
+    renderSheet();
+
+    const pickers = screen.getAllByRole('button', { name: /pick existing/ });
+    expect(pickers.length).toBeGreaterThan(0);
+    expect(pickers.every(picker => picker.getAttribute('data-can-create') === 'yes')).toBe(true);
+  });
+
+  // Ticking it is what leaves the End picker with nothing to say, so it has to be
+  // read before End rather than after it.
+  it('asks whether the role is current before asking when it ended', () => {
+    renderSheet();
+
+    const isCurrent = screen.getByRole('checkbox');
+    const end = screen.getByLabelText('End month');
+
+    expect(isCurrent.compareDocumentPosition(end) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  describe('editing an existing row', () => {
+    const initial = {
+      company: { id: 'org-geo', name: 'Geo', isNew: false },
+      title: { id: 'title-engineer', name: 'Engineer', isNew: false },
+      employmentType: null,
+      skills: [{ id: 'skill-1', name: 'Product development', isNew: false }],
+      startDate: '2022-06-01Z',
+      endDate: null,
+      status: 'current' as const,
+      description: 'Here are some highlights',
+    };
+
+    it('opens with the row already in it', () => {
+      renderSheet({ initial });
+
+      expect(screen.getByRole('heading', { name: 'Edit position' })).toBeInTheDocument();
+      expect(screen.getByText('Geo')).toBeInTheDocument();
+      expect(screen.getByText('Engineer')).toBeInTheDocument();
+      expect(screen.getByText('Product development')).toBeInTheDocument();
+      expect(screen.getByDisplayValue('Here are some highlights')).toBeInTheDocument();
+      expect(screen.getByLabelText('Start month')).toHaveValue('6');
+      expect(screen.getByLabelText('Start year')).toHaveValue('2022');
+      expect(screen.getByRole('checkbox')).toHaveAttribute('aria-checked', 'true');
+    });
+
+    // Unlike the promotion case, where the company is the one thing already
+    // answered: a row opened to be corrected may be at the wrong company.
+    it('lets the company be changed', async () => {
+      const props = renderSheet({ initial });
+
+      // The company's, which is the first of the two — the title has one too.
+      await userEvent.click(screen.getAllByRole('button', { name: 'Change' })[0]);
+      await userEvent.click(screen.getAllByRole('button', { name: /pick existing/ })[0]);
+      await userEvent.click(screen.getByRole('button', { name: 'Save position' }));
+
+      expect(props.onSave).toHaveBeenCalledWith(
+        expect.objectContaining({ company: { id: 'picked-id', name: 'Coinbase', isNew: false } })
+      );
+    });
+
+    it('hands back everything it was given when nothing is touched', async () => {
+      const props = renderSheet({ initial });
+
+      await userEvent.click(screen.getByRole('button', { name: 'Save position' }));
+
+      expect(props.onSave).toHaveBeenCalledWith(expect.objectContaining(initial));
+    });
   });
 
   it('says what the wait is and locks the controls while saving', () => {

--- a/apps/web/partials/profile/add-position-sheet.test.tsx
+++ b/apps/web/partials/profile/add-position-sheet.test.tsx
@@ -4,7 +4,7 @@ import userEvent from '@testing-library/user-event';
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { COMPANY_TYPE, JOB_TYPE } from '~/core/profile/history-ontology';
+import { EMPLOYER_TYPE, JOB_TYPE } from '~/core/profile/history-ontology';
 
 import { AddPositionSheet } from './add-position-sheet';
 
@@ -70,7 +70,7 @@ describe('AddPositionSheet', () => {
     renderSheet();
 
     const scopes = screen.getAllByRole('button', { name: /pick existing/ }).map(b => b.getAttribute('data-scoped-to'));
-    expect(scopes).toContain(COMPANY_TYPE);
+    expect(scopes).toContain(EMPLOYER_TYPE);
     expect(scopes).toContain(JOB_TYPE);
   });
 

--- a/apps/web/partials/profile/add-position-sheet.test.tsx
+++ b/apps/web/partials/profile/add-position-sheet.test.tsx
@@ -20,7 +20,8 @@ vi.mock('~/core/hooks/use-suggested-skills', () => ({
   useSuggestedSkills: ({ roleId, picked }: { roleId: string | undefined; picked: string[] }) => {
     mocks.suggestedFor = roleId;
     mocks.alreadyPicked = picked;
-    return { suggestions: roleId ? mocks.suggestions : [], isLoading: false };
+    const forRole = roleId ? mocks.suggestions : [];
+    return { suggestions: forRole.slice(0, 5), all: forRole, isLoading: false };
   },
 }));
 
@@ -35,10 +36,12 @@ vi.mock('~/design-system/select-entity', () => ({
   SelectEntity: ({
     relationValueTypes,
     onCreateEntity,
+    pinnedResults,
     onDone,
   }: {
     relationValueTypes?: { id: string; name: string | null }[];
     onCreateEntity?: (result: { id: string; name: string | null }) => void | string;
+    pinnedResults?: { id: string; name: string | null }[];
     onDone: (result: { id: string; name: string | null }, fromCreateFn?: boolean) => void;
   }) => (
     <div>
@@ -46,6 +49,7 @@ vi.mock('~/design-system/select-entity', () => ({
         type="button"
         data-scoped-to={relationValueTypes?.map(type => type.id).join(',') ?? ''}
         data-can-create={onCreateEntity ? 'yes' : 'no'}
+        data-pinned={(pinnedResults ?? []).map(result => result.name).join('|')}
         onClick={() => onDone({ id: 'picked-id', name: 'Coinbase' })}
       >
         pick existing
@@ -287,6 +291,23 @@ describe('AddPositionSheet', () => {
       await pickTitle();
 
       expect(screen.queryByText('Common for this role')).not.toBeInTheDocument();
+    });
+
+    // Five pills are a shortcut past searching, not the set. A product manager
+    // has dozens recorded, so choosing from five meant choosing from whichever
+    // five ranked highest — the rest have to be reachable without guessing at a
+    // search term.
+    it('offers every skill for the role inside the picker, not just the five pills', async () => {
+      mocks.suggestions = Array.from({ length: 9 }, (_, index) => suggestion(`Skill ${index}`));
+      renderSheet();
+
+      await pickCompany();
+      await pickTitle();
+
+      expect(screen.getAllByRole('button', { name: /^\+ Skill/ })).toHaveLength(5);
+
+      const pinned = screen.getAllByRole('button', { name: /pick existing/ }).map(picker => picker.dataset.pinned);
+      expect(pinned).toContain(Array.from({ length: 9 }, (_, index) => `Skill ${index}`).join('|'));
     });
   });
 

--- a/apps/web/partials/profile/add-position-sheet.test.tsx
+++ b/apps/web/partials/profile/add-position-sheet.test.tsx
@@ -8,6 +8,22 @@ import { EMPLOYER_TYPE, JOB_TYPE } from '~/core/profile/history-ontology';
 
 import { AddPositionSheet } from './add-position-sheet';
 
+const mocks = vi.hoisted(() => ({
+  suggestions: [] as { id: string; name: string | null; isRequired: boolean; rank: number }[],
+  suggestedFor: undefined as string | undefined,
+  alreadyPicked: [] as string[],
+}));
+
+// The taxonomy read behind the suggestions. Stubbed to record what it was asked
+// about, since which role the sheet asks for is the part this file owns.
+vi.mock('~/core/hooks/use-suggested-skills', () => ({
+  useSuggestedSkills: ({ roleId, picked }: { roleId: string | undefined; picked: string[] }) => {
+    mocks.suggestedFor = roleId;
+    mocks.alreadyPicked = picked;
+    return { suggestions: roleId ? mocks.suggestions : [], isLoading: false };
+  },
+}));
+
 /**
  * `SelectEntity` is a search box over the graph. Stubbed down to the three things
  * this sheet depends on: which types it was scoped to, whether the result came
@@ -41,7 +57,12 @@ vi.mock('~/design-system/select-entity', () => ({
   ),
 }));
 
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  mocks.suggestions = [];
+  mocks.suggestedFor = undefined;
+  mocks.alreadyPicked = [];
+});
 
 function renderSheet(overrides: Partial<Parameters<typeof AddPositionSheet>[0]> = {}) {
   const props = {
@@ -211,6 +232,61 @@ describe('AddPositionSheet', () => {
       await userEvent.click(screen.getByRole('button', { name: 'Save position' }));
 
       expect(props.onSave).toHaveBeenCalledWith(expect.objectContaining(initial));
+    });
+  });
+
+  describe('skills suggested for the role', () => {
+    const suggestion = (name: string) => ({ id: `skill-${name}`, name, isRequired: true, rank: 3 });
+
+    it('asks about the role only once one has been picked', async () => {
+      renderSheet();
+
+      expect(mocks.suggestedFor).toBeUndefined();
+
+      await pickCompany();
+      await pickTitle();
+
+      expect(mocks.suggestedFor).toBe('picked-id');
+    });
+
+    // Marked as existing rather than new: the taxonomy owns these entities, and
+    // minting a second `Debug software` is exactly what suggesting them avoids.
+    it('adds a suggestion to the draft as an existing entity', async () => {
+      mocks.suggestions = [suggestion('Debug software')];
+      const props = renderSheet();
+
+      await pickCompany();
+      await pickTitle();
+      await userEvent.click(screen.getByRole('button', { name: '+ Debug software' }));
+      await userEvent.click(screen.getByRole('button', { name: 'Save position' }));
+
+      expect(props.onSave).toHaveBeenCalledWith(
+        expect.objectContaining({
+          skills: [{ id: 'skill-Debug software', name: 'Debug software', isNew: false }],
+        })
+      );
+    });
+
+    it('tells the reader what is already on the draft so it is not offered again', async () => {
+      mocks.suggestions = [suggestion('Debug software')];
+      renderSheet();
+
+      await pickCompany();
+      await pickTitle();
+      await userEvent.click(screen.getByRole('button', { name: '+ Debug software' }));
+
+      expect(mocks.alreadyPicked).toEqual(['skill-Debug software']);
+    });
+
+    // A job title somebody typed in themselves has no taxonomy behind it, and an
+    // empty row would read as something failing to load.
+    it('shows nothing at all when the role has no skills', async () => {
+      renderSheet();
+
+      await pickCompany();
+      await pickTitle();
+
+      expect(screen.queryByText('Common for this role')).not.toBeInTheDocument();
     });
   });
 

--- a/apps/web/partials/profile/add-position-sheet.test.tsx
+++ b/apps/web/partials/profile/add-position-sheet.test.tsx
@@ -1,0 +1,148 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { COMPANY_TYPE, JOB_TYPE } from '~/core/profile/history-ontology';
+
+import { AddPositionSheet } from './add-position-sheet';
+
+/**
+ * `SelectEntity` is a search box over the graph. Stubbed down to the two things
+ * this sheet depends on: which types it was scoped to, and whether the result
+ * came back as an existing entity or one the user is creating.
+ */
+vi.mock('~/design-system/select-entity', () => ({
+  SelectEntity: ({
+    relationValueTypes,
+    onDone,
+  }: {
+    relationValueTypes?: { id: string; name: string | null }[];
+    onDone: (result: { id: string; name: string | null }, fromCreateFn?: boolean) => void;
+  }) => (
+    <div>
+      <button
+        type="button"
+        data-scoped-to={relationValueTypes?.map(type => type.id).join(',') ?? ''}
+        onClick={() => onDone({ id: 'picked-id', name: 'Coinbase' })}
+      >
+        pick existing
+      </button>
+      <button type="button" onClick={() => onDone({ id: 'new-id', name: 'Fathom' }, true)}>
+        create new
+      </button>
+    </div>
+  ),
+}));
+
+afterEach(cleanup);
+
+function renderSheet(overrides: Partial<Parameters<typeof AddPositionSheet>[0]> = {}) {
+  const props = {
+    spaceId: 'space-1',
+    isSaving: false,
+    onCancel: vi.fn(),
+    onSave: vi.fn(),
+    ...overrides,
+  };
+  render(<AddPositionSheet {...props} />);
+  return props;
+}
+
+const pickCompany = () => userEvent.click(screen.getAllByRole('button', { name: /pick existing/ })[0]);
+const pickTitle = () => userEvent.click(screen.getAllByRole('button', { name: /pick existing/ })[0]);
+
+describe('AddPositionSheet', () => {
+  it('cannot save until both the company and the title are answered', async () => {
+    renderSheet();
+
+    expect(screen.getByRole('button', { name: 'Save position' })).toBeDisabled();
+
+    await pickCompany();
+    expect(screen.getByRole('button', { name: 'Save position' })).toBeDisabled();
+
+    await pickTitle();
+    expect(screen.getByRole('button', { name: 'Save position' })).toBeEnabled();
+  });
+
+  it('scopes each picker to the type it should search', () => {
+    renderSheet();
+
+    const scopes = screen.getAllByRole('button', { name: /pick existing/ }).map(b => b.getAttribute('data-scoped-to'));
+    expect(scopes).toContain(COMPANY_TYPE);
+    expect(scopes).toContain(JOB_TYPE);
+  });
+
+  it('saves the four answers as a position', async () => {
+    const props = renderSheet();
+
+    await pickCompany();
+    await pickTitle();
+    await userEvent.selectOptions(screen.getByLabelText('Start month'), '3');
+    await userEvent.selectOptions(screen.getByLabelText('Start year'), '2019');
+    await userEvent.selectOptions(screen.getByLabelText('End month'), '1');
+    await userEvent.selectOptions(screen.getByLabelText('End year'), '2021');
+    await userEvent.click(screen.getByRole('button', { name: 'Save position' }));
+
+    expect(props.onSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        company: { id: 'picked-id', name: 'Coinbase', isNew: false },
+        title: { id: 'picked-id', name: 'Coinbase', isNew: false },
+        startDate: '2019-03-01Z',
+        endDate: '2021-01-01Z',
+        status: 'former',
+      })
+    );
+  });
+
+  // Current and Former are a clean pair, so work gets a checkbox rather than the
+  // three-way control education needs.
+  it('writes a role still held as current with no end date', async () => {
+    const props = renderSheet();
+
+    await pickCompany();
+    await pickTitle();
+    await userEvent.selectOptions(screen.getByLabelText('End month'), '1');
+    await userEvent.selectOptions(screen.getByLabelText('End year'), '2021');
+    await userEvent.click(screen.getByRole('checkbox'));
+    await userEvent.click(screen.getByRole('button', { name: 'Save position' }));
+
+    // The end date the picker was left showing is discarded rather than published
+    // alongside a claim that the role is current.
+    expect(props.onSave).toHaveBeenCalledWith(expect.objectContaining({ status: 'current', endDate: null }));
+  });
+
+  it('marks a new company so it gets named and typed on save', async () => {
+    const props = renderSheet();
+
+    await userEvent.click(screen.getAllByRole('button', { name: /create new/ })[0]);
+    await pickTitle();
+    await userEvent.click(screen.getByRole('button', { name: 'Save position' }));
+
+    expect(props.onSave).toHaveBeenCalledWith(
+      expect.objectContaining({ company: { id: 'new-id', name: 'Fathom', isNew: true } })
+    );
+  });
+
+  // The promotion case: same sheet, company answered and locked, three fields left.
+  it('locks the company and reuses its stint when adding a second role there', async () => {
+    const props = renderSheet({ company: { id: 'coinbase', name: 'Coinbase', stintId: 'stint-1' } });
+
+    expect(screen.getByText('Coinbase')).toBeInTheDocument();
+    expect(screen.getByText(/Already on your profile/)).toBeInTheDocument();
+
+    await pickTitle();
+    await userEvent.click(screen.getByRole('button', { name: 'Save position' }));
+
+    expect(props.onSave).toHaveBeenCalledWith(expect.objectContaining({ existingStintId: 'stint-1' }));
+  });
+
+  it('says what the wait is and locks the controls while saving', () => {
+    renderSheet({ isSaving: true });
+
+    expect(screen.getByText(/about 10 seconds/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Saving' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeDisabled();
+  });
+});

--- a/apps/web/partials/profile/add-position-sheet.test.tsx
+++ b/apps/web/partials/profile/add-position-sheet.test.tsx
@@ -196,6 +196,8 @@ describe('AddPositionSheet', () => {
       title: { id: 'title-engineer', name: 'Engineer', isNew: false },
       employmentType: null,
       skills: [{ id: 'skill-1', name: 'Product development', isNew: false }],
+      location: { id: 'city-sf', name: 'San Francisco', isNew: false },
+      locationType: { id: 'loc-remote', name: 'Remote' },
       startDate: '2022-06-01Z',
       endDate: null,
       status: 'current' as const,
@@ -236,6 +238,45 @@ describe('AddPositionSheet', () => {
       await userEvent.click(screen.getByRole('button', { name: 'Save position' }));
 
       expect(props.onSave).toHaveBeenCalledWith(expect.objectContaining(initial));
+    });
+  });
+
+  describe('location', () => {
+    it('saves the city and the arrangement onto the position', async () => {
+      const props = renderSheet();
+
+      await pickCompany();
+      await pickTitle();
+      // The location picker is the next unanswered one.
+      await userEvent.click(screen.getAllByRole('button', { name: /pick existing/ })[0]);
+      await userEvent.selectOptions(screen.getByLabelText('Location type'), 'Remote');
+      await userEvent.click(screen.getByRole('button', { name: 'Save position' }));
+
+      expect(props.onSave).toHaveBeenCalledWith(
+        expect.objectContaining({
+          location: { id: 'picked-id', name: 'Coinbase', isNew: false },
+          locationType: { id: '8f5e23aa70394ea4b7946fa0a9878da7', name: 'Remote' },
+        })
+      );
+    });
+
+    // Optional on LinkedIn and optional here.
+    it('leaves both unanswered rather than guessing', async () => {
+      const props = renderSheet();
+
+      await pickCompany();
+      await pickTitle();
+      await userEvent.click(screen.getByRole('button', { name: 'Save position' }));
+
+      expect(props.onSave).toHaveBeenCalledWith(expect.objectContaining({ location: null, locationType: null }));
+    });
+
+    it('offers the three arrangements the graph records', () => {
+      renderSheet();
+
+      for (const option of ['Onsite', 'Hybrid', 'Remote']) {
+        expect(screen.getByRole('option', { name: option })).toBeInTheDocument();
+      }
     });
   });
 

--- a/apps/web/partials/profile/add-position-sheet.tsx
+++ b/apps/web/partials/profile/add-position-sheet.tsx
@@ -1,0 +1,134 @@
+'use client';
+
+import * as React from 'react';
+
+import { type MonthYear, toGraphDate } from '~/core/profile/history-dates';
+import { COMPANY_TYPE, JOB_TYPE } from '~/core/profile/history-ontology';
+import type { EntityChoice, PositionDraft } from '~/core/profile/stage-history';
+
+import { Checkbox } from '~/design-system/checkbox';
+import { inputStyles } from '~/design-system/input';
+import { SelectEntity } from '~/design-system/select-entity';
+
+import { HistorySheet, PickedEntity } from './history-sheet';
+import { MonthYearField } from './month-year-field';
+
+type Props = {
+  spaceId: string;
+  /** Pre-filled and locked when adding a second role at a company already listed. */
+  company?: { id: string; name: string | null; stintId: string };
+  isSaving: boolean;
+  onCancel: () => void;
+  onSave: (draft: PositionDraft) => void;
+};
+
+/**
+ * Four questions, which become three relations, two entities and two or three
+ * values. None of that appears here — that is the entire point.
+ */
+export function AddPositionSheet({ spaceId, company, isSaving, onCancel, onSave }: Props) {
+  const locked = company ? { id: company.id, name: company.name, isNew: false } : null;
+
+  const [pickedCompany, setPickedCompany] = React.useState<EntityChoice | null>(locked);
+  const [title, setTitle] = React.useState<EntityChoice | null>(null);
+  const [start, setStart] = React.useState<MonthYear | null>(null);
+  const [end, setEnd] = React.useState<MonthYear | null>(null);
+  const [isCurrent, setIsCurrent] = React.useState(false);
+  const [description, setDescription] = React.useState('');
+
+  const canSave = pickedCompany !== null && title !== null && !isSaving;
+
+  const save = () => {
+    if (!pickedCompany || !title) return;
+
+    onSave({
+      company: pickedCompany,
+      title,
+      startDate: start ? toGraphDate(start) : null,
+      // A role still held has no end date, whatever the picker was left showing.
+      endDate: isCurrent || !end ? null : toGraphDate(end),
+      status: isCurrent ? 'current' : 'former',
+      description,
+      existingStintId: company?.stintId,
+    });
+  };
+
+  return (
+    <HistorySheet
+      title="Add position"
+      isSaving={isSaving}
+      canSave={canSave}
+      saveLabel="Save position"
+      onCancel={onCancel}
+      onSave={save}
+    >
+      <div className="flex flex-col gap-1.5">
+        <span className="text-metadataMedium text-grey-04">Company</span>
+        {locked ? (
+          // The promotion case. Locked rather than hidden so it still reads as an
+          // answered question, and so the role visibly attaches to that employer.
+          <PickedEntity name={locked.name} note="Already on your profile — this role attaches to it." />
+        ) : pickedCompany ? (
+          <PickedEntity name={pickedCompany.name} onClear={() => setPickedCompany(null)} />
+        ) : (
+          <SelectEntity
+            spaceId={spaceId}
+            relationValueTypes={[{ id: COMPANY_TYPE, name: 'Company' }]}
+            onDone={(result, fromCreateFn) =>
+              setPickedCompany({ id: result.id, name: result.name, isNew: Boolean(fromCreateFn) })
+            }
+            width="full"
+          />
+        )}
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        <span className="text-metadataMedium text-grey-04">Title</span>
+        {title ? (
+          <PickedEntity name={title.name} onClear={() => setTitle(null)} />
+        ) : (
+          <SelectEntity
+            spaceId={spaceId}
+            relationValueTypes={[{ id: JOB_TYPE, name: 'Job' }]}
+            onDone={(result, fromCreateFn) =>
+              setTitle({ id: result.id, name: result.name, isNew: Boolean(fromCreateFn) })
+            }
+            width="full"
+          />
+        )}
+      </div>
+
+      <div className="flex flex-wrap items-end gap-4">
+        <MonthYearField label="Start" value={start} onChange={setStart} disabled={isSaving} />
+        <MonthYearField label="End" value={end} onChange={setEnd} disabled={isSaving || isCurrent} />
+      </div>
+
+      <div className="flex items-center gap-2">
+        {/* The shared Checkbox renders a bare button with no checkbox semantics.
+            Supplied here rather than fixed there: several callers assert on it
+            being a button, so correcting the component is its own change. */}
+        <Checkbox
+          checked={isCurrent}
+          onChange={() => setIsCurrent(current => !current)}
+          disabled={isSaving}
+          role="checkbox"
+          aria-checked={isCurrent}
+          aria-label="I’m in this role now"
+        />
+        <span className="text-footnote text-text">I’m in this role now</span>
+      </div>
+
+      <label className="flex flex-col gap-1.5">
+        <span className="text-metadataMedium text-grey-04">Description</span>
+        <textarea
+          value={description}
+          onChange={event => setDescription(event.currentTarget.value)}
+          disabled={isSaving}
+          rows={3}
+          placeholder="Optional"
+          className={`${inputStyles()} resize-none`}
+        />
+      </label>
+    </HistorySheet>
+  );
+}

--- a/apps/web/partials/profile/add-position-sheet.tsx
+++ b/apps/web/partials/profile/add-position-sheet.tsx
@@ -4,7 +4,13 @@ import * as React from 'react';
 
 import { useSuggestedSkills } from '~/core/hooks/use-suggested-skills';
 import { type MonthYear, fromGraphDate, toGraphDate } from '~/core/profile/history-dates';
-import { EMPLOYER_TYPE, EMPLOYMENT_TYPE_OPTIONS, JOB_TYPE, SKILL_TYPE } from '~/core/profile/history-ontology';
+import {
+  EMPLOYER_TYPE,
+  EMPLOYMENT_TYPE_OPTIONS,
+  JOB_TYPE,
+  SKILL_TYPE,
+  TAXONOMY_SPACE_ID,
+} from '~/core/profile/history-ontology';
 import type { EntityChoice, PositionDraft } from '~/core/profile/stage-history';
 
 import { Checkbox } from '~/design-system/checkbox';
@@ -13,6 +19,13 @@ import { SelectEntity } from '~/design-system/select-entity';
 
 import { HistorySheet, PickedEntity, findOrCreate } from './history-sheet';
 import { MonthYearField } from './month-year-field';
+
+/**
+ * Stable so it does not re-trigger the search on every render. The taxonomy is
+ * in one space and it is not one the viewer belongs to, so both pickers have to
+ * ask for it by name — see `TAXONOMY_SPACE_ID`.
+ */
+const TAXONOMY_SPACE_ID_LIST = [TAXONOMY_SPACE_ID];
 
 type Props = {
   spaceId: string;
@@ -50,12 +63,35 @@ export function AddPositionSheet({ spaceId, company, initial, isSaving, onCancel
   const [isCurrent, setIsCurrent] = React.useState(initial ? initial.status === 'current' : false);
   const [description, setDescription] = React.useState(initial?.description ?? '');
 
-  // Only ESCO occupations carry these; a title somebody typed in themselves has
-  // none, and the row simply does not appear.
-  const { suggestions } = useSuggestedSkills({
+  const pickedSkillIds = React.useMemo(() => skills.map(skill => skill.id), [skills]);
+
+  // Only occupations from the taxonomy carry these; a title somebody typed in
+  // themselves has none, and neither the pills nor the pinned rows appear.
+  const { suggestions, all: allForRole } = useSuggestedSkills({
     roleId: title?.id,
-    picked: React.useMemo(() => skills.map(skill => skill.id), [skills]),
+    picked: pickedSkillIds,
   });
+
+  /**
+   * Every skill the occupation is recorded as needing, offered inside the search
+   * box before anything is typed.
+   *
+   * The five pills below are a shortcut, not the set: a product manager has
+   * dozens, and picking from five meant picking from whichever five ranked
+   * highest. These are the same ranking, all of it, where the user is already
+   * looking when they go to add a skill.
+   */
+  const pinnedSkills = React.useMemo(
+    () =>
+      allForRole.map(skill => ({
+        id: skill.id,
+        name: skill.name,
+        description: null,
+        types: [],
+        spaces: [],
+      })),
+    [allForRole]
+  );
 
   const addSkill = (skill: EntityChoice) =>
     setSkills(current => (current.some(picked => picked.id === skill.id) ? current : [...current, skill]));
@@ -119,6 +155,7 @@ export function AddPositionSheet({ spaceId, company, initial, isSaving, onCancel
             spaceId={spaceId}
             relationValueTypes={[{ id: JOB_TYPE, name: 'Person role' }]}
             placeholder="Find or create a job title..."
+            alsoSearchSpaceIds={TAXONOMY_SPACE_ID_LIST}
             onCreateEntity={findOrCreate}
             onDone={(result, fromCreateFn) =>
               setTitle({ id: result.id, name: result.name, isNew: Boolean(fromCreateFn) })
@@ -207,6 +244,10 @@ export function AddPositionSheet({ spaceId, company, initial, isSaving, onCancel
             spaceId={spaceId}
             relationValueTypes={[{ id: SKILL_TYPE, name: 'Skill' }]}
             placeholder="Find or create a skill..."
+            alsoSearchSpaceIds={TAXONOMY_SPACE_ID_LIST}
+            pinnedResults={pinnedSkills}
+            pinnedLabel="Recommended for this role"
+            restLabel="All skills"
             onCreateEntity={findOrCreate}
             onDone={(result, fromCreateFn) => {
               addSkill({ id: result.id, name: result.name, isNew: Boolean(fromCreateFn) });

--- a/apps/web/partials/profile/add-position-sheet.tsx
+++ b/apps/web/partials/profile/add-position-sheet.tsx
@@ -3,7 +3,7 @@
 import * as React from 'react';
 
 import { type MonthYear, toGraphDate } from '~/core/profile/history-dates';
-import { EMPLOYER_TYPE, JOB_TYPE } from '~/core/profile/history-ontology';
+import { EMPLOYER_TYPE, EMPLOYMENT_TYPE_OPTIONS, JOB_TYPE, SKILL_TYPE } from '~/core/profile/history-ontology';
 import type { EntityChoice, PositionDraft } from '~/core/profile/stage-history';
 
 import { Checkbox } from '~/design-system/checkbox';
@@ -33,6 +33,9 @@ export function AddPositionSheet({ spaceId, company, isSaving, onCancel, onSave 
   const [title, setTitle] = React.useState<EntityChoice | null>(null);
   const [start, setStart] = React.useState<MonthYear | null>(null);
   const [end, setEnd] = React.useState<MonthYear | null>(null);
+  const [employmentType, setEmploymentType] = React.useState<{ id: string; name: string } | null>(null);
+  const [skills, setSkills] = React.useState<EntityChoice[]>([]);
+  const [isAddingSkill, setIsAddingSkill] = React.useState(false);
   const [isCurrent, setIsCurrent] = React.useState(false);
   const [description, setDescription] = React.useState('');
 
@@ -44,6 +47,8 @@ export function AddPositionSheet({ spaceId, company, isSaving, onCancel, onSave 
     onSave({
       company: pickedCompany,
       title,
+      employmentType,
+      skills,
       startDate: start ? toGraphDate(start) : null,
       // A role still held has no end date, whatever the picker was left showing.
       endDate: isCurrent || !end ? null : toGraphDate(end),
@@ -98,6 +103,25 @@ export function AddPositionSheet({ spaceId, company, isSaving, onCancel, onSave 
         )}
       </div>
 
+      <label className="flex flex-col gap-1.5">
+        <span className="text-metadataMedium text-grey-04">Employment type</span>
+        <select
+          value={employmentType?.id ?? ''}
+          disabled={isSaving}
+          onChange={event =>
+            setEmploymentType(EMPLOYMENT_TYPE_OPTIONS.find(option => option.id === event.currentTarget.value) ?? null)
+          }
+          className={inputStyles()}
+        >
+          <option value="">Please select</option>
+          {EMPLOYMENT_TYPE_OPTIONS.map(option => (
+            <option key={option.id} value={option.id}>
+              {option.name}
+            </option>
+          ))}
+        </select>
+      </label>
+
       <div className="flex flex-wrap items-end gap-4">
         <MonthYearField label="Start" value={start} onChange={setStart} disabled={isSaving} />
         <MonthYearField label="End" value={end} onChange={setEnd} disabled={isSaving || isCurrent} />
@@ -119,7 +143,7 @@ export function AddPositionSheet({ spaceId, company, isSaving, onCancel, onSave 
       </div>
 
       <label className="flex flex-col gap-1.5">
-        <span className="text-metadataMedium text-grey-04">Description</span>
+        <span className="text-metadataMedium text-grey-04">Highlights</span>
         <textarea
           value={description}
           onChange={event => setDescription(event.currentTarget.value)}
@@ -129,6 +153,52 @@ export function AddPositionSheet({ spaceId, company, isSaving, onCancel, onSave 
           className={`${inputStyles()} resize-none`}
         />
       </label>
+
+      <div className="flex flex-col gap-1.5">
+        <span className="text-metadataMedium text-grey-04">Skills</span>
+        {skills.length > 0 && (
+          <ul className="flex flex-wrap gap-1.5">
+            {skills.map(skill => (
+              <li key={skill.id} className="flex items-center gap-1.5 rounded bg-divider px-2 py-1">
+                <span className="text-footnote text-text">{skill.name ?? 'Untitled'}</span>
+                {skill.isNew && <span className="text-footnote text-ctaPrimary">NEW</span>}
+                <button
+                  type="button"
+                  onClick={() => setSkills(current => current.filter(item => item.id !== skill.id))}
+                  aria-label={`Remove skill ${skill.name ?? 'skill'}`}
+                  className="text-footnote text-grey-04 hover:underline"
+                >
+                  ×
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+
+        {isAddingSkill || skills.length === 0 ? (
+          <SelectEntity
+            spaceId={spaceId}
+            relationValueTypes={[{ id: SKILL_TYPE, name: 'Skill' }]}
+            onDone={(result, fromCreateFn) => {
+              setSkills(current =>
+                current.some(skill => skill.id === result.id)
+                  ? current
+                  : [...current, { id: result.id, name: result.name, isNew: Boolean(fromCreateFn) }]
+              );
+              setIsAddingSkill(false);
+            }}
+            width="full"
+          />
+        ) : (
+          <button
+            type="button"
+            onClick={() => setIsAddingSkill(true)}
+            className="self-start text-footnote text-ctaPrimary hover:underline"
+          >
+            + Add skill
+          </button>
+        )}
+      </div>
     </HistorySheet>
   );
 }

--- a/apps/web/partials/profile/add-position-sheet.tsx
+++ b/apps/web/partials/profile/add-position-sheet.tsx
@@ -147,7 +147,7 @@ export function AddPositionSheet({ spaceId, company, initial, isSaving, onCancel
           <SelectEntity
             spaceId={spaceId}
             relationValueTypes={[{ id: EMPLOYER_TYPE, name: 'Project' }]}
-            placeholder="Find or create a company..."
+            placeholder="Example: Microsoft"
             onCreateEntity={findOrCreate}
             onDone={(result, fromCreateFn) =>
               setPickedCompany({ id: result.id, name: result.name, isNew: Boolean(fromCreateFn) })
@@ -165,7 +165,7 @@ export function AddPositionSheet({ spaceId, company, initial, isSaving, onCancel
           <SelectEntity
             spaceId={spaceId}
             relationValueTypes={[{ id: JOB_TYPE, name: 'Person role' }]}
-            placeholder="Find or create a job title..."
+            placeholder="Example: Senior Product Manager"
             alsoSearchSpaceIds={TAXONOMY_SPACE_ID_LIST}
             onCreateEntity={findOrCreate}
             onDone={(result, fromCreateFn) =>
@@ -219,6 +219,7 @@ export function AddPositionSheet({ spaceId, company, initial, isSaving, onCancel
 
       <div className="flex flex-col gap-1.5">
         <span className="text-metadataMedium text-grey-04">Location</span>
+        <span className="text-footnote text-grey-04">Where the role was based, whether or not you went in.</span>
         {location ? (
           <PickedEntity name={location.name} onClear={() => setLocation(null)} />
         ) : (
@@ -227,7 +228,7 @@ export function AddPositionSheet({ spaceId, company, initial, isSaving, onCancel
           <SelectEntity
             spaceId={spaceId}
             relationValueTypes={LOCATION_TYPE_FILTER}
-            placeholder="Find or create a city..."
+            placeholder="City or region"
             onCreateEntity={findOrCreate}
             onDone={(result, fromCreateFn) =>
               setLocation({ id: result.id, name: result.name, isNew: Boolean(fromCreateFn) })
@@ -263,13 +264,14 @@ export function AddPositionSheet({ spaceId, company, initial, isSaving, onCancel
           onChange={event => setDescription(event.currentTarget.value)}
           disabled={isSaving}
           rows={3}
-          placeholder="Optional"
+          placeholder="Projects, problems you solved, or results you achieved"
           className={`${inputStyles()} resize-none`}
         />
       </label>
 
       <div className="flex flex-col gap-1.5">
         <span className="text-metadataMedium text-grey-04">Skills</span>
+        <span className="text-footnote text-grey-04">Add skills to show what you do best.</span>
         {skills.length > 0 && (
           <ul className="flex flex-wrap gap-1.5">
             {skills.map(skill => (
@@ -293,7 +295,7 @@ export function AddPositionSheet({ spaceId, company, initial, isSaving, onCancel
           <SelectEntity
             spaceId={spaceId}
             relationValueTypes={[{ id: SKILL_TYPE, name: 'Skill' }]}
-            placeholder="Find or create a skill..."
+            placeholder="Example: Product management"
             alsoSearchSpaceIds={TAXONOMY_SPACE_ID_LIST}
             pinnedResults={pinnedSkills}
             pinnedLabel="Recommended for this role"

--- a/apps/web/partials/profile/add-position-sheet.tsx
+++ b/apps/web/partials/profile/add-position-sheet.tsx
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 
-import { type MonthYear, toGraphDate } from '~/core/profile/history-dates';
+import { type MonthYear, fromGraphDate, toGraphDate } from '~/core/profile/history-dates';
 import { EMPLOYER_TYPE, EMPLOYMENT_TYPE_OPTIONS, JOB_TYPE, SKILL_TYPE } from '~/core/profile/history-ontology';
 import type { EntityChoice, PositionDraft } from '~/core/profile/stage-history';
 
@@ -10,13 +10,15 @@ import { Checkbox } from '~/design-system/checkbox';
 import { inputStyles } from '~/design-system/input';
 import { SelectEntity } from '~/design-system/select-entity';
 
-import { HistorySheet, PickedEntity } from './history-sheet';
+import { HistorySheet, PickedEntity, findOrCreate } from './history-sheet';
 import { MonthYearField } from './month-year-field';
 
 type Props = {
   spaceId: string;
   /** Pre-filled and locked when adding a second role at a company already listed. */
   company?: { id: string; name: string | null; stintId: string };
+  /** The row being changed, when this is an edit rather than an addition. */
+  initial?: PositionDraft;
   isSaving: boolean;
   onCancel: () => void;
   onSave: (draft: PositionDraft) => void;
@@ -25,19 +27,27 @@ type Props = {
 /**
  * Four questions, which become three relations, two entities and two or three
  * values. None of that appears here — that is the entire point.
+ *
+ * The same sheet edits a row as adds one: everything shown on a card was typed
+ * in here, so there is nothing a separate edit form could offer that this one
+ * does not already ask.
  */
-export function AddPositionSheet({ spaceId, company, isSaving, onCancel, onSave }: Props) {
-  const locked = company ? { id: company.id, name: company.name, isNew: false } : null;
+export function AddPositionSheet({ spaceId, company, initial, isSaving, onCancel, onSave }: Props) {
+  const locked = !initial && company ? { id: company.id, name: company.name, isNew: false } : null;
 
-  const [pickedCompany, setPickedCompany] = React.useState<EntityChoice | null>(locked);
-  const [title, setTitle] = React.useState<EntityChoice | null>(null);
-  const [start, setStart] = React.useState<MonthYear | null>(null);
-  const [end, setEnd] = React.useState<MonthYear | null>(null);
-  const [employmentType, setEmploymentType] = React.useState<{ id: string; name: string } | null>(null);
-  const [skills, setSkills] = React.useState<EntityChoice[]>([]);
+  const [pickedCompany, setPickedCompany] = React.useState<EntityChoice | null>(
+    initial ? initial.company : (locked ?? null)
+  );
+  const [title, setTitle] = React.useState<EntityChoice | null>(initial?.title ?? null);
+  const [start, setStart] = React.useState<MonthYear | null>(fromGraphDate(initial?.startDate));
+  const [end, setEnd] = React.useState<MonthYear | null>(fromGraphDate(initial?.endDate));
+  const [employmentType, setEmploymentType] = React.useState<{ id: string; name: string } | null>(
+    initial?.employmentType ?? null
+  );
+  const [skills, setSkills] = React.useState<EntityChoice[]>(initial?.skills ?? []);
   const [isAddingSkill, setIsAddingSkill] = React.useState(false);
-  const [isCurrent, setIsCurrent] = React.useState(false);
-  const [description, setDescription] = React.useState('');
+  const [isCurrent, setIsCurrent] = React.useState(initial ? initial.status === 'current' : false);
+  const [description, setDescription] = React.useState(initial?.description ?? '');
 
   const canSave = pickedCompany !== null && title !== null && !isSaving;
 
@@ -60,7 +70,7 @@ export function AddPositionSheet({ spaceId, company, isSaving, onCancel, onSave 
 
   return (
     <HistorySheet
-      title="Add position"
+      title={initial ? 'Edit position' : 'Add position'}
       isSaving={isSaving}
       canSave={canSave}
       saveLabel="Save position"
@@ -79,6 +89,8 @@ export function AddPositionSheet({ spaceId, company, isSaving, onCancel, onSave 
           <SelectEntity
             spaceId={spaceId}
             relationValueTypes={[{ id: EMPLOYER_TYPE, name: 'Project' }]}
+            placeholder="Find or create a company..."
+            onCreateEntity={findOrCreate}
             onDone={(result, fromCreateFn) =>
               setPickedCompany({ id: result.id, name: result.name, isNew: Boolean(fromCreateFn) })
             }
@@ -95,6 +107,8 @@ export function AddPositionSheet({ spaceId, company, isSaving, onCancel, onSave 
           <SelectEntity
             spaceId={spaceId}
             relationValueTypes={[{ id: JOB_TYPE, name: 'Job' }]}
+            placeholder="Find or create a job title..."
+            onCreateEntity={findOrCreate}
             onDone={(result, fromCreateFn) =>
               setTitle({ id: result.id, name: result.name, isNew: Boolean(fromCreateFn) })
             }
@@ -122,11 +136,8 @@ export function AddPositionSheet({ spaceId, company, isSaving, onCancel, onSave 
         </select>
       </label>
 
-      <div className="flex flex-wrap items-end gap-4">
-        <MonthYearField label="Start" value={start} onChange={setStart} disabled={isSaving} />
-        <MonthYearField label="End" value={end} onChange={setEnd} disabled={isSaving || isCurrent} />
-      </div>
-
+      {/* Above the dates, because it decides what the End picker is for: ticking
+          it puts the role in the present and leaves End with nothing to say. */}
       <div className="flex items-center gap-2">
         {/* The shared Checkbox renders a bare button with no checkbox semantics.
             Supplied here rather than fixed there: several callers assert on it
@@ -140,6 +151,11 @@ export function AddPositionSheet({ spaceId, company, isSaving, onCancel, onSave 
           aria-label="I’m in this role now"
         />
         <span className="text-footnote text-text">I’m in this role now</span>
+      </div>
+
+      <div className="flex flex-wrap items-end gap-4">
+        <MonthYearField label="Start" value={start} onChange={setStart} disabled={isSaving} />
+        <MonthYearField label="End" value={end} onChange={setEnd} disabled={isSaving || isCurrent} />
       </div>
 
       <label className="flex flex-col gap-1.5">
@@ -179,6 +195,8 @@ export function AddPositionSheet({ spaceId, company, isSaving, onCancel, onSave 
           <SelectEntity
             spaceId={spaceId}
             relationValueTypes={[{ id: SKILL_TYPE, name: 'Skill' }]}
+            placeholder="Find or create a skill..."
+            onCreateEntity={findOrCreate}
             onDone={(result, fromCreateFn) => {
               setSkills(current =>
                 current.some(skill => skill.id === result.id)

--- a/apps/web/partials/profile/add-position-sheet.tsx
+++ b/apps/web/partials/profile/add-position-sheet.tsx
@@ -8,6 +8,8 @@ import {
   EMPLOYER_TYPE,
   EMPLOYMENT_TYPE_OPTIONS,
   JOB_TYPE,
+  LOCATION_TYPES,
+  LOCATION_TYPE_OPTIONS,
   SKILL_TYPE,
   TAXONOMY_SPACE_ID,
 } from '~/core/profile/history-ontology';
@@ -26,6 +28,9 @@ import { MonthYearField } from './month-year-field';
  * ask for it by name — see `TAXONOMY_SPACE_ID`.
  */
 const TAXONOMY_SPACE_ID_LIST = [TAXONOMY_SPACE_ID];
+
+/** Cities, regions and countries — see `LOCATION_TYPES` for why not addresses. */
+const LOCATION_TYPE_FILTER = LOCATION_TYPES.map(id => ({ id, name: null }));
 
 type Props = {
   spaceId: string;
@@ -59,6 +64,10 @@ export function AddPositionSheet({ spaceId, company, initial, isSaving, onCancel
     initial?.employmentType ?? null
   );
   const [skills, setSkills] = React.useState<EntityChoice[]>(initial?.skills ?? []);
+  const [location, setLocation] = React.useState<EntityChoice | null>(initial?.location ?? null);
+  const [locationType, setLocationType] = React.useState<{ id: string; name: string } | null>(
+    initial?.locationType ?? null
+  );
   const [isAddingSkill, setIsAddingSkill] = React.useState(false);
   const [isCurrent, setIsCurrent] = React.useState(initial ? initial.status === 'current' : false);
   const [description, setDescription] = React.useState(initial?.description ?? '');
@@ -106,6 +115,8 @@ export function AddPositionSheet({ spaceId, company, initial, isSaving, onCancel
       title,
       employmentType,
       skills,
+      location,
+      locationType,
       startDate: start ? toGraphDate(start) : null,
       // A role still held has no end date, whatever the picker was left showing.
       endDate: isCurrent || !end ? null : toGraphDate(end),
@@ -205,6 +216,45 @@ export function AddPositionSheet({ spaceId, company, initial, isSaving, onCancel
         <MonthYearField label="Start" value={start} onChange={setStart} disabled={isSaving} />
         <MonthYearField label="End" value={end} onChange={setEnd} disabled={isSaving || isCurrent} />
       </div>
+
+      <div className="flex flex-col gap-1.5">
+        <span className="text-metadataMedium text-grey-04">Location</span>
+        {location ? (
+          <PickedEntity name={location.name} onClear={() => setLocation(null)} />
+        ) : (
+          // A place in the graph rather than a string, so the San Francisco on
+          // this profile is the one everybody else means.
+          <SelectEntity
+            spaceId={spaceId}
+            relationValueTypes={LOCATION_TYPE_FILTER}
+            placeholder="Find or create a city..."
+            onCreateEntity={findOrCreate}
+            onDone={(result, fromCreateFn) =>
+              setLocation({ id: result.id, name: result.name, isNew: Boolean(fromCreateFn) })
+            }
+            width="full"
+          />
+        )}
+      </div>
+
+      <label className="flex flex-col gap-1.5">
+        <span className="text-metadataMedium text-grey-04">Location type</span>
+        <select
+          value={locationType?.id ?? ''}
+          disabled={isSaving}
+          onChange={event =>
+            setLocationType(LOCATION_TYPE_OPTIONS.find(option => option.id === event.currentTarget.value) ?? null)
+          }
+          className={inputStyles()}
+        >
+          <option value="">Please select</option>
+          {LOCATION_TYPE_OPTIONS.map(option => (
+            <option key={option.id} value={option.id}>
+              {option.name}
+            </option>
+          ))}
+        </select>
+      </label>
 
       <label className="flex flex-col gap-1.5">
         <span className="text-metadataMedium text-grey-04">Highlights</span>

--- a/apps/web/partials/profile/add-position-sheet.tsx
+++ b/apps/web/partials/profile/add-position-sheet.tsx
@@ -2,6 +2,7 @@
 
 import * as React from 'react';
 
+import { useSuggestedSkills } from '~/core/hooks/use-suggested-skills';
 import { type MonthYear, fromGraphDate, toGraphDate } from '~/core/profile/history-dates';
 import { EMPLOYER_TYPE, EMPLOYMENT_TYPE_OPTIONS, JOB_TYPE, SKILL_TYPE } from '~/core/profile/history-ontology';
 import type { EntityChoice, PositionDraft } from '~/core/profile/stage-history';
@@ -48,6 +49,16 @@ export function AddPositionSheet({ spaceId, company, initial, isSaving, onCancel
   const [isAddingSkill, setIsAddingSkill] = React.useState(false);
   const [isCurrent, setIsCurrent] = React.useState(initial ? initial.status === 'current' : false);
   const [description, setDescription] = React.useState(initial?.description ?? '');
+
+  // Only ESCO occupations carry these; a title somebody typed in themselves has
+  // none, and the row simply does not appear.
+  const { suggestions } = useSuggestedSkills({
+    roleId: title?.id,
+    picked: React.useMemo(() => skills.map(skill => skill.id), [skills]),
+  });
+
+  const addSkill = (skill: EntityChoice) =>
+    setSkills(current => (current.some(picked => picked.id === skill.id) ? current : [...current, skill]));
 
   const canSave = pickedCompany !== null && title !== null && !isSaving;
 
@@ -106,7 +117,7 @@ export function AddPositionSheet({ spaceId, company, initial, isSaving, onCancel
         ) : (
           <SelectEntity
             spaceId={spaceId}
-            relationValueTypes={[{ id: JOB_TYPE, name: 'Job' }]}
+            relationValueTypes={[{ id: JOB_TYPE, name: 'Person role' }]}
             placeholder="Find or create a job title..."
             onCreateEntity={findOrCreate}
             onDone={(result, fromCreateFn) =>
@@ -198,11 +209,7 @@ export function AddPositionSheet({ spaceId, company, initial, isSaving, onCancel
             placeholder="Find or create a skill..."
             onCreateEntity={findOrCreate}
             onDone={(result, fromCreateFn) => {
-              setSkills(current =>
-                current.some(skill => skill.id === result.id)
-                  ? current
-                  : [...current, { id: result.id, name: result.name, isNew: Boolean(fromCreateFn) }]
-              );
+              addSkill({ id: result.id, name: result.name, isNew: Boolean(fromCreateFn) });
               setIsAddingSkill(false);
             }}
             width="full"
@@ -215,6 +222,29 @@ export function AddPositionSheet({ spaceId, company, initial, isSaving, onCancel
           >
             + Add skill
           </button>
+        )}
+
+        {/* What the occupation itself says the job needs, essential first and
+            most distinctive within that. Offered rather than applied: they are a
+            shortcut past typing, not a claim about what this person did. */}
+        {suggestions.length > 0 && (
+          <div className="flex flex-col gap-1.5">
+            <span className="text-footnote text-grey-04">Common for this role</span>
+            <ul className="flex flex-wrap gap-1.5">
+              {suggestions.map(suggestion => (
+                <li key={suggestion.id}>
+                  <button
+                    type="button"
+                    onClick={() => addSkill({ id: suggestion.id, name: suggestion.name, isNew: false })}
+                    disabled={isSaving}
+                    className="rounded border border-grey-02 px-2 py-1 text-footnote text-text transition-colors hover:border-text disabled:text-grey-03"
+                  >
+                    + {suggestion.name ?? 'Untitled'}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </div>
         )}
       </div>
     </HistorySheet>

--- a/apps/web/partials/profile/add-position-sheet.tsx
+++ b/apps/web/partials/profile/add-position-sheet.tsx
@@ -3,7 +3,7 @@
 import * as React from 'react';
 
 import { type MonthYear, toGraphDate } from '~/core/profile/history-dates';
-import { COMPANY_TYPE, JOB_TYPE } from '~/core/profile/history-ontology';
+import { EMPLOYER_TYPE, JOB_TYPE } from '~/core/profile/history-ontology';
 import type { EntityChoice, PositionDraft } from '~/core/profile/stage-history';
 
 import { Checkbox } from '~/design-system/checkbox';
@@ -73,7 +73,7 @@ export function AddPositionSheet({ spaceId, company, isSaving, onCancel, onSave 
         ) : (
           <SelectEntity
             spaceId={spaceId}
-            relationValueTypes={[{ id: COMPANY_TYPE, name: 'Company' }]}
+            relationValueTypes={[{ id: EMPLOYER_TYPE, name: 'Project' }]}
             onDone={(result, fromCreateFn) =>
               setPickedCompany({ id: result.id, name: result.name, isNew: Boolean(fromCreateFn) })
             }

--- a/apps/web/partials/profile/edit-profile-dialog.test.tsx
+++ b/apps/web/partials/profile/edit-profile-dialog.test.tsx
@@ -23,21 +23,24 @@ const mocks = vi.hoisted(() => ({
     bannerUrl: undefined as string | undefined,
     avatarUrl: undefined as string | undefined,
   },
+  hasPendingHistory: false,
+  stagedHistory: { values: [], relations: [] } as { values: unknown[]; relations: unknown[] },
 }));
 
-// The sections have their own hook and their own publishes; these tests are about
-// the four header fields, so it is stubbed to empty rather than exercised here.
+// The sections keep their own pending state and their own tests; these are about
+// the four header fields and what the sections owe them at Save, so it is stubbed
+// to empty except where a test says otherwise.
 vi.mock('~/core/hooks/use-profile-history', () => ({
   useProfileHistory: () => ({
     employment: [],
     education: [],
     isLoading: false,
-    hasPendingChanges: false,
+    hasPendingChanges: mocks.hasPendingHistory,
     addPosition: vi.fn(),
     addEducation: vi.fn(),
     removeEntry: vi.fn(),
-    removeCard: vi.fn(),
-    stagePending: () => ({ values: [], relations: [] }),
+    editEntry: vi.fn(),
+    stagePending: () => mocks.stagedHistory,
     settle: vi.fn(),
     discard: vi.fn(),
   }),
@@ -76,6 +79,8 @@ beforeEach(() => {
   mocks.isLoading = false;
   mocks.status = 'idle';
   mocks.errorMessage = null;
+  mocks.hasPendingHistory = false;
+  mocks.stagedHistory = { values: [], relations: [] };
   mocks.current = {
     name: 'Preston Mantel',
     description: 'Working on debates.',
@@ -135,6 +140,30 @@ describe('EditProfileDialog', () => {
 
     expect(descriptionField()).toHaveValue(long);
     expect(saveButton()).toBeEnabled();
+  });
+
+  // Work and education write nothing of their own, so a position added with the
+  // four fields left alone is the whole of the edit — and Save has to offer it.
+  describe('work and education', () => {
+    it('offers to save an edit that is only a position', async () => {
+      mocks.hasPendingHistory = true;
+      renderDialog();
+
+      expect(saveButton()).toBeEnabled();
+    });
+
+    it('publishes those rows in the same edit as the header fields', async () => {
+      mocks.hasPendingHistory = true;
+      mocks.stagedHistory = { values: [{ id: 'value-1' }], relations: [{ id: 'relation-1' }] };
+      renderDialog();
+
+      await userEvent.click(saveButton());
+
+      expect(mocks.publish).toHaveBeenCalledWith(expect.anything(), {
+        values: [{ id: 'value-1' }],
+        relations: [{ id: 'relation-1' }],
+      });
+    });
   });
 
   it('publishes the trimmed draft', async () => {

--- a/apps/web/partials/profile/edit-profile-dialog.test.tsx
+++ b/apps/web/partials/profile/edit-profile-dialog.test.tsx
@@ -25,13 +25,30 @@ const mocks = vi.hoisted(() => ({
   },
 }));
 
+// The sections have their own hook and their own publishes; these tests are about
+// the four header fields, so it is stubbed to empty rather than exercised here.
+vi.mock('~/core/hooks/use-profile-history', () => ({
+  useProfileHistory: () => ({
+    employment: [],
+    education: [],
+    isLoading: false,
+    status: 'idle',
+    errorMessage: null,
+    addPosition: vi.fn(),
+    addEducation: vi.fn(),
+    removeEntry: vi.fn(),
+    removeCard: vi.fn(),
+    dismissError: vi.fn(),
+  }),
+}));
+
 vi.mock('~/core/hooks/use-edit-profile', () => ({
   useEditProfile: () => ({
     canEdit: mocks.canEdit,
     isHydrated: mocks.isHydrated,
     isLoading: mocks.isLoading,
     entityId: mocks.entityId,
-    spaceId: 'space',
+    spaceId: 'space-1',
     current: mocks.current,
     status: mocks.status,
     errorMessage: mocks.errorMessage,

--- a/apps/web/partials/profile/edit-profile-dialog.test.tsx
+++ b/apps/web/partials/profile/edit-profile-dialog.test.tsx
@@ -32,13 +32,14 @@ vi.mock('~/core/hooks/use-profile-history', () => ({
     employment: [],
     education: [],
     isLoading: false,
-    status: 'idle',
-    errorMessage: null,
+    hasPendingChanges: false,
     addPosition: vi.fn(),
     addEducation: vi.fn(),
     removeEntry: vi.fn(),
     removeCard: vi.fn(),
-    dismissError: vi.fn(),
+    stagePending: () => ({ values: [], relations: [] }),
+    settle: vi.fn(),
+    discard: vi.fn(),
   }),
 }));
 
@@ -143,12 +144,17 @@ describe('EditProfileDialog', () => {
     await userEvent.paste('  Preston  ');
     await userEvent.click(saveButton());
 
-    expect(mocks.publish).toHaveBeenCalledWith({
-      name: 'Preston',
-      description: 'Working on debates.',
-      banner: { kind: 'unchanged' },
-      avatar: { kind: 'unchanged' },
-    });
+    // Second argument is the work and education rows, which go out in the same
+    // edit as the header fields.
+    expect(mocks.publish).toHaveBeenCalledWith(
+      {
+        name: 'Preston',
+        description: 'Working on debates.',
+        banner: { kind: 'unchanged' },
+        avatar: { kind: 'unchanged' },
+      },
+      { values: [], relations: [] }
+    );
   });
 
   // The status bar carries the upload, the publish and the result, and a failure
@@ -376,7 +382,7 @@ describe('EditProfileDialog', () => {
     await userEvent.click(saveButton());
 
     // The name goes out exactly as stored, not silently re-trimmed.
-    expect(mocks.publish).toHaveBeenCalledWith(expect.objectContaining({ name: 'Preston Mantel ' }));
+    expect(mocks.publish).toHaveBeenCalledWith(expect.objectContaining({ name: 'Preston Mantel ' }), expect.anything());
   });
 
   it('holds save until hydration actually produced an entity', () => {

--- a/apps/web/partials/profile/edit-profile-dialog.tsx
+++ b/apps/web/partials/profile/edit-profile-dialog.tsx
@@ -7,12 +7,17 @@ import * as React from 'react';
 import cx from 'classnames';
 
 import { type ProfileImageEdit, useEditProfile } from '~/core/hooks/use-edit-profile';
+import { useProfileHistory } from '~/core/hooks/use-profile-history';
+import type { HistoryCard, HistoryEntry } from '~/core/profile/normalize-history';
 
 import { Button, SquareButton } from '~/design-system/button';
 import { Close } from '~/design-system/icons/close';
 import { Warning } from '~/design-system/icons/warning';
 import { Input, inputStyles } from '~/design-system/input';
 
+import { AddEducationSheet } from './add-education-sheet';
+import { AddPositionSheet } from './add-position-sheet';
+import { HistorySection } from './history-section';
 import { ProfileImageField } from './profile-image-field';
 
 const UNCHANGED: ProfileImageEdit = { kind: 'unchanged' };
@@ -44,9 +49,26 @@ type Props = {
  * locks rather than offering to start a second one.
  */
 export function EditProfileDialog({ open, onOpenChange }: Props) {
-  const { canEdit, entityId, isHydrated, isLoading, current, status, errorMessage, publish, reset } = useEditProfile({
-    isOpen: open,
-  });
+  const { canEdit, entityId, isHydrated, isLoading, spaceId, current, status, errorMessage, publish, reset } =
+    useEditProfile({ isOpen: open });
+
+  const history = useProfileHistory({ entityId, spaceId, enabled: open && entityId !== '' });
+
+  /**
+   * Which sheet is open, if any. A sheet replaces the modal's body rather than
+   * stacking over it — the four fields underneath have nothing to do with the
+   * position being added, and two scroll areas fighting is worse than one.
+   */
+  const [sheet, setSheet] = React.useState<
+    | { kind: 'position'; company?: { id: string; name: string | null; stintId: string } }
+    | { kind: 'education'; school?: { id: string; name: string | null; stintId: string } }
+    | null
+  >(null);
+
+  const openSheetFor = (kind: 'employment' | 'education', card?: HistoryCard<HistoryEntry>) => {
+    const org = card ? { id: card.organization.id, name: card.organization.name, stintId: card.stintId } : undefined;
+    setSheet(kind === 'employment' ? { kind: 'position', company: org } : { kind: 'education', school: org });
+  };
 
   const [name, setName] = React.useState('');
   const [description, setDescription] = React.useState('');
@@ -240,110 +262,156 @@ export function EditProfileDialog({ open, onOpenChange }: Props) {
             onSubmit={onSubmit}
             className="my-10 flex w-full max-w-[560px] flex-col rounded-lg border border-grey-02 bg-white shadow-dropdown"
           >
-            <header className="flex items-center justify-between px-5 py-4">
-              <Title className="text-smallTitle text-text">Edit profile</Title>
-              <SquareButton type="button" onClick={close} icon={<Close />} aria-label="Close" />
-            </header>
-
-            <Description className="sr-only">
-              Update your banner, photo, name and description. Saving publishes to your personal space.
-            </Description>
-
-            {hasFailed && errorMessage && (
-              <div role="alert" className="mx-5 mb-4 flex items-start gap-2 rounded-lg bg-red-02 p-3">
-                <div className="text-red-01">
-                  <Warning />
-                </div>
-                <p className="text-metadata text-text">{errorMessage}</p>
-              </div>
-            )}
-
-            {rejection && (
-              <div role="alert" className="mx-5 mb-4 rounded-lg bg-red-02 p-3">
-                <p className="text-metadata text-text">{rejection}</p>
-              </div>
-            )}
-
-            <div className="px-5">
-              <ProfileImageField
-                kind="banner"
-                src={imageSrc(banner, current.bannerUrl)}
-                disabled={isPublishing}
-                onPick={onPick('banner')}
-                onRemove={onRemove('banner')}
-                onReject={setRejection}
-              />
-
-              {/* Hangs off the banner's bottom edge, matching how a profile already
-                  reads on a space page. */}
-              <div className="-mt-11 pl-4">
-                <ProfileImageField
-                  kind="avatar"
-                  src={imageSrc(avatar, current.avatarUrl)}
-                  disabled={isPublishing}
-                  onPick={onPick('avatar')}
-                  onRemove={onRemove('avatar')}
-                  onReject={setRejection}
-                />
-              </div>
-            </div>
-
-            <div className="flex flex-col gap-4 px-5 pt-5">
-              <label className="flex flex-col gap-1.5">
-                <span className="text-metadataMedium text-grey-04">Name</span>
-                <Input
-                  value={name}
-                  onChange={event => {
-                    pristineRef.current.name = false;
-                    setName(event.currentTarget.value);
+            {sheet ? (
+              sheet.kind === 'position' ? (
+                <AddPositionSheet
+                  spaceId={spaceId}
+                  company={sheet.company}
+                  isSaving={history.status === 'saving'}
+                  onCancel={() => setSheet(null)}
+                  onSave={async draft => {
+                    await history.addPosition(draft);
+                    setSheet(null);
                   }}
-                  disabled={isPublishing}
-                  placeholder="Your name"
-                  required
-                  aria-required="true"
-                  aria-invalid={isNameMissing}
-                  aria-describedby={isNameMissing ? 'edit-profile-name-error' : undefined}
                 />
-                {/* Name is the only thing that blocks Save. Without this the button
+              ) : (
+                <AddEducationSheet
+                  spaceId={spaceId}
+                  school={sheet.school}
+                  isSaving={history.status === 'saving'}
+                  onCancel={() => setSheet(null)}
+                  onSave={async draft => {
+                    await history.addEducation(draft);
+                    setSheet(null);
+                  }}
+                />
+              )
+            ) : (
+              <>
+                <header className="flex items-center justify-between px-5 py-4">
+                  <Title className="text-smallTitle text-text">Edit profile</Title>
+                  <SquareButton type="button" onClick={close} icon={<Close />} aria-label="Close" />
+                </header>
+
+                <Description className="sr-only">
+                  Update your banner, photo, name and description. Saving publishes to your personal space.
+                </Description>
+
+                {hasFailed && errorMessage && (
+                  <div role="alert" className="mx-5 mb-4 flex items-start gap-2 rounded-lg bg-red-02 p-3">
+                    <div className="text-red-01">
+                      <Warning />
+                    </div>
+                    <p className="text-metadata text-text">{errorMessage}</p>
+                  </div>
+                )}
+
+                {rejection && (
+                  <div role="alert" className="mx-5 mb-4 rounded-lg bg-red-02 p-3">
+                    <p className="text-metadata text-text">{rejection}</p>
+                  </div>
+                )}
+
+                <div className="px-5">
+                  <ProfileImageField
+                    kind="banner"
+                    src={imageSrc(banner, current.bannerUrl)}
+                    disabled={isPublishing}
+                    onPick={onPick('banner')}
+                    onRemove={onRemove('banner')}
+                    onReject={setRejection}
+                  />
+
+                  {/* Hangs off the banner's bottom edge, matching how a profile already
+                  reads on a space page. */}
+                  <div className="-mt-11 pl-4">
+                    <ProfileImageField
+                      kind="avatar"
+                      src={imageSrc(avatar, current.avatarUrl)}
+                      disabled={isPublishing}
+                      onPick={onPick('avatar')}
+                      onRemove={onRemove('avatar')}
+                      onReject={setRejection}
+                    />
+                  </div>
+                </div>
+
+                <div className="flex flex-col gap-4 px-5 pt-5">
+                  <label className="flex flex-col gap-1.5">
+                    <span className="text-metadataMedium text-grey-04">Name</span>
+                    <Input
+                      value={name}
+                      onChange={event => {
+                        pristineRef.current.name = false;
+                        setName(event.currentTarget.value);
+                      }}
+                      disabled={isPublishing}
+                      placeholder="Your name"
+                      required
+                      aria-required="true"
+                      aria-invalid={isNameMissing}
+                      aria-describedby={isNameMissing ? 'edit-profile-name-error' : undefined}
+                    />
+                    {/* Name is the only thing that blocks Save. Without this the button
                     just sits disabled, which says nothing to anyone and nothing at
                     all to a screen reader. */}
-                {isNameMissing && (
-                  <span id="edit-profile-name-error" role="alert" className="text-footnote text-red-01">
-                    Name is required.
-                  </span>
-                )}
-              </label>
+                    {isNameMissing && (
+                      <span id="edit-profile-name-error" role="alert" className="text-footnote text-red-01">
+                        Name is required.
+                      </span>
+                    )}
+                  </label>
 
-              <label className="flex flex-col gap-1.5">
-                <span className="text-metadataMedium text-grey-04">Description</span>
-                <textarea
-                  value={description}
-                  onChange={event => {
-                    pristineRef.current.description = false;
-                    setDescription(event.currentTarget.value);
-                  }}
-                  disabled={isPublishing}
-                  rows={3}
-                  placeholder="A sentence about who you are and what you work on."
-                  className={cx(inputStyles(), 'resize-none')}
-                />
-                <span className="text-footnote text-grey-04">Shown under your name across Geo.</span>
-              </label>
-            </div>
+                  <label className="flex flex-col gap-1.5">
+                    <span className="text-metadataMedium text-grey-04">Description</span>
+                    <textarea
+                      value={description}
+                      onChange={event => {
+                        pristineRef.current.description = false;
+                        setDescription(event.currentTarget.value);
+                      }}
+                      disabled={isPublishing}
+                      rows={3}
+                      placeholder="A sentence about who you are and what you work on."
+                      className={cx(inputStyles(), 'resize-none')}
+                    />
+                    <span className="text-footnote text-grey-04">Shown under your name across Geo.</span>
+                  </label>
 
-            <footer className="mt-5 flex items-center justify-between gap-3 border-t border-grey-02 px-5 py-4">
-              {/* One line, carrying whatever the modal currently owes the reader:
+                  <HistorySection
+                    kind="employment"
+                    cards={history.employment}
+                    disabled={isPublishing || history.status === 'saving'}
+                    onAdd={() => openSheetFor('employment')}
+                    onAddTo={card => openSheetFor('employment', card)}
+                    onRemoveEntry={(card, entry) => void history.removeEntry(card, entry, 'employment')}
+                  />
+
+                  <HistorySection
+                    kind="education"
+                    cards={history.education}
+                    disabled={isPublishing || history.status === 'saving'}
+                    onAdd={() => openSheetFor('education')}
+                    onAddTo={card => openSheetFor('education', card)}
+                    onRemoveEntry={(card, entry) => void history.removeEntry(card, entry, 'education')}
+                  />
+                </div>
+
+                <footer className="mt-5 flex items-center justify-between gap-3 border-t border-grey-02 px-5 py-4">
+                  {/* One line, carrying whatever the modal currently owes the reader:
                   why Save is dead, how long the wait is, or what a failure cost. */}
-              <p className={cx('text-footnote', isUnavailable ? 'text-red-01' : 'text-grey-04')}>{footerNote}</p>
-              <div className="flex items-center gap-2">
-                <Button type="button" variant="secondary" onClick={close}>
-                  {isPublishing ? 'Close' : 'Cancel'}
-                </Button>
-                <Button type="submit" disabled={!canSave}>
-                  {isPublishing ? 'Publishing' : hasFailed ? 'Retry' : 'Save profile'}
-                </Button>
-              </div>
-            </footer>
+                  <p className={cx('text-footnote', isUnavailable ? 'text-red-01' : 'text-grey-04')}>{footerNote}</p>
+                  <div className="flex items-center gap-2">
+                    <Button type="button" variant="secondary" onClick={close}>
+                      {isPublishing ? 'Close' : 'Cancel'}
+                    </Button>
+                    <Button type="submit" disabled={!canSave}>
+                      {isPublishing ? 'Publishing' : hasFailed ? 'Retry' : 'Save profile'}
+                    </Button>
+                  </div>
+                </footer>
+              </>
+            )}
           </form>
         </Content>
       </Portal>

--- a/apps/web/partials/profile/edit-profile-dialog.tsx
+++ b/apps/web/partials/profile/edit-profile-dialog.tsx
@@ -385,6 +385,7 @@ export function EditProfileDialog({ open, onOpenChange }: Props) {
                     onAdd={() => openSheetFor('employment')}
                     onAddTo={card => openSheetFor('employment', card)}
                     onRemoveEntry={(card, entry) => void history.removeEntry(card, entry, 'employment')}
+                    onRemoveCard={card => void history.removeCard(card, 'employment')}
                   />
 
                   <HistorySection
@@ -394,6 +395,7 @@ export function EditProfileDialog({ open, onOpenChange }: Props) {
                     onAdd={() => openSheetFor('education')}
                     onAddTo={card => openSheetFor('education', card)}
                     onRemoveEntry={(card, entry) => void history.removeEntry(card, entry, 'education')}
+                    onRemoveCard={card => void history.removeCard(card, 'education')}
                   />
                 </div>
 

--- a/apps/web/partials/profile/edit-profile-dialog.tsx
+++ b/apps/web/partials/profile/edit-profile-dialog.tsx
@@ -133,8 +133,9 @@ export function EditProfileDialog({ open, onOpenChange }: Props) {
     if (status !== 'published') return;
     resetForm();
     reset();
+    history.settle();
     if (open) onOpenChange(false);
-  }, [status, open, onOpenChange, resetForm, reset]);
+  }, [status, open, onOpenChange, resetForm, reset, history]);
 
   // A failure that lands after the user closed has nowhere else to go. The status
   // bar's generic publish error carries no Retry — `toUserFacingError` only
@@ -207,6 +208,7 @@ export function EditProfileDialog({ open, onOpenChange }: Props) {
     if (!isPublishing) {
       reset();
       resetForm();
+      history.discard();
     }
     onOpenChange(false);
   };
@@ -231,7 +233,10 @@ export function EditProfileDialog({ open, onOpenChange }: Props) {
     //
     // No `resetForm()` here: the draft has to survive in case the publish fails
     // and the modal is reopened on it.
-    void publish({ name: publishName, description: publishDescription, banner: banner.edit, avatar: avatar.edit });
+    void publish(
+      { name: publishName, description: publishDescription, banner: banner.edit, avatar: avatar.edit },
+      history.stagePending()
+    );
     onOpenChange(false);
   };
 
@@ -267,7 +272,7 @@ export function EditProfileDialog({ open, onOpenChange }: Props) {
                 <AddPositionSheet
                   spaceId={spaceId}
                   company={sheet.company}
-                  isSaving={history.status === 'saving'}
+                  isSaving={false}
                   onCancel={() => setSheet(null)}
                   onSave={async draft => {
                     await history.addPosition(draft);
@@ -278,7 +283,7 @@ export function EditProfileDialog({ open, onOpenChange }: Props) {
                 <AddEducationSheet
                   spaceId={spaceId}
                   school={sheet.school}
-                  isSaving={history.status === 'saving'}
+                  isSaving={false}
                   onCancel={() => setSheet(null)}
                   onSave={async draft => {
                     await history.addEducation(draft);
@@ -381,7 +386,7 @@ export function EditProfileDialog({ open, onOpenChange }: Props) {
                   <HistorySection
                     kind="employment"
                     cards={history.employment}
-                    disabled={isPublishing || history.status === 'saving'}
+                    disabled={isPublishing}
                     onAdd={() => openSheetFor('employment')}
                     onAddTo={card => openSheetFor('employment', card)}
                     onRemoveEntry={(card, entry) => void history.removeEntry(card, entry, 'employment')}
@@ -391,7 +396,7 @@ export function EditProfileDialog({ open, onOpenChange }: Props) {
                   <HistorySection
                     kind="education"
                     cards={history.education}
-                    disabled={isPublishing || history.status === 'saving'}
+                    disabled={isPublishing}
                     onAdd={() => openSheetFor('education')}
                     onAddTo={card => openSheetFor('education', card)}
                     onRemoveEntry={(card, entry) => void history.removeEntry(card, entry, 'education')}

--- a/apps/web/partials/profile/edit-profile-dialog.tsx
+++ b/apps/web/partials/profile/edit-profile-dialog.tsx
@@ -8,7 +8,8 @@ import cx from 'classnames';
 
 import { type ProfileImageEdit, useEditProfile } from '~/core/hooks/use-edit-profile';
 import { useProfileHistory } from '~/core/hooks/use-profile-history';
-import type { HistoryCard, HistoryEntry } from '~/core/profile/normalize-history';
+import type { EducationEntry, EmploymentEntry, HistoryCard, HistoryEntry } from '~/core/profile/normalize-history';
+import { educationDraftFromEntry, positionDraftFromEntry } from '~/core/profile/stage-history';
 
 import { Button, SquareButton } from '~/design-system/button';
 import { Close } from '~/design-system/icons/close';
@@ -58,16 +59,31 @@ export function EditProfileDialog({ open, onOpenChange }: Props) {
    * Which sheet is open, if any. A sheet replaces the modal's body rather than
    * stacking over it — the four fields underneath have nothing to do with the
    * position being added, and two scroll areas fighting is worse than one.
+   *
+   * `editing` is the row the sheet was opened on, where it was opened on one.
+   * Saving then replaces that row rather than adding beside it.
    */
+  type Organization = { id: string; name: string | null; stintId: string };
+  type Editing = { card: HistoryCard<HistoryEntry>; entry: HistoryEntry };
+
   const [sheet, setSheet] = React.useState<
-    | { kind: 'position'; company?: { id: string; name: string | null; stintId: string } }
-    | { kind: 'education'; school?: { id: string; name: string | null; stintId: string } }
+    | { kind: 'position'; company?: Organization; editing?: Editing }
+    | { kind: 'education'; school?: Organization; editing?: Editing }
     | null
   >(null);
 
   const openSheetFor = (kind: 'employment' | 'education', card?: HistoryCard<HistoryEntry>) => {
-    const org = card ? { id: card.organization.id, name: card.organization.name, stintId: card.stintId } : undefined;
+    // Any of the card's edges will do as the one to hang a new row off; a card
+    // holds more than one only where the same employer was recorded twice.
+    const org = card?.edges[0]
+      ? { id: card.organization.id, name: card.organization.name, stintId: card.edges[0].stintId }
+      : undefined;
     setSheet(kind === 'employment' ? { kind: 'position', company: org } : { kind: 'education', school: org });
+  };
+
+  const openSheetOn = (kind: 'employment' | 'education', card: HistoryCard<HistoryEntry>, entry: HistoryEntry) => {
+    const editing = { card, entry };
+    setSheet(kind === 'employment' ? { kind: 'position', editing } : { kind: 'education', editing });
   };
 
   const [name, setName] = React.useState('');
@@ -189,7 +205,10 @@ export function EditProfileDialog({ open, onOpenChange }: Props) {
     publishName !== current.name ||
     publishDescription !== current.description ||
     changesImage(banner, current.bannerUrl) ||
-    changesImage(avatar, current.avatarUrl);
+    changesImage(avatar, current.avatarUrl) ||
+    // Work and education write nothing until this Save, so a position added with
+    // the four fields left alone is the whole of the edit.
+    history.hasPendingChanges;
 
   // A failed save has already written its rows to the local store, so the entity
   // now reads back the edit and `hasChanges` goes false. Retry has to stay live
@@ -272,10 +291,16 @@ export function EditProfileDialog({ open, onOpenChange }: Props) {
                 <AddPositionSheet
                   spaceId={spaceId}
                   company={sheet.company}
+                  initial={
+                    sheet.editing &&
+                    positionDraftFromEntry(sheet.editing.card.organization, sheet.editing.entry as EmploymentEntry)
+                  }
                   isSaving={false}
                   onCancel={() => setSheet(null)}
-                  onSave={async draft => {
-                    await history.addPosition(draft);
+                  onSave={draft => {
+                    const editing = sheet.editing;
+                    if (editing) history.editEntry(editing.card, editing.entry, 'employment', draft);
+                    else history.addPosition(draft);
                     setSheet(null);
                   }}
                 />
@@ -283,10 +308,16 @@ export function EditProfileDialog({ open, onOpenChange }: Props) {
                 <AddEducationSheet
                   spaceId={spaceId}
                   school={sheet.school}
+                  initial={
+                    sheet.editing &&
+                    educationDraftFromEntry(sheet.editing.card.organization, sheet.editing.entry as EducationEntry)
+                  }
                   isSaving={false}
                   onCancel={() => setSheet(null)}
-                  onSave={async draft => {
-                    await history.addEducation(draft);
+                  onSave={draft => {
+                    const editing = sheet.editing;
+                    if (editing) history.editEntry(editing.card, editing.entry, 'education', draft);
+                    else history.addEducation(draft);
                     setSheet(null);
                   }}
                 />
@@ -389,8 +420,8 @@ export function EditProfileDialog({ open, onOpenChange }: Props) {
                     disabled={isPublishing}
                     onAdd={() => openSheetFor('employment')}
                     onAddTo={card => openSheetFor('employment', card)}
-                    onRemoveEntry={(card, entry) => void history.removeEntry(card, entry, 'employment')}
-                    onRemoveCard={card => void history.removeCard(card, 'employment')}
+                    onEditEntry={(card, entry) => openSheetOn('employment', card, entry)}
+                    onRemoveEntry={(card, entry) => history.removeEntry(card, entry, 'employment')}
                   />
 
                   <HistorySection
@@ -399,8 +430,8 @@ export function EditProfileDialog({ open, onOpenChange }: Props) {
                     disabled={isPublishing}
                     onAdd={() => openSheetFor('education')}
                     onAddTo={card => openSheetFor('education', card)}
-                    onRemoveEntry={(card, entry) => void history.removeEntry(card, entry, 'education')}
-                    onRemoveCard={card => void history.removeCard(card, 'education')}
+                    onEditEntry={(card, entry) => openSheetOn('education', card, entry)}
+                    onRemoveEntry={(card, entry) => history.removeEntry(card, entry, 'education')}
                   />
                 </div>
 

--- a/apps/web/partials/profile/edit-profile-dialog.tsx
+++ b/apps/web/partials/profile/edit-profile-dialog.tsx
@@ -9,7 +9,12 @@ import cx from 'classnames';
 import { type ProfileImageEdit, useEditProfile } from '~/core/hooks/use-edit-profile';
 import { useProfileHistory } from '~/core/hooks/use-profile-history';
 import type { EducationEntry, EmploymentEntry, HistoryCard, HistoryEntry } from '~/core/profile/normalize-history';
-import { educationDraftFromEntry, positionDraftFromEntry } from '~/core/profile/stage-history';
+import {
+  type EducationDraft,
+  type PositionDraft,
+  educationDraftFromEntry,
+  positionDraftFromEntry,
+} from '~/core/profile/stage-history';
 
 import { Button, SquareButton } from '~/design-system/button';
 import { Close } from '~/design-system/icons/close';
@@ -293,7 +298,10 @@ export function EditProfileDialog({ open, onOpenChange }: Props) {
                   company={sheet.company}
                   initial={
                     sheet.editing &&
-                    positionDraftFromEntry(sheet.editing.card.organization, sheet.editing.entry as EmploymentEntry)
+                    // The original where there is one: a reconstruction cannot know
+                    // the company was created here and still needs its name written.
+                    ((history.draftFor(sheet.editing.entry) as PositionDraft | undefined) ??
+                      positionDraftFromEntry(sheet.editing.card.organization, sheet.editing.entry as EmploymentEntry))
                   }
                   isSaving={false}
                   onCancel={() => setSheet(null)}
@@ -310,7 +318,8 @@ export function EditProfileDialog({ open, onOpenChange }: Props) {
                   school={sheet.school}
                   initial={
                     sheet.editing &&
-                    educationDraftFromEntry(sheet.editing.card.organization, sheet.editing.entry as EducationEntry)
+                    ((history.draftFor(sheet.editing.entry) as EducationDraft | undefined) ??
+                      educationDraftFromEntry(sheet.editing.card.organization, sheet.editing.entry as EducationEntry))
                   }
                   isSaving={false}
                   onCancel={() => setSheet(null)}

--- a/apps/web/partials/profile/history-section.test.tsx
+++ b/apps/web/partials/profile/history-section.test.tsx
@@ -1,0 +1,119 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup, render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { EmploymentCard } from '~/core/profile/normalize-history';
+
+import { HistorySection } from './history-section';
+
+afterEach(cleanup);
+
+const entry = (name: string, startDate: string | null, endDate: string | null) => ({
+  relationId: `rel-${name}`,
+  tenureId: `tenure-${name}`,
+  subject: { id: `subject-${name}`, name },
+  startDate,
+  endDate,
+  description: null,
+  isLegacy: false,
+  status: null,
+});
+
+const card = (org: string, entries: ReturnType<typeof entry>[]): EmploymentCard => ({
+  relationId: `edge-${org}`,
+  stintId: `stint-${org}`,
+  organization: { id: `org-${org}`, name: org },
+  entries,
+});
+
+function renderSection(cards: EmploymentCard[] = [], overrides: Partial<Parameters<typeof HistorySection>[0]> = {}) {
+  const props = {
+    kind: 'employment' as const,
+    cards,
+    onAdd: vi.fn(),
+    onAddTo: vi.fn(),
+    onRemoveEntry: vi.fn(),
+    ...overrides,
+  };
+  render(<HistorySection {...props} />);
+  return props;
+}
+
+describe('HistorySection', () => {
+  it('names the section and offers a way in when there is nothing yet', () => {
+    renderSection();
+
+    expect(screen.getByRole('heading', { name: 'Work' })).toBeInTheDocument();
+    expect(screen.getByText(/Nothing here yet/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '+ Add position' })).toBeInTheDocument();
+  });
+
+  // The promotion case, and the only place the nesting shows: two roles under one
+  // employer rather than the company repeated twice.
+  it('shows one card per employer with every role under it', () => {
+    renderSection([
+      card('Geo', [entry('Product Lead', '2024-01-01Z', null), entry('Engineer', '2022-06-01Z', '2024-01-01Z')]),
+    ]);
+
+    const cards = screen.getAllByRole('listitem').filter(item => within(item).queryByText('Geo'));
+    expect(cards).toHaveLength(1);
+
+    expect(screen.getByText('Product Lead')).toBeInTheDocument();
+    expect(screen.getByText('Jan 2024 – Present')).toBeInTheDocument();
+    expect(screen.getByText('Jun 2022 – Jan 2024')).toBeInTheDocument();
+  });
+
+  // "Add another role here" is the entire disclosure of the level underneath.
+  it('attaches a new role to the employer whose card it was clicked on', async () => {
+    const cards = [card('Geo', [entry('Engineer', '2022-06-01Z', null)])];
+    const props = renderSection(cards);
+
+    await userEvent.click(screen.getByRole('button', { name: '+ Add another role here' }));
+
+    expect(props.onAddTo).toHaveBeenCalledWith(cards[0]);
+  });
+
+  it('adds an unattached position from the section header', async () => {
+    const props = renderSection([card('Geo', [entry('Engineer', '2022-06-01Z', null)])]);
+
+    await userEvent.click(screen.getByRole('button', { name: '+ Add position' }));
+
+    expect(props.onAdd).toHaveBeenCalled();
+    expect(props.onAddTo).not.toHaveBeenCalled();
+  });
+
+  it('removes the row that was asked for', async () => {
+    const cards = [card('Geo', [entry('Product Lead', '2024-01-01Z', null), entry('Engineer', '2022-06-01Z', null)])];
+    const props = renderSection(cards);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Remove Engineer' }));
+
+    expect(props.onRemoveEntry).toHaveBeenCalledWith(cards[0], cards[0].entries[1]);
+  });
+
+  // About a third of records carry no dates. A lone dash reads as a rendering
+  // fault rather than as missing data.
+  it('shows no date line at all when a row has no dates', () => {
+    renderSection([card('Apple', [entry('Engineer', null, null)])]);
+
+    expect(screen.getByText('Engineer')).toBeInTheDocument();
+    expect(screen.queryByText('–')).not.toBeInTheDocument();
+  });
+
+  it('locks every control while a save is in flight', () => {
+    renderSection([card('Geo', [entry('Engineer', '2022-06-01Z', null)])], { disabled: true });
+
+    expect(screen.getByRole('button', { name: '+ Add position' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: '+ Add another role here' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Remove Engineer' })).toBeDisabled();
+  });
+
+  it('uses the education wording for the education section', () => {
+    renderSection([], { kind: 'education' });
+
+    expect(screen.getByRole('heading', { name: 'Education' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '+ Add education' })).toBeInTheDocument();
+  });
+});

--- a/apps/web/partials/profile/history-section.test.tsx
+++ b/apps/web/partials/profile/history-section.test.tsx
@@ -19,6 +19,8 @@ const entry = (name: string, startDate: string | null, endDate: string | null) =
   description: null,
   isLegacy: false,
   status: null,
+  employmentType: null,
+  skills: [],
 });
 
 const card = (org: string, entries: ReturnType<typeof entry>[]): EmploymentCard => ({
@@ -62,8 +64,8 @@ describe('HistorySection', () => {
     expect(cards).toHaveLength(1);
 
     expect(screen.getByText('Product Lead')).toBeInTheDocument();
-    expect(screen.getByText('Jan 2024 – Present')).toBeInTheDocument();
-    expect(screen.getByText('Jun 2022 – Jan 2024')).toBeInTheDocument();
+    expect(screen.getByText(/Jan 2024 – Present/)).toBeInTheDocument();
+    expect(screen.getByText(/Jun 2022 – Jan 2024/)).toBeInTheDocument();
   });
 
   // "Add another role here" is the entire disclosure of the level underneath.

--- a/apps/web/partials/profile/history-section.test.tsx
+++ b/apps/web/partials/profile/history-section.test.tsx
@@ -5,6 +5,7 @@ import userEvent from '@testing-library/user-event';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { EmploymentCard } from '~/core/profile/normalize-history';
+import { NOTHING_TO_CLEAN } from '~/core/profile/pending-history';
 
 import { HistorySection } from './history-section';
 
@@ -15,7 +16,8 @@ type Entry = EmploymentCard['entries'][number];
 const entry = (name: string, startDate: string | null, endDate: string | null, org = 'Geo'): Entry => ({
   relationId: `rel-${name}`,
   tenureId: `tenure-${name}`,
-  edge: { relationId: `edge-${org}`, stintId: `stint-${org}` },
+  edge: { relationId: `edge-${org}`, stintId: `stint-${org}`, subtree: NOTHING_TO_CLEAN },
+  subtree: NOTHING_TO_CLEAN,
   subject: { id: `subject-${name}`, name },
   startDate,
   endDate,
@@ -30,7 +32,7 @@ const entry = (name: string, startDate: string | null, endDate: string | null, o
 
 const card = (org: string, entries: ReturnType<typeof entry>[]): EmploymentCard => ({
   organization: { id: `org-${org}`, name: org },
-  edges: [{ relationId: `edge-${org}`, stintId: `stint-${org}` }],
+  edges: [{ relationId: `edge-${org}`, stintId: `stint-${org}`, subtree: NOTHING_TO_CLEAN }],
   entries,
 });
 

--- a/apps/web/partials/profile/history-section.test.tsx
+++ b/apps/web/partials/profile/history-section.test.tsx
@@ -10,7 +10,9 @@ import { HistorySection } from './history-section';
 
 afterEach(cleanup);
 
-const entry = (name: string, startDate: string | null, endDate: string | null, org = 'Geo') => ({
+type Entry = EmploymentCard['entries'][number];
+
+const entry = (name: string, startDate: string | null, endDate: string | null, org = 'Geo'): Entry => ({
   relationId: `rel-${name}`,
   tenureId: `tenure-${name}`,
   edge: { relationId: `edge-${org}`, stintId: `stint-${org}` },
@@ -22,6 +24,8 @@ const entry = (name: string, startDate: string | null, endDate: string | null, o
   status: null,
   employmentType: null,
   skills: [],
+  location: null,
+  locationType: null,
 });
 
 const card = (org: string, entries: ReturnType<typeof entry>[]): EmploymentCard => ({
@@ -123,6 +127,27 @@ describe('HistorySection', () => {
 
     expect(screen.getByText('Engineer')).toBeInTheDocument();
     expect(screen.queryByText('–')).not.toBeInTheDocument();
+  });
+
+  // One line the way a CV states it, and either half stands on its own: a remote
+  // role need not name a city, and a city says something without an arrangement
+  // beside it.
+  it('reads the location and the working arrangement as one line', () => {
+    const row = entry('Engineer', '2022-06-01Z', null);
+    renderSection([
+      card('Geo', [
+        { ...row, location: { id: 'city-sf', name: 'San Francisco' }, locationType: { id: 'r', name: 'Remote' } },
+      ]),
+    ]);
+
+    expect(screen.getByText('San Francisco · Remote')).toBeInTheDocument();
+  });
+
+  it('shows whichever half it has', () => {
+    const row = entry('Engineer', '2022-06-01Z', null);
+    renderSection([card('Geo', [{ ...row, locationType: { id: 'r', name: 'Remote' } }])]);
+
+    expect(screen.getByText('Remote')).toBeInTheDocument();
   });
 
   it('locks every control while a save is in flight', () => {

--- a/apps/web/partials/profile/history-section.test.tsx
+++ b/apps/web/partials/profile/history-section.test.tsx
@@ -10,9 +10,10 @@ import { HistorySection } from './history-section';
 
 afterEach(cleanup);
 
-const entry = (name: string, startDate: string | null, endDate: string | null) => ({
+const entry = (name: string, startDate: string | null, endDate: string | null, org = 'Geo') => ({
   relationId: `rel-${name}`,
   tenureId: `tenure-${name}`,
+  edge: { relationId: `edge-${org}`, stintId: `stint-${org}` },
   subject: { id: `subject-${name}`, name },
   startDate,
   endDate,
@@ -24,9 +25,8 @@ const entry = (name: string, startDate: string | null, endDate: string | null) =
 });
 
 const card = (org: string, entries: ReturnType<typeof entry>[]): EmploymentCard => ({
-  relationId: `edge-${org}`,
-  stintId: `stint-${org}`,
   organization: { id: `org-${org}`, name: org },
+  edges: [{ relationId: `edge-${org}`, stintId: `stint-${org}` }],
   entries,
 });
 
@@ -36,8 +36,8 @@ function renderSection(cards: EmploymentCard[] = [], overrides: Partial<Paramete
     cards,
     onAdd: vi.fn(),
     onAddTo: vi.fn(),
+    onEditEntry: vi.fn(),
     onRemoveEntry: vi.fn(),
-    onRemoveCard: vi.fn(),
     ...overrides,
   };
   render(<HistorySection {...props} />);
@@ -96,31 +96,30 @@ describe('HistorySection', () => {
     expect(props.onRemoveEntry).toHaveBeenCalledWith(cards[0], cards[0].entries[1]);
   });
 
-  it('removes a single position from the row it sits on', async () => {
+  // Everything on a row was typed into the sheet, so the row is the way back to it.
+  it('opens the row that was clicked for editing', async () => {
     const cards = [card('Geo', [entry('Product Lead', '2024-01-01Z', null), entry('Engineer', '2022-06-01Z', null)])];
     const props = renderSection(cards);
 
-    await userEvent.click(screen.getByRole('button', { name: 'Remove position Product Lead' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Edit position Engineer' }));
 
-    expect(props.onRemoveEntry).toHaveBeenCalledWith(cards[0], cards[0].entries[0]);
-    expect(props.onRemoveCard).not.toHaveBeenCalled();
+    expect(props.onEditEntry).toHaveBeenCalledWith(cards[0], cards[0].entries[1]);
+    expect(props.onRemoveEntry).not.toHaveBeenCalled();
   });
 
-  // Leaving an employer should not mean deleting each role there one at a time.
-  it('removes a whole employer and everything under it', async () => {
-    const cards = [card('Geo', [entry('Product Lead', '2024-01-01Z', null), entry('Engineer', '2022-06-01Z', null)])];
-    const props = renderSection(cards);
+  // A card-level "Remove employer" sat beside this and did exactly the same work
+  // on a card with one role, which read as two different things.
+  it('offers removal on the row and nowhere else', () => {
+    renderSection([card('Geo', [entry('Engineer', '2022-06-01Z', null)])]);
 
-    await userEvent.click(screen.getByRole('button', { name: 'Remove employer Geo' }));
-
-    expect(props.onRemoveCard).toHaveBeenCalledWith(cards[0]);
-    expect(props.onRemoveEntry).not.toHaveBeenCalled();
+    expect(screen.getByRole('button', { name: 'Remove position Engineer' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Remove employer/ })).not.toBeInTheDocument();
   });
 
   // About a third of records carry no dates. A lone dash reads as a rendering
   // fault rather than as missing data.
   it('shows no date line at all when a row has no dates', () => {
-    renderSection([card('Apple', [entry('Engineer', null, null)])]);
+    renderSection([card('Apple', [entry('Engineer', null, null, 'Apple')])]);
 
     expect(screen.getByText('Engineer')).toBeInTheDocument();
     expect(screen.queryByText('–')).not.toBeInTheDocument();
@@ -131,7 +130,7 @@ describe('HistorySection', () => {
 
     expect(screen.getByRole('button', { name: '+ Add position' })).toBeDisabled();
     expect(screen.getByRole('button', { name: '+ Add another role here' })).toBeDisabled();
-    expect(screen.getByRole('button', { name: 'Remove employer Geo' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Edit position Engineer' })).toBeDisabled();
     expect(screen.getByRole('button', { name: 'Remove position Engineer' })).toBeDisabled();
   });
 

--- a/apps/web/partials/profile/history-section.test.tsx
+++ b/apps/web/partials/profile/history-section.test.tsx
@@ -35,6 +35,7 @@ function renderSection(cards: EmploymentCard[] = [], overrides: Partial<Paramete
     onAdd: vi.fn(),
     onAddTo: vi.fn(),
     onRemoveEntry: vi.fn(),
+    onRemoveCard: vi.fn(),
     ...overrides,
   };
   render(<HistorySection {...props} />);
@@ -88,9 +89,30 @@ describe('HistorySection', () => {
     const cards = [card('Geo', [entry('Product Lead', '2024-01-01Z', null), entry('Engineer', '2022-06-01Z', null)])];
     const props = renderSection(cards);
 
-    await userEvent.click(screen.getByRole('button', { name: 'Remove Engineer' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Remove position Engineer' }));
 
     expect(props.onRemoveEntry).toHaveBeenCalledWith(cards[0], cards[0].entries[1]);
+  });
+
+  it('removes a single position from the row it sits on', async () => {
+    const cards = [card('Geo', [entry('Product Lead', '2024-01-01Z', null), entry('Engineer', '2022-06-01Z', null)])];
+    const props = renderSection(cards);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Remove position Product Lead' }));
+
+    expect(props.onRemoveEntry).toHaveBeenCalledWith(cards[0], cards[0].entries[0]);
+    expect(props.onRemoveCard).not.toHaveBeenCalled();
+  });
+
+  // Leaving an employer should not mean deleting each role there one at a time.
+  it('removes a whole employer and everything under it', async () => {
+    const cards = [card('Geo', [entry('Product Lead', '2024-01-01Z', null), entry('Engineer', '2022-06-01Z', null)])];
+    const props = renderSection(cards);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Remove employer Geo' }));
+
+    expect(props.onRemoveCard).toHaveBeenCalledWith(cards[0]);
+    expect(props.onRemoveEntry).not.toHaveBeenCalled();
   });
 
   // About a third of records carry no dates. A lone dash reads as a rendering
@@ -107,7 +129,8 @@ describe('HistorySection', () => {
 
     expect(screen.getByRole('button', { name: '+ Add position' })).toBeDisabled();
     expect(screen.getByRole('button', { name: '+ Add another role here' })).toBeDisabled();
-    expect(screen.getByRole('button', { name: 'Remove Engineer' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Remove employer Geo' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Remove position Engineer' })).toBeDisabled();
   });
 
   it('uses the education wording for the education section', () => {

--- a/apps/web/partials/profile/history-section.tsx
+++ b/apps/web/partials/profile/history-section.tsx
@@ -2,10 +2,13 @@
 
 import * as React from 'react';
 
-import { formatDateRange } from '~/core/profile/history-dates';
+import cx from 'classnames';
+
+import { formatDateRange, formatDuration } from '~/core/profile/history-dates';
 import type { EducationCard, EmploymentCard, HistoryCard, HistoryEntry } from '~/core/profile/normalize-history';
 
 import { SmallButton, SquareButton } from '~/design-system/button';
+import { FallbackImage } from '~/design-system/fallback-image';
 import { Trash } from '~/design-system/icons/trash';
 
 type Kind = 'employment' | 'education';
@@ -39,12 +42,13 @@ const COPY: Record<Kind, { title: string; add: string; addHere: string; empty: s
 
 /**
  * The resting state: one card per organisation, every role or degree held there
- * as a dated row beneath it.
+ * beneath it.
  *
- * The nesting underneath — a relation carrying an entity carrying another
- * relation — surfaces nowhere except "Add another role here". Someone with one
- * job at one company adds a position, sees a card, and never learns there was a
- * level below it.
+ * Two or more rows are drawn against a spine, the way a run of promotions reads
+ * on LinkedIn — the organisation is stated once and the roles are what change.
+ * That grouping is the only place the nesting underneath surfaces: someone with
+ * one job at one company adds a position, sees a card, and never learns there
+ * was a level below it.
  */
 export function HistorySection({ kind, cards, disabled, onAdd, onAddTo, onRemoveEntry, onRemoveCard }: Props) {
   const copy = COPY[kind];
@@ -66,46 +70,95 @@ export function HistorySection({ kind, cards, disabled, onAdd, onAddTo, onRemove
         <ul className="flex flex-col gap-2">
           {cards.map(card => (
             <li key={card.relationId} className="rounded-lg border border-grey-02 p-3">
-              <div className="flex items-start justify-between gap-2">
-                <p className="min-w-0 truncate text-metadataMedium text-text">{card.organization.name ?? 'Untitled'}</p>
-                {/* Removing the organisation takes every row with it. Offered
-                    separately from the per-row delete so leaving one employer
-                    does not mean deleting each role there one at a time. */}
-                <SmallButton
-                  onClick={() => onRemoveCard(card)}
-                  disabled={disabled}
-                  aria-label={`${copy.removeCard} ${card.organization.name ?? 'Untitled'}`}
-                >
-                  {copy.removeCard}
-                </SmallButton>
-              </div>
+              <div className="flex items-start gap-2.5">
+                <OrganizationAvatar name={card.organization.name} url={card.avatarUrl} />
 
-              <ul className="mt-2 flex flex-col gap-1.5">
-                {card.entries.map(entry => (
-                  <EntryRow
-                    key={entry.relationId}
-                    kind={kind}
-                    entry={entry}
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-start justify-between gap-2">
+                    <div className="min-w-0">
+                      <p className="truncate text-metadataMedium text-text">{card.organization.name ?? 'Untitled'}</p>
+                      {/* Total time at the employer — the number a run of roles is
+                          actually read for. Only where there is a run. */}
+                      {card.entries.length > 1 && <CardDuration entries={card.entries} />}
+                    </div>
+
+                    {/* Removing the organisation takes every row with it. Offered
+                        separately so leaving one employer does not mean deleting
+                        each role there one at a time. */}
+                    <SmallButton
+                      onClick={() => onRemoveCard(card)}
+                      disabled={disabled}
+                      aria-label={`${copy.removeCard} ${card.organization.name ?? 'Untitled'}`}
+                    >
+                      {copy.removeCard}
+                    </SmallButton>
+                  </div>
+
+                  <ul
+                    className={cx(
+                      'mt-2 flex flex-col gap-2.5',
+                      card.entries.length > 1 && 'border-l border-grey-02 pl-3'
+                    )}
+                  >
+                    {card.entries.map(entry => (
+                      <EntryRow
+                        key={entry.relationId}
+                        kind={kind}
+                        entry={entry}
+                        disabled={disabled}
+                        onRemove={() => onRemoveEntry(card, entry)}
+                      />
+                    ))}
+                  </ul>
+
+                  <button
+                    type="button"
+                    onClick={() => onAddTo(card)}
                     disabled={disabled}
-                    onRemove={() => onRemoveEntry(card, entry)}
-                  />
-                ))}
-              </ul>
-
-              <button
-                type="button"
-                onClick={() => onAddTo(card)}
-                disabled={disabled}
-                className="mt-2 text-footnote text-ctaPrimary hover:underline disabled:text-grey-03 disabled:no-underline"
-              >
-                + {copy.addHere}
-              </button>
+                    className="mt-2 text-footnote text-ctaPrimary hover:underline disabled:text-grey-03 disabled:no-underline"
+                  >
+                    + {copy.addHere}
+                  </button>
+                </div>
+              </div>
             </li>
           ))}
         </ul>
       )}
     </section>
   );
+}
+
+/** The organisation's logo, or its initial where it has none. */
+function OrganizationAvatar({ name, url }: { name: string | null; url?: string | null }) {
+  if (url) {
+    return (
+      <div className="relative size-9 shrink-0 overflow-hidden rounded bg-grey-01">
+        <FallbackImage value={url} sizes="36px" className="object-cover" />
+      </div>
+    );
+  }
+
+  return (
+    <div
+      aria-hidden
+      className="flex size-9 shrink-0 items-center justify-center rounded bg-divider text-metadataMedium text-grey-04"
+    >
+      {(name ?? '?').trim().charAt(0).toUpperCase()}
+    </div>
+  );
+}
+
+function CardDuration({ entries }: { entries: HistoryEntry[] }) {
+  const starts = entries.map(entry => entry.startDate).filter((date): date is string => date !== null);
+  if (starts.length === 0) return null;
+
+  // Open at the employer if any role there is still held.
+  const isOpen = entries.some(entry => entry.startDate !== null && entry.endDate === null);
+  const ends = entries.map(entry => entry.endDate).filter((date): date is string => date !== null);
+
+  const duration = formatDuration([...starts].sort()[0], isOpen ? null : ([...ends].sort().at(-1) ?? null));
+  return duration ? <p className="text-footnote text-grey-04">{duration}</p> : null;
 }
 
 function EntryRow({
@@ -120,17 +173,38 @@ function EntryRow({
   onRemove: () => void;
 }) {
   const dates = formatDateRange(entry.startDate, entry.endDate);
-  const fields = 'fields' in entry ? (entry as { fields: { name: string | null }[] }).fields : [];
+  const duration = formatDuration(entry.startDate, entry.endDate);
   const subject = entry.subject.name ?? 'Untitled';
+
+  const fields = 'fields' in entry ? (entry as { fields: { name: string | null }[] }).fields : [];
+  const employmentType =
+    'employmentType' in entry ? (entry as { employmentType: { name: string | null } | null }).employmentType : null;
+  const skills = 'skills' in entry ? (entry as { skills: { name: string | null }[] }).skills : [];
+
   const heading = fields.length > 0 ? `${subject}, ${fields.map(field => field.name).join(', ')}` : subject;
 
   return (
     <li className="flex items-start justify-between gap-2">
       <div className="min-w-0">
         <p className="truncate text-footnote text-text">{heading}</p>
+        {employmentType?.name && <p className="text-footnote text-grey-04">{employmentType.name}</p>}
+
         {/* About a third of records carry no dates. A lone dash there reads as a
             rendering fault rather than as missing data, so the line is dropped. */}
-        {dates && <p className="text-footnote text-grey-04">{dates}</p>}
+        {dates && (
+          <p className="text-footnote text-grey-04">
+            {dates}
+            {duration && ` · ${duration}`}
+          </p>
+        )}
+
+        {entry.description && <p className="mt-1 text-footnote text-text">{entry.description}</p>}
+
+        {skills.length > 0 && (
+          <p className="mt-1 text-footnote text-grey-04">
+            <span className="text-text">Skills:</span> {skills.map(skill => skill.name).join(', ')}
+          </p>
+        )}
       </div>
 
       <SquareButton

--- a/apps/web/partials/profile/history-section.tsx
+++ b/apps/web/partials/profile/history-section.tsx
@@ -1,0 +1,129 @@
+'use client';
+
+import * as React from 'react';
+
+import { formatDateRange } from '~/core/profile/history-dates';
+import type { EducationCard, EmploymentCard, HistoryCard, HistoryEntry } from '~/core/profile/normalize-history';
+
+import { SmallButton, SquareButton } from '~/design-system/button';
+import { Trash } from '~/design-system/icons/trash';
+
+type Kind = 'employment' | 'education';
+
+type Props = {
+  kind: Kind;
+  cards: (EmploymentCard | EducationCard)[];
+  disabled?: boolean;
+  onAdd: () => void;
+  onAddTo: (card: HistoryCard<HistoryEntry>) => void;
+  onRemoveEntry: (card: HistoryCard<HistoryEntry>, entry: HistoryEntry) => void;
+};
+
+const COPY: Record<Kind, { title: string; add: string; addHere: string; empty: string }> = {
+  employment: {
+    title: 'Work',
+    add: 'Add position',
+    addHere: 'Add another role here',
+    empty: 'Nothing here yet. Add a position and it appears on your profile.',
+  },
+  education: {
+    title: 'Education',
+    add: 'Add education',
+    addHere: 'Add another degree here',
+    empty: 'Nothing here yet. Add a school and it appears on your profile.',
+  },
+};
+
+/**
+ * The resting state: one card per organisation, every role or degree held there
+ * as a dated row beneath it.
+ *
+ * The nesting underneath — a relation carrying an entity carrying another
+ * relation — surfaces nowhere except "Add another role here". Someone with one
+ * job at one company adds a position, sees a card, and never learns there was a
+ * level below it.
+ */
+export function HistorySection({ kind, cards, disabled, onAdd, onAddTo, onRemoveEntry }: Props) {
+  const copy = COPY[kind];
+
+  return (
+    <section className="flex flex-col gap-2">
+      <header className="flex items-center justify-between">
+        <h3 className="text-metadataMedium text-grey-04">{copy.title}</h3>
+        <SmallButton onClick={onAdd} disabled={disabled}>
+          + {copy.add}
+        </SmallButton>
+      </header>
+
+      {cards.length === 0 ? (
+        <p className="rounded-lg border border-dashed border-grey-02 px-3 py-4 text-center text-footnote text-grey-04">
+          {copy.empty}
+        </p>
+      ) : (
+        <ul className="flex flex-col gap-2">
+          {cards.map(card => (
+            <li key={card.relationId} className="rounded-lg border border-grey-02 p-3">
+              <p className="text-metadataMedium text-text">{card.organization.name ?? 'Untitled'}</p>
+
+              <ul className="mt-2 flex flex-col gap-1.5">
+                {card.entries.map(entry => (
+                  <EntryRow
+                    key={entry.relationId}
+                    kind={kind}
+                    entry={entry}
+                    disabled={disabled}
+                    onRemove={() => onRemoveEntry(card, entry)}
+                  />
+                ))}
+              </ul>
+
+              <button
+                type="button"
+                onClick={() => onAddTo(card)}
+                disabled={disabled}
+                className="mt-2 text-footnote text-ctaPrimary hover:underline disabled:text-grey-03 disabled:no-underline"
+              >
+                + {copy.addHere}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+function EntryRow({
+  kind,
+  entry,
+  disabled,
+  onRemove,
+}: {
+  kind: Kind;
+  entry: HistoryEntry;
+  disabled?: boolean;
+  onRemove: () => void;
+}) {
+  const dates = formatDateRange(entry.startDate, entry.endDate);
+  const fields = 'fields' in entry ? (entry as { fields: { name: string | null }[] }).fields : [];
+  const subject = entry.subject.name ?? 'Untitled';
+  const heading = fields.length > 0 ? `${subject}, ${fields.map(field => field.name).join(', ')}` : subject;
+
+  return (
+    <li className="flex items-start justify-between gap-2">
+      <div className="min-w-0">
+        <p className="truncate text-footnote text-text">{heading}</p>
+        {/* About a third of records carry no dates. A lone dash there reads as a
+            rendering fault rather than as missing data, so the line is dropped. */}
+        {dates && <p className="text-footnote text-grey-04">{dates}</p>}
+      </div>
+
+      <SquareButton
+        onClick={onRemove}
+        disabled={disabled}
+        icon={<Trash />}
+        aria-label={`Remove ${subject}${kind === 'employment' ? '' : ' degree'}`}
+      />
+    </li>
+  );
+}

--- a/apps/web/partials/profile/history-section.tsx
+++ b/apps/web/partials/profile/history-section.tsx
@@ -181,6 +181,7 @@ function EntryRow({
   // something without a working arrangement beside it.
   const place = [location?.name, locationType?.name].filter(Boolean).join(' · ');
   const skills = 'skills' in entry ? (entry as { skills: { name: string | null }[] }).skills : [];
+  const grade = 'grade' in entry ? (entry as { grade: number | null }).grade : null;
 
   const heading = fields.length > 0 ? `${subject}, ${fields.map(field => field.name).join(', ')}` : subject;
 
@@ -209,6 +210,7 @@ function EntryRow({
         )}
 
         {place && <p className="text-footnote text-grey-04">{place}</p>}
+        {grade !== null && <p className="text-footnote text-grey-04">Grade {grade}</p>}
 
         {entry.description && <p className="mt-1 text-footnote text-text">{entry.description}</p>}
 

--- a/apps/web/partials/profile/history-section.tsx
+++ b/apps/web/partials/profile/history-section.tsx
@@ -17,20 +17,23 @@ type Props = {
   onAdd: () => void;
   onAddTo: (card: HistoryCard<HistoryEntry>) => void;
   onRemoveEntry: (card: HistoryCard<HistoryEntry>, entry: HistoryEntry) => void;
+  onRemoveCard: (card: HistoryCard<HistoryEntry>) => void;
 };
 
-const COPY: Record<Kind, { title: string; add: string; addHere: string; empty: string }> = {
+const COPY: Record<Kind, { title: string; add: string; addHere: string; empty: string; removeCard: string }> = {
   employment: {
     title: 'Work',
     add: 'Add position',
     addHere: 'Add another role here',
     empty: 'Nothing here yet. Add a position and it appears on your profile.',
+    removeCard: 'Remove employer',
   },
   education: {
     title: 'Education',
     add: 'Add education',
     addHere: 'Add another degree here',
     empty: 'Nothing here yet. Add a school and it appears on your profile.',
+    removeCard: 'Remove school',
   },
 };
 
@@ -43,7 +46,7 @@ const COPY: Record<Kind, { title: string; add: string; addHere: string; empty: s
  * job at one company adds a position, sees a card, and never learns there was a
  * level below it.
  */
-export function HistorySection({ kind, cards, disabled, onAdd, onAddTo, onRemoveEntry }: Props) {
+export function HistorySection({ kind, cards, disabled, onAdd, onAddTo, onRemoveEntry, onRemoveCard }: Props) {
   const copy = COPY[kind];
 
   return (
@@ -63,7 +66,19 @@ export function HistorySection({ kind, cards, disabled, onAdd, onAddTo, onRemove
         <ul className="flex flex-col gap-2">
           {cards.map(card => (
             <li key={card.relationId} className="rounded-lg border border-grey-02 p-3">
-              <p className="text-metadataMedium text-text">{card.organization.name ?? 'Untitled'}</p>
+              <div className="flex items-start justify-between gap-2">
+                <p className="min-w-0 truncate text-metadataMedium text-text">{card.organization.name ?? 'Untitled'}</p>
+                {/* Removing the organisation takes every row with it. Offered
+                    separately from the per-row delete so leaving one employer
+                    does not mean deleting each role there one at a time. */}
+                <SmallButton
+                  onClick={() => onRemoveCard(card)}
+                  disabled={disabled}
+                  aria-label={`${copy.removeCard} ${card.organization.name ?? 'Untitled'}`}
+                >
+                  {copy.removeCard}
+                </SmallButton>
+              </div>
 
               <ul className="mt-2 flex flex-col gap-1.5">
                 {card.entries.map(entry => (
@@ -122,7 +137,7 @@ function EntryRow({
         onClick={onRemove}
         disabled={disabled}
         icon={<Trash />}
-        aria-label={`Remove ${subject}${kind === 'employment' ? '' : ' degree'}`}
+        aria-label={`Remove ${kind === 'employment' ? 'position' : 'degree'} ${subject}`}
       />
     </li>
   );

--- a/apps/web/partials/profile/history-section.tsx
+++ b/apps/web/partials/profile/history-section.tsx
@@ -172,6 +172,14 @@ function EntryRow({
   const fields = 'fields' in entry ? (entry as { fields: { name: string | null }[] }).fields : [];
   const employmentType =
     'employmentType' in entry ? (entry as { employmentType: { name: string | null } | null }).employmentType : null;
+  const location = 'location' in entry ? (entry as { location: { name: string | null } | null }).location : null;
+  const locationType =
+    'locationType' in entry ? (entry as { locationType: { name: string | null } | null }).locationType : null;
+
+  // One line, the way a CV states it: "San Francisco · Remote". Either half
+  // stands on its own — a remote role need not name a city, and a city says
+  // something without a working arrangement beside it.
+  const place = [location?.name, locationType?.name].filter(Boolean).join(' · ');
   const skills = 'skills' in entry ? (entry as { skills: { name: string | null }[] }).skills : [];
 
   const heading = fields.length > 0 ? `${subject}, ${fields.map(field => field.name).join(', ')}` : subject;
@@ -199,6 +207,8 @@ function EntryRow({
             {duration && ` · ${duration}`}
           </p>
         )}
+
+        {place && <p className="text-footnote text-grey-04">{place}</p>}
 
         {entry.description && <p className="mt-1 text-footnote text-text">{entry.description}</p>}
 

--- a/apps/web/partials/profile/history-section.tsx
+++ b/apps/web/partials/profile/history-section.tsx
@@ -19,24 +19,24 @@ type Props = {
   disabled?: boolean;
   onAdd: () => void;
   onAddTo: (card: HistoryCard<HistoryEntry>) => void;
+  onEditEntry: (card: HistoryCard<HistoryEntry>, entry: HistoryEntry) => void;
   onRemoveEntry: (card: HistoryCard<HistoryEntry>, entry: HistoryEntry) => void;
-  onRemoveCard: (card: HistoryCard<HistoryEntry>) => void;
 };
 
-const COPY: Record<Kind, { title: string; add: string; addHere: string; empty: string; removeCard: string }> = {
+const COPY: Record<Kind, { title: string; add: string; addHere: string; empty: string; noun: string }> = {
   employment: {
     title: 'Work',
     add: 'Add position',
     addHere: 'Add another role here',
     empty: 'Nothing here yet. Add a position and it appears on your profile.',
-    removeCard: 'Remove employer',
+    noun: 'position',
   },
   education: {
     title: 'Education',
     add: 'Add education',
     addHere: 'Add another degree here',
     empty: 'Nothing here yet. Add a school and it appears on your profile.',
-    removeCard: 'Remove school',
+    noun: 'degree',
   },
 };
 
@@ -49,8 +49,13 @@ const COPY: Record<Kind, { title: string; add: string; addHere: string; empty: s
  * That grouping is the only place the nesting underneath surfaces: someone with
  * one job at one company adds a position, sees a card, and never learns there
  * was a level below it.
+ *
+ * Removal is per row and nowhere else. A card-level "Remove employer" sat beside
+ * it for a while and read as a second, different thing on a card with one role,
+ * where the two buttons did exactly the same work — so the last role standing
+ * takes its employer with it, and that is the only way an employer leaves.
  */
-export function HistorySection({ kind, cards, disabled, onAdd, onAddTo, onRemoveEntry, onRemoveCard }: Props) {
+export function HistorySection({ kind, cards, disabled, onAdd, onAddTo, onEditEntry, onRemoveEntry }: Props) {
   const copy = COPY[kind];
 
   return (
@@ -69,30 +74,15 @@ export function HistorySection({ kind, cards, disabled, onAdd, onAddTo, onRemove
       ) : (
         <ul className="flex flex-col gap-2">
           {cards.map(card => (
-            <li key={card.relationId} className="rounded-lg border border-grey-02 p-3">
+            <li key={card.organization.id} className="rounded-lg border border-grey-02 p-3">
               <div className="flex items-start gap-2.5">
                 <OrganizationAvatar name={card.organization.name} url={card.avatarUrl} />
 
                 <div className="min-w-0 flex-1">
-                  <div className="flex items-start justify-between gap-2">
-                    <div className="min-w-0">
-                      <p className="truncate text-metadataMedium text-text">{card.organization.name ?? 'Untitled'}</p>
-                      {/* Total time at the employer — the number a run of roles is
-                          actually read for. Only where there is a run. */}
-                      {card.entries.length > 1 && <CardDuration entries={card.entries} />}
-                    </div>
-
-                    {/* Removing the organisation takes every row with it. Offered
-                        separately so leaving one employer does not mean deleting
-                        each role there one at a time. */}
-                    <SmallButton
-                      onClick={() => onRemoveCard(card)}
-                      disabled={disabled}
-                      aria-label={`${copy.removeCard} ${card.organization.name ?? 'Untitled'}`}
-                    >
-                      {copy.removeCard}
-                    </SmallButton>
-                  </div>
+                  <p className="truncate text-metadataMedium text-text">{card.organization.name ?? 'Untitled'}</p>
+                  {/* Total time at the employer — the number a run of roles is
+                      actually read for. Only where there is a run. */}
+                  {card.entries.length > 1 && <CardDuration entries={card.entries} />}
 
                   <ul
                     className={cx(
@@ -103,9 +93,10 @@ export function HistorySection({ kind, cards, disabled, onAdd, onAddTo, onRemove
                     {card.entries.map(entry => (
                       <EntryRow
                         key={entry.relationId}
-                        kind={kind}
+                        noun={copy.noun}
                         entry={entry}
                         disabled={disabled}
+                        onEdit={() => onEditEntry(card, entry)}
                         onRemove={() => onRemoveEntry(card, entry)}
                       />
                     ))}
@@ -162,14 +153,16 @@ function CardDuration({ entries }: { entries: HistoryEntry[] }) {
 }
 
 function EntryRow({
-  kind,
+  noun,
   entry,
   disabled,
+  onEdit,
   onRemove,
 }: {
-  kind: Kind;
+  noun: string;
   entry: HistoryEntry;
   disabled?: boolean;
+  onEdit: () => void;
   onRemove: () => void;
 }) {
   const dates = formatDateRange(entry.startDate, entry.endDate);
@@ -185,7 +178,16 @@ function EntryRow({
 
   return (
     <li className="flex items-start justify-between gap-2">
-      <div className="min-w-0">
+      {/* The row itself opens it. Everything shown here was typed into the sheet,
+          so the sheet is where it is changed — a separate pencil would only be a
+          smaller target for the same thing. */}
+      <button
+        type="button"
+        onClick={onEdit}
+        disabled={disabled}
+        aria-label={`Edit ${noun} ${subject}`}
+        className="min-w-0 flex-1 text-left"
+      >
         <p className="truncate text-footnote text-text">{heading}</p>
         {employmentType?.name && <p className="text-footnote text-grey-04">{employmentType.name}</p>}
 
@@ -205,14 +207,9 @@ function EntryRow({
             <span className="text-text">Skills:</span> {skills.map(skill => skill.name).join(', ')}
           </p>
         )}
-      </div>
+      </button>
 
-      <SquareButton
-        onClick={onRemove}
-        disabled={disabled}
-        icon={<Trash />}
-        aria-label={`Remove ${kind === 'employment' ? 'position' : 'degree'} ${subject}`}
-      />
+      <SquareButton onClick={onRemove} disabled={disabled} icon={<Trash />} aria-label={`Remove ${noun} ${subject}`} />
     </li>
   );
 }

--- a/apps/web/partials/profile/history-sheet.tsx
+++ b/apps/web/partials/profile/history-sheet.tsx
@@ -53,6 +53,23 @@ export function HistorySheet({ title, saveLabel, isSaving, canSave, onCancel, on
 }
 
 /**
+ * Turns a `SelectEntity` search box into the find-or-create the rest of the app
+ * uses.
+ *
+ * Its "Create new" footer only renders when an `onCreateEntity` is supplied —
+ * the prop is there so a caller can decorate the new entity, but its presence is
+ * also what offers the option at all. Without it these pickers could only find a
+ * company that somebody else had already entered.
+ *
+ * Nothing to decorate here: the sheet types and names what it creates when the
+ * modal saves, so this only has to exist. Returning nothing keeps the id
+ * `SelectEntity` minted, which is the one it hands back to `onDone`.
+ */
+export function findOrCreate() {
+  return undefined;
+}
+
+/**
  * What a picker shows once it has an answer. `SelectEntity` is a search box, so
  * without this the chosen company disappears back into a placeholder the moment
  * focus leaves it.

--- a/apps/web/partials/profile/history-sheet.tsx
+++ b/apps/web/partials/profile/history-sheet.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import * as React from 'react';
+
+import { Button, SquareButton } from '~/design-system/button';
+import { CheckCloseSmall } from '~/design-system/icons/check-close-small';
+
+type Props = {
+  title: string;
+  saveLabel: string;
+  isSaving: boolean;
+  canSave: boolean;
+  onCancel: () => void;
+  onSave: () => void;
+  children: React.ReactNode;
+};
+
+/**
+ * The chrome shared by the two sheets: a back title, the fields, and a footer
+ * that says where the save lands before it is clicked.
+ *
+ * Rendered in place of the modal's own body rather than over it — one thing on
+ * screen at a time, and the fields underneath have nothing to do with the
+ * position being added.
+ */
+export function HistorySheet({ title, saveLabel, isSaving, canSave, onCancel, onSave, children }: Props) {
+  return (
+    <div className="flex flex-col">
+      <header className="flex items-center gap-2 px-5 py-4">
+        <SquareButton onClick={onCancel} disabled={isSaving} icon={<CheckCloseSmall />} aria-label="Back" />
+        <h2 className="text-smallTitle text-text">{title}</h2>
+      </header>
+
+      <div className="flex flex-col gap-4 px-5">{children}</div>
+
+      <footer className="mt-5 flex items-center justify-between gap-3 border-t border-grey-02 px-5 py-4">
+        <p className="text-footnote text-grey-04">
+          {isSaving
+            ? 'Publishing to your space. This usually takes about 10 seconds.'
+            : 'Saving publishes to your space.'}
+        </p>
+        <div className="flex items-center gap-2">
+          <Button type="button" variant="secondary" onClick={onCancel} disabled={isSaving}>
+            Cancel
+          </Button>
+          <Button type="button" onClick={onSave} disabled={!canSave}>
+            {isSaving ? 'Saving' : saveLabel}
+          </Button>
+        </div>
+      </footer>
+    </div>
+  );
+}
+
+/**
+ * What a picker shows once it has an answer. `SelectEntity` is a search box, so
+ * without this the chosen company disappears back into a placeholder the moment
+ * focus leaves it.
+ */
+export function PickedEntity({ name, note, onClear }: { name: string | null; note?: string; onClear?: () => void }) {
+  return (
+    <div className="flex flex-col gap-1">
+      <div className="flex items-center justify-between gap-2 rounded border border-grey-02 px-[10px] py-[9px]">
+        <span className="truncate text-input text-text">{name ?? 'Untitled'}</span>
+        {onClear && (
+          <button type="button" onClick={onClear} className="shrink-0 text-footnote text-grey-04 hover:underline">
+            Change
+          </button>
+        )}
+      </div>
+      {note && <span className="text-footnote text-grey-04">{note}</span>}
+    </div>
+  );
+}

--- a/apps/web/partials/profile/month-year-field.tsx
+++ b/apps/web/partials/profile/month-year-field.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import * as React from 'react';
+
+import { MONTH_NAMES, type MonthYear, yearOptions } from '~/core/profile/history-dates';
+
+type Props = {
+  label: string;
+  value: MonthYear | null;
+  onChange: (value: MonthYear | null) => void;
+  disabled?: boolean;
+};
+
+const selectClassName =
+  'appearance-none rounded border border-grey-02 bg-white px-2 py-1.5 text-metadata text-text outline-none transition-colors hover:border-text focus-visible:border-text disabled:cursor-not-allowed disabled:bg-divider disabled:text-grey-03';
+
+/**
+ * Month and year, no day.
+ *
+ * Every date already in the graph lands on the first of a month and most on the
+ * first of January, so a day picker would advertise a precision nobody has —
+ * and nobody filling in a CV remembers which Tuesday they started.
+ */
+export function MonthYearField({ label, value, onChange, disabled }: Props) {
+  const years = React.useMemo(() => yearOptions(), []);
+
+  /**
+   * The half-filled pair lives here rather than upstream.
+   *
+   * A month on its own cannot be stored — the graph wants a whole date — so the
+   * field reports `null` until both are chosen. Keeping only what it reported
+   * would lose the month the instant it was picked, leaving the year with
+   * nothing to pair with and the date silently unset.
+   *
+   * Seeded once: the sheets own this field's output, and they unmount between
+   * openings, so there is no later external value to follow.
+   */
+  const [month, setMonth] = React.useState(value?.month ?? 0);
+  const [year, setYear] = React.useState(value?.year ?? 0);
+
+  const update = (next: { month?: number; year?: number }) => {
+    const nextMonth = next.month ?? month;
+    const nextYear = next.year ?? year;
+
+    setMonth(nextMonth);
+    setYear(nextYear);
+    onChange(nextMonth > 0 && nextYear > 0 ? { month: nextMonth, year: nextYear } : null);
+  };
+
+  return (
+    <fieldset className="flex flex-col gap-1.5">
+      <legend className="text-metadataMedium text-grey-04">{label}</legend>
+      <div className="flex items-center gap-2">
+        <select
+          aria-label={`${label} month`}
+          value={month === 0 ? '' : month}
+          disabled={disabled}
+          onChange={event => update({ month: Number(event.currentTarget.value) })}
+          className={selectClassName}
+        >
+          <option value="">Month</option>
+          {MONTH_NAMES.map((name, index) => (
+            <option key={name} value={index + 1}>
+              {name}
+            </option>
+          ))}
+        </select>
+
+        <select
+          aria-label={`${label} year`}
+          value={year === 0 ? '' : year}
+          disabled={disabled}
+          onChange={event => update({ year: Number(event.currentTarget.value) })}
+          className={selectClassName}
+        >
+          <option value="">Year</option>
+          {years.map(year => (
+            <option key={year} value={year}>
+              {year}
+            </option>
+          ))}
+        </select>
+      </div>
+    </fieldset>
+  );
+}

--- a/apps/web/partials/profile/month-year-field.tsx
+++ b/apps/web/partials/profile/month-year-field.tsx
@@ -6,6 +6,13 @@ import { MONTH_NAMES, type MonthYear, yearOptions } from '~/core/profile/history
 
 type Props = {
   label: string;
+  /**
+   * A qualifier shown beside the label — "or expected" on a degree not finished
+   * yet. Kept out of `label` because that is what names the two selects to a
+   * screen reader, and "End (or expected) year" is a worse thing to hear than
+   * "End year".
+   */
+  note?: string;
   value: MonthYear | null;
   onChange: (value: MonthYear | null) => void;
   disabled?: boolean;
@@ -21,7 +28,7 @@ const selectClassName =
  * first of January, so a day picker would advertise a precision nobody has —
  * and nobody filling in a CV remembers which Tuesday they started.
  */
-export function MonthYearField({ label, value, onChange, disabled }: Props) {
+export function MonthYearField({ label, note, value, onChange, disabled }: Props) {
   const years = React.useMemo(() => yearOptions(), []);
 
   /**
@@ -49,7 +56,10 @@ export function MonthYearField({ label, value, onChange, disabled }: Props) {
 
   return (
     <fieldset className="flex flex-col gap-1.5">
-      <legend className="text-metadataMedium text-grey-04">{label}</legend>
+      <legend className="text-metadataMedium text-grey-04">
+        {label}
+        {note && <span className="text-footnote text-grey-04"> ({note})</span>}
+      </legend>
       <div className="flex items-center gap-2">
         <select
           aria-label={`${label} month`}


### PR DESCRIPTION
Closes [GEO-2858](https://linear.app/geobrowser/issue/GEO-2858/add-work-and-education-to-the-edit-profile-modal). Built against the [UI design](https://claude.ai/code/artifact/c52e111f-8828-4e82-8bcb-b182cc37f62a) (section 09). Builds on the Edit profile modal from #2386.

Filling in where you used to work now asks four questions. Behind them it writes three relations, the two entities those relations carry, and two or three values — none of which appears anywhere in the form.

## The shape

One `Employment` edge per company, with every role held there hanging off it. That is what lets a promotion read as two dated rows under one employer rather than the company appearing twice, and it is the only arrangement that survives four titles at one place over nine years.

The part that is easy to miss is the middle level: a relation carries an entity of its own, and that entity is what the next level hangs off.

```
person ──Employment──▶ company
           └─ stint = the Employment relation's own entity
                └─ ──Roles──▶ job title
                       └─ tenure = the Roles relation's own entity
                            ├─ Employment status ──▶ Current | Former
                            └─ Start date, End date, Description
```

Status lives on the **tenure**, not the stint — one company can hold a role you left in 2021 and a role you hold now.

## What's here

**Resting state** — one card per organisation, every role or degree under it as a dated row, plus "Add another role here". That link is the whole disclosure of the nesting: someone with one job at one company adds a position, sees a card, and never learns there was a level underneath.

**Add position** — company, title, dates, optional description. Adding a second role at a company already listed opens the same sheet with the company answered and locked, so a promotion costs three fields.

**Add education** — the one sheet with a three-way status. *Incomplete* is not *still studying* and both look identical as a missing end date, so the choice is explicit. **Still studying writes no status at all** rather than inventing an option the graph does not have; the empty End date carries it.

**Dates are month and year.** Everything already in the graph lands on the first of a month and most on the first of January, so a day picker would advertise a precision nobody has.

## Things worth knowing

**Every id was read back from the graph before being written down**, rather than copied from the ticket on trust — and a test pins all eleven. Worth doing: three arrive from the SDK under names describing the first feature that used them (Start date is `RANK_START_DATE_PROPERTY`), and I had them on the wrong namespace until the check caught it.

**A position publishes all at once or not at all.** A stint with no role under it renders as a company you are somehow attached to with nothing to say about it, so a failed write takes every row back out.

**The legacy fallback is real and needed.** Confirmed against the graph — stint `333463c7` carries `Start date`, `Description` and `Employment status` with two `Roles` whose tenures are both empty. Without the fallback those render as a company and a job title with no dates. Legacy is judged on the whole row rather than field by field: a role held now has a real start and a deliberately empty end, and testing the end alone would misread it as unstructured and hand it the stint's dates.

**Removing the last row takes its organisation with it**, for the same reason a position is written all at once.

## Decisions I made

- **The migration of those nineteen records is not here.** The ticket frames it as the better end state but separately; this ships the fallback.
- **Every picker is scoped to what its property declares**, read off the graph rather than guessed from the name:

  | Field | Type(s) searched | Why |
  |---|---|---|
  | Company | `Project` | What `Employment` points at here |
  | Title | `Person role` `e4e366e9…` | What `Roles` declares. It was scoped to `Job` at first — 32 entities against 4,014 — which hid every ESCO occupation |
  | Location | City, Region, Country, Place | What `Location` declares, minus Address: a job is held in a city, not at a street number |
  | Skills | `Skill` | 14,114 entities after the ESCO import |
  | School | `University` `0235f3d2…` | Chosen deliberately; the Project/Institution-typed schools are being migrated onto it. Pinned by id, since that entity may be renamed to `Institution` |
  | Degree | `Degree` `bfd47a54…` **and** `65256c54…` | Two real types share the name. The declared one holds 40 entities; the second holds the 29 anybody has actually used — Ph.D., Master, Bachelor. Scoping to the declared one alone would hide all of them |
  | Field of study | `Field of study` | Renamed from `Academic fields`; same id |

  The pickers also search the taxonomy space explicitly. Its 4,014 roles and 14,114 skills come back flagged non-canonical, in a space almost nobody is a member of, so the default eligibility rules filtered them out entirely.
- **Rows can be edited as well as removed.** This started out remove-only — the design shows a `⋮` without saying what is in it, and editing has to write through the legacy fallback correctly. It was asked for during review, so it is here: opening a row reopens the sheet on its draft, and saving replaces the row rather than rewriting it in place, which is also what lets a row move to another employer.

## Shared changes

`SquareButton` destructured `disabled` for its styling and never passed it to the element, so the button looked disabled and stayed clickable. Both existing callers passing it — a remove button with no image, a menu trigger mid-request — clearly meant it to block the click. `TextButton` had the same fault. While there, all five shared button components now default `type="button"` ahead of the spread; I audited every `<form>` in the app to confirm nothing relied on the implicit submit.

`SelectEntity` gains two opt-in props, both defaulting to today's behaviour:

- `deferCreate` hands a newly created entity to `onDone` without writing its name to the store. Creating otherwise names it immediately, so backing out of a modal that publishes on its own schedule left the name behind on an entity nothing pointed at. This modal writes that name itself when Save lands.
- `inputLabelledBy` puts an `aria-labelledby` on the search input, for a caller whose visible label sits outside it. Without one the input is announced by its placeholder — "Example: Microsoft" where the field says Company.

I also found that the shared `Checkbox` renders a bare button with no checkbox semantics. I supplied those locally rather than fixing the component, because several tests assert on it being a button — worth its own change.

## Testing

**312 tests across thirteen files**; full suite 5372 passing. Fixtures are modelled on records that exist rather than invented.

Two bugs the tests caught while writing them: the month/year field dropped the month whenever the pair was still incomplete, so picking March then 2019 stored nothing; and the picker fields were wrapped in `<label>`, which folded the label text into every control's accessible name.

## Not verified in a browser

Tests and typecheck only — the publish path needs a funded testnet account, so no position has actually been written to the graph yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


