### PR TITLE
feat(debates): move the recording indicator onto your own tile and rebuild the intro screen

### DIFF
--- a/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
@@ -682,7 +682,10 @@ describe('DebateRoomPageClient', () => {
     expect(screen.getByRole('button', { name: 'Mute microphone' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Turn camera off' })).toBeInTheDocument();
     // The issue asks for this line explicitly, and it has to stay true to when capture starts.
-    expect(screen.getByText(/this part isn't recorded/i)).toBeInTheDocument();
+    // GEO-2819 asked for "this part isn't recorded" in so many words. The sentence is gone from the
+    // copy, but the fact it was there to state is now on the tile the sentence was talking about,
+    // in both of its states — which is the assertion below and the one worth keeping.
+    expect(screen.getByText('Introduce yourselves before debating')).toBeInTheDocument();
     expect(screen.getByText('Speak to test your mic')).toBeInTheDocument();
     expect(screen.getByRole('meter')).toBeInTheDocument();
     expect(screen.queryByText('Ready')).not.toBeInTheDocument();
@@ -1302,6 +1305,20 @@ describe('DebateRoomPageClient', () => {
     expect(screen.queryByText('Enable video to start')).not.toBeInTheDocument();
   });
 
+  // The room orders its tiles by which side of the claim each speaker holds. The intro does not:
+  // it is about your own setup, so you are on the left of it whichever side you are arguing.
+  it('puts you on the left of the intro screen whichever position you hold', async () => {
+    mocks.debate = readyDebate({ localReady: false, remoteReady: false });
+
+    render(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
+
+    await screen.findByRole('button', { name: "I'm ready to debate" });
+    // The card wrapping your tile takes the first column; the document order is the mobile one,
+    // where your opponent is on top and you sit directly above your own controls.
+    expect(debateVideoTile('local').parentElement).toHaveClass('order-1');
+    expect(debateVideoTile('remote').parentElement).toHaveClass('order-2');
+  });
+
   // The neutral state is the assurance, so it has to be somewhere the eye already is: on the tile
   // showing the camera it is talking about.
   it('puts the not-recording pill in the local tile on the intro screen', async () => {
@@ -1320,8 +1337,11 @@ describe('DebateRoomPageClient', () => {
     render(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
 
     expect(await screen.findByRole('button', { name: 'Waiting for Bri…' })).toBeDisabled();
-    expect(within(debateVideoTile('local')).getByText('Ready')).toBeInTheDocument();
-    expect(within(debateVideoTile('remote')).queryByText('Ready')).not.toBeInTheDocument();
+    // Your own readiness is the button, not a badge: the bottom-right of your tile is the recording
+    // indicator, and two different places to read "ready" was the state this screen used to be in.
+    expect(within(debateVideoTile('local')).getByText('Not recording')).toBeInTheDocument();
+    expect(within(debateVideoTile('local')).queryByText('Ready')).not.toBeInTheDocument();
+    expect(within(debateVideoTile('remote')).getByText('Not ready')).toBeInTheDocument();
   });
 
   // The intro screen and the debate room own different media elements, and the status flip swaps
@@ -2494,8 +2514,11 @@ describe('DebateRoomPageClient', () => {
 
     const heading = screen.getByRole('heading', { name: 'The protocol should ship debates' });
     expect(heading).toBeInTheDocument();
-    expect(heading.closest('main')).toHaveClass('max-w-[430px]');
-    expect(heading).toHaveClass('mb-5', 'max-w-[390px]', 'text-[1.375rem]', 'leading-[1.1]');
+    // The claim is set exactly as the intro screen sets it — wide band, `text-mainPage` on desktop
+    // — so the headline does not resize under you at the swap. Only the video column is still held
+    // to the room's 430px, which is what `main` used to hold everything to.
+    expect(heading).toHaveClass('mb-5', 'max-w-[900px]', 'text-mainPage', 'md:max-w-[390px]', 'md:text-[1.5rem]');
+    expect(debateVideoTile('local').parentElement).toHaveClass('max-w-[430px]');
     expect(screen.queryByRole('button', { name: 'Mute microphone' })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Turn camera off' })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Disable audio' })).not.toBeInTheDocument();

--- a/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.test.tsx
@@ -670,14 +670,17 @@ describe('DebateRoomPageClient', () => {
 
     expect(screen.getByRole('dialog', { name: 'Debate readiness' })).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'The protocol should ship debates' })).toBeInTheDocument();
-    expect(await screen.findByRole('button', { name: "I'm ready" })).toBeInTheDocument();
+    expect(await screen.findByRole('button', { name: "I'm ready to debate" })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Audio settings' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Video settings' })).toBeInTheDocument();
-    // No mic or camera toggle on the intro. The screen exists so the two of them see and hear each
-    // other before the debate; muting the person you are about to introduce yourself to is not a
-    // state worth supporting, and every way of reaching it costs the recorder its video track.
-    expect(screen.queryByRole('button', { name: 'Mute microphone' })).not.toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: 'Turn camera off' })).not.toBeInTheDocument();
+    // The intro carries mic and camera toggles, reversing GEO-2819's decision not to. The concern
+    // that produced that decision — "muting the person you are about to introduce yourself to is
+    // not a state worth supporting" — is answered by the gate below rather than by the absence of
+    // the control: you can mute the introduction, you cannot carry it into a recorded debate.
+    // Toggling still goes through `enabled` rather than LiveKit's `mute()`, so the recorder never
+    // loses the track it captured at publish time.
+    expect(screen.getByRole('button', { name: 'Mute microphone' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Turn camera off' })).toBeInTheDocument();
     // The issue asks for this line explicitly, and it has to stay true to when capture starts.
     expect(screen.getByText(/this part isn't recorded/i)).toBeInTheDocument();
     expect(screen.getByText('Speak to test your mic')).toBeInTheDocument();
@@ -827,11 +830,11 @@ describe('DebateRoomPageClient', () => {
       })
     );
     expect(screen.getByText('Requesting camera and mic…')).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: "I'm ready" })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: "I'm ready to debate" })).not.toBeInTheDocument();
 
     pendingTracks.resolve([createLocalAudioTrack(), { mediaStreamTrack: { kind: 'video' }, stop: vi.fn() }]);
 
-    expect(await screen.findByRole('button', { name: "I'm ready" })).toBeEnabled();
+    expect(await screen.findByRole('button', { name: "I'm ready to debate" })).toBeEnabled();
   });
 
   it('locks background scrolling while the pre-screen modal is open', () => {
@@ -896,12 +899,12 @@ describe('DebateRoomPageClient', () => {
     render(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
 
     expect(await screen.findByText('Allow access to your camera and microphone to continue.')).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: "I'm ready" })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: "I'm ready to debate" })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Audio settings' })).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'Allow access' }));
 
-    expect(await screen.findByRole('button', { name: "I'm ready" })).toBeEnabled();
+    expect(await screen.findByRole('button', { name: "I'm ready to debate" })).toBeEnabled();
     expect(mocks.createLocalTracks).toHaveBeenCalledTimes(2);
   });
 
@@ -913,7 +916,7 @@ describe('DebateRoomPageClient', () => {
 
     expect(await screen.findByText('Connect a camera and microphone, then try again.')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Try again' })).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: "I'm ready" })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: "I'm ready to debate" })).not.toBeInTheDocument();
   });
 
   it('cleans up acquired tracks when device enumeration fails', async () => {
@@ -934,7 +937,7 @@ describe('DebateRoomPageClient', () => {
     ).toBeInTheDocument();
     expect(audioTrack.stop).toHaveBeenCalled();
     expect(videoTrack.stop).toHaveBeenCalled();
-    expect(screen.queryByRole('button', { name: "I'm ready" })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: "I'm ready to debate" })).not.toBeInTheDocument();
   });
 
   // GEO-2819 moved the room connection into the intro, so `debateRoomOptions` no longer sees a
@@ -995,7 +998,7 @@ describe('DebateRoomPageClient', () => {
     expect(screen.getByRole('radio', { name: 'System default' })).toBeChecked();
     expect(screen.getByRole('radio', { name: 'System default' })).toBeDisabled();
     expect(screen.queryByRole('radio', { name: 'Studio Speakers' })).not.toBeInTheDocument();
-    expect(screen.getByRole('button', { name: "I'm ready" })).toBeEnabled();
+    expect(screen.getByRole('button', { name: "I'm ready to debate" })).toBeEnabled();
   });
 
   it('falls back to System default when speaker authorization is rejected', async () => {
@@ -1132,11 +1135,11 @@ describe('DebateRoomPageClient', () => {
     fireEvent.click(screen.getByRole('radio', { name: 'Studio Mic' }));
 
     expect(screen.getByRole('dialog', { name: 'Audio settings' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: "I'm ready" })).toBeDisabled();
+    expect(screen.getByRole('button', { name: "I'm ready to debate" })).toBeDisabled();
 
     pendingTracks.resolve([createLocalAudioTrack(), { mediaStreamTrack: { kind: 'video' }, stop: vi.fn() }]);
     await waitFor(() => expect(screen.getByRole('radio', { name: 'Studio Mic' })).toBeChecked());
-    expect(screen.getByRole('button', { name: "I'm ready" })).toBeEnabled();
+    expect(screen.getByRole('button', { name: "I'm ready to debate" })).toBeEnabled();
   });
 
   it('opens mobile video settings as a bottom sheet using the existing preview stream', async () => {
@@ -1221,7 +1224,7 @@ describe('DebateRoomPageClient', () => {
     mocks.debate = readyDebate({ localReady: false, remoteReady: false });
 
     render(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
-    await screen.findByRole('button', { name: "I'm ready" });
+    await screen.findByRole('button', { name: "I'm ready to debate" });
     const olderEnumeration = deferred<MediaDeviceInfo[]>();
     mocks.enumerateDevices.mockReturnValueOnce(olderEnumeration.promise).mockResolvedValueOnce([
       { kind: 'audioinput', deviceId: 'mic-2', groupId: 'mic-group-2', label: 'Studio Mic' },
@@ -1258,7 +1261,57 @@ describe('DebateRoomPageClient', () => {
 
     expect(within(debateVideoTile('remote')).getByText('Ready')).toBeInTheDocument();
     expect(within(debateVideoTile('local')).queryByText('Ready')).not.toBeInTheDocument();
-    expect(await screen.findByRole('button', { name: "I'm ready too" })).toBeEnabled();
+    expect(await screen.findByRole('button', { name: "I'm ready to debate too" })).toBeEnabled();
+  });
+
+  it('shows the opponent as not ready rather than showing nothing', async () => {
+    mocks.debate = readyDebate({ localReady: false, remoteReady: false });
+
+    render(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
+
+    expect(await screen.findByRole('button', { name: "I'm ready to debate" })).toBeInTheDocument();
+    expect(within(debateVideoTile('remote')).getByText('Not ready')).toBeInTheDocument();
+    expect(within(debateVideoTile('local')).queryByText('Not ready')).not.toBeInTheDocument();
+  });
+
+  // The intro's answer to GEO-2819's objection to having these toggles at all: the state is
+  // reachable, and it is not a state a recorded debate can start from.
+  it('holds readiness back until the microphone and the camera are both on', async () => {
+    mocks.debate = readyDebate({ localReady: false, remoteReady: false });
+
+    render(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
+
+    expect(await screen.findByRole('button', { name: "I'm ready to debate" })).toBeEnabled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Mute microphone' }));
+
+    expect(screen.getByRole('button', { name: "I'm ready to debate" })).toBeDisabled();
+    expect(screen.getByText('Enable audio to start')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Turn camera off' }));
+
+    expect(screen.getByText('Enable video and audio to start')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Unmute microphone' }));
+
+    expect(screen.getByText('Enable video to start')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Turn camera on' }));
+
+    expect(screen.getByRole('button', { name: "I'm ready to debate" })).toBeEnabled();
+    expect(screen.queryByText('Enable video to start')).not.toBeInTheDocument();
+  });
+
+  // The neutral state is the assurance, so it has to be somewhere the eye already is: on the tile
+  // showing the camera it is talking about.
+  it('puts the not-recording pill in the local tile on the intro screen', async () => {
+    mocks.debate = readyDebate({ localReady: false, remoteReady: false });
+
+    render(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
+
+    await screen.findByRole('button', { name: "I'm ready to debate" });
+    expect(within(debateVideoTile('local')).getByText('Not recording')).toBeInTheDocument();
+    expect(within(debateVideoTile('remote')).queryByText('Not recording')).not.toBeInTheDocument();
   });
 
   it('disables the ready button while waiting for the opponent', async () => {
@@ -1488,7 +1541,7 @@ describe('DebateRoomPageClient', () => {
     expect(await screen.findByRole('button', { name: 'Connecting…' })).toBeDisabled();
 
     act(() => pendingConnect.resolve());
-    await waitFor(() => expect(screen.getByRole('button', { name: "I'm ready" })).toBeEnabled());
+    await waitFor(() => expect(screen.getByRole('button', { name: "I'm ready to debate" })).toBeEnabled());
   });
 
   // Disabling the trigger is not enough: an open picker keeps its radios clickable.
@@ -1518,7 +1571,7 @@ describe('DebateRoomPageClient', () => {
 
     render(<DebateRoomPageClient spaceId="space-1" debateId="debate-1" />);
 
-    fireEvent.click(await screen.findByRole('button', { name: "I'm ready" }));
+    fireEvent.click(await screen.findByRole('button', { name: "I'm ready to debate" }));
 
     await waitFor(() => {
       expect(mocks.readyMutateAsync).toHaveBeenCalled();
@@ -2555,6 +2608,18 @@ describe('DebateRoomPageClient', () => {
     await waitFor(() => expect(mocks.mediaRecorderStart).toHaveBeenCalled());
     expect(await screen.findByText('Recording')).toBeInTheDocument();
     expect(screen.queryByText('Not recording')).not.toBeInTheDocument();
+  });
+
+  // It is the local `MediaRecorder` this reports on, so it belongs to the local tile and to no
+  // other. It used to be `fixed` to the top of the viewport, far from either.
+  it('puts the recording pill in the local tile rather than over the screen', async () => {
+    installRecordingMocks();
+
+    await renderLiveDebate();
+
+    await waitFor(() => expect(mocks.mediaRecorderStart).toHaveBeenCalled());
+    await waitFor(() => expect(within(debateVideoTile('local')).getByText('Recording')).toBeInTheDocument());
+    expect(within(debateVideoTile('remote')).queryByText('Recording')).not.toBeInTheDocument();
   });
 
   // A recorder can end without `stopLocalRecorder`: a disconnect stops the local tracks, the

--- a/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.tsx
@@ -2176,6 +2176,10 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
             remoteVideoReady={remoteVideoReady}
             remotePresence={remotePresence}
             capturing={capturing}
+            audioMuted={audioMuted}
+            videoEnabled={videoEnabled}
+            onToggleAudioMuted={toggleAudioMuted}
+            onToggleVideoEnabled={toggleVideoEnabled}
             previewStream={previewStream}
             previewState={previewState}
             previewBusy={previewBusy}
@@ -2195,9 +2199,7 @@ function DebateRoomSurface({ spaceId, debateId }: DebateRoomPageClientProps) {
             onVideoInputChange={changeVideoInput}
             onRetryMedia={() => void ensureLocalPreview({ forceRestart: true }).catch(() => undefined)}
             devicesLocked={
-              Boolean(preScreenLocalParticipant?.ready_at) ||
-              roomState === 'connecting' ||
-              roomState === 'reconnecting'
+              Boolean(preScreenLocalParticipant?.ready_at) || roomState === 'connecting' || roomState === 'reconnecting'
             }
             connectionSettling={roomState === 'connecting' || roomState === 'reconnecting'}
             canRetryConnection={roomState === 'idle' && roomError !== null && !connectionConflict}
@@ -2490,6 +2492,7 @@ function DebateRecordingModal({
         localSlot !== null &&
         thankingSlot === localSlot
       }
+      recordingStatus={<DebateRecordingStatusPill recording={capturing} />}
     >
       <video ref={setLocalVideoElement} className="h-full w-full bg-grey-01 object-cover" playsInline muted autoPlay />
     </DebateVideoTile>
@@ -2541,8 +2544,6 @@ function DebateRecordingModal({
       aria-label="Debate recording"
       className="fixed inset-0 z-[1000] overflow-y-auto bg-white text-text outline-none"
     >
-      <DebateRecordingStatusPill recording={capturing} />
-
       {debateDebuggingEnabled && (
         <DebateDebugMenu
           debate={debate}

--- a/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.tsx
+++ b/apps/web/app/space/[id]/(space)/debates/[debateId]/debate-room-page-client.tsx
@@ -2492,7 +2492,7 @@ function DebateRecordingModal({
         localSlot !== null &&
         thankingSlot === localSlot
       }
-      recordingStatus={<DebateRecordingStatusPill recording={capturing} />}
+      status={<DebateRecordingStatusPill recording={capturing} />}
     >
       <video ref={setLocalVideoElement} className="h-full w-full bg-grey-01 object-cover" playsInline muted autoPlay />
     </DebateVideoTile>
@@ -2561,12 +2561,15 @@ function DebateRecordingModal({
         />
       )}
 
-      <main className="mx-auto flex min-h-dvh w-full max-w-[430px] flex-col items-center justify-center px-2 py-8 sm:px-5">
-        <h1 className="mb-5 max-w-[390px] text-center text-[1.375rem] leading-[1.1] font-semibold text-text">
+      {/* `main` is wide enough for the claim, which is set and sized exactly as the intro screen
+          sets it so the headline does not change under you at the swap. Everything below it stays
+          in the single 430px column the room has always used. */}
+      <main className="mx-auto flex min-h-dvh w-full max-w-[940px] flex-col items-center justify-center px-2 py-8 sm:px-5 md:max-w-[430px]">
+        <h1 className="mb-5 w-full max-w-[900px] text-center text-mainPage text-text md:max-w-[390px] md:text-[1.5rem] md:leading-[1.8125rem] md:font-semibold md:tracking-[-0.75px]">
           {debate.claim.claim}
         </h1>
 
-        <div className="relative grid w-full gap-2">
+        <div className="relative grid w-full max-w-[430px] gap-2">
           {orderedVideoTiles}
 
           {countdown.effectiveStatus === 'thanking' && countdown.remainingSeconds > 0 && (
@@ -2590,13 +2593,13 @@ function DebateRecordingModal({
         </div>
 
         {roomState === 'reconnecting' && (
-          <div className="mt-3 w-full rounded-lg border border-grey-02 bg-white px-4 py-3">
+          <div className="mt-3 w-full max-w-[430px] rounded-lg border border-grey-02 bg-white px-4 py-3">
             <Text>Reconnecting to the debate room…</Text>
           </div>
         )}
 
         {roomError && (
-          <div className="mt-3 flex w-full flex-wrap items-center justify-between gap-3 rounded-lg border border-red-01 bg-white px-4 py-3">
+          <div className="mt-3 flex w-full max-w-[430px] flex-wrap items-center justify-between gap-3 rounded-lg border border-red-01 bg-white px-4 py-3">
             <Text color="red-01">{roomError}</Text>
             {['thanking', 'complete'].includes(debate.status) && (
               <Button type="button" variant="tertiary" onClick={onRetryFinalization} disabled={roomState === 'saving'}>
@@ -2611,7 +2614,7 @@ function DebateRecordingModal({
           </div>
         )}
 
-        <div className="mt-5 flex w-full justify-end">
+        <div className="mt-5 flex w-full max-w-[430px] justify-end">
           <RecordingCircleButton
             ariaLabel={roomState === 'saving' ? 'Saving local recording' : 'Leave debate'}
             title={roomState === 'saving' ? 'Saving local recording' : 'Leave debate'}

--- a/apps/web/core/debates/browse/debate-feed-player.tsx
+++ b/apps/web/core/debates/browse/debate-feed-player.tsx
@@ -5,6 +5,7 @@ import * as React from 'react';
 import cx from 'classnames';
 
 import type { Debate, DebateParticipant } from '~/core/debates/api';
+import { DebateTileChip, tileChipSurface } from '~/core/debates/debate-video-tile';
 import { type TurnState, clampSeconds, speakerLabel } from '~/core/debates/playback-utils';
 import { useDebatePlayback } from '~/core/debates/use-debate-playback';
 import type { DebateVotesResult } from '~/core/debates/use-debate-votes';
@@ -273,9 +274,9 @@ function DebaterVideo({
           {name}
         </span>
         {participant && (
-          <span className="inline-flex h-4 shrink-0 items-center rounded-full bg-white/60 px-1.5 text-[0.75rem] leading-none text-text">
+          <DebateTileChip className={cx('shrink-0 text-text', tileChipSurface)}>
             {participant.position_label}
-          </span>
+          </DebateTileChip>
         )}
       </button>
 

--- a/apps/web/core/debates/debate-pre-join-screen.tsx
+++ b/apps/web/core/debates/debate-pre-join-screen.tsx
@@ -10,6 +10,7 @@ import { useIsMobileCallLayout } from '~/core/community-calls/use-is-mobile-call
 import type { DebateParticipant } from '~/core/debates/api';
 import type { MediaDeviceOption, PreJoinMediaState } from '~/core/debates/media-session';
 
+import { Avatar } from '~/design-system/avatar';
 import { Check } from '~/design-system/icons/check';
 import { ChevronDownSmall } from '~/design-system/icons/chevron-down-small';
 import { Text } from '~/design-system/text';
@@ -17,7 +18,13 @@ import { useElevatedPopoverPortal } from '~/design-system/use-elevated-popover-p
 
 import { AudioSettings, MobileSettingsSheet } from './audio-settings';
 import { DebateRecordingStatusPill } from './debate-recording-status-pill';
-import { CameraIcon, LeaveIcon, MicrophoneIcon, RecordingCircleButton } from './debate-room-controls';
+import {
+  CameraIcon,
+  DebateTileToggleButton,
+  LeaveIcon,
+  MicrophoneIcon,
+  RecordingCircleButton,
+} from './debate-room-controls';
 import { DebateVideoTile } from './debate-video-tile';
 import { DeviceOptionGroup } from './device-option-group';
 import { MicrophoneLevelMeter } from './microphone-level-meter';
@@ -29,8 +36,10 @@ export type DebatePreScreenRemotePresence = 'absent' | 'present' | 'left';
  * The pre-debate screen: a live two-way call from the moment both sides grant the camera, ending
  * when both press ready. Nothing here is recorded.
  *
- * Shares the room's tile, ordering and geometry so crossing into the debate changes the chrome
- * rather than the layout.
+ * Shares the room's tile and its ordering rule, so neither speaker changes places when the debate
+ * starts. The geometry is no longer shared on desktop: this screen puts the two speakers in the
+ * design's side-by-side cards where the room keeps one column, so a wide viewport does reflow at
+ * the swap. Mobile — where the debate is actually held — still stacks both the same way.
  */
 export function DebatePreScreen({
   claim,
@@ -43,6 +52,10 @@ export function DebatePreScreen({
   remoteVideoReady,
   remotePresence,
   capturing,
+  audioMuted,
+  videoEnabled,
+  onToggleAudioMuted,
+  onToggleVideoEnabled,
   previewStream,
   previewState,
   previewBusy,
@@ -82,6 +95,18 @@ export function DebatePreScreen({
   remoteVideoReady: boolean;
   remotePresence: DebatePreScreenRemotePresence;
   capturing: boolean;
+  /**
+   * Your microphone and camera, shared with the debate room rather than local to this screen, so
+   * whatever you set here is what the recorder starts with.
+   *
+   * GEO-2819 deliberately shipped the intro without these controls. The design brings them back
+   * with a rule attached: readiness is held until both are on, so muting is a thing you can do to
+   * the introduction but not a state you can take into a recorded debate.
+   */
+  audioMuted: boolean;
+  videoEnabled: boolean;
+  onToggleAudioMuted: () => void;
+  onToggleVideoEnabled: () => void;
   previewStream: MediaStream | null;
   previewState: PreJoinMediaState;
   previewBusy: boolean;
@@ -143,6 +168,16 @@ export function DebatePreScreen({
   const mediaReady = previewState === 'ready';
   const selectedCameraLabel =
     videoInputDevices.find(device => device.deviceId === selectedVideoInputId)?.label ?? 'Camera';
+  // Named after what the person has to do, not after which flag is false — it is the only thing
+  // the screen says about a disabled ready button.
+  const enableMediaPrompt =
+    audioMuted && !videoEnabled
+      ? 'Enable video and audio to start'
+      : audioMuted
+        ? 'Enable audio to start'
+        : !videoEnabled
+          ? 'Enable video to start'
+          : null;
 
   useScrollLock();
 
@@ -180,8 +215,46 @@ export function DebatePreScreen({
       inactiveIndicatorId="local"
       tileLabel="You"
       badge={localReady ? <PreScreenReadyBadge /> : null}
+      badgeAlign="right"
+      tileControls={
+        mediaReady ? (
+          <div className="flex items-center gap-2">
+            <DebateTileToggleButton
+              ariaLabel={audioMuted ? 'Unmute microphone' : 'Mute microphone'}
+              enabled={!audioMuted}
+              onClick={onToggleAudioMuted}
+              disabled={localReady}
+            >
+              <MicrophoneIcon muted={audioMuted} />
+            </DebateTileToggleButton>
+            <DebateTileToggleButton
+              ariaLabel={videoEnabled ? 'Turn camera off' : 'Turn camera on'}
+              enabled={videoEnabled}
+              onClick={onToggleVideoEnabled}
+              disabled={localReady}
+            >
+              <CameraIcon disabled={!videoEnabled} />
+            </DebateTileToggleButton>
+          </div>
+        ) : null
+      }
+      recordingStatus={<DebateRecordingStatusPill recording={capturing} />}
     >
       <video ref={setLocalVideoElement} className="h-full w-full bg-grey-01 object-cover" playsInline muted autoPlay />
+      {/* A disabled camera track keeps sending — as black frames, so the recorder never loses it —
+          which is a broken-looking tile rather than a deliberate one. The avatar says "off". */}
+      {mediaReady && !videoEnabled && (
+        <div className="absolute inset-0 grid place-items-center bg-grey-01">
+          <div className="size-16 overflow-hidden rounded-full">
+            <Avatar
+              avatarUrl={localParticipant?.avatar_cid}
+              value={localParticipant?.profile_space_id}
+              alt=""
+              size={64}
+            />
+          </div>
+        </div>
+      )}
     </DebateVideoTile>
   );
 
@@ -205,7 +278,10 @@ export function DebatePreScreen({
       overlayCompact={remotePresence !== 'present'}
       inactiveIndicatorId="remote"
       tileLabel={remoteName}
-      badge={remoteReady ? <PreScreenReadyBadge /> : null}
+      // Their readiness is stated either way. "No badge" was ambiguous between not ready and a
+      // badge that had not rendered, which is the same reason the recording pill has two states.
+      badge={remoteReady ? <PreScreenReadyBadge /> : <PreScreenNotReadyBadge />}
+      badgeAlign="right"
     >
       <div
         ref={setRemoteMediaElement}
@@ -214,8 +290,142 @@ export function DebatePreScreen({
     </DebateVideoTile>
   );
 
+  /**
+   * Each speaker is a group: their tile, plus — for you — everything you can change before the
+   * debate starts. Each group is one of the design's side-by-side cards.
+   *
+   * `md` — this stylesheet's breakpoints are desktop-first max-widths, so `md` means *at most*
+   * 767px — dissolves the groups with `display: contents`, which drops their boxes and promotes
+   * their children into the one card the mobile design draws. That is what lets the tiles keep the
+   * room's position ordering (below) while your controls still land under both of them rather than
+   * between them: `order-last` can only reach across a group it is no longer inside.
+   */
+  const cardGroup = 'flex flex-1 flex-col gap-3 rounded-lg border border-grey-02 bg-white p-3 md:contents';
+  const controlsOrder = 'md:order-last';
+
+  const remoteGroup = (
+    <div key="remote" className={cardGroup}>
+      {remoteTile}
+    </div>
+  );
+
+  const localGroup = (
+    <div key="local" className={cardGroup}>
+      {localTile}
+
+      {!mediaReady && previewState !== 'requesting' && (
+        <button
+          type="button"
+          onClick={onRetryMedia}
+          className={cx(
+            'inline-flex min-h-9 items-center justify-center self-center rounded-full bg-text px-4 text-button text-white hover:bg-text/90',
+            controlsOrder
+          )}
+        >
+          {previewState === 'denied' ? 'Allow access' : 'Try again'}
+        </button>
+      )}
+
+      {mediaReady && (
+        <>
+          <div className={cx('flex w-full flex-col gap-[6px]', controlsOrder)}>
+            {isMobile ? (
+              <>
+                <PreScreenSettingsTrigger
+                  ref={audioTriggerRef}
+                  ariaLabel="Audio settings"
+                  icon={<MicrophoneIcon muted={false} />}
+                  label="Custom combination"
+                  open={openSettings === 'audio'}
+                  disabled={devicesLocked}
+                  onClick={() => setOpenSettings(current => (current === 'audio' ? null : 'audio'))}
+                />
+                <PreScreenSettingsTrigger
+                  ref={videoTriggerRef}
+                  ariaLabel="Video settings"
+                  icon={<CameraIcon disabled={false} />}
+                  label={selectedCameraLabel}
+                  open={openSettings === 'video'}
+                  disabled={devicesLocked}
+                  onClick={() => setOpenSettings(current => (current === 'video' ? null : 'video'))}
+                />
+              </>
+            ) : (
+              <>
+                <DesktopSettingsPopover
+                  ariaLabel="Audio settings"
+                  icon={<MicrophoneIcon muted={false} />}
+                  label="Custom combination"
+                  open={openSettings === 'audio'}
+                  disabled={devicesLocked}
+                  onOpenChange={open => setOpenSettings(open ? 'audio' : null)}
+                >
+                  <AudioSettings
+                    audioInputDevices={audioInputDevices}
+                    audioOutputDevices={audioOutputDevices}
+                    selectedAudioInputId={selectedAudioInputId}
+                    selectedAudioOutputId={selectedAudioOutputId}
+                    audioOutputSupported={audioOutputSupported}
+                    error={audioOutputError}
+                    devicesLocked={devicesLocked}
+                    onAudioInputChange={onAudioInputChange}
+                    onAudioOutputChange={onAudioOutputChange}
+                  />
+                </DesktopSettingsPopover>
+                <DesktopSettingsPopover
+                  ariaLabel="Video settings"
+                  icon={<CameraIcon disabled={false} />}
+                  label={selectedCameraLabel}
+                  open={openSettings === 'video'}
+                  disabled={devicesLocked}
+                  onOpenChange={open => setOpenSettings(open ? 'video' : null)}
+                >
+                  <DeviceOptionGroup
+                    label="Select a camera"
+                    options={videoInputDevices}
+                    selectedDeviceId={selectedVideoInputId}
+                    disabled={devicesLocked}
+                    onChange={onVideoInputChange}
+                  />
+                </DesktopSettingsPopover>
+              </>
+            )}
+          </div>
+
+          <div className={cx('flex w-full flex-col gap-2', controlsOrder)}>
+            <div className="flex items-center justify-between gap-3">
+              <p className="text-[12px] leading-4 font-normal text-grey-04">Speak to test your mic</p>
+              <MicrophoneLevelMeter stream={previewStream} />
+            </div>
+            <div className="h-px w-full bg-divider" />
+          </div>
+
+          <div className={cx('flex w-full flex-col items-center gap-2', controlsOrder)}>
+            <button
+              type="button"
+              onClick={onReady}
+              disabled={readyBusy || localReady || previewBusy || connectionSettling || enableMediaPrompt !== null}
+              className="flex min-h-10 w-full items-center justify-center rounded-full bg-text px-5 text-button text-white transition-colors hover:bg-text/90 disabled:bg-grey-01 disabled:text-grey-03 disabled:hover:bg-grey-01"
+            >
+              {localReady
+                ? `Waiting for ${remoteName}…`
+                : connectionSettling
+                  ? 'Connecting…'
+                  : readyBusy
+                    ? 'Saving...'
+                    : remoteReady
+                      ? "I'm ready to debate too"
+                      : "I'm ready to debate"}
+            </button>
+            {enableMediaPrompt && <p className="text-[12px] leading-4 text-grey-04">{enableMediaPrompt}</p>}
+          </div>
+        </>
+      )}
+    </div>
+  );
+
   // The room's ordering rule, so neither tile moves when the debate starts.
-  const orderedTiles = localParticipant?.position === false ? [remoteTile, localTile] : [localTile, remoteTile];
+  const orderedGroups = localParticipant?.position === false ? [remoteGroup, localGroup] : [localGroup, remoteGroup];
 
   return (
     <div
@@ -226,102 +436,24 @@ export function DebatePreScreen({
       aria-label="Debate readiness"
       className="fixed inset-0 z-[1000] overflow-y-auto bg-white text-text outline-none"
     >
-      <DebateRecordingStatusPill recording={capturing} />
+      {/* The claim is given more room than the speakers, as the design has it — a wide headline
+          over a narrower pair of cards — so the column caps are set per band rather than on `main`. */}
+      <main className="mx-auto flex min-h-dvh w-full max-w-[820px] flex-col items-center justify-center px-2 py-8 sm:px-5 md:max-w-[430px]">
+        <div className="mb-5 flex w-full max-w-[740px] flex-col items-center gap-3 md:mb-4 md:max-w-none md:gap-2">
+          {/* Was a paragraph under the claim. It keeps the assurance GEO-2819 asked for — the
+              recording pill on your own tile now says the same thing in the same breath — and
+              moves into the eyebrow slot the design gives it above the claim. */}
+          <p className="text-center text-mediumTitle text-grey-04 md:text-metadataMedium">
+            Introduce yourselves before debating — this part isn&apos;t recorded
+          </p>
+          <h1 className="text-center text-mainPage text-text md:max-w-[390px] md:text-[1.5rem] md:leading-[1.8125rem] md:font-semibold md:tracking-[-0.75px]">
+            {claim}
+          </h1>
+        </div>
 
-      {/* `pt-16` clears the fixed recording pill, which is centred over the top of both screens. */}
-      <main className="mx-auto flex min-h-dvh w-full max-w-[430px] flex-col items-center justify-center px-2 pt-16 pb-8 sm:px-5">
-        <h1 className="mb-2 max-w-[390px] text-center text-[1.375rem] leading-[1.1] font-semibold text-text">
-          {claim}
-        </h1>
-        {/* Not "when you are both ready": that moves the debate to `connecting`, and the recorder
-            does not start until `preflight` a beat later. */}
-        <Text as="p" variant="metadata" color="grey-04" className="mb-5 max-w-[390px] text-center">
-          Say hello first. This part isn&apos;t recorded, and recording starts when the debate does.
-        </Text>
-
-        <div className="grid w-full gap-2">{orderedTiles}</div>
-
-        {!mediaReady && previewState !== 'requesting' && (
-          <button
-            type="button"
-            onClick={onRetryMedia}
-            className="mt-3 inline-flex min-h-9 items-center justify-center rounded-full bg-text px-4 text-button text-white hover:bg-text/90"
-          >
-            {previewState === 'denied' ? 'Allow access' : 'Try again'}
-          </button>
-        )}
-
-        {mediaReady && (
-          <div className="mt-3 w-full rounded-lg border border-grey-02 bg-white p-3">
-            <div className="flex flex-col gap-[6px]">
-              {isMobile ? (
-                <>
-                  <PreScreenSettingsTrigger
-                    ref={audioTriggerRef}
-                    ariaLabel="Audio settings"
-                    icon={<MicrophoneIcon muted={false} />}
-                    label="Custom combination"
-                    open={openSettings === 'audio'}
-                    disabled={devicesLocked}
-                    onClick={() => setOpenSettings(current => (current === 'audio' ? null : 'audio'))}
-                  />
-                  <PreScreenSettingsTrigger
-                    ref={videoTriggerRef}
-                    ariaLabel="Video settings"
-                    icon={<CameraIcon disabled={false} />}
-                    label={selectedCameraLabel}
-                    open={openSettings === 'video'}
-                    disabled={devicesLocked}
-                    onClick={() => setOpenSettings(current => (current === 'video' ? null : 'video'))}
-                  />
-                </>
-              ) : (
-                <>
-                  <DesktopSettingsPopover
-                    ariaLabel="Audio settings"
-                    icon={<MicrophoneIcon muted={false} />}
-                    label="Custom combination"
-                    open={openSettings === 'audio'}
-                    disabled={devicesLocked}
-                    onOpenChange={open => setOpenSettings(open ? 'audio' : null)}
-                  >
-                    <AudioSettings
-                      audioInputDevices={audioInputDevices}
-                      audioOutputDevices={audioOutputDevices}
-                      selectedAudioInputId={selectedAudioInputId}
-                      selectedAudioOutputId={selectedAudioOutputId}
-                      audioOutputSupported={audioOutputSupported}
-                      error={audioOutputError}
-                      devicesLocked={devicesLocked}
-                      onAudioInputChange={onAudioInputChange}
-                      onAudioOutputChange={onAudioOutputChange}
-                    />
-                  </DesktopSettingsPopover>
-                  <DesktopSettingsPopover
-                    ariaLabel="Video settings"
-                    icon={<CameraIcon disabled={false} />}
-                    label={selectedCameraLabel}
-                    open={openSettings === 'video'}
-                    disabled={devicesLocked}
-                    onOpenChange={open => setOpenSettings(open ? 'video' : null)}
-                  >
-                    <DeviceOptionGroup
-                      label="Select a camera"
-                      options={videoInputDevices}
-                      selectedDeviceId={selectedVideoInputId}
-                      disabled={devicesLocked}
-                      onChange={onVideoInputChange}
-                    />
-                  </DesktopSettingsPopover>
-                </>
-              )}
-            </div>
-            <div className="mt-3 flex items-center justify-between border-t border-grey-02 pt-2">
-              <p className="text-[12px] leading-4 font-normal text-grey-04">Speak to test your mic</p>
-              <MicrophoneLevelMeter stream={previewStream} />
-            </div>
-          </div>
-        )}
+        <div className="flex w-full max-w-[600px] items-start gap-5 md:max-w-none md:flex-col md:items-stretch md:gap-3 md:rounded-lg md:border md:border-grey-02 md:bg-white md:p-3">
+          {orderedGroups}
+        </div>
 
         {error && (
           <div className="mt-3 flex w-full flex-wrap items-center justify-between gap-3 rounded-lg border border-red-01 bg-white px-4 py-3">
@@ -340,26 +472,7 @@ export function DebatePreScreen({
           </div>
         )}
 
-        {mediaReady && (
-          <button
-            type="button"
-            onClick={onReady}
-            disabled={readyBusy || localReady || previewBusy || connectionSettling}
-            className="mt-3 flex min-h-11 w-full items-center justify-center rounded-full bg-text px-5 text-button text-white transition-colors hover:bg-text/90 disabled:opacity-50"
-          >
-            {localReady
-              ? `Waiting for ${remoteName}…`
-              : connectionSettling
-                ? 'Connecting…'
-                : readyBusy
-                  ? 'Saving...'
-                  : remoteReady
-                    ? "I'm ready too"
-                    : "I'm ready"}
-          </button>
-        )}
-
-        <div className="mt-5 flex w-full justify-end">
+        <div className="mt-5 flex w-full justify-center">
           <RecordingCircleButton
             ariaLabel="Leave debate"
             title="Leave debate"
@@ -420,6 +533,14 @@ function PreScreenReadyBadge() {
     <span className="inline-flex items-center gap-1.5 rounded-full bg-green px-3 py-1.5 text-metadata leading-none text-text">
       <Check />
       Ready
+    </span>
+  );
+}
+
+function PreScreenNotReadyBadge() {
+  return (
+    <span className="inline-flex items-center rounded-full bg-grey-01 px-3 py-1.5 text-metadata leading-none text-grey-04">
+      Not ready
     </span>
   );
 }

--- a/apps/web/core/debates/debate-pre-join-screen.tsx
+++ b/apps/web/core/debates/debate-pre-join-screen.tsx
@@ -215,6 +215,28 @@ export function DebatePreScreen({
       overlayCompact={!mediaReady || switchingDevice}
       inactiveIndicatorId="local"
       tileLabel="You"
+      tileControls={
+        mediaReady ? (
+          <div className="flex items-center gap-2">
+            <DebateTileToggleButton
+              ariaLabel={audioMuted ? 'Unmute microphone' : 'Mute microphone'}
+              enabled={!audioMuted}
+              onClick={onToggleAudioMuted}
+              disabled={localReady}
+            >
+              <MicrophoneIcon muted={audioMuted} />
+            </DebateTileToggleButton>
+            <DebateTileToggleButton
+              ariaLabel={videoEnabled ? 'Turn camera off' : 'Turn camera on'}
+              enabled={videoEnabled}
+              onClick={onToggleVideoEnabled}
+              disabled={localReady}
+            >
+              <CameraIcon disabled={!videoEnabled} />
+            </DebateTileToggleButton>
+          </div>
+        ) : null
+      }
       // Your readiness is not stated here the way theirs is: the ready button becomes "Waiting for
       // …", and the bottom-right of your own tile is spent on the recording indicator.
       status={<DebateRecordingStatusPill recording={capturing} />}
@@ -306,29 +328,6 @@ export function DebatePreScreen({
 
       {mediaReady && (
         <>
-          {/* Their own row under your tile rather than overlaid on it. On the tile they shared the
-              bottom band with the position label and the recording indicator, which at a two-column
-              tile width was three things deep in a strip ~40px tall. Here they also sit with the
-              mic and camera pickers, which is what they are about. */}
-          <div className={cx('flex w-full items-center justify-center gap-2', controlsOrder)}>
-            <DebateTileToggleButton
-              ariaLabel={audioMuted ? 'Unmute microphone' : 'Mute microphone'}
-              enabled={!audioMuted}
-              onClick={onToggleAudioMuted}
-              disabled={localReady}
-            >
-              <MicrophoneIcon muted={audioMuted} />
-            </DebateTileToggleButton>
-            <DebateTileToggleButton
-              ariaLabel={videoEnabled ? 'Turn camera off' : 'Turn camera on'}
-              enabled={videoEnabled}
-              onClick={onToggleVideoEnabled}
-              disabled={localReady}
-            >
-              <CameraIcon disabled={!videoEnabled} />
-            </DebateTileToggleButton>
-          </div>
-
           <div className={cx('flex w-full flex-col gap-[6px]', controlsOrder)}>
             {isMobile ? (
               <>

--- a/apps/web/core/debates/debate-pre-join-screen.tsx
+++ b/apps/web/core/debates/debate-pre-join-screen.tsx
@@ -36,10 +36,11 @@ export type DebatePreScreenRemotePresence = 'absent' | 'present' | 'left';
  * The pre-debate screen: a live two-way call from the moment both sides grant the camera, ending
  * when both press ready. Nothing here is recorded.
  *
- * Shares the room's tile and its ordering rule, so neither speaker changes places when the debate
- * starts. The geometry is no longer shared on desktop: this screen puts the two speakers in the
- * design's side-by-side cards where the room keeps one column, so a wide viewport does reflow at
- * the swap. Mobile — where the debate is actually held — still stacks both the same way.
+ * Shares the room's tile but not its layout. This screen puts the two speakers in the design's
+ * side-by-side cards, you always on the left, where the room keeps one column ordered by which
+ * side of the claim each speaker holds — so crossing into the debate does reflow, and on mobile
+ * can swap which of you is on top. That is the cost of "you are always on the left here", and it
+ * is deliberate: before the debate the screen is about your own setup, during it about the claim.
  */
 export function DebatePreScreen({
   claim,
@@ -214,31 +215,9 @@ export function DebatePreScreen({
       overlayCompact={!mediaReady || switchingDevice}
       inactiveIndicatorId="local"
       tileLabel="You"
-      badge={localReady ? <PreScreenReadyBadge /> : null}
-      badgeAlign="right"
-      tileControls={
-        mediaReady ? (
-          <div className="flex items-center gap-2">
-            <DebateTileToggleButton
-              ariaLabel={audioMuted ? 'Unmute microphone' : 'Mute microphone'}
-              enabled={!audioMuted}
-              onClick={onToggleAudioMuted}
-              disabled={localReady}
-            >
-              <MicrophoneIcon muted={audioMuted} />
-            </DebateTileToggleButton>
-            <DebateTileToggleButton
-              ariaLabel={videoEnabled ? 'Turn camera off' : 'Turn camera on'}
-              enabled={videoEnabled}
-              onClick={onToggleVideoEnabled}
-              disabled={localReady}
-            >
-              <CameraIcon disabled={!videoEnabled} />
-            </DebateTileToggleButton>
-          </div>
-        ) : null
-      }
-      recordingStatus={<DebateRecordingStatusPill recording={capturing} />}
+      // Your readiness is not stated here the way theirs is: the ready button becomes "Waiting for
+      // …", and the bottom-right of your own tile is spent on the recording indicator.
+      status={<DebateRecordingStatusPill recording={capturing} />}
     >
       <video ref={setLocalVideoElement} className="h-full w-full bg-grey-01 object-cover" playsInline muted autoPlay />
       {/* A disabled camera track keeps sending — as black frames, so the recorder never loses it —
@@ -280,8 +259,7 @@ export function DebatePreScreen({
       tileLabel={remoteName}
       // Their readiness is stated either way. "No badge" was ambiguous between not ready and a
       // badge that had not rendered, which is the same reason the recording pill has two states.
-      badge={remoteReady ? <PreScreenReadyBadge /> : <PreScreenNotReadyBadge />}
-      badgeAlign="right"
+      status={remoteReady ? <PreScreenReadyBadge /> : <PreScreenNotReadyBadge />}
     >
       <div
         ref={setRemoteMediaElement}
@@ -304,13 +282,13 @@ export function DebatePreScreen({
   const controlsOrder = 'md:order-last';
 
   const remoteGroup = (
-    <div key="remote" className={cardGroup}>
+    <div key="remote" className={cx(cardGroup, 'order-2')}>
       {remoteTile}
     </div>
   );
 
   const localGroup = (
-    <div key="local" className={cardGroup}>
+    <div key="local" className={cx(cardGroup, 'order-1')}>
       {localTile}
 
       {!mediaReady && previewState !== 'requesting' && (
@@ -328,6 +306,29 @@ export function DebatePreScreen({
 
       {mediaReady && (
         <>
+          {/* Their own row under your tile rather than overlaid on it. On the tile they shared the
+              bottom band with the position label and the recording indicator, which at a two-column
+              tile width was three things deep in a strip ~40px tall. Here they also sit with the
+              mic and camera pickers, which is what they are about. */}
+          <div className={cx('flex w-full items-center justify-center gap-2', controlsOrder)}>
+            <DebateTileToggleButton
+              ariaLabel={audioMuted ? 'Unmute microphone' : 'Mute microphone'}
+              enabled={!audioMuted}
+              onClick={onToggleAudioMuted}
+              disabled={localReady}
+            >
+              <MicrophoneIcon muted={audioMuted} />
+            </DebateTileToggleButton>
+            <DebateTileToggleButton
+              ariaLabel={videoEnabled ? 'Turn camera off' : 'Turn camera on'}
+              enabled={videoEnabled}
+              onClick={onToggleVideoEnabled}
+              disabled={localReady}
+            >
+              <CameraIcon disabled={!videoEnabled} />
+            </DebateTileToggleButton>
+          </div>
+
           <div className={cx('flex w-full flex-col gap-[6px]', controlsOrder)}>
             {isMobile ? (
               <>
@@ -424,8 +425,14 @@ export function DebatePreScreen({
     </div>
   );
 
-  // The room's ordering rule, so neither tile moves when the debate starts.
-  const orderedGroups = localParticipant?.position === false ? [remoteGroup, localGroup] : [localGroup, remoteGroup];
+  /**
+   * You are always on the left on desktop, whichever side of the claim you are arguing — hence the
+   * `order` above rather than the room's position ordering, which put whoever holds the first slot
+   * first. The document order is the mobile one the design draws: your opponent on top, you
+   * directly above your own controls. `order` is ignored there, because at that width the groups
+   * are `display: contents` and it is their children that are the flex items.
+   */
+  const orderedGroups = [remoteGroup, localGroup];
 
   return (
     <div
@@ -436,27 +443,27 @@ export function DebatePreScreen({
       aria-label="Debate readiness"
       className="fixed inset-0 z-[1000] overflow-y-auto bg-white text-text outline-none"
     >
-      {/* The claim is given more room than the speakers, as the design has it — a wide headline
-          over a narrower pair of cards — so the column caps are set per band rather than on `main`. */}
-      <main className="mx-auto flex min-h-dvh w-full max-w-[820px] flex-col items-center justify-center px-2 py-8 sm:px-5 md:max-w-[430px]">
-        <div className="mb-5 flex w-full max-w-[740px] flex-col items-center gap-3 md:mb-4 md:max-w-none md:gap-2">
-          {/* Was a paragraph under the claim. It keeps the assurance GEO-2819 asked for — the
-              recording pill on your own tile now says the same thing in the same breath — and
-              moves into the eyebrow slot the design gives it above the claim. */}
+      {/* The claim is given the full width and the speakers a little less, as the design has it —
+          a wide headline over the cards — so the caps are per band rather than on `main`. The
+          cards are sized so each tile lands back at the ~415px the single-column layout gave it. */}
+      <main className="mx-auto flex min-h-dvh w-full max-w-[940px] flex-col items-center justify-center px-2 py-8 sm:px-5 md:max-w-[430px]">
+        <div className="mb-5 flex w-full max-w-[900px] flex-col items-center gap-3 md:mb-4 md:max-w-none md:gap-2">
+          {/* Replaces the paragraph that sat under the claim. The assurance it also carried — that
+              this part is not recorded — is now the "Not recording" pill on your own tile. */}
           <p className="text-center text-mediumTitle text-grey-04 md:text-metadataMedium">
-            Introduce yourselves before debating — this part isn&apos;t recorded
+            Introduce yourselves before debating
           </p>
           <h1 className="text-center text-mainPage text-text md:max-w-[390px] md:text-[1.5rem] md:leading-[1.8125rem] md:font-semibold md:tracking-[-0.75px]">
             {claim}
           </h1>
         </div>
 
-        <div className="flex w-full max-w-[600px] items-start gap-5 md:max-w-none md:flex-col md:items-stretch md:gap-3 md:rounded-lg md:border md:border-grey-02 md:bg-white md:p-3">
+        <div className="flex w-full max-w-[900px] items-start gap-5 md:max-w-none md:flex-col md:items-stretch md:gap-3 md:rounded-lg md:border md:border-grey-02 md:bg-white md:p-3">
           {orderedGroups}
         </div>
 
         {error && (
-          <div className="mt-3 flex w-full flex-wrap items-center justify-between gap-3 rounded-lg border border-red-01 bg-white px-4 py-3">
+          <div className="mt-3 flex w-full max-w-[900px] flex-wrap items-center justify-between gap-3 rounded-lg border border-red-01 bg-white px-4 py-3">
             <Text as="p" variant="metadata" color="red-01">
               {error}
             </Text>
@@ -527,11 +534,21 @@ export function DebatePreScreen({
   );
 }
 
-/** Readiness as a fact on a tile, deliberately not a prompt or countdown near the ready button. */
+/**
+ * Readiness as a fact on a tile, deliberately not a prompt or countdown near the ready button.
+ *
+ * Sized like the position label and the recording pill rather than as its own badge: all three are
+ * chips on a tile, and the opponent's readiness sits in the same bottom-right slot your recording
+ * state does. Green survives as the fill because "ready" is the one state worth spotting from
+ * across the layout.
+ */
 function PreScreenReadyBadge() {
   return (
-    <span className="inline-flex items-center gap-1.5 rounded-full bg-green px-3 py-1.5 text-metadata leading-none text-text">
-      <Check />
+    <span className="inline-flex h-4 items-center gap-1 rounded-full bg-green px-1.5 text-[0.75rem] leading-none text-text">
+      {/* The icon ships at 16px, which is the whole chip. */}
+      <span aria-hidden className="grid size-2.5 shrink-0 place-items-center [&>svg]:size-full">
+        <Check />
+      </span>
       Ready
     </span>
   );
@@ -539,7 +556,7 @@ function PreScreenReadyBadge() {
 
 function PreScreenNotReadyBadge() {
   return (
-    <span className="inline-flex items-center rounded-full bg-grey-01 px-3 py-1.5 text-metadata leading-none text-grey-04">
+    <span className="inline-flex h-4 items-center rounded-full bg-white/60 px-1.5 text-[0.75rem] leading-none text-text">
       Not ready
     </span>
   );

--- a/apps/web/core/debates/debate-pre-join-screen.tsx
+++ b/apps/web/core/debates/debate-pre-join-screen.tsx
@@ -25,7 +25,7 @@ import {
   MicrophoneIcon,
   RecordingCircleButton,
 } from './debate-room-controls';
-import { DebateVideoTile } from './debate-video-tile';
+import { DebateTileChip, DebateVideoTile } from './debate-video-tile';
 import { DeviceOptionGroup } from './device-option-group';
 import { MicrophoneLevelMeter } from './microphone-level-meter';
 import { useScrollLock } from './use-scroll-lock';
@@ -222,7 +222,10 @@ export function DebatePreScreen({
               ariaLabel={audioMuted ? 'Unmute microphone' : 'Mute microphone'}
               enabled={!audioMuted}
               onClick={onToggleAudioMuted}
-              disabled={localReady}
+              // `readyBusy` as well as `localReady`: readiness is confirmed by the server, so
+              // between pressing ready and the round trip returning you could still turn the camera
+              // off — and carry exactly the state the gate exists to prevent into the recording.
+              disabled={readyBusy || localReady}
             >
               <MicrophoneIcon muted={audioMuted} />
             </DebateTileToggleButton>
@@ -230,7 +233,10 @@ export function DebatePreScreen({
               ariaLabel={videoEnabled ? 'Turn camera off' : 'Turn camera on'}
               enabled={videoEnabled}
               onClick={onToggleVideoEnabled}
-              disabled={localReady}
+              // `readyBusy` as well as `localReady`: readiness is confirmed by the server, so
+              // between pressing ready and the round trip returning you could still turn the camera
+              // off — and carry exactly the state the gate exists to prevent into the recording.
+              disabled={readyBusy || localReady}
             >
               <CameraIcon disabled={!videoEnabled} />
             </DebateTileToggleButton>
@@ -296,9 +302,9 @@ export function DebatePreScreen({
    *
    * `md` — this stylesheet's breakpoints are desktop-first max-widths, so `md` means *at most*
    * 767px — dissolves the groups with `display: contents`, which drops their boxes and promotes
-   * their children into the one card the mobile design draws. That is what lets the tiles keep the
-   * room's position ordering (below) while your controls still land under both of them rather than
-   * between them: `order-last` can only reach across a group it is no longer inside.
+   * their children into the one card the mobile design draws. That is what lets your controls land
+   * under both tiles rather than between them: `order-last` can only reach across a group it is no
+   * longer inside.
    */
   const cardGroup = 'flex flex-1 flex-col gap-3 rounded-lg border border-grey-02 bg-white p-3 md:contents';
   const controlsOrder = 'md:order-last';
@@ -543,22 +549,18 @@ export function DebatePreScreen({
  */
 function PreScreenReadyBadge() {
   return (
-    <span className="inline-flex h-4 items-center gap-1 rounded-full bg-green px-1.5 text-[0.75rem] leading-none text-text">
+    <DebateTileChip className="bg-green text-text">
       {/* The icon ships at 16px, which is the whole chip. */}
       <span aria-hidden className="grid size-2.5 shrink-0 place-items-center [&>svg]:size-full">
         <Check />
       </span>
       Ready
-    </span>
+    </DebateTileChip>
   );
 }
 
 function PreScreenNotReadyBadge() {
-  return (
-    <span className="inline-flex h-4 items-center rounded-full bg-white/60 px-1.5 text-[0.75rem] leading-none text-text">
-      Not ready
-    </span>
-  );
+  return <DebateTileChip className="bg-white/60 text-text">Not ready</DebateTileChip>;
 }
 
 type PreScreenSettingsTriggerProps = Omit<React.ComponentPropsWithoutRef<'button'>, 'aria-label'> & {

--- a/apps/web/core/debates/debate-pre-join-screen.tsx
+++ b/apps/web/core/debates/debate-pre-join-screen.tsx
@@ -25,7 +25,7 @@ import {
   MicrophoneIcon,
   RecordingCircleButton,
 } from './debate-room-controls';
-import { DebateTileChip, DebateVideoTile } from './debate-video-tile';
+import { DebateTileChip, DebateVideoTile, tileChipSurface } from './debate-video-tile';
 import { DeviceOptionGroup } from './device-option-group';
 import { MicrophoneLevelMeter } from './microphone-level-meter';
 import { useScrollLock } from './use-scroll-lock';
@@ -560,7 +560,7 @@ function PreScreenReadyBadge() {
 }
 
 function PreScreenNotReadyBadge() {
-  return <DebateTileChip className="bg-white/60 text-text">Not ready</DebateTileChip>;
+  return <DebateTileChip className={cx(tileChipSurface, 'text-text')}>Not ready</DebateTileChip>;
 }
 
 type PreScreenSettingsTriggerProps = Omit<React.ComponentPropsWithoutRef<'button'>, 'aria-label'> & {

--- a/apps/web/core/debates/debate-recording-status-pill.tsx
+++ b/apps/web/core/debates/debate-recording-status-pill.tsx
@@ -11,15 +11,14 @@ import cx from 'classnames';
  * Both states are shown deliberately: an absent indicator is ambiguous between "not recording"
  * and "failed to render", so the neutral state is the assurance.
  *
- * Sized and coloured to sit inside a video tile — it is rendered in the local tile's
- * `recordingStatus` slot on both screens, the one corner neither screen spends on something else.
- * It used to be `fixed` to the top of the viewport, which put it nowhere near the thing it
- * describes and, because both screens centre their content vertically, left it floating alone
- * above the layout. On the tile it also reads as a statement about *your* camera, which is exactly
- * what it is: this is driven by the local `MediaRecorder`, not by the debate's status.
+ * Wears the position label's chip — same height, same translucent white, same type — because it
+ * sits at the other end of the same row in the local tile's `status` slot, and two chips on one
+ * line reading as two different components is worse than either. Colour carries the state: black
+ * for the resting one, red once the recorder is running. It used to be `fixed` to the top of the
+ * viewport, which put it nowhere near the thing it describes and, because both screens centre
+ * their content vertically, left it floating alone above the layout.
  *
- * Opaque backgrounds rather than the position label's `bg-white/60`: this indicator of all things
- * should not depend on what is behind it.
+ * The dot is hollow when idle and filled when live, so the state does not rest on colour alone.
  */
 export function DebateRecordingStatusPill({ recording }: { recording: boolean }) {
   return (
@@ -27,17 +26,15 @@ export function DebateRecordingStatusPill({ recording }: { recording: boolean })
       role="status"
       aria-live="polite"
       className={cx(
-        'inline-flex items-center gap-1.5 rounded-full border px-2 py-1 text-tag leading-none whitespace-nowrap',
-        // Dark text on the red, matching the Ready badge's dark-on-green: white on red-01 is
-        // 3.2:1, under the 4.5:1 this indicator of all things should clear.
-        recording ? 'border-red-01 bg-red-01 text-text' : 'border-grey-02 bg-white text-grey-04'
+        'inline-flex h-4 items-center gap-1 rounded-full bg-white/60 px-1.5 text-[0.75rem] leading-none whitespace-nowrap',
+        recording ? 'text-red-01' : 'text-text'
       )}
     >
       <span
         aria-hidden
         className={cx(
-          'size-1.5 shrink-0 rounded-full',
-          recording ? 'bg-text motion-safe:animate-pulse' : 'border border-grey-03 bg-transparent'
+          'size-1.5 shrink-0 rounded-full border',
+          recording ? 'border-red-01 bg-red-01 motion-safe:animate-pulse' : 'border-text bg-transparent'
         )}
       />
       {recording ? 'Recording' : 'Not recording'}

--- a/apps/web/core/debates/debate-recording-status-pill.tsx
+++ b/apps/web/core/debates/debate-recording-status-pill.tsx
@@ -19,22 +19,30 @@ import cx from 'classnames';
  * their content vertically, left it floating alone above the layout.
  *
  * The dot is hollow when idle and filled when live, so the state does not rest on colour alone.
+ *
+ * The red is `red-01` taken down to 30% lightness at the same hue, rather than `red-01` itself.
+ * The chip is 60% white over whatever the camera is pointed at, so against dark video it settles
+ * around mid-grey — where `red-01` measures about 1.1:1 and is effectively invisible. This clears
+ * 3:1 even in that worst case and around 8:1 over a bright frame. It is a literal because the
+ * palette has no dark red; if one is ever added, this is the value it wants.
  */
+const recordingRed = '#991200';
 export function DebateRecordingStatusPill({ recording }: { recording: boolean }) {
   return (
     <span
       role="status"
       aria-live="polite"
+      style={recording ? { color: recordingRed } : undefined}
       className={cx(
         'inline-flex h-4 items-center gap-1 rounded-full bg-white/60 px-1.5 text-[0.75rem] leading-none whitespace-nowrap',
-        recording ? 'text-red-01' : 'text-text'
+        !recording && 'text-text'
       )}
     >
       <span
         aria-hidden
         className={cx(
-          'size-1.5 shrink-0 rounded-full border',
-          recording ? 'border-red-01 bg-red-01 motion-safe:animate-pulse' : 'border-text bg-transparent'
+          'size-1.5 shrink-0 rounded-full border border-current',
+          recording ? 'bg-current motion-safe:animate-pulse' : 'bg-transparent'
         )}
       />
       {recording ? 'Recording' : 'Not recording'}

--- a/apps/web/core/debates/debate-recording-status-pill.tsx
+++ b/apps/web/core/debates/debate-recording-status-pill.tsx
@@ -11,36 +11,36 @@ import cx from 'classnames';
  * Both states are shown deliberately: an absent indicator is ambiguous between "not recording"
  * and "failed to render", so the neutral state is the assurance.
  *
- * `fixed`, because both screens are scroll containers and an `absolute` child scrolls out of view
- * with the content.
+ * Sized and coloured to sit inside a video tile — it is rendered in the local tile's
+ * `recordingStatus` slot on both screens, the one corner neither screen spends on something else.
+ * It used to be `fixed` to the top of the viewport, which put it nowhere near the thing it
+ * describes and, because both screens centre their content vertically, left it floating alone
+ * above the layout. On the tile it also reads as a statement about *your* camera, which is exactly
+ * what it is: this is driven by the local `MediaRecorder`, not by the debate's status.
  *
- * Rendered inside each screen rather than once above both: the screens are `aria-modal`, so a
- * sibling can be pruned from the accessibility tree entirely. The cost is that the live region
- * remounts at the swap and the transition goes unannounced; a single persistent dialog wrapper
- * would buy both.
+ * Opaque backgrounds rather than the position label's `bg-white/60`: this indicator of all things
+ * should not depend on what is behind it.
  */
 export function DebateRecordingStatusPill({ recording }: { recording: boolean }) {
   return (
-    <div className="pointer-events-none fixed top-4 left-1/2 z-[1020] -translate-x-1/2">
+    <span
+      role="status"
+      aria-live="polite"
+      className={cx(
+        'inline-flex items-center gap-1.5 rounded-full border px-2 py-1 text-tag leading-none whitespace-nowrap',
+        // Dark text on the red, matching the Ready badge's dark-on-green: white on red-01 is
+        // 3.2:1, under the 4.5:1 this indicator of all things should clear.
+        recording ? 'border-red-01 bg-red-01 text-text' : 'border-grey-02 bg-white text-grey-04'
+      )}
+    >
       <span
-        role="status"
-        aria-live="polite"
+        aria-hidden
         className={cx(
-          'inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-metadata leading-none whitespace-nowrap',
-          // Dark text on the red, matching the Ready badge's dark-on-green: white on red-01 is
-          // 3.2:1, under the 4.5:1 this indicator of all things should clear.
-          recording ? 'border-red-01 bg-red-01 text-text' : 'border-grey-02 bg-white text-grey-04'
+          'size-1.5 shrink-0 rounded-full',
+          recording ? 'bg-text motion-safe:animate-pulse' : 'border border-grey-03 bg-transparent'
         )}
-      >
-        <span
-          aria-hidden
-          className={cx(
-            'size-2 shrink-0 rounded-full',
-            recording ? 'bg-text motion-safe:animate-pulse' : 'border border-grey-03 bg-transparent'
-          )}
-        />
-        {recording ? 'Recording' : 'Not recording'}
-      </span>
-    </div>
+      />
+      {recording ? 'Recording' : 'Not recording'}
+    </span>
   );
 }

--- a/apps/web/core/debates/debate-recording-status-pill.tsx
+++ b/apps/web/core/debates/debate-recording-status-pill.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 
 import cx from 'classnames';
 
-import { DebateTileChip } from './debate-video-tile';
+import { DebateTileChip, tileChipSurface } from './debate-video-tile';
 
 /**
  * GEO-2819. Says whether the camera is being written to disk, in the same place on the intro
@@ -22,11 +22,12 @@ import { DebateTileChip } from './debate-video-tile';
  *
  * The dot is hollow when idle and filled when live, so the state does not rest on colour alone.
  *
- * The red is `red-01` taken down to 30% lightness at the same hue, rather than `red-01` itself.
- * The chip is 60% white over whatever the camera is pointed at, so against dark video it settles
- * around mid-grey — where `red-01` measures about 1.1:1 and is effectively invisible. This clears
- * 3:1 even in that worst case and around 8:1 over a bright frame. It is a literal because the
- * palette has no dark red; if one is ever added, this is the value it wants.
+ * The red is `red-01` taken down to 30% lightness at the same hue, rather than `red-01` itself,
+ * which measures about 1.1:1 against the darkest the chip can composite to and is effectively
+ * invisible there. Paired with `tileChipSurface` — see the note on it for why the fill is 85% and
+ * not 60% — this measures 6.1:1 at worst and 8.6:1 over a bright frame, clearing the 4.5:1 that
+ * 12px text is held to. It is a literal because the palette has no dark red; if one is ever added,
+ * this is the value it wants.
  */
 const recordingRed = '#991200';
 export function DebateRecordingStatusPill({ recording }: { recording: boolean }) {
@@ -35,7 +36,7 @@ export function DebateRecordingStatusPill({ recording }: { recording: boolean })
       role="status"
       aria-live="polite"
       style={recording ? { color: recordingRed } : undefined}
-      className={cx('bg-white/60', !recording && 'text-text')}
+      className={cx(tileChipSurface, !recording && 'text-text')}
     >
       <span
         aria-hidden

--- a/apps/web/core/debates/debate-recording-status-pill.tsx
+++ b/apps/web/core/debates/debate-recording-status-pill.tsx
@@ -4,6 +4,8 @@ import * as React from 'react';
 
 import cx from 'classnames';
 
+import { DebateTileChip } from './debate-video-tile';
+
 /**
  * GEO-2819. Says whether the camera is being written to disk, in the same place on the intro
  * screen and in the debate room.
@@ -29,14 +31,11 @@ import cx from 'classnames';
 const recordingRed = '#991200';
 export function DebateRecordingStatusPill({ recording }: { recording: boolean }) {
   return (
-    <span
+    <DebateTileChip
       role="status"
       aria-live="polite"
       style={recording ? { color: recordingRed } : undefined}
-      className={cx(
-        'inline-flex h-4 items-center gap-1 rounded-full bg-white/60 px-1.5 text-[0.75rem] leading-none whitespace-nowrap',
-        !recording && 'text-text'
-      )}
+      className={cx('bg-white/60', !recording && 'text-text')}
     >
       <span
         aria-hidden
@@ -46,6 +45,6 @@ export function DebateRecordingStatusPill({ recording }: { recording: boolean })
         )}
       />
       {recording ? 'Recording' : 'Not recording'}
-    </span>
+    </DebateTileChip>
   );
 }

--- a/apps/web/core/debates/debate-room-controls.tsx
+++ b/apps/web/core/debates/debate-room-controls.tsx
@@ -62,8 +62,11 @@ export function DebateTileToggleButton({
   return (
     <button
       type="button"
+      // No `aria-pressed`: the label is the action, not the state, so it already flips between
+      // "Mute microphone" and "Unmute microphone". Pairing the two announces "Unmute microphone,
+      // pressed" while the mic is muted, which states the opposite of what is true. Same reason
+      // `RecordingCircleButton` omits it.
       aria-label={ariaLabel}
-      aria-pressed={!enabled}
       title={ariaLabel}
       onClick={onClick}
       disabled={disabled}

--- a/apps/web/core/debates/debate-room-controls.tsx
+++ b/apps/web/core/debates/debate-room-controls.tsx
@@ -39,6 +39,44 @@ export function RecordingCircleButton({
   );
 }
 
+/**
+ * A mic or camera toggle that sits over a video tile, as the intro screen has them.
+ *
+ * `enabled` is styled as the resting state and `off` as the exceptional one — red-03 behind a
+ * red-01 glyph — because the intro screen will not let you press ready while either is off, so
+ * "off" is a thing to undo rather than a setting.
+ */
+export function DebateTileToggleButton({
+  ariaLabel,
+  enabled,
+  onClick,
+  disabled,
+  children,
+}: {
+  ariaLabel: string;
+  enabled: boolean;
+  onClick: () => void;
+  disabled?: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={ariaLabel}
+      aria-pressed={!enabled}
+      title={ariaLabel}
+      onClick={onClick}
+      disabled={disabled}
+      className={cx(
+        'grid size-10 place-items-center rounded-full shadow-light transition disabled:opacity-50',
+        enabled ? 'bg-text text-white hover:bg-text/85' : 'bg-red-03 text-red-01 hover:bg-red-03/85'
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
 export function LeaveIcon() {
   return (
     <svg viewBox="0 0 24 24" aria-hidden="true" className="size-4" fill="none" stroke="currentColor" strokeWidth="2">

--- a/apps/web/core/debates/debate-video-tile.tsx
+++ b/apps/web/core/debates/debate-video-tile.tsx
@@ -19,9 +19,26 @@ export const recordingLabelTextShadow = {
 };
 
 /**
+ * The translucent fill the tile chips share.
+ *
+ * 85% rather than the 60% these started at, and that is a contrast requirement rather than taste.
+ * The chip composites over whatever the camera is pointed at, so its effective background is a
+ * range, and the floor of that range — 60% white over a black frame — is `#999`. Chip text is
+ * 12px, which WCAG counts as body text at 4.5:1, and against `#999` the recording red measures
+ * 3.02:1. No red that still reads as red clears 4.5:1 there; the value that does is around
+ * `#660B00`, which reads as brown. Taking the fill to 85% fixes the background instead: the range
+ * narrows to `#d9d9d9`–`#fff`, where the red measures 6.1:1 at worst and the dark text 11.5:1.
+ *
+ * A constant rather than a default inside `DebateTileChip`, because `cx` concatenates and does not
+ * merge — a caller passing `bg-green` would emit both classes and let stylesheet order decide.
+ */
+export const tileChipSurface = 'bg-white/85';
+
+/**
  * The chip every small label overlaid on a tile wears: the position label, the recording
- * indicator, and the intro screen's readiness badges. They sit on the same row at the same optical
- * size, so the geometry lives here once and callers bring only the fill and the text colour.
+ * indicator, the intro screen's readiness badges, and the playback feed's speaker label. They sit
+ * at the same optical size, so the geometry lives here once and callers bring only the fill and
+ * the text colour.
  */
 export function DebateTileChip({
   className,
@@ -141,7 +158,9 @@ export function DebateVideoTile({
         <div className="pointer-events-none absolute inset-x-3 bottom-3 z-30 flex items-center justify-between gap-2">
           <div className="flex min-w-0 flex-1 justify-start">
             {positionLabel && (
-              <DebateTileChip className="max-w-full truncate bg-white/60 text-text">{positionLabel}</DebateTileChip>
+              <DebateTileChip className={cx('max-w-full truncate text-text', tileChipSurface)}>
+                {positionLabel}
+              </DebateTileChip>
             )}
           </div>
           {tileControls && <div className="pointer-events-auto shrink-0">{tileControls}</div>}

--- a/apps/web/core/debates/debate-video-tile.tsx
+++ b/apps/web/core/debates/debate-video-tile.tsx
@@ -19,6 +19,29 @@ export const recordingLabelTextShadow = {
 };
 
 /**
+ * The chip every small label overlaid on a tile wears: the position label, the recording
+ * indicator, and the intro screen's readiness badges. They sit on the same row at the same optical
+ * size, so the geometry lives here once and callers bring only the fill and the text colour.
+ */
+export function DebateTileChip({
+  className,
+  children,
+  ...spanProps
+}: React.ComponentPropsWithoutRef<'span'> & { className?: string }) {
+  return (
+    <span
+      {...spanProps}
+      className={cx(
+        'inline-flex h-4 items-center gap-1 rounded-full px-1.5 text-[0.75rem] leading-none whitespace-nowrap',
+        className
+      )}
+    >
+      {children}
+    </span>
+  );
+}
+
+/**
  * One participant's tile, shared by the intro screen and the recording modal so the two have the
  * same geometry. Everything past the video is optional: the intro passes a label and an overlay,
  * the debate adds turn countdowns and phase overlays.
@@ -108,19 +131,21 @@ export function DebateVideoTile({
       {countdown && <div className="pointer-events-none absolute top-3 right-3 z-20">{countdown}</div>}
 
       {/* One row rather than three corners. Everything that wants the bottom of the tile is laid
-          out here instead of absolutely positioned, so the position label truncates under pressure
-          rather than ending up underneath the controls or the status. */}
+          out here instead of absolutely positioned, so nothing can end up underneath anything else.
+          The label is the only flexible cell: the controls and the status hold their natural width
+          and the label truncates to pay for them. Giving the status a share of the free space
+          instead — `flex-1` with a zero basis — sized it to the viewport rather than to its own
+          text, and the wider "Not recording" state then overflowed onto the camera toggle on any
+          tile under ~330px, which is most phones. */}
       {(positionLabel || tileControls || status) && (
         <div className="pointer-events-none absolute inset-x-3 bottom-3 z-30 flex items-center justify-between gap-2">
           <div className="flex min-w-0 flex-1 justify-start">
             {positionLabel && (
-              <span className="inline-flex h-4 max-w-full items-center truncate rounded-full bg-white/60 px-1.5 text-[0.75rem] leading-none text-text">
-                {positionLabel}
-              </span>
+              <DebateTileChip className="max-w-full truncate bg-white/60 text-text">{positionLabel}</DebateTileChip>
             )}
           </div>
           {tileControls && <div className="pointer-events-auto shrink-0">{tileControls}</div>}
-          <div className="flex min-w-0 flex-1 shrink-0 justify-end">{status}</div>
+          <div className="flex shrink-0 justify-end">{status}</div>
         </div>
       )}
 

--- a/apps/web/core/debates/debate-video-tile.tsx
+++ b/apps/web/core/debates/debate-video-tile.tsx
@@ -44,6 +44,9 @@ export function DebateVideoTile({
   countdown,
   closingMessage = false,
   badge,
+  badgeAlign = 'left',
+  tileControls,
+  recordingStatus,
   children,
 }: {
   participantPosition: boolean | null;
@@ -67,8 +70,25 @@ export function DebateVideoTile({
   showMutedIndicator?: boolean;
   countdown?: React.ReactNode;
   closingMessage?: boolean;
-  /** Top-right chip. The intro screen puts the opponent's readiness here. */
+  /** Top chip. The intro screen puts the opponent's readiness here. */
   badge?: React.ReactNode;
+  /**
+   * Which top corner the badge takes. `left` by default because the debate room spends the right
+   * one on the turn countdown and the muted indicator; the intro screen, which has neither, puts
+   * the opponent's readiness on the right as the design has it.
+   */
+  badgeAlign?: 'left' | 'right';
+  /**
+   * The middle of the tile's bottom row. The intro screen puts your mic and camera here. It sits
+   * between the other two slots rather than at the tile's centre, so a long position label or the
+   * wider "Not recording" state shifts it a little either way.
+   */
+  tileControls?: React.ReactNode;
+  /**
+   * Bottom-right. Reserved for the recording indicator on both screens, so the one thing that has
+   * to be findable in the same place throughout is never displaced by a phase overlay.
+   */
+  recordingStatus?: React.ReactNode;
   children: React.ReactNode;
 }) {
   const showInactiveIndicator =
@@ -98,13 +118,25 @@ export function DebateVideoTile({
         {showInactiveIndicator && <MutedMicrophoneIndicator />}
       </div>
       {countdown && <div className="pointer-events-none absolute top-3 right-3 z-20">{countdown}</div>}
-      {/* Top-left: the muted indicator and the turn countdown both own the right corner, and
-          "muted and ready" is a very ordinary combination on the intro screen. */}
-      {badge && <div className="absolute top-3 left-3 z-30">{badge}</div>}
+      {/* Top-left by default: the muted indicator and the turn countdown both own the right
+          corner, and "muted and ready" is a very ordinary combination. */}
+      {badge && <div className={cx('absolute top-3 z-30', badgeAlign === 'right' ? 'right-3' : 'left-3')}>{badge}</div>}
 
-      {positionLabel && (
-        <div className="pointer-events-none absolute bottom-3 left-3 z-20 inline-flex h-4 items-center rounded-full bg-white/60 px-1.5 text-[0.75rem] leading-none text-text">
-          {positionLabel}
+      {/* One row rather than three corners. The position label, the intro's mic and camera, and the
+          recording indicator all want the bottom of the tile, and a tile is only ~270px wide in the
+          intro's two-column layout — absolutely positioning each to its own corner had the
+          indicator sitting on top of the camera button there. */}
+      {(positionLabel || tileControls || recordingStatus) && (
+        <div className="pointer-events-none absolute inset-x-3 bottom-3 z-30 flex items-center justify-between gap-2">
+          <div className="flex min-w-0 flex-1 justify-start">
+            {positionLabel && (
+              <span className="inline-flex h-4 max-w-full items-center truncate rounded-full bg-white/60 px-1.5 text-[0.75rem] leading-none text-text">
+                {positionLabel}
+              </span>
+            )}
+          </div>
+          {tileControls && <div className="pointer-events-auto shrink-0">{tileControls}</div>}
+          <div className="flex flex-1 shrink-0 justify-end">{recordingStatus}</div>
         </div>
       )}
 

--- a/apps/web/core/debates/debate-video-tile.tsx
+++ b/apps/web/core/debates/debate-video-tile.tsx
@@ -43,6 +43,7 @@ export function DebateVideoTile({
   showMutedIndicator = false,
   countdown,
   closingMessage = false,
+  tileControls,
   status,
   children,
 }: {
@@ -67,6 +68,8 @@ export function DebateVideoTile({
   showMutedIndicator?: boolean;
   countdown?: React.ReactNode;
   closingMessage?: boolean;
+  /** The middle of the bottom row. The intro screen puts your mic and camera here. */
+  tileControls?: React.ReactNode;
   /**
    * Bottom-right: where this tile says how its own speaker stands. Yours carries the recording
    * indicator, theirs their readiness on the intro screen — one place to look per person, rather
@@ -104,9 +107,10 @@ export function DebateVideoTile({
       </div>
       {countdown && <div className="pointer-events-none absolute top-3 right-3 z-20">{countdown}</div>}
 
-      {/* One row rather than two corners: the position label and the status both want the bottom of
-          the tile, and laying them out means a long label can never end up underneath the status. */}
-      {(positionLabel || status) && (
+      {/* One row rather than three corners. Everything that wants the bottom of the tile is laid
+          out here instead of absolutely positioned, so the position label truncates under pressure
+          rather than ending up underneath the controls or the status. */}
+      {(positionLabel || tileControls || status) && (
         <div className="pointer-events-none absolute inset-x-3 bottom-3 z-30 flex items-center justify-between gap-2">
           <div className="flex min-w-0 flex-1 justify-start">
             {positionLabel && (
@@ -115,7 +119,8 @@ export function DebateVideoTile({
               </span>
             )}
           </div>
-          <div className="flex shrink-0 justify-end">{status}</div>
+          {tileControls && <div className="pointer-events-auto shrink-0">{tileControls}</div>}
+          <div className="flex min-w-0 flex-1 shrink-0 justify-end">{status}</div>
         </div>
       )}
 

--- a/apps/web/core/debates/debate-video-tile.tsx
+++ b/apps/web/core/debates/debate-video-tile.tsx
@@ -43,10 +43,7 @@ export function DebateVideoTile({
   showMutedIndicator = false,
   countdown,
   closingMessage = false,
-  badge,
-  badgeAlign = 'left',
-  tileControls,
-  recordingStatus,
+  status,
   children,
 }: {
   participantPosition: boolean | null;
@@ -70,25 +67,13 @@ export function DebateVideoTile({
   showMutedIndicator?: boolean;
   countdown?: React.ReactNode;
   closingMessage?: boolean;
-  /** Top chip. The intro screen puts the opponent's readiness here. */
-  badge?: React.ReactNode;
   /**
-   * Which top corner the badge takes. `left` by default because the debate room spends the right
-   * one on the turn countdown and the muted indicator; the intro screen, which has neither, puts
-   * the opponent's readiness on the right as the design has it.
+   * Bottom-right: where this tile says how its own speaker stands. Yours carries the recording
+   * indicator, theirs their readiness on the intro screen — one place to look per person, rather
+   * than a different corner per fact. Deliberately the same slot on both screens and both tiles,
+   * so nothing the debate does later can displace it.
    */
-  badgeAlign?: 'left' | 'right';
-  /**
-   * The middle of the tile's bottom row. The intro screen puts your mic and camera here. It sits
-   * between the other two slots rather than at the tile's centre, so a long position label or the
-   * wider "Not recording" state shifts it a little either way.
-   */
-  tileControls?: React.ReactNode;
-  /**
-   * Bottom-right. Reserved for the recording indicator on both screens, so the one thing that has
-   * to be findable in the same place throughout is never displaced by a phase overlay.
-   */
-  recordingStatus?: React.ReactNode;
+  status?: React.ReactNode;
   children: React.ReactNode;
 }) {
   const showInactiveIndicator =
@@ -118,15 +103,10 @@ export function DebateVideoTile({
         {showInactiveIndicator && <MutedMicrophoneIndicator />}
       </div>
       {countdown && <div className="pointer-events-none absolute top-3 right-3 z-20">{countdown}</div>}
-      {/* Top-left by default: the muted indicator and the turn countdown both own the right
-          corner, and "muted and ready" is a very ordinary combination. */}
-      {badge && <div className={cx('absolute top-3 z-30', badgeAlign === 'right' ? 'right-3' : 'left-3')}>{badge}</div>}
 
-      {/* One row rather than three corners. The position label, the intro's mic and camera, and the
-          recording indicator all want the bottom of the tile, and a tile is only ~270px wide in the
-          intro's two-column layout — absolutely positioning each to its own corner had the
-          indicator sitting on top of the camera button there. */}
-      {(positionLabel || tileControls || recordingStatus) && (
+      {/* One row rather than two corners: the position label and the status both want the bottom of
+          the tile, and laying them out means a long label can never end up underneath the status. */}
+      {(positionLabel || status) && (
         <div className="pointer-events-none absolute inset-x-3 bottom-3 z-30 flex items-center justify-between gap-2">
           <div className="flex min-w-0 flex-1 justify-start">
             {positionLabel && (
@@ -135,8 +115,7 @@ export function DebateVideoTile({
               </span>
             )}
           </div>
-          {tileControls && <div className="pointer-events-auto shrink-0">{tileControls}</div>}
-          <div className="flex flex-1 shrink-0 justify-end">{recordingStatus}</div>
+          <div className="flex shrink-0 justify-end">{status}</div>
         </div>
       )}
 


### PR DESCRIPTION
## The problem

The recording pill was `fixed top-4` — anchored to the viewport, while both debate screens centre their content vertically. So it floated detached above the layout, nowhere near the thing it reports on, and forced a `pt-16` on the intro screen just to keep clear of the claim.

## Where it went

**The bottom-right of your own video tile**, on both the intro screen and the debate room.

- It is the one corner neither screen spends on something else — top-right is the turn countdown and the muted indicator, top-left the badge slot, bottom-left the position label.
- It moves with the tile, so mobile and desktop need no separate rule.
- It reads as a statement about *your* camera, which is what it is: the pill is driven by the local `MediaRecorder`'s own events, not by the debate's status.

`DebateVideoTile`'s bottom is now **one flex row** — position label, mic/camera toggles, status — instead of independently positioned corners, so the label truncates under pressure rather than anything overlapping. Verified down to a 320px viewport.

Nothing else about the debate room changed except the claim (below).

## The intro screen, rebuilt to the Figma

- Eyebrow line above the claim; the claim gets a wide headline band over the cards.
- Desktop: the two speakers in side-by-side cards, **you always on the left**. Mobile: one card, opponent on top, you directly above your own controls.
- Each tile's bottom-right states how *that* speaker stands: yours the recording indicator, theirs **Ready / Not ready** — stated either way, rather than a badge that is simply absent when they aren't.
- Mic and camera toggles on your own tile, with an avatar placeholder when the camera is off.
- Leave button centred; ready button reads "I'm ready to debate".

## The debate room

Only the claim changed: it is set exactly as the intro screen sets it, so the headline does not resize under you at the swap. The video column stays in the 430px column the room has always used.

## Decisions worth a look

1. **Mic/camera toggles reverse a previous deliberate decision.** GEO-2819 shipped the intro *without* them, on the grounds that "muting the person you are about to introduce yourself to is not a state worth supporting." The design adds them, so I added the gate that answers it: **readiness is held until both are on**, with the button saying which one to turn on. The state is reachable; it cannot be carried into a recording. Toggling reuses the room's `audioMuted` / `videoEnabled`, which set `enabled` rather than LiveKit's `mute()` — the technical constraint that made toggling unsafe here originally.

2. **Tile ordering deliberately diverges from the room.** The room orders tiles by which side of the claim each speaker holds, so neither speaker moves mid-debate. The intro does not: you are on the left whichever side you are arguing, because the screen is about your own setup. The consequence is that crossing into the debate can reflow, and on mobile can swap which of you is on top. Called out because it is a real trade and easy to read as a bug.

3. **Copy.** The designs replace the "Say hello first. This part isn't recorded…" paragraph with an eyebrow, but GEO-2819 explicitly required that assurance line. The eyebrow is the designer's — "Introduce yourselves before debating" — and the assurance is now carried by the "Not recording" pill on the tile that sentence was talking about.

4. **Figma sizes adapted, not traced.** The frames have scaled component instances (28px pills around 16px text, 12px icons), so I used the project's real control sizes — 40px circle buttons, 36px pickers, `text-mainPage` for the desktop claim — and the design's structure, spacing and colours. Tile aspect stays 5/3 since `DebateVideoTile` is shared with the room.

5. **The recording red is a literal.** `red-01` taken to 30% lightness at the same hue (`#991200`); the palette has no dark red, and `red-01` itself measures ~1.1:1 against the darkest the chip can composite to.

## Known gap — tracked, not fixed here

The toggles set `mediaStreamTrack.enabled`, never `mute()`, so **no signal reaches your opponent**: them turning their camera off shows you an unexplained black tile, muting shows nothing. There is no remote media-state signalling in the room to reuse — `participantIsInactive` is turn-derived and no `TrackMuted` listener exists — so this needs new plumbing. The ready gate means neither state can reach a recording, so it self-resolves; filed as **GEO-2891** (Bryan).

Long claim names are also unhandled on both full-screen debate surfaces, which this PR makes more visible by taking the claim to 52px. Pre-existing; filed as **GEO-2890**.

## Testing

- `debate-room-page-client.test.tsx`: 169 pass, including new coverage for the indicator in the local tile on each screen, the readiness gate across all four mic/camera combinations, "Not ready" on the opponent tile, and you-on-the-left ordering.
- Full `core/debates` + `app/space`: 109 files / 1834 tests.
- `tsc --noEmit` clean for every touched file.
- Rendered at 320/360/390/402/430/768/1440 and measured: no overlap in the tile's bottom row at any width, in either recording state.
- Chip contrast measured off rendered pixels over black and white frames — worst case 6.09:1 against a 4.5:1 bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
