### PR TITLE
feat: create a claim inline from the Claims tab and debate-again flow

### DIFF
--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -22,6 +22,9 @@ import {
 } from '~/core/debates/api';
 import { type ClaimPickerEntity, useClaimEntitiesByIds } from '~/core/debates/claim-picker-page';
 import { isClaimSpaceAllowed } from '~/core/debates/claim-space-allowlist';
+import { CreateDebateClaimForm } from '~/core/debates/create-claim/create-debate-claim-form';
+import { PendingClaimCard } from '~/core/debates/create-claim/pending-claim-card';
+import { usePendingDebateClaims } from '~/core/debates/create-claim/use-pending-debate-claims';
 import { markEnteringDebate } from '~/core/debates/debate-entry-intent';
 import { useDebateGatewaySpaceScopes } from '~/core/debates/debate-gateway';
 import { debatePublishableSpacePredicate } from '~/core/debates/debate-publish-target';
@@ -80,7 +83,9 @@ import { responsePositionLabel } from '~/core/responses/entity-response';
 import { getTopRankedSpaceId } from '~/core/utils/space/space-ranking';
 import { validateEntityId } from '~/core/utils/utils';
 
+import { Button } from '~/design-system/button';
 import { ChevronDownSmall } from '~/design-system/icons/chevron-down-small';
+import { Plus } from '~/design-system/icons/plus';
 import { Input } from '~/design-system/input';
 import { Skeleton } from '~/design-system/skeleton';
 import { Text } from '~/design-system/text';
@@ -144,6 +149,8 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
   const sessionQuery = useDebateRematch(sessionId);
   const [search, setSearch] = React.useState('');
   const { value: debouncedSearch, pending: searchSettling } = useDebouncedSearch(search);
+  const [creatingClaim, setCreatingClaim] = React.useState(false);
+  const { openSidePanel } = useEntitySidePanel();
 
   const [spaceIds, setSpaceIds] = React.useState<string[]>([]);
   const [topicIds, setTopicIds] = React.useState<string[]>([]);
@@ -941,6 +948,22 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
 
   const hasFilters = Boolean(debouncedSearch || spaceIds.length || topicIds.length);
 
+  // Optimistic rows for just-created claims; drop once the real list has them.
+  const { pendingClaims, dismissPendingClaim } = usePendingDebateClaims();
+  const listedClaimId = React.useCallback(
+    (claimId: string) => visibleClaims.some(entry => idEquals(entry.claim.claim_entity_id, claimId)),
+    [visibleClaims]
+  );
+  const pinnedPendingClaims = React.useMemo(
+    () => pendingClaims.filter(claim => !listedClaimId(claim.claimId)),
+    [pendingClaims, listedClaimId]
+  );
+  React.useEffect(() => {
+    for (const claim of pendingClaims) {
+      if (listedClaimId(claim.claimId)) dismissPendingClaim(claim.claimId);
+    }
+  }, [pendingClaims, listedClaimId, dismissPendingClaim]);
+
   const sentinelRef = useInfiniteScrollSentinel({
     hasNextPage: taggedHasNextPage,
     isFetchingNextPage: taggedFetchingNextPage,
@@ -1268,6 +1291,48 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
             {rematchCancellationMessage(session.request.cancellation_reason)}
           </Text>
         )}
+
+        {tab === 'claims' ? (
+          <div className="mb-3 flex flex-col gap-3">
+            {creatingClaim ? (
+              <CreateDebateClaimForm
+                candidateSpaceIds={eligibleSpaceIds}
+                defaultSpaceId={spaceIds[0] ?? session?.source_space_id ?? null}
+                onCreated={({ claimId, spaceId, alreadyExisted }) => {
+                  setCreatingClaim(false);
+                  setSearch('');
+                  setTopicIds([]);
+                  setSpaceIds(current =>
+                    current.length === 0 || current.includes(spaceId) ? current : [...current, spaceId]
+                  );
+
+                  if (alreadyExisted) {
+                    openSidePanel(claimId, spaceId, false);
+                  }
+                }}
+                onCancel={() => setCreatingClaim(false)}
+              />
+            ) : (
+              <div className="flex justify-end">
+                <Button type="button" variant="secondary" icon={<Plus />} onClick={() => setCreatingClaim(true)}>
+                  New claim
+                </Button>
+              </div>
+            )}
+
+            {pinnedPendingClaims.length > 0 ? (
+              <HubCardList>
+                {pinnedPendingClaims.map(claim => (
+                  <PendingClaimCard
+                    key={claim.claimId}
+                    claim={claim}
+                    onDismiss={() => dismissPendingClaim(claim.claimId)}
+                  />
+                ))}
+              </HubCardList>
+            ) : null}
+          </div>
+        ) : null}
 
         <HubQueryState
           // Only what the visible tab actually draws from, and only while it has nothing to show.

