### PR TITLE
fix(analytics): preserve accurate vote and ranking outcomes

### DIFF
--- a/apps/web/core/analytics-operations.test.ts
+++ b/apps/web/core/analytics-operations.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { classifyOperationFailure, observeOperation } from './analytics-operations';
+import { ReceiptConfirmationTimeoutError } from './errors';
 
 const { capture, revision } = vi.hoisted(() => ({ capture: vi.fn(), revision: vi.fn(() => 0) }));
 vi.mock('./analytics', () => ({ capture, analyticsContextRevision: revision }));
@@ -48,18 +49,27 @@ describe('operation evidence', () => {
 });
 
 describe('operation failure classification', () => {
+  it('keeps a submitted operation unknown when its receipt query was rejected', () => {
+    const receipt = new ReceiptConfirmationTimeoutError('Receipt unavailable', { cause: { code: 4001 } });
+    expect(classifyOperationFailure(receipt)).toBe('unknown');
+    expect(classifyOperationFailure(new Error('User rejected receipt request', { cause: receipt }))).toBe('unknown');
+  });
   it('recognizes wrapped wallet rejection', () => {
     expect(classifyOperationFailure(new Error('Transaction failed', { cause: { code: 4001 } }))).toBe('rejected');
-    expect(classifyOperationFailure(new Error('Transaction failed', { cause: new Error('User rejected the request.') }))).toBe('rejected');
+    expect(
+      classifyOperationFailure(new Error('Transaction failed', { cause: new Error('User rejected the request.') }))
+    ).toBe('rejected');
   });
   it('distinguishes an unsent queue timeout from an uncertain submitted transaction', () => {
-    const queued = new Error('never submitted'); queued.name = 'QueuedSendTimeoutError';
+    const queued = new Error('never submitted');
+    queued.name = 'QueuedSendTimeoutError';
     expect(classifyOperationFailure(new Error('Transaction failed', { cause: queued }))).toBe('unavailable');
     expect(classifyOperationFailure(new Error('receipt timeout'))).toBe('unknown');
     expect(classifyOperationFailure(new Error('network unavailable'))).toBe('unknown');
   });
   it('bounds cyclic causes and handles non-errors conservatively', () => {
-    const cycle: { cause?: unknown } = {}; cycle.cause = cycle;
+    const cycle: { cause?: unknown } = {};
+    cycle.cause = cycle;
     expect(classifyOperationFailure(cycle)).toBe('unknown');
     expect(classifyOperationFailure(null)).toBe('unknown');
   });

--- a/apps/web/core/analytics-operations.test.ts
+++ b/apps/web/core/analytics-operations.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { observeOperation } from './analytics-operations';
+import { classifyOperationFailure, observeOperation } from './analytics-operations';
 
 const { capture, revision } = vi.hoisted(() => ({ capture: vi.fn(), revision: vi.fn(() => 0) }));
 vi.mock('./analytics', () => ({ capture, analyticsContextRevision: revision }));
@@ -44,5 +44,23 @@ describe('operation evidence', () => {
     revision.mockReturnValue(1);
     operation.outcome('vote_cast', 'indexed', {});
     expect(capture).not.toHaveBeenCalled();
+  });
+});
+
+describe('operation failure classification', () => {
+  it('recognizes wrapped wallet rejection', () => {
+    expect(classifyOperationFailure(new Error('Transaction failed', { cause: { code: 4001 } }))).toBe('rejected');
+    expect(classifyOperationFailure(new Error('Transaction failed', { cause: new Error('User rejected the request.') }))).toBe('rejected');
+  });
+  it('distinguishes an unsent queue timeout from an uncertain submitted transaction', () => {
+    const queued = new Error('never submitted'); queued.name = 'QueuedSendTimeoutError';
+    expect(classifyOperationFailure(new Error('Transaction failed', { cause: queued }))).toBe('unavailable');
+    expect(classifyOperationFailure(new Error('receipt timeout'))).toBe('unknown');
+    expect(classifyOperationFailure(new Error('network unavailable'))).toBe('unknown');
+  });
+  it('bounds cyclic causes and handles non-errors conservatively', () => {
+    const cycle: { cause?: unknown } = {}; cycle.cause = cycle;
+    expect(classifyOperationFailure(cycle)).toBe('unknown');
+    expect(classifyOperationFailure(null)).toBe('unknown');
   });
 });

