### PR TITLE
fix(bounties): anchor search left and the filters right

### DIFF
--- a/apps/web/partials/bounties/bounty-board.test.tsx
+++ b/apps/web/partials/bounties/bounty-board.test.tsx
@@ -245,6 +245,13 @@ describe('BountyBoard', () => {
     expect(within(viewOptions).getByRole('button', { name: /Recently updated/ })).toBeInTheDocument();
     expect(within(viewOptions).getByRole('button', { name: /No grouping/ })).toBeInTheDocument();
     expect(within(screen.getByTestId('bounty-filters')).queryByRole('button', { name: /Recently updated/ })).toBeNull();
+
+    // Search is a sibling of both groups, not a member of either: the bar anchors it to the left
+    // edge while the groups are pushed right, which it cannot do from inside one of them.
+    const bar = screen.getByTestId('bounty-filter-bar');
+    const search = screen.getByLabelText('Search bounties');
+    expect(within(screen.getByTestId('bounty-filters')).queryByLabelText('Search bounties')).toBeNull();
+    expect(search.closest('label')?.parentElement).toBe(bar);
   });
 
   it('Featured is a checkbox: toggling on writes the scope param, the All row clears it', () => {

--- a/apps/web/partials/bounties/bounty-filter-bar.tsx
+++ b/apps/web/partials/bounties/bounty-filter-bar.tsx
@@ -125,118 +125,123 @@ export function BountyFilterBar({ filters, onChange, bounties, spaces, skills }:
     !isDefaultStatuses(filters.statuses);
 
   return (
-    <div className="flex flex-wrap items-center justify-center gap-x-3 gap-y-2" data-testid="bounty-filter-bar">
-      {/* The text search is a filter like the dropdowns: same group, same pill geometry. */}
-      <div className="flex flex-wrap items-center gap-2" data-testid="bounty-filters">
-        <label
-          className={`${FILTER_PILL_CLASS} w-[220px] cursor-text gap-1.5 focus-within:border-grey-03 hover:bg-white`}
-        >
-          <Search />
-          <input
-            value={query}
-            onChange={event => setQuery(event.target.value)}
-            placeholder="Search bounties"
-            aria-label="Search bounties"
-            className="min-w-0 flex-1 bg-transparent text-[16px] leading-[20px] outline-none placeholder:text-grey-03"
-          />
-        </label>
-        {spaces && spaces.length > 1 ? (
-          <FilterMenu
-            label={spaceLabel}
-            multiple
-            options={withDisabledZeros(spaceOptions)}
-            selectedKeys={new Set(filters.spaceIds)}
-            onToggle={key => onChange({ ...filters, spaceIds: toggle(filters.spaceIds, key) })}
-            allLabel="All spaces"
-            onSelectAll={() => onChange({ ...filters, spaceIds: [] })}
-            emptyMeansAll
-            maxHeightClass="max-h-[400px] overflow-y-auto"
-          />
-        ) : null}
-
-        <FilterMenu
-          label={filters.featuredOnly ? 'Featured' : 'All'}
-          multiple
-          options={[{ key: 'featured', label: 'Featured', count: bounties.filter(b => b.isFeatured).length }]}
-          selectedKeys={new Set(filters.featuredOnly ? ['featured'] : [])}
-          onToggle={() => onChange({ ...filters, featuredOnly: !filters.featuredOnly })}
-          allLabel="All"
-          onSelectAll={() => onChange({ ...filters, featuredOnly: false })}
-          emptyMeansAll
-        />
-
-        <FilterMenu
-          label={statusLabel}
-          multiple
-          options={withDisabledZeros(statusOptions)}
-          selectedKeys={new Set(filters.statuses)}
-          onToggle={key => {
-            const next = toggle(filters.statuses, key as WorkflowStatusKey);
-            // Never allow an empty set (it would show nothing); fall back to the toggled key alone.
-            onChange({ ...filters, statuses: next.length === 0 ? [key as WorkflowStatusKey] : next });
-          }}
-          allLabel="All statuses"
-          onSelectAll={() => onChange({ ...filters, statuses: WORKFLOW_STATUSES.map(status => status.key) })}
-        />
-
-        <FilterMenu
-          label={difficultyLabel}
-          multiple
-          options={withDisabledZeros(difficultyOptions)}
-          selectedKeys={new Set(filters.difficulties)}
-          onToggle={key => onChange({ ...filters, difficulties: toggle(filters.difficulties, key as DifficultyKey) })}
-          allLabel="Any difficulty"
-          onSelectAll={() => onChange({ ...filters, difficulties: [] })}
-          emptyMeansAll
-        />
-
-        {skills.length > 0 ? (
-          <FilterMenu
-            label={skillLabel}
-            multiple
-            options={withDisabledZeros(skillOptions)}
-            selectedKeys={new Set(filters.skillIds)}
-            onToggle={key => onChange({ ...filters, skillIds: toggle(filters.skillIds, key) })}
-            allLabel="Any skill"
-            onSelectAll={() => onChange({ ...filters, skillIds: [] })}
-            emptyMeansAll
-            maxHeightClass="max-h-[400px] overflow-y-auto"
-          />
-        ) : null}
-
-        {isFiltered ? (
-          <button
-            type="button"
-            onClick={() => onChange({ ...DEFAULT_BOUNTY_FILTERS, sort: filters.sort, groupBy: filters.groupBy })}
-            className={FILTER_PILL_CLASS}
-          >
-            Clear filters
-          </button>
-        ) : null}
-      </div>
-
-      {/* Sorting and grouping are view options, not filters — same row, own group behind the divider. */}
-      <div
-        className="flex flex-wrap items-center gap-2 border-l border-grey-02 pl-3"
-        data-testid="bounty-view-options"
-        aria-label="Sort and group"
+    <div className="flex flex-wrap items-center gap-x-3 gap-y-2" data-testid="bounty-filter-bar">
+      {/* Search anchors the left edge, matching the board's left gutter; everything that narrows or
+          reorders the board is pushed to the right by `ml-auto`, which keeps holding when the right
+          group wraps onto its own line. Search keeps the pill geometry of the controls it faces. */}
+      <label
+        className={`${FILTER_PILL_CLASS} w-[220px] cursor-text gap-1.5 focus-within:border-grey-03 hover:bg-white`}
       >
-        <FilterMenu
-          label={SORT_LABELS[filters.sort]}
-          options={(Object.keys(SORT_LABELS) as BountySort[]).map(sort => ({ key: sort, label: SORT_LABELS[sort] }))}
-          selectedKey={filters.sort}
-          onSelect={key => onChange({ ...filters, sort: key as BountySort })}
+        <Search />
+        <input
+          value={query}
+          onChange={event => setQuery(event.target.value)}
+          placeholder="Search bounties"
+          aria-label="Search bounties"
+          className="min-w-0 flex-1 bg-transparent text-[16px] leading-[20px] outline-none placeholder:text-grey-03"
         />
+      </label>
 
-        <FilterMenu
-          label={GROUP_BY_LABELS[filters.groupBy]}
-          options={(Object.keys(GROUP_BY_LABELS) as BountyGroupBy[]).map(groupBy => ({
-            key: groupBy,
-            label: GROUP_BY_LABELS[groupBy],
-          }))}
-          selectedKey={filters.groupBy}
-          onSelect={key => onChange({ ...filters, groupBy: key as BountyGroupBy })}
-        />
+      <div className="ml-auto flex flex-wrap items-center justify-end gap-x-3 gap-y-2">
+        <div className="flex flex-wrap items-center justify-end gap-2" data-testid="bounty-filters">
+          {spaces && spaces.length > 1 ? (
+            <FilterMenu
+              label={spaceLabel}
+              multiple
+              options={withDisabledZeros(spaceOptions)}
+              selectedKeys={new Set(filters.spaceIds)}
+              onToggle={key => onChange({ ...filters, spaceIds: toggle(filters.spaceIds, key) })}
+              allLabel="All spaces"
+              onSelectAll={() => onChange({ ...filters, spaceIds: [] })}
+              emptyMeansAll
+              maxHeightClass="max-h-[400px] overflow-y-auto"
+            />
+          ) : null}
+
+          <FilterMenu
+            label={filters.featuredOnly ? 'Featured' : 'All'}
+            multiple
+            options={[{ key: 'featured', label: 'Featured', count: bounties.filter(b => b.isFeatured).length }]}
+            selectedKeys={new Set(filters.featuredOnly ? ['featured'] : [])}
+            onToggle={() => onChange({ ...filters, featuredOnly: !filters.featuredOnly })}
+            allLabel="All"
+            onSelectAll={() => onChange({ ...filters, featuredOnly: false })}
+            emptyMeansAll
+          />
+
+          <FilterMenu
+            label={statusLabel}
+            multiple
+            options={withDisabledZeros(statusOptions)}
+            selectedKeys={new Set(filters.statuses)}
+            onToggle={key => {
+              const next = toggle(filters.statuses, key as WorkflowStatusKey);
+              // Never allow an empty set (it would show nothing); fall back to the toggled key alone.
+              onChange({ ...filters, statuses: next.length === 0 ? [key as WorkflowStatusKey] : next });
+            }}
+            allLabel="All statuses"
+            onSelectAll={() => onChange({ ...filters, statuses: WORKFLOW_STATUSES.map(status => status.key) })}
+          />
+
+          <FilterMenu
+            label={difficultyLabel}
+            multiple
+            options={withDisabledZeros(difficultyOptions)}
+            selectedKeys={new Set(filters.difficulties)}
+            onToggle={key => onChange({ ...filters, difficulties: toggle(filters.difficulties, key as DifficultyKey) })}
+            allLabel="Any difficulty"
+            onSelectAll={() => onChange({ ...filters, difficulties: [] })}
+            emptyMeansAll
+          />
+
+          {skills.length > 0 ? (
+            <FilterMenu
+              label={skillLabel}
+              multiple
+              options={withDisabledZeros(skillOptions)}
+              selectedKeys={new Set(filters.skillIds)}
+              onToggle={key => onChange({ ...filters, skillIds: toggle(filters.skillIds, key) })}
+              allLabel="Any skill"
+              onSelectAll={() => onChange({ ...filters, skillIds: [] })}
+              emptyMeansAll
+              maxHeightClass="max-h-[400px] overflow-y-auto"
+            />
+          ) : null}
+
+          {isFiltered ? (
+            <button
+              type="button"
+              onClick={() => onChange({ ...DEFAULT_BOUNTY_FILTERS, sort: filters.sort, groupBy: filters.groupBy })}
+              className={FILTER_PILL_CLASS}
+            >
+              Clear filters
+            </button>
+          ) : null}
+        </div>
+
+        {/* Sorting and grouping are view options, not filters — same row, own group behind the divider. */}
+        <div
+          className="flex flex-wrap items-center gap-2 border-l border-grey-02 pl-3"
+          data-testid="bounty-view-options"
+          aria-label="Sort and group"
+        >
+          <FilterMenu
+            label={SORT_LABELS[filters.sort]}
+            options={(Object.keys(SORT_LABELS) as BountySort[]).map(sort => ({ key: sort, label: SORT_LABELS[sort] }))}
+            selectedKey={filters.sort}
+            onSelect={key => onChange({ ...filters, sort: key as BountySort })}
+          />
+
+          <FilterMenu
+            label={GROUP_BY_LABELS[filters.groupBy]}
+            options={(Object.keys(GROUP_BY_LABELS) as BountyGroupBy[]).map(groupBy => ({
+              key: groupBy,
+              label: GROUP_BY_LABELS[groupBy],
+            }))}
+            selectedKey={filters.groupBy}
+            onSelect={key => onChange({ ...filters, groupBy: key as BountyGroupBy })}
+          />
+        </div>
       </div>
     </div>
   );

--- a/apps/web/partials/bounties/bounty-filter-bar.tsx
+++ b/apps/web/partials/bounties/bounty-filter-bar.tsx
@@ -129,26 +129,23 @@ export function BountyFilterBar({ filters, onChange, bounties, spaces, skills }:
       className="flex flex-wrap items-center gap-x-3 gap-y-2 lg:gap-x-1.5 lg:[&_button]:px-2"
       data-testid="bounty-filter-bar"
     >
-      {/* Search anchors the left edge, matching the board's left gutter; everything that narrows or
-          reorders the board is pushed to the right by `ml-auto`. Search keeps the pill geometry of
-          the controls it faces.
+      {/* Wide: search anchors the board's left gutter and `ml-auto` pushes everything that narrows
+          or reorders the board to the right edge. An auto margin rather than `justify-between`,
+          which would strand the right group at flex-start on any line it wrapped onto.
 
-          That right-hand arrangement only reads as alignment while the bar fits on one line, which
-          it stops doing around 1024px. Under `lg` it is dismantled rather than wrapped: search takes
-          its own full-width row, and the two groups below it go `display: contents` so all seven
-          pills become items of this one flex container. Nesting them is what stranded a pill — the
-          groups are separate flex items, so a leftover filter could never share a row with the sort
-          pills no matter how much room was going spare beside it. Flattened, they simply pack, and
-          the divider disappears with the box that drew it.
+          Narrow: that arrangement only reads as alignment while the bar fits on one line, so under
+          `lg` it comes apart instead of wrapping. Search takes a full-width row, and the wrapper
+          and both groups go `display: contents` — nesting is what stranded a pill, since separate
+          flex items cannot share a row however much room is going spare beside them. Flattened,
+          the pills pack, and the divider goes with the box that drew it.
 
-          Packing alone still left the last pill over: measured in Calibre on a 431px phone, the
-          second row ran to 237 of 355px and the remaining pill needed 119 — one pixel more than
-          the 118 left. So the pills also lose 2px of side padding and the row 2px of gap here,
-          which buys ~15px and settles the whole bar into two rows. The narrower padding is scoped
-          to descendants of this bar, leaving `FILTER_PILL_CLASS` alone for the surfaces that share
-          it; menu contents are portaled out, so only the triggers and Clear filters are touched.
+          The pills also lose 2px of side padding and the row 2px of gap here, which is what settles
+          all seven into two rows on a phone rather than three: measured in Calibre at 355px, the
+          second row needed one more pixel than it had. That padding is scoped to descendants of
+          this bar, leaving `FILTER_PILL_CLASS` as it is for the surfaces that share it; menu
+          contents are portaled out, so it reaches the triggers and Clear filters only.
 
-          Note this file's breakpoints are max-width (styles.css): `lg` is ≤1023px. */}
+          Breakpoints here are max-width (styles.css): `lg` is ≤1023px. */}
       <label
         className={`${FILTER_PILL_CLASS} w-[220px] cursor-text gap-1.5 focus-within:border-grey-03 hover:bg-white lg:w-full`}
       >

--- a/apps/web/partials/bounties/bounty-filter-bar.tsx
+++ b/apps/web/partials/bounties/bounty-filter-bar.tsx
@@ -127,10 +127,17 @@ export function BountyFilterBar({ filters, onChange, bounties, spaces, skills }:
   return (
     <div className="flex flex-wrap items-center gap-x-3 gap-y-2" data-testid="bounty-filter-bar">
       {/* Search anchors the left edge, matching the board's left gutter; everything that narrows or
-          reorders the board is pushed to the right by `ml-auto`, which keeps holding when the right
-          group wraps onto its own line. Search keeps the pill geometry of the controls it faces. */}
+          reorders the board is pushed to the right by `ml-auto`. Search keeps the pill geometry of
+          the controls it faces.
+
+          Right-alignment only earns its keep while the whole bar fits on one line, which it stops
+          doing around 1024px. Below `lg` the pills wrap, and right-aligned wrapped rows are ragged
+          — a lone "Any skill" stranded at the right edge, and the sort/group divider starting a row
+          with nothing to its left. So under `lg` the bar reverts to one left-aligned flow and the
+          divider goes away with the side-by-side arrangement it was dividing. Note this file's
+          breakpoints are max-width (styles.css): `lg` is ≤1023px, `sm` is ≤639px. */}
       <label
-        className={`${FILTER_PILL_CLASS} w-[220px] cursor-text gap-1.5 focus-within:border-grey-03 hover:bg-white`}
+        className={`${FILTER_PILL_CLASS} w-[220px] cursor-text gap-1.5 focus-within:border-grey-03 hover:bg-white sm:w-full`}
       >
         <Search />
         <input
@@ -142,8 +149,8 @@ export function BountyFilterBar({ filters, onChange, bounties, spaces, skills }:
         />
       </label>
 
-      <div className="ml-auto flex flex-wrap items-center justify-end gap-x-3 gap-y-2">
-        <div className="flex flex-wrap items-center justify-end gap-2" data-testid="bounty-filters">
+      <div className="ml-auto flex flex-wrap items-center justify-end gap-x-3 gap-y-2 lg:ml-0 lg:justify-start">
+        <div className="flex flex-wrap items-center justify-end gap-2 lg:justify-start" data-testid="bounty-filters">
           {spaces && spaces.length > 1 ? (
             <FilterMenu
               label={spaceLabel}
@@ -221,7 +228,7 @@ export function BountyFilterBar({ filters, onChange, bounties, spaces, skills }:
 
         {/* Sorting and grouping are view options, not filters — same row, own group behind the divider. */}
         <div
-          className="flex flex-wrap items-center gap-2 border-l border-grey-02 pl-3"
+          className="flex flex-wrap items-center gap-2 border-l border-grey-02 pl-3 lg:border-l-0 lg:pl-0"
           data-testid="bounty-view-options"
           aria-label="Sort and group"
         >

--- a/apps/web/partials/bounties/bounty-filter-bar.tsx
+++ b/apps/web/partials/bounties/bounty-filter-bar.tsx
@@ -125,7 +125,10 @@ export function BountyFilterBar({ filters, onChange, bounties, spaces, skills }:
     !isDefaultStatuses(filters.statuses);
 
   return (
-    <div className="flex flex-wrap items-center gap-x-3 gap-y-2 lg:gap-x-2" data-testid="bounty-filter-bar">
+    <div
+      className="flex flex-wrap items-center gap-x-3 gap-y-2 lg:gap-x-1.5 lg:[&_button]:px-2"
+      data-testid="bounty-filter-bar"
+    >
       {/* Search anchors the left edge, matching the board's left gutter; everything that narrows or
           reorders the board is pushed to the right by `ml-auto`. Search keeps the pill geometry of
           the controls it faces.
@@ -137,6 +140,13 @@ export function BountyFilterBar({ filters, onChange, bounties, spaces, skills }:
           groups are separate flex items, so a leftover filter could never share a row with the sort
           pills no matter how much room was going spare beside it. Flattened, they simply pack, and
           the divider disappears with the box that drew it.
+
+          Packing alone still left the last pill over: measured in Calibre on a 431px phone, the
+          second row ran to 237 of 355px and the remaining pill needed 119 — one pixel more than
+          the 118 left. So the pills also lose 2px of side padding and the row 2px of gap here,
+          which buys ~15px and settles the whole bar into two rows. The narrower padding is scoped
+          to descendants of this bar, leaving `FILTER_PILL_CLASS` alone for the surfaces that share
+          it; menu contents are portaled out, so only the triggers and Clear filters are touched.
 
           Note this file's breakpoints are max-width (styles.css): `lg` is ≤1023px. */}
       <label

--- a/apps/web/partials/bounties/bounty-filter-bar.tsx
+++ b/apps/web/partials/bounties/bounty-filter-bar.tsx
@@ -125,19 +125,22 @@ export function BountyFilterBar({ filters, onChange, bounties, spaces, skills }:
     !isDefaultStatuses(filters.statuses);
 
   return (
-    <div className="flex flex-wrap items-center gap-x-3 gap-y-2" data-testid="bounty-filter-bar">
+    <div className="flex flex-wrap items-center gap-x-3 gap-y-2 lg:gap-x-2" data-testid="bounty-filter-bar">
       {/* Search anchors the left edge, matching the board's left gutter; everything that narrows or
           reorders the board is pushed to the right by `ml-auto`. Search keeps the pill geometry of
           the controls it faces.
 
-          Right-alignment only earns its keep while the whole bar fits on one line, which it stops
-          doing around 1024px. Below `lg` the pills wrap, and right-aligned wrapped rows are ragged
-          — a lone "Any skill" stranded at the right edge, and the sort/group divider starting a row
-          with nothing to its left. So under `lg` the bar reverts to one left-aligned flow and the
-          divider goes away with the side-by-side arrangement it was dividing. Note this file's
-          breakpoints are max-width (styles.css): `lg` is ≤1023px, `sm` is ≤639px. */}
+          That right-hand arrangement only reads as alignment while the bar fits on one line, which
+          it stops doing around 1024px. Under `lg` it is dismantled rather than wrapped: search takes
+          its own full-width row, and the two groups below it go `display: contents` so all seven
+          pills become items of this one flex container. Nesting them is what stranded a pill — the
+          groups are separate flex items, so a leftover filter could never share a row with the sort
+          pills no matter how much room was going spare beside it. Flattened, they simply pack, and
+          the divider disappears with the box that drew it.
+
+          Note this file's breakpoints are max-width (styles.css): `lg` is ≤1023px. */}
       <label
-        className={`${FILTER_PILL_CLASS} w-[220px] cursor-text gap-1.5 focus-within:border-grey-03 hover:bg-white sm:w-full`}
+        className={`${FILTER_PILL_CLASS} w-[220px] cursor-text gap-1.5 focus-within:border-grey-03 hover:bg-white lg:w-full`}
       >
         <Search />
         <input
@@ -149,8 +152,8 @@ export function BountyFilterBar({ filters, onChange, bounties, spaces, skills }:
         />
       </label>
 
-      <div className="ml-auto flex flex-wrap items-center justify-end gap-x-3 gap-y-2 lg:ml-0 lg:justify-start">
-        <div className="flex flex-wrap items-center justify-end gap-2 lg:justify-start" data-testid="bounty-filters">
+      <div className="ml-auto flex flex-wrap items-center justify-end gap-x-3 gap-y-2 lg:contents">
+        <div className="flex flex-wrap items-center justify-end gap-2 lg:contents" data-testid="bounty-filters">
           {spaces && spaces.length > 1 ? (
             <FilterMenu
               label={spaceLabel}
@@ -228,7 +231,7 @@ export function BountyFilterBar({ filters, onChange, bounties, spaces, skills }:
 
         {/* Sorting and grouping are view options, not filters — same row, own group behind the divider. */}
         <div
-          className="flex flex-wrap items-center gap-2 border-l border-grey-02 pl-3 lg:border-l-0 lg:pl-0"
+          className="flex flex-wrap items-center gap-2 border-l border-grey-02 pl-3 lg:contents"
           data-testid="bounty-view-options"
           aria-label="Sort and group"
         >


### PR DESCRIPTION
Left-aligns the search field on the bounties board, right-aligns every filter, and rearranges the bar rather than wrapping it once that stops fitting.

## Wide: search left, filters right

The bar was `justify-center` with the search field sitting *inside* the filters group, so nine controls read as one clump floating in the middle of a full-width board, aligned to nothing above or below them.

Search is now a direct child of the bar and comes first, so it starts in the page's left gutter alongside the heading and the first card. The five filter dropdowns and the two view options move into one right-hand wrapper that ends flush with the last card.

That wrapper is pushed over with `ml-auto` rather than making the bar `justify-between`: with two flex children, `justify-between` puts the filter block at flex-start on any line it wraps onto, while an auto margin resolves against each line's own free space.

## Narrow: the nesting comes apart

The right-hand arrangement only reads as alignment while the bar fits on one line, which it stops doing around 1024px. Simply wrapping it left a pill stranded on a row with room to spare beside it — the filters and the sort pills are separate flex items, so a leftover filter could never join the sort pills however much space was going begging.

Under `lg` the nesting is therefore dismantled rather than realigned:

- search takes its own full-width row (`lg:w-full`);
- the wrapper and both groups go `display: contents` (`lg:contents`), so all seven pills become items of the bar's own flex container and pack row by row;
- the divider disappears with the box that drew it.

Packing alone still left the last pill over, by a hair. Measured in Calibre at the 355px of content a 431px phone gives: the second row ran to 237px and "No grouping" needed 119px — one pixel more than the 118px left. So the pills also give up 2px of side padding (`lg:[&_button]:px-2`, 10px → 8px) and the row 2px of column gap (`lg:gap-x-1.5`, 8px → 6px), which buys about 15px and settles all seven pills into two rows instead of three.

That padding is scoped to descendants of this bar rather than changed on `FILTER_PILL_CLASS`, which the community tab and the home and governance filters also render. Menu contents are portaled out of the bar, so the rule reaches the triggers and Clear filters only — and the option rows it would otherwise have reached are already `px-2`.

The DOM is untouched by `display: contents`, so both `data-testid` groups still contain exactly what they did.

Breakpoints here are **max-width**: `styles.css` clears Tailwind's defaults and redefines `sm`/`md`/`lg` as `@media (max-width: …)`, so `lg:` means ≤1023px, not ≥1024px.

## Testing

- All 13 `partials/bounties` test files pass (67 tests). The structural test in `bounty-board.test.tsx` gains an assertion that search is a sibling of both groups rather than a member of either — the arrangement above depends on it and nothing covered it. Checked that it fails when search is nested again (`expected <div><label …></div> to be <div …>`) rather than trusting it green.
- `bun run build` passes. All four new utilities are in the compiled CSS inside `@media (max-width: 1023px)`: `lg:contents` → `display:contents`, `lg:gap-x-1.5` → `column-gap:calc(var(--spacing) * 1.5)`, `lg:w-full` → `width:100%`, and `.lg\:\[\&_button\]\:px-2 button` → `padding-inline:calc(var(--spacing) * 2)`.
- Rendered the bar's exact rules — real `FILTER_PILL_CLASS` geometry, the locally-hosted Calibre face, and the `max-width` media queries — at 431px, 820px, 1024px and 1366px. 431px: full-width search, then `[All spaces][All][Open][Any difficulty]` and `[Any skill][Recently updated][No grouping]`, two rows with nothing stranded. 820px: full-width search and all seven pills on one row. 1024px: search left, all seven right-aligned on their own row with the divider between the groups. 1366px: search left, filters right, one line.

`data-testid="bounty-filters"` no longer contains the search input — it is now just the dropdowns that narrow the board, which matches its name.

## Not addressed here

Two pre-existing things this PR surfaced but does not touch, both filed: the global `[data-radix-popper-content-wrapper]` width rule (GEO-2892) and the mobile-first breakpoints in three sibling bounty files (GEO-2893).