--- a/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/rematches/[sessionId]/rematch-page-client.tsx
@@ -1296,7 +1296,7 @@ export function DebateRematchPageClient({ sessionId }: { sessionId: string }) {
           <div className="mb-3 flex flex-col gap-3">
             {creatingClaim ? (
               <CreateDebateClaimForm
-                candidateSpaceIds={eligibleSpaceIds}
+                candidateSpaceIds={allowlistPending ? null : eligibleSpaceIds}
                 defaultSpaceId={spaceIds[0] ?? session?.source_space_id ?? null}
                 onCreated={({ claimId, spaceId, alreadyExisted }) => {
                   setCreatingClaim(false);

--- a/apps/web/atoms/debate-create-claim.ts
+++ b/apps/web/atoms/debate-create-claim.ts
@@ -1,0 +1,20 @@
+'use client';
+
+import { atom } from 'jotai';
+
+import type { ClaimDraftSelection } from '~/core/claims/claim-draft';
+
+export type PendingDebateClaimStatus = 'publishing' | 'indexed';
+
+/**
+ * A claim the viewer just created inline from a debates surface, held in memory until it is indexed.
+ */
+export type PendingDebateClaim = {
+  claimId: string;
+  spaceId: string;
+  text: string;
+  topics: ClaimDraftSelection[];
+  status: PendingDebateClaimStatus;
+};
+
+export const pendingDebateClaimsAtom = atom<PendingDebateClaim[]>([]);

--- a/apps/web/core/claims/claim-draft.ts
+++ b/apps/web/core/claims/claim-draft.ts
@@ -1,5 +1,6 @@
 import { Position, SystemIds } from '@geoprotocol/geo-sdk/lite';
 
+import { TAG_PROPERTY_ID } from '~/core/constants';
 import { ID } from '~/core/id';
 import type { Relation } from '~/core/types';
 
@@ -14,6 +15,7 @@ export type BuildClaimDraftInput = {
   spaceId: string;
   claimText: string;
   topics?: ClaimDraftSelection[];
+  tags?: ClaimDraftSelection[];
 };
 
 export type ClaimDraft = {
@@ -88,6 +90,17 @@ export function buildClaimDraft(input: BuildClaimDraftInput, options: BuildClaim
         propertyName: 'Topics',
         toEntityId: topic.id,
         toEntityName: topic.name,
+      })
+    );
+  }
+
+  for (const tag of input.tags ?? []) {
+    relations.push(
+      makeRelation({
+        propertyId: TAG_PROPERTY_ID,
+        propertyName: 'Tags',
+        toEntityId: tag.id,
+        toEntityName: tag.name,
       })
     );
   }

--- a/apps/web/core/debates/create-claim/create-debate-claim-form.tsx
+++ b/apps/web/core/debates/create-claim/create-debate-claim-form.tsx
@@ -1,0 +1,159 @@
+'use client';
+
+import * as React from 'react';
+
+import { TOPIC_TYPE_ID } from '~/core/claims/ontology';
+import { useCreatableSpaceIds } from '~/core/hooks/use-creatable-space-ids';
+import { spaceLabel, useSpaceLabels } from '~/core/hooks/use-space-labels';
+
+import { Button } from '~/design-system/button';
+import { SelectEntityCompact, type SelectEntityCompactResult } from '~/design-system/select-entity-compact';
+import { Text } from '~/design-system/text';
+
+import { HubFilterMenu, type HubFilterOption } from '../matchmaking/hub-filter-menu';
+import { usePublishDebateClaim } from './use-publish-debate-claim';
+
+export type CreateDebateClaimResult = {
+  claimId: string;
+  spaceId: string;
+  /** The claim already existed in the space and was surfaced rather than created a second time. */
+  alreadyExisted: boolean;
+};
+
+type Props = {
+  candidateSpaceIds: string[] | null | undefined;
+  defaultSpaceId?: string | null;
+  onCreated: (result: CreateDebateClaimResult) => void;
+  onCancel: () => void;
+};
+
+/**
+ * Create a claim inline and publish it straight into the chosen space — no review-edits flow.
+ */
+export function CreateDebateClaimForm({ candidateSpaceIds, defaultSpaceId, onCreated, onCancel }: Props) {
+  const { publishClaim } = usePublishDebateClaim();
+
+  const candidates = React.useMemo(() => candidateSpaceIds ?? [], [candidateSpaceIds]);
+  const { canCreateInSpace, isResolved: creatableResolved } = useCreatableSpaceIds(candidates, true);
+  const creatableSpaceIds = React.useMemo(() => candidates.filter(canCreateInSpace), [candidates, canCreateInSpace]);
+  const { labelsById } = useSpaceLabels(creatableSpaceIds);
+
+  const [claimText, setClaimText] = React.useState('');
+  const [spaceId, setSpaceId] = React.useState<string | null>(null);
+  const [topics, setTopics] = React.useState<SelectEntityCompactResult[]>([]);
+  const [submitting, setSubmitting] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    if (spaceId || creatableSpaceIds.length === 0) return;
+    const preferred =
+      defaultSpaceId && creatableSpaceIds.includes(defaultSpaceId) ? defaultSpaceId : creatableSpaceIds[0];
+    setSpaceId(preferred);
+  }, [creatableSpaceIds, defaultSpaceId, spaceId]);
+
+  const spaceOptions = React.useMemo<HubFilterOption<string>[]>(
+    () =>
+      creatableSpaceIds.map(id => {
+        const label = spaceLabel(labelsById, id);
+        return { value: id, label: label?.name ?? 'Space', image: label?.image ?? null };
+      }),
+    [creatableSpaceIds, labelsById]
+  );
+
+  const addTopic = (selection: SelectEntityCompactResult) =>
+    setTopics(current => (current.some(topic => topic.id === selection.id) ? current : [...current, selection]));
+  const removeTopic = (id: string) => setTopics(current => current.filter(topic => topic.id !== id));
+
+  const canSubmit = claimText.trim().length > 0 && Boolean(spaceId) && !submitting;
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!spaceId || claimText.trim().length === 0 || submitting) return;
+
+    setSubmitting(true);
+    setError(null);
+
+    try {
+      const topicSelections = topics.map(topic => ({ id: topic.id, name: topic.name ?? null }));
+      const result = await publishClaim({ spaceId, claimText, topics: topicSelections });
+      onCreated({ claimId: result.claimId, spaceId, alreadyExisted: result.alreadyExisted });
+    } catch {
+      setError('Could not create the claim. Please try again.');
+      setSubmitting(false);
+    }
+  };
+
+  // No creatable space among the candidates — say so instead of an empty dropdown.
+  const noCreatableSpaces = candidates.length === 0 || (creatableResolved && creatableSpaceIds.length === 0);
+
+  return (
+    <form onSubmit={handleSubmit} className="rounded-lg border border-grey-02 bg-white p-4 shadow-light">
+      <div className="space-y-4">
+        <label className="block">
+          <Text as="span" variant="metadataMedium" color="text">
+            Claim
+          </Text>
+          <textarea
+            value={claimText}
+            onChange={event => setClaimText(event.target.value)}
+            rows={3}
+            autoFocus
+            className="mt-2 block w-full resize-y rounded-md border border-grey-02 bg-white px-3 py-2 text-body text-text shadow-inner shadow-grey-02 outline-hidden placeholder:text-grey-03 focus:shadow-inner-lg focus:shadow-text"
+            placeholder="What should people debate?"
+          />
+        </label>
+
+        <div>
+          <Text as="div" variant="metadataMedium" color="text" className="mb-2">
+            Space
+          </Text>
+          {noCreatableSpaces ? (
+            <Text as="p" variant="footnote" color="grey-04">
+              You don’t have a space you can publish a claim to yet.
+            </Text>
+          ) : (
+            <HubFilterMenu
+              label={
+                spaceId ? (spaceOptions.find(option => option.value === spaceId)?.label ?? 'Space') : 'Choose a space'
+              }
+              options={spaceOptions}
+              value={spaceId ?? ''}
+              onChange={setSpaceId}
+            />
+          )}
+        </div>
+
+        {spaceId ? (
+          <div>
+            <Text as="div" variant="metadataMedium" color="text" className="mb-2">
+              Topics <span className="text-grey-03">(optional)</span>
+            </Text>
+            <SelectEntityCompact
+              spaceId={spaceId}
+              placeholder="Search topics..."
+              relationValueTypes={[{ id: TOPIC_TYPE_ID }]}
+              selected={topics}
+              onDone={addTopic}
+              onRemoveSelected={removeTopic}
+            />
+          </div>
+        ) : null}
+      </div>
+
+      {error && (
+        <Text as="p" variant="footnote" color="red-01" className="mt-3">
+          {error}
+        </Text>
+      )}
+
+      <div className="mt-4 flex justify-end gap-2">
+        <Button type="button" variant="secondary" onClick={onCancel} disabled={submitting}>
+          Cancel
+        </Button>
+        <Button type="submit" disabled={!canSubmit}>
+          {submitting ? 'Creating…' : 'Create claim'}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/apps/web/core/debates/create-claim/create-debate-claim-form.tsx
+++ b/apps/web/core/debates/create-claim/create-debate-claim-form.tsx
@@ -13,6 +13,8 @@ import { Text } from '~/design-system/text';
 import { HubFilterMenu, type HubFilterOption } from '../matchmaking/hub-filter-menu';
 import { usePublishDebateClaim } from './use-publish-debate-claim';
 
+const PENDING_ROW_COUNT = 3;
+
 export type CreateDebateClaimResult = {
   claimId: string;
   spaceId: string;
@@ -33,10 +35,15 @@ type Props = {
 export function CreateDebateClaimForm({ candidateSpaceIds, defaultSpaceId, onCreated, onCancel }: Props) {
   const { publishClaim } = usePublishDebateClaim();
 
+  const candidatesPending = candidateSpaceIds == null;
   const candidates = React.useMemo(() => candidateSpaceIds ?? [], [candidateSpaceIds]);
-  const { canCreateInSpace, isResolved: creatableResolved } = useCreatableSpaceIds(candidates, true);
+  const {
+    canCreateInSpace,
+    isResolved: creatableResolved,
+    isLoading: creatableLoading,
+  } = useCreatableSpaceIds(candidates, !candidatesPending);
   const creatableSpaceIds = React.useMemo(() => candidates.filter(canCreateInSpace), [candidates, canCreateInSpace]);
-  const { labelsById } = useSpaceLabels(creatableSpaceIds);
+  const { labelsById, isLoading: labelsLoading } = useSpaceLabels(creatableSpaceIds);
 
   const [claimText, setClaimText] = React.useState('');
   const [spaceId, setSpaceId] = React.useState<string | null>(null);
@@ -51,14 +58,29 @@ export function CreateDebateClaimForm({ candidateSpaceIds, defaultSpaceId, onCre
     setSpaceId(preferred);
   }, [creatableSpaceIds, defaultSpaceId, spaceId]);
 
-  const spaceOptions = React.useMemo<HubFilterOption<string>[]>(
-    () =>
-      creatableSpaceIds.map(id => {
-        const label = spaceLabel(labelsById, id);
-        return { value: id, label: label?.name ?? 'Space', image: label?.image ?? null };
-      }),
-    [creatableSpaceIds, labelsById]
-  );
+  const spacesLoading = candidatesPending || creatableLoading || (candidates.length > 0 && !creatableResolved);
+
+  const spaceOptions = React.useMemo<HubFilterOption<string>[]>(() => {
+    if (spacesLoading) {
+      const count = candidatesPending ? PENDING_ROW_COUNT : Math.min(Math.max(candidates.length, 1), PENDING_ROW_COUNT);
+      return Array.from({ length: count }, (_, index) => ({
+        value: `__pending-${index}`,
+        label: '',
+        pending: true,
+      }));
+    }
+    return creatableSpaceIds.map(id => {
+      const label = spaceLabel(labelsById, id);
+      return {
+        value: id,
+        label: label?.name ?? 'Space',
+        image: label?.image ?? null,
+        pending: labelsLoading && !label,
+      };
+    });
+  }, [candidates.length, candidatesPending, creatableSpaceIds, labelsById, labelsLoading, spacesLoading]);
+
+  const selectedLabelPending = spacesLoading || (Boolean(spaceId) && labelsLoading && !spaceLabel(labelsById, spaceId));
 
   const addTopic = (selection: SelectEntityCompactResult) =>
     setTopics(current => (current.some(topic => topic.id === selection.id) ? current : [...current, selection]));
@@ -83,8 +105,9 @@ export function CreateDebateClaimForm({ candidateSpaceIds, defaultSpaceId, onCre
     }
   };
 
-  // No creatable space among the candidates — say so instead of an empty dropdown.
-  const noCreatableSpaces = candidates.length === 0 || (creatableResolved && creatableSpaceIds.length === 0);
+  // Only after both the candidate set and the access check have settled.
+  const noCreatableSpaces =
+    !candidatesPending && (candidates.length === 0 || (creatableResolved && creatableSpaceIds.length === 0));
 
   return (
     <form onSubmit={handleSubmit} className="rounded-lg border border-grey-02 bg-white p-4 shadow-light">
@@ -119,6 +142,9 @@ export function CreateDebateClaimForm({ candidateSpaceIds, defaultSpaceId, onCre
               options={spaceOptions}
               value={spaceId ?? ''}
               onChange={setSpaceId}
+              labelPending={selectedLabelPending}
+              showImages
+              viewportClassName="w-full max-h-[180px] min-h-0 min-w-0 overflow-y-auto overscroll-contain scroll-smooth bg-white [background-clip:padding-box]"
             />
           )}
         </div>

--- a/apps/web/core/debates/create-claim/find-existing-claim.ts
+++ b/apps/web/core/debates/create-claim/find-existing-claim.ts
@@ -1,0 +1,73 @@
+import type { TypedDocumentNode } from '@graphql-typed-document-node/core';
+
+import { Effect } from 'effect';
+import { parse } from 'graphql';
+
+import { CLAIM_TYPE_ID } from '~/core/claims/ontology';
+import { ID } from '~/core/id';
+import { graphql } from '~/core/io/graphql-client';
+
+/**
+ * Duplicate protection for the debates create-claim flow: does a Claim with this exact text already
+ * exist in this space?
+ *
+ * `includesInsensitive` narrows on the server — an exact-equality name filter is not exposed, and a
+ * substring match of the whole text is a superset of the exact one — and the normalized comparison
+ * below confirms it, so a claim that merely *contains* the typed text is not treated as the same
+ * claim. Scoped to the target space client-side off each row's `spaceIds`, because a claim of the
+ * same text living only in another space is not this space's duplicate (a claim is created per
+ * space here).
+ */
+const EXISTING_CLAIM_SOURCE = /* GraphQL */ `
+  query ExistingDebateClaim($claimTypeId: UUID!, $text: String!) {
+    entitiesConnection(first: 100, typeId: $claimTypeId, filter: { name: { includesInsensitive: $text } }) {
+      nodes {
+        id
+        name
+        spaceIds
+      }
+    }
+  }
+`;
+
+type ExistingClaimQuery = {
+  entitiesConnection: {
+    nodes: Array<{ id: string; name: string | null; spaceIds: string[] | null } | null> | null;
+  } | null;
+};
+
+type ExistingClaimVariables = { claimTypeId: string; text: string };
+
+const existingClaimDocument = parse(EXISTING_CLAIM_SOURCE) as TypedDocumentNode<
+  ExistingClaimQuery,
+  ExistingClaimVariables
+>;
+
+/** Trim and case-fold so "  Ban cars  " and "ban cars" are the same claim. */
+function normalizeClaimText(text: string): string {
+  return text.trim().replace(/\s+/g, ' ').toLowerCase();
+}
+
+export function findExistingClaimInSpace(spaceId: string, text: string, signal?: AbortSignal): Promise<string | null> {
+  const trimmed = text.trim();
+  if (trimmed.length === 0) return Promise.resolve(null);
+
+  return Effect.runPromise(
+    graphql({
+      query: existingClaimDocument,
+      decoder: (data: ExistingClaimQuery) => {
+        const nodes = data.entitiesConnection?.nodes ?? [];
+        const normalizedTarget = normalizeClaimText(trimmed);
+        for (const node of nodes) {
+          if (!node?.name) continue;
+          if (normalizeClaimText(node.name) !== normalizedTarget) continue;
+          if (!(node.spaceIds ?? []).some(id => ID.equals(id, spaceId))) continue;
+          return node.id;
+        }
+        return null;
+      },
+      variables: { claimTypeId: CLAIM_TYPE_ID, text: trimmed },
+      signal,
+    })
+  );
+}

--- a/apps/web/core/debates/create-claim/pending-claim-card.tsx
+++ b/apps/web/core/debates/create-claim/pending-claim-card.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import * as React from 'react';
+
+import { SmallButton } from '~/design-system/button';
+import { Text } from '~/design-system/text';
+
+import type { DebateClaimSummary, MatchmakingReadiness } from '../api';
+import { MatchmakingClaimCard } from '../matchmaking/matchmaking-claim-card';
+import type { PendingDebateClaim } from '~/atoms/debate-create-claim';
+
+/**
+ * The optimistic row for a claim the viewer just created inline, shown until the real list has it.
+ *
+ * It is the ordinary claim card, deliberately — a just-made claim should look like it belongs where
+ * it was made — held in a non-interactive "publishing" state. `answersReady={false}` and a
+ * `responseBlockedReason` gate the position pills together: taking a position is itself a graph
+ * publish geo-chat only learns about after indexing, so the creator (the very person here) must not
+ * be able to take one on a claim geo-chat cannot resolve yet and have it rejected as
+ * `claim_not_supported`. `hideEndSlot` drops the Request-debate offer for the same window and, as a
+ * side effect, disables the match/summary reads the card would otherwise make against an id the
+ * graph has never seen.
+ */
+export function PendingClaimCard({ claim, onDismiss }: { claim: PendingDebateClaim; onDismiss: () => void }) {
+  const summary: DebateClaimSummary = {
+    id: claim.claimId,
+    space_id: claim.spaceId,
+    claim_entity_id: claim.claimId,
+    claim: claim.text,
+    description: null,
+  };
+
+  // Stance vocabulary: the claim is created without an `Is factual` value, so its sides read
+  // Agree/Disagree — the same default the debates surfaces resolve for it.
+  const readiness: MatchmakingReadiness = {
+    response_kind: 'stance',
+    viewer_response: null,
+    viewer_debate_ready: false,
+    readiness_disabled_reason: null,
+  };
+
+  const blockedReason = claim.status === 'publishing' ? 'Publishing this claim…' : 'Finishing up…';
+  const indexed = claim.status === 'indexed';
+
+  return (
+    <MatchmakingClaimCard
+      claim={summary}
+      positions={[]}
+      readiness={readiness}
+      answersReady={false}
+      responseBlockedReason={blockedReason}
+      hideEndSlot
+      // A no-op opener rather than a link: the entity page has nothing to show until the claim
+      // indexes, so a click through to it would land on an empty page.
+      onOpenClaim={() => {}}
+      footer={
+        <div className="mt-3 flex items-center gap-2 border-t border-divider pt-3">
+          <span aria-hidden className="size-1.5 shrink-0 animate-pulse rounded-full bg-grey-03" />
+          <Text as="span" variant="footnote" color="grey-04" className="min-w-0 flex-1">
+            {claim.status === 'publishing'
+              ? 'Publishing — this claim will be ready to debate once it’s indexed.'
+              : 'Published — finishing up, this claim will be ready to debate shortly.'}
+          </Text>
+          {indexed ? (
+            <SmallButton type="button" variant="secondary" onClick={onDismiss}>
+              Dismiss
+            </SmallButton>
+          ) : null}
+        </div>
+      }
+    />
+  );
+}

--- a/apps/web/core/debates/create-claim/use-pending-debate-claims.ts
+++ b/apps/web/core/debates/create-claim/use-pending-debate-claims.ts
@@ -1,0 +1,134 @@
+'use client';
+
+import { useQueries, useQueryClient } from '@tanstack/react-query';
+
+import * as React from 'react';
+
+import { useAtom } from 'jotai';
+
+import type { ClaimDraftSelection } from '~/core/claims/claim-draft';
+import { fetchClaimPickerEntities } from '~/core/debates/claim-picker-page';
+import { debateQueryKeys, useGeoChatAuth } from '~/core/debates/hooks';
+
+import { pendingDebateClaimsAtom } from '~/atoms/debate-create-claim';
+
+/** How often the graph is polled for a just-published claim, until it resolves. */
+const INDEXING_POLL_INTERVAL_MS = 4_000;
+
+const INDEXED_DISMISS_GRACE_MS = 12_000;
+
+/**
+ * The inline-created claims that have not yet indexed, and the controls to manage them.
+ *
+ * Also runs the indexing watch: each still-`publishing` claim is polled on the graph (the same
+ * projection the rematch picker reads) and flipped to `indexed` the first time it resolves. React
+ * Query dedupes by key, so mounting this hook from more than one place on a page polls each claim
+ * once, not once per caller.
+ *
+ * A claim stays in the list after it indexes — the caller keeps showing it selected until the real
+ * list it belongs to has caught up and taken over — and is removed by `dismissPendingClaim`. If the
+ * filtered list never includes it, a grace timeout dismisses it after indexing so it cannot stick.
+ */
+export function usePendingDebateClaims() {
+  const queryClient = useQueryClient();
+  const { accountKey } = useGeoChatAuth();
+  const [pendingClaims, setPendingClaims] = useAtom(pendingDebateClaimsAtom);
+  // Which claims this hook has already reacted to indexing for, so the invalidation below fires once
+  // per claim rather than on every poll after it resolves.
+  const flipped = React.useRef(new Set<string>());
+  const indexedDismissTimers = React.useRef(new Map<string, ReturnType<typeof setTimeout>>());
+
+  const addPendingClaim = React.useCallback(
+    (claim: { claimId: string; spaceId: string; text: string; topics: ClaimDraftSelection[] }) => {
+      setPendingClaims(current => {
+        if (current.some(existing => existing.claimId === claim.claimId)) return current;
+        return [...current, { ...claim, status: 'publishing' as const }];
+      });
+    },
+    [setPendingClaims]
+  );
+
+  const dismissPendingClaim = React.useCallback(
+    (claimId: string) => {
+      const timer = indexedDismissTimers.current.get(claimId);
+      if (timer) {
+        clearTimeout(timer);
+        indexedDismissTimers.current.delete(claimId);
+      }
+      setPendingClaims(current => current.filter(claim => claim.claimId !== claimId));
+    },
+    [setPendingClaims]
+  );
+
+  const markIndexed = React.useCallback(
+    (claimId: string) =>
+      setPendingClaims(current =>
+        current.map(claim => (claim.claimId === claimId ? { ...claim, status: 'indexed' as const } : claim))
+      ),
+    [setPendingClaims]
+  );
+
+  const watching = React.useMemo(() => pendingClaims.filter(claim => claim.status === 'publishing'), [pendingClaims]);
+
+  const indexingResults = useQueries({
+    queries: watching.map(claim => ({
+      queryKey: ['debate-create-claim', 'indexing', claim.claimId] as const,
+      queryFn: async ({ signal }: { signal?: AbortSignal }) => {
+        const entities = await fetchClaimPickerEntities([claim.claimId], signal);
+        // Resolved as a Claim in the graph — the query filters on the Claim type — means the debates
+        // lists can see it now. Report the id so the effect below can flip it.
+        return entities.length > 0 ? claim.claimId : null;
+      },
+      // Poll until it resolves; once found the row leaves `watching` and the query unmounts.
+      refetchInterval: INDEXING_POLL_INTERVAL_MS,
+      staleTime: 0,
+    })),
+  });
+
+  React.useEffect(() => {
+    for (const result of indexingResults) {
+      const claimId = result.data;
+      if (!claimId || flipped.current.has(claimId)) continue;
+      flipped.current.add(claimId);
+      markIndexed(claimId);
+      // Graph-sourced lists read `['tagged-claims', …]`; mine / debate_now read matchmaking-claims.
+      void queryClient.invalidateQueries({ queryKey: ['tagged-claims'] });
+      void queryClient.invalidateQueries({ queryKey: debateQueryKeys.matchmakingClaimsRoot(accountKey) });
+    }
+  }, [accountKey, indexingResults, markIndexed, queryClient]);
+
+  // Grace-dismiss indexed cards the filtered list never absorbs. Driven off `pendingClaims` status
+  // rather than the flip moment
+  React.useEffect(() => {
+    const timers = indexedDismissTimers.current;
+    const pendingIds = new Set(pendingClaims.map(claim => claim.claimId));
+
+    for (const claim of pendingClaims) {
+      if (claim.status !== 'indexed') continue;
+      if (timers.has(claim.claimId)) continue;
+      timers.set(
+        claim.claimId,
+        setTimeout(() => {
+          timers.delete(claim.claimId);
+          dismissPendingClaim(claim.claimId);
+        }, INDEXED_DISMISS_GRACE_MS)
+      );
+    }
+
+    for (const [claimId, timer] of timers) {
+      if (pendingIds.has(claimId)) continue;
+      clearTimeout(timer);
+      timers.delete(claimId);
+    }
+  }, [dismissPendingClaim, pendingClaims]);
+
+  React.useEffect(() => {
+    const timers = indexedDismissTimers.current;
+    return () => {
+      for (const timer of timers.values()) clearTimeout(timer);
+      timers.clear();
+    };
+  }, []);
+
+  return { pendingClaims, addPendingClaim, dismissPendingClaim };
+}

--- a/apps/web/core/debates/create-claim/use-publish-debate-claim.ts
+++ b/apps/web/core/debates/create-claim/use-publish-debate-claim.ts
@@ -1,0 +1,98 @@
+'use client';
+
+import { SystemIds } from '@geoprotocol/geo-sdk/lite';
+
+import * as React from 'react';
+
+import { type ClaimDraftSelection, buildClaimDraft } from '~/core/claims/claim-draft';
+import { DEBATE_TAG_ID } from '~/core/debates/ontology';
+import { usePublish } from '~/core/hooks/use-publish';
+import { ID } from '~/core/id';
+import type { Value } from '~/core/types';
+
+import { findExistingClaimInSpace } from './find-existing-claim';
+import { usePendingDebateClaims } from './use-pending-debate-claims';
+
+export type PublishDebateClaimInput = {
+  spaceId: string;
+  claimText: string;
+  topics?: ClaimDraftSelection[];
+};
+
+export type PublishDebateClaimResult = {
+  claimId: string;
+  alreadyExisted: boolean;
+};
+
+function claimEditName(claimText: string): string {
+  const trimmed = claimText.trim();
+  return trimmed.length > 80 ? `Claim: ${trimmed.slice(0, 77)}…` : `Claim: ${trimmed}`;
+}
+
+/**
+ * Creates a debate claim and posts it directly to the selected space - no review-edits flow.
+ *
+ * The Claim has Claim Type, the claim text as name and the Debate tag (required: it is what
+ * makes the claim visible to the debates surfaces, which query the graph by that tag) and any selected
+ * subjects. `is factual` is not written intentionally. So, the claim reads Agree/Disagree.
+ */
+export function usePublishDebateClaim() {
+  const { makeProposal } = usePublish();
+  const { addPendingClaim, dismissPendingClaim } = usePendingDebateClaims();
+
+  const publishClaim = React.useCallback(
+    async (
+      input: PublishDebateClaimInput,
+      callbacks?: { onSuccess?: () => void; onError?: () => void }
+    ): Promise<PublishDebateClaimResult> => {
+      const { spaceId, claimText, topics } = input;
+      const trimmedText = claimText.trim();
+
+      try {
+        const existingId = await findExistingClaimInSpace(spaceId, claimText);
+        if (existingId) {
+          callbacks?.onSuccess?.();
+          return { claimId: existingId, alreadyExisted: true };
+        }
+      } catch {
+        // fall through to creation
+      }
+
+      const topicSelections = topics ?? [];
+      const draft = buildClaimDraft({
+        spaceId,
+        claimText,
+        topics: topicSelections,
+        tags: [{ id: DEBATE_TAG_ID, name: 'Debate' }],
+      });
+
+      const values: Value[] = draft.names.map(name => ({
+        id: ID.createEntityId(),
+        entity: { id: name.entityId, name: name.value },
+        property: { id: SystemIds.NAME_PROPERTY, name: 'Name', dataType: 'TEXT' },
+        value: name.value,
+        spaceId: name.spaceId,
+      }));
+
+      addPendingClaim({ claimId: draft.claimId, spaceId, text: trimmedText, topics: topicSelections });
+
+      void makeProposal({
+        values,
+        relations: draft.relations,
+        spaceId,
+        name: claimEditName(claimText),
+        votingMode: 'FAST',
+        onSuccess: callbacks?.onSuccess,
+        onError: () => {
+          dismissPendingClaim(draft.claimId);
+          callbacks?.onError?.();
+        },
+      });
+
+      return { claimId: draft.claimId, alreadyExisted: false };
+    },
+    [addPendingClaim, dismissPendingClaim, makeProposal]
+  );
+
+  return { publishClaim };
+}

--- a/apps/web/core/debates/matchmaking/claims-tab.tsx
+++ b/apps/web/core/debates/matchmaking/claims-tab.tsx
@@ -662,7 +662,7 @@ export function ClaimsTab() {
       <div className="flex flex-col gap-3 px-4 py-3">
         {creatingClaim ? (
           <CreateDebateClaimForm
-            candidateSpaceIds={eligibleSpaceIds}
+            candidateSpaceIds={spacesPending ? null : eligibleSpaceIds}
             defaultSpaceId={spaceIds[0] ?? null}
             onCreated={({ spaceId }) => {
               setCreatingClaim(false);

--- a/apps/web/core/debates/matchmaking/claims-tab.tsx
+++ b/apps/web/core/debates/matchmaking/claims-tab.tsx
@@ -17,6 +17,8 @@ import { ID } from '~/core/id';
 import { responsePositionLabel } from '~/core/responses/entity-response';
 import { validateEntityId } from '~/core/utils/utils';
 
+import { Button } from '~/design-system/button';
+import { Plus } from '~/design-system/icons/plus';
 import { Input } from '~/design-system/input';
 
 import type {
@@ -27,6 +29,9 @@ import type {
   MatchmakingClaimsQuery,
 } from '../api';
 import { eligibleClaimSpaceIds, isClaimSpaceAllowed } from '../claim-space-allowlist';
+import { CreateDebateClaimForm } from '../create-claim/create-debate-claim-form';
+import { PendingClaimCard } from '../create-claim/pending-claim-card';
+import { usePendingDebateClaims } from '../create-claim/use-pending-debate-claims';
 import { useDebateActivity, useDebateClaimsBySpaces, useGeoChatAuth } from '../hooks';
 import {
   type TaggedClaim,
@@ -175,6 +180,7 @@ export function ClaimsTab() {
   const [spaceIds, setSpaceIds] = useAtom(debatesHubClaimsSpaceIdsAtom);
   const [topicIds, setTopicIds] = useAtom(debatesHubClaimsTopicIdsAtom);
   const [spaceSeedSpent, setSpaceSeedSpent] = useAtom(debatesHubClaimsSpaceSeedSpentAtom);
+  const [creatingClaim, setCreatingClaim] = React.useState(false);
 
   const {
     allowlist: spaceAllowlist,
@@ -514,6 +520,26 @@ export function ClaimsTab() {
   // Nothing left to filter here: both lists are narrowed by their server now.
   const visibleClaims = claims;
 
+  // Claims the viewer just created inline, held as optimistic "publishing" rows until the graph has
+  // them. Pinned above the list regardless of the active filters
+  const { pendingClaims, dismissPendingClaim } = usePendingDebateClaims();
+  const listedClaimId = React.useCallback(
+    (claimId: string) => visibleClaims.some(entry => ID.equals(entry.claim.claim_entity_id, claimId)),
+    [visibleClaims]
+  );
+  const pinnedPendingClaims = React.useMemo(
+    () => pendingClaims.filter(claim => !listedClaimId(claim.claimId)),
+    [pendingClaims, listedClaimId]
+  );
+  React.useEffect(() => {
+    for (const claim of pendingClaims) {
+      if (listedClaimId(claim.claimId)) dismissPendingClaim(claim.claimId);
+    }
+  }, [pendingClaims, listedClaimId, dismissPendingClaim]);
+
+  // Signed-out visitors can't publish, so the button prompts sign-in the same way the pills do.
+  const onNewClaim = onRequireSignIn ? onRequireSignIn : () => setCreatingClaim(true);
+
   // The topic menu, from the server's count over the tag. It describes every claim the current
   // filters allow rather than the pages loaded so far — which is what a client-side version could
   // never do: it read topics off the loaded claims, so the menu grew as the viewer scrolled and a
@@ -634,6 +660,40 @@ export function ClaimsTab() {
       </HubStickyControls>
 
       <div className="flex flex-col gap-3 px-4 py-3">
+        {creatingClaim ? (
+          <CreateDebateClaimForm
+            candidateSpaceIds={eligibleSpaceIds}
+            defaultSpaceId={spaceIds[0] ?? null}
+            onCreated={({ spaceId }) => {
+              setCreatingClaim(false);
+              setSearch('');
+              setTopicIds([]);
+              setSpaceIds(current =>
+                current.length === 0 || current.includes(spaceId) ? current : [...current, spaceId]
+              );
+            }}
+            onCancel={() => setCreatingClaim(false)}
+          />
+        ) : (
+          <div className="flex justify-end">
+            <Button type="button" variant="secondary" icon={<Plus />} onClick={onNewClaim}>
+              New claim
+            </Button>
+          </div>
+        )}
+
+        {pinnedPendingClaims.length > 0 ? (
+          <HubCardList>
+            {pinnedPendingClaims.map(claim => (
+              <PendingClaimCard
+                key={claim.claimId}
+                claim={claim}
+                onDismiss={() => dismissPendingClaim(claim.claimId)}
+              />
+            ))}
+          </HubCardList>
+        ) : null}
+
         <HubQueryState
           isLoading={spacesPending || (graphSourced ? taggedLoading : claimsQuery.isLoading)}
           // The catalog only. It is the list — without it there is nothing to show, and an error is

--- a/apps/web/core/debates/matchmaking/hub-filter-menu.tsx
+++ b/apps/web/core/debates/matchmaking/hub-filter-menu.tsx
@@ -33,6 +33,7 @@ type Props<T extends string> = {
   showImages?: boolean;
   /** As {@link HubFilterOption.pending}, for the name in the trigger pill. */
   labelPending?: boolean;
+  viewportClassName?: string;
 };
 
 /**
@@ -50,6 +51,7 @@ export function HubFilterMenu<T extends string>({
   onChange,
   showImages,
   labelPending,
+  viewportClassName,
 }: Props<T>) {
   const [open, setOpen] = React.useState(false);
 
@@ -59,6 +61,7 @@ export function HubFilterMenu<T extends string>({
       onOpenChange={setOpen}
       asChild
       className="max-w-[280px]"
+      viewportClassName={viewportClassName}
       // Space names come from the knowledge graph and can be long enough to burst the pill.
       trigger={
         <SmallButton icon={<ChevronDownSmall />} className="max-w-[160px]">

--- a/apps/web/core/hooks/use-creatable-space-ids.ts
+++ b/apps/web/core/hooks/use-creatable-space-ids.ts
@@ -56,7 +56,8 @@ export function useCreatableSpaceIds(spaceIds: string[], enabled: boolean) {
     [spaceIds]
   );
 
-  const canLoad = enabled && hydrated && Boolean(personalSpaceId) && spaceIdsKey.length > 0;
+  const hasSpaceIds = spaceIdsKey.length > 0;
+  const canLoad = enabled && hydrated && Boolean(personalSpaceId) && hasSpaceIds;
 
   const query = useQuery({
     queryKey: ['creatable-space-ids', personalSpaceId, spaceIdsKey],
@@ -73,9 +74,20 @@ export function useCreatableSpaceIds(spaceIds: string[], enabled: boolean) {
     [query.data, query.isSuccess]
   );
 
+  // Settled once we have an answer, know we cannot ask (no personal space), or there is nothing to ask.
+  const isResolved =
+    !enabled ||
+    !hasSpaceIds ||
+    query.isSuccess ||
+    query.isError ||
+    (hydrated && !isLoadingPersonalSpaceId && !personalSpaceId);
+
+  const isLoading =
+    enabled && hasSpaceIds && hydrated && !isResolved && (isLoadingPersonalSpaceId || Boolean(personalSpaceId));
+
   return {
     canCreateInSpace,
-    isLoading: canLoad && (query.isLoading || isLoadingPersonalSpaceId),
-    isResolved: query.isSuccess,
+    isLoading,
+    isResolved,
   };
 }


### PR DESCRIPTION
feat: Add a "New claim" affordance to the debates Claims tab and rematch picker, allowing a viewer to create and publish a claim without leaving the surface, then debate/rematch on it once it indexes.

Work:
- New create-claim form (text + space + optional topics) - Directly publishes to a creatable space via a FAST proposal, no reviewed-edits flow.
    The claim has the Debate tag so the debates surfaces can see it and omits `Is factual` so it reads Agree/Disagree.
  - Optimistic "publishing" row (jotai atom + usePendingDebateClaims) pinned above the list until the graph indexes the claim; polls the claim-picker projection and invalidates both tagged-claims and matchmaking-claims so the real list takes over.
  - Per space duplicate protection: if a claim already exists in the space, an identical claim is surfaced instead of a second claim being created (fails open on a graph blip).
  - Stuck pending card? Reset search/topic filters, broaden the space filter on create, grace-dismiss an indexed card the filtered list never absorbs, provide a manual Dismiss.