--- a/apps/web/core/analytics-operations.ts
+++ b/apps/web/core/analytics-operations.ts
@@ -1,5 +1,23 @@
 import { analyticsContextRevision, capture } from './analytics';
 
+/** Only classify outcomes that prove the action did not execute. Network and
+ * receipt timeouts remain unknown: retrying those could duplicate a landed write.
+ * Emit an allowlisted category, never the provider message or request payload.
+ */
+export function classifyOperationFailure(error: unknown): 'rejected' | 'unavailable' | 'unknown' {
+  for (let current = error, depth = 0; current != null && depth < 10; depth++) {
+    if (typeof current !== 'object') break;
+    const failure = current as { code?: unknown; cause?: unknown };
+    if (failure.code === 4001) return 'rejected';
+    if (current instanceof Error) {
+      if (current.name === 'QueuedSendTimeoutError') return 'unavailable';
+      if (/user rejected/i.test(current.message)) return 'rejected';
+    }
+    current = failure.cause;
+  }
+  return 'unknown';
+}
+
 export type OperationContext = { opportunity_id: string; presentation_instance_id: string };
 
 /** One logical client attempt; transport retries reuse the SDK's immutable event ID. */

--- a/apps/web/core/analytics-operations.ts
+++ b/apps/web/core/analytics-operations.ts
@@ -1,21 +1,26 @@
 import { analyticsContextRevision, capture } from './analytics';
+import { ReceiptConfirmationTimeoutError } from './errors';
 
 /** Only classify outcomes that prove the action did not execute. Network and
  * receipt timeouts remain unknown: retrying those could duplicate a landed write.
  * Emit an allowlisted category, never the provider message or request payload.
  */
 export function classifyOperationFailure(error: unknown): 'rejected' | 'unavailable' | 'unknown' {
+  let classification: 'rejected' | 'unavailable' | 'unknown' = 'unknown';
   for (let current = error, depth = 0; current != null && depth < 10; depth++) {
     if (typeof current !== 'object') break;
+    // A receipt query may itself be rejected. That does not undo the submission,
+    // even if a surrounding wrapper copied the cause's message or code.
+    if (current instanceof ReceiptConfirmationTimeoutError) return 'unknown';
     const failure = current as { code?: unknown; cause?: unknown };
-    if (failure.code === 4001) return 'rejected';
+    if (failure.code === 4001) classification = 'rejected';
     if (current instanceof Error) {
-      if (current.name === 'QueuedSendTimeoutError') return 'unavailable';
-      if (/user rejected/i.test(current.message)) return 'rejected';
+      if (current.name === 'QueuedSendTimeoutError') classification = 'unavailable';
+      if (/user rejected/i.test(current.message)) classification = 'rejected';
     }
     current = failure.cause;
   }
-  return 'unknown';
+  return classification;
 }
 
 export type OperationContext = { opportunity_id: string; presentation_instance_id: string };

