### PR TITLE
perf(debates): read the browse ranking from the by-type connection (GEO-2793)

### DIFF
--- a/apps/web/core/debates/browse/debates-best-order-document.test.ts
+++ b/apps/web/core/debates/browse/debates-best-order-document.test.ts
@@ -42,9 +42,30 @@ function nodeFieldNames(doc: DocumentNode): string[] {
 
 describe('debatesBestOrderDocument', () => {
   // The whole point is that this is the same ranking the explore page sorts by, not a lookalike.
-  it('reads the same ranked connection the explore Best sort does', () => {
-    expect(rootField(debatesBestOrderDocument).name.value).toBe(rootField(exploreBestConnectionDocument).name.value);
-    expect(rootField(debatesBestOrderDocument).name.value).toBe('entitiesRankedForFeedConnection');
+  // It reads the by-type sibling rather than the connection explore uses: same function body and
+  // same `ranking_score DESC, entity_id DESC`, but the type predicate is planned as a semi-join
+  // instead of a filter on a ranked walk (GEO-2793). This document must filter by type, and that
+  // walk does not terminate for a type as rare as Debate; explore sends no `typeIds` at all, so
+  // the walk is the right plan there. Both names are asserted so a drift in either is caught.
+  it('reads the by-type ranked connection', () => {
+    expect(rootField(debatesBestOrderDocument).name.value).toBe('entitiesRankedForFeedByTypeConnection');
+  });
+
+  // Explore stays on the original connection. Note its *document* still declares and passes
+  // `typeIds` — it is `fetchBestEntitiesPage` that leaves the variable undefined at the call site
+  // (#2345), so the walk gets no type argument in practice. That is a runtime decision and cannot
+  // be asserted here; what this pins is that the two documents no longer read the same field.
+  it('reads a different connection from explore Best', () => {
+    expect(rootField(exploreBestConnectionDocument).name.value).toBe('entitiesRankedForFeedConnection');
+    expect(rootField(debatesBestOrderDocument).name.value).not.toBe(
+      rootField(exploreBestConnectionDocument).name.value
+    );
+  });
+
+  // The by-type connection matches nothing when `type_ids` is null, so omitting the argument here
+  // would silently empty the feed rather than fall back to an unfiltered ranking.
+  it('always sends typeIds, which the by-type connection requires to match anything', () => {
+    expect(argNames(rootField(debatesBestOrderDocument))).toContain('typeIds');
   });
 
   it('asks for ids alone — the feed already has the debates', () => {

--- a/apps/web/core/debates/browse/debates-best-order-document.ts
+++ b/apps/web/core/debates/browse/debates-best-order-document.ts
@@ -5,10 +5,22 @@ import { parse } from 'graphql';
 /**
  * The order the explore page's "Best" sort would put a space's debates in.
  *
- * Same source as that sort — `entities_ranked_for_feed`, ordered by the function's own
- * `ranking_score DESC, entity_id DESC` — narrowed to Debate-typed entities in one space. It asks
- * for ids alone: the feed already has every debate it needs from geo-chat and is only missing the
- * order to show them in.
+ * Same ranking as that sort — `ranking_score DESC, entity_id DESC` — narrowed to Debate-typed
+ * entities in one space. It asks for ids alone: the feed already has every debate it needs from
+ * geo-chat and is only missing the order to show them in.
+ *
+ * Reads `entitiesRankedForFeedByTypeConnection`, *not* the `entitiesRankedForFeedConnection` the
+ * explore document uses. Same ranking function body; the difference is how the type predicate is
+ * planned. The explore connection applies `type_ids` as a filter on a ranked index walk, so it has
+ * to descend until it has collected `first` matches — and Debate has ~65 members against 48.9M
+ * rows in `entity_ranking_scores`, so that walk crosses most of the table. The by-type connection
+ * gathers the typed set first (GEO-2793, gaia #925). Measured against testnet at this document's
+ * own `first: 100`, one space: **2.26s -> 0.33s**, identical rows.
+ *
+ * Explore's document stays on the original connection deliberately: it sends no `typeIds` at all
+ * (it filters the returned rows instead), and with no type argument the ranked walk is the right
+ * plan — 33ms. This one must keep passing `typeIds`; the by-type connection matches nothing
+ * without it.
  *
  * Deliberately no `filter`, no `totalCount` and no `orderBy`, for the reasons spelled out on
  * `exploreBestConnectionDocument` — the combination is what keeps this on the ranking index's fast
@@ -20,7 +32,7 @@ import { parse } from 'graphql';
  */
 const DEBATES_BEST_ORDER_SOURCE = /* GraphQL */ `
   query DebatesBestOrder($first: Int, $after: Cursor, $spaceIds: [UUID!], $typeIds: [UUID!]) {
-    entitiesRankedForFeedConnection(first: $first, after: $after, spaceIds: $spaceIds, typeIds: $typeIds) {
+    entitiesRankedForFeedByTypeConnection(first: $first, after: $after, spaceIds: $spaceIds, typeIds: $typeIds) {
       pageInfo {
         endCursor
         hasNextPage

--- a/apps/web/core/debates/browse/use-debates-best-order.test.ts
+++ b/apps/web/core/debates/browse/use-debates-best-order.test.ts
@@ -14,7 +14,7 @@ vi.mock('~/core/io/graphql-client', () => ({
     const page = mocks.pages[mocks.calls.length - 1] ?? { ids: [], endCursor: null, hasNextPage: false };
     return Effect.succeed(
       decoder({
-        entitiesRankedForFeedConnection: {
+        entitiesRankedForFeedByTypeConnection: {
           pageInfo: { endCursor: page.endCursor, hasNextPage: page.hasNextPage },
           nodes: page.ids.map(id => ({ id })),
         },

--- a/apps/web/core/debates/browse/use-debates-best-order.ts
+++ b/apps/web/core/debates/browse/use-debates-best-order.ts
@@ -38,12 +38,12 @@ export async function fetchDebatesBestOrder(spaceId: string, signal?: AbortSigna
       graphql({
         query: debatesBestOrderDocument,
         decoder: (data: {
-          entitiesRankedForFeedConnection?: {
+          entitiesRankedForFeedByTypeConnection?: {
             pageInfo?: { endCursor?: string | null; hasNextPage?: boolean | null } | null;
             nodes?: ({ id?: string | null } | null)[] | null;
           } | null;
         }) => {
-          const connection = data.entitiesRankedForFeedConnection;
+          const connection = data.entitiesRankedForFeedByTypeConnection;
           return {
             ids: (connection?.nodes ?? []).flatMap(node => (node?.id ? [node.id] : [])),
             endCursor: connection?.pageInfo?.endCursor ?? null,


### PR DESCRIPTION
The frontend half of GEO-2793. Backend half is gaia #925, merged and deployed.

## What was slow

`use-debates-best-order.ts` ranks a space's debates through `entitiesRankedForFeedConnection` with `typeIds: [DEBATE_TYPE_ID]` at `first: 100`.

That connection applies the type predicate as a **filter on a ranked index walk**, so it has to descend until it has collected `first` matches. Debate has ~**65** members against **48,886,636** rows in `entity_ranking_scores`, so the walk crosses most of the table before it can answer. Cost tracks how rare the type is, not how many ids you ask for.

## The change

Point the document at `entitiesRankedForFeedByTypeConnection` (gaia #925), which gathers the typed set first. Same ranking function body, same `ranking_score DESC, entity_id DESC`.

Measured against testnet at this document's own `first: 100`, single space:

| connection | time | rows |
| --- | --- | --- |
| `entitiesRankedForFeedConnection` (today) | **2.26 s** | 4 |
| `entitiesRankedForFeedByTypeConnection` | **0.33 s** | 4 |

Identical rows, same order.

## Why explore's Best document is not changed

It stays on the original connection on purpose. `fetchBestEntitiesPage` leaves `typeIds` undefined at the call site (#2345) and applies the whitelist to the returned rows instead — and with no type argument the ranked walk is the right plan, at 33 ms. Explore's *document* still declares and passes `$typeIds`; it is the fetcher that omits it, which is a runtime decision and not something the document test can assert. There is a comment on the test saying so, because it is the kind of thing that looks like a mistake later.

This document has no such option — it exists to rank exactly one type — so it wants the connection built for that case.

## `claims-best-order.ts` is deliberately left alone

It also passes `typeIds`, but it bounds itself with `filter: { id: { in: claimIds } }` to a dozen ids it already holds, so it never opens the walk up. Its own header records ~0.3 s. Nothing to win there, and switching it would mean re-verifying the filter interaction for no benefit.

## One sharp edge, pinned by a test

The by-type connection matches **nothing** when `type_ids` is null — it is a semi-join against the typed set, not a guarded filter. So omitting the argument would silently empty the feed rather than fall back to an unfiltered ranking. A test asserts `typeIds` is always sent.

## Testing

`vitest run core/debates/browse/` — 90 passed, 7 files. `tsc --noEmit` shows the same 5 pre-existing errors as `master` (in `governance`, `hooks` and `responses` test files), none in the touched paths — verified by running it with and without the change.
