### PR TITLE
fix(search): stop caching a cancelled search as "no matches"

### DIFF
--- a/apps/web/core/chat/read-dispatcher.ts
+++ b/apps/web/core/chat/read-dispatcher.ts
@@ -9,6 +9,7 @@ import { type UIMessage, isToolUIPart } from 'ai';
 import * as Effect from 'effect/Effect';
 
 import { DEFAULT_ENTITY_SCHEMA } from '~/core/database/entities';
+import { isSearchCancellation } from '~/core/hooks/search-cancellation';
 import { getEntity, getResults, getSpace, getSpaces } from '~/core/io/queries';
 import { queryClient } from '~/core/query-client';
 import { E } from '~/core/sync/orm';
@@ -411,7 +412,13 @@ export async function executeSearchGraph(input: SearchGraphInput, ctx: ReadCtx):
             ),
         })
         .catch(err => {
-          console.error('[chat/read-dispatcher] searchGraph remote failed', err);
+          // A cancellation is not a failure and should not be logged as one. The
+          // empty list stands either way — unlike the picker search this does not
+          // cache, so the fallback costs this one call rather than sticking — and
+          // the local matches below still answer.
+          if (!isSearchCancellation(err)) {
+            console.error('[chat/read-dispatcher] searchGraph remote failed', err);
+          }
           return [] as SearchResult[];
         }),
     ]);

--- a/apps/web/core/hooks/search-cancellation.test.ts
+++ b/apps/web/core/hooks/search-cancellation.test.ts
@@ -1,3 +1,5 @@
+import { CancelledError } from '@tanstack/react-query';
+
 import * as Effect from 'effect/Effect';
 import { describe, expect, it } from 'vitest';
 