--- a/apps/web/core/blocks/ranking/use-ranking-submissions-outcomes.test.tsx
+++ b/apps/web/core/blocks/ranking/use-ranking-submissions-outcomes.test.tsx
@@ -1,0 +1,85 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook } from '@testing-library/react';
+
+import type { ReactNode } from 'react';
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useRankingSubmissions } from './use-ranking-submissions';
+
+const mocks = vi.hoisted(() => ({
+  send: vi.fn(),
+  capture: vi.fn(),
+  publish: vi.fn(),
+  reportError: vi.fn(),
+}));
+const SPACE = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const BLOCK = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+const ITEM = 'cccccccccccccccccccccccccccccccc';
+
+vi.mock('~/core/analytics', () => ({ capture: mocks.capture, analyticsContextRevision: () => 0 }));
+vi.mock('~/core/hooks/use-smart-account', () => ({
+  useSmartAccount: () => ({ smartAccount: { account: { address: '0xabc' }, sendUserOperation: mocks.send } }),
+}));
+vi.mock('~/core/hooks/use-personal-space-id', () => ({
+  usePersonalSpaceId: () => ({ personalSpaceId: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' }),
+  personalSpaceIdQueryKey: (address: string) => ['personal-space', address],
+}));
+vi.mock('~/core/hooks/use-geo-profile', () => ({ useGeoProfile: () => ({ profile: null }) }));
+vi.mock('~/core/hooks/use-toast', () => ({ useToast: () => [null, vi.fn()] }));
+vi.mock('~/core/state/status-bar-store', () => ({ useReportError: () => mocks.reportError }));
+vi.mock('~/core/sdk/geo-client', () => ({ geo: { personalSpaces: { publishEdit: mocks.publish } } }));
+vi.mock('./use-my-ranking', () => ({
+  useMyRanking: () => ({ myRankEntity: null, orderedEntityIds: [], isLoading: false, refetchMyRanking: vi.fn() }),
+  recordPublishedRank: vi.fn(),
+}));
+vi.mock('./use-ranking-block-config', () => ({
+  useRankingBlockConfig: () => ({ isRolling: false, submissionFrequencyHours: null }),
+}));
+vi.mock('@geoprotocol/geo-sdk', async importOriginal => {
+  const actual = await importOriginal<typeof import('@geoprotocol/geo-sdk')>();
+  return {
+    ...actual,
+    Ops: {
+      ...actual.Ops,
+      ranks: { create: () => ({ id: 'dddddddddddddddddddddddddddddddd', ops: [{ op: 'noop' }] }) },
+    },
+  };
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.send.mockReset();
+  mocks.send.mockResolvedValue('0xhash');
+  mocks.publish.mockResolvedValue({ to: '0xabc', calldata: '0x01' });
+});
+
+describe('ranking submission outcomes', () => {
+  it.each([
+    ['uncertain response', new Error('Connection lost after sending'), 'action_outcome_unknown', 'unknown'],
+    ['wallet rejection', Object.assign(new Error('Request denied'), { code: 4001 }), 'action_failed', 'rejected'],
+  ])('does not resend after a %s', async (_label, error, event, failureCode) => {
+    mocks.send.mockRejectedValueOnce(error);
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    client.setQueryData(['personal-space', '0xabc'], { personalSpaceId: SPACE, isRegistered: true });
+    const view = renderHook(() => useRankingSubmissions(BLOCK, SPACE, 'Test ranking'), {
+      wrapper: ({ children }: { children: ReactNode }) => (
+        <QueryClientProvider client={client}>{children}</QueryClientProvider>
+      ),
+    });
+
+    await act(async () => {
+      expect(await view.result.current.saveMySubmission([{ id: ITEM, name: null, spaceId: SPACE }])).toBeNull();
+    });
+
+    expect(mocks.send).toHaveBeenCalledTimes(1);
+    expect(mocks.capture).toHaveBeenCalledWith(
+      event,
+      expect.objectContaining({ action_kind: 'ranking', failure_code: failureCode })
+    );
+    expect(mocks.capture.mock.calls.some(([name]) => name === 'ranking_submitted')).toBe(false);
+    expect(view.result.current.isSaving).toBe(false);
+    view.unmount();
+    client.clear();
+  });
+});

--- a/apps/web/core/blocks/ranking/use-ranking-submissions.ts
+++ b/apps/web/core/blocks/ranking/use-ranking-submissions.ts
@@ -7,7 +7,7 @@ import * as React from 'react';
 
 import { Duration, Effect, Either, Schedule } from 'effect';
 
-import { type OperationContext, observeOperation } from '~/core/analytics-operations';
+import { type OperationContext, classifyOperationFailure, observeOperation } from '~/core/analytics-operations';
 import { PLACEHOLDER_SPACE_IMAGE } from '~/core/constants';
 import { TransactionWriteFailedError } from '~/core/errors';
 import { readCachedPersonalSpace, readCachedSmartAccount } from '~/core/hooks/cached-write-identity';
@@ -302,7 +302,7 @@ export function useRankingSubmissions(blockId: string, spaceId: string, blockNam
 
         if (Either.isLeft(result)) {
           const err = result.left;
-          operation.failed(err instanceof Error && err.message.includes('User rejected') ? 'rejected' : 'unknown');
+          operation.failed(classifyOperationFailure(err));
           if (err instanceof Error && err.message.includes('User rejected')) {
             return null;
           }

--- a/apps/web/core/blocks/ranking/use-ranking-submissions.ts
+++ b/apps/web/core/blocks/ranking/use-ranking-submissions.ts
@@ -279,16 +279,15 @@ export function useRankingSubmissions(blockId: string, spaceId: string, blockNam
             retrySchedule('publishEdit', Duration.minutes(1))
           );
 
-          const txHash = yield* Effect.retry(
-            Effect.tryPromise({
-              try: () =>
-                account.sendUserOperation({
-                  calls: [{ to: result.to, value: 0n, data: result.calldata }],
-                }),
-              catch: error => new TransactionWriteFailedError('Transaction failed', { cause: error }),
-            }),
-            retrySchedule('sendUserOperation', Duration.seconds(10))
-          );
+          // Safe submission retries belong to the wallet. An uncertain response
+          // must not cause another ranking write here.
+          const txHash = yield* Effect.tryPromise({
+            try: () =>
+              account.sendUserOperation({
+                calls: [{ to: result.to, value: 0n, data: result.calldata }],
+              }),
+            catch: error => new TransactionWriteFailedError('Transaction failed', { cause: error }),
+          });
 
           return txHash;
         });

--- a/apps/web/core/debates/use-debate-votes.test.tsx
+++ b/apps/web/core/debates/use-debate-votes.test.tsx
@@ -422,6 +422,22 @@ describe('useDebateVotes castVote', () => {
     expect(publishAt(1).winnerCreates[0]?.toEntity.id).toBe(BOB_SPACE);
   });
 
+  it.each([
+    ['uncertain submission', new Error('Connection lost after sending'), 'action_outcome_unknown', 'unknown'],
+    ['wallet rejection', Object.assign(new Error('Request denied'), { code: 4001 }), 'action_failed', 'rejected'],
+  ])('does not repeat a %s at the voting layer', async (_label, error, event, failureCode) => {
+    mocks.sendUserOperation.mockRejectedValueOnce(error);
+    const view = await renderVotes();
+
+    await act(async () => {
+      await view.result.current.castVote(ALICE);
+    });
+
+    expect(mocks.sendUserOperation).toHaveBeenCalledTimes(1);
+    expect(mocks.capture).toHaveBeenCalledWith(event, expect.objectContaining({ failure_code: failureCode }));
+    expect(mocks.capture.mock.calls.some(([name]) => name === 'vote_cast')).toBe(false);
+  });
+
   it('restores the previous pick when a change fails to publish', async () => {
     mocks.voteEntities = [voteEntity('vote-1', ALICE_SPACE, 'winner-rel-1')];
     mocks.prepareFails = true;

--- a/apps/web/core/debates/use-debate-votes.tsx
+++ b/apps/web/core/debates/use-debate-votes.tsx
@@ -340,13 +340,12 @@ export function useDebateVotes(debate: Debate): DebateVotesResult {
           retrySchedule(Duration.minutes(1))
         );
 
-        return yield* Effect.retry(
-          Effect.tryPromise({
-            try: () => smartAccount.sendUserOperation({ calls: [{ to: result.to, value: 0n, data: result.calldata }] }),
-            catch: error => new TransactionWriteFailedError('Transaction failed', { cause: error }),
-          }),
-          retrySchedule(Duration.seconds(10))
-        );
+        // The wallet retries known pre-submission failures. Repeating this whole
+        // call after an uncertain response could submit the vote twice.
+        return yield* Effect.tryPromise({
+          try: () => smartAccount.sendUserOperation({ calls: [{ to: result.to, value: 0n, data: result.calldata }] }),
+          catch: error => new TransactionWriteFailedError('Transaction failed', { cause: error }),
+        });
       });
 
       try {

--- a/apps/web/core/debates/use-debate-votes.tsx
+++ b/apps/web/core/debates/use-debate-votes.tsx
@@ -8,7 +8,7 @@ import * as React from 'react';
 
 import { Duration, Effect, Either, Schedule } from 'effect';
 
-import { observeOperation } from '~/core/analytics-operations';
+import { classifyOperationFailure, observeOperation } from '~/core/analytics-operations';
 import type { Debate, DebateParticipant } from '~/core/debates/api';
 import { useGeoChatAuth } from '~/core/debates/hooks';
 import {
@@ -363,7 +363,7 @@ export function useDebateVotes(debate: Debate): DebateVotesResult {
           });
 
           const error = result.left;
-          operation.failed(error instanceof Error && error.message.includes('User rejected') ? 'rejected' : 'unknown');
+          operation.failed(classifyOperationFailure(error));
           if (error instanceof Error && error.message.includes('User rejected')) return;
 
           console.error('[useDebateVotes] Publish failed:', error);

--- a/apps/web/core/errors.ts
+++ b/apps/web/core/errors.ts
@@ -5,3 +5,8 @@ export class TransactionWriteFailedError extends Error {
 export class PrepareOpsError extends Error {
   readonly _tag = 'PrepareOpsError';
 }
+
+/** Submission succeeded; a receipt error cannot prove that the write failed. */
+export class ReceiptConfirmationTimeoutError extends Error {
+  override readonly name = 'ReceiptConfirmationTimeoutError';
+}

--- a/apps/web/core/hooks/use-entity-vote.test.tsx
+++ b/apps/web/core/hooks/use-entity-vote.test.tsx
@@ -473,10 +473,11 @@ describe('useEntityResponse indexing reconciliation', () => {
     await act(async () => Promise.resolve());
 
     await act(async () => {
-      secondTransaction.resolve({ _tag: 'Left', left: new Error('rejected') });
+      secondTransaction.resolve({ _tag: 'Left', left: new Error('Transaction failed', { cause: { code: 4001 } }) });
       await Promise.resolve();
       await Promise.resolve();
     });
+    expect(mocks.capture).toHaveBeenCalledWith('action_failed', expect.objectContaining({ failure_code: 'rejected', action_kind: 'vote' }));
     expect(result.current.indexingStatus).toBe('reconciling');
     expect(result.current.first.optimisticResponse).toBe('positive');
 

--- a/apps/web/core/hooks/use-entity-vote.test.tsx
+++ b/apps/web/core/hooks/use-entity-vote.test.tsx
@@ -145,7 +145,11 @@ describe('useEntityResponse indexing reconciliation', () => {
         ([name, properties]) => name === 'vote_cast' && properties.outcome_phase === 'submitted'
       );
       expect(votes).toHaveLength(1);
-      expect(mocks.capture.mock.calls.filter(([name, properties]) => name === 'vote_cast' && properties.outcome_phase === 'indexed')).toHaveLength(1);
+      expect(
+        mocks.capture.mock.calls.filter(
+          ([name, properties]) => name === 'vote_cast' && properties.outcome_phase === 'indexed'
+        )
+      ).toHaveLength(1);
       expect(votes[0][1]).toMatchObject({
         vote_direction: direction === 'positive' ? 'up' : direction === 'negative' ? 'down' : 'none',
         response_kind: 'curation',
@@ -477,7 +481,10 @@ describe('useEntityResponse indexing reconciliation', () => {
       await Promise.resolve();
       await Promise.resolve();
     });
-    expect(mocks.capture).toHaveBeenCalledWith('action_failed', expect.objectContaining({ failure_code: 'rejected', action_kind: 'vote' }));
+    expect(mocks.capture).toHaveBeenCalledWith(
+      'action_failed',
+      expect.objectContaining({ failure_code: 'rejected', action_kind: 'vote' })
+    );
     expect(result.current.indexingStatus).toBe('reconciling');
     expect(result.current.first.optimisticResponse).toBe('positive');
 

--- a/apps/web/core/hooks/use-entity-vote.ts
+++ b/apps/web/core/hooks/use-entity-vote.ts
@@ -7,7 +7,7 @@ import { useCallback, useEffect, useMemo, useRef, useSyncExternalStore } from 'r
 import { Effect, Either } from 'effect';
 
 import { ensureSpaceMembership } from '~/core/access/request-space-membership';
-import { observeOperation } from '~/core/analytics-operations';
+import { classifyOperationFailure, observeOperation } from '~/core/analytics-operations';
 import { usePersonalSpaceId } from '~/core/hooks/use-personal-space-id';
 import { useSmartAccountTransaction } from '~/core/hooks/use-smart-account-transaction';
 import {
@@ -544,7 +544,7 @@ export function useEntityResponse({ entityId, spaceId, responseKind }: UseEntity
     },
     onError: (_error, _direction, context) => {
       context?.operation.failed(
-        _error instanceof Error && _error.message.includes('User rejected') ? 'rejected' : 'unknown'
+        classifyOperationFailure(_error)
       );
       if (!context) return;
       const runs = responseIndexingRegistry.submissionRuns.get(indexingKeyId);

--- a/apps/web/core/hooks/use-entity-vote.ts
+++ b/apps/web/core/hooks/use-entity-vote.ts
@@ -543,9 +543,7 @@ export function useEntityResponse({ entityId, spaceId, responseKind }: UseEntity
       }
     },
     onError: (_error, _direction, context) => {
-      context?.operation.failed(
-        classifyOperationFailure(_error)
-      );
+      context?.operation.failed(classifyOperationFailure(_error));
       if (!context) return;
       const runs = responseIndexingRegistry.submissionRuns.get(indexingKeyId);
       const failedRun = runs?.get(context.runId);

--- a/apps/web/core/hooks/use-smart-account.ts
+++ b/apps/web/core/hooks/use-smart-account.ts
@@ -8,6 +8,7 @@ import { useQuery } from '@tanstack/react-query';
 import { useCookies } from 'react-cookie';
 
 import { Cookie, WALLET_ADDRESS } from '../cookie';
+import { ReceiptConfirmationTimeoutError } from '../errors';
 import { GEO_NETWORK } from '../sdk/geo-network';
 import { MAX_QUEUE_WAIT_MS, enqueueFor, withSubmissionRetry } from './smart-account-send-queue';
 
@@ -138,7 +139,7 @@ export function useSmartAccount() {
             }
             lastError = error;
             if (Date.now() - startedAt >= RECEIPT_DEADLINE_MS) {
-              throw new Error(
+              throw new ReceiptConfirmationTimeoutError(
                 `UserOperation ${hash} was submitted but its receipt did not arrive within ${
                   RECEIPT_DEADLINE_MS / 1000
                 }s. It may still land on-chain — do not resubmit blindly.`,


### PR DESCRIPTION
Votes and rankings now distinguish wallet cancellations from uncertain transaction outcomes, without automatically sending the same write again after an uncertain response. Safe pre-submission retries remain in the wallet layer; receipt-query failures cannot be misclassified as rejected writes.

This improves ongoing analytics diagnostics but does not retrospectively resolve previously recorded unknown operations. Regression tests reproduced duplicate sends before the fix; all 62 targeted tests now pass, alongside changed-file ESLint. No collector or database migration is required.
