### PR TITLE
fix(debates): scale the online dot to the face it sits on

### DIFF
--- a/apps/web/core/debates/matchmaking/matchmaking-claim-card.tsx
+++ b/apps/web/core/debates/matchmaking/matchmaking-claim-card.tsx
@@ -1147,18 +1147,11 @@ function PositionAvatars({
           {/* Everyone in this stack is present by construction — the sides are built from
               `online_choices` — so the dot needs no condition. It rings in the pill's own colour
               rather than white, which is the surface actually behind it here. */}
-          {/* Top-left, per the Figma card: the dot's 4px body sits on the face's own top-left
-              corner and its 2px ring bleeds outside, so the avatar reads as notched rather than
-              badged. `-translate-*-0.5` is that 2px, which is what puts the *green* on the corner
-              instead of the ring. */}
-          {/* Figma's ellipse is `r=3` under an opaque `stroke-width=2`, so the green reads 4px
-              across inside a 2px ring — 8px overall, which is `OnlineDot`'s default. Its 4px box
-              sits on the picture's top-left corner and the svg overhangs it by half, so the element
-              starts 2px up and left of that corner. */}
-          <OnlineDot
-            ringClassName={ringClassName}
-            className="absolute top-0 left-0 -translate-x-0.5 -translate-y-0.5"
-          />
+          {/* Sized and placed from the 16px face: 4px of green in a 2px ring, sitting on the
+              picture's top-left corner with the ring bleeding outside it. Those numbers are
+              `OnlineDot`'s to derive now — the People tab needed the same proportions on a 32px
+              face and two hand-written copies had already drifted. */}
+          <OnlineDot faceSize={16} ringClassName={ringClassName} />
         </span>
       ))}
       {overflow > 0 && (

--- a/apps/web/core/debates/matchmaking/people-tab.tsx
+++ b/apps/web/core/debates/matchmaking/people-tab.tsx
@@ -213,7 +213,10 @@ function PersonRow({
         <div className="h-8 w-8 overflow-hidden rounded-full">
           <Avatar avatarUrl={person.avatar_cid} value={person.profile_space_id} size={32} />
         </div>
-        <OnlineDot className="absolute top-0 left-0 -translate-x-0.5 -translate-y-0.5" />
+        {/* The face here is 32px, twice the claim pills', so the dot is twice theirs: 8px of green
+            in a 4px ring. It carried the pills' 8px dot before, which on a face this size read as
+            a speck rather than a badge. */}
+        <OnlineDot faceSize={32} />
       </div>
       <div className="flex min-w-0 flex-col gap-0.5">
         {/* The name goes to their personal space, which is the profile page GEO-2611 settled on.

--- a/apps/web/design-system/online-dot.test.tsx
+++ b/apps/web/design-system/online-dot.test.tsx
@@ -7,9 +7,13 @@ import { OnlineDot } from './online-dot';
 
 afterEach(cleanup);
 
+// The claim pills' face, and the size this geometry was drawn at. Named so the tests that are not
+// about size do not each pick a number.
+const FACE = 16;
+
 describe('OnlineDot', () => {
   it('is the design’s green', () => {
-    const { container } = render(<OnlineDot />);
+    const { container } = render(<OnlineDot faceSize={FACE} />);
 
     // `bg-green` is `#2ACE9D`, the Figma card's colour — named rather than inlined so the token
     // stays the one place it is defined.
@@ -17,13 +21,13 @@ describe('OnlineDot', () => {
   });
 
   it('rings itself in white unless told otherwise', () => {
-    const { container } = render(<OnlineDot />);
+    const { container } = render(<OnlineDot faceSize={FACE} />);
 
     expect(container.firstChild).toHaveClass('border-white');
   });
 
   it('takes the ring colour of whatever it is standing on', () => {
-    const { container } = render(<OnlineDot ringClassName="border-grey-01" />);
+    const { container } = render(<OnlineDot faceSize={FACE} ringClassName="border-grey-01" />);
 
     // The dot sits on the rim of a face, so the ring has to be the surface behind it — on a held
     // pill that is grey, not white. Getting this wrong is not subtle: the green runs straight into
@@ -33,7 +37,7 @@ describe('OnlineDot', () => {
   });
 
   it('keeps the ring outside the dot, so the green has somewhere to paint', () => {
-    const { container } = render(<OnlineDot />);
+    const { container } = render(<OnlineDot faceSize={FACE} />);
 
     // The bug this pins shipped once and showed nothing at all: preflight makes everything
     // `border-box`, so 4px of box with a 2px border each side leaves a zero-width content box. The
@@ -42,41 +46,28 @@ describe('OnlineDot', () => {
     expect(container.firstChild).toHaveClass('box-content');
   });
 
-  describe('scales to the face it sits on', () => {
-    // The proportions, not the pixels: green is a quarter of the face, the ring half the green.
-    // The People tab's 32px faces wore the 16px face's dot, which read as a speck.
-    it.each([
-      [16, '4px', '2px', 'translate(-2px, -2px)'],
-      [32, '8px', '4px', 'translate(-4px, -4px)'],
-    ])('on a %ipx face', (faceSize, green, ring, offset) => {
-      const { container } = render(<OnlineDot faceSize={faceSize} />);
-      const dot = container.firstChild as HTMLElement;
+  // The proportions, not the pixels: green is a quarter of the face, the ring half the green. The
+  // People tab's 32px faces wore the 16px face's dot, which read as a speck. Asserted as style
+  // rather than class on purpose — a size computed into a class name is one the compiler never
+  // sees, so these reads are also what would fail if the sizing moved back into Tailwind.
+  it.each([
+    [16, '4px', '2px', 'translate(-2px, -2px)'],
+    [32, '8px', '4px', 'translate(-4px, -4px)'],
+  ])('scales to the %ipx face it sits on', (faceSize, green, ring, offset) => {
+    const { container } = render(<OnlineDot faceSize={faceSize} />);
 
-      expect(dot.style.width).toBe(green);
-      expect(dot.style.height).toBe(green);
-      expect(dot.style.borderWidth).toBe(ring);
+    expect(container.firstChild).toHaveStyle({
+      width: green,
+      height: green,
+      borderWidth: ring,
       // The green body sits on the face's corner and the ring bleeds outside, so the element starts
       // one ring-width up and left — which is what makes the avatar read as notched, not badged.
-      expect(dot.style.transform).toBe(offset);
-    });
-
-    it('draws the claim pills’ face without being told', () => {
-      const { container } = render(<OnlineDot />);
-
-      expect((container.firstChild as HTMLElement).style.width).toBe('4px');
-    });
-
-    // Sized inline rather than through Tailwind: a class name computed from a prop is one the
-    // compiler never sees, so it would ship without the rule that sizes it.
-    it('carries its size as style rather than a computed class', () => {
-      const { container } = render(<OnlineDot faceSize={32} />);
-
-      expect((container.firstChild as HTMLElement).className).not.toMatch(/size-|border-\d/);
+      transform: offset,
     });
   });
 
   it('is hidden from assistive tech', () => {
-    const { container } = render(<OnlineDot />);
+    const { container } = render(<OnlineDot faceSize={FACE} />);
 
     // Decoration beside a face that is itself `aria-hidden` in these stacks; presence is not
     // something a screen reader should hear as an unnamed graphic.

--- a/apps/web/design-system/online-dot.test.tsx
+++ b/apps/web/design-system/online-dot.test.tsx
@@ -42,6 +42,39 @@ describe('OnlineDot', () => {
     expect(container.firstChild).toHaveClass('box-content');
   });
 
+  describe('scales to the face it sits on', () => {
+    // The proportions, not the pixels: green is a quarter of the face, the ring half the green.
+    // The People tab's 32px faces wore the 16px face's dot, which read as a speck.
+    it.each([
+      [16, '4px', '2px', 'translate(-2px, -2px)'],
+      [32, '8px', '4px', 'translate(-4px, -4px)'],
+    ])('on a %ipx face', (faceSize, green, ring, offset) => {
+      const { container } = render(<OnlineDot faceSize={faceSize} />);
+      const dot = container.firstChild as HTMLElement;
+
+      expect(dot.style.width).toBe(green);
+      expect(dot.style.height).toBe(green);
+      expect(dot.style.borderWidth).toBe(ring);
+      // The green body sits on the face's corner and the ring bleeds outside, so the element starts
+      // one ring-width up and left — which is what makes the avatar read as notched, not badged.
+      expect(dot.style.transform).toBe(offset);
+    });
+
+    it('draws the claim pills’ face without being told', () => {
+      const { container } = render(<OnlineDot />);
+
+      expect((container.firstChild as HTMLElement).style.width).toBe('4px');
+    });
+
+    // Sized inline rather than through Tailwind: a class name computed from a prop is one the
+    // compiler never sees, so it would ship without the rule that sizes it.
+    it('carries its size as style rather than a computed class', () => {
+      const { container } = render(<OnlineDot faceSize={32} />);
+
+      expect((container.firstChild as HTMLElement).className).not.toMatch(/size-|border-\d/);
+    });
+  });
+
   it('is hidden from assistive tech', () => {
     const { container } = render(<OnlineDot />);
 

--- a/apps/web/design-system/online-dot.tsx
+++ b/apps/web/design-system/online-dot.tsx
@@ -4,6 +4,13 @@ import cx from 'classnames';
 
 type Props = {
   /**
+   * The diameter of the face this sits on, in px. The dot is drawn as a fraction of it.
+   *
+   * Defaults to 16, the claim pills' face — which is where this geometry came from, and where it
+   * was the only size that existed.
+   */
+  faceSize?: number;
+  /**
    * The surface the dot sits on, as a Tailwind *border* colour.
    *
    * The ring is not decoration: the dot sits on the edge of a face, so without a band of the
@@ -18,26 +25,57 @@ type Props = {
 /**
  * The green "online now" dot on a face.
  *
- * `bg-green` is the design's `#2ACE9D` exactly, already a token here. 8px overall — 4px of green
- * in a 2px ring — which is Figma's `r=3` circle under an opaque `stroke-width=2`: the stroke
- * straddles the radius, so it eats the outer third of the fill and the green reads 4px, not 6px.
- * One size: the 12px faces that briefly wanted a smaller one are 16px again.
+ * `bg-green` is the design's `#2ACE9D` exactly, already a token here.
  *
- * `box-content` is load-bearing and its absence is silent. Tailwind's preflight makes everything
- * `border-box`, so a 4px box with a 2px border on each side has a *zero-width* content box: the
- * ring paints and the green has no area left to paint in. The dot then renders as a 4px disc in
- * whatever colour the surface behind it already is — invisible, on every avatar, with no error.
- * The avatar wrapper these sit on top of carries `box-content` for the same reason.
+ * ## Scaled to the face, not fixed
  *
- * Deliberately not part of `Avatar`: it says the person is *present*, which is a fact about a live
- * session rather than about the picture. Only the stacks built from presence pass it, so an avatar
- * cannot pick up a green dot by being rendered somewhere that never knew whether they were online.
+ * On a 16px face the dot is 4px of green in a 2px ring — 8px overall — which is Figma's `r=3`
+ * circle under an opaque `stroke-width=2`: the stroke straddles the radius, so it eats the outer
+ * third of the fill and the green reads 4px, not 6px.
+ *
+ * Those are the proportions, not the measurements: green is a quarter of the face and the ring half
+ * the green. Hard-coding the 16px numbers left the 32px faces in the People tab wearing a dot built
+ * for a face half their size, which read as a speck rather than a badge. One definition here rather
+ * than a magic number at each call site, because the two had already drifted.
+ *
+ * Placement comes with it. The dot's green body sits on the face's own top-left corner and its ring
+ * bleeds outside, so the avatar reads as notched rather than badged — which means the element
+ * starts one ring-width up and left of that corner. Callers supply a `relative` wrapper the size of
+ * the face; they do not do this arithmetic.
+ *
+ * ## `box-content` is load-bearing and its absence is silent
+ *
+ * Tailwind's preflight makes everything `border-box`, so a 4px box with a 2px border on each side
+ * has a *zero-width* content box: the ring paints and the green has no area left to paint in. The
+ * dot then renders as a 4px disc in whatever colour the surface behind it already is — invisible,
+ * on every avatar, with no error. The avatar wrapper these sit on carries `box-content` too.
+ *
+ * ## Deliberately not part of `Avatar`
+ *
+ * It says the person is *present*, which is a fact about a live session rather than about the
+ * picture. Only the stacks built from presence pass it, so an avatar cannot pick up a green dot by
+ * being rendered somewhere that never knew whether they were online.
  */
-export function OnlineDot({ ringClassName = 'border-white', className }: Props) {
+export function OnlineDot({ faceSize = 16, ringClassName = 'border-white', className }: Props) {
+  const green = faceSize / 4;
+  const ring = green / 2;
+
   return (
     <span
       aria-hidden
-      className={cx('box-content block size-1 rounded-full border-2 bg-green', ringClassName, className)}
+      // Inline rather than Tailwind sizes: these are derived from `faceSize`, and a computed class
+      // name is one the compiler never sees, so it would ship without the rule that sizes it.
+      style={{
+        width: green,
+        height: green,
+        borderWidth: ring,
+        transform: `translate(${-ring}px, ${-ring}px)`,
+      }}
+      className={cx(
+        'box-content absolute top-0 left-0 block rounded-full border-solid bg-green',
+        ringClassName,
+        className
+      )}
     />
   );
 }

--- a/apps/web/design-system/online-dot.tsx
+++ b/apps/web/design-system/online-dot.tsx
@@ -6,10 +6,11 @@ type Props = {
   /**
    * The diameter of the face this sits on, in px. The dot is drawn as a fraction of it.
    *
-   * Defaults to 16, the claim pills' face — which is where this geometry came from, and where it
-   * was the only size that existed.
+   * Required, with no default: a dot that is silently the wrong size for its face is the bug this
+   * prop exists to stop, and a default would let the next face size reintroduce it without so much
+   * as a type error. `ringClassName` defaults because a wrong colour is visible; this is not.
    */
-  faceSize?: number;
+  faceSize: number;
   /**
    * The surface the dot sits on, as a Tailwind *border* colour.
    *
@@ -19,7 +20,6 @@ type Props = {
    * caller has to say what it is standing on rather than this guessing white.
    */
   ringClassName?: string;
-  className?: string;
 };
 
 /**
@@ -40,15 +40,17 @@ type Props = {
  *
  * Placement comes with it. The dot's green body sits on the face's own top-left corner and its ring
  * bleeds outside, so the avatar reads as notched rather than badged — which means the element
- * starts one ring-width up and left of that corner. Callers supply a `relative` wrapper the size of
- * the face; they do not do this arithmetic.
+ * starts one ring-width up and left of that corner. Callers owe it a `relative` box the size of the
+ * face and nothing else; they do not do this arithmetic, and there is deliberately no `className`
+ * for them to re-place it with.
  *
  * ## `box-content` is load-bearing and its absence is silent
  *
  * Tailwind's preflight makes everything `border-box`, so a 4px box with a 2px border on each side
  * has a *zero-width* content box: the ring paints and the green has no area left to paint in. The
  * dot then renders as a 4px disc in whatever colour the surface behind it already is — invisible,
- * on every avatar, with no error. The avatar wrapper these sit on carries `box-content` too.
+ * on every avatar, with no error. The claim pills' ringed face wrapper carries `box-content` for
+ * the same reason; a wrapper with no border of its own, like the People tab's, does not need it.
  *
  * ## Deliberately not part of `Avatar`
  *
@@ -56,26 +58,23 @@ type Props = {
  * picture. Only the stacks built from presence pass it, so an avatar cannot pick up a green dot by
  * being rendered somewhere that never knew whether they were online.
  */
-export function OnlineDot({ faceSize = 16, ringClassName = 'border-white', className }: Props) {
+export function OnlineDot({ faceSize, ringClassName = 'border-white' }: Props) {
   const green = faceSize / 4;
   const ring = green / 2;
 
   return (
     <span
       aria-hidden
-      // Inline rather than Tailwind sizes: these are derived from `faceSize`, and a computed class
-      // name is one the compiler never sees, so it would ship without the rule that sizes it.
+      // Inline rather than Tailwind sizes, as `RecordingCountdownRing` does with its own derived
+      // geometry: these come from `faceSize`, and a computed class name is one the compiler never
+      // sees, so it would ship without the rule that sizes it.
       style={{
         width: green,
         height: green,
         borderWidth: ring,
         transform: `translate(${-ring}px, ${-ring}px)`,
       }}
-      className={cx(
-        'box-content absolute top-0 left-0 block rounded-full border-solid bg-green',
-        ringClassName,
-        className
-      )}
+      className={cx('box-content absolute top-0 left-0 block rounded-full border-solid bg-green', ringClassName)}
     />
   );
 }


### PR DESCRIPTION
The People tab's green "online now" dot is too small. Its 32px faces were wearing the dot built for the claim pills' 16px ones, so it read as a speck rather than a badge.

## The cause

The dot's geometry was written out at each call site, in pixels:

```tsx
// claim pills, 16px face
<OnlineDot ringClassName={ringClassName} className="absolute top-0 left-0 -translate-x-0.5 -translate-y-0.5" />
// People tab, 32px face — the same dot, and the same 2px offset
<OnlineDot className="absolute top-0 left-0 -translate-x-0.5 -translate-y-0.5" />
```

`OnlineDot` had one fixed size, so the two call sites could only agree by accident, and the `-translate-*-0.5` was 2px at both — correct for a 2px ring and wrong for a 4px one.

## What changed

`OnlineDot` derives the whole unit from the face, as you asked — the pills' proportions, scaled:

| face | green | ring | overall | offset |
| --- | --- | --- | --- | --- |
| 16px (claim pills) | 4px | 2px | 8px | 2px |
| 32px (People tab) | 8px | 4px | 16px | 4px |

Green is a quarter of the face, the ring half the green. The 16px numbers are exactly what was already shipping, so the pills are untouched.

**Placement moved in with it.** The green body sits on the face's own top-left corner with the ring bleeding outside — which is what makes the avatar read as notched rather than badged — so the element starts one ring-width up and left. Callers were each doing that arithmetic by hand; now they supply a `relative` wrapper the size of the face and nothing else.

## One implementation note

The sizes are inline styles, not Tailwind classes. A class name computed from a prop is one the compiler never sees, so `size-[${green}px]` would ship without the rule that sizes it — invisibly, which is the same failure mode the `box-content` comment in that file already warns about. There is a test asserting the element carries no computed size class, alongside tests for the proportions at both sizes.

## Verification

**459 test files, 5097 tests passing.** Real `bun run build`. ESLint clean. `tsc --noEmit` at 5 errors, identical on master.

Mutation-checked: pinning green back to a fixed 4px fails `on a 32px face` and only that.

## Worth a look

The proportions are inferred from the pills' 16px implementation rather than read off a design — the pills are 4px-in-2px and I scaled that. If Figma specifies something different for the 32px face, that number is one constant in `online-dot.tsx`.