@@ -80,6 +82,19 @@ describe('isSearchCancellation', () => {
 
   it("recognises the repo's tagged AbortError thrown directly", () => {
     expect(isSearchCancellation(new AbortError(), live())).toBe(true);
+  });
+
+  // A caller awaiting `fetchQuery` — the chat dispatcher — is rejected with this
+  // when React Query cancels that query. It never reaches the `queryFn`, so it is
+  // wrapped by nothing, and it is invisible to every check above: its `name` is
+  // "Error" and it renders as "Error: CancelledError".
+  it("recognises React Query's CancelledError, which identifies itself by neither name nor text", () => {
+    const cancelled = new CancelledError();
+
+    expect(cancelled.name).toBe('Error');
+    expect(String(cancelled)).toBe('Error: CancelledError');
+    expect(isSearchCancellation(cancelled)).toBe(true);
+    expect(isSearchCancellation(cancelled, live())).toBe(true);
   });
 
   it('leaves a real failure alone, so it is still logged and reported', () => {

--- a/apps/web/core/hooks/search-cancellation.test.ts
+++ b/apps/web/core/hooks/search-cancellation.test.ts
@@ -1,6 +1,19 @@
+import * as Effect from 'effect/Effect';
 import { describe, expect, it } from 'vitest';
 
+import { AbortError } from '~/core/io/subgraph/errors';
+
 import { isSearchCancellation } from './search-cancellation';
+
+/** The rejection `Effect.runPromise` hands back, rather than a hand-made look-alike. */
+const rejectionOf = async (effect: Effect.Effect<never, unknown>): Promise<unknown> => {
+  try {
+    await Effect.runPromise(effect);
+    throw new Error('expected the effect to fail');
+  } catch (error) {
+    return error;
+  }
+};
 
 const live = () => new AbortController().signal;
 
@@ -31,12 +44,42 @@ describe('isSearchCancellation', () => {
 
   // The one that actually bit. A deduplicated inner fetch, started by a query
   // that was then cancelled, rejects into whichever query is now awaiting it —
-  // so our signal is live and the name is Effect's, not the DOM's.
-  it("recognises Effect's wrapped abort, which carries neither our signal nor the name", () => {
-    const error = new Error('signal is aborted without reason');
-    error.name = 'FiberFailure';
+  // so our signal is live and the wrapper is Effect's, not the DOM's.
+  //
+  // These three go through `Effect.runPromise` rather than asserting against a
+  // hand-built stand-in, because the wrapper is exactly what the code has to see
+  // through: its own name is "(FiberFailure) Error", it has no `cause`, and the
+  // original is reachable only through Effect's API. A stand-in that merely looks
+  // the part would pass while the real rejection did not — which is how the
+  // tagged case below went unnoticed.
+  it("sees through Effect's wrapper to the repo's tagged AbortError, as restFetch produces", async () => {
+    const rejection = await rejectionOf(Effect.fail(new AbortError()));
 
-    expect(isSearchCancellation(error, live())).toBe(true);
+    expect(isSearchCancellation(rejection, live())).toBe(true);
+  });
+
+  it("sees through Effect's wrapper to a DOM AbortError arriving as a defect", async () => {
+    const dom = new Error('signal is aborted without reason');
+    dom.name = 'AbortError';
+    const rejection = await rejectionOf(Effect.die(dom));
+
+    expect(isSearchCancellation(rejection, live())).toBe(true);
+  });
+
+  it('treats an interrupted fiber as a cancellation', async () => {
+    const rejection = await rejectionOf(Effect.interrupt as Effect.Effect<never, never>);
+
+    expect(isSearchCancellation(rejection, live())).toBe(true);
+  });
+
+  it('still lets a genuine failure through the wrapper', async () => {
+    const rejection = await rejectionOf(Effect.fail(new Error('500 Internal Server Error')));
+
+    expect(isSearchCancellation(rejection, live())).toBe(false);
+  });
+
+  it("recognises the repo's tagged AbortError thrown directly", () => {
+    expect(isSearchCancellation(new AbortError(), live())).toBe(true);
   });
 
   it('leaves a real failure alone, so it is still logged and reported', () => {

--- a/apps/web/core/hooks/search-cancellation.test.ts
+++ b/apps/web/core/hooks/search-cancellation.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+
+import { isSearchCancellation } from './search-cancellation';
+
+const live = () => new AbortController().signal;
+
+const aborted = () => {
+  const controller = new AbortController();
+  controller.abort();
+  return controller.signal;
+};
+
+describe('isSearchCancellation', () => {
+  it('recognises our own signal being cancelled', () => {
+    expect(isSearchCancellation(new Error('whatever'), aborted())).toBe(true);
+  });
+
+  it('recognises a plain AbortError', () => {
+    const error = new Error('The operation was aborted');
+    error.name = 'AbortError';
+
+    expect(isSearchCancellation(error, live())).toBe(true);
+  });
+
+  it('recognises one wrapped a level down', () => {
+    const inner = new Error('The operation was aborted');
+    inner.name = 'AbortError';
+
+    expect(isSearchCancellation(new Error('request failed', { cause: inner }), live())).toBe(true);
+  });
+
+  // The one that actually bit. A deduplicated inner fetch, started by a query
+  // that was then cancelled, rejects into whichever query is now awaiting it —
+  // so our signal is live and the name is Effect's, not the DOM's.
+  it("recognises Effect's wrapped abort, which carries neither our signal nor the name", () => {
+    const error = new Error('signal is aborted without reason');
+    error.name = 'FiberFailure';
+
+    expect(isSearchCancellation(error, live())).toBe(true);
+  });
+
+  it('leaves a real failure alone, so it is still logged and reported', () => {
+    expect(isSearchCancellation(new Error('500 Internal Server Error'), live())).toBe(false);
+    expect(isSearchCancellation(new TypeError('Failed to fetch'), live())).toBe(false);
+  });
+
+  // A cause chain can be circular; a rejected search is the last place to hang.
+  it('terminates on a circular cause chain', () => {
+    const error = new Error('boom') as Error & { cause?: unknown };
+    error.cause = error;
+
+    expect(isSearchCancellation(error, live())).toBe(false);
+  });
+
+  // One caller classifies the error after the promise has been handed back, with
+  // no signal in scope.
+  it('works without a signal', () => {
+    const error = new Error('signal is aborted without reason');
+    error.name = 'FiberFailure';
+
+    expect(isSearchCancellation(error)).toBe(true);
+    expect(isSearchCancellation(new Error('500 Internal Server Error'))).toBe(false);
+  });
+
+  it('copes with whatever was thrown not being an error at all', () => {
+    expect(isSearchCancellation(null, live())).toBe(false);
+    expect(isSearchCancellation(undefined, live())).toBe(false);
+    expect(isSearchCancellation('signal is aborted without reason', live())).toBe(true);
+  });
+});

--- a/apps/web/core/hooks/search-cancellation.ts
+++ b/apps/web/core/hooks/search-cancellation.ts
@@ -1,0 +1,37 @@
+/**
+ * Whether a failed search was cancelled rather than broken.
+ *
+ * This decides whether the failure is cached. A cancellation has to be re-thrown
+ * so React Query treats it as a cancel; swallowing it into an empty page caches
+ * "no matches" under that query's key, and the key only changes when the text
+ * does — so the picker sits on an empty list until the searcher types another
+ * character. Adding a trailing space was enough to fix it, which is what made it
+ * look like a search problem rather than a caching one.
+ *
+ * Three shapes, because an abort reaches this from three places:
+ *
+ * - This query's own signal, when React Query cancels us directly.
+ * - A `DOMException` named `AbortError`, possibly wrapped a level or two down.
+ * - An Effect `FiberFailure` carrying an abort from a *deduplicated inner fetch*.
+ *   That is the one that actually bit: the inner request is shared by key, so a
+ *   query that starts while a previous one is being cancelled attaches to the
+ *   dying promise and receives its rejection. Our own signal is untouched and the
+ *   error's name is `FiberFailure`, so neither of the first two checks sees it —
+ *   only the message does.
+ */
+export function isSearchCancellation(error: unknown, signal?: AbortSignal): boolean {
+  if (signal?.aborted) return true;
+
+  // Bounded rather than `while`: a cause chain can be circular, and this runs on
+  // a rejected search where the last thing wanted is a hang.
+  let cause: unknown = error;
+  for (let depth = 0; cause !== null && cause !== undefined && depth < 5; depth++) {
+    const step = cause as { name?: unknown; cause?: unknown };
+    if (step.name === 'AbortError') return true;
+    cause = step.cause;
+  }
+
+  // Effect stringifies the wrapped abort; the DOM's own wording for a signal
+  // aborted with no reason given.
+  return /signal is aborted/i.test(String(error));
+}

--- a/apps/web/core/hooks/search-cancellation.ts
+++ b/apps/web/core/hooks/search-cancellation.ts
@@ -1,3 +1,6 @@
+import * as Cause from 'effect/Cause';
+import * as Runtime from 'effect/Runtime';
+
 /**
  * Whether a failed search was cancelled rather than broken.
  *
@@ -8,30 +11,55 @@
  * character. Adding a trailing space was enough to fix it, which is what made it
  * look like a search problem rather than a caching one.
  *
- * Three shapes, because an abort reaches this from three places:
+ * An abort reaches this from two directions, and neither is obvious:
  *
- * - This query's own signal, when React Query cancels us directly.
- * - A `DOMException` named `AbortError`, possibly wrapped a level or two down.
- * - An Effect `FiberFailure` carrying an abort from a *deduplicated inner fetch*.
- *   That is the one that actually bit: the inner request is shared by key, so a
- *   query that starts while a previous one is being cancelled attaches to the
- *   dying promise and receives its rejection. Our own signal is untouched and the
- *   error's name is `FiberFailure`, so neither of the first two checks sees it —
- *   only the message does.
+ * - **This query's own signal**, when React Query cancels us directly.
+ * - **Somebody else's**, because the inner REST fetch is deduplicated by key. A
+ *   query starting while a previous one is being cancelled attaches to the dying
+ *   promise and inherits its rejection, so our signal stays live. That is the one
+ *   that actually bit.
+ *
+ * The second arrives through `Effect.runPromise`, which tells you almost nothing
+ * from the outside: the rejection's own name is `"(FiberFailure) Error"`, it has
+ * no `cause` property, and the original hangs off a private symbol. So the wrapper
+ * is unwrapped with Effect's own API rather than read off the rendered message —
+ * which matters, because what it wraps is not always shaped the same way:
+ *
+ * - `restFetch` converts an aborted fetch into this repo's **tagged** `AbortError`
+ *   (`_tag`, no `name`), which arrives as a typed failure.
+ * - An abort that escapes as a **defect** is still the DOM's `AbortError` (`name`,
+ *   no `_tag`).
+ * - Effect can also interrupt the fiber outright, which carries neither.
  */
 export function isSearchCancellation(error: unknown, signal?: AbortSignal): boolean {
   if (signal?.aborted) return true;
 
-  // Bounded rather than `while`: a cause chain can be circular, and this runs on
-  // a rejected search where the last thing wanted is a hang.
-  let cause: unknown = error;
-  for (let depth = 0; cause !== null && cause !== undefined && depth < 5; depth++) {
-    const step = cause as { name?: unknown; cause?: unknown };
-    if (step.name === 'AbortError') return true;
-    cause = step.cause;
+  if (Runtime.isFiberFailure(error)) {
+    const cause = error[Runtime.FiberFailureCauseId];
+    if (Cause.isInterrupted(cause)) return true;
+    if (isAbortShaped(Cause.squash(cause))) return true;
   }
 
-  // Effect stringifies the wrapped abort; the DOM's own wording for a signal
-  // aborted with no reason given.
-  return /signal is aborted/i.test(String(error));
+  // Bounded rather than `while`: a cause chain can be circular, and this runs on
+  // a rejected search where the last thing wanted is a hang.
+  let step: unknown = error;
+  for (let depth = 0; step !== null && step !== undefined && depth < 5; depth++) {
+    if (isAbortShaped(step)) return true;
+    step = (step as { cause?: unknown }).cause;
+  }
+
+  // Last resort, for an abort that reaches us as text rather than an object — and
+  // as cover for `isFiberFailure` failing to recognise a wrapper built by a second
+  // copy of Effect, since being wrong here re-caches the empty page this exists to
+  // prevent. Both renderings: the tagged error serialized, and the DOM's own
+  // wording for a signal aborted with no reason given.
+  const rendered = String(error);
+  return /"_tag":\s*"AbortError"/.test(rendered) || /signal is aborted/i.test(rendered);
+}
+
+/** The DOM's `AbortError` carries a `name`; this repo's tagged one carries a `_tag`. */
+function isAbortShaped(value: unknown): boolean {
+  if (value === null || typeof value !== 'object') return false;
+  const { name, _tag } = value as { name?: unknown; _tag?: unknown };
+  return name === 'AbortError' || _tag === 'AbortError';
 }

--- a/apps/web/core/hooks/search-cancellation.ts
+++ b/apps/web/core/hooks/search-cancellation.ts
@@ -1,3 +1,5 @@
+import { isCancelledError } from '@tanstack/react-query';
+
 import * as Cause from 'effect/Cause';
 import * as Runtime from 'effect/Runtime';
 
@@ -30,9 +32,16 @@ import * as Runtime from 'effect/Runtime';
  * - An abort that escapes as a **defect** is still the DOM's `AbortError` (`name`,
  *   no `_tag`).
  * - Effect can also interrupt the fiber outright, which carries neither.
+ *
+ * React Query has a fourth of its own. A caller awaiting `fetchQuery` is rejected
+ * with `CancelledError` when that query is cancelled, which never reaches the
+ * `queryFn` and so is wrapped by nothing — and it is unrecognisable by shape: its
+ * `name` is `"Error"` and it renders as `"Error: CancelledError"`. Only the
+ * library's own predicate identifies it, as `debate-gateway` also does.
  */
 export function isSearchCancellation(error: unknown, signal?: AbortSignal): boolean {
   if (signal?.aborted) return true;
+  if (isCancelledError(error)) return true;
 
   if (Runtime.isFiberFailure(error)) {
     const cause = error[Runtime.FiberFailureCauseId];

--- a/apps/web/core/hooks/use-place-search.ts
+++ b/apps/web/core/hooks/use-place-search.ts
@@ -5,10 +5,7 @@ import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useCallback, useEffect, useState } from 'react';
 
 import { Duration } from 'effect';
-import * as Effect from 'effect/Effect';
-import * as Either from 'effect/Either';
 
-import { Subgraph } from '~/core/io';
 import { EntityId } from '~/core/io/substream-schema';
 import { validateEntityId } from '~/core/utils/utils';
 
@@ -18,6 +15,7 @@ import { E } from '../sync/orm';
 import { useSyncEngine } from '../sync/use-sync-engine';
 import { PLACE_TYPE } from '../system-ids';
 import { SearchResult } from '../types';
+import { isSearchCancellation } from './search-cancellation';
 import { useDebouncedValue } from './use-debounced-value';
 
 export type Feature = {
@@ -53,86 +51,43 @@ export const usePlaceSearch = () => {
       if (isValidEntityId) {
         const id = EntityId(maybeEntityId);
 
-        const fetchResultEffect = Effect.either(
-          Effect.tryPromise({
-            try: async () =>
-              await mergeSearchResult({
-                id,
-                store,
-              }),
+        try {
+          const merged = await mergeSearchResult({ id, store });
+          return merged ? [merged] : [];
+        } catch (error) {
+          // See `isSearchCancellation`: an empty array returned here is cached under
+          // this key as a successful "no matches".
+          if (isSearchCancellation(error)) throw error;
+          console.error('usePlaceSearch entity lookup failed:', error);
+          return [];
+        }
+      }
 
-            catch: error => {
-              console.error('error', error);
-              return new Subgraph.Errors.AbortError();
+      try {
+        return await E.findFuzzy({
+          store,
+          cache,
+          where: {
+            name: {
+              fuzzy: debouncedQuery,
             },
-          })
-        );
-
-        const resultOrError = await Effect.runPromise(fetchResultEffect);
-
-        if (Either.isLeft(resultOrError)) {
-          const error = resultOrError.left;
-
-          switch (error._tag) {
-            case 'AbortError':
-              console.log(`abort error`);
-              return [];
-            default:
-              console.error('useSearch error:', String(error));
-              throw error;
-          }
-        }
-        console.log('resultOrError.right', resultOrError.right);
-        return resultOrError.right ? [resultOrError.right] : [];
-      }
-
-      const fetchResultsEffect = Effect.either(
-        Effect.tryPromise({
-          try: async () =>
-            await E.findFuzzy({
-              store,
-              cache,
-              where: {
-                name: {
-                  fuzzy: debouncedQuery,
+            // Hardcoded
+            types: mockFilterByTypes?.map(t => {
+              return {
+                id: {
+                  equals: t,
                 },
-                // Hardcoded
-                types: mockFilterByTypes?.map(t => {
-                  return {
-                    id: {
-                      equals: t,
-                    },
-                  };
-                }),
-              },
-              first: 10,
-              skip: 0,
+              };
             }),
-          catch: error => {
-            console.error('error', error);
-            return new Subgraph.Errors.AbortError();
           },
-        })
-      );
-
-      const resultOrError = await Effect.runPromise(fetchResultsEffect);
-
-      if (Either.isLeft(resultOrError)) {
-        const error = resultOrError.left;
-
-        switch (error._tag) {
-          case 'AbortError':
-            console.log(`abort error`);
-            return [];
-          default:
-            console.error('useSearch error:', String(error));
-            throw error;
-        }
+          first: 10,
+          skip: 0,
+        });
+      } catch (error) {
+        if (isSearchCancellation(error)) throw error;
+        console.error('usePlaceSearch error:', error);
+        return [];
       }
-
-      console.log('resultOrError.right', resultOrError.right);
-
-      return resultOrError.right;
     },
     /**
      * We don't want to return stale search results. Instead we just

--- a/apps/web/core/hooks/use-search.ts
+++ b/apps/web/core/hooks/use-search.ts
@@ -15,6 +15,7 @@ import { E } from '../sync/orm';
 import { useSyncEngine } from '../sync/use-sync-engine';
 import type { SearchResult } from '../types';
 import { selectSearchAdditionalSpaceIds } from './search-additional-space-ids';
+import { isSearchCancellation } from './search-cancellation';
 import { useDebouncedValue } from './use-debounced-value';
 import { useGlobalSearchSpaceIds } from './use-global-search-space-ids';
 
@@ -48,6 +49,13 @@ interface SearchOptions {
    *   genuinely wants that specific restriction lifted.
    */
   includeNonCanonical?: boolean;
+  /**
+   * Extra spaces to make eligible, for a caller that knows where the thing it is
+   * searching for lives. Appended to the scoped spaces rather than replacing
+   * them, and ignored when the search is already scoped to one space or has
+   * asked for unrestricted results.
+   */
+  alsoSearchSpaceIds?: string[];
 }
 
 const DEFAULT_SEARCH_PAGE_SIZE = 10;
@@ -95,6 +103,7 @@ export function useSearch({
   enabled,
   pageSize = DEFAULT_SEARCH_PAGE_SIZE,
   includeNonCanonical,
+  alsoSearchSpaceIds,
 }: SearchOptions = {}) {
   const { store } = useSyncEngine();
   const cache = useQueryClient();
@@ -105,6 +114,7 @@ export function useSearch({
   const additionalSpaceIds = selectSearchAdditionalSpaceIds({
     filterBySpace,
     includeNonCanonical,
+    alsoSearchSpaceIds,
     globalAdditionalSpaceIds,
   });
 
@@ -193,10 +203,13 @@ export function useSearch({
         // Re-throw cancellations so React Query treats them as a cancel, not a
         // successful empty result. Returning `emptySearchPage` here would let RQ
         // cache the empty page under the canceled queryKey — leaving popovers
-        // stuck on "No matches" when the key changes mid-fetch (e.g.
-        // `additionalSpaceIds` settles after mount, or React StrictMode
-        // double-mounts in dev).
-        if (signal.aborted || (error as { name?: string })?.name === 'AbortError') {
+        // stuck on "No matches" until the query text changes, which is what made
+        // typing a trailing space look like it fixed the search.
+        //
+        // See `isSearchCancellation` for why the obvious two checks were not
+        // enough: an abort from a deduplicated inner fetch leaves this signal
+        // untouched and arrives wrapped by Effect.
+        if (isSearchCancellation(error, signal)) {
           throw error;
         }
         console.error(error);

--- a/apps/web/core/hooks/use-search.ts
+++ b/apps/web/core/hooks/use-search.ts
@@ -49,13 +49,6 @@ interface SearchOptions {
    *   genuinely wants that specific restriction lifted.
    */
   includeNonCanonical?: boolean;
-  /**
-   * Extra spaces to make eligible, for a caller that knows where the thing it is
-   * searching for lives. Appended to the scoped spaces rather than replacing
-   * them, and ignored when the search is already scoped to one space or has
-   * asked for unrestricted results.
-   */
-  alsoSearchSpaceIds?: string[];
 }
 
 const DEFAULT_SEARCH_PAGE_SIZE = 10;
@@ -103,7 +96,6 @@ export function useSearch({
   enabled,
   pageSize = DEFAULT_SEARCH_PAGE_SIZE,
   includeNonCanonical,
-  alsoSearchSpaceIds,
 }: SearchOptions = {}) {
   const { store } = useSyncEngine();
   const cache = useQueryClient();
@@ -114,7 +106,6 @@ export function useSearch({
   const additionalSpaceIds = selectSearchAdditionalSpaceIds({
     filterBySpace,
     includeNonCanonical,
-    alsoSearchSpaceIds,
     globalAdditionalSpaceIds,
   });
 

--- a/apps/web/core/hooks/use-spaces-query.ts
+++ b/apps/web/core/hooks/use-spaces-query.ts
@@ -4,10 +4,8 @@ import { useInfiniteQuery, useQueryClient } from '@tanstack/react-query';
 
 import { useState } from 'react';
 
-import { Effect, Either } from 'effect';
-
+import { isSearchCancellation } from '~/core/hooks/search-cancellation';
 import { useDebouncedValue } from '~/core/hooks/use-debounced-value';
-import { Subgraph } from '~/core/io';
 import { capSearchQuery } from '~/core/io/search-query';
 
 import { E } from '../sync/orm';
@@ -41,56 +39,45 @@ export function useSpacesQuery(enabled = true, options?: UseSpacesQueryOptions) 
     queryKey: ['spaces-by-name', cappedQuery, matchLimit],
     initialPageParam: 0,
     queryFn: async ({ pageParam, signal }) => {
-      const fetchResultsEffect = Effect.either(
-        Effect.tryPromise({
-          try: async () =>
-            await E.findFuzzyPage({
-              store,
-              cache,
-              where: {
-                name: {
-                  fuzzy: cappedQuery,
+      try {
+        const page = await E.findFuzzyPage({
+          store,
+          cache,
+          where: {
+            name: {
+              fuzzy: cappedQuery,
+            },
+            types: filterByTypes?.map(t => {
+              return {
+                id: {
+                  equals: t,
                 },
-                types: filterByTypes?.map(t => {
-                  return {
-                    id: {
-                      equals: t,
-                    },
-                  };
-                }),
-              },
-              first: matchLimit,
-              skip: pageParam,
-              signal,
+              };
             }),
-          catch: error => {
-            console.error('error', error);
-            return new Subgraph.Errors.AbortError();
           },
-        })
-      );
+          first: matchLimit,
+          skip: pageParam,
+          signal,
+        });
 
-      const resultOrError = await Effect.runPromise(fetchResultsEffect);
+        return { rows: page.results, offset: pageParam, rawCount: page.rawCount, total: page.total };
+      } catch (error) {
+        // Re-throw cancellations for the same reason `useSearch` does: returning an
+        // empty page here caches "no matches" under this key, and the key only
+        // changes when the query text does, so the space picker sits empty until
+        // the searcher types another character. This hook shares `findFuzzyPage`
+        // with `useSearch`, so it shares the deduplicated inner fetch that made
+        // somebody else's cancellation arrive here.
+        if (isSearchCancellation(error, signal)) throw error;
 
-      if (Either.isLeft(resultOrError)) {
-        const error = resultOrError.left;
-
-        switch (error._tag) {
-          case 'AbortError':
-            console.log(`abort error`);
-            return { rows: [], offset: pageParam, rawCount: 0, total: 0 };
-          default:
-            console.error('useSearch error:', String(error));
-            throw error;
-        }
+        // Genuine failures still degrade to an empty page rather than throwing at
+        // the picker, which is what this did before — but they are now logged as
+        // themselves. Every rejection used to be relabelled `AbortError` and then
+        // handled as one, so a real failure was silently indistinguishable from a
+        // cancelled keystroke and the branch meant to re-throw it was unreachable.
+        console.error('useSpacesQuery error:', error);
+        return { rows: [], offset: pageParam, rawCount: 0, total: 0 };
       }
-
-      return {
-        rows: resultOrError.right.results,
-        offset: pageParam,
-        rawCount: resultOrError.right.rawCount,
-        total: resultOrError.right.total,
-      };
     },
     getNextPageParam: lastPage => {
       const nextOffset = lastPage.offset + matchLimit;

--- a/apps/web/partials/blocks/table/table-block-properties-menu.tsx
+++ b/apps/web/partials/blocks/table/table-block-properties-menu.tsx
@@ -22,15 +22,14 @@ import { useQuery, useQueryClient } from '@tanstack/react-query';
 
 import * as React from 'react';
 
-import { Effect, Either } from 'effect';
 import { useSetAtom } from 'jotai';
 
 import { isBlockMediaProperty, resolveMainMediaProperty } from '~/core/blocks/data/resolve-main-media-property';
 import { columnPropertyIdFromRelation } from '~/core/blocks/data/shown-column-relations';
 import type { Source } from '~/core/blocks/data/source';
+import { isSearchCancellation } from '~/core/hooks/search-cancellation';
 import { useDebouncedValue } from '~/core/hooks/use-debounced-value';
 import { ID } from '~/core/id';
-import { Subgraph } from '~/core/io';
 import { E } from '~/core/sync/orm';
 import { useSyncEngine } from '~/core/sync/use-sync-engine';
 import { Property, Relation } from '~/core/types';
@@ -195,28 +194,26 @@ export function TableBlockPropertiesMenu({
 
   const { data: geoPropertyHits = [], isFetching: isGeoPropertySearchFetching } = useQuery({
     queryKey: ['table-block-properties-menu', 'geo-property-search', q],
-    queryFn: async () => {
-      const fetchResultsEffect = Effect.either(
-        Effect.tryPromise({
-          try: async () =>
-            await E.findFuzzy({
-              store,
-              cache,
-              where: {
-                name: { fuzzy: debouncedSearch },
-                types: [{ id: { equals: SystemIds.PROPERTY } }],
-              },
-              first: GEO_PROPERTY_SEARCH_LIMIT,
-              skip: 0,
-            }),
-          catch: () => new Subgraph.Errors.AbortError(),
-        })
-      );
-      const resultOrError = await Effect.runPromise(fetchResultsEffect);
-      if (Either.isLeft(resultOrError)) {
+    queryFn: async ({ signal }) => {
+      try {
+        return await E.findFuzzy({
+          store,
+          cache,
+          where: {
+            name: { fuzzy: debouncedSearch },
+            types: [{ id: { equals: SystemIds.PROPERTY } }],
+          },
+          first: GEO_PROPERTY_SEARCH_LIMIT,
+          skip: 0,
+        });
+      } catch (error) {
+        // See `isSearchCancellation`: an empty list returned here is cached under
+        // this key as a successful "no matches", and the key only changes when the
+        // search text does.
+        if (isSearchCancellation(error, signal)) throw error;
+        console.error('table-block-properties-menu geo property search failed:', error);
         return [];
       }
-      return resultOrError.right;
     },
     enabled: open && q.length > 0,
   });


### PR DESCRIPTION
Searching a picker for something that plainly exists returned nothing, and typing a trailing space fixed it.

## What was actually happening

The space was not fixing the search. `capSearchQuery` keeps trailing whitespace deliberately — leading whitespace is stripped, trailing is not — so `"Purdue"` and `"Purdue "` are different React Query keys. The space simply dodged what the first key had cached.

What it had cached was a **cancellation**, stored as a successful empty page.

`useSearch` already re-throws aborts so React Query treats them as cancels rather than results, and looked for one two ways: this query's own signal, and an error named `AbortError`. Neither sees the case that happens most:

- The inner REST fetch is shared by key, so a query starting while a previous one is being cancelled attaches to the dying promise and inherits its rejection — **our signal is untouched**.
- It comes back wrapped by `Effect.runPromise`, whose rejection is named **`(FiberFailure) Error`**, not `AbortError`, and exposes neither the name nor a `cause` to check.

It fell through to `emptySearchPage`, and React Query served that under the key until the query text changed.

```
FiberFailure: signal is aborted without reason
  at catch (...)
```

## The fix

`isSearchCancellation` decides whether a failed search was cancelled rather than broken, and it unwraps Effect rather than reading its message.

That matters because the rejection tells you almost nothing from the outside: its own name is `"(FiberFailure) Error"`, it has no `cause` property, and the original hangs off a private symbol — so neither a name check nor a cause walk reaches it. Effect publishes the way in, and the helper uses it: `Runtime.isFiberFailure` and `Runtime.FiberFailureCauseId` give the `Cause`, `Cause.squash` the error underneath, `Cause.isInterrupted` the interrupt case that carries no error at all.

Unwrapping structurally matters because what is wrapped is not always shaped the same way:

| shape | carries | where it comes from |
| --- | --- | --- |
| tagged `AbortError` | `_tag` | `restFetch` converts an aborted fetch into this repo's own error |
| DOM `AbortError` | `name` | an abort escaping as a defect |
| interrupted fiber | neither | Effect interrupting the fiber outright |

The predicate reads `_tag` as well as `name`, so the tagged error is also recognised when thrown directly, as `fetch-proposals-by-user` does. A bounded cause walk still handles ordinary wrapped errors, and a text match remains as a last resort — widened to the tagged rendering — because being wrong here re-caches the very empty page this exists to prevent, and `isFiberFailure` would not recognise a wrapper built by a second copy of Effect.

A genuine failure still logs and still returns empty.

Tests assert against real rejections from `Effect.runPromise` rather than hand-built look-alikes, which is the difference that caught the tagged case: a stand-in with `name = 'FiberFailure'` passes while the real rejection, whose name is not that, does not.

## Scope

**This was originally scoped wrong, and review caught it.** The claim was that every picker shares `useSearch`, so fixing that hook fixed all of them. It does not: three other hooks run their own `queryFn` over the same `findFuzzy` machinery, and each had the identical bug.

Swept by signature — a `catch` converting a rejection to `Subgraph.Errors.AbortError()`, then handling `AbortError` by returning an empty result — which found all of them. These four are now every such conversion left in the app:

| hook | surfaces | cached |
| --- | --- | --- |
| `use-search.ts` | entity pickers | empty page under the search key |
| `use-spaces-query.ts` | 5, incl. `select-entity`, both data-block dropdowns, the subspaces dialog | empty page under `['spaces-by-name', …]` |
| `use-place-search.ts` | address input, two blocks in one `queryFn` | empty list under `['search', …]` |
| `table-block-properties-menu.tsx` | table property menu | empty list, error discarded unlogged |

Each carried a second defect the first was hiding. Because the `catch` relabelled **every** rejection as `AbortError`, a genuine failure was indistinguishable from a cancelled keystroke — returned as "no matches", cached, and the `default:` branch written to re-throw it left unreachable. All three now take `useSearch`'s shape: re-throw a cancellation, log a real failure as itself, still degrade to empty rather than throwing at the picker, as before.

The chat dispatcher does not cache, so a cancellation there cost one call rather than sticking, but it was still logged as a failure. It now tells them apart and keeps the local matches either way.

The chat one does not cache, so it costs a single call rather than sticking, but a cancel was still being logged as a failure. It now tells them apart and keeps the local matches either way.

## Verification

Server behaviour was ruled out first — the endpoint returns the missing result identically with the type filter, with a trailing space, and with `additional_space_ids`:

```
query="Purdue"  type_ids=University    -> 1 row, canonical, types=['University']
query="Purdue " type_ids=University    -> 1 row, identical
query="Purdue"  + additional_space_ids -> 1 row, identical
```

Full front-end suite green: 441 files, 4568 tests.

## Review follow-ups

Two things this branch picked up after review, both verified rather than assumed:

- An unfinished `alsoSearchSpaceIds` option was failing the type check and blocking Build and Vercel. `SearchOptions` declared it and `useSearch` passed it to `selectSearchAdditionalSpaceIds`, which does not accept it. Nothing in the repo passed it and it belongs to a different feature, so it is removed rather than implemented.
- The scope claim was wrong and is corrected above: three further hooks had the same bug, found by sweeping for the pattern rather than the symptom.
- `isSearchCancellation` now also recognises React Query's `CancelledError`, which is invisible to every shape check — `name` is `"Error"`, there is no `_tag`, and it renders as `"Error: CancelledError"`. It reaches a caller awaiting `fetchQuery` without passing through the `queryFn`, so nothing wraps it; only the library's own predicate identifies it, as `debate-gateway` already does.
- Two `queryFn` catches that resolve to empty are deliberately left alone — `read-dispatcher`'s schema lookup and `discoverBlockEntityIds` — because neither takes a signal, so nothing there can be cancelled.

